### PR TITLE
clean up state testing

### DIFF
--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -258,9 +258,9 @@ func (r *RestoreSuite) TestNewConnection(c *gc.C) {
 	st := statetesting.Initialize(c, names.NewLocalUserTag("test-admin"), nil, nil)
 	c.Assert(st.Close(), jc.ErrorIsNil)
 
-	r.PatchValue(&mongoDefaultDialOpts, coretesting.NewDialOpts)
+	r.PatchValue(&mongoDefaultDialOpts, statetesting.NewDialOpts)
 	r.PatchValue(&environsNewStatePolicy, func() state.Policy { return nil })
-	st, err = newStateConnection(coretesting.NewMongoInfo())
+	st, err = newStateConnection(statetesting.NewMongoInfo())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st.Close(), jc.ErrorIsNil)
 }

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -108,7 +108,7 @@ func (s *CleanupSuite) TestCleanupRelationSettings(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
 	// Create a relation with a unit in scope.
-	pr := NewPeerRelation(c, s.State, s.owner)
+	pr := NewPeerRelation(c, s.State, s.Owner)
 	rel := pr.ru0.Relation()
 	err := pr.ru0.EnterScope(map[string]interface{}{"some": "settings"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -157,7 +157,7 @@ func (s *CleanupSuite) TestCleanupForceDestroyedMachineUnit(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a relation with a unit in scope and assigned to the machine.
-	pr := NewPeerRelation(c, s.State, s.owner)
+	pr := NewPeerRelation(c, s.State, s.Owner)
 	err = pr.u0.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 	err = pr.ru0.EnterScope(nil)

--- a/state/collections_test.go
+++ b/state/collections_test.go
@@ -97,7 +97,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll",
 			test: func() (int, error) {
-				_, err := coll.RemoveAll(bson.D{{"createdby", s.owner.Name()}})
+				_, err := coll.RemoveAll(bson.D{{"createdby", s.Owner.Name()}})
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},

--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -41,7 +41,7 @@ func (s *compatSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
 	owner := names.NewLocalUserTag("test-admin")
-	st, err := Initialize(owner, TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), nil)
+	st, err := Initialize(owner, testing.NewMongoInfo(), testing.EnvironConfig(c), testing.NewDialOpts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.state = st
 	env, err := s.state.Environment()

--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -4,57 +4,30 @@
 package state
 
 import (
-	"github.com/juju/names"
-	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/testcharms"
-	"github.com/juju/juju/testing"
 )
 
 // compatSuite contains backwards compatibility tests,
 // for ensuring state operations behave correctly across
 // schema changes.
 type compatSuite struct {
-	testing.BaseSuite
-	gitjujutesting.MgoSuite
-	state *State
-	env   *Environment
+	internalStateSuite
+	env *Environment
 }
 
 var _ = gc.Suite(&compatSuite{})
 
-func (s *compatSuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
-	s.MgoSuite.SetUpSuite(c)
-}
-
-func (s *compatSuite) TearDownSuite(c *gc.C) {
-	s.MgoSuite.TearDownSuite(c)
-	s.BaseSuite.TearDownSuite(c)
-}
-
 func (s *compatSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-	s.MgoSuite.SetUpTest(c)
-	owner := names.NewLocalUserTag("test-admin")
-	st, err := Initialize(owner, testing.NewMongoInfo(), testing.EnvironConfig(c), testing.NewDialOpts(), nil)
-	c.Assert(err, jc.ErrorIsNil)
-	s.state = st
+	s.internalStateSuite.SetUpTest(c)
+
 	env, err := s.state.Environment()
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env
-}
-
-func (s *compatSuite) TearDownTest(c *gc.C) {
-	if s.state != nil {
-		s.state.Close()
-	}
-	s.MgoSuite.TearDownTest(c)
-	s.BaseSuite.TearDownTest(c)
 }
 
 func (s *compatSuite) TestEnvironAssertAlive(c *gc.C) {

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -60,7 +60,7 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	cs.policy = statetesting.MockPolicy{}
 	cfg := testing.EnvironConfig(c)
 	cs.owner = names.NewLocalUserTag("test-admin")
-	cs.State = TestingInitialize(c, cs.owner, cfg, &cs.policy)
+	cs.State = statetesting.Initialize(c, cs.owner, cfg, &cs.policy)
 	uuid, ok := cfg.UUID()
 	c.Assert(ok, jc.IsTrue)
 	cs.envTag = names.NewEnvironTag(uuid)

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -7,8 +7,6 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/names"
-	gitjujutesting "github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 
@@ -26,8 +24,7 @@ func TestPackage(t *stdtesting.T) {
 // ConnSuite provides the infrastructure for all other
 // test suites (StateSuite, CharmSuite, MachineSuite, etc).
 type ConnSuite struct {
-	gitjujutesting.MgoSuite
-	testing.BaseSuite
+	statetesting.StateSuite
 	annotations  *mgo.Collection
 	charms       *mgo.Collection
 	machines     *mgo.Collection
@@ -36,34 +33,20 @@ type ConnSuite struct {
 	services     *mgo.Collection
 	units        *mgo.Collection
 	stateServers *mgo.Collection
-	State        *state.State
 	policy       statetesting.MockPolicy
 	factory      *factory.Factory
 	envTag       names.EnvironTag
-	owner        names.UserTag
-}
-
-func (cs *ConnSuite) SetUpSuite(c *gc.C) {
-	cs.BaseSuite.SetUpSuite(c)
-	cs.MgoSuite.SetUpSuite(c)
-}
-
-func (cs *ConnSuite) TearDownSuite(c *gc.C) {
-	cs.MgoSuite.TearDownSuite(c)
-	cs.BaseSuite.TearDownSuite(c)
 }
 
 func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	c.Log("SetUpTest")
-	cs.BaseSuite.SetUpTest(c)
-	cs.MgoSuite.SetUpTest(c)
+
 	cs.policy = statetesting.MockPolicy{}
-	cfg := testing.EnvironConfig(c)
-	cs.owner = names.NewLocalUserTag("test-admin")
-	cs.State = statetesting.Initialize(c, cs.owner, cfg, &cs.policy)
-	uuid, ok := cfg.UUID()
-	c.Assert(ok, jc.IsTrue)
-	cs.envTag = names.NewEnvironTag(uuid)
+	cs.StateSuite.Policy = &cs.policy
+
+	cs.StateSuite.SetUpTest(c)
+
+	cs.envTag = cs.State.EnvironTag()
 	cs.factory = factory.NewFactory(cs.State)
 
 	jujuDB := cs.MgoSuite.Session.DB("juju")
@@ -79,25 +62,16 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	c.Log("SetUpTest done")
 }
 
-func (cs *ConnSuite) TearDownTest(c *gc.C) {
-	if cs.State != nil {
-		// If setup fails, we don't have a State yet
-		cs.State.Close()
-	}
-	cs.MgoSuite.TearDownTest(c)
-	cs.BaseSuite.TearDownTest(c)
-}
-
 func (s *ConnSuite) AddTestingCharm(c *gc.C, name string) *state.Charm {
 	return state.AddTestingCharm(c, s.State, name)
 }
 
 func (s *ConnSuite) AddTestingService(c *gc.C, name string, ch *state.Charm) *state.Service {
-	return state.AddTestingService(c, s.State, name, ch, s.owner)
+	return state.AddTestingService(c, s.State, name, ch, s.Owner)
 }
 
 func (s *ConnSuite) AddTestingServiceWithNetworks(c *gc.C, name string, ch *state.Charm, networks []string) *state.Service {
-	return state.AddTestingServiceWithNetworks(c, s.State, name, ch, s.owner, networks)
+	return state.AddTestingServiceWithNetworks(c, s.State, name, ch, s.Owner, networks)
 }
 
 func (s *ConnSuite) AddSeriesCharm(c *gc.C, name, series string) *state.Charm {

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -29,7 +29,7 @@ func (s *EnvironSuite) TestEnvironment(c *gc.C) {
 	c.Assert(env.Tag(), gc.Equals, expectedTag)
 	c.Assert(env.ServerTag(), gc.Equals, expectedTag)
 	c.Assert(env.Name(), gc.Equals, "testenv")
-	c.Assert(env.Owner(), gc.Equals, s.owner)
+	c.Assert(env.Owner(), gc.Equals, s.Owner)
 	c.Assert(env.Life(), gc.Equals, state.Alive)
 }
 
@@ -90,7 +90,7 @@ func (s *EnvironSuite) TestStateServerEnvironment(c *gc.C) {
 	c.Assert(env.Tag(), gc.Equals, expectedTag)
 	c.Assert(env.ServerTag(), gc.Equals, expectedTag)
 	c.Assert(env.Name(), gc.Equals, "testenv")
-	c.Assert(env.Owner(), gc.Equals, s.owner)
+	c.Assert(env.Owner(), gc.Equals, s.Owner)
 	c.Assert(env.Life(), gc.Equals, state.Alive)
 }
 
@@ -103,7 +103,7 @@ func (s *EnvironSuite) TestStateServerEnvironmentAccessibleFromOtherEnvironments
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Tag(), gc.Equals, s.envTag)
 	c.Assert(env.Name(), gc.Equals, "testenv")
-	c.Assert(env.Owner(), gc.Equals, s.owner)
+	c.Assert(env.Owner(), gc.Equals, s.Owner)
 	c.Assert(env.Life(), gc.Equals, state.Alive)
 }
 

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -40,7 +40,7 @@ func (s *InitializeSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *InitializeSuite) openState(c *gc.C) {
-	st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 }
@@ -60,7 +60,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	uuid, _ := cfg.UUID()
 	initial := cfg.AllAttrs()
 	owner := names.NewLocalUserTag("initialize-admin")
-	st, err := state.Initialize(owner, testing.NewMongoInfo(), cfg, testing.NewDialOpts(), nil)
+	st, err := state.Initialize(owner, statetesting.NewMongoInfo(), cfg, statetesting.NewDialOpts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
 	envTag := st.EnvironTag()
@@ -117,7 +117,7 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 	// for originally...
 	cfg, err := cfg.Apply(map[string]interface{}{"authorized-keys": "something-else"})
 	c.Assert(err, jc.ErrorIsNil)
-	st, err = state.Initialize(owner, testing.NewMongoInfo(), cfg, testing.NewDialOpts(), state.Policy(nil))
+	st, err = state.Initialize(owner, statetesting.NewMongoInfo(), cfg, statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
 	st.Close()
@@ -135,7 +135,7 @@ func (s *InitializeSuite) TestEnvironConfigWithAdminSecret(c *gc.C) {
 	bad, err := good.Apply(badUpdateAttrs)
 	owner := names.NewLocalUserTag("initialize-admin")
 
-	_, err = state.Initialize(owner, testing.NewMongoInfo(), bad, testing.NewDialOpts(), state.Policy(nil))
+	_, err = state.Initialize(owner, statetesting.NewMongoInfo(), bad, statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, gc.ErrorMatches, "admin-secret should never be written to the state")
 
 	// admin-secret blocks UpdateEnvironConfig.
@@ -161,7 +161,7 @@ func (s *InitializeSuite) TestEnvironConfigWithoutAgentVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	owner := names.NewLocalUserTag("initialize-admin")
 
-	_, err = state.Initialize(owner, testing.NewMongoInfo(), bad, testing.NewDialOpts(), state.Policy(nil))
+	_, err = state.Initialize(owner, statetesting.NewMongoInfo(), bad, statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, gc.ErrorMatches, "agent-version must always be set in state")
 
 	st := statetesting.Initialize(c, owner, good, nil)

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
 )
 
@@ -108,7 +109,7 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 	cfg := testing.EnvironConfig(c)
 	initial := cfg.AllAttrs()
 	owner := names.NewLocalUserTag("initialize-admin")
-	st := TestingInitialize(c, owner, cfg, nil)
+	st := statetesting.Initialize(c, owner, cfg, nil)
 	st.Close()
 
 	// A second initialize returns an open *State, but ignores its params.
@@ -138,7 +139,7 @@ func (s *InitializeSuite) TestEnvironConfigWithAdminSecret(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "admin-secret should never be written to the state")
 
 	// admin-secret blocks UpdateEnvironConfig.
-	st := TestingInitialize(c, owner, good, nil)
+	st := statetesting.Initialize(c, owner, good, nil)
 	st.Close()
 
 	s.openState(c)
@@ -163,7 +164,7 @@ func (s *InitializeSuite) TestEnvironConfigWithoutAgentVersion(c *gc.C) {
 	_, err = state.Initialize(owner, state.TestingMongoInfo(), bad, state.TestingDialOpts(), state.Policy(nil))
 	c.Assert(err, gc.ErrorMatches, "agent-version must always be set in state")
 
-	st := TestingInitialize(c, owner, good, nil)
+	st := statetesting.Initialize(c, owner, good, nil)
 	// yay side effects
 	st.Close()
 

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -40,7 +40,7 @@ func (s *InitializeSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *InitializeSuite) openState(c *gc.C) {
-	st, err := state.Open(state.TestingMongoInfo(), state.TestingDialOpts(), state.Policy(nil))
+	st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 }
@@ -60,7 +60,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	uuid, _ := cfg.UUID()
 	initial := cfg.AllAttrs()
 	owner := names.NewLocalUserTag("initialize-admin")
-	st, err := state.Initialize(owner, state.TestingMongoInfo(), cfg, state.TestingDialOpts(), nil)
+	st, err := state.Initialize(owner, testing.NewMongoInfo(), cfg, testing.NewDialOpts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
 	envTag := st.EnvironTag()
@@ -117,7 +117,7 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 	// for originally...
 	cfg, err := cfg.Apply(map[string]interface{}{"authorized-keys": "something-else"})
 	c.Assert(err, jc.ErrorIsNil)
-	st, err = state.Initialize(owner, state.TestingMongoInfo(), cfg, state.TestingDialOpts(), state.Policy(nil))
+	st, err = state.Initialize(owner, testing.NewMongoInfo(), cfg, testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
 	st.Close()
@@ -135,7 +135,7 @@ func (s *InitializeSuite) TestEnvironConfigWithAdminSecret(c *gc.C) {
 	bad, err := good.Apply(badUpdateAttrs)
 	owner := names.NewLocalUserTag("initialize-admin")
 
-	_, err = state.Initialize(owner, state.TestingMongoInfo(), bad, state.TestingDialOpts(), state.Policy(nil))
+	_, err = state.Initialize(owner, testing.NewMongoInfo(), bad, testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, gc.ErrorMatches, "admin-secret should never be written to the state")
 
 	// admin-secret blocks UpdateEnvironConfig.
@@ -161,7 +161,7 @@ func (s *InitializeSuite) TestEnvironConfigWithoutAgentVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	owner := names.NewLocalUserTag("initialize-admin")
 
-	_, err = state.Initialize(owner, state.TestingMongoInfo(), bad, state.TestingDialOpts(), state.Policy(nil))
+	_, err = state.Initialize(owner, testing.NewMongoInfo(), bad, testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, gc.ErrorMatches, "agent-version must always be set in state")
 
 	st := statetesting.Initialize(c, owner, good, nil)

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
 )
 
@@ -39,13 +40,18 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.owner = names.NewLocalUserTag("test-admin")
-	st, err := Initialize(
-		s.owner,
-		testing.NewMongoInfo(),
-		testing.EnvironConfig(c),
-		testing.NewDialOpts(),
-		nil,
-	)
+	// Copied from NewMongoInfo (due to import loops).
+	info := &mongo.MongoInfo{
+		Info: mongo.Info{
+			Addrs:  []string{jujutesting.MgoServer.Addr()},
+			CACert: testing.CACert,
+		},
+	}
+	// Copied from NewDialOpts (due to import loops).
+	dialopts := mongo.DialOpts{
+		Timeout: testing.LongWait,
+	}
+	st, err := Initialize(s.owner, info, testing.EnvironConfig(c), dialopts, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.state = st
 	s.AddCleanup(func(*gc.C) { s.state.Close() })

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -1,0 +1,57 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/names"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&internalStateSuite{})
+
+// internalStateSuite manages a *State instance for tests in the state
+// package (i.e. internal tests) that need it. It is similar to
+// state.testing.StateSuite but is duplicated to avoid cyclic imports.
+type internalStateSuite struct {
+	jujutesting.MgoSuite
+	testing.BaseSuite
+	state *State
+	owner names.UserTag
+}
+
+func (s *internalStateSuite) SetUpSuite(c *gc.C) {
+	s.MgoSuite.SetUpSuite(c)
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *internalStateSuite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+	s.MgoSuite.TearDownSuite(c)
+}
+
+func (s *internalStateSuite) SetUpTest(c *gc.C) {
+	s.MgoSuite.SetUpTest(c)
+	s.BaseSuite.SetUpTest(c)
+
+	s.owner = names.NewLocalUserTag("test-admin")
+	st, err := Initialize(
+		s.owner,
+		testing.NewMongoInfo(),
+		testing.EnvironConfig(c),
+		testing.NewDialOpts(),
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.state = st
+	s.AddCleanup(func(*gc.C) { s.state.Close() })
+}
+
+func (s *internalStateSuite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
+	s.MgoSuite.TearDownTest(c)
+}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -448,8 +448,8 @@ func (s *MachineSuite) TestTag(c *gc.C) {
 }
 
 func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
-	info := coretesting.NewMongoInfo()
-	st, err := state.Open(info, coretesting.NewDialOpts(), state.Policy(nil))
+	info := testing.NewMongoInfo()
+	st, err := state.Open(info, testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	// Turn on fully-authenticated mode.
@@ -472,7 +472,7 @@ func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 
 	// Check that we can log in with the correct password.
 	info.Password = "foo"
-	st1, err := state.Open(info, coretesting.NewDialOpts(), state.Policy(nil))
+	st1, err := state.Open(info, testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -448,8 +448,8 @@ func (s *MachineSuite) TestTag(c *gc.C) {
 }
 
 func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
-	info := state.TestingMongoInfo()
-	st, err := state.Open(info, state.TestingDialOpts(), state.Policy(nil))
+	info := coretesting.NewMongoInfo()
+	st, err := state.Open(info, coretesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	// Turn on fully-authenticated mode.
@@ -472,7 +472,7 @@ func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 
 	// Check that we can log in with the correct password.
 	info.Password = "foo"
-	st1, err := state.Open(info, state.TestingDialOpts(), state.Policy(nil))
+	st1, err := state.Open(info, coretesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -65,7 +65,7 @@ func (s *storeManagerStateSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.owner = names.NewLocalUserTag("test-admin")
-	st, err := Initialize(s.owner, TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), nil)
+	st, err := Initialize(s.owner, testing.NewMongoInfo(), testing.EnvironConfig(c), testing.NewDialOpts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 	s.AddCleanup(func(*gc.C) { s.State.Close() })

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -77,7 +77,7 @@ func (s *RelationUnitSuite) TestReadSettingsErrors(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestPeerSettings(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.owner)
+	pr := NewPeerRelation(c, s.State, s.Owner)
 	rus := RUs{pr.ru0, pr.ru1}
 
 	// Check missing settings cannot be read by any RU.
@@ -294,7 +294,7 @@ func (s *RelationUnitSuite) TestContainerCreateSubordinate(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.owner)
+	pr := NewPeerRelation(c, s.State, s.Owner)
 	rel := pr.ru0.Relation()
 
 	// Enter two units, and check that Destroying the service sets the
@@ -361,7 +361,7 @@ func (s *RelationUnitSuite) TestDestroyRelationWithUnitsInScope(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.owner)
+	pr := NewPeerRelation(c, s.State, s.Owner)
 	rel := pr.ru0.Relation()
 
 	// Two units enter...
@@ -412,7 +412,7 @@ func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {
 
 func (s *StateSuite) TestWatchWatchScopeDiesOnStateClose(c *gc.C) {
 	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
-		pr := NewPeerRelation(c, st, s.owner)
+		pr := NewPeerRelation(c, st, s.Owner)
 		w := pr.ru0.WatchScope()
 		<-w.Changes()
 		return w
@@ -420,7 +420,7 @@ func (s *StateSuite) TestWatchWatchScopeDiesOnStateClose(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestPeerWatchScope(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.owner)
+	pr := NewPeerRelation(c, s.State, s.Owner)
 
 	// Test empty initial event.
 	w0 := pr.ru0.WatchScope()
@@ -637,7 +637,7 @@ func (s *RelationUnitSuite) TestContainerWatchScope(c *gc.C) {
 }
 
 func (s *RelationUnitSuite) TestCoalesceWatchScope(c *gc.C) {
-	pr := NewPeerRelation(c, s.State, s.owner)
+	pr := NewPeerRelation(c, s.State, s.Owner)
 
 	// Test empty initial event.
 	w0 := pr.ru0.WatchScope()

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
 )
 
@@ -23,25 +22,6 @@ type SettingsSuite struct {
 }
 
 var _ = gc.Suite(&SettingsSuite{})
-
-// TestingMongoInfo returns information suitable for
-// connecting to the testing state server's mongo database.
-func TestingMongoInfo() *mongo.MongoInfo {
-	return &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
-		},
-	}
-}
-
-// TestingDialOpts returns configuration parameters for
-// connecting to the testing state server.
-func TestingDialOpts() mongo.DialOpts {
-	return mongo.DialOpts{
-		Timeout: testing.LongWait,
-	}
-}
 
 func (s *SettingsSuite) SetUpSuite(c *gc.C) {
 	s.MgoSuite.SetUpSuite(c)
@@ -59,7 +39,7 @@ func (s *SettingsSuite) SetUpTest(c *gc.C) {
 	// TODO(dfc) this logic is duplicated with the metawatcher_test.
 	cfg := testing.EnvironConfig(c)
 	owner := names.NewLocalUserTag("settings-admin")
-	state, err := Initialize(owner, TestingMongoInfo(), cfg, TestingDialOpts(), Policy(nil))
+	state, err := Initialize(owner, testing.NewMongoInfo(), cfg, testing.NewDialOpts(), Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { state.Close() })
 	s.state = state

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -5,50 +5,21 @@ package state
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/names"
-	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/txn"
-
-	"github.com/juju/juju/testing"
 )
 
 type SettingsSuite struct {
-	testing.BaseSuite
-	gitjujutesting.MgoSuite
-	state *State
-	key   string
+	internalStateSuite
+	key string
 }
 
 var _ = gc.Suite(&SettingsSuite{})
 
-func (s *SettingsSuite) SetUpSuite(c *gc.C) {
-	s.MgoSuite.SetUpSuite(c)
-	s.BaseSuite.SetUpSuite(c)
-}
-
-func (s *SettingsSuite) TearDownSuite(c *gc.C) {
-	s.BaseSuite.TearDownSuite(c)
-	s.MgoSuite.TearDownSuite(c)
-}
-
 func (s *SettingsSuite) SetUpTest(c *gc.C) {
-	s.MgoSuite.SetUpTest(c)
-	s.BaseSuite.SetUpTest(c)
-	// TODO(dfc) this logic is duplicated with the metawatcher_test.
-	cfg := testing.EnvironConfig(c)
-	owner := names.NewLocalUserTag("settings-admin")
-	state, err := Initialize(owner, testing.NewMongoInfo(), cfg, testing.NewDialOpts(), Policy(nil))
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { state.Close() })
-	s.state = state
+	s.internalStateSuite.SetUpTest(c)
 	s.key = "config"
-}
-
-func (s *SettingsSuite) TearDownTest(c *gc.C) {
-	s.BaseSuite.TearDownTest(c)
-	s.MgoSuite.TearDownTest(c)
 }
 
 func (s *SettingsSuite) TestCreateEmptySettings(c *gc.C) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -108,14 +108,14 @@ func (s *StateSuite) TestStrictLocalIDWithNoPrefix(c *gc.C) {
 func (s *StateSuite) TestDialAgain(c *gc.C) {
 	// Ensure idempotent operations on Dial are working fine.
 	for i := 0; i < 2; i++ {
-		st, err := state.Open(state.TestingMongoInfo(), state.TestingDialOpts(), state.Policy(nil))
+		st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st.Close(), gc.IsNil)
 	}
 }
 
 func (s *StateSuite) TestOpenSetsEnvironmentTag(c *gc.C) {
-	st, err := state.Open(state.TestingMongoInfo(), state.TestingDialOpts(), state.Policy(nil))
+	st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -2323,7 +2323,7 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 }
 
 func tryOpenState(info *mongo.MongoInfo) error {
-	st, err := state.Open(info, state.TestingDialOpts(), state.Policy(nil))
+	st, err := state.Open(info, testing.NewDialOpts(), state.Policy(nil))
 	if err == nil {
 		st.Close()
 	}
@@ -2331,7 +2331,7 @@ func tryOpenState(info *mongo.MongoInfo) error {
 }
 
 func (s *StateSuite) TestOpenWithoutSetMongoPassword(c *gc.C) {
-	info := state.TestingMongoInfo()
+	info := testing.NewMongoInfo()
 	info.Tag, info.Password = names.NewUserTag("arble"), "bar"
 	err := tryOpenState(info)
 	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
@@ -2346,7 +2346,7 @@ func (s *StateSuite) TestOpenWithoutSetMongoPassword(c *gc.C) {
 }
 
 func (s *StateSuite) TestOpenBadAddress(c *gc.C) {
-	info := state.TestingMongoInfo()
+	info := testing.NewMongoInfo()
 	info.Addrs = []string{"0.1.2.3:1234"}
 	st, err := state.Open(info, mongo.DialOpts{
 		Timeout: 1 * time.Millisecond,
@@ -2360,7 +2360,7 @@ func (s *StateSuite) TestOpenBadAddress(c *gc.C) {
 func (s *StateSuite) TestOpenDelaysRetryBadAddress(c *gc.C) {
 	// Default mgo retry delay
 	retryDelay := 500 * time.Millisecond
-	info := state.TestingMongoInfo()
+	info := testing.NewMongoInfo()
 	info.Addrs = []string{"0.1.2.3:1234"}
 
 	t0 := time.Now()
@@ -3078,7 +3078,7 @@ type waiter interface {
 // interact with the closed state, causing it to return an
 // unexpected error (often "Closed explictly").
 func testWatcherDiesWhenStateCloses(c *gc.C, startWatcher func(c *gc.C, st *state.State) waiter) {
-	st, err := state.Open(state.TestingMongoInfo(), state.TestingDialOpts(), state.Policy(nil))
+	st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	watcher := startWatcher(c, st)
 	err = st.Close()
@@ -3126,7 +3126,7 @@ func (s *StateSuite) TestReopenWithNoMachines(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, expected)
 
-	st, err := state.Open(state.TestingMongoInfo(), state.TestingDialOpts(), state.Policy(nil))
+	st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -3768,7 +3768,7 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 	}
 	cfg := testing.EnvironConfig(c)
 	owner := names.NewLocalUserTag("initialize-admin")
-	st, err := state.Initialize(owner, mongoInfo, cfg, state.TestingDialOpts(), nil)
+	st, err := state.Initialize(owner, mongoInfo, cfg, testing.NewDialOpts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -108,14 +108,14 @@ func (s *StateSuite) TestStrictLocalIDWithNoPrefix(c *gc.C) {
 func (s *StateSuite) TestDialAgain(c *gc.C) {
 	// Ensure idempotent operations on Dial are working fine.
 	for i := 0; i < 2; i++ {
-		st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
+		st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st.Close(), gc.IsNil)
 	}
 }
 
 func (s *StateSuite) TestOpenSetsEnvironmentTag(c *gc.C) {
-	st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -2323,7 +2323,7 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 }
 
 func tryOpenState(info *mongo.MongoInfo) error {
-	st, err := state.Open(info, testing.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(info, statetesting.NewDialOpts(), state.Policy(nil))
 	if err == nil {
 		st.Close()
 	}
@@ -2331,7 +2331,7 @@ func tryOpenState(info *mongo.MongoInfo) error {
 }
 
 func (s *StateSuite) TestOpenWithoutSetMongoPassword(c *gc.C) {
-	info := testing.NewMongoInfo()
+	info := statetesting.NewMongoInfo()
 	info.Tag, info.Password = names.NewUserTag("arble"), "bar"
 	err := tryOpenState(info)
 	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
@@ -2346,7 +2346,7 @@ func (s *StateSuite) TestOpenWithoutSetMongoPassword(c *gc.C) {
 }
 
 func (s *StateSuite) TestOpenBadAddress(c *gc.C) {
-	info := testing.NewMongoInfo()
+	info := statetesting.NewMongoInfo()
 	info.Addrs = []string{"0.1.2.3:1234"}
 	st, err := state.Open(info, mongo.DialOpts{
 		Timeout: 1 * time.Millisecond,
@@ -2360,7 +2360,7 @@ func (s *StateSuite) TestOpenBadAddress(c *gc.C) {
 func (s *StateSuite) TestOpenDelaysRetryBadAddress(c *gc.C) {
 	// Default mgo retry delay
 	retryDelay := 500 * time.Millisecond
-	info := testing.NewMongoInfo()
+	info := statetesting.NewMongoInfo()
 	info.Addrs = []string{"0.1.2.3:1234"}
 
 	t0 := time.Now()
@@ -3078,7 +3078,7 @@ type waiter interface {
 // interact with the closed state, causing it to return an
 // unexpected error (often "Closed explictly").
 func testWatcherDiesWhenStateCloses(c *gc.C, startWatcher func(c *gc.C, st *state.State) waiter) {
-	st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	watcher := startWatcher(c, st)
 	err = st.Close()
@@ -3126,7 +3126,7 @@ func (s *StateSuite) TestReopenWithNoMachines(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, expected)
 
-	st, err := state.Open(testing.NewMongoInfo(), testing.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -3760,6 +3760,7 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer inst.DestroyWithLog()
 
+	owner := names.NewLocalUserTag("initialize-admin")
 	mongoInfo := &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{inst.Addr()},
@@ -3767,8 +3768,7 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 		},
 	}
 	cfg := testing.EnvironConfig(c)
-	owner := names.NewLocalUserTag("initialize-admin")
-	st, err := state.Initialize(owner, mongoInfo, cfg, testing.NewDialOpts(), nil)
+	st, err := state.Initialize(owner, mongoInfo, cfg, statetesting.NewDialOpts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1272,19 +1272,19 @@ func (s *StateSuite) TestAllNetworks(c *gc.C) {
 
 func (s *StateSuite) TestAddService(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("haha/borken", s.owner.String(), charm, nil)
+	_, err := s.State.AddService("haha/borken", s.Owner.String(), charm, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "haha/borken": invalid name`)
 	_, err = s.State.Service("haha/borken")
 	c.Assert(err, gc.ErrorMatches, `"haha/borken" is not a valid service name`)
 
 	// set that a nil charm is handled correctly
-	_, err = s.State.AddService("umadbro", s.owner.String(), nil, nil)
+	_, err = s.State.AddService("umadbro", s.Owner.String(), nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "umadbro": charm is nil`)
 
-	wordpress, err := s.State.AddService("wordpress", s.owner.String(), charm, nil)
+	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), charm, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
-	mysql, err := s.State.AddService("mysql", s.owner.String(), charm, nil)
+	mysql, err := s.State.AddService("mysql", s.Owner.String(), charm, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 
@@ -1311,7 +1311,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddService("s1", s.owner.String(), charm, nil)
+	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1326,7 +1326,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDyingAfterInitial(c *gc.C) {
 		c.Assert(env.Life(), gc.Equals, state.Alive)
 		c.Assert(env.Destroy(), gc.IsNil)
 	}).Check()
-	_, err = s.State.AddService("s1", s.owner.String(), charm, nil)
+	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1361,13 +1361,13 @@ func (s *StateSuite) TestAllServices(c *gc.C) {
 	c.Assert(len(services), gc.Equals, 0)
 
 	// Check that after adding services the result is ok.
-	_, err = s.State.AddService("wordpress", s.owner.String(), charm, nil)
+	_, err = s.State.AddService("wordpress", s.Owner.String(), charm, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(services), gc.Equals, 1)
 
-	_, err = s.State.AddService("mysql", s.owner.String(), charm, nil)
+	_, err = s.State.AddService("mysql", s.Owner.String(), charm, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2885,7 +2885,7 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	// Add a service and 4 units: one with a different version, one
 	// with an empty version, one with the current version, and one
 	// with the new version.
-	service, err := s.State.AddService("wordpress", s.owner.String(), s.AddTestingCharm(c, "wordpress"), nil)
+	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	unit0, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2935,7 +2935,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C) (*config.Config, string) 
 	// Add a machine and a unit with the current version.
 	machine, err := s.State.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	service, err := s.State.AddService("wordpress", s.owner.String(), s.AddTestingCharm(c, "wordpress"), nil)
+	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	unit, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -51,18 +51,6 @@ func preventUnitDestroyRemove(c *gc.C, u *state.Unit) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-// TestingInitialize initializes the state and returns it. If state was not
-// already initialized, and cfg is nil, the minimal default environment
-// configuration will be used.
-func TestingInitialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.Policy) *state.State {
-	if cfg == nil {
-		cfg = testing.EnvironConfig(c)
-	}
-	st, err := state.Initialize(owner, state.TestingMongoInfo(), cfg, state.TestingDialOpts(), policy)
-	c.Assert(err, jc.ErrorIsNil)
-	return st
-}
-
 type StateSuite struct {
 	ConnSuite
 }

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -5,10 +5,12 @@ package testing
 
 import (
 	"github.com/juju/names"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -20,12 +22,31 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.P
 	if cfg == nil {
 		cfg = testing.EnvironConfig(c)
 	}
-	mgoInfo := testing.NewMongoInfo()
-	dialOpts := testing.NewDialOpts()
+	mgoInfo := NewMongoInfo()
+	dialOpts := NewDialOpts()
 
 	st, err := state.Initialize(owner, mgoInfo, cfg, dialOpts, policy)
 	c.Assert(err, jc.ErrorIsNil)
 	return st
+}
+
+// NewMongoInfo returns information suitable for
+// connecting to the testing state server's mongo database.
+func NewMongoInfo() *mongo.MongoInfo {
+	return &mongo.MongoInfo{
+		Info: mongo.Info{
+			Addrs:  []string{jujutesting.MgoServer.Addr()},
+			CACert: testing.CACert,
+		},
+	}
+}
+
+// NewDialOpts returns configuration parameters for
+// connecting to the testing state server.
+func NewDialOpts() mongo.DialOpts {
+	return mongo.DialOpts{
+		Timeout: testing.LongWait,
+	}
 }
 
 // NewState initializes a new state with default values for testing and

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -5,40 +5,13 @@ package testing
 
 import (
 	"github.com/juju/names"
-	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
-
-// TODO(ericsnow) The corresponding functions in state and state_test
-// (see state_test.go and settings_test.go) should be dropped and these
-// used instead.  Doing so is complicated by the fact that some of the
-// test files are in the state package rather than state_test, resulting
-// in import cycles when switching to these functions.
-
-// NewMongoInfo returns information suitable for
-// connecting to the testing state server's mongo database.
-func NewMongoInfo() *mongo.MongoInfo {
-	return &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: testing.CACert,
-		},
-	}
-}
-
-// NewDialOpts returns configuration parameters for
-// connecting to the testing state server.
-func NewDialOpts() mongo.DialOpts {
-	return mongo.DialOpts{
-		Timeout: testing.LongWait,
-	}
-}
 
 // Initialize initializes the state and returns it. If state was not
 // already initialized, and cfg is nil, the minimal default environment
@@ -47,8 +20,8 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.P
 	if cfg == nil {
 		cfg = testing.EnvironConfig(c)
 	}
-	mgoInfo := NewMongoInfo()
-	dialOpts := NewDialOpts()
+	mgoInfo := testing.NewMongoInfo()
+	dialOpts := testing.NewDialOpts()
 
 	st, err := state.Initialize(owner, mgoInfo, cfg, dialOpts, policy)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/names"
+	jujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&StateSuite{})
+
+// StateSuite provides setup and teardown for tests that require a
+// state.State.
+type StateSuite struct {
+	jujutesting.MgoSuite
+	testing.BaseSuite
+	Policy state.Policy
+	State  *state.State
+	Owner  names.UserTag
+}
+
+func (s *StateSuite) SetUpSuite(c *gc.C) {
+	s.MgoSuite.SetUpSuite(c)
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *StateSuite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+	s.MgoSuite.TearDownSuite(c)
+}
+
+func (s *StateSuite) SetUpTest(c *gc.C) {
+	s.MgoSuite.SetUpTest(c)
+	s.BaseSuite.SetUpTest(c)
+
+	s.Owner = names.NewLocalUserTag("test-admin")
+	s.State = Initialize(c, s.Owner, nil, s.Policy)
+	s.AddCleanup(func(*gc.C) { s.State.Close() })
+}
+
+func (s *StateSuite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
+	s.MgoSuite.TearDownTest(c)
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
@@ -20,46 +19,10 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testcharms"
-	"github.com/juju/juju/testing"
 )
 
 type upgradesSuite struct {
-	gitjujutesting.CleanupSuite
-	testing.BaseSuite
-	gitjujutesting.MgoSuite
-	state *State
-	owner names.UserTag
-}
-
-func (s *upgradesSuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
-	s.MgoSuite.SetUpSuite(c)
-	s.CleanupSuite.SetUpSuite(c)
-}
-
-func (s *upgradesSuite) TearDownSuite(c *gc.C) {
-	s.CleanupSuite.TearDownSuite(c)
-	s.MgoSuite.TearDownSuite(c)
-	s.BaseSuite.TearDownSuite(c)
-}
-
-func (s *upgradesSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-	s.MgoSuite.SetUpTest(c)
-	s.CleanupSuite.SetUpTest(c)
-	var err error
-	s.owner = names.NewLocalUserTag("upgrade-admin")
-	s.state, err = Initialize(s.owner, testing.NewMongoInfo(), testing.EnvironConfig(c), testing.NewDialOpts(), Policy(nil))
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *upgradesSuite) TearDownTest(c *gc.C) {
-	if s.state != nil {
-		s.state.Close()
-	}
-	s.CleanupSuite.TearDownTest(c)
-	s.MgoSuite.TearDownTest(c)
-	s.BaseSuite.TearDownTest(c)
+	internalStateSuite
 }
 
 var _ = gc.Suite(&upgradesSuite{})

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -49,7 +49,7 @@ func (s *upgradesSuite) SetUpTest(c *gc.C) {
 	s.CleanupSuite.SetUpTest(c)
 	var err error
 	s.owner = names.NewLocalUserTag("upgrade-admin")
-	s.state, err = Initialize(s.owner, TestingMongoInfo(), testing.EnvironConfig(c), TestingDialOpts(), Policy(nil))
+	s.state, err = Initialize(s.owner, testing.NewMongoInfo(), testing.EnvironConfig(c), testing.NewDialOpts(), Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -194,7 +194,7 @@ func (s *UserSuite) TestPasswordValidUpdatesSalt(c *gc.C) {
 }
 
 func (s *UserSuite) TestCantDisableAdmin(c *gc.C) {
-	user, err := s.State.User(s.owner)
+	user, err := s.State.User(s.Owner)
 	c.Assert(err, jc.ErrorIsNil)
 	err = user.Disable()
 	c.Assert(err, gc.ErrorMatches, "cannot disable state server environment owner")

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -9,14 +9,12 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
@@ -24,52 +22,16 @@ import (
 )
 
 type factorySuite struct {
-	testing.BaseSuite
-	jtesting.MgoSuite
-	State   *state.State
+	statetesting.StateSuite
 	Factory *factory.Factory
 }
 
 var _ = gc.Suite(&factorySuite{})
 
-func (s *factorySuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
-	s.MgoSuite.SetUpSuite(c)
-}
-
-func (s *factorySuite) TearDownSuite(c *gc.C) {
-	s.MgoSuite.TearDownSuite(c)
-	s.BaseSuite.TearDownSuite(c)
-}
-
 func (s *factorySuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-	s.MgoSuite.SetUpTest(c)
-	policy := statetesting.MockPolicy{}
-
-	info := &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{jtesting.MgoServer.Addr()},
-			CACert: testing.CACert,
-		},
-	}
-	opts := mongo.DialOpts{
-		Timeout: testing.LongWait,
-	}
-	cfg := testing.EnvironConfig(c)
-	owner := names.NewLocalUserTag("factory-admin")
-	st, err := state.Initialize(owner, info, cfg, opts, &policy)
-	c.Assert(err, jc.ErrorIsNil)
-	s.State = st
+	s.Policy = new(statetesting.MockPolicy)
+	s.StateSuite.SetUpTest(c)
 	s.Factory = factory.NewFactory(s.State)
-}
-
-func (s *factorySuite) TearDownTest(c *gc.C) {
-	if s.State != nil {
-		s.State.Close()
-	}
-	s.MgoSuite.TearDownTest(c)
-	s.BaseSuite.TearDownTest(c)
 }
 
 func (s *factorySuite) TestMakeUserNil(c *gc.C) {

--- a/testing/mgo.go
+++ b/testing/mgo.go
@@ -6,6 +6,7 @@ package testing
 import (
 	"testing"
 
+	"github.com/juju/juju/mongo"
 	gitjujutesting "github.com/juju/testing"
 )
 
@@ -13,4 +14,23 @@ import (
 // that requires a secure connection to a MongoDB server.
 func MgoTestPackage(t *testing.T) {
 	gitjujutesting.MgoTestPackage(t, Certs)
+}
+
+// NewMongoInfo returns information suitable for
+// connecting to the testing state server's mongo database.
+func NewMongoInfo() *mongo.MongoInfo {
+	return &mongo.MongoInfo{
+		Info: mongo.Info{
+			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
+			CACert: CACert,
+		},
+	}
+}
+
+// NewDialOpts returns configuration parameters for
+// connecting to the testing state server.
+func NewDialOpts() mongo.DialOpts {
+	return mongo.DialOpts{
+		Timeout: LongWait,
+	}
 }

--- a/testing/mgo.go
+++ b/testing/mgo.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"testing"
 
-	"github.com/juju/juju/mongo"
 	gitjujutesting "github.com/juju/testing"
 )
 
@@ -14,23 +13,4 @@ import (
 // that requires a secure connection to a MongoDB server.
 func MgoTestPackage(t *testing.T) {
 	gitjujutesting.MgoTestPackage(t, Certs)
-}
-
-// NewMongoInfo returns information suitable for
-// connecting to the testing state server's mongo database.
-func NewMongoInfo() *mongo.MongoInfo {
-	return &mongo.MongoInfo{
-		Info: mongo.Info{
-			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
-			CACert: CACert,
-		},
-	}
-}
-
-// NewDialOpts returns configuration parameters for
-// connecting to the testing state server.
-func NewDialOpts() mongo.DialOpts {
-	return mongo.DialOpts{
-		Timeout: LongWait,
-	}
 }


### PR DESCRIPTION
These changes all eliminate a significant amount of duplication that existed around mongo initialisation for tests in the state package. They also introduce a new suite at state.testing.StateSuite which can be used by tests requiring a state.State.



(Review request: http://reviews.vapour.ws/r/759/)