### PR TITLE
Merge pull request #1266 from wallyworld/azure-services-for-env

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -892,16 +892,41 @@ func (env *azureEnviron) StopInstances(ids ...instance.Id) error {
 	return nil
 }
 
+// hostedServices returns all services for this environment.
+func (env *azureEnviron) hostedServices() ([]gwacl.HostedServiceDescriptor, error) {
+	snap := env.getSnapshot()
+	services, err := snap.api.ListHostedServices()
+	if err != nil {
+		return nil, err
+	}
+
+	var filteredServices []gwacl.HostedServiceDescriptor
+	// Service names are prefixed with the environment name, followed by "-".
+	// We must be careful not to include services where the environment name
+	// is a substring of another name. ie we mustn't allow "azure" to match "azure-1".
+	envPrefix := env.getEnvPrefix()
+	// Just in case.
+	filterPrefix := regexp.QuoteMeta(envPrefix)
+
+	// Now filter the services.
+	prefixMatch := regexp.MustCompile("^" + filterPrefix + "[^-]*$")
+	for _, service := range services {
+		if prefixMatch.Match([]byte(service.ServiceName)) {
+			filteredServices = append(filteredServices, service)
+		}
+	}
+	return filteredServices, nil
+}
+
 // destroyAllServices destroys all Cloud Services and deployments contained.
 // This is needed to clean up broken environments, in which there are cloud
 // services with no deployments.
 func (env *azureEnviron) destroyAllServices() error {
-	snap := env.getSnapshot()
-	request := &gwacl.ListPrefixedHostedServicesRequest{ServiceNamePrefix: env.getEnvPrefix()}
-	services, err := snap.api.ListPrefixedHostedServices(request)
+	services, err := env.hostedServices()
 	if err != nil {
 		return err
 	}
+	snap := env.getSnapshot()
 	for _, service := range services {
 		if err := snap.api.DeleteHostedService(service.ServiceName); err != nil {
 			return err
@@ -1013,8 +1038,7 @@ func (env *azureEnviron) AllInstances() ([]instance.Instance, error) {
 	// Acquire management API object.
 	snap := env.getSnapshot()
 
-	request := &gwacl.ListPrefixedHostedServicesRequest{ServiceNamePrefix: env.getEnvPrefix()}
-	serviceDescriptors, err := snap.api.ListPrefixedHostedServices(request)
+	serviceDescriptors, err := env.hostedServices()
 	if err != nil {
 		return nil, err
 	}

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -212,12 +212,14 @@ func (*environSuite) TestGetContainerName(c *gc.C) {
 
 func (suite *environSuite) TestAllInstances(c *gc.C) {
 	env := makeEnviron(c)
-	prefix := env.getEnvPrefix()
-	service1 := makeLegacyDeployment(env, prefix+"service1")
-	service2 := makeDeployment(env, prefix+"service2")
-	service3 := makeDeployment(env, "not"+prefix+"service3")
+	name := env.Config().Name()
+	service1 := makeLegacyDeployment(env, "juju-"+name+"-service1")
+	service2 := makeDeployment(env, "juju-"+name+"-service2")
+	service3 := makeDeployment(env, "notjuju-"+name+"-service3")
+	service4 := makeDeployment(env, "juju-"+name+"-1-service3")
 
-	requests := patchInstancesResponses(c, prefix, service1, service2, service3)
+	prefix := env.getEnvPrefix()
+	requests := patchInstancesResponses(c, prefix, service1, service2, service3, service4)
 	instances, err := env.AllInstances()
 	c.Assert(err, gc.IsNil)
 	c.Check(len(instances), gc.Equals, 3)
@@ -1070,12 +1072,15 @@ func assertOneRequestMatches(c *gc.C, requests []*gwacl.X509Request, method stri
 func (s *environSuite) TestDestroyStopsAllInstances(c *gc.C) {
 	env := makeEnviron(c)
 	s.setDummyStorage(c, env)
-	prefix := env.getEnvPrefix()
-	service1 := makeDeployment(env, prefix+"service1")
-	service2 := makeDeployment(env, prefix+"service2")
+	name := env.Config().Name()
+	service1 := makeDeployment(env, "juju-"+name+"-service1")
+	service2 := makeDeployment(env, "juju-"+name+"-service2")
+	service3 := makeDeployment(env, "juju-"+name+"-1-service3")
 
 	// The call to AllInstances() will return only one service (service1).
-	responses := getAzureServiceListResponse(c, service1.HostedServiceDescriptor, service2.HostedServiceDescriptor)
+	responses := getAzureServiceListResponse(
+		c, service1.HostedServiceDescriptor, service2.HostedServiceDescriptor, service3.HostedServiceDescriptor,
+	)
 	responses = append(responses, buildStatusOKResponses(c, 2)...) // DeleteHostedService
 	responses = append(responses, getVnetCleanupResponse(c))
 	responses = append(responses, buildStatusOKResponses(c, 1)...) // DeleteAffinityGroup


### PR DESCRIPTION
Ensure only instances for this environment are used in azure operations

Instead of using the gwacl method ListPrefixedHostedServices() which can return services from other environments, we use out own method to return services for this environment.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1398820

(Review request: http://reviews.vapour.ws/r/580/)

(Review request: http://reviews.vapour.ws/r/582/)
