### PR TITLE
Backport: Updating goyaml and goamz versions to latest.

### DIFF
--- a/agent/format-1.16.go
+++ b/agent/format-1.16.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"strconv"
 
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/version"

--- a/agent/format-1.18.go
+++ b/agent/format-1.18.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"strconv"
 
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/version"

--- a/cloudinit/cloudinit.go
+++ b/cloudinit/cloudinit.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"text/template"
 
-	yaml "launchpad.net/goyaml"
+	"gopkg.in/yaml.v1"
 )
 
 // Config represents a set of cloud-init configuration options.

--- a/cmd/juju/ensureavailability_test.go
+++ b/cmd/juju/ensureavailability_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/constraints"

--- a/cmd/juju/get_test.go
+++ b/cmd/juju/get_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/juju/charm"
 	"github.com/juju/cmd"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/juju/testing"

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -14,8 +14,8 @@ import (
 	charmtesting "github.com/juju/charm/testing"
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/constraints"

--- a/cmd/juju/user_add_test.go
+++ b/cmd/juju/user_add_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs/configstore"

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	goyaml "gopkg.in/yaml.v1"
 	"launchpad.net/gnuflag"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/constraints"

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -15,8 +15,8 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/constraints"

--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -20,8 +20,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
+	goyaml "gopkg.in/yaml.v1"
 	"launchpad.net/gnuflag"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/constraints"

--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	jc "github.com/juju/testing/checkers"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/proxy"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
 	"launchpad.net/golxc"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/container"

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,8 +5,8 @@ github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	
-github.com/juju/charm	git	e4306c516ce4fc36dd8f1b9f986d587b4ad75618	
-github.com/juju/cmd	git	e2d7df426d54b663f8616901b75d1ccfafcd9997	
+github.com/juju/charm	git	b9a309f5b8827ec0c63527fdd684fd1daeec5438	
+github.com/juju/cmd	git	7ef40be0cb5a4107d29fcfca5dff3b03ba0644dc	
 github.com/juju/errgo	git	2cf7b553faddc588f903020c33e71c527d5e0838	
 github.com/juju/errors	git	09734a904adc602da4334cbf29cb4515fbeb8feb	
 github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	
@@ -18,14 +18,14 @@ github.com/juju/ratelimit	git	0025ab75db6c6eaa4ffff0240c2c9e617ad1a0eb
 github.com/juju/schema	git	de545dbe6bec9a1586adfed8b47b99b616796c98	
 github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
-github.com/juju/utils	git	cf90c5739741e9af857babd42a205918f87d638f	
+github.com/juju/utils	git	87c163e49e480bff02fcfd0beb64a39aa3623913	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
+gopkg.in/yaml.v1	git	1418a9bc452f9cf4efa70307cafcb10743e64a56	
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
-launchpad.net/goamz	bzr	ian.booth@canonical.com-20140604055617-b7qt909ir9qf4959	47
+launchpad.net/goamz	bzr	martin.packman@canonical.com-20140813150539-umttn7s536u85eiz	49
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20140730020217-xa1jyuytye6g1qie	12
 launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140728022143-mth8hx6p0i546y0w	52
 launchpad.net/goose	bzr	tarmac-20140613065325-tlt6r3jg7saby4ub	126
-launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624093241-rlqsuf7pqxnrztgw	236
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/apt"
 	"github.com/juju/utils/proxy"
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/agent"
 	coreCloudinit "github.com/juju/juju/cloudinit"

--- a/environs/cloudinit_test.go
+++ b/environs/cloudinit_test.go
@@ -8,8 +8,8 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cert"

--- a/environs/config.go
+++ b/environs/config.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"

--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/juju/osenv"
 )

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -13,8 +13,8 @@ import (
 	charmtesting "github.com/juju/charm/testing"
 	gitjujutesting "github.com/juju/testing"
 	"github.com/juju/utils"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/environs"

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -11,13 +11,13 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	goyaml "gopkg.in/yaml.v1"
 	"launchpad.net/goamz/aws"
 	amzec2 "launchpad.net/goamz/ec2"
 	"launchpad.net/goamz/ec2/ec2test"
 	"launchpad.net/goamz/s3"
 	"launchpad.net/goamz/s3/s3test"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -95,6 +95,7 @@ func registerLocalTests() {
 	// has entries in the images/query txt files.
 	aws.Regions["test"] = aws.Region{
 		Name: "test",
+		Sign: aws.SignV2,
 	}
 
 	gc.Suite(&localServerSuite{})
@@ -146,6 +147,7 @@ func (srv *localServer) startServer(c *gc.C) {
 		EC2Endpoint:          srv.ec2srv.URL(),
 		S3Endpoint:           srv.s3srv.URL(),
 		S3LocationConstraint: true,
+		Sign:                 aws.SignV2,
 	}
 	s3inst := s3.New(aws.Auth{}, aws.Regions["test"])
 	storage := ec2.BucketStorage(s3inst.Bucket("juju-dist"))

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -16,9 +16,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
 	"launchpad.net/gomaasapi"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/utils"
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"

--- a/provider/maas/util_test.go
+++ b/provider/maas/util_test.go
@@ -6,8 +6,8 @@ package maas
 import (
 	"fmt"
 
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -12,8 +12,8 @@ import (
 	stdtesting "testing"
 
 	"gopkg.in/mgo.v2/bson"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"

--- a/worker/localstorage/config.go
+++ b/worker/localstorage/config.go
@@ -4,7 +4,7 @@
 package localstorage
 
 import (
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/agent"
 )

--- a/worker/localstorage/config_test.go
+++ b/worker/localstorage/config_test.go
@@ -6,8 +6,8 @@ package localstorage_test
 import (
 	stdtesting "testing"
 
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/worker/localstorage"
 )

--- a/worker/uniter/debug/client.go
+++ b/worker/uniter/debug/client.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"strings"
 
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 )
 
 type hookArgs struct {

--- a/worker/uniter/debug/server.go
+++ b/worker/uniter/debug/server.go
@@ -11,7 +11,7 @@ import (
 	"os/exec"
 
 	"github.com/juju/utils/set"
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v1"
 )
 
 // ServerSession represents a "juju debug-hooks" session.

--- a/worker/uniter/jujuc/config-get_test.go
+++ b/worker/uniter/jujuc/config-get_test.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/juju/cmd"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/jujuc"

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -28,8 +28,8 @@ import (
 	utilexec "github.com/juju/utils/exec"
 	"github.com/juju/utils/fslock"
 	"github.com/juju/utils/proxy"
+	goyaml "gopkg.in/yaml.v1"
 	gc "launchpad.net/gocheck"
-	"launchpad.net/goyaml"
 
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/juju/testing"


### PR DESCRIPTION
Conflicts:
    agent/format-1.16.go
    agent/format-1.18.go
    cmd/juju/get_test.go
    cmd/juju/status_test.go
    container/lxc/lxc_test.go
    dependencies.tsv
    environs/configstore/disk.go
    juju/testing/conn.go
    provider/common/state.go
    provider/common/state_test.go
    worker/uniter/uniter_test.go
