### PR TITLE
Ensure all fields are set on sequence docs

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -289,3 +289,7 @@ func NewMultiEnvRunnerForTesting(envUUID string, baseRunner jujutxn.Runner) juju
 		envUUID:   envUUID,
 	}
 }
+
+func Sequence(st *State, name string) (int, error) {
+	return st.sequence(name)
+}

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -20,7 +20,13 @@ type sequenceDoc struct {
 func (s *State) sequence(name string) (int, error) {
 	query := s.db.C(sequenceC).FindId(s.docID(name))
 	inc := mgo.Change{
-		Update: bson.M{"$inc": bson.M{"counter": 1}},
+		Update: bson.M{
+			"$set": bson.M{
+				"name":     name,
+				"env-uuid": s.EnvironUUID(),
+			},
+			"$inc": bson.M{"counter": 1},
+		},
 		Upsert: true,
 	}
 	result := &sequenceDoc{}

--- a/state/sequence_test.go
+++ b/state/sequence_test.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/state"
+)
+
+var _ = gc.Suite(&sequenceSuite{})
+
+type sequenceSuite struct {
+	ConnSuite
+}
+
+func (s *sequenceSuite) TestSequence(c *gc.C) {
+	s.incAndCheck(c, s.State, "foo", 0)
+	s.checkDocCount(c, 1)
+	s.checkDoc(c, s.State.EnvironUUID(), "foo", 1)
+
+	s.incAndCheck(c, s.State, "foo", 1)
+	s.checkDocCount(c, 1)
+	s.checkDoc(c, s.State.EnvironUUID(), "foo", 2)
+}
+
+func (s *sequenceSuite) TestMultipleSequences(c *gc.C) {
+	s.incAndCheck(c, s.State, "foo", 0)
+	s.incAndCheck(c, s.State, "bar", 0)
+	s.incAndCheck(c, s.State, "bar", 1)
+	s.incAndCheck(c, s.State, "foo", 1)
+	s.incAndCheck(c, s.State, "bar", 2)
+
+	s.checkDocCount(c, 2)
+	s.checkDoc(c, s.State.EnvironUUID(), "foo", 2)
+	s.checkDoc(c, s.State.EnvironUUID(), "bar", 3)
+}
+
+func (s *sequenceSuite) TestSequenceWithMultipleEnvs(c *gc.C) {
+	state1 := s.State
+	state2 := s.factory.MakeEnvironment(c, nil)
+	defer state2.Close()
+
+	s.incAndCheck(c, state1, "foo", 0)
+	s.incAndCheck(c, state2, "foo", 0)
+	s.incAndCheck(c, state1, "foo", 1)
+	s.incAndCheck(c, state2, "foo", 1)
+	s.incAndCheck(c, state1, "foo", 2)
+
+	s.checkDocCount(c, 2)
+	s.checkDoc(c, state1.EnvironUUID(), "foo", 3)
+	s.checkDoc(c, state2.EnvironUUID(), "foo", 2)
+}
+
+func (s *sequenceSuite) incAndCheck(c *gc.C, st *state.State, name string, expectedCount int) {
+	value, err := state.Sequence(st, name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(value, gc.Equals, expectedCount)
+}
+
+func (s *sequenceSuite) checkDocCount(c *gc.C, expectedCount int) {
+	coll, closer := state.GetRawCollection(s.State, "sequence")
+	defer closer()
+	count, err := coll.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, expectedCount)
+}
+
+func (s *sequenceSuite) checkDoc(c *gc.C, envUUID, name string, value int) {
+	coll, closer := state.GetRawCollection(s.State, "sequence")
+	defer closer()
+
+	docID := envUUID + ":" + name
+	var doc bson.M
+	err := coll.FindId(docID).One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(doc["_id"], gc.Equals, docID)
+	c.Check(doc["name"], gc.Equals, name)
+	c.Check(doc["env-uuid"], gc.Equals, envUUID)
+	c.Check(doc["counter"], gc.Equals, value)
+}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -896,3 +896,46 @@ func FixMinUnitsEnvUUID(st *State) error {
 	}
 	return st.runRawTransaction(ops)
 }
+
+// FixSequenceFields sets the env-uuid and name fields on documents in
+// the sequence collection where these fields are blank. This is
+// needed because code changes were missed with the env UUID migration
+// was done for this collection (in 1.21).
+func FixSequenceFields(st *State) error {
+	sequence, closer := st.getRawCollection(sequenceC)
+	defer closer()
+
+	sel := bson.D{{"$or", []bson.D{
+		bson.D{{"env-uuid", ""}},
+		bson.D{{"name", ""}},
+	}}}
+	iter := sequence.Find(sel).Select(bson.D{{"_id", 1}}).Iter()
+	defer iter.Close()
+
+	uuid := st.EnvironUUID()
+	ops := []txn.Op{}
+	var doc bson.M
+	for iter.Next(&doc) {
+		docID, ok := doc["_id"].(string)
+		if !ok {
+			return errors.Errorf("unexpected sequence id: %v", doc["_id"])
+		}
+		name, err := st.strictLocalID(docID)
+		if err != nil {
+			return err
+		}
+		ops = append(ops, txn.Op{
+			C:  sequenceC,
+			Id: docID,
+			Update: bson.D{{"$set", bson.D{
+				{"env-uuid", uuid},
+				{"name", name},
+			}}},
+			Assert: txn.DocExists,
+		})
+	}
+	if err := iter.Err(); err != nil {
+		return err
+	}
+	return st.runRawTransaction(ops)
+}

--- a/upgrades/steps122.go
+++ b/upgrades/steps122.go
@@ -81,6 +81,12 @@ func stateStepsFor122() []Step {
 				return state.FixMinUnitsEnvUUID(context.State())
 			},
 		}, &upgradeStep{
+			description: "fix sequence documents",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.FixSequenceFields(context.State())
+			},
+		}, &upgradeStep{
 			description: "update system identity in state",
 			targets:     []Target{DatabaseMaster},
 			run:         ensureSystemSSHKeyRedux,

--- a/upgrades/steps122_test.go
+++ b/upgrades/steps122_test.go
@@ -31,6 +31,7 @@ func (s *steps122Suite) TestStateStepsFor122(c *gc.C) {
 		"prepend the environment UUID to the ID of all meterStatus docs",
 		"prepend the environment UUID to the ID of all openPorts docs",
 		"fix environment UUID for minUnits docs",
+		"fix sequence documents",
 		"update system identity in state",
 		"set AvailZone in instanceData",
 	}


### PR DESCRIPTION
There's 2 commits here. The first fixes the sequence manipulation code so that the "name" and "env-uuid" fields are set. The second adds a DB migration step to fix existing sequence documents.

(Review request: http://reviews.vapour.ws/r/682/)