### PR TITLE
Map ppc64 to ppc64el

### DIFF
--- a/juju/arch/arch.go
+++ b/juju/arch/arch.go
@@ -52,7 +52,7 @@ var archREs = []struct {
 	{regexp.MustCompile("i?[3-9]86"), I386},
 	{regexp.MustCompile("(arm$)|(armv.*)"), ARM},
 	{regexp.MustCompile("aarch64"), ARM64},
-	{regexp.MustCompile("ppc64el|ppc64le"), PPC64},
+	{regexp.MustCompile("ppc64|ppc64el|ppc64le"), PPC64},
 }
 
 // Override for testing.

--- a/juju/arch/arch_test.go
+++ b/juju/arch/arch_test.go
@@ -40,6 +40,7 @@ func (s *archSuite) TestNormaliseArch(c *gc.C) {
 		{"arm64", "arm64"},
 		{"ppc64el", "ppc64el"},
 		{"ppc64le", "ppc64el"},
+		{"ppc64", "ppc64el"},
 	} {
 		arch := arch.NormaliseArch(test.raw)
 		c.Check(arch, gc.Equals, test.arch)


### PR DESCRIPTION
The previous branch didn't rename ppc64 to ppc64el, just ppc64le.
