### PR TITLE
Enable replicasets unconditionally

### DIFF
--- a/cmd/jujud/agent_test.go
+++ b/cmd/jujud/agent_test.go
@@ -241,7 +241,7 @@ func (s *agentSuite) SetUpSuite(c *gc.C) {
 	// a bit when some tests are restarting every 50ms for 10 seconds,
 	// so use a slightly more friendly delay.
 	worker.RestartDelay = 250 * time.Millisecond
-	s.PatchValue(&ensureMongoServer, func(string, string, params.StateServingInfo, bool) error {
+	s.PatchValue(&ensureMongoServer, func(string, string, params.StateServingInfo) error {
 		return nil
 	})
 }

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -186,19 +186,13 @@ func (c *BootstrapCommand) startMongo(addrs []network.Address, agentConfig agent
 	}
 
 	logger.Debugf("calling ensureMongoServer")
-	withHA := shouldEnableHA(agentConfig)
 	err = ensureMongoServer(
 		agentConfig.DataDir(),
 		agentConfig.Value(agent.Namespace),
 		servingInfo,
-		withHA,
 	)
 	if err != nil {
 		return err
-	}
-	// If we are not doing HA, there is no need to set up replica set.
-	if !withHA {
-		return nil
 	}
 
 	peerAddr := mongo.SelectPeerAddress(addrs)

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -57,15 +57,14 @@ type fakeEnsure struct {
 	initiateCount  int
 	dataDir        string
 	namespace      string
-	withHA         bool
 	info           params.StateServingInfo
 	initiateParams peergrouper.InitiateMongoParams
 	err            error
 }
 
-func (f *fakeEnsure) fakeEnsureMongo(dataDir, namespace string, info params.StateServingInfo, withHA bool) error {
+func (f *fakeEnsure) fakeEnsureMongo(dataDir, namespace string, info params.StateServingInfo) error {
 	f.ensureCount++
-	f.dataDir, f.namespace, f.info, f.withHA = dataDir, namespace, info, withHA
+	f.dataDir, f.namespace, f.info = dataDir, namespace, info
 	return f.err
 }
 
@@ -160,7 +159,6 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	c.Assert(s.fakeEnsureMongo.initiateCount, gc.Equals, 1)
 	c.Assert(s.fakeEnsureMongo.ensureCount, gc.Equals, 1)
 	c.Assert(s.fakeEnsureMongo.dataDir, gc.Equals, s.dataDir)
-	c.Assert(s.fakeEnsureMongo.withHA, jc.IsTrue)
 
 	expectInfo, exists := machConf.StateServingInfo()
 	c.Assert(exists, jc.IsTrue)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -134,13 +134,6 @@ func RemoveService(namespace string) error {
 	return upstartServiceStopAndRemove(svc)
 }
 
-const (
-	// WithHA is used when we want to start a mongo service with HA support.
-	WithHA = true
-	// WithoutHA is used when we want to start a mongo service without HA support.
-	WithoutHA = false
-)
-
 // EnsureMongoServer ensures that the correct mongo upstart script is installed
 // and running.
 //
@@ -150,7 +143,7 @@ const (
 // The namespace is a unique identifier to prevent multiple instances of mongo
 // on this machine from colliding. This should be empty unless using
 // the local provider.
-func EnsureServer(dataDir string, namespace string, info params.StateServingInfo, withHA bool) error {
+func EnsureServer(dataDir string, namespace string, info params.StateServingInfo) error {
 	logger.Infof("Ensuring mongo server is running; data directory %s; port %d", dataDir, info.StatePort)
 	dbDir := filepath.Join(dataDir, "db")
 
@@ -187,7 +180,7 @@ func EnsureServer(dataDir string, namespace string, info params.StateServingInfo
 		return fmt.Errorf("cannot install mongod: %v", err)
 	}
 
-	upstartConf, mongoPath, err := upstartService(namespace, dataDir, dbDir, info.StatePort, withHA)
+	upstartConf, mongoPath, err := upstartService(namespace, dataDir, dbDir, info.StatePort)
 	if err != nil {
 		return err
 	}
@@ -268,7 +261,7 @@ func sharedSecretPath(dataDir string) string {
 // upstartService returns the upstart config for the mongo state service.
 // It also returns the path to the mongod executable that the upstart config
 // will be using.
-func upstartService(namespace, dataDir, dbDir string, port int, withHA bool) (*upstart.Conf, string, error) {
+func upstartService(namespace, dataDir, dbDir string, port int) (*upstart.Conf, string, error) {
 	svc := upstart.NewService(ServiceName(namespace))
 
 	mongoPath, err := Path()
@@ -287,10 +280,8 @@ func upstartService(namespace, dataDir, dbDir string, port int, withHA bool) (*u
 		" --syslog" +
 		" --smallfiles" +
 		" --journal" +
-		" --keyFile " + utils.ShQuote(sharedSecretPath(dataDir))
-	if withHA {
-		mongoCmd += " --replSet " + ReplicaSetName
-	}
+		" --keyFile " + utils.ShQuote(sharedSecretPath(dataDir)) +
+		" --replSet " + ReplicaSetName
 	conf := &upstart.Conf{
 		Service: *svc,
 		Desc:    "juju state database",

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -127,7 +127,7 @@ func (s *MongoSuite) TestEnsureServer(c *gc.C) {
 
 	mockShellCommand(c, &s.CleanupSuite, "apt-get")
 
-	err := mongo.EnsureServer(dataDir, namespace, testInfo, mongo.WithHA)
+	err := mongo.EnsureServer(dataDir, namespace, testInfo)
 	c.Assert(err, gc.IsNil)
 
 	testJournalDirs(dbDir, c)
@@ -158,7 +158,7 @@ func (s *MongoSuite) TestEnsureServer(c *gc.C) {
 
 	s.installed = nil
 	// now check we can call it multiple times without error
-	err = mongo.EnsureServer(dataDir, namespace, testInfo, mongo.WithHA)
+	err = mongo.EnsureServer(dataDir, namespace, testInfo)
 	c.Assert(err, gc.IsNil)
 	assertInstalled()
 
@@ -194,7 +194,7 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 
 		s.PatchValue(&version.Current.Series, test.series)
 
-		err := mongo.EnsureServer(dataDir, namespace, testInfo, mongo.WithHA)
+		err := mongo.EnsureServer(dataDir, namespace, testInfo)
 		c.Assert(err, gc.IsNil)
 
 		cmds := getMockShellCalls(c, output)
@@ -212,22 +212,18 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 	}
 }
 
-func (s *MongoSuite) TestUpstartServiceWithHA(c *gc.C) {
+func (s *MongoSuite) TestUpstartServiceWithReplSet(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, mongo.WithHA)
+	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234)
 	c.Assert(err, gc.IsNil)
 	c.Assert(strings.Contains(svc.Cmd, "--replSet"), jc.IsTrue)
-
-	svc, _, err = mongo.UpstartService("", dataDir, dataDir, 1234, mongo.WithoutHA)
-	c.Assert(err, gc.IsNil)
-	c.Assert(strings.Contains(svc.Cmd, "--replSet"), jc.IsFalse)
 }
 
 func (s *MongoSuite) TestUpstartServiceWithJournal(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, mongo.WithHA)
+	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234)
 	c.Assert(err, gc.IsNil)
 	journalPresent := strings.Contains(svc.Cmd, " --journal ") || strings.HasSuffix(svc.Cmd, " --journal")
 	c.Assert(journalPresent, jc.IsTrue)
@@ -265,11 +261,11 @@ func (s *MongoSuite) TestQuantalAptAddRepo(c *gc.C) {
 	// test that we call add-apt-repository only for quantal (and that if it
 	// fails, we return the error)
 	s.PatchValue(&version.Current.Series, "quantal")
-	err := mongo.EnsureServer(dir, "", testInfo, mongo.WithHA)
+	err := mongo.EnsureServer(dir, "", testInfo)
 	c.Assert(err, gc.ErrorMatches, "cannot install mongod: cannot add apt repository: exit status 1.*")
 
 	s.PatchValue(&version.Current.Series, "trusty")
-	err = mongo.EnsureServer(dir, "", testInfo, mongo.WithHA)
+	err = mongo.EnsureServer(dir, "", testInfo)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -278,7 +274,7 @@ func (s *MongoSuite) TestNoMongoDir(c *gc.C) {
 	// created.
 	mockShellCommand(c, &s.CleanupSuite, "apt-get")
 	dataDir := filepath.Join(c.MkDir(), "dir", "data")
-	err := mongo.EnsureServer(dataDir, "", testInfo, mongo.WithHA)
+	err := mongo.EnsureServer(dataDir, "", testInfo)
 	c.Check(err, gc.IsNil)
 
 	_, err = os.Stat(filepath.Join(dataDir, "db"))
@@ -344,7 +340,7 @@ func (s *MongoSuite) TestAddPPAInQuantal(c *gc.C) {
 	s.PatchValue(&version.Current.Series, "quantal")
 
 	dataDir := c.MkDir()
-	err := mongo.EnsureServer(dataDir, "", testInfo, mongo.WithHA)
+	err := mongo.EnsureServer(dataDir, "", testInfo)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(getMockShellCalls(c, addAptRepoOut), gc.DeepEquals, [][]string{{


### PR DESCRIPTION
Once #82 lands, we can enable replsets
unconditionally. This makes it possible
to do limited testing of HA on the local
provider currently, and gets rid of a
code burden that we don't need.
