### PR TITLE
Implement loop storage provider

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -304,9 +304,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	}}
 	volumeAttachments := []params.VolumeAttachment{{
 		VolumeTag:  "disk-0",
-		VolumeId:   "vol-123",
 		MachineTag: "machine-1",
-		InstanceId: "i-will",
 		DeviceName: "xvdf1",
 	}}
 

--- a/apiserver/diskformatter/diskformatter.go
+++ b/apiserver/diskformatter/diskformatter.go
@@ -158,9 +158,7 @@ func (a *DiskFormatterAPI) oneAttachedVolumes(tag names.MachineTag) ([]params.Vo
 		if _, ok := matchingBlockDevice(blockDevices, volumeInfo, attachmentInfo); ok {
 			result = append(result, params.VolumeAttachment{
 				attachment.Volume().String(),
-				volumeInfo.VolumeId,
 				attachment.Machine().String(),
-				"", // instance ID is not important
 				attachmentInfo.DeviceName,
 			})
 		}

--- a/apiserver/diskformatter/diskformatter_test.go
+++ b/apiserver/diskformatter/diskformatter_test.go
@@ -118,11 +118,9 @@ func (s *DiskFormatterSuite) TestAttachedVolumes(c *gc.C) {
 		Results: []params.VolumeAttachmentsResult{{
 			Attachments: []params.VolumeAttachment{{
 				VolumeTag:  volume0.String(),
-				VolumeId:   "vol-0",
 				MachineTag: machine0.String(),
 			}, {
 				VolumeTag:  volume1.String(),
-				VolumeId:   "vol-1",
 				MachineTag: machine0.String(),
 				DeviceName: "sdb",
 			}},

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -120,9 +120,7 @@ type VolumeAttachmentIds struct {
 // VolumeAttachment describes a volume attachment.
 type VolumeAttachment struct {
 	VolumeTag  string `json:"volumetag"`
-	VolumeId   string `json:"volumeid"`
 	MachineTag string `json:"machinetag"`
-	InstanceId string `json:"instanceid,omitempty"`
 	DeviceName string `json:"devicename,omitempty"`
 }
 

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1050,9 +1050,7 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		}},
 		VolumeAttachments: []params.VolumeAttachment{{
 			VolumeTag:  "disk-0",
-			VolumeId:   "vol-0",
 			MachineTag: volumesMachine.Tag().String(),
-			InstanceId: "i-am-also",
 			DeviceName: "sda",
 		}},
 	},

--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -111,9 +111,8 @@ func getBlockDeviceMappings(
 		}
 		attachment := storage.VolumeAttachment{
 			Volume:     params.Tag,
+			Machine:    params.Attachment.Machine,
 			DeviceName: actualDeviceName,
-			// MachineId, InstanceId and VolumeID are filled out
-			// by the caller once the information is available.
 		}
 		blockDeviceMappings = append(blockDeviceMappings, mapping)
 		volumes[i] = volume
@@ -124,6 +123,9 @@ func getBlockDeviceMappings(
 
 // validateVolumParams validates the volume parameters.
 func validateVolumeParams(params storage.VolumeParams) error {
+	if params.Attachment == nil {
+		return errors.NotImplementedf("allocating unattached volumes")
+	}
 	if params.Size > volumeSizeMaxMiB {
 		return errors.Errorf("%d MiB exceeds the maximum of %d MiB", params.Size, volumeSizeMaxMiB)
 	}

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -83,15 +83,26 @@ func (*DisksSuite) TestBlockDeviceNamer(c *gc.C) {
 func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 	volume0 := names.NewDiskTag("0")
 	volume1 := names.NewDiskTag("1")
+	machine0 := names.NewMachineTag("0")
 
 	mapping, volumes, volumeAttachments, err := ec2.GetBlockDeviceMappings(
-		"pv", &environs.StartInstanceParams{Volumes: []storage.VolumeParams{
-			{Tag: volume0, Size: 1234},
-			{Tag: volume1,
-				Size:       4321,
-				Attributes: map[string]interface{}{"volume-type": "standard", "iops": "1234"},
+		"pv", &environs.StartInstanceParams{Volumes: []storage.VolumeParams{{
+			Tag:  volume0,
+			Size: 1234,
+			Attachment: &storage.AttachmentParams{
+				Machine: machine0,
 			},
-		}},
+		}, {
+			Tag:  volume1,
+			Size: 4321,
+			Attributes: map[string]interface{}{
+				"volume-type": "standard",
+				"iops":        "1234",
+			},
+			Attachment: &storage.AttachmentParams{
+				Machine: machine0,
+			},
+		}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mapping, gc.DeepEquals, []amzec2.BlockDeviceMapping{{
@@ -123,7 +134,7 @@ func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 		{Tag: volume1, Size: 5120},
 	})
 	c.Assert(volumeAttachments, gc.DeepEquals, []storage.VolumeAttachment{
-		{Volume: volume0, DeviceName: "xvdf1"},
-		{Volume: volume1, DeviceName: "xvdf2"},
+		{Volume: volume0, Machine: machine0, DeviceName: "xvdf1"},
+		{Volume: volume1, Machine: machine0, DeviceName: "xvdf2"},
 	})
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	"github.com/juju/utils"
 	"gopkg.in/amz.v2/aws"
 	"gopkg.in/amz.v2/ec2"
@@ -521,10 +520,6 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	// TODO(axw) extract volume ID, store in BlockDevice.ProviderId field,
 	// and tag all resources (instances and volumes). We can't do this until
 	// goamz's BlockDeviceMapping structure is updated to include VolumeId.
-	for i := range volumes {
-		volumeAttachments[i].Machine = names.NewMachineTag(args.MachineConfig.MachineId)
-		volumeAttachments[i].InstanceId = inst.Id()
-	}
 
 	if multiwatcher.AnyJobNeedsState(args.MachineConfig.Jobs...) {
 		if err := common.AddStateInstance(e.Storage(), inst.Id()); err != nil {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"gopkg.in/amz.v2/aws"
@@ -902,13 +903,20 @@ func (t *localServerSuite) TestStartInstanceVolumes(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
+	attachmentParams := &storage.AttachmentParams{
+		Machine: names.NewMachineTag("0"),
+	}
+
 	params := environs.StartInstanceParams{
 		Volumes: []storage.VolumeParams{{
-			Size: 512, // round up to 1GiB
+			Size:       512, // round up to 1GiB
+			Attachment: attachmentParams,
 		}, {
-			Size: 1024, // 1GiB exactly
+			Size:       1024, // 1GiB exactly
+			Attachment: attachmentParams,
 		}, {
-			Size: 1025, // round up to 2GiB
+			Size:       1025, // round up to 2GiB
+			Attachment: attachmentParams,
 		}},
 	}
 	result, err := testing.StartInstanceWithParams(env, "1", params, nil)

--- a/storage/config.go
+++ b/storage/config.go
@@ -3,6 +3,19 @@
 
 package storage
 
+const (
+	// ConfigStorageDir is the path to the directory which a
+	// machine-scoped storage source may use to contain storage
+	// artifacts. This should not be used for environment-wide
+	// storage sources, as the contents are bound to the
+	// lifetime of the machine.
+	//
+	// ConfigStorageDir is set by the storage provisioner, so
+	// should not be relied upon until a storage source is
+	// constructed.
+	ConfigStorageDir = "storage-dir"
+)
+
 // Config defines the configuration for a storage source.
 type Config struct {
 	name     string

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -20,15 +20,7 @@ type Provider interface {
 	// If the storage provider does not support creating volumes as a
 	// first-class primitive, then VolumeSource must return an error
 	// satisfying errors.IsNotSupported.
-	//
-	// The storage provider may use the provided storage directory
-	// to contain local storage artifacts for machine-scoped storage.
-	// The directory does not necessarily exist.
-	VolumeSource(
-		environConfig *config.Config,
-		providerConfig *Config,
-		storageDir string,
-	) (VolumeSource, error)
+	VolumeSource(environConfig *config.Config, providerConfig *Config) (VolumeSource, error)
 
 	// TODO(axw) define filesystem source. If the user requests a
 	// filesystem and that can be provided first-class, it should be

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -20,7 +20,15 @@ type Provider interface {
 	// If the storage provider does not support creating volumes as a
 	// first-class primitive, then VolumeSource must return an error
 	// satisfying errors.IsNotSupported.
-	VolumeSource(environConfig *config.Config, providerConfig *Config) (VolumeSource, error)
+	//
+	// The storage provider may use the provided storage directory
+	// to contain local storage artifacts for machine-scoped storage.
+	// The directory does not necessarily exist.
+	VolumeSource(
+		environConfig *config.Config,
+		providerConfig *Config,
+		storageDir string,
+	) (VolumeSource, error)
 
 	// TODO(axw) define filesystem source. If the user requests a
 	// filesystem and that can be provided first-class, it should be
@@ -123,11 +131,11 @@ type VolumeAttachmentParams struct {
 // AttachmentParams describes the parameters for attaching a volume or
 // filesystem to a machine.
 type AttachmentParams struct {
-	// MachineId is the ID of the Juju machine that the storage should be
+	// Machine is the tag of the Juju machine that the storage should be
 	// attached to. Storage providers may use this to perform machine-
 	// specific operations, such as configuring access controls for the
 	// machine.
-	MachineId string
+	Machine names.MachineTag
 
 	// InstanceId is the ID of the cloud instance that the storage should
 	// be attached to. This will only be of interest to storage providers

--- a/storage/pool/defaultpool.go
+++ b/storage/pool/defaultpool.go
@@ -4,8 +4,6 @@
 package pool
 
 import (
-	"path/filepath"
-
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/storage"
@@ -43,10 +41,7 @@ func AddDefaultStoragePools(settings SettingsManager, config poolConfig) error {
 	}
 
 	// Register the default loop pool.
-	// TODO(wallyworld) - remove loop data dir as we don't want to hard code it here
-	cfg := map[string]interface{}{
-		provider.LoopDataDir: filepath.Join(config.DataDir(), "storage", "block", "loop"),
-	}
+	cfg := map[string]interface{}{}
 	return addDefaultPool(pm, "loop", provider.LoopProviderType, cfg)
 }
 

--- a/storage/provider/export_test.go
+++ b/storage/provider/export_test.go
@@ -8,3 +8,7 @@ import "github.com/juju/juju/storage"
 func LoopVolumeSource(storageDir string, run func(string, ...string) (string, error)) storage.VolumeSource {
 	return &loopVolumeSource{run, storageDir}
 }
+
+func LoopProvider(run func(string, ...string) (string, error)) storage.Provider {
+	return &loopProvider{run}
+}

--- a/storage/provider/export_test.go
+++ b/storage/provider/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import "github.com/juju/juju/storage"
+
+func LoopVolumeSource(storageDir string, run func(string, ...string) (string, error)) storage.VolumeSource {
+	return &loopVolumeSource{run, storageDir}
+}

--- a/storage/provider/init.go
+++ b/storage/provider/init.go
@@ -6,7 +6,7 @@ package provider
 import "github.com/juju/juju/storage"
 
 func init() {
-	storage.RegisterProvider(LoopProviderType, &loopProvider{})
+	storage.RegisterProvider(LoopProviderType, &loopProvider{logAndExec})
 
 	// TODO(axw) provide a function for registering common storage providers.
 }

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -4,87 +4,224 @@
 package provider
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/storage"
 )
 
 const (
-	// Loop provider types
+	// Loop provider types.
 	LoopProviderType     = storage.ProviderType("loop")
 	HostLoopProviderType = storage.ProviderType("hostloop")
-
-	// Config attributes
-	LoopDataDir = "data-dir" // top level directory where loop devices are created.
-	LoopSubDir  = "sub-dir"  // optional subdirectory for loop devices.
 )
 
 // loopProviders create volume sources which use loop devices.
-type loopProvider struct{}
+type loopProvider struct {
+	run runCommandFunc
+}
 
 var _ storage.Provider = (*loopProvider)(nil)
 
 // ValidateConfig is defined on the Provider interface.
 func (lp *loopProvider) ValidateConfig(providerConfig *storage.Config) error {
-	dataDir, ok := providerConfig.ValueString(LoopDataDir)
-	if !ok || dataDir == "" {
-		return errors.New("no data directory specified")
-	}
+	// Loop provider has no configuration.
 	return nil
 }
 
 // VolumeSource is defined on the Provider interface.
-func (lp *loopProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
-	if err := lp.ValidateConfig(providerConfig); err != nil {
+func (lp *loopProvider) VolumeSource(
+	environConfig *config.Config,
+	sourceConfig *storage.Config,
+	storageDir string,
+) (storage.VolumeSource, error) {
+	if err := lp.ValidateConfig(sourceConfig); err != nil {
 		return nil, err
 	}
-	dataDir, _ := providerConfig.ValueString(LoopDataDir)
-	subDir, _ := providerConfig.ValueString(LoopDataDir)
-	return &loopVolumeSource{
-		dataDir,
-		subDir,
-	}, nil
+	return &loopVolumeSource{lp.run, storageDir}, nil
 }
 
 // loopVolumeSource provides common functionality to handle
 // loop devices for rootfs and host loop volume sources.
 type loopVolumeSource struct {
-	dataDir string
-	subDir  string
+	run        runCommandFunc
+	storageDir string
 }
 
 var _ storage.VolumeSource = (*loopVolumeSource)(nil)
 
-func (lvs *loopVolumeSource) rootDeviceDir() string {
-	dirParts := []string{lvs.dataDir}
-	dirParts = append(dirParts, strings.Split(lvs.subDir, "/")...)
-	return filepath.Join(dirParts...)
+// CreateVolumes is defined on the VolumeSource interface.
+func (lvs *loopVolumeSource) CreateVolumes(args []storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
+	volumes := make([]storage.Volume, len(args))
+	volumeAttachments := make([]storage.VolumeAttachment, len(args))
+	for i, arg := range args {
+		volume, volumeAttachment, err := lvs.createVolume(arg)
+		if err != nil {
+			return nil, nil, errors.Annotate(err, "creating volume")
+		}
+		volumes[i] = volume
+		volumeAttachments[i] = volumeAttachment
+	}
+	return volumes, volumeAttachments, nil
 }
 
-func (lvs *loopVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
-	panic("not implemented")
+func (lvs *loopVolumeSource) createVolume(params storage.VolumeParams) (storage.Volume, storage.VolumeAttachment, error) {
+	var volume storage.Volume
+	var volumeAttachment storage.VolumeAttachment
+	if err := lvs.ValidateVolumeParams(params); err != nil {
+		return volume, volumeAttachment, errors.Trace(err)
+	}
+
+	volumeId := fmt.Sprintf("%s", params.Tag)
+	loopFilePath := lvs.volumeFilePath(volumeId)
+
+	if err := os.MkdirAll(lvs.storageDir, 0755); err != nil {
+		return volume, volumeAttachment, errors.Annotate(err, "creating storage directory")
+	}
+	if err := createBlockFile(lvs.run, loopFilePath, params.Size); err != nil {
+		return volume, volumeAttachment, errors.Annotate(err, "could not create block file")
+	}
+
+	deviceName, err := attachLoopDevice(lvs.run, loopFilePath)
+	if err != nil {
+		os.Remove(loopFilePath)
+		return volume, volumeAttachment, errors.Annotate(err, "attaching loop device")
+	}
+
+	volume = storage.Volume{
+		Tag:      params.Tag,
+		VolumeId: volumeId,
+		Size:     params.Size,
+	}
+	volumeAttachment = storage.VolumeAttachment{
+		Volume:     params.Tag,
+		Machine:    params.Attachment.Machine,
+		DeviceName: deviceName,
+	}
+	return volume, volumeAttachment, nil
 }
 
-func (lvs *loopVolumeSource) DescribeVolumes(volIds []string) ([]storage.Volume, error) {
-	panic("not implemented")
+func (lvs *loopVolumeSource) volumeFilePath(volumeId string) string {
+	return filepath.Join(lvs.storageDir, volumeId)
 }
 
-func (lvs *loopVolumeSource) DestroyVolumes(volIds []string) error {
-	panic("not implemented")
+// DescribeVolumes is defined on the VolumeSource interface.
+func (lvs *loopVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.Volume, error) {
+	// TODO(axw) implement this when we need it.
+	return nil, errors.NotImplementedf("DescribeVolumes")
 }
 
+// DestroyVolumes is defined on the VolumeSource interface.
+func (lvs *loopVolumeSource) DestroyVolumes(volumeIds []string) error {
+	for _, volumeId := range volumeIds {
+		if _, err := names.ParseDiskTag(volumeId); err != nil {
+			return errors.Errorf("invalid loop volume ID %q", volumeId)
+		}
+		loopFilePath := lvs.volumeFilePath(volumeId)
+		deviceNames, err := associatedLoopDevices(lvs.run, loopFilePath)
+		if err != nil {
+			return errors.Annotate(err, "locating loop device")
+		}
+		if len(deviceNames) > 1 {
+			logger.Warningf("expected 1 loop device, got %d", len(deviceNames))
+		}
+		for _, deviceName := range deviceNames {
+			if err := detachLoopDevice(lvs.run, deviceName); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		if err := os.Remove(loopFilePath); err != nil {
+			return errors.Annotate(err, "removing loop backing file")
+		}
+	}
+	return nil
+}
+
+// ValidateVolumeParams is defined on the VolumeSource interface.
 func (lvs *loopVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
-	panic("not implemented")
+	// ValdiateVolumeParams may be called on a machine other than the
+	// machine where the loop device will be created, so we cannot check
+	// available size until we get to CreateVolumes.
+	if params.Attachment == nil {
+		return errors.NotSupportedf(
+			"creating loop device without machine attachment",
+		)
+	}
+	return nil
 }
 
+// AttachVolumes is defined on the VolumeSource interface.
 func (lvs *loopVolumeSource) AttachVolumes([]storage.VolumeAttachmentParams) ([]storage.VolumeAttachment, error) {
-	panic("not implemented")
+	return nil, errors.NotSupportedf("attaching loop devices")
 }
 
+// DetachVolumes is defined on the VolumeSource interface.
 func (lvs *loopVolumeSource) DetachVolumes([]storage.VolumeAttachmentParams) error {
-	panic("not implemented")
+	return errors.NotSupportedf("detaching loop devices")
+}
+
+// createBlockFile creates a file at the specified path, with the
+// given size in mebibytes.
+func createBlockFile(run runCommandFunc, filePath string, sizeInMiB uint64) error {
+	// fallocate will reserve the space without actually writing to it.
+	_, err := run("fallocate", "-l", fmt.Sprintf("%dMiB", sizeInMiB), filePath)
+	if err != nil {
+		return errors.Annotatef(err, "allocating loop backing file %q", filePath)
+	}
+	return nil
+}
+
+// attachLoopDevice attaches a loop device to the file with the
+// specified path, and returns the loop device's name (e.g. "loop0").
+// losetup will create additional loop devices as necessary.
+func attachLoopDevice(run runCommandFunc, filePath string) (loopDeviceName string, _ error) {
+	// -f automatically finds the first available loop-device.
+	// --show returns the loop device chosen on stdout.
+	stdout, err := run("losetup", "-f", "--show", filePath)
+	if err != nil {
+		return "", errors.Annotatef(err, "attaching loop device to %q", filePath)
+	}
+	stdout = strings.TrimSpace(stdout)
+	loopDeviceName = stdout[len("/dev/"):]
+	return loopDeviceName, nil
+}
+
+// detachLoopDevice detaches the loop device with the specified name.
+func detachLoopDevice(run runCommandFunc, deviceName string) error {
+	_, err := run("losetup", "-d", filepath.Join("/dev", deviceName))
+	if err != nil {
+		return errors.Annotatef(err, "detaching loop device %q", deviceName)
+	}
+	return err
+}
+
+// associatedLoopDevices returns the device names of the loop devices
+// associated with the specified file path.
+func associatedLoopDevices(run runCommandFunc, filePath string) ([]string, error) {
+	stdout, err := run("losetup", "-j", filePath)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if stdout == "" {
+		return nil, nil
+	}
+	// The output will be zero or more lines with the format:
+	//    "/dev/loop0: [0021]:7504142 (/tmp/test.dat)"
+	lines := strings.Split(stdout, "\n")
+	deviceNames := make([]string, len(lines))
+	for i, line := range lines {
+		pos := strings.IndexRune(line, ':')
+		if pos == -1 {
+			return nil, errors.Errorf("unexpected output %q", line)
+		}
+		deviceName := line[:pos][len("/dev/"):]
+		deviceNames[i] = deviceName
+	}
+	return deviceNames, nil
 }

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -92,7 +92,7 @@ func (lvs *loopVolumeSource) createVolume(params storage.VolumeParams) (storage.
 		return volume, volumeAttachment, errors.Trace(err)
 	}
 
-	volumeId := fmt.Sprintf("%s", params.Tag)
+	volumeId := params.Tag.String()
 	loopFilePath := lvs.volumeFilePath(volumeId)
 
 	if err := os.MkdirAll(lvs.storageDir, 0755); err != nil {

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -44,6 +44,30 @@ func (s *loopSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
+func (s *loopSuite) TestVolumeSource(c *gc.C) {
+	p := provider.LoopProvider(s.commands.run)
+	cfg, err := storage.NewConfig("name", provider.LoopProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = p.VolumeSource(nil, cfg)
+	c.Assert(err, gc.ErrorMatches, "storage directory not specified")
+	cfg, err = storage.NewConfig("name", provider.LoopProviderType, map[string]interface{}{
+		"storage-dir": c.MkDir(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = p.VolumeSource(nil, cfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *loopSuite) TestValidateConfig(c *gc.C) {
+	p := provider.LoopProvider(s.commands.run)
+	cfg, err := storage.NewConfig("name", provider.LoopProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.ValidateConfig(cfg)
+	// The loop provider does not have any user
+	// configuration, so an empty map will pass.
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *loopSuite) TestCreateVolumes(c *gc.C) {
 	s.commands.expect("fallocate", "-l", "2MiB", filepath.Join(s.storageDir, "disk-0"))
 	cmd := s.commands.expect("losetup", "-f", "--show", filepath.Join(s.storageDir, "disk-0"))

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -148,39 +148,3 @@ func (s *loopSuite) TestDetachVolumes(c *gc.C) {
 	err := s.source.DetachVolumes(nil)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
-
-type mockRunCommand struct {
-	c        *gc.C
-	commands []*mockCommand
-}
-
-type mockCommand struct {
-	cmd    string
-	args   []string
-	result string
-	err    error
-}
-
-func (c *mockCommand) respond(result string, err error) {
-	c.result = result
-	c.err = err
-}
-
-func (m *mockRunCommand) expect(cmd string, args ...string) *mockCommand {
-	command := &mockCommand{cmd: cmd, args: args}
-	m.commands = append(m.commands, command)
-	return command
-}
-
-func (m *mockRunCommand) assertDrained() {
-	m.c.Assert(m.commands, gc.HasLen, 0)
-}
-
-func (m *mockRunCommand) run(cmd string, args ...string) (stdout string, err error) {
-	m.c.Assert(m.commands, gc.Not(gc.HasLen), 0)
-	expect := m.commands[0]
-	m.commands = m.commands[1:]
-	m.c.Assert(cmd, gc.Equals, expect.cmd)
-	m.c.Assert(args, gc.DeepEquals, expect.args)
-	return expect.result, expect.err
-}

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -1,0 +1,162 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/testing"
+)
+
+const stubMachineId = "machine101"
+
+var _ = gc.Suite(&loopSuite{})
+
+type loopSuite struct {
+	testing.BaseSuite
+	storageDir string
+	commands   *mockRunCommand
+	source     storage.VolumeSource
+}
+
+func (s *loopSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.storageDir = c.MkDir()
+	s.commands = &mockRunCommand{c: c}
+	s.source = provider.LoopVolumeSource(
+		s.storageDir,
+		s.commands.run,
+	)
+}
+
+func (s *loopSuite) TearDownTest(c *gc.C) {
+	s.commands.assertDrained()
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *loopSuite) TestCreateVolumes(c *gc.C) {
+	s.commands.expect("fallocate", "-l", "2MiB", filepath.Join(s.storageDir, "disk-0"))
+	cmd := s.commands.expect("losetup", "-f", "--show", filepath.Join(s.storageDir, "disk-0"))
+	cmd.respond("/dev/loop99", nil)
+
+	volumes, volumeAttachments, err := s.source.CreateVolumes([]storage.VolumeParams{{
+		Tag:  names.NewDiskTag("0"),
+		Size: 2,
+		Attachment: &storage.AttachmentParams{
+			Machine:    names.NewMachineTag("1"),
+			InstanceId: "instance-id",
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumes, gc.HasLen, 1)
+	c.Assert(volumeAttachments, gc.HasLen, 1)
+	c.Assert(volumes[0], gc.Equals, storage.Volume{
+		Tag:      names.NewDiskTag("0"),
+		VolumeId: "disk-0",
+		Size:     2,
+	})
+	c.Assert(volumeAttachments[0], gc.Equals, storage.VolumeAttachment{
+		Volume:     names.NewDiskTag("0"),
+		Machine:    names.NewMachineTag("1"),
+		DeviceName: "loop99",
+	})
+}
+
+func (s *loopSuite) TestCreateVolumesNoAttachment(c *gc.C) {
+	_, _, err := s.source.CreateVolumes([]storage.VolumeParams{{
+		Tag:  names.NewDiskTag("0"),
+		Size: 2,
+	}})
+	c.Assert(err, gc.ErrorMatches, "creating volume: creating loop device without machine attachment not supported")
+}
+
+func (s *loopSuite) TestDestroyVolumes(c *gc.C) {
+	fileName := filepath.Join(s.storageDir, "disk-0")
+	cmd := s.commands.expect("losetup", "-j", fileName)
+	cmd.respond("/dev/loop0: foo\n/dev/loop1: bar", nil)
+	s.commands.expect("losetup", "-d", "/dev/loop0")
+	s.commands.expect("losetup", "-d", "/dev/loop1")
+
+	err := ioutil.WriteFile(fileName, nil, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.source.DestroyVolumes([]string{"disk-0"})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *loopSuite) TestDestroyVolumesDetachFails(c *gc.C) {
+	fileName := filepath.Join(s.storageDir, "disk-0")
+	cmd := s.commands.expect("losetup", "-j", fileName)
+	cmd.respond("/dev/loop0: foo\n/dev/loop1: bar", nil)
+	cmd = s.commands.expect("losetup", "-d", "/dev/loop0")
+	cmd.respond("", errors.New("oy"))
+
+	err := s.source.DestroyVolumes([]string{"disk-0"})
+	c.Assert(err, gc.ErrorMatches, `detaching loop device "loop0": oy`)
+}
+
+func (s *loopSuite) TestDestroyVolumesInvalidVolumeId(c *gc.C) {
+	err := s.source.DestroyVolumes([]string{"../super/important/stuff"})
+	c.Assert(err, gc.ErrorMatches, `invalid loop volume ID "\.\./super/important/stuff"`)
+}
+
+func (s *loopSuite) TestDescribeVolumes(c *gc.C) {
+	_, err := s.source.DescribeVolumes([]string{"a", "b"})
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+}
+
+func (s *loopSuite) TestAttachVolumes(c *gc.C) {
+	_, err := s.source.AttachVolumes(nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (s *loopSuite) TestDetachVolumes(c *gc.C) {
+	err := s.source.DetachVolumes(nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+type mockRunCommand struct {
+	c        *gc.C
+	commands []*mockCommand
+}
+
+type mockCommand struct {
+	cmd    string
+	args   []string
+	result string
+	err    error
+}
+
+func (c *mockCommand) respond(result string, err error) {
+	c.result = result
+	c.err = err
+}
+
+func (m *mockRunCommand) expect(cmd string, args ...string) *mockCommand {
+	command := &mockCommand{cmd: cmd, args: args}
+	m.commands = append(m.commands, command)
+	return command
+}
+
+func (m *mockRunCommand) assertDrained() {
+	m.c.Assert(m.commands, gc.HasLen, 0)
+}
+
+func (m *mockRunCommand) run(cmd string, args ...string) (stdout string, err error) {
+	m.c.Assert(m.commands, gc.Not(gc.HasLen), 0)
+	expect := m.commands[0]
+	m.commands = m.commands[1:]
+	m.c.Assert(cmd, gc.Equals, expect.cmd)
+	m.c.Assert(args, gc.DeepEquals, expect.args)
+	return expect.result, expect.err
+}

--- a/storage/provider/package_test.go
+++ b/storage/provider/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/storage/provider/package_test.go
+++ b/storage/provider/package_test.go
@@ -12,3 +12,39 @@ import (
 func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }
+
+type mockRunCommand struct {
+	c        *gc.C
+	commands []*mockCommand
+}
+
+type mockCommand struct {
+	cmd    string
+	args   []string
+	result string
+	err    error
+}
+
+func (c *mockCommand) respond(result string, err error) {
+	c.result = result
+	c.err = err
+}
+
+func (m *mockRunCommand) expect(cmd string, args ...string) *mockCommand {
+	command := &mockCommand{cmd: cmd, args: args}
+	m.commands = append(m.commands, command)
+	return command
+}
+
+func (m *mockRunCommand) assertDrained() {
+	m.c.Assert(m.commands, gc.HasLen, 0)
+}
+
+func (m *mockRunCommand) run(cmd string, args ...string) (stdout string, err error) {
+	m.c.Assert(m.commands, gc.Not(gc.HasLen), 0)
+	expect := m.commands[0]
+	m.commands = m.commands[1:]
+	m.c.Assert(cmd, gc.Equals, expect.cmd)
+	m.c.Assert(args, gc.DeepEquals, expect.args)
+	return expect.result, expect.err
+}

--- a/storage/provider/utils.go
+++ b/storage/provider/utils.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.storage.provider")
+
+// runCommandFunc is a function type used for running commands
+// on the local machine. We use this rather than os/exec directly
+// for testing purposes.
+type runCommandFunc func(cmd string, args ...string) (string, error)
+
+// logAndExec logs the specified command and arguments, executes
+// them, and returns the combined stdout/stderr and an error if
+// the command fails.
+func logAndExec(cmd string, args ...string) (string, error) {
+	logger.Debugf("running: %s %s", cmd, strings.Join(args, " "))
+	c := exec.Command(cmd, args...)
+	output, err := c.CombinedOutput()
+	if err != nil {
+		output := strings.TrimSpace(string(output))
+		if len(output) > 0 {
+			err = errors.Annotate(err, output)
+		}
+	}
+	return string(output), err
+}

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -19,7 +19,7 @@ var _ = gc.Suite(&providerRegistrySuite{})
 type mockProvider struct {
 }
 
-func (p *mockProvider) VolumeSource(*config.Config, *storage.Config) (storage.VolumeSource, error) {
+func (p *mockProvider) VolumeSource(*config.Config, *storage.Config, string) (storage.VolumeSource, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -4,11 +4,9 @@
 package storage_test
 
 import (
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/storage"
 )
 
@@ -17,14 +15,7 @@ type providerRegistrySuite struct{}
 var _ = gc.Suite(&providerRegistrySuite{})
 
 type mockProvider struct {
-}
-
-func (p *mockProvider) VolumeSource(*config.Config, *storage.Config, string) (storage.VolumeSource, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (p *mockProvider) ValidateConfig(*storage.Config) error {
-	return nil
+	storage.Provider
 }
 
 func (s *providerRegistrySuite) TestRegisterProvider(c *gc.C) {

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -3,10 +3,7 @@
 
 package storage
 
-import (
-	"github.com/juju/juju/instance"
-	"github.com/juju/names"
-)
+import "github.com/juju/names"
 
 // Volume describes a volume (disk, logical volume, etc.)
 type Volume struct {
@@ -35,17 +32,9 @@ type VolumeAttachment struct {
 	// that this attachment corresponds to.
 	Volume names.DiskTag
 
-	// VolumeId is the unique provider-supplied ID for the volume that
-	// this attachment corresponds to.
-	VolumeId string
-
 	// MachineId is the unique tag assigned by Juju for the machine that
 	// this attachment corresponds to.
 	Machine names.MachineTag
-
-	// InstanceId is the unique provider-supplied ID for the cloud
-	// instance that this attachment corresponds to.
-	InstanceId instance.Id
 
 	// DeviceName is the volume's OS-specific device name (e.g. "sdb").
 	//

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -500,7 +500,7 @@ func constructStartInstanceParams(
 			v.Size,
 			storage.ProviderType(v.Provider),
 			v.Attributes,
-			&storage.AttachmentParams{machineTag.Id(), ""},
+			&storage.AttachmentParams{machineTag, ""},
 		}
 	}
 
@@ -690,9 +690,7 @@ func volumeAttachmentsToApiserver(attachments []storage.VolumeAttachment) []para
 	for i, a := range attachments {
 		result[i] = params.VolumeAttachment{
 			a.Volume.String(),
-			a.VolumeId,
 			a.Machine.String(),
-			string(a.InstanceId),
 			a.DeviceName,
 		}
 	}


### PR DESCRIPTION
The loop storage provider allocates files in the agent's
data-dir ($data-dir/storage/loop), and attaches loop
devices to them. This gives us a universal storage
provider for block devices.

There is a change to the storage.Provider.VolumeSource
method signature: it now takes a storage directory.
This is a directory that will be provided by the storage
provisioner, based on data-dir, for the storage provider
to store local artifacts. It should only be used by
machine-scoped storage providers.

Also, drive-by simplification of VolumeAttachment,
removing the VolumeId and InstanceId fields. We only
need to convey those in the params, we don't ever need
to inform Juju of the volume ID or instance ID when
creating an attachment.

(Review request: http://reviews.vapour.ws/r/923/)