### PR TITLE
cmd/set: Allow empty string fix #1348829

### DIFF
--- a/cmd/juju/set.go
+++ b/cmd/juju/set.go
@@ -34,7 +34,7 @@ In case a value starts with an at sign (@) the rest of the value is interpreted
 as a filename. The value itself is then read out of the named file. The maximum
 size of this value is 5M.
 
-Option values may be any UTF-8 encoded string. UTF-8 is accepted on the command 
+Option values may be any UTF-8 encoded string. UTF-8 is accepted on the command
 line and in configuration files.
 `
 
@@ -88,6 +88,12 @@ func (c *SetCommand) Run(ctx *cmd.Context) error {
 	}
 	settings := map[string]string{}
 	for k, v := range c.SettingsStrings {
+		//empty string is also valid as a setting value
+		if v == "" {
+			settings[k] = v
+			continue
+		}
+
 		if v[0] != '@' {
 			if !utf8.ValidString(v) {
 				return fmt.Errorf("value for option %q contains non-UTF-8 sequences", k)

--- a/cmd/juju/set_test.go
+++ b/cmd/juju/set_test.go
@@ -66,6 +66,12 @@ func (s *SetSuite) TestSetOptionSuccess(c *gc.C) {
 		"username": validSetTestValue,
 		"outlook":  "hello@world.tld",
 	})
+	assertSetSuccess(c, s.dir, s.svc, []string{
+		"username=",
+	}, charm.Settings{
+		"username": "",
+		"outlook":  "hello@world.tld",
+	})
 }
 
 func (s *SetSuite) TestSetOptionFail(c *gc.C) {


### PR DESCRIPTION
Fixes LP: #1348829 bug.

Since there is a plenty amount of charms accepting "" as a valid value and is a valid char, we should allow it.

Signed-off-by: Jorge Niedbalski R niedbalski@gmail.com
