### PR TITLE
Add Restore Mode to stop api calls while restoring

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -62,3 +62,20 @@ func TestingUpgradingRoot(st *state.State) *upgradingRoot {
 		srvRoot: *TestingSrvRoot(st),
 	}
 }
+
+// TestingRestoreInProgressRoot returns a limited restoreInProgressRoot
+// containing a srvRoot as returned by TestingSrvRoot.
+func TestingRestoreInProgressRoot(st *state.State) *restoreInProgressRoot {
+	return &restoreInProgressRoot{
+		srvRoot: *TestingSrvRoot(st),
+	}
+}
+
+// TestingAboutToRestoreRoot returns a limited aboutToRestoreRoot
+// containing a srvRoot as returned by TestingSrvRoot.
+func TestingAboutToRestoreRoot(st *state.State) *aboutToRestoreRoot {
+	return &aboutToRestoreRoot{
+		srvRoot: *TestingSrvRoot(st),
+	}
+
+}

--- a/apiserver/restoring_root.go
+++ b/apiserver/restoring_root.go
@@ -1,0 +1,71 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/rpc/rpcreflect"
+	"github.com/juju/juju/state"
+)
+
+var aboutToRestoreError = errors.New("juju restore is in progress - Juju functionality is limited to avoid data loss")
+var restoreInProgressError = errors.New("juju restore is in progress - Juju api is off to prevent data loss")
+
+type aboutToRestoreRoot struct {
+	srvRoot
+}
+
+type restoreInProgressRoot struct {
+	srvRoot
+}
+
+// newAboutToRestoreRoot creates a root where all API calls
+// but restore will fail with aboutToRestoreError.
+func newAboutToRestoreRoot(root *initialRoot, entity state.Entity) *aboutToRestoreRoot {
+	return &aboutToRestoreRoot{
+		srvRoot: *newSrvRoot(root, entity),
+	}
+}
+
+// newRestoreInProressRoot creates a root where all API calls
+// but restore will fail with restoreInProgressError.
+func newRestoreInProgressRoot(root *initialRoot, entity state.Entity) *restoreInProgressRoot {
+	return &restoreInProgressRoot{
+		srvRoot: *newSrvRoot(root, entity),
+	}
+}
+
+// FindMethod extended srvRoot.FindMethod. It returns aboutToRestoreError
+// for all API calls except Client.Restore
+// for use while Juju is preparing to restore a backup.
+func (r *aboutToRestoreRoot) FindMethod(rootName string, version int, methodName string) (rpcreflect.MethodCaller, error) {
+	if _, _, err := r.lookupMethod(rootName, version, methodName); err != nil {
+		return nil, err
+	}
+	if !isMethodAllowedAboutToRestore(rootName, methodName) {
+		return nil, aboutToRestoreError
+	}
+	return r.srvRoot.FindMethod(rootName, version, methodName)
+}
+
+var allowedMethodsAboutToRestore = set.NewStrings(
+	"Client.Restore", // for "juju restore"
+)
+
+func isMethodAllowedAboutToRestore(rootName, methodName string) bool {
+	fullName := rootName + "." + methodName
+	return allowedMethodsAboutToRestore.Contains(fullName)
+}
+
+// FindMethod extended srvRoot.FindMethod. It returns restoreInProgressError
+// for all API calls.
+// for use while Juju is restoring a backup.
+func (r *restoreInProgressRoot) FindMethod(rootName string, version int, methodName string) (rpcreflect.MethodCaller, error) {
+	if _, _, err := r.lookupMethod(rootName, version, methodName); err != nil {
+		return nil, err
+	}
+	return nil, restoreInProgressError
+}

--- a/apiserver/restoring_root_test.go
+++ b/apiserver/restoring_root_test.go
@@ -1,0 +1,55 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/testing"
+)
+
+type restoreRootSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&restoreRootSuite{})
+
+// TODO(perrito666): Uncomment when Restore lands.
+//func (r *restoreRootSuite) TestFindAllowedMethodWhenPreparing(c *gc.C) {
+//	root := apiserver.TestingAboutToRestoreRoot(nil)
+//
+//	caller, err := root.FindMethod("Client", 0, "Restore")
+//
+//	c.Assert(err, gc.IsNil)
+//	c.Assert(caller, gc.NotNil)
+//}
+
+// TODO(perrito666): Uncomment when Restore lands.
+//func (r *restoreRootSuite) TestNothingAllowedMethodWhenPreparing(c *gc.C) {
+//	root := apiserver.TestingRestoreInProgressRoot(nil)
+//
+//	caller, err := root.FindMethod("Client", 0, "Restore")
+//
+//	c.Assert(err, gc.IsNil)
+//	c.Assert(caller, gc.NotNil)
+//}
+
+func (r *restoreRootSuite) TestFindDisallowedMethodWhenPreparing(c *gc.C) {
+	root := apiserver.TestingAboutToRestoreRoot(nil)
+
+	caller, err := root.FindMethod("Client", 0, "ServiceDeploy")
+
+	c.Assert(err, gc.ErrorMatches, "juju restore is in progress - Juju functionality is limited to avoid data loss")
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restoreRootSuite) TestFindDisallowedMethodWhenRestoring(c *gc.C) {
+	root := apiserver.TestingRestoreInProgressRoot(nil)
+
+	caller, err := root.FindMethod("Client", 0, "ServiceDeploy")
+
+	c.Assert(err, gc.ErrorMatches, "juju restore is in progress - Juju api is off to prevent data loss")
+	c.Assert(caller, gc.IsNil)
+}

--- a/cmd/jujud/machine_test.go
+++ b/cmd/jujud/machine_test.go
@@ -1066,6 +1066,53 @@ func (s *MachineSuite) TestMachineAgentUpgradeMongo(c *gc.C) {
 	c.Assert(s.fakeEnsureMongo.initiateCount, gc.Equals, 1)
 }
 
+func (s *MachineSuite) TestMachineAgentSetsPrepareRestore(c *gc.C) {
+	// Start the machine agent.
+	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
+	a := s.newAgent(c, m)
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+	c.Check(a.IsRestorePreparing(), gc.Equals, false)
+	c.Check(a.IsRestoreRunning(), gc.Equals, false)
+	err := a.PrepareRestore()
+	c.Assert(err, gc.IsNil)
+	c.Assert(a.IsRestorePreparing(), gc.Equals, true)
+	c.Assert(a.IsRestoreRunning(), gc.Equals, false)
+	err = a.PrepareRestore()
+	c.Assert(err, gc.ErrorMatches, "already in restore mode")
+}
+
+func (s *MachineSuite) TestMachineAgentSetsRestoreInProgress(c *gc.C) {
+	// Start the machine agent.
+	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
+	a := s.newAgent(c, m)
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+	c.Check(a.IsRestorePreparing(), gc.Equals, false)
+	c.Check(a.IsRestoreRunning(), gc.Equals, false)
+	err := a.PrepareRestore()
+	c.Assert(err, gc.IsNil)
+	c.Assert(a.IsRestorePreparing(), gc.Equals, true)
+	err = a.BeginRestore()
+	c.Assert(err, gc.IsNil)
+	c.Assert(a.IsRestoreRunning(), gc.Equals, true)
+	err = a.BeginRestore()
+	c.Assert(err, gc.ErrorMatches, "already restoring")
+}
+
+func (s *MachineSuite) TestMachineAgentRestoreRequiresPrepare(c *gc.C) {
+	// Start the machine agent.
+	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
+	a := s.newAgent(c, m)
+	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	defer func() { c.Check(a.Stop(), gc.IsNil) }()
+	c.Check(a.IsRestorePreparing(), gc.Equals, false)
+	c.Check(a.IsRestoreRunning(), gc.Equals, false)
+	err := a.BeginRestore()
+	c.Assert(err, gc.ErrorMatches, "not in restore mode, cannot begin restoration")
+	c.Assert(a.IsRestoreRunning(), gc.Equals, false)
+}
+
 // MachineWithCharmsSuite provides infrastructure for tests which need to
 // work with charms.
 type MachineWithCharmsSuite struct {


### PR DESCRIPTION
The main goal of this PR is to prevent data loss
during the different steps of the restore process.
This will be used by restore once it lands.
This is the basic required functionality for this
API server mode.
Following a feaure implemented for Upgrade, an
api root server that can selectively allow API
commands depending on the Restore step we are
running.
When we are preparing a restore: that includes
uploading files if required for instance, the
API will only accept Client.Restore to be
triggered in order to avoid data loss when the
restore runs.
When Restore is running no calls will be allowed
since state server will be down.
