### PR TITLE
Merge pull request #745 from wallyworld/tools-simplestreams-v2

### DIFF
--- a/environs/imagemetadata/export_test.go
+++ b/environs/imagemetadata/export_test.go
@@ -3,6 +3,8 @@
 
 package imagemetadata
 
+var CurrentStreamsVersion = currentStreamsVersion
+
 // SetSigningPublicKey sets a new public key for testing and returns the original key.
 func SetSigningPublicKey(key string) string {
 	oldKey := simplestreamsImagesPublicKey

--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -38,8 +38,7 @@ func readMetadata(metadataStore storage.Storage) ([]*ImageMetadata, error) {
 	// Read any existing metadata so we can merge the new tools metadata with what's there.
 	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", metadataStore, storage.BaseImagesPath)
 	imageConstraint := NewImageConstraint(simplestreams.LookupParams{})
-	existingMetadata, _, err := Fetch(
-		[]simplestreams.DataSource{dataSource}, simplestreams.DefaultIndexPath, imageConstraint, false)
+	existingMetadata, _, err := Fetch([]simplestreams.DataSource{dataSource}, imageConstraint, false)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}
@@ -99,7 +98,7 @@ func writeMetadata(metadata []*ImageMetadata, cloudSpec []simplestreams.CloudSpe
 		return err
 	}
 	metadataInfo := []MetadataFile{
-		{simplestreams.UnsignedIndex, index},
+		{simplestreams.UnsignedIndex(currentStreamsVersion), index},
 		{ProductMetadataPath, products},
 	}
 	for _, md := range metadataInfo {

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -27,8 +27,7 @@ func assertFetch(c *gc.C, stor storage.Storage, series, arch, region, endpoint, 
 		Arches:    []string{arch},
 	})
 	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images")
-	metadata, _, err := imagemetadata.Fetch(
-		[]simplestreams.DataSource{dataSource}, simplestreams.DefaultIndexPath, cons, false)
+	metadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, cons, false)
 	c.Assert(err, gc.IsNil)
 	c.Assert(metadata, gc.HasLen, 1)
 	c.Assert(metadata[0].Id, gc.Equals, id)

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -20,8 +20,14 @@ func init() {
 }
 
 const (
+	// ImageIds is the simplestreams image content type.
 	ImageIds = "image-ids"
+
+	// StreamsVersionV1 is used to construct the path for accessing streams data.
+	StreamsVersionV1 = "v1"
 )
+
+var currentStreamsVersion = StreamsVersionV1
 
 // simplestreamsImagesPublicKey is the public key required to
 // authenticate the simple streams data on http://cloud-images.ubuntu.com.
@@ -168,7 +174,7 @@ func (im *ImageMetadata) productId() string {
 // Signed data is preferred, but if there is no signed data available and onlySigned is false,
 // then unsigned data is used.
 func Fetch(
-	sources []simplestreams.DataSource, indexPath string, cons *ImageConstraint,
+	sources []simplestreams.DataSource, cons *ImageConstraint,
 	onlySigned bool) ([]*ImageMetadata, *simplestreams.ResolveInfo, error) {
 	params := simplestreams.ValueParams{
 		DataType:      ImageIds,
@@ -176,7 +182,7 @@ func Fetch(
 		ValueTemplate: ImageMetadata{},
 		PublicKey:     simplestreamsImagesPublicKey,
 	}
-	items, resolveInfo, err := simplestreams.GetMetadata(sources, indexPath, cons, onlySigned, params)
+	items, resolveInfo, err := simplestreams.GetMetadata(sources, currentStreamsVersion, cons, onlySigned, params)
 	if err != nil {
 		return nil, resolveInfo, err
 	}

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -39,7 +39,7 @@ var liveUrls = map[string]liveTestData{
 	"canonistack": {
 		baseURL:        "https://swift.canonistack.canonical.com/v1/AUTH_a48765cc0e864be980ee21ae26aaaed4/simplestreams/data",
 		requireSigned:  false,
-		validCloudSpec: simplestreams.CloudSpec{"lcy01", "https://keystone.canonistack.canonical.com:443/v2.0/"},
+		validCloudSpec: simplestreams.CloudSpec{"lcy01", "https://keystone.canonistack.canonical.com:443/v1.0/"},
 	},
 }
 
@@ -69,8 +69,9 @@ func registerSimpleStreamsTests() {
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
 			Source: simplestreams.NewURLDataSource(
 				"test roundtripper", "test:", utils.VerifySSLHostnames),
-			RequireSigned: false,
-			DataType:      imagemetadata.ImageIds,
+			RequireSigned:  false,
+			DataType:       imagemetadata.ImageIds,
+			StreamsVersion: imagemetadata.CurrentStreamsVersion,
 			ValidConstraint: imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 				CloudSpec: simplestreams.CloudSpec{
 					Region:   "us-east-1",
@@ -270,8 +271,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 		// Add invalid datasource and check later that resolveInfo is correct.
 		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames)
 		images, resolveInfo, err := imagemetadata.Fetch(
-			[]simplestreams.DataSource{invalidSource, s.Source}, simplestreams.DefaultIndexPath,
-			imageConstraint, s.RequireSigned)
+			[]simplestreams.DataSource{invalidSource, s.Source}, imageConstraint, s.RequireSigned)
 		if !c.Check(err, gc.IsNil) {
 			continue
 		}
@@ -382,8 +382,7 @@ func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
 		Series:    []string{"precise"},
 		Arches:    []string{"amd64"},
 	})
-	images, resolveInfo, err := imagemetadata.Fetch(
-		[]simplestreams.DataSource{signedSource}, simplestreams.DefaultIndexPath, imageConstraint, true)
+	images, resolveInfo, err := imagemetadata.Fetch([]simplestreams.DataSource{signedSource}, imageConstraint, true)
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(images), gc.Equals, 1)
 	c.Assert(images[0].Id, gc.Equals, "ami-123456")
@@ -403,8 +402,7 @@ func (s *signedSuite) TestSignedImageMetadataInvalidSignature(c *gc.C) {
 		Arches:    []string{"amd64"},
 	})
 	imagemetadata.SetSigningPublicKey(s.origKey)
-	_, _, err := imagemetadata.Fetch(
-		[]simplestreams.DataSource{signedSource}, simplestreams.DefaultIndexPath, imageConstraint, true)
+	_, _, err := imagemetadata.Fetch([]simplestreams.DataSource{signedSource}, imageConstraint, true)
 	c.Assert(err, gc.ErrorMatches, "cannot read index data.*")
 }
 

--- a/environs/imagemetadata/testing/testing.go
+++ b/environs/imagemetadata/testing/testing.go
@@ -35,9 +35,10 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader) []*imagemetad
 		ValueTemplate: imagemetadata.ImageMetadata{},
 	}
 	const requireSigned = false
-	indexPath := simplestreams.UnsignedIndex
+	indexPath := simplestreams.UnsignedIndex("v1")
+	mirrorsPath := simplestreams.MirrorsPath("v1")
 	indexRef, err := simplestreams.GetIndexWithFormat(
-		source, indexPath, "index:1.0", requireSigned, simplestreams.CloudSpec{}, params)
+		source, indexPath, "index:1.0", mirrorsPath, requireSigned, simplestreams.CloudSpec{}, params)
 	c.Assert(err, gc.IsNil)
 	c.Assert(indexRef.Indexes, gc.HasLen, 1)
 

--- a/environs/imagemetadata/upload.go
+++ b/environs/imagemetadata/upload.go
@@ -24,7 +24,7 @@ func UploadImageMetadata(stor storage.Storage, sourceDir string) error {
 	if sourceDir == "" {
 		return nil
 	}
-	metadataDir := path.Join(sourceDir, storage.BaseImagesPath, simplestreams.StreamsDir)
+	metadataDir := path.Join(sourceDir, storage.BaseImagesPath, simplestreams.StreamsDir(currentStreamsVersion))
 	info, err := os.Stat(metadataDir)
 	if err != nil {
 		return err
@@ -57,6 +57,6 @@ func uploadMetadataFile(stor storage.Storage, metadataDir, fileName string, size
 		return err
 	}
 	defer f.Close()
-	destMetadataDir := path.Join(storage.BaseImagesPath, simplestreams.StreamsDir)
+	destMetadataDir := path.Join(storage.BaseImagesPath, simplestreams.StreamsDir(currentStreamsVersion))
 	return stor.Put(path.Join(destMetadataDir, fileName), f, size)
 }

--- a/environs/imagemetadata/upload_test.go
+++ b/environs/imagemetadata/upload_test.go
@@ -80,7 +80,8 @@ func (s *uploadSuite) TestUploadIgnoresNonJsonFiles(c *gc.C) {
 	sourceDir, destDir, destStor, _ := createImageMetadata(c)
 
 	// Add an extra file.
-	sourceMetadataPath := filepath.Join(sourceDir, storage.BaseImagesPath, simplestreams.StreamsDir)
+	sourceMetadataPath := filepath.Join(
+		sourceDir, storage.BaseImagesPath, simplestreams.StreamsDir(imagemetadata.CurrentStreamsVersion))
 	err := ioutil.WriteFile(filepath.Join(sourceMetadataPath, "foo.txt"), []byte("hello"), 0644)
 	c.Assert(err, gc.IsNil)
 
@@ -89,7 +90,8 @@ func (s *uploadSuite) TestUploadIgnoresNonJsonFiles(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Check only json files are uploaded.
-	destMetadataPath := filepath.Join(destDir, storage.BaseImagesPath, simplestreams.StreamsDir)
+	destMetadataPath := filepath.Join(
+		destDir, storage.BaseImagesPath, simplestreams.StreamsDir(imagemetadata.CurrentStreamsVersion))
 	files, err := ioutil.ReadDir(destMetadataPath)
 	c.Assert(err, gc.IsNil)
 	c.Assert(files, gc.HasLen, 2)

--- a/environs/imagemetadata/validation.go
+++ b/environs/imagemetadata/validation.go
@@ -36,7 +36,7 @@ func ValidateImageMetadata(params *simplestreams.MetadataLookupParams) ([]string
 		Arches: params.Architectures,
 		Stream: params.Stream,
 	})
-	matchingImages, resolveInfo, err := Fetch(params.Sources, simplestreams.DefaultIndexPath, imageConstraint, false)
+	matchingImages, resolveInfo, err := Fetch(params.Sources, imageConstraint, false)
 	if err != nil {
 		return nil, resolveInfo, err
 	}

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -26,9 +26,10 @@ func Test(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-			Source:        simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames),
-			RequireSigned: false,
-			DataType:      "image-ids",
+			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames),
+			RequireSigned:  false,
+			DataType:       "image-ids",
+			StreamsVersion: "v1",
 			ValidConstraint: sstesting.NewTestConstraint(simplestreams.LookupParams{
 				CloudSpec: simplestreams.CloudSpec{
 					Region:   "us-east-1",
@@ -331,7 +332,7 @@ func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 
 	items, resolveInfo, err := simplestreams.GetMetadata(
 		sources,
-		simplestreams.DefaultIndexPath,
+		s.StreamsVersion,
 		constraint,
 		false,
 		params,
@@ -449,7 +450,8 @@ func (s *simplestreamsSuite) TestGetMirrorMetadata(c *gc.C) {
 			MirrorContentId: "com.ubuntu.juju:released:tools",
 		}
 		indexRef, err := simplestreams.GetIndexWithFormat(
-			s.Source, s.IndexPath(), sstesting.Index_v1, s.RequireSigned, cloud, params)
+			s.Source, simplestreams.UnsignedIndex("v1"), sstesting.Index_v1,
+			simplestreams.MirrorsPath("v1"), s.RequireSigned, cloud, params)
 		if !c.Check(err, gc.IsNil) {
 			continue
 		}

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -529,6 +529,7 @@ type LocalLiveSimplestreamsSuite struct {
 	testing.BaseSuite
 	Source          simplestreams.DataSource
 	RequireSigned   bool
+	StreamsVersion  string
 	DataType        string
 	ValidConstraint simplestreams.LookupConstraint
 }
@@ -584,9 +585,9 @@ type TestItem struct {
 
 func (s *LocalLiveSimplestreamsSuite) IndexPath() string {
 	if s.RequireSigned {
-		return simplestreams.DefaultIndexPath + ".sjson"
+		return simplestreams.SignedIndex(s.StreamsVersion) + ".sjson"
 	}
-	return simplestreams.UnsignedIndex
+	return simplestreams.UnsignedIndex(s.StreamsVersion)
 }
 
 func (s *LocalLiveSimplestreamsSuite) TestGetIndex(c *gc.C) {
@@ -603,7 +604,8 @@ func (s *LocalLiveSimplestreamsSuite) GetIndexRef(format string) (*simplestreams
 		ValueTemplate: TestItem{},
 	}
 	return simplestreams.GetIndexWithFormat(
-		s.Source, s.IndexPath(), format, s.RequireSigned, s.ValidConstraint.Params().CloudSpec, params)
+		s.Source, s.IndexPath(), format, simplestreams.MirrorsPath(s.StreamsVersion), s.RequireSigned,
+		s.ValidConstraint.Params().CloudSpec, params)
 }
 
 func (s *LocalLiveSimplestreamsSuite) TestGetIndexWrongFormat(c *gc.C) {

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -240,7 +240,7 @@ func assertToolsList(c *gc.C, list coretools.List, expected []version.Binary) {
 }
 
 func assertMirrors(c *gc.C, stor storage.StorageReader, expectMirrors bool) {
-	r, err := storage.Get(stor, "tools/"+simplestreams.UnsignedMirror)
+	r, err := storage.Get(stor, "tools/"+simplestreams.UnsignedMirror("v1"))
 	if err == nil {
 		defer r.Close()
 	}

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -69,7 +69,7 @@ func (s *ToolsFixture) UploadFakeTools(c *gc.C, stor storage.Storage) {
 
 // RemoveFakeToolsMetadata deletes the fake simplestreams tools metadata from the supplied storage.
 func RemoveFakeToolsMetadata(c *gc.C, stor storage.Storage) {
-	files := []string{simplestreams.UnsignedIndex, envtools.ProductMetadataPath}
+	files := []string{simplestreams.UnsignedIndex("v1"), envtools.ProductMetadataPath}
 	for _, file := range files {
 		toolspath := path.Join("tools", file)
 		err := stor.Remove(toolspath)

--- a/environs/tools/export_test.go
+++ b/environs/tools/export_test.go
@@ -3,11 +3,12 @@
 
 package tools
 
-var Setenv = setenv
-
-var FindExecutable = findExecutable
-
-var CheckToolsSeries = checkToolsSeries
+var (
+	Setenv                = setenv
+	FindExecutable        = findExecutable
+	CheckToolsSeries      = checkToolsSeries
+	CurrentStreamsVersion = currentStreamsVersion
+)
 
 // SetSigningPublicKey sets a new public key for testing and returns the original key.
 func SetSigningPublicKey(key string) string {

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -47,7 +47,7 @@ var liveUrls = map[string]liveTestData{
 	"canonistack": {
 		baseURL:        "https://swift.canonistack.canonical.com/v1/AUTH_526ad877f3e3464589dc1145dfeaac60/juju-tools",
 		requireSigned:  false,
-		validCloudSpec: simplestreams.CloudSpec{"lcy01", "https://keystone.canonistack.canonical.com:443/v2.0/"},
+		validCloudSpec: simplestreams.CloudSpec{"lcy01", "https://keystone.canonistack.canonical.com:443/v1.0/"},
 	},
 }
 
@@ -75,9 +75,10 @@ func setupSimpleStreamsTests(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-			Source:        simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames),
-			RequireSigned: false,
-			DataType:      tools.ContentDownload,
+			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames),
+			RequireSigned:  false,
+			DataType:       tools.ContentDownload,
+			StreamsVersion: tools.CurrentStreamsVersion,
 			ValidConstraint: tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 				CloudSpec: simplestreams.CloudSpec{
 					Region:   "us-east-1",
@@ -96,6 +97,7 @@ func registerLiveSimpleStreamsTests(baseURL string, validToolsConstraint simples
 		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames),
 		RequireSigned:   requireSigned,
 		DataType:        tools.ContentDownload,
+		StreamsVersion:  tools.CurrentStreamsVersion,
 		ValidConstraint: validToolsConstraint,
 	})
 }
@@ -249,8 +251,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 		// Add invalid datasource and check later that resolveInfo is correct.
 		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames)
 		tools, resolveInfo, err := tools.Fetch(
-			[]simplestreams.DataSource{invalidSource, s.Source},
-			simplestreams.DefaultIndexPath, toolsConstraint, s.RequireSigned)
+			[]simplestreams.DataSource{invalidSource, s.Source}, toolsConstraint, s.RequireSigned)
 		if !c.Check(err, gc.IsNil) {
 			continue
 		}
@@ -275,7 +276,7 @@ func (s *simplestreamsSuite) TestFetchWithMirror(c *gc.C) {
 		Arches:    []string{"amd64"},
 	})
 	toolsMetadata, resolveInfo, err := tools.Fetch(
-		[]simplestreams.DataSource{s.Source}, simplestreams.DefaultIndexPath, toolsConstraint, s.RequireSigned)
+		[]simplestreams.DataSource{s.Source}, toolsConstraint, s.RequireSigned)
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(toolsMetadata), gc.Equals, 1)
 
@@ -776,7 +777,7 @@ func (s *signedSuite) TestSignedToolsMetadata(c *gc.C) {
 		Arches:    []string{"amd64"},
 	})
 	toolsMetadata, resolveInfo, err := tools.Fetch(
-		[]simplestreams.DataSource{signedSource}, simplestreams.DefaultIndexPath, toolsConstraint, true)
+		[]simplestreams.DataSource{signedSource}, toolsConstraint, true)
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(toolsMetadata), gc.Equals, 1)
 	c.Assert(toolsMetadata[0].Path, gc.Equals, "tools/releases/20130806/juju-1.13.1-precise-amd64.tgz")

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -136,9 +136,10 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader, expectMirrors
 	}
 
 	const requireSigned = false
-	indexPath := simplestreams.UnsignedIndex
+	indexPath := simplestreams.UnsignedIndex("v1")
+	mirrorsPath := simplestreams.MirrorsPath("v1")
 	indexRef, err := simplestreams.GetIndexWithFormat(
-		source, indexPath, "index:1.0", requireSigned, simplestreams.CloudSpec{}, params)
+		source, indexPath, "index:1.0", mirrorsPath, requireSigned, simplestreams.CloudSpec{}, params)
 	c.Assert(err, gc.IsNil)
 	c.Assert(indexRef.Indexes, gc.HasLen, 1)
 
@@ -184,7 +185,7 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader, expectMirrors
 	}
 
 	if expectMirrors {
-		r, err = stor.Get(path.Join("tools", simplestreams.UnsignedMirror))
+		r, err = stor.Get(path.Join("tools", simplestreams.UnsignedMirror("v1")))
 		defer r.Close()
 		c.Assert(err, gc.IsNil)
 		data, err = ioutil.ReadAll(r)
@@ -214,7 +215,7 @@ func generateMetadata(c *gc.C, versions ...version.Binary) []metadataFile {
 	index, products, err := tools.MarshalToolsMetadataJSON(metadata, time.Now())
 	c.Assert(err, gc.IsNil)
 	objects := []metadataFile{
-		{simplestreams.UnsignedIndex, index},
+		{simplestreams.UnsignedIndex("v1"), index},
 		{tools.ProductMetadataPath, products},
 	}
 	return objects

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -119,7 +119,7 @@ func FindToolsForCloud(sources []simplestreams.DataSource, cloudSpec simplestrea
 	if err != nil {
 		return nil, err
 	}
-	toolsMetadata, _, err := Fetch(sources, simplestreams.DefaultIndexPath, toolsConstraint, false)
+	toolsMetadata, _, err := Fetch(sources, toolsConstraint, false)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			err = ErrNoTools

--- a/environs/tools/validation.go
+++ b/environs/tools/validation.go
@@ -54,7 +54,7 @@ func ValidateToolsMetadata(params *ToolsMetadataLookupParams) ([]string, *simple
 			Arches: params.Architectures,
 		})
 	}
-	matchingTools, resolveInfo, err := Fetch(params.Sources, simplestreams.DefaultIndexPath, toolsConstraint, false)
+	matchingTools, resolveInfo, err := Fetch(params.Sources, toolsConstraint, false)
 	if err != nil {
 		return nil, resolveInfo, err
 	}

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -82,8 +82,7 @@ func findMatchingImages(e *azureEnviron, location, series string, arches []strin
 	if err != nil {
 		return nil, err
 	}
-	indexPath := simplestreams.DefaultIndexPath
-	images, _, err := imagemetadata.Fetch(sources, indexPath, constraint, signedImageDataOnly)
+	images, _, err := imagemetadata.Fetch(sources, constraint, signedImageDataOnly)
 	if len(images) == 0 || errors.IsNotFound(err) {
 		return nil, fmt.Errorf("no OS images found for location %q, series %q, architectures %q (and endpoint: %q)", location, series, arches, endpoint)
 	} else if err != nil {

--- a/provider/common/supportedarchitectures.go
+++ b/provider/common/supportedarchitectures.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
-	"github.com/juju/juju/environs/simplestreams"
 )
 
 // SupportedArchitectures returns all the image architectures for env matching the constraints.
@@ -17,7 +16,7 @@ func SupportedArchitectures(env environs.Environ, imageConstraint *imagemetadata
 	if err != nil {
 		return nil, err
 	}
-	matchingImages, _, err := imagemetadata.Fetch(sources, simplestreams.DefaultIndexPath, imageConstraint, false)
+	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, false)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -48,8 +48,7 @@ func findInstanceSpec(
 		Arches:    ic.Arches,
 		Stream:    stream,
 	})
-	matchingImages, _, err := imagemetadata.Fetch(
-		sources, simplestreams.DefaultIndexPath, imageConstraint, signedImageDataOnly)
+	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, signedImageDataOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -335,7 +335,7 @@ func (env *joyentEnviron) FindInstanceSpec(ic *instances.InstanceConstraint) (*i
 		return nil, err
 	}
 
-	matchingImages, _, err := imagemetadata.Fetch(sources, simplestreams.DefaultIndexPath, imageConstraint, signedImageDataOnly)
+	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, signedImageDataOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/jujutest"
 	"github.com/juju/juju/environs/simplestreams"
@@ -246,13 +247,13 @@ func UseTestImageData(stor storage.Storage, cred *identity.Credentials) {
 		panic(fmt.Errorf("cannot generate index metdata: %v", err))
 	}
 	data := metadata.Bytes()
-	stor.Put(simplestreams.DefaultIndexPath+".json", bytes.NewReader(data), int64(len(data)))
+	stor.Put(simplestreams.UnsignedIndex(imagemetadata.StreamsVersionV1), bytes.NewReader(data), int64(len(data)))
 	stor.Put(
 		productMetadatafile, strings.NewReader(imagesData), int64(len(imagesData)))
 }
 
 func RemoveTestImageData(stor storage.Storage) {
-	stor.Remove(simplestreams.DefaultIndexPath + ".json")
+	stor.Remove(simplestreams.UnsignedIndex("v1"))
 	stor.Remove(productMetadatafile)
 }
 

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -43,7 +43,7 @@ func findInstanceSpec(e *environ, ic *instances.InstanceConstraint) (*instances.
 		return nil, err
 	}
 	// TODO (wallyworld): use an env parameter (default true) to mandate use of only signed image metadata.
-	matchingImages, _, err := imagemetadata.Fetch(sources, simplestreams.DefaultIndexPath, imageConstraint, false)
+	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow streams version to be parameterised so that it can be different for tools and images

This started out as a branch to use "v2" simplestreams metadata for tools to allow different metadata for 1.20 and newer vs 1.18 and older version of Juju. The fix is to change how simplestreams paths are resolved such that the streams version is now parameterised.

A different direction was decided on, but this change is still useful because it simplifies how Fetch() is invoked, provided a cleaner implementation of path resolution, and allows for easy changes of the streams versions in the future when needed. The changes are mechanical.
