### PR TITLE
charmrevisionupdater retries on error 

### DIFF
--- a/worker/charmrevisionworker/revisionupdater.go
+++ b/worker/charmrevisionworker/revisionupdater.go
@@ -78,6 +78,10 @@ func (ruw *RevisionUpdateWorker) loop() error {
 }
 
 func (ruw *RevisionUpdateWorker) updateVersions() error {
+	return UpdateVersions(ruw)
+}
+
+var UpdateVersions = func(ruw *RevisionUpdateWorker) error {
 	if err := ruw.st.UpdateLatestRevisions(); err != nil {
 		logger.Errorf("cannot process charms: %v", err)
 		return errors.Annotatef(err, "failed updating charms")

--- a/worker/charmrevisionworker/revisionupdater.go
+++ b/worker/charmrevisionworker/revisionupdater.go
@@ -60,7 +60,10 @@ func (ruw *RevisionUpdateWorker) Wait() error {
 }
 
 func (ruw *RevisionUpdateWorker) loop() error {
-	ruw.updateVersions()
+	err := ruw.updateVersions()
+	if err != nil {
+		return err
+	}
 	for {
 		select {
 		case <-ruw.tomb.Dying():

--- a/worker/charmrevisionworker/revisionupdater.go
+++ b/worker/charmrevisionworker/revisionupdater.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"launchpad.net/tomb"
 
@@ -65,13 +66,18 @@ func (ruw *RevisionUpdateWorker) loop() error {
 		case <-ruw.tomb.Dying():
 			return tomb.ErrDying
 		case <-time.After(interval):
-			ruw.updateVersions()
+			err := ruw.updateVersions()
+			if err != nil {
+				return err
+			}
 		}
 	}
 }
 
-func (ruw *RevisionUpdateWorker) updateVersions() {
+func (ruw *RevisionUpdateWorker) updateVersions() error {
 	if err := ruw.st.UpdateLatestRevisions(); err != nil {
 		logger.Errorf("cannot process charms: %v", err)
+		return errors.Annotatef(err, "failed updating charms")
 	}
+	return nil
 }


### PR DESCRIPTION
The charmrevisionupdater now dies (causing a retry) if there is an error fetching charm revisions. This specifically helps with the case where juju is behind a proxy and needs the proxy settings to be in place before it can access the internet.


(Review request: http://reviews.vapour.ws/r/896/)