### PR TITLE
Merge pull request #1206 from wallyworld/fix-deprecation-warning

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -398,7 +398,10 @@ func (c *Config) fillInStringDefault(attr string) {
 // Ths ensures that older versions of Juju which require that deprecated
 // attribute values still be used will work as expected.
 func ProcessDeprecatedAttributes(attrs map[string]interface{}) map[string]interface{} {
-	processedAttrs := attrs
+	processedAttrs := make(map[string]interface{}, len(attrs))
+	for k, v := range attrs {
+		processedAttrs[k] = v
+	}
 	// The tools url has changed so ensure that both old and new values are in the config so that
 	// upgrades work. "agent-metadata-url" is the old attribute name.
 	if oldToolsURL, ok := attrs[ToolsMetadataURLKey]; ok && oldToolsURL.(string) != "" {

--- a/environs/config_test.go
+++ b/environs/config_test.go
@@ -431,7 +431,7 @@ environments:
 
 const (
 	// This is a standard configuration warning when old attribute was specified.
-	standardDeprecationWarning = `.*Your configuration should be updated to set .*`
+	standardDeprecationWarning = `.*Your configuration should be updated to set .* %v.*`
 
 	// This is a standard deprecation warning when both old and new attributes were specified.
 	standardDeprecationWarningWithNew = `.*is deprecated and will be ignored since the new .*`
@@ -441,14 +441,14 @@ func (s *ConfigDeprecationSuite) TestDeprecatedToolsURLWarning(c *gc.C) {
 	attrs := testing.Attrs{
 		"tools-metadata-url": "aknowndeprecatedfield",
 	}
-	expected := fmt.Sprintf(standardDeprecationWarning)
+	expected := fmt.Sprintf(standardDeprecationWarning, "aknowndeprecatedfield")
 	s.checkDeprecationWarning(c, attrs, expected)
 }
 
 func (s *ConfigDeprecationSuite) TestDeprecatedSafeModeWarning(c *gc.C) {
 	// Test that the warning is logged.
 	attrs := testing.Attrs{"provisioner-safe-mode": true}
-	expected := fmt.Sprintf(standardDeprecationWarning)
+	expected := fmt.Sprintf(standardDeprecationWarning, "destroyed")
 	s.checkDeprecationWarning(c, attrs, expected)
 }
 
@@ -479,13 +479,13 @@ func (s *ConfigDeprecationSuite) TestDeprecatedTypeNullWarning(c *gc.C) {
 
 func (s *ConfigDeprecationSuite) TestDeprecatedLxcUseCloneWarning(c *gc.C) {
 	attrs := testing.Attrs{"lxc-use-clone": true}
-	expected := fmt.Sprintf(standardDeprecationWarning)
+	expected := fmt.Sprintf(standardDeprecationWarning, true)
 	s.checkDeprecationWarning(c, attrs, expected)
 }
 
 func (s *ConfigDeprecationSuite) TestDeprecatedToolsStreamWarning(c *gc.C) {
 	attrs := testing.Attrs{"tools-stream": "devel"}
-	expected := fmt.Sprintf(standardDeprecationWarning)
+	expected := fmt.Sprintf(standardDeprecationWarning, "devel")
 	s.checkDeprecationWarning(c, attrs, expected)
 }
 


### PR DESCRIPTION
Ensure correct value is logged in config deprecation warning

Fixes: https://bugs.launchpad.net/juju-core/+bug/1394751

When logging a warning about using provisioner-safe-mode, the warning message had the wrong suggested value for the new harvest mode setting.  The logger function now is given what the new value should be so it can use it in the log message.

(Review request: http://reviews.vapour.ws/r/516/)

(Review request: http://reviews.vapour.ws/r/517/)
