### PR TITLE
Fixed lp:1308146 -  charm config options with $ and . in the names now work

### DIFF
--- a/state/charm.go
+++ b/state/charm.go
@@ -34,6 +34,17 @@ type Charm struct {
 }
 
 func newCharm(st *State, cdoc *charmDoc) *Charm {
+	// Because we probably just read the doc from state, make sure we
+	// unescape any config option names for "$" and ".". See
+	// http://pad.lv/1308146
+	if cdoc != nil && cdoc.Config != nil {
+		unescapedConfig := charm.NewConfig()
+		for optionName, option := range cdoc.Config.Options {
+			unescapedName := unescapeReplacer.Replace(optionName)
+			unescapedConfig.Options[unescapedName] = option
+		}
+		cdoc.Config = unescapedConfig
+	}
 	return &Charm{st: st, doc: *cdoc}
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -1019,9 +1019,17 @@ func (st *State) UpdateUploadedCharm(ch charm.Charm, curl *charm.URL, storagePat
 func (st *State) updateCharmDoc(
 	ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string, preReq interface{}) (*Charm, error) {
 
+	// Make sure we escape any "$" and "." in config option names
+	// first. See http://pad.lv/1308146.
+	cfg := ch.Config()
+	escapedConfig := charm.NewConfig()
+	for optionName, option := range cfg.Options {
+		escapedName := escapeReplacer.Replace(optionName)
+		escapedConfig.Options[escapedName] = option
+	}
 	updateFields := bson.D{{"$set", bson.D{
 		{"meta", ch.Meta()},
-		{"config", ch.Config()},
+		{"config", escapedConfig},
 		{"actions", ch.Actions()},
 		{"storagepath", storagePath},
 		{"bundlesha256", bundleSha256},

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -363,6 +364,49 @@ func (s *StateSuite) TestUpdateUploadedCharm(c *gc.C) {
 	_, err = s.State.PrepareLocalCharmUpload(missingCurl)
 	c.Assert(err, gc.IsNil)
 	sch, err = s.State.UpdateUploadedCharm(ch, missingCurl, storagePath, "missing")
+	c.Assert(err, gc.IsNil)
+	c.Assert(sch.URL(), gc.DeepEquals, missingCurl)
+	c.Assert(sch.Revision(), gc.Equals, missingCurl.Revision)
+	c.Assert(sch.IsUploaded(), jc.IsTrue)
+	c.Assert(sch.IsPlaceholder(), jc.IsFalse)
+	c.Assert(sch.Meta(), gc.DeepEquals, ch.Meta())
+	c.Assert(sch.Config(), gc.DeepEquals, ch.Config())
+	c.Assert(sch.StoragePath(), gc.DeepEquals, storagePath)
+	c.Assert(sch.BundleSha256(), gc.Equals, "missing")
+}
+
+func (s *StateSuite) TestUpdateUploadedCharmEscapesSpecialCharsInConfig(c *gc.C) {
+	// Make sure when we have mongodb special characters like "$" and
+	// "." in the name of any charm config option, we do proper
+	// escaping before storing them and unescaping after loading. See
+	// also http://pad.lv/1308146.
+
+	// Clone the dummy charm and change the config.
+	configWithProblematicKeys := []byte(`
+options:
+  $bad.key: {default: bad, description: bad, type: string}
+  not.ok.key: {description: not ok, type: int}
+  valid-key: {description: all good, type: boolean}
+  still$bad.: {description: not good, type: float}
+  $.$: {description: awful, type: string}
+  ...: {description: oh boy, type: int}
+  just$: {description: no no, type: float}
+`[1:])
+	chDir := charmtesting.Charms.ClonedDirPath(c.MkDir(), "dummy")
+	err := utils.AtomicWriteFile(
+		filepath.Join(chDir, "config.yaml"),
+		configWithProblematicKeys,
+		0666,
+	)
+	c.Assert(err, gc.IsNil)
+	ch, err := charm.ReadCharmDir(chDir)
+	c.Assert(err, gc.IsNil)
+	missingCurl := charm.MustParseURL("local:quantal/missing-1")
+	storagePath := "dummy-1"
+
+	preparedCurl, err := s.State.PrepareLocalCharmUpload(missingCurl)
+	c.Assert(err, gc.IsNil)
+	sch, err := s.State.UpdateUploadedCharm(ch, preparedCurl, storagePath, "missing")
 	c.Assert(err, gc.IsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, missingCurl)
 	c.Assert(sch.Revision(), gc.Equals, missingCurl.Revision)


### PR DESCRIPTION
Since local charms can be uploaded via the API server, this issue was
introduced: charms with config options having "$" and/or "." in their
names caused notOkForStorage error from mongodb when trying to save
the charm config into the charms collection. See http://pad.lv/1308146.

Service settings were already treated properly (escaping $ and . on the
way into mongo and unescaping on the way out), so the fix uses the same
approach.

Tested live with a local environment and added a unit test for it.
