### PR TITLE
Set environment variables from correct values

### DIFF
--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -145,7 +145,7 @@ func (w *proxyWorker) writeEnvironment() error {
 }
 
 func (w *proxyWorker) handleProxyValues(proxySettings proxyutils.Settings) {
-	w.proxy.SetEnvironmentValues()
+	proxySettings.SetEnvironmentValues()
 	if proxySettings != w.proxy || w.first {
 		logger.Debugf("new proxy settings %#v", proxySettings)
 		w.proxy = proxySettings


### PR DESCRIPTION
A fix to an incorrectly done backport. Set proxy environment variables from the new values not the old ones.

(Review request: http://reviews.vapour.ws/r/898/)