### PR TITLE
Remove installation of cloud-image-utils

### DIFF
--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -214,7 +214,6 @@ func AddAptCommands(
 		// leave it to the networker worker.
 		c.AddPackage("bridge-utils")
 		c.AddPackage("rsyslog-gnutls")
-		c.AddPackage("cloud-image-utils")
 	}
 
 	// Write out the apt proxy settings


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1407699

We could need cloud-images-utils for local but not cloud installs, so remove it to get CI working again and a separate branch will deal with local.

(Review request: http://reviews.vapour.ws/r/675/)