### PR TITLE
Force-destroy machine if manual provisioning fails

### DIFF
--- a/cmd/juju/addmachine.go
+++ b/cmd/juju/addmachine.go
@@ -112,7 +112,7 @@ type addMachineAPI interface {
 	AddMachines([]params.AddMachineParams) ([]params.AddMachinesResult, error)
 	AddMachines1dot18([]params.AddMachineParams) ([]params.AddMachinesResult, error)
 	Close() error
-	DestroyMachines(machines ...string) error
+	ForceDestroyMachines(machines ...string) error
 	EnvironmentUUID() string
 	ProvisioningScript(params.ProvisioningScriptParams) (script string, err error)
 }

--- a/cmd/juju/addmachine_test.go
+++ b/cmd/juju/addmachine_test.go
@@ -234,7 +234,7 @@ func (f *fakeAddMachineAPI) AddMachines1dot18(args []params.AddMachineParams) ([
 	return f.AddMachines(args)
 }
 
-func (f *fakeAddMachineAPI) DestroyMachines(machines ...string) error {
+func (f *fakeAddMachineAPI) ForceDestroyMachines(machines ...string) error {
 	return fmt.Errorf("not implemented")
 }
 func (f *fakeAddMachineAPI) ProvisioningScript(params.ProvisioningScriptParams) (script string, err error) {

--- a/environs/manual/provisioner.go
+++ b/environs/manual/provisioner.go
@@ -32,7 +32,7 @@ var logger = loggo.GetLogger("juju.environs.manual")
 // consumer from the actual API implementation type.
 type ProvisioningClientAPI interface {
 	AddMachines([]params.AddMachineParams) ([]params.AddMachinesResult, error)
-	DestroyMachines(machines ...string) error
+	ForceDestroyMachines(machines ...string) error
 	ProvisioningScript(params.ProvisioningScriptParams) (script string, err error)
 }
 
@@ -74,7 +74,7 @@ func ProvisionMachine(args ProvisionMachineArgs) (machineId string, err error) {
 	defer func() {
 		if machineId != "" && err != nil {
 			logger.Errorf("provisioning failed, removing machine %v: %v", machineId, err)
-			if cleanupErr := args.Client.DestroyMachines(machineId); cleanupErr != nil {
+			if cleanupErr := args.Client.ForceDestroyMachines(machineId); cleanupErr != nil {
 				logger.Warningf("error cleaning up machine: %s", cleanupErr)
 			}
 			machineId = ""


### PR DESCRIPTION
If manual provisioning fails, we leave a machine
record in state that can only be removed with
"juju destroy-machine --force". We change the
manual provisioning code to call destroy the machine
with force if it fails.

(Partially) fixes https://bugs.launchpad.net/juju-core/+bug/1356886
