### PR TITLE
state/apiserver/common: NewEnvironMachinesWatcher takes an authorizer

### DIFF
--- a/state/apiserver/common/environmachineswatcher.go
+++ b/state/apiserver/common/environmachineswatcher.go
@@ -14,19 +14,19 @@ import (
 // EnvironMachinesWatcher implements a common WatchEnvironMachines
 // method for use by various facades.
 type EnvironMachinesWatcher struct {
-	st          state.EnvironMachinesWatcher
-	resources   *Resources
-	getCanWatch GetAuthFunc
+	st         state.EnvironMachinesWatcher
+	resources  *Resources
+	authorizer Authorizer
 }
 
 // NewEnvironMachinesWatcher returns a new EnvironMachinesWatcher. The
 // GetAuthFunc will be used on each invocation of WatchUnits to
 // determine current permissions.
-func NewEnvironMachinesWatcher(st state.EnvironMachinesWatcher, resources *Resources, getCanWatch GetAuthFunc) *EnvironMachinesWatcher {
+func NewEnvironMachinesWatcher(st state.EnvironMachinesWatcher, resources *Resources, authorizer Authorizer) *EnvironMachinesWatcher {
 	return &EnvironMachinesWatcher{
-		st:          st,
-		resources:   resources,
-		getCanWatch: getCanWatch,
+		st:         st,
+		resources:  resources,
+		authorizer: authorizer,
 	}
 }
 
@@ -35,11 +35,7 @@ func NewEnvironMachinesWatcher(st state.EnvironMachinesWatcher, resources *Resou
 // environment.
 func (e *EnvironMachinesWatcher) WatchEnvironMachines() (params.StringsWatchResult, error) {
 	result := params.StringsWatchResult{}
-	canWatch, err := e.getCanWatch()
-	if err != nil {
-		return params.StringsWatchResult{}, err
-	}
-	if !canWatch("") {
+	if !e.authorizer.AuthEnvironManager() {
 		return result, ErrPerm
 	}
 	watch := e.st.WatchEnvironMachines()

--- a/state/apiserver/common/environmachineswatcher_test.go
+++ b/state/apiserver/common/environmachineswatcher_test.go
@@ -4,14 +4,14 @@
 package common_test
 
 import (
-	"fmt"
-
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/apiserver/common"
+	apiservertesting "github.com/juju/juju/state/apiserver/testing"
 	"github.com/juju/juju/testing"
 )
 
@@ -34,17 +34,16 @@ func (f *fakeEnvironMachinesWatcher) WatchEnvironMachines() state.StringsWatcher
 }
 
 func (s *environMachinesWatcherSuite) TestWatchEnvironMachines(c *gc.C) {
-	getCanWatch := func() (common.AuthFunc, error) {
-		return func(tag string) bool {
-			return true
-		}, nil
+	authorizer := apiservertesting.FakeAuthorizer{
+		Tag:            names.NewMachineTag("0"),
+		EnvironManager: true,
 	}
 	resources := common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
 	e := common.NewEnvironMachinesWatcher(
 		&fakeEnvironMachinesWatcher{initial: []string{"foo"}},
 		resources,
-		getCanWatch,
+		authorizer,
 	)
 	result, err := e.WatchEnvironMachines()
 	c.Assert(err, gc.IsNil)
@@ -52,34 +51,17 @@ func (s *environMachinesWatcherSuite) TestWatchEnvironMachines(c *gc.C) {
 	c.Assert(resources.Count(), gc.Equals, 1)
 }
 
-func (s *environMachinesWatcherSuite) TestWatchGetAuthError(c *gc.C) {
-	getCanWatch := func() (common.AuthFunc, error) {
-		return nil, fmt.Errorf("pow")
-	}
-	resources := common.NewResources()
-	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
-	e := common.NewEnvironMachinesWatcher(
-		&fakeEnvironMachinesWatcher{},
-		resources,
-		getCanWatch,
-	)
-	_, err := e.WatchEnvironMachines()
-	c.Assert(err, gc.ErrorMatches, "pow")
-	c.Assert(resources.Count(), gc.Equals, 0)
-}
-
 func (s *environMachinesWatcherSuite) TestWatchAuthError(c *gc.C) {
-	getCanWatch := func() (common.AuthFunc, error) {
-		return func(tag string) bool {
-			return false
-		}, nil
+	authorizer := apiservertesting.FakeAuthorizer{
+		Tag:            names.NewMachineTag("1"),
+		EnvironManager: false,
 	}
 	resources := common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
 	e := common.NewEnvironMachinesWatcher(
 		&fakeEnvironMachinesWatcher{},
 		resources,
-		getCanWatch,
+		authorizer,
 	)
 	_, err := e.WatchEnvironMachines()
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/state/apiserver/firewaller/firewaller.go
+++ b/state/apiserver/firewaller/firewaller.go
@@ -75,7 +75,7 @@ func NewFirewallerAPI(
 	machinesWatcher := common.NewEnvironMachinesWatcher(
 		st,
 		resources,
-		accessEnviron,
+		authorizer,
 	)
 	// InstanceId() is supported for machines.
 	instanceIdGetter := common.NewInstanceIdGetter(

--- a/state/apiserver/provisioner/provisioner.go
+++ b/state/apiserver/provisioner/provisioner.go
@@ -92,7 +92,7 @@ func NewProvisionerAPI(st *state.State, resources *common.Resources, authorizer 
 		APIAddresser:           common.NewAPIAddresser(st, resources),
 		ToolsGetter:            common.NewToolsGetter(st, getAuthFunc),
 		EnvironWatcher:         common.NewEnvironWatcher(st, resources, getCanReadSecrets),
-		EnvironMachinesWatcher: common.NewEnvironMachinesWatcher(st, resources, getCanReadSecrets),
+		EnvironMachinesWatcher: common.NewEnvironMachinesWatcher(st, resources, authorizer),
 		InstanceIdGetter:       common.NewInstanceIdGetter(st, getAuthFunc),
 		st:                     st,
 		resources:              resources,


### PR DESCRIPTION
This PR removes the incorrect use of `canWatch("")`, replacing it with a call to the underlying authorizer as it is that authorizer which can tell if the authenticated entity is permitted to act as an Environment manager.

A similar change is coming for EnvironWatcher in a followup PR.
