### PR TITLE
cmd/jujud: fixed patch race in upgrade tests

### DIFF
--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -627,9 +627,9 @@ func (s *UpgradeSuite) runUpgradeWorkerUsingAgent(
 	agent *fakeUpgradingMachineAgent,
 	jobs ...multiwatcher.MachineJob,
 ) (error, *upgradeWorkerContext) {
+	s.setInstantRetryStrategy(c)
 	context := NewUpgradeWorkerContext()
 	worker := context.Worker(agent, nil, jobs)
-	s.setInstantRetryStrategy(c)
 	return worker.Wait(), context
 }
 


### PR DESCRIPTION
The patch to the attempt strategy used during upgrades was done just /after/ the upgrade worker had already been started so there was a race. The worker was occasionally getting the real attempt strategy instead of the test one, causing long test runs and unexpected numbers of retries.

The patch is now made before starting the worker.

Fixes LP #1389389.

(Review request: http://reviews.vapour.ws/r/618/)
