### PR TITLE
mongo: check all addresses when deciding if machine is master

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -94,7 +94,6 @@ func IsMaster(session *mgo.Session, obj WithAddresses) (bool, error) {
 	if err == replicaset.ErrMasterNotConfigured {
 		return true, nil
 	}
-
 	if err != nil {
 		return false, err
 	}
@@ -104,8 +103,12 @@ func IsMaster(session *mgo.Session, obj WithAddresses) (bool, error) {
 		return false, err
 	}
 
-	machinePeerAddr := SelectPeerAddress(addrs)
-	return machinePeerAddr == masterAddr, nil
+	for _, addr := range addrs {
+		if addr.Value == masterAddr {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // SelectPeerAddress returns the address to use as the


### PR DESCRIPTION
The recent fix for LP #1397376 meant that on MAAS the replicaset master address no longer matches the address returned by SelectPeerAddress - no state server thought it was the master. This breaks upgrades among other things.

All machine addresses are no compared against the replicaset master address.

Fixes LP #1403200.

(Review request: http://reviews.vapour.ws/r/648/)
