### PR TITLE
state/apiserver/uniter: fix test

### DIFF
--- a/state/apiserver/uniter/uniter_test.go
+++ b/state/apiserver/uniter/uniter_test.go
@@ -1057,10 +1057,9 @@ func (s *uniterSuite) TestActionNotPresent(c *gc.C) {
 func (s *uniterSuite) TestActionWrongUnit(c *gc.C) {
 	// Action doesn't match unit.
 	fakeBadAuth := apiservertesting.FakeAuthorizer{
-		Tag:       s.mysqlUnit.Tag(),
 		LoggedIn:  true,
 		UnitAgent: true,
-		Entity:    s.wordpressUnit,
+		Entity:    s.mysqlUnit,
 	}
 	fakeBadAPI, err := uniter.NewUniterAPI(
 		s.State,


### PR DESCRIPTION
When authenticating, against a unit in state, it is the Entity, not the Tag that takes priority.
