### PR TITLE
Fix .reviewboardrc

### DIFF
--- a/.reviewboardrc
+++ b/.reviewboardrc
@@ -1,3 +1,4 @@
 REVIEWBOARD_URL = "https://reviews.vapour.ws/"
 REPOSITORY = "juju (core)"
 BRANCH = "master"
+TRACKING_BRANCH = "upstream/master"


### PR DESCRIPTION
Add TRACKING_BRANCH to .reviewboardrc.

In CONTRIBUTING.md we recommend that "origin" be set to your github clone.  We also recommend configuring a remote repo called "upstream" that points to the official juju repo.  However, this complicates interaction with ReviewBoard since it only knows about the official repo (to which .reviewboardrc is already pointing).  So when using "rbt push" this disconnect often results in review requests with incorrect diffs.

The TRACKING_BRANCH setting corrects this.  Without this patch people have to add it to ~/.reviewboardrc or use an extra option to rbt.  However, since we expect that everyone will have their "remotes" set as described above, setting this in the repo's .reviewboardrc will benefit everyone.
