### PR TITLE
Use prefix search for ActionTag in action fetch command

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action

--- a/cmd/juju/action/common_test.go
+++ b/cmd/juju/action/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // This is necessary since it must test a recursive unexported function,

--- a/cmd/juju/action/common_test.go
+++ b/cmd/juju/action/common_test.go
@@ -5,7 +5,9 @@
 // i.e., the function cannot be exported via a var
 package action
 
-import gc "gopkg.in/check.v1"
+import (
+	gc "gopkg.in/check.v1"
+)
 
 type CommonSuite struct{}
 

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -17,10 +17,6 @@ func (c *DefinedCommand) FullSchema() bool {
 	return c.fullSchema
 }
 
-func (c *FetchCommand) ActionTag() names.ActionTag {
-	return c.actionTag
-}
-
 func (c *DoCommand) UnitTag() names.UnitTag {
 	return c.unitTag
 }

--- a/cmd/juju/action/fetch.go
+++ b/cmd/juju/action/fetch.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 Canonical Ltd.
+// Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action

--- a/cmd/juju/action/fetch_test.go
+++ b/cmd/juju/action/fetch_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 Canonical Ltd.
+// Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action_test

--- a/cmd/juju/action/fetch_test.go
+++ b/cmd/juju/action/fetch_test.go
@@ -62,7 +62,7 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 func (s *FetchSuite) TestRun(c *gc.C) {
 	tests := []struct {
 		should         string
-		withTags       map[string][]params.Entity
+		withTags       params.FindTagsResults
 		withResults    []params.ActionResult
 		withAPIError   string
 		expectedErr    string
@@ -73,24 +73,24 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 		expectedErr:  "api call error",
 	}, {
 		should:      "fail with no results",
-		withTags:    tagsForId(validActionId),
+		withTags:    tagsForIdPrefix(validActionId),
 		withResults: []params.ActionResult{},
 		expectedErr: `actions for identifier "` + validActionId + `" not found`,
 	}, {
 		should:      "error correctly with multiple results",
-		withTags:    tagsForId(validActionId, validActionTagString),
+		withTags:    tagsForIdPrefix(validActionId, validActionTagString),
 		withResults: []params.ActionResult{{}, {}},
 		expectedErr: "too many results for action " + validActionId,
 	}, {
 		should:   "pass through an error from the API server",
-		withTags: tagsForId(validActionId, validActionTagString),
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
 		withResults: []params.ActionResult{{
 			Error: common.ServerError(errors.New("an apiserver error")),
 		}},
 		expectedErr: "an apiserver error",
 	}, {
 		should:   "pretty-print action output",
-		withTags: tagsForId(validActionId, validActionTagString),
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
 		withResults: []params.ActionResult{{
 			Status:  "complete",
 			Message: "oh dear",

--- a/cmd/juju/action/fetch_test.go
+++ b/cmd/juju/action/fetch_test.go
@@ -43,14 +43,6 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 		args:        []string{},
 		expectError: "no action UUID specified",
 	}, {
-		should:      "fail properly with a bad ID",
-		args:        []string{invalidActionId},
-		expectError: "invalid action ID \"" + invalidActionId + "\"",
-	}, {
-		should:    "init properly with single arg",
-		args:      []string{validActionId},
-		expectTag: names.NewActionTag(validActionId),
-	}, {
 		should:      "fail with multiple args",
 		args:        []string{"12345", "54321"},
 		expectError: `unrecognized args: \["54321"\]`,
@@ -61,9 +53,7 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 		c.Logf("test %d: it should %s: juju actions fetch %s", i,
 			t.should, strings.Join(t.args, " "))
 		err := testing.InitCommand(s.subcommand, t.args)
-		if t.expectError == "" {
-			c.Check(s.subcommand.ActionTag(), gc.Equals, t.expectTag)
-		} else {
+		if t.expectError != "" {
 			c.Check(err, gc.ErrorMatches, t.expectError)
 		}
 	}
@@ -72,6 +62,7 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 func (s *FetchSuite) TestRun(c *gc.C) {
 	tests := []struct {
 		should         string
+		withTags       map[string][]params.Entity
 		withResults    []params.ActionResult
 		withAPIError   string
 		expectedErr    string
@@ -81,21 +72,25 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 		withAPIError: "api call error",
 		expectedErr:  "api call error",
 	}, {
-		should:         "fail gracefully with no results",
-		withResults:    []params.ActionResult{},
-		expectedOutput: "No results for action " + validActionId + "\n",
+		should:      "fail with no results",
+		withTags:    tagsForId(validActionId),
+		withResults: []params.ActionResult{},
+		expectedErr: `actions for identifier "` + validActionId + `" not found`,
 	}, {
 		should:      "error correctly with multiple results",
+		withTags:    tagsForId(validActionId, validActionTagString),
 		withResults: []params.ActionResult{{}, {}},
 		expectedErr: "too many results for action " + validActionId,
 	}, {
-		should: "pass through an error from the API server",
+		should:   "pass through an error from the API server",
+		withTags: tagsForId(validActionId, validActionTagString),
 		withResults: []params.ActionResult{{
 			Error: common.ServerError(errors.New("an apiserver error")),
 		}},
 		expectedErr: "an apiserver error",
 	}, {
-		should: "pretty-print action output",
+		should:   "pretty-print action output",
+		withTags: tagsForId(validActionId, validActionTagString),
 		withResults: []params.ActionResult{{
 			Status:  "complete",
 			Message: "oh dear",
@@ -114,17 +109,18 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 
 	for i, t := range tests {
 		func() { // for the defer of restoring patch function
-			s.subcommand = &action.FetchCommand{}
-			c.Logf("test %d: it should %s", i, t.should)
 			client := &fakeAPIClient{
-				actionResults: t.withResults,
+				actionTagMatches: t.withTags,
+				actionResults:    t.withResults,
 			}
 			if t.withAPIError != "" {
 				client.apiErr = errors.New(t.withAPIError)
 			}
-			restore := s.BaseActionSuite.patchAPIClient(client)
-			defer restore()
-			//args := fmt.Sprintf("%s %s", s.subcommand.Info().Name, "some-action-id")
+			defer s.BaseActionSuite.patchAPIClient(client)()
+
+			s.subcommand = &action.FetchCommand{}
+			c.Logf("test %d: it should %s", i, t.should)
+
 			ctx, err := testing.RunCommand(c, s.subcommand, validActionId)
 			if t.expectedErr != "" || t.withAPIError != "" {
 				c.Check(err, gc.ErrorMatches, t.expectedErr)

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -102,6 +102,14 @@ var someCharmActions = &charm.Actions{
 	},
 }
 
+func tagsForId(prefix string, tags ...string) map[string][]params.Entity {
+	var entities []params.Entity
+	for _, t := range tags {
+		entities = append(entities, params.Entity{Tag: t})
+	}
+	return map[string][]params.Entity{prefix: entities}
+}
+
 type fakeAPIClient struct {
 	actionResults      []params.ActionResult
 	actionsByReceivers []params.ActionsByReceiver

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action_test

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -102,18 +102,21 @@ var someCharmActions = &charm.Actions{
 	},
 }
 
-func tagsForId(prefix string, tags ...string) map[string][]params.Entity {
+// tagsForIdPrefix builds a params.FindTagResults for a given id prefix
+// and 0..n given tags. This is useful for stubbing out the API and
+// ensuring that the API returns expected tags for a given id prefix.
+func tagsForIdPrefix(prefix string, tags ...string) params.FindTagsResults {
 	var entities []params.Entity
 	for _, t := range tags {
 		entities = append(entities, params.Entity{Tag: t})
 	}
-	return map[string][]params.Entity{prefix: entities}
+	return params.FindTagsResults{Matches: map[string][]params.Entity{prefix: entities}}
 }
 
 type fakeAPIClient struct {
 	actionResults      []params.ActionResult
 	actionsByReceivers []params.ActionsByReceiver
-	actionTagMatches   map[string][]params.Entity
+	actionTagMatches   params.FindTagsResults
 	charmActions       *charm.Actions
 	apiErr             error
 }
@@ -165,7 +168,5 @@ func (c *fakeAPIClient) Actions(args params.Entities) (params.ActionResults, err
 }
 
 func (c *fakeAPIClient) FindActionTagsByPrefix(arg params.FindTags) (params.FindTagsResults, error) {
-	return params.FindTagsResults{
-		Matches: c.actionTagMatches,
-	}, c.apiErr
+	return c.actionTagMatches, c.apiErr
 }

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 Canonical Ltd.
+// Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -6,15 +6,16 @@ package action
 import (
 	"github.com/juju/cmd"
 	errors "github.com/juju/errors"
-	"github.com/juju/juju/apiserver/params"
 	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
 )
 
 // StatusCommand shows the status of an Action by ID.
 type StatusCommand struct {
 	ActionCommandBase
-	requestedId string
 	out         cmd.Output
+	requestedId string
 }
 
 const statusDoc = `
@@ -56,26 +57,10 @@ func (c *StatusCommand) Run(ctx *cmd.Context) error {
 	}
 	defer api.Close()
 
-	tags, err := api.FindActionTagsByPrefix(params.FindTags{Prefixes: []string{c.requestedId}})
+	actionTag, err := getActionTagFromPrefix(api, c.requestedId)
 	if err != nil {
 		return err
 	}
-
-	results, ok := tags.Matches[c.requestedId]
-	if !ok || len(results) < 1 {
-		return errors.Errorf("actions for identifier %q not found", c.requestedId)
-	}
-
-	actiontags, rejects := getActionTags(results)
-	if len(rejects) > 0 {
-		return errors.Errorf("identifier %q got unrecognized entity tags %v", c.requestedId, rejects)
-	}
-
-	if len(actiontags) > 1 {
-		return errors.Errorf("identifier %q matched multiple actions %v", c.requestedId, actiontags)
-	}
-
-	actionTag := actiontags[0]
 
 	actions, err := api.Actions(params.Entities{
 		Entities: []params.Entity{{actionTag.String()}},

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -87,11 +87,3 @@ type statusTestCase struct {
 	tags        map[string][]params.Entity
 	results     []params.ActionResult
 }
-
-func tagsForId(prefix string, tags ...string) map[string][]params.Entity {
-	var entities []params.Entity
-	for _, t := range tags {
-		entities = append(entities, params.Entity{Tag: t})
-	}
-	return map[string][]params.Entity{prefix: entities}
-}

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -50,11 +50,11 @@ func (s *StatusSuite) TestRun(c *gc.C) {
 	tests := []statusTestCase{
 		{expectError: errNotSpecified},
 		{args: args, expectError: errNotFound},
-		{args: args, expectError: errNotFound, tags: tagsForId(prefix)},
-		{args: args, expectError: errNotRecognized, tags: tagsForId(prefix, "bb", "bc")},
-		{args: args, expectError: errMultipleMatches, tags: tagsForId(prefix, faketag, faketag2)},
-		{args: args, expectError: errNoResults, tags: tagsForId(prefix, faketag)},
-		{args: args, tags: tagsForId(prefix, faketag), results: result},
+		{args: args, expectError: errNotFound, tags: tagsForIdPrefix(prefix)},
+		{args: args, expectError: errNotRecognized, tags: tagsForIdPrefix(prefix, "bb", "bc")},
+		{args: args, expectError: errMultipleMatches, tags: tagsForIdPrefix(prefix, faketag, faketag2)},
+		{args: args, expectError: errNoResults, tags: tagsForIdPrefix(prefix, faketag)},
+		{args: args, tags: tagsForIdPrefix(prefix, faketag), results: result},
 	}
 
 	for _, test := range tests {
@@ -84,6 +84,6 @@ func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
 type statusTestCase struct {
 	args        []string
 	expectError string
-	tags        map[string][]params.Entity
+	tags        params.FindTagsResults
 	results     []params.ActionResult
 }

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action_test


### PR DESCRIPTION
Add ability to use `juju action fetch` with an action prefix (initial substring) instead of only the full action UUID

(Review request: http://reviews.vapour.ws/r/674/)