### PR TITLE
State: envrionment.Destroy: safeguard destroying state server

### DIFF
--- a/apiserver/client/destroy.go
+++ b/apiserver/client/destroy.go
@@ -71,6 +71,18 @@ func (c *Client) DestroyEnvironment() error {
 		return err
 	}
 
+	// If this is not the state server environment, remove all documents from
+	// state associated with the environment.
+	st := c.api.state
+	ssinfo, err := st.StateServerInfo()
+	if err != nil {
+		return errors.Annotate(err, "could not get state server info")
+	}
+	ssuuid := ssinfo.EnvironmentTag.Id()
+	if st.EnvironUUID() != ssuuid {
+		st.RemoveAllEnvironDocs()
+	}
+
 	// Return to the caller. If it's the CLI, it will finish up
 	// by calling the provider's Destroy method, which will
 	// destroy the state servers, any straggler instances, and

--- a/apiserver/client/destroy_test.go
+++ b/apiserver/client/destroy_test.go
@@ -7,15 +7,21 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/client"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type destroyEnvironmentSuite struct {
@@ -41,20 +47,20 @@ func (s *destroyEnvironmentSuite) setUpManual(c *gc.C) (m0, m1 *state.Machine) {
 // setUpInstances adds machines to state backed by instances:
 // one manager machine, one non-manager, and a container in the
 // non-manager.
-func (s *destroyEnvironmentSuite) setUpInstances(c *gc.C) (m0, m1, m2 *state.Machine) {
-	m0, err := s.State.AddMachine("precise", state.JobManageEnviron)
+func (s *destroyEnvironmentSuite) setUpInstances(st *state.State, c *gc.C) (m0, m1, m2 *state.Machine) {
+	m0, err := st.AddMachine("precise", state.JobManageEnviron)
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, s.Environ, m0.Id())
 	err = m0.SetProvisioned(inst.Id(), "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	m1, err = s.State.AddMachine("precise", state.JobHostUnits)
+	m1, err = st.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ = testing.AssertStartInstance(c, s.Environ, m1.Id())
 	err = m1.SetProvisioned(inst.Id(), "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	m2, err = s.State.AddMachineInsideMachine(state.MachineTemplate{
+	m2, err = st.AddMachineInsideMachine(state.MachineTemplate{
 		Series: "precise",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}, m1.Id(), instance.LXC)
@@ -90,7 +96,7 @@ func (s *destroyEnvironmentSuite) TestDestroyEnvironmentManual(c *gc.C) {
 }
 
 func (s *destroyEnvironmentSuite) TestDestroyEnvironment(c *gc.C) {
-	manager, nonManager, _ := s.setUpInstances(c)
+	manager, nonManager, _ := s.setUpInstances(s.State, c)
 	managerId, _ := manager.InstanceId()
 	nonManagerId, _ := nonManager.InstanceId()
 
@@ -133,11 +139,56 @@ func (s *destroyEnvironmentSuite) TestDestroyEnvironment(c *gc.C) {
 	c.Assert(env.Life(), gc.Equals, state.Dying)
 }
 
+func (s *destroyEnvironmentSuite) TestDestroyOtherEnvironment(c *gc.C) {
+	cfg := dummy.SampleConfig().Merge(coretesting.Attrs{"state-server": false, "state-id": "2", "agent-version": "1.13.2"})
+	delete(cfg, "uuid")
+
+	envUser := names.NewUserTag("jess@dummy")
+	st2 := s.Factory.MakeEnvironment(c, &factory.EnvParams{Owner: envUser, ConfigAttrs: cfg}) //coretesting.Attrs{"type": "dummy", "state-server": false}
+	defer st2.Close()
+
+	// try to destroy state server environment
+	err := s.APIState.Client().DestroyEnvironment()
+	c.Assert(err, gc.ErrorMatches, "state server environment cannot be destroyed before all other environments are destroyed")
+
+	// get the client for the other environ
+	auth := apiservertesting.FakeAuthorizer{
+		Tag:            envUser,
+		EnvironManager: false,
+	}
+	client2, err := client.NewClient(st2, common.NewResources(), auth)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// destroy the other environment
+	err = client2.DestroyEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// now we can destroy the state server environment
+	err = s.APIState.Client().DestroyEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// func (s *destroyEnvironmentSuite) cleanupEnvironDocs(){
+// 		// add instances to non-state-server environment
+// 	manager, nonManager, _ := s.setUpInstances(st2, c)
+// 	managerId, _ := manager.InstanceId()
+// 	nonManagerId, _ := nonManager.InstanceId()
+
+// 	instances, err := s.Environ.Instances([]instance.Id{managerId, nonManagerId})
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	for _, inst := range instances {
+// 		c.Assert(inst, gc.NotNil)
+// 	}
+
+// 	services, err := st2.AllServices()
+// 	c.Assert(err, jc.ErrorIsNil)
+// }
+
 func (s *destroyEnvironmentSuite) TestDestroyEnvironmentWithContainers(c *gc.C) {
 	ops := make(chan dummy.Operation, 500)
 	dummy.Listen(ops)
 
-	_, nonManager, _ := s.setUpInstances(c)
+	_, nonManager, _ := s.setUpInstances(s.State, c)
 	nonManagerId, _ := nonManager.InstanceId()
 
 	err := s.APIState.Client().DestroyEnvironment()
@@ -152,7 +203,7 @@ func (s *destroyEnvironmentSuite) TestDestroyEnvironmentWithContainers(c *gc.C) 
 
 func (s *destroyEnvironmentSuite) TestBlockDestroyDestroyEnvironment(c *gc.C) {
 	// Setup environment
-	s.setUpInstances(c)
+	s.setUpInstances(s.State, c)
 	// lock environment: can't destroy locked environment
 	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-destroy-environment": true}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -162,7 +213,7 @@ func (s *destroyEnvironmentSuite) TestBlockDestroyDestroyEnvironment(c *gc.C) {
 
 func (s *destroyEnvironmentSuite) TestBlockRemoveDestroyEnvironment(c *gc.C) {
 	// Setup environment
-	s.setUpInstances(c)
+	s.setUpInstances(s.State, c)
 	// lock environment: can't destroy locked environment
 	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-remove-object": true}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -172,7 +223,7 @@ func (s *destroyEnvironmentSuite) TestBlockRemoveDestroyEnvironment(c *gc.C) {
 
 func (s *destroyEnvironmentSuite) TestBlockChangesDestroyEnvironment(c *gc.C) {
 	// Setup environment
-	s.setUpInstances(c)
+	s.setUpInstances(s.State, c)
 	// lock environment: can't destroy locked environment
 	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-all-changes": true}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/doc/death-and-destruction.txt
+++ b/doc/death-and-destruction.txt
@@ -10,9 +10,9 @@ destruction differ by entity, but there are common features:
 
   * Only Alive entities can be destroyed; if destruction is already in progress,
     as evidenced by an entity not being Alive, its "destruction" is a no-op.
-  * Entities might be removed immediately they are destroyed, but this is not
+  * Entities might be removed immediately when they are destroyed, but this is not
     guaranteed.
-  * If an entity is not removed immediately it is destroyed, its eventual
+  * If an entity is not removed immediately when it is destroyed, its eventual
     removal is very likely; but it is not currently guaranteed, for the
     following reasons:
       * Hardware failure, even when detected and corrected by a Provisioner, can

--- a/state/environ.go
+++ b/state/environ.go
@@ -203,6 +203,10 @@ func (e *Environment) refresh(query *mgo.Query) error {
 // Destroy sets the environment's lifecycle to Dying, preventing
 // addition of services or machines to state.
 func (e *Environment) Destroy() error {
+	if err := e.ensureDestroyable(); err != nil {
+		return err
+	}
+
 	if e.Life() != Alive {
 		return nil
 	}
@@ -236,6 +240,33 @@ func (e *Environment) Destroy() error {
 	return err
 }
 
+// ensureDestroyable returns an error if there is more than one environment and the
+// environment to be destroyed is the state server environment.
+func (e *Environment) ensureDestroyable() error {
+	ssinfo, err := e.st.StateServerInfo()
+	if err != nil {
+		return errors.Annotate(err, "could not get state server info")
+	}
+	ssuuid := ssinfo.EnvironmentTag.Id()
+
+	// This is not the state server environment, so it can be destroyed
+	if ssuuid != e.UUID() {
+		return nil
+	}
+
+	environments, closer := e.st.getCollection(environmentsC)
+	defer closer()
+	n, err := environments.Count()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if n > 1 {
+		return errors.Errorf("state server environment cannot be destroyed before all other environments are destroyed")
+	}
+	return nil
+}
+
 // createEnvironmentOp returns the operation needed to create
 // an environment document with the given name and UUID.
 func createEnvironmentOp(st *State, owner names.UserTag, name, uuid, server string) txn.Op {
@@ -263,7 +294,7 @@ func (e *Environment) assertAliveOp() txn.Op {
 	}
 }
 
-// isEnvAlive is an Environment-specific versio nof isAliveDoc.
+// isEnvAlive is an Environment-specific version of isAliveDoc.
 //
 // Environment documents from versions of Juju prior to 1.17
 // do not have the life field; if it does not exist, it should

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2064,6 +2064,17 @@ func (s *StateSuite) TestAdditionalValidation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
+	st := s.factory.MakeEnvironment(c, nil)
+	defer st.Close()
+	err := st.RemoveAllEnvironDocs()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(c.GetTestLog(), jc.Contains, "removed 1 constraints documents")
+	c.Assert(c.GetTestLog(), jc.Contains, "removed 1 settings documents")
+	c.Assert(c.GetTestLog(), jc.Contains, "removed environment document")
+}
+
 type attrs map[string]interface{}
 
 func (s *StateSuite) TestWatchEnvironConfig(c *gc.C) {


### PR DESCRIPTION
Ensure envrionment.Destroy will not destroy the state server
environment unless it is the last environment. Update cleanup to
remove the environmentsC doc when cleaning up a destroyed environment.

(Review request: http://reviews.vapour.ws/r/602/)