### PR TITLE
Specify a smaller mongo oplog size on local provider

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -56,6 +56,7 @@ const (
 	StorageDir       = "STORAGE_DIR"
 	StorageAddr      = "STORAGE_ADDR"
 	AgentServiceName = "AGENT_SERVICE_NAME"
+	MongoOplogSize   = "MONGO_OPLOG_SIZE"
 )
 
 // The Config interface is the sole way that the agent gets access to the

--- a/cmd/jujud/agent_test.go
+++ b/cmd/jujud/agent_test.go
@@ -241,7 +241,7 @@ func (s *agentSuite) SetUpSuite(c *gc.C) {
 	// a bit when some tests are restarting every 50ms for 10 seconds,
 	// so use a slightly more friendly delay.
 	worker.RestartDelay = 250 * time.Millisecond
-	s.PatchValue(&ensureMongoServer, func(string, string, params.StateServingInfo) error {
+	s.PatchValue(&ensureMongoServer, func(mongo.EnsureServerParams) error {
 		return nil
 	})
 }

--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -554,7 +554,6 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 	if !ok {
 		return fmt.Errorf("state worker was started with no state serving info")
 	}
-	namespace := agentConfig.Value(agent.Namespace)
 
 	// When upgrading from a pre-HA-capable environment,
 	// we must add machine-0 to the admin database and
@@ -598,11 +597,11 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 	}
 
 	// ensureMongoServer installs/upgrades the upstart config as necessary.
-	if err := ensureMongoServer(
-		agentConfig.DataDir(),
-		namespace,
-		servingInfo,
-	); err != nil {
+	ensureServerParams, err := newEnsureServerParams(agentConfig)
+	if err != nil {
+		return err
+	}
+	if err := ensureMongoServer(ensureServerParams); err != nil {
 		return err
 	}
 	if !shouldInitiateMongoServer {

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -25,7 +25,7 @@ var (
 	MaxOplogSizeMB = &maxOplogSizeMB
 	PreallocFile   = &preallocFile
 
-	OplogSize         = oplogSize
+	DefaultOplogSize  = defaultOplogSize
 	FsAvailSpace      = fsAvailSpace
 	PreallocFileSizes = preallocFileSizes
 	PreallocFiles     = preallocFiles

--- a/mongo/prealloc.go
+++ b/mongo/prealloc.go
@@ -38,24 +38,20 @@ var (
 
 // preallocOplog preallocates the Mongo oplog in the
 // specified Mongo datadabase directory.
-func preallocOplog(dir string) error {
-	size, err := oplogSize(dir)
-	if err != nil {
-		return err
-	}
-	// oplogSize returns MB, we want to work in bytes.
-	sizes := preallocFileSizes(size * 1024 * 1024)
+func preallocOplog(dir string, oplogSizeMB int) error {
+	// preallocFiles expects sizes in bytes.
+	sizes := preallocFileSizes(oplogSizeMB * 1024 * 1024)
 	prefix := filepath.Join(dir, "local.")
 	return preallocFiles(prefix, sizes...)
 }
 
-// oplogSize returns the default size in MB for the mongo oplog
-// based on the directory of the mongo database.
+// defaultOplogSize returns the default size in MB for the
+// mongo oplog based on the directory of the mongo database.
 //
 // The size of the oplog is calculated according to the
 // formula used by Mongo:
 //     http://docs.mongodb.org/manual/core/replica-set-oplog/
-func oplogSize(dir string) (int, error) {
+func defaultOplogSize(dir string) (int, error) {
 	if hostWordSize == 32 {
 		// "For 32-bit systems, MongoDB allocates about 48 megabytes
 		// of space to the oplog."

--- a/mongo/prealloc_test.go
+++ b/mongo/prealloc_test.go
@@ -71,7 +71,7 @@ func (s *preallocSuite) TestOplogSize(c *gc.C) {
 		s.PatchValue(mongo.HostWordSize, test.hostWordSize)
 		s.PatchValue(mongo.RuntimeGOOS, test.runtimeGOOS)
 		availSpace = test.availSpace
-		size, err := mongo.OplogSize("")
+		size, err := mongo.DefaultOplogSize("")
 		c.Check(err, gc.IsNil)
 		c.Check(size, gc.Equals, test.expected)
 	}

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -161,6 +161,11 @@ func (env *localEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.
 		agent.Namespace:   env.config.namespace(),
 		agent.StorageDir:  env.config.storageDir(),
 		agent.StorageAddr: env.config.storageAddr(),
+
+		// The local provider only supports a single state server,
+		// so we make the oplog size to a small value. This makes
+		// the preallocation faster with no disadvantage.
+		agent.MongoOplogSize: "1", // 1MB
 	}
 	if err := environs.FinishMachineConfig(mcfg, cfg, args.Constraints); err != nil {
 		return err


### PR DESCRIPTION
Since the local provider has a single Mongo instance,
the oplog is unuseful. We reduce the size to speed up
preallocation.

Fixes https://bugs.launchpad.net/juju-core/+bug/1338179
