### PR TITLE
Update deps for lxc testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ else
 endif
 
 define DEPENDENCIES
+  ca-certificates
   bzr
   distro-info-data
   git-core
@@ -82,10 +83,9 @@ simplify:
 	gofmt -w -l -s .
 
 # Install packages required to develop Juju and run tests. The stable
-# PPA includes the required mongodb-server binaries. However, neither
-# PPA works on Saucy just yet.
+# PPA includes the required mongodb-server binaries.
 install-dependencies:
-ifeq ($(shell lsb_release -cs|sed -r 's/precise|quantal|raring/old/'),old)
+ifeq ($(shell lsb_release -cs|sed -r 's/precise/old/'),old)
 	@echo Adding juju PPAs for golang and mongodb-server
 	@sudo apt-add-repository --yes ppa:juju/golang
 	@sudo apt-add-repository --yes ppa:juju/stable


### PR DESCRIPTION
The test scripts use in CI installed undocumented deps and correct the makefile to test on many series and in other envs like lxc.

The master branch needs ca-certificates which is implicitly provided by desktop envs, but not other envs like cloud and lxc. I removed support for quantal and raring because there is no golang or mongo that will work for them.
