### PR TITLE
Pass net.Listener into apiserver.NewServer

### DIFF
--- a/state/apiserver/apiserver.go
+++ b/state/apiserver/apiserver.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -54,7 +53,6 @@ type LoginValidator func(params.Creds) error
 
 // ServerConfig holds parameters required to set up an API server.
 type ServerConfig struct {
-	Port      int
 	Cert      []byte
 	Key       []byte
 	DataDir   string
@@ -65,12 +63,7 @@ type ServerConfig struct {
 // NewServer serves the given state by accepting requests on the given
 // listener, using the given certificate and key (in PEM format) for
 // authentication.
-func NewServer(s *state.State, cfg ServerConfig) (*Server, error) {
-	endpoint := net.JoinHostPort("", strconv.Itoa(cfg.Port))
-	lis, err := net.Listen("tcp", endpoint)
-	if err != nil {
-		return nil, err
-	}
+func NewServer(s *state.State, lis net.Listener, cfg ServerConfig) (*Server, error) {
 	logger.Infof("listening on %q", lis.Addr())
 	tlsCert, err := tls.X509KeyPair(cfg.Cert, cfg.Key)
 	if err != nil {

--- a/state/apiserver/login_test.go
+++ b/state/apiserver/login_test.go
@@ -538,10 +538,12 @@ func (s *loginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.LoginV
 }
 
 func (s *loginSuite) setupServerWithValidator(c *gc.C, validator apiserver.LoginValidator) (*api.Info, func()) {
+	listener, err := net.Listen("tcp", ":0")
+	c.Assert(err, gc.IsNil)
 	srv, err := apiserver.NewServer(
 		s.State,
+		listener,
 		apiserver.ServerConfig{
-			Port:      0,
 			Cert:      []byte(coretesting.ServerCert),
 			Key:       []byte(coretesting.ServerKey),
 			Validator: validator,

--- a/state/apiserver/server_test.go
+++ b/state/apiserver/server_test.go
@@ -46,8 +46,9 @@ var _ = gc.Suite(&serverSuite{})
 func (s *serverSuite) TestStop(c *gc.C) {
 	// Start our own instance of the server so we have
 	// a handle on it to stop it.
-	srv, err := apiserver.NewServer(s.State, apiserver.ServerConfig{
-		Port: 0,
+	listener, err := net.Listen("tcp", ":0")
+	c.Assert(err, gc.IsNil)
+	srv, err := apiserver.NewServer(s.State, listener, apiserver.ServerConfig{
 		Cert: []byte(coretesting.ServerCert),
 		Key:  []byte(coretesting.ServerKey),
 	})
@@ -95,10 +96,10 @@ func (s *serverSuite) TestStop(c *gc.C) {
 
 func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 	// Start our own instance of the server listening on
-	// both IPv4 and IPv6 localhost addresses and port 0,
-	// so that an available port is choosen.
-	srv, err := apiserver.NewServer(s.State, apiserver.ServerConfig{
-		Port: 0,
+	// both IPv4 and IPv6 localhost addresses and an ephemeral port.
+	listener, err := net.Listen("tcp", ":0")
+	c.Assert(err, gc.IsNil)
+	srv, err := apiserver.NewServer(s.State, listener, apiserver.ServerConfig{
 		Cert: []byte(coretesting.ServerCert),
 		Key:  []byte(coretesting.ServerKey),
 	})
@@ -296,8 +297,9 @@ func dialWebsocket(c *gc.C, addr, path string) (*websocket.Conn, error) {
 func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 	// we expose the API at '/' for compatibility, and at '/ENVUUID/api'
 	// for the correct location, but other Paths should fail.
-	srv, err := apiserver.NewServer(s.State, apiserver.ServerConfig{
-		Port: 0,
+	listener, err := net.Listen("tcp", ":0")
+	c.Assert(err, gc.IsNil)
+	srv, err := apiserver.NewServer(s.State, listener, apiserver.ServerConfig{
 		Cert: []byte(coretesting.ServerCert),
 		Key:  []byte(coretesting.ServerKey),
 	})


### PR DESCRIPTION
The dummy provider will soon be changed to
create a net.Listener with an ephemeral port,
and then later use this Listener in its
embedded apiserver.Server.

In this PR, we change apiserver.NewServer
to accept a Listener, as opposed to creating
one internally. We record the ephemeral port
as api-port in the dummy provider's environment
config; this will be used in a future change
to use api-port as the basis of computing the
API server addresses, as we do in normal operation.

This change also opens the door to testing without
a TCP-based listener (e.g. using a mock listener
than returns in-memory net.Conns created with
net.Pipe).
