### PR TITLE
Update Juju 1.20 to work with latest mgo

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/utils"
 	"github.com/juju/utils/voyeur"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	"launchpad.net/gnuflag"
 	"launchpad.net/tomb"
 

--- a/cmd/jujud/machine_test.go
+++ b/cmd/jujud/machine_test.go
@@ -248,7 +248,7 @@ func (s *MachineSuite) TestDyingMachine(c *gc.C) {
 	select {
 	case err := <-done:
 		c.Assert(err, gc.IsNil)
-	case <-time.After(watcher.Period * 5 / 4):
+	case <-time.After(watcher.Period * 2):
 		// TODO(rog) Fix this so it doesn't wait for so long.
 		// https://bugs.github.com/juju/juju/+bug/1163983
 		c.Fatalf("timed out waiting for agent to terminate")

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,7 +5,7 @@ github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	
-github.com/juju/charm	git	270e2e0cde8af92c5960dd7894f0646c9aa87786	
+github.com/juju/charm	git	e4306c516ce4fc36dd8f1b9f986d587b4ad75618	
 github.com/juju/cmd	git	e2d7df426d54b663f8616901b75d1ccfafcd9997	
 github.com/juju/errgo	git	2cf7b553faddc588f903020c33e71c527d5e0838	
 github.com/juju/errors	git	09734a904adc602da4334cbf29cb4515fbeb8feb	
@@ -16,15 +16,15 @@ github.com/juju/loggo	git	7e8c70b24b80b95b2284f09306aac0bd93588db8
 github.com/juju/names	git	aca402daf8e87fe85fb908a7cd282e83f371865e	
 github.com/juju/ratelimit	git	0025ab75db6c6eaa4ffff0240c2c9e617ad1a0eb	
 github.com/juju/schema	git	de545dbe6bec9a1586adfed8b47b99b616796c98	
-github.com/juju/testing	git	f424d031cbe5b2cd99834ee398d551f72d9c8f27	
-github.com/juju/txn	git	1bc7d3e5e9cad446e5d1d659856b67f0f869d3d7	
+github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76	
+github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	cf90c5739741e9af857babd42a205918f87d638f	
-labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
+gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/goamz	bzr	ian.booth@canonical.com-20140604055617-b7qt909ir9qf4959	47
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20140730020217-xa1jyuytye6g1qie	12
-launchpad.net/gomaasapi	bzr	ian.booth@canonical.com-20140716050440-8uf0y4vm7s6de4op	51
+launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140728022143-mth8hx6p0i546y0w	52
 launchpad.net/goose	bzr	tarmac-20140613065325-tlt6r3jg7saby4ub	126
 launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624093241-rlqsuf7pqxnrztgw	236

--- a/mongo/admin.go
+++ b/mongo/admin.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"syscall"
 
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/upstart"
 )

--- a/mongo/admin_test.go
+++ b/mongo/admin_test.go
@@ -11,8 +11,8 @@ import (
 
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/mongo"
@@ -112,7 +112,7 @@ func (s *adminSuite) TestEnsureAdminUserError(c *gc.C) {
 	// Second call fails, as there is another user and the database doesn't
 	// actually get reopened with --noauth in the test; mimics AddUser failure
 	_, err = s.ensureAdminUser(c, dialInfo, "whomeverelse", "whateverelse")
-	c.Assert(err, gc.ErrorMatches, `failed to add "whomeverelse" to admin database: cannot set admin password: not authorized for upsert on admin.system.users`)
+	c.Assert(err, gc.ErrorMatches, `failed to add "whomeverelse" to admin database: cannot set admin password: not authorized for update on admin.system.users`)
 }
 
 func (s *adminSuite) ensureAdminUser(c *gc.C, dialInfo *mgo.DialInfo, user, password string) (added bool, err error) {

--- a/mongo/collections.go
+++ b/mongo/collections.go
@@ -3,7 +3,7 @@
 
 package mongo
 
-import "labix.org/v2/mgo"
+import "gopkg.in/mgo.v2"
 
 // CollectionFromName returns a named collection on the specified database,
 // initialised with a new session. Also returned is a close function which

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"github.com/juju/utils/apt"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/replicaset"

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -11,7 +11,7 @@ import (
 	"net"
 	"time"
 
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/cert"
 )

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	"launchpad.net/gomaasapi"
 
 	"github.com/juju/juju/agent"

--- a/replicaset/replicaset.go
+++ b/replicaset/replicaset.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/juju/loggo"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 const (

--- a/replicaset/replicaset_test.go
+++ b/replicaset/replicaset_test.go
@@ -8,7 +8,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
 	coretesting "github.com/juju/juju/testing"

--- a/state/action.go
+++ b/state/action.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/txn"
 )
 
 type actionDoc struct {

--- a/state/actionresult.go
+++ b/state/actionresult.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // ActionStatus represents the possible end states for an action.

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -10,8 +10,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"

--- a/state/address.go
+++ b/state/address.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/network"
 )

--- a/state/annotator.go
+++ b/state/annotator.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/errors"
 )

--- a/state/api/agent/machine_test.go
+++ b/state/api/agent/machine_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/environs"

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 )
 
 type cleanupKind string

--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -6,8 +6,8 @@ package state
 import (
 	charmtesting "github.com/juju/charm/testing"
 	gitjujutesting "github.com/juju/testing"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/testing"

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -7,7 +7,7 @@ import (
 	stdtesting "testing"
 
 	gitjujutesting "github.com/juju/testing"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/state"

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"

--- a/state/container.go
+++ b/state/container.go
@@ -6,8 +6,8 @@ package state
 import (
 	"strings"
 
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/instance"
 )

--- a/state/environ.go
+++ b/state/environ.go
@@ -6,9 +6,9 @@ package state
 import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // environGlobalKey is the key for the environment, its

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -13,9 +13,9 @@ import (
 	charmtesting "github.com/juju/charm/testing"
 	jujutxn "github.com/juju/txn"
 	txntesting "github.com/juju/txn/testing"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/environs/config"

--- a/state/life.go
+++ b/state/life.go
@@ -4,8 +4,8 @@
 package state
 
 import (
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/api/params"

--- a/state/life_test.go
+++ b/state/life_test.go
@@ -4,7 +4,7 @@
 package state_test
 
 import (
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/state"

--- a/state/machine.go
+++ b/state/machine.go
@@ -14,9 +14,9 @@ import (
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/txn"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/constraints"

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/multiwatcher"

--- a/state/minimumunits.go
+++ b/state/minimumunits.go
@@ -6,8 +6,8 @@ package state
 import (
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // minUnitsDoc keeps track of relevant changes on the service's MinUnits field

--- a/state/minimumunits_test.go
+++ b/state/minimumunits_test.go
@@ -4,7 +4,7 @@
 package state_test
 
 import (
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/state"

--- a/state/multiwatcher/multiwatcher_internal_test.go
+++ b/state/multiwatcher/multiwatcher_internal_test.go
@@ -11,7 +11,7 @@ import (
 	stdtesting "testing"
 	"time"
 
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/state/api/params"

--- a/state/networkinterfaces.go
+++ b/state/networkinterfaces.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/names"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // NetworkInterface represents the state of a machine network

--- a/state/networks.go
+++ b/state/networks.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/names"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/network"
 )

--- a/state/open.go
+++ b/state/open.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/juju/loggo"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"launchpad.net/tomb"
 )
 

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	gitjujutesting "github.com/juju/testing"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 	"launchpad.net/tomb"
 

--- a/state/relation.go
+++ b/state/relation.go
@@ -14,9 +14,9 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // relationKey returns a string describing the relation defined by

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -12,9 +12,9 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // RelationUnit holds information about a single unit in a relation, and

--- a/state/requestednetworks.go
+++ b/state/requestednetworks.go
@@ -4,8 +4,8 @@
 package state
 
 import (
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // requestedNetworksDoc represents the network restrictions for a

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -6,8 +6,8 @@ package state
 import (
 	"fmt"
 
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type sequenceDoc struct {

--- a/state/service.go
+++ b/state/service.go
@@ -14,9 +14,9 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/state/api/params"

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/constraints"

--- a/state/settings.go
+++ b/state/settings.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // See: http://docs.mongodb.org/manual/faq/developers/#faq-dollar-sign-escaping

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2/txn"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/mongo"

--- a/state/state.go
+++ b/state/state.go
@@ -22,9 +22,9 @@ import (
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -19,8 +19,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/txn"
 	"github.com/juju/utils"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/constraints"
@@ -2154,10 +2154,8 @@ func (s *StateSuite) TestOpenDelaysRetryBadAddress(c *gc.C) {
 	}
 	c.Assert(err, gc.ErrorMatches, "no reachable servers")
 	// tryOpenState should have delayed for at least retryDelay
-	// internally mgo will try three times in a row before returning
-	// to the caller.
-	if t1 := time.Since(t0); t1 < 3*retryDelay {
-		c.Errorf("mgo.Dial only paused for %v, expected at least %v", t1, 3*retryDelay)
+	if t1 := time.Since(t0); t1 < retryDelay {
+		c.Errorf("mgo.Dial only paused for %v, expected at least %v", t1, retryDelay)
 	}
 }
 

--- a/state/status.go
+++ b/state/status.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/state/api/params"
 )

--- a/state/unit.go
+++ b/state/unit.go
@@ -14,9 +14,9 @@ import (
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"

--- a/state/user.go
+++ b/state/user.go
@@ -7,9 +7,9 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 )
 
 func (st *State) checkUserExists(name string) (bool, error) {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -13,8 +13,8 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/environs/config"

--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"launchpad.net/tomb"
 )
 

--- a/state/watcher/watcher_test.go
+++ b/state/watcher/watcher_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	gitjujutesting "github.com/juju/testing"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
 	gc "launchpad.net/gocheck"
 	"launchpad.net/tomb"
 

--- a/tools/marshal.go
+++ b/tools/marshal.go
@@ -4,7 +4,7 @@
 package tools
 
 import (
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/version"
 )

--- a/tools/marshal_test.go
+++ b/tools/marshal_test.go
@@ -4,7 +4,7 @@
 package tools_test
 
 import (
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/tools"

--- a/version/version.go
+++ b/version/version.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"strings"
 
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/juju/arch"
 )

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	stdtesting "testing"
 
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 	"launchpad.net/goyaml"
 

--- a/worker/peergrouper/initiate.go
+++ b/worker/peergrouper/initiate.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/utils"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/mongo"

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -4,7 +4,7 @@
 package peergrouper
 
 import (
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/replicaset"

--- a/worker/singular/mongo_test.go
+++ b/worker/singular/mongo_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
 	"github.com/juju/utils"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/replicaset"


### PR DESCRIPTION
This required to deal with a mgo bug (LP #1318366). The mgo repo changed location after 1.20 so this update is more complex than it otherwise would have been.

Although the change is mostly about dependencies and import paths, a test change was also required due to changes in mgo's internal behaviour.
