### PR TITLE
Add .exe to commands on Windows

### DIFF
--- a/juju/names/names.go
+++ b/juju/names/names.go
@@ -1,0 +1,13 @@
+// Copyright 2014 Cloudbase Solutions
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
+
+package names
+
+const (
+	Juju    = "juju"
+	Jujud   = "jujud"
+	Jujuc   = "jujuc"
+	JujuRun = "juju-run"
+)

--- a/juju/names/names_windows.go
+++ b/juju/names/names_windows.go
@@ -1,0 +1,12 @@
+// Copyright 2014 Cloudbase Solutions
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package names
+
+const (
+	Juju    = "juju.exe"
+	Jujud   = "jujud.exe"
+	Jujuc   = "jujuc.exe"
+	JujuRun = "juju-run.exe"
+)

--- a/worker/uniter/jujuc/commands.go
+++ b/worker/uniter/jujuc/commands.go
@@ -1,0 +1,8 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions
+// Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
+
+package jujuc
+
+const cmdSuffix = ""

--- a/worker/uniter/jujuc/commands_windows.go
+++ b/worker/uniter/jujuc/commands_windows.go
@@ -1,0 +1,7 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+const cmdSuffix = ".exe"

--- a/worker/uniter/jujuc/server.go
+++ b/worker/uniter/jujuc/server.go
@@ -24,16 +24,16 @@ var logger = loggo.GetLogger("worker.uniter.jujuc")
 
 // newCommands maps Command names to initializers.
 var newCommands = map[string]func(Context) cmd.Command{
-	"close-port":    NewClosePortCommand,
-	"config-get":    NewConfigGetCommand,
-	"juju-log":      NewJujuLogCommand,
-	"open-port":     NewOpenPortCommand,
-	"relation-get":  NewRelationGetCommand,
-	"relation-ids":  NewRelationIdsCommand,
-	"relation-list": NewRelationListCommand,
-	"relation-set":  NewRelationSetCommand,
-	"unit-get":      NewUnitGetCommand,
-	"owner-get":     NewOwnerGetCommand,
+	"close-port" + cmdSuffix:    NewClosePortCommand,
+	"config-get" + cmdSuffix:    NewConfigGetCommand,
+	"juju-log" + cmdSuffix:      NewJujuLogCommand,
+	"open-port" + cmdSuffix:     NewOpenPortCommand,
+	"relation-get" + cmdSuffix:  NewRelationGetCommand,
+	"relation-ids" + cmdSuffix:  NewRelationIdsCommand,
+	"relation-list" + cmdSuffix: NewRelationListCommand,
+	"relation-set" + cmdSuffix:  NewRelationSetCommand,
+	"unit-get" + cmdSuffix:      NewUnitGetCommand,
+	"owner-get" + cmdSuffix:     NewOwnerGetCommand,
 }
 
 // CommandNames returns the names of all jujuc commands.

--- a/worker/uniter/tools.go
+++ b/worker/uniter/tools.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/juju/utils/symlink"
-
+	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/worker/uniter/jujuc"
+	"github.com/juju/utils/symlink"
 )
 
 // EnsureJujucSymlinks creates a symbolic link to jujuc within dir for each
@@ -20,7 +20,8 @@ func EnsureJujucSymlinks(dir string) (err error) {
 		// The link operation fails when the target already exists,
 		// so this is a no-op when the command names already
 		// exist.
-		err := symlink.New("./jujud", filepath.Join(dir, name))
+		jujudPath := filepath.Join(dir, names.Jujud)
+		err := symlink.New(jujudPath, filepath.Join(dir, name))
 		if err == nil {
 			continue
 		}

--- a/worker/uniter/tools_test.go
+++ b/worker/uniter/tools_test.go
@@ -13,6 +13,7 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/jujuc"
@@ -34,14 +35,14 @@ func (s *ToolsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ToolsSuite) TestEnsureJujucSymlinks(c *gc.C) {
-	jujudPath := filepath.Join(s.toolsDir, "jujud")
+	jujudPath := filepath.Join(s.toolsDir, names.Jujud)
 	err := ioutil.WriteFile(jujudPath, []byte("assume sane"), 0755)
 	c.Assert(err, gc.IsNil)
 
 	assertLink := func(path string) time.Time {
 		target, err := symlink.Read(path)
 		c.Assert(err, gc.IsNil)
-		c.Assert(target, gc.Equals, "./jujud")
+		c.Assert(target, gc.Equals, jujudPath)
 		fi, err := os.Lstat(path)
 		c.Assert(err, gc.IsNil)
 		return fi.ModTime()


### PR DESCRIPTION
On windows, executable commands must have one of the extensions found in $env:PATHEXT. This branch creates a newCommand map where names contain the .exe extension.
