### PR TITLE
Move mgo dependency forward to get bug fix

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	7f3110a0b4f01e5800e72b50cc92c8e9de4ea658	
 gopkg.in/natefinch/npipe.v2	git	86d100b9cc0fb2e0d27f2222801c16cd6fe9916a	
-gopkg.in/mgo.v2	git	3116f72d0fe0216b75201cb3a1ae61c82c2a4d63	
+gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/goamz	bzr	ian.booth@canonical.com-20140708164959-72q70lo1du0e4qki	48
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87


### PR DESCRIPTION
Addresses the "rescanned document misses transaction in queue" issue as per LP #1318366.
