### PR TITLE
provider/manual: add manual-provider defaults to prepared config

### DIFF
--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -94,6 +94,10 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 	if err != nil {
 		return nil, err
 	}
+	cfg, err = cfg.Apply(validated)
+	if err != nil {
+		return nil, err
+	}
 	envConfig := newEnvironConfig(cfg, validated)
 	if envConfig.bootstrapHost() == "" {
 		return nil, errNoBootstrapHost
@@ -130,7 +134,7 @@ func (p manualProvider) Validate(cfg, old *config.Config) (valid *config.Config,
 	if err != nil {
 		return nil, err
 	}
-	return cfg.Apply(envConfig.attrs)
+	return envConfig.Config, nil
 }
 
 func (_ manualProvider) BoilerplateConfig() string {

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -62,6 +62,19 @@ func (s *providerSuite) TestPrepareUseSSHStorage(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "initialising SSH storage failed: newSSHStorage failed")
 }
 
+func (s *providerSuite) TestValidateSetsUseSSHStorage(c *gc.C) {
+	attrs := manual.MinimalConfigValues()
+	delete(attrs, "use-sshstorage")
+	testConfig, err := config.New(config.UseDefaults, attrs)
+	c.Assert(err, gc.IsNil)
+
+	env, err := manual.ProviderInstance.Prepare(coretesting.Context(c), testConfig)
+	c.Assert(err, gc.IsNil)
+	cfg := env.Config()
+	value := cfg.AllAttrs()["use-sshstorage"]
+	c.Assert(value, gc.Equals, true)
+}
+
 func (s *providerSuite) TestNullAlias(c *gc.C) {
 	p, err := environs.Provider("manual")
 	c.Assert(p, gc.NotNil)


### PR DESCRIPTION
Prepare calls "validate", which was not updating the config
with manual-provider specific attributes (Validate calls validate
and updates the config too). This meant that the manual-provider
config attribute defaults were not being populated in the .jenv
file, so we were not using SSH storage from the client when we
should have been.

Fixes https://bugs.launchpad.net/juju-core/+bug/1347715
