### PR TITLE
maas: static-ipaddresses capability detection

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -31,7 +31,7 @@ gopkg.in/yaml.v1	git	1418a9bc452f9cf4efa70307cafcb10743e64a56
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/goamz	bzr	martin.packman@canonical.com-20140813150539-umttn7s536u85eiz	49
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20140730020217-xa1jyuytye6g1qie	12
-launchpad.net/gomaasapi	bzr	andrew.wilkins@canonical.com-20141015031225-0mj1vxsqautaukw8	56
+launchpad.net/gomaasapi	bzr	dimiter.naydenov@canonical.com-20141020145519-s8tr5tpagsoatz83	57
 launchpad.net/goose	bzr	tarmac-20140908075634-5iinsru19k3d8w55	128
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20140624093241-rlqsuf7pqxnrztgw	236
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -166,8 +166,12 @@ func (env *maasEnviron) SupportedArchitectures() ([]string, error) {
 }
 
 // SupportAddressAllocation is specified on the EnvironCapability interface.
-func (e *maasEnviron) SupportAddressAllocation(netId network.Id) (bool, error) {
-	return false, nil
+func (env *maasEnviron) SupportAddressAllocation(netId network.Id) (bool, error) {
+	caps, err := env.getCapabilities()
+	if err != nil {
+		return false, errors.Annotatef(err, "getCapabilities failed")
+	}
+	return caps.Contains(capStaticIPAddresses), nil
 }
 
 // allBootImages queries MAAS for all of the boot-images across
@@ -403,7 +407,10 @@ func (env *maasEnviron) PrecheckInstance(series string, cons constraints.Value, 
 	return err
 }
 
-const capNetworksManagement = "networks-management"
+const (
+	capNetworksManagement = "networks-management"
+	capStaticIPAddresses  = "static-ipaddresses"
+)
 
 // getCapabilities asks the MAAS server for its capabilities, if
 // supported by the server.

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -662,8 +662,12 @@ func (suite *environSuite) TestGetNetworkMACs(c *gc.C) {
 
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node_1"}`)
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node_2"}`)
-	suite.testMAASObject.TestServer.NewNetwork(`{"name": "net_1"}`)
-	suite.testMAASObject.TestServer.NewNetwork(`{"name": "net_2"}`)
+	suite.testMAASObject.TestServer.NewNetwork(
+		`{"name": "net_1","ip":"0.1.2.0","netmask":"255.255.255.0"}`,
+	)
+	suite.testMAASObject.TestServer.NewNetwork(
+		`{"name": "net_2","ip":"0.2.2.0","netmask":"255.255.255.0"}`,
+	)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node_2", "net_2", "aa:bb:cc:dd:ee:22")
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node_1", "net_1", "aa:bb:cc:dd:ee:11")
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node_2", "net_1", "aa:bb:cc:dd:ee:21")
@@ -868,9 +872,9 @@ func (suite *environSuite) TestSupportNetworks(c *gc.C) {
 
 func (suite *environSuite) TestSupportAddressAllocation(c *gc.C) {
 	env := suite.makeEnviron()
-	result, err := env.SupportAddressAllocation("")
-	c.Assert(result, jc.IsFalse)
+	supported, err := env.SupportAddressAllocation("")
 	c.Assert(err, gc.IsNil)
+	c.Assert(supported, jc.IsTrue)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {


### PR DESCRIPTION
Now the environment capability SupportsAddressAllocation
actually uses the MAAS version API to check if the needed
"static-ipaddresses" capability is supported. Bumped the
gomaasapi revision in dependencies.tsv.
