### PR TITLE
renamed network.Info to InterfaceInfo (with extra fields), added it to StartInstanceParams

### DIFF
--- a/api/networker/networker.go
+++ b/api/networker/networker.go
@@ -25,8 +25,9 @@ func NewState(caller base.APICaller) *State {
 	return &State{base.NewFacadeCaller(caller, networkerFacade)}
 }
 
-// MachineNetworkInfo returns information about networks to setup only for a single machine.
-func (st *State) MachineNetworkInfo(tag names.MachineTag) ([]network.Info, error) {
+// MachineNetworkInfo returns information about network interfaces to
+// setup only for a single machine.
+func (st *State) MachineNetworkInfo(tag names.MachineTag) ([]network.InterfaceInfo, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag.String()}},
 	}
@@ -45,7 +46,22 @@ func (st *State) MachineNetworkInfo(tag names.MachineTag) ([]network.Info, error
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	return results.Results[0].Info, nil
+	interfaceInfo := make([]network.InterfaceInfo, len(result.Info))
+	for i, ifaceInfo := range result.Info {
+		interfaceInfo[i].DeviceIndex = ifaceInfo.DeviceIndex
+		interfaceInfo[i].MACAddress = ifaceInfo.MACAddress
+		interfaceInfo[i].CIDR = ifaceInfo.CIDR
+		interfaceInfo[i].NetworkName = ifaceInfo.NetworkName
+		interfaceInfo[i].ProviderId = ifaceInfo.ProviderId
+		interfaceInfo[i].VLANTag = ifaceInfo.VLANTag
+		interfaceInfo[i].InterfaceName = ifaceInfo.InterfaceName
+		interfaceInfo[i].Disabled = ifaceInfo.Disabled
+		// TODO(dimitern) Once we store all the information from
+		// network.InterfaceInfo in state, change this as needed to
+		// return it.
+	}
+
+	return interfaceInfo, nil
 }
 
 // WatchInterfaces returns a NotifyWatcher that notifies of changes to network

--- a/api/networker/networker_test.go
+++ b/api/networker/networker_test.go
@@ -175,7 +175,7 @@ func (s *networkerSuite) TestMachineNetworkInfoPermissionDenied(c *gc.C) {
 
 func (s *networkerSuite) TestMachineNetworkInfo(c *gc.C) {
 	// Expected results of MachineNetworkInfo for a machine and containers
-	expectedMachineInfo := []network.Info{{
+	expectedMachineInfo := []network.InterfaceInfo{{
 		MACAddress:    "aa:bb:cc:dd:ee:f0",
 		CIDR:          "0.1.2.0/24",
 		NetworkName:   "net1",
@@ -212,7 +212,7 @@ func (s *networkerSuite) TestMachineNetworkInfo(c *gc.C) {
 		InterfaceName: "eth2",
 		Disabled:      true,
 	}}
-	expectedContainerInfo := []network.Info{{
+	expectedContainerInfo := []network.InterfaceInfo{{
 		MACAddress:    "aa:bb:cc:dd:ee:e0",
 		CIDR:          "0.1.2.0/24",
 		NetworkName:   "net1",
@@ -234,7 +234,7 @@ func (s *networkerSuite) TestMachineNetworkInfo(c *gc.C) {
 		VLANTag:       42,
 		InterfaceName: "eth1",
 	}}
-	expectedNestedContainerInfo := []network.Info{{
+	expectedNestedContainerInfo := []network.InterfaceInfo{{
 		MACAddress:    "aa:bb:cc:dd:ee:d0",
 		CIDR:          "0.1.2.0/24",
 		NetworkName:   "net1",

--- a/apiserver/networker/networker.go
+++ b/apiserver/networker/networker.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
@@ -77,7 +76,7 @@ func NewNetworkerAPI(
 	}, nil
 }
 
-func (n *NetworkerAPI) oneMachineInfo(id string) ([]network.Info, error) {
+func (n *NetworkerAPI) oneMachineInfo(id string) ([]params.NetworkInfo, error) {
 	machine, err := n.st.Machine(id)
 	if err != nil {
 		return nil, err
@@ -86,13 +85,13 @@ func (n *NetworkerAPI) oneMachineInfo(id string) ([]network.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	info := make([]network.Info, len(ifaces))
+	info := make([]params.NetworkInfo, len(ifaces))
 	for i, iface := range ifaces {
 		nw, err := n.st.Network(iface.NetworkName())
 		if err != nil {
 			return nil, err
 		}
-		info[i] = network.Info{
+		info[i] = params.NetworkInfo{
 			MACAddress:    iface.MACAddress(),
 			CIDR:          nw.CIDR(),
 			NetworkName:   iface.NetworkName(),
@@ -100,6 +99,8 @@ func (n *NetworkerAPI) oneMachineInfo(id string) ([]network.Info, error) {
 			VLANTag:       nw.VLANTag(),
 			InterfaceName: iface.RawInterfaceName(),
 			Disabled:      iface.IsDisabled(),
+			// TODO(dimitern) Add the rest of the fields, once we
+			// store them in state.
 		}
 	}
 	return info, nil

--- a/apiserver/networker/networker_test.go
+++ b/apiserver/networker/networker_test.go
@@ -14,7 +14,6 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 )
@@ -211,7 +210,7 @@ func (s *networkerSuite) TestMachineNetworkInfoPermissions(c *gc.C) {
 
 func (s *networkerSuite) TestMachineNetworkInfo(c *gc.C) {
 	// Expected results of MachineNetworkInfo for a machine and containers
-	expectedMachineInfo := []network.Info{{
+	expectedMachineInfo := []params.NetworkInfo{{
 		MACAddress:    "aa:bb:cc:dd:ee:f0",
 		CIDR:          "0.1.2.0/24",
 		NetworkName:   "net1",
@@ -248,7 +247,7 @@ func (s *networkerSuite) TestMachineNetworkInfo(c *gc.C) {
 		InterfaceName: "eth2",
 		Disabled:      true,
 	}}
-	expectedContainerInfo := []network.Info{{
+	expectedContainerInfo := []params.NetworkInfo{{
 		MACAddress:    "aa:bb:cc:dd:ee:e0",
 		CIDR:          "0.1.2.0/24",
 		NetworkName:   "net1",
@@ -270,7 +269,7 @@ func (s *networkerSuite) TestMachineNetworkInfo(c *gc.C) {
 		VLANTag:       42,
 		InterfaceName: "eth1",
 	}}
-	expectedNestedContainerInfo := []network.Info{{
+	expectedNestedContainerInfo := []params.NetworkInfo{{
 		MACAddress:    "aa:bb:cc:dd:ee:d0",
 		CIDR:          "0.1.2.0/24",
 		NetworkName:   "net1",

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -426,15 +426,79 @@ type RequestedNetworksResults struct {
 	Results []RequestedNetworkResult
 }
 
+// NetworkInfo describes all the necessary information to configure
+// all network interfaces on a machine. This mostly duplicates
+// network.InterfaceInfo type and it's defined here so it can be kept
+// separate and stable as definition to ensure proper wire-format for
+// the API.
+type NetworkInfo struct {
+	// DeviceIndex specifies the order in which the network interface
+	// appears on the host. The primary interface has an index of 0.
+	DeviceIndex int
+
+	// MACAddress is the network interface's hardware MAC address
+	// (e.g. "aa:bb:cc:dd:ee:ff").
+	MACAddress string
+
+	// CIDR of the network, in 123.45.67.89/24 format.
+	CIDR string
+
+	// NetworkName is juju-internal name of the network.
+	// TODO(dimitern) This should be removed or adapted to the model
+	// once spaces are introduced.
+	NetworkName string
+
+	// ProviderId is a provider-specific network id.
+	ProviderId network.Id
+
+	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
+	// normal networks. It's defined by IEEE 802.1Q standard.
+	VLANTag int
+
+	// InterfaceName is the raw OS-specific network device name (e.g.
+	// "eth1", even for a VLAN eth1.42 virtual interface).
+	InterfaceName string
+
+	// Disabled is true when the interface needs to be disabled on the
+	// machine, e.g. not to configure it at all or stop it if running.
+	Disabled bool
+
+	// NoAutoStart is true when the interface should not be configured
+	// to start automatically on boot. By default and for
+	// backwards-compatibility, interfaces are configured to
+	// auto-start.
+	NoAutoStart bool `json:",omitempty"`
+
+	// ConfigType, if set, defines what type of configuration to use.
+	// See network.InterfaceConfigType for more info. If not set, for
+	// backwards-compatibility, "dhcp" is assumed.
+	ConfigType string `json:",omitempty"`
+
+	// Address contains an optional static IP address to configure for
+	// this network interface. The subnet mask to set will be inferred
+	// from the CIDR value.
+	Address string `json:",omitempty"`
+
+	// DNSServers contains an optional list of IP addresses and/or
+	// hostnames to configure as DNS servers for this network
+	// interface.
+	DNSServers []string `json:",omitempty"`
+
+	// Gateway address, if set, defines the default gateway to
+	// configure for this network interface. For containers this
+	// usually (one of) the host address(es).
+	GatewayAddress string `json:",omitempty"`
+
+	// ExtraConfig can contain any valid setting and its value allowed
+	// inside an "iface" section of a interfaces(5) config file, e.g.
+	// "up", "down", "mtu", etc.
+	ExtraConfig map[string]string `json:",omitempty"`
+}
+
 // MachineNetworkInfoResult holds network info for a single machine.
 type MachineNetworkInfoResult struct {
 	Error *Error
-	// TODO(dimitern): Add explicit JSON serialization tags and use
-	// []NetworkInfo (locally defined) instead in order to break the
-	// dependency on the network package, as this potentially
-	// introduces hard to catch and debug wire-format changes in the
-	// protocol when the type changes!
-	Info []network.Info
+	Info  []NetworkInfo `json:"Info"`
 }
 
 // MachineNetworkInfoResults holds network info for multiple machines.

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -43,6 +43,10 @@ type StartInstanceParams struct {
 	// If any of the disks cannot be created, StartInstance must
 	// return an error.
 	Disks []storage.DiskParams
+
+	// NetworkInfo is an optional list of network interface details,
+	// necessary to configure on the instance.
+	NetworkInfo []network.InterfaceInfo
 }
 
 // StartInstanceResult holds the result of an
@@ -55,8 +59,11 @@ type StartInstanceResult struct {
 	// of the newly created instance.
 	Hardware *instance.HardwareCharacteristics
 
-	// NetworkInfo contains information about configured networks.
-	NetworkInfo []network.Info
+	// NetworkInfo contains information about how to configure network
+	// interfaces on the instance. Depending on the provider, this
+	// might be the same StartInstanceParams.NetworkInfo or may be
+	// modified as needed.
+	NetworkInfo []network.InterfaceInfo
 
 	// Disks contains a list of block devices created, each one having
 	// the same Name as one of the DiskParams in StartInstanceParams.Disks.

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -83,7 +83,7 @@ func AssertStartInstance(
 func StartInstance(
 	env environs.Environ, machineId string,
 ) (
-	instance.Instance, *instance.HardwareCharacteristics, []network.Info, error,
+	instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error,
 ) {
 	return StartInstanceWithConstraints(env, machineId, constraints.Value{})
 }
@@ -107,7 +107,7 @@ func AssertStartInstanceWithConstraints(
 func StartInstanceWithConstraints(
 	env environs.Environ, machineId string, cons constraints.Value,
 ) (
-	instance.Instance, *instance.HardwareCharacteristics, []network.Info, error,
+	instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error,
 ) {
 	return StartInstanceWithConstraintsAndNetworks(env, machineId, cons, nil)
 }
@@ -134,7 +134,7 @@ func StartInstanceWithConstraintsAndNetworks(
 	env environs.Environ, machineId string, cons constraints.Value,
 	networks []string,
 ) (
-	instance.Instance, *instance.HardwareCharacteristics, []network.Info, error,
+	instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error,
 ) {
 	params := environs.StartInstanceParams{Constraints: cons}
 	result, err := StartInstanceWithParams(env, machineId, params, networks)

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -11,36 +11,56 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type InfoSuite struct {
-	info []network.Info
+type InterfaceInfoSuite struct {
+	info []network.InterfaceInfo
 }
 
-var _ = gc.Suite(&InfoSuite{})
+var _ = gc.Suite(&InterfaceInfoSuite{})
 
-func (n *InfoSuite) SetUpTest(c *gc.C) {
-	n.info = []network.Info{
+func (s *InterfaceInfoSuite) SetUpTest(c *gc.C) {
+	s.info = []network.InterfaceInfo{
 		{VLANTag: 1, DeviceIndex: 0, InterfaceName: "eth0"},
 		{VLANTag: 0, DeviceIndex: 1, InterfaceName: "eth1"},
 		{VLANTag: 42, DeviceIndex: 2, InterfaceName: "br2"},
+		{ConfigType: network.ConfigDHCP, NoAutoStart: true},
+		{Address: network.NewAddress("0.1.2.3", network.ScopeUnknown)},
+		{DNSServers: network.NewAddresses("1.1.1.1", "2.2.2.2")},
+		{GatewayAddress: network.NewAddress("4.3.2.1", network.ScopeUnknown)},
+		{ExtraConfig: map[string]string{
+			"foo": "bar",
+			"baz": "nonsense",
+		}},
 	}
 }
 
-func (n *InfoSuite) TestActualInterfaceName(c *gc.C) {
-	c.Check(n.info[0].ActualInterfaceName(), gc.Equals, "eth0.1")
-	c.Check(n.info[1].ActualInterfaceName(), gc.Equals, "eth1")
-	c.Check(n.info[2].ActualInterfaceName(), gc.Equals, "br2.42")
+func (s *InterfaceInfoSuite) TestActualInterfaceName(c *gc.C) {
+	c.Check(s.info[0].ActualInterfaceName(), gc.Equals, "eth0.1")
+	c.Check(s.info[1].ActualInterfaceName(), gc.Equals, "eth1")
+	c.Check(s.info[2].ActualInterfaceName(), gc.Equals, "br2.42")
 }
 
-func (n *InfoSuite) TestIsVirtual(c *gc.C) {
-	c.Check(n.info[0].IsVirtual(), jc.IsTrue)
-	c.Check(n.info[1].IsVirtual(), jc.IsFalse)
-	c.Check(n.info[2].IsVirtual(), jc.IsTrue)
+func (s *InterfaceInfoSuite) TestIsVirtual(c *gc.C) {
+	c.Check(s.info[0].IsVirtual(), jc.IsTrue)
+	c.Check(s.info[1].IsVirtual(), jc.IsFalse)
+	c.Check(s.info[2].IsVirtual(), jc.IsTrue)
 }
 
-func (n *InfoSuite) TestIsVLAN(c *gc.C) {
-	c.Check(n.info[0].IsVLAN(), jc.IsTrue)
-	c.Check(n.info[1].IsVLAN(), jc.IsFalse)
-	c.Check(n.info[2].IsVLAN(), jc.IsTrue)
+func (s *InterfaceInfoSuite) TestIsVLAN(c *gc.C) {
+	c.Check(s.info[0].IsVLAN(), jc.IsTrue)
+	c.Check(s.info[1].IsVLAN(), jc.IsFalse)
+	c.Check(s.info[2].IsVLAN(), jc.IsTrue)
+}
+
+func (s *InterfaceInfoSuite) TestAdditionalFields(c *gc.C) {
+	c.Check(s.info[3].ConfigType, gc.Equals, network.ConfigDHCP)
+	c.Check(s.info[3].NoAutoStart, jc.IsTrue)
+	c.Check(s.info[4].Address, jc.DeepEquals, network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	c.Check(s.info[5].DNSServers, jc.DeepEquals, network.NewAddresses("1.1.1.1", "2.2.2.2"))
+	c.Check(s.info[6].GatewayAddress, jc.DeepEquals, network.NewAddress("4.3.2.1", network.ScopeUnknown))
+	c.Check(s.info[7].ExtraConfig, jc.DeepEquals, map[string]string{
+		"foo": "bar",
+		"baz": "nonsense",
+	})
 }
 
 type NetworkSuite struct {

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -92,7 +92,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 		_ []string,
 		possibleTools tools.List,
 		mcfg *cloudinit.MachineConfig,
-	) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error) {
+	) (instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error) {
 		c.Assert(placement, gc.DeepEquals, checkPlacement)
 		c.Assert(cons, gc.DeepEquals, checkCons)
 
@@ -126,7 +126,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 	startInstance := func(
 		_ string, _ constraints.Value, _ []string, _ tools.List, mcfg *cloudinit.MachineConfig,
 	) (
-		instance.Instance, *instance.HardwareCharacteristics, []network.Info, error,
+		instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error,
 	) {
 		return &mockInstance{id: checkInstanceId}, &checkHardware, nil, nil
 	}

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 type allInstancesFunc func() ([]instance.Instance, error)
-type startInstanceFunc func(string, constraints.Value, []string, tools.List, *cloudinit.MachineConfig) (instance.Instance, *instance.HardwareCharacteristics, []network.Info, error)
+type startInstanceFunc func(string, constraints.Value, []string, tools.List, *cloudinit.MachineConfig) (instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error)
 type stopInstancesFunc func([]instance.Id) error
 type getToolsSourcesFunc func() ([]simplestreams.DataSource, error)
 type configFunc func() *config.Config

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -181,7 +181,7 @@ type OpStartInstance struct {
 	Instance         instance.Instance
 	Constraints      constraints.Value
 	Networks         []string
-	NetworkInfo      []network.Info
+	NetworkInfo      []network.InterfaceInfo
 	Info             *mongo.MongoInfo
 	Jobs             []multiwatcher.MachineJob
 	APIInfo          *api.Info
@@ -905,17 +905,17 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	}
 	// Simulate networks added when requested.
 	networks := append(args.Constraints.IncludeNetworks(), args.MachineConfig.Networks...)
-	networkInfo := make([]network.Info, len(networks))
+	networkInfo := make([]network.InterfaceInfo, len(networks))
 	for i, netName := range networks {
 		if strings.HasPrefix(netName, "bad-") {
 			// Simulate we didn't get correct information for the network.
-			networkInfo[i] = network.Info{
+			networkInfo[i] = network.InterfaceInfo{
 				ProviderId:  network.Id(netName),
 				NetworkName: netName,
 				CIDR:        "invalid",
 			}
 		} else {
-			networkInfo[i] = network.Info{
+			networkInfo[i] = network.InterfaceInfo{
 				ProviderId:    network.Id(netName),
 				NetworkName:   netName,
 				CIDR:          fmt.Sprintf("0.%d.2.0/24", i+1),
@@ -924,6 +924,8 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 				MACAddress:    fmt.Sprintf("aa:bb:cc:dd:ee:f%d", i),
 			}
 		}
+		// TODO(dimitern) Add the rest of the network.InterfaceInfo
+		// fields when we can use them.
 	}
 	estate.insts[i.id] = i
 	estate.maxId++

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -728,12 +728,12 @@ func (environ *maasEnviron) ConstraintsValidator() (constraints.Validator, error
 	return validator, nil
 }
 
-// setupNetworks prepares a []network.Info for the given instance. Any
-// networks in networksToDisable will be configured as disabled on the
-// machine. Any disabled network interfaces (as discovered from the
-// lshw output for the node) will stay disabled. The interface name
-// discovered as primary is also returned.
-func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisable set.Strings) ([]network.Info, string, error) {
+// setupNetworks prepares a []network.InterfaceInfo for the given
+// instance. Any networks in networksToDisable will be configured as
+// disabled on the machine. Any disabled network interfaces (as
+// discovered from the lshw output for the node) will stay disabled.
+// The interface name discovered as primary is also returned.
+func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisable set.Strings) ([]network.InterfaceInfo, string, error) {
 	// Get the instance network interfaces first.
 	interfaces, primaryIface, err := environ.getInstanceNetworkInterfaces(inst)
 	if err != nil {
@@ -745,7 +745,7 @@ func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisa
 		return nil, "", errors.Annotatef(err, "getInstanceNetworks failed")
 	}
 	logger.Debugf("node %q has networks %v", inst.Id(), networks)
-	var tempNetworkInfo []network.Info
+	var tempInterfaceInfo []network.InterfaceInfo
 	for _, netw := range networks {
 		disabled := networksToDisable.Contains(netw.Name)
 		netCIDR := &net.IPNet{
@@ -759,7 +759,7 @@ func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisa
 		logger.Debugf("network %q has MACs: %v", netw.Name, macs)
 		for _, mac := range macs {
 			if ifinfo, ok := interfaces[mac]; ok {
-				tempNetworkInfo = append(tempNetworkInfo, network.Info{
+				tempInterfaceInfo = append(tempInterfaceInfo, network.InterfaceInfo{
 					MACAddress:    mac,
 					InterfaceName: ifinfo.InterfaceName,
 					DeviceIndex:   ifinfo.DeviceIndex,
@@ -774,8 +774,8 @@ func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisa
 	}
 	// Verify we filled-in everything for all networks/interfaces
 	// and drop incomplete records.
-	var networkInfo []network.Info
-	for _, info := range tempNetworkInfo {
+	var interfaceInfo []network.InterfaceInfo
+	for _, info := range tempInterfaceInfo {
 		if info.ProviderId == "" || info.NetworkName == "" || info.CIDR == "" {
 			logger.Warningf("ignoring network interface %q: missing network information", info.InterfaceName)
 			continue
@@ -784,10 +784,10 @@ func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisa
 			logger.Warningf("ignoring network %q: missing network interface information", info.ProviderId)
 			continue
 		}
-		networkInfo = append(networkInfo, info)
+		interfaceInfo = append(interfaceInfo, info)
 	}
-	logger.Debugf("node %q network information: %#v", inst.Id(), networkInfo)
-	return networkInfo, primaryIface, nil
+	logger.Debugf("node %q network information: %#v", inst.Id(), interfaceInfo)
+	return interfaceInfo, primaryIface, nil
 }
 
 // DistributeInstances implements the state.InstanceDistributor policy.
@@ -881,7 +881,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	}
 	args.MachineConfig.Tools = selectedTools[0]
 
-	var networkInfo []network.Info
+	var networkInfo []network.InterfaceInfo
 	networkInfo, primaryIface, err := environ.setupNetworks(inst, set.NewStrings(excludeNetworks...))
 	if err != nil {
 		return nil, err

--- a/worker/networker/configfiles_test.go
+++ b/worker/networker/configfiles_test.go
@@ -23,14 +23,14 @@ type configFilesSuite struct {
 var _ = gc.Suite(&configFilesSuite{})
 
 func (s *configFilesSuite) TestSimpleGetters(c *gc.C) {
-	info := network.Info{
+	info := network.InterfaceInfo{
 		InterfaceName: "blah",
 	}
 	data := []byte("some data")
 	cf := networker.NewConfigFile("ethX", "/some/path", info, data)
 	c.Assert(cf.InterfaceName(), gc.Equals, "ethX")
 	c.Assert(cf.FileName(), gc.Equals, "/some/path")
-	c.Assert(cf.NetworkInfo(), jc.DeepEquals, info)
+	c.Assert(cf.InterfaceInfo(), jc.DeepEquals, info)
 	c.Assert(cf.Data(), jc.DeepEquals, data)
 	c.Assert(cf.NeedsUpdating(), jc.IsFalse)
 	c.Assert(cf.IsPendingRemoval(), jc.IsFalse)
@@ -38,7 +38,7 @@ func (s *configFilesSuite) TestSimpleGetters(c *gc.C) {
 }
 
 func (s *configFilesSuite) TestRenderManaged(c *gc.C) {
-	info := network.Info{
+	info := network.InterfaceInfo{
 		InterfaceName: "ethX",
 		VLANTag:       42,
 	}
@@ -68,7 +68,7 @@ iface ethX inet dhcp
 }
 
 func (s *configFilesSuite) TestUpdateData(c *gc.C) {
-	cf := networker.NewConfigFile("ethX", "", network.Info{}, nil)
+	cf := networker.NewConfigFile("ethX", "", network.InterfaceInfo{}, nil)
 	assertData := func(expectData []byte, expectNeedsUpdating bool) {
 		c.Assert(string(cf.Data()), jc.DeepEquals, string(expectData))
 		c.Assert(cf.NeedsUpdating(), gc.Equals, expectNeedsUpdating)
@@ -99,7 +99,7 @@ func (s *configFilesSuite) TestReadData(c *gc.C) {
 
 	err := ioutil.WriteFile(testFile, data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	cf := networker.NewConfigFile("ethX", testFile, network.Info{}, nil)
+	cf := networker.NewConfigFile("ethX", testFile, network.InterfaceInfo{}, nil)
 	err = cf.ReadData()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(cf.Data()), jc.DeepEquals, string(data))
@@ -107,7 +107,7 @@ func (s *configFilesSuite) TestReadData(c *gc.C) {
 }
 
 func (s *configFilesSuite) TestMarkForRemoval(c *gc.C) {
-	cf := networker.NewConfigFile("ethX", "", network.Info{}, nil)
+	cf := networker.NewConfigFile("ethX", "", network.InterfaceInfo{}, nil)
 	c.Assert(cf.IsPendingRemoval(), jc.IsFalse)
 	c.Assert(cf.NeedsUpdating(), jc.IsFalse)
 	cf.MarkForRemoval()
@@ -116,7 +116,7 @@ func (s *configFilesSuite) TestMarkForRemoval(c *gc.C) {
 }
 
 func (s *configFilesSuite) TestIsManaged(c *gc.C) {
-	info := network.Info{
+	info := network.InterfaceInfo{
 		InterfaceName: "ethX",
 	}
 	cf := networker.NewConfigFile("ethX", "", info, nil)
@@ -132,7 +132,7 @@ func (s *configFilesSuite) TestApply(c *gc.C) {
 	testFile := filepath.Join(c.MkDir(), "test")
 	defer os.Remove(testFile)
 
-	cf := networker.NewConfigFile("ethX", testFile, network.Info{}, data)
+	cf := networker.NewConfigFile("ethX", testFile, network.InterfaceInfo{}, data)
 	c.Assert(cf.NeedsUpdating(), jc.IsFalse)
 	c.Assert(cf.IsPendingRemoval(), jc.IsFalse)
 	c.Assert(string(cf.Data()), jc.DeepEquals, string(data))

--- a/worker/networker/export_test.go
+++ b/worker/networker/export_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 // NewConfigFile is a helper use to create a *configFile for testing.
-func NewConfigFile(interfaceName, fileName string, info network.Info, data []byte) ConfigFile {
+func NewConfigFile(interfaceName, fileName string, info network.InterfaceInfo, data []byte) ConfigFile {
 	return &configFile{
 		interfaceName: interfaceName,
 		fileName:      fileName,
-		networkInfo:   info,
+		interfaceInfo: info,
 		data:          data,
 	}
 }

--- a/worker/networker/networker.go
+++ b/worker/networker/networker.go
@@ -62,9 +62,9 @@ type Networker struct {
 	// full file path as key.
 	configFiles map[string]*configFile
 
-	// networkInfo holds the network info for all interfaces
+	// interfaceInfo holds the info for all network interfaces
 	// discovered via the API, using the interface name as key.
-	networkInfo map[string]network.Info
+	interfaceInfo map[string]network.InterfaceInfo
 
 	// interfaces holds all known network interfaces on the machine,
 	// using their name as key.
@@ -98,7 +98,7 @@ func NewNetworker(
 		intrusiveMode: intrusiveMode,
 		configBaseDir: configBaseDir,
 		configFiles:   make(map[string]*configFile),
-		networkInfo:   make(map[string]network.Info),
+		interfaceInfo: make(map[string]network.InterfaceInfo),
 		interfaces:    make(map[string]net.Interface),
 	}
 	go func() {
@@ -278,20 +278,20 @@ func (nw *Networker) updateInterfaces() error {
 
 	// Fetch network info from the API and generate managed config as
 	// needed.
-	if err := nw.fetchNetworkInfo(); err != nil {
+	if err := nw.fetchInterfaceInfo(); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// fetchNetworkInfo makes an API call to get all known *network.Info
-// entries for each interface on the machine. If there are any VLAN
-// interfaces to setup, it also generates commands to load the kernal
-// 8021q VLAN module, if not already loaded and when not running
-// inside an LXC container.
-func (nw *Networker) fetchNetworkInfo() error {
-	networkInfo, err := nw.st.MachineNetworkInfo(nw.tag)
+// fetchInterfaceInfo makes an API call to get all known
+// *network.InterfaceInfo entries for each interface on the machine.
+// If there are any VLAN interfaces to setup, it also generates
+// commands to load the kernal 8021q VLAN module, if not already
+// loaded and when not running inside an LXC container.
+func (nw *Networker) fetchInterfaceInfo() error {
+	interfaceInfo, err := nw.st.MachineNetworkInfo(nw.tag)
 	if err != nil {
 		logger.Errorf("failed to retrieve network info: %v", err)
 		return err
@@ -299,8 +299,8 @@ func (nw *Networker) fetchNetworkInfo() error {
 	logger.Debugf("fetched known network info from state")
 
 	haveVLANs := false
-	nw.networkInfo = make(map[string]network.Info)
-	for _, info := range networkInfo {
+	nw.interfaceInfo = make(map[string]network.InterfaceInfo)
+	for _, info := range interfaceInfo {
 		actualName := info.ActualInterfaceName()
 		logger.Debugf(
 			"have network info for %q: MAC=%q, disabled: %v, vlan-tag: %d",
@@ -312,7 +312,7 @@ func (nw *Networker) fetchNetworkInfo() error {
 		if info.IsVLAN() {
 			haveVLANs = true
 		}
-		nw.networkInfo[actualName] = info
+		nw.interfaceInfo[actualName] = info
 		fullPath := nw.ConfigFile(actualName)
 		cfgFile, ok := nw.configFiles[fullPath]
 		if !ok {
@@ -325,7 +325,7 @@ func (nw *Networker) fetchNetworkInfo() error {
 			}
 			cfgFile = nw.configFiles[fullPath]
 		}
-		cfgFile.networkInfo = info
+		cfgFile.interfaceInfo = info
 
 		// Make sure we generate managed config, in case it changed.
 		cfgFile.UpdateData(cfgFile.RenderManaged())
@@ -441,7 +441,7 @@ func (nw *Networker) prepareVLANModule() {
 func (nw *Networker) prepareUpCommands() {
 	bringUp := []string{}
 	logger.Debugf("preparing to bring interfaces up")
-	for name, info := range nw.networkInfo {
+	for name, info := range nw.interfaceInfo {
 		if nw.IsPrimaryInterfaceOrLoopback(name) {
 			logger.Debugf("skipping primary or loopback interface %q", name)
 			continue
@@ -480,7 +480,7 @@ func (nw *Networker) prepareDownCommands() {
 			logger.Debugf("skipping primary or loopback interface %q", name)
 			continue
 		}
-		info := cfgFile.NetworkInfo()
+		info := cfgFile.InterfaceInfo()
 		if info.Disabled {
 			if InterfaceIsUp(name) {
 				bringDown = append(bringDown, name)

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -537,7 +537,7 @@ func (task *provisionerTask) setErrorStatus(message string, machine *apiprovisio
 	return nil
 }
 
-func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.Info) (
+func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.InterfaceInfo) (
 	networks []params.Network, ifaces []params.NetworkInterface) {
 	if len(networkInfo) == 0 {
 		return nil, nil
@@ -594,6 +594,11 @@ func (task *provisionerTask) startMachine(
 	networks, ifaces := task.prepareNetworkAndInterfaces(result.NetworkInfo)
 	disks := result.Disks
 
+	// TODO(dimitern) In a newer Provisioner API version, change
+	// SetInstanceInfo or add a new method that takes and saves in
+	// state all the information available on a network.InterfaceInfo
+	// for each interface, so we can later manage interfaces
+	// dynamically at run-time.
 	err = machine.SetInstanceInfo(inst.Id(), nonce, hardware, networks, ifaces, disks)
 	if err != nil && params.IsCodeNotImplemented(err) {
 		return fmt.Errorf("cannot provision instance %v for machine %q with networks: not implemented", inst.Id(), machine)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -186,7 +186,7 @@ func (s *CommonProvisionerSuite) checkStartInstanceNoSecureConnection(c *gc.C, m
 func (s *CommonProvisionerSuite) checkStartInstanceCustom(
 	c *gc.C, m *state.Machine,
 	secret string, cons constraints.Value,
-	networks []string, networkInfo []network.Info,
+	networks []string, networkInfo []network.InterfaceInfo,
 	secureServerConnection bool,
 	checkPossibleTools coretools.List,
 	waitInstanceId bool,
@@ -720,7 +720,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithRequestedNetworks(c *gc.C
 	// Add and provision a machine with networks specified.
 	requestedNetworks := []string{"net1", "net2"}
 	cons := constraints.MustParse(s.defaultConstraints.String(), "networks=^net3,^net4")
-	expectNetworkInfo := []network.Info{{
+	expectNetworkInfo := []network.InterfaceInfo{{
 		MACAddress:    "aa:bb:cc:dd:ee:f0",
 		InterfaceName: "eth0",
 		ProviderId:    "net1",
@@ -768,8 +768,8 @@ func (s *ProvisionerSuite) TestSetInstanceInfoFailureSetsErrorStatusAndStopsInst
 	// Add and provision a machine with networks specified.
 	networks := []string{"bad-net1"}
 	// "bad-" prefix for networks causes dummy provider to report
-	// invalid network.Info.
-	expectNetworkInfo := []network.Info{
+	// invalid network.InterfaceInfo.
+	expectNetworkInfo := []network.InterfaceInfo{
 		{ProviderId: "bad-net1", NetworkName: "bad-net1", CIDR: "invalid"},
 	}
 	m, err := s.addMachineWithRequestedNetworks(networks, constraints.Value{})


### PR DESCRIPTION
This paves the way to allow configuring static addresses for containers,
as well as richer NIC configuration (e.g. bridges). Notable changes:

* network.Info is renamed to network.InterfaceInfo
* added params.NetworkInfo which duplicates network.InterfaceInfo, but
  in a backwards-compatible way, adding omitempty JSON tags as needed.
  Also this way params depends less on types defined in other
  packages (e.g. network), so it guarantees a stable on-the-wire
  serialization for the API.
* params.MachineNetworkInfoResult.Info field changed to use
  params.NetworkInfo instead of network.Info (or InterfaceInfo as it's
  now called).
* environs.StartInstanceParams now takes an optional NetworkInfo field
  of type network.InterfaceInfo to allow the provisioner to eventually
  pass static IPs to configure for the network interfaces (among other
  things).

No API version bump needed as all the added fields are optional and not
yet used.

Live tested on local, MAAS, EC2.

(Review request: http://reviews.vapour.ws/r/719/)