### PR TITLE
prefer-ipv6 honored by state when setting addresses

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -131,8 +131,10 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	// Check that the API host ports are initialised correctly.
 	apiHostPorts, err := st.APIHostPorts()
 	c.Assert(err, gc.IsNil)
-	c.Assert(apiHostPorts, gc.DeepEquals, [][]network.HostPort{
-		network.AddressesWithPort(mcfg.Addresses, 1234),
+	c.Assert(apiHostPorts, jc.DeepEquals, [][]network.HostPort{
+		network.AddressesWithPort(
+			network.NewAddresses("zeroonetwothree", "0.1.2.3"),
+			1234),
 	})
 
 	// Check that the state serving info is initialised correctly.

--- a/juju/apiconn_test.go
+++ b/juju/apiconn_test.go
@@ -131,15 +131,7 @@ func (s *NewAPIClientSuite) TestWithInfoOnly(c *gc.C) {
 	store := newConfigStore("noconfig", dummyStoreInfo)
 
 	called := 0
-	expectState := &mockAPIState{
-		apiHostPorts: [][]network.HostPort{
-			network.AddressesWithPort(
-				[]network.Address{network.NewAddress("0.1.2.3", network.ScopeUnknown)},
-				1234,
-			),
-		},
-		environTag: "environment-fake-uuid",
-	}
+	expectState := mockedAPIState(mockedHostPort | mockedEnvironTag)
 	apiOpen := func(apiInfo *api.Info, opts api.DialOpts) (juju.APIState, error) {
 		checkCommonAPIInfoAttrs(c, apiInfo, opts)
 		c.Check(apiInfo.EnvironTag, gc.Equals, names.NewEnvironTag("fake-uuid"))
@@ -158,7 +150,9 @@ func (s *NewAPIClientSuite) TestWithInfoOnly(c *gc.C) {
 	info, err := store.ReadInfo("noconfig")
 	c.Assert(err, gc.IsNil)
 	ep := info.APIEndpoint()
-	c.Assert(ep.Addresses, gc.DeepEquals, []string{"0.1.2.3:1234"})
+	c.Check(ep.Addresses, jc.DeepEquals, []string{
+		"0.1.2.3:1234", "[fc00::1]:1234",
+	})
 	c.Check(ep.EnvironUUID, gc.Equals, "fake-uuid")
 	mockStore.written = false
 
@@ -196,7 +190,7 @@ func (s *NewAPIClientSuite) TestWithConfigAndNoInfo(c *gc.C) {
 	c.Assert(info.APICredentials(), jc.DeepEquals, configstore.APICredentials{})
 
 	called := 0
-	expectState := &mockAPIState{}
+	expectState := mockedAPIState(0)
 	apiOpen := func(apiInfo *api.Info, opts api.DialOpts) (juju.APIState, error) {
 		c.Check(apiInfo.Tag, gc.Equals, names.NewUserTag("admin"))
 		c.Check(string(apiInfo.CACert), gc.Not(gc.Equals), "")
@@ -259,12 +253,32 @@ var noTagStoreInfo = &environInfo{
 	},
 }
 
-func mockedAPIState(hasHostPort, hasEnvironTag bool) *mockAPIState {
+type mockedStateFlags int
+
+const (
+	noFlags          mockedStateFlags = 0x0000
+	mockedHostPort   mockedStateFlags = 0x0001
+	mockedEnvironTag mockedStateFlags = 0x0002
+	mockedPreferIPv6 mockedStateFlags = 0x0004
+)
+
+func mockedAPIState(flags mockedStateFlags) *mockAPIState {
+	hasHostPort := flags&mockedHostPort == mockedHostPort
+	hasEnvironTag := flags&mockedEnvironTag == mockedEnvironTag
+	preferIPv6 := flags&mockedPreferIPv6 == mockedPreferIPv6
+
 	apiHostPorts := [][]network.HostPort{}
 	if hasHostPort {
-		address := network.NewAddress("0.1.2.3", network.ScopeUnknown)
-		apiHostPorts = [][]network.HostPort{
-			network.AddressesWithPort([]network.Address{address}, 1234),
+		ipv4Address := network.NewAddress("0.1.2.3", network.ScopeUnknown)
+		ipv6Address := network.NewAddress("fc00::1", network.ScopeUnknown)
+		if preferIPv6 {
+			apiHostPorts = [][]network.HostPort{
+				network.AddressesWithPort([]network.Address{ipv6Address, ipv4Address}, 1234),
+			}
+		} else {
+			apiHostPorts = [][]network.HostPort{
+				network.AddressesWithPort([]network.Address{ipv4Address, ipv6Address}, 1234),
+			}
 		}
 	}
 	environTag := ""
@@ -288,7 +302,7 @@ func (s *NewAPIClientSuite) TestWithInfoNoEnvironTag(c *gc.C) {
 	store := newConfigStore("noconfig", noTagStoreInfo)
 
 	called := 0
-	expectState := mockedAPIState(true, true)
+	expectState := mockedAPIState(mockedHostPort | mockedEnvironTag)
 	apiOpen := func(apiInfo *api.Info, opts api.DialOpts) (juju.APIState, error) {
 		checkCommonAPIInfoAttrs(c, apiInfo, opts)
 		c.Check(apiInfo.EnvironTag, gc.IsNil)
@@ -306,7 +320,25 @@ func (s *NewAPIClientSuite) TestWithInfoNoEnvironTag(c *gc.C) {
 	c.Assert(mockStore.written, jc.IsTrue)
 	info, err := store.ReadInfo("noconfig")
 	c.Assert(err, gc.IsNil)
-	c.Assert(info.APIEndpoint().Addresses, gc.DeepEquals, []string{"0.1.2.3:1234"})
+	c.Check(info.APIEndpoint().Addresses, jc.DeepEquals, []string{
+		"0.1.2.3:1234", "[fc00::1]:1234",
+	})
+	c.Check(info.APIEndpoint().EnvironUUID, gc.Equals, "fake-uuid")
+
+	// Now simulate prefer-ipv6: true
+	store = newConfigStore("noconfig", noTagStoreInfo)
+	mockStore = &storageWithWriteNotify{store: store}
+	expectState = mockedAPIState(mockedHostPort | mockedEnvironTag | mockedPreferIPv6)
+	st, err = juju.NewAPIFromStore("noconfig", mockStore, apiOpen)
+	c.Assert(err, gc.IsNil)
+	c.Assert(st, gc.Equals, expectState)
+	c.Assert(called, gc.Equals, 2)
+	c.Assert(mockStore.written, jc.IsTrue)
+	info, err = store.ReadInfo("noconfig")
+	c.Assert(err, gc.IsNil)
+	c.Check(info.APIEndpoint().Addresses, jc.DeepEquals, []string{
+		"[fc00::1]:1234", "0.1.2.3:1234",
+	})
 	c.Check(info.APIEndpoint().EnvironUUID, gc.Equals, "fake-uuid")
 }
 
@@ -317,7 +349,7 @@ func (s *NewAPIClientSuite) TestWithInfoNoAPIHostports(c *gc.C) {
 	store := newConfigStore("noconfig", noTagStoreInfo)
 
 	called := 0
-	expectState := mockedAPIState(false, true)
+	expectState := mockedAPIState(mockedEnvironTag | mockedPreferIPv6)
 	apiOpen := func(apiInfo *api.Info, opts api.DialOpts) (juju.APIState, error) {
 		checkCommonAPIInfoAttrs(c, apiInfo, opts)
 		c.Check(apiInfo.EnvironTag, gc.IsNil)
@@ -346,7 +378,7 @@ func (s *NewAPIClientSuite) TestNoEnvironTagDoesntOverwriteCached(c *gc.C) {
 	called := 0
 	// State returns a new set of APIHostPorts but not a new EnvironTag. We
 	// shouldn't override the cached value with environ tag of "".
-	expectState := mockedAPIState(true, false)
+	expectState := mockedAPIState(mockedHostPort)
 	apiOpen := func(apiInfo *api.Info, opts api.DialOpts) (juju.APIState, error) {
 		checkCommonAPIInfoAttrs(c, apiInfo, opts)
 		c.Check(apiInfo.EnvironTag, gc.Equals, names.NewEnvironTag("fake-uuid"))
@@ -363,7 +395,24 @@ func (s *NewAPIClientSuite) TestNoEnvironTagDoesntOverwriteCached(c *gc.C) {
 	info, err := store.ReadInfo("noconfig")
 	c.Assert(err, gc.IsNil)
 	ep := info.APIEndpoint()
-	c.Assert(ep.Addresses, gc.DeepEquals, []string{"0.1.2.3:1234"})
+	c.Check(ep.Addresses, gc.DeepEquals, []string{
+		"0.1.2.3:1234", "[fc00::1]:1234",
+	})
+	c.Check(ep.EnvironUUID, gc.Equals, "fake-uuid")
+
+	// Now simulate prefer-ipv6: true
+	expectState = mockedAPIState(mockedHostPort | mockedPreferIPv6)
+	st, err = juju.NewAPIFromStore("noconfig", mockStore, apiOpen)
+	c.Assert(err, gc.IsNil)
+	c.Assert(st, gc.Equals, expectState)
+	c.Assert(called, gc.Equals, 2)
+	c.Assert(mockStore.written, jc.IsTrue)
+	info, err = store.ReadInfo("noconfig")
+	c.Assert(err, gc.IsNil)
+	ep = info.APIEndpoint()
+	c.Check(ep.Addresses, gc.DeepEquals, []string{
+		"[fc00::1]:1234", "0.1.2.3:1234",
+	})
 	c.Check(ep.EnvironUUID, gc.Equals, "fake-uuid")
 }
 
@@ -389,9 +438,9 @@ func (s *NewAPIClientSuite) TestWithSlowInfoConnect(c *gc.C) {
 	bootstrapEnv(c, coretesting.SampleEnvName, store)
 	setEndpointAddress(c, store, coretesting.SampleEnvName, "infoapi.invalid")
 
-	infoOpenedState := &mockAPIState{}
+	infoOpenedState := mockedAPIState(noFlags)
 	infoEndpointOpened := make(chan struct{})
-	cfgOpenedState := &mockAPIState{}
+	cfgOpenedState := mockedAPIState(noFlags)
 	// On a sample run with no delay, the logic took 45ms to run, so
 	// we make the delay slightly more than that, so that if the
 	// logic doesn't delay at all, the test will fail reasonably consistently.
@@ -474,9 +523,9 @@ func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
 	bootstrapEnv(c, coretesting.SampleEnvName, store)
 	setEndpointAddress(c, store, coretesting.SampleEnvName, "infoapi.invalid")
 
-	infoOpenedState := &mockAPIState{}
+	infoOpenedState := mockedAPIState(noFlags)
 	infoEndpointOpened := make(chan struct{})
-	cfgOpenedState := &mockAPIState{}
+	cfgOpenedState := mockedAPIState(noFlags)
 	cfgEndpointOpened := make(chan struct{})
 
 	s.PatchValue(juju.ProviderConnectDelay, 0*time.Second)
@@ -584,7 +633,7 @@ func (s *NewAPIClientSuite) TestWithBootstrapConfigAndNoEnvironmentsFile(c *gc.C
 	c.Assert(err, gc.IsNil)
 
 	apiOpen := func(*api.Info, api.DialOpts) (juju.APIState, error) {
-		return &mockAPIState{}, nil
+		return mockedAPIState(noFlags), nil
 	}
 	st, err := juju.NewAPIFromStore(coretesting.SampleEnvName, store, apiOpen)
 	c.Check(err, gc.IsNil)
@@ -615,7 +664,7 @@ func (*NewAPIClientSuite) TestWithBootstrapConfigTakesPrecedence(c *gc.C) {
 	// cause a connection to the originally bootstrapped
 	// state.
 	apiOpen := func(*api.Info, api.DialOpts) (juju.APIState, error) {
-		return &mockAPIState{}, nil
+		return mockedAPIState(noFlags), nil
 	}
 	st, err := juju.NewAPIFromStore(envName2, store, apiOpen)
 	c.Check(err, gc.IsNil)

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -4,6 +4,7 @@
 package network_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/network"
@@ -572,4 +573,40 @@ func (*AddressSuite) TestNetAddr(c *gc.C) {
 		}
 		c.Assert(hp.NetAddr(), gc.Equals, test.expect)
 	}
+}
+
+func (*AddressSuite) TestSortAddresses(c *gc.C) {
+	addrs := network.NewAddresses(
+		"127.0.0.1",
+		"localhost",
+		"example.com",
+		"::1",
+		"fc00::1",
+		"fe80::2",
+		"172.16.0.1",
+		"8.8.8.8",
+	)
+	network.SortAddresses(addrs, false)
+	c.Assert(addrs, jc.DeepEquals, network.NewAddresses(
+		"example.com",
+		"localhost",
+		"127.0.0.1",
+		"172.16.0.1",
+		"8.8.8.8",
+		"::1",
+		"fe80::2",
+		"fc00::1",
+	))
+
+	network.SortAddresses(addrs, true)
+	c.Assert(addrs, jc.DeepEquals, network.NewAddresses(
+		"example.com",
+		"localhost",
+		"fe80::2",
+		"::1",
+		"fc00::1",
+		"127.0.0.1",
+		"172.16.0.1",
+		"8.8.8.8",
+	))
 }

--- a/network/port.go
+++ b/network/port.go
@@ -63,3 +63,50 @@ func (p portSlice) Less(i, j int) bool {
 func SortPorts(ports []Port) {
 	sort.Sort(portSlice(ports))
 }
+
+type hostPortPreferringIPv4Slice []HostPort
+
+func (h hostPortPreferringIPv4Slice) Len() int      { return len(h) }
+func (h hostPortPreferringIPv4Slice) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h hostPortPreferringIPv4Slice) Less(i, j int) bool {
+	addr1 := h[i].Address
+	addr2 := h[j].Address
+	if addr1.Type == HostName {
+		// Prefer hostnames on top, if possible.
+		return addr2.Type != HostName
+	}
+	if addr1.Type == IPv4Address || addr2.Type == IPv4Address {
+		// Prefer IPv4 addresses to IPv6 ones.
+		return addr1.Type == IPv4Address
+	}
+	return addr1.Value == addr2.Value
+}
+
+type hostPortPreferringIPv6Slice struct {
+	hostPortPreferringIPv4Slice
+}
+
+func (h hostPortPreferringIPv6Slice) Less(i, j int) bool {
+	addr1 := h.hostPortPreferringIPv4Slice[i].Address
+	addr2 := h.hostPortPreferringIPv4Slice[j].Address
+	if addr1.Type == HostName {
+		// Prefer hostnames on top, if possible.
+		return addr2.Type != HostName
+	}
+	if addr1.Type == IPv6Address || addr2.Type == IPv6Address {
+		// Prefer IPv6 addresses to IPv4 ones.
+		return addr1.Type == IPv6Address
+	}
+	return addr1.Value == addr2.Value
+}
+
+// SortHostPorts sorts the given HostPort slice, putting hostnames on
+// top and depending on the preferIPv6 flag either IPv6 or IPv4
+// addresses after that.
+func SortHostPorts(hps []HostPort, preferIPv6 bool) {
+	if preferIPv6 {
+		sort.Sort(hostPortPreferringIPv6Slice{hostPortPreferringIPv4Slice(hps)})
+	} else {
+		sort.Sort(hostPortPreferringIPv4Slice(hps))
+	}
+}

--- a/network/port_test.go
+++ b/network/port_test.go
@@ -98,3 +98,48 @@ func (*PortSuite) TestAddressesWithPort(c *gc.C) {
 		Port:    999,
 	}})
 }
+
+func (*PortSuite) TestSortHostPorts(c *gc.C) {
+	hps := network.AddressesWithPort(
+		network.NewAddresses(
+			"127.0.0.1",
+			"localhost",
+			"example.com",
+			"::1",
+			"fc00::1",
+			"fe80::2",
+			"172.16.0.1",
+			"8.8.8.8",
+		),
+		1234,
+	)
+	network.SortHostPorts(hps, false)
+	c.Assert(hps, jc.DeepEquals, network.AddressesWithPort(
+		network.NewAddresses(
+			"example.com",
+			"localhost",
+			"127.0.0.1",
+			"172.16.0.1",
+			"8.8.8.8",
+			"::1",
+			"fe80::2",
+			"fc00::1",
+		),
+		1234,
+	))
+
+	network.SortHostPorts(hps, true)
+	c.Assert(hps, jc.DeepEquals, network.AddressesWithPort(
+		network.NewAddresses(
+			"example.com",
+			"localhost",
+			"fe80::2",
+			"::1",
+			"fc00::1",
+			"127.0.0.1",
+			"172.16.0.1",
+			"8.8.8.8",
+		),
+		1234,
+	))
+}

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -42,6 +42,8 @@ func Bootstrap(ctx environs.BootstrapContext, env environs.Environ, args environ
 	var inst instance.Instance
 	defer func() { handleBootstrapError(err, ctx, inst, env) }()
 
+	network.InitializeFromConfig(env.Config())
+
 	// First thing, ensure we have tools otherwise there's no point.
 	selectedTools, err := EnsureBootstrapTools(ctx, env, config.PreferredSeries(env.Config()), args.Constraints.Arch)
 	if err != nil {

--- a/state/address.go
+++ b/state/address.go
@@ -85,10 +85,19 @@ type apiHostPortsDoc struct {
 	APIHostPorts [][]hostPort
 }
 
-// SetAPIHostPorts sets the addresses of the API server
-// instances. Each server is represented by one element
-// in the top level slice.
+// SetAPIHostPorts sets the addresses of the API server instances.
+// Each server is represented by one element in the top level slice.
+// If prefer-ipv6 environment setting is true, the addresses will be
+// sorted before setting them to bring IPv6 addresses on top (if
+// available).
 func (st *State) SetAPIHostPorts(hps [][]network.HostPort) error {
+	envConfig, err := st.EnvironConfig()
+	if err != nil {
+		return err
+	}
+	for i, _ := range hps {
+		network.SortHostPorts(hps[i], envConfig.PreferIPv6())
+	}
 	doc := apiHostPortsDoc{
 		APIHostPorts: instanceHostPortsToHostPorts(hps),
 	}

--- a/state/machine.go
+++ b/state/machine.go
@@ -956,6 +956,11 @@ func (m *Machine) SetMachineAddresses(addresses ...network.Address) (err error) 
 // MachineAddresses, depending on the field argument).
 func (m *Machine) setAddresses(addresses []network.Address, field *[]address, fieldName string) error {
 	var changed bool
+	envConfig, err := m.st.EnvironConfig()
+	if err != nil {
+		return err
+	}
+	network.SortAddresses(addresses, envConfig.PreferIPv6())
 	stateAddresses := instanceAddressesToAddresses(addresses)
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		changed = false

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3489,6 +3489,79 @@ func (s *StateSuite) TestSetAPIHostPorts(c *gc.C) {
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 }
 
+func (s *StateSuite) TestSetAPIHostPortsPreferIPv6(c *gc.C) {
+	envConfig, err := s.State.EnvironConfig()
+	c.Assert(err, gc.IsNil)
+	s.changeEnviron(c, envConfig, "prefer-ipv6", true)
+
+	addrs, err := s.State.APIHostPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(addrs, gc.HasLen, 0)
+
+	newHostPorts := [][]network.HostPort{
+		network.AddressesWithPort(
+			network.NewAddresses(
+				"172.16.0.1",
+				"example.com",
+				"::1",
+				"127.0.0.1",
+				"8.8.8.8",
+				"fc00::1",
+				"localhost",
+				"fe80::2",
+			),
+			1234,
+		),
+		network.AddressesWithPort(
+			network.NewAddresses(
+				"127.0.0.1",
+				"localhost",
+				"example.org",
+				"::1",
+				"fc00::1",
+				"fe80::2",
+				"172.16.0.1",
+				"8.8.8.8",
+			),
+			1234,
+		),
+	}
+	err = s.State.SetAPIHostPorts(newHostPorts)
+	c.Assert(err, gc.IsNil)
+
+	expectHostPorts := [][]network.HostPort{
+		network.AddressesWithPort(
+			network.NewAddresses(
+				"fe80::2",
+				"::1",
+				"localhost",
+				"example.com",
+				"fc00::1",
+				"8.8.8.8",
+				"127.0.0.1",
+				"172.16.0.1",
+			),
+			1234,
+		),
+		network.AddressesWithPort(
+			network.NewAddresses(
+				"fc00::1",
+				"::1",
+				"localhost",
+				"example.org",
+				"fe80::2",
+				"127.0.0.1",
+				"172.16.0.1",
+				"8.8.8.8",
+			),
+			1234,
+		),
+	}
+	gotHostPorts, err := s.State.APIHostPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(gotHostPorts, jc.DeepEquals, expectHostPorts)
+}
+
 func (s *StateSuite) TestWatchAPIHostPorts(c *gc.C) {
 	w := s.State.WatchAPIHostPorts()
 	defer statetesting.AssertStop(c, w)

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/agent"
@@ -154,10 +155,10 @@ func (s *MachinerSuite) TestMachineAddresses(c *gc.C) {
 	s.State.StartSync()
 	c.Assert(mr.Wait(), gc.Equals, worker.ErrTerminateAgent)
 	c.Assert(s.machine.Refresh(), gc.IsNil)
-	c.Assert(s.machine.MachineAddresses(), gc.DeepEquals, []network.Address{
+	c.Assert(s.machine.MachineAddresses(), jc.DeepEquals, []network.Address{
+		network.NewAddress("2001:db8::1", network.ScopeUnknown),
+		network.NewAddress("::1", network.ScopeMachineLocal),
 		network.NewAddress("10.0.0.1", network.ScopeCloudLocal),
 		network.NewAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewAddress("::1", network.ScopeMachineLocal),
-		network.NewAddress("2001:db8::1", network.ScopeUnknown),
 	})
 }


### PR DESCRIPTION
Added network.SortAddresses() and network.SortHostPorts()
which use the prefer-ipv6 flag to determine which addresses
or HostPorts come on top.

Changed machine.SetAddresses and SetMachineAddresses to
sort the addresses according to whether prefer-ipv6 flag
is set in the environ config.

A few other places where changed as needed, including the
caching of API endpoints in the CLI client and mongo addresses
used to connect to state.

This is the final step of the prefer-ipv6 flag implementation.
