### PR TITLE
Add dependency check for cloud-image-utils when boostrapping local provider

### DIFF
--- a/provider/local/prereqs.go
+++ b/provider/local/prereqs.go
@@ -28,6 +28,11 @@ installed to enable the local provider:
 
     sudo apt-get install lxc`
 
+const installCloudImageUtils = `
+cloud-image-utils must be installed to enable the local provider:
+
+    sudo apt-get install cloud-image-utils`
+
 const installJujuLocalUbuntu = `
 juju-local must be installed to enable the local provider:
 
@@ -78,7 +83,14 @@ func verifyLxc() error {
 	if err != nil {
 		return wrapLxcNotFound(err)
 	}
-	return nil
+	return verifyCloudImageUtils()
+}
+
+func verifyCloudImageUtils() error {
+	if isPackageInstalled("cloud-image-utils") {
+		return nil
+	}
+	return errors.New(installCloudImageUtils)
 }
 
 func verifyJujuLocal() error {

--- a/provider/local/prereqs_test.go
+++ b/provider/local/prereqs_test.go
@@ -96,6 +96,21 @@ func (s *prereqsSuite) TestLxcPrereq(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+const jujuLocalInstalled = `#!/bin/sh
+if [ "$2" = "juju-local" ]; then return 0; else return 1; fi
+`
+
+func (s *prereqsSuite) TestCloudImageUtilsPrereq(c *gc.C) {
+	err := os.Remove(filepath.Join(s.tmpdir, "dpkg-query"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(filepath.Join(s.tmpdir, "dpkg-query"), []byte(jujuLocalInstalled), 0777)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = VerifyPrerequisites(instance.LXC)
+	c.Assert(err, gc.ErrorMatches, "(.|\n)*cloud-image-utils must be installed(.|\n)*")
+	c.Assert(err, gc.ErrorMatches, "(.|\n)*apt-get install cloud-image-utils(.|\n)*")
+}
+
 func (s *prereqsSuite) TestJujuLocalPrereq(c *gc.C) {
 	err := os.Remove(filepath.Join(s.tmpdir, "dpkg-query"))
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Second part of fix for https://bugs.launchpad.net/juju-core/+bug/1407699

Check that cloud-image-utils is installed when running local provider.

(Review request: http://reviews.vapour.ws/r/677/)