### PR TITLE
fix for lp:1212538: cmd/juju: deploy --to a non existent machine fails too late in the process

### DIFF
--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -258,9 +258,9 @@ func (s *DeploySuite) TestForceMachineNewContainer(c *gc.C) {
 func (s *DeploySuite) TestForceMachineNotFound(c *gc.C) {
 	charmtesting.Charms.BundlePath(s.SeriesPath, "dummy")
 	err := runDeploy(c, "--to", "42", "local:dummy", "portlandia")
-	c.Assert(err, gc.ErrorMatches, `cannot assign unit "portlandia/0" to machine: machine 42 not found`)
-	_, err = s.State.Service("dummy")
-	c.Assert(err, gc.ErrorMatches, `service "dummy" not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy "portlandia" to machine 42: machine 42 not found`)
+	_, err = s.State.Service("portlandia")
+	c.Assert(err, gc.ErrorMatches, `service "portlandia" not found`)
 }
 
 func (s *DeploySuite) TestForceMachineSubordinate(c *gc.C) {

--- a/state/apiserver/client/client.go
+++ b/state/apiserver/client/client.go
@@ -250,6 +250,13 @@ func (c *Client) ServiceDeploy(args params.ServiceDeploy) error {
 		return fmt.Errorf("charm url must include revision")
 	}
 
+	if args.ToMachineSpec != "" && names.IsMachine(args.ToMachineSpec) {
+		_, err = c.api.state.Machine(args.ToMachineSpec)
+		if err != nil {
+			return fmt.Errorf(`cannot deploy "%v" to machine %v: %v`, args.ServiceName, args.ToMachineSpec, err)
+		}
+	}
+
 	// Try to find the charm URL in state first.
 	ch, err := c.api.state.Charm(curl)
 	if errors.IsNotFound(err) {

--- a/state/apiserver/client/client_test.go
+++ b/state/apiserver/client/client_test.go
@@ -863,6 +863,16 @@ func (s *clientSuite) TestClientServiceDeployToMachine(c *gc.C) {
 	c.Assert(mid, gc.Equals, machine.Id())
 }
 
+func (s *clientSuite) TestClientServiceDeployToMachineNotFound(c *gc.C) {
+	err := s.APIState.Client().ServiceDeploy(
+		"cs:precise/service-name-1", "service-name", 1, "", constraints.Value{}, "42",
+	)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy "service-name" to machine 42: machine 42 not found`)
+
+	_, err = s.State.Service("service-name")
+	c.Assert(err, gc.ErrorMatches, `service "service-name" not found`)
+}
+
 func (s *clientSuite) TestClientServiceDeployServiceOwner(c *gc.C) {
 	store, restore := makeMockCharmStore()
 	defer restore()


### PR DESCRIPTION
https://bugs.launchpad.net/juju-core/+bug/1212538.

There was already a test for the behaviour of deploying to a machine that didn't exist. But it was passing for the wrong reasons.

Currently deploying to a machine that doesn't exists still creates the service in the environment - but it won't be deployed- even when the correct machine id is added.

This fix will prevent a service being deployed if the machine doesn't exist.

Only applies if using the "--to" flag
