### PR TITLE
Introducing intermediate types for storing charm data.

### DIFF
--- a/state/charm.go
+++ b/state/charm.go
@@ -14,10 +14,10 @@ type charmDoc struct {
 	DocID   string     `bson:"_id"`
 	URL     *charm.URL `bson:"url"`
 	EnvUUID string     `bson:"env-uuid"`
-	Meta    *charm.Meta
-	Config  *charm.Config
-	Actions *charm.Actions
-	Metrics *charm.Metrics
+	Meta    *charmMeta
+	Config  *charmConfig
+	Actions *charmActions
+	Metrics *charmMetrics
 
 	// DEPRECATED: BundleURL is deprecated, and exists here
 	// only for migration purposes. We should remove this
@@ -44,9 +44,9 @@ func newCharm(st *State, cdoc *charmDoc) *Charm {
 		unescapedConfig := charm.NewConfig()
 		for optionName, option := range cdoc.Config.Options {
 			unescapedName := unescapeReplacer.Replace(optionName)
-			unescapedConfig.Options[unescapedName] = option
+			unescapedConfig.Options[unescapedName] = option.convert()
 		}
-		cdoc.Config = unescapedConfig
+		cdoc.Config = storeCharmConfig(unescapedConfig)
 	}
 	return &Charm{st: st, doc: *cdoc}
 }
@@ -69,22 +69,34 @@ func (c *Charm) Revision() int {
 
 // Meta returns the metadata of the charm.
 func (c *Charm) Meta() *charm.Meta {
-	return c.doc.Meta
+	if c.doc.Meta == nil {
+		return nil
+	}
+	return c.doc.Meta.convert()
 }
 
 // Config returns the configuration of the charm.
 func (c *Charm) Config() *charm.Config {
-	return c.doc.Config
+	if c.doc.Config == nil {
+		return nil
+	}
+	return c.doc.Config.convert()
 }
 
 // Metrics returns the metrics declared for the charm.
 func (c *Charm) Metrics() *charm.Metrics {
-	return c.doc.Metrics
+	if c.doc.Metrics == nil {
+		return nil
+	}
+	return c.doc.Metrics.convert()
 }
 
 // Actions returns the actions definition of the charm.
 func (c *Charm) Actions() *charm.Actions {
-	return c.doc.Actions
+	if c.doc.Actions == nil {
+		return nil
+	}
+	return c.doc.Actions.convert()
 }
 
 // StoragePath returns the storage path of the charm bundle.

--- a/state/charm_storage.go
+++ b/state/charm_storage.go
@@ -1,0 +1,305 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"gopkg.in/juju/charm.v4"
+)
+
+// charmMeta is an intermediate field used to store charm.Meta data,
+// decoupling the storage from the charm package.
+type charmMeta struct {
+	Name        string
+	Summary     string
+	Description string
+	Subordinate bool
+	Provides    map[string]charmRelation `bson:",omitempty"`
+	Requires    map[string]charmRelation `bson:",omitempty"`
+	Peers       map[string]charmRelation `bson:",omitempty"`
+	Format      int                      `bson:",omitempty"`
+	OldRevision int                      `bson:",omitempty"` // Obsolete
+	Categories  []string                 `bson:",omitempty"`
+	Tags        []string                 `bson:",omitempty"`
+	Series      string                   `bson:",omitempty"`
+}
+
+func storeCharmMeta(original *charm.Meta) *charmMeta {
+	if original == nil {
+		return nil
+	}
+	var provides map[string]charmRelation
+	if len(original.Provides) > 0 {
+		provides = make(map[string]charmRelation, len(original.Provides))
+		for key, rel := range original.Provides {
+			provides[key] = storeCharmRelation(rel)
+		}
+	}
+	var requires map[string]charmRelation
+	if len(original.Requires) > 0 {
+		requires = make(map[string]charmRelation, len(original.Requires))
+		for key, rel := range original.Requires {
+			requires[key] = storeCharmRelation(rel)
+		}
+	}
+	var peers map[string]charmRelation
+	if len(original.Peers) > 0 {
+		peers = make(map[string]charmRelation, len(original.Peers))
+		for key, rel := range original.Peers {
+			peers[key] = storeCharmRelation(rel)
+		}
+	}
+	return &charmMeta{
+		Name:        original.Name,
+		Summary:     original.Summary,
+		Description: original.Description,
+		Subordinate: original.Subordinate,
+		Provides:    provides,
+		Requires:    requires,
+		Peers:       peers,
+		Format:      original.Format,
+		OldRevision: original.OldRevision,
+		Categories:  original.Categories,
+		Tags:        original.Tags,
+		Series:      original.Series,
+	}
+}
+
+// convert converts the intermediate structure to the original charm.Meta representation.
+func (cm charmMeta) convert() *charm.Meta {
+	var provides map[string]charm.Relation
+	if len(cm.Provides) > 0 {
+		provides = make(map[string]charm.Relation, len(cm.Provides))
+		for key, rel := range cm.Provides {
+			provides[key] = rel.convert()
+		}
+	}
+	var requires map[string]charm.Relation
+	if len(cm.Requires) > 0 {
+		requires = make(map[string]charm.Relation, len(cm.Requires))
+		for key, rel := range cm.Requires {
+			requires[key] = rel.convert()
+		}
+	}
+	var peers map[string]charm.Relation
+	if len(cm.Peers) > 0 {
+		peers = make(map[string]charm.Relation, len(cm.Peers))
+		for key, rel := range cm.Peers {
+			peers[key] = rel.convert()
+		}
+	}
+	return &charm.Meta{
+		Name:        cm.Name,
+		Summary:     cm.Summary,
+		Description: cm.Description,
+		Subordinate: cm.Subordinate,
+		Provides:    provides,
+		Requires:    requires,
+		Peers:       peers,
+		Format:      cm.Format,
+		OldRevision: cm.OldRevision,
+		Categories:  cm.Categories,
+		Tags:        cm.Tags,
+		Series:      cm.Series,
+	}
+}
+
+// charmMeta is an intermediate field used to store charm.Meta data,
+// decoupling the storage from the charm package.
+type charmRelation struct {
+	Name      string
+	Role      string
+	Interface string
+	Optional  bool
+	Limit     int
+	Scope     string
+}
+
+func storeCharmRelation(original charm.Relation) charmRelation {
+	return charmRelation{
+		Name:      original.Name,
+		Role:      string(original.Role),
+		Interface: original.Interface,
+		Optional:  original.Optional,
+		Limit:     original.Limit,
+		Scope:     string(original.Scope),
+	}
+}
+
+// convert converts the intermediate structure to the original charm.Relation structure.
+func (cr charmRelation) convert() charm.Relation {
+	return charm.Relation{
+		Name:      cr.Name,
+		Role:      charm.RelationRole(cr.Role),
+		Interface: cr.Interface,
+		Optional:  cr.Optional,
+		Limit:     cr.Limit,
+		Scope:     charm.RelationScope(cr.Scope),
+	}
+}
+
+// charmConfig is an intermediate field used to store charm.Config data.
+type charmConfig struct {
+	Options map[string]charmOption
+}
+
+func storeCharmConfig(original *charm.Config) *charmConfig {
+	if original == nil {
+		return nil
+	}
+
+	options := make(map[string]charmOption, len(original.Options))
+	for key, option := range original.Options {
+		options[key] = storeCharmOption(option)
+	}
+
+	return &charmConfig{Options: options}
+}
+
+func (cc charmConfig) convert() *charm.Config {
+	options := make(map[string]charm.Option, len(cc.Options))
+	for key, option := range cc.Options {
+		options[key] = option.convert()
+	}
+
+	return &charm.Config{Options: options}
+}
+
+// charmOption is an intermediate field used to store charm.Option data.
+type charmOption struct {
+	Type        string
+	Description string
+	Default     interface{}
+}
+
+func storeCharmOption(original charm.Option) charmOption {
+	return charmOption{
+		Type:        original.Type,
+		Description: original.Description,
+		Default:     original.Default,
+	}
+}
+
+func (co charmOption) convert() charm.Option {
+	return charm.Option{
+		Type:        co.Type,
+		Description: co.Description,
+		Default:     co.Default,
+	}
+}
+
+// charmActions is an intermediate structure for storing charm.Actions data.
+type charmActions struct {
+	ActionSpecs map[string]charmActionSpec `yaml:"actions,omitempty" bson:",omitempty"`
+}
+
+func storeCharmActions(original *charm.Actions) *charmActions {
+	if original == nil {
+		return nil
+	}
+	var actionSpecs map[string]charmActionSpec
+	if original.ActionSpecs != nil {
+		actionSpecs = make(map[string]charmActionSpec, len(original.ActionSpecs))
+		for key, actionSpec := range original.ActionSpecs {
+			actionSpecs[key] = storeCharmActionSpec(actionSpec)
+		}
+	}
+	return &charmActions{ActionSpecs: actionSpecs}
+}
+
+func (ca *charmActions) convert() *charm.Actions {
+	var actionSpecs map[string]charm.ActionSpec
+	if ca.ActionSpecs != nil {
+		actionSpecs = make(map[string]charm.ActionSpec, len(ca.ActionSpecs))
+		for key, actionSpec := range ca.ActionSpecs {
+			actionSpecs[key] = actionSpec.convert()
+		}
+	}
+	return &charm.Actions{
+		ActionSpecs: actionSpecs,
+	}
+}
+
+// charmActionSpec is an intermediate structure for storing charm.ActionSpec data.
+type charmActionSpec struct {
+	Description string
+	Params      map[string]interface{}
+}
+
+func storeCharmActionSpec(original charm.ActionSpec) charmActionSpec {
+	params := make(map[string]interface{}, len(original.Params))
+	for key, param := range original.Params {
+		params[key] = param
+	}
+	return charmActionSpec{
+		Description: original.Description,
+		Params:      params,
+	}
+}
+
+func (cas charmActionSpec) convert() charm.ActionSpec {
+	params := make(map[string]interface{}, len(cas.Params))
+	for key, param := range cas.Params {
+		params[key] = param
+	}
+	return charm.ActionSpec{
+		Description: cas.Description,
+		Params:      params,
+	}
+
+}
+
+// charmMetrics is an intermediate type for storing charm.Metrics data.
+type charmMetrics struct {
+	Metrics map[string]charmMetric
+}
+
+func storeCharmMetrics(original *charm.Metrics) *charmMetrics {
+	if original == nil {
+		return nil
+	}
+	var metrics map[string]charmMetric
+	if original.Metrics != nil {
+		metrics = make(map[string]charmMetric, len(original.Metrics))
+		for key, metric := range original.Metrics {
+			metrics[key] = storeCharmMetric(metric)
+		}
+	}
+	return &charmMetrics{
+		Metrics: metrics,
+	}
+}
+
+func (cm charmMetrics) convert() *charm.Metrics {
+	var metrics map[string]charm.Metric
+	if cm.Metrics != nil {
+		metrics = make(map[string]charm.Metric, len(cm.Metrics))
+		for key, metric := range cm.Metrics {
+			metrics[key] = metric.convert()
+		}
+	}
+	return &charm.Metrics{
+		Metrics: metrics,
+	}
+
+}
+
+// charmMetric is an intermediate type for storing charm.Metric data.
+type charmMetric struct {
+	Type        string
+	Description string
+}
+
+func storeCharmMetric(original charm.Metric) charmMetric {
+	return charmMetric{
+		Type:        string(original.Type),
+		Description: original.Description,
+	}
+}
+
+func (cm charmMetric) convert() charm.Metric {
+	return charm.Metric{
+		Type:        charm.MetricType(cm.Type),
+		Description: cm.Description,
+	}
+}

--- a/state/charm_storage_test.go
+++ b/state/charm_storage_test.go
@@ -1,0 +1,88 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testcharms"
+)
+
+type CharmStorageSuite struct{}
+
+var _ = gc.Suite(&CharmStorageSuite{})
+
+func (*CharmStorageSuite) TestMetaStorage(c *gc.C) {
+	chd := testcharms.Repo.CharmDir("mysql")
+	meta := chd.Meta()
+	c.Assert(meta, gc.NotNil)
+
+	stored := state.StoreCharmMeta(meta)
+	c.Assert(stored, gc.NotNil)
+
+	metaRestored := stored.Convert()
+	c.Assert(metaRestored, gc.DeepEquals, meta)
+}
+
+func (*CharmStorageSuite) TestNilMetaStorage(c *gc.C) {
+	var meta *charm.Meta
+	stored := state.StoreCharmMeta(meta)
+	c.Assert(stored, gc.IsNil)
+}
+
+func (*CharmStorageSuite) TestConfigStorage(c *gc.C) {
+	chd := testcharms.Repo.CharmDir("mysql")
+	config := chd.Config()
+	c.Assert(config, gc.NotNil)
+
+	stored := state.StoreCharmConfig(config)
+	c.Assert(stored, gc.NotNil)
+
+	configRestored := stored.Convert()
+	c.Assert(configRestored, gc.DeepEquals, config)
+}
+
+func (*CharmStorageSuite) TestNilConfigStorage(c *gc.C) {
+	var config *charm.Config
+	stored := state.StoreCharmConfig(config)
+	c.Assert(stored, gc.IsNil)
+}
+
+func (*CharmStorageSuite) TestActionsStorage(c *gc.C) {
+	chd := testcharms.Repo.CharmDir("dummy")
+	actions := chd.Actions()
+	c.Assert(actions, gc.NotNil)
+
+	stored := state.StoreCharmActions(actions)
+	c.Assert(stored, gc.NotNil)
+
+	actionsRestored := stored.Convert()
+	c.Assert(actionsRestored, gc.DeepEquals, actions)
+}
+
+func (*CharmStorageSuite) TestNilActionsStorage(c *gc.C) {
+	var actions *charm.Actions
+	stored := state.StoreCharmActions(actions)
+	c.Assert(stored, gc.IsNil)
+}
+
+func (*CharmStorageSuite) TestMetricsStorage(c *gc.C) {
+	chd := testcharms.Repo.CharmDir("metered")
+	metrics := chd.Metrics()
+	c.Assert(metrics, gc.NotNil)
+
+	stored := state.StoreCharmMetrics(metrics)
+	c.Assert(stored, gc.NotNil)
+
+	metricsRestored := stored.Convert()
+	c.Assert(metricsRestored, gc.DeepEquals, metrics)
+}
+
+func (*CharmStorageSuite) TestNilMetricsStorage(c *gc.C) {
+	var metrics *charm.Metrics
+	stored := state.StoreCharmMetrics(metrics)
+	c.Assert(stored, gc.IsNil)
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -341,3 +341,71 @@ func SetServiceCharmURL(st *State, serviceName string, URL string) error {
 	}}
 	return errors.Trace(st.runTransaction(ops))
 }
+
+// CharmMeta wraps the private charmMeta type and exports its convert function.
+type CharmMeta struct {
+	charmMeta
+}
+
+func (m CharmMeta) Convert() *charm.Meta {
+	return m.charmMeta.convert()
+}
+
+func StoreCharmMeta(m *charm.Meta) *CharmMeta {
+	result := storeCharmMeta(m)
+	if result == nil {
+		return nil
+	}
+	return &CharmMeta{*result}
+}
+
+// CharmConfig wraps the private charmConfig type and exports its convert function.
+type CharmConfig struct {
+	charmConfig
+}
+
+func (m CharmConfig) Convert() *charm.Config {
+	return m.charmConfig.convert()
+}
+
+func StoreCharmConfig(m *charm.Config) *CharmConfig {
+	result := storeCharmConfig(m)
+	if result == nil {
+		return nil
+	}
+	return &CharmConfig{*result}
+}
+
+// CharmActions wraps the private charmActions type and exports its convert function.
+type CharmActions struct {
+	charmActions
+}
+
+func (m CharmActions) Convert() *charm.Actions {
+	return m.charmActions.convert()
+}
+
+func StoreCharmActions(m *charm.Actions) *CharmActions {
+	result := storeCharmActions(m)
+	if result == nil {
+		return nil
+	}
+	return &CharmActions{*result}
+}
+
+// CharmMetrics wraps the private charmMetrics type and exports its convert function.
+type CharmMetrics struct {
+	charmMetrics
+}
+
+func (m CharmMetrics) Convert() *charm.Metrics {
+	return m.charmMetrics.convert()
+}
+
+func StoreCharmMetrics(m *charm.Metrics) *CharmMetrics {
+	result := storeCharmMetrics(m)
+	if result == nil {
+		return nil
+	}
+	return &CharmMetrics{*result}
+}

--- a/state/state.go
+++ b/state/state.go
@@ -687,10 +687,10 @@ func (st *State) AddCharm(ch charm.Charm, curl *charm.URL, storagePath, bundleSh
 			DocID:        st.docID(curl.String()),
 			URL:          curl,
 			EnvUUID:      st.EnvironTag().Id(),
-			Meta:         ch.Meta(),
-			Config:       ch.Config(),
-			Metrics:      ch.Metrics(),
-			Actions:      ch.Actions(),
+			Meta:         storeCharmMeta(ch.Meta()),
+			Config:       storeCharmConfig(ch.Config()),
+			Metrics:      storeCharmMetrics(ch.Metrics()),
+			Actions:      storeCharmActions(ch.Actions()),
 			BundleSha256: bundleSha256,
 			StoragePath:  storagePath,
 		}
@@ -737,7 +737,7 @@ func (st *State) Charm(curl *charm.URL) (*Charm, error) {
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get charm %q", curl)
 	}
-	if err := cdoc.Meta.Check(); err != nil {
+	if err := cdoc.Meta.convert().Check(); err != nil {
 		return nil, errors.Annotatef(err, "malformed charm metadata found in state")
 	}
 	return newCharm(st, cdoc), nil


### PR DESCRIPTION
The intermediate type for charm.Meta, charm.Config, charm.Actions and charm.Metrics
decouple the storage of charms in state from changes in the charm package.
