### PR TITLE
Make backup IDs more human-readable.

### DIFF
--- a/state/backups.go
+++ b/state/backups.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
 	"github.com/juju/utils/filestorage"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -230,25 +229,21 @@ func getBackupMetadata(st *State, id string) (*metadata.Metadata, error) {
 	return doc.asMetadata(), nil
 }
 
-func newBackupIDBasic(*metadata.Metadata) (string, error) {
-	id, err := utils.NewUUID()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return id.String(), nil
-}
-
-func newBackupIDForHumans(metadata *metadata.Metadata) (string, error) {
+// newBackupID returns a new ID for a state backup.  The format is the
+// UTC timestamp from the metadata followed by the environment ID:
+// "YYYYMMDD-hhmmss.<env ID>".  This makes the ID a little more human-
+// consumable (in contrast to a plain UUID string).  Ideally we would
+// use some form of environment name rather than the UUID, but for now
+// the raw env ID is sufficient.
+func newBackupID(metadata *metadata.Metadata) string {
 	rawts := metadata.Started()
 	Y, M, D := rawts.Date()
 	h, m, s := rawts.Clock()
 	timestamp := fmt.Sprintf("%04d%02d%02d-%02d%02d%02d", Y, M, D, h, m, s)
 	origin := metadata.Origin()
 	env := origin.Environment()
-	return timestamp + "." + env, nil
+	return timestamp + "." + env
 }
-
-var newBackupID = newBackupIDForHumans
 
 // addBackupMetadata stores metadata for a backup where it can be
 // accessed later.  It returns a new ID that is associated with the
@@ -257,10 +252,7 @@ var newBackupID = newBackupIDForHumans
 func addBackupMetadata(st *State, metadata *metadata.Metadata) (string, error) {
 	// We use our own mongo _id value since the auto-generated one from
 	// mongo may contain sensitive data (see bson.ObjectID).
-	id, err := newBackupID(metadata)
-	if err != nil {
-		return "", errors.Annotate(err, "error generating new ID")
-	}
+	id := newBackupID(metadata)
 	return id, addBackupMetadataID(st, metadata, id)
 }
 

--- a/state/backups_test.go
+++ b/state/backups_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/state"
@@ -48,21 +47,12 @@ func (s *backupSuite) checkMetadata(
 	c.Check(metadata.Stored(), gc.DeepEquals, expected.Stored())
 }
 
-func (s *backupSuite) TestNewBackupIDBasic(c *gc.C) {
-	meta := s.metadata(c)
-	id, err := state.NewBackupIDBasic(meta)
-	c.Assert(err, gc.IsNil)
-
-	c.Check(utils.IsValidUUIDString(id), jc.IsTrue)
-}
-
-func (s *backupSuite) TestNewBackupIDForHumans(c *gc.C) {
+func (s *backupSuite) TestNewBackupID(c *gc.C) {
 	origin := metadata.NewOrigin("spam", "0", "localhost")
 	started := time.Date(2014, time.Month(9), 12, 13, 19, 27, 0, time.UTC)
 	meta := metadata.NewMetadata(*origin, "", &started)
 
-	id, err := state.NewBackupIDForHumans(meta)
-	c.Assert(err, gc.IsNil)
+	id := state.NewBackupID(meta)
 
 	c.Check(id, gc.Equals, "20140912-131927.spam")
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 var (
-	NewBackupIDBasic      = newBackupIDBasic
-	NewBackupIDForHumans  = newBackupIDForHumans
+	NewBackupID           = newBackupID
 	GetBackupMetadata     = getBackupMetadata
 	AddBackupMetadata     = addBackupMetadata
 	AddBackupMetadataID   = addBackupMetadataID


### PR DESCRIPTION
Currently we just use the current UUID.  This patch changes it to "<timestamp>.<env ID>".  A more human-readable ID will help juju users.
