### PR TITLE
Merge pull request #1249 from wallyworld/generate-old-simplestreams-index

### DIFF
--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -95,18 +95,26 @@ func makeExpectedOutput(templ, stream, toolsDir string) string {
 	return buf.String()
 }
 
+var expectedOutputDirectoryReleasedTemplate = expectedOutputCommon + `
+.*Writing tools/streams/v1/index2\.json
+.*Writing tools/streams/v1/index\.json
+.*Writing tools/streams/v1/com\.ubuntu\.juju:{{.Stream}}:tools\.json
+`
+
 var expectedOutputDirectoryTemplate = expectedOutputCommon + `
 .*Writing tools/streams/v1/index2\.json
 .*Writing tools/streams/v1/com\.ubuntu\.juju:{{.Stream}}:tools\.json
 `
+
 var expectedOutputMirrorsTemplate = expectedOutputCommon + `
 .*Writing tools/streams/v1/index2\.json
+.*Writing tools/streams/v1/index\.json
 .*Writing tools/streams/v1/com\.ubuntu\.juju:{{.Stream}}:tools\.json
 .*Writing tools/streams/v1/mirrors\.json
 `
 
 var expectedOutputDirectoryLegacyReleased = "No stream specified, defaulting to released tools in the releases directory.\n" +
-	makeExpectedOutput(expectedOutputDirectoryTemplate, "released", "releases")
+	makeExpectedOutput(expectedOutputDirectoryReleasedTemplate, "released", "releases")
 
 var expectedOutputMirrorsReleased = makeExpectedOutput(expectedOutputMirrorsTemplate, "released", "released")
 
@@ -310,6 +318,7 @@ Finding tools in .*
 .*Fetching tools from dir "released" to generate hash: %s
 .*Fetching tools from dir "released" to generate hash: %s
 .*Writing tools/streams/v1/index2\.json
+.*Writing tools/streams/v1/index\.json
 .*Writing tools/streams/v1/com\.ubuntu\.juju:released:tools\.json
 `[1:], regexp.QuoteMeta(versionStrings[0]), regexp.QuoteMeta(versionStrings[1]))
 	c.Assert(output, gc.Matches, expectedOutput)

--- a/environs/tools/export_test.go
+++ b/environs/tools/export_test.go
@@ -4,12 +4,13 @@
 package tools
 
 var (
-	Setenv                = setenv
-	FindExecutable        = findExecutable
-	CheckToolsSeries      = checkToolsSeries
-	ArchiveAndSHA256      = archiveAndSHA256
-	WriteMetadataFiles    = &writeMetadataFiles
-	CurrentStreamsVersion = currentStreamsVersion
+	Setenv                        = setenv
+	FindExecutable                = findExecutable
+	CheckToolsSeries              = checkToolsSeries
+	ArchiveAndSHA256              = archiveAndSHA256
+	WriteMetadataFiles            = &writeMetadataFiles
+	CurrentStreamsVersion         = currentStreamsVersion
+	MarshalToolsMetadataIndexJSON = marshalToolsMetadataIndexJSON
 )
 
 // SetSigningPublicKey sets a new public key for testing and returns the original key.

--- a/environs/tools/marshal.go
+++ b/environs/tools/marshal.go
@@ -28,29 +28,34 @@ func ProductMetadataPath(stream string) string {
 
 // MarshalToolsMetadataJSON marshals tools metadata to index and products JSON.
 // updated is the time at which the JSON file was updated.
-func MarshalToolsMetadataJSON(metadata map[string][]*ToolsMetadata, updated time.Time) (index []byte, products map[string][]byte, err error) {
-	if index, err = MarshalToolsMetadataIndexJSON(metadata, updated); err != nil {
-		return nil, nil, err
+func MarshalToolsMetadataJSON(metadata map[string][]*ToolsMetadata, updated time.Time) (index, legacyIndex []byte, products map[string][]byte, err error) {
+	if index, legacyIndex, err = marshalToolsMetadataIndexJSON(metadata, updated); err != nil {
+		return nil, nil, nil, err
 	}
 	if products, err = MarshalToolsMetadataProductsJSON(metadata, updated); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return index, products, err
+	return index, legacyIndex, products, err
 }
 
-// MarshalToolsMetadataIndexJSON marshals tools metadata to index JSON.
+// marshalToolsMetadataIndexJSON marshals tools metadata to index JSON.
 // updated is the time at which the JSON file was updated.
-func MarshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, updated time.Time) (out []byte, err error) {
+func marshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, updated time.Time) (out, outlegacy []byte, err error) {
 	var indices simplestreams.Indices
 	indices.Updated = updated.Format(time.RFC1123Z)
 	indices.Format = simplestreams.IndexFormat
 	indices.Indexes = make(map[string]*simplestreams.IndexMetadata, len(streamMetadata))
+
+	var indicesLegacy simplestreams.Indices
+	indicesLegacy.Updated = updated.Format(time.RFC1123Z)
+	indicesLegacy.Format = simplestreams.IndexFormat
+
 	for stream, metadata := range streamMetadata {
 		productIds := make([]string, len(metadata))
 		for i, t := range metadata {
 			productIds[i], err = t.productId()
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 		indexMetadata := &simplestreams.IndexMetadata{
@@ -61,8 +66,20 @@ func MarshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, u
 			ProductIds:       set.NewStrings(productIds...).SortedValues(),
 		}
 		indices.Indexes[ToolsContentId(stream)] = indexMetadata
+		if stream == ReleasedStream {
+			indicesLegacy.Indexes = make(map[string]*simplestreams.IndexMetadata, 1)
+			indicesLegacy.Indexes[ToolsContentId(stream)] = indexMetadata
+		}
 	}
-	return json.MarshalIndent(&indices, "", "    ")
+	out, err = json.MarshalIndent(&indices, "", "    ")
+	if len(indicesLegacy.Indexes) == 0 {
+		return out, nil, err
+	}
+	outlegacy, err = json.MarshalIndent(&indicesLegacy, "", "    ")
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, outlegacy, nil
 }
 
 // MarshalToolsMetadataProductsJSON marshals tools metadata to products JSON.

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -5,9 +5,11 @@ package tools_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -389,6 +391,10 @@ func (s *simplestreamsSuite) assertWriteMetadata(c *gc.C, withMirrors bool) {
 	c.Assert(err, gc.IsNil)
 	metadata := toolstesting.ParseMetadataFromDir(c, dir, "proposed", withMirrors)
 	assertMetadataMatches(c, dir, "proposed", toolsList, metadata)
+
+	// No release stream generated so there will not be a legacy index file created.
+	_, err = writer.Get("tools/streams/v1/index.json")
+	c.Assert(err, gc.NotNil)
 }
 
 func (s *simplestreamsSuite) TestWriteMetadata(c *gc.C) {
@@ -830,7 +836,7 @@ func (*metadataHelperSuite) TestReadWriteMetadataSingleStream(c *gc.C) {
 	c.Assert(out, jc.DeepEquals, metadata)
 }
 
-func (*metadataHelperSuite) TestReadWriteMetadataMultipleStream(c *gc.C) {
+func (*metadataHelperSuite) writeMetadataMultipleStream(c *gc.C) (storage.StorageReader, map[string][]*tools.ToolsMetadata) {
 	metadata := map[string][]*tools.ToolsMetadata{
 		"released": []*tools.ToolsMetadata{{
 			Release: "precise",
@@ -853,9 +859,14 @@ func (*metadataHelperSuite) TestReadWriteMetadataMultipleStream(c *gc.C) {
 	c.Assert(err, gc.IsNil) // non-existence is not an error
 	err = tools.WriteMetadata(stor, metadata, []string{"released", "proposed"}, tools.DoNotWriteMirrors)
 	c.Assert(err, gc.IsNil)
+	return stor, metadata
+}
 
+func (s *metadataHelperSuite) TestReadWriteMetadataMultipleStream(c *gc.C) {
+	stor, metadata := s.writeMetadataMultipleStream(c)
 	// Read back what was just written.
-	out, err = tools.ReadAllMetadata(stor)
+	out, err := tools.ReadAllMetadata(stor)
+	c.Assert(err, gc.IsNil)
 	for _, outMetadata := range out {
 		for _, md := range outMetadata {
 			// FullPath is set by ReadAllMetadata.
@@ -864,6 +875,34 @@ func (*metadataHelperSuite) TestReadWriteMetadataMultipleStream(c *gc.C) {
 		}
 	}
 	c.Assert(out, jc.DeepEquals, metadata)
+}
+
+func (s *metadataHelperSuite) TestWriteMetadataLegacyIndex(c *gc.C) {
+	stor, _ := s.writeMetadataMultipleStream(c)
+	// Read back the legacy index
+	rdr, err := stor.Get("tools/streams/v1/index.json")
+	c.Assert(err, gc.IsNil)
+	data, err := ioutil.ReadAll(rdr)
+	c.Assert(err, gc.IsNil)
+	var indices simplestreams.Indices
+	err = json.Unmarshal(data, &indices)
+	c.Assert(err, gc.IsNil)
+	c.Assert(indices.Indexes, gc.HasLen, 1)
+	indices.Updated = ""
+	c.Assert(indices.Indexes["com.ubuntu.juju:released:tools"], gc.NotNil)
+	indices.Indexes["com.ubuntu.juju:released:tools"].Updated = ""
+	expected := simplestreams.Indices{
+		Format: "index:1.0",
+		Indexes: map[string]*simplestreams.IndexMetadata{
+			"com.ubuntu.juju:released:tools": &simplestreams.IndexMetadata{
+				Format:           "products:1.0",
+				DataType:         "content-download",
+				ProductsFilePath: "streams/v1/com.ubuntu.juju:released:tools.json",
+				ProductIds:       []string{"com.ubuntu.juju:12.04:amd64"},
+			},
+		},
+	}
+	c.Assert(indices, jc.DeepEquals, expected)
 }
 
 func (s *metadataHelperSuite) TestReadWriteMetadataUnchanged(c *gc.C) {
@@ -887,9 +926,10 @@ func (s *metadataHelperSuite) TestReadWriteMetadataUnchanged(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	s.PatchValue(tools.WriteMetadataFiles, func(stor storage.Storage, metadataInfo []tools.MetadataFile) error {
-		// The product data is the same, we only write the index.
-		c.Assert(metadataInfo, gc.HasLen, 1)
+		// The product data is the same, we only write the indices.
+		c.Assert(metadataInfo, gc.HasLen, 2)
 		c.Assert(metadataInfo[0].Path, gc.Equals, "streams/v1/index2.json")
+		c.Assert(metadataInfo[1].Path, gc.Equals, "streams/v1/index.json")
 		return nil
 	})
 	err = tools.WriteMetadata(stor, metadata, []string{"released"}, tools.DoNotWriteMirrors)

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -211,10 +211,13 @@ func generateMetadata(c *gc.C, stream string, versions ...version.Binary) []meta
 	var streamMetadata = map[string][]*tools.ToolsMetadata{
 		stream: metadata,
 	}
-	index, products, err := tools.MarshalToolsMetadataJSON(streamMetadata, time.Now())
+	index, legacyIndex, products, err := tools.MarshalToolsMetadataJSON(streamMetadata, time.Now())
 	c.Assert(err, gc.IsNil)
 	objects := []metadataFile{
 		{simplestreams.UnsignedIndex("v1", 2), index},
+	}
+	if stream == "released" {
+		objects = append(objects, metadataFile{simplestreams.UnsignedIndex("v1", 1), legacyIndex})
 	}
 	for stream, metadata := range products {
 		objects = append(objects, metadataFile{tools.ProductMetadataPath(stream), metadata})


### PR DESCRIPTION
Backport from master

When writing metadata, copy any released metadata to the legacy index file

Fixes: https://bugs.launchpad.net/juju-core/+bug/1396981

The legacy index.json file needs to be written out to contain any released metadata. This allows the current release scripts to work.

(Review request: http://reviews.vapour.ws/r/560/)

(Review request: http://reviews.vapour.ws/r/570/)
