### PR TITLE
provider: remove unused constants

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -8,19 +8,18 @@
 package provider
 
 const (
-	Azure     = "azure"
-	Dummy     = "dummy"
-	EC2       = "ec2"
 	Joyent    = "joyent"
 	Local     = "local"
 	MAAS      = "maas"
-	Manual    = "manual"
-	Null      = "null"
-	OpenStack = "openstack"
 )
 
 // IsManual returns true iff the specified provider
 // type refers to the manual provider.
 func IsManual(provider string) bool {
-	return provider == Null || provider == Manual
+	switch provider {
+	case "null", "manual":
+		return true
+	default:
+		return false
+	}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -8,9 +8,9 @@
 package provider
 
 const (
-	Joyent    = "joyent"
-	Local     = "local"
-	MAAS      = "maas"
+	Joyent = "joyent"
+	Local  = "local"
+	MAAS   = "maas"
 )
 
 // IsManual returns true iff the specified provider


### PR DESCRIPTION
By its own admision this file should not exist. This PR is a first step towards its removal.

Importantly the purpose of this file is _not_ to enumerate all the known providers. This is for two reasons

1. If a set of provider names is required, it should be recovered from registered providers
2. The set of registered providers depends if they are registered or not, so making this list a set of all known providers is pointless if they are not registered.

(Review request: http://reviews.vapour.ws/r/856/)