### PR TITLE
State AllWatcher: filter by environment UUID

### DIFF
--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -612,7 +612,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				about: "no annotation in state, no annotation in store -> do nothing",
 				change: watcher.Change{
 					C:  "annotations",
-					Id: "m#0",
+					Id: st.docID("m#0"),
 				}}
 		}, func(c *gc.C, st *State) testCase {
 			return testCase{
@@ -620,7 +620,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				add:   []multiwatcher.EntityInfo{&multiwatcher.AnnotationInfo{Tag: "machine-0"}},
 				change: watcher.Change{
 					C:  "annotations",
-					Id: "m#0",
+					Id: st.docID("m#0"),
 				}}
 		}, func(c *gc.C, st *State) testCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
@@ -632,7 +632,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				about: "annotation is added if it's in backing but not in Store",
 				change: watcher.Change{
 					C:  "annotations",
-					Id: "m#0",
+					Id: st.docID("m#0"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.AnnotationInfo{
@@ -661,7 +661,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				}},
 				change: watcher.Change{
 					C:  "annotations",
-					Id: "m#0",
+					Id: st.docID("m#0"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.AnnotationInfo{
@@ -677,7 +677,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				about: "no unit in state -> do nothing",
 				change: watcher.Change{
 					C:  "statuses",
-					Id: "u#wordpress/0",
+					Id: st.docID("u#wordpress/0"),
 				}}
 		}, func(c *gc.C, st *State) testCase {
 			return testCase{
@@ -689,7 +689,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				}},
 				change: watcher.Change{
 					C:  "statuses",
-					Id: "u#wordpress/0",
+					Id: st.docID("u#wordpress/0"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
@@ -713,7 +713,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				}},
 				change: watcher.Change{
 					C:  "statuses",
-					Id: "u#wordpress/0",
+					Id: st.docID("u#wordpress/0"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
@@ -740,7 +740,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				}},
 				change: watcher.Change{
 					C:  "statuses",
-					Id: "u#wordpress/0",
+					Id: st.docID("u#wordpress/0"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
@@ -759,7 +759,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				about: "no machine in state -> do nothing",
 				change: watcher.Change{
 					C:  "statuses",
-					Id: "m#0",
+					Id: st.docID("m#0"),
 				}}
 		}, func(c *gc.C, st *State) testCase {
 			return testCase{
@@ -771,7 +771,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				}},
 				change: watcher.Change{
 					C:  "statuses",
-					Id: "m#0",
+					Id: st.docID("m#0"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.MachineInfo{
@@ -794,7 +794,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				}},
 				change: watcher.Change{
 					C:  "statuses",
-					Id: "m#0",
+					Id: st.docID("m#0"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.MachineInfo{
@@ -809,7 +809,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				about: "no service in state -> do nothing",
 				change: watcher.Change{
 					C:  "constraints",
-					Id: "s#wordpress",
+					Id: st.docID("s#wordpress"),
 				}}
 		}, func(c *gc.C, st *State) testCase {
 			return testCase{
@@ -820,7 +820,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				}},
 				change: watcher.Change{
 					C:  "constraints",
-					Id: "s#wordpress",
+					Id: st.docID("s#wordpress"),
 				},
 				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ServiceInfo{
 					Name:        "wordpress",
@@ -839,7 +839,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				}},
 				change: watcher.Change{
 					C:  "constraints",
-					Id: "s#wordpress",
+					Id: st.docID("s#wordpress"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ServiceInfo{

--- a/state/unit.go
+++ b/state/unit.go
@@ -351,7 +351,7 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 	}
 	ops := []txn.Op{{
 		C:      statusesC,
-		Id:     sdocId,
+		Id:     u.st.docID(sdocId),
 		Assert: bson.D{{"status", StatusPending}},
 	}, minUnitsOp}
 	removeAsserts := append(isAliveDoc, unitHasNoSubordinates...)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -581,6 +581,18 @@ func AddEnvUUIDToMachines(st *State) error {
 	return addEnvUUIDToEntityCollection(st, machinesC, "machineid")
 }
 
+// AddEnvUUIDToAnnotations prepends the environment UUID to the ID of
+// all annotation docs and adds new "env-uuid" field.
+func AddEnvUUIDToAnnotations(st *State) error {
+	return addEnvUUIDToEntityCollection(st, annotationsC, "globalkey")
+}
+
+// AddEnvUUIDToStatuses prepends the environment UUID to the ID of
+// all Statuses docs and adds new "env-uuid" field.
+func AddEnvUUIDToStatuses(st *State) error {
+	return addEnvUUIDToEntityCollection(st, statusesC, "")
+}
+
 // AddEnvUUIDToNetworks prepends the environment UUID to the ID of
 // all network docs and adds new "env-uuid" field.
 func AddEnvUUIDToNetworks(st *State) error {
@@ -660,6 +672,12 @@ func AddEnvUUIDToInstanceData(st *State) error {
 // all cleanup docs and adds new "env-uuid" field.
 func AddEnvUUIDToCleanups(st *State) error {
 	return addEnvUUIDToEntityCollection(st, cleanupsC, "")
+}
+
+// AddEnvUUIDToConstraints prepends the environment UUID to the ID of
+// all constraints docs and adds new "env-uuid" field.
+func AddEnvUUIDToConstraints(st *State) error {
+	return addEnvUUIDToEntityCollection(st, constraintsC, "")
 }
 
 // AddEnvUUIDToSettings prepends the environment UUID to the ID of

--- a/upgrades/steps122.go
+++ b/upgrades/steps122.go
@@ -44,6 +44,24 @@ func stateStepsFor122() []Step {
 			run: func(context Context) error {
 				return state.AddEnvUUIDToNetworkInterfaces(context.State())
 			},
+		}, &upgradeStep{
+			description: "prepend the environment UUID to the ID of all statuses docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToStatuses(context.State())
+			},
+		}, &upgradeStep{
+			description: "prepend the environment UUID to the ID of all annotations docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToAnnotations(context.State())
+			},
+		}, &upgradeStep{
+			description: "prepend the environment UUID to the ID of all constraints docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvUUIDToConstraints(context.State())
+			},
 		},
 	}
 }

--- a/upgrades/steps122_test.go
+++ b/upgrades/steps122_test.go
@@ -25,6 +25,9 @@ func (s *steps122Suite) TestStateStepsFor122(c *gc.C) {
 		"prepend the environment UUID to the ID of all networks docs",
 		"prepend the environment UUID to the ID of all requestedNetworks docs",
 		"prepend the environment UUID to the ID of all networkInterfaces docs",
+		"prepend the environment UUID to the ID of all statuses docs",
+		"prepend the environment UUID to the ID of all annotations docs",
+		"prepend the environment UUID to the ID of all constraints docs",
 	}
 	assertStateSteps(c, version.MustParse("1.22.0"), expected)
 }


### PR DESCRIPTION
Filter entities watched by the all watcher by environment UUID.

(Review request: https://reviews.vapour.ws/r/473/)
