### PR TITLE
Merge pull request #762 from wallyworld/sshstorage-not-found

### DIFF
--- a/environs/sshstorage/storage.go
+++ b/environs/sshstorage/storage.go
@@ -248,11 +248,12 @@ func (s *SSHStorage) Get(name string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.runf(flockShared, "base64 < %s", utils.ShQuote(path))
+	filename := utils.ShQuote(path)
+	out, err := s.runf(flockShared, "(test -e %s || (echo No such file && exit 1)) && base64 < %s", filename, filename)
 	if err != nil {
 		err := err.(SSHStorageError)
 		if strings.Contains(err.Output, "No such file") {
-			return nil, errors.NewNotFound(err, "")
+			return nil, errors.NewNotFound(err, path+" not found")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Tweak bash used for sshstorage.Get()

Fixes: https://bugs.launchpad.net/juju-core/+bug/1367695

Return fixed, locale independent string when file is not found.
