### PR TITLE
Merge pull request #1095 from voidspace/maas-1381619

### DIFF
--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -512,6 +512,16 @@ func (suite *environSuite) TestStopInstancesStopsAndReleasesInstances(c *gc.C) {
 	c.Assert(suite.testMAASObject.TestServer.OwnedNodes()["test2"], jc.IsFalse)
 }
 
+func (suite *environSuite) TestStopInstancesIgnoresConflict(c *gc.C) {
+	releaseNodes := func(nodes gomaasapi.MAASObject, ids url.Values) error {
+		return gomaasapi.ServerError{StatusCode: 409}
+	}
+	suite.PatchValue(&ReleaseNodes, releaseNodes)
+	env := suite.makeEnviron()
+	err := env.StopInstances("test1")
+	c.Assert(err, gc.IsNil)
+}
+
 func (suite *environSuite) TestStateServerInstances(c *gc.C) {
 	env := suite.makeEnviron()
 	_, err := env.StateServerInstances()


### PR DESCRIPTION
Ignore conflict error when releasing maas nodes

When releasing a node that is not in a releasable status, i.e. typically is already released, maas returns an error 409. Instead of dying and refusing to destroy environment we now ignore that error.

Error 409 is only used for a limited set of statuses, so this seems like safe behaviour. See: https://bugs.launchpad.net/maas/+bug/1381619/comments/15

Fixes bug 1381619.
