### PR TITLE
state/apiserver: Ensure we always listen to IPv4+IPv6

### DIFF
--- a/cmd/juju/ssh_test.go
+++ b/cmd/juju/ssh_test.go
@@ -57,7 +57,7 @@ func (s *SSHCommonSuite) SetUpTest(c *gc.C) {
 
 const (
 	noProxy           = `-o StrictHostKeyChecking no -o PasswordAuthentication no -o ServerAliveInterval 30 `
-	args              = `-o StrictHostKeyChecking no -o ProxyCommand juju ssh --proxy=false --pty=false 127.0.0.1 nc -q0 %h %p -o PasswordAuthentication no -o ServerAliveInterval 30 `
+	args              = `-o StrictHostKeyChecking no -o ProxyCommand juju ssh --proxy=false --pty=false localhost nc -q0 %h %p -o PasswordAuthentication no -o ServerAliveInterval 30 `
 	commonArgsNoProxy = noProxy + `-o UserKnownHostsFile /dev/null `
 	commonArgs        = args + `-o UserKnownHostsFile /dev/null `
 	sshArgs           = args + `-t -t -o UserKnownHostsFile /dev/null `

--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -481,7 +481,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				dataDir := agentConfig.DataDir()
 				logDir := agentConfig.LogDir()
 				return apiserver.NewServer(st, apiserver.ServerConfig{
-					Addr:      fmt.Sprintf(":%d", port),
+					Port:      port,
 					Cert:      cert,
 					Key:       key,
 					DataDir:   dataDir,

--- a/juju/apiconn_test.go
+++ b/juju/apiconn_test.go
@@ -206,7 +206,7 @@ func (s *NewAPIClientSuite) TestWithConfigAndNoInfo(c *gc.C) {
 	c.Assert(info, gc.NotNil)
 	ep := info.APIEndpoint()
 	c.Assert(ep.Addresses, gc.HasLen, 1)
-	c.Check(ep.Addresses[0], gc.Matches, `127\.0\.0\.1:\d+`)
+	c.Check(ep.Addresses[0], gc.Matches, `localhost:\d+`)
 	c.Check(ep.CACert, gc.Not(gc.Equals), "")
 	// Old servers won't hand back EnvironTag, so it should stay empty in
 	// the cache

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -642,7 +642,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 			panic(err)
 		}
 		estate.apiServer, err = apiserver.NewServer(st, apiserver.ServerConfig{
-			Addr:    "localhost:0",
+			Port:    0,
 			Cert:    []byte(testing.ServerCert),
 			Key:     []byte(testing.ServerKey),
 			DataDir: DataDir,

--- a/state/apiserver/login_test.go
+++ b/state/apiserver/login_test.go
@@ -61,7 +61,7 @@ func (s *loginSuite) setupServerWithValidator(c *gc.C, validator apiserver.Login
 	srv, err := apiserver.NewServer(
 		s.State,
 		apiserver.ServerConfig{
-			Addr:      "localhost:0",
+			Port:      0,
 			Cert:      []byte(coretesting.ServerCert),
 			Key:       []byte(coretesting.ServerKey),
 			Validator: validator,

--- a/state/apiserver/server_test.go
+++ b/state/apiserver/server_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/cert"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/api"
@@ -44,7 +45,7 @@ func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have
 	// a handle on it to stop it.
 	srv, err := apiserver.NewServer(s.State, apiserver.ServerConfig{
-		Addr: "localhost:0",
+		Port: 0,
 		Cert: []byte(coretesting.ServerCert),
 		Key:  []byte(coretesting.ServerKey),
 	})
@@ -88,6 +89,64 @@ func (s *serverSuite) TestStop(c *gc.C) {
 
 	// Check it can be stopped twice.
 	err = srv.Stop()
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
+	// Start our own instance of the server listening on
+	// both IPv4 and IPv6 localhost addresses and port 54321.
+	srv, err := apiserver.NewServer(s.State, apiserver.ServerConfig{
+		Port: 54321,
+		Cert: []byte(coretesting.ServerCert),
+		Key:  []byte(coretesting.ServerKey),
+	})
+	c.Assert(err, gc.IsNil)
+	defer srv.Stop()
+
+	// srv.Addr() always reports "localhost" as address.
+	// This way it can be used to construct URLs which
+	// will work for both IPv4 and IPv6-only networks,
+	// as localhost resolves as both 127.0.0.1 and ::1.
+	c.Assert(srv.Addr(), gc.Equals, "localhost:54321")
+
+	stm, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, gc.IsNil)
+	err = stm.SetProvisioned("foo", "fake_nonce", nil)
+	c.Assert(err, gc.IsNil)
+	password, err := utils.RandomPassword()
+	c.Assert(err, gc.IsNil)
+	err = stm.SetPassword(password)
+	c.Assert(err, gc.IsNil)
+
+	// Now connect twice - using IPv4 and IPv6 endpoints.
+	apiInfo := &api.Info{
+		Tag:      stm.Tag().String(),
+		Password: password,
+		Nonce:    "fake_nonce",
+		Addrs:    []string{net.JoinHostPort("127.0.0.1", "54321")},
+		CACert:   coretesting.CACert,
+	}
+	ipv4State, err := api.Open(apiInfo, fastDialOpts)
+	c.Assert(err, gc.IsNil)
+	defer ipv4State.Close()
+	c.Assert(ipv4State.Addr(), gc.Equals, "127.0.0.1:54321")
+	c.Assert(ipv4State.APIHostPorts(), jc.DeepEquals, [][]network.HostPort{
+		[]network.HostPort{{network.NewAddress("127.0.0.1", network.ScopeMachineLocal), 54321}},
+	})
+
+	_, err = ipv4State.Machiner().Machine(stm.Tag().String())
+	c.Assert(err, gc.IsNil)
+
+	apiInfo.Addrs = []string{net.JoinHostPort("::1", "54321")}
+	ipv6State, err := api.Open(apiInfo, fastDialOpts)
+	c.Assert(err, gc.IsNil)
+	defer ipv6State.Close()
+	c.Assert(ipv6State.Addr(), gc.Equals, "[::1]:54321")
+	c.Assert(ipv6State.APIHostPorts(), jc.DeepEquals, [][]network.HostPort{
+		[]network.HostPort{{network.NewAddress("::1", network.ScopeMachineLocal), 54321}},
+	})
+
+	_, err = ipv6State.Machiner().Machine(stm.Tag().String())
 	c.Assert(err, gc.IsNil)
 }
 
@@ -230,7 +289,7 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 	// we expose the API at '/' for compatibility, and at '/ENVUUID/api'
 	// for the correct location, but other Paths should fail.
 	srv, err := apiserver.NewServer(s.State, apiserver.ServerConfig{
-		Addr: "localhost:0",
+		Port: 0,
 		Cert: []byte(coretesting.ServerCert),
 		Key:  []byte(coretesting.ServerKey),
 	})


### PR DESCRIPTION
API server is now dual stack (IPv4+IPv6) capable, as it
listens on both 127.0.0.1 and ::1, and clients can connect
to it using both protocols. Added tests and some internal
details needed tweaking. Live tested on EC2.
