### PR TITLE
version: Reset version to alpha3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "1.21-alpha2"
+const version = "1.21-alpha3"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
An earlier branch accidentially reverted the version to alpha2,
change it back to alpha3 here.
