### PR TITLE
worker/uniter/jujuc: Fix TestAddMetric on gccgo

### DIFF
--- a/worker/uniter/jujuc/add-metric_test.go
+++ b/worker/uniter/jujuc/add-metric_test.go
@@ -97,7 +97,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			2,
 			"",
-			"error: cannot set the same metric key twice: \"key\" already set\n",
+			"error: duplicate metric key given: \"key\"\n",
 			nil,
 		}, {
 			"can't add metrics",
@@ -116,15 +116,13 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		ctx := testing.Context(c)
 		ret := cmd.Main(com, ctx, t.cmd[1:])
-		c.Assert(ret, gc.Equals, t.result)
-		c.Assert(bufferString(ctx.Stdout), gc.Equals, t.stdout)
-		c.Assert(bufferString(ctx.Stderr), gc.Equals, t.stderr)
-		c.Assert(len(hctx.metrics), gc.Equals, len(t.expect))
-		if len(t.expect) > 0 {
-			for i, expected := range t.expect {
-				c.Assert(expected.Key, gc.Equals, hctx.metrics[i].Key)
-				c.Assert(expected.Value, gc.Equals, hctx.metrics[i].Value)
-			}
+		c.Check(ret, gc.Equals, t.result)
+		c.Check(bufferString(ctx.Stdout), gc.Equals, t.stdout)
+		c.Check(bufferString(ctx.Stderr), gc.Equals, t.stderr)
+		c.Check(hctx.metrics, gc.HasLen, len(t.expect))
+		for i, expected := range t.expect {
+			c.Check(expected.Key, gc.Equals, hctx.metrics[i].Key)
+			c.Check(expected.Value, gc.Equals, hctx.metrics[i].Value)
 		}
 	}
 }


### PR DESCRIPTION
Change logic of add-metric command to avoid relying on map ordering
in tests, which is undefined and different on gccgo. Rather than
recording metrics as a map, keep it as a slice, but use a map when
parsing to check and error still on duplicate keys.

Also shortens error message on duplicate keys and makes output
from TestAddMetrics clearer.

http://reviews.vapour.ws/r/159/
