### PR TITLE
Fix restore/azure

### DIFF
--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -297,7 +297,7 @@ func rebootstrap(cfg *config.Config, ctx *cmd.Context, cons constraints.Value) (
 		return nil, err
 	}
 	instanceIds, err := env.StateServerInstances()
-	switch err {
+	switch errors.Cause(err) {
 	case nil, environs.ErrNoInstances:
 		// Some providers will return a nil error even
 		// if there are no live state server instances.
@@ -309,7 +309,7 @@ func rebootstrap(cfg *config.Config, ctx *cmd.Context, cons constraints.Value) (
 	}
 	if len(instanceIds) > 0 {
 		instances, err := env.Instances(instanceIds)
-		switch err {
+		switch errors.Cause(err) {
 		case nil, environs.ErrPartialInstances:
 			return nil, fmt.Errorf("old bootstrap instances %q still seems to exist; will not replace", instances)
 		case environs.ErrNoInstances:

--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -297,18 +297,25 @@ func rebootstrap(cfg *config.Config, ctx *cmd.Context, cons constraints.Value) (
 		return nil, err
 	}
 	instanceIds, err := env.StateServerInstances()
-	if err != nil && err != environs.ErrNoInstances {
+	switch err {
+	case nil, environs.ErrNoInstances:
+		// Some providers will return a nil error even
+		// if there are no live state server instances.
+		break
+	case environs.ErrNotBootstrapped:
+		return nil, errors.Trace(err)
+	default:
 		return nil, errors.Annotate(err, "cannot determine state server instances")
 	}
-	if len(instanceIds) == 0 && err != environs.ErrNoInstances {
-		return nil, fmt.Errorf("no instances found; perhaps the environment was not bootstrapped")
-	}
 	if len(instanceIds) > 0 {
-		inst, err := env.Instances(instanceIds)
-		if err == nil || err == environs.ErrPartialInstances {
-			return nil, fmt.Errorf("old bootstrap instance %q still seems to exist; will not replace", inst)
-		}
-		if err != environs.ErrNoInstances {
+		instances, err := env.Instances(instanceIds)
+		switch err {
+		case nil, environs.ErrPartialInstances:
+			return nil, fmt.Errorf("old bootstrap instances %q still seems to exist; will not replace", instances)
+		case environs.ErrNoInstances:
+			// No state server instances, so keep running.
+			break
+		default:
 			return nil, errors.Annotate(err, "cannot detect whether old instance is still running")
 		}
 	}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -286,7 +286,14 @@ func EnsureNotBootstrapped(env environs.Environ) error {
 	switch err {
 	case nil:
 		return environs.ErrAlreadyBootstrapped
-	case environs.ErrNoInstances, environs.ErrNotBootstrapped:
+	case environs.ErrNoInstances:
+		// TODO(axw) 2015-02-03 #1417526
+		// We should not be relying on this result,
+		// as it is possible for there to be no
+		// state servers despite the environment
+		// being bootstrapped.
+		fallthrough
+	case environs.ErrNotBootstrapped:
 		return nil
 	}
 	return err

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -283,7 +283,7 @@ func EnsureNotBootstrapped(env environs.Environ) error {
 	_, err := env.StateServerInstances()
 	// If there is no error determining state server instaces,
 	// then we are bootstrapped.
-	switch err {
+	switch errors.Cause(err) {
 	case nil:
 		return environs.ErrAlreadyBootstrapped
 	case environs.ErrNoInstances:

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -283,10 +283,10 @@ func EnsureNotBootstrapped(env environs.Environ) error {
 	_, err := env.StateServerInstances()
 	// If there is no error determining state server instaces,
 	// then we are bootstrapped.
-	if err == nil {
+	switch err {
+	case nil:
 		return environs.ErrAlreadyBootstrapped
-	}
-	if err == environs.ErrNotBootstrapped {
+	case environs.ErrNoInstances, environs.ErrNotBootstrapped:
 		return nil
 	}
 	return err

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -160,7 +160,9 @@ type Environ interface {
 
 	// StateServerInstances returns the IDs of instances corresponding
 	// to Juju state servers. If there are no state server instances,
-	// ErrNotBootstrapped is returned.
+	// ErrNoInstances is returned. If it can be determined that the
+	// environment has not been bootstrapped, then ErrNotBootstrapped
+	// should be returned instead.
 	StateServerInstances() ([]instance.Id, error)
 
 	// Destroy shuts down all known machines and destroys the

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -414,7 +414,7 @@ func (env *azureEnviron) StateServerInstances() ([]instance.Id, error) {
 		stateServerInstanceIds = append(stateServerInstanceIds, instanceIds...)
 	}
 	if len(stateServerInstanceIds) == 0 {
-		return nil, environs.ErrNotBootstrapped
+		return nil, environs.ErrNoInstances
 	}
 	return stateServerInstanceIds, nil
 }
@@ -1068,7 +1068,7 @@ func (env *azureEnviron) Instances(ids []instance.Id) ([]instance.Instance, erro
 		hostedServices[s.ServiceName] = hostedService
 	}
 
-	err = nil
+	var validInstances int
 	instances := make([]instance.Instance, len(ids))
 	for i, id := range instancesIds {
 		if id.serviceName == "" {
@@ -1079,14 +1079,20 @@ func (env *azureEnviron) Instances(ids []instance.Id) ([]instance.Instance, erro
 		instance, err := snap.getInstance(hostedService, id.roleName)
 		if err == nil {
 			instances[i] = instance
+			validInstances++
 		} else {
 			logger.Debugf("failed to get instance for role %q in service %q: %v", id.roleName, hostedService.ServiceName, err)
 		}
 	}
-	for _, instance := range instances {
-		if instance == nil {
-			err = environs.ErrPartialInstances
-		}
+
+	switch validInstances {
+	case len(instances):
+		err = nil
+	case 0:
+		instances = nil
+		err = environs.ErrNoInstances
+	default:
+		err = environs.ErrPartialInstances
 	}
 	return instances, err
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -244,10 +244,13 @@ func (suite *environSuite) TestInstancesReturnsErrNoInstancesIfNoInstancesReques
 }
 
 func (suite *environSuite) TestInstancesReturnsErrNoInstancesIfNoInstanceFound(c *gc.C) {
-	services := []gwacl.HostedServiceDescriptor{}
-	patchWithServiceListResponse(c, services)
 	env := makeEnviron(c)
-	instances, err := env.Instances([]instance.Id{"deploy-id"})
+	prefix := env.getEnvPrefix()
+	service := makeDeployment(env, prefix+"service")
+	service.Deployments = nil
+	patchInstancesResponses(c, prefix, service)
+
+	instances, err := env.Instances([]instance.Id{instance.Id(prefix + "service-unknown")})
 	c.Check(err, gc.Equals, environs.ErrNoInstances)
 	c.Check(instances, gc.IsNil)
 }
@@ -490,7 +493,7 @@ func (s *environSuite) TestStateServerInstancesFailsIfNoStateInstances(c *gc.C) 
 	patchInstancesResponses(c, prefix, service)
 
 	_, err := env.StateServerInstances()
-	c.Check(err, gc.Equals, environs.ErrNotBootstrapped)
+	c.Check(err, gc.Equals, environs.ErrNoInstances)
 }
 
 func (s *environSuite) TestStateServerInstancesNoLegacy(c *gc.C) {


### PR DESCRIPTION
Azure was returning ErrNotBootstrapped from its StateServerInstances
method, which is not necessarily true. In the restore scenario run
by QA, Azure is bootstrapped and then the state server instance is
killed OOB. So, we change the StateServerInstances method to return
ErrNotBootstrapped instead. The "EnsureNotBootstrapped" code still
assumes that the environment is not bootstrapped if this error is
returned from StateServerInstances (i.e. the conversion moves up a
level).

The Azure provider will now also handle the scenario where there
are cloud services without deployments, returning ErrNoInstances
instead of ErrPartialInstances.

We also update the restore plugin to check for: ErrPartialInstances
(multiple state server instances created, some but not all alive),
and ErrNoInstances in the result of StateServerInstances.

Fixes https://bugs.launchpad.net/juju-core/+bug/1417178

(Review request: http://reviews.vapour.ws/r/851/)