### PR TITLE
provider/ec2: try next AZ on "no default subnet" error (backport)

### DIFF
--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -473,12 +473,21 @@ var azInsufficientInstanceCapacityErr = &amzec2.Error{
 		"us-east-1c, us-east-1a.",
 }
 
+var azNoDefaultSubnetErr = &amzec2.Error{
+	Code:    "InvalidInput",
+	Message: "No default subnet for availability zone: ''us-east-1e''.",
+}
+
 func (t *localServerSuite) TestStartInstanceAvailZoneAllConstrained(c *gc.C) {
 	t.testStartInstanceAvailZoneAllConstrained(c, azConstrainedErr)
 }
 
 func (t *localServerSuite) TestStartInstanceAvailZoneAllInsufficientInstanceCapacity(c *gc.C) {
 	t.testStartInstanceAvailZoneAllConstrained(c, azInsufficientInstanceCapacityErr)
+}
+
+func (t *localServerSuite) TestStartInstanceAvailZoneAllNoDefaultSubnet(c *gc.C) {
+	t.testStartInstanceAvailZoneAllConstrained(c, azNoDefaultSubnetErr)
 }
 
 func (t *localServerSuite) testStartInstanceAvailZoneAllConstrained(c *gc.C, runInstancesError *amzec2.Error) {
@@ -513,6 +522,10 @@ func (t *localServerSuite) TestStartInstanceAvailZoneOneConstrained(c *gc.C) {
 
 func (t *localServerSuite) TestStartInstanceAvailZoneOneInsufficientInstanceCapacity(c *gc.C) {
 	t.testStartInstanceAvailZoneOneConstrained(c, azInsufficientInstanceCapacityErr)
+}
+
+func (t *localServerSuite) TestStartInstanceAvailZoneOneNoDefaultSubnetErr(c *gc.C) {
+	t.testStartInstanceAvailZoneOneConstrained(c, azNoDefaultSubnetErr)
 }
 
 func (t *localServerSuite) testStartInstanceAvailZoneOneConstrained(c *gc.C, runInstancesError *amzec2.Error) {


### PR DESCRIPTION
(backport to 1.21)

If the account/region has a default VPC, but one of the
AZs lacks a default subnet, then Juju may get into a
situation where it cannot provision any instances
successfully. We handle the "no default subnet" error
just as we do constrained zones, by trying the next one.

Fixes https://bugs.launchpad.net/juju-core/+bug/1388860
