### PR TITLE
Store params for requested block devices in state

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -36,7 +36,8 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/presence"
-	"github.com/juju/juju/state/storage"
+	statestorage "github.com/juju/juju/state/storage"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -2788,6 +2789,36 @@ func (s *clientSuite) TestClientAddMachinesWithPlacement(c *gc.C) {
 	c.Assert(m.Placement(), gc.DeepEquals, apiParams[3].Placement.Directive)
 }
 
+func (s *clientSuite) TestClientAddMachinesWithDisks(c *gc.C) {
+	apiParams := make([]params.AddMachineParams, 3)
+	for i := range apiParams {
+		apiParams[i] = params.AddMachineParams{
+			Jobs: []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+		}
+	}
+	apiParams[0].Disks = []storage.Constraints{{Size: 1, Count: 2}, {Size: 2, Count: 1}}
+	apiParams[1].Disks = []storage.Constraints{{Size: 1, Count: 2, Pool: "three"}}
+	apiParams[2].Disks = []storage.Constraints{{Size: 0, Count: 0}}
+	machines, err := s.APIState.Client().AddMachines(apiParams)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(machines), gc.Equals, 3)
+	c.Assert(machines[0].Machine, gc.Equals, "0")
+	c.Assert(machines[1].Error, gc.ErrorMatches, "cannot compute block device parameters: storage pools not implemented")
+	c.Assert(machines[2].Error, gc.ErrorMatches, "cannot compute block device parameters: invalid size 0")
+
+	m, err := s.BackingState.Machine(machines[0].Machine)
+	c.Assert(err, jc.ErrorIsNil)
+	blockDevices, err := m.BlockDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	expectParams := []state.BlockDeviceParams{{Size: 1}, {Size: 1}, {Size: 2}}
+	c.Assert(blockDevices, gc.HasLen, len(expectParams))
+	for i, dev := range blockDevices {
+		params, ok := dev.Params()
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(params, gc.DeepEquals, expectParams[i])
+	}
+}
+
 func (s *clientSuite) TestClientAddMachines1dot18(c *gc.C) {
 	apiParams := make([]params.AddMachineParams, 2)
 	for i := range apiParams {
@@ -3059,8 +3090,8 @@ func (s *clientSuite) TestAddCharm(c *gc.C) {
 	s.makeMockCharmStore()
 
 	var blobs blobs
-	s.PatchValue(client.NewStateStorage, func(uuid string, session *mgo.Session) storage.Storage {
-		storage := storage.NewStorage(uuid, session)
+	s.PatchValue(client.NewStateStorage, func(uuid string, session *mgo.Session) statestorage.Storage {
+		storage := statestorage.NewStorage(uuid, session)
 		return &recordingStorage{Storage: storage, blobs: &blobs}
 	})
 
@@ -3093,7 +3124,7 @@ func (s *clientSuite) TestAddCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify it's in state and it got uploaded.
-	storage := storage.NewStorage(s.State.EnvironUUID(), s.State.MongoSession())
+	storage := statestorage.NewStorage(s.State.EnvironUUID(), s.State.MongoSession())
 	sch, err = s.State.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertUploaded(c, storage, sch.StoragePath(), sch.BundleSha256())
@@ -3176,7 +3207,7 @@ func (b *blobs) check() {
 }
 
 type recordingStorage struct {
-	storage.Storage
+	statestorage.Storage
 	putBarrier *sync.WaitGroup
 	blobs      *blobs
 }
@@ -3208,8 +3239,8 @@ func (s *clientSuite) TestAddCharmConcurrently(c *gc.C) {
 
 	var putBarrier sync.WaitGroup
 	var blobs blobs
-	s.PatchValue(client.NewStateStorage, func(uuid string, session *mgo.Session) storage.Storage {
-		storage := storage.NewStorage(uuid, session)
+	s.PatchValue(client.NewStateStorage, func(uuid string, session *mgo.Session) statestorage.Storage {
+		storage := statestorage.NewStorage(uuid, session)
 		return &recordingStorage{Storage: storage, blobs: &blobs, putBarrier: &putBarrier}
 	})
 
@@ -3254,7 +3285,7 @@ func (s *clientSuite) TestAddCharmConcurrently(c *gc.C) {
 		}
 	}
 
-	storage := storage.NewStorage(s.State.EnvironUUID(), s.State.MongoSession())
+	storage := statestorage.NewStorage(s.State.EnvironUUID(), s.State.MongoSession())
 	s.assertUploaded(c, storage, sch.StoragePath(), sch.BundleSha256())
 }
 
@@ -3283,7 +3314,7 @@ func (s *clientSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
 }
 
-func (s *clientSuite) assertUploaded(c *gc.C, storage storage.Storage, storagePath, expectedSHA256 string) {
+func (s *clientSuite) assertUploaded(c *gc.C, storage statestorage.Storage, storagePath, expectedSHA256 string) {
 	reader, _, err := storage.Get(storagePath)
 	c.Assert(err, jc.ErrorIsNil)
 	defer reader.Close()

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -123,6 +123,10 @@ type AddMachineParams struct {
 	Constraints constraints.Value
 	Jobs        []multiwatcher.MachineJob
 
+	// Disks describes constraints for disks that must be attached to
+	// the machine when it is provisioned.
+	Disks []storage.Constraints
+
 	// If Placement is non-nil, it contains a placement directive
 	// that will be used to decide how to instantiate the machine.
 	Placement *instance.Placement

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -125,6 +125,8 @@ type AddMachineParams struct {
 
 	// Disks describes constraints for disks that must be attached to
 	// the machine when it is provisioned.
+	//
+	// NOTE: this is ignored unless the "storage" feature flag is enabled.
 	Disks []storage.Constraints
 
 	// If Placement is non-nil, it contains a placement directive

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -120,9 +120,9 @@ func (c *AddCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
 	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "additional machine constraints")
 	if featureflag.Enabled(storage.FeatureFlag) {
-		// NOTE: if/when the feature is removed, check that the
-		// AddMachines facade version supports disks, and error
-		// if it doesn't.
+		// NOTE: if/when the feature flag is removed, bump the client
+		// facade and check that the AddMachines facade version supports
+		// disks, and error if it doesn't.
 		f.Var(disksFlag{&c.Disks}, "disks", "constraints for disks to attach to the machine")
 	}
 }

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils/featureflag"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
@@ -22,6 +23,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/version"
 )
 
@@ -98,8 +100,10 @@ type AddCommand struct {
 	Constraints constraints.Value
 	// Placement is passed verbatim to the API, to be parsed and evaluated server-side.
 	Placement *instance.Placement
-
+	// NumMachines is the number of machines to add.
 	NumMachines int
+	// Disks describes disks that are to be attached to the machine.
+	Disks []storage.Constraints
 }
 
 func (c *AddCommand) Info() *cmd.Info {
@@ -115,6 +119,12 @@ func (c *AddCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Series, "series", "", "the charm series")
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
 	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "additional machine constraints")
+	if featureflag.Enabled(storage.FeatureFlag) {
+		// NOTE: if/when the feature is removed, check that the
+		// AddMachines facade version supports disks, and error
+		// if it doesn't.
+		f.Var(disksFlag{&c.Disks}, "disks", "constraints for disks to attach to the machine")
+	}
 }
 
 func (c *AddCommand) Init(args []string) error {
@@ -228,6 +238,7 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 		Series:      c.Series,
 		Constraints: c.Constraints,
 		Jobs:        jobs,
+		Disks:       c.Disks,
 	}
 	machines := make([]params.AddMachineParams, c.NumMachines)
 	for i := 0; i < c.NumMachines; i++ {

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -3,6 +3,8 @@
 
 package machine
 
+import "github.com/juju/juju/storage"
+
 var (
 	ManualProvisioner = &manualProvisioner
 )
@@ -19,4 +21,8 @@ func NewRemoveCommand(api RemoveMachineAPI) *RemoveCommand {
 	return &RemoveCommand{
 		api: api,
 	}
+}
+
+func NewDisksFlag(disks *[]storage.Constraints) *disksFlag {
+	return &disksFlag{disks}
 }

--- a/cmd/juju/machine/flags.go
+++ b/cmd/juju/machine/flags.go
@@ -1,0 +1,36 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/storage"
+)
+
+type disksFlag struct {
+	disks *[]storage.Constraints
+}
+
+func (f disksFlag) Set(s string) error {
+	for _, field := range strings.Fields(s) {
+		cons, err := storage.ParseConstraints(field)
+		if err != nil {
+			return errors.Annotate(err, "cannot parse disk constraints")
+		}
+		*f.disks = append(*f.disks, cons)
+	}
+	return nil
+}
+
+func (f disksFlag) String() string {
+	strs := make([]string, len(*f.disks))
+	for i, cons := range *f.disks {
+		strs[i] = fmt.Sprint(cons)
+	}
+	return strings.Join(strs, " ")
+}

--- a/cmd/juju/machine/flags.go
+++ b/cmd/juju/machine/flags.go
@@ -16,6 +16,7 @@ type disksFlag struct {
 	disks *[]storage.Constraints
 }
 
+// Set implements gnuflag.Value.Set.
 func (f disksFlag) Set(s string) error {
 	for _, field := range strings.Fields(s) {
 		cons, err := storage.ParseConstraints(field)
@@ -27,6 +28,7 @@ func (f disksFlag) Set(s string) error {
 	return nil
 }
 
+// Set implements gnuflag.Value.String.
 func (f disksFlag) String() string {
 	strs := make([]string, len(*f.disks))
 	for i, cons := range *f.disks {

--- a/cmd/juju/machine/flags_test.go
+++ b/cmd/juju/machine/flags_test.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/machine"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+)
+
+type FlagsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&FlagsSuite{})
+
+func (*FlagsSuite) TestDisksFlagErrors(c *gc.C) {
+	var disks []storage.Constraints
+	f := machine.NewDisksFlag(&disks)
+	err := f.Set("-1")
+	c.Assert(err, gc.ErrorMatches, `cannot parse disk constraints: cannot parse count: count must be greater than zero, got "-1"`)
+	c.Assert(disks, gc.HasLen, 0)
+}
+
+func (*FlagsSuite) TestDisksFlag(c *gc.C) {
+	var disks []storage.Constraints
+	f := machine.NewDisksFlag(&disks)
+	err := f.Set("crystal,1G")
+	c.Assert(err, jc.ErrorIsNil)
+	err = f.Set("2,2G")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(disks, gc.DeepEquals, []storage.Constraints{
+		{Pool: "crystal", Size: 1024, Count: 1},
+		{Size: 2048, Count: 2},
+	})
+}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/proxy"
 	"github.com/juju/utils/set"
 	"github.com/juju/utils/symlink"
@@ -43,6 +44,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -1100,6 +1102,15 @@ func (s *MachineSuite) TestMachineAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineAgentRunsDiskManagerWorker(c *gc.C) {
+	// The disk manager should only run with the feature flag set.
+	s.testMachineAgentRunsDiskManagerWorker(c, false, coretesting.ShortWait)
+
+	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+	s.testMachineAgentRunsDiskManagerWorker(c, true, coretesting.LongWait)
+}
+
+func (s *MachineSuite) testMachineAgentRunsDiskManagerWorker(c *gc.C, shouldRun bool, timeout time.Duration) {
 	// Start the machine agent.
 	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
 	a := s.newAgent(c, m)
@@ -1116,12 +1127,20 @@ func (s *MachineSuite) TestMachineAgentRunsDiskManagerWorker(c *gc.C) {
 	// Wait for worker to be started.
 	select {
 	case <-started:
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timeout while waiting for diskmanager worker to start")
+		if !shouldRun {
+			c.Fatalf("disk manager should not run without feature flag")
+		}
+	case <-time.After(timeout):
+		if shouldRun {
+			c.Fatalf("timeout while waiting for diskmanager worker to start")
+		}
 	}
 }
 
 func (s *MachineSuite) TestDiskManagerWorkerUpdatesState(c *gc.C) {
+	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+
 	expected := []storage.BlockDevice{{DeviceName: "whatever"}}
 	s.PatchValue(&diskmanager.DefaultListBlockDevices, func() ([]storage.BlockDevice, error) {
 		return expected, nil

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1140,7 +1140,9 @@ func (s *MachineSuite) TestDiskManagerWorkerUpdatesState(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		if len(devices) > 0 {
 			c.Assert(devices, gc.HasLen, 1)
-			c.Assert(devices[0].Info().DeviceName, gc.Equals, expected[0].DeviceName)
+			info, err := devices[0].Info()
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(info.DeviceName, gc.Equals, expected[0].DeviceName)
 			return
 		}
 	}

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -58,9 +58,8 @@ type StartInstanceResult struct {
 	// NetworkInfo contains information about configured networks.
 	NetworkInfo []network.Info
 
-	// Disks contains a list of block devices created, each one
-	// corresponding to the DiskParams in the same position of
-	// StartInstanceParams.Disks.
+	// Disks contains a list of block devices created, each one having
+	// the same Name as one of the DiskParams in StartInstanceParams.Disks.
 	Disks []storage.BlockDevice
 }
 

--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -92,6 +92,7 @@ func getBlockDeviceMappings(
 			// TODO(axw) VolumeType, IOPS and DeleteOnTermination
 		}
 		disk := storage.BlockDevice{
+			Name:       params.Name,
 			DeviceName: actualDeviceName,
 			Size:       gibToMib(uint64(mapping.VolumeSize)),
 			// ProviderId will be filled in once the instance has

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -251,7 +251,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 	mdoc := st.machineDocForTemplate(template, strconv.Itoa(seq))
 	prereqOps, machineOp, err := st.insertNewMachineOps(mdoc, template)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Trace(err)
 	}
 	prereqOps = append(prereqOps, st.insertNewContainerRefOp(mdoc.Id))
 	if template.InstanceId != "" {
@@ -331,7 +331,7 @@ func (st *State) addMachineInsideMachineOps(template MachineTemplate, parentId s
 	mdoc.ContainerType = string(containerType)
 	prereqOps, machineOp, err := st.insertNewMachineOps(mdoc, template)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Trace(err)
 	}
 	prereqOps = append(prereqOps,
 		// Update containers record for host machine.
@@ -394,11 +394,11 @@ func (st *State) addMachineInsideNewMachineOps(template, parentTemplate MachineT
 	mdoc.ContainerType = string(containerType)
 	parentPrereqOps, parentOp, err := st.insertNewMachineOps(parentDoc, parentTemplate)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Trace(err)
 	}
 	prereqOps, machineOp, err := st.insertNewMachineOps(mdoc, template)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Trace(err)
 	}
 	prereqOps = append(prereqOps, parentPrereqOps...)
 	prereqOps = append(prereqOps,

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -58,6 +58,10 @@ type MachineTemplate struct {
 	// should be part of.
 	RequestedNetworks []string
 
+	// BlockDevices holds the parameters for block devices that should be
+	// created and attached to the machine.
+	BlockDevices []BlockDeviceParams
+
 	// Nonce holds a unique value that can be used to check
 	// if a new instance was really started for this machine.
 	// See Machine.SetProvisioned. This must be set if InstanceId is set.
@@ -245,7 +249,10 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 		return nil, nil, err
 	}
 	mdoc := st.machineDocForTemplate(template, strconv.Itoa(seq))
-	prereqOps, machineOp := st.insertNewMachineOps(mdoc, template)
+	prereqOps, machineOp, err := st.insertNewMachineOps(mdoc, template)
+	if err != nil {
+		return nil, nil, err
+	}
 	prereqOps = append(prereqOps, st.insertNewContainerRefOp(mdoc.Id))
 	if template.InstanceId != "" {
 		prereqOps = append(prereqOps, txn.Op{
@@ -322,7 +329,10 @@ func (st *State) addMachineInsideMachineOps(template MachineTemplate, parentId s
 	}
 	mdoc := st.machineDocForTemplate(template, newId)
 	mdoc.ContainerType = string(containerType)
-	prereqOps, machineOp := st.insertNewMachineOps(mdoc, template)
+	prereqOps, machineOp, err := st.insertNewMachineOps(mdoc, template)
+	if err != nil {
+		return nil, nil, err
+	}
 	prereqOps = append(prereqOps,
 		// Update containers record for host machine.
 		st.addChildToContainerRefOp(parentId, mdoc.Id),
@@ -382,8 +392,14 @@ func (st *State) addMachineInsideNewMachineOps(template, parentTemplate MachineT
 	}
 	mdoc := st.machineDocForTemplate(template, newId)
 	mdoc.ContainerType = string(containerType)
-	parentPrereqOps, parentOp := st.insertNewMachineOps(parentDoc, parentTemplate)
-	prereqOps, machineOp := st.insertNewMachineOps(mdoc, template)
+	parentPrereqOps, parentOp, err := st.insertNewMachineOps(parentDoc, parentTemplate)
+	if err != nil {
+		return nil, nil, err
+	}
+	prereqOps, machineOp, err := st.insertNewMachineOps(mdoc, template)
+	if err != nil {
+		return nil, nil, err
+	}
 	prereqOps = append(prereqOps, parentPrereqOps...)
 	prereqOps = append(prereqOps,
 		// The host machine doesn't exist yet, create a new containers record.
@@ -414,7 +430,7 @@ func (st *State) machineDocForTemplate(template MachineTemplate, id string) *mac
 // insertNewMachineOps returns operations to insert the given machine
 // document into the database, based on the given template. Only the
 // constraints and networks are used from the template.
-func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate) (prereqOps []txn.Op, machineOp txn.Op) {
+func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate) (prereqOps []txn.Op, machineOp txn.Op, err error) {
 	machineOp = txn.Op{
 		C:      machinesC,
 		Id:     mdoc.DocID,
@@ -422,7 +438,7 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 		Insert: mdoc,
 	}
 
-	return []txn.Op{
+	prereqOps = []txn.Op{
 		createConstraintsOp(st, machineGlobalKey(mdoc.Id), template.Constraints),
 		createStatusOp(st, machineGlobalKey(mdoc.Id), statusDoc{
 			Status:  StatusPending,
@@ -433,7 +449,15 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 		// provisioning, we should check the given networks are valid
 		// and known before setting them.
 		createRequestedNetworksOp(st, machineGlobalKey(mdoc.Id), template.RequestedNetworks),
-	}, machineOp
+	}
+
+	diskOps, err := createMachineBlockDeviceOps(st, mdoc.Id, template.BlockDevices...)
+	if err != nil {
+		return nil, txn.Op{}, errors.Trace(err)
+	}
+	prereqOps = append(prereqOps, diskOps...)
+
+	return prereqOps, machineOp, nil
 }
 
 func hasJob(jobs []MachineJob, job MachineJob) bool {

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/storage"
 	"github.com/juju/names"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/storage"
 )
 
 // BlockDevice represents the state of a block device attached to a machine.
@@ -202,7 +203,6 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 
 		// Create ops to insert new block devices.
 		for i, info := range newInfo {
-			info := info
 			if found[i] {
 				continue
 			}
@@ -210,12 +210,13 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 			if err != nil {
 				return nil, errors.Annotate(err, "cannot generate disk name")
 			}
+			infoCopy := info // copy for the insert
 			newDoc := blockDeviceDoc{
 				Name:    name,
 				Machine: machineId,
 				EnvUUID: st.EnvironUUID(),
 				DocID:   st.docID(name),
-				Info:    &info,
+				Info:    &infoCopy,
 			}
 			ops = append(ops, txn.Op{
 				C:      blockDevicesC,

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/storage"
 	"github.com/juju/names"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -24,8 +25,14 @@ type BlockDevice interface {
 	// Machine returns the ID of the machine the block device is attached to.
 	Machine() string
 
-	// Info returns the block device's BlockDeviceInfo.
-	Info() BlockDeviceInfo
+	// Info returns the block device's BlockDeviceInfo, or a NotProvisioned
+	// error if the block device has not yet been provisioned.
+	Info() (BlockDeviceInfo, error)
+
+	// Params returns the parameters for provisioning the block device,
+	// if it has not already been provisioned. Params returns true if the
+	// returned parameters are usable for provisioning, otherwise false.
+	Params() (BlockDeviceParams, bool)
 }
 
 type blockDevice struct {
@@ -34,11 +41,17 @@ type blockDevice struct {
 
 // blockDeviceDoc records information about a disk attached to a machine.
 type blockDeviceDoc struct {
-	DocID   string          `bson:"_id"`
-	Name    string          `bson:"name"`
-	EnvUUID string          `bson:"env-uuid"`
-	Machine string          `bson:"machine"`
-	Info    BlockDeviceInfo `bson:"info"`
+	DocID   string             `bson:"_id"`
+	Name    string             `bson:"name"`
+	EnvUUID string             `bson:"env-uuid"`
+	Machine string             `bson:"machine"`
+	Info    *BlockDeviceInfo   `bson:"info,omitempty"`
+	Params  *BlockDeviceParams `bson:"params,omitempty"`
+}
+
+// BlockDeviceParams records parameters for provisioning a new block device.
+type BlockDeviceParams struct {
+	Size uint64 `bson:"size"`
 }
 
 // BlockDeviceInfo describes information about a block device.
@@ -63,8 +76,18 @@ func (b *blockDevice) Machine() string {
 	return b.doc.Machine
 }
 
-func (b *blockDevice) Info() BlockDeviceInfo {
-	return b.doc.Info
+func (b *blockDevice) Info() (BlockDeviceInfo, error) {
+	if b.doc.Info == nil {
+		return BlockDeviceInfo{}, errors.NotProvisionedf("block device %q", b.doc.Name)
+	}
+	return *b.doc.Info, nil
+}
+
+func (b *blockDevice) Params() (BlockDeviceParams, bool) {
+	if b.doc.Params == nil {
+		return BlockDeviceParams{}, false
+	}
+	return *b.doc.Params, true
 }
 
 // BlockDevice returns the BlockDevice with the specified name.
@@ -80,6 +103,29 @@ func (st *State) BlockDevice(diskName string) (BlockDevice, error) {
 		return nil, errors.Annotate(err, "cannot get block device details")
 	}
 	return &d, nil
+}
+
+// BlockDeviceParams converts a storage.Constraints and optional charm
+// and store name pair into one or more BlockDeviceParams.
+func (st *State) BlockDeviceParams(cons storage.Constraints, ch *Charm, store string) ([]BlockDeviceParams, error) {
+	if ch != nil || store != "" {
+		return nil, errors.NotImplementedf("charm storage metadata")
+	}
+	if cons.Pool != "" {
+		return nil, errors.NotImplementedf("storage pools")
+	}
+	if cons.Size == 0 {
+		return nil, errors.Errorf("invalid size %v", cons.Size)
+	}
+	if cons.Count == 0 {
+		return nil, errors.Errorf("invalid count %v", cons.Count)
+	}
+	// TODO(axw) if specified, validate constraints against charm storage metadata.
+	params := make([]BlockDeviceParams, cons.Count)
+	for i := range params {
+		params[i].Size = cons.Size
+	}
+	return params, nil
 }
 
 // newDiskName returns a unique disk name.
@@ -114,15 +160,22 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 		// Create ops to update and remove existing block devices.
 		found := make([]bool, len(newInfo))
 		for _, oldDev := range oldDevices {
+			oldInfo, err := oldDev.Info()
+			if err != nil && errors.IsNotProvisioned(err) {
+				// Leave unprovisioned block devices alone.
+				continue
+			} else if err != nil {
+				return nil, errors.Trace(err)
+			}
 			var updated bool
 			for j, newInfo := range newInfo {
 				if found[j] {
 					continue
 				}
-				if blockDevicesSame(oldDev.Info(), newInfo) {
+				if blockDevicesSame(oldInfo, newInfo) {
 					// Merge the two structures by replacing the old document's
 					// BlockDeviceInfo with the new one.
-					if oldDev.doc.Info != newInfo {
+					if oldInfo != newInfo {
 						ops = append(ops, txn.Op{
 							C:      blockDevicesC,
 							Id:     oldDev.doc.DocID,
@@ -149,6 +202,7 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 
 		// Create ops to insert new block devices.
 		for i, info := range newInfo {
+			info := info
 			if found[i] {
 				continue
 			}
@@ -161,7 +215,7 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 				Machine: machineId,
 				EnvUUID: st.EnvironUUID(),
 				DocID:   st.docID(name),
-				Info:    info,
+				Info:    &info,
 			}
 			ops = append(ops, txn.Op{
 				C:      blockDevicesC,
@@ -176,6 +230,8 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 	return st.run(buildTxn)
 }
 
+// getMachineBlockDevices returns all of the block devices associated with the
+// specified machine, including unprovisioned ones.
 func getMachineBlockDevices(st *State, machineId string) ([]*blockDevice, error) {
 	sel := bson.D{{"machine", machineId}}
 	blockDevices, closer := st.getCollection(blockDevicesC)
@@ -210,6 +266,31 @@ func removeMachineBlockDevicesOps(st *State, machineId string) ([]txn.Op, error)
 		})
 	}
 	return ops, errors.Trace(iter.Close())
+}
+
+// createMachineBlockDeviceOps creates txn.Ops to create unprovisioned
+// block device documents associated with the specified machine, with
+// the given parameters.
+func createMachineBlockDeviceOps(st *State, machineId string, params ...BlockDeviceParams) ([]txn.Op, error) {
+	ops := make([]txn.Op, len(params))
+	for i, params := range params {
+		params := params
+		name, err := newDiskName(st)
+		if err != nil {
+			return nil, errors.Annotate(err, "cannot generate disk name")
+		}
+		ops[i] = txn.Op{
+			C:      blockDevicesC,
+			Id:     name,
+			Assert: txn.DocMissing,
+			Insert: &blockDeviceDoc{
+				Name:    name,
+				Machine: machineId,
+				Params:  &params,
+			},
+		}
+	}
+	return ops, nil
 }
 
 // blockDevicesSame reports whether or not two BlockDevices identify the

--- a/state/blockdevices_test.go
+++ b/state/blockdevices_test.go
@@ -4,10 +4,13 @@
 package state_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
 )
 
 type BlockDevicesSuite struct {
@@ -24,12 +27,17 @@ func (s *BlockDevicesSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *BlockDevicesSuite) assertBlockDevices(c *gc.C, expected map[string]state.BlockDeviceInfo) {
-	devices, err := s.machine.BlockDevices()
+func (s *BlockDevicesSuite) assertBlockDevices(c *gc.C, m *state.Machine, expected map[string]state.BlockDeviceInfo) {
+	devices, err := m.BlockDevices()
 	c.Assert(err, gc.IsNil)
 	info := make(map[string]state.BlockDeviceInfo)
 	for _, dev := range devices {
-		info[dev.Name()] = dev.Info()
+		devInfo, err := dev.Info()
+		if err != nil {
+			c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+			devInfo = state.BlockDeviceInfo{}
+		}
+		info[dev.Name()] = devInfo
 	}
 	c.Assert(info, gc.DeepEquals, expected)
 }
@@ -38,7 +46,7 @@ func (s *BlockDevicesSuite) TestSetMachineBlockDevices(c *gc.C) {
 	sda := state.BlockDeviceInfo{DeviceName: "sda"}
 	err := s.machine.SetMachineBlockDevices(sda)
 	c.Assert(err, gc.IsNil)
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{"0": sda})
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{"0": sda})
 }
 
 func (s *BlockDevicesSuite) TestSetMachineBlockDevicesReplaces(c *gc.C) {
@@ -49,7 +57,7 @@ func (s *BlockDevicesSuite) TestSetMachineBlockDevicesReplaces(c *gc.C) {
 	sdb := state.BlockDeviceInfo{DeviceName: "sdb"}
 	err = s.machine.SetMachineBlockDevices(sdb)
 	c.Assert(err, gc.IsNil)
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{"1": sdb})
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{"1": sdb})
 }
 
 func (s *BlockDevicesSuite) TestSetMachineBlockDevicesUpdates(c *gc.C) {
@@ -57,19 +65,19 @@ func (s *BlockDevicesSuite) TestSetMachineBlockDevicesUpdates(c *gc.C) {
 	sdb := state.BlockDeviceInfo{DeviceName: "sdb"}
 	err := s.machine.SetMachineBlockDevices(sda, sdb)
 	c.Assert(err, gc.IsNil)
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{"0": sda, "1": sdb})
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{"0": sda, "1": sdb})
 
 	sdb.Label = "root"
 	err = s.machine.SetMachineBlockDevices(sdb)
 	c.Assert(err, gc.IsNil)
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{"1": sdb})
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{"1": sdb})
 
 	// If a device is attached, unattached, then attached again,
 	// then it gets a new name.
 	sdb.Label = "" // Label should be reset.
 	err = s.machine.SetMachineBlockDevices(sda, sdb)
 	c.Assert(err, gc.IsNil)
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{
 		"2": sda,
 		"1": sdb,
 	})
@@ -93,7 +101,7 @@ func (s *BlockDevicesSuite) TestSetMachineBlockDevicesConcurrently(c *gc.C) {
 	// block devices. This is fine in practice, because there is
 	// a single worker responsible for populating machine block
 	// devices.
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{
 		"1": sdaInner,
 		// The outer call gets 0 because it's called first;
 		// the before-hook call is called second but completes
@@ -106,11 +114,30 @@ func (s *BlockDevicesSuite) TestSetMachineBlockDevicesEmpty(c *gc.C) {
 	sda := state.BlockDeviceInfo{DeviceName: "sda"}
 	err := s.machine.SetMachineBlockDevices(sda)
 	c.Assert(err, gc.IsNil)
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{"0": sda})
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{"0": sda})
 
 	err = s.machine.SetMachineBlockDevices()
 	c.Assert(err, gc.IsNil)
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{})
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{})
+}
+
+func (s *BlockDevicesSuite) TestSetMachineBlockDevicesLeavesUnprovisioned(c *gc.C) {
+	m, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		BlockDevices: []state.BlockDeviceParams{
+			{Size: 123},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	sda := state.BlockDeviceInfo{DeviceName: "sda"}
+	err = m.SetMachineBlockDevices(sda)
+	c.Assert(err, gc.IsNil)
+	s.assertBlockDevices(c, m, map[string]state.BlockDeviceInfo{
+		"0": state.BlockDeviceInfo{}, // unprovisioned
+		"1": sda,
+	})
 }
 
 func (s *BlockDevicesSuite) TestBlockDevicesMachineRemove(c *gc.C) {
@@ -123,5 +150,80 @@ func (s *BlockDevicesSuite) TestBlockDevicesMachineRemove(c *gc.C) {
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertBlockDevices(c, map[string]state.BlockDeviceInfo{})
+	s.assertBlockDevices(c, s.machine, map[string]state.BlockDeviceInfo{})
+}
+
+func (s *BlockDevicesSuite) TestBlockDeviceInfo(c *gc.C) {
+	sdaInfo := state.BlockDeviceInfo{DeviceName: "sda"}
+	err := state.RunTransaction(s.State, []txn.Op{{
+		C:      state.BlockDevicesC,
+		Id:     "0",
+		Insert: &state.BlockDeviceDoc{Name: "0"},
+	}, {
+		C:      state.BlockDevicesC,
+		Id:     "1",
+		Insert: &state.BlockDeviceDoc{Name: "1", Info: &sdaInfo},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+
+	b0, err := s.State.BlockDevice("0")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = b0.Info()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	b1, err := s.State.BlockDevice("1")
+	c.Assert(err, jc.ErrorIsNil)
+	info, err := b1.Info()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, gc.DeepEquals, sdaInfo)
+}
+
+func (s *BlockDevicesSuite) TestBlockDeviceParamsMethod(c *gc.C) {
+	disk1Params := state.BlockDeviceParams{Size: 123}
+	err := state.RunTransaction(s.State, []txn.Op{{
+		C:      state.BlockDevicesC,
+		Id:     "0",
+		Insert: &state.BlockDeviceDoc{Name: "0"},
+	}, {
+		C:      state.BlockDevicesC,
+		Id:     "1",
+		Insert: &state.BlockDeviceDoc{Name: "1", Params: &disk1Params},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+
+	b0, err := s.State.BlockDevice("0")
+	c.Assert(err, jc.ErrorIsNil)
+	_, ok := b0.Params()
+	c.Assert(ok, jc.IsFalse)
+	b1, err := s.State.BlockDevice("1")
+	c.Assert(err, jc.ErrorIsNil)
+	params, ok := b1.Params()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(params, gc.DeepEquals, disk1Params)
+}
+
+func (s *BlockDevicesSuite) TestBlockDeviceParams(c *gc.C) {
+	test := func(cons storage.Constraints, expect []state.BlockDeviceParams) {
+		params, err := s.State.BlockDeviceParams(cons, nil, "")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(params, gc.DeepEquals, expect)
+	}
+	test(storage.Constraints{Size: 1024, Count: 1}, []state.BlockDeviceParams{
+		{Size: 1024},
+	})
+	test(storage.Constraints{Size: 2048, Count: 2}, []state.BlockDeviceParams{
+		{Size: 2048}, {Size: 2048},
+	})
+}
+
+func (s *BlockDevicesSuite) TestBlockDeviceParamsErrors(c *gc.C) {
+	test := func(cons storage.Constraints, ch *state.Charm, store string, expectErr string) {
+		_, err := s.State.BlockDeviceParams(cons, ch, store)
+		c.Assert(err, gc.ErrorMatches, expectErr)
+	}
+	wordpress := s.AddTestingCharm(c, "wordpress")
+	test(storage.Constraints{Count: 1}, nil, "", "invalid size 0")
+	test(storage.Constraints{Size: 1}, nil, "", "invalid count 0")
+	test(storage.Constraints{Size: 1, Count: 1}, wordpress, "", "charm storage metadata not implemented")
+	test(storage.Constraints{Size: 1, Count: 1}, nil, "shared-fs", "charm storage metadata not implemented")
+	test(storage.Constraints{Size: 1, Count: 1, Pool: "bingo"}, nil, "", "storage pools not implemented")
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -28,6 +28,7 @@ const (
 	SettingsC          = settingsC
 	UnitsC             = unitsC
 	UsersC             = usersC
+	BlockDevicesC      = blockDevicesC
 )
 
 var (
@@ -45,11 +46,12 @@ var (
 )
 
 type (
-	CharmDoc    charmDoc
-	MachineDoc  machineDoc
-	RelationDoc relationDoc
-	ServiceDoc  serviceDoc
-	UnitDoc     unitDoc
+	CharmDoc       charmDoc
+	MachineDoc     machineDoc
+	RelationDoc    relationDoc
+	ServiceDoc     serviceDoc
+	UnitDoc        unitDoc
+	BlockDeviceDoc blockDeviceDoc
 )
 
 func SetTestHooks(c *gc.C, st *State, hooks ...jujutxn.TestHook) txntesting.TransactionChecker {

--- a/state/machine.go
+++ b/state/machine.go
@@ -1359,8 +1359,8 @@ func (m *Machine) SetMachineBlockDevices(info ...BlockDeviceInfo) error {
 	return setMachineBlockDevices(m.st, m.Id(), info)
 }
 
-// BlockDevices gets the aggregated list of block devices attached to the
-// machine.
+// BlockDevices gets the aggregated list of block devices associated with
+// the machine, including unprovisioned ones.
 func (m *Machine) BlockDevices() ([]BlockDevice, error) {
 	devices, err := getMachineBlockDevices(m.st, m.Id())
 	if err != nil {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -3,10 +3,17 @@
 
 package storage
 
+// FeatureFlag is the name of the feature for the JUJU_DEV_FEATURE_FLAGS
+// envar. Add this string to the envar to enable support for storage.
+const FeatureFlag = "storage"
+
 // DiskParams is a fully specified set of parameters for disk creation,
 // derived from one or more of user-specified storage constraints, a
 // storage pool definition, and charm storage metadata.
 type DiskParams struct {
+	// Name is a unique name assigned by Juju for the requested disk.
+	Name string
+
 	// Size is the minimum size of the disk in MiB.
 	Size uint64
 


### PR DESCRIPTION
We introduce a feature-flag protected "--disks" flag to
"juju machine add", which will pass a set of storage
constraints to the AddMachine call. These constraints
will be converted to parameters for disk provisioning
and recorded in state, with a reference to the machine.

A follow-up branch will update the machine provisioner
so that it retrieves these requested block devices and
passes the parameters to StartInstance. The instance
broker will create the disks and return information
about them to then store in state along with the other
instance info.

(Review request: http://reviews.vapour.ws/r/699/)