### PR TITLE
Introducing Environ.ListNetworks()

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -120,6 +120,11 @@ type Environ interface {
 	// given instance on the given network.
 	AllocateAddress(instId instance.Id, netId network.Id) (network.Address, error)
 
+	// ListNetworks returns basic information about all networks known
+	// by the provider for the environment. They may be unknown to juju
+	// yet (i.e. when called initially or when a new network was created).
+	ListNetworks() ([]network.BasicInfo, error)
+
 	// ConfigGetter allows the retrieval of the configuration data.
 	ConfigGetter
 

--- a/network/network.go
+++ b/network/network.go
@@ -10,6 +10,24 @@ import (
 // Id defines a provider-specific network id.
 type Id string
 
+// BasicInfo describes the bare minimum information for a network,
+// which the provider knows about but juju might not yet.
+type BasicInfo struct {
+	// CIDR of the network, in 123.45.67.89/24 format. Can be empty if
+	// unknown.
+	CIDR string
+
+	// ProviderId is a provider-specific network id. This the only
+	// required field.
+	ProviderId Id
+
+	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
+	// normal networks. It's defined by IEEE 802.1Q standard, and used
+	// to define a VLAN network. For more information, see:
+	// http://en.wikipedia.org/wiki/IEEE_802.1Q.
+	VLANTag int
+}
+
 // Info describes a single network interface available on an instance.
 // For providers that support networks, this will be available at
 // StartInstance() time.
@@ -36,7 +54,7 @@ type Info struct {
 	InterfaceName string
 
 	// IsVirtual is true when the interface is a virtual device, as
-	// opposed to a physical device (e.g. a VLAN or a network alias)
+	// opposed to a physical device (e.g. a VLAN or a network alias).
 	IsVirtual bool
 
 	// Disabled is true when the interface needs to be disabled on the

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -947,6 +947,14 @@ func (*azureEnviron) AllocateAddress(_ instance.Id, _ network.Id) (network.Addre
 	return network.Address{}, errors.NotImplementedf("AllocateAddress")
 }
 
+// ListNetworks returns basic information about all networks known
+// by the provider for the environment. They may be unknown to juju
+// yet (i.e. when called initially or when a new network was created).
+// This is not implemented by the Azure provider yet.
+func (*azureEnviron) ListNetworks() ([]network.BasicInfo, error) {
+	return nil, errors.NotImplementedf("ListNetworks")
+}
+
 // AllInstances is specified in the InstanceBroker interface.
 func (env *azureEnviron) AllInstances() ([]instance.Instance, error) {
 	// The instance list is built using the list of all the Azure

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -7,6 +7,7 @@ import (
 	stdtesting "testing"
 	"time"
 
+	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/environs"
@@ -81,7 +82,7 @@ func (s *suite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-func (s *suite) TestAllocateAddress(c *gc.C) {
+func (s *suite) bootstrapTestEnviron(c *gc.C) environs.Environ {
 	cfg, err := config.New(config.NoDefaults, s.TestConfig)
 	c.Assert(err, gc.IsNil)
 	e, err := environs.Prepare(cfg, testing.Context(c), s.ConfigStore)
@@ -93,6 +94,11 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	err = bootstrap.Bootstrap(testing.Context(c), e, environs.BootstrapParams{})
 	c.Assert(err, gc.IsNil)
+	return e
+}
+
+func (s *suite) TestAllocateAddress(c *gc.C) {
+	e := s.bootstrapTestEnviron(c)
 
 	inst, _ := jujutesting.AssertStartInstance(c, e, "0")
 	c.Assert(inst, gc.NotNil)
@@ -115,6 +121,22 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 	assertAllocateAddress(c, e, opc, inst.Id(), netId, expectAddress)
 }
 
+func (s *suite) TestListNetworks(c *gc.C) {
+	e := s.bootstrapTestEnviron(c)
+
+	opc := make(chan dummy.Operation, 200)
+	dummy.Listen(opc)
+
+	expectInfo := []network.BasicInfo{
+		{CIDR: "0.10.0.0/8", ProviderId: "dummy-private"},
+		{CIDR: "0.20.0.0/24", ProviderId: "dummy-public"},
+	}
+	netInfo, err := e.ListNetworks()
+	c.Assert(err, gc.IsNil)
+	c.Assert(netInfo, jc.DeepEquals, expectInfo)
+	assertListNetworks(c, e, opc, expectInfo)
+}
+
 func assertAllocateAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectNetId network.Id, expectAddress network.Address) {
 	select {
 	case op := <-opc:
@@ -125,6 +147,20 @@ func assertAllocateAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation
 		c.Check(addrOp.NetworkId, gc.Equals, expectNetId)
 		c.Check(addrOp.InstanceId, gc.Equals, expectInstId)
 		c.Check(addrOp.Address, gc.Equals, expectAddress)
+		return
+	case <-time.After(testing.ShortWait):
+		c.Fatalf("time out wating for operation")
+	}
+}
+
+func assertListNetworks(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInfo []network.BasicInfo) {
+	select {
+	case op := <-opc:
+		netOp, ok := op.(dummy.OpListNetworks)
+		if !ok {
+			c.Fatalf("unexpected op: %#v", op)
+		}
+		c.Check(netOp.Info, jc.DeepEquals, expectInfo)
 		return
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("time out wating for operation")

--- a/provider/ec2/ec2.go
+++ b/provider/ec2/ec2.go
@@ -749,6 +749,14 @@ func (*environ) AllocateAddress(_ instance.Id, _ network.Id) (network.Address, e
 	return network.Address{}, errors.NotImplementedf("AllocateAddress")
 }
 
+// ListNetworks returns basic information about all networks known
+// by the provider for the environment. They may be unknown to juju
+// yet (i.e. when called initially or when a new network was created).
+// This is not implemented by the EC2 provider yet.
+func (*environ) ListNetworks() ([]network.BasicInfo, error) {
+	return nil, errors.NotImplementedf("ListNetworks")
+}
+
 func (e *environ) AllInstances() ([]instance.Instance, error) {
 	filter := ec2.NewFilter()
 	filter.Add("instance-state-name", "pending", "running")

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -232,6 +232,14 @@ func (*joyentEnviron) AllocateAddress(_ instance.Id, _ network.Id) (network.Addr
 	return network.Address{}, errors.NotImplementedf("AllocateAddress")
 }
 
+// ListNetworks returns basic information about all networks known by
+// the provider for the environment. They may be unknown to juju yet
+// (i.e. when called initially or when a new network was created).
+// This is not implemented on the Joyent provider yet.
+func (*joyentEnviron) ListNetworks() ([]network.BasicInfo, error) {
+	return nil, errors.NotImplementedf("ListNetworks")
+}
+
 func (env *joyentEnviron) StopInstances(ids ...instance.Id) error {
 	// Remove all the instances in parallel so that we incur less round-trips.
 	var wg sync.WaitGroup

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -407,6 +407,14 @@ func (*localEnviron) AllocateAddress(_ instance.Id, _ network.Id) (network.Addre
 	return network.Address{}, errors.NotSupportedf("AllocateAddress")
 }
 
+// ListNetworks returns basic information about all networks known
+// by the provider for the environment. They may be unknown to juju
+// yet (i.e. when called initially or when a new network was created).
+// This is not implemented by the local provider yet.
+func (*localEnviron) ListNetworks() ([]network.BasicInfo, error) {
+	return nil, errors.NotImplementedf("ListNetworks")
+}
+
 // AllInstances is specified in the InstanceBroker interface.
 func (env *localEnviron) AllInstances() (instances []instance.Instance, err error) {
 	instances = append(instances, &localInstance{bootstrapInstanceId, env})

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -647,6 +647,14 @@ func (*maasEnviron) AllocateAddress(_ instance.Id, _ network.Id) (network.Addres
 	return network.Address{}, errors.NotImplementedf("AllocateAddress")
 }
 
+// ListNetworks returns basic information about all networks known
+// by the provider for the environment. They may be unknown to juju
+// yet (i.e. when called initially or when a new network was created).
+// This is not implemented by the MAAS provider yet.
+func (*maasEnviron) ListNetworks() ([]network.BasicInfo, error) {
+	return nil, errors.NotImplementedf("ListNetworks")
+}
+
 // AllInstances returns all the instance.Instance in this provider.
 func (environ *maasEnviron) AllInstances() ([]instance.Instance, error) {
 	return environ.instances(nil)

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -207,6 +207,14 @@ func (*manualEnviron) AllocateAddress(_ instance.Id, _ network.Id) (network.Addr
 	return network.Address{}, errors.NotSupportedf("AllocateAddress")
 }
 
+// ListNetworks returns basic information about all networks known
+// by the provider for the environment. They may be unknown to juju
+// yet (i.e. when called initially or when a new network was created).
+// This is not implemented by the manual provider yet.
+func (*manualEnviron) ListNetworks() ([]network.BasicInfo, error) {
+	return nil, errors.NotImplementedf("ListNetworks")
+}
+
 var newSSHStorage = func(sshHost, storageDir, storageTmpdir string) (storage.Storage, error) {
 	logger.Debugf("using ssh storage at host %q dir %q", sshHost, storageDir)
 	return sshstorage.NewSSHStorage(sshstorage.NewSSHStorageParams{

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1051,6 +1051,14 @@ func (*environ) AllocateAddress(_ instance.Id, _ network.Id) (network.Address, e
 	return network.Address{}, jujuerrors.NotImplementedf("AllocateAddress")
 }
 
+// ListNetworks returns basic information about all networks known
+// by the provider for the environment. They may be unknown to juju
+// yet (i.e. when called initially or when a new network was created).
+// This is not implemented by the OpenStack provider yet.
+func (*environ) ListNetworks() ([]network.BasicInfo, error) {
+	return nil, jujuerrors.NotImplementedf("ListNetworks")
+}
+
 func (e *environ) AllInstances() (insts []instance.Instance, err error) {
 	servers, err := e.nova().ListServersDetail(e.machinesFilter())
 	if err != nil {


### PR DESCRIPTION
Provides a way for juju to discover what networks
are available from the provider. Later, we'll use
that information to discover networks initially
(at bootstrap) and to update them when they change.

Implemented in dummy provider only and stubbed it
out in the others

In a follow-up a concept of "pending networks" will
be introduced in state to hold such networks until
the user decides to use them (i.e. by running
juju add-network --existing).
