### PR TITLE
Factor out cmd testing helpers.

### DIFF
--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -16,6 +16,7 @@ import (
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/cmd/envcmd"
+	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -126,7 +127,7 @@ func (test bootstrapTest) run(c *gc.C) {
 	}
 
 	// Run command and check for uploads.
-	opc, errc := runCommand(nullContext(c), envcmd.Wrap(new(BootstrapCommand)), test.args...)
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), envcmd.Wrap(new(BootstrapCommand)), test.args...)
 	// Check for remaining operations/errors.
 	if test.err != "" {
 		err := <-errc
@@ -345,7 +346,7 @@ func (s *BootstrapSuite) TestBootstrapCleansUpIfEnvironPrepFails(c *gc.C) {
 	)
 
 	ctx := coretesting.Context(c)
-	_, errc := runCommand(ctx, envcmd.Wrap(new(BootstrapCommand)), "-e", "peckham")
+	_, errc := cmdtesting.RunCommand(ctx, envcmd.Wrap(new(BootstrapCommand)), "-e", "peckham")
 	c.Check(<-errc, gc.Not(gc.IsNil))
 	c.Check(cleanupRan, gc.Equals, true)
 }
@@ -409,7 +410,7 @@ func (s *BootstrapSuite) TestBootstrapFailToPrepareDiesGracefully(c *gc.C) {
 	s.PatchValue(&destroyEnvInfo, mockDestroyEnvInfo)
 
 	ctx := coretesting.Context(c)
-	_, errc := runCommand(ctx, envcmd.Wrap(new(BootstrapCommand)), "-e", "peckham")
+	_, errc := cmdtesting.RunCommand(ctx, envcmd.Wrap(new(BootstrapCommand)), "-e", "peckham")
 	c.Check(<-errc, gc.ErrorMatches, ".*mock-prepare$")
 	c.Check(destroyedEnvRan, gc.Equals, false)
 	c.Check(destroyedInfoRan, gc.Equals, true)
@@ -435,7 +436,7 @@ func (s *BootstrapSuite) TestBootstrapJenvWarning(c *gc.C) {
 	loggo.RegisterWriter(logger, &testWriter, loggo.WARNING)
 	defer loggo.RemoveWriter(logger)
 
-	_, errc := runCommand(ctx, envcmd.Wrap(new(BootstrapCommand)), "-e", "peckham")
+	_, errc := cmdtesting.RunCommand(ctx, envcmd.Wrap(new(BootstrapCommand)), "-e", "peckham")
 	c.Assert(<-errc, gc.IsNil)
 	c.Assert(testWriter.Log(), jc.LogMatches, []string{"ignoring environments.yaml: using bootstrap config in .*"})
 }
@@ -593,7 +594,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.
-	opc, errc := runCommand(nullContext(c), envcmd.Wrap(new(BootstrapCommand)))
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), envcmd.Wrap(new(BootstrapCommand)))
 	c.Assert(<-errc, gc.IsNil)
 	c.Check((<-opc).(dummy.OpPutFile).Env, gc.Equals, "peckham") // verify storage
 	c.Check((<-opc).(dummy.OpBootstrap).Env, gc.Equals, "peckham")
@@ -604,7 +605,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 
 func (s *BootstrapSuite) TestAutoUploadOnlyForDev(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "precise")
-	_, errc := runCommand(nullContext(c), envcmd.Wrap(new(BootstrapCommand)))
+	_, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), envcmd.Wrap(new(BootstrapCommand)))
 	err := <-errc
 	c.Assert(err, gc.ErrorMatches,
 		"failed to bootstrap environment: Juju cannot bootstrap because no tools are available for your environment(.|\n)*")
@@ -645,7 +646,7 @@ func (s *BootstrapSuite) TestBootstrapDestroy(c *gc.C) {
 	// upload is only enabled for dev versions.
 	devVersion.Build = 1234
 	s.PatchValue(&version.Current, devVersion)
-	opc, errc := runCommand(nullContext(c), envcmd.Wrap(new(BootstrapCommand)), "-e", "brokenenv")
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), envcmd.Wrap(new(BootstrapCommand)), "-e", "brokenenv")
 	err := <-errc
 	c.Assert(err, gc.ErrorMatches, "failed to bootstrap environment: dummy.Bootstrap is broken")
 	var opDestroy *dummy.OpDestroy
@@ -672,7 +673,7 @@ func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 	// upload is only enabled for dev versions.
 	devVersion.Build = 1234
 	s.PatchValue(&version.Current, devVersion)
-	opc, errc := runCommand(nullContext(c), envcmd.Wrap(new(BootstrapCommand)), "-e", "brokenenv", "--keep-broken")
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), envcmd.Wrap(new(BootstrapCommand)), "-e", "brokenenv", "--keep-broken")
 	err := <-errc
 	c.Assert(err, gc.ErrorMatches, "failed to bootstrap environment: dummy.Bootstrap is broken")
 	done := false
@@ -715,7 +716,7 @@ func resetJujuHome(c *gc.C) environs.Environ {
 	dummy.Reset()
 	store, err := configstore.Default()
 	c.Assert(err, gc.IsNil)
-	env, err := environs.PrepareFromName("peckham", nullContext(c), store)
+	env, err := environs.PrepareFromName("peckham", cmdtesting.NullContext(c), store)
 	c.Assert(err, gc.IsNil)
 	envtesting.RemoveAllTools(c, env)
 	return env

--- a/cmd/juju/cmd_test.go
+++ b/cmd/juju/cmd_test.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/cmd"
@@ -15,7 +13,6 @@ import (
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -117,38 +114,6 @@ func (*CmdSuite) TestEnvironmentInit(c *gc.C) {
 		os.Setenv(osenv.JujuEnvEnvKey, oldenv)
 		assertEnvName(c, com, "walthamstow")
 	}
-}
-
-func nullContext(c *gc.C) *cmd.Context {
-	ctx, err := cmd.DefaultContext()
-	c.Assert(err, gc.IsNil)
-	ctx.Stdin = io.LimitReader(nil, 0)
-	ctx.Stdout = ioutil.Discard
-	ctx.Stderr = ioutil.Discard
-	return ctx
-}
-
-func runCommand(ctx *cmd.Context, com cmd.Command, args ...string) (opc chan dummy.Operation, errc chan error) {
-	if ctx == nil {
-		panic("ctx == nil")
-	}
-	errc = make(chan error, 1)
-	opc = make(chan dummy.Operation, 200)
-	dummy.Listen(opc)
-	go func() {
-		// signal that we're done with this ops channel.
-		defer dummy.Listen(nil)
-
-		err := coretesting.InitCommand(com, args)
-		if err != nil {
-			errc <- err
-			return
-		}
-
-		err = com.Run(ctx)
-		errc <- err
-	}()
-	return
 }
 
 var deployTests = []struct {

--- a/cmd/juju/destroyenvironment_test.go
+++ b/cmd/juju/destroyenvironment_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
+	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/instance"
@@ -27,15 +28,15 @@ var _ = gc.Suite(&destroyEnvSuite{})
 
 func (s *destroyEnvSuite) TestDestroyEnvironmentCommand(c *gc.C) {
 	// Prepare the environment so we can destroy it.
-	_, err := environs.PrepareFromName("dummyenv", nullContext(c), s.ConfigStore)
+	_, err := environs.PrepareFromName("dummyenv", cmdtesting.NullContext(c), s.ConfigStore)
 	c.Assert(err, gc.IsNil)
 
 	// check environment is mandatory
-	opc, errc := runCommand(nullContext(c), new(DestroyEnvironmentCommand))
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), new(DestroyEnvironmentCommand))
 	c.Check(<-errc, gc.Equals, NoEnvironmentError)
 
 	// normal destroy
-	opc, errc = runCommand(nullContext(c), new(DestroyEnvironmentCommand), "dummyenv", "--yes")
+	opc, errc = cmdtesting.RunCommand(cmdtesting.NullContext(c), new(DestroyEnvironmentCommand), "dummyenv", "--yes")
 	c.Check(<-errc, gc.IsNil)
 	c.Check((<-opc).(dummy.OpDestroy).Env, gc.Equals, "dummyenv")
 
@@ -46,22 +47,22 @@ func (s *destroyEnvSuite) TestDestroyEnvironmentCommand(c *gc.C) {
 
 func (s *destroyEnvSuite) TestDestroyEnvironmentCommandEFlag(c *gc.C) {
 	// Prepare the environment so we can destroy it.
-	_, err := environs.PrepareFromName("dummyenv", nullContext(c), s.ConfigStore)
+	_, err := environs.PrepareFromName("dummyenv", cmdtesting.NullContext(c), s.ConfigStore)
 	c.Assert(err, gc.IsNil)
 
 	// check that either environment or the flag is mandatory
-	opc, errc := runCommand(nullContext(c), new(DestroyEnvironmentCommand))
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), new(DestroyEnvironmentCommand))
 	c.Check(<-errc, gc.Equals, NoEnvironmentError)
 
 	// We don't allow them to supply both entries at the same time
-	opc, errc = runCommand(nullContext(c), new(DestroyEnvironmentCommand), "-e", "dummyenv", "dummyenv", "--yes")
+	opc, errc = cmdtesting.RunCommand(cmdtesting.NullContext(c), new(DestroyEnvironmentCommand), "-e", "dummyenv", "dummyenv", "--yes")
 	c.Check(<-errc, gc.Equals, DoubleEnvironmentError)
 	// We treat --environment the same way
-	opc, errc = runCommand(nullContext(c), new(DestroyEnvironmentCommand), "--environment", "dummyenv", "dummyenv", "--yes")
+	opc, errc = cmdtesting.RunCommand(cmdtesting.NullContext(c), new(DestroyEnvironmentCommand), "--environment", "dummyenv", "dummyenv", "--yes")
 	c.Check(<-errc, gc.Equals, DoubleEnvironmentError)
 
 	// destroy using the -e flag
-	opc, errc = runCommand(nullContext(c), new(DestroyEnvironmentCommand), "-e", "dummyenv", "--yes")
+	opc, errc = cmdtesting.RunCommand(cmdtesting.NullContext(c), new(DestroyEnvironmentCommand), "-e", "dummyenv", "--yes")
 	c.Check(<-errc, gc.IsNil)
 	c.Check((<-opc).(dummy.OpDestroy).Env, gc.Equals, "dummyenv")
 
@@ -99,11 +100,11 @@ func (s *destroyEnvSuite) TestDestroyEnvironmentCommandBroken(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Prepare the environment so we can destroy it.
-	_, err = environs.PrepareFromName("dummyenv", nullContext(c), s.ConfigStore)
+	_, err = environs.PrepareFromName("dummyenv", cmdtesting.NullContext(c), s.ConfigStore)
 	c.Assert(err, gc.IsNil)
 
 	// destroy with broken environment
-	opc, errc := runCommand(nullContext(c), new(DestroyEnvironmentCommand), "dummyenv", "--yes")
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), new(DestroyEnvironmentCommand), "dummyenv", "--yes")
 	op, ok := (<-opc).(dummy.OpDestroy)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(op.Error, gc.ErrorMatches, "dummy.Destroy is broken")
@@ -133,14 +134,14 @@ func (s *destroyEnvSuite) TestDestroyEnvironmentCommandConfirmation(c *gc.C) {
 	ctx.Stdin = &stdin
 
 	// Prepare the environment so we can destroy it.
-	env, err := environs.PrepareFromName("dummyenv", nullContext(c), s.ConfigStore)
+	env, err := environs.PrepareFromName("dummyenv", cmdtesting.NullContext(c), s.ConfigStore)
 	c.Assert(err, gc.IsNil)
 
 	assertEnvironNotDestroyed(c, env, s.ConfigStore)
 
 	// Ensure confirmation is requested if "-y" is not specified.
 	stdin.WriteString("n")
-	opc, errc := runCommand(ctx, new(DestroyEnvironmentCommand), "dummyenv")
+	opc, errc := cmdtesting.RunCommand(ctx, new(DestroyEnvironmentCommand), "dummyenv")
 	c.Check(<-errc, gc.ErrorMatches, "environment destruction aborted")
 	c.Check(<-opc, gc.IsNil)
 	c.Check(stdout.String(), gc.Matches, "WARNING!.*dummyenv.*\\(type: dummy\\)(.|\n)*")
@@ -149,7 +150,7 @@ func (s *destroyEnvSuite) TestDestroyEnvironmentCommandConfirmation(c *gc.C) {
 	// EOF on stdin: equivalent to answering no.
 	stdin.Reset()
 	stdout.Reset()
-	opc, errc = runCommand(ctx, new(DestroyEnvironmentCommand), "dummyenv")
+	opc, errc = cmdtesting.RunCommand(ctx, new(DestroyEnvironmentCommand), "dummyenv")
 	c.Check(<-opc, gc.IsNil)
 	c.Check(<-errc, gc.ErrorMatches, "environment destruction aborted")
 	assertEnvironNotDestroyed(c, env, s.ConfigStore)
@@ -157,7 +158,7 @@ func (s *destroyEnvSuite) TestDestroyEnvironmentCommandConfirmation(c *gc.C) {
 	// "--yes" passed: no confirmation request.
 	stdin.Reset()
 	stdout.Reset()
-	opc, errc = runCommand(ctx, new(DestroyEnvironmentCommand), "dummyenv", "--yes")
+	opc, errc = cmdtesting.RunCommand(ctx, new(DestroyEnvironmentCommand), "dummyenv", "--yes")
 	c.Check(<-errc, gc.IsNil)
 	c.Check((<-opc).(dummy.OpDestroy).Env, gc.Equals, "dummyenv")
 	c.Check(stdout.String(), gc.Equals, "")
@@ -167,13 +168,13 @@ func (s *destroyEnvSuite) TestDestroyEnvironmentCommandConfirmation(c *gc.C) {
 	for _, answer := range []string{"y", "Y", "yes", "YES"} {
 		// Prepare the environment so we can destroy it.
 		s.Reset(c)
-		env, err := environs.PrepareFromName("dummyenv", nullContext(c), s.ConfigStore)
+		env, err := environs.PrepareFromName("dummyenv", cmdtesting.NullContext(c), s.ConfigStore)
 		c.Assert(err, gc.IsNil)
 
 		stdin.Reset()
 		stdout.Reset()
 		stdin.WriteString(answer)
-		opc, errc = runCommand(ctx, new(DestroyEnvironmentCommand), "dummyenv")
+		opc, errc = cmdtesting.RunCommand(ctx, new(DestroyEnvironmentCommand), "dummyenv")
 		c.Check(<-errc, gc.IsNil)
 		c.Check((<-opc).(dummy.OpDestroy).Env, gc.Equals, "dummyenv")
 		c.Check(stdout.String(), gc.Matches, "WARNING!.*dummyenv.*\\(type: dummy\\)(.|\n)*")

--- a/cmd/juju/main_test.go
+++ b/cmd/juju/main_test.go
@@ -4,31 +4,22 @@
 package main
 
 import (
-	"bytes"
-	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	stdtesting "testing"
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
-	"launchpad.net/gnuflag"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/cmd/envcmd"
+	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/juju/osenv"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
-
-func TestPackage(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
-}
 
 type MainSuite struct {
 	testing.FakeJujuHomeSuite
@@ -36,50 +27,16 @@ type MainSuite struct {
 
 var _ = gc.Suite(&MainSuite{})
 
-var (
-	flagRunMain = flag.Bool("run-main", false, "Run the application's main function for recursive testing")
-)
-
-// Reentrancy point for testing (something as close as possible to) the juju
-// tool itself.
-func TestRunMain(t *stdtesting.T) {
-	if *flagRunMain {
-		Main(flag.Args())
-	}
-}
-
-func badrun(c *gc.C, exit int, args ...string) string {
-	localArgs := append([]string{"-test.run", "TestRunMain", "-run-main", "--", "juju"}, args...)
-	ps := exec.Command(os.Args[0], localArgs...)
-	ps.Env = append(os.Environ(), osenv.JujuHomeEnvKey+"="+osenv.JujuHome())
-	output, err := ps.CombinedOutput()
-	c.Logf("command output: %q", output)
-	if exit != 0 {
-		c.Assert(err, gc.ErrorMatches, fmt.Sprintf("exit status %d", exit))
-	}
-	return string(output)
-}
-
-func helpText(command cmd.Command, name string) string {
-	buff := &bytes.Buffer{}
-	info := command.Info()
-	info.Name = name
-	f := gnuflag.NewFlagSet(info.Name, gnuflag.ContinueOnError)
-	command.SetFlags(f)
-	buff.Write(info.Help(f))
-	return buff.String()
-}
-
 func deployHelpText() string {
-	return helpText(envcmd.Wrap(&DeployCommand{}), "juju deploy")
+	return cmdtesting.HelpText(envcmd.Wrap(&DeployCommand{}), "juju deploy")
 }
 
 func setHelpText() string {
-	return helpText(envcmd.Wrap(&SetCommand{}), "juju set")
+	return cmdtesting.HelpText(envcmd.Wrap(&SetCommand{}), "juju set")
 }
 
 func syncToolsHelpText() string {
-	return helpText(envcmd.Wrap(&SyncToolsCommand{}), "juju sync-tools")
+	return cmdtesting.HelpText(envcmd.Wrap(&SyncToolsCommand{}), "juju sync-tools")
 }
 
 func (s *MainSuite) TestRunMain(c *gc.C) {

--- a/cmd/juju/package_test.go
+++ b/cmd/juju/package_test.go
@@ -1,0 +1,32 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"flag"
+	stdtesting "testing"
+
+	gc "launchpad.net/gocheck"
+
+	cmdtesting "github.com/juju/juju/cmd/testing"
+	_ "github.com/juju/juju/provider/dummy" // XXX Why?
+	"github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}
+
+func badrun(c *gc.C, exit int, args ...string) string {
+	args = append([]string{"juju"}, args...)
+	return cmdtesting.BadRun(c, exit, args...)
+}
+
+// Reentrancy point for testing (something as close as possible to) the juju
+// tool itself.
+func TestRunMain(t *stdtesting.T) {
+	if *cmdtesting.FlagRunMain {
+		Main(flag.Args())
+	}
+}

--- a/cmd/testing/testing.go
+++ b/cmd/testing/testing.go
@@ -1,0 +1,84 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/provider/dummy"
+	coretesting "github.com/juju/juju/testing"
+)
+
+// FlagRunMain is used to indicate that the -run-main flag was used.
+var FlagRunMain = flag.Bool("run-main", false, "Run the application's main function for recursive testing")
+
+// BadRun is used to run a command, check the exit code, and return the output.
+func BadRun(c *gc.C, exit int, args ...string) string {
+	localArgs := append([]string{"-test.run", "TestRunMain", "-run-main", "--"}, args...)
+	ps := exec.Command(os.Args[0], localArgs...)
+	ps.Env = append(os.Environ(), osenv.JujuHomeEnvKey+"="+osenv.JujuHome())
+	output, err := ps.CombinedOutput()
+	c.Logf("command output: %q", output)
+	if exit != 0 {
+		c.Assert(err, gc.ErrorMatches, fmt.Sprintf("exit status %d", exit))
+	}
+	return string(output)
+}
+
+// HelpText returns a command's formatted help text.
+func HelpText(command cmd.Command, name string) string {
+	buff := &bytes.Buffer{}
+	info := command.Info()
+	info.Name = name
+	f := gnuflag.NewFlagSet(info.Name, gnuflag.ContinueOnError)
+	command.SetFlags(f)
+	buff.Write(info.Help(f))
+	return buff.String()
+}
+
+// NullContext returns a no-op command context.
+func NullContext(c *gc.C) *cmd.Context {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+	ctx.Stdin = io.LimitReader(nil, 0)
+	ctx.Stdout = ioutil.Discard
+	ctx.Stderr = ioutil.Discard
+	return ctx
+}
+
+// RunCommand runs the command and returns channels holding the
+// command's operations and errors.
+func RunCommand(ctx *cmd.Context, com cmd.Command, args ...string) (opc chan dummy.Operation, errc chan error) {
+	if ctx == nil {
+		panic("ctx == nil")
+	}
+	errc = make(chan error, 1)
+	opc = make(chan dummy.Operation, 200)
+	dummy.Listen(opc)
+	go func() {
+		// signal that we're done with this ops channel.
+		defer dummy.Listen(nil)
+
+		err := coretesting.InitCommand(com, args)
+		if err != nil {
+			errc <- err
+			return
+		}
+
+		err = com.Run(ctx)
+		errc <- err
+	}()
+	return
+}


### PR DESCRIPTION
For the backups CLI I'm adding the subcommands in a subpackage of cmd/juju.  For that to work, I need some of the testing helpers in cmd/juju to live in their own package.  This patch makes that happen.  This is basically a copy-and-paste patch.
