### PR TITLE
Merge pull request #1401 from anastasiamac/annotations-tags

### DIFF
--- a/api/annotations/client.go
+++ b/api/annotations/client.go
@@ -52,7 +52,7 @@ func entitiesAnnotations(annotations map[string]map[string]string) []params.Enti
 	all := []params.EntityAnnotations{}
 	for tag, pairs := range annotations {
 		one := params.EntityAnnotations{
-			Entity:      params.Entity{tag},
+			EntityTag:   tag,
 			Annotations: pairs,
 		}
 		all = append(all, one)

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -49,7 +49,7 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 				// architectures vary the order within params.AnnotationsSet,
 				// simply assert that each entity has its own annotations.
 				// Bug 1409141
-				c.Assert(aParam.Annotations, gc.DeepEquals, setParams[aParam.Entity.Tag])
+				c.Assert(aParam.Annotations, gc.DeepEquals, setParams[aParam.EntityTag])
 			}
 			return nil
 		})
@@ -75,13 +75,12 @@ func (s *annotationsMockSuite) TestGetEntitiesAnnotations(c *gc.C) {
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(args.Entities, gc.HasLen, 1)
 			c.Assert(args.Entities[0], gc.DeepEquals, params.Entity{"charm"})
-
 			result := response.(*params.AnnotationsGetResults)
 			facadeAnnts := map[string]string{
 				"annotations": "test",
 			}
 			entitiesAnnts := params.AnnotationsGetResult{
-				Entity:      params.Entity{"charm"},
+				EntityTag:   "charm",
 				Annotations: facadeAnnts,
 			}
 			result.Results = []params.AnnotationsGetResult{entitiesAnnts}

--- a/apiserver/annotations/client.go
+++ b/apiserver/annotations/client.go
@@ -55,7 +55,7 @@ func NewAPI(
 func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
 	entityResults := []params.AnnotationsGetResult{}
 	for _, entity := range args.Entities {
-		anEntityResult := params.AnnotationsGetResult{Entity: entity}
+		anEntityResult := params.AnnotationsGetResult{EntityTag: entity.Tag}
 		if annts, err := api.getEntityAnnotations(entity.Tag); err != nil {
 			anEntityResult.Error = params.ErrorResult{annotateError(err, entity.Tag, "getting")}
 		} else {
@@ -70,10 +70,10 @@ func (api *API) Get(args params.Entities) params.AnnotationsGetResults {
 func (api *API) Set(args params.AnnotationsSet) params.ErrorResults {
 	setErrors := []params.ErrorResult{}
 	for _, entityAnnotation := range args.Annotations {
-		err := api.setEntityAnnotations(entityAnnotation.Entity.Tag, entityAnnotation.Annotations)
+		err := api.setEntityAnnotations(entityAnnotation.EntityTag, entityAnnotation.Annotations)
 		if err != nil {
 			setErrors = append(setErrors,
-				params.ErrorResult{Error: annotateError(err, entityAnnotation.Entity.Tag, "setting")})
+				params.ErrorResult{Error: annotateError(err, entityAnnotation.EntityTag, "setting")})
 		}
 	}
 	return params.ErrorResults{Results: setErrors}

--- a/apiserver/annotations/client_test.go
+++ b/apiserver/annotations/client_test.go
@@ -65,19 +65,19 @@ func (s *annotationSuite) TestServiceAnnotations(c *gc.C) {
 }
 
 func (s *annotationSuite) TestInvalidEntityAnnotations(c *gc.C) {
-	entity := params.Entity{"charm-invalid"}
-	entities := params.Entities{[]params.Entity{entity}}
+	entity := "charm-invalid"
+	entities := params.Entities{[]params.Entity{params.Entity{entity}}}
 	annotations := map[string]string{"mykey": "myvalue"}
 
 	setResult := s.annotationsApi.Set(
-		params.AnnotationsSet{Annotations: constructSetParameters(entities, annotations)})
+		params.AnnotationsSet{Annotations: constructSetParameters([]string{entity}, annotations)})
 	c.Assert(setResult.OneError().Error(), gc.Matches, ".*permission denied.*")
 
 	got := s.annotationsApi.Get(entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
-	c.Assert(aResult.Entity, gc.DeepEquals, entity)
+	c.Assert(aResult.EntityTag, gc.DeepEquals, entity)
 	c.Assert(aResult.Error.Error.Error(), gc.Matches, ".*permission denied.*")
 
 }
@@ -127,30 +127,30 @@ func (s *annotationSuite) makeRelation(c *gc.C) (*state.Service, *state.Relation
 func (s *annotationSuite) TestRelationAnnotations(c *gc.C) {
 	_, relation := s.makeRelation(c)
 
-	tag := relation.Tag()
-	entity := params.Entity{tag.String()}
+	tag := relation.Tag().String()
+	entity := params.Entity{tag}
 	entities := params.Entities{[]params.Entity{entity}}
 	annotations := map[string]string{"mykey": "myvalue"}
 
 	setResult := s.annotationsApi.Set(
-		params.AnnotationsSet{Annotations: constructSetParameters(entities, annotations)})
+		params.AnnotationsSet{Annotations: constructSetParameters([]string{tag}, annotations)})
 	c.Assert(setResult.OneError().Error(), gc.Matches, ".*does not support annotations.*")
 
 	got := s.annotationsApi.Get(entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
-	c.Assert(aResult.Entity, gc.DeepEquals, entity)
+	c.Assert(aResult.EntityTag, gc.DeepEquals, tag)
 	c.Assert(aResult.Error.Error.Error(), gc.Matches, ".*does not support annotations.*")
 }
 
 func constructSetParameters(
-	entities params.Entities,
+	entities []string,
 	annotations map[string]string) []params.EntityAnnotations {
 	result := []params.EntityAnnotations{}
-	for _, entity := range entities.Entities {
+	for _, entity := range entities {
 		one := params.EntityAnnotations{
-			Entity:      entity,
+			EntityTag:   entity,
 			Annotations: annotations,
 		}
 		result = append(result, one)
@@ -162,14 +162,14 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 	s1, relation := s.makeRelation(c)
 
 	rTag := relation.Tag()
-	rEntity := params.Entity{rTag.String()}
+	rEntity := rTag.String()
 	sTag := s1.Tag()
-	sEntity := params.Entity{sTag.String()}
+	sEntity := sTag.String()
 
-	entities := params.Entities{[]params.Entity{
+	entities := []string{
 		sEntity, //service: expect success in set/get
 		rEntity, //relation:expect failure in set/get - cannot annotate relations
-	}}
+	}
 	annotations := map[string]string{"mykey": "myvalue"}
 
 	setResult := s.annotationsApi.Set(
@@ -181,17 +181,19 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 	c.Assert(oneError, gc.Matches, fmt.Sprintf(".*%q.*", rTag))
 	c.Assert(oneError, gc.Matches, ".*does not support annotations.*")
 
-	got := s.annotationsApi.Get(entities)
+	got := s.annotationsApi.Get(params.Entities{[]params.Entity{
+		params.Entity{rEntity},
+		params.Entity{sEntity}}})
 	c.Assert(got.Results, gc.HasLen, 2)
 
 	var rGet, sGet bool
 	for _, aResult := range got.Results {
-		if aResult.Entity.Tag == rTag.String() {
+		if aResult.EntityTag == rTag.String() {
 			rGet = true
 			c.Assert(aResult.Error.Error.Error(), gc.Matches, ".*does not support annotations.*")
 		} else {
 			sGet = true
-			c.Assert(aResult.Entity, gc.DeepEquals, sEntity)
+			c.Assert(aResult.EntityTag, gc.DeepEquals, sEntity)
 			c.Assert(aResult.Annotations, gc.DeepEquals, annotations)
 		}
 	}
@@ -201,8 +203,8 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 }
 
 func (s *annotationSuite) testSetGetEntitiesAnnotations(c *gc.C, tag names.Tag) {
-	entity := params.Entity{tag.String()}
-	entities := params.Entities{[]params.Entity{entity}}
+	entity := tag.String()
+	entities := []string{entity}
 	for i, t := range clientAnnotationsTests {
 		c.Logf("test %d. %s. entity %s", i, t.about, tag.Id())
 		s.setupEntity(c, entities, t.initial)
@@ -210,14 +212,14 @@ func (s *annotationSuite) testSetGetEntitiesAnnotations(c *gc.C, tag names.Tag) 
 		if t.err != "" {
 			continue
 		}
-		aResult := s.assertGetEntityAnnotations(c, entities, entity, t.expected)
+		aResult := s.assertGetEntityAnnotations(c, params.Entities{[]params.Entity{params.Entity{entity}}}, entity, t.expected)
 		s.cleanupEntityAnnotations(c, entities, aResult)
 	}
 }
 
 func (s *annotationSuite) setupEntity(
 	c *gc.C,
-	entities params.Entities,
+	entities []string,
 	initialAnnotations map[string]string) {
 	if initialAnnotations != nil {
 		initialResult := s.annotationsApi.Set(
@@ -228,7 +230,7 @@ func (s *annotationSuite) setupEntity(
 }
 
 func (s *annotationSuite) assertSetEntityAnnotations(c *gc.C,
-	entities params.Entities,
+	entities []string,
 	annotations map[string]string,
 	expectedError string) {
 	setResult := s.annotationsApi.Set(
@@ -242,19 +244,19 @@ func (s *annotationSuite) assertSetEntityAnnotations(c *gc.C,
 
 func (s *annotationSuite) assertGetEntityAnnotations(c *gc.C,
 	entities params.Entities,
-	entity params.Entity,
+	entity string,
 	expected map[string]string) params.AnnotationsGetResult {
 	got := s.annotationsApi.Get(entities)
 	c.Assert(got.Results, gc.HasLen, 1)
 
 	aResult := got.Results[0]
-	c.Assert(aResult.Entity, gc.DeepEquals, entity)
+	c.Assert(aResult.EntityTag, gc.DeepEquals, entity)
 	c.Assert(aResult.Annotations, gc.DeepEquals, expected)
 	return aResult
 }
 
 func (s *annotationSuite) cleanupEntityAnnotations(c *gc.C,
-	entities params.Entities,
+	entities []string,
 	aResult params.AnnotationsGetResult) {
 	cleanup := make(map[string]string)
 	for key := range aResult.Annotations {

--- a/apiserver/params/annotations.go
+++ b/apiserver/params/annotations.go
@@ -5,7 +5,7 @@ package params
 
 // AnnotationsGetResult holds entity annotations or retrieval error.
 type AnnotationsGetResult struct {
-	Entity      Entity
+	EntityTag   string
 	Annotations map[string]string
 	Error       ErrorResult
 }
@@ -15,13 +15,13 @@ type AnnotationsGetResults struct {
 	Results []AnnotationsGetResult
 }
 
-// AnnotationsSet stores parameters for making the SetEntitiesAnnotations call.
+// AnnotationsSet stores parameters for making Set call on Annotations client.
 type AnnotationsSet struct {
 	Annotations []EntityAnnotations
 }
 
 // EntityAnnotations stores annotations for an entity.
 type EntityAnnotations struct {
-	Entity      Entity
+	EntityTag   string
 	Annotations map[string]string
 }


### PR DESCRIPTION
Changed SET to use entity tags as []string rather than params.Entity

Changed GET result to return entity tag as string rather than params.Entity with Tag string inside.

(Review request: http://reviews.vapour.ws/r/722/)

(Review request: http://reviews.vapour.ws/r/728/)