### PR TITLE
Use right loggo in network/network.go

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -6,7 +6,7 @@ package network
 import (
 	"fmt"
 
-	"launchpad.net/loggo"
+	"github.com/juju/loggo"
 )
 
 var logger = loggo.GetLogger("juju.network")


### PR DESCRIPTION
The correct location of loggo these days in on github, not launchpad. Switch newly added import to the correct path.
