### PR TITLE
Port the plugins to not use EnvName.

### DIFF
--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/utils"
 	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
@@ -23,7 +22,7 @@ import (
 
 // ValidateImageMetadataCommand
 type ValidateImageMetadataCommand struct {
-	envcmd.EnvCommandBase
+	ImageMetadataCommandBase
 	out          cmd.Output
 	providerType string
 	metadataDir  string
@@ -137,7 +136,7 @@ func (c *ValidateImageMetadataCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		environ, err := environs.PrepareFromName(c.EnvName, context, store)
+		environ, err := c.prepare(context, store)
 		if err != nil {
 			return err
 		}

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/utils"
 	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/environs/simplestreams"
@@ -23,7 +22,7 @@ import (
 
 // ValidateToolsMetadataCommand
 type ValidateToolsMetadataCommand struct {
-	envcmd.EnvCommandBase
+	ImageMetadataCommandBase
 	out          cmd.Output
 	providerType string
 	metadataDir  string
@@ -145,7 +144,7 @@ func (c *ValidateToolsMetadataCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		environ, err := environs.PrepareFromName(c.EnvName, context, store)
+		environ, err := c.prepare(context, store)
 		if err == nil {
 			mdLookup, ok := environ.(simplestreams.MetadataValidator)
 			if !ok {

--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -216,7 +216,7 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	cfg, _, err := environs.ConfigForName(c.EnvName, store)
+	cfg, err := c.Config(store)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This branch introduces another intermediate structure that provides a method to prepare the environment.
