### PR TITLE
Cleaner agent status reporting

### DIFF
--- a/state/api/client.go
+++ b/state/api/client.go
@@ -45,24 +45,40 @@ func (c *Client) call(method string, params, result interface{}) error {
 	return c.st.Call("Client", "", method, params, result)
 }
 
+// AgentStatus holds status info about a machine or unit agent.
+type AgentStatus struct {
+	Status  params.Status
+	Info    string
+	Data    params.StatusData
+	Version string
+	Life    string
+	Err     error
+}
+
 // MachineStatus holds status info about a machine.
 type MachineStatus struct {
-	Err            error
+	Agent AgentStatus
+
+	// The following fields mirror fields in AgentStatus (introduced
+	// in 1.19.x). The old fields below are being kept for
+	// compatibility with old clients. They can be removed once API
+	// versioning lands or for 1.21, whichever comes first.
 	AgentState     params.Status
 	AgentStateInfo string
-	AgentStateData params.StatusData
 	AgentVersion   string
-	DNSName        string
-	InstanceId     instance.Id
-	InstanceState  string
 	Life           string
-	Series         string
-	Id             string
-	Containers     map[string]MachineStatus
-	Hardware       string
-	Jobs           []params.MachineJob
-	HasVote        bool
-	WantsVote      bool
+	Err            error
+
+	DNSName       string
+	InstanceId    instance.Id
+	InstanceState string
+	Series        string
+	Id            string
+	Containers    map[string]MachineStatus
+	Hardware      string
+	Jobs          []params.MachineJob
+	HasVote       bool
+	WantsVote     bool
 }
 
 // ServiceStatus holds status info about a service.
@@ -80,17 +96,20 @@ type ServiceStatus struct {
 
 // UnitStatus holds status info about a unit.
 type UnitStatus struct {
-	Err            error
+	Agent AgentStatus
+
+	// See the comment in MachineStatus regarding these fields.
 	AgentState     params.Status
 	AgentStateInfo string
-	AgentStateData params.StatusData
 	AgentVersion   string
 	Life           string
-	Machine        string
-	OpenedPorts    []string
-	PublicAddress  string
-	Charm          string
-	Subordinates   map[string]UnitStatus
+	Err            error
+
+	Machine       string
+	OpenedPorts   []string
+	PublicAddress string
+	Charm         string
+	Subordinates  map[string]UnitStatus
 }
 
 // RelationStatus holds status info about a relation.

--- a/state/apiserver/client/api_test.go
+++ b/state/apiserver/client/api_test.go
@@ -148,11 +148,14 @@ var scenarioStatus = &api.Status{
 	EnvironmentName: "dummyenv",
 	Machines: map[string]api.MachineStatus{
 		"0": {
-			Id:             "0",
-			InstanceId:     instance.Id("i-machine-0"),
+			Id:         "0",
+			InstanceId: instance.Id("i-machine-0"),
+			Agent: api.AgentStatus{
+				Status: "started",
+				Data:   params.StatusData{},
+			},
 			AgentState:     "down",
 			AgentStateInfo: "(started)",
-			AgentStateData: params.StatusData{},
 			Series:         "quantal",
 			Containers:     map[string]api.MachineStatus{},
 			Jobs:           []params.MachineJob{params.JobManageEnviron},
@@ -160,11 +163,14 @@ var scenarioStatus = &api.Status{
 			WantsVote:      true,
 		},
 		"1": {
-			Id:             "1",
-			InstanceId:     instance.Id("i-machine-1"),
+			Id:         "1",
+			InstanceId: instance.Id("i-machine-1"),
+			Agent: api.AgentStatus{
+				Status: "started",
+				Data:   params.StatusData{},
+			},
 			AgentState:     "down",
 			AgentStateInfo: "(started)",
-			AgentStateData: params.StatusData{},
 			Series:         "quantal",
 			Containers:     map[string]api.MachineStatus{},
 			Jobs:           []params.MachineJob{params.JobHostUnits},
@@ -172,11 +178,14 @@ var scenarioStatus = &api.Status{
 			WantsVote:      false,
 		},
 		"2": {
-			Id:             "2",
-			InstanceId:     instance.Id("i-machine-2"),
+			Id:         "2",
+			InstanceId: instance.Id("i-machine-2"),
+			Agent: api.AgentStatus{
+				Status: "started",
+				Data:   params.StatusData{},
+			},
 			AgentState:     "down",
 			AgentStateInfo: "(started)",
-			AgentStateData: params.StatusData{},
 			Series:         "quantal",
 			Containers:     map[string]api.MachineStatus{},
 			Jobs:           []params.MachineJob{params.JobHostUnits},
@@ -206,27 +215,38 @@ var scenarioStatus = &api.Status{
 			SubordinateTo: []string{},
 			Units: map[string]api.UnitStatus{
 				"wordpress/0": api.UnitStatus{
+					Agent: api.AgentStatus{
+						Status: "error",
+						Info:   "blam",
+						Data:   params.StatusData{"relation-id": "0"},
+					},
 					AgentState:     "down",
 					AgentStateInfo: "(error: blam)",
-					AgentStateData: params.StatusData{
-						"relation-id": "0",
-					},
-					Machine: "1",
+					Machine:        "1",
 					Subordinates: map[string]api.UnitStatus{
 						"logging/0": api.UnitStatus{
-							AgentState:     "pending",
-							AgentStateData: params.StatusData{},
+							Agent: api.AgentStatus{
+								Status: "pending",
+								Data:   params.StatusData{},
+							},
+							AgentState: "pending",
 						},
 					},
 				},
 				"wordpress/1": api.UnitStatus{
-					AgentState:     "pending",
-					AgentStateData: params.StatusData{},
-					Machine:        "2",
+					Agent: api.AgentStatus{
+						Status: "pending",
+						Data:   params.StatusData{},
+					},
+					AgentState: "pending",
+					Machine:    "2",
 					Subordinates: map[string]api.UnitStatus{
 						"logging/1": api.UnitStatus{
-							AgentState:     "pending",
-							AgentStateData: params.StatusData{},
+							Agent: api.AgentStatus{
+								Status: "pending",
+								Data:   params.StatusData{},
+							},
+							AgentState: "pending",
 						},
 					},
 				},

--- a/state/apiserver/client/status.go
+++ b/state/apiserver/client/status.go
@@ -351,13 +351,10 @@ func (context *statusContext) processMachine(machines []*state.Machine, host *ap
 
 func (context *statusContext) makeMachineStatus(machine *state.Machine) (status api.MachineStatus) {
 	status.Id = machine.Id()
-	agentStatus := processAgent(machine)
-	status.Life = agentStatus.Life
-	status.AgentVersion = agentStatus.Version
-	status.AgentState = agentStatus.Status
-	status.AgentStateInfo = agentStatus.Info
-	status.AgentStateData = agentStatus.Data
-	status.Err = agentStatus.Err
+	status.Agent, status.AgentState, status.AgentStateInfo = processAgent(machine)
+	status.AgentVersion = status.Agent.Version
+	status.Life = status.Agent.Life
+	status.Err = status.Agent.Err
 	status.Series = machine.Series()
 	status.Jobs = paramsJobsFromJobs(machine.Jobs())
 	status.WantsVote = machine.WantsVote()
@@ -551,13 +548,10 @@ func (context *statusContext) processUnit(unit *state.Unit, serviceCharm string)
 	if serviceCharm != "" && curl != nil && curl.String() != serviceCharm {
 		status.Charm = curl.String()
 	}
-	agentStatus := processAgent(unit)
-	status.Life = agentStatus.Life
-	status.AgentVersion = agentStatus.Version
-	status.AgentState = agentStatus.Status
-	status.AgentStateInfo = agentStatus.Info
-	status.AgentStateData = agentStatus.Data
-	status.Err = agentStatus.Err
+	status.Agent, status.AgentState, status.AgentStateInfo = processAgent(unit)
+	status.AgentVersion = status.Agent.Version
+	status.Life = status.Agent.Life
+	status.Err = status.Agent.Err
 	if subUnits := unit.SubordinateNames(); len(subUnits) > 0 {
 		status.Subordinates = make(map[string]api.UnitStatus)
 		for _, name := range subUnits {
@@ -616,17 +610,10 @@ type stateAgent interface {
 	Status() (params.Status, string, params.StatusData, error)
 }
 
-type agentStatus struct {
-	Life    string
-	Version string
-	Status  params.Status
-	Info    string
-	Data    params.StatusData
-	Err     error
-}
-
 // processAgent retrieves version and status information from the given entity.
-func processAgent(entity stateAgent) (out agentStatus) {
+func processAgent(entity stateAgent) (
+	out api.AgentStatus, compatStatus params.Status, compatInfo string) {
+
 	out.Life = processLife(entity)
 
 	if t, err := entity.AgentTools(); err == nil {
@@ -634,6 +621,8 @@ func processAgent(entity stateAgent) (out agentStatus) {
 	}
 
 	out.Status, out.Info, out.Data, out.Err = entity.Status()
+	compatStatus = out.Status
+	compatInfo = out.Info
 	out.Data = filterStatusData(out.Data)
 	if out.Err != nil {
 		return
@@ -651,14 +640,27 @@ func processAgent(entity stateAgent) (out agentStatus) {
 	}
 
 	if entity.Life() != state.Dead && !agentAlive {
-		// The agent *should* be alive but is not.
-		// Add the original status to the info, so it's not lost.
+		// The agent *should* be alive but is not. Set status to
+		// StatusDown and munge Info to indicate the previous status and
+		// info. This is unfortunately making presentation decisions
+		// on behalf of the client (crappy).
+		//
+		// This is munging is only being left in place for
+		// compatibility with older clients.  TODO: At some point we
+		// should change this so that Info left alone. API version may
+		// help here.
+		//
+		// Better yet, Status shouldn't be changed here in the API at
+		// all! Status changes should only happen in State. One
+		// problem caused by this is that this status change won't be
+		// seen by clients using a watcher because it didn't happen in
+		// State.
 		if out.Info != "" {
-			out.Info = fmt.Sprintf("(%s: %s)", out.Status, out.Info)
+			compatInfo = fmt.Sprintf("(%s: %s)", out.Status, out.Info)
 		} else {
-			out.Info = fmt.Sprintf("(%s)", out.Status)
+			compatInfo = fmt.Sprintf("(%s)", out.Status)
 		}
-		out.Status = params.StatusDown
+		compatStatus = params.StatusDown
 	}
 
 	return


### PR DESCRIPTION
Machine and unit agent status is now reported under a separate "Agent"
struct. For compatibility reasons the existing agent status fields
have been left as is (but will eventually be removed). StatusData was
moved and only exists under Agent because it was recently added and
didn't make it in to any Juju release yet - there's no reason to
maintain backwards compatibility for that field.

If API versioning lands soon I will revisit this and remove field
duplication.

The main driver for this change is to allow clients to to easily
access the original status and info after the API has set the status
to StatusDown and munged the info string. These will be used by the
command line client in a later PR.
