### PR TITLE
Update juju/utils in dependencies.tsv

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d
 github.com/juju/syslog	git	2b69d6582feb16ff8b6d644495e16c2d8314fcb8	
 github.com/juju/testing	git	3cae07cf4f821a476e80255e75c1e3d32ca1d911	
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	
-github.com/juju/utils	git	ce9c77310e1aa22d103c43d354c597ebf6484f7a	
+github.com/juju/utils	git	d5d4c839cbe2f496b1c1fc6646eefae77cdb449e	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
 gopkg.in/juju/charm.v4	git	f7e5613ff75457d2700d1c3269546cc903ea0471	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	


### PR DESCRIPTION
Update to get ParseSize.

(Review request: https://reviews.vapour.ws/r/480/)
