### PR TITLE
environs/sshstorage: fix intermittent test failure

### DIFF
--- a/environs/sshstorage/storage_test.go
+++ b/environs/sshstorage/storage_test.go
@@ -178,7 +178,7 @@ func (s *storageSuite) TestWriteFailure(c *gc.C) {
 		invocations++
 		switch invocations {
 		case 1, 3:
-			return s.sshCommand(c, host, "true")
+			return s.sshCommand(c, host, "head -n 1 > /dev/null")
 		case 2:
 			// Note: must close stdin before responding the first time, or
 			// the second command will race with closing stdin, and may


### PR DESCRIPTION
The initial "bash" command was changed at some point from being all-on-the-command-line to bash executing a script on stdin. The test changes to reflect that.

Fixes https://bugs.launchpad.net/juju-core/+bug/1323898
