### PR TITLE
Increment juju to 1.21.beta4

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "1.21-beta3"
+#define MyAppVersion "1.21-beta4"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.ubuntu.com/"
 #define MyAppExeName "juju.exe"

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "1.21-beta3"
+const version = "1.21-beta4"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
Increment the juju devel and win installer version th 1.21-beta4. We may not release this version. If no regressions are reported about beta3, we will rename this version 1.20.0.

(Review request: http://reviews.vapour.ws/r/494/)
