### PR TITLE
Disabled networker worker and relevant tests - backport to 1.22

### DIFF
--- a/worker/networker/networker.go
+++ b/worker/networker/networker.go
@@ -158,6 +158,12 @@ func (nw *Networker) IsPrimaryInterfaceOrLoopback(interfaceName string) bool {
 
 // loop is the worker's main loop.
 func (nw *Networker) loop() error {
+	// TODO(dimitern) Networker is disabled until we have time to fix
+	// it so it's not overwriting /etc/network/interfaces
+	// indiscriminately for containers and possibly other cases.
+	logger.Infof("networker is disabled - not starting on machine %q", nw.tag)
+	return nil
+
 	logger.Debugf("starting on machine %q", nw.tag)
 	if !nw.IntrusiveMode() {
 		logger.Warningf("running in non-intrusive mode - no commands or changes to network config will be done")

--- a/worker/networker/networker_test.go
+++ b/worker/networker/networker_test.go
@@ -94,6 +94,8 @@ func (s *networkerSuite) TestConfigPaths(c *gc.C) {
 }
 
 func (s *networkerSuite) TestSafeNetworkerCannotWriteConfig(c *gc.C) {
+	c.Skip("enable once the networker is enabled again")
+
 	nw := s.newNetworker(c, false)
 	defer worker.Stop(nw)
 	c.Assert(nw.IntrusiveMode(), jc.IsFalse)
@@ -107,6 +109,8 @@ func (s *networkerSuite) TestSafeNetworkerCannotWriteConfig(c *gc.C) {
 }
 
 func (s *networkerSuite) TestNormalNetworkerCanWriteConfigAndLoadsVLANModule(c *gc.C) {
+	c.Skip("enable once the networker is enabled again")
+
 	nw := s.newNetworker(c, true)
 	defer worker.Stop(nw)
 	c.Assert(nw.IntrusiveMode(), jc.IsTrue)
@@ -127,6 +131,8 @@ func (s *networkerSuite) TestNormalNetworkerCanWriteConfigAndLoadsVLANModule(c *
 }
 
 func (s *networkerSuite) TestPrimaryOrLoopbackInterfacesAreSkipped(c *gc.C) {
+	c.Skip("enable once the networker is enabled again")
+
 	// Reset what's considered up, so we can test eth0 and lo are not
 	// touched.
 	s.upInterfaces = make(set.Strings)
@@ -159,6 +165,8 @@ func (s *networkerSuite) TestPrimaryOrLoopbackInterfacesAreSkipped(c *gc.C) {
 }
 
 func (s *networkerSuite) TestDisabledInterfacesAreBroughtDown(c *gc.C) {
+	c.Skip("enable once the networker is enabled again")
+
 	// Simulate eth1 is up and then disable it, so we can test it's
 	// brought down. Also test the VLAN interface eth1.42 is also
 	// brought down, as it's physical interface eth1 is disabled.
@@ -218,6 +226,8 @@ func (s *networkerSuite) TestIsRunningInLXC(c *gc.C) {
 }
 
 func (s *networkerSuite) TestNoModprobeWhenRunningInLXC(c *gc.C) {
+	c.Skip("enable once the networker is enabled again")
+
 	// Create a new container.
 	template := state.MachineTemplate{
 		Series: coretesting.FakeDefaultSeries,


### PR DESCRIPTION
Backport of #1493 for 1.22.

(Review request: http://reviews.vapour.ws/r/878/)