### PR TITLE
Mock out lumberjack config for tests.

### DIFF
--- a/cmd/jujud/agent_test.go
+++ b/cmd/jujud/agent_test.go
@@ -288,6 +288,12 @@ func (s *agentSuite) TearDownSuite(c *gc.C) {
 
 func (s *agentSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	// The standard jujud setupLogging replaces the default logger with one
+	// that uses a lumberjack rolling log file.  We want to make sure that all
+	// logging information from the agents when run through the tests continue
+	// to have the logging information available in the gocheck test logs, so
+	// we mock it out here.
+	s.PatchValue(&setupLogging, func(conf agent.Config) error { return nil })
 	// Set API host ports so FindTools/Tools API calls succeed.
 	hostPorts := [][]network.HostPort{{{
 		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
@@ -301,6 +307,7 @@ func (s *agentSuite) SetUpTest(c *gc.C) {
 // for an agent with the given entity name.  It returns the agent's
 // configuration and the current tools.
 func (s *agentSuite) primeAgent(c *gc.C, tag names.Tag, password string, vers version.Binary) (agent.ConfigSetterWriter, *coretools.Tools) {
+	logger.Debugf("priming agent %s", tag.String())
 	stor := s.Environ.Storage()
 	agentTools := envtesting.PrimeTools(c, stor, s.DataDir(), vers)
 	err := envtools.MergeAndWriteMetadata(stor, coretools.List{agentTools}, envtools.DoNotWriteMirrors)
@@ -337,6 +344,8 @@ func (s *agentSuite) primeAPIHostPorts(c *gc.C) {
 
 	err = s.State.SetAPIHostPorts([][]network.HostPort{{hostPort}})
 	c.Assert(err, gc.IsNil)
+
+	logger.Debugf("api host ports primed %#v", hostPort)
 }
 
 func parseHostPort(s string) (network.HostPort, error) {

--- a/cmd/jujud/machine_test.go
+++ b/cmd/jujud/machine_test.go
@@ -676,6 +676,7 @@ func (s *MachineSuite) assertAgentOpensState(
 	stm, conf, _ := s.primeAgent(c, version.Current, job)
 	a := s.newAgent(c, stm)
 	defer a.Stop()
+	logger.Debugf("new agent %#v", a)
 
 	// All state jobs currently also run an APIWorker, so no
 	// need to check for that here, like in assertJobWithState.

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -189,7 +189,7 @@ func (*simpleFormatter) Format(level loggo.Level, module string, timestamp time.
 //
 // NOTE: do not use this in the bootstrap agent, or
 // if you do, change the bootstrap error reporting.
-func setupLogging(conf agent.Config) error {
+func setupAgentLogging(conf agent.Config) error {
 	filename := filepath.Join(conf.LogDir(), conf.Tag().String()+".log")
 
 	log := &lumberjack.Logger{
@@ -202,3 +202,5 @@ func setupLogging(conf agent.Config) error {
 	_, err := loggo.ReplaceDefaultWriter(writer)
 	return err
 }
+
+var setupLogging = setupAgentLogging

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -244,7 +244,7 @@ var argsTests = []struct {
 
 func (s *JujuCMainSuite) TestArgs(c *gc.C) {
 	for _, t := range argsTests {
-		fmt.Println(t.args)
+		c.Log(t.args)
 		output := run(c, s.sockPath, "bill", t.code, t.args...)
 		c.Assert(output, gc.Equals, t.output)
 	}


### PR DESCRIPTION
Drive by also adds a few extra logging bits.
Changed a fmt.Printf to a c.Log to avoid extra test noise.
