### PR TITLE
Multi-environment filtering for the Allwatcher

### DIFF
--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -71,10 +71,6 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id interfa
 }
 
 func (m *backingMachine) removed(st *State, store *multiwatcherStore, id interface{}) {
-	// TODO(mjs) This isn't correct - the store should be using
-	// environment UUID prefixed ids but we can't fix it properly
-	// until davecheney smashes the allwatcher to apiserver/params
-	// dependency.
 	store.Remove(multiwatcher.EntityId{
 		Kind: "machine",
 		Id:   st.localID(id.(string)),
@@ -154,7 +150,6 @@ func getUnitAddresses(st *State, unitName string) (publicAddress, privateAddress
 }
 
 func (u *backingUnit) removed(st *State, store *multiwatcherStore, id interface{}) {
-	// TODO(mjs) as per backingMachine.removed()
 	store.Remove(multiwatcher.EntityId{
 		Kind: "unit",
 		Id:   st.localID(id.(string)),
@@ -221,7 +216,6 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id inter
 }
 
 func (svc *backingService) removed(st *State, store *multiwatcherStore, id interface{}) {
-	// TODO(mjs) as per backingMachine.removed()
 	store.Remove(multiwatcher.EntityId{
 		Kind: "service",
 		Id:   st.localID(id.(string)),
@@ -261,7 +255,6 @@ func (r *backingRelation) updated(st *State, store *multiwatcherStore, id interf
 }
 
 func (r *backingRelation) removed(st *State, store *multiwatcherStore, id interface{}) {
-	// TODO(mjs) as per backingMachine.removed()
 	store.Remove(multiwatcher.EntityId{
 		Kind: "relation",
 		Id:   st.localID(id.(string)),
@@ -532,10 +525,15 @@ func newAllWatcherStateBacking(st *State) Backing {
 	return b
 }
 
+func (b *allWatcherStateBacking) filterEnv(docID interface{}) bool {
+	_, err := b.st.strictLocalID(docID.(string))
+	return err == nil
+}
+
 // Watch watches all the collections.
 func (b *allWatcherStateBacking) Watch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.watcher.WatchCollection(c.Name, in)
+		b.st.watcher.WatchCollectionWithFilter(c.Name, in, b.filterEnv)
 	}
 }
 


### PR DESCRIPTION
These changes are all about ensuring that the AllWatcher only sends events for the correct environment. The actual change for this is small (allWatcherStateBacking.Watch() is the critical part) - most of this pull request is the tests.

(Review request: http://reviews.vapour.ws/r/697/)