### PR TITLE
Ignore empty machine addresses

### DIFF
--- a/network/address.go
+++ b/network/address.go
@@ -261,10 +261,6 @@ func bestAddressIndex(numAddr int, getAddr func(i int) Address, match func(addr 
 	fallbackAddressIndex := -1
 	for i := 0; i < numAddr; i++ {
 		addr := getAddr(i)
-		// Older versions of Juju may have stored an empty address so ignore it here.
-		if addr.Value == "" {
-			continue
-		}
 		if addr.Type != IPv6Address {
 			switch match(addr) {
 			case exactScope:

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -113,13 +113,6 @@ var selectPublicTests = []selectTest{{
 	},
 	0,
 }, {
-	"empty addresses are ignored",
-	[]network.Address{
-		{"", network.IPv4Address, "public", network.ScopeUnknown},
-		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
-	},
-	1,
-}, {
 	"a machine local address is not selected",
 	[]network.Address{
 		{"127.0.0.1", network.IPv4Address, "machine", network.ScopeMachineLocal},
@@ -159,13 +152,6 @@ var selectInternalTests = []selectTest{{
 	"no addresses gives empty string result",
 	[]network.Address{},
 	-1,
-}, {
-	"empty addresses are ignored",
-	[]network.Address{
-		{"", network.IPv4Address, "public", network.ScopeUnknown},
-		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
-	},
-	1,
 }, {
 	"a public address is selected",
 	[]network.Address{

--- a/provider/joyent/instance.go
+++ b/provider/joyent/instance.go
@@ -30,7 +30,7 @@ func (inst *joyentInstance) Refresh() error {
 }
 
 func (inst *joyentInstance) Addresses() ([]network.Address, error) {
-	addresses := make([]network.Address, len(inst.machine.IPs))
+	addresses := make([]network.Address, 0, len(inst.machine.IPs))
 	for _, ip := range inst.machine.IPs {
 		address := network.NewAddress(ip, network.ScopeUnknown)
 		if ip == inst.machine.PrimaryIP {

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -319,7 +319,7 @@ func (s *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 
 	addresses, err := insts[0].Addresses()
 	c.Assert(err, gc.IsNil)
-	c.Assert(addresses, gc.Not(gc.HasLen), 0)
+	c.Assert(addresses, gc.HasLen, 2)
 }
 
 func (s *localServerSuite) TestGetImageMetadataSources(c *gc.C) {


### PR DESCRIPTION
Older versions of juju could write empty machine addresses to state. This messes up the peer address selection when upgrading a nonha env to a ha one. So we add code to ignore such empty addresses.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1329123
