### PR TITLE
Implement automatic availability zone spread

### DIFF
--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -27,19 +27,19 @@ type ZonedEnviron interface {
 	// AvailabilityZones returns all availability zones in the environment.
 	AvailabilityZones() ([]AvailabilityZone, error)
 
-	// InstanceAvailabilityZones returns the names of the availability zones
-	// for the specified instances. The error returned follows the same rules as
-	// Environ.Instances.
-	InstanceAvailabilityZones(ids []instance.Id) ([]string, error)
+	// InstanceAvailabilityZoneNames returns the names of the availability
+	// zones for the specified instances. The error returned follows the same
+	// rules as Environ.Instances.
+	InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, error)
 }
 
-// BestAvailabilityZone returns the availability zones with the
-// fewest instances from the specified group, along with the
-// instances from the group currently allocated to those zones.
+// BestAvailabilityZoneAllocations returns the availability zones with the
+// fewest instances from the specified group, along with the instances from
+// the group currently allocated to those zones.
 //
-// If the specified group is empty, then it will behave as if the
-// result of AllInstances were provided.
-func BestAvailabilityZones(env ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
+// If the specified group is empty, then it will behave as if the result of
+// AllInstances were provided.
+func BestAvailabilityZoneAllocations(env ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
 	if len(group) == 0 {
 		instances, err := env.AllInstances()
 		if err != nil {
@@ -50,7 +50,7 @@ func BestAvailabilityZones(env ZonedEnviron, group []instance.Id) (map[string][]
 			group[i] = inst.Id()
 		}
 	}
-	instanceZones, err := env.InstanceAvailabilityZones(group)
+	instanceZones, err := env.InstanceAvailabilityZoneNames(group)
 	if err != nil && err != environs.ErrPartialInstances {
 		return nil, err
 	}
@@ -106,14 +106,14 @@ func BestAvailabilityZones(env ZonedEnviron, group []instance.Id) (map[string][]
 	return zoneInstances, nil
 }
 
-var internalBestAvailabilityZones = BestAvailabilityZones
+var internalBestAvailabilityZoneAllocations = BestAvailabilityZoneAllocations
 
 // DistributeInstances is a common function for implement the
 // state.InstanceDistributor policy based on availability zone
 // spread.
 func DistributeInstances(env ZonedEnviron, candidates, group []instance.Id) ([]instance.Id, error) {
 	// Determine the best availability zones for the group.
-	bestAvailabilityZones, err := internalBestAvailabilityZones(env, group)
+	bestAvailabilityZones, err := internalBestAvailabilityZoneAllocations(env, group)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/common/availabilityzones_test.go
+++ b/provider/common/availabilityzones_test.go
@@ -45,14 +45,14 @@ func (s *AvailabilityZoneSuite) SetUpSuite(c *gc.C) {
 	}
 }
 
-func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesAllInstances(c *gc.C) {
+func (s *AvailabilityZoneSuite) TestBestAvailabilityZoneAllocationsAllInstances(c *gc.C) {
 	var called int
-	s.PatchValue(&s.env.instanceAvailabilityZones, func(ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ids []instance.Id) ([]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"inst0", "inst1", "inst2"})
 		called++
 		return []string{"az0", "az1", "az2"}, nil
 	})
-	best, err := common.BestAvailabilityZones(&s.env, nil)
+	best, err := common.BestAvailabilityZoneAllocations(&s.env, nil)
 	c.Assert(called, gc.Equals, 1)
 	c.Assert(err, gc.IsNil)
 	// az0 is unavailable, so az1 and az2 come out as equal best.
@@ -62,69 +62,69 @@ func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesAllInstances(c *gc.C) {
 	})
 }
 
-func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesAllInstancesErrors(c *gc.C) {
+func (s *AvailabilityZoneSuite) TestBestAvailabilityZoneAllocationsAllInstancesErrors(c *gc.C) {
 	resultErr := fmt.Errorf("oh noes")
 	s.PatchValue(&s.env.allInstances, func() ([]instance.Instance, error) {
 		return nil, resultErr
 	})
-	best, err := common.BestAvailabilityZones(&s.env, nil)
+	best, err := common.BestAvailabilityZoneAllocations(&s.env, nil)
 	c.Assert(err, gc.Equals, resultErr)
 	c.Assert(best, gc.HasLen, 0)
 }
 
-func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesPartialInstances(c *gc.C) {
+func (s *AvailabilityZoneSuite) TestBestAvailabilityZoneAllocationsPartialInstances(c *gc.C) {
 	var called int
-	s.PatchValue(&s.env.instanceAvailabilityZones, func(ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ids []instance.Id) ([]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"nichts", "inst1", "null", "inst2"})
 		called++
 		return []string{"", "az1", "", "az1"}, environs.ErrPartialInstances
 	})
-	best, err := common.BestAvailabilityZones(&s.env, []instance.Id{"nichts", "inst1", "null", "inst2"})
+	best, err := common.BestAvailabilityZoneAllocations(&s.env, []instance.Id{"nichts", "inst1", "null", "inst2"})
 	c.Assert(called, gc.Equals, 1)
 	c.Assert(err, gc.IsNil)
 	// All known instances are in az1 and az0 is unavailable, so az2 is the best.
 	c.Assert(best, gc.DeepEquals, map[string][]instance.Id{"az2": nil})
 }
 
-func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesInstanceAvailabilityZonesErrors(c *gc.C) {
+func (s *AvailabilityZoneSuite) TestBestAvailabilityZoneAllocationsInstanceAvailabilityZonesErrors(c *gc.C) {
 	var returnErr error
 	var called int
-	s.PatchValue(&s.env.instanceAvailabilityZones, func(ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ids []instance.Id) ([]string, error) {
 		called++
 		return nil, returnErr
 	})
 	errors := []error{environs.ErrNoInstances, fmt.Errorf("whatever")}
 	for i, err := range errors {
 		returnErr = err
-		best, err := common.BestAvailabilityZones(&s.env, nil)
+		best, err := common.BestAvailabilityZoneAllocations(&s.env, nil)
 		c.Assert(called, gc.Equals, i+1)
 		c.Assert(err, gc.Equals, returnErr)
 		c.Assert(best, gc.HasLen, 0)
 	}
 }
 
-func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesNoZones(c *gc.C) {
+func (s *AvailabilityZoneSuite) TestBestAvailabilityZoneAllocationsNoZones(c *gc.C) {
 	var calls []string
-	s.PatchValue(&s.env.instanceAvailabilityZones, func(ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ids []instance.Id) ([]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"inst0", "inst1", "inst2"})
-		calls = append(calls, "InstanceAvailabilityZones")
+		calls = append(calls, "InstanceAvailabilityZoneNames")
 		return []string{"", "", ""}, nil
 	})
 	s.PatchValue(&s.env.availabilityZones, func() ([]common.AvailabilityZone, error) {
 		calls = append(calls, "AvailabilityZones")
 		return []common.AvailabilityZone{}, nil
 	})
-	best, err := common.BestAvailabilityZones(&s.env, nil)
-	c.Assert(calls, gc.DeepEquals, []string{"InstanceAvailabilityZones", "AvailabilityZones"})
+	best, err := common.BestAvailabilityZoneAllocations(&s.env, nil)
+	c.Assert(calls, gc.DeepEquals, []string{"InstanceAvailabilityZoneNames", "AvailabilityZones"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(best, gc.HasLen, 0)
 }
 
-func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesErrors(c *gc.C) {
+func (s *AvailabilityZoneSuite) TestBestAvailabilityZoneAllocationsErrors(c *gc.C) {
 	var calls []string
-	s.PatchValue(&s.env.instanceAvailabilityZones, func(ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ids []instance.Id) ([]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"inst0", "inst1", "inst2"})
-		calls = append(calls, "InstanceAvailabilityZones")
+		calls = append(calls, "InstanceAvailabilityZoneNames")
 		return []string{"", "", ""}, nil
 	})
 	resultErr := fmt.Errorf("u can haz no az")
@@ -132,8 +132,8 @@ func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesErrors(c *gc.C) {
 		calls = append(calls, "AvailabilityZones")
 		return nil, resultErr
 	})
-	best, err := common.BestAvailabilityZones(&s.env, nil)
-	c.Assert(calls, gc.DeepEquals, []string{"InstanceAvailabilityZones", "AvailabilityZones"})
+	best, err := common.BestAvailabilityZoneAllocations(&s.env, nil)
+	c.Assert(calls, gc.DeepEquals, []string{"InstanceAvailabilityZoneNames", "AvailabilityZones"})
 	c.Assert(err, gc.Equals, resultErr)
 	c.Assert(best, gc.HasLen, 0)
 }
@@ -141,7 +141,7 @@ func (s *AvailabilityZoneSuite) TestBestAvailabilityZonesErrors(c *gc.C) {
 func (s *AvailabilityZoneSuite) TestDistributeInstancesGroup(c *gc.C) {
 	expectedGroup := []instance.Id{"0", "1", "2"}
 	var called bool
-	s.PatchValue(common.InternalBestAvailabilityZones, func(_ common.ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
+	s.PatchValue(common.InternalBestAvailabilityZoneAllocations, func(_ common.ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
 		c.Assert(group, gc.DeepEquals, expectedGroup)
 		called = true
 		return nil, nil
@@ -152,7 +152,7 @@ func (s *AvailabilityZoneSuite) TestDistributeInstancesGroup(c *gc.C) {
 
 func (s *AvailabilityZoneSuite) TestDistributeInstancesGroupErrors(c *gc.C) {
 	resultErr := fmt.Errorf("whatever")
-	s.PatchValue(common.InternalBestAvailabilityZones, func(_ common.ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
+	s.PatchValue(common.InternalBestAvailabilityZoneAllocations, func(_ common.ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
 		return nil, resultErr
 	})
 	_, err := common.DistributeInstances(&s.env, nil, nil)
@@ -161,7 +161,7 @@ func (s *AvailabilityZoneSuite) TestDistributeInstancesGroupErrors(c *gc.C) {
 
 func (s *AvailabilityZoneSuite) TestDistributeInstances(c *gc.C) {
 	var bestAvailabilityZones map[string][]instance.Id
-	s.PatchValue(common.InternalBestAvailabilityZones, func(_ common.ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
+	s.PatchValue(common.InternalBestAvailabilityZoneAllocations, func(_ common.ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
 		return bestAvailabilityZones, nil
 	})
 

--- a/provider/common/export_test.go
+++ b/provider/common/export_test.go
@@ -4,10 +4,10 @@
 package common
 
 var (
-	GetAddresses                  = getAddresses
-	GetStateInfo                  = getStateInfo
-	ComposeAddresses              = composeAddresses
-	ConnectSSH                    = &connectSSH
-	WaitSSH                       = waitSSH
-	InternalBestAvailabilityZones = &internalBestAvailabilityZones
+	GetAddresses                            = getAddresses
+	GetStateInfo                            = getStateInfo
+	ComposeAddresses                        = composeAddresses
+	ConnectSSH                              = &connectSSH
+	WaitSSH                                 = waitSSH
+	InternalBestAvailabilityZoneAllocations = &internalBestAvailabilityZoneAllocations
 )

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -89,20 +89,20 @@ func (env *mockEnviron) GetImageSources() ([]simplestreams.DataSource, error) {
 }
 
 type availabilityZonesFunc func() ([]common.AvailabilityZone, error)
-type instanceAvailabilityZonesFunc func([]instance.Id) ([]string, error)
+type instanceAvailabilityZoneNamesFunc func([]instance.Id) ([]string, error)
 
 type mockZonedEnviron struct {
 	mockEnviron
-	availabilityZones         availabilityZonesFunc
-	instanceAvailabilityZones instanceAvailabilityZonesFunc
+	availabilityZones             availabilityZonesFunc
+	instanceAvailabilityZoneNames instanceAvailabilityZoneNamesFunc
 }
 
 func (env *mockZonedEnviron) AvailabilityZones() ([]common.AvailabilityZone, error) {
 	return env.availabilityZones()
 }
 
-func (env *mockZonedEnviron) InstanceAvailabilityZones(ids []instance.Id) ([]string, error) {
-	return env.instanceAvailabilityZones(ids)
+func (env *mockZonedEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, error) {
+	return env.instanceAvailabilityZoneNames(ids)
 }
 
 type mockInstance struct {

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -41,11 +41,10 @@ func InstanceEC2(inst instance.Instance) *ec2.Instance {
 	return inst.(*ec2Instance).Instance
 }
 
-func GetAvailabilityZones(e environs.Environ) ([]ec2.AvailabilityZoneInfo, error) {
-	return e.(*environ).getAvailabilityZones()
-}
-
-var EC2AvailabilityZones = &ec2AvailabilityZones
+var (
+	EC2AvailabilityZones            = &ec2AvailabilityZones
+	BestAvailabilityZoneAllocations = &bestAvailabilityZoneAllocations
+)
 
 // BucketStorage returns a storage instance addressing
 // an arbitrary s3 bucket.

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/ec2"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/utils/ssh"
@@ -370,30 +371,125 @@ func (t *localServerSuite) TestGetAvailabilityZones(c *gc.C) {
 		}
 		return resp, resultErr
 	})
-	env := t.Prepare(c)
+	env := t.Prepare(c).(common.ZonedEnviron)
 
 	resultErr = fmt.Errorf("failed to get availability zones")
-	zones, err := ec2.GetAvailabilityZones(env)
+	zones, err := env.AvailabilityZones()
 	c.Assert(err, gc.Equals, resultErr)
 	c.Assert(zones, gc.IsNil)
 
 	resultErr = nil
 	resultZones = make([]amzec2.AvailabilityZoneInfo, 1)
 	resultZones[0].Name = "whatever"
-	zones, err = ec2.GetAvailabilityZones(env)
+	zones, err = env.AvailabilityZones()
 	c.Assert(err, gc.IsNil)
 	c.Assert(zones, gc.HasLen, 1)
-	c.Assert(zones[0].Name, gc.Equals, "whatever")
+	c.Assert(zones[0].Name(), gc.Equals, "whatever")
 
 	// A successful result is cached, currently for the lifetime
 	// of the Environ. This will change if/when we have long-lived
 	// Environs to cut down repeated IaaS requests.
 	resultErr = fmt.Errorf("failed to get availability zones")
 	resultZones[0].Name = "andever"
-	zones, err = ec2.GetAvailabilityZones(env)
+	zones, err = env.AvailabilityZones()
 	c.Assert(err, gc.IsNil)
 	c.Assert(zones, gc.HasLen, 1)
-	c.Assert(zones[0].Name, gc.Equals, "whatever")
+	c.Assert(zones[0].Name(), gc.Equals, "whatever")
+}
+
+func (t *localServerSuite) TestGetAvailabilityZonesCommon(c *gc.C) {
+	var resultZones []amzec2.AvailabilityZoneInfo
+	t.PatchValue(ec2.EC2AvailabilityZones, func(e *amzec2.EC2, f *amzec2.Filter) (*amzec2.AvailabilityZonesResp, error) {
+		resp := &amzec2.AvailabilityZonesResp{
+			Zones: append([]amzec2.AvailabilityZoneInfo{}, resultZones...),
+		}
+		return resp, nil
+	})
+	env := t.Prepare(c).(common.ZonedEnviron)
+	resultZones = make([]amzec2.AvailabilityZoneInfo, 2)
+	resultZones[0].Name = "az1"
+	resultZones[1].Name = "az2"
+	resultZones[0].State = "available"
+	resultZones[1].State = "impaired"
+	zones, err := env.AvailabilityZones()
+	c.Assert(err, gc.IsNil)
+	c.Assert(zones, gc.HasLen, 2)
+	c.Assert(zones[0].Name(), gc.Equals, resultZones[0].Name)
+	c.Assert(zones[1].Name(), gc.Equals, resultZones[1].Name)
+	c.Assert(zones[0].Available(), jc.IsTrue)
+	c.Assert(zones[1].Available(), jc.IsFalse)
+}
+
+type mockBestAvailabilityZoneAllocation struct {
+	group  []instance.Id // input param
+	result map[string][]instance.Id
+	err    error
+}
+
+func (t *mockBestAvailabilityZoneAllocation) F(e common.ZonedEnviron, group []instance.Id) (map[string][]instance.Id, error) {
+	t.group = group
+	return t.result, t.err
+}
+
+func (t *localServerSuite) TestStartInstanceDistributionParams(c *gc.C) {
+	env := t.Prepare(c)
+	envtesting.UploadFakeTools(c, env.Storage())
+	err := bootstrap.Bootstrap(coretesting.Context(c), env, environs.BootstrapParams{})
+	c.Assert(err, gc.IsNil)
+
+	var mock mockBestAvailabilityZoneAllocation
+	t.PatchValue(ec2.BestAvailabilityZoneAllocations, mock.F)
+
+	// no distribution group specified
+	testing.AssertStartInstance(c, env, "1")
+	c.Assert(mock.group, gc.HasLen, 0)
+
+	// distribution group specified: ensure it's passed through to BestAvailabilityZone.
+	expectedInstances := []instance.Id{"i-0", "i-1"}
+	params := environs.StartInstanceParams{
+		DistributionGroup: func() ([]instance.Id, error) {
+			return expectedInstances, nil
+		},
+	}
+	_, _, _, err = testing.StartInstanceWithParams(env, "1", params, nil)
+	c.Assert(err, gc.IsNil)
+	c.Assert(mock.group, gc.DeepEquals, expectedInstances)
+}
+
+func (t *localServerSuite) TestStartInstanceDistributionErrors(c *gc.C) {
+	env := t.Prepare(c)
+	envtesting.UploadFakeTools(c, env.Storage())
+	err := bootstrap.Bootstrap(coretesting.Context(c), env, environs.BootstrapParams{})
+	c.Assert(err, gc.IsNil)
+
+	mock := mockBestAvailabilityZoneAllocation{
+		err: fmt.Errorf("BestAvailabilityZoneAllocations failed"),
+	}
+	t.PatchValue(ec2.BestAvailabilityZoneAllocations, mock.F)
+	_, _, _, err = testing.StartInstance(env, "1")
+	c.Assert(err, gc.Equals, mock.err)
+
+	mock.err = nil
+	dgErr := fmt.Errorf("DistributionGroup failed")
+	params := environs.StartInstanceParams{
+		DistributionGroup: func() ([]instance.Id, error) {
+			return nil, dgErr
+		},
+	}
+	_, _, _, err = testing.StartInstanceWithParams(env, "1", params, nil)
+	c.Assert(err, gc.Equals, dgErr)
+}
+
+func (t *localServerSuite) TestStartInstanceDistribution(c *gc.C) {
+	env := t.Prepare(c)
+	envtesting.UploadFakeTools(c, env.Storage())
+	err := bootstrap.Bootstrap(coretesting.Context(c), env, environs.BootstrapParams{})
+	c.Assert(err, gc.IsNil)
+
+	// test-available is the only available AZ, so BestAvailabilityZoneAllocations
+	// is guaranteed to return that.
+	inst, _ := testing.AssertStartInstance(c, env, "1")
+	c.Assert(ec2.InstanceEC2(inst).AvailZone, gc.Equals, "test-available")
 }
 
 func (t *localServerSuite) TestAddresses(c *gc.C) {


### PR DESCRIPTION
There are two components to this PR:
- new functionality in `provider/common` to enable automatic spread of instances across AZs;
- updates to `provider/ec2` to make use of this common code.

The openstack provider will be updated in a followup.
