### PR TITLE
Propagate machine jobs from state to StartInstance

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -55,6 +55,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/api"
+	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/apiserver"
 	"github.com/juju/juju/testing"
 )
@@ -133,6 +134,7 @@ type OpStartInstance struct {
 	Networks     []string
 	NetworkInfo  []network.Info
 	Info         *state.Info
+	Jobs         []params.MachineJob
 	APIInfo      *api.Info
 	Secret       string
 }
@@ -834,6 +836,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		Constraints:  args.Constraints,
 		Networks:     args.MachineConfig.Networks,
 		NetworkInfo:  networkInfo,
+		Jobs:         args.MachineConfig.Jobs,
 		Instance:     i,
 		Info:         args.MachineConfig.StateInfo,
 		APIInfo:      args.MachineConfig.APIInfo,

--- a/state/api/params/internal.go
+++ b/state/api/params/internal.go
@@ -622,6 +622,7 @@ type ProvisioningInfo struct {
 	Series      string
 	Placement   string
 	Networks    []string
+	Jobs        []MachineJob
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.

--- a/state/apiserver/provisioner/provisioner.go
+++ b/state/apiserver/provisioner/provisioner.go
@@ -348,11 +348,16 @@ func getProvisioningInfo(m *state.Machine) (*params.ProvisioningInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	var jobs []params.MachineJob
+	for _, job := range m.Jobs() {
+		jobs = append(jobs, job.ToParams())
+	}
 	return &params.ProvisioningInfo{
 		Constraints: cons,
 		Series:      m.Series(),
 		Placement:   m.Placement(),
 		Networks:    networks,
+		Jobs:        jobs,
 	}, nil
 }
 

--- a/state/apiserver/provisioner/provisioner_test.go
+++ b/state/apiserver/provisioner/provisioner_test.go
@@ -754,12 +754,14 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 			{Result: &params.ProvisioningInfo{
 				Series:   "quantal",
 				Networks: []string{},
+				Jobs:     []params.MachineJob{params.JobHostUnits},
 			}},
 			{Result: &params.ProvisioningInfo{
 				Series:      "quantal",
 				Constraints: template.Constraints,
 				Placement:   template.Placement,
 				Networks:    template.RequestedNetworks,
+				Jobs:        []params.MachineJob{params.JobHostUnits},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -793,6 +795,7 @@ func (s *withoutStateServerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 			{Result: &params.ProvisioningInfo{
 				Series:   "quantal",
 				Networks: []string{},
+				Jobs:     []params.MachineJob{params.JobHostUnits},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 0/lxc/0")},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -544,6 +544,9 @@ func (task *provisionerTask) provisioningInfo(machine *apiprovisioner.Machine) (
 	}
 	nonce := fmt.Sprintf("%s:%s", task.machineTag, uuid.String())
 	machineConfig := environs.NewMachineConfig(machine.Id(), nonce, pInfo.Networks, stateInfo, apiInfo)
+	if len(pInfo.Jobs) > 0 {
+		machineConfig.Jobs = pInfo.Jobs
+	}
 	return &provisioningInfo{
 		Constraints:   pInfo.Constraints,
 		Series:        pInfo.Series,

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -189,6 +189,12 @@ func (s *CommonProvisionerSuite) checkStartInstanceCustom(c *gc.C, m *state.Mach
 				c.Assert(o.Networks, jc.DeepEquals, networks)
 				c.Assert(o.NetworkInfo, jc.DeepEquals, networkInfo)
 
+				var jobs []params.MachineJob
+				for _, job := range m.Jobs() {
+					jobs = append(jobs, job.ToParams())
+				}
+				c.Assert(o.Jobs, jc.SameContents, jobs)
+
 				// All provisioned machines in this test suite have
 				// their hardware characteristics attributes set to
 				// the same values as the constraints due to the dummy
@@ -361,6 +367,18 @@ func (s *CommonProvisionerSuite) addMachineWithRequestedNetworks(networks []stri
 		Constraints:       cons,
 		RequestedNetworks: networks,
 	})
+}
+
+func (s *CommonProvisionerSuite) ensureAvailability(c *gc.C, n int) []*state.Machine {
+	changes, err := s.BackingState.EnsureAvailability(n, s.defaultConstraints, coretesting.FakeDefaultSeries)
+	c.Assert(err, gc.IsNil)
+	added := make([]*state.Machine, len(changes.Added))
+	for i, mid := range changes.Added {
+		m, err := s.BackingState.Machine(mid)
+		c.Assert(err, gc.IsNil)
+		added[i] = m
+	}
+	return added
 }
 
 func (s *ProvisionerSuite) SetUpTest(c *gc.C) {
@@ -993,9 +1011,27 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 	c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
 }
 
+func (s *ProvisionerSuite) TestProvisionerObservesMachineJobs(c *gc.C) {
+	s.PatchValue(&apiserverprovisioner.ErrorRetryWaitDelay, 5*time.Millisecond)
+	broker := &mockBroker{Environ: s.APIConn.Environ, retryCount: make(map[string]int)}
+	task := s.newProvisionerTask(c, false, broker, s.provisioner)
+	defer stop(c, task)
+
+	added := s.ensureAvailability(c, 3)
+	c.Assert(added, gc.HasLen, 2)
+	byId := make(map[string]*state.Machine)
+	for _, m := range added {
+		byId[m.Id()] = m
+	}
+	for _, id := range broker.ids {
+		s.checkStartInstance(c, byId[id])
+	}
+}
+
 type mockBroker struct {
 	environs.Environ
 	retryCount map[string]int
+	ids        []string
 }
 
 func (b *mockBroker) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
@@ -1003,6 +1039,8 @@ func (b *mockBroker) StartInstance(args environs.StartInstanceParams) (instance.
 	// Machines 3 is provisioned after some attempts have been made.
 	// Machine 4 is never provisioned.
 	id := args.MachineConfig.MachineId
+	// record ids so we can call checkStartInstance in the appropriate order.
+	b.ids = append(b.ids, id)
 	retries := b.retryCount[id]
 	if (id != "3" && id != "4") || retries > 2 {
 		return b.Environ.StartInstance(args)


### PR DESCRIPTION
The provisioner is updated to send the correct set
of machine jobs from state through to the broker's
StartInstance call. This allows us to now expose and
load balance the correct set of ports for state
servers in Azure.

Fixes https://bugs.launchpad.net/juju-core/+bug/1347371
