### PR TITLE
Only have bootstrap-state use --debug if bootstrap uses --debug

### DIFF
--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -622,6 +623,34 @@ func (*cloudinitSuite) TestCloudInitConfigure(c *gc.C) {
 		err = udata.Configure()
 		c.Assert(err, jc.ErrorIsNil)
 	}
+}
+
+func (*cloudinitSuite) TestCloudInitConfigureBootstrapLogging(c *gc.C) {
+	loggo.GetLogger("").SetLogLevel(loggo.INFO)
+	machineConfig := minimalMachineConfig()
+	machineConfig.Config = minimalConfig(c)
+
+	cloudcfg := coreCloudinit.New()
+	udata, err := cloudinit.NewUserdataConfig(&machineConfig, cloudcfg)
+
+	c.Assert(err, jc.ErrorIsNil)
+	err = udata.Configure()
+	c.Assert(err, jc.ErrorIsNil)
+	data, err := udata.Render()
+	c.Assert(err, jc.ErrorIsNil)
+	configKeyValues := make(map[interface{}]interface{})
+	err = goyaml.Unmarshal(data, &configKeyValues)
+	c.Assert(err, jc.ErrorIsNil)
+
+	scripts := getScripts(configKeyValues)
+	for i, script := range scripts {
+		if strings.Contains(script, "bootstrap") {
+			c.Logf("scripts[%d]: %q", i, script)
+		}
+	}
+	expected := "jujud bootstrap-state --data-dir '.*' --env-config '.*'" +
+		" --instance-id '.*' --constraints 'mem=2048M' --show-log"
+	assertScriptMatch(c, scripts, expected, false)
 }
 
 func (*cloudinitSuite) TestCloudInitConfigureUsesGivenConfig(c *gc.C) {

--- a/environs/cloudinit/cloudinit_ubuntu.go
+++ b/environs/cloudinit/cloudinit_ubuntu.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/proxy"
 
@@ -270,6 +271,12 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 			}
 		}
 		w.conf.AddRunCmd(cloudinit.LogProgressCmd("Bootstrapping Juju machine agent"))
+		loggingOption := " --show-log"
+		// If the bootstrap command was requsted with --debug, then the root
+		// logger will be set to DEBUG.  If it is, then we use --debug here too.
+		if loggo.GetLogger("").LogLevel() == loggo.DEBUG {
+			loggingOption = " --debug"
+		}
 		w.conf.AddScripts(
 			// The bootstrapping is always run with debug on.
 			w.mcfg.jujuTools() + "/jujud bootstrap-state" +
@@ -279,7 +286,7 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 				hardware +
 				cons +
 				metadataDir +
-				" --debug",
+				loggingOption,
 		)
 	}
 


### PR DESCRIPTION
Forward port fix from 1.22.

(Review request: http://reviews.vapour.ws/r/954/)