### PR TITLE
state: implemented an environments lifecycle watcher

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -293,3 +293,16 @@ func NewMultiEnvRunnerForTesting(envUUID string, baseRunner jujutxn.Runner) juju
 func Sequence(st *State, name string) (int, error) {
 	return st.sequence(name)
 }
+
+// TODO(mjs) - This is a temporary and naive environment destruction
+// function, used to test environment watching. Once the environment
+// destroying work is completed it can go away.
+func RemoveEnvironment(st *State, uuid string) error {
+	ops := []txn.Op{{
+		C:      environmentsC,
+		Id:     uuid,
+		Assert: txn.DocExists,
+		Remove: true,
+	}}
+	return st.runTransaction(ops)
+}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -140,7 +140,7 @@ type lifecycleWatcher struct {
 	commonWatcher
 	out chan []string
 
-	// coll is a function returning the mgo.Collection holding all
+	// coll is a function returning the stateCollection holding all
 	// interesting entities
 	coll     func() (stateCollection, func())
 	collName string
@@ -157,6 +157,12 @@ func collFactory(st *State, collName string) func() (stateCollection, func()) {
 	return func() (stateCollection, func()) {
 		return st.getCollection(collName)
 	}
+}
+
+// WatchEnvironments returns a StringsWatcher that notifies of changes
+// to the lifecycles of all environments.
+func (st *State) WatchEnvironments() StringsWatcher {
+	return newLifecycleWatcher(st, environmentsC, nil, nil)
 }
 
 // WatchServices returns a StringsWatcher that notifies of changes to


### PR DESCRIPTION
Reports when environments are created and destroyed.

Environment destruction is somewhat faked to support testing. This will be replaced with something more realistic soon.

(Review request: http://reviews.vapour.ws/r/711/)