### PR TITLE
Propagate machine jobs from state to StartInstance

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -56,6 +56,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/api"
+	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/apiserver"
 	"github.com/juju/juju/testing"
 )
@@ -150,6 +151,7 @@ type OpStartInstance struct {
 	Networks     []string
 	NetworkInfo  []network.Info
 	Info         *authentication.MongoInfo
+	Jobs         []params.MachineJob
 	APIInfo      *api.Info
 	Secret       string
 }
@@ -879,6 +881,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		Constraints:  args.Constraints,
 		Networks:     args.MachineConfig.Networks,
 		NetworkInfo:  networkInfo,
+		Jobs:         args.MachineConfig.Jobs,
 		Instance:     i,
 		Info:         args.MachineConfig.MongoInfo,
 		APIInfo:      args.MachineConfig.APIInfo,

--- a/state/api/params/internal.go
+++ b/state/api/params/internal.go
@@ -650,6 +650,7 @@ type ProvisioningInfo struct {
 	Series      string
 	Placement   string
 	Networks    []string
+	Jobs        []MachineJob
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.

--- a/state/apiserver/provisioner/provisioner.go
+++ b/state/apiserver/provisioner/provisioner.go
@@ -349,11 +349,16 @@ func getProvisioningInfo(m *state.Machine) (*params.ProvisioningInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	var jobs []params.MachineJob
+	for _, job := range m.Jobs() {
+		jobs = append(jobs, job.ToParams())
+	}
 	return &params.ProvisioningInfo{
 		Constraints: cons,
 		Series:      m.Series(),
 		Placement:   m.Placement(),
 		Networks:    networks,
+		Jobs:        jobs,
 	}, nil
 }
 

--- a/state/apiserver/provisioner/provisioner_test.go
+++ b/state/apiserver/provisioner/provisioner_test.go
@@ -754,12 +754,14 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 			{Result: &params.ProvisioningInfo{
 				Series:   "quantal",
 				Networks: []string{},
+				Jobs:     []params.MachineJob{params.JobHostUnits},
 			}},
 			{Result: &params.ProvisioningInfo{
 				Series:      "quantal",
 				Constraints: template.Constraints,
 				Placement:   template.Placement,
 				Networks:    template.RequestedNetworks,
+				Jobs:        []params.MachineJob{params.JobHostUnits},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -793,6 +795,7 @@ func (s *withoutStateServerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 			{Result: &params.ProvisioningInfo{
 				Series:   "quantal",
 				Networks: []string{},
+				Jobs:     []params.MachineJob{params.JobHostUnits},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 0/lxc/0")},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -546,6 +546,9 @@ func (task *provisionerTask) provisioningInfo(machine *apiprovisioner.Machine) (
 	}
 	nonce := fmt.Sprintf("%s:%s", task.machineTag, uuid.String())
 	machineConfig := environs.NewMachineConfig(machine.Id(), nonce, pInfo.Networks, stateInfo, apiInfo)
+	if len(pInfo.Jobs) > 0 {
+		machineConfig.Jobs = pInfo.Jobs
+	}
 	return &provisioningInfo{
 		Constraints:   pInfo.Constraints,
 		Series:        pInfo.Series,


### PR DESCRIPTION
The provisioner is updated to send the correct set
of machine jobs from state through to the broker's
StartInstance call. This allows us to now expose and
load balance the correct set of ports for state
servers in Azure.

Fixes https://bugs.launchpad.net/juju-core/+bug/1347371
