### PR TITLE
Clean up output for `defined` and `fetch`

### DIFF
--- a/cmd/juju/action/defined.go
+++ b/cmd/juju/action/defined.go
@@ -80,7 +80,12 @@ func (c *DefinedCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if c.fullSchema {
-		return c.out.Write(ctx, output)
+		verboseSpecs := make(map[string]interface{})
+		for k, v := range output {
+			verboseSpecs[k] = v.Params
+		}
+
+		return c.out.Write(ctx, verboseSpecs)
 	}
 
 	shortOutput := make(map[string]string)

--- a/cmd/juju/action/defined_test.go
+++ b/cmd/juju/action/defined_test.go
@@ -143,10 +143,11 @@ func (s *DefinedSuite) TestRun(c *gc.C) {
 }
 
 func checkFullSchema(c *gc.C, expected *charm.Actions, actual []byte) {
-	unmarshaledActual := map[string]interface{}{}
-	err := yaml.Unmarshal([]byte(actual), &unmarshaledActual)
-	c.Assert(err, gc.IsNil)
-	c.Check(string(actual), jc.YAMLEquals, expected.ActionSpecs)
+	expectedOutput := make(map[string]interface{})
+	for k, v := range expected.ActionSpecs {
+		expectedOutput[k] = v.Params
+	}
+	c.Check(string(actual), jc.YAMLEquals, expectedOutput)
 }
 
 func checkSimpleSchema(c *gc.C, expected *charm.Actions, actualOutput []byte) {

--- a/cmd/juju/action/fetch.go
+++ b/cmd/juju/action/fetch.go
@@ -5,6 +5,7 @@ package action
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/cmd"
 	errors "github.com/juju/errors"
@@ -91,14 +92,29 @@ func (c *FetchCommand) Run(ctx *cmd.Context) error {
 }
 
 func formatActionResult(result params.ActionResult) map[string]interface{} {
-	return map[string]interface{}{
-		"status":  result.Status,
-		"message": result.Message,
-		"results": result.Output,
-		"timing": map[string]string{
-			"enqueued":  result.Enqueued.String(),
-			"started":   result.Started.String(),
-			"completed": result.Completed.String(),
-		},
+	response := map[string]interface{}{"status": result.Status}
+	if result.Message != "" {
+		response["message"] = result.Message
 	}
+	if len(result.Output) != 0 {
+		response["results"] = result.Output
+	}
+
+	if result.Enqueued.IsZero() && result.Started.IsZero() && result.Completed.IsZero() {
+		return response
+	}
+
+	responseTiming := make(map[string]string)
+	for k, v := range map[string]time.Time{
+		"enqueued":  result.Enqueued,
+		"started":   result.Started,
+		"completed": result.Completed,
+	} {
+		if !v.IsZero() {
+			responseTiming[k] = v.String()
+		}
+	}
+	response["timing"] = responseTiming
+
+	return response
 }

--- a/cmd/juju/action/fetch_test.go
+++ b/cmd/juju/action/fetch_test.go
@@ -115,6 +115,72 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 			"  enqueued: 2015-02-14 08:13:00 \\+0000 UTC\n" +
 			"  started: 2015-02-14 08:15:00 \\+0000 UTC\n" +
 			"",
+	}, {
+		should:   "pretty-print action output with no completed time",
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		withResults: []params.ActionResult{{
+			Status: "pending",
+			Output: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			},
+			Enqueued: time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:  time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+		}},
+		expectedOutput: "" +
+			"results:\n" +
+			"  foo:\n" +
+			"    bar: baz\n" +
+			"status: pending\n" +
+			"timing:\n" +
+			"  enqueued: 2015-02-14 08:13:00 \\+0000 UTC\n" +
+			"  started: 2015-02-14 08:15:00 \\+0000 UTC\n" +
+			"",
+	}, {
+		should:   "pretty-print action output with no enqueued time",
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		withResults: []params.ActionResult{{
+			Status: "pending",
+			Output: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			},
+			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
+			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+		}},
+		expectedOutput: "" +
+			"results:\n" +
+			"  foo:\n" +
+			"    bar: baz\n" +
+			"status: pending\n" +
+			"timing:\n" +
+			"  completed: 2015-02-14 08:15:30 \\+0000 UTC\n" +
+			"  started: 2015-02-14 08:15:00 \\+0000 UTC\n" +
+			"",
+	}, {
+		should:   "pretty-print action output with no started time",
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		withResults: []params.ActionResult{{
+			Status: "pending",
+			Output: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
+		}},
+		expectedOutput: "" +
+			"results:\n" +
+			"  foo:\n" +
+			"    bar: baz\n" +
+			"status: pending\n" +
+			"timing:\n" +
+			"  completed: 2015-02-14 08:15:30 \\+0000 UTC\n" +
+			"  enqueued: 2015-02-14 08:13:00 \\+0000 UTC\n" +
+			"",
 	}}
 
 	for i, t := range tests {

--- a/cmd/juju/action/fetch_test.go
+++ b/cmd/juju/action/fetch_test.go
@@ -50,10 +50,10 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 	}}
 
 	for i, t := range tests {
-		s.subcommand = &action.FetchCommand{}
+
 		c.Logf("test %d: it should %s: juju actions fetch %s", i,
 			t.should, strings.Join(t.args, " "))
-		err := testing.InitCommand(s.subcommand, t.args)
+		err := testing.InitCommand(&action.FetchCommand{}, t.args)
 		if t.expectError != "" {
 			c.Check(err, gc.ErrorMatches, t.expectError)
 		}
@@ -62,37 +62,37 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 
 func (s *FetchSuite) TestRun(c *gc.C) {
 	tests := []struct {
-		should         string
-		withTags       params.FindTagsResults
-		withResults    []params.ActionResult
-		withAPIError   string
-		expectedErr    string
-		expectedOutput string
+		should          string
+		withTags        params.FindTagsResults
+		withAPIResponse []params.ActionResult
+		withAPIError    string
+		expectedErr     string
+		expectedOutput  string
 	}{{
 		should:       "pass api error through properly",
 		withAPIError: "api call error",
 		expectedErr:  "api call error",
 	}, {
-		should:      "fail with no results",
-		withTags:    tagsForIdPrefix(validActionId),
-		withResults: []params.ActionResult{},
-		expectedErr: `actions for identifier "` + validActionId + `" not found`,
+		should:          "fail with no results",
+		withTags:        tagsForIdPrefix(validActionId),
+		withAPIResponse: []params.ActionResult{},
+		expectedErr:     `actions for identifier "` + validActionId + `" not found`,
 	}, {
-		should:      "error correctly with multiple results",
-		withTags:    tagsForIdPrefix(validActionId, validActionTagString),
-		withResults: []params.ActionResult{{}, {}},
-		expectedErr: "too many results for action " + validActionId,
+		should:          "error correctly with multiple results",
+		withTags:        tagsForIdPrefix(validActionId, validActionTagString),
+		withAPIResponse: []params.ActionResult{{}, {}},
+		expectedErr:     "too many results for action " + validActionId,
 	}, {
 		should:   "pass through an error from the API server",
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
-		withResults: []params.ActionResult{{
+		withAPIResponse: []params.ActionResult{{
 			Error: common.ServerError(errors.New("an apiserver error")),
 		}},
 		expectedErr: "an apiserver error",
 	}, {
 		should:   "pretty-print action output",
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
-		withResults: []params.ActionResult{{
+		withAPIResponse: []params.ActionResult{{
 			Status:  "complete",
 			Message: "oh dear",
 			Output: map[string]interface{}{
@@ -104,21 +104,21 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
-		expectedOutput: "" +
-			"message: oh dear\n" +
-			"results:\n" +
-			"  foo:\n" +
-			"    bar: baz\n" +
-			"status: complete\n" +
-			"timing:\n" +
-			"  completed: 2015-02-14 08:15:30 \\+0000 UTC\n" +
-			"  enqueued: 2015-02-14 08:13:00 \\+0000 UTC\n" +
-			"  started: 2015-02-14 08:15:00 \\+0000 UTC\n" +
-			"",
+		expectedOutput: `
+message: oh dear
+results:
+  foo:
+    bar: baz
+status: complete
+timing:
+  completed: 2015-02-14 08:15:30 +0000 UTC
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+  started: 2015-02-14 08:15:00 +0000 UTC
+`[1:],
 	}, {
 		should:   "pretty-print action output with no completed time",
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
-		withResults: []params.ActionResult{{
+		withAPIResponse: []params.ActionResult{{
 			Status: "pending",
 			Output: map[string]interface{}{
 				"foo": map[string]interface{}{
@@ -128,19 +128,19 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 			Enqueued: time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
 			Started:  time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 		}},
-		expectedOutput: "" +
-			"results:\n" +
-			"  foo:\n" +
-			"    bar: baz\n" +
-			"status: pending\n" +
-			"timing:\n" +
-			"  enqueued: 2015-02-14 08:13:00 \\+0000 UTC\n" +
-			"  started: 2015-02-14 08:15:00 \\+0000 UTC\n" +
-			"",
+		expectedOutput: `
+results:
+  foo:
+    bar: baz
+status: pending
+timing:
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+  started: 2015-02-14 08:15:00 +0000 UTC
+`[1:],
 	}, {
 		should:   "pretty-print action output with no enqueued time",
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
-		withResults: []params.ActionResult{{
+		withAPIResponse: []params.ActionResult{{
 			Status: "pending",
 			Output: map[string]interface{}{
 				"foo": map[string]interface{}{
@@ -150,19 +150,19 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 		}},
-		expectedOutput: "" +
-			"results:\n" +
-			"  foo:\n" +
-			"    bar: baz\n" +
-			"status: pending\n" +
-			"timing:\n" +
-			"  completed: 2015-02-14 08:15:30 \\+0000 UTC\n" +
-			"  started: 2015-02-14 08:15:00 \\+0000 UTC\n" +
-			"",
+		expectedOutput: `
+results:
+  foo:
+    bar: baz
+status: pending
+timing:
+  completed: 2015-02-14 08:15:30 +0000 UTC
+  started: 2015-02-14 08:15:00 +0000 UTC
+`[1:],
 	}, {
 		should:   "pretty-print action output with no started time",
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
-		withResults: []params.ActionResult{{
+		withAPIResponse: []params.ActionResult{{
 			Status: "pending",
 			Output: map[string]interface{}{
 				"foo": map[string]interface{}{
@@ -172,38 +172,47 @@ func (s *FetchSuite) TestRun(c *gc.C) {
 			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
-		expectedOutput: "" +
-			"results:\n" +
-			"  foo:\n" +
-			"    bar: baz\n" +
-			"status: pending\n" +
-			"timing:\n" +
-			"  completed: 2015-02-14 08:15:30 \\+0000 UTC\n" +
-			"  enqueued: 2015-02-14 08:13:00 \\+0000 UTC\n" +
-			"",
+		expectedOutput: `
+results:
+  foo:
+    bar: baz
+status: pending
+timing:
+  completed: 2015-02-14 08:15:30 +0000 UTC
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+`[1:],
 	}}
 
 	for i, t := range tests {
-		func() { // for the defer of restoring patch function
-			client := &fakeAPIClient{
-				actionTagMatches: t.withTags,
-				actionResults:    t.withResults,
-			}
-			if t.withAPIError != "" {
-				client.apiErr = errors.New(t.withAPIError)
-			}
-			defer s.BaseActionSuite.patchAPIClient(client)()
-
-			s.subcommand = &action.FetchCommand{}
-			c.Logf("test %d: it should %s", i, t.should)
-
-			ctx, err := testing.RunCommand(c, s.subcommand, validActionId)
-			if t.expectedErr != "" || t.withAPIError != "" {
-				c.Check(err, gc.ErrorMatches, t.expectedErr)
-			} else {
-				c.Assert(err, gc.IsNil)
-				c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Matches, t.expectedOutput)
-			}
-		}()
+		c.Logf("test %d: should %s", i, t.should)
+		testRunHelper(
+			c, s,
+			makeFakeClient(t.withTags, t.withAPIResponse, t.withAPIError),
+			t.expectedErr,
+			t.expectedOutput,
+		)
 	}
+}
+
+func testRunHelper(c *gc.C, s *FetchSuite, client *fakeAPIClient, expectedErr, expectedOutput string) {
+	unpatch := s.BaseActionSuite.patchAPIClient(client)
+	defer unpatch()
+	ctx, err := testing.RunCommand(c, &action.FetchCommand{}, validActionId)
+	if expectedErr != "" {
+		c.Check(err, gc.ErrorMatches, expectedErr)
+	} else {
+		c.Assert(err, gc.IsNil)
+		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, expectedOutput)
+	}
+}
+
+func makeFakeClient(tags params.FindTagsResults, response []params.ActionResult, errStr string) *fakeAPIClient {
+	client := &fakeAPIClient{
+		actionTagMatches: tags,
+		actionResults:    response,
+	}
+	if errStr != "" {
+		client.apiErr = errors.New(errStr)
+	}
+	return client
 }


### PR DESCRIPTION
This PR removes empty values from `juju action fetch` output and cleans up
the output of `juju action defined`.