### PR TITLE
state: infrastructure for synchronising state server upgrades

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -256,3 +256,22 @@ var (
 	GetPorts         = getPorts
 	NowToTheSecond   = nowToTheSecond
 )
+
+var CurrentUpgradeId = currentUpgradeId
+
+func GetAllUpgradeInfos(st *State) ([]*UpgradeInfo, error) {
+	upgradeInfos, closer := st.getCollection(upgradeInfoC)
+	defer closer()
+
+	var out []*UpgradeInfo
+	var doc upgradeInfoDoc
+	iter := upgradeInfos.Find(nil).Iter()
+	defer iter.Close()
+	for iter.Next(&doc) {
+		out = append(out, &UpgradeInfo{st: st, doc: doc})
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/state/state.go
+++ b/state/state.go
@@ -67,6 +67,7 @@ const (
 	stateServersC      = "stateServers"
 	openedPortsC       = "openedPorts"
 	metricsC           = "metrics"
+	upgradeInfoC       = "upgradeInfo"
 
 	// This collection is used just for storing metadata.
 	backupsMetaC = "backupsmetadata"

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -1,0 +1,447 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+/*
+This file defines infrastructure for synchronising state server tools
+upgrades. Synchronisation is handled via a mongo DB document in the
+"upgradeInfo" collection.
+
+The functionality here is intended to be used as follows:
+
+1. When state servers come up running the new tools version, they call
+EnsureUpgradeInfo before running upgrade steps.
+
+2a. Any secondary state server watches the UpgradeInfo document and
+waits for the status to change to UpgradeFinishing.
+
+2b. The master state server watches the UpgradeInfo document and waits
+for AllProvisionedStateServersReady to return true. This indicates
+that all provisioned state servers have called EnsureUpgradeInfo and
+are ready to upgrade.
+
+3. The master state server calls SetStatus with UpgradeRunning and
+runs its upgrade steps.
+
+4. The master state server calls SetStatus with UpgradeFinishing and
+then calls SetStateServerDone with it's own machine id.
+
+5. Secondary state servers, seeing that the status has changed to
+UpgradeFinishing, run their upgrade steps and then call
+SetStateServerDone when complete.
+
+6. Once the final state server calls SetStateServerDone, the status is
+changed to UpgradeComplete and the upgradeInfo document is archived.
+*/
+
+package state
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils/set"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/version"
+)
+
+// UpgradeStatus describes the states an upgrade operation may be in.
+type UpgradeStatus string
+
+const (
+	// UpgradePending indicates that an upgrade is queued but not yet started.
+	UpgradePending UpgradeStatus = "pending"
+
+	// UpgradeRunning indicates that the master state server has started
+	// running upgrade logic, and other state servers are waiting for it.
+	UpgradeRunning UpgradeStatus = "running"
+
+	// UpgradeFinishing indicates that the master state server has finished
+	// running upgrade logic, and other state servers are catching up.
+	UpgradeFinishing UpgradeStatus = "finishing"
+
+	// UpgradeComplete indicates that all state servers have finished running
+	// upgrade logic.
+	UpgradeComplete UpgradeStatus = "complete"
+
+	// currentUpgradeId is the mongo _id of the current upgrade info document.
+	currentUpgradeId = "current"
+)
+
+type upgradeInfoDoc struct {
+	Id                string         `bson:"_id"`
+	PreviousVersion   version.Number `bson:"previousVersion"`
+	TargetVersion     version.Number `bson:"targetVersion"`
+	Status            UpgradeStatus  `bson:"status"`
+	Started           time.Time      `bson:"started"`
+	StateServersReady []string       `bson:"stateServersReady"`
+	StateServersDone  []string       `bson:"stateServersDone"`
+}
+
+// UpgradeInfo is used to synchronise state server upgrades.
+type UpgradeInfo struct {
+	st  *State
+	doc upgradeInfoDoc
+}
+
+// PreviousVersion returns the version being upgraded from.
+func (info *UpgradeInfo) PreviousVersion() version.Number {
+	return info.doc.PreviousVersion
+}
+
+// TargetVersion returns the version being upgraded to.
+func (info *UpgradeInfo) TargetVersion() version.Number {
+	return info.doc.TargetVersion
+}
+
+// Status returns the status of the upgrade.
+func (info *UpgradeInfo) Status() UpgradeStatus {
+	return info.doc.Status
+}
+
+// Started returns the time at which the upgrade was started.
+func (info *UpgradeInfo) Started() time.Time {
+	return info.doc.Started
+}
+
+// StateServersReady returns the machine ids for state servers that
+// have signalled that they are ready for upgrade.
+func (info *UpgradeInfo) StateServersReady() []string {
+	result := make([]string, len(info.doc.StateServersReady))
+	copy(result, info.doc.StateServersReady)
+	return result
+}
+
+// StateServersDone returns the machine ids for state servers that
+// have completed their upgrades.
+func (info *UpgradeInfo) StateServersDone() []string {
+	result := make([]string, len(info.doc.StateServersDone))
+	copy(result, info.doc.StateServersDone)
+	return result
+}
+
+// Refresh updates the contents of the UpgradeInfo from underlying state.
+func (info *UpgradeInfo) Refresh() error {
+	doc, err := currentUpgradeInfoDoc(info.st)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	info.doc = *doc
+	return nil
+}
+
+// Watcher returns a watcher for the state underlying the current
+// UpgradeInfo instance. This is provided purely for convenience.
+func (info *UpgradeInfo) Watch() NotifyWatcher {
+	return info.st.WatchUpgradeInfo()
+}
+
+// AllProvisionedStateServersReady returns true if and only if all state servers
+// that have been started by the provisioner have called EnsureUpgradeInfo with
+// matching versions.
+//
+// When this returns true the master state state server can begin it's
+// own upgrade.
+func (info *UpgradeInfo) AllProvisionedStateServersReady() (bool, error) {
+	// Get current state servers.
+	stateServerInfo, err := info.st.StateServerInfo()
+	if err != nil {
+		return false, errors.Annotate(err, "cannot read state servers")
+	}
+
+	// Extract current and provisioned state servers.
+	sel := bson.D{{
+		"_id", bson.D{{"$in", stateServerInfo.MachineIds}},
+	}}
+
+	instanceData, closer := info.st.getCollection(instanceDataC)
+	defer closer()
+	iter := instanceData.Find(sel).Select(bson.D{{"_id", 1}}).Iter()
+
+	var doc struct {
+		Id string `bson:"_id"`
+	}
+	provisionedMachineIds := set.NewStrings()
+	for iter.Next(&doc) {
+		provisionedMachineIds.Add(doc.Id)
+	}
+	if err := iter.Close(); err != nil {
+		return false, errors.Annotate(err, "cannot read provisioned machines")
+	}
+	// Find provisioned state machines that haven't indicated
+	// themselves as ready for upgrade.
+	missingMachineIds := provisionedMachineIds.Difference(
+		set.NewStrings(info.doc.StateServersReady...),
+	)
+	return missingMachineIds.IsEmpty(), nil
+}
+
+// SetStatus sets the status of the current upgrade. Checks are made
+// to ensure that status changes are performed in the correct order.
+func (info *UpgradeInfo) SetStatus(status UpgradeStatus) error {
+	var assertSane bson.D
+	switch status {
+	case UpgradePending, UpgradeComplete:
+		return errors.Errorf("cannot explicitly set upgrade %s", status)
+	case UpgradeRunning:
+		assertSane = bson.D{{"status", bson.D{{"$in",
+			[]UpgradeStatus{UpgradePending, UpgradeRunning},
+		}}}}
+	case UpgradeFinishing:
+		assertSane = bson.D{{"status", bson.D{{"$in",
+			[]UpgradeStatus{UpgradeRunning, UpgradeFinishing},
+		}}}}
+	default:
+		return errors.Errorf("unknown upgrade status: %s", status)
+	}
+	if info.doc.Id != currentUpgradeId {
+		return errors.New("cannot set status on non-current upgrade")
+	}
+
+	ops := []txn.Op{{
+		C:  upgradeInfoC,
+		Id: currentUpgradeId,
+		Assert: append(bson.D{{
+			"previousVersion", info.doc.PreviousVersion,
+		}, {
+			"targetVersion", info.doc.TargetVersion,
+		}}, assertSane...),
+		Update: bson.D{{"$set", bson.D{{"status", status}}}},
+	}}
+	err := info.st.runTransaction(ops)
+	if err == txn.ErrAborted {
+		return errors.Errorf("cannot set upgrade status to %q: Another "+
+			"status change may have occurred concurrently", status)
+	}
+	return errors.Annotate(err, "cannot set upgrade status")
+}
+
+// EnsureUpgradeInfo returns an UpgradeInfo describing a current upgrade between the
+// supplied versions. If a matching upgrade is in progress, that upgrade is returned;
+// if there's a mismatch, an error is returned. The supplied machine id must correspond
+// to a current state server.
+func (st *State) EnsureUpgradeInfo(machineId string, previousVersion, targetVersion version.Number) (*UpgradeInfo, error) {
+
+	assertSanity, err := checkUpgradeInfoSanity(st, machineId, previousVersion, targetVersion)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	doc := upgradeInfoDoc{
+		Id:                currentUpgradeId,
+		PreviousVersion:   previousVersion,
+		TargetVersion:     targetVersion,
+		Status:            UpgradePending,
+		Started:           time.Now().UTC(),
+		StateServersReady: []string{machineId},
+	}
+	ops := []txn.Op{{
+		C:      upgradeInfoC,
+		Id:     currentUpgradeId,
+		Assert: txn.DocMissing,
+		Insert: doc,
+	}, {
+		C:      instanceDataC,
+		Id:     machineId,
+		Assert: txn.DocExists,
+	}}
+	if err := st.runTransaction(ops); err == nil {
+		return &UpgradeInfo{st: st, doc: doc}, nil
+	} else if err != txn.ErrAborted {
+		return nil, errors.Annotate(err, "cannot create upgrade info")
+	}
+
+	if provisioned, err := st.isMachineProvisioned(machineId); err != nil {
+		return nil, errors.Trace(err)
+	} else if !provisioned {
+		return nil, errors.Errorf(
+			"machine %s is not provisioned and should not be participating in upgrades",
+			machineId)
+	}
+
+	if info, err := ensureUpgradeInfoUpdated(st, machineId, previousVersion, targetVersion); err == nil {
+		return info, nil
+	} else if errors.Cause(err) != errUpgradeInfoNotUpdated {
+		return nil, errors.Trace(err)
+	}
+
+	ops = []txn.Op{{
+		C:      upgradeInfoC,
+		Id:     currentUpgradeId,
+		Assert: assertSanity,
+		Update: bson.D{{
+			"$addToSet", bson.D{{"stateServersReady", machineId}},
+		}},
+	}}
+	switch err := st.runTransaction(ops); err {
+	case nil:
+		return ensureUpgradeInfoUpdated(st, machineId, previousVersion, targetVersion)
+	case txn.ErrAborted:
+		return nil, errors.New("upgrade info changed during update")
+	}
+	return nil, errors.Annotate(err, "cannot update upgrade info")
+}
+
+func (st *State) isMachineProvisioned(machineId string) (bool, error) {
+	instanceData, closer := st.getCollection(instanceDataC)
+	defer closer()
+	count, err := instanceData.FindId(machineId).Count()
+	if err != nil {
+		return false, errors.Annotate(err, "cannot read instance data")
+	}
+	return count > 0, nil
+}
+
+var errUpgradeInfoNotUpdated = errors.New("upgrade info not updated")
+
+func ensureUpgradeInfoUpdated(st *State, machineId string, previousVersion, targetVersion version.Number) (*UpgradeInfo, error) {
+	var doc upgradeInfoDoc
+	if pdoc, err := currentUpgradeInfoDoc(st); err != nil {
+		return nil, errors.Trace(err)
+	} else {
+		doc = *pdoc
+	}
+
+	if doc.PreviousVersion != previousVersion {
+		return nil, errors.Errorf(
+			"current upgrade info mismatch: expected previous version %s, got %s",
+			previousVersion, doc.PreviousVersion)
+	}
+	if doc.TargetVersion != targetVersion {
+		return nil, errors.Errorf(
+			"current upgrade info mismatch: expected target version %s, got %s",
+			targetVersion, doc.TargetVersion)
+	}
+
+	stateServersReady := set.NewStrings(doc.StateServersReady...)
+	if !stateServersReady.Contains(machineId) {
+		return nil, errors.Trace(errUpgradeInfoNotUpdated)
+	}
+	return &UpgradeInfo{st: st, doc: doc}, nil
+}
+
+// SetStateServerDone marks the supplied state machineId as having
+// completed its upgrades. When SetStateServerDone is called by the
+// last provisioned state server, the current upgrade info document
+// will be archived with a status of UpgradeComplete.
+func (info *UpgradeInfo) SetStateServerDone(machineId string) error {
+	assertSanity, err := checkUpgradeInfoSanity(info.st, machineId,
+		info.doc.PreviousVersion, info.doc.TargetVersion)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		doc, err := currentUpgradeInfoDoc(info.st)
+		if errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		switch doc.Status {
+		case UpgradePending, UpgradeRunning:
+			return nil, errors.New("upgrade has not yet run")
+		}
+
+		stateServersDone := set.NewStrings(doc.StateServersDone...)
+		if stateServersDone.Contains(machineId) {
+			return nil, jujutxn.ErrNoOperations
+		}
+		stateServersDone.Add(machineId)
+
+		stateServersReady := set.NewStrings(doc.StateServersReady...)
+		stateServersNotDone := stateServersReady.Difference(stateServersDone)
+		if stateServersNotDone.IsEmpty() {
+			// This is the last state server. Archive the current
+			// upgradeInfo document by setting its status to the final
+			// value and changing its id.
+			doc.StateServersDone = stateServersDone.SortedValues()
+			doc.Status = UpgradeComplete
+			doc.Id = bson.NewObjectId().String()
+			return []txn.Op{{
+				C:      upgradeInfoC,
+				Id:     currentUpgradeId,
+				Assert: assertSanity,
+				Remove: true,
+			}, {
+				C:      upgradeInfoC,
+				Id:     doc.Id,
+				Assert: txn.DocMissing,
+				Insert: doc,
+			}}, nil
+		}
+
+		return []txn.Op{{
+			C:  upgradeInfoC,
+			Id: currentUpgradeId,
+			// This is not the last state server, but we need to be
+			// sure it still isn't when we run this.
+			Assert: append(assertSanity, bson.D{{
+				"stateServersDone", bson.D{{"$nin", stateServersNotDone.Values()}},
+			}}...),
+			Update: bson.D{{"$addToSet", bson.D{{"stateServersDone", machineId}}}},
+		}}, nil
+	}
+	err = info.st.run(buildTxn)
+	return errors.Annotate(err, "cannot complete upgrade")
+}
+
+// IsUpgrading returns true if an upgrade is currently in progress.
+func (st *State) IsUpgrading() (bool, error) {
+	doc, err := currentUpgradeInfoDoc(st)
+	if doc != nil && err == nil {
+		return true, nil
+	} else if errors.IsNotFound(err) {
+		return false, nil
+	} else {
+		return false, errors.Trace(err)
+	}
+}
+
+func currentUpgradeInfoDoc(st *State) (*upgradeInfoDoc, error) {
+	var doc upgradeInfoDoc
+	upgradeInfo, closer := st.getCollection(upgradeInfoC)
+	defer closer()
+	if err := upgradeInfo.FindId(currentUpgradeId).One(&doc); err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("current upgrade info")
+	} else if err != nil {
+		return nil, errors.Annotate(err, "cannot read upgrade info")
+	}
+	return &doc, nil
+}
+
+func checkUpgradeInfoSanity(st *State, machineId string, previousVersion, targetVersion version.Number) (bson.D, error) {
+	if previousVersion.Compare(targetVersion) != -1 {
+		return nil, errors.Errorf("cannot sanely upgrade from %s to %s", previousVersion, targetVersion)
+	}
+	stateServerInfo, err := st.StateServerInfo()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot read state servers")
+	}
+	validIds := set.NewStrings(stateServerInfo.MachineIds...)
+	if !validIds.Contains(machineId) {
+		return nil, errors.Errorf("machine %q is not a state server", machineId)
+	}
+	assertSanity := bson.D{{
+		"previousVersion", previousVersion,
+	}, {
+		"targetVersion", targetVersion,
+	}}
+	return assertSanity, nil
+}
+
+// ClearUpgradeInfo clears information about an upgrade in progress. It returns
+// an error if no upgrade is current.
+func (st *State) ClearUpgradeInfo() error {
+	ops := []txn.Op{{
+		C:      upgradeInfoC,
+		Id:     currentUpgradeId,
+		Assert: txn.DocExists,
+		Remove: true,
+	}}
+	err := st.runTransaction(ops)
+	return errors.Annotate(err, "cannot clear upgrade info")
+}

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -1,0 +1,576 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/version"
+)
+
+type UpgradeSuite struct {
+	ConnSuite
+	serverIdA string
+}
+
+var _ = gc.Suite(&UpgradeSuite{})
+
+func vers(s string) version.Number {
+	return version.MustParse(s)
+}
+
+func (s *UpgradeSuite) provision(c *gc.C, machineIds ...string) {
+	for _, machineId := range machineIds {
+		machine, err := s.State.Machine(machineId)
+		c.Assert(err, gc.IsNil)
+		err = machine.SetProvisioned(
+			instance.Id(fmt.Sprintf("instance-%s", machineId)),
+			fmt.Sprintf("nonce-%s", machineId),
+			nil,
+		)
+	}
+}
+
+func (s *UpgradeSuite) addStateServers(c *gc.C) (machineId1, machineId2 string) {
+	changes, err := s.State.EnsureAvailability(3, constraints.Value{}, "quantal")
+	c.Assert(err, gc.IsNil)
+	return changes.Added[0], changes.Added[1]
+}
+
+func (s *UpgradeSuite) assertUpgrading(c *gc.C, expect bool) {
+	upgrading, err := s.State.IsUpgrading()
+	c.Assert(err, gc.IsNil)
+	c.Assert(upgrading, gc.Equals, expect)
+}
+
+func (s *UpgradeSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+	stateServer, err := s.State.AddMachine("quantal", state.JobManageEnviron)
+	c.Assert(err, gc.IsNil)
+	pinger, err := stateServer.SetAgentPresence()
+	c.Assert(err, gc.IsNil)
+	s.AddCleanup(func(c *gc.C) {
+		err := pinger.Stop()
+		c.Check(err, gc.IsNil)
+	})
+	s.serverIdA = stateServer.Id()
+	s.provision(c, s.serverIdA)
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfo(c *gc.C) {
+	vPrevious := vers("1.2.3")
+	vTarget := vers("2.3.4")
+	vMismatch := vers("1.9.1")
+
+	// create
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, vPrevious, vTarget)
+	c.Assert(err, gc.IsNil)
+	c.Assert(info.PreviousVersion(), gc.DeepEquals, vPrevious)
+	c.Assert(info.TargetVersion(), gc.DeepEquals, vTarget)
+	c.Assert(info.Status(), gc.Equals, state.UpgradePending)
+	c.Assert(info.Started().IsZero(), jc.IsFalse)
+	c.Assert(info.StateServersReady(), gc.DeepEquals, []string{s.serverIdA})
+	c.Assert(info.StateServersDone(), gc.HasLen, 0)
+
+	// retrieve existing
+	info, err = s.State.EnsureUpgradeInfo(s.serverIdA, vPrevious, vTarget)
+	c.Assert(err, gc.IsNil)
+	c.Assert(info.PreviousVersion(), gc.DeepEquals, vPrevious)
+	c.Assert(info.TargetVersion(), gc.DeepEquals, vTarget)
+
+	// mismatching previous
+	info, err = s.State.EnsureUpgradeInfo(s.serverIdA, vMismatch, vTarget)
+	c.Assert(err, gc.ErrorMatches, "current upgrade info mismatch: expected previous version 1.9.1, got 1.2.3")
+	c.Assert(info, gc.IsNil)
+
+	// mismatching target
+	info, err = s.State.EnsureUpgradeInfo(s.serverIdA, vPrevious, vMismatch)
+	c.Assert(err, gc.ErrorMatches, "current upgrade info mismatch: expected target version 1.9.1, got 2.3.4")
+	c.Assert(info, gc.IsNil)
+}
+
+func (s *UpgradeSuite) TestStateServersReadyCopies(c *gc.C) {
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, vers("1.2.3"), vers("2.4.5"))
+	c.Assert(err, gc.IsNil)
+	stateServersReady := info.StateServersReady()
+	c.Assert(stateServersReady, gc.DeepEquals, []string{"0"})
+	stateServersReady[0] = "lol"
+	stateServersReady = info.StateServersReady()
+	c.Assert(stateServersReady, gc.DeepEquals, []string{"0"})
+}
+
+func (s *UpgradeSuite) TestStateServersDoneCopies(c *gc.C) {
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, vers("1.2.3"), vers("2.4.5"))
+	c.Assert(err, gc.IsNil)
+	s.setToFinishing(c, info)
+	err = info.SetStateServerDone("0")
+	c.Assert(err, gc.IsNil)
+
+	info = s.getOneUpgradeInfo(c)
+	stateServersDone := info.StateServersDone()
+	c.Assert(stateServersDone, gc.DeepEquals, []string{"0"})
+	stateServersDone[0] = "lol"
+	stateServersDone = info.StateServersReady()
+	c.Assert(stateServersDone, gc.DeepEquals, []string{"0"})
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoDowngrade(c *gc.C) {
+	v123 := vers("1.2.3")
+	v111 := vers("1.1.1")
+
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v123, v111)
+	c.Assert(err, gc.ErrorMatches, "cannot sanely upgrade from 1.2.3 to 1.1.1")
+	c.Assert(info, gc.IsNil)
+
+	info, err = s.State.EnsureUpgradeInfo(s.serverIdA, v123, v123)
+	c.Assert(err, gc.ErrorMatches, "cannot sanely upgrade from 1.2.3 to 1.2.3")
+	c.Assert(info, gc.IsNil)
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoNonStateServer(c *gc.C) {
+	info, err := s.State.EnsureUpgradeInfo("2345678", vers("1.2.3"), vers("2.3.4"))
+	c.Assert(err, gc.ErrorMatches, "machine \"2345678\" is not a state server")
+	c.Assert(info, gc.IsNil)
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoNotProvisioned(c *gc.C) {
+	serverIdB, _ := s.addStateServers(c)
+	_, err := s.State.EnsureUpgradeInfo(serverIdB, vers("1.1.1"), vers("1.2.3"))
+	expectErr := fmt.Sprintf("machine %s is not provisioned and should not be participating in upgrades", serverIdB)
+	c.Assert(err, gc.ErrorMatches, expectErr)
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoMultipleServers(c *gc.C) {
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	_, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+
+	// add first new state server with bad version
+	info, err := s.State.EnsureUpgradeInfo(serverIdB, v111, vers("1.2.4"))
+	c.Assert(err, gc.ErrorMatches, "current upgrade info mismatch: expected target version 1.2.4, got 1.2.3")
+	c.Assert(info, gc.IsNil)
+
+	// add first new state server properly
+	info, err = s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.IsNil)
+	expectReady := []string{s.serverIdA, serverIdB}
+	c.Assert(info.StateServersReady(), jc.SameContents, expectReady)
+
+	// add second new state server
+	info, err = s.State.EnsureUpgradeInfo(serverIdC, v111, v123)
+	c.Assert(err, gc.IsNil)
+	expectReady = append(expectReady, serverIdC)
+	c.Assert(info.StateServersReady(), jc.SameContents, expectReady)
+
+	// add second new state server again
+	info, err = s.State.EnsureUpgradeInfo(serverIdC, v111, v123)
+	c.Assert(err, gc.IsNil)
+	c.Assert(info.StateServersReady(), jc.SameContents, expectReady)
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoRace(c *gc.C) {
+	v100 := vers("1.0.0")
+	v200 := vers("2.0.0")
+
+	_, err := s.State.EnsureUpgradeInfo(s.serverIdA, v100, v200)
+	c.Assert(err, gc.IsNil)
+
+	defer state.SetAfterHooks(c, s.State, func() {
+		err := s.State.ClearUpgradeInfo()
+		c.Assert(err, gc.IsNil)
+	}).Check()
+
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v100, v200)
+	c.Assert(err, gc.ErrorMatches, "current upgrade info not found")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(info, gc.IsNil)
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoMultipleServersRace1(c *gc.C) {
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	defer state.SetBeforeHooks(c, s.State, func() {
+		_, err := s.State.EnsureUpgradeInfo(serverIdC, v111, v123)
+		c.Assert(err, gc.IsNil)
+	}).Check()
+
+	info, err := s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.IsNil)
+	expectReady := []string{serverIdB, serverIdC}
+	c.Assert(info.StateServersReady(), jc.SameContents, expectReady)
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoMultipleServersRace2(c *gc.C) {
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	_, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+
+	defer state.SetAfterHooks(c, s.State, func() {
+		_, err := s.State.EnsureUpgradeInfo(serverIdC, v111, v123)
+		c.Assert(err, gc.IsNil)
+	}).Check()
+
+	info, err := s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.IsNil)
+	expectReady := []string{s.serverIdA, serverIdB, serverIdC}
+	c.Assert(info.StateServersReady(), jc.SameContents, expectReady)
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoMultipleServersRace3(c *gc.C) {
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	v124 := vers("1.2.4")
+	_, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+
+	defer state.SetBeforeHooks(c, s.State, nil, func() {
+		err := s.State.ClearUpgradeInfo()
+		c.Assert(err, gc.IsNil)
+		_, err = s.State.EnsureUpgradeInfo(serverIdC, v111, v124)
+		c.Assert(err, gc.IsNil)
+	}).Check()
+
+	_, err = s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.ErrorMatches, "upgrade info changed during update")
+}
+
+func (s *UpgradeSuite) TestEnsureUpgradeInfoMultipleServersRace4(c *gc.C) {
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	v124 := vers("1.2.4")
+	_, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+
+	defer state.SetAfterHooks(c, s.State, nil, func() {
+		err := s.State.ClearUpgradeInfo()
+		c.Assert(err, gc.IsNil)
+		_, err = s.State.EnsureUpgradeInfo(serverIdC, v111, v124)
+		c.Assert(err, gc.IsNil)
+	}).Check()
+
+	_, err = s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.ErrorMatches, "current upgrade info mismatch: expected target version 1.2.3, got 1.2.4")
+}
+
+func (s *UpgradeSuite) TestRefresh(c *gc.C) {
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	serverIdB, _ := s.addStateServers(c)
+	s.provision(c, serverIdB)
+
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+	info2, err := s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.IsNil)
+	info2.SetStatus(state.UpgradeRunning)
+
+	c.Assert(info.StateServersReady(), jc.SameContents, []string{s.serverIdA})
+	c.Assert(info.Status(), gc.Equals, state.UpgradePending)
+
+	err = info.Refresh()
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(info.StateServersReady(), jc.SameContents, []string{s.serverIdA, serverIdB})
+	c.Assert(info.Status(), gc.Equals, state.UpgradeRunning)
+}
+
+func (s *UpgradeSuite) TestWatch(c *gc.C) {
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+
+	w := s.State.WatchUpgradeInfo()
+	defer statetesting.AssertStop(c, w)
+
+	// initial event
+	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
+	wc.AssertOneChange()
+
+	// single change is reported
+	_, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+	wc.AssertOneChange()
+
+	// non-change is not reported
+	_, err = s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+	wc.AssertNoChange()
+
+	// changes are coalesced
+	_, err = s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.IsNil)
+	_, err = s.State.EnsureUpgradeInfo(serverIdC, v111, v123)
+	c.Assert(err, gc.IsNil)
+	wc.AssertOneChange()
+
+	// closed on stop
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
+}
+
+func (s *UpgradeSuite) TestWatchMethod(c *gc.C) {
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+
+	w := info.Watch()
+	defer statetesting.AssertStop(c, w)
+
+	// initial event
+	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
+	wc.AssertOneChange()
+
+	// single change is reported
+	info, err = s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.IsNil)
+	wc.AssertOneChange()
+
+	// non-change is not reported
+	info, err = s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.IsNil)
+	wc.AssertNoChange()
+
+	// changes are coalesced
+	_, err = s.State.EnsureUpgradeInfo(serverIdC, v111, v123)
+	c.Assert(err, gc.IsNil)
+	err = info.SetStatus(state.UpgradeRunning)
+	c.Assert(err, gc.IsNil)
+	wc.AssertOneChange()
+
+	// closed on stop
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
+}
+func (s *UpgradeSuite) TestAllProvisionedStateServersReady(c *gc.C) {
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB)
+
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+
+	assertReady := func(expect bool) {
+		ok, err := info.AllProvisionedStateServersReady()
+		c.Assert(err, gc.IsNil)
+		c.Assert(ok, gc.Equals, expect)
+	}
+	assertReady(false)
+
+	info, err = s.State.EnsureUpgradeInfo(serverIdB, v111, v123)
+	c.Assert(err, gc.IsNil)
+	assertReady(true)
+
+	s.provision(c, serverIdC)
+	assertReady(false)
+
+	info, err = s.State.EnsureUpgradeInfo(serverIdC, v111, v123)
+	c.Assert(err, gc.IsNil)
+	assertReady(true)
+}
+
+func (s *UpgradeSuite) TestSetStatus(c *gc.C) {
+	v123 := vers("1.2.3")
+	v234 := vers("2.3.4")
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v123, v234)
+	c.Assert(err, gc.IsNil)
+
+	assertStatus := func(expect state.UpgradeStatus) {
+		info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v123, v234)
+		c.Assert(err, gc.IsNil)
+		c.Assert(info.Status(), gc.Equals, expect)
+	}
+	err = info.SetStatus(state.UpgradePending)
+	c.Assert(err, gc.ErrorMatches, "cannot explicitly set upgrade pending")
+	assertStatus(state.UpgradePending)
+	err = info.SetStatus(state.UpgradeFinishing)
+	c.Assert(err, gc.ErrorMatches, "cannot set upgrade status to \"finishing\": "+
+		"Another status change may have occurred concurrently")
+	assertStatus(state.UpgradePending)
+	err = info.SetStatus(state.UpgradeComplete)
+	c.Assert(err, gc.ErrorMatches, "cannot explicitly set upgrade complete")
+	assertStatus(state.UpgradePending)
+	err = info.SetStatus(state.UpgradeStatus("lol"))
+	c.Assert(err, gc.ErrorMatches, "unknown upgrade status: lol")
+	assertStatus(state.UpgradePending)
+
+	err = info.SetStatus(state.UpgradeRunning)
+	c.Assert(err, gc.IsNil)
+	assertStatus(state.UpgradeRunning)
+	err = info.SetStatus(state.UpgradeRunning)
+	c.Assert(err, gc.IsNil)
+	assertStatus(state.UpgradeRunning)
+
+	err = info.SetStatus(state.UpgradeFinishing)
+	c.Assert(err, gc.IsNil)
+	assertStatus(state.UpgradeFinishing)
+	err = info.SetStatus(state.UpgradeFinishing)
+	c.Assert(err, gc.IsNil)
+	assertStatus(state.UpgradeFinishing)
+	err = info.SetStatus(state.UpgradeRunning)
+	c.Assert(err, gc.ErrorMatches, "cannot set upgrade status to \"running\": "+
+		"Another status change may have occurred concurrently")
+	assertStatus(state.UpgradeFinishing)
+}
+
+func (s *UpgradeSuite) TestSetStateServerDone(c *gc.C) {
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, vers("1.2.3"), vers("2.3.4"))
+	c.Assert(err, gc.IsNil)
+
+	err = info.SetStateServerDone(s.serverIdA)
+	c.Assert(err, gc.ErrorMatches, "cannot complete upgrade: upgrade has not yet run")
+
+	err = info.SetStatus(state.UpgradeRunning)
+	c.Assert(err, gc.IsNil)
+	err = info.SetStateServerDone(s.serverIdA)
+	c.Assert(err, gc.ErrorMatches, "cannot complete upgrade: upgrade has not yet run")
+
+	err = info.SetStatus(state.UpgradeFinishing)
+	c.Assert(err, gc.IsNil)
+	err = info.SetStateServerDone(s.serverIdA)
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, false)
+
+	s.checkUpgradeInfoArchived(c, 1, info)
+}
+
+func (s *UpgradeSuite) TestSetStateServerDoneMultipleServers(c *gc.C) {
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+	for _, id := range []string{serverIdB, serverIdC} {
+		_, err := s.State.EnsureUpgradeInfo(id, v111, v123)
+		c.Assert(err, gc.IsNil)
+	}
+
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+	s.setToFinishing(c, info)
+
+	err = info.SetStateServerDone(s.serverIdA)
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, true)
+
+	err = info.SetStateServerDone(s.serverIdA)
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, true)
+
+	err = info.SetStateServerDone(serverIdB)
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, true)
+
+	err = info.SetStateServerDone(serverIdC)
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, false)
+
+	s.checkUpgradeInfoArchived(c, 3, info)
+}
+
+func (s *UpgradeSuite) TestSetStateServerDoneMultipleServersRace(c *gc.C) {
+	v100 := vers("1.0.0")
+	v200 := vers("2.0.0")
+	serverIdB, serverIdC := s.addStateServers(c)
+	s.provision(c, serverIdB, serverIdC)
+
+	info, err := s.State.EnsureUpgradeInfo(s.serverIdA, v100, v200)
+	c.Assert(err, gc.IsNil)
+	_, err = s.State.EnsureUpgradeInfo(serverIdB, v100, v200)
+	c.Assert(err, gc.IsNil)
+	_, err = s.State.EnsureUpgradeInfo(serverIdC, v100, v200)
+	c.Assert(err, gc.IsNil)
+	s.setToFinishing(c, info)
+
+	// Interrupt the transaction for state server A twice with calls
+	// from the other machines.
+	defer state.SetBeforeHooks(c, s.State, func() {
+		err = info.SetStateServerDone(serverIdB)
+		c.Assert(err, gc.IsNil)
+	}, func() {
+		err = info.SetStateServerDone(serverIdC)
+		c.Assert(err, gc.IsNil)
+	}).Check()
+	err = info.SetStateServerDone(s.serverIdA)
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, false)
+
+	info = s.getOneUpgradeInfo(c)
+	c.Assert(info.Status(), gc.Equals, state.UpgradeComplete)
+	c.Assert(info.StateServersDone(), jc.SameContents, []string{"0", "1", "2"})
+}
+
+func (s *UpgradeSuite) getOneUpgradeInfo(c *gc.C) *state.UpgradeInfo {
+	upgradeInfos, err := state.GetAllUpgradeInfos(s.State)
+	c.Assert(err, gc.IsNil)
+	c.Assert(len(upgradeInfos), gc.Equals, 1)
+	return upgradeInfos[0]
+}
+
+func (s *UpgradeSuite) checkUpgradeInfoArchived(c *gc.C, expectedStateServers int, initialInfo *state.UpgradeInfo) {
+	info := s.getOneUpgradeInfo(c)
+	c.Assert(info.Status(), gc.Equals, state.UpgradeComplete)
+	c.Assert(info.PreviousVersion(), gc.Equals, initialInfo.PreviousVersion())
+	c.Assert(info.TargetVersion(), gc.Equals, initialInfo.TargetVersion())
+	// Truncate because mongo only stores times down to millisecond resolution.
+	c.Assert(info.Started().Equal(initialInfo.Started().Truncate(time.Millisecond)), jc.IsTrue)
+	c.Assert(len(info.StateServersDone()), gc.Equals, expectedStateServers)
+	c.Assert(info.StateServersDone(), jc.SameContents, info.StateServersReady())
+}
+
+func (s *UpgradeSuite) TestClearUpgradeInfo(c *gc.C) {
+	v111 := vers("1.1.1")
+	v123 := vers("1.2.3")
+	v153 := vers("1.5.3")
+
+	s.assertUpgrading(c, false)
+	_, err := s.State.EnsureUpgradeInfo(s.serverIdA, v111, v123)
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, true)
+
+	err = s.State.ClearUpgradeInfo()
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, false)
+
+	_, err = s.State.EnsureUpgradeInfo(s.serverIdA, v111, v153)
+	c.Assert(err, gc.IsNil)
+	s.assertUpgrading(c, true)
+}
+
+func (s *UpgradeSuite) setToFinishing(c *gc.C, info *state.UpgradeInfo) {
+	err := info.SetStatus(state.UpgradeRunning)
+	c.Assert(err, gc.IsNil)
+	err = info.SetStatus(state.UpgradeFinishing)
+	c.Assert(err, gc.IsNil)
+}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1197,6 +1197,12 @@ func (e *Environment) Watch() NotifyWatcher {
 	return newEntityWatcher(e.st, environmentsC, e.doc.UUID)
 }
 
+// WatchUpgradeInfo returns a watcher for observing changes to upgrade
+// synchronisation state.
+func (st *State) WatchUpgradeInfo() NotifyWatcher {
+	return newEntityWatcher(st, upgradeInfoC, currentUpgradeId)
+}
+
 // WatchForEnvironConfigChanges returns a NotifyWatcher waiting for the Environ
 // Config to change. This differs from WatchEnvironConfig in that the watcher
 // is a NotifyWatcher that does not give content during Changes()


### PR DESCRIPTION
Introduce a new UpgradeInfo struct (and underlying mongo document) which will be used by state servers to synchronise tools upgrades.

Later commits will integrate this infrastructure with the upgrade machinery in jujud.

William Reade and Menno Smits both contributed to this revision.
