### PR TITLE
Remove varargs and test context object from factory.

### DIFF
--- a/cmd/juju/authorizedkeys_test.go
+++ b/cmd/juju/authorizedkeys_test.go
@@ -140,7 +140,7 @@ func (s *ListKeysSuite) TestListKeysNonDefaultUser(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
 	s.setAuthorizedKeys(c, key1, key2)
-	s.Factory.MakeUser(factory.UserParams{Name: "fred"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
 
 	context, err := coretesting.RunCommand(c, envcmd.Wrap(&ListKeysCommand{}), "--user", "fred")
 	c.Assert(err, gc.IsNil)
@@ -174,7 +174,7 @@ func (s *AddKeySuite) TestAddKey(c *gc.C) {
 func (s *AddKeySuite) TestAddKeyNonDefaultUser(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	s.setAuthorizedKeys(c, key1)
-	s.Factory.MakeUser(factory.UserParams{Name: "fred"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
 
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
 	context, err := coretesting.RunCommand(c, envcmd.Wrap(&AddKeysCommand{}), "--user", "fred", key2)
@@ -205,7 +205,7 @@ func (s *DeleteKeySuite) TestDeleteKeyNonDefaultUser(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
 	s.setAuthorizedKeys(c, key1, key2)
-	s.Factory.MakeUser(factory.UserParams{Name: "fred"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
 
 	context, err := coretesting.RunCommand(c, envcmd.Wrap(&DeleteKeysCommand{}),
 		"--user", "fred", sshtesting.ValidKeyTwo.Fingerprint)
@@ -238,7 +238,7 @@ func (s *ImportKeySuite) TestImportKeys(c *gc.C) {
 func (s *ImportKeySuite) TestImportKeyNonDefaultUser(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	s.setAuthorizedKeys(c, key1)
-	s.Factory.MakeUser(factory.UserParams{Name: "fred"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
 
 	context, err := coretesting.RunCommand(c, envcmd.Wrap(&ImportKeysCommand{}), "--user", "fred", "lp:validuser")
 	c.Assert(err, gc.IsNil)

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -73,7 +73,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployOwnerTag(c *gc.C) {
-	s.Factory.MakeUser(factory.UserParams{Name: "foobar"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 	service, err := juju.DeployService(s.State,
 		juju.DeployServiceParams{
 			ServiceName:  "bobwithowner",

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -91,7 +91,7 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 	s.MgoSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	s.setUpConn(c)
-	s.Factory = factory.NewFactory(s.State, c)
+	s.Factory = factory.NewFactory(s.State)
 }
 
 func (s *JujuConnSuite) TearDownTest(c *gc.C) {

--- a/state/api/usermanager/client_test.go
+++ b/state/api/usermanager/client_test.go
@@ -79,7 +79,7 @@ func (s *usermanagerSuite) TestCantRemoveAdminUser(c *gc.C) {
 
 func (s *usermanagerSuite) TestUserInfo(c *gc.C) {
 	tag := names.NewUserTag("foobar")
-	user := s.Factory.MakeUser(factory.UserParams{Name: tag.Id(), DisplayName: "Foo Bar"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: tag.Id(), DisplayName: "Foo Bar"})
 
 	obtained, err := s.usermanager.UserInfo(tag.String())
 	c.Assert(err, gc.IsNil)

--- a/state/apiserver/admin_test.go
+++ b/state/apiserver/admin_test.go
@@ -115,7 +115,7 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer st.Close()
 	password := "password"
-	u := s.Factory.MakeUser(factory.UserParams{Password: password})
+	u := s.Factory.MakeUser(c, &factory.UserParams{Password: password})
 	err = u.Deactivate()
 	c.Assert(err, gc.IsNil)
 

--- a/state/apiserver/authentication/agent_test.go
+++ b/state/apiserver/authentication/agent_test.go
@@ -29,7 +29,7 @@ var _ = gc.Suite(&agentAuthenticatorSuite{})
 func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
-	s.user = s.Factory.MakeUser(factory.UserParams{
+	s.user = s.Factory.MakeUser(c, &factory.UserParams{
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		Password:    "password",

--- a/state/apiserver/authentication/authenticator_test.go
+++ b/state/apiserver/authentication/authenticator_test.go
@@ -31,8 +31,8 @@ func (s *AgentAuthenticatorSuite) TestFindEntityAuthenticatorFails(c *gc.C) {
 }
 
 func (s *AgentAuthenticatorSuite) TestFindEntityAuthenticator(c *gc.C) {
-	fact := factory.NewFactory(s.State, c)
-	user := fact.MakeUser(factory.UserParams{Password: "password"})
+	fact := factory.NewFactory(s.State)
+	user := fact.MakeUser(c, &factory.UserParams{Password: "password"})
 	authenticator, err := authentication.FindEntityAuthenticator(user)
 	c.Assert(err, gc.IsNil)
 	c.Assert(authenticator, gc.NotNil)

--- a/state/apiserver/authentication/user_test.go
+++ b/state/apiserver/authentication/user_test.go
@@ -57,7 +57,7 @@ func (s *userAuthenticatorSuite) TestUnitLoginFails(c *gc.C) {
 }
 
 func (s *userAuthenticatorSuite) TestValidUserLogin(c *gc.C) {
-	user := s.Factory.MakeUser(factory.UserParams{
+	user := s.Factory.MakeUser(c, &factory.UserParams{
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		Password:    "password",
@@ -70,7 +70,7 @@ func (s *userAuthenticatorSuite) TestValidUserLogin(c *gc.C) {
 }
 
 func (s *userAuthenticatorSuite) TestUserLoginWrongPassword(c *gc.C) {
-	user := s.Factory.MakeUser(factory.UserParams{
+	user := s.Factory.MakeUser(c, &factory.UserParams{
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		Password:    "password",

--- a/state/apiserver/charms_test.go
+++ b/state/apiserver/charms_test.go
@@ -38,7 +38,7 @@ type authHttpSuite struct {
 func (s *authHttpSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.password = "password"
-	user := s.Factory.MakeUser(factory.UserParams{Password: s.password})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: s.password})
 	s.userTag = user.Tag().String()
 }
 

--- a/state/apiserver/client/api_test.go
+++ b/state/apiserver/client/api_test.go
@@ -332,7 +332,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	setDefaultPassword(c, u)
 	add(u)
 
-	u = s.Factory.MakeUser(factory.UserParams{Name: "other"})
+	u = s.Factory.MakeUser(c, &factory.UserParams{Name: "other"})
 	setDefaultPassword(c, u)
 	add(u)
 

--- a/state/apiserver/client/client_test.go
+++ b/state/apiserver/client/client_test.go
@@ -879,7 +879,7 @@ func (s *clientSuite) TestClientServiceDeployServiceOwner(c *gc.C) {
 	defer restore()
 	curl, _ := addCharm(c, store, "dummy")
 
-	user := s.Factory.MakeUser(factory.UserParams{Password: "password"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "password"})
 	s.APIState = s.OpenAPIAs(c, user.Tag(), "password")
 
 	err := s.APIState.Client().ServiceDeploy(

--- a/state/apiserver/usermanager/usermanager_test.go
+++ b/state/apiserver/usermanager/usermanager_test.go
@@ -127,8 +127,8 @@ func (s *userManagerSuite) TestUserInfoUsersExist(c *gc.C) {
 	barfoo := "barfoo"
 	fooTag := names.NewUserTag(foobar)
 	barTag := names.NewUserTag(barfoo)
-	userFoo := s.Factory.MakeUser(factory.UserParams{Name: foobar, DisplayName: "Foo Bar"})
-	userBar := s.Factory.MakeUser(factory.UserParams{Name: barfoo, DisplayName: "Bar Foo"})
+	userFoo := s.Factory.MakeUser(c, &factory.UserParams{Name: foobar, DisplayName: "Foo Bar"})
+	userBar := s.Factory.MakeUser(c, &factory.UserParams{Name: barfoo, DisplayName: "Bar Foo"})
 
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: fooTag.String()}, {Tag: barTag.String()}},
@@ -162,7 +162,7 @@ func (s *userManagerSuite) TestUserInfoUsersExist(c *gc.C) {
 func (s *userManagerSuite) TestUserInfoUserExists(c *gc.C) {
 	foobar := "foobar"
 	fooTag := names.NewUserTag(foobar)
-	user := s.Factory.MakeUser(factory.UserParams{Name: foobar, DisplayName: "Foo Bar"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: foobar, DisplayName: "Foo Bar"})
 
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: fooTag.String()}},
@@ -328,7 +328,7 @@ func (s *userManagerSuite) TestSetMultiplePasswords(c *gc.C) {
 // users to change other users passwords. For the time being we only allow
 // the password of the current user to be changed
 func (s *userManagerSuite) TestSetPasswordOnDifferentUser(c *gc.C) {
-	s.Factory.MakeUser(factory.UserParams{Name: "foobar"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 	args := usermanager.ModifyUsers{
 		Changes: []usermanager.ModifyUser{{
 			Username:    "foobar",

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -61,7 +61,7 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	cs.units = cs.MgoSuite.Session.DB("juju").C("units")
 	cs.stateServers = cs.MgoSuite.Session.DB("juju").C("stateServers")
 	cs.State.AddAdminUser("pass")
-	cs.factory = factory.NewFactory(cs.State, c)
+	cs.factory = factory.NewFactory(cs.State)
 }
 
 func (cs *ConnSuite) TearDownTest(c *gc.C) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2379,7 +2379,7 @@ func (s *StateSuite) TestFindEntity(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	_, err = unit.AddAction("fakeaction", nil)
 	c.Assert(err, gc.IsNil)
-	s.factory.MakeUser(factory.UserParams{Name: "arble"})
+	s.factory.MakeUser(c, &factory.UserParams{Name: "arble"})
 	c.Assert(err, gc.IsNil)
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	eps, err := s.State.InferEndpoints([]string{"wordpress", "ser-vice2"})
@@ -2476,7 +2476,7 @@ func (s *StateSuite) TestParseActionTag(c *gc.C) {
 }
 
 func (s *StateSuite) TestParseUserTag(c *gc.C) {
-	user := s.factory.MakeUser()
+	user := s.factory.MakeUser(c, nil)
 	coll, id, err := state.ParseTag(s.State, user.Tag())
 	c.Assert(err, gc.IsNil)
 	c.Assert(coll, gc.Equals, "users")

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -58,6 +58,7 @@ func (s *factorySuite) SetUpTest(c *gc.C) {
 	st, err := state.Initialize(info, cfg, opts, &policy)
 	c.Assert(err, gc.IsNil)
 	s.State = st
+	s.Factory = factory.NewFactory(s.State)
 }
 
 func (s *factorySuite) TearDownTest(c *gc.C) {
@@ -69,9 +70,7 @@ func (s *factorySuite) TearDownTest(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeUserNil(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	user := s.Factory.MakeUser()
+	user := s.Factory.MakeUser(c, nil)
 	c.Assert(user.IsDeactivated(), jc.IsFalse)
 
 	saved, err := s.State.User(user.Name())
@@ -86,13 +85,11 @@ func (s *factorySuite) TestMakeUserNil(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeUserParams(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
 	username := "bob"
 	displayName := "Bob the Builder"
 	creator := "eric"
 	password := "sekrit"
-	user := s.Factory.MakeUser(factory.UserParams{
+	user := s.Factory.MakeUser(c, &factory.UserParams{
 		Name:        username,
 		DisplayName: displayName,
 		Creator:     creator,
@@ -116,9 +113,7 @@ func (s *factorySuite) TestMakeUserParams(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeMachineNil(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	machine := s.Factory.MakeMachine()
+	machine := s.Factory.MakeMachine(c, nil)
 	c.Assert(machine, gc.NotNil)
 
 	saved, err := s.State.Machine(machine.Id())
@@ -139,8 +134,6 @@ func (s *factorySuite) TestMakeMachineNil(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeMachine(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
 	series := "quantal"
 	jobs := []state.MachineJob{state.JobManageEnviron}
 	password, err := utils.RandomPassword()
@@ -148,7 +141,7 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 	nonce := "some-nonce"
 	id := instance.Id("some-id")
 
-	machine := s.Factory.MakeMachine(factory.MachineParams{
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Series:     series,
 		Jobs:       jobs,
 		Password:   password,
@@ -180,9 +173,7 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeCharmNil(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	charm := s.Factory.MakeCharm()
+	charm := s.Factory.MakeCharm(c, nil)
 	c.Assert(charm, gc.NotNil)
 
 	saved, err := s.State.Charm(charm.URL())
@@ -195,13 +186,11 @@ func (s *factorySuite) TestMakeCharmNil(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeCharm(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
 	series := "quantal"
 	name := "wordpress"
 	revision := 13
 	url := fmt.Sprintf("cs:%s/%s-%d", series, name, revision)
-	ch := s.Factory.MakeCharm(factory.CharmParams{
+	ch := s.Factory.MakeCharm(c, &factory.CharmParams{
 		Name: name,
 		URL:  url,
 	})
@@ -220,9 +209,7 @@ func (s *factorySuite) TestMakeCharm(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeServiceNil(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	service := s.Factory.MakeService()
+	service := s.Factory.MakeService(c, nil)
 	c.Assert(service, gc.NotNil)
 
 	saved, err := s.State.Service(service.Name())
@@ -234,11 +221,9 @@ func (s *factorySuite) TestMakeServiceNil(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeService(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	charm := s.Factory.MakeCharm(factory.CharmParams{Name: "wordpress"})
-	creator := s.Factory.MakeUser(factory.UserParams{Name: "bill"}).Tag().String()
-	service := s.Factory.MakeService(factory.ServiceParams{
+	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
+	creator := s.Factory.MakeUser(c, &factory.UserParams{Name: "bill"}).Tag().String()
+	service := s.Factory.MakeService(c, &factory.ServiceParams{
 		Charm:   charm,
 		Creator: creator,
 	})
@@ -258,9 +243,7 @@ func (s *factorySuite) TestMakeService(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeUnitNil(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	unit := s.Factory.MakeUnit()
+	unit := s.Factory.MakeUnit(c, nil)
 	c.Assert(unit, gc.NotNil)
 
 	saved, err := s.State.Unit(unit.Name())
@@ -273,10 +256,8 @@ func (s *factorySuite) TestMakeUnitNil(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeUnit(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	service := s.Factory.MakeService()
-	unit := s.Factory.MakeUnit(factory.UnitParams{
+	service := s.Factory.MakeService(c, nil)
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{
 		Service: service,
 	})
 	c.Assert(unit, gc.NotNil)
@@ -293,9 +274,7 @@ func (s *factorySuite) TestMakeUnit(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeRelationNil(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	relation := s.Factory.MakeRelation()
+	relation := s.Factory.MakeRelation(c, nil)
 	c.Assert(relation, gc.NotNil)
 
 	saved, err := s.State.Relation(relation.Id())
@@ -308,27 +287,25 @@ func (s *factorySuite) TestMakeRelationNil(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeRelation(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	s1 := s.Factory.MakeService(factory.ServiceParams{
+	s1 := s.Factory.MakeService(c, &factory.ServiceParams{
 		Name: "service1",
-		Charm: s.Factory.MakeCharm(factory.CharmParams{
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
 			Name: "wordpress",
 		}),
 	})
 	e1, err := s1.Endpoint("db")
 	c.Assert(err, gc.IsNil)
 
-	s2 := s.Factory.MakeService(factory.ServiceParams{
+	s2 := s.Factory.MakeService(c, &factory.ServiceParams{
 		Name: "service2",
-		Charm: s.Factory.MakeCharm(factory.CharmParams{
+		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
 			Name: "mysql",
 		}),
 	})
 	e2, err := s2.Endpoint("server")
 	c.Assert(err, gc.IsNil)
 
-	relation := s.Factory.MakeRelation(factory.RelationParams{
+	relation := s.Factory.MakeRelation(c, &factory.RelationParams{
 		Endpoints: []state.Endpoint{e1, e2},
 	})
 	c.Assert(relation, gc.NotNil)
@@ -340,21 +317,4 @@ func (s *factorySuite) TestMakeRelation(c *gc.C) {
 	c.Assert(saved.Tag(), gc.Equals, relation.Tag())
 	c.Assert(saved.Life(), gc.Equals, relation.Life())
 	c.Assert(saved.Endpoints(), gc.DeepEquals, relation.Endpoints())
-}
-
-func (s *factorySuite) TestMultileParamPanics(c *gc.C) {
-	s.Factory = factory.NewFactory(s.State, c)
-
-	c.Assert(func() { s.Factory.MakeUser(factory.UserParams{}, factory.UserParams{}) },
-		gc.PanicMatches, "expecting 1 parameter or none")
-	c.Assert(func() { s.Factory.MakeMachine(factory.MachineParams{}, factory.MachineParams{}) },
-		gc.PanicMatches, "expecting 1 parameter or none")
-	c.Assert(func() { s.Factory.MakeService(factory.ServiceParams{}, factory.ServiceParams{}) },
-		gc.PanicMatches, "expecting 1 parameter or none")
-	c.Assert(func() { s.Factory.MakeCharm(factory.CharmParams{}, factory.CharmParams{}) },
-		gc.PanicMatches, "expecting 1 parameter or none")
-	c.Assert(func() { s.Factory.MakeUnit(factory.UnitParams{}, factory.UnitParams{}) },
-		gc.PanicMatches, "expecting 1 parameter or none")
-	c.Assert(func() { s.Factory.MakeRelation(factory.RelationParams{}, factory.RelationParams{}) },
-		gc.PanicMatches, "expecting 1 parameter or none")
 }


### PR DESCRIPTION
Due to lifetime differences, it is impractical and not recommended to set the test context for the factory during initialization, so all creation methods (MakeUser, MakeService, etc.) now take an additional *gc.C parameter.

Also, variadic parameters are exchanged for a pointer parameter for object properties - MakeUser() becomes MakeUser(c, nil). This makes the code more readable and idiomatic.
