### PR TITLE
Make the rest of the apiserver handle multiple environments.

### DIFF
--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -331,7 +331,7 @@ func (s *debugLogSuite) openWebsocket(c *gc.C, values url.Values) *bufio.Reader 
 func (s *debugLogSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Reader {
 	server := s.logURL(c, "wss", nil)
 	server.Path = path
-	header := utils.BasicAuthHeader(s.userTag, s.password)
+	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
 	conn, err := s.dialWebsocketFromURL(c, server.String(), header)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
@@ -378,7 +378,7 @@ func (s *debugLogSuite) dialWebsocketFromURL(c *gc.C, server string, header http
 }
 
 func (s *debugLogSuite) dialWebsocket(c *gc.C, queryParams url.Values) (*websocket.Conn, error) {
-	header := utils.BasicAuthHeader(s.userTag, s.password)
+	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
 	return s.dialWebsocketInternal(c, queryParams, header)
 }
 

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
 	envtools "github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/toolstorage"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -44,14 +45,16 @@ type toolsDownloadHandler struct {
 }
 
 func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if err := h.validateEnvironUUID(r); err != nil {
+	stateWrapper, err := h.validateEnvironUUID(r)
+	if err != nil {
 		h.sendError(w, http.StatusNotFound, err.Error())
 		return
 	}
+	defer stateWrapper.cleanup()
 
 	switch r.Method {
 	case "GET":
-		tarball, err := h.processGet(r)
+		tarball, err := h.processGet(r, stateWrapper.state)
 		if err != nil {
 			logger.Errorf("GET(%s) failed: %v", r.URL, err)
 			h.sendError(w, http.StatusBadRequest, err.Error())
@@ -64,20 +67,24 @@ func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if err := h.authenticate(r); err != nil {
-		h.authError(w, h)
+	// Validate before authenticate because the authentication is dependent
+	// on the state connection that is determined during the validation.
+	stateWrapper, err := h.validateEnvironUUID(r)
+	if err != nil {
+		h.sendError(w, http.StatusNotFound, err.Error())
 		return
 	}
+	defer stateWrapper.cleanup()
 
-	if err := h.validateEnvironUUID(r); err != nil {
-		h.sendError(w, http.StatusNotFound, err.Error())
+	if err := stateWrapper.authenticate(r); err != nil {
+		h.authError(w, h)
 		return
 	}
 
 	switch r.Method {
 	case "POST":
 		// Add tools to storage.
-		agentTools, err := h.processPost(r)
+		agentTools, err := h.processPost(r, stateWrapper.state)
 		if err != nil {
 			h.sendError(w, http.StatusBadRequest, err.Error())
 			return
@@ -110,12 +117,12 @@ func (h *toolsHandler) sendError(w http.ResponseWriter, statusCode int, message 
 }
 
 // processGet handles a tools GET request.
-func (h *toolsDownloadHandler) processGet(r *http.Request) ([]byte, error) {
+func (h *toolsDownloadHandler) processGet(r *http.Request, st *state.State) ([]byte, error) {
 	version, err := version.ParseBinary(r.URL.Query().Get(":version"))
 	if err != nil {
 		return nil, errors.Annotate(err, "error parsing version")
 	}
-	storage, err := h.state.ToolsStorage()
+	storage, err := st.ToolsStorage()
 	if err != nil {
 		return nil, errors.Annotate(err, "error getting tools storage")
 	}
@@ -126,7 +133,7 @@ func (h *toolsDownloadHandler) processGet(r *http.Request) ([]byte, error) {
 		// so look for them in simplestreams, fetch
 		// them and cache in toolstorage.
 		logger.Infof("%v tools not found locally, fetching", version)
-		reader, err = h.fetchAndCacheTools(version, storage)
+		reader, err = h.fetchAndCacheTools(version, storage, st)
 		if err != nil {
 			err = errors.Annotate(err, "error fetching tools")
 		}
@@ -145,8 +152,8 @@ func (h *toolsDownloadHandler) processGet(r *http.Request) ([]byte, error) {
 // fetchAndCacheTools fetches tools with the specified version by searching for a URL
 // in simplestreams and GETting it, caching the result in toolstorage before returning
 // to the caller.
-func (h *toolsDownloadHandler) fetchAndCacheTools(v version.Binary, stor toolstorage.Storage) (io.ReadCloser, error) {
-	envcfg, err := h.state.EnvironConfig()
+func (h *toolsDownloadHandler) fetchAndCacheTools(v version.Binary, stor toolstorage.Storage, st *state.State) (io.ReadCloser, error) {
+	envcfg, err := st.EnvironConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +215,7 @@ func (h *toolsDownloadHandler) sendTools(w http.ResponseWriter, statusCode int, 
 }
 
 // processPost handles a tools upload POST request after authentication.
-func (h *toolsUploadHandler) processPost(r *http.Request) (*tools.Tools, error) {
+func (h *toolsUploadHandler) processPost(r *http.Request, st *state.State) (*tools.Tools, error) {
 	query := r.URL.Query()
 
 	binaryVersionParam := query.Get("binaryVersion")
@@ -227,7 +234,7 @@ func (h *toolsUploadHandler) processPost(r *http.Request) (*tools.Tools, error) 
 	}
 
 	// Get the server root, so we know how to form the URL in the Tools returned.
-	serverRoot, err := h.getServerRoot(r, query)
+	serverRoot, err := h.getServerRoot(r, query, st)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot to determine server root")
 	}
@@ -245,13 +252,13 @@ func (h *toolsUploadHandler) processPost(r *http.Request) (*tools.Tools, error) 
 			toolsVersions = append(toolsVersions, v)
 		}
 	}
-	return h.handleUpload(r.Body, toolsVersions, serverRoot)
+	return h.handleUpload(r.Body, toolsVersions, serverRoot, st)
 }
 
-func (h *toolsUploadHandler) getServerRoot(r *http.Request, query url.Values) (string, error) {
+func (h *toolsUploadHandler) getServerRoot(r *http.Request, query url.Values, st *state.State) (string, error) {
 	uuid := query.Get(":envuuid")
 	if uuid == "" {
-		env, err := h.state.Environment()
+		env, err := st.Environment()
 		if err != nil {
 			return "", err
 		}
@@ -261,13 +268,13 @@ func (h *toolsUploadHandler) getServerRoot(r *http.Request, query url.Values) (s
 }
 
 // handleUpload uploads the tools data from the reader to env storage as the specified version.
-func (h *toolsUploadHandler) handleUpload(r io.Reader, toolsVersions []version.Binary, serverRoot string) (*tools.Tools, error) {
+func (h *toolsUploadHandler) handleUpload(r io.Reader, toolsVersions []version.Binary, serverRoot string, st *state.State) (*tools.Tools, error) {
 	// Check if changes are allowed and the command may proceed.
-	blockChecker := common.NewBlockChecker(h.state)
+	blockChecker := common.NewBlockChecker(st)
 	if err := blockChecker.ChangeAllowed(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	storage, err := h.state.ToolsStorage()
+	storage, err := st.ToolsStorage()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -126,12 +126,11 @@ func (s *toolsSuite) TestUpload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the response.
-	info := s.APIInfo(c)
-	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), info.EnvironTag.Id(), vers)
+	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
 
 	// Check the contents.
-	_, uploadedData := s.getToolsFromStorage(c, vers)
+	_, uploadedData := s.getToolsFromStorage(c, s.State, vers)
 	expectedData, err := ioutil.ReadFile(toolPath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uploadedData, gc.DeepEquals, expectedData)
@@ -166,23 +165,32 @@ func (s *toolsSuite) TestUploadAllowsTopLevelPath(c *gc.C) {
 	resp, err := s.uploadRequest(c, url.String(), true, toolPath)
 	c.Assert(err, jc.ErrorIsNil)
 	// Check the response.
-	info := s.APIInfo(c)
-	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), info.EnvironTag.Id(), vers)
+	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
 }
 
 func (s *toolsSuite) TestUploadAllowsEnvUUIDPath(c *gc.C) {
 	// Check that we can upload tools to https://host:port/ENVUUID/tools
-	environ, err := s.State.Environment()
-	c.Assert(err, jc.ErrorIsNil)
 	expectedTools, vers, toolPath := s.setupToolsForUpload(c)
 	url := s.toolsURL(c, "binaryVersion="+vers.String())
-	url.Path = fmt.Sprintf("/environment/%s/tools", environ.UUID())
+	url.Path = fmt.Sprintf("/environment/%s/tools", s.State.EnvironUUID())
 	resp, err := s.uploadRequest(c, url.String(), true, toolPath)
 	c.Assert(err, jc.ErrorIsNil)
 	// Check the response.
-	info := s.APIInfo(c)
-	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), info.EnvironTag.Id(), vers)
+	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
+	s.assertUploadResponse(c, resp, expectedTools[0])
+}
+
+func (s *toolsSuite) TestUploadAllowsOtherEnvUUIDPath(c *gc.C) {
+	envState := s.setupOtherEnvironment(c)
+	// Check that we can upload tools to https://host:port/ENVUUID/tools
+	expectedTools, vers, toolPath := s.setupToolsForUpload(c)
+	url := s.toolsURL(c, "binaryVersion="+vers.String())
+	url.Path = fmt.Sprintf("/environment/%s/tools", envState.EnvironUUID())
+	resp, err := s.uploadRequest(c, url.String(), true, toolPath)
+	c.Assert(err, jc.ErrorIsNil)
+	// Check the response.
+	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), envState.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
 }
 
@@ -234,18 +242,26 @@ func (s *toolsSuite) TestUploadSeriesExpanded(c *gc.C) {
 }
 
 func (s *toolsSuite) TestDownloadEnvUUIDPath(c *gc.C) {
-	environ, err := s.State.Environment()
-	c.Assert(err, jc.ErrorIsNil)
-	tools := s.storeFakeTools(c, "abc", toolstorage.Metadata{
+	tools := s.storeFakeTools(c, s.State, "abc", toolstorage.Metadata{
 		Version: version.Current,
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})
-	s.testDownload(c, tools, environ.UUID())
+	s.testDownload(c, tools, s.State.EnvironUUID())
+}
+
+func (s *toolsSuite) TestDownloadOtherEnvUUIDPath(c *gc.C) {
+	envState := s.setupOtherEnvironment(c)
+	tools := s.storeFakeTools(c, envState, "abc", toolstorage.Metadata{
+		Version: version.Current,
+		Size:    3,
+		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+	})
+	s.testDownload(c, tools, envState.EnvironUUID())
 }
 
 func (s *toolsSuite) TestDownloadTopLevelPath(c *gc.C) {
-	tools := s.storeFakeTools(c, "abc", toolstorage.Metadata{
+	tools := s.storeFakeTools(c, s.State, "abc", toolstorage.Metadata{
 		Version: version.Current,
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
@@ -263,7 +279,7 @@ func (s *toolsSuite) TestDownloadFetchesAndCaches(c *gc.C) {
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", vers)[0]
 	data := s.testDownload(c, tools, "")
 
-	metadata, cachedData := s.getToolsFromStorage(c, tools.Version)
+	metadata, cachedData := s.getToolsFromStorage(c, s.State, tools.Version)
 	c.Assert(metadata.Size, gc.Equals, tools.Size)
 	c.Assert(metadata.SHA256, gc.Equals, tools.SHA256)
 	c.Assert(string(cachedData), gc.Equals, string(data))
@@ -298,8 +314,8 @@ func (s *toolsSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 	s.assertToolsNotStored(c, tools.Version)
 }
 
-func (s *toolsSuite) storeFakeTools(c *gc.C, content string, metadata toolstorage.Metadata) *coretools.Tools {
-	storage, err := s.State.ToolsStorage()
+func (s *toolsSuite) storeFakeTools(c *gc.C, st *state.State, content string, metadata toolstorage.Metadata) *coretools.Tools {
+	storage, err := st.ToolsStorage()
 	c.Assert(err, jc.ErrorIsNil)
 	defer storage.Close()
 	err = storage.AddTools(strings.NewReader(content), metadata)
@@ -311,8 +327,8 @@ func (s *toolsSuite) storeFakeTools(c *gc.C, content string, metadata toolstorag
 	}
 }
 
-func (s *toolsSuite) getToolsFromStorage(c *gc.C, vers version.Binary) (toolstorage.Metadata, []byte) {
-	storage, err := s.State.ToolsStorage()
+func (s *toolsSuite) getToolsFromStorage(c *gc.C, st *state.State, vers version.Binary) (toolstorage.Metadata, []byte) {
+	storage, err := st.ToolsStorage()
 	c.Assert(err, jc.ErrorIsNil)
 	defer storage.Close()
 	metadata, r, err := storage.Tools(vers)
@@ -353,7 +369,7 @@ func (s *toolsSuite) TestDownloadRejectsWrongEnvUUIDPath(c *gc.C) {
 
 func (s *toolsSuite) toolsURL(c *gc.C, query string) *url.URL {
 	uri := s.baseURL(c)
-	uri.Path += "/tools"
+	uri.Path = fmt.Sprintf("/environment/%s/tools", s.envUUID)
 	uri.RawQuery = query
 	return uri
 }

--- a/apiserver/utils.go
+++ b/apiserver/utils.go
@@ -4,8 +4,10 @@
 package apiserver
 
 import (
-	"fmt"
+	"github.com/juju/errors"
+	"github.com/juju/names"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/state"
 )
 
@@ -28,7 +30,58 @@ func setPassword(e state.Authenticator, password string) error {
 	// Catch expected common case of misspelled
 	// or missing Password parameter.
 	if password == "" {
-		return fmt.Errorf("password is empty")
+		return errors.New("password is empty")
 	}
 	return e.SetPassword(password)
+}
+
+type validateArgs struct {
+	st      *state.State
+	envUUID string
+	// strict validation does not allow empty UUID values
+	strict bool
+	// stateServerEnvOnly only validates the state server environment
+	stateServerEnvOnly bool
+}
+
+// validateEnvironUUID is the common validator for the various apiserver
+// components that need to check for a valid environment UUID.
+// An empty envUUID means that the connection has come in at the root
+// of the URL space and refers to the state server environment.
+// The *state.State parameter is expected to be the state server State
+// connection.  The return *state.State is a connection for the specified
+// environment UUID if the UUID refers to an environment contained in the
+// database.  If the bool return value is true, the state connection should
+// be closed at the end of serving the client connection.
+func validateEnvironUUID(args validateArgs) (*state.State, bool, error) {
+	if args.envUUID == "" {
+		// We allow the environUUID to be empty for 2 cases
+		// 1) Compatibility with older clients
+		// 2) TODO: server a limited API at the root (empty envUUID)
+		//    with just the user manager and environment manager
+		//    if the connection comes over a sufficiently up to date
+		//    login command.
+		if args.strict {
+			return nil, false, errors.Trace(common.UnknownEnvironmentError(args.envUUID))
+		}
+		logger.Debugf("validate env uuid: empty envUUID")
+		return args.st, false, nil
+	}
+	if args.envUUID == args.st.EnvironUUID() {
+		logger.Debugf("validate env uuid: state server environment - %s", args.envUUID)
+		return args.st, false, nil
+	}
+	if args.stateServerEnvOnly || !names.IsValidEnvironment(args.envUUID) {
+		return nil, false, errors.Trace(common.UnknownEnvironmentError(args.envUUID))
+	}
+	envTag := names.NewEnvironTag(args.envUUID)
+	if _, err := args.st.GetEnvironment(envTag); err != nil {
+		return nil, false, errors.Wrap(err, common.UnknownEnvironmentError(args.envUUID))
+	}
+	logger.Debugf("validate env uuid: %s", args.envUUID)
+	result, err := args.st.ForEnviron(envTag)
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
+	return result, true, nil
 }

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -1,0 +1,96 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/testing"
+)
+
+type utilsSuite struct {
+	testing.StateSuite
+}
+
+var _ = gc.Suite(&utilsSuite{})
+
+func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
+	st, needsClosing, err := validateEnvironUUID(
+		validateArgs{
+			st: s.State,
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(needsClosing, jc.IsFalse)
+	c.Assert(st.EnvironUUID(), gc.Equals, s.State.EnvironUUID())
+}
+
+func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
+	_, _, err := validateEnvironUUID(
+		validateArgs{
+			st:     s.State,
+			strict: true,
+		})
+	c.Assert(err, gc.ErrorMatches, `unknown environment: ""`)
+}
+
+func (s *utilsSuite) TestValidateStateServer(c *gc.C) {
+	st, needsClosing, err := validateEnvironUUID(
+		validateArgs{
+			st:      s.State,
+			envUUID: s.State.EnvironUUID(),
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(needsClosing, jc.IsFalse)
+	c.Assert(st.EnvironUUID(), gc.Equals, s.State.EnvironUUID())
+}
+
+func (s *utilsSuite) TestValidateStateServerStrict(c *gc.C) {
+	st, needsClosing, err := validateEnvironUUID(
+		validateArgs{
+			st:      s.State,
+			envUUID: s.State.EnvironUUID(),
+			strict:  true,
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(needsClosing, jc.IsFalse)
+	c.Assert(st.EnvironUUID(), gc.Equals, s.State.EnvironUUID())
+}
+
+func (s *utilsSuite) TestValidateBadEnvUUID(c *gc.C) {
+	_, _, err := validateEnvironUUID(
+		validateArgs{
+			st:      s.State,
+			envUUID: "bad",
+		})
+	c.Assert(err, gc.ErrorMatches, `unknown environment: "bad"`)
+}
+
+func (s *utilsSuite) TestValidateOtherEnvironment(c *gc.C) {
+	envState := s.Factory.MakeEnvironment(c, nil)
+	defer envState.Close()
+
+	st, needsClosing, err := validateEnvironUUID(
+		validateArgs{
+			st:      s.State,
+			envUUID: envState.EnvironUUID(),
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(needsClosing, jc.IsTrue)
+	c.Assert(st.EnvironUUID(), gc.Equals, envState.EnvironUUID())
+	st.Close()
+}
+
+func (s *utilsSuite) TestValidateOtherEnvironmentStateServerOnly(c *gc.C) {
+	envState := s.Factory.MakeEnvironment(c, nil)
+	defer envState.Close()
+
+	_, _, err := validateEnvironUUID(
+		validateArgs{
+			st:                 s.State,
+			envUUID:            envState.EnvironUUID(),
+			stateServerEnvOnly: true,
+		})
+	c.Assert(err, gc.ErrorMatches, `unknown environment: ".*"`)
+}

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -92,5 +92,21 @@ func (s *utilsSuite) TestValidateOtherEnvironmentStateServerOnly(c *gc.C) {
 			envUUID:            envState.EnvironUUID(),
 			stateServerEnvOnly: true,
 		})
-	c.Assert(err, gc.ErrorMatches, `unknown environment: ".*"`)
+	c.Assert(err, gc.ErrorMatches, `requested environment ".*" is not the state server environment`)
+}
+
+func (s *utilsSuite) TestValidateNonAliveEnvironment(c *gc.C) {
+	envState := s.Factory.MakeEnvironment(c, nil)
+	defer envState.Close()
+	env, err := envState.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = validateEnvironUUID(
+		validateArgs{
+			st:      s.State,
+			envUUID: envState.EnvironUUID(),
+		})
+	c.Assert(err, gc.ErrorMatches, `environment ".*" is no longer live`)
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -63,8 +63,8 @@ type JujuConnSuite struct {
 	// /var/lib/juju: the use cases are completely non-overlapping, and any tests that
 	// really do need both to exist ought to be embedding distinct fixtures for the
 	// distinct environments.
-	testing.FakeJujuHomeSuite
 	gitjujutesting.MgoSuite
+	testing.FakeJujuHomeSuite
 	envtesting.ToolsFixture
 
 	DefaultToolsStorageDir string
@@ -87,18 +87,18 @@ type JujuConnSuite struct {
 const AdminSecret = "dummy-secret"
 
 func (s *JujuConnSuite) SetUpSuite(c *gc.C) {
-	s.FakeJujuHomeSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
+	s.FakeJujuHomeSuite.SetUpSuite(c)
 }
 
 func (s *JujuConnSuite) TearDownSuite(c *gc.C) {
-	s.MgoSuite.TearDownSuite(c)
 	s.FakeJujuHomeSuite.TearDownSuite(c)
+	s.MgoSuite.TearDownSuite(c)
 }
 
 func (s *JujuConnSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
+	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&configstore.DefaultAdminUsername, dummy.AdminUserTag().Name())
 	s.setUpConn(c)
@@ -108,8 +108,8 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 func (s *JujuConnSuite) TearDownTest(c *gc.C) {
 	s.tearDownConn(c)
 	s.ToolsFixture.TearDownTest(c)
-	s.MgoSuite.TearDownTest(c)
 	s.FakeJujuHomeSuite.TearDownTest(c)
+	s.MgoSuite.TearDownTest(c)
 }
 
 // Reset returns environment state to that which existed at the start of

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 var _ = gc.Suite(&StateSuite{})
@@ -19,9 +20,10 @@ var _ = gc.Suite(&StateSuite{})
 type StateSuite struct {
 	jujutesting.MgoSuite
 	testing.BaseSuite
-	Policy state.Policy
-	State  *state.State
-	Owner  names.UserTag
+	Policy  state.Policy
+	State   *state.State
+	Owner   names.UserTag
+	Factory *factory.Factory
 }
 
 func (s *StateSuite) SetUpSuite(c *gc.C) {
@@ -41,6 +43,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 	s.Owner = names.NewLocalUserTag("test-admin")
 	s.State = Initialize(c, s.Owner, nil, s.Policy)
 	s.AddCleanup(func(*gc.C) { s.State.Close() })
+	s.Factory = factory.NewFactory(s.State)
 }
 
 func (s *StateSuite) TearDownTest(c *gc.C) {


### PR DESCRIPTION
The httpHandler needed to be updated to handle environment validation for non state server environments.  I moved the validation code that was being used by the apiHandler into utils and gave it a few more args, and explicit tests (utils_test.go).

A key part I noticed was that the *state.State value that was used by the various concrete httpHandler implementations had to be one that was only there for the session.  To make this happen, I created the stateWrapper.  The authentication is then hung off this as it is environment dependent.

Extra tests were added to each of the concrete handlers to test for new environments.

The debuglog handler only used the httpHandler for authentication, and not for the state connection.  We need some thought around how to handle the logging across multiple environments, but we knew this before.

The backup endpoint is only valid for the state server environment - this we also knew is an issue to be solved later.

The order of the embedded suites in the JujuConnSuite was altered so the cleanup code is run before the mgo cleanup, that way we can have cleanup functions that close state connections.

(Review request: http://reviews.vapour.ws/r/776/)