### PR TITLE
Drop an error condition unrelated to mongo.

### DIFF
--- a/replicaset/replicaset.go
+++ b/replicaset/replicaset.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/juju/errors"
@@ -461,6 +462,14 @@ func IsReady(session *mgo.Session) (bool, error) {
 	return true, nil
 }
 
+var connectionErrors = []syscall.Errno{
+	syscall.ECONNABORTED, // "software caused connection abort"
+	syscall.ECONNREFUSED, // "connection refused"
+	syscall.ECONNRESET,   // "connection reset by peer"
+	syscall.ENETRESET,    // "network dropped connection on reset"
+	syscall.ETIMEDOUT,    // "connection timed out"
+}
+
 func isConnectionNotAvailable(err error) bool {
 	if err == nil {
 		return false
@@ -469,6 +478,12 @@ func isConnectionNotAvailable(err error) bool {
 	// has been dropped.
 	if errors.Cause(err) == io.EOF {
 		return true
+	}
+	// An errno may be returned so we check the connection-related ones.
+	for _, errno := range connectionErrors {
+		if errors.Cause(err) == errno {
+			return true
+		}
 	}
 	return false
 }

--- a/replicaset/replicaset_test.go
+++ b/replicaset/replicaset_test.go
@@ -417,6 +417,13 @@ func (s *MongoSuite) TestIsReadyConnectionDropped(c *gc.C) {
 	s.checkConnectionFailure(c, io.EOF)
 }
 
+func (s *MongoSuite) TestIsReadyConnectionFailedWithErrno(c *gc.C) {
+	for _, errno := range connectionErrors {
+		c.Logf("Checking errno %#v (%v)", errno, errno)
+		s.checkConnectionFailure(c, errno)
+	}
+}
+
 func (s *MongoSuite) TestIsReadyError(c *gc.C) {
 	failure := errors.New("failed!")
 	s.PatchValue(&getCurrentStatus,


### PR DESCRIPTION
The motivating error actually came from the API client, not mongo.  So leaving the check in might lead a future reader to erroneously believe mongo might produce such an error (or that isConnectionNotAvailable should handle it).

(Review request: http://reviews.vapour.ws/r/591/)
