### PR TITLE
juju action do now permits explicit CLI args

### DIFF
--- a/cmd/juju/action/do.go
+++ b/cmd/juju/action/do.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2014, 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action
@@ -6,6 +6,7 @@ package action
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -16,6 +17,8 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
+var keyRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+
 // DoCommand enqueues an Action for running on the given unit with given
 // params
 type DoCommand struct {
@@ -24,6 +27,7 @@ type DoCommand struct {
 	actionName string
 	paramsYAML cmd.FileVar
 	out        cmd.Output
+	args       [][]string
 }
 
 const doDoc = `
@@ -31,8 +35,14 @@ Queue an Action for execution on a given unit, with a given set of params.
 Displays the ID of the Action for use with 'juju kill', 'juju status', etc.
 
 Params are validated according to the charm for the unit's service.  The 
-valid params can be seen using "juju action defined <service>".  Params must
-be in a yaml file which is passed with the --params flag.
+valid params can be seen using "juju action defined <service>".  Params may 
+be in a yaml file which is passed with the --params flag, or they may be
+specified by a key.key.key...=value format.
+
+Note that the explicit format only permits string values at this time.
+
+If --params is passed, along with key.key...=value explicit arguments, the
+explicit arguments will override the parameter file.
 
 Examples:
 
@@ -49,6 +59,34 @@ result:
 
 $ juju action do mysql/3 backup --params parameters.yml
 ...
+Params sent will be the contents of parameters.yml.
+...
+
+$ juju action do mysql/3 backup out=out.tar.bz2 file.kind=xz file.quality=high
+...
+Params sent will be:
+
+out: out.tar.bz2
+file:
+  kind: xz
+  quality: high
+...
+
+$ juju action do mysql/3 backup --params p.yml file.kind=xz file.quality=high
+...
+If p.yml contains:
+
+file:
+  location: /var/backups/mysql/
+  kind: gzip
+
+then the merged args passed will be:
+
+file:
+  location: /var/backups/mysql/
+  kind: xz
+  quality: high
+...
 `
 
 // actionNameRule describes the format an action name must match to be valid.
@@ -63,7 +101,7 @@ func (c *DoCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *DoCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "do",
-		Args:    "<unit> <action name>",
+		Args:    "<unit> <action name> [<key>=<value> ...]",
 		Purpose: "WIP: queue an action for execution",
 		Doc:     doDoc,
 	}
@@ -76,7 +114,8 @@ func (c *DoCommand) Init(args []string) error {
 		return errors.New("no unit specified")
 	case 1:
 		return errors.New("no action specified")
-	case 2:
+	default:
+		// Grab and verify the unit and action names.
 		unitName := args[0]
 		if !names.IsValidUnit(unitName) {
 			return errors.Errorf("invalid unit name %q", unitName)
@@ -87,9 +126,27 @@ func (c *DoCommand) Init(args []string) error {
 		}
 		c.unitTag = names.NewUnitTag(unitName)
 		c.actionName = actionName
+		if len(args) == 2 {
+			return nil
+		}
+		// Parse CLI key-value args if they exist.
+		c.args = make([][]string, 0)
+		for _, arg := range args[2:] {
+			thisArg := strings.SplitN(arg, "=", 2)
+			if len(thisArg) != 2 {
+				return fmt.Errorf("argument %q must be of the form key...=value", arg)
+			}
+			keySlice := strings.Split(thisArg[0], ".")
+			// check each key for validity
+			for _, key := range keySlice {
+				if valid := keyRule.MatchString(key); !valid {
+					return fmt.Errorf("key %q must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens", key)
+				}
+			}
+			// c.args={..., [key, key, key, key, value]}
+			c.args = append(c.args, append(keySlice, thisArg[1]))
+		}
 		return nil
-	default:
-		return cmd.CheckEmpty(args[1:])
 	}
 }
 
@@ -109,6 +166,9 @@ func (c *DoCommand) Run(ctx *cmd.Context) error {
 		}
 
 		err = yaml.Unmarshal(b, &actionParams)
+		if err != nil {
+			return err
+		}
 
 		conformantParams, err := conform(actionParams)
 		if err != nil {
@@ -121,6 +181,26 @@ func (c *DoCommand) Run(ctx *cmd.Context) error {
 		}
 
 		actionParams = betterParams
+	}
+
+	// If we had explicit args {..., [key, key, key, key, value], ...}
+	// then iterate and set params ..., key.key.key.key=value, ...
+	for _, argSlice := range c.args {
+		valueIndex := len(argSlice) - 1
+		keys := argSlice[:valueIndex]
+		value := argSlice[valueIndex]
+		// Insert the value in the map.
+		addValueToMap(keys, value, actionParams)
+	}
+
+	conformantParams, err := conform(actionParams)
+	if err != nil {
+		return err
+	}
+
+	typedConformantParams, ok := conformantParams.(map[string]interface{})
+	if !ok {
+		return errors.Errorf("params must be a map, got %T", typedConformantParams)
 	}
 
 	actionParam := params.Actions{

--- a/cmd/juju/action/do_test.go
+++ b/cmd/juju/action/do_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2014, 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action_test
@@ -7,26 +7,52 @@ import (
 	"bytes"
 	"errors"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v1"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/testing"
 )
 
+var (
+	validParamsYaml = `
+out: name
+compression:
+  kind: xz
+  quality: high
+`[1:]
+	invalidParamsYaml = `
+broken-map:
+  foo:
+    foo
+    bar: baz
+`[1:]
+	invalidUTFYaml = "out: ok" + string([]byte{0xFF, 0xFF})
+)
+
 type DoSuite struct {
 	BaseActionSuite
 	subcommand *action.DoCommand
+	dir        string
 }
 
 var _ = gc.Suite(&DoSuite{})
 
 func (s *DoSuite) SetUpTest(c *gc.C) {
 	s.BaseActionSuite.SetUpTest(c)
+	s.dir = c.MkDir()
+	c.Assert(utf8.ValidString(validParamsYaml), jc.IsTrue)
+	c.Assert(utf8.ValidString(invalidParamsYaml), jc.IsTrue)
+	c.Assert(utf8.ValidString(invalidUTFYaml), jc.IsFalse)
+	setupValueFile(c, s.dir, "validParams.yml", validParamsYaml)
+	setupValueFile(c, s.dir, "invalidParams.yml", invalidParamsYaml)
+	setupValueFile(c, s.dir, "invalidUTF.yml", invalidUTFYaml)
 }
 
 func (s *DoSuite) TestHelp(c *gc.C) {
@@ -40,6 +66,7 @@ func (s *DoSuite) TestInit(c *gc.C) {
 		expectUnit           names.UnitTag
 		expectAction         string
 		expectParamsYamlPath string
+		expectKVArgs         [][]string
 		expectOutput         string
 		expectError          string
 	}{{
@@ -59,30 +86,87 @@ func (s *DoSuite) TestInit(c *gc.C) {
 		args:        []string{validUnitId, "BadName"},
 		expectError: "invalid action name \"BadName\"",
 	}, {
-		should:      "fail with too many args",
-		args:        []string{"1", "2", "3"},
-		expectError: "unrecognized args: \\[\"2\" \"3\"\\]",
+		should:      "fail with wrong formatting of k-v args",
+		args:        []string{validUnitId, "valid-action-name", "uh"},
+		expectError: "argument \"uh\" must be of the form key...=value",
+	}, {
+		should:      "fail with wrong formatting of k-v args",
+		args:        []string{validUnitId, "valid-action-name", "foo.Baz=3"},
+		expectError: "key \"Baz\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens",
+	}, {
+		should:      "fail with wrong formatting of k-v args",
+		args:        []string{validUnitId, "valid-action-name", "no-go?od=3"},
+		expectError: "key \"no-go\\?od\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens",
+	}, {
+		should:       "work with empty values",
+		args:         []string{validUnitId, "valid-action-name", "ok="},
+		expectUnit:   names.NewUnitTag(validUnitId),
+		expectAction: "valid-action-name",
+		expectKVArgs: [][]string{{"ok", ""}},
+	}, {
+		// cf. worker/uniter/runner/jujuc/action-set_test.go per @fwereade
+		should:       "work with multiple '=' signs",
+		args:         []string{validUnitId, "valid-action-name", "ok=this=is=weird="},
+		expectUnit:   names.NewUnitTag(validUnitId),
+		expectAction: "valid-action-name",
+		expectKVArgs: [][]string{{"ok", "this=is=weird="}},
 	}, {
 		should:       "init properly with no params",
 		args:         []string{validUnitId, "valid-action-name"},
 		expectUnit:   names.NewUnitTag(validUnitId),
 		expectAction: "valid-action-name",
 	}, {
-		should:       "handle --params properly",
-		args:         []string{validUnitId, "valid-action-name"},
+		should:               "handle --params properly",
+		args:                 []string{validUnitId, "valid-action-name", "--params=foo.yml"},
+		expectUnit:           names.NewUnitTag(validUnitId),
+		expectAction:         "valid-action-name",
+		expectParamsYamlPath: "foo.yml",
+	}, {
+		should: "handle --params and key-value args",
+		args: []string{
+			validUnitId,
+			"valid-action-name",
+			"--params=foo.yml",
+			"foo.bar=2",
+			"foo.baz.bo=3",
+			"bar.foo=hello",
+		},
+		expectUnit:           names.NewUnitTag(validUnitId),
+		expectAction:         "valid-action-name",
+		expectParamsYamlPath: "foo.yml",
+		expectKVArgs: [][]string{
+			{"foo", "bar", "2"},
+			{"foo", "baz", "bo", "3"},
+			{"bar", "foo", "hello"},
+		},
+	}, {
+		should: "handle key-value args with no --params",
+		args: []string{
+			validUnitId,
+			"valid-action-name",
+			"foo.bar=2",
+			"foo.baz.bo=3",
+			"bar.foo=hello",
+		},
 		expectUnit:   names.NewUnitTag(validUnitId),
 		expectAction: "valid-action-name",
+		expectKVArgs: [][]string{
+			{"foo", "bar", "2"},
+			{"foo", "baz", "bo", "3"},
+			{"bar", "foo", "hello"},
+		},
 	}}
 
 	for i, t := range tests {
 		s.subcommand = &action.DoCommand{}
-		c.Logf("test %d: it should %s: juju actions do %s", i,
+		c.Logf("test %d: should %s:\n$ juju actions do %s\n", i,
 			t.should, strings.Join(t.args, " "))
 		err := testing.InitCommand(s.subcommand, t.args)
 		if t.expectError == "" {
 			c.Check(s.subcommand.UnitTag(), gc.Equals, t.expectUnit)
 			c.Check(s.subcommand.ActionName(), gc.Equals, t.expectAction)
 			c.Check(s.subcommand.ParamsYAMLPath(), gc.Equals, t.expectParamsYamlPath)
+			c.Check(s.subcommand.KeyValueDoArgs(), jc.DeepEquals, t.expectKVArgs)
 		} else {
 			c.Check(err, gc.ErrorMatches, t.expectError)
 		}
@@ -93,24 +177,183 @@ func (s *DoSuite) TestRun(c *gc.C) {
 	tests := []struct {
 		should                 string
 		withArgs               []string
-		withParamsFileContents string
-		withParamsFileError    string
 		withAPIErr             string
 		withActionResults      []params.ActionResult
+		expectedActionEnqueued params.Action
 		expectedErr            string
 	}{{
+		should:   "fail with multiple results",
+		withArgs: []string{validUnitId, "some-action"},
+		withActionResults: []params.ActionResult{
+			{Action: &params.Action{Tag: validActionTagString}},
+			{Action: &params.Action{Tag: validActionTagString}},
+		},
+		expectedErr: "illegal number of results returned",
+	}, {
+		should:   "fail with API error",
+		withArgs: []string{validUnitId, "some-action"},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: validActionTagString}},
+		},
+		withAPIErr:  "something wrong in API",
+		expectedErr: "something wrong in API",
+	}, {
+		should:   "fail with error in result",
+		withArgs: []string{validUnitId, "some-action"},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: validActionTagString},
+			Error:  common.ServerError(errors.New("database error")),
+		}},
+		expectedErr: "database error",
+	}, {
+		should:   "fail with invalid tag in result",
+		withArgs: []string{validUnitId, "some-action"},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: invalidActionTagString},
+		}},
+		expectedErr: "\"" + invalidActionTagString + "\" is not a valid action tag",
+	}, {
+		should: "fail with missing file passed",
+		withArgs: []string{validUnitId, "some-action",
+			"--params", s.dir + "/" + "missing.yml",
+		},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: validActionTagString},
+		}},
+		expectedErr: "open .*missing.yml: no such file or directory",
+	}, {
+		should: "fail with invalid yaml in file",
+		withArgs: []string{validUnitId, "some-action",
+			"--params", s.dir + "/" + "invalidParams.yml",
+		},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: validActionTagString},
+		}},
+		expectedErr: "YAML error: line 3: mapping values are not allowed in this context",
+	}, {
+		should: "fail with invalid UTF in file",
+		withArgs: []string{validUnitId, "some-action",
+			"--params", s.dir + "/" + "invalidUTF.yml",
+		},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: validActionTagString},
+		}},
+		expectedErr: "YAML error: invalid leading UTF-8 octet",
+	}, {
 		should:   "enqueue a basic action with no params",
 		withArgs: []string{validUnitId, "some-action"},
 		withActionResults: []params.ActionResult{{
+			Action: &params.Action{Tag: validActionTagString},
+		}},
+		expectedActionEnqueued: params.Action{
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		},
+	}, {
+		should: "enqueue an action with some explicit params",
+		withArgs: []string{validUnitId, "some-action",
+			"out.name=bar",
+			"out.kind=tmpfs",
+		},
+		withActionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag: validActionTagString,
+				Parameters: map[string]interface{}{
+					"out": map[string]interface{}{
+						"name": "bar",
+						"kind": "tmpfs",
+					},
+				},
 			},
 		}},
+		expectedActionEnqueued: params.Action{
+			Name:     "some-action",
+			Receiver: names.NewUnitTag(validUnitId).String(),
+			Parameters: map[string]interface{}{
+				"out": map[string]interface{}{
+					"name": "bar",
+					"kind": "tmpfs",
+				},
+			},
+		},
+	}, {
+		should: "enqueue an action with file params",
+		withArgs: []string{validUnitId, "some-action",
+			"--params", s.dir + "/" + "validParams.yml",
+		},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{
+				Tag: validActionTagString,
+				Parameters: map[string]interface{}{
+					"out": "name",
+					"compression": map[string]interface{}{
+						"kind":    "xz",
+						"quality": "high",
+					},
+				},
+			},
+		}},
+		expectedActionEnqueued: params.Action{
+			Name:     "some-action",
+			Receiver: names.NewUnitTag(validUnitId).String(),
+			Parameters: map[string]interface{}{
+				"out": "name",
+				"compression": map[string]interface{}{
+					"kind":    "xz",
+					"quality": "high",
+				},
+			},
+		},
+	}, {
+		should: "enqueue an action with file params and explicit params",
+		withArgs: []string{validUnitId, "some-action",
+			"out.name=bar",
+			"out.kind=tmpfs",
+			"compression.quality.speed=high",
+			"compression.quality.size=small",
+			"--params", s.dir + "/" + "validParams.yml",
+		},
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{
+				Tag: validActionTagString,
+				Parameters: map[string]interface{}{
+					"out": map[string]interface{}{
+						"name": "bar",
+						"kind": "tmpfs",
+					},
+					"compression": map[string]interface{}{
+						"kind": "xz",
+						"quality": map[string]interface{}{
+							"speed": "high",
+							"size":  "small",
+						},
+					},
+				},
+			},
+		}},
+		expectedActionEnqueued: params.Action{
+			Name:     "some-action",
+			Receiver: names.NewUnitTag(validUnitId).String(),
+			Parameters: map[string]interface{}{
+				"out": map[string]interface{}{
+					"name": "bar",
+					"kind": "tmpfs",
+				},
+				"compression": map[string]interface{}{
+					"kind": "xz",
+					"quality": map[string]interface{}{
+						"speed": "high",
+						"size":  "small",
+					},
+				},
+			},
+		},
 	}}
 
 	for i, t := range tests {
 		func() {
-			c.Logf("test %d: it should %s: juju actions do %s", i,
+			c.Logf("test %d: should %s:\n$ juju actions do %s\n", i,
 				t.should, strings.Join(t.withArgs, " "))
 			fakeClient := &fakeAPIClient{
 				actionResults: t.withActionResults,
@@ -128,20 +371,27 @@ func (s *DoSuite) TestRun(c *gc.C) {
 				c.Check(err, gc.ErrorMatches, t.expectedErr)
 			} else {
 				c.Assert(err, gc.IsNil)
-				// only one result?
+				// Before comparing, double-check to avoid
+				// panics in malformed tests.
 				c.Assert(len(t.withActionResults), gc.Equals, 1)
-				// result contains non-nil action?
+				// Make sure the test's expected Action was
+				// non-nil and correct.
 				c.Assert(t.withActionResults[0].Action, gc.NotNil)
-				// get the tag
 				expectedTag, err := names.ParseActionTag(t.withActionResults[0].Action.Tag)
 				c.Assert(err, gc.IsNil)
+				// Make sure the CLI responded with the expected tag
 				sillyKey := "Action queued with id"
 				expectedMap := map[string]string{sillyKey: expectedTag.Id()}
-				result := ctx.Stdout.(*bytes.Buffer).Bytes()
+				outputResult := ctx.Stdout.(*bytes.Buffer).Bytes()
 				resultMap := make(map[string]string)
-				err = yaml.Unmarshal(result, &resultMap)
+				err = yaml.Unmarshal(outputResult, &resultMap)
 				c.Assert(err, gc.IsNil)
 				c.Check(resultMap, jc.DeepEquals, expectedMap)
+				// Make sure the Action sent to the API to be
+				// enqueued was indeed the expected map
+				enqueued := fakeClient.EnqueuedActions()
+				c.Assert(enqueued.Actions, gc.HasLen, 1)
+				c.Check(enqueued.Actions[0], jc.DeepEquals, t.expectedActionEnqueued)
 			}
 		}()
 	}

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -28,3 +28,7 @@ func (c *DoCommand) ActionName() string {
 func (c *DoCommand) ParamsYAMLPath() string {
 	return c.paramsYAML.Path
 }
+
+func (c *DoCommand) KeyValueDoArgs() [][]string {
+	return c.args
+}


### PR DESCRIPTION
Explicit arguments can now be passed using `juju action do` as follows:

```bash
$ juju action do mysql/0 snapshot --params=p.yml outfile.name=newname.out
...

$ juju action do mysql/0 snapshot outfile.name=newname outfile.kind=xz
...
```

etc.

Arguments will override preexisting values from params file or other
explicit params from the CLI, as in action-set.