### PR TITLE
provider/azure: use Location in vnet creation; always delete AG

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -26,5 +26,5 @@ launchpad.net/golxc	bzr	francesco.banconi@canonical.com-20140528132419-q1lubarf0
 launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140513111813-kstzbs2kx1ujl3m3	50
 launchpad.net/goose	bzr	tarmac-20140613065325-tlt6r3jg7saby4ub	126
 launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50
-launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624032805-01qeezmdn1husc5f	235
+launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624093241-rlqsuf7pqxnrztgw	236
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -980,7 +980,9 @@ func (s *environSuite) TestDestroyDoesNotFailIfVirtualNetworkDeletionFails(c *gc
 	s.setDummyStorage(c, env)
 	responses := getAzureServiceListResponse(c)
 	cleanupResponses := []gwacl.DispatcherResponse{
-		// Fail to delete vnet
+		// Fail to get vnet for deletion
+		gwacl.NewDispatcherResponse(nil, http.StatusConflict, nil),
+		// Fail to delete affinity group
 		gwacl.NewDispatcherResponse(nil, http.StatusConflict, nil),
 	}
 	responses = append(responses, cleanupResponses...)
@@ -988,11 +990,15 @@ func (s *environSuite) TestDestroyDoesNotFailIfVirtualNetworkDeletionFails(c *gc
 
 	err := env.Destroy()
 	c.Check(err, gc.IsNil)
-	c.Assert(*requests, gc.HasLen, 2)
+	c.Assert(*requests, gc.HasLen, 3)
 
 	getRequest := (*requests)[1]
 	c.Check(getRequest.Method, gc.Equals, "GET")
 	c.Check(strings.HasSuffix(getRequest.URL, "services/networking/media"), gc.Equals, true)
+
+	deleteRequest := (*requests)[2]
+	c.Check(deleteRequest.Method, gc.Equals, "DELETE")
+	c.Check(strings.Contains(deleteRequest.URL, env.getAffinityGroupName()), jc.IsTrue)
 }
 
 func (s *environSuite) TestDestroyDoesNotFailIfAffinityGroupDeletionFails(c *gc.C) {
@@ -1254,7 +1260,8 @@ func (*environSuite) TestCreateVirtualNetwork(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	networkConf := (*body.VirtualNetworkSites)[0]
 	c.Check(networkConf.Name, gc.Equals, env.getVirtualNetworkName())
-	c.Check(networkConf.AffinityGroup, gc.Equals, env.getAffinityGroupName())
+	c.Check(networkConf.AffinityGroup, gc.Equals, "")
+	c.Check(networkConf.Location, gc.Equals, env.getSnapshot().ecfg.location())
 }
 
 func (*environSuite) TestDestroyVirtualNetwork(c *gc.C) {


### PR DESCRIPTION
The Azure docs recommend using Location when creating a virtual
network site, so we do that (with a prerequisite gwacl branch).
Also, now that the vnet is not tied to an affinity group, we can
attempt to delete the affinity group even if deleting the virtual
network failed.

Fixes https://bugs.launchpad.net/juju-core/+bug/1259947
