### PR TITLE
provider/openstack: support zone placement

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -22,7 +22,7 @@ launchpad.net/goamz	bzr	ian.booth@canonical.com-20140604055617-b7qt909ir9qf4959	
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
 launchpad.net/golxc	bzr	francesco.banconi@canonical.com-20140528132419-q1lubarf0uepk4a1	9
 launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140513111813-kstzbs2kx1ujl3m3	50
-launchpad.net/goose	bzr	tarmac-20140516070929-jdddyozs81236kk0	124
+launchpad.net/goose	bzr	tarmac-20140610122728-ontdj4574u0nfbq2	125
 launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50
 launchpad.net/gwacl	bzr	tarmac-20140312041035-ac7gw7kcqjx7db63	234
 launchpad.net/lpad	bzr	gustavo@niemeyer.net-20120626194701-536yx0g9jdq2ik3h	64

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -60,6 +60,16 @@ func InstanceAddress(addresses map[string][]nova.IPAddress) string {
 	return network.SelectPublicAddress(convertNovaAddresses(addresses))
 }
 
+func InstanceServerDetail(inst instance.Instance) *nova.ServerDetail {
+	return inst.(*openstackInstance).serverDetail
+}
+
+func GetAvailabilityZones(e environs.Environ) ([]nova.AvailabilityZone, error) {
+	return e.(*environ).getAvailabilityZones()
+}
+
+var NovaListAvailabilityZones = &novaListAvailabilityZones
+
 var indexData = `
 		{
 		 "index": {


### PR DESCRIPTION
This is essentially the same as the work done for ec2 in https://github.com/juju/juju/pull/8. Like many other things in the two providers, there is a lot of overlap.

I have not yet updated dependencies.tsv; will do so when the goose branch lands (https://codereview.appspot.com/103900045).

A followup will add support for automatic spread across AZs.
