### PR TITLE
provider/ec2: allocate disks

### DIFF
--- a/environs/broker.go
+++ b/environs/broker.go
@@ -40,9 +40,8 @@ type StartInstanceParams struct {
 	DistributionGroup func() ([]instance.Id, error)
 
 	// Disks is a set of parameters for disks that must be created.
-	// Constraints specify the minimum and preferred values for each
-	// variable. If any of the disks cannot be created, StartInstance
-	// will return an error.
+	// If any of the disks cannot be created, StartInstance must
+	// return an error.
 	Disks []storage.DiskParams
 }
 

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -37,6 +37,10 @@ type StartInstanceParams struct {
 	// this information to distribute instances for
 	// high availability.
 	DistributionGroup func() ([]instance.Id, error)
+
+	// Disks is a set of constraints for requested disks. Constraints
+	// specify the minimum and preferred values for each variable.
+	Disks []storage.Constraints
 }
 
 // StartInstanceResult holds the result of an
@@ -51,6 +55,10 @@ type StartInstanceResult struct {
 
 	// NetworkInfo contains information about configured networks.
 	NetworkInfo []network.Info
+
+	// Disks contains a mapping from storage constraints to a list
+	// of block devices that were created to satisfy those constraints.
+	Disks map[storage.Constraints][]storage.BlockDevice
 }
 
 // TODO(wallyworld) - we want this in the environs/instance package but import loops

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
 )
 
@@ -38,9 +39,11 @@ type StartInstanceParams struct {
 	// high availability.
 	DistributionGroup func() ([]instance.Id, error)
 
-	// Disks is a set of constraints for requested disks. Constraints
-	// specify the minimum and preferred values for each variable.
-	Disks []storage.Constraints
+	// Disks is a set of parameters for disks that must be created.
+	// Constraints specify the minimum and preferred values for each
+	// variable. If any of the disks cannot be created, StartInstance
+	// will return an error.
+	Disks []storage.DiskParams
 }
 
 // StartInstanceResult holds the result of an
@@ -56,9 +59,10 @@ type StartInstanceResult struct {
 	// NetworkInfo contains information about configured networks.
 	NetworkInfo []network.Info
 
-	// Disks contains a mapping from storage constraints to a list
-	// of block devices that were created to satisfy those constraints.
-	Disks map[storage.Constraints][]storage.BlockDevice
+	// Disks contains a list of block devices created, each one
+	// corresponding to the DiskParams in the same position of
+	// StartInstanceParams.Disks.
+	Disks []storage.BlockDevice
 }
 
 // TODO(wallyworld) - we want this in the environs/instance package but import loops

--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -1,0 +1,252 @@
+// Copyright 2011-2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2
+
+import (
+	"github.com/juju/errors"
+	"launchpad.net/goamz/ec2"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	ebsStorageSource = "ebs"
+
+	// minRootDiskSize is the minimum/default size (in mebibytes) for ec2 root disks.
+	minRootDiskSize uint64 = 8 * 1024
+
+	// volumeSizeMax is the maximum disk size (in mebibytes) for EBS volumes.
+	volumeSizeMax = 1024 * 1024 // 1024 GiB
+
+	// iopsMin is the minimum IOPS value.
+	iopsMin = 100
+
+	// iopsMax is the maximum IOPS value.
+	iopsMax = 4000
+
+	// iopsSizeRatioMax is the maximum ratio of IOPS to size (in GiB).
+	iopsSizeRatioMax = 30
+)
+
+// getBlockDeviceMappings translates a StartInstanceParams into
+// BlockDeviceMappings.
+//
+// The first entry is always the root disk mapping, instance stores
+// (ephemeral disks) last.
+func getBlockDeviceMappings(
+	virtType string,
+	args *environs.StartInstanceParams,
+) (
+	[]ec2.BlockDeviceMapping, map[storage.Constraints][]storage.BlockDevice, error,
+) {
+	rootDiskSize := minRootDiskSize
+	if args.Constraints.RootDisk != nil {
+		if *args.Constraints.RootDisk >= minRootDiskSize {
+			rootDiskSize = *args.Constraints.RootDisk
+		} else {
+			logger.Infof(
+				"Ignoring root-disk constraint of %dM because it is smaller than the EC2 image size of %dM",
+				*args.Constraints.RootDisk,
+				minRootDiskSize,
+			)
+		}
+	}
+
+	// The first block device is for the root disk.
+	blockDeviceMappings := []ec2.BlockDeviceMapping{{
+		DeviceName: "/dev/sda1",
+		VolumeSize: int64(mibToGib(rootDiskSize)),
+	}}
+
+	// Not all machines have this many instance stores.
+	// Instances will be started with as many of the
+	// instance stores as they can support.
+	blockDeviceMappings = append(blockDeviceMappings, []ec2.BlockDeviceMapping{{
+		VirtualName: "ephemeral0",
+		DeviceName:  "/dev/sdb",
+	}, {
+		VirtualName: "ephemeral1",
+		DeviceName:  "/dev/sdc",
+	}, {
+		VirtualName: "ephemeral2",
+		DeviceName:  "/dev/sdd",
+	}, {
+		VirtualName: "ephemeral3",
+		DeviceName:  "/dev/sde",
+	}}...)
+
+	// TODO(axw) if preference is to use ephemeral, use ephemeral
+	// until the instance stores run out. We'll need to know how
+	// many there are and how big each one is. We also need to
+	// unmap ephemeral0 in cloud-init.
+	disks := make([][]storage.BlockDevice, len(args.Disks))
+
+	mappings := make([]ec2.BlockDeviceMapping, len(args.Disks))
+	for i, diskCons := range args.Disks {
+		// Check minimum constraints can be satisfied.
+		if err := validateConstraints(&diskCons); err != nil {
+			// TODO(axw) we need to determine if another storage
+			// provider can provide the disks, when there are
+			// other storage providers.
+			return nil, nil, errors.Annotate(err, "cannot satisfy disk constraints")
+		}
+		mapping := ec2.BlockDeviceMapping{
+			VolumeSize: int64(mibToGib(diskCons.Preferred.Size)),
+			IOPS:       int64(diskCons.Preferred.IOPS),
+			// TODO(axw) when we model storage persistence,
+			// honour the constraint.
+			//DeleteOnTermination: diskCons.Preferred.Persistent,
+		}
+		if mapping.IOPS > 0 {
+			mapping.VolumeType = "io1"
+			if mapping.IOPS < iopsMin {
+				mapping.IOPS = iopsMin
+			} else if mapping.IOPS > iopsMax {
+				mapping.IOPS = iopsMax
+			}
+		} else {
+			// TODO(axw) we need a way of specifying the volume type,
+			// so users can request an SSD.
+			mapping.VolumeType = "standard"
+		}
+		mappings[i] = mapping
+	}
+
+	nextDeviceName := blockDeviceNamer(virtType == paravirtual)
+	createBlockDevice := func(mapping ec2.BlockDeviceMapping) (name string, _ storage.BlockDevice, _ error) {
+		requestDeviceName, actualDeviceName, err := nextDeviceName()
+		if err != nil {
+			// Can't allocate any more disks.
+			//
+			// TODO(axw) we need to determine if another storage
+			// provider can provide the disks, when there are
+			// other storage providers.
+			return "", storage.BlockDevice{}, errors.Annotate(err, "cannot satisfy disk constraints")
+		}
+		disk := storage.BlockDevice{
+			DeviceName: actualDeviceName,
+			Size:       gibToMib(uint64(mapping.VolumeSize)),
+			// TODO(axw) record other properties (media type, IOPS, ...)
+		}
+		return requestDeviceName, disk, nil
+	}
+
+	// First go through and create the minimum count of the preferred
+	// constraints. Once we've done that, we'll go through each in turn
+	// creating up to the preference until the number of available disks
+	// runs out.
+	for i, mapping := range mappings {
+		if mapping.VolumeSize == 0 {
+			continue
+		}
+		for j := uint64(0); j < args.Disks[i].Minimum.Count; j++ {
+			deviceName, disk, err := createBlockDevice(mapping)
+			if err != nil {
+				return nil, nil, err
+			}
+			mapping.DeviceName = deviceName
+			disks[i] = append(disks[i], disk)
+			blockDeviceMappings = append(blockDeviceMappings, mapping)
+		}
+	}
+	for i, mapping := range mappings {
+		if mapping.VolumeSize == 0 {
+			continue
+		}
+		for j := args.Disks[i].Minimum.Count; j < args.Disks[i].Preferred.Count; j++ {
+			deviceName, disk, err := createBlockDevice(mapping)
+			if err != nil {
+				// Cannot create any more disks. Not an actual error, as this
+				// is just a preference.
+				logger.Infof("cannot create any more disks: %v", err)
+				break
+			}
+			mapping.DeviceName = deviceName
+			disks[i] = append(disks[i], disk)
+			blockDeviceMappings = append(blockDeviceMappings, mapping)
+		}
+	}
+
+	var diskConstraintMapping map[storage.Constraints][]storage.BlockDevice
+	for i, disks := range disks {
+		if len(disks) > 0 {
+			if diskConstraintMapping == nil {
+				diskConstraintMapping = make(map[storage.Constraints][]storage.BlockDevice)
+			}
+			diskConstraintMapping[args.Disks[i]] = disks
+		}
+	}
+	return blockDeviceMappings, diskConstraintMapping, nil
+}
+
+// validateConstraints validates the specified storage constraints.
+func validateConstraints(cons *storage.Constraints) error {
+	if cons.Source != "" && cons.Source != ebsStorageSource {
+		return errors.Errorf("designated for storage source %q", cons.Source)
+	}
+	if cons.Minimum.IOPS > iopsMax {
+		return errors.Errorf("%d IOPS exceeds the maximum of %d", cons.Minimum.IOPS, iopsMax)
+	}
+	if cons.Minimum.Size > volumeSizeMax {
+		return errors.Errorf("%d MiB exceeds the maximum of %d MiB", cons.Minimum.Size, volumeSizeMax)
+	}
+	if cons.Minimum.Persistent {
+		// TODO(axw) when we model storage persistence, handle persistent.
+		return errors.NotSupportedf("persistent volumes")
+	}
+	return nil
+}
+
+// mibToGib converts mebibytes to gibibytes.
+// AWS expects GiB, we work in MiB; round up
+// to nearest GiB.
+func mibToGib(m uint64) uint64 {
+	return (m + 1023) / 1024
+}
+
+// gibToMib converts gibibytes to mebibytes.
+func gibToMib(g uint64) uint64 {
+	return g / 1024
+}
+
+var errTooManyVolumes = errors.New("too many EBS volumes to attach")
+
+// blockDeviceNamer returns a function that cycles through block device names.
+//
+// The returned function returns the device name that should be used in
+// requests to the EC2 API, and and also the (kernel) device name as it
+// will appear on the machine.
+//
+// See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
+func blockDeviceNamer(numbers bool) func() (requestName, actualName string, err error) {
+	const (
+		// deviceLetterMin is the first letter to use for EBS block device names.
+		deviceLetterMin = 'f'
+		// deviceLetterMax is the last letter to use for EBS block device names.
+		deviceLetterMax = 'p'
+		// deviceNumMax is the maximum value for trailing numbers on block device name.
+		deviceNumMax = 6
+		// devicePrefix is the prefix for device names specified when creating volumes.
+		devicePrefix = "/dev/sd"
+		// renamedDevicePrefix is the prefix for device names after they have
+		// been renamed. This should replace "devicePrefix" in the device name
+		// when recording the block device info in state.
+		renamedDevicePrefix = "xvd"
+	)
+	var n int
+	return func() (string, string, error) {
+		letter := deviceLetterMin + (n / deviceNumMax)
+		if letter > deviceLetterMax {
+			return "", "", errTooManyVolumes
+		}
+		deviceName := devicePrefix + string(letter)
+		if numbers {
+			deviceName += string('1' + (n % deviceNumMax))
+		}
+		n++
+		realDeviceName := renamedDevicePrefix + deviceName[len(devicePrefix):]
+		return deviceName, realDeviceName, nil
+	}
+}

--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -1,4 +1,4 @@
-// Copyright 2011-2014 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package ec2
@@ -19,15 +19,6 @@ const (
 
 	// volumeSizeMax is the maximum disk size (in mebibytes) for EBS volumes.
 	volumeSizeMax = 1024 * 1024 // 1024 GiB
-
-	// iopsMin is the minimum IOPS value.
-	iopsMin = 100
-
-	// iopsMax is the maximum IOPS value.
-	iopsMax = 4000
-
-	// iopsSizeRatioMax is the maximum ratio of IOPS to size (in GiB).
-	iopsSizeRatioMax = 30
 )
 
 // getBlockDeviceMappings translates a StartInstanceParams into
@@ -39,7 +30,7 @@ func getBlockDeviceMappings(
 	virtType string,
 	args *environs.StartInstanceParams,
 ) (
-	[]ec2.BlockDeviceMapping, map[storage.Constraints][]storage.BlockDevice, error,
+	[]ec2.BlockDeviceMapping, []storage.BlockDevice, error,
 ) {
 	rootDiskSize := minRootDiskSize
 	if args.Constraints.RootDisk != nil {
@@ -81,120 +72,41 @@ func getBlockDeviceMappings(
 	// until the instance stores run out. We'll need to know how
 	// many there are and how big each one is. We also need to
 	// unmap ephemeral0 in cloud-init.
-	disks := make([][]storage.BlockDevice, len(args.Disks))
 
+	disks := make([]storage.BlockDevice, len(args.Disks))
 	mappings := make([]ec2.BlockDeviceMapping, len(args.Disks))
-	for i, diskCons := range args.Disks {
-		// Check minimum constraints can be satisfied.
-		if err := validateConstraints(&diskCons); err != nil {
-			// TODO(axw) we need to determine if another storage
-			// provider can provide the disks, when there are
-			// other storage providers.
-			return nil, nil, errors.Annotate(err, "cannot satisfy disk constraints")
-		}
-		mapping := ec2.BlockDeviceMapping{
-			VolumeSize: int64(mibToGib(diskCons.Preferred.Size)),
-			IOPS:       int64(diskCons.Preferred.IOPS),
-			// TODO(axw) when we model storage persistence,
-			// honour the constraint.
-			//DeleteOnTermination: diskCons.Preferred.Persistent,
-		}
-		if mapping.IOPS > 0 {
-			mapping.VolumeType = "io1"
-			if mapping.IOPS < iopsMin {
-				mapping.IOPS = iopsMin
-			} else if mapping.IOPS > iopsMax {
-				mapping.IOPS = iopsMax
-			}
-		} else {
-			// TODO(axw) we need a way of specifying the volume type,
-			// so users can request an SSD.
-			mapping.VolumeType = "standard"
-		}
-		mappings[i] = mapping
-	}
-
 	nextDeviceName := blockDeviceNamer(virtType == paravirtual)
-	createBlockDevice := func(mapping ec2.BlockDeviceMapping) (name string, _ storage.BlockDevice, _ error) {
+	for i, params := range args.Disks {
+		// Check minimum constraints can be satisfied.
+		if err := validateDiskParams(params); err != nil {
+			return nil, nil, errors.Annotate(err, "invalid disk parameters")
+		}
 		requestDeviceName, actualDeviceName, err := nextDeviceName()
 		if err != nil {
 			// Can't allocate any more disks.
-			//
-			// TODO(axw) we need to determine if another storage
-			// provider can provide the disks, when there are
-			// other storage providers.
-			return "", storage.BlockDevice{}, errors.Annotate(err, "cannot satisfy disk constraints")
+			return nil, nil, err
+		}
+		mapping := ec2.BlockDeviceMapping{
+			VolumeSize: int64(mibToGib(params.Size)),
+			DeviceName: requestDeviceName,
+			// TODO(axw) VolumeType, IOPS and DeleteOnTermination
 		}
 		disk := storage.BlockDevice{
 			DeviceName: actualDeviceName,
 			Size:       gibToMib(uint64(mapping.VolumeSize)),
-			// TODO(axw) record other properties (media type, IOPS, ...)
+			// ProviderId will be filled in once the instance has
+			// been created, which will create the volumes too.
 		}
-		return requestDeviceName, disk, nil
+		mappings[i] = mapping
+		disks[i] = disk
 	}
-
-	// First go through and create the minimum count of the preferred
-	// constraints. Once we've done that, we'll go through each in turn
-	// creating up to the preference until the number of available disks
-	// runs out.
-	for i, mapping := range mappings {
-		if mapping.VolumeSize == 0 {
-			continue
-		}
-		for j := uint64(0); j < args.Disks[i].Minimum.Count; j++ {
-			deviceName, disk, err := createBlockDevice(mapping)
-			if err != nil {
-				return nil, nil, err
-			}
-			mapping.DeviceName = deviceName
-			disks[i] = append(disks[i], disk)
-			blockDeviceMappings = append(blockDeviceMappings, mapping)
-		}
-	}
-	for i, mapping := range mappings {
-		if mapping.VolumeSize == 0 {
-			continue
-		}
-		for j := args.Disks[i].Minimum.Count; j < args.Disks[i].Preferred.Count; j++ {
-			deviceName, disk, err := createBlockDevice(mapping)
-			if err != nil {
-				// Cannot create any more disks. Not an actual error, as this
-				// is just a preference.
-				logger.Infof("cannot create any more disks: %v", err)
-				break
-			}
-			mapping.DeviceName = deviceName
-			disks[i] = append(disks[i], disk)
-			blockDeviceMappings = append(blockDeviceMappings, mapping)
-		}
-	}
-
-	var diskConstraintMapping map[storage.Constraints][]storage.BlockDevice
-	for i, disks := range disks {
-		if len(disks) > 0 {
-			if diskConstraintMapping == nil {
-				diskConstraintMapping = make(map[storage.Constraints][]storage.BlockDevice)
-			}
-			diskConstraintMapping[args.Disks[i]] = disks
-		}
-	}
-	return blockDeviceMappings, diskConstraintMapping, nil
+	return blockDeviceMappings, disks, nil
 }
 
-// validateConstraints validates the specified storage constraints.
-func validateConstraints(cons *storage.Constraints) error {
-	if cons.Source != "" && cons.Source != ebsStorageSource {
-		return errors.Errorf("designated for storage source %q", cons.Source)
-	}
-	if cons.Minimum.IOPS > iopsMax {
-		return errors.Errorf("%d IOPS exceeds the maximum of %d", cons.Minimum.IOPS, iopsMax)
-	}
-	if cons.Minimum.Size > volumeSizeMax {
-		return errors.Errorf("%d MiB exceeds the maximum of %d MiB", cons.Minimum.Size, volumeSizeMax)
-	}
-	if cons.Minimum.Persistent {
-		// TODO(axw) when we model storage persistence, handle persistent.
-		return errors.NotSupportedf("persistent volumes")
+// validateDiskParams validates the disk parameters.
+func validateDiskParams(params storage.DiskParams) error {
+	if params.Size > volumeSizeMax {
+		return errors.Errorf("%d MiB exceeds the maximum of %d MiB", params.Size, volumeSizeMax)
 	}
 	return nil
 }
@@ -208,7 +120,7 @@ func mibToGib(m uint64) uint64 {
 
 // gibToMib converts gibibytes to mebibytes.
 func gibToMib(g uint64) uint64 {
-	return g / 1024
+	return g * 1024
 }
 
 var errTooManyVolumes = errors.New("too many EBS volumes to attach")
@@ -236,8 +148,12 @@ func blockDeviceNamer(numbers bool) func() (requestName, actualName string, err 
 		renamedDevicePrefix = "xvd"
 	)
 	var n int
+	letterRepeats := 1
+	if numbers {
+		letterRepeats = deviceNumMax
+	}
 	return func() (string, string, error) {
-		letter := deviceLetterMin + (n / deviceNumMax)
+		letter := deviceLetterMin + (n / letterRepeats)
 		if letter > deviceLetterMax {
 			return "", "", errTooManyVolumes
 		}

--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -14,11 +14,11 @@ import (
 const (
 	ebsStorageSource = "ebs"
 
-	// minRootDiskSize is the minimum/default size (in mebibytes) for ec2 root disks.
-	minRootDiskSize uint64 = 8 * 1024
+	// minRootDiskSizeMiB is the minimum/default size (in mebibytes) for ec2 root disks.
+	minRootDiskSizeMiB uint64 = 8 * 1024
 
-	// volumeSizeMax is the maximum disk size (in mebibytes) for EBS volumes.
-	volumeSizeMax = 1024 * 1024 // 1024 GiB
+	// volumeSizeMaxMiB is the maximum disk size (in mebibytes) for EBS volumes.
+	volumeSizeMaxMiB = 1024 * 1024 // 1024 GiB
 )
 
 // getBlockDeviceMappings translates a StartInstanceParams into
@@ -32,15 +32,15 @@ func getBlockDeviceMappings(
 ) (
 	[]ec2.BlockDeviceMapping, []storage.BlockDevice, error,
 ) {
-	rootDiskSize := minRootDiskSize
+	rootDiskSizeMiB := minRootDiskSizeMiB
 	if args.Constraints.RootDisk != nil {
-		if *args.Constraints.RootDisk >= minRootDiskSize {
-			rootDiskSize = *args.Constraints.RootDisk
+		if *args.Constraints.RootDisk >= minRootDiskSizeMiB {
+			rootDiskSizeMiB = *args.Constraints.RootDisk
 		} else {
 			logger.Infof(
 				"Ignoring root-disk constraint of %dM because it is smaller than the EC2 image size of %dM",
 				*args.Constraints.RootDisk,
-				minRootDiskSize,
+				minRootDiskSizeMiB,
 			)
 		}
 	}
@@ -48,7 +48,7 @@ func getBlockDeviceMappings(
 	// The first block device is for the root disk.
 	blockDeviceMappings := []ec2.BlockDeviceMapping{{
 		DeviceName: "/dev/sda1",
-		VolumeSize: int64(mibToGib(rootDiskSize)),
+		VolumeSize: int64(mibToGib(rootDiskSizeMiB)),
 	}}
 
 	// Not all machines have this many instance stores.
@@ -105,8 +105,8 @@ func getBlockDeviceMappings(
 
 // validateDiskParams validates the disk parameters.
 func validateDiskParams(params storage.DiskParams) error {
-	if params.Size > volumeSizeMax {
-		return errors.Errorf("%d MiB exceeds the maximum of %d MiB", params.Size, volumeSizeMax)
+	if params.Size > volumeSizeMaxMiB {
+		return errors.Errorf("%d MiB exceeds the maximum of %d MiB", params.Size, volumeSizeMaxMiB)
 	}
 	return nil
 }

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -1,0 +1,77 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2_test
+
+import (
+	"strconv"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/ec2"
+	"github.com/juju/juju/testing"
+)
+
+type DisksSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&DisksSuite{})
+
+func (*DisksSuite) TestBlockDeviceNamer(c *gc.C) {
+	var nextName func() (string, string, error)
+	expect := func(expectRequest, expectActual string) {
+		request, actual, err := nextName()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(request, gc.Equals, expectRequest)
+		c.Assert(actual, gc.Equals, expectActual)
+	}
+	expectN := func(expectRequest, expectActual string) {
+		for i := 1; i <= 6; i++ {
+			request, actual, err := nextName()
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(request, gc.Equals, expectRequest+strconv.Itoa(i))
+			c.Assert(actual, gc.Equals, expectActual+strconv.Itoa(i))
+		}
+	}
+	expectErr := func(expectErr string) {
+		_, _, err := nextName()
+		c.Assert(err, gc.ErrorMatches, expectErr)
+	}
+
+	// First without numbers.
+	nextName = ec2.BlockDeviceNamer(false)
+	expect("/dev/sdf", "xvdf")
+	expect("/dev/sdg", "xvdg")
+	expect("/dev/sdh", "xvdh")
+	expect("/dev/sdi", "xvdi")
+	expect("/dev/sdj", "xvdj")
+	expect("/dev/sdk", "xvdk")
+	expect("/dev/sdl", "xvdl")
+	expect("/dev/sdm", "xvdm")
+	expect("/dev/sdn", "xvdn")
+	expect("/dev/sdo", "xvdo")
+	expect("/dev/sdp", "xvdp")
+	expectErr("too many EBS volumes to attach")
+
+	// Now with numbers.
+	nextName = ec2.BlockDeviceNamer(true)
+	expect("/dev/sdf1", "xvdf1")
+	expect("/dev/sdf2", "xvdf2")
+	expect("/dev/sdf3", "xvdf3")
+	expect("/dev/sdf4", "xvdf4")
+	expect("/dev/sdf5", "xvdf5")
+	expect("/dev/sdf6", "xvdf6")
+	expectN("/dev/sdg", "xvdg")
+	expectN("/dev/sdh", "xvdh")
+	expectN("/dev/sdi", "xvdi")
+	expectN("/dev/sdj", "xvdj")
+	expectN("/dev/sdk", "xvdk")
+	expectN("/dev/sdl", "xvdl")
+	expectN("/dev/sdm", "xvdm")
+	expectN("/dev/sdn", "xvdn")
+	expectN("/dev/sdo", "xvdo")
+	expectN("/dev/sdp", "xvdp")
+	expectErr("too many EBS volumes to attach")
+}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -541,17 +541,12 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	}
 
 	// Tag created resources.
-	// FIXME(axw) uncomment below when we've migrated to go-amz/amz,
-	//            after implementing support for the CreateTags
 	//            action in the ec2 test server.
-	/*
-		// TODO(axw) expose EnvironTag directly in StartInstanceParams.
-		tag := ec2.Tag{"juju-env", args.MachineConfig.APIInfo.EnvironTag.Id()}
-		if _, err := e.ec2().CreateTags(resourceIds, []ec2.Tag{tag}); err != nil {
-			logger.Errorf("could not tag resources: %v", err)
-		}
-	*/
-	_ = resourceIds
+	// TODO(axw) expose EnvironTag directly in StartInstanceParams.
+	tag := ec2.Tag{"juju-env", args.MachineConfig.APIInfo.EnvironTag.Id()}
+	if _, err := createTags(e.ec2(), resourceIds, []ec2.Tag{tag}); err != nil {
+		logger.Errorf("could not tag resources: %v", err)
+	}
 
 	if multiwatcher.AnyJobNeedsState(args.MachineConfig.Jobs...) {
 		if err := common.AddStateInstance(e.Storage(), inst.Id()); err != nil {
@@ -575,7 +570,10 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	}, nil
 }
 
-var runInstances = _runInstances
+var (
+	runInstances = _runInstances
+	createTags   = (*ec2.EC2).CreateTags
+)
 
 // runInstances calls ec2.RunInstances for a fixed number of attempts until
 // RunInstances returns an error code that does not indicate an error that

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -68,7 +68,6 @@ var rootDiskTests = []RootDiskTest{
 func (*Suite) TestRootDiskBlockDeviceMapping(c *gc.C) {
 	for _, t := range rootDiskTests {
 		c.Logf("Test %s", t.name)
-		cons := constraints.Value{RootDisk: t.constraint}
 		args := &environs.StartInstanceParams{
 			Constraints: constraints.Value{RootDisk: t.constraint},
 		}

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -9,6 +9,7 @@ import (
 	amzec2 "launchpad.net/goamz/ec2"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
 )
 
@@ -64,11 +65,14 @@ var rootDiskTests = []RootDiskTest{
 	},
 }
 
-func (*Suite) TestBlockDeviceMappings(c *gc.C) {
+func (*Suite) TestRootDiskBlockDeviceMapping(c *gc.C) {
 	for _, t := range rootDiskTests {
 		c.Logf("Test %s", t.name)
 		cons := constraints.Value{RootDisk: t.constraint}
-		mappings, err := getBlockDeviceMappings(cons)
+		args := &environs.StartInstanceParams{
+			Constraints: constraints.Value{RootDisk: t.constraint},
+		}
+		mappings, _, err := getBlockDeviceMappings(paravirtual, args)
 		c.Assert(err, jc.ErrorIsNil)
 		expected := append([]amzec2.BlockDeviceMapping{t.device}, commonInstanceStoreDisks...)
 		c.Assert(mappings, gc.DeepEquals, expected)

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -46,7 +46,6 @@ var (
 	AvailabilityZoneAllocations = &availabilityZoneAllocations
 	RunInstances                = &runInstances
 	BlockDeviceNamer            = blockDeviceNamer
-	CreateTags                  = &createTags
 )
 
 // BucketStorage returns a storage instance addressing

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -46,6 +46,7 @@ var (
 	AvailabilityZoneAllocations = &availabilityZoneAllocations
 	RunInstances                = &runInstances
 	BlockDeviceNamer            = blockDeviceNamer
+	CreateTags                  = &createTags
 )
 
 // BucketStorage returns a storage instance addressing

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -45,6 +45,7 @@ var (
 	EC2AvailabilityZones        = &ec2AvailabilityZones
 	AvailabilityZoneAllocations = &availabilityZoneAllocations
 	RunInstances                = &runInstances
+	BlockDeviceNamer            = blockDeviceNamer
 )
 
 // BucketStorage returns a storage instance addressing

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/ec2"
+	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/utils/ssh"
 	"github.com/juju/juju/version"
@@ -326,8 +327,11 @@ func (t *localServerSuite) testStartInstanceAvailZone(c *gc.C, zone string) (ins
 	c.Assert(err, jc.ErrorIsNil)
 
 	params := environs.StartInstanceParams{Placement: "zone=" + zone}
-	inst, _, _, err := testing.StartInstanceWithParams(env, "1", params, nil)
-	return inst, err
+	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return result.Instance, nil
 }
 
 func (t *localServerSuite) TestGetAvailabilityZones(c *gc.C) {
@@ -422,7 +426,7 @@ func (t *localServerSuite) TestStartInstanceDistributionParams(c *gc.C) {
 			return expectedInstances, nil
 		},
 	}
-	_, _, _, err = testing.StartInstanceWithParams(env, "1", params, nil)
+	_, err = testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mock.group, gc.DeepEquals, expectedInstances)
 }
@@ -446,7 +450,7 @@ func (t *localServerSuite) TestStartInstanceDistributionErrors(c *gc.C) {
 			return nil, dgErr
 		},
 	}
-	_, _, _, err = testing.StartInstanceWithParams(env, "1", params, nil)
+	_, err = testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(errors.Cause(err), gc.Equals, dgErr)
 }
 
@@ -848,6 +852,28 @@ func (t *localServerSuite) TestSupportAddressAllocationFalse(c *gc.C) {
 	result, err := env.SupportAddressAllocation("")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.IsFalse)
+}
+
+func (t *localServerSuite) TestStartInstanceDisks(c *gc.C) {
+	env := t.Prepare(c)
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	params := environs.StartInstanceParams{
+		Disks: []storage.DiskParams{{
+			Size: 512, // round up to 1GiB
+		}, {
+			Size: 1024, // 1GiB exactly
+		}, {
+			Size: 1025, // round up to 2GiB
+		}},
+	}
+	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Disks, gc.HasLen, 3)
+	c.Assert(result.Disks[0].Size, gc.Equals, uint64(1024))
+	c.Assert(result.Disks[1].Size, gc.Equals, uint64(1024))
+	c.Assert(result.Disks[2].Size, gc.Equals, uint64(2048))
 }
 
 // localNonUSEastSuite is similar to localServerSuite but the S3 mock server

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -920,7 +921,11 @@ func patchEC2ForTesting() func() {
 	ec2.UseTestRegionData(ec2.TestRegions)
 	restoreTimeouts := envtesting.PatchAttemptStrategies(ec2.ShortAttempt, ec2.StorageAttempt)
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
+	restoreCreateTags := gitjujutesting.PatchValue(ec2.CreateTags, func(*amzec2.EC2, []string, []amzec2.Tag) (*amzec2.SimpleResp, error) {
+		return &amzec2.SimpleResp{}, nil
+	})
 	return func() {
+		restoreCreateTags()
 		restoreFinishBootstrap()
 		restoreTimeouts()
 		ec2.UseTestImageData(nil)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -921,11 +920,7 @@ func patchEC2ForTesting() func() {
 	ec2.UseTestRegionData(ec2.TestRegions)
 	restoreTimeouts := envtesting.PatchAttemptStrategies(ec2.ShortAttempt, ec2.StorageAttempt)
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
-	restoreCreateTags := gitjujutesting.PatchValue(ec2.CreateTags, func(*amzec2.EC2, []string, []amzec2.Tag) (*amzec2.SimpleResp, error) {
-		return &amzec2.SimpleResp{}, nil
-	})
 	return func() {
-		restoreCreateTags()
 		restoreFinishBootstrap()
 		restoreTimeouts()
 		ec2.UseTestImageData(nil)

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1117,8 +1117,11 @@ func (s *environSuite) TestStartInstanceAvailZoneUnknown(c *gc.C) {
 func (s *environSuite) testStartInstanceAvailZone(c *gc.C, zone string) (instance.Instance, error) {
 	env := s.bootstrap(c)
 	params := environs.StartInstanceParams{Placement: "zone=" + zone}
-	inst, _, _, err := testing.StartInstanceWithParams(env, "1", params, nil)
-	return inst, err
+	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return result.Instance, nil
 }
 
 func (s *environSuite) TestGetAvailabilityZones(c *gc.C) {
@@ -1206,7 +1209,7 @@ func (s *environSuite) TestStartInstanceDistributionParams(c *gc.C) {
 			return expectedInstances, nil
 		},
 	}
-	_, _, _, err := testing.StartInstanceWithParams(env, "1", params, nil)
+	_, err := testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mock.group, gc.DeepEquals, expectedInstances)
 }
@@ -1227,7 +1230,7 @@ func (s *environSuite) TestStartInstanceDistributionErrors(c *gc.C) {
 			return nil, dgErr
 		},
 	}
-	_, _, _, err = testing.StartInstanceWithParams(env, "1", params, nil)
+	_, err = testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, gc.ErrorMatches, "cannot get distribution group: DistributionGroup failed")
 }
 

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1356,8 +1356,11 @@ func (t *localServerSuite) testStartInstanceAvailZone(c *gc.C, zone string) (ins
 	c.Assert(err, jc.ErrorIsNil)
 
 	params := environs.StartInstanceParams{Placement: "zone=" + zone}
-	inst, _, _, err := testing.StartInstanceWithParams(env, "1", params, nil)
-	return inst, err
+	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return result.Instance, nil
 }
 
 func (t *localServerSuite) TestGetAvailabilityZones(c *gc.C) {
@@ -1444,7 +1447,7 @@ func (t *localServerSuite) TestStartInstanceDistributionParams(c *gc.C) {
 			return expectedInstances, nil
 		},
 	}
-	_, _, _, err = testing.StartInstanceWithParams(env, "1", params, nil)
+	_, err = testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mock.group, gc.DeepEquals, expectedInstances)
 }
@@ -1468,7 +1471,7 @@ func (t *localServerSuite) TestStartInstanceDistributionErrors(c *gc.C) {
 			return nil, dgErr
 		},
 	}
-	_, _, _, err = testing.StartInstanceWithParams(env, "1", params, nil)
+	_, err = testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(jujuerrors.Cause(err), gc.Equals, dgErr)
 }
 

--- a/storage/blockdevice.go
+++ b/storage/blockdevice.go
@@ -8,6 +8,11 @@ type BlockDevice struct {
 	// Name is a unique name assigned by Juju to the block device.
 	Name string `yaml:"name"`
 
+	// ProviderId is a unique provider-supplied ID for the block device.
+	// ProviderId is required to be unique for the lifetime of the block-
+	// device, but may be reused.
+	ProviderId string `yaml:"providerid"`
+
 	// DeviceName is the block device's OS-specific name (e.g. "sdb").
 	DeviceName string `yaml:"devicename,omitempty"`
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+// DiskProvider provides an interface for creating, destroying and
+// describing disks in the environment.
+type DiskProvider interface {
+	// CreateDisks creates disks with the specified size, in MiB.
+	CreateDisks(spec []*DiskParams) ([]*BlockDevice, error)
+
+	// DescribeDisks returns the properties of the disks with the
+	// specified provider disk IDs.
+	DescribeDisks(diskIds []string) ([]*BlockDevice, error)
+
+	// DestroyDisks destroys the disks with the specified provider
+	// disk IDs.
+	DestroyDisks(diskIds []string) error
+
+	// ListDisks returns provider disk IDs for each disk in the pool.
+	ListDisks() ([]string, error)
+
+	// ValidateDiskParams validates the provided disk parameters,
+	// returning an error if they are invalid.
+	ValidateDiskParams(params DiskParams) error
+
+	//AttachDisks(diskIds []string, instId []instance.Id) error
+	//DetachDisks(diskIds []string, instId []instance.Id) error
+}
+
+// DiskParams is a fully specified set of parameters for disk creation,
+// derived from one or more of user-specified storage constraints, a
+// storage pool definition, and charm storage metadata.
+type DiskParams struct {
+	// Size is the minimum size of the disk in MiB.
+	Size uint64
+
+	// Options is a set of provider-specific options for storage creation,
+	// as defined in a storage pool.
+	Options map[string]interface{}
+}

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -3,31 +3,6 @@
 
 package storage
 
-// DiskProvider provides an interface for creating, destroying and
-// describing disks in the environment.
-type DiskProvider interface {
-	// CreateDisks creates disks with the specified size, in MiB.
-	CreateDisks(spec []*DiskParams) ([]*BlockDevice, error)
-
-	// DescribeDisks returns the properties of the disks with the
-	// specified provider disk IDs.
-	DescribeDisks(diskIds []string) ([]*BlockDevice, error)
-
-	// DestroyDisks destroys the disks with the specified provider
-	// disk IDs.
-	DestroyDisks(diskIds []string) error
-
-	// ListDisks returns provider disk IDs for each disk in the pool.
-	ListDisks() ([]string, error)
-
-	// ValidateDiskParams validates the provided disk parameters,
-	// returning an error if they are invalid.
-	ValidateDiskParams(params DiskParams) error
-
-	//AttachDisks(diskIds []string, instId []instance.Id) error
-	//DetachDisks(diskIds []string, instId []instance.Id) error
-}
-
 // DiskParams is a fully specified set of parameters for disk creation,
 // derived from one or more of user-specified storage constraints, a
 // storage pool definition, and charm storage metadata.


### PR DESCRIPTION
We introduce the Disks field to StartInstanceParams, which is a slice of
[]storage.DiskParams. Each element describes the parameters for creating a
disk with the provider's default storage provider. StartInstance is
required to create all of the disks, or fail. StartInstanceResult contains
a []storage.BlockDevice, each of which corresponds to the storage.DiskParam
in the same position.

The EC2 provider is updated to allocate disks at machine provisioning time.
We currently only support allocating magnetic disks; we will expand support
when configurable pools are implemented. We are not yet recording volume IDs
or tagging volumes; these operations require modifications to goamz. When
we have migrated to using the goamz on GitHub, we will extend the functionality.

(Review request: http://reviews.vapour.ws/r/683/)