### PR TITLE
provider/azure: sanity check cert

### DIFF
--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -34,6 +34,25 @@ func (s *ImageMetadataSuite) SetUpSuite(c *gc.C) {
 	s.environ = os.Environ()
 }
 
+var testCert = `
+-----BEGIN PRIVATE KEY-----
+MIIBCgIBADANBgkqhkiG9w0BAQEFAASB9TCB8gIBAAIxAKQGQxP1i0VfCWn4KmMP
+taUFn8sMBKjP/9vHnUYdZRvvmoJCA1C6arBUDp8s2DNX+QIDAQABAjBLRqhwN4dU
+LfqHDKJ/Vg1aD8u3Buv4gYRBxdFR5PveyqHSt5eJ4g/x/4ndsvr2OqUCGQDNfNlD
+zxHCiEAwZZAPaAkn8jDkFupTljcCGQDMWCujiVZ1NNuBD/N32Yt8P9JDiNzZa08C
+GBW7VXLxbExpgnhb1V97vjQmTfthXQjYAwIYSTEjoFXm4+Bk5xuBh2IidgSeGZaC
+FFY9AhkAsteo31cyQw2xJ80SWrmsIw+ps7Cvt5W9
+-----END PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+MIIBDzCByqADAgECAgkAgIBb3+lSwzEwDQYJKoZIhvcNAQEFBQAwFTETMBEGA1UE
+AxQKQEhvc3ROYW1lQDAeFw0xMzA3MTkxNjA1NTRaFw0yMzA3MTcxNjA1NTRaMBUx
+EzARBgNVBAMUCkBIb3N0TmFtZUAwTDANBgkqhkiG9w0BAQEFAAM7ADA4AjEApAZD
+E/WLRV8JafgqYw+1pQWfywwEqM//28edRh1lG++agkIDULpqsFQOnyzYM1f5AgMB
+AAGjDTALMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQEFBQADMQABKfn08tKfzzqMMD2w
+PI2fs3bw5bRH8tmGjrsJeEdp9crCBS8I3hKcxCkTTRTowdY=
+-----END CERTIFICATE-----
+`
+
 func (s *ImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.dir = c.MkDir()
@@ -41,7 +60,7 @@ func (s *ImageMetadataSuite) SetUpTest(c *gc.C) {
 	certfile, err := ioutil.TempFile(s.dir, "")
 	c.Assert(err, gc.IsNil)
 	filename := certfile.Name()
-	err = ioutil.WriteFile(filename, []byte("test certificate"), 0644)
+	err = ioutil.WriteFile(filename, []byte(testCert), 0644)
 	c.Assert(err, gc.IsNil)
 	envConfig := strings.Replace(metadataTestEnvConfig, "/home/me/azure.pem", filename, -1)
 	testing.WriteEnvironments(c, envConfig)

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -4,8 +4,11 @@
 package azure
 
 import (
+	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/juju/schema"
 
@@ -99,17 +102,41 @@ func (prov azureEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.C
 	cert := envCfg.managementCertificate()
 	if cert == "" {
 		certPath := envCfg.attrs["management-certificate-path"].(string)
-		pemData, err := ioutil.ReadFile(certPath)
+		pemData, err := readPEMFile(certPath)
 		if err != nil {
 			return nil, fmt.Errorf("invalid management-certificate-path: %s", err)
 		}
 		envCfg.attrs["management-certificate"] = string(pemData)
+	} else {
+		if block, _ := pem.Decode([]byte(cert)); block == nil {
+			return nil, fmt.Errorf("invalid management-certificate: not a PEM encoded certificate")
+		}
 	}
 	delete(envCfg.attrs, "management-certificate-path")
+
 	if envCfg.location() == "" {
 		return nil, fmt.Errorf("environment has no location; you need to set one.  E.g. 'West US'")
 	}
 	return cfg.Apply(envCfg.attrs)
+}
+
+func readPEMFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// 640K ought to be enough for anybody.
+	data, err := ioutil.ReadAll(io.LimitReader(f, 1024*640))
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("%q is not a PEM encoded certificate file", path)
+	}
+	return data, nil
 }
 
 var boilerplateYAML = `


### PR DESCRIPTION
- Don't read an unbounded amount of data
  from management-cert-path, because users
  are prone to specifying the wrong file.
- Verify the contents are PEM.

Fixes https://bugs.launchpad.net/ubuntu/+source/juju-core/+bug/1250007
