### PR TITLE
Update charm interface implementation.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -23,7 +23,7 @@ github.com/juju/testing	git	ab9111f762f6cdaaceb44c879b6e146164a22b0b
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	
 github.com/juju/utils	git	6ef4a86e1de1bd7af882d17476fb1f129ab6fbdd	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
-gopkg.in/juju/charm.v4	git	8b3cc836f54c2c78ce73d198100a30bb31d28392	
+gopkg.in/juju/charm.v4	git	f97c8d630e45651f7b39ce352dd7329082f134c4	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	

--- a/state/charm.go
+++ b/state/charm.go
@@ -15,6 +15,7 @@ type charmDoc struct {
 	Meta    *charm.Meta
 	Config  *charm.Config
 	Actions *charm.Actions
+	Metrics *charm.Metrics
 
 	// DEPRECATED: BundleURL is deprecated, and exists here
 	// only for migration purposes. We should remove this
@@ -72,6 +73,11 @@ func (c *Charm) Meta() *charm.Meta {
 // Config returns the configuration of the charm.
 func (c *Charm) Config() *charm.Config {
 	return c.doc.Config
+}
+
+// Metrics returns the metrics declared for the charm.
+func (c *Charm) Metrics() *charm.Metrics {
+	return c.doc.Metrics
 }
 
 // Actions returns the actions definition of the charm.

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -77,10 +77,11 @@ type CharmTestHelperSuite struct {
 
 var _ = gc.Suite(&CharmTestHelperSuite{})
 
-func assertCustomCharm(c *gc.C, ch *state.Charm, series string, meta *charm.Meta, config *charm.Config, revision int) {
+func assertCustomCharm(c *gc.C, ch *state.Charm, series string, meta *charm.Meta, config *charm.Config, metrics *charm.Metrics, revision int) {
 	// Check Charm interface method results.
 	c.Assert(ch.Meta(), gc.DeepEquals, meta)
 	c.Assert(ch.Config(), gc.DeepEquals, config)
+	c.Assert(ch.Metrics(), gc.DeepEquals, metrics)
 	c.Assert(ch.Revision(), gc.DeepEquals, revision)
 
 	// Test URL matches charm and expected series.
@@ -93,7 +94,7 @@ func assertCustomCharm(c *gc.C, ch *state.Charm, series string, meta *charm.Meta
 
 func assertStandardCharm(c *gc.C, ch *state.Charm, series string) {
 	chd := charmtesting.Charms.CharmDir(ch.Meta().Name)
-	assertCustomCharm(c, ch, series, chd.Meta(), chd.Config(), chd.Revision())
+	assertCustomCharm(c, ch, series, chd.Meta(), chd.Config(), chd.Metrics(), chd.Revision())
 }
 
 func forEachStandardCharm(c *gc.C, f func(name string)) {
@@ -110,13 +111,14 @@ func (s *CharmTestHelperSuite) TestSimple(c *gc.C) {
 		chd := charmtesting.Charms.CharmDir(name)
 		meta := chd.Meta()
 		config := chd.Config()
+		metrics := chd.Metrics()
 		revision := chd.Revision()
 
 		ch := s.AddTestingCharm(c, name)
-		assertCustomCharm(c, ch, "quantal", meta, config, revision)
+		assertCustomCharm(c, ch, "quantal", meta, config, metrics, revision)
 
 		ch = s.AddSeriesCharm(c, name, "anotherseries")
-		assertCustomCharm(c, ch, "anotherseries", meta, config, revision)
+		assertCustomCharm(c, ch, "anotherseries", meta, config, metrics, revision)
 	})
 }
 
@@ -135,9 +137,10 @@ func (s *CharmTestHelperSuite) TestConfigCharm(c *gc.C) {
 	forEachStandardCharm(c, func(name string) {
 		chd := charmtesting.Charms.CharmDir(name)
 		meta := chd.Meta()
+		metrics := chd.Metrics()
 
 		ch := s.AddConfigCharm(c, name, configYaml, 123)
-		assertCustomCharm(c, ch, "quantal", meta, config, 123)
+		assertCustomCharm(c, ch, "quantal", meta, config, metrics, 123)
 	})
 }
 
@@ -161,6 +164,27 @@ func (s *CharmTestHelperSuite) TestActionsCharm(c *gc.C) {
 	})
 }
 
+var metricsYaml = `
+metrics:
+  blips:
+    description: A custom metric.
+    type: gauge
+`
+
+func (s *CharmTestHelperSuite) TestMetricsCharm(c *gc.C) {
+	metrics, err := charm.ReadMetrics(bytes.NewBuffer([]byte(metricsYaml)))
+	c.Assert(err, gc.IsNil)
+
+	forEachStandardCharm(c, func(name string) {
+		chd := charmtesting.Charms.CharmDir(name)
+		meta := chd.Meta()
+		config := chd.Config()
+
+		ch := s.AddMetricsCharm(c, name, metricsYaml, 123)
+		assertCustomCharm(c, ch, "quantal", meta, config, metrics, 123)
+	})
+}
+
 var metaYamlSnippet = `
 summary: blah
 description: blah blah
@@ -170,11 +194,20 @@ func (s *CharmTestHelperSuite) TestMetaCharm(c *gc.C) {
 	forEachStandardCharm(c, func(name string) {
 		chd := charmtesting.Charms.CharmDir(name)
 		config := chd.Config()
+		metrics := chd.Metrics()
 		metaYaml := "name: " + name + metaYamlSnippet
 		meta, err := charm.ReadMeta(bytes.NewBuffer([]byte(metaYaml)))
 		c.Assert(err, gc.IsNil)
 
 		ch := s.AddMetaCharm(c, name, metaYaml, 123)
-		assertCustomCharm(c, ch, "quantal", meta, config, 123)
+		assertCustomCharm(c, ch, "quantal", meta, config, metrics, 123)
 	})
+}
+
+func (s *CharmTestHelperSuite) TestTestingCharm(c *gc.C) {
+	added := s.AddTestingCharm(c, "metered-custom")
+	c.Assert(added.Metrics(), gc.NotNil)
+
+	chd := charmtesting.Charms.CharmDir("metered-custom")
+	c.Assert(chd.Metrics(), gc.DeepEquals, added.Metrics())
 }

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -122,3 +122,9 @@ func (s *ConnSuite) AddActionsCharm(c *gc.C, name, actionsYaml string, revision 
 func (s *ConnSuite) AddMetaCharm(c *gc.C, name, metaYaml string, revsion int) *state.Charm {
 	return state.AddCustomCharm(c, s.State, name, "metadata.yaml", metaYaml, "quantal", revsion)
 }
+
+// AddMetricsCharm clones a testing charm, replaces its metrics declaration with the
+// given YAML string and adds it to the state, using the given revision.
+func (s *ConnSuite) AddMetricsCharm(c *gc.C, name, metricsYaml string, revsion int) *state.Charm {
+	return state.AddCustomCharm(c, s.State, name, "metrics.yaml", metricsYaml, "quantal", revsion)
+}

--- a/state/state.go
+++ b/state/state.go
@@ -671,6 +671,7 @@ func (st *State) AddCharm(ch charm.Charm, curl *charm.URL, storagePath, bundleSh
 			URL:          curl,
 			Meta:         ch.Meta(),
 			Config:       ch.Config(),
+			Metrics:      ch.Metrics(),
 			Actions:      ch.Actions(),
 			BundleSha256: bundleSha256,
 			StoragePath:  storagePath,


### PR DESCRIPTION
The Charm interface defined in the the charm package has been updated with a Metrics() method that returns the metrics the charm author has defined in a metrics.yaml file. This PR updates the Charm structure defined in core to conform with the updated interface, storing metrics definitions in mongo.
