### PR TITLE
provider/openstack: Avoid nil deref in testcase

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1561,8 +1561,7 @@ func (t *localServerSuite) TestStartInstanceWithUnknownAZError(c *gc.C) {
 	)
 	defer cleanup()
 	_, _, _, err = testing.StartInstance(env, "1")
-	errString := strings.Replace(err.Error(), "\n", "", -1)
-	c.Assert(errString, gc.Matches, ".*Some unknown error.*")
+	c.Assert(err, gc.ErrorMatches, "(?s).*Some unknown error.*")
 }
 
 func (t *localServerSuite) TestStartInstanceDistributionAZNotImplemented(c *gc.C) {


### PR DESCRIPTION
Rather than poking an err.Error() return to remove newlines
before matching, use err directly but use a regexp flag so
dot will match newlines.