### PR TITLE
Fixed lp:1416134 - backport for 1.22

### DIFF
--- a/provider/local/config.go
+++ b/provider/local/config.go
@@ -76,9 +76,6 @@ func (c *environConfig) container() instance.ContainerType {
 
 // setDefaultNetworkBridge sets default network bridge if none is provided.
 // Default network bridge varies based on container type.
-// Originally, default values were returned in getter. However,
-// this meant that older clients were getting incorrect defaults
-// (http://pad.lv/1394450)
 func (c *environConfig) setDefaultNetworkBridge() {
 	name := c.networkBridge()
 	switch c.container() {
@@ -87,10 +84,7 @@ func (c *environConfig) setDefaultNetworkBridge() {
 			name = lxc.DefaultLxcBridge
 		}
 	case instance.KVM:
-		if name == "" || name == lxc.DefaultLxcBridge {
-			// Older versions of juju used "lxcbr0" by default,
-			// without checking the container type. See also
-			// http://pad.lv/1307677.
+		if name == "" {
 			name = kvm.DefaultKvmBridge
 		}
 	}

--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -62,7 +62,19 @@ func (s *configSuite) TestDefaultNetworkBridge(c *gc.C) {
 	c.Assert(unknownAttrs["network-bridge"], gc.Equals, "lxcbr0")
 }
 
-func (s *configSuite) TestDefaultNetworkBridgeForKVMContainersWithOldDefault(c *gc.C) {
+func (s *configSuite) TestExplicitNetworkBridgeForLXCContainers(c *gc.C) {
+	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+		"container":      "lxc",
+		"network-bridge": "foo",
+	})
+	testConfig, err := config.New(config.NoDefaults, minAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
+	c.Check(containerType, gc.Equals, string(instance.LXC))
+	c.Check(bridgeName, gc.Equals, "foo")
+}
+
+func (s *configSuite) TestExplicitNetworkBridgeForKVMContainers(c *gc.C) {
 	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
 		"container":      "kvm",
 		"network-bridge": "lxcbr0",
@@ -71,8 +83,7 @@ func (s *configSuite) TestDefaultNetworkBridgeForKVMContainersWithOldDefault(c *
 	c.Assert(err, jc.ErrorIsNil)
 	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
 	c.Check(containerType, gc.Equals, string(instance.KVM))
-	//should have corrected default for kvm container
-	c.Check(bridgeName, gc.Equals, kvm.DefaultKvmBridge)
+	c.Check(bridgeName, gc.Equals, "lxcbr0")
 }
 
 func (s *configSuite) TestDefaultNetworkBridgeForKVMContainers(c *gc.C) {


### PR DESCRIPTION
Just a backport of #1508 for 1.22.

Live tested on local/kvm.

(Review request: http://reviews.vapour.ws/r/831/)