### PR TITLE
Changed to use entity tags as []string rather than params.Entities

### DIFF
--- a/api/annotations/client.go
+++ b/api/annotations/client.go
@@ -25,7 +25,7 @@ func NewClient(st base.APICallCloser) *Client {
 // Get returns annotations that have been set on the given entities.
 func (c *Client) Get(tags []string) ([]params.AnnotationsGetResult, error) {
 	annotations := params.AnnotationsGetResults{}
-	if err := c.facade.FacadeCall("Get", entitiesFromTags(tags), &annotations); err != nil {
+	if err := c.facade.FacadeCall("Get", params.AnnotationsGet{EntityTags: tags}, &annotations); err != nil {
 		return annotations.Results, errors.Trace(err)
 	}
 	return annotations.Results, nil
@@ -40,19 +40,11 @@ func (c *Client) Set(annotations map[string]map[string]string) error {
 	return nil
 }
 
-func entitiesFromTags(tags []string) params.Entities {
-	entities := []params.Entity{}
-	for _, tag := range tags {
-		entities = append(entities, params.Entity{tag})
-	}
-	return params.Entities{entities}
-}
-
 func entitiesAnnotations(annotations map[string]map[string]string) []params.EntityAnnotations {
 	all := []params.EntityAnnotations{}
 	for tag, pairs := range annotations {
 		one := params.EntityAnnotations{
-			Entity:      params.Entity{tag},
+			EntityTag:   tag,
 			Annotations: pairs,
 		}
 		all = append(all, one)

--- a/api/annotations/client.go
+++ b/api/annotations/client.go
@@ -25,7 +25,7 @@ func NewClient(st base.APICallCloser) *Client {
 // Get returns annotations that have been set on the given entities.
 func (c *Client) Get(tags []string) ([]params.AnnotationsGetResult, error) {
 	annotations := params.AnnotationsGetResults{}
-	if err := c.facade.FacadeCall("Get", params.AnnotationsGet{EntityTags: tags}, &annotations); err != nil {
+	if err := c.facade.FacadeCall("Get", entitiesFromTags(tags), &annotations); err != nil {
 		return annotations.Results, errors.Trace(err)
 	}
 	return annotations.Results, nil
@@ -38,6 +38,14 @@ func (c *Client) Set(annotations map[string]map[string]string) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func entitiesFromTags(tags []string) params.Entities {
+	entities := []params.Entity{}
+	for _, tag := range tags {
+		entities = append(entities, params.Entity{tag})
+	}
+	return params.Entities{entities}
 }
 
 func entitiesAnnotations(annotations map[string]map[string]string) []params.EntityAnnotations {

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -71,11 +71,10 @@ func (s *annotationsMockSuite) TestGetEntitiesAnnotations(c *gc.C) {
 			c.Check(objType, gc.Equals, "Annotations")
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "Get")
-			args, ok := a.(params.AnnotationsGet)
+			args, ok := a.(params.Entities)
 			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.EntityTags, gc.HasLen, 1)
-			c.Assert(args.EntityTags[0], gc.Equals, "charm")
-
+			c.Assert(args.Entities, gc.HasLen, 1)
+			c.Assert(args.Entities[0], gc.DeepEquals, params.Entity{"charm"})
 			result := response.(*params.AnnotationsGetResults)
 			facadeAnnts := map[string]string{
 				"annotations": "test",

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -49,7 +49,7 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 				// architectures vary the order within params.AnnotationsSet,
 				// simply assert that each entity has its own annotations.
 				// Bug 1409141
-				c.Assert(aParam.Annotations, gc.DeepEquals, setParams[aParam.Entity.Tag])
+				c.Assert(aParam.Annotations, gc.DeepEquals, setParams[aParam.EntityTag])
 			}
 			return nil
 		})
@@ -71,17 +71,17 @@ func (s *annotationsMockSuite) TestGetEntitiesAnnotations(c *gc.C) {
 			c.Check(objType, gc.Equals, "Annotations")
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "Get")
-			args, ok := a.(params.Entities)
+			args, ok := a.(params.AnnotationsGet)
 			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Entities, gc.HasLen, 1)
-			c.Assert(args.Entities[0], gc.DeepEquals, params.Entity{"charm"})
+			c.Assert(args.EntityTags, gc.HasLen, 1)
+			c.Assert(args.EntityTags[0], gc.Equals, "charm")
 
 			result := response.(*params.AnnotationsGetResults)
 			facadeAnnts := map[string]string{
 				"annotations": "test",
 			}
 			entitiesAnnts := params.AnnotationsGetResult{
-				Entity:      params.Entity{"charm"},
+				EntityTag:   "charm",
 				Annotations: facadeAnnts,
 			}
 			result.Results = []params.AnnotationsGetResult{entitiesAnnts}

--- a/apiserver/annotations/client.go
+++ b/apiserver/annotations/client.go
@@ -22,7 +22,7 @@ var getState = func(st *state.State) annotationAccess {
 
 // Annotations defines the methods on the service API end point.
 type Annotations interface {
-	Get(args params.Entities) params.AnnotationsGetResults
+	Get(args params.AnnotationsGet) params.AnnotationsGetResults
 	Set(args params.AnnotationsSet) params.ErrorResults
 }
 
@@ -52,12 +52,12 @@ func NewAPI(
 // Get returns annotations for given entities.
 // If annotations cannot be retrieved for a given entity, an error is returned.
 // Each entity is treated independently and, hence, will fail or succeed independently.
-func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
+func (api *API) Get(args params.AnnotationsGet) params.AnnotationsGetResults {
 	entityResults := []params.AnnotationsGetResult{}
-	for _, entity := range args.Entities {
-		anEntityResult := params.AnnotationsGetResult{Entity: entity}
-		if annts, err := api.getEntityAnnotations(entity.Tag); err != nil {
-			anEntityResult.Error = params.ErrorResult{annotateError(err, entity.Tag, "getting")}
+	for _, entity := range args.EntityTags {
+		anEntityResult := params.AnnotationsGetResult{EntityTag: entity}
+		if annts, err := api.getEntityAnnotations(entity); err != nil {
+			anEntityResult.Error = params.ErrorResult{annotateError(err, entity, "getting")}
 		} else {
 			anEntityResult.Annotations = annts
 		}
@@ -70,10 +70,10 @@ func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
 func (api *API) Set(args params.AnnotationsSet) params.ErrorResults {
 	setErrors := []params.ErrorResult{}
 	for _, entityAnnotation := range args.Annotations {
-		err := api.setEntityAnnotations(entityAnnotation.Entity.Tag, entityAnnotation.Annotations)
+		err := api.setEntityAnnotations(entityAnnotation.EntityTag, entityAnnotation.Annotations)
 		if err != nil {
 			setErrors = append(setErrors,
-				params.ErrorResult{Error: annotateError(err, entityAnnotation.Entity.Tag, "setting")})
+				params.ErrorResult{Error: annotateError(err, entityAnnotation.EntityTag, "setting")})
 		}
 	}
 	return params.ErrorResults{Results: setErrors}

--- a/apiserver/annotations/client.go
+++ b/apiserver/annotations/client.go
@@ -22,7 +22,7 @@ var getState = func(st *state.State) annotationAccess {
 
 // Annotations defines the methods on the service API end point.
 type Annotations interface {
-	Get(args params.AnnotationsGet) params.AnnotationsGetResults
+	Get(args params.Entities) params.AnnotationsGetResults
 	Set(args params.AnnotationsSet) params.ErrorResults
 }
 
@@ -52,12 +52,12 @@ func NewAPI(
 // Get returns annotations for given entities.
 // If annotations cannot be retrieved for a given entity, an error is returned.
 // Each entity is treated independently and, hence, will fail or succeed independently.
-func (api *API) Get(args params.AnnotationsGet) params.AnnotationsGetResults {
+func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
 	entityResults := []params.AnnotationsGetResult{}
-	for _, entity := range args.EntityTags {
-		anEntityResult := params.AnnotationsGetResult{EntityTag: entity}
-		if annts, err := api.getEntityAnnotations(entity); err != nil {
-			anEntityResult.Error = params.ErrorResult{annotateError(err, entity, "getting")}
+	for _, entity := range args.Entities {
+		anEntityResult := params.AnnotationsGetResult{EntityTag: entity.Tag}
+		if annts, err := api.getEntityAnnotations(entity.Tag); err != nil {
+			anEntityResult.Error = params.ErrorResult{annotateError(err, entity.Tag, "getting")}
 		} else {
 			anEntityResult.Annotations = annts
 		}

--- a/apiserver/params/annotations.go
+++ b/apiserver/params/annotations.go
@@ -5,7 +5,7 @@ package params
 
 // AnnotationsGetResult holds entity annotations or retrieval error.
 type AnnotationsGetResult struct {
-	Entity      Entity
+	EntityTag   string
 	Annotations map[string]string
 	Error       ErrorResult
 }
@@ -15,13 +15,18 @@ type AnnotationsGetResults struct {
 	Results []AnnotationsGetResult
 }
 
-// AnnotationsSet stores parameters for making the SetEntitiesAnnotations call.
+// AnnotationsSet stores parameters for making Set call on Annotations client.
 type AnnotationsSet struct {
 	Annotations []EntityAnnotations
 }
 
+// AnnotationsGet stores parameters for making Get call on Annotations client.
+type AnnotationsGet struct {
+	EntityTags []string
+}
+
 // EntityAnnotations stores annotations for an entity.
 type EntityAnnotations struct {
-	Entity      Entity
+	EntityTag   string
 	Annotations map[string]string
 }

--- a/apiserver/params/annotations.go
+++ b/apiserver/params/annotations.go
@@ -20,11 +20,6 @@ type AnnotationsSet struct {
 	Annotations []EntityAnnotations
 }
 
-// AnnotationsGet stores parameters for making Get call on Annotations client.
-type AnnotationsGet struct {
-	EntityTags []string
-}
-
 // EntityAnnotations stores annotations for an entity.
 type EntityAnnotations struct {
 	EntityTag   string


### PR DESCRIPTION
Changed to use entity tags as []string rather than params.Entities

(Review request: http://reviews.vapour.ws/r/722/)