### PR TITLE
Backport fix-os-version to 1.20.

### DIFF
--- a/version/osversion_darwin.go
+++ b/version/osversion_darwin.go
@@ -1,8 +1,6 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// +build darwin
-
 package version
 
 import (

--- a/version/osversion_darwin_test.go
+++ b/version/osversion_darwin_test.go
@@ -1,8 +1,6 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// +build darwin
-
 package version
 
 import (

--- a/version/osversion_linux.go
+++ b/version/osversion_linux.go
@@ -1,8 +1,6 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// +build linux
-
 package version
 
 func osVersion() string {

--- a/version/osversion_windows.go
+++ b/version/osversion_windows.go
@@ -1,10 +1,8 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// +build !darwin,!linux
-
 package version
 
 func osVersion() string {
-	return "unknown"
+	return getWinVersion()
 }


### PR DESCRIPTION
This is a cherry-pick of Dave's fix for the windows version to 1.20.

Merge pull request #186 from davecheney/fix-os-version
Fix os version

Fix Lp 1334493

Remove all the double underpants // +build tags, the os is inferred from the name of the file.

Remove osversion_unknown.go, Juju cannot operate without knowing the series of the machine, so cause a compilation failure, rather than produce tools that explode on use.

lucky(~/src/github.com/juju/juju/version) % GOOS=windows go list -f '{{.GoFiles}}'
[osversion.go osversion_windows.go supportedseries.go version.go]
lucky(~/src/github.com/juju/juju/version) % GOOS=linux go list -f '{{.GoFiles}}'
[osversion.go osversion_linux.go supportedseries.go version.go]
lucky(~/src/github.com/juju/juju/version) % GOOS=darwin go list -f '{{.GoFiles}}'
[osversion.go osversion_darwin.go supportedseries.go version.go]
