### PR TITLE
Added OS field to version.Binary, version.Current

### DIFF
--- a/agent/tools/diskmanager_test.go
+++ b/agent/tools/diskmanager_test.go
@@ -41,20 +41,20 @@ func (s *DiskManagerSuite) toolsDir() string {
 // Copied from environs/agent/tools_test.go
 func (s *DiskManagerSuite) TestUnpackToolsContents(c *gc.C) {
 	files := []*coretesting.TarFile{
-		coretesting.NewTarFile("bar", agenttools.DirPerm, "bar contents"),
-		coretesting.NewTarFile("foo", agenttools.DirPerm, "foo contents"),
+		coretesting.NewTarFile("amd64", agenttools.DirPerm, "bar contents"),
+		coretesting.NewTarFile("quantal", agenttools.DirPerm, "foo contents"),
 	}
 	gzfile, checksum := coretesting.TarGz(files...)
 	t1 := &coretools.Tools{
 		URL:     "http://foo/bar",
-		Version: version.MustParseBinary("1.2.3-foo-bar"),
+		Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 		Size:    int64(len(gzfile)),
 		SHA256:  checksum,
 	}
 
 	err := s.manager.UnpackTools(t1, bytes.NewReader(gzfile))
 	c.Assert(err, gc.IsNil)
-	assertDirNames(c, s.toolsDir(), []string{"1.2.3-foo-bar"})
+	assertDirNames(c, s.toolsDir(), []string{"1.2.3-quantal-amd64"})
 	s.assertToolsContents(c, t1, files)
 
 	// Try to unpack the same version of tools again - it should succeed,
@@ -66,13 +66,13 @@ func (s *DiskManagerSuite) TestUnpackToolsContents(c *gc.C) {
 	gzfile2, checksum2 := coretesting.TarGz(files2...)
 	t2 := &coretools.Tools{
 		URL:     "http://arble",
-		Version: version.MustParseBinary("1.2.3-foo-bar"),
+		Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 		Size:    int64(len(gzfile2)),
 		SHA256:  checksum2,
 	}
 	err = s.manager.UnpackTools(t2, bytes.NewReader(gzfile2))
 	c.Assert(err, gc.IsNil)
-	assertDirNames(c, s.toolsDir(), []string{"1.2.3-foo-bar"})
+	assertDirNames(c, s.toolsDir(), []string{"1.2.3-quantal-amd64"})
 	s.assertToolsContents(c, t1, files)
 }
 

--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -83,7 +83,7 @@ func (t *ToolsSuite) TestUnpackToolsBadData(c *gc.C) {
 		c.Logf("test %d", i)
 		testTools := &coretest.Tools{
 			URL:     "http://foo/bar",
-			Version: version.MustParseBinary("1.2.3-foo-bar"),
+			Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 			Size:    int64(len(test.data)),
 			SHA256:  test.checksum,
 		}
@@ -97,7 +97,7 @@ func (t *ToolsSuite) TestUnpackToolsBadChecksum(c *gc.C) {
 	data, _ := testing.TarGz(testing.NewTarFile("tools", agenttools.DirPerm, "some data"))
 	testTools := &coretest.Tools{
 		URL:     "http://foo/bar",
-		Version: version.MustParseBinary("1.2.3-foo-bar"),
+		Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 		Size:    int64(len(data)),
 		SHA256:  "1234",
 	}
@@ -119,14 +119,14 @@ func (t *ToolsSuite) TestUnpackToolsContents(c *gc.C) {
 	data, checksum := testing.TarGz(files...)
 	testTools := &coretest.Tools{
 		URL:     "http://foo/bar",
-		Version: version.MustParseBinary("1.2.3-foo-bar"),
+		Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 		Size:    int64(len(data)),
 		SHA256:  checksum,
 	}
 
 	err := agenttools.UnpackTools(t.dataDir, testTools, bytes.NewReader(data))
 	c.Assert(err, gc.IsNil)
-	assertDirNames(c, t.toolsDir(), []string{"1.2.3-foo-bar"})
+	assertDirNames(c, t.toolsDir(), []string{"1.2.3-quantal-amd64"})
 	t.assertToolsContents(c, testTools, files)
 
 	// Try to unpack the same version of tools again - it should succeed,
@@ -138,13 +138,13 @@ func (t *ToolsSuite) TestUnpackToolsContents(c *gc.C) {
 	data2, checksum2 := testing.TarGz(files2...)
 	tools2 := &coretest.Tools{
 		URL:     "http://arble",
-		Version: version.MustParseBinary("1.2.3-foo-bar"),
+		Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 		Size:    int64(len(data2)),
 		SHA256:  checksum2,
 	}
 	err = agenttools.UnpackTools(t.dataDir, tools2, bytes.NewReader(data2))
 	c.Assert(err, gc.IsNil)
-	assertDirNames(c, t.toolsDir(), []string{"1.2.3-foo-bar"})
+	assertDirNames(c, t.toolsDir(), []string{"1.2.3-quantal-amd64"})
 	t.assertToolsContents(c, testTools, files)
 }
 
@@ -174,7 +174,7 @@ func (t *ToolsSuite) TestChangeAgentTools(c *gc.C) {
 	data, checksum := testing.TarGz(files...)
 	testTools := &coretest.Tools{
 		URL:     "http://foo/bar1",
-		Version: version.MustParseBinary("1.2.3-foo-bar"),
+		Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 		Size:    int64(len(data)),
 		SHA256:  checksum,
 	}
@@ -185,18 +185,18 @@ func (t *ToolsSuite) TestChangeAgentTools(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(*gotTools, gc.Equals, *testTools)
 
-	assertDirNames(c, t.toolsDir(), []string{"1.2.3-foo-bar", "testagent"})
+	assertDirNames(c, t.toolsDir(), []string{"1.2.3-quantal-amd64", "testagent"})
 	assertDirNames(c, agenttools.ToolsDir(t.dataDir, "testagent"), []string{"jujuc", "jujud", toolsFile})
 
 	// Upgrade again to check that the link replacement logic works ok.
 	files2 := []*testing.TarFile{
-		testing.NewTarFile("foo", agenttools.DirPerm, "foo content"),
-		testing.NewTarFile("bar", agenttools.DirPerm, "bar content"),
+		testing.NewTarFile("quantal", agenttools.DirPerm, "foo content"),
+		testing.NewTarFile("amd64", agenttools.DirPerm, "bar content"),
 	}
 	data2, checksum2 := testing.TarGz(files2...)
 	tools2 := &coretest.Tools{
 		URL:     "http://foo/bar2",
-		Version: version.MustParseBinary("1.2.4-foo-bar"),
+		Version: version.MustParseBinary("1.2.4-quantal-amd64"),
 		Size:    int64(len(data2)),
 		SHA256:  checksum2,
 	}
@@ -207,8 +207,8 @@ func (t *ToolsSuite) TestChangeAgentTools(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(*gotTools, gc.Equals, *tools2)
 
-	assertDirNames(c, t.toolsDir(), []string{"1.2.3-foo-bar", "1.2.4-foo-bar", "testagent"})
-	assertDirNames(c, agenttools.ToolsDir(t.dataDir, "testagent"), []string{"foo", "bar", toolsFile})
+	assertDirNames(c, t.toolsDir(), []string{"1.2.3-quantal-amd64", "1.2.4-quantal-amd64", "testagent"})
+	assertDirNames(c, agenttools.ToolsDir(t.dataDir, "testagent"), []string{"quantal", "amd64", toolsFile})
 }
 
 func (t *ToolsSuite) TestSharedToolsDir(c *gc.C) {

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -281,7 +281,7 @@ var statusTests = []testCase{
 			},
 		},
 
-		setTools{"0", version.MustParseBinary("1.2.3-gutsy-ppc")},
+		setTools{"0", version.MustParseBinary("1.2.3-trusty-ppc")},
 		expect{
 			"simulate the MA setting the version",
 			M{

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -22,8 +22,8 @@ func CreateContainer(c *gc.C, manager container.Manager, machineId string) insta
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig := environs.NewMachineConfig(machineId, "fake-nonce", nil, stateInfo, apiInfo)
 	machineConfig.Tools = &tools.Tools{
-		Version: version.MustParseBinary("2.3.4-foo-bar"),
-		URL:     "http://tools.testing.invalid/2.3.4-foo-bar.tgz",
+		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}
 
 	series := "series"

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -197,7 +197,7 @@ ln -s 1\.2\.3-raring-amd64 '/var/lib/juju/tools/machine-0'
 			Jobs:               normalMachineJobs,
 			CloudInitOutputLog: environs.CloudInitOutputLog,
 			Bootstrap:          false,
-			Tools:              newSimpleTools("1.2.3-linux-amd64"),
+			Tools:              newSimpleTools("1.2.3-quantal-amd64"),
 			MachineNonce:       "FAKE_NONCE",
 			MongoInfo: &authentication.MongoInfo{
 				Tag:      names.NewMachineTag("99"),
@@ -227,18 +227,18 @@ mkdir -p /var/lib/juju/locks
 mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 echo 'Fetching tools.*
-bin='/var/lib/juju/tools/1\.2\.3-linux-amd64'
+bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
 mkdir -p \$bin
-curl -sSfw 'tools from %{url_effective} downloaded: HTTP %{http_code}; time %{time_total}s; size %{size_download} bytes; speed %{speed_download} bytes/s ' -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/releases/juju1\.2\.3-linux-amd64\.tgz'
-sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-linux-amd64\.sha256
-grep '1234' \$bin/juju1\.2\.3-linux-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
+curl -sSfw 'tools from %{url_effective} downloaded: HTTP %{http_code}; time %{time_total}s; size %{size_download} bytes; speed %{speed_download} bytes/s ' -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/releases/juju1\.2\.3-quantal-amd64\.tgz'
+sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-quantal-amd64\.sha256
+grep '1234' \$bin/juju1\.2\.3-quantal-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-linux-amd64\.sha256
-printf %s '{"version":"1\.2\.3-linux-amd64","url":"http://foo\.com/tools/releases/juju1\.2\.3-linux-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
+printf %s '{"version":"1\.2\.3-quantal-amd64","url":"http://foo\.com/tools/releases/juju1\.2\.3-quantal-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-99'
 install -m 600 /dev/null '/var/lib/juju/agents/machine-99/agent\.conf'
 printf '%s\\n' '.*' > '/var/lib/juju/agents/machine-99/agent\.conf'
-ln -s 1\.2\.3-linux-amd64 '/var/lib/juju/tools/machine-99'
+ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-99'
 echo 'Starting Juju machine agent \(jujud-machine-99\)'.*
 cat >> /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju machine-99 agent"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec /var/lib/juju/tools/machine-99/jujud machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-99
@@ -255,7 +255,7 @@ start jujud-machine-99
 			Jobs:                 normalMachineJobs,
 			CloudInitOutputLog:   environs.CloudInitOutputLog,
 			Bootstrap:            false,
-			Tools:                newSimpleTools("1.2.3-linux-amd64"),
+			Tools:                newSimpleTools("1.2.3-quantal-amd64"),
 			MachineNonce:         "FAKE_NONCE",
 			MongoInfo: &authentication.MongoInfo{
 				Tag:      names.NewMachineTag("2/lxc/1"),
@@ -278,7 +278,7 @@ start jujud-machine-99
 mkdir -p '/var/lib/juju/agents/machine-2-lxc-1'
 install -m 600 /dev/null '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf'
 printf '%s\\n' '.*' > '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf'
-ln -s 1\.2\.3-linux-amd64 '/var/lib/juju/tools/machine-2-lxc-1'
+ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-2-lxc-1'
 cat >> /etc/init/jujud-machine-2-lxc-1\.conf << 'EOF'\\ndescription "juju machine-2-lxc-1 agent"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-2-lxc-1\.log\\n  chown syslog:syslog /var/log/juju/machine-2-lxc-1\.log\\n  chmod 0600 /var/log/juju/machine-2-lxc-1\.log\\n\\n  exec /var/lib/juju/tools/machine-2-lxc-1/jujud machine --data-dir '/var/lib/juju' --machine-id 2/lxc/1 --debug >> /var/log/juju/machine-2-lxc-1\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-2-lxc-1
 `,
@@ -293,7 +293,7 @@ start jujud-machine-2-lxc-1
 			Jobs:               normalMachineJobs,
 			CloudInitOutputLog: environs.CloudInitOutputLog,
 			Bootstrap:          false,
-			Tools:              newSimpleTools("1.2.3-linux-amd64"),
+			Tools:              newSimpleTools("1.2.3-quantal-amd64"),
 			MachineNonce:       "FAKE_NONCE",
 			MongoInfo: &authentication.MongoInfo{
 				Tag:      names.NewMachineTag("99"),
@@ -314,7 +314,7 @@ start jujud-machine-2-lxc-1
 		},
 		inexactMatch: true,
 		expectScripts: `
-curl -sSfw 'tools from %{url_effective} downloaded: HTTP %{http_code}; time %{time_total}s; size %{size_download} bytes; speed %{speed_download} bytes/s ' --insecure -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/releases/juju1\.2\.3-linux-amd64\.tgz'
+curl -sSfw 'tools from %{url_effective} downloaded: HTTP %{http_code}; time %{time_total}s; size %{size_download} bytes; speed %{speed_download} bytes/s ' --insecure -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/releases/juju1\.2\.3-quantal-amd64\.tgz'
 `,
 	}, {
 		// empty contraints.
@@ -762,7 +762,7 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 		Bootstrap:        true,
 		StateServingInfo: stateServingInfo,
 		MachineId:        "99",
-		Tools:            newSimpleTools("9.9.9-linux-arble"),
+		Tools:            newSimpleTools("9.9.9-quantal-arble"),
 		AuthorizedKeys:   "sshkey1",
 		AgentEnvironment: map[string]string{agent.ProviderType: "dummy"},
 		MongoInfo: &authentication.MongoInfo{
@@ -813,8 +813,8 @@ func (*cloudinitSuite) createMachineConfig(c *gc.C, environConfig *config.Config
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig := environs.NewMachineConfig(machineId, machineNonce, nil, stateInfo, apiInfo)
 	machineConfig.Tools = &tools.Tools{
-		Version: version.MustParseBinary("2.3.4-foo-bar"),
-		URL:     "http://tools.testing.invalid/2.3.4-foo-bar.tgz",
+		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}
 	err := environs.FinishMachineConfig(machineConfig, environConfig, constraints.Value{})
 	c.Assert(err, gc.IsNil)

--- a/environs/cloudinit_test.go
+++ b/environs/cloudinit_test.go
@@ -155,8 +155,8 @@ func (*CloudInitSuite) testUserData(c *gc.C, bootstrap bool) {
 	testJujuHome := c.MkDir()
 	defer osenv.SetJujuHome(osenv.SetJujuHome(testJujuHome))
 	tools := &tools.Tools{
-		URL:     "http://foo.com/tools/releases/juju1.2.3-linux-amd64.tgz",
-		Version: version.MustParseBinary("1.2.3-linux-amd64"),
+		URL:     "http://foo.com/tools/releases/juju1.2.3-quantal-amd64.tgz",
+		Version: version.MustParseBinary("1.2.3-quantal-amd64"),
 	}
 	envConfig, err := config.New(config.NoDefaults, dummySampleConfig())
 	c.Assert(err, gc.IsNil)

--- a/environs/manual/provisioner_test.go
+++ b/environs/manual/provisioner_test.go
@@ -44,6 +44,7 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	const series = "precise"
 	const arch = "amd64"
+	const operatingSystem = version.Ubuntu
 
 	args := s.getArgs(c)
 	hostname := args.Host
@@ -64,7 +65,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	cfg := s.Environ.Config()
 	number, ok := cfg.AgentVersion()
 	c.Assert(ok, jc.IsTrue)
-	binVersion := version.Binary{number, series, arch}
+	binVersion := version.Binary{number, series, arch, operatingSystem}
 	envtesting.AssertUploadFakeToolsVersions(c, s.Environ.Storage(), binVersion)
 
 	for i, errorCode := range []int{255, 0} {

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -154,6 +154,7 @@ func (t *ToolsMetadata) binary() version.Binary {
 		Number: version.MustParse(t.Version),
 		Series: t.Release,
 		Arch:   t.Arch,
+		OS:     version.MustOSFromSeries(t.Release),
 	}
 }
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -806,7 +806,7 @@ func (s *MachineSuite) TestMachineRefresh(c *gc.C) {
 	oldTools, _ := m0.AgentTools()
 	m1, err := s.State.Machine(m0.Id())
 	c.Assert(err, gc.IsNil)
-	err = m0.SetAgentVersion(version.MustParseBinary("0.0.3-series-arch"))
+	err = m0.SetAgentVersion(version.MustParseBinary("0.0.3-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 	newTools, _ := m0.AgentTools()
 
@@ -961,7 +961,7 @@ func (s *MachineSuite) TestWatchMachine(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Make two changes, check one event.
-	err = machine.SetAgentVersion(version.MustParseBinary("0.0.3-series-arch"))
+	err = machine.SetAgentVersion(version.MustParseBinary("0.0.3-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 	err = machine.Destroy()
 	c.Assert(err, gc.IsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -964,7 +964,7 @@ func (s *StateSuite) TestAllMachines(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		err = m.SetProvisioned(instance.Id(fmt.Sprintf("foo-%d", i)), "fake_nonce", nil)
 		c.Assert(err, gc.IsNil)
-		err = m.SetAgentVersion(version.MustParseBinary("7.8.9-foo-bar"))
+		err = m.SetAgentVersion(version.MustParseBinary("7.8.9-quantal-amd64"))
 		c.Assert(err, gc.IsNil)
 		err = m.Destroy()
 		c.Assert(err, gc.IsNil)
@@ -978,7 +978,7 @@ func (s *StateSuite) TestAllMachines(c *gc.C) {
 		c.Assert(string(instId), gc.Equals, fmt.Sprintf("foo-%d", i))
 		tools, err := m.AgentTools()
 		c.Check(err, gc.IsNil)
-		c.Check(tools.Version, gc.DeepEquals, version.MustParseBinary("7.8.9-foo-bar"))
+		c.Check(tools.Version, gc.DeepEquals, version.MustParseBinary("7.8.9-quantal-amd64"))
 		c.Assert(m.Life(), gc.Equals, state.Dying)
 	}
 }
@@ -1822,7 +1822,7 @@ func (s *StateSuite) TestWatchMachineHardwareCharacteristics(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Alter the machine: not reported.
-	vers := version.MustParseBinary("1.2.3-gutsy-ppc")
+	vers := version.MustParseBinary("1.2.3-quantal-ppc")
 	err = machine.SetAgentVersion(vers)
 	c.Assert(err, gc.IsNil)
 	wc.AssertNoChange()
@@ -2771,17 +2771,17 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	// the new version.
 	machine0, err := s.State.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, gc.IsNil)
-	err = machine0.SetAgentVersion(version.MustParseBinary("9.9.9-series-arch"))
+	err = machine0.SetAgentVersion(version.MustParseBinary("9.9.9-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 	machine1, err := s.State.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, gc.IsNil)
 	machine2, err := s.State.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, gc.IsNil)
-	err = machine2.SetAgentVersion(version.MustParseBinary(stringVersion + "-series-arch"))
+	err = machine2.SetAgentVersion(version.MustParseBinary(stringVersion + "-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 	machine3, err := s.State.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, gc.IsNil)
-	err = machine3.SetAgentVersion(version.MustParseBinary("4.5.6-series-arch"))
+	err = machine3.SetAgentVersion(version.MustParseBinary("4.5.6-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 
 	// Verify machine0 and machine1 are reported as error.
@@ -2797,17 +2797,17 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	unit0, err := service.AddUnit()
 	c.Assert(err, gc.IsNil)
-	err = unit0.SetAgentVersion(version.MustParseBinary("6.6.6-series-arch"))
+	err = unit0.SetAgentVersion(version.MustParseBinary("6.6.6-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 	_, err = service.AddUnit()
 	c.Assert(err, gc.IsNil)
 	unit2, err := service.AddUnit()
 	c.Assert(err, gc.IsNil)
-	err = unit2.SetAgentVersion(version.MustParseBinary(stringVersion + "-series-arch"))
+	err = unit2.SetAgentVersion(version.MustParseBinary(stringVersion + "-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 	unit3, err := service.AddUnit()
 	c.Assert(err, gc.IsNil)
-	err = unit3.SetAgentVersion(version.MustParseBinary("4.5.6-series-arch"))
+	err = unit3.SetAgentVersion(version.MustParseBinary("4.5.6-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 
 	// Verify unit0 and unit1 are reported as error, along with the
@@ -2848,9 +2848,9 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C) (*config.Config, string) 
 	unit, err := service.AddUnit()
 	c.Assert(err, gc.IsNil)
 
-	err = machine.SetAgentVersion(version.MustParseBinary(currentVersion + "-series-arch"))
+	err = machine.SetAgentVersion(version.MustParseBinary(currentVersion + "-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
-	err = unit.SetAgentVersion(version.MustParseBinary(currentVersion + "-series-arch"))
+	err = unit.SetAgentVersion(version.MustParseBinary(currentVersion + "-quantal-amd64"))
 	c.Assert(err, gc.IsNil)
 
 	return envConfig, currentVersion

--- a/state/tools_test.go
+++ b/state/tools_test.go
@@ -48,7 +48,7 @@ func testAgentTools(c *gc.C, obj tooler, agent string) {
 	err = obj.SetAgentVersion(version.Binary{})
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("cannot set agent version for %s: empty series or arch", agent))
 
-	v2 := version.MustParseBinary("7.8.9-foo-bar")
+	v2 := version.MustParseBinary("7.8.9-quantal-amd64")
 	err = obj.SetAgentVersion(v2)
 	c.Assert(err, gc.IsNil)
 	t3, err := obj.AgentTools()

--- a/tools/marshal_test.go
+++ b/tools/marshal_test.go
@@ -26,7 +26,7 @@ func newTools(vers, url string) *tools.Tools {
 }
 
 func (s *marshalSuite) TestMarshalUnmarshal(c *gc.C) {
-	testTools := newTools("7.8.9-foo-bar", "http://arble.tgz")
+	testTools := newTools("7.8.9-quantal-amd64", "http://arble.tgz")
 	data, err := bson.Marshal(&testTools)
 	c.Assert(err, gc.IsNil)
 

--- a/version/osversion.go
+++ b/version/osversion.go
@@ -28,6 +28,16 @@ func mustOSVersion() string {
 	return version
 }
 
+// MustOSFromSeries will panic if the series represents an "unknown"
+// operating system
+func MustOSFromSeries(series string) OSType {
+	operatingSystem, err := GetOSFromSeries(series)
+	if err != nil {
+		panic("osVersion reported an error: " + err.Error())
+	}
+	return operatingSystem
+}
+
 func readSeries(releaseFile string) (string, error) {
 	f, err := os.Open(releaseFile)
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -33,13 +33,16 @@ var switchOverVersion = MustParse("1.19.9")
 // the release version of ubuntu.
 var lsbReleaseFile = "/etc/lsb-release"
 
+var osVers = mustOSVersion()
+
 // Current gives the current version of the system.  If the file
 // "FORCE-VERSION" is present in the same directory as the running
 // binary, it will override this.
 var Current = Binary{
 	Number: MustParse(version),
-	Series: mustOSVersion(),
+	Series: osVers,
 	Arch:   arch.HostArch(),
+	OS:     MustOSFromSeries(osVers),
 }
 
 var Compiler = runtime.Compiler
@@ -82,6 +85,7 @@ type Binary struct {
 	Number
 	Series string
 	Arch   string
+	OS     OSType
 }
 
 func (v Binary) String() string {
@@ -187,6 +191,11 @@ func ParseBinary(s string) (Binary, error) {
 	}
 	v.Series = m[7]
 	v.Arch = m[8]
+	operatingSystem, err := GetOSFromSeries(v.Series)
+	if err != nil {
+		return Binary{}, err
+	}
+	v.OS = operatingSystem
 	return v, nil
 }
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -163,6 +163,7 @@ func binaryVersion(major, minor, patch, build int, tag, series, arch string) ver
 		},
 		Series: series,
 		Arch:   arch,
+		OS:     version.Ubuntu,
 	}
 }
 
@@ -172,17 +173,17 @@ func (*suite) TestParseBinary(c *gc.C) {
 		err    string
 		expect version.Binary
 	}{{
-		v:      "1.2.3-a-b",
-		expect: binaryVersion(1, 2, 3, 0, "", "a", "b"),
+		v:      "1.2.3-trusty-amd64",
+		expect: binaryVersion(1, 2, 3, 0, "", "trusty", "amd64"),
 	}, {
-		v:      "1.2.3.4-a-b",
-		expect: binaryVersion(1, 2, 3, 4, "", "a", "b"),
+		v:      "1.2.3.4-trusty-amd64",
+		expect: binaryVersion(1, 2, 3, 4, "", "trusty", "amd64"),
 	}, {
-		v:      "1.2-alpha3-a-b",
-		expect: binaryVersion(1, 2, 3, 0, "alpha", "a", "b"),
+		v:      "1.2-alpha3-trusty-amd64",
+		expect: binaryVersion(1, 2, 3, 0, "alpha", "trusty", "amd64"),
 	}, {
-		v:      "1.2-alpha3.4-a-b",
-		expect: binaryVersion(1, 2, 3, 4, "alpha", "a", "b"),
+		v:      "1.2-alpha3.4-trusty-amd64",
+		expect: binaryVersion(1, 2, 3, 4, "alpha", "trusty", "amd64"),
 	}, {
 		v:   "1.2.3",
 		err: "invalid binary version.*",
@@ -190,10 +191,10 @@ func (*suite) TestParseBinary(c *gc.C) {
 		v:   "1.2-beta1",
 		err: "invalid binary version.*",
 	}, {
-		v:   "1.2.3--b",
+		v:   "1.2.3--amd64",
 		err: "invalid binary version.*",
 	}, {
-		v:   "1.2.3-a-",
+		v:   "1.2.3-trusty-",
 		err: "invalid binary version.*",
 	}}
 
@@ -210,12 +211,13 @@ func (*suite) TestParseBinary(c *gc.C) {
 
 	for i, test := range parseTests {
 		c.Logf("test 2: %d", i)
-		v := test.v + "-a-b"
+		v := test.v + "-trusty-amd64"
 		got, err := version.ParseBinary(v)
 		expect := version.Binary{
 			Number: test.expect,
-			Series: "a",
-			Arch:   "b",
+			Series: "trusty",
+			Arch:   "amd64",
+			OS:     version.Ubuntu,
 		}
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, strings.Replace(test.err, "version", "binary version", 1))
@@ -253,7 +255,7 @@ func (*suite) TestBinaryMarshalUnmarshal(c *gc.C) {
 		}
 		// Work around goyaml bug #1096149
 		// SetYAML is not called for non-pointer fields.
-		bp := version.MustParseBinary("1.2.3-foo-bar")
+		bp := version.MustParseBinary("1.2.3-trusty-amd64")
 		v := doc{&bp}
 		data, err := m.marshal(&v)
 		c.Assert(err, gc.IsNil)

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -66,8 +66,8 @@ func (s *kvmSuite) TearDownTest(c *gc.C) {
 func (s *kvmBrokerSuite) SetUpTest(c *gc.C) {
 	s.kvmSuite.SetUpTest(c)
 	tools := &coretools.Tools{
-		Version: version.MustParseBinary("2.3.4-foo-bar"),
-		URL:     "http://tools.testing.invalid/2.3.4-foo-bar.tgz",
+		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}
 	var err error
 	s.agentConfig, err = agent.NewAgentConfig(

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -68,8 +68,8 @@ func (s *lxcSuite) TearDownTest(c *gc.C) {
 func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 	s.lxcSuite.SetUpTest(c)
 	tools := &coretools.Tools{
-		Version: version.MustParseBinary("2.3.4-foo-bar"),
-		URL:     "http://tools.testing.invalid/2.3.4-foo-bar.tgz",
+		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}
 	var err error
 	s.agentConfig, err = agent.NewAgentConfig(


### PR DESCRIPTION
This change allows us to cache the current OS we are running on, so we will not have to do a version.GetOSFromSeries(version.Current.Series) every time we need to get the operating system type
