### PR TITLE
 Set environ config fields on bootstrap

### DIFF
--- a/cmd/juju/user_info_test.go
+++ b/cmd/juju/user_info_test.go
@@ -55,7 +55,7 @@ func (f *fakeUserInfoAPI) UserInfo(username string) (result usermanager.UserInfo
 		LastConnection: &lastConnection,
 	}
 	switch username {
-	case "":
+	case "admin":
 		info.Username = "admin"
 	case "foobar":
 		info.Username = "foobar"

--- a/environs/open.go
+++ b/environs/open.go
@@ -182,6 +182,23 @@ func Prepare(cfg *config.Config, ctx BootstrapContext, store configstore.Storage
 			}
 			return nil, err
 		}
+		cfg = env.Config()
+		creds := configstore.APICredentials{
+			User:     "admin", // TODO(waigani) admin@local once we have that set
+			Password: cfg.AdminSecret(),
+		}
+		info.SetAPICredentials(creds)
+		endpoint := configstore.APIEndpoint{}
+		var ok bool
+		endpoint.CACert, ok = cfg.CACert()
+		if !ok {
+			return nil, errors.Errorf("CACert is not set")
+		}
+		endpoint.EnvironUUID, ok = cfg.UUID()
+		if !ok {
+			return nil, errors.Errorf("CACert is not set")
+		}
+		info.SetAPIEndpoint(endpoint)
 		info.SetBootstrapConfig(env.Config().AllAttrs())
 		if err := info.Write(); err != nil {
 			return nil, errors.Annotatef(err, "cannot create environment info %q", env.Config().Name())

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -49,6 +49,21 @@ func (*OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
+func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
+	store := configstore.NewMem()
+	ctx := testing.Context(c)
+	_, err := environs.PrepareFromName("erewhemos", ctx, store)
+	c.Assert(err, gc.IsNil)
+
+	info, err := store.ReadInfo("erewhemos")
+	c.Assert(err, gc.IsNil)
+	c.Assert(info, gc.NotNil)
+	c.Assert(info.APIEndpoint().CACert, gc.Not(gc.Equals), "")
+	c.Assert(info.APIEndpoint().EnvironUUID, gc.Not(gc.Equals), "")
+	c.Assert(info.APICredentials().Password, gc.Not(gc.Equals), "")
+	c.Assert(info.APICredentials().User, gc.Equals, "admin")
+}
+
 func (*OpenSuite) TestNewUnknownEnviron(c *gc.C) {
 	attrs := dummySampleConfig().Merge(testing.Attrs{
 		"type": "wondercloud",

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -211,12 +211,9 @@ func (s *NewAPIClientSuite) TestWithConfigAndNoInfo(c *gc.C) {
 	})
 	bootstrapEnv(c, coretesting.SampleEnvName, store)
 
-	// Verify the cache is empty.
 	info, err := store.ReadInfo("myenv")
 	c.Assert(err, gc.IsNil)
 	c.Assert(info, gc.NotNil)
-	c.Assert(info.APIEndpoint(), jc.DeepEquals, configstore.APIEndpoint{})
-	c.Assert(info.APICredentials(), jc.DeepEquals, configstore.APICredentials{})
 
 	called := 0
 	expectState := mockedAPIState(0)
@@ -243,12 +240,6 @@ func (s *NewAPIClientSuite) TestWithConfigAndNoInfo(c *gc.C) {
 	c.Assert(ep.Addresses, gc.HasLen, 1)
 	c.Check(ep.Addresses[0], gc.Matches, `localhost:\d+`)
 	c.Check(ep.CACert, gc.Not(gc.Equals), "")
-	// Old servers won't hand back EnvironTag, so it should stay empty in
-	// the cache
-	c.Check(ep.EnvironUUID, gc.Equals, "")
-	creds := info.APICredentials()
-	c.Check(creds.User, gc.Equals, "admin")
-	c.Check(creds.Password, gc.Equals, "adminpass")
 }
 
 func (s *NewAPIClientSuite) TestWithInfoError(c *gc.C) {


### PR DESCRIPTION
Add environment info to config on bootstrap prepare. API endpoints will be added in a followup branch.
