### PR TITLE
State: add EnvUUID to statusDoc

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -424,7 +424,8 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	return []txn.Op{
 		createConstraintsOp(st, machineGlobalKey(mdoc.Id), template.Constraints),
 		createStatusOp(st, machineGlobalKey(mdoc.Id), statusDoc{
-			Status: StatusPending,
+			Status:  StatusPending,
+			EnvUUID: st.EnvironUUID(),
 		}),
 		// TODO(dimitern) 2014-04-04 bug #1302498
 		// Once we can add networks independently of machine

--- a/state/service.go
+++ b/state/service.go
@@ -595,7 +595,8 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		Principal: principalName,
 	}
 	sdoc := statusDoc{
-		Status: StatusPending,
+		Status:  StatusPending,
+		EnvUUID: s.st.EnvironUUID(),
 	}
 	msdoc := meterStatusDoc{
 		Code: MeterNotSet,


### PR DESCRIPTION
Add State's environment UUID to the EnvUUID field of a statusDoc on creation.

(Review request: http://reviews.vapour.ws/r/543/)
