### PR TITLE
provider/ec2: set UploadArches for tests

### DIFF
--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -74,6 +74,8 @@ type LiveTests struct {
 }
 
 func (t *LiveTests) SetUpSuite(c *gc.C) {
+	// Upload arches that ec2 supports; add to this
+	// as ec2 coverage expands.
 	t.UploadArches = []string{arch.AMD64, arch.I386}
 	t.BaseSuite.SetUpSuite(c)
 	t.LiveTests.SetUpSuite(c)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -77,6 +77,8 @@ type localLiveSuite struct {
 }
 
 func (t *localLiveSuite) SetUpSuite(c *gc.C) {
+	// Upload arches that ec2 supports; add to this
+	// as ec2 coverage expands.
 	t.UploadArches = []string{arch.AMD64, arch.I386}
 	t.TestConfig = localConfigAttrs
 	t.restoreEC2Patching = patchEC2ForTesting()
@@ -165,6 +167,8 @@ type localServerSuite struct {
 }
 
 func (t *localServerSuite) SetUpSuite(c *gc.C) {
+	// Upload arches that ec2 supports; add to this
+	// as ec2 coverage expands.
 	t.UploadArches = []string{arch.AMD64, arch.I386}
 	t.TestConfig = localConfigAttrs
 	t.restoreEC2Patching = patchEC2ForTesting()


### PR DESCRIPTION
Ensure we upload AMD64 tools in tests,
regardless of host architecture.

Fixes https://bugs.launchpad.net/juju-core/+bug/1372961
