### PR TITLE
Merge pull request #1321 from wallyworld/lp-1328958

### DIFF
--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -208,7 +208,7 @@ printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -e /proc/self/fd/9 \|\| exec 9>&2
 \(\[ ! -e /home/ubuntu/.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
 mkdir -p /var/lib/juju/locks
-grep -q ubuntu /etc/passwd && chown ubuntu:ubuntu /var/lib/juju/locks
+\(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-precise-amd64'
@@ -312,7 +312,7 @@ printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -e /proc/self/fd/9 \|\| exec 9>&2
 \(\[ ! -e /home/ubuntu/\.profile \] \|\| grep -q '.juju-proxy' /home/ubuntu/.profile\) \|\| printf .* >> /home/ubuntu/.profile
 mkdir -p /var/lib/juju/locks
-grep -q ubuntu /etc/passwd && chown ubuntu:ubuntu /var/lib/juju/locks
+\(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
 chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
@@ -1040,7 +1040,7 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 		`export HTTP_PROXY=http://user@10.0.0.1`,
 		`export no_proxy=localhost,10.0.3.1`,
 		`export NO_PROXY=localhost,10.0.3.1`,
-		`grep -q ubuntu /etc/passwd && (printf '%s\n' 'export http_proxy=http://user@10.0.0.1
+		`(id ubuntu &> /dev/null) && (printf '%s\n' 'export http_proxy=http://user@10.0.0.1
 export HTTP_PROXY=http://user@10.0.0.1
 export no_proxy=localhost,10.0.3.1
 export NO_PROXY=localhost,10.0.3.1' > /home/ubuntu/.juju-proxy && chown ubuntu:ubuntu /home/ubuntu/.juju-proxy)`,

--- a/environs/cloudinit/cloudinit_ubuntu.go
+++ b/environs/cloudinit/cloudinit_ubuntu.go
@@ -150,7 +150,7 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 		w.conf.AddScripts(strings.Split(exportedProxyEnv, "\n")...)
 		w.conf.AddScripts(
 			fmt.Sprintf(
-				`grep -q ubuntu /etc/passwd && (printf '%%s\n' %s > /home/ubuntu/.juju-proxy && chown ubuntu:ubuntu /home/ubuntu/.juju-proxy)`,
+				`(id ubuntu &> /dev/null) && (printf '%%s\n' %s > /home/ubuntu/.juju-proxy && chown ubuntu:ubuntu /home/ubuntu/.juju-proxy)`,
 				shquote(w.mcfg.ProxySettings.AsScriptEnvironment())))
 	}
 
@@ -162,7 +162,7 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 	w.conf.AddScripts(
 		fmt.Sprintf("mkdir -p %s", lockDir),
 		// We only try to change ownership if there is an ubuntu user defined.
-		fmt.Sprintf("grep -q ubuntu /etc/passwd && chown ubuntu:ubuntu %s", lockDir),
+		fmt.Sprintf("(id ubuntu &> /dev/null) && chown ubuntu:ubuntu %s", lockDir),
 		fmt.Sprintf("mkdir -p %s", w.mcfg.LogDir),
 		fmt.Sprintf("chown syslog:adm %s", w.mcfg.LogDir),
 	)


### PR DESCRIPTION
Change the way the ubuntu user is detected

Fixes https://bugs.launchpad.net/ubuntu/+source/juju-core/+bug/1328958

Instead of looking for /home/ubuntu, we grep the passwd file to determine if the ubuntu user exists.

(Review request: http://reviews.vapour.ws/r/640/)

(Review request: http://reviews.vapour.ws/r/642/)
