### PR TITLE
Restricted API for clients during upgrades

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -528,10 +528,12 @@ func (a *MachineAgent) limitLoginsDuringUpgrade(creds params.Creds) error {
 		}
 		switch authTag := authTag.(type) {
 		case names.UserTag:
-			return nil // user logins always allowed
+			// use a restricted API mode
+			return apiserver.UpgradeInProgressError
 		case names.MachineTag:
 			if authTag == a.Tag() {
-				return nil // allow logins from the local machine
+				// allow logins from the local machine
+				return nil
 			}
 		}
 		return errors.Errorf("login for %q blocked because upgrade is in progress", authTag)

--- a/cmd/jujud/upgrade_test.go
+++ b/cmd/jujud/upgrade_test.go
@@ -33,6 +33,13 @@ type UpgradeSuite struct {
 
 var _ = gc.Suite(&UpgradeSuite{})
 
+type exposedAPI bool
+
+var (
+	FullAPIExposed       exposedAPI = true
+	RestrictedAPIExposed exposedAPI = false
+)
+
 func fakeRestart() error { return nil }
 
 func (s *UpgradeSuite) SetUpTest(c *gc.C) {
@@ -68,7 +75,7 @@ func (s *UpgradeSuite) TestUpgradeStepsHostMachine(c *gc.C) {
 	s.assertHostUpgrades(c)
 }
 
-func (s *UpgradeSuite) TestClientLoginsOnlyDuringUpgrade(c *gc.C) {
+func (s *UpgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 	// Override the main upgrade entry point so that the test can
 	// control when upgrades start and finish.
 	upgradeCh := make(chan bool)
@@ -99,8 +106,8 @@ func (s *UpgradeSuite) TestClientLoginsOnlyDuringUpgrade(c *gc.C) {
 
 	c.Assert(waitForUpgradeToStart(upgradeCh), gc.Equals, true)
 
-	// Only user and local logins are allowed during upgrade
-	c.Assert(s.canLoginToAPIAsUser(c), gc.Equals, true)
+	// Only user and local logins are allowed during upgrade. Users get a restricted API.
+	s.checkLoginToAPIAsUser(c, RestrictedAPIExposed)
 	c.Assert(s.canLoginToAPIAsMachine(c, s.machine0Config), gc.Equals, true)
 	c.Assert(s.canLoginToAPIAsMachine(c, machine1Config), gc.Equals, false)
 
@@ -108,8 +115,8 @@ func (s *UpgradeSuite) TestClientLoginsOnlyDuringUpgrade(c *gc.C) {
 
 	s.waitForUpgradeToFinish(c)
 
-	// All user and machine logins are allowed after upgrade
-	c.Assert(s.canLoginToAPIAsUser(c), gc.Equals, true)
+	// All logins are allowed after upgrade
+	s.checkLoginToAPIAsUser(c, FullAPIExposed)
 	c.Assert(s.canLoginToAPIAsMachine(c, s.machine0Config), gc.Equals, true)
 	c.Assert(s.canLoginToAPIAsMachine(c, machine1Config), gc.Equals, true)
 }
@@ -204,33 +211,47 @@ func (s *UpgradeSuite) waitForUpgradeToFinish(c *gc.C) {
 	c.Assert(success, jc.IsTrue)
 }
 
-func (s *UpgradeSuite) canLoginToAPIAsUser(c *gc.C) bool {
+func (s *UpgradeSuite) checkLoginToAPIAsUser(c *gc.C, expectFullApi exposedAPI) {
 	info := s.machine0Config.APIInfo()
 	defaultInfo := s.APIInfo(c)
 	info.Tag = defaultInfo.Tag
 	info.Password = defaultInfo.Password
 	info.Nonce = ""
-	return s.canLoginToAPI(info)
+
+	apiState, err := api.Open(info, upgradeTestDialOpts)
+	c.Assert(err, gc.IsNil)
+	defer apiState.Close()
+
+	// this call should always work
+	var result api.Status
+	err = apiState.Call("Client", "", "FullStatus", nil, &result)
+	c.Assert(err, gc.IsNil)
+
+	// this call should only work if API is not restricted
+	err = apiState.Call("Client", "", "DestroyEnvironment", nil, nil)
+	if expectFullApi {
+		c.Assert(err, gc.IsNil)
+	} else {
+		c.Assert(err, gc.ErrorMatches, "upgrade in progress .+")
+	}
 }
 
 func (s *UpgradeSuite) canLoginToAPIAsMachine(c *gc.C, config agent.Config) bool {
 	// Ensure logins are always to the API server (machine-0)
 	info := config.APIInfo()
 	info.Addrs = s.machine0Config.APIInfo().Addrs
-	return s.canLoginToAPI(info)
+	apiState, err := api.Open(info, upgradeTestDialOpts)
+	if apiState != nil {
+		apiState.Close()
+	}
+	if apiState != nil && err == nil {
+		return true
+	}
+	return false
 }
 
 var upgradeTestDialOpts = api.DialOpts{
 	DialAddressInterval: 50 * time.Millisecond,
 	Timeout:             1 * time.Minute,
 	RetryDelay:          250 * time.Millisecond,
-}
-
-func (s *UpgradeSuite) canLoginToAPI(info *api.Info) (out bool) {
-	apiState, err := api.Open(info, upgradeTestDialOpts)
-	if apiState != nil && err == nil {
-		apiState.Close()
-		return true
-	}
-	return false
 }

--- a/state/apiserver/apiroot_interface.go
+++ b/state/apiserver/apiroot_interface.go
@@ -1,0 +1,17 @@
+package apiserver
+
+import (
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/state/api/params"
+	"github.com/juju/juju/state/apiserver/common"
+)
+
+// apiRoot describes an API root after login.
+type apiRoot interface {
+	getResources() *common.Resources
+	getRpcConn() *rpc.Conn
+	DescribeFacades() []params.FacadeVersions
+	rpc.Killer
+	rpc.MethodFinder
+	common.Authorizer
+}

--- a/state/apiserver/export_test.go
+++ b/state/apiserver/export_test.go
@@ -54,3 +54,11 @@ func TestingSrvRoot(st *state.State) *srvRoot {
 		objectCache: make(map[objectKey]reflect.Value),
 	}
 }
+
+// TestingUpgradingSrvRoot returns a limited upgradingSrvRoot
+// containing a srvRoot as returned by TestingSrvRoot.
+func TestingUpgradingRoot(st *state.State) *upgradingRoot {
+	return &upgradingRoot{
+		srvRoot: *TestingSrvRoot(st),
+	}
+}

--- a/state/apiserver/upgrading_root.go
+++ b/state/apiserver/upgrading_root.go
@@ -1,0 +1,51 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/rpc/rpcreflect"
+	"github.com/juju/utils/set"
+)
+
+var inUpgradeError = errors.New("upgrade in progress - Juju functionality is limited")
+
+type upgradingRoot struct {
+	srvRoot
+}
+
+var _ apiRoot = (*upgradingRoot)(nil)
+
+// newUpgradingRoot creates a root where all but a few "safe" API
+// calls fail with inUpgradeError.
+func newUpgradingRoot(root *initialRoot, entity taggedAuthenticator) *upgradingRoot {
+	return &upgradingRoot{
+		srvRoot: *newSrvRoot(root, entity),
+	}
+}
+
+// FindMethod extended srvRoot.FindMethod. It returns inUpgradeError
+// for most API calls except those that are deemed safe or important
+// for use while Juju is upgrading.
+func (r *upgradingRoot) FindMethod(rootName string, version int, methodName string) (rpcreflect.MethodCaller, error) {
+	if _, _, err := r.lookupMethod(rootName, version, methodName); err != nil {
+		return nil, err
+	}
+	if !isMethodAllowedDuringUpgrade(rootName, methodName) {
+		return nil, inUpgradeError
+	}
+	return r.srvRoot.FindMethod(rootName, version, methodName)
+}
+
+var allowedMethodsDuringUpgrades = set.NewStrings(
+	"Client.FullStatus",     // for "juju status"
+	"Client.PrivateAddress", // for "juju ssh"
+	"Client.PublicAddress",  // for "juju ssh"
+	"Client.WatchDebugLog",  // for "juju debug-log"
+)
+
+func isMethodAllowedDuringUpgrade(rootName, methodName string) bool {
+	fullName := rootName + "." + methodName
+	return allowedMethodsDuringUpgrades.Contains(fullName)
+}

--- a/state/apiserver/upgrading_root_test.go
+++ b/state/apiserver/upgrading_root_test.go
@@ -1,0 +1,52 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"github.com/juju/juju/state/apiserver"
+	"github.com/juju/juju/testing"
+	gc "launchpad.net/gocheck"
+)
+
+type upgradingRootSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&upgradingRootSuite{})
+
+func (r *upgradingRootSuite) TestFindAllowedMethod(c *gc.C) {
+	root := apiserver.TestingUpgradingRoot(nil)
+
+	caller, err := root.FindMethod("Client", 0, "FullStatus")
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(caller, gc.NotNil)
+}
+
+func (r *upgradingRootSuite) TestFindDisallowedMethod(c *gc.C) {
+	root := apiserver.TestingUpgradingRoot(nil)
+
+	caller, err := root.FindMethod("Client", 0, "ServiceDeploy")
+
+	c.Assert(err, gc.ErrorMatches, "upgrade in progress - Juju functionality is limited")
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *upgradingRootSuite) TestFindNonExistentMethod(c *gc.C) {
+	root := apiserver.TestingUpgradingRoot(nil)
+
+	caller, err := root.FindMethod("Foo", 0, "Bar")
+
+	c.Assert(err, gc.ErrorMatches, "unknown object type \"Foo\"")
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *upgradingRootSuite) TestFindMethodNonExistentVersion(c *gc.C) {
+	root := apiserver.TestingUpgradingRoot(nil)
+
+	caller, err := root.FindMethod("Client", 99999999, "Status")
+
+	c.Assert(err, gc.ErrorMatches, "unknown version \\(99999999\\) of interface \"Client\"")
+	c.Assert(caller, gc.IsNil)
+}


### PR DESCRIPTION
This is a little rough (with no tests) and is not intended for merging as-is. This demonstrates how the API available to clients can be restricted during upgrades.

With this change in place, most API calls made by clients will fail with an "upgrade in progress" error. A select few API calls used by commands for monitoring will still function. For example:

```
# During upgrade...
$ juju status
environment: local
machines:
  "0":
    agent-state: started
    agent-version: 1.19.5.3
    dns-name: localhost
    instance-id: localhost
    series: trusty
    state-server-member-status: has-vote
services: {}
$ juju deploy local:precise/dummy-source
ERROR upgrade in progress - method Client.EnvironmentGet is not available

# Time passes ... upgrade completes.
$ juju deploy local:precise/dummy-source
Added charm "local:precise/dummy-source-0" to the environment.
```
