### PR TITLE
Fix another out-of-order randomly triggered bug

### DIFF
--- a/state/apiserver/uniter/uniter_test.go
+++ b/state/apiserver/uniter/uniter_test.go
@@ -803,14 +803,13 @@ func (s *uniterSuite) TestWatchPreexistingActions(c *gc.C) {
 
 	result, err := s.uniter.WatchActions(args)
 	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
-		Results: []params.StringsWatchResult{
-			{StringsWatcherId: "1", Changes: []string{
-				firstAction.Id(),
-				secondAction.Id(),
-			}},
-		},
-	})
+	c.Assert(len(result.Results), gc.Equals, 1)
+
+	expected := []string{
+		firstAction.Id(),
+		secondAction.Id(),
+	}
+	c.Assert(result.Results[0].Changes, jc.SameContents, expected)
 
 	// Verify the resource was registered and stop when done
 	c.Assert(s.resources.Count(), gc.Equals, 1)


### PR DESCRIPTION
Testing with Go 1.3 exposed another implicit ordering bug - I noticed this cropping up in the run-unit-tests-precise-amd64 CI builds also, which makes me think we might want this merged sooner rather than later.
