### PR TITLE
state/apiserver/common: NewEnvironsWatcher takes an authorizer

### DIFF
--- a/state/apiserver/common/environwatcher.go
+++ b/state/apiserver/common/environwatcher.go
@@ -13,9 +13,9 @@ import (
 // EnvironWatcher implements two common methods for use by various
 // facades - WatchForEnvironConfigChanges and EnvironConfig.
 type EnvironWatcher struct {
-	st                state.EnvironAccessor
-	resources         *Resources
-	getCanReadSecrets GetAuthFunc
+	st         state.EnvironAccessor
+	resources  *Resources
+	authorizer Authorizer
 }
 
 // NewEnvironWatcher returns a new EnvironWatcher. Active watchers
@@ -24,11 +24,11 @@ type EnvironWatcher struct {
 // determine current permissions.
 // Right now, environment tags are not used, so both created AuthFuncs
 // are called with "" for tag, which means "the current environment".
-func NewEnvironWatcher(st state.EnvironAccessor, resources *Resources, getCanReadSecrets GetAuthFunc) *EnvironWatcher {
+func NewEnvironWatcher(st state.EnvironAccessor, resources *Resources, authorizer Authorizer) *EnvironWatcher {
 	return &EnvironWatcher{
-		st:                st,
-		resources:         resources,
-		getCanReadSecrets: getCanReadSecrets,
+		st:         st,
+		resources:  resources,
+		authorizer: authorizer,
 	}
 }
 
@@ -56,20 +56,13 @@ func (e *EnvironWatcher) WatchForEnvironConfigChanges() (params.NotifyWatchResul
 func (e *EnvironWatcher) EnvironConfig() (params.EnvironConfigResult, error) {
 	result := params.EnvironConfigResult{}
 
-	canReadSecrets, err := e.getCanReadSecrets()
-	if err != nil {
-		return result, err
-	}
-
 	config, err := e.st.EnvironConfig()
 	if err != nil {
 		return result, err
 	}
 	allAttrs := config.AllAttrs()
 
-	// TODO(dimitern) If we have multiple environments in state, use a
-	// tag argument here and as a method argument.
-	if !canReadSecrets("") {
+	if !e.authorizer.AuthEnvironManager() {
 		// Mask out any secrets in the environment configuration
 		// with values of the same type, so it'll pass validation.
 		//

--- a/state/apiserver/environment/environment.go
+++ b/state/apiserver/environment/environment.go
@@ -19,9 +19,7 @@ type EnvironmentAPI struct {
 
 // NewEnvironmentAPI creates a new instance of the Environment API.
 func NewEnvironmentAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*EnvironmentAPI, error) {
-	// Does not get the secrets.
-	getCanReadSecrets := common.AuthNever()
 	return &EnvironmentAPI{
-		EnvironWatcher: common.NewEnvironWatcher(st, resources, getCanReadSecrets),
+		EnvironWatcher: common.NewEnvironWatcher(st, resources, authorizer),
 	}, nil
 }

--- a/state/apiserver/firewaller/firewaller.go
+++ b/state/apiserver/firewaller/firewaller.go
@@ -44,7 +44,6 @@ func NewFirewallerAPI(
 	accessUnit := getAuthFuncForTagKind(names.UnitTagKind)
 	accessService := getAuthFuncForTagKind(names.ServiceTagKind)
 	accessMachine := getAuthFuncForTagKind(names.MachineTagKind)
-	accessEnviron := common.AuthAlways()
 	accessUnitOrService := common.AuthEither(accessUnit, accessService)
 	accessUnitServiceOrMachine := common.AuthEither(accessUnitOrService, accessMachine)
 
@@ -58,7 +57,7 @@ func NewFirewallerAPI(
 	environWatcher := common.NewEnvironWatcher(
 		st,
 		resources,
-		accessEnviron,
+		authorizer,
 	)
 	// Watch() is supported for units or services.
 	entityWatcher := common.NewAgentEntityWatcher(

--- a/state/apiserver/provisioner/provisioner.go
+++ b/state/apiserver/provisioner/provisioner.go
@@ -36,11 +36,10 @@ type ProvisionerAPI struct {
 	*common.EnvironMachinesWatcher
 	*common.InstanceIdGetter
 
-	st                  *state.State
-	resources           *common.Resources
-	authorizer          common.Authorizer
-	getAuthFunc         common.GetAuthFunc
-	getCanWatchMachines common.GetAuthFunc
+	st          *state.State
+	resources   *common.Resources
+	authorizer  common.Authorizer
+	getAuthFunc common.GetAuthFunc
 }
 
 // NewProvisionerAPI creates a new server-side ProvisionerAPI facade.
@@ -77,11 +76,6 @@ func NewProvisionerAPI(st *state.State, resources *common.Resources, authorizer 
 			return isMachineAgent && names.NewMachineTag(parentId) == authEntityTag
 		}, nil
 	}
-	// Only the environment provisioner can read secrets.
-	getCanReadSecrets := common.AuthNever()
-	if authorizer.AuthEnvironManager() {
-		getCanReadSecrets = common.AuthAlways()
-	}
 	return &ProvisionerAPI{
 		Remover:                common.NewRemover(st, false, getAuthFunc),
 		StatusSetter:           common.NewStatusSetter(st, getAuthFunc),
@@ -91,14 +85,13 @@ func NewProvisionerAPI(st *state.State, resources *common.Resources, authorizer 
 		StateAddresser:         common.NewStateAddresser(st),
 		APIAddresser:           common.NewAPIAddresser(st, resources),
 		ToolsGetter:            common.NewToolsGetter(st, getAuthFunc),
-		EnvironWatcher:         common.NewEnvironWatcher(st, resources, getCanReadSecrets),
+		EnvironWatcher:         common.NewEnvironWatcher(st, resources, authorizer),
 		EnvironMachinesWatcher: common.NewEnvironMachinesWatcher(st, resources, authorizer),
 		InstanceIdGetter:       common.NewInstanceIdGetter(st, getAuthFunc),
 		st:                     st,
 		resources:              resources,
 		authorizer:             authorizer,
 		getAuthFunc:            getAuthFunc,
-		getCanWatchMachines:    getCanReadSecrets,
 	}, nil
 }
 

--- a/state/apiserver/rsyslog/rsyslog.go
+++ b/state/apiserver/rsyslog/rsyslog.go
@@ -31,10 +31,8 @@ func NewRsyslogAPI(st *state.State, resources *common.Resources, authorizer comm
 	if !authorizer.AuthMachineAgent() && !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm
 	}
-	// Does not get the secrets.
-	getCanReadSecrets := common.AuthNever()
 	return &RsyslogAPI{
-		EnvironWatcher: common.NewEnvironWatcher(st, resources, getCanReadSecrets),
+		EnvironWatcher: common.NewEnvironWatcher(st, resources, authorizer),
 		st:             st,
 		authorizer:     authorizer,
 		resources:      resources,

--- a/state/apiserver/rsyslog/rsyslog_test.go
+++ b/state/apiserver/rsyslog/rsyslog_test.go
@@ -36,7 +36,7 @@ func (s *rsyslogSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag:            names.NewMachineTag("1"),
-		EnvironManager: true,
+		EnvironManager: false,
 	}
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })

--- a/state/apiserver/uniter/uniter.go
+++ b/state/apiserver/uniter/uniter.go
@@ -63,15 +63,13 @@ func NewUniterAPI(st *state.State, resources *common.Resources, authorizer commo
 		}
 	}
 	accessUnitOrService := common.AuthEither(accessUnit, accessService)
-	// Uniter can not get the secrets.
-	getCanReadSecrets := common.AuthNever()
 	return &UniterAPI{
 		LifeGetter:         common.NewLifeGetter(st, accessUnitOrService),
 		StatusSetter:       common.NewStatusSetter(st, accessUnit),
 		DeadEnsurer:        common.NewDeadEnsurer(st, accessUnit),
 		AgentEntityWatcher: common.NewAgentEntityWatcher(st, resources, accessUnitOrService),
 		APIAddresser:       common.NewAPIAddresser(st, resources),
-		EnvironWatcher:     common.NewEnvironWatcher(st, resources, getCanReadSecrets),
+		EnvironWatcher:     common.NewEnvironWatcher(st, resources, authorizer),
 
 		st:            st,
 		auth:          authorizer,


### PR DESCRIPTION
This PR is a followup to #540, and removes the last incorrect use of canWatch(""), replacing it with a call to the underlying authorizer as it is that authorizer which can tell if the authenticated entity is permitted to act as an Environment manager.
