### PR TITLE
Improve LXC config generation and updates

### DIFF
--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -12,8 +12,7 @@ var (
 	ContainerDirFilesystem  = containerDirFilesystem
 	GenerateNetworkConfig   = generateNetworkConfig
 	ParseConfigLine         = parseConfigLine
-	ReplaceContainerConfig  = replaceContainerConfig
-	AppendToContainerConfig = appendToContainerConfig
+	UpdateContainerConfig   = updateContainerConfig
 	DiscoverHostNIC         = &discoverHostNIC
 	NetworkConfigTemplate   = networkConfigTemplate
 	RestartSymlink          = restartSymlink

--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -11,6 +11,9 @@ var (
 	ContainerConfigFilename = containerConfigFilename
 	ContainerDirFilesystem  = containerDirFilesystem
 	GenerateNetworkConfig   = generateNetworkConfig
+	ParseConfigLine         = parseConfigLine
+	ReplaceContainerConfig  = replaceContainerConfig
+	AppendToContainerConfig = appendToContainerConfig
 	DiscoverHostNIC         = &discoverHostNIC
 	NetworkConfigTemplate   = networkConfigTemplate
 	RestartSymlink          = restartSymlink

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -620,6 +620,16 @@ func networkConfigTemplate(config container.NetworkConfig) string {
 				nic.IPv4Address += fmt.Sprintf("/%d", ones)
 			}
 		}
+		if nic.NoAutoStart && nic.IPv4Gateway != "" {
+			// LXC refuses to add an ipv4 gateway when the NIC is not
+			// brought up.
+			logger.Warningf(
+				"not setting IPv4 gateway %q for non-auto start interface %q",
+				nic.IPv4Gateway, nic.Name,
+			)
+			nic.IPv4Gateway = ""
+		}
+
 		data.Interfaces = append(data.Interfaces, nic)
 	}
 	templateName := multipleNICsTemplate

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -54,8 +54,18 @@ func CreateContainerWithMachineConfig(
 	machineConfig *cloudinit.MachineConfig,
 ) instance.Instance {
 
-	network := container.BridgeNetworkConfig("nic42", nil)
-	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", network)
+	networkConfig := container.BridgeNetworkConfig("nic42", nil)
+	return CreateContainerWithMachineAndNetworkConfig(c, manager, machineConfig, networkConfig)
+}
+
+func CreateContainerWithMachineAndNetworkConfig(
+	c *gc.C,
+	manager container.Manager,
+	machineConfig *cloudinit.MachineConfig,
+	networkConfig *container.NetworkConfig,
+) instance.Instance {
+
+	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", networkConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	c.Assert(hardware.String(), gc.Not(gc.Equals), "")


### PR DESCRIPTION
Building on top of #1459, this introduces a few more changes:

 * updateContainerConfig implemented, which allows to selectively
 update an existing LXC config (replacing or removing existing
 settings, and appending new ones) and write it back atomically.
 This is needed to allow overriding the network config of a cloned
 LXC container. Tested extensively.
 * appendToContainerConfig is replaced by the above method.
 * containertesting.CreateContainerWithMachineAndNetworkConfig
 helper added to facilitate better mock testing for container
 networking config.
 * Both when creating a new container and cloning an existing
 template, the correct network config is used. In the latter
 before it wasn't easy or even possible to do that in some
 cases.
 * While live testing I discovered a case where invalid LXC
 network config was generated (explicit ipv4.gateway set but
 on a non-auto-start NIC). Fixed and added a test.

Live tested on Local in a number of scenarios (with and without
lxc-clone and lxc-clone-aufs set to true, with a clean machine
and existing template containers). It seems to work smoothly.

(Review request: http://reviews.vapour.ws/r/790/)