### PR TITLE
EnvironProvider needs to understand multiple environments.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -600,7 +600,7 @@ func (c *Client) Close() error {
 
 // EnvironmentGet returns all environment settings.
 func (c *Client) EnvironmentGet() (map[string]interface{}, error) {
-	result := params.EnvironmentGetResults{}
+	result := params.EnvironmentConfigResults{}
 	err := c.facade.FacadeCall("EnvironmentGet", nil, &result)
 	return result.Config, err
 }

--- a/api/environmentmanager/environmentmanager.go
+++ b/api/environmentmanager/environmentmanager.go
@@ -31,6 +31,23 @@ func NewClient(st base.APICallCloser) *Client {
 	return &Client{ClientFacade: frontend, facade: backend}
 }
 
+// ConfigSkeleton returns config values to be used as a starting point for the
+// API caller to construct a valid environment specific config.  The provider
+// and region params are there for future use, and current behaviour expects
+// both of these to be empty.
+func (c *Client) ConfigSkeleton(provider, region string) (params.EnvironConfig, error) {
+	var result params.EnvironConfigResult
+	args := params.EnvironmentSkeletonConfigArgs{
+		Provider: provider,
+		Region:   region,
+	}
+	err := c.facade.FacadeCall("ConfigSkeleton", args, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return result.Config, nil
+}
+
 // CreateEnvironment creates a new environment using the account and
 // environment config specified in the args.
 func (c *Client) CreateEnvironment(owner string, account, config map[string]interface{}) (params.Environment, error) {

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -1107,8 +1107,8 @@ func (c *Client) AgentVersion() (params.AgentVersionResult, error) {
 
 // EnvironmentGet implements the server-side part of the
 // get-environment CLI command.
-func (c *Client) EnvironmentGet() (params.EnvironmentGetResults, error) {
-	result := params.EnvironmentGetResults{}
+func (c *Client) EnvironmentGet() (params.EnvironmentConfigResults, error) {
+	result := params.EnvironmentConfigResults{}
 	// Get the existing environment config from the state.
 	config, err := c.api.state.EnvironConfig()
 	if err != nil {

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -15,7 +15,16 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
+
+	// Register the providers for the field check test
+	_ "github.com/juju/juju/provider/azure"
+	_ "github.com/juju/juju/provider/ec2"
+	_ "github.com/juju/juju/provider/joyent"
+	_ "github.com/juju/juju/provider/local"
+	_ "github.com/juju/juju/provider/maas"
+	_ "github.com/juju/juju/provider/openstack"
 )
 
 type envManagerSuite struct {
@@ -105,6 +114,75 @@ func (s *envManagerSuite) TestNonAdminCannotCreateEnvironmentForSomeoneElse(c *g
 	owner := names.NewUserTag("external@remote")
 	_, err := s.envmanager.CreateEnvironment(s.createArgs(c, owner))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *envManagerSuite) TestRestrictedProviderFields(c *gc.C) {
+	s.setAPIUser(c, names.NewUserTag("non-admin@remote"))
+	for i, test := range []struct {
+		provider string
+		expected []string
+	}{
+		{
+			provider: "azure",
+			expected: []string{
+				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert",
+				"location"},
+		}, {
+			provider: "dummy",
+			expected: []string{
+				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert"},
+		}, {
+			provider: "joyent",
+			expected: []string{
+				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert"},
+		}, {
+			provider: "local",
+			expected: []string{
+				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert",
+				"container", "network-bridge", "root-dir"},
+		}, {
+			provider: "maas",
+			expected: []string{
+				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert",
+				"maas-server"},
+		}, {
+			provider: "openstack",
+			expected: []string{
+				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert",
+				"region", "auth-url", "auth-mode"},
+		},
+	} {
+		c.Logf("%d: %s provider", i, test.provider)
+		fields, err := environmentmanager.RestrictedProviderFields(s.envmanager, test.provider)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(fields, jc.SameContents, test.expected)
+	}
+}
+
+func (s *envManagerSuite) TestConfigSkeleton(c *gc.C) {
+	s.setAPIUser(c, names.NewUserTag("non-admin@remote"))
+
+	_, err := s.envmanager.ConfigSkeleton(
+		params.EnvironmentSkeletonConfigArgs{Provider: "ec2"})
+	c.Check(err, gc.ErrorMatches, `provider value "ec2" not valid`)
+	_, err = s.envmanager.ConfigSkeleton(
+		params.EnvironmentSkeletonConfigArgs{Region: "the sun"})
+	c.Check(err, gc.ErrorMatches, `region value "the sun" not valid`)
+
+	skeleton, err := s.envmanager.ConfigSkeleton(params.EnvironmentSkeletonConfigArgs{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The apiPort changes every test run as the dummy provider
+	// looks for a random open port.
+	apiPort := s.Environ.Config().APIPort()
+
+	c.Assert(skeleton.Config, jc.DeepEquals, params.EnvironConfig{
+		"type":        "dummy",
+		"ca-cert":     coretesting.CACert,
+		"state-port":  1234,
+		"api-port":    apiPort,
+		"syslog-port": 2345,
+	})
 }
 
 func (s *envManagerSuite) TestCreateEnvironmentValidatesConfig(c *gc.C) {

--- a/apiserver/environmentmanager/export_test.go
+++ b/apiserver/environmentmanager/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environmentmanager
+
+var ConfigValuesFromStateServer = configValuesFromStateServer
+
+func RestrictedProviderFields(em *EnvironmentManagerAPI, providerType string) ([]string, error) {
+	return em.restrictedProviderFields(providerType)
+}

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -143,6 +143,12 @@ type EnvironmentResult struct {
 	UUID  string
 }
 
+// EnvironmentSkeletonConfigArgs wraps the args for environmentmanager.SkeletonConfig.
+type EnvironmentSkeletonConfigArgs struct {
+	Provider string
+	Region   string
+}
+
 // EnvironmentCreateArgs holds the arguments that are necessary to create
 // and environment.
 type EnvironmentCreateArgs struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -512,9 +512,9 @@ type ProvisioningScriptResult struct {
 	Script string
 }
 
-// EnvironmentGetResults contains the result of EnvironmentGet client
-// API call.
-type EnvironmentGetResults struct {
+// EnvironmentConfigResults contains the result of client API calls
+// to get environment config values.
+type EnvironmentConfigResults struct {
 	Config map[string]interface{}
 }
 

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -660,7 +660,7 @@ func (s *BootstrapSuite) makeTestEnv(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	provider, err := environs.Provider(cfg.Type())
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.Prepare(nullContext(), cfg)
+	env, err := provider.PrepareForBootstrap(nullContext(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	envtesting.MustUploadFakeTools(s.toolsStorage, cfg.AgentStream(), cfg.AgentStream())

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -19,11 +19,22 @@ import (
 
 // A EnvironProvider represents a computing and storage provider.
 type EnvironProvider interface {
-	// Prepare prepares an environment for use. Any additional
+	// RestrictedConfigAttributes are provider specific attributes stored in
+	// the config that really cannot or should not be changed across
+	// environments running inside a single juju server.
+	RestrictedConfigAttributes() []string
+
+	// PrepareForCreateEnvironment prepares an environment for creation. Any
+	// additional configuration attributes are added to the config passed in
+	// and returned.  This allows providers to add additional required config
+	// for new environments that may be created in an existing juju server.
+	PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error)
+
+	// PrepareForBootstrap prepares an environment for use. Any additional
 	// configuration attributes in the returned environment should
 	// be saved to be used later. If the environment is already
 	// prepared, this call is equivalent to Open.
-	Prepare(ctx BootstrapContext, cfg *config.Config) (Environ, error)
+	PrepareForBootstrap(ctx BootstrapContext, cfg *config.Config) (Environ, error)
 
 	// Open opens the environment and returns it.
 	// The configuration must have come from a previously

--- a/environs/open.go
+++ b/environs/open.go
@@ -231,7 +231,7 @@ func prepare(ctx BootstrapContext, cfg *config.Config, info configstore.EnvironI
 		return nil, errors.Annotate(err, "cannot ensure uuid")
 	}
 
-	return p.Prepare(ctx, cfg)
+	return p.PrepareForBootstrap(ctx, cfg)
 }
 
 // ensureAdminSecret returns a config with a non-empty admin-secret.

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -244,7 +244,7 @@ func (s *configSuite) TestAvailabilitySetsEnabledDefault(c *gc.C) {
 		}
 		cfg, err := config.New(config.UseDefaults, attrs)
 		c.Assert(err, jc.ErrorIsNil)
-		env, err := azureEnvironProvider{}.Prepare(envtesting.BootstrapContext(c), cfg)
+		env, err := azureEnvironProvider{}.PrepareForBootstrap(envtesting.BootstrapContext(c), cfg)
 		c.Assert(err, jc.ErrorIsNil)
 		azureEnv := env.(*azureEnviron)
 		c.Assert(azureEnv.ecfg.availabilitySetsEnabled(), checker)
@@ -257,7 +257,7 @@ func (s *configSuite) TestAvailabilitySetsEnabledImmutable(c *gc.C) {
 	})
 	cfg, err := config.New(config.UseDefaults, makeAzureConfigMap(c))
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := azureEnvironProvider{}.Prepare(envtesting.BootstrapContext(c), cfg)
+	env, err := azureEnvironProvider{}.PrepareForBootstrap(envtesting.BootstrapContext(c), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err = env.Config().Apply(map[string]interface{}{"availability-sets-enabled": false})
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -39,8 +39,18 @@ func (prov azureEnvironProvider) Open(cfg *config.Config) (environs.Environ, err
 	return environ, nil
 }
 
-// Prepare is specified in the EnvironProvider interface.
-func (prov azureEnvironProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+func (prov azureEnvironProvider) RestrictedConfigAttributes() []string {
+	return []string{"location"}
+}
+
+// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
+func (p azureEnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
+}
+
+// PrepareForBootstrap is specified in the EnvironProvider interface.
+func (prov azureEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	// Set availability-sets-enabled to true
 	// by default, unless the user set a value.
 	if _, ok := cfg.AllAttrs()["availability-sets-enabled"]; !ok {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -537,7 +537,17 @@ func (p *environProvider) Open(cfg *config.Config) (environs.Environ, error) {
 	return env, nil
 }
 
-func (p *environProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+func (p *environProvider) RestrictedConfigAttributes() []string {
+	return nil
+}
+
+// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
+func (p *environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return p.prepare(cfg)
+}
+
+func (p *environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	cfg, err := p.prepare(cfg)
 	if err != nil {
 		return nil, err

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -302,12 +302,12 @@ func (s *ConfigSuite) TestPrepareInsertsUniqueControlBucket(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := envtesting.BootstrapContext(c)
-	env0, err := providerInstance.Prepare(ctx, cfg)
+	env0, err := providerInstance.PrepareForBootstrap(ctx, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	bucket0 := env0.(*environ).ecfg().controlBucket()
 	c.Assert(bucket0, gc.Matches, "[a-f0-9]{32}")
 
-	env1, err := providerInstance.Prepare(ctx, cfg)
+	env1, err := providerInstance.PrepareForBootstrap(ctx, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	bucket1 := env1.(*environ).ecfg().controlBucket()
 	c.Assert(bucket1, gc.Matches, "[a-f0-9]{32}")
@@ -324,7 +324,7 @@ func (s *ConfigSuite) TestPrepareDoesNotTouchExistingControlBucket(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	env, err := providerInstance.Prepare(envtesting.BootstrapContext(c), cfg)
+	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	bucket := env.(*environ).ecfg().controlBucket()
 	c.Assert(bucket, gc.Equals, "burblefoo")

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -31,6 +31,16 @@ func (environProvider) BoilerplateConfig() string {
 	return boilerplateConfig[1:]
 }
 
+// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+func (p environProvider) RestrictedConfigAttributes() []string {
+	return []string{"region"}
+}
+
+// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
+func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
+}
+
 func (p environProvider) Open(cfg *config.Config) (environs.Environ, error) {
 	logger.Infof("opening environment %q", cfg.Name())
 	e := new(environ)
@@ -42,7 +52,7 @@ func (p environProvider) Open(cfg *config.Config) (environs.Environ, error) {
 	return e, nil
 }
 
-func (p environProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	attrs := cfg.UnknownAttrs()
 	if _, ok := attrs["control-bucket"]; !ok {
 		uuid, err := utils.NewUUID()

--- a/provider/joyent/config_test.go
+++ b/provider/joyent/config_test.go
@@ -371,13 +371,13 @@ var prepareConfigTests = []struct {
 	err:    "invalid Joyent provider config: open .*: " + utils.NoSuchFileErrRegexp,
 }}
 
-func (s *ConfigSuite) TestPrepare(c *gc.C) {
+func (s *ConfigSuite) TestPrepareForBootstrap(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	for i, test := range prepareConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 		attrs := validPrepareAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)
-		preparedConfig, err := jp.Provider.Prepare(ctx, testConfig)
+		preparedConfig, err := jp.Provider.PrepareForBootstrap(ctx, testConfig)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 			attrs := preparedConfig.Config().AllAttrs()
@@ -401,7 +401,7 @@ func (s *ConfigSuite) TestPrepareWithDefaultKeyFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer os.Remove(keyFilePath)
 	testConfig := newConfig(c, attrs)
-	preparedConfig, err := jp.Provider.Prepare(ctx, testConfig)
+	preparedConfig, err := jp.Provider.PrepareForBootstrap(ctx, testConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	attrs = preparedConfig.Config().AllAttrs()
 	c.Check(attrs["private-key-path"], gc.Equals, jp.DefaultPrivateKey)

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -4,13 +4,13 @@
 package joyent
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/joyent/gocommon/client"
 	joyenterrors "github.com/joyent/gocommon/errors"
 	"github.com/joyent/gosdc/cloudapi"
 	"github.com/joyent/gosign/auth"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/environs"
@@ -33,7 +33,17 @@ func init() {
 
 var errNotImplemented = errors.New("not implemented in Joyent provider")
 
-func (joyentProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+func (joyentProvider) RestrictedConfigAttributes() []string {
+	return nil
+}
+
+// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
+func (joyentProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
+}
+
+func (joyentProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	preparedCfg, err := prepareConfig(cfg)
 	if err != nil {
 		return nil, err

--- a/provider/local/config.go
+++ b/provider/local/config.go
@@ -22,20 +22,23 @@ var checkIfRoot = func() bool {
 }
 
 // Attribute keys
-var (
+const (
+	BootstrapIpKey   = "bootstrap-ip"
 	ContainerKey     = "container"
+	NamespaceKey     = "namespace"
 	NetworkBridgeKey = "network-bridge"
 	RootDirKey       = "root-dir"
+	StoragePortKey   = "storage-port"
 )
 
 var (
 	configFields = schema.Fields{
 		RootDirKey:       schema.String(),
-		"bootstrap-ip":   schema.String(),
+		BootstrapIpKey:   schema.String(),
 		NetworkBridgeKey: schema.String(),
 		ContainerKey:     schema.String(),
-		"storage-port":   schema.ForceInt(),
-		"namespace":      schema.String(),
+		StoragePortKey:   schema.ForceInt(),
+		NamespaceKey:     schema.String(),
 	}
 	// The port defaults below are not entirely arbitrary.  Local user web
 	// frameworks often use 8000 or 8080, so I didn't want to use either of
@@ -45,9 +48,9 @@ var (
 		RootDirKey:       "",
 		NetworkBridgeKey: "",
 		ContainerKey:     string(instance.LXC),
-		"bootstrap-ip":   schema.Omit,
-		"storage-port":   8040,
-		"namespace":      "",
+		BootstrapIpKey:   schema.Omit,
+		StoragePortKey:   8040,
+		NamespaceKey:     "",
 	}
 )
 
@@ -67,7 +70,7 @@ func newEnvironConfig(config *config.Config, attrs map[string]interface{}) *envi
 // have the same local provider name, we need to have a simple way to
 // namespace the file locations, but more importantly the containers.
 func (c *environConfig) namespace() string {
-	return c.attrs["namespace"].(string)
+	return c.attrs[NamespaceKey].(string)
 }
 
 func (c *environConfig) rootDir() string {
@@ -123,7 +126,7 @@ func (c *environConfig) logDir() string {
 // As of 1.18 this is only set inside the environment, and not in the
 // .jenv file.
 func (c *environConfig) bootstrapIPAddress() string {
-	addr, _ := c.attrs["bootstrap-ip"].(string)
+	addr, _ := c.attrs[BootstrapIpKey].(string)
 	return addr
 }
 
@@ -132,7 +135,7 @@ func (c *environConfig) stateServerAddr() string {
 }
 
 func (c *environConfig) storagePort() int {
-	return c.attrs["storage-port"].(int)
+	return c.attrs[StoragePortKey].(int)
 }
 
 func (c *environConfig) storageAddr() string {

--- a/provider/local/config.go
+++ b/provider/local/config.go
@@ -22,14 +22,18 @@ var checkIfRoot = func() bool {
 }
 
 // Attribute keys
-var NetworkBridgeKey = "network-bridge"
+var (
+	ContainerKey     = "container"
+	NetworkBridgeKey = "network-bridge"
+	RootDirKey       = "root-dir"
+)
 
 var (
 	configFields = schema.Fields{
-		"root-dir":       schema.String(),
+		RootDirKey:       schema.String(),
 		"bootstrap-ip":   schema.String(),
 		NetworkBridgeKey: schema.String(),
-		"container":      schema.String(),
+		ContainerKey:     schema.String(),
 		"storage-port":   schema.ForceInt(),
 		"namespace":      schema.String(),
 	}
@@ -38,9 +42,9 @@ var (
 	// these, but did want the familiarity of using something in the 8000
 	// range.
 	configDefaults = schema.Defaults{
-		"root-dir":       "",
+		RootDirKey:       "",
 		NetworkBridgeKey: "",
-		"container":      string(instance.LXC),
+		ContainerKey:     string(instance.LXC),
 		"bootstrap-ip":   schema.Omit,
 		"storage-port":   8040,
 		"namespace":      "",
@@ -67,11 +71,11 @@ func (c *environConfig) namespace() string {
 }
 
 func (c *environConfig) rootDir() string {
-	return c.attrs["root-dir"].(string)
+	return c.attrs[RootDirKey].(string)
 }
 
 func (c *environConfig) container() instance.ContainerType {
-	return instance.ContainerType(c.attrs["container"].(string))
+	return instance.ContainerType(c.attrs[ContainerKey].(string))
 }
 
 // setDefaultNetworkBridge sets default network bridge if none is provided.

--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -150,7 +150,7 @@ func (s *configSuite) TestNamespace(c *gc.C) {
 
 func (s *configSuite) TestBootstrapAsRoot(c *gc.C) {
 	s.PatchValue(local.CheckIfRoot, func() bool { return true })
-	env, err := local.Provider.Prepare(envtesting.BootstrapContext(c), minimalConfig(c))
+	env, err := local.Provider.PrepareForBootstrap(envtesting.BootstrapContext(c), minimalConfig(c))
 	c.Assert(err, jc.ErrorIsNil)
 	_, _, _, err = env.Bootstrap(envtesting.BootstrapContext(c), environs.BootstrapParams{})
 	c.Assert(err, gc.ErrorMatches, "bootstrapping a local environment must not be done as root")

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -169,7 +169,7 @@ func (s *localJujuTestSuite) TestStartStop(c *gc.C) {
 
 func (s *localJujuTestSuite) testBootstrap(c *gc.C, cfg *config.Config) environs.Environ {
 	ctx := envtesting.BootstrapContext(c)
-	environ, err := local.Provider.Prepare(ctx, cfg)
+	environ, err := local.Provider.PrepareForBootstrap(ctx, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	availableTools := coretools.List{&coretools.Tools{
 		Version: version.Current,
@@ -353,7 +353,7 @@ func (s *localJujuTestSuite) TestBootstrapRemoveLeftovers(c *gc.C) {
 
 func (s *localJujuTestSuite) TestConstraintsValidator(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
-	env, err := local.Provider.Prepare(ctx, minimalConfig(c))
+	env, err := local.Provider.PrepareForBootstrap(ctx, minimalConfig(c))
 	c.Assert(err, jc.ErrorIsNil)
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -117,8 +117,18 @@ func (p environProvider) correctLocalhostURLs(cfg *config.Config, providerCfg *e
 
 var detectAptProxies = apt.DetectProxies
 
+// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+func (p environProvider) RestrictedConfigAttributes() []string {
+	return []string{ContainerKey, NetworkBridgeKey, RootDirKey}
+}
+
+// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
+func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
+}
+
 // Prepare implements environs.EnvironProvider.Prepare.
-func (p environProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	// The user must not set bootstrap-ip; this is determined by the provider,
 	// and its presence used to determine whether the environment has yet been
 	// bootstrapped.

--- a/provider/local/environprovider_test.go
+++ b/provider/local/environprovider_test.go
@@ -237,7 +237,7 @@ Acquire::magic::Proxy "none";
 			testConfig, err = baseConfig.Apply(test.extraConfig)
 			c.Assert(err, jc.ErrorIsNil)
 		}
-		env, err := provider.Prepare(envtesting.BootstrapContext(c), testConfig)
+		env, err := provider.PrepareForBootstrap(envtesting.BootstrapContext(c), testConfig)
 		c.Assert(err, jc.ErrorIsNil)
 
 		envConfig := env.Config()
@@ -293,7 +293,7 @@ func (s *prepareSuite) TestPrepareNamespace(c *gc.C) {
 		s.PatchValue(local.UserCurrent, func() (*user.User, error) {
 			return &user.User{Username: test.userOS}, test.userOSErr
 		})
-		env, err := provider.Prepare(envtesting.BootstrapContext(c), basecfg)
+		env, err := provider.PrepareForBootstrap(envtesting.BootstrapContext(c), basecfg)
 		if test.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			cfg := env.Config()
@@ -314,7 +314,7 @@ func (s *prepareSuite) TestPrepareProxySSH(c *gc.C) {
 	})
 	provider, err := environs.Provider("local")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := provider.Prepare(envtesting.BootstrapContext(c), basecfg)
+	env, err := provider.PrepareForBootstrap(envtesting.BootstrapContext(c), basecfg)
 	c.Assert(err, jc.ErrorIsNil)
 	// local provider sets proxy-ssh to false
 	c.Assert(env.Config().ProxySSH(), jc.IsFalse)
@@ -346,7 +346,7 @@ func (s *prepareSuite) TesteProxyLocalhostFix(c *gc.C) {
 		cfg, err := basecfg.Apply(proxyAttrValues)
 		c.Assert(err, jc.ErrorIsNil)
 		//this call should replace all loopback urls with bridge ip
-		env, err := provider.Prepare(envtesting.BootstrapContext(c), cfg)
+		env, err := provider.PrepareForBootstrap(envtesting.BootstrapContext(c), cfg)
 		c.Assert(err, jc.ErrorIsNil)
 
 		// verify that correct replacement took place

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -4,9 +4,9 @@
 package maas
 
 import (
-	"errors"
 	"net/http"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"launchpad.net/gomaasapi"
@@ -40,7 +40,17 @@ func (maasEnvironProvider) Open(cfg *config.Config) (environs.Environ, error) {
 var errAgentNameAlreadySet = errors.New(
 	"maas-agent-name is already set; this should not be set by hand")
 
-func (p maasEnvironProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+func (p maasEnvironProvider) RestrictedConfigAttributes() []string {
+	return []string{"maas-server"}
+}
+
+// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
+func (p maasEnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
+}
+
+func (p maasEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	attrs := cfg.UnknownAttrs()
 	oldName, found := attrs["maas-agent-name"]
 	if found && oldName != "" {

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -53,7 +53,7 @@ func (suite *EnvironProviderSuite) TestUnknownAttrsContainAgentName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := envtesting.BootstrapContext(c)
-	environ, err := suite.makeEnviron().Provider().Prepare(ctx, config)
+	environ, err := suite.makeEnviron().Provider().PrepareForBootstrap(ctx, config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	preparedConfig := environ.Config()
@@ -78,7 +78,7 @@ func (suite *EnvironProviderSuite) TestAgentNameShouldNotBeSetByHand(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err = suite.makeEnviron().Provider().Prepare(ctx, config)
+	_, err = suite.makeEnviron().Provider().PrepareForBootstrap(ctx, config)
 	c.Assert(err, gc.Equals, errAgentNameAlreadySet)
 }
 

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -4,9 +4,9 @@
 package manual
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/environs"
@@ -38,7 +38,18 @@ func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, cfg *environConfig
 	return nil
 }
 
-func (p manualProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+func (p manualProvider) RestrictedConfigAttributes() []string {
+	return []string{"bootstrap-host", "bootstrap-user"}
+}
+
+// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
+func (p manualProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	// Not even sure if this will ever make sense.
+	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
+}
+
+func (p manualProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	if _, ok := cfg.UnknownAttrs()["storage-auth-key"]; !ok {
 		uuid, err := utils.NewUUID()
 		if err != nil {

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -32,13 +32,13 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (s *providerSuite) TestPrepare(c *gc.C) {
+func (s *providerSuite) TestPrepareForBootstrap(c *gc.C) {
 	minimal := manual.MinimalConfigValues()
 	minimal["use-sshstorage"] = true
 	delete(minimal, "storage-auth-key")
 	testConfig, err := config.New(config.UseDefaults, minimal)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := manual.ProviderInstance.Prepare(envtesting.BootstrapContext(c), testConfig)
+	env, err := manual.ProviderInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), testConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := env.Config()
 	key, _ := cfg.UnknownAttrs()["storage-auth-key"].(string)
@@ -50,7 +50,7 @@ func (s *providerSuite) TestPrepareUseSSHStorage(c *gc.C) {
 	minimal["use-sshstorage"] = false
 	testConfig, err := config.New(config.UseDefaults, minimal)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = manual.ProviderInstance.Prepare(envtesting.BootstrapContext(c), testConfig)
+	_, err = manual.ProviderInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), testConfig)
 	c.Assert(err, gc.ErrorMatches, "use-sshstorage must not be specified")
 
 	s.PatchValue(manual.NewSSHStorage, func(sshHost, storageDir, storageTmpdir string) (storage.Storage, error) {
@@ -59,7 +59,7 @@ func (s *providerSuite) TestPrepareUseSSHStorage(c *gc.C) {
 	minimal["use-sshstorage"] = true
 	testConfig, err = config.New(config.UseDefaults, minimal)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = manual.ProviderInstance.Prepare(envtesting.BootstrapContext(c), testConfig)
+	_, err = manual.ProviderInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), testConfig)
 	c.Assert(err, gc.ErrorMatches, "initialising SSH storage failed: newSSHStorage failed")
 }
 
@@ -69,7 +69,7 @@ func (s *providerSuite) TestPrepareSetsUseSSHStorage(c *gc.C) {
 	testConfig, err := config.New(config.UseDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	env, err := manual.ProviderInstance.Prepare(envtesting.BootstrapContext(c), testConfig)
+	env, err := manual.ProviderInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), testConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := env.Config()
 	value := cfg.AllAttrs()["use-sshstorage"]

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -479,12 +479,12 @@ func (s *ConfigSuite) TestPrepareInsertsUniqueControlBucket(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := envtesting.BootstrapContext(c)
-	env0, err := providerInstance.Prepare(ctx, cfg)
+	env0, err := providerInstance.PrepareForBootstrap(ctx, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	bucket0 := env0.(*environ).ecfg().controlBucket()
 	c.Assert(bucket0, gc.Matches, "[a-f0-9]{32}")
 
-	env1, err := providerInstance.Prepare(ctx, cfg)
+	env1, err := providerInstance.PrepareForBootstrap(ctx, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	bucket1 := env1.(*environ).ecfg().controlBucket()
 	c.Assert(bucket1, gc.Matches, "[a-f0-9]{32}")
@@ -501,7 +501,7 @@ func (s *ConfigSuite) TestPrepareDoesNotTouchExistingControlBucket(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	env, err := providerInstance.Prepare(envtesting.BootstrapContext(c), cfg)
+	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	bucket := env.(*environ).ecfg().controlBucket()
 	c.Assert(bucket, gc.Equals, "burblefoo")

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -255,7 +255,17 @@ func (p environProvider) Open(cfg *config.Config) (environs.Environ, error) {
 	return e, nil
 }
 
-func (p environProvider) Prepare(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
+// RestrictedConfigAttributes is specified in the EnvironProvider interface.
+func (p environProvider) RestrictedConfigAttributes() []string {
+	return []string{"region", "auth-url", "auth-mode"}
+}
+
+// PrepareForCreateEnvironment is specified in the EnvironProvider interface.
+func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return nil, jujuerrors.NotImplementedf("PrepareForCreateEnvironment")
+}
+
+func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	attrs := cfg.UnknownAttrs()
 	if _, ok := attrs["control-bucket"]; !ok {
 		uuid, err := utils.NewUUID()

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -437,10 +437,10 @@ func (factory *Factory) MakeEnvironment(c *gc.C, params *EnvParams) *state.State
 		// Prepare the environment.
 		provider, err := environs.Provider(cfg.Type())
 		c.Assert(err, jc.ErrorIsNil)
-		env, err := provider.Prepare(nil, cfg)
+		cfg, err = provider.PrepareForCreateEnvironment(cfg)
 		c.Assert(err, jc.ErrorIsNil)
 		// Now save the config back.
-		err = st.UpdateEnvironConfig(env.Config().AllAttrs(), nil, nil)
+		err = st.UpdateEnvironConfig(cfg.AllAttrs(), nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	return st


### PR DESCRIPTION
Two extra methods are added to the EnvironProvider interface.

RestrictedConfigAttributes returns a list of strings of attributes that cannot be changed between different environments on a single state server.

Prepare has been renamed to PrepareForBootstrap.

An additional method has been added: PrepareForCreateEnvironment.

Almost all providers just return a not implemented error in this branch.  Most should also be simple to implement, but I didn't want to do too much here.

In order for the create environment CLI command to work properly we need to be able to construct a valid config on the client side, which means getting the skeleton values from the state server.  The API for getting the values has provider/region args which aren't used in this branch, but we know we need RSN.

(Review request: http://reviews.vapour.ws/r/811/)