### PR TITLE
Juju provider for CloudSigma - global (for review)

### DIFF
--- a/cmd/jujud/agent.go
+++ b/cmd/jujud/agent.go
@@ -213,6 +213,7 @@ func openAPIState(
 		info := *info
 		info.Password = agentConfig.OldPassword()
 		usedOldPassword = true
+		time.Sleep(1 * time.Second)
 		st, err = apiOpen(&info, api.DialOpts{})
 	}
 	if err != nil {

--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -434,7 +434,9 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 	// Take advantage of special knowledge here in that we will only ever want
 	// the storage provider on one machine, and that is the "bootstrap" node.
 	providerType := agentConfig.Value(agent.ProviderType)
-	if (providerType == provider.Local || provider.IsManual(providerType)) && m.Id() == bootstrapMachineId {
+	if (providerType == provider.Local ||
+		provider.IsManual(providerType) ||
+		providerType == "cloudsigma") && m.Id() == bootstrapMachineId {
 		a.startWorkerAfterUpgrade(runner, "local-storage", func() (worker.Worker, error) {
 			// TODO(axw) 2013-09-24 bug #1229507
 			// Make another job to enable storage.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,6 @@
 code.google.com/p/go.crypto	hg	5478be1963aafa9025e9bf0837aff6013eb92e5b	199
 code.google.com/p/go.net	hg	c17ad62118ea511e1051721b429779fa40bddc74	116
+github.com/Altoros/gosigma	git	c56c52eb785e48ec0f7fcc0da385c85210c7ff3d	
 github.com/binary132/gojsonpointer	git	57ab5e9c764219a3e0c4d7759797fefdcab22e9c	
 github.com/binary132/gojsonreference	git	d774f519af21e55b21eff9ec6fb4559b2672f260	
 github.com/binary132/gojsonschema	git	02df8b8c5ebaa15fd38697a667dd1a6587ac17eb	

--- a/provider/all/all.go
+++ b/provider/all/all.go
@@ -6,6 +6,7 @@ package all
 // Register all the available providers.
 import (
 	_ "github.com/juju/juju/provider/azure"
+	_ "github.com/juju/juju/provider/cloudsigma"
 	_ "github.com/juju/juju/provider/ec2"
 	_ "github.com/juju/juju/provider/joyent"
 	_ "github.com/juju/juju/provider/local"

--- a/provider/cloudsigma/client.go
+++ b/provider/cloudsigma/client.go
@@ -1,0 +1,307 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
+	"github.com/juju/loggo"
+	"github.com/juju/utils"
+)
+
+// This file contains implementation of CloudSigma client.
+type environClient struct {
+	conn     *gosigma.Client
+	region   string
+	username string
+	password string
+	name     string
+	storage  *environStorage
+}
+
+type tracer struct{}
+
+func (tracer) Logf(format string, args ...interface{}) {
+	logger.Tracef(format, args...)
+}
+
+// newClient creates new CloudSigma client connection.
+var newClient = func(cfg *environConfig) (*environClient, error) {
+
+	// fetch and validate configuration
+	region, err := gosigma.ResolveEndpoint(cfg.region())
+	if err != nil {
+		region = cfg.region()
+	}
+	username := cfg.username()
+	password := cfg.password()
+	name := cfg.Name()
+
+	logger.Debugf("creating CloudSigma client: region=%s, user=%s, password=%s, name=%q",
+		region, username, strings.Repeat("*", len(password)), name)
+
+	// create connection to CloudSigma
+	conn, err := gosigma.NewClient(region, username, password, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// configure trace logger
+	if logger.LogLevel() <= loggo.TRACE {
+		conn.Logger(&tracer{})
+	}
+
+	c := &environClient{
+		conn:     conn,
+		region:   region,
+		name:     name,
+		username: username,
+		password: password,
+	}
+
+	return c, nil
+}
+
+// configChanged checks if CloudSigma client environment configuration is changed
+func (c environClient) configChanged(cfg *environConfig) bool {
+	// fetch configuration
+	region, err := gosigma.ResolveEndpoint(cfg.region())
+	if err != nil {
+		return true
+	}
+	username := cfg.username()
+	password := cfg.password()
+	name := cfg.Name()
+
+	// compare
+	if region != c.region || username != c.username ||
+		password != c.password || name != c.name {
+		return true
+	}
+
+	return false
+}
+
+const (
+	jujuMetaInstance            = "juju-instance"
+	jujuMetaInstanceStateServer = "state-server"
+	jujuMetaInstanceServer      = "server"
+
+	jujuMetaEnvironment = "juju-environment"
+)
+
+func (c environClient) isMyEnvironment(s gosigma.Server) bool {
+	if v, _ := s.Get(jujuMetaEnvironment); c.name == v {
+		return true
+	}
+	return false
+}
+
+func (c environClient) isMyServer(s gosigma.Server) bool {
+	if _, ok := s.Get(jujuMetaInstance); ok {
+		return c.isMyEnvironment(s)
+	}
+	return false
+}
+
+func (c environClient) isMyStateServer(s gosigma.Server) bool {
+	if v, ok := s.Get(jujuMetaInstance); ok && v == jujuMetaInstanceStateServer {
+		return c.isMyEnvironment(s)
+	}
+	return false
+}
+
+// instances of servers at CloudSigma account
+func (c environClient) instances() ([]gosigma.Server, error) {
+	return c.conn.ServersFiltered(gosigma.RequestDetail, c.isMyServer)
+}
+
+// instanceMap of server ids to servers at CloudSigma account
+func (c environClient) instanceMap() (map[string]gosigma.Server, error) {
+	servers, err := c.conn.ServersFiltered(gosigma.RequestDetail, c.isMyServer)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]gosigma.Server, len(servers))
+	for _, s := range servers {
+		m[s.UUID()] = s
+	}
+
+	return m, nil
+}
+
+func (c environClient) stateServerAddress() (string, string, bool) {
+	logger.Debugf("query state...")
+
+	servers, err := c.conn.ServersFiltered(gosigma.RequestDetail, c.isMyStateServer)
+	if err != nil {
+		return "", "", false
+	}
+
+	logger.Debugf("...servers count: %d", len(servers))
+	if logger.LogLevel() <= loggo.TRACE {
+		for _, s := range servers {
+			logger.Tracef("... %s", s)
+		}
+	}
+
+	for _, s := range servers {
+		if s.Status() != gosigma.ServerRunning {
+			continue
+		}
+		if addrs := s.IPv4(); len(addrs) != 0 {
+			return s.UUID(), addrs[0], true
+		}
+	}
+
+	return "", "", false
+}
+
+// stop instance
+func (c environClient) stopInstance(id instance.Id) error {
+	uuid := string(id)
+	if uuid == "" {
+		return fmt.Errorf("invalid instance id")
+	}
+
+	var err error
+
+	s, err := c.conn.Server(uuid)
+	if err != nil {
+		return err
+	}
+
+	if c.storage != nil && c.isMyStateServer(s) {
+		c.storage.onStateInstanceStop(uuid)
+	}
+
+	err = s.StopWait()
+	logger.Tracef("environClient.StopInstance - stop server, %q = %v", uuid, err)
+
+	err = s.Remove(gosigma.RecurseAllDrives)
+	logger.Tracef("environClient.StopInstance - remove server, %q = %v", uuid, err)
+
+	return nil
+}
+
+// start new instance
+func (c environClient) newInstance(args environs.StartInstanceParams) (srv gosigma.Server, drv gosigma.Drive, err error) {
+
+	cleanup := func() {
+		if err == nil {
+			return
+		}
+		if srv != nil {
+			srv.Remove(gosigma.RecurseAllDrives)
+		} else if drv != nil {
+			drv.Remove()
+		}
+		srv = nil
+		drv = nil
+	}
+	defer cleanup()
+
+	if args.MachineConfig == nil {
+		err = fmt.Errorf("invalid configuration for new instance")
+		return
+	}
+
+	logger.Tracef("Tools: %v", args.Tools.URLs())
+	logger.Tracef("Juju Constraints:" + args.Constraints.String())
+	logger.Tracef("MachineConfig: %#v", args.MachineConfig)
+
+	cs, err := newConstraints(args.MachineConfig.Bootstrap,
+		args.Constraints, args.MachineConfig.Tools.Version.Series)
+	if err != nil {
+		return
+	}
+	logger.Debugf("CloudSigma Constraints: %v", cs)
+
+	originalDrive, err := c.conn.Drive(cs.driveTemplate, gosigma.LibraryMedia)
+	if err != nil {
+		err = fmt.Errorf("query drive template: %v", err)
+		return
+	}
+
+	baseName := "juju-" + c.name + "-" + args.MachineConfig.MachineId
+
+	cloneParams := gosigma.CloneParams{Name: baseName}
+	if drv, err = originalDrive.CloneWait(cloneParams, nil); err != nil {
+		err = fmt.Errorf("error cloning drive: %v", err)
+		return
+	}
+
+	if drv.Size() < cs.driveSize {
+		if err = drv.ResizeWait(cs.driveSize); err != nil {
+			err = fmt.Errorf("error resizing drive: %v", err)
+			return
+		}
+	}
+
+	var cc gosigma.Components
+	cc.SetName(baseName)
+	cc.SetDescription(baseName)
+
+	if cs.cores != 0 {
+		cc.SetSMP(cs.cores)
+	}
+
+	if cs.power != 0 {
+		cc.SetCPU(cs.power)
+	}
+
+	if cs.mem != 0 {
+		cc.SetMem(cs.mem)
+	}
+
+	vncpass, err := utils.RandomPassword()
+	if err != nil {
+		err = fmt.Errorf("error generating password: %v", err)
+		return
+	}
+	cc.SetVNCPassword(vncpass)
+
+	cc.SetSSHPublicKey(args.MachineConfig.AuthorizedKeys)
+	cc.AttachDrive(1, "0:0", "virtio", drv.UUID())
+	cc.NetworkDHCP4(gosigma.ModelVirtio)
+
+	if args.MachineConfig.Bootstrap {
+		cc.SetMeta(jujuMetaInstance, jujuMetaInstanceStateServer)
+	} else {
+		cc.SetMeta(jujuMetaInstance, jujuMetaInstanceServer)
+	}
+
+	if c.name != "" {
+		cc.SetMeta(jujuMetaEnvironment, c.name)
+	}
+
+	if srv, err = c.conn.CreateServer(cc); err != nil {
+		err = fmt.Errorf("error creating new instance: %v", err)
+		return
+	}
+
+	if err = srv.StartWait(); err != nil {
+		err = fmt.Errorf("error booting new instance: %v", err)
+		return
+	}
+
+	var ipaddr string
+	instanceNetworkAvailable := func(s gosigma.Server) bool {
+		ipaddr = sigmaInstance{s}.findIPv4()
+		return ipaddr != ""
+	}
+	if err = srv.Wait(instanceNetworkAvailable); err != nil {
+		err = fmt.Errorf("error waiting for instance IP address: %v", err)
+		return
+	}
+
+	logger.Tracef("instance ip %q", ipaddr)
+
+	return
+}

--- a/provider/cloudsigma/client_test.go
+++ b/provider/cloudsigma/client_test.go
@@ -1,0 +1,316 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Altoros/gosigma"
+	"github.com/Altoros/gosigma/data"
+	"github.com/Altoros/gosigma/mock"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/cloudinit"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
+	"github.com/juju/juju/version"
+	"github.com/juju/loggo"
+	gc "launchpad.net/gocheck"
+)
+
+type clientSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&clientSuite{})
+
+func (s *clientSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	mock.Start()
+}
+
+func (s *clientSuite) TearDownSuite(c *gc.C) {
+	mock.Stop()
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *clientSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	ll := logger.LogLevel()
+	logger.SetLogLevel(loggo.TRACE)
+	s.AddCleanup(func(*gc.C) { logger.SetLogLevel(ll) })
+
+	mock.Reset()
+}
+
+func (s *clientSuite) TearDownTest(c *gc.C) {
+	mock.Reset()
+	s.BaseSuite.TearDownTest(c)
+}
+
+func testNewClient(c *gc.C, endpoint, username, password string) (*environClient, error) {
+	ecfg := &environConfig{
+		Config: newConfig(c, testing.Attrs{"name": "client-test"}),
+		attrs: map[string]interface{}{
+			"region":   endpoint,
+			"username": username,
+			"password": password,
+		},
+	}
+	return newClient(ecfg)
+}
+
+func (s *clientSuite) TestClientNew(c *gc.C) {
+	cli, err := testNewClient(c, "https://testing.invalid", "user", "password")
+	c.Check(err, gc.IsNil)
+	c.Check(cli, gc.NotNil)
+
+	cli, err = testNewClient(c, "http://testing.invalid", "user", "password")
+	c.Check(err, gc.ErrorMatches, "endpoint must use https scheme")
+	c.Check(cli, gc.IsNil)
+
+	cli, err = testNewClient(c, "https://testing.invalid", "", "password")
+	c.Check(err, gc.ErrorMatches, "username is not allowed to be empty")
+	c.Check(cli, gc.IsNil)
+}
+
+func (s *clientSuite) TestClientConfigChanged(c *gc.C) {
+	ecfg := &environConfig{
+		Config: newConfig(c, testing.Attrs{"name": "client-test"}),
+		attrs: map[string]interface{}{
+			"region":   "https://testing.invalid",
+			"username": "user",
+			"password": "password",
+		},
+	}
+
+	cli, err := newClient(ecfg)
+	c.Check(err, gc.IsNil)
+	c.Check(cli, gc.NotNil)
+
+	rc := cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, false)
+
+	ecfg.attrs["region"] = ""
+	rc = cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, true)
+
+	ecfg.attrs["region"] = "https://testing.invalid"
+	ecfg.attrs["username"] = "user1"
+	rc = cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, true)
+
+	ecfg.attrs["username"] = "user"
+	ecfg.attrs["password"] = "password1"
+	rc = cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, true)
+
+	ecfg.attrs["password"] = "password"
+	ecfg.Config = newConfig(c, testing.Attrs{"name": "changed"})
+	rc = cli.configChanged(ecfg)
+	c.Check(rc, gc.Equals, true)
+}
+
+func addTestClientServer(c *gc.C, instance, env, ip string) string {
+	json := `{"meta": {`
+	if instance != "" {
+		json += fmt.Sprintf(`"juju-instance": "%s"`, instance)
+		if env != "" {
+			json += fmt.Sprintf(`, "juju-environment": "%s"`, env)
+		}
+	}
+	json += fmt.Sprintf(`}, "status": "running", "nics":[{
+            "runtime": {
+                "interface_type": "public",
+                "ip_v4": {
+                    "resource_uri": "/api/2.0/ips/%s/",
+                    "uuid": "%s"
+                }}}]}`, ip, ip)
+	r := strings.NewReader(json)
+	s, err := data.ReadServer(r)
+	c.Assert(err, gc.IsNil)
+	mock.AddServer(s)
+	return s.UUID
+}
+
+func (s *clientSuite) TestClientInstances(c *gc.C) {
+	addTestClientServer(c, "", "", "")
+	addTestClientServer(c, jujuMetaInstanceServer, "alien", "")
+	addTestClientServer(c, jujuMetaInstanceStateServer, "alien", "")
+	addTestClientServer(c, jujuMetaInstanceServer, "client-test", "1.1.1.1")
+	addTestClientServer(c, jujuMetaInstanceServer, "client-test", "2.2.2.2")
+	suuid := addTestClientServer(c, jujuMetaInstanceStateServer, "client-test", "3.3.3.3")
+
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	ss, err := cli.instances()
+	c.Assert(err, gc.IsNil)
+	c.Assert(ss, gc.NotNil)
+	c.Check(ss, gc.HasLen, 3)
+
+	sm, err := cli.instanceMap()
+	c.Assert(err, gc.IsNil)
+	c.Assert(sm, gc.NotNil)
+	c.Check(sm, gc.HasLen, 3)
+
+	uuid, ip, rc := cli.stateServerAddress()
+	c.Check(uuid, gc.Equals, suuid)
+	c.Check(ip, gc.Equals, "3.3.3.3")
+	c.Check(rc, gc.Equals, true)
+}
+
+func (s *clientSuite) TestClientStopStateInstance(c *gc.C) {
+	addTestClientServer(c, "", "", "")
+	addTestClientServer(c, jujuMetaInstanceServer, "alien", "")
+	addTestClientServer(c, jujuMetaInstanceStateServer, "alien", "")
+	addTestClientServer(c, jujuMetaInstanceServer, "client-test", "1.1.1.1")
+	addTestClientServer(c, jujuMetaInstanceServer, "client-test", "2.2.2.2")
+	suuid := addTestClientServer(c, jujuMetaInstanceStateServer, "client-test", "3.3.3.3")
+
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	cli.storage = &environStorage{uuid: suuid, tmp: true}
+
+	err = cli.stopInstance(instance.Id(suuid))
+	c.Assert(err, gc.IsNil)
+
+	uuid, ip, rc := cli.stateServerAddress()
+	c.Check(uuid, gc.Equals, "")
+	c.Check(ip, gc.Equals, "")
+	c.Check(rc, gc.Equals, false)
+
+	c.Check(cli.storage.tmp, gc.Equals, false)
+}
+
+func (s *clientSuite) TestClientInvalidStopInstance(c *gc.C) {
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	var id instance.Id
+	err = cli.stopInstance(id)
+	c.Check(err, gc.ErrorMatches, "invalid instance id")
+
+	err = cli.stopInstance("1234")
+	c.Check(err, gc.ErrorMatches, "404 Not Found.*")
+}
+
+func (s *clientSuite) TestClientInvalidServer(c *gc.C) {
+	cli, err := testNewClient(c, "https://testing.invalid", mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	cli.conn.ConnectTimeout(10 * time.Millisecond)
+
+	err = cli.stopInstance("1234")
+	c.Check(err, gc.ErrorMatches, "broken connection")
+
+	_, err = cli.instanceMap()
+	c.Check(err, gc.ErrorMatches, "broken connection")
+
+	uuid, ip, ok := cli.stateServerAddress()
+	c.Check(uuid, gc.Equals, "")
+	c.Check(ip, gc.Equals, "")
+	c.Check(ok, gc.Equals, false)
+}
+
+func (s *clientSuite) TestClientNewInstanceInvalidParams(c *gc.C) {
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	params := environs.StartInstanceParams{
+		Constraints: constraints.Value{},
+	}
+	server, drive, err := cli.newInstance(params)
+	c.Check(server, gc.IsNil)
+	c.Check(drive, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "invalid configuration for new instance")
+
+	params.MachineConfig = &cloudinit.MachineConfig{
+		Bootstrap: true,
+		Tools: &tools.Tools{
+			Version: version.Binary{
+				Series: "series",
+			},
+		},
+	}
+	server, drive, err = cli.newInstance(params)
+	c.Check(server, gc.IsNil)
+	c.Check(drive, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "series 'series' not supported")
+
+	var arch = "arch"
+	params.Constraints.Arch = &arch
+	server, drive, err = cli.newInstance(params)
+	c.Check(server, gc.IsNil)
+	c.Check(drive, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "arch 'arch' not supported")
+}
+
+func (s *clientSuite) TestClientNewInstanceInvalidTemplate(c *gc.C) {
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	params := environs.StartInstanceParams{
+		Constraints: constraints.Value{},
+		MachineConfig: &cloudinit.MachineConfig{
+			Bootstrap: true,
+			Tools: &tools.Tools{
+				Version: version.Binary{
+					Series: "trusty",
+				},
+			},
+		},
+	}
+	server, drive, err := cli.newInstance(params)
+	c.Check(server, gc.IsNil)
+	c.Check(drive, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "query drive template: 404 Not Found.*")
+}
+
+func (s *clientSuite) TestClientNewInstance(c *gc.C) {
+	cli, err := testNewClient(c, mock.Endpoint(""), mock.TestUser, mock.TestPassword)
+	c.Assert(err, gc.IsNil)
+
+	cli.conn.OperationTimeout(1 * time.Second)
+
+	params := environs.StartInstanceParams{
+		Constraints: constraints.Value{},
+		MachineConfig: &cloudinit.MachineConfig{
+			Bootstrap: true,
+			Tools: &tools.Tools{
+				Version: version.Binary{
+					Series: "trusty",
+				},
+			},
+		},
+	}
+	cs, err := newConstraints(params.MachineConfig.Bootstrap,
+		params.Constraints, params.MachineConfig.Tools.Version.Series)
+	c.Assert(cs, gc.NotNil)
+	c.Check(err, gc.IsNil)
+
+	templateDrive := &data.Drive{
+		Resource: data.Resource{URI: "uri", UUID: cs.driveTemplate},
+		LibraryDrive: data.LibraryDrive{
+			Arch:      "arch",
+			ImageType: "image-type",
+			OS:        "os",
+			Paid:      true,
+		},
+		Size:   2200 * gosigma.Megabyte,
+		Status: "unmounted",
+	}
+	mock.ResetDrives()
+	mock.LibDrives.Add(templateDrive)
+
+	server, drive, err := cli.newInstance(params)
+	c.Check(server, gc.NotNil)
+	c.Check(drive, gc.NotNil)
+	c.Check(err, gc.IsNil)
+}

--- a/provider/cloudsigma/config.go
+++ b/provider/cloudsigma/config.go
@@ -1,0 +1,165 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/schema"
+	"github.com/juju/utils"
+)
+
+// boilerplateConfig will be shown in help output, so please keep it up to
+// date when you change environment configuration below.
+var boilerplateConfig = `# https://juju.ubuntu.com/docs/config-cloudsigma.html
+cloudsigma:
+    type: cloudsigma
+
+    # region holds the cloudsigma region (zrh, lvs, ...).
+    #
+    # region: <your region>
+
+    # credentials for CloudSigma account
+    #
+    # username: <your username>
+    # password: <secret>
+
+    # storage-port specifes the TCP port that the
+    # bootstrap machine's Juju storage server will listen
+    # on. It defaults to ` + fmt.Sprint(defaultStoragePort) + `
+    #
+    # storage-port: ` + fmt.Sprint(defaultStoragePort) + `
+
+`
+
+const defaultStoragePort = 8040
+
+var configFields = schema.Fields{
+	"username": schema.String(),
+	"password": schema.String(),
+	"region":   schema.String(),
+
+	"storage-port":     schema.ForceInt(),
+	"storage-auth-key": schema.String(),
+}
+
+var configDefaultFields = schema.Defaults{
+	"username": "",
+	"password": "",
+	"region":   gosigma.DefaultRegion,
+
+	"storage-port": defaultStoragePort,
+}
+
+var configSecretFields = []string{
+	"storage-auth-key",
+}
+
+var configImmutableFields = []string{
+	"storage-port",
+	"storage-auth-key",
+	"region",
+}
+
+func prepareConfig(cfg *config.Config) (*config.Config, error) {
+	// Turn an incomplete config into a valid one, if possible.
+	attrs := cfg.UnknownAttrs()
+
+	if _, ok := attrs["storage-auth-key"]; !ok {
+		uuid, err := utils.NewUUID()
+		if err != nil {
+			return nil, err
+		}
+		attrs["storage-auth-key"] = uuid.String()
+	}
+
+	return cfg.Apply(attrs)
+}
+
+func validateConfig(cfg *config.Config, old *environConfig) (*environConfig, error) {
+	// Check sanity of juju-level fields.
+	var oldCfg *config.Config
+	if old != nil {
+		oldCfg = old.Config
+	}
+	if err := config.Validate(cfg, oldCfg); err != nil {
+		return nil, err
+	}
+
+	// Extract validated provider-specific fields. All of configFields will be
+	// present in validated, and defaults will be inserted if necessary. If the
+	// schema you passed in doesn't quite express what you need, you can make
+	// whatever checks you need here, before continuing.
+	// In particular, if you want to extract (say) credentials from the user's
+	// shell environment variables, you'll need to allow missing values to pass
+	// through the schema by setting a value of schema.Omit in the configFields
+	// map, and then to set and check them at this point. These values *must* be
+	// stored in newAttrs: a Config will be generated on the user's machine only
+	// to begin with, and will subsequently be used on a different machine that
+	// will probably not have those variables set.
+	newAttrs, err := cfg.ValidateUnknownAttrs(configFields, configDefaultFields)
+	if err != nil {
+		return nil, err
+	}
+	for field := range configFields {
+		if newAttrs[field] == "" {
+			return nil, fmt.Errorf("%s: must not be empty", field)
+		}
+	}
+
+	// If an old config was supplied, check any immutable fields have not changed.
+	if old != nil {
+		for _, field := range configImmutableFields {
+			if old.attrs[field] != newAttrs[field] {
+				return nil, fmt.Errorf(
+					"%s: cannot change from %v to %v",
+					field, old.attrs[field], newAttrs[field],
+				)
+			}
+		}
+	}
+
+	// Merge the validated provider-specific fields into the original config,
+	// to ensure the object we return is internally consistent.
+	newCfg, err := cfg.Apply(newAttrs)
+	if err != nil {
+		return nil, err
+	}
+	ecfg := &environConfig{
+		Config: newCfg,
+		attrs:  newAttrs,
+	}
+
+	return ecfg, nil
+}
+
+type environConfig struct {
+	*config.Config
+	attrs map[string]interface{}
+}
+
+func (c environConfig) region() string {
+	return c.attrs["region"].(string)
+}
+
+func (c environConfig) username() string {
+	return c.attrs["username"].(string)
+}
+
+func (c environConfig) password() string {
+	return c.attrs["password"].(string)
+}
+
+func (c environConfig) storagePort() int {
+	return c.attrs["storage-port"].(int)
+}
+
+func (c environConfig) storageAuthKey() string {
+	if v, ok := c.attrs["storage-auth-key"].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -1,0 +1,329 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/testing"
+	"github.com/juju/schema"
+	gc "launchpad.net/gocheck"
+)
+
+func newConfig(c *gc.C, attrs testing.Attrs) *config.Config {
+	attrs = testing.FakeConfig().Merge(attrs)
+	cfg, err := config.New(config.UseDefaults, attrs)
+	c.Assert(err, gc.IsNil)
+	return cfg
+}
+
+func validAttrs() testing.Attrs {
+	return testing.FakeConfig().Merge(testing.Attrs{
+		"type":             "cloudsigma",
+		"username":         "user",
+		"password":         "password",
+		"region":           "zrh",
+		"storage-port":     8040,
+		"storage-auth-key": "ABCDEFGH",
+	})
+}
+
+type configSuite struct {
+	testing.BaseSuite
+}
+
+func (s *configSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *configSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	// speed up tests, do not create heavy stuff inside providers created withing this test suite
+	s.PatchValue(&newClient, func(cfg *environConfig) (*environClient, error) {
+		return nil, nil
+	})
+	s.PatchValue(&newStorage, func(ecfg *environConfig, client *environClient) (*environStorage, error) {
+		return nil, nil
+	})
+}
+
+var _ = gc.Suite(&configSuite{})
+
+func (s *configSuite) TestNewEnvironConfig(c *gc.C) {
+
+	type checker struct {
+		checker gc.Checker
+		value   interface{}
+	}
+
+	var newConfigTests = []struct {
+		info   string
+		insert testing.Attrs
+		remove []string
+		expect testing.Attrs
+		err    string
+	}{{
+		info:   "username is required",
+		remove: []string{"username"},
+		err:    "username: must not be empty",
+	}, {
+		info:   "username cannot be empty",
+		insert: testing.Attrs{"username": ""},
+		err:    "username: must not be empty",
+	}, {
+		info:   "password is required",
+		remove: []string{"password"},
+		err:    "password: must not be empty",
+	}, {
+		info:   "password cannot be empty",
+		insert: testing.Attrs{"password": ""},
+		err:    "password: must not be empty",
+	}, {
+		info:   "region is inserted if missing",
+		remove: []string{"region"},
+		expect: testing.Attrs{"region": "zrh"},
+	}, {
+		info:   "region must not be empty",
+		insert: testing.Attrs{"region": ""},
+		err:    "region: must not be empty",
+	}, {
+		info:   "storage-port is inserted if missing",
+		remove: []string{"storage-port"},
+		expect: testing.Attrs{"storage-port": 8040},
+	}, {
+		info:   "storage-port must be number",
+		insert: testing.Attrs{"storage-port": "abcd"},
+		err:    "storage-port: expected number, got string\\(\"abcd\"\\)",
+	}, {
+		info:   "storage-auth-key is inserted if missing",
+		remove: []string{"storage-auth-key"},
+		expect: testing.Attrs{"storage-auth-key": checker{gc.HasLen, 36}},
+	}, {
+		info:   "storage-auth-key must not be empty",
+		insert: testing.Attrs{"storage-auth-key": ""},
+		err:    "storage-auth-key: must not be empty",
+	}}
+
+	for i, test := range newConfigTests {
+		c.Logf("test %d: %s", i, test.info)
+		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+		testConfig := newConfig(c, attrs)
+		environ, err := environs.New(testConfig)
+		if test.err == "" {
+			c.Check(err, gc.IsNil)
+			attrs := environ.Config().AllAttrs()
+			for field, value := range test.expect {
+				if chk, ok := value.(checker); ok {
+					c.Check(attrs[field], chk.checker, chk.value)
+				} else {
+					c.Check(attrs[field], gc.Equals, value)
+				}
+			}
+		} else {
+			c.Check(environ, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}
+
+var changeConfigTests = []struct {
+	info   string
+	insert testing.Attrs
+	remove []string
+	expect testing.Attrs
+	err    string
+}{{
+	info:   "no change, no error",
+	expect: validAttrs(),
+}, {
+	info:   "can change username",
+	insert: testing.Attrs{"username": "cloudsigma_user"},
+	expect: testing.Attrs{"username": "cloudsigma_user"},
+}, {
+	info:   "can not change username to empty",
+	insert: testing.Attrs{"username": ""},
+	err:    "username: must not be empty",
+}, {
+	info:   "can change password",
+	insert: testing.Attrs{"password": "cloudsigma_password"},
+	expect: testing.Attrs{"password": "cloudsigma_password"},
+}, {
+	info:   "can not change password to empty",
+	insert: testing.Attrs{"password": ""},
+	err:    "password: must not be empty",
+}, {
+	info:   "can change region",
+	insert: testing.Attrs{"region": "lvs"},
+	err:    "region: cannot change from .* to .*",
+}, {
+	info:   "can not change storage-port",
+	insert: testing.Attrs{"storage-port": 0},
+	err:    "storage-port: cannot change from .* to .*",
+}, {
+	info:   "can not change storage-auth-key",
+	insert: testing.Attrs{"storage-auth-key": "xxx"},
+	err:    "storage-auth-key: cannot change from .* to .*",
+}}
+
+func (s *configSuite) TestValidateChange(c *gc.C) {
+
+	baseConfig := newConfig(c, validAttrs())
+	for i, test := range changeConfigTests {
+		c.Logf("test %d: %s", i, test.info)
+		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+		testConfig := newConfig(c, attrs)
+		validatedConfig, err := providerInstance.Validate(testConfig, baseConfig)
+		if test.err == "" {
+			c.Check(err, gc.IsNil)
+			attrs := validatedConfig.AllAttrs()
+			for field, value := range test.expect {
+				c.Check(attrs[field], gc.Equals, value)
+			}
+		} else {
+			c.Check(validatedConfig, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, "invalid config.*: "+test.err)
+		}
+
+		// reverse change
+		validatedConfig, err = providerInstance.Validate(baseConfig, testConfig)
+		if test.err == "" {
+			c.Check(err, gc.IsNil)
+			attrs := validatedConfig.AllAttrs()
+			for field, value := range validAttrs() {
+				c.Check(attrs[field], gc.Equals, value)
+			}
+		} else {
+			c.Check(validatedConfig, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, "invalid .*config.*: "+test.err)
+		}
+	}
+}
+
+func (s *configSuite) TestSetConfig(c *gc.C) {
+	baseConfig := newConfig(c, validAttrs())
+	for i, test := range changeConfigTests {
+		c.Logf("test %d: %s", i, test.info)
+		environ, err := environs.New(baseConfig)
+		c.Assert(err, gc.IsNil)
+		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+		testConfig := newConfig(c, attrs)
+		err = environ.SetConfig(testConfig)
+		newAttrs := environ.Config().AllAttrs()
+		if test.err == "" {
+			c.Check(err, gc.IsNil)
+			for field, value := range test.expect {
+				c.Check(newAttrs[field], gc.Equals, value)
+			}
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+			for field, value := range baseConfig.UnknownAttrs() {
+				c.Check(newAttrs[field], gc.Equals, value)
+			}
+		}
+	}
+}
+
+func (s *configSuite) TestConfigName(c *gc.C) {
+	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
+	environ, err := environs.New(baseConfig)
+	c.Assert(err, gc.IsNil)
+	c.Check(environ.Name(), gc.Equals, "testname")
+}
+
+func (s *configSuite) TestBadUUIDGenerator(c *gc.C) {
+	fail := failReader{fmt.Errorf("error")}
+	s.PatchValue(&rand.Reader, &fail)
+
+	attrs := validAttrs().Delete("storage-auth-key")
+	testConfig := newConfig(c, attrs)
+	cfg, err := providerInstance.Prepare(nil, testConfig)
+
+	c.Check(cfg, gc.IsNil)
+	c.Check(err, gc.Equals, fail.err)
+}
+
+func (s *configSuite) TestEnvironConfig(c *gc.C) {
+	testConfig := newConfig(c, validAttrs())
+	ecfg, err := validateConfig(testConfig, nil)
+	c.Assert(ecfg, gc.NotNil)
+	c.Assert(err, gc.IsNil)
+	c.Check(ecfg.username(), gc.Equals, "user")
+	c.Check(ecfg.password(), gc.Equals, "password")
+	c.Check(ecfg.region(), gc.Equals, "zrh")
+	c.Check(ecfg.storagePort(), gc.Equals, 8040)
+	c.Check(ecfg.storageAuthKey(), gc.Equals, "ABCDEFGH")
+}
+
+func (s *configSuite) TestInvalidConfigChange(c *gc.C) {
+	oldAttrs := validAttrs().Merge(testing.Attrs{"name": "123"})
+	oldConfig := newConfig(c, oldAttrs)
+	newAttrs := validAttrs().Merge(testing.Attrs{"name": "321"})
+	newConfig := newConfig(c, newAttrs)
+
+	oldecfg, _ := providerInstance.Validate(oldConfig, nil)
+	c.Assert(oldecfg, gc.NotNil)
+
+	newecfg, err := providerInstance.Validate(newConfig, oldecfg)
+	c.Assert(newecfg, gc.IsNil)
+	c.Assert(err, gc.NotNil)
+}
+
+var secretAttrsConfigTests = []struct {
+	info   string
+	insert testing.Attrs
+	remove []string
+	expect map[string]string
+	err    string
+}{{
+	info:   "no change, no error",
+	expect: map[string]string{"storage-auth-key": "ABCDEFGH"},
+}, {
+	info:   "invalid config",
+	insert: testing.Attrs{"username": ""},
+	err:    ".* must not be empty.*",
+}}
+
+func (s *configSuite) TestSecretAttrs(c *gc.C) {
+	for i, test := range secretAttrsConfigTests {
+		c.Logf("test %d: %s", i, test.info)
+		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+		testConfig := newConfig(c, attrs)
+		sa, err := providerInstance.SecretAttrs(testConfig)
+		if test.err == "" {
+			c.Check(sa, gc.HasLen, len(test.expect))
+			for field, value := range test.expect {
+				c.Check(sa[field], gc.Equals, value)
+			}
+			c.Check(err, gc.IsNil)
+		} else {
+			c.Check(sa, gc.IsNil)
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}
+
+func (s *configSuite) TestSecretAttrsAreStrings(c *gc.C) {
+	for i, field := range configSecretFields {
+		c.Logf("test %d: %s", i, field)
+		attrs := validAttrs().Merge(testing.Attrs{field: 0})
+
+		if v, ok := configFields[field]; ok {
+			configFields[field] = schema.ForceInt()
+			defer func(c schema.Checker) {
+				configFields[field] = c
+			}(v)
+		} else {
+			c.Errorf("secrect field %s not found in configFields", field)
+			continue
+		}
+
+		testConfig := newConfig(c, attrs)
+		sa, err := providerInstance.SecretAttrs(testConfig)
+		c.Check(sa, gc.IsNil)
+		c.Check(err, gc.ErrorMatches, "secret .* field must have a string value; got .*")
+	}
+}

--- a/provider/cloudsigma/constraints.go
+++ b/provider/cloudsigma/constraints.go
@@ -1,0 +1,95 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/constraints"
+)
+
+// This file contains implementation of CloudSigma instance constraints
+type sigmaConstraints struct {
+	driveTemplate string
+	driveSize     uint64
+	cores         uint64
+	power         uint64
+	mem           uint64
+}
+
+const defaultCPUPower = 2000
+const driveUbuntuTrusty64 = "473adb38-3b64-43b2-93bd-f1a3443c19ea"
+
+// newConstraints creates new CloudSigma constraints from juju common constraints
+func newConstraints(bootstrap bool, jc constraints.Value, series string) (*sigmaConstraints, error) {
+	var sc sigmaConstraints
+
+	if a := jc.Arch; a != nil {
+		switch *a {
+		case "amd64":
+			switch series {
+			case "trusty":
+				sc.driveTemplate = driveUbuntuTrusty64
+			default:
+				return nil, fmt.Errorf("series '%s' not supported", series)
+			}
+		default:
+			return nil, fmt.Errorf("arch '%s' not supported", *a)
+		}
+	} else {
+		switch series {
+		case "trusty":
+			sc.driveTemplate = driveUbuntuTrusty64
+		default:
+			return nil, fmt.Errorf("series '%s' not supported", series)
+		}
+	}
+
+	if size := jc.RootDisk; bootstrap && size == nil {
+		sc.driveSize = 5 * gosigma.Gigabyte
+	} else if size != nil {
+		sc.driveSize = *size * gosigma.Megabyte
+	}
+
+	if c := jc.CpuCores; c != nil {
+		sc.cores = *c
+	} else {
+		sc.cores = 1
+	}
+
+	if p := jc.CpuPower; p != nil {
+		sc.power = *p
+	} else {
+		if sc.cores == 1 {
+			// The default of cpu power is 2000 Mhz
+			sc.power = defaultCPUPower
+		} else {
+			// The maximum amount of cpu per smp is 2300
+			sc.power = sc.cores * defaultCPUPower
+		}
+	}
+
+	if m := jc.Mem; m != nil {
+		sc.mem = *m * gosigma.Megabyte
+	} else {
+		sc.mem = 2 * gosigma.Gigabyte
+	}
+
+	return &sc, nil
+}
+
+func (c *sigmaConstraints) String() string {
+	s := fmt.Sprintf("template=%s,drive=%dG", c.driveTemplate, c.driveSize/gosigma.Gigabyte)
+	if c.cores > 0 {
+		s += fmt.Sprintf(",cores=%d", c.cores)
+	}
+	if c.power > 0 {
+		s += fmt.Sprintf(",power=%d", c.power)
+	}
+	if c.mem > 0 {
+		s += fmt.Sprintf(",mem=%dG", c.mem/gosigma.Gigabyte)
+	}
+	return s
+}

--- a/provider/cloudsigma/constraints_test.go
+++ b/provider/cloudsigma/constraints_test.go
@@ -1,0 +1,136 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/testing"
+	gc "launchpad.net/gocheck"
+)
+
+type constraintsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&constraintsSuite{})
+
+type strv struct{ v string }
+type uint64v struct{ v uint64 }
+
+var defConstraints = map[string]sigmaConstraints{
+	"bootstrap-trusty": sigmaConstraints{
+		driveTemplate: driveUbuntuTrusty64,
+		driveSize:     5 * gosigma.Gigabyte,
+		cores:         1,
+		power:         2000,
+		mem:           2 * gosigma.Gigabyte,
+	},
+	"trusty": sigmaConstraints{
+		driveTemplate: driveUbuntuTrusty64,
+		driveSize:     0,
+		cores:         1,
+		power:         2000,
+		mem:           2 * gosigma.Gigabyte,
+	},
+	"trusty-c2-p4000": sigmaConstraints{
+		driveTemplate: driveUbuntuTrusty64,
+		driveSize:     0,
+		cores:         2,
+		power:         4000,
+		mem:           2 * gosigma.Gigabyte,
+	},
+}
+
+var newConstraintTests = []struct {
+	bootstrap bool
+	arch      *strv
+	cores     *uint64v
+	power     *uint64v
+	mem       *uint64v
+	disk      *uint64v
+	series    string
+	expected  sigmaConstraints
+	err       *strv
+}{
+	{true, nil, nil, nil, nil, nil, "trusty", defConstraints["bootstrap-trusty"], nil},
+	{false, nil, nil, nil, nil, nil, "trusty", defConstraints["trusty"], nil},
+	{true, nil, nil, nil, nil, nil, "", sigmaConstraints{}, &strv{"series '.*' not supported"}},
+	{false, nil, nil, nil, nil, nil, "", sigmaConstraints{}, &strv{"series '.*' not supported"}},
+	{true, &strv{"amd64"}, nil, nil, nil, nil, "trusty", defConstraints["bootstrap-trusty"], nil},
+	{false, &strv{"amd64"}, nil, nil, nil, nil, "trusty", defConstraints["trusty"], nil},
+	{true, &strv{"amd64"}, nil, nil, nil, nil, "", sigmaConstraints{}, &strv{"series '.*' not supported"}},
+	{false, &strv{"amd64"}, nil, nil, nil, nil, "", sigmaConstraints{}, &strv{"series '.*' not supported"}},
+	{true, nil, &uint64v{1}, nil, nil, nil, "trusty", defConstraints["bootstrap-trusty"], nil},
+	{false, nil, &uint64v{1}, nil, nil, nil, "trusty", defConstraints["trusty"], nil},
+	{false, nil, &uint64v{2}, nil, nil, nil, "trusty", defConstraints["trusty-c2-p4000"], nil},
+	{false, nil, &uint64v{2}, &uint64v{4000}, nil, nil, "trusty", defConstraints["trusty-c2-p4000"], nil},
+	{false, nil, nil, nil, &uint64v{2 * 1024}, nil, "trusty", defConstraints["trusty"], nil},
+	{false, nil, nil, nil, nil, &uint64v{5 * 1024}, "trusty", defConstraints["bootstrap-trusty"], nil},
+}
+
+func (s *constraintsSuite) TestConstraints(c *gc.C) {
+	for i, t := range newConstraintTests {
+		var cv constraints.Value
+		if t.arch != nil {
+			cv.Arch = &t.arch.v
+		}
+		if t.cores != nil {
+			cv.CpuCores = &t.cores.v
+		}
+		if t.power != nil {
+			cv.CpuPower = &t.power.v
+		}
+		if t.mem != nil {
+			cv.Mem = &t.mem.v
+		}
+		if t.disk != nil {
+			cv.RootDisk = &t.disk.v
+		}
+		v, err := newConstraints(t.bootstrap, cv, t.series)
+		if t.err == nil {
+			if !c.Check(*v, gc.Equals, t.expected) {
+				c.Logf("test (%d): %+v", i, t)
+			}
+		} else {
+			if !c.Check(err, gc.ErrorMatches, t.err.v) {
+				c.Logf("test (%d): %+v", i, t)
+			}
+		}
+	}
+}
+
+func (s *constraintsSuite) TestConstraintsArch(c *gc.C) {
+	var cv constraints.Value
+	var expected = sigmaConstraints{
+		driveTemplate: driveUbuntuTrusty64,
+		driveSize:     5 * gosigma.Gigabyte,
+		cores:         1,
+		power:         2000,
+		mem:           2 * gosigma.Gigabyte,
+	}
+
+	sc, err := newConstraints(true, cv, "trusty")
+	c.Check(err, gc.IsNil)
+	c.Check(*sc, gc.Equals, expected)
+
+	sc, err = newConstraints(true, cv, "")
+	c.Check(err, gc.ErrorMatches, "series '.*' not supported")
+	c.Check(sc, gc.IsNil)
+
+	arch := "amd64"
+	cv.Arch = &arch
+	sc, err = newConstraints(true, cv, "trusty")
+	c.Check(err, gc.IsNil)
+	c.Check(*sc, gc.Equals, expected)
+
+	sc, err = newConstraints(true, cv, "")
+	c.Check(err, gc.ErrorMatches, "series '.*' not supported")
+	c.Check(sc, gc.IsNil)
+
+	arch = ""
+	sc, err = newConstraints(true, cv, "")
+	c.Check(err, gc.ErrorMatches, "arch '.*' not supported")
+	c.Check(sc, gc.IsNil)
+}

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -1,0 +1,164 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"sync"
+
+	"github.com/Altoros/gosigma"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/api"
+)
+
+// This file contains the core of the Environ implementation.
+type environ struct {
+	name string
+
+	lock sync.Mutex
+
+	ecfg    *environConfig
+	client  *environClient
+	storage *environStorage
+}
+
+var _ environs.Environ = (*environ)(nil)
+var _ tools.SupportsCustomSources = (*environ)(nil)
+var _ simplestreams.HasRegion = (*environ)(nil)
+
+// Name returns the Environ's name.
+func (env environ) Name() string {
+	return env.name
+}
+
+// Provider returns the EnvironProvider that created this Environ.
+func (environ) Provider() environs.EnvironProvider {
+	return providerInstance
+}
+
+// SetConfig updates the Environ's configuration.
+//
+// Calls to SetConfig do not affect the configuration of values previously obtained
+// from Storage.
+func (env *environ) SetConfig(cfg *config.Config) error {
+	env.lock.Lock()
+	defer env.lock.Unlock()
+
+	ecfg, err := validateConfig(cfg, env.ecfg)
+	if err != nil {
+		return err
+	}
+
+	if env.client == nil || env.client.configChanged(ecfg) {
+		client, err := newClient(ecfg)
+		if err != nil {
+			return err
+		}
+
+		storage, err := newStorage(ecfg, client)
+		if err != nil {
+			return err
+		}
+
+		env.client = client
+		env.storage = storage
+	}
+
+	env.ecfg = ecfg
+
+	return nil
+}
+
+// Config returns the configuration data with which the Environ was created.
+// Note that this is not necessarily current; the canonical location
+// for the configuration data is stored in the state.
+func (env environ) Config() *config.Config {
+	return env.ecfg.Config
+}
+
+// Storage returns storage specific to the environment.
+func (env environ) Storage() storage.Storage {
+	return env.storage
+}
+
+// Bootstrap initializes the state for the environment, possibly
+// starting one or more instances.  If the configuration's
+// AdminSecret is non-empty, the administrator password on the
+// newly bootstrapped state will be set to a hash of it (see
+// utils.PasswordHash), When first connecting to the
+// environment via the juju package, the password hash will be
+// automatically replaced by the real password.
+//
+// The supplied constraints are used to choose the initial instance
+// specification, and will be stored in the new environment's state.
+//
+// Bootstrap is responsible for selecting the appropriate tools,
+// and setting the agent-version configuration attribute prior to
+// bootstrapping the environment.
+func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.BootstrapParams) error {
+	// You can probably ignore this method; the common implementation should work.
+	return common.Bootstrap(ctx, env, params)
+}
+
+// StateInfo returns information on the state initialized by Bootstrap.
+func (env *environ) StateInfo() (*state.Info, *api.Info, error) {
+	// You can probably ignore this method; the common implementation should work.
+	return common.StateInfo(env)
+}
+
+// Destroy shuts down all known machines and destroys the
+// rest of the environment. Note that on some providers,
+// very recently started instances may not be destroyed
+// because they are not yet visible.
+//
+// When Destroy has been called, any Environ referring to the
+// same remote environment may become invalid
+func (env *environ) Destroy() error {
+	// You can probably ignore this method; the common implementation should work.
+	return common.Destroy(env)
+}
+
+// PrecheckInstance performs a preflight check on the specified
+// series and constraints, ensuring that they are possibly valid for
+// creating an instance in this environment.
+//
+// PrecheckInstance is best effort, and not guaranteed to eliminate
+// all invalid parameters. If PrecheckInstance returns nil, it is not
+// guaranteed that the constraints are valid; if a non-nil error is
+// returned, then the constraints are definitely invalid.
+func (env environ) PrecheckInstance(series string, cons constraints.Value, placement string) error {
+	logger.Infof("cloudsigma:environ:PrecheckInstance")
+	return nil
+}
+
+// GetToolsSources returns a list of sources which are
+// used to search for simplestreams tools metadata.
+func (env environ) GetToolsSources() ([]simplestreams.DataSource, error) {
+	// Add the simplestreams source off private storage.
+	return []simplestreams.DataSource{
+		storage.NewStorageSimpleStreamsDataSource("cloud storage", env.Storage(), storage.BaseToolsPath),
+	}, nil
+}
+
+// Region is specified in the HasRegion interface.
+func (env environ) Region() (simplestreams.CloudSpec, error) {
+	return env.cloudSpec(env.ecfg.region())
+}
+
+func (env environ) cloudSpec(region string) (simplestreams.CloudSpec, error) {
+	endpoint, err := gosigma.ResolveEndpoint(region)
+	if err != nil {
+		return simplestreams.CloudSpec{}, err
+	}
+	return simplestreams.CloudSpec{
+		Region:   region,
+		Endpoint: endpoint,
+	}, nil
+}

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -1,0 +1,96 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/testing"
+	gc "launchpad.net/gocheck"
+)
+
+type environSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&environSuite{})
+
+func (s *environSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *environSuite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *environSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *environSuite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *environSuite) TestBase(c *gc.C) {
+	var emptyStorage environStorage
+
+	s.PatchValue(&newClient, func(*environConfig) (*environClient, error) {
+		return nil, nil
+	})
+	s.PatchValue(&newStorage, func(*environConfig, *environClient) (*environStorage, error) {
+		return &emptyStorage, nil
+	})
+
+	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
+	environ, err := environs.New(baseConfig)
+	c.Assert(err, gc.IsNil)
+
+	cfg := environ.Config()
+	c.Assert(cfg, gc.NotNil)
+	c.Check(cfg.Name(), gc.Equals, "testname")
+
+	c.Check(environ.Storage(), gc.Equals, &emptyStorage)
+
+	c.Check(environ.PrecheckInstance("", constraints.Value{}, ""), gc.IsNil)
+
+	customSource, ok := environ.(tools.SupportsCustomSources)
+	c.Check(ok, gc.Equals, true)
+	c.Assert(customSource, gc.NotNil)
+
+	src, err := customSource.GetToolsSources()
+	c.Check(src, gc.NotNil)
+	c.Check(err, gc.IsNil)
+
+	hasRegion, ok := environ.(simplestreams.HasRegion)
+	c.Check(ok, gc.Equals, true)
+	c.Assert(hasRegion, gc.NotNil)
+
+	cloudSpec, err := hasRegion.Region()
+	c.Check(err, gc.IsNil)
+	c.Check(cloudSpec.Region, gc.Not(gc.Equals), "")
+	c.Check(cloudSpec.Endpoint, gc.Not(gc.Equals), "")
+
+	archs, err := environ.SupportedArchitectures()
+	c.Check(err, gc.IsNil)
+	c.Assert(archs, gc.NotNil)
+	c.Assert(archs, gc.HasLen, 1)
+	c.Check(archs[0], gc.Equals, arch.AMD64)
+
+	validator, err := environ.ConstraintsValidator()
+	c.Check(validator, gc.NotNil)
+	c.Check(err, gc.IsNil)
+
+	c.Check(environ.SupportNetworks(), gc.Equals, false)
+	c.Check(environ.SupportsUnitPlacement(), gc.IsNil)
+
+	c.Check(environ.OpenPorts(nil), gc.IsNil)
+	c.Check(environ.ClosePorts(nil), gc.IsNil)
+
+	ports, err := environ.Ports()
+	c.Check(ports, gc.IsNil)
+	c.Check(err, gc.IsNil)
+}

--- a/provider/cloudsigma/environcaps.go
+++ b/provider/cloudsigma/environcaps.go
@@ -1,0 +1,50 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/constraints"
+)
+
+// SupportedArchitectures returns the image architectures which can
+// be hosted by this environment.
+func (env *environ) SupportedArchitectures() ([]string, error) {
+	return []string{arch.AMD64}, nil
+}
+
+var unsupportedConstraints = []string{
+	constraints.Container,
+	constraints.InstanceType,
+	constraints.Tags,
+}
+
+// ConstraintsValidator returns a Validator instance which
+// is used to validate and merge constraints.
+func (env *environ) ConstraintsValidator() (constraints.Validator, error) {
+	validator := constraints.NewValidator()
+	validator.RegisterUnsupported(unsupportedConstraints)
+	supportedArches, err := env.SupportedArchitectures()
+	if err != nil {
+		return nil, err
+	}
+	validator.RegisterVocabulary(constraints.Arch, supportedArches)
+	return validator, nil
+}
+
+// SupportNetworks returns whether the environment has support to
+// specify networks for services and machines.
+func (env *environ) SupportNetworks() bool {
+	logger.Debugf("environ:SupportedNetworks")
+	return false
+}
+
+// SupportsUnitAssignment returns an error which, if non-nil, indicates
+// that the environment does not support unit placement. If the environment
+// does not support unit placement, then machines may not be created
+// without units, and units cannot be placed explcitly.
+func (env *environ) SupportsUnitPlacement() error {
+	logger.Debugf("cloudsigma:environ:SupportsUnitPlacement not implemented")
+	return nil
+}

--- a/provider/cloudsigma/environfirewall.go
+++ b/provider/cloudsigma/environfirewall.go
@@ -1,0 +1,30 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import "github.com/juju/juju/network"
+
+// Implementing the methods below (to do something other than return nil) will
+// cause `juju expose` to work when the firewall-mode is "global". If you
+// implement one of them, you should implement them all.
+
+// OpenPorts opens the given ports for the whole environment.
+// Must only be used if the environment was setup with the FwGlobal firewall mode.
+func (env environ) OpenPorts(ports []network.Port) error {
+	logger.Warningf("pretending to open ports %v for all instances", ports)
+	return nil
+}
+
+// ClosePorts closes the given ports for the whole environment.
+// Must only be used if the environment was setup with the FwGlobal firewall mode.
+func (env environ) ClosePorts(ports []network.Port) error {
+	logger.Warningf("pretending to close ports %v for all instances", ports)
+	return nil
+}
+
+// Ports returns the ports opened for the whole environment.
+// Must only be used if the environment was setup with the FwGlobal firewall mode.
+func (env environ) Ports() ([]network.Port, error) {
+	return nil, nil
+}

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -1,0 +1,301 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/Altoros/gosigma"
+	"github.com/juju/errors"
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cloudinit/sshinit"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/cloudinit"
+	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/utils/ssh"
+	"github.com/juju/juju/worker/localstorage"
+	"github.com/juju/loggo"
+	"github.com/juju/utils"
+
+	coreCloudinit "github.com/juju/juju/cloudinit"
+	"github.com/juju/juju/instance"
+)
+
+//
+// Imlementation of InstanceBroker: methods for starting and stopping instances.
+//
+
+// StartInstance asks for a new instance to be created, associated with
+// the provided config in machineConfig. The given config describes the juju
+// state for the new instance to connect to. The config MachineNonce, which must be
+// unique within an environment, is used by juju to protect against the
+// consequences of multiple instances being started with the same machine id.
+func (env environ) StartInstance(args environs.StartInstanceParams) (
+	instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
+	logger.Infof("sigmaEnviron.StartInstance...")
+
+	if args.MachineConfig == nil {
+		return nil, nil, nil, fmt.Errorf("machine configuration is nil")
+	}
+
+	if args.MachineConfig.HasNetworks() {
+		return nil, nil, nil, fmt.Errorf("starting instances with networks is not supported yet")
+	}
+
+	if len(args.Tools) == 0 {
+		return nil, nil, nil, fmt.Errorf("tools not found")
+	}
+
+	args.MachineConfig.Tools = args.Tools[0]
+	if err := environs.FinishMachineConfig(args.MachineConfig, env.Config(), args.Constraints); err != nil {
+		return nil, nil, nil, err
+	}
+
+	client := env.client
+	server, rootdrive, err := client.newInstance(args)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed start instance: %v", err)
+	}
+
+	inst := sigmaInstance{server: server}
+	addr := inst.findIPv4()
+	if addr == "" {
+		return nil, nil, nil, fmt.Errorf("failed obtain instance IP address")
+	}
+
+	// prepare new instance: wait up and running, populate nonce file, etc
+	if err := env.prepareInstance(addr, args.MachineConfig); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed prepare instanse: %v", err)
+	}
+
+	// provide additional agent config for localstorage, if any
+	if env.storage.tmp && args.MachineConfig.Bootstrap {
+		if err := env.prepareStorage(addr, args.MachineConfig); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed prepare storage: %v", err)
+		}
+	}
+
+	// prepare hardware characteristics
+	hwch := inst.hardware()
+
+	// populate root drive hardware characteristics
+	switch rootdrive.Arch() {
+	case "64":
+		var a = arch.AMD64
+		hwch.Arch = &a
+	}
+
+	diskSpace := rootdrive.Size() / gosigma.Megabyte
+	if diskSpace > 0 {
+		hwch.RootDisk = &diskSpace
+	}
+
+	logger.Tracef("hardware: %v", hwch)
+
+	return inst, hwch, nil, nil
+}
+
+// AllInstances returns all instances currently known to the broker.
+func (env environ) AllInstances() ([]instance.Instance, error) {
+	// Please note that this must *not* return instances that have not been
+	// allocated as part of this environment -- if it does, juju will see they
+	// are not tracked in state, assume they're stale/rogue, and shut them down.
+
+	logger.Tracef("environ.AllInstances...")
+
+	servers, err := env.client.instances()
+	if err != nil {
+		logger.Tracef("environ.AllInstances failed: %v", err)
+		return nil, err
+	}
+
+	instances := make([]instance.Instance, 0, len(servers))
+	for _, server := range servers {
+		instance := sigmaInstance{server: server}
+		instances = append(instances, instance)
+	}
+
+	if logger.LogLevel() <= loggo.TRACE {
+		logger.Tracef("All instances, len = %d:", len(instances))
+		for _, instance := range instances {
+			logger.Tracef("... id: %q, status: %q", instance.Id(), instance.Status())
+		}
+	}
+
+	return instances, nil
+}
+
+// Instances returns a slice of instances corresponding to the
+// given instance ids.  If no instances were found, but there
+// was no other error, it will return ErrNoInstances.  If
+// some but not all the instances were found, the returned slice
+// will have some nil slots, and an ErrPartialInstances error
+// will be returned.
+func (env environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
+	logger.Tracef("environ.Instances %#v", ids)
+	// Please note that this must *not* return instances that have not been
+	// allocated as part of this environment -- if it does, juju will see they
+	// are not tracked in state, assume they're stale/rogue, and shut them down.
+	// This advice applies even if an instance id passed in corresponds to a
+	// real instance that's not part of the environment -- the Environ should
+	// treat that no differently to a request for one that does not exist.
+
+	m, err := env.client.instanceMap()
+	if err != nil {
+		logger.Tracef("environ.Instances failed: %v", err)
+		return nil, err
+	}
+
+	var found int
+	r := make([]instance.Instance, len(ids))
+	for i, id := range ids {
+		if s, ok := m[string(id)]; ok {
+			r[i] = sigmaInstance{server: s}
+			found++
+		}
+	}
+
+	if found == 0 {
+		err = environs.ErrNoInstances
+	} else if found != len(ids) {
+		err = environs.ErrPartialInstances
+	}
+
+	return r, err
+}
+
+// StopInstances shuts down the given instances.
+func (env environ) StopInstances(instances ...instance.Id) error {
+	logger.Infof("stop instances %+v", instances)
+
+	var err error
+
+	for _, instance := range instances {
+		if e := env.client.stopInstance(instance); e != nil {
+			err = e
+		}
+	}
+
+	return err
+}
+
+func (env environ) prepareInstance(addr string, mcfg *cloudinit.MachineConfig) error {
+	host := "ubuntu@" + addr
+	logger.Debugf("Running prepare script on %s", host)
+
+	cmds := []string{"#!/bin/bash", "set -e"}
+	cmds = append(cmds, fmt.Sprintf("mkdir -p '%s'", mcfg.DataDir))
+
+	nonceFile := path.Join(mcfg.DataDir, cloudinit.NonceFile)
+	nonceContent := mcfg.MachineNonce
+	cmds = append(cmds, fmt.Sprintf("echo '%s' > %s", nonceContent, nonceFile))
+
+	script := strings.Join(cmds, "\n")
+
+	if !mcfg.Bootstrap {
+		cloudcfg := coreCloudinit.New()
+		if err := cloudinit.ConfigureJuju(mcfg, cloudcfg); err != nil {
+			return err
+		}
+		configScript, err := sshinit.ConfigureScript(cloudcfg)
+		if err != nil {
+			return err
+		}
+
+		script += "\n\n"
+		script += configScript
+	}
+
+	logger.Tracef("Script:\n%s", script)
+
+	keyfile := path.Join(mcfg.DataDir, agent.SystemIdentity)
+	if _, err := os.Stat(keyfile); err != nil {
+		keyfile = ""
+	}
+	logger.Tracef("System identity file: %q", keyfile)
+
+	var retryAttempts = utils.AttemptStrategy{
+		Total: 120 * time.Second,
+		Delay: 300 * time.Millisecond,
+	}
+
+	var err error
+	for attempt := retryAttempts.Start(); attempt.Next(); {
+		var options ssh.Options
+		if keyfile != "" {
+			options.SetIdentities(keyfile)
+		}
+
+		cmd := ssh.Command(host, []string{"sudo", "/bin/bash"}, &options)
+		cmd.Stdin = strings.NewReader(script)
+
+		var logw = loggerWriter{logger.LogLevel()}
+		cmd.Stderr = &logw
+		cmd.Stdout = &logw
+
+		if err = cmd.Run(); err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed running prepare script: %v", err)
+	}
+
+	logger.Tracef("Bootstrap script done for machine '%s', '%s'", mcfg.MachineId, addr)
+
+	return nil
+}
+
+func (env environ) prepareStorage(addr string, mcfg *cloudinit.MachineConfig) error {
+	storagePort := env.ecfg.storagePort()
+	storageDir := mcfg.DataDir + "/" + storageSubdir
+
+	logger.Debugf("Moving local temporary storage to %s:%d (%s)...", addr, storagePort, storageDir)
+	if err := env.storage.MoveToSSH("ubuntu", addr); err != nil {
+		return err
+	}
+
+	if strings.Contains(mcfg.Tools.URL, "%s") {
+		mcfg.Tools.URL = fmt.Sprintf(mcfg.Tools.URL, "file://"+storageDir)
+		logger.Tracef("Tools URL patched to %q", mcfg.Tools.URL)
+	}
+
+	// prepare configuration for local storage at bootstrap host
+	storageConfig := storageConfig{
+		ecfg:        env.ecfg,
+		storageDir:  storageDir,
+		storageAddr: addr,
+		storagePort: storagePort,
+	}
+
+	agentEnv, err := localstorage.StoreConfig(&storageConfig)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range agentEnv {
+		mcfg.AgentEnvironment[k] = v
+	}
+
+	return nil
+}
+
+// AllocateAddress requests a new address to be allocated for the
+// given instance on the given network.
+func (env environ) AllocateAddress(instID instance.Id, netID network.Id) (network.Address, error) {
+	return network.Address{}, errors.NotSupportedf("AllocateAddress")
+}
+
+// ListNetworks returns basic information about all networks known
+// by the provider for the environment. They may be unknown to juju
+// yet (i.e. when called initially or when a new network was created).
+func (env environ) ListNetworks() ([]network.BasicInfo, error) {
+	return nil, errors.NotImplementedf("ListNetworks")
+}

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -1,0 +1,206 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"time"
+
+	"github.com/Altoros/gosigma/mock"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/cloudinit"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state/api"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
+	"github.com/juju/loggo"
+	gc "launchpad.net/gocheck"
+)
+
+type environInstanceSuite struct {
+	testing.BaseSuite
+	baseConfig *config.Config
+}
+
+var _ = gc.Suite(&environInstanceSuite{})
+
+func (s *environInstanceSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+
+	mock.Start()
+
+	attrs := testing.Attrs{
+		"name":     "testname",
+		"region":   mock.Endpoint(""),
+		"username": mock.TestUser,
+		"password": mock.TestPassword,
+	}
+	s.baseConfig = newConfig(c, validAttrs().Merge(attrs))
+}
+
+func (s *environInstanceSuite) TearDownSuite(c *gc.C) {
+	mock.Stop()
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *environInstanceSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	ll := logger.LogLevel()
+	logger.SetLogLevel(loggo.TRACE)
+	s.AddCleanup(func(*gc.C) { logger.SetLogLevel(ll) })
+
+	mock.Reset()
+}
+
+func (s *environInstanceSuite) TearDownTest(c *gc.C) {
+	mock.Reset()
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *environInstanceSuite) createEnviron(c *gc.C, cfg *config.Config) environs.Environ {
+	var emptyStorage environStorage
+	s.PatchValue(&newStorage, func(*environConfig, *environClient) (*environStorage, error) {
+		return &emptyStorage, nil
+	})
+	if cfg == nil {
+		cfg = s.baseConfig
+	}
+	environ, err := environs.New(cfg)
+	c.Assert(environ, gc.NotNil)
+	c.Assert(err, gc.IsNil)
+	return environ
+}
+
+func (s *environInstanceSuite) TestInstances(c *gc.C) {
+	environ := s.createEnviron(c, nil)
+
+	instances, err := environ.AllInstances()
+	c.Assert(instances, gc.NotNil)
+	c.Assert(err, gc.IsNil)
+	c.Check(instances, gc.HasLen, 0)
+
+	uuid0 := addTestClientServer(c, jujuMetaInstanceServer, "testname", "1.1.1.1")
+	uuid1 := addTestClientServer(c, jujuMetaInstanceStateServer, "testname", "2.2.2.2")
+	addTestClientServer(c, jujuMetaInstanceServer, "other-env", "0.1.1.1")
+	addTestClientServer(c, jujuMetaInstanceStateServer, "other-env", "0.2.2.2")
+
+	instances, err = environ.AllInstances()
+	c.Assert(instances, gc.NotNil)
+	c.Assert(err, gc.IsNil)
+	c.Check(instances, gc.HasLen, 2)
+
+	ids := []instance.Id{instance.Id(uuid0), instance.Id(uuid1)}
+	instances, err = environ.Instances(ids)
+	c.Assert(instances, gc.NotNil)
+	c.Assert(err, gc.IsNil)
+	c.Check(instances, gc.HasLen, 2)
+
+	ids = append(ids, instance.Id("fake-instance"))
+	instances, err = environ.Instances(ids)
+	c.Assert(instances, gc.NotNil)
+	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
+	c.Check(instances, gc.HasLen, 3)
+	c.Check(instances[0], gc.NotNil)
+	c.Check(instances[1], gc.NotNil)
+	c.Check(instances[2], gc.IsNil)
+
+	err = environ.StopInstances(ids...)
+	c.Assert(err, gc.ErrorMatches, "404 Not Found.*")
+
+	instances, err = environ.Instances(ids)
+	c.Assert(instances, gc.NotNil)
+	c.Assert(err, gc.Equals, environs.ErrNoInstances)
+	c.Check(instances, gc.HasLen, 3)
+	c.Check(instances[0], gc.IsNil)
+	c.Check(instances[1], gc.IsNil)
+	c.Check(instances[2], gc.IsNil)
+}
+
+func (s *environInstanceSuite) TestInstancesFail(c *gc.C) {
+	attrs := testing.Attrs{
+		"name":     "testname",
+		"region":   "https://0.1.2.3:2000/api/2.0/",
+		"username": mock.TestUser,
+		"password": mock.TestPassword,
+	}
+	baseConfig := newConfig(c, validAttrs().Merge(attrs))
+
+	newClientFunc := newClient
+	s.PatchValue(&newClient, func(cfg *environConfig) (*environClient, error) {
+		cli, err := newClientFunc(cfg)
+		if cli != nil {
+			cli.conn.ConnectTimeout(10 * time.Millisecond)
+		}
+		return cli, err
+	})
+
+	environ := s.createEnviron(c, baseConfig)
+
+	instances, err := environ.AllInstances()
+	c.Assert(instances, gc.IsNil)
+	c.Assert(err, gc.NotNil)
+
+	instances, err = environ.Instances([]instance.Id{instance.Id("123"), instance.Id("321")})
+	c.Assert(instances, gc.IsNil)
+	c.Assert(err, gc.NotNil)
+}
+
+func (s *environInstanceSuite) TestAllocateAddress(c *gc.C) {
+	environ := s.createEnviron(c, nil)
+
+	addr, err := environ.AllocateAddress(instance.Id(""), network.Id(""))
+	c.Check(addr, gc.Equals, network.Address{})
+	c.Check(err, gc.ErrorMatches, "AllocateAddress not supported")
+}
+
+func (s *environInstanceSuite) TestStartInstanceError(c *gc.C) {
+	environ := s.createEnviron(c, nil)
+
+	inst, hw, ni, err := environ.StartInstance(environs.StartInstanceParams{})
+	c.Check(inst, gc.IsNil)
+	c.Check(hw, gc.IsNil)
+	c.Check(ni, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "machine configuration is nil")
+
+	inst, hw, ni, err = environ.StartInstance(environs.StartInstanceParams{
+		MachineConfig: &cloudinit.MachineConfig{
+			Networks: []string{"value"},
+		},
+	})
+	c.Check(inst, gc.IsNil)
+	c.Check(hw, gc.IsNil)
+	c.Check(ni, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "starting instances with networks is not supported yet")
+
+	inst, hw, ni, err = environ.StartInstance(environs.StartInstanceParams{
+		MachineConfig: &cloudinit.MachineConfig{},
+	})
+	c.Check(inst, gc.IsNil)
+	c.Check(hw, gc.IsNil)
+	c.Check(ni, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "tools not found")
+
+	inst, hw, ni, err = environ.StartInstance(environs.StartInstanceParams{
+		Tools: tools.List{&tools.Tools{}},
+		MachineConfig: &cloudinit.MachineConfig{
+			Bootstrap: true,
+			APIInfo:   &api.Info{},
+		},
+	})
+	c.Check(inst, gc.IsNil)
+	c.Check(hw, gc.IsNil)
+	c.Check(ni, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "cannot complete machine configuration:.*")
+
+	inst, hw, ni, err = environ.StartInstance(environs.StartInstanceParams{
+		Tools:         tools.List{&tools.Tools{}},
+		MachineConfig: &cloudinit.MachineConfig{},
+	})
+	c.Check(inst, gc.IsNil)
+	c.Check(hw, gc.IsNil)
+	c.Check(ni, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "failed start instance:.*")
+}

--- a/provider/cloudsigma/instance.go
+++ b/provider/cloudsigma/instance.go
@@ -1,0 +1,152 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+
+	"github.com/Altoros/gosigma"
+)
+
+type sigmaInstance struct {
+	server gosigma.Server
+}
+
+var ErrNoDNSName = fmt.Errorf("IPv4 address not found")
+
+// Id returns a provider-generated identifier for the Instance.
+func (i sigmaInstance) Id() instance.Id {
+	if i.server == nil {
+		return instance.Id("")
+	}
+	id := instance.Id(i.server.UUID())
+	logger.Tracef("sigmaInstance.Id: %s", id)
+	return id
+}
+
+// Status returns the provider-specific status for the instance.
+func (i sigmaInstance) Status() string {
+	if i.server == nil {
+		return ""
+	}
+	status := i.server.Status()
+	logger.Tracef("sigmaInstance.Status: %s", status)
+	return status
+}
+
+// Refresh refreshes local knowledge of the instance from the provider.
+func (i sigmaInstance) Refresh() error {
+	if i.server == nil {
+		return fmt.Errorf("invalid instance")
+	}
+	err := i.server.Refresh()
+	logger.Tracef("sigmaInstance.Refresh: %s", err)
+	return err
+}
+
+// Addresses returns a list of hostnames or ip addresses
+// associated with the instance. This will supercede DNSName
+// which can be implemented by selecting a preferred address.
+func (i sigmaInstance) Addresses() ([]network.Address, error) {
+
+	ip := i.findIPv4()
+
+	if ip == "" {
+		logger.Tracef("IPv4 address not found")
+		return nil, ErrNoDNSName
+	}
+
+	addr := network.Address{
+		Value: ip,
+		Type:  network.IPv4Address,
+		Scope: network.ScopePublic,
+	}
+
+	logger.Tracef("sigmaInstance.Addresses: %v", addr)
+
+	return []network.Address{addr}, nil
+}
+
+// DNSName returns the DNS name for the instance.
+// If the name is not yet allocated, it will return
+// an ErrNoDNSName error.
+func (i sigmaInstance) DNSName() (string, error) {
+	ip := i.findIPv4()
+
+	if ip == "" {
+		logger.Tracef("sigmaInstance.DNSName: IPv4 address not found, refreshing...")
+		if err := i.Refresh(); err != nil {
+			return "", err
+		}
+
+		ip = i.findIPv4()
+		if ip == "" {
+			return "", ErrNoDNSName
+		}
+	}
+
+	logger.Infof("sigmaInstance.DNSName: %s", ip)
+
+	return ip, nil
+}
+
+/* TODO REMOVE
+// WaitDNSName returns the DNS name for the instance,
+// waiting until it is allocated if necessary.
+// TODO: We may not need this in the interface any more.  All
+// implementations now delegate to environs.WaitDNSName.
+func (i sigmaInstance) WaitDNSName() (string, error) {
+	return common.WaitDNSName(i)
+}
+*/
+
+// OpenPorts opens the given ports on the instance, which
+// should have been started with the given machine id.
+func (i sigmaInstance) OpenPorts(machineID string, ports []network.Port) error {
+	logger.Tracef("sigmaInstance.OpenPorts: not implemented")
+	return nil
+}
+
+// ClosePorts closes the given ports on the instance, which
+// should have been started with the given machine id.
+func (i sigmaInstance) ClosePorts(machineID string, ports []network.Port) error {
+	logger.Tracef("sigmaInstance.ClosePorts: not implemented")
+	return nil
+}
+
+// Ports returns the set of ports open on the instance, which
+// should have been started with the given machine id.
+// The ports are returned as sorted by SortPorts.
+func (i sigmaInstance) Ports(machineID string) ([]network.Port, error) {
+	logger.Tracef("sigmaInstance.Ports: not implemented")
+	return []network.Port{}, nil
+}
+
+func (i sigmaInstance) findIPv4() string {
+	if i.server == nil {
+		return ""
+	}
+	addrs := i.server.IPv4()
+	if len(addrs) == 0 {
+		return ""
+	}
+	return addrs[0]
+}
+
+func (i sigmaInstance) hardware() *instance.HardwareCharacteristics {
+	if i.server == nil {
+		return nil
+	}
+	memory := i.server.Mem() / gosigma.Megabyte
+	cores := uint64(i.server.SMP())
+	cpu := i.server.CPU()
+	hw := instance.HardwareCharacteristics{
+		Mem:      &memory,
+		CpuCores: &cores,
+		CpuPower: &cpu,
+	}
+	return &hw
+}

--- a/provider/cloudsigma/instance_test.go
+++ b/provider/cloudsigma/instance_test.go
@@ -1,0 +1,317 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"strings"
+
+	"github.com/Altoros/gosigma"
+	"github.com/Altoros/gosigma/data"
+	"github.com/Altoros/gosigma/mock"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/testing"
+	gc "launchpad.net/gocheck"
+)
+
+type instanceSuite struct {
+	testing.BaseSuite
+	inst          *sigmaInstance
+	instWithoutIP *sigmaInstance
+}
+
+var _ = gc.Suite(&instanceSuite{})
+
+func (s *instanceSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	mock.Start()
+}
+
+func (s *instanceSuite) TearDownSuite(c *gc.C) {
+	mock.Stop()
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *instanceSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	cli, err := gosigma.NewClient(mock.Endpoint(""), mock.TestUser, mock.TestPassword, nil)
+	c.Assert(err, gc.IsNil)
+
+	mock.ResetServers()
+
+	ds, err := data.ReadServer(strings.NewReader(jsonInstanceData))
+	c.Assert(err, gc.IsNil)
+	mock.AddServer(ds)
+
+	mock.AddServer(&data.Server{
+		Resource: data.Resource{URI: "uri", UUID: "uuid-no-ip"},
+	})
+
+	server, err := cli.Server("f4ec5097-121e-44a7-a207-75bc02163260")
+	c.Assert(err, gc.IsNil)
+	c.Assert(server, gc.NotNil)
+	s.inst = &sigmaInstance{server}
+
+	server, err = cli.Server("uuid-no-ip")
+	c.Assert(err, gc.IsNil)
+	c.Assert(server, gc.NotNil)
+	s.instWithoutIP = &sigmaInstance{server}
+}
+
+func (s *instanceSuite) TearDownTest(c *gc.C) {
+	mock.ResetServers()
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *instanceSuite) TestInstanceEmpty(c *gc.C) {
+	e := sigmaInstance{}
+	c.Check(e.Id(), gc.Equals, instance.Id(""))
+	c.Check(e.Status(), gc.Equals, "")
+	c.Check(e.Refresh(), gc.ErrorMatches, "invalid instance")
+
+	addrs, err := e.Addresses()
+	c.Check(addrs, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "IPv4 address not found")
+
+	name, err := e.DNSName()
+	c.Check(name, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "invalid instance")
+
+	c.Check(e.hardware(), gc.IsNil)
+}
+
+func (s *instanceSuite) TestInstanceId(c *gc.C) {
+	c.Check(s.inst.Id(), gc.Equals, instance.Id("f4ec5097-121e-44a7-a207-75bc02163260"))
+}
+
+func (s *instanceSuite) TestInstanceStatus(c *gc.C) {
+	c.Check(s.inst.Status(), gc.Equals, "running")
+}
+
+func (s *instanceSuite) TestInstanceRefresh(c *gc.C) {
+	c.Check(s.inst.Status(), gc.Equals, "running")
+
+	mock.SetServerStatus("f4ec5097-121e-44a7-a207-75bc02163260", "stopped")
+
+	err := s.inst.Refresh()
+	c.Check(err, gc.IsNil)
+
+	c.Check(s.inst.Status(), gc.Equals, "stopped")
+}
+
+func (s *instanceSuite) TestInstanceAddresses(c *gc.C) {
+	addrs, err := s.inst.Addresses()
+	c.Check(addrs, gc.HasLen, 1)
+	c.Check(err, gc.IsNil)
+	a := addrs[0]
+	c.Check(a.Value, gc.Equals, "178.22.70.33")
+	c.Check(a.Type, gc.Equals, network.IPv4Address)
+	c.Check(a.Scope, gc.Equals, network.ScopePublic)
+	c.Check(a.NetworkName, gc.Equals, "")
+
+	addrs, err = s.instWithoutIP.Addresses()
+	c.Check(addrs, gc.IsNil)
+	c.Check(err, gc.Equals, ErrNoDNSName)
+}
+
+func (s *instanceSuite) TestInstanceDNSName(c *gc.C) {
+	name, err := s.inst.DNSName()
+	c.Check(name, gc.Equals, "178.22.70.33")
+	c.Check(err, gc.IsNil)
+
+	name, err = s.instWithoutIP.DNSName()
+	c.Check(name, gc.Equals, "")
+	c.Check(err, gc.Equals, ErrNoDNSName)
+
+	go func() {
+		mock.AddServer(&data.Server{
+			Resource: data.Resource{URI: "uri", UUID: "uuid-no-ip"},
+			NICs: []data.NIC{
+				data.NIC{
+					IPv4: &data.IPv4{
+						Conf: "static",
+						IP:   data.MakeIPResource("31.171.246.37"),
+					},
+					Runtime: &data.RuntimeNetwork{
+						InterfaceType: "public",
+						IPv4:          data.MakeIPResource("31.171.246.37"),
+					},
+				},
+			},
+		})
+	}()
+}
+
+func (s *instanceSuite) TestInstancePorts(c *gc.C) {
+	c.Check(s.inst.OpenPorts("", nil), gc.IsNil)
+	c.Check(s.inst.ClosePorts("", nil), gc.IsNil)
+
+	ports, err := s.inst.Ports("")
+	c.Check(ports, gc.NotNil)
+	if ports != nil {
+		c.Check(ports, gc.HasLen, 0)
+	}
+	c.Check(err, gc.IsNil)
+}
+
+func (s *instanceSuite) TestInstanceHardware(c *gc.C) {
+	hw := s.inst.hardware()
+	c.Assert(hw, gc.NotNil)
+
+	c.Check(hw.Arch, gc.IsNil)
+
+	c.Check(hw.Mem, gc.NotNil)
+	if hw.Mem != nil {
+		c.Check(*hw.Mem, gc.Equals, uint64(2048))
+	}
+
+	c.Check(hw.RootDisk, gc.IsNil)
+
+	c.Check(hw.CpuCores, gc.NotNil)
+	if hw.CpuCores != nil {
+		c.Check(*hw.CpuCores, gc.Equals, uint64(1))
+	}
+
+	c.Check(hw.CpuPower, gc.NotNil)
+	if hw.CpuPower != nil {
+		c.Check(*hw.CpuPower, gc.Equals, uint64(2000))
+	}
+
+	c.Check(hw.Tags, gc.IsNil)
+}
+
+const jsonInstanceData = `{
+    "context": true,
+    "cpu": 2000,
+    "cpu_model": null,
+    "cpus_instead_of_cores": false,
+    "drives": [
+        {
+            "boot_order": 1,
+            "dev_channel": "0:0",
+            "device": "virtio",
+            "drive": {
+                "resource_uri": "/api/2.0/drives/f968dc48-25a0-4d46-8f16-e12e073e1fe6/",
+                "uuid": "f968dc48-25a0-4d46-8f16-e12e073e1fe6"
+            },
+            "runtime": {
+                "io": {
+                    "bytes_read": 82980352,
+                    "bytes_written": 189440,
+                    "count_flush": 0,
+                    "count_read": 3952,
+                    "count_written": 19,
+                    "total_time_ns_flush": 0,
+                    "total_time_ns_read": 4435322816,
+                    "total_time_ns_write": 123240430
+                }
+            }
+        }
+    ],
+    "enable_numa": false,
+    "hv_relaxed": false,
+    "hv_tsc": false,
+    "jobs": [],
+    "mem": 2147483648,
+    "meta": {
+        "description": "test-description",
+        "ssh_public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDiwTGBsmFKBYHcKaVy5IgsYBR4XVYLS6KP/NKClE7gONlIGURE3+/45BX8TfHJHM5WTN8NBqJejKDHqwfyueR1f2VGoPkJxODGt/X/ZDNftLZLYwPd2DfDBs27ahOadZCk4Cl5l7mU0aoE74UnIcQoNPl6w7axkIFTIXr8+0HMk8DFB0iviBSJK118p1RGwhsoA1Hudn1CsgqARGPmNn6mxwvmQfQY7hZxZoOH9WMcvkNZ7rAFrwS/BuvEpEXkoC95K/JDPvmQVVJk7we+WeHfTYSmApkDFcSaypyjL2HOV8pvE+VntcIIhZccHiOubyjsBAx5aoTI+ueCsoz5AL1 maxim.perenesenko@altoros.com"
+    },
+    "name": "LiveTest-srv-17-54-51-999999999",
+    "nics": [
+        {
+            "boot_order": null,
+            "firewall_policy": null,
+            "ip_v4_conf": {
+                "conf": "dhcp",
+                "ip": null
+            },
+            "ip_v6_conf": null,
+            "mac": "22:ab:bf:26:e1:be",
+            "model": "virtio",
+            "runtime": {
+                "interface_type": "public",
+                "io": {
+                    "bytes_recv": 0,
+                    "bytes_sent": 17540,
+                    "packets_recv": 0,
+                    "packets_sent": 256
+                },
+                "ip_v4": {
+                    "resource_uri": "/api/2.0/ips/178.22.70.33/",
+                    "uuid": "178.22.70.33"
+                },
+                "ip_v6": null
+            },
+            "vlan": null
+        },
+        {
+            "boot_order": null,
+            "firewall_policy": null,
+            "ip_v4_conf": null,
+            "ip_v6_conf": null,
+            "mac": "22:9e:e7:d7:86:94",
+            "model": "virtio",
+            "runtime": {
+                "interface_type": "private",
+                "io": {
+                    "bytes_recv": 0,
+                    "bytes_sent": 1046,
+                    "packets_recv": 0,
+                    "packets_sent": 13
+                },
+                "ip_v4": null,
+                "ip_v6": null
+            },
+            "vlan": {
+                "resource_uri": "/api/2.0/vlans/5bc05e7e-6555-4f40-add8-3b8e91447702/",
+                "uuid": "5bc05e7e-6555-4f40-add8-3b8e91447702"
+            }
+        }
+    ],
+    "owner": {
+        "resource_uri": "/api/2.0/user/c25eb0ed-161f-44f4-ac1d-d584ce3a5312/",
+        "uuid": "c25eb0ed-161f-44f4-ac1d-d584ce3a5312"
+    },
+    "requirements": [],
+    "resource_uri": "/api/2.0/servers/f4ec5097-121e-44a7-a207-75bc02163260/",
+    "runtime": {
+        "active_since": "2014-04-24T14:56:58+00:00",
+        "nics": [
+            {
+                "interface_type": "public",
+                "io": {
+                    "bytes_recv": 0,
+                    "bytes_sent": 17540,
+                    "packets_recv": 0,
+                    "packets_sent": 256
+                },
+                "ip_v4": {
+                    "resource_uri": "/api/2.0/ips/178.22.70.33/",
+                    "uuid": "178.22.70.33"
+                },
+                "ip_v6": null,
+                "mac": "22:ab:bf:26:e1:be"
+            },
+            {
+                "interface_type": "private",
+                "io": {
+                    "bytes_recv": 0,
+                    "bytes_sent": 1046,
+                    "packets_recv": 0,
+                    "packets_sent": 13
+                },
+                "ip_v4": null,
+                "ip_v6": null,
+                "mac": "22:9e:e7:d7:86:94"
+            }
+        ]
+    },
+    "smp": 1,
+    "status": "running",
+    "tags": [],
+    "uuid": "f4ec5097-121e-44a7-a207-75bc02163260",
+    "vnc_password": "test-vnc-password"
+}`

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -1,0 +1,139 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Juju provider for CloudSigma
+
+package cloudsigma
+
+import (
+	"fmt"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.provider.cloudsigma")
+
+type loggerWriter struct {
+	level loggo.Level
+}
+
+func (lw loggerWriter) Write(p []byte) (n int, err error) {
+	logger.Logf(lw.level, string(p))
+	return len(p), nil
+}
+
+type environProvider struct{}
+
+var providerInstance = environProvider{}
+
+// check the provider implements environs.EnvironProvider interface
+var _ environs.EnvironProvider = (*environProvider)(nil)
+
+func init() {
+	// This will only happen in binaries that actually import this provider
+	// somewhere. To enable a provider, import it in the "providers/all"
+	// package; please do *not* import individual providers anywhere else,
+	// except in direct tests for that provider.
+	environs.RegisterProvider("cloudsigma", providerInstance)
+}
+
+// Boilerplate returns a default configuration for the environment in yaml format.
+// The text should be a key followed by some number of attributes:
+//    `environName:
+//        type: environTypeName
+//        attr1: val1
+//    `
+// The text is used as a template (see the template package) with one extra template
+// function available, rand, which expands to a random hexadecimal string when invoked.
+func (environProvider) BoilerplateConfig() string {
+	return boilerplateConfig
+}
+
+// Open opens the environment and returns it.
+// The configuration must have come from a previously
+// prepared environment.
+func (environProvider) Open(cfg *config.Config) (environs.Environ, error) {
+	logger.Infof("opening environment %q", cfg.Name())
+
+	cfg, err := prepareConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	env := &environ{name: cfg.Name()}
+	if err := env.SetConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}
+
+// Prepare prepares an environment for use. Any additional
+// configuration attributes in the returned environment should
+// be saved to be used later. If the environment is already
+// prepared, this call is equivalent to Open.
+func (environProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+	logger.Infof("preparing environment %q", cfg.Name())
+	return providerInstance.Open(cfg)
+}
+
+// Validate ensures that config is a valid configuration for this
+// provider, applying changes to it if necessary, and returns the
+// validated configuration.
+// If old is not nil, it holds the previous environment configuration
+// for consideration when validating changes.
+func (environProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
+	logger.Infof("validating environment %q", cfg.Name())
+
+	// You should almost certainly not change this method; if you need to change
+	// how configs are validated, you should edit validateConfig itself, to ensure
+	// that your checks are always applied.
+	newEcfg, err := validateConfig(cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("invalid config: %v", err)
+	}
+	if old != nil {
+		oldEcfg, err := validateConfig(old, nil)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base config: %v", err)
+		}
+		if newEcfg, err = validateConfig(cfg, oldEcfg); err != nil {
+			return nil, fmt.Errorf("invalid config change: %v", err)
+		}
+	}
+
+	return newEcfg.Config, nil
+}
+
+// SecretAttrs filters the supplied configuration returning only values
+// which are considered sensitive. All of the values of these secret
+// attributes need to be strings.
+func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
+	logger.Infof("filtering secret attributes for environment %q", cfg.Name())
+
+	// If you keep configSecretFields up to date, this method should Just Work.
+	ecfg, err := validateConfig(cfg, nil)
+	if err != nil {
+		return nil, err
+	}
+	secretAttrs := map[string]string{}
+	for _, field := range configSecretFields {
+		if value, ok := ecfg.attrs[field]; ok {
+			if stringValue, ok := value.(string); ok {
+				secretAttrs[field] = stringValue
+			} else {
+				// All your secret attributes must be strings at the moment. Sorry.
+				// It's an expedient and hopefully temporary measure that helps us
+				// plug a security hole in the API.
+				return nil, fmt.Errorf(
+					"secret %q field must have a string value; got %v",
+					field, value,
+				)
+			}
+		}
+	}
+
+	return secretAttrs, nil
+}

--- a/provider/cloudsigma/provider_test.go
+++ b/provider/cloudsigma/provider_test.go
@@ -1,0 +1,94 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"flag"
+	"io"
+	"testing"
+
+	tt "github.com/juju/juju/testing"
+	"github.com/juju/utils"
+	gc "launchpad.net/gocheck"
+)
+
+var live = flag.Bool("live", false, "run tests on live CloudSigma account")
+
+func TestCloudSigma(t *testing.T) {
+	/*
+		if *live {
+			registerLiveTests()
+		}
+	*/
+	gc.TestingT(t)
+}
+
+type providerSuite struct {
+	tt.BaseSuite
+}
+
+var _ = gc.Suite(&providerSuite{})
+
+func (s *providerSuite) TestProviderBoilerplateConfig(c *gc.C) {
+	cfg := providerInstance.BoilerplateConfig()
+	c.Assert(cfg, gc.Not(gc.Equals), "")
+}
+
+type failReader struct {
+	err error
+}
+
+func (f *failReader) Read(p []byte) (n int, err error) {
+	return 0, f.err
+}
+
+type fakeStorage struct {
+	call   string
+	name   string
+	prefix string
+	err    error
+	reader io.Reader
+	length int64
+}
+
+func (f *fakeStorage) Get(name string) (io.ReadCloser, error) {
+	f.call = "Get"
+	f.name = name
+	return nil, nil
+}
+func (f *fakeStorage) List(prefix string) ([]string, error) {
+	f.call = "List"
+	f.prefix = prefix
+	return []string{prefix}, nil
+}
+func (f *fakeStorage) URL(name string) (string, error) {
+	f.call = "URL"
+	f.name = name
+	return "", nil
+}
+func (f *fakeStorage) DefaultConsistencyStrategy() utils.AttemptStrategy {
+	f.call = "DefaultConsistencyStrategy"
+	return utils.AttemptStrategy{}
+}
+func (f *fakeStorage) ShouldRetry(err error) bool {
+	f.call = "ShouldRetry"
+	f.err = err
+	return false
+}
+func (f *fakeStorage) Put(name string, r io.Reader, length int64) error {
+	f.call = "Put"
+	f.name = name
+	f.reader = r
+	f.length = length
+	return nil
+}
+func (f *fakeStorage) Remove(name string) error {
+	f.call = "Remove"
+	f.name = name
+	return nil
+}
+func (f *fakeStorage) RemoveAll() error {
+	f.call = "RemoveAll"
+	return nil
+}

--- a/provider/cloudsigma/storage.go
+++ b/provider/cloudsigma/storage.go
@@ -1,0 +1,252 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/environs/filestorage"
+	"github.com/juju/juju/environs/httpstorage"
+	"github.com/juju/juju/environs/sshstorage"
+	"github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/loggo"
+	"github.com/juju/utils"
+)
+
+const (
+	// storageSubdir is the subdirectory of
+	// dataDir in which storage will be located.
+	storageSubdir = "storage"
+
+	// storageTmpSubdir is the subdirectory of
+	// dataDir in which temporary storage will
+	// be located.
+	storageTmpSubdir = "storage-tmp"
+)
+
+type environStorage struct {
+	storage storage.Storage
+	uuid    string
+	tmp     bool
+}
+
+var _ storage.Storage = (*environStorage)(nil)
+
+var newStorage = func(ecfg *environConfig, client *environClient) (*environStorage, error) {
+	var stg storage.Storage
+	var err error
+	var tmp bool
+
+	uuid, ip, ok := client.stateServerAddress()
+	if ok {
+		logger.Debugf("active state server: %q", ip)
+		// create https storage client
+		stg, err = newRemoteStorage(ecfg, ip)
+	} else {
+		// create tmp storage
+		tmp = true
+		path := path.Join(osenv.JujuHome(), "tmp")
+
+		logger.Debugf("prepare %q for tmp storage", path)
+		logger.Debugf("  removing all...")
+		if err := os.RemoveAll(path); err != nil {
+			return nil, fmt.Errorf("create tmp storage (RemoveAll): %v", err)
+		}
+
+		logger.Debugf("  creating path...")
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return nil, fmt.Errorf("create tmp storage (MkdirAll): %v", err)
+		}
+		stg, err = filestorage.NewFileStorageWriter(path)
+		logger.Debugf("using local tmp storage at: %q", path)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	result := &environStorage{
+		storage: stg,
+		uuid:    uuid,
+		tmp:     tmp,
+	}
+
+	client.storage = result
+
+	return result, nil
+}
+
+func newRemoteStorage(ecfg *environConfig, ip string) (storage.Storage, error) {
+	caCertPEM, ok := ecfg.CACert()
+	if !ok {
+		// should not be possible to validate base config
+		return nil, fmt.Errorf("ca-cert not set")
+	}
+
+	addr := fmt.Sprintf("%s:%d", ip, ecfg.storagePort())
+	logger.Debugf("using https storage at: %q", addr)
+
+	authkey := ecfg.storageAuthKey()
+	stg, err := httpstorage.ClientTLS(addr, caCertPEM, authkey)
+	if err != nil {
+		return nil, fmt.Errorf("initializing HTTPS storage failed: %v", err)
+	}
+
+	return stg, nil
+}
+
+func (s *environStorage) onStateInstanceStop(uuid string) {
+	if s.uuid != uuid {
+		return
+	}
+	s.storage = nil
+	s.uuid = ""
+	s.tmp = false
+}
+
+func (s *environStorage) List(prefix string) ([]string, error) {
+	if s.storage == nil {
+		return nil, fmt.Errorf("storage is not initialized")
+	}
+	list, err := s.storage.List(prefix)
+	logger.Tracef("environStorage.List, prefix = %s, len = %d, err = %v", prefix, len(list), err)
+	if err == nil && logger.LogLevel() <= loggo.TRACE {
+		for _, name := range list {
+			logger.Tracef("...%q", name)
+		}
+	}
+	return list, err
+}
+
+func (s *environStorage) URL(name string) (string, error) {
+	if s.storage == nil {
+		return "", fmt.Errorf("storage is not initialized")
+	}
+	if s.tmp {
+		return "%s/" + name, nil
+	}
+	url, err := s.storage.URL(name)
+	logger.Tracef("environStorage.URL, name = %q, url = %q, err = %v", name, url, err)
+	return url, err
+}
+
+func (s *environStorage) Get(name string) (io.ReadCloser, error) {
+	if s.storage == nil {
+		return nil, fmt.Errorf("storage is not initialized")
+	}
+	r, err := s.storage.Get(name)
+	logger.Tracef("environStorage.Get, name = %q, err = %v", name, err)
+	return r, err
+}
+
+func (s *environStorage) Put(name string, r io.Reader, length int64) error {
+	if s.storage == nil {
+		return fmt.Errorf("storage is not initialized")
+	}
+	err := s.storage.Put(name, r, length)
+	logger.Tracef("environStorage.Put, name = %q, len = %d, err = %v", name, length, err)
+	return err
+}
+
+func (s *environStorage) Remove(name string) error {
+	if s.storage == nil {
+		return fmt.Errorf("storage is not initialized")
+	}
+	err := s.storage.Remove(name)
+	logger.Tracef("environStorage.Remove, name = %q, err = %v", name, err)
+	return err
+}
+
+func (s *environStorage) RemoveAll() error {
+	if s.storage == nil {
+		// this method is called after state server destroy at destroy-environment
+		return nil
+	}
+	err := s.storage.RemoveAll()
+	logger.Tracef("environStorage.RemoveAll, err = %v", err)
+	return err
+}
+
+func (s *environStorage) DefaultConsistencyStrategy() utils.AttemptStrategy {
+	if s.storage == nil {
+		return utils.AttemptStrategy{}
+	}
+	return s.storage.DefaultConsistencyStrategy()
+}
+
+func (s *environStorage) ShouldRetry(err error) bool {
+	if s.storage == nil {
+		return false
+	}
+	return s.storage.ShouldRetry(err)
+}
+
+var newSSHStorage = func(sshurl, dir, tmpdir string) (storage.Storage, error) {
+	return sshstorage.NewSSHStorage(sshstorage.NewSSHStorageParams{
+		Host:       sshurl,
+		StorageDir: dir,
+		TmpDir:     tmpdir,
+	})
+}
+
+func (s *environStorage) MoveToSSH(user, host string) error {
+	if s.storage == nil {
+		return fmt.Errorf("storage is not initialized")
+	}
+
+	sshurl := user + "@" + host
+	if !s.tmp {
+		return fmt.Errorf("failed to move non-temporary storage to %q", sshurl)
+	}
+
+	storageDir := path.Join(agent.DefaultDataDir, storageSubdir)
+	storageTmpdir := path.Join(agent.DefaultDataDir, storageTmpSubdir)
+
+	logger.Debugf("using ssh storage at host %q dir %q", sshurl, storageDir)
+	stor, err := newSSHStorage(sshurl, storageDir, storageTmpdir)
+	if err != nil {
+		return fmt.Errorf("initializing SSH storage failed: %v", err)
+	}
+
+	list, err := s.List("")
+	if err != nil {
+		return fmt.Errorf("listing tmp storage failed: %v", err)
+	}
+
+	logger.Tracef("list to move:\n%s", strings.Join(list, "\n"))
+
+	for _, path := range list {
+		r, err := s.Get(path)
+		if err != nil {
+			return fmt.Errorf("getting %q from tmp storage failed: %v", path, err)
+		}
+		defer r.Close()
+
+		bb, err := ioutil.ReadAll(r)
+		if err != nil {
+			return fmt.Errorf("error MoveToSSH: reading %q from ssh storage failed: %v", path, err)
+		}
+
+		rb := bytes.NewReader(bb)
+		length := len(bb)
+		if err := stor.Put(path, rb, int64(length)); err != nil {
+			return fmt.Errorf("error MoveToSSH: putting %q to ssh storage failed: %v", path, err)
+		}
+	}
+
+	s.storage.RemoveAll()
+
+	s.storage = stor
+	s.tmp = false
+
+	return nil
+}

--- a/provider/cloudsigma/storage_test.go
+++ b/provider/cloudsigma/storage_test.go
@@ -1,0 +1,374 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudsigma
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"github.com/juju/loggo"
+	"github.com/juju/utils"
+
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/environs/testing"
+	tt "github.com/juju/juju/testing"
+)
+
+type StorageSuite struct {
+	tt.BaseSuite
+}
+
+var _ = gc.Suite(&StorageSuite{})
+
+func (s *StorageSuite) TestStorageEmpty(c *gc.C) {
+	stg := &environStorage{}
+
+	lst, err := stg.List("")
+	c.Check(lst, gc.IsNil)
+	c.Check(err, gc.NotNil)
+
+	url, err := stg.URL("")
+	c.Check(url, gc.Equals, "")
+	c.Check(err, gc.NotNil)
+
+	r, err := stg.Get("")
+	c.Check(r, gc.IsNil)
+	c.Check(err, gc.NotNil)
+
+	err = stg.Put("", nil, 0)
+	c.Check(err, gc.NotNil)
+
+	err = stg.Remove("")
+	c.Check(err, gc.NotNil)
+
+	err = stg.RemoveAll()
+	c.Check(err, gc.IsNil)
+
+	strategy := stg.DefaultConsistencyStrategy()
+	c.Check(strategy, gc.Equals, utils.AttemptStrategy{})
+
+	shr := stg.ShouldRetry(nil)
+	c.Check(shr, gc.Equals, false)
+
+	err = stg.MoveToSSH("", "")
+	c.Check(err, gc.NotNil)
+}
+
+func (s *StorageSuite) TestStorageInstanceStop(c *gc.C) {
+	stg := &environStorage{
+		storage: &fakeStorage{},
+		uuid:    "uuid",
+		tmp:     true,
+	}
+	stg.onStateInstanceStop("")
+	c.Check(stg.uuid, gc.Equals, "uuid")
+	stg.onStateInstanceStop("uuid")
+	c.Check(stg.storage, gc.IsNil)
+	c.Check(stg.uuid, gc.Equals, "")
+	c.Check(stg.tmp, gc.Equals, false)
+}
+
+func (s *StorageSuite) TestStorageURL(c *gc.C) {
+	fs := &fakeStorage{}
+	stg := &environStorage{
+		storage: fs,
+		uuid:    "uuid",
+		tmp:     true,
+	}
+
+	url, err := stg.URL("")
+	c.Check(err, gc.IsNil)
+	c.Check(url, gc.Equals, "%s/")
+
+	url, err = stg.URL("path/name")
+	c.Check(err, gc.IsNil)
+	c.Check(url, gc.Equals, "%s/path/name")
+
+	stg.tmp = false
+
+	url, err = stg.URL("path/name")
+	c.Check(err, gc.IsNil)
+	c.Check(url, gc.Equals, "")
+	c.Check(fs.call, gc.Equals, "URL")
+	c.Check(fs.name, gc.Equals, "path/name")
+}
+
+func (s *StorageSuite) TestStorageProxy(c *gc.C) {
+	fs := &fakeStorage{}
+	stg := &environStorage{
+		storage: fs,
+		uuid:    "uuid",
+		tmp:     true,
+	}
+
+	test := func(s storage.Storage) {
+
+		ll := logger.LogLevel()
+		logger.SetLogLevel(loggo.TRACE)
+		s.List("list")
+		c.Check(fs.call, gc.Equals, "List")
+		c.Check(fs.prefix, gc.Equals, "list")
+		logger.SetLogLevel(ll)
+
+		s.Get("get")
+		c.Check(fs.call, gc.Equals, "Get")
+		c.Check(fs.name, gc.Equals, "get")
+
+		r := strings.NewReader("")
+		s.Put("put", r, 1024)
+		c.Check(fs.call, gc.Equals, "Put")
+		c.Check(fs.name, gc.Equals, "put")
+		c.Check(fs.reader, gc.Equals, r)
+		c.Check(fs.length, gc.Equals, int64(1024))
+
+		s.Remove("remove")
+		c.Check(fs.call, gc.Equals, "Remove")
+		c.Check(fs.name, gc.Equals, "remove")
+
+		s.RemoveAll()
+		c.Check(fs.call, gc.Equals, "RemoveAll")
+
+		s.DefaultConsistencyStrategy()
+		c.Check(fs.call, gc.Equals, "DefaultConsistencyStrategy")
+
+		err := fmt.Errorf("test")
+		s.ShouldRetry(err)
+		c.Check(fs.call, gc.Equals, "ShouldRetry")
+		c.Check(fs.err, gc.Equals, err)
+	}
+
+	test(stg)
+
+	stg.tmp = false
+	test(stg)
+}
+
+func (s *StorageSuite) TestStorageMoveNonTemp(c *gc.C) {
+	fs := &fakeStorage{}
+	stg := &environStorage{
+		storage: fs,
+		uuid:    "uuid",
+		tmp:     false,
+	}
+
+	err := stg.MoveToSSH("", "")
+	c.Check(err, gc.NotNil)
+}
+
+func (s *StorageSuite) TestStorageMoveFailSsh(c *gc.C) {
+	fs := &fakeStorage{}
+	stg := &environStorage{
+		storage: fs,
+		uuid:    "uuid",
+		tmp:     true,
+	}
+
+	s.PatchValue(&newSSHStorage,
+		func(sshurl, dir, tmpdir string) (storage.Storage, error) {
+			return nil, fmt.Errorf("test")
+		})
+
+	err := stg.MoveToSSH("", "")
+	c.Check(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "initializing SSH storage failed: test")
+}
+
+func (s *StorageSuite) TestStorageMoveFailList(c *gc.C) {
+	fs := &fakeStorage{}
+	stg := &environStorage{
+		storage: fs,
+		uuid:    "uuid",
+		tmp:     true,
+	}
+
+	s.PatchValue(&newSSHStorage,
+		func(sshurl, dir, tmpdir string) (storage.Storage, error) {
+			stg.storage = nil
+			return nil, nil
+		})
+
+	err := stg.MoveToSSH("", "")
+	c.Check(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, "listing tmp storage failed: storage is not initialized")
+}
+
+func newTestStorage(s *StorageSuite, c *gc.C) storage.Storage {
+	closer, stor, _ := testing.CreateLocalTestStorage(c)
+	s.AddCleanup(func(*gc.C) { closer.Close() })
+	return stor
+}
+
+type moveStorageTest struct {
+	stg     storage.Storage
+	handler func(_, _, _ string) (storage.Storage, error)
+	data    map[string]string
+	emsg    string
+}
+
+func (s *StorageSuite) testMoveStorage(c *gc.C, d *moveStorageTest) {
+
+	s.PatchValue(&newSSHStorage, d.handler)
+
+	for k, v := range d.data {
+		err := d.stg.Put(k, strings.NewReader(v), int64(len(v)))
+		c.Assert(err, gc.IsNil)
+	}
+
+	src := &environStorage{
+		storage: d.stg,
+		uuid:    "uuid",
+		tmp:     true,
+	}
+
+	err := src.MoveToSSH("user", "host")
+	if d.emsg == "" {
+		c.Check(err, gc.IsNil)
+	} else {
+		c.Check(err, gc.ErrorMatches, d.emsg)
+		return
+	}
+
+	kk, err := src.storage.List("")
+	c.Assert(err, gc.IsNil)
+
+	var result = make(map[string]string, len(kk))
+	for _, k := range kk {
+		r, err := src.storage.Get(k)
+		c.Assert(err, gc.IsNil)
+		defer r.Close()
+		bb, err := ioutil.ReadAll(r)
+		c.Assert(err, gc.IsNil)
+		result[k] = string(bb)
+	}
+
+	for k, v := range d.data {
+		if vv, ok := result[k]; !ok {
+			c.Errorf("key %s not found", k)
+		} else {
+			c.Check(vv, gc.Equals, v)
+		}
+	}
+}
+
+func (s *StorageSuite) TestStorageMoveEmpty(c *gc.C) {
+	data := &moveStorageTest{
+		stg: newTestStorage(s, c),
+		handler: func(sshurl, dir, tmpdir string) (storage.Storage, error) {
+			c.Check(sshurl, gc.Equals, "user@host")
+			return newTestStorage(s, c), nil
+		}}
+	s.testMoveStorage(c, data)
+}
+
+var moveData = map[string]string{
+	"test0":      "0987654321",
+	"test/test1": "1234567890",
+}
+
+func (s *StorageSuite) TestStorageMoveData(c *gc.C) {
+	data := &moveStorageTest{
+		stg: newTestStorage(s, c),
+		handler: func(sshurl, dir, tmpdir string) (storage.Storage, error) {
+			c.Check(sshurl, gc.Equals, "user@host")
+			return newTestStorage(s, c), nil
+		},
+		data: moveData,
+	}
+	s.testMoveStorage(c, data)
+}
+
+type storageProxyGetFailed struct {
+	storage.Storage
+}
+
+func (s *storageProxyGetFailed) Get(name string) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("test")
+}
+
+func (s *StorageSuite) TestStorageMoveGetFailed(c *gc.C) {
+	data := &moveStorageTest{
+		stg: &storageProxyGetFailed{newTestStorage(s, c)},
+		handler: func(sshurl, dir, tmpdir string) (storage.Storage, error) {
+			c.Check(sshurl, gc.Equals, "user@host")
+			return newTestStorage(s, c), nil
+		},
+		data: moveData,
+		emsg: "getting .* from tmp storage failed: test",
+	}
+	s.testMoveStorage(c, data)
+}
+
+type storageProxyGetReadFailed struct {
+	storage.Storage
+}
+
+func (s *storageProxyGetReadFailed) Get(name string) (io.ReadCloser, error) {
+	err := fmt.Errorf("test")
+	r := &failReader{err}
+	return ioutil.NopCloser(r), nil
+}
+
+func (s *StorageSuite) TestStorageMoveGetReadFailed(c *gc.C) {
+	data := &moveStorageTest{
+		stg: &storageProxyGetReadFailed{newTestStorage(s, c)},
+		handler: func(sshurl, dir, tmpdir string) (storage.Storage, error) {
+			c.Check(sshurl, gc.Equals, "user@host")
+			return newTestStorage(s, c), nil
+		},
+		data: moveData,
+		emsg: ".*MoveToSSH: reading .* from ssh storage failed: test",
+	}
+	s.testMoveStorage(c, data)
+}
+
+type storageProxyPutFailed struct {
+	storage.Storage
+}
+
+func (s *storageProxyPutFailed) Put(name string, r io.Reader, length int64) error {
+	return fmt.Errorf("test")
+}
+
+func (s *StorageSuite) TestStorageMovePutFailed(c *gc.C) {
+	data := &moveStorageTest{
+		stg: newTestStorage(s, c),
+		handler: func(sshurl, dir, tmpdir string) (storage.Storage, error) {
+			c.Check(sshurl, gc.Equals, "user@host")
+			return &storageProxyPutFailed{newTestStorage(s, c)}, nil
+		},
+		data: moveData,
+		emsg: ".*MoveToSSH: putting .* to ssh storage failed: test",
+	}
+	s.testMoveStorage(c, data)
+}
+
+func (s *StorageSuite) TestStorageNewRemoteStorage(c *gc.C) {
+	ecfg := &environConfig{
+		Config: newConfig(c, tt.Attrs{
+			"name": "client-test",
+		}),
+		attrs: map[string]interface{}{
+			"storage-port": 1234,
+		},
+	}
+	stg, err := newRemoteStorage(ecfg, "0.1.2.3")
+	c.Check(stg, gc.NotNil)
+	c.Check(err, gc.IsNil)
+
+	attrs := tt.FakeConfig().Delete("ca-cert", "ca-private-key")
+	cfg, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, gc.IsNil)
+	ecfg = &environConfig{
+		Config: cfg,
+		attrs: map[string]interface{}{
+			"storage-port": 1234,
+		}}
+	stg, err = newRemoteStorage(ecfg, "0.1.2.3")
+	c.Check(stg, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "ca-cert not set")
+}


### PR DESCRIPTION
This pull request is part of juju provider for CloudSigma contaning the following files:
- cmd/jujud/agent.go
- cmd/jujud/machine.go
- dependencies.tsv
- provider/all/all.go

See the incremental diff here - https://github.com/Altoros/juju-cloudsigma/pull/8

Provider for CloudSigma (https://www.cloudsigma.com) uses CloudSigma API v2.0 (https://cloudsigma-docs.readthedocs.org/en/2.10/).

Minimal client for communicating with the CloudSigma Web API from Go program was implemented as separate library https://www.github.com/Altoros/gosigma. This library is published under AGPLv3 license.