### PR TITLE
Rework auth checks for gccgo.

### DIFF
--- a/state/apiserver/deployer/deployer.go
+++ b/state/apiserver/deployer/deployer.go
@@ -49,14 +49,10 @@ func NewDeployerAPI(
 		}
 		// Then we just check if the unit is already known.
 		return func(tag names.Tag) bool {
-			// gcc has horrible problems comparing types and interfaces
-			// so convert to concrete types.
-			utag, ok := tag.(names.UnitTag)
-			if !ok {
-				return false
-			}
 			for _, unit := range units {
-				if names.NewUnitTag(unit) == utag {
+				// TODO (thumper): remove the names.Tag conversion when gccgo
+				// implements concrete-type-to-interface comparison correctly.
+				if names.Tag(names.NewUnitTag(unit)) == tag {
 					return true
 				}
 			}

--- a/state/apiserver/networker/networker.go
+++ b/state/apiserver/networker/networker.go
@@ -52,18 +52,13 @@ func NewNetworkerAPI(
 				// Only machine tags are allowed.
 				return false
 			}
-
-			// gcc has horrible problems comparing types and interfaces
-			// so convert to concrete types.
-			authMachine, ok := authEntityTag.(names.MachineTag)
-			if !ok {
-				// the auth tag should always be a machine...
-				return false
-			}
 			id := tag.Id()
 			for parentId := state.ParentId(id); parentId != ""; parentId = state.ParentId(parentId) {
 				// Until a top-level machine is reached.
-				if names.NewMachineTag(parentId) == authMachine {
+
+				// TODO (thumper): remove the names.Tag conversion when gccgo
+				// implements concrete-type-to-interface comparison correctly.
+				if names.Tag(names.NewMachineTag(parentId)) == authEntityTag {
 					// All containers with the authenticated machine as a
 					// parent are accessible by it.
 					return true


### PR DESCRIPTION
gccgo has problems comparing concrete types and interfaces. I'm betting it is actually only interfaces implemented by non-pointer types, but hey, I'm not a compiler writer.\

Reworks the auth checks.
