### PR TITLE
worker/uniter: fix racy test

### DIFF
--- a/worker/uniter/filter_test.go
+++ b/worker/uniter/filter_test.go
@@ -460,6 +460,7 @@ func (s *FilterSuite) TestConfigAndAddressEventsDiscarded(c *gc.C) {
 
 	// We should not receive any config-change events.
 	s.BackingState.StartSync()
+	time.Sleep(250 * time.Millisecond)
 	f.DiscardConfigEvent()
 	select {
 	case <-f.ConfigEvents():


### PR DESCRIPTION
Test needs to wait for events to coalesce
before asserting that they are both discarded.
