### PR TITLE
LP-1351089 :: Isolate tests from users BASH_ENV

### DIFF
--- a/testing/base.go
+++ b/testing/base.go
@@ -82,6 +82,10 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.LoggingSuite.SetUpTest(c)
 	s.JujuOSEnvSuite.SetUpTest(c)
 
+	// We do this to isolate invocations of bash from pulling in the
+	// ambient user environment, and potentially affecting the tests.
+	// We can't always just use IsolationSuite because we still need
+	// PATH and possibly a couple other envars.
 	s.PatchEnvironment("BASH_ENV", "")
 }
 


### PR DESCRIPTION
By suppressing bash from loading the BASH_ENV files
