### PR TITLE
Only start the identity-file-writer if managing state.

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -240,13 +240,6 @@ func (a *MachineAgent) Run(_ *cmd.Context) error {
 	a.runner.StartWorker("termination", func() (worker.Worker, error) {
 		return terminationworker.NewWorker(), nil
 	})
-	a.startWorkerAfterUpgrade(a.runner, "identity-file-writer", func() (worker.Worker, error) {
-		inner := func(<-chan struct{}) error {
-			agentConfig := a.CurrentConfig()
-			return agent.WriteSystemIdentityFile(agentConfig)
-		}
-		return worker.NewSimpleWorker(inner), nil
-	})
 	// At this point, all workers will have been configured to start
 	close(a.workersStarted)
 	err := a.runner.Wait()
@@ -556,6 +549,13 @@ func (a *MachineAgent) APIWorker() (worker.Worker, error) {
 			})
 			a.startWorkerAfterUpgrade(runner, "metricsenderworker", func() (worker.Worker, error) {
 				return metricworker.NewSender(getMetricAPI(st)), nil
+			})
+			a.startWorkerAfterUpgrade(runner, "identity-file-writer", func() (worker.Worker, error) {
+				inner := func(<-chan struct{}) error {
+					agentConfig := a.CurrentConfig()
+					return agent.WriteSystemIdentityFile(agentConfig)
+				}
+				return worker.NewSimpleWorker(inner), nil
 			})
 		case params.JobManageStateDeprecated:
 			// Legacy environments may set this, but we ignore it.


### PR DESCRIPTION
Same fix as in master.

(Review request: http://reviews.vapour.ws/r/535/)
