### PR TITLE
Add force reconfig of peergrouper

### DIFF
--- a/cmd/jujud/machine.go
+++ b/cmd/jujud/machine.go
@@ -982,7 +982,7 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 		// TODO(dfc) InitiateMongoParams should take a Tag
 		User:     stateInfo.Tag.String(),
 		Password: stateInfo.Password,
-	}); err != nil {
+	}); err != nil && err != peergrouper.ErrReplicaSetAlreadyInitiated {
 		return err
 	}
 	return nil

--- a/worker/peergrouper/initiate_test.go
+++ b/worker/peergrouper/initiate_test.go
@@ -40,7 +40,19 @@ func (s *InitiateSuite) TestInitiateReplicaSet(c *gc.C) {
 	// This would return a mgo.QueryError if a ReplicaSet
 	// configuration already existed but we tried to create
 	// one with replicaset.Initiate again.
+	// ErrReplicaSetAlreadyInitiated is not a failure but an
+	// indication that we tried to initiate an initiated rs
 	err = peergrouper.MaybeInitiateMongoServer(args)
+	c.Assert(err, gc.Equals, peergrouper.ErrReplicaSetAlreadyInitiated)
+
+	// Make sure running InitiateMongoServer without forcing will behave
+	// in the same way as MaybeInitiateMongoServer
+	err = peergrouper.InitiateMongoServer(args, false)
+	c.Assert(err, gc.Equals, peergrouper.ErrReplicaSetAlreadyInitiated)
+
+	// Assert that passing Force to initiate will re-create the replicaset
+	// even though it exists already
+	err = peergrouper.InitiateMongoServer(args, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// TODO test login


### PR DESCRIPTION
When restoring sometimes we need to re-set peergrouper
even if there is a configuration in place.

(Review request: http://reviews.vapour.ws/r/620/)
