### PR TITLE
upgrades: fix steps iteration when current version has a tag

### DIFF
--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -68,9 +68,17 @@ func newOpsIterator(from, to version.Number, ops []Operation) *opsIterator {
 	if from == version.Zero {
 		from = version.MustParse("1.16.0")
 	}
+
 	// Clear the version tag of the target release to ensure that all
-	// upgrade steps for the release are run for alpha and beta releases.
-	to.Tag = ""
+	// upgrade steps for the release are run for alpha and beta
+	// releases.
+	// ...but only do this if the agent version has actually changed,
+	// lest we trigger upgrade mode unnecessarily for non-final
+	// versions.
+	if from.Compare(to) != 0 {
+		to.Tag = ""
+	}
+
 	return &opsIterator{
 		from:    from,
 		to:      to,

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -330,6 +330,18 @@ var areUpgradesDefinedTests = []areUpgradesDefinedTest{
 		fromVersion: "",
 		expected:    true,
 	},
+	{
+		about:       "upgrade between pre-final versions",
+		fromVersion: "1.21-beta4",
+		toVersion:   "1.21-beta5",
+		expected:    true,
+	},
+	{
+		about:       "no upgrades when version hasn't changed, even with release tags",
+		fromVersion: "1.21-beta5",
+		toVersion:   "1.21-beta5",
+		expected:    false,
+	},
 }
 
 func (s *upgradeSuite) TestAreUpgradesDefined(c *gc.C) {
@@ -499,6 +511,20 @@ var upgradeTests = []upgradeTest{
 		toVersion:     "1.21.0",
 		targets:       targets(upgrades.HostMachine),
 		expectedSteps: []string{"step 1 - 1.20.0", "step 2 - 1.20.0", "step 1 - 1.21.0"},
+	},
+	{
+		about:         "nothing happens when the version hasn't changed but contains a tag",
+		fromVersion:   "1.21-alpha1",
+		toVersion:     "1.21-alpha1",
+		targets:       targets(upgrades.DatabaseMaster),
+		expectedSteps: []string{},
+	},
+	{
+		about:         "upgrades between pre-final versions should run steps for the final version",
+		fromVersion:   "1.21-beta2",
+		toVersion:     "1.21-beta3",
+		targets:       targets(upgrades.DatabaseMaster),
+		expectedSteps: []string{"state step 1 - 1.21.0", "step 1 - 1.21.0"},
 	},
 }
 


### PR DESCRIPTION
Don't report an upgrade as being necessary when the target version has a tag but is the same as the "from" version.

Fixes LP #1411502.

(Review request: http://reviews.vapour.ws/r/755/)