### PR TITLE
Drop an import-cycle-waiting-to-happen from apiserver/params.

### DIFF
--- a/api/backups/create_test.go
+++ b/api/backups/create_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/backups"
+	apiserverbackups "github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
 	backupstesting "github.com/juju/juju/state/backups/testing"
 )
@@ -28,7 +29,7 @@ func (s *createSuite) TestCreate(c *gc.C) {
 			c.Check(p.Notes, gc.Equals, "important")
 
 			if result, ok := resp.(*params.BackupsMetadataResult); ok {
-				result.UpdateFromMetadata(s.Meta)
+				*result = apiserverbackups.ResultFromMetadata(s.Meta)
 				result.Notes = p.Notes
 			} else {
 				c.Fatalf("wrong output structure")

--- a/api/backups/info_test.go
+++ b/api/backups/info_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/backups"
+	apiserverbackups "github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -27,7 +28,7 @@ func (s *infoSuite) TestInfo(c *gc.C) {
 			c.Check(p.ID, gc.Equals, "spam")
 
 			if result, ok := resp.(*params.BackupsMetadataResult); ok {
-				result.UpdateFromMetadata(s.Meta)
+				*result = apiserverbackups.ResultFromMetadata(s.Meta)
 			} else {
 				c.Fatalf("wrong output structure")
 			}

--- a/api/backups/list_test.go
+++ b/api/backups/list_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/backups"
+	apiserverbackups "github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -26,9 +27,7 @@ func (s *listSuite) TestList(c *gc.C) {
 
 			if result, ok := resp.(*params.BackupsListResult); ok {
 				result.List = make([]params.BackupsMetadataResult, 1)
-				var resultItem params.BackupsMetadataResult
-				resultItem.UpdateFromMetadata(s.Meta)
-				result.List[0] = resultItem
+				result.List[0] = apiserverbackups.ResultFromMetadata(s.Meta)
 			} else {
 				c.Fatalf("wrong output structure")
 			}

--- a/api/backups/package_test.go
+++ b/api/backups/package_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/backups"
+	apiserverbackups "github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
 	stbackups "github.com/juju/juju/state/backups"
@@ -34,9 +35,8 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *baseSuite) metadataResult() *params.BackupsMetadataResult {
-	result := &params.BackupsMetadataResult{}
-	result.UpdateFromMetadata(s.Meta)
-	return result
+	result := apiserverbackups.ResultFromMetadata(s.Meta)
+	return &result
 }
 
 func (s *baseSuite) checkMetadataResult(c *gc.C, result *params.BackupsMetadataResult, meta *stbackups.Metadata) {

--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
 )
@@ -78,4 +79,32 @@ func extractResourceValue(resources *common.Resources, key string) (string, erro
 var newBackups = func(st *state.State) (backups.Backups, io.Closer) {
 	stor := backups.NewStorage(st)
 	return backups.NewBackups(stor), stor
+}
+
+// ResultFromMetadata updates the result with the information in the
+// metadata value.
+func ResultFromMetadata(meta *backups.Metadata) params.BackupsMetadataResult {
+	var result params.BackupsMetadataResult
+
+	result.ID = meta.ID()
+
+	result.Checksum = meta.Checksum()
+	result.ChecksumFormat = meta.ChecksumFormat()
+	result.Size = meta.Size()
+	if meta.Stored() != nil {
+		result.Stored = *(meta.Stored())
+	}
+
+	result.Started = meta.Started
+	if meta.Finished != nil {
+		result.Finished = *meta.Finished
+	}
+	result.Notes = meta.Notes
+
+	result.Environment = meta.Origin.Environment
+	result.Machine = meta.Origin.Machine
+	result.Hostname = meta.Origin.Hostname
+	result.Version = meta.Origin.Version
+
+	return result
 }

--- a/apiserver/backups/create.go
+++ b/apiserver/backups/create.go
@@ -45,7 +45,5 @@ func (a *API) Create(args params.BackupsCreateArgs) (p params.BackupsMetadataRes
 		return p, errors.Trace(err)
 	}
 
-	p.UpdateFromMetadata(meta)
-
-	return p, nil
+	return ResultFromMetadata(meta), nil
 }

--- a/apiserver/backups/create_test.go
+++ b/apiserver/backups/create_test.go
@@ -20,8 +20,7 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	var args params.BackupsCreateArgs
 	result, err := s.api.Create(args)
 	c.Assert(err, jc.ErrorIsNil)
-	var expected params.BackupsMetadataResult
-	expected.UpdateFromMetadata(s.meta)
+	expected := backups.ResultFromMetadata(s.meta)
 
 	c.Check(result, gc.DeepEquals, expected)
 }
@@ -37,8 +36,7 @@ func (s *backupsSuite) TestCreateNotes(c *gc.C) {
 	}
 	result, err := s.api.Create(args)
 	c.Assert(err, jc.ErrorIsNil)
-	var expected params.BackupsMetadataResult
-	expected.UpdateFromMetadata(s.meta)
+	expected := backups.ResultFromMetadata(s.meta)
 	expected.Notes = "this backup is important"
 
 	c.Check(result, gc.DeepEquals, expected)

--- a/apiserver/backups/info.go
+++ b/apiserver/backups/info.go
@@ -11,17 +11,13 @@ import (
 
 // Info provides the implementation of the API method.
 func (a *API) Info(args params.BackupsInfoArgs) (params.BackupsMetadataResult, error) {
-	var result params.BackupsMetadataResult
-
 	backups, closer := newBackups(a.st)
 	defer closer.Close()
 
 	meta, _, err := backups.Get(args.ID) // Ignore the archive file.
 	if err != nil {
-		return result, errors.Trace(err)
+		return params.BackupsMetadataResult{}, errors.Trace(err)
 	}
 
-	result.UpdateFromMetadata(meta)
-
-	return result, nil
+	return ResultFromMetadata(meta), nil
 }

--- a/apiserver/backups/info_test.go
+++ b/apiserver/backups/info_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -21,8 +22,7 @@ func (s *backupsSuite) TestInfoOkay(c *gc.C) {
 	}
 	result, err := s.api.Info(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.BackupsMetadataResult{}
-	expected.UpdateFromMetadata(s.meta)
+	expected := backups.ResultFromMetadata(s.meta)
 
 	c.Check(result, gc.DeepEquals, expected)
 }
@@ -34,8 +34,7 @@ func (s *backupsSuite) TestInfoMissingFile(c *gc.C) {
 	}
 	result, err := s.api.Info(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.BackupsMetadataResult{}
-	expected.UpdateFromMetadata(s.meta)
+	expected := backups.ResultFromMetadata(s.meta)
 
 	c.Check(result, gc.DeepEquals, expected)
 }

--- a/apiserver/backups/list.go
+++ b/apiserver/backups/list.go
@@ -23,9 +23,7 @@ func (a *API) List(args params.BackupsListArgs) (params.BackupsListResult, error
 
 	result.List = make([]params.BackupsMetadataResult, len(metaList))
 	for i, meta := range metaList {
-		var resultItem params.BackupsMetadataResult
-		resultItem.UpdateFromMetadata(meta)
-		result.List[i] = resultItem
+		result.List[i] = ResultFromMetadata(meta)
 	}
 
 	return result, nil

--- a/apiserver/backups/list_test.go
+++ b/apiserver/backups/list_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -20,8 +21,7 @@ func (s *backupsSuite) TestListOkay(c *gc.C) {
 	result, err := s.api.List(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	item := params.BackupsMetadataResult{}
-	item.UpdateFromMetadata(s.meta)
+	item := backups.ResultFromMetadata(s.meta)
 	expected := params.BackupsListResult{
 		List: []params.BackupsMetadataResult{item},
 	}

--- a/apiserver/params/backups.go
+++ b/apiserver/params/backups.go
@@ -6,7 +6,6 @@ package params
 import (
 	"time"
 
-	"github.com/juju/juju/state/backups"
 	"github.com/juju/juju/version"
 )
 
@@ -56,28 +55,4 @@ type BackupsMetadataResult struct {
 	Machine     string
 	Hostname    string
 	Version     version.Number
-}
-
-// UpdateFromMetadata updates the result with the information in the
-// metadata value.
-func (r *BackupsMetadataResult) UpdateFromMetadata(meta *backups.Metadata) {
-	r.ID = meta.ID()
-
-	r.Checksum = meta.Checksum()
-	r.ChecksumFormat = meta.ChecksumFormat()
-	r.Size = meta.Size()
-	if meta.Stored() != nil {
-		r.Stored = *(meta.Stored())
-	}
-
-	r.Started = meta.Started
-	if meta.Finished != nil {
-		r.Finished = *meta.Finished
-	}
-	r.Notes = meta.Notes
-
-	r.Environment = meta.Origin.Environment
-	r.Machine = meta.Origin.Machine
-	r.Hostname = meta.Origin.Hostname
-	r.Version = meta.Origin.Version
 }


### PR DESCRIPTION
Factor out the UpdateFromMetadata method of params.BackupsMetadataResult into apiserver/backups as ResultFromMetadata. This helps avoid the possibility of import cycles with anything backups imports since apiserver.params is imported in all sorts of places you wouldn't expect.

(Review request: http://reviews.vapour.ws/r/578/)
