### PR TITLE
Add an owner to state.InitializeState.

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -87,7 +87,8 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	envCfg, err := config.New(config.NoDefaults, envAttrs)
 	c.Assert(err, gc.IsNil)
 
-	st, m, err := agent.InitializeState(cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
+	adminUser := names.NewLocalUserTag("agent-admin")
+	st, m, err := agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
 	c.Assert(err, gc.IsNil)
 	defer st.Close()
 
@@ -179,7 +180,8 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	_, available := cfg.StateServingInfo()
 	c.Assert(available, gc.Equals, false)
 
-	_, _, err = agent.InitializeState(cfg, nil, agent.BootstrapMachineConfig{}, mongo.DialOpts{}, environs.NewStatePolicy())
+	adminUser := names.NewLocalUserTag("agent-admin")
+	_, _, err = agent.InitializeState(adminUser, cfg, nil, agent.BootstrapMachineConfig{}, mongo.DialOpts{}, environs.NewStatePolicy())
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
 }
@@ -221,10 +223,12 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	envCfg, err := config.New(config.NoDefaults, envAttrs)
 	c.Assert(err, gc.IsNil)
 
-	st, _, err := agent.InitializeState(cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
+	adminUser := names.NewLocalUserTag("agent-admin")
+	st, _, err := agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
 	c.Assert(err, gc.IsNil)
+	st.Close()
 
-	st, _, err = agent.InitializeState(cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, _, err = agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
 	if err == nil {
 		st.Close()
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -192,7 +192,7 @@ func (s *clientSuite) TestShareEnvironmentRealAPIServer(c *gc.C) {
 	envUser, err := s.State.EnvironmentUser(user)
 	c.Assert(err, gc.IsNil)
 	c.Assert(envUser.UserName(), gc.Equals, user.Username())
-	c.Assert(envUser.CreatedBy(), gc.Equals, "admin@local")
+	c.Assert(envUser.CreatedBy(), gc.Equals, s.AdminUserTag(c).Username())
 	c.Assert(envUser.LastConnection(), gc.IsNil)
 }
 

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -74,7 +74,7 @@ func (s *usermanagerSuite) TestAddExistingUser(c *gc.C) {
 
 func (s *usermanagerSuite) TestCantRemoveAdminUser(c *gc.C) {
 	err := s.usermanager.RemoveUser(s.AdminUserTag(c).Name())
-	c.Assert(err, gc.ErrorMatches, "Failed to remove user: cannot deactivate admin user")
+	c.Assert(err, gc.ErrorMatches, "Failed to remove user: cannot deactivate initial environment owner")
 }
 
 func (s *usermanagerSuite) TestUserInfo(c *gc.C) {

--- a/apiserver/agent/agent_test.go
+++ b/apiserver/agent/agent_test.go
@@ -66,7 +66,7 @@ func (s *agentSuite) SetUpTest(c *gc.C) {
 
 func (s *agentSuite) TestAgentFailsWithNonAgent(c *gc.C) {
 	auth := s.authorizer
-	auth.Tag = names.NewUserTag("admin")
+	auth.Tag = names.NewLocalUserTag("admin")
 	api, err := agent.NewAPI(s.State, s.resources, auth)
 	c.Assert(err, gc.NotNil)
 	c.Assert(api, gc.IsNil)

--- a/apiserver/backups/backups_test.go
+++ b/apiserver/backups/backups_test.go
@@ -51,7 +51,7 @@ var _ = gc.Suite(&backupsSuite{})
 func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.resources = common.NewResources()
-	tag := names.NewUserTag("spam")
+	tag := names.NewLocalUserTag("spam")
 	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
 	var err error
 	s.api, err = backups.NewAPI(s.State, s.resources, s.authorizer)

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -31,6 +31,7 @@ import (
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/presence"
 	coretesting "github.com/juju/juju/testing"
@@ -58,7 +59,7 @@ func (s *serverSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	auth := testing.FakeAuthorizer{
-		Tag:            names.NewUserTag(state.AdminUser),
+		Tag:            s.AdminUserTag(c),
 		EnvironManager: true,
 	}
 	s.client, err = client.NewClient(s.State, common.NewResources(), auth)
@@ -111,7 +112,7 @@ func (s *serverSuite) TestEnsureAvailabilityDeprecated(c *gc.C) {
 func (s *serverSuite) TestShareEnvironmentAddMissingLocalFails(c *gc.C) {
 	args := params.ModifyEnvironUsers{
 		Changes: []params.ModifyEnvironUser{{
-			UserTag: names.NewUserTag("foobar").String(),
+			UserTag: names.NewLocalUserTag("foobar").String(),
 			Action:  params.AddEnvUser,
 		}}}
 
@@ -161,7 +162,7 @@ func (s *serverSuite) TestShareEnvironmentAddLocalUser(c *gc.C) {
 	envUser, err := s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, gc.IsNil)
 	c.Assert(envUser.UserName(), gc.Equals, user.UserTag().Username())
-	c.Assert(envUser.CreatedBy(), gc.Equals, "admin@local")
+	c.Assert(envUser.CreatedBy(), gc.Equals, dummy.AdminUserTag().Username())
 	c.Assert(envUser.LastConnection(), gc.IsNil)
 }
 
@@ -182,7 +183,7 @@ func (s *serverSuite) TestShareEnvironmentAddRemoteUser(c *gc.C) {
 	envUser, err := s.State.EnvironmentUser(user)
 	c.Assert(err, gc.IsNil)
 	c.Assert(envUser.UserName(), gc.Equals, user.Username())
-	c.Assert(envUser.CreatedBy(), gc.Equals, "admin@local")
+	c.Assert(envUser.CreatedBy(), gc.Equals, dummy.AdminUserTag().Username())
 	c.Assert(envUser.LastConnection(), gc.IsNil)
 }
 

--- a/apiserver/deployer/deployer_test.go
+++ b/apiserver/deployer/deployer_test.go
@@ -8,7 +8,6 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "launchpad.net/gocheck"
 
@@ -108,7 +107,7 @@ func (s *deployerSuite) SetUpTest(c *gc.C) {
 
 func (s *deployerSuite) TestDeployerFailsWithNonMachineAgentUser(c *gc.C) {
 	anAuthorizer := s.authorizer
-	anAuthorizer.Tag = names.NewUserTag("admin")
+	anAuthorizer.Tag = s.AdminUserTag(c)
 	aDeployer, err := deployer.NewDeployerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(err, gc.NotNil)
 	c.Assert(aDeployer, gc.IsNil)

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -6,7 +6,6 @@ package highavailability_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/names"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/apiserver/common"
@@ -54,7 +53,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.authoriser = apiservertesting.FakeAuthorizer{
-		Tag:            names.NewUserTag(state.AdminUser),
+		Tag:            s.AdminUserTag(c),
 		EnvironManager: true,
 	}
 

--- a/apiserver/logger/logger_test.go
+++ b/apiserver/logger/logger_test.go
@@ -50,7 +50,7 @@ func (s *loggerSuite) SetUpTest(c *gc.C) {
 func (s *loggerSuite) TestNewLoggerAPIRefusesNonAgent(c *gc.C) {
 	// We aren't even a machine agent
 	anAuthorizer := s.authorizer
-	anAuthorizer.Tag = names.NewUserTag("admin")
+	anAuthorizer.Tag = s.AdminUserTag(c)
 	endPoint, err := logger.NewLoggerAPI(s.State, s.resources, anAuthorizer)
 	c.Assert(endPoint, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -12,6 +12,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/apiserver/usermanager"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
 )
@@ -275,7 +276,7 @@ func (s *userManagerSuite) TestSetPassword(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0], gc.DeepEquals, params.ErrorResult{Error: nil})
 
-	adminUser, err := s.State.User(names.NewUserTag(s.adminName))
+	adminUser, err := s.State.User(s.AdminUserTag(c))
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(adminUser.PasswordValid("new-password"), gc.Equals, true)
@@ -308,7 +309,7 @@ func (s *userManagerSuite) TestSetMultiplePasswords(c *gc.C) {
 	c.Assert(results.Results[0], gc.DeepEquals, params.ErrorResult{Error: nil})
 	c.Assert(results.Results[1], gc.DeepEquals, params.ErrorResult{Error: nil})
 
-	adminUser, err := s.State.User(names.NewUserTag(s.adminName))
+	adminUser, err := s.State.User(s.AdminUserTag(c))
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(adminUser.PasswordValid("new-password2"), gc.Equals, true)
@@ -328,6 +329,7 @@ func (s *userManagerSuite) TestSetPasswordOnDifferentUser(c *gc.C) {
 	results, err := s.usermanager.SetPassword(args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
-	expectedError := apiservertesting.ServerError("can only change the password of the current user (admin@local)")
+	msg := "can only change the password of the current user (" + dummy.AdminUserTag().Username() + ")"
+	expectedError := apiservertesting.ServerError(msg)
 	c.Assert(results.Results[0], gc.DeepEquals, params.ErrorResult{Error: expectedError})
 }

--- a/cmd/juju/user_info_test.go
+++ b/cmd/juju/user_info_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/loggo"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/apiserver/common"
@@ -20,6 +21,7 @@ import (
 // This suite provides basic tests for the "user info" command
 type UserInfoCommandSuite struct {
 	jujutesting.JujuConnSuite
+	logger loggo.Logger
 }
 
 var (
@@ -33,8 +35,9 @@ var (
 func (s *UserInfoCommandSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.PatchValue(&getUserInfoAPI, func(*UserInfoCommand) (UserInfoAPI, error) {
-		return &fakeUserInfoAPI{}, nil
+		return &fakeUserInfoAPI{s}, nil
 	})
+	s.logger = loggo.GetLogger("juju.user-info-test")
 }
 
 func newUserInfoCommand() cmd.Command {
@@ -42,7 +45,7 @@ func newUserInfoCommand() cmd.Command {
 }
 
 type fakeUserInfoAPI struct {
-	UserInfoCommandSuite
+	*UserInfoCommandSuite
 }
 
 func (*fakeUserInfoAPI) Close() error {
@@ -50,13 +53,14 @@ func (*fakeUserInfoAPI) Close() error {
 }
 
 func (f *fakeUserInfoAPI) UserInfo(username string) (result usermanager.UserInfoResult, err error) {
+	f.logger.Infof("fakeUserInfoAPI.UserInfo(%q)", username)
 	info := usermanager.UserInfo{
 		DateCreated:    dateCreated,
 		LastConnection: &lastConnection,
 	}
 	switch username {
-	case "admin":
-		info.Username = "admin"
+	case "dummy-admin":
+		info.Username = "dummy-admin"
 	case "foobar":
 		info.Username = "foobar"
 		info.DisplayName = "Foo Bar"
@@ -70,7 +74,7 @@ func (f *fakeUserInfoAPI) UserInfo(username string) (result usermanager.UserInfo
 func (s *UserInfoCommandSuite) TestUserInfo(c *gc.C) {
 	context, err := testing.RunCommand(c, newUserInfoCommand())
 	c.Assert(err, gc.IsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `user-name: admin
+	c.Assert(testing.Stdout(context), gc.Equals, `user-name: dummy-admin
 display-name: ""
 date-created: `+dateCreated.String()+`
 last-connection: `+lastConnection.String()+"\n")
@@ -94,7 +98,7 @@ func (*UserInfoCommandSuite) TestUserInfoFormatJson(c *gc.C) {
 	context, err := testing.RunCommand(c, newUserInfoCommand(), "--format", "json")
 	c.Assert(err, gc.IsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, `
-{"user-name":"admin","display-name":"","date-created":"1981-02-27 16:10:05 +0000 UTC","last-connection":"2014-01-01 00:00:00 +0000 UTC"}
+{"user-name":"dummy-admin","display-name":"","date-created":"1981-02-27 16:10:05 +0000 UTC","last-connection":"2014-01-01 00:00:00 +0000 UTC"}
 `[1:])
 }
 
@@ -109,7 +113,7 @@ func (*UserInfoCommandSuite) TestUserInfoFormatJsonWithUsername(c *gc.C) {
 func (*UserInfoCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 	context, err := testing.RunCommand(c, newUserInfoCommand(), "--format", "yaml")
 	c.Assert(err, gc.IsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, `user-name: admin
+	c.Assert(testing.Stdout(context), gc.Equals, `user-name: dummy-admin
 display-name: ""
 date-created: `+dateCreated.String()+`
 last-connection: `+lastConnection.String()+"\n")

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -491,7 +491,7 @@ func (s *BootstrapSuite) TestBootstrapArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 	var called int
-	initializeState := func(_ agent.ConfigSetter, envCfg *config.Config, machineCfg agent.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
+	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, envCfg *config.Config, machineCfg agent.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, gc.Equals, true)
 		c.Assert(dialOpts.Timeout, gc.Equals, 30*time.Second)
@@ -508,7 +508,7 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 	var called int
-	initializeState := func(_ agent.ConfigSetter, envCfg *config.Config, machineCfg agent.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
+	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, envCfg *config.Config, machineCfg agent.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, gc.Equals, true)
 		c.Assert(dialOpts.SocketTimeout, gc.Equals, 1*time.Minute)

--- a/cmd/jujud/upgrade_test.go
+++ b/cmd/jujud/upgrade_test.go
@@ -449,7 +449,7 @@ func (s *UpgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 	c.Assert(waitForUpgradeToStart(upgradeCh), gc.Equals, true)
 
 	// Only user and local logins are allowed during upgrade. Users get a restricted API.
-	checkLoginToAPIAsUser(c, machine0Conf, RestrictedAPIExposed)
+	s.checkLoginToAPIAsUser(c, machine0Conf, RestrictedAPIExposed)
 	c.Assert(canLoginToAPIAsMachine(c, machine0Conf, machine0Conf), gc.Equals, true)
 	c.Assert(canLoginToAPIAsMachine(c, machine1Conf, machine0Conf), gc.Equals, false)
 
@@ -458,7 +458,7 @@ func (s *UpgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 	waitForUpgradeToFinish(c, machine0Conf)
 
 	// All logins are allowed after upgrade
-	checkLoginToAPIAsUser(c, machine0Conf, FullAPIExposed)
+	s.checkLoginToAPIAsUser(c, machine0Conf, FullAPIExposed)
 	c.Assert(canLoginToAPIAsMachine(c, machine0Conf, machine0Conf), gc.Equals, true)
 	c.Assert(canLoginToAPIAsMachine(c, machine1Conf, machine0Conf), gc.Equals, true)
 }
@@ -493,7 +493,7 @@ func (s *UpgradeSuite) TestUpgradeSkippedIfNoUpgradeRequired(c *gc.C) {
 
 	// Test that unrestricted API logins are possible (i.e. no
 	// "upgrade mode" in force)
-	checkLoginToAPIAsUser(c, agentConf, FullAPIExposed)
+	s.checkLoginToAPIAsUser(c, agentConf, FullAPIExposed)
 	c.Assert(attempts, gc.Equals, 0) // There should have been no attempt to upgrade.
 
 	// Even though no upgrade was done upgradedToVersion should have been updated.
@@ -780,9 +780,9 @@ func readConfigFromDisk(c *gc.C, dir string, tag names.Tag) agent.Config {
 	return conf
 }
 
-func checkLoginToAPIAsUser(c *gc.C, conf agent.Config, expectFullApi exposedAPI) {
+func (s *UpgradeSuite) checkLoginToAPIAsUser(c *gc.C, conf agent.Config, expectFullApi exposedAPI) {
 	info := conf.APIInfo()
-	info.Tag = names.NewUserTag("admin")
+	info.Tag = s.AdminUserTag(c)
 	info.Password = "dummy-secret"
 	info.Nonce = ""
 

--- a/environs/cloudinit_test.go
+++ b/environs/cloudinit_test.go
@@ -57,7 +57,7 @@ var cloudInitOutputLog = path.Join(logDir, "cloud-init-output.log")
 
 func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 
-	userTag := names.NewUserTag("not-touched")
+	userTag := names.NewLocalUserTag("not-touched")
 
 	expectedMcfg := &cloudinit.MachineConfig{
 		AuthorizedKeys: "we-are-the-keys",
@@ -102,7 +102,7 @@ func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 }
 
 func (s *CloudInitSuite) TestFinishMachineConfigNonDefault(c *gc.C) {
-	userTag := names.NewUserTag("not-touched")
+	userTag := names.NewLocalUserTag("not-touched")
 	attrs := dummySampleConfig().Merge(testing.Attrs{
 		"authorized-keys":           "we-are-the-keys",
 		"ssl-hostname-verification": false,

--- a/environs/configstore/interface.go
+++ b/environs/configstore/interface.go
@@ -7,6 +7,10 @@ import (
 	"errors"
 )
 
+// DefaultAdminUsername is used as the username to connect as in the
+// absense of any explicit username being defined in the config store.
+var DefaultAdminUsername = "admin"
+
 var ErrEnvironInfoAlreadyExists = errors.New("environment info already exists")
 
 // APIEndpoint holds information about an API endpoint.

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -395,8 +395,12 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	c.Logf("opening state")
 	st := t.Env.(testing.GetStater).GetStateInAPIServer()
 
+	env, err := st.Environment()
+	c.Assert(err, gc.IsNil)
+	owner := env.Owner()
+
 	c.Logf("opening API connection")
-	apiState, err := juju.NewAPIState(t.Env, api.DefaultDialOpts())
+	apiState, err := juju.NewAPIState(owner, t.Env, api.DefaultDialOpts())
 	c.Assert(err, gc.IsNil)
 	defer apiState.Close()
 
@@ -441,7 +445,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	url := charmtesting.Charms.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
 	sch, err := testing.PutCharm(st, url, &charm.LocalRepository{Path: repoDir}, false)
 	c.Assert(err, gc.IsNil)
-	svc, err := st.AddService("dummy", "user-admin", sch, nil)
+	svc, err := st.AddService("dummy", owner.String(), sch, nil)
 	c.Assert(err, gc.IsNil)
 	units, err := juju.AddUnits(st, svc, 1, "")
 	c.Assert(err, gc.IsNil)
@@ -547,7 +551,13 @@ func (t *LiveTests) TestCheckEnvironmentOnConnect(c *gc.C) {
 	}
 	t.BootstrapOnce(c)
 
-	apiState, err := juju.NewAPIState(t.Env, api.DefaultDialOpts())
+	c.Logf("opening state")
+	st := t.Env.(testing.GetStater).GetStateInAPIServer()
+	env, err := st.Environment()
+	c.Assert(err, gc.IsNil)
+	owner := env.Owner()
+
+	apiState, err := juju.NewAPIState(owner, t.Env, api.DefaultDialOpts())
 	c.Assert(err, gc.IsNil)
 	apiState.Close()
 }

--- a/environs/open.go
+++ b/environs/open.go
@@ -178,7 +178,6 @@ func Prepare(cfg *config.Config, ctx BootstrapContext, store configstore.Storage
 			}
 			return nil, err
 		}
-
 	} else if err != nil {
 		return nil, errors.Annotatef(err, "error reading environment info %q", cfg.Name())
 	} else if !info.Initialized() {
@@ -218,7 +217,7 @@ func decorateAndWriteInfo(info configstore.EnvironInfo, cfg *config.Config) erro
 	}
 
 	creds := configstore.APICredentials{
-		User:     "admin", // TODO(waigani) admin@local once we have that set
+		User:     configstore.DefaultAdminUsername,
 		Password: cfg.AdminSecret(),
 	}
 	info.SetAPICredentials(creds)

--- a/juju/api.go
+++ b/juju/api.go
@@ -48,8 +48,10 @@ type apiStateCachedInfo struct {
 var errAborted = fmt.Errorf("aborted")
 
 // NewAPIState creates an api.State object from an Environ
-func NewAPIState(environ environs.Environ, dialOpts api.DialOpts) (*api.State, error) {
-	info, err := environAPIInfo(environ)
+// This is almost certainly the wrong thing to do as it assumes
+// the old admin password (stored as admin-secret in the config).
+func NewAPIState(user names.UserTag, environ environs.Environ, dialOpts api.DialOpts) (*api.State, error) {
+	info, err := environAPIInfo(environ, user)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +165,7 @@ func newAPIFromStore(envName string, store configstore.Storage, apiOpen apiOpenF
 		if err != nil {
 			return nil, err
 		}
-		return apiConfigConnect(cfg, apiOpen, stop, delay)
+		return apiConfigConnect(cfg, apiOpen, stop, delay, environInfoUserTag(info))
 	})
 	try.Close()
 	val0, err := try.Result()
@@ -224,6 +226,14 @@ type infoConnectError struct {
 	error
 }
 
+func environInfoUserTag(info configstore.EnvironInfo) names.UserTag {
+	username := info.APICredentials().User
+	if username == "" {
+		username = configstore.DefaultAdminUsername
+	}
+	return names.NewUserTag(username)
+}
+
 // apiInfoConnect looks for endpoint on the given environment and
 // tries to connect to it, sending the result on the returned channel.
 func apiInfoConnect(store configstore.Storage, info configstore.EnvironInfo, apiOpen apiOpenFunc, stop <-chan struct{}) (apiState, error) {
@@ -238,14 +248,10 @@ func apiInfoConnect(store configstore.Storage, info configstore.EnvironInfo, api
 		// valid UUID.
 		environTag = names.NewEnvironTag(endpoint.EnvironUUID)
 	}
-	username := info.APICredentials().User
-	if username == "" {
-		username = "admin"
-	}
 	apiInfo := &api.Info{
 		Addrs:      endpoint.Addresses,
 		CACert:     endpoint.CACert,
-		Tag:        names.NewUserTag(username),
+		Tag:        environInfoUserTag(info),
 		Password:   info.APICredentials().Password,
 		EnvironTag: environTag,
 	}
@@ -261,7 +267,7 @@ func apiInfoConnect(store configstore.Storage, info configstore.EnvironInfo, api
 // its endpoint. It only starts the attempt after the given delay,
 // to allow the faster apiInfoConnect to hopefully succeed first.
 // It returns nil if there was no configuration information found.
-func apiConfigConnect(cfg *config.Config, apiOpen apiOpenFunc, stop <-chan struct{}, delay time.Duration) (apiState, error) {
+func apiConfigConnect(cfg *config.Config, apiOpen apiOpenFunc, stop <-chan struct{}, delay time.Duration, user names.UserTag) (apiState, error) {
 	select {
 	case <-time.After(delay):
 	case <-stop:
@@ -271,7 +277,7 @@ func apiConfigConnect(cfg *config.Config, apiOpen apiOpenFunc, stop <-chan struc
 	if err != nil {
 		return nil, err
 	}
-	apiInfo, err := environAPIInfo(environ)
+	apiInfo, err := environAPIInfo(environ, user)
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +308,7 @@ func getConfig(info configstore.EnvironInfo, envs *environs.Environs, envName st
 	return nil, errors.NotFoundf("environment %q", envName)
 }
 
-func environAPIInfo(environ environs.Environ) (*api.Info, error) {
+func environAPIInfo(environ environs.Environ, user names.UserTag) (*api.Info, error) {
 	config := environ.Config()
 	password := config.AdminSecret()
 	if password == "" {
@@ -312,7 +318,7 @@ func environAPIInfo(environ environs.Environ) (*api.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	info.Tag = names.NewUserTag("admin")
+	info.Tag = user
 	info.Password = password
 	return info, nil
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -90,6 +90,7 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	s.PatchValue(&configstore.DefaultAdminUsername, dummy.AdminUserTag().Name())
 	s.setUpConn(c)
 	s.Factory = factory.NewFactory(s.State)
 }
@@ -109,7 +110,9 @@ func (s *JujuConnSuite) Reset(c *gc.C) {
 }
 
 func (s *JujuConnSuite) AdminUserTag(c *gc.C) names.UserTag {
-	return names.NewLocalUserTag(state.AdminUser)
+	env, err := s.State.InitialEnvironment()
+	c.Assert(err, gc.IsNil)
+	return env.Owner()
 }
 
 func (s *JujuConnSuite) MongoInfo(c *gc.C) *mongo.MongoInfo {
@@ -242,7 +245,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.State, err = newState(environ, s.BackingState.MongoConnectionInfo())
 	c.Assert(err, gc.IsNil)
 
-	s.APIState, err = juju.NewAPIState(environ, api.DialOpts{})
+	s.APIState, err = juju.NewAPIState(s.AdminUserTag(c), environ, api.DialOpts{})
 	c.Assert(err, gc.IsNil)
 
 	err = s.State.SetAPIHostPorts(s.APIState.APIHostPorts())

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -92,13 +92,13 @@ func SampleConfig() testing.Attrs {
 	}
 }
 
-// AdminUser returns the name used to bootstrap the dummy environment. The
-// dummy bootstrapping is handled slightly differently, and the user is
+// AdminUserTag returns the user tag used to bootstrap the dummy environment.
+// The dummy bootstrapping is handled slightly differently, and the user is
 // created as part of the bootstrap process.  This method is used to provide
 // tests a way to get to the user name that was used to initialise the
 // database, and as such, is the owner of the initial environment.
 func AdminUserTag() names.UserTag {
-	return names.NewLocalUserTag("admin")
+	return names.NewLocalUserTag("dummy-admin")
 }
 
 // stateInfo returns a *state.Info which allows clients to connect to the
@@ -684,7 +684,13 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 		// so that we can call it here.
 
 		info := stateInfo(estate.preferIPv6)
-		st, err := state.Initialize(info, cfg, mongo.DefaultDialOpts(), estate.statePolicy)
+		// Since the admin user isn't setup until after here,
+		// the password in the info structure is empty, so the admin
+		// user is constructed with an empty password here.
+		// It is set just below.
+		st, err := state.Initialize(
+			AdminUserTag(), info, cfg,
+			mongo.DefaultDialOpts(), estate.statePolicy)
 		if err != nil {
 			panic(err)
 		}

--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
 	"gopkg.in/mgo.v2/bson"
@@ -39,7 +40,8 @@ func (s *compatSuite) TearDownSuite(c *gc.C) {
 func (s *compatSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
-	st, err := Initialize(TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), nil)
+	owner := names.NewLocalUserTag("test-admin")
+	st, err := Initialize(owner, TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), nil)
 	c.Assert(err, gc.IsNil)
 	s.state = st
 	env, err := s.state.Environment()

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -58,8 +58,8 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	cs.MgoSuite.SetUpTest(c)
 	cs.policy = statetesting.MockPolicy{}
 	cfg := testing.EnvironConfig(c)
-	cs.owner = names.NewLocalUserTag("admin")
-	cs.State = TestingInitialize(c, cfg, &cs.policy)
+	cs.owner = names.NewLocalUserTag("test-admin")
+	cs.State = TestingInitialize(c, cs.owner, cfg, &cs.policy)
 	uuid, ok := cfg.UUID()
 	c.Assert(ok, jc.IsTrue)
 	cs.envTag = names.NewEnvironTag(uuid)

--- a/state/envuser_test.go
+++ b/state/envuser_test.go
@@ -49,13 +49,13 @@ func (s *EnvUserSuite) TestAddEnvironmentUser(c *gc.C) {
 
 func (s *EnvUserSuite) TestAddEnvironmentNoUserFails(c *gc.C) {
 	createdBy := s.factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	_, err := s.State.AddEnvironmentUser(names.NewUserTag("validusername"), createdBy.UserTag())
+	_, err := s.State.AddEnvironmentUser(names.NewLocalUserTag("validusername"), createdBy.UserTag())
 	c.Assert(err, gc.ErrorMatches, `user "validusername" does not exist locally: user "validusername" not found`)
 }
 
 func (s *EnvUserSuite) TestAddEnvironmentNoCreatedByUserFails(c *gc.C) {
 	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
-	_, err := s.State.AddEnvironmentUser(user.UserTag(), names.NewUserTag("createdby"))
+	_, err := s.State.AddEnvironmentUser(user.UserTag(), names.NewLocalUserTag("createdby"))
 	c.Assert(err, gc.ErrorMatches, `createdBy user "createdby" does not exist locally: user "createdby" not found`)
 }
 

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -50,12 +50,10 @@ func (s *storeManagerStateSuite) TearDownSuite(c *gc.C) {
 func (s *storeManagerStateSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
-	st, err := Initialize(TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), nil)
+	s.owner = names.NewLocalUserTag("test-admin")
+	st, err := Initialize(s.owner, TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), nil)
 	c.Assert(err, gc.IsNil)
 	s.State = st
-	env, err := st.Environment()
-	c.Assert(err, gc.IsNil)
-	s.owner = env.Owner()
 }
 
 func (s *storeManagerStateSuite) TearDownTest(c *gc.C) {

--- a/state/open.go
+++ b/state/open.go
@@ -62,7 +62,7 @@ func open(info *mongo.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, er
 // Initialize sets up an initial empty state and returns it.
 // This needs to be performed only once for a given environment.
 // It returns unauthorizedError if access is unauthorized.
-func Initialize(info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (rst *State, err error) {
+func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (rst *State, err error) {
 	st, err := open(info, opts, policy)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -80,7 +80,6 @@ func Initialize(info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, 
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
-	owner := names.NewLocalUserTag("admin")
 	logger.Infof("initializing environment, owner: %q", owner.Username())
 	logger.Infof("info: %#v", info)
 	if err := checkEnvironConfig(cfg); err != nil {

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/mgo.v2/txn"
@@ -57,7 +58,8 @@ func (s *SettingsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	// TODO(dfc) this logic is duplicated with the metawatcher_test.
 	cfg := testing.EnvironConfig(c)
-	state, err := Initialize(TestingMongoInfo(), cfg, TestingDialOpts(), Policy(nil))
+	owner := names.NewLocalUserTag("settings-admin")
+	state, err := Initialize(owner, TestingMongoInfo(), cfg, TestingDialOpts(), Policy(nil))
 	c.Assert(err, gc.IsNil)
 	s.AddCleanup(func(*gc.C) { state.Close() })
 	s.state = state

--- a/state/state.go
+++ b/state/state.go
@@ -77,9 +77,6 @@ const (
 	txnLogC = "txns.log"
 	txnsC   = "txns"
 
-	// AdminUser is the mongo admin username.
-	AdminUser = "admin"
-
 	// blobstoreDB is the name of the blobstore GridFS database.
 	blobstoreDB = "blobstore"
 )

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -53,11 +53,11 @@ func preventUnitDestroyRemove(c *gc.C, u *state.Unit) {
 // TestingInitialize initializes the state and returns it. If state was not
 // already initialized, and cfg is nil, the minimal default environment
 // configuration will be used.
-func TestingInitialize(c *gc.C, cfg *config.Config, policy state.Policy) *state.State {
+func TestingInitialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.Policy) *state.State {
 	if cfg == nil {
 		cfg = testing.EnvironConfig(c)
 	}
-	st, err := state.Initialize(state.TestingMongoInfo(), cfg, state.TestingDialOpts(), policy)
+	st, err := state.Initialize(owner, state.TestingMongoInfo(), cfg, state.TestingDialOpts(), policy)
 	c.Assert(err, gc.IsNil)
 	return st
 }
@@ -3677,7 +3677,8 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 		},
 	}
 	cfg := testing.EnvironConfig(c)
-	st, err := state.Initialize(mongoInfo, cfg, state.TestingDialOpts(), nil)
+	owner := names.NewLocalUserTag("initialize-admin")
+	st, err := state.Initialize(owner, mongoInfo, cfg, state.TestingDialOpts(), nil)
 	c.Assert(err, gc.IsNil)
 	defer st.Close()
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -23,6 +23,7 @@ type upgradesSuite struct {
 	testing.BaseSuite
 	gitjujutesting.MgoSuite
 	state *State
+	owner names.UserTag
 }
 
 func (s *upgradesSuite) SetUpSuite(c *gc.C) {
@@ -39,12 +40,15 @@ func (s *upgradesSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
 	var err error
-	s.state, err = Initialize(TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), Policy(nil))
+	s.owner = names.NewLocalUserTag("upgrade-admin")
+	s.state, err = Initialize(s.owner, TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), Policy(nil))
 	c.Assert(err, gc.IsNil)
 }
 
 func (s *upgradesSuite) TearDownTest(c *gc.C) {
-	s.state.Close()
+	if s.state != nil {
+		s.state.Close()
+	}
 	s.MgoSuite.TearDownTest(c)
 	s.BaseSuite.TearDownTest(c)
 }
@@ -96,7 +100,6 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 func (s *upgradesSuite) TestAddStateUsersToEnviron(c *gc.C) {
 	stateBob, err := s.state.AddUser("bob", "notused", "notused", "bob")
 	c.Assert(err, gc.IsNil)
-	adminTag := names.NewUserTag("admin")
 	bobTag := stateBob.UserTag()
 
 	_, err = s.state.EnvironmentUser(bobTag)
@@ -105,9 +108,9 @@ func (s *upgradesSuite) TestAddStateUsersToEnviron(c *gc.C) {
 	err = AddStateUsersAsEnvironUsers(s.state)
 	c.Assert(err, gc.IsNil)
 
-	admin, err := s.state.EnvironmentUser(adminTag)
+	admin, err := s.state.EnvironmentUser(s.owner)
 	c.Assert(err, gc.IsNil)
-	c.Assert(admin.UserTag().Username(), gc.DeepEquals, adminTag.Username())
+	c.Assert(admin.UserTag().Username(), gc.DeepEquals, s.owner.Username())
 	bob, err := s.state.EnvironmentUser(bobTag)
 	c.Assert(err, gc.IsNil)
 	c.Assert(bob.UserTag().Username(), gc.DeepEquals, bobTag.Username())
@@ -116,7 +119,6 @@ func (s *upgradesSuite) TestAddStateUsersToEnviron(c *gc.C) {
 func (s *upgradesSuite) TestAddStateUsersToEnvironIdempotent(c *gc.C) {
 	stateBob, err := s.state.AddUser("bob", "notused", "notused", "bob")
 	c.Assert(err, gc.IsNil)
-	adminTag := names.NewUserTag("admin")
 	bobTag := stateBob.UserTag()
 
 	err = AddStateUsersAsEnvironUsers(s.state)
@@ -125,8 +127,8 @@ func (s *upgradesSuite) TestAddStateUsersToEnvironIdempotent(c *gc.C) {
 	err = AddStateUsersAsEnvironUsers(s.state)
 	c.Assert(err, gc.IsNil)
 
-	admin, err := s.state.EnvironmentUser(adminTag)
-	c.Assert(admin.UserTag().Username(), gc.DeepEquals, adminTag.Username())
+	admin, err := s.state.EnvironmentUser(s.owner)
+	c.Assert(admin.UserTag().Username(), gc.DeepEquals, s.owner.Username())
 	bob, err := s.state.EnvironmentUser(bobTag)
 	c.Assert(err, gc.IsNil)
 	c.Assert(bob.UserTag().Username(), gc.DeepEquals, bobTag.Username())

--- a/state/user.go
+++ b/state/user.go
@@ -270,8 +270,12 @@ func (u *User) Refresh() error {
 
 // Deactivate deactivates the user.  Deactivated identities cannot log in.
 func (u *User) Deactivate() error {
-	if u.doc.Name == AdminUser {
-		return errors.Unauthorizedf("cannot deactivate admin user")
+	initialEnv, err := u.st.InitialEnvironment()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if u.doc.Name == initialEnv.Owner().Name() {
+		return errors.Unauthorizedf("cannot deactivate initial environment owner")
 	}
 	return errors.Annotatef(u.setDeactivated(true), "cannot deactivate user %q", u.Name())
 }

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -197,5 +197,5 @@ func (s *UserSuite) TestCantDeactivateAdmin(c *gc.C) {
 	user, err := s.State.User(s.owner)
 	c.Assert(err, gc.IsNil)
 	err = user.Deactivate()
-	c.Assert(err, gc.ErrorMatches, "cannot deactivate admin user")
+	c.Assert(err, gc.ErrorMatches, "cannot deactivate initial environment owner")
 }

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -56,7 +57,8 @@ func (s *factorySuite) SetUpTest(c *gc.C) {
 		Timeout: testing.LongWait,
 	}
 	cfg := testing.EnvironConfig(c)
-	st, err := state.Initialize(info, cfg, opts, &policy)
+	owner := names.NewLocalUserTag("factory-admin")
+	st, err := state.Initialize(owner, info, cfg, opts, &policy)
 	c.Assert(err, gc.IsNil)
 	s.State = st
 	s.Factory = factory.NewFactory(s.State)


### PR DESCRIPTION
Instead of the owner being "admin", it is now whatever
gets passed in.  All existing tests now use a non-admin user
name.  The jujud bootstrap command now takes a name to use
as a command line arg, but it defaults to "admin", which is the
existing behaviour.  A follow-up branch will change the client
side bootstrap command to use the currently logged in user.
