### PR TITLE
Adapted environs storage tests for Windows.

### DIFF
--- a/environs/filestorage/filestorage_test.go
+++ b/environs/filestorage/filestorage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2013, 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package filestorage_test
@@ -79,7 +79,11 @@ func (s *filestorageSuite) TestList(c *gc.C) {
 		c.Logf("test %d: prefix=%q", i, test.prefix)
 		files, err := storage.List(s.reader, test.prefix)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(files, gc.DeepEquals, test.expected)
+		c.Assert(err, gc.IsNil)
+		c.Assert(len(files), gc.Equals, len(test.expected))
+		for i := range files {
+			c.Check(files[i], jc.SamePath, test.expected[i])
+		}
 	}
 }
 
@@ -235,5 +239,5 @@ func (s *filestorageSuite) TestRelativePath(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	url, err := reader.URL("")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(url, gc.Equals, utils.MakeFileURL(dir)+"/a")
+	c.Assert(url, gc.Equals, utils.MakeFileURL(filepath.Join(dir, "a")))
 }

--- a/environs/httpstorage/backend_test.go
+++ b/environs/httpstorage/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2013, 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package httpstorage_test
@@ -272,7 +272,10 @@ func testList(c *gc.C, client *http.Client, url string) {
 		_, err = buf.ReadFrom(resp.Body)
 		c.Assert(err, jc.ErrorIsNil)
 		names := strings.Split(buf.String(), "\n")
-		c.Assert(names, gc.DeepEquals, tc.found)
+		c.Assert(len(names), gc.Equals, len(tc.found))
+		for i := range names {
+			c.Check(names[i], jc.SamePath, tc.found[i])
+		}
 	}
 	for i, tc := range listTests {
 		c.Logf("test %d", i)

--- a/environs/httpstorage/storage_test.go
+++ b/environs/httpstorage/storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2013, 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package httpstorage_test
@@ -132,7 +132,10 @@ func (s *storageSuite) TestPersistence(c *gc.C) {
 func checkList(c *gc.C, stor storage.StorageReader, prefix string, names []string) {
 	lnames, err := storage.List(stor, prefix)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(lnames, gc.DeepEquals, names)
+	c.Assert(len(lnames), gc.Equals, len(names))
+	for i := range lnames {
+		c.Check(lnames[i], jc.SamePath, names[i])
+	}
 }
 
 type readerWithClose struct {


### PR DESCRIPTION
Made some minor adaptations to the storage-related tests in environs to work on Windows as well. Now both the environs/httpstorage and environs/filestorage packages' tests are up to scratch.