### PR TITLE
state: basic functionality for writing logs to the DB

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -1,0 +1,93 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Low-level functionality for interacting with the logs collection.
+
+package state
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+const logsDB = "logs"
+const logsC = "logs"
+
+// InitDbLogs sets up the indexes for the logs collection. It should
+// be called as state is opened. It is idempotent.
+func InitDbLogs(session *mgo.Session) error {
+	logColl := session.DB(logsDB).C(logsC)
+	for _, key := range [][]string{{"e", "t"}, {"e", "n"}} {
+		err := logColl.EnsureIndex(mgo.Index{Key: key})
+		if err != nil {
+			return errors.Annotate(err, "cannot create index for logs collection")
+		}
+	}
+	return nil
+}
+
+// logDoc describes log messages stored in MongoDB.
+//
+// Single character field names are used for serialisation to save
+// space. These documents will be inserted 1000's of times and each
+// document includes the field names.
+type logDoc struct {
+	Id       bson.ObjectId `bson:"_id"`
+	Time     time.Time     `bson:"t"`
+	EnvUUID  string        `bson:"e"`
+	Entity   string        `bson:"n"` // e.g. "machine-0"
+	Module   string        `bson:"m"` // e.g. "juju.worker.firewaller"
+	Location string        `bson:"l"` // "filename:lineno"
+	Level    loggo.Level   `bson:"v"`
+	Message  string        `bson:"x"`
+}
+
+type dbLogger struct {
+	logColl *mgo.Collection
+	envUUID string
+	entity  string
+}
+
+// NewDbLogger returns a dbLogger instance which is used to write logs
+// to the database.
+func NewDbLogger(st *State, entity names.Tag) *dbLogger {
+	session := st.MongoSession().Copy()
+	// To improve throughput, only wait for the logs to be written to
+	// the primary. For some reason, this makes a huge difference even
+	// when the replicaset only has one member (i.e. a single primary).
+	session.SetSafe(&mgo.Safe{
+		W: 1,
+	})
+	db := session.DB(logsDB)
+	return &dbLogger{
+		logColl: db.C(logsC).With(session),
+		envUUID: st.EnvironUUID(),
+		entity:  entity.String(),
+	}
+}
+
+// Log writes a log message to the database.
+func (logger *dbLogger) Log(t time.Time, module string, location string, level loggo.Level, msg string) error {
+	return logger.logColl.Insert(&logDoc{
+		Id:       bson.NewObjectId(),
+		Time:     t,
+		EnvUUID:  logger.envUUID,
+		Entity:   logger.entity,
+		Module:   module,
+		Location: location,
+		Level:    level,
+		Message:  msg,
+	})
+}
+
+// Close cleans up resources used by the dbLogger instance.
+func (logger *dbLogger) Close() {
+	if logger.logColl != nil {
+		logger.logColl.Database.Session.Close()
+	}
+}

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -1,0 +1,77 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"strings"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/state"
+)
+
+type LogsSuite struct {
+	ConnSuite
+	logsColl *mgo.Collection
+}
+
+var _ = gc.Suite(&LogsSuite{})
+
+func (s *LogsSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+
+	session := s.State.MongoSession()
+	s.logsColl = session.DB("logs").C("logs")
+}
+
+func (s *LogsSuite) TestIndexesCreated(c *gc.C) {
+	// Indexes should be created on the logs collection when state is opened.
+	indexes, err := s.logsColl.Indexes()
+	c.Assert(err, jc.ErrorIsNil)
+	var keys []string
+	for _, index := range indexes {
+		keys = append(keys, strings.Join(index.Key, "-"))
+	}
+	c.Assert(keys, jc.SameContents, []string{
+		"_id", // default index
+		"e-t", // env-uuid and timestamp
+		"e-n", // env-uuid and entity
+	})
+}
+
+func (s *LogsSuite) TestDbLogger(c *gc.C) {
+	logger := state.NewDbLogger(s.State, names.NewMachineTag("22"))
+	defer logger.Close()
+	t0 := time.Now().Truncate(time.Millisecond) // MongoDB only stores timestamps with ms precision.
+	logger.Log(t0, "some.where", "foo.go:99", loggo.INFO, "all is well")
+	t1 := t0.Add(time.Second)
+	logger.Log(t1, "else.where", "bar.go:42", loggo.ERROR, "oh noes")
+
+	var docs []bson.M
+	err := s.logsColl.Find(nil).Sort("t").All(&docs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(docs, gc.HasLen, 2)
+
+	c.Assert(docs[0]["t"], gc.Equals, t0)
+	c.Assert(docs[0]["e"], gc.Equals, s.State.EnvironUUID())
+	c.Assert(docs[0]["n"], gc.Equals, "machine-22")
+	c.Assert(docs[0]["m"], gc.Equals, "some.where")
+	c.Assert(docs[0]["l"], gc.Equals, "foo.go:99")
+	c.Assert(docs[0]["v"], gc.Equals, int(loggo.INFO))
+	c.Assert(docs[0]["x"], gc.Equals, "all is well")
+
+	c.Assert(docs[1]["t"], gc.Equals, t1)
+	c.Assert(docs[1]["e"], gc.Equals, s.State.EnvironUUID())
+	c.Assert(docs[1]["n"], gc.Equals, "machine-22")
+	c.Assert(docs[1]["m"], gc.Equals, "else.where")
+	c.Assert(docs[1]["l"], gc.Equals, "bar.go:42")
+	c.Assert(docs[1]["v"], gc.Equals, int(loggo.ERROR))
+	c.Assert(docs[1]["x"], gc.Equals, "oh noes")
+}

--- a/state/open.go
+++ b/state/open.go
@@ -265,6 +265,10 @@ func newState(session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (
 		}
 	}
 
+	if err := InitDbLogs(session); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return st, nil
 }
 


### PR DESCRIPTION
A separate database is used for logs because this greatly improves write performance. Indexes are added for env UUID and entity fields because these will be used by the debug-log API.

(Review request: http://reviews.vapour.ws/r/953/)