### PR TITLE
UniterAPI split into V0 and V1, improved tests, fixed tags types

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -32,7 +32,7 @@ var facadeVersions = map[string]int{
 	"Upgrader":             0,
 	"Firewaller":           1,
 	"Rsyslog":              0,
-	"Uniter":               0,
+	"Uniter":               1,
 	"Actions":              0,
 }
 

--- a/api/uniter/export_test.go
+++ b/api/uniter/export_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/juju/juju/api/base/testing"
 )
 
-var NewSettings = newSettings
+var (
+	NewSettings = newSettings
+	NewStateV0  = newStateV0
+	NewStateV1  = newStateV1
+)
 
 // PatchResponses changes the internal FacadeCaller to one that lets you return
 // canned results. The responseFunc will get the 'response' interface object,

--- a/api/uniter/package_test.go
+++ b/api/uniter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/api/uniter/relation.go
+++ b/api/uniter/relation.go
@@ -23,6 +23,11 @@ type Relation struct {
 	life params.Life
 }
 
+// Tag returns the relation tag.
+func (r *Relation) Tag() names.RelationTag {
+	return r.tag
+}
+
 // String returns the relation as a string.
 func (r *Relation) String() string {
 	return r.tag.Id()

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -27,7 +27,7 @@ func (s *relationSuite) SetUpTest(c *gc.C) {
 	s.commonRelationSuiteMixin.SetUpTest(c, s.uniterSuite)
 
 	var err error
-	s.apiRelation, err = s.uniter.Relation(s.stateRelation.Tag().String())
+	s.apiRelation, err = s.uniter.Relation(s.stateRelation.Tag().(names.RelationTag))
 	c.Assert(err, gc.IsNil)
 }
 
@@ -39,8 +39,9 @@ func (s *relationSuite) TestString(c *gc.C) {
 	c.Assert(s.apiRelation.String(), gc.Equals, "wordpress:db mysql:server")
 }
 
-func (s *relationSuite) TestId(c *gc.C) {
+func (s *relationSuite) TestIdAndTag(c *gc.C) {
 	c.Assert(s.apiRelation.Id(), gc.Equals, s.stateRelation.Id())
+	c.Assert(s.apiRelation.Tag(), gc.Equals, s.stateRelation.Tag().(names.RelationTag))
 }
 
 func (s *relationSuite) TestRefresh(c *gc.C) {

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -56,7 +56,7 @@ func (s *relationUnitSuite) TearDownTest(c *gc.C) {
 func (s *relationUnitSuite) getRelationUnits(c *gc.C) (*state.RelationUnit, *uniter.RelationUnit) {
 	wpRelUnit, err := s.stateRelation.Unit(s.wordpressUnit)
 	c.Assert(err, gc.IsNil)
-	apiRelation, err := s.uniter.Relation(s.stateRelation.Tag().String())
+	apiRelation, err := s.uniter.Relation(s.stateRelation.Tag().(names.RelationTag))
 	c.Assert(err, gc.IsNil)
 	// TODO(dfc)
 	apiUnit, err := s.uniter.Unit(s.wordpressUnit.Tag().(names.UnitTag))
@@ -164,7 +164,7 @@ func (s *relationUnitSuite) TestEnterScopeErrCannotEnterScopeYet(c *gc.C) {
 
 	apiUnit, err := s.uniter.Unit(s.wordpressUnit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
-	apiRel, err := s.uniter.Relation(subRel.Tag().String())
+	apiRel, err := s.uniter.Relation(subRel.Tag().(names.RelationTag))
 	c.Assert(err, gc.IsNil)
 	apiRelUnit, err := apiRel.Unit(apiUnit)
 	c.Assert(err, gc.IsNil)
@@ -262,7 +262,7 @@ func (s *relationUnitSuite) TestWatchRelationUnits(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	s.assertInScope(c, myRelUnit, true)
 
-	apiRel, err := s.uniter.Relation(s.stateRelation.Tag().String())
+	apiRel, err := s.uniter.Relation(s.stateRelation.Tag().(names.RelationTag))
 	c.Assert(err, gc.IsNil)
 	apiUnit, err := s.uniter.Unit(names.NewUnitTag("wordpress/0"))
 	c.Assert(err, gc.IsNil)

--- a/api/uniter/settings_test.go
+++ b/api/uniter/settings_test.go
@@ -107,7 +107,7 @@ func (s *settingsSuite) TestWrite(c *gc.C) {
 
 	apiUnit, err := s.uniter.Unit(s.wordpressUnit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
-	apiRelation, err := s.uniter.Relation(s.stateRelation.Tag().String())
+	apiRelation, err := s.uniter.Relation(s.stateRelation.Tag().(names.RelationTag))
 	c.Assert(err, gc.IsNil)
 	apiRelUnit, err := apiRelation.Unit(apiUnit)
 	c.Assert(err, gc.IsNil)

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -5,7 +5,7 @@ package uniter_test
 
 import (
 	"fmt"
-	"sort"
+	"net/url"
 	"time"
 
 	"github.com/juju/errors"
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
@@ -37,17 +38,13 @@ func (s *unitSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *unitSuite) TearDownTest(c *gc.C) {
-	s.uniterSuite.TearDownTest(c)
-}
-
 func (s *unitSuite) TestUnitAndUnitTag(c *gc.C) {
 	apiUnitFoo, err := s.uniter.Unit(names.NewUnitTag("foo/42"))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(apiUnitFoo, gc.IsNil)
 
-	c.Assert(s.apiUnit.Tag(), gc.Equals, "unit-wordpress-0")
+	c.Assert(s.apiUnit.Tag(), gc.Equals, s.wordpressUnit.Tag().(names.UnitTag))
 }
 
 func (s *unitSuite) TestSetStatus(c *gc.C) {
@@ -180,6 +177,22 @@ func (s *unitSuite) TestResolve(c *gc.C) {
 	mode, err = s.apiUnit.Resolved()
 	c.Assert(err, gc.IsNil)
 	c.Assert(mode, gc.Equals, params.ResolvedNone)
+}
+
+func (s *unitSuite) TestAssignedMachineV0NotImplemented(c *gc.C) {
+	s.patchNewState(c, uniter.NewStateV0)
+
+	_, err := s.apiUnit.AssignedMachine()
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+	c.Assert(err.Error(), gc.Equals, "unit.AssignedMachine() (need V1+) not implemented")
+}
+
+func (s *unitSuite) TestAssignedMachineV1(c *gc.C) {
+	s.patchNewState(c, uniter.NewStateV1)
+
+	machineTag, err := s.apiUnit.AssignedMachine()
+	c.Assert(err, gc.IsNil)
+	c.Assert(machineTag, gc.Equals, s.wordpressMachine.Tag())
 }
 
 func (s *unitSuite) TestIsPrincipal(c *gc.C) {
@@ -478,8 +491,8 @@ func (s *unitSuite) TestWatchActionsMoreResults(c *gc.C) {
 }
 
 func (s *unitSuite) TestServiceNameAndTag(c *gc.C) {
-	c.Assert(s.apiUnit.ServiceName(), gc.Equals, "wordpress")
-	c.Assert(s.apiUnit.ServiceTag(), gc.Equals, "service-wordpress")
+	c.Assert(s.apiUnit.ServiceName(), gc.Equals, s.wordpressService.Name())
+	c.Assert(s.apiUnit.ServiceTag(), gc.Equals, s.wordpressService.Tag())
 }
 
 func (s *unitSuite) TestJoinedRelations(c *gc.C) {
@@ -490,13 +503,17 @@ func (s *unitSuite) TestJoinedRelations(c *gc.C) {
 	rel1, _, _ := s.addRelatedService(c, "wordpress", "monitoring", s.wordpressUnit)
 	joinedRelations, err = s.apiUnit.JoinedRelations()
 	c.Assert(err, gc.IsNil)
-	c.Assert(joinedRelations, gc.DeepEquals, []string{rel1.Tag().String()})
+	c.Assert(joinedRelations, gc.DeepEquals, []names.RelationTag{
+		rel1.Tag().(names.RelationTag),
+	})
 
 	rel2, _, _ := s.addRelatedService(c, "wordpress", "logging", s.wordpressUnit)
 	joinedRelations, err = s.apiUnit.JoinedRelations()
 	c.Assert(err, gc.IsNil)
-	sort.Strings(joinedRelations)
-	c.Assert(joinedRelations, gc.DeepEquals, []string{rel2.Tag().String(), rel1.Tag().String()})
+	c.Assert(joinedRelations, gc.DeepEquals, []names.RelationTag{
+		rel2.Tag().(names.RelationTag),
+		rel1.Tag().(names.RelationTag),
+	})
 }
 
 func (s *unitSuite) TestWatchAddresses(c *gc.C) {
@@ -647,4 +664,14 @@ func (s *unitSuite) TestWatchMeterStatus(c *gc.C) {
 
 	statetesting.AssertStop(c, w)
 	wc.AssertClosed()
+}
+
+func (s *unitSuite) patchNewState(
+	c *gc.C,
+	patchFunc func(_ base.APICaller, _ names.UnitTag, _ *url.URL) *uniter.State,
+) {
+	s.uniterSuite.patchNewState(c, patchFunc)
+	var err error
+	s.apiUnit, err = s.uniter.Unit(s.wordpressUnit.Tag().(names.UnitTag))
+	c.Assert(err, gc.IsNil)
 }

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 )
 
 const uniterFacade = "Uniter"
@@ -30,9 +32,19 @@ type State struct {
 	charmsURL *url.URL
 }
 
-// NewState creates a new client-side Uniter facade.
-func NewState(caller base.APICaller, authTag names.UnitTag, charmsURL *url.URL) *State {
-	facadeCaller := base.NewFacadeCaller(caller, uniterFacade)
+// newStateForVersion creates a new client-side Uniter facade for the
+// given version.
+func newStateForVersion(
+	caller base.APICaller,
+	authTag names.UnitTag,
+	charmsURL *url.URL,
+	version int,
+) *State {
+	facadeCaller := base.NewFacadeCallerForVersion(
+		caller,
+		uniterFacade,
+		version,
+	)
 	return &State{
 		EnvironWatcher: common.NewEnvironWatcher(facadeCaller),
 		APIAddresser:   common.NewAPIAddresser(facadeCaller),
@@ -40,6 +52,26 @@ func NewState(caller base.APICaller, authTag names.UnitTag, charmsURL *url.URL) 
 		unitTag:        authTag,
 		charmsURL:      charmsURL,
 	}
+}
+
+// newStateV0 creates a new client-side Uniter facade, version 0.
+func newStateV0(caller base.APICaller, authTag names.UnitTag, charmsURL *url.URL) *State {
+	return newStateForVersion(caller, authTag, charmsURL, 0)
+}
+
+// newStateV1 creates a new client-side Uniter facade, version 1.
+func newStateV1(caller base.APICaller, authTag names.UnitTag, charmsURL *url.URL) *State {
+	return newStateForVersion(caller, authTag, charmsURL, 1)
+}
+
+// NewState creates a new client-side Uniter facade.
+// Defined like this to allow patching during tests.
+var NewState = newStateV1
+
+// BestAPIVersion returns the API version that we were able to
+// determine is supported by both the client and the API Server.
+func (st *State) BestAPIVersion() int {
+	return st.facade.BestAPIVersion()
 }
 
 // life requests the lifecycle of the given entity from the server.
@@ -153,18 +185,14 @@ func (st *State) Charm(curl *charm.URL) (*Charm, error) {
 }
 
 // Relation returns the existing relation with the given tag.
-func (st *State) Relation(relationTag string) (*Relation, error) {
-	rtag, err := names.ParseRelationTag(relationTag)
-	if err != nil {
-		return nil, err
-	}
-	result, err := st.relation(rtag, st.unitTag)
+func (st *State) Relation(relationTag names.RelationTag) (*Relation, error) {
+	result, err := st.relation(relationTag, st.unitTag)
 	if err != nil {
 		return nil, err
 	}
 	return &Relation{
 		id:   result.Id,
-		tag:  rtag,
+		tag:  relationTag,
 		life: result.Life,
 		st:   st,
 	}, nil
@@ -255,6 +283,39 @@ func (st *State) Environment() (*Environment, error) {
 		name: result.Name,
 		uuid: result.UUID,
 	}, nil
+}
+
+// AllMachinePorts returns all port ranges currently open on the given
+// machine, mapped to the tags of the unit that opened them and the
+// relation that applies.
+func (st *State) AllMachinePorts(machineTag names.MachineTag) (map[network.PortRange]params.RelationUnit, error) {
+	if st.BestAPIVersion() < 1 {
+		// AllMachinePorts() was introduced in UniterAPIV1.
+		return nil, errors.NotImplementedf("AllMachinePorts() (need V1+)")
+	}
+	var results params.MachinePortsResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: machineTag.String()}},
+	}
+	err := st.facade.FacadeCall("AllMachinePorts", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	portsMap := make(map[network.PortRange]params.RelationUnit)
+	for _, ports := range result.Ports {
+		portsMap[ports.PortRange] = params.RelationUnit{
+			Unit:     ports.UnitTag,
+			Relation: ports.RelationTag,
+		}
+	}
+	return portsMap, nil
 }
 
 // environment1dot16 requests just the UUID of the current environment, when

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -4,16 +4,17 @@
 package uniter_test
 
 import (
-	stdtesting "testing"
+	"net/url"
 
+	"github.com/juju/names"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
-	coretesting "github.com/juju/juju/testing"
 )
 
 // NOTE: This suite is intended for embedding into other suites,
@@ -33,10 +34,6 @@ type uniterSuite struct {
 }
 
 var _ = gc.Suite(&uniterSuite{})
-
-func TestAll(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
-}
 
 func (s *uniterSuite) SetUpTest(c *gc.C) {
 	s.setUpTest(c, true)
@@ -100,4 +97,15 @@ func (s *uniterSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScop
 	ok, err := relUnit.InScope()
 	c.Assert(err, gc.IsNil)
 	c.Assert(ok, gc.Equals, inScope)
+}
+
+func (s *uniterSuite) patchNewState(
+	c *gc.C,
+	patchFunc func(_ base.APICaller, _ names.UnitTag, _ *url.URL) *uniter.State,
+) {
+	s.PatchValue(&uniter.NewState, patchFunc)
+	var err error
+	s.uniter, err = s.st.Uniter()
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.uniter, gc.NotNil)
 }

--- a/apiserver/firewaller/firewaller_base_test.go
+++ b/apiserver/firewaller/firewaller_base_test.go
@@ -4,8 +4,6 @@
 package firewaller_test
 
 import (
-	"reflect"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -418,15 +416,6 @@ func (s *firewallerBaseSuite) assertLife(c *gc.C, index int, expectLife state.Li
 	err := s.machines[index].Refresh()
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.machines[index].Life(), gc.Equals, expectLife)
-}
-
-func (s *firewallerBaseSuite) assertNotImplemented(c *gc.C, apiFacade interface{}, methodName string) {
-	val := reflect.ValueOf(apiFacade)
-	c.Assert(val.IsValid(), jc.IsTrue)
-	indir := reflect.Indirect(val)
-	c.Assert(indir.IsValid(), jc.IsTrue)
-	method := indir.MethodByName(methodName)
-	c.Assert(method.IsValid(), jc.IsFalse)
 }
 
 var commonFakeEntities = []params.Entity{

--- a/apiserver/firewaller/firewaller_test.go
+++ b/apiserver/firewaller/firewaller_test.go
@@ -74,7 +74,7 @@ func (s *firewallerSuite) TestGetExposed(c *gc.C) {
 }
 
 func (s *firewallerSuite) TestOpenedPortsNotImplemented(c *gc.C) {
-	s.assertNotImplemented(c, s.firewaller, "OpenedPorts")
+	apiservertesting.AssertNotImplemented(c, s.firewaller, "OpenedPorts")
 }
 
 func (s *firewallerSuite) TestGetAssignedMachine(c *gc.C) {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -78,10 +78,11 @@ type MachinePorts struct {
 }
 
 // MachinePortRange holds a single port range open on a machine for
-// the given unit tag.
+// the given unit and relation tags.
 type MachinePortRange struct {
-	UnitTag   string
-	PortRange network.PortRange
+	UnitTag     string
+	RelationTag string
+	PortRange   network.PortRange
 }
 
 // MachinePortsParams holds the arguments for making a
@@ -91,14 +92,16 @@ type MachinePortsParams struct {
 }
 
 // MachinePortsResult holds a single result of the
-// FirewallerAPIV1.GetMachinePorts() API call.
+// FirewallerAPIV1.GetMachinePorts() and UniterAPI.AllMachinePorts()
+// API calls.
 type MachinePortsResult struct {
 	Error *Error
 	Ports []MachinePortRange
 }
 
 // MachinePortsResults holds all the results of the
-// FirewallerAPIV1.GetMachinePorts() API call.
+// FirewallerAPIV1.GetMachinePorts() and UniterAPI.AllMachinePorts()
+// API calls.
 type MachinePortsResults struct {
 	Results []MachinePortsResult
 }

--- a/apiserver/testing/errors.go
+++ b/apiserver/testing/errors.go
@@ -5,6 +5,10 @@ package testing
 
 import (
 	"fmt"
+	"reflect"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
 )
@@ -51,4 +55,13 @@ func ServerError(message string) *params.Error {
 
 func PrefixedError(prefix, message string) *params.Error {
 	return ServerError(prefix + message)
+}
+
+func AssertNotImplemented(c *gc.C, apiFacade interface{}, methodName string) {
+	val := reflect.ValueOf(apiFacade)
+	c.Assert(val.IsValid(), jc.IsTrue)
+	indir := reflect.Indirect(val)
+	c.Assert(indir.IsValid(), jc.IsTrue)
+	method := indir.MethodByName(methodName)
+	c.Assert(method.IsValid(), jc.IsFalse)
 }

--- a/apiserver/uniter/package_test.go
+++ b/apiserver/uniter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	stdtesting "testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	coretesting.MgoTestPackage(t)
+}

--- a/apiserver/uniter/uniter_v0.go
+++ b/apiserver/uniter/uniter_v0.go
@@ -1,0 +1,57 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The uniter package implements the API interface used by the uniter
+// worker. This file contains the API facade version 0.
+package uniter
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("Uniter", 0, NewUniterAPIV0)
+}
+
+// UniterAPIV0 implements the API facade version 0, used by the uniter
+// worker.
+type UniterAPIV0 struct {
+	uniterBaseAPI
+}
+
+// NewUniterAPIV0 creates a new instance of the Uniter API, version 0.
+func NewUniterAPIV0(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*UniterAPIV0, error) {
+	baseAPI, err := newUniterBaseAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, err
+	}
+	return &UniterAPIV0{
+		uniterBaseAPI: *baseAPI,
+	}, nil
+}
+
+// GetOwnerTag returns the user tag of the owner of the first given
+// service tag in args.
+//
+// NOTE: This is obsolete and is replaced by ServiceOwner in APIV1,
+// which should be used instead. This method is not propely handling
+// multiple tags and does not check for permissions. See also
+// http://pad.lv/1270795.
+func (u *UniterAPIV0) GetOwnerTag(args params.Entities) (params.StringResult, error) {
+	var nothing params.StringResult
+	tag, err := names.ParseServiceTag(args.Entities[0].Tag)
+	if err != nil {
+		return nothing, common.ErrPerm
+	}
+	service, err := u.getService(tag)
+	if err != nil {
+		return nothing, err
+	}
+	return params.StringResult{
+		Result: service.GetOwnerTag(),
+	}, nil
+}

--- a/apiserver/uniter/uniter_v0_test.go
+++ b/apiserver/uniter/uniter_v0_test.go
@@ -1,0 +1,321 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	commontesting "github.com/juju/juju/apiserver/common/testing"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/apiserver/uniter"
+	"github.com/juju/juju/state"
+)
+
+type uniterV0Suite struct {
+	uniterBaseSuite
+	*commontesting.EnvironWatcherTest
+
+	uniter *uniter.UniterAPIV0
+}
+
+var _ = gc.Suite(&uniterV0Suite{})
+
+func (s *uniterV0Suite) SetUpTest(c *gc.C) {
+	s.uniterBaseSuite.setUpTest(c)
+
+	uniterAPIV0, err := uniter.NewUniterAPIV0(
+		s.State,
+		s.resources,
+		s.authorizer,
+	)
+	c.Assert(err, gc.IsNil)
+	s.uniter = uniterAPIV0
+
+	s.EnvironWatcherTest = commontesting.NewEnvironWatcherTest(
+		s.uniter,
+		s.State,
+		s.resources,
+		commontesting.NoSecrets,
+	)
+}
+
+func (s *uniterV0Suite) TestUniterFailsWithNonUnitAgentUser(c *gc.C) {
+	factory := func(st *state.State, res *common.Resources, auth common.Authorizer) error {
+		_, err := uniter.NewUniterAPIV0(st, res, auth)
+		return err
+	}
+	s.testUniterFailsWithNonUnitAgentUser(c, factory)
+}
+
+func (s *uniterV0Suite) TestSetStatus(c *gc.C) {
+	s.testSetStatus(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestLife(c *gc.C) {
+	s.testLife(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestEnsureDead(c *gc.C) {
+	s.testEnsureDead(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatch(c *gc.C) {
+	s.testWatch(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestPublicAddress(c *gc.C) {
+	s.testPublicAddress(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestPrivateAddress(c *gc.C) {
+	s.testPrivateAddress(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestResolved(c *gc.C) {
+	s.testResolved(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestClearResolved(c *gc.C) {
+	s.testClearResolved(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestGetPrincipal(c *gc.C) {
+	factory := func(
+		st *state.State,
+		resources *common.Resources,
+		authorizer common.Authorizer,
+	) (getPrincipal, error) {
+		return uniter.NewUniterAPIV0(st, resources, authorizer)
+	}
+	s.testGetPrincipal(c, s.uniter, factory)
+}
+
+func (s *uniterV0Suite) TestHasSubordinates(c *gc.C) {
+	s.testHasSubordinates(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestDestroy(c *gc.C) {
+	s.testDestroy(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestDestroyAllSubordinates(c *gc.C) {
+	s.testDestroyAllSubordinates(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestCharmURL(c *gc.C) {
+	s.testCharmURL(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestSetCharmURL(c *gc.C) {
+	s.testSetCharmURL(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestOpenPorts(c *gc.C) {
+	s.testOpenPorts(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestClosePorts(c *gc.C) {
+	s.testClosePorts(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestOpenPort(c *gc.C) {
+	s.testOpenPort(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestClosePort(c *gc.C) {
+	s.testClosePort(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchConfigSettings(c *gc.C) {
+	s.testWatchConfigSettings(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchActions(c *gc.C) {
+	s.testWatchActions(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchPreexistingActions(c *gc.C) {
+	s.testWatchPreexistingActions(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchActionsMalformedTag(c *gc.C) {
+	s.testWatchActionsMalformedTag(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchActionsMalformedUnitName(c *gc.C) {
+	s.testWatchActionsMalformedUnitName(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchActionsNotUnit(c *gc.C) {
+	s.testWatchActionsNotUnit(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchActionsPermissionDenied(c *gc.C) {
+	s.testWatchActionsPermissionDenied(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestConfigSettings(c *gc.C) {
+	s.testConfigSettings(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchServiceRelations(c *gc.C) {
+	s.testWatchServiceRelations(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestCharmArchiveSha256(c *gc.C) {
+	s.testCharmArchiveSha256(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestCurrentEnvironUUID(c *gc.C) {
+	s.testCurrentEnvironUUID(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestCurrentEnvironment(c *gc.C) {
+	s.testCurrentEnvironment(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestActions(c *gc.C) {
+	s.testActions(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestActionsNotPresent(c *gc.C) {
+	s.testActionsNotPresent(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestActionsWrongUnit(c *gc.C) {
+	factory := func(
+		st *state.State,
+		resources *common.Resources,
+		authorizer common.Authorizer,
+	) (actions, error) {
+		return uniter.NewUniterAPIV0(st, resources, authorizer)
+	}
+	s.testActionsWrongUnit(c, factory)
+}
+
+func (s *uniterV0Suite) TestActionsPermissionDenied(c *gc.C) {
+	s.testActionsPermissionDenied(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestFinishActionsSuccess(c *gc.C) {
+	s.testFinishActionsSuccess(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestFinishActionsFailure(c *gc.C) {
+	s.testFinishActionsFailure(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestFinishActionsAuthAccess(c *gc.C) {
+	s.testFinishActionsAuthAccess(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestRelation(c *gc.C) {
+	s.testRelation(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestRelationById(c *gc.C) {
+	s.testRelationById(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestProviderType(c *gc.C) {
+	s.testProviderType(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestEnterScope(c *gc.C) {
+	s.testEnterScope(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestLeaveScope(c *gc.C) {
+	s.testLeaveScope(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestJoinedRelations(c *gc.C) {
+	s.testJoinedRelations(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestReadSettings(c *gc.C) {
+	s.testReadSettings(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestReadSettingsWithNonStringValuesFails(c *gc.C) {
+	s.testReadSettingsWithNonStringValuesFails(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestReadRemoteSettings(c *gc.C) {
+	s.testReadRemoteSettings(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestReadRemoteSettingsWithNonStringValuesFails(c *gc.C) {
+	s.testReadRemoteSettingsWithNonStringValuesFails(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestUpdateSettings(c *gc.C) {
+	s.testUpdateSettings(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchRelationUnits(c *gc.C) {
+	s.testWatchRelationUnits(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestAPIAddresses(c *gc.C) {
+	s.testAPIAddresses(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchUnitAddresses(c *gc.C) {
+	s.testWatchUnitAddresses(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestAddMetrics(c *gc.C) {
+	s.testAddMetrics(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestAddMetricsIncorrectTag(c *gc.C) {
+	s.testAddMetricsIncorrectTag(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestAddMetricsUnauthenticated(c *gc.C) {
+	s.testAddMetricsUnauthenticated(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestGetMeterStatus(c *gc.C) {
+	s.testGetMeterStatus(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestGetMeterStatusUnauthenticated(c *gc.C) {
+	s.testGetMeterStatusUnauthenticated(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestGetMeterStatusBadTag(c *gc.C) {
+	s.testGetMeterStatusBadTag(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestWatchMeterStatus(c *gc.C) {
+	s.testWatchMeterStatus(c, s.uniter)
+}
+
+func (s *uniterV0Suite) TestGetOwnerTag(c *gc.C) {
+	tag := s.mysql.Tag().String()
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: tag},
+	}}
+	result, err := s.uniter.GetOwnerTag(args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, params.StringResult{
+		Result: s.AdminUserTag(c).String(),
+	})
+}
+
+func (s *uniterV0Suite) TestServiceOwnerV0NotImplemented(c *gc.C) {
+	apiservertesting.AssertNotImplemented(c, s.uniter, "ServiceOwner")
+}
+
+func (s *uniterV0Suite) TestAssignedMachineV0NotImplemented(c *gc.C) {
+	apiservertesting.AssertNotImplemented(c, s.uniter, "AssignedMachine")
+}
+
+func (s *uniterV0Suite) TestAllMachinePortsV0NotImplemented(c *gc.C) {
+	apiservertesting.AssertNotImplemented(c, s.uniter, "AllMachinePorts")
+}

--- a/apiserver/uniter/uniter_v1.go
+++ b/apiserver/uniter/uniter_v1.go
@@ -1,0 +1,173 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The uniter package implements the API interface used by the uniter
+// worker. This file contains the API facade version 1.
+package uniter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("Uniter", 1, NewUniterAPIV1)
+}
+
+// UniterAPI implements the API version 1, used by the uniter worker.
+type UniterAPIV1 struct {
+	uniterBaseAPI
+
+	accessMachine common.GetAuthFunc
+}
+
+// NewUniterAPIV1 creates a new instance of the Uniter API, version 1.
+func NewUniterAPIV1(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*UniterAPIV1, error) {
+	baseAPI, err := newUniterBaseAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, err
+	}
+	accessMachine := func() (common.AuthFunc, error) {
+		switch tag := authorizer.GetAuthTag().(type) {
+		case names.UnitTag:
+			entity, err := st.Unit(tag.Id())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			machineId, err := entity.AssignedMachineId()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			machineTag := names.NewMachineTag(machineId)
+			return func(tag names.Tag) bool {
+				return tag == machineTag
+			}, nil
+		default:
+			return nil, errors.Errorf("expected names.UnitTag, got %T", tag)
+		}
+	}
+	return &UniterAPIV1{
+		uniterBaseAPI: *baseAPI,
+
+		accessMachine: accessMachine,
+	}, nil
+}
+
+// AllMachinePorts returns all opened port ranges for each given
+// machine (on all networks).
+func (u *UniterAPIV1) AllMachinePorts(args params.Entities) (params.MachinePortsResults, error) {
+	result := params.MachinePortsResults{
+		Results: make([]params.MachinePortsResult, len(args.Entities)),
+	}
+	canAccess, err := u.accessMachine()
+	if err != nil {
+		return params.MachinePortsResults{}, err
+	}
+	for i, entity := range args.Entities {
+		result.Results[i] = u.getOneMachinePorts(canAccess, entity.Tag)
+	}
+	return result, nil
+}
+
+// ServiceOwner returns the owner user for each given service tag.
+func (u *UniterAPIV1) ServiceOwner(args params.Entities) (params.StringResults, error) {
+	result := params.StringResults{
+		Results: make([]params.StringResult, len(args.Entities)),
+	}
+	canAccess, err := u.accessService()
+	if err != nil {
+		return params.StringResults{}, err
+	}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseServiceTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		if !canAccess(tag) {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		service, err := u.getService(tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		result.Results[i].Result = service.GetOwnerTag()
+	}
+	return result, nil
+}
+
+// AssignedMachine returns the machine tag for each given unit tag, or
+// an error satisfying params.IsCodeNotAssigned when a unit has no
+// assigned machine.
+func (u *UniterAPIV1) AssignedMachine(args params.Entities) (params.StringResults, error) {
+	result := params.StringResults{
+		Results: make([]params.StringResult, len(args.Entities)),
+	}
+	canAccess, err := u.accessUnit()
+	if err != nil {
+		return params.StringResults{}, err
+	}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		if !canAccess(tag) {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		unit, err := u.getUnit(tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		machineId, err := unit.AssignedMachineId()
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+		} else {
+			result.Results[i].Result = names.NewMachineTag(machineId).String()
+		}
+	}
+	return result, nil
+}
+
+func (u *UniterAPIV1) getMachine(tag names.MachineTag) (*state.Machine, error) {
+	return u.st.Machine(tag.Id())
+}
+
+func (u *UniterAPIV1) getOneMachinePorts(canAccess common.AuthFunc, machineTag string) params.MachinePortsResult {
+	tag, err := names.ParseMachineTag(machineTag)
+	if err != nil {
+		return params.MachinePortsResult{Error: common.ServerError(common.ErrPerm)}
+	}
+	if !canAccess(tag) {
+		return params.MachinePortsResult{Error: common.ServerError(common.ErrPerm)}
+	}
+	machine, err := u.getMachine(tag)
+	if err != nil {
+		return params.MachinePortsResult{Error: common.ServerError(err)}
+	}
+	allPorts, err := machine.AllPorts()
+	if err != nil {
+		return params.MachinePortsResult{Error: common.ServerError(err)}
+	}
+	var resultPorts []params.MachinePortRange
+	for _, ports := range allPorts {
+		for portRange, unitName := range ports.AllPortRanges() {
+			resultPorts = append(resultPorts, params.MachinePortRange{
+				UnitTag:   names.NewUnitTag(unitName).String(),
+				PortRange: portRange,
+			})
+		}
+	}
+	return params.MachinePortsResult{
+		Ports: resultPorts,
+	}
+}

--- a/apiserver/uniter/uniter_v1_test.go
+++ b/apiserver/uniter/uniter_v1_test.go
@@ -1,0 +1,410 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	commontesting "github.com/juju/juju/apiserver/common/testing"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/apiserver/uniter"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+type uniterV1Suite struct {
+	uniterBaseSuite
+	*commontesting.EnvironWatcherTest
+
+	uniter *uniter.UniterAPIV1
+}
+
+var _ = gc.Suite(&uniterV1Suite{})
+
+func (s *uniterV1Suite) SetUpTest(c *gc.C) {
+	s.uniterBaseSuite.setUpTest(c)
+
+	uniterAPIV1, err := uniter.NewUniterAPIV1(
+		s.State,
+		s.resources,
+		s.authorizer,
+	)
+	c.Assert(err, gc.IsNil)
+	s.uniter = uniterAPIV1
+
+	s.EnvironWatcherTest = commontesting.NewEnvironWatcherTest(
+		s.uniter,
+		s.State,
+		s.resources,
+		commontesting.NoSecrets,
+	)
+}
+
+func (s *uniterV1Suite) TestUniterFailsWithNonUnitAgentUser(c *gc.C) {
+	factory := func(st *state.State, res *common.Resources, auth common.Authorizer) error {
+		_, err := uniter.NewUniterAPIV1(st, res, auth)
+		return err
+	}
+	s.testUniterFailsWithNonUnitAgentUser(c, factory)
+}
+
+func (s *uniterV1Suite) TestSetStatus(c *gc.C) {
+	s.testSetStatus(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestLife(c *gc.C) {
+	s.testLife(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestEnsureDead(c *gc.C) {
+	s.testEnsureDead(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatch(c *gc.C) {
+	s.testWatch(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestPublicAddress(c *gc.C) {
+	s.testPublicAddress(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestPrivateAddress(c *gc.C) {
+	s.testPrivateAddress(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestResolved(c *gc.C) {
+	s.testResolved(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestClearResolved(c *gc.C) {
+	s.testClearResolved(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestGetPrincipal(c *gc.C) {
+	factory := func(
+		st *state.State,
+		resources *common.Resources,
+		authorizer common.Authorizer,
+	) (getPrincipal, error) {
+		return uniter.NewUniterAPIV1(st, resources, authorizer)
+	}
+	s.testGetPrincipal(c, s.uniter, factory)
+}
+
+func (s *uniterV1Suite) TestHasSubordinates(c *gc.C) {
+	s.testHasSubordinates(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestDestroy(c *gc.C) {
+	s.testDestroy(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestDestroyAllSubordinates(c *gc.C) {
+	s.testDestroyAllSubordinates(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestCharmURL(c *gc.C) {
+	s.testCharmURL(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestSetCharmURL(c *gc.C) {
+	s.testSetCharmURL(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestOpenPorts(c *gc.C) {
+	s.testOpenPorts(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestClosePorts(c *gc.C) {
+	s.testClosePorts(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestOpenPort(c *gc.C) {
+	s.testOpenPort(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestClosePort(c *gc.C) {
+	s.testClosePort(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchConfigSettings(c *gc.C) {
+	s.testWatchConfigSettings(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchActions(c *gc.C) {
+	s.testWatchActions(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchPreexistingActions(c *gc.C) {
+	s.testWatchPreexistingActions(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchActionsMalformedTag(c *gc.C) {
+	s.testWatchActionsMalformedTag(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchActionsMalformedUnitName(c *gc.C) {
+	s.testWatchActionsMalformedUnitName(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchActionsNotUnit(c *gc.C) {
+	s.testWatchActionsNotUnit(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchActionsPermissionDenied(c *gc.C) {
+	s.testWatchActionsPermissionDenied(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestConfigSettings(c *gc.C) {
+	s.testConfigSettings(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchServiceRelations(c *gc.C) {
+	s.testWatchServiceRelations(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestCharmArchiveSha256(c *gc.C) {
+	s.testCharmArchiveSha256(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestCurrentEnvironUUID(c *gc.C) {
+	s.testCurrentEnvironUUID(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestCurrentEnvironment(c *gc.C) {
+	s.testCurrentEnvironment(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestActions(c *gc.C) {
+	s.testActions(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestActionsNotPresent(c *gc.C) {
+	s.testActionsNotPresent(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestActionsWrongUnit(c *gc.C) {
+	factory := func(
+		st *state.State,
+		resources *common.Resources,
+		authorizer common.Authorizer,
+	) (actions, error) {
+		return uniter.NewUniterAPIV1(st, resources, authorizer)
+	}
+	s.testActionsWrongUnit(c, factory)
+}
+
+func (s *uniterV1Suite) TestActionsPermissionDenied(c *gc.C) {
+	s.testActionsPermissionDenied(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestFinishActionsSuccess(c *gc.C) {
+	s.testFinishActionsSuccess(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestFinishActionsFailure(c *gc.C) {
+	s.testFinishActionsFailure(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestFinishActionsAuthAccess(c *gc.C) {
+	s.testFinishActionsAuthAccess(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestRelation(c *gc.C) {
+	s.testRelation(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestRelationById(c *gc.C) {
+	s.testRelationById(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestProviderType(c *gc.C) {
+	s.testProviderType(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestEnterScope(c *gc.C) {
+	s.testEnterScope(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestLeaveScope(c *gc.C) {
+	s.testLeaveScope(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestJoinedRelations(c *gc.C) {
+	s.testJoinedRelations(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestReadSettings(c *gc.C) {
+	s.testReadSettings(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestReadSettingsWithNonStringValuesFails(c *gc.C) {
+	s.testReadSettingsWithNonStringValuesFails(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestReadRemoteSettings(c *gc.C) {
+	s.testReadRemoteSettings(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestReadRemoteSettingsWithNonStringValuesFails(c *gc.C) {
+	s.testReadRemoteSettingsWithNonStringValuesFails(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestUpdateSettings(c *gc.C) {
+	s.testUpdateSettings(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchRelationUnits(c *gc.C) {
+	s.testWatchRelationUnits(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestAPIAddresses(c *gc.C) {
+	s.testAPIAddresses(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchUnitAddresses(c *gc.C) {
+	s.testWatchUnitAddresses(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestAddMetrics(c *gc.C) {
+	s.testAddMetrics(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestAddMetricsIncorrectTag(c *gc.C) {
+	s.testAddMetricsIncorrectTag(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestAddMetricsUnauthenticated(c *gc.C) {
+	s.testAddMetricsUnauthenticated(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestGetMeterStatus(c *gc.C) {
+	s.testGetMeterStatus(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestGetMeterStatusUnauthenticated(c *gc.C) {
+	s.testGetMeterStatusUnauthenticated(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestGetMeterStatusBadTag(c *gc.C) {
+	s.testGetMeterStatusBadTag(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestWatchMeterStatus(c *gc.C) {
+	s.testWatchMeterStatus(c, s.uniter)
+}
+
+func (s *uniterV1Suite) TestGetOwnerTagV1NotImplemented(c *gc.C) {
+	apiservertesting.AssertNotImplemented(c, s.uniter, "GetOwnerTag")
+}
+
+func (s *uniterV1Suite) TestServiceOwner(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "service-wordpress"},
+		{Tag: "unit-wordpress-0"},
+		{Tag: "unit-foo-42"},
+		{Tag: "machine-0"},
+		{Tag: "service-foo"},
+	}}
+	result, err := s.uniter.ServiceOwner(args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, jc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Error: apiservertesting.ErrUnauthorized},
+			{Result: s.AdminUserTag(c).String()},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}
+
+func (s *uniterV1Suite) TestAssignedMachine(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "unit-wordpress-0"},
+		{Tag: "unit-foo-42"},
+		{Tag: "service-mysql"},
+		{Tag: "service-wordpress"},
+		{Tag: "machine-0"},
+		{Tag: "machine-1"},
+		{Tag: "machine-42"},
+		{Tag: "service-foo"},
+		{Tag: "relation-svc1.rel1#svc2.rel2"},
+	}}
+	result, err := s.uniter.AssignedMachine(args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, jc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Error: apiservertesting.ErrUnauthorized},
+			{Result: "machine-0"},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}
+
+func (s *uniterV1Suite) TestAllMachinePorts(c *gc.C) {
+	// Verify no ports are opened yet on the machine or unit.
+	machinePorts, err := s.machine0.AllPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(machinePorts, gc.HasLen, 0)
+	unitPorts, err := s.wordpressUnit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(unitPorts, gc.HasLen, 0)
+
+	// Add another mysql unit on machine 0.
+	mysqlUnit1, err := s.mysql.AddUnit()
+	c.Assert(err, gc.IsNil)
+	err = mysqlUnit1.AssignToMachine(s.machine0)
+	c.Assert(err, gc.IsNil)
+
+	// Open some ports on both units.
+	err = s.wordpressUnit.OpenPorts("tcp", 100, 200)
+	c.Assert(err, gc.IsNil)
+	err = s.wordpressUnit.OpenPorts("udp", 10, 20)
+	c.Assert(err, gc.IsNil)
+	err = mysqlUnit1.OpenPorts("tcp", 201, 250)
+	c.Assert(err, gc.IsNil)
+	err = mysqlUnit1.OpenPorts("udp", 1, 8)
+	c.Assert(err, gc.IsNil)
+
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "machine-0"},
+		{Tag: "machine-1"},
+		{Tag: "unit-foo-42"},
+		{Tag: "machine-42"},
+		{Tag: "service-wordpress"},
+	}}
+	expectPorts := []params.MachinePortRange{
+		{UnitTag: "unit-wordpress-0", PortRange: network.PortRange{100, 200, "tcp"}},
+		{UnitTag: "unit-wordpress-0", PortRange: network.PortRange{10, 20, "udp"}},
+		{UnitTag: "unit-mysql-1", PortRange: network.PortRange{201, 250, "tcp"}},
+		{UnitTag: "unit-mysql-1", PortRange: network.PortRange{1, 8, "udp"}},
+	}
+	result, err := s.uniter.AllMachinePorts(args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, params.MachinePortsResults{
+		Results: []params.MachinePortsResult{
+			{Error: apiservertesting.ErrUnauthorized},
+			{Ports: expectPorts},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}

--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -124,7 +124,11 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return uniter.NewUniter(uniterFacade, entity.Tag(), dataDir, hookLock), nil
+		unitTag, err := names.ParseUnitTag(entity.Tag())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return uniter.NewUniter(uniterFacade, unitTag, dataDir, hookLock), nil
 	})
 	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {
 		uniterFacade, err := st.Uniter()

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -134,7 +134,7 @@ func validateUnitPorts(st *State, unit *Unit) (
 			stateRange = stateRange.SanitizeBounds()
 			upgradesLogger.Debugf(
 				"merged range %v sanitized as %v",
-				mergedRange, stateRange, unit,
+				mergedRange, stateRange,
 			)
 			// Now try again.
 			if err := stateRange.Validate(); err != nil {

--- a/worker/uniter/context.go
+++ b/worker/uniter/context.go
@@ -107,8 +107,8 @@ type HookContext struct {
 	// apiAddrs contains the API server addresses.
 	apiAddrs []string
 
-	// serviceOwner contains the owner of the service.
-	serviceOwner string
+	// serviceOwner contains the user tag of the service owner.
+	serviceOwner names.UserTag
 
 	// proxySettings are the current proxy settings that the uniter knows about.
 	proxySettings proxy.Settings
@@ -133,7 +133,7 @@ func NewHookContext(
 	remoteUnitName string,
 	relations map[int]*ContextRelation,
 	apiAddrs []string,
-	serviceOwner string,
+	serviceOwner names.UserTag,
 	proxySettings proxy.Settings,
 	canAddMetrics bool,
 	actionData *actionData,
@@ -199,7 +199,7 @@ func (ctx *HookContext) ClosePorts(protocol string, fromPort, toPort int) error 
 }
 
 func (ctx *HookContext) OwnerTag() string {
-	return ctx.serviceOwner
+	return ctx.serviceOwner.String()
 }
 
 func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {

--- a/worker/uniter/filter.go
+++ b/worker/uniter/filter.go
@@ -102,7 +102,7 @@ type filter struct {
 
 // newFilter returns a filter that handles state changes pertaining to the
 // supplied unit.
-func newFilter(st *uniter.State, unitTag string) (*filter, error) {
+func newFilter(st *uniter.State, unitTag names.UnitTag) (*filter, error) {
 	f := &filter{
 		st:                st,
 		outUnitDying:      make(chan struct{}),
@@ -270,18 +270,14 @@ func (f *filter) maybeStopWatcher(w watcher.Stopper) {
 	}
 }
 
-func (f *filter) loop(unitTag string) (err error) {
+func (f *filter) loop(unitTag names.UnitTag) (err error) {
 	// TODO(dfc) named return value is a time bomb
 	defer func() {
 		if params.IsCodeNotFoundOrCodeUnauthorized(err) {
 			err = worker.ErrTerminateAgent
 		}
 	}()
-	tag, err := names.ParseUnitTag(unitTag)
-	if err != nil {
-		return err
-	}
-	if f.unit, err = f.st.Unit(tag); err != nil {
+	if f.unit, err = f.st.Unit(unitTag); err != nil {
 		return err
 	}
 	if err = f.unitChanged(); err != nil {
@@ -421,7 +417,7 @@ func (f *filter) loop(unitTag string) (err error) {
 			}
 			var ids []int
 			for _, key := range keys {
-				relationTag := names.NewRelationTag(key).String()
+				relationTag := names.NewRelationTag(key)
 				rel, err := f.st.Relation(relationTag)
 				if params.IsCodeNotFoundOrCodeUnauthorized(err) {
 					// If it's actually gone, this unit cannot have entered

--- a/worker/uniter/filter_test.go
+++ b/worker/uniter/filter_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -68,7 +69,7 @@ func (s *FilterSuite) APILogin(c *gc.C, unit *state.Unit) {
 }
 
 func (s *FilterSuite) TestUnitDeath(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer f.Stop() // no AssertStop, we test for an error below
 	asserter := coretesting.NotifyAsserterC{
@@ -102,7 +103,7 @@ func (s *FilterSuite) TestUnitDeath(c *gc.C) {
 }
 
 func (s *FilterSuite) TestUnitRemoval(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer f.Stop() // no AssertStop, we test for an error below
 
@@ -128,7 +129,7 @@ func (s *FilterSuite) assertAgentTerminates(c *gc.C, f *filter) {
 }
 
 func (s *FilterSuite) TestServiceDeath(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 	dyingAsserter := coretesting.NotifyAsserterC{
@@ -163,7 +164,7 @@ loop:
 }
 
 func (s *FilterSuite) TestResolvedEvents(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -225,7 +226,7 @@ func (s *FilterSuite) TestCharmUpgradeEvents(c *gc.C) {
 
 	s.APILogin(c, unit)
 
-	f, err := newFilter(s.uniter, unit.Tag().String())
+	f, err := newFilter(s.uniter, unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -291,7 +292,7 @@ func (s *FilterSuite) TestCharmUpgradeEvents(c *gc.C) {
 }
 
 func (s *FilterSuite) TestConfigEvents(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -355,7 +356,7 @@ func (s *FilterSuite) TestConfigEvents(c *gc.C) {
 
 	// Check that a filter's initial event works with DiscardConfigEvent
 	// as expected.
-	f, err = newFilter(s.uniter, s.unit.Tag().String())
+	f, err = newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 	s.BackingState.StartSync()
@@ -369,7 +370,7 @@ func (s *FilterSuite) TestConfigEvents(c *gc.C) {
 }
 
 func (s *FilterSuite) TestInitialAddressEventIgnored(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -408,7 +409,7 @@ func (s *FilterSuite) TestInitialAddressEventIgnored(c *gc.C) {
 }
 
 func (s *FilterSuite) TestConfigAndAddressEvents(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -446,7 +447,7 @@ func (s *FilterSuite) TestConfigAndAddressEvents(c *gc.C) {
 }
 
 func (s *FilterSuite) TestConfigAndAddressEventsDiscarded(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -513,7 +514,7 @@ func getAddAction(s *FilterSuite, c *gc.C) func(name string) string {
 }
 
 func (s *FilterSuite) TestActionEvents(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -547,7 +548,7 @@ func (s *FilterSuite) TestPreexistingActions(c *gc.C) {
 	testId := addAction("snapshot")
 
 	// Now create the Filter and see whether the Action comes in as expected.
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -561,7 +562,7 @@ func (s *FilterSuite) TestPreexistingActions(c *gc.C) {
 }
 
 func (s *FilterSuite) TestCharmErrorEvents(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer f.Stop() // no AssertStop, we test for an error below
 
@@ -581,7 +582,7 @@ func (s *FilterSuite) TestCharmErrorEvents(c *gc.C) {
 	s.assertFilterDies(c, f)
 
 	// Filter died after the error, so restart it.
-	f, err = newFilter(s.uniter, s.unit.Tag().String())
+	f, err = newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer f.Stop() // no AssertStop, we test for an error below
 
@@ -593,7 +594,7 @@ func (s *FilterSuite) TestCharmErrorEvents(c *gc.C) {
 }
 
 func (s *FilterSuite) TestRelationsEvents(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 
@@ -643,7 +644,7 @@ func (s *FilterSuite) TestRelationsEvents(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Start a new filter, check initial event.
-	f, err = newFilter(s.uniter, s.unit.Tag().String())
+	f, err = newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 	assertChange([]int{0, 2})
@@ -670,7 +671,7 @@ func (s *FilterSuite) addRelation(c *gc.C) *state.Relation {
 }
 
 func (s *FilterSuite) TestMeterStatusEvents(c *gc.C) {
-	f, err := newFilter(s.uniter, s.unit.Tag().String())
+	f, err := newFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertStop(c, f)
 

--- a/worker/uniter/jujuc/context.go
+++ b/worker/uniter/jujuc/context.go
@@ -69,7 +69,8 @@ type Context interface {
 	// currently participating in.
 	RelationIds() []int
 
-	// OwnerTag returns the owner of the service the executing units belongs to
+	// OwnerTag returns the user tag of the service the executing
+	// units belongs to.
 	OwnerTag() string
 
 	// AddMetric records a metric to return after hook execution.

--- a/worker/uniter/relationer_test.go
+++ b/worker/uniter/relationer_test.go
@@ -68,7 +68,7 @@ func (s *RelationerSuite) SetUpTest(c *gc.C) {
 
 	apiUnit, err := s.uniter.Unit(unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
-	apiRel, err := s.uniter.Relation(s.rel.Tag().String())
+	apiRel, err := s.uniter.Relation(s.rel.Tag().(names.RelationTag))
 	c.Assert(err, gc.IsNil)
 	s.apiRelUnit, err = apiRel.Unit(apiUnit)
 	c.Assert(err, gc.IsNil)
@@ -434,7 +434,7 @@ func (s *RelationerImplicitSuite) TestImplicitRelationer(c *gc.C) {
 
 	apiUnit, err := uniterState.Unit(u.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
-	apiRel, err := uniterState.Relation(rel.Tag().String())
+	apiRel, err := uniterState.Relation(rel.Tag().(names.RelationTag))
 	c.Assert(err, gc.IsNil)
 	apiRelUnit, err := apiRel.Unit(apiUnit)
 	c.Assert(err, gc.IsNil)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	gt "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
@@ -1863,10 +1864,14 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 	if ctx.s.uniter == nil {
 		panic("API connection not established")
 	}
+	tag, err := names.ParseUnitTag(s.unitTag)
+	if err != nil {
+		panic(err.Error())
+	}
 	locksDir := filepath.Join(ctx.dataDir, "locks")
 	lock, err := fslock.NewLock(locksDir, "uniter-hook-execution")
 	c.Assert(err, gc.IsNil)
-	ctx.uniter = uniter.NewUniter(ctx.s.uniter, s.unitTag, ctx.dataDir, lock)
+	ctx.uniter = uniter.NewUniter(ctx.s.uniter, tag, ctx.dataDir, lock)
 	uniter.SetUniterObserver(ctx.uniter, ctx)
 }
 


### PR DESCRIPTION
The Uniter API facade is now versioned:
- All existing methods, except GetOwnerTag are part of the
  UniterBaseAPI, and are common for both V0 and V1. 
- UniterAPIV0 has the deprecated GetOwnerTag, which
  is replaced by the improved ServiceOwner in V1.
- UniterAPIV1 has the following new methods: ServiceOwner,
  AllMachinePorts and AssignedMachine.
- Tests in both the server-side and client-side uniter API
  packages are improved, code is shared where possible.
- All client-side tags are now concrete tag kinds, rather than
  strings or generic names.Tag.
- Fixed http://pad.lv/1270795 as a side-effect.

These changes will be used in a follow-up that will make
the open-port and close-port hook tools sandboxed until
a hook is committed, while also ensuring each open-port
or close-port invocation also checks for conflicts.
