### PR TITLE
state: Make GetOwnerTag return names.UserTag

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -893,7 +893,9 @@ func (s *clientSuite) TestClientServiceDeployServiceOwner(c *gc.C) {
 
 	service, err := s.State.Service("service")
 	c.Assert(err, gc.IsNil)
-	c.Assert(service.GetOwnerTag(), gc.Equals, user.Tag().String())
+	tag, err := service.GetOwnerTag()
+	c.Assert(err, gc.IsNil)
+	c.Assert(tag, gc.Equals, user.Tag())
 }
 
 func (s *clientSuite) deployServiceForTests(c *gc.C, store *charmtesting.MockCharmStore) {

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -1250,8 +1250,12 @@ func (u *UniterAPI) GetOwnerTag(args params.Entities) (params.StringResult, erro
 	if err != nil {
 		return nothing, err
 	}
+	ownerTag, err := service.GetOwnerTag()
+	if err != nil {
+		return params.StringResult{}, errors.Trace(err)
+	}
 	return params.StringResult{
-		Result: service.GetOwnerTag(),
+		Result: ownerTag.String(),
 	}, nil
 }
 

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -69,11 +69,13 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	s.assertSettings(c, service, charm.Settings{})
 	s.assertConstraints(c, service, constraints.Value{})
 	s.assertMachines(c, service, constraints.Value{})
-	c.Assert(service.GetOwnerTag(), gc.Equals, s.AdminUserTag(c).String())
+	tag, err := service.GetOwnerTag()
+	c.Assert(err, gc.IsNil)
+	c.Assert(tag, gc.Equals, s.AdminUserTag(c))
 }
 
 func (s *DeployLocalSuite) TestDeployOwnerTag(c *gc.C) {
-	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 	service, err := juju.DeployService(s.State,
 		juju.DeployServiceParams{
 			ServiceName:  "bobwithowner",
@@ -81,7 +83,9 @@ func (s *DeployLocalSuite) TestDeployOwnerTag(c *gc.C) {
 			ServiceOwner: "user-foobar",
 		})
 	c.Assert(err, gc.IsNil)
-	c.Assert(service.GetOwnerTag(), gc.Equals, "user-foobar")
+	tag, err := service.GetOwnerTag()
+	c.Assert(err, gc.IsNil)
+	c.Assert(tag, gc.Equals, user.Tag())
 }
 
 func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {

--- a/state/service.go
+++ b/state/service.go
@@ -620,14 +620,18 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 
 // SCHEMACHANGE
 // TODO(mattyw) remove when schema upgrades are possible
-func (s *Service) GetOwnerTag() string {
+func (s *Service) GetOwnerTag() (names.UserTag, error) {
 	owner := s.doc.OwnerTag
 	if owner == "" {
 		// We know that if there was no owner, it was created with an early
 		// version of juju, and that admin was the only user.
-		owner = names.NewUserTag("admin").String()
+		return names.NewUserTag("admin"), nil
 	}
-	return owner
+	tag, err := names.ParseUserTag(s.doc.OwnerTag)
+	if err != nil {
+		return names.UserTag{}, errors.Trace(err)
+	}
+	return tag, nil
 }
 
 // AddUnit adds a new principal unit to the service.

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -1484,7 +1484,9 @@ func (s *ServiceSuite) TestOwnerTagSchemaProtection(c *gc.C) {
 	service := s.AddTestingService(c, "foobar", s.charm)
 	state.SetServiceOwnerTag(service, "")
 	c.Assert(state.GetServiceOwnerTag(service), gc.Equals, "")
-	c.Assert(service.GetOwnerTag(), gc.Equals, "user-admin")
+	tag, err := service.GetOwnerTag()
+	c.Assert(err, gc.IsNil)
+	c.Assert(tag, gc.Equals, s.owner)
 }
 
 func (s *ServiceSuite) TestNetworks(c *gc.C) {

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -285,7 +285,9 @@ func (s *factorySuite) TestMakeService(c *gc.C) {
 	c.Assert(service, gc.NotNil)
 
 	c.Assert(service.Name(), gc.Equals, "wordpress")
-	c.Assert(service.GetOwnerTag(), gc.Equals, creator)
+	tag, err := service.GetOwnerTag()
+	c.Assert(err, gc.IsNil)
+	c.Assert(tag.String(), gc.Equals, creator)
 	curl, _ := service.CharmURL()
 	c.Assert(curl, gc.DeepEquals, charm.URL())
 


### PR DESCRIPTION
Update service.GetOwnerTag() to return a names.UserTag instead of a
string.