### PR TITLE
api/reboot: Skip building tests on ppc64

### DIFF
--- a/api/reboot/reboot.go
+++ b/api/reboot/reboot.go
@@ -1,3 +1,7 @@
+// Copyright 2014 Cloudbase Solutions
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package reboot
 
 import (

--- a/api/reboot/reboot_test.go
+++ b/api/reboot/reboot_test.go
@@ -1,3 +1,9 @@
+// Copyright 2014 Cloudbase Solutions
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !ppc64
+
 package reboot_test
 
 import (


### PR DESCRIPTION
An apparent gccgo linking bug prevents the tests from building on
ppc64. Just avoid building the test file for now.

Also adds missing copyright headers.

http://reviews.vapour.ws/r/176/
