### PR TITLE
Merge pull request #1093 from dimitern/lp-1359714-juju-machine-id-for-charms

### DIFF
--- a/worker/uniter/context/env.go
+++ b/worker/uniter/context/env.go
@@ -29,6 +29,7 @@ func hookVars(context *HookContext, paths Paths) []string {
 		"JUJU_API_ADDRESSES="+strings.Join(context.apiAddrs, " "),
 		"JUJU_METER_STATUS="+context.meterStatus.code,
 		"JUJU_METER_INFO="+context.meterStatus.info,
+		"JUJU_MACHINE_ID="+context.assignedMachineTag.Id(),
 	)
 	if r, found := context.HookRelation(); found {
 		vars = append(vars,

--- a/worker/uniter/context/env_test.go
+++ b/worker/uniter/context/env_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/juju/names"
 	envtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/proxy"
@@ -93,6 +94,7 @@ func (s *EnvSuite) getContext() (ctx *context.HookContext, expectVars []string) 
 				Ftp:     "some-ftp-proxy",
 				NoProxy: "some-no-proxy",
 			},
+			names.NewMachineTag("42"),
 		), []string{
 			"JUJU_CONTEXT_ID=some-context-id",
 			"JUJU_ENV_UUID=env-uuid-deadbeef",
@@ -101,6 +103,7 @@ func (s *EnvSuite) getContext() (ctx *context.HookContext, expectVars []string) 
 			"JUJU_METER_STATUS=PURPLE",
 			"JUJU_METER_INFO=proceed with care",
 			"JUJU_API_ADDRESSES=he.re:12345 the.re:23456",
+			"JUJU_MACHINE_ID=42",
 			"http_proxy=some-http-proxy",
 			"HTTP_PROXY=some-http-proxy",
 			"https_proxy=some-https-proxy",

--- a/worker/uniter/context/export_test.go
+++ b/worker/uniter/context/export_test.go
@@ -74,6 +74,10 @@ func (c *HookContext) ActionData() *ActionData {
 	return c.actionData
 }
 
+func (c *HookContext) AssignedMachineTag() names.MachineTag {
+	return c.assignedMachineTag
+}
+
 func GetStubActionContext(in map[string]interface{}) *HookContext {
 	return &HookContext{
 		actionData: &ActionData{
@@ -148,6 +152,7 @@ func NewHookContext(
 func NewEnvironmentHookContext(
 	id, envUUID, envName, unitName, meterCode, meterInfo string,
 	apiAddresses []string, proxySettings proxy.Settings,
+	machineTag names.MachineTag,
 ) *HookContext {
 	return &HookContext{
 		id:            id,
@@ -160,7 +165,8 @@ func NewEnvironmentHookContext(
 			code: meterCode,
 			info: meterInfo,
 		},
-		relationId: -1,
+		relationId:         -1,
+		assignedMachineTag: machineTag,
 	}
 }
 

--- a/worker/uniter/context/factory.go
+++ b/worker/uniter/context/factory.go
@@ -160,16 +160,17 @@ func (f *factory) newId(name string) string {
 // coreContext creates a new context with all unspecialised fields filled in.
 func (f *factory) coreContext() (*HookContext, error) {
 	ctx := &HookContext{
-		unit:          f.unit,
-		state:         f.state,
-		uuid:          f.envUUID,
-		envName:       f.envName,
-		unitName:      f.unit.Name(),
-		serviceOwner:  f.ownerTag,
-		relations:     f.getContextRelations(),
-		relationId:    -1,
-		canAddMetrics: true,
-		pendingPorts:  make(map[PortRange]PortRangeInfo),
+		unit:               f.unit,
+		state:              f.state,
+		uuid:               f.envUUID,
+		envName:            f.envName,
+		unitName:           f.unit.Name(),
+		assignedMachineTag: f.machineTag,
+		serviceOwner:       f.ownerTag,
+		relations:          f.getContextRelations(),
+		relationId:         -1,
+		canAddMetrics:      true,
+		pendingPorts:       make(map[PortRange]PortRangeInfo),
 	}
 	if err := f.updateContext(ctx); err != nil {
 		return nil, err

--- a/worker/uniter/context/factory_test.go
+++ b/worker/uniter/context/factory_test.go
@@ -63,6 +63,7 @@ func (s *FactorySuite) getCache(relId int, unitName string) (params.RelationSett
 func (s *FactorySuite) AssertCoreContext(c *gc.C, ctx *context.HookContext) {
 	c.Assert(ctx.UnitName(), gc.Equals, "u/0")
 	c.Assert(ctx.OwnerTag(), gc.Equals, s.service.GetOwnerTag())
+	c.Assert(ctx.AssignedMachineTag(), jc.DeepEquals, names.NewMachineTag("0"))
 
 	expect, expectOK := s.unit.PrivateAddress()
 	actual, actualOK := ctx.PrivateAddress()


### PR DESCRIPTION
Fixed lp:1359714: JUJU_MACHINE_ID added to hook context

JUJU_MACHINE_ID is now available to charm hooks. It contains
the unit's assigned machine ID.
