### PR TITLE
Ports document now used to store opened ports for machine/network tuple.

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -11,6 +11,12 @@ import (
 
 var logger = loggo.GetLogger("juju.network")
 
+// Id of the default public juju network
+const DefaultPublic = "juju-public"
+
+// Id of the default private juju network
+const DefaultPrivate = "juju-private"
+
 // Id defines a provider-specific network id.
 type Id string
 

--- a/state/api/firewaller/unit_test.go
+++ b/state/api/firewaller/unit_test.go
@@ -103,13 +103,13 @@ func (s *unitSuite) TestOpenedPorts(c *gc.C) {
 	c.Assert(ports, jc.DeepEquals, []network.Port{})
 
 	// Open some ports and check again.
-	err = s.units[0].OpenPort("foo", 1234)
+	err = s.units[0].OpenPort("tcp", 1234)
 	c.Assert(err, gc.IsNil)
-	err = s.units[0].OpenPort("bar", 4321)
+	err = s.units[0].OpenPort("tcp", 4321)
 	c.Assert(err, gc.IsNil)
 	ports, err = s.apiUnit.OpenedPorts()
 	c.Assert(err, gc.IsNil)
-	c.Assert(ports, jc.DeepEquals, []network.Port{{"bar", 4321}, {"foo", 1234}})
+	c.Assert(ports, jc.DeepEquals, []network.Port{{"tcp", 1234}, {"tcp", 4321}})
 }
 
 func (s *unitSuite) TestService(c *gc.C) {

--- a/state/api/uniter/unit_test.go
+++ b/state/api/uniter/unit_test.go
@@ -230,21 +230,9 @@ func (s *unitSuite) TestOpenClosePort(c *gc.C) {
 	ports := s.wordpressUnit.OpenedPorts()
 	c.Assert(ports, gc.HasLen, 0)
 
-	err := s.apiUnit.OpenPort("foo", 1234)
+	err := s.apiUnit.OpenPort("tcp", 1234)
 	c.Assert(err, gc.IsNil)
-	err = s.apiUnit.OpenPort("bar", 4321)
-	c.Assert(err, gc.IsNil)
-
-	err = s.wordpressUnit.Refresh()
-	c.Assert(err, gc.IsNil)
-	ports = s.wordpressUnit.OpenedPorts()
-	// OpenedPorts returns a sorted slice.
-	c.Assert(ports, gc.DeepEquals, []network.Port{
-		{Protocol: "bar", Number: 4321},
-		{Protocol: "foo", Number: 1234},
-	})
-
-	err = s.apiUnit.ClosePort("bar", 4321)
+	err = s.apiUnit.OpenPort("tcp", 4321)
 	c.Assert(err, gc.IsNil)
 
 	err = s.wordpressUnit.Refresh()
@@ -252,10 +240,22 @@ func (s *unitSuite) TestOpenClosePort(c *gc.C) {
 	ports = s.wordpressUnit.OpenedPorts()
 	// OpenedPorts returns a sorted slice.
 	c.Assert(ports, gc.DeepEquals, []network.Port{
-		{Protocol: "foo", Number: 1234},
+		{Protocol: "tcp", Number: 1234},
+		{Protocol: "tcp", Number: 4321},
 	})
 
-	err = s.apiUnit.ClosePort("foo", 1234)
+	err = s.apiUnit.ClosePort("tcp", 4321)
+	c.Assert(err, gc.IsNil)
+
+	err = s.wordpressUnit.Refresh()
+	c.Assert(err, gc.IsNil)
+	ports = s.wordpressUnit.OpenedPorts()
+	// OpenedPorts returns a sorted slice.
+	c.Assert(ports, gc.DeepEquals, []network.Port{
+		{Protocol: "tcp", Number: 1234},
+	})
+
+	err = s.apiUnit.ClosePort("tcp", 1234)
 	c.Assert(err, gc.IsNil)
 
 	err = s.wordpressUnit.Refresh()

--- a/state/apiserver/firewaller/firewaller_test.go
+++ b/state/apiserver/firewaller/firewaller_test.go
@@ -327,11 +327,11 @@ func (s *firewallerSuite) TestGetExposed(c *gc.C) {
 
 func (s *firewallerSuite) TestOpenedPorts(c *gc.C) {
 	// Open some ports on two of the units.
-	err := s.units[0].OpenPort("foo", 1234)
+	err := s.units[0].OpenPort("tcp", 1234)
 	c.Assert(err, gc.IsNil)
-	err = s.units[0].OpenPort("bar", 4321)
+	err = s.units[0].OpenPort("tcp", 4321)
 	c.Assert(err, gc.IsNil)
-	err = s.units[2].OpenPort("baz", 1111)
+	err = s.units[2].OpenPort("tcp", 1111)
 	c.Assert(err, gc.IsNil)
 
 	args := addFakeEntities(params.Entities{Entities: []params.Entity{
@@ -343,9 +343,9 @@ func (s *firewallerSuite) TestOpenedPorts(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, jc.DeepEquals, params.PortsResults{
 		Results: []params.PortsResult{
-			{Ports: []network.Port{{"bar", 4321}, {"foo", 1234}}},
+			{Ports: []network.Port{{"tcp", 1234}, {"tcp", 4321}}},
 			{Ports: []network.Port{}},
-			{Ports: []network.Port{{"baz", 1111}}},
+			{Ports: []network.Port{{"tcp", 1111}}},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.NotFoundError(`unit "foo/0"`)},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -356,7 +356,7 @@ func (s *firewallerSuite) TestOpenedPorts(c *gc.C) {
 	})
 
 	// Now close unit 2's port and check again.
-	err = s.units[2].ClosePort("baz", 1111)
+	err = s.units[2].ClosePort("tcp", 1111)
 	c.Assert(err, gc.IsNil)
 
 	args = params.Entities{Entities: []params.Entity{

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -227,3 +227,8 @@ func EnsureActionMarker(prefix string) string {
 func GetActionResultId(actionId string) (string, bool) {
 	return convertActionIdToActionResultId(actionId)
 }
+
+var (
+	GetOrCreatePorts = getOrCreatePorts
+	GetPorts         = getPorts
+)

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -361,11 +361,11 @@ var allWatcherChangedTests = []struct {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, gc.IsNil)
-			err = u.OpenPort("tcp", 12345)
-			c.Assert(err, gc.IsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, gc.IsNil)
 			err = u.AssignToMachine(m)
+			c.Assert(err, gc.IsNil)
+			err = u.OpenPort("tcp", 12345)
 			c.Assert(err, gc.IsNil)
 			err = u.SetStatus(params.StatusError, "failure", nil)
 			c.Assert(err, gc.IsNil)
@@ -396,6 +396,10 @@ var allWatcherChangedTests = []struct {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, gc.IsNil)
+			m, err := st.AddMachine("quantal", JobHostUnits)
+			c.Assert(err, gc.IsNil)
+			err = u.AssignToMachine(m)
+			c.Assert(err, gc.IsNil)
 			err = u.OpenPort("udp", 17070)
 			c.Assert(err, gc.IsNil)
 		},
@@ -408,6 +412,7 @@ var allWatcherChangedTests = []struct {
 				Name:       "wordpress/0",
 				Service:    "wordpress",
 				Series:     "quantal",
+				MachineId:  "0",
 				Ports:      []network.Port{{"udp", 17070}},
 				Status:     params.StatusError,
 				StatusInfo: "another failure",
@@ -419,11 +424,11 @@ var allWatcherChangedTests = []struct {
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			u, err := wordpress.AddUnit()
 			c.Assert(err, gc.IsNil)
-			err = u.OpenPort("tcp", 12345)
-			c.Assert(err, gc.IsNil)
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, gc.IsNil)
 			err = u.AssignToMachine(m)
+			c.Assert(err, gc.IsNil)
+			err = u.OpenPort("tcp", 12345)
 			c.Assert(err, gc.IsNil)
 			publicAddress := network.NewAddress("public", network.ScopePublic)
 			privateAddress := network.NewAddress("private", network.ScopeCloudLocal)

--- a/state/open.go
+++ b/state/open.go
@@ -219,6 +219,7 @@ func newState(session *mgo.Session, mongoInfo *authentication.MongoInfo, policy 
 		annotations:       db.C("annotations"),
 		statuses:          db.C("statuses"),
 		stateServers:      db.C("stateServers"),
+		openedPorts:       db.C("openedPorts"),
 	}
 	log := db.C("txns.log")
 	logInfo := mgo.CollectionInfo{Capped: true, MaxBytes: logSize}

--- a/state/ports.go
+++ b/state/ports.go
@@ -1,0 +1,443 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	statetxn "github.com/juju/txn"
+	"labix.org/v2/mgo"
+	"labix.org/v2/mgo/bson"
+	"labix.org/v2/mgo/txn"
+
+	"github.com/juju/juju/network"
+)
+
+var portLogger = loggo.GetLogger("juju.state.ports")
+
+// A regular expression for parsing ports document id into
+// corresponding machine and network ids.
+var portsIdRe = regexp.MustCompile(fmt.Sprintf("m#(?P<machine>%s)#n#(?P<network>%s)$", names.MachineSnippet, names.NetworkSnippet))
+
+type portIdPart int
+
+const (
+	fullId portIdPart = iota
+	machineIdPart
+	networkIdPart
+)
+
+// PortRange represents a single range of ports opened
+// by one unit.
+type PortRange struct {
+	UnitName string
+	FromPort int
+	ToPort   int
+	Protocol string
+}
+
+// NewPortRange create a new port range.
+func NewPortRange(unitName string, fromPort, toPort int, protocol string) (PortRange, error) {
+	p := PortRange{
+		UnitName: unitName,
+		FromPort: fromPort,
+		ToPort:   toPort,
+		Protocol: strings.ToLower(protocol),
+	}
+	if !p.IsValid() {
+		return PortRange{}, fmt.Errorf("Port range %v for unit %v is invalid.", p, unitName)
+	}
+	return p, nil
+}
+
+// IsValid checks if the port range is valid.
+func (p PortRange) IsValid() bool {
+	proto := strings.ToLower(p.Protocol)
+	if proto != "tcp" && proto != "udp" {
+		return false
+	}
+	if !names.IsUnit(p.UnitName) {
+		return false
+	}
+	return p.FromPort <= p.ToPort
+}
+
+// ConflictsWith determines if the two port ranges conflict.
+func (a PortRange) ConflictsWith(b PortRange) bool {
+	if a.Protocol != b.Protocol {
+		return false
+	}
+	switch {
+	case a.FromPort >= b.FromPort && a.FromPort <= b.ToPort:
+		return true
+	case a.ToPort >= b.FromPort && a.ToPort <= b.ToPort:
+		return true
+	case a.FromPort <= b.FromPort && a.ToPort >= b.ToPort:
+		return true
+	}
+
+	return false
+}
+
+func (p PortRange) String() string {
+	return fmt.Sprintf("%d-%d/%s", p.FromPort, p.ToPort, strings.ToLower(p.Protocol))
+}
+
+// portsDoc represents the state of ports opened on machines for networks
+type portsDoc struct {
+	Id       string `bson:"_id"`
+	Ports    []PortRange
+	TxnRevno int64 `bson:"txn-revno"`
+}
+
+// Ports represents the state of ports on a machine.
+type Ports struct {
+	st  *State
+	doc portsDoc
+	// indicator for documents not in state yet
+	new bool
+}
+
+// Id returns the id of the ports document.
+func (p *Ports) Id() string {
+	return p.doc.Id
+}
+
+// Check if a port range can be opened.
+func (p *Ports) canOpenPorts(newPorts PortRange) bool {
+	for _, existingPorts := range p.doc.Ports {
+		if existingPorts.ConflictsWith(newPorts) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *Ports) extractPortIdPart(part portIdPart) (string, error) {
+	if part < 0 || part > 2 {
+		return "", fmt.Errorf("invalid ports document name part: %v", part)
+	}
+	if parts := portsIdRe.FindStringSubmatch(p.doc.Id); len(parts) == 3 {
+		return parts[part], nil
+	}
+	return "", fmt.Errorf("invalid ports document name: %v", p.doc.Id)
+}
+
+// MachineId returns the machine id associated with this port document.
+func (p *Ports) MachineId() (string, error) {
+	return p.extractPortIdPart(machineIdPart)
+}
+
+// NetworkName returns the network name associated with this port document.
+func (p *Ports) NetworkName() (string, error) {
+	return p.extractPortIdPart(networkIdPart)
+}
+
+// OpenPorts adds the specified port range to the ports maintained by this document.
+func (p *Ports) OpenPorts(portRange PortRange) error {
+	if !portRange.IsValid() {
+		return fmt.Errorf("port range %v is invalid", portRange)
+	}
+	ports := Ports{st: p.st, doc: p.doc, new: p.new}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		machineId, err := ports.MachineId()
+		if err != nil {
+			return nil, err
+		}
+
+		if attempt > 0 {
+			if err := ports.Refresh(); errors.IsNotFound(err) {
+				// the ports document no longer exists
+				if !ports.new {
+					return nil, fmt.Errorf("ports document not found for machine %v", machineId)
+				}
+			} else if err != nil {
+				return nil, err
+			} else if ports.new {
+				// the ports document was created by somebody else
+				ports.new = false
+			}
+		}
+
+		if !ports.canOpenPorts(portRange) {
+			return nil, fmt.Errorf("cannot open ports %v on machine %v due to conflict", portRange, machineId)
+		}
+
+		// a new ports document being created
+		if ports.new {
+			return addPortsDocOps(ports.st,
+				machineId,
+				portRange), nil
+		}
+		ops := []txn.Op{{
+			C:      ports.st.units.Name,
+			Id:     portRange.UnitName,
+			Assert: notDeadDoc,
+		}, {
+			C:      ports.st.machines.Name,
+			Id:     machineId,
+			Assert: notDeadDoc,
+		}, {
+			C:      ports.st.openedPorts.Name,
+			Id:     ports.Id(),
+			Assert: bson.D{{"txn-revno", ports.doc.TxnRevno}},
+			Update: bson.D{{"$addToSet", bson.D{{"ports", portRange}}}},
+		}}
+		return ops, nil
+	}
+	// Run the transaction using the state transaction runner.
+	err := p.st.run(buildTxn)
+	if err != nil {
+		return err
+	}
+	// Mark object as created.
+	p.new = false
+	return nil
+}
+
+// ClosePorts removes the specified port range from this document.
+func (p *Ports) ClosePorts(portRange PortRange) error {
+	ports := Ports{st: p.st, doc: p.doc, new: p.new}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := ports.Refresh(); errors.IsNotFound(err) {
+				return nil, statetxn.ErrNoOperations
+			} else if err != nil {
+				return nil, err
+			}
+		}
+		newPorts := []PortRange{}
+		// Create a list of ports with the specified port
+		// removed. This still relies on the assumption that
+		// we are not storing actual port ranges.
+		// TODO(domas) 2014-07-04 bug #1337817: update this section to deal with actual port ranges.
+		found := false
+		for _, existingPortsDef := range ports.doc.Ports {
+			if existingPortsDef == portRange {
+				found = true
+				continue
+			}
+			newPorts = append(newPorts, existingPortsDef)
+		}
+		if !found {
+			return nil, fmt.Errorf("no match found for port range: %v", portRange)
+		}
+		ops := []txn.Op{{
+			C:      ports.st.units.Name,
+			Id:     portRange.UnitName,
+			Assert: notDeadDoc,
+		}, {
+			C:      ports.st.openedPorts.Name,
+			Id:     ports.Id(),
+			Assert: bson.D{{"txn-revno", ports.doc.TxnRevno}},
+			Update: bson.D{{"$set", bson.D{{"ports", newPorts}}}},
+		}}
+		return ops, nil
+	}
+	return p.st.run(buildTxn)
+}
+
+// migratePorts migrates old-style unit ports collection to the ports document.
+func (p *Ports) migratePorts(u *Unit) error {
+	ports := Ports{st: p.st, doc: p.doc, new: p.new}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		machineId, err := ports.MachineId()
+		if err != nil {
+			return nil, err
+		}
+
+		if attempt > 0 {
+			if err := ports.Refresh(); errors.IsNotFound(err) {
+				// the ports document no longer exists
+				if !ports.new {
+					return nil, fmt.Errorf("ports document not found for machine %v", machineId)
+				}
+			} else if err != nil {
+				return nil, err
+			} else if ports.new {
+				// the ports document was created by somebody else
+				ports.new = false
+			}
+		}
+
+		migratedPorts := make([]PortRange, len(u.doc.Ports))
+		for i, port := range u.doc.Ports {
+			portDef, err := NewPortRange(u.Name(), port.Number, port.Number, port.Protocol)
+			if err != nil {
+				return nil, fmt.Errorf("cannot migrate port %v: %v", port, err)
+			}
+			if !ports.canOpenPorts(portDef) {
+				return nil, fmt.Errorf("cannot migrate port %v due to conflict", port)
+			}
+			migratedPorts[i] = portDef
+		}
+
+		// a new ports document being created
+		if ports.new {
+			return addPortsDocOps(ports.st, machineId, migratedPorts...), nil
+		}
+
+		// updating existing ports document
+		var ops []txn.Op
+
+		ops = append(ops, txn.Op{
+			C:      ports.st.machines.Name,
+			Id:     machineId,
+			Assert: isAliveDoc,
+		})
+
+		for _, portDef := range migratedPorts {
+			ops = append(ops, txn.Op{
+				C:      ports.st.openedPorts.Name,
+				Id:     ports.Id(),
+				Update: bson.D{{"$addToSet", bson.D{{"ports", portDef}}}},
+			})
+		}
+
+		// TODO(domas) 2014-07-04 bug #1337813: Clear the old port collection on the unit document
+		// once the firewaller no longer depends on the unit ports list.
+		return ops, nil
+	}
+	err := p.st.run(buildTxn)
+	if err != nil {
+		return err
+	}
+
+	p.new = false
+	return nil
+}
+
+// PortsForUnit returns the ports associated with specified unit
+// that are maintained on this document (i.e. are open on this unit's
+// assigned machine).
+func (p *Ports) PortsForUnit(unit string) []PortRange {
+	ports := []PortRange{}
+	for _, port := range p.doc.Ports {
+		if port.UnitName == unit {
+			ports = append(ports, port)
+		}
+	}
+	return ports
+}
+
+// Refresh refreshes the port document from state.
+func (p *Ports) Refresh() error {
+	err := p.st.openedPorts.FindId(p.Id()).One(&p.doc)
+	if err == mgo.ErrNotFound {
+		return errors.NotFoundf("ports document %v", p.Id())
+	} else if err != nil {
+		return fmt.Errorf("cannot refresh ports %v: %v", p.Id(), err)
+	}
+	return nil
+}
+
+// Remove removes the ports document from state.
+func (p *Ports) Remove() error {
+	prts := &Ports{st: p.st, doc: p.doc}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			err := prts.Refresh()
+			if errors.IsNotFound(err) {
+				return nil, statetxn.ErrNoOperations
+			} else if err != nil {
+				return nil, err
+			}
+		}
+		ops := prts.removeOps()
+		return ops, nil
+	}
+	return p.st.run(buildTxn)
+}
+
+// removeOps returns the ops for removing the ports document from mongo.
+func (p *Ports) removeOps() []txn.Op {
+	return []txn.Op{{
+		C:      p.st.openedPorts.Name,
+		Id:     p.Id(),
+		Remove: true,
+	}}
+}
+
+// OpenedPorts returns ports documents associated with specified machine.
+func (m *Machine) OpenedPorts(st *State) ([]*Ports, error) {
+	idRegex := fmt.Sprintf("m#%s#n#.*", m.Id())
+	docs := []portsDoc{}
+	err := st.openedPorts.Find(bson.M{"_id": bson.M{"$regex": idRegex}}).All(&docs)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]*Ports, len(docs))
+	for i, doc := range docs {
+		results[i] = &Ports{st: st, doc: doc}
+	}
+	return results, nil
+}
+
+// portsDocId generates the id of a ports document given the machine id and network name.
+func portsDocId(machineId string, networkName string) string {
+	return fmt.Sprintf("m#%s#n#%s", machineId, networkName)
+}
+
+func addPortsDocOps(st *State,
+	// TODO(domas) 2014-07-04 bug #1337804: network id is hard-coded until multiple network support lands.
+	//network string,
+	machineId string,
+	ports ...PortRange) []txn.Op {
+
+	id := portsDocId(machineId, network.DefaultPublic)
+
+	ops := []txn.Op{{
+		C:      st.machines.Name,
+		Id:     machineId,
+		Assert: notDeadDoc,
+	}, {
+		C:      st.openedPorts.Name,
+		Id:     id,
+		Assert: txn.DocMissing,
+		Insert: portsDoc{Id: id, Ports: ports},
+	}}
+	return ops
+}
+
+// getPorts returns the ports document for the specified
+// machine and network.
+func getPorts(st *State,
+	// TODO(domas) 2014-07-04 bug #1337804: network is hardcoded until multiple network support lands.
+	// networkName string,
+	machineId string) (*Ports, error) {
+	var doc portsDoc
+	id := portsDocId(machineId, network.DefaultPublic)
+	err := st.openedPorts.FindId(id).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("ports document for machine %v", machineId)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve ports document for machine %v: %v",
+			machineId, err)
+	}
+
+	return &Ports{st, doc, false}, nil
+}
+
+// getOrCreatePorts attempts to retrieve a ports document
+// and returns a newly created one if it does not exist.
+func getOrCreatePorts(st *State,
+	// Network is hardcoded until multiple network
+	// support lands.
+	//network string,
+	machineId string) (*Ports, error) {
+	ports, err := getPorts(st, machineId)
+	if errors.IsNotFound(err) {
+		doc := portsDoc{Id: portsDocId(machineId, network.DefaultPublic)}
+		ports = &Ports{st, doc, true}
+	} else if err != nil {
+		return nil, err
+	}
+	return ports, nil
+}

--- a/state/ports_test.go
+++ b/state/ports_test.go
@@ -1,0 +1,242 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/state"
+)
+
+type PortsDocSuite struct {
+	ConnSuite
+	charm   *state.Charm
+	service *state.Service
+	unit    *state.Unit
+	machine *state.Machine
+	ports   *state.Ports
+}
+
+var _ = gc.Suite(&PortsDocSuite{})
+
+func (s *PortsDocSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+	s.charm = s.AddTestingCharm(c, "wordpress")
+	var err error
+	s.service = s.AddTestingService(c, "wordpress", s.charm)
+	c.Assert(err, gc.IsNil)
+	s.unit, err = s.service.AddUnit()
+	c.Assert(err, gc.IsNil)
+	s.machine, err = s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, gc.IsNil)
+	err = s.unit.AssignToMachine(s.machine)
+	c.Assert(err, gc.IsNil)
+
+	s.ports, err = state.GetOrCreatePorts(s.State, s.machine.Id())
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.ports, gc.NotNil)
+}
+
+func (s *PortsDocSuite) TestCreatePorts(c *gc.C) {
+	ports, err := state.GetOrCreatePorts(s.State, s.machine.Id())
+	c.Assert(err, gc.IsNil)
+	c.Assert(ports, gc.NotNil)
+	err = ports.OpenPorts(state.PortRange{
+		FromPort: 100,
+		ToPort:   200,
+		UnitName: s.unit.Name(),
+		Protocol: "TCP",
+	})
+	c.Assert(err, gc.IsNil)
+
+	ports, err = state.GetPorts(s.State, s.machine.Id())
+	c.Assert(err, gc.IsNil)
+	c.Assert(ports, gc.NotNil)
+
+	c.Assert(ports.PortsForUnit(s.unit.Name()), gc.HasLen, 1)
+}
+
+func (s *PortsDocSuite) TestOpenAndClosePorts(c *gc.C) {
+	portRange := state.PortRange{
+		FromPort: 100,
+		ToPort:   200,
+		UnitName: s.unit.Name(),
+		Protocol: "TCP",
+	}
+	err := s.ports.OpenPorts(portRange)
+	c.Assert(err, gc.IsNil)
+
+	err = s.ports.Refresh()
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.ports.PortsForUnit(s.unit.Name()), gc.HasLen, 1)
+
+	err = s.ports.ClosePorts(portRange)
+	c.Assert(err, gc.IsNil)
+
+	err = s.ports.Refresh()
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.ports.PortsForUnit(s.unit.Name()), gc.HasLen, 0)
+}
+
+func (s *PortsDocSuite) TestOpenInvalidRange(c *gc.C) {
+	portRange := state.PortRange{
+		FromPort: 400,
+		ToPort:   200,
+		UnitName: s.unit.Name(),
+		Protocol: "TCP",
+	}
+	err := s.ports.OpenPorts(portRange)
+	c.Assert(err, gc.ErrorMatches, "port range .* is invalid")
+}
+
+func (s *PortsDocSuite) TestCloseInvalidRange(c *gc.C) {
+	portRange := state.PortRange{
+		FromPort: 100,
+		ToPort:   200,
+		UnitName: s.unit.Name(),
+		Protocol: "TCP",
+	}
+	err := s.ports.OpenPorts(portRange)
+	c.Assert(err, gc.IsNil)
+
+	err = s.ports.ClosePorts(state.PortRange{
+		FromPort: 150,
+		ToPort:   200,
+		UnitName: s.unit.Name(),
+		Protocol: "TCP",
+	})
+	c.Assert(err, gc.ErrorMatches, "no match found for port range: .*")
+}
+
+func (s *PortsDocSuite) TestRemovePortsDoc(c *gc.C) {
+	portRange := state.PortRange{
+		FromPort: 100,
+		ToPort:   200,
+		UnitName: s.unit.Name(),
+		Protocol: "TCP",
+	}
+	err := s.ports.OpenPorts(portRange)
+	c.Assert(err, gc.IsNil)
+
+	ports, err := state.GetPorts(s.State, s.machine.Id())
+	c.Assert(err, gc.IsNil)
+	c.Assert(ports, gc.NotNil)
+
+	allPorts, err := s.machine.OpenedPorts(s.State)
+	c.Assert(err, gc.IsNil)
+
+	for _, prt := range allPorts {
+		err := prt.Remove()
+		c.Assert(err, gc.IsNil)
+	}
+
+	ports, err = state.GetPorts(s.State, s.machine.Id())
+	c.Assert(ports, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "ports document for machine .* not found")
+}
+
+type PortRangeSuite struct{}
+
+var _ = gc.Suite(&PortRangeSuite{})
+
+func (p *PortRangeSuite) TestPortRangeConflicts(c *gc.C) {
+	var testCases = []struct {
+		about          string
+		first          state.PortRange
+		second         state.PortRange
+		expectConflict bool
+	}{{
+		"identical ports",
+		state.PortRange{"wordpress/0", 80, 80, "TCP"},
+		state.PortRange{"wordpress/0", 80, 80, "TCP"},
+		true,
+	}, {
+		"different ports",
+		state.PortRange{"wordpress/0", 80, 80, "TCP"},
+		state.PortRange{"wordpress/0", 90, 90, "TCP"},
+		false,
+	}, {
+		"touching ranges",
+		state.PortRange{"wordpress/0", 100, 200, "TCP"},
+		state.PortRange{"wordpress/0", 201, 240, "TCP"},
+		false,
+	}, {
+		"touching ranges with overlap",
+		state.PortRange{"wordpress/0", 100, 200, "TCP"},
+		state.PortRange{"wordpress/0", 200, 240, "TCP"},
+		true,
+	}, {
+		"different protocols",
+		state.PortRange{"wordpress/0", 80, 80, "UDP"},
+		state.PortRange{"wordpress/0", 80, 80, "TCP"},
+		false,
+	}, {
+		"outside range",
+		state.PortRange{"wordpress/0", 100, 200, "TCP"},
+		state.PortRange{"wordpress/0", 80, 80, "TCP"},
+		false,
+	}, {
+		"overlap end",
+		state.PortRange{"wordpress/0", 100, 200, "TCP"},
+		state.PortRange{"wordpress/0", 80, 120, "TCP"},
+		true,
+	}, {
+		"complete overlap",
+		state.PortRange{"wordpress/0", 100, 200, "TCP"},
+		state.PortRange{"wordpress/0", 120, 140, "TCP"},
+		true,
+	}}
+
+	for i, t := range testCases {
+		c.Logf("test %d: %s", i, t.about)
+		c.Check(t.first.ConflictsWith(t.second), gc.Equals, t.expectConflict)
+		c.Check(t.second.ConflictsWith(t.first), gc.Equals, t.expectConflict)
+	}
+}
+
+func (p *PortRangeSuite) TestPortRangeString(c *gc.C) {
+	c.Assert(state.PortRange{"wordpress/0", 80, 80, "TCP"}.String(),
+		gc.Equals,
+		"80-80/tcp")
+	c.Assert(state.PortRange{"wordpress/0", 80, 100, "TCP"}.String(),
+		gc.Equals,
+		"80-100/tcp")
+}
+
+func (p *PortRangeSuite) TestPortRangeValidity(c *gc.C) {
+	testCases := []struct {
+		about string
+		ports state.PortRange
+		valid bool
+	}{{
+		"single valid port",
+		state.PortRange{"wordpress/0", 80, 80, "tcp"},
+		true,
+	}, {
+		"valid port range",
+		state.PortRange{"wordpress/0", 80, 90, "tcp"},
+		true,
+	}, {
+		"valid udp port range",
+		state.PortRange{"wordpress/0", 80, 90, "UDP"},
+		true,
+	}, {
+		"invalid port range boundaries",
+		state.PortRange{"wordpress/0", 90, 80, "tcp"},
+		false,
+	}, {
+		"invalid protocol",
+		state.PortRange{"wordpress/0", 80, 80, "some protocol"},
+		false,
+	}, {
+		"invalid unit",
+		state.PortRange{"invalid unit", 80, 80, "tcp"},
+		false,
+	}}
+
+	for i, t := range testCases {
+		c.Logf("test %d: %s", i, t.about)
+		c.Assert(t.ports.IsValid(), gc.Equals, t.valid)
+	}
+}

--- a/state/state.go
+++ b/state/state.go
@@ -74,6 +74,7 @@ type State struct {
 	annotations       *mgo.Collection
 	statuses          *mgo.Collection
 	stateServers      *mgo.Collection
+	openedPorts       *mgo.Collection
 	watcher           *watcher.Watcher
 	pwatcher          *presence.Watcher
 	// mu guards allManager.

--- a/state/unit.go
+++ b/state/unit.go
@@ -729,6 +729,49 @@ func (u *Unit) SetStatus(status params.Status, info string, data params.StatusDa
 
 // OpenPort sets the policy of the port with protocol and number to be opened.
 func (u *Unit) OpenPort(protocol string, number int) (err error) {
+	ports, err := NewPortRange(u.Name(), number, number, protocol)
+	if err != nil {
+		return err
+	}
+	defer errors.Maskf(&err, "cannot open ports %v for unit %q", ports, u)
+
+	machineId, err := u.AssignedMachineId()
+	if err != nil {
+		return err
+	}
+
+	machinePorts, err := getOrCreatePorts(u.st, machineId)
+
+	// Check if this unit is still storing ports in its own document,
+	// if so - attempt a migration.
+	// Migration is only performed if the openedPorts document contains
+	// no ports for the unit - this condition will be removed when
+	// the unit ports list will be cleared after migration.
+	// TODO(domas) 2014-07-04 bug #1337817: remove second condition
+	if len(u.doc.Ports) != 0 && len(machinePorts.PortsForUnit(u.Name())) == 0 {
+		err = machinePorts.migratePorts(u)
+		if err != nil {
+			unitLogger.Errorf("could not migrate ports collection for unit %v: %v", u, err)
+			return err
+		}
+		err = machinePorts.Refresh()
+		if err != nil {
+			return err
+		}
+	}
+
+	err = machinePorts.OpenPorts(ports)
+	if err != nil {
+		return err
+	}
+	// TODO(domas) 2014-07-04 bug #1337813: remove once firewaller is updated to watch openedPorts collection
+	return u.openUnitPort(protocol, number)
+}
+
+// openUnitPort is the old implementation of OpenPort that amends the list of ports on the unit document.
+// TODO(domas) 2014-07-04 bug #1337813
+// This is kept in place until the firewaller is updated to watch the OpenedPorts collection.
+func (u *Unit) openUnitPort(protocol string, number int) (err error) {
 	port := network.Port{Protocol: protocol, Number: number}
 	defer errors.Maskf(&err, "cannot open port %v for unit %q", port, u)
 	ops := []txn.Op{{
@@ -754,8 +797,10 @@ func (u *Unit) OpenPort(protocol string, number int) (err error) {
 	return nil
 }
 
-// ClosePort sets the policy of the port with protocol and number to be closed.
-func (u *Unit) ClosePort(protocol string, number int) (err error) {
+// closeUnitPort is the old implementation of ClosePort that alters the list of ports on the unit document.
+// TODO(domas) 2014-07-04 bug #1337813
+// This is kept in place until the firewaller is updated to watch the OpenedPorts collection.
+func (u *Unit) closeUnitPort(protocol string, number int) (err error) {
 	port := network.Port{Protocol: protocol, Number: number}
 	defer errors.Maskf(&err, "cannot close port %v for unit %q", port, u)
 	ops := []txn.Op{{
@@ -778,11 +823,72 @@ func (u *Unit) ClosePort(protocol string, number int) (err error) {
 	return nil
 }
 
+// ClosePort sets the policy of the port with protocol and number to be closed.
+func (u *Unit) ClosePort(protocol string, number int) (err error) {
+	ports, err := NewPortRange(u.Name(), number, number, protocol)
+	if err != nil {
+		return err
+	}
+	defer errors.Maskf(&err, "cannot close ports %v for unit %q", ports, u)
+
+	machineId, err := u.AssignedMachineId()
+	if err != nil {
+		return err
+	}
+
+	machinePorts, err := getOrCreatePorts(u.st, machineId)
+	if err != nil {
+		return err
+	}
+
+	// Check if this unit is still storing ports in its own document,
+	// if so - attempt a migration.
+	// TODO(domas) 2014-07-04 bug #1337817: remove second condition
+	if len(u.doc.Ports) != 0 && len(machinePorts.PortsForUnit(u.Name())) == 0 {
+		err = machinePorts.migratePorts(u)
+		if err != nil {
+			unitLogger.Errorf("could not migrate ports collection for unit %v: %v", u, err)
+			return err
+		}
+		err = machinePorts.Refresh()
+		if err != nil {
+			return err
+		}
+	}
+
+	err = machinePorts.ClosePorts(ports)
+	if err != nil {
+		return err
+	}
+	// TODO(domas) 2014-07-04 bug #1337813: remove once firewaller is updated to watch openedPorts collection
+	return u.closeUnitPort(protocol, number)
+}
+
 // OpenedPorts returns a slice containing the open ports of the unit.
+// TODO(domas) 2014-07-04 but #1337817: update this function to return port ranges.
 func (u *Unit) OpenedPorts() []network.Port {
-	ports := append([]network.Port{}, u.doc.Ports...)
-	network.SortPorts(ports)
-	return ports
+	machineId, err := u.AssignedMachineId()
+	if err != nil {
+		unitLogger.Errorf("Cannot retrieve opened ports list for unit %v: %v", u, err)
+		return nil
+	}
+
+	machinePorts, err := getPorts(u.st, machineId)
+	result := []network.Port{}
+	if err == nil {
+		ports := machinePorts.PortsForUnit(u.Name())
+		for _, port := range ports {
+			result = append(result, network.Port{
+				Protocol: port.Protocol,
+				Number:   port.FromPort})
+		}
+	} else {
+		// Read the port list in the unit document if the ports
+		// document does not exist.
+		result = append([]network.Port{}, u.doc.Ports...)
+	}
+	network.SortPorts(result)
+	return result
 }
 
 // CharmURL returns the charm URL this unit is currently using.


### PR DESCRIPTION
This patch is the beginning of a solution for #1216644 . 

To implement this, a new openedPorts collection is introduced, with a ports document for each machine and network (only the "juju-public" network is supported at the moment).

Any existing port entries in the unit document are migrated to the ports document. New ports are still appended to the ports list in the unit document - this functionality will be removed when the firewaller is updated to watch the openedPorts collection.
