### PR TITLE
all: move state.*NotProvisioned* to juju/errors

### DIFF
--- a/api/firewaller/machine_test.go
+++ b/api/firewaller/machine_test.go
@@ -59,7 +59,7 @@ func (s *machineSuite) TestInstanceId(c *gc.C) {
 	apiNewMachine, err := s.firewaller.Machine(newMachine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = apiNewMachine.InstanceId()
-	c.Assert(err, gc.ErrorMatches, "machine 3 is not provisioned")
+	c.Assert(err, gc.ErrorMatches, "machine 3 not provisioned")
 	c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
 
 	instanceId, err := s.apiMachine.InstanceId()

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -215,7 +215,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 
 	instanceId, err := apiMachine.InstanceId()
 	c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
-	c.Assert(err, gc.ErrorMatches, "machine 1 is not provisioned")
+	c.Assert(err, gc.ErrorMatches, "machine 1 not provisioned")
 	c.Assert(instanceId, gc.Equals, instance.Id(""))
 
 	hwChars := instance.MustParseHardware("cpu-cores=123", "mem=4G")

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -270,7 +270,7 @@ func checkForValidMachineAgent(entity state.Entity, req params.LoginRequest) err
 	// connect.
 	if machine, ok := entity.(*state.Machine); ok {
 		if !machine.CheckProvisioned(req.Nonce) {
-			return state.NotProvisionedError(machine.Id())
+			return errors.NotProvisionedf("machine %v", machine.Id())
 		}
 	}
 	return nil

--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -4,6 +4,8 @@
 package authentication
 
 import (
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/state"
 )
@@ -33,7 +35,7 @@ func (*AgentAuthenticator) Authenticate(entity state.Entity, password, nonce str
 	// connect.
 	if machine, ok := authenticator.(*state.Machine); ok {
 		if !machine.CheckProvisioned(nonce) {
-			return state.NotProvisionedError(machine.Id())
+			return errors.NotProvisionedf("machine %v", machine.Id())
 		}
 	}
 

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -122,7 +122,7 @@ func (s *agentAuthenticatorSuite) TestInvalidLogins(c *gc.C) {
 		credentials:  s.machinePassword,
 		nonce:        "123",
 		about:        "machine login",
-		errorMessage: "machine 0 is not provisioned",
+		errorMessage: "machine 0 not provisioned",
 	}, {
 		entity:       s.user,
 		credentials:  "wrong-secret",

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -342,7 +342,7 @@ func makeMachineStatus(machine *state.Machine) (status api.MachineStatus) {
 		}
 		status.DNSName = network.SelectPublicAddress(machine.Addresses())
 	} else {
-		if state.IsNotProvisionedError(err) {
+		if errors.IsNotProvisioned(err) {
 			status.InstanceId = "pending"
 		} else {
 			status.InstanceId = "error"

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -133,7 +133,7 @@ func ServerError(err error) *params.Error {
 		code = params.CodeHasAssignedUnits
 	case IsNoAddressSetError(err):
 		code = params.CodeNoAddressSet
-	case state.IsNotProvisionedError(err):
+	case errors.IsNotProvisioned(err):
 		code = params.CodeNotProvisioned
 	case state.IsUpgradeInProgressError(err):
 		code = params.CodeUpgradeInProgress

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -77,7 +77,7 @@ var errorTransformTests = []struct {
 	code:       params.CodeUnauthorized,
 	helperFunc: params.IsCodeUnauthorized,
 }, {
-	err:        state.NotProvisionedError("0"),
+	err:        errors.NotProvisionedf("machine 0"),
 	code:       params.CodeNotProvisioned,
 	helperFunc: params.IsCodeNotProvisioned,
 }, {

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -6,6 +6,7 @@ package provisioner
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
 
@@ -443,7 +444,7 @@ func environManagerInstances(st *state.State) ([]instance.Id, error) {
 		instanceId, err := machine.InstanceId()
 		if err == nil {
 			instances = append(instances, instanceId)
-		} else if !state.IsNotProvisionedError(err) {
+		} else if !errors.IsNotProvisioned(err) {
 			return nil, err
 		}
 	}

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -168,7 +168,7 @@ func (s *serverSuite) TestOpenAsMachineErrors(c *gc.C) {
 	assertNotProvisioned := func(err error) {
 		c.Assert(err, gc.NotNil)
 		c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
-		c.Assert(err, gc.ErrorMatches, `machine \d+ is not provisioned`)
+		c.Assert(err, gc.ErrorMatches, `machine \d+ not provisioned`)
 	}
 	stm, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/testing/errors.go
+++ b/apiserver/testing/errors.go
@@ -27,7 +27,7 @@ func NotFoundError(prefixMessage string) *params.Error {
 
 func NotProvisionedError(machineId string) *params.Error {
 	return &params.Error{
-		Message: fmt.Sprintf("machine %s is not provisioned", machineId),
+		Message: fmt.Sprintf("machine %s not provisioned", machineId),
 		Code:    params.CodeNotProvisioned,
 	}
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -647,7 +647,7 @@ func (s *MachineSuite) waitProvisioned(c *gc.C, unit *state.Unit) (*state.Machin
 				c.Logf("unit provisioned with instance %s", instId)
 				return m, instId
 			} else {
-				c.Check(err, jc.Satisfies, state.IsNotProvisionedError)
+				c.Check(err, jc.Satisfies, errors.IsNotProvisioned)
 			}
 		}
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,7 +10,7 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	c8e097e6dc9619475be92918c20de5f2d05ffa0b	2014-09-25T11:47:50Z
 github.com/juju/cmd	git	f75cb03fd9ba687f573755b1075a2405f833952d	2014-12-03T02:17:39Z
-github.com/juju/errors	git	7a748941731116a391d328fd2ba9744f57efb51b	2014-12-11T10:41:41Z
+github.com/juju/errors	git	c3aaee403f140e8ab35eca129eb0a514bed780eb	2015-01-08T02:04:25Z
 github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	2014-07-18T03:59:30Z
 github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	2014-07-18T03:57:39Z
 github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	2014-07-17T16:12:25Z

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -669,7 +669,7 @@ func (t *LiveTests) assertStartInstance(c *gc.C, m *state.Machine) {
 		c.Assert(err, jc.ErrorIsNil)
 		instId, err := m.InstanceId()
 		if err != nil {
-			c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+			c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 			continue
 		}
 		_, err = t.Env.Instances([]instance.Id{instId})
@@ -708,7 +708,7 @@ func assertInstanceId(c *gc.C, m *state.Machine, inst instance.Instance) {
 		c.Assert(err, jc.ErrorIsNil)
 		gotId, err = m.InstanceId()
 		if err != nil {
-			c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+			c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 			if inst == nil {
 				return
 			}

--- a/state/distribution.go
+++ b/state/distribution.go
@@ -67,7 +67,7 @@ func ServiceInstances(st *State, service string) ([]instance.Id, error) {
 		instanceId, err := machine.InstanceId()
 		if err == nil {
 			instanceIds = append(instanceIds, instanceId)
-		} else if IsNotProvisionedError(err) {
+		} else if errors.IsNotProvisioned(err) {
 			continue
 		} else {
 			return nil, err

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -753,13 +753,13 @@ func (s *MachineSuite) TestMachineInstanceIdCorrupt(c *gc.C) {
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	iid, err := machine.InstanceId()
-	c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 	c.Assert(iid, gc.Equals, instance.Id(""))
 }
 
 func (s *MachineSuite) TestMachineInstanceIdMissing(c *gc.C) {
 	iid, err := s.machine.InstanceId()
-	c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 	c.Assert(string(iid), gc.Equals, "")
 }
 
@@ -775,7 +775,7 @@ func (s *MachineSuite) TestMachineInstanceIdBlank(c *gc.C) {
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	iid, err := machine.InstanceId()
-	c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 	c.Assert(string(iid), gc.Equals, "")
 }
 
@@ -942,7 +942,7 @@ func (s *MachineSuite) TestNotProvisionedMachineSetInstanceStatus(c *gc.C) {
 
 func (s *MachineSuite) TestNotProvisionedMachineInstanceStatus(c *gc.C) {
 	_, err := s.machine.InstanceStatus()
-	c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 }
 
 func (s *MachineSuite) TestMachineRefresh(c *gc.C) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -1479,7 +1479,7 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 	for _, mdoc := range mdocs {
 		m := newMachine(u.st, mdoc)
 		instance, err := m.InstanceId()
-		if IsNotProvisionedError(err) {
+		if errors.IsNotProvisioned(err) {
 			unprovisioned = append(unprovisioned, m)
 		} else if err != nil {
 			assignContextf(&err, u, context)

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -350,7 +350,7 @@ func (m *testMachine) Addresses() []network.Address {
 
 func (m *testMachine) InstanceId() (instance.Id, error) {
 	if m.instanceId == "" {
-		return "", state.NotProvisionedError(m.Id())
+		return "", errors.NotProvisionedf("machine %v", m.Id())
 	}
 	return m.instanceId, m.instanceIdErr
 }

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -180,7 +180,7 @@ func machineLoop(context machineContext, m machine, changed <-chan struct{}) err
 	for {
 		if pollInstance {
 			instInfo, err := pollInstanceInfo(context, m)
-			if err != nil && !state.IsNotProvisionedError(err) {
+			if err != nil && !errors.IsNotProvisioned(err) {
 				// If the provider doesn't implement Addresses/Status now,
 				// it never will until we're upgraded, so don't bother
 				// asking any more. We could use less resources
@@ -232,7 +232,7 @@ func pollInstanceInfo(context machineContext, m machine) (instInfo instanceInfo,
 	instInfo = instanceInfo{}
 	instId, err := m.InstanceId()
 	// We can't ask the machine for its addresses if it isn't provisioned yet.
-	if state.IsNotProvisionedError(err) {
+	if errors.IsNotProvisioned(err) {
 		return instInfo, err
 	}
 	if err != nil {

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -52,7 +53,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 	checkInstanceInfo := func(index int, m machine, expectedStatus string) bool {
 		isProvisioned := true
 		status, err := m.InstanceStatus()
-		if state.IsNotProvisionedError(err) {
+		if errors.IsNotProvisioned(err) {
 			isProvisioned = false
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
@@ -75,7 +76,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 			status, err := m.InstanceStatus()
 			if i%2 == 0 {
 				// Even machines not provisioned yet.
-				c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+				c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 			} else {
 				c.Assert(status, gc.Equals, "")
 			}
@@ -104,7 +105,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 			status, err := m.InstanceStatus()
 			if i%2 == 0 {
 				// Even machines not provisioned yet.
-				c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+				c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 			} else {
 				c.Assert(status, gc.Equals, "")
 			}

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -379,7 +379,7 @@ func (s *CommonProvisionerSuite) waitInstanceId(c *gc.C, m *state.Machine, expec
 		if actual, err := m.InstanceId(); err == nil {
 			c.Assert(actual, gc.Equals, expect)
 			return true
-		} else if !state.IsNotProvisionedError(err) {
+		} else if !errors.IsNotProvisioned(err) {
 			// We don't expect any errors.
 			panic(err)
 		}
@@ -1211,7 +1211,7 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, state.StatusError)
 	_, err = m4.InstanceId()
-	c.Assert(err, jc.Satisfies, state.IsNotProvisionedError)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 }
 
 func (s *ProvisionerSuite) TestProvisionerObservesMachineJobs(c *gc.C) {


### PR DESCRIPTION
The NotProvisioned error type and function will
be reused for disk provisioning. Let's move the
error type out of state while we're at it.

Requires https://github.com/juju/errors/pull/15

(Review request: http://reviews.vapour.ws/r/684/)