### PR TITLE
Made clear how to make the precommit hook

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -52,6 +52,7 @@ More detailed instructions for the general process are on the github site:
 To make sure that any changes you commit pass a basic sanity check, make sure to
 add the check script as a git hook:
 
+$ cd $GOPATH/src/github.com/juju/juju
 $ ln -s ../../scripts/pre-push.bash .git/hooks/pre-push
 
 Using pre-push requires git 1.8.2 or later, alternatively running the check as a


### PR DESCRIPTION
There is a pre-commit hook set up step in the docs that references
a relative path. The usual confusion is because the relative path
in ln is relative to where the link is created not to the current
path and therefore people thinks they have a folder missing.
A line exemplifying where that command is run from
has been added to address the frequent question of "what is this
relative to"
