### PR TITLE
Remove arch from constraint used in test

### DIFF
--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1186,7 +1186,7 @@ func (s *environSuite) testStartInstanceAvailZone(c *gc.C, zone string) (instanc
 func (s *environSuite) TestStartInstanceUnmetConstraints(c *gc.C) {
 	env := s.bootstrap(c)
 	s.newNode(c, "thenode1", "host1", nil)
-	params := environs.StartInstanceParams{Constraints: constraints.MustParse("mem=8G arch=amd64")}
+	params := environs.StartInstanceParams{Constraints: constraints.MustParse("mem=8G")}
 	_, err := testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, gc.ErrorMatches, "cannot run instances:.* 409.*")
 }


### PR DESCRIPTION
Remove arch from a constraint used in a test to allow the test to run with fake tools on all platforms.

(Review request: http://reviews.vapour.ws/r/721/)