### PR TITLE
cmd/jujud: fixed patch race in upgrade tests (backport to 1.21)

### DIFF
--- a/cmd/jujud/upgrade_test.go
+++ b/cmd/jujud/upgrade_test.go
@@ -579,9 +579,9 @@ func (s *UpgradeSuite) runUpgradeWorkerUsingAgent(
 	job params.MachineJob,
 	agent *fakeUpgradingMachineAgent,
 ) (error, *upgradeWorkerContext) {
+	s.setInstantRetryStrategy()
 	context := NewUpgradeWorkerContext()
 	worker := context.Worker(agent, nil, []params.MachineJob{job})
-	s.setInstantRetryStrategy()
 	return worker.Wait(), context
 }
 


### PR DESCRIPTION
The patch to the attempt strategy used during upgrades was done just /after/ the upgrade worker had already been started so there was a race. The worker was occasionally getting the real attempt strategy instead of the test one, causing long test runs and unexpected numbers of retries.

The patch is now made before starting the worker.

Fixes LP #1389389.

(Review request: http://reviews.vapour.ws/r/649/)
