### PR TITLE
storage: add StorageProvider, DiskSource

### DIFF
--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -183,7 +183,7 @@ func (m *Machine) DistributionGroup() ([]instance.Id, error) {
 // instance id cannot be changed.
 func (m *Machine) SetInstanceInfo(
 	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
-	networks []params.Network, interfaces []params.NetworkInterface, disks []storage.BlockDevice,
+	networks []params.Network, interfaces []params.NetworkInterface, volumes []storage.BlockDevice,
 ) error {
 	var result params.ErrorResults
 	args := params.InstancesInfo{
@@ -194,7 +194,7 @@ func (m *Machine) SetInstanceInfo(
 			Characteristics: characteristics,
 			Networks:        networks,
 			Interfaces:      interfaces,
-			Disks:           disks,
+			Volumes:         volumes,
 		}},
 	}
 	err := m.st.facade.FacadeCall("SetInstanceInfo", args, &result)

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -437,7 +437,7 @@ type InstanceInfo struct {
 	Characteristics *instance.HardwareCharacteristics
 	Networks        []Network
 	Interfaces      []NetworkInterface
-	Disks           []storage.BlockDevice
+	Volumes         []storage.BlockDevice
 }
 
 // InstancesInfo holds the parameters for making a SetInstanceInfo
@@ -738,7 +738,7 @@ type ProvisioningInfo struct {
 	Placement   string
 	Networks    []string
 	Jobs        []multiwatcher.MachineJob
-	Disks       []storage.DiskParams
+	Volumes     []storage.VolumeParams
 }
 
 // ProvisioningInfoResult holds machine provisioning info or an error.

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -372,7 +372,7 @@ func getProvisioningInfo(m *state.Machine) (*params.ProvisioningInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	disks, err := machineDiskParams(m)
+	volumes, err := machineVolumeParams(m)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -396,7 +396,7 @@ func getProvisioningInfo(m *state.Machine) (*params.ProvisioningInfo, error) {
 		Placement:   m.Placement(),
 		Networks:    networks,
 		Jobs:        jobs,
-		Disks:       disks,
+		Volumes:     volumes,
 	}, nil
 }
 
@@ -513,10 +513,10 @@ func (p *ProvisionerAPI) Constraints(args params.Entities) (params.ConstraintsRe
 	return result, nil
 }
 
-// machineDiskParams retrieves DiskParams for the disks that should be
+// machineVolumeParams retrieves VolumeParams for the volumes that should be
 // provisioned with and attached to the machine. The client should ignore
 // parameters that it does not know how to handle.
-func machineDiskParams(m *state.Machine) ([]storage.DiskParams, error) {
+func machineVolumeParams(m *state.Machine) ([]storage.VolumeParams, error) {
 	blockDevices, err := m.BlockDevices()
 	if err != nil {
 		return nil, err
@@ -524,13 +524,13 @@ func machineDiskParams(m *state.Machine) ([]storage.DiskParams, error) {
 	if len(blockDevices) == 0 {
 		return nil, nil
 	}
-	allParams := make([]storage.DiskParams, len(blockDevices))
+	allParams := make([]storage.VolumeParams, len(blockDevices))
 	for i, dev := range blockDevices {
 		params, ok := dev.Params()
 		if !ok {
-			return nil, errors.Errorf("cannot get parameters for disk %q", dev.Name())
+			return nil, errors.Errorf("cannot get parameters for volume %q", dev.Name())
 		}
-		allParams[i] = storage.DiskParams{
+		allParams[i] = storage.VolumeParams{
 			dev.Name(),
 			params.Size,
 			// TODO(axw) when pools are implemented,
@@ -685,7 +685,7 @@ func (p *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Erro
 		if err != nil {
 			return err
 		}
-		blockDevices, err := blockDevicesToState(arg.Disks)
+		blockDevices, err := blockDevicesToState(arg.Volumes)
 		if err != nil {
 			return err
 		}

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -536,6 +536,7 @@ func machineDiskParams(m *state.Machine) ([]storage.DiskParams, error) {
 			// TODO(axw) when pools are implemented,
 			// set Options here.
 			nil,
+			"", // no instance ID yet
 		}
 	}
 	return allParams, nil

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -759,7 +759,7 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 				Placement:   template.Placement,
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
-				Disks:       []storage.DiskParams{{Name: "0", Size: 1000}, {Name: "1", Size: 2000}},
+				Volumes:     []storage.VolumeParams{{Name: "0", Size: 1000}, {Name: "1", Size: 2000}},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -925,7 +925,7 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 	err := s.machines[0].SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	disksMachine, err := s.State.AddOneMachine(state.MachineTemplate{
+	volumesMachine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series:       "quantal",
 		Jobs:         []state.MachineJob{state.JobHostUnits},
 		BlockDevices: []state.BlockDeviceParams{{Size: 1000}},
@@ -1003,10 +1003,10 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		Networks:        networks,
 		Interfaces:      ifaces,
 	}, {
-		Tag:        disksMachine.Tag().String(),
+		Tag:        volumesMachine.Tag().String(),
 		InstanceId: "i-am-also",
 		Nonce:      "fake",
-		Disks:      []storage.BlockDevice{{Name: "0", Size: 1234}},
+		Volumes:    []storage.BlockDevice{{Name: "0", Size: 1234}},
 	},
 		{Tag: "machine-42"},
 		{Tag: "unit-foo-0"},
@@ -1081,16 +1081,16 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		c.Check(network.CIDR(), gc.Equals, networks[i].CIDR)
 	}
 
-	// Verify the machine with requested disks was provisioned, and the
-	// disk information recorded in state.
-	blockDevices, err := disksMachine.BlockDevices()
+	// Verify the machine with requested volumes was provisioned, and the
+	// volume information recorded in state.
+	blockDevices, err := volumesMachine.BlockDevices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blockDevices, gc.HasLen, 1)
 	blockDeviceInfo, err := blockDevices[0].Info()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blockDeviceInfo, gc.Equals, state.BlockDeviceInfo{Size: 1234})
 
-	// Verify the machine without requested disks still has no disks
+	// Verify the machine without requested volumes still has no volumes
 	// recorded in state.
 	blockDevices, err = s.machines[1].BlockDevices()
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -39,10 +39,10 @@ type StartInstanceParams struct {
 	// high availability.
 	DistributionGroup func() ([]instance.Id, error)
 
-	// Disks is a set of parameters for disks that must be created.
-	// If any of the disks cannot be created, StartInstance must
+	// Volumes is a set of parameters for volumes that must be created.
+	// If any of the volumes cannot be created, StartInstance must
 	// return an error.
-	Disks []storage.DiskParams
+	Volumes []storage.VolumeParams
 
 	// NetworkInfo is an optional list of network interface details,
 	// necessary to configure on the instance.
@@ -65,9 +65,9 @@ type StartInstanceResult struct {
 	// modified as needed.
 	NetworkInfo []network.InterfaceInfo
 
-	// Disks contains a list of block devices created, each one having
-	// the same Name as one of the DiskParams in StartInstanceParams.Disks.
-	Disks []storage.BlockDevice
+	// Volumes contains a list of volumes created, each one having the
+	// same Name as one of the VolumeParams in StartInstanceParams.Volumes.
+	Volumes []storage.BlockDevice
 }
 
 // TODO(wallyworld) - we want this in the environs/instance package but import loops

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -81,7 +81,7 @@ func (*DisksSuite) TestBlockDeviceNamer(c *gc.C) {
 
 func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 	mapping, blockDeviceInfo, err := ec2.GetBlockDeviceMappings(
-		"pv", &environs.StartInstanceParams{Disks: []storage.DiskParams{{
+		"pv", &environs.StartInstanceParams{Volumes: []storage.VolumeParams{{
 			Name: "0", Size: 1234,
 		}, {
 			Name: "1", Size: 4321,

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -486,7 +486,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	}
 	var instResp *ec2.RunInstancesResp
 
-	blockDeviceMappings, disks, err := getBlockDeviceMappings(
+	blockDeviceMappings, volumes, err := getBlockDeviceMappings(
 		*spec.InstanceType.VirtType, &args,
 	)
 	if err != nil {
@@ -546,7 +546,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	return &environs.StartInstanceResult{
 		Instance: inst,
 		Hardware: &hc,
-		Disks:    disks,
+		Volumes:  volumes,
 	}, nil
 }
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -854,13 +854,13 @@ func (t *localServerSuite) TestSupportAddressAllocationFalse(c *gc.C) {
 	c.Assert(result, jc.IsFalse)
 }
 
-func (t *localServerSuite) TestStartInstanceDisks(c *gc.C) {
+func (t *localServerSuite) TestStartInstanceVolumes(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	params := environs.StartInstanceParams{
-		Disks: []storage.DiskParams{{
+		Volumes: []storage.VolumeParams{{
 			Size: 512, // round up to 1GiB
 		}, {
 			Size: 1024, // 1GiB exactly
@@ -870,10 +870,10 @@ func (t *localServerSuite) TestStartInstanceDisks(c *gc.C) {
 	}
 	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Disks, gc.HasLen, 3)
-	c.Assert(result.Disks[0].Size, gc.Equals, uint64(1024))
-	c.Assert(result.Disks[1].Size, gc.Equals, uint64(1024))
-	c.Assert(result.Disks[2].Size, gc.Equals, uint64(2048))
+	c.Assert(result.Volumes, gc.HasLen, 3)
+	c.Assert(result.Volumes[0].Size, gc.Equals, uint64(1024))
+	c.Assert(result.Volumes[1].Size, gc.Equals, uint64(1024))
+	c.Assert(result.Volumes[2].Size, gc.Equals, uint64(2048))
 }
 
 // localNonUSEastSuite is similar to localServerSuite but the S3 mock server

--- a/storage/config.go
+++ b/storage/config.go
@@ -6,12 +6,12 @@ package storage
 // Config defines the configuration for a storage source.
 type Config struct {
 	name     string
-	provider string
+	provider ProviderType
 	attrs    map[string]interface{}
 }
 
 // NewConfig creates a new Config for instantiating a storage source.
-func NewConfig(name, provider string, attrs map[string]interface{}) (*Config, error) {
+func NewConfig(name string, provider ProviderType, attrs map[string]interface{}) (*Config, error) {
 	// TODO(axw) validate attributes.
 	return &Config{name, provider, attrs}, nil
 }
@@ -23,7 +23,7 @@ func (c *Config) Name() string {
 }
 
 // Provider returns the name of a storage provider.
-func (c *Config) Provider() string {
+func (c *Config) Provider() ProviderType {
 	return c.provider
 }
 

--- a/storage/config.go
+++ b/storage/config.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+// Config defines the configuration for a storage source.
+type Config struct {
+	name     string
+	provider string
+	attrs    map[string]interface{}
+}
+
+// NewConfig creates a new Config for instantiating a storage source.
+func NewConfig(name, provider string, attrs map[string]interface{}) (*Config, error) {
+	// TODO(axw) validate attributes.
+	return &Config{name, provider, attrs}, nil
+}
+
+// Name returns the name of a storage source. This is not necessarily unique,
+// and should only be used for informational purposes.
+func (c *Config) Name() string {
+	return c.name
+}
+
+// Provider returns the name of a storage provider.
+func (c *Config) Provider() string {
+	return c.provider
+}
+
+// Attrs returns the configuration attributes for a storage source.
+func (c *Config) Attrs() map[string]interface{} {
+	attrs := make(map[string]interface{})
+	for k, v := range c.attrs {
+		attrs[k] = v
+	}
+	return attrs
+}

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -3,6 +3,8 @@
 
 package storage
 
+import "github.com/juju/juju/instance"
+
 // FeatureFlag is the name of the feature for the JUJU_DEV_FEATURE_FLAGS
 // envar. Add this string to the envar to enable support for storage.
 const FeatureFlag = "storage"
@@ -20,4 +22,70 @@ type DiskParams struct {
 	// Options is a set of provider-specific options for storage creation,
 	// as defined in a storage pool.
 	Options map[string]interface{}
+
+	// Instance is the ID of the instance that the disk should be attached
+	// to initially. This will only be empty if the instance is not yet
+	// provisioned, in which case the parameters refer to a disk that is
+	// being created in conjunction with the instance.
+	Instance instance.Id
+}
+
+// StorageProvider is an interface for obtaining storage sources.
+type StorageProvider interface {
+	// DiskSource returns a DiskSource given the specified configuration.
+	//
+	// If the storage provider does not support creating disks as a
+	// first-class primitive, then DiskSource must return an error
+	// satisfying errors.IsNotSupported.
+	DiskSource(*Config) (DiskSource, error)
+
+	// TODO(axw) define filesystem source. If the user requests a
+	// filesystem and that can be provided first-class, it should be
+	// done that way. Otherwise we create a disk and then manage a
+	// filesystem on that.
+
+	// ValidateConfig validates the provided storage provider config,
+	// returning an error if it is invalid.
+	ValidateConfig(*Config) error
+}
+
+// DiskSource provides an interface for creating, destroying and
+// describing disks in the environment. A DiskSource is configured
+// in a particular way, and corresponds to a storage "pool".
+type DiskSource interface {
+	// CreateDisks creates disks with the specified size, in MiB.
+	CreateDisks(spec []DiskParams) ([]BlockDevice, error)
+
+	// DescribeDisks returns the properties of the disks with the
+	// specified provider disk IDs.
+	DescribeDisks(diskIds []string) ([]BlockDevice, error)
+
+	// DestroyDisks destroys the disks with the specified provider
+	// disk IDs.
+	DestroyDisks(diskIds []string) error
+
+	// ValidateDiskParams validates the provided disk parameters,
+	// returning an error if they are invalid.
+	//
+	// If the provider is incapable of provisioning disks separately
+	// from machine instances (e.g. MAAS), then ValidateDiskParams
+	// must return an error if params.Instance is non-empty.
+	ValidateDiskParams(params DiskParams) error
+
+	// AttachDisks attaches the disks with the specified provider
+	// disk IDs to the instances with the corresponding index.
+	//
+	// TODO(axw) we need to validate attachment requests prior to
+	// recording in state. For example, the ec2 disk provider must
+	// reject an attempt to attach a disk to an instance if they
+	// are in different availability zones.
+	AttachDisks(diskIds []string, instId []instance.Id) error
+
+	// DetachDisks detaches the disks with the specified provider
+	// disk IDs from the instances with the corresponding index.
+	//
+	// TODO(axw) we need to record in state whether or not disks
+	// are detachable, and reject attempts to attach/detach on
+	// that basis.
+	DetachDisks(diskIds []string, instId []instance.Id) error
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -30,8 +30,11 @@ type DiskParams struct {
 	Instance instance.Id
 }
 
-// StorageProvider is an interface for obtaining storage sources.
-type StorageProvider interface {
+// ProviderType uniquely identifies a storage provider, such as "ebs" or "loop".
+type ProviderType string
+
+// Provider is an interface for obtaining storage sources.
+type Provider interface {
 	// DiskSource returns a DiskSource given the specified configuration.
 	//
 	// If the storage provider does not support creating disks as a

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -9,23 +9,23 @@ import "github.com/juju/juju/instance"
 // envar. Add this string to the envar to enable support for storage.
 const FeatureFlag = "storage"
 
-// DiskParams is a fully specified set of parameters for disk creation,
+// VolumeParams is a fully specified set of parameters for volume creation,
 // derived from one or more of user-specified storage constraints, a
 // storage pool definition, and charm storage metadata.
-type DiskParams struct {
-	// Name is a unique name assigned by Juju for the requested disk.
+type VolumeParams struct {
+	// Name is a unique name assigned by Juju for the requested volume.
 	Name string
 
-	// Size is the minimum size of the disk in MiB.
+	// Size is the minimum size of the volume in MiB.
 	Size uint64
 
 	// Options is a set of provider-specific options for storage creation,
 	// as defined in a storage pool.
 	Options map[string]interface{}
 
-	// Instance is the ID of the instance that the disk should be attached
+	// Instance is the ID of the instance that the volume should be attached
 	// to initially. This will only be empty if the instance is not yet
-	// provisioned, in which case the parameters refer to a disk that is
+	// provisioned, in which case the parameters refer to a volume that is
 	// being created in conjunction with the instance.
 	Instance instance.Id
 }
@@ -35,16 +35,16 @@ type ProviderType string
 
 // Provider is an interface for obtaining storage sources.
 type Provider interface {
-	// DiskSource returns a DiskSource given the specified configuration.
+	// VolumeSource returns a VolumeSource given the specified configuration.
 	//
-	// If the storage provider does not support creating disks as a
-	// first-class primitive, then DiskSource must return an error
+	// If the storage provider does not support creating volumes as a
+	// first-class primitive, then VolumeSource must return an error
 	// satisfying errors.IsNotSupported.
-	DiskSource(*Config) (DiskSource, error)
+	VolumeSource(*Config) (VolumeSource, error)
 
 	// TODO(axw) define filesystem source. If the user requests a
 	// filesystem and that can be provided first-class, it should be
-	// done that way. Otherwise we create a disk and then manage a
+	// done that way. Otherwise we create a volume and then manage a
 	// filesystem on that.
 
 	// ValidateConfig validates the provided storage provider config,
@@ -52,43 +52,51 @@ type Provider interface {
 	ValidateConfig(*Config) error
 }
 
-// DiskSource provides an interface for creating, destroying and
-// describing disks in the environment. A DiskSource is configured
+// VolumeSource provides an interface for creating, destroying and
+// describing volumes in the environment. A VolumeSource is configured
 // in a particular way, and corresponds to a storage "pool".
-type DiskSource interface {
-	// CreateDisks creates disks with the specified size, in MiB.
-	CreateDisks(spec []DiskParams) ([]BlockDevice, error)
-
-	// DescribeDisks returns the properties of the disks with the
-	// specified provider disk IDs.
-	DescribeDisks(diskIds []string) ([]BlockDevice, error)
-
-	// DestroyDisks destroys the disks with the specified provider
-	// disk IDs.
-	DestroyDisks(diskIds []string) error
-
-	// ValidateDiskParams validates the provided disk parameters,
-	// returning an error if they are invalid.
+type VolumeSource interface {
+	// CreateVolumes creates volumes with the specified size, in MiB.
 	//
-	// If the provider is incapable of provisioning disks separately
-	// from machine instances (e.g. MAAS), then ValidateDiskParams
-	// must return an error if params.Instance is non-empty.
-	ValidateDiskParams(params DiskParams) error
+	// TODO(axw) CreateVolumes should return something other than
+	// []BlockDevice, so we can communicate additional information
+	// about the volumes that are not relevant at the attachment
+	// level.
+	CreateVolumes(params []VolumeParams) ([]BlockDevice, error)
 
-	// AttachDisks attaches the disks with the specified provider
-	// disk IDs to the instances with the corresponding index.
+	// DescribeVolumes returns the properties of the volumes with the
+	// specified provider volume IDs.
+	//
+	// TODO(axw) as in CreateVolumes, we should return something other
+	// than []BlockDevice here.
+	DescribeVolumes(volIds []string) ([]BlockDevice, error)
+
+	// DestroyVolumes destroys the volumes with the specified provider
+	// volume IDs.
+	DestroyVolumes(volIds []string) error
+
+	// ValidateVolumeParams validates the provided volume creation
+	// parameters, returning an error if they are invalid.
+	//
+	// If the provider is incapable of provisioning volumes separately
+	// from machine instances (e.g. MAAS), then ValidateVolumeParams
+	// must return an error if params.Instance is non-empty.
+	ValidateVolumeParams(params VolumeParams) error
+
+	// AttachVolumes attaches the volumes with the specified provider
+	// volume IDs to the instances with the corresponding index.
 	//
 	// TODO(axw) we need to validate attachment requests prior to
-	// recording in state. For example, the ec2 disk provider must
-	// reject an attempt to attach a disk to an instance if they
-	// are in different availability zones.
-	AttachDisks(diskIds []string, instId []instance.Id) error
+	// recording in state. For example, the ec2 provider must reject
+	// an attempt to attach a volume to an instance if they are in
+	// different availability zones.
+	AttachVolumes(volIds []string, instId []instance.Id) error
 
-	// DetachDisks detaches the disks with the specified provider
-	// disk IDs from the instances with the corresponding index.
+	// DetachVolumes detaches the volumes with the specified provider
+	// volume IDs from the instances with the corresponding index.
 	//
-	// TODO(axw) we need to record in state whether or not disks
+	// TODO(axw) we need to record in state whether or not volumes
 	// are detachable, and reject attempts to attach/detach on
 	// that basis.
-	DetachDisks(diskIds []string, instId []instance.Id) error
+	DetachVolumes(volIds []string, instId []instance.Id) error
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -486,7 +486,7 @@ func constructStartInstanceParams(
 		MachineConfig:     machineConfig,
 		Placement:         provisioningInfo.Placement,
 		DistributionGroup: machine.DistributionGroup,
-		Disks:             provisioningInfo.Disks,
+		Volumes:           provisioningInfo.Volumes,
 	}
 }
 
@@ -592,18 +592,18 @@ func (task *provisionerTask) startMachine(
 	hardware := result.Hardware
 	nonce := startInstanceParams.MachineConfig.MachineNonce
 	networks, ifaces := task.prepareNetworkAndInterfaces(result.NetworkInfo)
-	disks := result.Disks
+	volumes := result.Volumes
 
 	// TODO(dimitern) In a newer Provisioner API version, change
 	// SetInstanceInfo or add a new method that takes and saves in
 	// state all the information available on a network.InterfaceInfo
 	// for each interface, so we can later manage interfaces
 	// dynamically at run-time.
-	err = machine.SetInstanceInfo(inst.Id(), nonce, hardware, networks, ifaces, disks)
+	err = machine.SetInstanceInfo(inst.Id(), nonce, hardware, networks, ifaces, volumes)
 	if err != nil && params.IsCodeNotImplemented(err) {
 		return fmt.Errorf("cannot provision instance %v for machine %q with networks: not implemented", inst.Id(), machine)
 	} else if err == nil {
-		logger.Infof("started machine %s as instance %s with hardware %q, networks %v, interfaces %v, disks %v", machine, inst.Id(), hardware, networks, ifaces, disks)
+		logger.Infof("started machine %s as instance %s with hardware %q, networks %v, interfaces %v, volumes %v", machine, inst.Id(), hardware, networks, ifaces, volumes)
 		return nil
 	}
 	// We need to stop the instance right away here, set error status and go on.


### PR DESCRIPTION
Introduce the interfaces by which we will
provision disks and, later, file systems.

Storage provisioners will be running in one
of several places depending on the provider:
 - on state servers, if cloud-provider access
   is required (e.g. to create EBS volumes)
 - on machine agents, if access to the machine's
   root filesystem is required (e.g. loop).

(Review request: http://reviews.vapour.ws/r/757/)