### PR TITLE
Cycle through azs till we find one that works

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1442,6 +1442,88 @@ func (t *localServerSuite) TestStartInstanceDistribution(c *gc.C) {
 	c.Assert(openstack.InstanceServerDetail(inst).AvailabilityZone, gc.Equals, "test-available")
 }
 
+func (t *localServerSuite) TestStartInstancePicksValidZoneForHost(c *gc.C) {
+	t.srv.Service.Nova.SetAvailabilityZones(
+		// bootstrap node will be on az1.
+		nova.AvailabilityZone{
+			Name: "az1",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+		// az2 will be made to return an error.
+		nova.AvailabilityZone{
+			Name: "az2",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+		// az3 will be valid to host an instance.
+		nova.AvailabilityZone{
+			Name: "az3",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+	)
+
+	env := t.Prepare(c)
+	err := bootstrap.Bootstrap(coretesting.Context(c), env, bootstrap.BootstrapParams{})
+	c.Assert(err, gc.IsNil)
+
+	cleanup := t.srv.Service.Nova.RegisterControlPoint(
+		"addServer",
+		func(sc hook.ServiceControl, args ...interface{}) error {
+			serverDetail := args[0].(*nova.ServerDetail)
+			if serverDetail.AvailabilityZone == "az2" {
+				return fmt.Errorf("No valid host was found")
+			}
+			return nil
+		},
+	)
+	defer cleanup()
+	inst, _ := testing.AssertStartInstance(c, env, "1")
+	c.Assert(openstack.InstanceServerDetail(inst).AvailabilityZone, gc.Equals, "az3")
+}
+
+func (t *localServerSuite) TestStartInstanceWithUnknownAZError(c *gc.C) {
+	t.srv.Service.Nova.SetAvailabilityZones(
+		// bootstrap node will be on az1.
+		nova.AvailabilityZone{
+			Name: "az1",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+		// az2 will be made to return an unknown error.
+		nova.AvailabilityZone{
+			Name: "az2",
+			State: nova.AvailabilityZoneState{
+				Available: true,
+			},
+		},
+	)
+
+	env := t.Prepare(c)
+	err := bootstrap.Bootstrap(coretesting.Context(c), env, bootstrap.BootstrapParams{})
+	c.Assert(err, gc.IsNil)
+
+	cleanup := t.srv.Service.Nova.RegisterControlPoint(
+		"addServer",
+		func(sc hook.ServiceControl, args ...interface{}) error {
+			serverDetail := args[0].(*nova.ServerDetail)
+			if serverDetail.AvailabilityZone == "az2" {
+				return fmt.Errorf("Some unknown error")
+			}
+			return nil
+		},
+	)
+	defer cleanup()
+	_, _, _, err = testing.StartInstance(env, "1")
+	errString := strings.Replace(err.Error(), "\n", "", -1)
+	c.Assert(errString, gc.Matches, ".*Some unknown error.*")
+}
+
 func (t *localServerSuite) TestStartInstanceDistributionAZNotImplemented(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(coretesting.Context(c), env, bootstrap.BootstrapParams{})

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -945,7 +945,7 @@ var availabilityZoneAllocations = common.AvailabilityZoneAllocations
 
 // StartInstance is specified in the InstanceBroker interface.
 func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
-	var availabilityZone string
+	var availabilityZones []string
 	if args.Placement != "" {
 		placement, err := e.parsePlacement(args.Placement)
 		if err != nil {
@@ -954,13 +954,13 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		if !placement.availabilityZone.State.Available {
 			return nil, nil, nil, fmt.Errorf("availability zone %q is unavailable", placement.availabilityZone.Name)
 		}
-		availabilityZone = placement.availabilityZone.Name
+		availabilityZones = append(availabilityZones, placement.availabilityZone.Name)
 	}
 
 	// If no availability zone is specified, then automatically spread across
 	// the known zones for optimal spread across the instance distribution
 	// group.
-	if availabilityZone == "" {
+	if len(availabilityZones) == 0 {
 		var group []instance.Id
 		var err error
 		if args.DistributionGroup != nil {
@@ -975,8 +975,14 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 			// not implemented error; ignore these.
 		} else if err != nil {
 			return nil, nil, nil, err
-		} else if len(zoneInstances) > 0 {
-			availabilityZone = zoneInstances[0].ZoneName
+		} else {
+			for _, zone := range zoneInstances {
+				availabilityZones = append(availabilityZones, zone.ZoneName)
+			}
+		}
+		if len(availabilityZones) == 0 {
+			// No explicitly selectable zones available, so use an unspecified zone.
+			availabilityZones = []string{""}
 		}
 	}
 
@@ -1040,19 +1046,26 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 	for i, g := range groups {
 		groupNames[i] = nova.SecurityGroupName{g.Name}
 	}
-	var opts = nova.RunServerOpts{
-		Name:               e.machineFullName(args.MachineConfig.MachineId),
-		FlavorId:           spec.InstanceType.Id,
-		ImageId:            spec.Image.Id,
-		UserData:           userData,
-		SecurityGroupNames: groupNames,
-		Networks:           networks,
-		AvailabilityZone:   availabilityZone,
-	}
 	var server *nova.Entity
-	for a := shortAttempt.Start(); a.Next(); {
-		server, err = e.nova().RunServer(opts)
-		if err == nil || !gooseerrors.IsNotFound(err) {
+	for _, availZone := range availabilityZones {
+		var opts = nova.RunServerOpts{
+			Name:               e.machineFullName(args.MachineConfig.MachineId),
+			FlavorId:           spec.InstanceType.Id,
+			ImageId:            spec.Image.Id,
+			UserData:           userData,
+			SecurityGroupNames: groupNames,
+			Networks:           networks,
+			AvailabilityZone:   availZone,
+		}
+		for a := shortAttempt.Start(); a.Next(); {
+			server, err = e.nova().RunServer(opts)
+			if err == nil || !gooseerrors.IsNotFound(err) {
+				break
+			}
+		}
+		if isNoValidHostsError(err) {
+			logger.Infof("no valid hosts available in zone %q, trying another availability zone", availZone)
+		} else {
 			break
 		}
 	}
@@ -1087,6 +1100,11 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		}
 	}
 	return inst, inst.hardwareCharacteristics(), nil, nil
+}
+
+func isNoValidHostsError(err error) bool {
+	gooseErr, ok := err.(gooseerrors.Error)
+	return ok && strings.Contains(gooseErr.Cause().Error(), "No valid host was found")
 }
 
 func (e *environ) StopInstances(ids ...instance.Id) error {


### PR DESCRIPTION
Update the openstack provider to behave more like ec2. If an attempt to start an instance on an availability zone fails because openstack says there are no available hosts, then try another zone till we find one that works. The provider previously just picked the first zone and didn't try any others.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1380557
