### PR TITLE
Set up the repo for rbt (ReviewBoard).

### DIFF
--- a/.reviewboardrc
+++ b/.reviewboardrc
@@ -1,0 +1,3 @@
+REVIEWBOARD_URL = "https://reviews.vapour.ws/"
+REPOSITORY = "juju (core)"
+BRANCH = "master"


### PR DESCRIPTION
This obviates the need to run "rbt setup-repo".
