### PR TITLE
apiserver/params: add test to prevent state being added as dependency

### DIFF
--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -5,7 +5,7 @@ package params_test
 
 import (
 	"encoding/json"
-	"testing"
+	stdtesting "testing"
 
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
@@ -16,10 +16,11 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/testing"
 )
 
 // TestPackage integrates the tests into gotest.
-func TestPackage(t *testing.T) {
+func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }
 
@@ -251,5 +252,16 @@ func (s *ErrorResultsSuite) TestCombine(c *gc.C) {
 		} else {
 			c.Check(err, gc.ErrorMatches, test.errMatch)
 		}
+	}
+}
+
+type importSuite struct{}
+
+var _ = gc.Suite(&importSuite{})
+
+func (*importSuite) TestParamsDoesNotDependOnState(c *gc.C) {
+	imports := testing.FindJujuCoreImports(c, "github.com/juju/juju/apiserver/params")
+	for _, i := range imports {
+		c.Assert(i, gc.Not(gc.Equals), "state")
 	}
 }


### PR DESCRIPTION
`apiserver/params` should not depend, even transitively on `state`, because that will mean anything that uses the api also has a state in their dependency graph.

This test makes it a robot's job to check.

Requires #1202 

(Review request: http://reviews.vapour.ws/r/513/)
