### PR TITLE
Allow restore to retry connecting to state server

### DIFF
--- a/mongo/open.go
+++ b/mongo/open.go
@@ -89,7 +89,7 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		}
 		cc := tls.Client(c, tlsConfig)
 		if err := cc.Handshake(); err != nil {
-			logger.Errorf("TLS handshake failed: %v", err)
+			logger.Debugf("TLS handshake failed: %v", err)
 			return nil, err
 		}
 		logger.Infof("dialled mongo successfully")


### PR DESCRIPTION
The restore process recreates a state server but it may not have finished starting everything before attempting to reconnect. So a retry loop is added where needed. Tested live on EC2, first to reproduce the bug and then to verify the fix.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1336104
