### PR TITLE
Fix minor `go tool vet` warning

### DIFF
--- a/worker/deployer/simple_test.go
+++ b/worker/deployer/simple_test.go
@@ -247,7 +247,7 @@ func (fix *SimpleToolsFixture) checkUnitRemoved(c *gc.C, name string) {
 	for _, path := range []string{confPath, agentDir, toolsDir} {
 		_, err := ioutil.ReadFile(path)
 		if err == nil {
-			c.Log("Warning: %q not removed as expected", path)
+			c.Logf("Warning: %q not removed as expected", path)
 		} else {
 			c.Assert(err, jc.Satisfies, os.IsNotExist)
 		}


### PR DESCRIPTION
Was getting:

```
$ go tool vet -methods -printf -rangeloops .
worker/deployer/simple_test.go:250: possible formatting directive in Log call
```
