### PR TITLE
state: use a raw collection when load settings

### DIFF
--- a/state/settings.go
+++ b/state/settings.go
@@ -243,7 +243,7 @@ func (c *Settings) Read() error {
 // readSettingsDoc reads the settings with the given
 // key. It returns the settings and the current rxnRevno.
 func readSettingsDoc(st *State, key string) (map[string]interface{}, int64, error) {
-	settings, closer := st.getCollection(settingsC)
+	settings, closer := st.getRawCollection(settingsC)
 	defer closer()
 
 	config := map[string]interface{}{}


### PR DESCRIPTION
This is required to allow loading of settings before the env UUID migration for settings. Without this change upgrades to 1.22 fail.

(Review request: http://reviews.vapour.ws/r/595/)
