### PR TITLE
Collect metrics hook

### DIFF
--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3683,6 +3683,12 @@ func (s *StateSuite) TestWatchMachineAddresses(c *gc.C) {
 	c.Assert(w.Err(), jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *StateSuite) TestNowToTheSecond(c *gc.C) {
+	t := state.NowToTheSecond()
+	rounded := t.Round(time.Second)
+	c.Assert(t, gc.DeepEquals, rounded)
+}
+
 type SetAdminMongoPasswordSuite struct {
 	testing.BaseSuite
 }

--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -3,7 +3,12 @@
 
 package uniter
 
-import "github.com/juju/utils/proxy"
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/utils/proxy"
+)
 
 func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
 	u.observer = observer
@@ -13,6 +18,10 @@ func (u *Uniter) GetProxyValues() proxy.Settings {
 	u.proxyMutex.Lock()
 	defer u.proxyMutex.Unlock()
 	return u.proxy
+}
+
+func PatchMetricsTimer(newTimer func(now, lastRun time.Time, interval time.Duration) <-chan time.Time) {
+	collectMetricsAt = newTimer
 }
 
 func (c *HookContext) ActionResultsMap() map[string]interface{} {
@@ -57,11 +66,39 @@ func (ctx *HookContext) PatchMeterStatus(code, info string) func() {
 }
 
 var (
-	MergeEnvironment  = mergeEnvironment
-	SearchHook        = searchHook
-	HookCommand       = hookCommand
-	LookPath          = lookPath
-	ValidatePortRange = validatePortRange
-	TryOpenPorts      = tryOpenPorts
-	TryClosePorts     = tryClosePorts
+	MergeEnvironment    = mergeEnvironment
+	SearchHook          = searchHook
+	HookCommand         = hookCommand
+	LookPath            = lookPath
+	ValidatePortRange   = validatePortRange
+	TryOpenPorts        = tryOpenPorts
+	TryClosePorts       = tryClosePorts
+	CollectMetricsTimer = collectMetricsTimer
 )
+
+// manualTicker will be used to generate collect-metrics events
+// in a time-independent manner for testing.
+type ManualTicker struct {
+	c chan time.Time
+}
+
+// Tick sends a signal on the ticker channel.
+func (t *ManualTicker) Tick() error {
+	select {
+	case t.c <- time.Now():
+	default:
+		return fmt.Errorf("ticker channel blocked")
+	}
+	return nil
+}
+
+// ReturnTimer can be used to replace the metrics signal generator.
+func (t *ManualTicker) ReturnTimer(now, lastRun time.Time, interval time.Duration) <-chan time.Time {
+	return t.c
+}
+
+func NewManualTicker() *ManualTicker {
+	return &ManualTicker{
+		c: make(chan time.Time, 1),
+	}
+}

--- a/worker/uniter/filter.go
+++ b/worker/uniter/filter.go
@@ -429,7 +429,6 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 				}
 			}
 			f.relationsChanged(ids)
-
 		// Send events on active out chans.
 		case f.outUpgrade <- f.upgrade:
 			filterLogger.Debugf("sent upgrade event")

--- a/worker/uniter/filter_test.go
+++ b/worker/uniter/filter_test.go
@@ -674,7 +674,6 @@ func (s *FilterSuite) TestMeterStatusEvents(c *gc.C) {
 	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
-
 	assertNoChange := func() {
 		s.BackingState.StartSync()
 		select {
@@ -693,7 +692,6 @@ func (s *FilterSuite) TestMeterStatusEvents(c *gc.C) {
 		}
 		assertNoChange()
 	}
-
 	// Initial meter status does not trigger event.
 	assertNoChange()
 
@@ -707,6 +705,5 @@ func (s *FilterSuite) TestMeterStatusEvents(c *gc.C) {
 		err = s.unit.SetMeterStatus("RED", fmt.Sprintf("Update %d.", i))
 		c.Assert(err, gc.IsNil)
 	}
-
 	assertChange()
 }

--- a/worker/uniter/state_test.go
+++ b/worker/uniter/state_test.go
@@ -5,6 +5,7 @@ package uniter_test
 
 import (
 	"path/filepath"
+	"time"
 
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -24,6 +25,8 @@ var relhook = &hook.Info{
 	Kind:       hooks.RelationJoined,
 	RemoteUnit: "some-thing/123",
 }
+
+var now = time.Now().Round(time.Second)
 
 var stateTests = []struct {
 	st  uniter.State
@@ -155,9 +158,10 @@ var stateTests = []struct {
 		err: `unexpected charm URL`,
 	}, {
 		st: uniter.State{
-			Op:     uniter.Continue,
-			OpStep: uniter.Pending,
-			Hook:   relhook,
+			Op:                 uniter.Continue,
+			OpStep:             uniter.Pending,
+			Hook:               relhook,
+			CollectMetricsTime: now.Unix(),
 		},
 	},
 }
@@ -170,7 +174,7 @@ func (s *StateFileSuite) TestStates(c *gc.C) {
 		_, err := file.Read()
 		c.Assert(err, gc.Equals, uniter.ErrNoStateFile)
 		write := func() {
-			err := file.Write(t.st.Started, t.st.Op, t.st.OpStep, t.st.Hook, t.st.CharmURL)
+			err := file.Write(t.st.Started, t.st.Op, t.st.OpStep, t.st.Hook, t.st.CharmURL, t.st.CollectMetricsTime)
 			c.Assert(err, gc.IsNil)
 		}
 		if t.err != "" {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -46,6 +46,9 @@ const (
 	// workloads in the future, we'll need to move these into a file that is
 	// compiled conditionally for different targets and use tcp (most likely).
 	RunListenerFile = "run.socket"
+
+	// interval at which the unit's metrics should be collected
+	metricsPollInterval = 5 * time.Minute
 )
 
 // A UniterExecutionObserver gets the appropriate methods called when a hook
@@ -55,6 +58,18 @@ type UniterExecutionObserver interface {
 	HookCompleted(hookName string)
 	HookFailed(hookName string)
 }
+
+// collectMetricsTimer returns a channel that will signal the collect metrics hook
+// as close to metricsPollInterval after the last run as possible.
+func collectMetricsTimer(now, lastRun time.Time, interval time.Duration) <-chan time.Time {
+	waitDuration := interval - now.Sub(lastRun)
+	logger.Debugf("waiting for %v", waitDuration)
+	return time.After(waitDuration)
+}
+
+// collectMetricsAt defines a function that will be used to generate signals
+// for the collect-metrics hook. It will be replaced in tests.
+var collectMetricsAt func(now, lastSignal time.Time, interval time.Duration) <-chan time.Time = collectMetricsTimer
 
 // Uniter implements the capabilities of the unit agent. It is not intended to
 // implement the actual *behaviour* of the unit agent; that responsibility is
@@ -88,6 +103,7 @@ type Uniter struct {
 	proxyMutex sync.Mutex
 
 	ranConfigChanged bool
+
 	// The execution observer is only used in tests at this stage. Should this
 	// need to be extended, perhaps a list of observers would be needed.
 	observer UniterExecutionObserver
@@ -269,14 +285,24 @@ func (u *Uniter) Dead() <-chan struct{} {
 // writeState saves uniter state with the supplied values, and infers the appropriate
 // value of Started.
 func (u *Uniter) writeState(op Op, step OpStep, hi *hook.Info, url *corecharm.URL) error {
-	s := State{
-		Started:  op == RunHook && hi.Kind == hooks.Start || u.s != nil && u.s.Started,
-		Op:       op,
-		OpStep:   step,
-		Hook:     hi,
-		CharmURL: url,
+	var collectMetricsTime int64 = 0
+	if hi != nil && hi.Kind == hooks.CollectMetrics && step == Done {
+		// update collectMetricsTime if the collect-metrics hook was run
+		collectMetricsTime = time.Now().Unix()
+	} else if u.s != nil {
+		// or preserve existing value
+		collectMetricsTime = u.s.CollectMetricsTime
 	}
-	if err := u.sf.Write(s.Started, s.Op, s.OpStep, s.Hook, s.CharmURL); err != nil {
+
+	s := State{
+		Started:            op == RunHook && hi.Kind == hooks.Start || u.s != nil && u.s.Started,
+		Op:                 op,
+		OpStep:             step,
+		Hook:               hi,
+		CharmURL:           url,
+		CollectMetricsTime: collectMetricsTime,
+	}
+	if err := u.sf.Write(s.Started, s.Op, s.OpStep, s.Hook, s.CharmURL, s.CollectMetricsTime); err != nil {
 		return err
 	}
 	u.s = &s


### PR DESCRIPTION
The hook is fired every five minutes on all running units via a state server worker that updates the metrics request time field on each unit (that change is detected by the uniter watcher).
