### PR TITLE
cmd/jujud/agent: use valid config when adding extra environments

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1438,7 +1438,12 @@ func (s *MachineSuite) TestNewEnvironmentStartsNewWorkers(c *gc.C) {
 	c.Assert(workers, jc.DeepEquals, perEnvSingularWorkers)
 
 	// Now create a new environment and see the workers start for it.
-	factory.NewFactory(s.State).MakeEnvironment(c, nil).Close()
+	factory.NewFactory(s.State).MakeEnvironment(c, &factory.EnvParams{
+		ConfigAttrs: map[string]interface{}{
+			"state-server": false,
+		},
+		Prepare: true,
+	}).Close()
 	r1 := s.singularRecord.nextRunner(c)
 	workers = r1.waitForWorker(c, "firewaller")
 	c.Assert(workers, jc.DeepEquals, perEnvSingularWorkers)


### PR DESCRIPTION
TestNewEnvironmentStartsNewWorkers was using an environ config that the dummy provider didn't consider valid. The firewaller worker waits for a valid environment and was getting stuck when the machine agent was being stopped. Whether the problem was visible or not is highly timing dependent but was consistently occurring on some CI hosts.

Fixes LP #1416577.

(Review request: http://reviews.vapour.ws/r/839/)