### PR TITLE
rsyslog: fixes lp:1417875

### DIFF
--- a/api/rsyslog/rsyslog.go
+++ b/api/rsyslog/rsyslog.go
@@ -17,6 +17,7 @@ const rsyslogAPI = "Rsyslog"
 // RsyslogConfig holds the values needed for the rsyslog worker
 type RsyslogConfig struct {
 	CACert string
+	CAKey  string
 	// Port is only used by state servers as the port to listen on.
 	Port      int
 	HostPorts []network.HostPort
@@ -32,13 +33,16 @@ func NewState(caller base.APICaller) *State {
 	return &State{facade: base.NewFacadeCaller(caller, rsyslogAPI)}
 }
 
-// SetRsyslogCert sets the rsyslog CA certificate,
-// which is used by clients to verify the server's
-// identity and establish a TLS session.
-func (st *State) SetRsyslogCert(caCert string) error {
+// SetRsyslogCert sets the rsyslog CA and Key certificates.
+// The CA cert is used to verify the server's identify and establish
+// a TLS session. The Key is used to allow us to properly regenerate
+// rsyslog server certificates when adding and removing
+// state servers with ensure-availability.
+func (st *State) SetRsyslogCert(caCert, caKey string) error {
 	var result params.ErrorResult
 	args := params.SetRsyslogCertParams{
 		CACert: []byte(caCert),
+		CAKey:  []byte(caKey),
 	}
 	err := st.facade.FacadeCall("SetRsyslogCert", args, &result)
 	if err != nil {
@@ -92,6 +96,7 @@ func (st *State) GetRsyslogConfig(agentTag string) (*RsyslogConfig, error) {
 	}
 	return &RsyslogConfig{
 		CACert:    result.CACert,
+		CAKey:     result.CAKey,
 		Port:      result.Port,
 		HostPorts: result.HostPorts,
 	}, nil

--- a/api/rsyslog/rsyslog_test.go
+++ b/api/rsyslog/rsyslog_test.go
@@ -4,6 +4,7 @@
 package rsyslog_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -38,8 +39,11 @@ func (s *rsyslogSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *rsyslogSuite) TestGetRsyslogConfig(c *gc.C) {
-	err := s.APIState.Client().EnvironmentSet(map[string]interface{}{"rsyslog-ca-cert": coretesting.CACert})
-	c.Assert(err, gc.IsNil)
+	err := s.APIState.Client().EnvironmentSet(map[string]interface{}{
+		"rsyslog-ca-cert": coretesting.CACert,
+		"rsyslog-ca-key":  coretesting.CAKey,
+	})
+	c.Assert(err, jc.ErrorIsNil)
 
 	cfg, err := s.rsyslog.GetRsyslogConfig(s.machine.Tag().String())
 	c.Assert(err, gc.IsNil)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -759,12 +759,14 @@ type StatusParams struct {
 // SetRsyslogCertParams holds parameters for the SetRsyslogCert call.
 type SetRsyslogCertParams struct {
 	CACert []byte
+	CAKey  []byte
 }
 
 // RsyslogConfigResult holds the result of a GetRsyslogConfig call.
 type RsyslogConfigResult struct {
 	Error  *Error
 	CACert string
+	CAKey  string
 	// Port is only used by state servers as the port to listen on.
 	// Clients should use HostPorts for the rsyslog addresses to forward
 	// logs to.

--- a/apiserver/rsyslog/config.go
+++ b/apiserver/rsyslog/config.go
@@ -22,6 +22,7 @@ func newRsyslogConfig(envCfg *config.Config, api *RsyslogAPI) (*apirsyslog.Rsysl
 
 	return &apirsyslog.RsyslogConfig{
 		CACert:    envCfg.RsyslogCACert(),
+		CAKey:     envCfg.RsyslogCAKey(),
 		Port:      port,
 		HostPorts: network.AddressesWithPort(apiAddresses, port),
 	}, nil

--- a/apiserver/rsyslog/rsyslog.go
+++ b/apiserver/rsyslog/rsyslog.go
@@ -52,7 +52,11 @@ func (api *RsyslogAPI) SetRsyslogCert(args params.SetRsyslogCertParams) (params.
 		result.Error = common.ServerError(err)
 		return result, nil
 	}
-	attrs := map[string]interface{}{"rsyslog-ca-cert": string(args.CACert)}
+
+	attrs := map[string]interface{}{
+		"rsyslog-ca-cert": string(args.CACert),
+		"rsyslog-ca-key":  string(args.CAKey),
+	}
 	if err := api.st.UpdateEnvironConfig(attrs, nil, nil); err != nil {
 		result.Error = common.ServerError(err)
 	}
@@ -73,6 +77,7 @@ func (api *RsyslogAPI) GetRsyslogConfig(args params.Entities) (params.RsyslogCon
 		if err == nil {
 			result.Results[i] = params.RsyslogConfigResult{
 				CACert:    rsyslogCfg.CACert,
+				CAKey:     rsyslogCfg.CAKey,
 				Port:      rsyslogCfg.Port,
 				HostPorts: rsyslogCfg.HostPorts,
 			}

--- a/apiserver/rsyslog/rsyslog_test.go
+++ b/apiserver/rsyslog/rsyslog_test.go
@@ -46,10 +46,11 @@ func (s *rsyslogSuite) SetUpTest(c *gc.C) {
 		api, s.State, s.resources, commontesting.NoSecrets)
 }
 
-func verifyRsyslogCACert(c *gc.C, st *apirsyslog.State, expected string) {
+func verifyRsyslogCACert(c *gc.C, st *apirsyslog.State, expectedCA, expectedKey string) {
 	cfg, err := st.GetRsyslogConfig("foo")
-	c.Assert(err, gc.IsNil)
-	c.Assert(cfg.CACert, gc.DeepEquals, expected)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.CACert, gc.DeepEquals, expectedCA)
+	c.Assert(cfg.CAKey, gc.DeepEquals, expectedKey)
 }
 
 func (s *rsyslogSuite) TestSetRsyslogCert(c *gc.C) {
@@ -57,9 +58,9 @@ func (s *rsyslogSuite) TestSetRsyslogCert(c *gc.C) {
 	err := m.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
 	c.Assert(err, gc.IsNil)
 
-	err = st.Rsyslog().SetRsyslogCert(coretesting.CACert)
-	c.Assert(err, gc.IsNil)
-	verifyRsyslogCACert(c, st.Rsyslog(), coretesting.CACert)
+	err = st.Rsyslog().SetRsyslogCert(coretesting.CACert, coretesting.CAKey)
+	c.Assert(err, jc.ErrorIsNil)
+	verifyRsyslogCACert(c, st.Rsyslog(), coretesting.CACert, coretesting.CAKey)
 }
 
 func (s *rsyslogSuite) TestSetRsyslogCertNil(c *gc.C) {
@@ -67,9 +68,9 @@ func (s *rsyslogSuite) TestSetRsyslogCertNil(c *gc.C) {
 	err := m.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
 	c.Assert(err, gc.IsNil)
 
-	err = st.Rsyslog().SetRsyslogCert("")
+	err = st.Rsyslog().SetRsyslogCert("", "")
 	c.Assert(err, gc.ErrorMatches, "no certificates found")
-	verifyRsyslogCACert(c, st.Rsyslog(), "")
+	verifyRsyslogCACert(c, st.Rsyslog(), "", "")
 }
 
 func (s *rsyslogSuite) TestSetRsyslogCertInvalid(c *gc.C) {
@@ -80,9 +81,9 @@ func (s *rsyslogSuite) TestSetRsyslogCertInvalid(c *gc.C) {
 	err = st.Rsyslog().SetRsyslogCert(string(pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: []byte("not a valid certificate"),
-	})))
+	})), "")
 	c.Assert(err, gc.ErrorMatches, ".*structure error.*")
-	verifyRsyslogCACert(c, st.Rsyslog(), "")
+	verifyRsyslogCACert(c, st.Rsyslog(), "", "")
 }
 
 func (s *rsyslogSuite) TestSetRsyslogCertPerms(c *gc.C) {
@@ -93,11 +94,11 @@ func (s *rsyslogSuite) TestSetRsyslogCertPerms(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	unitState, _ := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
-	err = unitState.Rsyslog().SetRsyslogCert(coretesting.CACert)
+	err = unitState.Rsyslog().SetRsyslogCert(coretesting.CACert, coretesting.CAKey)
 	c.Assert(err, gc.ErrorMatches, "invalid entity name or password")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 	// Verify no change was effected.
-	verifyRsyslogCACert(c, unitState.Rsyslog(), "")
+	verifyRsyslogCACert(c, unitState.Rsyslog(), "", "")
 }
 
 func (s *rsyslogSuite) TestUpgraderAPIAllowsUnitAgent(c *gc.C) {

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -729,6 +729,16 @@ func (c *Config) RsyslogCACert() string {
 	return ""
 }
 
+// RsyslogCAKey returns the key of the CA that signed the
+// rsyslog certificate, in PEM format, or nil if one hasn't been
+// generated yet.
+func (c *Config) RsyslogCAKey() string {
+	if s, ok := c.defined["rsyslog-ca-key"]; ok {
+		return s.(string)
+	}
+	return ""
+}
+
 // AuthorizedKeys returns the content for ssh's authorized_keys file.
 func (c *Config) AuthorizedKeys() string {
 	return c.mustString("authorized-keys")
@@ -1084,6 +1094,7 @@ var fields = schema.Fields{
 	"api-port":                   schema.ForceInt(),
 	"syslog-port":                schema.ForceInt(),
 	"rsyslog-ca-cert":            schema.String(),
+	"rsyslog-ca-key":             schema.String(),
 	"logging-config":             schema.String(),
 	"charm-store-auth":           schema.String(),
 	ProvisionerHarvestModeKey:    schema.String(),
@@ -1136,6 +1147,7 @@ var alwaysOptional = schema.Defaults{
 	"bootstrap-retry-delay":      schema.Omit,
 	"bootstrap-addresses-delay":  schema.Omit,
 	"rsyslog-ca-cert":            schema.Omit,
+	"rsyslog-ca-key":             schema.Omit,
 	HttpProxyKey:                 schema.Omit,
 	HttpsProxyKey:                schema.Omit,
 	FtpProxyKey:                  schema.Omit,

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/syslog"
 	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -79,8 +80,11 @@ func (s *RsyslogSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
-	err := s.APIState.Client().EnvironmentSet(map[string]interface{}{"rsyslog-ca-cert": coretesting.CACert})
-	c.Assert(err, gc.IsNil)
+	err := s.APIState.Client().EnvironmentSet(map[string]interface{}{
+		"rsyslog-ca-cert": coretesting.CACert,
+		"rsyslog-ca-key":  coretesting.CAKey,
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
 	addrs := []string{"0.1.2.3", "0.2.4.6"}
 	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "foo", addrs)


### PR DESCRIPTION
In https://github.com/juju/juju/pull/499 we implemented streaming for forwarding logs. This broke log forwarding when operating in HA mode due to a mismatch of the ca-cert on disk and the ca-cert that the rsyslog server certs were generated from.

This patch ensures that the rsyslog server certs are properly regenerated using the ca-cert and key from the config when new state servers are added. This ensures that they can all interconnect between each other for log forwarding when units are deployed directly on to the bootstrap nodes (as happens with openstack).

Fixes: https://bugs.launchpad.net/juju-core/+bug/1417875

(Review request: http://reviews.vapour.ws/r/932/)