### PR TITLE
cmd/jujud: restrict API logins during upgrades

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -475,11 +475,12 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				dataDir := agentConfig.DataDir()
 				logDir := agentConfig.LogDir()
 				return apiserver.NewServer(st, apiserver.ServerConfig{
-					Addr:    fmt.Sprintf(":%d", port),
-					Cert:    cert,
-					Key:     key,
-					DataDir: dataDir,
-					LogDir:  logDir,
+					Addr:      fmt.Sprintf(":%d", port),
+					Cert:      cert,
+					Key:       key,
+					DataDir:   dataDir,
+					LogDir:    logDir,
+					Validator: a.limitLoginsDuringUpgrade,
 				})
 			})
 			a.startWorkerAfterUpgrade(singularRunner, "cleaner", func() (worker.Worker, error) {
@@ -501,6 +502,30 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 		}
 	}
 	return newCloseWorker(runner, st), nil
+}
+
+// limitLoginsDuringUpgrade is called by the API server for each login
+// attempt. It returns an error if upgrades are in progress unless the
+// login is for a user (i.e. a client) or the local machine.
+func (a *MachineAgent) limitLoginsDuringUpgrade(creds params.Creds) error {
+	select {
+	case <-a.upgradeComplete:
+		return nil // upgrade done so allow all logins
+	default:
+		authTag, err := names.ParseTag(creds.AuthTag)
+		if err != nil {
+			return errors.Annotate(err, "could not parse auth tag")
+		}
+		switch authTag := authTag.(type) {
+		case names.UserTag:
+			return nil // user logins always allowed
+		case names.MachineTag:
+			if authTag == a.Tag() {
+				return nil // allow logins from the local machine
+			}
+		}
+		return errors.Errorf("login for %q blocked because upgrade is in progress", authTag)
+	}
 }
 
 // ensureMongoServer ensures that mongo is installed and running,
@@ -736,6 +761,8 @@ func (a *MachineAgent) upgradeWorker(
 	})
 }
 
+var upgradesPerformUpgrade = upgrades.PerformUpgrade // Allow patching for tests
+
 // runUpgrades runs the upgrade operations for each job type and updates the updatedToVersion on success.
 func (a *MachineAgent) runUpgrades(
 	st *state.State,
@@ -758,7 +785,7 @@ func (a *MachineAgent) runUpgrades(
 				continue
 			}
 			logger.Infof("starting upgrade from %v to %v for %v %q", from, version.Current, target, a.Tag())
-			if err = upgrades.PerformUpgrade(from.Number, target, context); err != nil {
+			if err = upgradesPerformUpgrade(from.Number, target, context); err != nil {
 				err = fmt.Errorf("cannot perform upgrade from %v to %v for %v %q: %v", from, version.Current, target, a.Tag(), err)
 				return
 			}


### PR DESCRIPTION
Use the recently introduced API login validation functionality to only allow client and local machine agent logins while upgrade steps are running. The goal is minimise database activity during upgrades, specifically for schema migrations.

As well as the unit tests, this change has been heavily tested manually.
