### PR TITLE
Add machine ha status to megawatcher

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2265,6 +2265,8 @@ func (s *clientSuite) TestClientWatchAll(c *gc.C) {
 			Jobs:                    []multiwatcher.MachineJob{state.JobManageEnviron.ToParams()},
 			Addresses:               []network.Address{},
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
+			HasVote:                 false,
+			WantsVote:               true,
 		},
 	}}) {
 		c.Logf("got:")

--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -51,7 +51,7 @@ var marshalTestCases = []struct {
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
 		},
 	},
-	json: `["machine","change",{"Id":"Benji","InstanceId":"Shazam","Status":"error","StatusInfo":"foo","StatusData":null,"Life":"alive","Series":"trusty","SupportedContainers":["lxc"],"SupportedContainersKnown":false,"Jobs":["JobManageEnviron"],"Addresses":[],"HardwareCharacteristics":{}}]`,
+	json: `["machine","change",{"Id":"Benji","InstanceId":"Shazam","HasVote":false,"WantsVote":false,"Status":"error","StatusInfo":"foo","StatusData":null,"Life":"alive","Series":"trusty","SupportedContainers":["lxc"],"SupportedContainersKnown":false,"Jobs":["JobManageEnviron"],"Addresses":[],"HardwareCharacteristics":{}}]`,
 }, {
 	about: "ServiceInfo Delta",
 	value: multiwatcher.Delta{

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -343,7 +343,7 @@ func (sf *statusFormatter) formatMachine(machine api.MachineStatus) machineStatu
 
 	for _, job := range machine.Jobs {
 		if job == multiwatcher.JobManageEnviron {
-			out.HAStatus = multiwatcher.MakeHAStatus(machine.HasVote, machine.WantsVote)
+			out.HAStatus = makeHAStatus(machine.HasVote, machine.WantsVote)
 			break
 		}
 	}
@@ -418,6 +418,21 @@ func (sf *statusFormatter) formatNetwork(network api.NetworkStatus) networkStatu
 		CIDR:       network.CIDR,
 		VLANTag:    network.VLANTag,
 	}
+}
+
+func makeHAStatus(hasVote, wantsVote bool) string {
+	var s string
+	switch {
+	case hasVote && wantsVote:
+		s = "has-vote"
+	case hasVote && !wantsVote:
+		s = "removing-vote"
+	case !hasVote && wantsVote:
+		s = "adding-vote"
+	case !hasVote && !wantsVote:
+		s = "no-vote"
+	}
+	return s
 }
 
 func getRelationIdFromData(unit api.UnitStatus) int {

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -343,7 +343,7 @@ func (sf *statusFormatter) formatMachine(machine api.MachineStatus) machineStatu
 
 	for _, job := range machine.Jobs {
 		if job == multiwatcher.JobManageEnviron {
-			out.HAStatus = makeHAStatus(machine.HasVote, machine.WantsVote)
+			out.HAStatus = multiwatcher.MakeHAStatus(machine.HasVote, machine.WantsVote)
 			break
 		}
 	}
@@ -418,21 +418,6 @@ func (sf *statusFormatter) formatNetwork(network api.NetworkStatus) networkStatu
 		CIDR:       network.CIDR,
 		VLANTag:    network.VLANTag,
 	}
-}
-
-func makeHAStatus(hasVote, wantsVote bool) string {
-	var s string
-	switch {
-	case hasVote && wantsVote:
-		s = "has-vote"
-	case hasVote && !wantsVote:
-		s = "removing-vote"
-	case !hasVote && wantsVote:
-		s = "adding-vote"
-	case !hasVote && !wantsVote:
-		s = "no-vote"
-	}
-	return s
 }
 
 func getRelationIdFromData(unit api.UnitStatus) int {

--- a/state/machine.go
+++ b/state/machine.go
@@ -138,6 +138,10 @@ func newMachine(st *State, doc *machineDoc) *Machine {
 	return machine
 }
 
+func wantsVote(jobs []MachineJob, noVote bool) bool {
+	return hasJob(jobs, JobManageEnviron) && !noVote
+}
+
 // Id returns the machine id.
 func (m *Machine) Id() string {
 	return m.doc.Id
@@ -236,7 +240,7 @@ func (m *Machine) Jobs() []MachineJob {
 // WantsVote reports whether the machine is a state server
 // that wants to take part in peer voting.
 func (m *Machine) WantsVote() bool {
-	return hasJob(m.doc.Jobs, JobManageEnviron) && !m.doc.NoVote
+	return wantsVote(m.doc.Jobs, m.doc.NoVote)
 }
 
 // HasVote reports whether that machine is currently a voting

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -34,6 +34,7 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id interfa
 		Addresses:                mergedAddresses(m.MachineAddresses, m.Addresses),
 		SupportedContainers:      m.SupportedContainers,
 		SupportedContainersKnown: m.SupportedContainersKnown,
+		StateServerMemberStatus:  multiwatcher.MakeHAStatus(m.HasVote, wantsVote(m.Jobs, m.NoVote)),
 	}
 
 	oldInfo := store.Get(info.EntityId())

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -34,7 +34,8 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id interfa
 		Addresses:                mergedAddresses(m.MachineAddresses, m.Addresses),
 		SupportedContainers:      m.SupportedContainers,
 		SupportedContainersKnown: m.SupportedContainersKnown,
-		StateServerMemberStatus:  multiwatcher.MakeHAStatus(m.HasVote, wantsVote(m.Jobs, m.NoVote)),
+		HasVote:                  m.HasVote,
+		WantsVote:                wantsVote(m.Jobs, m.NoVote),
 	}
 
 	oldInfo := store.Get(info.EntityId())

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -106,6 +106,7 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C) (entities entityInfoSlic
 		Jobs:                    []multiwatcher.MachineJob{JobManageEnviron.ToParams()},
 		Addresses:               m.Addresses(),
 		HardwareCharacteristics: hc,
+		StateServerMemberStatus: "no-vote",
 	})
 
 	wordpress := AddTestingService(c, s.State, "wordpress", AddTestingCharm(c, s.State, "wordpress"), s.owner)
@@ -199,6 +200,7 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C) (entities entityInfoSlic
 			Jobs:                    []multiwatcher.MachineJob{JobHostUnits.ToParams()},
 			Addresses:               []network.Address{},
 			HardwareCharacteristics: hc,
+			StateServerMemberStatus: "no-vote",
 		})
 		err = wu.AssignToMachine(m)
 		c.Assert(err, jc.ErrorIsNil)
@@ -316,13 +318,14 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.MachineInfo{
-						Id:         "0",
-						Status:     multiwatcher.Status("error"),
-						StatusInfo: "failure",
-						Life:       multiwatcher.Life("alive"),
-						Series:     "quantal",
-						Jobs:       []multiwatcher.MachineJob{JobHostUnits.ToParams()},
-						Addresses:  []network.Address{},
+						Id:                      "0",
+						Status:                  multiwatcher.Status("error"),
+						StatusInfo:              "failure",
+						Life:                    multiwatcher.Life("alive"),
+						Series:                  "quantal",
+						Jobs:                    []multiwatcher.MachineJob{JobHostUnits.ToParams()},
+						Addresses:               []network.Address{},
+						StateServerMemberStatus: "no-vote",
 					}}}
 		},
 		// Machine status changes
@@ -360,6 +363,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 						HardwareCharacteristics:  &instance.HardwareCharacteristics{},
 						SupportedContainers:      []instance.ContainerType{instance.LXC},
 						SupportedContainersKnown: true,
+						StateServerMemberStatus:  "adding-vote",
 					}}}
 		},
 		// Unit changes
@@ -986,21 +990,23 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 	s.State.StartSync()
 	checkNext(c, w, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
-			Id:        "0",
-			Status:    multiwatcher.Status("pending"),
-			Life:      multiwatcher.Life("alive"),
-			Series:    "trusty",
-			Jobs:      []multiwatcher.MachineJob{JobManageEnviron.ToParams()},
-			Addresses: []network.Address{},
+			Id:                      "0",
+			Status:                  multiwatcher.Status("pending"),
+			Life:                    multiwatcher.Life("alive"),
+			Series:                  "trusty",
+			Jobs:                    []multiwatcher.MachineJob{JobManageEnviron.ToParams()},
+			Addresses:               []network.Address{},
+			StateServerMemberStatus: "adding-vote",
 		},
 	}, {
 		Entity: &multiwatcher.MachineInfo{
-			Id:        "1",
-			Status:    multiwatcher.Status("pending"),
-			Life:      multiwatcher.Life("alive"),
-			Series:    "saucy",
-			Jobs:      []multiwatcher.MachineJob{JobHostUnits.ToParams()},
-			Addresses: []network.Address{},
+			Id:                      "1",
+			Status:                  multiwatcher.Status("pending"),
+			Life:                    multiwatcher.Life("alive"),
+			Series:                  "saucy",
+			Jobs:                    []multiwatcher.MachineJob{JobHostUnits.ToParams()},
+			Addresses:               []network.Address{},
+			StateServerMemberStatus: "no-vote",
 		},
 	}}, "")
 
@@ -1054,25 +1060,28 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 			Jobs:                    []multiwatcher.MachineJob{JobManageEnviron.ToParams()},
 			Addresses:               []network.Address{},
 			HardwareCharacteristics: hc,
+			StateServerMemberStatus: "adding-vote",
 		},
 	}, {
 		Removed: true,
 		Entity: &multiwatcher.MachineInfo{
-			Id:        "1",
-			Status:    multiwatcher.Status("pending"),
-			Life:      multiwatcher.Life("alive"),
-			Series:    "saucy",
-			Jobs:      []multiwatcher.MachineJob{JobHostUnits.ToParams()},
-			Addresses: []network.Address{},
+			Id:                      "1",
+			Status:                  multiwatcher.Status("pending"),
+			Life:                    multiwatcher.Life("alive"),
+			Series:                  "saucy",
+			Jobs:                    []multiwatcher.MachineJob{JobHostUnits.ToParams()},
+			Addresses:               []network.Address{},
+			StateServerMemberStatus: "foo6",
 		},
 	}, {
 		Entity: &multiwatcher.MachineInfo{
-			Id:        "2",
-			Status:    multiwatcher.Status("pending"),
-			Life:      multiwatcher.Life("alive"),
-			Series:    "quantal",
-			Jobs:      []multiwatcher.MachineJob{JobHostUnits.ToParams()},
-			Addresses: []network.Address{},
+			Id:                      "2",
+			Status:                  multiwatcher.Status("pending"),
+			Life:                    multiwatcher.Life("alive"),
+			Series:                  "quantal",
+			Jobs:                    []multiwatcher.MachineJob{JobHostUnits.ToParams()},
+			Addresses:               []network.Address{},
+			StateServerMemberStatus: "no-vote",
 		},
 	}, {
 		Entity: &multiwatcher.ServiceInfo{

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -130,7 +130,8 @@ type MachineInfo struct {
 	HardwareCharacteristics  *instance.HardwareCharacteristics `json:",omitempty"`
 	Jobs                     []MachineJob
 	Addresses                []network.Address
-	StateServerMemberStatus  string
+	HasVote                  bool
+	WantsVote                bool
 }
 
 func (i *MachineInfo) EntityId() EntityId {
@@ -238,21 +239,4 @@ func AnyJobNeedsState(jobs ...MachineJob) bool {
 		}
 	}
 	return false
-}
-
-// MakeHAStatus constructs a displayable value to reflect
-// a machine's HA status.
-func MakeHAStatus(hasVote, wantsVote bool) string {
-	var s string
-	switch {
-	case hasVote && wantsVote:
-		s = "has-vote"
-	case hasVote && !wantsVote:
-		s = "removing-vote"
-	case !hasVote && wantsVote:
-		s = "adding-vote"
-	case !hasVote && !wantsVote:
-		s = "no-vote"
-	}
-	return s
 }

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -130,6 +130,7 @@ type MachineInfo struct {
 	HardwareCharacteristics  *instance.HardwareCharacteristics `json:",omitempty"`
 	Jobs                     []MachineJob
 	Addresses                []network.Address
+	StateServerMemberStatus  string
 }
 
 func (i *MachineInfo) EntityId() EntityId {
@@ -237,4 +238,21 @@ func AnyJobNeedsState(jobs ...MachineJob) bool {
 		}
 	}
 	return false
+}
+
+// MakeHAStatus constructs a displayable value to reflect
+// a machine's HA status.
+func MakeHAStatus(hasVote, wantsVote bool) string {
+	var s string
+	switch {
+	case hasVote && wantsVote:
+		s = "has-vote"
+	case hasVote && !wantsVote:
+		s = "removing-vote"
+	case !hasVote && wantsVote:
+		s = "adding-vote"
+	case !hasVote && !wantsVote:
+		s = "no-vote"
+	}
+	return s
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1402965

Adds machine ha status to the MachineInfo struct in megawatcher

(Review request: http://reviews.vapour.ws/r/748/)