### PR TITLE
state: only update API host ports if changed

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -6,6 +6,7 @@ package state
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"labix.org/v2/mgo/bson"
 	"labix.org/v2/mgo/txn"
 
@@ -98,28 +99,30 @@ func (st *State) SetAPIHostPorts(hps [][]network.HostPort) error {
 	for i, _ := range hps {
 		network.SortHostPorts(hps[i], envConfig.PreferIPv6())
 	}
-	existing, err := st.APIHostPorts()
-	if err != nil {
-		return err
-	}
-	if hostPortsEqual(hps, existing) {
-		return nil
-	}
 	doc := apiHostPortsDoc{
 		APIHostPorts: instanceHostPortsToHostPorts(hps),
 	}
-	// We need to insert the document if it does not already
-	// exist to make this method work even on old environments
-	// where the document was not created by Initialize.
-	ops := []txn.Op{{
-		C:  st.stateServers.Name,
-		Id: apiHostPortsKey,
-		Update: bson.D{{"$set", bson.D{
-			{"apihostports", doc.APIHostPorts},
-		}}},
-	}}
-	if err := st.runTransaction(ops); err != nil {
-		return fmt.Errorf("cannot set API addresses: %v", err)
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		existing, err := st.APIHostPorts()
+		if err != nil {
+			return nil, err
+		}
+		op := txn.Op{
+			C:  st.stateServers.Name,
+			Id: apiHostPortsKey,
+			Assert: bson.D{{
+				"apihostports", instanceHostPortsToHostPorts(existing),
+			}},
+		}
+		if !hostPortsEqual(hps, existing) {
+			op.Update = bson.D{{
+				"$set", bson.D{{"apihostports", doc.APIHostPorts}},
+			}}
+		}
+		return []txn.Op{op}, nil
+	}
+	if err := st.run(buildTxn); err != nil {
+		return errors.Annotate(err, "cannot set API addresses")
 	}
 	return nil
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3547,7 +3547,7 @@ func (s *StateSuite) TestSetAPIHostPortsPreferIPv6(c *gc.C) {
 	c.Assert(gotHostPorts, jc.DeepEquals, expectHostPorts)
 }
 
-func (s *StateSuite) TestSetAPIHostPortsSame(c *gc.C) {
+func (s *StateSuite) TestSetAPIHostPortsConcurrentSame(c *gc.C) {
 	hostPorts := [][]network.HostPort{{{
 		Address: network.Address{
 			Value:       "0.4.8.16",
@@ -3566,18 +3566,71 @@ func (s *StateSuite) TestSetAPIHostPortsSame(c *gc.C) {
 		Port: 1,
 	}}}
 
-	// Second call should not update txn-revno.
+	// API host ports are concurrently changed to the same
+	// desired value; second arrival will fail its assertion,
+	// refresh finding nothing to do, and then issue a
+	// read-only assertion that suceeds.
+
 	var prevRevno int64
-	for i := 0; i < 2; i++ {
+	defer state.SetBeforeHooks(c, s.State, func() {
 		err := s.State.SetAPIHostPorts(hostPorts)
 		c.Assert(err, gc.IsNil)
 		revno, err := state.TxnRevno(s.State, "stateServers", "apiHostPorts")
 		c.Assert(err, gc.IsNil)
-		if i > 0 {
-			c.Assert(revno, gc.Equals, prevRevno)
-		}
 		prevRevno = revno
-	}
+	}).Check()
+
+	err := s.State.SetAPIHostPorts(hostPorts)
+	c.Assert(err, gc.IsNil)
+	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
+	revno, err := state.TxnRevno(s.State, "stateServers", "apiHostPorts")
+	c.Assert(err, gc.IsNil)
+	c.Assert(revno, gc.Equals, prevRevno)
+}
+
+func (s *StateSuite) TestSetAPIHostPortsConcurrentDifferent(c *gc.C) {
+	hostPorts0 := []network.HostPort{{
+		Address: network.Address{
+			Value:       "0.4.8.16",
+			Type:        network.IPv4Address,
+			NetworkName: "foo",
+			Scope:       network.ScopePublic,
+		},
+		Port: 2,
+	}}
+	hostPorts1 := []network.HostPort{{
+		Address: network.Address{
+			Value:       "0.2.4.6",
+			Type:        network.IPv4Address,
+			NetworkName: "net",
+			Scope:       network.ScopeCloudLocal,
+		},
+		Port: 1,
+	}}
+
+	// API host ports are concurrently changed to different
+	// values; second arrival will fail its assertion, refresh
+	// finding and reattempt.
+
+	var prevRevno int64
+	defer state.SetBeforeHooks(c, s.State, func() {
+		err := s.State.SetAPIHostPorts([][]network.HostPort{hostPorts0})
+		c.Assert(err, gc.IsNil)
+		revno, err := state.TxnRevno(s.State, "stateServers", "apiHostPorts")
+		c.Assert(err, gc.IsNil)
+		prevRevno = revno
+	}).Check()
+
+	err := s.State.SetAPIHostPorts([][]network.HostPort{hostPorts1})
+	c.Assert(err, gc.IsNil)
+	c.Assert(prevRevno, gc.Not(gc.Equals), 0)
+	revno, err := state.TxnRevno(s.State, "stateServers", "apiHostPorts")
+	c.Assert(err, gc.IsNil)
+	c.Assert(revno, gc.Not(gc.Equals), prevRevno)
+
+	hostPorts, err := s.State.APIHostPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(hostPorts, gc.DeepEquals, [][]network.HostPort{hostPorts1})
 }
 
 func (s *StateSuite) TestWatchAPIHostPorts(c *gc.C) {


### PR DESCRIPTION
If the API host ports haven't changed, don't
update them. This avoids spamming the transaction log
with unnecessary writes.

Fixes https://bugs.launchpad.net/juju-core/+bug/1345832
