### PR TITLE
LXC network config generation now supports multiple NICs

### DIFF
--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -63,7 +63,7 @@ func (s *KVMSuite) TestListInitiallyEmpty(c *gc.C) {
 
 func (s *KVMSuite) createRunningContainer(c *gc.C, name string) kvm.Container {
 	kvmContainer := s.ContainerFactory.New(name)
-	network := container.BridgeNetworkConfig("testbr0")
+	network := container.BridgeNetworkConfig("testbr0", nil)
 	c.Assert(kvmContainer.Start(kvm.StartParams{
 		Series:       "quantal",
 		Arch:         version.Current.Arch,

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -87,7 +87,7 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	network := container.BridgeNetworkConfig("virbr0")
+	network := container.BridgeNetworkConfig("virbr0", nil)
 
 	machineConfig.Tools = &tools.Tools{
 		Version: version.MustParseBinary("2.3.4-foo-bar"),

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -603,9 +603,11 @@ func networkConfigTemplate(config container.NetworkConfig) string {
 			nic.Type = "vlan"
 		}
 		if nic.IPv4Address != "" {
-			// LXC expects IPv4 addresses formatted like this:
-			// 1.2.3.4/5, so extract the mask from the CIDR to append
-			// it.
+			// LXC expects IPv4 addresses formatted like a CIDR:
+			// 1.2.3.4/5 (but without masking the least significant
+			// octets). So we need to extract the mask part of the
+			// iface.CIDR and append it. If CIDR is empty or invalid
+			// "/24" is used as a sane default.
 			_, ipNet, err := net.ParseCIDR(iface.CIDR)
 			if err != nil {
 				logger.Warningf(

--- a/container/network.go
+++ b/container/network.go
@@ -3,6 +3,10 @@
 
 package container
 
+import (
+	"github.com/juju/juju/network"
+)
+
 const (
 	// BridgeNetwork will have the container use the network bridge.
 	BridgeNetwork = "bridge"
@@ -14,16 +18,24 @@ const (
 type NetworkConfig struct {
 	NetworkType string
 	Device      string
+
+	Interfaces []network.InterfaceInfo
 }
 
-// BridgeNetworkConfig returns a valid NetworkConfig to use the specified
-// device as a network bridge for the container.
-func BridgeNetworkConfig(device string) *NetworkConfig {
-	return &NetworkConfig{BridgeNetwork, device}
+// BridgeNetworkConfig returns a valid NetworkConfig to use the
+// specified device as a network bridge for the container. It also
+// allows passing in specific configuration for the container's
+// network interfaces. If interfaces is nil the default configuration
+// is used for the respective container type.
+func BridgeNetworkConfig(device string, interfaces []network.InterfaceInfo) *NetworkConfig {
+	return &NetworkConfig{BridgeNetwork, device, interfaces}
 }
 
-// PhysicalNetworkConfig returns a valid NetworkConfig to use the specified
-// device as the network device for the container.
-func PhysicalNetworkConfig(device string) *NetworkConfig {
-	return &NetworkConfig{PhysicalNetwork, device}
+// PhysicalNetworkConfig returns a valid NetworkConfig to use the
+// specified device as the network device for the container. It also
+// allows passing in specific configuration for the container's
+// network interfaces. If interfaces is nil the default configuration
+// is used for the respective container type.
+func PhysicalNetworkConfig(device string, interfaces []network.InterfaceInfo) *NetworkConfig {
+	return &NetworkConfig{PhysicalNetwork, device, interfaces}
 }

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -54,7 +54,7 @@ func CreateContainerWithMachineConfig(
 	machineConfig *cloudinit.MachineConfig,
 ) instance.Instance {
 
-	network := container.BridgeNetworkConfig("nic42")
+	network := container.BridgeNetworkConfig("nic42", nil)
 	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", network)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
@@ -84,7 +84,7 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 	}
 	machineConfig.Config = envConfig
 
-	network := container.BridgeNetworkConfig("nic42")
+	network := container.BridgeNetworkConfig("nic42", nil)
 
 	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", network)
 

--- a/network/network.go
+++ b/network/network.go
@@ -118,7 +118,7 @@ type InterfaceInfo struct {
 
 	// Gateway address, if set, defines the default gateway to
 	// configure for this network interface. For containers this
-	// usually (one of) the host address(es).
+	// usually is (one of) the host address(es).
 	GatewayAddress Address
 
 	// ExtraConfig can contain any valid setting and its value allowed

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -397,7 +397,7 @@ func (env *localEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 // Override for testing.
 var createContainer = func(env *localEnviron, args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, error) {
 	series := args.Tools.OneSeries()
-	network := container.BridgeNetworkConfig(env.config.networkBridge())
+	network := container.BridgeNetworkConfig(env.config.networkBridge(), args.NetworkInfo)
 	inst, hardware, err := env.containerManager.CreateContainer(args.MachineConfig, series, network)
 	if err != nil {
 		return nil, nil, err

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -56,7 +56,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = kvm.DefaultKvmBridge
 	}
-	network := container.BridgeNetworkConfig(bridgeDevice)
+	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
 
 	series := args.Tools.OneSeries()
 	args.MachineConfig.MachineContainerType = instance.KVM

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -62,7 +62,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
-	network := container.BridgeNetworkConfig(bridgeDevice)
+	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
 
 	series := args.Tools.OneSeries()
 	args.MachineConfig.MachineContainerType = instance.LXC


### PR DESCRIPTION
container.NetworkConfig type was extended to support an
optional slice of []network.InterfaceInfo for per-NIC config.
The initial interface info is taken from StartInstanceParams.
Since we lack the other half of the provisioner API changes
that prepare the interfaces info, nothing uses this yet, but
it will soon.

Improved the unit tests around LXC config generation as well.
Since we can't configure everything via LXC config files, in
a follow-up will be proposed a modification to the user-data
generated for cloud-init for containers to include the extra
networking config.

make check passes, live testing now on MAAS, Local, EC2.

UPDATE: Live tests show no regressions, although further
changes will be needed to actually make it work for container
addressability.

(Review request: http://reviews.vapour.ws/r/780/)