### PR TITLE
cmd/jujud: fix panic due to prematurely closed state

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -919,6 +919,7 @@ func (a *MachineAgent) startEnvWorkers(
 	defer func() {
 		if err != nil && runner != nil {
 			runner.Kill()
+			runner.Wait()
 		}
 	}()
 	// Close the API connection when the runner for this environment dies.
@@ -939,10 +940,11 @@ func (a *MachineAgent) startEnvWorkers(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// Kill the singular runner when the main runner for this environment dies.
-	go func() {
-		runner.Wait()
-		singularRunner.Kill()
+	defer func() {
+		if err != nil && singularRunner != nil {
+			singularRunner.Kill()
+			singularRunner.Wait()
+		}
 	}()
 
 	// Start workers that depend on a *state.State.


### PR DESCRIPTION
When returning with an error, startEnvWorkers wasn't waiting for the runners it created to be done before returning. This meant that sometimes the envWorkerManager would close the State that was still in use by workers and pingers attached to those runners, causing panics.

This change also removes an unnecessary goroutine that was being used to kill the singular runner created by startEnvWorkers. Singular runners stop themselves when the underlying runner stops so there was no need for this.

(Review request: http://reviews.vapour.ws/r/821/)