### PR TITLE
Reorder the closing of resources.

### DIFF
--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -451,7 +451,9 @@ func (s *JujuConnSuite) tearDownConn(c *gc.C) {
 	var dbSession *mgo.Session
 	if s.State != nil {
 		// Copy the mongo session so we can reset the mongo password below.
-		dbSession = s.State.MongoSession().Copy()
+		if serverAlive {
+			dbSession = s.State.MongoSession().Copy()
+		}
 		err := s.State.Close()
 		if serverAlive {
 			// This happens way too often with failing tests,


### PR DESCRIPTION
There seemed to be some ordering issues with the tear down.

We should be closing any api connections first, as they depend on the state connection.
Then we should close the state connection.
Once all that is done, we should reset the mongo admin password.

Hopefully fixes https://bugs.launchpad.net/juju-core/+bug/1348477
