### PR TITLE
Prepend environment UUID to Action and ActionResult document _id's

### DIFF
--- a/api/uniter/action_test.go
+++ b/api/uniter/action_test.go
@@ -96,7 +96,7 @@ func (s *actionSuite) TestActionComplete(c *gc.C) {
 	res, errstr := results[0].Results()
 	c.Assert(errstr, gc.Equals, "")
 	c.Assert(res, gc.DeepEquals, actionResult)
-	c.Assert(results[0].ActionName(), gc.Equals, "gabloxi")
+	c.Assert(results[0].Name(), gc.Equals, "gabloxi")
 }
 
 func (s *actionSuite) TestActionFail(c *gc.C) {
@@ -118,5 +118,5 @@ func (s *actionSuite) TestActionFail(c *gc.C) {
 	res, errstr := results[0].Results()
 	c.Assert(errstr, gc.Equals, errmsg)
 	c.Assert(res, gc.DeepEquals, map[string]interface{}{})
-	c.Assert(results[0].ActionName(), gc.Equals, "beebz")
+	c.Assert(results[0].Name(), gc.Equals, "beebz")
 }

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -1168,7 +1168,7 @@ func (s *uniterSuite) TestActionComplete(c *gc.C) {
 	res2, errstr := results[0].Results()
 	c.Assert(errstr, gc.Equals, "")
 	c.Assert(res2, gc.DeepEquals, testOutput)
-	c.Assert(results[0].ActionName(), gc.Equals, testName)
+	c.Assert(results[0].Name(), gc.Equals, testName)
 }
 
 func (s *uniterSuite) TestActionFail(c *gc.C) {
@@ -1202,7 +1202,7 @@ func (s *uniterSuite) TestActionFail(c *gc.C) {
 	res2, errstr := results[0].Results()
 	c.Assert(errstr, gc.Equals, testError)
 	c.Assert(res2, gc.DeepEquals, map[string]interface{}{})
-	c.Assert(results[0].ActionName(), gc.Equals, testName)
+	c.Assert(results[0].Name(), gc.Equals, testName)
 }
 
 func (s *uniterSuite) TestFinishActionAuthAccess(c *gc.C) {

--- a/state/action.go
+++ b/state/action.go
@@ -5,8 +5,6 @@ package state
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/juju/names"
 	"gopkg.in/mgo.v2/txn"
@@ -19,49 +17,60 @@ import (
 // performs all these actions.
 type ActionReceiver interface {
 	// AddAction queues an action with the given name and payload for this
-	// ActionReciever
+	// ActionReceiver.
 	AddAction(name string, payload map[string]interface{}) (*Action, error)
 
 	// WatchActions returns a StringsWatcher that will notify on changes to the
-	// queued actions for this ActionReceiver
+	// queued actions for this ActionReceiver.
 	WatchActions() StringsWatcher
 
 	// WatchActionResults returns a StringsWatcher that will notify on changes to
-	// the action results for this ActionReceiver
+	// the action results for this ActionReceiver.
 	WatchActionResults() StringsWatcher
 
-	// Actions returns the list of Actions queued for this ActionReceiver
+	// Actions returns the list of Actions queued for this ActionReceiver.
 	Actions() ([]*Action, error)
 
 	// ActionResults returns the list of completed ActionResults that were
-	// queued on this ActionReciever
+	// queued on this ActionReceiver.
 	ActionResults() ([]*ActionResult, error)
 
 	// Name returns the name that will be used to filter actions
-	// that are queued for this ActionReceiver
+	// that are queued for this ActionReceiver.
 	Name() string
 }
 
 var (
 	_ ActionReceiver = (*Unit)(nil)
-	// TODO(jcw4) - use when Actions can be queued for Services
+	// TODO(jcw4) - use when Actions can be queued for Services.
 	//_ ActionReceiver = (*Service)(nil)
 )
 
 const actionMarker string = "_a_"
 
 type actionDoc struct {
-	// Id is the key for this document. The structure of the key is
-	// a composite of ActionReciever.ActionKey() and a unique sequence,
-	// to facilitate indexing and prefix filtering
-	Id string `bson:"_id"`
+	// DocId is the key for this document. The structure of the key is
+	// a composite of ActionReceiver.ActionKey() and a unique sequence,
+	// to facilitate indexing and prefix filtering.
+	DocId string `bson:"_id"`
+
+	// EnvUUID is the environment identifier.
+	EnvUUID string `bson:"env-uuid"`
+
+	// Receiver is the Name of the Unit or any other ActionReceiver for
+	// which this Action is queued.
+	Receiver string `bson:"receiver"`
+
+	// Sequence is the unique identifier for this instance of this Action,
+	// and is encoded in the DocId too.
+	Sequence int `bson:"sequence"`
 
 	// Name identifies the action that should be run; it should
 	// match an action defined by the unit's charm.
 	Name string `bson:"name"`
 
 	// Parameters holds the action's parameters, if any; it should validate
-	// against the schema defined by the named action in the unit's charm
+	// against the schema defined by the named action in the unit's charm.
 	Parameters map[string]interface{} `bson:"parameters"`
 }
 
@@ -72,50 +81,44 @@ type Action struct {
 	doc actionDoc
 }
 
-// Id returns the id of the Action
+// Id returns the local name of the Action.
 func (a *Action) Id() string {
-	return a.doc.Id
+	return a.st.localID(a.doc.DocId)
 }
 
-// Prefix extracts the name of the unit or service from the encoded _id
-func (a *Action) Prefix() string {
-	if prefix, ok := extractPrefixName(a.doc.Id); ok {
-		return prefix
-	}
-	return ""
+// Receiver returns the Name of the ActionReceiver for which this action
+// is enqueued.  Usually this is a Unit Name().
+func (a *Action) Receiver() string {
+	return a.doc.Receiver
 }
 
-// Sequence extracts the unique sequence part of an action _id
+// Sequence returns the unique suffix of the _id of this Action.
 func (a *Action) Sequence() int {
-	sequence, ok := extractSequence(a.doc.Id)
-	if !ok {
-		panic(fmt.Sprintf("cannot extract sequence from _id %v", a.doc.Id))
-	}
-	return sequence
+	return a.doc.Sequence
 }
 
-// Tag implements the Entity interface and returns a names.Tag that
-// is a names.ActionTag
-func (a *Action) Tag() names.Tag {
-	return a.ActionTag()
-}
-
-// ActionTag returns an ActionTag constructed from this action's
-// Prefix and Sequence
-func (a *Action) ActionTag() names.ActionTag {
-	return names.JoinActionTag(a.Prefix(), a.Sequence())
-}
-
-// Name returns the name of the action, as defined in the charm
+// Name returns the name of the action, as defined in the charm.
 func (a *Action) Name() string {
 	return a.doc.Name
 }
 
 // Parameters will contain a structure representing arguments or parameters to
 // an action, and is expected to be validated by the Unit using the Charm
-// definition of the Action
+// definition of the Action.
 func (a *Action) Parameters() map[string]interface{} {
 	return a.doc.Parameters
+}
+
+// Tag implements the Entity interface and returns a names.Tag that
+// is a names.ActionTag.
+func (a *Action) Tag() names.Tag {
+	return a.ActionTag()
+}
+
+// ActionTag returns an ActionTag constructed from this action's
+// Prefix and Sequence.
+func (a *Action) ActionTag() names.ActionTag {
+	return names.JoinActionTag(a.Receiver(), a.Sequence())
 }
 
 // ActionResults is a data transfer object that holds the key Action
@@ -140,13 +143,13 @@ func (a *Action) removeAndLog(finalStatus ActionStatus, results map[string]inter
 		addActionResultOp(a.st, &doc),
 		{
 			C:      actionsC,
-			Id:     a.doc.Id,
+			Id:     a.doc.DocId,
 			Remove: true,
 		},
 	})
 }
 
-// newAction builds an Action for the given State and actionDoc
+// newAction builds an Action for the given State and actionDoc.
 func newAction(st *State, adoc actionDoc) *Action {
 	return &Action{
 		st:  st,
@@ -154,63 +157,32 @@ func newAction(st *State, adoc actionDoc) *Action {
 	}
 }
 
-// newActionDoc builds the actionDoc with the given name and parameters
+// newActionDoc builds the actionDoc with the given name and parameters.
 func newActionDoc(st *State, ar ActionReceiver, actionName string, parameters map[string]interface{}) (actionDoc, error) {
-	actionId, err := newActionId(st, ar)
+	prefix := ensureActionMarker(ar.Name())
+	sequence, err := st.sequence(prefix)
 	if err != nil {
 		return actionDoc{}, err
 	}
-	return actionDoc{Id: actionId, Name: actionName, Parameters: parameters}, nil
+	envuuid := st.EnvironTag().Id()
+	actionId := st.docID(fmt.Sprintf("%s%d", prefix, sequence))
+	return actionDoc{
+		DocId:      actionId,
+		EnvUUID:    envuuid,
+		Receiver:   ar.Name(),
+		Sequence:   sequence,
+		Name:       actionName,
+		Parameters: parameters,
+	}, nil
 }
 
 var ensureActionMarker = ensureSuffixFn(actionMarker)
 
-// newActionId generates a new id for an action on the given ActionReceiver
-func newActionId(st *State, ar ActionReceiver) (string, error) {
-	prefix := ensureActionMarker(ar.Name())
-	sequence, err := st.sequence(prefix)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s%d", prefix, sequence), nil
-}
-
-// actionIdFromTag converts an ActionTag to an actionId
+// actionIdFromTag converts an ActionTag to an actionId.
 func actionIdFromTag(tag names.ActionTag) string {
 	ptag := tag.PrefixTag()
 	if ptag == nil {
 		return ""
 	}
 	return fmt.Sprintf("%s%d", ensureActionMarker(ptag.Id()), tag.Sequence())
-}
-
-// actionGlobalKey returns the global database key for the named action.
-func actionGlobalKey(name string) string {
-	return "a#" + name
-}
-
-func extractSequence(id string) (int, bool) {
-	parts := strings.SplitN(id, actionMarker, 2)
-	if len(parts) != 2 {
-		return -1, false
-	}
-	parsed, err := strconv.ParseInt(parts[1], 10, 0)
-	if err != nil {
-		return -1, false
-	}
-	return int(parsed), true
-}
-
-func extractPrefixName(id string) (string, bool) {
-	mlen := len(actionMarker)
-	// id must contain the actionMarker plus
-	// two more characters at the very minimum
-	if len(id) <= mlen+2 {
-		return "", false
-	}
-	parts := strings.Split(id, actionMarker)
-	if len(parts) != 2 {
-		return "", false
-	}
-	return parts[0], true
 }

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -180,7 +180,7 @@ func (s *ActionSuite) TestFail(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(results), gc.Equals, 1)
 
-	c.Assert(results[0].ActionName(), gc.Equals, action.Name())
+	c.Assert(results[0].Name(), gc.Equals, action.Name())
 	c.Assert(results[0].Status(), gc.Equals, state.ActionFailed)
 	res, errstr := results[0].Results()
 	c.Assert(errstr, gc.Equals, reason)
@@ -219,7 +219,7 @@ func (s *ActionSuite) TestComplete(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(len(results), gc.Equals, 1)
 
-	c.Assert(results[0].ActionName(), gc.Equals, action.Name())
+	c.Assert(results[0].Name(), gc.Equals, action.Name())
 	c.Assert(results[0].Status(), gc.Equals, state.ActionCompleted)
 	res, errstr := results[0].Results()
 	c.Assert(errstr, gc.Equals, "")
@@ -356,7 +356,7 @@ func (s *ActionSuite) TestMergeIds(c *gc.C) {
 		expected := newSet(test.expected)
 
 		c.Log(fmt.Sprintf("test number %d %+v", ix, test))
-		err := state.WatcherMergeIds(changes, initial, updates)
+		err := state.WatcherMergeIds(s.State, changes, initial, updates)
 		c.Assert(err, gc.IsNil)
 		c.Assert(changes.SortedValues(), jc.DeepEquals, expected.SortedValues())
 	}
@@ -380,7 +380,7 @@ func (s *ActionSuite) TestMergeIdsErrors(c *gc.C) {
 		changes, initial, updates := newSet(""), newSet(""), map[interface{}]bool{}
 
 		updates[test.key] = true
-		err := state.WatcherMergeIds(changes, initial, updates)
+		err := state.WatcherMergeIds(s.State, changes, initial, updates)
 
 		if test.ok {
 			c.Assert(err, gc.IsNil)
@@ -414,12 +414,12 @@ func (s *ActionSuite) TestEnsureSuffix(c *gc.C) {
 func (s *ActionSuite) TestMakeIdFilter(c *gc.C) {
 	marker := "-marker-"
 	badmarker := "-bad-"
-	fn := state.WatcherMakeIdFilter(marker)
+	fn := state.WatcherMakeIdFilter(s.State, marker)
 	c.Assert(fn, gc.IsNil)
 
 	ar1 := mockAR{id: "mock1"}
 	ar2 := mockAR{id: "mock2"}
-	fn = state.WatcherMakeIdFilter(marker, ar1, ar2)
+	fn = state.WatcherMakeIdFilter(s.State, marker, ar1, ar2)
 	c.Assert(fn, gc.Not(gc.IsNil))
 
 	var tests = []struct {
@@ -448,7 +448,7 @@ func (s *ActionSuite) TestMakeIdFilter(c *gc.C) {
 	}
 
 	for _, test := range tests {
-		c.Assert(fn(test.id), gc.Equals, test.match)
+		c.Assert(fn(state.DocID(s.State, test.id)), gc.Equals, test.match)
 	}
 }
 

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -211,7 +211,7 @@ func (st *State) cleanupDyingUnit(name string) error {
 // cleanupRemovedUnit takes care of all the final cleanup required when
 // a unit is removed.
 func (st *State) cleanupRemovedUnit(unitId string) error {
-	actions, err := st.matchingActionsByPrefix(unitId)
+	actions, err := st.matchingActionsByReceiverName(unitId)
 	if err != nil {
 		return err
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -250,16 +250,16 @@ func GetActionResultId(actionId string) (string, bool) {
 	return convertActionIdToActionResultId(actionId)
 }
 
-func WatcherMergeIds(changes, initial set.Strings, updates map[interface{}]bool) error {
-	return mergeIds(changes, initial, updates)
+func WatcherMergeIds(st *State, changes, initial set.Strings, updates map[interface{}]bool) error {
+	return mergeIds(st, changes, initial, updates)
 }
 
 func WatcherEnsureSuffixFn(marker string) func(string) string {
 	return ensureSuffixFn(marker)
 }
 
-func WatcherMakeIdFilter(marker string, receivers ...ActionReceiver) func(interface{}) bool {
-	return makeIdFilter(marker, receivers...)
+func WatcherMakeIdFilter(st *State, marker string, receivers ...ActionReceiver) func(interface{}) bool {
+	return makeIdFilter(st, marker, receivers...)
 }
 
 var (

--- a/state/state.go
+++ b/state/state.go
@@ -1582,7 +1582,7 @@ func (st *State) Action(id string) (*Action, error) {
 	defer closer()
 
 	doc := actionDoc{}
-	err := actions.FindId(id).One(&doc)
+	err := actions.FindId(st.docID(id)).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("action %q", id)
 	}
@@ -1594,29 +1594,32 @@ func (st *State) Action(id string) (*Action, error) {
 
 // matchingActions finds actions that match ActionReceiver
 func (st *State) matchingActions(ar ActionReceiver) ([]*Action, error) {
-	return st.matchingActionsByPrefix(ar.Name())
+	return st.matchingActionsByReceiverName(ar.Name())
 }
 
-// ActionByTag returns an Action given an ActionTag
-func (st *State) ActionByTag(tag names.ActionTag) (*Action, error) {
-	return st.Action(actionIdFromTag(tag))
-}
-
-// matchingActionsByPrefix finds actions with a given prefix
-func (st *State) matchingActionsByPrefix(prefix string) ([]*Action, error) {
+// matchingActionsByReceiverName returns all Actions associated with the
+// ActionReceiver with the given name.
+func (st *State) matchingActionsByReceiverName(receiver string) ([]*Action, error) {
 	var doc actionDoc
 	var actions []*Action
 
 	actionsCollection, closer := st.getCollection(actionsC)
 	defer closer()
 
-	sel := bson.D{{"_id", bson.D{{"$regex", "^" + regexp.QuoteMeta(ensureActionMarker(prefix))}}}}
+	envuuid := st.EnvironTag().Id()
+	sel := bson.D{{"env-uuid", envuuid}, {"receiver", receiver}}
 	iter := actionsCollection.Find(sel).Iter()
 
 	for iter.Next(&doc) {
 		actions = append(actions, newAction(st, doc))
 	}
 	return actions, errors.Trace(iter.Close())
+
+}
+
+// ActionByTag returns an Action given an ActionTag
+func (st *State) ActionByTag(tag names.ActionTag) (*Action, error) {
+	return st.Action(actionIdFromTag(tag))
 }
 
 // ActionResult returns an ActionResult by Id.
@@ -1625,7 +1628,7 @@ func (st *State) ActionResult(id string) (*ActionResult, error) {
 	defer closer()
 
 	doc := actionResultDoc{}
-	err := actionresults.FindId(id).One(&doc)
+	err := actionresults.FindId(st.docID(id)).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("action result %q", id)
 	}
@@ -1635,7 +1638,7 @@ func (st *State) ActionResult(id string) (*ActionResult, error) {
 	return newActionResult(st, doc), nil
 }
 
-// matchingActionResults finds actions that match name
+// matchingActionResults finds action results from a given ActionReceiver.
 func (st *State) matchingActionResults(ar ActionReceiver) ([]*ActionResult, error) {
 	var doc actionResultDoc
 	var results []*ActionResult
@@ -1643,8 +1646,8 @@ func (st *State) matchingActionResults(ar ActionReceiver) ([]*ActionResult, erro
 	actionresults, closer := st.getCollection(actionresultsC)
 	defer closer()
 
-	prefix := actionResultPrefix(ar)
-	sel := bson.D{{"_id", bson.D{{"$regex", "^" + regexp.QuoteMeta(prefix)}}}}
+	envuuid := st.EnvironTag().Id()
+	sel := bson.D{{"env-uuid", envuuid}, {"receiver", ar.Name()}}
 	iter := actionresults.Find(sel).Iter()
 	for iter.Next(&doc) {
 		results = append(results, newActionResult(st, doc))

--- a/state/unit.go
+++ b/state/unit.go
@@ -1547,7 +1547,7 @@ func (u *Unit) AddAction(name string, payload map[string]interface{}) (*Action, 
 		Assert: notDeadDoc,
 	}, {
 		C:      actionsC,
-		Id:     doc.Id,
+		Id:     doc.DocId,
 		Assert: txn.DocMissing,
 		Insert: doc,
 	}}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1650,7 +1650,7 @@ func (w *idPrefixWatcher) loop() error {
 			if !ok {
 				return tomb.ErrDying
 			}
-			if err := mergeIds(changes, initial, updates); err != nil {
+			if err := mergeIds(w.st, changes, initial, updates); err != nil {
 				return err
 			}
 			if !changes.IsEmpty() {
@@ -1668,14 +1668,14 @@ func (w *idPrefixWatcher) loop() error {
 // makeIdFilter constructs a predicate to filter keys that have the
 // prefix matching one of the passed in ActionReceivers, or returns nil
 // if tags is empty
-func makeIdFilter(marker string, receivers ...ActionReceiver) func(interface{}) bool {
+func makeIdFilter(st *State, marker string, receivers ...ActionReceiver) func(interface{}) bool {
 	if len(receivers) == 0 {
 		return nil
 	}
 	ensureMarkerFn := ensureSuffixFn(marker)
 	prefixes := make([]string, len(receivers))
 	for ix, receiver := range receivers {
-		prefixes[ix] = ensureMarkerFn(receiver.Name())
+		prefixes[ix] = st.docID(ensureMarkerFn(receiver.Name()))
 	}
 
 	return func(key interface{}) bool {
@@ -1698,17 +1698,43 @@ func makeIdFilter(marker string, receivers ...ActionReceiver) func(interface{}) 
 func (w *idPrefixWatcher) initial() (set.Strings, error) {
 	var ids set.Strings
 	var doc struct {
-		Id string `bson:"_id"`
+		DocId string `bson:"_id"`
 	}
 	coll, closer := w.st.getCollection(w.targetC)
 	defer closer()
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
-		if w.filterFn == nil || w.filterFn(doc.Id) {
-			ids.Add(doc.Id)
+		if w.filterFn == nil || w.filterFn(doc.DocId) {
+			ids.Add(w.st.localID(doc.DocId))
 		}
 	}
 	return ids, iter.Close()
+}
+
+// mergeIds is used for merging actionId's and actionResultId's that
+// come in via the updates map. It cleans up the pending changes to
+// account for id's being removed before the watcher consumes them, and
+// to account for the slight potential overlap between the inital id's
+// pending before the watcher starts, and the id's the watcher detects.
+// Additionally, mergeIds strips the environment UUID prefix from the
+// id before emitting it through the watcher.
+func mergeIds(st *State, changes, initial set.Strings, updates map[interface{}]bool) error {
+	for id, exists := range updates {
+		switch id := id.(type) {
+		case string:
+			localId := st.localID(id)
+			if exists {
+				if !initial.Contains(localId) {
+					changes.Add(localId)
+				}
+			} else {
+				changes.Remove(localId)
+			}
+		default:
+			return errors.Errorf("id is not of type string, got %T", id)
+		}
+	}
+	return nil
 }
 
 // ensureSuffixFn returns a function that will make sure the passed in
@@ -1722,53 +1748,30 @@ func ensureSuffixFn(marker string) func(string) string {
 	}
 }
 
-// mergeIds is used for merging actionId's and actionResultId's that
-// come in via the updates map. It cleans up the pending changes to
-// account for id's being removed before the watcher consumes them, and
-// to account for the slight potential overlap between the inital id's
-// pending before the watcher starts, and the id's the watcher detects
-func mergeIds(changes, initial set.Strings, updates map[interface{}]bool) error {
-	for id, exists := range updates {
-		switch id := id.(type) {
-		case string:
-			if exists {
-				if !initial.Contains(id) {
-					changes.Add(id)
-				}
-			} else {
-				changes.Remove(id)
-			}
-		default:
-			return errors.Errorf("id is not of type string, got %T", id)
-		}
-	}
-	return nil
-}
-
 // WatchActions starts and returns a StringsWatcher that notifies on any
 // changes to the actions collection
 func (st *State) WatchActions() StringsWatcher {
-	return newIdPrefixWatcher(st, actionsC, makeIdFilter(actionMarker))
+	return newIdPrefixWatcher(st, actionsC, makeIdFilter(st, actionMarker))
 }
 
 // WatchActionsFilteredBy starts and returns a StringsWatcher that
 // notifies on changes to the actions collection that have Id's matching
 // the specified ActionReceivers
 func (st *State) WatchActionsFilteredBy(receivers ...ActionReceiver) StringsWatcher {
-	return newIdPrefixWatcher(st, actionsC, makeIdFilter(actionMarker, receivers...))
+	return newIdPrefixWatcher(st, actionsC, makeIdFilter(st, actionMarker, receivers...))
 }
 
 // WatchActionResults returns a StringsWatcher that notifies on changes
 // to the actionresults collection
 func (st *State) WatchActionResults() StringsWatcher {
-	return newIdPrefixWatcher(st, actionresultsC, makeIdFilter(actionResultMarker))
+	return newIdPrefixWatcher(st, actionresultsC, makeIdFilter(st, actionResultMarker))
 }
 
 // WatchActionResultsFilteredBy starts and returns a StringsWatcher that
 // notifies on changes to the actionresults collection that have Id's
 // matching the specified ActionReceivers
 func (st *State) WatchActionResultsFilteredBy(receivers ...ActionReceiver) StringsWatcher {
-	return newIdPrefixWatcher(st, actionresultsC, makeIdFilter(actionResultMarker, receivers...))
+	return newIdPrefixWatcher(st, actionresultsC, makeIdFilter(st, actionResultMarker, receivers...))
 }
 
 // machineInterfacesWatcher notifies about changes to all network interfaces

--- a/worker/uniter/filter_test.go
+++ b/worker/uniter/filter_test.go
@@ -497,7 +497,7 @@ func getAssertActionChange(s *FilterSuite, f *filter, c *gc.C) func(ids []string
 				c.Fatalf("timed out")
 			}
 		}
-		c.Assert(expected, jc.DeepEquals, seen)
+		c.Assert(seen, jc.DeepEquals, expected)
 
 		getAssertNoActionChange(s, f, c)()
 	}

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -2163,7 +2163,7 @@ func (s verifyActionResults) step(c *gc.C, ctx *context) {
 				c.Assert(err, gc.IsNil)
 				results, message := result.Results()
 				actualResults[i] = actionResult{
-					name:    result.ActionName(),
+					name:    result.Name(),
 					results: results,
 					status:  string(result.Status()),
 					message: message,


### PR DESCRIPTION
Also normalize Action and ActionResult methods to more closely resemble other entity use of methods like `Name()`, etc.
