### PR TITLE
Fix LP 1386968

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2372,8 +2372,6 @@ func (s *clientSuite) TestAddCharm(c *gc.C) {
 	err = client.AddCharm(sch.URL())
 	c.Assert(err, gc.IsNil)
 
-	// blobs.Lock()
-
 	c.Assert(blobs.m, gc.HasLen, 0)
 
 	// Now try adding another charm completely.
@@ -2445,17 +2443,17 @@ type blobs struct {
 // Add adds a path to the list of known paths.
 func (b *blobs) Add(path string) {
 	b.Lock()
+	defer b.Unlock()
 	b.check()
 	b.m[path] = true
-	b.Unlock()
 }
 
 // Remove marks a path as deleted, even if it was not previously Added.
 func (b *blobs) Remove(path string) {
 	b.Lock()
+	defer b.Unlock()
 	b.check()
 	b.m[path] = false
-	b.Unlock()
 }
 
 func (b *blobs) check() {


### PR DESCRIPTION
- move things around to make recordingStorage simpler
- break out the blobs file map into its own type as that is the bit we want to interrogate after the test run
- add more locks, that always seems to help

Passes several runs of stress.bash without puking, race detector is happy as well.
