### PR TITLE
Block api client.

### DIFF
--- a/api/block/client.go
+++ b/api/block/client.go
@@ -1,0 +1,74 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package block
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var logger = loggo.GetLogger("juju.api.block")
+
+// Client allows access to the block API end point.
+type Client struct {
+	base.ClientFacade
+	facade base.FacadeCaller
+}
+
+// NewClient creates a new client for accessing the block API.
+func NewClient(st base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(st, "Block")
+	logger.Debugf("\nSTORAGE FRONT-END: %#v", frontend)
+	logger.Debugf("\nSTORAGE BACK-END: %#v", backend)
+	return &Client{ClientFacade: frontend, facade: backend}
+}
+
+// List returns blocks that are switched on for current environment.
+func (c *Client) List() ([]params.Block, error) {
+	blocks := params.BlockResults{}
+	if err := c.facade.FacadeCall("List", nil, &blocks); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	all := []params.Block{}
+	allErr := params.ErrorResults{}
+	for _, result := range blocks.Results {
+		if result.Error != nil {
+			allErr.Results = append(allErr.Results, params.ErrorResult{result.Error})
+			continue
+		}
+		all = append(all, result.Result)
+	}
+	return all, allErr.Combine()
+}
+
+// SwitchBlockOn switches desired block on for the current environment.
+// Valid block types are "BlockDestroy", "BlockRemove" and "BlockChange".
+func (c *Client) SwitchBlockOn(blockType, msg string) error {
+	args := params.BlockSwitchParams{
+		Type:    blockType,
+		Message: msg,
+	}
+	result := params.ErrorResult{}
+	if err := c.facade.FacadeCall("SwitchBlockOn", args, &result); err != nil {
+		return errors.Trace(err)
+	}
+	return result.Error
+}
+
+// SwitchBlockOff switches desired block off for the current environment.
+// Valid block types are "BlockDestroy", "BlockRemove" and "BlockChange".
+func (c *Client) SwitchBlockOff(blockType string) error {
+	args := params.BlockSwitchParams{
+		Type: blockType,
+	}
+	result := params.ErrorResult{}
+	if err := c.facade.FacadeCall("SwitchBlockOff", args, &result); err != nil {
+		return errors.Trace(err)
+	}
+	return result.Error
+}

--- a/api/block/client_test.go
+++ b/api/block/client_test.go
@@ -1,0 +1,166 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package block_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/block"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type blockMockSuite struct {
+	coretesting.BaseSuite
+	blockClient *block.Client
+}
+
+var _ = gc.Suite(&blockMockSuite{})
+
+func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
+	called := false
+	bType := state.DestroyBlock.String()
+	msg := "for test switch block on"
+
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, response interface{},
+		) error {
+			called = true
+			c.Check(objType, gc.Equals, "Block")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "SwitchBlockOn")
+
+			args, ok := a.(params.BlockSwitchParams)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(args.Message, gc.DeepEquals, msg)
+			c.Assert(args.Type, gc.DeepEquals, bType)
+
+			_, ok = response.(*params.ErrorResult)
+			c.Assert(ok, jc.IsTrue)
+
+			return nil
+		})
+	blockClient := block.NewClient(apiCaller)
+	err := blockClient.SwitchBlockOn(bType, msg)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *blockMockSuite) TestSwitchBlockOnError(c *gc.C) {
+	called := false
+	errmsg := "test error"
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, response interface{},
+		) error {
+			called = true
+			result, ok := response.(*params.ErrorResult)
+			c.Assert(ok, jc.IsTrue)
+			result.Error = common.ServerError(errors.New(errmsg))
+
+			return nil
+		})
+	blockClient := block.NewClient(apiCaller)
+	err := blockClient.SwitchBlockOn("", "")
+	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
+}
+
+func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
+	called := false
+	bType := state.DestroyBlock.String()
+
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, response interface{},
+		) error {
+			called = true
+			c.Check(objType, gc.Equals, "Block")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "SwitchBlockOff")
+
+			args, ok := a.(params.BlockSwitchParams)
+			c.Assert(ok, jc.IsTrue)
+			// message is never sent, so this argument should
+			// always be empty string.
+			c.Assert(args.Message, gc.DeepEquals, "")
+			c.Assert(args.Type, gc.DeepEquals, bType)
+
+			_, ok = response.(*params.ErrorResult)
+			c.Assert(ok, jc.IsTrue)
+
+			return nil
+		})
+	blockClient := block.NewClient(apiCaller)
+	err := blockClient.SwitchBlockOff(bType)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *blockMockSuite) TestSwitchBlockOffError(c *gc.C) {
+	called := false
+	errmsg := "test error"
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, response interface{},
+		) error {
+			called = true
+			result, ok := response.(*params.ErrorResult)
+			c.Assert(ok, jc.IsTrue)
+			result.Error = common.ServerError(errors.New(errmsg))
+
+			return nil
+		})
+	blockClient := block.NewClient(apiCaller)
+	err := blockClient.SwitchBlockOff("")
+	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
+}
+
+func (s *blockMockSuite) TestList(c *gc.C) {
+	var called bool
+	one := params.BlockResult{
+		Result: params.Block{
+			Id:      "-42",
+			Type:    state.DestroyBlock.String(),
+			Message: "for test switch on",
+			Tag:     "some valid tag, right?",
+		},
+	}
+	errmsg := "another test error"
+	two := params.BlockResult{
+		Error: common.ServerError(errors.New(errmsg)),
+	}
+	apiCaller := basetesting.APICallerFunc(
+		func(
+			objType string,
+			version int,
+			id, request string,
+			a, response interface{}) error {
+			called = true
+			c.Check(objType, gc.Equals, "Block")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "List")
+			c.Assert(a, gc.IsNil)
+
+			result := response.(*params.BlockResults)
+			result.Results = []params.BlockResult{one, two}
+			return nil
+		})
+	blockClient := block.NewClient(apiCaller)
+	found, err := blockClient.List()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
+	c.Assert(found, gc.HasLen, 1)
+}

--- a/api/block/client_test.go
+++ b/api/block/client_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&blockMockSuite{})
 
 func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
 	called := false
-	bType := state.DestroyBlock.String()
+	blockType := state.DestroyBlock.String()
 	msg := "for test switch block on"
 
 	apiCaller := basetesting.APICallerFunc(
@@ -42,7 +42,7 @@ func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
 			args, ok := a.(params.BlockSwitchParams)
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(args.Message, gc.DeepEquals, msg)
-			c.Assert(args.Type, gc.DeepEquals, bType)
+			c.Assert(args.Type, gc.DeepEquals, blockType)
 
 			_, ok = response.(*params.ErrorResult)
 			c.Assert(ok, jc.IsTrue)
@@ -50,7 +50,7 @@ func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
 			return nil
 		})
 	blockClient := block.NewClient(apiCaller)
-	err := blockClient.SwitchBlockOn(bType, msg)
+	err := blockClient.SwitchBlockOn(blockType, msg)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -77,7 +77,7 @@ func (s *blockMockSuite) TestSwitchBlockOnError(c *gc.C) {
 
 func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
 	called := false
-	bType := state.DestroyBlock.String()
+	blockType := state.DestroyBlock.String()
 
 	apiCaller := basetesting.APICallerFunc(
 		func(objType string,
@@ -95,7 +95,7 @@ func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
 			// message is never sent, so this argument should
 			// always be empty string.
 			c.Assert(args.Message, gc.DeepEquals, "")
-			c.Assert(args.Type, gc.DeepEquals, bType)
+			c.Assert(args.Type, gc.DeepEquals, blockType)
 
 			_, ok = response.(*params.ErrorResult)
 			c.Assert(ok, jc.IsTrue)
@@ -103,7 +103,7 @@ func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
 			return nil
 		})
 	blockClient := block.NewClient(apiCaller)
-	err := blockClient.SwitchBlockOff(bType)
+	err := blockClient.SwitchBlockOff(blockType)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/api/block/package_test.go
+++ b/api/block/package_test.go
@@ -1,0 +1,13 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package block_test
+
+import (
+	gc "gopkg.in/check.v1"
+	"testing"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -16,6 +16,7 @@ var facadeVersions = map[string]int{
 	"AllWatcher":           0,
 	"Annotations":          1,
 	"Backups":              0,
+	"Block":                1,
 	"Charms":               1,
 	"CharmRevisionUpdater": 0,
 	"Client":               0,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/juju/juju/apiserver/agent"
 	_ "github.com/juju/juju/apiserver/annotations"
 	_ "github.com/juju/juju/apiserver/backups"
+	_ "github.com/juju/juju/apiserver/block"
 	_ "github.com/juju/juju/apiserver/charmrevisionupdater"
 	_ "github.com/juju/juju/apiserver/charms"
 	_ "github.com/juju/juju/apiserver/client"

--- a/apiserver/block/client.go
+++ b/apiserver/block/client.go
@@ -1,0 +1,98 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package block
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("Block", 1, NewAPI)
+}
+
+// Block defines the methods on the block API end point.
+type Block interface {
+	// List returns all current blocks for this environment.
+	List() (params.BlockResults, error)
+
+	// SwitchBlockOn switches desired block type on for this
+	// environment.
+	SwitchBlockOn(params.BlockSwitchParams) params.ErrorResult
+
+	// SwitchBlockOff switches desired block type off for this
+	// environment.
+	SwitchBlockOff(params.BlockSwitchParams) params.ErrorResult
+}
+
+// API implements Block interface and is the concrete
+// implementation of the api end point.
+type API struct {
+	access     blockAccess
+	authorizer common.Authorizer
+}
+
+// NewAPI returns a new block API facade.
+func NewAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*API, error) {
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
+
+	return &API{
+		access:     getState(st),
+		authorizer: authorizer,
+	}, nil
+}
+
+var getState = func(st *state.State) blockAccess {
+	return stateShim{st}
+}
+
+// List implements Block.List().
+func (a *API) List() (params.BlockResults, error) {
+	all, err := a.access.AllBlocks()
+	if err != nil {
+		return params.BlockResults{}, common.ServerError(err)
+	}
+	found := make([]params.BlockResult, len(all))
+	for i, one := range all {
+		found[i] = convertBlock(one)
+	}
+	return params.BlockResults{Results: found}, nil
+}
+
+func convertBlock(b state.Block) params.BlockResult {
+	result := params.BlockResult{}
+	tag, err := b.Tag()
+	if err != nil {
+		err := errors.Annotatef(err, "getting block %v", b.Type().String())
+		result.Error = common.ServerError(err)
+	}
+	result.Result = params.Block{
+		Id:      b.Id(),
+		Tag:     tag.String(),
+		Type:    b.Type().String(),
+		Message: b.Message(),
+	}
+	return result
+}
+
+// SwitchBlockOn implements Block.SwitchBlockOn().
+func (a *API) SwitchBlockOn(args params.BlockSwitchParams) params.ErrorResult {
+	err := a.access.SwitchBlockOn(state.ParseBlockType(args.Type), args.Message)
+	return params.ErrorResult{Error: common.ServerError(err)}
+}
+
+// SwitchBlockOff implements Block.SwitchBlockOff().
+func (a *API) SwitchBlockOff(args params.BlockSwitchParams) params.ErrorResult {
+	err := a.access.SwitchBlockOff(state.ParseBlockType(args.Type))
+	return params.ErrorResult{Error: common.ServerError(err)}
+}

--- a/apiserver/block/client_test.go
+++ b/apiserver/block/client_test.go
@@ -1,0 +1,81 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package block_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/block"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+)
+
+type blockSuite struct {
+	// TODO(anastasiamac) mock to remove JujuConnSuite
+	jujutesting.JujuConnSuite
+	api *block.API
+}
+
+var _ = gc.Suite(&blockSuite{})
+
+func (s *blockSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	var err error
+	auth := testing.FakeAuthorizer{
+		Tag:            s.AdminUserTag(c),
+		EnvironManager: true,
+	}
+	s.api, err = block.NewAPI(s.State, common.NewResources(), auth)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *blockSuite) TestListBlockNoneExistent(c *gc.C) {
+	s.assertBlockList(c, 0)
+}
+
+func (s *blockSuite) assertBlockList(c *gc.C, length int) {
+	all, err := s.api.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all.Results, gc.HasLen, length)
+}
+
+func (s *blockSuite) TestSwitchValidBlockOn(c *gc.C) {
+	s.assertSwitchBlockOn(c, state.DestroyBlock.String(), "for TestSwitchValidBlockOn")
+}
+
+func (s *blockSuite) assertSwitchBlockOn(c *gc.C, blockType, msg string) {
+	on := params.BlockSwitchParams{
+		Type:    blockType,
+		Message: msg,
+	}
+	err := s.api.SwitchBlockOn(on)
+	c.Assert(err.Error, gc.IsNil)
+	s.assertBlockList(c, 1)
+}
+
+func (s *blockSuite) TestSwitchInvalidBlockOn(c *gc.C) {
+	on := params.BlockSwitchParams{
+		Type:    "invalid_block_type",
+		Message: "for TestSwitchInvalidBlockOn",
+	}
+
+	c.Assert(func() { s.api.SwitchBlockOn(on) }, gc.PanicMatches, ".*unknown block type.*")
+}
+
+func (s *blockSuite) TestSwitchBlockOff(c *gc.C) {
+	valid := state.DestroyBlock
+	s.assertSwitchBlockOn(c, valid.String(), "for TestSwitchBlockOff")
+
+	off := params.BlockSwitchParams{
+		Type: valid.String(),
+	}
+	err := s.api.SwitchBlockOff(off)
+	c.Assert(err.Error, gc.IsNil)
+	s.assertBlockList(c, 0)
+}

--- a/apiserver/block/package_test.go
+++ b/apiserver/block/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package block_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/block/state.go
+++ b/apiserver/block/state.go
@@ -1,0 +1,16 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package block
+
+import "github.com/juju/juju/state"
+
+type blockAccess interface {
+	AllBlocks() ([]state.Block, error)
+	SwitchBlockOn(t state.BlockType, msg string) error
+	SwitchBlockOff(t state.BlockType) error
+}
+
+type stateShim struct {
+	*state.State
+}

--- a/apiserver/params/block.go
+++ b/apiserver/params/block.go
@@ -1,0 +1,46 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+// Block describes a Juju block that protects environment from
+// corruption.
+type Block struct {
+	// Id is this blocks id.
+	Id string `json:"id"`
+
+	// Tag holds the tag of the entity that is blocked.
+	Tag string `json:"tag"`
+
+	// Type is block type as per state.multiwatcher.BlockType.
+	// Valid types are "BlockDestroy", "BlockRemove" and "BlockChange".
+	Type string `json:"type"`
+
+	// Message is a descriptive or an explanatory message
+	// that the block was created with.
+	Message string `json:"message,omitempty"`
+}
+
+// BlockSwitchParams holds the parameters for switching
+// a block on/off.
+type BlockSwitchParams struct {
+	// Type is block type as per state.multiwatcher.BlockType.
+	// Valid types are "BlockDestroy", "BlockRemove" and "BlockChange".
+	Type string `json:"type"`
+
+	// Message is a descriptive or an explanatory message
+	// that accompanies the switch.
+	Message string `json:"message,omitempty"`
+}
+
+// BlockResult holds the result of an API call to retrieve details
+// for a block.
+type BlockResult struct {
+	Result Block  `json:"result"`
+	Error  *Error `json:"error,omitempty"`
+}
+
+// BlockResults holds the result of an API call to list blocks.
+type BlockResults struct {
+	Results []BlockResult `json:"results,omitempty"`
+}

--- a/featuretests/block_test.go
+++ b/featuretests/block_test.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/block"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+)
+
+type blockSuite struct {
+	jujutesting.JujuConnSuite
+	blockClient *block.Client
+}
+
+var _ = gc.Suite(&blockSuite{})
+
+func (s *blockSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.blockClient = block.NewClient(s.APIState)
+	c.Assert(s.blockClient, gc.NotNil)
+}
+
+func (s *blockSuite) TearDownTest(c *gc.C) {
+	s.blockClient.ClientFacade.Close()
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *blockSuite) TestBlockFacadeCall(c *gc.C) {
+	found, err := s.blockClient.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found, gc.HasLen, 0)
+}
+
+func (s *blockSuite) TestBlockFacadeCallGettingErrors(c *gc.C) {
+	err := s.blockClient.SwitchBlockOff(state.DestroyBlock.String())
+	c.Assert(errors.Cause(err), gc.ErrorMatches, `.*is already OFF.*`)
+}

--- a/state/block.go
+++ b/state/block.go
@@ -75,6 +75,16 @@ func (t BlockType) String() string {
 	return string(t.ToParams())
 }
 
+// ParseBlockType returns BlockType from humanly readable type representation.
+func ParseBlockType(str string) BlockType {
+	for _, one := range AllTypes() {
+		if one.String() == str {
+			return one
+		}
+	}
+	panic(fmt.Sprintf("unknown block type %v", str))
+}
+
 type block struct {
 	doc blockDoc
 }


### PR DESCRIPTION
Block api client provides means of listing current blocks as well switching blocks on and off.

To minimise the size of this PR, the follow-on PRs will  contain:
1. changes to CLI commands and supporting operations to use this client instead of old implementation;
2. Upgrade step and env var deprecation step;
3. Block list CLI command.

(Review request: http://reviews.vapour.ws/r/930/)