### PR TITLE
Actions API :: Add Actions() method to return Actions by ID

### DIFF
--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -103,7 +103,7 @@ func (s *actionSuite) TestServiceCharmActions(c *gc.C) {
 			c.Logf("test %d: %s", i, t.description)
 			cleanup := patchServiceCharmActions(c, s.client, t.patchResults, t.patchErr)
 			defer cleanup()
-			result, err := s.client.ServiceCharmActions(names.NewServiceTag("foo"))
+			result, err := s.client.ServiceCharmActions(params.Entity{Tag: names.NewServiceTag("foo").String()})
 			if t.expectedErr != "" {
 				c.Check(err, gc.ErrorMatches, t.expectedErr)
 			} else {

--- a/api/uniter/action_test.go
+++ b/api/uniter/action_test.go
@@ -52,7 +52,9 @@ func (s *actionSuite) TestAction(c *gc.C) {
 			actionTest.action.Parameters)
 		c.Assert(err, jc.ErrorIsNil)
 
-		actionTag := names.JoinActionTag(s.uniterSuite.wordpressUnit.Name(), a.Id())
+		ok := names.IsValidAction(a.Id())
+		c.Assert(ok, gc.Equals, true)
+		actionTag := names.NewActionTag(a.Id())
 		c.Assert(a.Tag(), gc.Equals, actionTag)
 
 		retrievedAction, err := s.uniter.Action(actionTag)
@@ -64,9 +66,9 @@ func (s *actionSuite) TestAction(c *gc.C) {
 }
 
 func (s *actionSuite) TestActionNotFound(c *gc.C) {
-	_, err := s.uniter.Action(names.JoinActionTag("wordpress/0", "0"))
+	_, err := s.uniter.Action(names.NewActionTag("feedface-0123-4567-8901-2345deadbeef"))
 	c.Assert(err, gc.NotNil)
-	c.Assert(err, gc.ErrorMatches, `action "0" not found`)
+	c.Assert(err, gc.ErrorMatches, `action "feedface-0123-4567-8901-2345deadbeef" not found`)
 }
 
 func (s *actionSuite) TestNewActionAndAccessors(c *gc.C) {

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -425,7 +425,7 @@ func (s *unitSuite) TestWatchActionNotifications(c *gc.C) {
 		"outfile": "foo.txt",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange(action.NotificationId())
+	wc.AssertChange(action.Id())
 
 	action, err = s.wordpressUnit.AddAction("backup", map[string]interface{}{
 		"outfile": "foo.bz2",
@@ -435,7 +435,7 @@ func (s *unitSuite) TestWatchActionNotifications(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange(action.NotificationId())
+	wc.AssertChange(action.Id())
 
 	statetesting.AssertStop(c, w)
 	wc.AssertClosed()

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -22,6 +22,18 @@ import (
 	"github.com/juju/juju/version"
 )
 
+// FindTags wraps a slice of strings that are prefixes to use when
+// searching for matching tags.
+type FindTags struct {
+	Prefixes []string `json:"prefixes"`
+}
+
+// FindTagResults wraps the mapping between the requested prefix and the
+// matching tags for each requested prefix.
+type FindTagsResults struct {
+	Matches map[string][]Entity `json:"matches"`
+}
+
 // Entity identifies a single entity.
 type Entity struct {
 	Tag string

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -1448,20 +1448,26 @@ func (u *uniterBaseAPI) authAndActionFromTagFn() (func(string) (*state.Action, e
 	}
 
 	return func(tag string) (*state.Action, error) {
-		atag, err := names.ParseActionTag(tag)
+		actionTag, err := names.ParseActionTag(tag)
 		if err != nil {
-			return nil, common.ErrBadId
+			return nil, err
 		}
-		unitTag := atag.PrefixTag()
-		if unitTag != unit {
+		action, err := u.st.ActionByTag(actionTag)
+		if err != nil {
+			return nil, err
+		}
+		receiverTag, err := names.ActionReceiverTag(action.Receiver())
+		if err != nil {
+			return nil, err
+		}
+		if unit != receiverTag {
 			return nil, common.ErrPerm
 		}
 
-		if !canAccess(unitTag) {
+		if !canAccess(receiverTag) {
 			return nil, common.ErrPerm
 		}
-
-		return u.st.ActionByTag(atag)
+		return action, nil
 	}, nil
 }
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,7 +15,7 @@ github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8
 github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	
 github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	
-github.com/juju/names	git	d68794726573f3042eda8e8d77925b6ae5b4d77f	
+github.com/juju/names	git	4bd61d19a7fce663e2821fe05ddf69f774d444da	
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
 github.com/juju/syslog	git	2b69d6582feb16ff8b6d644495e16c2d8314fcb8	

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -46,7 +46,7 @@ func (s *ActionSuite) TestActionTag(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	tag := action.Tag()
-	c.Assert(tag.String(), gc.Equals, "action-wordpress/0_a_"+action.Id())
+	c.Assert(tag.String(), gc.Equals, "action-"+action.Id())
 
 	result, err := action.Finish(state.ActionResults{Status: state.ActionCompleted})
 	c.Assert(err, jc.ErrorIsNil)
@@ -59,7 +59,7 @@ func (s *ActionSuite) TestActionTag(c *gc.C) {
 	c.Assert(actionResult, gc.DeepEquals, result)
 
 	tag = actionResult.Tag()
-	c.Assert(tag.String(), gc.Equals, "action-wordpress/0_a_"+actionResult.Id())
+	c.Assert(tag.String(), gc.Equals, "action-"+actionResult.Id())
 }
 
 func (s *ActionSuite) TestAddAction(c *gc.C) {
@@ -311,7 +311,7 @@ func (s *ActionSuite) TestUnitWatchActionNotifications(c *gc.C) {
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, s.State, w)
 	// make sure the previously pending actions are sent on the watcher
-	expect := expectActionNotificationIds(fa1, fa2)
+	expect := expectActionIds(fa1, fa2)
 	wc.AssertChange(expect...)
 	wc.AssertNoChange()
 
@@ -327,7 +327,7 @@ func (s *ActionSuite) TestUnitWatchActionNotifications(c *gc.C) {
 	fa3, err := unit2.AddAction("fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
-	expect2 := expectActionNotificationIds(fa3)
+	expect2 := expectActionIds(fa3)
 	wc2.AssertChange(expect2...)
 	wc2.AssertNoChange()
 
@@ -337,7 +337,7 @@ func (s *ActionSuite) TestUnitWatchActionNotifications(c *gc.C) {
 	fa5, err := unit1.AddAction("fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	expect = expectActionNotificationIds(fa4, fa5)
+	expect = expectActionIds(fa4, fa5)
 	wc.AssertChange(expect...)
 	wc.AssertNoChange()
 }
@@ -492,7 +492,7 @@ func (s *ActionSuite) TestWatchActionNotifications(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// expect the first and last one in the watcher
-	expect := expectActionNotificationIds(fa1, fa3)
+	expect := expectActionIds(fa1, fa3)
 	wc.AssertChange(expect...)
 	wc.AssertNoChange()
 }
@@ -567,14 +567,6 @@ func expectActionIds(actions ...*state.Action) []string {
 	ids := make([]string, len(actions))
 	for i, action := range actions {
 		ids[i] = action.Id()
-	}
-	return ids
-}
-
-func expectActionNotificationIds(actions ...*state.Action) []string {
-	ids := make([]string, len(actions))
-	for i, action := range actions {
-		ids[i] = action.NotificationId()
 	}
 	return ids
 }

--- a/state/state.go
+++ b/state/state.go
@@ -671,7 +671,7 @@ func (st *State) tagToCollectionAndId(tag names.Tag) (string, interface{}, error
 		id = st.docID(id)
 	case names.ActionTag:
 		coll = actionsC
-		id = tag.Suffix()
+		id = tag.Id()
 	default:
 		return "", nil, errors.Errorf("%q is not a valid collection tag", tag)
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2374,8 +2374,8 @@ var findEntityTests = []findEntityTest{{
 }, {
 	tag: names.NewNetworkTag("net1"),
 }, {
-	tag: names.NewActionTag("ser-vice2_a_0"),
-	err: `action "0" not found`,
+	tag: names.NewActionTag("fedcba98-7654-4321-ba98-76543210beef"),
+	err: `action "fedcba98-7654-4321-ba98-76543210beef" not found`,
 }, {
 	tag: names.NewUserTag("eric"),
 }, {
@@ -2497,7 +2497,7 @@ func (s *StateSuite) TestParseActionTag(c *gc.C) {
 	f, err := u.AddAction("fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	action, err := s.State.Action(f.Id())
-	c.Assert(action.Tag(), gc.Equals, names.JoinActionTag(u.Name(), action.Id()))
+	c.Assert(action.Tag(), gc.Equals, names.NewActionTag(action.Id()))
 	coll, id, err := state.ConvertTagToCollectionNameAndId(s.State, action.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coll, gc.Equals, "actions")

--- a/state/unit.go
+++ b/state/unit.go
@@ -1544,7 +1544,7 @@ func (u *Unit) UnassignFromMachine() (err error) {
 // AddAction adds a new Action of type name and using arguments payload to
 // this Unit, and returns its ID
 func (u *Unit) AddAction(name string, payload map[string]interface{}) (*Action, error) {
-	return u.st.addAction(u, name, payload)
+	return u.st.EnqueueAction(u.Tag(), name, payload)
 }
 
 // CancelAction removes a pending Action from the queue for this

--- a/worker/uniter/context/factory.go
+++ b/worker/uniter/context/factory.go
@@ -175,10 +175,11 @@ func (f *factory) NewActionContext(actionId string) (*HookContext, error) {
 		return nil, errors.Trace(err)
 	}
 
-	tag, ok := names.ParseActionTagFromId(actionId)
+	ok := names.IsValidAction(actionId)
 	if !ok {
 		return nil, &badActionError{actionId, "not valid actionId"}
 	}
+	tag := names.NewActionTag(actionId)
 	action, err := f.state.Action(tag)
 	if params.IsCodeNotFoundOrCodeUnauthorized(errors.Cause(err)) {
 		return nil, ErrActionNotAvailable

--- a/worker/uniter/context/factory_test.go
+++ b/worker/uniter/context/factory_test.go
@@ -362,7 +362,7 @@ func (s *FactorySuite) TestNewActionContext(c *gc.C) {
 		"outfile": "/some/file.bz2",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := s.factory.NewActionContext(action.NotificationId())
+	ctx, err := s.factory.NewActionContext(action.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	data, err := ctx.ActionData()
 	c.Assert(err, jc.ErrorIsNil)
@@ -380,7 +380,7 @@ func (s *FactorySuite) TestNewActionContextBadName(c *gc.C) {
 	s.charm = s.AddTestingCharm(c, "dummy")
 	action, err := s.unit.AddAction("no-such-action", nil)
 	c.Assert(err, jc.ErrorIsNil) // this will fail when state is done right
-	ctx, err := s.factory.NewActionContext(action.NotificationId())
+	ctx, err := s.factory.NewActionContext(action.Id())
 	c.Check(ctx, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "cannot run \"no-such-action\" action: not defined")
 	c.Check(err, jc.Satisfies, context.IsBadActionError)
@@ -392,7 +392,7 @@ func (s *FactorySuite) TestNewActionContextBadParams(c *gc.C) {
 		"outfile": 123,
 	})
 	c.Assert(err, jc.ErrorIsNil) // this will fail when state is done right
-	ctx, err := s.factory.NewActionContext(action.NotificationId())
+	ctx, err := s.factory.NewActionContext(action.Id())
 	c.Check(ctx, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "cannot run \"snapshot\" action: .*")
 	c.Check(err, jc.Satisfies, context.IsBadActionError)
@@ -404,7 +404,7 @@ func (s *FactorySuite) TestNewActionContextMissingAction(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.unit.CancelAction(action)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := s.factory.NewActionContext(action.NotificationId())
+	ctx, err := s.factory.NewActionContext(action.Id())
 	c.Check(ctx, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "action no longer available")
 	c.Check(err, gc.Equals, context.ErrActionNotAvailable)
@@ -416,7 +416,7 @@ func (s *FactorySuite) TestNewActionContextUnauthAction(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	action, err := otherUnit.AddAction("snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := s.factory.NewActionContext(action.NotificationId())
+	ctx, err := s.factory.NewActionContext(action.Id())
 	c.Check(ctx, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "action no longer available")
 	c.Check(err, gc.Equals, context.ErrActionNotAvailable)

--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -509,7 +509,7 @@ func getAddAction(s *FilterSuite, c *gc.C) func(name string) string {
 	return func(name string) string {
 		newAction, err := s.unit.AddAction(name, nil)
 		c.Assert(err, jc.ErrorIsNil)
-		newId := newAction.NotificationId()
+		newId := newAction.Id()
 		return newId
 	}
 }

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -41,7 +41,7 @@ var validateTests = []struct {
 		hook.Info{Kind: hooks.Action},
 		`action id "" cannot be parsed as an action tag`,
 	},
-	{hook.Info{Kind: hooks.Action, ActionId: "wordpress/0_a_1"}, ""},
+	{hook.Info{Kind: hooks.Action, ActionId: "badadded-0123-4567-89ab-cdef01234567"}, ""},
 	{hook.Info{Kind: hooks.UpgradeCharm}, ""},
 	{hook.Info{Kind: hooks.Stop}, ""},
 	{hook.Info{Kind: hooks.RelationJoined, RemoteUnit: "x"}, ""},

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -107,7 +107,7 @@ var stateTests = []struct {
 			Step: operation.Pending,
 			Hook: &hook.Info{
 				Kind:     hooks.Action,
-				ActionId: "wordpress/0_a_1",
+				ActionId: "feedface-dead-4567-beef-123456789012",
 			},
 		},
 	}, {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -484,11 +484,11 @@ func (u *Uniter) notifyHookFailed(hook string, hctx *context.HookContext) {
 func (u *Uniter) runAction(hi hook.Info) (err error) {
 	hctx, err := u.contextFactory.NewActionContext(hi.ActionId)
 	if cause := errors.Cause(err); context.IsBadActionError(cause) {
-		tag, ok := names.ParseActionTagFromId(hi.ActionId)
+		ok := names.IsValidAction(hi.ActionId)
 		if !ok {
 			return errors.Annotatef(err, "invalid actionId %q", hi.ActionId)
 		}
-		return u.st.ActionFinish(tag, params.ActionFailed, nil, err.Error())
+		return u.st.ActionFinish(names.NewActionTag(hi.ActionId), params.ActionFailed, nil, err.Error())
 	} else if cause == context.ErrActionNotAvailable {
 		return nil
 	} else if err != nil {


### PR DESCRIPTION
Now that we have UUID identifiers for Actions, allow retrieving by ID

(Review request: http://reviews.vapour.ws/r/510/)
