### PR TITLE
Missing found = true in for loop

### DIFF
--- a/state/unit.go
+++ b/state/unit.go
@@ -653,6 +653,7 @@ func (u *Unit) OpenPort(protocol string, number int) (err error) {
 	found := false
 	for _, p := range u.doc.Ports {
 		if p == port {
+			found = true
 			break
 		}
 	}


### PR DESCRIPTION
If the given port is already in u.doc.Ports, set found to true, ensuring that the port is not appended again.
