### PR TITLE
Move the tests inline

### DIFF
--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -29,125 +29,6 @@ var _ = gc.Suite(&permSuite{})
 // (usually due to "permission denied"). There are separate test cases
 // testing each individual API call data flow later on.
 
-var (
-	userAdmin = names.NewUserTag("admin")
-	userOther = names.NewUserTag("other")
-)
-
-var operationPermTests = []struct {
-	about string
-	// op performs the operation to be tested using the given state
-	// connection. It returns a function that should be used to
-	// undo any changes made by the operation.
-	op    func(c *gc.C, st *api.State, mst *state.State) (reset func(), err error)
-	allow []names.Tag
-	deny  []names.Tag
-}{{
-	about: "Client.Status",
-	op:    opClientStatus,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceSet",
-	op:    opClientServiceSet,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceSetYAML",
-	op:    opClientServiceSetYAML,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceGet",
-	op:    opClientServiceGet,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.Resolved",
-	op:    opClientResolved,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceExpose",
-	op:    opClientServiceExpose,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceUnexpose",
-	op:    opClientServiceUnexpose,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceDeploy",
-	op:    opClientServiceDeploy,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceDeployWithNetworks",
-	op:    opClientServiceDeployWithNetworks,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceUpdate",
-	op:    opClientServiceUpdate,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceSetCharm",
-	op:    opClientServiceSetCharm,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.GetAnnotations",
-	op:    opClientGetAnnotations,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.SetAnnotations",
-	op:    opClientSetAnnotations,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.AddServiceUnits",
-	op:    opClientAddServiceUnits,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.DestroyServiceUnits",
-	op:    opClientDestroyServiceUnits,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.ServiceDestroy",
-	op:    opClientServiceDestroy,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.GetServiceConstraints",
-	op:    opClientGetServiceConstraints,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.SetServiceConstraints",
-	op:    opClientSetServiceConstraints,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.SetEnvironmentConstraints",
-	op:    opClientSetEnvironmentConstraints,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.EnvironmentGet",
-	op:    opClientEnvironmentGet,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.EnvironmentSet",
-	op:    opClientEnvironmentSet,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.SetEnvironAgentVersion",
-	op:    opClientSetEnvironAgentVersion,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.WatchAll",
-	op:    opClientWatchAll,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.CharmInfo",
-	op:    opClientCharmInfo,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.AddRelation",
-	op:    opClientAddRelation,
-	allow: []names.Tag{userAdmin, userOther},
-}, {
-	about: "Client.DestroyRelation",
-	op:    opClientDestroyRelation,
-	allow: []names.Tag{userAdmin, userOther},
-}}
-
 // allowed returns the set of allowed entities given an allow list and a
 // deny list.  If an allow list is specified, only those entities are
 // allowed; otherwise those in deny are disallowed.
@@ -172,8 +53,124 @@ loop:
 }
 
 func (s *permSuite) TestOperationPerm(c *gc.C) {
+	var (
+		userAdmin = names.NewUserTag("admin")
+		userOther = names.NewUserTag("other")
+	)
 	entities := s.setUpScenario(c)
-	for i, t := range operationPermTests {
+	for i, t := range []struct {
+		about string
+		// op performs the operation to be tested using the given state
+		// connection. It returns a function that should be used to
+		// undo any changes made by the operation.
+		op    func(c *gc.C, st *api.State, mst *state.State) (reset func(), err error)
+		allow []names.Tag
+		deny  []names.Tag
+	}{{
+		about: "Client.Status",
+		op:    opClientStatus,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceSet",
+		op:    opClientServiceSet,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceSetYAML",
+		op:    opClientServiceSetYAML,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceGet",
+		op:    opClientServiceGet,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.Resolved",
+		op:    opClientResolved,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceExpose",
+		op:    opClientServiceExpose,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceUnexpose",
+		op:    opClientServiceUnexpose,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceDeploy",
+		op:    opClientServiceDeploy,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceDeployWithNetworks",
+		op:    opClientServiceDeployWithNetworks,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceUpdate",
+		op:    opClientServiceUpdate,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceSetCharm",
+		op:    opClientServiceSetCharm,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.GetAnnotations",
+		op:    opClientGetAnnotations,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.SetAnnotations",
+		op:    opClientSetAnnotations,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.AddServiceUnits",
+		op:    opClientAddServiceUnits,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.DestroyServiceUnits",
+		op:    opClientDestroyServiceUnits,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.ServiceDestroy",
+		op:    opClientServiceDestroy,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.GetServiceConstraints",
+		op:    opClientGetServiceConstraints,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.SetServiceConstraints",
+		op:    opClientSetServiceConstraints,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.SetEnvironmentConstraints",
+		op:    opClientSetEnvironmentConstraints,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.EnvironmentGet",
+		op:    opClientEnvironmentGet,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.EnvironmentSet",
+		op:    opClientEnvironmentSet,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.SetEnvironAgentVersion",
+		op:    opClientSetEnvironAgentVersion,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.WatchAll",
+		op:    opClientWatchAll,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.CharmInfo",
+		op:    opClientCharmInfo,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.AddRelation",
+		op:    opClientAddRelation,
+		allow: []names.Tag{userAdmin, userOther},
+	}, {
+		about: "Client.DestroyRelation",
+		op:    opClientDestroyRelation,
+		allow: []names.Tag{userAdmin, userOther},
+	}} {
 		allow := allowed(entities, t.allow, t.deny)
 		for _, e := range entities {
 			c.Logf("test %d; %s; entity %q", i, t.about, e)


### PR DESCRIPTION
Refactoring the test to allow for a smaller diff later when we change the user tags.

This change just moves the tests and the variables to be in the test function.
