### PR TITLE
Fixed lp:1401130 - networker is disabled for joyent environments

### DIFF
--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -202,10 +202,12 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 	}
 
 	jobs := []multiwatcher.MachineJob{multiwatcher.JobHostUnits}
-	if config.Type() != provider.MAAS {
-		// In case of MAAS JobManageNetworking is not added to ensure
-		// the non-intrusive start of a networker like above for the
-		// manual provisioning.
+	if config.Type() != provider.MAAS &&
+		config.Type() != provider.Joyent {
+		// In case of MAAS and Joyent JobManageNetworking is not added
+		// to ensure the non-intrusive start of a networker like above
+		// for the manual provisioning. See this related joyent bug
+		// http://pad.lv/1401423
 		jobs = append(jobs, multiwatcher.JobManageNetworking)
 	}
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -814,6 +814,7 @@ func setOldID(name string) updateFunc {
 // machines except for:
 //
 // - machines in a MAAS environment,
+// - machines in a Joyent environment,
 // - machines in a manual environment,
 // - bootstrap node (host machine) in a local environment, and
 // - manually provisioned machines.
@@ -825,8 +826,10 @@ func MigrateJobManageNetworking(st *State) error {
 	}
 	envType := envConfig.Type()
 
-	// Check for MAAS or manual (aka null) provider.
-	if envType == provider.MAAS || provider.IsManual(envType) {
+	// Check for MAAS, Joyent, or manual (aka null) provider.
+	if envType == provider.MAAS ||
+		envType == provider.Joyent ||
+		provider.IsManual(envType) {
 		// No job adding for these environment types.
 		return nil
 	}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1833,12 +1833,12 @@ func (s *upgradesSuite) TestJobManageNetworking(c *gc.C) {
 		description: "joyent provider, no manual provisioned machines",
 		provider:    "joyent",
 		manual:      false,
-		hasJob:      []bool{true, true, true},
+		hasJob:      []bool{false, false, false},
 	}, {
 		description: "joyent provider, one manual provisioned machine",
 		provider:    "joyent",
 		manual:      true,
-		hasJob:      []bool{true, true, false},
+		hasJob:      []bool{false, false, false},
 	}, {
 		description: "local provider, no manual provisioned machines",
 		provider:    "local",


### PR DESCRIPTION
Networker was causing problems on Joyent environemnts.
Since http://pad.lv/1401130 is a CI blocker, this is
a temporary fix that disables the networker for Joyent.

I've filed a separate low-priorty bug http://pad.lv/1401423
to propely fix the networker for joyent, when possible.

Live tested on Joyent.

(Review request: http://reviews.vapour.ws/r/623/)
