### PR TITLE
Remove the Remove

### DIFF
--- a/replicaset/replicaset_test.go
+++ b/replicaset/replicaset_test.go
@@ -201,6 +201,8 @@ func assertAddRemoveSet(c *gc.C, root *gitjujutesting.MgoInstance, getAddr func(
 	for i := 1; i < len(instances); i++ {
 		inst := newServer(c)
 		instances[i] = inst
+		// no need to Remove the instances from the replicaset as
+		// we're destroying the replica set immediately afterwards
 		defer inst.Destroy()
 		key := fmt.Sprintf("key%d", i)
 		val := fmt.Sprintf("val%d", i)


### PR DESCRIPTION
replicaset/replicaset_test : get rid of extraneous calls to Remove

Remove is a slow operation, and we're seeing spurious failures in CI here. We create a bunch of mongo instances and defer removing them from the replicaset. We destroy them immediately after removal, and then destroy the root, so the Remove is extraneous. This should improve test reliability.
