### PR TITLE
state: fixes LP #1391046

### DIFF
--- a/state/action_test.go
+++ b/state/action_test.go
@@ -360,7 +360,7 @@ func (s *ActionSuite) TestMergeIds(c *gc.C) {
 		c.Log(fmt.Sprintf("test number %d %#v", ix, test))
 		err := state.WatcherMergeIds(s.State, &changes, updates)
 		c.Assert(err, gc.IsNil)
-		c.Assert(changes, jc.DeepEquals, expected)
+		c.Assert(changes, jc.SameContents, expected)
 	}
 }
 


### PR DESCRIPTION
The godoc for state.mergeIds states they come from a map, and are then passed through a set, so there is no guarentee of ordering. Adjust the test to match reality.
