### PR TITLE
provider/manual: default enable-os-refresh-update to true

### DIFF
--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -138,15 +138,6 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 		if err := environs.FinishMachineConfig(mcfg, e.Config()); err != nil {
 			return err
 		}
-		// If the tools are on the machine already, get a file:// scheme tools URL.
-		// TODO(axw) this can go once environs/bootstrap.Bootstrap takes care of
-		// serialising tools through cloudconfig/sshinit.
-		storageDir := e.StorageDir()
-		toolsStorageName := envtools.StorageName(mcfg.Tools.Version)
-		bootstrapStorage := e.Storage()
-		if url, _ := bootstrapStorage.URL(toolsStorageName); url == mcfg.Tools.URL {
-			mcfg.Tools.URL = fmt.Sprintf("file://%s/%s", storageDir, toolsStorageName)
-		}
 		for k, v := range agentEnv {
 			mcfg.AgentEnvironment[k] = v
 		}

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -144,9 +144,9 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 		}
 	}
 
-	// If the user hasn't specified a value, don't perform updates on
-	// manual providers.
-	defineIfNot("enable-os-refresh-update", false)
+	// If the user hasn't specified a value, refresh the
+	// available updates, but don't upgrade.
+	defineIfNot("enable-os-refresh-update", true)
 	defineIfNot("enable-os-upgrade", false)
 
 	return envConfig, nil

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -112,8 +112,9 @@ func (s *providerSuite) TestDisablesUpdatesByDefault(c *gc.C) {
 	validCfg, err := p.Validate(testConfig, nil)
 	c.Assert(err, gc.IsNil)
 
-	// Unless specified, updates should default to false.
-	c.Check(validCfg.EnableOSRefreshUpdate(), gc.Equals, false)
+	// Unless specified, update should default to true,
+	// upgrade to false.
+	c.Check(validCfg.EnableOSRefreshUpdate(), gc.Equals, true)
 	c.Check(validCfg.EnableOSUpgrade(), gc.Equals, false)
 }
 


### PR DESCRIPTION
The manual provider should be doing "apt-get update" and
installing packages by default.

Fixes https://bugs.launchpad.net/juju-core/+bug/1363130
