### PR TITLE
state: ParseTag now returns interface ids

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -223,7 +223,7 @@ func MinUnitsRevno(st *State, serviceName string) (int, error) {
 	return doc.Revno, nil
 }
 
-func ParseTag(st *State, tag names.Tag) (string, string, error) {
+func ParseTag(st *State, tag names.Tag) (string, interface{}, error) {
 	return st.parseTag(tag)
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -606,9 +606,9 @@ func (st *State) FindEntity(tag names.Tag) (Entity, error) {
 
 // parseTag, given an entity tag, returns the collection name and id
 // of the entity document.
-func (st *State) parseTag(tag names.Tag) (string, string, error) {
+func (st *State) parseTag(tag names.Tag) (string, interface{}, error) {
 	if tag == nil {
-		return "", "", errors.Errorf("tag is nil")
+		return "", nil, errors.Errorf("tag is nil")
 	}
 	coll := ""
 	id := tag.Id()
@@ -624,7 +624,7 @@ func (st *State) parseTag(tag names.Tag) (string, string, error) {
 	case names.UserTag:
 		coll = usersC
 		if !tag.IsLocal() {
-			return "", "", fmt.Errorf("%q is not a local user", tag.Username())
+			return "", nil, fmt.Errorf("%q is not a local user", tag.Username())
 		}
 		id = tag.Name()
 	case names.RelationTag:
@@ -637,7 +637,7 @@ func (st *State) parseTag(tag names.Tag) (string, string, error) {
 		coll = actionsC
 		id = actionIdFromTag(tag)
 	default:
-		return "", "", errors.Errorf("%q is not a valid collection tag", tag)
+		return "", nil, errors.Errorf("%q is not a valid collection tag", tag)
 	}
 	return coll, id, nil
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2420,7 +2420,7 @@ func (s *StateSuite) TestParseNilTagReturnsAnError(c *gc.C) {
 	coll, id, err := state.ParseTag(s.State, nil)
 	c.Assert(err, gc.ErrorMatches, "tag is nil")
 	c.Assert(coll, gc.Equals, "")
-	c.Assert(id, gc.Equals, "")
+	c.Assert(id, gc.IsNil)
 }
 
 func (s *StateSuite) TestParseMachineTag(c *gc.C) {


### PR DESCRIPTION
Instead of assuming that all collection ids will be strings, they are now returned as interface{}. This is required to support subdocument style document ids (coming soon).

http://reviews.vapour.ws/r/148/diff/
