### PR TITLE
Account for AWS VolumeTypeNotAvailableInZone errors

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1286,6 +1286,8 @@ func isZoneConstrainedError(err error) bool {
 			// if the AZ does not have a default subnet. Until we have proper
 			// support for networks, we'll skip over these.
 			return strings.HasPrefix(err.Message, "No default subnet for availability zone")
+		case "VolumeTypeNotAvailableInZone":
+			return true
 		}
 	}
 	return false

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -478,6 +478,11 @@ var azConstrainedErr = &amzec2.Error{
 	Message: "The requested Availability Zone is currently constrained etc.",
 }
 
+var azVolumeTypeNotAvailableInZoneErr = &amzec2.Error{
+	Code:    "VolumeTypeNotAvailableInZone",
+	Message: "blah blah",
+}
+
 var azInsufficientInstanceCapacityErr = &amzec2.Error{
 	Code: "InsufficientInstanceCapacity",
 	Message: "We currently do not have sufficient m1.small capacity in the " +
@@ -494,6 +499,10 @@ var azNoDefaultSubnetErr = &amzec2.Error{
 
 func (t *localServerSuite) TestStartInstanceAvailZoneAllConstrained(c *gc.C) {
 	t.testStartInstanceAvailZoneAllConstrained(c, azConstrainedErr)
+}
+
+func (t *localServerSuite) TestStartInstanceVolumeTypeNotAvailable(c *gc.C) {
+	t.testStartInstanceAvailZoneAllConstrained(c, azVolumeTypeNotAvailableInZoneErr)
 }
 
 func (t *localServerSuite) TestStartInstanceAvailZoneAllInsufficientInstanceCapacity(c *gc.C) {


### PR DESCRIPTION
We need to account for AWS VolumeTypeNotAvailableInZone errors when specifying EBS volumes.

(Review request: http://reviews.vapour.ws/r/943/)