### PR TITLE
juju/api: use the environuuid if set

### DIFF
--- a/juju/api.go
+++ b/juju/api.go
@@ -335,7 +335,7 @@ func cacheAPIInfo(info configstore.EnvironInfo, apiInfo *api.Info) (err error) {
 	defer errors.Contextf(&err, "failed to cache API credentials")
 	environUUID := ""
 	if apiInfo.EnvironTag != "" {
-		tag, err := names.ParseEnvironTag(apiInfo.Tag)
+		tag, err := names.ParseEnvironTag(apiInfo.EnvironTag)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix a bug where the wrong tag was used when caching api credentials.
