### PR TITLE
Fixed lp:1418433 - populate unit ports and port ranges in megawatcher

### DIFF
--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -78,11 +78,15 @@ var marshalTestCases = []struct {
 			Service:  "Shazam",
 			Series:   "precise",
 			CharmURL: "cs:~user/precise/wordpress-42",
-			Ports: []network.Port{
-				{
-					Protocol: "http",
-					Number:   80},
-			},
+			Ports: []network.Port{{
+				Protocol: "http",
+				Number:   80,
+			}},
+			PortRanges: []network.PortRange{{
+				FromPort: 80,
+				ToPort:   80,
+				Protocol: "http",
+			}},
 			PublicAddress:  "testing.invalid",
 			PrivateAddress: "10.0.0.1",
 			MachineId:      "1",
@@ -90,7 +94,7 @@ var marshalTestCases = []struct {
 			StatusInfo:     "foo",
 		},
 	},
-	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "Subordinate": false}]`,
+	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "PortRanges": [{"FromPort": 80, "ToPort": 80, "Protocol": "http"}], "Ports": [{"Protocol": "http", "Number": 80}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "Subordinate": false}]`,
 }, {
 	about: "RelationInfo Delta",
 	value: multiwatcher.Delta{

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -105,17 +105,16 @@ func translateLegacyUnitAgentStatus(in multiwatcher.Status) multiwatcher.Status 
 }
 
 func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange, []network.Port, error) {
-	// Get opened port ranges for the unit and convert them to ports
-	// in a backwards-compatible way (add those where FromPort==ToPort
-	// and drop the rest, as older clients/servers do not know about
-	// ranges).
+	// Get opened port ranges for the unit and convert them to ports,
+	// as older clients/servers do not know about ranges. See bug
+	// http://pad.lv/1418433 for more info.
 	unit, err := st.Unit(unitName)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "failed to get unit %q", unitName)
 	}
 	portRanges, err := unit.OpenedPorts()
 	// Since the port ranges are associated with the unit's machine,
-	// we need to check if for NotAssignedError.
+	// we need to check for NotAssignedError.
 	if IsNotAssigned(errors.Cause(err)) {
 		// Not assigned, so there won't be any ports opened.
 		return nil, nil, nil
@@ -127,6 +126,13 @@ func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange,
 		if portRange.FromPort == portRange.ToPort {
 			compatiblePorts = append(compatiblePorts, network.Port{
 				Number:   portRange.FromPort,
+				Protocol: portRange.Protocol,
+			})
+			continue
+		}
+		for j := portRange.FromPort; j <= portRange.ToPort; j++ {
+			compatiblePorts = append(compatiblePorts, network.Port{
+				Number:   j,
 				Protocol: portRange.Protocol,
 			})
 		}

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/mgo.v2"
 
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
 )
@@ -103,13 +104,48 @@ func translateLegacyUnitAgentStatus(in multiwatcher.Status) multiwatcher.Status 
 	return in
 }
 
+func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange, []network.Port, error) {
+	// Get opened port ranges for the unit and convert them to ports
+	// in a backwards-compatible way (add those where FromPort==ToPort
+	// and drop the rest, as older clients/servers do not know about
+	// ranges).
+	unit, err := st.Unit(unitName)
+	if err != nil {
+		return nil, nil, errors.Annotatef(err, "failed to get unit %q", unitName)
+	}
+	portRanges, err := unit.OpenedPorts()
+	// Since the port ranges are associated with the unit's machine,
+	// we need to check if for NotAssignedError.
+	if IsNotAssigned(errors.Cause(err)) {
+		// Not assigned, so there won't be any ports opened.
+		return nil, nil, nil
+	} else if err != nil {
+		return nil, nil, errors.Annotate(err, "failed to get unit port ranges")
+	}
+	var compatiblePorts []network.Port
+	for _, portRange := range portRanges {
+		if portRange.FromPort == portRange.ToPort {
+			compatiblePorts = append(compatiblePorts, network.Port{
+				Number:   portRange.FromPort,
+				Protocol: portRange.Protocol,
+			})
+		}
+	}
+	return portRanges, compatiblePorts, nil
+}
+
 func (u *backingUnit) updated(st *State, store *multiwatcherStore, id interface{}) error {
+	portRanges, compatiblePorts, err := getUnitPortRangesAndPorts(st, u.Name)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	info := &multiwatcher.UnitInfo{
 		Name:        u.Name,
 		Service:     u.Service,
 		Series:      u.Series,
 		MachineId:   u.MachineId,
-		Ports:       u.Ports,
+		Ports:       compatiblePorts,
+		PortRanges:  portRanges,
 		Subordinate: u.Principal != "",
 	}
 	if u.CharmURL != nil {

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -403,10 +403,10 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			// Open two ports and one range.
 			err = u.OpenPort("tcp", 12345)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPort("udp", 54321)
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.OpenPorts("tcp", 5555, 6666)
+			err = u.OpenPorts("tcp", 5555, 5558)
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.SetStatus(StatusError, "failure", nil)
 			c.Assert(err, jc.ErrorIsNil)
@@ -424,11 +424,15 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 						Series:    "quantal",
 						MachineId: "0",
 						Ports: []network.Port{
+							{"tcp", 5555},
+							{"tcp", 5556},
+							{"tcp", 5557},
+							{"tcp", 5558},
 							{"tcp", 12345},
 							{"udp", 54321},
 						},
 						PortRanges: []network.PortRange{
-							{5555, 6666, "tcp"},
+							{5555, 5558, "tcp"},
 							{12345, 12345, "tcp"},
 							{54321, 54321, "udp"},
 						},

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -169,6 +169,7 @@ type UnitInfo struct {
 	PrivateAddress string
 	MachineId      string
 	Ports          []network.Port
+	PortRanges     []network.PortRange
 	Status         Status
 	StatusInfo     string
 	StatusData     map[string]interface{}


### PR DESCRIPTION
Foreport of #1558 to 1.22, no other changes.

(Review request: http://reviews.vapour.ws/r/891/)