### PR TITLE
Always close mgo.Iter after use

### DIFF
--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"labix.org/v2/mgo"
 	"labix.org/v2/mgo/bson"
@@ -416,8 +417,8 @@ func (w *Watcher) sync() error {
 			}
 		}
 	}
-	if iter.Err() != nil {
-		return fmt.Errorf("watcher iteration error: %v", iter.Err())
+	if err := iter.Close(); err != nil {
+		return errors.Errorf("watcher iteration error: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
The documentation for mgo.Itr says that the iterator should be closed after use. Reading the source the difference between Iter.Close() and Iter.Err() is the latter doesn't close the iterator (cursor), but both will return any error that occured so are interchangable in this respect.

Replace all the calls to Iter.Err() with Iter.Close, do some general cleanups and replace fmt.Errorf with errors.Errorf in affected functions.
