### PR TITLE
state/apiserver: derive svrRoot authorizer from state.Entity

### DIFF
--- a/state/apiserver/root.go
+++ b/state/apiserver/root.go
@@ -204,20 +204,20 @@ func (r *srvRoot) lookupMethod(rootName string, version int, methodName string) 
 
 // AuthMachineAgent returns whether the current client is a machine agent.
 func (r *srvRoot) AuthMachineAgent() bool {
-	_, ok := r.entity.(*state.Machine)
-	return ok
+	_, isMachine := r.GetAuthTag().(names.MachineTag)
+	return isMachine
 }
 
 // AuthUnitAgent returns whether the current client is a unit agent.
 func (r *srvRoot) AuthUnitAgent() bool {
-	_, ok := r.entity.(*state.Unit)
-	return ok
+	_, isUnit := r.GetAuthTag().(names.UnitTag)
+	return isUnit
 }
 
 // AuthOwner returns whether the authenticated user's tag matches the
 // given entity tag.
 func (r *srvRoot) AuthOwner(tag string) bool {
-	return r.entity.Tag().String() == tag
+	return r.GetAuthTag().String() == tag
 }
 
 // AuthEnvironManager returns whether the authenticated user is a
@@ -229,7 +229,7 @@ func (r *srvRoot) AuthEnvironManager() bool {
 // AuthClient returns whether the authenticated entity is a client
 // user.
 func (r *srvRoot) AuthClient() bool {
-	_, isUser := r.entity.(*state.User)
+	_, isUser := r.GetAuthTag().(names.UserTag)
 	return isUser
 }
 


### PR DESCRIPTION
This change updates the method on `svrRoot` to derive their behaviour the their `state.Entity` field via the entity's Tag.

As an entity, and its tag, are interchangeable there is no change to the perceived behaviour of `svrRoot`. However this change will allow the logic to be shared with `apiserver/testing.FakeAuthorizer` which derives its actions from a Tag, not a `state.Entity` 

Discussion: https://lists.ubuntu.com/archives/juju-dev/2014-July/003104.html
