### PR TITLE
Write upgraded to version even when no upgrade

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -164,11 +164,14 @@ func (a *MachineAgent) Run(_ *cmd.Context) error {
 		return fmt.Errorf("cannot read agent configuration: %v", err)
 	}
 	logger.Infof("machine agent %v start (%s [%s])", a.Tag(), version.Current, runtime.Compiler)
+
+	if err := a.upgradeWorkerContext.InitializeUsingAgent(a); err != nil {
+		return errors.Annotate(err, "error during upgradeWorkerContext initialisation")
+	}
 	a.configChangedVal.Set(struct{}{})
 	agentConfig := a.CurrentConfig()
 	a.previousAgentVersion = agentConfig.UpgradedToVersion()
 	network.InitializeFromConfig(agentConfig)
-	a.upgradeWorkerContext.InitializeFromConfig(agentConfig)
 	charm.CacheDir = filepath.Join(agentConfig.DataDir(), "charmcache")
 	if err := a.createJujuRun(agentConfig.DataDir()); err != nil {
 		return fmt.Errorf("cannot create juju run symlink: %v", err)


### PR DESCRIPTION
Two related changes here:
1. Store the initial UpgradedToVersion as the the machine agent starts up and use that when deciding whether HA initialisation is required. Previously it could have been possible for the upgrade-steps worker to update UpgradedToVersion before ensureMongoServer got to check it.
2. Recent changes to avoid entering "upgrade mode" unnecessarily have meant that the upgradedToVersion field in a machine agent's config wasnt't getting updated whenever upgrade mode is skipped. This canhave a variety of negative effects.

This change fixes that by writing the current version to agent.conf when upgrade mode is skipped.

See also: https://bugs.launchpad.net/juju-core/+bug/1359484
