### PR TITLE
New worker to manage workers that need to run per-environment

### DIFF
--- a/worker/envworkermanager/envworkermanager.go
+++ b/worker/envworkermanager/envworkermanager.go
@@ -1,0 +1,139 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package envworkermanager
+
+import (
+	"github.com/juju/errors"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"launchpad.net/tomb"
+)
+
+var logger = loggo.GetLogger("juju.worker.envworkermanager")
+
+// NewEnvWorkerManager returns a Worker which manages the workers which
+// need to run on a per environment basis. It takes a function which will
+// be called to start workers for a new environment. These workers
+// will be killed when an environment goes away.
+func NewEnvWorkerManager(
+	st InitialState,
+	startEnvWorkers func(*state.State) (worker.Runner, error),
+) worker.Worker {
+	m := &envWorkerManager{
+		st:              st,
+		startEnvWorkers: startEnvWorkers,
+	}
+	m.runner = worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant)
+	go func() {
+		m.tomb.Kill(m.loop())
+		m.tomb.Done()
+	}()
+	return m
+}
+
+// InitialState defines the State functionality used by
+// envWorkerManager. It mainly exists to support testing.
+type InitialState interface {
+	WatchEnvironments() state.StringsWatcher
+	ForEnviron(names.EnvironTag) (*state.State, error)
+	GetEnvironment(names.EnvironTag) (*state.Environment, error)
+}
+
+type envWorkerManager struct {
+	runner          worker.Runner
+	tomb            tomb.Tomb
+	st              InitialState
+	startEnvWorkers func(*state.State) (worker.Runner, error)
+}
+
+// Kill satisfies the Worker interface.
+func (m *envWorkerManager) Kill() {
+	m.tomb.Kill(nil)
+}
+
+// Wait satisfies the Worker interface.
+func (m *envWorkerManager) Wait() error {
+	return m.tomb.Wait()
+}
+
+func (m *envWorkerManager) loop() error {
+	w := m.st.WatchEnvironments()
+	defer w.Stop()
+	for {
+		select {
+		case uuids := <-w.Changes():
+			// One or more environments have changed.
+			for _, uuid := range uuids {
+				if err := m.envHasChanged(uuid); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		case <-m.runner.Dying():
+			// The runner for the environment is dying: wait for it to
+			// finish dying and report its error (if any).
+			return m.runner.Wait()
+		case <-m.tomb.Dying():
+			// The envWorkerManager has been asked to die: kill the
+			// runner and stop.
+			m.runner.Kill()
+			return tomb.ErrDying
+		}
+	}
+}
+
+func (m *envWorkerManager) envHasChanged(uuid string) error {
+	envTag := names.NewEnvironTag(uuid)
+	envAlive, err := m.isEnvAlive(envTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if envAlive {
+		err = m.envIsAlive(envTag)
+	} else {
+		err = m.envIsDead(envTag)
+	}
+	return errors.Trace(err)
+}
+
+func (m *envWorkerManager) envIsAlive(envTag names.EnvironTag) error {
+	return m.runner.StartWorker(envTag.Id(), func() (worker.Worker, error) {
+		st, err := m.st.ForEnviron(envTag)
+		if err != nil {
+			return nil, errors.Annotatef(err, "failed to open state for environment %s", envTag.Id())
+		}
+
+		envRunner, err := m.startEnvWorkers(st)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		// Make sure the State is closed when the runner for the
+		// environment is done.
+		go func() {
+			envRunner.Wait()
+			err := st.Close()
+			if err != nil {
+				logger.Errorf("error closing state for env %s: %v", envTag.Id(), err)
+			}
+		}()
+		return envRunner, nil
+	})
+}
+
+func (m *envWorkerManager) envIsDead(envTag names.EnvironTag) error {
+	err := m.runner.StopWorker(envTag.Id())
+	return errors.Trace(err)
+}
+
+func (m *envWorkerManager) isEnvAlive(tag names.EnvironTag) (bool, error) {
+	env, err := m.st.GetEnvironment(tag)
+	if errors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Annotatef(err, "error loading environment %s", tag.Id())
+	}
+	return env.Life() == state.Alive, nil
+}

--- a/worker/envworkermanager/envworkermanager_test.go
+++ b/worker/envworkermanager/envworkermanager_test.go
@@ -1,0 +1,298 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package envworkermanager_test
+
+import (
+	stdtesting "testing"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/envworkermanager"
+)
+
+func TestPackage(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}
+
+var _ = gc.Suite(&suite{})
+
+type suite struct {
+	statetesting.StateSuite
+	factory *factory.Factory
+	runnerC chan *fakeRunner
+}
+
+func (s *suite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+	s.factory = factory.NewFactory(s.State)
+	s.runnerC = make(chan *fakeRunner, 1)
+}
+
+func (s *suite) makeEnvironment(c *gc.C) *state.State {
+	st := s.factory.MakeEnvironment(c, nil)
+	s.AddCleanup(func(*gc.C) { st.Close() })
+	return st
+}
+
+func (s *suite) TestStartsWorkersForPreExistingEnvs(c *gc.C) {
+	moreState := s.makeEnvironment(c)
+
+	var seenEnvs []string
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorkers)
+	defer m.Kill()
+	for _, r := range s.seeRunnersStart(c, 2) {
+		seenEnvs = append(seenEnvs, r.envUUID)
+	}
+	c.Assert(seenEnvs, jc.SameContents,
+		[]string{s.State.EnvironUUID(), moreState.EnvironUUID()})
+}
+
+func (s *suite) TestStartsWorkersForNewEnv(c *gc.C) {
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorkers)
+	defer m.Kill()
+	s.seeRunnersStart(c, 1) // Runner for state server env
+
+	// Create another environment and watch a runner be created for it.
+	st2 := s.makeEnvironment(c)
+	runner := s.seeRunnersStart(c, 1)[0]
+	c.Assert(runner.envUUID, gc.Equals, st2.EnvironUUID())
+}
+
+func (s *suite) TestStopsWorkersWhenEnvGoesAway(c *gc.C) {
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorkers)
+	defer m.Kill()
+	runner0 := s.seeRunnersStart(c, 1)[0]
+
+	// Create an environment and grab the runner for it.
+	otherState := s.makeEnvironment(c)
+	runner1 := s.seeRunnersStart(c, 1)[0]
+
+	// Destroy the new environment.
+	env, err := otherState.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// See that the first runner is still running but the runner for
+	// the new environment is stopped.
+	s.State.StartSync()
+	select {
+	case <-runner0.tomb.Dying():
+		c.Fatal("first runner should not die here")
+	case <-runner1.tomb.Dying():
+		break
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for runner to die")
+	}
+
+	// Make sure the first runner doesn't get stopped.
+	s.State.StartSync()
+	select {
+	case <-runner0.tomb.Dying():
+		c.Fatal("first runner should not die here")
+	case <-time.After(testing.ShortWait):
+		break
+	}
+}
+
+func (s *suite) TestKillPropogates(c *gc.C) {
+	s.makeEnvironment(c)
+
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorkers)
+	runners := s.seeRunnersStart(c, 2)
+	c.Assert(runners[0].killed, jc.IsFalse)
+	c.Assert(runners[1].killed, jc.IsFalse)
+
+	m.Kill()
+	err := waitOrPanic(m.Wait)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(runners[0].killed, jc.IsTrue)
+	c.Assert(runners[1].killed, jc.IsTrue)
+}
+
+func (s *suite) TestNothingHappensWhenEnvIsSeenAgain(c *gc.C) {
+	// This could happen if there's a change to an environment doc but
+	// it's otherwise still alive (unlikely but possible).
+	st := newStateWithFakeWatcher(s.State)
+	uuid := st.EnvironUUID()
+
+	m := envworkermanager.NewEnvWorkerManager(st, s.startEnvWorkers)
+	defer m.Kill()
+
+	// First time: runners started
+	st.sendEnvChange(uuid)
+	s.seeRunnersStart(c, 1)
+
+	// Second time: no runners started
+	st.sendEnvChange(uuid)
+	s.checkNoRunnersStart(c)
+}
+
+func (s *suite) TestNothingHappensWhenUnknownEnvReported(c *gc.C) {
+	// This could perhaps happen when an environment is dying just as
+	// the EnvWorkerManager is coming up (unlikely but possible).
+	st := newStateWithFakeWatcher(s.State)
+
+	m := envworkermanager.NewEnvWorkerManager(st, s.startEnvWorkers)
+	defer m.Kill()
+
+	st.sendEnvChange("unknown-env-uuid")
+	s.checkNoRunnersStart(c)
+
+	// Existing environment still works.
+	st.sendEnvChange(st.EnvironUUID())
+	s.seeRunnersStart(c, 1)
+}
+
+func (s *suite) TestFatalErrorKillsEnvWorkerManager(c *gc.C) {
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorkers)
+	runner := s.seeRunnersStart(c, 1)[0]
+
+	runner.tomb.Kill(worker.ErrTerminateAgent)
+	runner.tomb.Done()
+
+	err := waitOrPanic(m.Wait)
+	c.Assert(errors.Cause(err), gc.Equals, worker.ErrTerminateAgent)
+}
+
+func (s *suite) TestNonFatalErrorCausesRunnerRestart(c *gc.C) {
+	s.PatchValue(&worker.RestartDelay, time.Millisecond)
+
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorkers)
+	defer m.Kill()
+	runner0 := s.seeRunnersStart(c, 1)[0]
+
+	runner0.tomb.Kill(errors.New("trivial"))
+	runner0.tomb.Done()
+
+	s.seeRunnersStart(c, 1)
+}
+
+func (s *suite) seeRunnersStart(c *gc.C, expectedCount int) []*fakeRunner {
+	if expectedCount < 1 {
+		panic("expectedCount must be >= 1")
+	}
+	s.State.StartSync()
+	runners := make([]*fakeRunner, 0, expectedCount)
+	for {
+		select {
+		case r := <-s.runnerC:
+			runners = append(runners, r)
+			if len(runners) == expectedCount {
+				s.checkNoRunnersStart(c) // Check no more runners start
+				return runners
+			}
+		case <-time.After(testing.LongWait):
+			c.Fatal("timed out waiting for runners to be started")
+		}
+	}
+}
+
+func (s *suite) checkNoRunnersStart(c *gc.C) {
+	s.State.StartSync()
+	for {
+		select {
+		case <-s.runnerC:
+			c.Fatal("saw runner creation when expecting none")
+		case <-time.After(testing.ShortWait):
+			return
+		}
+	}
+}
+
+// startEnvWorkers is passed to NewEnvWorkerManager in these tests. It
+// creates fake Runner instances when envWorkerManager starts workers
+// for an environment.
+func (s *suite) startEnvWorkers(st *state.State) (worker.Runner, error) {
+	runner := &fakeRunner{
+		envUUID: st.EnvironUUID(),
+	}
+	s.runnerC <- runner
+	return runner, nil
+}
+
+func waitOrPanic(wait func() error) error {
+	errC := make(chan error)
+	go func() {
+		errC <- wait()
+	}()
+
+	select {
+	case err := <-errC:
+		return err
+	case <-time.After(testing.LongWait):
+		panic("waited too long")
+	}
+}
+
+// fakeRunner minimally implements the worker.Runner interface. It
+// doesn't actually run anything, recording some execution details for
+// testing.
+type fakeRunner struct {
+	worker.Runner
+	tomb    tomb.Tomb
+	envUUID string
+	killed  bool
+}
+
+func (r *fakeRunner) Kill() {
+	r.killed = true
+	r.tomb.Done()
+}
+
+func (r *fakeRunner) Wait() error {
+	e := r.tomb.Wait()
+	return e
+}
+
+func newStateWithFakeWatcher(realSt *state.State) *stateWithFakeWatcher {
+	return &stateWithFakeWatcher{
+		State: realSt,
+		envWatcher: &fakeEnvWatcher{
+			changes: make(chan []string),
+		},
+	}
+}
+
+// stateWithFakeWatcher wraps a *state.State, overriding the
+// WatchEnvironments method to allow control over the reported
+// environment lifecycle events for testing.
+//
+// Use sendEnvChange to cause an environment event to be emitted by
+// the watcher returned by WatchEnvironments.
+type stateWithFakeWatcher struct {
+	*state.State
+	envWatcher *fakeEnvWatcher
+}
+
+func (s *stateWithFakeWatcher) WatchEnvironments() state.StringsWatcher {
+	return s.envWatcher
+}
+
+func (s *stateWithFakeWatcher) sendEnvChange(uuids ...string) {
+	s.envWatcher.changes <- uuids
+}
+
+type fakeEnvWatcher struct {
+	state.StringsWatcher
+	changes chan []string
+}
+
+func (w *fakeEnvWatcher) Stop() error {
+	return nil
+}
+
+func (w *fakeEnvWatcher) Changes() <-chan []string {
+	return w.changes
+}

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -29,6 +29,7 @@ type Runner interface {
 	Worker
 	StartWorker(id string, startFunc func() (Worker, error)) error
 	StopWorker(id string) error
+	Dying() <-chan struct{}
 }
 
 // runner runs a set of workers, restarting them as necessary
@@ -125,6 +126,10 @@ func (runner *runner) Wait() error {
 func (runner *runner) Kill() {
 	logger.Debugf("killing runner %p", runner)
 	runner.tomb.Kill(nil)
+}
+
+func (runner *runner) Dying() <-chan struct{} {
+	return runner.tomb.Dying()
 }
 
 // Stop kills the given worker and waits for it to exit.


### PR DESCRIPTION
Workers are started and stopped as environments come and go (using State.WatchEnvironments).

It's Runners and Workers all the way down. A Runner is used to manage the Workers for each environment. Another Runner is used to manage the per-environment Runners.

A future PR will hook this up within the machine agent.

(Review request: http://reviews.vapour.ws/r/754/)