### PR TITLE
Actions :: EnqueueAction requires actionName

### DIFF
--- a/apiserver/action/action_test.go
+++ b/apiserver/action/action_test.go
@@ -206,7 +206,7 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 	c.Assert(res.Results[2].Error, gc.DeepEquals, expectedError)
 	c.Assert(res.Results[2].Action, gc.IsNil)
 
-	c.Assert(res.Results[3].Error, gc.ErrorMatches, "actionName required")
+	c.Assert(res.Results[3].Error, gc.ErrorMatches, "action name required")
 	c.Assert(res.Results[3].Action, gc.IsNil)
 
 	// Make sure an Action was enqueued for the wordpress Unit.

--- a/state/action.go
+++ b/state/action.go
@@ -289,7 +289,7 @@ func (st *State) FindActionTagsByPrefix(prefix string) []names.ActionTag {
 // EnqueueAction
 func (st *State) EnqueueAction(receiver names.Tag, actionName string, payload map[string]interface{}) (*Action, error) {
 	if len(actionName) == 0 {
-		return nil, errors.Errorf("actionName required")
+		return nil, errors.New("action name required")
 	}
 
 	receiverCollectionName, receiverId, err := st.tagToCollectionAndId(receiver)

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -94,7 +94,7 @@ func (s *ActionSuite) TestAddActionRequiresName(c *gc.C) {
 
 	// verify can not add an Action without a name
 	_, err := s.State.EnqueueAction(s.unit.Tag(), name, nil)
-	c.Assert(err, gc.ErrorMatches, "actionName required")
+	c.Assert(err, gc.ErrorMatches, "action name required")
 }
 
 func (s *ActionSuite) TestAddActionAcceptsDuplicateNames(c *gc.C) {


### PR DESCRIPTION
Make sure the action has a name before enqueuing it.

Trivial change just ensuring that a new action actually has a name.

(Review request: http://reviews.vapour.ws/r/550/)
