### PR TITLE
apiserver: allow an extra API method during upgrades

### DIFF
--- a/apiserver/upgrading_root.go
+++ b/apiserver/upgrading_root.go
@@ -42,6 +42,7 @@ func (r *upgradingRoot) FindMethod(rootName string, version int, methodName stri
 
 var allowedMethodsDuringUpgrades = set.NewStrings(
 	"Client.FullStatus",     // for "juju status"
+	"Client.EnvironmentGet", // for "juju ssh"
 	"Client.PrivateAddress", // for "juju ssh"
 	"Client.PublicAddress",  // for "juju ssh"
 	"Client.WatchDebugLog",  // for "juju debug-log"


### PR DESCRIPTION
Client.EnvironmentGet is required to support "juju ssh". SSH should be available during upgrades but this method was not in the list of upgradingRoot's allowed API methods.

This revision fixes the issue (tested manually). A CI test change will be made next ensure that SSH continues to work during upgrades.

Fixes LP#1367009.

http://reviews.vapour.ws/r/61/diff/
