### PR TITLE
Limit collect-metrics hook to fire only on charms that have metrics declared.

### DIFF
--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -12,11 +12,8 @@ func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
 	u.observer = observer
 }
 
-func PatchMetricsTimer(newTimer func(now, lastRun time.Time, interval time.Duration) <-chan time.Time) {
-	collectMetricsAt = newTimer
-}
-
 var (
+	ActiveMetricsTimer  = &activeMetricsTimer
 	CollectMetricsTimer = collectMetricsTimer
 )
 

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -46,7 +46,23 @@ func ModeContinue(u *Uniter) (next Mode, err error) {
 		}
 	}
 
-	// Filter out states not related to charm deployment.
+	// Resume interrupted deployment operations.
+	if u.operationState.Kind == operation.Install {
+		logger.Infof("resuming charm install")
+		return ModeInstalling(u.operationState.CharmURL), nil
+	} else if u.operationState.Kind == operation.Upgrade {
+		logger.Infof("resuming charm upgrade")
+		return ModeUpgrading(u.operationState.CharmURL), nil
+	}
+
+	// If we got this far, we should have an installed charm,
+	// so initialize the metrics collector according to what's
+	// deployed.
+	err = u.initializeMetricsCollector()
+	if err != nil {
+		return nil, err
+	}
+
 	switch u.operationState.Kind {
 	case operation.Continue:
 		logger.Infof("continuing after %q hook", u.operationState.Hook.Kind)
@@ -83,17 +99,7 @@ func ModeContinue(u *Uniter) (next Mode, err error) {
 		logger.Infof("awaiting error resolution for %q hook", u.operationState.Hook.Kind)
 		return ModeHookError, nil
 	}
-
-	// Resume interrupted deployment operations.
-	curl := u.operationState.CharmURL
-	if u.operationState.Kind == operation.Install {
-		logger.Infof("resuming charm install")
-		return ModeInstalling(curl), nil
-	} else if u.operationState.Kind == operation.Upgrade {
-		logger.Infof("resuming charm upgrade")
-		return ModeUpgrading(curl), nil
-	}
-	panic(fmt.Errorf("unhandled uniter operation %q", u.operationState.Kind))
+	return nil, fmt.Errorf("unhandled uniter operation %q", u.operationState.Kind)
 }
 
 // ModeInstalling is responsible for the initial charm deployment.
@@ -246,7 +252,7 @@ func ModeAbide(u *Uniter) (next Mode, err error) {
 func modeAbideAliveLoop(u *Uniter) (Mode, error) {
 	for {
 		lastCollectMetrics := time.Unix(u.operationState.CollectMetricsTime, 0)
-		collectMetricsSignal := collectMetricsAt(
+		collectMetricsSignal := u.collectMetricsAt(
 			time.Now(), lastCollectMetrics, metricsPollInterval,
 		)
 		hi := hook.Info{}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -50,6 +50,10 @@ type UniterExecutionObserver interface {
 	HookFailed(hookName string)
 }
 
+// CollectMetricsSignal is the signature of the function used to generate a collect-metrics
+// signal.
+type CollectMetricsSignal func(now, lastSignal time.Time, interval time.Duration) <-chan time.Time
+
 // collectMetricsTimer returns a channel that will signal the collect metrics hook
 // as close to metricsPollInterval after the last run as possible.
 func collectMetricsTimer(now, lastRun time.Time, interval time.Duration) <-chan time.Time {
@@ -58,9 +62,15 @@ func collectMetricsTimer(now, lastRun time.Time, interval time.Duration) <-chan 
 	return time.After(waitDuration)
 }
 
-// collectMetricsAt defines a function that will be used to generate signals
-// for the collect-metrics hook. It will be replaced in tests.
-var collectMetricsAt func(now, lastSignal time.Time, interval time.Duration) <-chan time.Time = collectMetricsTimer
+// activeMetricsTimer is the timer function used to generate metrics collections
+// signals for metrics-enabled charms.
+var activeMetricsTimer CollectMetricsSignal = collectMetricsTimer
+
+// inactiveMetricsTimer is the default metrics signal generation function, that returns no signal.
+// It will be used in charms that do not declare metrics.
+func inactiveMetricsTimer(_, _ time.Time, _ time.Duration) <-chan time.Time {
+	return nil
+}
 
 // Uniter implements the capabilities of the unit agent. It is not intended to
 // implement the actual *behaviour* of the unit agent; that responsibility is
@@ -88,6 +98,10 @@ type Uniter struct {
 	// The execution observer is only used in tests at this stage. Should this
 	// need to be extended, perhaps a list of observers would be needed.
 	observer UniterExecutionObserver
+
+	// collectMetricsAt defines a function that will be used to generate signals
+	// for the collect-metrics hook.
+	collectMetricsAt CollectMetricsSignal
 }
 
 // NewUniter creates a new Uniter which will install, run, and upgrade
@@ -95,9 +109,10 @@ type Uniter struct {
 // hooks and operations provoked by changes in st.
 func NewUniter(st *uniter.State, unitTag names.UnitTag, dataDir string, hookLock *fslock.Lock) *Uniter {
 	u := &Uniter{
-		st:       st,
-		paths:    NewPaths(dataDir, unitTag),
-		hookLock: hookLock,
+		st:               st,
+		paths:            NewPaths(dataDir, unitTag),
+		hookLock:         hookLock,
+		collectMetricsAt: inactiveMetricsTimer,
 	}
 	go func() {
 		defer u.tomb.Done()
@@ -330,6 +345,14 @@ func (u *Uniter) deploy(curl *corecharm.URL, reason operation.Kind) error {
 			return err
 		}
 	}
+
+	// The new charm may have declared metrics where the old one had none (or vice versa),
+	// so reset the metrics collection policy according to current state.
+	err := u.initializeMetricsCollector()
+	if err != nil {
+		return err
+	}
+
 	logger.Infof("charm %q is deployed", curl)
 	status := operation.Queued
 	if hi != nil {
@@ -346,6 +369,19 @@ func (u *Uniter) deploy(curl *corecharm.URL, reason operation.Kind) error {
 		}
 	}
 	return u.writeOperationState(operation.RunHook, status, hi, nil)
+}
+
+// initializeMetricsCollector enables the periodic collect-metrics hook
+// for charms that declare metrics.
+func (u *Uniter) initializeMetricsCollector() error {
+	charm, err := u.getCharm()
+	if err != nil {
+		return err
+	}
+	if metrics := charm.Metrics(); metrics != nil && len(metrics.Metrics) > 0 {
+		u.collectMetricsAt = activeMetricsTimer
+	}
+	return nil
 }
 
 // errHookFailed indicates that a hook failed to execute, but that the Uniter's


### PR DESCRIPTION
Currently when in debug-hooks mode, the collect-metrics hook will be executed periodically (even when the charm has no metrics-collect hook script) - this is annoying to charm developers.
