### PR TITLE
Fix 1373611 dont fail when backup is HA

### DIFF
--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -303,9 +303,6 @@ func rebootstrap(cfg *config.Config, ctx *cmd.Context, cons constraints.Value) (
 	if len(instanceIds) == 0 {
 		return nil, fmt.Errorf("no instances found; perhaps the environment was not bootstrapped")
 	}
-	if len(instanceIds) > 1 {
-		return nil, fmt.Errorf("restore does not support HA juju configurations yet")
-	}
 	inst, err := env.Instances(instanceIds)
 	if err == nil {
 		return nil, fmt.Errorf("old bootstrap instance %q still seems to exist; will not replace", inst)


### PR DESCRIPTION
Remove a verification on restore that is outdated.
In the past it was not possible to restore to an HA environment, 
this restriction has been lifted and this error is deprecated
