### PR TITLE
Use tmp location for tool cache to avoid issues deleting machines

### DIFF
--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -308,11 +308,11 @@ func mountHostToolsDir(name, toolsDir string) error {
 	// Make sure that the mount dir has been created.
 	logger.Tracef("make the mount dir for the tools")
 	if err := os.MkdirAll(internalToolsDir(name), 0755); err != nil {
-		logger.Errorf("failed to create internal /var/lib/juju/storage/tools mount dir: %v", err)
+		logger.Errorf("failed to create internal /tmp/juju/tools mount dir: %v", err)
 		return err
 	}
 	line := fmt.Sprintf(
-		"lxc.mount.entry=%s var/lib/juju/storage/tools none defaults,bind 0 0\n",
+		"lxc.mount.entry=%s tmp/juju/tools none defaults,bind 0 0\n",
 		toolsDir)
 	return appendToContainerConfig(name, line)
 }
@@ -368,7 +368,7 @@ func internalLogDir(containerName string) string {
 	return fmt.Sprintf(internalLogDirTemplate, LxcContainerDir, containerName)
 }
 
-const internalToolsDirTemplate = "%s/%s/rootfs/var/lib/juju/storage/tools"
+const internalToolsDirTemplate = "%s/%s/rootfs/tmp/juju/tools"
 
 func internalToolsDir(containerName string) string {
 	return fmt.Sprintf(internalToolsDirTemplate, LxcContainerDir, containerName)

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -328,7 +328,7 @@ func (s *LxcSuite) TestCreateContainerWithCloneMountsAndAutostarts(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	mountLine := "lxc.mount.entry=/var/log/juju var/log/juju none defaults,bind 0 0"
 	c.Assert(string(config), jc.Contains, mountLine)
-	mountLine = "lxc.mount.entry=/mount/tools var/lib/juju/storage/tools none defaults,bind 0 0"
+	mountLine = "lxc.mount.entry=/mount/tools tmp/juju/tools none defaults,bind 0 0"
 	c.Assert(string(config), jc.Contains, mountLine)
 	c.Assert(autostartLink, jc.IsSymlink)
 }
@@ -469,7 +469,7 @@ lxc.network.link = nic42
 lxc.network.flags = up
 lxc.start.auto = 1
 lxc.mount.entry=/var/log/juju var/log/juju none defaults,bind 0 0
-lxc.mount.entry=/mount/tools var/lib/juju/storage/tools none defaults,bind 0 0
+lxc.mount.entry=/mount/tools tmp/juju/tools none defaults,bind 0 0
 `
 	c.Assert(string(config), gc.Equals, expected)
 }

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -358,7 +358,7 @@ func (env *localEnviron) StartInstance(args environs.StartInstanceParams) (insta
 			return nil, nil, nil, err
 		}
 		args.MachineConfig.Tools.URL = strings.Replace(
-			args.MachineConfig.Tools.URL, storageReleasesDir, "file:///var/lib/juju/storage/tools", -1)
+			args.MachineConfig.Tools.URL, storageReleasesDir, "file:///tmp/juju/tools", -1)
 	}
 
 	args.MachineConfig.MachineContainerType = env.config.container()

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -341,7 +341,7 @@ func (s *localJujuTestSuite) TestToolsURLPatchedForLxc(c *gc.C) {
 		MachineConfig: machineConfig,
 	}
 
-	local.PatchCreateContainer(&s.CleanupSuite, c, "file:///var/lib/juju/storage/tools/juju-5.4.5-precise-amd64.tgz")
+	local.PatchCreateContainer(&s.CleanupSuite, c, "file:///tmp/juju/tools/juju-5.4.5-precise-amd64.tgz")
 	inst, _, _, err := env.StartInstance(params)
 	c.Assert(err, gc.IsNil)
 	c.Assert(inst.Id(), gc.Equals, instance.Id("mock"))


### PR DESCRIPTION
When starting an LXC container for the local provider, if we put the tools tarballs in a bind mounted dir which lives under /var/lib/juju, the contents of this dir are deleted when the agent exits on machine deletion. Thus subsequent containers can't find tools. So we use a tmp dir instead.

Fixes: https://bugs.launchpad.net/juju-core/1.20/+bug/1379802
