### PR TITLE
Don't attempt to read a file if no juju home set.

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -629,6 +629,10 @@ func isEmpty(val interface{}) bool {
 //
 // The defined[attr+"-path"] key is always deleted.
 func maybeReadAttrFromFile(defined map[string]interface{}, attr, defaultPath string) error {
+	if !osenv.IsJujuHomeSet() {
+		logger.Debugf("JUJU_HOME not set, not attempting to read file %q", defaultPath)
+		return nil
+	}
 	pathAttr := attr + "-path"
 	path, _ := defined[pathAttr].(string)
 	delete(defined, pathAttr)

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1045,6 +1045,21 @@ func (s *ConfigSuite) TestConfigEmptyCertFiles(c *gc.C) {
 	}
 }
 
+func (s *ConfigSuite) TestNoDefinedPrivateCert(c *gc.C) {
+	// Server-side there is no juju home.
+	osenv.SetJujuHome("")
+	attrs := testing.Attrs{
+		"type":            "my-type",
+		"name":            "my-name",
+		"authorized-keys": testing.FakeAuthKeys,
+		"ca-cert":         testing.CACert,
+		"ca-private-key":  "",
+	}
+
+	_, err := config.New(config.UseDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *ConfigSuite) TestSafeModeDeprecatesGracefully(c *gc.C) {
 
 	cfg, err := config.New(config.UseDefaults, testing.Attrs{

--- a/juju/osenv/home.go
+++ b/juju/osenv/home.go
@@ -42,6 +42,13 @@ func JujuHome() string {
 	return jujuHome
 }
 
+// IsJujuHomeSet is a way to check if SetJuuHome has been called.
+func IsJujuHomeSet() bool {
+	jujuHomeMu.Lock()
+	defer jujuHomeMu.Unlock()
+	return jujuHome != ""
+}
+
 // JujuHomePath returns the path to a file in the
 // current juju home.
 func JujuHomePath(names ...string) string {

--- a/juju/osenv/home_test.go
+++ b/juju/osenv/home_test.go
@@ -6,20 +6,22 @@ package osenv_test
 import (
 	"path/filepath"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/testing"
 )
 
 type JujuHomeSuite struct {
-	jujuHome string
+	testing.BaseSuite
 }
 
 var _ = gc.Suite(&JujuHomeSuite{})
 
 func (s *JujuHomeSuite) TestStandardHome(c *gc.C) {
 	testJujuHome := c.MkDir()
-	defer osenv.SetJujuHome(osenv.SetJujuHome(testJujuHome))
+	osenv.SetJujuHome(testJujuHome)
 	c.Assert(osenv.JujuHome(), gc.Equals, testJujuHome)
 }
 
@@ -33,7 +35,13 @@ func (s *JujuHomeSuite) TestErrorHome(c *gc.C) {
 
 func (s *JujuHomeSuite) TestHomePath(c *gc.C) {
 	testJujuHome := c.MkDir()
-	defer osenv.SetJujuHome(osenv.SetJujuHome(testJujuHome))
+	osenv.SetJujuHome(testJujuHome)
 	envPath := osenv.JujuHomePath("environments.yaml")
 	c.Assert(envPath, gc.Equals, filepath.Join(testJujuHome, "environments.yaml"))
+}
+
+func (s *JujuHomeSuite) TestIsHomeSet(c *gc.C) {
+	c.Assert(osenv.IsJujuHomeSet(), jc.IsFalse)
+	osenv.SetJujuHome(c.MkDir())
+	c.Assert(osenv.IsJujuHomeSet(), jc.IsTrue)
 }

--- a/testing/base.go
+++ b/testing/base.go
@@ -27,6 +27,7 @@ var logger = loggo.GetLogger("juju.testing")
 // github.com/juju/testing, and this suite will be removed.
 // Do not use JujuOSEnvSuite when writing new tests.
 type JujuOSEnvSuite struct {
+	oldJujuHome    string
 	oldHomeEnv     string
 	oldEnvironment map[string]string
 }
@@ -53,6 +54,7 @@ func (s *JujuOSEnvSuite) SetUpTest(c *gc.C) {
 	// Update the feature flag set to be empty (given we have just set the
 	// environment value to the empty string)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+	s.oldJujuHome = osenv.SetJujuHome("")
 }
 
 func (s *JujuOSEnvSuite) TearDownTest(c *gc.C) {
@@ -60,6 +62,7 @@ func (s *JujuOSEnvSuite) TearDownTest(c *gc.C) {
 		os.Setenv(name, value)
 	}
 	utils.SetHome(s.oldHomeEnv)
+	osenv.SetJujuHome(s.oldJujuHome)
 }
 
 func (s *JujuOSEnvSuite) SetFeatureFlags(flag ...string) {


### PR DESCRIPTION
In order to validate some environ config instances server side, we want to make sure we don't try to read files from the $JUJU_HOME directory as there isn't one set.


(Review request: http://reviews.vapour.ws/r/870/)