### PR TITLE
worker/rsyslog: use namespace in the syslog tag

### DIFF
--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -31,8 +31,9 @@ func TestPackage(t *stdtesting.T) {
 type RsyslogSuite struct {
 	jujutesting.JujuConnSuite
 
-	st      *api.State
-	machine *state.Machine
+	st       *api.State
+	machine  *state.Machine
+	dialTags []string
 }
 
 var _ = gc.Suite(&RsyslogSuite{})
@@ -65,7 +66,9 @@ func (s *RsyslogSuite) SetUpSuite(c *gc.C) {
 func (s *RsyslogSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.PatchValue(rsyslog.RestartRsyslog, func() error { return nil })
+	s.dialTags = nil
 	s.PatchValue(rsyslog.DialSyslog, func(network, raddr string, priority syslog.Priority, tag string, tlsCfg *tls.Config) (*syslog.Writer, error) {
+		s.dialTags = append(s.dialTags, tag)
 		return &syslog.Writer{}, nil
 	})
 	s.PatchValue(rsyslog.LogDir, c.MkDir())
@@ -81,7 +84,7 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
 	addrs := []string{"0.1.2.3", "0.2.4.6"}
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", addrs)
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "foo", addrs)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -93,4 +96,7 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 	c.Assert(string(caCertPEM), gc.DeepEquals, coretesting.CACert)
 
 	c.Assert(*rsyslog.SyslogTargets, gc.HasLen, 2)
+	for _, dialTag := range s.dialTags {
+		c.Assert(dialTag, gc.Equals, "juju-foo-"+m.Tag().String())
+	}
 }

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -179,7 +179,9 @@ func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {
 			host = j
 		}
 		target := fmt.Sprintf("%s:%d", host, h.syslogConfig.Port)
-		writer, err := dialSyslog("tcp", target, rsyslog.LOG_DEBUG, "juju-"+h.tag.String(), tlsConf)
+		logTag := "juju" + h.syslogConfig.Namespace + "-" + h.tag.String()
+		logger.Debugf("making syslog connection for %q to %s", logTag, target)
+		writer, err := dialSyslog("tcp", target, rsyslog.LOG_DEBUG, logTag, tlsConf)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Without this, the syslog client may not be using the syslog tag expected by rsyslogd on the state servers. This issue only affected the local provider.

Fixes LP 1396796.

(Review request: http://reviews.vapour.ws/r/538/)
