### PR TITLE
Merge pull request #1066 from wallyworld/validate-joyent-credentials

### DIFF
--- a/provider/joyent/config_test.go
+++ b/provider/joyent/config_test.go
@@ -30,12 +30,12 @@ func newConfig(c *gc.C, attrs coretesting.Attrs) *config.Config {
 func validAttrs() coretesting.Attrs {
 	return coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"type":             "joyent",
-		"sdc-user":         "juju-test",
+		"sdc-user":         "test",
 		"sdc-key-id":       "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
-		"sdc-url":          "https://test.api.joyentcloud.com",
-		"manta-user":       "juju-test",
+		"sdc-url":          "test://test.api.joyentcloud.com",
+		"manta-user":       "test",
 		"manta-key-id":     "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
-		"manta-url":        "https://test.manta.joyent.com",
+		"manta-url":        "test://test.manta.joyent.com",
 		"private-key-path": "~/.ssh/provider_id_rsa",
 		"algorithm":        "rsa-sha256",
 		"control-dir":      "juju-test",
@@ -61,6 +61,8 @@ func (s *ConfigSuite) SetUpSuite(c *gc.C) {
 	restoreMantaKeyId := testing.PatchEnvironment(jp.MantaKeyId, "ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00")
 	s.AddSuiteCleanup(func(*gc.C) { restoreMantaKeyId() })
 	s.privateKeyData = generatePrivateKey(c)
+	jp.RegisterMachinesEndpoint()
+	s.AddSuiteCleanup(func(*gc.C) { jp.UnregisterMachinesEndpoint() })
 }
 
 func generatePrivateKey(c *gc.C) string {
@@ -135,15 +137,15 @@ var newConfigTests = []struct {
 	},
 }, {
 	info:   "sdc-url is inserted if missing",
-	expect: coretesting.Attrs{"sdc-url": "https://test.api.joyentcloud.com"},
+	expect: coretesting.Attrs{"sdc-url": "test://test.api.joyentcloud.com"},
 }, {
 	info:   "sdc-url cannot be empty",
 	insert: coretesting.Attrs{"sdc-url": ""},
 	err:    ".* cannot get sdc-url value from environment variable .*",
 }, {
 	info:   "sdc-url is untouched if present",
-	insert: coretesting.Attrs{"sdc-url": "https://test.api.joyentcloud.com"},
-	expect: coretesting.Attrs{"sdc-url": "https://test.api.joyentcloud.com"},
+	insert: coretesting.Attrs{"sdc-url": "test://test.api.joyentcloud.com"},
+	expect: coretesting.Attrs{"sdc-url": "test://test.api.joyentcloud.com"},
 }, {
 	info:   "manta-user is required",
 	remove: []string{"manta-user"},
@@ -190,15 +192,15 @@ var newConfigTests = []struct {
 	},
 }, {
 	info:   "manta-url is inserted if missing",
-	expect: coretesting.Attrs{"manta-url": "https://test.manta.joyent.com"},
+	expect: coretesting.Attrs{"manta-url": "test://test.manta.joyent.com"},
 }, {
 	info:   "manta-url cannot be empty",
 	insert: coretesting.Attrs{"manta-url": ""},
 	err:    ".* cannot get manta-url value from environment variable .*",
 }, {
 	info:   "manta-url is untouched if present",
-	insert: coretesting.Attrs{"manta-url": "https://test.manta.joyent.com"},
-	expect: coretesting.Attrs{"manta-url": "https://test.manta.joyent.com"},
+	insert: coretesting.Attrs{"manta-url": "test://test.manta.joyent.com"},
+	expect: coretesting.Attrs{"manta-url": "test://test.manta.joyent.com"},
 }, {
 	info:   "private-key-path is inserted if missing",
 	remove: []string{"private-key-path"},
@@ -275,8 +277,8 @@ var changeConfigTests = []struct {
 	expect: coretesting.Attrs{"sdc-key-id": "ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00"},
 }, {
 	info:   "can change sdc-url",
-	insert: coretesting.Attrs{"sdc-url": "https://test.api.joyentcloud.com"},
-	expect: coretesting.Attrs{"sdc-url": "https://test.api.joyentcloud.com"},
+	insert: coretesting.Attrs{"sdc-url": "test://test.api.joyentcloud.com"},
+	expect: coretesting.Attrs{"sdc-url": "test://test.api.joyentcloud.com"},
 }, {
 	info:   "can change manta-user",
 	insert: coretesting.Attrs{"manta-user": "manta_user"},
@@ -287,8 +289,8 @@ var changeConfigTests = []struct {
 	expect: coretesting.Attrs{"manta-key-id": "ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00"},
 }, {
 	info:   "can change manta-url",
-	insert: coretesting.Attrs{"manta-url": "https://test.manta.joyent.com"},
-	expect: coretesting.Attrs{"manta-url": "https://test.manta.joyent.com"},
+	insert: coretesting.Attrs{"manta-url": "test://test.manta.joyent.com"},
+	expect: coretesting.Attrs{"manta-url": "test://test.manta.joyent.com"},
 }, {
 	info:   "can insert unknown field",
 	insert: coretesting.Attrs{"unknown": "ignoti"},

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -164,6 +164,20 @@ func UnregisterExternalTestImageMetadata() {
 	imagemetadata.DefaultBaseURL = origImagesUrl
 }
 
+// RegisterMachinesEndpoint creates a fake endpoint so that
+// machines api calls succeed.
+func RegisterMachinesEndpoint() {
+	files := map[string]string{
+		"/test/machines": "",
+	}
+	testRoundTripper.Sub = jujutest.NewCannedRoundTripper(files, nil)
+}
+
+// UnregisterMachinesEndpoint resets the machines endpoint.
+func UnregisterMachinesEndpoint() {
+	testRoundTripper.Sub = nil
+}
+
 func FindInstanceSpec(e environs.Environ, series, arch, cons string) (spec *instances.InstanceSpec, err error) {
 	env := e.(*joyentEnviron)
 	spec, err = env.FindInstanceSpec(&instances.InstanceConstraint{

--- a/provider/joyent/storage_test.go
+++ b/provider/joyent/storage_test.go
@@ -36,6 +36,8 @@ var _ = gc.Suite(&storageSuite{})
 func (s *storageSuite) SetUpSuite(c *gc.C) {
 	s.providerSuite.SetUpSuite(c)
 	s.localMantaServer.setupServer(c)
+	jp.RegisterMachinesEndpoint()
+	s.AddSuiteCleanup(func(*gc.C) { jp.UnregisterMachinesEndpoint() })
 }
 
 func (s *storageSuite) TearDownSuite(c *gc.C) {
@@ -45,7 +47,7 @@ func (s *storageSuite) TearDownSuite(c *gc.C) {
 
 // makeStorage creates a Manta storage object for the running test.
 func (s *storageSuite) makeStorage(name string, c *gc.C) *jp.JoyentStorage {
-	stor := joyent.MakeStorage(c, GetFakeConfig("localhost", s.localMantaServer.Server.URL))
+	stor := joyent.MakeStorage(c, GetFakeConfig("test://test.api.joyentcloud.com", s.localMantaServer.Server.URL))
 	return stor.(*jp.JoyentStorage)
 }
 


### PR DESCRIPTION
Validate creedentials are correct before attempting to bootstrap a joyent environment

Partially fixes: https://bugs.launchpad.net/bugs/1362072

In a similar vein to what was done for ec2 etc, validate joyent credentials prior to bootstrapping.

Tested live.
