### PR TITLE
Bug#1304126

### DIFF
--- a/cmd/juju/environment.go
+++ b/cmd/juju/environment.go
@@ -141,7 +141,7 @@ func (c *SetEnvironmentCommand) Run(ctx *cmd.Context) error {
 		// and warn the user if the key is not defined in
 		// the existing config
 		if _, exists := envAttrs[key]; !exists {
-			logger.Warningf("key %v is not defined in the current environemnt configuration: possible misspelling", key)
+			logger.Warningf("key %q is not defined in the current environemnt configuration: possible misspelling", key)
 		}
 
 	}
@@ -199,7 +199,7 @@ func (c *UnsetEnvironmentCommand) Run(ctx *cmd.Context) error {
 		// and warn the user if the key is not defined in
 		// the existing config
 		if _, exists := envAttrs[key]; !exists {
-			logger.Warningf("key %v is not defined in the current environemnt configuration: possible misspelling", key)
+			logger.Warningf("key %q is not defined in the current environemnt configuration: possible misspelling", key)
 		}
 
 	}


### PR DESCRIPTION
Possible fix for Bug #1304126

In the SetEnvironmentCommand's Init function I added an additional API call to retrieve existing environment config. All keys a user specifies in the "juju set-env" command are checked against the existing config keys and if the user defined key does not exist in the existing config a warning of a possible misspelling is issued.

This way if the users tries: 
juju set-env ss-hostname-verification=false 

A warning will be returned (though the setting is still forwarded to the state):
2014-10-23 09:45:03 WARNING juju.cmd.juju environment.go:135 key ss-hostname-verification is not defined in the current environemnt configuration: possible misspelling

In addition i fixes a few capitalisation in some of the returned error messages.
