### PR TITLE
Merge pull request #1094 from dimitern/lp-1382709-openstack-instance-shutoff-not-respected

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -447,10 +447,10 @@ func (inst *openstackInstance) Addresses() ([]network.Address, error) {
 		return nil, err
 	}
 	var floatingIP string
-	if inst.floatingIP != nil {
+	if inst.floatingIP != nil && inst.floatingIP.IP != "" {
 		floatingIP = inst.floatingIP.IP
+		logger.Debugf("instance %v has floating IP address: %v", inst.Id(), floatingIP)
 	}
-	logger.Infof("instance %v has floating IP address: %v", inst.Id(), floatingIP)
 	return convertNovaAddresses(floatingIP, addresses), nil
 }
 
@@ -910,7 +910,7 @@ func (e *environ) allocatePublicIP() (*nova.FloatingIP, error) {
 		if err != nil {
 			return nil, err
 		}
-		logger.Debugf("allocated new public ip: %v", newfip.IP)
+		logger.Debugf("allocated new public IP: %v", newfip.IP)
 	}
 	return newfip, nil
 }
@@ -1167,7 +1167,7 @@ func (e *environ) collectInstances(ids []instance.Id, out map[string]instance.In
 		if server, found := serversById[string(id)]; found {
 			// HPCloud uses "BUILD(spawning)" as an intermediate BUILD states once networking is available.
 			switch server.Status {
-			case nova.StatusActive, nova.StatusBuild, nova.StatusBuildSpawning:
+			case nova.StatusActive, nova.StatusBuild, nova.StatusBuildSpawning, nova.StatusShutoff, nova.StatusSuspended:
 				// TODO(wallyworld): lookup the flavor details to fill in the instance type data
 				out[string(id)] = &openstackInstance{e: e, serverDetail: &server}
 				continue

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -254,7 +254,7 @@ func pollInstanceInfo(context machineContext, m machine) (instInfo instanceInfo,
 		instInfo.status = ""
 	} else {
 		if instInfo.status != currentInstStatus {
-			logger.Infof("machine %q has new instance status: %v", m.Id(), instInfo.status)
+			logger.Infof("machine %q instance status changed from %q to %q", m.Id(), currentInstStatus, instInfo.status)
 			if err = m.SetInstanceStatus(instInfo.status); err != nil {
 				logger.Errorf("cannot set instance status on %q: %v", m, err)
 			}


### PR DESCRIPTION
Fixed lp:1382709: openstack provider now returns SHUTOFF and SUSPENDED instances as well

This fixes http://pad.lv/1382709. When an OpenStack instance
managed by Juju is manually stopped or suspended, its state
changes to SHUTOFF or SUSPENDED, respectively. Because the
openstack provider does not return details for instances
with states other than ACTIVE, BUILD, or BUILD(spawning),
the instance updater worker will fail to retrieve the status
of a manually stopped or suspended instance (there is a warning
in the log instead, which is misleading, as it says "unknown
instance id").

With this patch, instance updater will properly refresh the status
of such instances, after the LongPoll interval (15m) since the last
check has passed. Environ.Instances() for openstack will return
also instances with SHUTOFF or SUSPENDED state.

A quick drive-by fix was done for an annoying log spam at DEBUG
level about floating IP assigned to an instance.
