### PR TITLE
juju/testing: do not tear down connection if setup fails

### DIFF
--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -279,6 +279,7 @@ func (s *JujuConnSuite) tearDownConn(c *gc.C) {
 			c.Assert(err, gc.IsNil)
 		}
 	}
+	s.apiStates = nil
 	if s.Conn != nil {
 		err := s.Conn.Close()
 		if serverAlive {
@@ -291,7 +292,7 @@ func (s *JujuConnSuite) tearDownConn(c *gc.C) {
 		if serverAlive {
 			c.Assert(err, gc.IsNil)
 		}
-		s.apiStates = nil
+		s.APIConn = nil
 	}
 	dummy.Reset()
 	utils.SetHome(s.oldHome)


### PR DESCRIPTION
Our test suite helpers are a double edged sword. They tend to expect the best, and blow up when the worst happens. This change is an example of this, if the setup phase failed, then what was a c.Assert("couldn't talk to mongo") becomes a panic when the tear down phase tries to close a connection which was never opened.
