### PR TITLE
Fixed lp:1418433 - populate unit ports and port ranges in megawatcher

### DIFF
--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -602,6 +602,7 @@ type UnitInfo struct {
 	// and debug wire-format changes in the protocol when the type
 	// changes!
 	Ports       []network.Port
+	PortRanges  []network.PortRange
 	Status      Status
 	StatusInfo  string
 	StatusData  map[string]interface{}

--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -76,11 +76,15 @@ var marshalTestCases = []struct {
 			Service:  "Shazam",
 			Series:   "precise",
 			CharmURL: "cs:~user/precise/wordpress-42",
-			Ports: []network.Port{
-				{
-					Protocol: "http",
-					Number:   80},
-			},
+			Ports: []network.Port{{
+				Protocol: "http",
+				Number:   80,
+			}},
+			PortRanges: []network.PortRange{{
+				FromPort: 80,
+				ToPort:   80,
+				Protocol: "http",
+			}},
 			PublicAddress:  "testing.invalid",
 			PrivateAddress: "10.0.0.1",
 			MachineId:      "1",
@@ -88,7 +92,7 @@ var marshalTestCases = []struct {
 			StatusInfo:     "foo",
 		},
 	},
-	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "Subordinate": false}]`,
+	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "PortRanges": [{"FromPort": 80, "ToPort": 80, "Protocol": "http"}], "Ports": [{"Protocol": "http", "Number": 80}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "Subordinate": false}]`,
 }, {
 	about: "RelationInfo Delta",
 	value: params.Delta{

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
 )
@@ -88,13 +89,48 @@ func (m *backingMachine) mongoId() interface{} {
 
 type backingUnit unitDoc
 
+func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange, []network.Port, error) {
+	// Get opened port ranges for the unit and convert them to ports
+	// in a backwards-compatible way (add those where FromPort==ToPort
+	// and drop the rest, as older clients/servers do not know about
+	// ranges).
+	unit, err := st.Unit(unitName)
+	if err != nil {
+		return nil, nil, errors.Annotatef(err, "failed to get unit %q", unitName)
+	}
+	portRanges, err := unit.OpenedPorts()
+	// Since the port ranges are associated with the unit's machine,
+	// we need to check if for NotAssignedError.
+	if IsNotAssigned(errors.Cause(err)) {
+		// Not assigned, so there won't be any ports opened.
+		return nil, nil, nil
+	} else if err != nil {
+		return nil, nil, errors.Annotate(err, "failed to get unit port ranges")
+	}
+	var compatiblePorts []network.Port
+	for _, portRange := range portRanges {
+		if portRange.FromPort == portRange.ToPort {
+			compatiblePorts = append(compatiblePorts, network.Port{
+				Number:   portRange.FromPort,
+				Protocol: portRange.Protocol,
+			})
+		}
+	}
+	return portRanges, compatiblePorts, nil
+}
+
 func (u *backingUnit) updated(st *State, store *multiwatcher.Store, id interface{}) error {
+	portRanges, compatiblePorts, err := getUnitPortRangesAndPorts(st, u.Name)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	info := &params.UnitInfo{
 		Name:        u.Name,
 		Service:     u.Service,
 		Series:      u.Series,
 		MachineId:   u.MachineId,
-		Ports:       u.Ports,
+		Ports:       compatiblePorts,
+		PortRanges:  portRanges,
 		Subordinate: u.Principal != "",
 	}
 	if u.CharmURL != nil {

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -90,17 +90,16 @@ func (m *backingMachine) mongoId() interface{} {
 type backingUnit unitDoc
 
 func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange, []network.Port, error) {
-	// Get opened port ranges for the unit and convert them to ports
-	// in a backwards-compatible way (add those where FromPort==ToPort
-	// and drop the rest, as older clients/servers do not know about
-	// ranges).
+	// Get opened port ranges for the unit and convert them to ports,
+	// as older clients/servers do not know about ranges. See bug
+	// http://pad.lv/1418433 for more info.
 	unit, err := st.Unit(unitName)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "failed to get unit %q", unitName)
 	}
 	portRanges, err := unit.OpenedPorts()
 	// Since the port ranges are associated with the unit's machine,
-	// we need to check if for NotAssignedError.
+	// we need to check for NotAssignedError.
 	if IsNotAssigned(errors.Cause(err)) {
 		// Not assigned, so there won't be any ports opened.
 		return nil, nil, nil
@@ -112,6 +111,13 @@ func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange,
 		if portRange.FromPort == portRange.ToPort {
 			compatiblePorts = append(compatiblePorts, network.Port{
 				Number:   portRange.FromPort,
+				Protocol: portRange.Protocol,
+			})
+			continue
+		}
+		for j := portRange.FromPort; j <= portRange.ToPort; j++ {
+			compatiblePorts = append(compatiblePorts, network.Port{
+				Number:   j,
 				Protocol: portRange.Protocol,
 			})
 		}

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -6,7 +6,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"time"
 
@@ -162,7 +161,6 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C) (entities entityInfoSlic
 			Service:     wordpress.Name(),
 			Series:      m.Series(),
 			MachineId:   m.Id(),
-			Ports:       []network.Port{},
 			Status:      params.StatusPending,
 			Subordinate: false,
 		})
@@ -216,7 +214,6 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C) (entities entityInfoSlic
 			Name:        fmt.Sprintf("logging/%d", i),
 			Service:     "logging",
 			Series:      "quantal",
-			Ports:       []network.Port{},
 			Status:      params.StatusPending,
 			Subordinate: true,
 		})
@@ -229,6 +226,14 @@ func serviceCharmURL(svc *Service) *charm.URL {
 	return url
 }
 
+func jcDeepEqualsCheck(c *gc.C, got, want interface{}) bool {
+	ok, message := jc.DeepEquals.Check([]interface{}{got, want}, []string{"got", "want"})
+	if !ok {
+		c.Logf(message)
+	}
+	return ok
+}
+
 func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 	if len(got) == 0 {
 		got = nil
@@ -236,7 +241,7 @@ func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 	if len(want) == 0 {
 		want = nil
 	}
-	if reflect.DeepEqual(got, want) {
+	if jcDeepEqualsCheck(c, got, want) {
 		return
 	}
 	c.Errorf("entity mismatch; got len %d; want %d", len(got), len(want))
@@ -392,8 +397,13 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				c.Assert(err, gc.IsNil)
 				err = u.AssignToMachine(m)
 				c.Assert(err, gc.IsNil)
+				// Open two ports and one range.
 				err = u.OpenPort("tcp", 12345)
 				c.Assert(err, gc.IsNil)
+				err = u.OpenPort("udp", 54321)
+				c.Assert(err, jc.ErrorIsNil)
+				err = u.OpenPorts("tcp", 5555, 6666)
+				c.Assert(err, jc.ErrorIsNil)
 				err = u.SetStatus(StatusError, "failure", nil)
 				c.Assert(err, gc.IsNil)
 			},
@@ -405,11 +415,19 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 			},
 			expectContents: []multiwatcher.EntityInfo{
 				&params.UnitInfo{
-					Name:       "wordpress/0",
-					Service:    "wordpress",
-					Series:     "quantal",
-					MachineId:  "0",
-					Ports:      []network.Port{},
+					Name:      "wordpress/0",
+					Service:   "wordpress",
+					Series:    "quantal",
+					MachineId: "0",
+					Ports: []network.Port{
+						{"tcp", 12345},
+						{"udp", 54321},
+					},
+					PortRanges: []network.PortRange{
+						{5555, 6666, "tcp"},
+						{12345, 12345, "tcp"},
+						{54321, 54321, "udp"},
+					},
 					Status:     params.StatusError,
 					StatusInfo: "failure",
 				},
@@ -444,7 +462,8 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 					Service:    "wordpress",
 					Series:     "quantal",
 					MachineId:  "0",
-					Ports:      []network.Port{},
+					Ports:      []network.Port{{"udp", 17070}},
+					PortRanges: []network.PortRange{{17070, 17070, "udp"}},
 					Status:     params.StatusError,
 					StatusInfo: "another failure",
 				},
@@ -482,7 +501,8 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 					PublicAddress:  "public",
 					PrivateAddress: "private",
 					MachineId:      "0",
-					Ports:          []network.Port{},
+					Ports:          []network.Port{{"tcp", 12345}},
+					PortRanges:     []network.PortRange{{12345, 12345, "tcp"}},
 					Status:         params.StatusError,
 					StatusInfo:     "failure",
 				},

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -402,7 +402,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				c.Assert(err, gc.IsNil)
 				err = u.OpenPort("udp", 54321)
 				c.Assert(err, jc.ErrorIsNil)
-				err = u.OpenPorts("tcp", 5555, 6666)
+				err = u.OpenPorts("tcp", 5555, 5558)
 				c.Assert(err, jc.ErrorIsNil)
 				err = u.SetStatus(StatusError, "failure", nil)
 				c.Assert(err, gc.IsNil)
@@ -420,11 +420,15 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 					Series:    "quantal",
 					MachineId: "0",
 					Ports: []network.Port{
+						{"tcp", 5555},
+						{"tcp", 5556},
+						{"tcp", 5557},
+						{"tcp", 5558},
 						{"tcp", 12345},
 						{"udp", 54321},
 					},
 					PortRanges: []network.PortRange{
-						{5555, 6666, "tcp"},
+						{5555, 5558, "tcp"},
 						{12345, 12345, "tcp"},
 						{54321, 54321, "udp"},
 					},


### PR DESCRIPTION
This fixes http://pad.lv/1418433 which caused an issue with Juju GUI,
and that's due to a backwards-incompatible client API change in the
way we report opened ports for units. Since port ranges support have
landed, the Ports slice on the unitDoc is no longer populated as the
port ranges are associated with the unit's assigned machine, not the
unit itself. This fixes the issue by:

 * adding a PortRanges field to megawatcher's UnitInfo changes struct,
 which contains all (new-style) port ranges opened by the unit;
 * out of these, the UnitInfo.Ports field is populated in a way that
 was expected by older juju clients (before port ranges were
 introduced), which is done by converting all ranges to individual ports.

This needs forward-porting to 1.22 and 1.23 as well. As a drive-by
fix the megawatcher_internal_test.go's handling of deltas was improved
to use jc.DeepEquals checker rather than reflect.DeepEquals.

(Review request: http://reviews.vapour.ws/r/890/)