### PR TITLE
Remove environs.{VerifyStorage,CheckEnvironment}

### DIFF
--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -136,10 +136,6 @@ func (test bootstrapTest) run(c *gc.C) {
 		return
 	}
 
-	opPutBootstrapVerifyFile := (<-opc).(dummy.OpPutFile)
-	c.Check(opPutBootstrapVerifyFile.Env, gc.Equals, "peckham")
-	c.Check(opPutBootstrapVerifyFile.FileName, gc.Equals, environs.VerificationFilename)
-
 	opBootstrap := (<-opc).(dummy.OpBootstrap)
 	c.Check(opBootstrap.Env, gc.Equals, "peckham")
 	c.Check(opBootstrap.Args.Constraints, gc.DeepEquals, test.constraints)
@@ -531,7 +527,6 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	// the current juju version.
 	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), envcmd.Wrap(new(BootstrapCommand)), "-e", "devenv")
 	c.Assert(<-errc, gc.IsNil)
-	c.Check((<-opc).(dummy.OpPutFile).Env, gc.Equals, "devenv") // verify storage
 	c.Check((<-opc).(dummy.OpBootstrap).Env, gc.Equals, "devenv")
 	mcfg := (<-opc).(dummy.OpFinalizeBootstrap).MachineConfig
 	c.Assert(mcfg, gc.NotNil)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -31,8 +31,6 @@ You may want to use the 'tools-metadata-url' configuration setting to specify th
 
 var (
 	logger = loggo.GetLogger("juju.environs.bootstrap")
-
-	environsVerifyStorage = environs.VerifyStorage
 )
 
 // BootstrapParams holds the parameters for bootstrapping an environment.
@@ -80,11 +78,6 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	}
 	if _, hasCAKey := cfg.CAPrivateKey(); !hasCAKey {
 		return errors.Errorf("environment configuration has no ca-private-key")
-	}
-
-	// Write out the bootstrap-init file, and confirm storage is writeable.
-	if err := environsVerifyStorage(environ.Storage()); err != nil {
-		return err
 	}
 
 	// Set default tools metadata source, add image metadata source,

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -47,7 +47,6 @@ var _ = gc.Suite(&bootstrapSuite{})
 func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
-	s.PatchValue(bootstrap.EnvironsVerifyStorage, func(storage.Storage) error { return nil })
 
 	storageDir := c.MkDir()
 	s.PatchValue(&envtools.DefaultBaseURL, storageDir)

--- a/environs/bootstrap/export_test.go
+++ b/environs/bootstrap/export_test.go
@@ -6,7 +6,6 @@ package bootstrap
 var (
 	ValidateUploadAllowed = validateUploadAllowed
 	SetBootstrapTools     = setBootstrapTools
-	EnvironsVerifyStorage = &environsVerifyStorage
 	FindTools             = &findTools
 	FindBootstrapTools    = findBootstrapTools
 	FindAvailableTools    = findAvailableTools

--- a/environs/emptystorage_test.go
+++ b/environs/emptystorage_test.go
@@ -4,15 +4,10 @@
 package environs_test
 
 import (
-	"io/ioutil"
-
-	"github.com/juju/errors"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/environs/storage"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
 
@@ -38,55 +33,4 @@ func (s *EmptyStorageSuite) TestList(c *gc.C) {
 	names, err := storage.List(environs.EmptyStorage, "anything")
 	c.Assert(names, gc.IsNil)
 	c.Assert(err, gc.IsNil)
-}
-
-type verifyStorageSuite struct {
-	testing.FakeJujuHomeSuite
-}
-
-var _ = gc.Suite(&verifyStorageSuite{})
-
-const existingEnv = `
-environments:
-    test:
-        type: dummy
-        state-server: false
-        authorized-keys: i-am-a-key
-`
-
-func (s *verifyStorageSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuHomeSuite.SetUpTest(c)
-	testing.WriteEnvironments(c, existingEnv)
-}
-
-func (s *verifyStorageSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
-	s.FakeJujuHomeSuite.TearDownTest(c)
-}
-
-func (s *verifyStorageSuite) TestVerifyStorage(c *gc.C) {
-	ctx := testing.Context(c)
-	environ, err := environs.PrepareFromName("test", ctx, configstore.NewMem())
-	c.Assert(err, gc.IsNil)
-	stor := environ.Storage()
-	err = environs.VerifyStorage(stor)
-	c.Assert(err, gc.IsNil)
-	reader, err := storage.Get(stor, environs.VerificationFilename)
-	c.Assert(err, gc.IsNil)
-	defer reader.Close()
-	contents, err := ioutil.ReadAll(reader)
-	c.Assert(err, gc.IsNil)
-	c.Check(string(contents), gc.Equals,
-		"juju-core storage writing verified: ok\n")
-}
-
-func (s *verifyStorageSuite) TestVerifyStorageFails(c *gc.C) {
-	ctx := testing.Context(c)
-	environ, err := environs.PrepareFromName("test", ctx, configstore.NewMem())
-	c.Assert(err, gc.IsNil)
-	stor := environ.Storage()
-	someError := errors.Unauthorizedf("you shall not pass")
-	dummy.Poison(stor, environs.VerificationFilename, someError)
-	err = environs.VerifyStorage(stor)
-	c.Assert(err, gc.Equals, environs.VerifyStorageError)
 }

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -7,9 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
-
-	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -541,47 +538,6 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	}
 	c.Logf("waiting for instance to be removed")
 	t.assertStopInstance(c, t.Env, instId1)
-}
-
-func (t *LiveTests) TestBootstrapVerifyStorage(c *gc.C) {
-	// Bootstrap automatically verifies that storage is writable.
-	t.BootstrapOnce(c)
-	environ := t.Env
-	stor := environ.Storage()
-	reader, err := storage.Get(stor, "bootstrap-verify")
-	c.Assert(err, gc.IsNil)
-	defer reader.Close()
-	contents, err := ioutil.ReadAll(reader)
-	c.Assert(err, gc.IsNil)
-	c.Check(string(contents), gc.Equals,
-		"juju-core storage writing verified: ok\n")
-}
-
-func restoreBootstrapVerificationFile(c *gc.C, stor storage.Storage) {
-	content := "juju-core storage writing verified: ok\n"
-	contentReader := strings.NewReader(content)
-	err := stor.Put("bootstrap-verify", contentReader,
-		int64(len(content)))
-	c.Assert(err, gc.IsNil)
-}
-
-func (t *LiveTests) TestCheckEnvironmentOnConnect(c *gc.C) {
-	// When new connection is established to a bootstraped environment,
-	// it is checked that we are running against a juju-core environment.
-	if !t.CanOpenState {
-		c.Skip("CanOpenState is false; cannot open state connection")
-	}
-	t.BootstrapOnce(c)
-
-	c.Logf("opening state")
-	st := t.Env.(testing.GetStater).GetStateInAPIServer()
-	env, err := st.Environment()
-	c.Assert(err, gc.IsNil)
-	owner := env.Owner()
-
-	apiState, err := juju.NewAPIState(owner, t.Env, api.DefaultDialOpts())
-	c.Assert(err, gc.IsNil)
-	apiState.Close()
 }
 
 type tooler interface {

--- a/environs/open.go
+++ b/environs/open.go
@@ -5,8 +5,6 @@ package environs
 
 import (
 	"fmt"
-	"io/ioutil"
-	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -15,21 +13,9 @@ import (
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
-	"github.com/juju/juju/environs/storage"
-)
-
-// File named `VerificationFilename` in the storage will contain
-// `verificationContent`.  This is also used to differentiate between
-// Python Juju and juju-core environments, so change the content with
-// care (and update CheckEnvironment below when you do that).
-const (
-	VerificationFilename = "bootstrap-verify"
-	verificationContent  = "juju-core storage writing verified: ok\n"
 )
 
 var (
-	VerifyStorageError error = fmt.Errorf(
-		"provider storage is not writable")
 	InvalidEnvironmentError = fmt.Errorf(
 		"environment is not a juju-core environment")
 )
@@ -320,45 +306,6 @@ func DestroyInfo(envName string, store configstore.Storage) error {
 	}
 	if err := info.Destroy(); err != nil {
 		return errors.Annotate(err, "cannot destroy environment configuration information")
-	}
-	return nil
-}
-
-// VerifyStorage writes the bootstrap init file to the storage to indicate
-// that the storage is writable.
-func VerifyStorage(stor storage.Storage) error {
-	reader := strings.NewReader(verificationContent)
-	err := stor.Put(VerificationFilename, reader,
-		int64(len(verificationContent)))
-	if err != nil {
-		logger.Warningf("failed to write bootstrap-verify file: %v", err)
-		return VerifyStorageError
-	}
-	return nil
-}
-
-// CheckEnvironment checks if an environment has a bootstrap-verify
-// that is written by juju-core commands (as compared to one being
-// written by Python juju).
-//
-// If there is no bootstrap-verify file in the storage, it is still
-// considered to be a Juju-core environment since early versions have
-// not written it out.
-//
-// Returns InvalidEnvironmentError on failure, nil otherwise.
-func CheckEnvironment(environ Environ) error {
-	stor := environ.Storage()
-	reader, err := storage.Get(stor, VerificationFilename)
-	if errors.IsNotFound(err) {
-		// When verification file does not exist, this is a juju-core
-		// environment.
-		return nil
-	} else if err != nil {
-		return err
-	} else if content, err := ioutil.ReadAll(reader); err != nil {
-		return err
-	} else if string(content) != verificationContent {
-		return InvalidEnvironmentError
 	}
 	return nil
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -309,9 +309,6 @@ func newState(environ environs.Environ, mongoInfo *mongo.MongoInfo) (*state.Stat
 	if password == "" {
 		return nil, fmt.Errorf("cannot connect without admin-secret")
 	}
-	if err := environs.CheckEnvironment(environ); err != nil {
-		return nil, err
-	}
 
 	mongoInfo.Password = password
 	opts := mongo.DefaultDialOpts()


### PR DESCRIPTION
environs.VerifyStorage was being called at
Bootstrap time; we're getting rid of provider
storage so this needs to go. Also, the related
CheckEnvironment function (which checks the
contents of the bootstrap-verify file) is only
called in tests.

Exact copy of #575, which the bot seems to be ignoring (maybe because I closed/reopened)
