### PR TITLE
state/api{,server}: more FullStatus API data

### DIFF
--- a/state/api/client.go
+++ b/state/api/client.go
@@ -50,6 +50,7 @@ type MachineStatus struct {
 	Err            error
 	AgentState     params.Status
 	AgentStateInfo string
+	AgentStateData params.StatusData
 	AgentVersion   string
 	DNSName        string
 	InstanceId     instance.Id
@@ -82,6 +83,7 @@ type UnitStatus struct {
 	Err            error
 	AgentState     params.Status
 	AgentStateInfo string
+	AgentStateData params.StatusData
 	AgentVersion   string
 	Life           string
 	Machine        string
@@ -89,6 +91,27 @@ type UnitStatus struct {
 	PublicAddress  string
 	Charm          string
 	Subordinates   map[string]UnitStatus
+}
+
+// RelationStatus holds status info about a relation.
+type RelationStatus struct {
+	Id        int
+	Key       string
+	Interface string
+	Scope     charm.RelationScope
+	Endpoints []EndpointStatus
+}
+
+// EndpointStatus holds status info about a single endpoint
+type EndpointStatus struct {
+	ServiceName string
+	Name        string
+	Role        charm.RelationRole
+	Subordinate bool
+}
+
+func (epStatus *EndpointStatus) String() string {
+	return epStatus.ServiceName + ":" + epStatus.Name
 }
 
 // NetworkStatus holds status info about a network.
@@ -105,6 +128,7 @@ type Status struct {
 	Machines        map[string]MachineStatus
 	Services        map[string]ServiceStatus
 	Networks        map[string]NetworkStatus
+	Relations       []RelationStatus
 }
 
 // Status returns the status of the juju environment.

--- a/state/apiserver/client/perm_test.go
+++ b/state/apiserver/client/perm_test.go
@@ -279,7 +279,7 @@ func opClientServiceUnexpose(c *gc.C, st *api.State, mst *state.State) (func(), 
 }
 
 func opClientResolved(c *gc.C, st *api.State, _ *state.State) (func(), error) {
-	err := st.Client().Resolved("wordpress/0", false)
+	err := st.Client().Resolved("wordpress/1", false)
 	// There are several scenarios in which this test is called, one is
 	// that the user is not authorized.  In that case we want to exit now,
 	// letting the error percolate out so the caller knows that the
@@ -292,7 +292,7 @@ func opClientResolved(c *gc.C, st *api.State, _ *state.State) (func(), error) {
 	// the error.  Therefore, since it is complaining it means that the
 	// call to Resolved worked, so we're happy.
 	c.Assert(err, gc.NotNil)
-	c.Assert(err.Error(), gc.Equals, `unit "wordpress/0" is not in an error state`)
+	c.Assert(err.Error(), gc.Equals, `unit "wordpress/1" is not in an error state`)
 	return func() {}, nil
 }
 

--- a/state/apiserver/client/status.go
+++ b/state/apiserver/client/status.go
@@ -62,6 +62,7 @@ func (c *Client) FullStatus(args params.StatusParams) (api.Status, error) {
 		Machines:        context.processMachines(),
 		Services:        context.processServices(),
 		Networks:        context.processNetworks(),
+		Relations:       context.processRelations(),
 	}, nil
 }
 
@@ -285,10 +286,10 @@ func fetchUnitMachineIds(units map[string]map[string]*state.Unit) (*set.Strings,
 
 // fetchRelations returns a map of all relations keyed by service name.
 //
-// This structure is useful for processRelations() which needs to have
-// the relations for each service. Reading them once here avoids the
-// repeated DB hits to retrieve the relations for each service that
-// used to happen in processRelations().
+// This structure is useful for processServiceRelations() which needs
+// to have the relations for each service. Reading them once here
+// avoids the repeated DB hits to retrieve the relations for each
+// service that used to happen in processServiceRelations().
 func fetchRelations(st *state.State) (map[string][]*state.Relation, error) {
 	relations, err := st.AllRelations()
 	if err != nil {
@@ -350,11 +351,13 @@ func (context *statusContext) processMachine(machines []*state.Machine, host *ap
 
 func (context *statusContext) makeMachineStatus(machine *state.Machine) (status api.MachineStatus) {
 	status.Id = machine.Id()
-	status.Life,
-		status.AgentVersion,
-		status.AgentState,
-		status.AgentStateInfo,
-		status.Err = processAgent(machine)
+	agentStatus := processAgent(machine)
+	status.Life = agentStatus.Life
+	status.AgentVersion = agentStatus.Version
+	status.AgentState = agentStatus.Status
+	status.AgentStateInfo = agentStatus.Info
+	status.AgentStateData = agentStatus.Data
+	status.Err = agentStatus.Err
 	status.Series = machine.Series()
 	status.Jobs = paramsJobsFromJobs(machine.Jobs())
 	status.WantsVote = machine.WantsVote()
@@ -391,6 +394,52 @@ func (context *statusContext) makeMachineStatus(machine *state.Machine) (status 
 	return
 }
 
+func (context *statusContext) processRelations() []api.RelationStatus {
+	var out []api.RelationStatus
+	relations := context.getAllRelations()
+	for _, relation := range relations {
+		var eps []api.EndpointStatus
+		var scope charm.RelationScope
+		var relationInterface string
+		for _, ep := range relation.Endpoints() {
+			eps = append(eps, api.EndpointStatus{
+				ServiceName: ep.ServiceName,
+				Name:        ep.Name,
+				Role:        ep.Role,
+				Subordinate: context.isSubordinate(&ep),
+			})
+			// these should match on both sides so use the last
+			relationInterface = ep.Interface
+			scope = ep.Scope
+		}
+		relStatus := api.RelationStatus{
+			Id:        relation.Id(),
+			Key:       relation.String(),
+			Interface: relationInterface,
+			Scope:     scope,
+			Endpoints: eps,
+		}
+		out = append(out, relStatus)
+	}
+	return out
+}
+
+// This method exists only to dedup the loaded relations as they will
+// appear multiple times in context.relations.
+func (context *statusContext) getAllRelations() []*state.Relation {
+	var out []*state.Relation
+	seenRelations := make(map[int]bool)
+	for _, relations := range context.relations {
+		for _, relation := range relations {
+			if _, found := seenRelations[relation.Id()]; !found {
+				out = append(out, relation)
+				seenRelations[relation.Id()] = true
+			}
+		}
+	}
+	return out
+}
+
 func (context *statusContext) processNetworks() map[string]api.NetworkStatus {
 	networksMap := make(map[string]api.NetworkStatus)
 	for name, network := range context.networks {
@@ -405,6 +454,18 @@ func (context *statusContext) makeNetworkStatus(network *state.Network) api.Netw
 		CIDR:       network.CIDR(),
 		VLANTag:    network.VLANTag(),
 	}
+}
+
+func (context *statusContext) isSubordinate(ep *state.Endpoint) bool {
+	service := context.services[ep.ServiceName]
+	if service == nil {
+		return false
+	}
+	return isSubordinate(ep, service)
+}
+
+func isSubordinate(ep *state.Endpoint, service *state.Service) bool {
+	return ep.Scope == charm.ScopeContainer && !service.IsPrincipal()
 }
 
 // paramsJobsFromJobs converts state jobs to params jobs.
@@ -435,7 +496,7 @@ func (context *statusContext) processService(service *state.Service) (status api
 		status.CanUpgradeTo = latestCharm
 	}
 	var err error
-	status.Relations, status.SubordinateTo, err = context.processRelations(service)
+	status.Relations, status.SubordinateTo, err = context.processServiceRelations(service)
 	if err != nil {
 		status.Err = err
 		return
@@ -490,11 +551,13 @@ func (context *statusContext) processUnit(unit *state.Unit, serviceCharm string)
 	if serviceCharm != "" && curl != nil && curl.String() != serviceCharm {
 		status.Charm = curl.String()
 	}
-	status.Life,
-		status.AgentVersion,
-		status.AgentState,
-		status.AgentStateInfo,
-		status.Err = processAgent(unit)
+	agentStatus := processAgent(unit)
+	status.Life = agentStatus.Life
+	status.AgentVersion = agentStatus.Version
+	status.AgentState = agentStatus.Status
+	status.AgentStateInfo = agentStatus.Info
+	status.AgentStateData = agentStatus.Data
+	status.Err = agentStatus.Err
 	if subUnits := unit.SubordinateNames(); len(subUnits) > 0 {
 		status.Subordinates = make(map[string]api.UnitStatus)
 		for _, name := range subUnits {
@@ -513,7 +576,8 @@ func (context *statusContext) unitByName(name string) *state.Unit {
 	return context.units[serviceName][name]
 }
 
-func (context *statusContext) processRelations(service *state.Service) (related map[string][]string, subord []string, err error) {
+func (context *statusContext) processServiceRelations(service *state.Service) (
+	related map[string][]string, subord []string, err error) {
 	var subordSet set.Strings
 	related = make(map[string][]string)
 	relations := context.relations[service.Name()]
@@ -528,7 +592,7 @@ func (context *statusContext) processRelations(service *state.Service) (related 
 			return nil, nil, err
 		}
 		for _, ep := range eps {
-			if ep.Scope == charm.ScopeContainer && !service.IsPrincipal() {
+			if isSubordinate(&ep, service) {
 				subordSet.Add(ep.ServiceName)
 			}
 			related[relationName] = append(related[relationName], ep.ServiceName)
@@ -552,38 +616,65 @@ type stateAgent interface {
 	Status() (params.Status, string, params.StatusData, error)
 }
 
-// processAgent retrieves version and status information from the given entity
-// and sets the destination version, status and info values accordingly.
-func processAgent(entity stateAgent) (life string, version string, status params.Status, info string, err error) {
-	life = processLife(entity)
+type agentStatus struct {
+	Life    string
+	Version string
+	Status  params.Status
+	Info    string
+	Data    params.StatusData
+	Err     error
+}
+
+// processAgent retrieves version and status information from the given entity.
+func processAgent(entity stateAgent) (out agentStatus) {
+	out.Life = processLife(entity)
+
 	if t, err := entity.AgentTools(); err == nil {
-		version = t.Version.Number.String()
+		out.Version = t.Version.Number.String()
 	}
-	// TODO(mue) StatusData may be useful here too.
-	status, info, _, err = entity.Status()
-	if err != nil {
+
+	out.Status, out.Info, out.Data, out.Err = entity.Status()
+	out.Data = filterStatusData(out.Data)
+	if out.Err != nil {
 		return
 	}
-	if status == params.StatusPending {
+
+	if out.Status == params.StatusPending {
 		// The status is pending - there's no point
 		// in enquiring about the agent liveness.
 		return
 	}
+
 	agentAlive, err := entity.AgentAlive()
 	if err != nil {
 		return
 	}
+
 	if entity.Life() != state.Dead && !agentAlive {
 		// The agent *should* be alive but is not.
 		// Add the original status to the info, so it's not lost.
-		if info != "" {
-			info = fmt.Sprintf("(%s: %s)", status, info)
+		if out.Info != "" {
+			out.Info = fmt.Sprintf("(%s: %s)", out.Status, out.Info)
 		} else {
-			info = fmt.Sprintf("(%s)", status)
+			out.Info = fmt.Sprintf("(%s)", out.Status)
 		}
-		status = params.StatusDown
+		out.Status = params.StatusDown
 	}
+
 	return
+}
+
+// filterStatusData limits what agent StatusData data is passed over
+// the API. This prevents unintended leakage of internal-only data.
+func filterStatusData(status params.StatusData) params.StatusData {
+	out := make(params.StatusData)
+	for name, value := range status {
+		// use a set here if we end up with a larger whitelist
+		if name == "relation-id" {
+			out[name] = value
+		}
+	}
+	return out
 }
 
 func processLife(entity lifer) string {


### PR DESCRIPTION
The FullStatus client API response now includes a new Relations field
containing relation and endpoint data.

Machines and units now also have a StatusData map in the FullStatus
response which holds extra status information that a client may choose
to use when displaying status. This was already being created but not
passed through the client API. The returned StatusData map is
whitelisted to prevent unintentional leakage of internal-only data of
over the API.

The client API test scenario has been extended to include a case of a
unit with an error with extra status data included.

Apart from providing opportunities for showing more detail in juju
status output generally, these new items will be used to display
relation details in the "juju status" output when a relation hook
fails (LP #1194481). This change will be done in a different branch.
