### PR TITLE
Added Environ.NetworkInterfaces()

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -131,6 +131,10 @@ type Environ interface {
 	// AllocateAddress.
 	ReleaseAddress(instId instance.Id, netId network.Id, addr network.Address) error
 
+	// NetworkInterfaces requests information about the network
+	// interfaces on the given instance.
+	NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error)
+
 	// Subnets returns basic information about all subnets known
 	// by the provider for the environment, for a specific instance. A
 	// provider may return all networks instead of just those for the

--- a/network/network.go
+++ b/network/network.go
@@ -79,7 +79,8 @@ type InterfaceInfo struct {
 	// NetworkName is juju-internal name of the network.
 	NetworkName string
 
-	// ProviderId is a provider-specific network id.
+	// ProviderId is a provider-specific subnet id.
+	// TODO(dimitern) Rename this to SubnetId.
 	ProviderId Id
 
 	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1114,6 +1114,12 @@ func (*azureEnviron) ReleaseAddress(_ instance.Id, _ network.Id, _ network.Addre
 	return errors.NotImplementedf("ReleaseAddress")
 }
 
+// NetworkInterfaces implements Environ.NetworkInterfaces, but it's
+// not implemented on this provider yet.
+func (*azureEnviron) NetworkInterfaces(_ instance.Id) ([]network.InterfaceInfo, error) {
+	return nil, errors.NotImplementedf("NetworkInterfaces")
+}
+
 // Subnets returns basic information about all subnets known
 // by the provider for the environment. They may be unknown to juju
 // yet (i.e. when called initially or when a new network was created).

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -777,6 +777,12 @@ func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.
 	return nil
 }
 
+// NetworkInterfaces implements Environ.NetworkInterfaces, but it's
+// not implemented on this provider yet.
+func (*environ) NetworkInterfaces(_ instance.Id) ([]network.InterfaceInfo, error) {
+	return nil, errors.NotImplementedf("NetworkInterfaces")
+}
+
 // Subnets returns basic information about all subnets known
 // by the provider for the environment. They may be unknown to juju
 // yet (i.e. when called initially or when a new subnet was created).

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -269,6 +269,12 @@ func (*joyentEnviron) ReleaseAddress(_ instance.Id, _ network.Id, _ network.Addr
 	return errors.NotImplementedf("ReleaseAddress")
 }
 
+// NetworkInterfaces implements Environ.NetworkInterfaces, but it's
+// not implemented on this provider yet.
+func (*joyentEnviron) NetworkInterfaces(_ instance.Id) ([]network.InterfaceInfo, error) {
+	return nil, errors.NotImplementedf("NetworkInterfaces")
+}
+
 // Subnets returns basic information about all subnets known by
 // the provider for the environment. They may be unknown to juju yet
 // (i.e. when called initially or when a new network was created).

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -462,6 +462,12 @@ func (*localEnviron) ReleaseAddress(_ instance.Id, _ network.Id, _ network.Addre
 	return errors.NotSupportedf("ReleaseAddress")
 }
 
+// NetworkInterfaces implements Environ.NetworkInterfaces, but it's
+// not supported on this provider yet.
+func (*localEnviron) NetworkInterfaces(_ instance.Id) ([]network.InterfaceInfo, error) {
+	return nil, errors.NotSupportedf("NetworkInterfaces")
+}
+
 // Subnets returns basic information about all subnets known
 // by the provider for the environment. They may be unknown to juju
 // yet (i.e. when called initially or when a new network was created).

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1205,6 +1205,12 @@ func (environ *maasEnviron) ReleaseAddress(_ instance.Id, _ network.Id, addr net
 	return nil
 }
 
+// NetworkInterfaces implements Environ.NetworkInterfaces, but it's
+// not implemented on this provider yet.
+func (*maasEnviron) NetworkInterfaces(_ instance.Id) ([]network.InterfaceInfo, error) {
+	return nil, errors.NotImplementedf("NetworkInterfaces")
+}
+
 // Subnets returns basic information about all subnets known
 // by the provider for the environment, for a specific instance.
 func (environ *maasEnviron) Subnets(instId instance.Id) ([]network.SubnetInfo, error) {

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -267,6 +267,12 @@ func (*manualEnviron) ReleaseAddress(_ instance.Id, _ network.Id, _ network.Addr
 	return errors.NotSupportedf("ReleaseAddress")
 }
 
+// NetworkInterfaces implements Environ.NetworkInterfaces, but it's
+// not supported on this provider yet.
+func (*manualEnviron) NetworkInterfaces(_ instance.Id) ([]network.InterfaceInfo, error) {
+	return nil, errors.NotSupportedf("NetworkInterfaces")
+}
+
 // Subnets returns basic information about all subnets known
 // by the provider for the environment. They may be unknown to juju
 // yet (i.e. when called initially or when a new network was created).

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1252,6 +1252,12 @@ func (*environ) ReleaseAddress(_ instance.Id, _ network.Id, _ network.Address) e
 	return errors.NotImplementedf("ReleaseAddress")
 }
 
+// NetworkInterfaces implements Environ.NetworkInterfaces, but it's
+// not implemented on this provider yet.
+func (*environ) NetworkInterfaces(_ instance.Id) ([]network.InterfaceInfo, error) {
+	return nil, errors.NotImplementedf("NetworkInterfaces")
+}
+
 // Subnets returns basic information about all subnets known
 // by the provider for the environment. They may be unknown to juju
 // yet (i.e. when called initially or when a new network was created).


### PR DESCRIPTION
This is needed to discover what the cloud provider knows about all NICs
of an instance. Later, the new method will be used during container
provisioning to allow static IP configuration.

All providers, except dummy (for testing), have a minimal stub
implementation of NetworkInterfaces().

In follow-ups implementations for EC2 and MAAS will be proposed.

(Review request: http://reviews.vapour.ws/r/742/)