### PR TITLE
Rename InitialEnvironment to StateServerEnvironment.

### DIFF
--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -56,7 +56,7 @@ func (api *UserManagerAPI) permissionCheck(user names.UserTag) error {
 	// TODO(thumper): PERMISSIONS Change this permission check when we have
 	// real permissions. For now, only the owner of the initial environment is
 	// able to add users.
-	initialEnv, err := api.state.InitialEnvironment()
+	initialEnv, err := api.state.StateServerEnvironment()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -117,7 +117,7 @@ func (s *JujuConnSuite) Reset(c *gc.C) {
 }
 
 func (s *JujuConnSuite) AdminUserTag(c *gc.C) names.UserTag {
-	env, err := s.State.InitialEnvironment()
+	env, err := s.State.StateServerEnvironment()
 	c.Assert(err, gc.IsNil)
 	return env.Owner()
 }

--- a/state/environ.go
+++ b/state/environ.go
@@ -31,12 +31,12 @@ type environmentDoc struct {
 	ServerUUID string `bson:"server-uuid"`
 }
 
-// InitialEnvironment returns the environment that was bootstrapped.
+// StateServerEnvironment returns the environment that was bootstrapped.
 // This is the only environment that can have state server machines.
 // The owner of this environment is also considered "special", in that
 // they are the only user that is able to create other users (until we
 // have more fine grained permissions), and they cannot be disabled.
-func (st *State) InitialEnvironment() (*Environment, error) {
+func (st *State) StateServerEnvironment() (*Environment, error) {
 	ssinfo, err := st.StateServerInfo()
 	if err != nil {
 		return nil, errors.Annotate(err, "could not get state server info")

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -74,8 +74,8 @@ func (s *EnvironSuite) TestNewEnvironment(c *gc.C) {
 	assertMatches(env)
 }
 
-func (s *EnvironSuite) TestInitialEnvironment(c *gc.C) {
-	env, err := s.State.InitialEnvironment()
+func (s *EnvironSuite) TestStateServerEnvironment(c *gc.C) {
+	env, err := s.State.StateServerEnvironment()
 	c.Assert(err, gc.IsNil)
 
 	expectedTag := names.NewEnvironTag(env.UUID())
@@ -90,7 +90,7 @@ func (s *EnvironSuite) TestInitialEnvironment(c *gc.C) {
 	})
 }
 
-func (s *EnvironSuite) TestInitialEnvironmentAccessibleFromOtherEnvironments(c *gc.C) {
+func (s *EnvironSuite) TestStateServerEnvironmentAccessibleFromOtherEnvironments(c *gc.C) {
 	owner := names.NewUserTag("test@remote")
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
@@ -102,7 +102,7 @@ func (s *EnvironSuite) TestInitialEnvironmentAccessibleFromOtherEnvironments(c *
 	c.Assert(err, gc.IsNil)
 	defer st.Close()
 
-	env, err := s.State.InitialEnvironment()
+	env, err := s.State.StateServerEnvironment()
 	c.Assert(err, gc.IsNil)
 
 	expectedTag := names.NewEnvironTag(env.UUID())

--- a/state/user.go
+++ b/state/user.go
@@ -270,11 +270,11 @@ func (u *User) Refresh() error {
 
 // Disable deactivates the user.  Disabled identities cannot log in.
 func (u *User) Disable() error {
-	initialEnv, err := u.st.InitialEnvironment()
+	environment, err := u.st.StateServerEnvironment()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if u.doc.Name == initialEnv.Owner().Name() {
+	if u.doc.Name == environment.Owner().Name() {
 		return errors.Unauthorizedf("cannot disable state server environment owner")
 	}
 	return errors.Annotatef(u.setDeactivated(true), "cannot disable user %q", u.Name())


### PR DESCRIPTION
The name was decided in discussions at the sprint with sabdfl.

Updating the code to match how we'll talk about it.
