### PR TITLE
Handle constrained AZs

### DIFF
--- a/provider/common/export_test.go
+++ b/provider/common/export_test.go
@@ -4,10 +4,10 @@
 package common
 
 var (
-	GetAddresses                            = getAddresses
-	GetStateInfo                            = getStateInfo
-	ComposeAddresses                        = composeAddresses
-	ConnectSSH                              = &connectSSH
-	WaitSSH                                 = waitSSH
-	InternalBestAvailabilityZoneAllocations = &internalBestAvailabilityZoneAllocations
+	GetAddresses                        = getAddresses
+	GetStateInfo                        = getStateInfo
+	ComposeAddresses                    = composeAddresses
+	ConnectSSH                          = &connectSSH
+	WaitSSH                             = waitSSH
+	InternalAvailabilityZoneAllocations = &internalAvailabilityZoneAllocations
 )

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -42,8 +42,9 @@ func InstanceEC2(inst instance.Instance) *ec2.Instance {
 }
 
 var (
-	EC2AvailabilityZones            = &ec2AvailabilityZones
-	BestAvailabilityZoneAllocations = &bestAvailabilityZoneAllocations
+	EC2AvailabilityZones        = &ec2AvailabilityZones
+	AvailabilityZoneAllocations = &availabilityZoneAllocations
+	RunInstances                = &runInstances
 )
 
 // BucketStorage returns a storage instance addressing

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -65,8 +65,8 @@ func InstanceServerDetail(inst instance.Instance) *nova.ServerDetail {
 }
 
 var (
-	NovaListAvailabilityZones       = &novaListAvailabilityZones
-	BestAvailabilityZoneAllocations = &bestAvailabilityZoneAllocations
+	NovaListAvailabilityZones   = &novaListAvailabilityZones
+	AvailabilityZoneAllocations = &availabilityZoneAllocations
 )
 
 var indexData = `

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -873,7 +873,7 @@ func (e *environ) DistributeInstances(candidates, distributionGroup []instance.I
 	return common.DistributeInstances(e, candidates, distributionGroup)
 }
 
-var bestAvailabilityZoneAllocations = common.BestAvailabilityZoneAllocations
+var availabilityZoneAllocations = common.AvailabilityZoneAllocations
 
 // StartInstance is specified in the InstanceBroker interface.
 func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
@@ -901,16 +901,14 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 				return nil, nil, nil, err
 			}
 		}
-		bestAvailabilityZones, err := bestAvailabilityZoneAllocations(e, group)
+		zoneInstances, err := availabilityZoneAllocations(e, group)
 		if jujuerrors.IsNotImplemented(err) {
 			// Availability zones are an extension, so we may get a
 			// not implemented error; ignore these.
 		} else if err != nil {
 			return nil, nil, nil, err
-		} else {
-			for availabilityZone = range bestAvailabilityZones {
-				break
-			}
+		} else if len(zoneInstances) > 0 {
+			availabilityZone = zoneInstances[0].ZoneName
 		}
 	}
 


### PR DESCRIPTION
In EC2, an AZ may be "constrained", meaning that
you may not allocate new instances of certain
instance types to that AZ unless you already have
resources in that AZ. With this change we will
deal with this by attempting an a different AZ.

We'll now attempt all AZs until one either succeeds
or fails with an error other than one indicating
the AZ is constrained. We also now sort AZs by
population and then by name, to ensure the first
unit of each service is allocated to the same AZ
(barring pathological constrained AZ cases).

Fixes https://bugs.launchpad.net/juju-core/+bug/1330163
