### PR TITLE
Revert "Merge pull request #416 from axw/mongo-journalenabled"

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"fmt"
 
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils"
 
@@ -88,7 +87,7 @@ func InitializeState(c ConfigSetter, envCfg *config.Config, machineCfg Bootstrap
 	logger.Debugf("initializing address %v", info.Addrs)
 	st, err := state.Initialize(info, envCfg, timeout, policy)
 	if err != nil {
-		return nil, nil, errors.Annotate(err, "failed to initialize state")
+		return nil, nil, fmt.Errorf("failed to initialize state: %v", err)
 	}
 	logger.Debugf("connected to initial state")
 	defer func() {
@@ -102,7 +101,7 @@ func InitializeState(c ConfigSetter, envCfg *config.Config, machineCfg Bootstrap
 		return nil, nil, err
 	}
 	if err := st.SetStateServingInfo(servingInfo); err != nil {
-		return nil, nil, errors.Annotate(err, "cannot set state serving info")
+		return nil, nil, fmt.Errorf("cannot set state serving info: %v", err)
 	}
 	m, err := initUsersAndBootstrapMachine(c, st, machineCfg)
 	if err != nil {

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -4,7 +4,6 @@
 package agent_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -232,7 +231,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	if err == nil {
 		st.Close()
 	}
-	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
+	c.Assert(err, gc.ErrorMatches, "failed to initialize state: cannot create log collection: unauthorized mongo access: unauthorized")
 }
 
 func (*bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, password string) {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/apt"
 	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/replicaset"
@@ -90,18 +89,6 @@ func IsMaster(session *mgo.Session, obj WithAddresses) (bool, error) {
 
 	machinePeerAddr := SelectPeerAddress(addrs)
 	return machinePeerAddr == masterAddr, nil
-}
-
-// JournalEnabled reports whether mongo has journaling enabled.
-func JournalEnabled(session *mgo.Session) (bool, error) {
-	var result bson.M
-	if err := session.Run("serverStatus", &result); err != nil {
-		return false, err
-	}
-	// The Journaling (dur) document is present if journaling is enabled.
-	// http://docs.mongodb.org/manual/reference/server-status/
-	_, ok := result["dur"]
-	return ok, nil
 }
 
 // SelectPeerAddress returns the address to use as the

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -465,27 +465,6 @@ func (s *MongoSuite) TestAddPPAInQuantal(c *gc.C) {
 	}})
 }
 
-func (s *MongoSuite) TestJournalEnabledDetected(c *gc.C) {
-	s.testJournalEnabled(c, true)
-}
-
-func (s *MongoSuite) TestJournalDisabledDetected(c *gc.C) {
-	s.testJournalEnabled(c, false)
-}
-
-func (s *MongoSuite) testJournalEnabled(c *gc.C, enabled bool) {
-	inst := &testing.MgoInstance{EnableJournal: enabled}
-	err := inst.Start(coretesting.Certs)
-	c.Assert(err, gc.IsNil)
-	defer inst.DestroyWithLog()
-	session, err := inst.Dial()
-	c.Assert(err, gc.IsNil)
-	defer session.Close()
-	isEnabled, err := mongo.JournalEnabled(session)
-	c.Assert(err, gc.IsNil)
-	c.Assert(isEnabled, gc.Equals, enabled)
-}
-
 // mockShellCommand creates a new command with the given
 // name and contents, and patches $PATH so that it will be
 // executed by preference. It returns the name of a file

--- a/state/open.go
+++ b/state/open.go
@@ -44,6 +44,15 @@ func Open(info *authentication.MongoInfo, opts mongo.DialOpts, policy Policy) (*
 	}
 	logger.Debugf("connection established")
 
+	_, err = replicaset.CurrentConfig(session)
+	safe := &mgo.Safe{J: true}
+	if err == nil {
+		// set mongo to write-majority (writes only returned after replicated
+		// to a majority of replica-set members)
+		safe.WMode = "majority"
+	}
+	session.SetSafe(safe)
+
 	st, err := newState(session, info, policy)
 	if err != nil {
 		session.Close()
@@ -186,21 +195,6 @@ func newState(session *mgo.Session, mongoInfo *authentication.MongoInfo, policy 
 		authenticated = true
 	}
 
-	var safe mgo.Safe
-	if _, err := replicaset.CurrentConfig(session); err == nil {
-		// set mongo to write-majority (writes only returned after replicated
-		// to a majority of replica-set members)
-		safe.WMode = "majority"
-	}
-	// Setting J=true fails in Mongo 2.6 when journaling is disabled.
-	// https://bugs.launchpad.net/mgo/+bug/1340275
-	journalEnabled, err := mongo.JournalEnabled(session)
-	if err != nil {
-		return nil, maybeUnauthorized(err, "cannot detect journaling")
-	}
-	safe.J = journalEnabled
-	session.SetSafe(&safe)
-
 	st := &State{
 		mongoInfo:     mongoInfo,
 		policy:        policy,
@@ -211,7 +205,7 @@ func newState(session *mgo.Session, mongoInfo *authentication.MongoInfo, policy 
 	logInfo := mgo.CollectionInfo{Capped: true, MaxBytes: logSize}
 	// The lack of error code for this error was reported upstream:
 	//     https://jira.klmongodb.org/browse/SERVER-6992
-	err = log.Create(&logInfo)
+	err := log.Create(&logInfo)
 	if err != nil && err.Error() != "collection already exists" {
 		return nil, maybeUnauthorized(err, "cannot create log collection")
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2111,6 +2111,7 @@ func (s *StateSuite) TestOpenDoesnotSetWriteMajority(c *gc.C) {
 	session := st.MongoSession()
 	safe := session.Safe()
 	c.Assert(safe.WMode, gc.Not(gc.Equals), "majority")
+	c.Assert(safe.J, gc.Equals, true)
 }
 
 func (s *StateSuite) TestOpenSetsWriteMajority(c *gc.C) {
@@ -2137,32 +2138,7 @@ func (s *StateSuite) TestOpenSetsWriteMajority(c *gc.C) {
 	stateSession := st.MongoSession()
 	safe := stateSession.Safe()
 	c.Assert(safe.WMode, gc.Equals, "majority")
-}
-
-func (s *StateSuite) TestOpenDoesNotForceGroupCommits(c *gc.C) {
-	info := state.TestingMongoInfo()
-	st, err := state.Open(info, state.TestingDialOpts(), state.Policy(nil))
-	c.Assert(err, gc.IsNil)
-	defer st.Close()
-
-	session := st.MongoSession()
-	safe := session.Safe()
-	c.Assert(safe.J, jc.IsFalse)
-}
-
-func (s *StateSuite) TestOpenForcesGroupCommits(c *gc.C) {
-	inst := gitjujutesting.MgoInstance{EnableJournal: true}
-	err := inst.Start(testing.Certs)
-	c.Assert(err, gc.IsNil)
-	defer inst.Destroy()
-	stateInfo := &authentication.MongoInfo{Info: mongo.Info{Addrs: []string{inst.Addr()}, CACert: testing.CACert}}
-	st, err := state.Open(stateInfo, state.TestingDialOpts(), state.Policy(nil))
-	c.Assert(err, gc.IsNil)
-	defer st.Close()
-
-	stateSession := st.MongoSession()
-	safe := stateSession.Safe()
-	c.Assert(safe.J, jc.IsTrue)
+	c.Assert(safe.J, gc.Equals, true)
 }
 
 func (s *StateSuite) TestOpenBadAddress(c *gc.C) {


### PR DESCRIPTION
This reverts commit 62e172632c3e9d8496805ed5223f9f4acc28986a, reversing
changes made to 8275fa461e1644ac073db177c5e456db24991a0c.

The commit being reverted appears to cause mongo to consume large amounts of resources and get stuck when "juju ensure-availability" is run, effectively trashing the environment. 
