### PR TITLE
Fixes LP-1403596

### DIFF
--- a/state/backups/metadata_darwin.go
+++ b/state/backups/metadata_darwin.go
@@ -1,8 +1,6 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// +build !windows
-
 package backups
 
 import (
@@ -15,7 +13,7 @@ func creationTime(fi os.FileInfo) time.Time {
 	rawstat := fi.Sys()
 	if rawstat != nil {
 		if stat, ok := rawstat.(*syscall.Stat_t); ok {
-			return time.Unix(int64(stat.Ctim.Sec), 0)
+			return time.Unix(int64(stat.Ctimespec.Sec), 0)
 		}
 	}
 	return time.Time{}

--- a/state/backups/metadata_linux.go
+++ b/state/backups/metadata_linux.go
@@ -1,0 +1,20 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func creationTime(fi os.FileInfo) time.Time {
+	rawstat := fi.Sys()
+	if rawstat != nil {
+		if stat, ok := rawstat.(*syscall.Stat_t); ok {
+			return time.Unix(int64(stat.Ctim.Sec), 0)
+		}
+	}
+	return time.Time{}
+}


### PR DESCRIPTION
  OS X (darwin) uses `stat.Ctimespec` not `stat.Ctim`

(Review request: http://reviews.vapour.ws/r/655/)
