### PR TITLE
Add networks= constraint

### DIFF
--- a/state/constraints.go
+++ b/state/constraints.go
@@ -25,6 +25,7 @@ type constraintsDoc struct {
 	InstanceType *string
 	Container    *instance.ContainerType
 	Tags         *[]string `bson:",omitempty"`
+	Networks     *[]string `bson:",omitempty"`
 }
 
 func (doc constraintsDoc) value() constraints.Value {
@@ -34,9 +35,10 @@ func (doc constraintsDoc) value() constraints.Value {
 		CpuPower:     doc.CpuPower,
 		Mem:          doc.Mem,
 		RootDisk:     doc.RootDisk,
+		InstanceType: doc.InstanceType,
 		Container:    doc.Container,
 		Tags:         doc.Tags,
-		InstanceType: doc.InstanceType,
+		Networks:     doc.Networks,
 	}
 }
 
@@ -47,9 +49,10 @@ func newConstraintsDoc(cons constraints.Value) constraintsDoc {
 		CpuPower:     cons.CpuPower,
 		Mem:          cons.Mem,
 		RootDisk:     cons.RootDisk,
+		InstanceType: cons.InstanceType,
 		Container:    cons.Container,
 		Tags:         cons.Tags,
-		InstanceType: cons.InstanceType,
+		Networks:     cons.Networks,
 	}
 }
 

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/constraints"
@@ -39,50 +40,56 @@ var setConstraintsTests = []struct {
 	consFallback string
 	cons         string
 	expected     string
-}{
-	{
-		cons:         "root-disk=8G mem=4G arch=amd64",
-		consFallback: "cpu-power=1000 cpu-cores=4",
-		expected:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
-	}, {
-		cons:         "root-disk=8G mem=4G arch=amd64",
-		consFallback: "cpu-power=1000 cpu-cores=4 mem=8G",
-		expected:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
-	}, {
-		consFallback: "root-disk=8G cpu-cores=4 instance-type=foo",
-		expected:     "root-disk=8G cpu-cores=4 instance-type=foo",
-	}, {
-		cons:     "root-disk=8G cpu-cores=4 instance-type=foo",
-		expected: "root-disk=8G cpu-cores=4 instance-type=foo",
-	}, {
-		consFallback: "root-disk=8G instance-type=foo",
-		cons:         "root-disk=8G cpu-cores=4 instance-type=bar",
-		expected:     "root-disk=8G cpu-cores=4 instance-type=bar",
-	}, {
-		consFallback: "root-disk=8G mem=4G",
-		cons:         "root-disk=8G cpu-cores=4 instance-type=bar",
-		expected:     "root-disk=8G cpu-cores=4 instance-type=bar",
-	}, {
-		consFallback: "root-disk=8G cpu-cores=4 instance-type=bar",
-		cons:         "root-disk=8G mem=4G",
-		expected:     "root-disk=8G cpu-cores=4 mem=4G",
-	}, {
-		consFallback: "root-disk=8G cpu-cores=4 instance-type=bar",
-		cons:         "root-disk=8G arch=amd64 mem=4G",
-		expected:     "root-disk=8G cpu-cores=4 arch=amd64 mem=4G",
-	},
-}
+}{{
+	cons:         "root-disk=8G mem=4G arch=amd64",
+	consFallback: "cpu-power=1000 cpu-cores=4",
+	expected:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
+}, {
+	cons:         "root-disk=8G mem=4G arch=amd64",
+	consFallback: "cpu-power=1000 cpu-cores=4 mem=8G",
+	expected:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
+}, {
+	consFallback: "root-disk=8G cpu-cores=4 instance-type=foo",
+	expected:     "root-disk=8G cpu-cores=4 instance-type=foo",
+}, {
+	cons:     "root-disk=8G cpu-cores=4 instance-type=foo",
+	expected: "root-disk=8G cpu-cores=4 instance-type=foo",
+}, {
+	consFallback: "root-disk=8G instance-type=foo",
+	cons:         "root-disk=8G cpu-cores=4 instance-type=bar",
+	expected:     "root-disk=8G cpu-cores=4 instance-type=bar",
+}, {
+	consFallback: "root-disk=8G mem=4G",
+	cons:         "root-disk=8G cpu-cores=4 instance-type=bar",
+	expected:     "root-disk=8G cpu-cores=4 instance-type=bar",
+}, {
+	consFallback: "root-disk=8G cpu-cores=4 instance-type=bar",
+	cons:         "root-disk=8G mem=4G",
+	expected:     "root-disk=8G cpu-cores=4 mem=4G",
+}, {
+	consFallback: "root-disk=8G cpu-cores=4 instance-type=bar",
+	cons:         "root-disk=8G arch=amd64 mem=4G",
+	expected:     "root-disk=8G cpu-cores=4 arch=amd64 mem=4G",
+}, {
+	consFallback: "cpu-cores=4 mem=4G networks=net1,^net3",
+	cons:         "networks=net2,^net4 mem=4G",
+	expected:     "cpu-cores=4 mem=4G networks=net2,^net4",
+}, {
+	consFallback: "cpu-cores=4 mem=2G networks=",
+	cons:         "mem=4G networks=net1,^net3",
+	expected:     "cpu-cores=4 mem=4G networks=net1,^net3",
+}}
 
 func (s *constraintsValidationSuite) TestMachineConstraints(c *gc.C) {
 	for i, t := range setConstraintsTests {
-		c.Logf("test %d", i)
+		c.Logf("test %d: fallback: %q, cons: %q", i, t.consFallback, t.cons)
 		err := s.State.SetEnvironConstraints(constraints.MustParse(t.consFallback))
 		c.Check(err, gc.IsNil)
 		m, err := s.addOneMachine(c, constraints.MustParse(t.cons))
 		c.Check(err, gc.IsNil)
 		cons, err := m.Constraints()
 		c.Check(err, gc.IsNil)
-		c.Check(cons, gc.DeepEquals, constraints.MustParse(t.expected))
+		c.Check(cons, jc.DeepEquals, constraints.MustParse(t.expected))
 	}
 }
 
@@ -90,15 +97,15 @@ func (s *constraintsValidationSuite) TestServiceConstraints(c *gc.C) {
 	charm := s.AddTestingCharm(c, "wordpress")
 	service := s.AddTestingService(c, "wordpress", charm)
 	for i, t := range setConstraintsTests {
-		c.Logf("test %d", i)
+		c.Logf("test %d: fallback: %q, cons: %q", i, t.consFallback, t.cons)
 		err := s.State.SetEnvironConstraints(constraints.MustParse(t.consFallback))
 		c.Check(err, gc.IsNil)
 		err = service.SetConstraints(constraints.MustParse(t.cons))
 		c.Check(err, gc.IsNil)
 		u, err := service.AddUnit()
 		c.Check(err, gc.IsNil)
-		cons, err := state.UnitConstraints(u)
+		ucons, err := state.UnitConstraints(u)
 		c.Check(err, gc.IsNil)
-		c.Check(*cons, gc.DeepEquals, constraints.MustParse(t.expected))
+		c.Check(*ucons, jc.DeepEquals, constraints.MustParse(t.expected))
 	}
 }


### PR DESCRIPTION
state/constraints: Networks constraints added

This adds "networks=..." constraint in the constraints
and state packages. The ability to specify networks
to include/exclude when selecting a machine to deploy
a service's unit with specified constraints. Both
positive and negative entries are supported and the
value of "networks=" is a comma-delimited list of
(juju) network names. Negative entries have "^" prefix.

Examples: networks=logging,^db,storage,^dmz

Means: use machines (if possible) on the "logging" and
"storage" networks and not on "db" or "dmz" networks.

No changes to cmd/juju/deploy or other commands yet,
this will come in a follow-up.

NOTE: This branch was migrated from Launchpad and
was already reviewed at https://codereview.appspot.com/93670046/
