### PR TITLE
Specify a smaller mongo oplog size on local provider

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -48,6 +48,7 @@ const (
 	StorageDir       = "STORAGE_DIR"
 	StorageAddr      = "STORAGE_ADDR"
 	AgentServiceName = "AGENT_SERVICE_NAME"
+	MongoOplogSize   = "MONGO_OPLOG_SIZE"
 )
 
 // The Config interface is the sole way that the agent gets access to the

--- a/cmd/jujud/agent_test.go
+++ b/cmd/jujud/agent_test.go
@@ -241,7 +241,7 @@ func (s *agentSuite) SetUpSuite(c *gc.C) {
 	// a bit when some tests are restarting every 50ms for 10 seconds,
 	// so use a slightly more friendly delay.
 	worker.RestartDelay = 250 * time.Millisecond
-	s.PatchValue(&ensureMongoServer, func(string, string, params.StateServingInfo) error {
+	s.PatchValue(&ensureMongoServer, func(mongo.EnsureServerParams) error {
 		return nil
 	})
 }

--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -546,7 +546,6 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 	if !ok {
 		return fmt.Errorf("state worker was started with no state serving info")
 	}
-	namespace := agentConfig.Value(agent.Namespace)
 
 	// When upgrading from a pre-HA-capable environment,
 	// we must add machine-0 to the admin database and
@@ -590,11 +589,11 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 	}
 
 	// ensureMongoServer installs/upgrades the upstart config as necessary.
-	if err := ensureMongoServer(
-		agentConfig.DataDir(),
-		namespace,
-		servingInfo,
-	); err != nil {
+	ensureServerParams, err := newEnsureServerParams(agentConfig)
+	if err != nil {
+		return err
+	}
+	if err := ensureMongoServer(ensureServerParams); err != nil {
 		return err
 	}
 	if !shouldInitiateMongoServer {

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -25,7 +25,7 @@ var (
 	MaxOplogSizeMB = &maxOplogSizeMB
 	PreallocFile   = &preallocFile
 
-	OplogSize         = oplogSize
+	DefaultOplogSize  = defaultOplogSize
 	FsAvailSpace      = fsAvailSpace
 	PreallocFileSizes = preallocFileSizes
 	PreallocFiles     = preallocFiles

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
@@ -134,7 +135,25 @@ func RemoveService(namespace string) error {
 	return upstartServiceStopAndRemove(svc)
 }
 
-// EnsureMongoServer ensures that the correct mongo upstart script is installed
+// EnsureServerParams is a parameter struct for EnsureServer.
+type EnsureServerParams struct {
+	params.StateServingInfo
+
+	// DataDir is the machine agent data directory.
+	DataDir string
+
+	// Namespace is the machine agent's namespace, which is used to
+	// generate a unique service name for Mongo.
+	Namespace string
+
+	// OplogSize is the size of the Mongo oplog.
+	// If this is zero, then EnsureServer will
+	// calculate a default size according to the
+	// algorithm defined in Mongo.
+	OplogSize int
+}
+
+// EnsureServer ensures that the correct mongo upstart script is installed
 // and running.
 //
 // This method will remove old versions of the mongo upstart script as necessary
@@ -143,21 +162,24 @@ func RemoveService(namespace string) error {
 // The namespace is a unique identifier to prevent multiple instances of mongo
 // on this machine from colliding. This should be empty unless using
 // the local provider.
-func EnsureServer(dataDir string, namespace string, info params.StateServingInfo) error {
-	logger.Infof("Ensuring mongo server is running; data directory %s; port %d", dataDir, info.StatePort)
-	dbDir := filepath.Join(dataDir, "db")
+func EnsureServer(args EnsureServerParams) error {
+	logger.Infof(
+		"Ensuring mongo server is running; data directory %s; port %d",
+		args.DataDir, args.StatePort,
+	)
+	dbDir := filepath.Join(args.DataDir, "db")
 
 	if err := os.MkdirAll(dbDir, 0700); err != nil {
 		return fmt.Errorf("cannot create mongo database directory: %v", err)
 	}
 
-	certKey := info.Cert + "\n" + info.PrivateKey
-	err := utils.AtomicWriteFile(sslKeyPath(dataDir), []byte(certKey), 0600)
+	certKey := args.Cert + "\n" + args.PrivateKey
+	err := utils.AtomicWriteFile(sslKeyPath(args.DataDir), []byte(certKey), 0600)
 	if err != nil {
 		return fmt.Errorf("cannot write SSL key: %v", err)
 	}
 
-	err = utils.AtomicWriteFile(sharedSecretPath(dataDir), []byte(info.SharedSecret), 0600)
+	err = utils.AtomicWriteFile(sharedSecretPath(args.DataDir), []byte(args.SharedSecret), 0600)
 	if err != nil {
 		return fmt.Errorf("cannot write mongod shared secret: %v", err)
 	}
@@ -180,7 +202,14 @@ func EnsureServer(dataDir string, namespace string, info params.StateServingInfo
 		return fmt.Errorf("cannot install mongod: %v", err)
 	}
 
-	upstartConf, mongoPath, err := upstartService(namespace, dataDir, dbDir, info.StatePort)
+	oplogSizeMB := args.OplogSize
+	if oplogSizeMB == 0 {
+		if oplogSizeMB, err = defaultOplogSize(dbDir); err != nil {
+			return err
+		}
+	}
+
+	upstartConf, mongoPath, err := upstartService(args.Namespace, args.DataDir, dbDir, args.StatePort, oplogSizeMB)
 	if err != nil {
 		return err
 	}
@@ -192,7 +221,7 @@ func EnsureServer(dataDir string, namespace string, info params.StateServingInfo
 	if err := makeJournalDirs(dbDir); err != nil {
 		return fmt.Errorf("error creating journal directories: %v", err)
 	}
-	if err := preallocOplog(dbDir); err != nil {
+	if err := preallocOplog(dbDir, oplogSizeMB); err != nil {
 		return fmt.Errorf("error creating oplog files: %v", err)
 	}
 	return upstartConfInstall(upstartConf)
@@ -242,7 +271,7 @@ func sharedSecretPath(dataDir string) string {
 // upstartService returns the upstart config for the mongo state service.
 // It also returns the path to the mongod executable that the upstart config
 // will be using.
-func upstartService(namespace, dataDir, dbDir string, port int) (*upstart.Conf, string, error) {
+func upstartService(namespace, dataDir, dbDir string, port, oplogSizeMB int) (*upstart.Conf, string, error) {
 	svc := upstart.NewService(ServiceName(namespace))
 
 	mongoPath, err := Path()
@@ -262,7 +291,8 @@ func upstartService(namespace, dataDir, dbDir string, port int) (*upstart.Conf, 
 		" --smallfiles" +
 		" --journal" +
 		" --keyFile " + utils.ShQuote(sharedSecretPath(dataDir)) +
-		" --replSet " + ReplicaSetName
+		" --replSet " + ReplicaSetName +
+		" --oplogSize " + strconv.Itoa(oplogSizeMB)
 	conf := &upstart.Conf{
 		Service: *svc,
 		Desc:    "juju state database",

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -50,6 +50,14 @@ var testInfo = params.StateServingInfo{
 	SharedSecret: "foobar-sharedsecret",
 }
 
+func makeEnsureServerParams(dataDir, namespace string) mongo.EnsureServerParams {
+	return mongo.EnsureServerParams{
+		StateServingInfo: testInfo,
+		DataDir:          dataDir,
+		Namespace:        namespace,
+	}
+}
+
 func (s *MongoSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	// Try to make sure we don't execute any commands accidentally.
@@ -131,7 +139,7 @@ func (s *MongoSuite) TestEnsureServer(c *gc.C) {
 
 	mockShellCommand(c, &s.CleanupSuite, "apt-get")
 
-	err := mongo.EnsureServer(dataDir, namespace, testInfo)
+	err := mongo.EnsureServer(makeEnsureServerParams(dataDir, namespace))
 	c.Assert(err, gc.IsNil)
 
 	testJournalDirs(dbDir, c)
@@ -162,7 +170,7 @@ func (s *MongoSuite) TestEnsureServer(c *gc.C) {
 
 	s.installed = nil
 	// now check we can call it multiple times without error
-	err = mongo.EnsureServer(dataDir, namespace, testInfo)
+	err = mongo.EnsureServer(makeEnsureServerParams(dataDir, namespace))
 	c.Assert(err, gc.IsNil)
 	assertInstalled()
 
@@ -198,7 +206,7 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 
 		s.PatchValue(&version.Current.Series, test.series)
 
-		err := mongo.EnsureServer(dataDir, namespace, testInfo)
+		err := mongo.EnsureServer(makeEnsureServerParams(dataDir, namespace))
 		c.Assert(err, gc.IsNil)
 
 		cmds := getMockShellCalls(c, output)
@@ -219,7 +227,7 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 func (s *MongoSuite) TestUpstartServiceWithReplSet(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234)
+	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, 1024)
 	c.Assert(err, gc.IsNil)
 	c.Assert(strings.Contains(svc.Cmd, "--replSet"), jc.IsTrue)
 }
@@ -227,7 +235,7 @@ func (s *MongoSuite) TestUpstartServiceWithReplSet(c *gc.C) {
 func (s *MongoSuite) TestUpstartServiceWithJournal(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234)
+	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, 1024)
 	c.Assert(err, gc.IsNil)
 	journalPresent := strings.Contains(svc.Cmd, " --journal ") || strings.HasSuffix(svc.Cmd, " --journal")
 	c.Assert(journalPresent, jc.IsTrue)
@@ -265,11 +273,11 @@ func (s *MongoSuite) TestQuantalAptAddRepo(c *gc.C) {
 	// test that we call add-apt-repository only for quantal (and that if it
 	// fails, we return the error)
 	s.PatchValue(&version.Current.Series, "quantal")
-	err := mongo.EnsureServer(dir, "", testInfo)
+	err := mongo.EnsureServer(makeEnsureServerParams(dir, ""))
 	c.Assert(err, gc.ErrorMatches, "cannot install mongod: cannot add apt repository: exit status 1.*")
 
 	s.PatchValue(&version.Current.Series, "trusty")
-	err = mongo.EnsureServer(dir, "", testInfo)
+	err = mongo.EnsureServer(makeEnsureServerParams(dir, ""))
 	c.Assert(err, gc.IsNil)
 }
 
@@ -278,7 +286,7 @@ func (s *MongoSuite) TestNoMongoDir(c *gc.C) {
 	// created.
 	mockShellCommand(c, &s.CleanupSuite, "apt-get")
 	dataDir := filepath.Join(c.MkDir(), "dir", "data")
-	err := mongo.EnsureServer(dataDir, "", testInfo)
+	err := mongo.EnsureServer(makeEnsureServerParams(dataDir, ""))
 	c.Check(err, gc.IsNil)
 
 	_, err = os.Stat(filepath.Join(dataDir, "db"))
@@ -344,7 +352,7 @@ func (s *MongoSuite) TestAddPPAInQuantal(c *gc.C) {
 	s.PatchValue(&version.Current.Series, "quantal")
 
 	dataDir := c.MkDir()
-	err := mongo.EnsureServer(dataDir, "", testInfo)
+	err := mongo.EnsureServer(makeEnsureServerParams(dataDir, ""))
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(getMockShellCalls(c, addAptRepoOut), gc.DeepEquals, [][]string{{

--- a/mongo/prealloc.go
+++ b/mongo/prealloc.go
@@ -38,24 +38,20 @@ var (
 
 // preallocOplog preallocates the Mongo oplog in the
 // specified Mongo datadabase directory.
-func preallocOplog(dir string) error {
-	size, err := oplogSize(dir)
-	if err != nil {
-		return err
-	}
-	// oplogSize returns MB, we want to work in bytes.
-	sizes := preallocFileSizes(size * 1024 * 1024)
+func preallocOplog(dir string, oplogSizeMB int) error {
+	// preallocFiles expects sizes in bytes.
+	sizes := preallocFileSizes(oplogSizeMB * 1024 * 1024)
 	prefix := filepath.Join(dir, "local.")
 	return preallocFiles(prefix, sizes...)
 }
 
-// oplogSize returns the default size in MB for the mongo oplog
-// based on the directory of the mongo database.
+// defaultOplogSize returns the default size in MB for the
+// mongo oplog based on the directory of the mongo database.
 //
 // The size of the oplog is calculated according to the
 // formula used by Mongo:
 //     http://docs.mongodb.org/manual/core/replica-set-oplog/
-func oplogSize(dir string) (int, error) {
+func defaultOplogSize(dir string) (int, error) {
 	if hostWordSize == 32 {
 		// "For 32-bit systems, MongoDB allocates about 48 megabytes
 		// of space to the oplog."

--- a/mongo/prealloc_test.go
+++ b/mongo/prealloc_test.go
@@ -71,7 +71,7 @@ func (s *preallocSuite) TestOplogSize(c *gc.C) {
 		s.PatchValue(mongo.HostWordSize, test.hostWordSize)
 		s.PatchValue(mongo.RuntimeGOOS, test.runtimeGOOS)
 		availSpace = test.availSpace
-		size, err := mongo.OplogSize("")
+		size, err := mongo.DefaultOplogSize("")
 		c.Check(err, gc.IsNil)
 		c.Check(size, gc.Equals, test.expected)
 	}

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -160,6 +160,11 @@ func (env *localEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.
 		agent.Namespace:   env.config.namespace(),
 		agent.StorageDir:  env.config.storageDir(),
 		agent.StorageAddr: env.config.storageAddr(),
+
+		// The local provider only supports a single state server,
+		// so we make the oplog size to a small value. This makes
+		// the preallocation faster with no disadvantage.
+		agent.MongoOplogSize: "1", // 1MB
 	}
 	if err := environs.FinishMachineConfig(mcfg, cfg, args.Constraints); err != nil {
 		return err


### PR DESCRIPTION
Since the local provider has a single Mongo instance,
the oplog is unuseful. We reduce the size to speed up
preallocation.

(Cherry-pick from master)

Fixes https://bugs.launchpad.net/juju-core/+bug/1338179
