### PR TITLE
Partial fix for LP-1351089

### DIFF
--- a/environs/sshstorage/storage.go
+++ b/environs/sshstorage/storage.go
@@ -318,7 +318,7 @@ func (s *SSHStorage) Put(name string, r io.Reader, length int64) error {
 	tmpdir := utils.ShQuote(s.tmpdir)
 
 	// Write to a temporary file ($TMPFILE), then mv atomically.
-	command := fmt.Sprintf("mkdir -p `dirname %s` && cat > $TMPFILE", path)
+	command := fmt.Sprintf("mkdir -p `dirname %s` && cat >| $TMPFILE", path)
 	command = fmt.Sprintf(
 		"TMPFILE=`mktemp --tmpdir=%s` && ((%s && mv $TMPFILE %s) || rm -f $TMPFILE)",
 		tmpdir, command, path,


### PR DESCRIPTION
If the environment has `set -o noclobber` then `cat > $TMPFILE` will fail if $TMPFILE exists.

The test referenced in [lp-1351089](https://bugs.launchpad.net/juju-core/+bug/1351089) should still be isolated better from the environment, but this seems like a good change to make anyway.
