### PR TITLE
juju-run: help message was not properly displaying

### DIFF
--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -57,8 +57,6 @@ func (c *RunCommand) Info() *cmd.Info {
 }
 
 func (c *RunCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.showHelp, "h", false, "show help on juju-run")
-	f.BoolVar(&c.showHelp, "help", false, "")
 	f.BoolVar(&c.noContext, "no-context", false, "do not run the command in a unit context")
 	f.StringVar(&c.relationId, "r", "", "run the commands for a specific relation context on a unit")
 	f.StringVar(&c.relationId, "relation", "", "")
@@ -98,10 +96,6 @@ func (c *RunCommand) Init(args []string) error {
 }
 
 func (c *RunCommand) Run(ctx *cmd.Context) error {
-	if c.showHelp {
-		return gnuflag.ErrHelp
-	}
-
 	var result *exec.ExecResponse
 	var err error
 	if c.noContext {


### PR DESCRIPTION
Currently you cannot get the help output from juju-run after you SSH to a unit. This removes some unneeded flag checks and allows juju-run to use the default h/help flags.

(Review request: http://reviews.vapour.ws/r/601/)
