### PR TITLE
state/multiwatcher: rename Watcher to Multiwatcher

### DIFF
--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -35,7 +35,7 @@ func newClientAllWatcher(st *state.State, resources *common.Resources, auth comm
 	if !auth.AuthClient() {
 		return nil, common.ErrPerm
 	}
-	watcher, ok := resources.Get(id).(*multiwatcher.Watcher)
+	watcher, ok := resources.Get(id).(*multiwatcher.Multiwatcher)
 	if !ok {
 		return nil, common.ErrUnknownWatcher
 	}
@@ -50,7 +50,7 @@ func newClientAllWatcher(st *state.State, resources *common.Resources, auth comm
 // which watches any changes to the state. Each client has its own current set
 // of watchers, stored in resources.
 type srvClientAllWatcher struct {
-	watcher   *multiwatcher.Watcher
+	watcher   *multiwatcher.Multiwatcher
 	id        string
 	resources *common.Resources
 }

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -988,7 +988,7 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 	b := newAllWatcherStateBacking(s.State)
 	aw := multiwatcher.NewStoreManager(b)
 	defer aw.Stop()
-	w := multiwatcher.NewWatcher(aw)
+	w := multiwatcher.NewMultiwatcher(aw)
 	s.State.StartSync()
 	checkNext(c, w, b, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
@@ -1102,7 +1102,7 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	_, err = w.Next()
-	c.Assert(err, gc.ErrorMatches, multiwatcher.ErrWatcherStopped.Error())
+	c.Assert(err, gc.ErrorMatches, multiwatcher.ErrStopped.Error())
 }
 
 type entityInfoSlice []multiwatcher.EntityInfo
@@ -1124,7 +1124,7 @@ func (s entityInfoSlice) Less(i, j int) bool {
 
 var errTimeout = errors.New("no change received in sufficient time")
 
-func getNext(c *gc.C, w *multiwatcher.Watcher, timeout time.Duration) ([]multiwatcher.Delta, error) {
+func getNext(c *gc.C, w *multiwatcher.Multiwatcher, timeout time.Duration) ([]multiwatcher.Delta, error) {
 	var deltas []multiwatcher.Delta
 	var err error
 	ch := make(chan struct{}, 1)
@@ -1140,7 +1140,7 @@ func getNext(c *gc.C, w *multiwatcher.Watcher, timeout time.Duration) ([]multiwa
 	return nil, errTimeout
 }
 
-func checkNext(c *gc.C, w *multiwatcher.Watcher, b multiwatcher.Backing, deltas []multiwatcher.Delta, expectErr string) {
+func checkNext(c *gc.C, w *multiwatcher.Multiwatcher, b multiwatcher.Backing, deltas []multiwatcher.Delta, expectErr string) {
 	d, err := getNext(c, w, 1*time.Second)
 	if expectErr != "" {
 		c.Check(err, gc.ErrorMatches, expectErr)

--- a/state/state.go
+++ b/state/state.go
@@ -222,13 +222,13 @@ func (st *State) ResumeTransactions() error {
 	return st.txnRunner(session).ResumeTransactions()
 }
 
-func (st *State) Watch() *multiwatcher.Watcher {
+func (st *State) Watch() *multiwatcher.Multiwatcher {
 	st.mu.Lock()
 	if st.allManager == nil {
 		st.allManager = multiwatcher.NewStoreManager(newAllWatcherStateBacking(st))
 	}
 	st.mu.Unlock()
-	return multiwatcher.NewWatcher(st.allManager)
+	return multiwatcher.NewMultiwatcher(st.allManager)
 }
 
 func (st *State) EnvironConfig() (*config.Config, error) {


### PR DESCRIPTION
Rename `multiwatcher.Watcher` to `multiwatcher.Multiwatcher` in preparation for moving this type into the `state` package.
