### PR TITLE
Merge pull request #1164 from axw/ec2-blockdevicemapping-allephemeral

### DIFF
--- a/provider/ec2/ec2.go
+++ b/provider/ec2/ec2.go
@@ -704,7 +704,12 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 	}
 	var instResp *ec2.RunInstancesResp
 
-	device, diskSize := getDiskSize(args.Constraints)
+	blockDeviceMappings, err := getBlockDeviceMappings(args.Constraints)
+	if err != nil {
+		return nil, nil, nil, errors.Annotate(err, "cannot create block device mappings")
+	}
+	rootDiskSize := uint64(blockDeviceMappings[0].VolumeSize) * 1024
+
 	for _, availZone := range availabilityZones {
 		instResp, err = runInstances(e.ec2(), &ec2.RunInstances{
 			AvailZone:           availZone,
@@ -714,7 +719,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 			UserData:            userData,
 			InstanceType:        spec.InstanceType.Name,
 			SecurityGroups:      groups,
-			BlockDeviceMappings: []ec2.BlockDeviceMapping{device},
+			BlockDeviceMappings: blockDeviceMappings,
 		})
 		if isZoneConstrainedError(err) {
 			logger.Infof("%q is constrained, trying another availability zone", availZone)
@@ -746,7 +751,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (instance.Ins
 		Mem:      &spec.InstanceType.Mem,
 		CpuCores: &spec.InstanceType.CpuCores,
 		CpuPower: spec.InstanceType.CpuPower,
-		RootDisk: &diskSize,
+		RootDisk: &rootDiskSize,
 		// Tags currently not supported by EC2
 	}
 	return inst, &hc, nil, nil
@@ -777,29 +782,54 @@ func (e *environ) StopInstances(ids ...instance.Id) error {
 // minDiskSize is the minimum/default size (in megabytes) for ec2 root disks.
 const minDiskSize uint64 = 8 * 1024
 
-// getDiskSize translates a RootDisk constraint (or lackthereof) into a
-// BlockDeviceMapping request for EC2.  megs is the size in megabytes of
-// the disk that was requested.
-func getDiskSize(cons constraints.Value) (dvc ec2.BlockDeviceMapping, megs uint64) {
-	diskSize := minDiskSize
-
+// getBlockDeviceMappings translates a StartInstanceParams into
+// BlockDeviceMappings.
+//
+// The first entry is always the root disk mapping, instance stores
+// (ephemeral disks) last.
+func getBlockDeviceMappings(cons constraints.Value) ([]ec2.BlockDeviceMapping, error) {
+	rootDiskSize := minDiskSize
 	if cons.RootDisk != nil {
 		if *cons.RootDisk >= minDiskSize {
-			diskSize = *cons.RootDisk
+			rootDiskSize = *cons.RootDisk
 		} else {
-			logger.Infof("Ignoring root-disk constraint of %dM because it is smaller than the EC2 image size of %dM",
-				*cons.RootDisk, minDiskSize)
+			logger.Infof(
+				"Ignoring root-disk constraint of %dM because it is smaller than the EC2 image size of %dM",
+				*cons.RootDisk,
+				minDiskSize,
+			)
 		}
 	}
 
-	// AWS's volume size is in gigabytes, root-disk is in megabytes,
-	// so round up to the nearest gigabyte.
-	volsize := int64((diskSize + 1023) / 1024)
-	return ec2.BlockDeviceMapping{
-			DeviceName: "/dev/sda1",
-			VolumeSize: volsize,
-		},
-		uint64(volsize * 1024)
+	// The first block device is for the root disk.
+	blockDeviceMappings := []ec2.BlockDeviceMapping{{
+		DeviceName: "/dev/sda1",
+		VolumeSize: int64(roundVolumeSize(rootDiskSize)),
+	}}
+
+	// Not all machines have this many instance stores.
+	// Instances will be started with as many of the
+	// instance stores as they can support.
+	blockDeviceMappings = append(blockDeviceMappings, []ec2.BlockDeviceMapping{{
+		VirtualName: "ephemeral0",
+		DeviceName:  "/dev/sdb",
+	}, {
+		VirtualName: "ephemeral1",
+		DeviceName:  "/dev/sdc",
+	}, {
+		VirtualName: "ephemeral2",
+		DeviceName:  "/dev/sdd",
+	}, {
+		VirtualName: "ephemeral3",
+		DeviceName:  "/dev/sde",
+	}}...)
+
+	return blockDeviceMappings, nil
+}
+
+// AWS expects GiB, we work in MiB; round up to nearest G.
+func roundVolumeSize(m uint64) uint64 {
+	return (m + 1023) / 1024
 }
 
 // groupInfoByName returns information on the security group

--- a/provider/ec2/ec2_test.go
+++ b/provider/ec2/ec2_test.go
@@ -22,6 +22,20 @@ type RootDiskTest struct {
 	device     amzec2.BlockDeviceMapping
 }
 
+var commonInstanceStoreDisks = []amzec2.BlockDeviceMapping{{
+	DeviceName:  "/dev/sdb",
+	VirtualName: "ephemeral0",
+}, {
+	DeviceName:  "/dev/sdc",
+	VirtualName: "ephemeral1",
+}, {
+	DeviceName:  "/dev/sdd",
+	VirtualName: "ephemeral2",
+}, {
+	DeviceName:  "/dev/sde",
+	VirtualName: "ephemeral3",
+}}
+
 var rootDiskTests = []RootDiskTest{
 	{
 		"nil constraint",
@@ -49,13 +63,14 @@ var rootDiskTests = []RootDiskTest{
 	},
 }
 
-func (*Suite) TestRootDisk(c *gc.C) {
+func (*Suite) TestBlockDeviceMappings(c *gc.C) {
 	for _, t := range rootDiskTests {
 		c.Logf("Test %s", t.name)
 		cons := constraints.Value{RootDisk: t.constraint}
-		device, size := getDiskSize(cons)
-		c.Check(size, gc.Equals, t.disksize)
-		c.Check(device, gc.DeepEquals, t.device)
+		mappings, err := getBlockDeviceMappings(cons)
+		c.Assert(err, gc.IsNil)
+		expected := append([]amzec2.BlockDeviceMapping{t.device}, commonInstanceStoreDisks...)
+		c.Assert(mappings, gc.DeepEquals, expected)
 	}
 }
 


### PR DESCRIPTION
provider/ec2: allocate all instance stores

When starting an instance in EC2, specify all of the
instance stores in the block device mapping. The instance
started will have as many four attached, according to
the instance type.

getBlockDeviceMappings will be enhanced in the near
future to support attaching additional volumes to
instances at creation time (i.e. for charm storage).

(Review request: https://reviews.vapour.ws/r/475/)

(Review request: http://reviews.vapour.ws/r/587/)
