### PR TITLE
cmd/jujud: integrate envWorkerManager into the machine agent

### DIFF
--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -143,67 +143,38 @@ type apiOpener interface {
 
 type configChanger func(c *agent.Config)
 
-// openAPIState opens the API using the given information, and
-// returns the opened state and the api entity with
-// the given tag. The given changeConfig function is
-// called if the password changes to set the password.
-func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.Entity, resultErr error) {
-	// We let the API dial fail immediately because the
-	// runner's loop outside the caller of openAPIState will
-	// keep on retrying. If we block for ages here,
-	// then the worker that's calling this cannot
-	// be interrupted.
+// OpenAPIState opens the API using the given information. The agent's
+// password is changed if the fallback password was used to connect to
+// the API.
+func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.Entity, outErr error) {
 	info := agentConfig.APIInfo()
-	st, err := apiOpen(info, api.DialOpts{})
-	usedOldPassword := false
-	if params.IsCodeUnauthorized(err) {
-		// We've perhaps used the wrong password, so
-		// try again with the fallback password.
-		infoCopy := *info
-		info = &infoCopy
-		info.Password = agentConfig.OldPassword()
-		usedOldPassword = true
-		st, err = apiOpen(info, api.DialOpts{})
-	}
-	// The provisioner may take some time to record the agent's
-	// machine instance ID, so wait until it does so.
-	if params.IsCodeNotProvisioned(err) {
-		for a := checkProvisionedStrategy.Start(); a.Next(); {
-			st, err = apiOpen(info, api.DialOpts{})
-			if !params.IsCodeNotProvisioned(err) {
-				break
-			}
-		}
-	}
+	st, usedOldPassword, err := openAPIStateUsingInfo(info, a, agentConfig.OldPassword())
 	if err != nil {
-		if params.IsCodeNotProvisioned(err) || params.IsCodeUnauthorized(err) {
-			logger.Errorf("agent terminating due to error returned during API open: %v", err)
-			return nil, nil, worker.ErrTerminateAgent
-		}
 		return nil, nil, err
 	}
 	defer func() {
-		if resultErr != nil && st != nil {
+		if outErr != nil && st != nil {
 			st.Close()
 		}
 	}()
+
 	entity, err := st.Agent().Entity(a.Tag())
 	if err == nil && entity.Life() == params.Dead {
 		logger.Errorf("agent terminating - entity %q is dead", a.Tag())
 		return nil, nil, worker.ErrTerminateAgent
 	}
+	if params.IsCodeUnauthorized(err) {
+		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)
+		return nil, nil, worker.ErrTerminateAgent
+	}
 	if err != nil {
-		if params.IsCodeUnauthorized(err) {
-			logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)
-			return nil, nil, worker.ErrTerminateAgent
-		}
 		return nil, nil, err
 	}
+
 	if usedOldPassword {
 		// We succeeded in connecting with the fallback
 		// password, so we need to create a new password
 		// for the future.
-
 		newPassword, err := utils.RandomPassword()
 		if err != nil {
 			return nil, nil, err
@@ -224,6 +195,7 @@ func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.
 			return nil, nil, err
 		}
 
+		// Reconnect to the API with the new password.
 		st.Close()
 		info.Password = newPassword
 		st, err = apiOpen(info, api.DialOpts{})
@@ -232,5 +204,51 @@ func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.
 		}
 	}
 
-	return st, entity, nil
+	return st, entity, err
+}
+
+// OpenAPIStateUsingInfo opens the API using the given API
+// information, and returns the opened state and the api entity with
+// the given tag.
+func OpenAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.State, error) {
+	st, _, err := openAPIStateUsingInfo(info, a, oldPassword)
+	return st, err
+}
+
+func openAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.State, bool, error) {
+	// We let the API dial fail immediately because the
+	// runner's loop outside the caller of openAPIState will
+	// keep on retrying. If we block for ages here,
+	// then the worker that's calling this cannot
+	// be interrupted.
+	st, err := apiOpen(info, api.DialOpts{})
+	usedOldPassword := false
+	if params.IsCodeUnauthorized(err) {
+		// We've perhaps used the wrong password, so
+		// try again with the fallback password.
+		infoCopy := *info
+		info = &infoCopy
+		info.Password = oldPassword
+		usedOldPassword = true
+		st, err = apiOpen(info, api.DialOpts{})
+	}
+	// The provisioner may take some time to record the agent's
+	// machine instance ID, so wait until it does so.
+	if params.IsCodeNotProvisioned(err) {
+		for a := checkProvisionedStrategy.Start(); a.Next(); {
+			st, err = apiOpen(info, api.DialOpts{})
+			if !params.IsCodeNotProvisioned(err) {
+				break
+			}
+		}
+	}
+	if err != nil {
+		if params.IsCodeNotProvisioned(err) || params.IsCodeUnauthorized(err) {
+			logger.Errorf("agent terminating due to error returned during API open: %v", err)
+			return nil, false, worker.ErrTerminateAgent
+		}
+		return nil, false, err
+	}
+
+	return st, usedOldPassword, nil
 }

--- a/worker/envworkermanager/envworkermanager.go
+++ b/worker/envworkermanager/envworkermanager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"gopkg.in/mgo.v2"
 	"launchpad.net/tomb"
 
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
@@ -45,6 +46,7 @@ type InitialState interface {
 	GetEnvironment(names.EnvironTag) (*state.Environment, error)
 	EnvironUUID() string
 	Machine(string) (*state.Machine, error)
+	MongoSession() *mgo.Session
 }
 
 type envWorkerManager struct {


### PR DESCRIPTION
Workers that need to start and stop on a per-environment basis are now managed by a envWorkerManager instance.

Related changes here:
- cleaner testing of machine agent worker starting
- TestManageEnvironDoesNotRunFirewallerWhenModeIsNone actually sets firewall-mode to "none" instead of passing by accident

(Review request: http://reviews.vapour.ws/r/813/)