### PR TITLE
Merge pull request #1427 from wallyworld/add-hastatus-to-megawatcher

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2268,6 +2268,8 @@ func (s *clientSuite) TestClientWatchAll(c *gc.C) {
 			Jobs:                    []multiwatcher.MachineJob{state.JobManageEnviron.ToParams()},
 			Addresses:               []network.Address{},
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
+			HasVote:                 false,
+			WantsVote:               true,
 		},
 	}}) {
 		c.Logf("got:")

--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -51,7 +51,7 @@ var marshalTestCases = []struct {
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
 		},
 	},
-	json: `["machine","change",{"Id":"Benji","InstanceId":"Shazam","Status":"error","StatusInfo":"foo","StatusData":null,"Life":"alive","Series":"trusty","SupportedContainers":["lxc"],"SupportedContainersKnown":false,"Jobs":["JobManageEnviron"],"Addresses":[],"HardwareCharacteristics":{}}]`,
+	json: `["machine","change",{"Id":"Benji","InstanceId":"Shazam","HasVote":false,"WantsVote":false,"Status":"error","StatusInfo":"foo","StatusData":null,"Life":"alive","Series":"trusty","SupportedContainers":["lxc"],"SupportedContainersKnown":false,"Jobs":["JobManageEnviron"],"Addresses":[],"HardwareCharacteristics":{}}]`,
 }, {
 	about: "ServiceInfo Delta",
 	value: multiwatcher.Delta{

--- a/state/machine.go
+++ b/state/machine.go
@@ -138,6 +138,10 @@ func newMachine(st *State, doc *machineDoc) *Machine {
 	return machine
 }
 
+func wantsVote(jobs []MachineJob, noVote bool) bool {
+	return hasJob(jobs, JobManageEnviron) && !noVote
+}
+
 // Id returns the machine id.
 func (m *Machine) Id() string {
 	return m.doc.Id
@@ -242,7 +246,7 @@ func (m *Machine) Jobs() []MachineJob {
 // WantsVote reports whether the machine is a state server
 // that wants to take part in peer voting.
 func (m *Machine) WantsVote() bool {
-	return hasJob(m.doc.Jobs, JobManageEnviron) && !m.doc.NoVote
+	return wantsVote(m.doc.Jobs, m.doc.NoVote)
 }
 
 // HasVote reports whether that machine is currently a voting

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -34,6 +34,8 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id interfa
 		Addresses:                mergedAddresses(m.MachineAddresses, m.Addresses),
 		SupportedContainers:      m.SupportedContainers,
 		SupportedContainersKnown: m.SupportedContainersKnown,
+		HasVote:                  m.HasVote,
+		WantsVote:                wantsVote(m.Jobs, m.NoVote),
 	}
 
 	oldInfo := store.Get(info.EntityId())

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -191,7 +191,7 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C, st *State, units int) (e
 		Addresses:               m.Addresses(),
 		HardwareCharacteristics: hc,
 		HasVote:                 true,
-		WantsVote:               true,
+		WantsVote:               false,
 	})
 
 	wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -172,6 +172,8 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C, st *State, units int) (e
 	m, err := st.AddMachine("quantal", JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, names.NewMachineTag("0"))
+	err = m.SetHasVote(true)
+	c.Assert(err, jc.ErrorIsNil)
 	// TODO(dfc) instance.Id should take a TAG!
 	err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -188,6 +190,8 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C, st *State, units int) (e
 		Jobs:                    []multiwatcher.MachineJob{JobHostUnits.ToParams()},
 		Addresses:               m.Addresses(),
 		HardwareCharacteristics: hc,
+		HasVote:                 true,
+		WantsVote:               true,
 	})
 
 	wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
@@ -281,6 +285,8 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C, st *State, units int) (e
 			Jobs:                    []multiwatcher.MachineJob{JobHostUnits.ToParams()},
 			Addresses:               []network.Address{},
 			HardwareCharacteristics: hc,
+			HasVote:                 false,
+			WantsVote:               false,
 		})
 		err = wu.AssignToMachine(m)
 		c.Assert(err, jc.ErrorIsNil)
@@ -371,6 +377,8 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 						Series:     "quantal",
 						Jobs:       []multiwatcher.MachineJob{JobHostUnits.ToParams()},
 						Addresses:  []network.Address{},
+						HasVote:    false,
+						WantsVote:  false,
 					}}}
 		},
 		// Machine status changes
@@ -408,6 +416,8 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 						HardwareCharacteristics:  &instance.HardwareCharacteristics{},
 						SupportedContainers:      []instance.ContainerType{instance.LXC},
 						SupportedContainersKnown: true,
+						HasVote:                  false,
+						WantsVote:                true,
 					}}}
 		},
 		// Unit changes
@@ -1040,6 +1050,8 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 			Series:    "trusty",
 			Jobs:      []multiwatcher.MachineJob{JobManageEnviron.ToParams()},
 			Addresses: []network.Address{},
+			HasVote:   false,
+			WantsVote: true,
 		},
 	}, {
 		Entity: &multiwatcher.MachineInfo{
@@ -1049,6 +1061,8 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 			Series:    "saucy",
 			Jobs:      []multiwatcher.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []network.Address{},
+			HasVote:   false,
+			WantsVote: false,
 		},
 	}})
 
@@ -1091,6 +1105,8 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 			Jobs:                    []multiwatcher.MachineJob{JobManageEnviron.ToParams()},
 			Addresses:               []network.Address{},
 			HardwareCharacteristics: hc,
+			HasVote:                 false,
+			WantsVote:               true,
 		},
 	}, {
 		Removed: true,
@@ -1110,6 +1126,8 @@ func (s *storeManagerStateSuite) TestStateWatcher(c *gc.C) {
 			Series:    "quantal",
 			Jobs:      []multiwatcher.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []network.Address{},
+			HasVote:   false,
+			WantsVote: false,
 		},
 	}, {
 		Entity: &multiwatcher.ServiceInfo{

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -130,6 +130,8 @@ type MachineInfo struct {
 	HardwareCharacteristics  *instance.HardwareCharacteristics `json:",omitempty"`
 	Jobs                     []MachineJob
 	Addresses                []network.Address
+	HasVote                  bool
+	WantsVote                bool
 }
 
 func (i *MachineInfo) EntityId() EntityId {


### PR DESCRIPTION
Add machine ha status to megawatcher

Fixes: https://bugs.launchpad.net/juju-core/+bug/1402965

Adds machine ha status to the MachineInfo struct in megawatcher

(Review request: http://reviews.vapour.ws/r/748/)

(Review request: http://reviews.vapour.ws/r/758/)