### PR TITLE
Skip unreliable ipv6 test

### DIFF
--- a/replicaset/replicaset_test.go
+++ b/replicaset/replicaset_test.go
@@ -159,6 +159,8 @@ type MongoIPV6Suite struct {
 var _ = gc.Suite(&MongoIPV6Suite{})
 
 func (s *MongoIPV6Suite) TestAddRemoveSetIPv6(c *gc.C) {
+	c.Skip("Skipping test until mgo issue 22 is fixed")
+
 	root := newServer(c)
 	defer root.Destroy()
 	// Note: we use the ::1:port format because mongo doesn't understand


### PR DESCRIPTION
replicaset/replicaset_test : skip unreliable test due to mgo issue

Due to a bug in mongo, now fixed in 2.7.4, when creating replicasets with ipv6 we must specify the address in the form "::1:port", not the more correct "[::1]:port".

https://jira.mongodb.org/browse/SERVER-5436

mgo, in resolveAddr (in cluster.go, called from syncServers), calls net.DialTimeout which fails with "too many colons in address" when we use this format.

This is filed as issue 22 in mgo https://github.com/go-mgo/mgo/issues/22

Until this is resolved the test is skipped.
