### PR TITLE
provider/maas: fixes lp:1392390

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -881,8 +881,9 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 			args.IncludeNetworks,
 			args.ExcludeNetworks,
 		)
+
 		if err, ok := err.(gomaasapi.ServerError); ok && err.StatusCode == http.StatusConflict {
-			if i <= len(args.AvailabilityZones) {
+			if i+1 < len(args.AvailabilityZones) {
 				logger.Infof("could not acquire a node in zone %q, trying another zone", zoneName)
 				continue
 			}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -295,9 +295,7 @@ func (suite *environSuite) TestSelectNodeInvalidZone(c *gc.C) {
 	}
 
 	_, err := env.selectNode(snArgs)
-	gomaaserr := err.(gomaasapi.ServerError)
-
-	c.Assert(gomaaserr.StatusCode, gc.Equals, 409)
+	c.Assert(fmt.Sprintf("%s", err), gc.Equals, "cannot run instances: gomaasapi: got error back from server: 409 Conflict ()")
 }
 
 func (suite *environSuite) TestAcquireNode(c *gc.C) {


### PR DESCRIPTION
Fix for loop used for maas availability zone selection.
Add tests for maas availability zone selection.
- Bug: https://bugs.launchpad.net/juju-core/+bug/1392390 
