### PR TITLE
fix lp:1342937 restore fails if apt running

### DIFF
--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -113,6 +113,9 @@ var updateBootstrapMachineTemplate = mustParseTemplate(`
 	tar xzf juju-backup.tgz
 	test -d juju-backup
 
+
+	initctl stop jujud-machine-0
+
 	#The code apt-get throws when lock is taken
 	APTOUTPUT=100 
 	while [ $APTOUTPUT -gt 0 ]
@@ -126,7 +129,7 @@ var updateBootstrapMachineTemplate = mustParseTemplate(`
 		fi
 	done
 	
-	initctl stop jujud-machine-0
+
 
 	initctl stop juju-db
 	rm -r /var/lib/juju


### PR DESCRIPTION
Stop jujud before everything else so no worker will be running when we destroy the basic bootstrap.
Retry APT to make sure it is not failing because some other apt is finishing.
