### PR TITLE
Hard code logdir/datadir to Ubuntu paths

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/environmentserver/authentication"
-	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/api"
@@ -33,10 +32,16 @@ var logger = loggo.GetLogger("juju.agent")
 
 // logDir returns a filesystem path to the location where juju
 // may create a folder containing its logs
-var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
+//
+// TODO(gsamfira) 2014-07-31 https://github.com/juju/juju/pull/189
+// Use the target series to decide the path.
+var logDir = "/var/log"
 
 // dataDir returns the default data directory for this running system
-var dataDir = paths.MustSucceed(paths.DataDir(version.Current.Series))
+//
+// TODO(gsamfira) 2014-07-31 https://github.com/juju/juju/pull/189
+// Use the target series to decide the path.
+var dataDir = "/var/lib/juju"
 
 // DefaultLogDir defines the default log directory for juju agents.
 // It's defined as a variable so it could be overridden in tests.

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -18,11 +18,9 @@ import (
 	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/api"
 	"github.com/juju/juju/state/api/params"
-	"github.com/juju/juju/version"
 )
 
 // DataDir is the default data directory.
@@ -32,7 +30,10 @@ var DataDir = agent.DefaultDataDir
 
 // logDir returns a filesystem path to the location where applications
 // may create a folder containing logs
-var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
+//
+// TODO(gsamfira) 2014-07-31 https://github.com/juju/juju/pull/189
+// Use the target series to decide the path.
+var logDir = "/var/log"
 
 // CloudInitOutputLog is the default cloud-init-output.log file path.
 var CloudInitOutputLog = path.Join(logDir, "cloud-init-output.log")


### PR DESCRIPTION
We should never use the client's OS to
decide how to form paths for the target.
This change hardcodes an Ubuntu series
to generate the paths for now, until
Windows support is in.

Fixes https://bugs.launchpad.net/juju-core/+bug/1342725
