### PR TITLE
Merge pull request #602 from wallyworld/agent-version-on-startup

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -42,6 +42,9 @@ import (
 	apiagent "github.com/juju/juju/state/api/agent"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/apiserver"
+	coretools "github.com/juju/juju/tools"
+	"github.com/juju/juju/upgrades"
+	"github.com/juju/juju/upstart"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -286,6 +289,13 @@ func (a *MachineAgent) APIWorker() (worker.Worker, error) {
 			}
 			break
 		}
+	}
+
+	// Before starting any workers, ensure we record the Juju version this machine
+	// agent is running.
+	currentTools := &coretools.Tools{Version: version.Current}
+	if err := st.Upgrader().SetVersion(agentConfig.Tag(), currentTools.Version); err != nil {
+		return nil, errors.Annotate(err, "cannot set machine agent version")
 	}
 
 	providerType := agentConfig.Value(agent.ProviderType)

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -86,7 +86,7 @@ func (cs *ContainerSetup) Handle(containerIds []string) (resultError error) {
 		return nil
 	}
 
-	logger.Tracef("initial container setup with ids: %v", containerIds)
+	logger.Infof("initial container setup with ids: %v", containerIds)
 	for _, id := range containerIds {
 		containerType := state.ContainerTypeFromId(id)
 		// If this container type has been dealt with, do nothing.
@@ -119,12 +119,6 @@ func (cs *ContainerSetup) initialiseAndStartProvisioner(containerType instance.C
 		}
 	}
 
-	// We only care about the initial container creation.
-	// This worker has done its job so stop it.
-	// We do not expect there will be an error, and there's not much we can do anyway.
-	if err := cs.runner.StopWorker(cs.workerName); err != nil {
-		logger.Warningf("stopping machine agent container watcher: %v", err)
-	}
 	if initialiser, broker, err := cs.getContainerArtifacts(containerType); err != nil {
 		return fmt.Errorf("initialising container infrastructure on host machine: %v", err)
 	} else {

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -104,11 +104,6 @@ func allowedTargetVersion(
 }
 
 func (u *Upgrader) loop() error {
-	currentTools := &coretools.Tools{Version: version.Current}
-	err := u.st.SetVersion(u.tag.String(), currentTools.Version)
-	if err != nil {
-		return err
-	}
 	versionWatcher, err := u.st.WatchAPIVersion(u.tag.String())
 	if err != nil {
 		return err
@@ -142,7 +137,7 @@ func (u *Upgrader) loop() error {
 		case <-dying:
 			return nil
 		}
-		if wantVersion == currentTools.Version.Number {
+		if wantVersion == version.Current.Number {
 			continue
 		} else if !allowedTargetVersion(u.origAgentVersion, version.Current.Number,
 			u.isUpgradeRunning(), wantVersion) {
@@ -155,7 +150,7 @@ func (u *Upgrader) loop() error {
 				wantVersion, version.Current)
 			continue
 		}
-		logger.Infof("upgrade requested from %v to %v", currentTools.Version, wantVersion)
+		logger.Infof("upgrade requested from %v to %v", version.Current, wantVersion)
 
 		// Check if tools have already been downloaded.
 		wantVersionBinary := toBinaryVersion(wantVersion)


### PR DESCRIPTION
Set a machine's tools version when the agent starts

Fixes: https://bugs.launchpad.net/juju-core/+bug/1359800

The referenced bug shows an error initialising container support when a machine's agent starts up.

2014-08-20 22:06:07 ERROR juju.provisioner container_initialisation.go:154 cannot get tools from machine for lxc container
2014-08-20 22:06:07 ERROR juju.provisioner container_initialisation.go:95 starting container provisioner for lxc: initialising container infrastructure on host machine: agent tools for machine 5 not found
2014-08-20 22:06:07 ERROR juju.worker runner.go:218 exited "5-container-watcher": initialising container infrastructure on host machine: agent tools for machine 5 not found

The only way I can see that happening is if the container worker starts before the upgrade work sets the tools version. That can happen as both upgrade worker and container worker start up in parallel.

I moved the logic to set the tools version on a machine from the upgrade worker to the agent's APIWorker() method, thus ensuring the tools version is set early before it is needed.

I also found what looks to be bad logic in the container initialisation worker - the code to stop the worker was duplicated and one of the copies was called in the wrong place; it looked like the worker was terminated after the first container type was handled, meaning subsequent container types added to the machine may not have been started properly.
