### PR TITLE
Expose a top-level abstraction for all the backups functionality.

### DIFF
--- a/state/backups/backups_test.go
+++ b/state/backups/backups_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io/ioutil"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/filestorage"
 	gc "launchpad.net/gocheck"
@@ -36,6 +37,14 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.api = backups.NewBackups(s.storage)
 }
 
+func (s *backupsSuite) checkFailure(c *gc.C, expected string) {
+	dbInfo := db.ConnInfo{"a", "b", "c"}
+	origin := metadata.NewOrigin("<env ID>", "<machine ID>", "<hostname>")
+	_, err := s.api.Create(dbInfo, *origin, "some notes")
+
+	c.Check(err, gc.ErrorMatches, expected)
+}
+
 func (s *backupsSuite) TestNewBackups(c *gc.C) {
 	api := backups.NewBackups(s.storage)
 
@@ -43,10 +52,11 @@ func (s *backupsSuite) TestNewBackups(c *gc.C) {
 }
 
 func (s *backupsSuite) TestCreateOkay(c *gc.C) {
+
 	// Patch the internals.
 	archiveFile := ioutil.NopCloser(bytes.NewBufferString("<compressed tarball>"))
 	result := backups.NewTestCreateResult(archiveFile, 10, "<checksum>")
-	received, testCreate := backups.NewTestCreate(result, nil)
+	received, testCreate := backups.NewTestCreate(result)
 	s.PatchValue(backups.RunCreate, testCreate)
 
 	rootDir := "<was never set>"
@@ -96,4 +106,44 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	data, err := ioutil.ReadAll(storedFile)
 	c.Assert(err, gc.IsNil)
 	c.Check(string(data), gc.Equals, "<compressed tarball>")
+}
+
+func (s *backupsSuite) TestCreateFailToListFiles(c *gc.C) {
+	s.PatchValue(backups.GetFilesToBackUp, func(root string) ([]string, error) {
+		return nil, errors.New("failed!")
+	})
+
+	s.checkFailure(c, "while listing files to back up: failed!")
+}
+
+func (s *backupsSuite) TestCreateFailToCreate(c *gc.C) {
+	s.PatchValue(backups.GetFilesToBackUp, func(root string) ([]string, error) {
+		return []string{}, nil
+	})
+	s.PatchValue(backups.RunCreate, backups.NewTestCreateFailure("failed!"))
+
+	s.checkFailure(c, "while creating backup archive: failed!")
+}
+
+func (s *backupsSuite) TestCreateFailToFinishMeta(c *gc.C) {
+	s.PatchValue(backups.GetFilesToBackUp, func(root string) ([]string, error) {
+		return []string{}, nil
+	})
+	_, testCreate := backups.NewTestCreate(nil)
+	s.PatchValue(backups.RunCreate, testCreate)
+	s.PatchValue(backups.FinishMeta, backups.NewTestMetaFinisher("failed!"))
+
+	s.checkFailure(c, "while updating metadata: failed!")
+}
+
+func (s *backupsSuite) TestCreateFailToStoreArchive(c *gc.C) {
+	s.PatchValue(backups.GetFilesToBackUp, func(root string) ([]string, error) {
+		return []string{}, nil
+	})
+	_, testCreate := backups.NewTestCreate(nil)
+	s.PatchValue(backups.RunCreate, testCreate)
+	s.PatchValue(backups.FinishMeta, backups.NewTestMetaFinisher(""))
+	s.PatchValue(backups.StoreArchive, backups.NewTestArchiveStorer("failed!"))
+
+	s.checkFailure(c, "while storing backup archive: failed!")
 }

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -4,9 +4,15 @@
 package backups
 
 import (
+	"bytes"
 	"io"
+	"io/ioutil"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/filestorage"
 
 	"github.com/juju/juju/state/backups/db"
+	"github.com/juju/juju/state/backups/metadata"
 )
 
 var (
@@ -15,6 +21,8 @@ var (
 	GetFilesToBackUp = &getFilesToBackUp
 	GetDBDumper      = &getDBDumper
 	RunCreate        = &runCreate
+	FinishMeta       = &finishMeta
+	StoreArchive     = &storeArchive
 )
 
 func ExposeCreateResult(result *createResult) (io.ReadCloser, int64, string) {
@@ -42,16 +50,42 @@ func NewTestCreateResult(file io.ReadCloser, size int64, checksum string) *creat
 	return &result
 }
 
-func NewTestCreate(result *createResult, err error) (*createArgs, func(*createArgs) (*createResult, error)) {
+func NewTestCreate(result *createResult) (*createArgs, func(*createArgs) (*createResult, error)) {
 	var received createArgs
+
+	if result == nil {
+		archiveFile := ioutil.NopCloser(bytes.NewBufferString("<archive>"))
+		result = NewTestCreateResult(archiveFile, 10, "<checksum>")
+	}
 
 	testCreate := func(args *createArgs) (*createResult, error) {
 		received = *args
-		if err != nil {
-			return nil, err
-		}
 		return result, nil
 	}
 
 	return &received, testCreate
+}
+
+func NewTestCreateFailure(failure string) func(*createArgs) (*createResult, error) {
+	return func(*createArgs) (*createResult, error) {
+		return nil, errors.New(failure)
+	}
+}
+
+func NewTestMetaFinisher(failure string) func(*metadata.Metadata, *createResult) error {
+	return func(*metadata.Metadata, *createResult) error {
+		if failure == "" {
+			return nil
+		}
+		return errors.New(failure)
+	}
+}
+
+func NewTestArchiveStorer(failure string) func(filestorage.FileStorage, *metadata.Metadata, io.Reader) error {
+	return func(filestorage.FileStorage, *metadata.Metadata, io.Reader) error {
+		if failure == "" {
+			return nil
+		}
+		return errors.New(failure)
+	}
 }


### PR DESCRIPTION
This patch adds a top-level backups abstraction.  It also exposes the backup creation functionality through a method.

The PR that will follow this one:
  https://github.com/ericsnowcurrently/juju/pull/4
