### PR TITLE
provider/ec2: support availability zone placement

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -14,7 +14,7 @@ github.com/juju/ratelimit	git	0025ab75db6c6eaa4ffff0240c2c9e617ad1a0eb
 github.com/juju/testing	git	77f66ce9a8a203fd6af74b38fb207666d5cdeae6	
 labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20121003093437-zcyyw0lpvj2nifpk	12
-launchpad.net/goamz	bzr	roger.peppe@canonical.com-20131218155244-hbnkvlkkzy3vmlh9	44
+launchpad.net/goamz	bzr	ian.booth@canonical.com-20140604055617-b7qt909ir9qf4959	47
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
 launchpad.net/golxc	bzr	francesco.banconi@canonical.com-20140528132419-q1lubarf0uepk4a1	9
 launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140513111813-kstzbs2kx1ujl3m3	50

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -114,12 +114,30 @@ func StartInstanceWithConstraintsAndNetworks(
 ) (
 	instance.Instance, *instance.HardwareCharacteristics, []network.Info, error,
 ) {
+	params := environs.StartInstanceParams{Constraints: cons}
+	return StartInstanceWithParams(
+		env, machineId, params, includeNetworks, excludeNetworks)
+}
+
+// StartInstanceWithParams is a test helper function that starts an instance
+// with the given parameters, and a plausible but invalid configuration, and
+// returns the result of Environ.StartInstance. The provided params's
+// MachineConfig and Tools field values will be ignored.
+func StartInstanceWithParams(
+	env environs.Environ, machineId string,
+	params environs.StartInstanceParams,
+	includeNetworks, excludeNetworks []string,
+) (
+	instance.Instance, *instance.HardwareCharacteristics, []network.Info, error,
+) {
 	series := config.PreferredSeries(env.Config())
 	agentVersion, ok := env.Config().AgentVersion()
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("missing agent version in environment config")
 	}
-	possibleTools, err := tools.FindInstanceTools(env, agentVersion, series, cons.Arch)
+	possibleTools, err := tools.FindInstanceTools(
+		env, agentVersion, series, params.Constraints.Arch,
+	)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -130,9 +148,7 @@ func StartInstanceWithConstraintsAndNetworks(
 		machineId, machineNonce,
 		includeNetworks, excludeNetworks,
 		stateInfo, apiInfo)
-	return env.StartInstance(environs.StartInstanceParams{
-		Constraints:   cons,
-		Tools:         possibleTools,
-		MachineConfig: machineConfig,
-	})
+	params.Tools = possibleTools
+	params.MachineConfig = machineConfig
+	return env.StartInstance(params)
 }

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -41,6 +41,12 @@ func InstanceEC2(inst instance.Instance) *ec2.Instance {
 	return inst.(*ec2Instance).Instance
 }
 
+func GetAvailabilityZones(e environs.Environ) ([]ec2.AvailabilityZoneInfo, error) {
+	return e.(*environ).getAvailabilityZones()
+}
+
+var EC2AvailabilityZones = &ec2AvailabilityZones
+
 // BucketStorage returns a storage instance addressing
 // an arbitrary s3 bucket.
 func BucketStorage(b *s3.Bucket) storage.Storage {


### PR DESCRIPTION
Support "add-machine zone=us-east-1a" in ec2, for explicit availability zone placement.
