### PR TITLE
Implement prepare for new environment for the local provider.

### DIFF
--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -38,6 +38,8 @@ func minimalConfig(c *gc.C) *config.Config {
 	minimal := minimalConfigValues()
 	testConfig, err := config.New(config.NoDefaults, minimal)
 	c.Assert(err, jc.ErrorIsNil)
+	testConfig, err = local.Provider.PrepareForCreateEnvironment(testConfig)
+	c.Assert(err, jc.ErrorIsNil)
 	valid, err := local.Provider.Validate(testConfig, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return valid
@@ -49,6 +51,8 @@ func localConfig(c *gc.C, extra map[string]interface{}) *config.Config {
 		values[key] = value
 	}
 	testConfig, err := config.New(config.NoDefaults, values)
+	c.Assert(err, jc.ErrorIsNil)
+	testConfig, err = local.Provider.PrepareForCreateEnvironment(testConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	valid, err := local.Provider.Validate(testConfig, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -63,46 +67,38 @@ func (s *configSuite) TestDefaultNetworkBridge(c *gc.C) {
 }
 
 func (s *configSuite) TestDefaultNetworkBridgeForKVMContainers(c *gc.C) {
-	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+	testConfig := localConfig(c, map[string]interface{}{
 		"container": "kvm",
 	})
-	testConfig, err := config.New(config.NoDefaults, minAttrs)
-	c.Assert(err, jc.ErrorIsNil)
 	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
 	c.Check(containerType, gc.Equals, string(instance.KVM))
 	c.Check(bridgeName, gc.Equals, kvm.DefaultKvmBridge)
 }
 
 func (s *configSuite) TestExplicitNetworkBridgeForLXCContainers(c *gc.C) {
-	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+	testConfig := localConfig(c, map[string]interface{}{
 		"container":      "lxc",
 		"network-bridge": "foo",
 	})
-	testConfig, err := config.New(config.NoDefaults, minAttrs)
-	c.Assert(err, jc.ErrorIsNil)
 	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
 	c.Check(containerType, gc.Equals, string(instance.LXC))
 	c.Check(bridgeName, gc.Equals, "foo")
 }
 
 func (s *configSuite) TestExplicitNetworkBridgeForKVMContainers(c *gc.C) {
-	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+	testConfig := localConfig(c, map[string]interface{}{
 		"container":      "kvm",
 		"network-bridge": "lxcbr0",
 	})
-	testConfig, err := config.New(config.NoDefaults, minAttrs)
-	c.Assert(err, jc.ErrorIsNil)
 	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
 	c.Check(containerType, gc.Equals, string(instance.KVM))
 	c.Check(bridgeName, gc.Equals, "lxcbr0")
 }
 
 func (s *configSuite) TestDefaultNetworkBridgeForLXCContainers(c *gc.C) {
-	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+	testConfig := localConfig(c, map[string]interface{}{
 		"container": "lxc",
 	})
-	testConfig, err := config.New(config.NoDefaults, minAttrs)
-	c.Assert(err, jc.ErrorIsNil)
 	containerType, bridgeName := local.ContainerAndBridge(c, testConfig)
 	c.Check(containerType, gc.Equals, string(instance.LXC))
 	c.Check(bridgeName, gc.Equals, lxc.DefaultLxcBridge)
@@ -154,8 +150,9 @@ func (s *configSuite) TestValidateConfigWithFloatPort(c *gc.C) {
 }
 
 func (s *configSuite) TestNamespace(c *gc.C) {
-	testConfig := minimalConfig(c)
 	s.PatchEnvironment("USER", "tester")
+	testConfig := minimalConfig(c)
+	c.Logf("\n\nname: %s\n\n", testConfig.Name())
 	c.Assert(local.ConfigNamespace(testConfig), gc.Equals, "tester-test")
 }
 
@@ -174,13 +171,9 @@ func (s *configSuite) TestLocalDisablesUpgradesWhenCloning(c *gc.C) {
 	c.Check(testConfig.EnableOSUpgrade(), jc.IsTrue)
 
 	// If using lxc-clone, we set updates to false
-	minAttrs := testing.FakeConfig().Merge(testing.Attrs{
+	validConfig := localConfig(c, map[string]interface{}{
 		"lxc-clone": true,
 	})
-	testConfig, err := config.New(config.NoDefaults, minAttrs)
-	c.Assert(err, jc.ErrorIsNil)
-	validConfig, err := local.Provider.Validate(testConfig, nil)
-	c.Assert(err, jc.ErrorIsNil)
 	c.Check(validConfig.EnableOSRefreshUpdate(), jc.IsTrue)
 	c.Check(validConfig.EnableOSUpgrade(), jc.IsFalse)
 }

--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -153,7 +153,7 @@ func (s *configSuite) TestNamespace(c *gc.C) {
 	s.PatchEnvironment("USER", "tester")
 	testConfig := minimalConfig(c)
 	c.Logf("\n\nname: %s\n\n", testConfig.Name())
-	c.Assert(local.ConfigNamespace(testConfig), gc.Equals, "tester-test")
+	local.CheckConfigNamespace(c, testConfig, "tester-test")
 }
 
 func (s *configSuite) TestBootstrapAsRoot(c *gc.C) {

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -242,7 +242,7 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 	ecfg, err := providerInstance.newConfig(cfg)
 	if err != nil {
 		logger.Errorf("failed to create new environ config: %v", err)
-		return err
+		return errors.Trace(err)
 	}
 	env.localMutex.Lock()
 	defer env.localMutex.Unlock()
@@ -274,7 +274,7 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 	env.containerManager, err = factory.NewContainerManager(
 		containerType, managerConfig, imageURLGetter)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	// When the localEnviron value is created on the client
@@ -288,18 +288,18 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 	// httpstorage.
 	if addr := ecfg.bootstrapIPAddress(); addr != "" {
 		env.bridgeAddress = addr
-		return nil
+		return errors.Trace(err)
 	}
 	// If we get to here, it is because we haven't yet bootstrapped an
 	// environment, and saved the config in it, or we are running a command
 	// from the command line, so it is ok to work on the assumption that we
 	// have direct access to the directories.
 	if err := env.config.createDirs(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	// Record the network bridge address and create a filestorage.
 	if err := env.resolveBridgeAddress(cfg); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return env.setLocalStorage()
 }

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -288,7 +288,7 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 	// httpstorage.
 	if addr := ecfg.bootstrapIPAddress(); addr != "" {
 		env.bridgeAddress = addr
-		return errors.Trace(err)
+		return nil
 	}
 	// If we get to here, it is because we haven't yet bootstrapped an
 	// environment, and saved the config in it, or we are running a command

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -166,14 +166,14 @@ func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*confi
 
 // Prepare implements environs.EnvironProvider.Prepare.
 func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	// The user must not set bootstrap-ip; this is determined by the provider,
-	// and its presence used to determine whether the environment has yet been
-	// bootstrapped.
 	cfg, err := p.PrepareForCreateEnvironment(cfg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
+	// The user must not set bootstrap-ip; this is determined by the provider,
+	// and its presence used to determine whether the environment has yet been
+	// bootstrapped.
 	if _, ok := cfg.UnknownAttrs()["bootstrap-ip"]; ok {
 		return nil, errors.Errorf("bootstrap-ip must not be specified")
 	}

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -164,7 +164,7 @@ func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*confi
 	return cfg, nil
 }
 
-// Prepare implements environs.EnvironProvider.Prepare.
+// PrepareForBootstrap implements environs.EnvironProvider.PrepareForBootstrap.
 func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	cfg, err := p.PrepareForCreateEnvironment(cfg)
 	if err != nil {

--- a/provider/local/export_test.go
+++ b/provider/local/export_test.go
@@ -3,7 +3,6 @@
 package local
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -22,15 +21,13 @@ var (
 	UserCurrent        = &userCurrent
 )
 
-// ConfigNamespace returns the result of the namespace call on the
+// CheckConfigNamespace checks the result of the namespace call on the
 // localConfig.
-func ConfigNamespace(cfg *config.Config) string {
+func CheckConfigNamespace(c *gc.C, cfg *config.Config, expected string) {
 	env, err := providerInstance.Open(cfg)
-	if err != nil {
-		logger.Debugf(errors.ErrorStack(err))
-		panic(err)
-	}
-	return env.(*localEnviron).config.namespace()
+	c.Assert(err, jc.ErrorIsNil)
+	namespace := env.(*localEnviron).config.namespace()
+	c.Assert(namespace, gc.Equals, expected)
 }
 
 // CreateDirs calls createDirs on the localEnviron.

--- a/provider/local/export_test.go
+++ b/provider/local/export_test.go
@@ -3,6 +3,7 @@
 package local
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -24,7 +25,11 @@ var (
 // ConfigNamespace returns the result of the namespace call on the
 // localConfig.
 func ConfigNamespace(cfg *config.Config) string {
-	env, _ := providerInstance.Open(cfg)
+	env, err := providerInstance.Open(cfg)
+	if err != nil {
+		logger.Debugf(errors.ErrorStack(err))
+		panic(err)
+	}
 	return env.(*localEnviron).config.namespace()
 }
 


### PR DESCRIPTION
Moved functionality common for prepare for new environment and prepare for bootstrap into the former, and make prepare for bootstrap call the other prepare method.

The Open method was modifying config, which it really shouldn't, so this setting of the namespace was moved into the prepare for new environment method. This caused many test failures, which had to be updated to make sure the config objects had called the prepare method first.

Some errors are now wrapped, and the test function ConfigNamespace now no longer throws away the error.

(Review request: http://reviews.vapour.ws/r/902/)