### PR TITLE
Fixed lp:1416928 - ignore lxcbr0 addresses on machine-0 for non-local environments

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
 )
@@ -96,6 +97,15 @@ func InitializeState(adminUser names.UserTag, c ConfigSetter, envCfg *config.Con
 	}()
 	servingInfo.SharedSecret = machineCfg.SharedSecret
 	c.SetStateServingInfo(servingInfo)
+
+	// Filter out any LXC bridge addresses from the machine addresses,
+	// except for local environments. See LP bug #1416928.
+	if !isLocalEnv(envCfg) {
+		machineCfg.Addresses = network.FilterLXCAddresses(machineCfg.Addresses)
+	} else {
+		logger.Debugf("local environment - not filtering addresses from %v", machineCfg.Addresses)
+	}
+
 	if err = initAPIHostPorts(c, st, machineCfg.Addresses, servingInfo.APIPort); err != nil {
 		return nil, nil, err
 	}
@@ -108,6 +118,12 @@ func InitializeState(adminUser names.UserTag, c ConfigSetter, envCfg *config.Con
 		return nil, nil, err
 	}
 	return st, m, nil
+}
+
+// isLocalEnv returns true if the given config is for a local
+// environment. Defined like this for testing.
+var isLocalEnv = func(cfg *config.Config) bool {
+	return cfg.Type() == provider.Local
 }
 
 func paramsStateServingInfoToStateStateServingInfo(i params.StateServingInfo) state.StateServingInfo {

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -4,6 +4,10 @@
 package agent_test
 
 import (
+	"io/ioutil"
+	"net"
+	"path/filepath"
+
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -45,8 +49,39 @@ func (s *bootstrapSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
+func (s *bootstrapSuite) TestInitializeStateNonLocal(c *gc.C) {
+	s.testInitializeState(c, false)
+}
+
+func (s *bootstrapSuite) TestInitializeStateLocal(c *gc.C) {
+	s.testInitializeState(c, true)
+}
+
+func (s *bootstrapSuite) testInitializeState(c *gc.C, fakeLocalEnv bool) {
 	dataDir := c.MkDir()
+
+	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
+	netConf := []byte(`
+  # comments ignored
+LXC_BR= ignored
+LXC_ADDR = "fooo"
+LXC_BRIDGE="foobar" # detected
+anything else ignored
+LXC_BRIDGE="ignored"`[1:])
+	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+		c.Assert(name, gc.Equals, "foobar")
+		return []net.Addr{
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+		}, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
+	s.PatchValue(agent.IsLocalEnv, func(*config.Config) bool {
+		c.Logf("fakeLocalEnv=%v", fakeLocalEnv)
+		return fakeLocalEnv
+	})
 
 	pwHash := utils.UserPasswordHash(testing.DefaultMongoPassword, utils.CompatSalt)
 	configParams := agent.AgentConfigParams{
@@ -72,13 +107,29 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	c.Assert(available, gc.Equals, true)
 	expectConstraints := constraints.MustParse("mem=1024M")
 	expectHW := instance.MustParseHardware("mem=2048M")
+	initialAddrs := network.NewAddresses(
+		"zeroonetwothree",
+		"0.1.2.3",
+		"10.0.3.1", // lxc bridge address filtered (when fakeLocalEnv=false).
+		"10.0.3.4", // lxc bridge address filtered (-"-).
+		"10.0.3.3", // not a lxc bridge address
+	)
 	mcfg := agent.BootstrapMachineConfig{
-		Addresses:       network.NewAddresses("zeroonetwothree", "0.1.2.3"),
+		Addresses:       initialAddrs,
 		Constraints:     expectConstraints,
 		Jobs:            []params.MachineJob{params.JobManageEnviron},
 		InstanceId:      "i-bootstrap",
 		Characteristics: expectHW,
 		SharedSecret:    "abc123",
+	}
+	filteredAddrs := network.NewAddresses(
+		"zeroonetwothree",
+		"0.1.2.3",
+		"10.0.3.3",
+	)
+	if fakeLocalEnv {
+		// For local environments - no filtering.
+		filteredAddrs = append([]network.Address{}, initialAddrs...)
 	}
 	envAttrs := dummy.SampleConfig().Delete("admin-secret").Merge(testing.Attrs{
 		"agent-version": version.Current.Number.String(),
@@ -118,7 +169,7 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageEnviron})
 	c.Assert(m.Series(), gc.Equals, version.Current.Series)
 	c.Assert(m.CheckProvisioned(agent.BootstrapNonce), jc.IsTrue)
-	c.Assert(m.Addresses(), gc.DeepEquals, mcfg.Addresses)
+	c.Assert(m.Addresses(), jc.DeepEquals, filteredAddrs)
 	gotConstraints, err := m.Constraints()
 	c.Assert(err, gc.IsNil)
 	c.Assert(gotConstraints, gc.DeepEquals, expectConstraints)
@@ -126,14 +177,12 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	gotHW, err := m.HardwareCharacteristics()
 	c.Assert(err, gc.IsNil)
 	c.Assert(*gotHW, gc.DeepEquals, expectHW)
-	gotAddrs := m.Addresses()
-	c.Assert(gotAddrs, gc.DeepEquals, mcfg.Addresses)
 
 	// Check that the API host ports are initialised correctly.
 	apiHostPorts, err := st.APIHostPorts()
 	c.Assert(err, gc.IsNil)
 	c.Assert(apiHostPorts, jc.DeepEquals, [][]network.HostPort{
-		network.NewHostPorts(1234, "zeroonetwothree", "0.1.2.3"),
+		network.AddressesWithPort(filteredAddrs, 1234),
 	})
 
 	// Check that the state serving info is initialised correctly.

--- a/agent/export_test.go
+++ b/agent/export_test.go
@@ -51,4 +51,7 @@ func ConfigFileExists(config Config) bool {
 	return err == nil
 }
 
-var MachineJobFromParams = machineJobFromParams
+var (
+	MachineJobFromParams = machineJobFromParams
+	IsLocalEnv           = &isLocalEnv
+)

--- a/network/network.go
+++ b/network/network.go
@@ -4,7 +4,11 @@
 package network
 
 import (
+	"bufio"
 	"fmt"
+	"net"
+	"os"
+	"strings"
 
 	"github.com/juju/loggo"
 )
@@ -104,4 +108,96 @@ type PreferIPv6Getter interface {
 func InitializeFromConfig(config PreferIPv6Getter) {
 	globalPreferIPv6 = config.PreferIPv6()
 	logger.Infof("setting prefer-ipv6 to %v", globalPreferIPv6)
+}
+
+// LXCNetDefaultConfig is the location of the default network config
+// of the lxc package. It's exported to allow cross-package testing.
+var LXCNetDefaultConfig = "/etc/default/lxc-net"
+
+// InterfaceByNameAddrs returns the addresses for the given interface
+// name. It's exported to facilitate cross-package testing.
+var InterfaceByNameAddrs = func(name string) ([]net.Addr, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return iface.Addrs()
+}
+
+// FilterLXCAddresses tries to discover the default lxc bridge name
+// and all of its addresses, then filters those addresses out of the
+// given ones and returns the result. Any errors encountered during
+// this process are logged, but not considered fatal. See LP bug
+// #1416928.
+func FilterLXCAddresses(addresses []Address) []Address {
+	file, err := os.Open(LXCNetDefaultConfig)
+	if os.IsNotExist(err) {
+		// No lxc-net config found, nothing to do.
+		logger.Debugf("no lxc bridge addresses to filter for machine")
+		return addresses
+	} else if err != nil {
+		// Just log it, as it's not fatal.
+		logger.Warningf("cannot open %q: %v", LXCNetDefaultConfig, err)
+		return addresses
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "#"):
+			// Skip comments.
+		case strings.HasPrefix(line, "LXC_BRIDGE"):
+			// Extract <name> from LXC_BRIDGE="<name>".
+			parts := strings.Split(line, `"`)
+			if len(parts) < 2 {
+				logger.Debugf("ignoring invalid line '%s' in %q", line, LXCNetDefaultConfig)
+				continue
+			}
+			bridgeName := strings.TrimSpace(parts[1])
+			// Discover all addresses of bridgeName interface.
+			addrs, err := InterfaceByNameAddrs(bridgeName)
+			if err != nil {
+				logger.Warningf("cannot get %q addresses: %v (ignoring)", bridgeName, err)
+				continue
+			}
+			logger.Debugf("%q has addresses %v", bridgeName, addrs)
+			// Filter out any bridge addresses.
+			filtered := make([]Address, 0, len(addresses))
+			for _, addr := range addresses {
+				found := false
+				for _, ifaceAddr := range addrs {
+					// First check if this is a CIDR, as
+					// net.InterfaceAddrs might return this instead of
+					// a plain IP.
+					ip, ipNet, err := net.ParseCIDR(ifaceAddr.String())
+					if err != nil {
+						// It's not a CIDR, try parsing as IP.
+						ip = net.ParseIP(ifaceAddr.String())
+					}
+					if ip == nil {
+						logger.Debugf("cannot parse %q as IP, ignoring", ifaceAddr)
+						continue
+					}
+					// Filter by CIDR if known or single IP otherwise.
+					if ipNet != nil && ipNet.Contains(net.ParseIP(addr.Value)) ||
+						ip.String() == addr.Value {
+						found = true
+						logger.Debugf("filtering %q address %s for machine", bridgeName, ifaceAddr.String())
+					}
+				}
+				if !found {
+					logger.Debugf("not filtering address %s for machine", addr)
+					filtered = append(filtered, addr)
+				}
+			}
+			logger.Debugf("addresses after filtering: %v", filtered)
+			return filtered
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		logger.Warningf("failed to read %q: %v (ignoring)", LXCNetDefaultConfig, err)
+	}
+	return addresses
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -4,6 +4,10 @@
 package network_test
 
 import (
+	"io/ioutil"
+	"net"
+	"path/filepath"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -63,4 +67,45 @@ func (*NetworkSuite) TestInitializeFromConfig(c *gc.C) {
 	})
 	network.InitializeFromConfig(envConfig)
 	c.Check(network.GetPreferIPv6(), jc.IsFalse)
+}
+
+func (s *NetworkSuite) TestFilterLXCAddresses(c *gc.C) {
+	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
+	netConf := []byte(`
+  # comments ignored
+LXC_BR= ignored
+LXC_ADDR = "fooo"
+ LXC_BRIDGE = " foobar " # detected, spaces stripped
+anything else ignored
+LXC_BRIDGE="ignored"`[1:])
+	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+		c.Assert(name, gc.Equals, "foobar")
+		return []net.Addr{
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+			// Try a CIDR 10.0.3.5/24 as well.
+			&net.IPNet{IP: net.IPv4(10, 0, 3, 5), Mask: net.IPv4Mask(255, 255, 255, 0)},
+		}, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
+
+	inputAddresses := network.NewAddresses(
+		"127.0.0.1",
+		"2001:db8::1",
+		"10.0.0.1",
+		"10.0.3.1", // filtered (directly as IP)
+		"10.0.3.3", // filtered (by the 10.0.3.5/24 CIDR)
+		"10.0.3.5", // filtered (directly)
+		"10.0.3.4", // filtered (directly)
+		"192.168.123.42",
+	)
+	filteredAddresses := network.NewAddresses(
+		"127.0.0.1",
+		"2001:db8::1",
+		"10.0.0.1",
+		"192.168.123.42",
+	)
+	c.Assert(network.FilterLXCAddresses(inputAddresses), jc.DeepEquals, filteredAddresses)
 }

--- a/worker/apiaddressupdater/apiaddressupdater_test.go
+++ b/worker/apiaddressupdater/apiaddressupdater_test.go
@@ -94,7 +94,7 @@ func (s *APIAddressUpdaterSuite) TestAddressChange(c *gc.C) {
 	// and then the updated value.
 	select {
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for SetAPIHostPorts to be called first")
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called initially")
 	case servers := <-setter.servers:
 		c.Assert(servers, gc.HasLen, 0)
 	}
@@ -103,7 +103,7 @@ func (s *APIAddressUpdaterSuite) TestAddressChange(c *gc.C) {
 	s.BackingState.StartSync()
 	select {
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for SetAPIHostPorts to be called second")
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called after update")
 	case servers := <-setter.servers:
 		c.Assert(servers, gc.DeepEquals, updatedServers)
 	}
@@ -160,7 +160,7 @@ LXC_BRIDGE="ignored"`[1:])
 	// then the updated value, but filtering occurs in both cases.
 	select {
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for SetAPIHostPorts to be called first")
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called initially")
 	case servers := <-setter.servers:
 		c.Assert(servers, gc.HasLen, 2)
 		c.Assert(servers, jc.DeepEquals, [][]network.HostPort{
@@ -173,7 +173,7 @@ LXC_BRIDGE="ignored"`[1:])
 	s.BackingState.StartSync()
 	select {
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for SetAPIHostPorts to be called second")
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called after update")
 	case servers := <-setter.servers:
 		c.Assert(servers, gc.HasLen, 2)
 		c.Assert(servers, jc.DeepEquals, [][]network.HostPort{

--- a/worker/apiaddressupdater/apiaddressupdater_test.go
+++ b/worker/apiaddressupdater/apiaddressupdater_test.go
@@ -4,9 +4,13 @@
 package apiaddressupdater_test
 
 import (
+	"io/ioutil"
+	"net"
+	"path/filepath"
 	stdtesting "testing"
 	"time"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -30,6 +34,11 @@ func (s *APIAddressUpdaterSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	err := s.State.SetAPIHostPorts(nil)
 	c.Assert(err, gc.IsNil)
+	// By default mock these to better isolate the test from the real machine.
+	s.PatchValue(&network.InterfaceByNameAddrs, func(string) ([]net.Addr, error) {
+		return nil, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, "")
 }
 
 type apiAddressSetter struct {
@@ -97,5 +106,79 @@ func (s *APIAddressUpdaterSuite) TestAddressChange(c *gc.C) {
 		c.Fatalf("timed out waiting for SetAPIHostPorts to be called second")
 	case servers := <-setter.servers:
 		c.Assert(servers, gc.DeepEquals, updatedServers)
+	}
+}
+
+func (s *APIAddressUpdaterSuite) TestLXCBridgeAddressesFiltering(c *gc.C) {
+	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
+	netConf := []byte(`
+  # comments ignored
+LXC_BR= ignored
+LXC_ADDR = "fooo"
+LXC_BRIDGE="foobar" # detected
+anything else ignored
+LXC_BRIDGE="ignored"`[1:])
+	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+		c.Assert(name, gc.Equals, "foobar")
+		return []net.Addr{
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+		}, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
+
+	initialServers := [][]network.HostPort{
+		network.NewHostPorts(1234, "localhost", "127.0.0.1"),
+		network.NewHostPorts(
+			4321,
+			"10.0.3.1", // filtered
+			"10.0.3.3", // not filtered (not a lxc bridge address)
+		),
+		network.NewHostPorts(4242, "10.0.3.4"), // filtered
+	}
+	err = s.State.SetAPIHostPorts(initialServers)
+	c.Assert(err, jc.ErrorIsNil)
+
+	setter := &apiAddressSetter{servers: make(chan [][]network.HostPort, 1)}
+	st, _ := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
+	worker := apiaddressupdater.NewAPIAddressUpdater(st.Machiner(), setter)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+	s.BackingState.StartSync()
+	updatedServers := [][]network.HostPort{
+		network.NewHostPorts(1234, "localhost", "127.0.0.1"),
+		network.NewHostPorts(
+			4001,
+			"10.0.3.1", // filtered
+			"10.0.3.3", // not filtered (not a lxc bridge address)
+		),
+		network.NewHostPorts(4200, "10.0.3.4"), // filtered
+	}
+	// SetAPIHostPorts should be called with the initial value, and
+	// then the updated value, but filtering occurs in both cases.
+	select {
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called first")
+	case servers := <-setter.servers:
+		c.Assert(servers, gc.HasLen, 2)
+		c.Assert(servers, jc.DeepEquals, [][]network.HostPort{
+			network.NewHostPorts(1234, "localhost", "127.0.0.1"),
+			network.NewHostPorts(4321, "10.0.3.3"),
+		})
+	}
+	err = s.State.SetAPIHostPorts(updatedServers)
+	c.Assert(err, gc.IsNil)
+	s.BackingState.StartSync()
+	select {
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called second")
+	case servers := <-setter.servers:
+		c.Assert(servers, gc.HasLen, 2)
+		c.Assert(servers, jc.DeepEquals, [][]network.HostPort{
+			network.NewHostPorts(1234, "localhost", "127.0.0.1"),
+			network.NewHostPorts(4001, "10.0.3.3"),
+		})
 	}
 }

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -89,6 +89,8 @@ func setMachineAddresses(m *machiner.Machine) error {
 	if len(hostAddresses) == 0 {
 		return nil
 	}
+	// Filter out any LXC bridge addresses.
+	hostAddresses = network.FilterLXCAddresses(hostAddresses)
 	logger.Infof("setting addresses for %v to %q", m.Tag(), hostAddresses)
 	return m.SetMachineAddresses(hostAddresses)
 }

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -4,7 +4,9 @@
 package machiner_test
 
 import (
+	"io/ioutil"
 	"net"
+	"path/filepath"
 	stdtesting "testing"
 	"time"
 
@@ -58,6 +60,15 @@ func (s *MachinerSuite) SetUpTest(c *gc.C) {
 	s.apiMachine, err = s.machinerState.Machine(s.machine.Tag().(names.MachineTag))
 	c.Assert(err, gc.IsNil)
 	c.Assert(s.apiMachine.Tag(), gc.Equals, s.machine.Tag())
+	// Isolate tests better by not using real interface addresses.
+	s.PatchValue(machiner.InterfaceAddrs, func() ([]net.Addr, error) {
+		return nil, nil
+	})
+	s.PatchValue(&network.InterfaceByNameAddrs, func(string) ([]net.Addr, error) {
+		return nil, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, "")
+
 }
 
 func (s *MachinerSuite) waitMachineStatus(c *gc.C, m *state.Machine, expectStatus state.Status) {
@@ -139,18 +150,39 @@ func (s *MachinerSuite) TestSetDead(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestMachineAddresses(c *gc.C) {
+	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
+	netConf := []byte(`
+  # comments ignored
+LXC_BR= ignored
+LXC_ADDR = "fooo"
+LXC_BRIDGE="foobar" # detected
+anything else ignored
+LXC_BRIDGE="ignored"`[1:])
+	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(machiner.InterfaceAddrs, func() ([]net.Addr, error) {
 		addrs := []net.Addr{
 			&net.IPAddr{IP: net.IPv4(10, 0, 0, 1)},
 			&net.IPAddr{IP: net.IPv4(127, 0, 0, 1)},
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)}, // lxc bridge address ignored
 			&net.IPAddr{IP: net.IPv6loopback},
-			&net.UnixAddr{}, // not IP, ignored
+			&net.UnixAddr{},                        // not IP, ignored
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)}, // lxc bridge address ignored
 			&net.IPNet{IP: net.ParseIP("2001:db8::1")},
 			&net.IPAddr{IP: net.IPv4(169, 254, 1, 20)}, // LinkLocal Ignored
 			&net.IPNet{IP: net.ParseIP("fe80::1")},     // LinkLocal Ignored
 		}
 		return addrs, nil
 	})
+	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+		c.Assert(name, gc.Equals, "foobar")
+		return []net.Addr{
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+		}, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
+
 	mr := s.makeMachiner()
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), gc.IsNil)


### PR DESCRIPTION
The address(es) of the LXC bridge device is detected and filtered before
setting API hosts:ports (on bootstrap and when changes are detected by
the apiaddressesupdater) and also when updating machine addresses
discovered from the machiner locally. This means that bootstrapping on
a machine with the lxc package installed (i.e. having lxcbr0) or
installing the lxc package later won't cause the state or API addresses
to change and include the lxcbr0 address(es), which are unusable in all
but local environments.

See http://pad.lv/1416928 for more info.

Live tested on local (kvm, lxc), maas, amazon, manual (bootstrap, provisioning).

(Review request: http://reviews.vapour.ws/r/946/)