### PR TITLE
Do not use syscall in backups tests.

### DIFF
--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 var (
-	Create = create
+	Create        = create
+	FileTimestamp = fileTimestamp
 
 	TestGetFilesToBackUp = &getFilesToBackUp
 	GetDBDumper          = &getDBDumper

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -205,6 +205,15 @@ func NewMetadataJSONReader(in io.Reader) (*Metadata, error) {
 	return meta, nil
 }
 
+func fileTimestamp(fi os.FileInfo) time.Time {
+	timestamp := creationTime(fi)
+	if !timestamp.IsZero() {
+		return timestamp
+	}
+	// Fall back to modification time.
+	return fi.ModTime()
+}
+
 // BuildMetadata generates the metadata for a backup archive file.
 func BuildMetadata(file *os.File) (*Metadata, error) {
 
@@ -216,11 +225,7 @@ func BuildMetadata(file *os.File) (*Metadata, error) {
 	size := fi.Size()
 
 	// Extract the timestamp.
-	timestamp := creationTime(fi)
-	if timestamp.IsZero() {
-		// Fall back to modification time.
-		timestamp = fi.ModTime()
-	}
+	timestamp := fileTimestamp(fi)
 
 	// Get the checksum.
 	hasher := sha1.New()

--- a/state/backups/metadata_test.go
+++ b/state/backups/metadata_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -100,9 +99,7 @@ func (s *metadataSuite) TestBuildMetadata(c *gc.C) {
 
 	fi, err := archive.Stat()
 	c.Assert(err, jc.ErrorIsNil)
-	rawstat := fi.Sys()
-	c.Assert(rawstat, gc.NotNil)
-	finished := rawstat.(*syscall.Stat_t).Ctim.Sec
+	finished := backups.FileTimestamp(fi).Unix()
 
 	meta, err := backups.BuildMetadata(archive)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
(Review request: http://reviews.vapour.ws/r/600/)
