### PR TITLE
Better status information when a relation hook fails

### DIFF
--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -94,7 +94,7 @@ func (c *StatusCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		fmt.Fprintf(ctx.Stderr, "%v\n", err)
 	}
-	result := formatStatus(status)
+	result := newStatusFormatter(status).format()
 	return c.out.Write(ctx, result)
 }
 
@@ -232,35 +232,47 @@ func (n networkStatus) GetYAML() (tag string, value interface{}) {
 	return "", nNoMethods(n)
 }
 
-func formatStatus(status *api.Status) formattedStatus {
-	if status == nil {
+type statusFormatter struct {
+	status    *api.Status
+	relations map[int]api.RelationStatus
+}
+
+func newStatusFormatter(status *api.Status) *statusFormatter {
+	sf := statusFormatter{
+		status:    status,
+		relations: make(map[int]api.RelationStatus),
+	}
+	for _, relation := range status.Relations {
+		sf.relations[relation.Id] = relation
+	}
+	return &sf
+}
+
+func (sf *statusFormatter) format() formattedStatus {
+	if sf.status == nil {
 		return formattedStatus{}
 	}
-	relations := make(map[int]api.RelationStatus)
-	for _, relation := range status.Relations {
-		relations[relation.Id] = relation
-	}
 	out := formattedStatus{
-		Environment: status.EnvironmentName,
+		Environment: sf.status.EnvironmentName,
 		Machines:    make(map[string]machineStatus),
 		Services:    make(map[string]serviceStatus),
 	}
-	for k, m := range status.Machines {
-		out.Machines[k] = formatMachine(m)
+	for k, m := range sf.status.Machines {
+		out.Machines[k] = sf.formatMachine(m)
 	}
-	for sn, s := range status.Services {
-		out.Services[sn] = formatService(sn, s, relations)
+	for sn, s := range sf.status.Services {
+		out.Services[sn] = sf.formatService(sn, s)
 	}
-	for k, n := range status.Networks {
+	for k, n := range sf.status.Networks {
 		if out.Networks == nil {
 			out.Networks = make(map[string]networkStatus)
 		}
-		out.Networks[k] = formatNetwork(n)
+		out.Networks[k] = sf.formatNetwork(n)
 	}
 	return out
 }
 
-func formatMachine(machine api.MachineStatus) machineStatus {
+func (sf *statusFormatter) formatMachine(machine api.MachineStatus) machineStatus {
 	var out machineStatus
 
 	if machine.Agent.Status == "" {
@@ -300,7 +312,7 @@ func formatMachine(machine api.MachineStatus) machineStatus {
 	}
 
 	for k, m := range machine.Containers {
-		out.Containers[k] = formatMachine(m)
+		out.Containers[k] = sf.formatMachine(m)
 	}
 
 	for _, job := range machine.Jobs {
@@ -312,22 +324,7 @@ func formatMachine(machine api.MachineStatus) machineStatus {
 	return out
 }
 
-func makeHAStatus(hasVote, wantsVote bool) string {
-	var s string
-	switch {
-	case hasVote && wantsVote:
-		s = "has-vote"
-	case hasVote && !wantsVote:
-		s = "removing-vote"
-	case !hasVote && wantsVote:
-		s = "adding-vote"
-	case !hasVote && !wantsVote:
-		s = "no-vote"
-	}
-	return s
-}
-
-func formatService(name string, service api.ServiceStatus, relations map[int]api.RelationStatus) serviceStatus {
+func (sf *statusFormatter) formatService(name string, service api.ServiceStatus) serviceStatus {
 	out := serviceStatus{
 		Err:           service.Err,
 		Charm:         service.Charm,
@@ -346,16 +343,16 @@ func formatService(name string, service api.ServiceStatus, relations map[int]api
 		out.Networks["disabled"] = service.Networks.Disabled
 	}
 	for k, m := range service.Units {
-		out.Units[k] = formatUnit(m, name, relations)
+		out.Units[k] = sf.formatUnit(m, name)
 	}
 	return out
 }
 
-func formatUnit(unit api.UnitStatus, serviceName string, relations map[int]api.RelationStatus) unitStatus {
+func (sf *statusFormatter) formatUnit(unit api.UnitStatus, serviceName string) unitStatus {
 	out := unitStatus{
 		Err:            unit.Err,
 		AgentState:     unit.AgentState,
-		AgentStateInfo: getUnitStatusInfo(unit, serviceName, relations),
+		AgentStateInfo: sf.getUnitStatusInfo(unit, serviceName),
 		AgentVersion:   unit.AgentVersion,
 		Life:           unit.Life,
 		Machine:        unit.Machine,
@@ -365,26 +362,51 @@ func formatUnit(unit api.UnitStatus, serviceName string, relations map[int]api.R
 		Subordinates:   make(map[string]unitStatus),
 	}
 	for k, m := range unit.Subordinates {
-		out.Subordinates[k] = formatUnit(m, serviceName, relations)
+		out.Subordinates[k] = sf.formatUnit(m, serviceName)
 	}
 	return out
 }
 
-func getUnitStatusInfo(unit api.UnitStatus, serviceName string, relations map[int]api.RelationStatus) string {
+func (sf *statusFormatter) getUnitStatusInfo(unit api.UnitStatus, serviceName string) string {
 	if unit.Agent.Status == "" {
-		// Old client that doesn't support this field and others.
+		// Old server that doesn't support this field and others.
 		// Just return the info string as-is.
 		return unit.AgentStateInfo
 	}
 	statusInfo := unit.Agent.Info
 	if unit.Agent.Status == params.StatusError {
-		if relation, ok := relations[getRelationIdFromData(unit)]; ok {
+		if relation, ok := sf.relations[getRelationIdFromData(unit)]; ok {
+			// Append the details of the other endpoint on to the status info string.
 			if ep, ok := findOtherEndpoint(relation.Endpoints, serviceName); ok {
 				statusInfo = statusInfo + " for " + ep.String()
 			}
 		}
 	}
 	return adjustInfoIfAgentDown(unit.AgentState, unit.Agent.Status, statusInfo)
+}
+
+func (sf *statusFormatter) formatNetwork(network api.NetworkStatus) networkStatus {
+	return networkStatus{
+		Err:        network.Err,
+		ProviderId: network.ProviderId,
+		CIDR:       network.CIDR,
+		VLANTag:    network.VLANTag,
+	}
+}
+
+func makeHAStatus(hasVote, wantsVote bool) string {
+	var s string
+	switch {
+	case hasVote && wantsVote:
+		s = "has-vote"
+	case hasVote && !wantsVote:
+		s = "removing-vote"
+	case !hasVote && wantsVote:
+		s = "adding-vote"
+	case !hasVote && !wantsVote:
+		s = "no-vote"
+	}
+	return s
 }
 
 func getRelationIdFromData(unit api.UnitStatus) int {
@@ -399,6 +421,9 @@ func getRelationIdFromData(unit api.UnitStatus) int {
 	return -1
 }
 
+// findOtherEndpoint searches the provided endpoints for an endpoint
+// that *doesn't* match serviceName. The returned bool indicates if
+// such an endpoint was found.
 func findOtherEndpoint(endpoints []api.EndpointStatus, serviceName string) (api.EndpointStatus, bool) {
 	for _, endpoint := range endpoints {
 		if endpoint.ServiceName != serviceName {
@@ -419,13 +444,4 @@ func adjustInfoIfAgentDown(status, origStatus params.Status, info string) string
 		return fmt.Sprintf("(%s: %s)", origStatus, info)
 	}
 	return info
-}
-
-func formatNetwork(network api.NetworkStatus) networkStatus {
-	return networkStatus{
-		Err:        network.Err,
-		ProviderId: network.ProviderId,
-		CIDR:       network.CIDR,
-		VLANTag:    network.VLANTag,
-	}
 }

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -2188,9 +2188,9 @@ func (a *fakeApiClient) Close() error {
 	return nil
 }
 
-// Check that the client works with an older server which doesn't the
-// top level Relations field nor the unit and machine level Agent
-// field (they were introduced at the same time).
+// Check that the client works with an older server which doesn't
+// return the top level Relations field nor the unit and machine level
+// Agent field (they were introduced at the same time).
 func (s *StatusSuite) TestStatusWithPreRelationsServer(c *gc.C) {
 	// Construct an older style status response
 	client := newFakeApiClient(&api.Status{


### PR DESCRIPTION
The first commit makes a  bunch of changes which take advantage of new data now available in the FullStatus API response to show the remote endpoint details when a relation hook fails. This addresses LP #1194481.

The second commit refactors the status formatting code to make some of the changes made in the previous revision somewhat cleaner.
