### PR TITLE
Product of a 'make simplify' run.

### DIFF
--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -75,8 +75,8 @@ var unpackToolsBadDataTests = []badDataTest{
 	initBadDataTest("bar", os.ModeDir, "", "bad file type.*"),
 	initBadDataTest("../../etc/passwd", agenttools.DirPerm, "", "bad name.*"),
 	initBadDataTest(`\ini.sys`, agenttools.DirPerm, "", "bad name.*"),
-	badDataTest{[]byte("x"), "2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881", "unexpected EOF"},
-	badDataTest{gzyesses, "8d900c68a1a847aae4e95edcb29fcecd142c9b88ca4fe63209c216edbed546e1", "archive/tar: invalid tar header"},
+	{[]byte("x"), "2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881", "unexpected EOF"},
+	{gzyesses, "8d900c68a1a847aae4e95edcb29fcecd142c9b88ca4fe63209c216edbed546e1", "archive/tar: invalid tar header"},
 }
 
 func (t *ToolsSuite) TestUnpackToolsBadData(c *gc.C) {

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -37,7 +37,7 @@ func (s *actionSuite) TestServiceCharmActions(c *gc.C) {
 	}{{
 		description: "result from wrong service",
 		patchResults: []params.ServiceCharmActionsResult{
-			params.ServiceCharmActionsResult{
+			{
 				ServiceTag: names.NewServiceTag("bar").String(),
 			},
 		},
@@ -45,7 +45,7 @@ func (s *actionSuite) TestServiceCharmActions(c *gc.C) {
 	}, {
 		description: "some other error",
 		patchResults: []params.ServiceCharmActionsResult{
-			params.ServiceCharmActionsResult{
+			{
 				ServiceTag: names.NewServiceTag("foo").String(),
 				Error: &params.Error{
 					Message: "something bad",
@@ -56,8 +56,8 @@ func (s *actionSuite) TestServiceCharmActions(c *gc.C) {
 	}, {
 		description: "more than one result",
 		patchResults: []params.ServiceCharmActionsResult{
-			params.ServiceCharmActionsResult{},
-			params.ServiceCharmActionsResult{},
+			{},
+			{},
 		},
 		expectedErr: "2 results, expected 1",
 	}, {
@@ -71,11 +71,11 @@ func (s *actionSuite) TestServiceCharmActions(c *gc.C) {
 	}, {
 		description: "normal result",
 		patchResults: []params.ServiceCharmActionsResult{
-			params.ServiceCharmActionsResult{
+			{
 				ServiceTag: names.NewServiceTag("foo").String(),
 				Actions: &charm.Actions{
 					ActionSpecs: map[string]charm.ActionSpec{
-						"action": charm.ActionSpec{
+						"action": {
 							Description: "description",
 							Params: map[string]interface{}{
 								"foo": "bar",
@@ -87,7 +87,7 @@ func (s *actionSuite) TestServiceCharmActions(c *gc.C) {
 		},
 		expectedResult: &charm.Actions{
 			ActionSpecs: map[string]charm.ActionSpec{
-				"action": charm.ActionSpec{
+				"action": {
 					Description: "description",
 					Params: map[string]interface{}{
 						"foo": "bar",

--- a/api/facadeversions_test.go
+++ b/api/facadeversions_test.go
@@ -29,7 +29,7 @@ func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *gc.C) {
 	// code just to list out what versions are available. However, we do
 	// want to make sure that the two sides are kept in sync.
 	clientFacadeNames := set.NewStrings()
-	for name, _ := range *api.FacadeVersions {
+	for name := range *api.FacadeVersions {
 		clientFacadeNames.Add(name)
 	}
 	allServerFacades := common.Facades.List()
@@ -84,7 +84,7 @@ func (s *facadeVersionSuite) TestBestFacadeVersionExactMatch(c *gc.C) {
 	s.PatchValue(api.FacadeVersions, map[string]int{"Client": 1})
 	st := api.NewTestingState(api.TestingStateParams{
 		FacadeVersions: map[string][]int{
-			"Client": []int{0, 1},
+			"Client": {0, 1},
 		}})
 	c.Check(st.BestFacadeVersion("Client"), gc.Equals, 1)
 }
@@ -93,7 +93,7 @@ func (s *facadeVersionSuite) TestBestFacadeVersionNewerServer(c *gc.C) {
 	s.PatchValue(api.FacadeVersions, map[string]int{"Client": 1})
 	st := api.NewTestingState(api.TestingStateParams{
 		FacadeVersions: map[string][]int{
-			"Client": []int{0, 1, 2},
+			"Client": {0, 1, 2},
 		}})
 	c.Check(st.BestFacadeVersion("Client"), gc.Equals, 1)
 }
@@ -102,7 +102,7 @@ func (s *facadeVersionSuite) TestBestFacadeVersionNewerClient(c *gc.C) {
 	s.PatchValue(api.FacadeVersions, map[string]int{"Client": 2})
 	st := api.NewTestingState(api.TestingStateParams{
 		FacadeVersions: map[string][]int{
-			"Client": []int{0, 1},
+			"Client": {0, 1},
 		}})
 	c.Check(st.BestFacadeVersion("Client"), gc.Equals, 1)
 }
@@ -111,7 +111,7 @@ func (s *facadeVersionSuite) TestBestFacadeVersionServerUnknown(c *gc.C) {
 	s.PatchValue(api.FacadeVersions, map[string]int{"TestingAPI": 2})
 	st := api.NewTestingState(api.TestingStateParams{
 		FacadeVersions: map[string][]int{
-			"Client": []int{0, 1},
+			"Client": {0, 1},
 		}})
 	c.Check(st.BestFacadeVersion("TestingAPI"), gc.Equals, 0)
 }

--- a/api/leadership/client_test.go
+++ b/api/leadership/client_test.go
@@ -58,7 +58,7 @@ func (s *clientSuite) TestClaimLeadershipTranslation(c *gc.C) {
 
 			typedR, ok := response.(*params.ClaimLeadershipBulkResults)
 			c.Assert(ok, gc.Equals, true)
-			typedR.Results = []params.ClaimLeadershipResults{params.ClaimLeadershipResults{
+			typedR.Results = []params.ClaimLeadershipResults{{
 				ClaimDurationInSec: claimTime.Seconds(),
 			}}
 
@@ -88,7 +88,7 @@ func (s *clientSuite) TestClaimLeadershipErrorTranslation(c *gc.C) {
 			numStubCalls++
 			typedR, ok := response.(*params.ClaimLeadershipBulkResults)
 			c.Assert(ok, gc.Equals, true)
-			typedR.Results = []params.ClaimLeadershipResults{params.ClaimLeadershipResults{
+			typedR.Results = []params.ClaimLeadershipResults{{
 				Error: &params.Error{Message: errMsg},
 			}}
 			return nil

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -301,7 +301,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(instanceId, gc.Equals, instance.Id("i-manager"))
 
 	// Check the networks are created.
-	for i, _ := range networks {
+	for i := range networks {
 		if i == 3 {
 			// Last one was ignored, so skip it.
 			break

--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -77,9 +77,9 @@ func (s *stateSuite) TestAllMachinePortsV1(c *gc.C) {
 	portsMap, err := s.uniter.AllMachinePorts(s.wordpressMachine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(portsMap, jc.DeepEquals, map[network.PortRange]params.RelationUnit{
-		network.PortRange{100, 200, "tcp"}: params.RelationUnit{Unit: s.wordpressUnit.Tag().String()},
-		network.PortRange{10, 20, "udp"}:   params.RelationUnit{Unit: s.wordpressUnit.Tag().String()},
-		network.PortRange{201, 250, "tcp"}: params.RelationUnit{Unit: wordpressUnit1.Tag().String()},
-		network.PortRange{1, 8, "udp"}:     params.RelationUnit{Unit: wordpressUnit1.Tag().String()},
+		network.PortRange{100, 200, "tcp"}: {Unit: s.wordpressUnit.Tag().String()},
+		network.PortRange{10, 20, "udp"}:   {Unit: s.wordpressUnit.Tag().String()},
+		network.PortRange{201, 250, "tcp"}: {Unit: wordpressUnit1.Tag().String()},
+		network.PortRange{1, 8, "udp"}:     {Unit: wordpressUnit1.Tag().String()},
 	})
 }

--- a/apiserver/action/action_test.go
+++ b/apiserver/action/action_test.go
@@ -576,7 +576,7 @@ func (s *actionSuite) TestCancel(c *gc.C) {
 
 func (s *actionSuite) TestServicesCharmActions(c *gc.C) {
 	actionSchemas := map[string]map[string]interface{}{
-		"snapshot": map[string]interface{}{
+		"snapshot": {
 			"type":        "object",
 			"title":       "snapshot",
 			"description": "Take a snapshot of the database.",
@@ -588,7 +588,7 @@ func (s *actionSuite) TestServicesCharmActions(c *gc.C) {
 				},
 			},
 		},
-		"fakeaction": map[string]interface{}{
+		"fakeaction": {
 			"type":        "object",
 			"title":       "fakeaction",
 			"description": "No description",
@@ -602,11 +602,11 @@ func (s *actionSuite) TestServicesCharmActions(c *gc.C) {
 		serviceNames: []string{"dummy"},
 		expectedResults: params.ServicesCharmActionsResults{
 			Results: []params.ServiceCharmActionsResult{
-				params.ServiceCharmActionsResult{
+				{
 					ServiceTag: names.NewServiceTag("dummy").String(),
 					Actions: &charm.Actions{
 						ActionSpecs: map[string]charm.ActionSpec{
-							"snapshot": charm.ActionSpec{
+							"snapshot": {
 								Description: "Take a snapshot of the database.",
 								Params:      actionSchemas["snapshot"],
 							},
@@ -619,11 +619,11 @@ func (s *actionSuite) TestServicesCharmActions(c *gc.C) {
 		serviceNames: []string{"wordpress"},
 		expectedResults: params.ServicesCharmActionsResults{
 			Results: []params.ServiceCharmActionsResult{
-				params.ServiceCharmActionsResult{
+				{
 					ServiceTag: names.NewServiceTag("wordpress").String(),
 					Actions: &charm.Actions{
 						ActionSpecs: map[string]charm.ActionSpec{
-							"fakeaction": charm.ActionSpec{
+							"fakeaction": {
 								Description: "No description",
 								Params:      actionSchemas["fakeaction"],
 							},
@@ -636,7 +636,7 @@ func (s *actionSuite) TestServicesCharmActions(c *gc.C) {
 		serviceNames: []string{"nonsense"},
 		expectedResults: params.ServicesCharmActionsResults{
 			Results: []params.ServiceCharmActionsResult{
-				params.ServiceCharmActionsResult{
+				{
 					ServiceTag: names.NewServiceTag("nonsense").String(),
 					Error: &params.Error{
 						Message: `service "nonsense" not found`,

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -267,7 +267,7 @@ func (s *loginSuite) TestLoginAddrs(c *gc.C) {
 	connectedAddrPort, err := strconv.Atoi(connectedAddrPortString)
 	c.Assert(err, jc.ErrorIsNil)
 	connectedAddrHostPorts := [][]network.HostPort{
-		[]network.HostPort{{
+		{{
 			network.NewAddress(connectedAddrHost, network.ScopeUnknown),
 			connectedAddrPort,
 		}},

--- a/apiserver/annotations/client_test.go
+++ b/apiserver/annotations/client_test.go
@@ -78,7 +78,7 @@ func (s *annotationSuite) TestServiceAnnotations(c *gc.C) {
 
 func (s *annotationSuite) assertAnnotationsRemoval(c *gc.C, tag names.Tag) {
 	entity := tag.String()
-	entities := params.Entities{[]params.Entity{params.Entity{entity}}}
+	entities := params.Entities{[]params.Entity{{entity}}}
 	ann := s.annotationsApi.Get(entities)
 	c.Assert(ann.Results, gc.HasLen, 1)
 
@@ -89,7 +89,7 @@ func (s *annotationSuite) assertAnnotationsRemoval(c *gc.C, tag names.Tag) {
 
 func (s *annotationSuite) TestInvalidEntityAnnotations(c *gc.C) {
 	entity := "charm-invalid"
-	entities := params.Entities{[]params.Entity{params.Entity{entity}}}
+	entities := params.Entities{[]params.Entity{{entity}}}
 	annotations := map[string]string{"mykey": "myvalue"}
 
 	setResult := s.annotationsApi.Set(
@@ -211,8 +211,8 @@ func (s *annotationSuite) TestMultipleEntitiesAnnotations(c *gc.C) {
 	c.Assert(oneError, gc.Matches, ".*does not support annotations.*")
 
 	got := s.annotationsApi.Get(params.Entities{[]params.Entity{
-		params.Entity{rEntity},
-		params.Entity{sEntity}}})
+		{rEntity},
+		{sEntity}}})
 	c.Assert(got.Results, gc.HasLen, 2)
 
 	var rGet, sGet bool
@@ -241,7 +241,7 @@ func (s *annotationSuite) testSetGetEntitiesAnnotations(c *gc.C, tag names.Tag) 
 		if t.err != "" {
 			continue
 		}
-		aResult := s.assertGetEntityAnnotations(c, params.Entities{[]params.Entity{params.Entity{entity}}}, entity, t.expected)
+		aResult := s.assertGetEntityAnnotations(c, params.Entities{[]params.Entity{{entity}}}, entity, t.expected)
 		s.cleanupEntityAnnotations(c, entities, aResult)
 	}
 }

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -55,7 +55,7 @@ func (s *baseCharmsSuite) TestClientCharmInfo(c *gc.C) {
 			url:   "local:quantal/dummy-1",
 			expectedActions: &charm.Actions{
 				ActionSpecs: map[string]charm.ActionSpec{
-					"snapshot": charm.ActionSpec{
+					"snapshot": {
 						Description: "Take a snapshot of the database.",
 						Params: map[string]interface{}{
 							"type":        "object",
@@ -78,7 +78,7 @@ func (s *baseCharmsSuite) TestClientCharmInfo(c *gc.C) {
 			// Use wordpress for tests so that we can compare Provides and Requires.
 			charm: "wordpress",
 			expectedActions: &charm.Actions{ActionSpecs: map[string]charm.ActionSpec{
-				"fakeaction": charm.ActionSpec{
+				"fakeaction": {
 					Description: "No description",
 					Params: map[string]interface{}{
 						"type":        "object",

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -196,27 +196,27 @@ var scenarioStatus = &api.Status{
 		},
 	},
 	Services: map[string]api.ServiceStatus{
-		"logging": api.ServiceStatus{
+		"logging": {
 			Charm: "local:quantal/logging-1",
 			Relations: map[string][]string{
-				"logging-directory": []string{"wordpress"},
+				"logging-directory": {"wordpress"},
 			},
 			SubordinateTo: []string{"wordpress"},
 		},
-		"mysql": api.ServiceStatus{
+		"mysql": {
 			Charm:         "local:quantal/mysql-1",
 			Relations:     map[string][]string{},
 			SubordinateTo: []string{},
 			Units:         map[string]api.UnitStatus{},
 		},
-		"wordpress": api.ServiceStatus{
+		"wordpress": {
 			Charm: "local:quantal/wordpress-3",
 			Relations: map[string][]string{
-				"logging-dir": []string{"logging"},
+				"logging-dir": {"logging"},
 			},
 			SubordinateTo: []string{},
 			Units: map[string]api.UnitStatus{
-				"wordpress/0": api.UnitStatus{
+				"wordpress/0": {
 					Agent: api.AgentStatus{
 						Status: "error",
 						Info:   "blam",
@@ -226,7 +226,7 @@ var scenarioStatus = &api.Status{
 					AgentStateInfo: "(error: blam)",
 					Machine:        "1",
 					Subordinates: map[string]api.UnitStatus{
-						"logging/0": api.UnitStatus{
+						"logging/0": {
 							Agent: api.AgentStatus{
 								Status: "allocating",
 								Data:   make(map[string]interface{}),
@@ -235,7 +235,7 @@ var scenarioStatus = &api.Status{
 						},
 					},
 				},
-				"wordpress/1": api.UnitStatus{
+				"wordpress/1": {
 					Agent: api.AgentStatus{
 						Status: "allocating",
 						Data:   make(map[string]interface{}),
@@ -243,7 +243,7 @@ var scenarioStatus = &api.Status{
 					AgentState: "allocating",
 					Machine:    "2",
 					Subordinates: map[string]api.UnitStatus{
-						"logging/1": api.UnitStatus{
+						"logging/1": {
 							Agent: api.AgentStatus{
 								Status: "allocating",
 								Data:   make(map[string]interface{}),
@@ -256,17 +256,17 @@ var scenarioStatus = &api.Status{
 		},
 	},
 	Relations: []api.RelationStatus{
-		api.RelationStatus{
+		{
 			Id:  0,
 			Key: "logging:logging-directory wordpress:logging-dir",
 			Endpoints: []api.EndpointStatus{
-				api.EndpointStatus{
+				{
 					ServiceName: "logging",
 					Name:        "logging-directory",
 					Role:        "requirer",
 					Subordinate: true,
 				},
-				api.EndpointStatus{
+				{
 					ServiceName: "wordpress",
 					Name:        "logging-dir",
 					Role:        "provider",

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -802,7 +802,7 @@ func (s *clientSuite) TestClientCharmInfo(c *gc.C) {
 			url:   "local:quantal/dummy-1",
 			expectedActions: &charm.Actions{
 				ActionSpecs: map[string]charm.ActionSpec{
-					"snapshot": charm.ActionSpec{
+					"snapshot": {
 						Description: "Take a snapshot of the database.",
 						Params: map[string]interface{}{
 							"type":        "object",
@@ -825,7 +825,7 @@ func (s *clientSuite) TestClientCharmInfo(c *gc.C) {
 			// Use wordpress for tests so that we can compare Provides and Requires.
 			charm: "wordpress",
 			expectedActions: &charm.Actions{ActionSpecs: map[string]charm.ActionSpec{
-				"fakeaction": charm.ActionSpec{
+				"fakeaction": {
 					Description: "No description",
 					Params: map[string]interface{}{
 						"type":        "object",
@@ -1439,7 +1439,7 @@ func (s *clientSuite) testClientServiceDeployWithStorage(c *gc.C, expectConstrai
 	s.makeMockCharmStore()
 	curl, bundle := addCharm(c, "storage-block")
 	storageConstraints := map[string]storage.Constraints{
-		"data": storage.Constraints{
+		"data": {
 			Count: 1,
 			Size:  1024,
 		},
@@ -1457,7 +1457,7 @@ func (s *clientSuite) testClientServiceDeployWithStorage(c *gc.C, expectConstrai
 
 	if expectConstraints {
 		c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
-			"data": state.StorageConstraints{
+			"data": {
 				Count: 1,
 				Size:  1024,
 			},

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -200,7 +200,7 @@ func opClientCharmInfo(c *gc.C, st *api.State, mst *state.State) (func(), error)
 	c.Assert(info.Revision, gc.Equals, 3)
 	c.Assert(info.Actions, jc.DeepEquals, &charm.Actions{
 		ActionSpecs: map[string]charm.ActionSpec{
-			"fakeaction": charm.ActionSpec{
+			"fakeaction": {
 				Description: "No description",
 				Params: map[string]interface{}{
 					"type":        "object",

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -180,7 +180,7 @@ func (s *runSuite) TestParallelExecuteErrorsOnBlankHost(c *gc.C) {
 	s.mockSSH(c, echoInputShowArgs)
 
 	params := []*client.RemoteExec{
-		&client.RemoteExec{
+		{
 			ExecParams: ssh.ExecParams{
 				Command: "foo",
 				Timeout: testing.LongWait,
@@ -198,7 +198,7 @@ func (s *runSuite) TestParallelExecuteAddsIdentity(c *gc.C) {
 	s.mockSSH(c, echoInputShowArgs)
 
 	params := []*client.RemoteExec{
-		&client.RemoteExec{
+		{
 			ExecParams: ssh.ExecParams{
 				Host:    "localhost",
 				Command: "foo",
@@ -218,7 +218,7 @@ func (s *runSuite) TestParallelExecuteCopiesAcrossMachineAndUnit(c *gc.C) {
 	s.mockSSH(c, echoInputShowArgs)
 
 	params := []*client.RemoteExec{
-		&client.RemoteExec{
+		{
 			ExecParams: ssh.ExecParams{
 				Host:    "localhost",
 				Command: "foo",
@@ -309,16 +309,16 @@ func (s *runSuite) TestRunMachineAndService(c *gc.C) {
 	c.Assert(results, gc.HasLen, 3)
 
 	expectedResults := []params.RunResult{
-		params.RunResult{
+		{
 			ExecResponse: exec.ExecResponse{Stdout: []byte(expectedCommand[0])},
 			MachineId:    "0",
 		},
-		params.RunResult{
+		{
 			ExecResponse: exec.ExecResponse{Stdout: []byte(expectedCommand[1])},
 			MachineId:    "1",
 			UnitId:       "magic/0",
 		},
-		params.RunResult{
+		{
 			ExecResponse: exec.ExecResponse{Stdout: []byte(expectedCommand[2])},
 			MachineId:    "2",
 			UnitId:       "magic/1",

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -216,7 +216,7 @@ func fetchAllServicesAndUnits(
 			}
 		}
 	}
-	for baseURL, _ := range latestCharms {
+	for baseURL := range latestCharms {
 		ch, err := st.LatestPlaceholderCharm(&baseURL)
 		if errors.IsNotFound(err) {
 			continue

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -78,7 +78,7 @@ func (s *statusUnitTestSuite) TestProcessMachinesWithOneMachineAndOneContainer(c
 	host := s.MakeMachine(c, &factory.MachineParams{InstanceId: instance.Id("0")})
 	container := s.MakeMachineNested(c, host.Id(), nil)
 	machines := map[string][]*state.Machine{
-		host.Id(): []*state.Machine{host, container},
+		host.Id(): {host, container},
 	}
 
 	statuses := client.ProcessMachines(machines)
@@ -93,7 +93,7 @@ func (s *statusUnitTestSuite) TestProcessMachinesWithEmbeddedContainers(c *gc.C)
 	host := s.MakeMachine(c, &factory.MachineParams{InstanceId: instance.Id("1")})
 	lxcHost := s.MakeMachineNested(c, host.Id(), nil)
 	machines := map[string][]*state.Machine{
-		host.Id(): []*state.Machine{
+		host.Id(): {
 			host,
 			lxcHost,
 			s.MakeMachineNested(c, lxcHost.Id(), nil),

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -163,7 +163,7 @@ func (s *clientSuite) TestEnsureAvailabilityConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
 	expectedCons := []constraints.Value{
-		constraints.Value{},
+		{},
 		constraints.MustParse("mem=4G"),
 		constraints.MustParse("mem=4G"),
 	}
@@ -203,7 +203,7 @@ func (s *clientSuite) TestEnsureAvailabilityPlacement(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
 	expectedCons := []constraints.Value{
-		constraints.Value{},
+		{},
 		constraints.MustParse("mem=4G"),
 		constraints.MustParse("mem=4G"),
 	}

--- a/apiserver/leadership/leadership_test.go
+++ b/apiserver/leadership/leadership_test.go
@@ -93,7 +93,7 @@ func (s *leadershipSuite) TestClaimLeadershipTranslation(c *gc.C) {
 	ldrSvc := &leadershipService{LeadershipManager: &ldrMgr, authorizer: &stubAuthorizer{}}
 	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
-			params.ClaimLeadershipParams{
+			{
 				ServiceTag: names.NewServiceTag(StubServiceNm).String(),
 				UnitTag:    names.NewUnitTag(StubUnitNm).String(),
 			},
@@ -116,7 +116,7 @@ func (s *leadershipSuite) TestReleaseLeadershipTranslation(c *gc.C) {
 	ldrSvc := &leadershipService{LeadershipManager: &ldrMgr, authorizer: &stubAuthorizer{}}
 	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
-			params.ClaimLeadershipParams{
+			{
 				ServiceTag: names.NewServiceTag(StubServiceNm).String(),
 				UnitTag:    names.NewUnitTag(StubUnitNm).String(),
 			},
@@ -150,7 +150,7 @@ func (s *leadershipSuite) TestClaimLeadershipFailOnAuthorizerErrors(c *gc.C) {
 	ldrSvc := &leadershipService{LeadershipManager: nil, authorizer: authorizer}
 	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
-			params.ClaimLeadershipParams{
+			{
 				ServiceTag: names.NewServiceTag(StubServiceNm).String(),
 				UnitTag:    names.NewUnitTag(StubUnitNm).String(),
 			},
@@ -171,7 +171,7 @@ func (s *leadershipSuite) TestReleaseLeadershipFailOnAuthorizerErrors(c *gc.C) {
 	ldrSvc := &leadershipService{LeadershipManager: nil, authorizer: authorizer}
 	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
-			params.ClaimLeadershipParams{
+			{
 				ServiceTag: names.NewServiceTag(StubServiceNm).String(),
 				UnitTag:    names.NewUnitTag(StubUnitNm).String(),
 			},

--- a/apiserver/metricsender/sender_test.go
+++ b/apiserver/metricsender/sender_test.go
@@ -80,7 +80,7 @@ func (s *SenderSuite) TestDefaultSender(c *gc.C) {
 
 	now := time.Now()
 	metrics := make([]*state.MetricBatch, metricCount)
-	for i, _ := range metrics {
+	for i := range metrics {
 		metrics[i] = s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now})
 	}
 	var sender metricsender.DefaultSender
@@ -162,7 +162,7 @@ func (s *SenderSuite) TestErrorCodes(c *gc.C) {
 
 		now := time.Now()
 		batches := make([]*state.MetricBatch, 3)
-		for i, _ := range batches {
+		for i := range batches {
 			batches[i] = s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now})
 		}
 		var sender metricsender.DefaultSender

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1064,7 +1064,7 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(ifacesMachine2[0].MACAddress(), gc.Equals, ifaces[5].MACAddress)
 	c.Assert(ifacesMachine2[0].NetworkTag().String(), gc.Equals, ifaces[5].NetworkTag)
 	c.Assert(ifacesMachine2[0].MachineId(), gc.Equals, s.machines[2].Id())
-	for i, _ := range networks {
+	for i := range networks {
 		if i == 3 {
 			// Last one was ignored, so don't check.
 			break

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -146,7 +146,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 	defer ipv4State.Close()
 	c.Assert(ipv4State.Addr(), gc.Equals, net.JoinHostPort("127.0.0.1", portString))
 	c.Assert(ipv4State.APIHostPorts(), jc.DeepEquals, [][]network.HostPort{
-		[]network.HostPort{{network.NewAddress("127.0.0.1", network.ScopeMachineLocal), port}},
+		{{network.NewAddress("127.0.0.1", network.ScopeMachineLocal), port}},
 	})
 
 	_, err = ipv4State.Machiner().Machine(stm.Tag().(names.MachineTag))
@@ -158,7 +158,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 	defer ipv6State.Close()
 	c.Assert(ipv6State.Addr(), gc.Equals, net.JoinHostPort("::1", portString))
 	c.Assert(ipv6State.APIHostPorts(), jc.DeepEquals, [][]network.HostPort{
-		[]network.HostPort{{network.NewAddress("::1", network.ScopeMachineLocal), port}},
+		{{network.NewAddress("::1", network.ScopeMachineLocal), port}},
 	})
 
 	_, err = ipv6State.Machiner().Machine(stm.Tag().(names.MachineTag))

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -38,7 +38,7 @@ func (s *uniterV2Suite) TestStorageInstances(c *gc.C) {
 	// We need to set up a unit that has storage metadata defined.
 	ch := s.AddTestingCharm(c, "storage-block")
 	sCons := map[string]state.StorageConstraints{
-		"data": state.StorageConstraints{Pool: "", Size: 1024, Count: 1},
+		"data": {Pool: "", Size: 1024, Count: 1},
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, sCons)
 	factory := jujufactory.NewFactory(s.State)

--- a/cmd/juju/action/action_test.go
+++ b/cmd/juju/action/action_test.go
@@ -44,11 +44,11 @@ func (s *ActionCommandSuite) TestHelp(c *gc.C) {
 
 func (s *ActionCommandSuite) checkHelpSubCommands(c *gc.C, ctx *cmd.Context) {
 	var expectedSubCommmands = [][]string{
-		[]string{"defined", "WIP: show actions defined for a service"},
-		[]string{"do", "WIP: queue an action for execution"},
-		[]string{"fetch", "WIP: show results of an action by UUID"},
-		[]string{"help", "show help on a command or other topic"},
-		[]string{"status", "WIP: show results of an action by identifier"},
+		{"defined", "WIP: show actions defined for a service"},
+		{"do", "WIP: queue an action for execution"},
+		{"fetch", "WIP: show results of an action by UUID"},
+		{"help", "show help on a command or other topic"},
+		{"status", "WIP: show results of an action by identifier"},
 	}
 
 	// Check that we have registered all the sub commands by

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -72,7 +72,7 @@ func (s *BaseActionSuite) checkHelp(c *gc.C, subcmd envcmd.EnvironCommand) {
 
 var someCharmActions = &charm.Actions{
 	ActionSpecs: map[string]charm.ActionSpec{
-		"snapshot": charm.ActionSpec{
+		"snapshot": {
 			Description: "Take a snapshot of the database.",
 			Params: map[string]interface{}{
 				"foo": map[string]interface{}{
@@ -81,7 +81,7 @@ var someCharmActions = &charm.Actions{
 				"baz": "bar",
 			},
 		},
-		"kill": charm.ActionSpec{
+		"kill": {
 			Description: "Kill the database.",
 			Params: map[string]interface{}{
 				"bar": map[string]interface{}{
@@ -90,7 +90,7 @@ var someCharmActions = &charm.Actions{
 				"foo": "baz",
 			},
 		},
-		"no-description": charm.ActionSpec{
+		"no-description": {
 			Params: map[string]interface{}{
 				"bar": map[string]interface{}{
 					"baz": "foo",
@@ -98,7 +98,7 @@ var someCharmActions = &charm.Actions{
 				"foo": "baz",
 			},
 		},
-		"no-params": charm.ActionSpec{
+		"no-params": {
 			Description: "An action with no parameters.",
 		},
 	},

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -125,7 +125,7 @@ func (s *BaseBackupsSuite) diffStrings(c *gc.C, value, expected string) {
 		smaller = vlines
 	}
 
-	for i, _ := range smaller {
+	for i := range smaller {
 		vline := vlines[i]
 		eline := elines[i]
 		if vline != eline {

--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -287,7 +287,7 @@ type mockBootstrapInstance struct {
 }
 
 func (*mockBootstrapInstance) Addresses() ([]network.Address, error) {
-	return []network.Address{network.Address{Value: "localhost"}}, nil
+	return []network.Address{{Value: "localhost"}}, nil
 }
 
 func (s *BootstrapSuite) TestSeriesDeprecation(c *gc.C) {

--- a/cmd/juju/debughooks.go
+++ b/cmd/juju/debughooks.go
@@ -80,7 +80,7 @@ func (c *DebugHooksCommand) validateHooks() error {
 	for _, hook := range c.hooks {
 		if !validHooks[hook] {
 			names := make([]string, 0, len(validHooks))
-			for hookName, _ := range validHooks {
+			for hookName := range validHooks {
 				names = append(names, hookName)
 			}
 			sort.Strings(names)

--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -220,7 +220,7 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 	cons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, map[string]state.StorageConstraints{
-		"data": state.StorageConstraints{
+		"data": {
 			Count: 1,
 			Size:  1024,
 		},

--- a/cmd/juju/environment/ensureavailability_test.go
+++ b/cmd/juju/environment/ensureavailability_test.go
@@ -115,8 +115,8 @@ func (s *EnsureAvailabilitySuite) TestEnsureAvailabilityPlacementError(c *gc.C) 
 
 func (s *EnsureAvailabilitySuite) TestEnsureAvailabilityFormatYaml(c *gc.C) {
 	expected := map[string][]string{
-		"maintained": []string{"0"},
-		"added":      []string{"1", "2"},
+		"maintained": {"0"},
+		"added":      {"1", "2"},
 	}
 
 	ctx, err := s.runEnsureAvailability(c, "-n", "3", "--format", "yaml")
@@ -135,8 +135,8 @@ func (s *EnsureAvailabilitySuite) TestEnsureAvailabilityFormatYaml(c *gc.C) {
 
 func (s *EnsureAvailabilitySuite) TestEnsureAvailabilityFormatJson(c *gc.C) {
 	expected := map[string][]string{
-		"maintained": []string{"0"},
-		"added":      []string{"1", "2"},
+		"maintained": {"0"},
+		"added":      {"1", "2"},
 	}
 
 	ctx, err := s.runEnsureAvailability(c, "-n", "3", "--format", "json")

--- a/cmd/juju/environment/retryprovisioning_test.go
+++ b/cmd/juju/environment/retryprovisioning_test.go
@@ -81,9 +81,9 @@ func (s *retryProvisioningSuite) SetUpTest(c *gc.C) {
 	// machine 1 (not broken).
 	s.fake = &fakeRetryProvisioningClient{
 		m: map[string]fakeMachine{
-			"0": fakeMachine{info: "broken",
+			"0": {info: "broken",
 				data: make(map[string]interface{})},
-			"1": fakeMachine{info: "",
+			"1": {info: "",
 				data: make(map[string]interface{})},
 		},
 	}

--- a/cmd/juju/environment/set.go
+++ b/cmd/juju/environment/set.go
@@ -82,7 +82,7 @@ func (c *SetCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	for key, _ := range c.values {
+	for key := range c.values {
 		// check if the key exists in the existing env config
 		// and warn the user if the key is not defined in
 		// the existing config

--- a/cmd/juju/run_test.go
+++ b/cmd/juju/run_test.go
@@ -194,7 +194,7 @@ func (s *RunSuite) TestConvertRunResults(c *gc.C) {
 	}, {
 		message: "stdout and stderr are base64 encoded if not valid utf8",
 		results: []params.RunResult{
-			params.RunResult{
+			{
 				ExecResponse: exec.ExecResponse{
 					Stdout: []byte{0xff},
 					Stderr: []byte{0xfe},

--- a/cmd/juju/scp_unix_test.go
+++ b/cmd/juju/scp_unix_test.go
@@ -162,12 +162,12 @@ type userHost struct {
 }
 
 var userHostsFromTargets = map[string]userHost{
-	"0":               userHost{"ubuntu", "dummyenv-0.dns"},
-	"mysql/0":         userHost{"ubuntu", "dummyenv-0.dns"},
-	"mongodb/0":       userHost{"ubuntu", "dummyenv-1.dns"},
-	"mongodb/1":       userHost{"ubuntu", "dummyenv-2.dns"},
-	"mongo@mongodb/1": userHost{"mongo", "dummyenv-2.dns"},
-	"ipv6-svc/0":      userHost{"ubuntu", "2001:db8::1"},
+	"0":               {"ubuntu", "dummyenv-0.dns"},
+	"mysql/0":         {"ubuntu", "dummyenv-0.dns"},
+	"mongodb/0":       {"ubuntu", "dummyenv-1.dns"},
+	"mongodb/1":       {"ubuntu", "dummyenv-2.dns"},
+	"mongo@mongodb/1": {"mongo", "dummyenv-2.dns"},
+	"ipv6-svc/0":      {"ubuntu", "2001:db8::1"},
 }
 
 func dummyHostsFromTarget(target string) (string, string, error) {

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -2137,26 +2137,26 @@ func (s *StatusSuite) TestStatusWithPreRelationsServer(c *gc.C) {
 			},
 		},
 		Services: map[string]api.ServiceStatus{
-			"mysql": api.ServiceStatus{
+			"mysql": {
 				Charm: "local:quantal/mysql-1",
 				Relations: map[string][]string{
-					"server": []string{"wordpress"},
+					"server": {"wordpress"},
 				},
 				Units: map[string]api.UnitStatus{
-					"mysql/0": api.UnitStatus{
+					"mysql/0": {
 						// Agent field intentionally not set
 						Machine:    "1",
 						AgentState: "allocating",
 					},
 				},
 			},
-			"wordpress": api.ServiceStatus{
+			"wordpress": {
 				Charm: "local:quantal/wordpress-3",
 				Relations: map[string][]string{
-					"db": []string{"mysql"},
+					"db": {"mysql"},
 				},
 				Units: map[string]api.UnitStatus{
-					"wordpress/0": api.UnitStatus{
+					"wordpress/0": {
 						// Agent field intentionally not set
 						AgentState:     "error",
 						AgentStateInfo: "blam",

--- a/cmd/juju/upgradejuju_test.go
+++ b/cmd/juju/upgradejuju_test.go
@@ -446,7 +446,7 @@ type DryRunTest struct {
 
 func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 	tests := []DryRunTest{
-		DryRunTest{
+		{
 			about:          "dry run outputs and doesn't change anything when uploading tools",
 			cmdArgs:        []string{"--upload-tools", "--dry-run"},
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
@@ -464,7 +464,7 @@ upgrade to this version by running
     juju upgrade-juju --version="2.1.3"
 `,
 		},
-		DryRunTest{
+		{
 			about:          "dry run outputs and doesn't change anything",
 			cmdArgs:        []string{"--dry-run"},
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},

--- a/constraints/validation_test.go
+++ b/constraints/validation_test.go
@@ -71,45 +71,45 @@ var validationTests = []struct {
 	},
 	{
 		cons:  "arch=amd64 mem=4G cpu-cores=4",
-		vocab: map[string][]interface{}{"arch": []interface{}{"amd64", "i386"}},
+		vocab: map[string][]interface{}{"arch": {"amd64", "i386"}},
 	},
 	{
 		cons:  "mem=4G cpu-cores=4",
-		vocab: map[string][]interface{}{"cpu-cores": []interface{}{2, 4, 8}},
+		vocab: map[string][]interface{}{"cpu-cores": {2, 4, 8}},
 	},
 	{
 		cons:  "mem=4G instance-type=foo",
-		vocab: map[string][]interface{}{"instance-type": []interface{}{"foo", "bar"}},
+		vocab: map[string][]interface{}{"instance-type": {"foo", "bar"}},
 	},
 	{
 		cons:  "mem=4G tags=foo,bar",
-		vocab: map[string][]interface{}{"tags": []interface{}{"foo", "bar", "another"}},
+		vocab: map[string][]interface{}{"tags": {"foo", "bar", "another"}},
 	},
 	{
 		cons:  "arch=i386 mem=4G cpu-cores=4",
-		vocab: map[string][]interface{}{"arch": []interface{}{"amd64"}},
+		vocab: map[string][]interface{}{"arch": {"amd64"}},
 		err:   "invalid constraint value: arch=i386\nvalid values are:.*",
 	},
 	{
 		cons:  "mem=4G cpu-cores=5",
-		vocab: map[string][]interface{}{"cpu-cores": []interface{}{2, 4, 8}},
+		vocab: map[string][]interface{}{"cpu-cores": {2, 4, 8}},
 		err:   "invalid constraint value: cpu-cores=5\nvalid values are:.*",
 	},
 	{
 		cons:  "mem=4G instance-type=foo",
-		vocab: map[string][]interface{}{"instance-type": []interface{}{"bar"}},
+		vocab: map[string][]interface{}{"instance-type": {"bar"}},
 		err:   "invalid constraint value: instance-type=foo\nvalid values are:.*",
 	},
 	{
 		cons:  "mem=4G tags=foo,other",
-		vocab: map[string][]interface{}{"tags": []interface{}{"foo", "bar", "another"}},
+		vocab: map[string][]interface{}{"tags": {"foo", "bar", "another"}},
 		err:   "invalid constraint value: tags=other\nvalid values are:.*",
 	},
 	{
 		cons: "arch=i386 mem=4G instance-type=foo",
 		vocab: map[string][]interface{}{
-			"instance-type": []interface{}{"foo", "bar"},
-			"arch":          []interface{}{"amd64", "i386"}},
+			"instance-type": {"foo", "bar"},
+			"arch":          {"amd64", "i386"}},
 	},
 }
 

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -483,7 +483,7 @@ curl .* --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid
 			InstanceId:              "i-bootstrap",
 			MachineAgentServiceName: "jujud-machine-0",
 			EnableOSRefreshUpdate:   true,
-			CustomImageMetadata: []*imagemetadata.ImageMetadata{&imagemetadata.ImageMetadata{
+			CustomImageMetadata: []*imagemetadata.ImageMetadata{{
 				Id:         "image-id",
 				Storage:    "ebs",
 				VirtType:   "pv",

--- a/environs/configstore/mem.go
+++ b/environs/configstore/mem.go
@@ -61,7 +61,7 @@ func (m *memStore) List() ([]string, error) {
 	var envs []string
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for name, _ := range m.envs {
+	for name := range m.envs {
 		envs = append(envs, name)
 	}
 	return envs, nil

--- a/environs/filestorage/filestorage_test.go
+++ b/environs/filestorage/filestorage_test.go
@@ -82,7 +82,7 @@ func (s *filestorageSuite) TestList(c *gc.C) {
 		i := len(files)
 		j := len(test.expected)
 		c.Assert(i, gc.Equals, j)
-		for i, _ := range files {
+		for i := range files {
 			c.Assert(files[i], jc.SamePath, test.expected[i])
 		}
 	}

--- a/environs/httpstorage/backend_test.go
+++ b/environs/httpstorage/backend_test.go
@@ -275,7 +275,7 @@ func testList(c *gc.C, client *http.Client, url string) {
 		i := len(names)
 		j := len(tc.found)
 		c.Assert(i, gc.Equals, j)
-		for i, _ := range names {
+		for i := range names {
 			c.Assert(names[i], jc.SamePath, tc.found[i])
 		}
 	}

--- a/environs/httpstorage/storage_test.go
+++ b/environs/httpstorage/storage_test.go
@@ -135,7 +135,7 @@ func checkList(c *gc.C, stor storage.StorageReader, prefix string, names []strin
 	i := len(lnames)
 	j := len(names)
 	c.Assert(i, gc.Equals, j)
-	for i, _ := range lnames {
+	for i := range lnames {
 		c.Assert(lnames[i], jc.SamePath, names[i])
 	}
 }

--- a/environs/imagemetadata/marshal.go
+++ b/environs/imagemetadata/marshal.go
@@ -46,7 +46,7 @@ func MarshalImageMetadataIndexJSON(metadata []*ImageMetadata, cloudSpec []simple
 	indices.Updated = updated.Format(time.RFC1123Z)
 	indices.Format = simplestreams.IndexFormat
 	indices.Indexes = map[string]*simplestreams.IndexMetadata{
-		ImageContentId: &simplestreams.IndexMetadata{
+		ImageContentId: {
 			CloudName:        "custom",
 			Updated:          indices.Updated,
 			Format:           simplestreams.ProductFormat,
@@ -83,7 +83,7 @@ func MarshalImageMetadataProductsJSON(metadata []*ImageMetadata, updated time.Ti
 				Arch:    t.Arch,
 				Version: t.Version,
 				Items: map[string]*simplestreams.ItemCollection{
-					itemsversion: &simplestreams.ItemCollection{
+					itemsversion: {
 						Items: map[string]interface{}{t.Id: toWrite},
 					},
 				},

--- a/environs/imagemetadata/marshal_test.go
+++ b/environs/imagemetadata/marshal_test.go
@@ -94,17 +94,17 @@ var expectedProducts = `{
 }`
 
 var imageMetadataForTesting = []*imagemetadata.ImageMetadata{
-	&imagemetadata.ImageMetadata{
+	{
 		Id:      "1234",
 		Version: "13.10",
 		Arch:    "arm",
 	},
-	&imagemetadata.ImageMetadata{
+	{
 		Id:      "5678",
 		Version: "12.04",
 		Arch:    "arm",
 	},
-	&imagemetadata.ImageMetadata{
+	{
 		Id:       "abcd",
 		Version:  "12.04",
 		Arch:     "amd64",

--- a/environs/tools/marshal.go
+++ b/environs/tools/marshal.go
@@ -109,7 +109,7 @@ func MarshalToolsMetadataProductsJSON(
 					Arch:    t.Arch,
 					Version: t.Version,
 					Items: map[string]*simplestreams.ItemCollection{
-						itemsversion: &simplestreams.ItemCollection{
+						itemsversion: {
 							Items: map[string]interface{}{itemid: t},
 						},
 					},

--- a/environs/tools/marshal_test.go
+++ b/environs/tools/marshal_test.go
@@ -28,8 +28,8 @@ func (s *marshalSuite) SetUpTest(c *gc.C) {
 
 func (s *marshalSuite) TestLargeNumber(c *gc.C) {
 	metadata := map[string][]*tools.ToolsMetadata{
-		"released": []*tools.ToolsMetadata{
-			&tools.ToolsMetadata{
+		"released": {
+			{
 				Release:  "saucy",
 				Version:  "1.2.3.4",
 				Arch:     "arm",
@@ -201,7 +201,7 @@ var expectedProposedProducts = `{
 }`
 
 var releasedToolMetadataForTesting = []*tools.ToolsMetadata{
-	&tools.ToolsMetadata{
+	{
 		Release:  "saucy",
 		Version:  "1.2.3.4",
 		Arch:     "arm",
@@ -209,7 +209,7 @@ var releasedToolMetadataForTesting = []*tools.ToolsMetadata{
 		Path:     "/somewhere/over/the/rainbow.tar.gz",
 		FileType: "tar.gz",
 	},
-	&tools.ToolsMetadata{
+	{
 		Release:  "precise",
 		Version:  "1.2.3.4",
 		Arch:     "arm",
@@ -217,7 +217,7 @@ var releasedToolMetadataForTesting = []*tools.ToolsMetadata{
 		Path:     "toenlightenment.tar.gz",
 		FileType: "tar.gz",
 	},
-	&tools.ToolsMetadata{
+	{
 		Release:  "precise",
 		Version:  "4.3.2.1",
 		Arch:     "amd64",
@@ -228,7 +228,7 @@ var releasedToolMetadataForTesting = []*tools.ToolsMetadata{
 }
 
 var proposedToolMetadataForTesting = []*tools.ToolsMetadata{
-	&tools.ToolsMetadata{
+	{
 		Release:  "utopic",
 		Version:  "1.2-alpha1",
 		Arch:     "ppc64el",
@@ -236,7 +236,7 @@ var proposedToolMetadataForTesting = []*tools.ToolsMetadata{
 		Path:     "/funkytown.tar.gz",
 		FileType: "tar.gz",
 	},
-	&tools.ToolsMetadata{
+	{
 		Release:  "trusty",
 		Version:  "1.2-beta1",
 		Arch:     "arm64",

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -491,7 +491,7 @@ func WriteMetadata(stor storage.Storage, streamMetadata map[string][]*ToolsMetad
 	}
 	if writeMirrors {
 		streamsMirrorsMetadata := make(map[string][]simplestreams.MirrorReference)
-		for stream, _ := range streamMetadata {
+		for stream := range streamMetadata {
 			streamsMirrorsMetadata[ToolsContentId(stream)] = []simplestreams.MirrorReference{{
 				Updated:  updated.Format("20060102"), // YYYYMMDD
 				DataType: ContentDownload,

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -804,7 +804,7 @@ func (*metadataHelperSuite) TestMergeMetadata(c *gc.C) {
 
 func (*metadataHelperSuite) TestReadWriteMetadataSingleStream(c *gc.C) {
 	metadata := map[string][]*tools.ToolsMetadata{
-		"released": []*tools.ToolsMetadata{{
+		"released": {{
 			Release: "precise",
 			Version: "1.2.3",
 			Arch:    "amd64",
@@ -839,13 +839,13 @@ func (*metadataHelperSuite) TestReadWriteMetadataSingleStream(c *gc.C) {
 
 func (*metadataHelperSuite) writeMetadataMultipleStream(c *gc.C) (storage.StorageReader, map[string][]*tools.ToolsMetadata) {
 	metadata := map[string][]*tools.ToolsMetadata{
-		"released": []*tools.ToolsMetadata{{
+		"released": {{
 			Release: "precise",
 			Version: "1.2.3",
 			Arch:    "amd64",
 			Path:    "path1",
 		}},
-		"proposed": []*tools.ToolsMetadata{{
+		"proposed": {{
 			Release: "raring",
 			Version: "1.2.3",
 			Arch:    "amd64",
@@ -895,7 +895,7 @@ func (s *metadataHelperSuite) TestWriteMetadataLegacyIndex(c *gc.C) {
 	expected := simplestreams.Indices{
 		Format: "index:1.0",
 		Indexes: map[string]*simplestreams.IndexMetadata{
-			"com.ubuntu.juju:released:tools": &simplestreams.IndexMetadata{
+			"com.ubuntu.juju:released:tools": {
 				Format:           "products:1.0",
 				DataType:         "content-download",
 				ProductsFilePath: "streams/v1/com.ubuntu.juju-released-tools.json",
@@ -908,7 +908,7 @@ func (s *metadataHelperSuite) TestWriteMetadataLegacyIndex(c *gc.C) {
 
 func (s *metadataHelperSuite) TestReadWriteMetadataUnchanged(c *gc.C) {
 	metadata := map[string][]*tools.ToolsMetadata{
-		"released": []*tools.ToolsMetadata{{
+		"released": {{
 			Release: "precise",
 			Version: "1.2.3",
 			Arch:    "amd64",
@@ -945,13 +945,13 @@ func (*metadataHelperSuite) TestReadMetadataPrefersNewIndex(c *gc.C) {
 
 	// Generate metadata and rename index to index.json
 	metadata := map[string][]*tools.ToolsMetadata{
-		"proposed": []*tools.ToolsMetadata{{
+		"proposed": {{
 			Release: "precise",
 			Version: "1.2.3",
 			Arch:    "amd64",
 			Path:    "path1",
 		}},
-		"released": []*tools.ToolsMetadata{{
+		"released": {{
 			Release: "trusty",
 			Version: "1.2.3",
 			Arch:    "amd64",
@@ -970,7 +970,7 @@ func (*metadataHelperSuite) TestReadMetadataPrefersNewIndex(c *gc.C) {
 
 	// Generate different metadata with index2.json
 	metadata = map[string][]*tools.ToolsMetadata{
-		"released": []*tools.ToolsMetadata{{
+		"released": {{
 			Release: "precise",
 			Version: "1.2.3",
 			Arch:    "amd64",

--- a/lease/lease_test.go
+++ b/lease/lease_test.go
@@ -303,8 +303,8 @@ func (s *leaseSuite) TestManagerDepersistsAllTokensOnStart(c *gc.C) {
 
 	numCalls := 0
 	testToks := []Token{
-		Token{testNamespace, testId, time.Now().Add(testDuration)},
-		Token{testNamespace + "2", "a" + testId, time.Now().Add(testDuration)},
+		{testNamespace, testId, time.Now().Add(testDuration)},
+		{testNamespace + "2", "a" + testId, time.Now().Add(testDuration)},
 	}
 	persistor.PersistedTokensFn = func() ([]Token, error) {
 

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -146,13 +146,13 @@ func (s *instanceSuite) TestAddresses(c *gc.C) {
 	gwacl.PatchManagementAPIResponses(responses)
 
 	expected := []network.Address{
-		network.Address{
+		{
 			"1.2.3.4",
 			network.IPv4Address,
 			vnn,
 			network.ScopeCloudLocal,
 		},
-		network.Address{
+		{
 			s.service.ServiceName + "." + AzureDomainName,
 			network.HostName,
 			"",

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -282,10 +282,10 @@ func (s *BootstrapSuite) TestWaitSSHRefreshAddresses(c *gc.C) {
 	_, err := common.WaitSSH(envcmd.BootstrapContext(ctx), nil, ssh.DefaultClient, "", &addressesChange{addrs: [][]string{
 		nil,
 		nil,
-		[]string{"0.1.2.3"},
-		[]string{"0.1.2.3"},
+		{"0.1.2.3"},
+		{"0.1.2.3"},
 		nil,
-		[]string{"0.1.2.4"},
+		{"0.1.2.4"},
 	}}, testSSHTimeout)
 	// Not necessarily the last one in the list, due to scheduling.
 	c.Check(err, gc.ErrorMatches,

--- a/provider/dummy/storage.go
+++ b/provider/dummy/storage.go
@@ -133,7 +133,7 @@ func (s *storageServer) URL(name string) (string, error) {
 	if name != "" {
 		if _, ok := s.files[name]; !ok {
 			found := false
-			for file, _ := range s.files {
+			for file := range s.files {
 				found = strings.HasPrefix(file, name+"/")
 				if found {
 					break

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -734,7 +734,7 @@ func (t *localServerSuite) TestAllocateAddressFailureToFindNetworkInterface(c *g
 func (t *localServerSuite) setUpInstanceWithDefaultVpc(c *gc.C) (environs.NetworkingEnviron, instance.Id) {
 	// setting a default-vpc will create a network interface
 	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
-		"default-vpc": []string{"vpc-xxxxxxx"},
+		"default-vpc": {"vpc-xxxxxxx"},
 	})
 	env := t.prepareEnviron(c)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
@@ -860,7 +860,7 @@ func (t *localServerSuite) TestSubnetsMissingSubnet(c *gc.C) {
 
 func (t *localServerSuite) TestSupportsAddressAllocationTrue(c *gc.C) {
 	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
-		"default-vpc": []string{"vpc-xxxxxxx"},
+		"default-vpc": {"vpc-xxxxxxx"},
 	})
 	env := t.prepareEnviron(c)
 	result, err := env.SupportsAddressAllocation("")
@@ -870,7 +870,7 @@ func (t *localServerSuite) TestSupportsAddressAllocationTrue(c *gc.C) {
 
 func (t *localServerSuite) TestSupportsAddressAllocationCaches(c *gc.C) {
 	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
-		"default-vpc": []string{"none"},
+		"default-vpc": {"none"},
 	})
 	env := t.prepareEnviron(c)
 	result, err := env.SupportsAddressAllocation("")
@@ -880,7 +880,7 @@ func (t *localServerSuite) TestSupportsAddressAllocationCaches(c *gc.C) {
 	// this value won't change normally, the change here is to
 	// ensure that subsequent calls use the cached value
 	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
-		"default-vpc": []string{"vpc-xxxxxxx"},
+		"default-vpc": {"vpc-xxxxxxx"},
 	})
 	result, err = env.SupportsAddressAllocation("")
 	c.Assert(err, jc.ErrorIsNil)
@@ -889,7 +889,7 @@ func (t *localServerSuite) TestSupportsAddressAllocationCaches(c *gc.C) {
 
 func (t *localServerSuite) TestSupportsAddressAllocationFalse(c *gc.C) {
 	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
-		"default-vpc": []string{"none"},
+		"default-vpc": {"none"},
 	})
 	env := t.prepareEnviron(c)
 	result, err := env.SupportsAddressAllocation("")

--- a/provider/joyent/storage.go
+++ b/provider/joyent/storage.go
@@ -168,7 +168,7 @@ func (s *JoyentStorage) Put(name string, r io.Reader, length int64) error {
 	if strings.Contains(name, "/") {
 		var parents []string
 		dirs := strings.Split(name, "/")
-		for i, _ := range dirs {
+		for i := range dirs {
 			if i < (len(dirs) - 1) {
 				parents = append(parents, strings.Join(dirs[:(i+1)], "/"))
 			}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -565,7 +565,7 @@ func (suite *environSuite) TestStopInstancesIgnoresMissingNodeAndRecurses(c *gc.
 	err := env.StopInstances("test1", "test2")
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedNodes := [][]string{[]string{"test1", "test2"}, []string{"test1"}, []string{"test2"}}
+	expectedNodes := [][]string{{"test1", "test2"}, {"test1"}, {"test2"}}
 	c.Assert(attemptedNodes, gc.DeepEquals, expectedNodes)
 }
 

--- a/replicaset/replicaset_test.go
+++ b/replicaset/replicaset_test.go
@@ -74,7 +74,7 @@ func dialAndTestInitiate(c *gc.C, inst *gitjujutesting.MgoInstance, addr string)
 	c.Assert(session.Mode(), gc.Equals, mode)
 
 	// Ids start at 1 for us, so we can differentiate between set and unset
-	expectedMembers := []Member{Member{Id: 1, Address: addr, Tags: initialTags}}
+	expectedMembers := []Member{{Id: 1, Address: addr, Tags: initialTags}}
 
 	// need to set mode to strong so that we wait for the write to succeed
 	// before reading and thus ensure that we're getting consistent reads.
@@ -554,7 +554,7 @@ func (s *MongoSuite) TestCurrentStatus(c *gc.C) {
 		}
 	}
 
-	for x, _ := range res.Members {
+	for x := range res.Members {
 		// non-empty uptime and ping
 		c.Check(res.Members[x].Uptime, gc.Not(gc.Equals), 0)
 

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -41,7 +41,7 @@ func (s *AssignSuite) SetUpTest(c *gc.C) {
 	s.storageSvc = s.AddTestingServiceWithStorage(
 		c, "storage-block", s.AddTestingCharm(c, "storage-block"),
 		map[string]state.StorageConstraints{
-			"data": state.StorageConstraints{
+			"data": {
 				Count: 1,
 				Size:  1024,
 			},

--- a/state/backups/db_restore_test.go
+++ b/state/backups/db_restore_test.go
@@ -79,6 +79,6 @@ func (s *mongoRestoreSuite) TestPlaceNewMongo(c *gc.C) {
 	expectedCommands := []string{"initctl", "/fake/mongo/restore/path", "initctl"}
 	c.Assert(ranCommands, gc.DeepEquals, expectedCommands)
 	c.Assert(len(ranArgs), gc.Equals, 3)
-	expectedArgs := [][]string{[]string{"stop", "juju-db"}, []string{"a", "set", "of", "args"}, []string{"start", "juju-db"}}
+	expectedArgs := [][]string{{"stop", "juju-db"}, {"a", "set", "of", "args"}, {"start", "juju-db"}}
 	c.Assert(ranArgs, gc.DeepEquals, expectedArgs)
 }

--- a/state/backups/testing/file.go
+++ b/state/backups/testing/file.go
@@ -138,21 +138,21 @@ func NewArchive(meta *backups.Metadata, files, dump []File) (*bytes.Buffer, erro
 // NewArchiveBasic returns a new archive file with a few files provided.
 func NewArchiveBasic(meta *backups.Metadata) (*bytes.Buffer, error) {
 	files := []File{
-		File{
+		{
 			Name:    "var/lib/juju/tools/1.21-alpha2.1-trusty-amd64/jujud",
 			Content: "<some binary data goes here>",
 		},
-		File{
+		{
 			Name:    "var/lib/juju/system-identity",
 			Content: "<an ssh key goes here>",
 		},
 	}
 	dump := []File{
-		File{
+		{
 			Name:    "juju/machines.bson",
 			Content: "<BSON data goes here>",
 		},
-		File{
+		{
 			Name:    "oplog.bson",
 			Content: "<BSON data goes here>",
 		},

--- a/state/bench_test.go
+++ b/state/bench_test.go
@@ -70,7 +70,7 @@ func benchmarkAddMetrics(metricsPerBatch, batches int, c *gc.C) {
 	defer s.TearDownTest(c)
 	now := time.Now()
 	metrics := make([]state.Metric, metricsPerBatch)
-	for i, _ := range metrics {
+	for i := range metrics {
 		metrics[i] = state.Metric{
 			Key:   "metricKey",
 			Value: "keyValue",

--- a/state/blockdevices_test.go
+++ b/state/blockdevices_test.go
@@ -135,7 +135,7 @@ func (s *BlockDevicesSuite) TestSetMachineBlockDevicesLeavesUnprovisioned(c *gc.
 	err = m.SetMachineBlockDevices(sda)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertBlockDevices(c, m, map[string]state.BlockDeviceInfo{
-		"0": state.BlockDeviceInfo{}, // unprovisioned
+		"0": {}, // unprovisioned
 		"1": sda,
 	})
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -912,7 +912,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	c.Assert(err, gc.ErrorMatches, `cannot add network interface "" to machine "1": MAC address must be not empty`)
 	assertNotProvisioned()
 
-	invalidBlockDevices := map[string]state.BlockDeviceInfo{"1065": state.BlockDeviceInfo{}}
+	invalidBlockDevices := map[string]state.BlockDeviceInfo{"1065": {}}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidBlockDevices)
 	c.Assert(err, gc.ErrorMatches, "cannot set provisioned block device info: already provisioned")
 	assertNotProvisioned()
@@ -920,7 +920,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	// Create a disk associated with a different machine, and ensure that trying
 	// to SetInstanceInfo with that disk fails.
 	blockDeviceName := s.createBlockDeviceParams(c, s.machine0.Id(), state.BlockDeviceParams{Size: 1000})
-	invalidBlockDevices = map[string]state.BlockDeviceInfo{blockDeviceName: state.BlockDeviceInfo{}}
+	invalidBlockDevices = map[string]state.BlockDeviceInfo{blockDeviceName: {}}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidBlockDevices)
 	c.Assert(err, gc.ErrorMatches, "cannot set provisioned block device info: already provisioned")
 	assertNotProvisioned()
@@ -946,7 +946,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
 		{MACAddress: "aa:bb:cc:dd:ee:ff", NetworkName: "net1", InterfaceName: "eth0", IsVirtual: false},
 	}
 	blockDeviceInfo := map[string]state.BlockDeviceInfo{
-		"0": state.BlockDeviceInfo{Size: 1234},
+		"0": {Size: 1234},
 	}
 	err := s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, networks, interfaces, blockDeviceInfo)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit.go
+++ b/state/unit.go
@@ -435,15 +435,15 @@ func (u *Unit) destroyHostOps(s *Service) (ops []txn.Op, err error) {
 	var machineAssert bson.D
 	if machineCheck {
 		machineAssert = bson.D{{"$and", []bson.D{
-			bson.D{{"principals", []string{u.doc.Name}}},
-			bson.D{{"jobs", bson.D{{"$nin", []MachineJob{JobManageEnviron}}}}},
-			bson.D{{"hasvote", bson.D{{"$ne", true}}}},
+			{{"principals", []string{u.doc.Name}}},
+			{{"jobs", bson.D{{"$nin", []MachineJob{JobManageEnviron}}}}},
+			{{"hasvote", bson.D{{"$ne", true}}}},
 		}}}
 	} else {
 		machineAssert = bson.D{{"$or", []bson.D{
-			bson.D{{"principals", bson.D{{"$ne", []string{u.doc.Name}}}}},
-			bson.D{{"jobs", bson.D{{"$in", []MachineJob{JobManageEnviron}}}}},
-			bson.D{{"hasvote", true}},
+			{{"principals", bson.D{{"$ne", []string{u.doc.Name}}}}},
+			{{"jobs", bson.D{{"$in", []MachineJob{JobManageEnviron}}}}},
+			{{"hasvote", true}},
 		}}}
 	}
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -906,8 +906,8 @@ func FixSequenceFields(st *State) error {
 	defer closer()
 
 	sel := bson.D{{"$or", []bson.D{
-		bson.D{{"env-uuid", ""}},
-		bson.D{{"name", ""}},
+		{{"env-uuid", ""}},
+		{{"name", ""}},
 	}}}
 	iter := sequence.Find(sel).Select(bson.D{{"_id", 1}}).Iter()
 	defer iter.Close()

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -44,7 +44,7 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 	}
 
 	ops := []txn.Op{
-		txn.Op{
+		{
 			C:      "users",
 			Id:     userId,
 			Assert: txn.DocMissing,
@@ -1597,7 +1597,7 @@ func (s *upgradesSuite) instanceIdSetUp(c *gc.C, machineID string, instID instan
 		"instanceid": instID,
 	}
 	ops := []txn.Op{
-		txn.Op{
+		{
 			C:      machinesC,
 			Id:     machineID,
 			Assert: txn.DocMissing,
@@ -1991,7 +1991,7 @@ func (s *upgradesSuite) TestDropOldIndexesv123(c *gc.C) {
 	DropOldIndexesv123(s.state)
 
 	// check that all old indexes are now missing
-	for collName, _ := range oldIndexesv123 {
+	for collName := range oldIndexesv123 {
 		func() {
 			coll, closer := s.state.getRawCollection(collName)
 			defer closer()

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -441,7 +441,7 @@ func (s *factorySuite) TestMakeMetric(c *gc.C) {
 		Unit:    unit,
 		Time:    &now,
 		Sent:    true,
-		Metrics: []state.Metric{state.Metric{"pings", "1", now}},
+		Metrics: []state.Metric{{"pings", "1", now}},
 	})
 	c.Assert(metric, gc.NotNil)
 

--- a/upgrades/toolstorage_test.go
+++ b/upgrades/toolstorage_test.go
@@ -99,12 +99,12 @@ func (s *migrateToolsStorageSuite) testMigrateToolsStorage(c *gc.C, agentConfig 
 	err := upgrades.MigrateToolsStorage(s.State, agentConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeToolsStorage.stored, gc.DeepEquals, map[version.Binary]toolstorage.Metadata{
-		migrateToolsVersions[0]: toolstorage.Metadata{
+		migrateToolsVersions[0]: {
 			Version: migrateToolsVersions[0],
 			Size:    129,
 			SHA256:  "f26c7a6832cc5fd3a01eaa46c79a7fa7f4714ff3263f7372cedb9470a7b40bae",
 		},
-		migrateToolsVersions[1]: toolstorage.Metadata{
+		migrateToolsVersions[1]: {
 			Version: migrateToolsVersions[1],
 			Size:    129,
 			SHA256:  "eba00d942f9f69e2c862c23095fdb2a0ff578c7c4e77cc28829fcc98cb152693",

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -257,7 +257,7 @@ func (l byId) Less(i, j int) bool { return l[i].id < l[j].id }
 func (info *peerGroupInfo) membersMap() (members map[*machine]*replicaset.Member, extra []replicaset.Member, maxId int) {
 	maxId = -1
 	members = make(map[*machine]*replicaset.Member)
-	for key, _ := range info.members {
+	for key := range info.members {
 		// key is used instead of value to have a loop scoped member value
 		member := info.members[key]
 		mid, ok := member.Tags[jujuMachineKey]

--- a/worker/uniter/runner/export_test.go
+++ b/worker/uniter/runner/export_test.go
@@ -174,7 +174,7 @@ func SetEnvironmentHookContextRelation(
 	context.relationId = relationId
 	context.remoteUnitName = remoteUnitName
 	context.relations = map[int]*ContextRelation{
-		relationId: &ContextRelation{
+		relationId: {
 			endpointName: endpointName,
 			relationId:   relationId,
 		},

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -272,7 +272,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	// We need to set up a unit that has storage metadata defined.
 	ch := s.AddTestingCharm(c, "storage-block")
 	sCons := map[string]state.StorageConstraints{
-		"data": state.StorageConstraints{Pool: "", Size: 1024, Count: 1},
+		"data": {Pool: "", Size: 1024, Count: 1},
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, sCons)
 

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -52,18 +52,18 @@ func (s *ActionGetSuite) TestNonActionRunFail(c *gc.C) {
 
 func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 	var actionGetTestMaps = []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"outfile": "foo.bz2",
 		},
 
-		map[string]interface{}{
+		{
 			"outfile": map[string]interface{}{
 				"filename": "foo.bz2",
 				"format":   "bzip",
 			},
 		},
 
-		map[string]interface{}{
+		{
 			"outfile": map[string]interface{}{
 				"type": map[string]interface{}{
 					"1": "raw",
@@ -74,7 +74,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		},
 
 		// A map with a non-string key is not usable.
-		map[string]interface{}{
+		{
 			"outfile": map[interface{}]interface{}{
 				5: map[string]interface{}{
 					"1": "raw",
@@ -86,7 +86,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 
 		// A map with an inner map[interface{}]interface{} is OK if
 		// the keys are strings.
-		map[string]interface{}{
+		{
 			"outfile": map[interface{}]interface{}{
 				"type": map[string]interface{}{
 					"1": "raw",

--- a/worker/uniter/runner/jujuc/action-set_test.go
+++ b/worker/uniter/runner/jujuc/action-set_test.go
@@ -75,26 +75,26 @@ func (s *ActionSetSuite) TestActionSet(c *gc.C) {
 		summary: "empty values are not an error",
 		command: []string{"result="},
 		expected: [][]string{
-			[]string{"result", ""},
+			{"result", ""},
 		},
 	}, {
 		summary: "a response of one key to one value",
 		command: []string{"outfile=foo.bz2"},
 		expected: [][]string{
-			[]string{"outfile", "foo.bz2"},
+			{"outfile", "foo.bz2"},
 		},
 	}, {
 		summary: "two keys, two values",
 		command: []string{"outfile=foo.bz2", "size=10G"},
 		expected: [][]string{
-			[]string{"outfile", "foo.bz2"},
-			[]string{"size", "10G"},
+			{"outfile", "foo.bz2"},
+			{"size", "10G"},
 		},
 	}, {
 		summary: "multiple = are ok",
 		command: []string{"outfile=foo=bz2"},
 		expected: [][]string{
-			[]string{"outfile", "foo=bz2"},
+			{"outfile", "foo=bz2"},
 		},
 	}, {
 		summary: "several interleaved values",
@@ -102,23 +102,23 @@ func (s *ActionSetSuite) TestActionSet(c *gc.C) {
 			"outfile.kind.util=bzip2",
 			"outfile.kind.ratio=high"},
 		expected: [][]string{
-			[]string{"outfile", "name", "foo.bz2"},
-			[]string{"outfile", "kind", "util", "bzip2"},
-			[]string{"outfile", "kind", "ratio", "high"},
+			{"outfile", "name", "foo.bz2"},
+			{"outfile", "kind", "util", "bzip2"},
+			{"outfile", "kind", "ratio", "high"},
 		},
 	}, {
 		summary: "conflicting simple values",
 		command: []string{"util=bzip2", "util=5"},
 		expected: [][]string{
-			[]string{"util", "bzip2"},
-			[]string{"util", "5"},
+			{"util", "bzip2"},
+			{"util", "5"},
 		},
 	}, {
 		summary: "conflicted map spec: {map1:{key:val}} vs {map1:val2}",
 		command: []string{"map1.key=val", "map1=val"},
 		expected: [][]string{
-			[]string{"map1", "key", "val"},
-			[]string{"map1", "val"},
+			{"map1", "key", "val"},
+			{"map1", "val"},
 		},
 	}}
 


### PR DESCRIPTION
`make simplify` in the project Makefile calls `gofmt -l -w -s .`, which
cleans up code that is more complicated than necessary.

This PR is just the result of running that command from the project
Makefile.

(Review request: http://reviews.vapour.ws/r/871/)