### PR TITLE
Enable windows service in juju

### DIFF
--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -135,10 +135,6 @@ func Main(args []string) {
 	os.Exit(code)
 }
 
-func main() {
-	Main(os.Args)
-}
-
 type writerFactory struct{}
 
 func (*writerFactory) NewWriter(target io.Writer) loggo.Writer {

--- a/cmd/jujud/main_nix.go
+++ b/cmd/jujud/main_nix.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions
+// Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
+
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	Main(os.Args)
+}

--- a/cmd/jujud/main_windows.go
+++ b/cmd/jujud/main_windows.go
@@ -1,0 +1,60 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/juju/juju/juju/names"
+
+	"bitbucket.org/kardianos/service"
+)
+
+func runService() {
+	var name = "juju"
+	var displayName = "juju service"
+	var desc = "juju service"
+
+	var s, err = service.NewService(name, displayName, desc)
+	if err != nil {
+		logger.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	run := func() error {
+		go Main(os.Args)
+		return nil
+	}
+	stop := func() error {
+		os.Exit(0)
+		return nil
+	}
+	err = s.Run(run, stop)
+
+	if err != nil {
+		s.Error(err.Error())
+	}
+}
+
+func runConsole() {
+	Main(os.Args)
+}
+
+func main() {
+	var mode uint32
+	err := syscall.GetConsoleMode(syscall.Stdin, &mode)
+
+	isConsole := err == nil
+
+	commandName := filepath.Base(os.Args[0])
+
+	if isConsole == true || commandName != names.Jujud {
+		runConsole()
+	} else {
+		runService()
+	}
+}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -30,3 +30,4 @@ launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140728022143-mth8hx6p
 launchpad.net/goose	bzr	tarmac-20140702055133-xpuj6gm4pa0f3a0e	127
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624093241-rlqsuf7pqxnrztgw	236
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17
+bitbucket.org/kardianos/service	hg	d2fd4f8afd23d9b5d57250b8d3f0bc0c8bf363ec	

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -17,15 +17,15 @@ import (
 
 var logger = loggo.GetLogger("juju.worker.deployer.service")
 
-var serviceInstallScript = `$data = Get-Content C:\Juju\Jujud.pass
-$serviceName = "%s"
+var serviceInstallScript = `$data = Get-Content "C:\Juju\Jujud.pass"
 if($? -eq $false){Write-Error "Failed to read encrypted password"; exit 1}
+$serviceName = "%s"
 $secpasswd = $data | convertto-securestring
 if($? -eq $false){Write-Error "Failed decode password"; exit 1}
 $juju_user = whoami
 $jujuCreds = New-Object System.Management.Automation.PSCredential($juju_user, $secpasswd)
 if($? -eq $false){Write-Error "Failed to create secure credentials"; exit 1}
-New-Service -Credential $jujuCreds -Name '$serviceName' -DisplayName '%s' '%s'
+New-Service -Credential $jujuCreds -Name "$serviceName" -DisplayName '%s' '%s'
 if($? -eq $false){Write-Error "Failed to install service $serviceName"; exit 1}
 cmd.exe /C call sc config $serviceName start=delayed-auto
 if($? -eq $false){Write-Error "Failed execute sc"; exit 1}
@@ -57,9 +57,12 @@ func (s *Service) UpdateConfig(conf common.Conf) {
 
 // Status gets the service status
 func (s *Service) Status() (string, error) {
-	cmd := fmt.Sprintf(`(Get-Service "%s").Status`, s.Name)
+	cmd := fmt.Sprintf(`$ErrorActionPreference="Stop"; (Get-Service "%s").Status`, s.Name)
 	out, err := runPsCommand(cmd)
-	return string(out.Stdout), err
+	if err != nil {
+		return "", err
+	}
+	return string(out.Stdout), nil
 }
 
 // Running returns true if the Service appears to be running.
@@ -87,15 +90,15 @@ func (s *Service) Installed() bool {
 // Exists returns whether the service configuration exists in the
 // init directory with the same content that this Service would have
 // if installed.
+// TODO (gabriel-samfira): 2014-07-30 bug 1350171
+// Needs a proper implementation when testing is improved
 func (s *Service) Exists() bool {
-	// TODO (thumper): 2014-07-30 bug 1350171
-	// No idea how to check, so for now, the answer is no, they are not the same.
 	return false
 }
 
 // Start starts the service.
 func (s *Service) Start() error {
-	cmd := fmt.Sprintf(`Start-Service  "%s"`, s.Name)
+	cmd := fmt.Sprintf(`$ErrorActionPreference="Stop"; Start-Service  "%s"`, s.Name)
 	logger.Infof("Starting service %q", s.Name)
 	if s.Running() {
 		logger.Infof("Service %q already running", s.Name)
@@ -110,7 +113,7 @@ func (s *Service) Stop() error {
 	if !s.Running() {
 		return nil
 	}
-	cmd := fmt.Sprintf(`Stop-Service  "%s"`, s.Name)
+	cmd := fmt.Sprintf(`$ErrorActionPreference="Stop"; Stop-Service  "%s"`, s.Name)
 	_, err := runPsCommand(cmd)
 	return err
 }
@@ -121,7 +124,7 @@ func (s *Service) Remove() error {
 	if err != nil {
 		return err
 	}
-	cmd := fmt.Sprintf(`(gwmi win32_service -filter 'name="%s"').Delete()`, s.Name)
+	cmd := fmt.Sprintf(`$ErrorActionPreference="Stop"; (gwmi win32_service -filter 'name="%s"').Delete()`, s.Name)
 	_, err = runPsCommand(cmd)
 	return err
 }


### PR DESCRIPTION
On windows, services need to be able to respond to events in order to be compatible with SCM (Service Control Manager). This PR detects whether we are running from a command line or if we are trying to run it as a service, and executes the appropriate routine.
- Added $ErrorActionPreference="Stop", in all powershell commands in github.com/juju/juju/service/windows. ErrorActionPreference is a powershell variable that dictates how errors should be handled. By default its set to "Continue". Setting it to "Stop" is the equivalent of -e (Stop on error) in BASH.
- updated dependencies.tsv to include the WriteYaml windows fix in utils, a fix for named pipes and to add the windows service package
