### PR TITLE
Give apt-proxy settings a scheme if they are missing from the URL.

### DIFF
--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -219,8 +219,7 @@ func AddAptCommands(
 	if (proxySettings != proxy.Settings{}) {
 		filename := apt.ConfFile
 		c.AddBootCmd(fmt.Sprintf(
-			`[ -f %s ] || (printf '%%s\n' %s > %s)`,
-			filename,
+			`printf '%%s\n' %s > %s`,
 			shquote(apt.ProxyContent(proxySettings)),
 			filename))
 	}

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -1008,7 +1008,7 @@ func (s *cloudinitSuite) TestAptProxyWritten(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	cmds := cloudcfg.BootCmds()
-	expected := "[ -f /etc/apt/apt.conf.d/42-juju-proxy-settings ] || (printf '%s\\n' 'Acquire::http::Proxy \"http://user@10.0.0.1\";' > /etc/apt/apt.conf.d/42-juju-proxy-settings)"
+	expected := "printf '%s\\n' 'Acquire::http::Proxy \"http://user@10.0.0.1\";' > /etc/apt/apt.conf.d/42-juju-proxy-settings"
 	c.Assert(cmds, jc.DeepEquals, []interface{}{expected})
 }
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -780,6 +780,14 @@ func (c *Config) getWithFallback(key, fallback string) string {
 	return value
 }
 
+// addSchemeIfMissing adds a scheme to a URL if it is missing
+func addSchemeIfMissing(defaultScheme string, url string) string {
+	if url != "" && !strings.Contains(url, "://") {
+		url = defaultScheme + "://" + url
+	}
+	return url
+}
+
 // AptProxySettings returns all three proxy settings; http, https and ftp.
 func (c *Config) AptProxySettings() proxy.Settings {
 	return proxy.Settings{
@@ -792,19 +800,19 @@ func (c *Config) AptProxySettings() proxy.Settings {
 // AptHttpProxy returns the apt http proxy for the environment.
 // Falls back to the default http-proxy if not specified.
 func (c *Config) AptHttpProxy() string {
-	return c.getWithFallback(AptHttpProxyKey, HttpProxyKey)
+	return addSchemeIfMissing("http", c.getWithFallback(AptHttpProxyKey, HttpProxyKey))
 }
 
 // AptHttpsProxy returns the apt https proxy for the environment.
 // Falls back to the default https-proxy if not specified.
 func (c *Config) AptHttpsProxy() string {
-	return c.getWithFallback(AptHttpsProxyKey, HttpsProxyKey)
+	return addSchemeIfMissing("https", c.getWithFallback(AptHttpsProxyKey, HttpsProxyKey))
 }
 
 // AptFtpProxy returns the apt ftp proxy for the environment.
 // Falls back to the default ftp-proxy if not specified.
 func (c *Config) AptFtpProxy() string {
-	return c.getWithFallback(AptFtpProxyKey, FtpProxyKey)
+	return addSchemeIfMissing("ftp", c.getWithFallback(AptFtpProxyKey, FtpProxyKey))
 }
 
 // AptMirror sets the apt mirror for the environment.

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1568,6 +1568,24 @@ func (s *ConfigSuite) TestProxyValuesWithFallback(c *gc.C) {
 	c.Assert(config.NoProxy(), gc.Equals, "localhost,10.0.3.1")
 }
 
+func (s *ConfigSuite) TestProxyValuesWithFallbackNoScheme(c *gc.C) {
+	s.addJujuFiles(c)
+
+	config := newTestConfig(c, testing.Attrs{
+		"http-proxy":  "user@10.0.0.1",
+		"https-proxy": "user@10.0.0.1",
+		"ftp-proxy":   "user@10.0.0.1",
+		"no-proxy":    "localhost,10.0.3.1",
+	})
+	c.Assert(config.HttpProxy(), gc.Equals, "user@10.0.0.1")
+	c.Assert(config.AptHttpProxy(), gc.Equals, "http://user@10.0.0.1")
+	c.Assert(config.HttpsProxy(), gc.Equals, "user@10.0.0.1")
+	c.Assert(config.AptHttpsProxy(), gc.Equals, "https://user@10.0.0.1")
+	c.Assert(config.FtpProxy(), gc.Equals, "user@10.0.0.1")
+	c.Assert(config.AptFtpProxy(), gc.Equals, "ftp://user@10.0.0.1")
+	c.Assert(config.NoProxy(), gc.Equals, "localhost,10.0.3.1")
+}
+
 func (s *ConfigSuite) TestProxyValues(c *gc.C) {
 	s.addJujuFiles(c)
 	config := newTestConfig(c, testing.Attrs{
@@ -1607,21 +1625,26 @@ func (s *ConfigSuite) TestProxyConfigMap(c *gc.C) {
 		Ftp:     "ftp proxy",
 		NoProxy: "no proxy",
 	}
+	expectedProxySettings := proxy.Settings{
+		Http:    "http://http proxy",
+		Https:   "https://https proxy",
+		Ftp:     "ftp://ftp proxy",
+		NoProxy: "",
+	}
 	cfg, err := cfg.Apply(config.ProxyConfigMap(proxySettings))
 	c.Assert(err, gc.IsNil)
 	c.Assert(cfg.ProxySettings(), gc.DeepEquals, proxySettings)
-	// Apt proxy and proxy differ by the content of the no-proxy values.
-	proxySettings.NoProxy = ""
-	c.Assert(cfg.AptProxySettings(), gc.DeepEquals, proxySettings)
+	// Apt proxy settings always include the scheme. NoProxy is empty.
+	c.Assert(cfg.AptProxySettings(), gc.DeepEquals, expectedProxySettings)
 }
 
 func (s *ConfigSuite) TestAptProxyConfigMap(c *gc.C) {
 	s.addJujuFiles(c)
 	cfg := newTestConfig(c, testing.Attrs{})
 	proxySettings := proxy.Settings{
-		Http:  "http proxy",
-		Https: "https proxy",
-		Ftp:   "ftp proxy",
+		Http:  "http://httpproxy",
+		Https: "https://httpsproxy",
+		Ftp:   "ftp://ftpproxy",
 	}
 	cfg, err := cfg.Apply(config.AptProxyConfigMap(proxySettings))
 	c.Assert(err, gc.IsNil)

--- a/provider/local/environprovider_test.go
+++ b/provider/local/environprovider_test.go
@@ -170,56 +170,56 @@ func (s *prepareSuite) TestPrepareCapturesEnvironment(c *gc.C) {
 		message: "apt-proxies detected",
 		aptOutput: `CommandLine::AsString "apt-config dump";
 Acquire::http::Proxy  "10.0.3.1:3142";
-Acquire::https::Proxy "false";
-Acquire::ftp::Proxy "none";
-Acquire::magic::Proxy "none";
+Acquire::https::Proxy "";
+Acquire::ftp::Proxy "";
+Acquire::magic::Proxy "";
 `,
 		expectedAptProxy: proxy.Settings{
-			Http:  "10.0.3.1:3142",
-			Https: "false",
-			Ftp:   "none",
+			Http:  "http://10.0.3.1:3142",
+			Https: "",
+			Ftp:   "",
 		},
 	}, {
 		message: "apt-proxies not used if apt-http-proxy set",
 		extraConfig: map[string]interface{}{
-			"apt-http-proxy": "value-set",
+			"apt-http-proxy": "http://value-set",
 		},
 		aptOutput: `CommandLine::AsString "apt-config dump";
 Acquire::http::Proxy  "10.0.3.1:3142";
-Acquire::https::Proxy "false";
-Acquire::ftp::Proxy "none";
-Acquire::magic::Proxy "none";
+Acquire::https::Proxy "";
+Acquire::ftp::Proxy "";
+Acquire::magic::Proxy "";
 `,
 		expectedAptProxy: proxy.Settings{
-			Http: "value-set",
+			Http: "http://value-set",
 		},
 	}, {
 		message: "apt-proxies not used if apt-https-proxy set",
 		extraConfig: map[string]interface{}{
-			"apt-https-proxy": "value-set",
+			"apt-https-proxy": "https://value-set",
 		},
 		aptOutput: `CommandLine::AsString "apt-config dump";
 Acquire::http::Proxy  "10.0.3.1:3142";
-Acquire::https::Proxy "false";
-Acquire::ftp::Proxy "none";
-Acquire::magic::Proxy "none";
+Acquire::https::Proxy "";
+Acquire::ftp::Proxy "";
+Acquire::magic::Proxy "";
 `,
 		expectedAptProxy: proxy.Settings{
-			Https: "value-set",
+			Https: "https://value-set",
 		},
 	}, {
 		message: "apt-proxies not used if apt-ftp-proxy set",
 		extraConfig: map[string]interface{}{
-			"apt-ftp-proxy": "value-set",
+			"apt-ftp-proxy": "ftp://value-set",
 		},
 		aptOutput: `CommandLine::AsString "apt-config dump";
 Acquire::http::Proxy  "10.0.3.1:3142";
-Acquire::https::Proxy "false";
-Acquire::ftp::Proxy "none";
-Acquire::magic::Proxy "none";
+Acquire::https::Proxy "";
+Acquire::ftp::Proxy "";
+Acquire::magic::Proxy "";
 `,
 		expectedAptProxy: proxy.Settings{
-			Ftp: "value-set",
+			Ftp: "ftp://value-set",
 		},
 	}} {
 		c.Logf("\n%v: %s", i, test.message)

--- a/worker/machineenvironmentworker/machineenvironmentworker_test.go
+++ b/worker/machineenvironmentworker/machineenvironmentworker_test.go
@@ -135,9 +135,9 @@ func (s *MachineEnvironmentWatcherSuite) updateConfig(c *gc.C) (proxy.Settings, 
 	// proxy settings which is what we would get if we don't explicitly set
 	// apt values.
 	aptProxySettings := proxy.Settings{
-		Http:  "apt http proxy",
-		Https: "apt https proxy",
-		Ftp:   "apt ftp proxy",
+		Http:  "http://apt.http.proxy",
+		Https: "https://apt.https.proxy",
+		Ftp:   "ftp://apt.ftp.proxy",
 	}
 	for k, v := range config.AptProxyConfigMap(aptProxySettings) {
 		attrs[k] = v


### PR DESCRIPTION
Fixes-1417617

(Review request: http://reviews.vapour.ws/r/895/)