### PR TITLE
mongo: reduce min/max oplog size

### DIFF
--- a/mongo/prealloc.go
+++ b/mongo/prealloc.go
@@ -29,8 +29,8 @@ var (
 	// preallocated Mongo data files.
 	zeroes = make([]byte, 64*1024)
 
-	minOplogSizeMB = 1024
-	maxOplogSizeMB = 50 * 1024
+	minOplogSizeMB = 512
+	maxOplogSizeMB = 1024
 
 	availSpace   = fsAvailSpace
 	preallocFile = doPreallocFile
@@ -51,6 +51,10 @@ func preallocOplog(dir string, oplogSizeMB int) error {
 // The size of the oplog is calculated according to the
 // formula used by Mongo:
 //     http://docs.mongodb.org/manual/core/replica-set-oplog/
+//
+// NOTE: we deviate from the specified minimum and maximum
+//       sizes. Mongo suggests a minimum of 1GB and maximum
+//       of 50GB; we set these to 512MB and 1GB respectively.
 func defaultOplogSize(dir string) (int, error) {
 	if hostWordSize == 32 {
 		// "For 32-bit systems, MongoDB allocates about 48 megabytes

--- a/mongo/prealloc_test.go
+++ b/mongo/prealloc_test.go
@@ -39,7 +39,7 @@ func (s *preallocSuite) TestOplogSize(c *gc.C) {
 		hostWordSize: 64,
 		runtimeGOOS:  "windows",
 		availSpace:   99999,
-		expected:     1024,
+		expected:     512,
 	}, {
 		hostWordSize: 32,
 		runtimeGOOS:  "linux",
@@ -49,17 +49,17 @@ func (s *preallocSuite) TestOplogSize(c *gc.C) {
 		hostWordSize: 64,
 		runtimeGOOS:  "linux",
 		availSpace:   1024,
-		expected:     1024,
+		expected:     512,
 	}, {
 		hostWordSize: 64,
 		runtimeGOOS:  "linux",
 		availSpace:   420 * 1024,
-		expected:     21504,
+		expected:     1024,
 	}, {
 		hostWordSize: 64,
 		runtimeGOOS:  "linux",
 		availSpace:   1024 * 1024,
-		expected:     50 * 1024,
+		expected:     1024,
 	}}
 	var availSpace int
 	getAvailSpace := func(dir string) (float64, error) {


### PR DESCRIPTION
Reduce oplog minimum size to 512MB,
and maximum size to 1024MB.

See comments on bug for backstory
and analysis.

Fixes https://bugs.launchpad.net/juju-core/+bug/1344940
