### PR TITLE
state/apiserver/testing: remove GetAuthEntity

### DIFF
--- a/state/apiserver/environment/environment_test.go
+++ b/state/apiserver/environment/environment_test.go
@@ -37,7 +37,6 @@ func (s *environmentSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:          s.machine0.Tag(),
 		MachineAgent: true,
-		Entity:       s.machine0,
 	}
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })

--- a/state/apiserver/testing/fakeauthorizer.go
+++ b/state/apiserver/testing/fakeauthorizer.go
@@ -5,8 +5,6 @@ package testing
 
 import (
 	"github.com/juju/names"
-
-	"github.com/juju/juju/state"
 )
 
 // FakeAuthorizer implements the common.Authorizer interface.
@@ -16,7 +14,6 @@ type FakeAuthorizer struct {
 	MachineAgent   bool
 	UnitAgent      bool
 	Client         bool
-	Entity         state.Entity
 }
 
 func (fa FakeAuthorizer) AuthOwner(tag string) bool {
@@ -50,8 +47,4 @@ func (fa FakeAuthorizer) AuthClient() bool {
 
 func (fa FakeAuthorizer) GetAuthTag() names.Tag {
 	return fa.Tag
-}
-
-func (fa FakeAuthorizer) GetAuthEntity() state.Entity {
-	return fa.Entity
 }

--- a/state/apiserver/uniter/uniter_test.go
+++ b/state/apiserver/uniter/uniter_test.go
@@ -77,7 +77,6 @@ func (s *uniterSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:       s.wordpressUnit.Tag(),
 		UnitAgent: true,
-		Entity:    s.wordpressUnit,
 	}
 
 	// Create the resource registry separately to track invocations to
@@ -1057,7 +1056,6 @@ func (s *uniterSuite) TestActionWrongUnit(c *gc.C) {
 	fakeBadAuth := apiservertesting.FakeAuthorizer{
 		Tag:       s.mysqlUnit.Tag(),
 		UnitAgent: true,
-		Entity:    s.wordpressUnit,
 	}
 	fakeBadAPI, err := uniter.NewUniterAPI(
 		s.State,

--- a/state/apiserver/usermanager/usermanager_test.go
+++ b/state/apiserver/usermanager/usermanager_test.go
@@ -32,9 +32,8 @@ func (s *userManagerSuite) SetUpTest(c *gc.C) {
 	user, err := s.State.User("admin")
 	c.Assert(err, gc.IsNil)
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag:    names.NewUserTag("admin"),
+		Tag:    user.Tag(),
 		Client: true,
-		Entity: user,
 	}
 	s.usermanager, err = usermanager.NewUserManagerAPI(s.State, nil, s.authorizer)
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
GetAuthEntity is no longer part of the Authorizer interface.

The Fake Authorizer always determines it's authentication from the Tag of the entity, so the entity itself is unnecessary.
