### PR TITLE
Fixing bulk set call to accept list of entity annotations.

### DIFF
--- a/api/annotations/client.go
+++ b/api/annotations/client.go
@@ -52,8 +52,7 @@ func entitiesAnnotations(tags []string, pairs map[string]string) []params.Entity
 	all := []params.EntityAnnotations{}
 	for _, tag := range tags {
 		one := params.EntityAnnotations{
-			Entities: params.Entities{
-				[]params.Entity{params.Entity{tag}}},
+			Entity:      params.Entity{tag},
 			Annotations: pairs,
 		}
 		all = append(all, one)

--- a/api/annotations/client.go
+++ b/api/annotations/client.go
@@ -31,9 +31,9 @@ func (c *Client) Get(tags []string) ([]params.AnnotationsGetResult, error) {
 	return annotations.Results, nil
 }
 
-// Set sets the same annotation pairs on all given entities.
-func (c *Client) Set(tags []string, pairs map[string]string) error {
-	args := params.AnnotationsSet{entitiesAnnotations(tags, pairs)}
+// Set sets entity annotation pairs.
+func (c *Client) Set(annotations map[string]map[string]string) error {
+	args := params.AnnotationsSet{entitiesAnnotations(annotations)}
 	if err := c.facade.FacadeCall("Set", args, nil); err != nil {
 		return errors.Trace(err)
 	}
@@ -48,9 +48,9 @@ func entitiesFromTags(tags []string) params.Entities {
 	return params.Entities{entities}
 }
 
-func entitiesAnnotations(tags []string, pairs map[string]string) []params.EntityAnnotations {
+func entitiesAnnotations(annotations map[string]map[string]string) []params.EntityAnnotations {
 	all := []params.EntityAnnotations{}
-	for _, tag := range tags {
+	for tag, pairs := range annotations {
 		one := params.EntityAnnotations{
 			Entity:      params.Entity{tag},
 			Annotations: pairs,

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -24,7 +24,8 @@ var _ = gc.Suite(&annotationsMockSuite{})
 
 func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 	var called bool
-	annts := map[string]string{"annotation": "test"}
+	annts := map[string]string{"annotation1": "test"}
+	annts2 := map[string]string{"annotation2": "test"}
 	apiCaller := basetesting.APICallerFunc(
 		func(
 			objType string,
@@ -41,16 +42,17 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 			expected := params.AnnotationsSet{
 				Annotations: []params.EntityAnnotations{
 					{Entity: params.Entity{"charmA"}, Annotations: annts},
-					{Entity: params.Entity{"serviceB"}, Annotations: annts},
+					{Entity: params.Entity{"serviceB"}, Annotations: annts2},
 				}}
 			c.Assert(args, gc.DeepEquals, expected)
 			return nil
 		})
 	annotationsClient := annotations.NewClient(apiCaller)
 	err := annotationsClient.Set(
-		constructTestEntityAnnotations(
-			[]string{"charmA", "serviceB"},
-			annts))
+		map[string]map[string]string{
+			"charmA":   annts,
+			"serviceB": annts2,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }
@@ -89,13 +91,6 @@ func (s *annotationsMockSuite) TestGetEntitiesAnnotations(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(found, gc.HasLen, 1)
 }
-func constructTestEntityAnnotations(tags []string, pairs map[string]string) map[string]map[string]string {
-	result := make(map[string]map[string]string)
-	for _, tag := range tags {
-		result[tag] = pairs
-	}
-	return result
-}
 
 type annotationsSuite struct {
 	jujutesting.JujuConnSuite
@@ -120,8 +115,9 @@ func (s *annotationsSuite) TestAnnotationFacadeCall(c *gc.C) {
 
 	annts := map[string]string{"annotation": "test"}
 	err := s.annotationsClient.Set(
-		constructTestEntityAnnotations([]string{charm.Tag().String()},
-			annts))
+		map[string]map[string]string{
+			charm.Tag().String(): annts,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 
 	found, err := s.annotationsClient.Get([]string{charm.Tag().String()})

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -40,12 +40,8 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 			c.Assert(ok, jc.IsTrue)
 			expected := params.AnnotationsSet{
 				Annotations: []params.EntityAnnotations{
-					{Entities: params.Entities{
-						[]params.Entity{params.Entity{"charmA"}}},
-						Annotations: annts},
-					{Entities: params.Entities{
-						[]params.Entity{params.Entity{"serviceB"}}},
-						Annotations: annts},
+					{Entity: params.Entity{"charmA"}, Annotations: annts},
+					{Entity: params.Entity{"serviceB"}, Annotations: annts},
 				}}
 			c.Assert(args, gc.DeepEquals, expected)
 			return nil

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -47,7 +47,10 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 			return nil
 		})
 	annotationsClient := annotations.NewClient(apiCaller)
-	err := annotationsClient.Set([]string{"charmA", "serviceB"}, annts)
+	err := annotationsClient.Set(
+		constructTestEntityAnnotations(
+			[]string{"charmA", "serviceB"},
+			annts))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }
@@ -86,6 +89,13 @@ func (s *annotationsMockSuite) TestGetEntitiesAnnotations(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(found, gc.HasLen, 1)
 }
+func constructTestEntityAnnotations(tags []string, pairs map[string]string) map[string]map[string]string {
+	result := make(map[string]map[string]string)
+	for _, tag := range tags {
+		result[tag] = pairs
+	}
+	return result
+}
 
 type annotationsSuite struct {
 	jujutesting.JujuConnSuite
@@ -109,7 +119,9 @@ func (s *annotationsSuite) TestAnnotationFacadeCall(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
 
 	annts := map[string]string{"annotation": "test"}
-	err := s.annotationsClient.Set([]string{charm.Tag().String()}, annts)
+	err := s.annotationsClient.Set(
+		constructTestEntityAnnotations([]string{charm.Tag().String()},
+			annts))
 	c.Assert(err, jc.ErrorIsNil)
 
 	found, err := s.annotationsClient.Get([]string{charm.Tag().String()})

--- a/apiserver/annotations/client.go
+++ b/apiserver/annotations/client.go
@@ -69,13 +69,11 @@ func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
 // Set stores annotations for given entities
 func (api *API) Set(args params.AnnotationsSet) params.ErrorResults {
 	setErrors := []params.ErrorResult{}
-	for _, entityAnnotations := range args.Annotations {
-		for _, entity := range entityAnnotations.Entities.Entities {
-			err := api.setEntityAnnotations(entity.Tag, entityAnnotations.Annotations)
-			if err != nil {
-				setErrors = append(setErrors,
-					params.ErrorResult{Error: annotateError(err, entity.Tag, "setting")})
-			}
+	for _, entityAnnotation := range args.Annotations {
+		err := api.setEntityAnnotations(entityAnnotation.Entity.Tag, entityAnnotation.Annotations)
+		if err != nil {
+			setErrors = append(setErrors,
+				params.ErrorResult{Error: annotateError(err, entityAnnotation.Entity.Tag, "setting")})
 		}
 	}
 	return params.ErrorResults{Results: setErrors}

--- a/apiserver/annotations/client_test.go
+++ b/apiserver/annotations/client_test.go
@@ -150,8 +150,7 @@ func constructSetParameters(
 	result := []params.EntityAnnotations{}
 	for _, entity := range entities.Entities {
 		one := params.EntityAnnotations{
-			Entities: params.Entities{
-				[]params.Entity{entity}},
+			Entity:      entity,
 			Annotations: annotations,
 		}
 		result = append(result, one)

--- a/apiserver/params/annotations.go
+++ b/apiserver/params/annotations.go
@@ -20,8 +20,8 @@ type AnnotationsSet struct {
 	Annotations []EntityAnnotations
 }
 
-// EntityAnnotations stores annotations for entities.
+// EntityAnnotations stores annotations for an entity.
 type EntityAnnotations struct {
-	Entities    Entities
+	Entity      Entity
 	Annotations map[string]string
 }


### PR DESCRIPTION
This change ensures that bulk Set call parameters are in the format consistent with the rest of codebase.
Take a list of entities and their corresponding annotations, thus setting different annotations on individual entity from the entities list in one call.

E.g. entity a will be annotated with pairs1 whereas entity b with pairs2.
......{
            "Type": "Annotations",
            "Request": "Set",
            "Params": {
                 "Annotations": {
                     {"Entity": a, "Annotations": pairs1},
                     {"Entity": b, "Annotations": pairs2}
                 }
             }
}......

(Review request: http://reviews.vapour.ws/r/701/)