### PR TITLE
Fixed a racy firewaller test for the new FwNone firewall-mode

### DIFF
--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -45,32 +45,55 @@ type Firewaller struct {
 
 // NewFirewaller returns a new Firewaller or a new FirewallerV0,
 // depending on what the API supports.
-func NewFirewaller(st *apifirewaller.State) (worker.Worker, error) {
-	environWatcher, err := st.WatchForEnvironConfigChanges()
+func NewFirewaller(st *apifirewaller.State) (_ worker.Worker, err error) {
+	fw := &Firewaller{
+		st:            st,
+		machineds:     make(map[names.MachineTag]*machineData),
+		unitsChange:   make(chan *unitsChange),
+		unitds:        make(map[names.UnitTag]*unitData),
+		serviceds:     make(map[names.ServiceTag]*serviceData),
+		exposedChange: make(chan *exposedChange),
+		machinePorts:  make(map[names.MachineTag]machineRanges),
+	}
+	defer func() {
+		if err != nil {
+			fw.stopWatchers()
+		}
+	}()
+
+	fw.environWatcher, err = st.WatchForEnvironConfigChanges()
 	if err != nil {
 		return nil, err
 	}
-	machinesWatcher, err := st.WatchEnvironMachines()
+
+	fw.machinesWatcher, err = st.WatchEnvironMachines()
 	if err != nil {
 		return nil, err
 	}
-	portsWatcher, err := st.WatchOpenedPorts()
+
+	fw.portsWatcher, err = st.WatchOpenedPorts()
 	if err != nil {
 		return nil, errors.Annotatef(err, "failed to start ports watcher")
 	}
 	logger.Debugf("started watching opened port ranges for the environment")
-	fw := &Firewaller{
-		st:              st,
-		environWatcher:  environWatcher,
-		machinesWatcher: machinesWatcher,
-		portsWatcher:    portsWatcher,
-		machineds:       make(map[names.MachineTag]*machineData),
-		unitsChange:     make(chan *unitsChange),
-		unitds:          make(map[names.UnitTag]*unitData),
-		serviceds:       make(map[names.ServiceTag]*serviceData),
-		exposedChange:   make(chan *exposedChange),
-		machinePorts:    make(map[names.MachineTag]machineRanges),
+
+	// We won't "wait" actually, because the environ is already
+	// available and has a guaranteed valid config, but until
+	// WaitForEnviron goes away, this code needs to stay.
+	fw.environ, err = worker.WaitForEnviron(fw.environWatcher, fw.st, fw.tomb.Dying())
+	if err != nil {
+		return nil, err
 	}
+
+	switch fw.environ.Config().FirewallMode() {
+	case config.FwGlobal:
+		fw.globalMode = true
+		fw.globalPortRef = make(map[network.PortRange]int)
+	case config.FwNone:
+		logger.Warningf("stopping firewaller - firewall-mode is %q", config.FwNone)
+		return nil, errors.Errorf("firewaller is disabled when firewall-mode is %q", config.FwNone)
+	}
+
 	go func() {
 		defer fw.tomb.Done()
 		fw.tomb.Kill(fw.loop())
@@ -83,23 +106,9 @@ var _ worker.Worker = (*Firewaller)(nil)
 func (fw *Firewaller) loop() error {
 	defer fw.stopWatchers()
 
-	var err error
 	var reconciled bool
 
-	fw.environ, err = worker.WaitForEnviron(fw.environWatcher, fw.st, fw.tomb.Dying())
-	if err != nil {
-		return err
-	}
-
 	portsChange := fw.portsWatcher.Changes()
-	switch fw.environ.Config().FirewallMode() {
-	case config.FwGlobal:
-		fw.globalMode = true
-		fw.globalPortRef = make(map[network.PortRange]int)
-	case config.FwNone:
-		logger.Warningf("stopping firewaller - firewall-mode is %q", config.FwNone)
-		return errors.Errorf("firewaller is disabled when firewall-mode is %q", config.FwNone)
-	}
 	for {
 		select {
 		case <-fw.tomb.Dying():
@@ -654,14 +663,24 @@ func (fw *Firewaller) forgetUnit(unitd *unitData) {
 
 // stopWatchers stops all the firewaller's watchers.
 func (fw *Firewaller) stopWatchers() {
-	watcher.Stop(fw.environWatcher, &fw.tomb)
-	watcher.Stop(fw.machinesWatcher, &fw.tomb)
-	watcher.Stop(fw.portsWatcher, &fw.tomb)
+	if fw.environWatcher != nil {
+		watcher.Stop(fw.environWatcher, &fw.tomb)
+	}
+	if fw.machinesWatcher != nil {
+		watcher.Stop(fw.machinesWatcher, &fw.tomb)
+	}
+	if fw.portsWatcher != nil {
+		watcher.Stop(fw.portsWatcher, &fw.tomb)
+	}
 	for _, serviced := range fw.serviceds {
-		watcher.Stop(serviced, &fw.tomb)
+		if serviced != nil {
+			watcher.Stop(serviced, &fw.tomb)
+		}
 	}
 	for _, machined := range fw.machineds {
-		watcher.Stop(machined, &fw.tomb)
+		if machined != nil {
+			watcher.Stop(machined, &fw.tomb)
+		}
 	}
 }
 

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -797,10 +797,8 @@ func (s *NoneModeSuite) TearDownTest(c *gc.C) {
 	s.firewallerBaseSuite.JujuConnSuite.TearDownTest(c)
 }
 
-func (s *NoneModeSuite) TestStopsAfterGettingMode(c *gc.C) {
+func (s *NoneModeSuite) TestDoesNotStartAtAll(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
-	c.Assert(err, gc.IsNil)
-	c.Assert(fw, gc.NotNil)
-	fw.Kill()
-	c.Assert(fw.Wait(), gc.ErrorMatches, `firewaller is disabled when firewall-mode is "none"`)
+	c.Assert(err, gc.ErrorMatches, `firewaller is disabled when firewall-mode is "none"`)
+	c.Assert(fw, gc.IsNil)
 }


### PR DESCRIPTION
It seems the way "firewall-mode: none" is tested in the firewaller
worker is racy, although I haven't seen any failures on my machine
or on the merge bot. John Weldon however managed to readily reproduce
the issue - http://paste.ubuntu.com/8565153/. Thanks for the report!

The correct fix actually made both the tests and the implementation
inside the worker simpler -- rather than calling worker.WaitForEnviron
inside the loop() method and assuming it can block, now it's called
directly into the NewFirewaller constructor. The reason this works is
because by the time the worker stats and connects to the API, we
_already_ have a valid environment configuration and don't need to
wait for it. In fact, WaitForEnviron is on the way out and some more
simplifications can be done when it's gone, but now's not the time.
