### PR TITLE
environs/tools: fix SHA256 summing

### DIFF
--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -19,12 +19,11 @@ import (
 )
 
 // Archive writes the executable files found in the given directory in
-// gzipped tar format to w, returning the SHA256 hash of the resulting file.
-// An error is returned if an entry inside dir is not a regular executable file.
-func Archive(w io.Writer, dir string) (string, error) {
+// gzipped tar format to w.
+func Archive(w io.Writer, dir string) error {
 	entries, err := ioutil.ReadDir(dir)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	gzw := gzip.NewWriter(w)
@@ -33,7 +32,6 @@ func Archive(w io.Writer, dir string) (string, error) {
 	tarw := tar.NewWriter(gzw)
 	defer closeErrorCheck(&err, tarw)
 
-	sha256hash := sha256.New()
 	for _, ent := range entries {
 		h := tarHeader(ent)
 		logger.Debugf("adding entry: %#v", h)
@@ -45,17 +43,25 @@ func Archive(w io.Writer, dir string) (string, error) {
 		}
 		err := tarw.WriteHeader(h)
 		if err != nil {
-			return "", err
+			return err
 		}
 		fileName := filepath.Join(dir, ent.Name())
 		if err := copyFile(tarw, fileName); err != nil {
-			return "", err
-		}
-		if err := copyFile(sha256hash, fileName); err != nil {
-			return "", err
+			return err
 		}
 	}
-	return fmt.Sprintf("%x", sha256hash.Sum(nil)), nil
+	return nil
+}
+
+// archiveAndSHA256 calls Archive with the provided arguments,
+// and returns a hex-encoded SHA256 hash of the resulting
+// archive.
+func archiveAndSHA256(w io.Writer, dir string) (sha256hash string, err error) {
+	h := sha256.New()
+	if err := Archive(io.MultiWriter(h, w), dir); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), err
 }
 
 // copyFile writes the contents of the given file to w.
@@ -239,9 +245,10 @@ func bundleTools(w io.Writer, forceVersion *version.Number) (tvers version.Binar
 	if err != nil {
 		return version.Binary{}, "", fmt.Errorf("invalid version %q printed by jujud", tvs)
 	}
-	sha256Hash, err = Archive(w, dir)
+
+	sha256hash, err := archiveAndSHA256(w, dir)
 	if err != nil {
 		return version.Binary{}, "", err
 	}
-	return tvers, sha256Hash, err
+	return tvers, sha256hash, err
 }

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -4,6 +4,8 @@
 package tools_test
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -90,4 +92,26 @@ func (b *buildSuite) TestFindExecutable(c *gc.C) {
 			c.Assert(result, gc.Equals, "")
 		}
 	}
+}
+
+const emptyArchive = "\x1f\x8b\b\x00\x00\tn\x88\x00\xffb\x18\x05\xa3`\x14\x8cX\x00\b\x00\x00\xff\xff.\xaf\xb5\xef\x00\x04\x00\x00"
+
+func (b *buildSuite) TestEmptyArchive(c *gc.C) {
+	var buf bytes.Buffer
+	dir := c.MkDir()
+	err := tools.Archive(&buf, dir)
+	c.Assert(err, gc.IsNil)
+	c.Assert(buf.String(), gc.Equals, emptyArchive)
+}
+
+func (b *buildSuite) TestArchiveAndSHA256(c *gc.C) {
+	var buf bytes.Buffer
+	dir := c.MkDir()
+	sha256hash, err := tools.ArchiveAndSHA256(&buf, dir)
+	c.Assert(err, gc.IsNil)
+	c.Assert(buf.String(), gc.Equals, emptyArchive)
+
+	h := sha256.New()
+	h.Write([]byte(emptyArchive))
+	c.Assert(sha256hash, gc.Equals, fmt.Sprintf("%x", h.Sum(nil)))
 }

--- a/environs/tools/export_test.go
+++ b/environs/tools/export_test.go
@@ -3,11 +3,12 @@
 
 package tools
 
-var Setenv = setenv
-
-var FindExecutable = findExecutable
-
-var CheckToolsSeries = checkToolsSeries
+var (
+	Setenv           = setenv
+	FindExecutable   = findExecutable
+	CheckToolsSeries = checkToolsSeries
+	ArchiveAndSHA256 = archiveAndSHA256
+)
 
 // SetSigningPublicKey sets a new public key for testing and returns the original key.
 func SetSigningPublicKey(key string) string {


### PR DESCRIPTION
SHA256 summing of archives was totally
broken; summing the contents rather
than the resulting tgz file. Changed
Archive to just tgz, and added another
function to do the hash.
