### PR TITLE
Force the requests in TestAddCharmConcurrently to actually be concurrent by adding a Barrier.

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2397,7 +2397,7 @@ func (s *clientSuite) TestResolveCharm(c *gc.C) {
 type recordingStorage struct {
 	*sync.Mutex
 	state.Storage
-	blobs map[string]bool
+	blobs      map[string]bool
 	putBarrier *sync.WaitGroup
 }
 
@@ -2437,7 +2437,7 @@ func (s *clientSuite) TestAddCharmConcurrently(c *gc.C) {
 	s.PatchValue(client.StateStorage, func(st *state.State) state.Storage {
 		storage := st.Storage()
 		return &recordingStorage{Mutex: &blobsMu, Storage: storage, blobs: blobs,
-					 putBarrier: &putBarrier}
+			putBarrier: &putBarrier}
 	})
 
 	client := s.APIState.Client()


### PR DESCRIPTION
The code wanted to make sure that we would have concurrent requests to Put, so we make sure to
pause Put() until all of the requests have been started.
Adding a time.Sleep(10ms) to the goroutine loop causes it to fail reliably (because the
goroutines end up effectively serialized), but if we add the putBarrier it makes them
concurrent again even with the sleeps.
