### PR TITLE
uniter: open-port and close-port now sandboxed and validated

### DIFF
--- a/network/port.go
+++ b/network/port.go
@@ -135,10 +135,21 @@ type PortRange struct {
 func (p PortRange) Validate() error {
 	proto := strings.ToLower(p.Protocol)
 	if proto != "tcp" && proto != "udp" {
-		return errors.Errorf("invalid protocol %q", proto)
+		return errors.Errorf(`invalid protocol %q, expected "tcp" or "udp"`, proto)
 	}
-	if p.FromPort > p.ToPort {
-		return errors.Errorf("invalid port range %d-%d", p.FromPort, p.ToPort)
+	err := errors.Errorf(
+		"invalid port range %d-%d/%s",
+		p.FromPort,
+		p.ToPort,
+		p.Protocol,
+	)
+	switch {
+	case p.FromPort > p.ToPort:
+		return err
+	case p.FromPort < 1 || p.FromPort > 65535:
+		return err
+	case p.ToPort < 1 || p.ToPort > 65535:
+		return err
 	}
 	return nil
 }

--- a/network/port_test.go
+++ b/network/port_test.go
@@ -228,11 +228,31 @@ func (p *PortSuite) TestPortRangeValidity(c *gc.C) {
 	}, {
 		"invalid port range boundaries",
 		network.PortRange{90, 80, "tcp"},
-		"invalid port range.*",
+		"invalid port range 90-80/tcp",
+	}, {
+		"both FromPort and ToPort too large",
+		network.PortRange{88888, 99999, "tcp"},
+		"invalid port range 88888-99999/tcp",
+	}, {
+		"FromPort too large",
+		network.PortRange{88888, 65535, "tcp"},
+		"invalid port range 88888-65535/tcp",
+	}, {
+		"FromPort too small",
+		network.PortRange{0, 80, "tcp"},
+		"invalid port range 0-80/tcp",
+	}, {
+		"ToPort too large",
+		network.PortRange{1, 99999, "tcp"},
+		"invalid port range 1-99999/tcp",
+	}, {
+		"both ports 0",
+		network.PortRange{0, 0, "tcp"},
+		"invalid port range 0-0/tcp",
 	}, {
 		"invalid protocol",
 		network.PortRange{80, 80, "some protocol"},
-		"invalid protocol.*",
+		`invalid protocol "some protocol", expected "tcp" or "udp"`,
 	}}
 
 	for i, t := range testCases {

--- a/worker/uniter/context.go
+++ b/worker/uniter/context.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/version"
 	unitdebug "github.com/juju/juju/worker/uniter/debug"
 	"github.com/juju/juju/worker/uniter/jujuc"
@@ -53,6 +54,21 @@ func IsMissingHookError(err error) bool {
 type meterStatus struct {
 	code string
 	info string
+}
+
+// PortRangeInfo contains information about a pending open- or
+// close-port operation for a port range. This is only exported for
+// testing.
+type PortRangeInfo struct {
+	ShouldOpen  bool
+	RelationTag names.RelationTag
+}
+
+// PortRange contains a port range and a relation id. Used as key to
+// pendingRelations and is only exported for testing.
+type PortRange struct {
+	Ports      network.PortRange
+	RelationId int
 }
 
 // HookContext is the implementation of jujuc.Context.
@@ -121,6 +137,19 @@ type HookContext struct {
 
 	// meterStatus is the status of the unit's metering.
 	meterStatus *meterStatus
+
+	// pendingPorts contains a list of port ranges to be opened or
+	// closed when the current hook is committed.
+	pendingPorts map[PortRange]PortRangeInfo
+
+	// machinePorts contains cached information about all opened port
+	// ranges on the unit's assigned machine, mapped to the unit that
+	// opened each range and the relevant relation.
+	machinePorts map[network.PortRange]params.RelationUnit
+
+	// assignedMachineTag contains the tag of the unit's assigned
+	// machine.
+	assignedMachineTag names.MachineTag
 }
 
 func NewHookContext(
@@ -137,21 +166,24 @@ func NewHookContext(
 	proxySettings proxy.Settings,
 	canAddMetrics bool,
 	actionData *actionData,
+	assignedMachineTag names.MachineTag,
 ) (*HookContext, error) {
 	ctx := &HookContext{
-		unit:           unit,
-		state:          state,
-		id:             id,
-		uuid:           uuid,
-		envName:        envName,
-		relationId:     relationId,
-		remoteUnitName: remoteUnitName,
-		relations:      relations,
-		apiAddrs:       apiAddrs,
-		serviceOwner:   serviceOwner,
-		proxySettings:  proxySettings,
-		canAddMetrics:  canAddMetrics,
-		actionData:     actionData,
+		unit:               unit,
+		state:              state,
+		id:                 id,
+		uuid:               uuid,
+		envName:            envName,
+		relationId:         relationId,
+		remoteUnitName:     remoteUnitName,
+		relations:          relations,
+		apiAddrs:           apiAddrs,
+		serviceOwner:       serviceOwner,
+		proxySettings:      proxySettings,
+		canAddMetrics:      canAddMetrics,
+		actionData:         actionData,
+		pendingPorts:       make(map[PortRange]PortRangeInfo),
+		assignedMachineTag: assignedMachineTag,
 	}
 	// Get and cache the addresses.
 	var err error
@@ -162,6 +194,10 @@ func NewHookContext(
 	ctx.privateAddress, err = unit.PrivateAddress()
 	if err != nil && !params.IsCodeNoAddressSet(err) {
 		return nil, err
+	}
+	ctx.machinePorts, err = state.AllMachinePorts(ctx.assignedMachineTag)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	statusCode, statusInfo, err := unit.MeterStatus()
@@ -191,11 +227,19 @@ func (ctx *HookContext) PrivateAddress() (string, bool) {
 }
 
 func (ctx *HookContext) OpenPorts(protocol string, fromPort, toPort int) error {
-	return ctx.unit.OpenPorts(protocol, fromPort, toPort)
+	return tryOpenPorts(
+		protocol, fromPort, toPort,
+		ctx.unit.Tag(),
+		ctx.machinePorts, ctx.pendingPorts,
+	)
 }
 
 func (ctx *HookContext) ClosePorts(protocol string, fromPort, toPort int) error {
-	return ctx.unit.ClosePorts(protocol, fromPort, toPort)
+	return tryClosePorts(
+		protocol, fromPort, toPort,
+		ctx.unit.Tag(),
+		ctx.machinePorts, ctx.pendingPorts,
+	)
 }
 
 func (ctx *HookContext) OwnerTag() string {
@@ -417,6 +461,34 @@ func (ctx *HookContext) finalizeContext(process string, ctxErr error) (err error
 		rctx.ClearCache()
 	}
 
+	for rangeKey, rangeInfo := range ctx.pendingPorts {
+		if ctxErr == nil {
+			var e error
+			var op string
+			if rangeInfo.ShouldOpen {
+				e = ctx.unit.OpenPorts(
+					rangeKey.Ports.Protocol,
+					rangeKey.Ports.FromPort,
+					rangeKey.Ports.ToPort,
+				)
+				op = "open"
+			} else {
+				e = ctx.unit.ClosePorts(
+					rangeKey.Ports.Protocol,
+					rangeKey.Ports.FromPort,
+					rangeKey.Ports.ToPort,
+				)
+				op = "close"
+			}
+			if e != nil {
+				e = errors.Annotatef(e, "cannot %s %v", op, rangeKey.Ports)
+				logger.Errorf("%v", e)
+				if ctxErr == nil {
+					ctxErr = e
+				}
+			}
+		}
+	}
 	if ctxErr != nil {
 		return ctxErr
 	}
@@ -836,4 +908,148 @@ func addValueToMap(keys []string, value string, target map[string]interface{}) {
 		next[keys[i]] = m
 		next = m
 	}
+}
+
+func validatePortRange(protocol string, fromPort, toPort int) (network.PortRange, error) {
+	// Validate the given range.
+	newRange := network.PortRange{
+		Protocol: strings.ToLower(protocol),
+		FromPort: fromPort,
+		ToPort:   toPort,
+	}
+	if err := newRange.Validate(); err != nil {
+		return network.PortRange{}, err
+	}
+	return newRange, nil
+}
+
+func tryOpenPorts(
+	protocol string,
+	fromPort, toPort int,
+	unitTag names.UnitTag,
+	machinePorts map[network.PortRange]params.RelationUnit,
+	pendingPorts map[PortRange]PortRangeInfo,
+) error {
+	// TODO(dimitern) Once port ranges are linked to relations in
+	// addition to networks, refactor this functions and test it
+	// better to ensure it handles relations properly.
+	relationId := -1
+
+	//Validate the given range.
+	newRange, err := validatePortRange(protocol, fromPort, toPort)
+	if err != nil {
+		return err
+	}
+	rangeKey := PortRange{
+		Ports:      newRange,
+		RelationId: relationId,
+	}
+
+	rangeInfo, isKnown := pendingPorts[rangeKey]
+	if isKnown {
+		if !rangeInfo.ShouldOpen {
+			// If the same range is already pending to be closed, just
+			// mark is pending to be opened.
+			rangeInfo.ShouldOpen = true
+			pendingPorts[rangeKey] = rangeInfo
+		}
+		return nil
+	}
+
+	// Ensure there are no conflicts with existing ports on the
+	// machine.
+	for portRange, relUnit := range machinePorts {
+		relUnitTag, err := names.ParseUnitTag(relUnit.Unit)
+		if err != nil {
+			return errors.Annotatef(
+				err,
+				"machine ports %v contain invalid unit tag",
+				portRange,
+			)
+		}
+		if newRange.ConflictsWith(portRange) {
+			if portRange == newRange && relUnitTag == unitTag {
+				// The same unit trying to open the same range is just
+				// ignored.
+				return nil
+			}
+			return errors.Errorf(
+				"cannot open %v (unit %q): conflicts with existing %v (unit %q)",
+				newRange, unitTag.Id(), portRange, relUnitTag.Id(),
+			)
+		}
+	}
+	// Ensure other pending port ranges do not conflict with this one.
+	for rangeKey, rangeInfo := range pendingPorts {
+		if newRange.ConflictsWith(rangeKey.Ports) && rangeInfo.ShouldOpen {
+			return errors.Errorf(
+				"cannot open %v (unit %q): conflicts with %v requested earlier",
+				newRange, unitTag.Id(), rangeKey.Ports,
+			)
+		}
+	}
+
+	rangeInfo = pendingPorts[rangeKey]
+	rangeInfo.ShouldOpen = true
+	pendingPorts[rangeKey] = rangeInfo
+	return nil
+}
+
+func tryClosePorts(
+	protocol string,
+	fromPort, toPort int,
+	unitTag names.UnitTag,
+	machinePorts map[network.PortRange]params.RelationUnit,
+	pendingPorts map[PortRange]PortRangeInfo,
+) error {
+	// TODO(dimitern) Once port ranges are linked to relations in
+	// addition to networks, refactor this functions and test it
+	// better to ensure it handles relations properly.
+	relationId := -1
+
+	// Validate the given range.
+	newRange, err := validatePortRange(protocol, fromPort, toPort)
+	if err != nil {
+		return err
+	}
+	rangeKey := PortRange{
+		Ports:      newRange,
+		RelationId: relationId,
+	}
+
+	rangeInfo, isKnown := pendingPorts[rangeKey]
+	if isKnown {
+		if rangeInfo.ShouldOpen {
+			// If the same range is already pending to be opened, just
+			// remove it from pending.
+			delete(pendingPorts, rangeKey)
+		}
+		return nil
+	}
+
+	// Ensure the range we're trying to close is opened on the
+	// machine.
+	relUnit, found := machinePorts[newRange]
+	if !found {
+		// Trying to close a range which is not open is ignored.
+		return nil
+	} else if relUnit.Unit != unitTag.String() {
+		relUnitTag, err := names.ParseUnitTag(relUnit.Unit)
+		if err != nil {
+			return errors.Annotatef(
+				err,
+				"machine ports %v contain invalid unit tag",
+				newRange,
+			)
+		}
+		return errors.Errorf(
+			"cannot close %v (opened by %q) from %q",
+			newRange, relUnitTag.Id(), unitTag.Id(),
+		)
+	}
+
+	rangeInfo = pendingPorts[rangeKey]
+	rangeInfo.ShouldOpen = false
+	pendingPorts[rangeKey] = rangeInfo
+	return nil
 }

--- a/worker/uniter/context_test.go
+++ b/worker/uniter/context_test.go
@@ -425,6 +425,98 @@ func (s *RunHookSuite) TestRunHookMetricSendingDisabled(c *gc.C) {
 	c.Assert(metricBatches, gc.HasLen, 0)
 }
 
+func (s *RunHookSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
+	// Initially, no port ranges are open on the unit or its machine.
+	unitRanges, err := s.unit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(unitRanges, gc.HasLen, 0)
+	machinePorts, err := s.machine.AllPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(machinePorts, gc.HasLen, 0)
+
+	// Add another unit on the same machine.
+	otherUnit, err := s.service.AddUnit()
+	c.Assert(err, gc.IsNil)
+	err = otherUnit.AssignToMachine(s.machine)
+	c.Assert(err, gc.IsNil)
+
+	// Open some ports on both units.
+	err = s.unit.OpenPorts("tcp", 100, 200)
+	c.Assert(err, gc.IsNil)
+	err = otherUnit.OpenPorts("udp", 200, 300)
+	c.Assert(err, gc.IsNil)
+
+	unitRanges, err = s.unit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(unitRanges, jc.DeepEquals, []network.PortRange{
+		{100, 200, "tcp"},
+	})
+
+	// Get the context.
+	uuid, err := utils.NewUUID()
+	c.Assert(err, gc.IsNil)
+	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, false)
+	charmDir, _ := makeCharm(c, hookSpec{
+		name: "some-hook",
+		perm: 0700,
+	})
+
+	// Try opening some ports via the context.
+	err = ctx.OpenPorts("tcp", 100, 200)
+	c.Assert(err, gc.IsNil) // duplicates are ignored
+	err = ctx.OpenPorts("udp", 200, 300)
+	c.Assert(err, gc.ErrorMatches, `cannot open 200-300/udp \(unit "u/0"\): conflicts with existing 200-300/udp \(unit "u/1"\)`)
+	err = ctx.OpenPorts("udp", 100, 200)
+	c.Assert(err, gc.ErrorMatches, `cannot open 100-200/udp \(unit "u/0"\): conflicts with existing 200-300/udp \(unit "u/1"\)`)
+	err = ctx.OpenPorts("udp", 10, 20)
+	c.Assert(err, gc.IsNil)
+	err = ctx.OpenPorts("tcp", 50, 100)
+	c.Assert(err, gc.ErrorMatches, `cannot open 50-100/tcp \(unit "u/0"\): conflicts with existing 100-200/tcp \(unit "u/0"\)`)
+	err = ctx.OpenPorts("tcp", 50, 80)
+	c.Assert(err, gc.IsNil)
+	err = ctx.OpenPorts("tcp", 40, 90)
+	c.Assert(err, gc.ErrorMatches, `cannot open 40-90/tcp \(unit "u/0"\): conflicts with 50-80/tcp requested earlier`)
+
+	// Now try closing some ports as well.
+	err = ctx.ClosePorts("udp", 8080, 8088)
+	c.Assert(err, gc.IsNil) // not existing -> ignored
+	err = ctx.ClosePorts("tcp", 100, 200)
+	c.Assert(err, gc.IsNil)
+	err = ctx.ClosePorts("tcp", 100, 200)
+	c.Assert(err, gc.IsNil) // duplicates are ignored
+	err = ctx.ClosePorts("udp", 200, 300)
+	c.Assert(err, gc.ErrorMatches, `cannot close 200-300/udp \(opened by "u/1"\) from "u/0"`)
+	err = ctx.ClosePorts("tcp", 50, 80)
+	c.Assert(err, gc.IsNil) // still pending -> no longer pending
+
+	// Ensure the ports are not actually changed on the unit yet.
+	unitRanges, err = s.unit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(unitRanges, jc.DeepEquals, []network.PortRange{
+		{100, 200, "tcp"},
+	})
+
+	// Simulate a hook ran and was committed successfully.
+	err = ctx.RunHook("some-hook", charmDir, c.MkDir(), "/path/to/socket")
+	c.Assert(err, gc.IsNil)
+
+	// Verify the unit ranges are now open.
+	expectUnitRanges := []network.PortRange{
+		{FromPort: 10, ToPort: 20, Protocol: "udp"},
+	}
+	unitRanges, err = s.unit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(unitRanges, jc.DeepEquals, expectUnitRanges)
+
+	// Test idempotency by running the hook again.
+	err = ctx.RunHook("some-hook", charmDir, c.MkDir(), "/path/to/socket")
+	c.Assert(err, gc.IsNil)
+
+	unitRanges, err = s.unit.OpenedPorts()
+	c.Assert(err, gc.IsNil)
+	c.Assert(unitRanges, jc.DeepEquals, expectUnitRanges)
+}
+
 type ContextRelationSuite struct {
 	testing.JujuConnSuite
 	svc *state.Service
@@ -727,6 +819,258 @@ func (s *InterfaceSuite) TestConfigCaching(c *gc.C) {
 	c.Assert(settings, gc.DeepEquals, charm.Settings{"blog-title": "My Title"})
 }
 
+func (s *InterfaceSuite) TestValidatePortRange(c *gc.C) {
+	tests := []struct {
+		about     string
+		proto     string
+		ports     []int
+		portRange network.PortRange
+		expectErr string
+	}{{
+		about:     "invalid range - 0-0/tcp",
+		proto:     "tcp",
+		ports:     []int{0, 0},
+		expectErr: "invalid port range 0-0/tcp",
+	}, {
+		about:     "invalid range - 0-1/tcp",
+		proto:     "tcp",
+		ports:     []int{0, 1},
+		expectErr: "invalid port range 0-1/tcp",
+	}, {
+		about:     "invalid range - -1-1/tcp",
+		proto:     "tcp",
+		ports:     []int{-1, 1},
+		expectErr: "invalid port range -1-1/tcp",
+	}, {
+		about:     "invalid range - 1-99999/tcp",
+		proto:     "tcp",
+		ports:     []int{1, 99999},
+		expectErr: "invalid port range 1-99999/tcp",
+	}, {
+		about:     "invalid range - 88888-99999/tcp",
+		proto:     "tcp",
+		ports:     []int{88888, 99999},
+		expectErr: "invalid port range 88888-99999/tcp",
+	}, {
+		about:     "invalid protocol - 1-65535/foo",
+		proto:     "foo",
+		ports:     []int{1, 65535},
+		expectErr: `invalid protocol "foo", expected "tcp" or "udp"`,
+	}, {
+		about: "valid range - 100-200/udp",
+		proto: "UDP",
+		ports: []int{100, 200},
+		portRange: network.PortRange{
+			FromPort: 100,
+			ToPort:   200,
+			Protocol: "udp",
+		},
+	}, {
+		about: "valid single port - 100/tcp",
+		proto: "TCP",
+		ports: []int{100, 100},
+		portRange: network.PortRange{
+			FromPort: 100,
+			ToPort:   100,
+			Protocol: "tcp",
+		},
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.about)
+		portRange, err := uniter.ValidatePortRange(
+			test.proto,
+			test.ports[0],
+			test.ports[1],
+		)
+		if test.expectErr != "" {
+			c.Check(err, gc.ErrorMatches, test.expectErr)
+			c.Check(portRange, jc.DeepEquals, network.PortRange{})
+		} else {
+			c.Check(err, gc.IsNil)
+			c.Check(portRange, jc.DeepEquals, test.portRange)
+		}
+	}
+}
+
+func makeMachinePorts(
+	unitName, proto string, fromPort, toPort int,
+) map[network.PortRange]params.RelationUnit {
+	result := make(map[network.PortRange]params.RelationUnit)
+	portRange := network.PortRange{
+		FromPort: fromPort,
+		ToPort:   toPort,
+		Protocol: proto,
+	}
+	unitTag := ""
+	if unitName != "invalid" {
+		unitTag = names.NewUnitTag(unitName).String()
+	} else {
+		unitTag = unitName
+	}
+	result[portRange] = params.RelationUnit{
+		Unit: unitTag,
+	}
+	return result
+}
+
+func makePendingPorts(
+	proto string, fromPort, toPort int, shouldOpen bool,
+) map[uniter.PortRange]uniter.PortRangeInfo {
+	result := make(map[uniter.PortRange]uniter.PortRangeInfo)
+	portRange := network.PortRange{
+		FromPort: fromPort,
+		ToPort:   toPort,
+		Protocol: proto,
+	}
+	key := uniter.PortRange{
+		Ports:      portRange,
+		RelationId: -1,
+	}
+	result[key] = uniter.PortRangeInfo{
+		ShouldOpen: shouldOpen,
+	}
+	return result
+}
+
+type portsTest struct {
+	about         string
+	proto         string
+	ports         []int
+	machinePorts  map[network.PortRange]params.RelationUnit
+	pendingPorts  map[uniter.PortRange]uniter.PortRangeInfo
+	expectErr     string
+	expectPending map[uniter.PortRange]uniter.PortRangeInfo
+}
+
+func (p portsTest) withDefaults(proto string, fromPort, toPort int) portsTest {
+	if p.proto == "" {
+		p.proto = proto
+	}
+	if len(p.ports) != 2 {
+		p.ports = []int{fromPort, toPort}
+	}
+	if p.pendingPorts == nil {
+		p.pendingPorts = make(map[uniter.PortRange]uniter.PortRangeInfo)
+	}
+	return p
+}
+
+func (s *InterfaceSuite) TestTryOpenPorts(c *gc.C) {
+	tests := []portsTest{{
+		about:     "invalid port range",
+		ports:     []int{0, 0},
+		expectErr: "invalid port range 0-0/tcp",
+	}, {
+		about:     "invalid protocol - 10-20/foo",
+		proto:     "foo",
+		expectErr: `invalid protocol "foo", expected "tcp" or "udp"`,
+	}, {
+		about:         "open a new range (no machine ports yet)",
+		expectPending: makePendingPorts("tcp", 10, 20, true),
+	}, {
+		about:         "open an existing range (ignored)",
+		machinePorts:  makeMachinePorts("u/0", "tcp", 10, 20),
+		expectPending: map[uniter.PortRange]uniter.PortRangeInfo{},
+	}, {
+		about:         "open a range pending to be closed already",
+		pendingPorts:  makePendingPorts("tcp", 10, 20, false),
+		expectPending: makePendingPorts("tcp", 10, 20, true),
+	}, {
+		about:         "open a range pending to be opened already (ignored)",
+		pendingPorts:  makePendingPorts("tcp", 10, 20, true),
+		expectPending: makePendingPorts("tcp", 10, 20, true),
+	}, {
+		about:        "try opening a range when machine ports has invalid unit tag",
+		machinePorts: makeMachinePorts("invalid", "tcp", 80, 90),
+		expectErr:    `machine ports 80-90/tcp contain invalid unit tag: "invalid" is not a valid tag`,
+	}, {
+		about:        "try opening a range conflicting with another unit",
+		machinePorts: makeMachinePorts("u/1", "tcp", 10, 20),
+		expectErr:    `cannot open 10-20/tcp \(unit "u/0"\): conflicts with existing 10-20/tcp \(unit "u/1"\)`,
+	}, {
+		about:         "open a range conflicting with the same unit (ignored)",
+		machinePorts:  makeMachinePorts("u/0", "tcp", 10, 20),
+		expectPending: map[uniter.PortRange]uniter.PortRangeInfo{},
+	}, {
+		about:        "try opening a range conflicting with another pending range",
+		pendingPorts: makePendingPorts("tcp", 5, 25, true),
+		expectErr:    `cannot open 10-20/tcp \(unit "u/0"\): conflicts with 5-25/tcp requested earlier`,
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.about)
+
+		test = test.withDefaults("tcp", 10, 20)
+		err := uniter.TryOpenPorts(
+			test.proto,
+			test.ports[0],
+			test.ports[1],
+			names.NewUnitTag("u/0"),
+			test.machinePorts,
+			test.pendingPorts,
+		)
+		if test.expectErr != "" {
+			c.Check(err, gc.ErrorMatches, test.expectErr)
+		} else {
+			c.Check(err, gc.IsNil)
+			c.Check(test.pendingPorts, jc.DeepEquals, test.expectPending)
+		}
+	}
+}
+
+func (s *InterfaceSuite) TestTryClosePorts(c *gc.C) {
+	tests := []portsTest{{
+		about:     "invalid port range",
+		ports:     []int{0, 0},
+		expectErr: "invalid port range 0-0/tcp",
+	}, {
+		about:     "invalid protocol - 10-20/foo",
+		proto:     "foo",
+		expectErr: `invalid protocol "foo", expected "tcp" or "udp"`,
+	}, {
+		about:         "close a new range (no machine ports yet; ignored)",
+		expectPending: map[uniter.PortRange]uniter.PortRangeInfo{},
+	}, {
+		about:         "close an existing range",
+		machinePorts:  makeMachinePorts("u/0", "tcp", 10, 20),
+		expectPending: makePendingPorts("tcp", 10, 20, false),
+	}, {
+		about:         "close a range pending to be opened already (removed from pending)",
+		pendingPorts:  makePendingPorts("tcp", 10, 20, true),
+		expectPending: map[uniter.PortRange]uniter.PortRangeInfo{},
+	}, {
+		about:         "close a range pending to be closed already (ignored)",
+		pendingPorts:  makePendingPorts("tcp", 10, 20, false),
+		expectPending: makePendingPorts("tcp", 10, 20, false),
+	}, {
+		about:        "try closing an existing range when machine ports has invalid unit tag",
+		machinePorts: makeMachinePorts("invalid", "tcp", 10, 20),
+		expectErr:    `machine ports 10-20/tcp contain invalid unit tag: "invalid" is not a valid tag`,
+	}, {
+		about:        "try closing a range of another unit",
+		machinePorts: makeMachinePorts("u/1", "tcp", 10, 20),
+		expectErr:    `cannot close 10-20/tcp \(opened by "u/1"\) from "u/0"`,
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.about)
+
+		test = test.withDefaults("tcp", 10, 20)
+		err := uniter.TryClosePorts(
+			test.proto,
+			test.ports[0],
+			test.ports[1],
+			names.NewUnitTag("u/0"),
+			test.machinePorts,
+			test.pendingPorts,
+		)
+		if test.expectErr != "" {
+			c.Check(err, gc.ErrorMatches, test.expectErr)
+		} else {
+			c.Check(err, gc.IsNil)
+			c.Check(test.pendingPorts, jc.DeepEquals, test.expectPending)
+		}
+	}
+}
+
 type HookContextSuite struct {
 	testing.JujuConnSuite
 	service  *state.Service
@@ -809,9 +1153,11 @@ func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int,
 		_, found := s.relctxs[relid]
 		c.Assert(found, jc.IsTrue)
 	}
-	context, err := uniter.NewHookContext(s.apiUnit, nil, "TestCtx", uuid,
+	facade, err := s.st.Uniter()
+	c.Assert(err, gc.IsNil)
+	context, err := uniter.NewHookContext(s.apiUnit, facade, "TestCtx", uuid,
 		"test-env-name", relid, remote, s.relctxs, apiAddrs, names.NewUserTag("owner"),
-		proxies, addMetrics, nil)
+		proxies, addMetrics, nil, s.machine.Tag().(names.MachineTag))
 	c.Assert(err, gc.IsNil)
 	return context
 }

--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -3,9 +3,7 @@
 
 package uniter
 
-import (
-	"github.com/juju/utils/proxy"
-)
+import "github.com/juju/utils/proxy"
 
 func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
 	u.observer = observer
@@ -58,10 +56,12 @@ func (ctx *HookContext) PatchMeterStatus(code, info string) func() {
 	}
 }
 
-var MergeEnvironment = mergeEnvironment
-
-var SearchHook = searchHook
-
-var HookCommand = hookCommand
-
-var LookPath = lookPath
+var (
+	MergeEnvironment  = mergeEnvironment
+	SearchHook        = searchHook
+	HookCommand       = hookCommand
+	LookPath          = lookPath
+	ValidatePortRange = validatePortRange
+	TryOpenPorts      = tryOpenPorts
+	TryClosePorts     = tryClosePorts
+)


### PR DESCRIPTION
An important improvement in supporting opening and
closing port ranges for charms is to also provide
sandboxing for these operations. This PR implements
an internal caching of all pending port ranges to
open or close for the unit, as well as existing ports
opened on the unit's assigned machine by other units.
Each time open-port or close-port is called, we validate
the given range against other existing ranges on the
machine and other pending ranges and returns errors
when there's a conflict. Ports are only actually opened
or closed when the current hook is committed.

NOTE: This was proposed as WIP as dimitern:#5 and was
reviewed as http://reviews.vapour.ws/r/125/. After
fixing some suggestions from reviews, now proposing
against juju:master
