### PR TITLE
MaaS provider should expose the bootstrap timeout options.

### DIFF
--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -77,11 +77,6 @@ maas:
     # bootstrap-timeout time to wait contacting a state server, in seconds.
     bootstrap-timeout: 1800
 
-    # bootstrap-retry-delay time between attempts to connect to an address, in seconds.
-    # bootstrap-retry-delay: 5
-
-    # bootstrap-addresses-delay time between refreshing the addresses, in seconds.
-    # bootstrap-addresses-delay: 10
 
 `[1:]
 


### PR DESCRIPTION
Most of the MAAS deployments takes longer times, in fact a install with d-i typically takes around 20 minutes on a good day.

Would be a good thing to at least have the timeout settings exposed ( commented ) for being
noticed by all users.

Please see reference LP: #1325891
