### PR TITLE
Remove AddAdminUser and create the user when the environment is created.

### DIFF
--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -42,8 +42,6 @@ func (s *compatSuite) SetUpTest(c *gc.C) {
 	st, err := Initialize(TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), nil)
 	c.Assert(err, gc.IsNil)
 	s.state = st
-	_, err = s.state.AddAdminUser("pass")
-	c.Assert(err, gc.IsNil)
 	env, err := s.state.Environment()
 	c.Assert(err, gc.IsNil)
 	s.env = env

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -70,7 +70,6 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	cs.services = cs.MgoSuite.Session.DB("juju").C("services")
 	cs.units = cs.MgoSuite.Session.DB("juju").C("units")
 	cs.stateServers = cs.MgoSuite.Session.DB("juju").C("stateServers")
-	cs.State.AddAdminUser("pass")
 	cs.factory = factory.NewFactory(cs.State)
 	c.Log("SetUpTest done")
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
@@ -70,11 +71,25 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	cfg, err = s.State.EnvironConfig()
 	c.Assert(err, gc.IsNil)
 	c.Assert(cfg.AllAttrs(), gc.DeepEquals, initial)
-
+	// Check that the environment has been created.
 	env, err := s.State.Environment()
 	c.Assert(err, gc.IsNil)
 	c.Assert(env.Tag(), gc.Equals, envTag)
-	entity, err := s.State.FindEntity(envTag)
+	// Check that the owner has been created.
+	owner := names.NewUserTag("admin")
+	c.Assert(env.Owner(), gc.Equals, owner)
+	// Check that the owner can be retrieved by the tag.
+	entity, err := s.State.FindEntity(env.Owner())
+	c.Assert(err, gc.IsNil)
+	c.Assert(entity.Tag(), gc.Equals, owner)
+	// Check that the owner has an EnvUser created for the bootstrapped environment.
+	envUser, err := s.State.EnvironmentUser(env.Owner())
+	c.Assert(err, gc.IsNil)
+	c.Assert(envUser.UserTag().Username(), gc.Equals, env.Owner().Username())
+	c.Assert(envUser.EnvironmentTag(), gc.Equals, env.Tag())
+
+	// Check that the environment can be found through the tag.
+	entity, err = s.State.FindEntity(envTag)
 	c.Assert(err, gc.IsNil)
 	annotator := entity.(state.Annotator)
 	annotations, err := annotator.Annotations()

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -53,9 +53,9 @@ func (s *storeManagerStateSuite) SetUpTest(c *gc.C) {
 	st, err := Initialize(TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), nil)
 	c.Assert(err, gc.IsNil)
 	s.State = st
-	user, err := s.State.AddAdminUser("pass")
+	env, err := st.Environment()
 	c.Assert(err, gc.IsNil)
-	s.owner = user.UserTag()
+	s.owner = env.Owner()
 }
 
 func (s *storeManagerStateSuite) TearDownTest(c *gc.C) {

--- a/state/service.go
+++ b/state/service.go
@@ -618,20 +618,16 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	return name, ops, nil
 }
 
-// GetOwnerTag returns the owner of this service
-// SCHEMACHANGE
-// TODO(mattyw) remove when schema upgrades are possible
-func (s *serviceDoc) GetOwnerTag() string {
-	if s.OwnerTag != "" {
-		return s.OwnerTag
-	}
-	return "user-admin"
-}
-
 // SCHEMACHANGE
 // TODO(mattyw) remove when schema upgrades are possible
 func (s *Service) GetOwnerTag() string {
-	return s.doc.GetOwnerTag()
+	owner := s.doc.OwnerTag
+	if owner == "" {
+		// We know that if there was no owner, it was created with an early
+		// version of juju, and that admin was the only user.
+		owner = names.NewUserTag("admin").String()
+	}
+	return owner
 }
 
 // AddUnit adds a new principal unit to the service.

--- a/state/state.go
+++ b/state/state.go
@@ -1654,7 +1654,7 @@ func (st *State) StartSync() {
 // all subsequent attempts to access the state must
 // be authorized; otherwise no authorization is required.
 func (st *State) SetAdminMongoPassword(password string) error {
-	err := mongo.SetAdminMongoPassword(st.db.Session, AdminUser, password)
+	err := mongo.SetAdminMongoPassword(st.db.Session, mongo.AdminUser, password)
 	return errors.Trace(err)
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -6,6 +6,7 @@ package state
 import (
 	"time"
 
+	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/mgo.v2/bson"
@@ -90,15 +91,11 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestAddStateUsersToEnviron(c *gc.C) {
-	stateAdmin, err := s.state.AddUser("admin", "notused", "notused", "admin")
-	c.Assert(err, gc.IsNil)
 	stateBob, err := s.state.AddUser("bob", "notused", "notused", "bob")
 	c.Assert(err, gc.IsNil)
-	adminTag := stateAdmin.UserTag()
+	adminTag := names.NewUserTag("admin")
 	bobTag := stateBob.UserTag()
 
-	_, err = s.state.EnvironmentUser(adminTag)
-	c.Assert(err, gc.ErrorMatches, `envUser "admin@local" not found`)
 	_, err = s.state.EnvironmentUser(bobTag)
 	c.Assert(err, gc.ErrorMatches, `envUser "bob@local" not found`)
 
@@ -114,11 +111,9 @@ func (s *upgradesSuite) TestAddStateUsersToEnviron(c *gc.C) {
 }
 
 func (s *upgradesSuite) TestAddStateUsersToEnvironIdempotent(c *gc.C) {
-	stateAdmin, err := s.state.AddUser("admin", "notused", "notused", "admin")
-	c.Assert(err, gc.IsNil)
 	stateBob, err := s.state.AddUser("bob", "notused", "notused", "bob")
 	c.Assert(err, gc.IsNil)
-	adminTag := stateAdmin.UserTag()
+	adminTag := names.NewUserTag("admin")
 	bobTag := stateBob.UserTag()
 
 	err = AddStateUsersAsEnvironUsers(s.state)


### PR DESCRIPTION
The admin user is now created when the environment is created as part of the state initialization function.
The admin user also has an environment user record added for the initial environment.
