### PR TITLE
uniter: open(close)-port now sandboxed until hook is committed

### DIFF
--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -5,6 +5,9 @@ package uniter
 
 import (
 	"github.com/juju/utils/proxy"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/worker/uniter/jujuc"
 )
 
 func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
@@ -24,3 +27,7 @@ var SearchHook = searchHook
 var HookCommand = hookCommand
 
 var LookPath = lookPath
+
+func ContextPortRanges(ctx jujuc.Context) map[network.PortRange]bool {
+	return ctx.(*HookContext).portRanges
+}

--- a/worker/uniter/jujuc/context.go
+++ b/worker/uniter/jujuc/context.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 )
 
 // Context is the interface that all hook helper commands
@@ -35,6 +36,14 @@ type Context interface {
 	// the executing unit's service is exposed (unless it is opened
 	// separately by a co- located unit).
 	ClosePorts(protocol string, fromPort, toPort int) error
+
+	// OpeningPorts returns all port ranges for the unit pending to be
+	// opened when the current hook it committed.
+	OpeningPorts() []network.PortRange
+
+	// ClosingPorts returns all port ranges for the unit pending to be
+	// closed when the current hook it committed.
+	ClosingPorts() []network.PortRange
 
 	// Config returns the current service configuration of the executing unit.
 	ConfigSettings() (charm.Settings, error)


### PR DESCRIPTION
An important improvement in supporting opening and
closing port ranges for charms is to also provide
sandboxing for these operations. This PR implements
an internal caching of all pending port ranges to
open or close for the unit, and only actually tries
to open or close them when a hook is run and about to
be committed.
