### PR TITLE
Don't expose the user command yet

### DIFF
--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -142,7 +142,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(NewAuthorizedKeysCommand())
 
 	// Manage users and access
-	r.Register(NewUserCommand())
+	// Disable for 1.20 release
+	// r.Register(NewUserCommand())
 
 	// Manage state server availability.
 	r.Register(wrapEnvCommand(&EnsureAvailabilityCommand{}))

--- a/cmd/juju/main_test.go
+++ b/cmd/juju/main_test.go
@@ -238,7 +238,7 @@ var commandNames = []string{
 	"unset-environment",
 	"upgrade-charm",
 	"upgrade-juju",
-	"user",
+	// "user", -- disabled for 1.20
 	"version",
 }
 


### PR DESCRIPTION
Just for the 1.20 release. Still enabled on master.

The user command is undergoing more change with the upcoming identity work. Rather than publicly expose something that we know is changing soon, just keep it disabled.

The enabling was introduced during 1.19.
