### PR TITLE
Pass prefer-ipv6 flag through agent config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -132,6 +132,10 @@ type Config interface {
 	// Value returns the value associated with the key, or an empty string if
 	// the key is not found.
 	Value(key string) string
+
+	// PreferIPv6 returns whether to prefer using IPv6 addresses (if
+	// available) when connecting to the state or API server.
+	PreferIPv6() bool
 }
 
 type ConfigSetterOnly interface {
@@ -238,6 +242,7 @@ type configInternal struct {
 	oldPassword       string
 	servingInfo       *params.StateServingInfo
 	values            map[string]string
+	preferIPv6        bool
 }
 
 type AgentConfigParams struct {
@@ -252,6 +257,7 @@ type AgentConfigParams struct {
 	APIAddresses      []string
 	CACert            string
 	Values            map[string]string
+	PreferIPv6        bool
 }
 
 // NewAgentConfig returns a new config object suitable for use for a
@@ -292,6 +298,7 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		caCert:            configParams.CACert,
 		oldPassword:       configParams.Password,
 		values:            configParams.Values,
+		preferIPv6:        configParams.PreferIPv6,
 	}
 	if len(configParams.StateAddresses) > 0 {
 		config.stateDetails = &connectionDetails{
@@ -537,6 +544,10 @@ func (c *configInternal) Value(key string) string {
 	return c.values[key]
 }
 
+func (c *configInternal) PreferIPv6() bool {
+	return c.preferIPv6
+}
+
 func (c *configInternal) StateServingInfo() (params.StateServingInfo, bool) {
 	if c.servingInfo == nil {
 		return params.StateServingInfo{}, false
@@ -624,16 +635,19 @@ func (c *configInternal) APIInfo() *api.Info {
 	addrs := c.apiDetails.addresses
 	if isStateServer {
 		port := servingInfo.APIPort
-		localApiAddr := fmt.Sprintf("localhost:%d", port)
+		localAPIAddr := net.JoinHostPort("localhost", strconv.Itoa(port))
+		if c.preferIPv6 {
+			localAPIAddr = net.JoinHostPort("::1", strconv.Itoa(port))
+		}
 		addrInAddrs := false
 		for _, addr := range addrs {
-			if addr == localApiAddr {
+			if addr == localAPIAddr {
 				addrInAddrs = true
 				break
 			}
 		}
 		if !addrInAddrs {
-			addrs = append(addrs, localApiAddr)
+			addrs = append(addrs, localAPIAddr)
 		}
 	}
 	return &api.Info{
@@ -651,6 +665,9 @@ func (c *configInternal) MongoInfo() (info *authentication.MongoInfo, ok bool) {
 		return nil, false
 	}
 	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(ssi.StatePort))
+	if c.preferIPv6 {
+		addr = net.JoinHostPort("::1", strconv.Itoa(ssi.StatePort))
+	}
 	return &authentication.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{addr},

--- a/agent/format-1.18.go
+++ b/agent/format-1.18.go
@@ -43,6 +43,8 @@ type format_1_18Serialization struct {
 	OldPassword string
 	Values      map[string]string
 
+	PreferIPv6 bool `yaml:"prefer-ipv6,omitempty"`
+
 	// Only state server machines have these next three items
 	StateServerCert string `yaml:",omitempty"`
 	StateServerKey  string `yaml:",omitempty"`
@@ -86,6 +88,7 @@ func (formatter_1_18) unmarshal(data []byte) (*configInternal, error) {
 		caCert:            format.CACert,
 		oldPassword:       format.OldPassword,
 		values:            format.Values,
+		preferIPv6:        format.PreferIPv6,
 	}
 	if config.logDir == "" {
 		config.logDir = DefaultLogDir
@@ -148,6 +151,7 @@ func (formatter_1_18) marshal(config *configInternal) ([]byte, error) {
 		CACert:            string(config.caCert),
 		OldPassword:       config.oldPassword,
 		Values:            config.values,
+		PreferIPv6:        config.preferIPv6,
 	}
 	if config.servingInfo != nil {
 		format.StateServerCert = config.servingInfo.Cert

--- a/agent/format-1.18_whitebox_test.go
+++ b/agent/format-1.18_whitebox_test.go
@@ -37,6 +37,7 @@ func (s *format_1_18Suite) TestMissingAttributes(c *gc.C) {
 	c.Assert(readConfig.UpgradedToVersion(), gc.Equals, version.MustParse("1.16.0"))
 	c.Assert(readConfig.LogDir(), gc.Equals, "/var/log/juju")
 	c.Assert(readConfig.DataDir(), gc.Equals, "/var/lib/juju")
+	c.Assert(readConfig.PreferIPv6(), jc.IsFalse)
 }
 
 func (s *format_1_18Suite) TestStatePortNotParsedWithoutSecret(c *gc.C) {
@@ -60,6 +61,7 @@ func (*format_1_18Suite) TestReadConfWithExisting1_18ConfigFileContents(c *gc.C)
 	c.Assert(err, gc.IsNil)
 	c.Assert(config.UpgradedToVersion(), jc.DeepEquals, version.MustParse("1.17.5.1"))
 	c.Assert(config.Jobs(), jc.DeepEquals, []params.MachineJob{params.JobManageEnviron})
+	c.Assert(config.PreferIPv6(), jc.IsTrue)
 }
 
 var agentConfig1_18Contents = `
@@ -177,6 +179,7 @@ stateserverkey: '-----BEGIN RSA PRIVATE KEY-----
 
 '
 apiport: 17070
+prefer-ipv6: true
 `[1:]
 
 var agentConfig1_18NotStateMachine = `
@@ -235,4 +238,5 @@ values:
   STORAGE_ADDR: 10.0.3.1:8040
   STORAGE_DIR: /home/user/.juju/local/storage
 apiport: 17070
+prefer-ipv6: true
 `[1:]

--- a/agent/format_whitebox_test.go
+++ b/agent/format_whitebox_test.go
@@ -33,6 +33,7 @@ var agentParams = AgentConfigParams{
 	StateAddresses:    []string{"localhost:1234"},
 	APIAddresses:      []string{"localhost:1235"},
 	Nonce:             "a nonce",
+	PreferIPv6:        false,
 }
 
 func newTestConfig(c *gc.C) *configInternal {

--- a/cmd/juju/scp_test.go
+++ b/cmd/juju/scp_test.go
@@ -143,7 +143,11 @@ func (s *SCPSuite) TestSCPCommand(c *gc.C) {
 			c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "")
 			data, err := ioutil.ReadFile(filepath.Join(s.bin, "scp.args"))
 			c.Check(err, gc.IsNil)
-			c.Check(string(data), gc.Equals, t.result)
+			actual := string(data)
+			if t.proxy {
+				actual = strings.Replace(actual, ".dns", ".internal", 2)
+			}
+			c.Check(actual, gc.Equals, t.result)
 		}
 	}
 }

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -73,6 +73,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	agentConfig := c.CurrentConfig()
+	network.InitializeFromConfig(agentConfig)
 
 	// agent.Jobs is an optional field in the agent config, and was
 	// introduced after 1.17.2. We default to allowing units on

--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -155,12 +155,13 @@ func (a *MachineAgent) Run(_ *cmd.Context) error {
 	// lines of all logging in the log file.
 	loggo.RemoveWriter("logfile")
 	defer a.tomb.Done()
-	logger.Infof("machine agent %v start (%s [%s])", a.Tag(), version.Current, runtime.Compiler)
 	if err := a.ReadConfig(a.Tag().String()); err != nil {
 		return fmt.Errorf("cannot read agent configuration: %v", err)
 	}
+	logger.Infof("machine agent %v start (%s [%s])", a.Tag(), version.Current, runtime.Compiler)
 	a.configChangedVal.Set(struct{}{})
 	agentConfig := a.CurrentConfig()
+	network.InitializeFromConfig(agentConfig)
 	charm.CacheDir = filepath.Join(agentConfig.DataDir(), "charmcache")
 	if err := a.createJujuRun(agentConfig.DataDir()); err != nil {
 		return fmt.Errorf("cannot create juju run symlink: %v", err)

--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -13,6 +13,7 @@ import (
 	"launchpad.net/gnuflag"
 	"launchpad.net/tomb"
 
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -74,6 +75,7 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 		return err
 	}
 	agentLogger.Infof("unit agent %v start (%s [%s])", a.Tag().String(), version.Current, runtime.Compiler)
+	network.InitializeFromConfig(a.CurrentConfig())
 	a.runner.StartWorker("api", a.APIWorkers)
 	err := agentDone(a.runner.Wait())
 	a.tomb.Kill(err)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/network"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/utils/ssh"
 	"github.com/juju/juju/version"
@@ -21,6 +22,7 @@ var logger = loggo.GetLogger("juju.environs.bootstrap")
 // environment.
 func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args environs.BootstrapParams) error {
 	cfg := environ.Config()
+	network.InitializeFromConfig(cfg)
 	if secret := cfg.AdminSecret(); secret == "" {
 		return fmt.Errorf("environment configuration has no admin-secret")
 	}

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -85,6 +85,7 @@ func PopulateMachineConfig(mcfg *cloudinit.MachineConfig,
 	providerType, authorizedKeys string,
 	sslHostnameVerification bool,
 	proxySettings, aptProxySettings proxy.Settings,
+	preferIPv6 bool,
 ) error {
 	if authorizedKeys == "" {
 		return fmt.Errorf("environment configuration has no authorized-keys")
@@ -98,6 +99,7 @@ func PopulateMachineConfig(mcfg *cloudinit.MachineConfig,
 	mcfg.DisableSSLHostnameVerification = !sslHostnameVerification
 	mcfg.ProxySettings = proxySettings
 	mcfg.AptProxySettings = aptProxySettings
+	mcfg.PreferIPv6 = preferIPv6
 	return nil
 }
 
@@ -121,6 +123,7 @@ func FinishMachineConfig(mcfg *cloudinit.MachineConfig, cfg *config.Config, cons
 		cfg.SSLHostnameVerification(),
 		cfg.ProxySettings(),
 		cfg.AptProxySettings(),
+		cfg.PreferIPv6(),
 	); err != nil {
 		return err
 	}

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -7,7 +7,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
@@ -144,6 +146,11 @@ type MachineConfig struct {
 	// AptProxySettings define the http, https and ftp proxy settings to use
 	// for apt, which may or may not be the same as the normal ProxySettings.
 	AptProxySettings proxy.Settings
+
+	// PreferIPv6 mirrors the value of prefer-ipv6 environment setting
+	// and when set IPv6 addresses for connecting to the API/state
+	// servers will be preferred over IPv4 ones.
+	PreferIPv6 bool
 }
 
 func base64yaml(m *config.Config) string {
@@ -387,6 +394,7 @@ func (cfg *MachineConfig) agentConfig(tag string) (agent.ConfigSetter, error) {
 		APIAddresses:      cfg.apiHostAddrs(),
 		CACert:            cfg.MongoInfo.CACert,
 		Values:            cfg.AgentEnvironment,
+		PreferIPv6:        cfg.PreferIPv6,
 	}
 	if !cfg.Bootstrap {
 		return agent.NewAgentConfig(configParams)
@@ -445,7 +453,11 @@ func (cfg *MachineConfig) jujuTools() string {
 func (cfg *MachineConfig) stateHostAddrs() []string {
 	var hosts []string
 	if cfg.Bootstrap {
-		hosts = append(hosts, fmt.Sprintf("localhost:%d", cfg.StateServingInfo.StatePort))
+		if cfg.PreferIPv6 {
+			hosts = append(hosts, net.JoinHostPort("::1", strconv.Itoa(cfg.StateServingInfo.StatePort)))
+		} else {
+			hosts = append(hosts, net.JoinHostPort("localhost", strconv.Itoa(cfg.StateServingInfo.StatePort)))
+		}
 	}
 	if cfg.MongoInfo != nil {
 		hosts = append(hosts, cfg.MongoInfo.Addrs...)
@@ -456,7 +468,11 @@ func (cfg *MachineConfig) stateHostAddrs() []string {
 func (cfg *MachineConfig) apiHostAddrs() []string {
 	var hosts []string
 	if cfg.Bootstrap {
-		hosts = append(hosts, fmt.Sprintf("localhost:%d", cfg.StateServingInfo.APIPort))
+		if cfg.PreferIPv6 {
+			hosts = append(hosts, net.JoinHostPort("::1", strconv.Itoa(cfg.StateServingInfo.APIPort)))
+		} else {
+			hosts = append(hosts, net.JoinHostPort("localhost", strconv.Itoa(cfg.StateServingInfo.APIPort)))
+		}
 	}
 	if cfg.APIInfo != nil {
 		hosts = append(hosts, cfg.APIInfo.Addrs...)

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -214,6 +214,7 @@ ln -s 1\.2\.3-raring-amd64 '/var/lib/juju/tools/machine-0'
 				CACert:   "CA CERT\n" + testing.CACert,
 			},
 			MachineAgentServiceName: "jujud-machine-99",
+			PreferIPv6:              true,
 		},
 		expectScripts: `
 set -xe

--- a/environs/cloudinit_test.go
+++ b/environs/cloudinit_test.go
@@ -58,7 +58,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 	}
 	err = environs.FinishMachineConfig(mcfg, cfg, constraints.Value{})
 	c.Assert(err, gc.IsNil)
-	c.Assert(mcfg, gc.DeepEquals, &cloudinit.MachineConfig{
+	c.Assert(mcfg, jc.DeepEquals, &cloudinit.MachineConfig{
 		AuthorizedKeys: "we-are-the-keys",
 		AgentEnvironment: map[string]string{
 			agent.ProviderType:  "dummy",
@@ -67,6 +67,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 		MongoInfo: &authentication.MongoInfo{Tag: userTag},
 		APIInfo:   &api.Info{Tag: userTag},
 		DisableSSLHostnameVerification: false,
+		PreferIPv6:                     true,
 	})
 }
 
@@ -84,7 +85,7 @@ func (s *CloudInitSuite) TestFinishMachineConfigNonDefault(c *gc.C) {
 	}
 	err = environs.FinishMachineConfig(mcfg, cfg, constraints.Value{})
 	c.Assert(err, gc.IsNil)
-	c.Assert(mcfg, gc.DeepEquals, &cloudinit.MachineConfig{
+	c.Assert(mcfg, jc.DeepEquals, &cloudinit.MachineConfig{
 		AuthorizedKeys: "we-are-the-keys",
 		AgentEnvironment: map[string]string{
 			agent.ProviderType:  "dummy",
@@ -93,6 +94,7 @@ func (s *CloudInitSuite) TestFinishMachineConfigNonDefault(c *gc.C) {
 		MongoInfo: &authentication.MongoInfo{Tag: userTag},
 		APIInfo:   &api.Info{Tag: userTag},
 		DisableSSLHostnameVerification: true,
+		PreferIPv6:                     true,
 	})
 }
 

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1198,6 +1198,11 @@ var validationTests = []validationTest{{
 	old:   testing.Attrs{"lxc-clone-aufs": false},
 	new:   testing.Attrs{"lxc-clone-aufs": true},
 	err:   `cannot change lxc-clone-aufs from false to true`,
+}, {
+	about: "Cannot change prefer-ipv6",
+	old:   testing.Attrs{"prefer-ipv6": false},
+	new:   testing.Attrs{"prefer-ipv6": true},
+	err:   `cannot change prefer-ipv6 from false to true`,
 }}
 
 func (s *ConfigSuite) TestValidateChange(c *gc.C) {

--- a/juju/apiconn_test.go
+++ b/juju/apiconn_test.go
@@ -736,7 +736,7 @@ func (s *CacheChangedAPISuite) TestAPIEndpointNotMachineLocalOrLinkLocal(c *gc.C
 			network.NewAddress("::1", network.ScopeUnknown),
 			network.NewAddress("fe80::1", network.ScopeUnknown),
 			network.NewAddress("fc00::1", network.ScopeUnknown),
-			network.NewAddress("2001:db1::1", network.ScopeUnknown),
+			network.NewAddress("2001:db8::1", network.ScopeUnknown),
 		}, 1234),
 		network.AddressesWithPort([]network.Address{
 			network.NewAddress("1.0.0.2", network.ScopeUnknown),
@@ -756,7 +756,7 @@ func (s *CacheChangedAPISuite) TestAPIEndpointNotMachineLocalOrLinkLocal(c *gc.C
 		"1.0.0.1:1234",
 		"192.0.0.1:1234",
 		"[fc00::1]:1234",
-		"[2001:db1::1]:1234",
+		"[2001:db8::1]:1234",
 		"1.0.0.2:1235",
 		"[2002:0:0:0:0:0:100:2]:1235",
 	})

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -137,7 +137,7 @@ func (s *AddressSuite) TestNewAddresses(c *gc.C) {
 		network.IPv4Address,
 		network.ScopePublic,
 	}, {
-		[]string{"2001:db1::1", "64:ff9b::1", "2002::1"},
+		[]string{"2001:db8::1", "64:ff9b::1", "2002::1"},
 		network.IPv6Address,
 		network.ScopePublic,
 	}, {
@@ -207,7 +207,7 @@ var selectPublicTests = []selectTest{{
 }, {
 	"a public IPv6 address is selected",
 	[]network.Address{
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 	},
 	0,
 	false,
@@ -215,7 +215,7 @@ var selectPublicTests = []selectTest{{
 	"first public address is selected",
 	[]network.Address{
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 	},
 	0,
 	false,
@@ -225,7 +225,7 @@ var selectPublicTests = []selectTest{{
 		{"172.16.1.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
 		{"fc00:1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 	},
 	1,
 	false,
@@ -235,7 +235,7 @@ var selectPublicTests = []selectTest{{
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
 		{"172.16.1.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
 		{"fc00:1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 	},
 	3,
 	true,
@@ -316,7 +316,7 @@ var selectInternalTests = []selectTest{{
 }, {
 	"a public IPv6 address is selected",
 	[]network.Address{
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 	},
 	0,
 	false,
@@ -324,7 +324,7 @@ var selectInternalTests = []selectTest{{
 	"a public IPv6 address is selected when both IPv4 and IPv6 addresses exist and preferIPv6 is true",
 	[]network.Address{
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 	},
 	1,
 	true,
@@ -333,20 +333,24 @@ var selectInternalTests = []selectTest{{
 	[]network.Address{
 		{"127.0.0.1", network.IPv4Address, "machine", network.ScopeMachineLocal},
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"169.254.1.1", network.IPv4Address, "link", network.ScopeLinkLocal},
+		{"8.8.4.4", network.IPv4Address, "public", network.ScopePublic},
 	},
 	1,
 	true,
 }, {
 	"a cloud local IPv4 address is selected",
 	[]network.Address{
+		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
 		{"10.0.0.1", network.IPv4Address, "private", network.ScopeCloudLocal},
 	},
-	0,
+	1,
 	false,
 }, {
 	"a cloud local IPv6 address is selected",
 	[]network.Address{
 		{"fc00::1", network.IPv6Address, "private", network.ScopeCloudLocal},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 	},
 	0,
 	false,
@@ -362,22 +366,22 @@ var selectInternalTests = []selectTest{{
 }, {
 	"a cloud local address is preferred to a public address",
 	[]network.Address{
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
 		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
 	},
-	0,
+	1,
 	false,
 }, {
 	"an IPv6 cloud local address is preferred to a public address when preferIPv6 is true",
 	[]network.Address{
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
 		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
 	},
-	1,
+	2,
 	false,
 }}
 
@@ -397,19 +401,49 @@ var selectInternalMachineTests = []selectTest{{
 	"first cloud local address is selected",
 	[]network.Address{
 		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
 	},
 	0,
 	false,
 }, {
+	"first cloud local hostname is selected when preferIPv6 is false",
+	[]network.Address{
+		{"example.com", network.HostName, "public", network.ScopePublic},
+		{"cloud1.internal", network.HostName, "cloud", network.ScopeCloudLocal},
+		{"cloud2.internal", network.HostName, "cloud", network.ScopeCloudLocal},
+		{"example.org", network.HostName, "public", network.ScopePublic},
+	},
+	1,
+	false,
+}, {
+	"first cloud local hostname is selected when preferIPv6 is true (public first)",
+	[]network.Address{
+		{"example.org", network.HostName, "public", network.ScopePublic},
+		{"example.com", network.HostName, "public", network.ScopePublic},
+		{"cloud1.internal", network.HostName, "cloud", network.ScopeCloudLocal},
+		{"cloud2.internal", network.HostName, "cloud", network.ScopeCloudLocal},
+	},
+	2,
+	true,
+}, {
+	"first cloud local hostname is selected when preferIPv6 is true (public last)",
+	[]network.Address{
+		{"cloud1.internal", network.HostName, "cloud", network.ScopeCloudLocal},
+		{"cloud2.internal", network.HostName, "cloud", network.ScopeCloudLocal},
+		{"example.org", network.HostName, "public", network.ScopePublic},
+		{"example.com", network.HostName, "public", network.ScopePublic},
+	},
+	0,
+	true,
+}, {
 	"first IPv6 cloud local address is selected when preferIPv6 is true",
 	[]network.Address{
 		{"10.0.0.1", network.IPv4Address, "cloud", network.ScopeCloudLocal},
 		{"8.8.8.8", network.IPv4Address, "public", network.ScopePublic},
 		{"fc00::1", network.IPv6Address, "cloud", network.ScopeCloudLocal},
-		{"2001:db1::1", network.IPv6Address, "public", network.ScopePublic},
+		{"2001:db8::1", network.IPv6Address, "public", network.ScopePublic},
 	},
 	2,
 	true,
@@ -474,10 +508,10 @@ var stringTests = []struct {
 }, {
 	addr: network.Address{
 		Type:  network.IPv6Address,
-		Value: "2001:db1::1",
+		Value: "2001:db8::1",
 		Scope: network.ScopePublic,
 	},
-	str: "public:2001:db1::1",
+	str: "public:2001:db8::1",
 }, {
 	addr: network.Address{
 		Type:  network.HostName,

--- a/network/network.go
+++ b/network/network.go
@@ -88,5 +88,5 @@ type PreferIPv6Getter interface {
 // settings.
 func InitializeFromConfig(config PreferIPv6Getter) {
 	preferIPv6 = config.PreferIPv6()
-	logger.Debugf("network.preferIPv6 = %v", preferIPv6)
+	logger.Infof("setting prefer-ipv6 to %v", preferIPv6)
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -82,6 +82,7 @@ func SampleConfig() testing.Attrs {
 
 		"secret":       "pork",
 		"state-server": true,
+		"prefer-ipv6":  true,
 	}
 }
 

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/user"
+	"strconv"
 	"syscall"
 
 	"github.com/juju/loggo"
@@ -152,7 +153,7 @@ func (p environProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Conf
 var checkLocalPort = func(port int, description string) error {
 	logger.Infof("checking %s", description)
 	// Try to connect the port on localhost.
-	address := fmt.Sprintf("localhost:%d", port)
+	address := net.JoinHostPort("localhost", strconv.Itoa(port))
 	// TODO(mue) Add a timeout?
 	conn, err := net.Dial("tcp", address)
 	if err != nil {

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -81,19 +81,19 @@ var addressTests = []struct {
 	expected: "8.8.8.8",
 }, {
 	summary:  "public IPv6 only",
-	public:   []nova.IPAddress{{6, "2001:db1::1"}},
+	public:   []nova.IPAddress{{6, "2001:db8::1"}},
 	networks: []string{"", "public"},
-	expected: "2001:db1::1",
+	expected: "2001:db8::1",
 }, {
 	summary:  "public only, both IPv4 and IPv6",
-	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db1::1"}},
+	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db8::1"}},
 	networks: []string{"", "public"},
 	expected: "8.8.8.8",
 }, {
 	summary:  "public only, both IPv6 and IPv4",
-	public:   []nova.IPAddress{{6, "2001:db1::1"}, {4, "8.8.8.8"}},
+	public:   []nova.IPAddress{{6, "2001:db8::1"}, {4, "8.8.8.8"}},
 	networks: []string{"", "public"},
-	expected: "2001:db1::1",
+	expected: "2001:db8::1",
 }, {
 	summary:  "public and private both IPv4",
 	private:  []nova.IPAddress{{4, "10.0.0.4"}},
@@ -103,9 +103,9 @@ var addressTests = []struct {
 }, {
 	summary:  "public and private both IPv6",
 	private:  []nova.IPAddress{{6, "fc00::1"}},
-	public:   []nova.IPAddress{{6, "2001:db1::1"}},
+	public:   []nova.IPAddress{{6, "2001:db8::1"}},
 	networks: []string{"private", "public"},
-	expected: "2001:db1::1",
+	expected: "2001:db8::1",
 }, {
 	summary:  "public, private, and localhost IPv4",
 	private:  []nova.IPAddress{{4, "127.0.0.4"}, {4, "192.168.0.1"}},
@@ -115,21 +115,21 @@ var addressTests = []struct {
 }, {
 	summary:  "public, private, and localhost IPv6",
 	private:  []nova.IPAddress{{6, "::1"}, {6, "fc00::1"}},
-	public:   []nova.IPAddress{{6, "2001:db1::1"}},
+	public:   []nova.IPAddress{{6, "2001:db8::1"}},
 	networks: []string{"private", "public"},
-	expected: "2001:db1::1",
+	expected: "2001:db8::1",
 }, {
 	summary:  "public, private, and localhost - both IPv4 and IPv6",
 	private:  []nova.IPAddress{{4, "127.0.0.4"}, {4, "192.168.0.1"}, {6, "::1"}, {6, "fc00::1"}},
-	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db1::1"}},
+	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db8::1"}},
 	networks: []string{"private", "public"},
 	expected: "8.8.8.8",
 }, {
 	summary:  "public, private, and localhost - both IPv6 and IPv4",
 	private:  []nova.IPAddress{{6, "::1"}, {6, "fc00::1"}, {4, "127.0.0.4"}, {4, "192.168.0.1"}},
-	public:   []nova.IPAddress{{6, "2001:db1::1"}, {4, "8.8.8.8"}},
+	public:   []nova.IPAddress{{6, "2001:db8::1"}, {4, "8.8.8.8"}},
 	networks: []string{"private", "public"},
-	expected: "2001:db1::1",
+	expected: "2001:db8::1",
 }, {
 	summary:  "custom only IPv4",
 	private:  []nova.IPAddress{{4, "192.168.0.1"}},
@@ -159,21 +159,21 @@ var addressTests = []struct {
 }, {
 	summary:  "custom and public IPv6",
 	private:  []nova.IPAddress{{6, "fc00::1"}},
-	public:   []nova.IPAddress{{6, "2001:db1::1"}},
+	public:   []nova.IPAddress{{6, "2001:db8::1"}},
 	networks: []string{"special", "public"},
-	expected: "2001:db1::1",
+	expected: "2001:db8::1",
 }, {
 	summary:  "custom and public - both IPv4 and IPv6",
 	private:  []nova.IPAddress{{4, "172.16.0.1"}, {6, "fc00::1"}},
-	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db1::1"}},
+	public:   []nova.IPAddress{{4, "8.8.8.8"}, {6, "2001:db8::1"}},
 	networks: []string{"special", "public"},
 	expected: "8.8.8.8",
 }, {
 	summary:  "custom and public - both IPv6 and IPv4",
 	private:  []nova.IPAddress{{6, "fc00::1"}, {4, "172.16.0.1"}},
-	public:   []nova.IPAddress{{6, "2001:db1::1"}, {4, "8.8.8.8"}},
+	public:   []nova.IPAddress{{6, "2001:db8::1"}, {4, "8.8.8.8"}},
 	networks: []string{"special", "public"},
-	expected: "2001:db1::1",
+	expected: "2001:db8::1",
 }}
 
 func (t *localTests) TestGetServerAddresses(c *gc.C) {

--- a/state/api/params/params.go
+++ b/state/api/params/params.go
@@ -627,6 +627,7 @@ type ContainerConfig struct {
 	SSLHostnameVerification bool
 	Proxy                   proxy.Settings
 	AptProxy                proxy.Settings
+	PreferIPv6              bool
 }
 
 // ProvisioningScriptParams contains the parameters for the

--- a/state/api/provisioner/provisioner_test.go
+++ b/state/api/provisioner/provisioner_test.go
@@ -614,6 +614,7 @@ func (s *provisionerSuite) TestContainerConfig(c *gc.C) {
 	c.Assert(result.ProviderType, gc.Equals, "dummy")
 	c.Assert(result.AuthorizedKeys, gc.Equals, coretesting.FakeAuthKeys)
 	c.Assert(result.SSLHostnameVerification, jc.IsTrue)
+	c.Assert(result.PreferIPv6, jc.IsTrue)
 }
 
 func (s *provisionerSuite) TestToolsWrongMachine(c *gc.C) {

--- a/state/apiserver/provisioner/provisioner.go
+++ b/state/apiserver/provisioner/provisioner.go
@@ -232,6 +232,7 @@ func (p *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
 	result.SSLHostnameVerification = config.SSLHostnameVerification()
 	result.Proxy = config.ProxySettings()
 	result.AptProxy = config.AptProxySettings()
+	result.PreferIPv6 = config.PreferIPv6()
 	return result, nil
 }
 

--- a/state/apiserver/provisioner/provisioner_test.go
+++ b/state/apiserver/provisioner/provisioner_test.go
@@ -1165,6 +1165,7 @@ func (s *withoutStateServerSuite) TestContainerConfig(c *gc.C) {
 	c.Check(results.SSLHostnameVerification, jc.IsTrue)
 	c.Check(results.Proxy, gc.DeepEquals, expectedProxy)
 	c.Check(results.AptProxy, gc.DeepEquals, expectedProxy)
+	c.Check(results.PreferIPv6, jc.IsTrue)
 }
 
 func (s *withoutStateServerSuite) TestToolsRefusesWrongAgent(c *gc.C) {

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -90,6 +90,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (insta
 		config.SSLHostnameVerification,
 		config.Proxy,
 		config.AptProxy,
+		config.PreferIPv6,
 	); err != nil {
 		kvmLogger.Errorf("failed to populate machine config: %v", err)
 		return nil, nil, nil, err

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -87,6 +87,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (insta
 		config.SSLHostnameVerification,
 		config.Proxy,
 		config.AptProxy,
+		config.PreferIPv6,
 	); err != nil {
 		lxcLogger.Errorf("failed to populate machine config: %v", err)
 		return nil, nil, nil, err


### PR DESCRIPTION
This builds upon the previous PR adding the prefer-ipv6 environ
config setting. Now, the prefer-ipv6 flag is passed through further
to the agent config, so the agents can initialize the network package
with it even before connecting to the API/state servers (no environ
config yet).
