### PR TITLE
Fixes bug #1386425: juju authorised-keys import only imports last key

### DIFF
--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -250,14 +250,14 @@ func runSSHKeyImport(keyIds []string) []importedSSHKey {
 			// ignore key comment (e.g., user@host)
 			fingerprint, _, err := ssh.KeyFingerprint(line)
 			keyInfo = append(keyInfo, importedSSHKey{
-				key: line,
+				key:         line,
 				fingerprint: fingerprint,
-				err: errors.Annotatef(err, "invalid ssh key for %s", keyId),
+				err:         errors.Annotatef(err, "invalid ssh key for %s", keyId),
 			})
 		}
 		if !hasKey {
 			keyInfo = append(keyInfo, importedSSHKey{
-			    err: fmt.Errorf("invalid ssh key id: %s", keyId),
+				err: fmt.Errorf("invalid ssh key id: %s", keyId),
 			})
 		}
 	}

--- a/apiserver/keymanager/keymanager.go
+++ b/apiserver/keymanager/keymanager.go
@@ -247,19 +247,13 @@ func runSSHKeyImport(keyIds []string) []importedSSHKey {
 				continue
 			}
 			hasKey = true
+			// ignore key comment (e.g., user@host)
 			fingerprint, _, err := ssh.KeyFingerprint(line)
-			if err == nil {
-				keyInfo = append(keyInfo, importedSSHKey{
-				    key: line,
-				    fingerprint: fingerprint,
-				})
-			} else {
-				keyInfo = append(keyInfo, importedSSHKey{
-				    key: "",
-				    fingerprint: fingerprint,
-				    err: fmt.Errorf("invalid ssh key for %s: %s", keyId, line),
-				})
-			}
+			keyInfo = append(keyInfo, importedSSHKey{
+				key: line,
+				fingerprint: fingerprint,
+				err: errors.Annotatef(err, "invalid ssh key for %s", keyId),
+			})
 		}
 		if !hasKey {
 			keyInfo = append(keyInfo, importedSSHKey{

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -298,12 +298,14 @@ func (s *keyManagerSuite) TestImportKeys(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	key2 := sshtesting.ValidKeyTwo.Key
 	key3 := sshtesting.ValidKeyThree.Key
+	keymv := strings.Split(sshtesting.ValidKeyMulti, "\n")
+	keymp := strings.Split(sshtesting.PartValidKeyMulti, "\n")
 	initialKeys := []string{key1, key2, "bad key"}
 	s.setAuthorisedKeys(c, strings.Join(initialKeys, "\n"))
 
 	args := params.ModifyUserSSHKeys{
 		User: s.AdminUserTag(c).Name(),
-		Keys: []string{"lp:existing", "lp:validuser", "invalid-key"},
+		Keys: []string{"lp:existing", "lp:validuser", "invalid-key", "lp:multi", "lp:multiempty", "lp:multipartial"},
 	}
 	results, err := s.keymanager.ImportKeys(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -312,9 +314,14 @@ func (s *keyManagerSuite) TestImportKeys(c *gc.C) {
 			{Error: apiservertesting.ServerError(fmt.Sprintf("duplicate ssh key: %s", key2))},
 			{Error: nil},
 			{Error: apiservertesting.ServerError("invalid ssh key id: invalid-key")},
+			{Error: nil},
+			{Error: nil},
+			{Error: apiservertesting.ServerError("invalid ssh key id: lp:multiempty")},
+			{Error: nil},
+			{Error: apiservertesting.ServerError(fmt.Sprintf("invalid ssh key for lp:multipartial: %s", keymp[1]))},
 		},
 	})
-	s.assertEnvironKeys(c, append(initialKeys, key3))
+	s.assertEnvironKeys(c, append(initialKeys, key3, keymv[0], keymv[1], keymp[0]))
 }
 
 func (s *keyManagerSuite) TestBlockImportKeys(c *gc.C) {

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -305,7 +305,14 @@ func (s *keyManagerSuite) TestImportKeys(c *gc.C) {
 
 	args := params.ModifyUserSSHKeys{
 		User: s.AdminUserTag(c).Name(),
-		Keys: []string{"lp:existing", "lp:validuser", "invalid-key", "lp:multi", "lp:multiempty", "lp:multipartial"},
+		Keys: []string{
+			"lp:existing",
+			"lp:validuser",
+			"invalid-key",
+			"lp:multi",
+			"lp:multiempty",
+			"lp:multipartial",
+		},
 	}
 	results, err := s.keymanager.ImportKeys(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -318,7 +325,10 @@ func (s *keyManagerSuite) TestImportKeys(c *gc.C) {
 			{Error: nil},
 			{Error: apiservertesting.ServerError("invalid ssh key id: lp:multiempty")},
 			{Error: nil},
-			{Error: apiservertesting.ServerError(fmt.Sprintf("invalid ssh key for lp:multipartial: %s", keymp[1]))},
+			{Error: apiservertesting.ServerError(fmt.Sprintf(
+				`invalid ssh key for lp:multipartial: ` +
+				`generating key fingerprint: ` +
+				`invalid authorized_key "%s"`, keymp[1]))},
 		},
 	})
 	s.assertEnvironKeys(c, append(initialKeys, key3, keymv[0], keymv[1], keymp[0]))

--- a/apiserver/keymanager/keymanager_test.go
+++ b/apiserver/keymanager/keymanager_test.go
@@ -326,9 +326,9 @@ func (s *keyManagerSuite) TestImportKeys(c *gc.C) {
 			{Error: apiservertesting.ServerError("invalid ssh key id: lp:multiempty")},
 			{Error: nil},
 			{Error: apiservertesting.ServerError(fmt.Sprintf(
-				`invalid ssh key for lp:multipartial: ` +
-				`generating key fingerprint: ` +
-				`invalid authorized_key "%s"`, keymp[1]))},
+				`invalid ssh key for lp:multipartial: `+
+					`generating key fingerprint: `+
+					`invalid authorized_key "%s"`, keymp[1]))},
 		},
 	})
 	s.assertEnvironKeys(c, append(initialKeys, key3, keymv[0], keymv[1], keymp[0]))

--- a/apiserver/keymanager/testing/fakesshimport.go
+++ b/apiserver/keymanager/testing/fakesshimport.go
@@ -12,6 +12,9 @@ import (
 var importResponses = map[string]string{
 	"lp:validuser": sshtesting.ValidKeyThree.Key,
 	"lp:existing":  sshtesting.ValidKeyTwo.Key,
+	"lp:multi":  sshtesting.ValidKeyMulti,
+	"lp:multipartial":  sshtesting.PartValidKeyMulti,
+	"lp:multiempty":  sshtesting.EmptyKeyMulti,
 }
 
 var FakeImport = func(keyId string) (string, error) {

--- a/apiserver/keymanager/testing/fakesshimport.go
+++ b/apiserver/keymanager/testing/fakesshimport.go
@@ -10,11 +10,11 @@ import (
 )
 
 var importResponses = map[string]string{
-	"lp:validuser": sshtesting.ValidKeyThree.Key,
-	"lp:existing":  sshtesting.ValidKeyTwo.Key,
-	"lp:multi":  sshtesting.ValidKeyMulti,
-	"lp:multipartial":  sshtesting.PartValidKeyMulti,
-	"lp:multiempty":  sshtesting.EmptyKeyMulti,
+	"lp:validuser":    sshtesting.ValidKeyThree.Key,
+	"lp:existing":     sshtesting.ValidKeyTwo.Key,
+	"lp:multi":        sshtesting.ValidKeyMulti,
+	"lp:multipartial": sshtesting.PartValidKeyMulti,
+	"lp:multiempty":   sshtesting.EmptyKeyMulti,
 }
 
 var FakeImport = func(keyId string) (string, error) {

--- a/utils/ssh/testing/keys.go
+++ b/utils/ssh/testing/keys.go
@@ -43,28 +43,28 @@ var (
 	}
 
 	ValidKeyMulti = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDW+8zWO6qqXrHlcMK7obliuYp7D` +
-				`vZBsK6rHlnbeV5Hh38Qn0GUX4Ahm6XeQ/NSx53wqkBQDGOJFY3s4w1a/hbd` +
-				`PyLM2/yFXCYsj5FRf01JmUjAzWhuJMH9ViqzD//l4v8cR/pHC2B8PD6abKd` +
-				`mIH+yLI9Cl3C4ICMKteG54egsUyboBOVKCDIKmWRLAak6sE5DPpqKF53NvD` +
-				`cuDufWtaCfVAOrq6NW8wSQ7PAvfDh8gsG5uvZjY3gcWl9yI3EJVGFHcdxcv` +
-				`4LtQI8mKdeg3JoufnEmeBJTZMoo83Gru5Z7tjv8J4JTUeQpd9uCCED1JAMe` +
-				`cJSKgQ2gZMTbTshobpHr` + "\n" +
-			`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSgfrzyGpE5eLiXusvLcxEmoE6e` +
-				`SMUDvTW1dd2BZgfvUVwq+toQdZ6C0C1JmbC3X563n8fmKVUAQGo5JavzABG` +
-				`Kpy90L3cwoGCFtb+A28YsT+bfuP+LdnCbFXm9c3DPJQx6Dch8prnDtzRjRV` +
-				`CorbPvm35NY73liUXVF6g58Owlx5rWtb8OnoTh5KQps9JTSfyNckdV9bFxP` +
-				`7bZvMyRYW5X33KaA+CQGpTNAKDHruSuKdAdaS6rBIZRvzzzSCF28BWwFL7Z` +
-				`ghQo0ADlUMnqIeQ58nwRImZHpmvadsZi47aMKFeykk4JQUQlwjbM0xGi0uj` +
-				`+hlaqGYbNo0Evcjn23cj`
+		`vZBsK6rHlnbeV5Hh38Qn0GUX4Ahm6XeQ/NSx53wqkBQDGOJFY3s4w1a/hbd` +
+		`PyLM2/yFXCYsj5FRf01JmUjAzWhuJMH9ViqzD//l4v8cR/pHC2B8PD6abKd` +
+		`mIH+yLI9Cl3C4ICMKteG54egsUyboBOVKCDIKmWRLAak6sE5DPpqKF53NvD` +
+		`cuDufWtaCfVAOrq6NW8wSQ7PAvfDh8gsG5uvZjY3gcWl9yI3EJVGFHcdxcv` +
+		`4LtQI8mKdeg3JoufnEmeBJTZMoo83Gru5Z7tjv8J4JTUeQpd9uCCED1JAMe` +
+		`cJSKgQ2gZMTbTshobpHr` + "\n" +
+		`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSgfrzyGpE5eLiXusvLcxEmoE6e` +
+		`SMUDvTW1dd2BZgfvUVwq+toQdZ6C0C1JmbC3X563n8fmKVUAQGo5JavzABG` +
+		`Kpy90L3cwoGCFtb+A28YsT+bfuP+LdnCbFXm9c3DPJQx6Dch8prnDtzRjRV` +
+		`CorbPvm35NY73liUXVF6g58Owlx5rWtb8OnoTh5KQps9JTSfyNckdV9bFxP` +
+		`7bZvMyRYW5X33KaA+CQGpTNAKDHruSuKdAdaS6rBIZRvzzzSCF28BWwFL7Z` +
+		`ghQo0ADlUMnqIeQ58nwRImZHpmvadsZi47aMKFeykk4JQUQlwjbM0xGi0uj` +
+		`+hlaqGYbNo0Evcjn23cj`
 
 	PartValidKeyMulti = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZRvG2miYVkbWOr2I+9xHWXqALb` +
-				`eBcyxAlYtbjxBRwrq8oFOw9vtIIZSO0r1FM6+JHzKhLSiPCMR/PK78ZqPgZ` +
-				`fia8Y7cEZKaUWLtZUAl0RF9w8EtsA/2gpuLZErjcoIx6fzfEYFCJcLgcQSc` +
-				`RlKG8VZT6tWIjvoLj9ki6unkG5YGmapkT60afhf3/vd7pCJO/uyszkQ9qU8` +
-				`odUDTTlwftpJtUb8xGmzpEZJTgk1lbZKlZm5pVXwjNEodH7Je88RBzR7PBB` +
-				`Jct+vf8wVJ/UEFXCnamvHLanJTcJIi/I5qRlKns65Bwb8M0HszPYmvTfFRD` +
-				`ZLi3sPUmw6PJCJ0SgATd` + "\n" +
-			`ssh-rsa bad key`
+		`eBcyxAlYtbjxBRwrq8oFOw9vtIIZSO0r1FM6+JHzKhLSiPCMR/PK78ZqPgZ` +
+		`fia8Y7cEZKaUWLtZUAl0RF9w8EtsA/2gpuLZErjcoIx6fzfEYFCJcLgcQSc` +
+		`RlKG8VZT6tWIjvoLj9ki6unkG5YGmapkT60afhf3/vd7pCJO/uyszkQ9qU8` +
+		`odUDTTlwftpJtUb8xGmzpEZJTgk1lbZKlZm5pVXwjNEodH7Je88RBzR7PBB` +
+		`Jct+vf8wVJ/UEFXCnamvHLanJTcJIi/I5qRlKns65Bwb8M0HszPYmvTfFRD` +
+		`ZLi3sPUmw6PJCJ0SgATd` + "\n" +
+		`ssh-rsa bad key`
 
 	EmptyKeyMulti = ""
 )

--- a/utils/ssh/testing/keys.go
+++ b/utils/ssh/testing/keys.go
@@ -41,4 +41,30 @@ var (
 			`SQwJ/6QHvf73yksJTncz`,
 		"1d:cf:ab:66:8a:f6:77:fb:4c:b2:59:6f:12:cf:cb:2f",
 	}
+
+	ValidKeyMulti = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDW+8zWO6qqXrHlcMK7obliuYp7D` +
+				`vZBsK6rHlnbeV5Hh38Qn0GUX4Ahm6XeQ/NSx53wqkBQDGOJFY3s4w1a/hbd` +
+				`PyLM2/yFXCYsj5FRf01JmUjAzWhuJMH9ViqzD//l4v8cR/pHC2B8PD6abKd` +
+				`mIH+yLI9Cl3C4ICMKteG54egsUyboBOVKCDIKmWRLAak6sE5DPpqKF53NvD` +
+				`cuDufWtaCfVAOrq6NW8wSQ7PAvfDh8gsG5uvZjY3gcWl9yI3EJVGFHcdxcv` +
+				`4LtQI8mKdeg3JoufnEmeBJTZMoo83Gru5Z7tjv8J4JTUeQpd9uCCED1JAMe` +
+				`cJSKgQ2gZMTbTshobpHr` + "\n" +
+			`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSgfrzyGpE5eLiXusvLcxEmoE6e` +
+				`SMUDvTW1dd2BZgfvUVwq+toQdZ6C0C1JmbC3X563n8fmKVUAQGo5JavzABG` +
+				`Kpy90L3cwoGCFtb+A28YsT+bfuP+LdnCbFXm9c3DPJQx6Dch8prnDtzRjRV` +
+				`CorbPvm35NY73liUXVF6g58Owlx5rWtb8OnoTh5KQps9JTSfyNckdV9bFxP` +
+				`7bZvMyRYW5X33KaA+CQGpTNAKDHruSuKdAdaS6rBIZRvzzzSCF28BWwFL7Z` +
+				`ghQo0ADlUMnqIeQ58nwRImZHpmvadsZi47aMKFeykk4JQUQlwjbM0xGi0uj` +
+				`+hlaqGYbNo0Evcjn23cj`
+
+	PartValidKeyMulti = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZRvG2miYVkbWOr2I+9xHWXqALb` +
+				`eBcyxAlYtbjxBRwrq8oFOw9vtIIZSO0r1FM6+JHzKhLSiPCMR/PK78ZqPgZ` +
+				`fia8Y7cEZKaUWLtZUAl0RF9w8EtsA/2gpuLZErjcoIx6fzfEYFCJcLgcQSc` +
+				`RlKG8VZT6tWIjvoLj9ki6unkG5YGmapkT60afhf3/vd7pCJO/uyszkQ9qU8` +
+				`odUDTTlwftpJtUb8xGmzpEZJTgk1lbZKlZm5pVXwjNEodH7Je88RBzR7PBB` +
+				`Jct+vf8wVJ/UEFXCnamvHLanJTcJIi/I5qRlKns65Bwb8M0HszPYmvTfFRD` +
+				`ZLi3sPUmw6PJCJ0SgATd` + "\n" +
+			`ssh-rsa bad key`
+
+	EmptyKeyMulti = ""
 )


### PR DESCRIPTION
Fixes [bug #1386425](https://bugs.launchpad.net/juju-core/+bug/1386425) to import all keys for a given key id.

NB: New to go, so constructive criticism for making things more idiomatic, efficient, etc. appreciated.

(Review request: http://reviews.vapour.ws/r/694/)