### PR TITLE
Update juju/names in dependencies.tsv

### DIFF
--- a/api/firewaller/unit.go
+++ b/api/firewaller/unit.go
@@ -44,15 +44,18 @@ func (u *Unit) Refresh() error {
 
 // Service returns the service.
 func (u *Unit) Service() (*Service, error) {
-	serviceTag := names.NewServiceTag(names.UnitService(u.Name()))
+	serviceName, err := names.UnitService(u.Name())
+	if err != nil {
+		return nil, err
+	}
+	serviceTag := names.NewServiceTag(serviceName)
 	service := &Service{
 		st:  u.st,
 		tag: serviceTag,
 	}
 	// Call Refresh() immediately to get the up-to-date
 	// life and other needed locally cached fields.
-	err := service.Refresh()
-	if err != nil {
+	if err := service.Refresh(); err != nil {
 		return nil, err
 	}
 	return service, nil

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -142,7 +142,11 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 
 // ServiceName returns the service name.
 func (u *Unit) ServiceName() string {
-	return names.UnitService(u.Name())
+	service, err := names.UnitService(u.Name())
+	if err != nil {
+		panic(err)
+	}
+	return service
 }
 
 // ServiceTag returns the service tag.

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -1473,7 +1473,10 @@ func (u *uniterBaseAPI) checkRemoteUnit(relUnit *state.RelationUnit, remoteUnitT
 		return "", common.ErrPerm
 	}
 	remoteUnitName := tag.Id()
-	remoteServiceName := names.UnitService(remoteUnitName)
+	remoteServiceName, err := names.UnitService(remoteUnitName)
+	if err != nil {
+		return "", common.ErrPerm
+	}
 	rel := relUnit.Relation()
 	_, err = rel.RelatedEndpoints(remoteServiceName)
 	if err != nil {

--- a/cmd/juju/debughooks.go
+++ b/cmd/juju/debughooks.go
@@ -58,7 +58,10 @@ func (c *DebugHooksCommand) validateHooks() error {
 	if len(c.hooks) == 0 {
 		return nil
 	}
-	service := names.UnitService(c.Target)
+	service, err := names.UnitService(c.Target)
+	if err != nil {
+		return err
+	}
 	relations, err := c.apiClient.ServiceCharmRelations(service)
 	if err != nil {
 		return err

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,7 +15,7 @@ github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	2014-
 github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	2014-07-18T03:57:39Z
 github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	2014-07-17T16:12:25Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
-github.com/juju/names	git	e7394f4ce9389fb57cfb7cbe9fa30790d01a8875	2014-12-17T04:05:00Z
+github.com/juju/names	git	f2761fa05db34fb5b4ceb44721a067ffd22d5956	2015-01-20T11:23:30Z
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
 github.com/juju/syslog	git	2b69d6582feb16ff8b6d644495e16c2d8314fcb8	2014-08-06T00:00:34Z


### PR DESCRIPTION
The signature of names.UnitStorage has changed to return an error,
whereas previously it would panic. I have updated juju/juju to
the new signature; in one case I have added a panic call, but in
reality it is impossible for it to occur (hence a panic).

(Review request: http://reviews.vapour.ws/r/766/)