### PR TITLE
Parse `juju action do` CLI args as YAML; offer explicit flag

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -143,7 +143,7 @@ func entityToActionTag(entity params.Entity) (names.ActionTag, error) {
 // addValueToMap adds the given value to the map on which the method is run.
 // This allows us to merge maps such as {foo: {bar: baz}} and {foo: {baz: faz}}
 // into {foo: {bar: baz, baz: faz}}.
-func addValueToMap(keys []string, value string, target map[string]interface{}) {
+func addValueToMap(keys []string, value interface{}, target map[string]interface{}) {
 	next := target
 
 	for i := range keys {

--- a/cmd/juju/action/common_test.go
+++ b/cmd/juju/action/common_test.go
@@ -116,8 +116,8 @@ func (s *CommonSuite) TestConform(c *gc.C) {
 }
 
 type insertSliceValue struct {
-	atSlice []string
-	value   interface{}
+	valuePath []string
+	value     interface{}
 }
 
 func (s *CommonSuite) TestAddValueToMap(c *gc.C) {
@@ -137,12 +137,12 @@ func (s *CommonSuite) TestAddValueToMap(c *gc.C) {
 		},
 		insertSlices: []insertSliceValue{
 			{
-				atSlice: []string{"well", "now"},
-				value:   5,
+				valuePath: []string{"well", "now"},
+				value:     5,
 			},
 			{
-				atSlice: []string{"foo"},
-				value:   "kek",
+				valuePath: []string{"foo"},
+				value:     "kek",
 			},
 		},
 		expectedMap: map[string]interface{}{
@@ -158,7 +158,7 @@ func (s *CommonSuite) TestAddValueToMap(c *gc.C) {
 	}} {
 		c.Logf("test %d: should %s", i, t.should)
 		for _, sVal := range t.insertSlices {
-			addValueToMap(sVal.atSlice, sVal.value, t.startingMap)
+			addValueToMap(sVal.valuePath, sVal.value, t.startingMap)
 		}
 		// note addValueToMap mutates target.
 		c.Check(t.startingMap, jc.DeepEquals, t.expectedMap)

--- a/cmd/juju/action/common_test.go
+++ b/cmd/juju/action/common_test.go
@@ -115,11 +115,16 @@ func (s *CommonSuite) TestConform(c *gc.C) {
 	}
 }
 
+type insertSliceValue struct {
+	atSlice []string
+	value   interface{}
+}
+
 func (s *CommonSuite) TestAddValueToMap(c *gc.C) {
 	for i, t := range []struct {
 		should       string
 		startingMap  map[string]interface{}
-		insertSlices [][]string
+		insertSlices []insertSliceValue
 		expectedMap  map[string]interface{}
 	}{{
 		should: "insert a couple of values",
@@ -130,9 +135,15 @@ func (s *CommonSuite) TestAddValueToMap(c *gc.C) {
 				"bur": "bor",
 			},
 		},
-		insertSlices: [][]string{
-			{"well", "now", "5"},
-			{"foo", "kek"},
+		insertSlices: []insertSliceValue{
+			{
+				atSlice: []string{"well", "now"},
+				value:   5,
+			},
+			{
+				atSlice: []string{"foo"},
+				value:   "kek",
+			},
 		},
 		expectedMap: map[string]interface{}{
 			"foo": "kek",
@@ -141,14 +152,13 @@ func (s *CommonSuite) TestAddValueToMap(c *gc.C) {
 				"bur": "bor",
 			},
 			"well": map[string]interface{}{
-				"now": "5",
+				"now": 5,
 			},
 		},
 	}} {
 		c.Logf("test %d: should %s", i, t.should)
-		for _, thisSlice := range t.insertSlices {
-			valAt := len(thisSlice) - 1
-			addValueToMap(thisSlice[:valAt], thisSlice[valAt], t.startingMap)
+		for _, sVal := range t.insertSlices {
+			addValueToMap(sVal.atSlice, sVal.value, t.startingMap)
 		}
 		// note addValueToMap mutates target.
 		c.Check(t.startingMap, jc.DeepEquals, t.expectedMap)

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -32,3 +32,7 @@ func (c *DoCommand) ParamsYAMLPath() string {
 func (c *DoCommand) KeyValueDoArgs() [][]string {
 	return c.args
 }
+
+func (c *DoCommand) ParseStrings() bool {
+	return c.parseStrings
+}


### PR DESCRIPTION
Using --string-args will interpret all passed values as raw strings;
otherwise we assume we have YAML for our values.