### PR TITLE
state/apiserver/provisioner: refactor canWatchMachines logic

### DIFF
--- a/state/apiserver/provisioner/provisioner.go
+++ b/state/apiserver/provisioner/provisioner.go
@@ -591,11 +591,7 @@ func (p *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Erro
 // the provisioner should retry provisioning machines with transient errors.
 func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
-	canWatch, err := p.getCanWatchMachines()
-	if err != nil {
-		return params.NotifyWatchResult{}, err
-	}
-	if !canWatch("") {
+	if !p.authorizer.AuthEnvironManager() {
 		return result, common.ErrPerm
 	}
 	watch := newWatchMachineErrorRetry()


### PR DESCRIPTION
This proposal removes the last deliberate use of `canWatch("")` in the apiserver.

There are some inadvertent uses where the tag string passed to `canWatch` will be addressed in the next proposal.
