### PR TITLE
Mechanical change to accommodate explicit jujuMongod for mgo-related tes...

### DIFF
--- a/mongo/admin_test.go
+++ b/mongo/admin_test.go
@@ -47,7 +47,7 @@ func (s *adminSuite) SetUpTest(c *gc.C) {
 
 func (s *adminSuite) TestEnsureAdminUser(c *gc.C) {
 	inst := &gitjujutesting.MgoInstance{}
-	err := inst.Start(coretesting.Certs)
+	err := inst.Start(coretesting.Certs, mongo.JujuMongodPath)
 	c.Assert(err, gc.IsNil)
 	defer inst.DestroyWithLog()
 	dialInfo := inst.DialInfo()
@@ -99,7 +99,7 @@ func (s *adminSuite) TestEnsureAdminUser(c *gc.C) {
 
 func (s *adminSuite) TestEnsureAdminUserError(c *gc.C) {
 	inst := &gitjujutesting.MgoInstance{}
-	err := inst.Start(coretesting.Certs)
+	err := inst.Start(coretesting.Certs, mongo.JujuMongodPath)
 	c.Assert(err, gc.IsNil)
 	defer inst.Destroy()
 	dialInfo := inst.DialInfo()
@@ -130,7 +130,7 @@ func (s *adminSuite) ensureAdminUser(c *gc.C, dialInfo *mgo.DialInfo, user, pass
 
 func (s *adminSuite) setUpMongo(c *gc.C) *mgo.DialInfo {
 	inst := &gitjujutesting.MgoInstance{}
-	err := inst.Start(coretesting.Certs)
+	err := inst.Start(coretesting.Certs, mongo.JujuMongodPath)
 	c.Assert(err, gc.IsNil)
 	s.AddCleanup(func(*gc.C) { inst.Destroy() })
 	dialInfo := inst.DialInfo()

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -475,7 +475,7 @@ func (s *MongoSuite) TestJournalDisabledDetected(c *gc.C) {
 
 func (s *MongoSuite) testJournalEnabled(c *gc.C, enabled bool) {
 	inst := &testing.MgoInstance{EnableJournal: enabled}
-	err := inst.Start(coretesting.Certs)
+	err := inst.Start(coretesting.Certs, mongo.JujuMongodPath)
 	c.Assert(err, gc.IsNil)
 	defer inst.DestroyWithLog()
 	session, err := inst.Dial()

--- a/replicaset/export_test.go
+++ b/replicaset/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package replicaset
+
+var (
+	GetCurrentStatus = &getCurrentStatus
+)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2115,7 +2115,7 @@ func (s *StateSuite) TestOpenDoesnotSetWriteMajority(c *gc.C) {
 
 func (s *StateSuite) TestOpenSetsWriteMajority(c *gc.C) {
 	inst := gitjujutesting.MgoInstance{Params: []string{"--replSet", "juju"}}
-	err := inst.Start(testing.Certs)
+	err := inst.Start(testing.Certs, mongo.JujuMongodPath)
 	c.Assert(err, gc.IsNil)
 	defer inst.Destroy()
 
@@ -2152,7 +2152,7 @@ func (s *StateSuite) TestOpenDoesNotForceGroupCommits(c *gc.C) {
 
 func (s *StateSuite) TestOpenForcesGroupCommits(c *gc.C) {
 	inst := gitjujutesting.MgoInstance{EnableJournal: true}
-	err := inst.Start(testing.Certs)
+	err := inst.Start(testing.Certs, mongo.JujuMongodPath)
 	c.Assert(err, gc.IsNil)
 	defer inst.Destroy()
 	stateInfo := &authentication.MongoInfo{Info: mongo.Info{Addrs: []string{inst.Addr()}, CACert: testing.CACert}}

--- a/testing/mgo.go
+++ b/testing/mgo.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	gitjujutesting "github.com/juju/testing"
+
+	"github.com/juju/juju/mongo"
 )
 
 // MgoTestPackage should be called to register the tests for any package
 // that requires a secure connection to a MongoDB server.
 func MgoTestPackage(t *testing.T) {
-	gitjujutesting.MgoTestPackage(t, Certs)
+	gitjujutesting.MgoTestPackage(t, Certs, mongo.JujuMongodPath)
 }

--- a/worker/peergrouper/initiate_test.go
+++ b/worker/peergrouper/initiate_test.go
@@ -7,6 +7,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	gc "launchpad.net/gocheck"
 
+	"github.com/juju/juju/mongo"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/peergrouper"
 )
@@ -23,7 +24,7 @@ var _ = gc.Suite(&InitiateSuite{})
 func (s *InitiateSuite) TestInitiateReplicaSet(c *gc.C) {
 	var err error
 	inst := &gitjujutesting.MgoInstance{Params: []string{"--replSet", "juju"}}
-	err = inst.Start(coretesting.Certs)
+	err = inst.Start(coretesting.Certs, mongo.JujuMongodPath)
 	c.Assert(err, gc.IsNil)
 	defer inst.Destroy()
 

--- a/worker/singular/mongo_test.go
+++ b/worker/singular/mongo_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/replicaset"
 	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -544,7 +545,7 @@ func startReplicaSet(n int) (_ []*gitjujutesting.MgoInstance, err error) {
 
 func newMongoInstance() (*gitjujutesting.MgoInstance, error) {
 	inst := &gitjujutesting.MgoInstance{Params: []string{"--replSet", replicaSetName}}
-	if err := inst.Start(testing.Certs); err != nil {
+	if err := inst.Start(testing.Certs, mongo.JujuMongodPath); err != nil {
 		return nil, fmt.Errorf("cannot start mongo server: %s", err.Error())
 	}
 	return inst, nil


### PR DESCRIPTION
~~This is for part of the solution for https://bugs.launchpad.net/juju-core/+bug/1351019.  It does not fix the issue, but does take a step toward fixing it.~~
This patch accommodates being explicit about where to look for the juju-built mongod binary.  It accompanies https://github.com/juju/testing/pull/27.
