### PR TITLE
Use a new client for the backups download call.

### DIFF
--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -138,6 +138,7 @@ func (c *CreateCommand) decideFilename(ctx *cmd.Context, filename string, timest
 func (c *CreateCommand) download(ctx *cmd.Context, id string, filename string) error {
 	fmt.Fprintln(ctx.Stdout, "downloading to "+filename)
 
+	// TODO(ericsnow) lp-1399722 This needs further investigation:
 	// There is at least anecdotal evidence that we cannot use an API
 	// client for more than a single request. So we use a new client
 	// for download.


### PR DESCRIPTION
Apparently an API client is good for only one connection.

(See http://juju-ci.vapour.ws:8080/job/functional-ha-backup-restore/1190/console.)

(Review request: http://reviews.vapour.ws/r/590/)
