### PR TITLE
api/uniter: validate unit name before relation-get

### DIFF
--- a/api/uniter/relationunit.go
+++ b/api/uniter/relationunit.go
@@ -6,6 +6,7 @@ package uniter
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/api/watcher"
@@ -135,6 +136,9 @@ func (ru *RelationUnit) Settings() (*Settings, error) {
 // guaranteed to persist for the lifetime of the relation, regardless
 // of the lifetime of the unit.
 func (ru *RelationUnit) ReadSettings(uname string) (params.RelationSettings, error) {
+	if !names.IsValidUnit(uname) {
+		return nil, errors.Errorf("%q is not a valid unit", uname)
+	}
 	tag := names.NewUnitTag(uname)
 	var results params.RelationSettingsResults
 	args := params.RelationUnitPairs{

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -239,6 +239,21 @@ func (s *relationUnitSuite) TestReadSettings(c *gc.C) {
 	})
 }
 
+func (s *relationUnitSuite) TestReadSettingsInvalidUnitTag(c *gc.C) {
+	// First try to read the settings which are not set.
+	myRelUnit, err := s.stateRelation.Unit(s.mysqlUnit)
+	c.Assert(err, gc.IsNil)
+	err = myRelUnit.EnterScope(nil)
+	c.Assert(err, gc.IsNil)
+	s.assertInScope(c, myRelUnit, true)
+
+	// Try reading - should be ok.
+	wpRelUnit, apiRelUnit := s.getRelationUnits(c)
+	s.assertInScope(c, wpRelUnit, false)
+	_, err = apiRelUnit.ReadSettings("mysql")
+	c.Assert(err, gc.ErrorMatches, "\"mysql\" is not a valid unit")
+}
+
 func (s *relationUnitSuite) TestWatchRelationUnits(c *gc.C) {
 	// Enter scope with mysqlUnit.
 	myRelUnit, err := s.stateRelation.Unit(s.mysqlUnit)


### PR DESCRIPTION
The name of the unit passed in from the cli is not a string form of a tag so we have to validate that it actaully is a unit name (the id part of a unit tag).
