### PR TITLE
Move the ifdown/ifup logic to the interface definition file

### DIFF
--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -197,7 +197,6 @@ func (*environSuite) TestNewEnvironSetsConfig(c *gc.C) {
 var expectedCloudinitConfig = []interface{}{
 	"set -xe",
 	"mkdir -p '/var/lib/juju'; echo -n 'hostname: testing.invalid\n' > '/var/lib/juju/MAASmachine.txt'",
-	"ifdown eth0",
 	`mkdir -p etc/network/interfaces.d
 cat > /etc/network/interfaces.d/eth0.cfg << EOF
 # The primary network interface
@@ -218,7 +217,10 @@ EOF
 	`cat > /etc/network/interfaces.d/br0.cfg << EOF
 auto br0
 iface br0 inet dhcp
-  bridge_ports eth0
+  pre-up ifconfig eth0 down
+  pre-up brctl addbr br0
+  pre-up brctl addif br0 eth0
+  pre-up ifconfig eth0 up
 EOF
 sed -i 's/iface eth0 inet dhcp/iface eth0 inet manual/' /etc/network/interfaces.d/eth0.cfg
 `,


### PR DESCRIPTION
This is a proposed fix for https://bugs.launchpad.net/juju-core/+bug/1341524 , which is a specific issue caused by the 'ifdown interface' performed on the injected cloud-init, this change was introduced in favor of the previous 'service networking restart' as you can see performing a git diff -r 411dbff^! . This change was made because that command were killing dbus on the local provider.

So, my proposal is that instead of forcing the ifdown of the interface, we can use the network interface configuration to pass a set of pre-up command that brings the bridge and the associated interface up after configure it.

Please let me know any observation.

Signed-off-by: Jorge Niedbalski R niedbalski@gmail.com
