### PR TITLE
rpc/apiserver: close State only after connection is done

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -105,7 +105,7 @@ func (a *admin) doLogin(req params.LoginRequest) (params.LoginResultV1, error) {
 	}
 
 	// authedApi is the API method finder we'll use after getting logged in.
-	var authedApi rpc.MethodFinder = newApiRoot(a.root.state, a.root.resources, a.root)
+	var authedApi rpc.MethodFinder = newApiRoot(a.root.state, a.root.closeState, a.root.resources, a.root)
 
 	// Use the login validation function, if one was specified.
 	if a.srv.validator != nil {


### PR DESCRIPTION
rpc: added support for cleaning up an API root

This allows resources to be cleaned up after the connection is completely closed (as opposed to the existing Kill feature which allows resources to be shutdown in order to close the connection).

---

apiserver: close State once connection closed

Using resources to clean up a State connection used by the API means that the State could be closed while it's still being used, causing panics. The new Cleaner interface is now used to close State instead (when required).

Cleanup was implemented on both apiRoot and apiHandler because either one may be used for serving a connection.


(Review request: http://reviews.vapour.ws/r/808/)