### PR TITLE
Increment juju to 1.21-beta5

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "1.21-beta4"
+#define MyAppVersion "1.21-beta5"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.ubuntu.com/"
 #define MyAppExeName "juju.exe"

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "1.21-beta4"
+const version = "1.21-beta5"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
Update juju and win installer 1.21.beta5, we hope to rename to 1.21.0 after testing

(Review request: http://reviews.vapour.ws/r/650/)
