### PR TITLE
Added two more tests for multiple and no api-endpoints

### DIFF
--- a/cmd/juju/endpoint_test.go
+++ b/cmd/juju/endpoint_test.go
@@ -33,12 +33,12 @@ func (s *EndpointSuite) TestMultipleEndpoints(c *gc.C) {
 	// Run command once to create store in test.
 	_, err := coretesting.RunCommand(c, envcmd.Wrap(&EndpointCommand{}))
 	c.Assert(err, gc.IsNil)
-	s.modifyAddresses(c, []string{"10.0.0.1:17070", "10.0.0.2:17070"})
+	info := s.APIInfo(c)
+	s.setAPIAddresses(c, info.Addrs[0], "0.1.2.3:17070", "0.2.3.4:17070")
 	ctx, err := coretesting.RunCommand(c, envcmd.Wrap(&EndpointCommand{}))
 	c.Assert(err, gc.IsNil)
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
 	output := string(ctx.Stdout.(*bytes.Buffer).Bytes())
-	info := s.APIInfo(c)
 	c.Assert(output, gc.Equals, fmt.Sprintf("%s\n", info.Addrs[0]))
 }
 
@@ -46,30 +46,24 @@ func (s *EndpointSuite) TestNoEndpoints(c *gc.C) {
 	// Run command once to create store in test.
 	_, err := coretesting.RunCommand(c, envcmd.Wrap(&EndpointCommand{}))
 	c.Assert(err, gc.IsNil)
-	s.modifyAddresses(c, nil)
+	info := s.APIInfo(c)
+	s.setAPIAddresses(c)
 	ctx, err := coretesting.RunCommand(c, envcmd.Wrap(&EndpointCommand{}))
 	c.Assert(err, gc.IsNil)
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
 	output := string(ctx.Stdout.(*bytes.Buffer).Bytes())
-	info := s.APIInfo(c)
 	c.Assert(output, gc.Equals, fmt.Sprintf("%s\n", info.Addrs[0]))
 }
 
-// modifyAddresses adds more endpoint addresses or removes all
-// in case of nil.
-func (s *EndpointSuite) modifyAddresses(c *gc.C, addresses []string) {
+// setAPIAddresses changes the API endpoint addresses to the
+// passed ones.
+func (s *EndpointSuite) setAPIAddresses(c *gc.C, addresses ...string) {
 	env, err := s.State.Environment()
 	c.Assert(err, gc.IsNil)
 	info, err := s.ConfigStore.ReadInfo(env.Name())
 	c.Assert(err, gc.IsNil)
 	endpoint := info.APIEndpoint()
-	if len(addresses) == 0 {
-		// Remove all endpoint addresses.
-		endpoint.Addresses = []string{}
-	} else {
-		// Add additional addresses.
-		endpoint.Addresses = append(endpoint.Addresses, addresses...)
-	}
+	endpoint.Addresses = addresses
 	info.SetAPIEndpoint(endpoint)
 	err = info.Write()
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
Added two more api-endpoint test cases for multiple endpoints (and using only the first one) and no endpoints (so automatically refresh and return the first endpoint then).
