### PR TITLE
Alter the behavior of opening and closing ports

### DIFF
--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -202,9 +202,9 @@ func (s *compatSuite) TestMigratePortsOnClose(c *gc.C) {
 	err = unit.Refresh()
 	c.Assert(err, gc.IsNil)
 
-	// Check if closing an unopened port causes error
+	// Check if closing an unopened port works
 	err = unit.ClosePort("tcp", 8080)
-	c.Assert(err, gc.ErrorMatches, "cannot close ports 8080-8080/tcp for unit \"mysql/0\": no match found for port range: 8080-8080/tcp")
+	c.Assert(err, gc.IsNil)
 
 	err = unit.ClosePort("tcp", 80)
 	c.Assert(err, gc.IsNil)

--- a/state/ports.go
+++ b/state/ports.go
@@ -213,20 +213,19 @@ func (p *Ports) ClosePorts(portRange PortRange) error {
 			}
 		}
 		newPorts := []PortRange{}
-		// Create a list of ports with the specified port
-		// removed. This still relies on the assumption that
-		// we are not storing actual port ranges.
-		// TODO(domas) 2014-07-04 bug #1337817: update this section to deal with actual port ranges.
+
 		found := false
 		for _, existingPortsDef := range ports.doc.Ports {
 			if existingPortsDef == portRange {
 				found = true
 				continue
+			} else if existingPortsDef.UnitName == portRange.UnitName && existingPortsDef.ConflictsWith(portRange) {
+				return nil, fmt.Errorf("mismatched port ranges %v and %v", existingPortsDef, portRange)
 			}
 			newPorts = append(newPorts, existingPortsDef)
 		}
 		if !found {
-			return nil, fmt.Errorf("no match found for port range: %v", portRange)
+			return nil, statetxn.ErrNoOperations
 		}
 		ops := []txn.Op{{
 			C:      unitsC,

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1103,7 +1103,7 @@ func (s *UnitSuite) TestOpenedPorts(c *gc.C) {
 	})
 
 	err = s.unit.ClosePort("tcp", 80)
-	c.Assert(err, gc.ErrorMatches, ".* no match found for port range: .*")
+	c.Assert(err, gc.IsNil)
 	open = s.unit.OpenedPorts()
 	c.Assert(open, gc.DeepEquals, []network.Port{
 		{"tcp", 53},


### PR DESCRIPTION
Closing a port range that has not been opened will not result in an error.

This is an outcome of the discussions on the juju-dev mailing list. Furthermore it follows the practices adopted by charm authors, where closing a port that was not open is often expected to be a noop.
