### PR TITLE
state/apiserver/usermanager: removed unused dummy authenticators

### DIFF
--- a/state/apiserver/usermanager/usermanager.go
+++ b/state/apiserver/usermanager/usermanager.go
@@ -70,8 +70,6 @@ type ModifyUser struct {
 type UserManagerAPI struct {
 	state       *state.State
 	authorizer  common.Authorizer
-	getCanWrite common.GetAuthFunc
-	getCanRead  common.GetAuthFunc
 }
 
 var _ UserManager = (*UserManagerAPI)(nil)
@@ -85,17 +83,10 @@ func NewUserManagerAPI(
 		return nil, common.ErrPerm
 	}
 
-	// TODO(mattyw) - replace stub with real canWrite function
-	getCanWrite := common.AuthAlways(true)
-
-	// TODO(waigani) - replace stub with real canRead function
-	getCanRead := common.AuthAlways(true)
 	return &UserManagerAPI{
 			state:       st,
 			authorizer:  authorizer,
-			getCanWrite: getCanWrite,
-			getCanRead:  getCanRead},
-		nil
+		}, nil
 }
 
 // AddUser adds a user.
@@ -106,20 +97,11 @@ func (api *UserManagerAPI) AddUser(args ModifyUsers) (params.ErrorResults, error
 	if len(args.Changes) == 0 {
 		return result, nil
 	}
-	canWrite, err := api.getCanWrite()
-	if err != nil {
-		result.Results[0].Error = common.ServerError(err)
-		return result, err
-	}
 	user := api.getLoggedInUser()
 	if user == nil {
 		return result, fmt.Errorf("api connection is not through a user")
 	}
 	for i, arg := range args.Changes {
-		if !canWrite(arg.Tag) {
-			result.Results[0].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
 		username := arg.Username
 		if username == "" {
 			username = arg.Tag
@@ -142,15 +124,7 @@ func (api *UserManagerAPI) RemoveUser(args params.Entities) (params.ErrorResults
 	if len(args.Entities) == 0 {
 		return result, nil
 	}
-	canWrite, err := api.getCanWrite()
-	if err != nil {
-		return result, err
-	}
 	for i, arg := range args.Entities {
-		if !canWrite(arg.Tag) {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
 		user, err := api.state.User(arg.Tag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(common.ErrPerm)
@@ -171,15 +145,7 @@ func (api *UserManagerAPI) UserInfo(args params.Entities) (UserInfoResults, erro
 		Results: make([]UserInfoResult, len(args.Entities)),
 	}
 
-	canRead, err := api.getCanRead()
-	if err != nil {
-		return results, err
-	}
 	for i, userArg := range args.Entities {
-		if !canRead(userArg.Tag) {
-			results.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
 		tag, err := names.ParseUserTag(userArg.Tag)
 		if err != nil {
 			results.Results[0].Error = common.ServerError(err)
@@ -218,16 +184,7 @@ func (api *UserManagerAPI) SetPassword(args ModifyUsers) (params.ErrorResults, e
 	if len(args.Changes) == 0 {
 		return result, nil
 	}
-	canWrite, err := api.getCanWrite()
-	if err != nil {
-		return result, err
-	}
 	for i, arg := range args.Changes {
-		if !canWrite(arg.Tag) {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-
 		username := arg.Username
 		if username == "" {
 			username = arg.Tag


### PR DESCRIPTION
This PR removes the unused canRead/canWrite authenticators from this package. The justification is as follows.
- The authentators were hard coded to always authenticate whatever value was passed, _even if it was not valid_
- If the authenticators did validate their data they would find that arg.Tag passed to them was commonly empty, which is bad for two reasons
1. "" is not a valid API tag
2. "" is the synonym for "admin"
- Lastly, the tests continue to pass without them ...
