### PR TITLE
Unconditionally set proxy environment variables

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -594,6 +594,15 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	}
 
 	runner := newConnRunner(st)
+	// TODO(fwereade): this is *still* a hideous layering violation, but at least
+	// it's confined to jujud rather than extending into the worker itself.
+	// Start this worker first to try and get proxy settings in place
+	// before we do anything else.
+	writeSystemFiles := shouldWriteProxyFiles(agentConfig)
+	runner.StartWorker("proxyupdater", func() (worker.Worker, error) {
+		return proxyupdater.New(st.Environment(), writeSystemFiles), nil
+	})
+
 	runner.StartWorker("machiner", func() (worker.Worker, error) {
 		return machiner.NewMachiner(st.Machiner(), agentConfig), nil
 	})
@@ -613,13 +622,6 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	})
 	runner.StartWorker("logger", func() (worker.Worker, error) {
 		return workerlogger.NewLogger(st.Logger(), agentConfig), nil
-	})
-
-	// TODO(fwereade): this is *still* a hideous layering violation, but at least
-	// it's confined to jujud rather than extending into the worker itself.
-	writeSystemFiles := shouldWriteProxyFiles(agentConfig)
-	runner.StartWorker("proxyupdater", func() (worker.Worker, error) {
-		return proxyupdater.New(st.Environment(), writeSystemFiles), nil
 	})
 
 	runner.StartWorker("rsyslog", func() (worker.Worker, error) {

--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -157,6 +157,10 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 	}
 
 	runner := worker.NewRunner(cmdutil.ConnectionIsFatal(logger, st), cmdutil.MoreImportant)
+	// start proxyupdater first to ensure proxy settings are correct
+	runner.StartWorker("proxyupdater", func() (worker.Worker, error) {
+		return proxyupdater.New(st.Environment(), false), nil
+	})
 	runner.StartWorker("upgrader", func() (worker.Worker, error) {
 		return upgrader.NewUpgrader(
 			st.Upgrader(),
@@ -174,9 +178,6 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 			return nil, errors.Trace(err)
 		}
 		return uniter.NewUniter(uniterFacade, unitTag, dataDir, hookLock), nil
-	})
-	runner.StartWorker("proxyupdater", func() (worker.Worker, error) {
-		return proxyupdater.New(st.Environment(), false), nil
 	})
 
 	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -145,10 +145,10 @@ func (w *proxyWorker) writeEnvironment() error {
 }
 
 func (w *proxyWorker) handleProxyValues(proxySettings proxyutils.Settings) {
+	proxySettings.SetEnvironmentValues()
 	if proxySettings != w.proxy || w.first {
 		logger.Debugf("new proxy settings %#v", proxySettings)
 		w.proxy = proxySettings
-		w.proxy.SetEnvironmentValues()
 		if w.writeSystemFiles {
 			if err := w.writeEnvironment(); err != nil {
 				// It isn't really fatal, but we should record it.

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -187,6 +187,9 @@ func (s *ProxyUpdaterSuite) TestEnvironmentVariables(c *gc.C) {
 		c.Assert(os.Getenv(strings.ToUpper(proxy)), gc.Equals, value)
 	}
 	assertEnv("http_proxy", proxySettings.Http)
+	assertEnv("https_proxy", proxySettings.Https)
+	assertEnv("ftp_proxy", proxySettings.Ftp)
+	assertEnv("no_proxy", proxySettings.NoProxy)
 }
 
 func (s *ProxyUpdaterSuite) TestDontWriteSystemFiles(c *gc.C) {

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -164,6 +164,16 @@ func (s *ProxyUpdaterSuite) TestWriteSystemFiles(c *gc.C) {
 	s.waitForFile(c, apt.ConfFile, apt.ProxyContent(aptProxySettings)+"\n")
 }
 
+func (s *ProxyUpdaterSuite) TestEnvironmentVariables(c *gc.C) {
+	proxySettings, _ := s.updateConfig(c)
+
+	updater := proxyupdater.New(s.environmentAPI, true)
+	defer worker.Stop(updater)
+	s.waitForPostSetup(c)
+
+	s.waitProxySettings(c, proxySettings)
+}
+
 func (s *ProxyUpdaterSuite) TestDontWriteSystemFiles(c *gc.C) {
 	proxySettings, _ := s.updateConfig(c)
 

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -165,13 +166,27 @@ func (s *ProxyUpdaterSuite) TestWriteSystemFiles(c *gc.C) {
 }
 
 func (s *ProxyUpdaterSuite) TestEnvironmentVariables(c *gc.C) {
+	setenv := func(proxy, value string) {
+		os.Setenv(proxy, value)
+		os.Setenv(strings.ToUpper(proxy), value)
+	}
+	setenv("http_proxy", "foo")
+	setenv("https_proxy", "foo")
+	setenv("ftp_proxy", "foo")
+	setenv("no_proxy", "foo")
+
 	proxySettings, _ := s.updateConfig(c)
 
 	updater := proxyupdater.New(s.environmentAPI, true)
 	defer worker.Stop(updater)
 	s.waitForPostSetup(c)
-
 	s.waitProxySettings(c, proxySettings)
+
+	assertEnv := func(proxy, value string) {
+		c.Assert(os.Getenv(proxy), gc.Equals, value)
+		c.Assert(os.Getenv(strings.ToUpper(proxy)), gc.Equals, value)
+	}
+	assertEnv("http_proxy", proxySettings.Http)
 }
 
 func (s *ProxyUpdaterSuite) TestDontWriteSystemFiles(c *gc.C) {


### PR DESCRIPTION
Proxy environment variables, from environments.yaml, weren't being set. This changes them to be set unconditionally. In addition the proxyupdateworker is started before other workers. This should make it more likely that the environment (used by the net.DefaultClient) are in place before other workers that access the internet need them. 

With this change in place juju can be deployed, and charms deployed, behind a proxy. Manually tested. 

(Review request: http://reviews.vapour.ws/r/853/)