### PR TITLE
Juju provider for CloudSigma - client (for review)

### DIFF
--- a/provider/cloudsigma/client.go
+++ b/provider/cloudsigma/client.go
@@ -1,0 +1,307 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
+	"github.com/juju/loggo"
+	"github.com/juju/utils"
+)
+
+// This file contains implementation of CloudSigma client.
+type environClient struct {
+	conn     *gosigma.Client
+	region   string
+	username string
+	password string
+	name     string
+	storage  *environStorage
+}
+
+type tracer struct{}
+
+func (tracer) Logf(format string, args ...interface{}) {
+	logger.Tracef(format, args...)
+}
+
+// newClient creates new CloudSigma client connection.
+var newClient = func(cfg *environConfig) (*environClient, error) {
+
+	// fetch and validate configuration
+	region, err := gosigma.ResolveEndpoint(cfg.region())
+	if err != nil {
+		region = cfg.region()
+	}
+	username := cfg.username()
+	password := cfg.password()
+	name := cfg.Name()
+
+	logger.Debugf("creating CloudSigma client: region=%s, user=%s, password=%s, name=%q",
+		region, username, strings.Repeat("*", len(password)), name)
+
+	// create connection to CloudSigma
+	conn, err := gosigma.NewClient(region, username, password, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// configure trace logger
+	if logger.LogLevel() <= loggo.TRACE {
+		conn.Logger(&tracer{})
+	}
+
+	c := &environClient{
+		conn:     conn,
+		region:   region,
+		name:     name,
+		username: username,
+		password: password,
+	}
+
+	return c, nil
+}
+
+// configChanged checks if CloudSigma client environment configuration is changed
+func (c environClient) configChanged(cfg *environConfig) bool {
+	// fetch configuration
+	region, err := gosigma.ResolveEndpoint(cfg.region())
+	if err != nil {
+		return true
+	}
+	username := cfg.username()
+	password := cfg.password()
+	name := cfg.Name()
+
+	// compare
+	if region != c.region || username != c.username ||
+		password != c.password || name != c.name {
+		return true
+	}
+
+	return false
+}
+
+const (
+	jujuMetaInstance            = "juju-instance"
+	jujuMetaInstanceStateServer = "state-server"
+	jujuMetaInstanceServer      = "server"
+
+	jujuMetaEnvironment = "juju-environment"
+)
+
+func (c environClient) isMyEnvironment(s gosigma.Server) bool {
+	if v, _ := s.Get(jujuMetaEnvironment); c.name == v {
+		return true
+	}
+	return false
+}
+
+func (c environClient) isMyServer(s gosigma.Server) bool {
+	if _, ok := s.Get(jujuMetaInstance); ok {
+		return c.isMyEnvironment(s)
+	}
+	return false
+}
+
+func (c environClient) isMyStateServer(s gosigma.Server) bool {
+	if v, ok := s.Get(jujuMetaInstance); ok && v == jujuMetaInstanceStateServer {
+		return c.isMyEnvironment(s)
+	}
+	return false
+}
+
+// instances of servers at CloudSigma account
+func (c environClient) instances() ([]gosigma.Server, error) {
+	return c.conn.ServersFiltered(gosigma.RequestDetail, c.isMyServer)
+}
+
+// instanceMap of server ids to servers at CloudSigma account
+func (c environClient) instanceMap() (map[string]gosigma.Server, error) {
+	servers, err := c.conn.ServersFiltered(gosigma.RequestDetail, c.isMyServer)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]gosigma.Server, len(servers))
+	for _, s := range servers {
+		m[s.UUID()] = s
+	}
+
+	return m, nil
+}
+
+func (c environClient) stateServerAddress() (string, string, bool) {
+	logger.Debugf("query state...")
+
+	servers, err := c.conn.ServersFiltered(gosigma.RequestDetail, c.isMyStateServer)
+	if err != nil {
+		return "", "", false
+	}
+
+	logger.Debugf("...servers count: %d", len(servers))
+	if logger.LogLevel() <= loggo.TRACE {
+		for _, s := range servers {
+			logger.Tracef("... %s", s)
+		}
+	}
+
+	for _, s := range servers {
+		if s.Status() != gosigma.ServerRunning {
+			continue
+		}
+		if addrs := s.IPv4(); len(addrs) != 0 {
+			return s.UUID(), addrs[0], true
+		}
+	}
+
+	return "", "", false
+}
+
+// stop instance
+func (c environClient) stopInstance(id instance.Id) error {
+	uuid := string(id)
+	if uuid == "" {
+		return fmt.Errorf("invalid instance id")
+	}
+
+	var err error
+
+	s, err := c.conn.Server(uuid)
+	if err != nil {
+		return err
+	}
+
+	if c.storage != nil && c.isMyStateServer(s) {
+		c.storage.onStateInstanceStop(uuid)
+	}
+
+	err = s.StopWait()
+	logger.Tracef("environClient.StopInstance - stop server, %q = %v", uuid, err)
+
+	err = s.Remove(gosigma.RecurseAllDrives)
+	logger.Tracef("environClient.StopInstance - remove server, %q = %v", uuid, err)
+
+	return nil
+}
+
+// start new instance
+func (c environClient) newInstance(args environs.StartInstanceParams) (srv gosigma.Server, drv gosigma.Drive, err error) {
+
+	cleanup := func() {
+		if err == nil {
+			return
+		}
+		if srv != nil {
+			srv.Remove(gosigma.RecurseAllDrives)
+		} else if drv != nil {
+			drv.Remove()
+		}
+		srv = nil
+		drv = nil
+	}
+	defer cleanup()
+
+	if args.MachineConfig == nil {
+		err = fmt.Errorf("invalid configuration for new instance")
+		return
+	}
+
+	logger.Tracef("Tools: %v", args.Tools.URLs())
+	logger.Tracef("Juju Constraints:" + args.Constraints.String())
+	logger.Tracef("MachineConfig: %#v", args.MachineConfig)
+
+	cs, err := newConstraints(args.MachineConfig.Bootstrap,
+		args.Constraints, args.MachineConfig.Tools.Version.Series)
+	if err != nil {
+		return
+	}
+	logger.Debugf("CloudSigma Constraints: %v", cs)
+
+	originalDrive, err := c.conn.Drive(cs.driveTemplate, gosigma.LibraryMedia)
+	if err != nil {
+		err = fmt.Errorf("query drive template: %v", err)
+		return
+	}
+
+	baseName := "juju-" + c.name + "-" + args.MachineConfig.MachineId
+
+	cloneParams := gosigma.CloneParams{Name: baseName}
+	if drv, err = originalDrive.CloneWait(cloneParams, nil); err != nil {
+		err = fmt.Errorf("error cloning drive: %v", err)
+		return
+	}
+
+	if drv.Size() < cs.driveSize {
+		if err = drv.ResizeWait(cs.driveSize); err != nil {
+			err = fmt.Errorf("error resizing drive: %v", err)
+			return
+		}
+	}
+
+	var cc gosigma.Components
+	cc.SetName(baseName)
+	cc.SetDescription(baseName)
+
+	if cs.cores != 0 {
+		cc.SetSMP(cs.cores)
+	}
+
+	if cs.power != 0 {
+		cc.SetCPU(cs.power)
+	}
+
+	if cs.mem != 0 {
+		cc.SetMem(cs.mem)
+	}
+
+	vncpass, err := utils.RandomPassword()
+	if err != nil {
+		err = fmt.Errorf("error generating password: %v", err)
+		return
+	}
+	cc.SetVNCPassword(vncpass)
+
+	cc.SetSSHPublicKey(args.MachineConfig.AuthorizedKeys)
+	cc.AttachDrive(1, "0:0", "virtio", drv.UUID())
+	cc.NetworkDHCP4(gosigma.ModelVirtio)
+
+	if args.MachineConfig.Bootstrap {
+		cc.SetMeta(jujuMetaInstance, jujuMetaInstanceStateServer)
+	} else {
+		cc.SetMeta(jujuMetaInstance, jujuMetaInstanceServer)
+	}
+
+	if c.name != "" {
+		cc.SetMeta(jujuMetaEnvironment, c.name)
+	}
+
+	if srv, err = c.conn.CreateServer(cc); err != nil {
+		err = fmt.Errorf("error creating new instance: %v", err)
+		return
+	}
+
+	if err = srv.StartWait(); err != nil {
+		err = fmt.Errorf("error booting new instance: %v", err)
+		return
+	}
+
+	var ipaddr string
+	instanceNetworkAvailable := func(s gosigma.Server) bool {
+		ipaddr = sigmaInstance{s}.findIPv4()
+		return ipaddr != ""
+	}
+	if err = srv.Wait(instanceNetworkAvailable); err != nil {
+		err = fmt.Errorf("error waiting for instance IP address: %v", err)
+		return
+	}
+
+	logger.Tracef("instance ip %q", ipaddr)
+
+	return
+}

--- a/provider/cloudsigma/client.go
+++ b/provider/cloudsigma/client.go
@@ -24,6 +24,8 @@ type environClient struct {
 	storage  *environStorage
 }
 
+// tracer matches the gosigma Log interface and maps all of the gosigma 
+// logging to a Trace level logging of juju.provider.cloudsigma
 type tracer struct{}
 
 func (tracer) Logf(format string, args ...interface{}) {

--- a/provider/cloudsigma/client.go
+++ b/provider/cloudsigma/client.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Altoros/gosigma"
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/instance"
+	"github.com/altoros/gosigma"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
+	
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
 )
 
 // This file contains implementation of CloudSigma client.

--- a/provider/cloudsigma/client_test.go
+++ b/provider/cloudsigma/client_test.go
@@ -1,0 +1,316 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Altoros/gosigma"
+	"github.com/Altoros/gosigma/data"
+	"github.com/Altoros/gosigma/mock"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/cloudinit"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
+	"github.com/juju/juju/version"
+	"github.com/juju/loggo"
+	gc "launchpad.net/gocheck"
+)
+
+type clientSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&clientSuite{})
+
+func (s *clientSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	mock.Start()
+}
+
+func (s *clientSuite) TearDownSuite(c *gc.C) {
+	mock.Stop()
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *clientSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	ll := logger.LogLevel()
+	logger.SetLogLevel(loggo.TRACE)
+	s.AddCleanup(func(*gc.C) { logger.SetLogLevel(ll) })
+
+	mock.Reset()
+}
+
+func (s *clientSuite) TearDownTest(c *gc.C) {
+	mock.Reset()
+	s.BaseSuite.TearDownTest(c)
+}
+
+func testNewClient(c *gc.C, endpoint, username, password string) (*environClient, error) {
+	ecfg := &environConfig{
+		Config: newConfig(c, testing.Attrs{"name": "client-test"}),
+		attrs: map[string]interface{}{
+			"region":   endpoint,
+			"username": username,
+			"password": password,
+		},
+	}
+	return newClient(ecfg)
+}
+
+func (s *clientSuite) TestClientNew(c *gc.C) {
+	cli, err := testNewClient(c, "https://testing.invalid", "user", "password")
+	c.Check(err, gc.IsNil)
+	c.Check(cli, gc.NotNil)
+
+	cli, err = testNewClient(c, "http://testing.invalid", "user", "password")
+	c.Check(err, gc.ErrorMatches, "endpoint must use https scheme")
+	c.Check(cli, gc.IsNil)
+
+	cli, err = testNewClient(c, "https://testing.invalid", "", "password")
+	c.Check(err, gc.ErrorMatches, "username is not allowed to be empty")
+	c.Check(cli, gc.IsNil)
+}
+
+func (s *clientSuite) TestClientConfigChanged(c *gc.C) {
+	ecfg := &environConfig{
+		Config: newConfig(c, testing.Attrs{"name": "client-test"}),
+		attrs: map[string]interface{}{
+			"region":   "https://testing.invalid",
+			"username": "user",
+			"password": "password",
+		},
+	}
+
+	cli, err := newClient(ecfg)
+	c.Check(err, gc.IsNil)
+	c.Check(cli, gc.NotNil)
+
+	rc := cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, false)
+
+	ecfg.attrs["region"] = ""
+	rc = cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, true)
+
+	ecfg.attrs["region"] = "https://testing.invalid"
+	ecfg.attrs["username"] = "user1"
+	rc = cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, true)
+
+	ecfg.attrs["username"] = "user"
+	ecfg.attrs["password"] = "password1"
+	rc = cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, true)
+
+	ecfg.attrs["password"] = "password"
+	ecfg.Config = newConfig(c, testing.Attrs{"name": "changed"})
+	rc = cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, true)
+}
+
+func addTestClientServer(c *gc.C, instance, env, ip string) string {
+	json := `{"meta": {`
+	if instance != "" {
+		json += fmt.Sprintf(`"juju-instance": "%s"`, instance)
+		if env != "" {
+			json += fmt.Sprintf(`, "juju-environment": "%s"`, env)
+		}
+	}
+	json += fmt.Sprintf(`}, "status": "running", "nics":[{
+            "runtime": {
+                "interface_type": "public",
+                "ip_v4": {
+                    "resource_uri": "/api/2.0/ips/%s/",
+                    "uuid": "%s"
+                }}}]}`, ip, ip)
+	r := strings.NewReader(json)
+	s, err := data.ReadServer(r)
+	c.Assert(err, gc.IsNil)
+	mock.AddServer(s)
+	return s.UUID
+}
+
+func (s *clientSuite) TestClientInstances(c *gc.C) {
+	addTestClientServer(c, "", "", "")
+	addTestClientServer(c, jujuMetaInstanceServer, "alien", "")
+	addTestClientServer(c, jujuMetaInstanceStateServer, "alien", "")
+	addTestClientServer(c, jujuMetaInstanceServer, "client-test", "1.1.1.1")
+	addTestClientServer(c, jujuMetaInstanceServer, "client-test", "2.2.2.2")
+	suuid := addTestClientServer(c, jujuMetaInstanceStateServer, "client-test", "3.3.3.3")
+
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	ss, err := cli.instances()
+	c.Assert(err, gc.IsNil)
+	c.Assert(ss, gc.NotNil)
+	c.Check(ss, gc.HasLen, 3)
+
+	sm, err := cli.instanceMap()
+	c.Assert(err, gc.IsNil)
+	c.Assert(sm, gc.NotNil)
+	c.Check(sm, gc.HasLen, 3)
+
+	uuid, ip, rc := cli.stateServerAddress()
+	c.Check(uuid, gc.Equals, suuid)
+	c.Check(ip, gc.Equals, "3.3.3.3")
+	c.Check(rc, gc.Equals, true)
+}
+
+func (s *clientSuite) TestClientStopStateInstance(c *gc.C) {
+	addTestClientServer(c, "", "", "")
+	addTestClientServer(c, jujuMetaInstanceServer, "alien", "")
+	addTestClientServer(c, jujuMetaInstanceStateServer, "alien", "")
+	addTestClientServer(c, jujuMetaInstanceServer, "client-test", "1.1.1.1")
+	addTestClientServer(c, jujuMetaInstanceServer, "client-test", "2.2.2.2")
+	suuid := addTestClientServer(c, jujuMetaInstanceStateServer, "client-test", "3.3.3.3")
+
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	cli.storage = &environStorage{uuid: suuid, tmp: true}
+
+	err = cli.stopInstance(instance.Id(suuid))
+	c.Assert(err, gc.IsNil)
+
+	uuid, ip, rc := cli.stateServerAddress()
+	c.Check(uuid, gc.Equals, "")
+	c.Check(ip, gc.Equals, "")
+	c.Check(rc, gc.Equals, false)
+
+	c.Check(cli.storage.tmp, gc.Equals, false)
+}
+
+func (s *clientSuite) TestClientInvalidStopInstance(c *gc.C) {
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	var id instance.Id
+	err = cli.stopInstance(id)
+	c.Check(err, gc.ErrorMatches, "invalid instance id")
+
+	err = cli.stopInstance("1234")
+	c.Check(err, gc.ErrorMatches, "404 Not Found.*")
+}
+
+func (s *clientSuite) TestClientInvalidServer(c *gc.C) {
+	cli, err := testNewClient(c, "https://testing.invalid", mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	cli.conn.ConnectTimeout(10 * time.Millisecond)
+
+	err = cli.stopInstance("1234")
+	c.Check(err, gc.ErrorMatches, "broken connection")
+
+	_, err = cli.instanceMap()
+	c.Check(err, gc.ErrorMatches, "broken connection")
+
+	uuid, ip, ok := cli.stateServerAddress()
+	c.Check(uuid, gc.Equals, "")
+	c.Check(ip, gc.Equals, "")
+	c.Check(ok, gc.Equals, false)
+}
+
+func (s *clientSuite) TestClientNewInstanceInvalidParams(c *gc.C) {
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	params := environs.StartInstanceParams{
+		Constraints: constraints.Value{},
+	}
+	server, drive, err := cli.newInstance(params)
+	c.Check(server, gc.IsNil)
+	c.Check(drive, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "invalid configuration for new instance")
+
+	params.MachineConfig = &cloudinit.MachineConfig{
+		Bootstrap: true,
+		Tools: &tools.Tools{
+			Version: version.Binary{
+				Series: "series",
+			},
+		},
+	}
+	server, drive, err = cli.newInstance(params)
+	c.Check(server, gc.IsNil)
+	c.Check(drive, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "series 'series' not supported")
+
+	var arch = "arch"
+	params.Constraints.Arch = &arch
+	server, drive, err = cli.newInstance(params)
+	c.Check(server, gc.IsNil)
+	c.Check(drive, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "arch 'arch' not supported")
+}
+
+func (s *clientSuite) TestClientNewInstanceInvalidTemplate(c *gc.C) {
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	params := environs.StartInstanceParams{
+		Constraints: constraints.Value{},
+		MachineConfig: &cloudinit.MachineConfig{
+			Bootstrap: true,
+			Tools: &tools.Tools{
+				Version: version.Binary{
+					Series: "trusty",
+				},
+			},
+		},
+	}
+	server, drive, err := cli.newInstance(params)
+	c.Check(server, gc.IsNil)
+	c.Check(drive, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "query drive template: 404 Not Found.*")
+}
+
+func (s *clientSuite) TestClientNewInstance(c *gc.C) {
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	cli.conn.OperationTimeout(1 * time.Second)
+
+	params := environs.StartInstanceParams{
+		Constraints: constraints.Value{},
+		MachineConfig: &cloudinit.MachineConfig{
+			Bootstrap: true,
+			Tools: &tools.Tools{
+				Version: version.Binary{
+					Series: "trusty",
+				},
+			},
+		},
+	}
+	cs, err := newConstraints(params.MachineConfig.Bootstrap,
+		params.Constraints, params.MachineConfig.Tools.Version.Series)
+	c.Assert(cs, gc.NotNil)
+	c.Check(err, gc.IsNil)
+
+	templateDrive := &data.Drive{
+		Resource: data.Resource{URI: "uri", UUID: cs.driveTemplate},
+		LibraryDrive: data.LibraryDrive{
+			Arch:      "arch",
+			ImageType: "image-type",
+			OS:        "os",
+			Paid:      true,
+		},
+		Size:   2200 * gosigma.Megabyte,
+		Status: "unmounted",
+	}
+	mock.ResetDrives()
+	mock.LibDrives.Add(templateDrive)
+
+	server, drive, err := cli.newInstance(params)
+	c.Check(server, gc.NotNil)
+	c.Check(drive, gc.NotNil)
+	c.Check(err, gc.IsNil)
+}

--- a/provider/cloudsigma/client_test.go
+++ b/provider/cloudsigma/client_test.go
@@ -8,9 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Altoros/gosigma"
-	"github.com/Altoros/gosigma/data"
-	"github.com/Altoros/gosigma/mock"
+	"github.com/altoros/gosigma"
+	"github.com/altoros/gosigma/data"
+	"github.com/altoros/gosigma/mock"
+	gc "launchpad.net/gocheck"
+	"github.com/juju/loggo"
+	
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
@@ -18,8 +21,6 @@ import (
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
-	"github.com/juju/loggo"
-	gc "launchpad.net/gocheck"
 )
 
 type clientSuite struct {

--- a/provider/cloudsigma/config.go
+++ b/provider/cloudsigma/config.go
@@ -6,10 +6,11 @@ package cloudsigma
 import (
 	"fmt"
 
-	"github.com/Altoros/gosigma"
-	"github.com/juju/juju/environs/config"
+	"github.com/altoros/gosigma"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
+	
+	"github.com/juju/juju/environs/config"
 )
 
 // boilerplateConfig will be shown in help output, so please keep it up to

--- a/provider/cloudsigma/config.go
+++ b/provider/cloudsigma/config.go
@@ -1,0 +1,165 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/schema"
+	"github.com/juju/utils"
+)
+
+// boilerplateConfig will be shown in help output, so please keep it up to
+// date when you change environment configuration below.
+var boilerplateConfig = `# https://juju.ubuntu.com/docs/config-cloudsigma.html
+cloudsigma:
+    type: cloudsigma
+
+    # region holds the cloudsigma region (zrh, lvs, ...).
+    #
+    # region: <your region>
+
+    # credentials for CloudSigma account
+    #
+    # username: <your username>
+    # password: <secret>
+
+    # storage-port specifes the TCP port that the
+    # bootstrap machine's Juju storage server will listen
+    # on. It defaults to ` + fmt.Sprint(defaultStoragePort) + `
+    #
+    # storage-port: ` + fmt.Sprint(defaultStoragePort) + `
+
+`
+
+const defaultStoragePort = 8040
+
+var configFields = schema.Fields{
+	"username": schema.String(),
+	"password": schema.String(),
+	"region":   schema.String(),
+
+	"storage-port":     schema.ForceInt(),
+	"storage-auth-key": schema.String(),
+}
+
+var configDefaultFields = schema.Defaults{
+	"username": "",
+	"password": "",
+	"region":   gosigma.DefaultRegion,
+
+	"storage-port": defaultStoragePort,
+}
+
+var configSecretFields = []string{
+	"storage-auth-key",
+}
+
+var configImmutableFields = []string{
+	"storage-port",
+	"storage-auth-key",
+	"region",
+}
+
+func prepareConfig(cfg *config.Config) (*config.Config, error) {
+	// Turn an incomplete config into a valid one, if possible.
+	attrs := cfg.UnknownAttrs()
+
+	if _, ok := attrs["storage-auth-key"]; !ok {
+		uuid, err := utils.NewUUID()
+		if err != nil {
+			return nil, err
+		}
+		attrs["storage-auth-key"] = uuid.String()
+	}
+
+	return cfg.Apply(attrs)
+}
+
+func validateConfig(cfg *config.Config, old *environConfig) (*environConfig, error) {
+	// Check sanity of juju-level fields.
+	var oldCfg *config.Config
+	if old != nil {
+		oldCfg = old.Config
+	}
+	if err := config.Validate(cfg, oldCfg); err != nil {
+		return nil, err
+	}
+
+	// Extract validated provider-specific fields. All of configFields will be
+	// present in validated, and defaults will be inserted if necessary. If the
+	// schema you passed in doesn't quite express what you need, you can make
+	// whatever checks you need here, before continuing.
+	// In particular, if you want to extract (say) credentials from the user's
+	// shell environment variables, you'll need to allow missing values to pass
+	// through the schema by setting a value of schema.Omit in the configFields
+	// map, and then to set and check them at this point. These values *must* be
+	// stored in newAttrs: a Config will be generated on the user's machine only
+	// to begin with, and will subsequently be used on a different machine that
+	// will probably not have those variables set.
+	newAttrs, err := cfg.ValidateUnknownAttrs(configFields, configDefaultFields)
+	if err != nil {
+		return nil, err
+	}
+	for field := range configFields {
+		if newAttrs[field] == "" {
+			return nil, fmt.Errorf("%s: must not be empty", field)
+		}
+	}
+
+	// If an old config was supplied, check any immutable fields have not changed.
+	if old != nil {
+		for _, field := range configImmutableFields {
+			if old.attrs[field] != newAttrs[field] {
+				return nil, fmt.Errorf(
+					"%s: cannot change from %v to %v",
+					field, old.attrs[field], newAttrs[field],
+				)
+			}
+		}
+	}
+
+	// Merge the validated provider-specific fields into the original config,
+	// to ensure the object we return is internally consistent.
+	newCfg, err := cfg.Apply(newAttrs)
+	if err != nil {
+		return nil, err
+	}
+	ecfg := &environConfig{
+		Config: newCfg,
+		attrs:  newAttrs,
+	}
+
+	return ecfg, nil
+}
+
+type environConfig struct {
+	*config.Config
+	attrs map[string]interface{}
+}
+
+func (c environConfig) region() string {
+	return c.attrs["region"].(string)
+}
+
+func (c environConfig) username() string {
+	return c.attrs["username"].(string)
+}
+
+func (c environConfig) password() string {
+	return c.attrs["password"].(string)
+}
+
+func (c environConfig) storagePort() int {
+	return c.attrs["storage-port"].(int)
+}
+
+func (c environConfig) storageAuthKey() string {
+	if v, ok := c.attrs["storage-auth-key"].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -1,0 +1,329 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/testing"
+	"github.com/juju/schema"
+	gc "launchpad.net/gocheck"
+)
+
+func newConfig(c *gc.C, attrs testing.Attrs) *config.Config {
+	attrs = testing.FakeConfig().Merge(attrs)
+	cfg, err := config.New(config.UseDefaults, attrs)
+	c.Assert(err, gc.IsNil)
+	return cfg
+}
+
+func validAttrs() testing.Attrs {
+	return testing.FakeConfig().Merge(testing.Attrs{
+		"type":             "cloudsigma",
+		"username":         "user",
+		"password":         "password",
+		"region":           "zrh",
+		"storage-port":     8040,
+		"storage-auth-key": "ABCDEFGH",
+	})
+}
+
+type configSuite struct {
+	testing.BaseSuite
+}
+
+func (s *configSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *configSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	// speed up tests, do not create heavy stuff inside providers created withing this test suite
+	s.PatchValue(&newClient, func(cfg *environConfig) (*environClient, error) {
+		return nil, nil
+	})
+	s.PatchValue(&newStorage, func(ecfg *environConfig, client *environClient) (*environStorage, error) {
+		return nil, nil
+	})
+}
+
+var _ = gc.Suite(&configSuite{})
+
+func (s *configSuite) TestNewEnvironConfig(c *gc.C) {
+
+	type checker struct {
+		checker gc.Checker
+		value   interface{}
+	}
+
+	var newConfigTests = []struct {
+		info   string
+		insert testing.Attrs
+		remove []string
+		expect testing.Attrs
+		err    string
+	}{{
+		info:   "username is required",
+		remove: []string{"username"},
+		err:    "username: must not be empty",
+	}, {
+		info:   "username cannot be empty",
+		insert: testing.Attrs{"username": ""},
+		err:    "username: must not be empty",
+	}, {
+		info:   "password is required",
+		remove: []string{"password"},
+		err:    "password: must not be empty",
+	}, {
+		info:   "password cannot be empty",
+		insert: testing.Attrs{"password": ""},
+		err:    "password: must not be empty",
+	}, {
+		info:   "region is inserted if missing",
+		remove: []string{"region"},
+		expect: testing.Attrs{"region": "zrh"},
+	}, {
+		info:   "region must not be empty",
+		insert: testing.Attrs{"region": ""},
+		err:    "region: must not be empty",
+	}, {
+		info:   "storage-port is inserted if missing",
+		remove: []string{"storage-port"},
+		expect: testing.Attrs{"storage-port": 8040},
+	}, {
+		info:   "storage-port must be number",
+		insert: testing.Attrs{"storage-port": "abcd"},
+		err:    "storage-port: expected number, got string\\(\"abcd\"\\)",
+	}, {
+		info:   "storage-auth-key is inserted if missing",
+		remove: []string{"storage-auth-key"},
+		expect: testing.Attrs{"storage-auth-key": checker{gc.HasLen, 36}},
+	}, {
+		info:   "storage-auth-key must not be empty",
+		insert: testing.Attrs{"storage-auth-key": ""},
+		err:    "storage-auth-key: must not be empty",
+	}}
+
+	for i, test := range newConfigTests {
+		c.Logf("test %d: %s", i, test.info)
+		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+		testConfig := newConfig(c, attrs)
+		environ, err := environs.New(testConfig)
+		if test.err == "" {
+			c.Check(err, gc.IsNil)
+			attrs := environ.Config().AllAttrs()
+			for field, value := range test.expect {
+				if chk, ok := value.(checker); ok {
+					c.Check(attrs[field], chk.checker, chk.value)
+				} else {
+					c.Check(attrs[field], gc.Equals, value)
+				}
+			}
+		} else {
+			c.Check(environ, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}
+
+var changeConfigTests = []struct {
+	info   string
+	insert testing.Attrs
+	remove []string
+	expect testing.Attrs
+	err    string
+}{{
+	info:   "no change, no error",
+	expect: validAttrs(),
+}, {
+	info:   "can change username",
+	insert: testing.Attrs{"username": "cloudsigma_user"},
+	expect: testing.Attrs{"username": "cloudsigma_user"},
+}, {
+	info:   "can not change username to empty",
+	insert: testing.Attrs{"username": ""},
+	err:    "username: must not be empty",
+}, {
+	info:   "can change password",
+	insert: testing.Attrs{"password": "cloudsigma_password"},
+	expect: testing.Attrs{"password": "cloudsigma_password"},
+}, {
+	info:   "can not change password to empty",
+	insert: testing.Attrs{"password": ""},
+	err:    "password: must not be empty",
+}, {
+	info:   "can change region",
+	insert: testing.Attrs{"region": "lvs"},
+	err:    "region: cannot change from .* to .*",
+}, {
+	info:   "can not change storage-port",
+	insert: testing.Attrs{"storage-port": 0},
+	err:    "storage-port: cannot change from .* to .*",
+}, {
+	info:   "can not change storage-auth-key",
+	insert: testing.Attrs{"storage-auth-key": "xxx"},
+	err:    "storage-auth-key: cannot change from .* to .*",
+}}
+
+func (s *configSuite) TestValidateChange(c *gc.C) {
+
+	baseConfig := newConfig(c, validAttrs())
+	for i, test := range changeConfigTests {
+		c.Logf("test %d: %s", i, test.info)
+		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+		testConfig := newConfig(c, attrs)
+		validatedConfig, err := providerInstance.Validate(testConfig, baseConfig)
+		if test.err == "" {
+			c.Check(err, gc.IsNil)
+			attrs := validatedConfig.AllAttrs()
+			for field, value := range test.expect {
+				c.Check(attrs[field], gc.Equals, value)
+			}
+		} else {
+			c.Check(validatedConfig, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, "invalid config.*: "+test.err)
+		}
+
+		// reverse change
+		validatedConfig, err = providerInstance.Validate(baseConfig, testConfig)
+		if test.err == "" {
+			c.Check(err, gc.IsNil)
+			attrs := validatedConfig.AllAttrs()
+			for field, value := range validAttrs() {
+				c.Check(attrs[field], gc.Equals, value)
+			}
+		} else {
+			c.Check(validatedConfig, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, "invalid .*config.*: "+test.err)
+		}
+	}
+}
+
+func (s *configSuite) TestSetConfig(c *gc.C) {
+	baseConfig := newConfig(c, validAttrs())
+	for i, test := range changeConfigTests {
+		c.Logf("test %d: %s", i, test.info)
+		environ, err := environs.New(baseConfig)
+		c.Assert(err, gc.IsNil)
+		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+		testConfig := newConfig(c, attrs)
+		err = environ.SetConfig(testConfig)
+		newAttrs := environ.Config().AllAttrs()
+		if test.err == "" {
+			c.Check(err, gc.IsNil)
+			for field, value := range test.expect {
+				c.Check(newAttrs[field], gc.Equals, value)
+			}
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+			for field, value := range baseConfig.UnknownAttrs() {
+				c.Check(newAttrs[field], gc.Equals, value)
+			}
+		}
+	}
+}
+
+func (s *configSuite) TestConfigName(c *gc.C) {
+	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
+	environ, err := environs.New(baseConfig)
+	c.Assert(err, gc.IsNil)
+	c.Check(environ.Name(), gc.Equals, "testname")
+}
+
+func (s *configSuite) TestBadUUIDGenerator(c *gc.C) {
+	fail := failReader{fmt.Errorf("error")}
+	s.PatchValue(&rand.Reader, &fail)
+
+	attrs := validAttrs().Delete("storage-auth-key")
+	testConfig := newConfig(c, attrs)
+	cfg, err := providerInstance.Prepare(nil, testConfig)
+
+	c.Check(cfg, gc.IsNil)
+	c.Check(err, gc.Equals, fail.err)
+}
+
+func (s *configSuite) TestEnvironConfig(c *gc.C) {
+	testConfig := newConfig(c, validAttrs())
+	ecfg, err := validateConfig(testConfig, nil)
+	c.Assert(ecfg, gc.NotNil)
+	c.Assert(err, gc.IsNil)
+	c.Check(ecfg.username(), gc.Equals, "user")
+	c.Check(ecfg.password(), gc.Equals, "password")
+	c.Check(ecfg.region(), gc.Equals, "zrh")
+	c.Check(ecfg.storagePort(), gc.Equals, 8040)
+	c.Check(ecfg.storageAuthKey(), gc.Equals, "ABCDEFGH")
+}
+
+func (s *configSuite) TestInvalidConfigChange(c *gc.C) {
+	oldAttrs := validAttrs().Merge(testing.Attrs{"name": "123"})
+	oldConfig := newConfig(c, oldAttrs)
+	newAttrs := validAttrs().Merge(testing.Attrs{"name": "321"})
+	newConfig := newConfig(c, newAttrs)
+
+	oldecfg, _ := providerInstance.Validate(oldConfig, nil)
+	c.Assert(oldecfg, gc.NotNil)
+
+	newecfg, err := providerInstance.Validate(newConfig, oldecfg)
+	c.Assert(newecfg, gc.IsNil)
+	c.Assert(err, gc.NotNil)
+}
+
+var secretAttrsConfigTests = []struct {
+	info   string
+	insert testing.Attrs
+	remove []string
+	expect map[string]string
+	err    string
+}{{
+	info:   "no change, no error",
+	expect: map[string]string{"storage-auth-key": "ABCDEFGH"},
+}, {
+	info:   "invalid config",
+	insert: testing.Attrs{"username": ""},
+	err:    ".* must not be empty.*",
+}}
+
+func (s *configSuite) TestSecretAttrs(c *gc.C) {
+	for i, test := range secretAttrsConfigTests {
+		c.Logf("test %d: %s", i, test.info)
+		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+		testConfig := newConfig(c, attrs)
+		sa, err := providerInstance.SecretAttrs(testConfig)
+		if test.err == "" {
+			c.Check(sa, gc.HasLen, len(test.expect))
+			for field, value := range test.expect {
+				c.Check(sa[field], gc.Equals, value)
+			}
+			c.Check(err, gc.IsNil)
+		} else {
+			c.Check(sa, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}
+
+func (s *configSuite) TestSecretAttrsAreStrings(c *gc.C) {
+	for i, field := range configSecretFields {
+		c.Logf("test %d: %s", i, field)
+		attrs := validAttrs().Merge(testing.Attrs{field: 0})
+
+		if v, ok := configFields[field]; ok {
+			configFields[field] = schema.ForceInt()
+			defer func(c schema.Checker) {
+				configFields[field] = c
+			}(v)
+		} else {
+			c.Errorf("secrect field %s not found in configFields", field)
+			continue
+		}
+
+		testConfig := newConfig(c, attrs)
+		sa, err := providerInstance.SecretAttrs(testConfig)
+		c.Check(sa, gc.IsNil)
+		c.Check(err, gc.ErrorMatches, "secret .* field must have a string value; got .*")
+	}
+}

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -7,11 +7,12 @@ import (
 	"crypto/rand"
 	"fmt"
 
+	gc "launchpad.net/gocheck"
+	"github.com/juju/schema"
+	
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
-	"github.com/juju/schema"
-	gc "launchpad.net/gocheck"
 )
 
 func newConfig(c *gc.C, attrs testing.Attrs) *config.Config {

--- a/provider/cloudsigma/constraints.go
+++ b/provider/cloudsigma/constraints.go
@@ -1,0 +1,95 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/constraints"
+)
+
+// This file contains implementation of CloudSigma instance constraints
+type sigmaConstraints struct {
+	driveTemplate string
+	driveSize     uint64
+	cores         uint64
+	power         uint64
+	mem           uint64
+}
+
+const defaultCPUPower = 2000
+const driveUbuntuTrusty64 = "473adb38-3b64-43b2-93bd-f1a3443c19ea"
+
+// newConstraints creates new CloudSigma constraints from juju common constraints
+func newConstraints(bootstrap bool, jc constraints.Value, series string) (*sigmaConstraints, error) {
+	var sc sigmaConstraints
+
+	if a := jc.Arch; a != nil {
+		switch *a {
+		case "amd64":
+			switch series {
+			case "trusty":
+				sc.driveTemplate = driveUbuntuTrusty64
+			default:
+				return nil, fmt.Errorf("series '%s' not supported", series)
+			}
+		default:
+			return nil, fmt.Errorf("arch '%s' not supported", *a)
+		}
+	} else {
+		switch series {
+		case "trusty":
+			sc.driveTemplate = driveUbuntuTrusty64
+		default:
+			return nil, fmt.Errorf("series '%s' not supported", series)
+		}
+	}
+
+	if size := jc.RootDisk; bootstrap && size == nil {
+		sc.driveSize = 5 * gosigma.Gigabyte
+	} else if size != nil {
+		sc.driveSize = *size * gosigma.Megabyte
+	}
+
+	if c := jc.CpuCores; c != nil {
+		sc.cores = *c
+	} else {
+		sc.cores = 1
+	}
+
+	if p := jc.CpuPower; p != nil {
+		sc.power = *p
+	} else {
+		if sc.cores == 1 {
+			// The default of cpu power is 2000 Mhz
+			sc.power = defaultCPUPower
+		} else {
+			// The maximum amount of cpu per smp is 2300
+			sc.power = sc.cores * defaultCPUPower
+		}
+	}
+
+	if m := jc.Mem; m != nil {
+		sc.mem = *m * gosigma.Megabyte
+	} else {
+		sc.mem = 2 * gosigma.Gigabyte
+	}
+
+	return &sc, nil
+}
+
+func (c *sigmaConstraints) String() string {
+	s := fmt.Sprintf("template=%s,drive=%dG", c.driveTemplate, c.driveSize/gosigma.Gigabyte)
+	if c.cores > 0 {
+		s += fmt.Sprintf(",cores=%d", c.cores)
+	}
+	if c.power > 0 {
+		s += fmt.Sprintf(",power=%d", c.power)
+	}
+	if c.mem > 0 {
+		s += fmt.Sprintf(",mem=%dG", c.mem/gosigma.Gigabyte)
+	}
+	return s
+}

--- a/provider/cloudsigma/constraints.go
+++ b/provider/cloudsigma/constraints.go
@@ -6,7 +6,8 @@ package cloudsigma
 import (
 	"fmt"
 
-	"github.com/Altoros/gosigma"
+	"github.com/altoros/gosigma"
+	
 	"github.com/juju/juju/constraints"
 )
 

--- a/provider/cloudsigma/constraints_test.go
+++ b/provider/cloudsigma/constraints_test.go
@@ -4,10 +4,11 @@
 package cloudsigma
 
 import (
-	"github.com/Altoros/gosigma"
+	"github.com/altoros/gosigma"
+	gc "launchpad.net/gocheck"
+	
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/testing"
-	gc "launchpad.net/gocheck"
 )
 
 type constraintsSuite struct {

--- a/provider/cloudsigma/constraints_test.go
+++ b/provider/cloudsigma/constraints_test.go
@@ -1,0 +1,136 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/testing"
+	gc "launchpad.net/gocheck"
+)
+
+type constraintsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&constraintsSuite{})
+
+type strv struct{ v string }
+type uint64v struct{ v uint64 }
+
+var defConstraints = map[string]sigmaConstraints{
+	"bootstrap-trusty": sigmaConstraints{
+		driveTemplate: driveUbuntuTrusty64,
+		driveSize:     5 * gosigma.Gigabyte,
+		cores:         1,
+		power:         2000,
+		mem:           2 * gosigma.Gigabyte,
+	},
+	"trusty": sigmaConstraints{
+		driveTemplate: driveUbuntuTrusty64,
+		driveSize:     0,
+		cores:         1,
+		power:         2000,
+		mem:           2 * gosigma.Gigabyte,
+	},
+	"trusty-c2-p4000": sigmaConstraints{
+		driveTemplate: driveUbuntuTrusty64,
+		driveSize:     0,
+		cores:         2,
+		power:         4000,
+		mem:           2 * gosigma.Gigabyte,
+	},
+}
+
+var newConstraintTests = []struct {
+	bootstrap bool
+	arch      *strv
+	cores     *uint64v
+	power     *uint64v
+	mem       *uint64v
+	disk      *uint64v
+	series    string
+	expected  sigmaConstraints
+	err       *strv
+}{
+	{true, nil, nil, nil, nil, nil, "trusty", defConstraints["bootstrap-trusty"], nil},
+	{false, nil, nil, nil, nil, nil, "trusty", defConstraints["trusty"], nil},
+	{true, nil, nil, nil, nil, nil, "", sigmaConstraints{}, &strv{"series '.*' not supported"}},
+	{false, nil, nil, nil, nil, nil, "", sigmaConstraints{}, &strv{"series '.*' not supported"}},
+	{true, &strv{"amd64"}, nil, nil, nil, nil, "trusty", defConstraints["bootstrap-trusty"], nil},
+	{false, &strv{"amd64"}, nil, nil, nil, nil, "trusty", defConstraints["trusty"], nil},
+	{true, &strv{"amd64"}, nil, nil, nil, nil, "", sigmaConstraints{}, &strv{"series '.*' not supported"}},
+	{false, &strv{"amd64"}, nil, nil, nil, nil, "", sigmaConstraints{}, &strv{"series '.*' not supported"}},
+	{true, nil, &uint64v{1}, nil, nil, nil, "trusty", defConstraints["bootstrap-trusty"], nil},
+	{false, nil, &uint64v{1}, nil, nil, nil, "trusty", defConstraints["trusty"], nil},
+	{false, nil, &uint64v{2}, nil, nil, nil, "trusty", defConstraints["trusty-c2-p4000"], nil},
+	{false, nil, &uint64v{2}, &uint64v{4000}, nil, nil, "trusty", defConstraints["trusty-c2-p4000"], nil},
+	{false, nil, nil, nil, &uint64v{2 * 1024}, nil, "trusty", defConstraints["trusty"], nil},
+	{false, nil, nil, nil, nil, &uint64v{5 * 1024}, "trusty", defConstraints["bootstrap-trusty"], nil},
+}
+
+func (s *constraintsSuite) TestConstraints(c *gc.C) {
+	for i, t := range newConstraintTests {
+		var cv constraints.Value
+		if t.arch != nil {
+			cv.Arch = &t.arch.v
+		}
+		if t.cores != nil {
+			cv.CpuCores = &t.cores.v
+		}
+		if t.power != nil {
+			cv.CpuPower = &t.power.v
+		}
+		if t.mem != nil {
+			cv.Mem = &t.mem.v
+		}
+		if t.disk != nil {
+			cv.RootDisk = &t.disk.v
+		}
+		v, err := newConstraints(t.bootstrap, cv, t.series)
+		if t.err == nil {
+			if !c.Check(*v, gc.Equals, t.expected) {
+				c.Logf("test (%d): %+v", i, t)
+			}
+		} else {
+			if !c.Check(err, gc.ErrorMatches, t.err.v) {
+				c.Logf("test (%d): %+v", i, t)
+			}
+		}
+	}
+}
+
+func (s *constraintsSuite) TestConstraintsArch(c *gc.C) {
+	var cv constraints.Value
+	var expected = sigmaConstraints{
+		driveTemplate: driveUbuntuTrusty64,
+		driveSize:     5 * gosigma.Gigabyte,
+		cores:         1,
+		power:         2000,
+		mem:           2 * gosigma.Gigabyte,
+	}
+
+	sc, err := newConstraints(true, cv, "trusty")
+	c.Check(err, gc.IsNil)
+	c.Check(*sc, gc.Equals, expected)
+
+	sc, err = newConstraints(true, cv, "")
+	c.Check(err, gc.ErrorMatches, "series '.*' not supported")
+	c.Check(sc, gc.IsNil)
+
+	arch := "amd64"
+	cv.Arch = &arch
+	sc, err = newConstraints(true, cv, "trusty")
+	c.Check(err, gc.IsNil)
+	c.Check(*sc, gc.Equals, expected)
+
+	sc, err = newConstraints(true, cv, "")
+	c.Check(err, gc.ErrorMatches, "series '.*' not supported")
+	c.Check(sc, gc.IsNil)
+
+	arch = ""
+	sc, err = newConstraints(true, cv, "")
+	c.Check(err, gc.ErrorMatches, "arch '.*' not supported")
+	c.Check(sc, gc.IsNil)
+}


### PR DESCRIPTION
This pull request is part of juju provider for CloudSigma contaning the following files:
- provider/cloudsigma/client.go
- provider/cloudsigma/client_test.go

See the incremental diff here - https://github.com/Altoros/juju-cloudsigma/pull/1

Provider for CloudSigma (https://www.cloudsigma.com) uses CloudSigma API v2.0 (https://cloudsigma-docs.readthedocs.org/en/2.10/).

Minimal client for communicating with the CloudSigma Web API from Go program was implemented as separate library https://www.github.com/Altoros/gosigma. This library is published under AGPLv3 license.
