### PR TITLE
Limit adding and sending metrics to the collect-metrics hook.

### DIFF
--- a/cmd/juju/helptool.go
+++ b/cmd/juju/helptool.go
@@ -42,7 +42,6 @@ func (dummyHookContext) ConfigSettings() (charm.Settings, error) {
 func (dummyHookContext) ActionParams() map[string]interface{} {
 	return nil
 }
-
 func (dummyHookContext) HookRelation() (jujuc.ContextRelation, bool) {
 	return nil, false
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d
 github.com/juju/testing	git	87af103ad72f6ef2b391252bab51d217659e0af3	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	27f6e1b91f3ca1da6789e1641a115f284bf49833	
-gopkg.in/juju/charm.v3	git	eb7dae8ed9dfa44b89e4e8eee6e21f80e31a3b69	
+gopkg.in/juju/charm.v3	git	a06606aa4ae97d21e63ba4954b7242198612f076	
 github.com/juju/syslog	git	2b69d6582feb16ff8b6d644495e16c2d8314fcb8	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	

--- a/worker/uniter/context_test.go
+++ b/worker/uniter/context_test.go
@@ -252,7 +252,7 @@ func (s *RunHookSuite) TestRunHook(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	for i, t := range runHookTests {
 		c.Logf("\ntest %d: %s; perm %v", i, t.summary, t.spec.perm)
-		ctx := s.getHookContext(c, uuid.String(), t.relid, t.remote, t.proxySettings)
+		ctx := s.getHookContext(c, uuid.String(), t.relid, t.remote, t.proxySettings, false)
 		var charmDir, outPath string
 		var hookExists bool
 		if t.spec.perm == 0 {
@@ -304,7 +304,7 @@ func (s *RunHookSuite) TestRunHookRelationFlushing(c *gc.C) {
 	// Create a charm with a breaking hook.
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies)
+	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, false)
 	charmDir, _ := makeCharm(c, hookSpec{
 		name: "something-happened",
 		perm: 0700,
@@ -381,9 +381,9 @@ func (s *RunHookSuite) TestRunHookRelationFlushing(c *gc.C) {
 func (s *RunHookSuite) TestRunHookMetricSending(c *gc.C) {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies)
+	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, true)
 	charmDir, _ := makeCharm(c, hookSpec{
-		name: "something-happened",
+		name: "collect-metrics",
 		perm: 0700,
 	})
 
@@ -391,7 +391,7 @@ func (s *RunHookSuite) TestRunHookMetricSending(c *gc.C) {
 	ctx.AddMetrics("key", "50", now)
 
 	// Run the hook.
-	err = ctx.RunHook("something-happened", charmDir, c.MkDir(), "/path/to/socket")
+	err = ctx.RunHook("collect-metrics", charmDir, c.MkDir(), "/path/to/socket")
 	c.Assert(err, gc.IsNil)
 
 	metricBatches, err := s.State.MetricBatches()
@@ -401,6 +401,28 @@ func (s *RunHookSuite) TestRunHookMetricSending(c *gc.C) {
 	c.Assert(metrics, gc.HasLen, 1)
 	c.Assert(metrics[0].Key, gc.Equals, "key")
 	c.Assert(metrics[0].Value, gc.Equals, "50")
+}
+
+func (s *RunHookSuite) TestRunHookMetricSendingDisabled(c *gc.C) {
+	uuid, err := utils.NewUUID()
+	c.Assert(err, gc.IsNil)
+	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, false)
+	charmDir, _ := makeCharm(c, hookSpec{
+		name: "some-hook",
+		perm: 0700,
+	})
+
+	now := time.Now()
+	err = ctx.AddMetrics("key", "50", now)
+	c.Assert(err, gc.ErrorMatches, "metrics disabled")
+
+	// Run the hook.
+	err = ctx.RunHook("some-hook", charmDir, c.MkDir(), "/path/to/socket")
+	c.Assert(err, gc.IsNil)
+
+	metricBatches, err := s.State.MetricBatches()
+	c.Assert(err, gc.IsNil)
+	c.Assert(metricBatches, gc.HasLen, 0)
 }
 
 type ContextRelationSuite struct {
@@ -619,7 +641,7 @@ func (s *InterfaceSuite) GetContext(c *gc.C, relId int,
 	remoteName string) jujuc.Context {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	return s.HookContextSuite.getHookContext(c, uuid.String(), relId, remoteName, noProxies)
+	return s.HookContextSuite.getHookContext(c, uuid.String(), relId, remoteName, noProxies, false)
 }
 
 func (s *InterfaceSuite) TestUtils(c *gc.C) {
@@ -771,14 +793,14 @@ func (s *HookContextSuite) AddContextRelation(c *gc.C, name string) {
 }
 
 func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int,
-	remote string, proxies proxy.Settings) *uniter.HookContext {
+	remote string, proxies proxy.Settings, addMetrics bool) *uniter.HookContext {
 	if relid != -1 {
 		_, found := s.relctxs[relid]
 		c.Assert(found, jc.IsTrue)
 	}
 	context, err := uniter.NewHookContext(s.apiUnit, "TestCtx", uuid,
 		"test-env-name", relid, remote, s.relctxs, apiAddrs, "test-owner",
-		proxies, map[string]interface{}(nil))
+		proxies, map[string]interface{}(nil), addMetrics)
 	c.Assert(err, gc.IsNil)
 	return context
 }
@@ -805,14 +827,14 @@ type RunCommandSuite struct {
 
 var _ = gc.Suite(&RunCommandSuite{})
 
-func (s *RunCommandSuite) getHookContext(c *gc.C) *uniter.HookContext {
+func (s *RunCommandSuite) getHookContext(c *gc.C, addMetrics bool) *uniter.HookContext {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	return s.HookContextSuite.getHookContext(c, uuid.String(), -1, "", noProxies)
+	return s.HookContextSuite.getHookContext(c, uuid.String(), -1, "", noProxies, addMetrics)
 }
 
 func (s *RunCommandSuite) TestRunCommandsHasEnvironSet(c *gc.C) {
-	context := s.getHookContext(c)
+	context := s.getHookContext(c, false)
 	charmDir := c.MkDir()
 	result, err := context.RunCommands("env | sort", charmDir, "/path/to/tools", "/path/to/socket")
 	c.Assert(err, gc.IsNil)
@@ -839,7 +861,7 @@ func (s *RunCommandSuite) TestRunCommandsHasEnvironSet(c *gc.C) {
 }
 
 func (s *RunCommandSuite) TestRunCommandsStdOutAndErrAndRC(c *gc.C) {
-	context := s.getHookContext(c)
+	context := s.getHookContext(c, false)
 	charmDir := c.MkDir()
 	commands := `
 echo this is standard out

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -41,7 +41,7 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("%q hook requires a remote unit", hi.Kind)
 		}
 		fallthrough
-	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken:
+	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken, hooks.CollectMetrics:
 		return nil
 	case hooks.ActionRequested:
 		if !names.IsValidAction(hi.ActionId) {

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -40,6 +40,7 @@ var validateTests = []struct {
 	{hook.Info{Kind: hooks.Install}, ""},
 	{hook.Info{Kind: hooks.Start}, ""},
 	{hook.Info{Kind: hooks.ConfigChanged}, ""},
+	{hook.Info{Kind: hooks.CollectMetrics}, ""},
 	{
 		hook.Info{Kind: hooks.ActionRequested},
 		`action id "" cannot be parsed as an action tag`,

--- a/worker/uniter/jujuc/add-metric.go
+++ b/worker/uniter/jujuc/add-metric.go
@@ -5,6 +5,7 @@ package jujuc
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -66,6 +67,7 @@ func (c *AddMetricCommand) Run(ctx *cmd.Context) (err error) {
 	for _, metric := range c.Metrics {
 		err := c.ctx.AddMetrics(metric.Key, metric.Value, metric.Time)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "can't add metrics!")
 			return errors.Annotate(err, "cannot record metric")
 		}
 	}

--- a/worker/uniter/jujuc/add-metric_test.go
+++ b/worker/uniter/jujuc/add-metric_test.go
@@ -35,16 +35,18 @@ purpose: send metrics
 
 func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 	testCases := []struct {
-		about  string
-		cmd    []string
-		result int
-		stdout string
-		stderr string
-		expect []jujuc.Metric
+		about         string
+		cmd           []string
+		canAddMetrics bool
+		result        int
+		stdout        string
+		stderr        string
+		expect        []jujuc.Metric
 	}{
 		{
 			"add single metric",
 			[]string{"add-metric", "key=50"},
+			true,
 			0,
 			"",
 			"",
@@ -52,6 +54,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 		}, {
 			"no parameters error",
 			[]string{"add-metric"},
+			true,
 			2,
 			"",
 			"error: no metrics specified\n",
@@ -59,6 +62,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 		}, {
 			"invalid metric value",
 			[]string{"add-metric", "key=invalidvalue"},
+			true,
 			2,
 			"",
 			"error: invalid value type: expected float, got \"invalidvalue\"\n",
@@ -66,6 +70,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 		}, {
 			"invalid argument format",
 			[]string{"add-metric", "key"},
+			true,
 			2,
 			"",
 			"error: expected \"key=value\", got \"key\"\n",
@@ -73,6 +78,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 		}, {
 			"invalid argument format",
 			[]string{"add-metric", "=key"},
+			true,
 			2,
 			"",
 			"error: expected \"key=value\", got \"=key\"\n",
@@ -80,6 +86,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 		}, {
 			"multiple metrics",
 			[]string{"add-metric", "key=60", "key2=50.4"},
+			true,
 			0,
 			"",
 			"",
@@ -87,15 +94,24 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 		}, {
 			"multiple metrics, matching keys",
 			[]string{"add-metric", "key=60", "key=50.4"},
+			true,
 			0,
 			"",
 			"",
 			[]jujuc.Metric{{"key", "60", time.Now()}, {"key", "50.4", time.Now()}},
-		},
-	}
+		}, {
+			"can't add metrics",
+			[]string{"add-metric", "key=60", "key2=50.4"},
+			false,
+			1,
+			"",
+			"error: cannot record metric: metrics disabled\n",
+			nil,
+		}}
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
 		hctx := s.GetHookContext(c, -1, "")
+		hctx.canAddMetrics = t.canAddMetrics
 		com, err := jujuc.NewCommand(hctx, t.cmd[0])
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)

--- a/worker/uniter/jujuc/util_test.go
+++ b/worker/uniter/jujuc/util_test.go
@@ -81,15 +81,19 @@ func setSettings(c *gc.C, ru *state.RelationUnit, settings map[string]interface{
 }
 
 type Context struct {
-	actionParams map[string]interface{}
-	ports        set.Strings
-	relid        int
-	remote       string
-	rels         map[int]*ContextRelation
-	metrics      []jujuc.Metric
+	actionParams  map[string]interface{}
+	ports         set.Strings
+	relid         int
+	remote        string
+	rels          map[int]*ContextRelation
+	metrics       []jujuc.Metric
+	canAddMetrics bool
 }
 
 func (c *Context) AddMetrics(key, value string, created time.Time) error {
+	if !c.canAddMetrics {
+		return fmt.Errorf("metrics disabled")
+	}
 	c.metrics = append(c.metrics, jujuc.Metric{key, value, created})
 	return nil
 }


### PR DESCRIPTION
Now that the hook tool add-metrics has been introduced, its usage will be limited to the collect-metrics hook. At this point the hook is only defined, not actually executed.
