### PR TITLE
MAAS provider uses hostname as cloud local address

### DIFF
--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -75,6 +75,11 @@ func (mi *maasInstance) Addresses() ([]network.Address, error) {
 	}
 	host := network.Address{name, network.HostName, "", network.ScopePublic}
 	addrs := []network.Address{host}
+	// MAAS prefers to use the dns name for intra-node communication.
+	// When Juju looks up the address to use for communicating between nodes, it looks
+	// up the address bu scope. So we add a cloud local address for that purpose.
+	cloudHost := network.Address{name, network.HostName, "", network.ScopeCloudLocal}
+	addrs = append(addrs, cloudHost)
 
 	ips, err := mi.ipAddresses()
 	if err != nil {

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -72,6 +72,7 @@ func (s *instanceTest) TestAddresses(c *gc.C) {
 
 	expected := []network.Address{
 		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopePublic},
+		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopeCloudLocal},
 		network.NewAddress("1.2.3.4", network.ScopeUnknown),
 		network.NewAddress("fe80::d806:dbff:fe23:1199", network.ScopeUnknown),
 	}
@@ -96,6 +97,7 @@ func (s *instanceTest) TestAddressesMissing(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Check(addr, gc.DeepEquals, []network.Address{
 		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopePublic},
+		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopeCloudLocal},
 	})
 }
 


### PR DESCRIPTION
Forward port pull request 473 from 1.20

The MAAS provider inserts a cloud local address equal to the dns name into the list of addresses returned by the instance.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1353442
