### PR TITLE
Ordered the lookup of machine IDs to guard against randomly ordered map ...

### DIFF
--- a/cmd/juju/run_test.go
+++ b/cmd/juju/run_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/juju/cmd"
@@ -409,12 +410,19 @@ func (*mockRunAPI) Close() error {
 }
 
 func (m *mockRunAPI) RunOnAllMachines(commands string, timeout time.Duration) ([]params.RunResult, error) {
+
+	sortedMachineIds := make([]string, 0, len(m.machines))
+	for machineId := range m.machines {
+		sortedMachineIds = append(sortedMachineIds, machineId)
+	}
+	sort.Strings(sortedMachineIds)
+
 	var result []params.RunResult
-	for machine := range m.machines {
-		response, found := m.responses[machine]
+	for _, machineId := range sortedMachineIds {
+		response, found := m.responses[machineId]
 		if !found {
 			// Consider this a timeout
-			response = params.RunResult{MachineId: machine, Error: "command timed out"}
+			response = params.RunResult{MachineId: machineId, Error: "command timed out"}
 		}
 		result = append(result, response)
 	}


### PR DESCRIPTION
In Go v1.3, map ordering was intentionally randomized to discourage relying on maps which were coincidentally ordered how expected. This corrects a non-deterministic bug in one of the tests which was caused by this change to Go.
