### PR TITLE
Local environment owners must exist.

### DIFF
--- a/state/environ.go
+++ b/state/environ.go
@@ -106,6 +106,12 @@ func (st *State) GetEnvironment(tag names.EnvironTag) (*Environment, error) {
 // environments, perhaps for future use around cross environment
 // relations.
 func (st *State) NewEnvironment(cfg *config.Config, owner names.UserTag) (_ *Environment, _ *State, err error) {
+	if owner.IsLocal() {
+		if _, err := st.User(owner); err != nil {
+			return nil, nil, errors.Annotate(err, "cannot create environment")
+		}
+	}
+
 	ssEnv, err := st.StateServerEnvironment()
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "could not load state server environment")

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -37,7 +37,7 @@ func (s *EnvironSuite) TestEnvironment(c *gc.C) {
 	})
 }
 
-func (s *EnvironSuite) TestNewEnvironmentNonExistantLocalUser(c *gc.C) {
+func (s *EnvironSuite) TestNewEnvironmentNonExistentLocalUser(c *gc.C) {
 	cfg, _ := s.createTestEnvConfig(c)
 	owner := names.NewUserTag("non-existent@local")
 

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -37,6 +37,14 @@ func (s *EnvironSuite) TestEnvironment(c *gc.C) {
 	})
 }
 
+func (s *EnvironSuite) TestNewEnvironmentNonExistantLocalUser(c *gc.C) {
+	cfg, _ := s.createTestEnvConfig(c)
+	owner := names.NewUserTag("non-existent@local")
+
+	_, _, err := s.State.NewEnvironment(cfg, owner)
+	c.Assert(err, gc.ErrorMatches, `cannot create environment: user "non-existent" not found`)
+}
+
 func (s *EnvironSuite) TestNewEnvironment(c *gc.C) {
 	cfg, uuid := s.createTestEnvConfig(c)
 	owner := names.NewUserTag("test@remote")

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -512,10 +512,12 @@ func (s *factorySuite) TestMakeEnvironmentNil(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeEnvironment(c *gc.C) {
-	owner := names.NewUserTag("owner@local")
+	owner := s.Factory.MakeUser(c, &factory.UserParams{
+		Name: "owner",
+	})
 	params := &factory.EnvParams{
 		Name:        "foo",
-		Owner:       owner,
+		Owner:       owner.UserTag(),
 		ConfigAttrs: testing.Attrs{"default-series": "precise"},
 	}
 
@@ -526,7 +528,7 @@ func (s *factorySuite) TestMakeEnvironment(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Name(), gc.Equals, "foo")
 	c.Assert(env.UUID() == s.State.EnvironUUID(), jc.IsFalse)
-	c.Assert(env.Owner(), gc.Equals, owner)
+	c.Assert(env.Owner(), gc.Equals, owner.UserTag())
 
 	cfg, err := st.EnvironConfig()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
There was a gap in the test coverage where we didn't check that the owner of a new environment actually existed.

We only need to do this check for local users.

(Review request: http://reviews.vapour.ws/r/690/)