### PR TITLE
Add support for inheriting Region and Endpoint from top level

### DIFF
--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -99,11 +99,13 @@ type attributeValues map[string]string
 type aliasesByAttribute map[string]attributeValues
 
 type CloudMetadata struct {
-	Products  map[string]MetadataCatalog    `json:"products"`
-	Aliases   map[string]aliasesByAttribute `json:"_aliases,omitempty"`
-	Updated   string                        `json:"updated"`
-	Format    string                        `json:"format"`
-	ContentId string                        `json:"content_id"`
+	Products   map[string]MetadataCatalog    `json:"products"`
+	Aliases    map[string]aliasesByAttribute `json:"_aliases,omitempty"`
+	Updated    string                        `json:"updated"`
+	Format     string                        `json:"format"`
+	ContentId  string                        `json:"content_id"`
+	RegionName string                        `json:"region,omitempty"`
+	Endpoint   string                        `json:"endpoint,omitempty"`
 }
 
 type MetadataCatalog struct {
@@ -677,6 +679,7 @@ func (metadata *CloudMetadata) denormaliseMetadata() {
 		for _, ItemCollection := range metadataCatalog.Items {
 			for _, item := range ItemCollection.Items {
 				coll := *ItemCollection
+				inherit(&metadataCatalog, metadata)
 				inherit(&coll, metadataCatalog)
 				inherit(item, &coll)
 			}
@@ -751,7 +754,7 @@ func RegisterStructTags(vals ...interface{}) {
 }
 
 func init() {
-	RegisterStructTags(MetadataCatalog{}, ItemCollection{})
+	RegisterStructTags(CloudMetadata{}, MetadataCatalog{}, ItemCollection{})
 }
 
 func mkTags(vals ...interface{}) map[reflect.Type]map[string]int {

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -352,7 +352,7 @@ func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 
 func (s *simplestreamsSuite) TestMetadataCatalog(c *gc.C) {
 	metadata := s.AssertGetMetadata(c)
-	c.Check(len(metadata.Products), gc.Equals, 2)
+	c.Check(len(metadata.Products), gc.Equals, 3)
 	c.Check(len(metadata.Aliases), gc.Equals, 1)
 	metadataCatalog := metadata.Products["com.ubuntu.cloud:server:12.04:amd64"]
 	c.Check(len(metadataCatalog.Items), gc.Equals, 2)
@@ -390,6 +390,15 @@ func (s *simplestreamsSuite) TestDenormalisationFromCatalog(c *gc.C) {
 	ti := ic.Items["usww3pe"].(*sstesting.TestItem)
 	c.Check(ti.RegionName, gc.Equals, metadataCatalog.RegionName)
 	c.Check(ti.Endpoint, gc.Equals, metadataCatalog.Endpoint)
+}
+
+func (s *simplestreamsSuite) TestDenormalisationFromTopLevel(c *gc.C) {
+	metadata := s.AssertGetMetadata(c)
+	metadataCatalog := metadata.Products["com.ubuntu.cloud:server:14.04:amd64"]
+	ic := metadataCatalog.Items["20140118"]
+	ti := ic.Items["nzww1pe"].(*sstesting.TestItem)
+	c.Check(ti.RegionName, gc.Equals, metadata.RegionName)
+	c.Check(ti.Endpoint, gc.Equals, metadata.Endpoint)
 }
 
 func (s *simplestreamsSuite) TestDealiasing(c *gc.C) {

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -389,7 +389,27 @@ var imageData = map[string]string{
 {
  "updated": "Wed, 01 May 2013 13:31:26 +0000",
  "content_id": "com.ubuntu.cloud:released:aws",
+ "region": "nz-east-1",
+ "endpoint": "https://anywhere",
  "products": {
+  "com.ubuntu.cloud:server:14.04:amd64": {
+   "release": "trusty",
+   "version": "14.04",
+   "arch": "amd64",
+   "versions": {
+    "20140118": {
+     "items": {
+      "nzww1pe": {
+       "root_store": "ebs",
+       "virt": "pv",
+       "id": "ami-36745463"
+      }
+     },
+     "pubname": "ubuntu-trusty-14.04-amd64-server-20140118",
+     "label": "release"
+    }
+   }
+  },
   "com.ubuntu.cloud:server:12.04:amd64": {
    "release": "precise",
    "version": "12.04",


### PR DESCRIPTION
We never supported inheriting region and endpoint attributes from top level simplestreams metadata but it appears some users do generate files with this expectation. So this branch adds that support.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1329805
