### PR TITLE
worker/rsyslog: use namespace in the syslog tag

### DIFF
--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -179,7 +179,9 @@ func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {
 			host = j
 		}
 		target := fmt.Sprintf("%s:%d", host, h.syslogConfig.Port)
-		writer, err := dialSyslog("tcp", target, rsyslog.LOG_DEBUG, "juju-"+h.tag.String(), tlsConf)
+		logTag := "juju" + h.syslogConfig.Namespace + "-" + h.tag.String()
+		logger.Debugf("making syslog connection for %q to %s", logTag, target)
+		writer, err := dialSyslog("tcp", target, rsyslog.LOG_DEBUG, logTag, tlsConf)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Without this, the syslog client may not be using the syslog tag expected by rsyslogd on the state servers. This issue only affected the local provider.

Fixes LP 1396796.

(Review request: http://reviews.vapour.ws/r/539/)
