### PR TITLE
Break pre-migration environment UUID chicken-and-egg scenerio

### DIFF
--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2887,6 +2887,18 @@ func (s *StateSuite) TestStateServerInfo(c *gc.C) {
 	// state servers.
 }
 
+func (s *StateSuite) TestStateServerInfoWithPreMigrationDoc(c *gc.C) {
+	err := s.stateServers.Update(
+		nil,
+		bson.D{{"$unset", bson.D{{"env-uuid", 1}}}},
+	)
+	c.Assert(err, gc.IsNil)
+
+	ids, err := s.State.StateServerInfo()
+	c.Assert(err, gc.IsNil)
+	c.Assert(ids.EnvironmentTag, gc.Equals, s.envTag)
+}
+
 func (s *StateSuite) TestReopenWithNoMachines(c *gc.C) {
 	expected := &state.StateServerInfo{
 		EnvironmentTag: s.envTag,


### PR DESCRIPTION
Multi-env state server related migration steps were relying on functionality that needed upgrade steps to have run (so that st.Environment() worked). This hack does just enough to allow to let the upgrade steps run on the master state server.

This fixes LP #1370635.

@howbazaar may have a view on how to solve this differently but this fix solves the upgrade issue seen in CI and by users until he's back in.

http://reviews.vapour.ws/r/56/diff/
