### PR TITLE
Merge pull request #1090 from wallyworld/unit-public-address-ec2

### DIFF
--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -162,7 +162,7 @@ func FinishMachineConfig(mcfg *cloudinit.MachineConfig, cfg *config.Config) (err
 	if isStateMachineConfig(mcfg) {
 		// Add NUMACTL preference. Needed to work for both bootstrap and high availability
 		// Only makes sense for state server
-		logger.Debugf("Setting numa ctl preference to %q", cfg.NumaCtlPreference())
+		logger.Debugf("Setting numa ctl preference to %v", cfg.NumaCtlPreference())
 		// Unfortunately, AgentEnvironment can only take strings as values
 		mcfg.AgentEnvironment[agent.NumaCtlPreference] = fmt.Sprintf("%v", cfg.NumaCtlPreference())
 	}

--- a/provider/ec2/ec2.go
+++ b/provider/ec2/ec2.go
@@ -137,27 +137,8 @@ func (inst *ec2Instance) refresh() (*ec2.Instance, error) {
 func (inst *ec2Instance) Addresses() ([]network.Address, error) {
 	// TODO(gz): Stop relying on this requerying logic, maybe remove error
 	instInstance := inst.getInstance()
-	if instInstance.DNSName == "" {
-		// Fetch the instance information again, in case
-		// the DNS information has become available.
-		var err error
-		instInstance, err = inst.refresh()
-		if err != nil {
-			return nil, err
-		}
-	}
 	var addresses []network.Address
 	possibleAddresses := []network.Address{
-		{
-			Value: instInstance.DNSName,
-			Type:  network.HostName,
-			Scope: network.ScopePublic,
-		},
-		{
-			Value: instInstance.PrivateDNSName,
-			Type:  network.HostName,
-			Scope: network.ScopeCloudLocal,
-		},
 		{
 			Value: instInstance.IPAddress,
 			Type:  network.IPv4Address,

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -123,7 +123,7 @@ func (t *LiveTests) TestInstanceAttributes(c *gc.C) {
 	c.Assert(len(insts), gc.Equals, 1)
 
 	ec2inst := ec2.InstanceEC2(insts[0])
-	c.Assert(ec2inst.DNSName, gc.Equals, addresses[0].Value)
+	c.Assert(ec2inst.IPAddress, gc.Equals, addresses[0].Value)
 	c.Assert(ec2inst.InstanceType, gc.Equals, "m1.small")
 }
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -567,14 +567,6 @@ func (t *localServerSuite) TestAddresses(c *gc.C) {
 	// Expected values use Address type but really contain a regexp for
 	// the value rather than a valid ip or hostname.
 	expected := []network.Address{{
-		Value: "*.testing.invalid",
-		Type:  network.HostName,
-		Scope: network.ScopePublic,
-	}, {
-		Value: "*.internal.invalid",
-		Type:  network.HostName,
-		Scope: network.ScopeCloudLocal,
-	}, {
 		Value: "8.0.0.*",
 		Type:  network.IPv4Address,
 		Scope: network.ScopePublic,


### PR DESCRIPTION
Unit public address ec2

Fixes: https://bugs.launchpad.net/bugs/1308374

The EC2 provider waits for the instance to advertise its DNS name, and when it does, it inserts this as a public address against the machine.
The unit's get public address method looks at the slice of machine addresses recorded and picks the first public one. If the DNS name is available before the first public IP address is recorded, this will be printed as the public address. So you sometimes get an IP address, sometimes a DNS name.

People want to get just IP addresses for unit's public/private addresses. So the EC2 provider recording of DNS name has been removed. This means that the juju status dns-name value will show an ip address, but that's what happens for HP Cloud and some other providers anyway, and we also want to get rid of dns-name.

Also a drive by fix for a go vet issue.
