### PR TITLE
Meter status

### DIFF
--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -669,3 +669,15 @@ type MetricsParam struct {
 type MetricsParams struct {
 	Metrics []MetricsParam
 }
+
+// MeterStatusResult holds unit meter status or error.
+type MeterStatusResult struct {
+	Code  string
+	Info  string
+	Error *Error
+}
+
+// MeterStatusResults holds meter status results for multiple units.
+type MeterStatusResults struct {
+	Results []MeterStatusResult
+}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -23,7 +23,7 @@ github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c
 github.com/juju/utils	git	f4ce20edb098e37f8cd6ff06dc71fc108cc0a236	
 github.com/juju/syslog	git	2b69d6582feb16ff8b6d644495e16c2d8314fcb8	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
-gopkg.in/juju/charm.v4	git	6e22113b2209e9cf9bf308a58f982e6f92f2667e	
+gopkg.in/juju/charm.v4	git	8b3cc836f54c2c78ce73d198100a30bb31d28392	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	

--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -1,0 +1,117 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+var meterStatusLogger = loggo.GetLogger("juju.state.meterstatus")
+
+// MeterStatusCode represents the meter status code of a unit.
+type MeterStatusCode string
+
+const (
+	MeterNotSet       MeterStatusCode = "NOT SET"
+	MeterNotAvailable MeterStatusCode = "NOT AVAILABLE"
+	MeterGreen        MeterStatusCode = "GREEN"
+	MeterAmber        MeterStatusCode = "AMBER"
+	MeterRed          MeterStatusCode = "RED"
+)
+
+type meterStatusDoc struct {
+	Id   string          `bson:"_id"`
+	Code MeterStatusCode `bson:"code"`
+	Info string          `bson:"info"`
+}
+
+// SetMeterStatus sets the meter status for the unit.
+func (u *Unit) SetMeterStatus(codeRaw, info string) error {
+	code := MeterStatusCode(codeRaw)
+	switch code {
+	case MeterGreen, MeterAmber, MeterRed:
+	default:
+		return errors.Errorf("invalid meter status %q", code)
+	}
+	meterDoc, err := u.getMeterStatusDoc()
+	if err != nil {
+		return errors.Annotatef(err, "cannot update meter status for unit %s", u.Name())
+	}
+	if meterDoc.Code == code && meterDoc.Info == info {
+		return nil
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			err := u.Refresh()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			meterDoc, err = u.getMeterStatusDoc()
+			if err != nil {
+				return nil, errors.Annotatef(err, "cannot update meter status for unit %s", u.Name())
+			}
+			if meterDoc.Code == code && meterDoc.Info == info {
+				return nil, jujutxn.ErrNoOperations
+			}
+		}
+		return []txn.Op{
+			{
+				C:      unitsC,
+				Id:     u.doc.DocID,
+				Assert: isAliveDoc,
+			}, {
+				C:      meterStatusC,
+				Id:     u.globalKey(),
+				Assert: txn.DocExists,
+				Update: bson.D{{"$set", bson.D{{"code", code}, {"info", info}}}},
+			}}, nil
+	}
+	return errors.Annotatef(u.st.run(buildTxn), "cannot set meter state for unit %s", u.Name())
+}
+
+// createMeterStatusOp returns the operation needed to create the meter status
+// document associated with the given globalKey.
+func createMeterStatusOp(st *State, globalKey string, doc meterStatusDoc) txn.Op {
+	return txn.Op{
+		C:      meterStatusC,
+		Id:     globalKey,
+		Assert: txn.DocMissing,
+		Insert: doc,
+	}
+}
+
+// removeMeterStatusOp returns the operation needed to remove the meter status
+// document associated with the given globalKey.
+func removeMeterStatusOp(st *State, globalKey string) txn.Op {
+	return txn.Op{
+		C:      meterStatusC,
+		Id:     globalKey,
+		Remove: true,
+	}
+}
+
+// GetMeterStatus returns the meter status for the unit.
+func (u *Unit) GetMeterStatus() (code, info string, err error) {
+	status, err := u.getMeterStatusDoc()
+	if err != nil {
+		return string(MeterNotAvailable), "", errors.Annotatef(err, "cannot retrieve meter status for unit %s", u.Name())
+	}
+	return string(status.Code), status.Info, nil
+}
+
+func (u *Unit) getMeterStatusDoc() (*meterStatusDoc, error) {
+	meterStatuses, closer := u.st.getCollection(meterStatusC)
+	defer closer()
+	var status meterStatusDoc
+	err := meterStatuses.FindId(u.globalKey()).One(&status)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &status, nil
+}

--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -1,0 +1,83 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+type MeterStateSuite struct {
+	ConnSuite
+	unit    *state.Unit
+	factory *factory.Factory
+}
+
+var _ = gc.Suite(&MeterStateSuite{})
+
+func (s *MeterStateSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+	s.factory = factory.NewFactory(s.State)
+	s.unit = s.factory.MakeUnit(c, nil)
+	c.Assert(s.unit.Series(), gc.Equals, "quantal")
+}
+
+func (s *UnitSuite) TestMeterStatus(c *gc.C) {
+	status, info, err := s.unit.GetMeterStatus()
+	c.Assert(status, gc.Equals, "NOT SET")
+	c.Assert(info, gc.Equals, "")
+	c.Assert(err, gc.IsNil)
+	err = s.unit.SetMeterStatus("GREEN", "Additional information.")
+	c.Assert(err, gc.IsNil)
+	status, info, err = s.unit.GetMeterStatus()
+	c.Assert(status, gc.Equals, "GREEN")
+	c.Assert(info, gc.Equals, "Additional information.")
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *UnitSuite) TestSetMeterStatusIncorrect(c *gc.C) {
+	err := s.unit.SetMeterStatus("NOT SET", "Additional information.")
+	c.Assert(err, gc.NotNil)
+	status, info, err := s.unit.GetMeterStatus()
+	c.Assert(status, gc.Equals, "NOT SET")
+	c.Assert(info, gc.Equals, "")
+	c.Assert(err, gc.IsNil)
+
+	err = s.unit.SetMeterStatus("this-is-not-a-valid-status", "Additional information.")
+	c.Assert(err, gc.NotNil)
+	status, info, err = s.unit.GetMeterStatus()
+	c.Assert(status, gc.Equals, "NOT SET")
+	c.Assert(info, gc.Equals, "")
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *UnitSuite) TestSetMeterStatusWhenDying(c *gc.C) {
+	preventUnitDestroyRemove(c, s.unit)
+	testWhenDying(c, s.unit, contentionErr, contentionErr, func() error {
+		err := s.unit.SetMeterStatus("GREEN", "Additional information.")
+		if err != nil {
+			return err
+		}
+		status, info, err := s.unit.GetMeterStatus()
+		c.Assert(status, gc.Equals, "NOT SET")
+		c.Assert(info, gc.Equals, "")
+		c.Assert(err, gc.IsNil)
+		return nil
+	})
+}
+
+func (s *UnitSuite) TestMeterStatusRemovedWithUnit(c *gc.C) {
+	err := s.unit.SetMeterStatus("GREEN", "Information.")
+	c.Assert(err, gc.IsNil)
+	err = s.unit.EnsureDead()
+	c.Assert(err, gc.IsNil)
+	err = s.unit.Remove()
+	c.Assert(err, gc.IsNil)
+	code, info, err := s.unit.GetMeterStatus()
+	c.Assert(err, gc.ErrorMatches, "cannot retrieve meter status for unit .*: not found")
+	c.Assert(code, gc.Equals, "NOT AVAILABLE")
+	c.Assert(info, gc.Equals, "")
+}

--- a/state/service.go
+++ b/state/service.go
@@ -585,6 +585,9 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	sdoc := statusDoc{
 		Status: StatusPending,
 	}
+	msdoc := meterStatusDoc{
+		Code: MeterNotSet,
+	}
 	ops := []txn.Op{
 		{
 			C:      unitsC,
@@ -593,6 +596,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 			Insert: udoc,
 		},
 		createStatusOp(s.st, globalKey, sdoc),
+		createMeterStatusOp(s.st, globalKey, msdoc),
 		{
 			C:      servicesC,
 			Id:     s.doc.DocID,
@@ -678,6 +682,7 @@ func (s *Service) removeUnitOps(u *Unit, asserts bson.D) ([]txn.Op, error) {
 	},
 		removeConstraintsOp(s.st, u.globalKey()),
 		removeStatusOp(s.st, u.globalKey()),
+		removeMeterStatusOp(s.st, u.globalKey()),
 		annotationRemoveOp(s.st, u.globalKey()),
 		s.st.newCleanupOp(cleanupRemovedUnit, u.doc.Name),
 	)

--- a/state/state.go
+++ b/state/state.go
@@ -67,6 +67,9 @@ const (
 	metricsC           = "metrics"
 	upgradeInfoC       = "upgradeInfo"
 
+	// meterStatusC is the collection used to store meter status information.
+	meterStatusC = "meterStatus"
+
 	// toolsmetadataC is the collection used to store tools metadata.
 	toolsmetadataC = "toolsmetadata"
 

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1235,6 +1235,12 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 	return newEntityWatcher(u.st, settingsC, settingsKey), nil
 }
 
+// WatchMeterStatus returns a watcher observing the changes to the unit's
+// meter status.
+func (u *Unit) WatchMeterStatus() NotifyWatcher {
+	return newEntityWatcher(u.st, meterStatusC, u.globalKey())
+}
+
 func newEntityWatcher(st *State, collName string, key string) NotifyWatcher {
 	w := &entityWatcher{
 		commonWatcher: commonWatcher{st: st},

--- a/upgrades/steps121.go
+++ b/upgrades/steps121.go
@@ -84,5 +84,12 @@ func stepsFor121a2() []Step {
 				return state.MigrateUnitPortsToOpenedPorts(context.State())
 			},
 		},
+		&upgradeStep{
+			description: "create entries in meter status collection for existing units",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.CreateUnitMeterStatus(context.State())
+			},
+		},
 	}
 }

--- a/upgrades/steps121_test.go
+++ b/upgrades/steps121_test.go
@@ -43,6 +43,7 @@ func (s *steps121a2Suite) TestUpgradeOperationsContent(c *gc.C) {
 		"migrate custom image metadata into environment storage",
 		"migrate tools into environment storage",
 		"migrate individual unit ports to openedPorts collection",
+		"create entries in meter status collection for existing units",
 	}
 
 	upgradeSteps := upgrades.StepsFor121a2()

--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -46,6 +46,18 @@ func GetStubActionContext(in map[string]interface{}) *HookContext {
 	}
 }
 
+// PatchMeterStatus changes the meter status of the context.
+func (ctx *HookContext) PatchMeterStatus(code, info string) func() {
+	oldMeterStatus := ctx.meterStatus
+	ctx.meterStatus = &meterStatus{
+		code: code,
+		info: info,
+	}
+	return func() {
+		ctx.meterStatus = oldMeterStatus
+	}
+}
+
 var MergeEnvironment = mergeEnvironment
 
 var SearchHook = searchHook

--- a/worker/uniter/filter_test.go
+++ b/worker/uniter/filter_test.go
@@ -668,3 +668,44 @@ func (s *FilterSuite) addRelation(c *gc.C) *state.Relation {
 	c.Assert(err, gc.IsNil)
 	return rel
 }
+
+func (s *FilterSuite) TestMeterStatusEvents(c *gc.C) {
+	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	c.Assert(err, gc.IsNil)
+	defer statetesting.AssertStop(c, f)
+
+	assertNoChange := func() {
+		s.BackingState.StartSync()
+		select {
+		case <-f.MeterStatusEvents():
+			c.Fatalf("unexpected meter status event")
+		case <-time.After(coretesting.ShortWait):
+		}
+	}
+	assertChange := func() {
+		s.BackingState.StartSync()
+		select {
+		case _, ok := <-f.MeterStatusEvents():
+			c.Assert(ok, gc.Equals, true)
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out")
+		}
+		assertNoChange()
+	}
+
+	// Initial meter status does not trigger event.
+	assertNoChange()
+
+	// Set unit meter status to trigger event.
+	err = s.unit.SetMeterStatus("GREEN", "Operating normally.")
+	c.Assert(err, gc.IsNil)
+	assertChange()
+
+	// Make sure bundled events arrive properly.
+	for i := 0; i < 5; i++ {
+		err = s.unit.SetMeterStatus("RED", fmt.Sprintf("Update %d.", i))
+		c.Assert(err, gc.IsNil)
+	}
+
+	assertChange()
+}

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -41,7 +41,7 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("%q hook requires a remote unit", hi.Kind)
 		}
 		fallthrough
-	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken, hooks.CollectMetrics:
+	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken, hooks.CollectMetrics, hooks.MeterStatusChanged:
 		return nil
 	case hooks.Action:
 		if !names.IsValidAction(hi.ActionId) {

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -41,6 +41,7 @@ var validateTests = []struct {
 	{hook.Info{Kind: hooks.Start}, ""},
 	{hook.Info{Kind: hooks.ConfigChanged}, ""},
 	{hook.Info{Kind: hooks.CollectMetrics}, ""},
+	{hook.Info{Kind: hooks.MeterStatusChanged}, ""},
 	{
 		hook.Info{Kind: hooks.Action},
 		`action id "" cannot be parsed as an action tag`,

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -246,6 +246,8 @@ func modeAbideAliveLoop(u *Uniter) (Mode, error) {
 			return nil, tomb.ErrDying
 		case <-u.f.UnitDying():
 			return modeAbideDyingLoop(u)
+		case <-u.f.MeterStatusEvents():
+			hi = hook.Info{Kind: hooks.MeterStatusChanged}
 		case <-u.f.ConfigEvents():
 			hi = hook.Info{Kind: hooks.ConfigChanged}
 		case info := <-u.f.ActionEvents():

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1306,6 +1306,19 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 	s.runUniterTests(c, relationsErrorTests)
 }
 
+var meterStatusEventTests = []uniterTest{
+	ut(
+		"meter status event triggered by unit meter status change",
+		quickStart{},
+		changeMeterStatus{"AMBER", "Investigate charm."},
+		waitHooks{"meter-status-changed"},
+	),
+}
+
+func (s *UniterSuite) TestUniterMeterStatusChanged(c *gc.C) {
+	s.runUniterTests(c, meterStatusEventTests)
+}
+
 var actionEventTests = []uniterTest{
 	ut(
 		"simple action event: defined in actions.yaml, no args",
@@ -1722,7 +1735,7 @@ type createCharm struct {
 var charmHooks = []string{
 	"install", "start", "config-changed", "upgrade-charm", "stop",
 	"db-relation-joined", "db-relation-changed", "db-relation-departed",
-	"db-relation-broken",
+	"db-relation-broken", "meter-status-changed",
 }
 
 func (s createCharm) step(c *gc.C, ctx *context) {
@@ -2237,6 +2250,16 @@ type fixHook struct {
 func (s fixHook) step(c *gc.C, ctx *context) {
 	path := filepath.Join(ctx.path, "charm", "hooks", s.name)
 	ctx.writeHook(c, path, true)
+}
+
+type changeMeterStatus struct {
+	code string
+	info string
+}
+
+func (s changeMeterStatus) step(c *gc.C, ctx *context) {
+	err := ctx.unit.SetMeterStatus(s.code, s.info)
+	c.Assert(err, gc.IsNil)
 }
 
 type changeConfig map[string]interface{}


### PR DESCRIPTION
Meter status information available as hook context environment variables.

Meter status information will be set per-unit, once the metrics pipeline is in place.
