### PR TITLE
State: cleanup code

### DIFF
--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -962,11 +962,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 		for _, info := range test.add {
 			all.Update(info)
 		}
-		change := test.change
-		col, closer := s.State.getCollection(change.C)
-		closer()
-		change.C = col.Name
-		err := b.Changed(all, change)
+		err := b.Changed(all, test.change)
 		c.Assert(err, gc.IsNil)
 		assertEntitiesEqual(c, all.All(), test.expectContents)
 		s.Reset(c)


### PR DESCRIPTION
Remove useless code. change.C is the collection name, which is used to get the collection, which intern is used to set change.C to the collection name.
