### PR TITLE
Add user info cmd

### DIFF
--- a/cmd/juju/user_info.go
+++ b/cmd/juju/user_info.go
@@ -1,0 +1,124 @@
+// Copyright 2012, 2013, 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for infos.
+
+package main
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/names"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/juju"
+	"github.com/juju/juju/state/api/params"
+)
+
+const userInfoCommandDoc = `
+Display infomation on a user.
+
+Examples:
+  	# Show information on the current user
+  	$ juju user info  
+  	user-name: foobar
+  	display-name: Foo Bar
+  	date-created : 1981-02-27 16:10:05 +0000 UTC
+	last-connection: 2014-01-01 00:00:00 +0000 UTC
+
+  	# Show information on a user with the given username
+  	$ juju user info jsmith
+  	user-name: jsmith
+  	display-name: John Smith
+  	date-created : 1981-02-27 16:10:05 +0000 UTC
+	last-connection: 2014-01-01 00:00:00 +0000 UTC
+
+  	# Show information on the current user in JSON format
+  	$ juju user info --format json
+  	{"user-name":"foobar",
+  	"display-name":"Foo Bar",
+	"date-created": "1981-02-27 16:10:05 +0000 UTC",
+	"last-connection": "2014-01-01 00:00:00 +0000 UTC"}
+
+  	# Show information on the current user in YAML format
+  	$ juju user info --format yaml
+ 	user-name: foobar
+ 	display-name: Foo Bar
+ 	date-created : 1981-02-27 16:10:05 +0000 UTC
+	last-connection: 2014-01-01 00:00:00 +0000 UTC
+`
+
+type UserInfoCommand struct {
+	envcmd.EnvCommandBase
+	Username string
+	out      cmd.Output
+}
+
+type UserInfo struct {
+	Username       string `yaml:"user-name" json:"user-name"`
+	DisplayName    string `yaml:"display-name" json:"display-name"`
+	DateCreated    string `yaml:"date-created" json:"date-created"`
+	LastConnection string `yaml:"last-connection" json:"last-connection"`
+}
+
+func (c *UserInfoCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "info",
+		Args:    "<username>",
+		Purpose: "shows information on a user",
+		Doc:     userInfoCommandDoc,
+	}
+}
+
+func (c *UserInfoCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
+}
+
+func (c *UserInfoCommand) Init(args []string) (err error) {
+	c.Username, err = cmd.ZeroOrOneArgs(args)
+	return err
+}
+
+type UserInfoAPI interface {
+	UserInfo(username string) (params.UserInfoResult, error)
+	Close() error
+}
+
+var getUserInfoAPI = func(c *UserInfoCommand) (UserInfoAPI, error) {
+	return juju.NewUserManagerClient(c.EnvName)
+}
+
+func (c *UserInfoCommand) Run(ctx *cmd.Context) (err error) {
+	client, err := getUserInfoAPI(c)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	username := c.Username
+	if username == "" {
+		// No username given, get current user
+		store, err := configstore.Default()
+		if err != nil {
+			return err
+		}
+		info, err := store.ReadInfo(c.EnvName)
+		if err != nil {
+			return err
+		}
+		username = info.APICredentials().User
+	}
+	userTag := names.NewUserTag(username)
+	result, err := client.UserInfo(userTag.Id())
+	if err != nil {
+		return err
+	}
+	info := UserInfo{
+		Username:       result.Result.Username,
+		DisplayName:    result.Result.DisplayName,
+		DateCreated:    result.Result.DateCreated.String(),
+		LastConnection: result.Result.LastConnection.String(),
+	}
+	if err = c.out.Write(ctx, info); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/juju/user_info_test.go
+++ b/cmd/juju/user_info_test.go
@@ -1,0 +1,121 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for info.
+
+package main
+
+import (
+	"time"
+
+	"github.com/juju/cmd"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/cmd/envcmd"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state/api/params"
+	"github.com/juju/juju/state/apiserver/common"
+	"github.com/juju/juju/testing"
+)
+
+// All of the functionality of the UserInfo api call is contained elsewhere.
+// This suite provides basic tests for the "user info" command
+type UserInfoCommandSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+var (
+	_ = gc.Suite(&UserInfoCommandSuite{})
+
+	// Mock out timestamps
+	dateCreated    = time.Unix(352138205, 0).UTC()
+	lastConnection = time.Unix(1388534400, 0).UTC()
+)
+
+func (s *UserInfoCommandSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.PatchValue(&getUserInfoAPI, func(*UserInfoCommand) (UserInfoAPI, error) {
+		return &fakeUserInfoAPI{}, nil
+	})
+}
+
+func newUserInfoCommand() cmd.Command {
+	return envcmd.Wrap(&UserInfoCommand{})
+}
+
+type fakeUserInfoAPI struct {
+	UserInfoCommandSuite
+}
+
+func (*fakeUserInfoAPI) Close() error {
+	return nil
+}
+
+func (f *fakeUserInfoAPI) UserInfo(username string) (result params.UserInfoResult, err error) {
+	info := params.UserInfo{
+		DateCreated:    dateCreated,
+		LastConnection: &lastConnection,
+	}
+	switch username {
+	case "":
+		info.Username = "admin"
+	case "foobar":
+		info.Username = "foobar"
+		info.DisplayName = "Foo Bar"
+	default:
+		return params.UserInfoResult{}, common.ErrPerm
+	}
+	result.Result = &info
+	return result, nil
+}
+
+func (s *UserInfoCommandSuite) TestUserInfo(c *gc.C) {
+	context, err := testing.RunCommand(c, newUserInfoCommand())
+	c.Assert(err, gc.IsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, `user-name: admin
+display-name: ""
+date-created: `+dateCreated.String()+`
+last-connection: `+lastConnection.String()+"\n")
+}
+
+func (s *UserInfoCommandSuite) TestUserInfoWithUsername(c *gc.C) {
+	context, err := testing.RunCommand(c, newUserInfoCommand(), "foobar")
+	c.Assert(err, gc.IsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, `user-name: foobar
+display-name: Foo Bar
+date-created: `+dateCreated.String()+`
+last-connection: `+lastConnection.String()+"\n")
+}
+
+func (*UserInfoCommandSuite) TestUserInfoUserDoesNotExist(c *gc.C) {
+	_, err := testing.RunCommand(c, newUserInfoCommand(), "barfoo")
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (*UserInfoCommandSuite) TestUserInfoFormatJson(c *gc.C) {
+	context, err := testing.RunCommand(c, newUserInfoCommand(), "--format", "json")
+	c.Assert(err, gc.IsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, `
+{"user-name":"admin","display-name":"","date-created":"1981-02-27 16:10:05 +0000 UTC","last-connection":"2014-01-01 00:00:00 +0000 UTC"}
+`[1:])
+}
+
+func (*UserInfoCommandSuite) TestUserInfoFormatJsonWithUsername(c *gc.C) {
+	context, err := testing.RunCommand(c, newUserInfoCommand(), "foobar", "--format", "json")
+	c.Assert(err, gc.IsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, `
+{"user-name":"foobar","display-name":"Foo Bar","date-created":"1981-02-27 16:10:05 +0000 UTC","last-connection":"2014-01-01 00:00:00 +0000 UTC"}
+`[1:])
+}
+
+func (*UserInfoCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
+	context, err := testing.RunCommand(c, newUserInfoCommand(), "--format", "yaml")
+	c.Assert(err, gc.IsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, `user-name: admin
+display-name: ""
+date-created: `+dateCreated.String()+`
+last-connection: `+lastConnection.String()+"\n")
+}
+
+func (*UserInfoCommandSuite) TestTooManyArgs(c *gc.C) {
+	_, err := testing.RunCommand(c, newUserInfoCommand(), "username", "whoops")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+}


### PR DESCRIPTION
Add the`$juju user info` cmd to call the recently landed UserInfo API method. See user docs in user_info.go for an outline of how `juju info` behaves.
