### PR TITLE
More robust HA upgrade in machine agent

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -419,7 +419,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 	if err := a.ensureMongoServer(agentConfig); err != nil {
 		return nil, err
 	}
-	st, m, err := openState(agentConfig)
+	st, m, err := openState(agentConfig, mongo.DialOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +563,10 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 			}
 			agentConfig = a.CurrentConfig()
 		}
-		st, m, err := openState(agentConfig)
+		// Note: we set Direct=true in the mongo options because it's
+		// possible that we've previously upgraded the mongo server's
+		// configuration to form a replicaset, but failed to initiate it.
+		st, m, err := openState(agentConfig, mongo.DialOpts{Direct: true})
 		if err != nil {
 			return err
 		}
@@ -640,12 +643,12 @@ func isPreHAVersion(v version.Number) bool {
 	return v.Compare(version.MustParse("1.19.0")) < 0
 }
 
-func openState(agentConfig agent.Config) (_ *state.State, _ *state.Machine, err error) {
+func openState(agentConfig agent.Config, dialOpts mongo.DialOpts) (_ *state.State, _ *state.Machine, err error) {
 	info, ok := agentConfig.StateInfo()
 	if !ok {
 		return nil, nil, fmt.Errorf("no state info available")
 	}
-	st, err := state.Open(info, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, err := state.Open(info, dialOpts, environs.NewStatePolicy())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -35,6 +35,11 @@ type DialOpts struct {
 	// Timeout is the amount of time to wait contacting
 	// a state server.
 	Timeout time.Duration
+
+	// Direct informs whether to establish connections only with the
+	// specified seed servers, or to obtain information for the whole
+	// cluster and establish connections with further servers too.
+	Direct bool
 }
 
 // DefaultDialOpts returns a DialOpts representing the default
@@ -95,5 +100,6 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		Addrs:   info.Addrs,
 		Timeout: opts.Timeout,
 		Dial:    dial,
+		Direct:  opts.Direct,
 	}, nil
 }


### PR DESCRIPTION
If upgrading mongo to HA only partially
completes such that the replicaset is not
initiated, then we would previously failed
on the second attempt. Make sure we use
"Direct" connections when upgrading to HA.

Possibly fixes https://launchpad.net/bugs/1334273
