### PR TITLE
Fixed command not found error during tests on windows

### DIFF
--- a/worker/uniter/jujuc/action-get_test.go
+++ b/worker/uniter/jujuc/action-get_test.go
@@ -1,4 +1,5 @@
 // Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -222,7 +223,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		hctx := s.GetHookContext(c, -1, "")
 		hctx.actionParams = t.actionParams
 
-		com, err := jujuc.NewCommand(hctx, "action-get")
+		com, err := jujuc.NewCommand(hctx, cmdString("action-get"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
@@ -240,7 +241,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 
 func (s *ActionGetSuite) TestHelp(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewCommand(hctx, "action-get")
+	com, err := jujuc.NewCommand(hctx, cmdString("action-get"))
 	c.Assert(err, gc.IsNil)
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})

--- a/worker/uniter/jujuc/config-get_test.go
+++ b/worker/uniter/jujuc/config-get_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -41,7 +42,7 @@ func (s *ConfigGetSuite) TestOutputFormatKey(c *gc.C) {
 	for i, t := range configGetKeyTests {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx := s.GetHookContext(c, -1, "")
-		com, err := jujuc.NewCommand(hctx, "config-get")
+		com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
@@ -103,7 +104,7 @@ func (s *ConfigGetSuite) TestOutputFormatAll(c *gc.C) {
 	for i, t := range configGetAllTests {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx := s.GetHookContext(c, -1, "")
-		com, err := jujuc.NewCommand(hctx, "config-get")
+		com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
@@ -123,7 +124,7 @@ func (s *ConfigGetSuite) TestOutputFormatAll(c *gc.C) {
 
 func (s *ConfigGetSuite) TestHelp(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewCommand(hctx, "config-get")
+	com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 	c.Assert(err, gc.IsNil)
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
@@ -148,7 +149,7 @@ reported as null. <key> and --all are mutually exclusive.
 
 func (s *ConfigGetSuite) TestOutputPath(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewCommand(hctx, "config-get")
+	com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 	c.Assert(err, gc.IsNil)
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--output", "some-file", "monsters"})
@@ -162,14 +163,14 @@ func (s *ConfigGetSuite) TestOutputPath(c *gc.C) {
 
 func (s *ConfigGetSuite) TestUnknownArg(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewCommand(hctx, "config-get")
+	com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 	c.Assert(err, gc.IsNil)
 	testing.TestInit(c, com, []string{"multiple", "keys"}, `unrecognized args: \["keys"\]`)
 }
 
 func (s *ConfigGetSuite) TestAllPlusKey(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewCommand(hctx, "config-get")
+	com, err := jujuc.NewCommand(hctx, cmdString("config-get"))
 	c.Assert(err, gc.IsNil)
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--all", "--format", "json", "monsters"})

--- a/worker/uniter/jujuc/export_test.go
+++ b/worker/uniter/jujuc/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The worker/uniter/jujuc package implements the server side of the jujuc proxy
+// tool, which forwards command invocations to the unit agent process so that
+// they can be executed against specific state.
+package jujuc
+
+var CmdSuffix = cmdSuffix

--- a/worker/uniter/jujuc/juju-log_test.go
+++ b/worker/uniter/jujuc/juju-log_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -23,7 +24,7 @@ var _ = gc.Suite(&JujuLogSuite{})
 func assertLogs(c *gc.C, ctx jujuc.Context, writer *loggo.TestWriter, unitname, badge string) {
 	msg1 := "the chickens"
 	msg2 := "are 110% AWESOME"
-	com, err := jujuc.NewCommand(ctx, "juju-log")
+	com, err := jujuc.NewCommand(ctx, cmdString("juju-log"))
 	c.Assert(err, gc.IsNil)
 	for _, t := range []struct {
 		args  []string
@@ -75,7 +76,7 @@ func (s *JujuLogSuite) TestBadges(c *gc.C) {
 
 func newJujuLogCommand(c *gc.C) cmd.Command {
 	ctx := &Context{}
-	com, err := jujuc.NewCommand(ctx, "juju-log")
+	com, err := jujuc.NewCommand(ctx, cmdString("juju-log"))
 	c.Assert(err, gc.IsNil)
 	return com
 }

--- a/worker/uniter/jujuc/owner-get_test.go
+++ b/worker/uniter/jujuc/owner-get_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -31,7 +32,7 @@ var ownerGetTests = []struct {
 
 func (s *OwnerGetSuite) createCommand(c *gc.C) cmd.Command {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewCommand(hctx, "owner-get")
+	com, err := jujuc.NewCommand(hctx, cmdString("owner-get"))
 	c.Assert(err, gc.IsNil)
 	return com
 }

--- a/worker/uniter/jujuc/ports_test.go
+++ b/worker/uniter/jujuc/ports_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -32,7 +33,7 @@ var portsTests = []struct {
 func (s *PortsSuite) TestOpenClose(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	for _, t := range portsTests {
-		com, err := jujuc.NewCommand(hctx, t.cmd[0])
+		com, err := jujuc.NewCommand(hctx, cmdString(t.cmd[0]))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.cmd[1:])
@@ -60,7 +61,7 @@ func (s *PortsSuite) TestBadArgs(c *gc.C) {
 	for _, name := range []string{"open-port", "close-port"} {
 		for _, t := range badPortsTests {
 			hctx := s.GetHookContext(c, -1, "")
-			com, err := jujuc.NewCommand(hctx, name)
+			com, err := jujuc.NewCommand(hctx, cmdString(name))
 			c.Assert(err, gc.IsNil)
 			err = testing.InitCommand(com, t.args)
 			c.Assert(err, gc.ErrorMatches, t.err)
@@ -70,7 +71,7 @@ func (s *PortsSuite) TestBadArgs(c *gc.C) {
 
 func (s *PortsSuite) TestHelp(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	open, err := jujuc.NewCommand(hctx, "open-port")
+	open, err := jujuc.NewCommand(hctx, cmdString("open-port"))
 	c.Assert(err, gc.IsNil)
 	flags := testing.NewFlagSet()
 	c.Assert(string(open.Info().Help(flags)), gc.Equals, `
@@ -80,7 +81,7 @@ purpose: register a port to open
 The port will only be open while the service is exposed.
 `[1:])
 
-	close, err := jujuc.NewCommand(hctx, "close-port")
+	close, err := jujuc.NewCommand(hctx, cmdString("close-port"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(close.Info().Help(flags)), gc.Equals, `
 usage: close-port <port>[/<protocol>]
@@ -101,7 +102,7 @@ func (s *PortsSuite) TestOpenCloseDeprecation(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	for _, t := range portsFormatDeprectaionTests {
 		name := t.cmd[0]
-		com, err := jujuc.NewCommand(hctx, name)
+		com, err := jujuc.NewCommand(hctx, cmdString(name))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.cmd[1:])

--- a/worker/uniter/jujuc/relation-get_test.go
+++ b/worker/uniter/jujuc/relation-get_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -184,7 +185,7 @@ func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
 	for i, t := range relationGetTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx := s.GetHookContext(c, t.relid, t.unit)
-		com, err := jujuc.NewCommand(hctx, "relation-get")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
@@ -249,7 +250,7 @@ func (s *RelationGetSuite) TestHelp(c *gc.C) {
 	for i, t := range relationGetHelpTests {
 		c.Logf("test %d", i)
 		hctx := s.GetHookContext(c, t.relid, t.unit)
-		com, err := jujuc.NewCommand(hctx, "relation-get")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, []string{"--help"})
@@ -266,7 +267,7 @@ func (s *RelationGetSuite) TestHelp(c *gc.C) {
 
 func (s *RelationGetSuite) TestOutputPath(c *gc.C) {
 	hctx := s.GetHookContext(c, 1, "m/0")
-	com, err := jujuc.NewCommand(hctx, "relation-get")
+	com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
 	c.Assert(err, gc.IsNil)
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--output", "some-file", "pew"})

--- a/worker/uniter/jujuc/relation-ids_test.go
+++ b/worker/uniter/jujuc/relation-ids_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -105,7 +106,7 @@ func (s *RelationIdsSuite) TestRelationIds(c *gc.C) {
 	for i, t := range relationIdsTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx := s.GetHookContext(c, t.relid, "")
-		com, err := jujuc.NewCommand(hctx, "relation-ids")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-ids"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
@@ -145,7 +146,7 @@ options:
 	} {
 		c.Logf("relid %d", relid)
 		hctx := s.GetHookContext(c, relid, "")
-		com, err := jujuc.NewCommand(hctx, "relation-ids")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-ids"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, []string{"--help"})

--- a/worker/uniter/jujuc/relation-list_test.go
+++ b/worker/uniter/jujuc/relation-list_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -111,7 +112,7 @@ func (s *RelationListSuite) TestRelationList(c *gc.C) {
 		hctx := s.GetHookContext(c, t.relid, "")
 		setMembers(hctx.rels[0], t.members0)
 		setMembers(hctx.rels[1], t.members1)
-		com, err := jujuc.NewCommand(hctx, "relation-list")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-list"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
@@ -154,7 +155,7 @@ options:
 	} {
 		c.Logf("test relid %d", relid)
 		hctx := s.GetHookContext(c, relid, "")
-		com, err := jujuc.NewCommand(hctx, "relation-list")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-list"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, []string{"--help"})

--- a/worker/uniter/jujuc/relation-set_test.go
+++ b/worker/uniter/jujuc/relation-set_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -28,7 +29,7 @@ func (s *RelationSetSuite) TestHelp(c *gc.C) {
 	for i, t := range helpTests {
 		c.Logf("test %d", i)
 		hctx := s.GetHookContext(c, t.relid, "")
-		com, err := jujuc.NewCommand(hctx, "relation-set")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-set"))
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, []string{"--help"})
@@ -152,7 +153,7 @@ func (s *RelationSetSuite) TestInit(c *gc.C) {
 	for i, t := range relationSetInitTests {
 		c.Logf("test %d", i)
 		hctx := s.GetHookContext(c, t.ctxrelid, "")
-		com, err := jujuc.NewCommand(hctx, "relation-set")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-set"))
 		c.Assert(err, gc.IsNil)
 		err = testing.InitCommand(com, t.args)
 		if t.err == "" {
@@ -198,7 +199,7 @@ func (s *RelationSetSuite) TestRun(c *gc.C) {
 		hctx.rels[1].units["u/0"] = basic
 
 		// Run the command.
-		com, err := jujuc.NewCommand(hctx, "relation-set")
+		com, err := jujuc.NewCommand(hctx, cmdString("relation-set"))
 		c.Assert(err, gc.IsNil)
 		rset := com.(*jujuc.RelationSetCommand)
 		rset.RelationId = 1
@@ -215,7 +216,8 @@ func (s *RelationSetSuite) TestRun(c *gc.C) {
 
 func (s *RelationSetSuite) TestRunDeprecationWarning(c *gc.C) {
 	hctx := s.GetHookContext(c, 0, "")
-	com, _ := jujuc.NewCommand(hctx, "relation-set")
+	com, _ := jujuc.NewCommand(hctx, cmdString("relation-set"))
+
 	// The rel= is needed to make this a valid command.
 	ctx, err := testing.RunCommand(c, com, "--format", "foo", "rel=")
 

--- a/worker/uniter/jujuc/server_test.go
+++ b/worker/uniter/jujuc/server_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -200,13 +201,14 @@ var newCommandTests = []struct {
 	{"relation-list", ""},
 	{"relation-set", ""},
 	{"unit-get", ""},
-	{"random", "unknown command: random"},
+	// The error message contains .exe on Windows
+	{"random", "unknown command: random(.exe)?"},
 }
 
 func (s *NewCommandSuite) TestNewCommand(c *gc.C) {
 	ctx := s.GetHookContext(c, 0, "")
 	for _, t := range newCommandTests {
-		com, err := jujuc.NewCommand(ctx, t.name)
+		com, err := jujuc.NewCommand(ctx, cmdString(t.name))
 		if t.err == "" {
 			// At this level, just check basic sanity; commands are tested in
 			// more detail elsewhere.

--- a/worker/uniter/jujuc/unit-get_test.go
+++ b/worker/uniter/jujuc/unit-get_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -34,7 +35,7 @@ var unitGetTests = []struct {
 
 func (s *UnitGetSuite) createCommand(c *gc.C) cmd.Command {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewCommand(hctx, "unit-get")
+	com, err := jujuc.NewCommand(hctx, cmdString("unit-get"))
 	c.Assert(err, gc.IsNil)
 	return com
 }

--- a/worker/uniter/jujuc/util_test.go
+++ b/worker/uniter/jujuc/util_test.go
@@ -1,4 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package jujuc_test
@@ -207,4 +208,8 @@ func (s Settings) Map() params.RelationSettings {
 		r[k] = v
 	}
 	return r
+}
+
+func cmdString(cmd string) string {
+	return cmd + jujuc.CmdSuffix
 }


### PR DESCRIPTION
Added missing cmdSuffix in tests. Previously it was used only in the actual code. This fixes quite a number of tests on Windows.
