### PR TITLE
Changed test to ignore the order of returned collection. 

### DIFF
--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -46,7 +46,7 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 
 			for _, aParam := range args.Annotations {
 				// Since sometimes arrays returned on some
-				// architectures very the order within params.AnnotationsSet,
+				// architectures vary the order within params.AnnotationsSet,
 				// simply assert that each entity has its own annotations.
 				// Bug 1409141
 				c.Assert(aParam.Annotations, gc.DeepEquals, setParams[aParam.Entity.Tag])

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -34,8 +34,8 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 		func(objType string,
 			version int,
 			id, request string,
-			a, result interface{}) error {
-
+			a, result interface{},
+		) error {
 			called = true
 			c.Check(objType, gc.Equals, "Annotations")
 			c.Check(id, gc.Equals, "")

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -31,11 +31,11 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 		"serviceB": annts2,
 	}
 	apiCaller := basetesting.APICallerFunc(
-		func(
-			objType string,
+		func(objType string,
 			version int,
 			id, request string,
 			a, result interface{}) error {
+
 			called = true
 			c.Check(objType, gc.Equals, "Annotations")
 			c.Check(id, gc.Equals, "")


### PR DESCRIPTION
Test was failing because expected collection and obtained collection contained elements in different order. Since the order of elements is not important for the test, changed it to examine contents instead.


(Review request: http://reviews.vapour.ws/r/706/)