### PR TITLE
When writing metadata, copy any released metadata to the legacy index file

### DIFF
--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -96,18 +96,26 @@ func makeExpectedOutput(templ, stream, toolsDir string) string {
 	return buf.String()
 }
 
+var expectedOutputDirectoryReleasedTemplate = expectedOutputCommon + `
+.*Writing tools/streams/v1/index2\.json
+.*Writing tools/streams/v1/index\.json
+.*Writing tools/streams/v1/com\.ubuntu\.juju-{{.Stream}}-tools\.json
+`
+
 var expectedOutputDirectoryTemplate = expectedOutputCommon + `
 .*Writing tools/streams/v1/index2\.json
 .*Writing tools/streams/v1/com\.ubuntu\.juju-{{.Stream}}-tools\.json
 `
+
 var expectedOutputMirrorsTemplate = expectedOutputCommon + `
 .*Writing tools/streams/v1/index2\.json
+.*Writing tools/streams/v1/index\.json
 .*Writing tools/streams/v1/com\.ubuntu\.juju-{{.Stream}}-tools\.json
 .*Writing tools/streams/v1/mirrors\.json
 `
 
 var expectedOutputDirectoryLegacyReleased = "No stream specified, defaulting to released tools in the releases directory.\n" +
-	makeExpectedOutput(expectedOutputDirectoryTemplate, "released", "releases")
+	makeExpectedOutput(expectedOutputDirectoryReleasedTemplate, "released", "releases")
 
 var expectedOutputMirrorsReleased = makeExpectedOutput(expectedOutputMirrorsTemplate, "released", "released")
 
@@ -311,6 +319,7 @@ Finding tools in .*
 .*Fetching tools from dir "released" to generate hash: %s
 .*Fetching tools from dir "released" to generate hash: %s
 .*Writing tools/streams/v1/index2\.json
+.*Writing tools/streams/v1/index\.json
 .*Writing tools/streams/v1/com\.ubuntu\.juju-released-tools\.json
 `[1:], regexp.QuoteMeta(versionStrings[0]), regexp.QuoteMeta(versionStrings[1]))
 	c.Assert(output, gc.Matches, expectedOutput)

--- a/environs/tools/export_test.go
+++ b/environs/tools/export_test.go
@@ -4,12 +4,13 @@
 package tools
 
 var (
-	Setenv                = setenv
-	FindExecutable        = findExecutable
-	CheckToolsSeries      = checkToolsSeries
-	ArchiveAndSHA256      = archiveAndSHA256
-	WriteMetadataFiles    = &writeMetadataFiles
-	CurrentStreamsVersion = currentStreamsVersion
+	Setenv                        = setenv
+	FindExecutable                = findExecutable
+	CheckToolsSeries              = checkToolsSeries
+	ArchiveAndSHA256              = archiveAndSHA256
+	WriteMetadataFiles            = &writeMetadataFiles
+	CurrentStreamsVersion         = currentStreamsVersion
+	MarshalToolsMetadataIndexJSON = marshalToolsMetadataIndexJSON
 )
 
 // SetSigningPublicKey sets a new public key for testing and returns the original key.

--- a/environs/tools/marshal.go
+++ b/environs/tools/marshal.go
@@ -28,29 +28,34 @@ func ProductMetadataPath(stream string) string {
 
 // MarshalToolsMetadataJSON marshals tools metadata to index and products JSON.
 // updated is the time at which the JSON file was updated.
-func MarshalToolsMetadataJSON(metadata map[string][]*ToolsMetadata, updated time.Time) (index []byte, products map[string][]byte, err error) {
-	if index, err = MarshalToolsMetadataIndexJSON(metadata, updated); err != nil {
-		return nil, nil, err
+func MarshalToolsMetadataJSON(metadata map[string][]*ToolsMetadata, updated time.Time) (index, legacyIndex []byte, products map[string][]byte, err error) {
+	if index, legacyIndex, err = marshalToolsMetadataIndexJSON(metadata, updated); err != nil {
+		return nil, nil, nil, err
 	}
 	if products, err = MarshalToolsMetadataProductsJSON(metadata, updated); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return index, products, err
+	return index, legacyIndex, products, err
 }
 
-// MarshalToolsMetadataIndexJSON marshals tools metadata to index JSON.
+// marshalToolsMetadataIndexJSON marshals tools metadata to index JSON.
 // updated is the time at which the JSON file was updated.
-func MarshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, updated time.Time) (out []byte, err error) {
+func marshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, updated time.Time) (out, outlegacy []byte, err error) {
 	var indices simplestreams.Indices
 	indices.Updated = updated.Format(time.RFC1123Z)
 	indices.Format = simplestreams.IndexFormat
 	indices.Indexes = make(map[string]*simplestreams.IndexMetadata, len(streamMetadata))
+
+	var indicesLegacy simplestreams.Indices
+	indicesLegacy.Updated = updated.Format(time.RFC1123Z)
+	indicesLegacy.Format = simplestreams.IndexFormat
+
 	for stream, metadata := range streamMetadata {
 		productIds := make([]string, len(metadata))
 		for i, t := range metadata {
 			productIds[i], err = t.productId()
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 		indexMetadata := &simplestreams.IndexMetadata{
@@ -61,8 +66,20 @@ func MarshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, u
 			ProductIds:       set.NewStrings(productIds...).SortedValues(),
 		}
 		indices.Indexes[ToolsContentId(stream)] = indexMetadata
+		if stream == ReleasedStream {
+			indicesLegacy.Indexes = make(map[string]*simplestreams.IndexMetadata, 1)
+			indicesLegacy.Indexes[ToolsContentId(stream)] = indexMetadata
+		}
 	}
-	return json.MarshalIndent(&indices, "", "    ")
+	out, err = json.MarshalIndent(&indices, "", "    ")
+	if len(indicesLegacy.Indexes) == 0 {
+		return out, nil, err
+	}
+	outlegacy, err = json.MarshalIndent(&indicesLegacy, "", "    ")
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, outlegacy, nil
 }
 
 // MarshalToolsMetadataProductsJSON marshals tools metadata to products JSON.

--- a/environs/tools/marshal_test.go
+++ b/environs/tools/marshal_test.go
@@ -38,7 +38,7 @@ func (s *marshalSuite) TestLargeNumber(c *gc.C) {
 				FileType: "tar.gz",
 			}},
 	}
-	_, products, err := tools.MarshalToolsMetadataJSON(metadata, time.Now())
+	_, _, products, err := tools.MarshalToolsMetadataJSON(metadata, time.Now())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(products["released"]), jc.Contains, `"size": 9223372036854775807`)
 }
@@ -55,6 +55,24 @@ var expectedIndex = `{
                 "com.ubuntu.juju:14.10:ppc64el"
             ]
         },
+        "com.ubuntu.juju:released:tools": {
+            "updated": "Thu, 01 Jan 1970 00:00:00 +0000",
+            "format": "products:1.0",
+            "datatype": "content-download",
+            "path": "streams/v1/com.ubuntu.juju-released-tools.json",
+            "products": [
+                "com.ubuntu.juju:12.04:amd64",
+                "com.ubuntu.juju:12.04:arm",
+                "com.ubuntu.juju:13.10:arm"
+            ]
+        }
+    },
+    "updated": "Thu, 01 Jan 1970 00:00:00 +0000",
+    "format": "index:1.0"
+}`
+
+var expectedLegacyIndex = `{
+    "index": {
         "com.ubuntu.juju:released:tools": {
             "updated": "Thu, 01 Jan 1970 00:00:00 +0000",
             "format": "products:1.0",
@@ -229,13 +247,13 @@ var proposedToolMetadataForTesting = []*tools.ToolsMetadata{
 }
 
 func (s *marshalSuite) TestMarshalIndex(c *gc.C) {
-	index, err := tools.MarshalToolsMetadataIndexJSON(s.streamMetadata, time.Unix(0, 0).UTC())
+	index, legacyIndex, err := tools.MarshalToolsMetadataIndexJSON(s.streamMetadata, time.Unix(0, 0).UTC())
 	c.Assert(err, jc.ErrorIsNil)
-	assertIndex(c, index)
-
+	assertIndex(c, index, expectedIndex)
+	assertIndex(c, legacyIndex, expectedLegacyIndex)
 }
 
-func assertIndex(c *gc.C, obtainedIndex []byte) {
+func assertIndex(c *gc.C, obtainedIndex []byte, expectedIndex string) {
 	// Unmarshall into objects so an order independent comparison can be done.
 	var obtained interface{}
 	err := json.Unmarshal(obtainedIndex, &obtained)
@@ -258,8 +276,19 @@ func assertProducts(c *gc.C, obtainedProducts map[string][]byte) {
 }
 
 func (s *marshalSuite) TestMarshal(c *gc.C) {
-	index, products, err := tools.MarshalToolsMetadataJSON(s.streamMetadata, time.Unix(0, 0).UTC())
+	index, legacyIndex, products, err := tools.MarshalToolsMetadataJSON(s.streamMetadata, time.Unix(0, 0).UTC())
 	c.Assert(err, jc.ErrorIsNil)
-	assertIndex(c, index)
+	assertIndex(c, index, expectedIndex)
+	assertIndex(c, legacyIndex, expectedLegacyIndex)
 	assertProducts(c, products)
+}
+
+func (s *marshalSuite) TestMarshalNoReleaseStream(c *gc.C) {
+	metadata := s.streamMetadata
+	delete(metadata, "released")
+	index, legacyIndex, products, err := tools.MarshalToolsMetadataJSON(s.streamMetadata, time.Unix(0, 0).UTC())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(legacyIndex, gc.IsNil)
+	c.Assert(index, gc.NotNil)
+	c.Assert(products, gc.NotNil)
 }

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -211,10 +211,13 @@ func generateMetadata(c *gc.C, stream string, versions ...version.Binary) []meta
 	var streamMetadata = map[string][]*tools.ToolsMetadata{
 		stream: metadata,
 	}
-	index, products, err := tools.MarshalToolsMetadataJSON(streamMetadata, time.Now())
+	index, legacyIndex, products, err := tools.MarshalToolsMetadataJSON(streamMetadata, time.Now())
 	c.Assert(err, jc.ErrorIsNil)
 	objects := []metadataFile{
 		{simplestreams.UnsignedIndex("v1", 2), index},
+	}
+	if stream == "released" {
+		objects = append(objects, metadataFile{simplestreams.UnsignedIndex("v1", 1), legacyIndex})
 	}
 	for stream, metadata := range products {
 		objects = append(objects, metadataFile{tools.ProductMetadataPath(stream), metadata})


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1396981

The legacy index.json file needs to be written out to contain any released metadata. This allows the current release scripts to work.

(Review request: http://reviews.vapour.ws/r/560/)
