### PR TITLE
Upgrade selection increments minor version by 1

### DIFF
--- a/cmd/juju/upgradejuju.go
+++ b/cmd/juju/upgradejuju.go
@@ -307,15 +307,11 @@ func (context *upgradeContext) validate() (err error) {
 		// need to upgrade. If the CLI and agent major versions match, we find
 		// next available stable release to upgrade to by incrementing the
 		// minor version, starting from the current agent version and doing
-		// major.minor+1 or +2 as needed. If the CLI has a greater major version,
+		// major.minor+1. If the CLI has a greater major version,
 		// we just use the CLI version as is.
 		nextVersion := context.agent
 		if nextVersion.Major == context.client.Major {
-			if context.agent.IsDev() {
-				nextVersion.Minor += 1
-			} else {
-				nextVersion.Minor += 2
-			}
+			nextVersion.Minor += 1
 		} else {
 			nextVersion = context.client
 		}

--- a/cmd/juju/upgradejuju_test.go
+++ b/cmd/juju/upgradejuju_test.go
@@ -97,10 +97,10 @@ var upgradeJujuTests = []struct {
 	expectInitErr:  "cannot specify build number when uploading tools",
 }, {
 	about:          "latest supported stable release",
-	tools:          []string{"2.2.0-quantal-amd64", "2.2.2-quantal-i386", "2.2.3-quantal-amd64"},
+	tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
 	currentVersion: "2.0.0-quantal-amd64",
 	agentVersion:   "2.0.0",
-	expectVersion:  "2.2.3",
+	expectVersion:  "2.1.3",
 }, {
 	about:          "latest current release",
 	tools:          []string{"2.0.5-quantal-amd64", "2.0.1-quantal-i386", "2.3.3-quantal-amd64"},
@@ -127,16 +127,16 @@ var upgradeJujuTests = []struct {
 	expectErr:      "no compatible tools available",
 }, {
 	about:          "no next supported available",
-	tools:          []string{"2.1.0-quantal-amd64", "2.1.5-quantal-i386", "2.3.3-quantal-amd64"},
+	tools:          []string{"2.2.0-quantal-amd64", "2.2.5-quantal-i386", "2.3.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
 	currentVersion: "2.0.0-quantal-amd64",
 	agentVersion:   "2.0.0",
 	expectErr:      "no more recent supported versions available",
 }, {
 	about:          "latest supported stable, when client is dev",
-	tools:          []string{"2.1-dev1-quantal-amd64", "2.2.0-quantal-amd64", "2.3-dev0-quantal-amd64", "3.0.1-quantal-amd64"},
+	tools:          []string{"2.1-dev1-quantal-amd64", "2.1.0-quantal-amd64", "2.3-dev0-quantal-amd64", "3.0.1-quantal-amd64"},
 	currentVersion: "2.1-dev0-quantal-amd64",
 	agentVersion:   "2.0.0",
-	expectVersion:  "2.2.0",
+	expectVersion:  "2.1.0",
 }, {
 	about:          "latest current, when agent is dev",
 	tools:          []string{"2.1-dev1-quantal-amd64", "2.2.0-quantal-amd64", "2.3-dev0-quantal-amd64", "3.0.1-quantal-amd64"},
@@ -419,33 +419,37 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 		DryRunTest{
 			about:          "dry run outputs and doesn't change anything when uploading tools",
 			cmdArgs:        []string{"--upload-tools", "--dry-run"},
-			tools:          []string{"2.2.0-quantal-amd64", "2.2.2-quantal-i386", "2.2.3-quantal-amd64"},
+			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
 			expectedCmdOutput: `available tools:
-    2.2.0-quantal-amd64
-    2.2.2-quantal-i386
+    2.1-dev1-quantal-amd64
+    2.1.0-quantal-amd64
+    2.1.2-quantal-i386
+    2.1.3-quantal-amd64
     2.2.3-quantal-amd64
 best version:
-    2.2.3
+    2.1.3
 upgrade to this version by running
-    juju upgrade-juju --version="2.2.3"
+    juju upgrade-juju --version="2.1.3"
 `,
 		},
 		DryRunTest{
 			about:          "dry run outputs and doesn't change anything",
 			cmdArgs:        []string{"--dry-run"},
-			tools:          []string{"2.2.0-quantal-amd64", "2.2.2-quantal-i386", "2.2.3-quantal-amd64"},
+			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
 			expectedCmdOutput: `available tools:
-    2.2.0-quantal-amd64
-    2.2.2-quantal-i386
+    2.1-dev1-quantal-amd64
+    2.1.0-quantal-amd64
+    2.1.2-quantal-i386
+    2.1.3-quantal-amd64
     2.2.3-quantal-amd64
 best version:
-    2.2.3
+    2.1.3
 upgrade to this version by running
-    juju upgrade-juju --version="2.2.3"
+    juju upgrade-juju --version="2.1.3"
 `,
 		},
 	}


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1359435

When we upgrade and Juju chooses the next version, it now needs to increment minor version by 1 not 2.
