### PR TITLE
Fixes go vet errors:

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -25,7 +25,12 @@ func Audit(user Tagger, format string, args ...interface{}) {
 	if user.Tag() == "" {
 		panic("user tag cannot be blank")
 	}
+
+	// go vet thinks that the third parameter of aliasFn should be a string constant.
+	// fixes error message: "audit/audit.go:30: constant 3 not a string in call to Logf"
+	var aliasFn func(loggo.Level, string, ...interface{}) = logger.Logf
+
 	// Logf is called directly, rather than Infof so that the caller of Audit is
 	// recorded, not Audit itself.
-	logger.Logf(loggo.INFO, fmt.Sprintf("%s: %s", user.Tag(), format), args...)
+	aliasFn(loggo.INFO, fmt.Sprintf("%s: %s", user.Tag(), format), args...)
 }

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -162,7 +162,7 @@ func FinishMachineConfig(mcfg *cloudinit.MachineConfig, cfg *config.Config) (err
 	if isStateMachineConfig(mcfg) {
 		// Add NUMACTL preference. Needed to work for both bootstrap and high availability
 		// Only makes sense for state server
-		logger.Debugf("Setting numa ctl preference to %q", cfg.NumaCtlPreference())
+		logger.Debugf("Setting numa ctl preference to %t", cfg.NumaCtlPreference())
 		// Unfortunately, AgentEnvironment can only take strings as values
 		mcfg.AgentEnvironment[agent.NumaCtlPreference] = fmt.Sprintf("%v", cfg.NumaCtlPreference())
 	}


### PR DESCRIPTION
```
audit/audit.go:30: constant 3 not a string in call to Logf
environs/cloudinit.go:165: arg cfg.NumaCtlPreference() for printf verb %q of wrong type: bool
```
