### PR TITLE
state/{api,apiserver}: don't leak heartbeat goroutine

### DIFF
--- a/cmd/jujud/upgrade_test.go
+++ b/cmd/jujud/upgrade_test.go
@@ -228,5 +228,9 @@ var upgradeTestDialOpts = api.DialOpts{
 
 func (s *UpgradeSuite) canLoginToAPI(info *api.Info) (out bool) {
 	apiState, err := api.Open(info, upgradeTestDialOpts)
-	return apiState != nil && err == nil
+	if apiState != nil && err == nil {
+		apiState.Close()
+		return true
+	}
+	return false
 }

--- a/state/api/apiclient.go
+++ b/state/api/apiclient.go
@@ -55,6 +55,9 @@ type State struct {
 	// broken.
 	broken chan struct{}
 
+	// closed is a channel that gets closed when State.Close is called.
+	closed chan struct{}
+
 	// tag and password hold the cached login credentials.
 	tag      string
 	password string
@@ -193,7 +196,8 @@ func Open(info *Info, opts DialOpts) (*State, error) {
 		}
 	}
 	st.broken = make(chan struct{})
-	go st.heartbeatMonitor(PingPeriod)
+	st.closed = make(chan struct{})
+	go st.heartbeatMonitor()
 	return st, nil
 }
 
@@ -255,13 +259,16 @@ func newWebsocketDialer(cfg *websocket.Config, opts DialOpts) func(<-chan struct
 	}
 }
 
-func (s *State) heartbeatMonitor(pingPeriod time.Duration) {
+func (s *State) heartbeatMonitor() {
 	for {
 		if err := s.Ping(); err != nil {
 			close(s.broken)
 			return
 		}
-		time.Sleep(pingPeriod)
+		select {
+		case <-time.After(PingPeriod):
+		case <-s.closed:
+		}
 	}
 }
 
@@ -285,7 +292,14 @@ func (s *State) Call(objType, id, request string, args, response interface{}) er
 }
 
 func (s *State) Close() error {
-	return s.client.Close()
+	err := s.client.Close()
+	select {
+	case <-s.closed:
+	default:
+		close(s.closed)
+	}
+	<-s.broken
+	return err
 }
 
 // Broken returns a channel that's closed when the connection is broken.

--- a/state/apiserver/login_test.go
+++ b/state/apiserver/login_test.go
@@ -182,10 +182,10 @@ func (s *loginSuite) TestLoginSetsLogIdentifier(c *gc.C) {
 
 	apiConn, err := api.Open(info, fastDialOpts)
 	c.Assert(err, gc.IsNil)
+	defer apiConn.Close()
 	apiMachine, err := apiConn.Machiner().Machine(machineInState.Tag().String())
 	c.Assert(err, gc.IsNil)
 	c.Assert(apiMachine.Tag(), gc.Equals, machineInState.Tag().String())
-	apiConn.Close()
 
 	c.Assert(tw.Log, jc.LogMatches, []string{
 		`<- \[[0-9A-F]+\] <unknown> {"RequestId":1,"Type":"Admin","Request":"Login",` +
@@ -484,6 +484,7 @@ func (s *loginSuite) TestLoginReportsEnvironTag(c *gc.C) {
 	// response.
 	st, err := api.Open(info, fastDialOpts)
 	c.Assert(err, gc.IsNil)
+	defer st.Close()
 	var result params.LoginResult
 	creds := &params.Creds{
 		AuthTag:  "user-admin",
@@ -536,6 +537,7 @@ func (s *loginSuite) TestLoginReportsAvailableFacadeVersions(c *gc.C) {
 	defer cleanup()
 	st, err := api.Open(info, fastDialOpts)
 	c.Assert(err, gc.IsNil)
+	defer st.Close()
 	var result params.LoginResult
 	creds := &params.Creds{
 		AuthTag:  "user-admin",

--- a/state/apiserver/pinger_test.go
+++ b/state/apiserver/pinger_test.go
@@ -74,6 +74,7 @@ func (s *stateSuite) TestClientNoNeedToPing(c *gc.C) {
 	s.PatchValue(apiserver.MaxClientPingInterval, time.Duration(0))
 	st, err := api.Open(s.APIInfo(c), api.DefaultDialOpts())
 	c.Assert(err, gc.IsNil)
+	defer st.Close()
 	time.Sleep(coretesting.ShortWait)
 	err = st.Ping()
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
- In api.State.Close, signal and wait for the heartbeat
  goroutine to stop before returning.
- Add various missing api.State.Close calls to apiserver
  tests.

Fixes https://bugs.launchpad.net/juju-core/+bug/1334531
