### PR TITLE
UniterAPI: OpenPorts and ClosePorts added

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -303,11 +303,49 @@ func (u *Unit) PrivateAddress() (string, error) {
 	return result.Result, nil
 }
 
+// OpenPorts sets the policy of the port range with protocol to be
+// opened.
+func (u *Unit) OpenPorts(protocol string, fromPort, toPort int) error {
+	var result params.ErrorResults
+	args := params.EntitiesPortRanges{
+		Entities: []params.EntityPortRange{{
+			Tag:      u.tag.String(),
+			Protocol: protocol,
+			FromPort: fromPort,
+			ToPort:   toPort,
+		}},
+	}
+	err := u.st.facade.FacadeCall("OpenPorts", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}
+
+// ClosePorts sets the policy of the port range with protocol to be
+// closed.
+func (u *Unit) ClosePorts(protocol string, fromPort, toPort int) error {
+	var result params.ErrorResults
+	args := params.EntitiesPortRanges{
+		Entities: []params.EntityPortRange{{
+			Tag:      u.tag.String(),
+			Protocol: protocol,
+			FromPort: fromPort,
+			ToPort:   toPort,
+		}},
+	}
+	err := u.st.facade.FacadeCall("ClosePorts", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}
+
 // OpenPort sets the policy of the port with protocol and number to be
 // opened.
 //
-// TODO: We should really be opening and closing ports on machines,
-// rather than units.
+// TODO(dimitern): This is deprecated and is kept for
+// backwards-compatibility. Use OpenPorts instead.
 func (u *Unit) OpenPort(protocol string, number int) error {
 	var result params.ErrorResults
 	args := params.EntitiesPorts{
@@ -325,8 +363,8 @@ func (u *Unit) OpenPort(protocol string, number int) error {
 // ClosePort sets the policy of the port with protocol and number to
 // be closed.
 //
-// TODO: We should really be opening and closing ports on machines,
-// rather than units.
+// TODO(dimitern): This is deprecated and is kept for
+// backwards-compatibility. Use ClosePorts instead.
 func (u *Unit) ClosePort(protocol string, number int) error {
 	var result params.ErrorResults
 	args := params.EntitiesPorts{

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -226,6 +226,42 @@ func (s *unitSuite) TestPrivateAddress(c *gc.C) {
 	c.Assert(address, gc.Equals, "1.2.3.4")
 }
 
+func (s *unitSuite) TestOpenClosePortRanges(c *gc.C) {
+	ports, err := s.wordpressUnit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(ports, gc.HasLen, 0)
+
+	err = s.apiUnit.OpenPorts("tcp", 1234, 1400)
+	c.Assert(err, gc.IsNil)
+	err = s.apiUnit.OpenPorts("udp", 4321, 5000)
+	c.Assert(err, gc.IsNil)
+
+	ports, err = s.wordpressUnit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	// OpenedPorts returns a sorted slice.
+	c.Assert(ports, gc.DeepEquals, []network.PortRange{
+		{Protocol: "tcp", FromPort: 1234, ToPort: 1400},
+		{Protocol: "udp", FromPort: 4321, ToPort: 5000},
+	})
+
+	err = s.apiUnit.ClosePorts("udp", 4321, 5000)
+	c.Assert(err, gc.IsNil)
+
+	ports, err = s.wordpressUnit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	// OpenedPorts returns a sorted slice.
+	c.Assert(ports, gc.DeepEquals, []network.PortRange{
+		{Protocol: "tcp", FromPort: 1234, ToPort: 1400},
+	})
+
+	err = s.apiUnit.ClosePorts("tcp", 1234, 1400)
+	c.Assert(err, gc.IsNil)
+
+	ports, err = s.wordpressUnit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(ports, gc.HasLen, 0)
+}
+
 func (s *unitSuite) TestOpenClosePort(c *gc.C) {
 	ports, err := s.wordpressUnit.OpenedPorts()
 	c.Assert(err, gc.IsNil)
@@ -236,8 +272,6 @@ func (s *unitSuite) TestOpenClosePort(c *gc.C) {
 	err = s.apiUnit.OpenPort("tcp", 4321)
 	c.Assert(err, gc.IsNil)
 
-	err = s.wordpressUnit.Refresh()
-	c.Assert(err, gc.IsNil)
 	ports, err = s.wordpressUnit.OpenedPorts()
 	c.Assert(err, gc.IsNil)
 	// OpenedPorts returns a sorted slice.
@@ -249,8 +283,6 @@ func (s *unitSuite) TestOpenClosePort(c *gc.C) {
 	err = s.apiUnit.ClosePort("tcp", 4321)
 	c.Assert(err, gc.IsNil)
 
-	err = s.wordpressUnit.Refresh()
-	c.Assert(err, gc.IsNil)
 	ports, err = s.wordpressUnit.OpenedPorts()
 	c.Assert(err, gc.IsNil)
 	// OpenedPorts returns a sorted slice.
@@ -261,8 +293,6 @@ func (s *unitSuite) TestOpenClosePort(c *gc.C) {
 	err = s.apiUnit.ClosePort("tcp", 1234)
 	c.Assert(err, gc.IsNil)
 
-	err = s.wordpressUnit.Refresh()
-	c.Assert(err, gc.IsNil)
 	ports, err = s.wordpressUnit.OpenedPorts()
 	c.Assert(err, gc.IsNil)
 	c.Assert(ports, gc.HasLen, 0)

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -310,6 +310,20 @@ type EntitiesPorts struct {
 	Entities []EntityPort
 }
 
+// EntityPortRange holds an entity's tag, a protocol and a port range.
+type EntityPortRange struct {
+	Tag      string
+	Protocol string
+	FromPort int
+	ToPort   int
+}
+
+// EntitiesPortRanges holds the parameters for making an OpenPorts or
+// ClosePorts on some entities.
+type EntitiesPortRanges struct {
+	Entities []EntityPortRange
+}
+
 // EntityCharmURL holds an entity's tag and a charm URL.
 type EntityCharmURL struct {
 	Tag      string


### PR DESCRIPTION
Introduced OpenPorts and ClosePorts uniter API
methods, which allow opening and closing port
ranges on units. The existing OpenPort and ClosePort
methods are left for backwards-compatibility, but
internally they use the new methods.

NOTE: Already approved as http://reviews.vapour.ws/r/111/
This PR just re-targets the branch against juju:master
