### PR TITLE
Fixed tests involving "file not found" system messages under Windows.

### DIFF
--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -58,7 +58,7 @@ func (s *debugLogSuite) TestNoAuth(c *gc.C) {
 
 func (s *debugLogSuite) TestNoLogfile(c *gc.C) {
 	reader := s.openWebsocket(c, nil)
-	s.assertErrorResponse(c, reader, "cannot open log file: .*: no such file or directory")
+	s.assertErrorResponse(c, reader, "cannot open log file: .*: "+utils.NoSuchFileErrRegexp)
 	s.assertWebsocketClosed(c, reader)
 }
 

--- a/cmd/juju/action/do_test.go
+++ b/cmd/juju/action/do_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v1"
 
@@ -220,7 +221,7 @@ func (s *DoSuite) TestRun(c *gc.C) {
 		withActionResults: []params.ActionResult{{
 			Action: &params.Action{Tag: validActionTagString},
 		}},
-		expectedErr: "open .*missing.yml: no such file or directory",
+		expectedErr: "open .*missing.yml: " + utils.NoSuchFileErrRegexp,
 	}, {
 		should: "fail with invalid yaml in file",
 		withArgs: []string{validUnitId, "some-action",

--- a/cmd/juju/set_test.go
+++ b/cmd/juju/set_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 
@@ -98,7 +99,7 @@ func (s *SetSuite) TestSetOptionFail(c *gc.C) {
 	assertSetFail(c, s.dir, []string{"=bar"}, "error: expected \"key=value\", got \"=bar\"\n")
 	assertSetFail(c, s.dir, []string{
 		"username=@missing.txt",
-	}, "error: cannot read option from file \"missing.txt\": .* no such file or directory\n")
+	}, "error: cannot read option from file \"missing.txt\": .* "+utils.NoSuchFileErrRegexp+"\n")
 	assertSetFail(c, s.dir, []string{
 		"username=@big.txt",
 	}, "error: size of option file is larger than 5M\n")
@@ -111,7 +112,7 @@ func (s *SetSuite) TestSetConfig(c *gc.C) {
 	assertSetFail(c, s.dir, []string{
 		"--config",
 		"missing.yaml",
-	}, "error.*no such file or directory\n")
+	}, "error.* "+utils.NoSuchFileErrRegexp+"\n")
 
 	assertSetSuccess(c, s.dir, s.svc, []string{
 		"--config",

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/exec"
 	"github.com/juju/utils/fslock"
 	gc "gopkg.in/check.v1"
@@ -200,7 +201,7 @@ func (s *RunTestSuite) TestMissingSocket(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = testing.RunCommand(c, &RunCommand{}, "foo/1", "bar")
-	c.Assert(err, gc.ErrorMatches, `dial unix .*/run.socket: no such file or directory`)
+	c.Assert(err, gc.ErrorMatches, `dial unix .*/run.socket: `+utils.NoSuchFileErrRegexp)
 }
 
 func (s *RunTestSuite) TestRunning(c *gc.C) {

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
@@ -181,7 +182,7 @@ func (*configSuite) TestChecksExistingCertFile(c *gc.C) {
 	newConfig, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = provider.Validate(newConfig, nil)
-	c.Check(err, gc.ErrorMatches, ".*"+nonExistingCertPath+": no such file or directory.*")
+	c.Check(err, gc.ErrorMatches, ".*"+nonExistingCertPath+": "+utils.NoSuchFileErrRegexp)
 }
 
 func (*configSuite) TestChecksLocationIsRequired(c *gc.C) {

--- a/provider/joyent/config_test.go
+++ b/provider/joyent/config_test.go
@@ -368,7 +368,7 @@ var prepareConfigTests = []struct {
 }, {
 	info:   "bad private-key-path errors, not panics",
 	insert: coretesting.Attrs{"private-key-path": "~/.ssh/no-such-file"},
-	err:    "invalid Joyent provider config: open .*: no such file or directory",
+	err:    "invalid Joyent provider config: open .*: " + utils.NoSuchFileErrRegexp,
 }}
 
 func (s *ConfigSuite) TestPrepare(c *gc.C) {

--- a/worker/uniter/runner/jujuc/tools_test.go
+++ b/worker/uniter/runner/jujuc/tools_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/symlink"
 	gc "gopkg.in/check.v1"
 
@@ -78,5 +79,5 @@ func (s *ToolsSuite) testEnsureSymlinks(c *gc.C, dir string) {
 
 func (s *ToolsSuite) TestEnsureSymlinksBadDir(c *gc.C) {
 	err := jujuc.EnsureSymlinks(filepath.Join(c.MkDir(), "noexist"))
-	c.Assert(err, gc.ErrorMatches, "cannot initialize hook commands in .*: no such file or directory")
+	c.Assert(err, gc.ErrorMatches, "cannot initialize hook commands in .*: "+utils.NoSuchFileErrRegexp)
 }

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/symlink"
 	gc "gopkg.in/check.v1"
 
@@ -239,7 +240,7 @@ func (s *UpgraderSuite) TestChangeAgentTools(c *gc.C) {
 	target := agenttools.ToolsDir(s.DataDir(), newToolsBinary)
 	link, err := symlink.Read(agenttools.ToolsDir(s.DataDir(), "anAgent"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(link, gc.Equals, target)
+	c.Assert(link, jc.SamePath, target)
 }
 
 func (s *UpgraderSuite) TestUsesAlreadyDownloadedToolsIfAvailable(c *gc.C) {
@@ -284,7 +285,7 @@ func (s *UpgraderSuite) TestUpgraderRefusesToDowngradeMinorVersions(c *gc.C) {
 	// TODO: ReadTools *should* be returning some form of errors.NotFound,
 	// however, it just passes back a fmt.Errorf so we live with it
 	// c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Check(err, gc.ErrorMatches, "cannot read tools metadata in tools directory.*no such file or directory")
+	c.Check(err, gc.ErrorMatches, "cannot read tools metadata in tools directory.*"+utils.NoSuchFileErrRegexp)
 }
 
 func (s *UpgraderSuite) TestUpgraderAllowsDowngradingPatchVersions(c *gc.C) {


### PR DESCRIPTION
Now tests which involve calls to the system and expect a "not found" response error are platform-agnostic.

This pull depends on [the platform-specific regex-es from the utils package](https://github.com/juju/utils/pull/93),
which in turn depends on [the addition of the NoSuchUser error type in the errors package](https://github.com/juju/errors/pull/14).

(Review request: http://reviews.vapour.ws/r/548/)