### PR TITLE
Backport the fix for lp:1401130 to 1.21 - networker is disabled for joyent environments

### DIFF
--- a/cmd/juju/addmachine.go
+++ b/cmd/juju/addmachine.go
@@ -194,10 +194,12 @@ func (c *AddMachineCommand) Run(ctx *cmd.Context) error {
 	}
 
 	jobs := []params.MachineJob{params.JobHostUnits}
-	if config.Type() != provider.MAAS {
-		// In case of MAAS JobManageNetworking is not added to ensure
-		// the non-intrusive start of a networker like above for the
-		// manual provisioning.
+	if config.Type() != provider.MAAS &&
+		config.Type() != provider.Joyent {
+		// In case of MAAS and Joyent JobManageNetworking is not added
+		// to ensure the non-intrusive start of a networker like above
+		// for the manual provisioning. See this related joyent bug
+		// http://pad.lv/1401423
 		jobs = append(jobs, params.JobManageNetworking)
 	}
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -670,6 +670,7 @@ func addEnvUUIDToEntityCollection(st *State, collName, fieldForOldID string) err
 // machines except for:
 //
 // - machines in a MAAS environment,
+// - machines in a Joyent environment,
 // - machines in a manual environment,
 // - bootstrap node (host machine) in a local environment, and
 // - manually provisioned machines.
@@ -681,8 +682,10 @@ func MigrateJobManageNetworking(st *State) error {
 	}
 	envType := envConfig.Type()
 
-	// Check for MAAS or manual (aka null) provider.
-	if envType == provider.MAAS || provider.IsManual(envType) {
+	// Check for MAAS, Joyent, or manual (aka null) provider.
+	if envType == provider.MAAS ||
+		envType == provider.Joyent ||
+		provider.IsManual(envType) {
 		// No job adding for these environment types.
 		return nil
 	}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1249,12 +1249,12 @@ func (s *upgradesSuite) TestJobManageNetworking(c *gc.C) {
 		description: "joyent provider, no manual provisioned machines",
 		provider:    "joyent",
 		manual:      false,
-		hasJob:      []bool{true, true, true},
+		hasJob:      []bool{false, false, false},
 	}, {
 		description: "joyent provider, one manual provisioned machine",
 		provider:    "joyent",
 		manual:      true,
-		hasJob:      []bool{true, true, false},
+		hasJob:      []bool{false, false, false},
 	}, {
 		description: "local provider, no manual provisioned machines",
 		provider:    "local",

--- a/upgrades/jobmanagenetworking.go
+++ b/upgrades/jobmanagenetworking.go
@@ -11,6 +11,7 @@ import (
 // machines except for:
 //
 // - machines in a MAAS environment,
+// - machines in a Joyent environment,
 // - machines in a manual environment,
 // - bootstrap node (host machine) in a local environment, and
 // - manually provisioned machines.


### PR DESCRIPTION
No changes other than backporting #1308 for 1.21.

(Review request: http://reviews.vapour.ws/r/624/)
