### PR TITLE
Add ClusterAdmin role to mongo user creation

### DIFF
--- a/mongo/admin.go
+++ b/mongo/admin.go
@@ -135,7 +135,7 @@ func SetMongoPassword(name, password string, dbs ...*mgo.Database) error {
 	user := &mgo.User{
 		Username: name,
 		Password: password,
-		Roles:    []mgo.Role{mgo.RoleReadWriteAny, mgo.RoleUserAdmin},
+		Roles:    []mgo.Role{mgo.RoleReadWriteAny, mgo.RoleUserAdmin, mgo.RoleClusterAdmin},
 	}
 	for _, db := range dbs {
 		if err := db.UpsertUser(user); err != nil {


### PR DESCRIPTION
When cresting a user in mongo, ensure they have the CusterAdmin role. Otherwise peer group operations will fail with unauthorised errors.
