### PR TITLE
mongo: preallocate oplog data files

### DIFF
--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -4,15 +4,29 @@
 package mongo
 
 var (
-	MakeJournalDirs             = makeJournalDirs
-	MongoConfigPath             = &mongoConfigPath
-	NoauthCommand               = noauthCommand
-	ProcessSignal               = &processSignal
-	SharedSecretPath            = sharedSecretPath
-	SSLKeyPath                  = sslKeyPath
+	MakeJournalDirs = makeJournalDirs
+	MongoConfigPath = &mongoConfigPath
+	NoauthCommand   = noauthCommand
+	ProcessSignal   = &processSignal
+
+	SharedSecretPath = sharedSecretPath
+	SSLKeyPath       = sslKeyPath
+
 	UpstartConfInstall          = &upstartConfInstall
 	UpstartService              = upstartService
 	UpstartServiceStopAndRemove = &upstartServiceStopAndRemove
 	UpstartServiceStop          = &upstartServiceStop
 	UpstartServiceStart         = &upstartServiceStart
+
+	HostWordSize   = &hostWordSize
+	RuntimeGOOS    = &runtimeGOOS
+	AvailSpace     = &availSpace
+	MinOplogSizeMB = &minOplogSizeMB
+	MaxOplogSizeMB = &maxOplogSizeMB
+	PreallocFile   = &preallocFile
+
+	OplogSize         = oplogSize
+	FsAvailSpace      = fsAvailSpace
+	PreallocFileSizes = preallocFileSizes
+	PreallocFiles     = preallocFiles
 )

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -60,6 +60,10 @@ func (s *MongoSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	s.PatchValue(&mongo.JujuMongodPath, s.mongodPath)
 
+	// Patch "df" such that it always reports there's 1MB free.
+	s.PatchValue(mongo.AvailSpace, func(dir string) (float64, error) { return 1, nil })
+	s.PatchValue(mongo.MinOplogSizeMB, 1)
+
 	testPath := c.MkDir()
 	s.mongodConfigPath = filepath.Join(testPath, "mongodConfig")
 	s.PatchValue(mongo.MongoConfigPath, s.mongodConfigPath)

--- a/mongo/prealloc.go
+++ b/mongo/prealloc.go
@@ -1,0 +1,204 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongo
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/juju/juju/juju/arch"
+)
+
+const (
+	// preallocAlign must divide all preallocated files' sizes.
+	preallocAlign = 4096
+)
+
+var (
+	runtimeGOOS  = runtime.GOOS
+	hostWordSize = arch.Info[arch.HostArch()].WordSize
+
+	// zeroes is used by preallocFile to write zeroes to
+	// preallocated Mongo data files.
+	zeroes = make([]byte, 64*1024)
+
+	minOplogSizeMB = 1024
+	maxOplogSizeMB = 50 * 1024
+
+	availSpace   = fsAvailSpace
+	preallocFile = doPreallocFile
+)
+
+// preallocOplog preallocates the Mongo oplog in the
+// specified Mongo datadabase directory.
+func preallocOplog(dir string) error {
+	size, err := oplogSize(dir)
+	if err != nil {
+		return err
+	}
+	// oplogSize returns MB, we want to work in bytes.
+	sizes := preallocFileSizes(size * 1024 * 1024)
+	prefix := filepath.Join(dir, "local.")
+	return preallocFiles(prefix, sizes...)
+}
+
+// oplogSize returns the default size in MB for the mongo oplog
+// based on the directory of the mongo database.
+//
+// The size of the oplog is calculated according to the
+// formula used by Mongo:
+//     http://docs.mongodb.org/manual/core/replica-set-oplog/
+func oplogSize(dir string) (int, error) {
+	if hostWordSize == 32 {
+		// "For 32-bit systems, MongoDB allocates about 48 megabytes
+		// of space to the oplog."
+		return 48, nil
+	}
+
+	// "For 64-bit OS X systems, MongoDB allocates 183 megabytes of
+	// space to the oplog."
+	if runtimeGOOS == "darwin" {
+		return 183, nil
+	}
+
+	// FIXME calculate disk size on Windows like on Linux below.
+	if runtimeGOOS == "windows" {
+		return minOplogSizeMB, nil
+	}
+
+	avail, err := availSpace(dir)
+	if err != nil {
+		return -1, err
+	}
+	size := int(avail * 0.05)
+	if size < minOplogSizeMB {
+		size = minOplogSizeMB
+	} else if size > maxOplogSizeMB {
+		size = maxOplogSizeMB
+	}
+	return size, nil
+}
+
+// fsAvailSpace returns the available space in MB on the
+// filesystem containing the specified directory.
+func fsAvailSpace(dir string) (avail float64, err error) {
+	var stderr bytes.Buffer
+	cmd := exec.Command("df", dir)
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		err := fmt.Errorf("df failed: %v", err)
+		if stderr.Len() > 0 {
+			err = fmt.Errorf("%s (%q)", err, stderr.String())
+		}
+		return -1, err
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		logger.Errorf("unexpected output: %q", out)
+		return -1, fmt.Errorf("could not determine available space on %q", dir)
+	}
+	fields := strings.Fields(lines[1])
+	if len(fields) < 4 {
+		logger.Errorf("unexpected output: %q", out)
+		return -1, fmt.Errorf("could not determine available space on %q", dir)
+	}
+	kilobytes, err := strconv.Atoi(fields[3])
+	if err != nil {
+		return -1, err
+	}
+	return float64(kilobytes) / 1024, err
+}
+
+// preallocFiles preallocates n data files, zeroed to make
+// up the specified sizes in bytes. The file sizes must be
+// multiples of 4096 bytes.
+//
+// The filenames are constructed by appending the file index
+// to the specified prefix.
+func preallocFiles(prefix string, sizes ...int) error {
+	var err error
+	var createdFiles []string
+	for i, size := range sizes {
+		var created bool
+		filename := fmt.Sprintf("%s%d", prefix, i)
+		created, err = preallocFile(filename, size)
+		if created {
+			createdFiles = append(createdFiles, filename)
+		}
+		if err != nil {
+			break
+		}
+	}
+	if err != nil {
+		logger.Debugf("failed to preallocate %q, cleaning up")
+		for _, filename := range createdFiles {
+			if err := os.Remove(filename); err != nil {
+				logger.Errorf("failed to remove %q: %v", filename, err)
+			}
+		}
+	}
+	return err
+}
+
+// preallocFileSizes returns a slice of file sizes
+// that make up the specified total size, exceeding
+// the specified total as necessary to pad the
+// remainder to a multiple of 4096 bytes.
+func preallocFileSizes(totalSize int) []int {
+	// Divide the total size into 512MB chunks, and
+	// then round up the remaining chunk to a multiple
+	// of 4096 bytes.
+	const maxChunkSize = 512 * 1024 * 1024
+	var sizes []int
+	remainder := totalSize % maxChunkSize
+	if remainder > 0 {
+		aligned := remainder + preallocAlign - 1
+		aligned = aligned - (aligned % preallocAlign)
+		sizes = []int{aligned}
+	}
+	for i := 0; i < totalSize/maxChunkSize; i++ {
+		sizes = append(sizes, maxChunkSize)
+	}
+	return sizes
+}
+
+// doPreallocFile creates a file and writes zeroes up to the specified
+// extent. If the file exists already, nothing is done and no error
+// is returned.
+func doPreallocFile(filename string, size int) (created bool, err error) {
+	if size%preallocAlign != 0 {
+		return false, fmt.Errorf("specified size %v for file %q is not a multiple of %d", size, filename, preallocAlign)
+	}
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
+	// TODO(jam) 2014-04-12 https://launchpad.net/bugs/1306902
+	// When we support upgrading Mongo into Replica mode, we should
+	// start rewriting the upstart config
+	if os.IsExist(err) {
+		// already exists, don't overwrite
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to open mongo prealloc file %q: %v", filename, err)
+	}
+	defer f.Close()
+	for written := 0; written < size; {
+		n := len(zeroes)
+		if n > (size - written) {
+			n = size - written
+		}
+		n, err := f.Write(zeroes[:n])
+		if err != nil {
+			return true, fmt.Errorf("failed to write to mongo prealloc file %q: %v", filename, err)
+		}
+		written += n
+	}
+	return true, nil
+}

--- a/mongo/prealloc_test.go
+++ b/mongo/prealloc_test.go
@@ -1,0 +1,204 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongo_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/mongo"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type preallocSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&preallocSuite{})
+
+func (s *preallocSuite) TestOplogSize(c *gc.C) {
+	type test struct {
+		hostWordSize int
+		runtimeGOOS  string
+		availSpace   int
+		expected     int
+	}
+	tests := []test{{
+		hostWordSize: 64,
+		runtimeGOOS:  "darwin",
+		availSpace:   99999,
+		expected:     183,
+	}, {
+		hostWordSize: 64,
+		runtimeGOOS:  "windows",
+		availSpace:   99999,
+		expected:     1024,
+	}, {
+		hostWordSize: 32,
+		runtimeGOOS:  "linux",
+		availSpace:   48,
+		expected:     48,
+	}, {
+		hostWordSize: 64,
+		runtimeGOOS:  "linux",
+		availSpace:   1024,
+		expected:     1024,
+	}, {
+		hostWordSize: 64,
+		runtimeGOOS:  "linux",
+		availSpace:   420 * 1024,
+		expected:     21504,
+	}, {
+		hostWordSize: 64,
+		runtimeGOOS:  "linux",
+		availSpace:   1024 * 1024,
+		expected:     50 * 1024,
+	}}
+	var availSpace int
+	getAvailSpace := func(dir string) (float64, error) {
+		return float64(availSpace), nil
+	}
+	s.PatchValue(mongo.AvailSpace, getAvailSpace)
+	for i, test := range tests {
+		c.Logf("test %d: %+v", i, test)
+		s.PatchValue(mongo.HostWordSize, test.hostWordSize)
+		s.PatchValue(mongo.RuntimeGOOS, test.runtimeGOOS)
+		availSpace = test.availSpace
+		size, err := mongo.OplogSize("")
+		c.Check(err, gc.IsNil)
+		c.Check(size, gc.Equals, test.expected)
+	}
+}
+
+func (s *preallocSuite) TestFsAvailSpace(c *gc.C) {
+	output := `Filesystem     1K-blocks    Used Available Use% Mounted on
+    /dev/vda1        8124856 1365292     12345  18% /`
+	testing.PatchExecutable(c, s, "df", "#!/bin/sh\ncat<<EOF\n"+output+"\nEOF")
+
+	mb, err := mongo.FsAvailSpace("")
+	c.Assert(err, gc.IsNil)
+	c.Assert(mb, gc.Equals, float64(12345)/1024)
+}
+
+func (s *preallocSuite) TestFsAvailSpaceErrors(c *gc.C) {
+	tests := []struct {
+		desc   string
+		output string
+		err    string
+	}{{
+		desc: "result is non-numeric",
+		output: `Filesystem     1K-blocks    Used Available Use% Mounted on
+    /dev/vda1        8124856 1365292       abc  18% /`,
+		err: `strconv.ParseInt: parsing "abc": invalid syntax`,
+	}, {
+		desc:   "not enough lines",
+		output: "abc",
+		err:    `could not determine available space on ""`,
+	}, {
+		desc:   "not enough fields on second line",
+		output: "abc\ndef",
+		err:    `could not determine available space on ""`,
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.desc)
+		testing.PatchExecutable(c, s, "df", "#!/bin/sh\ncat<<EOF\n"+test.output+"\nEOF")
+		_, err := mongo.FsAvailSpace("")
+		c.Check(err, gc.ErrorMatches, test.err)
+	}
+}
+
+func (s *preallocSuite) TestPreallocFileSizes(c *gc.C) {
+	const MB = 1024 * 1024
+
+	tests := []struct {
+		desc   string
+		size   int
+		result []int
+	}{{
+		desc:   "zero size, zero files",
+		size:   0,
+		result: nil,
+	}, {
+		desc:   "exactly divides the max chunk size",
+		size:   1024 * MB,
+		result: []int{512 * MB, 512 * MB},
+	}, {
+		desc:   "remainder comes at the beginning",
+		size:   1025 * MB,
+		result: []int{1 * MB, 512 * MB, 512 * MB},
+	}, {
+		desc:   "remaining one byte must be padded out to 4096 bytes",
+		size:   1024*MB + 1,
+		result: []int{4096, 512 * MB, 512 * MB},
+	}}
+
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.desc)
+		sizes := mongo.PreallocFileSizes(test.size)
+		c.Check(sizes, gc.DeepEquals, test.result)
+	}
+}
+
+func (s *preallocSuite) TestPreallocFiles(c *gc.C) {
+	dir := c.MkDir()
+	prefix := filepath.Join(dir, "test.")
+	err := mongo.PreallocFiles(prefix, 0, 4096, 8192)
+	c.Assert(err, gc.IsNil)
+
+	zeroes := [8192]byte{}
+	for i := 0; i < 3; i++ {
+		filename := fmt.Sprintf("%s%d", prefix, i)
+		data, err := ioutil.ReadFile(filename)
+		c.Check(err, gc.IsNil)
+		c.Check(data, gc.DeepEquals, zeroes[:i*4096])
+	}
+
+	_, err = os.Stat(prefix + "3")
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+}
+
+func (s *preallocSuite) TestPreallocFilesErrors(c *gc.C) {
+	err := mongo.PreallocFiles("", 123)
+	c.Assert(err, gc.ErrorMatches, `specified size 123 for file "0" is not a multiple of 4096`)
+}
+
+func (s *preallocSuite) TestPreallocFilesWriteErrors(c *gc.C) {
+	dir := c.MkDir()
+	prefix := filepath.Join(dir, "test.")
+	err := ioutil.WriteFile(prefix+"0", nil, 0644)
+	c.Assert(err, gc.IsNil)
+	err = ioutil.WriteFile(prefix+"1", nil, 0644)
+	c.Assert(err, gc.IsNil)
+
+	var called int
+	s.PatchValue(mongo.PreallocFile, func(filename string, size int) (bool, error) {
+		var created bool
+		var err error
+		called++
+		if called == 2 {
+			created = true
+			err = fmt.Errorf("failed to zero test.1")
+		}
+		return created, err
+	})
+
+	err = mongo.PreallocFiles(prefix, 4096, 8192)
+	c.Assert(err, gc.ErrorMatches, "failed to zero test.1")
+
+	// test.0 still exists because we said we didn't
+	// create it (i.e. it already existed)
+	_, err = os.Stat(prefix + "0")
+	c.Assert(err, gc.IsNil)
+
+	// test.1 no longer exists because we said we created
+	// it, but then failed to write to it.
+	_, err = os.Stat(prefix + "1")
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+}


### PR DESCRIPTION
Preallocate oplog data files. If we don't do this, then mongo is not happy with us when running on big/slow disks. Probably because we pass --nopreallocate to mongod.

Fixes https://bugs.launchpad.net/juju-core/+bug/1327940
