### PR TITLE
envions/configstore: Storage.List()

### DIFF
--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -96,6 +96,24 @@ func (d *diskStore) CreateInfo(envName string) (EnvironInfo, error) {
 	}, nil
 }
 
+const extName = ".jenv"
+
+// List implements Storage.List
+func (d *diskStore) List() ([]string, error) {
+	path := filepath.Join(d.dir, "environments")
+	var envs []string
+	files, err := filepath.Glob(path + "/*" + extName)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		fName := filepath.Base(file)
+		name := fName[:len(fName)-len(extName)]
+		envs = append(envs, name)
+	}
+	return envs, nil
+}
+
 // ReadInfo implements Storage.ReadInfo.
 func (d *diskStore) ReadInfo(envName string) (EnvironInfo, error) {
 	path := d.envPath(envName)

--- a/environs/configstore/interface.go
+++ b/environs/configstore/interface.go
@@ -45,6 +45,10 @@ type Storage interface {
 	// It return ErrAlreadyExists if the
 	// information has already been created.
 	CreateInfo(envName string) (EnvironInfo, error)
+
+	// List returns a slice of existing environment names that the Storage
+	// knows about.
+	List() ([]string, error)
 }
 
 // EnvironInfo holds information associated with an environment.

--- a/environs/configstore/interface_test.go
+++ b/environs/configstore/interface_test.go
@@ -39,6 +39,20 @@ func (s *interfaceSuite) TestCreate(c *gc.C) {
 	c.Assert(info.Initialized(), jc.IsFalse)
 }
 
+func (s *interfaceSuite) TestList(c *gc.C) {
+	store := s.NewStore(c)
+	_, err := store.CreateInfo("enva")
+	c.Assert(err, gc.IsNil)
+	_, err = store.CreateInfo("envb")
+	c.Assert(err, gc.IsNil)
+	_, err = store.CreateInfo("envc")
+	c.Assert(err, gc.IsNil)
+
+	environs, err := store.List()
+	c.Assert(err, gc.IsNil)
+	c.Assert(environs, jc.SameContents, []string{"enva", "envb", "envc"})
+}
+
 func (s *interfaceSuite) TestSetAPIEndpointAndCredentials(c *gc.C) {
 	store := s.NewStore(c)
 

--- a/environs/configstore/mem.go
+++ b/environs/configstore/mem.go
@@ -60,6 +60,17 @@ func (m *memStore) CreateInfo(envName string) (EnvironInfo, error) {
 	return info, nil
 }
 
+// List implements Storage.List
+func (m *memStore) List() ([]string, error) {
+	var envs []string
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, _ := range m.envs {
+		envs = append(envs, name)
+	}
+	return envs, nil
+}
+
 // ReadInfo implements Storage.ReadInfo.
 func (m *memStore) ReadInfo(envName string) (EnvironInfo, error) {
 	m.mu.Lock()

--- a/juju/apiconn_test.go
+++ b/juju/apiconn_test.go
@@ -679,6 +679,10 @@ func (*storageWithWriteNotify) CreateInfo(envName string) (configstore.EnvironIn
 	panic("CreateInfo not implemented")
 }
 
+func (*storageWithWriteNotify) List() ([]string, error) {
+	panic("List not implemented")
+}
+
 func (s *storageWithWriteNotify) ReadInfo(envName string) (configstore.EnvironInfo, error) {
 	info, err := s.store.ReadInfo(envName)
 	if err != nil {


### PR DESCRIPTION
Add the List() method to the Storage interface. List lists all
the existing environments in storage.
