### PR TITLE
featuretests: fixed data race in leadershipSuite.TestUnblock

### DIFF
--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -144,7 +144,7 @@ func (s *leadershipSuite) TestUnblock(c *gc.C) {
 
 	unblocked := make(chan struct{})
 	go func() {
-		err = client.BlockUntilLeadershipReleased(s.serviceId)
+		err := client.BlockUntilLeadershipReleased(s.serviceId)
 		c.Check(err, gc.IsNil)
 		unblocked <- struct{}{}
 	}()


### PR DESCRIPTION
Picked up by the Go race detector. Probably not serious but worth fixing.

(Review request: http://reviews.vapour.ws/r/820/)