### PR TITLE
Fix dependencies.tsv and make npipe always a dependency.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -18,8 +18,9 @@ github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d
 github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	7f3110a0b4f01e5800e72b50cc92c8e9de4ea658	
-gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/juju/charm.v2	git	ffe7392a3c6128c088b05d681fad336c4d3a8c22	
+gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
+gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/goamz	bzr	ian.booth@canonical.com-20140708164959-72q70lo1du0e4qki	48
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87

--- a/juju/sockets/sockets.go
+++ b/juju/sockets/sockets.go
@@ -1,5 +1,9 @@
 package sockets
 
-import "github.com/juju/loggo"
+import (
+	"github.com/juju/loggo"
+	// this is only here so that godeps will produce the right deps on all platforms
+	_ "gopkg.in/natefinch/npipe.v2"
+)
 
 var logger = loggo.GetLogger("juju.juju.sockets")


### PR DESCRIPTION
All builds now include a dependency on gopkg.in/natefinch/npipe.v2, so godeps ./... > dependencies.tsv will do the right thing.  This required a slight change to the npipe package so it has a file that compiles on non-windows platforms (I just moved the package docs to doc.go).
