### PR TITLE
Add apt_preferences file with bootcmd

### DIFF
--- a/cloudinit/cloudinit_test.go
+++ b/cloudinit/cloudinit_test.go
@@ -186,7 +186,7 @@ var ctests = []struct {
 		`apt_sources:
 - source: keyName
   key: someKey
-runcmd:
+bootcmd:
 - install -D -m 644 /dev/null '/some/path'
 - 'printf ''%s\n'' ''Explanation: test
 

--- a/cloudinit/options.go
+++ b/cloudinit/options.go
@@ -108,8 +108,9 @@ func (cfg *Config) AddAptSource(name, key string, prefs *AptPreferences) {
 		},
 	)
 	if prefs != nil {
-		// Create the apt preferences file.
-		cfg.AddTextFile(prefs.Path, prefs.FileContents(), 0644)
+		// Create the apt preferences file. This needs to be done
+		// before apt-get upgrade, so it must be done as a bootcmd.
+		cfg.addBootTextFile(prefs.Path, prefs.FileContents(), 0644)
 	}
 }
 
@@ -341,30 +342,37 @@ func (cfg *Config) AddScripts(scripts ...string) {
 // AddTextFile will add multiple run_cmd entries to safely set the
 // contents of a specific file to the requested contents.
 func (cfg *Config) AddTextFile(filename, data string, mode uint) {
-	cfg.addFile(filename, []byte(data), mode, false)
+	addFile(cfg.AddRunCmd, filename, []byte(data), mode, false)
+}
+
+// addBootTextFile will add multiple bootcmd entries to safely set the
+// contents of a specific file to the requested contents early in the
+// boot process.
+func (cfg *Config) addBootTextFile(filename, data string, mode uint) {
+	addFile(cfg.AddBootCmd, filename, []byte(data), mode, false)
 }
 
 // AddBinaryFile will add multiple run_cmd entries to safely set the
 // contents of a specific file to the requested contents.
 func (cfg *Config) AddBinaryFile(filename string, data []byte, mode uint) {
-	cfg.addFile(filename, data, mode, true)
+	addFile(cfg.AddRunCmd, filename, data, mode, true)
 }
 
-func (cfg *Config) addFile(filename string, data []byte, mode uint, binary bool) {
+func addFile(addCmd func(string), filename string, data []byte, mode uint, binary bool) {
 	// Note: recent versions of cloud-init have the "write_files"
 	// module, which can write arbitrary files. We currently support
 	// 12.04 LTS, which uses an older version of cloud-init without
 	// this module.
 	p := shquote(filename)
-	cfg.AddRunCmd(fmt.Sprintf("install -D -m %o /dev/null %s", mode, p))
+	addCmd(fmt.Sprintf("install -D -m %o /dev/null %s", mode, p))
 	// Don't use the shell's echo builtin here; the interpretation
 	// of escape sequences differs between shells, namely bash and
 	// dash. Instead, we use printf (or we could use /bin/echo).
 	if binary {
 		encoded := base64.StdEncoding.EncodeToString(data)
-		cfg.AddRunCmd(fmt.Sprintf(`printf %%s %s | base64 -d > %s`, encoded, p))
+		addCmd(fmt.Sprintf(`printf %%s %s | base64 -d > %s`, encoded, p))
 	} else {
-		cfg.AddRunCmd(fmt.Sprintf(`printf '%%s\n' %s > %s`, shquote(string(data)), p))
+		addCmd(fmt.Sprintf(`printf '%%s\n' %s > %s`, shquote(string(data)), p))
 	}
 }
 

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -196,6 +196,8 @@ var cloudinitTests = []cloudinitTest{
 		},
 		setEnvConfig: true,
 		expectScripts: `
+install -D -m 644 /dev/null '/etc/apt/preferences\.d/50-cloud-tools'
+printf '%s\\n' '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
 set -xe
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
@@ -216,8 +218,6 @@ printf %s '{"version":"1\.2\.3-precise-amd64","url":"http://foo\.com/tools/relea
 mkdir -p '/var/lib/juju/agents/machine-0'
 install -m 600 /dev/null '/var/lib/juju/agents/machine-0/agent\.conf'
 printf '%s\\n' '.*' > '/var/lib/juju/agents/machine-0/agent\.conf'
-install -D -m 644 /dev/null '/etc/apt/preferences\.d/50-cloud-tools'
-printf '%s\\n' '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
 echo 'Bootstrapping Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'


### PR DESCRIPTION
The apt_preferences file must be written
before we run "apt-get upgrade", or the
pinning does not take effect on non-bootstrap
machines.

Fixes https://bugs.launchpad.net/juju-core/+bug/1370781
