### PR TITLE
Added UUID field to reboot doc and responses

### DIFF
--- a/api/reboot/reboot.go
+++ b/api/reboot/reboot.go
@@ -99,14 +99,14 @@ func (st *State) GetRebootAction() (params.RebootAction, error) {
 
 	err := st.facade.FacadeCall("GetRebootAction", args, &results)
 	if err != nil {
-		return params.ShouldDoNothing, err
+		return params.RebootAction{Action: params.ShouldDoNothing}, err
 	}
 	if len(results.Results) != 1 {
-		return params.ShouldDoNothing, errors.Errorf("expected 1 result, got %d", len(results.Results))
+		return params.RebootAction{Action: params.ShouldDoNothing}, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 
 	if results.Results[0].Error != nil {
-		return params.ShouldDoNothing, errors.Trace(results.Results[0].Error)
+		return params.RebootAction{Action: params.ShouldDoNothing}, errors.Trace(results.Results[0].Error)
 	}
 
 	return results.Results[0].Result, nil

--- a/api/reboot/reboot_test.go
+++ b/api/reboot/reboot_test.go
@@ -116,22 +116,22 @@ func (s *machineRebootSuite) TestGetRebootAction(c *gc.C) {
 	reboot.PatchFacadeCall(s, s.reboot, func(facade string, p interface{}, resp interface{}) error {
 		if resp, ok := resp.(*params.RebootActionResults); ok {
 			resp.Results = []params.RebootActionResult{
-				{Result: params.ShouldDoNothing},
+				{Result: params.RebootAction{Action: params.ShouldDoNothing}},
 			}
 		}
 		return nil
 	})
 	rAction, err := s.reboot.GetRebootAction()
 	c.Assert(err, gc.IsNil)
-	c.Assert(rAction, gc.Equals, params.ShouldDoNothing)
+	c.Assert(rAction, gc.DeepEquals, params.RebootAction{Action: params.ShouldDoNothing})
 }
 
 func (s *machineRebootSuite) TestGetRebootActionMultipleResults(c *gc.C) {
 	reboot.PatchFacadeCall(s, s.reboot, func(facade string, p interface{}, resp interface{}) error {
 		if resp, ok := resp.(*params.RebootActionResults); ok {
 			resp.Results = []params.RebootActionResult{
-				{Result: params.ShouldDoNothing},
-				{Result: params.ShouldDoNothing},
+				{Result: params.RebootAction{Action: params.ShouldDoNothing}},
+				{Result: params.RebootAction{Action: params.ShouldDoNothing}},
 			}
 		}
 		return nil

--- a/apiserver/params/constants.go
+++ b/apiserver/params/constants.go
@@ -13,23 +13,28 @@ const (
 	Dead  Life = "dead"
 )
 
-// RebootAction defines the action a machine should
-// take when a hook needs to reboot
-type RebootAction string
+type rebootAction string
 
 const (
 	// ShouldDoNothing instructs a machine agent that no action
 	// is required on its part
-	ShouldDoNothing RebootAction = "noop"
+	ShouldDoNothing rebootAction = "noop"
 	// ShouldReboot instructs a machine to reboot
 	// this happens when a hook running on a machine, requests
 	// a reboot
-	ShouldReboot RebootAction = "reboot"
+	ShouldReboot rebootAction = "reboot"
 	// ShouldShutdown instructs a machine to shut down. This usually
 	// happens when running inside a container, and a hook on the parent
 	// machine requests a reboot
-	ShouldShutdown RebootAction = "shutdown"
+	ShouldShutdown rebootAction = "shutdown"
 )
+
+// RebootAction defines the action a machine should
+// take when a hook needs to reboot
+type RebootAction struct {
+	Action rebootAction
+	UUID   string
+}
 
 // MachineJob values define responsibilities that machines may be
 // expected to fulfil.

--- a/apiserver/reboot/reboot_test.go
+++ b/apiserver/reboot/reboot_test.go
@@ -144,11 +144,14 @@ func (s *rebootSuite) TestRequestReboot(c *gc.C) {
 
 	s.machine.wc.AssertOneChange()
 
+	stateAction, err := s.machine.machine.ShouldRebootOrShutdown()
+	c.Assert(err, gc.IsNil)
+
 	res, err := s.machine.rebootAPI.GetRebootAction(s.machine.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldReboot},
+			{Result: params.RebootAction{Action: params.ShouldReboot, UUID: stateAction.UUID}},
 		}})
 }
 
@@ -163,11 +166,14 @@ func (s *rebootSuite) TestClearReboot(c *gc.C) {
 
 	s.machine.wc.AssertOneChange()
 
+	stateAction, err := s.machine.machine.ShouldRebootOrShutdown()
+	c.Assert(err, gc.IsNil)
+
 	res, err := s.machine.rebootAPI.GetRebootAction(s.machine.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldReboot},
+			{Result: params.RebootAction{Action: params.ShouldReboot, UUID: stateAction.UUID}},
 		}})
 
 	errResult, err = s.machine.rebootAPI.ClearReboot(s.machine.args)
@@ -178,11 +184,13 @@ func (s *rebootSuite) TestClearReboot(c *gc.C) {
 		},
 	})
 
+	s.machine.wc.AssertOneChange()
+
 	res, err = s.machine.rebootAPI.GetRebootAction(s.machine.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldDoNothing},
+			{Result: params.RebootAction{Action: params.ShouldDoNothing}},
 		}})
 }
 
@@ -202,25 +210,28 @@ func (s *rebootSuite) TestRebootRequestFromMachine(c *gc.C) {
 	s.container.wc.AssertOneChange()
 	s.nestedContainer.wc.AssertOneChange()
 
+	stateAction, err := s.machine.machine.ShouldRebootOrShutdown()
+	c.Assert(err, gc.IsNil)
+
 	res, err := s.machine.rebootAPI.GetRebootAction(s.machine.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldReboot},
+			{Result: params.RebootAction{Action: params.ShouldReboot, UUID: stateAction.UUID}},
 		}})
 
 	res, err = s.container.rebootAPI.GetRebootAction(s.container.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldShutdown},
+			{Result: params.RebootAction{Action: params.ShouldShutdown, UUID: stateAction.UUID}},
 		}})
 
 	res, err = s.nestedContainer.rebootAPI.GetRebootAction(s.nestedContainer.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldShutdown},
+			{Result: params.RebootAction{Action: params.ShouldShutdown, UUID: stateAction.UUID}},
 		}})
 
 	errResult, err = s.machine.rebootAPI.ClearReboot(s.machine.args)
@@ -256,21 +267,24 @@ func (s *rebootSuite) TestRebootRequestFromContainer(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldDoNothing},
+			{Result: params.RebootAction{Action: params.ShouldDoNothing}},
 		}})
+
+	stateAction, err := s.container.machine.ShouldRebootOrShutdown()
+	c.Assert(err, gc.IsNil)
 
 	res, err = s.container.rebootAPI.GetRebootAction(s.container.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldReboot},
+			{Result: params.RebootAction{Action: params.ShouldReboot, UUID: stateAction.UUID}},
 		}})
 
 	res, err = s.nestedContainer.rebootAPI.GetRebootAction(s.nestedContainer.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldShutdown},
+			{Result: params.RebootAction{Action: params.ShouldShutdown, UUID: stateAction.UUID}},
 		}})
 
 	errResult, err = s.container.rebootAPI.ClearReboot(s.container.args)
@@ -306,21 +320,24 @@ func (s *rebootSuite) TestRebootRequestFromNestedContainer(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldDoNothing},
+			{Result: params.RebootAction{Action: params.ShouldDoNothing}},
 		}})
 
 	res, err = s.container.rebootAPI.GetRebootAction(s.container.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldDoNothing},
+			{Result: params.RebootAction{Action: params.ShouldDoNothing}},
 		}})
+
+	stateAction, err := s.nestedContainer.machine.ShouldRebootOrShutdown()
+	c.Assert(err, gc.IsNil)
 
 	res, err = s.nestedContainer.rebootAPI.GetRebootAction(s.nestedContainer.args)
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
-			{Result: params.ShouldReboot},
+			{Result: params.RebootAction{Action: params.ShouldReboot, UUID: stateAction.UUID}},
 		}})
 
 	errResult, err = s.nestedContainer.rebootAPI.ClearReboot(s.nestedContainer.args)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -64,7 +64,7 @@ func (s *MachineSuite) TestSetRebootFlagDeadMachine(c *gc.C) {
 
 	action, err := s.machine.ShouldRebootOrShutdown()
 	c.Assert(err, gc.IsNil)
-	c.Assert(action, gc.Equals, state.ShouldDoNothing)
+	c.Assert(action.Action, gc.Equals, state.ShouldDoNothing)
 }
 
 func (s *MachineSuite) TestSetRebootFlagDeadMachineRace(c *gc.C) {
@@ -125,15 +125,18 @@ func (s *MachineSuite) TestShouldShutdownOrReboot(c *gc.C) {
 
 	rAction, err := s.machine.ShouldRebootOrShutdown()
 	c.Assert(err, gc.IsNil)
-	c.Assert(rAction, gc.Equals, state.ShouldDoNothing)
+	c.Assert(rAction.Action, gc.Equals, state.ShouldDoNothing)
+	c.Assert(rAction.UUID, gc.Equals, "")
 
 	rAction, err = c1.ShouldRebootOrShutdown()
 	c.Assert(err, gc.IsNil)
-	c.Assert(rAction, gc.Equals, state.ShouldDoNothing)
+	c.Assert(rAction.Action, gc.Equals, state.ShouldDoNothing)
+	c.Assert(rAction.UUID, gc.Equals, "")
 
 	rAction, err = c2.ShouldRebootOrShutdown()
 	c.Assert(err, gc.IsNil)
-	c.Assert(rAction, gc.Equals, state.ShouldReboot)
+	c.Assert(rAction.Action, gc.Equals, state.ShouldReboot)
+	c.Assert(rAction.UUID, gc.Not(gc.Equals), "")
 
 	// // Reboot happens on the root node
 	err = c2.SetRebootFlag(false)
@@ -144,15 +147,18 @@ func (s *MachineSuite) TestShouldShutdownOrReboot(c *gc.C) {
 
 	rAction, err = s.machine.ShouldRebootOrShutdown()
 	c.Assert(err, gc.IsNil)
-	c.Assert(rAction, gc.Equals, state.ShouldReboot)
+	c.Assert(rAction.Action, gc.Equals, state.ShouldReboot)
+	c.Assert(rAction.UUID, gc.Not(gc.Equals), "")
 
 	rAction, err = c1.ShouldRebootOrShutdown()
 	c.Assert(err, gc.IsNil)
-	c.Assert(rAction, gc.Equals, state.ShouldShutdown)
+	c.Assert(rAction.Action, gc.Equals, state.ShouldShutdown)
+	c.Assert(rAction.UUID, gc.Not(gc.Equals), "")
 
 	rAction, err = c2.ShouldRebootOrShutdown()
 	c.Assert(err, gc.IsNil)
-	c.Assert(rAction, gc.Equals, state.ShouldShutdown)
+	c.Assert(rAction.Action, gc.Equals, state.ShouldShutdown)
+	c.Assert(rAction.UUID, gc.Not(gc.Equals), "")
 }
 
 func (s *MachineSuite) TestContainerDefaults(c *gc.C) {

--- a/state/reboot_test.go
+++ b/state/reboot_test.go
@@ -106,6 +106,28 @@ func (s *RebootSuite) TearDownSuit(c *gc.C) {
 	}
 }
 
+func (s *RebootSuite) TestSetRebootFlagMultipleTimes(c *gc.C) {
+	err := s.machine.SetRebootFlag(true)
+	c.Assert(err, gc.IsNil)
+
+	rAction, err := s.machine.ShouldRebootOrShutdown()
+	c.Assert(err, gc.IsNil)
+	c.Assert(rAction.Action, gc.Equals, state.ShouldReboot)
+	c.Assert(rAction.UUID, gc.Not(gc.Equals), "")
+
+	// Setting the reboot flag twice without unsetting it
+	// should not change the UUID
+	uuid := rAction.UUID
+
+	err = s.machine.SetRebootFlag(true)
+	rAction, err = s.machine.ShouldRebootOrShutdown()
+	c.Assert(err, gc.IsNil)
+	c.Assert(rAction.Action, gc.Equals, state.ShouldReboot)
+	c.Assert(rAction.UUID, gc.Equals, uuid)
+
+	c.Assert(err, gc.IsNil)
+}
+
 func (s *RebootSuite) TestWatchForRebootEvent(c *gc.C) {
 	err := s.machine.SetRebootFlag(true)
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
This PR adds a UUID to the reboot document. This will be used by machines ti prevent race conditions where jujud within a container may start faster then its parent after a reboot. In this situation the container would still see ShouldShutdown action and shutdown. The parent would come up and clear the flag, and the container would never come up again.
