### PR TITLE
Provision new instances with version.Current

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -59,6 +59,7 @@ import (
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/apiserver"
 	"github.com/juju/juju/testing"
+	coretools "github.com/juju/juju/tools"
 )
 
 var logger = loggo.GetLogger("juju.provider.dummy")
@@ -143,17 +144,18 @@ type OpListNetworks struct {
 }
 
 type OpStartInstance struct {
-	Env          string
-	MachineId    string
-	MachineNonce string
-	Instance     instance.Instance
-	Constraints  constraints.Value
-	Networks     []string
-	NetworkInfo  []network.Info
-	Info         *authentication.MongoInfo
-	Jobs         []params.MachineJob
-	APIInfo      *api.Info
-	Secret       string
+	Env           string
+	MachineId     string
+	MachineNonce  string
+	PossibleTools coretools.List
+	Instance      instance.Instance
+	Constraints   constraints.Value
+	Networks      []string
+	NetworkInfo   []network.Info
+	Info          *authentication.MongoInfo
+	Jobs          []params.MachineJob
+	APIInfo       *api.Info
+	Secret        string
 }
 
 type OpStopInstances struct {
@@ -871,17 +873,18 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 	estate.insts[i.id] = i
 	estate.maxId++
 	estate.ops <- OpStartInstance{
-		Env:          e.name,
-		MachineId:    machineId,
-		MachineNonce: args.MachineConfig.MachineNonce,
-		Constraints:  args.Constraints,
-		Networks:     args.MachineConfig.Networks,
-		NetworkInfo:  networkInfo,
-		Jobs:         args.MachineConfig.Jobs,
-		Instance:     i,
-		Info:         args.MachineConfig.MongoInfo,
-		APIInfo:      args.MachineConfig.APIInfo,
-		Secret:       e.ecfg().secret(),
+		Env:           e.name,
+		MachineId:     machineId,
+		MachineNonce:  args.MachineConfig.MachineNonce,
+		PossibleTools: args.Tools,
+		Constraints:   args.Constraints,
+		Networks:      args.MachineConfig.Networks,
+		NetworkInfo:   networkInfo,
+		Instance:      i,
+		Jobs:          args.MachineConfig.Jobs,
+		Info:          args.MachineConfig.MongoInfo,
+		APIInfo:       args.MachineConfig.APIInfo,
+		Secret:        e.ecfg().secret(),
 	}
 	return i, hc, networkInfo, nil
 }

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -156,6 +156,8 @@ func (cs *ContainerSetup) getContainerArtifacts(containerType instance.Container
 	if !ok {
 		return nil, nil, errors.Errorf("expected names.MachineTag, got %T", tag)
 	}
+	// TODO(fwereade): 2014-07-24 bug 1347984
+	// This may give us a subtly incorrect version. See bug for details.
 	tools, err := cs.provisioner.Tools(machineTag)
 	if err != nil {
 		logger.Errorf("cannot get tools from machine for %s container", containerType)

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -25,6 +25,7 @@ import (
 	apiwatcher "github.com/juju/juju/state/api/watcher"
 	"github.com/juju/juju/state/watcher"
 	coretools "github.com/juju/juju/tools"
+	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 )
 
@@ -495,11 +496,7 @@ func (task *provisionerTask) startMachine(machine *apiprovisioner.Machine) error
 
 func (task *provisionerTask) possibleTools(series string, cons constraints.Value) (coretools.List, error) {
 	if env, ok := task.broker.(environs.Environ); ok {
-		agentVersion, ok := env.Config().AgentVersion()
-		if !ok {
-			return nil, fmt.Errorf("no agent version set in environment configuration")
-		}
-		return tools.FindInstanceTools(env, agentVersion, series, cons.Arch)
+		return tools.FindInstanceTools(env, version.Current.Number, series, cons.Arch)
 	}
 	if hasTools, ok := task.broker.(coretools.HasTools); ok {
 		return hasTools.Tools(series), nil


### PR DESCRIPTION
New instances were being provisioned with the agent-version from the
environ config instead of the currently running tools version. This
meant that there was a risk of new instances not running upgrade steps
if a juju upgrade occurred around the same time as the instance was
provisioned.
