### PR TITLE
Run Actions in ModeHookError

### DIFF
--- a/worker/uniter/op_plumbing.go
+++ b/worker/uniter/op_plumbing.go
@@ -75,9 +75,9 @@ func newCommandsOp(args operation.CommandArgs, sendResponse operation.CommandRes
 	}
 }
 
-func newActionOp(actionId string) creator {
+func newActionOp(actionId string, resume operation.Kind) creator {
 	return func(factory operation.Factory) (operation.Operation, error) {
-		return factory.NewAction(actionId)
+		return factory.NewAction(actionId, resume)
 	}
 }
 

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -125,7 +125,7 @@ func (f *factory) NewSkipHook(hookInfo hook.Info) (Operation, error) {
 }
 
 // NewAction is part of the Factory interface.
-func (f *factory) NewAction(actionId string, resume Kind) (Operation, error) {
+func (f *factory) NewAction(actionId string, continuation Kind) (Operation, error) {
 	if !names.IsValidAction(actionId) {
 		return nil, errors.Errorf("invalid action id %q", actionId)
 	}
@@ -133,7 +133,7 @@ func (f *factory) NewAction(actionId string, resume Kind) (Operation, error) {
 		actionId:      actionId,
 		callbacks:     f.callbacks,
 		runnerFactory: f.runnerFactory,
-		resumeKind:    resume,
+		continuation:  continuation,
 	}, nil
 }
 

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -125,7 +125,7 @@ func (f *factory) NewSkipHook(hookInfo hook.Info) (Operation, error) {
 }
 
 // NewAction is part of the Factory interface.
-func (f *factory) NewAction(actionId string) (Operation, error) {
+func (f *factory) NewAction(actionId string, resume Kind) (Operation, error) {
 	if !names.IsValidAction(actionId) {
 		return nil, errors.Errorf("invalid action id %q", actionId)
 	}
@@ -133,6 +133,7 @@ func (f *factory) NewAction(actionId string) (Operation, error) {
 		actionId:      actionId,
 		callbacks:     f.callbacks,
 		runnerFactory: f.runnerFactory,
+		resumeKind:    resume,
 	}, nil
 }
 

--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -82,13 +82,13 @@ func (s *FactorySuite) TestNewResolvedUpgradeString(c *gc.C) {
 }
 
 func (s *FactorySuite) TestNewActionError(c *gc.C) {
-	op, err := s.factory.NewAction("lol-something")
+	op, err := s.factory.NewAction("lol-something", operation.Continue)
 	c.Check(op, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, `invalid action id "lol-something"`)
 }
 
 func (s *FactorySuite) TestNewActionString(c *gc.C) {
-	op, err := s.factory.NewAction(someActionId)
+	op, err := s.factory.NewAction(someActionId, operation.Continue)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(op.String(), gc.Equals, "run action "+someActionId)
 }

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -87,10 +87,10 @@ type Factory interface {
 	// mark the supplied hook as completed successfully.
 	NewSkipHook(hookInfo hook.Info) (Operation, error)
 
-	// NewAction creates an operation to execute the supplied action. resume is
+	// NewAction creates an operation to execute the supplied action. continuation is
 	// the operation.Kind that the action should set the opState to on successful
 	// completion.
-	NewAction(actionId string, resume Kind) (Operation, error)
+	NewAction(actionId string, continuation Kind) (Operation, error)
 
 	// NewCommands creates an operation to execute the supplied script in the
 	// indicated relation context, and pass the results back over the supplied

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -87,8 +87,10 @@ type Factory interface {
 	// mark the supplied hook as completed successfully.
 	NewSkipHook(hookInfo hook.Info) (Operation, error)
 
-	// NewAction creates an operation to execute the supplied action.
-	NewAction(actionId string) (Operation, error)
+	// NewAction creates an operation to execute the supplied action. resume is
+	// the operation.Kind that the action should set the opState to on successful
+	// completion.
+	NewAction(actionId string, resume Kind) (Operation, error)
 
 	// NewCommands creates an operation to execute the supplied script in the
 	// indicated relation context, and pass the results back over the supplied

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -20,7 +20,7 @@ type runAction struct {
 	name   string
 	runner runner.Runner
 
-	resumeKind Kind
+	continuation Kind
 }
 
 // String is part of the Operation interface.
@@ -87,7 +87,7 @@ func (ra *runAction) Execute(state State) (*State, error) {
 // Commit is part of the Operation interface.
 func (ra *runAction) Commit(state State) (*State, error) {
 	return stateChange{
-		Kind: ra.resumeKind,
+		Kind: ra.continuation,
 		Step: Pending,
 		Hook: state.Hook,
 	}.apply(state), nil

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -19,6 +19,8 @@ type runAction struct {
 
 	name   string
 	runner runner.Runner
+
+	resumeKind Kind
 }
 
 // String is part of the Operation interface.
@@ -85,7 +87,7 @@ func (ra *runAction) Execute(state State) (*State, error) {
 // Commit is part of the Operation interface.
 func (ra *runAction) Commit(state State) (*State, error) {
 	return stateChange{
-		Kind: Continue,
+		Kind: ra.resumeKind,
 		Step: Pending,
 		Hook: state.Hook,
 	}.apply(state), nil

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1517,7 +1517,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			}}},
 			waitUnit{status: params.StatusActive},
 		), ut(
-			"actions are not attempted from ModeHookError and do not clear the error",
+			"actions can run from ModeHookError, but do not clear the error",
 			startupErrorWithCustomCharm{
 				badHook: "start",
 				customize: func(c *gc.C, ctx *context, path string) {
@@ -1533,7 +1533,18 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 					"hook": "start",
 				},
 			},
-			verifyNoActionResults{},
+			waitActionResults{[]actionResult{{
+				name:    "action-log",
+				results: map[string]interface{}{},
+				status:  params.ActionCompleted,
+			}}},
+			waitUnit{
+				status: params.StatusError,
+				info:   `hook failed: "start"`,
+				data: map[string]interface{}{
+					"hook": "start",
+				},
+			},
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
 			waitUnit{status: params.StatusActive},


### PR DESCRIPTION
 We need to be able to run Actions in ModeHookError without taking the
 uniter out of ModeHookError state.  This modification changes how
 actionOperations are started so that the Commit phase of the operation
 puts the uniter state back into the appropriate state;
 operation.Continue for most cases, and operation.RunHook for
 ModeHookError.

(Review request: http://reviews.vapour.ws/r/951/)