### PR TITLE
cmd/jujud: ensure we don't ensureMongoServer twice

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -534,13 +534,18 @@ func (a *MachineAgent) limitLoginsDuringUpgrade(creds params.Creds) error {
 
 // ensureMongoServer ensures that mongo is installed and running,
 // and ready for opening a state connection.
-func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
+func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 	a.mongoInitMutex.Lock()
 	defer a.mongoInitMutex.Unlock()
 	if a.mongoInitialized {
 		logger.Debugf("mongo is already initialized")
 		return nil
 	}
+	defer func() {
+		if err == nil {
+			a.mongoInitialized = true
+		}
+	}()
 
 	servingInfo, ok := agentConfig.StateServingInfo()
 	if !ok {
@@ -624,7 +629,6 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) error {
 	}); err != nil {
 		return err
 	}
-	a.mongoInitialized = true
 	return nil
 }
 


### PR DESCRIPTION
The upgrade-steps and StateWorker both call ensureMongoServer,
which is meant to check/set a flag so that we only set it up
once. There's an early exit case which meant that the flag was
not being set, which led to the upgrade-steps code restarting
mongo half-way through.

(Cherry pick from master)

Fixes https://bugs.launchpad.net/juju-core/+bug/1338511
