### PR TITLE
BACKPORT: Corrected panic in summary status.

### DIFF
--- a/cmd/juju/status_formatters.go
+++ b/cmd/juju/status_formatters.go
@@ -248,6 +248,7 @@ func (f *summaryFormatter) resolveAndTrackIp(publicDns string) {
 			publicDns,
 			err,
 		)
+		return
 	}
 	f.trackIp(ip.IP)
 }

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -2753,3 +2753,10 @@ func (s *StatusSuite) TestFilterMultipleHeterogenousPatterns(c *gc.C) {
 
 	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
+
+// TestSummaryStatusWithUnresolvableDns is result of bug# 1410320.
+func (s *StatusSuite) TestSummaryStatusWithUnresolvableDns(c *gc.C) {
+	formatter := &summaryFormatter{}
+	formatter.resolveAndTrackIp("invalidDns")
+	// Test should not panic.
+}


### PR DESCRIPTION
When a given DNS is unresolvable, we were correctly warning the user, but effectively ignoring the error by continuing on.

(Review request: http://reviews.vapour.ws/r/734/)