### PR TITLE
worker/peergrouper: avoid fragile timing tests

### DIFF
--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -358,41 +358,25 @@ func (s *workerSuite) TestSetMembersErrorIsNotFatal(c *gc.C) {
 		st := NewFakeState()
 		InitState(c, st, 3, ipVersion)
 		st.session.setStatus(mkStatuses("0p 1s 2s", ipVersion))
-		var isSet voyeur.Value
-		count := 0
+		var setCount voyeur.Value
 		setErrorFuncFor("Session.Set", func() error {
-			isSet.Set(count)
-			count++
+			setCount.Set(true)
 			return errors.New("sample")
 		})
 		s.PatchValue(&initialRetryInterval, 10*time.Microsecond)
 		s.PatchValue(&maxRetryInterval, coretesting.ShortWait/4)
 
-		expectedIterations := 0
-		for d := initialRetryInterval; d < maxRetryInterval*2; d *= 2 {
-			expectedIterations++
-		}
-
 		w := newWorker(st, noPublisher{})
 		defer func() {
 			c.Check(worker.Stop(w), gc.IsNil)
 		}()
-		isSetWatcher := isSet.Watch()
 
-		n0 := mustNext(c, isSetWatcher).(int)
-		time.Sleep(maxRetryInterval * 2)
-		n1 := mustNext(c, isSetWatcher).(int)
+		// See that the worker is retrying.
+		setCountW := setCount.Watch()
+		mustNext(c, setCountW)
+		mustNext(c, setCountW)
+		mustNext(c, setCountW)
 
-		// The worker should have backed off exponentially...
-		c.Assert(n1-n0, jc.LessThan, expectedIterations+1)
-		c.Logf("actual iterations %d; expected iterations %d", n1-n0, expectedIterations)
-
-		// ... but only up to the maximum retry interval
-		n0 = mustNext(c, isSetWatcher).(int)
-		time.Sleep(maxRetryInterval * 2)
-		n1 = mustNext(c, isSetWatcher).(int)
-
-		c.Assert(n1-n0, jc.LessThan, 3)
 		resetErrors()
 	})
 }


### PR DESCRIPTION
The testing of retry timing in TestSetMembersErrorIsNotFatal was overkill and breaks intermittently on some machines. The most important thing to know is that the worker is retrying. The actual timings are less important.

Fixes LP #1409827.

(Review request: http://reviews.vapour.ws/r/725/)