### PR TITLE
cmd/jujud: upgrade mode end fix

### DIFF
--- a/cmd/jujud/upgrade.go
+++ b/cmd/jujud/upgrade.go
@@ -144,6 +144,7 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 	c.toVersion = version.Current.Number
 	if c.fromVersion == c.toVersion {
 		logger.Infof("upgrade to %v already completed.", c.toVersion)
+		close(c.UpgradeComplete)
 		return nil
 	}
 

--- a/cmd/jujud/upgrade_test.go
+++ b/cmd/jujud/upgrade_test.go
@@ -166,6 +166,19 @@ func (s *UpgradeSuite) TestIsUpgradeRunning(c *gc.C) {
 	c.Assert(context.IsUpgradeRunning(), jc.IsFalse)
 }
 
+func (s *UpgradeSuite) TestNoUpgradeNecessary(c *gc.C) {
+	attemptsP := s.countUpgradeAttempts(nil)
+	s.captureLogs(c)
+	s.oldVersion = version.Current // nothing to do
+
+	workerErr, config, _, context := s.runUpgradeWorker(c, params.JobHostUnits)
+
+	c.Check(workerErr, gc.IsNil)
+	c.Check(*attemptsP, gc.Equals, 0)
+	c.Check(config.Version, gc.Equals, version.Current.Number)
+	assertUpgradeComplete(c, context)
+}
+
 func (s *UpgradeSuite) TestUpgradeStepsFailure(c *gc.C) {
 	// This test checks what happens when every upgrade attempt fails.
 	// A number of retries should be observed and the agent should end


### PR DESCRIPTION
Fixed a case where upgrade mode wasn't being stopped when it should. This is actually almost impossible to hit in practice but good to fix anyway. 

Added a unit test to cover this case.

http://reviews.vapour.ws/r/48/diff
