### PR TITLE
Add validation for AWS EBS parameters

### DIFF
--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -17,8 +17,16 @@ const (
 	// minRootDiskSizeMiB is the minimum/default size (in mebibytes) for ec2 root disks.
 	minRootDiskSizeMiB uint64 = 8 * 1024
 
-	// volumeSizeMaxMiB is the maximum disk size (in mebibytes) for EBS volumes.
-	volumeSizeMaxMiB = 1024 * 1024 // 1024 GiB
+	// provisionedIopsvolumeSizeMinGiB is the minimum disk size (in gibibytes)
+	// for provisioned IOPS EBS volumes.
+	provisionedIopsvolumeSizeMinGiB = 10 // 10 GiB
+
+	// volumeSizeMaxGiB is the maximum disk size (in gibibytes) for EBS volumes.
+	volumeSizeMaxGiB = 1024 // 1024 GiB
+
+	// maxProvisionedIopsSizeRatio is the maximum allowed ratio of IOPS to
+	// size (in GiB), for provisioend IOPS volumes.
+	maxProvisionedIopsSizeRatio = 30
 )
 
 // getBlockDeviceMappings translates a StartInstanceParams into
@@ -77,18 +85,14 @@ func getBlockDeviceMappings(
 	attachments := make([]storage.VolumeAttachment, len(args.Volumes))
 	nextDeviceName := blockDeviceNamer(virtType == paravirtual)
 	for i, params := range args.Volumes {
-		// Check minimum constraints can be satisfied.
-		if err := validateVolumeParams(params); err != nil {
-			return nil, nil, nil, errors.Annotate(err, "invalid volume parameters")
+		if params.Provider != EBS_ProviderType {
+			continue
 		}
-		requestDeviceName, actualDeviceName, err := nextDeviceName()
-		if err != nil {
-			// Can't attach any more volumes.
-			return nil, nil, nil, err
+		if params.Attachment == nil {
+			return nil, nil, nil, errors.NotImplementedf("allocating unattached volumes")
 		}
 		mapping := ec2.BlockDeviceMapping{
 			VolumeSize: int64(mibToGib(params.Size)),
-			DeviceName: requestDeviceName,
 			// TODO(axw) DeleteOnTermination
 		}
 		// Translate user values for storage provider parameters.
@@ -98,11 +102,24 @@ func getBlockDeviceMappings(
 			mapping.VolumeType = v.(string)
 		}
 		if v, ok := options[EBS_IOPS]; ok && v != "" {
+			var err error
 			mapping.IOPS, err = strconv.ParseInt(v.(string), 10, 64)
 			if err != nil {
 				return nil, nil, nil, errors.Annotatef(err, "invalid iops value %v, expected integer", v)
 			}
 		}
+
+		// Check mapping is valid (minus the device name).
+		if err := validateBlockDeviceMapping(mapping); err != nil {
+			return nil, nil, nil, errors.Annotate(err, "invalid volume parameters")
+		}
+		requestDeviceName, actualDeviceName, err := nextDeviceName()
+		if err != nil {
+			// Can't attach any more volumes.
+			return nil, nil, nil, err
+		}
+		mapping.DeviceName = requestDeviceName
+
 		volume := storage.Volume{
 			Tag:  params.Tag,
 			Size: gibToMib(uint64(mapping.VolumeSize)),
@@ -121,13 +138,32 @@ func getBlockDeviceMappings(
 	return blockDeviceMappings, volumes, attachments, nil
 }
 
-// validateVolumParams validates the volume parameters.
-func validateVolumeParams(params storage.VolumeParams) error {
-	if params.Attachment == nil {
-		return errors.NotImplementedf("allocating unattached volumes")
+// validateBlockDeviceMapping validates a block device mapping,
+// excluding the device name.
+func validateBlockDeviceMapping(m ec2.BlockDeviceMapping) error {
+	if m.VolumeSize > volumeSizeMaxGiB {
+		return errors.Errorf("%d GiB exceeds the maximum of %d GiB", m.VolumeSize, volumeSizeMaxGiB)
 	}
-	if params.Size > volumeSizeMaxMiB {
-		return errors.Errorf("%d MiB exceeds the maximum of %d MiB", params.Size, volumeSizeMaxMiB)
+	if m.VolumeType == "io1" {
+		if m.VolumeSize < provisionedIopsvolumeSizeMinGiB {
+			return errors.Errorf(
+				"volume size is %d GiB, must be at least %d GiB for provisioned IOPS",
+				m.VolumeSize,
+				provisionedIopsvolumeSizeMinGiB,
+			)
+		}
+	}
+	if m.IOPS > 0 {
+		if m.VolumeType != "io1" {
+			return errors.Errorf("IOPS specified, but volume type is %q", m.VolumeType)
+		}
+		minSize := m.IOPS / maxProvisionedIopsSizeRatio
+		if m.VolumeSize < minSize {
+			return errors.Errorf(
+				"volume size is %d GiB, must be at least %d GiB to support %d IOPS",
+				m.VolumeSize, minSize, m.IOPS,
+			)
+		}
 	}
 	return nil
 }

--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -81,10 +81,10 @@ func getBlockDeviceMappings(
 	// many there are and how big each one is. We also need to
 	// unmap ephemeral0 in cloud-init.
 
-	volumes := make([]storage.Volume, len(args.Volumes))
-	attachments := make([]storage.VolumeAttachment, len(args.Volumes))
+	var volumes []storage.Volume
+	var attachments []storage.VolumeAttachment
 	nextDeviceName := blockDeviceNamer(virtType == paravirtual)
-	for i, params := range args.Volumes {
+	for _, params := range args.Volumes {
 		if params.Provider != EBS_ProviderType {
 			continue
 		}
@@ -132,8 +132,8 @@ func getBlockDeviceMappings(
 			DeviceName: actualDeviceName,
 		}
 		blockDeviceMappings = append(blockDeviceMappings, mapping)
-		volumes[i] = volume
-		attachments[i] = attachment
+		volumes = append(volumes, volume)
+		attachments = append(attachments, attachment)
 	}
 	return blockDeviceMappings, volumes, attachments, nil
 }

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/testing"
 )
 
@@ -87,6 +88,9 @@ func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 
 	mapping, volumes, volumeAttachments, err := ec2.GetBlockDeviceMappings(
 		"pv", &environs.StartInstanceParams{Volumes: []storage.VolumeParams{{
+			Size:     1234,
+			Provider: provider.LoopProviderType,
+		}, {
 			Tag:      volume0,
 			Size:     1234,
 			Provider: ec2.EBS_ProviderType,

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -87,16 +87,18 @@ func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 
 	mapping, volumes, volumeAttachments, err := ec2.GetBlockDeviceMappings(
 		"pv", &environs.StartInstanceParams{Volumes: []storage.VolumeParams{{
-			Tag:  volume0,
-			Size: 1234,
+			Tag:      volume0,
+			Size:     1234,
+			Provider: ec2.EBS_ProviderType,
 			Attachment: &storage.AttachmentParams{
 				Machine: machine0,
 			},
 		}, {
-			Tag:  volume1,
-			Size: 4321,
+			Tag:      volume1,
+			Size:     45000,
+			Provider: ec2.EBS_ProviderType,
 			Attributes: map[string]interface{}{
-				"volume-type": "standard",
+				"volume-type": "io1",
 				"iops":        "1234",
 			},
 			Attachment: &storage.AttachmentParams{
@@ -124,17 +126,93 @@ func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 		VolumeSize: 2,
 		DeviceName: "/dev/sdf1",
 	}, {
-		VolumeSize: 5,
+		VolumeSize: 44,
 		DeviceName: "/dev/sdf2",
-		VolumeType: "standard",
+		VolumeType: "io1",
 		IOPS:       1234,
 	}})
 	c.Assert(volumes, gc.DeepEquals, []storage.Volume{
 		{Tag: volume0, Size: 2048},
-		{Tag: volume1, Size: 5120},
+		{Tag: volume1, Size: 45056},
 	})
 	c.Assert(volumeAttachments, gc.DeepEquals, []storage.VolumeAttachment{
 		{Volume: volume0, Machine: machine0, DeviceName: "xvdf1"},
 		{Volume: volume1, Machine: machine0, DeviceName: "xvdf2"},
 	})
+}
+
+func (*DisksSuite) TestGetBlockDeviceMappingErrors(c *gc.C) {
+	volume0 := names.NewDiskTag("0")
+	machine0 := names.NewMachineTag("0")
+
+	for _, test := range []struct {
+		params storage.VolumeParams
+		err    string
+	}{
+		{
+			params: storage.VolumeParams{
+				Provider: ec2.EBS_ProviderType,
+			},
+			err: "allocating unattached volumes not implemented",
+		},
+		{
+			params: storage.VolumeParams{
+				Size:     100000000,
+				Provider: ec2.EBS_ProviderType,
+				Attachment: &storage.AttachmentParams{
+					Machine: machine0,
+				},
+			},
+			err: "invalid volume parameters: 97657 GiB exceeds the maximum of 1024 GiB",
+		},
+		{
+			params: storage.VolumeParams{
+				Tag:      volume0,
+				Size:     1000,
+				Provider: ec2.EBS_ProviderType,
+				Attributes: map[string]interface{}{
+					"volume-type": "io1",
+					"iops":        "1234",
+				},
+				Attachment: &storage.AttachmentParams{
+					Machine: machine0,
+				},
+			},
+			err: "invalid volume parameters: volume size is 1 GiB, must be at least 10 GiB for provisioned IOPS",
+		},
+		{
+			params: storage.VolumeParams{
+				Tag:      volume0,
+				Size:     10000,
+				Provider: ec2.EBS_ProviderType,
+				Attributes: map[string]interface{}{
+					"volume-type": "io1",
+					"iops":        "1234",
+				},
+				Attachment: &storage.AttachmentParams{
+					Machine: machine0,
+				},
+			},
+			err: "invalid volume parameters: volume size is 10 GiB, must be at least 41 GiB to support 1234 IOPS",
+		},
+		{
+			params: storage.VolumeParams{
+				Tag:      volume0,
+				Size:     10000,
+				Provider: ec2.EBS_ProviderType,
+				Attributes: map[string]interface{}{
+					"volume-type": "standard",
+					"iops":        "1234",
+				},
+				Attachment: &storage.AttachmentParams{
+					Machine: machine0,
+				},
+			},
+			err: `invalid volume parameters: IOPS specified, but volume type is "standard"`,
+		}} {
+		_, _, _, err := ec2.GetBlockDeviceMappings(
+			"pv", &environs.StartInstanceParams{Volumes: []storage.VolumeParams{test.params}},
+		)
+		c.Check(err, gc.ErrorMatches, test.err)
+	}
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -910,12 +910,15 @@ func (t *localServerSuite) TestStartInstanceVolumes(c *gc.C) {
 	params := environs.StartInstanceParams{
 		Volumes: []storage.VolumeParams{{
 			Size:       512, // round up to 1GiB
+			Provider:   ec2.EBS_ProviderType,
 			Attachment: attachmentParams,
 		}, {
 			Size:       1024, // 1GiB exactly
+			Provider:   ec2.EBS_ProviderType,
 			Attachment: attachmentParams,
 		}, {
 			Size:       1025, // round up to 2GiB
+			Provider:   ec2.EBS_ProviderType,
 			Attachment: attachmentParams,
 		}},
 	}


### PR DESCRIPTION
Add error checking for EBS params passed to start instance for the AWS provider. 
Checks include:
- max volume size is not exceeded
- provisioned iops min size is 10GB
- volume type for EBS with iops is "io1"
- ratio of iops to volume size is <= 30

Also, for now, volumes being allocated but be attached to a machine.



(Review request: http://reviews.vapour.ws/r/942/)