### PR TITLE
Reaplaced os.Symlink and os.Readlink

### DIFF
--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -19,6 +19,7 @@ import (
 
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
+	"github.com/juju/utils/symlink"
 )
 
 const toolsFile = "downloaded-tools.txt"
@@ -175,7 +176,7 @@ func ChangeAgentTools(dataDir string, agentName string, vers version.Binary) (*c
 		return nil, err
 	}
 	tmpName := ToolsDir(dataDir, "tmplink-"+agentName)
-	err = os.Symlink(tools.Version.String(), tmpName)
+	err = symlink.New(tools.Version.String(), tmpName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create tools symlink: %v", err)
 	}

--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -59,6 +59,7 @@ import (
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
+	"github.com/juju/utils/symlink"
 )
 
 var logger = loggo.GetLogger("juju.cmd.jujud")
@@ -847,7 +848,7 @@ func (a *MachineAgent) createJujuRun(dataDir string) error {
 		return err
 	}
 	jujud := filepath.Join(dataDir, "tools", a.Tag().String(), "jujud")
-	return os.Symlink(jujud, jujuRun)
+	return symlink.New(jujud, jujuRun)
 }
 
 func (a *MachineAgent) uninstallAgent(agentConfig agent.Config) error {

--- a/cmd/jujud/machine_test.go
+++ b/cmd/jujud/machine_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/juju/juju/worker/rsyslog"
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/upgrader"
+	"github.com/juju/utils/symlink"
 )
 
 type commonMachineSuite struct {
@@ -833,7 +834,7 @@ func (s *MachineSuite) TestMachineAgentSymlinkJujuRun(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C) {
-	err := os.Symlink("/nowhere/special", jujuRun)
+	err := symlink.New("/nowhere/special", jujuRun)
 	c.Assert(err, gc.IsNil)
 	_, err = os.Stat(jujuRun)
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
@@ -841,7 +842,7 @@ func (s *MachineSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C) {
 		// juju-run should have been recreated
 		_, err := os.Stat(jujuRun)
 		c.Assert(err, gc.IsNil)
-		link, err := os.Readlink(jujuRun)
+		link, err := symlink.Read(jujuRun)
 		c.Assert(err, gc.IsNil)
 		c.Assert(link, gc.Not(gc.Equals), "/nowhere/special")
 	})

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/version"
+	"github.com/juju/utils/symlink"
 )
 
 var logger = loggo.GetLogger("juju.container.lxc")
@@ -268,7 +269,7 @@ func autostartContainer(name string) error {
 	// option should be set in the LXC config file, this is done in the networkConfigTemplate
 	// function below.
 	if useRestartDir() {
-		if err := os.Symlink(
+		if err := symlink.New(
 			containerConfigFilename(name),
 			restartSymlink(name),
 		); err != nil {

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -27,6 +27,7 @@ import (
 	containertesting "github.com/juju/juju/container/testing"
 	instancetest "github.com/juju/juju/instance/testing"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/utils/symlink"
 )
 
 func Test(t *stdtesting.T) {
@@ -211,7 +212,7 @@ func (s *LxcSuite) TestCreateContainer(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(linkInfo.Mode()&os.ModeSymlink, gc.Equals, os.ModeSymlink)
 
-	location, err := os.Readlink(expectedLinkLocation)
+	location, err := symlink.Read(expectedLinkLocation)
 	c.Assert(err, gc.IsNil)
 	c.Assert(location, gc.Equals, expectedTarget)
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -17,7 +17,7 @@ github.com/juju/names	git	b2e06a0ab1c09f138853d1ef6b11f94ca9f7b675
 github.com/juju/ratelimit	git	0025ab75db6c6eaa4ffff0240c2c9e617ad1a0eb	
 github.com/juju/schema	git	1887e824896b58a0f376fb8517b5eebb825828b8	
 github.com/juju/testing	git	b0941ff1bf4d3db1ffbbe09f75fa8383eae5764c	
-github.com/juju/utils	git	344b520c12afc98a18f5b4fd763313e340a9a992	
+github.com/juju/utils	git	4b5adaf91e6e53d8e294f9e40527d041db065dae	
 labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20121003093437-zcyyw0lpvj2nifpk	12
 launchpad.net/goamz	bzr	ian.booth@canonical.com-20140604055617-b7qt909ir9qf4959	47

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -11,6 +11,7 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/utils/symlink"
 )
 
 // RepoSuite acts as a JujuConnSuite but also sets up
@@ -38,7 +39,7 @@ func (s *RepoSuite) SetUpTest(c *gc.C) {
 	// and machines are written with hard-coded "quantal" series,
 	// hence they interact badly with a local repository that assumes
 	// only "precise" charms are available.
-	err = os.Symlink(s.SeriesPath, filepath.Join(repoPath, "quantal"))
+	err = symlink.New(s.SeriesPath, filepath.Join(repoPath, "quantal"))
 	c.Assert(err, gc.IsNil)
 }
 

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -45,6 +45,7 @@ import (
 	"github.com/juju/juju/upstart"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/terminationworker"
+	"github.com/juju/utils/symlink"
 )
 
 // boostrapInstanceId is just the name we give to the bootstrap machine.
@@ -177,7 +178,7 @@ func (env *localEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.
 	if err := os.RemoveAll(localLogDir); err != nil {
 		return err
 	}
-	if err := os.Symlink(mcfg.LogDir, localLogDir); err != nil {
+	if err := symlink.New(mcfg.LogDir, localLogDir); err != nil {
 		return err
 	}
 	if err := os.Remove(mcfg.CloudInitOutputLog); err != nil && !os.IsNotExist(err) {

--- a/provider/local/prereqs_test.go
+++ b/provider/local/prereqs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
+	"github.com/juju/utils/symlink"
 )
 
 type prereqsSuite struct {
@@ -57,7 +58,7 @@ func (s *prereqsSuite) SetUpTest(c *gc.C) {
 
 	// symlink $temp/dpkg-query to /bin/true, to
 	// simulate package installation query responses.
-	err = os.Symlink("/bin/true", filepath.Join(s.tmpdir, "dpkg-query"))
+	err = symlink.New("/bin/true", filepath.Join(s.tmpdir, "dpkg-query"))
 	c.Assert(err, gc.IsNil)
 	s.PatchValue(&isPackageInstalled, apt.IsPackageInstalled)
 }
@@ -97,7 +98,7 @@ func (s *prereqsSuite) TestLxcPrereq(c *gc.C) {
 func (s *prereqsSuite) TestJujuLocalPrereq(c *gc.C) {
 	err := os.Remove(filepath.Join(s.tmpdir, "dpkg-query"))
 	c.Assert(err, gc.IsNil)
-	err = os.Symlink("/bin/false", filepath.Join(s.tmpdir, "dpkg-query"))
+	err = symlink.New("/bin/false", filepath.Join(s.tmpdir, "dpkg-query"))
 	c.Assert(err, gc.IsNil)
 
 	err = VerifyPrerequisites(instance.LXC)

--- a/upgrades/agentconfig.go
+++ b/upgrades/agentconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state/api/params"
+	"github.com/juju/utils/symlink"
 )
 
 var (
@@ -122,11 +123,11 @@ func migrateLocalProviderAgentConfig(context Context) error {
 		return fmt.Errorf("cannot remove %q: %v", spoolConfig, err)
 	}
 	allMachinesLog := filepath.Join(logDir, "all-machines.log")
-	if err := os.Symlink(allMachinesLog, localLogDir+"/"); err != nil && !os.IsExist(err) {
+	if err := symlink.New(allMachinesLog, localLogDir+"/"); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("cannot symlink %q to %q: %v", allMachinesLog, localLogDir, err)
 	}
 	machine0Log := filepath.Join(localLogDir, "machine-0.log")
-	if err := os.Symlink(machine0Log, logDir+"/"); err != nil && !os.IsExist(err) {
+	if err := symlink.New(machine0Log, logDir+"/"); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("cannot symlink %q to %q: %v", machine0Log, logDir, err)
 	}
 

--- a/upstart/upstart_test.go
+++ b/upstart/upstart_test.go
@@ -16,6 +16,7 @@ import (
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/upstart"
+	"github.com/juju/utils/symlink"
 )
 
 func Test(t *testing.T) { gc.TestingT(t) }
@@ -246,7 +247,7 @@ func (s *UpstartSuite) TestInstallAlreadyRunning(c *gc.C) {
 		"rm %s; ln -s %s %s",
 		pathTo("status"), pathTo("status-started"), pathTo("status"),
 	))
-	err := os.Symlink(pathTo("status-started"), pathTo("status"))
+	err := symlink.New(pathTo("status-started"), pathTo("status"))
 	c.Assert(err, gc.IsNil)
 
 	conf := s.dummyConf(c)

--- a/worker/uniter/charm/converter.go
+++ b/worker/uniter/charm/converter.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/charm"
 	"github.com/juju/utils/set"
+	"github.com/juju/utils/symlink"
 )
 
 // NewDeployer returns a Deployer of whatever kind is currently in use for the
@@ -123,7 +124,7 @@ func ensureCurrentGitCharm(gitDeployer *gitDeployer, expectURL *charm.URL) error
 //      the manifestDeployer keeps track of what version it's upgrading from.
 // All paths are slash-separated, to match the bundle manifest format.
 func gitManifest(linkPath string) (set.Strings, error) {
-	dirPath, err := os.Readlink(linkPath)
+	dirPath, err := symlink.Read(linkPath)
 	if err != nil {
 		return set.NewStrings(), err
 	}

--- a/worker/uniter/charm/git_deployer.go
+++ b/worker/uniter/charm/git_deployer.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/juju/utils/symlink"
 )
 
 const (
@@ -94,7 +96,7 @@ func (d *gitDeployer) Stage(info BundleInfo, abort <-chan struct{}) error {
 
 	// Atomically rename fresh repository to current.
 	tmplink := filepath.Join(updatePath, "tmplink")
-	if err = os.Symlink(updatePath, tmplink); err != nil {
+	if err = symlink.New(updatePath, tmplink); err != nil {
 		return err
 	}
 	return os.Rename(tmplink, d.current.Path())
@@ -195,7 +197,7 @@ func (d *gitDeployer) upgrade() error {
 // repos are orphans, and all will be deleted; this should only be the case when
 // converting a gitDeployer to a manifestDeployer.
 func collectGitOrphans(dataPath string) {
-	current, err := os.Readlink(filepath.Join(dataPath, gitCurrentPath))
+	current, err := symlink.Read(filepath.Join(dataPath, gitCurrentPath))
 	if os.IsNotExist(err) {
 		logger.Warningf("no current staging repo")
 	} else if err != nil {

--- a/worker/uniter/charm/git_deployer_test.go
+++ b/worker/uniter/charm/git_deployer_test.go
@@ -5,7 +5,6 @@ package charm_test
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 
 	corecharm "github.com/juju/charm"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/charm"
+	"github.com/juju/utils/symlink"
 )
 
 type GitDeployerSuite struct {
@@ -73,7 +73,7 @@ func (s *GitDeployerSuite) TestUpgrade(c *gc.C) {
 	info1 := s.bundles.AddCustomBundle(c, corecharm.MustParseURL("cs:s/c-1"), func(path string) {
 		err := ioutil.WriteFile(filepath.Join(path, "some-file"), []byte("hello"), 0644)
 		c.Assert(err, gc.IsNil)
-		err = os.Symlink("./some-file", filepath.Join(path, "a-symlink"))
+		err = symlink.New("./some-file", filepath.Join(path, "a-symlink"))
 		c.Assert(err, gc.IsNil)
 	})
 	err := s.deployer.Stage(info1, nil)
@@ -206,7 +206,7 @@ func checkCleanup(c *gc.C, d charm.Deployer) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(updateDirs, gc.HasLen, 1)
 	deployerCurrent := charm.GitDeployerCurrent(d)
-	current, err := os.Readlink(deployerCurrent.Path())
+	current, err := symlink.Read(deployerCurrent.Path())
 	c.Assert(err, gc.IsNil)
 	c.Assert(updateDirs[0], gc.Equals, current)
 

--- a/worker/uniter/tools.go
+++ b/worker/uniter/tools.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/juju/juju/worker/uniter/jujuc"
+	"github.com/juju/utils/symlink"
 )
 
 // EnsureJujucSymlinks creates a symbolic link to jujuc within dir for each
@@ -18,7 +19,7 @@ func EnsureJujucSymlinks(dir string) (err error) {
 		// The link operation fails when the target already exists,
 		// so this is a no-op when the command names already
 		// exist.
-		err := os.Symlink("./jujud", filepath.Join(dir, name))
+		err := symlink.New("./jujud", filepath.Join(dir, name))
 		if err == nil {
 			continue
 		}

--- a/worker/uniter/tools_test.go
+++ b/worker/uniter/tools_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/jujuc"
+	"github.com/juju/utils/symlink"
 )
 
 type ToolsSuite struct {
@@ -28,7 +29,7 @@ func (s *ToolsSuite) SetUpTest(c *gc.C) {
 	s.toolsDir = tools.SharedToolsDir(s.dataDir, version.Current)
 	err := os.MkdirAll(s.toolsDir, 0755)
 	c.Assert(err, gc.IsNil)
-	err = os.Symlink(s.toolsDir, tools.ToolsDir(s.dataDir, "unit-u-123"))
+	err = symlink.New(s.toolsDir, tools.ToolsDir(s.dataDir, "unit-u-123"))
 	c.Assert(err, gc.IsNil)
 }
 
@@ -38,7 +39,7 @@ func (s *ToolsSuite) TestEnsureJujucSymlinks(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	assertLink := func(path string) time.Time {
-		target, err := os.Readlink(path)
+		target, err := symlink.Read(path)
 		c.Assert(err, gc.IsNil)
 		c.Assert(target, gc.Equals, "./jujud")
 		fi, err := os.Lstat(path)

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -28,6 +28,7 @@ import (
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/upgrader"
+	"github.com/juju/utils/symlink"
 )
 
 func TestPackage(t *stdtesting.T) {
@@ -219,7 +220,7 @@ func (s *UpgraderSuite) TestChangeAgentTools(c *gc.C) {
 	}
 	err = ugErr.ChangeAgentTools()
 	c.Assert(err, gc.IsNil)
-	link, err := os.Readlink(agenttools.ToolsDir(s.DataDir(), "anAgent"))
+	link, err := symlink.Read(agenttools.ToolsDir(s.DataDir(), "anAgent"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(link, gc.Equals, newTools.Version.String())
 }


### PR DESCRIPTION
Symlinks are not supported by standard go os package on windows. Replaced all instances of os.Symlink() and os.Readlink() with symlink.New() and symlink.Read(). On linux these functions simply call os.Symlink() and os.Readlink(). On windows they use our implementation
