### PR TITLE
cmd/jujud/agent: disable diskmanager worker

### DIFF
--- a/.reviewboardrc
+++ b/.reviewboardrc
@@ -1,4 +1,4 @@
 REVIEWBOARD_URL = "https://reviews.vapour.ws/"
 REPOSITORY = "juju (core)"
-BRANCH = "master"
-TRACKING_BRANCH = "upstream/master"
+BRANCH = "1.22"
+TRACKING_BRANCH = "upstream/1.22"

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -26,12 +26,16 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 	var called bool
 	annts := map[string]string{"annotation1": "test"}
 	annts2 := map[string]string{"annotation2": "test"}
+	setParams := map[string]map[string]string{
+		"charmA":   annts,
+		"serviceB": annts2,
+	}
 	apiCaller := basetesting.APICallerFunc(
-		func(
-			objType string,
+		func(objType string,
 			version int,
 			id, request string,
-			a, result interface{}) error {
+			a, result interface{},
+		) error {
 			called = true
 			c.Check(objType, gc.Equals, "Annotations")
 			c.Check(id, gc.Equals, "")
@@ -39,20 +43,18 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 
 			args, ok := a.(params.AnnotationsSet)
 			c.Assert(ok, jc.IsTrue)
-			expected := params.AnnotationsSet{
-				Annotations: []params.EntityAnnotations{
-					{Entity: params.Entity{"charmA"}, Annotations: annts},
-					{Entity: params.Entity{"serviceB"}, Annotations: annts2},
-				}}
-			c.Assert(args, gc.DeepEquals, expected)
+
+			for _, aParam := range args.Annotations {
+				// Since sometimes arrays returned on some
+				// architectures vary the order within params.AnnotationsSet,
+				// simply assert that each entity has its own annotations.
+				// Bug 1409141
+				c.Assert(aParam.Annotations, gc.DeepEquals, setParams[aParam.Entity.Tag])
+			}
 			return nil
 		})
 	annotationsClient := annotations.NewClient(apiCaller)
-	err := annotationsClient.Set(
-		map[string]map[string]string{
-			"charmA":   annts,
-			"serviceB": annts2,
-		})
+	err := annotationsClient.Set(setParams)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -62,7 +62,6 @@ import (
 	"github.com/juju/juju/worker/charmrevisionworker"
 	"github.com/juju/juju/worker/cleaner"
 	"github.com/juju/juju/worker/deployer"
-	"github.com/juju/juju/worker/diskmanager"
 	"github.com/juju/juju/worker/firewaller"
 	"github.com/juju/juju/worker/instancepoller"
 	"github.com/juju/juju/worker/localstorage"
@@ -99,7 +98,6 @@ var (
 	peergrouperNew           = peergrouper.New
 	newNetworker             = networker.NewNetworker
 	newFirewaller            = firewaller.NewFirewaller
-	newDiskManager           = diskmanager.NewWorker
 	newCertificateUpdater    = certupdater.NewCertificateUpdater
 	reportOpenedState        = func(interface{}) {}
 	reportOpenedAPI          = func(interface{}) {}
@@ -629,13 +627,6 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 
 	runner.StartWorker("rsyslog", func() (worker.Worker, error) {
 		return cmdutil.NewRsyslogConfigWorker(st.Rsyslog(), agentConfig, rsyslogMode)
-	})
-	runner.StartWorker("diskmanager", func() (worker.Worker, error) {
-		api, err := st.DiskManager()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		return newDiskManager(diskmanager.DefaultListBlockDevices, api), nil
 	})
 
 	// Check if the network management is disabled.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -32,7 +32,7 @@ gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:0
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/goamz	bzr	martin.packman@canonical.com-20140813150539-umttn7s536u85eiz	49
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20141121040613-ztm1q0iy9rune3zt	13
-launchpad.net/gomaasapi	bzr	raphael.badin@canonical.com-20141030154602-5noqak0jfeao9opr	58
+launchpad.net/gomaasapi	bzr	michael.foord@canonical.com-20150109124609-7a4llpwlmlcjbynw	59
 launchpad.net/goose	bzr	tarmac-20140908075634-5iinsru19k3d8w55	128
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20141203072923-27pcp2hckqyezbfe	242
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -180,7 +180,7 @@ func (env *maasEnviron) SupportedArchitectures() ([]string, error) {
 		return env.supportedArchitectures, nil
 	}
 	bootImages, err := env.allBootImages()
-	if err != nil {
+	if err != nil || len(bootImages) == 0 {
 		logger.Debugf("error querying boot-images: %v", err)
 		logger.Debugf("falling back to listing nodes")
 		supportedArchitectures, err := env.nodeArchitectures()
@@ -258,6 +258,55 @@ func (env *maasEnviron) getNodegroups() ([]string, error) {
 		nodegroups[i] = uuid
 	}
 	return nodegroups, nil
+}
+
+func (env *maasEnviron) getNodegroupInterfaces(nodegroups []string) map[string][]net.IP {
+	nodegroupsObject := env.getMAASClient().GetSubObject("nodegroups")
+
+	nodegroupsInterfacesMap := make(map[string][]net.IP)
+	for _, uuid := range nodegroups {
+		interfacesObject := nodegroupsObject.GetSubObject(uuid).GetSubObject("interfaces")
+		interfacesResult, err := interfacesObject.CallGet("list", nil)
+		if err != nil {
+			logger.Warningf("could not fetch nodegroup-interfaces for nodegroup %v: %v", uuid, err)
+			continue
+		}
+		interfaces, err := interfacesResult.GetArray()
+		if err != nil {
+			logger.Warningf("could not fetch nodegroup-interfaces for nodegroup %v: %v", uuid, err)
+			continue
+		}
+		for _, interfaceResult := range interfaces {
+			nic, err := interfaceResult.GetMap()
+			if err != nil {
+				logger.Warningf("could not fetch interface %v for nodegroup %v: %v", nic, uuid, err)
+				continue
+			}
+			ip, err := nic["ip"].GetString()
+			if err != nil {
+				logger.Warningf("could not fetch interface %v for nodegroup %v: %v", nic, uuid, err)
+				continue
+			}
+			static_low, err := nic["static_ip_range_low"].GetString()
+			if err != nil {
+				logger.Warningf("could not fetch static IP range lower bound for interface %v on nodegroup %v: %v", nic, uuid, err)
+				continue
+			}
+			static_high, err := nic["static_ip_range_high"].GetString()
+			if err != nil {
+				logger.Warningf("could not fetch static IP range higher bound for interface %v on nodegroup %v: %v", nic, uuid, err)
+				continue
+			}
+			static_low_ip := net.ParseIP(static_low)
+			static_high_ip := net.ParseIP(static_high)
+			if static_low_ip == nil || static_high_ip == nil {
+				logger.Warningf("invalid IP in static range for interface %v on nodegroup %v: %q %q", nic, uuid, static_low_ip, static_high_ip)
+				continue
+			}
+			nodegroupsInterfacesMap[ip] = []net.IP{static_low_ip, static_high_ip}
+		}
+	}
+	return nodegroupsInterfacesMap
 }
 
 type bootImage struct {
@@ -1172,17 +1221,33 @@ func (environ *maasEnviron) Subnets(instId instance.Id) ([]network.SubnetInfo, e
 		return nil, errors.Annotatef(err, "getInstanceNetworks failed")
 	}
 	logger.Debugf("node %q has networks %v", instId, networks)
+
+	nodegroups, err := environ.getNodegroups()
+	if err != nil {
+		return nil, errors.Annotatef(err, "getNodegroups failed")
+	}
+	nodegroupInterfaces := environ.getNodegroupInterfaces(nodegroups)
 	var networkInfo []network.SubnetInfo
 	for _, netw := range networks {
 		netCIDR := &net.IPNet{
 			IP:   net.ParseIP(netw.IP),
 			Mask: net.IPMask(net.ParseIP(netw.Mask)),
 		}
-		// TODO: (mfoord 2014-12-17) need to fill in AllocatableIPLow & High
+		var allocatableHigh, allocatableLow net.IP
+		for ip, bounds := range nodegroupInterfaces {
+			contained := netCIDR.Contains(net.ParseIP(ip))
+			if contained {
+				allocatableLow = bounds[0]
+				allocatableHigh = bounds[1]
+				break
+			}
+		}
 		netInfo := network.SubnetInfo{
-			CIDR:       netCIDR.String(),
-			VLANTag:    netw.VLANTag,
-			ProviderId: network.Id(netw.Name),
+			CIDR:              netCIDR.String(),
+			VLANTag:           netw.VLANTag,
+			ProviderId:        network.Id(netw.Name),
+			AllocatableIPLow:  allocatableLow,
+			AllocatableIPHigh: allocatableHigh,
 		}
 
 		// Verify we filled-in everything for all networks

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/url"
 	"text/template"
 
@@ -995,6 +996,63 @@ func (suite *environSuite) createSubnets(c *gc.C) instance.Instance {
 	// resulting CIDR 192.168.1.1/24
 	suite.getNetwork("WLAN", 1, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
+
+	// needed for getNodeGroups to work
+	suite.testMAASObject.TestServer.AddBootImage("uuid-0", `{"architecture": "amd64", "release": "precise"}`)
+	suite.testMAASObject.TestServer.AddBootImage("uuid-1", `{"architecture": "amd64", "release": "precise"}`)
+
+	jsonText1 := `{
+		"ip_range_high":        "192.168.2.255",
+		"ip_range_low":         "192.168.2.128",
+		"broadcast_ip":         "192.168.2.255",
+		"static_ip_range_low":  "192.168.2.0",
+		"name":                 "eth0",
+		"ip":                   "192.168.2.1",
+		"subnet_mask":          "255.255.255.0",
+		"management":           2,
+		"static_ip_range_high": "192.168.2.127",
+		"interface":            "eth0"
+	}`
+	jsonText2 := `{
+		"ip_range_high":        "172.16.0.128",
+		"ip_range_low":         "172.16.0.2",
+		"broadcast_ip":         "172.16.0.255",
+		"static_ip_range_low":  "172.16.0.129",
+		"name":                 "eth0",
+		"ip":                   "172.16.0.2",
+		"subnet_mask":          "255.255.255.0",
+		"management":           2,
+		"static_ip_range_high": "172.16.0.255",
+		"interface":            "eth0"
+	}`
+	jsonText3 := `{
+		"ip_range_high":        "192.168.1.128",
+		"ip_range_low":         "192.168.1.2",
+		"broadcast_ip":         "192.168.1.255",
+		"static_ip_range_low":  "192.168.1.129",
+		"name":                 "eth0",
+		"ip":                   "192.168.1.2",
+		"subnet_mask":          "255.255.255.0",
+		"management":           2,
+		"static_ip_range_high": "192.168.1.255",
+		"interface":            "eth0"
+	}`
+	jsonText4 := `{
+		"ip_range_high":        "172.16.8.128",
+		"ip_range_low":         "172.16.8.2",
+		"broadcast_ip":         "172.16.8.255",
+		"static_ip_range_low":  "172.16.0.129",
+		"name":                 "eth0",
+		"ip":                   "172.16.8.2",
+		"subnet_mask":          "255.255.255.0",
+		"management":           2,
+		"static_ip_range_high": "172.16.8.255",
+		"interface":            "eth0"
+	}`
+	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-0", jsonText1)
+	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-0", jsonText2)
+	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-1", jsonText3)
+	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-1", jsonText4)
 	return test_instance
 }
 
@@ -1005,10 +1063,9 @@ func (suite *environSuite) TestSubnets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedInfo := []network.SubnetInfo{
-		{CIDR: "192.168.2.1/24", ProviderId: "LAN", VLANTag: 42},
+		{CIDR: "192.168.2.1/24", ProviderId: "LAN", VLANTag: 42, AllocatableIPLow: net.ParseIP("192.168.2.0"), AllocatableIPHigh: net.ParseIP("192.168.2.127")},
 		{CIDR: "192.168.3.1/24", ProviderId: "Virt", VLANTag: 0},
-		{CIDR: "192.168.1.1/24", ProviderId: "WLAN", VLANTag: 0},
-	}
+		{CIDR: "192.168.1.1/24", ProviderId: "WLAN", VLANTag: 0, AllocatableIPLow: net.ParseIP("192.168.1.129"), AllocatableIPHigh: net.ParseIP("192.168.1.255")}}
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
 }
 
@@ -1029,7 +1086,7 @@ func (suite *environSuite) TestAllocateAddressInvalidInstance(c *gc.C) {
 }
 
 func (suite *environSuite) TestAllocateAddressMissingSubnet(c *gc.C) {
-	test_instance := suite.getInstance("node1")
+	test_instance := suite.createSubnets(c)
 	env := suite.makeEnviron()
 	err := env.AllocateAddress(test_instance.Id(), "bar", network.Address{Value: "192.168.2.1"})
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "could not find network matching bar")


### PR DESCRIPTION
Storage is incomplete, so the worker is of
no value currently. Disable so we do not
populate state with data whose schema may
change. On master, the worker is enabled
only if the "storage" feature flag is set.

(Review request: http://reviews.vapour.ws/r/715/)