### PR TITLE
mongo: fix vet warning

### DIFF
--- a/mongo/prealloc.go
+++ b/mongo/prealloc.go
@@ -138,7 +138,7 @@ func preallocFiles(prefix string, sizes ...int) error {
 		}
 	}
 	if err != nil {
-		logger.Debugf("failed to preallocate %q, cleaning up")
+		logger.Debugf("cleaning up after preallocation failure: %v", err)
 		for _, filename := range createdFiles {
 			if err := os.Remove(filename); err != nil {
 				logger.Errorf("failed to remove %q: %v", filename, err)


### PR DESCRIPTION
The pre-push script's vet invocation, it does nothing.
If you invoke "go tool vet .", it returns rc 0 even if
there's a warning; "go tool vet *.go" returns rc 1.
