### PR TITLE
Add API call to list and delete os images

### DIFF
--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -19,3 +19,7 @@ func (APICallerFunc) BestFacadeVersion(facade string) int {
 func (APICallerFunc) EnvironTag() (names.EnvironTag, error) {
 	return names.NewEnvironTag(""), nil
 }
+
+func (APICallerFunc) Close() error {
+	return nil
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -20,6 +20,7 @@ var facadeVersions = map[string]int{
 	"Networker":            0,
 	"StringsWatcher":       0,
 	"Environment":          0,
+	"ImageManager":         0,
 	"KeyManager":           0,
 	"Logger":               0,
 	"MetricsManager":       0,

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -20,7 +20,7 @@ var facadeVersions = map[string]int{
 	"Networker":            0,
 	"StringsWatcher":       0,
 	"Environment":          0,
-	"ImageManager":         0,
+	"ImageManager":         1,
 	"KeyManager":           0,
 	"Logger":               0,
 	"MetricsManager":       0,

--- a/api/imagemanager/client.go
+++ b/api/imagemanager/client.go
@@ -22,7 +22,11 @@ func NewClient(st base.APICallCloser) *Client {
 
 // ListImages returns the images.
 func (c *Client) ListImages(kind, series, arch string) ([]params.ImageMetadata, error) {
-	p := params.ImageSpec{Kind: kind, Series: series, Arch: arch}
+	p := params.ImageFilterParams{
+		Images: []params.ImageSpec{
+			{Kind: kind, Series: series, Arch: arch},
+		},
+	}
 	var result params.ListImageResult
 	err := c.facade.FacadeCall("ListImages", p, &result)
 	return result.Result, err
@@ -30,7 +34,7 @@ func (c *Client) ListImages(kind, series, arch string) ([]params.ImageMetadata, 
 
 // DeleteImage deletes the specified image.
 func (c *Client) DeleteImage(kind, series, arch string) error {
-	p := params.DeleteImageParams{
+	p := params.ImageFilterParams{
 		Images: []params.ImageSpec{
 			{Kind: kind, Series: series, Arch: arch},
 		},

--- a/api/imagemanager/client.go
+++ b/api/imagemanager/client.go
@@ -1,0 +1,44 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagemanager
+
+import (
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// Client provides access to the imagemanager, used to list/delete images.
+type Client struct {
+	base.ClientFacade
+	facade base.FacadeCaller
+}
+
+// NewClient returns a new imagemanager client.
+func NewClient(st base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(st, "ImageManager")
+	return &Client{ClientFacade: frontend, facade: backend}
+}
+
+// ListImages returns the images.
+func (c *Client) ListImages(kind, series, arch string) ([]params.ImageMetadata, error) {
+	p := params.ImageSpec{Kind: kind, Series: series, Arch: arch}
+	var result params.ListImageResult
+	err := c.facade.FacadeCall("ListImages", p, &result)
+	return result.Result, err
+}
+
+// DeleteImage deletes the specified image.
+func (c *Client) DeleteImage(kind, series, arch string) error {
+	p := params.DeleteImageParams{
+		Images: []params.ImageSpec{
+			{Kind: kind, Series: series, Arch: arch},
+		},
+	}
+	results := new(params.ErrorResults)
+	err := c.facade.FacadeCall("DeleteImages", p, results)
+	if err != nil {
+		return err
+	}
+	return results.OneError()
+}

--- a/api/imagemanager/client_test.go
+++ b/api/imagemanager/client_test.go
@@ -33,10 +33,12 @@ func (s *imagemanagerSuite) TestListImages(c *gc.C) {
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "ListImages")
-		c.Check(arg, gc.DeepEquals, params.ImageSpec{
-			Kind:   "lxc",
-			Series: "trusty",
-			Arch:   "amd64",
+		c.Check(arg, gc.DeepEquals, params.ImageFilterParams{
+			Images: []params.ImageSpec{{
+				Kind:   "lxc",
+				Series: "trusty",
+				Arch:   "amd64",
+			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ListImageResult{})
 		*(result.(*params.ListImageResult)) = params.ListImageResult{
@@ -74,7 +76,7 @@ func (s *imagemanagerSuite) TestDeleteImage(c *gc.C) {
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "DeleteImages")
-		c.Check(arg, gc.DeepEquals, params.DeleteImageParams{
+		c.Check(arg, gc.DeepEquals, params.ImageFilterParams{
 			Images: []params.ImageSpec{{
 				Kind:   "lxc",
 				Series: "trusty",

--- a/api/imagemanager/client_test.go
+++ b/api/imagemanager/client_test.go
@@ -1,0 +1,123 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagemanager_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/imagemanager"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type imagemanagerSuite struct {
+	coretesting.BaseSuite
+
+	imagemanager *imagemanager.Client
+}
+
+var _ = gc.Suite(&imagemanagerSuite{})
+
+var dummyTime = time.Now()
+
+func (s *imagemanagerSuite) TestListImages(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "ImageManager")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "ListImages")
+		c.Check(arg, gc.DeepEquals, params.ImageSpec{
+			Kind:   "lxc",
+			Series: "trusty",
+			Arch:   "amd64",
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ListImageResult{})
+		*(result.(*params.ListImageResult)) = params.ListImageResult{
+			Result: []params.ImageMetadata{{
+				Kind:    "lxc",
+				Series:  "trusty",
+				Arch:    "amd64",
+				Created: dummyTime,
+				URL:     "http://path",
+			}},
+		}
+		callCount++
+		return nil
+	})
+
+	im := imagemanager.NewClient(apiCaller)
+	imageMetadata, err := im.ListImages("lxc", "trusty", "amd64")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(callCount, gc.Equals, 1)
+	c.Check(imageMetadata, gc.HasLen, 1)
+	metadata := imageMetadata[0]
+	c.Assert(metadata, gc.Equals, params.ImageMetadata{
+		Kind:    "lxc",
+		Series:  "trusty",
+		Arch:    "amd64",
+		Created: dummyTime,
+		URL:     "http://path",
+	})
+}
+
+func (s *imagemanagerSuite) TestDeleteImage(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "ImageManager")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "DeleteImages")
+		c.Check(arg, gc.DeepEquals, params.DeleteImageParams{
+			Images: []params.ImageSpec{{
+				Kind:   "lxc",
+				Series: "trusty",
+				Arch:   "amd64",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: nil,
+			}},
+		}
+		callCount++
+		return nil
+	})
+
+	im := imagemanager.NewClient(apiCaller)
+	err := im.DeleteImage("lxc", "trusty", "amd64")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *imagemanagerSuite) TestDeleteImageCallError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("an error")
+	})
+
+	im := imagemanager.NewClient(apiCaller)
+	err := im.DeleteImage("lxc", "trusty", "amd64")
+	c.Check(err, gc.ErrorMatches, "an error")
+}
+
+func (s *imagemanagerSuite) TestDeleteImageError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "the devil made me do it", Code: "666"},
+			}},
+		}
+		return nil
+	})
+
+	im := imagemanager.NewClient(apiCaller)
+	err := im.DeleteImage("lxc", "trusty", "amd64")
+	c.Check(err, gc.ErrorMatches, "the devil made me do it")
+}

--- a/api/imagemanager/package_test.go
+++ b/api/imagemanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagemanager_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/juju/juju/apiserver/diskmanager"
 	_ "github.com/juju/juju/apiserver/environment"
 	_ "github.com/juju/juju/apiserver/firewaller"
+	_ "github.com/juju/juju/apiserver/imagemanager"
 	_ "github.com/juju/juju/apiserver/keymanager"
 	_ "github.com/juju/juju/apiserver/keyupdater"
 	_ "github.com/juju/juju/apiserver/logger"

--- a/apiserver/imagemanager/imagemanager.go
+++ b/apiserver/imagemanager/imagemanager.go
@@ -16,7 +16,7 @@ import (
 var logger = loggo.GetLogger("juju.apiserver.imagemanager")
 
 func init() {
-	common.RegisterStandardFacade("ImageManager", 0, NewImageManagerAPI)
+	common.RegisterStandardFacade("ImageManager", 1, NewImageManagerAPI)
 }
 
 // ImageManager defines the methods on the imagemanager API end point.

--- a/apiserver/imagemanager/imagemanager.go
+++ b/apiserver/imagemanager/imagemanager.go
@@ -1,0 +1,110 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagemanager
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/imagestorage"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.imagemanager")
+
+func init() {
+	common.RegisterStandardFacade("ImageManager", 0, NewImageManagerAPI)
+}
+
+// ImageManager defines the methods on the imagemanager API end point.
+type ImageManager interface {
+	ListImages(arg params.ImageSpec) (params.ListImageResult, error)
+	DeleteImages(arg params.DeleteImageParams) (params.ErrorResults, error)
+}
+
+// ImageManagerAPI implements the ImageManager interface and is the concrete
+// implementation of the api end point.
+type ImageManagerAPI struct {
+	state      *state.State
+	resources  *common.Resources
+	authorizer common.Authorizer
+	check      *common.BlockChecker
+}
+
+var _ ImageManager = (*ImageManagerAPI)(nil)
+
+// NewImageManagerAPI creates a new server-side imagemanager API end point.
+func NewImageManagerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*ImageManagerAPI, error) {
+	// Only clients can access the image manager service.
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
+	return &ImageManagerAPI{
+		state:      st,
+		resources:  resources,
+		authorizer: authorizer,
+		check:      common.NewBlockChecker(st),
+	}, nil
+}
+
+// ListImages returns images matching the specified filter.
+func (api *ImageManagerAPI) ListImages(arg params.ImageSpec) (params.ListImageResult, error) {
+	stor := api.state.ImageStorage()
+	filter := imagestorage.ImageFilter{
+		Kind:   arg.Kind,
+		Series: arg.Series,
+		Arch:   arg.Arch,
+	}
+	var result params.ListImageResult
+	metadata, err := stor.ListImages(filter)
+	if err != nil {
+		return result, nil
+	}
+	result.Result = make([]params.ImageMetadata, len(metadata))
+	for i, m := range metadata {
+		result.Result[i] = params.ImageMetadata{
+			Kind:    m.Kind,
+			Series:  m.Series,
+			Arch:    m.Arch,
+			URL:     m.SourceURL,
+			Created: m.Created,
+		}
+	}
+	return result, nil
+}
+
+// DeleteImages deletes the images matching the specified filter.
+func (api *ImageManagerAPI) DeleteImages(arg params.DeleteImageParams) (params.ErrorResults, error) {
+	if err := api.check.ChangeAllowed(); err != nil {
+		return params.ErrorResults{}, errors.Trace(err)
+	}
+	var result params.ErrorResults
+	result.Results = make([]params.ErrorResult, len(arg.Images))
+	stor := api.state.ImageStorage()
+	for i, imageSpec := range arg.Images {
+		filter := imagestorage.ImageFilter{
+			Kind:   imageSpec.Kind,
+			Series: imageSpec.Series,
+			Arch:   imageSpec.Arch,
+		}
+		imageMetadata, err := stor.ListImages(filter)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		if len(imageMetadata) != 1 {
+			result.Results[i].Error = common.ServerError(
+				errors.NotFoundf("image %s/%s/%s", filter.Kind, filter.Series, filter.Arch))
+			continue
+		}
+		logger.Infof("deleting image with metadata %+v", *imageMetadata[0])
+		err = stor.DeleteImage(imageMetadata[0])
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+		}
+	}
+	return result, nil
+}

--- a/apiserver/imagemanager/imagemanager.go
+++ b/apiserver/imagemanager/imagemanager.go
@@ -28,13 +28,17 @@ type ImageManager interface {
 // ImageManagerAPI implements the ImageManager interface and is the concrete
 // implementation of the api end point.
 type ImageManagerAPI struct {
-	state      *state.State
+	state      stateInterface
 	resources  *common.Resources
 	authorizer common.Authorizer
 	check      *common.BlockChecker
 }
 
 var _ ImageManager = (*ImageManagerAPI)(nil)
+
+var getState = func(st *state.State) stateInterface {
+	return stateShim{st}
+}
 
 // NewImageManagerAPI creates a new server-side imagemanager API end point.
 func NewImageManagerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*ImageManagerAPI, error) {
@@ -43,7 +47,7 @@ func NewImageManagerAPI(st *state.State, resources *common.Resources, authorizer
 		return nil, common.ErrPerm
 	}
 	return &ImageManagerAPI{
-		state:      st,
+		state:      getState(st),
 		resources:  resources,
 		authorizer: authorizer,
 		check:      common.NewBlockChecker(st),

--- a/apiserver/imagemanager/imagemanager_test.go
+++ b/apiserver/imagemanager/imagemanager_test.go
@@ -1,0 +1,141 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagemanager_test
+
+import (
+	"bytes"
+	"io"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/imagemanager"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state/imagestorage"
+)
+
+type imageManagerSuite struct {
+	jujutesting.JujuConnSuite
+
+	imagemanager *imagemanager.ImageManagerAPI
+	resources    *common.Resources
+	authoriser   apiservertesting.FakeAuthorizer
+}
+
+var _ = gc.Suite(&imageManagerSuite{})
+
+func (s *imageManagerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authoriser = apiservertesting.FakeAuthorizer{
+		Tag: s.AdminUserTag(c),
+	}
+	var err error
+	s.imagemanager, err = imagemanager.NewImageManagerAPI(s.State, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *imageManagerSuite) TestNewImageManagerAPIAcceptsClient(c *gc.C) {
+	endPoint, err := imagemanager.NewImageManagerAPI(s.State, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(endPoint, gc.NotNil)
+}
+
+func (s *imageManagerSuite) TestNewImageManagerAPIRefusesNonClient(c *gc.C) {
+	anAuthoriser := s.authoriser
+	anAuthoriser.Tag = names.NewUnitTag("mysql/0")
+	anAuthoriser.EnvironManager = false
+	endPoint, err := imagemanager.NewImageManagerAPI(s.State, s.resources, anAuthoriser)
+	c.Assert(endPoint, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *imageManagerSuite) addImage(c *gc.C, content string) {
+	var r io.Reader = bytes.NewReader([]byte(content))
+	addedMetadata := &imagestorage.Metadata{
+		EnvUUID:   s.State.EnvironUUID(),
+		Kind:      "lxc",
+		Series:    "trusty",
+		Arch:      "amd64",
+		Size:      int64(len(content)),
+		SHA256:    "hash(" + content + ")",
+		SourceURL: "http://lxc-trusty-amd64",
+	}
+	stor := s.State.ImageStorage()
+	err := stor.AddImage(r, addedMetadata)
+	c.Assert(err, gc.IsNil)
+	_, rdr, err := stor.Image("lxc", "trusty", "amd64")
+	c.Assert(err, jc.ErrorIsNil)
+	rdr.Close()
+}
+
+func (s *imageManagerSuite) TestListImages(c *gc.C) {
+	s.addImage(c, "image")
+	args := params.ImageSpec{}
+	result, err := s.imagemanager.ListImages(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Result, gc.HasLen, 1)
+	dummyTime := time.Now()
+	result.Result[0].Created = dummyTime
+	c.Assert(result.Result[0], gc.Equals, params.ImageMetadata{
+		Kind: "lxc", Arch: "amd64", Series: "trusty", URL: "http://lxc-trusty-amd64", Created: dummyTime,
+	})
+}
+
+func (s *imageManagerSuite) TestDeleteImages(c *gc.C) {
+	s.addImage(c, "image")
+	args := params.DeleteImageParams{
+		Images: []params.ImageSpec{
+			{
+				Kind:   "lxc",
+				Series: "trusty",
+				Arch:   "amd64",
+			}, {
+				Kind:   "lxc",
+				Series: "precise",
+				Arch:   "amd64",
+			},
+		},
+	}
+	results, err := s.imagemanager.DeleteImages(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: nil},
+			{Error: apiservertesting.NotFoundError("image lxc/precise/amd64")},
+		},
+	})
+	stor := s.State.ImageStorage()
+	_, _, err = stor.Image("lxc", "trusty", "amd64")
+	c.Assert(err, gc.ErrorMatches, ".*-lxc-trusty-amd64 image metadata not found")
+}
+
+func (s *imageManagerSuite) TestBlockDeleteImages(c *gc.C) {
+	s.addImage(c, "image")
+	args := params.DeleteImageParams{
+		Images: []params.ImageSpec{{
+			Kind:   "lxc",
+			Series: "trusty",
+			Arch:   "amd64",
+		}},
+	}
+
+	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	_, err := s.imagemanager.DeleteImages(args)
+	// Check that the call is blocked
+	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	// Check the image still exists.
+	stor := s.State.ImageStorage()
+	_, rdr, err := stor.Image("lxc", "trusty", "amd64")
+	c.Assert(err, jc.ErrorIsNil)
+	rdr.Close()
+}

--- a/apiserver/imagemanager/package_test.go
+++ b/apiserver/imagemanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagemanager_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/imagemanager/state.go
+++ b/apiserver/imagemanager/state.go
@@ -1,0 +1,21 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package imagemanager
+
+import (
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/imagestorage"
+)
+
+type stateInterface interface {
+	ImageStorage() imagestorage.Storage
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) ImageStorage() imagestorage.Storage {
+	return s.State.ImageStorage()
+}

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -156,12 +156,13 @@ func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Stora
 	rdr := io.TeeReader(resp.Body, hash)
 
 	metadata := &imagestorage.Metadata{
-		EnvUUID: envuuid,
-		Kind:    string(instance.LXC),
-		Series:  series,
-		Arch:    arch,
-		Size:    resp.ContentLength,
-		SHA256:  checksum,
+		EnvUUID:   envuuid,
+		Kind:      string(instance.LXC),
+		Series:    series,
+		Arch:      arch,
+		Size:      resp.ContentLength,
+		SHA256:    checksum,
+		SourceURL: imageURL,
 	}
 
 	// Stream the image to storage.

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -86,6 +86,7 @@ func (s *imageSuite) TestDownloadFetchesAndCaches(c *gc.C) {
 	metadata, cachedData := s.getImageFromStorage(c, "lxc", "trusty", "amd64")
 	c.Assert(metadata.Size, gc.Equals, int64(len(s.imageData)))
 	c.Assert(metadata.SHA256, gc.Equals, s.imageChecksum)
+	c.Assert(metadata.SourceURL, gc.Equals, "test://cloud-images/trusty-released-amd64-root.tar.gz")
 	c.Assert(string(data), gc.Equals, string(s.imageData))
 	c.Assert(string(data), gc.Equals, string(cachedData))
 }
@@ -152,12 +153,13 @@ func (s *imageSuite) downloadRequest(c *gc.C, uuid, kind, series, arch string) (
 func (s *imageSuite) storeFakeImage(c *gc.C, uuid, kind, series, arch string) {
 	storage := s.State.ImageStorage()
 	metadata := &imagestorage.Metadata{
-		EnvUUID: uuid,
-		Kind:    kind,
-		Series:  series,
-		Arch:    arch,
-		Size:    int64(len(s.imageData)),
-		SHA256:  s.imageChecksum,
+		EnvUUID:   uuid,
+		Kind:      kind,
+		Series:    series,
+		Arch:      arch,
+		Size:      int64(len(s.imageData)),
+		SHA256:    s.imageChecksum,
+		SourceURL: "http://path",
 	}
 	err := storage.AddImage(strings.NewReader(s.imageData), metadata)
 	c.Assert(err, gc.IsNil)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -752,12 +752,12 @@ type FindToolsResult struct {
 	Error *Error
 }
 
-// DeleteImageParams holds the parameters used to specify images to delete.
-type DeleteImageParams struct {
+// ImageFilterParams holds the parameters used to specify images to delete.
+type ImageFilterParams struct {
 	Images []ImageSpec `json:"images"`
 }
 
-// ImageSpec defines the parameters to select an image to delete.
+// ImageSpec defines the parameters to select images list or delete.
 type ImageSpec struct {
 	Kind   string `json:"kind"`
 	Arch   string `json:"arch"`

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -752,6 +752,32 @@ type FindToolsResult struct {
 	Error *Error
 }
 
+// DeleteImageParams holds the parameters used to specify images to delete.
+type DeleteImageParams struct {
+	Images []ImageSpec `json:"images"`
+}
+
+// ImageSpec defines the parameters to select an image to delete.
+type ImageSpec struct {
+	Kind   string `json:"kind"`
+	Arch   string `json:"arch"`
+	Series string `json:"series"`
+}
+
+// ListImageResult holds the results of querying images.
+type ListImageResult struct {
+	Result []ImageMetadata `json:"result"`
+}
+
+// ImageMetadata represents an image in storage.
+type ImageMetadata struct {
+	Kind    string    `json:"kind"`
+	Arch    string    `json:"arch"`
+	Series  string    `json:"series"`
+	URL     string    `json:"url"`
+	Created time.Time `json:"created"`
+}
+
 // RebootActionResults holds a list of RebootActionResult and any error.
 type RebootActionResults struct {
 	Results []RebootActionResult `json:"results,omitempty"`

--- a/state/imagestorage/image_test.go
+++ b/state/imagestorage/image_test.go
@@ -387,16 +387,16 @@ func (s *ImageSuite) TestDeleteNotExistentImage(c *gc.C) {
 
 func (s *ImageSuite) addMetadataDoc(c *gc.C, kind, series, arch string, size int64, checksum, path, sourceURL string) {
 	doc := struct {
-		Id        string `bson:"_id"`
-		EnvUUID   string `bson:"envuuid"`
-		Kind      string `bson:"kind"`
-		Series    string `bson:"series"`
-		Arch      string `bson:"arch"`
-		Size      int64  `bson:"size"`
-		SHA256    string `bson:"sha256,omitempty"`
-		Path      string `bson:"path"`
-		Created   string `bson:"created"`
-		SourceURL string `bson:"sourceurl"`
+		Id        string    `bson:"_id"`
+		EnvUUID   string    `bson:"envuuid"`
+		Kind      string    `bson:"kind"`
+		Series    string    `bson:"series"`
+		Arch      string    `bson:"arch"`
+		Size      int64     `bson:"size"`
+		SHA256    string    `bson:"sha256,omitempty"`
+		Path      string    `bson:"path"`
+		Created   time.Time `bson:"created"`
+		SourceURL string    `bson:"sourceurl"`
 	}{
 		Id:        fmt.Sprintf("my-uuid-%s-%s-%s", kind, series, arch),
 		EnvUUID:   "my-uuid",
@@ -406,7 +406,7 @@ func (s *ImageSuite) addMetadataDoc(c *gc.C, kind, series, arch string, size int
 		Size:      size,
 		SHA256:    checksum,
 		Path:      path,
-		Created:   time.Now().Format(time.RFC3339),
+		Created:   time.Now(),
 		SourceURL: sourceURL,
 	}
 	err := s.metadataCollection.Insert(&doc)

--- a/state/imagestorage/image_test.go
+++ b/state/imagestorage/image_test.go
@@ -74,22 +74,30 @@ func (s *ImageSuite) TestAddImageReplaces(c *gc.C) {
 	s.testAddImage(c, "defghi")
 }
 
-func checkMetadata(c *gc.C, metadata, fromDb *imagestorage.Metadata) {
+func checkMetadata(c *gc.C, fromDb, metadata *imagestorage.Metadata) {
 	c.Assert(fromDb.Created.IsZero(), jc.IsFalse)
 	c.Assert(fromDb.Created.Before(time.Now()), jc.IsTrue)
 	fromDb.Created = time.Time{}
 	c.Assert(metadata, gc.DeepEquals, fromDb)
 }
 
+func checkAllMetadata(c *gc.C, fromDb []*imagestorage.Metadata, metadata ...*imagestorage.Metadata) {
+	c.Assert(len(metadata), gc.Equals, len(fromDb))
+	for i, m := range metadata {
+		checkMetadata(c, fromDb[i], m)
+	}
+}
+
 func (s *ImageSuite) testAddImage(c *gc.C, content string) {
 	var r io.Reader = bytes.NewReader([]byte(content))
 	addedMetadata := &imagestorage.Metadata{
-		EnvUUID: "my-uuid",
-		Kind:    "lxc",
-		Series:  "trusty",
-		Arch:    "amd64",
-		Size:    int64(len(content)),
-		SHA256:  "hash(" + content + ")",
+		EnvUUID:   "my-uuid",
+		Kind:      "lxc",
+		Series:    "trusty",
+		Arch:      "amd64",
+		Size:      int64(len(content)),
+		SHA256:    "hash(" + content + ")",
+		SourceURL: "http://path",
 	}
 	err := s.storage.AddImage(r, addedMetadata)
 	c.Assert(err, gc.IsNil)
@@ -98,7 +106,7 @@ func (s *ImageSuite) testAddImage(c *gc.C, content string) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(r, gc.NotNil)
 	defer rc.Close()
-	checkMetadata(c, addedMetadata, metadata)
+	checkMetadata(c, metadata, addedMetadata)
 
 	data, err := ioutil.ReadAll(rc)
 	c.Assert(err, gc.IsNil)
@@ -110,7 +118,7 @@ func (s *ImageSuite) TestImage(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(err, gc.ErrorMatches, `.* image metadata not found`)
 
-	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "path")
+	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "path", "http://path")
 	_, _, err = s.storage.Image("lxc", "trusty", "amd64")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(err, gc.ErrorMatches, `resource at path "environs/my-uuid/path" not found`)
@@ -122,14 +130,15 @@ func (s *ImageSuite) TestImage(c *gc.C) {
 	metadata, r, err := s.storage.Image("lxc", "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
 	defer r.Close()
-	checkMetadata(c, &imagestorage.Metadata{
-		EnvUUID: "my-uuid",
-		Kind:    "lxc",
-		Series:  "trusty",
-		Arch:    "amd64",
-		Size:    3,
-		SHA256:  "hash(abc)",
-	}, metadata)
+	checkMetadata(c, metadata, &imagestorage.Metadata{
+		EnvUUID:   "my-uuid",
+		Kind:      "lxc",
+		Series:    "trusty",
+		Arch:      "amd64",
+		Size:      3,
+		SHA256:    "hash(abc)",
+		SourceURL: "http://path",
+	})
 
 	data, err := ioutil.ReadAll(r)
 	c.Assert(err, gc.IsNil)
@@ -139,18 +148,19 @@ func (s *ImageSuite) TestImage(c *gc.C) {
 func (s *ImageSuite) TestAddImageRemovesExisting(c *gc.C) {
 	// Add a metadata doc and a blob at a known path, then
 	// call AddImage and ensure the original blob is removed.
-	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "path")
+	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "path", "http://path")
 	managedStorage := imagestorage.ManagedStorage(s.storage, s.session)
 	err := managedStorage.PutForEnvironment("my-uuid", "path", strings.NewReader("blah"), 4)
 	c.Assert(err, gc.IsNil)
 
 	addedMetadata := &imagestorage.Metadata{
-		EnvUUID: "my-uuid",
-		Kind:    "lxc",
-		Series:  "trusty",
-		Arch:    "amd64",
-		Size:    6,
-		SHA256:  "hash(xyzzzz)",
+		EnvUUID:   "my-uuid",
+		Kind:      "lxc",
+		Series:    "trusty",
+		Arch:      "amd64",
+		Size:      6,
+		SHA256:    "hash(xyzzzz)",
+		SourceURL: "http://path",
 	}
 	err = s.storage.AddImage(strings.NewReader("xyzzzz"), addedMetadata)
 	c.Assert(err, gc.IsNil)
@@ -167,7 +177,7 @@ func (s *ImageSuite) TestAddImageRemovesExistingRemoveFails(c *gc.C) {
 	// call AddImage and ensure that AddImage attempts to remove
 	// the original blob, but does not return an error if it
 	// fails.
-	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "path")
+	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "path", "http://path")
 	managedStorage := imagestorage.ManagedStorage(s.storage, s.session)
 	err := managedStorage.PutForEnvironment("my-uuid", "path", strings.NewReader("blah"), 4)
 	c.Assert(err, gc.IsNil)
@@ -175,12 +185,13 @@ func (s *ImageSuite) TestAddImageRemovesExistingRemoveFails(c *gc.C) {
 	storage := imagestorage.NewStorage(s.session, "my-uuid")
 	s.PatchValue(imagestorage.GetManagedStorage, imagestorage.RemoveFailsManagedStorage)
 	addedMetadata := &imagestorage.Metadata{
-		EnvUUID: "my-uuid",
-		Kind:    "lxc",
-		Series:  "trusty",
-		Arch:    "amd64",
-		Size:    6,
-		SHA256:  "hash(xyzzzz)",
+		EnvUUID:   "my-uuid",
+		Kind:      "lxc",
+		Series:    "trusty",
+		Arch:      "amd64",
+		Size:      6,
+		SHA256:    "hash(xyzzzz)",
+		SourceURL: "http://path",
 	}
 	err = storage.AddImage(strings.NewReader("xyzzzz"), addedMetadata)
 	c.Assert(err, gc.IsNil)
@@ -248,7 +259,7 @@ func (s *ImageSuite) TestAddImageRemovesBlobOnFailureRemoveFails(c *gc.C) {
 
 func (s *ImageSuite) TestAddImageSame(c *gc.C) {
 	metadata := &imagestorage.Metadata{
-		EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "0",
+		EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "0", SourceURL: "http://path",
 	}
 	for i := 0; i < 2; i++ {
 		err := s.storage.AddImage(strings.NewReader("0"), metadata)
@@ -258,7 +269,7 @@ func (s *ImageSuite) TestAddImageSame(c *gc.C) {
 }
 
 func (s *ImageSuite) TestAddImageAndJustMetadataExists(c *gc.C) {
-	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "images/lxc-trusty-amd64:hash(abc)")
+	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "images/lxc-trusty-amd64:hash(abc)", "http://path")
 	n, err := s.metadataCollection.Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
@@ -269,7 +280,7 @@ func (s *ImageSuite) TestAddImageAndJustMetadataExists(c *gc.C) {
 }
 
 func (s *ImageSuite) TestJustMetadataFails(c *gc.C) {
-	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "images/lxc-trusty-amd64:hash(abc)")
+	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "images/lxc-trusty-amd64:hash(abc)", "http://path")
 	_, rc, err := s.storage.Image("lxc", "trusty", "amd64")
 	c.Assert(rc, gc.IsNil)
 	c.Assert(err, gc.NotNil)
@@ -277,10 +288,10 @@ func (s *ImageSuite) TestJustMetadataFails(c *gc.C) {
 
 func (s *ImageSuite) TestAddImageConcurrent(c *gc.C) {
 	metadata0 := &imagestorage.Metadata{
-		EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "0",
+		EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "0", SourceURL: "http://path",
 	}
 	metadata1 := &imagestorage.Metadata{
-		EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "1",
+		EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "1", SourceURL: "http://path",
 	}
 
 	addMetadata := func() {
@@ -306,10 +317,10 @@ func (s *ImageSuite) TestAddImageConcurrent(c *gc.C) {
 
 func (s *ImageSuite) TestAddImageExcessiveContention(c *gc.C) {
 	metadata := []*imagestorage.Metadata{
-		{EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "0"},
-		{EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "1"},
-		{EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "2"},
-		{EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "3"},
+		{EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "0", SourceURL: "http://path"},
+		{EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "1", SourceURL: "http://path"},
+		{EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "2", SourceURL: "http://path"},
+		{EnvUUID: "my-uuid", Kind: "lxc", Series: "trusty", Arch: "amd64", Size: 1, SHA256: "3", SourceURL: "http://path"},
 	}
 
 	i := 1
@@ -335,7 +346,7 @@ func (s *ImageSuite) TestAddImageExcessiveContention(c *gc.C) {
 }
 
 func (s *ImageSuite) TestDeleteImage(c *gc.C) {
-	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "images/lxc-trusty-amd64:sha256")
+	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "images/lxc-trusty-amd64:sha256", "http://lxc-trusty-amd64")
 	managedStorage := imagestorage.ManagedStorage(s.storage, s.session)
 	err := managedStorage.PutForEnvironment("my-uuid", "images/lxc-trusty-amd64:sha256", strings.NewReader("blah"), 4)
 	c.Assert(err, gc.IsNil)
@@ -374,25 +385,29 @@ func (s *ImageSuite) TestDeleteNotExistentImage(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *ImageSuite) addMetadataDoc(c *gc.C, kind, series, arch string, size int64, checksum, path string) {
+func (s *ImageSuite) addMetadataDoc(c *gc.C, kind, series, arch string, size int64, checksum, path, sourceURL string) {
 	doc := struct {
-		Id      string `bson:"_id"`
-		Kind    string `bson:"kind"`
-		Series  string `bson:"series"`
-		Arch    string `bson:"arch"`
-		Size    int64  `bson:"size"`
-		SHA256  string `bson:"sha256,omitempty"`
-		Path    string `bson:"path"`
-		Created string `bson:"created"`
+		Id        string `bson:"_id"`
+		EnvUUID   string `bson:"envuuid"`
+		Kind      string `bson:"kind"`
+		Series    string `bson:"series"`
+		Arch      string `bson:"arch"`
+		Size      int64  `bson:"size"`
+		SHA256    string `bson:"sha256,omitempty"`
+		Path      string `bson:"path"`
+		Created   string `bson:"created"`
+		SourceURL string `bson:"sourceurl"`
 	}{
-		Id:      fmt.Sprintf("my-uuid-%s-%s-%s", kind, series, arch),
-		Kind:    kind,
-		Series:  series,
-		Arch:    arch,
-		Size:    size,
-		SHA256:  checksum,
-		Path:    path,
-		Created: time.Now().Format(time.RFC3339),
+		Id:        fmt.Sprintf("my-uuid-%s-%s-%s", kind, series, arch),
+		EnvUUID:   "my-uuid",
+		Kind:      kind,
+		Series:    series,
+		Arch:      arch,
+		Size:      size,
+		SHA256:    checksum,
+		Path:      path,
+		Created:   time.Now().Format(time.RFC3339),
+		SourceURL: sourceURL,
 	}
 	err := s.metadataCollection.Insert(&doc)
 	c.Assert(err, gc.IsNil)
@@ -402,9 +417,74 @@ func (s *ImageSuite) assertImage(c *gc.C, expected *imagestorage.Metadata, conte
 	metadata, r, err := s.storage.Image(expected.Kind, expected.Series, expected.Arch)
 	c.Assert(err, gc.IsNil)
 	defer r.Close()
-	checkMetadata(c, expected, metadata)
+	checkMetadata(c, metadata, expected)
 
 	data, err := ioutil.ReadAll(r)
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(data), gc.Equals, content)
+}
+
+func (s *ImageSuite) createListImageMetadata(c *gc.C) []*imagestorage.Metadata {
+	s.addMetadataDoc(c, "lxc", "trusty", "amd64", 3, "hash(abc)", "images/lxc-trusty-amd64:sha256", "http://lxc-trusty-amd64")
+	metadataLxc := &imagestorage.Metadata{
+		EnvUUID:   "my-uuid",
+		Kind:      "lxc",
+		Series:    "trusty",
+		Arch:      "amd64",
+		SHA256:    "hash(abc)",
+		Size:      3,
+		SourceURL: "http://lxc-trusty-amd64",
+	}
+	s.addMetadataDoc(c, "kvm", "precise", "amd64", 4, "hash(abcd)", "images/kvm-precise-amd64:sha256", "http://kvm-precise-amd64")
+	metadataKvm := &imagestorage.Metadata{
+		EnvUUID:   "my-uuid",
+		Kind:      "kvm",
+		Series:    "precise",
+		Arch:      "amd64",
+		SHA256:    "hash(abcd)",
+		Size:      4,
+		SourceURL: "http://kvm-precise-amd64",
+	}
+	return []*imagestorage.Metadata{metadataLxc, metadataKvm}
+}
+
+func (s *ImageSuite) TestListAllImages(c *gc.C) {
+	testMetadata := s.createListImageMetadata(c)
+	metadata, err := s.storage.ListImages(imagestorage.ImageFilter{})
+	c.Assert(err, gc.IsNil)
+	checkAllMetadata(c, metadata, testMetadata...)
+}
+
+func (s *ImageSuite) TestListImagesByKind(c *gc.C) {
+	testMetadata := s.createListImageMetadata(c)
+	metadata, err := s.storage.ListImages(imagestorage.ImageFilter{Kind: "lxc"})
+	c.Assert(err, gc.IsNil)
+	checkAllMetadata(c, metadata, testMetadata[0])
+}
+
+func (s *ImageSuite) TestListImagesBySeries(c *gc.C) {
+	testMetadata := s.createListImageMetadata(c)
+	metadata, err := s.storage.ListImages(imagestorage.ImageFilter{Series: "precise"})
+	c.Assert(err, gc.IsNil)
+	checkAllMetadata(c, metadata, testMetadata[1])
+}
+
+func (s *ImageSuite) TestListImagesByArch(c *gc.C) {
+	testMetadata := s.createListImageMetadata(c)
+	metadata, err := s.storage.ListImages(imagestorage.ImageFilter{Arch: "amd64"})
+	c.Assert(err, gc.IsNil)
+	checkAllMetadata(c, metadata, testMetadata...)
+}
+
+func (s *ImageSuite) TestListImagesNoMatch(c *gc.C) {
+	metadata, err := s.storage.ListImages(imagestorage.ImageFilter{Series: "utopic"})
+	c.Assert(err, gc.IsNil)
+	checkAllMetadata(c, metadata)
+}
+
+func (s *ImageSuite) TestListImagesMultiFilter(c *gc.C) {
+	testMetadata := s.createListImageMetadata(c)
+	metadata, err := s.storage.ListImages(imagestorage.ImageFilter{Series: "trusty", Arch: "amd64"})
+	c.Assert(err, gc.IsNil)
+	checkAllMetadata(c, metadata, testMetadata[0])
 }

--- a/state/imagestorage/interface.go
+++ b/state/imagestorage/interface.go
@@ -10,13 +10,21 @@ import (
 
 // Metadata describes an image blob.
 type Metadata struct {
-	EnvUUID string
-	Series  string
-	Arch    string
-	Kind    string
-	Size    int64
-	SHA256  string
-	Created time.Time
+	EnvUUID   string
+	Series    string
+	Arch      string
+	Kind      string
+	Size      int64
+	SHA256    string
+	Created   time.Time
+	SourceURL string
+}
+
+// ImageFilter is used to query image metadata.
+type ImageFilter struct {
+	Kind   string
+	Series string
+	Arch   string
 }
 
 // Storage provides methods for storing and retrieving images by kind, series, and arch.
@@ -32,4 +40,7 @@ type Storage interface {
 	// for the specified kind, series, arch if it exists, else an error
 	// satisfying errors.IsNotFound.
 	Image(kind, series, arch string) (*Metadata, io.ReadCloser, error)
+
+	// ListImages returns the image metadata matching the specified filter.
+	ListImages(filter ImageFilter) ([]*Metadata, error)
 }


### PR DESCRIPTION
This branch adds API calls to be able to list and delete cached lxc and kvm images in the environment blob store. The next branch will provide a juju command to use the new API.

Also, fixes were made to the stored image metadata. The source URL of the image was added, as well as the env uuid. The latter is so that searches could be done for list image.

(Review request: http://reviews.vapour.ws/r/689/)