### PR TITLE
worker/envworkermanager: always wait for master runner to die

### DIFF
--- a/worker/envworkermanager/envworkermanager.go
+++ b/worker/envworkermanager/envworkermanager.go
@@ -79,13 +79,14 @@ func (m *envWorkerManager) loop() error {
 				}
 			}
 		case <-m.runner.Dying():
-			// The runner for the environment is dying: wait for it to
-			// finish dying and report its error (if any).
+			// The master runner is dying: wait for it to finish dying
+			// and report its error (if any).
 			return m.runner.Wait()
 		case <-m.tomb.Dying():
 			// The envWorkerManager has been asked to die: kill the
-			// runner and stop.
+			// master runner and stop.
 			m.runner.Kill()
+			m.runner.Wait()
 			return tomb.ErrDying
 		}
 	}


### PR DESCRIPTION
Possible fix to panics being seen in CI (LP #1416006).

When the envWorkerManager is asked to shut down it didn't wait for the underlying runner to finish. This could result in State used by the runner and its child runners being closed before they're done.

(Review request: http://reviews.vapour.ws/r/826/)