### PR TITLE
Various changes to support Mongo 2.6

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -36,6 +36,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	// Don't use MgoSuite, because we need to ensure
 	// we have a fresh mongo for each test case.
+	s.mgoInst.EnableAuth = true
 	err := s.mgoInst.Start(testing.Certs)
 	c.Assert(err, gc.IsNil)
 }
@@ -221,7 +222,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	if err == nil {
 		st.Close()
 	}
-	c.Assert(err, gc.ErrorMatches, "failed to initialize mongo admin user: cannot set admin password: not authorized for update on admin.system.users")
+	c.Assert(err, gc.ErrorMatches, "failed to initialize mongo admin user: cannot set admin password: not authorized .*")
 }
 
 func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, password string) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,7 +15,7 @@ github.com/juju/loggo	git	158009fb40c4a52b3d2c23eb56e72859cfc5321a
 github.com/juju/names	git	93fc8cbf8111c11d4ff47e603f668a0e29fb7cec	
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
-github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76	
+github.com/juju/testing	git	503e61bd033592d7b6003174389f68454deb7b7a	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	68554773385c32c354bf6357f8b6edd8a4742682	
 gopkg.in/juju/charm.v3	git	eb7dae8ed9dfa44b89e4e8eee6e21f80e31a3b69	

--- a/state/open.go
+++ b/state/open.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -146,13 +147,14 @@ func isUnauthorized(err error) bool {
 	}
 	// Some unauthorized access errors have no error code,
 	// just a simple error string.
-	if err.Error() == "auth fails" {
+	if strings.HasPrefix(err.Error(), "auth fail") {
 		return true
 	}
 	if err, ok := err.(*mgo.QueryError); ok {
 		return err.Code == 10057 ||
 			err.Message == "need to login" ||
-			err.Message == "unauthorized"
+			err.Message == "unauthorized" ||
+			strings.HasPrefix(err.Message, "not authorized")
 	}
 	return false
 }


### PR DESCRIPTION
Disable auth in Mongo for all except a handful of tests, which we segregate
and enable authentication for explicitly.

Ignore all commits other than 326c231: this builds on top of PR #498.

Requires https://github.com/juju/testing/pull/28
