### PR TITLE
state: added State.EnvironUUID and use it everywhere

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -184,7 +184,7 @@ func newActionDoc(st *State, ar ActionReceiver, actionName string, parameters ma
 	if err != nil {
 		return actionDoc{}, err
 	}
-	envuuid := st.EnvironTag().Id()
+	envuuid := st.EnvironUUID()
 	actionId := st.docID(fmt.Sprintf("%s%d", prefix, sequence))
 	return actionDoc{
 		DocId:      actionId,

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -397,7 +397,7 @@ func (st *State) machineDocForTemplate(template MachineTemplate, id string) *mac
 	return &machineDoc{
 		DocID:      st.docID(id),
 		Id:         id,
-		EnvUUID:    st.EnvironTag().Id(),
+		EnvUUID:    st.EnvironUUID(),
 		Series:     template.Series,
 		Jobs:       template.Jobs,
 		Clean:      !template.Dirty,

--- a/state/backups.go
+++ b/state/backups.go
@@ -313,7 +313,7 @@ func NewBackupsOrigin(st *State, machine string) *metadata.Origin {
 		panic(fmt.Sprintf("could not get hostname (system unstable?): %v", err))
 	}
 	origin := metadata.NewOrigin(
-		st.EnvironTag().Id(),
+		st.EnvironUUID(),
 		machine,
 		hostname,
 	)

--- a/state/backups_test.go
+++ b/state/backups_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&backupSuite{})
 
 func (s *backupSuite) metadata(c *gc.C) *metadata.Metadata {
 	origin := metadata.NewOrigin(
-		s.State.EnvironTag().Id(),
+		s.State.EnvironUUID(),
 		"0",
 		"localhost",
 	)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -38,7 +38,7 @@ type cleanupDoc struct {
 func (st *State) newCleanupOp(kind cleanupKind, prefix string) txn.Op {
 	doc := &cleanupDoc{
 		DocID:   st.docID(fmt.Sprint(bson.NewObjectId())),
-		EnvUUID: st.EnvironTag().Id(),
+		EnvUUID: st.EnvironUUID(),
 		Kind:    kind,
 		Prefix:  prefix,
 	}
@@ -167,7 +167,7 @@ func (st *State) cleanupUnitsForDyingService(serviceName string) error {
 	// when multiple environments exist.
 	sel := bson.D{
 		{"service", serviceName},
-		{"env-uuid", st.EnvironTag().Id()},
+		{"env-uuid", st.EnvironUUID()},
 		{"life", Alive},
 	}
 	iter := units.Find(sel).Iter()

--- a/state/envuser.go
+++ b/state/envuser.go
@@ -103,7 +103,7 @@ func (st *State) EnvironmentUser(user names.UserTag) (*EnvironmentUser, error) {
 	envUsers, closer := st.getCollection(envUsersC)
 	defer closer()
 
-	id := envUserID(st.EnvironTag().Id(), user.Username())
+	id := envUserID(st.EnvironUUID(), user.Username())
 	err := envUsers.FindId(id).One(&envUser.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("environment user %q", user.Username())
@@ -130,7 +130,7 @@ func (st *State) AddEnvironmentUser(user, createdBy names.UserTag) (*Environment
 		}
 	}
 
-	envuuid := st.EnvironTag().Id()
+	envuuid := st.EnvironUUID()
 	op, doc := createEnvUserOpAndDoc(envuuid, user, createdBy, displayName)
 	err := st.runTransaction([]txn.Op{op})
 	if err == txn.ErrAborted {
@@ -167,7 +167,7 @@ func createEnvUserOpAndDoc(envuuid string, user, createdBy names.UserTag, displa
 func (st *State) RemoveEnvironmentUser(user names.UserTag) error {
 	ops := []txn.Op{{
 		C:      envUsersC,
-		Id:     envUserID(st.EnvironTag().Id(), user.Username()),
+		Id:     envUserID(st.EnvironUUID(), user.Username()),
 		Assert: txn.DocExists,
 		Remove: true,
 	}}

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -67,7 +67,7 @@ func (st *State) addMetrics(unitTag names.UnitTag, charmUrl *charm.URL, created 
 		st: st,
 		doc: metricBatchDoc{
 			UUID:     uuid.String(),
-			EnvUUID:  st.EnvironTag().Id(),
+			EnvUUID:  st.EnvironUUID(),
 			Unit:     unitTag.Id(),
 			CharmUrl: charmUrl.String(),
 			Sent:     false,

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -34,7 +34,7 @@ func (s *MetricSuite) TestAddNoMetrics(c *gc.C) {
 
 func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	now := state.NowToTheSecond()
-	envUUID := s.State.EnvironTag().Id()
+	envUUID := s.State.EnvironUUID()
 	m := state.Metric{"item", "5", now, []byte("creds")}
 	metricBatch, err := s.unit.AddMetrics(now, []state.Metric{m})
 	c.Assert(err, gc.IsNil)

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -129,7 +129,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 		Insert: relationScopeDoc{
 			DocID:   rsDocID,
 			Key:     ruKey,
-			EnvUUID: ru.st.EnvironTag().Id(),
+			EnvUUID: ru.st.EnvironUUID(),
 		},
 	})
 

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -774,7 +774,7 @@ func (s *ServiceSuite) TestAddUnit(c *gc.C) {
 	c.Assert(unitZero.Name(), gc.Equals, "mysql/0")
 	c.Assert(unitZero.IsPrincipal(), gc.Equals, true)
 	c.Assert(unitZero.SubordinateNames(), gc.HasLen, 0)
-	c.Assert(state.GetUnitEnvUUID(unitZero), gc.Equals, s.State.EnvironTag().Id())
+	c.Assert(state.GetUnitEnvUUID(unitZero), gc.Equals, s.State.EnvironUUID())
 
 	unitOne, err := s.mysql.AddUnit()
 	c.Assert(err, gc.IsNil)

--- a/state/state.go
+++ b/state/state.go
@@ -140,6 +140,12 @@ func (st *State) EnvironTag() names.EnvironTag {
 	return st.environTag
 }
 
+// EnvironUUID returns the environment UUID for the environment
+// controlled by this state instance.
+func (st *State) EnvironUUID() string {
+	return st.environTag.Id()
+}
+
 // getCollection fetches a named collection using a new session if the
 // database has previously been logged in to.
 // It returns the collection and a closer function for the session.
@@ -1090,7 +1096,7 @@ func (st *State) addPeerRelationsOps(serviceName string, peers map[string]charm.
 		relDoc := &relationDoc{
 			DocID:     st.docID(relKey),
 			Key:       relKey,
-			EnvUUID:   st.EnvironTag().Id(),
+			EnvUUID:   st.EnvironUUID(),
 			Id:        relId,
 			Endpoints: eps,
 			Life:      Alive,
@@ -1320,13 +1326,13 @@ func (st *State) AllServices() (services []*Service, err error) {
 // where the environment uuid is prefixed to the
 // localID.
 func (st *State) docID(localID string) string {
-	return st.EnvironTag().Id() + ":" + localID
+	return st.EnvironUUID() + ":" + localID
 }
 
 // localID returns the local id value by stripping
 // off the environment uuid prefix if it is there.
 func (st *State) localID(ID string) string {
-	prefix := st.EnvironTag().Id() + ":"
+	prefix := st.EnvironUUID() + ":"
 	if strings.HasPrefix(ID, prefix) {
 		return ID[len(prefix):]
 	}
@@ -1340,7 +1346,7 @@ func (st *State) localID(ID string) string {
 // State's environment, false is returned. True is returned if the
 // expected prefix was present.
 func (st *State) strictLocalID(ID string) (string, bool) {
-	prefix := st.EnvironTag().Id() + ":"
+	prefix := st.EnvironUUID() + ":"
 	if !strings.HasPrefix(ID, prefix) {
 		return "", false
 	}
@@ -1538,7 +1544,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 		doc = &relationDoc{
 			DocID:     docID,
 			Key:       key,
-			EnvUUID:   st.EnvironTag().Id(),
+			EnvUUID:   st.EnvironUUID(),
 			Id:        id,
 			Endpoints: eps,
 			Life:      Alive,
@@ -1652,7 +1658,7 @@ func (st *State) matchingActionsByReceiverName(receiver string) ([]*Action, erro
 	actionsCollection, closer := st.getCollection(actionsC)
 	defer closer()
 
-	envuuid := st.EnvironTag().Id()
+	envuuid := st.EnvironUUID()
 	sel := bson.D{{"env-uuid", envuuid}, {"receiver", receiver}}
 	iter := actionsCollection.Find(sel).Iter()
 
@@ -1699,7 +1705,7 @@ func (st *State) matchingActionResults(ar ActionReceiver) ([]*ActionResult, erro
 	actionresults, closer := st.getCollection(actionresultsC)
 	defer closer()
 
-	envuuid := st.EnvironTag().Id()
+	envuuid := st.EnvironUUID()
 	sel := bson.D{{"env-uuid", envuuid}, {"action.receiver", ar.Name()}}
 	iter := actionresults.Find(sel).Iter()
 	for iter.Next(&doc) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -82,11 +82,11 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 func (s *StateSuite) TestDocID(c *gc.C) {
 	id := "wordpress"
 	docID := state.DocID(s.State, id)
-	c.Assert(docID, gc.Equals, s.State.EnvironTag().Id()+":"+id)
+	c.Assert(docID, gc.Equals, s.State.EnvironUUID()+":"+id)
 }
 
 func (s *StateSuite) TestLocalID(c *gc.C) {
-	id := s.State.EnvironTag().Id() + ":wordpress"
+	id := s.State.EnvironUUID() + ":wordpress"
 	localID := state.LocalID(s.State, id)
 	c.Assert(localID, gc.Equals, "wordpress")
 }
@@ -132,6 +132,10 @@ func (s *StateSuite) TestOpenSetsEnvironmentTag(c *gc.C) {
 	defer st.Close()
 
 	c.Assert(st.EnvironTag(), gc.Equals, s.envTag)
+}
+
+func (s *StateSuite) TestEnvironUUID(c *gc.C) {
+	c.Assert(s.State.EnvironUUID(), gc.Equals, s.envTag.Id())
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -181,7 +181,7 @@ func (info *UpgradeInfo) getProvisionedStateServers() ([]string, error) {
 	var sel bson.D
 	var field string
 	if upgradeDone {
-		sel = bson.D{{"env-uuid", info.st.EnvironTag().Id()}}
+		sel = bson.D{{"env-uuid", info.st.EnvironUUID()}}
 		field = "machineid"
 	} else {
 		field = "_id"

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -541,7 +541,7 @@ func MigrateMachineInstanceIdToInstanceData(st *State) error {
 				Insert: instanceData{
 					DocID:      mID,
 					MachineId:  mID,
-					EnvUUID:    st.EnvironTag().Id(),
+					EnvUUID:    st.EnvironUUID(),
 					InstanceId: instance.Id(instID.(string)),
 				},
 			})

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -507,7 +507,7 @@ func (s *upgradesSuite) checkAddEnvUUIDToCollection(
 	coll, closer := s.state.getCollection(collName)
 	var d map[string]string
 	var ids []string
-	envTag := s.state.EnvironTag().Id()
+	envTag := s.state.EnvironUUID()
 	for _, oldDoc := range oldDocs {
 		oldID := fmt.Sprint(oldDoc["_id"])
 		newID := s.state.docID(oldID)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -919,7 +919,7 @@ func (w *unitsWatcher) initial() ([]string, error) {
 	defer closer()
 	query := bson.D{
 		{"name", bson.D{{"$in", initialNames}}},
-		{"env-uuid", w.st.EnvironTag().Id()},
+		{"env-uuid", w.st.EnvironUUID()},
 	}
 	docs := []lifeWatchDoc{}
 	if err := newUnits.Find(query).Select(lifeWatchFields).All(&docs); err != nil {


### PR DESCRIPTION
EnvironTag().Id() is commonly used to get the environment UUID. A EnvironUUID method has been added to provide a more direct and easier to read way of obtaining the environment UUID.
