### PR TITLE
Modified PowerShell Charm resources dir

### DIFF
--- a/worker/uniter/context/env.go
+++ b/worker/uniter/context/env.go
@@ -65,12 +65,10 @@ func ubuntuEnv(paths Paths) []string {
 // a semicolon instead of a colon
 func windowsEnv(paths Paths) []string {
 	charmDir := paths.GetCharmDir()
-	// TODO(fwereade, gsamfira): if anything we should just use <charm>/lib/Modules
-	charmModules := filepath.Join(charmDir, "Modules")
-	hookModules := filepath.Join(charmDir, "hooks", "Modules")
+	charmModules := filepath.Join(charmDir, "lib", "Modules")
 	return []string{
 		"Path=" + paths.GetToolsDir() + ";" + os.Getenv("Path"),
-		"PSModulePath=" + os.Getenv("PSModulePath") + ";" + charmModules + ";" + hookModules,
+		"PSModulePath=" + os.Getenv("PSModulePath") + ";" + charmModules,
 	}
 }
 

--- a/worker/uniter/context/env_test.go
+++ b/worker/uniter/context/env_test.go
@@ -5,6 +5,7 @@ package context_test
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
 
 	envtesting "github.com/juju/testing"
@@ -58,9 +59,9 @@ func (s *EnvSuite) assertVars(c *gc.C, actual []string, expect ...[]string) {
 func (s *EnvSuite) getPaths() (paths context.Paths, expectVars []string) {
 	// note: path-munging is os-dependent, not included in expectVars
 	return MockEnvPaths{}, []string{
-		"CHARM_DIR=/path/to/charm",
-		"JUJU_CHARM_DIR=/path/to/charm",
-		"JUJU_AGENT_SOCKET=/path/to/jujuc.socket",
+		"CHARM_DIR=path-to-charm",
+		"JUJU_CHARM_DIR=path-to-charm",
+		"JUJU_AGENT_SOCKET=path-to-jujuc.socket",
 	}
 }
 
@@ -114,8 +115,8 @@ func (s *EnvSuite) TestEnvWindows(c *gc.C) {
 	os.Setenv("Path", "foo;bar")
 	os.Setenv("PSModulePath", "ping;pong")
 	windowsVars := []string{
-		"Path=/path/to/tools;foo;bar",
-		"PSModulePath=ping;pong;/path/to/charm/Modules;/path/to/charm/hooks/Modules",
+		"Path=path-to-tools;foo;bar",
+		"PSModulePath=ping;pong;" + filepath.FromSlash("path-to-charm/lib/Modules"),
 	}
 
 	ctx, contextVars := s.getContext()
@@ -132,7 +133,7 @@ func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 	s.PatchValue(&version.Current.OS, version.Ubuntu)
 	os.Setenv("PATH", "foo:bar")
 	ubuntuVars := []string{
-		"PATH=/path/to/tools:foo:bar",
+		"PATH=path-to-tools:foo:bar",
 		"APT_LISTCHANGES_FRONTEND=none",
 		"DEBIAN_FRONTEND=noninteractive",
 	}

--- a/worker/uniter/context/util_test.go
+++ b/worker/uniter/context/util_test.go
@@ -33,15 +33,15 @@ var expectedApiAddrs = strings.Join(apiAddrs, " ")
 type MockEnvPaths struct{}
 
 func (MockEnvPaths) GetToolsDir() string {
-	return "/path/to/tools"
+	return "path-to-tools"
 }
 
 func (MockEnvPaths) GetCharmDir() string {
-	return "/path/to/charm"
+	return "path-to-charm"
 }
 
 func (MockEnvPaths) GetJujucSocket() string {
-	return "/path/to/jujuc.socket"
+	return "path-to-jujuc.socket"
 }
 
 // RealPaths implements Paths for tests that do touch the filesystem.


### PR DESCRIPTION
Now all supporting modules for the PowerShell Juju Charms will be located under $env:JUJU_CHARM_DIR\lib\Modules\
