### PR TITLE
all: sort imports in the standard way

### DIFF
--- a/api/annotations/package_test.go
+++ b/api/annotations/package_test.go
@@ -4,8 +4,9 @@
 package annotations_test
 
 import (
-	gc "gopkg.in/check.v1"
 	"testing"
+
+	gc "gopkg.in/check.v1"
 )
 
 func TestAll(t *testing.T) {

--- a/api/charms/package_test.go
+++ b/api/charms/package_test.go
@@ -4,8 +4,9 @@
 package charms_test
 
 import (
-	gc "gopkg.in/check.v1"
 	"testing"
+
+	gc "gopkg.in/check.v1"
 )
 
 func TestAll(t *testing.T) {

--- a/api/diskformatter/diskformatter_test.go
+++ b/api/diskformatter/diskformatter_test.go
@@ -6,6 +6,7 @@ package diskformatter_test
 import (
 	"errors"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/juju/api/diskformatter"
 	"github.com/juju/juju/apiserver/params"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/names"
 )
 
 var _ = gc.Suite(&DiskFormatterSuite{})

--- a/api/diskmanager/diskmanager_test.go
+++ b/api/diskmanager/diskmanager_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/names"
 )
 
 var _ = gc.Suite(&DiskManagerSuite{})

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -6,13 +6,13 @@ package storage_test
 import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/storage"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/testing"
-	"github.com/juju/utils/set"
 )
 
 type storageMockSuite struct {

--- a/api/uniter/charm.go
+++ b/api/uniter/charm.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v4"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
 )
 

--- a/apiserver/annotations/state.go
+++ b/apiserver/annotations/state.go
@@ -4,8 +4,9 @@
 package annotations
 
 import (
-	"github.com/juju/juju/state"
 	"github.com/juju/names"
+
+	"github.com/juju/juju/state"
 )
 
 type annotationAccess interface {

--- a/apiserver/charms/client.go
+++ b/apiserver/charms/client.go
@@ -5,13 +5,13 @@ package charms
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/utils/set"
 )
 
 func init() {

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -4,15 +4,16 @@
 package charms_test
 
 import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/charms"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v4"
 )
 
 type baseCharmsSuite struct {

--- a/apiserver/charms/state.go
+++ b/apiserver/charms/state.go
@@ -4,8 +4,9 @@
 package charms
 
 import (
-	"github.com/juju/juju/state"
 	"gopkg.in/juju/charm.v4"
+
+	"github.com/juju/juju/state"
 )
 
 type charmsAccess interface {

--- a/apiserver/common/block_test.go
+++ b/apiserver/common/block_test.go
@@ -4,10 +4,9 @@
 package common_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/environs/config"

--- a/apiserver/common/common_test.go
+++ b/apiserver/common/common_test.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	stdtesting "testing"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/names"
 )
 
 func TestAll(t *stdtesting.T) {

--- a/apiserver/common/ensuredead.go
+++ b/apiserver/common/ensuredead.go
@@ -5,9 +5,10 @@ package common
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 // DeadEnsurer implements a common EnsureDead method for use by

--- a/apiserver/common/instanceidgetter.go
+++ b/apiserver/common/instanceidgetter.go
@@ -4,10 +4,11 @@
 package common
 
 import (
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 // InstanceIdGetter implements a common InstanceId method for use by

--- a/apiserver/common/life.go
+++ b/apiserver/common/life.go
@@ -5,9 +5,10 @@ package common
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 // LifeGetter implements a common Life method for use by various facades.

--- a/apiserver/common/life_test.go
+++ b/apiserver/common/life_test.go
@@ -6,6 +6,7 @@ package common_test
 import (
 	"fmt"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 type lifeSuite struct{}

--- a/apiserver/common/reboot.go
+++ b/apiserver/common/reboot.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 // RebootRequester implements the RequestReboot API method

--- a/apiserver/common/remove.go
+++ b/apiserver/common/remove.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 // Remover implements a common Remove method for use by various facades.

--- a/apiserver/common/remove_test.go
+++ b/apiserver/common/remove_test.go
@@ -6,6 +6,7 @@ package common_test
 import (
 	"fmt"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 type removeSuite struct{}

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 // StatusSetter implements a common SetStatus method for use by

--- a/apiserver/common/setstatus_test.go
+++ b/apiserver/common/setstatus_test.go
@@ -6,6 +6,7 @@ package common_test
 import (
 	"fmt"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 type statusSetterSuite struct{}

--- a/apiserver/common/unitswatcher.go
+++ b/apiserver/common/unitswatcher.go
@@ -5,10 +5,11 @@ package common
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
-	"github.com/juju/names"
 )
 
 // UnitsWatcher implements a common WatchUnits method for use by

--- a/apiserver/common/watch.go
+++ b/apiserver/common/watch.go
@@ -5,10 +5,11 @@ package common
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
-	"github.com/juju/names"
 )
 
 // AgentEntityWatcher implements a common Watch method for use by

--- a/apiserver/common/watch_test.go
+++ b/apiserver/common/watch_test.go
@@ -6,6 +6,7 @@ package common_test
 import (
 	"fmt"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 type agentEntityWatcherSuite struct{}

--- a/apiserver/diskformatter/state.go
+++ b/apiserver/diskformatter/state.go
@@ -4,8 +4,9 @@
 package diskformatter
 
 import (
-	"github.com/juju/juju/state"
 	"github.com/juju/names"
+
+	"github.com/juju/juju/state"
 )
 
 type stateInterface interface {

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/state"
-	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
-
 	// Register the providers for the field check test
 	_ "github.com/juju/juju/provider/azure"
 	_ "github.com/juju/juju/provider/ec2"
@@ -27,6 +23,9 @@ import (
 	_ "github.com/juju/juju/provider/local"
 	_ "github.com/juju/juju/provider/maas"
 	_ "github.com/juju/juju/provider/openstack"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type envManagerSuite struct {

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -4,10 +4,9 @@
 package machine_test
 
 import (
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/names"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/machine"

--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -4,8 +4,9 @@
 package storage
 
 import (
-	"github.com/juju/juju/state"
 	"github.com/juju/names"
+
+	"github.com/juju/juju/state"
 )
 
 type storageAccess interface {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -4,9 +4,9 @@
 package storage
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/feature"

--- a/apiserver/uniter/status.go
+++ b/apiserver/uniter/status.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-
 	"github.com/juju/juju/state"
 )
 

--- a/cmd/juju/addrelation_test.go
+++ b/cmd/juju/addrelation_test.go
@@ -4,11 +4,12 @@
 package main
 
 import (
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 	"strings"
 
 	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testcharms"

--- a/cmd/juju/authorizedkeys_add.go
+++ b/cmd/juju/authorizedkeys_add.go
@@ -6,9 +6,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"launchpad.net/gnuflag"
 
 	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/juju/block"
 )

--- a/cmd/juju/authorizedkeys_delete.go
+++ b/cmd/juju/authorizedkeys_delete.go
@@ -6,9 +6,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"launchpad.net/gnuflag"
 
 	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/juju/block"
 )

--- a/cmd/juju/authorizedkeys_import.go
+++ b/cmd/juju/authorizedkeys_import.go
@@ -6,9 +6,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"launchpad.net/gnuflag"
 
 	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/juju/block"
 )

--- a/cmd/juju/block/block_test.go
+++ b/cmd/juju/block/block_test.go
@@ -4,12 +4,12 @@
 package block_test
 
 import (
-	gc "gopkg.in/check.v1"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/envcmd"

--- a/cmd/juju/block/package_test.go
+++ b/cmd/juju/block/package_test.go
@@ -4,8 +4,9 @@
 package block_test
 
 import (
-	gc "gopkg.in/check.v1"
 	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/testing"

--- a/cmd/juju/environment/environment_test.go
+++ b/cmd/juju/environment/environment_test.go
@@ -8,10 +8,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/environment"
-	"github.com/juju/juju/testing"
-
 	// Bring in the dummy provider definition.
 	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
 )
 
 type EnvironmentCommandSuite struct {

--- a/cmd/juju/environment/unset_test.go
+++ b/cmd/juju/environment/unset_test.go
@@ -4,10 +4,10 @@
 package environment_test
 
 import (
+	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/cmd"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/environment"

--- a/cmd/juju/expose_test.go
+++ b/cmd/juju/expose_test.go
@@ -4,16 +4,17 @@
 package main
 
 import (
+	"strings"
+
+	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 
-	"github.com/juju/cmd"
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
-	"strings"
 )
 
 type ExposeSuite struct {

--- a/cmd/juju/machine/machine_test.go
+++ b/cmd/juju/machine/machine_test.go
@@ -8,10 +8,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/machine"
-	"github.com/juju/juju/testing"
-
 	// Bring in the dummy provider definition.
 	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
 )
 
 type MachineCommandSuite struct {

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -6,10 +6,10 @@ package machine_test
 import (
 	"strings"
 
+	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/cmd"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/machine"

--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -25,9 +25,9 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/juju/version"
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
+	"github.com/juju/juju/version"
 )
 
 func init() {

--- a/cmd/juju/removeservice_test.go
+++ b/cmd/juju/removeservice_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
-	"github.com/juju/juju/cmd/envcmd"
-	jujutesting "github.com/juju/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/envcmd"
+	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"

--- a/cmd/juju/removeunit_test.go
+++ b/cmd/juju/removeunit_test.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 
-	"github.com/juju/cmd"
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"

--- a/cmd/juju/resolved_test.go
+++ b/cmd/juju/resolved_test.go
@@ -4,11 +4,11 @@
 package main
 
 import (
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 	"strings"
 
 	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -8,9 +8,8 @@ import (
 	"fmt"
 
 	"github.com/juju/cmd"
-	"launchpad.net/gnuflag"
-
 	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -5,11 +5,11 @@ package storage
 
 import (
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
 	"launchpad.net/gnuflag"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/names"
 )
 
 const ShowCommandDoc = `

--- a/cmd/juju/upgradecharm_test.go
+++ b/cmd/juju/upgradecharm_test.go
@@ -14,13 +14,13 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
+	charmtesting "gopkg.in/juju/charm.v4/testing"
 
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
-	charmtesting "gopkg.in/juju/charm.v4/testing"
 )
 
 type UpgradeCharmErrorsSuite struct {

--- a/cmd/juju/user/disenable.go
+++ b/cmd/juju/user/disenable.go
@@ -6,6 +6,7 @@ package user
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/cmd/juju/block"
 )
 

--- a/cmd/juju/user_test.go
+++ b/cmd/juju/user_test.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 
 	"github.com/juju/cmd"
-	"github.com/juju/juju/testing/factory"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 // UserSuite tests the connectivity of all the user subcommands. These tests

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/utils/voyeur"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/natefinch/lumberjack.v2"
 	"launchpad.net/gnuflag"
 	"launchpad.net/tomb"
 
@@ -83,7 +84,6 @@ import (
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 const bootstrapMachineId = "0"

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -9,13 +9,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/juju/cmd"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/cmd"
 	"github.com/juju/juju/agent"
-
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/filestorage"

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -18,11 +18,11 @@ import (
 	"github.com/juju/utils/featureflag"
 
 	jujucmd "github.com/juju/juju/cmd"
+	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/sockets"
 	// Import the providers.
-	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )

--- a/cmd/jujud/main_windows.go
+++ b/cmd/jujud/main_windows.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/juju/juju/juju/names"
-
 	"bitbucket.org/kardianos/service"
+
+	"github.com/juju/juju/juju/names"
 )
 
 func runService() {

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -16,7 +17,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"fmt"
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	apirsyslog "github.com/juju/juju/api/rsyslog"

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/loggo"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -23,7 +24,6 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
-	"github.com/juju/testing"
 )
 
 type KVMSuite struct {

--- a/container/kvm/libvert_test.go
+++ b/container/kvm/libvert_test.go
@@ -8,12 +8,12 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/container/kvm"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/testing"
 )
 
 type LibVertSuite struct {

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils"
+	"github.com/juju/utils/keyvalues"
 	"github.com/juju/utils/symlink"
 	"launchpad.net/golxc"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/version"
-	"github.com/juju/utils/keyvalues"
 )
 
 var logger = loggo.GetLogger("juju.container.lxc")

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -23,7 +23,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
-
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"

--- a/featuretests/annotations_test.go
+++ b/featuretests/annotations_test.go
@@ -4,9 +4,8 @@
 package featuretests
 
 import (
-	gc "gopkg.in/check.v1"
-
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/annotations"
 	jujutesting "github.com/juju/juju/juju/testing"

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testing"
-	"github.com/juju/names"
 )
 
 type apiStorageSuite struct {

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -4,13 +4,13 @@
 package state_test
 
 import (
-	"github.com/juju/juju/testing/factory"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
 )
 
 type AddressSuite struct{}

--- a/state/backups/testing/fakes.go
+++ b/state/backups/testing/fakes.go
@@ -7,12 +7,11 @@ import (
 	"io"
 
 	"github.com/juju/errors"
-
-	"github.com/juju/juju/instance"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/filestorage"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/backups"
 )
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/juju/juju/testcharms"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	jujutxn "github.com/juju/txn"
@@ -18,6 +17,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/testcharms"
 )
 
 const (

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -5,10 +5,11 @@ package state_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/network"
-	"github.com/juju/juju/state"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
 )
 
 type IPAddressSuite struct {

--- a/state/lease.go
+++ b/state/lease.go
@@ -4,11 +4,11 @@
 package state
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
-
-	"time"
 
 	"github.com/juju/juju/lease"
 )

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v4"
-
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
-
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/state/multiwatcher"

--- a/state/storage.go
+++ b/state/storage.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/feature"
 	"github.com/juju/names"
 	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v4"
@@ -15,6 +14,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider/registry"

--- a/state/tools.go
+++ b/state/tools.go
@@ -4,9 +4,9 @@
 package state
 
 import (
+	"github.com/juju/blobstore"
 	"gopkg.in/mgo.v2"
 
-	"github.com/juju/blobstore"
 	"github.com/juju/juju/state/toolstorage"
 )
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -4,9 +4,10 @@
 package storage
 
 import (
+	"github.com/juju/names"
+
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
-	"github.com/juju/names"
 )
 
 // ProviderType uniquely identifies a storage provider, such as "ebs" or "loop".

--- a/storage/path_test.go
+++ b/storage/path_test.go
@@ -4,9 +4,10 @@
 package storage_test
 
 import (
-	"github.com/juju/juju/storage"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/storage"
 )
 
 type BlockDevicePathSuite struct{}

--- a/storage/provider/registry/providerregistry_test.go
+++ b/storage/provider/registry/providerregistry_test.go
@@ -8,12 +8,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
+	// Ensure environ providers are registered.
+	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
-
-	// Ensure environ providers are registered.
-	_ "github.com/juju/juju/provider/all"
 )
 
 type providerRegistrySuite struct{}

--- a/upgrades/agentconfig.go
+++ b/upgrades/agentconfig.go
@@ -5,12 +5,12 @@ package upgrades
 
 import (
 	"fmt"
-	"github.com/juju/errors"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils/symlink"
 
 	"github.com/juju/juju/agent"

--- a/upgrades/upgrade.go
+++ b/upgrades/upgrade.go
@@ -6,8 +6,9 @@ package upgrades
 import (
 	"fmt"
 
-	"github.com/juju/juju/version"
 	"github.com/juju/loggo"
+
+	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.upgrade")

--- a/version/supportedseries_windows_test.go
+++ b/version/supportedseries_windows_test.go
@@ -7,10 +7,10 @@ package version_test
 import (
 	"sort"
 
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
 

--- a/worker/diskformatter/diskformatter_test.go
+++ b/worker/diskformatter/diskformatter_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/names"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/diskformatter"
-	"github.com/juju/testing"
 )
 
 var _ = gc.Suite(&DiskFormatterWorkerSuite{})

--- a/worker/networker/networker.go
+++ b/worker/networker/networker.go
@@ -12,10 +12,9 @@ import (
 	"sort"
 	"strings"
 
-	"launchpad.net/tomb"
-
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
 	apinetworker "github.com/juju/juju/api/networker"

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -5,6 +5,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/fslock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -15,7 +16,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/reboot"
-	"github.com/juju/utils/fslock"
 )
 
 func TestPackage(t *stdtesting.T) {

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -7,11 +7,11 @@ package hook
 import (
 	"fmt"
 
+	"github.com/juju/names"
 	"github.com/juju/utils/featureflag"
+	"gopkg.in/juju/charm.v4/hooks"
 
 	"github.com/juju/juju/feature"
-	"github.com/juju/names"
-	"gopkg.in/juju/charm.v4/hooks"
 )
 
 // Info holds details required to execute a hook. Not all fields are

--- a/worker/uniter/relation/hooksender.go
+++ b/worker/uniter/relation/hooksender.go
@@ -4,9 +4,8 @@
 package relation
 
 import (
-	"launchpad.net/tomb"
-
 	"github.com/juju/errors"
+	"launchpad.net/tomb"
 
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/worker/uniter/hook"

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -9,13 +9,13 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/exec"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
-	"github.com/juju/utils/exec"
 )
 
 type InterfaceSuite struct {

--- a/wrench/wrench_test.go
+++ b/wrench/wrench_test.go
@@ -10,12 +10,12 @@ import (
 	"runtime"
 	stdtesting "testing"
 
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/wrench"
-	"github.com/juju/loggo"
-	jc "github.com/juju/testing/checkers"
 )
 
 func TestPackage(t *stdtesting.T) {


### PR DESCRIPTION
This is a totally automated change that groups the imports
into the standard (stdlib, external, local) sections.

I just ran sortimports ./... from juju-core root

See github.com/rogpeppe/sortimports


(Review request: http://reviews.vapour.ws/r/931/)