### PR TITLE
More robust HA upgrade in machine agent

### DIFF
--- a/mongo/open.go
+++ b/mongo/open.go
@@ -35,6 +35,11 @@ type DialOpts struct {
 	// Timeout is the amount of time to wait contacting
 	// a state server.
 	Timeout time.Duration
+
+	// Direct informs whether to establish connections only with the
+	// specified seed servers, or to obtain information for the whole
+	// cluster and establish connections with further servers too.
+	Direct bool
 }
 
 // DefaultDialOpts returns a DialOpts representing the default
@@ -95,5 +100,6 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		Addrs:   info.Addrs,
 		Timeout: opts.Timeout,
 		Dial:    dial,
+		Direct:  opts.Direct,
 	}, nil
 }


### PR DESCRIPTION
If upgrading mongo to HA only partially
completes such that the replicaset is not
initiated, then we would previously failed
on the second attempt. Make sure we use
"Direct" connections when upgrading to HA.

Possibly fixes https://launchpad.net/bugs/1334273
