### PR TITLE
cmd/jujud: reattempt api.Open if IsCodeNotProvisioned

### DIFF
--- a/cmd/jujud/agent.go
+++ b/cmd/jujud/agent.go
@@ -33,8 +33,16 @@ import (
 	"github.com/juju/juju/worker/upgrader"
 )
 
-var apiOpen = api.Open
-var dataDir = paths.MustSucceed(paths.DataDir(version.Current.Series))
+var (
+	apiOpen = api.Open
+
+	dataDir = paths.MustSucceed(paths.DataDir(version.Current.Series))
+
+	checkProvisionedStrategy = utils.AttemptStrategy{
+		Total: 1 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+)
 
 // requiredError is useful when complaining about missing command-line options.
 func requiredError(name string) error {
@@ -222,10 +230,21 @@ func openAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.
 	if params.IsCodeUnauthorized(err) {
 		// We've perhaps used the wrong password, so
 		// try again with the fallback password.
-		info := *info
+		infoCopy := *info
+		info = &infoCopy
 		info.Password = agentConfig.OldPassword()
 		usedOldPassword = true
-		st, err = apiOpen(&info, api.DialOpts{})
+		st, err = apiOpen(info, api.DialOpts{})
+	}
+	// The provisioner may take some time to record the agent's
+	// machine instance ID, so wait until it does so.
+	if params.IsCodeNotProvisioned(err) {
+		for a := checkProvisionedStrategy.Start(); a.Next(); {
+			st, err = apiOpen(info, api.DialOpts{})
+			if !params.IsCodeNotProvisioned(err) {
+				break
+			}
+		}
 	}
 	if err != nil {
 		if params.IsCodeNotProvisioned(err) {

--- a/cmd/jujud/agent_test.go
+++ b/cmd/jujud/agent_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/agent"
@@ -114,6 +115,10 @@ func (fakeAPIOpenConfig) Jobs() []params.MachineJob {
 
 var _ = gc.Suite(&apiOpenSuite{})
 
+func (s *apiOpenSuite) SetUpTest(c *gc.C) {
+	s.PatchValue(&checkProvisionedStrategy, utils.AttemptStrategy{})
+}
+
 func (s *apiOpenSuite) TestOpenAPIStateReplaceErrors(c *gc.C) {
 	type replaceErrors struct {
 		openErr    error
@@ -142,6 +147,35 @@ func (s *apiOpenSuite) TestOpenAPIStateReplaceErrors(c *gc.C) {
 			c.Check(err, gc.Equals, test.replaceErr)
 		}
 	}
+}
+
+func (s *apiOpenSuite) TestOpenAPIStateWaitsProvisioned(c *gc.C) {
+	s.PatchValue(&checkProvisionedStrategy.Min, 5)
+	var called int
+	s.PatchValue(&apiOpen, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		called++
+		if called == checkProvisionedStrategy.Min-1 {
+			return nil, &params.Error{Code: params.CodeUnauthorized}
+		}
+		return nil, &params.Error{Code: params.CodeNotProvisioned}
+	})
+	_, _, err := openAPIState(fakeAPIOpenConfig{}, nil)
+	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
+	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min-1)
+}
+
+func (s *apiOpenSuite) TestOpenAPIStateWaitsProvisionedGivesUp(c *gc.C) {
+	s.PatchValue(&checkProvisionedStrategy.Min, 5)
+	var called int
+	s.PatchValue(&apiOpen, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		called++
+		return nil, &params.Error{Code: params.CodeNotProvisioned}
+	})
+	_, _, err := openAPIState(fakeAPIOpenConfig{}, nil)
+	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
+	// +1 because we always attempt at least once outside the attempt strategy
+	// (twice if the API server initially returns CodeUnauthorized.)
+	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min+1)
 }
 
 type testPinger func() error


### PR DESCRIPTION
There is a race between the machine agent starting and
the provisioner recording its instance ID in state.
We modify the agent's logic around opening API
connections to retry for up to one minute if it receives
an error satisfying IsCodeNotProvisioned.

Fixes https://bugs.launchpad.net/juju-core/+bug/1345014
