### PR TITLE
Backout change to use replica sets for local provider

### DIFF
--- a/agent/mongo/mongo_test.go
+++ b/agent/mongo/mongo_test.go
@@ -127,7 +127,7 @@ func (s *MongoSuite) TestEnsureServer(c *gc.C) {
 
 	mockShellCommand(c, &s.CleanupSuite, "apt-get")
 
-	err := mongo.EnsureServer(dataDir, namespace, testInfo)
+	err := mongo.EnsureServer(dataDir, namespace, testInfo, mongo.WithHA)
 	c.Assert(err, gc.IsNil)
 
 	testJournalDirs(dbDir, c)
@@ -158,7 +158,7 @@ func (s *MongoSuite) TestEnsureServer(c *gc.C) {
 
 	s.installed = nil
 	// now check we can call it multiple times without error
-	err = mongo.EnsureServer(dataDir, namespace, testInfo)
+	err = mongo.EnsureServer(dataDir, namespace, testInfo, mongo.WithHA)
 	c.Assert(err, gc.IsNil)
 	assertInstalled()
 
@@ -194,7 +194,7 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 
 		s.PatchValue(&version.Current.Series, test.series)
 
-		err := mongo.EnsureServer(dataDir, namespace, testInfo)
+		err := mongo.EnsureServer(dataDir, namespace, testInfo, mongo.WithHA)
 		c.Assert(err, gc.IsNil)
 
 		cmds := getMockShellCalls(c, output)
@@ -212,18 +212,22 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 	}
 }
 
-func (s *MongoSuite) TestUpstartService(c *gc.C) {
+func (s *MongoSuite) TestUpstartServiceWithHA(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234)
+	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, mongo.WithHA)
 	c.Assert(err, gc.IsNil)
 	c.Assert(strings.Contains(svc.Cmd, "--replSet"), jc.IsTrue)
+
+	svc, _, err = mongo.UpstartService("", dataDir, dataDir, 1234, mongo.WithoutHA)
+	c.Assert(err, gc.IsNil)
+	c.Assert(strings.Contains(svc.Cmd, "--replSet"), jc.IsFalse)
 }
 
 func (s *MongoSuite) TestUpstartServiceWithJournal(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234)
+	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, mongo.WithHA)
 	c.Assert(err, gc.IsNil)
 	journalPresent := strings.Contains(svc.Cmd, " --journal ") || strings.HasSuffix(svc.Cmd, " --journal")
 	c.Assert(journalPresent, jc.IsTrue)
@@ -261,11 +265,11 @@ func (s *MongoSuite) TestQuantalAptAddRepo(c *gc.C) {
 	// test that we call add-apt-repository only for quantal (and that if it
 	// fails, we return the error)
 	s.PatchValue(&version.Current.Series, "quantal")
-	err := mongo.EnsureServer(dir, "", testInfo)
+	err := mongo.EnsureServer(dir, "", testInfo, mongo.WithHA)
 	c.Assert(err, gc.ErrorMatches, "cannot install mongod: cannot add apt repository: exit status 1.*")
 
 	s.PatchValue(&version.Current.Series, "trusty")
-	err = mongo.EnsureServer(dir, "", testInfo)
+	err = mongo.EnsureServer(dir, "", testInfo, mongo.WithHA)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -274,7 +278,7 @@ func (s *MongoSuite) TestNoMongoDir(c *gc.C) {
 	// created.
 	mockShellCommand(c, &s.CleanupSuite, "apt-get")
 	dataDir := filepath.Join(c.MkDir(), "dir", "data")
-	err := mongo.EnsureServer(dataDir, "", testInfo)
+	err := mongo.EnsureServer(dataDir, "", testInfo, mongo.WithHA)
 	c.Check(err, gc.IsNil)
 
 	_, err = os.Stat(filepath.Join(dataDir, "db"))
@@ -340,7 +344,7 @@ func (s *MongoSuite) TestAddPPAInQuantal(c *gc.C) {
 	s.PatchValue(&version.Current.Series, "quantal")
 
 	dataDir := c.MkDir()
-	err := mongo.EnsureServer(dataDir, "", testInfo)
+	err := mongo.EnsureServer(dataDir, "", testInfo, mongo.WithHA)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(getMockShellCalls(c, addAptRepoOut), gc.DeepEquals, [][]string{{

--- a/cmd/jujud/agent_test.go
+++ b/cmd/jujud/agent_test.go
@@ -239,7 +239,7 @@ func (s *agentSuite) SetUpSuite(c *gc.C) {
 	// a bit when some tests are restarting every 50ms for 10 seconds,
 	// so use a slightly more friendly delay.
 	worker.RestartDelay = 250 * time.Millisecond
-	s.PatchValue(&ensureMongoServer, func(string, string, params.StateServingInfo) error {
+	s.PatchValue(&ensureMongoServer, func(string, string, params.StateServingInfo, bool) error {
 		return nil
 	})
 }

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -185,13 +185,19 @@ func (c *BootstrapCommand) startMongo(addrs []instance.Address, agentConfig agen
 	}
 
 	logger.Debugf("calling ensureMongoServer")
+	withHA := shouldEnableHA(agentConfig)
 	err = ensureMongoServer(
 		agentConfig.DataDir(),
 		agentConfig.Value(agent.Namespace),
 		servingInfo,
+		withHA,
 	)
 	if err != nil {
 		return err
+	}
+	// If we are not doing HA, there is no need to set up replica set.
+	if !withHA {
+		return nil
 	}
 
 	peerAddr := mongo.SelectPeerAddress(addrs)

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -54,14 +54,15 @@ type fakeEnsure struct {
 	initiateCount  int
 	dataDir        string
 	namespace      string
+	withHA         bool
 	info           params.StateServingInfo
 	initiateParams peergrouper.InitiateMongoParams
 	err            error
 }
 
-func (f *fakeEnsure) fakeEnsureMongo(dataDir, namespace string, info params.StateServingInfo) error {
+func (f *fakeEnsure) fakeEnsureMongo(dataDir, namespace string, info params.StateServingInfo, withHA bool) error {
 	f.ensureCount++
-	f.dataDir, f.namespace, f.info = dataDir, namespace, info
+	f.dataDir, f.namespace, f.info, f.withHA = dataDir, namespace, info, withHA
 	return f.err
 }
 
@@ -156,6 +157,7 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	c.Assert(s.fakeEnsureMongo.initiateCount, gc.Equals, 1)
 	c.Assert(s.fakeEnsureMongo.ensureCount, gc.Equals, 1)
 	c.Assert(s.fakeEnsureMongo.dataDir, gc.Equals, s.dataDir)
+	c.Assert(s.fakeEnsureMongo.withHA, jc.IsTrue)
 
 	expectInfo, exists := machConf.StateServingInfo()
 	c.Assert(exists, jc.IsTrue)

--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -450,9 +450,11 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			a.startWorkerAfterUpgrade(runner, "instancepoller", func() (worker.Worker, error) {
 				return instancepoller.NewWorker(st), nil
 			})
-			a.startWorkerAfterUpgrade(runner, "peergrouper", func() (worker.Worker, error) {
-				return peergrouperNew(st)
-			})
+			if shouldEnableHA(agentConfig) {
+				a.startWorkerAfterUpgrade(runner, "peergrouper", func() (worker.Worker, error) {
+					return peergrouperNew(st)
+				})
+			}
 			runner.StartWorker("apiserver", func() (worker.Worker, error) {
 				// If the configuration does not have the required information,
 				// it is currently not a recoverable error, so we kill the whole
@@ -505,6 +507,7 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 		return fmt.Errorf("state worker was started with no state serving info")
 	}
 	namespace := agentConfig.Value(agent.Namespace)
+	withHA := shouldEnableHA(agentConfig)
 
 	// When upgrading from a pre-HA-capable environment,
 	// we must add machine-0 to the admin database and
@@ -541,7 +544,7 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 		}
 		st.Close()
 		addrs = m.Addresses()
-		shouldInitiateMongoServer = true
+		shouldInitiateMongoServer = withHA
 	}
 
 	// ensureMongoServer installs/upgrades the upstart config as necessary.
@@ -549,6 +552,7 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 		agentConfig.DataDir(),
 		namespace,
 		servingInfo,
+		withHA,
 	); err != nil {
 		return err
 	}
@@ -606,6 +610,16 @@ func (a *MachineAgent) ensureMongoAdminUser(agentConfig agent.Config) (added boo
 
 func isPreHAVersion(v version.Number) bool {
 	return v.Compare(version.MustParse("1.19.0")) < 0
+}
+
+// shouldEnableHA reports whether HA should be enabled.
+//
+// Eventually this should always be true, and ideally
+// it should be true before 1.20 is released or we'll
+// have more upgrade scenarios on our hands.
+func shouldEnableHA(agentConfig agent.Config) bool {
+	providerType := agentConfig.Value(agent.ProviderType)
+	return providerType != provider.Local
 }
 
 func openState(agentConfig agent.Config) (_ *state.State, _ *state.Machine, err error) {


### PR DESCRIPTION
This PR backs out the change that switched replica sets on for local provider. This is the change that broke local-deploy-precise-amd64 CI.
