### PR TITLE
Environment owner and new environment.

### DIFF
--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -328,6 +328,6 @@ func (s *userManagerSuite) TestSetPasswordOnDifferentUser(c *gc.C) {
 	results, err := s.usermanager.SetPassword(args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
-	expectedError := apiservertesting.ServerError("Can only change the password of the current user (admin@local)")
+	expectedError := apiservertesting.ServerError("can only change the password of the current user (admin@local)")
 	c.Assert(results.Results[0], gc.DeepEquals, params.ErrorResult{Error: expectedError})
 }

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -58,7 +58,7 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	cs.MgoSuite.SetUpTest(c)
 	cs.policy = statetesting.MockPolicy{}
 	cfg := testing.EnvironConfig(c)
-	cs.owner = names.NewUserTag("admin")
+	cs.owner = names.NewLocalUserTag("admin")
 	cs.State = TestingInitialize(c, cfg, &cs.policy)
 	uuid, ok := cfg.UUID()
 	c.Assert(ok, jc.IsTrue)

--- a/state/environ.go
+++ b/state/environ.go
@@ -24,9 +24,38 @@ type Environment struct {
 
 // environmentDoc represents the internal state of the environment in MongoDB.
 type environmentDoc struct {
-	UUID string `bson:"_id"`
-	Name string
-	Life Life
+	UUID       string `bson:"_id"`
+	Name       string
+	Life       Life
+	Owner      string `bson:"owner"`
+	ServerUUID string `bson:"server-uuid"`
+}
+
+// InitialEnvironment returns the environment that was bootstrapped.
+// This is the only environment that can have state server machines.
+// The owner of this environment is also considered "special", in that
+// they are the only user that is able to create other users (until we
+// have more fine grained permissions), and they cannot be disabled.
+func (st *State) InitialEnvironment() (*Environment, error) {
+	ssinfo, err := st.StateServerInfo()
+	if err != nil {
+		return nil, errors.Annotate(err, "could not get state server info")
+	}
+
+	environments, closer := st.getCollection(environmentsC)
+	defer closer()
+
+	env := &Environment{st: st}
+	uuid := ssinfo.EnvironmentTag.Id()
+	if err := env.refresh(environments.FindId(uuid)); err != nil {
+		return nil, errors.Trace(err)
+	}
+	env.annotator = annotator{
+		globalKey: environGlobalKey,
+		tag:       env.Tag(),
+		st:        st,
+	}
+	return env, nil
 }
 
 // Environment returns the environment entity.
@@ -35,22 +64,86 @@ func (st *State) Environment() (*Environment, error) {
 	defer closer()
 
 	env := &Environment{st: st}
-	if err := env.refresh(environments.Find(nil)); err != nil {
-		return nil, err
+	uuid := st.environTag.Id()
+	if err := env.refresh(environments.FindId(uuid)); err != nil {
+		return nil, errors.Trace(err)
 	}
 	env.annotator = annotator{
-		globalKey: env.globalKey(),
+		globalKey: environGlobalKey,
 		tag:       env.Tag(),
 		st:        st,
 	}
 	return env, nil
 }
 
+// GetEnvironment looks for the environment identified by the uuid passed in.
+func (st *State) GetEnvironment(tag names.EnvironTag) (*Environment, error) {
+	environments, closer := st.getCollection(environmentsC)
+	defer closer()
+
+	env := &Environment{st: st}
+	if err := env.refresh(environments.FindId(tag.Id())); err != nil {
+		return nil, errors.Trace(err)
+	}
+	env.annotator = annotator{
+		globalKey: environGlobalKey,
+		tag:       env.Tag(),
+		st:        st,
+	}
+	return env, nil
+}
+
+// NewEnvironment records information about an environment. At this stage it
+// only records the name, owner, state of life, and the UUIDs for the
+// environment and for the state server that the environment is running
+// within.  When a juju environment is bootstrapped, the environment is
+// created through state.Initialize.  That is the initial environment, and
+// will have both the environment UUID and the server UUID the same.  New
+// environments running in the same state server will have different
+// environment UUIDs but the server UUID will be the environment UUID of the
+// initial environment.  Having the server UUIDs stored with the environment
+// document means that we have a way to represent external environments,
+// perhaps for future use around cross environment relations.
+func (st *State) NewEnvironment(env, server names.EnvironTag, owner names.UserTag, name string) (*Environment, error) {
+	op := createEnvironmentOp(st, owner, name, env.Id(), server.Id())
+	doc := op.Insert.(*environmentDoc)
+
+	err := st.runTransaction([]txn.Op{op})
+	if err == txn.ErrAborted {
+		err = errors.New("environment already exists")
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	environment := &Environment{
+		st:  st,
+		doc: *doc,
+		annotator: annotator{
+			globalKey: environGlobalKey,
+			tag:       env,
+			st:        st,
+		},
+	}
+	return environment, nil
+}
+
 // Tag returns a name identifying the environment.
 // The returned name will be different from other Tag values returned
 // by any other entities from the same state.
 func (e *Environment) Tag() names.Tag {
+	return e.EnvironTag()
+}
+
+// EnvironTag is the concrete environ tag for this environment.
+func (e *Environment) EnvironTag() names.EnvironTag {
 	return names.NewEnvironTag(e.doc.UUID)
+}
+
+// ServerTag is the environ tag for the server that the environment is running
+// within.
+func (e *Environment) ServerTag() names.EnvironTag {
+	return names.NewEnvironTag(e.doc.ServerUUID)
 }
 
 // UUID returns the universally unique identifier of the environment.
@@ -71,8 +164,7 @@ func (e *Environment) Life() Life {
 // Owner returns tag representing the owner of the environment.
 // The owner is the user that created the environment.
 func (e *Environment) Owner() names.UserTag {
-	// For now, just returns "admin".
-	return names.NewLocalUserTag(AdminUser)
+	return names.NewUserTag(e.doc.Owner)
 }
 
 // globalKey returns the global database key for the environment.
@@ -133,8 +225,14 @@ func (e *Environment) Destroy() error {
 
 // createEnvironmentOp returns the operation needed to create
 // an environment document with the given name and UUID.
-func createEnvironmentOp(st *State, name, uuid string) txn.Op {
-	doc := &environmentDoc{uuid, name, Alive}
+func createEnvironmentOp(st *State, owner names.UserTag, name, uuid, server string) txn.Op {
+	doc := &environmentDoc{
+		UUID:       uuid,
+		Name:       name,
+		Life:       Alive,
+		Owner:      owner.Username(),
+		ServerUUID: server,
+	}
 	return txn.Op{
 		C:      environmentsC,
 		Id:     uuid,

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -4,7 +4,10 @@
 package state_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/state"
@@ -12,44 +15,103 @@ import (
 
 type EnvironSuite struct {
 	ConnSuite
-	env *state.Environment
 }
 
 var _ = gc.Suite(&EnvironSuite{})
 
-func (s *EnvironSuite) SetUpTest(c *gc.C) {
-	s.ConnSuite.SetUpTest(c)
+func (s *EnvironSuite) TestEnvironment(c *gc.C) {
 	env, err := s.State.Environment()
 	c.Assert(err, gc.IsNil)
-	s.env = env
-}
 
-func (s *EnvironSuite) TestTag(c *gc.C) {
-	expected := names.NewEnvironTag(s.env.UUID())
-	c.Assert(s.env.Tag(), gc.Equals, expected)
-}
+	expectedTag := names.NewEnvironTag(env.UUID())
+	c.Assert(env.Tag(), gc.Equals, expectedTag)
+	c.Assert(env.ServerTag(), gc.Equals, expectedTag)
+	c.Assert(env.Name(), gc.Equals, "testenv")
+	c.Assert(env.Owner(), gc.Equals, s.owner)
+	c.Assert(env.Life(), gc.Equals, state.Alive)
 
-func (s *EnvironSuite) TestName(c *gc.C) {
-	c.Assert(s.env.Name(), gc.Equals, "testenv")
-}
-
-func (s *EnvironSuite) TestUUID(c *gc.C) {
-	uuidA := s.env.UUID()
-	c.Assert(uuidA, gc.HasLen, 36)
-
-	// Check that two environments have different UUIDs.
-	s.State.Close()
-	s.MgoSuite.TearDownTest(c)
-	s.MgoSuite.SetUpTest(c)
-	s.State = TestingInitialize(c, nil, nil)
-	env, err := s.State.Environment()
-	c.Assert(err, gc.IsNil)
-	uuidB := env.UUID()
-	c.Assert(uuidA, gc.Not(gc.Equals), uuidB)
-}
-
-func (s *EnvironSuite) TestAnnotatorForEnvironment(c *gc.C) {
 	testAnnotator(c, func() (state.Annotator, error) {
-		return s.State.Environment()
+		return env, nil
+	})
+}
+
+func (s *EnvironSuite) TestNewEnvironment(c *gc.C) {
+	owner := names.NewUserTag("test@remote")
+	uuid, err := utils.NewUUID()
+	c.Assert(err, gc.IsNil)
+	envTag := names.NewEnvironTag(uuid.String())
+	env, err := s.State.NewEnvironment(envTag, s.envTag, owner, "testing")
+	c.Assert(err, gc.IsNil)
+
+	assertMatches := func(env *state.Environment) {
+		c.Assert(env.UUID(), gc.Equals, envTag.Id())
+		c.Assert(env.Tag(), gc.Equals, envTag)
+		c.Assert(env.ServerTag(), gc.Equals, s.envTag)
+		c.Assert(env.Owner(), gc.Equals, owner)
+		c.Assert(env.Name(), gc.Equals, "testing")
+		c.Assert(env.Life(), gc.Equals, state.Alive)
+	}
+	assertMatches(env)
+
+	// Since the environ tag for the State connection is different,
+	// asking for this environment through FindEntity returns a not found error.
+	env, err = s.State.GetEnvironment(envTag)
+	c.Assert(err, gc.IsNil)
+	assertMatches(env)
+
+	_, err = s.State.FindEntity(envTag)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	st, err := s.State.ForEnviron(envTag)
+	c.Assert(err, gc.IsNil)
+	defer st.Close()
+	entity, err := st.FindEntity(envTag)
+	c.Assert(err, gc.IsNil)
+	c.Assert(entity.Tag(), gc.Equals, envTag)
+
+	env, err = st.Environment()
+	c.Assert(err, gc.IsNil)
+	assertMatches(env)
+}
+
+func (s *EnvironSuite) TestInitialEnvironment(c *gc.C) {
+	env, err := s.State.InitialEnvironment()
+	c.Assert(err, gc.IsNil)
+
+	expectedTag := names.NewEnvironTag(env.UUID())
+	c.Assert(env.Tag(), gc.Equals, expectedTag)
+	c.Assert(env.ServerTag(), gc.Equals, expectedTag)
+	c.Assert(env.Name(), gc.Equals, "testenv")
+	c.Assert(env.Owner(), gc.Equals, s.owner)
+	c.Assert(env.Life(), gc.Equals, state.Alive)
+
+	testAnnotator(c, func() (state.Annotator, error) {
+		return env, nil
+	})
+}
+
+func (s *EnvironSuite) TestInitialEnvironmentAccessibleFromOtherEnvironments(c *gc.C) {
+	owner := names.NewUserTag("test@remote")
+	uuid, err := utils.NewUUID()
+	c.Assert(err, gc.IsNil)
+	envTag := names.NewEnvironTag(uuid.String())
+	_, err = s.State.NewEnvironment(envTag, s.envTag, owner, "testing")
+	c.Assert(err, gc.IsNil)
+
+	st, err := s.State.ForEnviron(envTag)
+	c.Assert(err, gc.IsNil)
+	defer st.Close()
+
+	env, err := s.State.InitialEnvironment()
+	c.Assert(err, gc.IsNil)
+
+	expectedTag := names.NewEnvironTag(env.UUID())
+	c.Assert(env.Tag(), gc.Equals, expectedTag)
+	c.Assert(env.Name(), gc.Equals, "testenv")
+	c.Assert(env.Owner(), gc.Equals, s.owner)
+	c.Assert(env.Life(), gc.Equals, state.Alive)
+
+	testAnnotator(c, func() (state.Annotator, error) {
+		return env, nil
 	})
 }

--- a/state/open.go
+++ b/state/open.go
@@ -96,7 +96,7 @@ func Initialize(info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, 
 		createConstraintsOp(st, environGlobalKey, constraints.Value{}),
 		createSettingsOp(st, environGlobalKey, cfg.AllAttrs()),
 		createInitialUserOp(st, owner, info.Password),
-		createEnvironmentOp(st, cfg.Name(), uuid),
+		createEnvironmentOp(st, owner, cfg.Name(), uuid, uuid),
 		newEnvUserOp,
 		{
 			C:      stateServersC,

--- a/state/state.go
+++ b/state/state.go
@@ -116,6 +116,17 @@ type StateServingInfo struct {
 	SystemIdentity string
 }
 
+// ForEnviron returns a connection to mongo for the specified environment. The
+// connection uses the same credentails and policy as the existing connection.
+func (st *State) ForEnviron(env names.EnvironTag) (*State, error) {
+	newState, err := open(st.mongoInfo, mongo.DialOpts{}, st.policy)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	newState.environTag = env
+	return newState, nil
+}
+
 // EnvironTag() returns the environment tag for the environment controlled by
 // this state instance.
 func (st *State) EnvironTag() names.EnvironTag {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"github.com/juju/names"
 	"time"
 
 	"github.com/juju/errors"
@@ -141,4 +142,31 @@ func AddCharmStoragePaths(st *State, storagePaths map[*charm.URL]string) error {
 		return errors.NotFoundf("charms")
 	}
 	return err
+}
+
+// SetOwnerAndServerUUIDForEnvironment adds the environment uuid as the server
+// uuid as well (it is the initial environment, so all good), and the owner to
+// "admin@local", again all good as all existing environments have a user
+// called "admin".
+func SetOwnerAndServerUUIDForEnvironment(st *State) error {
+	err := st.ResumeTransactions()
+	if err != nil {
+		return err
+	}
+
+	env, err := st.Environment()
+	if err != nil {
+		return errors.Annotate(err, "failed to load environment")
+	}
+	owner := names.NewLocalUserTag("admin")
+	ops := []txn.Op{{
+		C:      environmentsC,
+		Id:     env.UUID(),
+		Assert: txn.DocExists,
+		Update: bson.D{{"$set", bson.D{
+			{"server-uuid", env.UUID()},
+			{"owner", owner.Username()},
+		}}},
+	}}
+	return st.runTransaction(ops)
 }

--- a/upgrades/steps121.go
+++ b/upgrades/steps121.go
@@ -36,5 +36,12 @@ func stepsFor121() []Step {
 				return migrateCharmStorage(context.State(), context.AgentConfig())
 			},
 		},
+		&upgradeStep{
+			description: "set environment owner and server uuid",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.SetOwnerAndServerUUIDForEnvironment(context.State())
+			},
+		},
 	}
 }

--- a/upgrades/steps121_test.go
+++ b/upgrades/steps121_test.go
@@ -22,6 +22,7 @@ func (s *steps121Suite) TestUpgradeOperationsContent(c *gc.C) {
 		"add environment uuid to state server doc",
 		"add all users in state as environment users",
 		"migrate charm archives into environment storage",
+		"set environment owner and server uuid",
 	}
 
 	upgradeSteps := upgrades.StepsFor121()


### PR DESCRIPTION
Add owner and server uuid to the environment document.

The server uuid is added to allow us to be able to refer to environments that are not local.  This is a prelude to support for cross environment relations.  From the outside of a juju environment we have started using the pair of uuids to describe a juju environment (env uuid, server uuid).

There is a drive by fix to the usermanager which I thought was on the other branch, but it got merged already.
