### PR TITLE
remove persistent relation context from Relationer

### DIFF
--- a/worker/uniter/context/export_test.go
+++ b/worker/uniter/context/export_test.go
@@ -56,6 +56,10 @@ func (c *HookContext) ActionData() *ActionData {
 	return c.actionData
 }
 
+func (cr *ContextRelation) StoredMemberSettings(remoteUnit string) params.RelationSettings {
+	return cr.members[remoteUnit]
+}
+
 func GetStubActionContext(in map[string]interface{}) *HookContext {
 	return &HookContext{
 		actionData: &ActionData{

--- a/worker/uniter/context/factory.go
+++ b/worker/uniter/context/factory.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"gopkg.in/juju/charm.v4/hooks"
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
@@ -119,9 +120,15 @@ func (f *factory) NewHookContext(hookInfo hook.Info) (*HookContext, error) {
 	if hookInfo.Kind.IsRelation() {
 		ctx.relationId = hookInfo.RelationId
 		ctx.remoteUnitName = hookInfo.RemoteUnit
-		relation, found := ctx.Relation(hookInfo.RelationId)
+		relation, found := ctx.relations[hookInfo.RelationId]
 		if !found {
 			return nil, fmt.Errorf("unknown relation id: %v", hookInfo.RelationId)
+		}
+		if hookInfo.Kind == hooks.RelationDeparted {
+			relation.DeleteMember(hookInfo.RemoteUnit)
+		} else if hookInfo.RemoteUnit != "" {
+			// Clear remote settings cache for changing remote unit.
+			relation.UpdateMembers(SettingsMap{hookInfo.RemoteUnit: nil})
 		}
 		hookName = fmt.Sprintf("%s-%s", relation.Name(), hookInfo.Kind)
 	}

--- a/worker/uniter/context/util_test.go
+++ b/worker/uniter/context/util_test.go
@@ -50,6 +50,8 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	s.uniter, err = s.st.Uniter()
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.uniter, gc.NotNil)
+	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))
+	c.Assert(err, gc.IsNil)
 
 	// Note: The unit must always have a charm URL set, because this
 	// happens as part of the installation process (that happens
@@ -87,8 +89,6 @@ func (s *HookContextSuite) AddContextRelation(c *gc.C, name string) {
 	c.Assert(err, gc.IsNil)
 	s.relunits[rel.Id()] = ru
 	err = ru.EnterScope(map[string]interface{}{"relation-name": name})
-	c.Assert(err, gc.IsNil)
-	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))
 	c.Assert(err, gc.IsNil)
 	apiRel, err := s.uniter.Relation(rel.Tag().(names.RelationTag))
 	c.Assert(err, gc.IsNil)

--- a/worker/uniter/relationer_test.go
+++ b/worker/uniter/relationer_test.go
@@ -253,8 +253,7 @@ func (s *RelationerSuite) TestPrepareCommitHooks(c *gc.C) {
 	r := uniter.NewRelationer(s.apiRelUnit, s.dir, s.hooks)
 	err := r.Join()
 	c.Assert(err, gc.IsNil)
-	ctx := r.Context()
-	c.Assert(ctx.UnitNames(), gc.HasLen, 0)
+	c.Assert(r.Context().UnitNames(), gc.HasLen, 0)
 
 	// Check preparing an invalid hook changes nothing.
 	changed := hook.Info{
@@ -264,10 +263,10 @@ func (s *RelationerSuite) TestPrepareCommitHooks(c *gc.C) {
 	}
 	_, err = r.PrepareHook(changed)
 	c.Assert(err, gc.ErrorMatches, `inappropriate "relation-changed" for "u/1": unit has not joined`)
-	c.Assert(ctx.UnitNames(), gc.HasLen, 0)
+	c.Assert(r.Context().UnitNames(), gc.HasLen, 0)
 	c.Assert(s.dir.State().Members, gc.HasLen, 0)
 
-	// Check preparing a valid hook updates the context, but not persistent
+	// Check preparing a valid hook updates neither the context nor persistent
 	// relation state.
 	joined := hook.Info{
 		Kind:       hooks.RelationJoined,
@@ -277,50 +276,50 @@ func (s *RelationerSuite) TestPrepareCommitHooks(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.dir.State().Members, gc.HasLen, 0)
 	c.Assert(name, gc.Equals, "ring-relation-joined")
-	c.Assert(ctx.UnitNames(), gc.DeepEquals, []string{"u/1"})
+	c.Assert(r.Context().UnitNames(), gc.IsNil)
 
 	// Check that preparing the following hook fails as before...
 	_, err = r.PrepareHook(changed)
 	c.Assert(err, gc.ErrorMatches, `inappropriate "relation-changed" for "u/1": unit has not joined`)
 	c.Assert(s.dir.State().Members, gc.HasLen, 0)
-	c.Assert(ctx.UnitNames(), gc.DeepEquals, []string{"u/1"})
+	c.Assert(r.Context().UnitNames(), gc.IsNil)
 
 	// ...but that committing the previous hook updates the persistent
 	// relation state...
 	err = r.CommitHook(joined)
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.dir.State().Members, gc.DeepEquals, map[string]int64{"u/1": 0})
-	c.Assert(ctx.UnitNames(), gc.DeepEquals, []string{"u/1"})
+	c.Assert(r.Context().UnitNames(), gc.DeepEquals, []string{"u/1"})
 
 	// ...and allows us to prepare the next hook...
 	name, err = r.PrepareHook(changed)
 	c.Assert(err, gc.IsNil)
 	c.Assert(name, gc.Equals, "ring-relation-changed")
 	c.Assert(s.dir.State().Members, gc.DeepEquals, map[string]int64{"u/1": 0})
-	c.Assert(ctx.UnitNames(), gc.DeepEquals, []string{"u/1"})
+	c.Assert(r.Context().UnitNames(), gc.DeepEquals, []string{"u/1"})
 
 	// ...and commit it.
 	err = r.CommitHook(changed)
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.dir.State().Members, gc.DeepEquals, map[string]int64{"u/1": 7})
-	c.Assert(ctx.UnitNames(), gc.DeepEquals, []string{"u/1"})
+	c.Assert(r.Context().UnitNames(), gc.DeepEquals, []string{"u/1"})
 
 	// To verify implied behaviour above, prepare a new joined hook with
 	// missing membership information, and check relation context
-	// membership is updated appropriately...
+	// membership is stil not updated...
 	joined.RemoteUnit = "u/2"
 	joined.ChangeVersion = 3
 	name, err = r.PrepareHook(joined)
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.dir.State().Members, gc.HasLen, 1)
 	c.Assert(name, gc.Equals, "ring-relation-joined")
-	c.Assert(ctx.UnitNames(), gc.DeepEquals, []string{"u/1", "u/2"})
+	c.Assert(r.Context().UnitNames(), gc.DeepEquals, []string{"u/1"})
 
-	// ...and so is relation state on commit.
+	// ...until commit, at which point so is relation state.
 	err = r.CommitHook(joined)
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.dir.State().Members, gc.DeepEquals, map[string]int64{"u/1": 7, "u/2": 3})
-	c.Assert(ctx.UnitNames(), gc.DeepEquals, []string{"u/1", "u/2"})
+	c.Assert(r.Context().UnitNames(), gc.DeepEquals, []string{"u/1", "u/2"})
 }
 
 func (s *RelationerSuite) TestSetDying(c *gc.C) {


### PR DESCRIPTION
...such that relation contexts grabbed by the hook context factory are (1) fresh, and unable to change uniter state; and (2) changed to reflect desired context state by the context, rather than (somewhat magically) inside the uniter.
