### PR TITLE
Allow add-machine to take a -n param

### DIFF
--- a/cmd/juju/addmachine.go
+++ b/cmd/juju/addmachine.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/names"
@@ -188,18 +190,16 @@ func (c *AddMachineCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 	if len(errs) == 1 {
+		fmt.Fprintf(ctx.Stderr, "failed to create 1 machine\n")
 		return errs[0]
 	}
 	if len(errs) > 1 {
-		ctx.Infof("failed to create %d machines:", len(errs))
-		for _, err := range errs {
-			ctx.Infof("  %v\n", err)
-		}
-		returnErr := ""
+		fmt.Fprintf(ctx.Stderr, "failed to create %d machines\n", len(errs))
+		returnErr := []string{}
 		for _, e := range errs {
-			returnErr = fmt.Sprintf("%s%s\n", returnErr, e)
+			returnErr = append(returnErr, fmt.Sprintf("%s", e))
 		}
-		return fmt.Errorf(returnErr)
+		return errors.New(strings.Join(returnErr, ", "))
 	}
 	return nil
 }

--- a/cmd/juju/addmachine_test.go
+++ b/cmd/juju/addmachine_test.go
@@ -144,7 +144,7 @@ func (s *AddMachineSuite) TestAddUnsupportedContainerToMachine(c *gc.C) {
 	m.SetSupportedContainers([]instance.ContainerType{instance.KVM})
 	context, err = runAddMachine(c, "lxc:0")
 	c.Assert(err, gc.ErrorMatches, "cannot add a new machine: machine 0 cannot host lxc containers")
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(testing.Stderr(context), gc.Equals, "failed to create 1 machine\n")
 }
 
 func (s *AddMachineSuite) TestAddMachineErrors(c *gc.C) {
@@ -171,15 +171,10 @@ func (s *AddMachineSuite) TestAddThreeMachinesWithTwoFailures(c *gc.C) {
 	})
 	fakeApi.successOrder = []bool{true, false, false}
 	expectedOutput := `created machine 0
-failed to create 2 machines:
-  something went wrong
-  something went wrong
-`
-	expectedErr := `something went wrong
-something went wrong
+failed to create 2 machines
 `
 	context, err := runAddMachine(c, "-n", "3")
-	c.Assert(err, gc.ErrorMatches, expectedErr)
+	c.Assert(err, gc.ErrorMatches, "something went wrong, something went wrong")
 	c.Assert(testing.Stderr(context), gc.Equals, expectedOutput)
 }
 


### PR DESCRIPTION
Fix for https://bugs.launchpad.net/juju-core/+bug/1214209

Allow add-machine to take a -n param to add multiple machines
