### PR TITLE
Fixed lp:1416134 - backport for 1.21

### DIFF
--- a/provider/local/config.go
+++ b/provider/local/config.go
@@ -74,11 +74,8 @@ func (c *environConfig) container() instance.ContainerType {
 	return instance.ContainerType(c.attrs["container"].(string))
 }
 
-// setDefaultNetworkBridge sets default network bridge if none is provided.
-// Default network bridge varies based on container type.
-// Originally, default values were returned in getter. However,
-// this meant that older clients were getting incorrect defaults
-// (http://pad.lv/1394450)
+// setDefaultNetworkBridge sets default network bridge if none is
+// provided. Default network bridge varies based on container type.
 func (c *environConfig) setDefaultNetworkBridge() {
 	name := c.networkBridge()
 	switch c.container() {
@@ -87,10 +84,7 @@ func (c *environConfig) setDefaultNetworkBridge() {
 			name = lxc.DefaultLxcBridge
 		}
 	case instance.KVM:
-		if name == "" || name == lxc.DefaultLxcBridge {
-			// Older versions of juju used "lxcbr0" by default,
-			// without checking the container type. See also
-			// http://pad.lv/1307677.
+		if name == "" {
 			name = kvm.DefaultKvmBridge
 		}
 	}


### PR DESCRIPTION
Just a backport of #1508 for 1.21.

Live tested on local/kvm.

(Review request: http://reviews.vapour.ws/r/832/)