### PR TITLE
Fix 1420306 and 1420316

### DIFF
--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -170,8 +170,8 @@ var updateBootstrapMachineTemplate = mustParseTemplate(`
 		db.machines.update({machineid: "0"}, {$set: {instanceid: {{.NewInstanceId | printf "%q" }} } })
 		db.instanceData.update({_id: "0"}, {$set: {instanceid: {{.NewInstanceId | printf "%q" }} } })
 		db.machines.remove({machineid: {$ne:"0"}, hasvote: true})
-		db.stateServers.update({"_id":"e"}, {$set:{"machineids" : [0]}})
-		db.stateServers.update({"_id":"e"}, {$set:{"votingmachineids" : [0]}})
+		db.stateServers.update({"_id":"e"}, {$set:{"machineids" : ["0"]}})
+		db.stateServers.update({"_id":"e"}, {$set:{"votingmachineids" : ["0"]}})
 	'
 
 	# Give time to replset to initiate

--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -168,6 +168,7 @@ var updateBootstrapMachineTemplate = mustParseTemplate(`
 	mongoAdminEval '
 		db = db.getSiblingDB("juju")
 		db.machines.update({machineid: "0"}, {$set: {instanceid: {{.NewInstanceId | printf "%q" }} } })
+		db.machines.update({machineid: "0"}, {$set: {"addresses": ["{{.Address}}"] } })
 		db.instanceData.update({_id: "0"}, {$set: {instanceid: {{.NewInstanceId | printf "%q" }} } })
 		db.machines.remove({machineid: {$ne:"0"}, hasvote: true})
 		db.stateServers.update({"_id":"e"}, {$set:{"machineids" : ["0"]}})


### PR DESCRIPTION
Fix 1420306:

* Use string instead of int for machineids in stateservers collection.
* Use string instead of int for votingmachineids in stateservers collection.

Fix 1420316:

* Re-set addresses array for machine 0 in machines collection.

(Review request: http://reviews.vapour.ws/r/911/)