### PR TITLE
WIP: fix-1417178 make azure return a more sane error when no instances

### DIFF
--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -297,18 +297,20 @@ func rebootstrap(cfg *config.Config, ctx *cmd.Context, cons constraints.Value) (
 		return nil, err
 	}
 	instanceIds, err := env.StateServerInstances()
-	if err != nil {
+	if err != nil && err != environs.ErrNoInstances {
 		return nil, errors.Annotate(err, "cannot determine state server instances")
 	}
-	if len(instanceIds) == 0 {
+	if len(instanceIds) == 0 && err != environs.ErrNoInstances {
 		return nil, fmt.Errorf("no instances found; perhaps the environment was not bootstrapped")
 	}
-	inst, err := env.Instances(instanceIds)
-	if err == nil {
-		return nil, fmt.Errorf("old bootstrap instance %q still seems to exist; will not replace", inst)
-	}
-	if err != environs.ErrNoInstances {
-		return nil, errors.Annotate(err, "cannot detect whether old instance is still running")
+	if instanceIds != nil {
+		inst, err := env.Instances(instanceIds)
+		if err == nil {
+			return nil, fmt.Errorf("old bootstrap instance %q still seems to exist; will not replace", inst)
+		}
+		if err != environs.ErrNoInstances {
+			return nil, errors.Annotate(err, "cannot detect whether old instance is still running")
+		}
 	}
 	// Remove the storage so that we can bootstrap without the provider complaining.
 	if env, ok := env.(environs.EnvironStorage); ok {

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -414,7 +414,7 @@ func (env *azureEnviron) StateServerInstances() ([]instance.Id, error) {
 		stateServerInstanceIds = append(stateServerInstanceIds, instanceIds...)
 	}
 	if len(stateServerInstanceIds) == 0 {
-		return nil, environs.ErrNotBootstrapped
+		return nil, environs.ErrNoInstances
 	}
 	return stateServerInstanceIds, nil
 }


### PR DESCRIPTION
Azure returns ErrNotBootstrapped when it finds no
instances and it should be returning ErrNoInstances so
things like restore can tell the difference with an
env that was actually not bootstrapped

(Review request: http://reviews.vapour.ws/r/849/)