### PR TITLE
Fix LP-1412292

### DIFF
--- a/state/action_test.go
+++ b/state/action_test.go
@@ -409,7 +409,7 @@ func (s *ActionSuite) TestActionsWatcherEmitsInitialChanges(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// per contract, there should be at minimum an initial empty Change() result
-	wc.AssertChange()
+	wc.AssertChangeMaybeIncluding(expectActionIds(a1, a2)...)
 	wc.AssertNoChange()
 }
 

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -4,10 +4,10 @@
 package testing
 
 import (
-	"sort"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
@@ -158,16 +158,9 @@ func (c StringsWatcherC) AssertChangeMaybeIncluding(expect ...string) {
 		c.Assert(actual, gc.HasLen, 0)
 	} else {
 		actualCount := len(actual)
-		c.Assert(actualCount <= maxCount, jc.IsTrue)
-		for _, a := range actual {
-			expected := false
-			for _, e := range expect {
-				if a == e {
-					expected = true
-				}
-			}
-			c.Assert(expected, jc.IsTrue)
-		}
+		c.Assert(actualCount <= maxCount, jc.IsTrue, gc.Commentf("expected at most %d, got %d", maxCount, actualCount))
+		unexpected := set.NewStrings(actual...).Difference(set.NewStrings(expect...))
+		c.Assert(unexpected.Values(), gc.HasLen, 0)
 	}
 }
 
@@ -178,9 +171,7 @@ func (c StringsWatcherC) assertChange(single bool, expect ...string) {
 	if len(expect) == 0 {
 		c.Assert(actual, gc.HasLen, 0)
 	} else {
-		sort.Strings(expect)
-		sort.Strings(actual)
-		c.Assert(actual, gc.DeepEquals, expect)
+		c.Assert(actual, jc.SameContents, expect)
 	}
 }
 

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2012-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package testing


### PR DESCRIPTION
 Due to asynchronous timing issues, the
 `ActionSuite.TestActionsWatcherEmitsInitialChanges` test would
 occasionally fail because the watcher hadn't completed removing the
 id's of the removed actions.

 This change introduces a new `AssertChangeMaybeIncluding` test that
 allows for the possibility that a change might still include the id's
 of an action that was removed, but the watcher hadn't caught up yet.

(Review request: http://reviews.vapour.ws/r/769/)