### PR TITLE
Extract upgrade steps worker

### DIFF
--- a/cmd/jujud/upgrade_test.go
+++ b/cmd/jujud/upgrade_test.go
@@ -229,8 +229,8 @@ func (s *UpgradeSuite) runUpgradeWorker() (
 ) {
 	config := NewFakeConfigSetter(names.NewMachineTag("0"), s.oldVersion.Number)
 	agent := NewFakeUpgradingMachineAgent(config)
-	factory := NewUpgradeWorkerFactory(agent)
-	worker := factory.Worker(nil, []params.MachineJob{params.JobHostUnits})
+	context := NewUpgradeWorkerContext()
+	worker := context.Worker(agent, nil, []params.MachineJob{params.JobHostUnits})
 	s.setInstantRetryStrategy()
 	return worker.Wait(), config, agent
 }


### PR DESCRIPTION
Make the upgrade steps worker code more testable by ripping it out of the machine agent. Take advantage of this to make the upgrade tests significantly simpler and faster.

This is all in preparation for further changes around state agent synchronisation during upgrades.
