### PR TITLE
cmd/jujud: synchronise upgrade steps and ensureMongoServer

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/juju/charm"
@@ -102,6 +103,9 @@ type MachineAgent struct {
 	upgradeComplete  chan struct{}
 	workersStarted   chan struct{}
 	st               *state.State
+
+	mongoInitMutex   sync.Mutex
+	mongoInitialized bool
 }
 
 // Info returns usage information for the command.
@@ -532,6 +536,13 @@ func (a *MachineAgent) limitLoginsDuringUpgrade(creds params.Creds) error {
 // ensureMongoServer ensures that mongo is installed and running,
 // and ready for opening a state connection.
 func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
+	a.mongoInitMutex.Lock()
+	defer a.mongoInitMutex.Unlock()
+	if a.mongoInitialized {
+		logger.Debugf("mongo is already initialized")
+		return nil
+	}
+
 	servingInfo, ok := agentConfig.StateServingInfo()
 	if !ok {
 		return fmt.Errorf("state worker was started with no state serving info")
@@ -607,12 +618,16 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 	if peerAddr == "" {
 		return fmt.Errorf("no appropriate peer address found in %q", addrs)
 	}
-	return maybeInitiateMongoServer(peergrouper.InitiateMongoParams{
+	if err := maybeInitiateMongoServer(peergrouper.InitiateMongoParams{
 		DialInfo:       dialInfo,
 		MemberHostPort: net.JoinHostPort(peerAddr, fmt.Sprint(servingInfo.StatePort)),
 		User:           stateInfo.Tag,
 		Password:       stateInfo.Password,
-	})
+	}); err != nil {
+		return err
+	}
+	a.mongoInitialized = true
+	return nil
 }
 
 func (a *MachineAgent) ensureMongoAdminUser(agentConfig agent.Config) (added bool, err error) {
@@ -743,6 +758,9 @@ func (a *MachineAgent) upgradeWorker(
 		// and how often StateWorker might run.
 		var st *state.State
 		if needsState {
+			if err := a.ensureMongoServer(agentConfig); err != nil {
+				return err
+			}
 			var err error
 			info, ok := agentConfig.StateInfo()
 			if !ok {


### PR DESCRIPTION
It's possible for the upgrade steps to complete before the
state worker starts, thus preventing it from initialising
mongo properly on upgrade. This PR makes it so that the
upgrade steps runner waits for ensureMongoServer to finish
before proceeding.

Maybe fixes https://bugs.launchpad.net/juju-core/+bug/1334273
