### PR TITLE
state/metrics.go: Fixed an issue with cleaning up old metrics

### DIFF
--- a/state/metrics.go
+++ b/state/metrics.go
@@ -165,7 +165,7 @@ func (st *State) MetricBatch(id string) (*MetricBatch, error) {
 // and have been sent. Any metrics it finds are deleted.
 func (st *State) CleanupOldMetrics() error {
 	age := time.Now().Add(-(CleanupAge))
-	metricsLogger.Tracef("cleaning up metrics older than %v", age)
+	metricsLogger.Tracef("cleaning up metrics created before %v", age)
 	c, closer := st.getCollection(metricsC)
 	defer closer()
 	// Nothing else in the system will interact with sent metrics, and nothing needs

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -165,19 +165,17 @@ func (st *State) MetricBatch(id string) (*MetricBatch, error) {
 // and have been sent. Any metrics it finds are deleted.
 func (st *State) CleanupOldMetrics() error {
 	age := time.Now().Add(-(CleanupAge))
+	metricsLogger.Tracef("cleaning up metrics older than %v", age)
 	c, closer := st.getCollection(metricsC)
 	defer closer()
 	// Nothing else in the system will interact with sent metrics, and nothing needs
 	// to watch them either; so in this instance it's safe to do an end run around the
 	// mgo/txn package. See State.cleanupRelationSettings for a similar situation.
-	err := c.Remove(bson.M{
+	info, err := c.RemoveAll(bson.M{
 		"sent":    true,
 		"created": bson.M{"$lte": age},
 	})
-	if err == mgo.ErrNotFound {
-		metricsLogger.Infof("no metrics found to cleanup")
-		return nil
-	}
+	metricsLogger.Tracef("cleanup removed %d metrics", info.Removed)
 	return errors.Trace(err)
 }
 


### PR DESCRIPTION
We were making the wrong call to remove old sent metrics from the db, I've improved the test to capture this and fixed the bug.

Backport of #1561 for 1.22.

(Review request: http://reviews.vapour.ws/r/903/)