### PR TITLE
170 state apiserver testing drop unused field

### DIFF
--- a/state/apiserver/agent/agent_test.go
+++ b/state/apiserver/agent/agent_test.go
@@ -56,7 +56,6 @@ func (s *agentSuite) SetUpTest(c *gc.C) {
 	// set up assuming machine 1 has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:          s.machine1.Tag(),
-		LoggedIn:     true,
 		MachineAgent: true,
 	}
 

--- a/state/apiserver/charmrevisionupdater/updater_test.go
+++ b/state/apiserver/charmrevisionupdater/updater_test.go
@@ -44,7 +44,6 @@ func (s *charmVersionSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		LoggedIn:       true,
 		EnvironManager: true,
 	}
 	var err error

--- a/state/apiserver/deployer/deployer_test.go
+++ b/state/apiserver/deployer/deployer_test.go
@@ -89,7 +89,6 @@ func (s *deployerSuite) SetUpTest(c *gc.C) {
 	// set up assuming machine 1 has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:          names.NewMachineTag(s.machine1.Id()),
-		LoggedIn:     true,
 		MachineAgent: true,
 	}
 

--- a/state/apiserver/environment/environment_test.go
+++ b/state/apiserver/environment/environment_test.go
@@ -36,7 +36,6 @@ func (s *environmentSuite) SetUpTest(c *gc.C) {
 
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:          s.machine0.Tag(),
-		LoggedIn:     true,
 		MachineAgent: true,
 		Entity:       s.machine0,
 	}

--- a/state/apiserver/firewaller/firewaller_test.go
+++ b/state/apiserver/firewaller/firewaller_test.go
@@ -72,7 +72,6 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming we logged in as the environment manager.
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		LoggedIn:       true,
 		EnvironManager: true,
 	}
 

--- a/state/apiserver/keymanager/keymanager_test.go
+++ b/state/apiserver/keymanager/keymanager_test.go
@@ -37,9 +37,8 @@ func (s *keyManagerSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		Tag:      names.NewUserTag("admin"),
-		LoggedIn: true,
-		Client:   true,
+		Tag:    names.NewUserTag("admin"),
+		Client: true,
 	}
 	var err error
 	s.keymanager, err = keymanager.NewKeyManagerAPI(s.State, s.resources, s.authoriser)

--- a/state/apiserver/keyupdater/authorisedkeys_test.go
+++ b/state/apiserver/keyupdater/authorisedkeys_test.go
@@ -44,7 +44,6 @@ func (s *authorisedKeysSuite) SetUpTest(c *gc.C) {
 	// The default auth is as a state server
 	s.authoriser = apiservertesting.FakeAuthorizer{
 		Tag:          s.rawMachine.Tag(),
-		LoggedIn:     true,
 		MachineAgent: true,
 	}
 	s.keyupdater, err = keyupdater.NewKeyUpdaterAPI(s.State, s.resources, s.authoriser)

--- a/state/apiserver/logger/logger_test.go
+++ b/state/apiserver/logger/logger_test.go
@@ -41,7 +41,6 @@ func (s *loggerSuite) SetUpTest(c *gc.C) {
 	// The default auth is as the machine agent
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:          s.rawMachine.Tag(),
-		LoggedIn:     true,
 		MachineAgent: true,
 	}
 	s.logger, err = logger.NewLoggerAPI(s.State, s.resources, s.authorizer)

--- a/state/apiserver/machine/common_test.go
+++ b/state/apiserver/machine/common_test.go
@@ -38,7 +38,6 @@ func (s *commonSuite) SetUpTest(c *gc.C) {
 	// set up assuming machine 1 has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:          s.machine1.Tag(),
-		LoggedIn:     true,
 		MachineAgent: true,
 	}
 }

--- a/state/apiserver/networker/networker_test.go
+++ b/state/apiserver/networker/networker_test.go
@@ -156,7 +156,6 @@ func (s *networkerSuite) SetUpTest(c *gc.C) {
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming we logged in as a machine agent.
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		LoggedIn:     true,
 		MachineAgent: true,
 		Tag:          s.machine.Tag(),
 	}

--- a/state/apiserver/provisioner/provisioner_test.go
+++ b/state/apiserver/provisioner/provisioner_test.go
@@ -69,7 +69,6 @@ func (s *provisionerSuite) setUpTest(c *gc.C, withStateServer bool) {
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming we logged in as the environment manager.
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		LoggedIn:       true,
 		EnvironManager: true,
 	}
 

--- a/state/apiserver/rsyslog/rsyslog_test.go
+++ b/state/apiserver/rsyslog/rsyslog_test.go
@@ -34,7 +34,6 @@ var _ = gc.Suite(&rsyslogSuite{})
 func (s *rsyslogSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		LoggedIn:       true,
 		EnvironManager: true,
 		MachineAgent:   true,
 	}

--- a/state/apiserver/testing/fakeauthorizer.go
+++ b/state/apiserver/testing/fakeauthorizer.go
@@ -12,7 +12,6 @@ import (
 // FakeAuthorizer implements the common.Authorizer interface.
 type FakeAuthorizer struct {
 	Tag            names.Tag
-	LoggedIn       bool
 	EnvironManager bool
 	MachineAgent   bool
 	UnitAgent      bool

--- a/state/apiserver/uniter/uniter_test.go
+++ b/state/apiserver/uniter/uniter_test.go
@@ -76,7 +76,6 @@ func (s *uniterSuite) SetUpTest(c *gc.C) {
 	// set up assuming unit 0 has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:       s.wordpressUnit.Tag(),
-		LoggedIn:  true,
 		UnitAgent: true,
 		Entity:    s.wordpressUnit,
 	}
@@ -1058,7 +1057,6 @@ func (s *uniterSuite) TestActionWrongUnit(c *gc.C) {
 	// Action doesn't match unit.
 	fakeBadAuth := apiservertesting.FakeAuthorizer{
 		Tag:       s.mysqlUnit.Tag(),
-		LoggedIn:  true,
 		UnitAgent: true,
 		Entity:    s.wordpressUnit,
 	}

--- a/state/apiserver/upgrader/unitupgrader_test.go
+++ b/state/apiserver/upgrader/unitupgrader_test.go
@@ -56,7 +56,6 @@ func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 	// The default auth is as the unit agent
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:       s.rawUnit.Tag(),
-		LoggedIn:  true,
 		UnitAgent: true,
 	}
 	s.upgrader, err = upgrader.NewUnitUpgraderAPI(s.State, s.resources, s.authorizer)

--- a/state/apiserver/upgrader/upgrader_test.go
+++ b/state/apiserver/upgrader/upgrader_test.go
@@ -52,7 +52,6 @@ func (s *upgraderSuite) SetUpTest(c *gc.C) {
 	// The default auth is as the machine agent
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:          s.rawMachine.Tag(),
-		LoggedIn:     true,
 		MachineAgent: true,
 	}
 	s.upgrader, err = upgrader.NewUpgraderAPI(s.State, s.resources, s.authorizer)
@@ -308,7 +307,6 @@ func (s *upgraderSuite) TestDesiredVersionUnrestrictedForAPIAgents(c *gc.C) {
 	// Grab a different Upgrader for the apiMachine
 	authorizer := apiservertesting.FakeAuthorizer{
 		Tag:          s.apiMachine.Tag(),
-		LoggedIn:     true,
 		MachineAgent: true,
 	}
 	upgraderAPI, err := upgrader.NewUpgraderAPI(s.State, s.resources, authorizer)

--- a/state/apiserver/usermanager/usermanager_test.go
+++ b/state/apiserver/usermanager/usermanager_test.go
@@ -32,10 +32,9 @@ func (s *userManagerSuite) SetUpTest(c *gc.C) {
 	user, err := s.State.User("admin")
 	c.Assert(err, gc.IsNil)
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag:      names.NewUserTag("admin"),
-		LoggedIn: true,
-		Client:   true,
-		Entity:   user,
+		Tag:    names.NewUserTag("admin"),
+		Client: true,
+		Entity: user,
 	}
 	s.usermanager, err = usermanager.NewUserManagerAPI(s.State, nil, s.authorizer)
 	c.Assert(err, gc.IsNil)
@@ -258,7 +257,6 @@ func (s *userManagerSuite) TestAgentUnauthorized(c *gc.C) {
 	// set up assuming machine 1 has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:          machine1.Tag(),
-		LoggedIn:     true,
 		MachineAgent: true,
 	}
 


### PR DESCRIPTION
Arguably `LoggedIn` was supposed to mean _this authoriser has authenticated an entity_ but it doesn't actually do anything.

Each `state/apiserver/...` test diligently sets the `LoggedIn` field which has no effect on the `FakeAuthoriser` nor is its state checked by any tests.
