### PR TITLE
Align metricsDoc.EnvUUID serialization.

### DIFF
--- a/state/metrics.go
+++ b/state/metrics.go
@@ -31,7 +31,7 @@ type MetricBatch struct {
 
 type metricBatchDoc struct {
 	UUID     string    `bson:"_id"`
-	EnvUUID  string    `bson:"envuuid"`
+	EnvUUID  string    `bson:"env-uuid"`
 	Unit     string    `bson:"unit"`
 	CharmUrl string    `bson:"charmurl"`
 	Sent     bool      `bson:"sent"`


### PR DESCRIPTION
Follow the multi-environment document convention of serializing EnvUUID
as "env-uuid".
