### PR TITLE
New cached-images command

### DIFF
--- a/cmd/juju/cachedimages/cachedimages.go
+++ b/cmd/juju/cachedimages/cachedimages.go
@@ -1,0 +1,48 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cachedimages
+
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/api/imagemanager"
+	"github.com/juju/juju/cmd/envcmd"
+)
+
+const cachedimagesCommandDoc = `
+"juju cached-images" is used to manage the cached os images in
+the Juju environment.
+`
+
+const cachedImagesCommandPurpose = "manage cached os images"
+
+// NewSuperCommand creates the user supercommand and registers the subcommands
+// that it supports.
+func NewSuperCommand() cmd.Command {
+	usercmd := cmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name:        "cached-images",
+		Doc:         cachedimagesCommandDoc,
+		UsagePrefix: "juju",
+		Purpose:     cachedImagesCommandPurpose,
+	})
+	usercmd.Register(envcmd.Wrap(&DeleteCommand{}))
+	usercmd.Register(envcmd.Wrap(&ListCommand{}))
+	return usercmd
+}
+
+// CachedImagesCommandBase is a helper base structure that has a method to get the
+// image manager client.
+type CachedImagesCommandBase struct {
+	envcmd.EnvCommandBase
+}
+
+// NewImagesManagerClient returns a imagemanager client for the root api endpoint
+// that the environment command returns.
+func (c *CachedImagesCommandBase) NewImagesManagerClient() (*imagemanager.Client, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, err
+	}
+	return imagemanager.NewClient(root), nil
+}

--- a/cmd/juju/cachedimages/cachedimages_test.go
+++ b/cmd/juju/cachedimages/cachedimages_test.go
@@ -1,0 +1,32 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cachedimages_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/cachedimages"
+	"github.com/juju/juju/testing"
+)
+
+type cachedImagesSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&cachedImagesSuite{})
+
+var expectedCachedImagesCommmandNames = []string{
+	"delete",
+	"help",
+	"list",
+}
+
+func (s *cachedImagesSuite) TestHelp(c *gc.C) {
+	// Check the help output
+	ctx, err := testing.RunCommand(c, cachedimages.NewSuperCommand(), "--help")
+	c.Assert(err, jc.ErrorIsNil)
+	namesFound := testing.ExtractCommandsFromHelpOutput(ctx)
+	c.Assert(namesFound, gc.DeepEquals, expectedCachedImagesCommmandNames)
+}

--- a/cmd/juju/cachedimages/delete.go
+++ b/cmd/juju/cachedimages/delete.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for infos.
+
+package cachedimages
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+)
+
+const DeleteCommandDoc = `
+Delete cached os images in the Juju environment.
+
+Images are identified by:
+  Kind         eg "lxc"
+  Series       eg "trusty"
+  Architecture eg "amd64"
+
+Examples:
+
+  # Delete cached lxc image for trusty amd64.
+  juju cache-images delete --kind lxc --series trusty --arch amd64
+`
+
+// DeleteCommand shows the images in the Juju server.
+type DeleteCommand struct {
+	CachedImagesCommandBase
+	Kind, Series, Arch string
+}
+
+// Info implements Command.Info.
+func (c *DeleteCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "delete",
+		Purpose: "delete cached os images",
+		Doc:     DeleteCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *DeleteCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CachedImagesCommandBase.SetFlags(f)
+	f.StringVar(&c.Kind, "kind", "", "the image kind to delete eg lxc")
+	f.StringVar(&c.Series, "series", "", "the series of the image to delete eg trusty")
+	f.StringVar(&c.Arch, "arch", "", "the architecture of the image to delete eg amd64")
+}
+
+// Init implements Command.Init.
+func (c *DeleteCommand) Init(args []string) (err error) {
+	if c.Kind == "" {
+		return errors.New("image kind must be specified")
+	}
+	if c.Series == "" {
+		return errors.New("image series must be specified")
+	}
+	if c.Arch == "" {
+		return errors.New("image architecture must be specified")
+	}
+	return cmd.CheckEmpty(args)
+}
+
+// DeleteImageAPI defines the imagemanager API methods that the delete command uses.
+type DeleteImageAPI interface {
+	DeleteImage(kind, series, arch string) error
+	Close() error
+}
+
+var getDeleteImageAPI = func(p *DeleteCommand) (DeleteImageAPI, error) {
+	return p.NewImagesManagerClient()
+}
+
+// Run implements Command.Run.
+func (c *DeleteCommand) Run(ctx *cmd.Context) (err error) {
+	client, err := getDeleteImageAPI(c)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	return client.DeleteImage(c.Kind, c.Series, c.Arch)
+}

--- a/cmd/juju/cachedimages/delete_test.go
+++ b/cmd/juju/cachedimages/delete_test.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for info.
+
+package cachedimages_test
+
+import (
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/cachedimages"
+	"github.com/juju/juju/testing"
+)
+
+type deleteImageCommandSuite struct {
+	testing.FakeJujuHomeSuite
+	mockAPI *fakeImageDeleteAPI
+}
+
+var _ = gc.Suite(&deleteImageCommandSuite{})
+
+type fakeImageDeleteAPI struct {
+	kind   string
+	series string
+	arch   string
+}
+
+func (*fakeImageDeleteAPI) Close() error {
+	return nil
+}
+
+func (f *fakeImageDeleteAPI) DeleteImage(kind, series, arch string) error {
+	f.kind = kind
+	f.series = series
+	f.arch = arch
+	return nil
+}
+
+func (s *deleteImageCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+	s.mockAPI = &fakeImageDeleteAPI{}
+	s.PatchValue(cachedimages.GetDeleteImageAPI, func(c *cachedimages.DeleteCommand) (cachedimages.DeleteImageAPI, error) {
+		return s.mockAPI, nil
+	})
+}
+
+func runDeleteCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, envcmd.Wrap(&cachedimages.DeleteCommand{}), args...)
+}
+
+func (s *deleteImageCommandSuite) TestDeleteImage(c *gc.C) {
+	_, err := runDeleteCommand(c, "--kind", "lxc", "--series", "trusty", "--arch", "amd64")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.mockAPI.kind, gc.Equals, "lxc")
+	c.Assert(s.mockAPI.series, gc.Equals, "trusty")
+	c.Assert(s.mockAPI.arch, gc.Equals, "amd64")
+}
+
+func (*deleteImageCommandSuite) TestTooManyArgs(c *gc.C) {
+	_, err := runDeleteCommand(c, "--kind", "lxc", "--series", "trusty", "--arch", "amd64", "bad")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["bad"\]`)
+}
+
+func (*deleteImageCommandSuite) TestKindRequired(c *gc.C) {
+	_, err := runDeleteCommand(c, "--series", "trusty", "--arch", "amd64", "bad")
+	c.Assert(err, gc.ErrorMatches, `image kind must be specified`)
+}
+
+func (*deleteImageCommandSuite) TestSeriesRequired(c *gc.C) {
+	_, err := runDeleteCommand(c, "--kind", "lxc", "--arch", "amd64", "bad")
+	c.Assert(err, gc.ErrorMatches, `image series must be specified`)
+}
+
+func (*deleteImageCommandSuite) TestArchRequired(c *gc.C) {
+	_, err := runDeleteCommand(c, "--kind", "lxc", "--series", "trusty", "bad")
+	c.Assert(err, gc.ErrorMatches, `image architecture must be specified`)
+}

--- a/cmd/juju/cachedimages/export_test.go
+++ b/cmd/juju/cachedimages/export_test.go
@@ -1,0 +1,9 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cachedimages
+
+var (
+	GetListImagesAPI  = &getListImagesAPI
+	GetDeleteImageAPI = &getDeleteImageAPI
+)

--- a/cmd/juju/cachedimages/list.go
+++ b/cmd/juju/cachedimages/list.go
@@ -1,0 +1,123 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for infos.
+
+package cachedimages
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+const ListCommandDoc = `
+List cached os images in the Juju environment.
+
+Images can be filtered on:
+  Kind         eg "lxc"
+  Series       eg "trusty"
+  Architecture eg "amd64"
+The filter attributes are optional.
+
+Examples:
+
+  # List all cached images.
+  juju cache-images list
+
+  # List cached images for trusty.
+  juju cache-images list --series trusty
+
+  # List all cached lxc images for trusty amd64.
+  juju cache-images list --kind lxc --series trusty --arch amd64
+`
+
+// ListCommand shows the images in the Juju server.
+type ListCommand struct {
+	CachedImagesCommandBase
+	out                cmd.Output
+	Kind, Series, Arch string
+}
+
+// Info implements Command.Info.
+func (c *ListCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "list",
+		Purpose: "shows cached os images",
+		Doc:     ListCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CachedImagesCommandBase.SetFlags(f)
+	f.StringVar(&c.Kind, "kind", "", "the image kind to list eg lxc")
+	f.StringVar(&c.Series, "series", "", "the series of the image to list eg trusty")
+	f.StringVar(&c.Arch, "arch", "", "the architecture of the image to list eg amd64")
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements Command.Init.
+func (c *ListCommand) Init(args []string) (err error) {
+	return cmd.CheckEmpty(args)
+}
+
+// ListImagesAPI defines the imagemanager API methods that the list command uses.
+type ListImagesAPI interface {
+	ListImages(kind, series, arch string) ([]params.ImageMetadata, error)
+	Close() error
+}
+
+var getListImagesAPI = func(p *ListCommand) (ListImagesAPI, error) {
+	return p.NewImagesManagerClient()
+}
+
+// ImageInfo defines the serialization behaviour of image metadata.
+type ImageInfo struct {
+	Kind      string `yaml:"kind" json:"kind"`
+	Series    string `yaml:"series" json:"series"`
+	Arch      string `yaml:"arch" json:"arch"`
+	SourceURL string `yaml:"source-url" json:"source-url"`
+	Created   string `yaml:"created" json:"created"`
+}
+
+func (c *ListCommand) imageMetadataToImageInfo(images []params.ImageMetadata) []ImageInfo {
+	var output []ImageInfo
+	for _, metadata := range images {
+		imageInfo := ImageInfo{
+			Kind:      metadata.Kind,
+			Series:    metadata.Series,
+			Arch:      metadata.Arch,
+			Created:   metadata.Created.Format(time.RFC1123),
+			SourceURL: metadata.URL,
+		}
+		output = append(output, imageInfo)
+	}
+	return output
+}
+
+// Run implements Command.Run.
+func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
+	client, err := getListImagesAPI(c)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	results, err := client.ListImages(c.Kind, c.Series, c.Arch)
+	if err != nil {
+		return err
+	}
+	imageInfo := c.imageMetadataToImageInfo(results)
+	if len(imageInfo) == 0 {
+		fmt.Fprintf(ctx.Stdout, "no matching images found")
+		return nil
+	}
+	fmt.Fprintf(ctx.Stdout, "Cached images:\n")
+	return c.out.Write(ctx, imageInfo)
+}

--- a/cmd/juju/cachedimages/list.go
+++ b/cmd/juju/cachedimages/list.go
@@ -115,7 +115,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	imageInfo := c.imageMetadataToImageInfo(results)
 	if len(imageInfo) == 0 {
-		fmt.Fprintf(ctx.Stdout, "no matching images found")
+		fmt.Fprintf(ctx.Stdout, "no matching images found\n")
 		return nil
 	}
 	fmt.Fprintf(ctx.Stdout, "Cached images:\n")

--- a/cmd/juju/cachedimages/list_test.go
+++ b/cmd/juju/cachedimages/list_test.go
@@ -60,7 +60,7 @@ func runListCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 func (*listImagesCommandSuite) TestListImagesNone(c *gc.C) {
 	context, err := runListCommand(c, "--kind", "kvm")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, "no matching images found")
+	c.Assert(testing.Stdout(context), gc.Equals, "no matching images found\n")
 }
 
 func (*listImagesCommandSuite) TestListImagesFormatJson(c *gc.C) {

--- a/cmd/juju/cachedimages/list_test.go
+++ b/cmd/juju/cachedimages/list_test.go
@@ -1,0 +1,88 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for info.
+
+package cachedimages_test
+
+import (
+	"time"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/cachedimages"
+	"github.com/juju/juju/testing"
+)
+
+type listImagesCommandSuite struct {
+	testing.FakeJujuHomeSuite
+	mockAPI *fakeImagesListAPI
+}
+
+var _ = gc.Suite(&listImagesCommandSuite{})
+
+type fakeImagesListAPI struct{}
+
+func (*fakeImagesListAPI) Close() error {
+	return nil
+}
+
+func (f *fakeImagesListAPI) ListImages(kind, series, arch string) ([]params.ImageMetadata, error) {
+	if kind != "lxc" {
+		return nil, nil
+	}
+	result := []params.ImageMetadata{
+		{
+			Kind:    kind,
+			Series:  series,
+			Arch:    arch,
+			URL:     "http://image",
+			Created: time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	return result, nil
+}
+
+func (s *listImagesCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+	s.mockAPI = &fakeImagesListAPI{}
+	s.PatchValue(cachedimages.GetListImagesAPI, func(c *cachedimages.ListCommand) (cachedimages.ListImagesAPI, error) {
+		return s.mockAPI, nil
+	})
+}
+
+func runListCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, envcmd.Wrap(&cachedimages.ListCommand{}), args...)
+}
+
+func (*listImagesCommandSuite) TestListImagesNone(c *gc.C) {
+	context, err := runListCommand(c, "--kind", "kvm")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "no matching images found")
+}
+
+func (*listImagesCommandSuite) TestListImagesFormatJson(c *gc.C) {
+	context, err := runListCommand(c, "--format", "json", "--kind", "lxc", "--series", "trusty", "--arch", "amd64")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "Cached images:\n["+
+		`{"kind":"lxc","series":"trusty","arch":"amd64","source-url":"http://image","created":"Thu, 01 Jan 2015 00:00:00 UTC"}`+
+		"]\n")
+}
+
+func (*listImagesCommandSuite) TestListImagesFormatYaml(c *gc.C) {
+	context, err := runListCommand(c, "--format", "yaml", "--kind", "lxc", "--series", "trusty", "--arch", "amd64")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "Cached images:\n"+
+		"- kind: lxc\n"+
+		"  series: trusty\n"+
+		"  arch: amd64\n"+
+		"  source-url: http://image\n"+
+		"  created: Thu, 01 Jan 2015 00:00:00 UTC\n")
+}
+
+func (*listImagesCommandSuite) TestTooManyArgs(c *gc.C) {
+	_, err := runListCommand(c, "bad")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["bad"\]`)
+}

--- a/cmd/juju/cachedimages/package_test.go
+++ b/cmd/juju/cachedimages/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cachedimages_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/cmd/juju/backups"
 	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/juju/cachedimages"
 	"github.com/juju/juju/cmd/juju/environment"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/cmd/juju/user"
@@ -163,6 +164,9 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage users and access
 	r.Register(user.NewSuperCommand())
+
+	// Manage cached images
+	r.Register(cachedimages.NewSuperCommand())
 
 	// Manage machines
 	r.Register(machine.NewSuperCommand())

--- a/cmd/juju/main_test.go
+++ b/cmd/juju/main_test.go
@@ -187,6 +187,7 @@ var commandNames = []string{
 	"backups",
 	"block",
 	"bootstrap",
+	"cached-images",
 	"debug-hooks",
 	"debug-log",
 	"deploy",


### PR DESCRIPTION
A new cached-images command is added to allow the user to list and delete cached os images stored in the environment.

(Review request: http://reviews.vapour.ws/r/692/)