### PR TITLE
Add apt_preferences file with bootcmd

### DIFF
--- a/cloudinit/cloudinit_test.go
+++ b/cloudinit/cloudinit_test.go
@@ -185,7 +185,7 @@ var ctests = []struct {
 		`apt_sources:
 - source: keyName
   key: someKey
-runcmd:
+bootcmd:
 - install -D -m 644 /dev/null '/some/path'
 - 'printf ''%s\n'' ''Explanation: test
 

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -114,6 +114,8 @@ var cloudinitTests = []cloudinitTest{
 		},
 		setEnvConfig: true,
 		expectScripts: `
+install -D -m 644 /dev/null '/etc/apt/preferences\.d/50-cloud-tools'
+printf '%s\\n' '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
 set -xe
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
@@ -135,8 +137,6 @@ printf %s '{"version":"1\.2\.3-precise-amd64","url":"http://foo\.com/tools/relea
 mkdir -p '/var/lib/juju/agents/machine-0'
 install -m 600 /dev/null '/var/lib/juju/agents/machine-0/agent\.conf'
 printf '%s\\n' '.*' > '/var/lib/juju/agents/machine-0/agent\.conf'
-install -D -m 644 /dev/null '/etc/apt/preferences\.d/50-cloud-tools'
-printf '%s\\n' '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
 echo 'Bootstrapping Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'


### PR DESCRIPTION
The apt_preferences file must be written
before we run "apt-get upgrade", or the
pinning does not take effect on non-bootstrap
machines.

Fixes https://bugs.launchpad.net/juju-core/+bug/1370781
