### PR TITLE
upgrades: check for ErrNoTools in tools migration

### DIFF
--- a/upgrades/toolstorage.go
+++ b/upgrades/toolstorage.go
@@ -70,11 +70,13 @@ func migrateToolsStorage(st *state.State, agentConfig agent.Config) error {
 		simplestreams.CloudSpec{},
 		config.AgentStream(),
 		-1, -1, tools.Filter{})
-	if err == tools.ErrNoMatches {
+	switch err {
+	case nil:
+		break
+	case tools.ErrNoMatches, envtools.ErrNoTools:
 		// No tools in provider storage: nothing to do.
 		return nil
-	}
-	if err != nil {
+	default:
 		return errors.Annotate(err, "cannot find tools in provider storage")
 	}
 

--- a/upgrades/toolstorage_test.go
+++ b/upgrades/toolstorage_test.go
@@ -36,6 +36,22 @@ var migrateToolsVersions = []version.Binary{
 	version.MustParseBinary("2.3.4-trusty-ppc64el"),
 }
 
+func (s *migrateToolsStorageSuite) TestMigrateToolsStorageNoTools(c *gc.C) {
+	fakeToolsStorage := &fakeToolsStorage{
+		stored: make(map[version.Binary]toolstorage.Metadata),
+	}
+	s.PatchValue(upgrades.StateToolsStorage, func(*state.State) (toolstorage.StorageCloser, error) {
+		return fakeToolsStorage, nil
+	})
+
+	stor := s.Environ.(environs.EnvironStorage).Storage()
+	envtesting.RemoveFakeTools(c, stor, "released")
+	envtesting.RemoveFakeToolsMetadata(c, stor)
+	err := upgrades.MigrateToolsStorage(s.State, &mockAgentConfig{})
+	c.Assert(err, gc.IsNil)
+	c.Assert(fakeToolsStorage.stored, gc.HasLen, 0)
+}
+
 func (s *migrateToolsStorageSuite) TestMigrateToolsStorage(c *gc.C) {
 	stor := s.Environ.(environs.EnvironStorage).Storage()
 	envtesting.RemoveFakeTools(c, stor, "released")


### PR DESCRIPTION
The tools storage migration step was failing if
there were no tools in the private provider storage.
This is fixed by checking for an additional error
in the upgrade step.

Unit test added, and live tested on AWS by uploading
custom tools to my own S3 bucket.

Fixes https://bugs.launchpad.net/juju-core/+bug/1385289
