### PR TITLE
mongo: move MongoInfo type

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/cloudinit"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -120,7 +119,7 @@ type Config interface {
 
 	// MongoInfo returns details for connecting to the state server's mongo
 	// database and reports whether those details are available
-	MongoInfo() (*authentication.MongoInfo, bool)
+	MongoInfo() (*mongo.MongoInfo, bool)
 
 	// OldPassword returns the fallback password when connecting to the
 	// API server.
@@ -666,7 +665,7 @@ func (c *configInternal) APIInfo() *api.Info {
 	}
 }
 
-func (c *configInternal) MongoInfo() (info *authentication.MongoInfo, ok bool) {
+func (c *configInternal) MongoInfo() (info *mongo.MongoInfo, ok bool) {
 	ssi, ok := c.StateServingInfo()
 	if !ok {
 		return nil, false
@@ -675,7 +674,7 @@ func (c *configInternal) MongoInfo() (info *authentication.MongoInfo, ok bool) {
 	if c.preferIPv6 {
 		addr = net.JoinHostPort("::1", strconv.Itoa(ssi.StatePort))
 	}
-	return &authentication.MongoInfo{
+	return &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{addr},
 			CACert: c.caCert,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -12,7 +12,6 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/api"
@@ -610,7 +609,7 @@ func (*suite) TestSetPassword(c *gc.C) {
 	}
 	c.Assert(conf.APIInfo(), jc.DeepEquals, expectAPIInfo)
 	addr := fmt.Sprintf("127.0.0.1:%d", servingInfo.StatePort)
-	expectStateInfo := &authentication.MongoInfo{
+	expectStateInfo := &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{addr},
 			CACert: attrParams.CACert,

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -226,7 +225,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 }
 
 func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, password string) {
-	info := &authentication.MongoInfo{
+	info := &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{s.mgoInst.Addr()},
 			CACert: testing.CACert,

--- a/cmd/jujud/agent_test.go
+++ b/cmd/jujud/agent_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
@@ -344,7 +343,7 @@ func parseHostPort(s string) (network.HostPort, error) {
 }
 
 // writeStateAgentConfig creates and writes a state agent config.
-func writeStateAgentConfig(c *gc.C, stateInfo *authentication.MongoInfo, dataDir string, tag names.Tag, password string, vers version.Binary) agent.ConfigSetterWriter {
+func writeStateAgentConfig(c *gc.C, stateInfo *mongo.MongoInfo, dataDir string, tag names.Tag, password string, vers version.Binary) agent.ConfigSetterWriter {
 	port := gitjujutesting.FindTCPPort()
 	apiAddr := []string{fmt.Sprintf("localhost:%d", port)}
 	conf, err := agent.NewStateMachineConfig(

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
@@ -221,7 +220,7 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	c.Assert(s.fakeEnsureMongo.initiateParams.User, gc.Equals, "")
 	c.Assert(s.fakeEnsureMongo.initiateParams.Password, gc.Equals, "")
 
-	st, err := state.Open(&authentication.MongoInfo{
+	st, err := state.Open(&mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -272,7 +271,7 @@ func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, gc.IsNil)
 
-	st, err := state.Open(&authentication.MongoInfo{
+	st, err := state.Open(&mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -306,7 +305,7 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, gc.IsNil)
 
-	st, err := state.Open(&authentication.MongoInfo{
+	st, err := state.Open(&mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -327,7 +326,7 @@ func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, gc.IsNil)
 
-	st, err := state.Open(&authentication.MongoInfo{
+	st, err := state.Open(&mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -341,7 +340,7 @@ func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageEnviron})
 }
 
-func testOpenState(c *gc.C, info *authentication.MongoInfo, expectErrType error) {
+func testOpenState(c *gc.C, info *mongo.MongoInfo, expectErrType error) {
 	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	if st != nil {
 		st.Close()
@@ -360,7 +359,7 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, gc.IsNil)
 
-	info := &authentication.MongoInfo{
+	info := &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,

--- a/environmentserver/authentication/authentication.go
+++ b/environmentserver/authentication/authentication.go
@@ -14,20 +14,6 @@ import (
 	apiprovisioner "github.com/juju/juju/state/api/provisioner"
 )
 
-// MongoInfo encapsulates information about cluster of
-// servers holding juju state and can be used to make a
-// connection to that cluster.
-type MongoInfo struct {
-	// mongo.Info contains the addresses and cert of the mongo cluster.
-	mongo.Info
-	// Tag holds the name of the entity that is connecting.
-	// It should be nil when connecting as an administrator.
-	Tag names.Tag
-
-	// Password holds the password for the connecting entity.
-	Password string
-}
-
 // TaggedPasswordChanger defines an interface for a entity with a
 // Tag() and SetPassword() methods.
 type TaggedPasswordChanger interface {
@@ -36,7 +22,7 @@ type TaggedPasswordChanger interface {
 }
 
 // NewAuthenticator returns a simpleAuth populated with connectionInfo and apiInfo
-func NewAuthenticator(connectionInfo *MongoInfo, apiInfo *api.Info) AuthenticationProvider {
+func NewAuthenticator(connectionInfo *mongo.MongoInfo, apiInfo *api.Info) AuthenticationProvider {
 	return &simpleAuth{
 		stateInfo: connectionInfo,
 		apiInfo:   apiInfo,
@@ -46,7 +32,7 @@ func NewAuthenticator(connectionInfo *MongoInfo, apiInfo *api.Info) Authenticati
 // AuthenticationProvider defines the single method that the provisioner
 // task needs to set up authentication for a machine.
 type AuthenticationProvider interface {
-	SetupAuthentication(machine TaggedPasswordChanger) (*MongoInfo, *api.Info, error)
+	SetupAuthentication(machine TaggedPasswordChanger) (*mongo.MongoInfo, *api.Info, error)
 }
 
 // NewAPIAuthenticator gets the state and api info once from the
@@ -64,7 +50,7 @@ func NewAPIAuthenticator(st *apiprovisioner.State) (AuthenticationProvider, erro
 	if err != nil {
 		return nil, err
 	}
-	stateInfo := &MongoInfo{
+	stateInfo := &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  stateAddresses,
 			CACert: caCert,
@@ -78,11 +64,11 @@ func NewAPIAuthenticator(st *apiprovisioner.State) (AuthenticationProvider, erro
 }
 
 type simpleAuth struct {
-	stateInfo *MongoInfo
+	stateInfo *mongo.MongoInfo
 	apiInfo   *api.Info
 }
 
-func (auth *simpleAuth) SetupAuthentication(machine TaggedPasswordChanger) (*MongoInfo, *api.Info, error) {
+func (auth *simpleAuth) SetupAuthentication(machine TaggedPasswordChanger) (*mongo.MongoInfo, *api.Info, error) {
 	password, err := utils.RandomPassword()
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot make password for machine %v: %v", machine, err)

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/agent"
 	coreCloudinit "github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/paths"
@@ -43,7 +42,7 @@ func NewMachineConfig(
 	imageStream,
 	series string,
 	networks []string,
-	mongoInfo *authentication.MongoInfo,
+	mongoInfo *mongo.MongoInfo,
 	apiInfo *api.Info,
 ) (*cloudinit.MachineConfig, error) {
 	dataDir, err := paths.DataDir(series)
@@ -169,7 +168,7 @@ func FinishMachineConfig(mcfg *cloudinit.MachineConfig, cfg *config.Config) (err
 	}
 	passwordHash := utils.UserPasswordHash(password, utils.CompatSalt)
 	mcfg.APIInfo = &api.Info{Password: passwordHash, CACert: caCert}
-	mcfg.MongoInfo = &authentication.MongoInfo{Password: passwordHash, Info: mongo.Info{CACert: caCert}}
+	mcfg.MongoInfo = &mongo.MongoInfo{Password: passwordHash, Info: mongo.Info{CACert: caCert}}
 
 	// These really are directly relevant to running a state server.
 	cert, key, err := cfg.GenerateStateServerCertAndKey()

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -21,9 +21,9 @@ import (
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/api"
 	"github.com/juju/juju/state/api/params"
 	coretools "github.com/juju/juju/tools"
@@ -51,7 +51,7 @@ type MachineConfig struct {
 	// (StateServer is set), there must be at least one state server address supplied.
 	// The entity name must match that of the machine being started,
 	// or be empty when starting a state server.
-	MongoInfo *authentication.MongoInfo
+	MongoInfo *mongo.MongoInfo
 
 	// APIInfo holds the means for the new instance to communicate with the
 	// juju state API. Unless the new machine is running a state server (StateServer is

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/agent"
 	coreCloudinit "github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/environs/config"
@@ -73,7 +72,7 @@ func minimalMachineConfig(tweakers ...func(cloudinit.MachineConfig)) cloudinit.M
 		Bootstrap:        true,
 		StateServingInfo: stateServingInfo,
 		MachineNonce:     "FAKE_NONCE",
-		MongoInfo: &authentication.MongoInfo{
+		MongoInfo: &mongo.MongoInfo{
 			Password: "arble",
 			Info: mongo.Info{
 				CACert: "CA CERT\n" + testing.CACert,
@@ -176,7 +175,7 @@ var cloudinitTests = []cloudinitTest{
 			Bootstrap:        true,
 			StateServingInfo: stateServingInfo,
 			MachineNonce:     "FAKE_NONCE",
-			MongoInfo: &authentication.MongoInfo{
+			MongoInfo: &mongo.MongoInfo{
 				Password: "arble",
 				Info: mongo.Info{
 					CACert: "CA CERT\n" + testing.CACert,
@@ -239,7 +238,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
 			Bootstrap:        true,
 			StateServingInfo: stateServingInfo,
 			MachineNonce:     "FAKE_NONCE",
-			MongoInfo: &authentication.MongoInfo{
+			MongoInfo: &mongo.MongoInfo{
 				Password: "arble",
 				Info: mongo.Info{
 					CACert: "CA CERT\n" + testing.CACert,
@@ -284,7 +283,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-raring-amd64\.sha256
 			Tools:              newSimpleTools("1.2.3-quantal-amd64"),
 			Series:             "quantal",
 			MachineNonce:       "FAKE_NONCE",
-			MongoInfo: &authentication.MongoInfo{
+			MongoInfo: &mongo.MongoInfo{
 				Tag:      names.NewMachineTag("99"),
 				Password: "arble",
 				Info: mongo.Info{
@@ -344,7 +343,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 			Tools:                newSimpleTools("1.2.3-quantal-amd64"),
 			Series:               "quantal",
 			MachineNonce:         "FAKE_NONCE",
-			MongoInfo: &authentication.MongoInfo{
+			MongoInfo: &mongo.MongoInfo{
 				Tag:      names.NewMachineTag("2/lxc/1"),
 				Password: "arble",
 				Info: mongo.Info{
@@ -384,7 +383,7 @@ start jujud-machine-2-lxc-1
 			Tools:              newSimpleTools("1.2.3-quantal-amd64"),
 			Series:             "quantal",
 			MachineNonce:       "FAKE_NONCE",
-			MongoInfo: &authentication.MongoInfo{
+			MongoInfo: &mongo.MongoInfo{
 				Tag:      names.NewMachineTag("99"),
 				Password: "arble",
 				Info: mongo.Info{
@@ -418,7 +417,7 @@ aria2c --max-tries=0 --retry-wait=3 --check-certificate=false -d \$bin -o tools\
 			Bootstrap:        true,
 			StateServingInfo: stateServingInfo,
 			MachineNonce:     "FAKE_NONCE",
-			MongoInfo: &authentication.MongoInfo{
+			MongoInfo: &mongo.MongoInfo{
 				Password: "arble",
 				Info: mongo.Info{
 					CACert: "CA CERT\n" + testing.CACert,
@@ -738,7 +737,7 @@ var verifyTests = []struct {
 	}},
 	{"missing state hosts", func(cfg *cloudinit.MachineConfig) {
 		cfg.Bootstrap = false
-		cfg.MongoInfo = &authentication.MongoInfo{
+		cfg.MongoInfo = &mongo.MongoInfo{
 			Tag: names.NewMachineTag("99"),
 			Info: mongo.Info{
 				CACert: testing.CACert,
@@ -752,7 +751,7 @@ var verifyTests = []struct {
 	}},
 	{"missing API hosts", func(cfg *cloudinit.MachineConfig) {
 		cfg.Bootstrap = false
-		cfg.MongoInfo = &authentication.MongoInfo{
+		cfg.MongoInfo = &mongo.MongoInfo{
 			Info: mongo.Info{
 				Addrs:  []string{"foo:35"},
 				CACert: testing.CACert,
@@ -765,11 +764,11 @@ var verifyTests = []struct {
 		}
 	}},
 	{"missing CA certificate", func(cfg *cloudinit.MachineConfig) {
-		cfg.MongoInfo = &authentication.MongoInfo{Info: mongo.Info{Addrs: []string{"host:98765"}}}
+		cfg.MongoInfo = &mongo.MongoInfo{Info: mongo.Info{Addrs: []string{"host:98765"}}}
 	}},
 	{"missing CA certificate", func(cfg *cloudinit.MachineConfig) {
 		cfg.Bootstrap = false
-		cfg.MongoInfo = &authentication.MongoInfo{
+		cfg.MongoInfo = &mongo.MongoInfo{
 			Tag: names.NewMachineTag("99"),
 			Info: mongo.Info{
 				Addrs: []string{"host:98765"},
@@ -876,7 +875,7 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 		AuthorizedKeys:   "sshkey1",
 		Series:           "quantal",
 		AgentEnvironment: map[string]string{agent.ProviderType: "dummy"},
-		MongoInfo: &authentication.MongoInfo{
+		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
 				Addrs:  []string{"host:98765"},
 				CACert: testing.CACert,
@@ -1042,7 +1041,7 @@ var windowsCloudinitTests = []cloudinitTest{
 			Jobs:               normalMachineJobs,
 			MachineNonce:       "FAKE_NONCE",
 			CloudInitOutputLog: cloudInitOutputLog,
-			MongoInfo: &authentication.MongoInfo{
+			MongoInfo: &mongo.MongoInfo{
 				Tag:      names.NewMachineTag("10"),
 				Password: "arble",
 				Info: mongo.Info{

--- a/environs/cloudinit_test.go
+++ b/environs/cloudinit_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cert"
 	coreCloudinit "github.com/juju/juju/cloudinit"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/environs/config"
@@ -66,7 +65,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 			agent.ProviderType:  "dummy",
 			agent.ContainerType: "",
 		},
-		MongoInfo: &authentication.MongoInfo{Tag: userTag},
+		MongoInfo: &mongo.MongoInfo{Tag: userTag},
 		APIInfo:   &api.Info{Tag: userTag},
 		DisableSSLHostnameVerification: false,
 		PreferIPv6:                     true,
@@ -80,7 +79,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	mcfg := &cloudinit.MachineConfig{
-		MongoInfo: &authentication.MongoInfo{Tag: userTag},
+		MongoInfo: &mongo.MongoInfo{Tag: userTag},
 		APIInfo:   &api.Info{Tag: userTag},
 	}
 	err = environs.FinishMachineConfig(mcfg, cfg)
@@ -111,7 +110,7 @@ func (s *CloudInitSuite) TestFinishMachineConfigNonDefault(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, gc.IsNil)
 	mcfg := &cloudinit.MachineConfig{
-		MongoInfo: &authentication.MongoInfo{Tag: userTag},
+		MongoInfo: &mongo.MongoInfo{Tag: userTag},
 		APIInfo:   &api.Info{Tag: userTag},
 	}
 	err = environs.FinishMachineConfig(mcfg, cfg)
@@ -122,7 +121,7 @@ func (s *CloudInitSuite) TestFinishMachineConfigNonDefault(c *gc.C) {
 			agent.ProviderType:  "dummy",
 			agent.ContainerType: "",
 		},
-		MongoInfo: &authentication.MongoInfo{Tag: userTag},
+		MongoInfo: &mongo.MongoInfo{Tag: userTag},
 		APIInfo:   &api.Info{Tag: userTag},
 		DisableSSLHostnameVerification: true,
 		PreferIPv6:                     true,
@@ -152,7 +151,7 @@ func (s *CloudInitSuite) TestFinishBootstrapConfig(c *gc.C) {
 	c.Check(mcfg.APIInfo, gc.DeepEquals, &api.Info{
 		Password: password, CACert: testing.CACert,
 	})
-	c.Check(mcfg.MongoInfo, gc.DeepEquals, &authentication.MongoInfo{
+	c.Check(mcfg.MongoInfo, gc.DeepEquals, &mongo.MongoInfo{
 		Password: password, Info: mongo.Info{CACert: testing.CACert},
 	})
 	c.Check(mcfg.StateServingInfo.StatePort, gc.Equals, cfg.StatePort())
@@ -201,7 +200,7 @@ func (*CloudInitSuite) testUserData(c *gc.C, bootstrap bool) {
 		MachineNonce: "5432",
 		Tools:        tools,
 		Series:       "quantal",
-		MongoInfo: &authentication.MongoInfo{
+		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
 				Addrs:  []string{"127.0.0.1:1234"},
 				CACert: "CA CERT\n" + testing.CACert,

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -21,7 +21,6 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -108,7 +107,7 @@ func (s *JujuConnSuite) Reset(c *gc.C) {
 	s.setUpConn(c)
 }
 
-func (s *JujuConnSuite) MongoInfo(c *gc.C) *authentication.MongoInfo {
+func (s *JujuConnSuite) MongoInfo(c *gc.C) *mongo.MongoInfo {
 	info := s.State.MongoConnectionInfo()
 	info.Password = "dummy-secret"
 	return info
@@ -249,7 +248,7 @@ var redialStrategy = utils.AttemptStrategy{
 
 // newState returns a new State that uses the given environment.
 // The environment must have already been bootstrapped.
-func newState(environ environs.Environ, mongoInfo *authentication.MongoInfo) (*state.State, error) {
+func newState(environ environs.Environ, mongoInfo *mongo.MongoInfo) (*state.State, error) {
 	password := environ.Config().AdminSecret()
 	if password == "" {
 		return nil, fmt.Errorf("cannot connect without admin-secret")

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -10,7 +10,6 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -25,8 +24,8 @@ import (
 // FakeStateInfo holds information about no state - it will always
 // give an error when connected to.  The machine id gives the machine id
 // of the machine to be started.
-func FakeStateInfo(machineId string) *authentication.MongoInfo {
-	return &authentication.MongoInfo{
+func FakeStateInfo(machineId string) *mongo.MongoInfo {
+	return &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{"0.1.2.3:1234"},
 			CACert: testing.CACert,

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/cert"
@@ -74,6 +75,20 @@ type Info struct {
 	// CACert holds the CA certificate that will be used
 	// to validate the state server's certificate, in PEM format.
 	CACert string
+}
+
+// MongoInfo encapsulates information about cluster of
+// servers holding juju state and can be used to make a
+// connection to that cluster.
+type MongoInfo struct {
+	// mongo.Info contains the addresses and cert of the mongo cluster.
+	Info
+	// Tag holds the name of the entity that is connecting.
+	// It should be nil when connecting as an administrator.
+	Tag names.Tag
+
+	// Password holds the password for the connecting entity.
+	Password string
 }
 
 // DialInfo returns information on how to dial

--- a/provider/azure/customdata_test.go
+++ b/provider/azure/customdata_test.go
@@ -11,7 +11,6 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/juju/paths"
@@ -55,7 +54,7 @@ func makeMachineConfig(c *gc.C) *cloudinit.MachineConfig {
 			URL:     "http://testing.invalid/tools.tar.gz",
 		},
 		Series: "quantal",
-		MongoInfo: &authentication.MongoInfo{
+		MongoInfo: &mongo.MongoInfo{
 			Info: mongo.Info{
 				CACert: testing.CACert,
 				Addrs:  []string{"127.0.0.1:123"},

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -23,7 +23,6 @@ import (
 	"launchpad.net/gwacl"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -1538,7 +1537,7 @@ func (s *startInstanceSuite) SetUpTest(c *gc.C) {
 	s.env = s.setupEnvWithDummyMetadata(c)
 	s.env.ecfg.attrs["force-image-name"] = "my-image"
 	machineTag := names.NewMachineTag("1")
-	stateInfo := &authentication.MongoInfo{
+	stateInfo := &mongo.MongoInfo{
 		Info: mongo.Info{
 			CACert: coretesting.CACert,
 			Addrs:  []string{"localhost:123"},

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -40,7 +40,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/environs/config"
@@ -96,7 +95,7 @@ func SampleConfig() testing.Attrs {
 // stateInfo returns a *state.Info which allows clients to connect to the
 // shared dummy state, if it exists. If preferIPv6 is true, an IPv6 endpoint
 // will be added as primary.
-func stateInfo(preferIPv6 bool) *authentication.MongoInfo {
+func stateInfo(preferIPv6 bool) *mongo.MongoInfo {
 	if gitjujutesting.MgoServer.Addr() == "" {
 		panic("dummy environ state tests must be run with MgoTestPackage")
 	}
@@ -110,7 +109,7 @@ func stateInfo(preferIPv6 bool) *authentication.MongoInfo {
 	} else {
 		addrs = []string{net.JoinHostPort("localhost", mongoPort)}
 	}
-	return &authentication.MongoInfo{
+	return &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  addrs,
 			CACert: testing.CACert,
@@ -159,7 +158,7 @@ type OpStartInstance struct {
 	Constraints   constraints.Value
 	Networks      []string
 	NetworkInfo   []network.Info
-	Info          *authentication.MongoInfo
+	Info          *mongo.MongoInfo
 	Jobs          []params.MachineJob
 	APIInfo       *api.Info
 	Secret        string

--- a/state/api/agent/machine_test.go
+++ b/state/api/agent/machine_test.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
@@ -144,7 +143,7 @@ func (s *machineSuite) TestEntitySetPassword(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
 }
 
-func tryOpenState(info *authentication.MongoInfo) error {
+func tryOpenState(info *mongo.MongoInfo) error {
 	st, err := state.Open(info, mongo.DialOpts{}, environs.NewStatePolicy())
 	if err == nil {
 		st.Close()

--- a/state/backups/sources.go
+++ b/state/backups/sources.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/tar"
 
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/mongo"
 	coreutils "github.com/juju/juju/utils"
 )
@@ -155,7 +154,7 @@ func (ci *dbConnInfo) Password() string {
 }
 
 // UpdateFromMongoInfo pulls in the provided connection info.
-func (ci *dbConnInfo) UpdateFromMongoInfo(mgoInfo *authentication.MongoInfo) {
+func (ci *dbConnInfo) UpdateFromMongoInfo(mgoInfo *mongo.MongoInfo) {
 	ci.address = mgoInfo.Addrs[0]
 	ci.password = mgoInfo.Password
 

--- a/state/open.go
+++ b/state/open.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/api/params"
@@ -30,7 +29,7 @@ import (
 // may be provided.
 //
 // Open returns unauthorizedError if access is unauthorized.
-func Open(info *authentication.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, error) {
+func Open(info *mongo.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, error) {
 	st, err := open(info, opts, policy)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -44,7 +43,7 @@ func Open(info *authentication.MongoInfo, opts mongo.DialOpts, policy Policy) (*
 	return st, nil
 }
 
-func open(info *authentication.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, error) {
+func open(info *mongo.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, error) {
 	logger.Infof("opening state, mongo addresses: %q; entity %q", info.Addrs, info.Tag)
 	logger.Debugf("dialing mongo")
 	session, err := mongo.DialWithInfo(info.Info, opts)
@@ -64,7 +63,7 @@ func open(info *authentication.MongoInfo, opts mongo.DialOpts, policy Policy) (*
 // Initialize sets up an initial empty state and returns it.
 // This needs to be performed only once for a given environment.
 // It returns unauthorizedError if access is unauthorized.
-func Initialize(info *authentication.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (rst *State, err error) {
+func Initialize(info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (rst *State, err error) {
 	st, err := open(info, opts, policy)
 	if err != nil {
 		return nil, err
@@ -181,7 +180,7 @@ func isUnauthorized(err error) bool {
 	return false
 }
 
-func newState(session *mgo.Session, mongoInfo *authentication.MongoInfo, policy Policy) (_ *State, resultErr error) {
+func newState(session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (_ *State, resultErr error) {
 	admin := session.DB("admin")
 	authenticated := false
 	if mongoInfo.Tag != nil {
@@ -246,7 +245,7 @@ func newState(session *mgo.Session, mongoInfo *authentication.MongoInfo, policy 
 }
 
 // MongoConnectionInfo returns information for connecting to mongo
-func (st *State) MongoConnectionInfo() *authentication.MongoInfo {
+func (st *State) MongoConnectionInfo() *mongo.MongoInfo {
 	return st.mongoInfo
 }
 

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/mgo.v2/txn"
 	gc "launchpad.net/gocheck"
 
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
 )
@@ -26,8 +25,8 @@ var _ = gc.Suite(&SettingsSuite{})
 
 // TestingMongoInfo returns information suitable for
 // connecting to the testing state server's mongo database.
-func TestingMongoInfo() *authentication.MongoInfo {
-	return &authentication.MongoInfo{
+func TestingMongoInfo() *mongo.MongoInfo {
+	return &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,

--- a/state/state.go
+++ b/state/state.go
@@ -27,7 +27,6 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/api/params"
@@ -88,7 +87,7 @@ type State struct {
 	// be used instead of creating a new runnner each time.
 	transactionRunner jujutxn.Runner
 	authenticated     bool
-	mongoInfo         *authentication.MongoInfo
+	mongoInfo         *mongo.MongoInfo
 	policy            Policy
 	db                *mgo.Database
 	watcher           *watcher.Watcher

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
@@ -2089,7 +2088,7 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 	c.Assert(relation1, jc.DeepEquals, relation3)
 }
 
-func tryOpenState(info *authentication.MongoInfo) error {
+func tryOpenState(info *mongo.MongoInfo) error {
 	st, err := state.Open(info, state.TestingDialOpts(), state.Policy(nil))
 	if err == nil {
 		st.Close()
@@ -3493,7 +3492,7 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer inst.DestroyWithLog()
 
-	mongoInfo := &authentication.MongoInfo{
+	mongoInfo := &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{inst.Addr()},
 			CACert: testing.CACert,

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/juju/charm.v3"
 	gc "launchpad.net/gocheck"
 
-	"github.com/juju/juju/environmentserver/authentication"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
@@ -46,7 +45,7 @@ func (s *factorySuite) SetUpTest(c *gc.C) {
 	s.MgoSuite.SetUpTest(c)
 	policy := statetesting.MockPolicy{}
 
-	info := &authentication.MongoInfo{
+	info := &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{jtesting.MgoServer.Addr()},
 			CACert: testing.CACert,

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -14,7 +14,7 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/environmentserver/authentication"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/api"
 	"github.com/juju/juju/state/api/params"
@@ -109,7 +109,7 @@ type mockAgentConfig struct {
 	jobs         []params.MachineJob
 	apiAddresses []string
 	values       map[string]string
-	mongoInfo    *authentication.MongoInfo
+	mongoInfo    *mongo.MongoInfo
 }
 
 func (mock *mockAgentConfig) Tag() names.Tag {
@@ -140,7 +140,7 @@ func (mock *mockAgentConfig) Value(name string) string {
 	return mock.values[name]
 }
 
-func (mock *mockAgentConfig) MongoInfo() (*authentication.MongoInfo, bool) {
+func (mock *mockAgentConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 	return mock.mongoInfo, true
 }
 


### PR DESCRIPTION
This PR moves the `MongoInfo` type from the `environmentserver/authentication` package to the `mongo` package.

This change is necessary to unblock a larger change which was hitting a circular dependency.

With that said, as this change consists of _removing_ the import of the `environmentserver/authentication` from most packages (and renaming the type), it seems clear in hindsight that the `MongoInfo` type belongs in the `mongo` package.
