### PR TITLE
Charm actions fix, bug 1404397

### DIFF
--- a/apiserver/action/action_test.go
+++ b/apiserver/action/action_test.go
@@ -543,9 +543,10 @@ func (s *actionSuite) TestCancel(c *gc.C) {
 
 func (s *actionSuite) TestServicesCharmActions(c *gc.C) {
 	actionSchemas := map[string]map[string]interface{}{
-		"outfile": map[string]interface{}{
+		"snapshot": map[string]interface{}{
 			"type":        "object",
-			"description": "this boilerplate is insane, we have to fix it",
+			"title":       "snapshot",
+			"description": "Take a snapshot of the database.",
 			"properties": map[string]interface{}{
 				"outfile": map[string]interface{}{
 					"description": "The file to write out to.",
@@ -568,7 +569,7 @@ func (s *actionSuite) TestServicesCharmActions(c *gc.C) {
 						ActionSpecs: map[string]charm.ActionSpec{
 							"snapshot": charm.ActionSpec{
 								Description: "Take a snapshot of the database.",
-								Params:      actionSchemas["outfile"],
+								Params:      actionSchemas["snapshot"],
 							},
 						},
 					},

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -787,7 +787,8 @@ func (s *clientSuite) TestClientCharmInfo(c *gc.C) {
 						Description: "Take a snapshot of the database.",
 						Params: map[string]interface{}{
 							"type":        "object",
-							"description": "this boilerplate is insane, we have to fix it",
+							"title":       "snapshot",
+							"description": "Take a snapshot of the database.",
 							"properties": map[string]interface{}{
 								"outfile": map[string]interface{}{
 									"default":     "foo.bz2",

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -23,7 +23,7 @@ github.com/juju/testing	git	839334678c08487fb1c6ab032893fc8c85d74756
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	
 github.com/juju/utils	git	37016f78b9989f99222a5e09a26e25db124c1b17	2014-12-05T10:56:08+08:00
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
-gopkg.in/juju/charm.v4	git	f7e5613ff75457d2700d1c3269546cc903ea0471	
+gopkg.in/juju/charm.v4	git	fc2ec430f9825a89900f35c825b9e0292c4136d4	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -56,7 +56,8 @@ func (s *CharmSuite) TestCharm(c *gc.C) {
 			Description: "Take a snapshot of the database.",
 			Params: map[string]interface{}{
 				"type":        "object",
-				"description": "this boilerplate is insane, we have to fix it",
+				"title":       "snapshot",
+				"description": "Take a snapshot of the database.",
 				"properties": map[string]interface{}{
 					"outfile": map[string]interface{}{
 						"description": "The file to write out to.",

--- a/testcharms/charm-repo/quantal/dummy/actions.yaml
+++ b/testcharms/charm-repo/quantal/dummy/actions.yaml
@@ -1,11 +1,7 @@
-actions:
-    snapshot:
-        description: Take a snapshot of the database.
-        params:
-            type: object
-            description: this boilerplate is insane, we have to fix it
-            properties:
-                outfile:
-                    description: The file to write out to.
-                    type: string
-                    default: foo.bz2
+snapshot:
+  description: Take a snapshot of the database.
+  params:
+    outfile:
+      description: The file to write out to.
+      type: string
+      default: foo.bz2

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -238,36 +238,27 @@ juju-reboot --now || action-set reboot-now="good"
 
 func (ctx *context) writeActionsYaml(c *gc.C, path string, names ...string) {
 	var actionsYaml = map[string]string{
-		"base": `
-actions:
-`[1:],
+		"base": "",
 		"snapshot": `
-   snapshot:
-      description: Take a snapshot of the database.                           
-      params:                                                                 
-         title: "Snapshot"                                                    
-         type: "object"                                                       
-         properties:                                                          
-            outfile:                                                          
-               description: "The file to write out to."                       
-               type: string                                                   
-         required: ["outfile"]
+snapshot:
+   description: Take a snapshot of the database.
+   params:
+      outfile:
+         description: "The file to write out to."
+         type: string
+   required: ["outfile"]
 `[1:],
 		"action-log": `
-   action-log:
-      params:
+action-log:
 `[1:],
 		"action-log-fail": `
-   action-log-fail:
-      params:
+action-log-fail:
 `[1:],
 		"action-log-fail-error": `
-   action-log-fail-error:
-      params:
+action-log-fail-error:
 `[1:],
 		"action-reboot": `
-   action-reboot:
-      params:
+action-reboot:
 `[1:],
 	}
 	actionsYamlPath := filepath.Join(path, "actions.yaml")


### PR DESCRIPTION
Depends on https://github.com/juju/charm/pull/81.

Fixes https://bugs.launchpad.net/juju-core/+bug/1404397.

Charm now expects a much simpler format for actions.yaml:

```text
<action name>:
  [description]: <string>
  [params]:
    <param 1>: <JSON-schema>
    <param 2>: <JSON-schema>
    ...
  [required]: <string list>
  [other keys e.g. "definitions"]: ...
<next action name>: ...
```

This PR fixes tests on juju/juju to reflect this change.