### PR TITLE
Implemented prefer-ipv6 environment setting

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -667,6 +667,13 @@ func (c *Config) Development() bool {
 	return c.defined["development"].(bool)
 }
 
+// PreferIPv6 returns whether IPv6 addresses for API endpoints and
+// machines will be preferred (when available) over IPv4.
+func (c *Config) PreferIPv6() bool {
+	v, _ := c.defined["prefer-ipv6"].(bool)
+	return v
+}
+
 // SSLHostnameVerification returns weather the environment has requested
 // SSL hostname verification to be enabled.
 func (c *Config) SSLHostnameVerification() bool {
@@ -801,6 +808,7 @@ var fields = schema.Fields{
 	"proxy-ssh":                 schema.Bool(),
 	"lxc-clone":                 schema.Bool(),
 	"lxc-clone-aufs":            schema.Bool(),
+	"prefer-ipv6":               schema.Bool(),
 
 	// Deprecated fields, retain for backwards compatibility.
 	"tools-url":     schema.String(),
@@ -865,6 +873,7 @@ var alwaysOptional = schema.Defaults{
 	"test-mode":      false,
 	"proxy-ssh":      false,
 	"lxc-clone-aufs": false,
+	"prefer-ipv6":    false,
 }
 
 func allowEmpty(attr string) bool {
@@ -888,6 +897,7 @@ func allDefaults() schema.Defaults {
 		"bootstrap-retry-delay":     DefaultBootstrapSSHRetryDelay,
 		"bootstrap-addresses-delay": DefaultBootstrapSSHAddressesDelay,
 		"proxy-ssh":                 true,
+		"prefer-ipv6":               false,
 	}
 	for attr, val := range alwaysOptional {
 		if _, ok := d[attr]; !ok {
@@ -928,6 +938,7 @@ var immutableAttributes = []string{
 	"lxc-clone",
 	"lxc-clone-aufs",
 	"syslog-port",
+	"prefer-ipv6",
 }
 
 var (

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -338,6 +338,32 @@ var configTests = []configTest{
 		},
 		err: `development: expected bool, got string\("invalid"\)`,
 	}, {
+		about:       "Invalid prefer-ipv6 flag",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":            "my-type",
+			"name":            "my-name",
+			"authorized-keys": testing.FakeAuthKeys,
+			"prefer-ipv6":     "invalid",
+		},
+		err: `prefer-ipv6: expected bool, got string\("invalid"\)`,
+	}, {
+		about:       "prefer-ipv6 off",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":        "my-type",
+			"name":        "my-name",
+			"prefer-ipv6": false,
+		},
+	}, {
+		about:       "prefer-ipv6 on",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":        "my-type",
+			"name":        "my-name",
+			"prefer-ipv6": true,
+		},
+	}, {
 		about:       "Invalid agent version",
 		useDefaults: config.UseDefaults,
 		attrs: testing.Attrs{
@@ -1075,6 +1101,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 	attrs["image-stream"] = ""
 	attrs["proxy-ssh"] = false
 	attrs["lxc-clone-aufs"] = false
+	attrs["prefer-ipv6"] = false
 
 	// Default firewall mode is instance
 	attrs["firewall-mode"] = string(config.FwInstance)

--- a/network/address.go
+++ b/network/address.go
@@ -18,14 +18,11 @@ var (
 	ipv6UniqueLocal = mustParseCIDR("fc00::/7")
 )
 
-// PreferIPv6 determines whether IPv6 addresses will be preferred when
+// preferIPv6 determines whether IPv6 addresses will be preferred when
 // selecting a public or internal addresses, using the Select*()
-// methods below.
-//
-// TODO(dimitern): Expose prefer-ipv6 as an environment setting and/or
-// charm metadata config and use it as an argument to the Select*()
-// methods.
-var PreferIPv6 bool = false
+// methods below. InitializeFromConfig() needs to be called to
+// set this flag globally.
+var preferIPv6 bool = false
 
 func mustParseCIDR(s string) *net.IPNet {
 	_, net, err := net.ParseCIDR(s)
@@ -182,7 +179,7 @@ func NewAddress(value string, scope Scope) Address {
 // appropriate to display as a publicly accessible endpoint. If there
 // are no suitable addresses, the empty string is returned.
 func SelectPublicAddress(addresses []Address) string {
-	index := bestAddressIndex(len(addresses), PreferIPv6, func(i int) Address {
+	index := bestAddressIndex(len(addresses), preferIPv6, func(i int) Address {
 		return addresses[i]
 	}, publicMatch)
 	if index < 0 {
@@ -195,7 +192,7 @@ func SelectPublicAddress(addresses []Address) string {
 // appropriate to display as a publicly accessible endpoint. If there
 // are no suitable candidates, the empty string is returned.
 func SelectPublicHostPort(hps []HostPort) string {
-	index := bestAddressIndex(len(hps), PreferIPv6, func(i int) Address {
+	index := bestAddressIndex(len(hps), preferIPv6, func(i int) Address {
 		return hps[i].Address
 	}, publicMatch)
 	if index < 0 {
@@ -208,7 +205,7 @@ func SelectPublicHostPort(hps []HostPort) string {
 // used as an endpoint for juju internal communication. If there are
 // no suitable addresses, the empty string is returned.
 func SelectInternalAddress(addresses []Address, machineLocal bool) string {
-	index := bestAddressIndex(len(addresses), PreferIPv6, func(i int) Address {
+	index := bestAddressIndex(len(addresses), preferIPv6, func(i int) Address {
 		return addresses[i]
 	}, internalAddressMatcher(machineLocal))
 	if index < 0 {
@@ -222,7 +219,7 @@ func SelectInternalAddress(addresses []Address, machineLocal bool) string {
 // in its NetAddr form. If there are no suitable addresses, the empty
 // string is returned.
 func SelectInternalHostPort(hps []HostPort, machineLocal bool) string {
-	index := bestAddressIndex(len(hps), PreferIPv6, func(i int) Address {
+	index := bestAddressIndex(len(hps), preferIPv6, func(i int) Address {
 		return hps[i].Address
 	}, internalAddressMatcher(machineLocal))
 	if index < 0 {

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -290,12 +290,15 @@ var selectPublicTests = []selectTest{{
 }}
 
 func (s *AddressSuite) TestSelectPublicAddress(c *gc.C) {
+	oldValue := network.GetPreferIPv6()
+	defer func() {
+		network.SetPreferIPv6(oldValue)
+	}()
 	for i, t := range selectPublicTests {
 		c.Logf("test %d: %s", i, t.about)
-		network.PreferIPv6 = t.preferIPv6
+		network.SetPreferIPv6(t.preferIPv6)
 		c.Check(network.SelectPublicAddress(t.addresses), gc.Equals, t.expected())
 	}
-	network.PreferIPv6 = false
 }
 
 var selectInternalTests = []selectTest{{
@@ -379,12 +382,15 @@ var selectInternalTests = []selectTest{{
 }}
 
 func (s *AddressSuite) TestSelectInternalAddress(c *gc.C) {
+	oldValue := network.GetPreferIPv6()
+	defer func() {
+		network.SetPreferIPv6(oldValue)
+	}()
 	for i, t := range selectInternalTests {
 		c.Logf("test %d: %s", i, t.about)
-		network.PreferIPv6 = t.preferIPv6
+		network.SetPreferIPv6(t.preferIPv6)
 		c.Check(network.SelectInternalAddress(t.addresses, false), gc.Equals, t.expected())
 	}
-	network.PreferIPv6 = false
 }
 
 var selectInternalMachineTests = []selectTest{{
@@ -445,12 +451,15 @@ var selectInternalMachineTests = []selectTest{{
 }}
 
 func (s *AddressSuite) TestSelectInternalMachineAddress(c *gc.C) {
+	oldValue := network.GetPreferIPv6()
+	defer func() {
+		network.SetPreferIPv6(oldValue)
+	}()
 	for i, t := range selectInternalMachineTests {
 		c.Logf("test %d: %s", i, t.about)
-		network.PreferIPv6 = t.preferIPv6
+		network.SetPreferIPv6(t.preferIPv6)
 		c.Check(network.SelectInternalAddress(t.addresses, true), gc.Equals, t.expected())
 	}
-	network.PreferIPv6 = false
 }
 
 var stringTests = []struct {

--- a/network/export_test.go
+++ b/network/export_test.go
@@ -1,0 +1,12 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+func SetPreferIPv6(value bool) {
+	preferIPv6 = value
+}
+
+func GetPreferIPv6() bool {
+	return preferIPv6
+}

--- a/network/network.go
+++ b/network/network.go
@@ -5,7 +5,11 @@ package network
 
 import (
 	"fmt"
+
+	"launchpad.net/loggo"
 )
+
+var logger = loggo.GetLogger("juju.network")
 
 // Id defines a provider-specific network id.
 type Id string
@@ -71,4 +75,18 @@ func (i *Info) ActualInterfaceName() string {
 // opposed to a physical device (e.g. a VLAN or a network alias)
 func (i *Info) IsVirtual() bool {
 	return i.VLANTag > 0
+}
+
+// PreferIPv6Getter will be implemented by both the environment and agent
+// config.
+type PreferIPv6Getter interface {
+	PreferIPv6() bool
+}
+
+// InitializeFromConfig needs to be called once after the environment
+// or agent configuration is available to configure networking
+// settings.
+func InitializeFromConfig(config PreferIPv6Getter) {
+	preferIPv6 = config.PreferIPv6()
+	logger.Debugf("network.preferIPv6 = %v", preferIPv6)
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -8,6 +8,7 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/testing"
 )
 
 type InfoSuite struct {
@@ -34,4 +35,26 @@ func (n *InfoSuite) TestIsVirtual(c *gc.C) {
 	c.Check(n.info[0].IsVirtual(), jc.IsTrue)
 	c.Check(n.info[1].IsVirtual(), jc.IsFalse)
 	c.Check(n.info[2].IsVirtual(), jc.IsTrue)
+}
+
+type NetworkSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&NetworkSuite{})
+
+func (*NetworkSuite) TestInitializeFromConfig(c *gc.C) {
+	c.Check(network.GetPreferIPv6(), jc.IsFalse)
+
+	envConfig := testing.CustomEnvironConfig(c, testing.Attrs{
+		"prefer-ipv6": true,
+	})
+	network.InitializeFromConfig(envConfig)
+	c.Check(network.GetPreferIPv6(), jc.IsTrue)
+
+	envConfig = testing.CustomEnvironConfig(c, testing.Attrs{
+		"prefer-ipv6": false,
+	})
+	network.InitializeFromConfig(envConfig)
+	c.Check(network.GetPreferIPv6(), jc.IsFalse)
 }

--- a/network/port_test.go
+++ b/network/port_test.go
@@ -49,33 +49,42 @@ func (t hostPortTest) expected() string {
 }
 
 func (s *PortSuite) TestSelectPublicHostPort(c *gc.C) {
+	oldValue := network.GetPreferIPv6()
+	defer func() {
+		network.SetPreferIPv6(oldValue)
+	}()
 	for i, t0 := range selectPublicTests {
 		t := t0.hostPortTest()
 		c.Logf("test %d: %s", i, t.about)
-		network.PreferIPv6 = t.preferIPv6
+		network.SetPreferIPv6(t.preferIPv6)
 		c.Check(network.SelectPublicHostPort(t.hostPorts), jc.DeepEquals, t.expected())
 	}
-	network.PreferIPv6 = false
 }
 
 func (s *PortSuite) TestSelectInternalHostPort(c *gc.C) {
+	oldValue := network.GetPreferIPv6()
+	defer func() {
+		network.SetPreferIPv6(oldValue)
+	}()
 	for i, t0 := range selectInternalTests {
 		t := t0.hostPortTest()
 		c.Logf("test %d: %s", i, t.about)
-		network.PreferIPv6 = t.preferIPv6
+		network.SetPreferIPv6(t.preferIPv6)
 		c.Check(network.SelectInternalHostPort(t.hostPorts, false), jc.DeepEquals, t.expected())
 	}
-	network.PreferIPv6 = false
 }
 
 func (s *PortSuite) TestSelectInternalMachineHostPort(c *gc.C) {
+	oldValue := network.GetPreferIPv6()
+	defer func() {
+		network.SetPreferIPv6(oldValue)
+	}()
 	for i, t0 := range selectInternalMachineTests {
 		t := t0.hostPortTest()
 		c.Logf("test %d: %s", i, t.about)
-		network.PreferIPv6 = t.preferIPv6
+		network.SetPreferIPv6(t.preferIPv6)
 		c.Check(network.SelectInternalHostPort(t.hostPorts, true), gc.DeepEquals, t.expected())
 	}
-	network.PreferIPv6 = false
 }
 
 func (*PortSuite) TestAddressesWithPort(c *gc.C) {

--- a/provider/dummy/storage.go
+++ b/provider/dummy/storage.go
@@ -149,7 +149,7 @@ func (s *storageServer) URL(name string) (string, error) {
 		panic(err.Error())
 	}
 	hostPort := ""
-	if providerInstance.preferIPv6 {
+	if s.state.preferIPv6 {
 		hostPort = net.JoinHostPort("::1", port)
 	} else {
 		hostPort = net.JoinHostPort("127.0.0.1", port)


### PR DESCRIPTION
This is the first of a series of PRs to implement
a "prefer-ipv6" flag across the codebase. As a first
step the following changes were made:
- Added prefer-ipv6 Boolean flag to the environ config.
  It is optional and defaults to false, and is immutable
  once set.
- Rather than using a global variable network.PreferIPv6,
  now a new function was implemented: InitializeFromConfig(),
  which takes an interface with PreferIPv6() bool to set
  the (now internal) preferIPv6 flag. This needs to be called
  at start up in several places (bootstrap, MA, UA, CLI), but
  that will happen in follow-ups.
- Changed the dummy provider a bit to accommodate the changes
  done to the network and config packages.

Next in line will be implementing a PreferIPv6 field in the
agent config, so if it's true we can call InitializeFromConfig
before trying to connect to state or the API to ensure the
user's request to prefer IPv6 addresses / endpoints is honored.
