### PR TITLE
tls.Config clients should use a meaningful ServerName

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -230,7 +230,7 @@ func setUpWebsocket(addr, environUUID string, rootCAs *x509.CertPool) (*websocke
 	}
 	cfg.TlsConfig = &tls.Config{
 		RootCAs:    rootCAs,
-		ServerName: "anything",
+		ServerName: "juju-apiserver",
 	}
 	return cfg, nil
 }

--- a/api/client.go
+++ b/api/client.go
@@ -932,7 +932,7 @@ func (c *Client) WatchDebugLog(args DebugLogParams) (io.ReadCloser, error) {
 	}
 	cfg, err := websocket.NewConfig(target.String(), "http://localhost/")
 	cfg.Header = utils.BasicAuthHeader(c.st.tag, c.st.password)
-	cfg.TlsConfig = &tls.Config{RootCAs: c.st.certPool, ServerName: "anything"}
+	cfg.TlsConfig = &tls.Config{RootCAs: c.st.certPool, ServerName: "juju-apiserver"}
 	connection, err := websocketDialConfig(cfg)
 	if err != nil {
 		return nil, err

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -109,7 +109,7 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 	pool.AddCert(xcert)
 	tlsConfig := &tls.Config{
 		RootCAs:    pool,
-		ServerName: "anything",
+		ServerName: "juju-mongodb",
 	}
 	dial := func(addr net.Addr) (net.Conn, error) {
 		c, err := net.Dial("tcp", addr.String())

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -148,6 +148,10 @@ func (h *RsyslogConfigHandler) TearDown() error {
 	return nil
 }
 
+// composeTLS generates a new client certificate for connecting to the rsyslog server.
+// We explicitly set the ServerName field, this ensures that even if we are connecting
+// via an IP address and are using an old certificate (pre 1.20.9), we can still
+// successfully connect.
 func (h *RsyslogConfigHandler) composeTLS(caCert string) (*tls.Config, error) {
 	cert := x509.NewCertPool()
 	ok := cert.AppendCertsFromPEM([]byte(caCert))
@@ -155,7 +159,8 @@ func (h *RsyslogConfigHandler) composeTLS(caCert string) (*tls.Config, error) {
 		return nil, errors.Errorf("Failed to parse rsyslog root certificate")
 	}
 	return &tls.Config{
-		RootCAs: cert,
+		RootCAs:    cert,
+		ServerName: "juju-rsyslog",
 	}, nil
 }
 


### PR DESCRIPTION
This also fixes an issue with the rsyslog tls.Config not using a ServerName at all.
