### PR TITLE
Cleanup TODO comments

### DIFF
--- a/api/actions/client.go
+++ b/api/actions/client.go
@@ -59,7 +59,6 @@ func (c *Client) ListCompleted(arg params.Tags) (params.ActionsByReceivers, erro
 
 // Cancel attempts to cancel a queued up Action from running.
 func (c *Client) Cancel(arg params.Actions) (params.ActionResults, error) {
-	// TODO(jcw4) implement this fully
 	results := params.ActionResults{}
 	err := c.facade.FacadeCall("Cancel", arg, &results)
 	return results, err

--- a/apiserver/actions/actions.go
+++ b/apiserver/actions/actions.go
@@ -44,7 +44,6 @@ func NewActionsAPI(st *state.State, resources *common.Resources, authorizer comm
 // Action.
 func (a *ActionsAPI) Enqueue(arg params.Actions) (params.ActionResults, error) {
 	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Actions))}
-	// TODO(jcw4) authorization checks
 	for i, action := range arg.Actions {
 		current := &response.Results[i]
 
@@ -99,7 +98,6 @@ func (a *ActionsAPI) ListCompleted(arg params.Tags) (params.ActionsByReceivers, 
 // Cancel attempts to cancel queued up Actions from running.
 func (a *ActionsAPI) Cancel(arg params.ActionTags) (params.ActionResults, error) {
 	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Actions))}
-	// TODO(jcw4) authorization checks
 	for i, tag := range arg.Actions {
 		current := &response.Results[i]
 		receiver, err := tagToActionReceiver(a.state, tag.PrefixTag())
@@ -163,7 +161,6 @@ func (a *ActionsAPI) ServicesCharmActions(args params.ServiceTags) (params.Servi
 // ActionReceiver.
 func (a *ActionsAPI) internalList(arg params.Tags, fn extractorFn) (params.ActionsByReceivers, error) {
 	response := params.ActionsByReceivers{Actions: make([]params.ActionsByReceiver, len(arg.Tags))}
-	// TODO(jcw4) authorization checks
 	for i, tag := range arg.Tags {
 		current := &response.Actions[i]
 		receiver, err := tagToActionReceiver(a.state, tag)

--- a/apiserver/actions/actions_test.go
+++ b/apiserver/actions/actions_test.go
@@ -124,7 +124,7 @@ func (s *actionsSuite) TestEnqueue(c *gc.C) {
 			{Receiver: s.wordpressUnit.Tag(), Name: expectedName, Parameters: expectedParameters},
 			// Service tag instead of Unit tag.
 			{Receiver: s.wordpress.Tag(), Name: "baz"},
-			// TODO(jcw4) notice no Name.
+			// TODO(jcw4) notice no Name. Shouldn't Action Names be required?
 			{Receiver: s.mysqlUnit.Tag(), Parameters: expectedParameters},
 		},
 	}
@@ -163,7 +163,7 @@ func (s *actionsSuite) TestEnqueue(c *gc.C) {
 	actions, err = s.mysqlUnit.Actions()
 	c.Assert(err, gc.IsNil)
 	c.Assert(actions, gc.HasLen, 1)
-	// TODO(jcw4) notice Action Name empty.
+	// TODO(jcw4) notice Action Name empty. Shouldn't Action Names be required?
 	c.Assert(actions[0].Name(), gc.Equals, "")
 	c.Assert(actions[0].Parameters(), gc.DeepEquals, expectedParameters)
 	c.Assert(actions[0].Receiver(), gc.Equals, s.mysqlUnit.Name())


### PR DESCRIPTION
Unneeded TODO comments, and a couple TODO comment tweaks
(The authorization check when creating the actions facade covers all our authorization needs)
