### PR TITLE
Version detection for CentOS 7

### DIFF
--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -130,7 +130,6 @@ func (s *BootstrapSuite) TearDownSuite(c *gc.C) {
 
 func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.PatchValue(&version.Current.Series, "trusty") // for predictable tools
 	s.PatchValue(&sshGenerateKey, func(name string) (string, string, error) {
 		return "private-key", "public-key", nil
 	})

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -159,16 +159,18 @@ func (p environProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Conf
 		setIfNotBlank(config.FtpProxyKey, proxySettings.Ftp)
 		setIfNotBlank(config.NoProxyKey, proxySettings.NoProxy)
 	}
-	if cfg.AptHttpProxy() == "" &&
-		cfg.AptHttpsProxy() == "" &&
-		cfg.AptFtpProxy() == "" {
-		proxySettings, err := detectAptProxies()
-		if err != nil {
-			return nil, err
+	if version.Current.OS == version.Ubuntu {
+		if cfg.AptHttpProxy() == "" &&
+			cfg.AptHttpsProxy() == "" &&
+			cfg.AptFtpProxy() == "" {
+			proxySettings, err := detectAptProxies()
+			if err != nil {
+				return nil, err
+			}
+			setIfNotBlank(config.AptHttpProxyKey, proxySettings.Http)
+			setIfNotBlank(config.AptHttpsProxyKey, proxySettings.Https)
+			setIfNotBlank(config.AptFtpProxyKey, proxySettings.Ftp)
 		}
-		setIfNotBlank(config.AptHttpProxyKey, proxySettings.Http)
-		setIfNotBlank(config.AptHttpsProxyKey, proxySettings.Https)
-		setIfNotBlank(config.AptFtpProxyKey, proxySettings.Ftp)
 	}
 	if len(attrs) > 0 {
 		cfg, err = cfg.Apply(attrs)

--- a/provider/local/environprovider_test.go
+++ b/provider/local/environprovider_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/provider"
 	"github.com/juju/juju/provider/local"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type baseProviderSuite struct {
@@ -245,10 +246,11 @@ Acquire::magic::Proxy "none";
 		c.Assert(envConfig.FtpProxy(), gc.Equals, test.expectedProxy.Ftp)
 		c.Assert(envConfig.NoProxy(), gc.Equals, test.expectedProxy.NoProxy)
 
-		c.Assert(envConfig.AptHttpProxy(), gc.Equals, test.expectedAptProxy.Http)
-		c.Assert(envConfig.AptHttpsProxy(), gc.Equals, test.expectedAptProxy.Https)
-		c.Assert(envConfig.AptFtpProxy(), gc.Equals, test.expectedAptProxy.Ftp)
-
+		if version.Current.OS == version.Ubuntu {
+			c.Assert(envConfig.AptHttpProxy(), gc.Equals, test.expectedAptProxy.Http)
+			c.Assert(envConfig.AptHttpsProxy(), gc.Equals, test.expectedAptProxy.Https)
+			c.Assert(envConfig.AptFtpProxy(), gc.Equals, test.expectedAptProxy.Ftp)
+		}
 		for _, clean := range cleanup {
 			clean()
 		}

--- a/version/current_test.go
+++ b/version/current_test.go
@@ -34,6 +34,14 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 			c.Assert(s, gc.Equals, "n/a")
 		}
 	} else {
-		c.Assert(string(out), gc.Equals, "Codename:\t"+s+"\n")
+		os, err := version.GetOSFromSeries(s)
+		c.Assert(err, gc.IsNil)
+		// There is no lsb_release command on CentOS.
+		switch os {
+		case version.CentOS:
+			c.Check(s, gc.Matches, `centos7`)
+		default:
+			c.Assert(string(out), gc.Equals, "Codename:\t"+s+"\n")
+		}
 	}
 }

--- a/version/export_test.go
+++ b/version/export_test.go
@@ -9,7 +9,7 @@ var (
 	KernelToMajor                 = kernelToMajor
 	MacOSXSeriesFromKernelVersion = macOSXSeriesFromKernelVersion
 	MacOSXSeriesFromMajorVersion  = macOSXSeriesFromMajorVersion
-	LSBReleaseFileVar             = &lsbReleaseFile
+	OSReleaseFile                 = &osReleaseFile
 )
 
 func SetSeriesVersions(value map[string]string) func() {

--- a/version/osversion_linux.go
+++ b/version/osversion_linux.go
@@ -4,5 +4,5 @@
 package version
 
 func osVersion() (string, error) {
-	return readSeries(lsbReleaseFile)
+	return readSeries()
 }

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -19,6 +19,7 @@ const (
 	Ubuntu
 	Windows
 	OSX
+	CentOS
 )
 
 func (t OSType) String() string {
@@ -29,6 +30,8 @@ func (t OSType) String() string {
 		return "Windows"
 	case OSX:
 		return "OSX"
+	case CentOS:
+		return "CentOS"
 	}
 	return "Unknown"
 }
@@ -45,6 +48,7 @@ var seriesVersions = map[string]string{
 	"saucy":       "13.10",
 	"trusty":      "14.04",
 	"utopic":      "14.10",
+	"vivid":       "15.04",
 	"win2012hvr2": "win2012hvr2",
 	"win2012hv":   "win2012hv",
 	"win2012r2":   "win2012r2",
@@ -52,16 +56,21 @@ var seriesVersions = map[string]string{
 	"win7":        "win7",
 	"win8":        "win8",
 	"win81":       "win81",
+	"centos7":     "7",
 }
 
-var ubuntuSeries = []string{
-	"precise",
-	"quantal",
-	"raring",
-	"saucy",
-	"trusty",
-	"utopic",
-	"vivid",
+var centosSeries = map[string]string{
+	"centos7": "7",
+}
+
+var ubuntuSeries = map[string]string{
+	"precise": "12.04",
+	"quantal": "12.10",
+	"raring":  "13.04",
+	"saucy":   "13.10",
+	"trusty":  "14.04",
+	"utopic":  "14.10",
+	"vivid":   "15.04",
 }
 
 // windowsVersions is a mapping consisting of the output from
@@ -89,10 +98,11 @@ var distroInfo = "/usr/share/distro-info/ubuntu.csv"
 // GetOSFromSeries will return the operating system based
 // on the series that is passed to it
 func GetOSFromSeries(series string) (OSType, error) {
-	for _, val := range ubuntuSeries {
-		if val == series {
-			return Ubuntu, nil
-		}
+	if _, ok := ubuntuSeries[series]; ok {
+		return Ubuntu, nil
+	}
+	if _, ok := centosSeries[series]; ok {
+		return CentOS, nil
 	}
 	for _, val := range windowsVersions {
 		if val == series {
@@ -204,6 +214,7 @@ func updateDistroInfo() error {
 		// the numeric version may contain a LTS moniker so strip that out.
 		seriesInfo := strings.Split(parts[0], " ")
 		seriesVersions[series] = seriesInfo[0]
+		ubuntuSeries[series] = seriesInfo[0]
 	}
 	return nil
 }

--- a/version/supportedseries_linux_test.go
+++ b/version/supportedseries_linux_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func (s *supportedSeriesSuite) TestSeriesVersion(c *gc.C) {
+	// There is no distro-info on Windows or CentOS.
+	if version.Current.OS != version.Ubuntu {
+		c.Skip("This test is only relevant on Ubuntu.")
+	}
 	vers, err := version.SeriesVersion("precise")
 	if err != nil && err.Error() == `invalid series "precise"` {
 		c.Fatalf(`Unable to lookup series "precise", you may need to: apt-get install distro-info`)

--- a/version/supportedseries_test.go
+++ b/version/supportedseries_test.go
@@ -39,6 +39,9 @@ var getOSFromSeriesTests = []struct {
 }, {
 	series: "mountainlion",
 	want:   version.OSX,
+}, {
+	series: "centos7",
+	want:   version.CentOS,
 }}
 
 func (s *supportedSeriesSuite) TestGetOSFromSeries(c *gc.C) {
@@ -55,13 +58,16 @@ func (s *supportedSeriesSuite) TestGetOSFromSeries(c *gc.C) {
 
 func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
 	version.SetSeriesVersions(map[string]string{
-		"trusty": "14.04",
-		"utopic": "14.10",
-		"win7":   "win7",
-		"win81":  "win81",
+		"trusty":  "14.04",
+		"utopic":  "14.10",
+		"win7":    "win7",
+		"win81":   "win81",
+		"centos7": "centos7",
 	})
 	series := version.OSSupportedSeries(version.Ubuntu)
 	c.Assert(series, jc.SameContents, []string{"trusty", "utopic"})
 	series = version.OSSupportedSeries(version.Windows)
 	c.Assert(series, jc.SameContents, []string{"win7", "win81"})
+	series = version.OSSupportedSeries(version.CentOS)
+	c.Assert(series, jc.SameContents, []string{"centos7"})
 }

--- a/version/supportedseries_windows_test.go
+++ b/version/supportedseries_windows_test.go
@@ -32,7 +32,23 @@ func (s *supportedSeriesWindowsSuite) TestSeriesVersion(c *gc.C) {
 }
 
 func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
-	expectedSeries := []string{"precise", "quantal", "raring", "saucy", "trusty", "utopic", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win7", "win8", "win81"}
+	expectedSeries := []string{
+		"centos7",
+		"precise",
+		"quantal",
+		"raring",
+		"saucy",
+		"trusty",
+		"utopic",
+		"vivid",
+		"win2012",
+		"win2012hv",
+		"win2012hvr2",
+		"win2012r2",
+		"win7",
+		"win8",
+		"win81",
+	}
 	series := version.SupportedSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)

--- a/version/version.go
+++ b/version/version.go
@@ -29,9 +29,9 @@ const version = "1.22-alpha1"
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")
 
-// lsbReleaseFile is the name of the file that is read in order to determine
-// the release version of ubuntu.
-var lsbReleaseFile = "/etc/lsb-release"
+// osReleaseFile is the name of the file that is read in order to determine
+// the linux type release version.
+var osReleaseFile = "/etc/os-release"
 
 var osVers = mustOSVersion()
 
@@ -346,21 +346,15 @@ func (v Number) IsDev() bool {
 	return v.Tag != "" || v.Build > 0
 }
 
-// ReleaseVersion looks for the value of DISTRIB_RELEASE in the content of
-// the lsbReleaseFile.  If the value is not found, the file is not found, or
+// ReleaseVersion looks for the value of VERSION_ID in the content of
+// the os-release.  If the value is not found, the file is not found, or
 // an error occurs reading the file, an empty string is returned.
 func ReleaseVersion() string {
-	content, err := ioutil.ReadFile(lsbReleaseFile)
+	release, err := readOSRelease()
 	if err != nil {
 		return ""
 	}
-	const prefix = "DISTRIB_RELEASE="
-	for _, line := range strings.Split(string(content), "\n") {
-		if strings.HasPrefix(line, prefix) {
-			return strings.Trim(line[len(prefix):], "\t '\"")
-		}
-	}
-	return ""
+	return release["VERSION_ID"]
 }
 
 // ParseMajorMinor takes an argument of the form "major.minor" and returns ints major and minor.

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -333,42 +333,55 @@ func (s *suite) TestUseFastLXC(c *gc.C) {
 	}{{
 		message: "missing release file",
 	}, {
-		message:        "missing prefix in file",
+		message:        "OS release file is missing ID",
 		releaseContent: "some junk\nand more junk",
 	}, {
 		message: "precise release",
 		releaseContent: `
-DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=12.04
-DISTRIB_CODENAME=precise
-DISTRIB_DESCRIPTION="Ubuntu 12.04.3 LTS"
+NAME="Ubuntu"
+VERSION="12.04 LTS, Precise"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 12.04.3 LTS"
+VERSION_ID="12.04"
 `,
 		expected: "12.04",
 	}, {
 		message: "trusty release",
 		releaseContent: `
-DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=14.04
-DISTRIB_CODENAME=trusty
-DISTRIB_DESCRIPTION="Ubuntu Trusty Tahr (development branch)"
+NAME="Ubuntu"
+VERSION="14.04.1 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.1 LTS"
+VERSION_ID="14.04"
 `,
 		expected: "14.04",
 	}, {
-		message:        "minimal trusty release",
-		releaseContent: `DISTRIB_RELEASE=14.04`,
-		expected:       "14.04",
+		message: "minimal trusty release",
+		releaseContent: `
+ID=ubuntu
+VERSION_ID="14.04"
+`,
+		expected: "14.04",
 	}, {
-		message:        "minimal unstable unicorn",
-		releaseContent: `DISTRIB_RELEASE=14.10`,
-		expected:       "14.10",
+		message: "minimal unstable unicorn",
+		releaseContent: `
+ID=ubuntu
+VERSION_ID="14.10"
+`,
+		expected: "14.10",
 	}, {
-		message:        "minimal jaunty",
-		releaseContent: `DISTRIB_RELEASE=9.10`,
-		expected:       "9.10",
+		message: "minimal jaunty",
+		releaseContent: `
+ID=ubuntu
+VERSION_ID="9.10"
+`,
+		expected: "9.10",
 	}} {
 		c.Logf("%v: %v", i, test.message)
-		filename := filepath.Join(c.MkDir(), "lsbRelease")
-		s.PatchValue(version.LSBReleaseFileVar, filename)
+		filename := filepath.Join(c.MkDir(), "os-release")
+		s.PatchValue(version.OSReleaseFile, filename)
 		if test.releaseContent != "" {
 			err := ioutil.WriteFile(filename, []byte(test.releaseContent+"\n"), 0644)
 			c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/env.go
+++ b/worker/uniter/runner/env.go
@@ -17,17 +17,30 @@ func osDependentEnvVars(paths Paths) []string {
 		return windowsEnv(paths)
 	case version.Ubuntu:
 		return ubuntuEnv(paths)
+	case version.CentOS:
+		return centosEnv(paths)
 	}
 	return nil
 }
 
+func appendPath(paths Paths) []string {
+	return []string{
+		"PATH=" + paths.GetToolsDir() + ":" + os.Getenv("PATH"),
+	}
+}
+
 func ubuntuEnv(paths Paths) []string {
+	path := appendPath(paths)
 	env := []string{
 		"APT_LISTCHANGES_FRONTEND=none",
 		"DEBIAN_FRONTEND=noninteractive",
-		"PATH=" + paths.GetToolsDir() + ":" + os.Getenv("PATH"),
 	}
+	env = append(env, path...)
 	return env
+}
+
+func centosEnv(paths Paths) []string {
+	return appendPath(paths)
 }
 
 // windowsEnv adds windows specific environment variables. PSModulePath


### PR DESCRIPTION
This is the first PR in getting CentOS 7 support into juju-core 
- Detect when runing on CentOS 7
- This commit also makes all tests pass on CentOS

(Review request: http://reviews.vapour.ws/r/525/)
