### PR TITLE
Update dependencies to use gomaasapi rev 53

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -25,7 +25,7 @@ launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02
 launchpad.net/goamz	bzr	martin.packman@canonical.com-20140813150539-umttn7s536u85eiz	49
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20140730020217-xa1jyuytye6g1qie	12
-launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20140728022143-mth8hx6p0i546y0w	52
+launchpad.net/gomaasapi	bzr	ian.booth@canonical.com-20140822004003-bz8zclvxcc6ipvfg	53
 launchpad.net/goose	bzr	tarmac-20140613065325-tlt6r3jg7saby4ub	126
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624093241-rlqsuf7pqxnrztgw	236
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17


### PR DESCRIPTION
New gomaasapi revision.

Fixes: https://bugs.launchpad.net/bugs/1190986
