### PR TITLE
worker/certupdater: add "juju-apiserver" as DNS name

### DIFF
--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -97,8 +97,11 @@ func (c *CertificateUpdater) Handle() error {
 	if err != nil {
 		return errors.Annotate(err, "cannot add CA private key to environment config")
 	}
-	// We only want to include external IP addresses, so exclude local host.
-	var serverAddrs []string
+
+	// We only want to include externally accessible addresses, so exclude local
+	// host. For backwards compatibility, we must include "juju-apiserver" as a
+	// hostname as that is what clients specify as the hostname for verification.
+	serverAddrs := []string{"juju-apiserver"}
 	for _, addr := range addresses {
 		if addr.Value == "localhost" {
 			continue


### PR DESCRIPTION
The in-tree API clients are using "juju-apiserver" as the
hostname to verify when connecting to the API server,
rather than the actual hostname. The certupdater worker
was not setting this as a DNS name in the certificates it
generates. The Azure provider doesn't record any public IP
addresses, so the verification always takes place and always
fails.

We fix this by adding "juju-apiserver" as a DNS name in the
certificates. Ideally the clients should be using the actual
hostname used to connect with, but this will break backwards-
compatibility with older versions of Juju.

Fixes https://bugs.launchpad.net/juju-core/+bug/1400348
