### PR TITLE
Backport fix for replicaset startup from trunk

### DIFF
--- a/mongo/open.go
+++ b/mongo/open.go
@@ -16,13 +16,13 @@ import (
 	"github.com/juju/juju/cert"
 )
 
-// defaultSocketTimeout should be long enough that
+// SocketTimeout should be long enough that
 // even a slow mongo server will respond in that
 // length of time. Since mongo servers ping themselves
 // every 10 seconds, we use a value of just over 2
 // ping periods to allow for delayed pings due to
 // issues such as CPU starvation etc.
-const defaultSocketTimeout = 21 * time.Second
+const SocketTimeout = 21 * time.Second
 
 // defaultDialTimeout should be representative of
 // the upper bound of time taken to dial a mongo
@@ -53,7 +53,7 @@ type DialOpts struct {
 func DefaultDialOpts() DialOpts {
 	return DialOpts{
 		Timeout:       defaultDialTimeout,
-		SocketTimeout: defaultSocketTimeout,
+		SocketTimeout: SocketTimeout,
 	}
 }
 

--- a/replicaset/replicaset.go
+++ b/replicaset/replicaset.go
@@ -67,6 +67,7 @@ func Initiate(session *mgo.Session, address, name string, tags map[string]string
 	logger.Infof("Initiating replicaset with config %#v", cfg)
 	var err error
 	for i := 0; i < maxInitiateAttempts; i++ {
+		monotonicSession.Refresh()
 		err = monotonicSession.Run(bson.D{{"replSetInitiate", cfg}}, nil)
 		if err != nil && err.Error() == rsMembersUnreachableError {
 			time.Sleep(initiateAttemptDelay)


### PR DESCRIPTION
Done mainly to use longer 60s timeout, but also brings 1.20 implementation in line with trunk.
