### PR TITLE
Do not read entire charm into memory when downloading

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -429,11 +429,13 @@ func (h *charmsHandler) downloadCharm(curl *charm.URL, charmArchivePath string) 
 	// Use the storage to retrieve and save the charm archive.
 	reader, _, err := storage.Get(ch.StoragePath())
 	if err != nil {
-		return errors.Annotate(err, "charm not found in the provider storage")
+		defer os.Remove(tempCharmArchive.Name())
+		return errors.Annotate(err, "cannot get charm from environment storage")
 	}
 	defer reader.Close()
 
 	if _, err = io.Copy(tempCharmArchive, reader); err != nil {
+		defer os.Remove(tempCharmArchive.Name())
 		return errors.Annotate(err, "error processing charm archive download")
 	}
 	if err = os.Rename(tempCharmArchive.Name(), charmArchivePath); err != nil {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1386405

Do not pull entire charm into memory when downloading.
