### PR TITLE
Use type switch in merge functions

### DIFF
--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1645,7 +1645,7 @@ func (w *actionWatcher) merge(changes set.Strings, updates map[interface{}]bool)
 				changes.Remove(id)
 			}
 		default:
-			return errors.Errorf("id is not of type string, go %T", id)
+			return errors.Errorf("id is not of type string, got %T", id)
 		}
 	}
 	return nil


### PR DESCRIPTION
Followup PR from #262. 
- Use a type switch rather than a type assertion when checking for unexpected values in merge functions
- Drive by code cleanups.
