### PR TITLE
Fix LP-1355521 :: update config before making the worker

### DIFF
--- a/worker/machineenvironmentworker/machineenvironmentworker_test.go
+++ b/worker/machineenvironmentworker/machineenvironmentworker_test.go
@@ -162,12 +162,12 @@ func (s *MachineEnvironmentWatcherSuite) TestInitialState(c *gc.C) {
 }
 
 func (s *MachineEnvironmentWatcherSuite) TestRespondsToEvents(c *gc.C) {
+	proxySettings, aptProxySettings := s.updateConfig(c)
+
 	agentConfig := agentConfig(names.NewMachineTag("0"), "ec2")
 	envWorker := s.makeWorker(c, agentConfig)
 	defer worker.Stop(envWorker)
 	s.waitForPostSetup(c)
-
-	proxySettings, aptProxySettings := s.updateConfig(c)
 
 	s.waitProxySettings(c, proxySettings)
 	s.waitForFile(c, s.proxyFile, proxySettings.AsScriptEnvironment()+"\n")


### PR DESCRIPTION
Fixes lp-1355521

s.updateConfig was happening _after_ the suite already set up the worker.  This resulted in the environment not being consistently initialized, and resulted in the test timing out after 10 minutes on my machine.

Moving the s.updateConfig call to the beginning of the test, like all the other tests in this file, resolved the issue.
