### PR TITLE
Update dependencies to pull in gwacl rev to update instance types

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -33,5 +33,5 @@ launchpad.net/goamz	bzr	martin.packman@canonical.com-20140813150539-umttn7s536u8
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20140730020217-xa1jyuytye6g1qie	12
 launchpad.net/gomaasapi	bzr	raphael.badin@canonical.com-20141030154602-5noqak0jfeao9opr	58
 launchpad.net/goose	bzr	tarmac-20140908075634-5iinsru19k3d8w55	128
-launchpad.net/gwacl	bzr	kapil.foss@gmail.com-20141201140824-thku7udu3pui4h7i	239
+launchpad.net/gwacl	bzr	ian.booth@canonical.com-20141202015546-xwvnwzh5uduag7mj	240
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/provider/azure/instancetype_test.go
+++ b/provider/azure/instancetype_test.go
@@ -227,7 +227,7 @@ var findInstanceSpecTests = []struct {
 	{
 		series: "precise",
 		cons:   "mem=7G cpu-cores=2",
-		itype:  "Large",
+		itype:  "D2",
 	}, {
 		series: "precise",
 		cons:   "instance-type=ExtraLarge",


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1389422

Update dependencies to pull in gwacl rev 239 so that new Azure instance types are available.

(Review request: http://reviews.vapour.ws/r/555/)
