### PR TITLE
Implemented firewall-mode: none; fixed firewaller tests

### DIFF
--- a/cmd/juju/environment_test.go
+++ b/cmd/juju/environment_test.go
@@ -178,7 +178,7 @@ func (s *SetEnvironmentSuite) TestChangeAsCommandPair(c *gc.C) {
 var immutableConfigTests = map[string]string{
 	"name":          "foo",
 	"type":          "local",
-	"firewall-mode": "global",
+	"firewall-mode": config.FwGlobal,
 	"state-port":    "1",
 	"api-port":      "666",
 }

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -36,6 +36,12 @@ const (
 	// port opened.
 	FwGlobal = "global"
 
+	// FwNone requests that no firewalling should be performed inside
+	// the environment. No firewaller worker will be started. It's
+	// useful for clouds without support for either global or per
+	// instance security groups.
+	FwNone = "none"
+
 	// DefaultStatePort is the default port the state server is listening on.
 	DefaultStatePort int = 37017
 
@@ -425,7 +431,9 @@ func Validate(cfg, old *Config) error {
 	}
 
 	// Check firewall mode.
-	if mode := cfg.FirewallMode(); mode != FwInstance && mode != FwGlobal {
+	switch mode := cfg.FirewallMode(); mode {
+	case FwInstance, FwGlobal, FwNone:
+	default:
 		return fmt.Errorf("invalid firewall mode in environment configuration: %q", mode)
 	}
 
@@ -763,8 +771,8 @@ func (c *Config) AdminSecret() string {
 }
 
 // FirewallMode returns whether the firewall should
-// manage ports per machine or global
-// (FwInstance or FwGlobal)
+// manage ports per machine, globally, or not at all.
+// (FwInstance, FwGlobal, or FwNone).
 func (c *Config) FirewallMode() string {
 	return c.mustString("firewall-mode")
 }

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -430,6 +430,14 @@ var configTests = []configTest{
 			"firewall-mode": config.FwGlobal,
 		},
 	}, {
+		about:       "None firewall mode",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":          "my-type",
+			"name":          "my-name",
+			"firewall-mode": config.FwNone,
+		},
+	}, {
 		about:       "Illegal firewall mode",
 		useDefaults: config.UseDefaults,
 		attrs: testing.Attrs{
@@ -1270,10 +1278,15 @@ var validationTests = []validationTest{{
 	old:   testing.Attrs{"agent-version": "1.9.27"},
 	err:   `cannot clear agent-version`,
 }, {
-	about: "Can't change the firewall-mode",
+	about: "Can't change the firewall-mode (global->instance)",
 	old:   testing.Attrs{"firewall-mode": config.FwGlobal},
 	new:   testing.Attrs{"firewall-mode": config.FwInstance},
 	err:   `cannot change firewall-mode from "global" to "instance"`,
+}, {
+	about: "Can't change the firewall-mode (global->none)",
+	old:   testing.Attrs{"firewall-mode": config.FwGlobal},
+	new:   testing.Attrs{"firewall-mode": config.FwNone},
+	err:   `cannot change firewall-mode from "global" to "none"`,
 }, {
 	about: "Cannot change the state-port",
 	old:   testing.Attrs{"state-port": config.DefaultStatePort},

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -330,7 +330,7 @@ func (t *LiveTests) TestGlobalPorts(c *gc.C) {
 	}()
 
 	attrs := t.Env.Config().AllAttrs()
-	attrs["firewall-mode"] = "global"
+	attrs["firewall-mode"] = config.FwGlobal
 	newConfig, err := t.Env.Config().Apply(attrs)
 	c.Assert(err, gc.IsNil)
 	err = t.Env.SetConfig(newConfig)

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -212,6 +212,11 @@ var configTests = []configTest{
 		firewallMode: config.FwGlobal,
 	}, {
 		config: attrs{
+			"firewall-mode": "none",
+		},
+		firewallMode: config.FwNone,
+	}, {
+		config: attrs{
 			"ssl-hostname-verification": false,
 		},
 		err: "disabling ssh-hostname-verification is not supported",

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -396,6 +396,12 @@ var configTests = []configTest{
 		},
 		firewallMode: config.FwGlobal,
 	}, {
+		summary: "none firewall-mode",
+		config: attrs{
+			"firewall-mode": "none",
+		},
+		firewallMode: config.FwNone,
+	}, {
 		config: attrs{
 			"future": "hammerstein",
 		},

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -425,7 +425,7 @@ func assertSecurityGroups(c *gc.C, env environs.Environ, expected []string) {
 
 func (s *localServerSuite) TestStopInstance(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(coretesting.Attrs{
-		"firewall-mode": "instance"}))
+		"firewall-mode": config.FwInstance}))
 	c.Assert(err, gc.IsNil)
 	env, err := environs.New(cfg)
 	c.Assert(err, gc.IsNil)
@@ -456,7 +456,7 @@ func (s *localServerSuite) TestStopInstanceSecurityGroupNotDeleted(c *gc.C) {
 	)
 	defer cleanup()
 	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(coretesting.Attrs{
-		"firewall-mode": "instance"}))
+		"firewall-mode": config.FwInstance}))
 	c.Assert(err, gc.IsNil)
 	env, err := environs.New(cfg)
 	c.Assert(err, gc.IsNil)
@@ -472,7 +472,7 @@ func (s *localServerSuite) TestStopInstanceSecurityGroupNotDeleted(c *gc.C) {
 
 func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeInstance(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(coretesting.Attrs{
-		"firewall-mode": "instance"}))
+		"firewall-mode": config.FwInstance}))
 	c.Assert(err, gc.IsNil)
 	env, err := environs.New(cfg)
 	c.Assert(err, gc.IsNil)
@@ -488,7 +488,7 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeInst
 
 func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeGlobal(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(coretesting.Attrs{
-		"firewall-mode": "global"}))
+		"firewall-mode": config.FwGlobal}))
 	c.Assert(err, gc.IsNil)
 	env, err := environs.New(cfg)
 	c.Assert(err, gc.IsNil)

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -92,9 +92,13 @@ func (fw *Firewaller) loop() error {
 	}
 
 	portsChange := fw.portsWatcher.Changes()
-	if fw.environ.Config().FirewallMode() == config.FwGlobal {
+	switch fw.environ.Config().FirewallMode() {
+	case config.FwGlobal:
 		fw.globalMode = true
 		fw.globalPortRef = make(map[network.PortRange]int)
+	case config.FwNone:
+		logger.Warningf("stopping firewaller - firewall-mode is %q", config.FwNone)
+		return errors.Errorf("firewaller is disabled when firewall-mode is %q", config.FwNone)
 	}
 	for {
 		select {

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/juju/juju/worker/firewaller"
 )
 
-type FirewallerSuite struct {
+// firewallerBaseSuite implements common functionality for embedding
+// into each of the other per-mode suites.
+type firewallerBaseSuite struct {
 	testing.JujuConnSuite
 	op    <-chan dummy.Operation
 	charm *state.Charm
@@ -34,15 +36,35 @@ type FirewallerSuite struct {
 	firewaller *apifirewaller.State
 }
 
-type FirewallerGlobalModeSuite struct {
-	FirewallerSuite
-}
-
 var _ worker.Worker = (*firewaller.Firewaller)(nil)
+
+func (s *firewallerBaseSuite) setUpTest(c *gc.C, firewallMode string) {
+	add := map[string]interface{}{"firewall-mode": firewallMode}
+	s.DummyConfig = dummy.SampleConfig().Merge(add).Delete("admin-secret", "ca-private-key")
+
+	s.JujuConnSuite.SetUpTest(c)
+	s.charm = s.AddTestingCharm(c, "dummy")
+
+	// Create a manager machine and login to the API.
+	machine, err := s.State.AddMachine("quantal", state.JobManageEnviron)
+	c.Assert(err, gc.IsNil)
+	password, err := utils.RandomPassword()
+	c.Assert(err, gc.IsNil)
+	err = machine.SetPassword(password)
+	c.Assert(err, gc.IsNil)
+	err = machine.SetProvisioned("i-manager", "fake_nonce", nil)
+	c.Assert(err, gc.IsNil)
+	s.st = s.OpenAPIAsMachine(c, machine.Tag(), password, "fake_nonce")
+	c.Assert(s.st, gc.NotNil)
+
+	// Create the firewaller API facade.
+	s.firewaller = s.st.Firewaller()
+	c.Assert(s.firewaller, gc.NotNil)
+}
 
 // assertPorts retrieves the open ports of the instance and compares them
 // to the expected.
-func (s *FirewallerSuite) assertPorts(c *gc.C, inst instance.Instance, machineId string, expected []network.PortRange) {
+func (s *firewallerBaseSuite) assertPorts(c *gc.C, inst instance.Instance, machineId string, expected []network.PortRange) {
 	s.BackingState.StartSync()
 	start := time.Now()
 	for {
@@ -67,7 +89,7 @@ func (s *FirewallerSuite) assertPorts(c *gc.C, inst instance.Instance, machineId
 
 // assertEnvironPorts retrieves the open ports of environment and compares them
 // to the expected.
-func (s *FirewallerSuite) assertEnvironPorts(c *gc.C, expected []network.Port) {
+func (s *firewallerBaseSuite) assertEnvironPorts(c *gc.C, expected []network.PortRange) {
 	s.BackingState.StartSync()
 	start := time.Now()
 	for {
@@ -76,8 +98,8 @@ func (s *FirewallerSuite) assertEnvironPorts(c *gc.C, expected []network.Port) {
 			c.Fatal(err)
 			return
 		}
-		network.SortPorts(network.PortRangesToPorts(got))
-		network.SortPorts(expected)
+		network.SortPortRanges(got)
+		network.SortPortRanges(expected)
 		if reflect.DeepEqual(got, expected) {
 			c.Succeed()
 			return
@@ -90,43 +112,7 @@ func (s *FirewallerSuite) assertEnvironPorts(c *gc.C, expected []network.Port) {
 	}
 }
 
-var _ = gc.Suite(&FirewallerSuite{})
-
-func (s FirewallerGlobalModeSuite) SetUpTest(c *gc.C) {
-	add := map[string]interface{}{"firewall-mode": config.FwGlobal}
-	s.DummyConfig = dummy.SampleConfig().Merge(add).Delete("admin-secret", "ca-private-key")
-
-	s.FirewallerSuite.SetUpTest(c)
-}
-
-func (s *FirewallerSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
-	s.charm = s.AddTestingCharm(c, "dummy")
-
-	// Create a manager machine and login to the API.
-	machine, err := s.State.AddMachine("quantal", state.JobManageEnviron)
-	c.Assert(err, gc.IsNil)
-	password, err := utils.RandomPassword()
-	c.Assert(err, gc.IsNil)
-	err = machine.SetPassword(password)
-	c.Assert(err, gc.IsNil)
-	err = machine.SetProvisioned("i-manager", "fake_nonce", nil)
-	c.Assert(err, gc.IsNil)
-	s.st = s.OpenAPIAsMachine(c, machine.Tag(), password, "fake_nonce")
-	c.Assert(s.st, gc.NotNil)
-
-	// Create the firewaller API facade.
-	s.firewaller = s.st.Firewaller()
-	c.Assert(s.firewaller, gc.NotNil)
-}
-
-func (s *FirewallerSuite) TestStartStop(c *gc.C) {
-	fw, err := firewaller.NewFirewaller(s.firewaller)
-	c.Assert(err, gc.IsNil)
-	statetesting.AssertKillAndWait(c, fw)
-}
-
-func (s *FirewallerSuite) addUnit(c *gc.C, svc *state.Service) (*state.Unit, *state.Machine) {
+func (s *firewallerBaseSuite) addUnit(c *gc.C, svc *state.Service) (*state.Unit, *state.Machine) {
 	units, err := juju.AddUnits(s.State, svc, 1, "")
 	c.Assert(err, gc.IsNil)
 	u := units[0]
@@ -138,14 +124,34 @@ func (s *FirewallerSuite) addUnit(c *gc.C, svc *state.Service) (*state.Unit, *st
 }
 
 // startInstance starts a new instance for the given machine.
-func (s *FirewallerSuite) startInstance(c *gc.C, m *state.Machine) instance.Instance {
+func (s *firewallerBaseSuite) startInstance(c *gc.C, m *state.Machine) instance.Instance {
 	inst, hc := testing.AssertStartInstance(c, s.Environ, m.Id())
 	err := m.SetProvisioned(inst.Id(), "fake_nonce", hc)
 	c.Assert(err, gc.IsNil)
 	return inst
 }
 
-func (s *FirewallerSuite) TestNotExposedService(c *gc.C) {
+type InstanceModeSuite struct {
+	firewallerBaseSuite
+}
+
+var _ = gc.Suite(&InstanceModeSuite{})
+
+func (s *InstanceModeSuite) SetUpTest(c *gc.C) {
+	s.firewallerBaseSuite.setUpTest(c, config.FwInstance)
+}
+
+func (s *InstanceModeSuite) TearDownTest(c *gc.C) {
+	s.firewallerBaseSuite.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *InstanceModeSuite) TestStartStop(c *gc.C) {
+	fw, err := firewaller.NewFirewaller(s.firewaller)
+	c.Assert(err, gc.IsNil)
+	statetesting.AssertKillAndWait(c, fw)
+}
+
+func (s *InstanceModeSuite) TestNotExposedService(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -167,7 +173,7 @@ func (s *FirewallerSuite) TestNotExposedService(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 }
 
-func (s *FirewallerSuite) TestExposedService(c *gc.C) {
+func (s *InstanceModeSuite) TestExposedService(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -179,20 +185,20 @@ func (s *FirewallerSuite) TestExposedService(c *gc.C) {
 	u, m := s.addUnit(c, svc)
 	inst := s.startInstance(c, m)
 
-	err = u.OpenPort("tcp", 80)
+	err = u.OpenPorts("tcp", 80, 90)
 	c.Assert(err, gc.IsNil)
 	err = u.OpenPort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
 
-	s.assertPorts(c, inst, m.Id(), []network.PortRange{{80, 80, "tcp"}, {8080, 8080, "tcp"}})
+	s.assertPorts(c, inst, m.Id(), []network.PortRange{{80, 90, "tcp"}, {8080, 8080, "tcp"}})
 
-	err = u.ClosePort("tcp", 80)
+	err = u.ClosePorts("tcp", 80, 90)
 	c.Assert(err, gc.IsNil)
 
 	s.assertPorts(c, inst, m.Id(), []network.PortRange{{8080, 8080, "tcp"}})
 }
 
-func (s *FirewallerSuite) TestMultipleExposedServices(c *gc.C) {
+func (s *InstanceModeSuite) TestMultipleExposedServices(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -230,7 +236,7 @@ func (s *FirewallerSuite) TestMultipleExposedServices(c *gc.C) {
 	s.assertPorts(c, inst2, m2.Id(), nil)
 }
 
-func (s *FirewallerSuite) TestMachineWithoutInstanceId(c *gc.C) {
+func (s *InstanceModeSuite) TestMachineWithoutInstanceId(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -255,7 +261,7 @@ func (s *FirewallerSuite) TestMachineWithoutInstanceId(c *gc.C) {
 	s.assertPorts(c, inst1, m1.Id(), []network.PortRange{{8080, 8080, "tcp"}})
 }
 
-func (s *FirewallerSuite) TestMultipleUnits(c *gc.C) {
+func (s *InstanceModeSuite) TestMultipleUnits(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -286,7 +292,7 @@ func (s *FirewallerSuite) TestMultipleUnits(c *gc.C) {
 	s.assertPorts(c, inst2, m2.Id(), nil)
 }
 
-func (s *FirewallerSuite) TestStartWithState(c *gc.C) {
+func (s *InstanceModeSuite) TestStartWithState(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.charm)
 	err := svc.SetExposed()
 	c.Assert(err, gc.IsNil)
@@ -312,7 +318,7 @@ func (s *FirewallerSuite) TestStartWithState(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *FirewallerSuite) TestStartWithPartialState(c *gc.C) {
+func (s *InstanceModeSuite) TestStartWithPartialState(c *gc.C) {
 	m, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, gc.IsNil)
 	inst := s.startInstance(c, m)
@@ -339,7 +345,7 @@ func (s *FirewallerSuite) TestStartWithPartialState(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), []network.PortRange{{80, 80, "tcp"}})
 }
 
-func (s *FirewallerSuite) TestStartWithUnexposedService(c *gc.C) {
+func (s *InstanceModeSuite) TestStartWithUnexposedService(c *gc.C) {
 	m, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, gc.IsNil)
 	inst := s.startInstance(c, m)
@@ -365,7 +371,7 @@ func (s *FirewallerSuite) TestStartWithUnexposedService(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), []network.PortRange{{80, 80, "tcp"}})
 }
 
-func (s *FirewallerSuite) TestSetClearExposedService(c *gc.C) {
+func (s *InstanceModeSuite) TestSetClearExposedService(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -395,7 +401,7 @@ func (s *FirewallerSuite) TestSetClearExposedService(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 }
 
-func (s *FirewallerSuite) TestRemoveUnit(c *gc.C) {
+func (s *InstanceModeSuite) TestRemoveUnit(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -427,7 +433,7 @@ func (s *FirewallerSuite) TestRemoveUnit(c *gc.C) {
 	s.assertPorts(c, inst2, m2.Id(), []network.PortRange{{80, 80, "tcp"}})
 }
 
-func (s *FirewallerSuite) TestRemoveService(c *gc.C) {
+func (s *InstanceModeSuite) TestRemoveService(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -453,7 +459,7 @@ func (s *FirewallerSuite) TestRemoveService(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 }
 
-func (s *FirewallerSuite) TestRemoveMultipleServices(c *gc.C) {
+func (s *InstanceModeSuite) TestRemoveMultipleServices(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -498,7 +504,7 @@ func (s *FirewallerSuite) TestRemoveMultipleServices(c *gc.C) {
 	s.assertPorts(c, inst2, m2.Id(), nil)
 }
 
-func (s *FirewallerSuite) TestDeadMachine(c *gc.C) {
+func (s *InstanceModeSuite) TestDeadMachine(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -531,7 +537,7 @@ func (s *FirewallerSuite) TestDeadMachine(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 }
 
-func (s *FirewallerSuite) TestRemoveMachine(c *gc.C) {
+func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
@@ -564,7 +570,27 @@ func (s *FirewallerSuite) TestRemoveMachine(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *FirewallerGlobalModeSuite) TestGlobalMode(c *gc.C) {
+type GlobalModeSuite struct {
+	firewallerBaseSuite
+}
+
+var _ = gc.Suite(&GlobalModeSuite{})
+
+func (s *GlobalModeSuite) SetUpTest(c *gc.C) {
+	s.firewallerBaseSuite.setUpTest(c, config.FwGlobal)
+}
+
+func (s *GlobalModeSuite) TearDownTest(c *gc.C) {
+	s.firewallerBaseSuite.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *GlobalModeSuite) TestStartStop(c *gc.C) {
+	fw, err := firewaller.NewFirewaller(s.firewaller)
+	c.Assert(err, gc.IsNil)
+	statetesting.AssertKillAndWait(c, fw)
+}
+
+func (s *GlobalModeSuite) TestGlobalMode(c *gc.C) {
 	// Start firewaller and open ports.
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
@@ -576,7 +602,7 @@ func (s *FirewallerGlobalModeSuite) TestGlobalMode(c *gc.C) {
 
 	u1, m1 := s.addUnit(c, svc1)
 	s.startInstance(c, m1)
-	err = u1.OpenPort("tcp", 80)
+	err = u1.OpenPorts("tcp", 80, 90)
 	c.Assert(err, gc.IsNil)
 	err = u1.OpenPort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
@@ -588,28 +614,28 @@ func (s *FirewallerGlobalModeSuite) TestGlobalMode(c *gc.C) {
 
 	u2, m2 := s.addUnit(c, svc2)
 	s.startInstance(c, m2)
-	err = u2.OpenPort("tcp", 80)
+	err = u2.OpenPorts("tcp", 80, 90)
 	c.Assert(err, gc.IsNil)
 
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}, {"tcp", 8080}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 90, "tcp"}, {8080, 8080, "tcp"}})
 
 	// Closing a port opened by a different unit won't touch the environment.
-	err = u1.ClosePort("tcp", 80)
+	err = u1.ClosePorts("tcp", 80, 90)
 	c.Assert(err, gc.IsNil)
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}, {"tcp", 8080}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 90, "tcp"}, {8080, 8080, "tcp"}})
 
 	// Closing a port used just once changes the environment.
 	err = u1.ClosePort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 90, "tcp"}})
 
 	// Closing the last port also modifies the environment.
-	err = u2.ClosePort("tcp", 80)
+	err = u2.ClosePorts("tcp", 80, 90)
 	c.Assert(err, gc.IsNil)
 	s.assertEnvironPorts(c, nil)
 }
 
-func (s *FirewallerGlobalModeSuite) TestGlobalModeStartWithUnexposedService(c *gc.C) {
+func (s *GlobalModeSuite) TestStartWithUnexposedService(c *gc.C) {
 	m, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, gc.IsNil)
 	s.startInstance(c, m)
@@ -632,10 +658,10 @@ func (s *FirewallerGlobalModeSuite) TestGlobalModeStartWithUnexposedService(c *g
 	// Expose service.
 	err = svc.SetExposed()
 	c.Assert(err, gc.IsNil)
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 80, "tcp"}})
 }
 
-func (s *FirewallerGlobalModeSuite) TestGlobalModeRestart(c *gc.C) {
+func (s *GlobalModeSuite) TestRestart(c *gc.C) {
 	// Start firewaller and open ports.
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
@@ -646,12 +672,12 @@ func (s *FirewallerGlobalModeSuite) TestGlobalModeRestart(c *gc.C) {
 
 	u, m := s.addUnit(c, svc)
 	s.startInstance(c, m)
-	err = u.OpenPort("tcp", 80)
+	err = u.OpenPorts("tcp", 80, 90)
 	c.Assert(err, gc.IsNil)
 	err = u.OpenPort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
 
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}, {"tcp", 8080}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 90, "tcp"}, {8080, 8080, "tcp"}})
 
 	// Stop firewaller and close one and open a different port.
 	err = worker.Stop(fw)
@@ -667,10 +693,10 @@ func (s *FirewallerGlobalModeSuite) TestGlobalModeRestart(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}, {"tcp", 8888}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 90, "tcp"}, {8888, 8888, "tcp"}})
 }
 
-func (s *FirewallerGlobalModeSuite) TestGlobalModeRestartUnexposedService(c *gc.C) {
+func (s *GlobalModeSuite) TestRestartUnexposedService(c *gc.C) {
 	// Start firewaller and open ports.
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
@@ -686,7 +712,7 @@ func (s *FirewallerGlobalModeSuite) TestGlobalModeRestartUnexposedService(c *gc.
 	err = u.OpenPort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
 
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}, {"tcp", 8080}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 80, "tcp"}, {8080, 8080, "tcp"}})
 
 	// Stop firewaller and clear exposed flag on service.
 	err = worker.Stop(fw)
@@ -703,7 +729,7 @@ func (s *FirewallerGlobalModeSuite) TestGlobalModeRestartUnexposedService(c *gc.
 	s.assertEnvironPorts(c, nil)
 }
 
-func (s *FirewallerGlobalModeSuite) TestGlobalModeRestartPortCount(c *gc.C) {
+func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	// Start firewaller and open ports.
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, gc.IsNil)
@@ -719,7 +745,7 @@ func (s *FirewallerGlobalModeSuite) TestGlobalModeRestartPortCount(c *gc.C) {
 	err = u1.OpenPort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
 
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}, {"tcp", 8080}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 80, "tcp"}, {8080, 8080, "tcp"}})
 
 	// Stop firewaller and add another service using the port.
 	err = worker.Stop(fw)
@@ -739,20 +765,42 @@ func (s *FirewallerGlobalModeSuite) TestGlobalModeRestartPortCount(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer statetesting.AssertKillAndWait(c, fw)
 
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}, {"tcp", 8080}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 80, "tcp"}, {8080, 8080, "tcp"}})
 
 	// Closing a port opened by a different unit won't touch the environment.
 	err = u1.ClosePort("tcp", 80)
 	c.Assert(err, gc.IsNil)
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}, {"tcp", 8080}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 80, "tcp"}, {8080, 8080, "tcp"}})
 
 	// Closing a port used just once changes the environment.
 	err = u1.ClosePort("tcp", 8080)
 	c.Assert(err, gc.IsNil)
-	s.assertEnvironPorts(c, []network.Port{{"tcp", 80}})
+	s.assertEnvironPorts(c, []network.PortRange{{80, 80, "tcp"}})
 
 	// Closing the last port also modifies the environment.
 	err = u2.ClosePort("tcp", 80)
 	c.Assert(err, gc.IsNil)
 	s.assertEnvironPorts(c, nil)
+}
+
+type NoneModeSuite struct {
+	firewallerBaseSuite
+}
+
+var _ = gc.Suite(&NoneModeSuite{})
+
+func (s *NoneModeSuite) SetUpTest(c *gc.C) {
+	s.firewallerBaseSuite.setUpTest(c, config.FwNone)
+}
+
+func (s *NoneModeSuite) TearDownTest(c *gc.C) {
+	s.firewallerBaseSuite.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *NoneModeSuite) TestStopsAfterGettingMode(c *gc.C) {
+	fw, err := firewaller.NewFirewaller(s.firewaller)
+	c.Assert(err, gc.IsNil)
+	c.Assert(fw, gc.NotNil)
+	fw.Kill()
+	c.Assert(fw.Wait(), gc.ErrorMatches, `firewaller is disabled when firewall-mode is "none"`)
 }


### PR DESCRIPTION
Unitl now we only supported "global" and "instance" values for the
"firewall-mode" environment setting. Not all clouds support
firewalling, security groups, or other means of implementing OpenPort
and ClosePort on either global or instance level (e.g. OpenStack
without os-security-groups extension installed). Hence, this PR
introduces a new "none" value for "firewall-mode". If specified, the
firewaller worker won't be started and we won't try to open or close
ports at all.

As a drive-by fix, firewaller tests are improved and "global mode"
tests re-enabled after they were effectively disabled by introducing
FirewallGlobalModeSuite in https://codereview.appspot.com/70190050/
(https://code.launchpad.net/~waigani/juju-core/get-oldConfig-from-state/+merge/209569 branch), but not registered, so no global mode test were run
since then.
