### PR TITLE
fix distro info failures by faking out the filename

### DIFF
--- a/version/export_test.go
+++ b/version/export_test.go
@@ -21,3 +21,9 @@ func SetSeriesVersions(value map[string]string) func() {
 		updatedseriesVersions = origUpdated
 	}
 }
+
+func SetDistroInfo(s string) func() {
+	origDistro := distroInfo
+	distroInfo = s
+	return func() { distroInfo = origDistro }
+}

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -71,6 +71,8 @@ var windowsVersions = map[string]string{
 	"Windows 8.1":                    "win81",
 }
 
+var distroInfo = "/usr/share/distro-info/ubuntu.csv"
+
 // GetOSFromSeries will return the operating system based
 // on the series that is passed to it
 func GetOSFromSeries(series string) (OSType, error) {
@@ -155,7 +157,7 @@ func updateSeriesVersions() {
 func updateDistroInfo() error {
 	// We need to find the series version eg 12.04 from the series eg precise. Use the information found in
 	// /usr/share/distro-info/ubuntu.csv provided by distro-info-data package.
-	f, err := os.Open("/usr/share/distro-info/ubuntu.csv")
+	f, err := os.Open(distroInfo)
 	if err != nil {
 		// On non-Ubuntu systems this file won't exist but that's expected.
 		return nil

--- a/version/supportedseries_linux_test.go
+++ b/version/supportedseries_linux_test.go
@@ -4,6 +4,8 @@
 package version_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"sort"
 
 	gc "gopkg.in/check.v1"
@@ -21,8 +23,36 @@ func (s *supportedSeriesSuite) TestSeriesVersion(c *gc.C) {
 }
 
 func (s *supportedSeriesSuite) TestSupportedSeries(c *gc.C) {
-	expectedSeries := []string{"precise", "quantal", "raring", "saucy", "trusty", "utopic"}
+	d := c.MkDir()
+	fn := filepath.Join(d, "ubuntu.csv")
+	err := ioutil.WriteFile(fn, []byte(distInfoData), 0644)
+	c.Assert(err, gc.IsNil)
+	defer version.SetDistroInfo(fn)()
+
+	expectedSeries := []string{"precise", "quantal", "raring", "saucy"}
 	series := version.SupportedSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)
 }
+
+const distInfoData = `version,codename,series,created,release,eol,eol-server
+4.10,Warty Warthog,warty,2004-03-05,2004-10-20,2006-04-30
+5.04,Hoary Hedgehog,hoary,2004-10-20,2005-04-08,2006-10-31
+5.10,Breezy Badger,breezy,2005-04-08,2005-10-12,2007-04-13
+6.06 LTS,Dapper Drake,dapper,2005-10-12,2006-06-01,2009-07-14,2011-06-01
+6.10,Edgy Eft,edgy,2006-06-01,2006-10-26,2008-04-25
+7.04,Feisty Fawn,feisty,2006-10-26,2007-04-19,2008-10-19
+7.10,Gutsy Gibbon,gutsy,2007-04-19,2007-10-18,2009-04-18
+8.04 LTS,Hardy Heron,hardy,2007-10-18,2008-04-24,2011-05-12,2013-05-09
+8.10,Intrepid Ibex,intrepid,2008-04-24,2008-10-30,2010-04-30
+9.04,Jaunty Jackalope,jaunty,2008-10-30,2009-04-23,2010-10-23
+9.10,Karmic Koala,karmic,2009-04-23,2009-10-29,2011-04-29
+10.04 LTS,Lucid Lynx,lucid,2009-10-29,2010-04-29,2013-05-09,2015-04-29
+10.10,Maverick Meerkat,maverick,2010-04-29,2010-10-10,2012-04-10
+11.04,Natty Narwhal,natty,2010-10-10,2011-04-28,2012-10-28
+11.10,Oneiric Ocelot,oneiric,2011-04-28,2011-10-13,2013-05-09
+12.04 LTS,Precise Pangolin,precise,2011-10-13,2012-04-26,2017-04-26
+12.10,Quantal Quetzal,quantal,2012-04-26,2012-10-18,2014-04-18
+13.04,Raring Ringtail,raring,2012-10-18,2013-04-25,2014-01-27
+13.10,Saucy Salamander,saucy,2013-04-25,2013-10-17,2014-07-17
+`


### PR DESCRIPTION
this fixes https://bugs.launchpad.net/juju-core/+bug/1384175
Utopic test failures due to addition of vivid series

Instead of comparing the (dynamic) contents of /usr/share/distro-info/ubuntu.csv to a static list of series, how about we fake out the file being read and read something static?  Yeah, that sounds nice.
