### PR TITLE
Merge pull request #650 from wallyworld/machine-doc-insert-order

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -246,11 +246,10 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 		return nil, nil, err
 	}
 	mdoc := machineDocForTemplate(template, strconv.Itoa(seq))
-	var ops []txn.Op
-	ops = append(ops, st.insertNewMachineOps(mdoc, template)...)
-	ops = append(ops, st.insertNewContainerRefOp(mdoc.Id))
+	prereqOps, machineOp := st.insertNewMachineOps(mdoc, template)
+	prereqOps = append(prereqOps, st.insertNewContainerRefOp(mdoc.Id))
 	if template.InstanceId != "" {
-		ops = append(ops, txn.Op{
+		prereqOps = append(prereqOps, txn.Op{
 			C:      instanceDataC,
 			Id:     mdoc.Id,
 			Assert: txn.DocMissing,
@@ -266,7 +265,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 			},
 		})
 	}
-	return mdoc, ops, nil
+	return mdoc, append(prereqOps, machineOp), nil
 }
 
 // supportsContainerType reports whether the machine supports the given
@@ -321,15 +320,14 @@ func (st *State) addMachineInsideMachineOps(template MachineTemplate, parentId s
 	}
 	mdoc := machineDocForTemplate(template, newId)
 	mdoc.ContainerType = string(containerType)
-	var ops []txn.Op
-	ops = append(ops, st.insertNewMachineOps(mdoc, template)...)
-	ops = append(ops,
+	prereqOps, machineOp := st.insertNewMachineOps(mdoc, template)
+	prereqOps = append(prereqOps,
 		// Update containers record for host machine.
 		st.addChildToContainerRefOp(parentId, mdoc.Id),
 		// Create a containers reference document for the container itself.
 		st.insertNewContainerRefOp(mdoc.Id),
 	)
-	return mdoc, ops, nil
+	return mdoc, append(prereqOps, machineOp), nil
 }
 
 // newContainerId returns a new id for a machine within the machine
@@ -382,16 +380,16 @@ func (st *State) addMachineInsideNewMachineOps(template, parentTemplate MachineT
 	}
 	mdoc := machineDocForTemplate(template, newId)
 	mdoc.ContainerType = string(containerType)
-	var ops []txn.Op
-	ops = append(ops, st.insertNewMachineOps(parentDoc, parentTemplate)...)
-	ops = append(ops, st.insertNewMachineOps(mdoc, template)...)
-	ops = append(ops,
+	parentPrereqOps, parentOp := st.insertNewMachineOps(parentDoc, parentTemplate)
+	prereqOps, machineOp := st.insertNewMachineOps(mdoc, template)
+	prereqOps = append(prereqOps, parentPrereqOps...)
+	prereqOps = append(prereqOps,
 		// The host machine doesn't exist yet, create a new containers record.
 		st.insertNewContainerRefOp(mdoc.Id),
 		// Create a containers reference document for the container itself.
 		st.insertNewContainerRefOp(parentDoc.Id, mdoc.Id),
 	)
-	return mdoc, ops, nil
+	return mdoc, append(prereqOps, parentOp, machineOp), nil
 }
 
 func machineDocForTemplate(template MachineTemplate, id string) *machineDoc {
@@ -413,14 +411,15 @@ func machineDocForTemplate(template MachineTemplate, id string) *machineDoc {
 // insertNewMachineOps returns operations to insert the given machine
 // document into the database, based on the given template. Only the
 // constraints and networks are used from the template.
-func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate) []txn.Op {
+func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate) (prereqOps []txn.Op, machineOp txn.Op) {
+	machineOp = txn.Op{
+		C:      machinesC,
+		Id:     mdoc.Id,
+		Assert: txn.DocMissing,
+		Insert: mdoc,
+	}
+
 	return []txn.Op{
-		{
-			C:      machinesC,
-			Id:     mdoc.Id,
-			Assert: txn.DocMissing,
-			Insert: mdoc,
-		},
 		createConstraintsOp(st, machineGlobalKey(mdoc.Id), template.Constraints),
 		createStatusOp(st, machineGlobalKey(mdoc.Id), statusDoc{
 			Status: params.StatusPending,
@@ -430,7 +429,7 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 		// provisioning, we should check the given networks are valid
 		// and known before setting them.
 		createRequestedNetworksOp(st, machineGlobalKey(mdoc.Id), template.RequestedNetworks),
-	}
+	}, machineOp
 }
 
 func hasJob(jobs []MachineJob, job MachineJob) bool {

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v3"
 	gc "launchpad.net/gocheck"
 
@@ -1039,7 +1040,7 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 	// reasonable time.
 	var deltas []params.Delta
 	for {
-		d, err := getNext(c, w, 100*time.Millisecond)
+		d, err := getNext(c, w, 1*time.Second)
 		if err == errTimeout {
 			break
 		}
@@ -1047,6 +1048,17 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 		deltas = append(deltas, d...)
 	}
 	checkDeltasEqual(c, b, deltas, []params.Delta{{
+		Entity: &params.MachineInfo{
+			Id:                      "0",
+			InstanceId:              "i-0",
+			Status:                  params.StatusPending,
+			Life:                    params.Alive,
+			Series:                  "quantal",
+			Jobs:                    []params.MachineJob{JobManageEnviron.ToParams()},
+			Addresses:               []network.Address{},
+			HardwareCharacteristics: hc,
+		},
+	}, {
 		Removed: true,
 		Entity: &params.MachineInfo{
 			Id:        "1",
@@ -1058,23 +1070,13 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 		},
 	}, {
 		Entity: &params.MachineInfo{
-			Id:        "2",
-			Status:    params.StatusPending,
-			Life:      params.Alive,
-			Series:    "trusty",
-			Jobs:      []params.MachineJob{JobHostUnits.ToParams()},
-			Addresses: []network.Address{},
-		},
-	}, {
-		Entity: &params.MachineInfo{
-			Id:                      "0",
-			InstanceId:              "i-0",
-			Status:                  params.StatusPending,
-			Life:                    params.Alive,
-			Series:                  "quantal",
-			Jobs:                    []params.MachineJob{JobManageEnviron.ToParams()},
-			Addresses:               []network.Address{},
-			HardwareCharacteristics: hc,
+			Id:         "2",
+			Status:     params.StatusPending,
+			Life:       params.Alive,
+			Series:     "trusty",
+			Jobs:       []params.MachineJob{JobHostUnits.ToParams()},
+			Addresses:  []network.Address{},
+			StatusData: params.StatusData{},
 		},
 	}})
 
@@ -1115,7 +1117,7 @@ func getNext(c *gc.C, w *multiwatcher.Watcher, timeout time.Duration) ([]params.
 	select {
 	case <-ch:
 		return deltas, err
-	case <-time.After(1 * time.Second):
+	case <-time.After(timeout):
 	}
 	return nil, errTimeout
 }
@@ -1132,16 +1134,13 @@ func checkNext(c *gc.C, w *multiwatcher.Watcher, b multiwatcher.Backing, deltas 
 // deltas are returns in arbitrary order, so we compare
 // them as sets.
 func checkDeltasEqual(c *gc.C, b multiwatcher.Backing, d0, d1 []params.Delta) {
-	c.Check(deltaMap(d0, b), gc.DeepEquals, deltaMap(d1, b))
+	c.Check(deltaMap(d0, b), jc.DeepEquals, deltaMap(d1, b))
 }
 
 func deltaMap(deltas []params.Delta, b multiwatcher.Backing) map[multiwatcher.InfoId]params.EntityInfo {
 	m := make(map[multiwatcher.InfoId]params.EntityInfo)
 	for _, d := range deltas {
 		id := d.Entity.EntityId()
-		if _, ok := m[id]; ok {
-			panic(fmt.Errorf("%v mentioned twice in delta set", id))
-		}
 		if d.Removed {
 			m[id] = nil
 		} else {


### PR DESCRIPTION
Ensure machine doc is inserted last after any related docs

Maybe fixes: https://bugs.launchpad.net/juju-core/+bug/1354027

With debug turned on, it could be seen that the provisioner task was being notified of containers added to a host, which the provisioner then started to process. However, at this time, the machine records were not necessarily all written to the database yet. It turned out that for one container, its status document was not yet written, so the provisioner saw an error and ignored the container forever. A couple of seconds after this happened, the status record was written.

The txn ops to add a machine and its associated docs are re-ordered such that the main machine doc is created last.
