### PR TITLE
Corrections to LE functional tests.

### DIFF
--- a/api/leadership/client_test.go
+++ b/api/leadership/client_test.go
@@ -63,8 +63,8 @@ func (s *clientSuite) TestClaimLeadershipTranslation(c *gc.C) {
 			}}
 
 			c.Assert(typedP.Params, gc.HasLen, 1)
-			c.Check(typedP.Params[0].ServiceTag.Id(), gc.Equals, StubServiceNm)
-			c.Check(typedP.Params[0].UnitTag.Id(), gc.Equals, StubUnitNm)
+			c.Check(typedP.Params[0].ServiceTag, gc.Equals, names.NewServiceTag(StubServiceNm).String())
+			c.Check(typedP.Params[0].UnitTag, gc.Equals, names.NewUnitTag(StubUnitNm).String())
 
 			return nil
 		},
@@ -130,8 +130,8 @@ func (s *clientSuite) TestReleaseLeadershipTranslation(c *gc.C) {
 			typedR.Results = []params.ErrorResult{{}}
 
 			c.Assert(typedP.Params, gc.HasLen, 1)
-			c.Check(typedP.Params[0].ServiceTag.Id(), gc.Equals, StubServiceNm)
-			c.Check(typedP.Params[0].UnitTag.Id(), gc.Equals, StubUnitNm)
+			c.Check(typedP.Params[0].ServiceTag, gc.Equals, names.NewServiceTag(StubServiceNm).String())
+			c.Check(typedP.Params[0].UnitTag, gc.Equals, names.NewUnitTag(StubUnitNm).String())
 
 			return nil
 		},

--- a/apiserver/leadership/leadership.go
+++ b/apiserver/leadership/leadership.go
@@ -173,17 +173,22 @@ func callWithIds(fn func(string, string) error) func(st, ut names.Tag) params.Er
 	}
 }
 
+// parseServiceAndUnitTags takes in string representations of service
+// and unit tags and parses them into structs.
+//
+// NOTE: we return permissions errors when parsing fails to obfuscate
+// the parse-failure. This is for security purposes.
 func parseServiceAndUnitTags(
 	serviceTagString, unitTagString string,
 ) (serviceTag names.ServiceTag, unitTag names.UnitTag, _ *params.Error) {
 	serviceTag, err := names.ParseServiceTag(serviceTagString)
 	if err != nil {
-		return serviceTag, unitTag, common.ServerError(err)
+		return serviceTag, unitTag, common.ServerError(common.ErrPerm)
 	}
 
 	unitTag, err = names.ParseUnitTag(unitTagString)
 	if err != nil {
-		return serviceTag, unitTag, common.ServerError(err)
+		return serviceTag, unitTag, common.ServerError(common.ErrPerm)
 	}
 
 	return serviceTag, unitTag, nil

--- a/apiserver/leadership/leadership_test.go
+++ b/apiserver/leadership/leadership_test.go
@@ -96,8 +96,8 @@ func (s *leadershipSuite) TestClaimLeadershipTranslation(c *gc.C) {
 	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			params.ClaimLeadershipParams{
-				ServiceTag: names.NewServiceTag(StubServiceNm),
-				UnitTag:    names.NewUnitTag(StubUnitNm),
+				ServiceTag: names.NewServiceTag(StubServiceNm).String(),
+				UnitTag:    names.NewUnitTag(StubUnitNm).String(),
 			},
 		},
 	})
@@ -119,8 +119,8 @@ func (s *leadershipSuite) TestReleaseLeadershipTranslation(c *gc.C) {
 	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			params.ClaimLeadershipParams{
-				ServiceTag: names.NewServiceTag(StubServiceNm),
-				UnitTag:    names.NewUnitTag(StubUnitNm),
+				ServiceTag: names.NewServiceTag(StubServiceNm).String(),
+				UnitTag:    names.NewUnitTag(StubUnitNm).String(),
 			},
 		},
 	})
@@ -153,8 +153,8 @@ func (s *leadershipSuite) TestClaimLeadershipFailOnAuthorizerErrors(c *gc.C) {
 	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			params.ClaimLeadershipParams{
-				ServiceTag: names.NewServiceTag(StubServiceNm),
-				UnitTag:    names.NewUnitTag(StubUnitNm),
+				ServiceTag: names.NewServiceTag(StubServiceNm).String(),
+				UnitTag:    names.NewUnitTag(StubUnitNm).String(),
 			},
 		},
 	})
@@ -174,8 +174,8 @@ func (s *leadershipSuite) TestReleaseLeadershipFailOnAuthorizerErrors(c *gc.C) {
 	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			params.ClaimLeadershipParams{
-				ServiceTag: names.NewServiceTag(StubServiceNm),
-				UnitTag:    names.NewUnitTag(StubUnitNm),
+				ServiceTag: names.NewServiceTag(StubServiceNm).String(),
+				UnitTag:    names.NewUnitTag(StubUnitNm).String(),
 			},
 		},
 	})

--- a/apiserver/params/leadership.go
+++ b/apiserver/params/leadership.go
@@ -1,11 +1,7 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package params
-
-import (
-	"github.com/juju/names"
-)
 
 // ClaimLeadershipBulkParams is a collection of parameters for making
 // a bulk leadership claim.
@@ -21,10 +17,10 @@ type ClaimLeadershipParams struct {
 
 	// ServiceTag is the service for which you want to make a
 	// leadership claim.
-	ServiceTag names.ServiceTag
+	ServiceTag string
 
 	// UnitTag is the unit which is making the leadership claim.
-	UnitTag names.UnitTag
+	UnitTag string
 }
 
 // ClaimLeadershipBulkResults is the collection of results from a bulk
@@ -41,7 +37,7 @@ type ClaimLeadershipResults struct {
 
 	// ServiceTag is the service for which you want to make a
 	// leadership claim.
-	ServiceTag names.ServiceTag
+	ServiceTag string
 
 	// ClaimDurationInSec is the number of seconds a claim will be
 	// held.
@@ -63,10 +59,10 @@ type ReleaseLeadershipParams struct {
 
 	// ServiceTag is the service for which you want to make a
 	// leadership claim.
-	ServiceTag names.ServiceTag
+	ServiceTag string
 
 	// UnitTag is the unit which is making the leadership claim.
-	UnitTag names.UnitTag
+	UnitTag string
 }
 
 // ReleaseLeadershipBulkResults is a type which contains results from

--- a/featuretests/doc.go
+++ b/featuretests/doc.go
@@ -8,7 +8,7 @@ tested.
 
 Rules:
 
-1) Do NOT mirror the architecture/namespaces of Juju. This shouldbe a
+1) Do NOT mirror the architecture/namespaces of Juju. This should be a
 very flat folder.
 
 2) Whenever possible, do not mock anything. The goal is to test the

--- a/featuretests/doc.go
+++ b/featuretests/doc.go
@@ -2,19 +2,23 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 /*
-This package is for functional testing only. Each feature-set of
+This package contains functional tests only. Each feature-set of
 Juju should have it's own file in which all the happy-paths are
 tested.
 
 Rules:
-1) Do NOT mirror the architecture/namespaces of Juju. This should
-   be a very flat folder.
+
+1) Do NOT mirror the architecture/namespaces of Juju. This shouldbe a
+very flat folder.
 
 2) Whenever possible, do not mock anything. The goal is to test the
-   entire stack as well as can be done within a test suite.
+entire stack as well as can be done within a test suite.
 
-3) Avoid writing tests that do not specifically address a
-   user-facing feature. The place for that is in unit tests within
-   Juju Core.
+3) Avoid writing tests that do not specifically address a user-facing
+feature. The place for that is in unit tests within Juju Core.
+
+To run tests excluding the functional tests in this package, specify
+the "--featuretests=false" option:
+	go test github.com/juju/juju/... --featuretests=false
 */
-package feature_tests
+package featuretests

--- a/featuretests/init_all_test.go
+++ b/featuretests/init_all_test.go
@@ -1,9 +1,10 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package feature_tests
+package featuretests
 
 import (
+	"flag"
 	"testing"
 
 	gc "gopkg.in/check.v1"
@@ -11,9 +12,20 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-func Test(t *testing.T) {
-	coretesting.MgoTestPackage(t)
+var runFeatureTests = flag.Bool("featuretests", true, "Run long-running feature tests.")
+
+func init() {
+
+	flag.Parse()
+
+	if *runFeatureTests == false {
+		return
+	}
 
 	// Initialize all suites here.
 	gc.Suite(&leadershipSuite{})
+}
+
+func Test(t *testing.T) {
+	coretesting.MgoTestPackage(t)
 }

--- a/leadership/interface.go
+++ b/leadership/interface.go
@@ -23,7 +23,7 @@ type LeadershipManager interface {
 	ReleaseLeadership(serviceId, unitId string) (err error)
 	// BlockUntilLeadershipReleased blocks the caller until leadership is
 	// released for the given serviceId.
-	BlockUntilLeadershipReleased(serviceId string) error
+	BlockUntilLeadershipReleased(serviceId string) (err error)
 }
 
 type LeadershipLeaseManager interface {


### PR DESCRIPTION
- Changed declared package name to align with actual package name.
- Removed unecessary code from Leadership client.
- Removed irrelevant "stub" unit/service IDs. Using real ones for authentication.
- Migrated OtW parameters to strings and away from names.*Tags as these were not always serializable.
- Cleaned up doc.go's godoc formatting.
- Added flag to functional test initialization to skip tests.
- Added explanation of how to skip functional tests.

(Review request: http://reviews.vapour.ws/r/713/)