### PR TITLE
Added named pipes support

### DIFF
--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"net/rpc"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +17,7 @@ import (
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/juju/names"
+	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/worker/uniter/jujuc"
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
@@ -78,7 +78,7 @@ func jujuCMain(commandName string, args []string) (code int, err error) {
 	if err != nil {
 		return
 	}
-	client, err := rpc.Dial("unix", socketPath)
+	client, err := sockets.Dial(socketPath)
 	if err != nil {
 		return
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,6 +19,7 @@ github.com/juju/schema	git	de545dbe6bec9a1586adfed8b47b99b616796c98
 github.com/juju/testing	git	748599d14ccb0f11b0d2b6d64141749116c9fcd5	
 github.com/juju/txn	git	1bc7d3e5e9cad446e5d1d659856b67f0f869d3d7	
 github.com/juju/utils	git	7f3110a0b4f01e5800e72b50cc92c8e9de4ea658	
+gopkg.in/natefinch/npipe.v2	git	86d100b9cc0fb2e0d27f2222801c16cd6fe9916a	
 labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/goamz	bzr	ian.booth@canonical.com-20140708164959-72q70lo1du0e4qki	48

--- a/juju/sockets/sockets.go
+++ b/juju/sockets/sockets.go
@@ -1,0 +1,5 @@
+package sockets
+
+import "github.com/juju/loggo"
+
+var logger = loggo.GetLogger("juju.juju.sockets")

--- a/juju/sockets/sockets_nix.go
+++ b/juju/sockets/sockets_nix.go
@@ -1,0 +1,26 @@
+// +build !windows
+
+package sockets
+
+import (
+	"net"
+	"net/rpc"
+	"os"
+)
+
+func Dial(socketPath string) (*rpc.Client, error) {
+	return rpc.Dial("unix", socketPath)
+}
+
+func Listen(socketPath string) (net.Listener, error) {
+	// In case the unix socket is present, delete it.
+	if err := os.Remove(socketPath); err != nil {
+		logger.Tracef("ignoring error on removing %q: %v", socketPath, err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		logger.Errorf("failed to listen on unix:%s: %v", socketPath, err)
+		return nil, err
+	}
+	return listener, err
+}

--- a/juju/sockets/sockets_windows.go
+++ b/juju/sockets/sockets_windows.go
@@ -1,0 +1,25 @@
+package sockets
+
+import (
+	"net"
+	"net/rpc"
+
+	"gopkg.in/natefinch/npipe.v2"
+)
+
+func Dial(socketPath string) (*rpc.Client, error) {
+	conn, err := npipe.Dial(socketPath)
+	if err != nil {
+		return nil, err
+	}
+	return rpc.NewClient(conn), nil
+}
+
+func Listen(socketPath string) (net.Listener, error) {
+	listener, err := npipe.Listen(socketPath)
+	if err != nil {
+		logger.Errorf("failed to listen on:%s: %v", socketPath, err)
+		return nil, err
+	}
+	return listener, err
+}

--- a/worker/uniter/jujuc/server.go
+++ b/worker/uniter/jujuc/server.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"github.com/juju/cmd"
+	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/exec"
 )
@@ -126,7 +127,7 @@ func NewServer(getCmd CmdGetter, socketPath string) (*Server, error) {
 	if err := server.Register(&Jujuc{getCmd: getCmd}); err != nil {
 		return nil, err
 	}
-	listener, err := net.Listen("unix", socketPath)
+	listener, err := sockets.Listen(socketPath)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/uniter/runlistener.go
+++ b/worker/uniter/runlistener.go
@@ -9,9 +9,9 @@ package uniter
 import (
 	"net"
 	"net/rpc"
-	"os"
 	"sync"
 
+	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/utils/exec"
 )
 
@@ -51,7 +51,7 @@ func (r *JujuRunServer) RunCommands(commands string, result *exec.ExecResponse) 
 }
 
 // NewRunListener returns a new RunListener that is listening on given
-// unix socket path passed in. If a valid RunListener is returned, is
+// socket or named pipe passed in. If a valid RunListener is returned, is
 // has the go routine running, and should be closed by the creator
 // when they are done with it.
 func NewRunListener(runner CommandRunner, socketPath string) (*RunListener, error) {
@@ -59,13 +59,8 @@ func NewRunListener(runner CommandRunner, socketPath string) (*RunListener, erro
 	if err := server.Register(&JujuRunServer{runner}); err != nil {
 		return nil, err
 	}
-	// In case the unix socket is present, delete it.
-	if err := os.Remove(socketPath); err != nil {
-		logger.Tracef("ignoring error on removing %q: %v", socketPath, err)
-	}
-	listener, err := net.Listen("unix", socketPath)
+	listener, err := sockets.Listen(socketPath)
 	if err != nil {
-		logger.Errorf("failed to listen on unix:%s: %v", socketPath, err)
 		return nil, err
 	}
 	runListener := &RunListener{


### PR DESCRIPTION
This branch replaces unix sockets with named pipes on windows.

The "sockets" package name is temporary. It should be named something else that denotes that it will only dial either unix sockets or named pipes. Dialing TCP sockets works the same on both windows and linux.
