### PR TITLE
Deprecate the backup CLI plugin.

### DIFF
--- a/cmd/plugins/juju-backup/juju-backup
+++ b/cmd/plugins/juju-backup/juju-backup
@@ -6,7 +6,7 @@
 # Grab the first version out of juju status (should be machine 0).
 VERSION=$(juju status | grep 'agent-version:' | awk '{print $2}')
 
-# Use the new backups CLI if newer than 1.21.  Earlier versions did not
+# Use the new backups CLI if newer than 1.21. Earlier versions did not
 # have this plugin so we don't worry about them.
 if [[ ! $VERSION =~ 1.20 && ! $VERSION =~ 1.21 ]]; then
     juju backups create --download


### PR DESCRIPTION
We must keep "juju backup" around for backward-compatibility.  However, for everything but 1.20 (when "juju backup" was introduced) and 1.21 we can simply call "juju backups create --download".
