### PR TITLE
Change backup to be more env storage-centric.

### DIFF
--- a/state/backup/backup.go
+++ b/state/backup/backup.go
@@ -4,241 +4,145 @@
 package backup
 
 import (
-	"archive/tar"
-	"compress/gzip"
-	"crypto/sha1"
-	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"os/exec"
-	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/juju/loggo"
+
+	"github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/version"
 )
 
-var logger = loggo.GetLogger("juju.backup")
+var (
+	logger = loggo.GetLogger("juju.state.backup")
+	sep    = string(os.PathSeparator)
+)
 
-// tarFiles creates a tar archive at targetPath holding the files listed
-// in fileList. If compress is true, the archive will also be gzip
-// compressed.
-func tarFiles(fileList []string, targetPath, strip string, compress bool) (shaSum string, err error) {
-	shahash := sha1.New()
-	if err := tarAndHashFiles(fileList, targetPath, strip, compress, shahash); err != nil {
-		return "", err
+// CreateBackup creates a new backup archive.  If store is true, the
+// backup is stored to environment storage.
+// The backup contains a dump folder with the output of mongodump command
+// and a root.tar file which contains all the system files obtained from
+// the output of getFilesToBackup.
+func CreateBackup(
+	dbinfo *DBConnInfo, name string, storage storage.StorageWriter,
+) (*BackupInfo, error) {
+	logger.Infof("backing up juju state")
+	info := BackupInfo{Name: name}
+
+	archive, err := create(&info, dbinfo)
+	if err != nil {
+		return nil, err
 	}
-	// we use a base64 encoded sha1 hash, because this is the hash
-	// used by RFC 3230 Digest headers in http responses
-	encodedHash := base64.StdEncoding.EncodeToString(shahash.Sum(nil))
-	return encodedHash, nil
+	defer archive.Close()
+	logger.Infof("created: %q (SHA-1: %s)", info.Name, info.CheckSum)
+
+	// Store the backup.
+	err = store(&info, storage, archive)
+
+	return &info, err
 }
 
-func tarAndHashFiles(fileList []string, targetPath, strip string, compress bool, hashw io.Writer) (err error) {
-	checkClose := func(w io.Closer) {
-		if closeErr := w.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("error closing backup file: %v", closeErr)
+func create(info *BackupInfo, dbinfo *DBConnInfo) (_ io.ReadCloser, err error) {
+	newbackup := newBackup{}
+	cleanup := func() {
+		nbErr := newbackup.cleanup()
+		if nbErr != nil && err == nil {
+			err = nbErr
 		}
 	}
-	f, err := os.Create(targetPath)
+
+	// Prepare the backup.
+	err = newbackup.prepare()
 	if err != nil {
-		return fmt.Errorf("cannot create backup file %q", targetPath)
+		return nil, err
 	}
-	defer checkClose(f)
+	defer cleanup()
 
-	w := io.MultiWriter(f, hashw)
-
-	if compress {
-		gzw := gzip.NewWriter(w)
-		defer checkClose(gzw)
-		w = gzw
+	// Run the backup.
+	sha1sum, err := newbackup.run(dbinfo)
+	if err != nil {
+		return nil, err
 	}
 
-	tarw := tar.NewWriter(w)
-	defer checkClose(tarw)
-	for _, ent := range fileList {
-		if err := writeContents(ent, strip, tarw); err != nil {
-			return fmt.Errorf("backup failed: %v", err)
-		}
+	// Set the backup fields.
+	if info.Name == "" {
+		info.Name = filepath.Base(newbackup.filename)
+	}
+	timestamp, tsErr := ExtractTimestamp(newbackup.filename)
+	if tsErr != nil {
+		timestamp = time.Now().UTC()
+	}
+	info.Timestamp = timestamp
+	info.CheckSum = sha1sum
+	info.Version = version.Current.Number
+
+	// Open the archive (before we delete it).
+	archive, err := os.Open(newbackup.filename)
+	if err != nil {
+		return nil, fmt.Errorf("error opening archive: %v", err)
+	}
+	finfo, err := archive.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("error getting file info: %v", err)
+	}
+	info.Size = finfo.Size()
+
+	return archive, err
+}
+
+func store(info *BackupInfo, storage storage.StorageWriter, archive io.Reader) error {
+	logger.Debugf("storing %q", info.Name)
+
+	err := storage.Put(info.Name, archive, info.Size)
+	if err != nil {
+		return fmt.Errorf("error storing archive: %v", err)
+	}
+
+	logger.Infof("stored: %q (SHA-1: %s)", info.Name, info.CheckSum)
+	return nil
+}
+
+//---------------------------
+// legacy API
+
+type fileStore struct {
+	dirname string
+}
+
+func (f *fileStore) Put(name string, r io.Reader, len int64) error {
+	stored, err := os.Create(filepath.Join(f.dirname, name))
+	if err != nil {
+		return err
+	}
+	defer stored.Close()
+	if _, err = io.Copy(stored, r); err != nil {
+		return err
 	}
 	return nil
 }
 
-// writeContents creates an entry for the given file
-// or directory in the given tar archive.
-func writeContents(fileName, strip string, tarw *tar.Writer) error {
-	f, err := os.Open(fileName)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	fInfo, err := f.Stat()
-	if err != nil {
-		return err
-	}
-	h, err := tar.FileInfoHeader(fInfo, "")
-	if err != nil {
-		return fmt.Errorf("cannot create tar header for %q: %v", fileName, err)
-	}
-	h.Name = filepath.ToSlash(strings.TrimPrefix(fileName, strip))
-	if err := tarw.WriteHeader(h); err != nil {
-		return fmt.Errorf("cannot write header for %q: %v", fileName, err)
-	}
-	if !fInfo.IsDir() {
-		if _, err := io.Copy(tarw, f); err != nil {
-			return fmt.Errorf("failed to write %q: %v", fileName, err)
-		}
-		return nil
-	}
-	if !strings.HasSuffix(fileName, string(os.PathSeparator)) {
-		fileName = fileName + string(os.PathSeparator)
-	}
-
-	for {
-		names, err := f.Readdirnames(100)
-		if len(names) == 0 && err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("error reading directory %q: %v", fileName, err)
-		}
-		for _, name := range names {
-			if err := writeContents(filepath.Join(fileName, name), strip, tarw); err != nil {
-				return err
-			}
-		}
-	}
-
+func (f *fileStore) Remove(name string) error {
+	return nil
 }
 
-var getFilesToBackup = _getFilesToBackup
-
-func _getFilesToBackup() ([]string, error) {
-	const dataDir string = "/var/lib/juju"
-	initMachineConfs, err := filepath.Glob("/etc/init/jujud-machine-*.conf")
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch machine upstart files: %v", err)
-	}
-	agentConfs, err := filepath.Glob(filepath.Join(dataDir, "agents", "machine-*"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch agent configuration files: %v", err)
-	}
-	jujuLogConfs, err := filepath.Glob("/etc/rsyslog.d/*juju.conf")
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch juju log conf files: %v", err)
-	}
-
-	backupFiles := []string{
-		"/etc/init/juju-db.conf",
-		filepath.Join(dataDir, "tools"),
-		filepath.Join(dataDir, "server.pem"),
-		filepath.Join(dataDir, "system-identity"),
-		filepath.Join(dataDir, "nonce.txt"),
-		filepath.Join(dataDir, "shared-secret"),
-		"/home/ubuntu/.ssh/authorized_keys",
-		"/var/log/juju/all-machines.log",
-		"/var/log/juju/machine-0.log",
-	}
-	backupFiles = append(backupFiles, initMachineConfs...)
-	backupFiles = append(backupFiles, agentConfs...)
-	backupFiles = append(backupFiles, jujuLogConfs...)
-	return backupFiles, nil
+func (f *fileStore) RemoveAll() error {
+	return nil
 }
 
-var runCommand = _runCommand
-
-func _runCommand(cmd string, args ...string) error {
-	command := exec.Command(cmd, args...)
-	out, err := command.CombinedOutput()
-	if err == nil {
-		return nil
+// XXX Remove!
+func Backup(pw, tag, outputFolder, host string) (string, string, error) {
+	dbinfo := DBConnInfo{
+		Hostname: host,
+		Username: tag,
+		Password: pw,
 	}
-	if _, ok := err.(*exec.ExitError); ok && len(out) > 0 {
-		return fmt.Errorf("error executing %q: %s", cmd, strings.Replace(string(out), "\n", "; ", -1))
-	}
-	return fmt.Errorf("cannot execute %q: %v", cmd, err)
-}
-
-var getMongodumpPath = _getMongodumpPath
-
-func _getMongodumpPath() (string, error) {
-	const mongoDumpPath string = "/usr/lib/juju/bin/mongodump"
-
-	if _, err := os.Stat(mongoDumpPath); err == nil {
-		return mongoDumpPath, nil
-	}
-
-	path, err := exec.LookPath("mongodump")
+	stor := fileStore{outputFolder}
+	backup, err := CreateBackup(&dbinfo, "", &stor)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return path, nil
-}
-
-// Backup creates a tar.gz file named juju-backup_<date YYYYMMDDHHMMSS>.tar.gz
-// in the specified outputFolder.
-// The backup contains a dump folder with the output of mongodump command
-// and a root.tar file which contains all the system files obtained from
-// the output of getFilesToBackup
-func Backup(password string, username string, outputFolder string, addr string) (string, string, error) {
-	// YYYYMMDDHHMMSS
-	formattedDate := time.Now().Format("20060102150405")
-
-	bkpFile := fmt.Sprintf("juju-backup_%s.tar.gz", formattedDate)
-
-	mongodumpPath, err := getMongodumpPath()
-	if err != nil {
-		return "", "", fmt.Errorf("mongodump not available: %v", err)
-	}
-
-	tempDir, err := ioutil.TempDir("", "jujuBackup")
-	defer os.RemoveAll(tempDir)
-	bkpDir := filepath.Join(tempDir, "juju-backup")
-	dumpDir := filepath.Join(bkpDir, "dump")
-	err = os.MkdirAll(dumpDir, os.FileMode(0755))
-	if err != nil {
-		return "", "", fmt.Errorf("cannot create backup temporary directory: %v", err)
-	}
-
-	err = runCommand(
-		mongodumpPath,
-		"--oplog",
-		"--ssl",
-		"--host", addr,
-		"--username", username,
-		"--password", password,
-		"--out", dumpDir)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to dump database: %v", err)
-	}
-
-	tarFile := filepath.Join(bkpDir, "root.tar")
-	backupFiles, err := getFilesToBackup()
-	if err != nil {
-		return "", "", fmt.Errorf("cannot determine files to backup: %v", err)
-	}
-	_, err = tarFiles(backupFiles, tarFile, string(os.PathSeparator), false)
-	if err != nil {
-		return "", "", fmt.Errorf("cannot backup configuration files: %v", err)
-	}
-
-	shaSum, err := tarFiles([]string{bkpDir},
-		filepath.Join(outputFolder, bkpFile),
-		fmt.Sprintf("%s%s", tempDir, string(os.PathSeparator)),
-		true)
-	if err != nil {
-		return "", "", fmt.Errorf("cannot tar configuration files: %v", err)
-	}
-	return bkpFile, shaSum, nil
-}
-
-// StorageName returns the path in environment storage where a backup
-// should be stored.
-func StorageName(filename string) string {
-	// Use of path.Join instead of filepath.Join is intentional - this
-	// is an environment storage path not a filesystem path.
-	return path.Join("/backups", filepath.Base(filename))
+	return backup.Name, backup.CheckSum, nil
 }

--- a/state/backup/backup_test.go
+++ b/state/backup/backup_test.go
@@ -1,192 +1,71 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package backup
+package backup_test
 
 import (
-	"archive/tar"
-	"compress/gzip"
-	"crypto/sha1"
-	"encoding/base64"
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"path"
-	"strings"
-	stdtesting "testing"
+	"path/filepath"
 
 	gc "launchpad.net/gocheck"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/state/backup"
 )
 
-func Test(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+type fileStore struct {
+	dirname string
 }
 
-var _ = gc.Suite(&BackupSuite{})
-
-type BackupSuite struct {
-	testing.BaseSuite
-	cwd       string
-	testFiles []string
-}
-
-func (b *BackupSuite) SetUpTest(c *gc.C) {
-	b.cwd = c.MkDir()
-	b.BaseSuite.SetUpTest(c)
-}
-
-func (b *BackupSuite) createTestFiles(c *gc.C) {
-	tarDirE := path.Join(b.cwd, "TarDirectoryEmpty")
-	err := os.Mkdir(tarDirE, os.FileMode(0755))
-	c.Check(err, gc.IsNil)
-
-	tarDirP := path.Join(b.cwd, "TarDirectoryPopulated")
-	err = os.Mkdir(tarDirP, os.FileMode(0755))
-	c.Check(err, gc.IsNil)
-
-	tarSubFile1 := path.Join(tarDirP, "TarSubFile1")
-	tarSubFile1Handle, err := os.Create(tarSubFile1)
-	c.Check(err, gc.IsNil)
-	tarSubFile1Handle.WriteString("TarSubFile1")
-	tarSubFile1Handle.Close()
-
-	tarSubDir := path.Join(tarDirP, "TarDirectoryPopulatedSubDirectory")
-	err = os.Mkdir(tarSubDir, os.FileMode(0755))
-	c.Check(err, gc.IsNil)
-
-	tarFile1 := path.Join(b.cwd, "TarFile1")
-	tarFile1Handle, err := os.Create(tarFile1)
-	c.Check(err, gc.IsNil)
-	tarFile1Handle.WriteString("TarFile1")
-	tarFile1Handle.Close()
-
-	tarFile2 := path.Join(b.cwd, "TarFile2")
-	tarFile2Handle, err := os.Create(tarFile2)
-	c.Check(err, gc.IsNil)
-	tarFile2Handle.WriteString("TarFile2")
-	tarFile2Handle.Close()
-	b.testFiles = []string{tarDirE, tarDirP, tarFile1, tarFile2}
-
-}
-
-func (b *BackupSuite) removeTestFiles(c *gc.C) {
-	for _, removable := range b.testFiles {
-		err := os.RemoveAll(removable)
-		c.Assert(err, gc.IsNil)
+func (f *fileStore) Put(name string, r io.Reader, len int64) error {
+	stored, err := os.Create(filepath.Join(f.dirname, name))
+	if err != nil {
+		return err
 	}
-}
-
-type expectedTarContents struct {
-	Name string
-	Body string
-}
-
-var testExpectedTarContents = []expectedTarContents{
-	{"TarDirectoryEmpty", ""},
-	{"TarDirectoryPopulated", ""},
-	{"TarDirectoryPopulated/TarSubFile1", "TarSubFile1"},
-	{"TarDirectoryPopulated/TarDirectoryPopulatedSubDirectory", ""},
-	{"TarFile1", "TarFile1"},
-	{"TarFile2", "TarFile2"},
-}
-
-// Assert thar contents checks that the tar[.gz] file provided contains the
-// Expected files
-// expectedContents: is a slice of the filenames with relative paths that are
-// expected to be on the tar file
-// tarFile: is the path of the file to be checked
-func (b *BackupSuite) assertTarContents(c *gc.C, expectedContents []expectedTarContents,
-	tarFile string,
-	compressed bool) {
-	f, err := os.Open(tarFile)
-	c.Assert(err, gc.IsNil)
-	defer f.Close()
-	var r io.Reader = f
-	if compressed {
-		r, err = gzip.NewReader(r)
-		c.Assert(err, gc.IsNil)
+	defer stored.Close()
+	if _, err = io.Copy(stored, r); err != nil {
+		return err
 	}
-
-	tr := tar.NewReader(r)
-
-	tarContents := make(map[string]string)
-	// Iterate through the files in the archive.
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			// end of tar archive
-			break
-		}
-		c.Assert(err, gc.IsNil)
-		buf, err := ioutil.ReadAll(tr)
-		c.Assert(err, gc.IsNil)
-		tarContents[hdr.Name] = string(buf)
-	}
-	for _, expectedContent := range expectedContents {
-		fullExpectedContent := strings.TrimPrefix(expectedContent.Name, string(os.PathSeparator))
-		body, ok := tarContents[fullExpectedContent]
-		c.Log(tarContents)
-		c.Log(expectedContents)
-		c.Log(fmt.Sprintf("checking for presence of %q on tar file", fullExpectedContent))
-		c.Assert(ok, gc.Equals, true)
-		if expectedContent.Body != "" {
-			c.Log("Also checking the file contents")
-			c.Assert(body, gc.Equals, expectedContent.Body)
-		}
-	}
-
+	return nil
 }
 
-func shaSumFile(c *gc.C, fileToSum string) string {
-	f, err := os.Open(fileToSum)
-	c.Assert(err, gc.IsNil)
-	defer f.Close()
-	shahash := sha1.New()
-	_, err = io.Copy(shahash, f)
-	c.Assert(err, gc.IsNil)
-	return base64.StdEncoding.EncodeToString(shahash.Sum(nil))
+func (f *fileStore) Remove(name string) error {
+	return nil
 }
 
-func (b *BackupSuite) TestTarFilesUncompressed(c *gc.C) {
-	b.createTestFiles(c)
-	outputTar := path.Join(b.cwd, "output_tar_file.tar")
-	trimPath := fmt.Sprintf("%s/", b.cwd)
-	shaSum, err := tarFiles(b.testFiles, outputTar, trimPath, false)
-	c.Check(err, gc.IsNil)
-	fileShaSum := shaSumFile(c, outputTar)
-	c.Assert(shaSum, gc.Equals, fileShaSum)
-	b.removeTestFiles(c)
-	b.assertTarContents(c, testExpectedTarContents, outputTar, false)
+func (f *fileStore) RemoveAll() error {
+	return nil
 }
 
-func (b *BackupSuite) TestTarFilesCompressed(c *gc.C) {
-	b.createTestFiles(c)
-	outputTarGz := path.Join(b.cwd, "output_tar_file.tgz")
-	trimPath := fmt.Sprintf("%s/", b.cwd)
-	shaSum, err := tarFiles(b.testFiles, outputTarGz, trimPath, true)
-	c.Check(err, gc.IsNil)
-
-	fileShaSum := shaSumFile(c, outputTarGz)
-	c.Assert(shaSum, gc.Equals, fileShaSum)
-
-	b.assertTarContents(c, testExpectedTarContents, outputTarGz, true)
-}
+//---------------------------
+// tests
 
 func (b *BackupSuite) TestBackup(c *gc.C) {
 	b.createTestFiles(c)
 	ranCommand := false
-	getMongodumpPath = func() (string, error) { return "bogusmongodump", nil }
-	getFilesToBackup = func() ([]string, error) { return b.testFiles, nil }
-	runCommand = func(command string, args ...string) error {
+
+	b.PatchValue(backup.GetMongodumpPath, func() (string, error) {
+		return "bogusmongodump", nil
+	})
+	b.PatchValue(backup.GetFilesToBackup, func() ([]string, error) {
+		return b.testFiles, nil
+	})
+	b.PatchValue(backup.DoBackup, func(command string, args ...string) error {
 		ranCommand = true
 		return nil
+	})
+
+	dbinfo := backup.DBConnInfo{
+		Hostname: "localhost:8080",
+		Username: "bogus-user",
+		Password: "boguspassword",
 	}
-	bkpFile, shaSum, err := Backup("boguspassword", "bogus-user", b.cwd, "localhost:8080")
-	c.Check(err, gc.IsNil)
-	c.Assert(ranCommand, gc.Equals, true)
+	stor := fileStore{b.cwd}
+	backup, err := backup.CreateBackup(&dbinfo, "", &stor)
+	c.Assert(err, gc.IsNil)
+	c.Check(ranCommand, gc.Equals, true)
+
+	bkpFile, shaSum := backup.Name, backup.CheckSum
 
 	// It is important that the filename uses non-special characters
 	// only because it is returned in a header (unencoded) by the
@@ -194,19 +73,14 @@ func (b *BackupSuite) TestBackup(c *gc.C) {
 	// client side filename conventions.
 	c.Check(bkpFile, gc.Matches, `^[a-z0-9_.-]+$`)
 
-	fileShaSum := shaSumFile(c, path.Join(b.cwd, bkpFile))
-	c.Assert(shaSum, gc.Equals, fileShaSum)
+	filename := filepath.Join(b.cwd, bkpFile)
+	fileShaSum := shaSumFile(c, filename)
+	c.Check(shaSum, gc.Equals, fileShaSum)
 
 	bkpExpectedContents := []expectedTarContents{
 		{"juju-backup", ""},
 		{"juju-backup/dump", ""},
 		{"juju-backup/root.tar", ""},
 	}
-	b.assertTarContents(c, bkpExpectedContents, path.Join(b.cwd, bkpFile), true)
-}
-
-func (b *BackupSuite) TestStorageName(c *gc.C) {
-	c.Assert(StorageName("foo"), gc.Equals, "/backups/foo")
-	c.Assert(StorageName("/foo/bar"), gc.Equals, "/backups/bar")
-	c.Assert(StorageName("foo/bar"), gc.Equals, "/backups/bar")
+	b.checkTarContents(c, bkpExpectedContents, filename, true)
 }

--- a/state/backup/common_test.go
+++ b/state/backup/common_test.go
@@ -1,0 +1,146 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup_test
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/testing"
+)
+
+type expectedTarContents struct {
+	Name string
+	Body string
+}
+
+func shaSumFile(c *gc.C, fileToSum string) string {
+	var f io.ReadCloser
+	var err error
+
+	f, err = os.Open(fileToSum)
+	c.Assert(err, gc.IsNil)
+	defer f.Close()
+
+	shahash := sha1.New()
+	_, err = io.Copy(shahash, f)
+	c.Assert(err, gc.IsNil)
+	return base64.StdEncoding.EncodeToString(shahash.Sum(nil))
+}
+
+//---------------------------
+// the test suite
+
+var _ = gc.Suite(&BackupSuite{})
+
+type BackupSuite struct {
+	testing.BaseSuite
+	cwd       string
+	testFiles []string
+}
+
+func (b *BackupSuite) SetUpTest(c *gc.C) {
+	b.cwd = c.MkDir()
+	b.BaseSuite.SetUpTest(c)
+}
+
+func (b *BackupSuite) createTestFiles(c *gc.C) {
+	tarDirE := path.Join(b.cwd, "TarDirectoryEmpty")
+	err := os.Mkdir(tarDirE, os.FileMode(0755))
+	c.Check(err, gc.IsNil)
+
+	tarDirP := path.Join(b.cwd, "TarDirectoryPopulated")
+	err = os.Mkdir(tarDirP, os.FileMode(0755))
+	c.Check(err, gc.IsNil)
+
+	tarSubFile1 := path.Join(tarDirP, "TarSubFile1")
+	tarSubFile1Handle, err := os.Create(tarSubFile1)
+	c.Check(err, gc.IsNil)
+	tarSubFile1Handle.WriteString("TarSubFile1")
+	tarSubFile1Handle.Close()
+
+	tarSubDir := path.Join(tarDirP, "TarDirectoryPopulatedSubDirectory")
+	err = os.Mkdir(tarSubDir, os.FileMode(0755))
+	c.Check(err, gc.IsNil)
+
+	tarFile1 := path.Join(b.cwd, "TarFile1")
+	tarFile1Handle, err := os.Create(tarFile1)
+	c.Check(err, gc.IsNil)
+	tarFile1Handle.WriteString("TarFile1")
+	tarFile1Handle.Close()
+
+	tarFile2 := path.Join(b.cwd, "TarFile2")
+	tarFile2Handle, err := os.Create(tarFile2)
+	c.Check(err, gc.IsNil)
+	tarFile2Handle.WriteString("TarFile2")
+	tarFile2Handle.Close()
+	b.testFiles = []string{tarDirE, tarDirP, tarFile1, tarFile2}
+
+}
+
+func (b *BackupSuite) removeTestFiles(c *gc.C) {
+	for _, removable := range b.testFiles {
+		err := os.RemoveAll(removable)
+		c.Assert(err, gc.IsNil)
+	}
+}
+
+// Assert thar contents checks that the tar[.gz] file provided contains the
+// Expected files
+// expectedContents: is a slice of the filenames with relative paths that are
+// expected to be on the tar file
+// tarFile: is the path of the file to be checked
+func (b *BackupSuite) checkTarContents(
+	c *gc.C, expectedContents []expectedTarContents, tarFile string, compressed bool,
+) bool {
+	f, err := os.Open(tarFile)
+	c.Assert(err, gc.IsNil)
+	defer f.Close()
+	var r io.Reader = f
+	if compressed {
+		r, err = gzip.NewReader(r)
+		c.Assert(err, gc.IsNil)
+	}
+
+	tr := tar.NewReader(r)
+
+	tarContents := make(map[string]string)
+	// Iterate through the files in the archive.
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		c.Assert(err, gc.IsNil)
+		buf, err := ioutil.ReadAll(tr)
+		c.Assert(err, gc.IsNil)
+		tarContents[hdr.Name] = string(buf)
+		c.Log(fmt.Sprintf("archived: %q -> %s", hdr.Name, buf))
+	}
+	c.Log("checking...")
+
+	res := true
+	for _, expectedContent := range expectedContents {
+		fullExpectedContent := strings.TrimPrefix(expectedContent.Name, string(os.PathSeparator))
+		c.Log(fmt.Sprintf("checking for presence of %q on tar file", fullExpectedContent))
+		body, found := tarContents[fullExpectedContent]
+		res = c.Check(found, gc.Equals, true) && res
+		if expectedContent.Body != "" {
+			c.Log("Also checking the file contents")
+			res = c.Check(body, gc.Equals, expectedContent.Body) && res
+		}
+	}
+	return res
+}

--- a/state/backup/export_test.go
+++ b/state/backup/export_test.go
@@ -1,0 +1,12 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup
+
+var (
+	GetMongodumpPath = &getMongodumpPath
+	GetFilesToBackup = &getFilesToBackup
+	DoBackup         = &runCommand
+
+	DefaultFilename = defaultFilename
+)

--- a/state/backup/files.go
+++ b/state/backup/files.go
@@ -1,0 +1,73 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/juju/utils/hash"
+)
+
+const (
+	TimestampFormat  = "%04d%02d%02d-%02d%02d%02d" // YYMMDD-hhmmss
+	FilenameTemplate = "jujubackup-%s.tar.gz"      // takes a timestamp
+)
+
+func defaultFilename(now *time.Time) string {
+	if now == nil {
+		_now := time.Now().UTC()
+		now = &_now
+	}
+	Y, M, D := now.Date()
+	h, m, s := now.Clock()
+	formattedDate := fmt.Sprintf(TimestampFormat, Y, M, D, h, m, s)
+	return fmt.Sprintf(FilenameTemplate, formattedDate)
+}
+
+// ExtractTimestamp returns the timestamp embedded in the name.
+func ExtractTimestamp(name string) (time.Time, error) {
+	var timestamp time.Time
+	var Y, M, D, h, m, s int
+	template := fmt.Sprintf(FilenameTemplate, TimestampFormat)
+	_, err := fmt.Sscanf(name, template, &Y, &M, &D, &h, &m, &s)
+	if err != nil {
+		return timestamp, fmt.Errorf("error extracting timestamp: %v", err)
+	}
+	timestamp = time.Date(Y, time.Month(M), D, h, m, s, 0, time.UTC)
+	return timestamp, nil
+}
+
+// CreateEmptyFile returns a new file (and its filename).  The file is
+// created fresh and is intended as the target for writing a new backup
+// archive.  If excl is true, a file cannot exist at the filename already.
+//
+// If the provided filename is an empty string, a default filename is
+// generated using the current UTC timestamp.  Likewise if the filename
+// ends with the path separator (e.g. "/"), the default filename is
+// generated and appended to the provided one.
+func CreateEmptyFile(filename string, mode os.FileMode, excl bool) (*os.File, string, error) {
+	if filename == "" {
+		filename = defaultFilename(nil)
+	} else if strings.HasSuffix(filename, string(os.PathSeparator)) {
+		filename += defaultFilename(nil)
+	}
+
+	var file *os.File
+	var err error
+	if excl {
+		flags := os.O_RDWR | os.O_CREATE | os.O_EXCL
+		file, err = os.OpenFile(filename, flags, mode)
+	} else {
+		file, err = os.Create(filename)
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("could not create backup file: %v", err)
+	}
+	logger.Infof("created: %s", filename)
+	return file, filename, nil
+}

--- a/state/backup/files_test.go
+++ b/state/backup/files_test.go
@@ -1,0 +1,124 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/state/backup"
+	"github.com/juju/juju/testing"
+)
+
+//---------------------------
+// defaultFileName()
+
+func (b *BackupSuite) TestDefaultFilename(c *gc.C) {
+	filename := backup.DefaultFilename(nil)
+
+	// This is a sanity check that no one accidentally
+	// (or accidentally maliciously) breaks the default filename format.
+	c.Check(filename, gc.Matches, `jujubackup-\d{8}-\d{6}\..*`)
+	// The most crucial part is that the suffix is .tar.gz.
+	c.Check(filename, gc.Matches, `.*\.tar\.gz$`)
+}
+
+func (b *BackupSuite) TestDefaultFilenameDateFormat(c *gc.C) {
+	filename := backup.DefaultFilename(nil)
+
+	timestamp, err := backup.ExtractTimestamp(filename)
+	c.Assert(err, gc.IsNil)
+
+	elapsed := int(time.Since(timestamp)) / int(time.Second)
+	c.Check(elapsed < 10, gc.Equals, true)
+}
+
+func (b *BackupSuite) TestDefaultFilenameUnique(c *gc.C) {
+	filename1 := backup.DefaultFilename(nil)
+	time.Sleep(1 * time.Second)
+	filename2 := backup.DefaultFilename(nil)
+
+	c.Check(filename1, gc.Not(gc.Equals), filename2)
+}
+
+//---------------------------
+// CreateEmptyFile()
+
+func (b *BackupSuite) TestCreateEmptyFileFilenameExplicit(c *gc.C) {
+	requested := filepath.Join(c.MkDir(), "backup.tar.gz")
+	_, filename, err := backup.CreateEmptyFile(requested, 0666, false)
+	c.Check(err, gc.IsNil)
+
+	c.Check(filename, gc.Equals, requested)
+}
+
+func (b *BackupSuite) TestCreateEmptyFileFilenameDefault(c *gc.C) {
+	file, filename, err := backup.CreateEmptyFile("", 0666, false)
+	defer os.Remove(filename)
+	c.Check(err, gc.IsNil)
+	c.Check(file, gc.NotNil)
+	c.Check(filename, gc.Matches, `jujubackup-\d{8}-\d{6}\.tar\.gz`)
+}
+
+func (b *BackupSuite) TestCreateEmptyFileFilenameDirDefault(c *gc.C) {
+	file, filename, err := backup.CreateEmptyFile("/tmp/", 0666, false)
+	defer os.Remove(filename)
+	c.Check(err, gc.IsNil)
+	c.Check(file, gc.NotNil)
+	c.Check(filename, gc.Matches, `/tmp/jujubackup-\d{8}-\d{6}\.tar\.gz`)
+}
+
+func (b *BackupSuite) TestCreateEmptyFile(c *gc.C) {
+	requested := filepath.Join(c.MkDir(), "backup.tar.gz")
+	file, filename, err := backup.CreateEmptyFile(requested, 0666, false)
+	c.Check(err, gc.IsNil)
+	err = file.Close()
+	c.Assert(err, gc.IsNil)
+
+	file, err = os.Open(filename)
+	c.Assert(err, gc.IsNil)
+
+	buffer := make([]byte, 10)
+	size, err := file.Read(buffer)
+	c.Check(err, gc.Equals, io.EOF)
+	c.Check(size, gc.Equals, 0)
+}
+
+func (b *BackupSuite) TestCreateEmptyFileReallyEmpty(c *gc.C) {
+	requested := filepath.Join(c.MkDir(), "backup.tar.gz")
+	file, _, err := backup.CreateEmptyFile(requested, 0666, false)
+	c.Check(err, gc.IsNil)
+
+	buffer := make([]byte, 10)
+	size, err := file.Read(buffer)
+	c.Check(err, gc.Equals, io.EOF)
+	c.Check(size, gc.Equals, 0)
+}
+
+func (b *BackupSuite) TestCreateEmptyFileAlreadyExists(c *gc.C) {
+	requested := filepath.Join(c.MkDir(), "backup.tar.gz")
+	file, err := os.Create(requested)
+	c.Assert(err, gc.IsNil)
+	err = file.Close()
+	c.Assert(err, gc.IsNil)
+
+	_, _, err = backup.CreateEmptyFile(requested, 0666, false)
+	c.Check(err, gc.IsNil)
+}
+
+func (b *BackupSuite) TestCreateEmptyFileAlreadyExistsExclusive(c *gc.C) {
+	requested := filepath.Join(c.MkDir(), "backup.tar.gz")
+	file, err := os.Create(requested)
+	c.Assert(err, gc.IsNil)
+	err = file.Close()
+	c.Assert(err, gc.IsNil)
+
+	_, _, err = backup.CreateEmptyFile(requested, 0666, true)
+	c.Check(err, gc.ErrorMatches, "could not create backup file: .*")
+}

--- a/state/backup/info.go
+++ b/state/backup/info.go
@@ -1,0 +1,18 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup
+
+import (
+	"time"
+
+	"github.com/juju/juju/version"
+)
+
+type BackupInfo struct {
+	Name      string
+	Timestamp time.Time
+	CheckSum  string // SHA-1
+	Size      int64
+	Version   version.Number
+}

--- a/state/backup/new.go
+++ b/state/backup/new.go
@@ -1,0 +1,143 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/utils/hash"
+	"github.com/juju/utils/tar"
+)
+
+// This is effectively the "connection string".
+// It probably doesn't belong here in the long term.
+type DBConnInfo struct {
+	Hostname string
+	Username string
+	Password string
+}
+
+type newBackup struct {
+	tempdir  string
+	root     string
+	dumpdir  string
+	archive  io.WriteCloser
+	filename string
+}
+
+func (nb *newBackup) prepare() error {
+	// Prepare the temp directories.
+	var bkpDir, dumpDir string
+	tempDir, err := ioutil.TempDir("", "jujuBackup")
+	if err == nil {
+		logger.Debugf("backup temp dir: %s", tempDir)
+		bkpDir = filepath.Join(tempDir, "juju-backup")
+		dumpDir = filepath.Join(bkpDir, "dump")
+		err = os.MkdirAll(dumpDir, os.FileMode(0755))
+	}
+	if err != nil {
+		return fmt.Errorf("error creating backup temp directory: %v", err)
+	}
+	nb.tempdir = tempDir
+	nb.root = bkpDir
+	nb.dumpdir = dumpDir
+
+	// Prepare an empty file into which to store the backup.
+	archive, filename, err := CreateEmptyFile(tempDir+sep, 0600, false)
+	if err != nil {
+		return err
+	}
+	nb.archive = archive
+	nb.filename = filename
+	return nil
+}
+
+func (nb newBackup) cleanup() error {
+	if nb.tempdir != "" {
+		err := os.RemoveAll(nb.tempdir)
+		if err != nil {
+			logger.Warningf("error removing tempdir (%s): %v", nb.tempdir, err)
+		}
+	}
+	if nb.archive != nil {
+		err := nb.archive.Close()
+		if err != nil {
+			return fmt.Errorf("error closing backup file: %v", err)
+		}
+	}
+	return nil
+}
+
+func (nb newBackup) dumpDatabase(dbinfo *DBConnInfo) error {
+	logger.Debugf("dumping database")
+
+	err := dumpDatabase(dbinfo, nb.dumpdir)
+	if err != nil {
+		return fmt.Errorf("error dumping database: %v", err)
+	}
+	return nil
+}
+
+func (nb newBackup) bundleStateFiles() error {
+	logger.Debugf("bundling state files")
+
+	tarFile := filepath.Join(nb.root, "root.tar")
+	archive, err := os.Create(tarFile)
+	if err != nil {
+		return fmt.Errorf("error creating temp tar file: %v", err)
+	}
+
+	backupFiles, err := getFilesToBackup()
+	if err != nil {
+		return fmt.Errorf("could not determine files to backup: %v", err)
+	}
+
+	_, err = tar.TarFiles(backupFiles, archive, sep)
+	if err != nil {
+		return fmt.Errorf("could not back up state files: %v", err)
+	}
+	return nil
+}
+
+func (nb newBackup) writeTarball() (string, error) {
+	logger.Debugf("writing backup tarball: %s", nb.filename)
+
+	// Create the tarball.
+	hasher := hash.NewSHA1Proxy(nb.archive)
+	tarball := gzip.NewWriter(hasher)
+	_, err := tar.TarFiles([]string{nb.root}, tarball, nb.tempdir+sep)
+
+	// Close the writers.
+	tbErr := tarball.Close()
+	if tbErr != nil && err == nil {
+		err = fmt.Errorf("error closing gzip writer: %v", tbErr)
+	}
+
+	sha1sum := hasher.Hash()
+	return sha1sum, err
+}
+
+func (nb *newBackup) run(dbinfo *DBConnInfo) (string, error) {
+	err := nb.dumpDatabase(dbinfo)
+	if err != nil {
+		return "", err
+	}
+
+	err = nb.bundleStateFiles()
+	if err != nil {
+		return "", err
+	}
+
+	sha1sum, err := nb.writeTarball()
+	if err != nil {
+		return "", err
+	}
+
+	return sha1sum, nil
+}

--- a/state/backup/package_test.go
+++ b/state/backup/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func Test(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/state/backup/sources.go
+++ b/state/backup/sources.go
@@ -1,0 +1,105 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/utils"
+)
+
+//---------------------------
+// state-related files (configs, logs, keys)
+
+var getFilesToBackup = _getFilesToBackup
+
+func _getFilesToBackup() ([]string, error) {
+	const dataDir string = "/var/lib/juju"
+	initMachineConfs, err := filepath.Glob("/etc/init/jujud-machine-*.conf")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch machine upstart files: %v", err)
+	}
+	agentConfs, err := filepath.Glob(filepath.Join(dataDir, "agents", "machine-*"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch agent configuration files: %v", err)
+	}
+	jujuLogConfs, err := filepath.Glob("/etc/rsyslog.d/*juju.conf")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch juju log conf files: %v", err)
+	}
+
+	backupFiles := []string{
+		"/etc/init/juju-db.conf",
+		filepath.Join(dataDir, "tools"),
+		filepath.Join(dataDir, "server.pem"),
+		filepath.Join(dataDir, "system-identity"),
+		filepath.Join(dataDir, "nonce.txt"),
+		filepath.Join(dataDir, "shared-secret"),
+		"/home/ubuntu/.ssh/authorized_keys",
+		"/var/log/juju/all-machines.log",
+		"/var/log/juju/machine-0.log",
+	}
+	backupFiles = append(backupFiles, initMachineConfs...)
+	backupFiles = append(backupFiles, agentConfs...)
+	backupFiles = append(backupFiles, jujuLogConfs...)
+	return backupFiles, nil
+}
+
+//---------------------------
+// the database
+
+var runCommand = _runCommand
+
+func _runCommand(cmd string, args ...string) error {
+	out, err := utils.RunCommand(cmd, args...)
+	if err == nil {
+		return nil
+	}
+	if _, ok := err.(*exec.ExitError); ok && len(out) > 0 {
+		msg := strings.Replace(string(out), "\n", "; ", -1)
+		return fmt.Errorf("error executing %q: %s", cmd, msg)
+	} else {
+		return fmt.Errorf("cannot execute %q: %v", cmd, err)
+	}
+}
+
+var getMongodumpPath = _getMongodumpPath
+
+func _getMongodumpPath() (string, error) {
+	const mongoDumpPath string = "/usr/lib/juju/bin/mongodump"
+
+	if _, err := os.Stat(mongoDumpPath); err == nil {
+		return mongoDumpPath, nil
+	}
+
+	path, err := exec.LookPath("mongodump")
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func dumpDatabase(dbinfo *DBConnInfo, dumpDir string) error {
+	mongodumpPath, err := getMongodumpPath()
+	if err != nil {
+		return fmt.Errorf("mongodump not available: %v", err)
+	}
+	err = runCommand(
+		mongodumpPath,
+		"--oplog",
+		"--ssl",
+		"--host", dbinfo.Hostname,
+		"--username", dbinfo.Username,
+		"--password", dbinfo.Password,
+		"--out", dumpDir,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to dump database: %v", err)
+	}
+	return nil
+}

--- a/state/backup/storage.go
+++ b/state/backup/storage.go
@@ -1,0 +1,17 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup
+
+import (
+	"path"
+	"path/filepath"
+)
+
+// StorageName returns the path in environment storage where a backup
+// should be stored.
+func StorageName(filename string) string {
+	// Use of path.Join instead of filepath.Join is intentional - this
+	// is an environment storage path not a filesystem path.
+	return path.Join("/backups", filepath.Base(filename))
+}

--- a/state/backup/storage_test.go
+++ b/state/backup/storage_test.go
@@ -1,0 +1,16 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backup_test
+
+import (
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/state/backup"
+)
+
+func (b *BackupSuite) TestStorageName(c *gc.C) {
+	c.Assert(backup.StorageName("foo"), gc.Equals, "/backups/foo")
+	c.Assert(backup.StorageName("/foo/bar"), gc.Equals, "/backups/bar")
+	c.Assert(backup.StorageName("foo/bar"), gc.Equals, "/backups/bar")
+}


### PR DESCRIPTION
This is the first patch in a series that will fix backup to be storage-centric rather than file-centric.  The next step will involve changing apiserver to make backup an normal API method rather than a POST-based one.
