### PR TITLE
state: add Machine.WatchAddresses

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -241,3 +241,15 @@ func instanceHostPortsToHostPorts(instanceHostPorts [][]network.HostPort) [][]ho
 	}
 	return hps
 }
+
+func addressesEqual(a, b []network.Address) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, addrA := range a {
+		if addrA != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -179,6 +179,19 @@ func init() {
 	logSize = logSizeTests
 }
 
+// TxnRevno returns the txn-revno field of the document
+// associated with the given Id in the given collection.
+func TxnRevno(st *State, coll string, id interface{}) (int64, error) {
+	var doc struct {
+		TxnRevno int64 `bson:"txn-revno"`
+	}
+	err := st.db.C(coll).FindId(id).One(&doc)
+	if err != nil {
+		return 0, err
+	}
+	return doc.TxnRevno, nil
+}
+
 // MinUnitsRevno returns the Revno of the minUnits document
 // associated with the given service name.
 func MinUnitsRevno(st *State, serviceName string) (int, error) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -924,20 +924,9 @@ func (m *Machine) Addresses() (addresses []network.Address) {
 // SetAddresses records any addresses related to the machine, sourced
 // by asking the provider.
 func (m *Machine) SetAddresses(addresses ...network.Address) (err error) {
-	stateAddresses := instanceAddressesToAddresses(addresses)
-	ops := []txn.Op{
-		{
-			C:      m.st.machines.Name,
-			Id:     m.doc.Id,
-			Assert: notDeadDoc,
-			Update: bson.D{{"$set", bson.D{{"addresses", stateAddresses}}}},
-		},
+	if err = m.setAddresses(addresses, &m.doc.Addresses, "addresses"); err != nil {
+		return fmt.Errorf("cannot set addresses of machine %v: %v", m, err)
 	}
-
-	if err = m.st.runTransaction(ops); err != nil {
-		return fmt.Errorf("cannot set addresses of machine %v: %v", m, onAbort(err, errDead))
-	}
-	m.doc.Addresses = stateAddresses
 	return nil
 }
 
@@ -953,20 +942,49 @@ func (m *Machine) MachineAddresses() (addresses []network.Address) {
 // SetMachineAddresses records any addresses related to the machine, sourced
 // by asking the machine.
 func (m *Machine) SetMachineAddresses(addresses ...network.Address) (err error) {
+	if err = m.setAddresses(addresses, &m.doc.MachineAddresses, "machineaddresses"); err != nil {
+		return fmt.Errorf("cannot set machine addresses of machine %v: %v", m, err)
+	}
+	return nil
+}
+
+// setAddresses updates the machine's addresses (either Addresses or
+// MachineAddresses, depending on the field argument).
+func (m *Machine) setAddresses(addresses []network.Address, field *[]address, fieldName string) error {
+	var changed bool
 	stateAddresses := instanceAddressesToAddresses(addresses)
-	ops := []txn.Op{
-		{
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		changed = false
+		if attempt > 0 {
+			if err := m.Refresh(); err != nil {
+				return nil, err
+			}
+		}
+		if m.doc.Life == Dead {
+			return nil, errDead
+		}
+		op := txn.Op{
 			C:      m.st.machines.Name,
 			Id:     m.doc.Id,
-			Assert: notDeadDoc,
-			Update: bson.D{{"$set", bson.D{{"machineaddresses", stateAddresses}}}},
-		},
+			Assert: append(bson.D{{fieldName, *field}}, notDeadDoc...),
+		}
+		if !addressesEqual(addresses, addressesToInstanceAddresses(*field)) {
+			op.Update = bson.D{{"$set", bson.D{{fieldName, stateAddresses}}}}
+			changed = true
+		}
+		return []txn.Op{op}, nil
 	}
-
-	if err = m.st.runTransaction(ops); err != nil {
-		return fmt.Errorf("cannot set machine addresses of machine %v: %v", m, onAbort(err, errDead))
+	switch err := m.st.run(buildTxn); err {
+	case nil:
+	case statetxn.ErrExcessiveContention:
+		return errors.Annotatef(err, "cannot set %s for machine %s", fieldName, m)
+	default:
+		return err
 	}
-	m.doc.MachineAddresses = stateAddresses
+	if !changed {
+		return nil
+	}
+	*field = stateAddresses
 	return nil
 }
 


### PR DESCRIPTION
Introducing a watcher for machine addresses.
We'll initially use this behind the API for
watching a relation unit's addresses, until
we have a document containing network-specific
addresses.

Also, don't update a machine doc's addresses
if they're already equal to what we want to
set them to.

Fixes https://bugs.launchpad.net/juju-core/+bug/1289815
