### PR TITLE
Remove the user checking for the keymanager.

### DIFF
--- a/api/keymanager/client_test.go
+++ b/api/keymanager/client_test.go
@@ -43,7 +43,7 @@ func (s *keymanagerSuite) TestListKeys(c *gc.C) {
 	key2 := sshtesting.ValidKeyTwo.Key
 	s.setAuthorisedKeys(c, strings.Join([]string{key1, key2}, "\n"))
 
-	keyResults, err := s.keymanager.ListKeys(ssh.Fingerprints, state.AdminUser)
+	keyResults, err := s.keymanager.ListKeys(ssh.Fingerprints, s.AdminUserTag(c).Name())
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(keyResults), gc.Equals, 1)
 	result := keyResults[0]
@@ -53,6 +53,7 @@ func (s *keymanagerSuite) TestListKeys(c *gc.C) {
 }
 
 func (s *keymanagerSuite) TestListKeysErrors(c *gc.C) {
+	c.Skip("the user name isn't checked for existence yet")
 	keyResults, err := s.keymanager.ListKeys(ssh.Fingerprints, "invalid")
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(keyResults), gc.Equals, 1)
@@ -79,7 +80,7 @@ func (s *keymanagerSuite) TestAddKeys(c *gc.C) {
 	s.setAuthorisedKeys(c, key1)
 
 	newKeys := []string{sshtesting.ValidKeyTwo.Key, sshtesting.ValidKeyThree.Key, "invalid"}
-	errResults, err := s.keymanager.AddKeys(state.AdminUser, newKeys...)
+	errResults, err := s.keymanager.AddKeys(s.AdminUserTag(c).Name(), newKeys...)
 	c.Assert(err, gc.IsNil)
 	c.Assert(errResults, gc.DeepEquals, []params.ErrorResult{
 		{Error: nil},
@@ -125,7 +126,7 @@ func (s *keymanagerSuite) TestDeleteKeys(c *gc.C) {
 	initialKeys := []string{key1, key2, key3, "invalid"}
 	s.setAuthorisedKeys(c, strings.Join(initialKeys, "\n"))
 
-	errResults, err := s.keymanager.DeleteKeys(state.AdminUser, sshtesting.ValidKeyTwo.Fingerprint, "user@host", "missing")
+	errResults, err := s.keymanager.DeleteKeys(s.AdminUserTag(c).Name(), sshtesting.ValidKeyTwo.Fingerprint, "user@host", "missing")
 	c.Assert(err, gc.IsNil)
 	c.Assert(errResults, gc.DeepEquals, []params.ErrorResult{
 		{Error: nil},
@@ -142,7 +143,7 @@ func (s *keymanagerSuite) TestImportKeys(c *gc.C) {
 	s.setAuthorisedKeys(c, key1)
 
 	keyIds := []string{"lp:validuser", "invalid-key"}
-	errResults, err := s.keymanager.ImportKeys(state.AdminUser, keyIds...)
+	errResults, err := s.keymanager.ImportKeys(s.AdminUserTag(c).Name(), keyIds...)
 	c.Assert(err, gc.IsNil)
 	c.Assert(errResults, gc.DeepEquals, []params.ErrorResult{
 		{Error: nil},
@@ -165,6 +166,7 @@ func (s *keymanagerSuite) assertInvalidUserOperation(c *gc.C, test func(user str
 }
 
 func (s *keymanagerSuite) TestAddKeysInvalidUser(c *gc.C) {
+	c.Skip("no user validation done yet")
 	s.assertInvalidUserOperation(c, func(user string, keys []string) error {
 		_, err := s.keymanager.AddKeys(user, keys...)
 		return err
@@ -172,6 +174,7 @@ func (s *keymanagerSuite) TestAddKeysInvalidUser(c *gc.C) {
 }
 
 func (s *keymanagerSuite) TestDeleteKeysInvalidUser(c *gc.C) {
+	c.Skip("no user validation done yet")
 	s.assertInvalidUserOperation(c, func(user string, keys []string) error {
 		_, err := s.keymanager.DeleteKeys(user, keys...)
 		return err
@@ -179,6 +182,7 @@ func (s *keymanagerSuite) TestDeleteKeysInvalidUser(c *gc.C) {
 }
 
 func (s *keymanagerSuite) TestImportKeysInvalidUser(c *gc.C) {
+	c.Skip("no user validation done yet")
 	s.assertInvalidUserOperation(c, func(user string, keys []string) error {
 		_, err := s.keymanager.ImportKeys(user, keys...)
 		return err

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/utils/ssh"
 	sshtesting "github.com/juju/juju/utils/ssh/testing"
 )
@@ -37,7 +36,7 @@ func (s *keyManagerSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		Tag: names.NewUserTag(state.AdminUser),
+		Tag: s.AdminUserTag(c),
 	}
 	var err error
 	s.keymanager, err = keymanager.NewKeyManagerAPI(s.State, s.resources, s.authoriser)
@@ -91,7 +90,7 @@ func (s *keyManagerSuite) TestListKeys(c *gc.C) {
 
 	args := params.ListSSHKeys{
 		Entities: params.Entities{[]params.Entity{
-			{Tag: state.AdminUser},
+			{Tag: s.AdminUserTag(c).Name()},
 			{Tag: "invalid"},
 		}},
 		Mode: ssh.FullKeys,
@@ -101,7 +100,7 @@ func (s *keyManagerSuite) TestListKeys(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{
 			{Result: []string{key1, key2, "Invalid key: bad key"}},
-			{Error: apiservertesting.ErrUnauthorized},
+			{Result: []string{key1, key2, "Invalid key: bad key"}},
 		},
 	})
 }
@@ -121,7 +120,7 @@ func (s *keyManagerSuite) TestAddKeys(c *gc.C) {
 
 	newKey := sshtesting.ValidKeyThree.Key + " newuser@host"
 	args := params.ModifyUserSSHKeys{
-		User: state.AdminUser,
+		User: s.AdminUserTag(c).Name(),
 		Keys: []string{key2, newKey, "invalid-key"},
 	}
 	results, err := s.keymanager.AddKeys(args)
@@ -190,7 +189,7 @@ func (s *keyManagerSuite) TestDeleteKeys(c *gc.C) {
 	s.setAuthorisedKeys(c, strings.Join(initialKeys, "\n"))
 
 	args := params.ModifyUserSSHKeys{
-		User: state.AdminUser,
+		User: s.AdminUserTag(c).Name(),
 		Keys: []string{sshtesting.ValidKeyTwo.Fingerprint, sshtesting.ValidKeyThree.Fingerprint, "invalid-key"},
 	}
 	results, err := s.keymanager.DeleteKeys(args)
@@ -212,7 +211,7 @@ func (s *keyManagerSuite) TestCannotDeleteAllKeys(c *gc.C) {
 	s.setAuthorisedKeys(c, strings.Join(initialKeys, "\n"))
 
 	args := params.ModifyUserSSHKeys{
-		User: state.AdminUser,
+		User: s.AdminUserTag(c).Name(),
 		Keys: []string{sshtesting.ValidKeyTwo.Fingerprint, "user@host"},
 	}
 	_, err := s.keymanager.DeleteKeys(args)
@@ -239,6 +238,7 @@ func (s *keyManagerSuite) assertInvalidUserOperation(c *gc.C, runTestLogic func(
 }
 
 func (s *keyManagerSuite) TestAddKeysInvalidUser(c *gc.C) {
+	c.Skip("no user validation done yet")
 	s.assertInvalidUserOperation(c, func(args params.ModifyUserSSHKeys) error {
 		_, err := s.keymanager.AddKeys(args)
 		return err
@@ -246,6 +246,7 @@ func (s *keyManagerSuite) TestAddKeysInvalidUser(c *gc.C) {
 }
 
 func (s *keyManagerSuite) TestDeleteKeysInvalidUser(c *gc.C) {
+	c.Skip("no user validation done yet")
 	s.assertInvalidUserOperation(c, func(args params.ModifyUserSSHKeys) error {
 		_, err := s.keymanager.DeleteKeys(args)
 		return err
@@ -262,7 +263,7 @@ func (s *keyManagerSuite) TestImportKeys(c *gc.C) {
 	s.setAuthorisedKeys(c, strings.Join(initialKeys, "\n"))
 
 	args := params.ModifyUserSSHKeys{
-		User: state.AdminUser,
+		User: s.AdminUserTag(c).Name(),
 		Keys: []string{"lp:existing", "lp:validuser", "invalid-key"},
 	}
 	results, err := s.keymanager.ImportKeys(args)

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -30,14 +30,12 @@ var _ = gc.Suite(&metricsManagerSuite{})
 
 func (s *metricsManagerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-
-	user, err := s.State.User("admin")
-	c.Assert(err, gc.IsNil)
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag: user.Tag(),
+		Tag: s.AdminUserTag(c),
 	}
-	s.metricsmanager, err = metricsmanager.NewMetricsManagerAPI(s.State, nil, s.authorizer)
+	manager, err := metricsmanager.NewMetricsManagerAPI(s.State, nil, s.authorizer)
 	c.Assert(err, gc.IsNil)
+	s.metricsmanager = manager
 }
 
 func (s *metricsManagerSuite) TestCleanupOldMetrics(c *gc.C) {


### PR DESCRIPTION
The existing keymanager tests for specific users are skipped, but not removed.
I expect that sometime in the near future we will have keys stored for users, but we are not doing that just yet.
