### PR TITLE
Merge pull request #1078 from dimitern/lp-1307677

### DIFF
--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/container/kvm"
+	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider"
 	"github.com/juju/juju/provider/local"
 	"github.com/juju/juju/testing"
@@ -54,7 +57,30 @@ func localConfig(c *gc.C, extra map[string]interface{}) *config.Config {
 func (s *configSuite) TestDefaultNetworkBridge(c *gc.C) {
 	config := minimalConfig(c)
 	unknownAttrs := config.UnknownAttrs()
-	c.Assert(unknownAttrs["network-bridge"], gc.Equals, "lxcbr0")
+	c.Assert(unknownAttrs["container"], gc.Equals, "lxc")
+	c.Assert(unknownAttrs["network-bridge"], gc.Equals, "")
+}
+
+func (s *configSuite) TestDefaultNetworkBridgeForKVMContainers(c *gc.C) {
+	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+		"container": "kvm",
+	})
+	testConfig, err := config.New(config.NoDefaults, minAttrs)
+	c.Assert(err, gc.IsNil)
+	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
+	c.Check(containerType, gc.Equals, string(instance.KVM))
+	c.Check(bridgeName, gc.Equals, kvm.DefaultKvmBridge)
+}
+
+func (s *configSuite) TestDefaultNetworkBridgeForLXCContainers(c *gc.C) {
+	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+		"container": "lxc",
+	})
+	testConfig, err := config.New(config.NoDefaults, minAttrs)
+	c.Assert(err, gc.IsNil)
+	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
+	c.Check(containerType, gc.Equals, string(instance.LXC))
+	c.Check(bridgeName, gc.Equals, lxc.DefaultLxcBridge)
 }
 
 func (s *configSuite) TestSetNetworkBridge(c *gc.C) {
@@ -63,6 +89,8 @@ func (s *configSuite) TestSetNetworkBridge(c *gc.C) {
 	})
 	unknownAttrs := config.UnknownAttrs()
 	c.Assert(unknownAttrs["network-bridge"], gc.Equals, "br0")
+	_, bridgeName := local.ContainerAndBridge(c, config)
+	c.Check(bridgeName, gc.Equals, "br0")
 }
 
 func (s *configSuite) TestValidateConfig(c *gc.C) {
@@ -115,7 +143,6 @@ func (s *configSuite) TestBootstrapAsRoot(c *gc.C) {
 }
 
 func (s *configSuite) TestLocalDisablesUpgradesWhenCloning(c *gc.C) {
-
 	// Default config files set these to true.
 	testConfig := minimalConfig(c)
 	c.Check(testConfig.EnableOSRefreshUpdate(), gc.Equals, true)
@@ -135,7 +162,6 @@ func (s *configSuite) TestLocalDisablesUpgradesWhenCloning(c *gc.C) {
 
 // If settings are provided, don't overwrite with defaults.
 func (s *configSuite) TestLocalRespectsUpgradeSettings(c *gc.C) {
-
 	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
 		"lxc-clone":          true,
 		"enable-os-upgrades": true,

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -147,6 +147,7 @@ func (env *localEnviron) finishBootstrap(ctx environs.BootstrapContext, mcfg *cl
 		agent.Namespace:   env.config.namespace(),
 		agent.StorageDir:  env.config.storageDir(),
 		agent.StorageAddr: env.config.storageAddr(),
+		agent.LxcBridge:   env.config.networkBridge(),
 
 		// The local provider only supports a single state server,
 		// so we make the oplog size to a small value. This makes

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/params"
 	coreCloudinit "github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/constraints"
@@ -218,6 +219,7 @@ func (s *localJujuTestSuite) TestBootstrap(c *gc.C) {
 			c.Assert(cloudcfg.Packages(), gc.HasLen, 0)
 		}
 		c.Assert(mcfg.AgentEnvironment, gc.Not(gc.IsNil))
+		c.Assert(mcfg.AgentEnvironment[agent.LxcBridge], gc.Not(gc.Equals), "")
 		// local does not allow machine-0 to host units
 		c.Assert(mcfg.Jobs, gc.DeepEquals, []params.MachineJob{params.JobManageEnviron})
 		return nil

--- a/provider/local/export_test.go
+++ b/provider/local/export_test.go
@@ -45,6 +45,14 @@ func CheckDirs(c *gc.C, cfg *config.Config) []string {
 	}
 }
 
+// ContainerAndBridge returns the "container" and "network-bridge"
+// settings as seen by the local provider.
+func ContainerAndBridge(c *gc.C, cfg *config.Config) (string, string) {
+	localConfig, err := providerInstance.newConfig(cfg)
+	c.Assert(err, gc.IsNil)
+	return string(localConfig.container()), localConfig.networkBridge()
+}
+
 // MockAddressForInterface replaces the getAddressForInterface with a function
 // that returns a constant localhost ip address.
 func MockAddressForInterface() func() {


### PR DESCRIPTION
Fixed #1307677: Local provider network-bridge default respects container type

If "network-bridge" is not specified in environments.yaml for
a local environment, but "container" is explicitly given, this
PR changes the local provider to choose the correct default
network bridge name ("lxcbr0" or "virbr0").

Live tested.
