### PR TITLE
Limit collect-metrics hook to fire only on charms that have metrics declared.

### DIFF
--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -12,11 +12,8 @@ func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
 	u.observer = observer
 }
 
-func PatchMetricsTimer(newTimer func(now, lastRun time.Time, interval time.Duration) <-chan time.Time) {
-	collectMetricsAt = newTimer
-}
-
 var (
+	ActiveMetricsTimer  = &activeMetricsTimer
 	CollectMetricsTimer = collectMetricsTimer
 )
 

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -59,6 +59,7 @@ type UniterSuite struct {
 
 	st     *api.State
 	uniter *apiuniter.State
+	ticker *uniter.ManualTicker
 }
 
 var _ = gc.Suite(&UniterSuite{})
@@ -89,6 +90,8 @@ func (s *UniterSuite) TearDownSuite(c *gc.C) {
 func (s *UniterSuite) SetUpTest(c *gc.C) {
 	s.GitSuite.SetUpTest(c)
 	s.JujuConnSuite.SetUpTest(c)
+	s.ticker = uniter.NewManualTicker()
+	s.PatchValue(uniter.ActiveMetricsTimer, s.ticker.ReturnTimer)
 }
 
 func (s *UniterSuite) TearDownTest(c *gc.C) {
@@ -213,6 +216,18 @@ func (ctx *context) writeActions(c *gc.C, path string, names []string) {
 	for _, name := range names {
 		ctx.writeAction(c, path, name)
 	}
+}
+
+func (ctx *context) writeMetricsYaml(c *gc.C, path string) {
+	metricsYamlPath := filepath.Join(path, "metrics.yaml")
+	var metricsYamlFull []byte = []byte(`
+metrics:
+  pings:
+    type: gauge
+    description: sample metric
+`)
+	err := ioutil.WriteFile(metricsYamlPath, []byte(metricsYamlFull), 0755)
+	c.Assert(err, gc.IsNil)
 }
 
 func (ctx *context) writeAction(c *gc.C, path, name string) {
@@ -1328,23 +1343,60 @@ func (s *UniterSuite) TestUniterMeterStatusChanged(c *gc.C) {
 var collectMetricsEventTests = []uniterTest{
 	ut(
 		"collect-metrics event triggered by manual timer",
-		quickStart{},
+		createCharm{
+			customize: func(c *gc.C, ctx *context, path string) {
+				ctx.writeMetricsYaml(c, path)
+			},
+		},
+		serveCharm{},
+		createUniter{},
+		waitUnit{status: params.StatusStarted},
+		waitHooks{"install", "config-changed", "start"},
+		verifyCharm{},
 		metricsTick{},
 		waitHooks{"collect-metrics"},
 	),
-
 	ut(
 		"collect-metrics resumed after hook error",
-		startupError{"config-changed"},
+		startupErrorWithCustomCharm{
+			badHook: "config-changed",
+			customize: func(c *gc.C, ctx *context, path string) {
+				ctx.writeMetricsYaml(c, path)
+			},
+		},
 		metricsTick{},
-		verifyWaiting{},
 		fixHook{"config-changed"},
 		resolveError{state.ResolvedRetryHooks},
 		waitUnit{
 			status: params.StatusStarted,
 		},
-		waitHooks{"config-changed", "start", "collect-metrics", "config-changed"},
+		waitHooks{"config-changed", "start", "collect-metrics"},
 		verifyRunning{},
+	),
+	ut(
+		"collect-metrics state maintained during uniter restart",
+		startupErrorWithCustomCharm{
+			badHook: "config-changed",
+			customize: func(c *gc.C, ctx *context, path string) {
+				ctx.writeMetricsYaml(c, path)
+			},
+		},
+		metricsTick{},
+		fixHook{"config-changed"},
+		stopUniter{},
+		startUniter{},
+		resolveError{state.ResolvedRetryHooks},
+		waitUnit{
+			status: params.StatusStarted,
+		},
+		waitHooks{"config-changed", "start", "collect-metrics"},
+		verifyRunning{},
+	),
+	ut(
+		"collect-metrics event not triggered for non-metered charm",
+		quickStart{},
+		metricsTick{},
+		waitHooks{},
 	),
 }
 
@@ -1662,6 +1714,7 @@ func (s *UniterSuite) runUniterTests(c *gc.C, uniterTests []uniterTest) {
 				path:    s.unitDir,
 				dataDir: s.dataDir,
 				charms:  make(map[string][]byte),
+				ticker:  s.ticker,
 			}
 			ctx.run(c, t.steps)
 		}()
@@ -2059,10 +2112,6 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 	locksDir := filepath.Join(ctx.dataDir, "locks")
 	lock, err := fslock.NewLock(locksDir, "uniter-hook-execution")
 	c.Assert(err, gc.IsNil)
-	if ctx.ticker == nil {
-		ctx.ticker = uniter.NewManualTicker()
-		uniter.PatchMetricsTimer(ctx.ticker.ReturnTimer)
-	}
 	ctx.uniter = uniter.NewUniter(ctx.s.uniter, tag, ctx.dataDir, lock)
 	uniter.SetUniterObserver(ctx.uniter, ctx)
 }


### PR DESCRIPTION
This is a backport of fix for https://bugs.launchpad.net/juju-core/+bug/1392507, already landed in master.
