### PR TITLE
Allow IPv6 API endpoints; Improved IPv4/IPv6 addresses handling.

### DIFF
--- a/cmd/juju/scp.go
+++ b/cmd/juju/scp.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -82,14 +83,7 @@ func expandArgs(args []string, hostFromTarget func(string) (string, error)) ([]s
 		if err != nil {
 			return nil, err
 		}
-		// To ensure this works with IPv6 addresses, we need to
-		// wrap the host with \[..\], so the colons inside will be
-		// interpreted as part of the address and the last one as
-		// separator between host and remote path.
-		if strings.Contains(host, ":") {
-			host = fmt.Sprintf(`\[%s\]`, host)
-		}
-		outArgs[i] = "ubuntu@" + host + ":" + v[1]
+		outArgs[i] = "ubuntu@" + net.JoinHostPort(host, v[1])
 	}
 	return outArgs, nil
 }

--- a/cmd/juju/scp_test.go
+++ b/cmd/juju/scp_test.go
@@ -75,7 +75,7 @@ var scpTests = []struct {
 	}, {
 		about:  "scp works with IPv6 addresses",
 		args:   []string{"ipv6-svc/0:foo", "bar"},
-		result: commonArgsNoProxy + `ubuntu@\[2001:db8::\]:foo bar` + "\n",
+		result: commonArgsNoProxy + `ubuntu@[2001:db8::1]:foo bar` + "\n",
 	}, {
 		about:  "scp from machine 0 to unit mysql/0 with proxy",
 		args:   []string{"0:foo", "mysql/0:/foo"},
@@ -119,14 +119,8 @@ func (s *SCPSuite) TestSCPCommand(c *gc.C) {
 	s.addUnit(srv, m[2], c)
 	srv = s.AddTestingService(c, "ipv6-svc", dummyCharm)
 	s.addUnit(srv, m[3], c)
-	// TODO(dimitern) This is a horrible hack and needs to
-	// be fixed as we implement proper #IPv6 support.
 	// Simulate machine 3 has a public IPv6 address.
-	ipv6Addr := network.Address{
-		Value: "2001:db8::",
-		Type:  network.IPv4Address, // ..because SelectPublicAddress ignores IPv6 addresses
-		Scope: network.ScopePublic,
-	}
+	ipv6Addr := network.NewAddress("2001:db8::1", network.ScopePublic)
 	err = m[3].SetAddresses(ipv6Addr)
 	c.Assert(err, gc.IsNil)
 
@@ -159,7 +153,7 @@ var hostsFromTargets = map[string]string{
 	"mysql/0":    "dummyenv-0.dns",
 	"mongodb/0":  "dummyenv-1.dns",
 	"mongodb/1":  "dummyenv-2.dns",
-	"ipv6-svc/0": "2001:db8::",
+	"ipv6-svc/0": "2001:db8::1",
 }
 
 func dummyHostsFromTarget(target string) (string, error) {

--- a/juju/api.go
+++ b/juju/api.go
@@ -385,8 +385,9 @@ func cacheChangedAPIInfo(info configstore.EnvironInfo, st apiState) error {
 	for _, serverHostPorts := range st.APIHostPorts() {
 		for _, hostPort := range serverHostPorts {
 			// Only cache addresses that are likely to be usable,
-			// exclude IPv6 for now and localhost style ones.
-			if hostPort.Type != network.IPv6Address && hostPort.Scope != network.ScopeMachineLocal {
+			// exclude localhost style ones.
+			if hostPort.Scope != network.ScopeMachineLocal &&
+				hostPort.Scope != network.ScopeLinkLocal {
 				addrs = append(addrs, hostPort.NetAddr())
 			}
 		}

--- a/juju/apiconn_test.go
+++ b/juju/apiconn_test.go
@@ -800,21 +800,25 @@ func (s *APIEndpointForEnvSuite) TestAPIEndpointRefresh(c *gc.C) {
 	c.Check(endpoint.Addresses, gc.DeepEquals, []string{"0.1.2.3:1234"})
 }
 
-func (s *APIEndpointForEnvSuite) TestAPIEndpointNotMachineLocal(c *gc.C) {
+func (s *APIEndpointForEnvSuite) TestAPIEndpointNotMachineLocalOrLinkLocal(c *gc.C) {
 	store := newConfigStore("env-name", dummyStoreInfo)
 	called := 0
 	hostPorts := [][]network.HostPort{
 		network.AddressesWithPort([]network.Address{
-			network.NewAddress("1.0.0.1", network.ScopePublic),
-			network.NewAddress("192.0.0.1", network.ScopeCloudLocal),
-			network.NewAddress("127.0.0.1", network.ScopeMachineLocal),
+			network.NewAddress("1.0.0.1", network.ScopeUnknown),
+			network.NewAddress("192.0.0.1", network.ScopeUnknown),
+			network.NewAddress("127.0.0.1", network.ScopeUnknown),
 			network.NewAddress("localhost", network.ScopeMachineLocal),
+			network.NewAddress("::1", network.ScopeUnknown),
+			network.NewAddress("fe80::1", network.ScopeUnknown),
+			network.NewAddress("fc00::1", network.ScopeUnknown),
+			network.NewAddress("2001:db1::1", network.ScopeUnknown),
 		}, 1234),
 		network.AddressesWithPort([]network.Address{
 			network.NewAddress("1.0.0.2", network.ScopeUnknown),
 			network.NewAddress("2002:0:0:0:0:0:100:2", network.ScopeUnknown),
-			network.NewAddress("::1", network.ScopeMachineLocal),
-			network.NewAddress("127.0.0.1", network.ScopeMachineLocal),
+			network.NewAddress("::1", network.ScopeUnknown),
+			network.NewAddress("127.0.0.1", network.ScopeUnknown),
 			network.NewAddress("localhost", network.ScopeMachineLocal),
 		}, 1235),
 	}
@@ -830,6 +834,9 @@ func (s *APIEndpointForEnvSuite) TestAPIEndpointNotMachineLocal(c *gc.C) {
 	c.Check(endpoint.Addresses, gc.DeepEquals, []string{
 		"1.0.0.1:1234",
 		"192.0.0.1:1234",
+		"[fc00::1]:1234",
+		"[2001:db1::1]:1234",
 		"1.0.0.2:1235",
+		"[2002:0:0:0:0:0:100:2]:1235",
 	})
 }

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -16,7 +16,7 @@ type AddressSuite struct {
 
 var _ = gc.Suite(&AddressSuite{})
 
-func (s *AddressSuite) TestNewAddressIpv4(c *gc.C) {
+func (s *AddressSuite) TestNewAddressIPv4(c *gc.C) {
 	type test struct {
 		value         string
 		scope         network.Scope
@@ -44,6 +44,10 @@ func (s *AddressSuite) TestNewAddressIpv4(c *gc.C) {
 		scope:         network.ScopeUnknown,
 		expectedScope: network.ScopeCloudLocal,
 	}, {
+		value:         "169.254.1.1",
+		scope:         network.ScopeUnknown,
+		expectedScope: network.ScopeLinkLocal,
+	}, {
 		value:         "8.8.8.8",
 		scope:         network.ScopeUnknown,
 		expectedScope: network.ScopePublic,
@@ -58,32 +62,117 @@ func (s *AddressSuite) TestNewAddressIpv4(c *gc.C) {
 	}
 }
 
-func (s *AddressSuite) TestNewAddressIpv6(c *gc.C) {
-	addr := network.NewAddress("::1", network.ScopeUnknown)
-	c.Check(addr.Value, gc.Equals, "::1")
-	c.Check(addr.Type, gc.Equals, network.IPv6Address)
-	c.Check(addr.Scope, gc.Equals, network.ScopeMachineLocal)
-
-	addr = network.NewAddress("2001:DB8::1", network.ScopeUnknown)
-	c.Check(addr.Value, gc.Equals, "2001:DB8::1")
-	c.Check(addr.Type, gc.Equals, network.IPv6Address)
-	c.Check(addr.Scope, gc.Equals, network.ScopeUnknown)
+func (s *AddressSuite) TestNewAddressIPv6(c *gc.C) {
+	// Examples below taken from
+	// http://en.wikipedia.org/wiki/IPv6_address
+	testAddresses := []struct {
+		value string
+		scope network.Scope
+	}{
+		// IPv6 loopback address
+		{"::1", network.ScopeMachineLocal},
+		// used documentation examples
+		{"2001:db8::1", network.ScopePublic},
+		// link-local
+		{"fe80::1", network.ScopeLinkLocal},
+		// unique local address (ULA) - first group
+		{"fc00::1", network.ScopeCloudLocal},
+		// unique local address (ULA) - second group
+		{"fd00::1", network.ScopeCloudLocal},
+		// IPv4-mapped IPv6 address
+		{"::ffff:0:0:1", network.ScopePublic},
+		// IPv4-translated IPv6 address (SIIT)
+		{"::ffff:0:0:0:1", network.ScopePublic},
+		// "well-known" prefix for IPv4/IPv6 auto translation
+		{"64:ff9b::1", network.ScopePublic},
+		// used for 6to4 addressing
+		{"2002::1", network.ScopePublic},
+		// used for Teredo tunneling
+		{"2001::1", network.ScopePublic},
+		// used for IPv6 benchmarking
+		{"2001:2::1", network.ScopePublic},
+		// used for cryptographic hash identifiers
+		{"2001:10::1", network.ScopePublic},
+		// interface-local multicast (all nodes)
+		{"ff01::1", network.ScopeLinkLocal},
+		// link-local multicast (all nodes)
+		{"ff02::1", network.ScopeLinkLocal},
+		// interface-local multicast (all routers)
+		{"ff01::2", network.ScopeLinkLocal},
+		// link-local multicast (all routers)
+		{"ff02::2", network.ScopeLinkLocal},
+	}
+	for i, test := range testAddresses {
+		c.Logf("test %d: %q -> %q", i, test.value, test.scope)
+		addr := network.NewAddress(test.value, network.ScopeUnknown)
+		c.Check(addr.Value, gc.Equals, test.value)
+		c.Check(addr.Type, gc.Equals, network.IPv6Address)
+		c.Check(addr.Scope, gc.Equals, test.scope)
+	}
 }
 
 func (s *AddressSuite) TestNewAddresses(c *gc.C) {
-	addresses := network.NewAddresses("127.0.0.1", "192.168.1.1", "192.168.178.255")
-	c.Assert(len(addresses), gc.Equals, 3)
-	c.Assert(addresses[0].Value, gc.Equals, "127.0.0.1")
-	c.Assert(addresses[0].Scope, gc.Equals, network.ScopeMachineLocal)
-	c.Assert(addresses[1].Value, gc.Equals, "192.168.1.1")
-	c.Assert(addresses[1].Scope, gc.Equals, network.ScopeCloudLocal)
-	c.Assert(addresses[2].Value, gc.Equals, "192.168.178.255")
-	c.Assert(addresses[2].Scope, gc.Equals, network.ScopeCloudLocal)
+	testAddresses := []struct {
+		values   []string
+		addrType network.AddressType
+		scope    network.Scope
+	}{{
+		[]string{"127.0.0.1", "127.0.1.2"},
+		network.IPv4Address,
+		network.ScopeMachineLocal,
+	}, {
+		[]string{"::1"},
+		network.IPv6Address,
+		network.ScopeMachineLocal,
+	}, {
+		[]string{"192.168.1.1", "192.168.178.255", "10.5.1.1", "172.16.1.1"},
+		network.IPv4Address,
+		network.ScopeCloudLocal,
+	}, {
+		[]string{"fc00::1", "fd00::2"},
+		network.IPv6Address,
+		network.ScopeCloudLocal,
+	}, {
+		[]string{"8.8.8.8", "8.8.4.4"},
+		network.IPv4Address,
+		network.ScopePublic,
+	}, {
+		[]string{"2001:db1::1", "64:ff9b::1", "2002::1"},
+		network.IPv6Address,
+		network.ScopePublic,
+	}, {
+		[]string{"169.254.1.23", "169.254.1.1"},
+		network.IPv4Address,
+		network.ScopeLinkLocal,
+	}, {
+		[]string{"ff01::2", "ff01::1"},
+		network.IPv6Address,
+		network.ScopeLinkLocal,
+	}, {
+		[]string{"example.com", "example.org"},
+		network.HostName,
+		network.ScopeUnknown,
+	}}
+
+	for i, test := range testAddresses {
+		c.Logf("test %d: %v -> %q", i, test.values, test.scope)
+		addresses := network.NewAddresses(test.values...)
+		c.Check(addresses, gc.HasLen, len(test.values))
+		for j, addr := range addresses {
+			c.Check(addr.Value, gc.Equals, test.values[j])
+			c.Check(addr.Type, gc.Equals, test.addrType)
+			c.Check(addr.Scope, gc.Equals, test.scope)
+		}
+	}
 }
 
 func (s *AddressSuite) TestNewAddressHostname(c *gc.C) {
 	addr := network.NewAddress("localhost", network.ScopeUnknown)
 	c.Check(addr.Value, gc.Equals, "localhost")
+	c.Check(addr.Type, gc.Equals, network.HostName)
+	c.Check(addr.Scope, gc.Equals, network.ScopeUnknown)
+	addr = network.NewAddress("example.com", network.ScopeUnknown)
+	c.Check(addr.Value, gc.Equals, "example.com")
 	c.Check(addr.Type, gc.Equals, network.HostName)
 	c.Check(addr.Scope, gc.Equals, network.ScopeUnknown)
 }
@@ -92,6 +181,7 @@ type selectTest struct {
 	about         string
 	addresses     []network.Address
 	expectedIndex int
+	preferIPv6    bool
 }
 
 // expected returns the expected address for the test.
@@ -106,32 +196,89 @@ var selectPublicTests = []selectTest{{
 	"no addresses gives empty string result",
 	[]network.Address{},
 	-1,
+	false,
 }, {
-	"a public address is selected",
+	"a public IPv4 address is selected",
 	[]network.Address{
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
 	},
 	0,
+	false,
 }, {
-	"a machine local address is not selected",
+	"a public IPv6 address is selected",
+	[]network.Address{
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+	},
+	0,
+	false,
+}, {
+	"first public address is selected",
+	[]network.Address{
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+	},
+	0,
+	false,
+}, {
+	"the first public address is selected when cloud local fallbacks exist",
+	[]network.Address{
+		{"172.16.1.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"fc00:1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+	},
+	1,
+	false,
+}, {
+	"IPv6 public address is preferred to a cloud local one when preferIPv6 is true",
+	[]network.Address{
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"172.16.1.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+		{"fc00:1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+	},
+	3,
+	true,
+}, {
+	"a machine IPv4 local address is not selected",
 	[]network.Address{
 		{"127.0.0.1", network.IPv4Address, "machine", network.ScopeMachineLocal},
 	},
 	-1,
+	false,
 }, {
-	"an ipv6 address is not selected",
+	"a machine IPv6 local address is not selected",
 	[]network.Address{
-		{"2001:DB8::1", network.IPv6Address, "", network.ScopePublic},
+		{"::1", network.IPv6Address, "machine", network.ScopeMachineLocal},
 	},
 	-1,
+	false,
+}, {
+	"a link-local IPv4 address is not selected",
+	[]network.Address{
+		{"169.254.1.1", network.IPv4Address, "link", network.ScopeLinkLocal},
+	},
+	-1,
+	false,
+}, {
+	"a link-local (multicast or not) IPv6 address is not selected",
+	[]network.Address{
+		{"fe80::1", network.IPv6Address, "link", network.ScopeLinkLocal},
+		{"ff01::2", network.IPv6Address, "link", network.ScopeLinkLocal},
+		{"ff02::1:1", network.IPv6Address, "link", network.ScopeLinkLocal},
+	},
+	-1,
+	false,
 }, {
 	"a public name is preferred to an unknown or cloud local address",
 	[]network.Address{
 		{"127.0.0.1", network.IPv4Address, "local", network.ScopeUnknown},
 		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
 		{"public.invalid.testing", network.HostName, "public", network.ScopePublic},
 	},
-	2,
+	3,
+	false,
 }, {
 	"first unknown address selected",
 	[]network.Address{
@@ -139,78 +286,171 @@ var selectPublicTests = []selectTest{{
 		{"8.8.8.8", network.IPv4Address, "floating", network.ScopeUnknown},
 	},
 	0,
+	false,
 }}
 
 func (s *AddressSuite) TestSelectPublicAddress(c *gc.C) {
 	for i, t := range selectPublicTests {
 		c.Logf("test %d: %s", i, t.about)
+		network.PreferIPv6 = t.preferIPv6
 		c.Check(network.SelectPublicAddress(t.addresses), gc.Equals, t.expected())
 	}
+	network.PreferIPv6 = false
 }
 
 var selectInternalTests = []selectTest{{
 	"no addresses gives empty string result",
 	[]network.Address{},
 	-1,
+	false,
 }, {
-	"a public address is selected",
+	"a public IPv4 address is selected",
 	[]network.Address{
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
 	},
 	0,
+	false,
 }, {
-	"a cloud local address is selected",
+	"a public IPv6 address is selected",
+	[]network.Address{
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+	},
+	0,
+	false,
+}, {
+	"a public IPv6 address is selected when both IPv4 and IPv6 addresses exist and preferIPv6 is true",
+	[]network.Address{
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+	},
+	1,
+	true,
+}, {
+	"the first public IPv4 address is selected when preferIPv6 is true and no IPv6 addresses",
+	[]network.Address{
+		{"127.0.0.1", network.IPv4Address, "machine", network.ScopeMachineLocal},
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+	},
+	1,
+	true,
+}, {
+	"a cloud local IPv4 address is selected",
 	[]network.Address{
 		{"10.0.0.1", network.IPv4Address, "private", network.ScopeCloudLocal},
 	},
 	0,
+	false,
 }, {
-	"a machine local address is not selected",
+	"a cloud local IPv6 address is selected",
+	[]network.Address{
+		{"fc00::1", network.IPv6Address, "private", network.ScopeCloudLocal},
+	},
+	0,
+	false,
+}, {
+	"a machine local or link-local address is not selected",
 	[]network.Address{
 		{"127.0.0.1", network.IPv4Address, "machine", network.ScopeMachineLocal},
+		{"::1", network.IPv6Address, "machine", network.ScopeMachineLocal},
+		{"fe80::1", network.IPv6Address, "machine", network.ScopeLinkLocal},
 	},
 	-1,
-}, {
-	"ipv6 addresses are not selected",
-	[]network.Address{
-		{"::1", network.IPv6Address, "", network.ScopeCloudLocal},
-	},
-	-1,
+	false,
 }, {
 	"a cloud local address is preferred to a public address",
 	[]network.Address{
-		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
 	},
 	0,
+	false,
+}, {
+	"an IPv6 cloud local address is preferred to a public address when preferIPv6 is true",
+	[]network.Address{
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+	},
+	1,
+	false,
 }}
 
 func (s *AddressSuite) TestSelectInternalAddress(c *gc.C) {
 	for i, t := range selectInternalTests {
 		c.Logf("test %d: %s", i, t.about)
+		network.PreferIPv6 = t.preferIPv6
 		c.Check(network.SelectInternalAddress(t.addresses, false), gc.Equals, t.expected())
 	}
+	network.PreferIPv6 = false
 }
 
 var selectInternalMachineTests = []selectTest{{
-	"a cloud local address is selected",
+	"first cloud local address is selected",
+	[]network.Address{
+		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+	},
+	0,
+	false,
+}, {
+	"first IPv6 cloud local address is selected when preferIPv6 is true",
 	[]network.Address{
 		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
+		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
 	},
-	0,
+	2,
+	true,
 }, {
-	"a machine local address is selected",
+	"first IPv4 cloud local address is selected when preferIPv6 is true and no IPv6 addresses",
+	[]network.Address{
+		{"169.254.1.1", network.IPv4Address, "link", network.ScopeLinkLocal},
+		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+		{"172.16.1.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
+	},
+	1,
+	true,
+}, {
+	"first machine local address is selected",
 	[]network.Address{
 		{"127.0.0.1", network.IPv4Address, "container", network.ScopeMachineLocal},
+		{"::1", network.IPv6Address, "container", network.ScopeMachineLocal},
 	},
 	0,
+	false,
+}, {
+	"first IPv6 machine local address is selected when preferIPv6 is true",
+	[]network.Address{
+		{"127.0.0.1", network.IPv4Address, "container", network.ScopeMachineLocal},
+		{"::1", network.IPv6Address, "container", network.ScopeMachineLocal},
+		{"fe80::1", network.IPv6Address, "container", network.ScopeLinkLocal},
+	},
+	1,
+	true,
+}, {
+	"first IPv4 machine local address is selected when preferIPv6 is true and no IPv6 addresses",
+	[]network.Address{
+		{"168.254.1.1", network.IPv4Address, "link", network.ScopeLinkLocal},
+		{"127.0.0.1", network.IPv4Address, "container", network.ScopeMachineLocal},
+		{"127.0.0.2", network.IPv4Address, "container", network.ScopeMachineLocal},
+	},
+	1,
+	true,
 }}
 
 func (s *AddressSuite) TestSelectInternalMachineAddress(c *gc.C) {
 	for i, t := range selectInternalMachineTests {
 		c.Logf("test %d: %s", i, t.about)
+		network.PreferIPv6 = t.preferIPv6
 		c.Check(network.SelectInternalAddress(t.addresses, true), gc.Equals, t.expected())
 	}
+	network.PreferIPv6 = false
 }
 
 var stringTests = []struct {
@@ -222,6 +462,13 @@ var stringTests = []struct {
 		Value: "127.0.0.1",
 	},
 	str: "127.0.0.1",
+}, {
+	addr: network.Address{
+		Type:  network.IPv6Address,
+		Value: "2001:db1::1",
+		Scope: network.ScopePublic,
+	},
+	str: "public:2001:db1::1",
 }, {
 	addr: network.Address{
 		Type:  network.HostName,

--- a/network/port_test.go
+++ b/network/port_test.go
@@ -21,6 +21,7 @@ type hostPortTest struct {
 	about         string
 	hostPorts     []network.HostPort
 	expectedIndex int
+	preferIPv6    bool
 }
 
 // hostPortTest returns the HostPort equivalent test to the
@@ -34,6 +35,7 @@ func (t selectTest) hostPortTest() hostPortTest {
 		about:         t.about,
 		hostPorts:     hps,
 		expectedIndex: t.expectedIndex,
+		preferIPv6:    t.preferIPv6,
 	}
 }
 
@@ -50,24 +52,30 @@ func (s *PortSuite) TestSelectPublicHostPort(c *gc.C) {
 	for i, t0 := range selectPublicTests {
 		t := t0.hostPortTest()
 		c.Logf("test %d: %s", i, t.about)
-		c.Assert(network.SelectPublicHostPort(t.hostPorts), jc.DeepEquals, t.expected())
+		network.PreferIPv6 = t.preferIPv6
+		c.Check(network.SelectPublicHostPort(t.hostPorts), jc.DeepEquals, t.expected())
 	}
+	network.PreferIPv6 = false
 }
 
 func (s *PortSuite) TestSelectInternalHostPort(c *gc.C) {
 	for i, t0 := range selectInternalTests {
 		t := t0.hostPortTest()
 		c.Logf("test %d: %s", i, t.about)
-		c.Assert(network.SelectInternalHostPort(t.hostPorts, false), jc.DeepEquals, t.expected())
+		network.PreferIPv6 = t.preferIPv6
+		c.Check(network.SelectInternalHostPort(t.hostPorts, false), jc.DeepEquals, t.expected())
 	}
+	network.PreferIPv6 = false
 }
 
 func (s *PortSuite) TestSelectInternalMachineHostPort(c *gc.C) {
 	for i, t0 := range selectInternalMachineTests {
 		t := t0.hostPortTest()
 		c.Logf("test %d: %s", i, t.about)
-		c.Assert(network.SelectInternalHostPort(t.hostPorts, true), gc.DeepEquals, t.expected())
+		network.PreferIPv6 = t.preferIPv6
+		c.Check(network.SelectInternalHostPort(t.hostPorts, true), gc.DeepEquals, t.expected())
 	}
+	network.PreferIPv6 = false
 }
 
 func (*PortSuite) TestAddressesWithPort(c *gc.C) {

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -41,69 +41,140 @@ var addressTests = []struct {
 	networks []string
 	expected string
 	failure  error
-}{
-	{
-		summary:  "missing",
-		expected: "",
-	},
-	{
-		summary:  "empty",
-		private:  []nova.IPAddress{},
-		networks: []string{"private"},
-		expected: "",
-	},
-	{
-		summary:  "private only",
-		private:  []nova.IPAddress{{4, "192.168.0.1"}},
-		networks: []string{"private"},
-		expected: "192.168.0.1",
-	},
-	{
-		summary:  "private plus (HP cloud)",
-		private:  []nova.IPAddress{{4, "10.0.0.1"}, {4, "8.8.4.4"}},
-		networks: []string{"private"},
-		expected: "8.8.4.4",
-	},
-	{
-		summary:  "public only",
-		public:   []nova.IPAddress{{4, "8.8.8.8"}},
-		networks: []string{"", "public"},
-		expected: "8.8.8.8",
-	},
-	{
-		summary:  "public and private",
-		private:  []nova.IPAddress{{4, "10.0.0.4"}},
-		public:   []nova.IPAddress{{4, "8.8.4.4"}},
-		networks: []string{"private", "public"},
-		expected: "8.8.4.4",
-	},
-	{
-		summary:  "public private plus",
-		private:  []nova.IPAddress{{4, "127.0.0.4"}, {4, "192.168.0.1"}},
-		public:   []nova.IPAddress{{4, "8.8.8.8"}},
-		networks: []string{"private", "public"},
-		expected: "8.8.8.8",
-	},
-	{
-		summary:  "custom only",
-		private:  []nova.IPAddress{{4, "192.168.0.1"}},
-		networks: []string{"special"},
-		expected: "192.168.0.1",
-	},
-	{
-		summary:  "custom and public",
-		private:  []nova.IPAddress{{4, "172.16.0.1"}},
-		public:   []nova.IPAddress{{4, "8.8.8.8"}},
-		networks: []string{"special", "public"},
-		expected: "8.8.8.8",
-	},
-	{
-		summary:  "non-IPv4",
-		private:  []nova.IPAddress{{6, "::dead:beef:f00d"}},
-		networks: []string{"private"},
-		expected: "",
-	},
-}
+}{{
+	summary:  "missing",
+	expected: "",
+}, {
+	summary:  "empty",
+	private:  []nova.IPAddress{},
+	networks: []string{"private"},
+	expected: "",
+}, {
+	summary:  "private IPv4 only",
+	private:  []nova.IPAddress{{4, "192.168.0.1"}},
+	networks: []string{"private"},
+	expected: "192.168.0.1",
+}, {
+	summary:  "private IPv6 only",
+	private:  []nova.IPAddress{{6, "fc00::1"}},
+	networks: []string{"private"},
+	expected: "fc00::1",
+}, {
+	summary:  "private only, both IPv4 and IPv6",
+	private:  []nova.IPAddress{{4, "192.168.0.1"}, {6, "fc00::1"}},
+	networks: []string{"private"},
+	expected: "192.168.0.1",
+}, {
+	summary:  "private only, both IPv6 and IPv4",
+	private:  []nova.IPAddress{{6, "fc00::1"}, {4, "192.168.0.1"}},
+	networks: []string{"private"},
+	expected: "fc00::1",
+}, {
+	summary:  "private IPv4 plus (HP cloud)",
+	private:  []nova.IPAddress{{4, "10.0.0.1"}, {4, "8.8.4.4"}},
+	networks: []string{"private"},
+	expected: "8.8.4.4",
+}, {
+	summary:  "public IPv4 only",
+	public:   []nova.IPAddress{{4, "8.8.8.8"}},
+	networks: []string{"", "public"},
+	expected: "8.8.8.8",
+}, {
+	summary:  "public IPv6 only",
+	public:   []nova.IPAddress{{6, "2001:db1::1"}},
+	networks: []string{"", "public"},
+	expected: "2001:db1::1",
+}, {
+	summary:  "public only, both IPv4 and IPv6",
+	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db1::1"}},
+	networks: []string{"", "public"},
+	expected: "8.8.8.8",
+}, {
+	summary:  "public only, both IPv6 and IPv4",
+	public:   []nova.IPAddress{{6, "2001:db1::1"}, {4, "8.8.8.8"}},
+	networks: []string{"", "public"},
+	expected: "2001:db1::1",
+}, {
+	summary:  "public and private both IPv4",
+	private:  []nova.IPAddress{{4, "10.0.0.4"}},
+	public:   []nova.IPAddress{{4, "8.8.4.4"}},
+	networks: []string{"private", "public"},
+	expected: "8.8.4.4",
+}, {
+	summary:  "public and private both IPv6",
+	private:  []nova.IPAddress{{6, "fc00::1"}},
+	public:   []nova.IPAddress{{6, "2001:db1::1"}},
+	networks: []string{"private", "public"},
+	expected: "2001:db1::1",
+}, {
+	summary:  "public, private, and localhost IPv4",
+	private:  []nova.IPAddress{{4, "127.0.0.4"}, {4, "192.168.0.1"}},
+	public:   []nova.IPAddress{{4, "8.8.8.8"}},
+	networks: []string{"private", "public"},
+	expected: "8.8.8.8",
+}, {
+	summary:  "public, private, and localhost IPv6",
+	private:  []nova.IPAddress{{6, "::1"}, {6, "fc00::1"}},
+	public:   []nova.IPAddress{{6, "2001:db1::1"}},
+	networks: []string{"private", "public"},
+	expected: "2001:db1::1",
+}, {
+	summary:  "public, private, and localhost - both IPv4 and IPv6",
+	private:  []nova.IPAddress{{4, "127.0.0.4"}, {4, "192.168.0.1"}, {6, "::1"}, {6, "fc00::1"}},
+	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db1::1"}},
+	networks: []string{"private", "public"},
+	expected: "8.8.8.8",
+}, {
+	summary:  "public, private, and localhost - both IPv6 and IPv4",
+	private:  []nova.IPAddress{{6, "::1"}, {6, "fc00::1"}, {4, "127.0.0.4"}, {4, "192.168.0.1"}},
+	public:   []nova.IPAddress{{6, "2001:db1::1"}, {4, "8.8.8.8"}},
+	networks: []string{"private", "public"},
+	expected: "2001:db1::1",
+}, {
+	summary:  "custom only IPv4",
+	private:  []nova.IPAddress{{4, "192.168.0.1"}},
+	networks: []string{"special"},
+	expected: "192.168.0.1",
+}, {
+	summary:  "custom only IPv6",
+	private:  []nova.IPAddress{{6, "fc00::1"}},
+	networks: []string{"special"},
+	expected: "fc00::1",
+}, {
+	summary:  "custom only - both IPv4 and IPv6",
+	private:  []nova.IPAddress{{4, "192.168.0.1"}, {6, "fc00::1"}},
+	networks: []string{"special"},
+	expected: "192.168.0.1",
+}, {
+	summary:  "custom only - both IPv6 and IPv4",
+	private:  []nova.IPAddress{{6, "fc00::1"}, {4, "192.168.0.1"}},
+	networks: []string{"special"},
+	expected: "fc00::1",
+}, {
+	summary:  "custom and public IPv4",
+	private:  []nova.IPAddress{{4, "172.16.0.1"}},
+	public:   []nova.IPAddress{{4, "8.8.8.8"}},
+	networks: []string{"special", "public"},
+	expected: "8.8.8.8",
+}, {
+	summary:  "custom and public IPv6",
+	private:  []nova.IPAddress{{6, "fc00::1"}},
+	public:   []nova.IPAddress{{6, "2001:db1::1"}},
+	networks: []string{"special", "public"},
+	expected: "2001:db1::1",
+}, {
+	summary:  "custom and public - both IPv4 and IPv6",
+	private:  []nova.IPAddress{{4, "172.16.0.1"}, {6, "fc00::1"}},
+	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db1::1"}},
+	networks: []string{"special", "public"},
+	expected: "8.8.8.8",
+}, {
+	summary:  "custom and public - both IPv6 and IPv4",
+	private:  []nova.IPAddress{{6, "fc00::1"}, {4, "172.16.0.1"}},
+	public:   []nova.IPAddress{{6, "2001:db1::1"}, {4, "8.8.8.8"}},
+	networks: []string{"special", "public"},
+	expected: "2001:db1::1",
+}}
 
 func (t *localTests) TestGetServerAddresses(c *gc.C) {
 	for i, t := range addressTests {


### PR DESCRIPTION
Summary of the changes:
- API IPv6 endpoints are cached, just like IPv4 ones.
- Introduced network.ScopeLinkLocal and detection.
- Improved addresses selection (public/internal) in
  the network package not to discriminate IPv6 over IPv4.
- Added network.PreferIPv6 global flag (false by default)
  as a less intrusive way to tweak addresses selection to
  prefer IPv6 addresses when available. This needs to be
  exposed as an environment setting in a follow-up.
- Added a lot of tests for both IPv4 and IPv6 addresses
  in the network package and in the openstack provider.
- As a side-effect, fixed bug http://pad.lv/1328429.

With this PR, we no longer favor IPv4 over IPv6, and this allows us to
improve IPv6 support across the board. Some follow-up will be needed
to fix a few minor issues, like not verifying addesses of type
"hostname" (lots of tests need to stop using hostnames like
"zerotwothreefour" or "public", etc. and start using "example.com" or
subdomains thereof). Another improvement will be to expose the
PreferIPv6 flag to the end-user somehow.
