### PR TITLE
provider/local: don't put tools in cloud-config

### DIFF
--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -366,14 +366,6 @@ func (env *localEnviron) StartInstance(args environs.StartInstanceParams) (insta
 	logger.Debugf("StartInstance: %q, %s", args.MachineConfig.MachineId, series)
 	args.MachineConfig.Tools = args.Tools[0]
 
-	// The local provider's user-data size is only limited by the
-	// host's disk, so it's safe to serialise tools in cloud-config.
-	toolsPath := filepath.Join(
-		env.config.storageDir(),
-		envtools.StorageName(args.Tools[0].Version),
-	)
-	args.MachineConfig.Tools.URL = fmt.Sprintf("file://%s", toolsPath)
-
 	args.MachineConfig.MachineContainerType = env.config.container()
 	logger.Debugf("tools: %#v", args.MachineConfig.Tools)
 	if err := environs.FinishMachineConfig(args.MachineConfig, env.config.Config); err != nil {

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/juju/osenv"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/provider/local"
 	"github.com/juju/juju/service/common"
@@ -398,44 +397,4 @@ func (s *localJujuTestSuite) TestStateServerInstances(c *gc.C) {
 	instances, err = env.StateServerInstances()
 	c.Assert(err, gc.IsNil)
 	c.Assert(instances, gc.DeepEquals, []instance.Id{"localhost"})
-}
-
-func (s *localJujuTestSuite) TestToolsInCloudConfigForLXC(c *gc.C) {
-	s.testToolsInCloudConfig(c, "lxc")
-}
-
-func (s *localJujuTestSuite) TestToolsInCloudConfigForKVM(c *gc.C) {
-	s.testToolsInCloudConfig(c, "kvm")
-}
-
-func (s *localJujuTestSuite) testToolsInCloudConfig(c *gc.C, containerType string) {
-	dir := c.MkDir()
-	toolsDir := filepath.Join(dir, "storage", "tools", "releases")
-	err := os.MkdirAll(toolsDir, 0755)
-	c.Assert(err, gc.IsNil)
-	config := localConfig(c, map[string]interface{}{
-		"root-dir":  dir,
-		"container": containerType,
-	})
-	ctx := coretesting.Context(c)
-	env, err := local.Provider.Prepare(ctx, config)
-	c.Assert(err, gc.IsNil)
-
-	machineId := "1"
-	stateInfo := jujutesting.FakeStateInfo(machineId)
-	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	machineConfig, err := environs.NewMachineConfig(machineId, "", "", "precise", nil, stateInfo, apiInfo)
-	c.Assert(err, gc.IsNil)
-	params := environs.StartInstanceParams{
-		MachineConfig: machineConfig,
-		Tools: coretools.List{{
-			Version: version.MustParseBinary("5.4.5-precise-amd64"),
-			URL:     "whatevers",
-		}},
-	}
-
-	local.PatchCreateContainer(&s.CleanupSuite, c, "file://"+filepath.Join(toolsDir, "juju-5.4.5-precise-amd64.tgz"))
-	inst, _, _, err := env.StartInstance(params)
-	c.Assert(err, gc.IsNil)
-	c.Assert(inst.Id(), gc.Equals, instance.Id("mock"))
 }


### PR DESCRIPTION
While the user-data is not bounded like in ec2
etc., doing this does seem to cause additional
load on cloud-init.

Fixes https://bugs.launchpad.net/juju-core/+bug/1363143
