### PR TITLE
MachineAgent refactoring.

### DIFF
--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -117,7 +117,14 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	})
 	jujud.Log.Factory = &writerFactory{}
 	jujud.Register(&BootstrapCommand{})
-	jujud.Register(&agentcmd.MachineAgent{})
+
+	// TODO(katco-): AgentConf type is doing too much. The
+	// MachineAgent type has called out the seperate concerns; the
+	// AgentConf should be split up to follow suite.
+	var agentConf agentcmd.AgentConf
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(&agentConf, &agentConf)
+	jujud.Register(agentcmd.NewMachineAgentCmd(machineAgentFactory, &agentConf, &agentConf))
+
 	jujud.Register(&UnitAgent{})
 	code = cmd.Main(jujud, ctx, args[1:])
 	return code, nil


### PR DESCRIPTION
- A type, "machineAgentCmd" was split out from MachineAgent to handle command-line operations, and starting a MachineAgent.
- MachineAgent now requests 3 different interface types for various operations. Currently these are still fulfilled by cmd/jujud/agent/AgentConf, but this should be broken up later.

(Review request: http://reviews.vapour.ws/r/658/)