### PR TITLE
Actions :: Add Environment Variables to hook context 

### DIFF
--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -352,6 +352,13 @@ func (context *HookContext) HookVars(paths Paths) []string {
 			"JUJU_REMOTE_UNIT="+context.remoteUnitName,
 		)
 	}
+	if context.actionData != nil {
+		vars = append(vars,
+			"JUJU_ACTION_NAME="+context.actionData.ActionName,
+			"JUJU_ACTION_UUID="+context.actionData.ActionTag.Id(),
+			"JUJU_ACTION_TAG="+context.actionData.ActionTag.String(),
+		)
+	}
 	return append(vars, osDependentEnvVars(paths)...)
 }
 


### PR DESCRIPTION
Expose environment variables to the hook context for Actions:

  JUJU_ACTION_NAME : The name of the currently running action
  JUJU_ACTION_UUID : The unique identifier for the running action
  JUJU_ACTION_TAG : The tag representation of the running action

(Review request: http://reviews.vapour.ws/r/806/)