### PR TITLE
Temporarily disable image caching till upstream packaging bug fixed

### DIFF
--- a/apiserver/client/machineconfig.go
+++ b/apiserver/client/machineconfig.go
@@ -94,6 +94,9 @@ func MachineConfig(st *state.State, machineId, nonce, dataDir string) (*cloudini
 		return nil, err
 	}
 	secureServerConnection := info.CAPrivateKey != ""
+	// TODO (wallyworld): reenable this when cloud-image-utils is installed on precise
+	// See: https://bugs.launchpad.net/juju-core/+bug/1417594
+	secureServerConnection = false
 	mcfg, err := environs.NewMachineConfig(machineId, nonce, env.Config().ImageStream(), machine.Series(),
 		secureServerConnection, networks, mongoInfo, apiInfo,
 	)

--- a/apiserver/client/machineconfig_test.go
+++ b/apiserver/client/machineconfig_test.go
@@ -57,7 +57,9 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 	c.Check(machineConfig.APIInfo.Addrs, gc.DeepEquals, apiAddrs)
 	toolsURL := fmt.Sprintf("https://%s/environment/90168e4c-2f10-4e9c-83c2-feedfacee5a9/tools/%s", apiAddrs[0], machineConfig.Tools.Version)
 	c.Assert(machineConfig.Tools.URL, gc.Equals, toolsURL)
-	c.Assert(machineConfig.AgentEnvironment[agent.AllowsSecureConnection], gc.Equals, "true")
+	// TODO (wallyworld): reenable this when cloud-image-utils is installed on precise
+	// See: https://bugs.launchpad.net/juju-core/+bug/1417594
+	c.Assert(machineConfig.AgentEnvironment[agent.AllowsSecureConnection], gc.Equals, "false")
 }
 
 func (s *machineConfigSuite) TestSecureConnectionDisallowed(c *gc.C) {

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -90,7 +90,11 @@ func NewMachineConfig(
 func NewBootstrapMachineConfig(cons constraints.Value, series string) (*cloudinit.MachineConfig, error) {
 	// For a bootstrap instance, FinishMachineConfig will provide the
 	// state.Info and the api.Info. The machine id must *always* be "0".
-	mcfg, err := NewMachineConfig("0", agent.BootstrapNonce, "", series, true, nil, nil, nil)
+
+	// TODO (wallyworld): reenable this when cloud-image-utils is installed on precise
+	// See: https://bugs.launchpad.net/juju-core/+bug/1417594
+	secureServerConnection := false
+	mcfg, err := NewMachineConfig("0", agent.BootstrapNonce, "", series, secureServerConnection, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -134,9 +134,11 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 	}
 
 	secureServerConnection := false
-	if info, ok := p.agentConfig.StateServingInfo(); ok {
-		secureServerConnection = info.CAPrivateKey != ""
-	}
+	// TODO (wallyworld): reenable this when cloud-image-utils is installed on precise
+	// See: https://bugs.launchpad.net/juju-core/+bug/1417594
+	// if info, ok := p.agentConfig.StateServingInfo(); ok {
+	// secureServerConnection = info.CAPrivateKey != ""
+	// }
 	task := NewProvisionerTask(
 		machineTag,
 		harvestMode,


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1417594

precise can't install cloud-image-utils package, so we can't use lxc image caching until the upstream packaging is fixed.
So we disable it until then.

(Review request: http://reviews.vapour.ws/r/872/)