### PR TITLE
Move charm archive logic to API server

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -209,12 +209,7 @@ func (st *State) Uniter() (*uniter.State, error) {
 	if !ok {
 		return nil, errors.Errorf("expected UnitTag, got %T %v", st.authTag, st.authTag)
 	}
-	envTag, err := st.EnvironTag()
-	if err != nil {
-		logger.Warningf("ignoring invalid environ tag: %v", err)
-	}
-	charmsURL := uniter.CharmsURL(st.Addr(), envTag)
-	return uniter.NewState(st, unitTag, charmsURL), nil
+	return uniter.NewState(st, unitTag), nil
 }
 
 func (st *State) DiskManager() (*diskmanager.State, error) {

--- a/api/uniter/charm_test.go
+++ b/api/uniter/charm_test.go
@@ -7,11 +7,9 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/juju/names"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/uniter"
-	"github.com/juju/juju/testing"
 )
 
 type charmSuite struct {
@@ -48,49 +46,23 @@ func (s *charmSuite) TestURL(c *gc.C) {
 	c.Assert(s.apiCharm.URL(), gc.DeepEquals, s.wordpressCharm.URL())
 }
 
-func (s *charmSuite) TestArchiveURL(c *gc.C) {
+func (s *charmSuite) TestArchiveURLs(c *gc.C) {
 	apiInfo := s.APIInfo(c)
 	url, err := url.Parse(fmt.Sprintf(
-		"https://%s/environment/%s/charms?file=%s&url=%s",
-		apiInfo.Addrs[0],
+		"https://0.1.2.3:1234/environment/%s/charms?file=%s&url=%s",
 		apiInfo.EnvironTag.Id(),
 		url.QueryEscape("*"),
 		url.QueryEscape(s.apiCharm.URL().String()),
 	))
 	c.Assert(err, gc.IsNil)
-	archiveURL := s.apiCharm.ArchiveURL()
-	c.Assert(archiveURL, gc.DeepEquals, url)
+	archiveURLs, err := s.apiCharm.ArchiveURLs()
+	c.Assert(err, gc.IsNil)
+	c.Assert(archiveURLs, gc.HasLen, 1)
+	c.Assert(archiveURLs[0], gc.DeepEquals, url)
 }
 
 func (s *charmSuite) TestArchiveSha256(c *gc.C) {
 	archiveSha256, err := s.apiCharm.ArchiveSha256()
 	c.Assert(err, gc.IsNil)
 	c.Assert(archiveSha256, gc.Equals, s.wordpressCharm.BundleSha256())
-}
-
-type charmsURLSuite struct {
-	testing.BaseSuite
-}
-
-var _ = gc.Suite(&charmsURLSuite{})
-
-func (s *charmsURLSuite) TestCharmsURL(c *gc.C) {
-	testCharmsURL(c, "", "", "https:///charms")
-	testCharmsURL(c, "abc.com", "", "https://abc.com/charms")
-	testCharmsURL(c, "abc.com:123", "", "https://abc.com:123/charms")
-	testCharmsURL(c, "abc.com:123", "invalid-uuid", "https://abc.com:123/charms")
-	testCharmsURL(c, "abc.com:123", "environment-f47ac10b-58cc-4372-a567-0e02b2c3d479", "https://abc.com:123/environment/f47ac10b-58cc-4372-a567-0e02b2c3d479/charms")
-}
-
-func testCharmsURL(c *gc.C, addr, envTag, expected string) {
-	tag, err := names.ParseEnvironTag(envTag)
-	if err != nil {
-		// If it's invalid, pretend it's not set at all.
-		tag = names.NewEnvironTag("")
-	}
-	url := uniter.CharmsURL(addr, tag)
-	if !c.Check(url, gc.NotNil) {
-		return
-	}
-	c.Check(url.String(), gc.Equals, expected)
 }

--- a/api/uniter/service_test.go
+++ b/api/uniter/service_test.go
@@ -4,8 +4,6 @@
 package uniter_test
 
 import (
-	"net/url"
-
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -138,7 +136,7 @@ func (s *serviceSuite) TestOwnerTagV1(c *gc.C) {
 
 func (s *serviceSuite) patchNewState(
 	c *gc.C,
-	patchFunc func(_ base.APICaller, _ names.UnitTag, _ *url.URL) *uniter.State,
+	patchFunc func(_ base.APICaller, _ names.UnitTag) *uniter.State,
 ) {
 	s.uniterSuite.patchNewState(c, patchFunc)
 	var err error

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -5,7 +5,6 @@ package uniter_test
 
 import (
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/juju/errors"
@@ -676,7 +675,7 @@ func (s *unitSuite) TestWatchMeterStatus(c *gc.C) {
 
 func (s *unitSuite) patchNewState(
 	c *gc.C,
-	patchFunc func(_ base.APICaller, _ names.UnitTag, _ *url.URL) *uniter.State,
+	patchFunc func(_ base.APICaller, _ names.UnitTag) *uniter.State,
 ) {
 	s.uniterSuite.patchNewState(c, patchFunc)
 	var err error

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -5,7 +5,6 @@ package uniter
 
 import (
 	"fmt"
-	"net/url"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -27,9 +26,6 @@ type State struct {
 	facade base.FacadeCaller
 	// unitTag contains the authenticated unit's tag.
 	unitTag names.UnitTag
-
-	// charmsURL is the root URL used to fetch charm archives.
-	charmsURL *url.URL
 }
 
 // newStateForVersion creates a new client-side Uniter facade for the
@@ -37,7 +33,6 @@ type State struct {
 func newStateForVersion(
 	caller base.APICaller,
 	authTag names.UnitTag,
-	charmsURL *url.URL,
 	version int,
 ) *State {
 	facadeCaller := base.NewFacadeCallerForVersion(
@@ -50,18 +45,17 @@ func newStateForVersion(
 		APIAddresser:   common.NewAPIAddresser(facadeCaller),
 		facade:         facadeCaller,
 		unitTag:        authTag,
-		charmsURL:      charmsURL,
 	}
 }
 
 // newStateV0 creates a new client-side Uniter facade, version 0.
-func newStateV0(caller base.APICaller, authTag names.UnitTag, charmsURL *url.URL) *State {
-	return newStateForVersion(caller, authTag, charmsURL, 0)
+func newStateV0(caller base.APICaller, authTag names.UnitTag) *State {
+	return newStateForVersion(caller, authTag, 0)
 }
 
 // newStateV1 creates a new client-side Uniter facade, version 1.
-func newStateV1(caller base.APICaller, authTag names.UnitTag, charmsURL *url.URL) *State {
-	return newStateForVersion(caller, authTag, charmsURL, 1)
+func newStateV1(caller base.APICaller, authTag names.UnitTag) *State {
+	return newStateForVersion(caller, authTag, 1)
 }
 
 // NewState creates a new client-side Uniter facade.

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -4,8 +4,6 @@
 package uniter_test
 
 import (
-	"net/url"
-
 	"github.com/juju/names"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -101,7 +99,7 @@ func (s *uniterSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScop
 
 func (s *uniterSuite) patchNewState(
 	c *gc.C,
-	patchFunc func(_ base.APICaller, _ names.UnitTag, _ *url.URL) *uniter.State,
+	patchFunc func(_ base.APICaller, _ names.UnitTag) *uniter.State,
 ) {
 	s.PatchValue(&uniter.NewState, patchFunc)
 	var err error

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -7,6 +7,8 @@ package uniter
 
 import (
 	"fmt"
+	"net/url"
+	"path"
 	"time"
 
 	"github.com/juju/errors"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
@@ -678,6 +681,45 @@ func (u *uniterBaseAPI) CharmArchiveSha256(args params.CharmURLs) (params.String
 			}
 		}
 		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+// CharmArchiveURLs returns the URLS for the charm archive
+// (bundle) data for each charm url in the given parameters.
+func (u *uniterBaseAPI) CharmArchiveURLs(args params.CharmURLs) (params.StringsResults, error) {
+	apiHostPorts, err := u.st.APIHostPorts()
+	if err != nil {
+		return params.StringsResults{}, err
+	}
+	envUUID := u.st.EnvironUUID()
+	result := params.StringsResults{
+		Results: make([]params.StringsResult, len(args.URLs)),
+	}
+	for i, curl := range args.URLs {
+		if _, err := charm.ParseURL(curl.URL); err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		urlPath := "/"
+		if envUUID != "" {
+			urlPath = path.Join(urlPath, "environment", envUUID)
+		}
+		urlPath = path.Join(urlPath, "charms")
+		archiveURLs := make([]string, len(apiHostPorts))
+		for j, server := range apiHostPorts {
+			archiveURL := &url.URL{
+				Scheme: "https",
+				Host:   network.SelectInternalHostPort(server, false),
+				Path:   urlPath,
+			}
+			q := archiveURL.Query()
+			q.Set("url", curl.URL)
+			q.Set("file", "*")
+			archiveURL.RawQuery = q.Encode()
+			archiveURLs[j] = archiveURL.String()
+		}
+		result.Results[i].Result = archiveURLs
 	}
 	return result, nil
 }

--- a/apiserver/uniter/uniter_v0_test.go
+++ b/apiserver/uniter/uniter_v0_test.go
@@ -181,6 +181,10 @@ func (s *uniterV0Suite) TestCharmArchiveSha256(c *gc.C) {
 	s.testCharmArchiveSha256(c, s.uniter)
 }
 
+func (s *uniterV0Suite) TestCharmArchiveURLs(c *gc.C) {
+	s.testCharmArchiveURLs(c, s.uniter)
+}
+
 func (s *uniterV0Suite) TestCurrentEnvironUUID(c *gc.C) {
 	s.testCurrentEnvironUUID(c, s.uniter)
 }

--- a/apiserver/uniter/uniter_v1_test.go
+++ b/apiserver/uniter/uniter_v1_test.go
@@ -182,6 +182,10 @@ func (s *uniterV1Suite) TestCharmArchiveSha256(c *gc.C) {
 	s.testCharmArchiveSha256(c, s.uniter)
 }
 
+func (s *uniterV1Suite) TestCharmArchiveURLs(c *gc.C) {
+	s.testCharmArchiveURLs(c, s.uniter)
+}
+
 func (s *uniterV1Suite) TestCurrentEnvironUUID(c *gc.C) {
 	s.testCurrentEnvironUUID(c, s.uniter)
 }

--- a/worker/uniter/charm/charm.go
+++ b/worker/uniter/charm/charm.go
@@ -39,8 +39,9 @@ type BundleInfo interface {
 	// URL returns the charm URL identifying the bundle.
 	URL() *charm.URL
 
-	// Archive URL returns the location of the bundle data.
-	ArchiveURL() *url.URL
+	// ArchiveURLs returns the location(s) of the bundle data. ArchiveURLs
+	// may return multiple URLs; each should be tried until one succeeds.
+	ArchiveURLs() ([]*url.URL, error)
 
 	// ArchiveSha256 returns the hex-encoded SHA-256 digest of the bundle data.
 	ArchiveSha256() (string, error)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1740,7 +1740,7 @@ func (s *UniterSuite) TestSubordinateDying(c *gc.C) {
 		charms:  make(map[string][]byte),
 	}
 
-	testing.AddStateServerMachine(c, ctx.st)
+	addStateServerMachine(c, ctx.st)
 
 	// Create the subordinate service.
 	dir := testcharms.Repo.ClonedDir(c.MkDir(), "logging")
@@ -1946,11 +1946,22 @@ type ensureStateWorker struct{}
 func (s ensureStateWorker) step(c *gc.C, ctx *context) {
 	addresses, err := ctx.st.Addresses()
 	if err != nil || len(addresses) == 0 {
-		testing.AddStateServerMachine(c, ctx.st)
+		addStateServerMachine(c, ctx.st)
 	}
 	addresses, err = ctx.st.APIAddressesFromMachines()
 	c.Assert(err, gc.IsNil)
 	c.Assert(addresses, gc.HasLen, 1)
+}
+
+func addStateServerMachine(c *gc.C, st *state.State) {
+	// The AddStateServerMachine call will update the API host ports
+	// to made-up addresses. We need valid addresses so that the uniter
+	// can download charms from the API server.
+	apiHostPorts, err := st.APIHostPorts()
+	c.Assert(err, gc.IsNil)
+	testing.AddStateServerMachine(c, st)
+	err = st.SetAPIHostPorts(apiHostPorts)
+	c.Assert(err, gc.IsNil)
 }
 
 type createCharm struct {


### PR DESCRIPTION
The client no longer determines the charm archive URL
from the current API server address, but instead queries
the API server for a list of URLs to attempt. The uniter
will try each URL until one works.

Fixes https://bugs.launchpad.net/juju-core/+bug/1394976

(Review request: http://reviews.vapour.ws/r/522/)
