### PR TITLE
Fixed api-endpoints Purpose capitalization; added tests for Purpose and Doc for all commands

### DIFF
--- a/cmd/juju/endpoint.go
+++ b/cmd/juju/endpoint.go
@@ -30,7 +30,7 @@ func (c *EndpointCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "api-endpoints",
 		Args:    "",
-		Purpose: "Print the API server address",
+		Purpose: "print the API server address",
 		Doc:     endpointDoc,
 	}
 }

--- a/cmd/juju/main_test.go
+++ b/cmd/juju/main_test.go
@@ -323,3 +323,42 @@ func (s *MainSuite) TestEnvironCommands(c *gc.C) {
 		c.Check(cmd, gc.Not(gc.FitsTypeOf), envcmd.EnvironCommand(&BootstrapCommand{}))
 	}
 }
+
+func (s *MainSuite) TestAllCommandsPurposeDocCapitalization(c *gc.C) {
+	// Verify each command that:
+	// - the Purpose field is not empty and begins with a lowercase
+	// letter, and,
+	// - if set, the Doc field either begins with the name of the
+	// command or and uppercase letter.
+	//
+	// The first makes Purpose a required documentation. Also, makes
+	// both "help commands"'s output and "help <cmd>"'s header more
+	// uniform. The second makes the Doc content either start like a
+	// sentence, or start godoc-like by using the command's name in
+	// lowercase.
+	var commands commands
+	registerCommands(&commands, testing.Context(c))
+	for _, cmd := range commands {
+		info := cmd.Info()
+		c.Logf("%v", info.Name)
+		purpose := strings.TrimSpace(info.Purpose)
+		doc := strings.TrimSpace(info.Doc)
+		comment := func(message string) interface{} {
+			return gc.Commentf("command %q %s", info.Name, message)
+		}
+
+		c.Check(purpose, gc.Not(gc.Equals), "", comment("has empty Purpose"))
+		if purpose != "" {
+			prefix := string(purpose[0])
+			c.Check(prefix, gc.Equals, strings.ToLower(prefix),
+				comment("expected lowercase first-letter Purpose"),
+			)
+		}
+		if doc != "" && !strings.HasPrefix(doc, info.Name) {
+			prefix := string(doc[0])
+			c.Check(prefix, gc.Equals, strings.ToUpper(prefix),
+				comment("expected uppercase first-letter Doc"),
+			)
+		}
+	}
+}


### PR DESCRIPTION
The "api-endpoints" command's Purpose doc lowercased.
Added a test to validate the format of all commands'
Purpose and Doc fields (proper capitalization and makes
Purpose required). Only "api-endpoints" is affected by
the test so far.
