### PR TITLE
Fixed LXC/KVM bridge settings for maas and other environments

### DIFF
--- a/cmd/jujud/upgrade_test.go
+++ b/cmd/jujud/upgrade_test.go
@@ -581,7 +581,7 @@ func (s *UpgradeSuite) runUpgradeWorkerUsingAgent(
 ) (error, *upgradeWorkerContext) {
 	context := NewUpgradeWorkerContext()
 	worker := context.Worker(agent, nil, []params.MachineJob{job})
-	s.setInstantRetryStrategy()
+	s.setInstantRetryStrategy(c)
 	return worker.Wait(), context
 }
 
@@ -635,8 +635,9 @@ func waitForUpgradeToStart(upgradeCh chan bool) bool {
 
 const maxUpgradeRetries = 3
 
-func (s *UpgradeSuite) setInstantRetryStrategy() {
+func (s *UpgradeSuite) setInstantRetryStrategy(c *gc.C) {
 	s.PatchValue(&getUpgradeRetryStrategy, func() utils.AttemptStrategy {
+		c.Logf("setting instant retry strategy for upgrade: retries=%d", maxUpgradeRetries)
 		return utils.AttemptStrategy{
 			Delay: 0,
 			Min:   maxUpgradeRetries,

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -32,6 +32,10 @@ var DataDir = agent.DefaultDataDir
 // may create a folder containing logs
 var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
 
+// DefaultBridgeName is the network bridge device name used for LXC
+// and KVM containers.
+const DefaultBridgeName = "juju-br0"
+
 // NewMachineConfig sets up a basic machine configuration, for a
 // non-bootstrap node. You'll still need to supply more information,
 // but this takes care of the fixed entries and the ones that are
@@ -58,7 +62,7 @@ func NewMachineConfig(
 		// Fixed entries.
 		DataDir:                 dataDir,
 		LogDir:                  path.Join(logDir, "juju"),
-		Jobs:                    []params.MachineJob{params.JobHostUnits, params.JobManageNetworking},
+		Jobs:                    []params.MachineJob{params.JobHostUnits},
 		CloudInitOutputLog:      cloudInitOutputLog,
 		MachineAgentServiceName: "jujud-" + names.NewMachineTag(machineID).String(),
 		Series:                  series,
@@ -88,7 +92,6 @@ func NewBootstrapMachineConfig(cons constraints.Value, series string) (*cloudini
 	mcfg.Jobs = []params.MachineJob{
 		params.JobManageEnviron,
 		params.JobHostUnits,
-		params.JobManageNetworking,
 	}
 	mcfg.Constraints = cons
 	return mcfg, nil

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -80,6 +80,11 @@ type BootstrapParams struct {
 	// AvailableTools is a collection of tools which the Bootstrap method
 	// may use to decide which architecture/series to instantiate.
 	AvailableTools tools.List
+
+	// ContainerBridgeName, if non-empty, overrides the default
+	// network bridge device to use for LXC and KVM containers. See
+	// environs.DefaultBridgeName.
+	ContainerBridgeName string
 }
 
 // BootstrapFinalizer is a function returned from Environ.Bootstrap.

--- a/network/network.go
+++ b/network/network.go
@@ -42,6 +42,10 @@ type BasicInfo struct {
 // For providers that support networks, this will be available at
 // StartInstance() time.
 type Info struct {
+	// DeviceIndex specifies the order in which the network interface
+	// appears on the host. The primary interface has an index of 0.
+	DeviceIndex int
+
 	// MACAddress is the network interface's hardware MAC address
 	// (e.g. "aa:bb:cc:dd:ee:ff").
 	MACAddress string

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -19,9 +19,9 @@ var _ = gc.Suite(&InfoSuite{})
 
 func (n *InfoSuite) SetUpTest(c *gc.C) {
 	n.info = []network.Info{
-		{VLANTag: 1, InterfaceName: "eth0"},
-		{VLANTag: 0, InterfaceName: "eth1"},
-		{VLANTag: 42, InterfaceName: "br2"},
+		{VLANTag: 1, DeviceIndex: 0, InterfaceName: "eth0"},
+		{VLANTag: 0, DeviceIndex: 1, InterfaceName: "eth1"},
+		{VLANTag: 42, DeviceIndex: 2, InterfaceName: "br2"},
 	}
 }
 

--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -22,30 +22,16 @@ var configFields = schema.Fields{
 	// maas-agent-name is an optional UUID to group the instances
 	// acquired from MAAS, to support multiple environments per MAAS user.
 	"maas-agent-name": schema.String(),
-
-	// network-bridge is the interface name used by cloudInit
-	// to configure the bridge network, by default "eth0" is used.
-	"network-bridge": schema.String(),
 }
 var configDefaults = schema.Defaults{
 	// For backward-compatibility, maas-agent-name is the empty string
 	// by default. However, new environments should all use a UUID.
 	"maas-agent-name": "",
-	// For backward-compatibility, network-bridge is the empty string
-	// by default "eth0" will be returned.
-	"network-bridge": "",
 }
 
 type maasEnvironConfig struct {
 	*config.Config
 	attrs map[string]interface{}
-}
-
-func (cfg *maasEnvironConfig) networkBridge() string {
-	if bridge, ok := cfg.attrs["network-bridge"].(string); ok && bridge != "" {
-		return bridge
-	}
-	return "eth0"
 }
 
 func (cfg *maasEnvironConfig) maasServer() string {

--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -43,13 +43,11 @@ func (*configSuite) TestParsesMAASSettings(c *gc.C) {
 	server := "http://maas.testing.invalid/maas/"
 	oauth := "consumer-key:resource-token:resource-secret"
 	future := "futurama"
-	iface := "p1p2"
 
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
 	ecfg, err := newConfig(map[string]interface{}{
 		"maas-server":     server,
-		"network-bridge":  iface,
 		"maas-oauth":      oauth,
 		"maas-agent-name": uuid.String(),
 		"future-key":      future,
@@ -58,7 +56,6 @@ func (*configSuite) TestParsesMAASSettings(c *gc.C) {
 	c.Check(ecfg.maasServer(), gc.Equals, server)
 	c.Check(ecfg.maasOAuth(), gc.DeepEquals, oauth)
 	c.Check(ecfg.maasAgentName(), gc.Equals, uuid.String())
-	c.Check(ecfg.networkBridge(), gc.Equals, iface)
 	c.Check(ecfg.UnknownAttrs()["future-key"], gc.DeepEquals, future)
 }
 
@@ -69,15 +66,6 @@ func (*configSuite) TestMaasAgentNameDefault(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 	c.Check(ecfg.maasAgentName(), gc.Equals, "")
-}
-
-func (*configSuite) TestNetworkBridgeDefault(c *gc.C) {
-	ecfg, err := newConfig(map[string]interface{}{
-		"maas-server": "http://maas.testing.invalid/maas/",
-		"maas-oauth":  "consumer-key:resource-token:resource-secret",
-	})
-	c.Assert(err, gc.IsNil)
-	c.Check(ecfg.networkBridge(), gc.Equals, "eth0")
 }
 
 func (*configSuite) TestChecksWellFormedMaasServer(c *gc.C) {

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -198,31 +198,17 @@ var expectedCloudinitConfig = []interface{}{
 	"set -xe",
 	"mkdir -p '/var/lib/juju'\ninstall -m 755 /dev/null '/var/lib/juju/MAASmachine.txt'\nprintf '%s\\n' ''\"'\"'hostname: testing.invalid\n'\"'\"'' > '/var/lib/juju/MAASmachine.txt'",
 	"ifdown eth0",
-	`mkdir -p etc/network/interfaces.d
-cat > /etc/network/interfaces.d/eth0.cfg << EOF
-# The primary network interface
-auto eth0
-iface eth0 inet dhcp
+	`cat >> /etc/network/interfaces << EOF
+
+iface eth0 inet manual
+
+auto juju-br0
+iface juju-br0 inet dhcp
+    bridge_ports eth0
 EOF
-sed -i '/auto eth0/{N;s/auto eth0\niface eth0 inet dhcp//}' /etc/network/interfaces
-cat >> /etc/network/interfaces << EOF
-# Source interfaces
-# Please check /etc/network/interfaces.d before changing this file
-# as interfaces may have been defined in /etc/network/interfaces.d
-# NOTE: the primary ethernet device is defined in
-# /etc/network/interfaces.d/eth0.cfg
-# See LP: #1262951
-source /etc/network/interfaces.d/*.cfg
-EOF
-`,
-	`cat > /etc/network/interfaces.d/br0.cfg << EOF
-auto br0
-iface br0 inet dhcp
-  bridge_ports eth0
-EOF
-sed -i 's/iface eth0 inet dhcp/iface eth0 inet manual/' /etc/network/interfaces.d/eth0.cfg
-`,
-	"ifup br0",
+grep -q 'iface eth0 inet dhcp' /etc/network/interfaces && \
+sed -i 's/iface eth0 inet dhcp//' /etc/network/interfaces`,
+	"ifup juju-br0",
 }
 
 var expectedCloudinitConfigWithoutNetworking = []interface{}{

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -161,12 +161,12 @@ const lshwXMLTemplate = `
   <node id="core" claimed="true" class="bus" handle="DMI:0008">
    <description>Motherboard</description>
     <node id="pci" claimed="true" class="bridge" handle="PCIBUS:0000:00">
-     <description>Host bridge</description>{{range $m, $n := .}}
-      <node id="network:0" claimed="true" class="network" handle="PCI:0000:00:03.0">
+     <description>Host bridge</description>{{$list := .}}{{range $mac, $ifi := $list}}
+      <node id="network{{if gt (len $list) 1}}:{{$ifi.DeviceIndex}}{{end}}" claimed="true" class="network" handle="PCI:0000:00:03.0">
        <description>Ethernet interface</description>
        <product>82540EM Gigabit Ethernet Controller</product>
-       <logicalname>{{$n}}</logicalname>
-       <serial>{{$m}}</serial>
+       <logicalname>{{$ifi.InterfaceName}}</logicalname>
+       <serial>{{$mac}}</serial>
       </node>{{end}}
     </node>
   </node>
@@ -175,7 +175,7 @@ const lshwXMLTemplate = `
 </list>
 `
 
-func (suite *environSuite) generateHWTemplate(netMacs map[string]string) (string, error) {
+func (suite *environSuite) generateHWTemplate(netMacs map[string]ifaceInfo) (string, error) {
 	tmpl, err := template.New("test").Parse(lshwXMLTemplate)
 	if err != nil {
 		return "", err
@@ -196,7 +196,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 		`{"system_id": "node0", "hostname": "host0", "architecture": "%s/generic", "memory": 1024, "cpu_count": 1}`,
 		version.Current.Arch),
 	)
-	lshwXML, err := suite.generateHWTemplate(map[string]string{"aa:bb:cc:dd:ee:f0": "eth0"})
+	lshwXML, err := suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f0": {0, "eth0"}})
 	c.Assert(err, gc.IsNil)
 	suite.testMAASObject.TestServer.AddNodeDetails("node0", lshwXML)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
@@ -222,7 +222,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 		`{"system_id": "node1", "hostname": "host1", "architecture": "%s/generic", "memory": 1024, "cpu_count": 1}`,
 		version.Current.Arch),
 	)
-	lshwXML, err = suite.generateHWTemplate(map[string]string{"aa:bb:cc:dd:ee:f1": "eth0"})
+	lshwXML, err = suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f1": {0, "eth0"}})
 	c.Assert(err, gc.IsNil)
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
 	instance, hc := testing.AssertStartInstance(c, env, "1")
@@ -563,7 +563,7 @@ func (suite *environSuite) TestBootstrapSucceeds(c *gc.C) {
 		`{"system_id": "thenode", "hostname": "host", "architecture": "%s/generic", "memory": 256, "cpu_count": 8}`,
 		version.Current.Arch),
 	)
-	lshwXML, err := suite.generateHWTemplate(map[string]string{"aa:bb:cc:dd:ee:f0": "eth0"})
+	lshwXML, err := suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f0": {0, "eth0"}})
 	c.Assert(err, gc.IsNil)
 	suite.testMAASObject.TestServer.AddNodeDetails("thenode", lshwXML)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
@@ -714,18 +714,18 @@ const lshwXMLTestExtractInterfaces = `
     <node id="cpu" claimed="true" class="processor" handle="DMI:0004">
      <description>CPU</description>
       <node id="pci:2" claimed="true" class="bridge" handle="PCIBUS:0000:03">
-        <node id="network" claimed="true" class="network" handle="PCI:0000:03:00.0">
+        <node id="network:0" claimed="true" class="network" handle="PCI:0000:03:00.0">
          <logicalname>wlan0</logicalname>
          <serial>aa:bb:cc:dd:ee:ff</serial>
         </node>
-        <node id="network" claimed="true" class="network" handle="PCI:0000:04:00.0">
+        <node id="network:1" claimed="true" class="network" handle="PCI:0000:04:00.0">
          <logicalname>eth0</logicalname>
          <serial>aa:bb:cc:dd:ee:f1</serial>
         </node>
       </node>
     </node>
   </node>
-  <node id="network:0" claimed="true" class="network" handle="">
+  <node id="network:2" claimed="true" class="network" handle="">
    <logicalname>vnet1</logicalname>
    <serial>aa:bb:cc:dd:ee:f2</serial>
   </node>
@@ -735,37 +735,39 @@ const lshwXMLTestExtractInterfaces = `
 
 func (suite *environSuite) TestExtractInterfaces(c *gc.C) {
 	inst := suite.getInstance("testInstance")
-	interfaces, err := extractInterfaces(inst, []byte(lshwXMLTestExtractInterfaces))
+	interfaces, primaryIface, err := extractInterfaces(inst, []byte(lshwXMLTestExtractInterfaces))
 	c.Assert(err, gc.IsNil)
-	c.Check(interfaces, jc.DeepEquals, map[string]string{
-		"aa:bb:cc:dd:ee:ff": "wlan0",
-		"aa:bb:cc:dd:ee:f1": "eth0",
-		"aa:bb:cc:dd:ee:f2": "vnet1",
+	c.Check(primaryIface, gc.Equals, "wlan0")
+	c.Check(interfaces, jc.DeepEquals, map[string]ifaceInfo{
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
 	})
 }
 
 func (suite *environSuite) TestGetInstanceNetworkInterfaces(c *gc.C) {
 	inst := suite.getInstance("testInstance")
-	templateInterfaces := map[string]string{
-		"aa:bb:cc:dd:ee:ff": "wlan0",
-		"aa:bb:cc:dd:ee:f1": "eth0",
-		"aa:bb:cc:dd:ee:f2": "vnet1",
+	templateInterfaces := map[string]ifaceInfo{
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
 	}
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, gc.IsNil)
 
 	suite.testMAASObject.TestServer.AddNodeDetails("testInstance", lshwXML)
-	interfaces, err := inst.environ.getInstanceNetworkInterfaces(inst)
+	interfaces, primaryIface, err := inst.environ.getInstanceNetworkInterfaces(inst)
 	c.Assert(err, gc.IsNil)
+	c.Check(primaryIface, gc.Equals, "wlan0")
 	c.Check(interfaces, jc.DeepEquals, templateInterfaces)
 }
 
 func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 	test_instance := suite.getInstance("node1")
-	templateInterfaces := map[string]string{
-		"aa:bb:cc:dd:ee:ff": "wlan0",
-		"aa:bb:cc:dd:ee:f1": "eth0",
-		"aa:bb:cc:dd:ee:f2": "vnet1",
+	templateInterfaces := map[string]ifaceInfo{
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
 	}
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, gc.IsNil)
@@ -777,10 +779,14 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f2")
 	suite.getNetwork("WLAN", 1, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
-	networkInfo, err := suite.makeEnviron().setupNetworks(test_instance, set.NewStrings("LAN", "Virt"))
+	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
+		test_instance,
+		set.NewStrings("WLAN"), // Disable WLAN only.
+	)
 	c.Assert(err, gc.IsNil)
 
 	// Note: order of networks is based on lshwXML
+	c.Check(primaryIface, gc.Equals, "wlan0")
 	c.Check(networkInfo, jc.SameContents, []network.Info{
 		network.Info{
 			MACAddress:    "aa:bb:cc:dd:ee:ff",
@@ -788,6 +794,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			NetworkName:   "WLAN",
 			ProviderId:    "WLAN",
 			VLANTag:       0,
+			DeviceIndex:   0,
 			InterfaceName: "wlan0",
 			Disabled:      true,
 		},
@@ -797,6 +804,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			NetworkName:   "LAN",
 			ProviderId:    "LAN",
 			VLANTag:       42,
+			DeviceIndex:   1,
 			InterfaceName: "eth0",
 			Disabled:      false,
 		},
@@ -806,6 +814,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			NetworkName:   "Virt",
 			ProviderId:    "Virt",
 			VLANTag:       0,
+			DeviceIndex:   2,
 			InterfaceName: "vnet1",
 			Disabled:      false,
 		},
@@ -815,10 +824,10 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 // The same test, but now "Virt" network does not have matched MAC address
 func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	test_instance := suite.getInstance("node1")
-	templateInterfaces := map[string]string{
-		"aa:bb:cc:dd:ee:ff": "wlan0",
-		"aa:bb:cc:dd:ee:f1": "eth0",
-		"aa:bb:cc:dd:ee:f2": "vnet1",
+	templateInterfaces := map[string]ifaceInfo{
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
 	}
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, gc.IsNil)
@@ -828,10 +837,14 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
 	suite.getNetwork("Virt", 3, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f3")
-	networkInfo, err := suite.makeEnviron().setupNetworks(test_instance, set.NewStrings("LAN"))
+	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
+		test_instance,
+		set.NewStrings(), // All enabled.
+	)
 	c.Assert(err, gc.IsNil)
 
 	// Note: order of networks is based on lshwXML
+	c.Check(primaryIface, gc.Equals, "wlan0")
 	c.Check(networkInfo, jc.SameContents, []network.Info{
 		network.Info{
 			MACAddress:    "aa:bb:cc:dd:ee:f1",
@@ -839,6 +852,7 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 			NetworkName:   "LAN",
 			ProviderId:    "LAN",
 			VLANTag:       42,
+			DeviceIndex:   1,
 			InterfaceName: "eth0",
 			Disabled:      false,
 		},
@@ -848,10 +862,10 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 // The same test, but now no networks have matched MAC
 func (suite *environSuite) TestSetupNetworksNoMatch(c *gc.C) {
 	test_instance := suite.getInstance("node1")
-	templateInterfaces := map[string]string{
-		"aa:bb:cc:dd:ee:ff": "wlan0",
-		"aa:bb:cc:dd:ee:f1": "eth0",
-		"aa:bb:cc:dd:ee:f2": "vnet1",
+	templateInterfaces := map[string]ifaceInfo{
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
 	}
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, gc.IsNil)
@@ -859,10 +873,14 @@ func (suite *environSuite) TestSetupNetworksNoMatch(c *gc.C) {
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
 	suite.getNetwork("Virt", 3, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f3")
-	networkInfo, err := suite.makeEnviron().setupNetworks(test_instance, set.NewStrings("Virt"))
+	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
+		test_instance,
+		set.NewStrings(), // All enabled.
+	)
 	c.Assert(err, gc.IsNil)
 
 	// Note: order of networks is based on lshwXML
+	c.Check(primaryIface, gc.Equals, "wlan0")
 	c.Check(networkInfo, gc.HasLen, 0)
 }
 
@@ -986,7 +1004,7 @@ func (s *environSuite) newNode(c *gc.C, nodename, hostname string, attrs map[str
 	data, err := json.Marshal(allAttrs)
 	c.Assert(err, gc.IsNil)
 	s.testMAASObject.TestServer.NewNode(string(data))
-	lshwXML, err := s.generateHWTemplate(map[string]string{"aa:bb:cc:dd:ee:f0": "eth0"})
+	lshwXML, err := s.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f0": {0, "eth0"}})
 	c.Assert(err, gc.IsNil)
 	s.testMAASObject.TestServer.AddNodeDetails(nodename, lshwXML)
 }


### PR DESCRIPTION
This PR aims to address a number of bugs all related to LXC or
KVM containers on MAAS nodes not getting IP addresses, got stuck
in "pending" or failed to start due to networking issues:
- http://pad.lv/1368976
- http://pad.lv/1271144
- http://pad.lv/1386189
- http://pad.lv/1340261
- http://pad.lv/1386575
- http://pad.lv/1345433

Most of the issues arise from the way Juju creates a "br0" bridge
device and attaches the "eth0" interface on the machine to it, so
containers can use DHCP to acquire an IP address from MAAS. However,
after lots of testing the following fixes and changes were done:
- Removed the "network-bridge" MAAS environment setting (introduced
  in #227). This setting has a misleading name (it's supposed to
  allow users to pick which network interface on the machine to
  attach to the bridge, not the name of the bridge itself) and
  cannot work as intended (machines have different network interfaces
  in general). The impact of this change should be minimal, as it
  was never used properly.
- A few changes made to common.Bootstrap and cloudinit.FinishMachineConfig.
  BootstrapParams struct now has a "ContainersBridgeName" field. When
  set, it will cause the LXC_BRIDGE setting in the agent config on the
  bootstrap node to have the given value. Because the LXC_BRIDGE setting
  is used to determine the network bridge name for starting both LXC and
  KVM containers, setting ContainersBridgeName at bootstrap time (as the
  MAAS provider does now) will override the silent defaults otherwise
  used ("lxcbr0" for LXC and "virbr0" for KVM containers).
- MAAS provider changes simplified the generated cloudinit scripts (e.g.
  do not try to "restore" network interfaces file before adding the
  bridge config), a single "juju-br0" bridge is created and set to get
  an address using DHCP from the machine's primary network interface.
- Added code to discover the primary NIC from the lshw data MAAS holds.
  This should work in most cases, including with more complex networking
  setup per node (e.g. using custom preseed or commissioning scripts).
- I discovered the networker worker is not starting for machines deployed
  after bootstrap due to a missing JobManageNetworking (see DeployService
  and AddUnits), but that's fine because it was interfering with the bridge
  network config generated at cloudinit time.
  So, as a temporary measure, no JobManangeNetworking will be added to the
  bootstrap nodes by default and the networker will only work in "safe mode".

I spend the last 3 days extensively testing the changes with live environments
on MAAS, EC2, and local, to ensure no regressions are introduced and both
LXC and KVM containers get proper addresses on MAAS.
