### PR TITLE
Do not allow the peergrouper worker to publish empty/nil api server addresses

### DIFF
--- a/worker/peergrouper/publish.go
+++ b/worker/peergrouper/publish.go
@@ -4,6 +4,8 @@
 package peergrouper
 
 import (
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -20,6 +22,9 @@ func newPublisher(st *state.State) *publisher {
 }
 
 func (pub *publisher) publishAPIServers(apiServers [][]network.HostPort, instanceIds []instance.Id) error {
+	if len(apiServers) == 0 {
+		return errors.Errorf("no api servers specified")
+	}
 	// TODO(rog) publish instanceIds in environment storage.
 	return pub.st.SetAPIHostPorts(apiServers)
 }

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -62,6 +62,14 @@ func (s *workerJujuConnSuite) TestPublisherSetsAPIHostPorts(c *gc.C) {
 	assertAPIHostPorts(c, hps, expectedAPIHostPorts(3))
 }
 
+func (s *workerJujuConnSuite) TestPublisherRejectsNoServers(c *gc.C) {
+	st := newFakeState()
+	initState(c, st, 3)
+	statePublish := newPublisher(s.State)
+	err := statePublish.publishAPIServers(nil, nil)
+	c.Assert(err, gc.ErrorMatches, "no api servers specified")
+}
+
 type workerSuite struct {
 	coretesting.BaseSuite
 }


### PR DESCRIPTION
This is an attempt to fix bug https://bugs.launchpad.net/juju-core/+bug/1333682

Something is writing empty api server addresses to state, which are then propagated to the machine agents, which then update the agent.conf file and boom, the apiaddresses entry is deleted. So I've disallowed the peergrouper worker from publishing empty addresses.
