### PR TITLE
provider/azure: simplify role size selection, report hardware, fix costs

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -26,5 +26,5 @@ launchpad.net/golxc	bzr	francesco.banconi@canonical.com-20140528132419-q1lubarf0
 launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140513111813-kstzbs2kx1ujl3m3	50
 launchpad.net/goose	bzr	tarmac-20140613065325-tlt6r3jg7saby4ub	126
 launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50
-launchpad.net/gwacl	bzr	tarmac-20140312041035-ac7gw7kcqjx7db63	234
+launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624032805-01qeezmdn1husc5f	235
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -409,9 +409,9 @@ func (env *azureEnviron) SupportNetworks() bool {
 	return false
 }
 
-// selectInstanceTypeAndImage returns the appropriate instance-type name and
+// selectInstanceTypeAndImage returns the appropriate instances.InstanceType and
 // the OS image name for launching a virtual machine with the given parameters.
-func (env *azureEnviron) selectInstanceTypeAndImage(constraint *instances.InstanceConstraint) (string, string, error) {
+func (env *azureEnviron) selectInstanceTypeAndImage(constraint *instances.InstanceConstraint) (*instances.InstanceType, string, error) {
 	ecfg := env.getSnapshot().ecfg
 	sourceImageName := ecfg.forceImageName()
 	if sourceImageName != "" {
@@ -423,19 +423,19 @@ func (env *azureEnviron) selectInstanceTypeAndImage(constraint *instances.Instan
 		// instance type either.
 		//
 		// Select the instance type using simple, Azure-specific code.
-		machineType, err := selectMachineType(gwacl.RoleSizes, defaultToBaselineSpec(constraint.Constraints))
+		instanceType, err := selectMachineType(env, defaultToBaselineSpec(constraint.Constraints))
 		if err != nil {
-			return "", "", err
+			return nil, "", err
 		}
-		return machineType.Name, sourceImageName, nil
+		return instanceType, sourceImageName, nil
 	}
 
 	// Choose the most suitable instance type and OS image, based on simplestreams information.
 	spec, err := findInstanceSpec(env, constraint)
 	if err != nil {
-		return "", "", err
+		return nil, "", err
 	}
-	return spec.InstanceType.Id, spec.Image.Id, nil
+	return &spec.InstanceType, spec.Image.Id, nil
 }
 
 var unsupportedConstraints = []string{
@@ -452,11 +452,20 @@ func (env *azureEnviron) ConstraintsValidator() (constraints.Validator, error) {
 		return nil, err
 	}
 	validator.RegisterVocabulary(constraints.Arch, supportedArches)
-	instTypeNames := make([]string, len(gwacl.RoleSizes))
-	for i, role := range gwacl.RoleSizes {
-		instTypeNames[i] = role.Name
+
+	instanceTypes, err := listInstanceTypes(env)
+	if err != nil {
+		return nil, err
+	}
+	instTypeNames := make([]string, len(instanceTypes))
+	for i, instanceType := range instanceTypes {
+		instTypeNames[i] = instanceType.Name
 	}
 	validator.RegisterVocabulary(constraints.InstanceType, instTypeNames)
+	validator.RegisterConflicts(
+		[]string{constraints.InstanceType},
+		[]string{constraints.Mem, constraints.CpuCores, constraints.Arch, constraints.RootDisk})
+
 	return validator, nil
 }
 
@@ -469,7 +478,7 @@ func (env *azureEnviron) PrecheckInstance(series string, cons constraints.Value,
 		return nil
 	}
 	// Constraint has an instance-type constraint so let's see if it is valid.
-	instanceTypes, err := listInstanceTypes(env, gwacl.RoleSizes)
+	instanceTypes, err := listInstanceTypes(env)
 	if err != nil {
 		return err
 	}
@@ -478,7 +487,7 @@ func (env *azureEnviron) PrecheckInstance(series string, cons constraints.Value,
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid Azure instance %q specified", *cons.InstanceType)
+	return fmt.Errorf("invalid instance type %q", *cons.InstanceType)
 }
 
 // createInstance creates all of the Azure entities necessary for a
@@ -634,13 +643,20 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (_ ins
 			break
 		}
 	}
-	role := env.newRole(instanceType, vhd, userData, stateServer)
+	role := env.newRole(instanceType.Id, vhd, userData, stateServer)
 	inst, err := createInstance(env, azure.ManagementAPI, role, cloudServiceName, stateServer)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	// TODO(bug 1193998) - return instance hardware characteristics as well
-	return inst, &instance.HardwareCharacteristics{}, nil, nil
+	hc := &instance.HardwareCharacteristics{
+		Mem:      &instanceType.Mem,
+		RootDisk: &instanceType.RootDisk,
+		CpuCores: &instanceType.CpuCores,
+	}
+	if len(instanceType.Arches) == 1 {
+		hc.Arch = &instanceType.Arches[0]
+	}
+	return inst, hc, nil, nil
 }
 
 // getInstance returns an up-to-date version of the instance with the given

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -51,6 +51,15 @@ type environSuite struct {
 var _ = gc.Suite(&environSuite{})
 var _ = gc.Suite(&startInstanceSuite{})
 
+func roleSizeByName(name string) gwacl.RoleSize {
+	for _, roleSize := range gwacl.RoleSizes {
+		if roleSize.Name == name {
+			return roleSize
+		}
+	}
+	panic(fmt.Errorf("role size %s not found", name))
+}
+
 // makeEnviron creates a fake azureEnviron with arbitrary configuration.
 func makeEnviron(c *gc.C) *azureEnviron {
 	attrs := makeAzureConfigMap(c)
@@ -1345,12 +1354,12 @@ func (*environSuite) TestGetImageMetadataSigningRequiredDefaultsToTrue(c *gc.C) 
 	c.Check(env.getImageMetadataSigningRequired(), gc.Equals, true)
 }
 
-func (*environSuite) TestSelectInstanceTypeAndImageUsesForcedImage(c *gc.C) {
-	env := makeEnviron(c)
+func (s *environSuite) TestSelectInstanceTypeAndImageUsesForcedImage(c *gc.C) {
+	env := s.setupEnvWithDummyMetadata(c)
 	forcedImage := "my-image"
 	env.ecfg.attrs["force-image-name"] = forcedImage
 
-	aim := gwacl.RoleNameMap["ExtraLarge"]
+	aim := roleSizeByName("ExtraLarge")
 	cons := constraints.Value{
 		CpuCores: &aim.CpuCores,
 		Mem:      &aim.Mem,
@@ -1363,11 +1372,11 @@ func (*environSuite) TestSelectInstanceTypeAndImageUsesForcedImage(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	c.Check(instanceType, gc.Equals, aim.Name)
+	c.Check(instanceType.Name, gc.Equals, aim.Name)
 	c.Check(image, gc.Equals, forcedImage)
 }
 
-func (s *environSuite) setupEnvWithDummyMetadata(c *gc.C) *azureEnviron {
+func (s *baseEnvironSuite) setupEnvWithDummyMetadata(c *gc.C) *azureEnviron {
 	envAttrs := makeAzureConfigMap(c)
 	envAttrs["location"] = "North Europe"
 	env := makeEnvironWithConfig(c, envAttrs)
@@ -1390,7 +1399,7 @@ func (s *environSuite) setupEnvWithDummyMetadata(c *gc.C) *azureEnviron {
 func (s *environSuite) TestSelectInstanceTypeAndImageUsesSimplestreamsByDefault(c *gc.C) {
 	env := s.setupEnvWithDummyMetadata(c)
 	// We'll tailor our constraints so as to get a specific instance type.
-	aim := gwacl.RoleNameMap["ExtraSmall"]
+	aim := roleSizeByName("ExtraSmall")
 	cons := constraints.Value{
 		CpuCores: &aim.CpuCores,
 		Mem:      &aim.Mem,
@@ -1401,7 +1410,7 @@ func (s *environSuite) TestSelectInstanceTypeAndImageUsesSimplestreamsByDefault(
 		Constraints: cons,
 	})
 	c.Assert(err, gc.IsNil)
-	c.Assert(instanceType, gc.Equals, aim.Name)
+	c.Assert(instanceType.Name, gc.Equals, aim.Name)
 	c.Assert(image, gc.Equals, "image-id")
 }
 
@@ -1495,8 +1504,7 @@ type startInstanceSuite struct {
 
 func (s *startInstanceSuite) SetUpTest(c *gc.C) {
 	s.baseEnvironSuite.SetUpTest(c)
-	s.env = makeEnviron(c)
-	s.setDummyStorage(c, s.env)
+	s.env = s.setupEnvWithDummyMetadata(c)
 	s.env.ecfg.attrs["force-image-name"] = "my-image"
 	stateInfo := &state.Info{
 		Info: mongo.Info{
@@ -1524,16 +1532,31 @@ func (s *startInstanceSuite) SetUpTest(c *gc.C) {
 
 func (s *startInstanceSuite) startInstance(c *gc.C) (serviceName string, stateServer bool) {
 	var called bool
+	var roleSize gwacl.RoleSize
 	restore := testing.PatchValue(&createInstance, func(env *azureEnviron, azure *gwacl.ManagementAPI, role *gwacl.Role, serviceNameArg string, stateServerArg bool) (instance.Instance, error) {
 		serviceName = serviceNameArg
 		stateServer = stateServerArg
+		for _, r := range gwacl.RoleSizes {
+			if r.Name == role.RoleSize {
+				roleSize = r
+				break
+			}
+		}
 		called = true
 		return nil, nil
 	})
 	defer restore()
-	_, _, _, err := s.env.StartInstance(s.params)
+	_, hardware, _, err := s.env.StartInstance(s.params)
 	c.Assert(err, gc.IsNil)
 	c.Assert(called, jc.IsTrue)
+	c.Assert(hardware, gc.NotNil)
+	arch := "amd64"
+	c.Assert(hardware, gc.DeepEquals, &instance.HardwareCharacteristics{
+		Arch:     &arch,
+		Mem:      &roleSize.Mem,
+		RootDisk: &roleSize.OSDiskSpace,
+		CpuCores: &roleSize.CpuCores,
+	})
 	return serviceName, stateServer
 }
 
@@ -1610,6 +1633,17 @@ func (s *environSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	cons = constraints.MustParse("instance-type=foo")
 	_, err = validator.Validate(cons)
 	c.Assert(err, gc.ErrorMatches, "invalid constraint value: instance-type=foo\nvalid values are:.*")
+}
+
+func (s *environSuite) TestConstraintsMerge(c *gc.C) {
+	env := s.setupEnvWithDummyMetadata(c)
+	validator, err := env.ConstraintsValidator()
+	c.Assert(err, gc.IsNil)
+	consA := constraints.MustParse("arch=amd64 mem=1G root-disk=10G")
+	consB := constraints.MustParse("instance-type=ExtraSmall")
+	cons, err := validator.Merge(consA, consB)
+	c.Assert(err, gc.IsNil)
+	c.Assert(cons, gc.DeepEquals, constraints.MustParse("instance-type=ExtraSmall"))
 }
 
 func (s *environSuite) TestBootstrapReusesAffinityGroupAndVNet(c *gc.C) {

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -5,7 +5,7 @@ package azure
 
 import (
 	"fmt"
-	"sort"
+	"strings"
 
 	"github.com/juju/errors"
 	"launchpad.net/gwacl"
@@ -16,69 +16,11 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 )
 
-// preferredTypes is a list of machine types, in order of preference so that
-// the first type that matches a set of hardware constraints is also the best
-// (cheapest) fit for those constraints.  Or if your constraint is a maximum
-// price you're willing to pay, your best match is the last type that falls
-// within your threshold price.
-type preferredTypes []*gwacl.RoleSize
-
-// preferredTypes implements sort.Interface.
-var _ sort.Interface = (*preferredTypes)(nil)
-
-// newPreferredTypes creates a preferredTypes based on the given slice of
-// RoleSize objects.  It will hold pointers to the elements of that slice.
-func newPreferredTypes(availableTypes []gwacl.RoleSize) preferredTypes {
-	types := make(preferredTypes, len(availableTypes))
-	for index := range availableTypes {
-		types[index] = &availableTypes[index]
-	}
-	sort.Sort(&types)
-	return types
-}
-
-// Len is specified in sort.Interface.
-func (types *preferredTypes) Len() int {
-	return len(*types)
-}
-
-// Less is specified in sort.Interface.
-func (types *preferredTypes) Less(i, j int) bool {
-	// All we care about for now is cost.  If at some point Azure offers
-	// different tradeoffs for the same price, we may need a tie-breaker.
-	return (*types)[i].Cost < (*types)[j].Cost
-}
-
-// Swap is specified in sort.Interface.
-func (types *preferredTypes) Swap(i, j int) {
-	firstPtr := &(*types)[i]
-	secondPtr := &(*types)[j]
-	*secondPtr, *firstPtr = *firstPtr, *secondPtr
-}
-
-// suffices returns whether the given value is high enough to meet the
-// required value, if any.  If "required" is nil, there is no requirement
-// and so any given value will do.
-//
-// This is a method only to limit namespace pollution.  It ignores the receiver.
-func (*preferredTypes) suffices(given uint64, required *uint64) bool {
-	return required == nil || given >= *required
-}
-
-// satisfies returns whether the given machine type is enough to satisfy
-// the given constraints.  (It doesn't matter if it's overkill; all that
-// matters here is whether the machine type is good enough.)
-//
-// This is a method only to limit namespace pollution.  It ignores the receiver.
-func (types *preferredTypes) satisfies(machineType *gwacl.RoleSize, constraint constraints.Value) bool {
-	// gwacl does not model CPU power yet, although Azure does have the
-	// option of a shared core (for ExtraSmall instances).  For now we
-	// just pretend that's a full-fledged core.
-	return types.suffices(machineType.CpuCores, constraint.CpuCores) &&
-		types.suffices(machineType.Mem, constraint.Mem)
-}
-
 const defaultMem = 1 * gwacl.GB
+
+var (
+	roleSizeCost = gwacl.RoleSizeCost
+)
 
 // If you specify no constraints at all, you're going to get the smallest
 // instance type available.  In practice that one's a bit small.  So unless
@@ -86,7 +28,7 @@ const defaultMem = 1 * gwacl.GB
 // baseline constraints that are just slightly more ambitious than that.
 func defaultToBaselineSpec(constraint constraints.Value) constraints.Value {
 	result := constraint
-	if result.Mem == nil {
+	if !result.HasInstanceType() && result.Mem == nil {
 		var value uint64 = defaultMem
 		result.Mem = &value
 	}
@@ -95,14 +37,17 @@ func defaultToBaselineSpec(constraint constraints.Value) constraints.Value {
 
 // selectMachineType returns the Azure machine type that best matches the
 // supplied instanceConstraint.
-func selectMachineType(availableTypes []gwacl.RoleSize, constraint constraints.Value) (*gwacl.RoleSize, error) {
-	types := newPreferredTypes(availableTypes)
-	for _, machineType := range types {
-		if types.satisfies(machineType, constraint) {
-			return machineType, nil
-		}
+func selectMachineType(env *azureEnviron, cons constraints.Value) (*instances.InstanceType, error) {
+	instanceTypes, err := listInstanceTypes(env)
+	if err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("no machine type matches constraints %v", constraint)
+	region := env.getSnapshot().ecfg.location()
+	instanceTypes, err = instances.MatchingInstanceTypes(instanceTypes, region, cons)
+	if err != nil {
+		return nil, err
+	}
+	return &instanceTypes[0], nil
 }
 
 // getEndpoint returns the simplestreams endpoint to use for the given Azure
@@ -148,36 +93,49 @@ func findMatchingImages(e *azureEnviron, location, series string, arches []strin
 }
 
 // newInstanceType creates an InstanceType based on a gwacl.RoleSize.
-func newInstanceType(roleSize gwacl.RoleSize) instances.InstanceType {
-	vtype := "Hyper-V"
-	// Actually Azure has shared and dedicated CPUs, but gwacl doesn't
-	// model that distinction yet.
-	var cpuPower uint64 = 100
+func newInstanceType(roleSize gwacl.RoleSize, region string) (instances.InstanceType, error) {
+	cost, err := roleSizeCost(region, roleSize.Name)
+	if err != nil {
+		return instances.InstanceType{}, err
+	}
 
+	vtype := "Hyper-V"
 	return instances.InstanceType{
 		Id:       roleSize.Name,
 		Name:     roleSize.Name,
 		CpuCores: roleSize.CpuCores,
 		Mem:      roleSize.Mem,
-		RootDisk: roleSize.OSDiskSpaceVirt,
-		Cost:     roleSize.Cost,
+		RootDisk: roleSize.OSDiskSpace,
+		Cost:     cost,
 		VirtType: &vtype,
-		CpuPower: &cpuPower,
 		// tags are not currently supported by azure
-	}
+	}, nil
 }
 
 // listInstanceTypes describes the available instance types based on a
 // description in gwacl's terms.
-func listInstanceTypes(env *azureEnviron, roleSizes []gwacl.RoleSize) ([]instances.InstanceType, error) {
+func listInstanceTypes(env *azureEnviron) ([]instances.InstanceType, error) {
+	region := env.getSnapshot().ecfg.location()
 	arches, err := env.SupportedArchitectures()
 	if err != nil {
 		return nil, err
 	}
-	types := make([]instances.InstanceType, len(roleSizes))
-	for index, roleSize := range roleSizes {
-		types[index] = newInstanceType(roleSize)
-		types[index].Arches = arches
+	types := make([]instances.InstanceType, 0, len(gwacl.RoleSizes))
+	for _, roleSize := range gwacl.RoleSizes {
+		// TODO(axw) 2014-06-23 #1324666
+		// Support basic instance types. We need to not default
+		// to them as they do not support load balancing.
+		if strings.HasPrefix(roleSize.Name, "Basic_") {
+			continue
+		}
+		instanceType, err := newInstanceType(roleSize, region)
+		if err != nil {
+			return nil, err
+		}
+		types = append(types, instanceType)
+	}
+	for i := range types {
+		types[i].Arches = arches
 	}
 	return types, nil
 }
@@ -191,7 +149,7 @@ func findInstanceSpec(env *azureEnviron, constraint *instances.InstanceConstrain
 		return nil, err
 	}
 	images := instances.ImageMetadataToImages(imageData)
-	instanceTypes, err := listInstanceTypes(env, gwacl.RoleSizes)
+	instanceTypes, err := listInstanceTypes(env)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Use the newly exported environs/instances.MatchingInstanceTypes
  to simplify instance type selection when force-image-name is used.
- Update role costs and role sizes (bump gwacl rev).
- Emit hardware characteristics by converting gwacl.RoleSize to
  instance.HardwareCharacteristics.

Fixes https://bugs.launchpad.net/juju-core/+bug/1215177
