### PR TITLE
Fixed lp:1418433 - populate unit ports and port ranges in megawatcher

### DIFF
--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -78,11 +78,15 @@ var marshalTestCases = []struct {
 			Service:  "Shazam",
 			Series:   "precise",
 			CharmURL: "cs:~user/precise/wordpress-42",
-			Ports: []network.Port{
-				{
-					Protocol: "http",
-					Number:   80},
-			},
+			Ports: []network.Port{{
+				Protocol: "http",
+				Number:   80,
+			}},
+			PortRanges: []network.PortRange{{
+				FromPort: 80,
+				ToPort:   80,
+				Protocol: "http",
+			}},
 			PublicAddress:  "testing.invalid",
 			PrivateAddress: "10.0.0.1",
 			MachineId:      "1",
@@ -90,7 +94,7 @@ var marshalTestCases = []struct {
 			StatusInfo:     "foo",
 		},
 	},
-	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "Subordinate": false}]`,
+	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "PortRanges": [{"FromPort": 80, "ToPort": 80, "Protocol": "http"}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "Subordinate": false}]`,
 }, {
 	about: "RelationInfo Delta",
 	value: multiwatcher.Delta{
@@ -140,7 +144,7 @@ func (s *MarshalSuite) TestDeltaMarshalJSON(c *gc.C) {
 		var expected interface{}
 		err = json.Unmarshal([]byte(t.json), &expected)
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(unmarshalledOutput, gc.DeepEquals, expected)
+		c.Check(unmarshalledOutput, jc.DeepEquals, expected)
 	}
 }
 

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -111,7 +111,7 @@ func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange,
 	portRanges, err := unit.OpenedPorts()
 	// Since the port ranges are associated with the unit's machine,
 	// we need to check for NotAssignedError.
-	if IsNotAssigned(errors.Cause(err)) {
+	if errors.IsNotAssigned(errors.Cause(err)) {
 		// Not assigned, so there won't be any ports opened.
 		return nil, nil, nil
 	} else if err != nil {

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -119,13 +119,6 @@ func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange,
 	}
 	var compatiblePorts []network.Port
 	for _, portRange := range portRanges {
-		if portRange.FromPort == portRange.ToPort {
-			compatiblePorts = append(compatiblePorts, network.Port{
-				Number:   portRange.FromPort,
-				Protocol: portRange.Protocol,
-			})
-			continue
-		}
 		for j := portRange.FromPort; j <= portRange.ToPort; j++ {
 			compatiblePorts = append(compatiblePorts, network.Port{
 				Number:   j,

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/mgo.v2"
 
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
 )
@@ -99,13 +100,48 @@ func translateLegacyUnitAgentStatus(in multiwatcher.Status) multiwatcher.Status 
 	return in
 }
 
+func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange, []network.Port, error) {
+	// Get opened port ranges for the unit and convert them to ports
+	// in a backwards-compatible way (add those where FromPort==ToPort
+	// and drop the rest, as older clients/servers do not know about
+	// ranges).
+	unit, err := st.Unit(unitName)
+	if err != nil {
+		return nil, nil, errors.Annotatef(err, "failed to get unit %q", unitName)
+	}
+	portRanges, err := unit.OpenedPorts()
+	// Since the port ranges are associated with the unit's machine,
+	// we need to check if for NotAssignedError.
+	if IsNotAssigned(errors.Cause(err)) {
+		// Not assigned, so there won't be any ports opened.
+		return nil, nil, nil
+	} else if err != nil {
+		return nil, nil, errors.Annotate(err, "failed to get unit port ranges")
+	}
+	var compatiblePorts []network.Port
+	for _, portRange := range portRanges {
+		if portRange.FromPort == portRange.ToPort {
+			compatiblePorts = append(compatiblePorts, network.Port{
+				Number:   portRange.FromPort,
+				Protocol: portRange.Protocol,
+			})
+		}
+	}
+	return portRanges, compatiblePorts, nil
+}
+
 func (u *backingUnit) updated(st *State, store *multiwatcherStore, id interface{}) error {
+	portRanges, compatiblePorts, err := getUnitPortRangesAndPorts(st, u.Name)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	info := &multiwatcher.UnitInfo{
 		Name:        u.Name,
 		Service:     u.Service,
 		Series:      u.Series,
 		MachineId:   u.MachineId,
-		Ports:       u.Ports,
+		Ports:       compatiblePorts,
+		PortRanges:  portRanges,
 		Subordinate: u.Principal != "",
 	}
 	if u.CharmURL != nil {

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -429,7 +429,7 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPort("udp", 54321)
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.OpenPorts("tcp", 5555, 6666)
+			err = u.OpenPorts("tcp", 5555, 5558)
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.SetStatus(StatusError, "failure", nil)
 			c.Assert(err, jc.ErrorIsNil)
@@ -447,11 +447,15 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 						Series:    "quantal",
 						MachineId: "0",
 						Ports: []network.Port{
+							{"tcp", 5555},
+							{"tcp", 5556},
+							{"tcp", 5557},
+							{"tcp", 5558},
 							{"tcp", 12345},
 							{"udp", 54321},
 						},
 						PortRanges: []network.PortRange{
-							{5555, 6666, "tcp"},
+							{5555, 5558, "tcp"},
 							{12345, 12345, "tcp"},
 							{54321, 54321, "udp"},
 						},

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"time"
 
@@ -71,6 +70,14 @@ func (s *storeManagerStateSuite) Reset(c *gc.C) {
 	s.SetUpTest(c)
 }
 
+func jcDeepEqualsCheck(c *gc.C, got, want interface{}) bool {
+	ok, message := jc.DeepEquals.Check([]interface{}{got, want}, []string{"got", "want"})
+	if !ok {
+		c.Logf(message)
+	}
+	return ok
+}
+
 func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 	if len(got) == 0 {
 		got = nil
@@ -78,7 +85,7 @@ func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 	if len(want) == 0 {
 		want = nil
 	}
-	if reflect.DeepEqual(got, want) {
+	if jcDeepEqualsCheck(c, got, want) {
 		return
 	}
 	c.Errorf("entity mismatch; got len %d; want %d", len(got), len(want))
@@ -95,7 +102,7 @@ func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 		for i := 0; i < len(got); i++ {
 			g := got[i]
 			w := want[i]
-			if !reflect.DeepEqual(g, w) {
+			if !jcDeepEqualsCheck(c, g, w) {
 				c.Logf("")
 				c.Logf("first difference at position %d", i)
 				c.Logf("got:")
@@ -232,7 +239,6 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C, st *State, units int) (e
 			Service:     wordpress.Name(),
 			Series:      m.Series(),
 			MachineId:   m.Id(),
-			Ports:       []network.Port{},
 			Status:      multiwatcher.Status("allocating"),
 			Subordinate: false,
 		})
@@ -288,7 +294,6 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C, st *State, units int) (e
 			Name:        fmt.Sprintf("logging/%d", i),
 			Service:     "logging",
 			Series:      "quantal",
-			Ports:       []network.Port{},
 			Status:      multiwatcher.Status("allocating"),
 			Subordinate: true,
 		})
@@ -419,7 +424,12 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.AssignToMachine(m)
 			c.Assert(err, jc.ErrorIsNil)
+			// Open two ports and one range.
 			err = u.OpenPort("tcp", 12345)
+			c.Assert(err, jc.ErrorIsNil)
+			err = u.OpenPort("udp", 54321)
+			c.Assert(err, jc.ErrorIsNil)
+			err = u.OpenPorts("tcp", 5555, 6666)
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.SetStatus(StatusError, "failure", nil)
 			c.Assert(err, jc.ErrorIsNil)
@@ -432,11 +442,19 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						Name:       "wordpress/0",
-						Service:    "wordpress",
-						Series:     "quantal",
-						MachineId:  "0",
-						Ports:      []network.Port{},
+						Name:      "wordpress/0",
+						Service:   "wordpress",
+						Series:    "quantal",
+						MachineId: "0",
+						Ports: []network.Port{
+							{"tcp", 12345},
+							{"udp", 54321},
+						},
+						PortRanges: []network.PortRange{
+							{5555, 6666, "tcp"},
+							{12345, 12345, "tcp"},
+							{54321, 54321, "udp"},
+						},
 						Status:     multiwatcher.Status("error"),
 						StatusInfo: "failure",
 					}}}
@@ -468,7 +486,8 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 						Service:    "wordpress",
 						Series:     "quantal",
 						MachineId:  "0",
-						Ports:      []network.Port{},
+						Ports:      []network.Port{{"udp", 17070}},
+						PortRanges: []network.PortRange{{17070, 17070, "udp"}},
 						Status:     multiwatcher.Status("error"),
 						StatusInfo: "another failure",
 					}}}
@@ -503,9 +522,9 @@ func (s *storeManagerStateSuite) TestChanged(c *gc.C) {
 						PublicAddress:  "public",
 						PrivateAddress: "private",
 						MachineId:      "0",
-						Ports:          []network.Port{},
-						Status:         multiwatcher.Status("error"),
-						StatusInfo:     "failure",
+						Ports:          []network.Port{{"tcp", 12345}},
+						PortRanges:     []network.PortRange{{12345, 12345, "tcp"}}, Status: multiwatcher.Status("error"),
+						StatusInfo: "failure",
 					}}}
 		},
 		// Service changes

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -170,6 +170,7 @@ type UnitInfo struct {
 	PrivateAddress string
 	MachineId      string
 	Ports          []network.Port
+	PortRanges     []network.PortRange
 	Status         Status
 	StatusInfo     string
 	StatusData     map[string]interface{}


### PR DESCRIPTION
Foreport of #1558 to 1.23, no other changes except a slight improvement
inside assertEntitiesEqual.

(Review request: http://reviews.vapour.ws/r/892/)