### PR TITLE
Fixes 1414424: FindId and RemveId don't filter on env-uuid field

### DIFF
--- a/state/collections.go
+++ b/state/collections.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/juju/utils/set"
@@ -159,12 +158,14 @@ func (c *envStateCollection) Find(query interface{}) *mgo.Query {
 	return c.Collection.Find(c.mungeQuery(query))
 }
 
-// FindId looks up a single document by _id. The id must be a string
-// or bson.ObjectId. The environment UUID will be automatically
-// prefixed on to the id if it's a string and the prefix isn't there
-// already.
+// FindId looks up a single document by _id. If the id is a string the
+// relevant environment UUID prefix will be added on to it. Otherwise, the
+// query will be handled as per Find().
 func (c *envStateCollection) FindId(id interface{}) *mgo.Query {
-	return c.Collection.FindId(c.mungeId(id))
+	if sid, ok := id.(string); ok {
+		return c.Collection.FindId(addEnvUUID(c.envUUID, sid))
+	}
+	return c.Find(bson.D{{"_id", id}})
 }
 
 // Remove deletes a single document using the query provided. The
@@ -173,10 +174,14 @@ func (c *envStateCollection) Remove(query interface{}) error {
 	return c.Collection.Remove(c.mungeQuery(query))
 }
 
-// RemoveId deletes a single document by id. The id will be handled as
-// per FindId().
+// RemoveId deletes a single document by id. If the id is a string the
+// relevant environment UUID prefix will be added on to it. Otherwise, the
+// query will be handled as per Find().
 func (c *envStateCollection) RemoveId(id interface{}) error {
-	return c.Collection.RemoveId(c.mungeId(id))
+	if sid, ok := id.(string); ok {
+		return c.Collection.RemoveId(addEnvUUID(c.envUUID, sid))
+	}
+	return c.Remove(bson.D{{"_id", id}})
 }
 
 // RemoveAll deletes all docuemnts that match a query. The query will
@@ -207,17 +212,6 @@ func (c *envStateCollection) mungeQuery(inq interface{}) bson.D {
 		panic("query must either be bson.D or nil")
 	}
 	return outq
-}
-
-func (c *envStateCollection) mungeId(id interface{}) interface{} {
-	switch idv := id.(type) {
-	case string:
-		return addEnvUUID(c.envUUID, idv)
-	case bson.ObjectId:
-		return idv
-	default:
-		panic(fmt.Sprintf("multi-environment collections only use string or ObjectId ids. got: %+v", id))
-	}
 }
 
 func addEnvUUID(envUUID, id string) string {

--- a/state/collections_test.go
+++ b/state/collections_test.go
@@ -127,6 +127,15 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 	// (otherwise tests may not fail when they should)
 	c.Assert(m0.Id(), gc.Equals, otherM0.Id())
 
+	getIfaceId := func(st *state.State) bson.ObjectId {
+		var doc bson.M
+		coll, closer := state.GetRawCollection(st, state.NetworkInterfacesC)
+		defer closer()
+		err := coll.Find(bson.D{{"env-uuid", st.EnvironUUID()}}).One(&doc)
+		c.Assert(err, jc.ErrorIsNil)
+		return doc["_id"].(bson.ObjectId)
+	}
+
 	// Also add a network interface to test collections with ObjectId ids
 	_, err := s.State.AddNetwork(state.NetworkInfo{"net1", "net1", "0.1.2.3/24", 0})
 	c.Assert(err, jc.ErrorIsNil)
@@ -138,14 +147,20 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Grab the document id of the just added network interface for use in tests.
-	ifaceId := func() bson.ObjectId {
-		var doc bson.M
-		coll, closer := state.GetRawCollection(s.State, state.NetworkInterfacesC)
-		defer closer()
-		err = coll.Find(nil).One(&doc)
-		c.Assert(err, jc.ErrorIsNil)
-		return doc["_id"].(bson.ObjectId)
-	}()
+	ifaceId := getIfaceId(s.State)
+
+	// Add a network interface to the other environment to test collections that rely on the env-uuid field.
+	_, err = st1.AddNetwork(state.NetworkInfo{"net2", "net2", "0.1.2.4/24", 0})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = otherM0.AddNetworkInterface(state.NetworkInterfaceInfo{
+		MACAddress:    "91:de:f1:02:f6:f0",
+		InterfaceName: "foo1",
+		NetworkName:   "net2",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Grab the document id of the network interface just added to the other environment for use in tests.
+	otherIfaceId := getIfaceId(st1)
 
 	machines0, closer := state.GetCollection(s.State, state.MachinesC)
 	defer closer()
@@ -259,12 +274,13 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 			expectedCount: 1,
 		},
 		{
-			label: "FindId panics if id isn't a string",
+			label: "FindId adds env-uuid field",
 			test: func() (int, error) {
-				machines0.FindId(99)
-				return 0, nil
+				return networkInterfaces.FindId(otherIfaceId).Count()
 			},
-			expectedPanic: "multi-environment collections only use string or ObjectId ids. got: 99",
+			// expect to find no networks, as we are searching with the id of
+			// the network in the other environment.
+			expectedCount: 0,
 		},
 		{
 			label: "Insert works",
@@ -328,12 +344,13 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 			expectedCount: 2, // Expect machine-1 in first env and machine-0 in second env
 		},
 		{
-			label: "RemoveId panics if id isn't a string",
+			label: "RemoveId filters by env-uuid field",
 			test: func() (int, error) {
-				machines0.RemoveId(99)
-				return 0, nil
+				err := networkInterfaces.RemoveId(otherIfaceId)
+				c.Assert(err, gc.ErrorMatches, "not found")
+				return networkInterfaces.Count()
 			},
-			expectedPanic: "multi-environment collections only use string or ObjectId ids. got: 99",
+			expectedCount: 1, // ensure doc was not removed
 		},
 		{
 			label: "RemoveAll filters by env",


### PR DESCRIPTION
Foward envStateCollection.FindId() to
envStateCollection.Find(bson.D{{"_id", id}}), which then "munges" the
full query. Do the same for RemoveId(). Update tests.

(Review request: http://reviews.vapour.ws/r/803/)