### PR TITLE
add relation.Peeker

### DIFF
--- a/worker/uniter/relation/peeker.go
+++ b/worker/uniter/relation/peeker.go
@@ -1,0 +1,122 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package relation
+
+import (
+	"github.com/juju/errors"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/worker/uniter/hook"
+)
+
+// Peeker maintains a HookSource, and allows an external client to inspect
+// and consume, or reject, the head of the queue.
+type Peeker interface {
+	// Peeks returns a channel on which Peeks are delivered. The receiver of a
+	// Peek must Consume or Reject the Peek before further peeks will be sent.
+	Peeks() <-chan Peek
+	// Stop stops the Peeker's HookSource, and prevents any further Peeks from
+	// being delivered.
+	Stop() error
+}
+
+// Peek exists to support Peeker and has no independent meaning or existence.
+// Receiving a Peek from a Peeker's Peek channel implies acceptance of the
+// responsibility to either Consume or Reject the Peek.
+type Peek interface {
+	// HookInfo returns information about the hook at the head of the queue.
+	HookInfo() hook.Info
+	// Consume pops the hook from the head of the queue and makes new Peeks
+	// available.
+	Consume()
+	// Reject makes new Peeks available.
+	Reject()
+}
+
+// NewPeeker returns a new Peeker providing a view of the supplied source
+// (of which it takes ownership).
+func NewPeeker(source HookSource) Peeker {
+	p := &peeker{
+		peeks: make(chan Peek),
+	}
+	go func() {
+		defer p.tomb.Done()
+		defer close(p.peeks)
+		defer watcher.Stop(source, &p.tomb)
+		p.tomb.Kill(p.loop(source))
+	}()
+	return p
+}
+
+// peeker implements Peeker.
+type peeker struct {
+	tomb  tomb.Tomb
+	peeks chan Peek
+}
+
+// Peeks is part of the Peeker interface.
+func (p *peeker) Peeks() <-chan Peek {
+	return p.peeks
+}
+
+// Stop is part of the Peeker interface.
+func (p *peeker) Stop() error {
+	p.tomb.Kill(nil)
+	return p.tomb.Wait()
+}
+
+// loop delivers events from the source's Changes channel to its Update method,
+// continually, unless a Peek is active.
+func (p *peeker) loop(source HookSource) error {
+	for {
+		var next *peek
+		var peeks chan Peek
+		if !source.Empty() {
+			peeks = p.peeks
+			next = &peek{
+				source: source,
+				done:   make(chan struct{}),
+			}
+		}
+		select {
+		case <-p.tomb.Dying():
+			return tomb.ErrDying
+		case peeks <- next:
+			select {
+			case <-p.tomb.Dying():
+			case <-next.done:
+			}
+		case change, ok := <-source.Changes():
+			if !ok {
+				return errors.New("hook source stopped providing updates")
+			}
+			if err := source.Update(change); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}
+
+// peek implements Peek.
+type peek struct {
+	source HookSource
+	done   chan struct{}
+}
+
+// HookInfo is part of the Peek interface.
+func (p *peek) HookInfo() hook.Info {
+	return p.source.Next()
+}
+
+// Consume is part of the Peek interface.
+func (p *peek) Consume() {
+	p.source.Pop()
+	close(p.done)
+}
+
+// Reject is part of the Peek interface.
+func (p *peek) Reject() {
+	close(p.done)
+}

--- a/worker/uniter/relation/peeker_test.go
+++ b/worker/uniter/relation/peeker_test.go
@@ -1,0 +1,412 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package relation_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/state/multiwatcher"
+	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/relation"
+)
+
+type PeekerSuite struct {
+}
+
+var _ = gc.Suite(&PeekerSuite{})
+
+func (s *PeekerSuite) TestPeeks(c *gc.C) {
+	expect := hookList(hooks.Install, hooks.ConfigChanged, hooks.Start)
+	source := relation.NewListSource(expect)
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	timeout := time.After(coretesting.LongWait)
+	for _, expectInfo := range expect {
+		select {
+		case peek, ok := <-peeker.Peeks():
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(peek.HookInfo(), gc.Equals, expectInfo)
+			peek.Reject()
+		case <-timeout:
+			c.Fatalf("ran out of time")
+		}
+		select {
+		case peek, ok := <-peeker.Peeks():
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(peek.HookInfo(), gc.Equals, expectInfo)
+			peek.Consume()
+		case <-timeout:
+			c.Fatalf("ran out of time")
+		}
+	}
+	select {
+	case <-time.After(coretesting.ShortWait):
+	case peek, ok := <-peeker.Peeks():
+		c.Fatalf("unexpected peek from empty queue: %#v, %#v", peek, ok)
+	}
+}
+
+func (s *PeekerSuite) TestStopWhileRunning(c *gc.C) {
+	source := newFullUnbufferedSource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Grab and reject a peek to check we're running.
+	select {
+	case peek, ok := <-peeker.Peeks():
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(peek.HookInfo(), gc.Equals, hook.Info{Kind: hooks.Install})
+		peek.Reject()
+		assertStopPeeker(c, peeker, source)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out")
+	}
+}
+
+func (s *PeekerSuite) TestStopWhilePeeking(c *gc.C) {
+	source := newFullUnbufferedSource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	select {
+	case peek, ok := <-peeker.Peeks():
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(peek.HookInfo(), gc.Equals, hook.Info{Kind: hooks.Install})
+		assertStopPeeker(c, peeker, source)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out")
+	}
+}
+
+func (s *PeekerSuite) TestStopWhileUpdating(c *gc.C) {
+	source := newFullBufferedSource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Deliver a change; do not accept updates.
+	select {
+	case source.changes <- multiwatcher.RelationUnitsChange{}:
+		assertStopPeeker(c, peeker, source)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out")
+	}
+}
+
+func (s *PeekerSuite) TestUpdatesFullQueue(c *gc.C) {
+	source := newFullUnbufferedSource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Check we're being sent peeks but not updates.
+	timeout := time.After(coretesting.LongWait)
+	assertActive := func() {
+		select {
+		case peek, ok := <-peeker.Peeks():
+			c.Assert(ok, jc.IsTrue)
+			defer peek.Reject()
+			c.Assert(peek.HookInfo(), gc.Equals, hook.Info{Kind: hooks.Install})
+		case update, ok := <-source.updates:
+			c.Fatalf("got unexpected update: %#v %#v", update, ok)
+		case <-timeout:
+			c.Fatalf("timed out")
+		}
+	}
+	assertActive()
+
+	// Send an event on the Changes() chan.
+	sent := multiwatcher.RelationUnitsChange{Departed: []string{"sent"}}
+	select {
+	case source.changes <- sent:
+	case <-timeout:
+		c.Fatalf("could not send change")
+	}
+
+	// Now that a change has been delivered, nothing should be sent on the out
+	// chan, or read from the changes chan, until the Update method has completed.
+	notSent := multiwatcher.RelationUnitsChange{Departed: []string{"notSent"}}
+	select {
+	case source.changes <- notSent:
+		c.Fatalf("sent extra change while updating queue")
+	case peek, ok := <-peeker.Peeks():
+		c.Fatalf("got unexpected peek while updating queue: %#v %#v", peek, ok)
+	case got, ok := <-source.updates:
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(got, gc.DeepEquals, sent)
+	case <-timeout:
+		c.Fatalf("timed out")
+	}
+
+	// Check we're still being sent hooks and not updates.
+	assertActive()
+}
+
+func (s *PeekerSuite) TestUpdatesFullQueueSpam(c *gc.C) {
+	source := newFullUnbufferedSource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Spam all channels continuously for a bit.
+	timeout := time.After(coretesting.LongWait)
+	peekCount := 0
+	changeCount := 0
+	updateCount := 0
+	for i := 0; i < 100; i++ {
+		select {
+		case peek, ok := <-peeker.Peeks():
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(peek.HookInfo(), gc.DeepEquals, hook.Info{Kind: hooks.Install})
+			peek.Consume()
+			peekCount++
+		case source.changes <- multiwatcher.RelationUnitsChange{}:
+			changeCount++
+		case update, ok := <-source.updates:
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(update, gc.DeepEquals, multiwatcher.RelationUnitsChange{})
+			updateCount++
+		case <-timeout:
+			c.Fatalf("not enough things happened in time")
+		}
+	}
+
+	// Once we've finished sending, exhaust the updates...
+	for i := updateCount; i < changeCount && updateCount < changeCount; i++ {
+		select {
+		case update, ok := <-source.updates:
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(update, gc.DeepEquals, multiwatcher.RelationUnitsChange{})
+			updateCount++
+		case <-timeout:
+			c.Fatalf("expected %d updates, got %d", changeCount, updateCount)
+		}
+	}
+
+	// ...and check sane end state to validate the foregoing.
+	c.Check(peekCount, gc.Not(gc.Equals), 0)
+	c.Check(changeCount, gc.Not(gc.Equals), 0)
+}
+
+func (s *PeekerSuite) TestUpdatesEmptyQueue(c *gc.C) {
+	source := newEmptySource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Check no hooks are sent and no updates delivered.
+	assertIdle := func() {
+		select {
+		case peek, ok := <-peeker.Peeks():
+			c.Fatalf("got unexpected peek: %#v %#v", peek, ok)
+		case update, ok := <-source.updates:
+			c.Fatalf("got unexpected update: %#v %#v", update, ok)
+		case <-time.After(coretesting.ShortWait):
+		}
+	}
+	assertIdle()
+
+	// Send an event on the Changes() chan.
+	sent := multiwatcher.RelationUnitsChange{Departed: []string{"sent"}}
+	timeout := time.After(coretesting.LongWait)
+	select {
+	case source.changes <- sent:
+	case <-timeout:
+		c.Fatalf("timed out")
+	}
+
+	// Now that a change has been delivered, nothing should be sent on the out
+	// chan, or read from the changes chan, until the Update method has completed.
+	notSent := multiwatcher.RelationUnitsChange{Departed: []string{"notSent"}}
+	select {
+	case source.changes <- notSent:
+		c.Fatalf("sent extra change while updating queue")
+	case peek, ok := <-peeker.Peeks():
+		c.Fatalf("got unexpected peek while updating queue: %#v %#v", peek, ok)
+	case got, ok := <-source.updates:
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(got, gc.DeepEquals, sent)
+	case <-timeout:
+		c.Fatalf("timed out")
+	}
+
+	// Now the change has been delivered, nothing should be happening.
+	assertIdle()
+}
+
+func (s *PeekerSuite) TestUpdatesEmptyQueueSpam(c *gc.C) {
+	source := newEmptySource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Spam all channels continuously for a bit.
+	timeout := time.After(coretesting.LongWait)
+	changeCount := 0
+	updateCount := 0
+	for i := 0; i < 100; i++ {
+		select {
+		case peek, ok := <-peeker.Peeks():
+			c.Fatalf("got unexpected peek: %#v %#v", peek, ok)
+		case source.changes <- multiwatcher.RelationUnitsChange{}:
+			changeCount++
+		case update, ok := <-source.updates:
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(update, gc.DeepEquals, multiwatcher.RelationUnitsChange{})
+			updateCount++
+		case <-timeout:
+			c.Fatalf("not enough things happened in time")
+		}
+	}
+
+	// Check sane end state.
+	c.Check(changeCount, gc.Equals, 50)
+	c.Check(updateCount, gc.Equals, 50)
+}
+func (s *PeekerSuite) TestPeeksBlockUntilRejected(c *gc.C) {
+	source := newFullBufferedSource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Collect a peek...
+	timeout := time.After(coretesting.LongWait)
+	select {
+	case <-timeout:
+		c.Fatalf("failed to receive peek")
+	case peek, ok := <-peeker.Peeks():
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(peek.HookInfo(), gc.Equals, hook.Info{Kind: hooks.Install})
+
+		// ...and check that changes can't be delivered...
+		select {
+		case source.changes <- multiwatcher.RelationUnitsChange{}:
+			c.Fatalf("delivered change while supposedly peeking")
+		default:
+		}
+
+		// ...before the peek is rejected, at which point changes are unblocked.
+		peek.Reject()
+		select {
+		case source.changes <- multiwatcher.RelationUnitsChange{}:
+		case <-timeout:
+			c.Fatalf("failed to unblock changes")
+		}
+	}
+}
+
+func (s *PeekerSuite) TestPeeksBlockUntilConsumed(c *gc.C) {
+	source := newFullBufferedSource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Collect a peek...
+	timeout := time.After(coretesting.LongWait)
+	select {
+	case <-timeout:
+		c.Fatalf("failed to receive peek")
+	case peek, ok := <-peeker.Peeks():
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(peek.HookInfo(), gc.Equals, hook.Info{Kind: hooks.Install})
+
+		// ...and check that changes can't be delivered...
+		select {
+		case source.changes <- multiwatcher.RelationUnitsChange{}:
+			c.Fatalf("delivered change while supposedly peeking")
+		default:
+		}
+
+		// ...before the peek is consumed, at which point changes are unblocked.
+		peek.Consume()
+		select {
+		case source.changes <- multiwatcher.RelationUnitsChange{}:
+		case <-timeout:
+			c.Fatalf("failed to unblock changes")
+		}
+	}
+}
+
+func (s *PeekerSuite) TestBlocksWhenUpdating(c *gc.C) {
+	source := newFullUnbufferedSource()
+	defer statetesting.AssertStop(c, source)
+
+	peeker := relation.NewPeeker(source)
+	defer statetesting.AssertStop(c, peeker)
+
+	// Deliver a change.
+	timeout := time.After(coretesting.LongWait)
+	select {
+	case source.changes <- multiwatcher.RelationUnitsChange{}:
+	case <-timeout:
+		c.Fatalf("failed to send change")
+	}
+
+	// Check peeks are not delivered...
+	select {
+	case peek, ok := <-peeker.Peeks():
+		c.Fatalf("got unexpected peek: %#v, %#v", peek, ok)
+	default:
+	}
+
+	// ...before the update is handled...
+	select {
+	case update, ok := <-source.updates:
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(update, gc.DeepEquals, multiwatcher.RelationUnitsChange{})
+	case <-timeout:
+		c.Fatalf("failed to collect update")
+	}
+
+	// ...at which point peeks are expected again.
+	select {
+	case peek, ok := <-peeker.Peeks():
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(peek.HookInfo(), gc.Equals, hook.Info{Kind: hooks.Install})
+		peek.Reject()
+	case <-timeout:
+		c.Fatalf("failed to send peek")
+	}
+}
+
+func assertStopPeeker(c *gc.C, peeker relation.Peeker, source *updateSource) {
+	// Stop the peeker...
+	err := peeker.Stop()
+	c.Assert(err, gc.IsNil)
+
+	// ...and check it closed the channel...
+	select {
+	case peek, ok := <-peeker.Peeks():
+		c.Assert(peek, gc.IsNil)
+		c.Assert(ok, jc.IsFalse)
+	default:
+		c.Fatalf("peeks channel not closed")
+	}
+
+	// ...and stopped the source.
+	select {
+	case <-source.tomb.Dead():
+		c.Assert(source.tomb.Err(), jc.ErrorIsNil)
+	default:
+		c.Fatalf("source not stopped")
+	}
+}

--- a/worker/uniter/relation/util_test.go
+++ b/worker/uniter/relation/util_test.go
@@ -1,0 +1,92 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package relation_test
+
+import (
+	"gopkg.in/juju/charm.v4/hooks"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/worker/uniter/hook"
+)
+
+func hookList(kinds ...hooks.Kind) []hook.Info {
+	result := make([]hook.Info, len(kinds))
+	for i, kind := range kinds {
+		result[i].Kind = kind
+	}
+	return result
+}
+
+type updateSource struct {
+	tomb    tomb.Tomb
+	empty   bool
+	changes chan multiwatcher.RelationUnitsChange
+	updates chan multiwatcher.RelationUnitsChange
+}
+
+func newEmptySource() *updateSource {
+	return newUpdateSource(true, false)
+}
+
+func newFullBufferedSource() *updateSource {
+	return newUpdateSource(false, true)
+}
+
+func newFullUnbufferedSource() *updateSource {
+	return newUpdateSource(false, false)
+}
+
+func newUpdateSource(empty, buffered bool) *updateSource {
+	var bufferSize int
+	if buffered {
+		bufferSize = 1000
+	}
+	source := &updateSource{
+		empty:   empty,
+		changes: make(chan multiwatcher.RelationUnitsChange),
+		updates: make(chan multiwatcher.RelationUnitsChange, bufferSize),
+	}
+	go func() {
+		defer source.tomb.Done()
+		defer close(source.changes)
+		<-source.tomb.Dying()
+	}()
+	return source
+}
+
+func (source *updateSource) Stop() error {
+	source.tomb.Kill(nil)
+	return source.tomb.Wait()
+}
+
+func (source *updateSource) Changes() <-chan multiwatcher.RelationUnitsChange {
+	return source.changes
+}
+
+func (source *updateSource) Update(change multiwatcher.RelationUnitsChange) error {
+	select {
+	case <-source.tomb.Dying():
+		return tomb.ErrDying
+	case source.updates <- change:
+	}
+	return nil
+}
+
+func (source *updateSource) Empty() bool {
+	return source.empty
+}
+
+func (source *updateSource) Next() hook.Info {
+	if source.empty {
+		panic(nil)
+	}
+	return hook.Info{Kind: hooks.Install}
+}
+
+func (source *updateSource) Pop() {
+	if source.empty {
+		panic(nil)
+	}
+}


### PR DESCRIPTION
relation.Peeker is an alternative means of driving a relation.HookSource. It will be used to allow a full-unit hook queue implementation to selectively pause and inspect the hook queues for a given relation. Also found a race in some of the HookSender tests, fixed those, moved common test code into util_test.go.

(Review request: http://reviews.vapour.ws/r/761/)