### PR TITLE
state: Life no longer depends on apiserver/params

### DIFF
--- a/state/life.go
+++ b/state/life.go
@@ -7,7 +7,6 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/mongo"
 )
 
@@ -22,14 +21,17 @@ const (
 	nLife
 )
 
-var lifeStrings = [nLife]params.Life{
-	Alive: params.Alive,
-	Dying: params.Dying,
-	Dead:  params.Dead,
-}
-
 func (l Life) String() string {
-	return string(lifeStrings[l])
+	switch l {
+	case Alive:
+		return "alive"
+	case Dying:
+		return "dying"
+	case Dead:
+		return "dead"
+	default:
+		return "unknown"
+	}
 }
 
 var isAliveDoc = bson.D{{"life", Alive}}

--- a/state/life_test.go
+++ b/state/life_test.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
 
@@ -156,6 +157,22 @@ func (s *LifeSuite) TestLifecycleStateChanges(c *gc.C) {
 			err = living.Remove()
 			c.Assert(err, gc.IsNil)
 		}
+	}
+}
+
+func (s *LifeSuite) TestLifeString(c *gc.C) {
+	var tests = []struct {
+		life state.Life
+		want params.Life
+	}{
+		{state.Alive, params.Alive},
+		{state.Dying, params.Dying},
+		{state.Dead, params.Dead},
+		{42, "unknown"},
+	}
+	for _, test := range tests {
+		got := test.life.String()
+		c.Assert(got, gc.Equals, string(test.want))
 	}
 }
 


### PR DESCRIPTION
`state.Life` is a small integer, however it relies on params.State for its string representation. Apart from the coupling, this is nuts because common/life.go doesn't check the results of `state.Life.String()`, it just converts it to a `params.Life` and stuffs it back to the client.
