### PR TITLE
Connect block device model to machine provisioner

### DIFF
--- a/api/networker/networker_test.go
+++ b/api/networker/networker_test.go
@@ -105,7 +105,7 @@ func (s *networkerSuite) setUpMachine(c *gc.C) {
 		IsVirtual:     false,
 		Disabled:      true,
 	}}
-	err = s.machine.SetInstanceInfo("i-am", "fake_nonce", &hwChars, s.networks, s.machineIfaces)
+	err = s.machine.SetInstanceInfo("i-am", "fake_nonce", &hwChars, s.networks, s.machineIfaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAsMachine(c, s.machine.Tag(), password, "fake_nonce")
 	c.Assert(s.st, gc.NotNil)
@@ -138,7 +138,7 @@ func (s *networkerSuite) setUpContainers(c *gc.C) {
 	}}
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
 	err = s.container.SetInstanceInfo("i-container", "fake_nonce", &hwChars, s.networks[:2],
-		s.containerIfaces)
+		s.containerIfaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.nestedContainer, err = s.State.AddMachineInsideMachine(template, s.container.Id(), instance.LXC)
@@ -150,7 +150,7 @@ func (s *networkerSuite) setUpContainers(c *gc.C) {
 		IsVirtual:     false,
 	}}
 	err = s.nestedContainer.SetInstanceInfo("i-too", "fake_nonce", &hwChars, s.networks[:1],
-		s.nestedContainerIfaces)
+		s.nestedContainerIfaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
 )
 
 // Machine represents a juju machine as seen by the provisioner worker.
@@ -182,7 +183,7 @@ func (m *Machine) DistributionGroup() ([]instance.Id, error) {
 // instance id cannot be changed.
 func (m *Machine) SetInstanceInfo(
 	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
-	networks []params.Network, interfaces []params.NetworkInterface,
+	networks []params.Network, interfaces []params.NetworkInterface, disks []storage.BlockDevice,
 ) error {
 	var result params.ErrorResults
 	args := params.InstancesInfo{
@@ -193,6 +194,7 @@ func (m *Machine) SetInstanceInfo(
 			Characteristics: characteristics,
 			Networks:        networks,
 			Interfaces:      interfaces,
+			Disks:           disks,
 		}},
 	}
 	err := m.st.facade.FacadeCall("SetInstanceInfo", args, &result)

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -62,7 +62,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine.SetInstanceInfo("i-manager", "fake_nonce", nil, nil, nil)
+	err = s.machine.SetInstanceInfo("i-manager", "fake_nonce", nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAsMachine(c, s.machine.Tag(), password, "fake_nonce")
 	c.Assert(s.st, gc.NotNil)
@@ -282,7 +282,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 		IsVirtual:     false,
 	}}
 
-	err = apiMachine.SetInstanceInfo("i-will", "fake_nonce", &hwChars, networks, ifaces)
+	err = apiMachine.SetInstanceInfo("i-will", "fake_nonce", &hwChars, networks, ifaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceId, err = apiMachine.InstanceId()
@@ -290,8 +290,8 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(instanceId, gc.Equals, instance.Id("i-will"))
 
 	// Try it again - should fail.
-	err = apiMachine.SetInstanceInfo("i-wont", "fake", nil, nil, nil)
-	c.Assert(err, gc.ErrorMatches, `aborted instance "i-wont": cannot set instance data for machine "1": already set`)
+	err = apiMachine.SetInstanceInfo("i-wont", "fake", nil, nil, nil, nil)
+	c.Assert(err, gc.ErrorMatches, `cannot record provisioning info for "i-wont": cannot set instance data for machine "1": already set`)
 
 	// Now try to get machine 0's instance id.
 	apiMachine, err = s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
@@ -366,7 +366,7 @@ func (s *provisionerSuite) TestDistributionGroup(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
-	err = apiMachine.SetInstanceInfo("i-d", "fake", nil, nil, nil)
+	err = apiMachine.SetInstanceInfo("i-d", "fake", nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	instances, err = apiMachine.DistributionGroup()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/networker/networker_test.go
+++ b/apiserver/networker/networker_test.go
@@ -102,7 +102,7 @@ func (s *networkerSuite) setUpMachine(c *gc.C) {
 		IsVirtual:     false,
 		Disabled:      true,
 	}}
-	err = s.machine.SetInstanceInfo("i-am", "fake_nonce", &hwChars, s.networks, s.machineIfaces)
+	err = s.machine.SetInstanceInfo("i-am", "fake_nonce", &hwChars, s.networks, s.machineIfaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -133,7 +133,7 @@ func (s *networkerSuite) setUpContainers(c *gc.C) {
 	}}
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
 	err = s.container.SetInstanceInfo("i-container", "fake_nonce", &hwChars, s.networks[:2],
-		s.containerIfaces)
+		s.containerIfaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.nestedContainer, err = s.State.AddMachineInsideMachine(template, s.container.Id(), instance.LXC)
@@ -144,7 +144,7 @@ func (s *networkerSuite) setUpContainers(c *gc.C) {
 		NetworkName:   "net1",
 	}}
 	err = s.nestedContainer.SetInstanceInfo("i-too", "fake_nonce", &hwChars, s.networks[:1],
-		s.nestedContainerIfaces)
+		s.nestedContainerIfaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -406,6 +406,7 @@ type InstanceInfo struct {
 	Characteristics *instance.HardwareCharacteristics
 	Networks        []Network
 	Interfaces      []NetworkInterface
+	Disks           []storage.BlockDevice
 }
 
 // InstancesInfo holds the parameters for making a SetInstanceInfo
@@ -642,6 +643,7 @@ type ProvisioningInfo struct {
 	Placement   string
 	Networks    []string
 	Jobs        []multiwatcher.MachineJob
+	Disks       []storage.DiskParams
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -528,7 +528,7 @@ func machineDiskParams(m *state.Machine) ([]storage.DiskParams, error) {
 	for i, dev := range blockDevices {
 		params, ok := dev.Params()
 		if !ok {
-			return nil, errors.Errorf("cannot get parameters to create disk %q", dev.Name())
+			return nil, errors.Errorf("cannot get parameters for disk %q", dev.Name())
 		}
 		allParams[i] = storage.DiskParams{
 			dev.Name(),

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/storage"
 )
 
 func init() {
@@ -371,6 +372,10 @@ func getProvisioningInfo(m *state.Machine) (*params.ProvisioningInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	disks, err := machineDiskParams(m)
+	if err != nil {
+		return nil, err
+	}
 	// TODO(dimitern) For now, since network names and
 	// provider ids are the same, we return what we got
 	// from state. In the future, when networks can be
@@ -391,6 +396,7 @@ func getProvisioningInfo(m *state.Machine) (*params.ProvisioningInfo, error) {
 		Placement:   m.Placement(),
 		Networks:    networks,
 		Jobs:        jobs,
+		Disks:       disks,
 	}, nil
 }
 
@@ -507,6 +513,54 @@ func (p *ProvisionerAPI) Constraints(args params.Entities) (params.ConstraintsRe
 	return result, nil
 }
 
+// machineDiskParams retrieves DiskParams for the disks that should be
+// provisioned with and attached to the machine. The client should ignore
+// parameters that it does not know how to handle.
+func machineDiskParams(m *state.Machine) ([]storage.DiskParams, error) {
+	blockDevices, err := m.BlockDevices()
+	if err != nil {
+		return nil, err
+	}
+	if len(blockDevices) == 0 {
+		return nil, nil
+	}
+	allParams := make([]storage.DiskParams, len(blockDevices))
+	for i, dev := range blockDevices {
+		params, ok := dev.Params()
+		if !ok {
+			return nil, errors.Errorf("cannot get parameters to create disk %q", dev.Name())
+		}
+		allParams[i] = storage.DiskParams{
+			dev.Name(),
+			params.Size,
+			// TODO(axw) when pools are implemented,
+			// set Options here.
+			nil,
+		}
+	}
+	return allParams, nil
+}
+
+// blockDevicesToState converts a slice of storage.BlockDevice to a mapping
+// of block device names to state.BlockDeviceInfo.
+func blockDevicesToState(in []storage.BlockDevice) (map[string]state.BlockDeviceInfo, error) {
+	m := make(map[string]state.BlockDeviceInfo)
+	for _, dev := range in {
+		if dev.Name == "" {
+			return nil, errors.New("Name is empty")
+		}
+		m[dev.Name] = state.BlockDeviceInfo{
+			dev.DeviceName,
+			dev.Label,
+			dev.UUID,
+			dev.Serial,
+			dev.Size,
+			dev.InUse,
+		}
+	}
+	return m, nil
+}
+
 func networkParamsToStateParams(networks []params.Network, ifaces []params.NetworkInterface) (
 	[]state.NetworkInfo, []state.NetworkInterfaceInfo, error,
 ) {
@@ -617,27 +671,36 @@ func (p *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Erro
 	if err != nil {
 		return result, err
 	}
-	for i, arg := range args.Machines {
+	setInstanceInfo := func(arg params.InstanceInfo) error {
 		tag, err := names.ParseMachineTag(arg.Tag)
 		if err != nil {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
+			return common.ErrPerm
 		}
 		machine, err := p.getMachine(canAccess, tag)
-		if err == nil {
-			var networks []state.NetworkInfo
-			var interfaces []state.NetworkInterfaceInfo
-			networks, interfaces, err = networkParamsToStateParams(arg.Networks, arg.Interfaces)
-			if err == nil {
-				err = machine.SetInstanceInfo(
-					arg.InstanceId, arg.Nonce, arg.Characteristics,
-					networks, interfaces)
-			}
-			if err != nil {
-				// Give the user more context about the error.
-				err = fmt.Errorf("aborted instance %q: %v", arg.InstanceId, err)
-			}
+		if err != nil {
+			return err
 		}
+		networks, interfaces, err := networkParamsToStateParams(arg.Networks, arg.Interfaces)
+		if err != nil {
+			return err
+		}
+		blockDevices, err := blockDevicesToState(arg.Disks)
+		if err != nil {
+			return err
+		}
+		if err = machine.SetInstanceInfo(
+			arg.InstanceId, arg.Nonce, arg.Characteristics,
+			networks, interfaces, blockDevices); err != nil {
+			return errors.Annotatef(
+				err,
+				"cannot record provisioning info for %q",
+				arg.InstanceId,
+			)
+		}
+		return nil
+	}
+	for i, arg := range args.Machines {
+		err := setInstanceInfo(arg)
 		result.Results[i].Error = common.ServerError(err)
 	}
 	return result, nil

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -374,7 +374,7 @@ func getProvisioningInfo(m *state.Machine) (*params.ProvisioningInfo, error) {
 	}
 	disks, err := machineDiskParams(m)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	// TODO(dimitern) For now, since network names and
 	// provider ids are the same, we return what we got

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -731,6 +732,7 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 		Constraints:       cons,
 		Placement:         "valid",
 		RequestedNetworks: []string{"net1", "net2"},
+		BlockDevices:      []state.BlockDeviceParams{{Size: 1000}, {Size: 2000}},
 	}
 	placementMachine, err := s.State.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
@@ -757,6 +759,7 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 				Placement:   template.Placement,
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+				Disks:       []storage.DiskParams{{Name: "0", Size: 1000}, {Name: "1", Size: 2000}},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -919,8 +922,14 @@ func (s *withoutStateServerSuite) TestSetProvisioned(c *gc.C) {
 func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 	// Provision machine 0 first.
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
-	err := s.machines[0].SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil)
+	err := s.machines[0].SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
+
+	disksMachine, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series:       "quantal",
+		Jobs:         []state.MachineJob{state.JobHostUnits},
+		BlockDevices: []state.BlockDeviceParams{{Size: 1000}},
+	})
 
 	networks := []params.Network{{
 		Tag:        "network-net1",
@@ -993,6 +1002,11 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		Characteristics: nil,
 		Networks:        networks,
 		Interfaces:      ifaces,
+	}, {
+		Tag:        disksMachine.Tag().String(),
+		InstanceId: "i-am-also",
+		Nonce:      "fake",
+		Disks:      []storage.BlockDevice{{Name: "0", Size: 1234}},
 	},
 		{Tag: "machine-42"},
 		{Tag: "unit-foo-0"},
@@ -1003,8 +1017,9 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
 			{&params.Error{
-				Message: `aborted instance "i-was": cannot set instance data for machine "0": already set`,
+				Message: `cannot record provisioning info for "i-was": cannot set instance data for machine "0": already set`,
 			}},
+			{nil},
 			{nil},
 			{nil},
 			{apiservertesting.NotFoundError("machine 42")},
@@ -1065,6 +1080,15 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		c.Check(network.VLANTag(), gc.Equals, networks[i].VLANTag)
 		c.Check(network.CIDR(), gc.Equals, networks[i].CIDR)
 	}
+
+	// Verify the machine with requested disks was provisioned, and the
+	// disk information recorded in state.
+	blockDevices, err := disksMachine.BlockDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blockDevices, gc.HasLen, 1)
+	blockDeviceInfo, err := blockDevices[0].Info()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blockDeviceInfo, gc.Equals, state.BlockDeviceInfo{Size: 1234})
 }
 
 func (s *withoutStateServerSuite) TestInstanceId(c *gc.C) {

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1089,6 +1089,12 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 	blockDeviceInfo, err := blockDevices[0].Info()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blockDeviceInfo, gc.Equals, state.BlockDeviceInfo{Size: 1234})
+
+	// Verify the machine without requested disks still has no disks
+	// recorded in state.
+	blockDevices, err = s.machines[1].BlockDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blockDevices, gc.HasLen, 0)
 }
 
 func (s *withoutStateServerSuite) TestInstanceId(c *gc.C) {

--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -74,7 +74,6 @@ func getBlockDeviceMappings(
 	// unmap ephemeral0 in cloud-init.
 
 	disks := make([]storage.BlockDevice, len(args.Disks))
-	mappings := make([]ec2.BlockDeviceMapping, len(args.Disks))
 	nextDeviceName := blockDeviceNamer(virtType == paravirtual)
 	for i, params := range args.Disks {
 		// Check minimum constraints can be satisfied.
@@ -98,7 +97,7 @@ func getBlockDeviceMappings(
 			// ProviderId will be filled in once the instance has
 			// been created, which will create the volumes too.
 		}
-		mappings[i] = mapping
+		blockDeviceMappings = append(blockDeviceMappings, mapping)
 		disks[i] = disk
 	}
 	return blockDeviceMappings, disks, nil

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -8,8 +8,11 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	amzec2 "launchpad.net/goamz/ec2"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/ec2"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 )
 
@@ -74,4 +77,46 @@ func (*DisksSuite) TestBlockDeviceNamer(c *gc.C) {
 	expectN("/dev/sdo", "xvdo")
 	expectN("/dev/sdp", "xvdp")
 	expectErr("too many EBS volumes to attach")
+}
+
+func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
+	mapping, blockDeviceInfo, err := ec2.GetBlockDeviceMappings(
+		"pv", &environs.StartInstanceParams{Disks: []storage.DiskParams{{
+			Name: "0", Size: 1234,
+		}, {
+			Name: "1", Size: 4321,
+		}}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mapping, gc.DeepEquals, []amzec2.BlockDeviceMapping{{
+		VolumeSize: 8,
+		DeviceName: "/dev/sda1",
+	}, {
+		VirtualName: "ephemeral0",
+		DeviceName:  "/dev/sdb",
+	}, {
+		VirtualName: "ephemeral1",
+		DeviceName:  "/dev/sdc",
+	}, {
+		VirtualName: "ephemeral2",
+		DeviceName:  "/dev/sdd",
+	}, {
+		VirtualName: "ephemeral3",
+		DeviceName:  "/dev/sde",
+	}, {
+		VolumeSize: 2,
+		DeviceName: "/dev/sdf1",
+	}, {
+		VolumeSize: 5,
+		DeviceName: "/dev/sdf2",
+	}})
+	c.Assert(blockDeviceInfo, gc.DeepEquals, []storage.BlockDevice{{
+		Name:       "0",
+		DeviceName: "xvdf1",
+		Size:       2048,
+	}, {
+		Name:       "1",
+		DeviceName: "xvdf2",
+		Size:       5120,
+	}})
 }

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -46,6 +46,7 @@ var (
 	AvailabilityZoneAllocations = &availabilityZoneAllocations
 	RunInstances                = &runInstances
 	BlockDeviceNamer            = blockDeviceNamer
+	GetBlockDeviceMappings      = getBlockDeviceMappings
 )
 
 // BucketStorage returns a storage instance addressing

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -451,7 +451,7 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 		createRequestedNetworksOp(st, machineGlobalKey(mdoc.Id), template.RequestedNetworks),
 	}
 
-	diskOps, err := createMachineBlockDeviceOps(st, mdoc.Id, template.BlockDevices...)
+	diskOps, _, err := createMachineBlockDeviceOps(st, mdoc.Id, template.BlockDevices...)
 	if err != nil {
 		return nil, txn.Op{}, errors.Trace(err)
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -32,17 +32,18 @@ const (
 )
 
 var (
-	ToolstorageNewStorage  = &toolstorageNewStorage
-	ImageStorageNewStorage = &imageStorageNewStorage
-	MachineIdLessThan      = machineIdLessThan
-	NewAddress             = newAddress
-	StateServerAvailable   = &stateServerAvailable
-	GetOrCreatePorts       = getOrCreatePorts
-	GetPorts               = getPorts
-	PortsGlobalKey         = portsGlobalKey
-	CurrentUpgradeId       = currentUpgradeId
-	NowToTheSecond         = nowToTheSecond
-	PickAddress            = &pickAddress
+	ToolstorageNewStorage       = &toolstorageNewStorage
+	ImageStorageNewStorage      = &imageStorageNewStorage
+	MachineIdLessThan           = machineIdLessThan
+	NewAddress                  = newAddress
+	StateServerAvailable        = &stateServerAvailable
+	GetOrCreatePorts            = getOrCreatePorts
+	GetPorts                    = getPorts
+	PortsGlobalKey              = portsGlobalKey
+	CurrentUpgradeId            = currentUpgradeId
+	NowToTheSecond              = nowToTheSecond
+	PickAddress                 = &pickAddress
+	CreateMachineBlockDeviceOps = createMachineBlockDeviceOps
 )
 
 type (

--- a/state/machine.go
+++ b/state/machine.go
@@ -900,7 +900,8 @@ func (m *Machine) SetProvisioned(id instance.Id, nonce string, characteristics *
 // Merge SetProvisioned() in here or drop it at that point.
 func (m *Machine) SetInstanceInfo(
 	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
-	networks []NetworkInfo, interfaces []NetworkInterfaceInfo) error {
+	networks []NetworkInfo, interfaces []NetworkInterfaceInfo,
+	blockDevices map[string]BlockDeviceInfo) error {
 
 	// Add the networks and interfaces first.
 	for _, network := range networks {
@@ -920,6 +921,9 @@ func (m *Machine) SetInstanceInfo(
 		} else if err != nil {
 			return errors.Trace(err)
 		}
+	}
+	if err := setProvisionedBlockDeviceInfo(m.st, m.Id(), blockDevices); err != nil {
+		return errors.Trace(err)
 	}
 	return m.SetProvisioned(id, nonce, characteristics)
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -895,8 +895,8 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	c.Assert(err, gc.ErrorMatches, "cannot set provisioned block device info: already provisioned")
 	assertNotProvisioned()
 
-	// Create a disk associated with a different machine, and ensure that trying to SetInstanceInfo
-	// with that disk fails.
+	// Create a disk associated with a different machine, and ensure that trying
+	// to SetInstanceInfo with that disk fails.
 	blockDeviceName := s.createBlockDeviceParams(c, s.machine0.Id(), state.BlockDeviceParams{Size: 1000})
 	invalidBlockDevices = map[string]state.BlockDeviceInfo{blockDeviceName: state.BlockDeviceInfo{}}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidBlockDevices)

--- a/worker/networker/networker_test.go
+++ b/worker/networker/networker_test.go
@@ -241,7 +241,7 @@ func (s *networkerSuite) TestNoModprobeWhenRunningInLXC(c *gc.C) {
 		{Index: 2, MTU: 1500, Name: "eth0", Flags: net.FlagUp},
 	}
 
-	err = lxcMachine.SetInstanceInfo("i-am-lxc", "fake_nonce", nil, s.stateNetworks, lxcInterfaces)
+	err = lxcMachine.SetInstanceInfo("i-am-lxc", "fake_nonce", nil, s.stateNetworks, lxcInterfaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Login to the API as the machine agent of lxcMachine.
@@ -349,7 +349,7 @@ func (s *networkerSuite) setUpMachine(c *gc.C) {
 		NetworkName:   "net2",
 		IsVirtual:     false,
 	}}
-	err = s.stateMachine.SetInstanceInfo("i-am", "fake_nonce", nil, s.stateNetworks, s.stateInterfaces)
+	err = s.stateMachine.SetInstanceInfo("i-am", "fake_nonce", nil, s.stateNetworks, s.stateInterfaces, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.apiState = s.OpenAPIAsMachine(c, s.stateMachine.Tag(), password, "fake_nonce")
 	c.Assert(s.apiState, gc.NotNil)

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -486,6 +486,7 @@ func constructStartInstanceParams(
 		MachineConfig:     machineConfig,
 		Placement:         provisioningInfo.Placement,
 		DistributionGroup: machine.DistributionGroup,
+		Disks:             provisioningInfo.Disks,
 	}
 }
 
@@ -591,12 +592,13 @@ func (task *provisionerTask) startMachine(
 	hardware := result.Hardware
 	nonce := startInstanceParams.MachineConfig.MachineNonce
 	networks, ifaces := task.prepareNetworkAndInterfaces(result.NetworkInfo)
+	disks := result.Disks
 
-	err = machine.SetInstanceInfo(inst.Id(), nonce, hardware, networks, ifaces)
+	err = machine.SetInstanceInfo(inst.Id(), nonce, hardware, networks, ifaces, disks)
 	if err != nil && params.IsCodeNotImplemented(err) {
 		return fmt.Errorf("cannot provision instance %v for machine %q with networks: not implemented", inst.Id(), machine)
 	} else if err == nil {
-		logger.Infof("started machine %s as instance %s with hardware %q, networks %v, interfaces %v", machine, inst.Id(), hardware, networks, ifaces)
+		logger.Infof("started machine %s as instance %s with hardware %q, networks %v, interfaces %v, disks %v", machine, inst.Id(), hardware, networks, ifaces, disks)
 		return nil
 	}
 	// We need to stop the instance right away here, set error status and go on.

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -791,7 +791,7 @@ func (s *ProvisionerSuite) TestSetInstanceInfoFailureSetsErrorStatusAndStopsInst
 			continue
 		}
 		c.Assert(status, gc.Equals, state.StatusError)
-		c.Assert(info, gc.Matches, `aborted instance "dummyenv-0": cannot add network "bad-net1": invalid CIDR address: invalid`)
+		c.Assert(info, gc.Matches, `cannot record provisioning info for "dummyenv-0": cannot add network "bad-net1": invalid CIDR address: invalid`)
 		break
 	}
 	s.checkStopInstances(c, inst)


### PR DESCRIPTION
The provisioner will now obtain a set of requested disks when provisioning
a machine, and will return
(via SetInstanceInfo) a set of provisioned disks along with the existing
instance info.

Also: fix a small bug in the ec2 provider's block device mapping code.

(Review request: http://reviews.vapour.ws/r/717/)