### PR TITLE
uniter: make storage-get like relation-get

### DIFF
--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -194,7 +194,7 @@ func newStorageIdValue(ctx Context, result *names.StorageTag) *storageIdValue {
 	if s, found := ctx.HookStorageAttachment(); found {
 		tag, err := names.ParseStorageTag(s.StorageTag)
 		if err == nil {
-			*result = tag
+			*v.result = tag
 		}
 	}
 	return v

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/errors"
+	"github.com/juju/names"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
-	"github.com/juju/names"
 )
 
 type RebootPriority int
@@ -183,5 +184,47 @@ func (v *relationIdValue) Set(value string) error {
 	}
 	*v.result = id
 	v.value = value
+	return nil
+}
+
+// newStorageIdValue returns a gnuflag.Value for convenient parsing of storage
+// ids in ctx.
+func newStorageIdValue(ctx Context, result *names.StorageTag) *storageIdValue {
+	v := &storageIdValue{result: result, ctx: ctx}
+	if s, found := ctx.HookStorageAttachment(); found {
+		tag, err := names.ParseStorageTag(s.StorageTag)
+		if err == nil {
+			*result = tag
+		}
+	}
+	return v
+}
+
+// storageIdValue implements gnuflag.Value for use in storage commands.
+type storageIdValue struct {
+	result *names.StorageTag
+	ctx    Context
+}
+
+// String returns the current value.
+func (v *storageIdValue) String() string {
+	if *v.result == (names.StorageTag{}) {
+		return ""
+	}
+	return v.result.Id()
+}
+
+// Set interprets value as a storage id, if possible, and returns an error
+// if it is not known to the system. The parsed storage id will be written
+// to v.result.
+func (v *storageIdValue) Set(value string) error {
+	if !names.IsValidStorage(value) {
+		return errors.Errorf("invalid storage ID %q", value)
+	}
+	tag := names.NewStorageTag(value)
+	if _, found := v.ctx.StorageAttachment(tag); !found {
+		return fmt.Errorf("unknown storage attachment")
+	}
+	*v.result = tag
 	return nil
 }

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -32,7 +32,10 @@ func (s *storageGetSuite) SetUpTest(c *gc.C) {
 }
 
 var (
-	storageLocation = map[string]interface{}{"location": "/dev/sda"}
+	storageAttributes = map[string]interface{}{
+		"location": "/dev/sda",
+		"kind":     "block",
+	}
 )
 
 var storageGetTests = []struct {
@@ -40,10 +43,10 @@ var storageGetTests = []struct {
 	format int
 	out    interface{}
 }{
-	{[]string{"data/0", "location", "--format", "yaml"}, formatYaml, storageLocation},
-	{[]string{"data/0", "location", "--format", "json"}, formatJson, storageLocation},
-	{[]string{"data/0", "location", "kind"}, -1, "kind: 1\nlocation: /dev/sda\n"},
-	{[]string{"data/0", "location"}, -1, "/dev/sda\n"},
+	{[]string{"--format", "yaml"}, formatYaml, storageAttributes},
+	{[]string{"--format", "json"}, formatJson, storageAttributes},
+	{[]string{}, formatYaml, storageAttributes},
+	{[]string{"location"}, -1, "/dev/sda\n"},
 }
 
 func (s *storageGetSuite) TestOutputFormatKey(c *gc.C) {
@@ -80,7 +83,7 @@ func (s *storageGetSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: storage-get [options] <storageInstanceId> <key> [<key>]*
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: storage-get [options] [<key>]
 purpose: print information for storage instance with specified id
 
 options:
@@ -88,6 +91,8 @@ options:
     specify output format (json|smart|yaml)
 -o, --output (= "")
     specify an output file
+-s  (= data/0)
+    specify a storage instance by id
 
 When no <key> is supplied, all keys values are printed.
 `)
@@ -100,7 +105,7 @@ func (s *storageGetSuite) TestOutputPath(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := testing.Context(c)
-	code := cmd.Main(com, ctx, []string{"--format", "yaml", "--output", "some-file", "data/0", "location"})
+	code := cmd.Main(com, ctx, []string{"--format", "yaml", "--output", "some-file", "-s", "data/0"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
@@ -109,5 +114,5 @@ func (s *storageGetSuite) TestOutputPath(c *gc.C) {
 
 	var out map[string]interface{}
 	c.Assert(goyaml.Unmarshal(content, &out), gc.IsNil)
-	c.Assert(out, gc.DeepEquals, storageLocation)
+	c.Assert(out, gc.DeepEquals, storageAttributes)
 }

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -99,7 +99,6 @@ When no <key> is supplied, all keys values are printed.
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 }
 
-//
 func (s *storageGetSuite) TestOutputPath(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))


### PR DESCRIPTION
storage-get is updated to:
 - allow the user to specify a storage ID,
   but default to the hook storage ID.
 - only allow the specification of one or
   zero attribute keys; if none are specified
   then all attributes are output as a map,
   otherwise the single attribute is output.

We will need a storage-list command to list
all storage instances related to the unit.

(Review request: http://reviews.vapour.ws/r/929/)