### PR TITLE
Switching local updates to default of true.

### DIFF
--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -128,7 +128,7 @@ func (s *configSuite) TestLocalDisablesUpgradesWhenCloning(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	validConfig, err := local.Provider.Validate(testConfig, nil)
 	c.Assert(err, gc.IsNil)
-	c.Check(validConfig.EnableOSRefreshUpdate(), gc.Equals, false)
+	c.Check(validConfig.EnableOSRefreshUpdate(), gc.Equals, true)
 	c.Check(validConfig.EnableOSUpgrade(), gc.Equals, false)
 }
 

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -238,7 +238,7 @@ func (provider environProvider) Validate(cfg, old *config.Config) (valid *config
 	// If we're cloning, and the user hasn't specified otherwise,
 	// prefer to skip update logic.
 	if useClone, _ := localConfig.LXCUseClone(); useClone && containerType == instance.LXC {
-		defineIfNot("enable-os-refresh-update", false)
+		defineIfNot("enable-os-refresh-update", true)
 		defineIfNot("enable-os-upgrade", false)
 	}
 


### PR DESCRIPTION
We don't want local installs of Juju to become outdated, so unless the user has specified otherwise, we will default this value to true.
