### PR TITLE
fix panic about float in storage port, and add a test that verifies it

### DIFF
--- a/provider/manual/config.go
+++ b/provider/manual/config.go
@@ -60,7 +60,14 @@ func (c *environConfig) storageListenIPAddress() string {
 }
 
 func (c *environConfig) storagePort() int {
-	return c.attrs["storage-port"].(int)
+	switch val := c.attrs["storage-port"].(type) {
+	case float64:
+		return int(val)
+	case int:
+		return val
+	default:
+		panic(fmt.Sprintf("Unexpected %T in storage-port: %#v. Expected float64 or int.", val, val))
+	}
 }
 
 func (c *environConfig) storageAuthKey() string {

--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -157,3 +157,20 @@ func (s *configSuite) TestValidateConfigWithFloatPort(c *gc.C) {
 	unknownAttrs := valid.UnknownAttrs()
 	c.Assert(unknownAttrs["storage-port"], gc.Equals, int(8040))
 }
+
+func (s *configSuite) TestConfigWithFloatPort(c *gc.C) {
+	// When the config values get serialized through JSON, the integers
+	// get coerced to float64 values.  The parsing needs to handle this.
+	values := MinimalConfigValues()
+	values["storage-port"] = float64(8040)
+	cfg, err := config.New(config.UseDefaults, values)
+	c.Assert(err, gc.IsNil)
+	_, err = ProviderInstance.Validate(cfg, nil)
+	c.Assert(err, gc.IsNil)
+
+	env, err := ProviderInstance.Open(cfg)
+	c.Assert(err, gc.IsNil)
+
+	// really, we're asserting that this doesn't panic :)
+	c.Assert(env.(*manualEnviron).cfg.storagePort(), gc.Equals, int(8040))
+}


### PR DESCRIPTION
So, this **fixes-1347715** - at least the most problem thing to crop up.  We have tests in the code that were checking to make sure that if a float gets into the config via json deserialization, that we handle it correctly.  However, it wasn't doing precisely the same thing the production code does, so it wasn't actually getting the value into the right area of the environConfig, and wasn't actually calling storagePort().  The test I added does this, and I verified it fails with a panic with the old code for manualConfig... then fixed the code the do a type assertion first, handling float64 and int... reran the test and now the test passes.

My only concern is that I don't know what changed to cause this error to suddenly start occurring.  I'm going to look into it and see if I can find the change that revealed this error.
