### PR TITLE
Updated dependencies.tsv for juju/utils

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d
 github.com/juju/syslog	git	2b69d6582feb16ff8b6d644495e16c2d8314fcb8	
 github.com/juju/testing	git	bb82a35ea789fce462fcb81a071c2eb57aa22a6b	
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	
-github.com/juju/utils	git	d5d4c839cbe2f496b1c1fc6646eefae77cdb449e	
+github.com/juju/utils	git	6bfed5692f0d524bab3be5976f26d24bd4d3f677	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
 gopkg.in/juju/charm.v4	git	f7e5613ff75457d2700d1c3269546cc903ea0471	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	


### PR DESCRIPTION
This is needed to apply the fix for http://pad.lv/1394524
which landed on juju/utils, but juju-core is not yet using it.

(Review request: http://reviews.vapour.ws/r/506/)
