### PR TITLE
Fixed lp:1395908 for 1.20 - disabled NICs from lshw stay disabled

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -506,7 +506,9 @@ func (environ *maasEnviron) ConstraintsValidator() (constraints.Validator, error
 
 // setupNetworks prepares a []network.Info for the given instance. Any
 // networks in networksToDisable will be configured as disabled on the
-// machine. The interface name discovered as primary is also returned.
+// machine. Any disabled network interfaces (as discovered from the
+// lshw output for the node) will stay disabled. The interface name
+// discovered as primary is also returned.
 func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisable set.Strings) ([]network.Info, string, error) {
 	// Get the instance network interfaces first.
 	interfaces, primaryIface, err := environ.getInstanceNetworkInterfaces(inst)
@@ -541,7 +543,7 @@ func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisa
 					VLANTag:       netw.VLANTag,
 					ProviderId:    network.Id(netw.Name),
 					NetworkName:   netw.Name,
-					Disabled:      disabled,
+					Disabled:      disabled || ifinfo.Disabled,
 				})
 			}
 		}
@@ -960,6 +962,7 @@ func (environ *maasEnviron) getInstanceNetworkInterfaces(inst instance.Instance)
 type ifaceInfo struct {
 	DeviceIndex   int
 	InterfaceName string
+	Disabled      bool
 }
 
 // extractInterfaces parses the XML output of lswh and extracts all
@@ -968,6 +971,7 @@ type ifaceInfo struct {
 func extractInterfaces(inst instance.Instance, lshwXML []byte) (map[string]ifaceInfo, string, error) {
 	type Node struct {
 		Id          string `xml:"id,attr"`
+		Disabled    bool   `xml:"disabled,attr,omitempty"`
 		Description string `xml:"description"`
 		Serial      string `xml:"serial"`
 		LogicalName string `xml:"logicalname"`
@@ -997,13 +1001,17 @@ func extractInterfaces(inst instance.Instance, lshwXML []byte) (map[string]iface
 						return errors.Annotatef(err, "lshw output for node %q has invalid ID suffix for %q", inst.Id(), node.Id)
 					}
 				}
-				if index == 0 && primaryIface == "" {
+				if primaryIface == "" && !node.Disabled {
 					primaryIface = node.LogicalName
 					logger.Debugf("node %q primary network interface is %q", inst.Id(), primaryIface)
 				}
 				interfaces[node.Serial] = ifaceInfo{
 					DeviceIndex:   index,
 					InterfaceName: node.LogicalName,
+					Disabled:      node.Disabled,
+				}
+				if node.Disabled {
+					logger.Debugf("node %q skipping disabled network interface %q", inst.Id(), node.LogicalName)
 				}
 			}
 			if err := processNodes(node.Children); err != nil {

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -166,7 +166,7 @@ const lshwXMLTemplate = `
    <description>Motherboard</description>
     <node id="pci" claimed="true" class="bridge" handle="PCIBUS:0000:00">
      <description>Host bridge</description>{{$list := .}}{{range $mac, $ifi := $list}}
-      <node id="network{{if gt (len $list) 1}}:{{$ifi.DeviceIndex}}{{end}}" claimed="true" class="network" handle="PCI:0000:00:03.0">
+      <node id="network{{if gt (len $list) 1}}:{{$ifi.DeviceIndex}}{{end}}"{{if $ifi.Disabled}} disabled="true"{{end}} claimed="true" class="network" handle="PCI:0000:00:03.0">
        <description>Ethernet interface</description>
        <product>82540EM Gigabit Ethernet Controller</product>
        <logicalname>{{$ifi.InterfaceName}}</logicalname>
@@ -200,7 +200,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 		`{"system_id": "node0", "hostname": "host0", "architecture": "%s/generic", "memory": 1024, "cpu_count": 1}`,
 		version.Current.Arch),
 	)
-	lshwXML, err := suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f0": {0, "eth0"}})
+	lshwXML, err := suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f0": {0, "eth0", false}})
 	c.Assert(err, gc.IsNil)
 	suite.testMAASObject.TestServer.AddNodeDetails("node0", lshwXML)
 	err = bootstrap.Bootstrap(coretesting.Context(c), env, environs.BootstrapParams{})
@@ -226,7 +226,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 		`{"system_id": "node1", "hostname": "host1", "architecture": "%s/generic", "memory": 1024, "cpu_count": 1}`,
 		version.Current.Arch),
 	)
-	lshwXML, err = suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f1": {0, "eth0"}})
+	lshwXML, err = suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f1": {0, "eth0", false}})
 	c.Assert(err, gc.IsNil)
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
 	// TODO(wallyworld) - test instance metadata
@@ -511,7 +511,7 @@ func (suite *environSuite) TestBootstrapSucceeds(c *gc.C) {
 		`{"system_id": "thenode", "hostname": "host", "architecture": "%s/generic", "memory": 256, "cpu_count": 8}`,
 		version.Current.Arch),
 	)
-	lshwXML, err := suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f0": {0, "eth0"}})
+	lshwXML, err := suite.generateHWTemplate(map[string]ifaceInfo{"aa:bb:cc:dd:ee:f0": {0, "eth0", false}})
 	c.Assert(err, gc.IsNil)
 	suite.testMAASObject.TestServer.AddNodeDetails("thenode", lshwXML)
 	err = bootstrap.Bootstrap(coretesting.Context(c), env, environs.BootstrapParams{})
@@ -704,7 +704,7 @@ const lshwXMLTestExtractInterfaces = `
     <node id="cpu" claimed="true" class="processor" handle="DMI:0004">
      <description>CPU</description>
       <node id="pci:2" claimed="true" class="bridge" handle="PCIBUS:0000:03">
-        <node id="network:0" claimed="true" class="network" handle="PCI:0000:03:00.0">
+        <node id="network:0" disabled="true" claimed="true" class="network" handle="PCI:0000:03:00.0">
          <logicalname>wlan0</logicalname>
          <serial>aa:bb:cc:dd:ee:ff</serial>
         </node>
@@ -727,20 +727,20 @@ func (suite *environSuite) TestExtractInterfaces(c *gc.C) {
 	inst := suite.getInstance("testInstance")
 	interfaces, primaryIface, err := extractInterfaces(inst, []byte(lshwXMLTestExtractInterfaces))
 	c.Assert(err, gc.IsNil)
-	c.Check(primaryIface, gc.Equals, "wlan0")
+	c.Check(primaryIface, gc.Equals, "eth0")
 	c.Check(interfaces, jc.DeepEquals, map[string]ifaceInfo{
-		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
-		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
-		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0", false},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1", false},
 	})
 }
 
 func (suite *environSuite) TestGetInstanceNetworkInterfaces(c *gc.C) {
 	inst := suite.getInstance("testInstance")
 	templateInterfaces := map[string]ifaceInfo{
-		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
-		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
-		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0", true},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1", false},
 	}
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, gc.IsNil)
@@ -748,16 +748,17 @@ func (suite *environSuite) TestGetInstanceNetworkInterfaces(c *gc.C) {
 	suite.testMAASObject.TestServer.AddNodeDetails("testInstance", lshwXML)
 	interfaces, primaryIface, err := inst.environ.getInstanceNetworkInterfaces(inst)
 	c.Assert(err, gc.IsNil)
-	c.Check(primaryIface, gc.Equals, "wlan0")
+	// Both wlan0 and eth0 are disabled in lshw output.
+	c.Check(primaryIface, gc.Equals, "vnet1")
 	c.Check(interfaces, jc.DeepEquals, templateInterfaces)
 }
 
 func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 	test_instance := suite.getInstance("node1")
 	templateInterfaces := map[string]ifaceInfo{
-		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
-		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
-		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0", true},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1", false},
 	}
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, gc.IsNil)
@@ -776,7 +777,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Note: order of networks is based on lshwXML
-	c.Check(primaryIface, gc.Equals, "wlan0")
+	c.Check(primaryIface, gc.Equals, "vnet1")
 	c.Check(networkInfo, jc.SameContents, []network.Info{
 		network.Info{
 			MACAddress:    "aa:bb:cc:dd:ee:ff",
@@ -786,7 +787,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			VLANTag:       0,
 			DeviceIndex:   0,
 			InterfaceName: "wlan0",
-			Disabled:      true,
+			Disabled:      true, // from networksToDisable("WLAN")
 		},
 		network.Info{
 			MACAddress:    "aa:bb:cc:dd:ee:f1",
@@ -796,7 +797,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			VLANTag:       42,
 			DeviceIndex:   1,
 			InterfaceName: "eth0",
-			Disabled:      false,
+			Disabled:      true, // from the lshw interface info
 		},
 		network.Info{
 			MACAddress:    "aa:bb:cc:dd:ee:f2",
@@ -815,9 +816,9 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	test_instance := suite.getInstance("node1")
 	templateInterfaces := map[string]ifaceInfo{
-		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
-		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
-		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0", false},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1", false},
 	}
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, gc.IsNil)
@@ -834,7 +835,7 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Note: order of networks is based on lshwXML
-	c.Check(primaryIface, gc.Equals, "wlan0")
+	c.Check(primaryIface, gc.Equals, "eth0")
 	c.Check(networkInfo, jc.SameContents, []network.Info{
 		network.Info{
 			MACAddress:    "aa:bb:cc:dd:ee:f1",
@@ -853,9 +854,9 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 func (suite *environSuite) TestSetupNetworksNoMatch(c *gc.C) {
 	test_instance := suite.getInstance("node1")
 	templateInterfaces := map[string]ifaceInfo{
-		"aa:bb:cc:dd:ee:ff": {0, "wlan0"},
-		"aa:bb:cc:dd:ee:f1": {1, "eth0"},
-		"aa:bb:cc:dd:ee:f2": {2, "vnet1"},
+		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
+		"aa:bb:cc:dd:ee:f1": {1, "eth0", false},
+		"aa:bb:cc:dd:ee:f2": {2, "vnet1", false},
 	}
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, gc.IsNil)
@@ -870,7 +871,7 @@ func (suite *environSuite) TestSetupNetworksNoMatch(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Note: order of networks is based on lshwXML
-	c.Check(primaryIface, gc.Equals, "wlan0")
+	c.Check(primaryIface, gc.Equals, "eth0")
 	c.Check(networkInfo, gc.HasLen, 0)
 }
 


### PR DESCRIPTION
Backported the fix from master - #1247.

Live tested on MAAS.

(Review request: http://reviews.vapour.ws/r/561/)
