### PR TITLE
Skeleton code for loop storage provider

### DIFF
--- a/environs/config.go
+++ b/environs/config.go
@@ -157,6 +157,15 @@ func RegisterProvider(name string, p EnvironProvider, alias ...string) {
 	}
 }
 
+// RegisteredProviders enumerate all the environ providers which have been registered.
+func RegisteredProviders() []string {
+	var p []string
+	for k := range providers {
+		p = append(p, k)
+	}
+	return p
+}
+
 // Provider returns the previously registered provider with the given type.
 func Provider(providerType string) (EnvironProvider, error) {
 	if alias, ok := providerAliases[providerType]; ok {

--- a/storage/config.go
+++ b/storage/config.go
@@ -35,3 +35,13 @@ func (c *Config) Attrs() map[string]interface{} {
 	}
 	return attrs
 }
+
+// ValueString returns the named config attribute as a string.
+func (c *Config) ValueString(name string) (string, bool) {
+	if v, ok := c.attrs[name]; !ok {
+		return "", false
+	} else {
+		s, ok := v.(string)
+		return s, ok
+	}
+}

--- a/storage/config.go
+++ b/storage/config.go
@@ -38,10 +38,6 @@ func (c *Config) Attrs() map[string]interface{} {
 
 // ValueString returns the named config attribute as a string.
 func (c *Config) ValueString(name string) (string, bool) {
-	if v, ok := c.attrs[name]; !ok {
-		return "", false
-	} else {
-		s, ok := v.(string)
-		return s, ok
-	}
+	v, ok := c.attrs[name].(string)
+	return v, ok
 }

--- a/storage/pool/defaultpools.go
+++ b/storage/pool/defaultpools.go
@@ -23,7 +23,7 @@ func RegisterDefaultPools(pm PoolManager, agentConfig agent.Config) error {
 	return nil
 }
 
-const RootFsLoopPoolName = "rootfsloop"
+const RootFsLoopPoolName = "loop"
 
 func registerRootFsLoop(pm PoolManager, agentConfig agent.Config) error {
 	rootfsPoolConfig := map[string]interface{}{

--- a/storage/pool/defaultpools.go
+++ b/storage/pool/defaultpools.go
@@ -1,0 +1,48 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pool
+
+import (
+	"path/filepath"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+// RegisterDefaultPools ensures that the required out of the box storage pools
+// are registered.
+func RegisterDefaultPools(pm PoolManager, agentConfig agent.Config) error {
+	if err := registerRootFsLoop(pm, agentConfig); err != nil {
+		return err
+	}
+	// TODO - register other pools
+	return nil
+}
+
+const RootFsLoopPoolName = "rootfsloop"
+
+func registerRootFsLoop(pm PoolManager, agentConfig agent.Config) error {
+	rootfsPoolConfig := map[string]interface{}{
+		provider.LoopDataDir: filepath.Join(agentConfig.DataDir(), "storage", "block", "loop"),
+	}
+	return RegisterPool(pm, RootFsLoopPoolName, provider.LoopProviderType, false, rootfsPoolConfig)
+}
+
+// RegisterPool creates a named pool for the provider type with the specified config.
+func RegisterPool(pm PoolManager, name string, providerType storage.ProviderType, replace bool, cfg map[string]interface{}) error {
+	if _, err := pm.Get(name); err == nil {
+		// Already registered.
+		if !replace {
+			return nil
+		}
+		if err := pm.Delete(name); err != nil {
+			return errors.Annotatef(err, "deleting existing pool %q", name)
+		}
+	}
+	_, err := pm.Create(name, providerType, cfg)
+	return err
+}

--- a/storage/provider/init.go
+++ b/storage/provider/init.go
@@ -1,0 +1,30 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/juju/environs"
+	_ "github.com/juju/juju/provider/all"
+	"github.com/juju/juju/storage"
+)
+
+func init() {
+	storage.RegisterProvider(LoopProviderType, &loopProvider{})
+	storage.RegisterProvider(HostLoopProviderType, &hostLoopProvider{})
+
+	// local cloud provider
+	storage.RegisterEnvironStorageProviders("local", LoopProviderType, HostLoopProviderType)
+
+	// AWS cloud provider
+	storage.RegisterEnvironStorageProviders("ec2", LoopProviderType)
+	// TODO: register EBS and other storage providers for EC2
+
+	// TODO: register storage providers for other environs
+
+	// All environments providers support rootfs loop devices.
+	// As a failsafe, ensure at least this storage provider is registered.
+	for _, envType := range environs.RegisteredProviders() {
+		storage.RegisterEnvironStorageProviders(envType, LoopProviderType)
+	}
+}

--- a/storage/provider/init.go
+++ b/storage/provider/init.go
@@ -11,16 +11,6 @@ import (
 
 func init() {
 	storage.RegisterProvider(LoopProviderType, &loopProvider{})
-	storage.RegisterProvider(HostLoopProviderType, &hostLoopProvider{})
-
-	// local cloud provider
-	storage.RegisterEnvironStorageProviders("local", LoopProviderType, HostLoopProviderType)
-
-	// AWS cloud provider
-	storage.RegisterEnvironStorageProviders("ec2", LoopProviderType)
-	// TODO: register EBS and other storage providers for EC2
-
-	// TODO: register storage providers for other environs
 
 	// All environments providers support rootfs loop devices.
 	// As a failsafe, ensure at least this storage provider is registered.

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -51,31 +51,6 @@ func (lp *loopProvider) VolumeSource(environConfig *config.Config, providerConfi
 	}, nil
 }
 
-// hostLoopProviders create a loop volume source on the host machine
-// running a local provider, such that the devices are passed to
-// the instantiated containers.
-type hostLoopProvider struct{ loopProvider }
-
-var _ storage.Provider = (*hostLoopProvider)(nil)
-
-// VolumeSource is defined on the Provider interface.
-func (lp *hostLoopProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
-	if err := lp.ValidateConfig(providerConfig); err != nil {
-		return nil, err
-	}
-	dataDir, _ := providerConfig.ValueString(LoopDataDir)
-	return &hostLoopVolumeSource{
-		loopVolumeSource: loopVolumeSource{
-			dataDir: dataDir,
-			subDir:  "storage/block/loop",
-		},
-	}, nil
-}
-
-type hostLoopVolumeSource struct {
-	loopVolumeSource
-}
-
 // loopVolumeSource provides common functionality to handle
 // loop devices for rootfs and host loop volume sources.
 type loopVolumeSource struct {

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -1,0 +1,116 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	// Loop provider types
+	LoopProviderType     = storage.ProviderType("loop")
+	HostLoopProviderType = storage.ProviderType("hostloop")
+
+	// Config attributes
+	LoopDataDir = "data-dir" // top level directory where loop devices are created.
+	LoopSubDir  = "sub-dir"  // optional subdirectory for loop devices.
+)
+
+// loopProviders create volume sources which use loop devices.
+type loopProvider struct{}
+
+var _ storage.Provider = (*loopProvider)(nil)
+
+// ValidateConfig is defined on the Provider interface.
+func (lp *loopProvider) ValidateConfig(providerConfig *storage.Config) error {
+	dataDir, ok := providerConfig.ValueString(LoopDataDir)
+	if !ok || dataDir == "" {
+		return errors.New("no data directory specified")
+	}
+	return nil
+}
+
+// VolumeSource is defined on the Provider interface.
+func (lp *loopProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
+	if err := lp.ValidateConfig(providerConfig); err != nil {
+		return nil, err
+	}
+	dataDir, _ := providerConfig.ValueString(LoopDataDir)
+	subDir, _ := providerConfig.ValueString(LoopDataDir)
+	return &loopVolumeSource{
+		dataDir,
+		subDir,
+	}, nil
+}
+
+// hostLoopProviders create a loop volume source on the host machine
+// running a local provider, such that the devices are passed to
+// the instantiated containers.
+type hostLoopProvider struct{ loopProvider }
+
+var _ storage.Provider = (*hostLoopProvider)(nil)
+
+// VolumeSource is defined on the Provider interface.
+func (lp *hostLoopProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
+	if err := lp.ValidateConfig(providerConfig); err != nil {
+		return nil, err
+	}
+	dataDir, _ := providerConfig.ValueString(LoopDataDir)
+	return &hostLoopVolumeSource{
+		loopVolumeSource: loopVolumeSource{
+			dataDir: dataDir,
+			subDir:  "storage/block/loop",
+		},
+	}, nil
+}
+
+type hostLoopVolumeSource struct {
+	loopVolumeSource
+}
+
+// loopVolumeSource provides common functionality to handle
+// loop devices for rootfs and host loop volume sources.
+type loopVolumeSource struct {
+	dataDir string
+	subDir  string
+}
+
+var _ storage.VolumeSource = (*loopVolumeSource)(nil)
+
+func (lvs *loopVolumeSource) rootDeviceDir() string {
+	dirParts := []string{lvs.dataDir}
+	dirParts = append(dirParts, strings.Split(lvs.subDir, "/")...)
+	return filepath.Join(dirParts...)
+}
+
+func (lvs *loopVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.BlockDevice, error) {
+	panic("not implemented")
+}
+
+func (lvs *loopVolumeSource) DescribeVolumes(volIds []string) ([]storage.BlockDevice, error) {
+	panic("not implemented")
+}
+
+func (lvs *loopVolumeSource) DestroyVolumes(volIds []string) error {
+	panic("not implemented")
+}
+
+func (lvs *loopVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
+	panic("not implemented")
+}
+
+func (lvs *loopVolumeSource) AttachVolumes(volIds []string, instId []instance.Id) error {
+	panic("not implemented")
+}
+
+func (lvs *loopVolumeSource) DetachVolumes(volIds []string, instId []instance.Id) error {
+	panic("not implemented")
+}


### PR DESCRIPTION
Provides an initial local storage provider skeleton, plus registration infrastructure for storage pools.

There are 2 registration functions:

1. func RegisterDefaultPools(pm PoolManager, agentConfig agent.Config) error
- called from machine agent on state node when system is bootstrapped.
- eg register rootfsloop provider

2. func RegisterPool(pm PoolManager, name string, providerType storage.ProviderType, replace bool, cfg map[string]interface{}) error
- called when a cloud provider bootstraps an environment to register the out of the box pools for that environment
- eg local provider will register hostloop storage provider
- eg ec2 provider will register ebs storage provider

No tests in this branch; these will come as the work evolves.

(Review request: http://reviews.vapour.ws/r/779/)