### PR TITLE
configstore: use O_TRUNC when rewriting jenv file 

### DIFF
--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -287,7 +287,7 @@ func (d *diskStore) readJENVFile(envName string) (*environInfo, error) {
 	}
 	var values EnvironInfoData
 	if err := goyaml.Unmarshal(data, &values); err != nil {
-		return nil, fmt.Errorf("error unmarshalling %q: %v", path, err)
+		return nil, errors.Annotatef(err, "error unmarshalling %q", path)
 	}
 	info.name = envName
 	info.user = values.User


### PR DESCRIPTION
Fixes LP #1348458

Because thumper was determined not to write a temporary file then move it, we have to ensure that iff we rewrite the .jenv file, the contents of the existing file are truncated before writing to prevent future readers of the file seeing corrupt data at the end of the file.
