### PR TITLE
Fix temporal bug; adjust meaning of nowToTheSecond.

### DIFF
--- a/state/action_test.go
+++ b/state/action_test.go
@@ -66,7 +66,6 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 	name := "fakeaction"
 	params := map[string]interface{}{"outfile": "outfile.tar.bz2"}
 	before := state.NowToTheSecond()
-	later := before.Add(testing.LongWait)
 
 	// verify can add an Action
 	a, err := s.unit.AddAction(name, params)
@@ -84,9 +83,8 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 
 	// Enqueued time should be within a reasonable time of the beginning
 	// of the test
-	now := state.NowToTheSecond()
-	c.Check(action.Enqueued(), jc.TimeBetween(before, now))
-	c.Check(action.Enqueued(), jc.TimeBetween(before, later))
+	c.Assert(action.Enqueued().Sub(before) >= 0, jc.IsTrue)
+	c.Assert(action.Enqueued().Sub(before) < testing.LongWait, jc.IsTrue)
 }
 
 func (s *ActionSuite) TestAddActionAcceptsDuplicateNames(c *gc.C) {

--- a/state/user.go
+++ b/state/user.go
@@ -207,9 +207,9 @@ func (u *User) LastLogin() *time.Time {
 	return &result
 }
 
-// nowToTheSecond returns the current time in UTC to the nearest second.
+// nowToTheSecond returns the current time in UTC to the earliest second.
 func nowToTheSecond() time.Time {
-	return time.Now().Round(time.Second).UTC()
+	return time.Now().Truncate(time.Second).UTC()
 }
 
 // UpdateLastLogin sets the LastLogin time of the user to be now (to the

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -85,7 +85,7 @@ func (s *UserSuite) TestString(c *gc.C) {
 }
 
 func (s *UserSuite) TestUpdateLastLogin(c *gc.C) {
-	now := time.Now().Round(time.Second).UTC()
+	now := time.Now().Truncate(time.Second).UTC()
 	user := s.factory.MakeUser(c, nil)
 	err := user.UpdateLastLogin()
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
Changed action_test because TimeBetween excludes the boundary
conditions, and I don't want to resort to fiddling with changing
the time or pausing the tests to make sure the expected result is within
the boundary conditions.

Also the output of TimeBetween isn't really helpful in diagnosing the
test failures.

Changed nowToTheSecond because, in the tests, using time.Round() is
a little more unpredictable than time.Truncate(), and time.Truncate()
feels more consistent anyway.
