### PR TITLE
Fix build on non windows platforms

### DIFF
--- a/juju/sockets/sockets.go
+++ b/juju/sockets/sockets.go
@@ -2,8 +2,6 @@ package sockets
 
 import (
 	"github.com/juju/loggo"
-	// this is only here so that godeps will produce the right deps on all platforms
-	_ "gopkg.in/natefinch/npipe.v2"
 )
 
 var logger = loggo.GetLogger("juju.juju.sockets")


### PR DESCRIPTION
It turns out this workaround for a godeps bug breaks the build for any linux user as nate's pipe package is only buildable under windows.
