### PR TITLE
environs/instances: expose getMatchingInstanceTypes

### DIFF
--- a/environs/instances/image.go
+++ b/environs/instances/image.go
@@ -60,23 +60,9 @@ func FindInstanceSpec(possibleImages []Image, ic *InstanceConstraint, allInstanc
 			ic.Series, ic.Region, ic.Arches)
 	}
 
-	var matchingTypes []InstanceType
-	if ic.Constraints.HasInstanceType() {
-		for _, itype := range allInstanceTypes {
-			if itype.Name == *ic.Constraints.InstanceType {
-				matchingTypes = append(matchingTypes, itype)
-				break
-			}
-		}
-		if len(matchingTypes) == 0 {
-			return nil, fmt.Errorf("invalid instance type %q", *ic.Constraints.InstanceType)
-		}
-	} else {
-		var err error
-		matchingTypes, err = getMatchingInstanceTypes(ic, allInstanceTypes)
-		if err != nil {
-			return nil, err
-		}
+	matchingTypes, err := MatchingInstanceTypes(allInstanceTypes, ic.Region, ic.Constraints)
+	if err != nil {
+		return nil, err
 	}
 	if len(matchingTypes) == 0 {
 		return nil, fmt.Errorf("no instance types found matching constraint: %s", ic)

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -323,7 +323,7 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 		instanceTypes: []InstanceType{
 			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, VirtType: &hvm, Mem: 512, CpuCores: 2},
 		},
-		err: `invalid instance type "it-10"`,
+		err: `no instance types in test matching constraints "instance-type=it-10"`,
 	},
 	{
 		desc:   "no image exists in metadata",

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -737,7 +737,7 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 
 	env := s.Open(c)
 	_, err := openstack.FindInstanceSpec(env, "precise", "amd64", "instance-type=m1.large")
-	c.Assert(err, gc.ErrorMatches, `invalid instance type "m1.large"`)
+	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "instance-type=m1.large"`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {


### PR DESCRIPTION
The azure provider has some custom instance-type
matching code which can be made to use this function
if it's exposed.

Also, move instance-type constraint matching into `MatchingInstanceTypes` and friends, simplifying `FindInstanceSpec`.
