### PR TITLE
Reopen mongo sessions between replset initiation attempts

### DIFF
--- a/replicaset/replicaset.go
+++ b/replicaset/replicaset.go
@@ -23,6 +23,14 @@ const (
 	// attempts to replSetInitiate.
 	initiateAttemptDelay = 100 * time.Millisecond
 
+	// maxInitiateStatusAttempts is the maximum number of attempts
+	// to get the replication status after Initiate.
+	maxInitiateStatusAttempts = 50
+
+	// initiateAttemptStatusDelay is the amount of time to sleep between failed
+	// attempts to replSetGetStatus.
+	initiateAttemptStatusDelay = 500 * time.Millisecond
+
 	// rsMembersUnreachableError is the error message returned from mongo
 	// when it thinks that replicaset members are unreachable. This can
 	// occur if replSetInitiate is executed shortly after starting up mongo.
@@ -30,6 +38,8 @@ const (
 )
 
 var logger = loggo.GetLogger("juju.replicaset")
+
+var getCurrentStatus = CurrentStatus
 
 // Initiate sets up a replica set with the given replica set name with the
 // single given member.  It need be called only once for a given mongo replica
@@ -65,6 +75,22 @@ func Initiate(session *mgo.Session, address, name string, tags map[string]string
 		break
 	}
 
+	// Wait for replSetInitiate to complete. Even if err != nil,
+	// it may be that replSetInitiate is still in progress, so
+	// attempt CurrentStatus.
+	for i := 0; i < maxInitiateStatusAttempts; i++ {
+		monotonicSession.Refresh()
+		var status *Status
+		status, err = getCurrentStatus(monotonicSession)
+		if err != nil {
+			logger.Warningf("Initiate: fetching replication status failed: %v", err)
+		}
+		if err != nil || len(status.Members) == 0 {
+			time.Sleep(initiateAttemptStatusDelay)
+			continue
+		}
+		break
+	}
 	return err
 }
 

--- a/replicaset/replicaset_test.go
+++ b/replicaset/replicaset_test.go
@@ -86,6 +86,35 @@ func (s *MongoSuite) dialAndTestInitiate(c *gc.C) {
 	loadData(session, c)
 }
 
+func (s *MongoSuite) TestInitiateWaitsForStatus(c *gc.C) {
+	s.root.Destroy()
+
+	// create a new server that hasn't been initiated
+	s.root = newServer(c)
+	session := s.root.MustDialDirect()
+	defer session.Close()
+
+	i := 0
+	mockStatus := func(session *mgo.Session) (*Status, error) {
+		status := &Status{}
+		var err error
+		i += 1
+		if i < 20 {
+			err = fmt.Errorf("bang!")
+		} else if i > 20 {
+			// when i == 20 then len(status.Members) == 0
+			// so we will be called one more time until we populate
+			// Members
+			status.Members = append(status.Members, MemberStatus{Id: 1})
+		}
+		return status, err
+	}
+
+	s.PatchValue(&getCurrentStatus, mockStatus)
+	Initiate(session, s.root.Addr(), rsName, initialTags)
+	c.Assert(i, gc.Equals, 21)
+}
+
 func loadData(session *mgo.Session, c *gc.C) {
 	type foo struct {
 		Name    string


### PR DESCRIPTION
Also, reinstate a change made by mfoord to call CurrentStatus
after attempting intiation, and refresh session between attempts.

(Cherry-pick from master)

Fixes https://bugs.launchpad.net/juju-core/+bug/1339240
