### PR TITLE
Exluding provisioner tests for ppc and arm archs as gcc report compiler ...

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -1,7 +1,6 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-
 // TODO(anastasia) 2014-10-08 #1378716
 // Re-enable tests for PPC64/ARM64 when the fixed gccgo has been backported to trusty and the CI machines have been updated.
 


### PR DESCRIPTION
...errors.

 GCC has been fixed but are not yet available.
