### PR TITLE
Cache results of checking for ec2 default vpc

### DIFF
--- a/provider/ec2/ec2.go
+++ b/provider/ec2/ec2.go
@@ -70,6 +70,9 @@ type environ struct {
 
 	availabilityZonesMutex sync.Mutex
 	availabilityZones      []common.AvailabilityZone
+
+	// cachedDefaultVpc caches the id of the ec2 default vpc
+	cachedDefaultVpc *defaultVpc
 }
 
 var _ environs.Environ = (*environ)(nil)
@@ -82,6 +85,11 @@ type ec2Instance struct {
 
 	mu sync.Mutex
 	*ec2.Instance
+}
+
+type defaultVpc struct {
+	hasDefaultVpc bool
+	id            network.Id
 }
 
 func (inst *ec2Instance) String() string {
@@ -300,19 +308,35 @@ func (e *environ) SetConfig(cfg *config.Config) error {
 }
 
 func (e *environ) defaultVpc() (network.Id, bool, error) {
+	if e.cachedDefaultVpc != nil {
+		defaultVpc := e.cachedDefaultVpc
+		return defaultVpc.id, defaultVpc.hasDefaultVpc, nil
+	}
 	ec2 := e.ec2()
 	resp, err := ec2.AccountAttributes("default-vpc")
 	if err != nil {
 		return "", false, errors.Trace(err)
 	}
+
+	hasDefault := true
+	defaultVpcId := ""
+
 	if len(resp.Attributes) == 0 || len(resp.Attributes[0].Values) == 0 {
-		return "", false, nil
+		hasDefault = false
+		defaultVpcId = ""
+	} else {
+
+		defaultVpcId := resp.Attributes[0].Values[0]
+		if defaultVpcId == none {
+			hasDefault = false
+			defaultVpcId = ""
+		}
 	}
-	defaultVpc := resp.Attributes[0].Values[0]
-	if defaultVpc == none {
-		return "", false, nil
-	}
-	return network.Id(defaultVpc), true, nil
+	defaultVpc := &defaultVpc{
+		id:            network.Id(defaultVpcId),
+		hasDefaultVpc: hasDefault}
+	e.cachedDefaultVpc = defaultVpc
+	return defaultVpc.id, defaultVpc.hasDefaultVpc, nil
 }
 
 func (e *environ) ecfg() *environConfig {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -672,6 +672,25 @@ func (t *localServerSuite) TestSupportAddressAllocationTrue(c *gc.C) {
 	c.Assert(result, jc.IsTrue)
 }
 
+func (t *localServerSuite) TestSupportAddressAllocationCaches(c *gc.C) {
+	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
+		"default-vpc": []string{"none"},
+	})
+	env := t.Prepare(c)
+	result, err := env.SupportAddressAllocation("")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, jc.IsFalse)
+
+	// this value won't change normally, the change here is to
+	// ensure that subsequent calls use the cached value
+	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
+		"default-vpc": []string{"vpc-xxxxxxx"},
+	})
+	result, err = env.SupportAddressAllocation("")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, jc.IsFalse)
+}
+
 func (t *localServerSuite) TestSupportAddressAllocationFalse(c *gc.C) {
 	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
 		"default-vpc": []string{"none"},


### PR DESCRIPTION
The default-vpc of an ec2 account can't change during the lifetime of a juju environment (it requires days to change this and instances in 1 vpc can't communicate with instances in another via private network), so we can cache the result and avoid round tripping to Amazon every time we need it's Id or to check for its existence.
