### PR TITLE
Update dependencies to pull in new repos with licensing fixed

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -9,8 +9,8 @@ github.com/juju/charm	git	9430523b11b4f0f9112d62d819f5377f06d2f65b
 github.com/juju/cmd	git	e2d7df426d54b663f8616901b75d1ccfafcd9997	
 github.com/juju/errgo	git	2cf7b553faddc588f903020c33e71c527d5e0838	
 github.com/juju/errors	git	09734a904adc602da4334cbf29cb4515fbeb8feb	
-github.com/juju/gojsonpointer	git	57ab5e9c764219a3e0c4d7759797fefdcab22e9c	
-github.com/juju/gojsonreference	git	99b7aa4f082bbde91ecbd87a92022495bf12f259	
+github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	
+github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	
 github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	
 github.com/juju/loggo	git	158009fb40c4a52b3d2c23eb56e72859cfc5321a	
 github.com/juju/names	git	da1b2b31b1f88bbbcea02e8d874e3e44c9e1f4ad	


### PR DESCRIPTION
This is required for compliance with the licensing rules to allow Juju to be included in trusty
