### PR TITLE
Upgrade step to fix env UUID for minUnits

### DIFF
--- a/upgrades/steps122.go
+++ b/upgrades/steps122.go
@@ -75,6 +75,12 @@ func stateStepsFor122() []Step {
 				return state.AddEnvUUIDToOpenPorts(context.State())
 			},
 		}, &upgradeStep{
+			description: "fix environment UUID for minUnits docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.FixMinUnitsEnvUUID(context.State())
+			},
+		}, &upgradeStep{
 			description: "update system identity in state",
 			targets:     []Target{DatabaseMaster},
 			run:         ensureSystemSSHKeyRedux,

--- a/upgrades/steps122_test.go
+++ b/upgrades/steps122_test.go
@@ -30,6 +30,7 @@ func (s *steps122Suite) TestStateStepsFor122(c *gc.C) {
 		"prepend the environment UUID to the ID of all constraints docs",
 		"prepend the environment UUID to the ID of all meterStatus docs",
 		"prepend the environment UUID to the ID of all openPorts docs",
+		"fix environment UUID for minUnits docs",
 		"update system identity in state",
 		"set AvailZone in instanceData",
 	}


### PR DESCRIPTION
The environment UUID migration work for the minUnits collection missed a change to add environment UUID to new documents. This means minUnits documents added after the migration work landed will have a blank env-uuid field.

This change adds an upgrade step to repair this (the missed code change has already been corrected).

(Review request: http://reviews.vapour.ws/r/660/)