### PR TITLE
cmd/jujud: allow ConnectionIsFatal to check multiple connections

### DIFF
--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -116,12 +116,17 @@ type Pinger interface {
 // isFatal argument to worker.NewRunner, that diagnoses an error as
 // fatal if the connection has failed or if the error is otherwise
 // fatal.
-func ConnectionIsFatal(logger loggo.Logger, conn Pinger) func(err error) bool {
+func ConnectionIsFatal(logger loggo.Logger, conns ...Pinger) func(err error) bool {
 	return func(err error) bool {
 		if IsFatal(err) {
 			return true
 		}
-		return ConnectionIsDead(logger, conn)
+		for _, conn := range conns {
+			if ConnectionIsDead(logger, conn) {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/cmd/jujud/util/util_test.go
+++ b/cmd/jujud/util/util_test.go
@@ -97,6 +97,30 @@ func (s *toolSuite) TestConnectionIsFatal(c *gc.C) {
 	}
 }
 
+func (s *toolSuite) TestConnectionIsFatalWithMultipleConns(c *gc.C) {
+	var (
+		errPinger testPinger = func() error {
+			return stderrors.New("ping error")
+		}
+		okPinger testPinger = func() error {
+			return nil
+		}
+	)
+
+	someErr := stderrors.New("foo")
+
+	c.Assert(ConnectionIsFatal(logger, okPinger, okPinger)(someErr),
+		jc.IsFalse)
+	c.Assert(ConnectionIsFatal(logger, okPinger, okPinger, okPinger)(someErr),
+		jc.IsFalse)
+	c.Assert(ConnectionIsFatal(logger, okPinger, errPinger)(someErr),
+		jc.IsTrue)
+	c.Assert(ConnectionIsFatal(logger, okPinger, okPinger, errPinger)(someErr),
+		jc.IsTrue)
+	c.Assert(ConnectionIsFatal(logger, errPinger, okPinger, okPinger)(someErr),
+		jc.IsTrue)
+}
+
 func (*toolSuite) TestIsFatal(c *gc.C) {
 
 	for i, test := range isFatalTests {


### PR DESCRIPTION
Required for multi-env support in the machine agent.

(Review request: http://reviews.vapour.ws/r/788/)