### PR TITLE
cmd/juju: permit user@ in scp/ssh target

### DIFF
--- a/cmd/juju/ssh_test.go
+++ b/cmd/juju/ssh_test.go
@@ -87,6 +87,11 @@ var sshTests = []struct {
 		sshArgs + "ubuntu@dummyenv-0.internal\n",
 	},
 	{
+		"connect to unit mongodb/1 as the mongo user",
+		[]string{"ssh", "mongo@mongodb/1"},
+		sshArgs + "mongo@dummyenv-2.internal\n",
+	},
+	{
 		"connect to unit mongodb/1 and pass extra arguments",
 		[]string{"ssh", "mongodb/1", "ls", "/"},
 		sshArgs + "ubuntu@dummyenv-2.internal ls /\n",


### PR DESCRIPTION
The "juju ssh" and "juju scp" commands now
allow "user@" in the target. For example,
you can now do "juju ssh jenkins@jenkins/0"
to ssh to the first jenkins/0 unit as the
jenkins user.

Also, fix examples and clarify help for
"juju scp" regarding passing additional
arguments to "scp".

Fixes https://bugs.launchpad.net/juju-core/+bug/1387766
Fixes https://bugs.launchpad.net/juju-core/+bug/1387640
