### PR TITLE
provider/manual: ignore stderr when checking for existence of agents dir

### DIFF
--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -177,8 +177,11 @@ func (s *environSuite) TestStateServerInstances(c *gc.C) {
 	tests := []test{{
 		output: "",
 	}, {
-		output:      "woo",
+		output:      "no-agent-dir",
 		expectedErr: "environment is not bootstrapped",
+	}, {
+		output:      "woo",
+		expectedErr: `unexpected output: "woo"`,
 	}, {
 		err:         errors.New("an error"),
 		expectedErr: "an error",


### PR DESCRIPTION
We run an ssh command in StateServerInstances to verify that the bootstrap
machine is provisioned. We were accidentally considering that non-empty
stderr constituted a lack of environment, while we should only have been
considering stdout.

Fixes https://bugs.launchpad.net/juju-core/+bug/1347715
