### PR TITLE
state: Pending networks and related ops

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -70,3 +70,12 @@ func (i *Info) ActualInterfaceName() string {
 	}
 	return i.InterfaceName
 }
+
+// IsVLANTag returns nil if the given value is considered a valid VLAN
+// tag, as defined by IEEE 802.1Q standard, or an error otherwise.
+func IsVLANTag(value int) error {
+	if value < 0 || value > 4094 {
+		return fmt.Errorf("invalid VLAN tag %d: must be between 0 and 4094", value)
+	}
+	return nil
+}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1,0 +1,53 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/testing"
+)
+
+type NetworkSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&NetworkSuite{})
+
+func (s *NetworkSuite) TestIsVLANTag(c *gc.C) {
+	tests := []struct {
+		value int
+		valid bool
+	}{{
+		value: -100,
+		valid: false,
+	}, {
+		value: -0,
+		valid: true,
+	}, {
+		value: 9999,
+		valid: false,
+	}, {
+		value: 4095,
+		valid: false,
+	}, {
+		value: 4094,
+		valid: true,
+	}, {
+		value: 1,
+		valid: true,
+	}}
+
+	for i, t := range tests {
+		c.Logf("test %d: %d -> %v", i, t.value, t.valid)
+		err := network.IsVLANTag(t.value)
+		if t.valid {
+			c.Check(err, gc.IsNil)
+		} else {
+			expectErr := "invalid VLAN tag .*: must be between 0 and 4094"
+			c.Check(err, gc.ErrorMatches, expectErr)
+		}
+	}
+}

--- a/state/open.go
+++ b/state/open.go
@@ -216,6 +216,7 @@ func newState(session *mgo.Session, info *Info, policy Policy) (*State, error) {
 		services:          db.C("services"),
 		requestedNetworks: db.C("requestednetworks"),
 		networks:          db.C("networks"),
+		pendingNetworks:   db.C("pendingnetworks"),
 		networkInterfaces: db.C("networkinterfaces"),
 		minUnits:          db.C("minunits"),
 		settings:          db.C("settings"),

--- a/state/pendingnetworks.go
+++ b/state/pendingnetworks.go
@@ -1,0 +1,47 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"labix.org/v2/mgo/txn"
+
+	"github.com/juju/juju/network"
+)
+
+// pendingNetworkDoc represents a network, available in the
+// environment (i.e. known to the provider), but not yet used in juju
+// for deployments. It needs to be "promoted" to an actual network
+// before that.
+type pendingNetworkDoc struct {
+	ProviderId network.Id `bson:"_id"`
+	CIDR       string
+	VLANTag    int
+}
+
+func newPendingNetworkDoc(providerId network.Id, cidr string, vlanTag int) *pendingNetworkDoc {
+	return &pendingNetworkDoc{ProviderId: providerId, CIDR: cidr, VLANTag: vlanTag}
+}
+
+func createPendingNetworkOp(st *State, providerId network.Id, cidr string, vlanTag int) txn.Op {
+	return txn.Op{
+		C:      st.pendingNetworks.Name,
+		Id:     providerId,
+		Assert: txn.DocMissing,
+		Insert: newPendingNetworkDoc(providerId, cidr, vlanTag),
+	}
+}
+
+func removePendingNetworkOp(st *State, providerId network.Id) txn.Op {
+	return txn.Op{
+		C:      st.pendingNetworks.Name,
+		Id:     providerId,
+		Remove: true,
+	}
+}
+
+func getPendingNetwork(st *State, providerId network.Id) (pendingNetworkDoc, error) {
+	var doc pendingNetworkDoc
+	err := st.pendingNetworks.FindId(providerId).One(&doc)
+	return doc, err
+}


### PR DESCRIPTION
Created a new collection "pendingnetworks",
which contains information about networks
we'll get from the provider, but before we
can use them in juju (i.e. they have no juju
name, only provider id, and the user has to
explicitly request to "promote" them). Later,
we'll use the result of Environ.ListNetworks()
call to update pending networks in state.

Several new state.State methods added:
- UpdatePendingNetworks() - creates/updates pending
  networks given a []network.BasicInfo from the provider.
- PendingNetwork(providerId) - returns a single network
  as network.BasicInfo or a NotFound error.
- AllPendingNetworks() - returns all pending networks as
  []network.BasicInfo.

In the networks package, added a IsVLANTag() helper to
centralize VLAN tags validation, and added tests.
