### PR TITLE
state/api/...: introduce and use common.Watch

### DIFF
--- a/state/api/common/watch.go
+++ b/state/api/common/watch.go
@@ -1,0 +1,32 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/juju/juju/state/api/base"
+	"github.com/juju/juju/state/api/params"
+	"github.com/juju/juju/state/api/watcher"
+)
+
+// Watch starts a NotifyWatcher for the entity with the specified tag.
+func Watch(caller base.Caller, facadeName, tag string) (watcher.NotifyWatcher, error) {
+	var results params.NotifyWatchResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: tag}},
+	}
+	err := caller.Call(facadeName, "", "Watch", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return watcher.NewNotifyWatcher(caller, result), nil
+}

--- a/state/api/firewaller/service.go
+++ b/state/api/firewaller/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/names"
 
+	"github.com/juju/juju/state/api/common"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/api/watcher"
 )
@@ -34,23 +35,7 @@ func mustParseServiceTag(serviceTag string) names.ServiceTag {
 
 // Watch returns a watcher for observing changes to a service.
 func (s *Service) Watch() (watcher.NotifyWatcher, error) {
-	var results params.NotifyWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: s.tag}},
-	}
-	err := s.st.call("Watch", args, &results)
-	if err != nil {
-		return nil, err
-	}
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	w := watcher.NewNotifyWatcher(s.st.caller, result)
-	return w, nil
+	return common.Watch(s.st.caller, firewallerFacade, s.tag)
 }
 
 // Life returns the service's current life state.

--- a/state/api/firewaller/unit.go
+++ b/state/api/firewaller/unit.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/names"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state/api/common"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/api/watcher"
 )
@@ -50,23 +51,7 @@ func (u *Unit) Refresh() error {
 
 // Watch returns a watcher for observing changes to the unit.
 func (u *Unit) Watch() (watcher.NotifyWatcher, error) {
-	var results params.NotifyWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: u.tag}},
-	}
-	err := u.st.call("Watch", args, &results)
-	if err != nil {
-		return nil, err
-	}
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	w := watcher.NewNotifyWatcher(u.st.caller, result)
-	return w, nil
+	return common.Watch(u.st.caller, firewallerFacade, u.tag)
 }
 
 // Service returns the service.

--- a/state/api/machiner/machine.go
+++ b/state/api/machiner/machine.go
@@ -4,9 +4,8 @@
 package machiner
 
 import (
-	"fmt"
-
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state/api/common"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/api/watcher"
 )
@@ -84,21 +83,5 @@ func (m *Machine) EnsureDead() error {
 
 // Watch returns a watcher for observing changes to the machine.
 func (m *Machine) Watch() (watcher.NotifyWatcher, error) {
-	var results params.NotifyWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: m.tag}},
-	}
-	err := m.st.call("Watch", args, &results)
-	if err != nil {
-		return nil, err
-	}
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	w := watcher.NewNotifyWatcher(m.st.caller, result)
-	return w, nil
+	return common.Watch(m.st.caller, machinerFacade, m.tag)
 }

--- a/state/api/uniter/service.go
+++ b/state/api/uniter/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/charm"
 	"github.com/juju/names"
 
+	"github.com/juju/juju/state/api/common"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/api/watcher"
 )
@@ -43,23 +44,7 @@ func (s *Service) String() string {
 
 // Watch returns a watcher for observing changes to a service.
 func (s *Service) Watch() (watcher.NotifyWatcher, error) {
-	var results params.NotifyWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: s.tag}},
-	}
-	err := s.st.call("Watch", args, &results)
-	if err != nil {
-		return nil, err
-	}
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	w := watcher.NewNotifyWatcher(s.st.caller, result)
-	return w, nil
+	return common.Watch(s.st.caller, uniterFacade, s.tag)
 }
 
 // WatchRelations returns a StringsWatcher that notifies of changes to

--- a/state/api/uniter/unit.go
+++ b/state/api/uniter/unit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/charm"
 	"github.com/juju/names"
 
+	"github.com/juju/juju/state/api/common"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/api/watcher"
 )
@@ -90,23 +91,7 @@ func (u *Unit) EnsureDead() error {
 
 // Watch returns a watcher for observing changes to the unit.
 func (u *Unit) Watch() (watcher.NotifyWatcher, error) {
-	var results params.NotifyWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: u.tag}},
-	}
-	err := u.st.call("Watch", args, &results)
-	if err != nil {
-		return nil, err
-	}
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	w := watcher.NewNotifyWatcher(u.st.caller, result)
-	return w, nil
+	return common.Watch(u.st.caller, uniterFacade, u.tag)
 }
 
 // Service returns the service.


### PR DESCRIPTION
Introduce and use a common Watch implementation,
which is the client-side equivalent to apiserver's
AgentEntityWatcher.
