### PR TITLE
state: env UUID migration for meterStatus collection

### DIFF
--- a/state/meterstatus_test.go
+++ b/state/meterstatus_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
@@ -36,6 +37,16 @@ func (s *UnitSuite) TestMeterStatus(c *gc.C) {
 	c.Assert(status, gc.Equals, "GREEN")
 	c.Assert(info, gc.Equals, "Additional information.")
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *UnitSuite) TestMeterStatusIncludesEnvUUID(c *gc.C) {
+	jujuDB := s.MgoSuite.Session.DB("juju")
+	meterStatus := jujuDB.C("meterStatus")
+	var docs []bson.M
+	err := meterStatus.Find(nil).All(&docs)
+	c.Assert(err, gc.IsNil)
+	c.Assert(docs, gc.HasLen, 1)
+	c.Assert(docs[0]["env-uuid"], gc.Equals, s.State.EnvironUUID())
 }
 
 func (s *UnitSuite) TestSetMeterStatusIncorrect(c *gc.C) {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -704,6 +704,12 @@ func AddEnvUUIDToRelationScopes(st *State) error {
 	return addEnvUUIDToEntityCollection(st, relationScopesC, "key")
 }
 
+// AddEnvUUIDToMeterStatus prepends the environment UUID to the ID of
+// all meterStatus docs and adds new "env-uuid" field and "id" fields.
+func AddEnvUUIDToMeterStatus(st *State) error {
+	return addEnvUUIDToEntityCollection(st, meterStatusC, "")
+}
+
 func addEnvUUIDToEntityCollection(st *State, collName, fieldForOldID string) error {
 	env, err := st.Environment()
 	if err != nil {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -801,6 +801,31 @@ func (s *upgradesSuite) TestAddEnvUUIDToRelationScopesIdempotent(c *gc.C) {
 	s.checkAddEnvUUIDToCollectionIdempotent(c, AddEnvUUIDToRelationScopes, relationScopesC)
 }
 
+func (s *upgradesSuite) TestAddEnvUUIDToMeterStatus(c *gc.C) {
+	coll, closer, newIDs := s.checkAddEnvUUIDToCollection(c, AddEnvUUIDToMeterStatus, meterStatusC,
+		bson.M{
+			"_id":  "u#foo/0",
+			"code": MeterGreen,
+		},
+		bson.M{
+			"_id":  "u#bar/0",
+			"code": MeterRed,
+		},
+	)
+	defer closer()
+
+	var newDoc meterStatusDoc
+	s.FindId(c, coll, newIDs[0], &newDoc)
+	c.Assert(newDoc.Code, gc.Equals, MeterGreen)
+
+	s.FindId(c, coll, newIDs[1], &newDoc)
+	c.Assert(newDoc.Code, gc.Equals, MeterRed)
+}
+
+func (s *upgradesSuite) TestAddEnvUUIDToMeterStatusIdempotent(c *gc.C) {
+	s.checkAddEnvUUIDToCollectionIdempotent(c, AddEnvUUIDToMeterStatus, meterStatusC)
+}
+
 func (s *upgradesSuite) checkAddEnvUUIDToCollection(
 	c *gc.C,
 	upgradeStep func(*State) error,

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1269,7 +1269,7 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 // WatchMeterStatus returns a watcher observing the changes to the unit's
 // meter status.
 func (u *Unit) WatchMeterStatus() NotifyWatcher {
-	return newEntityWatcher(u.st, meterStatusC, u.globalKey())
+	return newEntityWatcher(u.st, meterStatusC, u.st.docID(u.globalKey()))
 }
 
 func newEntityWatcher(st *State, collName string, key interface{}) NotifyWatcher {


### PR DESCRIPTION
This is required for multi-environment support.

(Review request: http://reviews.vapour.ws/r/499/)
