### PR TITLE
Re-enable image caching and install cloud-image-utils on boot

### DIFF
--- a/apiserver/client/machineconfig.go
+++ b/apiserver/client/machineconfig.go
@@ -94,9 +94,6 @@ func MachineConfig(st *state.State, machineId, nonce, dataDir string) (*cloudini
 		return nil, err
 	}
 	secureServerConnection := info.CAPrivateKey != ""
-	// TODO (wallyworld): reenable this when cloud-image-utils is installed on precise
-	// See: https://bugs.launchpad.net/juju-core/+bug/1417594
-	secureServerConnection = false
 	mcfg, err := environs.NewMachineConfig(machineId, nonce, env.Config().ImageStream(), machine.Series(),
 		secureServerConnection, networks, mongoInfo, apiInfo,
 	)

--- a/apiserver/client/machineconfig_test.go
+++ b/apiserver/client/machineconfig_test.go
@@ -57,9 +57,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 	c.Check(machineConfig.APIInfo.Addrs, gc.DeepEquals, apiAddrs)
 	toolsURL := fmt.Sprintf("https://%s/environment/90168e4c-2f10-4e9c-83c2-feedfacee5a9/tools/%s", apiAddrs[0], machineConfig.Tools.Version)
 	c.Assert(machineConfig.Tools.URL, gc.Equals, toolsURL)
-	// TODO (wallyworld): reenable this when cloud-image-utils is installed on precise
-	// See: https://bugs.launchpad.net/juju-core/+bug/1417594
-	c.Assert(machineConfig.AgentEnvironment[agent.AllowsSecureConnection], gc.Equals, "false")
+	c.Assert(machineConfig.AgentEnvironment[agent.AllowsSecureConnection], gc.Equals, "true")
 }
 
 func (s *machineConfigSuite) TestSecureConnectionDisallowed(c *gc.C) {

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -90,11 +90,7 @@ func NewMachineConfig(
 func NewBootstrapMachineConfig(cons constraints.Value, series string) (*cloudinit.MachineConfig, error) {
 	// For a bootstrap instance, FinishMachineConfig will provide the
 	// state.Info and the api.Info. The machine id must *always* be "0".
-
-	// TODO (wallyworld): reenable this when cloud-image-utils is installed on precise
-	// See: https://bugs.launchpad.net/juju-core/+bug/1417594
-	secureServerConnection := false
-	mcfg, err := NewMachineConfig("0", agent.BootstrapNonce, "", series, secureServerConnection, nil, nil, nil)
+	mcfg, err := NewMachineConfig("0", agent.BootstrapNonce, "", series, true, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -214,6 +214,7 @@ func AddAptCommands(
 		// leave it to the networker worker.
 		c.AddPackage("bridge-utils")
 		c.AddPackage("rsyslog-gnutls")
+		c.AddPackage("cloud-image-utils")
 	}
 
 	// Write out the apt proxy settings

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -134,11 +134,9 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 	}
 
 	secureServerConnection := false
-	// TODO (wallyworld): reenable this when cloud-image-utils is installed on precise
-	// See: https://bugs.launchpad.net/juju-core/+bug/1417594
-	// if info, ok := p.agentConfig.StateServingInfo(); ok {
-	// secureServerConnection = info.CAPrivateKey != ""
-	// }
+	if info, ok := p.agentConfig.StateServingInfo(); ok {
+		secureServerConnection = info.CAPrivateKey != ""
+	}
 	task := NewProvisionerTask(
 		machineTag,
 		harvestMode,


### PR DESCRIPTION
Now that upstream has fixed the packaging for cloud-image-utils on precise, we can re-enable image caching.

Fixes: https://bugs.launchpad.net/bugs/1418454

(Review request: http://reviews.vapour.ws/r/927/)