### PR TITLE
state: openedPortsWatcher no longer exposes global keys

### DIFF
--- a/api/firewaller/state_test.go
+++ b/api/firewaller/state_test.go
@@ -87,8 +87,8 @@ func (s *stateSuite) TestWatchOpenedPortsV1(c *gc.C) {
 	wc := statetesting.NewStringsWatcherC(c, s.BackingState, w)
 
 	expectChanges := []string{
-		"m#0#n#juju-public",
-		"m#2#n#juju-public",
+		"0:juju-public",
+		"2:juju-public",
 	}
 	wc.AssertChangeInSingleEvent(expectChanges...)
 	wc.AssertNoChange()
@@ -113,7 +113,7 @@ func (s *stateSuite) TestWatchOpenedPortsV1(c *gc.C) {
 	// Open another port, ensure it's detected.
 	err = s.units[1].OpenPort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
-	wc.AssertChange("m#1#n#juju-public")
+	wc.AssertChange("1:juju-public")
 	wc.AssertNoChange()
 
 	statetesting.AssertStop(c, w)

--- a/apiserver/firewaller/firewaller_v1_test.go
+++ b/apiserver/firewaller/firewaller_v1_test.go
@@ -96,8 +96,8 @@ func (s *firewallerV1Suite) TestWatchOpenedPorts(c *gc.C) {
 
 	s.openPorts(c)
 	expectChanges := []string{
-		"m#0#n#juju-public",
-		"m#2#n#juju-public",
+		"0:juju-public",
+		"2:juju-public",
 	}
 
 	fakeEnvTag := names.NewEnvironTag("deadbeef-deaf-face-feed-0123456789ab")

--- a/state/ports_test.go
+++ b/state/ports_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/juju/errors"
@@ -344,17 +345,17 @@ func (s *PortsDocSuite) TestWatchPorts(c *gc.C) {
 		UnitName: s.unit1.Name(),
 		Protocol: "TCP",
 	}
-	globalKey := state.PortsGlobalKey(s.machine.Id(), network.DefaultPublic)
+	expectChange := fmt.Sprintf("%s:%s", s.machine.Id(), network.DefaultPublic)
 	// Open a port range, detect a change.
 	err := s.ports.OpenPorts(portRange)
 	c.Assert(err, gc.IsNil)
-	wc.AssertChange(globalKey)
+	wc.AssertChange(expectChange)
 	wc.AssertNoChange()
 
 	// Close the port range, detect a change.
 	err = s.ports.ClosePorts(portRange)
 	c.Assert(err, gc.IsNil)
-	wc.AssertChange(globalKey)
+	wc.AssertChange(expectChange)
 	wc.AssertNoChange()
 
 	// Close the port range again, no changes.

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -825,18 +825,16 @@ next:
 }
 
 // parsePortsKey parses a ports document global key coming from the
-// ports watcher (e.g. "m#42#n#juju-public") and returns the machine
-// and network tags from its components (in the last example
-// "machine-42" and "network-juju-public").
-//
-// TODO(dimitern) Change the state opened ports watcher to
-// return "<machine-id>:<network-name>" (i.e. "0:juju-public").
-func parsePortsKey(globalKey string) (machineTag names.MachineTag, networkTag names.NetworkTag, err error) {
-	defer errors.Maskf(&err, "invalid ports global key %q", globalKey)
+// ports watcher (e.g. "42:juju-public") and returns the machine and
+// network tags from its components (in the last example "machine-42"
+// and "network-juju-public").
+func parsePortsKey(change string) (machineTag names.MachineTag, networkTag names.NetworkTag, err error) {
+	defer errors.Maskf(&err, "invalid ports change %q", change)
 
-	parts := strings.SplitN(globalKey, "#", 4)
-	if len(parts) != 4 || parts[0] != "m" || parts[2] != "n" {
+	parts := strings.SplitN(change, ":", 2)
+	if len(parts) != 2 {
 		return names.MachineTag{}, names.NetworkTag{}, errors.Errorf("unexpected format")
 	}
-	return names.NewMachineTag(parts[1]), names.NewNetworkTag(parts[3]), nil
+	machineId, networkName := parts[0], parts[1]
+	return names.NewMachineTag(machineId), names.NewNetworkTag(networkName), nil
 }


### PR DESCRIPTION
Follow-up to #799: the openedPortsWatcher in state now
reports changes as "<machine-id>:<network-name>", rather
than as global keys ("m#<id>#n#<name>"), as this exposes
internal state details unnecessarily.

NOTE: Already approved as https://github.com/dimitern/juju/pull/1
and http://reviews.vapour.ws/r/85/, just re-proposing against juju:master.
