### PR TITLE
Change the way the ubuntu user is detected

### DIFF
--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -206,7 +206,7 @@ printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -e /proc/self/fd/9 \|\| exec 9>&2
 \(\[ ! -e /home/ubuntu/.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
 mkdir -p /var/lib/juju/locks
-\[ -e /home/ubuntu \] && chown ubuntu:ubuntu /var/lib/juju/locks
+grep -q ubuntu /etc/passwd && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-precise-amd64'
@@ -310,7 +310,7 @@ printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -e /proc/self/fd/9 \|\| exec 9>&2
 \(\[ ! -e /home/ubuntu/\.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
 mkdir -p /var/lib/juju/locks
-\[ -e /home/ubuntu \] && chown ubuntu:ubuntu /var/lib/juju/locks
+grep -q ubuntu /etc/passwd && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
@@ -1033,7 +1033,7 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 		`export HTTP_PROXY=http://user@10.0.0.1`,
 		`export no_proxy=localhost,10.0.3.1`,
 		`export NO_PROXY=localhost,10.0.3.1`,
-		`[ -e /home/ubuntu ] && (printf '%s\n' 'export http_proxy=http://user@10.0.0.1
+		`grep -q ubuntu /etc/passwd && (printf '%s\n' 'export http_proxy=http://user@10.0.0.1
 export HTTP_PROXY=http://user@10.0.0.1
 export no_proxy=localhost,10.0.3.1
 export NO_PROXY=localhost,10.0.3.1' > /home/ubuntu/.juju-proxy && chown ubuntu:ubuntu /home/ubuntu/.juju-proxy)`,

--- a/environs/cloudinit/cloudinit_ubuntu.go
+++ b/environs/cloudinit/cloudinit_ubuntu.go
@@ -140,7 +140,7 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 	// sourced by bash, and ssh through that.
 	w.conf.AddScripts(
 		// We look to see if the proxy line is there already as
-		// the manual provider may have had it aleady. The ubuntu
+		// the manual provider may have had it already. The ubuntu
 		// user may not exist (local provider only).
 		`([ ! -e /home/ubuntu/.profile ] || grep -q '.juju-proxy' /home/ubuntu/.profile) || ` +
 			`printf '\n# Added by juju\n[ -f "$HOME/.juju-proxy" ] && . "$HOME/.juju-proxy"\n' >> /home/ubuntu/.profile`)
@@ -149,7 +149,7 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 		w.conf.AddScripts(strings.Split(exportedProxyEnv, "\n")...)
 		w.conf.AddScripts(
 			fmt.Sprintf(
-				`[ -e /home/ubuntu ] && (printf '%%s\n' %s > /home/ubuntu/.juju-proxy && chown ubuntu:ubuntu /home/ubuntu/.juju-proxy)`,
+				`grep -q ubuntu /etc/passwd && (printf '%%s\n' %s > /home/ubuntu/.juju-proxy && chown ubuntu:ubuntu /home/ubuntu/.juju-proxy)`,
 				shquote(w.mcfg.ProxySettings.AsScriptEnvironment())))
 	}
 
@@ -160,9 +160,8 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 	lockDir := path.Join(w.mcfg.DataDir, "locks")
 	w.conf.AddScripts(
 		fmt.Sprintf("mkdir -p %s", lockDir),
-		// We only try to change ownership if there is an ubuntu user
-		// defined, and we determine this by the existance of the home dir.
-		fmt.Sprintf("[ -e /home/ubuntu ] && chown ubuntu:ubuntu %s", lockDir),
+		// We only try to change ownership if there is an ubuntu user defined.
+		fmt.Sprintf("grep -q ubuntu /etc/passwd && chown ubuntu:ubuntu %s", lockDir),
 		fmt.Sprintf("mkdir -p %s", w.mcfg.LogDir),
 		fmt.Sprintf("chown syslog:adm %s", w.mcfg.LogDir),
 	)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/ubuntu/+source/juju-core/+bug/1328958

Instead of looking for /home/ubuntu, we grep the passwd file to determine if the ubuntu user exists.

(Review request: http://reviews.vapour.ws/r/640/)
