### PR TITLE
Tags are now validated, so blank and spaces are no longer valid.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -12,7 +12,7 @@ github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8
 github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	
 github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	
 github.com/juju/loggo	git	158009fb40c4a52b3d2c23eb56e72859cfc5321a	
-github.com/juju/names	git	93fc8cbf8111c11d4ff47e603f668a0e29fb7cec	
+github.com/juju/names	git	4353dc0f909ca5030269bc29f4fa05887475b438	
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
 github.com/juju/testing	git	503e61bd033592d7b6003174389f68454deb7b7a	

--- a/environs/cloudinit_test.go
+++ b/environs/cloudinit_test.go
@@ -46,7 +46,7 @@ type CloudInitSuite struct {
 var _ = gc.Suite(&CloudInitSuite{})
 
 func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
-	userTag := names.NewUserTag("not touched")
+	userTag := names.NewUserTag("not-touched")
 	attrs := dummySampleConfig().Merge(testing.Attrs{
 		"authorized-keys": "we-are-the-keys",
 	})
@@ -72,7 +72,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 }
 
 func (s *CloudInitSuite) TestFinishMachineConfigNonDefault(c *gc.C) {
-	userTag := names.NewUserTag("not touched")
+	userTag := names.NewUserTag("not-touched")
 	attrs := dummySampleConfig().Merge(testing.Attrs{
 		"authorized-keys":           "we-are-the-keys",
 		"ssl-hostname-verification": false,

--- a/juju/api.go
+++ b/juju/api.go
@@ -238,10 +238,14 @@ func apiInfoConnect(store configstore.Storage, info configstore.EnvironInfo, api
 		// valid UUID.
 		environTag = names.NewEnvironTag(endpoint.EnvironUUID)
 	}
+	username := info.APICredentials().User
+	if username == "" {
+		username = "admin"
+	}
 	apiInfo := &api.Info{
 		Addrs:      endpoint.Addresses,
 		CACert:     endpoint.CACert,
-		Tag:        names.NewUserTag(info.APICredentials().User),
+		Tag:        names.NewUserTag(username),
 		Password:   info.APICredentials().Password,
 		EnvironTag: environTag,
 	}


### PR DESCRIPTION
Update to the latest names version.

User tags are now validated when created, so a few places had to change to make this work.
