### PR TITLE
provider/manual: don't alter config in provider.Open

### DIFF
--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -55,6 +55,11 @@ func (p manualProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Confi
 	if err != nil {
 		return nil, err
 	}
+	cfg, err = cfg.Apply(envConfig.attrs)
+	if err != nil {
+		return nil, err
+	}
+	envConfig = newEnvironConfig(cfg, envConfig.attrs)
 	if err := ensureBootstrapUbuntuUser(ctx, envConfig); err != nil {
 		return nil, err
 	}
@@ -94,10 +99,6 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 	if err != nil {
 		return nil, err
 	}
-	cfg, err = cfg.Apply(validated)
-	if err != nil {
-		return nil, err
-	}
 	envConfig := newEnvironConfig(cfg, validated)
 	if envConfig.bootstrapHost() == "" {
 		return nil, errNoBootstrapHost
@@ -134,7 +135,7 @@ func (p manualProvider) Validate(cfg, old *config.Config) (valid *config.Config,
 	if err != nil {
 		return nil, err
 	}
-	return envConfig.Config, nil
+	return cfg.Apply(envConfig.attrs)
 }
 
 func (_ manualProvider) BoilerplateConfig() string {

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -62,7 +62,7 @@ func (s *providerSuite) TestPrepareUseSSHStorage(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "initialising SSH storage failed: newSSHStorage failed")
 }
 
-func (s *providerSuite) TestValidateSetsUseSSHStorage(c *gc.C) {
+func (s *providerSuite) TestPrepareSetsUseSSHStorage(c *gc.C) {
 	attrs := manual.MinimalConfigValues()
 	delete(attrs, "use-sshstorage")
 	testConfig, err := config.New(config.UseDefaults, attrs)
@@ -73,6 +73,19 @@ func (s *providerSuite) TestValidateSetsUseSSHStorage(c *gc.C) {
 	cfg := env.Config()
 	value := cfg.AllAttrs()["use-sshstorage"]
 	c.Assert(value, gc.Equals, true)
+}
+
+func (s *providerSuite) TestOpenDoesntSetUseSSHStorage(c *gc.C) {
+	attrs := manual.MinimalConfigValues()
+	delete(attrs, "use-sshstorage")
+	testConfig, err := config.New(config.UseDefaults, attrs)
+	c.Assert(err, gc.IsNil)
+
+	env, err := manual.ProviderInstance.Open(testConfig)
+	c.Assert(err, gc.IsNil)
+	cfg := env.Config()
+	_, ok := cfg.AllAttrs()["use-sshstorage"]
+	c.Assert(ok, jc.IsFalse)
 }
 
 func (s *providerSuite) TestNullAlias(c *gc.C) {


### PR DESCRIPTION
(Follow up to #429)

I unintentionally changed other users of the validate
function, which _shouldn't_ just add defaults to the
config. For example, Open should just take the config
it's given.
