### PR TITLE
Add storage provider registry

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -39,7 +39,7 @@ type ProviderType string
 // Provider is an interface for obtaining storage sources.
 type Provider interface {
 	// VolumeSource returns a VolumeSource given the
-	// specified environment and provider configuration.
+	// specified cloud and storage provider configurations.
 	//
 	// If the storage provider does not support creating volumes as a
 	// first-class primitive, then VolumeSource must return an error

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -3,7 +3,10 @@
 
 package storage
 
-import "github.com/juju/juju/instance"
+import (
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+)
 
 // FeatureFlag is the name of the feature for the JUJU_DEV_FEATURE_FLAGS
 // envar. Add this string to the envar to enable support for storage.
@@ -35,12 +38,13 @@ type ProviderType string
 
 // Provider is an interface for obtaining storage sources.
 type Provider interface {
-	// VolumeSource returns a VolumeSource given the specified configuration.
+	// VolumeSource returns a VolumeSource given the
+	// specified environment and provider configuration.
 	//
 	// If the storage provider does not support creating volumes as a
 	// first-class primitive, then VolumeSource must return an error
 	// satisfying errors.IsNotSupported.
-	VolumeSource(*Config) (VolumeSource, error)
+	VolumeSource(environConfig *config.Config, providerConfig *Config) (VolumeSource, error)
 
 	// TODO(axw) define filesystem source. If the user requests a
 	// filesystem and that can be provided first-class, it should be

--- a/storage/providerregistry.go
+++ b/storage/providerregistry.go
@@ -27,7 +27,7 @@ func RegisterProvider(providerType ProviderType, p Provider) {
 func StorageProvider(providerType ProviderType) (Provider, error) {
 	p, ok := providers[providerType]
 	if !ok {
-		return nil, errors.Errorf("no registered provider for %q", providerType)
+		return nil, errors.NotFoundf("storage provider %q", providerType)
 	}
 	return p, nil
 }

--- a/storage/providerregistry.go
+++ b/storage/providerregistry.go
@@ -1,0 +1,72 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/errors"
+)
+
+//
+// A registry of storage providers.
+//
+
+// providers maps from provider type to storage.Provider for
+// each registered provider type.
+var providers = make(map[ProviderType]Provider)
+
+// RegisterProvider registers a new storage provider of the given type.
+func RegisterProvider(providerType ProviderType, p Provider) {
+	if providers[providerType] != nil {
+		panic(errors.Errorf("juju: duplicate storage provider type %q", providerType))
+	}
+	providers[providerType] = p
+}
+
+// StorageProvider returns the previously registered provider with the given type.
+func StorageProvider(providerType ProviderType) (Provider, error) {
+	p, ok := providers[providerType]
+	if !ok {
+		return nil, errors.Errorf("no registered provider for %q", providerType)
+	}
+	return p, nil
+}
+
+//
+// A registry of storage provider types which are
+// valid for a Juju Environ.
+//
+
+// supportedEnvironProviders maps from environment type to a slice of
+// supported ProviderType(s).
+var supportedEnvironProviders = make(map[string][]ProviderType)
+
+// RegisterEnvironStorageProviders records which storage provider types
+// are valid for an environment.
+// The first provider type in the slice is the default provider.
+func RegisterEnvironStorageProviders(envType string, providers ...ProviderType) {
+	supportedEnvironProviders[envType] = providers
+}
+
+// Returns true is provider is supported for the environment.
+func IsProviderSupported(envType string, providerType ProviderType) bool {
+	providerTypes, ok := supportedEnvironProviders[envType]
+	if !ok {
+		return false
+	}
+	for _, p := range providerTypes {
+		if p == providerType {
+			return true
+		}
+	}
+	return false
+}
+
+// DefaultProviderForEnviron returns the default provider, if any, for the environment.
+func DefaultProviderForEnviron(envType string) (ProviderType, bool) {
+	providerTypes, ok := supportedEnvironProviders[envType]
+	if !ok || len(providerTypes) == 0 {
+		return "", false
+	}
+	return providerTypes[0], true
+}

--- a/storage/providerregistry.go
+++ b/storage/providerregistry.go
@@ -49,6 +49,9 @@ var supportedEnvironProviders = make(map[string][]ProviderType)
 func RegisterEnvironStorageProviders(envType string, providers ...ProviderType) {
 	existing := supportedEnvironProviders[envType]
 	for _, p := range providers {
+		if IsProviderSupported(envType, p) {
+			continue
+		}
 		existing = append(existing, p)
 	}
 	supportedEnvironProviders[envType] = existing

--- a/storage/providerregistry.go
+++ b/storage/providerregistry.go
@@ -44,8 +44,14 @@ var supportedEnvironProviders = make(map[string][]ProviderType)
 // RegisterEnvironStorageProviders records which storage provider types
 // are valid for an environment.
 // The first provider type in the slice is the default provider.
+// If this is called more than once, the new providers are appended to the
+// current slice.
 func RegisterEnvironStorageProviders(envType string, providers ...ProviderType) {
-	supportedEnvironProviders[envType] = providers
+	existing := supportedEnvironProviders[envType]
+	for _, p := range providers {
+		existing = append(existing, p)
+	}
+	supportedEnvironProviders[envType] = existing
 }
 
 // Returns true is provider is supported for the environment.

--- a/storage/providerregistry.go
+++ b/storage/providerregistry.go
@@ -43,7 +43,6 @@ var supportedEnvironProviders = make(map[string][]ProviderType)
 
 // RegisterEnvironStorageProviders records which storage provider types
 // are valid for an environment.
-// The first provider type in the slice is the default provider.
 // If this is called more than once, the new providers are appended to the
 // current slice.
 func RegisterEnvironStorageProviders(envType string, providers ...ProviderType) {
@@ -69,13 +68,4 @@ func IsProviderSupported(envType string, providerType ProviderType) bool {
 		}
 	}
 	return false
-}
-
-// DefaultProviderForEnviron returns the default provider, if any, for the environment.
-func DefaultProviderForEnviron(envType string) (ProviderType, bool) {
-	providerTypes, ok := supportedEnvironProviders[envType]
-	if !ok || len(providerTypes) == 0 {
-		return "", false
-	}
-	return providerTypes[0], true
 }

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -69,6 +69,7 @@ func (s *providerRegistrySuite) TestRegisterEnvironProvidersMultipleCalls(c *gc.
 	ptypeBar := storage.ProviderType("bar")
 	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo)
 	storage.RegisterEnvironStorageProviders("ec2", ptypeBar)
+	storage.RegisterEnvironStorageProviders("ec2", ptypeBar)
 	c.Assert(storage.IsProviderSupported("ec2", ptypeFoo), jc.IsTrue)
 	c.Assert(storage.IsProviderSupported("ec2", ptypeBar), jc.IsTrue)
 	defaultProvider, ok := storage.DefaultProviderForEnviron("ec2")

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -64,6 +64,18 @@ func (s *providerRegistrySuite) TestSupportedEnvironProviders(c *gc.C) {
 	c.Assert(storage.IsProviderSupported("openstack", ptypeBar), jc.IsFalse)
 }
 
+func (s *providerRegistrySuite) TestRegisterEnvironProvidersMultipleCalls(c *gc.C) {
+	ptypeFoo := storage.ProviderType("foo")
+	ptypeBar := storage.ProviderType("bar")
+	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo)
+	storage.RegisterEnvironStorageProviders("ec2", ptypeBar)
+	c.Assert(storage.IsProviderSupported("ec2", ptypeFoo), jc.IsTrue)
+	c.Assert(storage.IsProviderSupported("ec2", ptypeBar), jc.IsTrue)
+	defaultProvider, ok := storage.DefaultProviderForEnviron("ec2")
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(defaultProvider, gc.Equals, ptypeFoo)
+}
+
 func (s *providerRegistrySuite) DefaultProviderForEnviron(c *gc.C) {
 	ptypeFoo := storage.ProviderType("foo")
 	ptypeBar := storage.ProviderType("bar")

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/storage"
+)
+
+type providerRegistrySuite struct{}
+
+var _ = gc.Suite(&providerRegistrySuite{})
+
+type mockProvider struct {
+}
+
+func (p *mockProvider) VolumeSource(*config.Config, *storage.Config) (storage.VolumeSource, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *mockProvider) ValidateConfig(*storage.Config) error {
+	return nil
+}
+
+func (s *providerRegistrySuite) TestRegisterProvider(c *gc.C) {
+	p1 := &mockProvider{}
+	ptype := storage.ProviderType("foo")
+	storage.RegisterProvider(ptype, p1)
+	p, err := storage.StorageProvider(ptype)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, gc.Equals, p1)
+}
+
+func (s *providerRegistrySuite) TestNoSuchProvider(c *gc.C) {
+	_, err := storage.StorageProvider(storage.ProviderType("foo"))
+	c.Assert(err, gc.ErrorMatches, `no registered provider for "foo"`)
+}
+
+func (s *providerRegistrySuite) TestRegisterProviderDuplicate(c *gc.C) {
+	defer func() {
+		if v := recover(); v != nil {
+			c.Assert(v, gc.ErrorMatches, `.*duplicate storage provider type "foo"`)
+		}
+	}()
+	p1 := &mockProvider{}
+	p2 := &mockProvider{}
+	storage.RegisterProvider(storage.ProviderType("foo"), p1)
+	storage.RegisterProvider(storage.ProviderType("foo"), p2)
+	c.Errorf("panic expected")
+}
+
+func (s *providerRegistrySuite) TestSupportedEnvironProviders(c *gc.C) {
+	ptypeFoo := storage.ProviderType("foo")
+	ptypeBar := storage.ProviderType("bar")
+	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo, ptypeBar)
+	c.Assert(storage.IsProviderSupported("ec2", ptypeFoo), jc.IsTrue)
+	c.Assert(storage.IsProviderSupported("ec2", ptypeBar), jc.IsTrue)
+	c.Assert(storage.IsProviderSupported("ec2", storage.ProviderType("foobar")), jc.IsFalse)
+	c.Assert(storage.IsProviderSupported("openstack", ptypeBar), jc.IsFalse)
+}
+
+func (s *providerRegistrySuite) DefaultProviderForEnviron(c *gc.C) {
+	ptypeFoo := storage.ProviderType("foo")
+	ptypeBar := storage.ProviderType("bar")
+	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo, ptypeBar)
+	defaultProvider, ok := storage.DefaultProviderForEnviron("ec2")
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(defaultProvider, gc.Equals, ptypeFoo)
+}
+
+func (s *providerRegistrySuite) NoDefaultProviderForEnviron(c *gc.C) {
+	ptypeFoo := storage.ProviderType("foo")
+	ptypeBar := storage.ProviderType("bar")
+	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo, ptypeBar)
+	_, ok := storage.DefaultProviderForEnviron("openstack")
+	c.Assert(ok, jc.IsFalse)
+}

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -38,7 +38,7 @@ func (s *providerRegistrySuite) TestRegisterProvider(c *gc.C) {
 
 func (s *providerRegistrySuite) TestNoSuchProvider(c *gc.C) {
 	_, err := storage.StorageProvider(storage.ProviderType("foo"))
-	c.Assert(err, gc.ErrorMatches, `no registered provider for "foo"`)
+	c.Assert(err, gc.ErrorMatches, `storage provider "foo" not found`)
 }
 
 func (s *providerRegistrySuite) TestRegisterProviderDuplicate(c *gc.C) {

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -72,24 +72,16 @@ func (s *providerRegistrySuite) TestRegisterEnvironProvidersMultipleCalls(c *gc.
 	storage.RegisterEnvironStorageProviders("ec2", ptypeBar)
 	c.Assert(storage.IsProviderSupported("ec2", ptypeFoo), jc.IsTrue)
 	c.Assert(storage.IsProviderSupported("ec2", ptypeBar), jc.IsTrue)
-	defaultProvider, ok := storage.DefaultProviderForEnviron("ec2")
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(defaultProvider, gc.Equals, ptypeFoo)
 }
 
 func (s *providerRegistrySuite) DefaultProviderForEnviron(c *gc.C) {
 	ptypeFoo := storage.ProviderType("foo")
 	ptypeBar := storage.ProviderType("bar")
 	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo, ptypeBar)
-	defaultProvider, ok := storage.DefaultProviderForEnviron("ec2")
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(defaultProvider, gc.Equals, ptypeFoo)
 }
 
 func (s *providerRegistrySuite) NoDefaultProviderForEnviron(c *gc.C) {
 	ptypeFoo := storage.ProviderType("foo")
 	ptypeBar := storage.ProviderType("bar")
 	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo, ptypeBar)
-	_, ok := storage.DefaultProviderForEnviron("openstack")
-	c.Assert(ok, jc.IsFalse)
 }


### PR DESCRIPTION
Add a registry that init() functions will use to populate the available storage providers and record which ones can be used with a given environment.

Also change the the Provider VolumeSource() signature to taken environ.Config so that credentials etc are available to the storage source. 

(Review request: http://reviews.vapour.ws/r/777/)