### PR TITLE
uniter: open-port and close-port accept ranges

### DIFF
--- a/worker/uniter/context.go
+++ b/worker/uniter/context.go
@@ -170,12 +170,12 @@ func (ctx *HookContext) PrivateAddress() (string, bool) {
 	return ctx.privateAddress, ctx.privateAddress != ""
 }
 
-func (ctx *HookContext) OpenPort(protocol string, port int) error {
-	return ctx.unit.OpenPort(protocol, port)
+func (ctx *HookContext) OpenPorts(protocol string, fromPort, toPort int) error {
+	return ctx.unit.OpenPorts(protocol, fromPort, toPort)
 }
 
-func (ctx *HookContext) ClosePort(protocol string, port int) error {
-	return ctx.unit.ClosePort(protocol, port)
+func (ctx *HookContext) ClosePorts(protocol string, fromPort, toPort int) error {
+	return ctx.unit.ClosePorts(protocol, fromPort, toPort)
 }
 
 func (ctx *HookContext) OwnerTag() string {

--- a/worker/uniter/jujuc/context.go
+++ b/worker/uniter/jujuc/context.go
@@ -27,14 +27,14 @@ type Context interface {
 	// PrivateAddress returns the executing unit's private address.
 	PrivateAddress() (string, bool)
 
-	// OpenPort marks the supplied port for opening when the executing unit's
-	// service is exposed.
-	OpenPort(protocol string, port int) error
+	// OpenPorst marks the supplied port range for opening when the
+	// executing unit's service is exposed.
+	OpenPorts(protocol string, fromPort, toPort int) error
 
-	// ClosePort ensures the supplied port is closed even when the executing
-	// unit's service is exposed (unless it is opened separately by a co-
-	// located unit).
-	ClosePort(protocol string, port int) error
+	// ClosePorts ensures the supplied port range is closed even when
+	// the executing unit's service is exposed (unless it is opened
+	// separately by a co- located unit).
+	ClosePorts(protocol string, fromPort, toPort int) error
 
 	// Config returns the current service configuration of the executing unit.
 	ConfigSettings() (charm.Settings, error)

--- a/worker/uniter/jujuc/ports_test.go
+++ b/worker/uniter/jujuc/ports_test.go
@@ -25,7 +25,12 @@ var portsTests = []struct {
 }{
 	{[]string{"open-port", "80"}, set.NewStrings("80/tcp")},
 	{[]string{"open-port", "99/tcp"}, set.NewStrings("80/tcp", "99/tcp")},
-	{[]string{"close-port", "80/TCP"}, set.NewStrings("99/tcp")},
+	{[]string{"open-port", "100-200"}, set.NewStrings("80/tcp", "99/tcp", "100-200/tcp")},
+	{[]string{"open-port", "443/udp"}, set.NewStrings("80/tcp", "99/tcp", "100-200/tcp", "443/udp")},
+	{[]string{"close-port", "80/TCP"}, set.NewStrings("99/tcp", "100-200/tcp", "443/udp")},
+	{[]string{"close-port", "100-200/tcP"}, set.NewStrings("99/tcp", "443/udp")},
+	{[]string{"close-port", "443"}, set.NewStrings("99/tcp", "443/udp")},
+	{[]string{"close-port", "443/udp"}, set.NewStrings("99/tcp")},
 	{[]string{"open-port", "123/udp"}, set.NewStrings("99/tcp", "123/udp")},
 	{[]string{"close-port", "9999/UDP"}, set.NewStrings("99/tcp", "123/udp")},
 }
@@ -48,13 +53,19 @@ var badPortsTests = []struct {
 	args []string
 	err  string
 }{
-	{nil, "no port specified"},
+	{nil, "no port or range specified"},
 	{[]string{"0"}, `port must be in the range \[1, 65535\]; got "0"`},
 	{[]string{"65536"}, `port must be in the range \[1, 65535\]; got "65536"`},
-	{[]string{"two"}, `port must be in the range \[1, 65535\]; got "two"`},
+	{[]string{"two"}, `expected <port>\[/<protocol>\] or <from>-<to>\[/<protocol>\]; got "two"`},
 	{[]string{"80/http"}, `protocol must be "tcp" or "udp"; got "http"`},
-	{[]string{"blah/blah/blah"}, `expected <port>\[/<protocol>\]; got "blah/blah/blah"`},
+	{[]string{"blah/blah/blah"}, `expected <port>\[/<protocol>\] or <from>-<to>\[/<protocol>\]; got "blah/blah/blah"`},
 	{[]string{"123", "haha"}, `unrecognized args: \["haha"\]`},
+	{[]string{"1-0"}, `invalid port range 1-0/tcp; expected fromPort <= toPort`},
+	{[]string{"-42"}, `flag provided but not defined: -4`},
+	{[]string{"99999/UDP"}, `port must be in the range \[1, 65535\]; got "99999"`},
+	{[]string{"9999/foo"}, `protocol must be "tcp" or "udp"; got "foo"`},
+	{[]string{"80-90/http"}, `protocol must be "tcp" or "udp"; got "http"`},
+	{[]string{"20-10/tcp"}, `invalid port range 20-10/tcp; expected fromPort <= toPort`},
 }
 
 func (s *PortsSuite) TestBadArgs(c *gc.C) {
@@ -75,17 +86,17 @@ func (s *PortsSuite) TestHelp(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	flags := testing.NewFlagSet()
 	c.Assert(string(open.Info().Help(flags)), gc.Equals, `
-usage: open-port <port>[/<protocol>]
-purpose: register a port to open
+usage: open-port <port>[/<protocol>] or <from>-<to>[/<protocol>]
+purpose: register a port or range to open
 
-The port will only be open while the service is exposed.
+The port range will only be open while the service is exposed.
 `[1:])
 
 	close, err := jujuc.NewCommand(hctx, cmdString("close-port"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(close.Info().Help(flags)), gc.Equals, `
-usage: close-port <port>[/<protocol>]
-purpose: ensure a port is always closed
+usage: close-port <port>[/<protocol>] or <from>-<to>[/<protocol>]
+purpose: ensure a port or range is always closed
 `[1:])
 }
 

--- a/worker/uniter/jujuc/util_test.go
+++ b/worker/uniter/jujuc/util_test.go
@@ -110,13 +110,21 @@ func (c *Context) PrivateAddress() (string, bool) {
 	return "192.168.0.99", true
 }
 
-func (c *Context) OpenPort(protocol string, port int) error {
-	c.ports.Add(fmt.Sprintf("%d/%s", port, protocol))
+func (c *Context) OpenPorts(protocol string, fromPort, toPort int) error {
+	if fromPort == toPort {
+		c.ports.Add(fmt.Sprintf("%d/%s", fromPort, protocol))
+	} else {
+		c.ports.Add(fmt.Sprintf("%d-%d/%s", fromPort, toPort, protocol))
+	}
 	return nil
 }
 
-func (c *Context) ClosePort(protocol string, port int) error {
-	c.ports.Remove(fmt.Sprintf("%d/%s", port, protocol))
+func (c *Context) ClosePorts(protocol string, fromPort, toPort int) error {
+	if fromPort == toPort {
+		c.ports.Remove(fmt.Sprintf("%d/%s", fromPort, protocol))
+	} else {
+		c.ports.Remove(fmt.Sprintf("%d-%d/%s", fromPort, toPort, protocol))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Hook tools "open-port" and "close-port" changed to accept
both "<port>[/<protocol>]" and "<from>-<to>[/<protocol>]".
Uniter hook context changed to call unit.OpenPorts and
unit.ClosePorts. Added more tests and better validation.

When this lands, charms can start opening and closing
port ranges instead of single ports.

NOTE: Already approved as http://reviews.vapour.ws/r/112/.
This PR just re-targets the branch against juju:master
