### PR TITLE
Fixed incorrect timeout in worker test

### DIFF
--- a/worker/environ_test.go
+++ b/worker/environ_test.go
@@ -130,7 +130,7 @@ loop:
 			if strings.Contains(msg, "error creating Environ") {
 				break loop
 			}
-		case <-time.After(coretesting.ShortWait):
+		case <-time.After(coretesting.LongWait):
 			c.Fatalf("timed out waiting to see broken environment")
 		}
 	}


### PR DESCRIPTION
In PR #366 a timeout in a test was unintentionally changed from LongWait to ShortWait. This PR fixes that.

See also: https://github.com/juju/juju/pull/366#discussion_r15334468
