### PR TITLE
mongo: always install mongodb in EnsureServer

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -170,11 +170,12 @@ func EnsureServer(args EnsureServerParams) error {
 		"Ensuring mongo server is running; data directory %s; port %d",
 		args.DataDir, args.StatePort,
 	)
-	dbDir := filepath.Join(args.DataDir, "db")
 
+	dbDir := filepath.Join(args.DataDir, "db")
 	if err := os.MkdirAll(dbDir, 0700); err != nil {
 		return fmt.Errorf("cannot create mongo database directory: %v", err)
 	}
+
 	oplogSizeMB := args.OplogSize
 	if oplogSizeMB == 0 {
 		var err error
@@ -183,7 +184,16 @@ func EnsureServer(args EnsureServerParams) error {
 		}
 	}
 
-	svc, mongoPath, err := upstartService(args.Namespace, args.DataDir, dbDir, args.StatePort, oplogSizeMB)
+	if err := aptGetInstallMongod(); err != nil {
+		return fmt.Errorf("cannot install mongod: %v", err)
+	}
+	mongoPath, err := Path()
+	if err != nil {
+		return err
+	}
+	logVersion(mongoPath)
+
+	svc, err := upstartService(args.Namespace, args.DataDir, dbDir, mongoPath, args.StatePort, oplogSizeMB)
 	if err != nil {
 		return err
 	}
@@ -219,12 +229,6 @@ func EnsureServer(args EnsureServerParams) error {
 			return err
 		}
 	}
-
-	if err := aptGetInstallMongod(); err != nil {
-		return fmt.Errorf("cannot install mongod: %v", err)
-	}
-
-	logVersion(mongoPath)
 
 	if err := upstartServiceStop(svc); err != nil {
 		return fmt.Errorf("failed to stop mongo: %v", err)
@@ -282,12 +286,7 @@ func sharedSecretPath(dataDir string) string {
 // upstartService returns the upstart config for the mongo state service.
 // It also returns the path to the mongod executable that the upstart config
 // will be using.
-func upstartService(namespace, dataDir, dbDir string, port, oplogSizeMB int) (*upstart.Service, string, error) {
-	mongoPath, err := Path()
-	if err != nil {
-		return nil, "", err
-	}
-
+func upstartService(namespace, dataDir, dbDir, mongoPath string, port, oplogSizeMB int) (*upstart.Service, error) {
 	mongoCmd := mongoPath + " --auth" +
 		" --dbpath=" + utils.ShQuote(dbDir) +
 		" --sslOnNormalPorts" +
@@ -311,7 +310,7 @@ func upstartService(namespace, dataDir, dbDir string, port, oplogSizeMB int) (*u
 		Cmd: mongoCmd,
 	}
 	svc := upstart.NewService(ServiceName(namespace), conf)
-	return svc, mongoPath, nil
+	return svc, nil
 }
 
 func aptGetInstallMongod() error {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -295,10 +295,34 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 	}
 }
 
+func (s *MongoSuite) TestInstallMongodServiceExists(c *gc.C) {
+	output := mockShellCommand(c, &s.CleanupSuite, "apt-get")
+	dataDir := c.MkDir()
+	namespace := "namespace"
+
+	s.PatchValue(mongo.UpstartServiceExists, func(svc *upstart.Service) bool {
+		return true
+	})
+	s.PatchValue(mongo.UpstartServiceRunning, func(svc *upstart.Service) bool {
+		return true
+	})
+	s.PatchValue(mongo.UpstartServiceStart, func(svc *upstart.Service) error {
+		return fmt.Errorf("shouldn't be called")
+	})
+
+	err := mongo.EnsureServer(makeEnsureServerParams(dataDir, namespace))
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.installed, gc.HasLen, 0)
+
+	// We still attempt to install mongodb, despite the service existing.
+	cmds := getMockShellCalls(c, output)
+	c.Assert(cmds, gc.HasLen, 1)
+}
+
 func (s *MongoSuite) TestUpstartServiceWithReplSet(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, 1024)
+	svc, err := mongo.UpstartService("", dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024)
 	c.Assert(err, gc.IsNil)
 	c.Assert(strings.Contains(svc.Conf.Cmd, "--replSet"), jc.IsTrue)
 }
@@ -306,7 +330,7 @@ func (s *MongoSuite) TestUpstartServiceWithReplSet(c *gc.C) {
 func (s *MongoSuite) TestUpstartServiceIPv6(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, 1024)
+	svc, err := mongo.UpstartService("", dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024)
 	c.Assert(err, gc.IsNil)
 	c.Assert(strings.Contains(svc.Conf.Cmd, "--ipv6"), jc.IsTrue)
 }
@@ -314,7 +338,7 @@ func (s *MongoSuite) TestUpstartServiceIPv6(c *gc.C) {
 func (s *MongoSuite) TestUpstartServiceWithJournal(c *gc.C) {
 	dataDir := c.MkDir()
 
-	svc, _, err := mongo.UpstartService("", dataDir, dataDir, 1234, 1024)
+	svc, err := mongo.UpstartService("", dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024)
 	c.Assert(err, gc.IsNil)
 	journalPresent := strings.Contains(svc.Conf.Cmd, " --journal ") || strings.HasSuffix(svc.Conf.Cmd, " --journal")
 	c.Assert(journalPresent, jc.IsTrue)
@@ -356,6 +380,7 @@ func (s *MongoSuite) TestQuantalAptAddRepo(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot install mongod: cannot add apt repository: exit status 1.*")
 
 	s.PatchValue(&version.Current.Series, "trusty")
+	failCmd(filepath.Join(dir, "mongod"))
 	err = mongo.EnsureServer(makeEnsureServerParams(dir, ""))
 	c.Assert(err, gc.IsNil)
 }


### PR DESCRIPTION
With the recent changes, we were leaving the
installation of mongodb until too late. We now
ensure that mongodb is installed early and we
do this unconditionally.

Fixes https://bugs.launchpad.net/juju-core/+bug/1350700
