### PR TITLE
Generated cloud-init userdata container now includes NICs config

### DIFF
--- a/container/export_test.go
+++ b/container/export_test.go
@@ -6,6 +6,7 @@ package container
 var (
 	NetworkInterfacesFile          = &networkInterfacesFile
 	NewCloudInitConfigWithNetworks = newCloudInitConfigWithNetworks
+	CloudInitUserData              = cloudInitUserData
 )
 
 // IsLocked is used just to see if the local lock instance is locked, and

--- a/container/export_test.go
+++ b/container/export_test.go
@@ -3,6 +3,11 @@
 
 package container
 
+var (
+	NetworkInterfacesFile          = &networkInterfacesFile
+	NewCloudInitConfigWithNetworks = newCloudInitConfigWithNetworks
+)
+
 // IsLocked is used just to see if the local lock instance is locked, and
 // is only required for use in tests.
 func IsLocked(lock *Lock) bool {

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -103,7 +103,7 @@ var startParams StartParams
 func (manager *containerManager) CreateContainer(
 	machineConfig *cloudinit.MachineConfig,
 	series string,
-	network *container.NetworkConfig,
+	networkConfig *container.NetworkConfig,
 ) (instance.Instance, *instance.HardwareCharacteristics, error) {
 
 	name := names.NewMachineTag(machineConfig.MachineId).String()
@@ -121,7 +121,7 @@ func (manager *containerManager) CreateContainer(
 		return nil, nil, errors.Annotate(err, "failed to create container directory")
 	}
 	logger.Tracef("write cloud-init")
-	userDataFilename, err := container.WriteUserData(machineConfig, directory)
+	userDataFilename, err := container.WriteUserData(machineConfig, networkConfig, directory)
 	if err != nil {
 		logger.Infof("machine config api %#v", *machineConfig.APIInfo)
 		err = errors.Annotate(err, "failed to write user data")
@@ -132,7 +132,7 @@ func (manager *containerManager) CreateContainer(
 	startParams = ParseConstraintsToStartParams(machineConfig.Constraints)
 	startParams.Arch = version.Current.Arch
 	startParams.Series = series
-	startParams.Network = network
+	startParams.Network = networkConfig
 	startParams.UserDataFile = userDataFilename
 
 	// If the Simplestream requested is anything but released, update

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -105,7 +105,7 @@ func AcquireTemplateLock(name, message string) (*container.Lock, error) {
 func EnsureCloneTemplate(
 	backingFilesystem string,
 	series string,
-	network *container.NetworkConfig,
+	networkConfig *container.NetworkConfig,
 	authorizedKeys string,
 	aptProxy proxy.Settings,
 	aptMirror string,
@@ -176,7 +176,7 @@ func EnsureCloneTemplate(
 	err = createContainer(
 		lxcContainer,
 		containerDirectory,
-		network,
+		networkConfig,
 		extraCreateArgs,
 		templateParams,
 		caCert,

--- a/container/userdata.go
+++ b/container/userdata.go
@@ -4,24 +4,33 @@
 package container
 
 import (
+	"bytes"
 	"io/ioutil"
 	"path/filepath"
+	"text/template"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	coreCloudinit "github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/environs/cloudinit"
+	"github.com/juju/juju/network"
 )
 
 var (
 	logger = loggo.GetLogger("juju.container")
 )
 
-// WriteUserData generates the cloud init for the specified machine config,
-// and writes the serialized form out to a cloud-init file in the directory
+// WriteUserData generates the cloud-init user-data using the
+// specified machine and network config for a container, and writes
+// the serialized form out to a cloud-init file in the directory
 // specified.
-func WriteUserData(machineConfig *cloudinit.MachineConfig, directory string) (string, error) {
-	userData, err := cloudInitUserData(machineConfig)
+func WriteUserData(
+	machineConfig *cloudinit.MachineConfig,
+	networkConfig *NetworkConfig,
+	directory string,
+) (string, error) {
+	userData, err := cloudInitUserData(machineConfig, networkConfig)
 	if err != nil {
 		logger.Errorf("failed to create user data: %v", err)
 		return "", err
@@ -40,8 +49,75 @@ func WriteCloudInitFile(directory string, userData []byte) (string, error) {
 	return userDataFilename, nil
 }
 
-func cloudInitUserData(machineConfig *cloudinit.MachineConfig) ([]byte, error) {
+// networkConfigTemplate defines how to render /etc/network/interfaces
+// file for a container with one or more NICs.
+const networkConfigTemplate = `{{define "static"}}
+{{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
+auto {{.InterfaceName}}{{end}}
+iface {{.InterfaceName}} inet static
+    address {{.Address.Value}}
+    netmask 255.255.255.255{{if gt (len .DNSServers) 0}}
+    dns-nameservers{{range $dns := .DNSServers}} {{$dns.Value}}{{end}}{{end}}
+    pre-up ip route add {{.GatewayAddress.Value}} dev {{.InterfaceName}}
+    pre-up ip route add default via {{.GatewayAddress.Value}}
+    post-down ip route del default via {{.GatewayAddress.Value}}
+    post-down ip route del {{.GatewayAddress.Value}} dev {{.InterfaceName}}
+{{end}}{{define "dhcp"}}
+{{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
+auto {{.InterfaceName}}{{end}}
+iface {{.InterfaceName}} inet dhcp
+{{end}}{{range $nic := . }}{{if eq $nic.ConfigType "static"}}
+{{template "static" $nic}}{{else}}{{template "dhcp" $nic}}{{end}}{{end}}`
+
+var networkInterfacesFile = "/etc/network/interfaces"
+
+// newCloudInitConfigWithNetworks creates a cloud-init config which
+// might include per-interface networking config if
+// networkConfig.Interfaces is not empty.
+func newCloudInitConfigWithNetworks(networkConfig *NetworkConfig) (*coreCloudinit.Config, error) {
 	cloudConfig := coreCloudinit.New()
+	if networkConfig == nil || len(networkConfig.Interfaces) == 0 {
+		// Don't generate networking config.
+		logger.Tracef("no cloud-init network config to generate")
+		return cloudConfig, nil
+	}
+
+	// TODO(dimitern) Just use the first NIC for now, add support
+	// for more later.
+	if len(networkConfig.Interfaces) != 1 {
+		logger.Tracef("multiple NICs in cloud-init network config not supported yet")
+		return cloudConfig, nil
+	}
+
+	// Add the loopback NIC which is always needed.
+	loopback := network.InterfaceInfo{
+		InterfaceName: "lo",
+		ConfigType:    network.ConfigDHCP,
+		NoAutoStart:   false,
+	}
+	allNICs := []network.InterfaceInfo{loopback, networkConfig.Interfaces[0]}
+
+	// Render the config first.
+	tmpl, err := template.New("config").Parse(networkConfigTemplate)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot parse cloud-init network config template")
+	}
+
+	var buf bytes.Buffer
+	if err = tmpl.Execute(&buf, allNICs); err != nil {
+		return nil, errors.Annotate(err, "cannot render cloud-init network config")
+	}
+
+	// Now add it to cloud-init as files.
+	cloudConfig.AddTextFile(networkInterfacesFile, buf.String(), 0644)
+	return cloudConfig, nil
+}
+
+func cloudInitUserData(
+	machineConfig *cloudinit.MachineConfig,
+	networkConfig *NetworkConfig,
+) ([]byte, error) {
+	cloudConfig, err := newCloudInitConfigWithNetworks(networkConfig)
 	udata, err := cloudinit.NewUserdataConfig(machineConfig, cloudConfig)
 	if err != nil {
 		return nil, err

--- a/container/userdata.go
+++ b/container/userdata.go
@@ -82,20 +82,13 @@ func newCloudInitConfigWithNetworks(networkConfig *NetworkConfig) (*coreCloudini
 		return cloudConfig, nil
 	}
 
-	// TODO(dimitern) Just use the first NIC for now, add support
-	// for more later.
-	if len(networkConfig.Interfaces) != 1 {
-		logger.Tracef("multiple NICs in cloud-init network config not supported yet")
-		return cloudConfig, nil
-	}
-
 	// Add the loopback NIC which is always needed.
 	loopback := network.InterfaceInfo{
 		InterfaceName: "lo",
 		ConfigType:    network.ConfigDHCP,
 		NoAutoStart:   false,
 	}
-	allNICs := []network.InterfaceInfo{loopback, networkConfig.Interfaces[0]}
+	allNICs := append([]network.InterfaceInfo{loopback}, networkConfig.Interfaces...)
 
 	// Render the config first.
 	tmpl, err := template.New("config").Parse(networkConfigTemplate)

--- a/container/userdata.go
+++ b/container/userdata.go
@@ -101,8 +101,8 @@ func newCloudInitConfigWithNetworks(networkConfig *NetworkConfig) (*coreCloudini
 		return nil, errors.Annotate(err, "cannot render cloud-init network config")
 	}
 
-	// Now add it to cloud-init as files.
-	cloudConfig.AddTextFile(networkInterfacesFile, buf.String(), 0644)
+	// Now add it to cloud-init as a file created early in the boot process.
+	cloudConfig.AddBootTextFile(networkInterfacesFile, buf.String(), 0644)
 	return cloudConfig, nil
 }
 

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -52,10 +52,9 @@ bootcmd:
 - install -D -m 644 /dev/null '`[1:] + s.networkInterfacesFile + `'
 - |-
   printf '%s\n' '
-  # interface "lo"
+  # loopback interface
   auto lo
-  iface lo inet dhcp
-
+  iface lo inet loopback
 
   # interface "eth0"
   auto eth0

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -48,7 +48,7 @@ func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 #cloud-config
-runcmd:
+bootcmd:
 - install -D -m 644 /dev/null '`[1:] + s.networkInterfacesFile + `'
 - |-
   printf '%s\n' '

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -1,0 +1,73 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package container_test
+
+import (
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloudinit"
+	"github.com/juju/juju/container"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/testing"
+)
+
+type UserDataSuite struct {
+	testing.BaseSuite
+
+	networkInterfacesFile string
+}
+
+var _ = gc.Suite(&UserDataSuite{})
+
+func (s *UserDataSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.networkInterfacesFile = filepath.Join(c.MkDir(), "interfaces")
+	s.PatchValue(container.NetworkInterfacesFile, s.networkInterfacesFile)
+}
+
+func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
+	// TODO(dimitern) Test all cases here.
+	ifaces := []network.InterfaceInfo{{
+		InterfaceName:  "eth0",
+		ConfigType:     network.ConfigStatic,
+		NoAutoStart:    false,
+		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		DNSServers:     network.NewAddresses("ns1.invalid", "ns2.invalid"),
+		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+	}}
+	netConfig := container.BridgeNetworkConfig("foo", ifaces)
+	cloudConf, err := container.NewCloudInitConfigWithNetworks(netConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	renderer, err := cloudinit.NewRenderer("quantal")
+	c.Assert(err, jc.ErrorIsNil)
+	data, err := renderer.Render(cloudConf)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := `
+#cloud-config
+runcmd:
+- install -D -m 644 /dev/null '`[1:] + s.networkInterfacesFile + `'
+- |-
+  printf '%s\n' '
+  # interface "lo"
+  auto lo
+  iface lo inet dhcp
+
+
+  # interface "eth0"
+  auto eth0
+  iface eth0 inet static
+      address 0.1.2.3
+      netmask 255.255.255.255
+      dns-nameservers ns1.invalid ns2.invalid
+      pre-up ip route add 0.1.2.1 dev eth0
+      pre-up ip route add default via 0.1.2.1
+      post-down ip route del default via 0.1.2.1
+      post-down ip route del 0.1.2.1 dev eth0
+  ' > '` + s.networkInterfacesFile + `'
+`
+	c.Assert(string(data), gc.Equals, expected)
+}


### PR DESCRIPTION
This is needed to allow generating /etc/network/interfaces file for containers.

(Review request: http://reviews.vapour.ws/r/822/)