### PR TITLE
MAAS: When starting bootstrap node, wait for node to be reported as Deployed

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -52,10 +52,19 @@ var shortAttempt = utils.AttemptStrategy{
 	Delay: 200 * time.Millisecond,
 }
 
+// longAttempt is used when we are polling for changes to
+// instance state. Such changes may involve a reboot so we
+// want to allow sufficient time for that to happen.
+var longAttempt = utils.AttemptStrategy{
+	Min:   50,
+	Delay: 5 * time.Second,
+}
+
 var (
-	ReleaseNodes     = releaseNodes
-	ReserveIPAddress = reserveIPAddress
-	ReleaseIPAddress = releaseIPAddress
+	ReleaseNodes         = releaseNodes
+	ReserveIPAddress     = reserveIPAddress
+	ReleaseIPAddress     = releaseIPAddress
+	DeploymentStatusCall = deploymentStatusCall
 )
 
 func releaseNodes(nodes gomaasapi.MAASObject, ids url.Values) error {
@@ -119,7 +128,24 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 	// containers, because we'll be creating juju-br0 at bootstrap
 	// time.
 	args.ContainerBridgeName = environs.DefaultBridgeName
-	return common.Bootstrap(ctx, env, args)
+	result, series, finalizer, err := common.BootstrapInstance(ctx, env, args)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	// We want to destroy the started instance if it doesn't transition to Deployed.
+	defer func() {
+		if err != nil {
+			if err := env.StopInstances(result.Instance.Id()); err != nil {
+				logger.Errorf("error releasing bootstrap instance: %v", err)
+			}
+		}
+	}()
+	// Wait for bootstrap instance to change to deployed state.
+	if err := env.waitForNodeDeployment(result.Instance.Id()); err != nil {
+		return "", "", nil, errors.Annotate(err, "bootstrap instance started but did not change to Deployed state")
+	}
+	return *result.Hardware.Arch, series, finalizer, nil
 }
 
 // StateServerInstances is specified in the Environ interface.
@@ -930,6 +956,61 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		Hardware:    hc,
 		NetworkInfo: networkInfo,
 	}, nil
+}
+
+func (environ *maasEnviron) waitForNodeDeployment(id instance.Id) (err error) {
+	var statusValues map[string]string
+	deployed := false
+	systemId := extractSystemId(id)
+	for a := longAttempt.Start(); a.Next(); {
+		statusValues, err = environ.deploymentStatus(id)
+		if err != nil {
+			break
+		}
+		if statusValues[systemId] == "Deployed" {
+			deployed = true
+			break
+		}
+	}
+	if errors.IsNotImplemented(err) || deployed {
+		return nil
+	}
+	if err == nil {
+		return errors.Errorf("instance %q is started but not deployed", id)
+	}
+	return errors.Trace(err)
+}
+
+// deploymentStatus returns the deployment state of MAAS instances with
+// the specified Juju instance ids.
+// Note: the result is a map of MAAS systemId to state.
+func (environ *maasEnviron) deploymentStatus(ids ...instance.Id) (map[string]string, error) {
+	nodesAPI := environ.getMAASClient().GetSubObject("nodes")
+	result, err := DeploymentStatusCall(nodesAPI, ids...)
+	if err != nil {
+		if err, ok := err.(gomaasapi.ServerError); ok && err.StatusCode == http.StatusBadRequest {
+			return nil, errors.NewNotImplemented(err, "deployment status")
+		}
+		return nil, errors.Trace(err)
+	}
+	resultMap, err := result.GetMap()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	statusValues := make(map[string]string)
+	for systemId, jsonValue := range resultMap {
+		status, err := jsonValue.GetString()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		statusValues[systemId] = status
+	}
+	return statusValues, nil
+}
+
+func deploymentStatusCall(nodes gomaasapi.MAASObject, ids ...instance.Id) (gomaasapi.JSONObject, error) {
+	filter := getSystemIdValues("nodes", ids)
+	return nodes.CallGet("deployment_status", filter)
 }
 
 type selectNodeArgs struct {

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	ShortAttempt = &shortAttempt
+	LongAttempt  = &longAttempt
 	APIVersion   = apiVersion
 )
 

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -22,7 +22,7 @@ type providerSuite struct {
 var _ = gc.Suite(&providerSuite{})
 
 func (s *providerSuite) SetUpSuite(c *gc.C) {
-	s.restoreTimeouts = envtesting.PatchAttemptStrategies(&shortAttempt)
+	s.restoreTimeouts = envtesting.PatchAttemptStrategies(&shortAttempt, &longAttempt)
 	s.BaseSuite.SetUpSuite(c)
 	TestMAASObject := gomaasapi.NewTestMAAS("1.0")
 	s.testMAASObject = TestMAASObject


### PR DESCRIPTION
When starting bootstrap node, wait for node to be reported as Deployed.
The API used is new in MAAS 1.7. When used with older versions of MAAS, a 400 is returned. In these cases, the error is ignored and the node is assumed to be deployed.

(Review request: http://reviews.vapour.ws/r/727/)