### PR TITLE
Increment version to 1.21.0 and add fallback vivid support

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "1.21-rc2"
+#define MyAppVersion "1.21.0"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.ubuntu.com/"
 #define MyAppExeName "juju.exe"

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -33,6 +33,7 @@ var seriesVersions = map[string]string{
 	"saucy":       "13.10",
 	"trusty":      "14.04",
 	"utopic":      "14.10",
+	"vivid":       "15.04",
 	"win2012hvr2": "win2012hvr2",
 	"win2012hv":   "win2012hv",
 	"win2012r2":   "win2012r2",

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "1.21-rc2"
+const version = "1.21.0"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
Increments version number to 1.21.0

Also fixes https://bugs.launchpad.net/juju-core/1.21/+bug/1413245
(The vivid line in support series info was accidentally cut out).


(Review request: http://reviews.vapour.ws/r/783/)