### PR TITLE
provider/maas: verify credentials early in bootstrap

### DIFF
--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -7,10 +7,9 @@ import (
 	"errors"
 	"net/http"
 
-	"launchpad.net/gomaasapi"
-
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
+	"launchpad.net/gomaasapi"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"


### PR DESCRIPTION
Verify credentials early in the bootstrap process by
issuing a query to MAAS and checking the status code
on the response (i.e. check if it's 401). Provide a
user-friendly error message, and log the underlying
error at debug level.

Partially fixes https://bugs.launchpad.net/juju-core/+bug/1362072
