### PR TITLE
Actions :: CLI - show timing

### DIFF
--- a/cmd/juju/action/fetch.go
+++ b/cmd/juju/action/fetch.go
@@ -95,5 +95,10 @@ func formatActionResult(result params.ActionResult) map[string]interface{} {
 		"status":  result.Status,
 		"message": result.Message,
 		"results": result.Output,
+		"timing": map[string]string{
+			"enqueued":  result.Enqueued.String(),
+			"started":   result.Started.String(),
+			"completed": result.Completed.String(),
+		},
 	}
 }

--- a/cmd/juju/action/fetch_test.go
+++ b/cmd/juju/action/fetch_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/juju/names"
 	gc "gopkg.in/check.v1"
@@ -99,12 +100,21 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 					"bar": "baz",
 				},
 			},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
-		expectedOutput: "message: oh dear\n" +
+		expectedOutput: "" +
+			"message: oh dear\n" +
 			"results:\n" +
 			"  foo:\n" +
 			"    bar: baz\n" +
-			"status: complete\n",
+			"status: complete\n" +
+			"timing:\n" +
+			"  completed: 2015-02-14 08:15:30 \\+0000 UTC\n" +
+			"  enqueued: 2015-02-14 08:13:00 \\+0000 UTC\n" +
+			"  started: 2015-02-14 08:15:00 \\+0000 UTC\n" +
+			"",
 	}}
 
 	for i, t := range tests {


### PR DESCRIPTION
Show Action timing (Enqueued, Started, Completed) in the CLI output of `juju action fetch <uuid>`

(Review request: http://reviews.vapour.ws/r/843/)