### PR TITLE
Fixed tests for version and agent to work on windows

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,10 +1,12 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package agent_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 
 	"github.com/juju/names"
@@ -425,7 +427,9 @@ func (*suite) TestAttributes(c *gc.C) {
 	conf, err := agent.NewAgentConfig(attributeParams)
 	c.Assert(err, gc.IsNil)
 	c.Assert(conf.DataDir(), gc.Equals, "/data/dir")
-	c.Assert(conf.SystemIdentityPath(), gc.Equals, "/data/dir/system-identity")
+	compareSystemIdentityPath := filepath.FromSlash("/data/dir/system-identity")
+	systemIdentityPath := filepath.FromSlash(conf.SystemIdentityPath())
+	c.Assert(systemIdentityPath, gc.Equals, compareSystemIdentityPath)
 	c.Assert(conf.Tag(), gc.Equals, names.NewMachineTag("1"))
 	c.Assert(conf.Dir(), gc.Equals, "/data/dir/agents/machine-1")
 	c.Assert(conf.Nonce(), gc.Equals, "a nonce")

--- a/agent/format-1.18_whitebox_test.go
+++ b/agent/format-1.18_whitebox_test.go
@@ -1,4 +1,5 @@
 // Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // The format tests are white box tests, meaning that the tests are in the
@@ -15,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
@@ -28,15 +30,26 @@ var _ = gc.Suite(&format_1_18Suite{})
 var configData1_18WithoutUpgradedToVersion = "# format 1.18\n" + configDataWithoutNewAttributes
 
 func (s *format_1_18Suite) TestMissingAttributes(c *gc.C) {
+	logDir, err := paths.LogDir(version.Current.Series)
+	c.Assert(err, gc.IsNil)
+	realDataDir, err := paths.DataDir(version.Current.Series)
+	c.Assert(err, gc.IsNil)
+
+	realDataDir = filepath.FromSlash(realDataDir)
+	logPath := filepath.Join(logDir, "juju")
+	logPath = filepath.FromSlash(logPath)
+
 	dataDir := c.MkDir()
 	configPath := filepath.Join(dataDir, agentConfigFilename)
-	err := utils.AtomicWriteFile(configPath, []byte(configData1_18WithoutUpgradedToVersion), 0600)
+	err = utils.AtomicWriteFile(configPath, []byte(configData1_18WithoutUpgradedToVersion), 0600)
 	c.Assert(err, gc.IsNil)
 	readConfig, err := ReadConfig(configPath)
 	c.Assert(err, gc.IsNil)
 	c.Assert(readConfig.UpgradedToVersion(), gc.Equals, version.MustParse("1.16.0"))
-	c.Assert(readConfig.LogDir(), gc.Equals, "/var/log/juju")
-	c.Assert(readConfig.DataDir(), gc.Equals, "/var/lib/juju")
+	configLogDir := filepath.FromSlash(readConfig.LogDir())
+	configDataDir := filepath.FromSlash(readConfig.DataDir())
+	c.Assert(configLogDir, gc.Equals, logPath)
+	c.Assert(configDataDir, gc.Equals, realDataDir)
 	c.Assert(readConfig.PreferIPv6(), jc.IsFalse)
 }
 

--- a/agent/format_whitebox_test.go
+++ b/agent/format_whitebox_test.go
@@ -1,4 +1,5 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package agent
@@ -6,6 +7,7 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -113,7 +115,12 @@ func assertFileExists(c *gc.C, path string) {
 	fileInfo, err := os.Stat(path)
 	c.Assert(err, gc.IsNil)
 	c.Assert(fileInfo.Mode().IsRegular(), jc.IsTrue)
-	c.Assert(fileInfo.Mode().Perm(), gc.Equals, os.FileMode(0600))
+
+	// Windows is not fully POSIX compliant. Chmod() and Chown() have unexpected behavior
+	// compared to linux/unix
+	if runtime.GOOS != "windows" {
+		c.Assert(fileInfo.Mode().Perm(), gc.Equals, os.FileMode(0600))
+	}
 	c.Assert(fileInfo.Size(), jc.GreaterThan, 0)
 }
 

--- a/juju/osenv/vars_linux_test.go
+++ b/juju/osenv/vars_linux_test.go
@@ -1,0 +1,19 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package osenv_test
+
+import (
+	"path/filepath"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/juju/osenv"
+)
+
+func (s *varsSuite) TestJujuHome(c *gc.C) {
+	path := `/foo/bar/baz/`
+	s.PatchEnvironment("HOME", path)
+	c.Assert(osenv.JujuHomeLinux(), gc.Equals, filepath.Join(path, ".juju"))
+}

--- a/juju/osenv/vars_test.go
+++ b/juju/osenv/vars_test.go
@@ -1,10 +1,10 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package osenv_test
 
 import (
-	"path/filepath"
 	"runtime"
 
 	gc "gopkg.in/check.v1"
@@ -18,18 +18,6 @@ type varsSuite struct {
 }
 
 var _ = gc.Suite(&varsSuite{})
-
-func (s *varsSuite) TestJujuHomeWin(c *gc.C) {
-	path := `P:\FooBar\AppData`
-	s.PatchEnvironment("APPDATA", path)
-	c.Assert(osenv.JujuHomeWin(), gc.Equals, filepath.Join(path, "Juju"))
-}
-
-func (s *varsSuite) TestJujuHomeLinux(c *gc.C) {
-	path := `/foo/bar/baz/`
-	s.PatchEnvironment("HOME", path)
-	c.Assert(osenv.JujuHomeLinux(), gc.Equals, filepath.Join(path, ".juju"))
-}
 
 func (s *varsSuite) TestJujuHomeEnvVar(c *gc.C) {
 	path := "/foo/bar/baz"

--- a/juju/osenv/vars_windows_test.go
+++ b/juju/osenv/vars_windows_test.go
@@ -1,0 +1,19 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package osenv_test
+
+import (
+	"path/filepath"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/juju/osenv"
+)
+
+func (s *varsSuite) TestJujuHome(c *gc.C) {
+	path := `P:\FooBar\AppData`
+	s.PatchEnvironment("APPDATA", path)
+	c.Assert(osenv.JujuHomeWin(), gc.Equals, filepath.Join(path, "Juju"))
+}

--- a/version/osversion_windows_test.go
+++ b/version/osversion_windows_test.go
@@ -1,0 +1,25 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package version
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+)
+
+type windowsVersionSuite struct{}
+
+var _ = gc.Suite(&windowsVersionSuite{})
+
+func (s *windowsVersionSuite) TestOSVersion(c *gc.C) {
+	knownSeries := set.NewStrings()
+	for _, series := range windowsVersions {
+		knownSeries.Add(series)
+	}
+	version, err := osVersion()
+	c.Assert(err, gc.IsNil)
+	c.Check(version, jc.Satisfies, knownSeries.Contains)
+}

--- a/version/supportedseries_linux_test.go
+++ b/version/supportedseries_linux_test.go
@@ -21,7 +21,8 @@ func (s *supportedSeriesSuite) TestSeriesVersion(c *gc.C) {
 }
 
 func (s *supportedSeriesSuite) TestSupportedSeries(c *gc.C) {
+	expectedSeries := []string{"precise", "quantal", "raring", "saucy", "trusty", "utopic"}
 	series := version.SupportedSeries()
 	sort.Strings(series)
-	c.Assert(series, gc.DeepEquals, []string{"precise", "quantal", "raring", "saucy", "trusty", "utopic"})
+	c.Assert(series, gc.DeepEquals, expectedSeries)
 }

--- a/version/supportedseries_windows_test.go
+++ b/version/supportedseries_windows_test.go
@@ -1,0 +1,38 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package version_test
+
+import (
+	"sort"
+
+	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/version"
+)
+
+type supportedSeriesWindowsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&supportedSeriesWindowsSuite{})
+
+func (s *supportedSeriesWindowsSuite) TestSeriesVersion(c *gc.C) {
+	vers, err := version.SeriesVersion("win8")
+	if err != nil {
+		c.Assert(err, gc.Not(gc.ErrorMatches), `invalid series "win8"`, gc.Commentf(`unable to lookup series "win8"`))
+	} else {
+		c.Assert(err, gc.IsNil)
+	}
+	c.Assert(err, gc.IsNil)
+	c.Assert(vers, gc.Equals, "win8")
+}
+
+func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
+	expectedSeries := []string{"precise", "quantal", "raring", "saucy", "trusty", "utopic", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win7", "win8", "win81"}
+	series := version.SupportedSeries()
+	sort.Strings(series)
+	c.Assert(series, gc.DeepEquals, expectedSeries)
+}


### PR DESCRIPTION
This patch fixes tests for juju/agent and juju/version to work on windows, as well as ubuntu.
Here are a few of the things that had to change:
1) because Windows is not fully POSIX compliant, the file permissions checks have been disabled. os.Chmod() only works reliably on POSIX systems
2) Abstracted some error messages that differ based on OS. For example the "no such file or directory error"
3) used filepath.Join and FromSlash wherever needed
