### PR TITLE
Better EnvironTag validation

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -136,7 +136,7 @@ func (st *State) Provisioner() *provisioner.State {
 func (st *State) Uniter() (*uniter.State, error) {
 	unitTag, ok := st.authTag.(names.UnitTag)
 	if !ok {
-		return nil, errors.Errorf("invalid authenticated unit tag %q", st.authTag)
+		return nil, errors.Errorf("expected UnitTag, got %T %v", st.authTag, st.authTag)
 	}
 	envTag, err := st.EnvironTag()
 	if err != nil {

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -87,7 +87,7 @@ func (s *stateSuite) TestLoginSetsEnvironTag(c *gc.C) {
 	// Now that we've logged in, EnvironTag should be updated correctly.
 	envTag, err = apistate.EnvironTag()
 	c.Check(err, gc.IsNil)
-	c.Check(envTag.String(), gc.Equals, env.EnvironTag().String())
+	c.Check(envTag, gc.Equals, env.EnvironTag())
 }
 
 func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {

--- a/apiserver/metricsmanager/metricsmanager.go
+++ b/apiserver/metricsmanager/metricsmanager.go
@@ -58,7 +58,7 @@ func NewMetricsManagerAPI(
 			if tag == nil {
 				return false
 			}
-			return tag.String() == st.EnvironTag().String()
+			return tag == st.EnvironTag()
 		}, nil
 	}
 


### PR DESCRIPTION
Implemented a few suggestions from http://reviews.vapour.ws/r/96/:
- Added validation of the EnvironTag on the API connection.
- Better checks in tests comparing EnvironTags.
