### PR TITLE
provider/azure: use affinity group in vnet site

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -201,20 +201,20 @@ func (env *azureEnviron) getVirtualNetworkName() string {
 }
 
 func (env *azureEnviron) createVirtualNetwork() error {
-	// Note: we use the location rather than affinity group
-	// when creating the virtual network, as that is what
-	// the Azure documentation recommends to do
-	// "whenever possible".
+	// Note: the Azure documentation recommends to use
+	// Location when creating virtual network sites.
+	// We have historically used Affinity Group, and
+	// have observed intermittent issues when switching.
+	// http://msdn.microsoft.com/en-us/library/azure/jj157100.aspx
 	vnetName := env.getVirtualNetworkName()
-	location := env.getSnapshot().ecfg.location()
 	azure, err := env.getManagementAPI()
 	if err != nil {
 		return err
 	}
 	defer env.releaseManagementAPI(azure)
 	virtualNetwork := gwacl.VirtualNetworkSite{
-		Name:     vnetName,
-		Location: location,
+		Name:          vnetName,
+		AffinityGroup: env.getAffinityGroupName(),
 		AddressSpacePrefixes: []string{
 			networkDefinition,
 		},

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1260,8 +1260,8 @@ func (*environSuite) TestCreateVirtualNetwork(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	networkConf := (*body.VirtualNetworkSites)[0]
 	c.Check(networkConf.Name, gc.Equals, env.getVirtualNetworkName())
-	c.Check(networkConf.AffinityGroup, gc.Equals, "")
-	c.Check(networkConf.Location, gc.Equals, env.getSnapshot().ecfg.location())
+	c.Check(networkConf.AffinityGroup, gc.Equals, env.getAffinityGroupName())
+	c.Check(networkConf.Location, gc.Equals, "")
 }
 
 func (*environSuite) TestDestroyVirtualNetwork(c *gc.C) {


### PR DESCRIPTION
Revert change based on observations of vnet
related issues. Azure console displays advisory
warning about vnets tied to locations, suggesting
vnets be tied to affinity groups to mitigate.
