### PR TITLE
environs: fixes for Windows

### DIFF
--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
@@ -36,7 +37,7 @@ func SharedToolsDir(dataDir string, vers version.Binary) string {
 // the tools used by the given agent within the given dataDir directory.
 // Conventionally it is a symbolic link to the actual tools directory.
 func ToolsDir(dataDir, agentName string) string {
-	return path.Join(dataDir, "tools", agentName)
+	return filepath.Join(dataDir, "tools", agentName)
 }
 
 // UnpackTools reads a set of juju tools in gzipped tar-archive

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -118,7 +118,7 @@ func (s *ImageMetadataSuite) assertCommandOutput(c *gc.C, expected expectedMetad
 
 const (
 	defaultIndexFileName = "index.json"
-	defaultImageFileName = "com.ubuntu.cloud:released:imagemetadata.json"
+	defaultImageFileName = "com.ubuntu.cloud-released-imagemetadata.json"
 )
 
 func (s *ImageMetadataSuite) TestImageMetadataFilesNoEnv(c *gc.C) {

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -97,11 +97,11 @@ func makeExpectedOutput(templ, stream, toolsDir string) string {
 
 var expectedOutputDirectoryTemplate = expectedOutputCommon + `
 .*Writing tools/streams/v1/index2\.json
-.*Writing tools/streams/v1/com\.ubuntu\.juju:{{.Stream}}:tools\.json
+.*Writing tools/streams/v1/com\.ubuntu\.juju-{{.Stream}}-tools\.json
 `
 var expectedOutputMirrorsTemplate = expectedOutputCommon + `
 .*Writing tools/streams/v1/index2\.json
-.*Writing tools/streams/v1/com\.ubuntu\.juju:{{.Stream}}:tools\.json
+.*Writing tools/streams/v1/com\.ubuntu\.juju-{{.Stream}}-tools\.json
 .*Writing tools/streams/v1/mirrors\.json
 `
 
@@ -310,7 +310,7 @@ Finding tools in .*
 .*Fetching tools from dir "released" to generate hash: %s
 .*Fetching tools from dir "released" to generate hash: %s
 .*Writing tools/streams/v1/index2\.json
-.*Writing tools/streams/v1/com\.ubuntu\.juju:released:tools\.json
+.*Writing tools/streams/v1/com\.ubuntu\.juju-released-tools\.json
 `[1:], regexp.QuoteMeta(versionStrings[0]), regexp.QuoteMeta(versionStrings[1]))
 	c.Assert(output, gc.Matches, expectedOutput)
 	metadata := toolstesting.ParseMetadataFromDir(c, metadataDir, "released", false)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d
 github.com/juju/syslog	git	2b69d6582feb16ff8b6d644495e16c2d8314fcb8	
 github.com/juju/testing	git	bb82a35ea789fce462fcb81a071c2eb57aa22a6b	
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	
-github.com/juju/utils	git	6bfed5692f0d524bab3be5976f26d24bd4d3f677	
+github.com/juju/utils	git	1942c197c7bc4ce805171c564df741777299e939	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
 gopkg.in/juju/charm.v4	git	f7e5613ff75457d2700d1c3269546cc903ea0471	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -485,7 +485,7 @@ curl .* --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid
 		inexactMatch: true,
 		expectScripts: `
 printf '%s\\n' '.*' > '/var/lib/juju/simplestreams/images/streams/v1/index\.json'
-printf '%s\\n' '.*' > '/var/lib/juju/simplestreams/images/streams/v1/com.ubuntu.cloud:released:imagemetadata\.json'
+printf '%s\\n' '.*' > '/var/lib/juju/simplestreams/images/streams/v1/com.ubuntu.cloud-released-imagemetadata\.json'
 `,
 	},
 }

--- a/environs/filestorage/filestorage.go
+++ b/environs/filestorage/filestorage.go
@@ -109,7 +109,7 @@ func (f *fileStorageReader) List(prefix string) ([]string, error) {
 
 // URL implements storage.StorageReader.URL.
 func (f *fileStorageReader) URL(name string) (string, error) {
-	return "file://" + filepath.Join(f.path, name), nil
+	return utils.MakeFileURL(filepath.Join(f.path, name)), nil
 }
 
 // DefaultConsistencyStrategy implements storage.StorageReader.ConsistencyStrategy.

--- a/environs/filestorage/filestorage_test.go
+++ b/environs/filestorage/filestorage_test.go
@@ -116,7 +116,7 @@ func (s *filestorageSuite) TestURL(c *gc.C) {
 	_, file := filepath.Split(expectedpath)
 	url, err := s.reader.URL(file)
 	c.Assert(err, gc.IsNil)
-	c.Assert(url, gc.Equals, "file://"+expectedpath)
+	c.Assert(url, gc.Equals, utils.MakeFileURL(expectedpath))
 }
 
 func (s *filestorageSuite) TestGet(c *gc.C) {
@@ -215,11 +215,11 @@ func (s *filestorageSuite) TestPathRelativeToHome(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer os.RemoveAll(tempDir)
 	dirName := strings.Replace(tempDir, homeDir, "", -1)
-	reader, err := filestorage.NewFileStorageReader(filepath.Join("~", dirName))
+	reader, err := filestorage.NewFileStorageReader(filepath.Join(utils.Home(), dirName))
 	c.Assert(err, gc.IsNil)
 	url, err := reader.URL("")
 	c.Assert(err, gc.IsNil)
-	c.Assert(url, gc.Equals, "file://"+filepath.Join(homeDir, dirName))
+	c.Assert(url, gc.Equals, utils.MakeFileURL(filepath.Join(homeDir, dirName)))
 }
 
 func (s *filestorageSuite) TestRelativePath(c *gc.C) {
@@ -235,5 +235,5 @@ func (s *filestorageSuite) TestRelativePath(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	url, err := reader.URL("")
 	c.Assert(err, gc.IsNil)
-	c.Assert(url, gc.Equals, "file://"+dir+"/a")
+	c.Assert(url, gc.Equals, utils.MakeFileURL(dir)+"/a")
 }

--- a/environs/imagemetadata/marshal.go
+++ b/environs/imagemetadata/marshal.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	ProductMetadataPath = "streams/v1/com.ubuntu.cloud:released:imagemetadata.json"
+	ProductMetadataPath = "streams/v1/com.ubuntu.cloud-released-imagemetadata.json"
 	ImageContentId      = "com.ubuntu.cloud:custom"
 )
 

--- a/environs/imagemetadata/marshal_test.go
+++ b/environs/imagemetadata/marshal_test.go
@@ -32,7 +32,7 @@ var expectedIndex = `{
                     "endpoint": "endpoint"
                 }
             ],
-            "path": "streams/v1/com.ubuntu.cloud:released:imagemetadata.json",
+            "path": "streams/v1/com.ubuntu.cloud-released-imagemetadata.json",
             "products": [
                 "com.ubuntu.cloud:server:12.04:amd64",
                 "com.ubuntu.cloud:server:12.04:arm",

--- a/environs/imagemetadata/urls.go
+++ b/environs/imagemetadata/urls.go
@@ -5,10 +5,9 @@ package imagemetadata
 
 import (
 	"fmt"
-	"net/url"
-	"strings"
 
 	"github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/environs/utils"
 )
 
 // ImageMetadataURL returns a valid image metadata URL constructed from source.
@@ -26,18 +25,6 @@ func ImageMetadataURL(source, stream string) (string, error) {
 		}
 		source = fmt.Sprintf("%s/%s", source, cloudImagesPath)
 	}
-	// If source is a raw directory, we need to append the file:// prefix
-	// so it can be used as a URL.
-	defaultURL := source
-	u, err := url.Parse(source)
-	if err != nil {
-		return "", fmt.Errorf("invalid default image metadata URL %s: %v", defaultURL, err)
-	}
-	if u.Scheme == "" {
-		defaultURL = "file://" + defaultURL
-		if !strings.HasSuffix(defaultURL, "/"+storage.BaseImagesPath) {
-			defaultURL = fmt.Sprintf("%s/%s", defaultURL, storage.BaseImagesPath)
-		}
-	}
-	return defaultURL, nil
+
+	return utils.GetURL(source, storage.BaseImagesPath)
 }

--- a/environs/imagemetadata/urls_test.go
+++ b/environs/imagemetadata/urls_test.go
@@ -1,9 +1,12 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2012, 2013, 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package imagemetadata_test
 
 import (
+	"fmt"
+
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/imagemetadata"
@@ -17,16 +20,34 @@ type URLsSuite struct {
 var _ = gc.Suite(&URLsSuite{})
 
 func (s *URLsSuite) TestImageMetadataURL(c *gc.C) {
-	for source, expected := range map[string]string{
-		"":           "",
-		"foo":        "file://foo/images",
-		"/home/foo":  "file:///home/foo/images",
-		"file://foo": "file://foo",
-		"http://foo": "http://foo",
-	} {
-		URL, err := imagemetadata.ImageMetadataURL(source, "")
-		c.Assert(err, gc.IsNil)
-		c.Assert(URL, gc.Equals, expected)
+	var imageTests = []struct {
+		in          string
+		expected    string
+		expectedErr error
+	}{{
+		in:          "",
+		expected:    "",
+		expectedErr: nil,
+	}, {
+		in:          "file://foo",
+		expected:    "file://foo",
+		expectedErr: nil,
+	}, {
+		in:          "http://foo",
+		expected:    "http://foo",
+		expectedErr: nil,
+	}, {
+		in:          "foo",
+		expected:    "",
+		expectedErr: fmt.Errorf("foo is not an absolute path"),
+	}}
+	imageTests = append(imageTests, imageTestsPlatformSpecific...)
+	for i, t := range imageTests {
+		c.Logf("Test %d:", i)
+
+		out, err := imagemetadata.ImageMetadataURL(t.in, "")
+		c.Assert(err, gc.DeepEquals, t.expectedErr)
+		c.Assert(out, gc.Equals, t.expected)
 	}
 }
 

--- a/environs/imagemetadata/urls_unix_test.go
+++ b/environs/imagemetadata/urls_unix_test.go
@@ -1,0 +1,21 @@
+// Copyright 2012, 2013, 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package imagemetadata_test
+
+var imageTestsPlatformSpecific = []struct {
+	in          string
+	expected    string
+	expectedErr error
+}{{
+	in:          "/home/foo",
+	expected:    "file:///home/foo/images",
+	expectedErr: nil,
+}, {
+	in:          "/home/foo/images",
+	expected:    "file:///home/foo/images",
+	expectedErr: nil,
+}}

--- a/environs/imagemetadata/urls_windows_test.go
+++ b/environs/imagemetadata/urls_windows_test.go
@@ -1,0 +1,21 @@
+// Copyright 2012, 2013, 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build windows
+
+package imagemetadata_test
+
+var imageTestsPlatformSpecific = []struct {
+	in          string
+	expected    string
+	expectedErr error
+}{{
+	in:          "C:/home/foo",
+	expected:    "file://\\\\localhost\\C$/home/foo/images",
+	expectedErr: nil,
+}, {
+	in:          "C:/home/foo/images",
+	expected:    "file://\\\\localhost\\C$/home/foo/images",
+	expectedErr: nil,
+}}

--- a/environs/imagemetadata/validation_test.go
+++ b/environs/imagemetadata/validation_test.go
@@ -59,7 +59,7 @@ func (s *ValidateSuite) assertMatch(c *gc.C, stream string) {
 		Endpoint:      "some-auth-url",
 		Stream:        stream,
 		Sources: []simplestreams.DataSource{
-			simplestreams.NewURLDataSource("test", "file://"+metadataPath, utils.VerifySSLHostnames)},
+			simplestreams.NewURLDataSource("test", utils.MakeFileURL(metadataPath), utils.VerifySSLHostnames)},
 	}
 	imageIds, resolveInfo, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, gc.IsNil)
@@ -67,7 +67,7 @@ func (s *ValidateSuite) assertMatch(c *gc.C, stream string) {
 	c.Check(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
 		Source:    "test",
 		Signed:    false,
-		IndexURL:  "file://" + path.Join(metadataPath, "streams/v1/index.json"),
+		IndexURL:  utils.MakeFileURL(path.Join(metadataPath, "streams/v1/index.json")),
 		MirrorURL: "",
 	})
 }

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -71,6 +71,8 @@ func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 	dataURL := urlJoin(h.baseURL, path)
 	client := utils.GetHTTPClient(h.hostnameVerification)
 	// dataURL can be http:// or file://
+	// MakeFileURL will only modify the URL if it's a file URL
+	dataURL = utils.MakeFileURL(dataURL)
 	resp, err := client.Get(dataURL)
 	if err != nil {
 		logger.Debugf("Got error requesting %q: %v", dataURL, err)
@@ -90,7 +92,7 @@ func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 
 // URL is defined in simplestreams.DataSource.
 func (h *urlDataSource) URL(path string) (string, error) {
-	return urlJoin(h.baseURL, path), nil
+	return utils.MakeFileURL(urlJoin(h.baseURL, path)), nil
 }
 
 // SetAllowRetry is defined in simplestreams.DataSource.

--- a/environs/tools/marshal.go
+++ b/environs/tools/marshal.go
@@ -23,7 +23,7 @@ func ToolsContentId(stream string) string {
 
 // ProductMetadataPath returns the tools product metadata path for the given stream.
 func ProductMetadataPath(stream string) string {
-	return fmt.Sprintf("streams/v1/com.ubuntu.juju:%s:tools.json", stream)
+	return fmt.Sprintf("streams/v1/com.ubuntu.juju-%s-tools.json", stream)
 }
 
 // MarshalToolsMetadataJSON marshals tools metadata to index and products JSON.

--- a/environs/tools/marshal_test.go
+++ b/environs/tools/marshal_test.go
@@ -49,7 +49,7 @@ var expectedIndex = `{
             "updated": "Thu, 01 Jan 1970 00:00:00 +0000",
             "format": "products:1.0",
             "datatype": "content-download",
-            "path": "streams/v1/com.ubuntu.juju:proposed:tools.json",
+            "path": "streams/v1/com.ubuntu.juju-proposed-tools.json",
             "products": [
                 "com.ubuntu.juju:14.04:arm64",
                 "com.ubuntu.juju:14.10:ppc64el"
@@ -59,7 +59,7 @@ var expectedIndex = `{
             "updated": "Thu, 01 Jan 1970 00:00:00 +0000",
             "format": "products:1.0",
             "datatype": "content-download",
-            "path": "streams/v1/com.ubuntu.juju:released:tools.json",
+            "path": "streams/v1/com.ubuntu.juju-released-tools.json",
             "products": [
                 "com.ubuntu.juju:12.04:amd64",
                 "com.ubuntu.juju:12.04:arm",

--- a/environs/tools/storage.go
+++ b/environs/tools/storage.go
@@ -6,6 +6,7 @@ package tools
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/juju/environs/storage"
@@ -48,6 +49,7 @@ func ReadList(stor storage.StorageReader, toolsDir string, majorVersion, minorVe
 	var list coretools.List
 	var foundAnyTools bool
 	for _, name := range names {
+		name = filepath.ToSlash(name)
 		if !strings.HasPrefix(name, storagePrefix) || !strings.HasSuffix(name, toolSuffix) {
 			continue
 		}

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -256,7 +256,7 @@ func UploadToDirectory(c *gc.C, stream, dir string, versions ...version.Binary) 
 	}
 	for _, vers := range versions {
 		basePath := fmt.Sprintf("%s/tools-%s.tar.gz", stream, vers.String())
-		uploaded[vers] = fmt.Sprintf("file://%s/%s", dir, basePath)
+		uploaded[vers] = utils.MakeFileURL(fmt.Sprintf("%s/%s", dir, basePath))
 	}
 	objects := generateMetadata(c, stream, versions...)
 	for _, object := range objects {

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
@@ -45,7 +46,7 @@ func (s *SimpleStreamsToolsSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *SimpleStreamsToolsSuite) SetUpTest(c *gc.C) {
-	s.ToolsFixture.DefaultBaseURL = "file://" + s.publicToolsDir
+	s.ToolsFixture.DefaultBaseURL = utils.MakeFileURL(s.publicToolsDir)
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	s.origCurrentVersion = version.Current
@@ -61,7 +62,7 @@ func (s *SimpleStreamsToolsSuite) TearDownTest(c *gc.C) {
 
 func (s *SimpleStreamsToolsSuite) reset(c *gc.C, attrs map[string]interface{}) {
 	final := map[string]interface{}{
-		"agent-metadata-url": "file://" + s.customToolsDir,
+		"agent-metadata-url": utils.MakeFileURL(s.customToolsDir),
 		"agent-stream":       "proposed",
 	}
 	for k, v := range attrs {

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -4,9 +4,6 @@
 package tools
 
 import (
-	"fmt"
-	"net/url"
-	"strings"
 	"sync"
 
 	"github.com/juju/errors"
@@ -16,6 +13,7 @@ import (
 	conf "github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
+	envutils "github.com/juju/juju/environs/utils"
 )
 
 type toolsDatasourceFuncId struct {
@@ -126,18 +124,6 @@ func ToolsURL(source string) (string, error) {
 	if source == "" {
 		return "", nil
 	}
-	// If source is a raw directory, we need to append the file:// prefix
-	// so it can be used as a URL.
-	defaultURL := source
-	u, err := url.Parse(source)
-	if err != nil {
-		return "", fmt.Errorf("invalid default tools URL %s: %v", defaultURL, err)
-	}
-	if u.Scheme == "" {
-		defaultURL = "file://" + defaultURL
-		if !strings.HasSuffix(defaultURL, "/"+storage.BaseToolsPath) {
-			defaultURL = fmt.Sprintf("%s/%s", defaultURL, storage.BaseToolsPath)
-		}
-	}
-	return defaultURL, nil
+
+	return envutils.GetURL(source, storage.BaseToolsPath)
 }

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -1,9 +1,12 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2012, 2013, 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package tools_test
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -100,15 +103,33 @@ func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncsError(c *gc.C) {
 }
 
 func (s *URLsSuite) TestToolsURL(c *gc.C) {
-	for source, expected := range map[string]string{
-		"":           "",
-		"foo":        "file://foo/tools",
-		"/home/foo":  "file:///home/foo/tools",
-		"file://foo": "file://foo",
-		"http://foo": "http://foo",
-	} {
-		URL, err := tools.ToolsURL(source)
-		c.Assert(err, gc.IsNil)
-		c.Assert(URL, gc.Equals, expected)
+	var toolsTests = []struct {
+		in          string
+		expected    string
+		expectedErr error
+	}{{
+		in:          "",
+		expected:    "",
+		expectedErr: nil,
+	}, {
+		in:          "file://foo",
+		expected:    "file://foo",
+		expectedErr: nil,
+	}, {
+		in:          "http://foo",
+		expected:    "http://foo",
+		expectedErr: nil,
+	}, {
+		in:          "foo",
+		expected:    "",
+		expectedErr: fmt.Errorf("foo is not an absolute path"),
+	}}
+	toolsTests = append(toolsTests, toolsTestsPlatformSpecific...)
+	for i, t := range toolsTests {
+		c.Logf("Test %d:", i)
+
+		out, err := tools.ToolsURL(t.in)
+		c.Assert(err, gc.DeepEquals, t.expectedErr)
+		c.Assert(out, gc.Equals, t.expected)
 	}
 }

--- a/environs/tools/urls_unix_test.go
+++ b/environs/tools/urls_unix_test.go
@@ -1,0 +1,21 @@
+// Copyright 2012, 2013, 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package tools_test
+
+var toolsTestsPlatformSpecific = []struct {
+	in          string
+	expected    string
+	expectedErr error
+}{{
+	in:          "/home/foo",
+	expected:    "file:///home/foo/tools",
+	expectedErr: nil,
+}, {
+	in:          "/home/foo/tools",
+	expected:    "file:///home/foo/tools",
+	expectedErr: nil,
+}}

--- a/environs/tools/urls_windows_test.go
+++ b/environs/tools/urls_windows_test.go
@@ -1,0 +1,21 @@
+// Copyright 2012, 2013, 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build windows
+
+package tools_test
+
+var toolsTestsPlatformSpecific = []struct {
+	in          string
+	expected    string
+	expectedErr error
+}{{
+	in:          "C:/home/foo",
+	expected:    "file://\\\\localhost\\C$/home/foo/tools",
+	expectedErr: nil,
+}, {
+	in:          "C:/home/foo/tools",
+	expected:    "file://\\\\localhost\\C$/home/foo/tools",
+	expectedErr: nil,
+}}

--- a/environs/tools/validation_test.go
+++ b/environs/tools/validation_test.go
@@ -48,7 +48,7 @@ func (s *ValidateSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ValidateSuite) toolsURL() string {
-	return "file://" + path.Join(s.metadataDir, "tools")
+	return utils.MakeFileURL(path.Join(s.metadataDir, "tools"))
 }
 
 func (s *ValidateSuite) TestExactVersionMatch(c *gc.C) {
@@ -71,7 +71,7 @@ func (s *ValidateSuite) TestExactVersionMatch(c *gc.C) {
 	c.Check(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
 		Source:    "test",
 		Signed:    false,
-		IndexURL:  "file://" + path.Join(s.metadataDir, "tools/streams/v1/index2.json"),
+		IndexURL:  utils.MakeFileURL(path.Join(s.metadataDir, "tools/streams/v1/index2.json")),
 		MirrorURL: "",
 	})
 }
@@ -97,7 +97,7 @@ func (s *ValidateSuite) TestMajorVersionMatch(c *gc.C) {
 	c.Check(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
 		Source:    "test",
 		Signed:    false,
-		IndexURL:  "file://" + path.Join(s.metadataDir, "tools/streams/v1/index2.json"),
+		IndexURL:  utils.MakeFileURL(path.Join(s.metadataDir, "tools/streams/v1/index2.json")),
 		MirrorURL: "",
 	})
 }
@@ -123,7 +123,7 @@ func (s *ValidateSuite) TestMajorMinorVersionMatch(c *gc.C) {
 	c.Check(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
 		Source:    "test",
 		Signed:    false,
-		IndexURL:  "file://" + path.Join(s.metadataDir, "tools/streams/v1/index2.json"),
+		IndexURL:  utils.MakeFileURL(path.Join(s.metadataDir, "tools/streams/v1/index2.json")),
 		MirrorURL: "",
 	})
 }

--- a/environs/utils/urls.go
+++ b/environs/utils/urls.go
@@ -1,0 +1,39 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/utils"
+)
+
+func GetURL(source, basePath string) (string, error) {
+	// If source is a raw directory, we need to append the file:// prefix
+	// so it can be used as a URL.
+	defaultURL := source
+	u, err := url.Parse(source)
+	if err != nil {
+		return "", fmt.Errorf("invalid default %s URL %s: %v", basePath, defaultURL, err)
+	}
+
+	switch u.Scheme {
+	case "http", "https", "file", "test":
+		return source, nil
+	}
+
+	if filepath.IsAbs(defaultURL) {
+		defaultURL = utils.MakeFileURL(defaultURL)
+		if !strings.HasSuffix(defaultURL, "/"+basePath) {
+			defaultURL = fmt.Sprintf("%s/%s", defaultURL, basePath)
+		}
+	} else {
+		return "", fmt.Errorf("%s is not an absolute path", source)
+	}
+	return defaultURL, nil
+}


### PR DESCRIPTION
This PR makes some transparent changes to implement filestorage on windows.

We cannot write files with : on the disk so we write everything with a -. This also means that anything that's read from the disk also has to contain dashes.

Depends on https://github.com/juju/utils/pull/45
