### PR TITLE
Merge pull request #1196 from anastasiamac/Bug1394450-older-client-destr...

### DIFF
--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -58,7 +58,20 @@ func (s *configSuite) TestDefaultNetworkBridge(c *gc.C) {
 	config := minimalConfig(c)
 	unknownAttrs := config.UnknownAttrs()
 	c.Assert(unknownAttrs["container"], gc.Equals, "lxc")
-	c.Assert(unknownAttrs["network-bridge"], gc.Equals, "")
+	c.Assert(unknownAttrs["network-bridge"], gc.Equals, "lxcbr0")
+}
+
+func (s *configSuite) TestDefaultNetworkBridgeForKVMContainersWithOldDefault(c *gc.C) {
+	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+		"container":      "kvm",
+		"network-bridge": "lxcbr0",
+	})
+	testConfig, err := config.New(config.NoDefaults, minAttrs)
+	c.Assert(err, gc.IsNil)
+	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
+	c.Check(containerType, gc.Equals, string(instance.KVM))
+	//should have corrected default for kvm container
+	c.Check(bridgeName, gc.Equals, kvm.DefaultKvmBridge)
 }
 
 func (s *configSuite) TestDefaultNetworkBridgeForKVMContainers(c *gc.C) {

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -241,6 +241,9 @@ func (provider environProvider) Validate(cfg, old *config.Config) (valid *config
 		return nil, errors.Annotatef(err, "failed to validate unknown attrs")
 	}
 	localConfig := newEnvironConfig(cfg, validated)
+	// Set correct default network bridge if needed
+	// fix for http://pad.lv/1394450
+	localConfig.setDefaultNetworkBridge()
 	// Before potentially creating directories, make sure that the
 	// root directory has not changed.
 	containerType := localConfig.container()


### PR DESCRIPTION
...oing-new-environment

Setting default network bridge name on config creation.

Older clients can't destroy newer environments because a) default network bridge name changed to empty string and b) reasonable default for network bridge name was only provided via getter.

This change moves the guess of reasonable default to config creation.

(Review request: http://reviews.vapour.ws/r/507/)

(Review request: http://reviews.vapour.ws/r/514/)
