### PR TITLE
Bump build number when uploading tools during bootstrap

### DIFF
--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -212,7 +212,7 @@ var bootstrapTests = []bootstrapTest{{
 	version:     "1.3.3-saucy-ppc64el",
 	hostArch:    "ppc64el",
 	args:        []string{"--upload-tools", "--constraints", "arch=ppc64el"},
-	upload:      "1.3.3-raring-ppc64el", // from version.Current
+	upload:      "1.3.3.1-raring-ppc64el", // from version.Current
 	constraints: constraints.MustParse("arch=ppc64el"),
 }, {
 	info:     "--upload-tools rejects mismatched arch",
@@ -227,10 +227,10 @@ var bootstrapTests = []bootstrapTest{{
 	args:     []string{"--upload-tools"},
 	err:      `failed to bootstrap environment: environment "peckham" of type dummy does not support instances running on "arm64"`,
 }, {
-	info:    "--upload-tools never bumps build number",
+	info:    "--upload-tools always bumps build number",
 	version: "1.2.3.4-raring-amd64",
 	args:    []string{"--upload-tools"},
-	upload:  "1.2.3.4-raring-amd64",
+	upload:  "1.2.3.5-raring-amd64",
 }, {
 	info:      "placement",
 	args:      []string{"--to", "something"},
@@ -506,7 +506,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	c.Check((<-opc).(dummy.OpBootstrap).Env, gc.Equals, "peckham")
 	mcfg := (<-opc).(dummy.OpFinalizeBootstrap).MachineConfig
 	c.Assert(mcfg, gc.NotNil)
-	c.Assert(mcfg.Tools.Version.String(), gc.Equals, "1.7.3-raring-"+version.Current.Arch)
+	c.Assert(mcfg.Tools.Version.String(), gc.Equals, "1.7.3.1-raring-"+version.Current.Arch)
 }
 
 func (s *BootstrapSuite) TestAutoUploadOnlyForDev(c *gc.C) {
@@ -538,7 +538,7 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 	c.Check(coretesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
 Bootstrapping environment "peckham"
 Starting new instance for initial state server
-Building tools to upload (1.7.3-raring-%s)
+Building tools to upload (1.7.3.1-raring-%s)
 `[1:], version.Current.Arch))
 	c.Check(err, gc.ErrorMatches, "failed to bootstrap environment: cannot upload bootstrap tools: an error")
 }

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -77,10 +77,10 @@ func findAvailableTools(env environs.Environ, arch *string, upload bool) (coreto
 		return nil, findToolsErr
 	}
 
-	if !dev || (vers != nil && version.Current.Number != *vers) {
-		// We are not running a development build, or the target
-		// version does not match the local version; the only tools
-		// available are the ones we've just found.
+	if !dev || vers != nil {
+		// We are not running a development build, or agent-version
+		// was specified; the only tools available are the ones we've
+		// just found.
 		return toolsList, findToolsErr
 	}
 	// The tools located may not include the ones that the
@@ -117,6 +117,8 @@ func locallyBuildableTools() (buildable coretools.List) {
 		}
 		binary := version.Current
 		binary.Series = series
+		// Increment the build number so we know it's a development build.
+		binary.Build++
 		buildable = append(buildable, &coretools.Tools{Version: binary})
 	}
 	return buildable

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -156,8 +156,10 @@ func (s *toolsSuite) TestFindAvailableToolsForceUpload(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(uploadedTools, gc.Not(gc.HasLen), 0)
 	c.Assert(findToolsCalled, gc.Equals, 0)
+	expectedVersion := version.Current.Number
+	expectedVersion.Build++
 	for _, tools := range uploadedTools {
-		c.Assert(tools.Version.Number, gc.Equals, version.Current.Number)
+		c.Assert(tools.Version.Number, gc.Equals, expectedVersion)
 		c.Assert(tools.URL, gc.Equals, "")
 	}
 }
@@ -195,11 +197,13 @@ func (s *toolsSuite) TestFindAvailableToolsAutoUpload(c *gc.C) {
 	c.Assert(len(availableTools), jc.GreaterThan, 1)
 	c.Assert(env.supportedArchitecturesCount, gc.Equals, 1)
 	var trustyToolsFound int
+	expectedVersion := version.Current.Number
+	expectedVersion.Build++
 	for _, tools := range availableTools {
 		if tools == trustyTools {
 			trustyToolsFound++
 		} else {
-			c.Assert(tools.Version.Number, gc.Equals, version.Current.Number)
+			c.Assert(tools.Version.Number, gc.Equals, expectedVersion)
 			c.Assert(tools.Version.Series, gc.Not(gc.Equals), "trusty")
 			c.Assert(tools.URL, gc.Equals, "")
 		}


### PR DESCRIPTION
CI was broken due to expectations of build number
being bumped when we upload tools for bootstrap.
Bumping the build number also makes it more straightforward
to identify tools that have been uploaded vs. official ones.
