### PR TITLE
Added systemd support for managing services.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,6 +4,7 @@ code.google.com/p/go.crypto	hg	aa2644fe4aa50e3b38d75187b4799b1f0c9ddcef	212
 code.google.com/p/go.net	hg	c17ad62118ea511e1051721b429779fa40bddc74	116
 code.google.com/p/winsvc	hg	d6f79143ccd1138cc9d86c9fc75b1d6f8b1b95fb	10
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
+github.com/coreos/go-systemd	git	415a79c4bfa377b484b16c632347b3925a0f35ff	
 github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z

--- a/service/common/common.go
+++ b/service/common/common.go
@@ -1,25 +1,34 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package common
 
 // Conf is responsible for defining services. Its fields
 // represent elements of a service configuration.
 type Conf struct {
-	// Desc is the init service's description.
+	// Desc is the service's description.
 	Desc string
 	// Env holds the environment variables that will be set when the command runs.
-	// Currently not used on Windows
+	// Currently not used on Windows.
 	Env map[string]string
 	// Limit holds the ulimit values that will be set when the command runs.
-	// Currently not used on Windows
+	// Currently not used on Windows.
 	Limit map[string]string
 	// Cmd is the command (with arguments) that will be run.
 	// The command will be restarted if it exits with a non-zero exit code.
 	Cmd string
 	// Out, if set, will redirect output to that path.
+	// Currently unusable on systemd-based systems,
+	// use `# journalctl -unit=servicename` instead.
 	Out string
-	// InitDir is the folder in which the init script should be written
-	// defaults to "/etc/init" on Ubuntu
-	// Currently not used on Windows
+	// InitDir is the folder in which the upstart config/systemd service file
+	// should be written under.
+	// defaults to "/etc/init" on Ubuntu.
+	// defaults to "/etc/systemd/system" on systemd-based systems.
+	// Currently not used on Windows.
 	InitDir string
-	// ExtraScript allows to insert script before command execution
+	// ExtraScript allows the insertion of a script before command execution.
+	// Currently unused under Windows.
 	ExtraScript string
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,0 +1,15 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"github.com/juju/juju/service/systemd"
+	"github.com/juju/juju/service/upstart"
+	"github.com/juju/juju/service/windows"
+)
+
+var _ Service = (*systemd.Service)(nil)
+var _ Service = (*upstart.Service)(nil)
+var _ Service = (*windows.Service)(nil)

--- a/service/systemd/dbus-wrappers.go
+++ b/service/systemd/dbus-wrappers.go
@@ -1,0 +1,112 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-systemd/dbus"
+	"github.com/juju/errors"
+)
+
+// listUnits returns a list of UnitStatus structures of all loaded units
+func listUnits() ([]dbus.UnitStatus, error) {
+	conn, err := dbus.New()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	return conn.ListUnits()
+}
+
+// reloadDaemon signals systemd to reload all unit files.
+func reloadDaemon() error {
+	conn, err := dbus.New()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	return conn.Reload()
+}
+
+// enableUnit issues the command to enable the given unit.
+// it may take an absolute path to the unit file if it lies outside of
+// systemd's search path.
+func enableUnit(name string) error {
+	conn, err := dbus.New()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, _, err = conn.EnableUnitFiles([]string{name}, false, true)
+
+	return err
+}
+
+// disableUnit issues the command to disable the specified unit.
+// it may take an absolute path to the unit file if it lies outside of
+// systemd's search path.
+func disableUnit(name string) error {
+	conn, err := dbus.New()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.DisableUnitFiles([]string{name}, false)
+
+	return err
+}
+
+// startUnit asks systemd to start the unit identified by the given name
+func startUnit(name string) error {
+	conn, err := dbus.New()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ch := make(chan string)
+
+	_, err = conn.StartUnit(name, "fail", ch)
+	if err != nil {
+		return err
+	}
+
+	// wait for the unit to start
+	status := <-ch
+	if status != "done" {
+		return errors.New(fmt.Sprintf("unit %s has failed to start", name))
+	}
+
+	return nil
+}
+
+// stopUnit asks systemd to stop the unit identified by the given name
+func stopUnit(name string) error {
+	conn, err := dbus.New()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ch := make(chan string)
+
+	_, err = conn.StopUnit(name, "fail", ch)
+	if err != nil {
+		return err
+	}
+
+	// wait for the unit to stop
+	status := <-ch
+	if status != "done" {
+		return errors.New(fmt.Sprintf("unit %s has failed to stop", name))
+	}
+
+	return nil
+}

--- a/service/systemd/export_test.go
+++ b/service/systemd/export_test.go
@@ -1,0 +1,43 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+var RunCommand = &runCommand
+var List = &list
+var Reload = &reload
+var Enable = &enable
+var Disable = &disable
+var Start = &start
+var Stop = &stop
+
+var ExtraScriptTemplate = extraScriptTemplate
+
+func (s *Service) ServiceName() string {
+	return s.serviceName()
+}
+
+func (s *Service) ServiceFilePath() string {
+	return s.serviceFilePath()
+}
+
+func (s *Service) ExtraScriptPath() string {
+	return s.extraScriptPath()
+}
+
+func (s *Service) Validate() error {
+	return s.validate()
+}
+
+func (s *Service) Render() ([]byte, error) {
+	return s.render()
+}
+
+func (s *Service) ExistsAndMatches() (bool, bool, error) {
+	return s.existsAndMatches()
+}
+
+func (s *Service) Enabled() bool {
+	return s.enabled()
+}

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -1,0 +1,32 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/service/common"
+)
+
+// MachineAgentSystemdService returns a systemd service conf for a machine
+// agent based on the tag and machineID passed to it.
+func MachineAgentSystemdService(name, toolsDir, dataDir, tag, machineID string, env map[string]string) *Service {
+	// The machine agent will always start with DEBUG on; the logging level
+	// being meant to updated by the logger worker as soon as it turns on.
+	conf := common.Conf{
+		Desc: fmt.Sprintf("juju %s agent", tag),
+		Cmd: path.Join(toolsDir, "jujud") +
+			" machine " +
+			" --data-dir " + utils.ShQuote(dataDir) +
+			" --machine-id " + machineID +
+			" --debug",
+		Env: env,
+	}
+
+	return NewService(name, conf)
+}

--- a/service/systemd/systemd.go
+++ b/service/systemd/systemd.go
@@ -1,0 +1,378 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"text/template"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/service/common"
+)
+
+// This regexp will match the common output of a running service's
+// `systemctl status unit.service` output.
+var runningRegexp = regexp.MustCompile(`.*Active: active \(running\).*`)
+
+// This regexp will match the common output of an enabled service's
+// `systemctl status unit.service` output.
+var enabledRegexp = regexp.MustCompile(`.*enabled.*`)
+
+// The systemd service file directory with the uppermost priority.
+var InitDir = "/etc/systemd/system"
+
+// Service is the structure which provides a handle on a systemd service.
+type Service struct {
+	Name string
+	Conf common.Conf
+}
+
+// New service returns a new *systemd.Service with the associated name and
+// initial Conf. If no InitDir is provided, it defaults to InitDir.
+func NewService(name string, conf common.Conf) *Service {
+	if conf.InitDir == "" {
+		conf.InitDir = InitDir
+	}
+
+	return &Service{Name: name, Conf: conf}
+}
+
+// UpdateConfig allows for the resetting of the Conf associated to s.
+func (s *Service) UpdateConfig(conf common.Conf) {
+	s.Conf = conf
+}
+
+// serviceName simply returns the fully qualified name of the service.
+func (s *Service) serviceName() string {
+	return s.Name + ".service"
+}
+
+// serviceFilePath returns the full path to the service file associated with s.
+func (s *Service) serviceFilePath() string {
+	return path.Join(s.Conf.InitDir, s.serviceName())
+}
+
+// extraScriptPath returns the full path to the file containing the ExtraScript
+// of the service if it was provided in the service's Conf.
+func (s *Service) extraScriptPath() string {
+	return path.Join(s.Conf.InitDir, fmt.Sprintf("%s-extra.sh", s.Name))
+}
+
+// validate returns an error if the Service is not properly defined.
+func (s *Service) validate() error {
+	if s.Name == "" {
+		return errors.New("missing Name")
+	}
+	if s.Conf.InitDir == "" {
+		return errors.New("missing InitDir")
+	}
+	if s.Conf.Desc == "" {
+		return errors.New("missing Desc")
+	}
+	if s.Conf.Cmd == "" {
+		return errors.New("missing Cmd")
+	}
+	return nil
+}
+
+// render returns the systemd service file in slice of bytes form.
+func (s *Service) render() ([]byte, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := serviceTemplate.Execute(&buf, s.Conf); err != nil {
+		return nil, err
+	}
+
+	res := buf.String()
+
+	// check for ExtraScript and apply its path (if applicable)
+	if s.Conf.ExtraScript != "" {
+		res = fmt.Sprintf(res, s.extraScriptPath())
+	}
+
+	return []byte(res), nil
+
+}
+
+// fileExistsAndMatches is a helper function which determines wether the file
+// pointed to by path exists and if it matches the expected contents.
+func fileExistsAndMatches(path string, expected []byte) (exists, matches bool, _ error) {
+	var err error
+	var found []byte
+
+	if found, err = ioutil.ReadFile(path); err != nil {
+		var reterr error
+		if os.IsNotExist(err) {
+			reterr = nil
+		} else {
+			reterr = err
+		}
+
+		return false, false, reterr
+	}
+
+	return true, bytes.Equal(found, expected), nil
+}
+
+// existsAndMatches is a helper function which determines whether a service file
+// with the same name exists and whether it has the same contents.
+// if applicable, it will also check for and compare the ExtraScript file.
+func (s *Service) existsAndMatches() (exists, matches bool, _ error) {
+	var err error
+	var expected []byte
+	var confExists, confMatches bool
+
+	if expected, err = s.render(); err != nil {
+		return false, false, errors.Trace(err)
+	}
+
+	// check for service file
+	confExists, confMatches, err = fileExistsAndMatches(s.serviceFilePath(), expected)
+	if err != nil {
+		return false, false, errors.Trace(err)
+	}
+
+	// check for ExtraScript file
+	if s.Conf.ExtraScript != "" {
+		expected = []byte(fmt.Sprintf(extraScriptTemplate, s.Conf.ExtraScript))
+		scriptExists, scriptMatches, err := fileExistsAndMatches(s.extraScriptPath(), expected)
+		if err != nil {
+			return false, false, errors.Trace(err)
+		}
+
+		return confExists && scriptExists, confMatches && scriptMatches, nil
+	}
+
+	return confExists, confMatches, nil
+}
+
+// runCommand is simply a variable for utils.RunCommand which was aliased for
+// testing purposes
+var runCommand = utils.RunCommand
+
+// below lie some variables represing the go-systemd/dbus wrapper functions
+// they were aliased for testing purposes
+var list = listUnits
+var reload = reloadDaemon
+var enable = enableUnit
+var disable = disableUnit
+var start = startUnit
+var stop = stopUnit
+
+// enabled returns true if the service has been enabled in systemd.
+// TODO (aznashwan): find a cleaner way to find the status of a unit
+func (s *Service) enabled() bool {
+	out, _ := runCommand("systemctl", "status", s.serviceName())
+
+	return enabledRegexp.MatchString(out)
+}
+
+// Install properly places the service file of s in the InitDir, writes the
+// ExtraScript file (if applicable) and starts the service through systemd.
+// NOTE: a service will be enabled by default for it to count as installed.
+// NOTE: the unit file daemon is automatically reloaded, making overriding an
+// existing services possible by creating a new systemd.Service instance and
+// Install()-ing it.
+func (s *Service) Install() error {
+	// check if the service is already installed
+	exists, matches, err := s.existsAndMatches()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if matches && s.enabled() {
+		return nil
+	}
+	if exists {
+		if err := s.StopAndRemove(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// write the service file to the InitDir
+	contents, err := s.render()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := ioutil.WriteFile(s.serviceFilePath(), contents, 0644); err != nil {
+		return errors.Trace(err)
+	}
+
+	// write the ExtraScript file (if applicable)
+	if s.Conf.ExtraScript != "" {
+		contents := fmt.Sprintf(extraScriptTemplate, s.Conf.ExtraScript)
+
+		if err := ioutil.WriteFile(s.extraScriptPath(), []byte(contents), 0755); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// tell systemd to reload all unit files
+	if err := reload(); err != nil {
+		return errors.Trace(err)
+	}
+
+	// enable our service
+	if err := enable(s.serviceFilePath()); err != nil {
+		return errors.Trace(err)
+	}
+
+	// start the service to finish off the install
+	return s.Start()
+}
+
+// Installed returns true if a service file was correctly set in the InitDir
+// and was properly enabled.
+func (s *Service) Installed() bool {
+	exists, _, err := s.existsAndMatches()
+	if err != nil {
+		return false
+	}
+
+	return exists && s.enabled()
+}
+
+// Exists returns a boolean representing whether or not the exact service file
+// which s would render to already exists and if it has been enabled.
+func (s *Service) Exists() bool {
+	_, matches, err := s.existsAndMatches()
+	if err != nil {
+		return false
+	}
+
+	return matches && s.enabled()
+}
+
+// Running returns a boolean of whether or not the service is actively running.
+func (s *Service) Running() bool {
+	// get all units currently present on the system
+	units, err := list()
+	if err != nil {
+		return false
+	}
+
+	// iterate over all the units in search of one with the same
+	// name as ours and check if it's running or not
+	for _, unit := range units {
+		if unit.Name == s.serviceName() {
+			if unit.ActiveState == "active" {
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+
+	return false
+}
+
+// Start issues the command to systemd to immediately start the service.
+func (s *Service) Start() error {
+	if err := start(s.serviceName()); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// Stop issues the command to systemd to immediately stop the service.
+func (s *Service) Stop() error {
+	if err := stop(s.serviceName()); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// Remove disables the service and deletes the existing service file associated
+// to s together with the ExtraScript file (if applicable).
+func (s *Service) Remove() error {
+	if err := disable(s.serviceFilePath()); err != nil {
+		return errors.Trace(err)
+	}
+
+	// remove all files associated with the service
+	os.Remove(s.serviceFilePath())
+
+	if s.Conf.ExtraScript != "" {
+		os.Remove(s.extraScriptPath())
+	}
+
+	// reload all unit files
+	if err := reload(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// StopAndRemove stops the service and removes the service file together with
+// the ExtraScript file (if applicable) from the InitDir.
+func (s *Service) StopAndRemove() error {
+	if err := s.Stop(); err != nil {
+		return err
+	}
+
+	return s.Remove()
+}
+
+// InstallCommands returns the shell commands to install the service file,
+// write the ExtraScript file (if applicable) and enable and run the service.
+func (s *Service) InstallCommands() (cmds []string, _ error) {
+	contents, err := s.render()
+	if err != nil {
+		return nil, err
+	}
+
+	if s.Conf.ExtraScript != "" {
+		extraScript := fmt.Sprintf(extraScriptTemplate, s.Conf.ExtraScript)
+		cmds = append(cmds, fmt.Sprintf("cat >> %s << 'EOF'\n%s\nEOF\n",
+			s.extraScriptPath(), extraScript))
+	}
+
+	cmds = append(cmds, []string{
+		fmt.Sprintf("cat >> %s << 'EOF'\n%s\nEOF\n", s.serviceFilePath(), contents),
+		"systemctl daemon-reload",
+		"systemctl enable " + s.Name,
+		"systemctl start " + s.Name,
+	}...)
+
+	return cmds, nil
+}
+
+var serviceTemplate = template.Must(template.New("").Parse(`
+[Unit]
+Description={{.Desc}}
+After=syslog.target
+After=network.target
+After=systemd-user-sessions.service
+
+[Service]
+Type=forking
+{{range $k, $v := .Env}}Environment={{$k}}={{$v}}
+{{end}}
+{{if .ExtraScript}}ExecStartPre=%s{{end}}
+ExecStart={{.Cmd}}
+RemainAfterExit=yes
+Restart=always
+TimeoutSec=300
+
+[Install]
+WantedBy=default.target
+`[1:]))
+
+var extraScriptTemplate = `
+#!/bin/sh
+
+%s
+`[1:]

--- a/service/systemd/systemd_test.go
+++ b/service/systemd/systemd_test.go
@@ -1,0 +1,396 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/coreos/go-systemd/dbus"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/service/common"
+	"github.com/juju/juju/service/systemd"
+	coretesting "github.com/juju/juju/testing"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type SystemdSuite struct {
+	coretesting.BaseSuite
+	service *systemd.Service
+	initDir string
+}
+
+var _ = gc.Suite(&SystemdSuite{})
+
+func (s *SystemdSuite) SetUpTest(c *gc.C) {
+	s.initDir = c.MkDir()
+	s.PatchValue(&systemd.InitDir, s.initDir)
+
+	env := make(map[string]string)
+	env["DIR"] = "dir"
+	env["VAR"] = "val"
+	s.service = systemd.NewService(
+		"dummy-service",
+		common.Conf{
+			Desc:        "dummy service for testing",
+			Cmd:         "some-command --execute",
+			Env:         env,
+			ExtraScript: "some -t extra --script",
+		},
+	)
+}
+
+// TestInitDirDefaulting tests wether the InitDir of a new service is properly
+// set to its default value if it is not directly provided.
+func (s *SystemdSuite) TestInitDirDefaulting(c *gc.C) {
+	service := systemd.NewService("service", common.Conf{})
+	c.Assert(service.Conf.InitDir, gc.Equals, s.initDir)
+}
+
+// TestServiceFilePath tests that servicePath() properly returns the full path of
+// the service file associated to a service.
+func (s *SystemdSuite) TestServiceFilePath(c *gc.C) {
+	c.Assert(s.service.ServiceFilePath(), gc.Equals, path.Join(s.initDir, "dummy-service.service"))
+}
+
+// TestExtraScriptPath tests that extraScriptPath() properly returns the full
+// path of the extra script file associated to a service.
+func (s *SystemdSuite) TestExtraScriptPath(c *gc.C) {
+	c.Assert(s.service.ExtraScriptPath(), gc.Equals, path.Join(s.initDir, "dummy-service-extra.sh"))
+}
+
+// buildDummyRunCommand returns a function with an identical signature to
+// systemd.RunCommand that returns the strings given by args and a nil error.
+// the returned function remembers the commands it recieved in *issuedcmds.
+func (s *SystemdSuite) buildDummyRunCommand(issuedcmds *[]string, args ...string) func(string, ...string) (string, error) {
+	*issuedcmds = []string{}
+	return func(cmd string, cmdargs ...string) (string, error) {
+		*issuedcmds = append(*issuedcmds, fmt.Sprintf("%s %s", cmd, strings.Join(cmdargs, " ")))
+		return strings.Join(args, "\n"), nil
+	}
+}
+
+// buildDummyListUnits returns a function with an identical signature to
+// listUnits() that returns a list dbus.UnitStatus structs which (depending on
+// the value of the parameter given) will return a list with our services
+// in/not in it, and a nil error.
+func (s *SystemdSuite) buildDummyListUnits(good bool) func() ([]dbus.UnitStatus, error) {
+	if good {
+		return func() ([]dbus.UnitStatus, error) {
+			return []dbus.UnitStatus{
+				dbus.UnitStatus{
+					Name:        s.service.ServiceName(),
+					ActiveState: "active",
+				},
+			}, nil
+		}
+	}
+
+	return func() ([]dbus.UnitStatus, error) {
+		return []dbus.UnitStatus{}, nil
+	}
+}
+
+// dummyReloadDaemon is a simple function which always returns a nil error.
+func dummyReloadDaemon() error {
+	return nil
+}
+
+// dummyFunctionProto is a simple function which takes the address of a boolean
+// and returns a function which takes a string and will set that boolean to true
+// if called and a nil error.
+func dummyFunctionProto(boolean *bool) func(string) error {
+	return func(string) error {
+		*boolean = true
+		return nil
+	}
+}
+
+// writeValidServiceFile writes a proper service file to the InitDir.
+func (s *SystemdSuite) writeValidServiceFile(c *gc.C) {
+	contents, err := s.service.Render()
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(s.service.ServiceFilePath(), contents, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// writeInvalidServiceFile writes an unrelated service file to the InitDir.
+func (s *SystemdSuite) writeInvalidServiceFile(c *gc.C) {
+	err := ioutil.WriteFile(s.service.ServiceFilePath(), []byte("nothing relevant"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// writeValidScriptFile writes a proper ExtraScript file to the InitDir.
+func (s *SystemdSuite) writeValidScriptFile(c *gc.C) {
+	contents := fmt.Sprintf(systemd.ExtraScriptTemplate, s.service.Conf.ExtraScript)
+	err := ioutil.WriteFile(s.service.ExtraScriptPath(), []byte(contents), 0755)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// writeInvalidScriptFile writes an unrelated ExtraScript file to the InitDir.
+func (s *SystemdSuite) writeInvalidScriptFile(c *gc.C) {
+	err := ioutil.WriteFile(s.service.ExtraScriptPath(), []byte("nothing relevant"), 0755)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// serviceStatusCommand returns a slice of strings with a single element
+// representing the systemctl command of statting the service represented by s.
+func (s *SystemdSuite) serviceStatusCommand() []string {
+	return []string{"systemctl status " + s.service.ServiceName()}
+}
+
+// TestExistsAndMatches tests existsAndMatches under various circumstances.
+func (s *SystemdSuite) TestExistsAndMatches(c *gc.C) {
+	// non-existent service file or ExtraScript file
+	exists, matches, err := s.service.ExistsAndMatches()
+	c.Assert(exists, jc.IsFalse)
+	c.Assert(matches, jc.IsFalse)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// properly installed service file and ExtraScript file with different content
+	s.writeInvalidServiceFile(c)
+	s.writeInvalidScriptFile(c)
+	exists, matches, err = s.service.ExistsAndMatches()
+	c.Assert(exists, jc.IsTrue)
+	c.Assert(matches, jc.IsFalse)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// properly installed matching service file with mismatching ExtraScript file
+	s.writeValidServiceFile(c)
+	s.writeInvalidServiceFile(c)
+	exists, matches, err = s.service.ExistsAndMatches()
+	c.Assert(exists, jc.IsTrue)
+	c.Assert(matches, jc.IsFalse)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// mismatching service file with matching ExtraScript file
+	s.writeInvalidServiceFile(c)
+	s.writeValidScriptFile(c)
+	exists, matches, err = s.service.ExistsAndMatches()
+	c.Assert(exists, jc.IsTrue)
+	c.Assert(matches, jc.IsFalse)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// properly installed service file with suitable content
+	s.writeValidServiceFile(c)
+	exists, matches, err = s.service.ExistsAndMatches()
+	c.Assert(exists, jc.IsTrue)
+	c.Assert(matches, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TestEnabled tests wether enabled properly recognises the status of the service.
+func (s *SystemdSuite) TestEnabled(c *gc.C) {
+	var issuedcmds []string
+
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "nothing about its status"))
+	c.Assert(s.service.Enabled(), jc.IsFalse)
+	c.Assert(issuedcmds, gc.DeepEquals, s.serviceStatusCommand())
+
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "the service is enabled"))
+	c.Assert(s.service.Enabled(), jc.IsTrue)
+	c.Assert(issuedcmds, gc.DeepEquals, s.serviceStatusCommand())
+}
+
+// TestInstallFromScratch tests a completely fresh installation of the service
+// using Install.
+func (s *SystemdSuite) TestInstallFromScratch(c *gc.C) {
+	var issuedcmds []string
+	var enableCalled, startCalled bool
+
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "the service is enabled"))
+	s.PatchValue(systemd.Reload, dummyReloadDaemon)
+	s.PatchValue(systemd.Enable, dummyFunctionProto(&enableCalled))
+	s.PatchValue(systemd.Start, dummyFunctionProto(&startCalled))
+
+	c.Assert(s.service.Install(), jc.ErrorIsNil)
+
+	// check that enabled() did not get a chance to get called
+	c.Assert(issuedcmds, gc.DeepEquals, []string{})
+
+	// check that enable() and start() were called
+	c.Assert(enableCalled, jc.IsTrue)
+	c.Assert(startCalled, jc.IsTrue)
+
+	// check service file contents
+	found, err := ioutil.ReadFile(s.service.ServiceFilePath())
+	c.Assert(err, jc.ErrorIsNil)
+	expected, err := s.service.Render()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found, gc.DeepEquals, expected)
+
+	// check ExtraScript file contents
+	found, err = ioutil.ReadFile(s.service.ExtraScriptPath())
+	c.Assert(err, jc.ErrorIsNil)
+	expected = []byte(fmt.Sprintf(systemd.ExtraScriptTemplate, s.service.Conf.ExtraScript))
+	c.Assert(found, gc.DeepEquals, expected)
+}
+
+// TestInstallDefaultsIfAlreadyInstalled tests wether Install promptly returns
+// if the service is already installed and enabled.
+func (s *SystemdSuite) TestInstallDefaultsIfAlreadyInstalled(c *gc.C) {
+	var issuedcmds []string
+	var enableCalled, startCalled bool
+
+	s.writeValidScriptFile(c)
+	s.writeValidServiceFile(c)
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "the service is enabled"))
+	s.PatchValue(systemd.Reload, dummyReloadDaemon)
+	s.PatchValue(systemd.Enable, dummyFunctionProto(&enableCalled))
+	s.PatchValue(systemd.Start, dummyFunctionProto(&startCalled))
+
+	c.Assert(s.service.Install(), jc.ErrorIsNil)
+
+	// check that enabled() was called
+	c.Assert(issuedcmds, gc.DeepEquals, s.serviceStatusCommand())
+
+	// check that enable() and start() were not called
+	c.Assert(enableCalled, jc.IsFalse)
+	c.Assert(startCalled, jc.IsFalse)
+}
+
+// TestInstalled tests Installed's behavior under any set of parameters.
+func (s *SystemdSuite) TestInstalled(c *gc.C) {
+	var issuedcmds []string
+
+	// non-existent service or ExtraScript files
+	c.Assert(s.service.Installed(), jc.IsFalse)
+
+	// existing service and ExtraScript files but disabled service
+	s.writeValidScriptFile(c)
+	s.writeValidServiceFile(c)
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "nothing about its status"))
+
+	c.Assert(s.service.Installed(), jc.IsFalse)
+	c.Assert(issuedcmds, gc.DeepEquals, s.serviceStatusCommand())
+
+	// properly installed and service and ExtraScript files, service enabled
+	s.writeValidScriptFile(c)
+	s.writeValidServiceFile(c)
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "the service is enabled"))
+
+	c.Assert(s.service.Installed(), jc.IsTrue)
+	c.Assert(issuedcmds, gc.DeepEquals, s.serviceStatusCommand())
+}
+
+// TestExists tests Exists'behavior under any possible set of parameters.
+func (s *SystemdSuite) TestExists(c *gc.C) {
+	var issuedcmds []string
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "totally not enabled"))
+
+	// non-existent service or ExtraScript files, service disabled
+	c.Assert(s.service.Exists(), jc.IsFalse)
+
+	// existing service and ExtraScript files with improper contents,
+	// service still disabled
+	s.writeInvalidScriptFile(c)
+	s.writeInvalidServiceFile(c)
+	c.Assert(s.service.Exists(), jc.IsFalse)
+
+	// existing service and ExtraScript files with improper contents,
+	// service now enabled
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "the service is enabled"))
+	c.Assert(s.service.Exists(), jc.IsFalse)
+
+	// proper service and ExtraScript files, service disabled
+	s.writeValidScriptFile(c)
+	s.writeValidServiceFile(c)
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "nothing about its status"))
+	c.Assert(s.service.Exists(), jc.IsFalse)
+
+	// proper service and ExtraScript files, service enabled
+	s.PatchValue(systemd.RunCommand, s.buildDummyRunCommand(&issuedcmds, "the service is enabled"))
+	c.Assert(s.service.Exists(), jc.IsTrue)
+}
+
+// TestRunning tests Running under both possible scenarios.
+func (s *SystemdSuite) TestRunning(c *gc.C) {
+	// service not appearing to be running
+	s.PatchValue(systemd.List, s.buildDummyListUnits(false))
+
+	c.Assert(s.service.Running(), jc.IsFalse)
+
+	// `systemctl status` saying service is running
+	s.PatchValue(systemd.List, s.buildDummyListUnits(true))
+
+	c.Assert(s.service.Running(), jc.IsTrue)
+}
+
+// TestStart tests that Start properly issues the commands to start the service.
+func (s *SystemdSuite) TestStart(c *gc.C) {
+	var startCalled bool
+
+	s.PatchValue(systemd.Start, dummyFunctionProto(&startCalled))
+
+	c.Assert(s.service.Start(), jc.ErrorIsNil)
+}
+
+// TestStop tests that Stop properly issues the command to stop the service.
+func (s *SystemdSuite) TestStop(c *gc.C) {
+	var stopCalled bool
+
+	s.PatchValue(systemd.Stop, dummyFunctionProto(&stopCalled))
+
+	c.Assert(s.service.Stop(), jc.ErrorIsNil)
+	c.Assert(stopCalled, jc.IsTrue)
+}
+
+// TestRemove tests if Remove properly cleans up an installed service.
+func (s *SystemdSuite) TestRemove(c *gc.C) {
+	var disableCalled bool
+
+	s.writeValidScriptFile(c)
+	s.writeValidServiceFile(c)
+
+	s.PatchValue(systemd.Disable, dummyFunctionProto(&disableCalled))
+	s.PatchValue(systemd.Reload, dummyReloadDaemon)
+
+	c.Assert(s.service.Remove(), jc.ErrorIsNil)
+
+	// check that service file was removed
+	_, err := os.Stat(s.service.ServiceFilePath())
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+
+	// check that ExtraScript file was removed
+	_, err = os.Stat(s.service.ExtraScriptPath())
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+
+	// check that the command for disabling the process was properly issued
+	c.Assert(disableCalled, jc.IsTrue)
+}
+
+// TestStopAndRemove tests StopAndRemove on a properly installed service.
+func (s *SystemdSuite) TestStopAndRemove(c *gc.C) {
+	var stopCalled, disableCalled bool
+
+	s.writeValidScriptFile(c)
+	s.writeValidServiceFile(c)
+	s.PatchValue(systemd.Stop, dummyFunctionProto(&stopCalled))
+	s.PatchValue(systemd.Disable, dummyFunctionProto(&disableCalled))
+	s.PatchValue(systemd.Reload, dummyReloadDaemon)
+
+	c.Assert(s.service.StopAndRemove(), jc.ErrorIsNil)
+
+	// check that the service file was removed
+	_, err := os.Stat(s.service.ServiceFilePath())
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+
+	// check that the ExtraScript file was removed
+	_, err = os.Stat(s.service.ExtraScriptPath())
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+
+	// check that the stopping and disabling commands were properly issued
+	c.Assert(stopCalled, jc.IsTrue)
+	c.Assert(disableCalled, jc.IsTrue)
+}


### PR DESCRIPTION
NOTES:
*  in order to mimic the behaviour of upstart services, systemd services **must be enabled** in order to be considered "installed".
*  as of this PR, manipulating systemd services requires root privileges (as systemd was indended to be used all along, and as upstart also is). I have [another branch](https://github.com/aznashwan/juju/tree/systemd-user) where I have already made the couple of adaptations required to use this in user mode should we so wish it; however, as of now, the version of dbus currently available in CentOS 7 has a bug in which it fails to set an environment variable that systemd relies on during operations in user mode...

Am looking forward to hearing what you guys think about the system vs. user mode topic and am open to any suggestions in that regard.
Until then, happy holidays and see you all in 2015 :smile: 

(Review request: http://reviews.vapour.ws/r/671/)