### PR TITLE
state: automatic multi-env handling for DB updates

### DIFF
--- a/state/collections.go
+++ b/state/collections.go
@@ -191,7 +191,7 @@ func (c *envStateCollection) mungeQuery(inq interface{}) bson.D {
 			switch elem.Name {
 			case "_id":
 				if id, ok := elem.Value.(string); ok {
-					elem.Value = c.addEnvUUID(id)
+					elem.Value = addEnvUUID(c.envUUID, id)
 				}
 			case "env-uuid":
 				panic("env-uuid is added automatically and should not be provided")
@@ -210,7 +210,7 @@ func (c *envStateCollection) mungeQuery(inq interface{}) bson.D {
 func (c *envStateCollection) mungeId(id interface{}) interface{} {
 	switch idv := id.(type) {
 	case string:
-		return c.addEnvUUID(idv)
+		return addEnvUUID(c.envUUID, idv)
 	case bson.ObjectId:
 		return idv
 	default:
@@ -218,8 +218,8 @@ func (c *envStateCollection) mungeId(id interface{}) interface{} {
 	}
 }
 
-func (c *envStateCollection) addEnvUUID(id string) string {
-	prefix := c.envUUID + ":"
+func addEnvUUID(envUUID, id string) string {
+	prefix := envUUID + ":"
 	if strings.HasPrefix(id, prefix) {
 		return id
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -52,27 +52,25 @@ type (
 )
 
 func SetTestHooks(c *gc.C, st *State, hooks ...jujutxn.TestHook) txntesting.TransactionChecker {
-	runner := jujutxn.NewRunner(jujutxn.RunnerParams{Database: st.db})
-	st.transactionRunner = runner
-	return txntesting.SetTestHooks(c, runner, hooks...)
+	return txntesting.SetTestHooks(c, newMultiEnvRunnerForHooks(st), hooks...)
 }
 
 func SetBeforeHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChecker {
-	runner := jujutxn.NewRunner(jujutxn.RunnerParams{Database: st.db})
-	st.transactionRunner = runner
-	return txntesting.SetBeforeHooks(c, runner, fs...)
+	return txntesting.SetBeforeHooks(c, newMultiEnvRunnerForHooks(st), fs...)
 }
 
 func SetAfterHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChecker {
-	runner := jujutxn.NewRunner(jujutxn.RunnerParams{Database: st.db})
-	st.transactionRunner = runner
-	return txntesting.SetAfterHooks(c, runner, fs...)
+	return txntesting.SetAfterHooks(c, newMultiEnvRunnerForHooks(st), fs...)
 }
 
 func SetRetryHooks(c *gc.C, st *State, block, check func()) txntesting.TransactionChecker {
-	runner := jujutxn.NewRunner(jujutxn.RunnerParams{Database: st.db})
+	return txntesting.SetRetryHooks(c, newMultiEnvRunnerForHooks(st), block, check)
+}
+
+func newMultiEnvRunnerForHooks(st *State) jujutxn.Runner {
+	runner := newMultiEnvRunner(st.EnvironUUID(), st.db)
 	st.transactionRunner = runner
-	return txntesting.SetRetryHooks(c, runner, block, check)
+	return getRawRunner(runner)
 }
 
 // SetPolicy updates the State's policy field to the
@@ -282,4 +280,11 @@ func GetCollection(st *State, name string) (stateCollection, func()) {
 
 func GetRawCollection(st *State, name string) (*mgo.Collection, func()) {
 	return st.getRawCollection(name)
+}
+
+func NewMultiEnvRunnerForTesting(envUUID string, baseRunner jujutxn.Runner) jujutxn.Runner {
+	return &multiEnvRunner{
+		rawRunner: baseRunner,
+		envUUID:   envUUID,
+	}
 }

--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -78,7 +78,7 @@ func (u *Unit) SetMeterStatus(codeRaw, info string) error {
 
 // createMeterStatusOp returns the operation needed to create the meter status
 // document associated with the given globalKey.
-func createMeterStatusOp(st *State, globalKey string, doc meterStatusDoc) txn.Op {
+func createMeterStatusOp(st *State, globalKey string, doc *meterStatusDoc) txn.Op {
 	doc.EnvUUID = st.EnvironUUID()
 	return txn.Op{
 		C:      meterStatusC,

--- a/state/ports.go
+++ b/state/ports.go
@@ -229,7 +229,7 @@ func (p *Ports) OpenPorts(portRange PortRange) (err error) {
 		if ports.areNew {
 			// Create a new document.
 			assert := txn.DocMissing
-			return addPortsDocOps(p.st, ports.doc, assert, portRange)
+			return addPortsDocOps(p.st, &ports.doc, assert, portRange)
 		} else {
 			// Update an existing document.
 			assert := bson.D{{"txn-revno", ports.doc.TxnRevno}}
@@ -389,7 +389,7 @@ func (m *Machine) AllPorts() ([]*Ports, error) {
 // statement for on the openedPorts collection op.
 var addPortsDocOps = addPortsDocOpsFunc
 
-func addPortsDocOpsFunc(st *State, pDoc portsDoc, portsAssert interface{}, ports ...PortRange) ([]txn.Op, error) {
+func addPortsDocOpsFunc(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) ([]txn.Op, error) {
 	pDoc.Ports = ports
 	return []txn.Op{{
 		C:      machinesC,

--- a/state/reboot.go
+++ b/state/reboot.go
@@ -46,12 +46,9 @@ func (m *Machine) setFlag() error {
 		Id:     m.doc.DocID,
 		Assert: notDeadDoc,
 	}, {
-		C:  rebootC,
-		Id: m.doc.DocID,
-		Insert: rebootDoc{
-			Id:      m.Id(),
-			EnvUUID: m.st.EnvironUUID(),
-		},
+		C:      rebootC,
+		Id:     m.doc.DocID,
+		Insert: &rebootDoc{Id: m.Id()},
 	}}
 	err := m.st.runTransaction(ops)
 	if err == txn.ErrAborted {

--- a/state/service.go
+++ b/state/service.go
@@ -599,9 +599,6 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		Status:  StatusPending,
 		EnvUUID: s.st.EnvironUUID(),
 	}
-	msdoc := meterStatusDoc{
-		Code: MeterNotSet,
-	}
 	ops := []txn.Op{
 		{
 			C:      unitsC,
@@ -610,7 +607,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 			Insert: udoc,
 		},
 		createStatusOp(s.st, globalKey, sdoc),
-		createMeterStatusOp(s.st, globalKey, msdoc),
+		createMeterStatusOp(s.st, globalKey, &meterStatusDoc{Code: MeterNotSet}),
 		{
 			C:      servicesC,
 			Id:     s.doc.DocID,

--- a/state/state.go
+++ b/state/state.go
@@ -191,45 +191,6 @@ func (st *State) MongoSession() *mgo.Session {
 
 type closeFunc func()
 
-// txnRunner returns a jujutxn.Runner instance.
-//
-// If st.transactionRunner is non-nil, then that will be
-// returned and the session argument will be ignored. This
-// is the case in tests only, when we want to test concurrent
-// operations.
-//
-// If st.transactionRunner is nil, then we create a new
-// transaction runner with the provided session and return
-// that.
-func (st *State) txnRunner(session *mgo.Session) jujutxn.Runner {
-	if st.transactionRunner != nil {
-		return st.transactionRunner
-	}
-	runnerDb := st.db.With(session)
-	return jujutxn.NewRunner(jujutxn.RunnerParams{Database: runnerDb})
-}
-
-// runTransaction is a convenience method delegating to transactionRunner.
-func (st *State) runTransaction(ops []txn.Op) error {
-	session := st.db.Session.Copy()
-	defer session.Close()
-	return st.txnRunner(session).RunTransaction(ops)
-}
-
-// run is a convenience method delegating to transactionRunner.
-func (st *State) run(transactions jujutxn.TransactionSource) error {
-	session := st.db.Session.Copy()
-	defer session.Close()
-	return st.txnRunner(session).Run(transactions)
-}
-
-// ResumeTransactions resumes all pending transactions.
-func (st *State) ResumeTransactions() error {
-	session := st.db.Session.Copy()
-	defer session.Close()
-	return st.txnRunner(session).ResumeTransactions()
-}
-
 func (st *State) Watch() *Multiwatcher {
 	st.mu.Lock()
 	if st.allManager == nil {

--- a/state/txns.go
+++ b/state/txns.go
@@ -1,0 +1,247 @@
+// Copyright 2012-2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"reflect"
+
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// txnRunner returns a jujutxn.Runner instance.
+//
+// If st.transactionRunner is non-nil, then that will be
+// returned and the session argument will be ignored. This
+// is the case in tests only, when we want to test concurrent
+// operations.
+//
+// If st.transactionRunner is nil, then we create a new
+// transaction runner with the provided session and return
+// that.
+func (st *State) txnRunner(session *mgo.Session) jujutxn.Runner {
+	if st.transactionRunner != nil {
+		return st.transactionRunner
+	}
+	return newMultiEnvRunner(st.EnvironUUID(), st.db.With(session))
+}
+
+// runTransaction is a convenience method delegating to transactionRunner.
+func (st *State) runTransaction(ops []txn.Op) error {
+	session := st.db.Session.Copy()
+	defer session.Close()
+	return st.txnRunner(session).RunTransaction(ops)
+}
+
+// run is a convenience method delegating to transactionRunner.
+func (st *State) run(transactions jujutxn.TransactionSource) error {
+	session := st.db.Session.Copy()
+	defer session.Close()
+	return st.txnRunner(session).Run(transactions)
+}
+
+// ResumeTransactions resumes all pending transactions.
+func (st *State) ResumeTransactions() error {
+	session := st.db.Session.Copy()
+	defer session.Close()
+	return st.txnRunner(session).ResumeTransactions()
+}
+
+func newMultiEnvRunner(envUUID string, db *mgo.Database) jujutxn.Runner {
+	return &multiEnvRunner{
+		rawRunner: jujutxn.NewRunner(jujutxn.RunnerParams{Database: db}),
+		envUUID:   envUUID,
+	}
+}
+
+type multiEnvRunner struct {
+	rawRunner jujutxn.Runner
+	envUUID   string
+}
+
+// RunTransaction is part of the jujutxn.Runner interface. Operations
+// that affect multi-environment collections will be modified in-place
+// to ensure correct interaction with these collections.
+func (r *multiEnvRunner) RunTransaction(ops []txn.Op) error {
+	r.updateOps(ops)
+	return r.rawRunner.RunTransaction(ops)
+}
+
+// Run is part of the jujutxn.Run interface. Operations returned by
+// the given "transactions" function that affect multi-environment
+// collections will be modified in-place to ensure correct interaction
+// with these collections.
+func (r *multiEnvRunner) Run(transactions jujutxn.TransactionSource) error {
+	return r.rawRunner.Run(func(attempt int) ([]txn.Op, error) {
+		ops, err := transactions(attempt)
+		if err != nil {
+			// Don't use Trace here as jujutxn doens't use juju/errors
+			// and won't deal correctly with some returned errors.
+			return nil, err
+		}
+		r.updateOps(ops)
+		return ops, nil
+	})
+}
+
+// Run is part of the jujutxn.Run interface.
+func (r *multiEnvRunner) ResumeTransactions() error {
+	return r.rawRunner.ResumeTransactions()
+}
+
+func (r *multiEnvRunner) updateOps(ops []txn.Op) {
+	for i, op := range ops {
+		if multiEnvCollections.Contains(op.C) {
+			var docID interface{}
+			if id, ok := op.Id.(string); ok {
+				docID = addEnvUUID(r.envUUID, id)
+				ops[i].Id = docID
+			} else {
+				docID = op.Id
+			}
+
+			if op.Insert != nil {
+				switch doc := op.Insert.(type) {
+				case bson.D:
+					ops[i].Insert = r.updateBsonD(doc, docID, op.C)
+				case bson.M:
+					r.updateBsonM(doc, docID, op.C)
+				default:
+					r.updateStruct(doc, docID, op.C)
+				}
+			}
+		}
+	}
+}
+
+func (r *multiEnvRunner) updateBsonD(doc bson.D, docID interface{}, collName string) bson.D {
+	idSeen := false
+	envUUIDSeen := false
+	for i, elem := range doc {
+		switch elem.Name {
+		case "_id":
+			idSeen = true
+			doc[i].Value = docID
+		case "env-uuid":
+			envUUIDSeen = true
+			if elem.Value != r.envUUID {
+				panic(fmt.Sprintf("environment UUID for document to insert into "+
+					"%s does not match state", collName))
+			}
+		}
+	}
+	if !idSeen {
+		doc = append(doc, bson.DocElem{"_id", docID})
+	}
+	if !envUUIDSeen {
+		doc = append(doc, bson.DocElem{"env-uuid", r.envUUID})
+	}
+	return doc
+}
+
+func (r *multiEnvRunner) updateBsonM(doc bson.M, docID interface{}, collName string) {
+	idSeen := false
+	envUUIDSeen := false
+	for key, value := range doc {
+		switch key {
+		case "_id":
+			idSeen = true
+			doc[key] = docID
+		case "env-uuid":
+			envUUIDSeen = true
+			if value != r.envUUID {
+				panic(fmt.Sprintf("environment UUID for document to insert into "+
+					"%s does not match state", collName))
+			}
+		}
+	}
+	if !idSeen {
+		doc["_id"] = docID
+	}
+	if !envUUIDSeen {
+		doc["env-uuid"] = r.envUUID
+	}
+}
+
+func (r *multiEnvRunner) updateStruct(doc, docID interface{}, collName string) {
+	v := reflect.ValueOf(doc)
+	t := v.Type()
+
+	if t.Kind() == reflect.Ptr {
+		v = v.Elem()
+		t = v.Type()
+	}
+
+	if t.Kind() == reflect.Struct {
+		envUUIDSeen := false
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			switch f.Tag.Get("bson") {
+			case "_id":
+				r.updateStructField(v, f.Name, docID, collName, overrideField)
+			case "env-uuid":
+				r.updateStructField(v, f.Name, r.envUUID, collName, fieldMustMatch)
+				envUUIDSeen = true
+			}
+		}
+		if !envUUIDSeen {
+			panic(fmt.Sprintf("struct for insert into %s is missing an env-uuid field", collName))
+		}
+	}
+
+}
+
+const overrideField = "override"
+const fieldMustMatch = "mustmatch"
+
+func (r *multiEnvRunner) updateStructField(v reflect.Value, name string, newValue interface{}, collName, updateType string) {
+	fv := v.FieldByName(name)
+	if fv.Interface() != newValue {
+		if updateType == fieldMustMatch && fv.String() != "" {
+			panic(fmt.Sprintf("%s for insert into %s does not match expected value",
+				name, collName))
+		}
+		if fv.CanSet() {
+			fv.Set(reflect.ValueOf(newValue))
+		} else {
+			panic(fmt.Sprintf("struct for insert into %s requires "+
+				"%s change but was passed by value", collName, name))
+		}
+	}
+}
+
+// rawTxnRunner returns a transaction runner that won't perform
+// automatic addition of environment UUIDs into transaction
+// operations, even for collections that contain documents for
+// multiple environments. It should be used rarely.
+func (st *State) rawTxnRunner(session *mgo.Session) jujutxn.Runner {
+	if st.transactionRunner != nil {
+		return getRawRunner(st.transactionRunner)
+	}
+	return jujutxn.NewRunner(jujutxn.RunnerParams{
+		Database: st.db.With(session),
+	})
+}
+
+// runRawTransaction is a convenience method that will run a single
+// transaction using a "raw" transaction runner, as returned by
+// rawTxnRunner.
+func (st *State) runRawTransaction(ops []txn.Op) error {
+	session := st.db.Session.Copy()
+	defer session.Close()
+	runner := st.rawTxnRunner(session)
+	return runner.RunTransaction(ops)
+}
+
+// getRawRunner returns the underlying "raw" transaction runner from
+// the passed transaction runner.
+func getRawRunner(runner jujutxn.Runner) jujutxn.Runner {
+	if runner, ok := runner.(*multiEnvRunner); ok {
+		return runner.rawRunner
+	}
+	return runner
+}

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -1,0 +1,356 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"errors"
+
+	jc "github.com/juju/testing/checkers"
+	jujutxn "github.com/juju/txn"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/testing"
+)
+
+type MultiEnvRunnerSuite struct {
+	testing.BaseSuite
+	multiEnvRunner jujutxn.Runner
+	testRunner     *recordingRunner
+}
+
+var _ = gc.Suite(&MultiEnvRunnerSuite{})
+
+// A fixed attempt counter value used to verify this is passed through
+// in Run()
+const testTxnAttempt = 42
+
+func (s *MultiEnvRunnerSuite) SetUpTest(c *gc.C) {
+	s.testRunner = &recordingRunner{}
+	s.multiEnvRunner = NewMultiEnvRunnerForTesting("uuid", s.testRunner)
+}
+
+// An alternative machine document to test that fields are matched by
+// struct tag.
+type altMachineDoc struct {
+	Identifier  string `bson:"_id"`
+	Environment string `bson:"env-uuid"`
+}
+
+type multiEnvRunnerTestCase struct {
+	label    string
+	input    txn.Op
+	expected txn.Op
+}
+
+// Test cases are returned by a function because transaction
+// operations are modified in place and can't be safely reused by
+// multiple tests.
+func getTestCases() []multiEnvRunnerTestCase {
+	return []multiEnvRunnerTestCase{
+		{
+			"ops for non-multi env collections are left alone",
+			txn.Op{
+				C:      "other",
+				Id:     "whatever",
+				Insert: bson.M{"_id": "whatever"},
+			},
+			txn.Op{
+				C:      "other",
+				Id:     "whatever",
+				Insert: bson.M{"_id": "whatever"},
+			},
+		}, {
+			"env UUID added to doc",
+			txn.Op{
+				C:  machinesC,
+				Id: "0",
+				Insert: &machineDoc{
+					DocID: "0",
+				},
+			},
+			txn.Op{
+				C:  machinesC,
+				Id: "uuid:0",
+				Insert: &machineDoc{
+					DocID:   "uuid:0",
+					EnvUUID: "uuid",
+				},
+			},
+		}, {
+			"_id added to doc if missing",
+			txn.Op{
+				C:      machinesC,
+				Id:     "1",
+				Insert: &machineDoc{},
+			},
+			txn.Op{
+				C:  machinesC,
+				Id: "uuid:1",
+				Insert: &machineDoc{
+					DocID:   "uuid:1",
+					EnvUUID: "uuid",
+				},
+			},
+		}, {
+			"fields matched by struct tag, not field name",
+			txn.Op{
+				C:  machinesC,
+				Id: "2",
+				Insert: &altMachineDoc{
+					Identifier:  "2",
+					Environment: "",
+				},
+			},
+			txn.Op{
+				C:  machinesC,
+				Id: "uuid:2",
+				Insert: &altMachineDoc{
+					Identifier:  "uuid:2",
+					Environment: "uuid",
+				},
+			},
+		}, {
+			"doc passed as struct value", // ok as long as no change to struct required
+			txn.Op{
+				C:  machinesC,
+				Id: "3",
+				// Passed by value
+				Insert: machineDoc{
+					DocID:   "uuid:3",
+					EnvUUID: "uuid",
+				},
+			},
+			txn.Op{
+				C:  machinesC,
+				Id: "uuid:3",
+				Insert: machineDoc{
+					DocID:   "uuid:3",
+					EnvUUID: "uuid",
+				},
+			},
+		}, {
+			"document passed as bson.D",
+			txn.Op{
+				C:      machinesC,
+				Id:     "4",
+				Insert: bson.D{},
+			},
+			txn.Op{
+				C:  machinesC,
+				Id: "uuid:4",
+				Insert: bson.D{
+					{"_id", "uuid:4"},
+					{"env-uuid", "uuid"},
+				},
+			},
+		}, {
+			"document passed as bson.M",
+			txn.Op{
+				C:      machinesC,
+				Id:     "5",
+				Insert: bson.M{},
+			},
+			txn.Op{
+				C:  machinesC,
+				Id: "uuid:5",
+				Insert: bson.M{
+					"_id":      "uuid:5",
+					"env-uuid": "uuid",
+				},
+			},
+		},
+	}
+}
+
+func (s *MultiEnvRunnerSuite) TestRunTransaction(c *gc.C) {
+	for i, t := range getTestCases() {
+		c.Logf("TestRunTransaction %d: %s", i, t.label)
+
+		inOps := []txn.Op{t.input}
+		err := s.multiEnvRunner.RunTransaction(inOps)
+		c.Assert(err, jc.ErrorIsNil)
+
+		expected := []txn.Op{t.expected}
+		// Check ops seen by underlying runner.
+		c.Check(s.testRunner.seenOps, gc.DeepEquals, expected)
+		// Input should have been modified in-place.
+		c.Check(inOps, gc.DeepEquals, expected)
+	}
+}
+
+func (s *MultiEnvRunnerSuite) TestMultipleOps(c *gc.C) {
+	var inOps []txn.Op
+	var expectedOps []txn.Op
+	for _, t := range getTestCases() {
+		inOps = append(inOps, t.input)
+		expectedOps = append(expectedOps, t.expected)
+	}
+
+	err := s.multiEnvRunner.RunTransaction(inOps)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.testRunner.seenOps, gc.DeepEquals, expectedOps)
+	c.Assert(inOps, gc.DeepEquals, expectedOps)
+}
+
+func (s *MultiEnvRunnerSuite) TestWithObjectIds(c *gc.C) {
+	id := bson.NewObjectId()
+	inOps := []txn.Op{{
+		C:      networkInterfacesC,
+		Id:     id,
+		Insert: &networkInterfaceDoc{},
+	}}
+
+	err := s.multiEnvRunner.RunTransaction(inOps)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedOps := []txn.Op{{
+		C:  networkInterfacesC,
+		Id: id,
+		Insert: &networkInterfaceDoc{
+			Id:      id,
+			EnvUUID: "uuid",
+		},
+	}}
+	c.Assert(s.testRunner.seenOps, gc.DeepEquals, expectedOps)
+	c.Assert(inOps, gc.DeepEquals, expectedOps)
+}
+
+func (s *MultiEnvRunnerSuite) TestPanicWhenStructIsPassedByValueAndNeedsChange(c *gc.C) {
+	// When a document struct is passed by reference it can't be
+	// changed in place. It's important that the caller sees any
+	// modifications made by multiEnvRunner in case the document
+	// struct is used to create an object after insertion into
+	// MongoDB.
+	attempt := func() {
+		s.multiEnvRunner.RunTransaction([]txn.Op{{
+			C:      machinesC,
+			Id:     "uuid:0",
+			Insert: machineDoc{},
+		}})
+	}
+	c.Assert(attempt, gc.PanicMatches,
+		"struct for insert into machines requires DocID change but was passed by value")
+}
+
+func (s *MultiEnvRunnerSuite) TestPanicWhenStructIsMissingEnvUUIDField(c *gc.C) {
+	type someDoc struct {
+		DocID string `bson:"_id"`
+	}
+	attempt := func() {
+		s.multiEnvRunner.RunTransaction([]txn.Op{{
+			C:      machinesC,
+			Id:     "uuid:0",
+			Insert: &someDoc{DocID: "uuid:0"},
+		}})
+	}
+	c.Assert(attempt, gc.PanicMatches,
+		"struct for insert into machines is missing an env-uuid field")
+}
+
+func (s *MultiEnvRunnerSuite) TestPanicWhenStructEnvUUIDMismatch(c *gc.C) {
+	attempt := func() {
+		s.multiEnvRunner.RunTransaction([]txn.Op{{
+			C:  machinesC,
+			Id: "uuid:0",
+			Insert: &machineDoc{
+				DocID:   "uuid:0",
+				EnvUUID: "somethingelse",
+			},
+		}})
+	}
+	c.Assert(attempt, gc.PanicMatches,
+		"EnvUUID for insert into machines does not match expected value")
+}
+
+func (s *MultiEnvRunnerSuite) TestPanicWhenBsonDEnvUUIDMismatch(c *gc.C) {
+	attempt := func() {
+		s.multiEnvRunner.RunTransaction([]txn.Op{{
+			C:      machinesC,
+			Id:     "uuid:0",
+			Insert: bson.D{{"env-uuid", "wtf"}},
+		}})
+	}
+	c.Assert(attempt, gc.PanicMatches,
+		"environment UUID for document to insert into machines does not match state")
+}
+
+func (s *MultiEnvRunnerSuite) TestPanicWhenBsonMEnvUUIDMismatch(c *gc.C) {
+	attempt := func() {
+		s.multiEnvRunner.RunTransaction([]txn.Op{{
+			C:      machinesC,
+			Id:     "uuid:0",
+			Insert: bson.M{"env-uuid": "wtf"},
+		}})
+	}
+	c.Assert(attempt, gc.PanicMatches,
+		"environment UUID for document to insert into machines does not match state")
+}
+
+func (s *MultiEnvRunnerSuite) TestRun(c *gc.C) {
+	for i, t := range getTestCases() {
+		c.Logf("TestRun %d: %s", i, t.label)
+
+		var seenAttempt int
+		err := s.multiEnvRunner.Run(func(attempt int) ([]txn.Op, error) {
+			seenAttempt = attempt
+			return []txn.Op{t.input}, nil
+		})
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Check(s.testRunner.seenOps, gc.DeepEquals, []txn.Op{t.expected})
+		c.Check(seenAttempt, gc.Equals, testTxnAttempt)
+	}
+}
+
+func (s *MultiEnvRunnerSuite) TestRunWithError(c *gc.C) {
+	err := s.multiEnvRunner.Run(func(attempt int) ([]txn.Op, error) {
+		return nil, errors.New("boom")
+	})
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(s.testRunner.seenOps, gc.IsNil)
+}
+
+func (s *MultiEnvRunnerSuite) TestResumeTransactions(c *gc.C) {
+	err := s.multiEnvRunner.ResumeTransactions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.testRunner.resumeTransactionsCalled, jc.IsTrue)
+}
+
+func (s *MultiEnvRunnerSuite) TestResumeTransactionsWithError(c *gc.C) {
+	s.testRunner.resumeTransactionsErr = errors.New("boom")
+	err := s.multiEnvRunner.ResumeTransactions()
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+// recordingRunner is fake transaction running that implements the
+// jujutxn.Runner interface. Instead of doing anything with a database
+// it simply records the transaction operations passed to it for later
+// inspection.
+//
+// Note that a recordingRunner is only good for a single test because
+// seenOps is overwritten for each call to RunTransaction and Run. A
+// fresh instance should be created for each test.
+type recordingRunner struct {
+	seenOps                  []txn.Op
+	resumeTransactionsCalled bool
+	resumeTransactionsErr    error
+}
+
+func (r *recordingRunner) RunTransaction(ops []txn.Op) error {
+	r.seenOps = ops
+	return nil
+}
+
+func (r *recordingRunner) Run(transactions jujutxn.TransactionSource) (err error) {
+	r.seenOps, err = transactions(testTxnAttempt)
+	return
+}
+
+func (r *recordingRunner) ResumeTransactions() error {
+	r.resumeTransactionsCalled = true
+	return r.resumeTransactionsErr
+}

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -286,7 +286,7 @@ func (st *State) EnsureUpgradeInfo(machineId string, previousVersion, targetVers
 		Id:     machine.doc.DocID,
 		Assert: txn.DocExists,
 	}}
-	if err := st.runTransaction(ops); err == nil {
+	if err := st.runRawTransaction(ops); err == nil {
 		return &UpgradeInfo{st: st, doc: doc}, nil
 	} else if err != txn.ErrAborted {
 		return nil, errors.Annotate(err, "cannot create upgrade info")

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -65,7 +65,7 @@ func MigrateUserLastConnectionToLastLogin(st *State) error {
 			})
 	}
 
-	return st.runTransaction(ops)
+	return st.runRawTransaction(ops)
 }
 
 // AddStateUsersAsEnvironUsers loops through all users stored in state and
@@ -342,7 +342,7 @@ func MigrateUnitPortsToOpenedPorts(st *State) error {
 			unit, rangesToMigrate, machinePorts.GlobalKey(), ops,
 		)
 
-		if err = st.runTransaction(ops); err != nil {
+		if err = st.runRawTransaction(ops); err != nil {
 			upgradesLogger.Warningf("migration failed for unit %q: %v", unit, err)
 		}
 
@@ -396,12 +396,10 @@ func CreateUnitMeterStatus(st *State) error {
 			upgradesLogger.Infof("meter status doc already exists for unit %q", unit)
 			continue
 		}
-
-		msdoc := meterStatusDoc{
-			Code: MeterNotSet,
+		ops := []txn.Op{
+			createMeterStatusOp(st, unit.globalKey(), &meterStatusDoc{Code: MeterNotSet}),
 		}
-		ops := []txn.Op{createMeterStatusOp(st, unit.globalKey(), msdoc)}
-		if err = st.runTransaction(ops); err != nil {
+		if err = st.runRawTransaction(ops); err != nil {
 			upgradesLogger.Warningf("migration failed for unit %q: %v", unit, err)
 		}
 	}
@@ -426,7 +424,7 @@ func AddEnvironmentUUIDToStateServerDoc(st *State) error {
 		}}},
 	}}
 
-	return st.runTransaction(ops)
+	return st.runRawTransaction(ops)
 }
 
 // AddCharmStoragePaths adds storagepath fields
@@ -446,7 +444,7 @@ func AddCharmStoragePaths(st *State, storagePaths map[*charm.URL]string) error {
 		}
 		ops = append(ops, op)
 	}
-	err := st.runTransaction(ops)
+	err := st.runRawTransaction(ops)
 	if err == txn.ErrAborted {
 		return errors.NotFoundf("charms")
 	}
@@ -477,7 +475,7 @@ func SetOwnerAndServerUUIDForEnvironment(st *State) error {
 			{"owner", owner.Username()},
 		}}},
 	}}
-	return st.runTransaction(ops)
+	return st.runRawTransaction(ops)
 }
 
 // MigrateMachineInstanceIdToInstanceData migrates the deprecated "instanceid"
@@ -538,7 +536,7 @@ func MigrateMachineInstanceIdToInstanceData(st *State) error {
 	if err = iter.Err(); err != nil {
 		return errors.Trace(err)
 	}
-	return st.runTransaction(ops)
+	return st.runRawTransaction(ops)
 }
 
 // AddAvailabilityZoneToInstanceData sets the AvailZone field on
@@ -670,7 +668,7 @@ func AddEnvUUIDToNetworkInterfaces(st *State) error {
 	if err := iter.Err(); err != nil {
 		return errors.Trace(err)
 	}
-	return st.runTransaction(ops)
+	return st.runRawTransaction(ops)
 }
 
 // AddEnvUUIDToCharms prepends the environment UUID to the ID of
@@ -796,7 +794,7 @@ func addEnvUUIDToEntityCollection(st *State, collName string, updates ...updateF
 	if err = iter.Err(); err != nil {
 		return errors.Trace(err)
 	}
-	return st.runTransaction(ops)
+	return st.runRawTransaction(ops)
 }
 
 type updateFunc func(bson.M) error
@@ -868,6 +866,5 @@ func MigrateJobManageNetworking(st *State) error {
 		})
 	}
 
-	// Run transaction.
-	return st.runTransaction(ops)
+	return st.runRawTransaction(ops)
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -87,7 +87,7 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 			Insert: oldDoc,
 		},
 	}
-	err := s.state.runTransaction(ops)
+	err := s.state.runRawTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = MigrateUserLastConnectionToLastLogin(s.state)
@@ -157,7 +157,7 @@ func (s *upgradesSuite) TestAddEnvironmentUUIDToStateServerDoc(c *gc.C) {
 			{"env-uuid", nil},
 		}}},
 	}}
-	err = s.state.runTransaction(ops)
+	err = s.state.runRawTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 	// Make sure it has gone.
 	stateServers, closer := s.state.getRawCollection(stateServersC)
@@ -981,7 +981,7 @@ func (s *upgradesSuite) addLegacyDoc(c *gc.C, collName string, legacyDoc bson.M)
 		Assert: txn.DocMissing,
 		Insert: legacyDoc,
 	}}
-	err := s.state.runTransaction(ops)
+	err := s.state.runRawTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1029,7 +1029,7 @@ func (s *upgradesSuite) TestSetOwnerAndServerUUIDForEnvironment(c *gc.C) {
 			{"server-uuid", nil}, {"owner", nil},
 		}}},
 	}}
-	err = s.state.runTransaction(ops)
+	err = s.state.runRawTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 	// Make sure it has gone.
 	environments, closer := s.state.getRawCollection(environmentsC)
@@ -1073,7 +1073,7 @@ func openLegacyPort(c *gc.C, unit *Unit, number int, proto string) {
 		Assert: notDeadDoc,
 		Update: bson.D{{"$addToSet", bson.D{{"ports", port}}}},
 	}}
-	err := unit.st.runTransaction(ops)
+	err := unit.st.runRawTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1174,15 +1174,30 @@ func (s *upgradesSuite) setUpPortsMigration(c *gc.C) ([]*Machine, map[int][]*Uni
 	// machines[2] (new-style port ranges):
 	// - 100-110/tcp (simulate a pre-existing range for units[2][1],
 	//   without opening the ports on the unit itself)
-	portRange, err := NewPortRange(units[2][1].Name(), 100, 110, "tcp")
-	c.Assert(err, jc.ErrorIsNil)
-	portsMachine2, err := GetOrCreatePorts(
-		s.state, machines[2].Id(), network.DefaultPublic,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	err = portsMachine2.OpenPorts(portRange)
-	c.Assert(err, jc.ErrorIsNil)
 	//
+	// This is done "manually" because doing it conventionally using
+	// State methods will mean that the document ID used will be env
+	// UUID prefixed and this migration runs before the openedPorts
+	// collection is migrated to using environment UUIDs. The
+	// migration step expects the openedPorts collection to be pre-env
+	// UUID migration.
+	err = s.state.runRawTransaction([]txn.Op{{
+		C:      openedPortsC,
+		Id:     portsGlobalKey("2", network.DefaultPublic),
+		Assert: txn.DocMissing,
+		Insert: bson.M{
+			"machine-id":   "2",
+			"network-name": network.DefaultPublic,
+			"ports": []bson.M{{
+				"unitname": units[2][1].Name(),
+				"fromport": 100,
+				"toport":   110,
+				"protocol": "tcp",
+			}},
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+
 	// units[0][0] (on machines[0]):
 	// - no ports opened
 	//
@@ -1380,7 +1395,7 @@ func (s *upgradesSuite) TestMigrateUnitPortsToOpenedPorts(c *gc.C) {
 	machines, units := s.setUpPortsMigration(c)
 
 	// Ensure there are no new-style port ranges before the migration,
-	// except for macines[2].
+	// except for machines[2].
 	s.assertInitialMachinePorts(c, machines, units)
 
 	err := MigrateUnitPortsToOpenedPorts(s.state)
@@ -1400,7 +1415,7 @@ func (s *upgradesSuite) TestMigrateUnitPortsToOpenedPortsIdempotent(c *gc.C) {
 	machines, units := s.setUpPortsMigration(c)
 
 	// Ensure there are no new-style port ranges before the migration,
-	// except for macines[2].
+	// except for machines[2].
 	s.assertInitialMachinePorts(c, machines, units)
 
 	err := MigrateUnitPortsToOpenedPorts(s.state)
@@ -1468,7 +1483,7 @@ func (s *upgradesSuite) patchPortOptFuncs() {
 
 	s.PatchValue(
 		&addPortsDocOps,
-		func(st *State, pDoc portsDoc, portsAssert interface{}, ports ...PortRange) ([]txn.Op, error) {
+		func(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) ([]txn.Op, error) {
 			pDoc.Ports = ports
 			return []txn.Op{{
 				C:      machinesC,
@@ -1558,7 +1573,7 @@ func (s *upgradesSuite) setUpMeterStatusCreation(c *gc.C) []*Unit {
 					Assert: isAliveDoc,
 					Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
 				}}
-			err = s.state.runTransaction(ops)
+			err = s.state.runRawTransaction(ops)
 			c.Assert(err, jc.ErrorIsNil)
 			units[i*3+j], err = s.state.Unit(name)
 			c.Assert(err, jc.ErrorIsNil)
@@ -1646,7 +1661,7 @@ func (s *upgradesSuite) instanceIdSetUp(c *gc.C, machineID string, instID instan
 			Insert: mDoc,
 		},
 	}
-	err := s.state.runTransaction(ops)
+	err := s.state.runRawTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1712,7 +1727,7 @@ func (s *upgradesSuite) azSetUp(c *gc.C, machineID string, instID instance.Id) {
 
 	// Ensure "availzone" isn't set.
 	var instanceMap bson.M
-	insts, closer := s.state.getRawCollection(instanceDataC)
+	insts, closer := s.state.getCollection(instanceDataC)
 	defer closer()
 	err = insts.FindId(machineID).One(&instanceMap)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1724,7 +1739,7 @@ func (s *upgradesSuite) azSetUp(c *gc.C, machineID string, instID instance.Id) {
 // for the instance data associated with the machine.
 func (s *upgradesSuite) checkAvailabilityZone(c *gc.C, machineID string, expectedZone string) {
 	var instanceMap bson.M
-	insts, closer := s.state.getRawCollection(instanceDataC)
+	insts, closer := s.state.getCollection(instanceDataC)
 	defer closer()
 	err := insts.FindId(machineID).One(&instanceMap)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1759,7 +1774,7 @@ func (s *upgradesSuite) setUpJobManageNetworking(c *gc.C, provider string, manua
 		})
 	}
 	// Run transaction.
-	err = s.state.runTransaction(ops)
+	err = s.state.runRawTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
Transaction operations that update collections that contain documents for multiple environments are now automatically updated to include the required environment specifiers.

(Review request: http://reviews.vapour.ws/r/605/)
