### PR TITLE
Tweak bash used for sshstorage.Get()

### DIFF
--- a/environs/sshstorage/storage.go
+++ b/environs/sshstorage/storage.go
@@ -253,7 +253,7 @@ func (s *SSHStorage) Get(name string) (io.ReadCloser, error) {
 	if err != nil {
 		err := err.(SSHStorageError)
 		if strings.Contains(err.Output, "No such file") {
-			return nil, errors.NewNotFound(err, filename+" not found")
+			return nil, errors.NewNotFound(err, path+" not found")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1367695

Return fixed, locale independent string when file is not found.
