### PR TITLE
Run Godeps as a test

### DIFF
--- a/cmd/jujud/main_nix.go
+++ b/cmd/jujud/main_nix.go
@@ -7,6 +7,9 @@ package main
 
 import (
 	"os"
+
+	// this is here to make godeps output the same on all OSes.
+	_ "bitbucket.org/kardianos/service"
 )
 
 func main() {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,3 +1,5 @@
+bitbucket.org/kardianos/osext	hg	5d3ddcf53a508cc2f7404eaebf546ef2cb5cdb6e	12
+bitbucket.org/kardianos/service	hg	d2fd4f8afd23d9b5d57250b8d3f0bc0c8bf363ec	58
 code.google.com/p/go.crypto	hg	aa2644fe4aa50e3b38d75187b4799b1f0c9ddcef	212
 code.google.com/p/go.net	hg	c17ad62118ea511e1051721b429779fa40bddc74	116
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	
@@ -19,8 +21,8 @@ github.com/juju/testing	git	503e61bd033592d7b6003174389f68454deb7b7a
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	28f5ce7a725633883b280766a4f835277cde79cb	
 gopkg.in/juju/charm.v3	git	eb7dae8ed9dfa44b89e4e8eee6e21f80e31a3b69	
-gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
+gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	
 gopkg.in/yaml.v1	git	1418a9bc452f9cf4efa70307cafcb10743e64a56	
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/goamz	bzr	martin.packman@canonical.com-20140813150539-umttn7s536u85eiz	49
@@ -30,4 +32,3 @@ launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140728022143-mth8hx6p
 launchpad.net/goose	bzr	tarmac-20140702055133-xpuj6gm4pa0f3a0e	127
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624093241-rlqsuf7pqxnrztgw	236
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17
-bitbucket.org/kardianos/service	hg	d2fd4f8afd23d9b5d57250b8d3f0bc0c8bf363ec	

--- a/dependencies_test.go
+++ b/dependencies_test.go
@@ -4,8 +4,13 @@
 package juju_test
 
 import (
-	"go/build"
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,15 +26,8 @@ type dependenciesTest struct{}
 
 var _ = gc.Suite(&dependenciesTest{})
 
-func projectRoot(c *gc.C) string {
-	p, err := build.Import("github.com/juju/juju", "", build.FindOnly)
-	c.Assert(err, gc.IsNil)
-	return p.Dir
-}
-
 func (*dependenciesTest) TestDependenciesTsvFormat(c *gc.C) {
-	filename := filepath.Join(projectRoot(c), "dependencies.tsv")
-	content, err := ioutil.ReadFile(filename)
+	content, err := ioutil.ReadFile("dependencies.tsv")
 	c.Assert(err, gc.IsNil)
 
 	for _, line := range strings.Split(string(content), "\n") {
@@ -39,4 +37,94 @@ func (*dependenciesTest) TestDependenciesTsvFormat(c *gc.C) {
 		segments := strings.Split(line, "\t")
 		c.Assert(segments, gc.HasLen, 4)
 	}
+}
+
+func (*dependenciesTest) TestGodepsIsRight(c *gc.C) {
+	f, err := os.Open("dependencies.tsv")
+	c.Assert(err, gc.IsNil)
+	defer f.Close()
+
+	gopath := os.Getenv("GOPATH")
+	gopath = strings.Split(gopath, fmt.Sprintf("%v", os.PathListSeparator))[0]
+
+	godeps, err := exec.LookPath("godeps")
+	if err != nil {
+		godeps = filepath.Join(gopath, "bin", "godeps")
+		if _, err := os.Stat(godeps); err != nil {
+			c.Skip("Godeps not found in $PATH or $GOPATH/bin")
+		}
+	}
+
+	cmd := exec.Command(godeps, "-t", "github.com/juju/juju/...")
+	output, err := cmd.StdoutPipe()
+	stderr, err := cmd.StderrPipe()
+	c.Assert(err, gc.IsNil)
+	err = cmd.Start()
+	c.Assert(err, gc.IsNil)
+	defer func() {
+		out, err := ioutil.ReadAll(stderr)
+		if err2 := cmd.Wait(); err2 != nil {
+			if err != nil {
+				c.Fatalf("Error running godeps: %s", err2)
+			}
+			c.Fatal(string(out))
+		}
+	}()
+
+	if err := diff(output, f); err != nil {
+		c.Fatal(err)
+	}
+}
+
+func diff(exp, act io.Reader) error {
+	// this whole monstrosity loops through the file contents and ensures each
+	// line is the same as in the godeps output.
+	actscan := bufio.NewScanner(act)
+	outscan := bufio.NewScanner(exp)
+	for actscan.Scan() {
+		if !outscan.Scan() {
+			// Scanning godeps output ended before the file contents ended.
+
+			if err := outscan.Err(); err != nil {
+				return fmt.Errorf("Error reading from godeps output: %v", err)
+			}
+
+			// Since there's no error, this means there are dependencies in the
+			// file that aren't actual dependnecies.
+			errs := []string{
+				"dependencies.tsv contains entries not reported by godeps: "}
+			errs = append(errs, actscan.Text())
+			for actscan.Scan() {
+				errs = append(errs, actscan.Text())
+			}
+			if err := actscan.Err(); err != nil {
+				return fmt.Errorf("Error reading from dependencies.tsv: %v", err)
+			}
+			return errors.New(strings.Join(errs, "\n"))
+		}
+		output := outscan.Text()
+		filedata := actscan.Text()
+		if output != filedata {
+			return fmt.Errorf("Godeps output does not match dependencies.tsv:\ngodeps: %s\n  .tsv: %s", output, filedata)
+		}
+	}
+	if err := actscan.Err(); err != nil {
+		return fmt.Errorf("Error reading from dependencies.tsv: %v", err)
+	}
+
+	if outscan.Scan() {
+		// dependencies.tsv scan ended before godeps output ended.
+		// This means there are dependendencies missing in the file.
+		errs := []string{
+			"Godeps reports dependencies not contained in dependencies.tsv: "}
+		errs = append(errs, outscan.Text())
+		for outscan.Scan() {
+			errs = append(errs, outscan.Text())
+		}
+		if err := outscan.Err(); err != nil {
+			return fmt.Errorf("Error reading from godeps output: %v", err)
+		}
+		return errors.New(strings.Join(errs, "\n"))
+	}
+	return nil
 }


### PR DESCRIPTION
run godeps -t ./... as a test and ensure that dependencies.tsv agrees with what godeps outputs.

This will fail if a dev hasn't run godeps -u, it will also fail if someone adds a dependency on a new external repo and doesn't specify it in dependencies.tsv. 

The nice thing is, this is one of the first tests that'll run if you're doing go test ./... from the root directory, so it should alert you right away if something is wrong.

I also simplified the other test a little...tests always run in the current directory, so you don't have to bend over backwards to read a file in the same directory, just read it.

This has only one added precondition that didn't exist before - godeps must be in your path.  Everyone contributing must have godeps in order to create a valid development environment, but in theory someone may have it in some directory that is not in their path.  I think the added requirement is perfectly acceptable in order to add this level of insurance to our build.  

The other option is we could call it as $GOPATH/bin/godeps which would require you to have used go install, but doesn't force it to be in the path.  Not sure which would be deemed less offensive.
