### PR TITLE
worker/envworkermanager: close State if workers fail to start

### DIFF
--- a/worker/envworkermanager/envworkermanager.go
+++ b/worker/envworkermanager/envworkermanager.go
@@ -5,12 +5,13 @@ package envworkermanager
 
 import (
 	"github.com/juju/errors"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/state"
-	"github.com/juju/juju/worker"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"launchpad.net/tomb"
+
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
 )
 
 var logger = loggo.GetLogger("juju.worker.envworkermanager")
@@ -108,20 +109,25 @@ func (m *envWorkerManager) envIsAlive(envTag names.EnvironTag) error {
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to open state for environment %s", envTag.Id())
 		}
-
-		envRunner, err := m.startEnvWorkers(m.st, st)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		// Make sure the State is closed when the runner for the
-		// environment is done.
-		go func() {
-			envRunner.Wait()
+		closeState := func() {
 			err := st.Close()
 			if err != nil {
 				logger.Errorf("error closing state for env %s: %v", envTag.Id(), err)
 			}
+		}
+
+		envRunner, err := m.startEnvWorkers(m.st, st)
+		if err != nil {
+			closeState()
+			return nil, errors.Trace(err)
+		}
+
+		// Close State when the runner for the environment is done.
+		go func() {
+			envRunner.Wait()
+			closeState()
 		}()
+
 		return envRunner, nil
 	})
 }


### PR DESCRIPTION
If startEnvWorkers failed, the State instance created by envWorkerManager wasn't closed.

(Review request: http://reviews.vapour.ws/r/799/)