### PR TITLE
worker/uniter: use LongWait in waitHooks

### DIFF
--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1949,7 +1949,7 @@ func (s waitHooks) step(c *gc.C, ctx *context) {
 	for {
 		ctx.s.BackingState.StartSync()
 		select {
-		case <-time.After(coretesting.ShortWait):
+		case <-time.After(coretesting.LongWait):
 			if match, _ = ctx.matchHooks(c); match {
 				return
 			}


### PR DESCRIPTION
waitHooks is waiting for an expected event,
which should be using LongWait according to
testing/constants.go.

Fixes https://bugs.launchpad.net/juju-core/+bug/1363002
