### PR TITLE
state.address.NetworkScope was renamed to

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -150,7 +150,7 @@ type address struct {
 	Value       string
 	AddressType network.AddressType
 	NetworkName string        `bson:",omitempty"`
-	Scope       network.Scope `bson:",omitempty"`
+	Scope       network.Scope `bson:"networkscope,omitempty"`
 }
 
 // TODO(dimitern) Make sure we integrate this with other networking
@@ -160,7 +160,7 @@ type hostPort struct {
 	Value       string
 	AddressType network.AddressType
 	NetworkName string        `bson:",omitempty"`
-	Scope       network.Scope `bson:",omitempty"`
+	Scope       network.Scope `bson:"networkscope,omitempty"`
 	Port        int
 }
 


### PR DESCRIPTION
Scope, with no explicit bson field name
specified. This is a schema change, and
broke upgrade from 1.18 to 1.19.

Fixes https://bugs.launchpad.net/juju-core/+bug/1334773
