### PR TITLE
Fixed logging prefixes after moving state/api -> api/ and state/apiserver -> apiserver/

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -24,7 +24,7 @@ import (
 	"github.com/juju/juju/rpc/jsoncodec"
 )
 
-var logger = loggo.GetLogger("juju.state.api")
+var logger = loggo.GetLogger("juju.api")
 
 // PingPeriod defines how often the internal connection health check
 // will run. It's a variable so it can be changed in tests.

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-var logger = loggo.GetLogger("juju.state.api.watcher")
+var logger = loggo.GetLogger("juju.api.watcher")
 
 // commonWatcher implements common watcher logic in one place to
 // reduce code duplication, but it's not in fact a complete watcher;

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -25,7 +25,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var logger = loggo.GetLogger("juju.state.apiserver")
+var logger = loggo.GetLogger("juju.apiserver")
 
 // loginRateLimit defines how many concurrent Login requests we will
 // accept

--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var logger = loggo.GetLogger("juju.state.apiserver.charmrevisionupdater")
+var logger = loggo.GetLogger("juju.apiserver.charmrevisionupdater")
 
 func init() {
 	common.RegisterStandardFacade("CharmRevisionUpdater", 0, NewCharmRevisionUpdaterAPI)

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -32,7 +32,7 @@ func init() {
 	common.RegisterStandardFacade("Client", 0, NewClient)
 }
 
-var logger = loggo.GetLogger("juju.state.apiserver.client")
+var logger = loggo.GetLogger("juju.apiserver.client")
 
 type API struct {
 	state     *state.State

--- a/apiserver/common/password.go
+++ b/apiserver/common/password.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var logger = loggo.GetLogger("juju.state.apiserver.common")
+var logger = loggo.GetLogger("juju.apiserver.common")
 
 // PasswordChanger implements a common SetPasswords method for use by
 // various facades.

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -309,14 +309,14 @@ machine-0: 2014-03-24 22:34:25 INFO juju runner.go:262 worker: start "instancepo
 machine-0: 2014-03-24 22:34:25 INFO juju runner.go:262 worker: start "apiserver"
 machine-0: 2014-03-24 22:34:25 INFO juju runner.go:262 worker: start "resumer"
 machine-0: 2014-03-24 22:34:25 INFO juju runner.go:262 worker: start "cleaner"
-machine-0: 2014-03-24 22:34:25 INFO juju.state.apiserver apiserver.go:43 listening on "[::]:17070"
+machine-0: 2014-03-24 22:34:25 INFO juju.apiserver apiserver.go:43 listening on "[::]:17070"
 machine-0: 2014-03-24 22:34:25 INFO juju runner.go:262 worker: start "minunitsworker"
 machine-0: 2014-03-24 22:34:28 INFO juju runner.go:262 worker: start "api"
 machine-0: 2014-03-24 22:34:28 INFO juju apiclient.go:114 api: dialing "wss://localhost:17070/"
-machine-0: 2014-03-24 22:34:28 INFO juju.state.apiserver apiserver.go:131 [1] API connection from 127.0.0.1:36491
+machine-0: 2014-03-24 22:34:28 INFO juju.apiserver apiserver.go:131 [1] API connection from 127.0.0.1:36491
 machine-0: 2014-03-24 22:34:28 INFO juju apiclient.go:124 api: connection established
-machine-0: 2014-03-24 22:34:28 DEBUG juju.state.apiserver apiserver.go:120 <- [1] <unknown> {"RequestId":1,"Type":"Admin","Request":"Login","Params":{"AuthTag":"machine-0","Password":"ARbW7iCV4LuMugFEG+Y4e0yr","Nonce":"user-admin:bootstrap"}}
-machine-0: 2014-03-24 22:34:28 DEBUG juju.state.apiserver apiserver.go:127 -> [1] machine-0 10.305679ms {"RequestId":1,"Response":{}} Admin[""].Login
+machine-0: 2014-03-24 22:34:28 DEBUG juju.apiserver apiserver.go:120 <- [1] <unknown> {"RequestId":1,"Type":"Admin","Request":"Login","Params":{"AuthTag":"machine-0","Password":"ARbW7iCV4LuMugFEG+Y4e0yr","Nonce":"user-admin:bootstrap"}}
+machine-0: 2014-03-24 22:34:28 DEBUG juju.apiserver apiserver.go:127 -> [1] machine-0 10.305679ms {"RequestId":1,"Response":{}} Admin[""].Login
 machine-1: 2014-03-24 22:36:28 INFO juju.cmd supercommand.go:297 running juju-1.17.7.1-precise-amd64 [gc]
 machine-1: 2014-03-24 22:36:28 INFO juju.cmd.jujud machine.go:127 machine agent machine-1 start (1.17.7.1-precise-amd64 [gc])
 machine-1: 2014-03-24 22:36:28 DEBUG juju.agent agent.go:384 read agent config, format "1.18"

--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/juju/utils/ssh"
 )
 
-var logger = loggo.GetLogger("juju.state.apiserver.keymanager")
+var logger = loggo.GetLogger("juju.apiserver.keymanager")
 
 func init() {
 	common.RegisterStandardFacade("KeyManager", 0, NewKeyManagerAPI)

--- a/apiserver/networker/networker.go
+++ b/apiserver/networker/networker.go
@@ -21,7 +21,7 @@ func init() {
 	common.RegisterStandardFacade("Networker", 0, NewNetworkerAPI)
 }
 
-var logger = loggo.GetLogger("juju.state.apiserver.networker")
+var logger = loggo.GetLogger("juju.apiserver.networker")
 
 // NetworkerAPI provides access to the Networker API facade.
 type NetworkerAPI struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -137,7 +137,7 @@ type AddMachinesResults struct {
 }
 
 // AddMachinesResults holds the name of a machine added by the
-// state.api.client.AddMachine call for a single machine.
+// api.client.AddMachine call for a single machine.
 type AddMachinesResult struct {
 	Machine string
 	Error   *Error

--- a/apiserver/upgrader/upgrader.go
+++ b/apiserver/upgrader/upgrader.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/version"
 )
 
-var logger = loggo.GetLogger("juju.state.apiserver.upgrader")
+var logger = loggo.GetLogger("juju.apiserver.upgrader")
 
 func init() {
 	common.RegisterStandardFacade("Upgrader", 0, upgraderFacade)

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var logger = loggo.GetLogger("juju.state.apiserver.usermanager")
+var logger = loggo.GetLogger("juju.apiserver.usermanager")
 
 func init() {
 	common.RegisterStandardFacade("UserManager", 0, NewUserManagerAPI)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -422,7 +422,8 @@ type GetStater interface {
 }
 
 func (s *JujuConnSuite) tearDownConn(c *gc.C) {
-	serverAlive := gitjujutesting.MgoServer.Addr() != ""
+	testServer := gitjujutesting.MgoServer.Addr()
+	serverAlive := testServer != ""
 
 	// Bootstrap will set the admin password, and render non-authorized use
 	// impossible. s.State may still hold the right password, so try to reset
@@ -435,7 +436,13 @@ func (s *JujuConnSuite) tearDownConn(c *gc.C) {
 		}
 		err := s.State.Close()
 		if serverAlive {
-			c.Check(err, gc.IsNil)
+			// This happens way too often with failing tests,
+			// so add some context in case of an error.
+			c.Check(
+				err,
+				gc.IsNil,
+				gc.Commentf("closing state failed, testing server %q is alive", testServer),
+			)
 		}
 		s.State = nil
 	}

--- a/state/open.go
+++ b/state/open.go
@@ -264,8 +264,16 @@ func (st *State) Close() error {
 	}
 	st.mu.Unlock()
 	st.db.Session.Close()
-	for _, err := range []error{err1, err2, err3} {
+	for i, err := range []error{err1, err2, err3} {
 		if err != nil {
+			switch i {
+			case 0:
+				logger.Errorf("failed to stop state watcher: %v", err)
+			case 1:
+				logger.Errorf("failed to stop presence watcher: %v", err)
+			case 2:
+				logger.Errorf("failed to stop all manager: %v", err)
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
After https://github.com/juju/juju/pull/655 got merged, I noticed some loggers are still using "state.api._" and "state.apiserver._", so this fixes these to drop the "state." prefix.

Also, added more logging to juju/testing/conn.go and state.Close() hoping to provide more context for fixing CI bugs like http://pad.lv/1348477.
