### PR TITLE
Fixed lp:1355813: Container NICs inherit host NIC's MTU

### DIFF
--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -11,6 +11,7 @@ var (
 	ContainerConfigFilename = containerConfigFilename
 	ContainerDirFilesystem  = containerDirFilesystem
 	GenerateNetworkConfig   = generateNetworkConfig
+	DiscoverHostNIC         = &discoverHostNIC
 	NetworkConfigTemplate   = networkConfigTemplate
 	RestartSymlink          = restartSymlink
 	ReleaseVersion          = &releaseVersion

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -5,14 +5,17 @@ package lxc
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/juju/loggo"
@@ -119,9 +122,9 @@ type containerManager struct {
 // containerManager implements container.Manager.
 var _ container.Manager = (*containerManager)(nil)
 
-// NewContainerManager returns a manager object that can start and stop lxc
-// containers. The containers that are created are namespaced by the name
-// parameter.
+// NewContainerManager returns a manager object that can start and
+// stop lxc containers. The containers that are created are namespaced
+// by the name parameter inside the given ManagerConfig.
 func NewContainerManager(conf container.ManagerConfig, imageURLGetter container.ImageURLGetter) (container.Manager, error) {
 	name := conf.PopValue(container.ConfigName)
 	if name == "" {
@@ -519,13 +522,75 @@ func containerConfigFilename(name string) string {
 }
 
 const networkTemplate = `
-lxc.network.type = %s
-lxc.network.link = %s
+lxc.network.type = {{.Type}}
+lxc.network.link = {{.Link}}
 lxc.network.flags = up
+{{if gt .MTU 0}}lxc.network.mtu = {{.MTU}}{{end}}
 `
 
 func networkConfigTemplate(networkType, networkLink string) string {
-	return fmt.Sprintf(networkTemplate, networkType, networkLink)
+	type config struct {
+		Type string
+		Link string
+		MTU  int
+	}
+	values := config{
+		Type: networkType,
+		Link: networkLink,
+	}
+
+	tmpl, err := template.New("config").Parse(networkTemplate)
+	if err != nil {
+		logger.Errorf("cannot parse container config template: %v", err)
+		return ""
+	}
+
+	primaryNIC, err := discoverHostNIC()
+	if err != nil {
+		logger.Warningf("cannot determine primary NIC MTU, not setting for container: %v", err)
+	} else {
+		logger.Debugf("setting container network interface MTU to %d", primaryNIC.MTU)
+		values.MTU = primaryNIC.MTU
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, values); err != nil {
+		logger.Errorf("cannot render container config: %v")
+		return ""
+	}
+	return buf.String()
+}
+
+// discoverHostNIC detects and returns the primary network interface
+// on the machine. Out of all interfaces, the first non-loopback
+// device which is up and has address is considered the primary.
+var discoverHostNIC = func() (net.Interface, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return net.Interface{}, errors.Annotatef(err, "cannot get network interfaces")
+	}
+	logger.Tracef("trying to discover primary network interface")
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			// Skip the loopback.
+			logger.Tracef("not using loopback interface %q", iface.Name)
+			continue
+		}
+		if iface.Flags&net.FlagUp != 0 {
+			// Possibly the primary, but ensure it has an address as
+			// well.
+			logger.Tracef("verifying interface %q has addresses", iface.Name)
+			addrs, err := iface.Addrs()
+			if err != nil {
+				return net.Interface{}, errors.Annotatef(err, "cannot get %q addresses", iface.Name)
+			}
+			if len(addrs) > 0 {
+				// We found it.
+				logger.Tracef("primary network interface is %q", iface.Name)
+				return iface, nil
+			}
+		}
+	}
+	return net.Interface{}, errors.Errorf("cannot detect the primary network interface")
 }
 
 func generateNetworkConfig(network *container.NetworkConfig) string {


### PR DESCRIPTION
This allows users to specify a given Maximum Transmission Unit (MTU)
value on the host machine's primary network interface and it will be
detected and applied to any containers that start on that host.

Needed for deployments utilizing overlay networks, e.g. OpenStack.

Live tested on local and maas.