### PR TITLE
Fix server cert regeneration; fix check to see if secure connection supported

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -51,15 +51,16 @@ var DefaultDataDir = dataDir
 const SystemIdentity = "system-identity"
 
 const (
-	LxcBridge         = "LXC_BRIDGE"
-	ProviderType      = "PROVIDER_TYPE"
-	ContainerType     = "CONTAINER_TYPE"
-	Namespace         = "NAMESPACE"
-	StorageDir        = "STORAGE_DIR"
-	StorageAddr       = "STORAGE_ADDR"
-	AgentServiceName  = "AGENT_SERVICE_NAME"
-	MongoOplogSize    = "MONGO_OPLOG_SIZE"
-	NumaCtlPreference = "NUMA_CTL_PREFERENCE"
+	LxcBridge              = "LXC_BRIDGE"
+	ProviderType           = "PROVIDER_TYPE"
+	ContainerType          = "CONTAINER_TYPE"
+	Namespace              = "NAMESPACE"
+	StorageDir             = "STORAGE_DIR"
+	StorageAddr            = "STORAGE_ADDR"
+	AgentServiceName       = "AGENT_SERVICE_NAME"
+	MongoOplogSize         = "MONGO_OPLOG_SIZE"
+	NumaCtlPreference      = "NUMA_CTL_PREFERENCE"
+	AllowsSecureConnection = "SECURE_STATESERVER_CONNECTION"
 )
 
 // The Config interface is the sole way that the agent gets access to the

--- a/apiserver/client/machineconfig.go
+++ b/apiserver/client/machineconfig.go
@@ -88,7 +88,15 @@ func MachineConfig(st *state.State, machineId, nonce, dataDir string) (*cloudini
 		return nil, err
 	}
 
-	mcfg, err := environs.NewMachineConfig(machineId, nonce, env.Config().ImageStream(), machine.Series(), networks, mongoInfo, apiInfo)
+	// Figure out if secure connections are supported.
+	info, err := st.StateServingInfo()
+	if err != nil {
+		return nil, err
+	}
+	secureServerConnection := info.CAPrivateKey != ""
+	mcfg, err := environs.NewMachineConfig(machineId, nonce, env.Config().ImageStream(), machine.Series(),
+		secureServerConnection, networks, mongoInfo, apiInfo,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/cloudinit/sshinit/configure_test.go
+++ b/cloudinit/sshinit/configure_test.go
@@ -61,7 +61,7 @@ func (s *configureSuite) getCloudConfig(c *gc.C, stateServer bool, vers version.
 		mcfg.InstanceId = "instance-id"
 		mcfg.Jobs = []multiwatcher.MachineJob{multiwatcher.JobManageEnviron, multiwatcher.JobHostUnits}
 	} else {
-		mcfg, err = environs.NewMachineConfig("0", "ya", imagemetadata.ReleasedStream, vers.Series, nil, nil, nil)
+		mcfg, err = environs.NewMachineConfig("0", "ya", imagemetadata.ReleasedStream, vers.Series, true, nil, nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		mcfg.Jobs = []multiwatcher.MachineJob{multiwatcher.JobHostUnits}
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -717,10 +717,8 @@ func (a *MachineAgent) updateSupportedContainers(
 	// it we can't ensure that other Juju nodes can connect securely, so only
 	// use an image URL getter if there's a private key.
 	var imageURLGetter container.ImageURLGetter
-	if servingInfo, ok := agentConfig.StateServingInfo(); ok {
-		if servingInfo.CAPrivateKey != "" {
-			imageURLGetter = container.NewImageURLGetter(st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()))
-		}
+	if agentConfig.Value(agent.AllowsSecureConnection) == "true" {
+		imageURLGetter = container.NewImageURLGetter(st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()))
 	}
 	params := provisioner.ContainerSetupParams{
 		Runner:              runner,

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -85,7 +85,7 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	machineNonce := "fake-nonce"
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", nil, stateInfo, apiInfo)
+	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	network := container.BridgeNetworkConfig("virbr0")
 

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -26,7 +26,7 @@ func MockMachineConfig(machineId string) (*cloudinit.MachineConfig, error) {
 
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	machineConfig, err := environs.NewMachineConfig(machineId, "fake-nonce", imagemetadata.ReleasedStream, "quantal", nil, stateInfo, apiInfo)
+	machineConfig, err := environs.NewMachineConfig(machineId, "fake-nonce", imagemetadata.ReleasedStream, "quantal", true, nil, stateInfo, apiInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -6,6 +6,7 @@ package environs
 import (
 	"fmt"
 	"path"
+	"strconv"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -46,6 +47,7 @@ func NewMachineConfig(
 	machineNonce,
 	imageStream,
 	series string,
+	secureServerConnections bool,
 	networks []string,
 	mongoInfo *mongo.MongoInfo,
 	apiInfo *api.Info,
@@ -75,6 +77,9 @@ func NewMachineConfig(
 		MongoInfo:    mongoInfo,
 		APIInfo:      apiInfo,
 		ImageStream:  imageStream,
+		AgentEnvironment: map[string]string{
+			agent.AllowsSecureConnection: strconv.FormatBool(secureServerConnections),
+		},
 	}
 	return mcfg, nil
 }
@@ -85,7 +90,7 @@ func NewMachineConfig(
 func NewBootstrapMachineConfig(cons constraints.Value, series string) (*cloudinit.MachineConfig, error) {
 	// For a bootstrap instance, FinishMachineConfig will provide the
 	// state.Info and the api.Info. The machine id must *always* be "0".
-	mcfg, err := NewMachineConfig("0", agent.BootstrapNonce, "", series, nil, nil, nil)
+	mcfg, err := NewMachineConfig("0", agent.BootstrapNonce, "", series, true, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -977,7 +977,7 @@ func (*cloudinitSuite) createMachineConfig(c *gc.C, environConfig *config.Config
 	machineNonce := "fake-nonce"
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", nil, stateInfo, apiInfo)
+	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	machineConfig.Tools = &tools.Tools{
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -726,7 +726,7 @@ func (t *LiveTests) TestStartInstanceWithEmptyNonceFails(c *gc.C) {
 	machineId := "4"
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	machineConfig, err := environs.NewMachineConfig(machineId, "", "released", "quantal", nil, stateInfo, apiInfo)
+	machineConfig, err := environs.NewMachineConfig(machineId, "", "released", "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	t.PrepareOnce(c)

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -176,6 +176,7 @@ func StartInstanceWithParams(
 		machineNonce,
 		imagemetadata.ReleasedStream,
 		series,
+		true,
 		networks,
 		stateInfo,
 		apiInfo,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1494,7 +1494,7 @@ func (s *startInstanceSuite) SetUpTest(c *gc.C) {
 		Password: "admin",
 		Tag:      machineTag,
 	}
-	mcfg, err := environs.NewMachineConfig("1", "yanonce", imagemetadata.ReleasedStream, "quantal", nil, stateInfo, apiInfo)
+	mcfg, err := environs.NewMachineConfig("1", "yanonce", imagemetadata.ReleasedStream, "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	s.params = environs.StartInstanceParams{
 		Tools: envtesting.AssertUploadFakeToolsVersions(

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -174,18 +174,19 @@ type OpListNetworks struct {
 }
 
 type OpStartInstance struct {
-	Env           string
-	MachineId     string
-	MachineNonce  string
-	PossibleTools coretools.List
-	Instance      instance.Instance
-	Constraints   constraints.Value
-	Networks      []string
-	NetworkInfo   []network.Info
-	Info          *mongo.MongoInfo
-	Jobs          []multiwatcher.MachineJob
-	APIInfo       *api.Info
-	Secret        string
+	Env              string
+	MachineId        string
+	MachineNonce     string
+	PossibleTools    coretools.List
+	Instance         instance.Instance
+	Constraints      constraints.Value
+	Networks         []string
+	NetworkInfo      []network.Info
+	Info             *mongo.MongoInfo
+	Jobs             []multiwatcher.MachineJob
+	APIInfo          *api.Info
+	Secret           string
+	AgentEnvironment map[string]string
 }
 
 type OpStopInstances struct {
@@ -927,18 +928,19 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	estate.insts[i.id] = i
 	estate.maxId++
 	estate.ops <- OpStartInstance{
-		Env:           e.name,
-		MachineId:     machineId,
-		MachineNonce:  args.MachineConfig.MachineNonce,
-		PossibleTools: args.Tools,
-		Constraints:   args.Constraints,
-		Networks:      args.MachineConfig.Networks,
-		NetworkInfo:   networkInfo,
-		Instance:      i,
-		Jobs:          args.MachineConfig.Jobs,
-		Info:          args.MachineConfig.MongoInfo,
-		APIInfo:       args.MachineConfig.APIInfo,
-		Secret:        e.ecfg().secret(),
+		Env:              e.name,
+		MachineId:        machineId,
+		MachineNonce:     args.MachineConfig.MachineNonce,
+		PossibleTools:    args.Tools,
+		Constraints:      args.Constraints,
+		Networks:         args.MachineConfig.Networks,
+		NetworkInfo:      networkInfo,
+		Instance:         i,
+		Jobs:             args.MachineConfig.Jobs,
+		Info:             args.MachineConfig.MongoInfo,
+		APIInfo:          args.MachineConfig.APIInfo,
+		AgentEnvironment: args.MachineConfig.AgentEnvironment,
+		Secret:           e.ecfg().secret(),
 	}
 	return &environs.StartInstanceResult{
 		Instance:    i,

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -106,7 +106,7 @@ func (s *ContainerSetupSuite) setupContainerWorker(c *gc.C, tag names.MachineTag
 }
 
 func (s *ContainerSetupSuite) createContainer(c *gc.C, host *state.Machine, ctype instance.ContainerType) {
-	inst := s.checkStartInstance(c, host)
+	inst := s.checkStartInstanceNoSecureConnection(c, host)
 	s.setupContainerWorker(c, host.Tag().(names.MachineTag))
 
 	// make a container on the host machine

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -85,7 +85,7 @@ func (s *kvmBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 	machineNonce := "fake-nonce"
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", nil, stateInfo, apiInfo)
+	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.Value{}
 	possibleTools := coretools.List{&coretools.Tools{

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -89,7 +89,7 @@ func (s *lxcBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 	machineNonce := "fake-nonce"
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
-	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", nil, stateInfo, apiInfo)
+	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.Value{}
 	possibleTools := coretools.List{&coretools.Tools{

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -133,6 +133,10 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		return nil, errors.Annotate(err, "could not retrieve the environment config.")
 	}
 
+	secureServerConnection := false
+	if info, ok := p.agentConfig.StateServingInfo(); ok {
+		secureServerConnection = info.CAPrivateKey != ""
+	}
 	task := NewProvisionerTask(
 		machineTag,
 		harvestMode,
@@ -143,6 +147,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		p.broker,
 		auth,
 		envCfg.ImageStream(),
+		secureServerConnection,
 	)
 	return task, nil
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -67,19 +67,21 @@ func NewProvisionerTask(
 	broker environs.InstanceBroker,
 	auth authentication.AuthenticationProvider,
 	imageStream string,
+	secureServerConnection bool,
 ) ProvisionerTask {
 	task := &provisionerTask{
-		machineTag:      machineTag,
-		machineGetter:   machineGetter,
-		toolsFinder:     toolsFinder,
-		machineWatcher:  machineWatcher,
-		retryWatcher:    retryWatcher,
-		broker:          broker,
-		auth:            auth,
-		harvestMode:     harvestMode,
-		harvestModeChan: make(chan config.HarvestMode, 1),
-		machines:        make(map[string]*apiprovisioner.Machine),
-		imageStream:     imageStream,
+		machineTag:             machineTag,
+		machineGetter:          machineGetter,
+		toolsFinder:            toolsFinder,
+		machineWatcher:         machineWatcher,
+		retryWatcher:           retryWatcher,
+		broker:                 broker,
+		auth:                   auth,
+		harvestMode:            harvestMode,
+		harvestModeChan:        make(chan config.HarvestMode, 1),
+		machines:               make(map[string]*apiprovisioner.Machine),
+		imageStream:            imageStream,
+		secureServerConnection: secureServerConnection,
 	}
 	go func() {
 		defer task.tomb.Done()
@@ -89,17 +91,18 @@ func NewProvisionerTask(
 }
 
 type provisionerTask struct {
-	machineTag      names.MachineTag
-	machineGetter   MachineGetter
-	toolsFinder     ToolsFinder
-	machineWatcher  apiwatcher.StringsWatcher
-	retryWatcher    apiwatcher.NotifyWatcher
-	broker          environs.InstanceBroker
-	tomb            tomb.Tomb
-	auth            authentication.AuthenticationProvider
-	imageStream     string
-	harvestMode     config.HarvestMode
-	harvestModeChan chan config.HarvestMode
+	machineTag             names.MachineTag
+	machineGetter          MachineGetter
+	toolsFinder            ToolsFinder
+	machineWatcher         apiwatcher.StringsWatcher
+	retryWatcher           apiwatcher.NotifyWatcher
+	broker                 environs.InstanceBroker
+	tomb                   tomb.Tomb
+	auth                   authentication.AuthenticationProvider
+	imageStream            string
+	secureServerConnection bool
+	harvestMode            config.HarvestMode
+	harvestModeChan        chan config.HarvestMode
 	// instance id -> instance
 	instances map[instance.Id]instance.Instance
 	// machine id -> machine
@@ -464,6 +467,7 @@ func (task *provisionerTask) constructMachineConfig(
 		nonce,
 		task.imageStream,
 		pInfo.Series,
+		task.secureServerConnection,
 		nil,
 		stateInfo,
 		apiInfo,

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -5,6 +5,7 @@ package provisioner_test
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -175,13 +176,18 @@ func (s *CommonProvisionerSuite) startUnknownInstance(c *gc.C, id string) instan
 }
 
 func (s *CommonProvisionerSuite) checkStartInstance(c *gc.C, m *state.Machine) instance.Instance {
-	return s.checkStartInstanceCustom(c, m, "pork", s.defaultConstraints, nil, nil, nil, true)
+	return s.checkStartInstanceCustom(c, m, "pork", s.defaultConstraints, nil, nil, true, nil, true)
+}
+
+func (s *CommonProvisionerSuite) checkStartInstanceNoSecureConnection(c *gc.C, m *state.Machine) instance.Instance {
+	return s.checkStartInstanceCustom(c, m, "pork", s.defaultConstraints, nil, nil, false, nil, true)
 }
 
 func (s *CommonProvisionerSuite) checkStartInstanceCustom(
 	c *gc.C, m *state.Machine,
 	secret string, cons constraints.Value,
 	networks []string, networkInfo []network.Info,
+	secureServerConnection bool,
 	checkPossibleTools coretools.List,
 	waitInstanceId bool,
 ) (
@@ -207,6 +213,7 @@ func (s *CommonProvisionerSuite) checkStartInstanceCustom(
 				c.Assert(o.Secret, gc.Equals, secret)
 				c.Assert(o.Networks, jc.DeepEquals, networks)
 				c.Assert(o.NetworkInfo, jc.DeepEquals, networkInfo)
+				c.Assert(o.AgentEnvironment["SECURE_STATESERVER_CONNECTION"], gc.Equals, strconv.FormatBool(secureServerConnection))
 
 				var jobs []multiwatcher.MachineJob
 				for _, job := range m.Jobs() {
@@ -424,7 +431,7 @@ func (s *ProvisionerSuite) TestSimple(c *gc.C) {
 	// Check that an instance is provisioned when the machine is created...
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
-	instance := s.checkStartInstance(c, m)
+	instance := s.checkStartInstanceNoSecureConnection(c, m)
 
 	// ...and removed, along with the machine, when the machine is Dead.
 	c.Assert(m.EnsureDead(), gc.IsNil)
@@ -443,7 +450,7 @@ func (s *ProvisionerSuite) TestConstraints(c *gc.C) {
 	// Start a provisioner and check those constraints are used.
 	p := s.newEnvironProvisioner(c)
 	defer stop(c, p)
-	s.checkStartInstanceCustom(c, m, "pork", cons, nil, nil, nil, true)
+	s.checkStartInstanceCustom(c, m, "pork", cons, nil, nil, false, nil, true)
 }
 
 func (s *ProvisionerSuite) TestPossibleTools(c *gc.C) {
@@ -485,7 +492,7 @@ func (s *ProvisionerSuite) TestPossibleTools(c *gc.C) {
 	defer stop(c, provisioner)
 	s.checkStartInstanceCustom(
 		c, machine, "pork", constraints.Value{},
-		nil, nil, expectedList, true,
+		nil, nil, false, expectedList, true,
 	)
 }
 
@@ -616,7 +623,7 @@ func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedRetrya
 
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
-	s.checkStartInstance(c, m)
+	s.checkStartInstanceNoSecureConnection(c, m)
 }
 
 func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedWrappedRetryableCreationError(c *gc.C) {
@@ -638,7 +645,7 @@ func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedWrappe
 
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
-	s.checkStartInstance(c, m)
+	s.checkStartInstanceNoSecureConnection(c, m)
 }
 
 func (s *ProvisionerSuite) TestProvisionerFailStartInstanceWithInjectedNonRetryableCreationError(c *gc.C) {
@@ -685,7 +692,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForContainers(c *gc.C) {
 	// create a machine to host the container.
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
-	inst := s.checkStartInstance(c, m)
+	inst := s.checkStartInstanceNoSecureConnection(c, m)
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
@@ -732,7 +739,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithRequestedNetworks(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	inst := s.checkStartInstanceCustom(
 		c, m, "pork", cons,
-		requestedNetworks, expectNetworkInfo,
+		requestedNetworks, expectNetworkInfo, false,
 		nil, true,
 	)
 
@@ -769,7 +776,7 @@ func (s *ProvisionerSuite) TestSetInstanceInfoFailureSetsErrorStatusAndStopsInst
 	c.Assert(err, jc.ErrorIsNil)
 	inst := s.checkStartInstanceCustom(
 		c, m, "pork", constraints.Value{},
-		networks, expectNetworkInfo,
+		networks, expectNetworkInfo, false,
 		nil, false,
 	)
 
@@ -838,7 +845,7 @@ func (s *ProvisionerSuite) TestProvisioningOccursWithFixedEnvironment(c *gc.C) {
 	err = s.fixEnvironment(c)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.checkStartInstance(c, m)
+	s.checkStartInstanceNoSecureConnection(c, m)
 }
 
 func (s *ProvisionerSuite) TestProvisioningDoesOccurAfterInvalidEnvironmentPublished(c *gc.C) {
@@ -852,7 +859,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesOccurAfterInvalidEnvironmentPubli
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.checkStartInstance(c, m)
+	s.checkStartInstanceNoSecureConnection(c, m)
 
 	s.invalidateEnvironment(c)
 
@@ -861,7 +868,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesOccurAfterInvalidEnvironmentPubli
 	c.Assert(err, jc.ErrorIsNil)
 
 	// the PA should create it using the old environment
-	s.checkStartInstance(c, m)
+	s.checkStartInstanceNoSecureConnection(c, m)
 }
 
 func (s *ProvisionerSuite) TestProvisioningDoesNotProvisionTheSameMachineAfterRestart(c *gc.C) {
@@ -871,7 +878,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotProvisionTheSameMachineAfterRe
 	// create a machine
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
-	s.checkStartInstance(c, m)
+	s.checkStartInstanceNoSecureConnection(c, m)
 
 	// restart the PA
 	stop(c, p)
@@ -896,7 +903,7 @@ func (s *ProvisionerSuite) TestDyingMachines(c *gc.C) {
 	// provision a machine
 	m0, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
-	s.checkStartInstance(c, m0)
+	s.checkStartInstanceNoSecureConnection(c, m0)
 
 	// stop the provisioner and make the machine dying
 	stop(c, p)
@@ -931,7 +938,7 @@ func (s *ProvisionerSuite) TestProvisioningRecoversAfterInvalidEnvironmentPublis
 	// place a new machine into the state
 	m, err := s.addMachine()
 	c.Assert(err, jc.ErrorIsNil)
-	s.checkStartInstance(c, m)
+	s.checkStartInstanceNoSecureConnection(c, m)
 
 	s.invalidateEnvironment(c)
 	s.BackingState.StartSync()
@@ -941,7 +948,7 @@ func (s *ProvisionerSuite) TestProvisioningRecoversAfterInvalidEnvironmentPublis
 	c.Assert(err, jc.ErrorIsNil)
 
 	// the PA should create it using the old environment
-	s.checkStartInstance(c, m)
+	s.checkStartInstanceNoSecureConnection(c, m)
 
 	err = s.fixEnvironment(c)
 	c.Assert(err, jc.ErrorIsNil)
@@ -967,7 +974,7 @@ func (s *ProvisionerSuite) TestProvisioningRecoversAfterInvalidEnvironmentPublis
 	c.Assert(err, jc.ErrorIsNil)
 
 	// the PA should create it using the new environment
-	s.checkStartInstanceCustom(c, m, "beef", s.defaultConstraints, nil, nil, nil, true)
+	s.checkStartInstanceCustom(c, m, "beef", s.defaultConstraints, nil, nil, false, nil, true)
 }
 
 type mockMachineGetter struct{}
@@ -1062,6 +1069,7 @@ func (s *ProvisionerSuite) newProvisionerTask(
 		broker,
 		auth,
 		imagemetadata.ReleasedStream,
+		true,
 	)
 }
 


### PR DESCRIPTION
This branch contains2 fixes.
1. The processing of new state server certificates was incorrectly implemented. This fix uses a custom connection struct to ensure the certificate updates do do occur at the same time as the connection handshake, which is when the cert is used.
2. Upgraded systems are not able to regenerate the state server certificate since the CA cert private key is not recorded. Without the ability to regenerate certs, secure connections cannot be made. A value is added to the agent conf file to indicate whether secure connections are supported. Once we figure out how to do upgrades, this value can be removed. Newly bootstrapped systems will have this value set to true, whereas it will be false for upgraded systems.

(Review request: http://reviews.vapour.ws/r/669/)
