### PR TITLE
Merged 1.21 upgrade steps into one list

### DIFF
--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -17,15 +17,7 @@ var upgradeOperations = func() []Operation {
 		},
 		upgradeToVersion{
 			version.MustParse("1.21-alpha1"),
-			stepsFor121a1(),
-		},
-		upgradeToVersion{
-			version.MustParse("1.21-alpha2"),
-			stepsFor121a2(),
-		},
-		upgradeToVersion{
-			version.MustParse("1.21-alpha3"),
-			stepsFor121a3(),
+			stepsFor121(),
 		},
 	}
 	return steps

--- a/upgrades/steps121.go
+++ b/upgrades/steps121.go
@@ -7,26 +7,14 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// stepsFor121a1 returns upgrade steps to upgrade to a Juju 1.21alpha1 deployment.
-func stepsFor121a1() []Step {
+// stepsFor121 returns upgrade steps to upgrade to a Juju 1.21 deployment.
+func stepsFor121() []Step {
 	return []Step{
-		&upgradeStep{
-			description: "rename the user LastConnection field to LastLogin",
-			targets:     []Target{DatabaseMaster},
-			run:         migrateLastConnectionToLastLogin,
-		},
 		&upgradeStep{
 			description: "add environment uuid to state server doc",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return state.AddEnvironmentUUIDToStateServerDoc(context.State())
-			},
-		},
-		&upgradeStep{
-			description: "add all users in state as environment users",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.AddStateUsersAsEnvironUsers(context.State())
 			},
 		},
 		&upgradeStep{
@@ -36,12 +24,35 @@ func stepsFor121a1() []Step {
 				return state.SetOwnerAndServerUUIDForEnvironment(context.State())
 			},
 		},
-	}
-}
 
-// stepsFor121a2 returns upgrade steps to upgrade to a Juju 1.21alpha2 deployment.
-func stepsFor121a2() []Step {
-	return []Step{
+		&upgradeStep{
+			description: "migrate machine instanceId into instanceData",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateMachineInstanceIdToInstanceData(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "prepend the environment UUID to the ID of all machine docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToMachines(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "prepend the environment UUID to the ID of all instanceData docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToInstanceData(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "prepend the environment UUID to the ID of all containerRef docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToContainerRefs(context.State())
+			},
+		},
 		&upgradeStep{
 			description: "prepend the environment UUID to the ID of all service docs",
 			targets:     []Target{DatabaseMaster},
@@ -54,6 +65,47 @@ func stepsFor121a2() []Step {
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return state.AddEnvUUIDToUnits(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "prepend the environment UUID to the ID of all reboot docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToReboots(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "prepend the environment UUID to the ID of all relations docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToRelations(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "prepend the environment UUID to the ID of all relationscopes docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToRelationScopes(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "prepend the environment UUID to the ID of all cleanup docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToCleanups(context.State())
+			},
+		},
+
+		&upgradeStep{
+			description: "rename the user LastConnection field to LastLogin",
+			targets:     []Target{DatabaseMaster},
+			run:         migrateLastConnectionToLastLogin,
+		},
+		&upgradeStep{
+			description: "add all users in state as environment users",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddStateUsersAsEnvironUsers(context.State())
 			},
 		},
 		&upgradeStep{
@@ -91,72 +143,10 @@ func stepsFor121a2() []Step {
 				return state.CreateUnitMeterStatus(context.State())
 			},
 		},
-	}
-}
-
-// stepsFor121a3 returns upgrade steps to upgrade to a Juju 1.21alpha3 deployment.
-func stepsFor121a3() []Step {
-	return []Step{
-		&upgradeStep{
-			description: "migrate machine instanceId into instanceData",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.MigrateMachineInstanceIdToInstanceData(context.State())
-			},
-		},
-		&upgradeStep{
-			description: "prepend the environment UUID to the ID of all machine docs",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.AddEnvUUIDToMachines(context.State())
-			},
-		},
-		&upgradeStep{
-			description: "prepend the environment UUID to the ID of all instanceData docs",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.AddEnvUUIDToInstanceData(context.State())
-			},
-		},
-		&upgradeStep{
-			description: "prepend the environment UUID to the ID of all containerRef docs",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.AddEnvUUIDToContainerRefs(context.State())
-			},
-		},
-		&upgradeStep{
-			description: "prepend the environment UUID to the ID of all reboot docs",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.AddEnvUUIDToReboots(context.State())
-			},
-		},
-		&upgradeStep{
-			description: "prepend the environment UUID to the ID of all relations docs",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.AddEnvUUIDToRelations(context.State())
-			},
-		},
-		&upgradeStep{
-			description: "prepend the environment UUID to the ID of all relationscopes docs",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.AddEnvUUIDToRelationScopes(context.State())
-			},
-		},
 		&upgradeStep{
 			description: "migrate machine jobs into ones with JobManageNetworking based on rules",
 			targets:     []Target{DatabaseMaster},
 			run:         migrateJobManageNetworking,
-		},
-		&upgradeStep{
-			description: "prepend the environment UUID to the ID of all cleanup docs",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return state.AddEnvUUIDToCleanups(context.State())
-			},
 		},
 	}
 }

--- a/upgrades/steps121_test.go
+++ b/upgrades/steps121_test.go
@@ -16,31 +16,12 @@ type steps121Suite struct {
 
 var _ = gc.Suite(&steps121Suite{})
 
-func (s *steps121Suite) TestStepsFor121a1(c *gc.C) {
+func (s *steps121Suite) TestStepsFor121(c *gc.C) {
 	var expectedSteps = []string{
-		"rename the user LastConnection field to LastLogin",
+		// Environment UUID related migrations should come first as
+		// other upgrade steps may rely on them.
 		"add environment uuid to state server doc",
-		"add all users in state as environment users",
 		"set environment owner and server uuid",
-	}
-	assertSteps(c, version.MustParse("1.21-alpha1"), expectedSteps)
-}
-
-func (s *steps121Suite) TestStepsFor121a2(c *gc.C) {
-	var expectedSteps = []string{
-		"prepend the environment UUID to the ID of all service docs",
-		"prepend the environment UUID to the ID of all unit docs",
-		"migrate charm archives into environment storage",
-		"migrate custom image metadata into environment storage",
-		"migrate tools into environment storage",
-		"migrate individual unit ports to openedPorts collection",
-		"create entries in meter status collection for existing units",
-	}
-	assertSteps(c, version.MustParse("1.21-alpha2"), expectedSteps)
-}
-
-func (s *steps121Suite) TestStepsFor121a3(c *gc.C) {
-	var expectedSteps = []string{
 		// It is important to keep the order of the following three steps:
 		// 1.migrate machine instanceId, 2. Add env ID to  machine docs, 3.
 		// Add env ID to instanceData docs. If the order changes, bad things
@@ -49,11 +30,22 @@ func (s *steps121Suite) TestStepsFor121a3(c *gc.C) {
 		"prepend the environment UUID to the ID of all machine docs",
 		"prepend the environment UUID to the ID of all instanceData docs",
 		"prepend the environment UUID to the ID of all containerRef docs",
+		"prepend the environment UUID to the ID of all service docs",
+		"prepend the environment UUID to the ID of all unit docs",
 		"prepend the environment UUID to the ID of all reboot docs",
 		"prepend the environment UUID to the ID of all relations docs",
 		"prepend the environment UUID to the ID of all relationscopes docs",
-		"migrate machine jobs into ones with JobManageNetworking based on rules",
 		"prepend the environment UUID to the ID of all cleanup docs",
+
+		// Non-environment UUID upgrade steps follow.
+		"rename the user LastConnection field to LastLogin",
+		"add all users in state as environment users",
+		"migrate charm archives into environment storage",
+		"migrate custom image metadata into environment storage",
+		"migrate tools into environment storage",
+		"migrate individual unit ports to openedPorts collection",
+		"create entries in meter status collection for existing units",
+		"migrate machine jobs into ones with JobManageNetworking based on rules",
 	}
-	assertSteps(c, version.MustParse("1.21-alpha3"), expectedSteps)
+	assertSteps(c, version.MustParse("1.21-alpha1"), expectedSteps)
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -399,7 +399,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 	}
 }
 
-var expectedVersions = []string{"1.18.0", "1.21-alpha1", "1.21-alpha2", "1.21-alpha3"}
+var expectedVersions = []string{"1.18.0", "1.21-alpha1"}
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	var versions []string


### PR DESCRIPTION
Without this, upgrade steps really end up running in the wrong order. Steps like the machine and instanceData env UUID migrations really need to go first.

This change solves the immediate issue. A future change will tidy this up so that the steps can be assigned against 1.21 final instead of alpha1.
