### PR TITLE
provider/ec2: try next AZ on "no default subnet" error

### DIFF
--- a/provider/ec2/ec2.go
+++ b/provider/ec2/ec2.go
@@ -1429,7 +1429,8 @@ func (m permSet) ipPerms() (ps []ec2.IPPerm) {
 
 // isZoneConstrainedError reports whether or not the error indicates
 // RunInstances failed due to the specified availability zone being
-// constrained for the instance type being provisioned.
+// constrained for the instance type being provisioned, or is
+// otherwise unusable for the specific request made.
 func isZoneConstrainedError(err error) bool {
 	switch err := err.(type) {
 	case *ec2.Error:
@@ -1440,6 +1441,11 @@ func isZoneConstrainedError(err error) bool {
 			// be. If the message contains "Availability Zone", it's a fair
 			// bet that it's constrained or otherwise unusable.
 			return strings.Contains(err.Message, "Availability Zone")
+		case "InvalidInput":
+			// If the region has a default VPC, then we will receive an error
+			// if the AZ does not have a default subnet. Until we have proper
+			// support for networks, we'll skip over these.
+			return strings.HasPrefix(err.Message, "No default subnet for availability zone")
 		}
 	}
 	return false

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -474,12 +474,21 @@ var azInsufficientInstanceCapacityErr = &amzec2.Error{
 		"us-east-1c, us-east-1a.",
 }
 
+var azNoDefaultSubnetErr = &amzec2.Error{
+	Code:    "InvalidInput",
+	Message: "No default subnet for availability zone: ''us-east-1e''.",
+}
+
 func (t *localServerSuite) TestStartInstanceAvailZoneAllConstrained(c *gc.C) {
 	t.testStartInstanceAvailZoneAllConstrained(c, azConstrainedErr)
 }
 
 func (t *localServerSuite) TestStartInstanceAvailZoneAllInsufficientInstanceCapacity(c *gc.C) {
 	t.testStartInstanceAvailZoneAllConstrained(c, azInsufficientInstanceCapacityErr)
+}
+
+func (t *localServerSuite) TestStartInstanceAvailZoneAllNoDefaultSubnet(c *gc.C) {
+	t.testStartInstanceAvailZoneAllConstrained(c, azNoDefaultSubnetErr)
 }
 
 func (t *localServerSuite) testStartInstanceAvailZoneAllConstrained(c *gc.C, runInstancesError *amzec2.Error) {
@@ -514,6 +523,10 @@ func (t *localServerSuite) TestStartInstanceAvailZoneOneConstrained(c *gc.C) {
 
 func (t *localServerSuite) TestStartInstanceAvailZoneOneInsufficientInstanceCapacity(c *gc.C) {
 	t.testStartInstanceAvailZoneOneConstrained(c, azInsufficientInstanceCapacityErr)
+}
+
+func (t *localServerSuite) TestStartInstanceAvailZoneOneNoDefaultSubnetErr(c *gc.C) {
+	t.testStartInstanceAvailZoneOneConstrained(c, azNoDefaultSubnetErr)
 }
 
 func (t *localServerSuite) testStartInstanceAvailZoneOneConstrained(c *gc.C, runInstancesError *amzec2.Error) {


### PR DESCRIPTION
If the account/region has a default VPC, but one of the
AZs lacks a default subnet, then Juju may get into a
situation where it cannot provision any instances
successfully. We handle the "no default subnet" error
just as we do constrained zones, by trying the next one.

Fixes https://bugs.launchpad.net/juju-core/+bug/1388860
