### PR TITLE
Fixed lp:1416425 - bump osext revision to latest

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,4 +1,4 @@
-bitbucket.org/kardianos/osext	hg	5d3ddcf53a508cc2f7404eaebf546ef2cb5cdb6e	12
+bitbucket.org/kardianos/osext	hg	44140c5fc69ecf1102c5ef451d73cd98ef59b178	14
 bitbucket.org/kardianos/service	hg	d2fd4f8afd23d9b5d57250b8d3f0bc0c8bf363ec	58
 code.google.com/p/go.crypto	hg	aa2644fe4aa50e3b38d75187b4799b1f0c9ddcef	212
 code.google.com/p/go.net	hg	c17ad62118ea511e1051721b429779fa40bddc74	116


### PR DESCRIPTION
Due to an updated LICENSE file. See http://pad.lv/1416425 for details.

(Review request: http://reviews.vapour.ws/r/833/)