### PR TITLE
Agent config mutators can now return errors

### DIFF
--- a/cmd/jujud/agent.go
+++ b/cmd/jujud/agent.go
@@ -48,6 +48,8 @@ type AgentConf struct {
 	_config agent.ConfigSetterWriter
 }
 
+type AgentConfigMutator func(agent.ConfigSetter) error
+
 // AddFlags injects common agent flags into f.
 func (c *AgentConf) AddFlags(f *gnuflag.FlagSet) {
 	// TODO(dimitern) 2014-02-19 bug 1282025
@@ -79,11 +81,16 @@ func (c *AgentConf) ReadConfig(tag string) error {
 	return nil
 }
 
-func (ch *AgentConf) ChangeConfig(change func(c agent.ConfigSetter)) error {
+func (ch *AgentConf) ChangeConfig(change AgentConfigMutator) error {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
-	change(ch._config)
-	return ch._config.Write()
+	if err := change(ch._config); err != nil {
+		return errors.Trace(err)
+	}
+	if err := ch._config.Write(); err != nil {
+		return errors.Annotate(err, "cannot write agent configuration")
+	}
+	return nil
 }
 
 func (ch *AgentConf) CurrentConfig() agent.Config {
@@ -94,8 +101,9 @@ func (ch *AgentConf) CurrentConfig() agent.Config {
 
 // SetAPIHostPorts satisfies worker/apiaddressupdater/APIAddressSetter.
 func (a *AgentConf) SetAPIHostPorts(servers [][]network.HostPort) error {
-	return a.ChangeConfig(func(c agent.ConfigSetter) {
+	return a.ChangeConfig(func(c agent.ConfigSetter) error {
 		c.SetAPIHostPorts(servers)
+		return nil
 	})
 }
 
@@ -126,7 +134,7 @@ func isUpgraded(err error) bool {
 
 type Agent interface {
 	Tag() names.Tag
-	ChangeConfig(func(agent.ConfigSetter)) error
+	ChangeConfig(AgentConfigMutator) error
 }
 
 // The AgentState interface is implemented by state types
@@ -257,9 +265,10 @@ func openAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.
 		// we might successfully change the entity's
 		// password but fail to write the configuration,
 		// thus locking us out completely.
-		if err := a.ChangeConfig(func(c agent.ConfigSetter) {
+		if err := a.ChangeConfig(func(c agent.ConfigSetter) error {
 			c.SetPassword(newPassword)
 			c.SetOldPassword(info.Password)
+			return nil
 		}); err != nil {
 			return nil, nil, err
 		}

--- a/cmd/jujud/agentconf_test.go
+++ b/cmd/jujud/agentconf_test.go
@@ -1,0 +1,80 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/agent"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&agentConfSuite{})
+
+type agentConfSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *agentConfSuite) TestChangeConfigSuccess(c *gc.C) {
+	mcsw := &mockConfigSetterWriter{}
+
+	conf := AgentConf{
+		dataDir: c.MkDir(),
+		_config: mcsw,
+	}
+
+	err := conf.ChangeConfig(func(agent.ConfigSetter) error {
+		return nil
+	})
+
+	c.Assert(err, gc.IsNil)
+	c.Assert(mcsw.WriteCalled, jc.IsTrue)
+}
+
+func (s *agentConfSuite) TestChangeConfigMutateFailure(c *gc.C) {
+	mcsw := &mockConfigSetterWriter{}
+
+	conf := AgentConf{
+		dataDir: c.MkDir(),
+		_config: mcsw,
+	}
+
+	err := conf.ChangeConfig(func(agent.ConfigSetter) error {
+		return errors.New("blam")
+	})
+
+	c.Assert(err, gc.ErrorMatches, "blam")
+	c.Assert(mcsw.WriteCalled, jc.IsFalse)
+}
+
+func (s *agentConfSuite) TestChangeConfigWriteFailure(c *gc.C) {
+	mcsw := &mockConfigSetterWriter{
+		WriteError: errors.New("boom"),
+	}
+
+	conf := AgentConf{
+		dataDir: c.MkDir(),
+		_config: mcsw,
+	}
+
+	err := conf.ChangeConfig(func(agent.ConfigSetter) error {
+		return nil
+	})
+
+	c.Assert(err, gc.ErrorMatches, "cannot write agent configuration: boom")
+	c.Assert(mcsw.WriteCalled, jc.IsTrue)
+}
+
+type mockConfigSetterWriter struct {
+	agent.ConfigSetterWriter
+	WriteError  error
+	WriteCalled bool
+}
+
+func (c *mockConfigSetterWriter) Write() error {
+	c.WriteCalled = true
+	return c.WriteError
+}

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -116,8 +116,9 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return fmt.Errorf("bootstrap machine config has no state serving info")
 	}
 	info.SharedSecret = sharedSecret
-	err = c.ChangeConfig(func(agentConfig agent.ConfigSetter) {
+	err = c.ChangeConfig(func(agentConfig agent.ConfigSetter) error {
 		agentConfig.SetStateServingInfo(info)
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("cannot write agent config: %v", err)
@@ -132,9 +133,9 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	// Initialise state, and store any agent config (e.g. password) changes.
 	var st *state.State
 	var m *state.Machine
-	err = nil
-	writeErr := c.ChangeConfig(func(agentConfig agent.ConfigSetter) {
-		st, m, err = agent.InitializeState(
+	err = c.ChangeConfig(func(agentConfig agent.ConfigSetter) error {
+		var stateErr error
+		st, m, stateErr = agent.InitializeState(
 			agentConfig,
 			envCfg,
 			agent.BootstrapMachineConfig{
@@ -148,10 +149,8 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 			mongo.DefaultDialOpts(),
 			environs.NewStatePolicy(),
 		)
+		return stateErr
 	})
-	if writeErr != nil {
-		return fmt.Errorf("cannot write initial configuration: %v", err)
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -183,10 +183,13 @@ func (a *MachineAgent) Run(_ *cmd.Context) error {
 	return err
 }
 
-func (a *MachineAgent) ChangeConfig(mutate func(config agent.ConfigSetter)) error {
+func (a *MachineAgent) ChangeConfig(mutate AgentConfigMutator) error {
 	err := a.AgentConf.ChangeConfig(mutate)
 	a.configChangedVal.Set(struct{}{})
-	return err
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // newStateStarterWorker wraps stateStarter in a simple worker for use in
@@ -250,8 +253,9 @@ func (a *MachineAgent) APIWorker() (worker.Worker, error) {
 			if err != nil {
 				return nil, fmt.Errorf("cannot get state serving info: %v", err)
 			}
-			err = a.ChangeConfig(func(config agent.ConfigSetter) {
+			err = a.ChangeConfig(func(config agent.ConfigSetter) error {
 				config.SetStateServingInfo(info)
+				return nil
 			})
 			if err != nil {
 				return nil, err
@@ -587,8 +591,9 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 			if err != nil {
 				return err
 			}
-			if err = a.ChangeConfig(func(config agent.ConfigSetter) {
+			if err = a.ChangeConfig(func(config agent.ConfigSetter) error {
 				config.SetStateServingInfo(servingInfo)
+				return nil
 			}); err != nil {
 				return err
 			}
@@ -862,8 +867,8 @@ func (a *MachineAgent) runUpgrades(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	var upgradeErr error
-	writeErr := a.ChangeConfig(func(agentConfig agent.ConfigSetter) {
+	err = a.ChangeConfig(func(agentConfig agent.ConfigSetter) error {
+		var upgradeErr error
 		a.setMachineStatus(apiState, params.StatusStarted,
 			fmt.Sprintf("upgrading to %v", version.Current))
 		context := upgrades.NewContext(agentConfig, apiState, st)
@@ -892,16 +897,14 @@ func (a *MachineAgent) runUpgrades(
 			}
 		}
 		if upgradeErr != nil {
-			return
+			return upgradeErr
 		}
 		agentConfig.SetUpgradedToVersion(version.Current.Number)
+		return nil
 	})
-	if upgradeErr != nil {
-		logger.Errorf("upgrade to %v failed.", version.Current)
-		return &fatalError{upgradeErr.Error()}
-	}
-	if writeErr != nil {
-		return fmt.Errorf("cannot write updated agent configuration: %v", writeErr)
+	if err != nil {
+		logger.Errorf("upgrade to %v failed: %v", version.Current, err)
+		return &fatalError{err.Error()}
 	}
 
 	logger.Infof("upgrade to %v completed successfully.", version.Current)

--- a/cmd/jujud/machine_test.go
+++ b/cmd/jujud/machine_test.go
@@ -481,8 +481,9 @@ func (s *MachineSuite) TestEnsureLocalEnvironDoesntRunPeergrouper(c *gc.C) {
 	})
 	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
 	a := s.newAgent(c, m)
-	err := a.ChangeConfig(func(config agent.ConfigSetter) {
+	err := a.ChangeConfig(func(config agent.ConfigSetter) error {
 		config.SetValue(agent.ProviderType, "local")
+		return nil
 	})
 	c.Assert(err, gc.IsNil)
 	defer func() { c.Check(a.Stop(), gc.IsNil) }()

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -219,7 +219,7 @@ func (f *fakeUnitAgent) Tag() names.Tag {
 	return names.NewUnitTag(f.unitName)
 }
 
-func (f *fakeUnitAgent) ChangeConfig(func(agent.ConfigSetter)) error {
+func (f *fakeUnitAgent) ChangeConfig(AgentConfigMutator) error {
 	panic("fakeUnitAgent.ChangeConfig called unexpectedly")
 }
 


### PR DESCRIPTION
Previously, functions that modify agent config could not return errors, requiring some gynamastics to get errors out of these functions. By requiring that errors are returned some areas that call ChangeConfig are now cleaner.
