### PR TITLE
Implementation of Environ.ReleaseAddress for maas

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1120,7 +1120,7 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, netId network.Id
 		if !ok {
 			return errors.Trace(err)
 		}
-		// For an "out of range" ip address, maas raises
+		// For an "out of range" IP address, maas raises
 		// StaticIPAddressOutOfRange - an error 403
 		// If there are no more addresses we get
 		// StaticIPAddressExhaustion - an error 503
@@ -1149,7 +1149,7 @@ func (environ *maasEnviron) ReleaseAddress(_ instance.Id, _ network.Id, addr net
 	// the caller.
 	err := ReleaseIPAddress(ipaddresses, addr)
 	if err != nil {
-		return errors.Annotatef(err, "failed to release ip address %v", addr.Value)
+		return errors.Annotatef(err, "failed to release IP address %v", addr.Value)
 	}
 	return nil
 }

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1069,7 +1069,7 @@ func (suite *environSuite) TestReleaseAddress(c *gc.C) {
 	// by releasing again we can test that the first release worked, *and*
 	// the error handling of ReleaseError
 	err = env.ReleaseAddress("foo", "bar", network.Address{Value: "192.168.2.1"})
-	c.Assert(err, gc.ErrorMatches, "(.|\n)*failed to release ip address 192\\.168\\.2\\.1(.|\n)*")
+	c.Assert(err, gc.ErrorMatches, "(.|\n)*failed to release IP address 192\\.168\\.2\\.1(.|\n)*")
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {


### PR DESCRIPTION
Implementation of maas provider. Release an ip address previously allocated with AllocateAddress.

(Review request: http://reviews.vapour.ws/r/492/)
