### PR TITLE
Increase timeout to wait for maas node deployment

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -52,14 +52,6 @@ var shortAttempt = utils.AttemptStrategy{
 	Delay: 200 * time.Millisecond,
 }
 
-// longAttempt is used when we are polling for changes to
-// instance state. Such changes may involve a reboot so we
-// want to allow sufficient time for that to happen.
-var longAttempt = utils.AttemptStrategy{
-	Min:   60,
-	Delay: 10 * time.Second,
-}
-
 var (
 	ReleaseNodes         = releaseNodes
 	ReserveIPAddress     = reserveIPAddress
@@ -958,8 +950,19 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	}, nil
 }
 
+// Override for testing.
+var nodeDeploymentTimeout = func(environ *maasEnviron) time.Duration {
+	sshTimeouts := environ.Config().BootstrapSSHOpts()
+	return sshTimeouts.Timeout
+}
+
 func (environ *maasEnviron) waitForNodeDeployment(id instance.Id) error {
 	systemId := extractSystemId(id)
+	longAttempt := utils.AttemptStrategy{
+		Delay: 10 * time.Second,
+		Total: nodeDeploymentTimeout(environ),
+	}
+
 	for a := longAttempt.Start(); a.Next(); {
 		statusValues, err := environ.deploymentStatus(id)
 		if errors.IsNotImplemented(err) {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -56,8 +56,8 @@ var shortAttempt = utils.AttemptStrategy{
 // instance state. Such changes may involve a reboot so we
 // want to allow sufficient time for that to happen.
 var longAttempt = utils.AttemptStrategy{
-	Min:   50,
-	Delay: 5 * time.Second,
+	Min:   60,
+	Delay: 10 * time.Second,
 }
 
 var (
@@ -971,6 +971,7 @@ func (environ *maasEnviron) waitForNodeDeployment(id instance.Id) error {
 		if statusValues[systemId] == "Deployed" {
 			return nil
 		}
+		logger.Debugf("maas instance %v has status %q", id, statusValues[systemId])
 	}
 	return errors.Errorf("instance %q is started but not deployed", id)
 }

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	ShortAttempt = &shortAttempt
-	LongAttempt  = &longAttempt
 	APIVersion   = apiVersion
 )
 

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -4,6 +4,8 @@
 package maas
 
 import (
+	"time"
+
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gomaasapi"
 
@@ -22,12 +24,15 @@ type providerSuite struct {
 var _ = gc.Suite(&providerSuite{})
 
 func (s *providerSuite) SetUpSuite(c *gc.C) {
-	s.restoreTimeouts = envtesting.PatchAttemptStrategies(&shortAttempt, &longAttempt)
+	s.restoreTimeouts = envtesting.PatchAttemptStrategies(&shortAttempt)
 	s.BaseSuite.SetUpSuite(c)
 	TestMAASObject := gomaasapi.NewTestMAAS("1.0")
 	s.testMAASObject = TestMAASObject
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
 	s.AddSuiteCleanup(func(*gc.C) { restoreFinishBootstrap() })
+	s.PatchValue(&nodeDeploymentTimeout, func(*maasEnviron) time.Duration {
+		return coretesting.ShortWait
+	})
 }
 
 func (s *providerSuite) SetUpTest(c *gc.C) {


### PR DESCRIPTION
MAAS nodes can take longer to transition to deploy state that Juju allows for.
The time to wait has been increased to 600s.
Additional debug added to see what the node state is when polling.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1415961

(Review request: http://reviews.vapour.ws/r/825/)