### PR TITLE
cmd/jujud: fix upgrade worker error handling

### DIFF
--- a/cmd/jujud/agent.go
+++ b/cmd/jujud/agent.go
@@ -188,12 +188,17 @@ func connectionIsFatal(conn pinger) func(err error) bool {
 		if isFatal(err) {
 			return true
 		}
-		if err := conn.Ping(); err != nil {
-			logger.Infof("error pinging %T: %v", conn, err)
-			return true
-		}
-		return false
+		return connectionIsDead(conn)
 	}
+}
+
+// connectionIsDead returns true if the given pinger fails to ping.
+var connectionIsDead = func(conn pinger) bool {
+	if err := conn.Ping(); err != nil {
+		logger.Infof("error pinging %T: %v", conn, err)
+		return true
+	}
+	return false
 }
 
 // isleep waits for the given duration or until it receives a value on


### PR DESCRIPTION
If the connection to state is lost then return an error so that the machine agent will restart. For other errors, don't return the error because we want the machine agent to stay running wait for user intervention.

This change also adds tests for the handling of upgradeWorkerContext's UpgradeComplete channel. This was previously untested.
