### PR TITLE
Mongo id fields should be specified as _id, not _id_.

### DIFF
--- a/state/user.go
+++ b/state/user.go
@@ -91,7 +91,7 @@ type User struct {
 }
 
 type userDoc struct {
-	Name           string `bson:"_id_"`
+	Name           string `bson:"_id"`
 	DisplayName    string
 	Deactivated    bool // Removing users means they still exist, but are marked deactivated
 	PasswordHash   string


### PR DESCRIPTION
Simple fix - looks like mongo id for the user document was not being specified correctly.
