### PR TITLE
Fixed lp:1416134 - don't ignore network-bridge for local/kvm

### DIFF
--- a/provider/local/config.go
+++ b/provider/local/config.go
@@ -81,11 +81,8 @@ func (c *environConfig) container() instance.ContainerType {
 	return instance.ContainerType(c.attrs[ContainerKey].(string))
 }
 
-// setDefaultNetworkBridge sets default network bridge if none is provided.
-// Default network bridge varies based on container type.
-// Originally, default values were returned in getter. However,
-// this meant that older clients were getting incorrect defaults
-// (http://pad.lv/1394450)
+// setDefaultNetworkBridge sets default network bridge if none is
+// provided. Default network bridge varies based on container type.
 func (c *environConfig) setDefaultNetworkBridge() {
 	name := c.networkBridge()
 	switch c.container() {
@@ -94,10 +91,7 @@ func (c *environConfig) setDefaultNetworkBridge() {
 			name = lxc.DefaultLxcBridge
 		}
 	case instance.KVM:
-		if name == "" || name == lxc.DefaultLxcBridge {
-			// Older versions of juju used "lxcbr0" by default,
-			// without checking the container type. See also
-			// http://pad.lv/1307677.
+		if name == "" {
 			name = kvm.DefaultKvmBridge
 		}
 	}

--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -88,13 +88,13 @@ func (s *configSuite) TestExplicitNetworkBridgeForLXCContainers(c *gc.C) {
 func (s *configSuite) TestExplicitNetworkBridgeForKVMContainers(c *gc.C) {
 	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
 		"container":      "kvm",
-		"network-bridge": "foo",
+		"network-bridge": "lxcbr0",
 	})
 	testConfig, err := config.New(config.NoDefaults, minAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
 	c.Check(containerType, gc.Equals, string(instance.KVM))
-	c.Check(bridgeName, gc.Equals, "foo")
+	c.Check(bridgeName, gc.Equals, "lxcbr0")
 }
 
 func (s *configSuite) TestDefaultNetworkBridgeForLXCContainers(c *gc.C) {

--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -62,19 +62,6 @@ func (s *configSuite) TestDefaultNetworkBridge(c *gc.C) {
 	c.Assert(unknownAttrs["network-bridge"], gc.Equals, "lxcbr0")
 }
 
-func (s *configSuite) TestDefaultNetworkBridgeForKVMContainersWithOldDefault(c *gc.C) {
-	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
-		"container":      "kvm",
-		"network-bridge": "lxcbr0",
-	})
-	testConfig, err := config.New(config.NoDefaults, minAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
-	c.Check(containerType, gc.Equals, string(instance.KVM))
-	//should have corrected default for kvm container
-	c.Check(bridgeName, gc.Equals, kvm.DefaultKvmBridge)
-}
-
 func (s *configSuite) TestDefaultNetworkBridgeForKVMContainers(c *gc.C) {
 	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
 		"container": "kvm",
@@ -84,6 +71,30 @@ func (s *configSuite) TestDefaultNetworkBridgeForKVMContainers(c *gc.C) {
 	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
 	c.Check(containerType, gc.Equals, string(instance.KVM))
 	c.Check(bridgeName, gc.Equals, kvm.DefaultKvmBridge)
+}
+
+func (s *configSuite) TestExplicitNetworkBridgeForLXCContainers(c *gc.C) {
+	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+		"container":      "lxc",
+		"network-bridge": "foo",
+	})
+	testConfig, err := config.New(config.NoDefaults, minAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
+	c.Check(containerType, gc.Equals, string(instance.LXC))
+	c.Check(bridgeName, gc.Equals, "foo")
+}
+
+func (s *configSuite) TestExplicitNetworkBridgeForKVMContainers(c *gc.C) {
+	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+		"container":      "kvm",
+		"network-bridge": "foo",
+	})
+	testConfig, err := config.New(config.NoDefaults, minAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
+	c.Check(containerType, gc.Equals, string(instance.KVM))
+	c.Check(bridgeName, gc.Equals, "foo")
 }
 
 func (s *configSuite) TestDefaultNetworkBridgeForLXCContainers(c *gc.C) {


### PR DESCRIPTION
Due to #1078, it became impossible to use lxcbr0 for local environments
where both container: kvm and network-bridge: lxcbr0 are set. This PR
fixes the issue for 1.23, but needs to be backported to 1.22 and 1.21 as
well.

See http://pad.lv/1416134 for more info.

Live tested on local provider with kvm containers and network-bridge set
to lxcbr0.

(Review request: http://reviews.vapour.ws/r/830/)