### PR TITLE
Added state opened ports watcher; allow opening/closing port ranges on units

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -255,6 +255,7 @@ func WatcherMakeIdFilter(marker string, receivers ...ActionReceiver) func(interf
 var (
 	GetOrCreatePorts = getOrCreatePorts
 	GetPorts         = getPorts
+	PortsGlobalKey   = portsGlobalKey
 	NowToTheSecond   = nowToTheSecond
 )
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -582,7 +582,7 @@ func (m *Machine) removePortsOps() ([]txn.Op, error) {
 	if m.doc.Life != Dead {
 		return nil, errors.Errorf("machine is not dead")
 	}
-	ports, err := m.OpenedPorts(m.st)
+	ports, err := m.AllPorts()
 	if err != nil {
 		return nil, err
 	}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -194,7 +194,7 @@ func (s *MachineSuite) TestDestroyRemovePorts(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	err = unit.OpenPort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
-	ports, err := state.GetPorts(s.State, s.machine.Id())
+	ports, err := state.GetPorts(s.State, s.machine.Id(), network.DefaultPublic)
 	c.Assert(ports, gc.NotNil)
 	c.Assert(err, gc.IsNil)
 	err = unit.UnassignFromMachine()
@@ -206,7 +206,7 @@ func (s *MachineSuite) TestDestroyRemovePorts(c *gc.C) {
 	err = s.machine.Remove()
 	c.Assert(err, gc.IsNil)
 	// once the machine is destroyed, there should be no ports documents present for it
-	ports, err = state.GetPorts(s.State, s.machine.Id())
+	ports, err = state.GetPorts(s.State, s.machine.Id(), network.DefaultPublic)
 	c.Assert(ports, gc.IsNil)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/state/ports.go
+++ b/state/ports.go
@@ -30,7 +30,7 @@ type portIdPart int
 const (
 	fullId portIdPart = iota
 	machineIdPart
-	networkIdPart
+	networkNamePart
 )
 
 // PortRange represents a single range of ports opened
@@ -56,7 +56,7 @@ func NewPortRange(unitName string, fromPort, toPort int, protocol string) (PortR
 	return p, nil
 }
 
-// IsValid checks if the port range is valid.
+// Validate checks if the port range is valid.
 func (p PortRange) Validate() error {
 	proto := strings.ToLower(p.Protocol)
 	if proto != "tcp" && proto != "udp" {
@@ -95,6 +95,7 @@ func (a PortRange) CheckConflicts(b PortRange) error {
 	return nil
 }
 
+// Strings returns the port range as a string.
 func (p PortRange) String() string {
 	return fmt.Sprintf("%d-%d/%s", p.FromPort, p.ToPort, strings.ToLower(p.Protocol))
 }
@@ -119,6 +120,25 @@ func (p *Ports) Id() string {
 	return p.doc.Id
 }
 
+// String returns p as a user-readable string.
+func (p *Ports) String() string {
+	// We do not check for errors here, as we assume
+	// the values have been validated on construction.
+	machineId, _ := p.MachineId()
+	networkName, _ := p.NetworkName()
+	return portsIdAsString(machineId, networkName)
+}
+
+func portsIdAsString(machineId, networkName string) string {
+	return fmt.Sprintf("ports for machine %s, network %q", machineId, networkName)
+}
+
+// portsGlobalKey returns the global database key for the opened ports
+// document for the given machine and network.
+func portsGlobalKey(machineId string, networkName string) string {
+	return fmt.Sprintf("m#%s#n#%s", machineId, networkName)
+}
+
 // Check if a port range can be opened, return the conflict error
 // for more accurate reporting.
 func (p *Ports) canOpenPorts(newPorts PortRange) error {
@@ -130,60 +150,71 @@ func (p *Ports) canOpenPorts(newPorts PortRange) error {
 	return nil
 }
 
-func (p *Ports) extractPortIdPart(part portIdPart) (string, error) {
-	if part < 0 || part > 2 {
-		return "", fmt.Errorf("invalid ports document name part: %v", part)
+func extractPortsIdPart(id string, part portIdPart) (string, error) {
+	if part <= fullId || part > networkNamePart {
+		return "", errors.Errorf("invalid ports document name part: %v", part)
 	}
-	if parts := portsIdRe.FindStringSubmatch(p.doc.Id); len(parts) == 3 {
+	if parts := portsIdRe.FindStringSubmatch(id); len(parts) == 3 {
 		return parts[part], nil
 	}
-	return "", fmt.Errorf("invalid ports document name: %v", p.doc.Id)
+	return "", errors.Errorf("invalid ports document name: %v", id)
 }
 
-// MachineId returns the machine id associated with this port document.
+// MachineId returns the machine id associated with this ports
+// document.
 func (p *Ports) MachineId() (string, error) {
-	return p.extractPortIdPart(machineIdPart)
+	return extractPortsIdPart(p.doc.Id, machineIdPart)
 }
 
-// NetworkName returns the network name associated with this port document.
+// NetworkName returns the network name associated with this ports
+// document.
 func (p *Ports) NetworkName() (string, error) {
-	return p.extractPortIdPart(networkIdPart)
+	return extractPortsIdPart(p.doc.Id, networkNamePart)
 }
 
-// OpenPorts adds the specified port range to the ports maintained by this document.
-func (p *Ports) OpenPorts(portRange PortRange) error {
-	if err := portRange.Validate(); err != nil {
-		return err
+// OpenPorts adds the specified port range to the list of ports
+// maintained by this document.
+func (p *Ports) OpenPorts(portRange PortRange) (err error) {
+	if err = portRange.Validate(); err != nil {
+		return errors.Trace(err)
 	}
 	ports := Ports{st: p.st, doc: p.doc, new: p.new}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		machineId, err := ports.MachineId()
+		var machineId string
+		machineId, err = ports.MachineId()
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 
 		if attempt > 0 {
-			if err := ports.Refresh(); errors.IsNotFound(err) {
-				// the ports document no longer exists
+			if err = ports.Refresh(); errors.IsNotFound(err) {
+				// No longer exists.
 				if !ports.new {
-					return nil, fmt.Errorf("ports document not found for machine %v", machineId)
+					return nil, errors.Annotatef(err, "no open ports for machine %s", machineId)
 				}
 			} else if err != nil {
-				return nil, err
+				return nil, errors.Trace(err)
 			} else if ports.new {
-				// the ports document was created by somebody else
+				// Already created.
 				ports.new = false
 			}
 		}
 
-		if err := ports.canOpenPorts(portRange); err != nil {
-			return nil, errors.Annotatef(err, "cannot open ports %v on machine %q", portRange, machineId)
+		if err = ports.canOpenPorts(portRange); err != nil {
+			return nil, errors.Annotatef(err, "cannot open ports %v on machine %s", portRange, machineId)
 		}
 
-		// a new ports document being created
 		if ports.new {
-			return addPortsDocOps(ports.st,
+			// Create a new document.
+			var networkName string
+			networkName, err = ports.NetworkName()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return addPortsDocOps(
+				ports.st,
 				machineId,
+				networkName,
 				portRange), nil
 		}
 		ops := []txn.Op{{
@@ -203,27 +234,31 @@ func (p *Ports) OpenPorts(portRange PortRange) error {
 		return ops, nil
 	}
 	// Run the transaction using the state transaction runner.
-	err := p.st.run(buildTxn)
-	if err != nil {
-		return err
+	if err = p.st.run(buildTxn); err != nil {
+		return errors.Trace(err)
 	}
 	// Mark object as created.
 	p.new = false
+	p.doc.Ports = append(p.doc.Ports, portRange)
 	return nil
 }
 
-// ClosePorts removes the specified port range from this document.
-func (p *Ports) ClosePorts(portRange PortRange) error {
+// ClosePorts removes the specified port range from the list of ports
+// maintained by this document.
+func (p *Ports) ClosePorts(portRange PortRange) (err error) {
+	var newPorts []PortRange
+
 	ports := Ports{st: p.st, doc: p.doc, new: p.new}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
-			if err := ports.Refresh(); errors.IsNotFound(err) {
+			if err = ports.Refresh(); errors.IsNotFound(err) {
+				// No longer exists.
 				return nil, statetxn.ErrNoOperations
 			} else if err != nil {
-				return nil, err
+				return nil, errors.Trace(err)
 			}
 		}
-		newPorts := []PortRange{}
+		newPorts = newPorts[0:0]
 
 		found := false
 		for _, existingPortsDef := range ports.doc.Ports {
@@ -231,9 +266,9 @@ func (p *Ports) ClosePorts(portRange PortRange) error {
 				found = true
 				continue
 			}
-			portConflictErr := existingPortsDef.CheckConflicts(portRange)
-			if existingPortsDef.UnitName == portRange.UnitName && portConflictErr != nil {
-				return nil, errors.Annotatef(portConflictErr, "mismatched port ranges")
+			err = existingPortsDef.CheckConflicts(portRange)
+			if existingPortsDef.UnitName == portRange.UnitName && err != nil {
+				return nil, errors.Annotatef(err, "mismatched port ranges")
 			}
 			newPorts = append(newPorts, existingPortsDef)
 		}
@@ -252,28 +287,35 @@ func (p *Ports) ClosePorts(portRange PortRange) error {
 		}}
 		return ops, nil
 	}
-	return p.st.run(buildTxn)
+	if err = p.st.run(buildTxn); err != nil {
+		return errors.Trace(err)
+	}
+	p.doc.Ports = newPorts
+	return nil
 }
 
-// migratePorts migrates old-style unit ports collection to the ports document.
+// migratePorts migrates old-style unit ports collection to the ports
+// document.
+//
+// TODO(dimitern) Convert this to an upgrade step to run once.
 func (p *Ports) migratePorts(u *Unit) error {
 	ports := Ports{st: p.st, doc: p.doc, new: p.new}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		machineId, err := ports.MachineId()
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 
 		if attempt > 0 {
 			if err := ports.Refresh(); errors.IsNotFound(err) {
-				// the ports document no longer exists
+				// No longer exists.
 				if !ports.new {
-					return nil, fmt.Errorf("ports document not found for machine %v", machineId)
+					return nil, errors.Annotatef(err, "no open ports for machine %s", machineId)
 				}
 			} else if err != nil {
-				return nil, err
+				return nil, errors.Trace(err)
 			} else if ports.new {
-				// the ports document was created by somebody else
+				// Already created.
 				ports.new = false
 			}
 		}
@@ -282,43 +324,51 @@ func (p *Ports) migratePorts(u *Unit) error {
 		for i, port := range u.doc.Ports {
 			portDef, err := NewPortRange(u.Name(), port.Number, port.Number, port.Protocol)
 			if err != nil {
-				return nil, fmt.Errorf("cannot migrate port %v: %v", port, err)
+				return nil, errors.Annotatef(err, "cannot migrate port %v", port)
 			}
 			if err := ports.canOpenPorts(portDef); err != nil {
-				return nil, fmt.Errorf("cannot migrate port %v: %v", port, err)
+				return nil, errors.Annotatef(err, "cannot migrate port %v", port)
 			}
 			migratedPorts[i] = portDef
 		}
 
-		// a new ports document being created
-		if ports.new {
-			return addPortsDocOps(ports.st, machineId, migratedPorts...), nil
-		}
-
-		// updating existing ports document
 		var ops []txn.Op
 
-		ops = append(ops, txn.Op{
-			C:      machinesC,
-			Id:     machineId,
-			Assert: isAliveDoc,
-		})
-
-		for _, portDef := range migratedPorts {
+		if ports.new {
+			// Create a new document.
+			networkName, err := ports.NetworkName()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = addPortsDocOps(
+				ports.st,
+				machineId,
+				networkName,
+				migratedPorts...)
+		} else {
+			// Updating an existing document.
 			ops = append(ops, txn.Op{
-				C:      openedPortsC,
-				Id:     ports.Id(),
-				Update: bson.D{{"$addToSet", bson.D{{"ports", portDef}}}},
+				C:      machinesC,
+				Id:     machineId,
+				Assert: isAliveDoc,
 			})
+
+			for _, portDef := range migratedPorts {
+				ops = append(ops, txn.Op{
+					C:      openedPortsC,
+					Id:     ports.Id(),
+					Update: bson.D{{"$addToSet", bson.D{{"ports", portDef}}}},
+				})
+			}
 		}
 
-		// TODO(domas) 2014-07-04 bug #1337813: Clear the old port collection on the unit document
-		// once the firewaller no longer depends on the unit ports list.
+		// TODO(domas) 2014-07-04 bug #1337813: Clear the old port
+		// collection on the unit document once the firewaller no
+		// longer depends on the unit ports list.
 		return ops, nil
 	}
-	err := p.st.run(buildTxn)
-	if err != nil {
-		return err
+	if err := p.st.run(buildTxn); err != nil {
+		return errors.Trace(err)
 	}
 
 	p.new = false
@@ -345,11 +395,26 @@ func (p *Ports) Refresh() error {
 
 	err := openedPorts.FindId(p.Id()).One(&p.doc)
 	if err == mgo.ErrNotFound {
-		return errors.NotFoundf("ports document %v", p.Id())
+		return errors.NotFoundf(p.String())
 	} else if err != nil {
-		return fmt.Errorf("cannot refresh ports %v: %v", p.Id(), err)
+		return errors.Annotatef(err, "cannot refresh %s", p)
 	}
 	return nil
+}
+
+// AllPortRanges returns a map with network.PortRange as keys and unit
+// names as values.
+func (p *Ports) AllPortRanges() map[network.PortRange]string {
+	result := make(map[network.PortRange]string)
+	for _, portRange := range p.doc.Ports {
+		rawRange := network.PortRange{
+			FromPort: portRange.FromPort,
+			ToPort:   portRange.ToPort,
+			Protocol: portRange.Protocol,
+		}
+		result[rawRange] = portRange.UnitName
+	}
+	return result
 }
 
 // Remove removes the ports document from state.
@@ -361,7 +426,7 @@ func (p *Ports) Remove() error {
 			if errors.IsNotFound(err) {
 				return nil, statetxn.ErrNoOperations
 			} else if err != nil {
-				return nil, err
+				return nil, errors.Trace(err)
 			}
 		}
 		ops := prts.removeOps()
@@ -370,7 +435,8 @@ func (p *Ports) Remove() error {
 	return p.st.run(buildTxn)
 }
 
-// removeOps returns the ops for removing the ports document from mongo.
+// removeOps returns the ops for removing the ports document from
+// state.
 func (p *Ports) removeOps() []txn.Op {
 	return []txn.Op{{
 		C:      openedPortsC,
@@ -379,86 +445,112 @@ func (p *Ports) removeOps() []txn.Op {
 	}}
 }
 
-// OpenedPorts returns ports documents associated with specified machine.
-func (m *Machine) OpenedPorts(st *State) ([]*Ports, error) {
+// OpenedPorts returns this machine ports document for the given
+// network.
+func (m *Machine) OpenedPorts(networkName string) (*Ports, error) {
+	key := portsGlobalKey(m.Id(), networkName)
+	ports, err := m.st.Ports(key)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+	return ports, nil
+}
+
+// AllPorts returns all opened ports for this machine (on all
+// networks).
+func (m *Machine) AllPorts() ([]*Ports, error) {
 	openedPorts, closer := m.st.getCollection(openedPortsC)
 	defer closer()
 
 	idRegex := fmt.Sprintf("m#%s#n#.*", m.Id())
 	docs := []portsDoc{}
-	err := openedPorts.Find(bson.M{"_id": bson.M{"$regex": idRegex}}).All(&docs)
+	query := bson.M{"_id": bson.M{"$regex": idRegex}}
+	err := openedPorts.Find(query).All(&docs)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	results := make([]*Ports, len(docs))
 	for i, doc := range docs {
-		results[i] = &Ports{st: st, doc: doc}
+		results[i] = &Ports{st: m.st, doc: doc}
 	}
 	return results, nil
 }
 
-// portsDocId generates the id of a ports document given the machine id and network name.
-func portsDocId(machineId string, networkName string) string {
-	return fmt.Sprintf("m#%s#n#%s", machineId, networkName)
-}
-
-func addPortsDocOps(st *State,
-	// TODO(domas) 2014-07-04 bug #1337804: network id is hard-coded until multiple network support lands.
-	//network string,
-	machineId string,
-	ports ...PortRange) []txn.Op {
-
-	id := portsDocId(machineId, network.DefaultPublic)
-
-	ops := []txn.Op{{
-		C:      machinesC,
-		Id:     machineId,
-		Assert: notDeadDoc,
-	}, {
-		C:      openedPortsC,
-		Id:     id,
-		Assert: txn.DocMissing,
-		Insert: portsDoc{Id: id, Ports: ports},
-	}}
-	return ops
-}
-
-// getPorts returns the ports document for the specified
-// machine and network.
-func getPorts(st *State,
-	// TODO(domas) 2014-07-04 bug #1337804: network is hardcoded until multiple network support lands.
-	// networkName string,
-	machineId string) (*Ports, error) {
+// Ports returns the opened ports document with the given global key.
+func (st *State) Ports(key string) (*Ports, error) {
 	openedPorts, closer := st.getCollection(openedPortsC)
 	defer closer()
 
+	machineId, err := extractPortsIdPart(key, machineIdPart)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	networkName, err := extractPortsIdPart(key, networkNamePart)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	portsId := portsIdAsString(machineId, networkName)
+
 	var doc portsDoc
-	id := portsDocId(machineId, network.DefaultPublic)
-	err := openedPorts.FindId(id).One(&doc)
+	err = openedPorts.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("ports document for machine %v", machineId)
+		return nil, errors.NotFoundf(portsId)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("cannot retrieve ports document for machine %v: %v",
-			machineId, err)
+		return nil, errors.Annotatef(err, "cannot get %s", portsId)
 	}
 
 	return &Ports{st, doc, false}, nil
 }
 
-// getOrCreatePorts attempts to retrieve a ports document
-// and returns a newly created one if it does not exist.
-func getOrCreatePorts(st *State,
-	// Network is hardcoded until multiple network
-	// support lands.
-	//network string,
-	machineId string) (*Ports, error) {
-	ports, err := getPorts(st, machineId)
+func addPortsDocOps(st *State, machineId, networkName string, ports ...PortRange) []txn.Op {
+	key := portsGlobalKey(machineId, networkName)
+	pdoc := &portsDoc{
+		Id:    key,
+		Ports: ports,
+	}
+	return []txn.Op{{
+		C:      machinesC,
+		Id:     machineId,
+		Assert: notDeadDoc,
+	}, {
+		C:      openedPortsC,
+		Id:     key,
+		Assert: txn.DocMissing,
+		Insert: pdoc,
+	}}
+}
+
+// getPorts returns the ports document for the specified machine and
+// network.
+func getPorts(st *State, machineId, networkName string) (*Ports, error) {
+	openedPorts, closer := st.getCollection(openedPortsC)
+	defer closer()
+
+	var doc portsDoc
+	key := portsGlobalKey(machineId, networkName)
+	stringId := portsIdAsString(machineId, networkName)
+	err := openedPorts.FindId(key).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf(stringId)
+	}
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get %s", stringId)
+	}
+
+	return &Ports{st, doc, false}, nil
+}
+
+// getOrCreatePorts attempts to retrieve a ports document and returns
+// a newly created one if it does not exist.
+func getOrCreatePorts(st *State, machineId, networkName string) (*Ports, error) {
+	ports, err := getPorts(st, machineId, networkName)
 	if errors.IsNotFound(err) {
-		doc := portsDoc{Id: portsDocId(machineId, network.DefaultPublic)}
+		key := portsGlobalKey(machineId, networkName)
+		doc := portsDoc{Id: key}
 		ports = &Ports{st, doc, true}
 	} else if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return ports, nil
 }

--- a/state/ports_test.go
+++ b/state/ports_test.go
@@ -6,9 +6,13 @@ package state_test
 import (
 	"strings"
 
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -35,13 +39,13 @@ func (s *PortsDocSuite) SetUpTest(c *gc.C) {
 	s.unit2 = f.MakeUnit(c, &factory.UnitParams{Service: s.service, Machine: s.machine})
 
 	var err error
-	s.ports, err = state.GetOrCreatePorts(s.State, s.machine.Id())
+	s.ports, err = state.GetOrCreatePorts(s.State, s.machine.Id(), network.DefaultPublic)
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.ports, gc.NotNil)
 }
 
 func (s *PortsDocSuite) TestCreatePorts(c *gc.C) {
-	ports, err := state.GetOrCreatePorts(s.State, s.machine.Id())
+	ports, err := state.GetOrCreatePorts(s.State, s.machine.Id(), network.DefaultPublic)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ports, gc.NotNil)
 	err = ports.OpenPorts(state.PortRange{
@@ -52,7 +56,7 @@ func (s *PortsDocSuite) TestCreatePorts(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	ports, err = state.GetPorts(s.State, s.machine.Id())
+	ports, err = state.GetPorts(s.State, s.machine.Id(), network.DefaultPublic)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ports, gc.NotNil)
 
@@ -156,7 +160,7 @@ func (s *PortsDocSuite) TestOpenAndClosePorts(c *gc.C) {
 			UnitName: s.unit2.Name(),
 			Protocol: "TCP",
 		},
-		expected: "cannot open ports 100-300/tcp on machine \"0\": port ranges 100-200/tcp \\(wordpress/0\\) and 100-300/tcp \\(wordpress/1\\) conflict",
+		expected: "cannot open ports 100-300/tcp on machine 0: port ranges 100-200/tcp \\(wordpress/0\\) and 100-300/tcp \\(wordpress/1\\) conflict",
 	}, {
 		about: "try to open an identical port range with different unit",
 		existing: []state.PortRange{{
@@ -171,7 +175,7 @@ func (s *PortsDocSuite) TestOpenAndClosePorts(c *gc.C) {
 			UnitName: s.unit2.Name(),
 			Protocol: "TCP",
 		},
-		expected: "cannot open ports 100-200/tcp on machine \"0\": port ranges 100-200/tcp \\(wordpress/0\\) and 100-200/tcp \\(wordpress/1\\) conflict",
+		expected: "cannot open ports 100-200/tcp on machine 0: port ranges 100-200/tcp \\(wordpress/0\\) and 100-200/tcp \\(wordpress/1\\) conflict",
 	}, {
 		about: "try to open a port range with different protocol with different unit",
 		existing: []state.PortRange{{
@@ -207,7 +211,7 @@ func (s *PortsDocSuite) TestOpenAndClosePorts(c *gc.C) {
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
 
-		ports, err := state.GetOrCreatePorts(s.State, s.machine.Id())
+		ports, err := state.GetOrCreatePorts(s.State, s.machine.Id(), network.DefaultPublic)
 		c.Assert(err, gc.IsNil)
 		c.Assert(ports, gc.NotNil)
 
@@ -243,6 +247,22 @@ func (s *PortsDocSuite) TestOpenAndClosePorts(c *gc.C) {
 		err = ports.Remove()
 		c.Check(err, gc.IsNil)
 	}
+}
+
+func (s *PortsDocSuite) TestAllPortRanges(c *gc.C) {
+	portRange := state.PortRange{
+		FromPort: 100,
+		ToPort:   200,
+		UnitName: s.unit1.Name(),
+		Protocol: "TCP",
+	}
+	err := s.ports.OpenPorts(portRange)
+	c.Assert(err, gc.IsNil)
+
+	ranges := s.ports.AllPortRanges()
+	c.Assert(ranges, gc.HasLen, 1)
+
+	c.Assert(ranges[network.PortRange{100, 200, "TCP"}], gc.Equals, s.unit1.Name())
 }
 
 func (s *PortsDocSuite) TestOpenInvalidRange(c *gc.C) {
@@ -287,11 +307,11 @@ func (s *PortsDocSuite) TestRemovePortsDoc(c *gc.C) {
 	err := s.ports.OpenPorts(portRange)
 	c.Assert(err, gc.IsNil)
 
-	ports, err := state.GetPorts(s.State, s.machine.Id())
+	ports, err := state.GetPorts(s.State, s.machine.Id(), network.DefaultPublic)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ports, gc.NotNil)
 
-	allPorts, err := s.machine.OpenedPorts(s.State)
+	allPorts, err := s.machine.AllPorts()
 	c.Assert(err, gc.IsNil)
 
 	for _, prt := range allPorts {
@@ -299,9 +319,37 @@ func (s *PortsDocSuite) TestRemovePortsDoc(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 	}
 
-	ports, err = state.GetPorts(s.State, s.machine.Id())
+	ports, err = state.GetPorts(s.State, s.machine.Id(), network.DefaultPublic)
 	c.Assert(ports, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "ports document for machine .* not found")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, `ports for machine 0, network "juju-public" not found`)
+}
+
+func (s *PortsDocSuite) TestWatchPorts(c *gc.C) {
+	w := s.State.WatchOpenedPorts()
+	c.Assert(w, gc.NotNil)
+
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, s.State, w)
+	wc.AssertChange()
+	wc.AssertNoChange()
+
+	portRange := state.PortRange{
+		FromPort: 100,
+		ToPort:   200,
+		UnitName: s.unit1.Name(),
+		Protocol: "TCP",
+	}
+	globalKey := state.PortsGlobalKey(s.machine.Id(), network.DefaultPublic)
+	err := s.ports.OpenPorts(portRange)
+	c.Assert(err, gc.IsNil)
+	wc.AssertChange(globalKey)
+
+	err = s.ports.Refresh()
+	c.Assert(err, gc.IsNil)
+	err = s.ports.ClosePorts(portRange)
+	c.Assert(err, gc.IsNil)
+	wc.AssertChange(globalKey)
 }
 
 type PortRangeSuite struct{}

--- a/state/unit.go
+++ b/state/unit.go
@@ -733,46 +733,58 @@ func (u *Unit) SetStatus(status params.Status, info string, data map[string]inte
 func (u *Unit) OpenPort(protocol string, number int) (err error) {
 	ports, err := NewPortRange(u.Name(), number, number, protocol)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer errors.Maskf(&err, "cannot open ports %v for unit %q", ports, u)
 
 	machineId, err := u.AssignedMachineId()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
-	machinePorts, err := getOrCreatePorts(u.st, machineId)
+	// TODO(dimitern) 2014-09-10 bug #1337804: network name is
+	// hard-coded until multiple network support lands
+	machinePorts, err := getOrCreatePorts(u.st, machineId, network.DefaultPublic)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Check if this unit is still storing ports in its own document,
-	// if so - attempt a migration.
-	// Migration is only performed if the openedPorts document contains
-	// no ports for the unit - this condition will be removed when
-	// the unit ports list will be cleared after migration.
-	// TODO(domas) 2014-07-04 bug #1337817: remove second condition
+	// if so - attempt a migration. Migration is only performed if the
+	// openedPorts document contains no ports for the unit.
+	//
+	// TODO(dimitern) Once the migration is performed as an upgrade
+	// step, this won't be necessary.
 	if len(u.doc.Ports) != 0 && len(machinePorts.PortsForUnit(u.Name())) == 0 {
 		err = machinePorts.migratePorts(u)
 		if err != nil {
 			unitLogger.Errorf("could not migrate ports collection for unit %v: %v", u, err)
-			return err
+			return errors.Trace(err)
 		}
 		err = machinePorts.Refresh()
 		if err != nil {
-			return err
+			return errors.Trace(err)
+		}
+		err = u.Refresh()
+		if err != nil {
+			return errors.Trace(err)
 		}
 	}
 
 	err = machinePorts.OpenPorts(ports)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
-	// TODO(domas) 2014-07-04 bug #1337813: remove once firewaller is updated to watch openedPorts collection
+	// TODO(domas) 2014-07-04 bug #1337813: remove once firewaller is
+	// updated to watch openedPorts collection
 	return u.openUnitPort(protocol, number)
 }
 
-// openUnitPort is the old implementation of OpenPort that amends the list of ports on the unit document.
-// TODO(domas) 2014-07-04 bug #1337813
-// This is kept in place until the firewaller is updated to watch the OpenedPorts collection.
+// openUnitPort is the old implementation of OpenPort that amends the
+// list of ports on the unit document.
+//
+// TODO(domas) 2014-07-04 bug #1337813 This is kept in place until the
+// firewaller is updated to watch the OpenedPorts collection.
 func (u *Unit) openUnitPort(protocol string, number int) (err error) {
 	port := network.Port{Protocol: protocol, Number: number}
 	defer errors.Maskf(&err, "cannot open port %v for unit %q", port, u)
@@ -799,9 +811,11 @@ func (u *Unit) openUnitPort(protocol string, number int) (err error) {
 	return nil
 }
 
-// closeUnitPort is the old implementation of ClosePort that alters the list of ports on the unit document.
-// TODO(domas) 2014-07-04 bug #1337813
-// This is kept in place until the firewaller is updated to watch the OpenedPorts collection.
+// closeUnitPort is the old implementation of ClosePort that alters
+// the list of ports on the unit document.
+//
+// TODO(domas) 2014-07-04 bug #1337813 This is kept in place until the
+// firewaller is updated to watch the OpenedPorts collection.
 func (u *Unit) closeUnitPort(protocol string, number int) (err error) {
 	port := network.Port{Protocol: protocol, Number: number}
 	defer errors.Maskf(&err, "cannot close port %v for unit %q", port, u)
@@ -829,53 +843,63 @@ func (u *Unit) closeUnitPort(protocol string, number int) (err error) {
 func (u *Unit) ClosePort(protocol string, number int) (err error) {
 	ports, err := NewPortRange(u.Name(), number, number, protocol)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer errors.Maskf(&err, "cannot close ports %v for unit %q", ports, u)
 
 	machineId, err := u.AssignedMachineId()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
-	machinePorts, err := getOrCreatePorts(u.st, machineId)
+	// TODO(dimitern) 2014-09-10 bug #1337804: network name is
+	// hard-coded until multiple network support lands
+	machinePorts, err := getOrCreatePorts(u.st, machineId, network.DefaultPublic)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	// Check if this unit is still storing ports in its own document,
 	// if so - attempt a migration.
-	// TODO(domas) 2014-07-04 bug #1337817: remove second condition
+	//
+	// TODO(dimitern) Once the ports migration is done as an upgrade
+	// step, remove this.
 	if len(u.doc.Ports) != 0 && len(machinePorts.PortsForUnit(u.Name())) == 0 {
 		err = machinePorts.migratePorts(u)
 		if err != nil {
 			unitLogger.Errorf("could not migrate ports collection for unit %v: %v", u, err)
-			return err
+			return errors.Trace(err)
 		}
 		err = machinePorts.Refresh()
 		if err != nil {
-			return err
+			return errors.Trace(err)
+		}
+		err = u.Refresh()
+		if err != nil {
+			return errors.Trace(err)
 		}
 	}
 
 	err = machinePorts.ClosePorts(ports)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
-	// TODO(domas) 2014-07-04 bug #1337813: remove once firewaller is updated to watch openedPorts collection
+	// TODO(domas) 2014-07-04 bug #1337813: remove once firewaller is
+	// updated to watch openedPorts collection
 	return u.closeUnitPort(protocol, number)
 }
 
 // OpenedPorts returns a slice containing the open ports of the unit.
-// TODO(domas) 2014-07-04 but #1337817: update this function to return port ranges.
 func (u *Unit) OpenedPorts() []network.Port {
 	machineId, err := u.AssignedMachineId()
 	if err != nil {
-		unitLogger.Errorf("Cannot retrieve opened ports list for unit %v: %v", u, err)
+		unitLogger.Errorf("cannot retrieve opened ports list for unit %v: %v", u, err)
 		return nil
 	}
 
-	machinePorts, err := getPorts(u.st, machineId)
+	// TODO(dimitern) 2014-09-10 bug #1337804: network name is
+	// hard-coded until multiple network support lands
+	machinePorts, err := getPorts(u.st, machineId, network.DefaultPublic)
 	result := []network.Port{}
 	if err == nil {
 		ports := machinePorts.PortsForUnit(u.Name())
@@ -885,6 +909,9 @@ func (u *Unit) OpenedPorts() []network.Port {
 				Number:   port.FromPort})
 		}
 	} else {
+		if !errors.IsNotFound(err) {
+			unitLogger.Errorf("getting ports for unit %v failed: %v", u, err)
+		}
 		// Read the port list in the unit document if the ports
 		// document does not exist.
 		result = append([]network.Port{}, u.doc.Ports...)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1897,3 +1897,96 @@ func (w *machineInterfacesWatcher) loop() error {
 		}
 	}
 }
+
+// openedPortsWatcher notifies of changes in the openedPorts
+// collection
+type openedPortsWatcher struct {
+	commonWatcher
+	out chan []string
+}
+
+var _ Watcher = (*openedPortsWatcher)(nil)
+
+// WatchOpenedPorts starts and returns a StringsWatcher notifying of
+// changes to the openedPorts collection.
+func (st *State) WatchOpenedPorts() StringsWatcher {
+	return newOpenedPortsWatcher(st)
+}
+
+func newOpenedPortsWatcher(st *State) StringsWatcher {
+	w := &openedPortsWatcher{
+		commonWatcher: commonWatcher{st: st},
+		out:           make(chan []string),
+	}
+	go func() {
+		defer w.tomb.Done()
+		defer close(w.out)
+		w.tomb.Kill(w.loop())
+	}()
+
+	return w
+}
+
+// Changes returns the event channel for w
+func (w *openedPortsWatcher) Changes() <-chan []string {
+	return w.out
+}
+
+func (w *openedPortsWatcher) initial() ([]string, error) {
+	ports, closer := w.st.getCollection(openedPortsC)
+	defer closer()
+
+	var portDocs set.Strings
+	var doc portsDoc
+	iter := ports.Find(nil).Select(bson.D{{"_id", 1}}).Iter()
+	for iter.Next(&doc) {
+		portDocs.Add(doc.Id)
+	}
+	return portDocs.SortedValues(), errors.Trace(iter.Close())
+}
+
+func (w *openedPortsWatcher) loop() error {
+	in := make(chan watcher.Change)
+	changes, err := w.initial()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	w.st.watcher.WatchCollection(openedPortsC, in)
+	defer w.st.watcher.UnwatchCollection(openedPortsC, in)
+	out := w.out
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-w.st.watcher.Dead():
+			return stateWatcherDeadError(w.st.watcher.Err())
+		case ch := <-in:
+			updates, ok := collect(ch, in, w.tomb.Dying())
+			if !ok {
+				return tomb.ErrDying
+			}
+			if changes, err = w.merge(changes, updates); err != nil {
+				return errors.Trace(err)
+			}
+			if len(changes) > 0 {
+				out = w.out
+			}
+		case out <- changes:
+			changes = nil
+			out = nil
+		}
+	}
+}
+
+func (w *openedPortsWatcher) merge(changes []string, updates map[interface{}]bool) ([]string, error) {
+	for id := range updates {
+		if id, ok := id.(string); ok {
+			if !hasString(changes, id) {
+				changes = append(changes, id)
+			}
+		} else {
+			return nil, errors.Errorf("id %v is not of type string, got %T", id, id)
+		}
+	}
+	return changes, nil
+}


### PR DESCRIPTION
Taking over the work Domas did in https://github.com/juju/juju/pull/517 and splitting this, 
as requested by reviewers in 4 chunks. This is 1/4 and is only
about changes in the state package.

Ports opened on a unit are now migrated to the openedPorts collection
on subsequent OpenPort/ClosePort calls, but the Ports list on the
unit document is not reset yet, as it's better done in a follow-up
one in an upgrade step.

Next: 2/4: upgrade step to migrate ports from units to openedPorts
collection; 3/4: firewaller api changes to enable watching ports;
4/4: firewaller worker using the new api.
