### PR TITLE
Metrics validation support in the uniter.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -23,7 +23,7 @@ github.com/juju/testing	git	ab9111f762f6cdaaceb44c879b6e146164a22b0b
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	
 github.com/juju/utils	git	6ef4a86e1de1bd7af882d17476fb1f129ab6fbdd	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
-gopkg.in/juju/charm.v4	git	f97c8d630e45651f7b39ce352dd7329082f134c4	
+gopkg.in/juju/charm.v4	git	1e5bb4b32d73cfc2fe1f46928c5b5189ffc37465	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -205,9 +205,9 @@ func (s *CharmTestHelperSuite) TestMetaCharm(c *gc.C) {
 }
 
 func (s *CharmTestHelperSuite) TestTestingCharm(c *gc.C) {
-	added := s.AddTestingCharm(c, "metered-custom")
+	added := s.AddTestingCharm(c, "metered")
 	c.Assert(added.Metrics(), gc.NotNil)
 
-	chd := charmtesting.Charms.CharmDir("metered-custom")
+	chd := charmtesting.Charms.CharmDir("metered")
 	c.Assert(chd.Metrics(), gc.DeepEquals, added.Metrics())
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1062,6 +1062,7 @@ func (st *State) updateCharmDoc(
 		{"meta", ch.Meta()},
 		{"config", escapedConfig},
 		{"actions", ch.Actions()},
+		{"metrics", ch.Metrics()},
 		{"storagepath", storagePath},
 		{"bundlesha256", bundleSha256},
 		{"pendingupload", false},

--- a/worker/uniter/context/context_test.go
+++ b/worker/uniter/context/context_test.go
@@ -26,7 +26,7 @@ func (s *InterfaceSuite) GetContext(
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
 	return s.HookContextSuite.getHookContext(
-		c, uuid.String(), relId, remoteName, noProxies, false,
+		c, uuid.String(), relId, remoteName, noProxies,
 	)
 }
 

--- a/worker/uniter/context/export_test.go
+++ b/worker/uniter/context/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils/proxy"
+	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
@@ -95,6 +96,7 @@ func NewHookContext(
 	serviceOwner names.UserTag,
 	proxySettings proxy.Settings,
 	canAddMetrics bool,
+	metrics *charm.Metrics,
 	actionData *ActionData,
 	assignedMachineTag names.MachineTag,
 ) (*HookContext, error) {
@@ -112,6 +114,7 @@ func NewHookContext(
 		serviceOwner:       serviceOwner,
 		proxySettings:      proxySettings,
 		canAddMetrics:      canAddMetrics,
+		definedMetrics:     metrics,
 		actionData:         actionData,
 		pendingPorts:       make(map[PortRange]PortRangeInfo),
 		assignedMachineTag: assignedMachineTag,

--- a/worker/uniter/context/runner_test.go
+++ b/worker/uniter/context/runner_test.go
@@ -50,14 +50,14 @@ type RunCommandSuite struct {
 
 var _ = gc.Suite(&RunCommandSuite{})
 
-func (s *RunCommandSuite) getHookContext(c *gc.C, addMetrics bool) *context.HookContext {
+func (s *RunCommandSuite) getHookContext(c *gc.C) *context.HookContext {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	return s.HookContextSuite.getHookContext(c, uuid.String(), -1, "", noProxies, addMetrics)
+	return s.HookContextSuite.getHookContext(c, uuid.String(), -1, "", noProxies)
 }
 
 func (s *RunCommandSuite) TestRunCommandsEnvStdOutAndErrAndRC(c *gc.C) {
-	ctx := s.getHookContext(c, false)
+	ctx := s.getHookContext(c)
 	paths := NewRealPaths(c)
 	runner := context.NewRunner(ctx, paths)
 
@@ -188,7 +188,7 @@ func (s *RunHookSuite) TestRunHook(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	for i, t := range runHookTests {
 		c.Logf("\ntest %d: %s; perm %v", i, t.summary, t.spec.perm)
-		ctx := s.getHookContext(c, uuid.String(), t.relid, t.remote, noProxies, false)
+		ctx := s.getHookContext(c, uuid.String(), t.relid, t.remote, noProxies)
 		paths := NewRealPaths(c)
 		runner := context.NewRunner(ctx, paths)
 		var hookExists bool
@@ -222,7 +222,7 @@ func (s *RunHookSuite) TestRunHookRelationFlushingError(c *gc.C) {
 	// Create a charm with a breaking hook.
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, false)
+	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies)
 	paths := NewRealPaths(c)
 	makeCharm(c, hookSpec{
 		name: "something-happened",
@@ -263,7 +263,7 @@ func (s *RunHookSuite) TestRunHookRelationFlushingSuccess(c *gc.C) {
 	// Create a charm with a working hook, and mess with settings again.
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, false)
+	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies)
 	paths := NewRealPaths(c)
 	makeCharm(c, hookSpec{
 		name: "something-happened",
@@ -307,7 +307,7 @@ func (s *RunHookSuite) TestRunHookMetricSending(c *gc.C) {
 	// execution.
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, true)
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"))
 	paths := NewRealPaths(c)
 	makeCharm(c, hookSpec{
 		name: "collect-metrics",
@@ -336,7 +336,33 @@ func (s *RunHookSuite) TestRunHookMetricSendingDisabled(c *gc.C) {
 	// execution.
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, false)
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, false, s.metricsDefinition("key"))
+	paths := NewRealPaths(c)
+	makeCharm(c, hookSpec{
+		name: "some-hook",
+		perm: 0700,
+	}, paths.charm)
+
+	now := time.Now()
+	err = ctx.AddMetrics("key", "50", now)
+	c.Assert(err, gc.ErrorMatches, "metrics disabled")
+
+	// Run the hook.
+	err = context.NewRunner(ctx, paths).RunHook("some-hook")
+	c.Assert(err, gc.IsNil)
+
+	metricBatches, err := s.State.MetricBatches()
+	c.Assert(err, gc.IsNil)
+	c.Assert(metricBatches, gc.HasLen, 0)
+}
+
+func (s *RunHookSuite) TestRunHookMetricSendingUndeclared(c *gc.C) {
+	// TODO(fwereade): these should be testing a public Flush() method on
+	// the context, or something, instead of faking up an unnecessary hook
+	// execution.
+	uuid, err := utils.NewUUID()
+	c.Assert(err, gc.IsNil)
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, nil)
 	paths := NewRealPaths(c)
 	makeCharm(c, hookSpec{
 		name: "some-hook",
@@ -389,7 +415,7 @@ func (s *RunHookSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	// Get the context.
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
-	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies, false)
+	ctx := s.getHookContext(c, uuid.String(), -1, "", noProxies)
 	paths := NewRealPaths(c)
 	makeCharm(c, hookSpec{
 		name: "some-hook",

--- a/worker/uniter/jujuc/add-metric.go
+++ b/worker/uniter/jujuc/add-metric.go
@@ -5,7 +5,6 @@ package jujuc
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/juju/cmd"
@@ -52,10 +51,6 @@ func (c *AddMetricCommand) Init(args []string) error {
 		return err
 	}
 	for key, value := range options {
-		_, err := strconv.ParseFloat(value, 64)
-		if err != nil {
-			return fmt.Errorf("invalid value type: expected float, got %q", value)
-		}
 		c.Metrics = append(c.Metrics, Metric{key, value, now})
 	}
 	return nil

--- a/worker/uniter/jujuc/add-metric_test.go
+++ b/worker/uniter/jujuc/add-metric_test.go
@@ -60,14 +60,6 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			"error: no metrics specified\n",
 			nil,
 		}, {
-			"invalid metric value",
-			[]string{"add-metric", "key=invalidvalue"},
-			true,
-			2,
-			"",
-			"error: invalid value type: expected float, got \"invalidvalue\"\n",
-			nil,
-		}, {
 			"invalid argument format",
 			[]string{"add-metric", "key"},
 			true,

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -204,7 +204,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		return err
 	}
 
-	u.contextFactory, err = context.NewFactory(u.st, unitTag, u.getRelationInfos)
+	u.contextFactory, err = context.NewFactory(u.st, unitTag, u.getRelationInfos, u.getCharm)
 	if err != nil {
 		return err
 	}
@@ -356,6 +356,14 @@ func (u *Uniter) getRelationInfos() map[int]*context.RelationInfo {
 		relationInfos[id] = r.ContextInfo()
 	}
 	return relationInfos
+}
+
+func (u *Uniter) getCharm() (corecharm.Charm, error) {
+	ch, err := corecharm.ReadCharm(u.paths.State.CharmDir)
+	if err != nil {
+		return nil, err
+	}
+	return ch, nil
 }
 
 func (u *Uniter) acquireHookLock(message string) (err error) {


### PR DESCRIPTION
Now that charms have a way of declaring the metrics they will report, validation of metrics will be performed by the charm package, when the metrics is added using the hook tool add-metric.

In addition to this, the MP fixes the way local charms are added to the charms collection in state, so that the Metrics component is also stored.
