### PR TITLE
worker/uniter/context/jujuc: symlink tools to correct destination

### DIFF
--- a/worker/uniter/context/jujuc/tools.go
+++ b/worker/uniter/context/jujuc/tools.go
@@ -4,10 +4,10 @@
 package jujuc
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils/symlink"
 
 	"github.com/juju/juju/juju/names"
@@ -15,19 +15,32 @@ import (
 
 // EnsureSymlinks creates a symbolic link to jujuc within dir for each
 // hook command. If the commands already exist, this operation does nothing.
+// If dir is a symbolic link, it will be dereferenced first.
 func EnsureSymlinks(dir string) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Annotatef(err, "cannot initialize hook commands in %q", dir)
+		}
+	}()
+	st, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if st.Mode()&os.ModeSymlink != 0 {
+		dir, err = os.Readlink(dir)
+		if err != nil {
+			return err
+		}
+	}
+
 	for _, name := range CommandNames() {
 		// The link operation fails when the target already exists,
 		// so this is a no-op when the command names already
 		// exist.
 		jujudPath := filepath.Join(dir, names.Jujud)
 		err := symlink.New(jujudPath, filepath.Join(dir, name))
-		if err == nil {
-			continue
-		}
-		// TODO(rog) drop LinkError check when fix is released (see http://codereview.appspot.com/6442080/)
-		if e, ok := err.(*os.LinkError); !ok || !os.IsExist(e.Err) {
-			return fmt.Errorf("cannot initialize hook commands in %q: %v", dir, err)
+		if err != nil && !os.IsExist(err) {
+			return err
 		}
 	}
 	return nil

--- a/worker/uniter/context/jujuc/tools_test.go
+++ b/worker/uniter/context/jujuc/tools_test.go
@@ -34,6 +34,17 @@ func (s *ToolsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ToolsSuite) TestEnsureSymlinks(c *gc.C) {
+	s.testEnsureSymlinks(c, s.toolsDir)
+}
+
+func (s *ToolsSuite) TestEnsureSymlinksSymlinkedDir(c *gc.C) {
+	toolsDirSymlink := filepath.Join(c.MkDir(), "unit-ubuntu-0")
+	err := symlink.New(s.toolsDir, toolsDirSymlink)
+	c.Assert(err, gc.IsNil)
+	s.testEnsureSymlinks(c, toolsDirSymlink)
+}
+
+func (s *ToolsSuite) testEnsureSymlinks(c *gc.C, dir string) {
 	jujudPath := filepath.Join(s.toolsDir, names.Jujud)
 	err := ioutil.WriteFile(jujudPath, []byte("assume sane"), 0755)
 	c.Assert(err, gc.IsNil)
@@ -48,7 +59,7 @@ func (s *ToolsSuite) TestEnsureSymlinks(c *gc.C) {
 	}
 
 	// Check that EnsureSymlinks writes appropriate symlinks.
-	err = jujuc.EnsureSymlinks(s.toolsDir)
+	err = jujuc.EnsureSymlinks(dir)
 	c.Assert(err, gc.IsNil)
 	mtimes := map[string]time.Time{}
 	for _, name := range jujuc.CommandNames() {


### PR DESCRIPTION
Hook tools were being symlinked to the unit-specific tools symlink
when the first unit was deployed. This causes problems when that
unit is destroyed, and another unit of the same service remains;
the symlinks remain broken.

We change EnsureSymlinks to dereference the target destination if
it is a symlink.

Fixes https://bugs.launchpad.net/juju-core/+bug/1391645
