### PR TITLE
Changed type of written data back into slice

### DIFF
--- a/cmd/juju/endpoint.go
+++ b/cmd/juju/endpoint.go
@@ -48,6 +48,6 @@ func (c *EndpointCommand) Run(ctx *cmd.Context) error {
 	}
 	// We rely on the fact that the returned API endoint always
 	// has the last address we connected to as the first address.
-	address := apiendpoint.Addresses[0]
+	address := apiendpoint.Addresses[0:1]
 	return c.out.Write(ctx, address)
 }


### PR DESCRIPTION
This way the rendering as JSON or YAML will be backwards compatible again. We still only return the first endpoint.
