### PR TITLE
Bump juju/charm dependency to purge old goyaml import

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,7 +5,7 @@ github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	
-github.com/juju/charm	git	b9a309f5b8827ec0c63527fdd684fd1daeec5438	
+github.com/juju/charm	git	566e3ca724e06d24dbeacd92bd7d17e8bd2a1961	
 github.com/juju/cmd	git	7ef40be0cb5a4107d29fcfca5dff3b03ba0644dc	
 github.com/juju/errgo	git	2cf7b553faddc588f903020c33e71c527d5e0838	
 github.com/juju/errors	git	09734a904adc602da4334cbf29cb4515fbeb8feb	


### PR DESCRIPTION
Building juju was still pulling in launchpad.net/goyaml - as well as the newer gopkg.in/yaml.v1 location.

Fixed in the 1.20 branch of charm by https://github.com/juju/charm/pull/48, this change just bumps the dependency to require that.
