### PR TITLE
provider/ec2: match more constrained AZ errors

### DIFF
--- a/provider/ec2/ec2.go
+++ b/provider/ec2/ec2.go
@@ -1258,10 +1258,11 @@ func (m permSet) ipPerms() (ps []ec2.IPPerm) {
 func isZoneConstrainedError(err error) bool {
 	ec2err, ok := err.(*ec2.Error)
 	if ok && ec2err.Code == "Unsupported" {
-		return strings.HasPrefix(
-			ec2err.Message,
-			"The requested Availability Zone is currently constrained",
-		)
+		// A big hammer, but we've now seen two different error messages
+		// for constrained zones, and who knows how many more there might
+		// be. If the message contains "Availability Zone", it's a fair
+		// bet that it's constrained or otherwise unusable.
+		return strings.Contains(ec2err.Message, "Availability Zone")
 	}
 	return false
 }


### PR DESCRIPTION
Horacio reports a bootstrap failure caused by
a constrained AZ, but received a different error
message from EC2:

"2014-06-17 13:35:22 ERROR juju.provider.common bootstrap.go:119 bootstrap failed:
cannot start bootstrap instance: cannot run instances: Your requested instance type
(m3.medium) is not supported in your requested Availability Zone (us-east-1a).
Please retry your request by not specifying an Availability Zone or choosing
us-east-1e, us-east-1c, us-east-1d. (Unsupported)"

The change I've made is simply to match any "Unsupported" error
that contains the string "Availability Zone".

Fixes https://bugs.launchpad.net/juju-core/+bug/1330163
