### PR TITLE
Clean up tests.

### DIFF
--- a/state/apiserver/agent/agent_test.go
+++ b/state/apiserver/agent/agent_test.go
@@ -51,6 +51,7 @@ func (s *agentSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	s.resources = common.NewResources()
+	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming machine 1 has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{
@@ -62,10 +63,6 @@ func (s *agentSuite) SetUpTest(c *gc.C) {
 	// Create a machiner API for machine 1.
 	s.agent, err = agent.NewAPI(s.State, s.resources, s.authorizer)
 	c.Assert(err, gc.IsNil)
-}
-func (s *agentSuite) TearDownTest(c *gc.C) {
-	s.resources.StopAll()
-	s.JujuConnSuite.TearDownTest(c)
 }
 
 func (s *agentSuite) TestAgentFailsWithNonAgent(c *gc.C) {

--- a/state/apiserver/charms_test.go
+++ b/state/apiserver/charms_test.go
@@ -96,7 +96,7 @@ type charmsSuite struct {
 var _ = gc.Suite(&charmsSuite{})
 
 func (s *charmsSuite) SetUpSuite(c *gc.C) {
-	s.JujuConnSuite.SetUpSuite(c)
+	s.authHttpSuite.SetUpSuite(c)
 	s.archiveContentType = "application/zip"
 }
 

--- a/state/apiserver/common/environmachineswatcher_test.go
+++ b/state/apiserver/common/environmachineswatcher_test.go
@@ -12,9 +12,12 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/apiserver/common"
+	"github.com/juju/juju/testing"
 )
 
-type environMachinesWatcherSuite struct{}
+type environMachinesWatcherSuite struct {
+	testing.BaseSuite
+}
 
 var _ = gc.Suite(&environMachinesWatcherSuite{})
 
@@ -30,13 +33,14 @@ func (f *fakeEnvironMachinesWatcher) WatchEnvironMachines() state.StringsWatcher
 	return &fakeStringsWatcher{changes}
 }
 
-func (*environMachinesWatcherSuite) TestWatchEnvironMachines(c *gc.C) {
+func (s *environMachinesWatcherSuite) TestWatchEnvironMachines(c *gc.C) {
 	getCanWatch := func() (common.AuthFunc, error) {
 		return func(tag string) bool {
 			return true
 		}, nil
 	}
 	resources := common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
 	e := common.NewEnvironMachinesWatcher(
 		&fakeEnvironMachinesWatcher{initial: []string{"foo"}},
 		resources,
@@ -48,11 +52,12 @@ func (*environMachinesWatcherSuite) TestWatchEnvironMachines(c *gc.C) {
 	c.Assert(resources.Count(), gc.Equals, 1)
 }
 
-func (*environMachinesWatcherSuite) TestWatchGetAuthError(c *gc.C) {
+func (s *environMachinesWatcherSuite) TestWatchGetAuthError(c *gc.C) {
 	getCanWatch := func() (common.AuthFunc, error) {
 		return nil, fmt.Errorf("pow")
 	}
 	resources := common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
 	e := common.NewEnvironMachinesWatcher(
 		&fakeEnvironMachinesWatcher{},
 		resources,
@@ -63,13 +68,14 @@ func (*environMachinesWatcherSuite) TestWatchGetAuthError(c *gc.C) {
 	c.Assert(resources.Count(), gc.Equals, 0)
 }
 
-func (*environMachinesWatcherSuite) TestWatchAuthError(c *gc.C) {
+func (s *environMachinesWatcherSuite) TestWatchAuthError(c *gc.C) {
 	getCanWatch := func() (common.AuthFunc, error) {
 		return func(tag string) bool {
 			return false
 		}, nil
 	}
 	resources := common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
 	e := common.NewEnvironMachinesWatcher(
 		&fakeEnvironMachinesWatcher{},
 		resources,

--- a/state/apiserver/common/environwatcher_test.go
+++ b/state/apiserver/common/environwatcher_test.go
@@ -51,13 +51,14 @@ func (s *environWatcherSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-func (*environWatcherSuite) TestWatchSuccess(c *gc.C) {
+func (s *environWatcherSuite) TestWatchSuccess(c *gc.C) {
 	getCanWatch := func() (common.AuthFunc, error) {
 		return func(tag string) bool {
 			return true
 		}, nil
 	}
 	resources := common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
 	e := common.NewEnvironWatcher(
 		&fakeEnvironAccessor{},
 		resources,
@@ -70,11 +71,12 @@ func (*environWatcherSuite) TestWatchSuccess(c *gc.C) {
 	c.Assert(resources.Count(), gc.Equals, 1)
 }
 
-func (*environWatcherSuite) TestWatchGetAuthError(c *gc.C) {
+func (s *environWatcherSuite) TestWatchGetAuthError(c *gc.C) {
 	getCanWatch := func() (common.AuthFunc, error) {
 		return nil, fmt.Errorf("pow")
 	}
 	resources := common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
 	e := common.NewEnvironWatcher(
 		&fakeEnvironAccessor{},
 		resources,
@@ -86,13 +88,14 @@ func (*environWatcherSuite) TestWatchGetAuthError(c *gc.C) {
 	c.Assert(resources.Count(), gc.Equals, 0)
 }
 
-func (*environWatcherSuite) TestWatchAuthError(c *gc.C) {
+func (s *environWatcherSuite) TestWatchAuthError(c *gc.C) {
 	getCanWatch := func() (common.AuthFunc, error) {
 		return func(tag string) bool {
 			return false
 		}, nil
 	}
 	resources := common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
 	e := common.NewEnvironWatcher(
 		&fakeEnvironAccessor{},
 		resources,

--- a/state/apiserver/deployer/deployer_test.go
+++ b/state/apiserver/deployer/deployer_test.go
@@ -96,6 +96,7 @@ func (s *deployerSuite) SetUpTest(c *gc.C) {
 	// Create the resource registry separately to track invocations to
 	// Register.
 	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	// Create a deployer API for machine 1.
 	deployer, err := deployer.NewDeployerAPI(

--- a/state/apiserver/environment/environment_test.go
+++ b/state/apiserver/environment/environment_test.go
@@ -41,6 +41,7 @@ func (s *environmentSuite) SetUpTest(c *gc.C) {
 		Entity:       s.machine0,
 	}
 	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.api, err = environment.NewEnvironmentAPI(
 		s.State,

--- a/state/apiserver/pinger_test.go
+++ b/state/apiserver/pinger_test.go
@@ -113,14 +113,14 @@ type mongoPingerSuite struct {
 
 var _ = gc.Suite(&mongoPingerSuite{})
 
-func (s *mongoPingerSuite) SetUpTest(c *gc.C) {
-	// We need to set the ping interval before the server is started.
-	s.PatchValue(apiserver.MongoPingInterval, coretesting.ShortWait)
-	s.JujuConnSuite.SetUpTest(c)
+func (s *mongoPingerSuite) SetUpSuite(c *gc.C) {
+	s.JujuConnSuite.SetUpSuite(c)
+	// We need to set the ping interval before the server is started in test setup.
+	restore := gitjujutesting.PatchValue(apiserver.MongoPingInterval, coretesting.ShortWait)
+	s.AddSuiteCleanup(func(*gc.C) { restore() })
 }
 
 func (s *mongoPingerSuite) TestAgentConnectionsShutDownWhenStateDies(c *gc.C) {
-	s.PatchValue(apiserver.MongoPingInterval, coretesting.ShortWait)
 	st, _ := s.OpenAPIAsNewMachine(c)
 	err := st.Ping()
 	c.Assert(err, gc.IsNil)

--- a/state/apiserver/rsyslog/rsyslog_test.go
+++ b/state/apiserver/rsyslog/rsyslog_test.go
@@ -39,6 +39,7 @@ func (s *rsyslogSuite) SetUpTest(c *gc.C) {
 		MachineAgent:   true,
 	}
 	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 	api, err := rsyslog.NewRsyslogAPI(s.State, s.resources, s.authorizer)
 	c.Assert(err, gc.IsNil)
 	s.EnvironWatcherTest = commontesting.NewEnvironWatcherTest(

--- a/state/apiserver/tools_test.go
+++ b/state/apiserver/tools_test.go
@@ -29,7 +29,7 @@ type toolsSuite struct {
 var _ = gc.Suite(&toolsSuite{})
 
 func (s *toolsSuite) SetUpSuite(c *gc.C) {
-	s.JujuConnSuite.SetUpSuite(c)
+	s.authHttpSuite.SetUpSuite(c)
 	s.archiveContentType = "application/x-tar-gz"
 }
 

--- a/state/apiserver/uniter/uniter_test.go
+++ b/state/apiserver/uniter/uniter_test.go
@@ -84,6 +84,7 @@ func (s *uniterSuite) SetUpTest(c *gc.C) {
 	// Create the resource registry separately to track invocations to
 	// Register.
 	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	// Create a uniter API for unit 0.
 	s.uniter, err = uniter.NewUniterAPI(

--- a/state/apiserver/upgrader/unitupgrader_test.go
+++ b/state/apiserver/upgrader/unitupgrader_test.go
@@ -40,6 +40,7 @@ var _ = gc.Suite(&unitUpgraderSuite{})
 func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	// Create a machine and unit to work with
 	var err error

--- a/state/apiserver/upgrader/upgrader_test.go
+++ b/state/apiserver/upgrader/upgrader_test.go
@@ -37,6 +37,7 @@ var _ = gc.Suite(&upgraderSuite{})
 func (s *upgraderSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	// Create a machine to work with
 	var err error


### PR DESCRIPTION
The machine pingers are added as resources to the API.  There were many tests that were adding resources to their API implementations without ever cleaning them up.

I have added cleanup calls, that at worst do nothing, and at best may actually stop some of the intermittent failures.

There were a few places where the Setup function was skipping a base suite.
