### PR TITLE
state/apiserver: Return filename from Backup API

### DIFF
--- a/state/apiserver/backup.go
+++ b/state/apiserver/backup.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/api/params"
@@ -44,6 +45,9 @@ func (h *backupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.Header().Set("Content-Type", "application/octet-stream")
+		filename := filepath.Base(file.Name())
+		w.Header().Set("Content-Disposition",
+			fmt.Sprintf("attachment; filename=\"%s\"", filename))
 		w.Header().Set("Digest", fmt.Sprintf("SHA=%s", sha))
 
 		w.WriteHeader(http.StatusOK)

--- a/state/apiserver/backup_test.go
+++ b/state/apiserver/backup_test.go
@@ -107,6 +107,8 @@ func (s *backupSuite) TestBackupCalledAndFileServed(c *gc.C) {
 
 	c.Check(resp.StatusCode, gc.Equals, 200)
 	c.Check(resp.Header.Get("Digest"), gc.Equals, "SHA=some-sha")
+	c.Check(resp.Header.Get("Content-Disposition"), gc.Equals,
+		"attachment; filename=\"testBackupFile\"")
 	c.Check(resp.Header.Get("Content-Type"), gc.Equals, "application/octet-stream")
 
 	body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
This change adds a Content-Disposition header to backup API responses which contains the server-generated backup filename. This becomes important once backups start being stored server side (soon) but also simplifies the client side of the backup API (no need to generate backup filenames).
