### PR TITLE
Avoid the possibility of returning a typed nil.

### DIFF
--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -149,10 +149,11 @@ func (d *diskStore) ReadInfo(envName string) (EnvironInfo, error) {
 			info, err = d.readJENVFile(envName)
 		}
 	}
-	if info != nil {
-		info.environmentDir = d.dir
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return info, errors.Trace(err)
+	info.environmentDir = d.dir
+	return info, nil
 }
 
 func (d *diskStore) readConnectionFile(envName string) (*environInfo, error) {


### PR DESCRIPTION
The test asserts "gc.IsNil", unfortunately this let a typed nil through.

The caller of this was doing "if info != nil", the typed nil is != nil, so it blew up on the second part.

We can't change the test for this until we write jc.IsNil that asserts a nil interface if the result is an interface, rather than just the value part of the interface.
