### PR TITLE
upgrades: migrate uploaded image metadata to environment storage

### DIFF
--- a/upgrades/customimagemetadata.go
+++ b/upgrades/customimagemetadata.go
@@ -1,0 +1,73 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"bytes"
+	"io/ioutil"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/filestorage"
+	"github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/provider"
+	"github.com/juju/juju/state"
+)
+
+var stateStorage = (*state.State).Storage
+
+// migrateCustomImageMetadata copies uploaded image metadata from provider
+// storage to environment storage, preserving paths.
+func migrateCustomImageMetadata(st *state.State, agentConfig agent.Config) error {
+	logger.Debugf("migrating custom image metadata to environment storage")
+	estor := stateStorage(st)
+
+	// Local and manual provider host storage on the state server's
+	// filesystem, and serve via HTTP storage. The storage worker
+	// doesn't run yet, so we just open the files directly.
+	var pstor storage.StorageReader
+	providerType := agentConfig.Value(agent.ProviderType)
+	if providerType == provider.Local || provider.IsManual(providerType) {
+		storageDir := agentConfig.Value(agent.StorageDir)
+		var err error
+		pstor, err = filestorage.NewFileStorageReader(storageDir)
+		if err != nil {
+			return errors.Annotate(err, "cannot get local filesystem storage reader")
+		}
+	} else {
+		var err error
+		pstor, err = environs.GetStorage(st)
+		if err != nil {
+			return errors.Annotate(err, "cannot get provider storage")
+		}
+	}
+
+	paths, err := pstor.List(storage.BaseImagesPath)
+	if err != nil {
+		return err
+	}
+	for _, path := range paths {
+		logger.Infof("migrating image metadata at path %q", path)
+		data, err := readImageMetadata(pstor, path)
+		if err != nil {
+			return errors.Annotate(err, "failed to read image metadata")
+		}
+		err = estor.Put(path, bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			return errors.Annotate(err, "failed to write image metadata")
+		}
+	}
+	return nil
+}
+
+func readImageMetadata(stor storage.StorageReader, path string) ([]byte, error) {
+	r, err := stor.Get(path)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return ioutil.ReadAll(r)
+}

--- a/upgrades/customimagemetadata_test.go
+++ b/upgrades/customimagemetadata_test.go
@@ -1,0 +1,63 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	"bytes"
+
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/environs/filestorage"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+type migrateCustomImageMetadataStorageSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+var _ = gc.Suite(&migrateCustomImageMetadataStorageSuite{})
+
+var customImageMetadata = map[string][]byte{
+	"images/abc":     []byte("abc"),
+	"images/def/ghi": []byte("xyz"),
+}
+
+func (s *migrateCustomImageMetadataStorageSuite) TestMigrateCustomImageMetadata(c *gc.C) {
+	stor := s.Environ.Storage()
+	for path, content := range customImageMetadata {
+		err := stor.Put(path, bytes.NewReader(content), int64(len(content)))
+		c.Assert(err, gc.IsNil)
+	}
+	s.testMigrateCustomImageMetadata(c, &mockAgentConfig{})
+}
+
+func (s *migrateCustomImageMetadataStorageSuite) TestMigrateCustomImageMetadataLocalstorage(c *gc.C) {
+	storageDir := c.MkDir()
+	stor, err := filestorage.NewFileStorageWriter(storageDir)
+	c.Assert(err, gc.IsNil)
+	for path, content := range customImageMetadata {
+		err := stor.Put(path, bytes.NewReader(content), int64(len(content)))
+		c.Assert(err, gc.IsNil)
+	}
+	s.testMigrateCustomImageMetadata(c, &mockAgentConfig{
+		values: map[string]string{
+			agent.ProviderType: "local",
+			agent.StorageDir:   storageDir,
+		},
+	})
+}
+
+func (s *migrateCustomImageMetadataStorageSuite) testMigrateCustomImageMetadata(c *gc.C, agentConfig agent.Config) {
+	var stor statetesting.MapStorage
+	s.PatchValue(upgrades.StateStorage, func(*state.State) state.Storage {
+		return &stor
+	})
+	err := upgrades.MigrateCustomImageMetadata(s.State, agentConfig)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stor.Map, gc.DeepEquals, customImageMetadata)
+}

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -11,6 +11,7 @@ var (
 	CharmBundleURL            = &charmBundleURL
 	CharmStoragePath          = &charmStoragePath
 	StateAddCharmStoragePaths = &stateAddCharmStoragePaths
+	StateStorage              = &stateStorage
 
 	ChownPath      = &chownPath
 	IsLocalEnviron = &isLocalEnviron
@@ -25,6 +26,7 @@ var (
 	MigrateLocalProviderAgentConfig        = migrateLocalProviderAgentConfig
 
 	// 121 upgrade functions
-	StepsFor121         = stepsFor121
-	MigrateCharmStorage = migrateCharmStorage
+	StepsFor121                = stepsFor121
+	MigrateCharmStorage        = migrateCharmStorage
+	MigrateCustomImageMetadata = migrateCustomImageMetadata
 )

--- a/upgrades/steps121.go
+++ b/upgrades/steps121.go
@@ -37,6 +37,13 @@ func stepsFor121() []Step {
 			},
 		},
 		&upgradeStep{
+			description: "migrate custom image metadata into environment storage",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return migrateCustomImageMetadata(context.State(), context.AgentConfig())
+			},
+		},
+		&upgradeStep{
 			description: "set environment owner and server uuid",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps121_test.go
+++ b/upgrades/steps121_test.go
@@ -22,6 +22,7 @@ func (s *steps121Suite) TestUpgradeOperationsContent(c *gc.C) {
 		"add environment uuid to state server doc",
 		"add all users in state as environment users",
 		"migrate charm archives into environment storage",
+		"migrate custom image metadata into environment storage",
 		"set environment owner and server uuid",
 	}
 


### PR DESCRIPTION
We no longer search for image metadata in provider storage.
This is the final piece: migrate existing metadata from provider
storage to environment storage, preserving paths and data exactly.
