### PR TITLE
Update code.google.com/p/go.crypto to the latest

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,4 +1,4 @@
-code.google.com/p/go.crypto	hg	6478cc9340cbbe6c04511280c5007722269108e9	184
+code.google.com/p/go.crypto	hg	5478be1963aafa9025e9bf0837aff6013eb92e5b	199
 code.google.com/p/go.net	hg	c17ad62118ea511e1051721b429779fa40bddc74	116
 github.com/binary132/gojsonpointer	git	57ab5e9c764219a3e0c4d7759797fefdcab22e9c	
 github.com/binary132/gojsonreference	git	75785fb7b21f9bf2051dca600da83ff57bc6582a	

--- a/utils/ssh/authorisedkeys.go
+++ b/utils/ssh/authorisedkeys.go
@@ -34,6 +34,7 @@ const (
 )
 
 type AuthorisedKey struct {
+	Type    string
 	Key     []byte
 	Comment string
 }
@@ -42,13 +43,13 @@ type AuthorisedKey struct {
 // authorized_keys file and returns the constituent parts.
 // Based on description in "man sshd".
 func ParseAuthorisedKey(line string) (*AuthorisedKey, error) {
-	key, comment, _, _, ok := ssh.ParseAuthorizedKey([]byte(line))
-	if !ok {
+	key, comment, _, _, err := ssh.ParseAuthorizedKey([]byte(line))
+	if err != nil {
 		return nil, fmt.Errorf("invalid authorized_key %q", line)
 	}
-	keyBytes := ssh.MarshalPublicKey(key)
 	return &AuthorisedKey{
-		Key:     keyBytes,
+		Type:    key.Type(),
+		Key:     key.Marshal(),
 		Comment: comment,
 	}, nil
 }


### PR DESCRIPTION
Fixes LP 1312940, Fixes #43

This PR applies a branch from mgz (https://code.launchpad.net/~gz/juju-core/gosshnew_1312940). This branch was proposed a while ago but was delayed until all builders and package builders were running Go 1.2. 

Sinzui has confirmed that this has now happened so we are unblocked and can move off this old version of go.crypto.

This has the further effect that Go can be built from source without godeps, and this unblocks tools that consume Juju via `go get`, and makes us look like good Go citizens.
