### PR TITLE
Merge pull request #1124 from wallyworld/swift-empty-containername

### DIFF
--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -336,6 +336,11 @@ func CreateCustomStorage(e environs.Environ, containerName string) storage.Stora
 	}
 }
 
+// BlankContainerStorage creates a Storage object with blank container name.
+func BlankContainerStorage() storage.Storage {
+	return &openstackstorage{}
+}
+
 func GetNovaClient(e environs.Environ) *nova.Client {
 	return e.(*environ).nova()
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1262,6 +1262,12 @@ func (s *localHTTPSServerSuite) TestFetchFromToolsMetadataSources(c *gc.C) {
 	// streams.canonical.com
 }
 
+func (s *localServerSuite) TestRemoveBlankContainer(c *gc.C) {
+	storage := openstack.BlankContainerStorage()
+	err := storage.Remove("some-file")
+	c.Assert(err, gc.ErrorMatches, `cannot remove "some-file": swift container name is empty`)
+}
+
 func (s *localServerSuite) TestAllInstancesIgnoresOtherMachines(c *gc.C) {
 	env := s.Prepare(c)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})

--- a/provider/openstack/storage.go
+++ b/provider/openstack/storage.go
@@ -87,6 +87,11 @@ func (s *openstackstorage) ShouldRetry(err error) bool {
 }
 
 func (s *openstackstorage) Remove(file string) error {
+	// Prevent a blank containerName combo being used, which
+	// can result in erroneously deleting the Swift account itself.
+	if s.containerName == "" {
+		return jujuerrors.Errorf("cannot remove %q: swift container name is empty", file)
+	}
 	err := s.swift.DeleteObject(s.containerName, file)
 	// If we can't delete the object because the bucket doesn't
 	// exist, then we don't care.


### PR DESCRIPTION
Abort Remove() if swift container name is empty

Fixes: https://bugs.launchpad.net/bugs/1312217

There have been a couple of goes at this fix. This version does not require any lp.net/goose changes.

From the original PR:

Hi,

I have discovered that through a series of unfortunate events involving a failed destroy-environment run (which I believe was due to a slow Swift API response), and a subsequent "working" (ish) destroy-environment run it is possible for Juju to erroneously send a DELETE HTTP request to the swift account API, which in older versions of swift (and keystone) will result in the account DB for that user in swift being marked as deleted (and the only fix for this is to either a) wait for a cron'd script to clean it up, or b) get someone to manually delete the sqlite3 db for that account hash).

Although I've been unable to find the condition in the environment (e.g. writing/loading the jenv, doing the Remove*(...) calls etc.), but I'm 99.9% recurring that this is the cause for the issue I've had with my Swift account getting into a hard-to-recover state

I've added a simple check to provider/openstack/storage.Remove(...) to ensure the containerName isn't empty (which on a call to delete the container itself, the last step in a destroy env cleanup, will result in a DELETE call to the base URL instead, which swift+keystone will gladly oblige in some OpenStack setups).

I couldn't figure out how to test this correctly, due to the way the Storage instance is created/used in the openstack tests, so any pointers on this would be appreciated.

I feel it's more important to catch this nasty edgecase here above finding it's cause in the env handling purely because it is so destructive in the openstack provider compared to others (e.g. you can't remove the base in S3 so easily).
