### PR TITLE
Introduce and use FindTools provisioner API

### DIFF
--- a/cmd/juju/synctools.go
+++ b/cmd/juju/synctools.go
@@ -86,7 +86,7 @@ func (c *SyncToolsCommand) Init(args []string) error {
 // syncToolsAPI provides an interface with a subset of the
 // state/api.Client API. This exists to enable mocking.
 type syncToolsAPI interface {
-	FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResults, error)
+	FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error)
 	UploadTools(r io.Reader, v version.Binary) (*coretools.Tools, error)
 	Close() error
 }

--- a/cmd/juju/synctools_test.go
+++ b/cmd/juju/synctools_test.go
@@ -202,13 +202,13 @@ func (s *syncToolsSuite) TestAPIAdapterFindTools(c *gc.C) {
 	var called bool
 	result := coretools.List{&coretools.Tools{}}
 	fake := fakeSyncToolsAPI{
-		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResults, error) {
+		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
 			called = true
 			c.Assert(majorVersion, gc.Equals, 2)
 			c.Assert(minorVersion, gc.Equals, -1)
 			c.Assert(series, gc.Equals, "")
 			c.Assert(arch, gc.Equals, "")
-			return params.FindToolsResults{List: result}, nil
+			return params.FindToolsResult{List: result}, nil
 		},
 	}
 	a := syncToolsAPIAdapter{&fake}
@@ -220,9 +220,9 @@ func (s *syncToolsSuite) TestAPIAdapterFindTools(c *gc.C) {
 
 func (s *syncToolsSuite) TestAPIAdapterFindToolsNotFound(c *gc.C) {
 	fake := fakeSyncToolsAPI{
-		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResults, error) {
+		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
 			err := common.ServerError(errors.NotFoundf("tools"))
-			return params.FindToolsResults{Error: err}, nil
+			return params.FindToolsResult{Error: err}, nil
 		},
 	}
 	a := syncToolsAPIAdapter{&fake}
@@ -234,8 +234,8 @@ func (s *syncToolsSuite) TestAPIAdapterFindToolsNotFound(c *gc.C) {
 func (s *syncToolsSuite) TestAPIAdapterFindToolsAPIError(c *gc.C) {
 	findToolsErr := common.ServerError(errors.NotFoundf("tools"))
 	fake := fakeSyncToolsAPI{
-		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResults, error) {
-			return params.FindToolsResults{Error: findToolsErr}, findToolsErr
+		findTools: func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
+			return params.FindToolsResult{Error: findToolsErr}, findToolsErr
 		},
 	}
 	a := syncToolsAPIAdapter{&fake}
@@ -261,11 +261,11 @@ func (s *syncToolsSuite) TestAPIAdapterUploadTools(c *gc.C) {
 }
 
 type fakeSyncToolsAPI struct {
-	findTools   func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResults, error)
+	findTools   func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error)
 	uploadTools func(r io.Reader, v version.Binary) (*coretools.Tools, error)
 }
 
-func (f *fakeSyncToolsAPI) FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResults, error) {
+func (f *fakeSyncToolsAPI) FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
 	return f.findTools(majorVersion, minorVersion, series, arch)
 }
 

--- a/state/api/client.go
+++ b/state/api/client.go
@@ -570,9 +570,10 @@ func (c *Client) SetEnvironAgentVersion(version version.Number) error {
 }
 
 // FindTools returns a List containing all tools matching the specified parameters.
-func (c *Client) FindTools(majorVersion, minorVersion int,
-	series, arch string) (result params.FindToolsResults, err error) {
-
+func (c *Client) FindTools(
+	majorVersion, minorVersion int,
+	series, arch string,
+) (result params.FindToolsResult, err error) {
 	args := params.FindToolsParams{
 		MajorVersion: majorVersion,
 		MinorVersion: minorVersion,

--- a/state/api/params/internal.go
+++ b/state/api/params/internal.go
@@ -506,20 +506,6 @@ type ToolsResults struct {
 	Results []ToolsResult
 }
 
-// FindToolsParams defines parameters for the FindTools method.
-type FindToolsParams struct {
-	MajorVersion int
-	MinorVersion int
-	Arch         string
-	Series       string
-}
-
-// FindToolsResults holds a list of tools from FindTools and any error.
-type FindToolsResults struct {
-	List  tools.List
-	Error *Error
-}
-
 // Version holds a specific binary version.
 type Version struct {
 	Version version.Binary

--- a/state/api/params/params.go
+++ b/state/api/params/params.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/tools"
 	"github.com/juju/juju/utils/ssh"
 	"github.com/juju/juju/version"
 )
@@ -776,4 +777,29 @@ type StateServersChanges struct {
 	Removed    []string `json:removed,omitempty`
 	Promoted   []string `json:promoted,omitempty`
 	Demoted    []string `json:demoted,omitempty`
+}
+
+// FindToolsParams defines parameters for the FindTools method.
+type FindToolsParams struct {
+	// Number will be used to match tools versions exactly if non-zero.
+	Number version.Number
+
+	// MajorVersion will be used to match the major version if non-zero.
+	MajorVersion int
+
+	// MinorVersion will be used to match the major version if greater
+	// than or equal to zero, and Number is zero.
+	MinorVersion int
+
+	// Arch will be used to match tools by architecture if non-empty.
+	Arch string
+
+	// Series will be used to match tools by series if non-empty.
+	Series string
+}
+
+// FindToolsResult holds a list of tools from FindTools and any error.
+type FindToolsResult struct {
+	List  tools.List
+	Error *Error
 }

--- a/state/apiserver/client/client.go
+++ b/state/apiserver/client/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
-	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/network"
@@ -26,7 +25,6 @@ import (
 	"github.com/juju/juju/state/api"
 	"github.com/juju/juju/state/api/params"
 	"github.com/juju/juju/state/apiserver/common"
-	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
 
@@ -906,24 +904,8 @@ func (c *Client) SetEnvironAgentVersion(args params.SetEnvironAgentVersion) erro
 }
 
 // FindTools returns a List containing all tools matching the given parameters.
-func (c *Client) FindTools(args params.FindToolsParams) (params.FindToolsResults, error) {
-	result := params.FindToolsResults{}
-	// Get the existing environment config from the state.
-	envConfig, err := c.api.state.EnvironConfig()
-	if err != nil {
-		return result, err
-	}
-	env, err := environs.New(envConfig)
-	if err != nil {
-		return result, err
-	}
-	filter := coretools.Filter{
-		Arch:   args.Arch,
-		Series: args.Series,
-	}
-	result.List, err = envtools.FindTools(env, args.MajorVersion, args.MinorVersion, filter, envtools.DoNotAllowRetry)
-	result.Error = common.ServerError(err)
-	return result, nil
+func (c *Client) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
+	return common.FindTools(c.api.state, args)
 }
 
 func destroyErr(desc string, ids, errs []string) error {

--- a/state/apiserver/common/export_test.go
+++ b/state/apiserver/common/export_test.go
@@ -7,6 +7,7 @@ var (
 	ValidateNewFacade = validateNewFacade
 	WrapNewFacade     = wrapNewFacade
 	NilFacadeRecord   = facadeRecord{}
+	EnvtoolsFindTools = &envtoolsFindTools
 )
 
 type Patcher interface {

--- a/state/apiserver/provisioner/provisioner.go
+++ b/state/apiserver/provisioner/provisioner.go
@@ -31,7 +31,6 @@ type ProvisionerAPI struct {
 	*common.LifeGetter
 	*common.StateAddresser
 	*common.APIAddresser
-	*common.ToolsGetter
 	*common.EnvironWatcher
 	*common.EnvironMachinesWatcher
 	*common.InstanceIdGetter
@@ -84,7 +83,6 @@ func NewProvisionerAPI(st *state.State, resources *common.Resources, authorizer 
 		LifeGetter:             common.NewLifeGetter(st, getAuthFunc),
 		StateAddresser:         common.NewStateAddresser(st),
 		APIAddresser:           common.NewAPIAddresser(st, resources),
-		ToolsGetter:            common.NewToolsGetter(st, getAuthFunc),
 		EnvironWatcher:         common.NewEnvironWatcher(st, resources, authorizer),
 		EnvironMachinesWatcher: common.NewEnvironMachinesWatcher(st, resources, authorizer),
 		InstanceIdGetter:       common.NewInstanceIdGetter(st, getAuthFunc),
@@ -645,4 +643,9 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 		return result, watcher.MustErr(watch)
 	}
 	return result, nil
+}
+
+// FindTools returns a List containing all tools matching the given parameters.
+func (p *ProvisionerAPI) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
+	return common.FindTools(p.st, args)
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -18,8 +18,3 @@ type Tools struct {
 	SHA256  string         `json:"sha256,omitempty"`
 	Size    int64          `json:"size"`
 }
-
-// HasTools instances can be asked for a tools list.
-type HasTools interface {
-	Tools(series string) List
-}

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	"github.com/juju/utils/fslock"
 
 	"github.com/juju/juju/agent"
@@ -153,19 +152,6 @@ func (cs *ContainerSetup) TearDown() error {
 }
 
 func (cs *ContainerSetup) getContainerArtifacts(containerType instance.ContainerType) (container.Initialiser, environs.InstanceBroker, error) {
-	logger.Debugf("finding tools for %s containers", containerType)
-	tag := cs.config.Tag()
-	machineTag, ok := tag.(names.MachineTag)
-	if !ok {
-		return nil, nil, errors.Errorf("expected names.MachineTag, got %T", tag)
-	}
-	// TODO(fwereade): 2014-07-24 bug 1347984
-	// This may give us a subtly incorrect version. See bug for details.
-	tools, err := cs.provisioner.Tools(machineTag)
-	if err != nil {
-		logger.Errorf("cannot get tools from machine for %s container", containerType)
-		return nil, nil, err
-	}
 	var initialiser container.Initialiser
 	var broker environs.InstanceBroker
 
@@ -182,13 +168,13 @@ func (cs *ContainerSetup) getContainerArtifacts(containerType instance.Container
 		}
 
 		initialiser = lxc.NewContainerInitialiser(series)
-		broker, err = NewLxcBroker(cs.provisioner, tools, cs.config, managerConfig)
+		broker, err = NewLxcBroker(cs.provisioner, cs.config, managerConfig)
 		if err != nil {
 			return nil, nil, err
 		}
 	case instance.KVM:
 		initialiser = kvm.NewContainerInitialiser()
-		broker, err = NewKvmBroker(cs.provisioner, tools, cs.config, managerConfig)
+		broker, err = NewKvmBroker(cs.provisioner, cs.config, managerConfig)
 		if err != nil {
 			logger.Errorf("failed to create new kvm broker")
 			return nil, nil, err

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -19,4 +19,7 @@ func GetRetryWatcher(p Provisioner) (watcher.NotifyWatcher, error) {
 	return p.getRetryWatcher()
 }
 
-var ContainerManagerConfig = containerManagerConfig
+var (
+	ContainerManagerConfig = containerManagerConfig
+	GetToolsFinder         = &getToolsFinder
+)

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -14,17 +14,14 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/tools"
 )
 
 var kvmLogger = loggo.GetLogger("juju.provisioner.kvm")
 
 var _ environs.InstanceBroker = (*kvmBroker)(nil)
-var _ tools.HasTools = (*kvmBroker)(nil)
 
 func NewKvmBroker(
 	api APICalls,
-	tools *tools.Tools,
 	agentConfig agent.Config,
 	managerConfig container.ManagerConfig,
 ) (environs.InstanceBroker, error) {
@@ -35,7 +32,6 @@ func NewKvmBroker(
 	return &kvmBroker{
 		manager:     manager,
 		api:         api,
-		tools:       tools,
 		agentConfig: agentConfig,
 	}, nil
 }
@@ -43,16 +39,7 @@ func NewKvmBroker(
 type kvmBroker struct {
 	manager     container.Manager
 	api         APICalls
-	tools       *tools.Tools
 	agentConfig agent.Config
-}
-
-func (broker *kvmBroker) Tools(series string) tools.List {
-	// TODO: thumper 2014-04-08 bug 1304151
-	// should use the api get get tools for the series.
-	seriesTools := *broker.tools
-	seriesTools.Version.Series = series
-	return tools.List{&seriesTools}
 }
 
 // StartInstance is specified in the Broker interface.
@@ -73,7 +60,6 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (insta
 	}
 	network := container.BridgeNetworkConfig(bridgeDevice)
 
-	// TODO: series doesn't necessarily need to be the same as the host.
 	series := args.Tools.OneSeries()
 	args.MachineConfig.MachineContainerType = instance.KVM
 	args.MachineConfig.Tools = args.Tools[0]

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -65,10 +65,6 @@ func (s *kvmSuite) TearDownTest(c *gc.C) {
 
 func (s *kvmBrokerSuite) SetUpTest(c *gc.C) {
 	s.kvmSuite.SetUpTest(c)
-	tools := &coretools.Tools{
-		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
-		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
-	}
 	var err error
 	s.agentConfig, err = agent.NewAgentConfig(
 		agent.AgentConfigParams{
@@ -82,7 +78,7 @@ func (s *kvmBrokerSuite) SetUpTest(c *gc.C) {
 		})
 	c.Assert(err, gc.IsNil)
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, tools, s.agentConfig, managerConfig)
+	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, s.agentConfig, managerConfig)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -93,7 +89,10 @@ func (s *kvmBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", nil, stateInfo, apiInfo)
 	c.Assert(err, gc.IsNil)
 	cons := constraints.Value{}
-	possibleTools := s.broker.(coretools.HasTools).Tools("precise")
+	possibleTools := coretools.List{&coretools.Tools{
+		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+	}}
 	kvm, _, _, err := s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:   cons,
 		Tools:         possibleTools,
@@ -212,10 +211,8 @@ func (s *kvmProvisionerSuite) TearDownTest(c *gc.C) {
 func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner {
 	machineTag := names.NewMachineTag("0")
 	agentConfig := s.AgentConfigForTag(c, machineTag)
-	tools, err := s.provisioner.Tools(agentConfig.Tag().(names.MachineTag))
-	c.Assert(err, gc.IsNil)
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	broker, err := provisioner.NewKvmBroker(s.provisioner, tools, agentConfig, managerConfig)
+	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig)
 	c.Assert(err, gc.IsNil)
 	return provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker)
 }

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -15,19 +15,17 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/api/params"
-	"github.com/juju/juju/tools"
 )
 
 var lxcLogger = loggo.GetLogger("juju.provisioner.lxc")
 
 var _ environs.InstanceBroker = (*lxcBroker)(nil)
-var _ tools.HasTools = (*lxcBroker)(nil)
 
 type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
 }
 
-func NewLxcBroker(api APICalls, tools *tools.Tools, agentConfig agent.Config, managerConfig container.ManagerConfig) (environs.InstanceBroker, error) {
+func NewLxcBroker(api APICalls, agentConfig agent.Config, managerConfig container.ManagerConfig) (environs.InstanceBroker, error) {
 	manager, err := lxc.NewContainerManager(managerConfig)
 	if err != nil {
 		return nil, err
@@ -35,7 +33,6 @@ func NewLxcBroker(api APICalls, tools *tools.Tools, agentConfig agent.Config, ma
 	return &lxcBroker{
 		manager:     manager,
 		api:         api,
-		tools:       tools,
 		agentConfig: agentConfig,
 	}, nil
 }
@@ -43,16 +40,7 @@ func NewLxcBroker(api APICalls, tools *tools.Tools, agentConfig agent.Config, ma
 type lxcBroker struct {
 	manager     container.Manager
 	api         APICalls
-	tools       *tools.Tools
 	agentConfig agent.Config
-}
-
-func (broker *lxcBroker) Tools(series string) tools.List {
-	// TODO: thumper 2014-04-08 bug 1304151
-	// should use the api get get tools for the series.
-	seriesTools := *broker.tools
-	seriesTools.Version.Series = series
-	return tools.List{&seriesTools}
 }
 
 // StartInstance is specified in the Broker interface.

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -100,6 +100,12 @@ func (p *provisioner) Stop() error {
 	return p.tomb.Wait()
 }
 
+// getToolsFinder returns a ToolsFinder for the provided State.
+// This exists for mocking.
+var getToolsFinder = func(st *apiprovisioner.State) ToolsFinder {
+	return st
+}
+
 // getStartTask creates a new worker for the provisioner,
 func (p *provisioner) getStartTask(safeMode bool) (ProvisionerTask, error) {
 	auth, err := authentication.NewAPIAuthenticator(p.st)
@@ -131,6 +137,7 @@ func (p *provisioner) getStartTask(safeMode bool) (ProvisionerTask, error) {
 		machineTag,
 		safeMode,
 		p.st,
+		getToolsFinder(p.st),
 		machineWatcher,
 		retryWatcher,
 		p.broker,


### PR DESCRIPTION
We introduce a new FindTools API in the
provisioner facade, and move the existing
client FindTools API implementation into
the apiserver/common package. The provisioner
worker is updated to use this API instead
of going directly to provider storage (via
environs/tools.FindTools).

There are a couple of bugs already that require
this to be done, but now that we're moving tools
storage behind the API server it is imperative.

Fixes https://bugs.launchpad.net/bugs/1347984
Fixes https://bugs.launchpad.net/bugs/1304151
