### PR TITLE
state: remove MachineJobFromParams helper

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -155,7 +155,7 @@ func initBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineC
 
 	jobs := make([]state.MachineJob, len(cfg.Jobs))
 	for i, job := range cfg.Jobs {
-		machineJob, err := state.MachineJobFromParams(job)
+		machineJob, err := machineJobFromParams(job)
 		if err != nil {
 			return nil, fmt.Errorf("invalid bootstrap machine job %q: %v", job, err)
 		}
@@ -199,4 +199,21 @@ func initBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineC
 func initAPIHostPorts(c ConfigSetter, st *state.State, addrs []network.Address, apiPort int) error {
 	hostPorts := network.AddressesWithPort(addrs, apiPort)
 	return st.SetAPIHostPorts([][]network.HostPort{hostPorts})
+}
+
+// machineJobFromParams returns the job corresponding to params.MachineJob.
+// TODO(dfc) this function should live in apiserver/params, move there once
+// state does not depend on apiserver/params
+func machineJobFromParams(job params.MachineJob) (state.MachineJob, error) {
+	switch job {
+	case params.JobHostUnits:
+		return state.JobHostUnits, nil
+	case params.JobManageEnviron:
+		return state.JobManageEnviron, nil
+	case params.JobManageStateDeprecated:
+		// Deprecated in 1.18.
+		return state.JobManageStateDeprecated, nil
+	default:
+		return -1, errors.Errorf("invalid machine job %q", job)
+	}
 }

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -231,6 +231,34 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "failed to initialize mongo admin user: cannot set admin password: not authorized .*")
 }
 
+func (s *bootstrapSuite) TestMachineJobFromParams(c *gc.C) {
+	var tests = []struct {
+		name params.MachineJob
+		want state.MachineJob
+		err  string
+	}{{
+		name: params.JobHostUnits,
+		want: state.JobHostUnits,
+	}, {
+		name: params.JobManageEnviron,
+		want: state.JobManageEnviron,
+	}, {
+		name: params.JobManageStateDeprecated,
+		want: state.JobManageStateDeprecated,
+	}, {
+		name: "invalid",
+		want: -1,
+		err:  `invalid machine job "invalid"`,
+	}}
+	for _, test := range tests {
+		got, err := agent.MachineJobFromParams(test.name)
+		if err != nil {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+		c.Check(got, gc.Equals, test.want)
+	}
+}
+
 func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, password string) {
 	info := &mongo.MongoInfo{
 		Info: mongo.Info{

--- a/agent/export_test.go
+++ b/agent/export_test.go
@@ -50,3 +50,5 @@ func ConfigFileExists(config Config) bool {
 	_, err := os.Lstat(conf.configFilePath)
 	return err == nil
 }
+
+var MachineJobFromParams = machineJobFromParams

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -685,13 +685,30 @@ func (c *Client) addOneMachine(p params.AddMachineParams) (*state.Machine, error
 func stateJobs(jobs []params.MachineJob) ([]state.MachineJob, error) {
 	newJobs := make([]state.MachineJob, len(jobs))
 	for i, job := range jobs {
-		newJob, err := state.MachineJobFromParams(job)
+		newJob, err := machineJobFromParams(job)
 		if err != nil {
 			return nil, err
 		}
 		newJobs[i] = newJob
 	}
 	return newJobs, nil
+}
+
+// machineJobFromParams returns the job corresponding to params.MachineJob.
+// TODO(dfc) this function should live in apiserver/params, move there once
+// state does not depend on apiserver/params
+func machineJobFromParams(job params.MachineJob) (state.MachineJob, error) {
+	switch job {
+	case params.JobHostUnits:
+		return state.JobHostUnits, nil
+	case params.JobManageEnviron:
+		return state.JobManageEnviron, nil
+	case params.JobManageStateDeprecated:
+		// Deprecated in 1.18.
+		return state.JobManageStateDeprecated, nil
+	default:
+		return -1, errors.Errorf("invalid machine job %q", job)
+	}
 }
 
 // ProvisioningScript returns a shell script that, when run,

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2563,3 +2563,31 @@ func (s *clientSuite) TestClientAgentVersion(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, current)
 }
+
+func (s *clientSuite) TestMachineJobFromParams(c *gc.C) {
+	var tests = []struct {
+		name params.MachineJob
+		want state.MachineJob
+		err  string
+	}{{
+		name: params.JobHostUnits,
+		want: state.JobHostUnits,
+	}, {
+		name: params.JobManageEnviron,
+		want: state.JobManageEnviron,
+	}, {
+		name: params.JobManageStateDeprecated,
+		want: state.JobManageStateDeprecated,
+	}, {
+		name: "invalid",
+		want: -1,
+		err:  `invalid machine job "invalid"`,
+	}}
+	for _, test := range tests {
+		got, err := client.MachineJobFromParams(test.name)
+		if err != nil {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+		c.Check(got, gc.Equals, test.want)
+	}
+}

--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -9,3 +9,5 @@ var (
 	GetAllUnitNames         = getAllUnitNames
 	StateStorage            = &stateStorage
 )
+
+var MachineJobFromParams = machineJobFromParams

--- a/environs/manual/provisioner.go
+++ b/environs/manual/provisioner.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/state"
 )
 
 const manualInstancePrefix = "manual:"
@@ -142,18 +141,6 @@ func recordMachineInState(client ProvisioningClientAPI, machineParams params.Add
 		return "", machineInfo.Error
 	}
 	return machineInfo.Machine, nil
-}
-
-// convertToStateJobs takes a slice of params.MachineJob and makes them a slice of state.MachineJob
-func convertToStateJobs(jobs []params.MachineJob) ([]state.MachineJob, error) {
-	outJobs := make([]state.MachineJob, len(jobs))
-	var err error
-	for j, job := range jobs {
-		if outJobs[j], err = state.MachineJobFromParams(job); err != nil {
-			return nil, err
-		}
-	}
-	return outJobs, nil
 }
 
 // gatherMachineParams collects all the information we know about the machine

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -142,8 +142,6 @@ func SetCharmBundleURL(c *gc.C, st *State, curl *charm.URL, bundleURL string) {
 
 var MachineIdLessThan = machineIdLessThan
 
-var JobNames = jobNames
-
 // SCHEMACHANGE
 // This method is used to reset a deprecated machine attribute.
 func SetMachineInstanceId(m *Machine, instanceId string) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -70,16 +70,6 @@ func (job MachineJob) ToParams() params.MachineJob {
 	return params.MachineJob(fmt.Sprintf("<unknown job %d>", int(job)))
 }
 
-// MachineJobFromParams returns the job corresponding to params.MachineJob.
-func MachineJobFromParams(job params.MachineJob) (MachineJob, error) {
-	for machineJob, paramJob := range jobNames {
-		if paramJob == job {
-			return machineJob, nil
-		}
-	}
-	return -1, fmt.Errorf("invalid machine job %q", job)
-}
-
 // paramsJobsFromJobs converts state jobs to params jobs.
 func paramsJobsFromJobs(jobs []MachineJob) []params.MachineJob {
 	paramsJobs := make([]params.MachineJob, len(jobs))

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -54,16 +54,6 @@ func (s *MachineSuite) TestContainerDefaults(c *gc.C) {
 	c.Assert(containers, gc.DeepEquals, []string(nil))
 }
 
-func (s *MachineSuite) TestMachineJobFromParams(c *gc.C) {
-	for stateMachineJob, paramsMachineJob := range state.JobNames {
-		job, err := state.MachineJobFromParams(paramsMachineJob)
-		c.Assert(err, gc.IsNil)
-		c.Assert(job, gc.Equals, stateMachineJob)
-	}
-	_, err := state.MachineJobFromParams("invalid")
-	c.Assert(err, gc.NotNil)
-}
-
 func (s *MachineSuite) TestParentId(c *gc.C) {
 	parentId, ok := s.machine.ParentId()
 	c.Assert(parentId, gc.Equals, "")


### PR DESCRIPTION
`MachineJobFromParams` forces `state` to depend on `apiserver/params` for its input parameters.

Ideally params should own these helpers, but that would require it to depend on state, which would currently cause an import loop.

Instead move the function to the calling packages temporarily.
