### PR TITLE
close file before renaming

### DIFF
--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -89,6 +89,8 @@ func (d *BundlesDir) download(info BundleInfo, abort <-chan struct{}) (err error
 			if err := os.MkdirAll(d.path, 0755); err != nil {
 				return err
 			}
+			// Renaming an open file is not possible on Windows
+			st.File.Close()
 			return os.Rename(st.File.Name(), d.bundlePath(info))
 		}
 	}


### PR DESCRIPTION
Renaming an open file is not possible on windows
