### PR TITLE
support for windows in ChangeAgentTools

### DIFF
--- a/agent/tools/diskmanager_test.go
+++ b/agent/tools/diskmanager_test.go
@@ -41,8 +41,8 @@ func (s *DiskManagerSuite) toolsDir() string {
 // Copied from environs/agent/tools_test.go
 func (s *DiskManagerSuite) TestUnpackToolsContents(c *gc.C) {
 	files := []*coretesting.TarFile{
-		coretesting.NewTarFile("bar", 0755, "bar contents"),
-		coretesting.NewTarFile("foo", 0755, "foo contents"),
+		coretesting.NewTarFile("bar", agenttools.DirPerm, "bar contents"),
+		coretesting.NewTarFile("foo", agenttools.DirPerm, "foo contents"),
 	}
 	gzfile, checksum := coretesting.TarGz(files...)
 	t1 := &coretools.Tools{
@@ -60,8 +60,8 @@ func (s *DiskManagerSuite) TestUnpackToolsContents(c *gc.C) {
 	// Try to unpack the same version of tools again - it should succeed,
 	// leaving the original version around.
 	files2 := []*coretesting.TarFile{
-		coretesting.NewTarFile("bar", 0755, "bar2 contents"),
-		coretesting.NewTarFile("x", 0755, "x contents"),
+		coretesting.NewTarFile("bar", agenttools.DirPerm, "bar2 contents"),
+		coretesting.NewTarFile("x", agenttools.DirPerm, "x contents"),
 	}
 	gzfile2, checksum2 := coretesting.TarGz(files2...)
 	t2 := &coretools.Tools{
@@ -105,5 +105,5 @@ func (s *DiskManagerSuite) assertToolsContents(c *gc.C, t *coretools.Tools, file
 	// juju-run)
 	info, err := os.Stat(dir)
 	c.Assert(err, gc.IsNil)
-	c.Assert(info.Mode().Perm(), gc.Equals, os.FileMode(0755))
+	c.Assert(info.Mode().Perm(), gc.Equals, os.FileMode(agenttools.DirPerm))
 }

--- a/agent/tools/export_test.go
+++ b/agent/tools/export_test.go
@@ -1,0 +1,20 @@
+package tools
+
+import (
+	"os"
+	"runtime"
+)
+
+func getDirPerm() os.FileMode {
+	// File permissions on windows yield diferent results then on Linux
+	// For example an os.FileMode of 0100 on a directory on Windows,
+	// will yield -r-xr-xr-x. os.FileMode of 0755 will yield -rwxrwxrwx
+	if runtime.GOOS == "windows" {
+		return os.FileMode(0777)
+	}
+	return os.FileMode(dirPerm)
+}
+
+var (
+	DirPerm = getDirPerm()
+)

--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -72,8 +72,8 @@ func initBadDataTest(name string, mode os.FileMode, contents string, err string)
 
 var unpackToolsBadDataTests = []badDataTest{
 	initBadDataTest("bar", os.ModeDir, "", "bad file type.*"),
-	initBadDataTest("../../etc/passwd", 0755, "", "bad name.*"),
-	initBadDataTest(`\ini.sys`, 0755, "", "bad name.*"),
+	initBadDataTest("../../etc/passwd", agenttools.DirPerm, "", "bad name.*"),
+	initBadDataTest(`\ini.sys`, agenttools.DirPerm, "", "bad name.*"),
 	badDataTest{[]byte("x"), "2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881", "unexpected EOF"},
 	badDataTest{gzyesses, "8d900c68a1a847aae4e95edcb29fcecd142c9b88ca4fe63209c216edbed546e1", "archive/tar: invalid tar header"},
 }
@@ -94,7 +94,7 @@ func (t *ToolsSuite) TestUnpackToolsBadData(c *gc.C) {
 }
 
 func (t *ToolsSuite) TestUnpackToolsBadChecksum(c *gc.C) {
-	data, _ := testing.TarGz(testing.NewTarFile("tools", 0755, "some data"))
+	data, _ := testing.TarGz(testing.NewTarFile("tools", agenttools.DirPerm, "some data"))
 	testTools := &coretest.Tools{
 		URL:     "http://foo/bar",
 		Version: version.MustParseBinary("1.2.3-foo-bar"),
@@ -113,8 +113,8 @@ func (t *ToolsSuite) toolsDir() string {
 
 func (t *ToolsSuite) TestUnpackToolsContents(c *gc.C) {
 	files := []*testing.TarFile{
-		testing.NewTarFile("bar", 0755, "bar contents"),
-		testing.NewTarFile("foo", 0755, "foo contents"),
+		testing.NewTarFile("bar", agenttools.DirPerm, "bar contents"),
+		testing.NewTarFile("foo", agenttools.DirPerm, "foo contents"),
 	}
 	data, checksum := testing.TarGz(files...)
 	testTools := &coretest.Tools{
@@ -132,8 +132,8 @@ func (t *ToolsSuite) TestUnpackToolsContents(c *gc.C) {
 	// Try to unpack the same version of tools again - it should succeed,
 	// leaving the original version around.
 	files2 := []*testing.TarFile{
-		testing.NewTarFile("bar", 0755, "bar2 contents"),
-		testing.NewTarFile("x", 0755, "x contents"),
+		testing.NewTarFile("bar", agenttools.DirPerm, "bar2 contents"),
+		testing.NewTarFile("x", agenttools.DirPerm, "x contents"),
 	}
 	data2, checksum2 := testing.TarGz(files2...)
 	tools2 := &coretest.Tools{
@@ -155,7 +155,7 @@ func (t *ToolsSuite) TestReadToolsErrors(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot read tools metadata in tools directory: .*")
 
 	dir := agenttools.SharedToolsDir(t.dataDir, vers)
-	err = os.MkdirAll(dir, 0755)
+	err = os.MkdirAll(dir, agenttools.DirPerm)
 	c.Assert(err, gc.IsNil)
 
 	err = ioutil.WriteFile(filepath.Join(dir, toolsFile), []byte(" \t\n"), 0644)
@@ -168,8 +168,8 @@ func (t *ToolsSuite) TestReadToolsErrors(c *gc.C) {
 
 func (t *ToolsSuite) TestChangeAgentTools(c *gc.C) {
 	files := []*testing.TarFile{
-		testing.NewTarFile("jujuc", 0755, "juju executable"),
-		testing.NewTarFile("jujud", 0755, "jujuc executable"),
+		testing.NewTarFile("jujuc", agenttools.DirPerm, "juju executable"),
+		testing.NewTarFile("jujud", agenttools.DirPerm, "jujuc executable"),
 	}
 	data, checksum := testing.TarGz(files...)
 	testTools := &coretest.Tools{
@@ -190,8 +190,8 @@ func (t *ToolsSuite) TestChangeAgentTools(c *gc.C) {
 
 	// Upgrade again to check that the link replacement logic works ok.
 	files2 := []*testing.TarFile{
-		testing.NewTarFile("foo", 0755, "foo content"),
-		testing.NewTarFile("bar", 0755, "bar content"),
+		testing.NewTarFile("foo", agenttools.DirPerm, "foo content"),
+		testing.NewTarFile("bar", agenttools.DirPerm, "bar content"),
 	}
 	data2, checksum2 := testing.TarGz(files2...)
 	tools2 := &coretest.Tools{

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -16,9 +16,9 @@ github.com/juju/loggo	git	158009fb40c4a52b3d2c23eb56e72859cfc5321a
 github.com/juju/names	git	f5d3d5383b5db0be3eebc5e0dfc0137f5231331d	
 github.com/juju/ratelimit	git	0025ab75db6c6eaa4ffff0240c2c9e617ad1a0eb	
 github.com/juju/schema	git	1887e824896b58a0f376fb8517b5eebb825828b8	
-github.com/juju/testing	git	28630f9533464203581e6b370ff17f30a8918019	
+github.com/juju/testing	git	139004c3438161f07e827fcb2b0872383d565923	
 github.com/juju/txn	git	5694f17794c492e3c8a83908f0e8b9a7cff9b9f8	
-github.com/juju/utils	git	317bba9af21723b32ccb16eb8c74f966469377a2	
+github.com/juju/utils	git	50eeabd5339fb7197fc5089633b4fcfe926f8f52	
 labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20121003093437-zcyyw0lpvj2nifpk	12
 launchpad.net/goamz	bzr	ian.booth@canonical.com-20140708164959-72q70lo1du0e4qki	48

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -209,7 +209,8 @@ func (s *UpgraderSuite) TestChangeAgentTools(c *gc.C) {
 		Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 	}
 	stor := s.Environ.Storage()
-	newTools := envtesting.PrimeTools(c, stor, s.DataDir(), version.MustParseBinary("5.4.3-precise-amd64"))
+	newToolsBinary := "5.4.3-precise-amd64"
+	newTools := envtesting.PrimeTools(c, stor, s.DataDir(), version.MustParseBinary(newToolsBinary))
 	s.PatchValue(&version.Current, newTools.Version)
 	err := envtools.MergeAndWriteMetadata(stor, coretools.List{newTools}, envtools.DoNotWriteMirrors)
 	c.Assert(err, gc.IsNil)
@@ -221,9 +222,10 @@ func (s *UpgraderSuite) TestChangeAgentTools(c *gc.C) {
 	}
 	err = ugErr.ChangeAgentTools()
 	c.Assert(err, gc.IsNil)
+	target := agenttools.ToolsDir(s.DataDir(), newToolsBinary)
 	link, err := symlink.Read(agenttools.ToolsDir(s.DataDir(), "anAgent"))
 	c.Assert(err, gc.IsNil)
-	c.Assert(link, gc.Equals, newTools.Version.String())
+	c.Assert(link, gc.Equals, target)
 }
 
 func (s *UpgraderSuite) TestEnsureToolsChecksBeforeDownloading(c *gc.C) {


### PR DESCRIPTION
The windows Symlink function checks for the existance of the source file before creating a symlink. If it cannot stat the file, then it errors. This is a limitation of how junction points work. You may not create a junction point (symlink) to an inexistent file.
