### PR TITLE
uniter: added opened-ports hook tool

### DIFF
--- a/cmd/juju/helptool.go
+++ b/cmd/juju/helptool.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/charm.v4"
 	"launchpad.net/gnuflag"
 
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker/uniter/jujuc"
 )
 
@@ -34,6 +35,9 @@ func (dummyHookContext) OpenPort(protocol string, port int) error {
 	return nil
 }
 func (dummyHookContext) ClosePort(protocol string, port int) error {
+	return nil
+}
+func (dummyHookContext) OpenedPorts() []network.PortRange {
 	return nil
 }
 func (dummyHookContext) ConfigSettings() (charm.Settings, error) {

--- a/worker/uniter/context.go
+++ b/worker/uniter/context.go
@@ -242,6 +242,17 @@ func (ctx *HookContext) ClosePorts(protocol string, fromPort, toPort int) error 
 	)
 }
 
+func (ctx *HookContext) OpenedPorts() []network.PortRange {
+	var unitRanges []network.PortRange
+	for portRange, relUnit := range ctx.machinePorts {
+		if relUnit.Unit == ctx.unit.Tag().String() {
+			unitRanges = append(unitRanges, portRange)
+		}
+	}
+	network.SortPortRanges(unitRanges)
+	return unitRanges
+}
+
 func (ctx *HookContext) OwnerTag() string {
 	return ctx.serviceOwner.String()
 }

--- a/worker/uniter/jujuc/context.go
+++ b/worker/uniter/jujuc/context.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 )
 
 // Context is the interface that all hook helper commands
@@ -35,6 +36,11 @@ type Context interface {
 	// the executing unit's service is exposed (unless it is opened
 	// separately by a co- located unit).
 	ClosePorts(protocol string, fromPort, toPort int) error
+
+	// OpenedPorts returns all port ranges currently opened by this
+	// unit on its assigned machine. The result is sorted first by
+	// protocol, then by number.
+	OpenedPorts() []network.PortRange
 
 	// Config returns the current service configuration of the executing unit.
 	ConfigSettings() (charm.Settings, error)

--- a/worker/uniter/jujuc/opened-ports.go
+++ b/worker/uniter/jujuc/opened-ports.go
@@ -1,0 +1,47 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+)
+
+// OpenedPortsCommand implements the opened-ports command.
+type OpenedPortsCommand struct {
+	cmd.CommandBase
+	ctx Context
+	out cmd.Output
+}
+
+func NewOpenedPortsCommand(ctx Context) cmd.Command {
+	return &OpenedPortsCommand{ctx: ctx}
+}
+
+func (c *OpenedPortsCommand) Info() *cmd.Info {
+	doc := `Each list entry has format <port>/<protocol> (e.g. "80/tcp") or
+<from>-<to>/<protocol> (e.g. "8080-8088/udp").`
+	return &cmd.Info{
+		Name:    "opened-ports",
+		Purpose: "lists all ports or ranges opened by the unit",
+		Doc:     doc,
+	}
+}
+
+func (c *OpenedPortsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+}
+
+func (c *OpenedPortsCommand) Init(args []string) error {
+	return cmd.CheckEmpty(args)
+}
+
+func (c *OpenedPortsCommand) Run(ctx *cmd.Context) error {
+	unitPorts := c.ctx.OpenedPorts()
+	results := make([]string, len(unitPorts))
+	for i, portRange := range unitPorts {
+		results[i] = portRange.String()
+	}
+	return c.out.Write(ctx, results)
+}

--- a/worker/uniter/jujuc/opened-ports_test.go
+++ b/worker/uniter/jujuc/opened-ports_test.go
@@ -1,0 +1,98 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/jujuc"
+)
+
+type OpenedPortsSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&OpenedPortsSuite{})
+
+func (s *OpenedPortsSuite) TestRunAllFormats(c *gc.C) {
+	expectedPorts := []network.PortRange{
+		{10, 20, "tcp"},
+		{80, 80, "tcp"},
+		{53, 55, "udp"},
+		{63, 63, "udp"},
+	}
+	network.SortPortRanges(expectedPorts)
+	portsAsStrings := make([]string, len(expectedPorts))
+	for i, portRange := range expectedPorts {
+		portsAsStrings[i] = portRange.String()
+	}
+	defaultOutput := strings.Join(portsAsStrings, "\n") + "\n"
+	jsonOutput := `["` + strings.Join(portsAsStrings, `","`) + `"]` + "\n"
+	yamlOutput := "- " + strings.Join(portsAsStrings, "\n- ") + "\n"
+
+	formatToOutput := map[string]string{
+		"":      defaultOutput,
+		"smart": defaultOutput,
+		"json":  jsonOutput,
+		"yaml":  yamlOutput,
+	}
+	for format, expectedOutput := range formatToOutput {
+		hctx := s.getContextAndOpenPorts(c)
+		stdout := ""
+		stderr := ""
+		if format == "" {
+			stdout, stderr = s.runCommand(c, hctx)
+		} else {
+			stdout, stderr = s.runCommand(c, hctx, "--format", format)
+		}
+		c.Check(stdout, gc.Equals, expectedOutput)
+		c.Check(stderr, gc.Equals, "")
+		c.Check(hctx.ports, gc.DeepEquals, expectedPorts)
+	}
+}
+
+func (s *OpenedPortsSuite) TestBadArgs(c *gc.C) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, cmdString("opened-ports"))
+	c.Assert(err, gc.IsNil)
+	err = testing.InitCommand(com, []string{"foo"})
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["foo"\]`)
+}
+
+func (s *OpenedPortsSuite) TestHelp(c *gc.C) {
+	hctx := s.GetHookContext(c, -1, "")
+	openedPorts, err := jujuc.NewCommand(hctx, cmdString("opened-ports"))
+	c.Assert(err, gc.IsNil)
+	flags := testing.NewFlagSet()
+	c.Assert(string(openedPorts.Info().Help(flags)), gc.Equals, `
+usage: opened-ports
+purpose: lists all ports or ranges opened by the unit
+
+Each list entry has format <port>/<protocol> (e.g. "80/tcp") or
+<from>-<to>/<protocol> (e.g. "8080-8088/udp").
+`[1:])
+}
+
+func (s *OpenedPortsSuite) getContextAndOpenPorts(c *gc.C) *Context {
+	hctx := s.GetHookContext(c, -1, "")
+	hctx.OpenPorts("tcp", 80, 80)
+	hctx.OpenPorts("tcp", 10, 20)
+	hctx.OpenPorts("udp", 63, 63)
+	hctx.OpenPorts("udp", 53, 55)
+	return hctx
+}
+
+func (s *OpenedPortsSuite) runCommand(c *gc.C, hctx *Context, args ...string) (stdout, stderr string) {
+	com, err := jujuc.NewCommand(hctx, cmdString("opened-ports"))
+	c.Assert(err, gc.IsNil)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, args)
+	c.Assert(code, gc.Equals, 0)
+	return bufferString(ctx.Stdout), bufferString(ctx.Stderr)
+}

--- a/worker/uniter/jujuc/server.go
+++ b/worker/uniter/jujuc/server.go
@@ -30,6 +30,7 @@ var newCommands = map[string]func(Context) cmd.Command{
 	"config-get" + cmdSuffix:    NewConfigGetCommand,
 	"juju-log" + cmdSuffix:      NewJujuLogCommand,
 	"open-port" + cmdSuffix:     NewOpenPortCommand,
+	"opened-ports" + cmdSuffix:  NewOpenedPortsCommand,
 	"relation-get" + cmdSuffix:  NewRelationGetCommand,
 	"action-get" + cmdSuffix:    NewActionGetCommand,
 	"action-set" + cmdSuffix:    NewActionSetCommand,

--- a/worker/uniter/jujuc/server_test.go
+++ b/worker/uniter/jujuc/server_test.go
@@ -196,6 +196,7 @@ var newCommandTests = []struct {
 	{"config-get", ""},
 	{"juju-log", ""},
 	{"open-port", ""},
+	{"opened-ports", ""},
 	{"relation-get", ""},
 	{"relation-ids", ""},
 	{"relation-list", ""},


### PR DESCRIPTION
Final step in enabling support to open and close port
ranges from charms is the new "opened-ports" hook tool.
It returns a sorted list of all port ranges opened by
the current unit, like this:

10-20/tcp
80-90/tcp
100-200/udp
8080/udp

As a side-effect, this patch also fixes the following
bug: http://pad.lv/1216644
