### PR TITLE
Fix NetworkInterfaceSuite.TestRemove random failure

### DIFF
--- a/state/networkinterfaces.go
+++ b/state/networkinterfaces.go
@@ -173,7 +173,7 @@ func (ni *NetworkInterface) Refresh() error {
 	doc := networkInterfaceDoc{}
 	err := ni.st.networkInterfaces.FindId(ni.doc.Id).One(&doc)
 	if err == mgo.ErrNotFound {
-		return errors.NotFoundf("network interface %v", ni)
+		return errors.NotFoundf("network interface %#v", ni)
 	}
 	if err != nil {
 		return fmt.Errorf("cannot refresh network interface %q on machine %q: %v",

--- a/state/networkinterfaces_test.go
+++ b/state/networkinterfaces_test.go
@@ -73,6 +73,7 @@ func (s *NetworkInterfaceSuite) TestRemove(c *gc.C) {
 	err := s.iface.Remove()
 	c.Assert(err, gc.IsNil)
 	err = s.iface.Refresh()
-	c.Assert(err, gc.ErrorMatches, `network interface .* not found`)
+	errMatch := `network interface &state\.NetworkInterface\{.*\} not found`
+	c.Check(err, gc.ErrorMatches, errMatch)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }


### PR DESCRIPTION
The NetworkInterface type must be serialised as %#v not %v for errors.NotFoundf so the GoString method gets used. Also improve the test error match to ensure the correct serialisation is used. Without this change, the test could randomly fail if the bson id happened to contain an 0x0A byte, as `.*` does not match newlines.
