### PR TITLE
provider/manual: don't change config in Open/SetConfig

### DIFF
--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -22,10 +22,13 @@ var _ = gc.Suite(&configSuite{})
 
 func MinimalConfigValues() map[string]interface{} {
 	return map[string]interface{}{
-		"name":             "test",
-		"type":             "manual",
-		"bootstrap-host":   "hostname",
-		"storage-auth-key": "whatever",
+		"name":              "test",
+		"type":              "manual",
+		"bootstrap-host":    "hostname",
+		"bootstrap-user":    "",
+		"storage-auth-key":  "whatever",
+		"storage-port":      8040,
+		"storage-listen-ip": "",
 		// Not strictly necessary, but simplifies testing by disabling
 		// ssh storage by default.
 		"use-sshstorage": false,
@@ -63,10 +66,15 @@ func (s *configSuite) TestValidateConfig(c *gc.C) {
 	_, err = manualProvider{}.Validate(testConfig, nil)
 	c.Assert(err, gc.ErrorMatches, "storage-auth-key: expected string, got nothing")
 
-	testConfig = MinimalConfig(c)
-	valid, err := manualProvider{}.Validate(testConfig, nil)
+	values := MinimalConfigValues()
+	delete(values, "bootstrap-user")
+	delete(values, "storage-listen-ip")
+	delete(values, "storage-port")
+	testConfig, err = config.New(config.UseDefaults, values)
 	c.Assert(err, gc.IsNil)
 
+	valid, err := manualProvider{}.Validate(testConfig, nil)
+	c.Assert(err, gc.IsNil)
 	unknownAttrs := valid.UnknownAttrs()
 	c.Assert(unknownAttrs["bootstrap-host"], gc.Equals, "hostname")
 	c.Assert(unknownAttrs["bootstrap-user"], gc.Equals, "")

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -160,10 +160,11 @@ func (e *manualEnviron) StateServerInstances() ([]instance.Id, error) {
 func (e *manualEnviron) SetConfig(cfg *config.Config) error {
 	e.cfgmutex.Lock()
 	defer e.cfgmutex.Unlock()
-	envConfig, err := manualProvider{}.validate(cfg, e.cfg.Config)
+	_, err := manualProvider{}.validate(cfg, e.cfg.Config)
 	if err != nil {
 		return err
 	}
+	envConfig := newEnvironConfig(cfg, cfg.UnknownAttrs())
 	// Set storage. If "use-sshstorage" is true then use the SSH storage.
 	// Otherwise, use HTTP storage.
 	//

--- a/provider/manual/export_test.go
+++ b/provider/manual/export_test.go
@@ -3,8 +3,20 @@
 
 package manual
 
+import (
+	"github.com/juju/juju/environs"
+)
+
 var (
 	ProviderInstance = manualProvider{}
 	NewSSHStorage    = &newSSHStorage
 	InitUbuntuUser   = &initUbuntuUser
 )
+
+func EnvironUseSSHStorage(env environs.Environ) bool {
+	e, ok := env.(*manualEnviron)
+	if !ok {
+		return false
+	}
+	return e.cfg.useSSHStorage()
+}

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -67,10 +67,14 @@ func (p manualProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Confi
 }
 
 func (p manualProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	envConfig, err := p.validate(cfg, nil)
+	_, err := p.validate(cfg, nil)
 	if err != nil {
 		return nil, err
 	}
+	// validate adds missing manual-specific config attributes
+	// with their defaults in the result; we don't wnat that in
+	// Open.
+	envConfig := newEnvironConfig(cfg, cfg.UnknownAttrs())
 	return p.open(envConfig)
 }
 

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -86,6 +86,8 @@ func (s *providerSuite) TestOpenDoesntSetUseSSHStorage(c *gc.C) {
 	cfg := env.Config()
 	_, ok := cfg.AllAttrs()["use-sshstorage"]
 	c.Assert(ok, jc.IsFalse)
+	ok = manual.EnvironUseSSHStorage(env)
+	c.Assert(ok, jc.IsFalse)
 }
 
 func (s *providerSuite) TestNullAlias(c *gc.C) {


### PR DESCRIPTION
The manual provider's Open and SetConfig methods were
both using the result of "validate", which replaces
missing manual-specific attributes with their defaults.
Open and SetConfig should not alter the input config.

Fixes https://bugs.launchpad.net/juju-core/+bug/1347715
