### PR TITLE
worker/diskmanager: don't publish disk partitions

### DIFF
--- a/worker/diskmanager/lsblk_test.go
+++ b/worker/diskmanager/lsblk_test.go
@@ -130,3 +130,18 @@ EOF`)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(devices, gc.HasLen, 0)
 }
+
+func (s *ListBlockDevicesSuite) TestListBlockDevicesDevicePartitions(c *gc.C) {
+	testing.PatchExecutable(c, s, "lsblk", `#!/bin/bash --norc
+cat <<EOF
+KNAME="sda" SIZE="240057409536" LABEL="" UUID="" TYPE="disk"
+KNAME="sda1" SIZE="254803968" LABEL="" UUID="" TYPE="part"
+EOF`)
+
+	devices, err := diskmanager.ListBlockDevices()
+	c.Assert(err, gc.IsNil)
+	c.Assert(devices, gc.DeepEquals, []storage.BlockDevice{{
+		DeviceName: "sda",
+		Size:       228936,
+	}})
+}


### PR DESCRIPTION
Don't publish partitions to state. Partitions may not be used
as there is no guarantee that the partition will remain available
(and we don't model hierarchy). Also, we will likely be using
partitions at least in some scenarios to synthesise a unique
identifier for block devices which can't otherwise be guaranteed.

(Review request: http://reviews.vapour.ws/r/540/)
