### PR TITLE
Change state.User to take a names.UserTag

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -94,9 +94,16 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	err = cfg.Write()
 	c.Assert(err, gc.IsNil)
 
+	// Check that the environment has been set up.
+	env, err := st.Environment()
+	c.Assert(err, gc.IsNil)
+	uuid, ok := envCfg.UUID()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(env.UUID(), gc.Equals, uuid)
+
 	// Check that initial admin user has been set up correctly.
 	s.assertCanLogInAsAdmin(c, pwHash)
-	user, err := st.User("admin")
+	user, err := st.User(env.Owner())
 	c.Assert(err, gc.IsNil)
 	c.Assert(user.PasswordValid(testing.DefaultMongoPassword), jc.IsTrue)
 

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -32,7 +32,7 @@ func (s *usermanagerSuite) SetUpTest(c *gc.C) {
 func (s *usermanagerSuite) TestAddUser(c *gc.C) {
 	err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, gc.IsNil)
-	_, err = s.State.User("foobar")
+	_, err = s.State.User(names.NewLocalUserTag("foobar"))
 	c.Assert(err, gc.IsNil)
 }
 
@@ -46,19 +46,20 @@ func (s *usermanagerSuite) TestAddUserOldClient(c *gc.C) {
 	// type of argument.
 	err := s.APIState.APICall("UserManager", 0, "", "AddUser", userArgs, results)
 	c.Assert(err, gc.IsNil)
-	_, err = s.State.User("foobar")
+	_, err = s.State.User(names.NewLocalUserTag("foobar"))
 	c.Assert(err, gc.IsNil)
 }
 
 func (s *usermanagerSuite) TestRemoveUser(c *gc.C) {
 	err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, gc.IsNil)
-	_, err = s.State.User("foobar")
+	userTag := names.NewLocalUserTag("foobar")
+	_, err = s.State.User(userTag)
 	c.Assert(err, gc.IsNil)
 
 	err = s.usermanager.RemoveUser("foobar")
 	c.Assert(err, gc.IsNil)
-	user, err := s.State.User("foobar")
+	user, err := s.State.User(userTag)
 	c.Assert(user.IsDeactivated(), gc.Equals, true)
 }
 
@@ -77,8 +78,9 @@ func (s *usermanagerSuite) TestCantRemoveAdminUser(c *gc.C) {
 }
 
 func (s *usermanagerSuite) TestUserInfo(c *gc.C) {
-	tag := names.NewUserTag("foobar")
-	user := s.Factory.MakeUser(c, &factory.UserParams{Name: tag.Id(), DisplayName: "Foo Bar"})
+	tag := names.NewLocalUserTag("foobar")
+	user := s.Factory.MakeUser(c, &factory.UserParams{
+		Name: tag.Name(), DisplayName: "Foo Bar"})
 
 	obtained, err := s.usermanager.UserInfo(tag.String())
 	c.Assert(err, gc.IsNil)
@@ -101,7 +103,7 @@ func (s *usermanagerSuite) TestUserInfoNoResults(c *gc.C) {
 			return nil
 		},
 	)
-	tag := names.NewUserTag("foobar")
+	tag := names.NewLocalUserTag("foobar")
 	_, err := s.usermanager.UserInfo(tag.String())
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 0")
 }
@@ -115,16 +117,16 @@ func (s *usermanagerSuite) TestUserInfoMoreThanOneResult(c *gc.C) {
 			return nil
 		},
 	)
-	tag := names.NewUserTag("foobar")
+	tag := names.NewLocalUserTag("foobar")
 	_, err := s.usermanager.UserInfo(tag.String())
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
 func (s *usermanagerSuite) TestSetUserPassword(c *gc.C) {
-	name := s.AdminUserTag(c).Name()
-	err := s.usermanager.SetPassword(name, "new-password")
+	tag := s.AdminUserTag(c)
+	err := s.usermanager.SetPassword(tag.Name(), "new-password")
 	c.Assert(err, gc.IsNil)
-	user, err := s.State.User(name)
+	user, err := s.State.User(tag)
 	c.Assert(err, gc.IsNil)
 	c.Assert(user.PasswordValid("new-password"), gc.Equals, true)
 }

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -327,7 +327,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	add := func(e state.Entity) {
 		entities = append(entities, e.Tag())
 	}
-	u, err := s.State.User(s.AdminUserTag(c).Name())
+	u, err := s.State.User(s.AdminUserTag(c))
 	c.Assert(err, gc.IsNil)
 	setDefaultPassword(c, u)
 	add(u)

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -54,8 +54,8 @@ loop:
 
 func (s *permSuite) TestOperationPerm(c *gc.C) {
 	var (
-		userAdmin = names.NewUserTag("admin")
-		userOther = names.NewUserTag("other")
+		userAdmin = s.AdminUserTag(c)
+		userOther = names.NewLocalUserTag("other")
 	)
 	entities := s.setUpScenario(c)
 	for i, t := range []struct {
@@ -172,8 +172,8 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 		allow: []names.Tag{userAdmin, userOther},
 	}} {
 		allow := allowed(entities, t.allow, t.deny)
-		for _, e := range entities {
-			c.Logf("test %d; %s; entity %q", i, t.about, e)
+		for j, e := range entities {
+			c.Logf("\n------\ntest %d,%d; %s; entity %q", i, j, t.about, e)
 			st := s.openAs(c, e)
 			reset, err := t.op(c, st, s.State)
 			if allow[e] {

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -61,7 +61,7 @@ func (s *userManagerSuite) TestAddUser(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0], gc.DeepEquals, params.ErrorResult{Error: nil})
 	// Check that the call results in a new user being created
-	user, err := s.State.User("foobar")
+	user, err := s.State.User(names.NewLocalUserTag("foobar"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(user, gc.NotNil)
 	c.Assert(user.Name(), gc.Equals, "foobar")
@@ -81,13 +81,13 @@ func (s *userManagerSuite) TestRemoveUser(c *gc.C) {
 	removeArgs := params.Entities{Entities: []params.Entity{removeArg}}
 	_, err := s.usermanager.AddUser(args)
 	c.Assert(err, gc.IsNil)
-	user, err := s.State.User("foobar")
+	user, err := s.State.User(names.NewLocalUserTag("foobar"))
 	c.Assert(user.IsDeactivated(), gc.Equals, false) // The user should be active
 
 	result, err := s.usermanager.RemoveUser(removeArgs)
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{params.ErrorResult{Error: nil}}})
-	user, err = s.State.User("foobar")
+	user, err = s.State.User(names.NewLocalUserTag("foobar"))
 	c.Assert(err, gc.IsNil)
 	// Removal makes the user in active
 	c.Assert(user.IsDeactivated(), gc.Equals, true)
@@ -113,7 +113,7 @@ func (s *userManagerSuite) TestCannotAddRemoveAdd(c *gc.C) {
 
 	_, err = s.usermanager.RemoveUser(removeArgs)
 	c.Assert(err, gc.IsNil)
-	_, err = s.State.User("addremove")
+	_, err = s.State.User(names.NewLocalUserTag("addremove"))
 	result, err := s.usermanager.AddUser(args)
 	expectedError := apiservertesting.ServerError("failed to create user: user already exists")
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
@@ -124,8 +124,8 @@ func (s *userManagerSuite) TestCannotAddRemoveAdd(c *gc.C) {
 func (s *userManagerSuite) TestUserInfoUsersExist(c *gc.C) {
 	foobar := "foobar"
 	barfoo := "barfoo"
-	fooTag := names.NewUserTag(foobar)
-	barTag := names.NewUserTag(barfoo)
+	fooTag := names.NewLocalUserTag(foobar)
+	barTag := names.NewLocalUserTag(barfoo)
 	userFoo := s.Factory.MakeUser(c, &factory.UserParams{Name: foobar, DisplayName: "Foo Bar"})
 	userBar := s.Factory.MakeUser(c, &factory.UserParams{Name: barfoo, DisplayName: "Bar Foo"})
 
@@ -160,7 +160,7 @@ func (s *userManagerSuite) TestUserInfoUsersExist(c *gc.C) {
 
 func (s *userManagerSuite) TestUserInfoUserExists(c *gc.C) {
 	foobar := "foobar"
-	fooTag := names.NewUserTag(foobar)
+	fooTag := names.NewLocalUserTag(foobar)
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: foobar, DisplayName: "Foo Bar"})
 
 	args := params.Entities{
@@ -186,7 +186,7 @@ func (s *userManagerSuite) TestUserInfoUserExists(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestUserInfoUserDoesNotExist(c *gc.C) {
-	userTag := names.NewUserTag("foobar")
+	userTag := names.NewLocalUserTag("foobar")
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: userTag.String()}},
 	}
@@ -263,6 +263,8 @@ func (s *userManagerSuite) TestAgentUnauthorized(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestSetPassword(c *gc.C) {
+	// We are using the admin user here until we add other checks about the
+	// owner of the initial environment.
 	args := usermanager.ModifyUsers{
 		Changes: []usermanager.ModifyUser{{
 			Username: s.adminName,
@@ -273,7 +275,7 @@ func (s *userManagerSuite) TestSetPassword(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0], gc.DeepEquals, params.ErrorResult{Error: nil})
 
-	adminUser, err := s.State.User(s.adminName)
+	adminUser, err := s.State.User(names.NewUserTag(s.adminName))
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(adminUser.PasswordValid("new-password"), gc.Equals, true)
@@ -306,7 +308,7 @@ func (s *userManagerSuite) TestSetMultiplePasswords(c *gc.C) {
 	c.Assert(results.Results[0], gc.DeepEquals, params.ErrorResult{Error: nil})
 	c.Assert(results.Results[1], gc.DeepEquals, params.ErrorResult{Error: nil})
 
-	adminUser, err := s.State.User(s.adminName)
+	adminUser, err := s.State.User(names.NewUserTag(s.adminName))
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(adminUser.PasswordValid("new-password2"), gc.Equals, true)
@@ -326,6 +328,6 @@ func (s *userManagerSuite) TestSetPasswordOnDifferentUser(c *gc.C) {
 	results, err := s.usermanager.SetPassword(args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
-	expectedError := apiservertesting.ServerError("Can only change the password of the current user (admin)")
+	expectedError := apiservertesting.ServerError("Can only change the password of the current user (admin@local)")
 	c.Assert(results.Results[0], gc.DeepEquals, params.ErrorResult{Error: expectedError})
 }

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -392,7 +392,7 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 
 	// Check that the admin user has been given an appropriate
 	// password
-	u, err := st.User("admin")
+	u, err := st.User(names.NewLocalUserTag("admin"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(u.PasswordValid(testPassword), gc.Equals, true)
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -110,7 +110,7 @@ func (s *JujuConnSuite) Reset(c *gc.C) {
 }
 
 func (s *JujuConnSuite) AdminUserTag(c *gc.C) names.UserTag {
-	return names.NewUserTag(state.AdminUser)
+	return names.NewLocalUserTag(state.AdminUser)
 }
 
 func (s *JujuConnSuite) MongoInfo(c *gc.C) *mongo.MongoInfo {
@@ -539,7 +539,8 @@ func (s *JujuConnSuite) AddTestingService(c *gc.C, name string, ch *state.Charm)
 
 func (s *JujuConnSuite) AddTestingServiceWithNetworks(c *gc.C, name string, ch *state.Charm, networks []string) *state.Service {
 	c.Assert(s.State, gc.NotNil)
-	service, err := s.State.AddService(name, "user-admin", ch, networks)
+	owner := s.AdminUserTag(c).String()
+	service, err := s.State.AddService(name, owner, ch, networks)
 	c.Assert(err, gc.IsNil)
 	return service
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -98,7 +98,7 @@ func SampleConfig() testing.Attrs {
 // tests a way to get to the user name that was used to initialise the
 // database, and as such, is the owner of the initial environment.
 func AdminUserTag() names.UserTag {
-	return names.NewUserTag("admin")
+	return names.NewLocalUserTag("admin")
 }
 
 // stateInfo returns a *state.Info which allows clients to connect to the
@@ -701,8 +701,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 		if err != nil {
 			panic(err)
 		}
-		// TODO(thumper): make the state.User method require a names.UserTag.
-		owner, err := st.User(env.Owner().Name())
+		owner, err := st.User(env.Owner())
 		if err != nil {
 			panic(err)
 		}

--- a/state/environ.go
+++ b/state/environ.go
@@ -72,7 +72,7 @@ func (e *Environment) Life() Life {
 // The owner is the user that created the environment.
 func (e *Environment) Owner() names.UserTag {
 	// For now, just returns "admin".
-	return names.NewUserTag(AdminUser)
+	return names.NewLocalUserTag(AdminUser)
 }
 
 // globalKey returns the global database key for the environment.

--- a/state/envuser.go
+++ b/state/envuser.go
@@ -106,7 +106,7 @@ func (st *State) EnvironmentUser(user names.UserTag) (*EnvironmentUser, error) {
 	id := envUserID(st.EnvironTag().Id(), user.Username())
 	err := envUsers.FindId(id).One(&envUser.doc)
 	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("envUser %q", user.Username())
+		return nil, errors.NotFoundf("environment user %q", user.Username())
 	}
 	return envUser, nil
 }
@@ -116,7 +116,7 @@ func (st *State) AddEnvironmentUser(user, createdBy names.UserTag) (*Environment
 	var displayName string
 	// Ensure local user exists in state before adding them as an environment user.
 	if user.IsLocal() {
-		localUser, err := st.User(user.Name())
+		localUser, err := st.User(user)
 		if err != nil {
 			return nil, errors.Annotate(err, fmt.Sprintf("user %q does not exist locally", user.Name()))
 		}
@@ -125,7 +125,7 @@ func (st *State) AddEnvironmentUser(user, createdBy names.UserTag) (*Environment
 
 	// Ensure local createdBy user exists.
 	if createdBy.IsLocal() {
-		if _, err := st.User(createdBy.Name()); err != nil {
+		if _, err := st.User(createdBy); err != nil {
 			return nil, errors.Annotate(err, fmt.Sprintf("createdBy user %q does not exist locally", createdBy.Name()))
 		}
 	}

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -76,7 +76,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(env.Tag(), gc.Equals, envTag)
 	// Check that the owner has been created.
-	owner := names.NewUserTag("admin")
+	owner := names.NewLocalUserTag("admin")
 	c.Assert(env.Owner(), gc.Equals, owner)
 	// Check that the owner can be retrieved by the tag.
 	entity, err := s.State.FindEntity(env.Owner())

--- a/state/open.go
+++ b/state/open.go
@@ -80,7 +80,7 @@ func Initialize(info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, 
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
-	owner := names.NewUserTag("admin")
+	owner := names.NewLocalUserTag("admin")
 	logger.Infof("initializing environment, owner: %q", owner.Username())
 	logger.Infof("info: %#v", info)
 	if err := checkEnvironConfig(cfg); err != nil {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1216,7 +1216,7 @@ func (s *StateSuite) TestAddServiceNotUserTag(c *gc.C) {
 func (s *StateSuite) TestAddServiceNonExistentUser(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
 	_, err := s.State.AddService("wordpress", "user-notAuser", charm, nil)
-	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": user notAuser doesn't exist")
+	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": environment user "notAuser@local" not found`)
 }
 
 func (s *StateSuite) TestAllServices(c *gc.C) {
@@ -2255,6 +2255,11 @@ var findEntityTests = []findEntityTest{{
 	err: `action "ser-vice2_a_0" not found`,
 }, {
 	tag: names.NewUserTag("eric"),
+}, {
+	tag: names.NewUserTag("eric@local"),
+}, {
+	tag: names.NewUserTag("eric@remote"),
+	err: `user "eric@remote" not found`,
 }}
 
 var entityTypes = map[string]interface{}{
@@ -2317,6 +2322,10 @@ func (s *StateSuite) TestFindEntity(c *gc.C) {
 				// We *should* only be able to get the entity with its tag, but
 				// for backwards-compatibility we accept any non-UUID tag.
 				c.Assert(e.Tag(), gc.Equals, env.Tag())
+			} else if kind == "user" {
+				// Test the fully qualified username rather than the tag structure itself.
+				expected := test.tag.(names.UserTag).Username()
+				c.Assert(e.Tag().(names.UserTag).Username(), gc.Equals, expected)
 			} else {
 				c.Assert(e.Tag(), gc.Equals, test.tag)
 			}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -76,7 +76,7 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 
 	err = MigrateUserLastConnectionToLastLogin(s.state)
 	c.Assert(err, gc.IsNil)
-	user, err := s.state.User(userId)
+	user, err := s.state.User(names.NewLocalUserTag(userId))
 	c.Assert(err, gc.IsNil)
 	c.Assert(*user.LastLogin(), gc.Equals, now)
 
@@ -97,7 +97,7 @@ func (s *upgradesSuite) TestAddStateUsersToEnviron(c *gc.C) {
 	bobTag := stateBob.UserTag()
 
 	_, err = s.state.EnvironmentUser(bobTag)
-	c.Assert(err, gc.ErrorMatches, `envUser "bob@local" not found`)
+	c.Assert(err, gc.ErrorMatches, `environment user "bob@local" not found`)
 
 	err = AddStateUsersAsEnvironUsers(s.state)
 	c.Assert(err, gc.IsNil)

--- a/state/user.go
+++ b/state/user.go
@@ -103,9 +103,12 @@ func (st *State) getUser(name string, udoc *userDoc) error {
 }
 
 // User returns the state User for the given name,
-func (st *State) User(name string) (*User, error) {
+func (st *State) User(tag names.UserTag) (*User, error) {
+	if !tag.IsLocal() {
+		return nil, errors.NotFoundf("user %q", tag.Username())
+	}
 	user := &User{st: st}
-	if err := st.getUser(name, &user.doc); err != nil {
+	if err := st.getUser(tag.Name(), &user.doc); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return user, nil
@@ -131,7 +134,7 @@ type userDoc struct {
 
 // String returns "<name>@local" where <name> is the Name of the user.
 func (u *User) String() string {
-	return fmt.Sprintf("%s@%s", u.Name(), localUserProviderName)
+	return u.UserTag().Username()
 }
 
 // Name returns the User name.
@@ -161,7 +164,7 @@ func (u *User) Tag() names.Tag {
 
 // UserTag returns the Tag for the User.
 func (u *User) UserTag() names.UserTag {
-	return names.NewUserTag(u.doc.Name)
+	return names.NewLocalUserTag(u.doc.Name)
 }
 
 // LastLogin returns when this User last connected through the API in UTC.

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -57,7 +57,7 @@ func (s *UserSuite) TestAddUser(c *gc.C) {
 		user.DateCreated().Equal(now), jc.IsTrue)
 	c.Assert(user.LastLogin(), gc.IsNil)
 
-	user, err = s.State.User(name)
+	user, err = s.State.User(user.UserTag())
 	c.Assert(err, gc.IsNil)
 	c.Assert(user, gc.NotNil)
 	c.Assert(user.Name(), gc.Equals, name)
@@ -96,7 +96,7 @@ func (s *UserSuite) TestUpdateLastLogin(c *gc.C) {
 func (s *UserSuite) TestSetPassword(c *gc.C) {
 	user := s.factory.MakeUser(c, nil)
 	testSetPassword(c, func() (state.Authenticator, error) {
-		return s.State.User(user.Name())
+		return s.State.User(user.UserTag())
 	})
 }
 
@@ -194,7 +194,7 @@ func (s *UserSuite) TestPasswordValidUpdatesSalt(c *gc.C) {
 }
 
 func (s *UserSuite) TestCantDeactivateAdmin(c *gc.C) {
-	user, err := s.State.User(state.AdminUser)
+	user, err := s.State.User(s.owner)
 	c.Assert(err, gc.IsNil)
 	err = user.Deactivate()
 	c.Assert(err, gc.ErrorMatches, "cannot deactivate admin user")

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -74,7 +74,7 @@ func (s *factorySuite) TestMakeUserNil(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	c.Assert(user.IsDeactivated(), jc.IsFalse)
 
-	saved, err := s.State.User(user.Name())
+	saved, err := s.State.User(user.UserTag())
 	c.Assert(err, gc.IsNil)
 	c.Assert(saved.Tag(), gc.Equals, user.Tag())
 	c.Assert(saved.Name(), gc.Equals, user.Name())
@@ -102,7 +102,7 @@ func (s *factorySuite) TestMakeUserParams(c *gc.C) {
 	c.Assert(user.CreatedBy(), gc.Equals, creator.Name())
 	c.Assert(user.PasswordValid(password), jc.IsTrue)
 
-	saved, err := s.State.User(user.Name())
+	saved, err := s.State.User(user.UserTag())
 	c.Assert(err, gc.IsNil)
 	c.Assert(saved.Tag(), gc.Equals, user.Tag())
 	c.Assert(saved.Name(), gc.Equals, user.Name())
@@ -129,7 +129,7 @@ func (s *factorySuite) TestMakeUserNoEnvUser(c *gc.C) {
 		NoEnvUser:   true,
 	})
 
-	_, err := s.State.User(user.Name())
+	_, err := s.State.User(user.UserTag())
 	c.Assert(err, gc.IsNil)
 	_, err = s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)


### PR DESCRIPTION
There are a few other drive by changes:
- bootstrap agent test also checks created environment
- the logging from the apiserver permission test has some breaks in it (to visually separate the test output when it fails)
- the user manager made me sad, we are looking at consistency of tags/names
- adding a service no longer enforces that the user exists, however an envuser must exist (remote users will exist soon)
- the UserTag returned from state.User instances is now explicitly a local user tag (rather than implicitly)
