### PR TITLE
cloudinit/sshinit: retry on apt-get failure

### DIFF
--- a/cloudinit/sshinit/configure_test.go
+++ b/cloudinit/sshinit/configure_test.go
@@ -174,11 +174,19 @@ func (s *configureSuite) TestAptUpgrade(c *gc.C) {
 }
 
 func (s *configureSuite) TestAptGetWrapper(c *gc.C) {
-	aptgetRegexp := "(.|\n)* $(which eatmydata || true) " + regexp.QuoteMeta(sshinit.Aptget)
+	aptgetRegexp := "(.|\n)*\\$\\(which eatmydata || true\\) " + regexp.QuoteMeta(sshinit.Aptget) + "(.|\n)*"
 	cfg := cloudinit.New()
 	cfg.SetAptUpdate(true)
 	cfg.SetAptGetWrapper("eatmydata")
-	assertScriptMatches(c, cfg, aptgetRegexp, false)
+	assertScriptMatches(c, cfg, aptgetRegexp, true)
+}
+
+func (s *configureSuite) TestAptGetRetry(c *gc.C) {
+	aptgetRegexp := "(.|\n)*apt_get_loop.*" + regexp.QuoteMeta(sshinit.Aptget) + "(.|\n)*"
+	cfg := cloudinit.New()
+	cfg.SetAptUpdate(true)
+	cfg.SetAptGetWrapper("eatmydata")
+	assertScriptMatches(c, cfg, aptgetRegexp, true)
 }
 
 func (s *configureSuite) TestAptMirrorWrapper(c *gc.C) {


### PR DESCRIPTION
If apt-get fails with an error of 100, we will
retry in case it is due to lock contention. We
loop retrying in this way forever, and rely on
bootstrap-timeout or user intervention (ctrl-c)
to shut things down.

Fixes https://bugs.launchpad.net/juju-core/+bug/1384259

(Review request: http://reviews.vapour.ws/r/747/)