### PR TITLE
added hookname to log

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -663,7 +663,7 @@ func (u *Uniter) runHook(hi hook.Info) (err error) {
 	if context.IsMissingHookError(err) {
 		ranHook = false
 	} else if err != nil {
-		logger.Errorf("hook failed: %s", err)
+		logger.Errorf("hook %q failed: %s", hookName, err)
 		u.notifyHookFailed(hookName, hctx)
 		return errHookFailed
 	}


### PR DESCRIPTION
This log message normally says something like hook failed: exit status 1.

In some charms I've seen errors happen quite far back in the log, in these cases it's hard to tell quickly which hook failed from just the log.

The new log messages helps a lot:

hook "config-changed" failed: exit status 1
