### PR TITLE
state/apiserver/client: don't send containers to StopInstances

### DIFF
--- a/state/apiserver/client/destroy.go
+++ b/state/apiserver/client/destroy.go
@@ -81,6 +81,9 @@ func destroyInstances(st *state.State, machines []*state.Machine) error {
 		if m.IsManager() {
 			continue
 		}
+		if _, isContainer := m.ParentId(); isContainer {
+			continue
+		}
 		manual, err := m.IsManual()
 		if manual {
 			continue


### PR DESCRIPTION
The DestroyEnvironment API attempts to destroy all non-manager,
non-manual instances. We should also ignore containers here.

Fixes https://bugs.launchpad.net/juju-core/+bug/1325830
