### PR TITLE
CharmInfo now contains charm Actions

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -465,6 +465,7 @@ type CharmInfo struct {
 	URL      string
 	Config   *charm.Config
 	Meta     *charm.Meta
+	Actions  *charm.Actions
 }
 
 // CharmInfo returns information about the requested charm.

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -780,6 +780,7 @@ func (c *Client) CharmInfo(args params.CharmInfo) (api.CharmInfo, error) {
 		URL:      curl.String(),
 		Config:   charm.Config(),
 		Meta:     charm.Meta(),
+		Actions:  charm.Actions(),
 	}
 	return info, nil
 }

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -519,40 +519,69 @@ func (s *clientSuite) TestClientAddServiceUnits(c *gc.C) {
 	c.Assert(assignedMachine, gc.Equals, "0")
 }
 
-var clientCharmInfoTests = []struct {
-	about string
-	url   string
-	err   string
-}{
-	{
-		about: "retrieves charm info",
-		url:   "local:quantal/wordpress-3",
-	},
-	{
-		about: "invalid URL",
-		url:   "not-valid",
-		err:   "charm url series is not resolved",
-	},
-	{
-		about: "invalid schema",
-		url:   "not-valid:your-arguments",
-		err:   `charm URL has invalid schema: "not-valid:your-arguments"`,
-	},
-	{
-		about: "unknown charm",
-		url:   "cs:missing/one-1",
-		err:   `charm "cs:missing/one-1" not found`,
-	},
-}
-
 func (s *clientSuite) TestClientCharmInfo(c *gc.C) {
-	// Use wordpress for tests so that we can compare Provides and Requires.
-	charm := s.AddTestingCharm(c, "wordpress")
+	var clientCharmInfoTests = []struct {
+		about           string
+		charm           string
+		url             string
+		expectedActions *charm.Actions
+		err             string
+	}{
+		{
+			about: "dummy charm which contains an expectedActions spec",
+			charm: "dummy",
+			url:   "local:quantal/dummy-1",
+			expectedActions: &charm.Actions{
+				ActionSpecs: map[string]charm.ActionSpec{
+					"snapshot": charm.ActionSpec{
+						Description: "Take a snapshot of the database.",
+						Params: map[string]interface{}{
+							"outfile": map[string]interface{}{
+								"default":     "foo.bz2",
+								"description": "The file to write out to.",
+								"type":        "string",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			about: "retrieves charm info",
+			// Use wordpress for tests so that we can compare Provides and Requires.
+			charm:           "wordpress",
+			expectedActions: &charm.Actions{ActionSpecs: nil},
+			url:             "local:quantal/wordpress-3",
+		},
+		{
+			about:           "invalid URL",
+			charm:           "wordpress",
+			expectedActions: &charm.Actions{ActionSpecs: nil},
+			url:             "not-valid",
+			err:             "charm url series is not resolved",
+		},
+		{
+			about:           "invalid schema",
+			charm:           "wordpress",
+			expectedActions: &charm.Actions{ActionSpecs: nil},
+			url:             "not-valid:your-arguments",
+			err:             `charm URL has invalid schema: "not-valid:your-arguments"`,
+		},
+		{
+			about:           "unknown charm",
+			charm:           "wordpress",
+			expectedActions: &charm.Actions{ActionSpecs: nil},
+			url:             "cs:missing/one-1",
+			err:             `charm "cs:missing/one-1" not found`,
+		},
+	}
+
 	for i, t := range clientCharmInfoTests {
 		c.Logf("test %d. %s", i, t.about)
+		charm := s.AddTestingCharm(c, t.charm)
 		info, err := s.APIState.Client().CharmInfo(t.url)
 		if t.err != "" {
-			c.Assert(err, gc.ErrorMatches, t.err)
+			c.Check(err, gc.ErrorMatches, t.err)
 			continue
 		}
 		c.Assert(err, gc.IsNil)
@@ -561,8 +590,10 @@ func (s *clientSuite) TestClientCharmInfo(c *gc.C) {
 			URL:      charm.URL().String(),
 			Config:   charm.Config(),
 			Meta:     charm.Meta(),
+			Actions:  charm.Actions(),
 		}
-		c.Assert(info, gc.DeepEquals, expected)
+		c.Check(info, jc.DeepEquals, expected)
+		c.Check(info.Actions, jc.DeepEquals, t.expectedActions)
 	}
 }
 

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
@@ -197,6 +198,7 @@ func opClientCharmInfo(c *gc.C, st *api.State, mst *state.State) (func(), error)
 	c.Assert(info.URL, gc.Equals, "local:quantal/wordpress-3")
 	c.Assert(info.Meta.Name, gc.Equals, "wordpress")
 	c.Assert(info.Revision, gc.Equals, 3)
+	c.Assert(info.Actions, jc.DeepEquals, &charm.Actions{ActionSpecs: nil})
 	return func() {}, nil
 }
 


### PR DESCRIPTION
This commit adds the apiserver test and endpoit to add Actions to the
CharmInfo api query response.
