### PR TITLE
apiserver/uniter: Fix TestAllMachinePorts on gccgo

### DIFF
--- a/apiserver/uniter/uniter_v1_test.go
+++ b/apiserver/uniter/uniter_v1_test.go
@@ -391,9 +391,9 @@ func (s *uniterV1Suite) TestAllMachinePorts(c *gc.C) {
 	}}
 	expectPorts := []params.MachinePortRange{
 		{UnitTag: "unit-wordpress-0", PortRange: network.PortRange{100, 200, "tcp"}},
-		{UnitTag: "unit-wordpress-0", PortRange: network.PortRange{10, 20, "udp"}},
 		{UnitTag: "unit-mysql-1", PortRange: network.PortRange{201, 250, "tcp"}},
 		{UnitTag: "unit-mysql-1", PortRange: network.PortRange{1, 8, "udp"}},
+		{UnitTag: "unit-wordpress-0", PortRange: network.PortRange{10, 20, "udp"}},
 	}
 	result, err := s.uniter.AllMachinePorts(args)
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
Change port range related apis to return the results in sorted order.
This fixes a failing test when compiled with gccgo which was relying
on the insertion sort order of golang-go when checking results.

http://reviews.vapour.ws/r/162/
