### PR TITLE
Workaround for go vet error with current version of go vet

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -25,7 +25,11 @@ func Audit(user Tagger, format string, args ...interface{}) {
 	if user.Tag() == "" {
 		panic("user tag cannot be blank")
 	}
-	// Logf is called directly, rather than Infof so that the caller of Audit is
-	// recorded, not Audit itself.
-	logger.Logf(loggo.INFO, fmt.Sprintf("%s: %s", user.Tag(), format), args...)
+
+	// LogCallf is called directly, rather than Infof so that the caller
+	// of Audit is recorded, not Audit itself.
+	// Also, we're using LogCallf instead of Logf to work around a bug
+	// in the go1.4 version of go vet (https://github.com/golang/go/issues/9080)
+	// which incorrectly flags the Logf call.
+	logger.LogCallf(1, loggo.INFO, fmt.Sprintf("%s: %s", user.Tag(), format), args...)
 }


### PR DESCRIPTION
  In go1.4 `go vet` incorrectly chokes on the call to
  `logger.Logf(loggo.INFO, fmt, args...)` because the `loggo.INFO` is an
  `iota` not an expected string.

  The error message was:
    `audit/audit.go:30: constant 3 not a string in call to Logf`
  which was confusing, but the `iota` value of `loggo.INFO` is `3`

  This fix sticks to the intent of the `audit.Audit` func, but uses
  `logger.LogCallf` which both bypasses the `go vet` check, and reduces
  one extra method call because `Logf` was previously calling `LogCallf`
  in turn.

(Review request: http://reviews.vapour.ws/r/630/)
