### PR TITLE
Backport: Implemented peer-review suggestions.

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -43,36 +43,9 @@ func (c *Client) FullStatus(args params.StatusParams) (api.Status, error) {
 	if len(args.Patterns) > 0 {
 		predicate := BuildPredicateFor(args.Patterns)
 
-		// Filter machines
-		for status, machineList := range context.machines {
-			for idx, m := range machineList {
-				if matches, err := predicate(m); err != nil {
-					return noStatus, errors.Annotate(err, "could not filter machines")
-				} else if !matches {
-					// TODO(katco-): Check for index errors.
-					context.machines[status] = append(machineList[:idx], machineList[idx+1:]...)
-				}
-			}
-		}
-
-		// TODO(katco-): BUG:1385456
-		//
-		// Uncomment to begin service functionality. WARNING: There is
-		// a bug in which filtering will fail on if the service would
-		// not otherwise be filtered because of a parent or child unit
-		// not being filtered. It is because it only considers units
-		// of its own type
-
-		// // Filter services
-		// for svcName, svc := range context.services {
-		// 	if matches, err := predicate(svc); err != nil {
-		// 		return noStatus, errors.Annotate(err, "could not filter services")
-		// 	} else if !matches {
-		// 		delete(context.services, svcName)
-		// 	}
-		// }
-
 		// Filter units
+		var unfilteredSvcs set.Strings
+		var unfilteredMachines set.Strings
 		unitChainPredicate := UnitChainPredicateFn(predicate, context.unitByName)
 		for _, unitMap := range context.units {
 			for name, unit := range unitMap {
@@ -86,8 +59,56 @@ func (c *Client) FullStatus(args params.StatusParams) (api.Status, error) {
 					return noStatus, errors.Annotate(err, "could not filter units")
 				} else if !matches {
 					delete(unitMap, name)
+					continue
+				}
+
+				// Track which services are utilized by the units so
+				// that we can be sure to not filter that service out.
+				unfilteredSvcs.Add(unit.ServiceName())
+				machineId, err := unit.AssignedMachineId()
+				if err != nil {
+					return noStatus, err
+				}
+				unfilteredMachines.Add(machineId)
+			}
+		}
+
+		// Filter services
+		for svcName, svc := range context.services {
+			if unfilteredSvcs.Contains(svcName) {
+				// Don't filter services which have units that were
+				// not filtered.
+				continue
+			} else if matches, err := predicate(svc); err != nil {
+				return noStatus, errors.Annotate(err, "could not filter services")
+			} else if !matches {
+				delete(context.services, svcName)
+			}
+		}
+
+		// Filter machines
+		for status, machineList := range context.machines {
+			filteredList := make([]*state.Machine, 0, len(machineList))
+			for _, m := range machineList {
+				machineContainers, err := m.Containers()
+				if err != nil {
+					return noStatus, err
+				}
+				machineContainersSet := set.NewStrings(machineContainers...)
+
+				if unfilteredMachines.Contains(m.Id()) || !unfilteredMachines.Intersection(machineContainersSet).IsEmpty() {
+					// Don't filter machines which have an unfiltered
+					// unit running on them.
+					logger.Debugf("mid %s is hosting something.", m.Id())
+					filteredList = append(filteredList, m)
+					continue
+				} else if matches, err := predicate(m); err != nil {
+					return noStatus, errors.Annotate(err, "could not filter machines")
+				} else if matches {
+					filteredList = append(filteredList, m)
 				}
 			}
+			context.machines[status] = filteredList
 		}
 	}
 

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -1435,31 +1435,44 @@ var statusTests = []testCase{
 			},
 		},
 
-		// TODO(katco-): BUG:1385456: Filtering services is currently broken.
-		// // once again, with a scope on mysql/1
-		// scopedExpect{
-		// 	"machines with nested containers",
-		// 	[]string{"mysql/1"},
-		// 	M{
-		// 		"environment": "dummyenv",
-		// 		"machines": M{
-		// 			"1": machine1WithContainersScoped,
-		// 		},
-		// 		"services": M{
-		// 			"mysql": M{
-		// 				"charm":   "cs:quantal/mysql-1",
-		// 				"exposed": true,
-		// 				"units": M{
-		// 					"mysql/1": M{
-		// 						"machine":        "1/lxc/0",
-		// 						"agent-state":    "started",
-		// 						"public-address": "dummyenv-2.dns",
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		// once again, with a scope on mysql/1
+		scopedExpect{
+			"machines with nested containers",
+			[]string{"mysql/1"},
+			M{
+				"environment": "dummyenv",
+				"machines": M{
+					"1": M{
+						"agent-state": "started",
+						"containers": M{
+							"1/lxc/0": M{
+								"agent-state": "started",
+								"dns-name":    "dummyenv-2.dns",
+								"instance-id": "dummyenv-2",
+								"series":      "quantal",
+							},
+						},
+						"dns-name":    "dummyenv-1.dns",
+						"instance-id": "dummyenv-1",
+						"series":      "quantal",
+						"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+					},
+				},
+				"services": M{
+					"mysql": M{
+						"charm":   "cs:quantal/mysql-1",
+						"exposed": true,
+						"units": M{
+							"mysql/1": M{
+								"machine":        "1/lxc/0",
+								"agent-state":    "started",
+								"public-address": "dummyenv-2.dns",
+							},
+						},
+					},
+				},
+			},
+		},
 	), test(
 		"service with out of date charm",
 		addMachine{machineId: "0", job: state.JobManageEnviron},


### PR DESCRIPTION
- Obviated need for bounds checking by building up a slice instead of tearing one down.
- Behavior of service filtering as it was before new filtering infrastructure.

Conflicts:
    apiserver/client/status.go
    cmd/juju/status_test.go

(Review request: http://reviews.vapour.ws/r/569/)
