### PR TITLE
Refactor InstanceBroker.StartInstance to return result struct

### DIFF
--- a/environs/broker.go
+++ b/environs/broker.go
@@ -39,6 +39,20 @@ type StartInstanceParams struct {
 	DistributionGroup func() ([]instance.Id, error)
 }
 
+// StartInstanceResult holds the result of an
+// InstanceBroker.StartInstance method call.
+type StartInstanceResult struct {
+	// Instance is an interface representing a cloud instance.
+	Instance instance.Instance
+
+	// HardwareCharacteristics represents the hardware characteristics
+	// of the newly created instance.
+	Hardware *instance.HardwareCharacteristics
+
+	// NetworkInfo contains information about configured networks.
+	NetworkInfo []network.Info
+}
+
 // TODO(wallyworld) - we want this in the environs/instance package but import loops
 // stop that from being possible right now.
 type InstanceBroker interface {
@@ -48,7 +62,7 @@ type InstanceBroker interface {
 	// unique within an environment, is used by juju to protect against the
 	// consequences of multiple instances being started with the same machine
 	// id.
-	StartInstance(args StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error)
+	StartInstance(args StartInstanceParams) (*StartInstanceResult, error)
 
 	// StopInstances shuts down the instances with the specified IDs.
 	// Unknown instance IDs are ignored, to enable idempotency.

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -731,15 +731,15 @@ func (t *LiveTests) TestStartInstanceWithEmptyNonceFails(c *gc.C) {
 
 	t.PrepareOnce(c)
 	possibleTools := envtesting.AssertUploadFakeToolsVersions(c, t.toolsStorage, "released", "released", version.MustParseBinary("5.4.5-trusty-amd64"))
-	inst, _, _, err := t.Env.StartInstance(environs.StartInstanceParams{
+	result, err := t.Env.StartInstance(environs.StartInstanceParams{
 		Tools:         possibleTools,
 		MachineConfig: machineConfig,
 	})
-	if inst != nil {
-		err := t.Env.StopInstances(inst.Id())
+	if result != nil && result.Instance != nil {
+		err := t.Env.StopInstances(result.Instance.Id())
 		c.Check(err, gc.IsNil)
 	}
-	c.Assert(inst, gc.IsNil)
+	c.Assert(result, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, ".*missing machine nonce")
 }
 

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -185,5 +185,10 @@ func StartInstanceWithParams(
 	}
 	params.Tools = possibleTools
 	params.MachineConfig = machineConfig
-	return env.StartInstance(params)
+	// TODO(axw) refactor these test helpers to return StartInstanceResult
+	result, err := env.StartInstance(params)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return result.Instance, result.Hardware, result.NetworkInfo, nil
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1515,12 +1515,13 @@ func (s *startInstanceSuite) startInstance(c *gc.C) (serviceName string, stateSe
 		return nil, nil
 	})
 	defer restore()
-	_, hardware, _, err := s.env.StartInstance(s.params)
+	result, err := s.env.StartInstance(s.params)
 	c.Assert(err, gc.IsNil)
 	c.Assert(called, jc.IsTrue)
-	c.Assert(hardware, gc.NotNil)
+	c.Assert(result, gc.NotNil)
+	c.Assert(result.Hardware, gc.NotNil)
 	arch := "amd64"
-	c.Assert(hardware, gc.DeepEquals, &instance.HardwareCharacteristics{
+	c.Assert(result.Hardware, gc.DeepEquals, &instance.HardwareCharacteristics{
 		Arch:     &arch,
 		Mem:      &roleSize.Mem,
 		RootDisk: &roleSize.OSDiskSpace,
@@ -1534,7 +1535,7 @@ func (s *startInstanceSuite) TestStartInstanceDistributionGroupError(c *gc.C) {
 		return nil, fmt.Errorf("DistributionGroupError")
 	}
 	s.env.ecfg.attrs["availability-sets-enabled"] = true
-	_, _, _, err := s.env.StartInstance(s.params)
+	_, err := s.env.StartInstance(s.params)
 	c.Assert(err, gc.ErrorMatches, "DistributionGroupError")
 	// DistributionGroup should not be called if availability-sets-enabled=false.
 	s.env.ecfg.attrs["availability-sets-enabled"] = false

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -47,13 +47,22 @@ func (env *mockEnviron) Storage() storage.Storage {
 func (env *mockEnviron) AllInstances() ([]instance.Instance, error) {
 	return env.allInstances()
 }
-func (env *mockEnviron) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
-	return env.startInstance(
+func (env *mockEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+	inst, hw, networkInfo, err := env.startInstance(
 		args.Placement,
 		args.Constraints,
 		args.MachineConfig.Networks,
 		args.Tools,
-		args.MachineConfig)
+		args.MachineConfig,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &environs.StartInstanceResult{
+		Instance:    inst,
+		Hardware:    hw,
+		NetworkInfo: networkInfo,
+	}, nil
 }
 
 func (env *mockEnviron) StopInstances(ids ...instance.Id) error {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -23,7 +23,6 @@
 package dummy
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -33,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/schema"
@@ -809,17 +809,17 @@ func (e *environ) ConstraintsValidator() (constraints.Validator, error) {
 }
 
 // StartInstance is specified in the InstanceBroker interface.
-func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
+func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 
 	defer delay()
 	machineId := args.MachineConfig.MachineId
 	logger.Infof("dummy startinstance, machine %s", machineId)
 	if err := e.checkBroken("StartInstance"); err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	estate, err := e.state()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	estate.mu.Lock()
 	defer estate.mu.Unlock()
@@ -827,21 +827,21 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 	// check if an error has been injected on the transientErrorInjection channel (testing purposes)
 	select {
 	case injectedError := <-transientErrorInjection:
-		return nil, nil, nil, injectedError
+		return nil, injectedError
 	default:
 	}
 
 	if args.MachineConfig.MachineNonce == "" {
-		return nil, nil, nil, fmt.Errorf("cannot start instance: missing machine nonce")
+		return nil, errors.New("cannot start instance: missing machine nonce")
 	}
 	if _, ok := e.Config().CACert(); !ok {
-		return nil, nil, nil, fmt.Errorf("no CA certificate in environment configuration")
+		return nil, errors.New("no CA certificate in environment configuration")
 	}
 	if args.MachineConfig.MongoInfo.Tag != names.NewMachineTag(machineId) {
-		return nil, nil, nil, fmt.Errorf("entity tag must match started machine")
+		return nil, errors.New("entity tag must match started machine")
 	}
 	if args.MachineConfig.APIInfo.Tag != names.NewMachineTag(machineId) {
-		return nil, nil, nil, fmt.Errorf("entity tag must match started machine")
+		return nil, errors.New("entity tag must match started machine")
 	}
 	logger.Infof("would pick tools from %s", args.Tools)
 	series := args.Tools.OneSeries()
@@ -932,7 +932,11 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		APIInfo:       args.MachineConfig.APIInfo,
 		Secret:        e.ecfg().secret(),
 	}
-	return i, hc, networkInfo, nil
+	return &environs.StartInstanceResult{
+		Instance:    i,
+		Hardware:    hc,
+		NetworkInfo: networkInfo,
+	}, nil
 }
 
 func (e *environ) StopInstances(ids ...instance.Id) error {

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -82,10 +82,10 @@ func (env *joyentEnviron) ConstraintsValidator() (constraints.Validator, error) 
 	return validator, nil
 }
 
-func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
+func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 
 	if args.MachineConfig.HasNetworks() {
-		return nil, nil, nil, errors.New("starting instances with networks is not supported yet")
+		return nil, errors.New("starting instances with networks is not supported yet")
 	}
 
 	series := args.Tools.OneSeries()
@@ -97,27 +97,27 @@ func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (inst
 		Constraints: args.Constraints,
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	tools, err := args.Tools.Match(tools.Filter{Arch: spec.Image.Arch})
 	if err != nil {
-		return nil, nil, nil, errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
+		return nil, errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
 	}
 
 	args.MachineConfig.Tools = tools[0]
 
 	if err := environs.FinishMachineConfig(args.MachineConfig, env.Config()); err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	userData, err := environs.ComposeUserData(args.MachineConfig, nil)
 	if err != nil {
-		return nil, nil, nil, errors.Annotate(err, "cannot make user data")
+		return nil, errors.Annotate(err, "cannot make user data")
 	}
 
 	// Unzipping as Joyent API expects it as string
 	userData, err = utils.Gunzip(userData)
 	if err != nil {
-		return nil, nil, nil, errors.Annotate(err, "cannot make user data")
+		return nil, errors.Annotate(err, "cannot make user data")
 	}
 	logger.Debugf("joyent user data: %d bytes", len(userData))
 
@@ -130,7 +130,7 @@ func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (inst
 		Tags:     map[string]string{"tag.group": "juju", "tag.env": env.Config().Name()},
 	})
 	if err != nil {
-		return nil, nil, nil, errors.Annotate(err, "cannot create instances")
+		return nil, errors.Annotate(err, "cannot create instances")
 	}
 	machineId := machine.Id
 
@@ -138,7 +138,7 @@ func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (inst
 
 	machine, err = env.compute.cloudapi.GetMachine(machineId)
 	if err != nil {
-		return nil, nil, nil, errors.Annotate(err, "cannot start instances")
+		return nil, errors.Annotate(err, "cannot start instances")
 	}
 
 	// wait for machine to start
@@ -147,7 +147,7 @@ func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (inst
 
 		machine, err = env.compute.cloudapi.GetMachine(machineId)
 		if err != nil {
-			return nil, nil, nil, errors.Annotate(err, "cannot start instances")
+			return nil, errors.Annotate(err, "cannot start instances")
 		}
 	}
 
@@ -173,7 +173,10 @@ func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (inst
 		RootDisk: &disk64,
 	}
 
-	return inst, &hc, nil, nil
+	return &environs.StartInstanceResult{
+		Instance: inst,
+		Hardware: &hc,
+	}, nil
 }
 
 func (env *joyentEnviron) AllInstances() ([]instance.Instance, error) {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -720,14 +720,14 @@ var availabilityZoneAllocations = common.AvailabilityZoneAllocations
 
 // StartInstance is specified in the InstanceBroker interface.
 func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
-	instance.Instance, *instance.HardwareCharacteristics, []network.Info, error,
+	*environs.StartInstanceResult, error,
 ) {
 	var availabilityZones []string
 	var nodeName string
 	if args.Placement != "" {
 		placement, err := environ.parsePlacement(args.Placement)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 		switch {
 		case placement.zoneName != "":
@@ -746,7 +746,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		if args.DistributionGroup != nil {
 			group, err = args.DistributionGroup()
 			if err != nil {
-				return nil, nil, nil, errors.Annotate(err, "cannot get distribution group")
+				return nil, errors.Annotate(err, "cannot get distribution group")
 			}
 		}
 		zoneInstances, err := availabilityZoneAllocations(environ, group)
@@ -754,7 +754,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 			// Availability zones are an extension, so we may get a
 			// not implemented error; ignore these.
 		} else if err != nil {
-			return nil, nil, nil, errors.Annotate(err, "cannot get availability zone allocations")
+			return nil, errors.Annotate(err, "cannot get availability zone allocations")
 		} else if len(zoneInstances) > 0 {
 			for _, z := range zoneInstances {
 				availabilityZones = append(availabilityZones, z.ZoneName)
@@ -786,7 +786,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 			}
 		}
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("cannot run instances: %v", err)
+			return nil, fmt.Errorf("cannot run instances: %v", err)
 		}
 	}
 
@@ -801,26 +801,26 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 
 	hc, err := inst.hardwareCharacteristics()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	selectedTools, err := args.Tools.Match(tools.Filter{
 		Arch: *hc.Arch,
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	args.MachineConfig.Tools = selectedTools[0]
 
 	var networkInfo []network.Info
 	networkInfo, primaryIface, err := environ.setupNetworks(inst, set.NewStrings(excludeNetworks...))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	hostname, err := inst.hostname()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	// Override the network bridge to use for both LXC and KVM
 	// containers on the new instance.
@@ -829,23 +829,23 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	}
 	args.MachineConfig.AgentEnvironment[agent.LxcBridge] = environs.DefaultBridgeName
 	if err := environs.FinishMachineConfig(args.MachineConfig, environ.Config()); err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	series := args.MachineConfig.Tools.Version.Series
 
 	cloudcfg, err := environ.newCloudinitConfig(hostname, primaryIface, series)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	userdata, err := environs.ComposeUserData(args.MachineConfig, cloudcfg)
 	if err != nil {
 		msg := fmt.Errorf("could not compose userdata for bootstrap node: %v", err)
-		return nil, nil, nil, msg
+		return nil, msg
 	}
 	logger.Debugf("maas user data; %d bytes", len(userdata))
 
 	if err := environ.startNode(*inst.maasObject, series, userdata); err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	logger.Debugf("started instance %q", inst.Id())
 
@@ -855,7 +855,11 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		}
 	}
 
-	return inst, hc, networkInfo, nil
+	return &environs.StartInstanceResult{
+		Instance:    inst,
+		Hardware:    hc,
+		NetworkInfo: networkInfo,
+	}, nil
 }
 
 // newCloudinitConfig creates a cloudinit.Config structure

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -68,8 +68,8 @@ type manualEnviron struct {
 var errNoStartInstance = errors.New("manual provider cannot start instances")
 var errNoStopInstance = errors.New("manual provider cannot stop instances")
 
-func (*manualEnviron) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
-	return nil, nil, nil, errNoStartInstance
+func (*manualEnviron) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+	return nil, errNoStartInstance
 }
 
 func (*manualEnviron) StopInstances(...instance.Id) error {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -944,15 +944,15 @@ func (e *environ) DistributeInstances(candidates, distributionGroup []instance.I
 var availabilityZoneAllocations = common.AvailabilityZoneAllocations
 
 // StartInstance is specified in the InstanceBroker interface.
-func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
+func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	var availabilityZones []string
 	if args.Placement != "" {
 		placement, err := e.parsePlacement(args.Placement)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 		if !placement.availabilityZone.State.Available {
-			return nil, nil, nil, fmt.Errorf("availability zone %q is unavailable", placement.availabilityZone.Name)
+			return nil, fmt.Errorf("availability zone %q is unavailable", placement.availabilityZone.Name)
 		}
 		availabilityZones = append(availabilityZones, placement.availabilityZone.Name)
 	}
@@ -966,7 +966,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		if args.DistributionGroup != nil {
 			group, err = args.DistributionGroup()
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, err
 			}
 		}
 		zoneInstances, err := availabilityZoneAllocations(e, group)
@@ -974,7 +974,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 			// Availability zones are an extension, so we may get a
 			// not implemented error; ignore these.
 		} else if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		} else {
 			for _, zone := range zoneInstances {
 				availabilityZones = append(availabilityZones, zone.ZoneName)
@@ -987,7 +987,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 	}
 
 	if args.MachineConfig.HasNetworks() {
-		return nil, nil, nil, fmt.Errorf("starting instances with networks is not supported yet.")
+		return nil, fmt.Errorf("starting instances with networks is not supported yet.")
 	}
 
 	series := args.Tools.OneSeries()
@@ -999,21 +999,21 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		Constraints: args.Constraints,
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	tools, err := args.Tools.Match(tools.Filter{Arch: spec.Image.Arch})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
+		return nil, fmt.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
 	}
 
 	args.MachineConfig.Tools = tools[0]
 
 	if err := environs.FinishMachineConfig(args.MachineConfig, e.Config()); err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	userData, err := environs.ComposeUserData(args.MachineConfig, nil)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("cannot make user data: %v", err)
+		return nil, fmt.Errorf("cannot make user data: %v", err)
 	}
 	logger.Debugf("openstack user data; %d bytes", len(userData))
 	var networks = []nova.ServerNetworks{}
@@ -1021,7 +1021,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 	if usingNetwork != "" {
 		networkId, err := e.resolveNetwork(usingNetwork)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 		logger.Debugf("using network id %q", networkId)
 		networks = append(networks, nova.ServerNetworks{NetworkId: networkId})
@@ -1031,7 +1031,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 	if withPublicIP {
 		logger.Debugf("allocating public IP address for openstack node")
 		if fip, err := e.allocatePublicIP(); err != nil {
-			return nil, nil, nil, fmt.Errorf("cannot allocate a public IP as needed: %v", err)
+			return nil, fmt.Errorf("cannot allocate a public IP as needed: %v", err)
 		} else {
 			publicIP = fip
 			logger.Infof("allocated public IP %s", publicIP.IP)
@@ -1040,7 +1040,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 	cfg := e.Config()
 	groups, err := e.setUpGroups(args.MachineConfig.MachineId, cfg.APIPort())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("cannot set up groups: %v", err)
+		return nil, fmt.Errorf("cannot set up groups: %v", err)
 	}
 	var groupNames = make([]nova.SecurityGroupName, len(groups))
 	for i, g := range groups {
@@ -1070,11 +1070,11 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		}
 	}
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("cannot run instance: %v", err)
+		return nil, fmt.Errorf("cannot run instance: %v", err)
 	}
 	detail, err := e.nova().GetServer(server.Id)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("cannot get started instance: %v", err)
+		return nil, fmt.Errorf("cannot get started instance: %v", err)
 	}
 	inst := &openstackInstance{
 		e:            e,
@@ -1089,7 +1089,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 				// ignore the failure at this stage, just log it
 				logger.Debugf("failed to terminate instance %q: %v", inst.Id(), err)
 			}
-			return nil, nil, nil, fmt.Errorf("cannot assign public address %s to instance %q: %v", publicIP.IP, inst.Id(), err)
+			return nil, fmt.Errorf("cannot assign public address %s to instance %q: %v", publicIP.IP, inst.Id(), err)
 		}
 		inst.floatingIP = publicIP
 		logger.Infof("assigned public IP %s to %q", publicIP.IP, inst.Id())
@@ -1099,7 +1099,10 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 			logger.Errorf("could not record instance in provider-state: %v", err)
 		}
 	}
-	return inst, inst.hardwareCharacteristics(), nil, nil
+	return &environs.StartInstanceResult{
+		Instance: inst,
+		Hardware: inst.hardwareCharacteristics(),
+	}, nil
 }
 
 func isNoValidHostsError(err error) bool {

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -92,13 +92,13 @@ func (s *kvmBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
-	kvm, _, _, err := s.broker.StartInstance(environs.StartInstanceParams{
+	result, err := s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:   cons,
 		Tools:         possibleTools,
 		MachineConfig: machineConfig,
 	})
 	c.Assert(err, gc.IsNil)
-	return kvm
+	return result.Instance
 }
 
 func (s *kvmBrokerSuite) TestStopInstance(c *gc.C) {

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -94,13 +94,13 @@ func (s *lxcBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
-	lxc, _, _, err := s.broker.StartInstance(environs.StartInstanceParams{
+	result, err := s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:   cons,
 		Tools:         possibleTools,
 		MachineConfig: machineConfig,
 	})
 	c.Assert(err, gc.IsNil)
-	return lxc
+	return result.Instance
 }
 
 func (s *lxcBrokerSuite) TestStartInstance(c *gc.C) {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -566,15 +566,14 @@ func (task *provisionerTask) startMachine(
 	startInstanceParams environs.StartInstanceParams,
 ) error {
 
-	inst, metadata, networkInfo, err := task.broker.StartInstance(startInstanceParams)
+	result, err := task.broker.StartInstance(startInstanceParams)
 	if err != nil {
 		// If this is a retryable error, we retry once
 		if instance.IsRetryableCreationError(errors.Cause(err)) {
-			logger.Infof("retryable error received on start instance - retrying instance creation.")
-			var derr error
-			inst, metadata, networkInfo, derr = task.broker.StartInstance(startInstanceParams)
-			if derr != nil {
-				return task.setErrorStatus("cannot start instance for machine after a retry %q: %v", machine, derr)
+			logger.Infof("retryable error received on start instance - retrying instance creation")
+			result, err = task.broker.StartInstance(startInstanceParams)
+			if err != nil {
+				return task.setErrorStatus("cannot start instance for machine after a retry %q: %v", machine, err)
 			}
 		} else {
 			// Set the state to error, so the machine will be skipped next
@@ -584,14 +583,16 @@ func (task *provisionerTask) startMachine(
 		}
 	}
 
+	inst := result.Instance
+	hardware := result.Hardware
 	nonce := startInstanceParams.MachineConfig.MachineNonce
-	networks, ifaces := task.prepareNetworkAndInterfaces(networkInfo)
+	networks, ifaces := task.prepareNetworkAndInterfaces(result.NetworkInfo)
 
-	err = machine.SetInstanceInfo(inst.Id(), nonce, metadata, networks, ifaces)
+	err = machine.SetInstanceInfo(inst.Id(), nonce, hardware, networks, ifaces)
 	if err != nil && params.IsCodeNotImplemented(err) {
 		return fmt.Errorf("cannot provision instance %v for machine %q with networks: not implemented", inst.Id(), machine)
 	} else if err == nil {
-		logger.Infof("started machine %s as instance %s with hardware %q, networks %v, interfaces %v", machine, inst.Id(), metadata, networks, ifaces)
+		logger.Infof("started machine %s as instance %s with hardware %q, networks %v, interfaces %v", machine, inst.Id(), hardware, networks, ifaces)
 		return nil
 	}
 	// We need to stop the instance right away here, set error status and go on.

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1228,7 +1228,7 @@ type mockBroker struct {
 	ids        []string
 }
 
-func (b *mockBroker) StartInstance(args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
+func (b *mockBroker) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	// All machines except machines 3, 4 are provisioned successfully the first time.
 	// Machines 3 is provisioned after some attempts have been made.
 	// Machine 4 is never provisioned.
@@ -1241,7 +1241,7 @@ func (b *mockBroker) StartInstance(args environs.StartInstanceParams) (instance.
 	} else {
 		b.retryCount[id] = retries + 1
 	}
-	return nil, nil, nil, fmt.Errorf("error: some error")
+	return nil, fmt.Errorf("error: some error")
 }
 
 type mockToolsFinder struct {


### PR DESCRIPTION
StartInstance will soon need to grow another result for
reporting back block devices allocated to a provisioned
instance. Rather than having to touch every bit of code
each time we expand the set, use a result struct.
