### PR TITLE
Add support for file system storage sources, and rootfs provider

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,7 +15,7 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	995b906ce18b2726e9d284efbfa79bd7070ec8c8	2015-02-19T20:49:45Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
-github.com/juju/names	git	6237024e4938fc3946d46d9e65039c959d260499	2015-02-20T04:54:01Z
+github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07:57:36Z
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T10:00:34Z

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -94,8 +94,10 @@ func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 			Tag:      volume0,
 			Size:     1234,
 			Provider: ec2.EBS_ProviderType,
-			Attachment: &storage.AttachmentParams{
-				Machine: machine0,
+			Attachment: &storage.VolumeAttachmentParams{
+				AttachmentParams: storage.AttachmentParams{
+					Machine: machine0,
+				},
 			},
 		}, {
 			Tag:      volume1,
@@ -105,8 +107,10 @@ func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 				"volume-type": "io1",
 				"iops":        "1234",
 			},
-			Attachment: &storage.AttachmentParams{
-				Machine: machine0,
+			Attachment: &storage.VolumeAttachmentParams{
+				AttachmentParams: storage.AttachmentParams{
+					Machine: machine0,
+				},
 			},
 		}}},
 	)
@@ -163,8 +167,10 @@ func (*DisksSuite) TestGetBlockDeviceMappingErrors(c *gc.C) {
 			params: storage.VolumeParams{
 				Size:     100000000,
 				Provider: ec2.EBS_ProviderType,
-				Attachment: &storage.AttachmentParams{
-					Machine: machine0,
+				Attachment: &storage.VolumeAttachmentParams{
+					AttachmentParams: storage.AttachmentParams{
+						Machine: machine0,
+					},
 				},
 			},
 			err: "invalid volume parameters: 97657 GiB exceeds the maximum of 1024 GiB",
@@ -178,8 +184,10 @@ func (*DisksSuite) TestGetBlockDeviceMappingErrors(c *gc.C) {
 					"volume-type": "io1",
 					"iops":        "1234",
 				},
-				Attachment: &storage.AttachmentParams{
-					Machine: machine0,
+				Attachment: &storage.VolumeAttachmentParams{
+					AttachmentParams: storage.AttachmentParams{
+						Machine: machine0,
+					},
 				},
 			},
 			err: "invalid volume parameters: volume size is 1 GiB, must be at least 10 GiB for provisioned IOPS",
@@ -193,8 +201,10 @@ func (*DisksSuite) TestGetBlockDeviceMappingErrors(c *gc.C) {
 					"volume-type": "io1",
 					"iops":        "1234",
 				},
-				Attachment: &storage.AttachmentParams{
-					Machine: machine0,
+				Attachment: &storage.VolumeAttachmentParams{
+					AttachmentParams: storage.AttachmentParams{
+						Machine: machine0,
+					},
 				},
 			},
 			err: "invalid volume parameters: volume size is 10 GiB, must be at least 41 GiB to support 1234 IOPS",
@@ -208,8 +218,10 @@ func (*DisksSuite) TestGetBlockDeviceMappingErrors(c *gc.C) {
 					"volume-type": "standard",
 					"iops":        "1234",
 				},
-				Attachment: &storage.AttachmentParams{
-					Machine: machine0,
+				Attachment: &storage.VolumeAttachmentParams{
+					AttachmentParams: storage.AttachmentParams{
+						Machine: machine0,
+					},
 				},
 			},
 			err: `invalid volume parameters: IOPS specified, but volume type is "standard"`,

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -85,6 +85,11 @@ func (e *ebsProvider) VolumeSource(environConfig *config.Config, providerConfig 
 	panic("not implemented")
 }
 
+// FilesystemSource is defined on the Provider interface.
+func (e *ebsProvider) FilesystemSource(environConfig *config.Config, providerConfig *storage.Config) (storage.FilesystemSource, error) {
+	return nil, errors.NotSupportedf("filesystems")
+}
+
 type ebsVolumeSoucre struct {
 }
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -913,10 +913,11 @@ func (t *localServerSuite) TestStartInstanceVolumes(c *gc.C) {
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	attachmentParams := &storage.AttachmentParams{
-		Machine: names.NewMachineTag("0"),
+	attachmentParams := &storage.VolumeAttachmentParams{
+		AttachmentParams: storage.AttachmentParams{
+			Machine: names.NewMachineTag("0"),
+		},
 	}
-
 	params := environs.StartInstanceParams{
 		Volumes: []storage.VolumeParams{{
 			Size:       512, // round up to 1GiB

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -1,0 +1,32 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import "github.com/juju/names"
+
+// Filesystem describes a filesystem, either
+// local or remote (NFS, Ceph etc).
+type Filesystem struct {
+	// Tag is a unique name assigned by Juju to the filesystem.
+	Tag names.FilesystemTag
+
+	// Size is the size of the filesystem, in MiB.
+	Size uint64
+}
+
+// FilesystemAttachment describes machine-specific volume attachment information,
+// including how the volume is exposed on the machine.
+type FilesystemAttachment struct {
+	// Filesystem is the unique tag assigned by Juju for the filesystem
+	// that this attachment corresponds to.
+	Filesystem names.FilesystemTag
+
+	// Machine is the unique tag assigned by Juju for the machine that
+	// this attachment corresponds to.
+	Machine names.MachineTag
+
+	// Location is the path at which the filesystem is mounted on the machine that
+	// this attachment corresponds to.
+	Location string
+}

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -15,8 +15,8 @@ type Filesystem struct {
 	Size uint64
 }
 
-// FilesystemAttachment describes machine-specific volume attachment information,
-// including how the volume is exposed on the machine.
+// FilesystemAttachment describes machine-specific filesystem attachment information,
+// including how the filesystem is exposed on the machine.
 type FilesystemAttachment struct {
 	// Filesystem is the unique tag assigned by Juju for the filesystem
 	// that this attachment corresponds to.
@@ -26,7 +26,7 @@ type FilesystemAttachment struct {
 	// this attachment corresponds to.
 	Machine names.MachineTag
 
-	// Location is the path at which the filesystem is mounted on the machine that
+	// Path is the path at which the filesystem is mounted on the machine that
 	// this attachment corresponds to.
-	Location string
+	Path string
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -187,7 +187,7 @@ type FilesystemAttachmentParams struct {
 	// should be attached/detached.
 	Filesystem names.FilesystemTag
 
-	// Path is the path at which the filesystem is mounted on the machine that
+	// Path is the path at which the filesystem is to be mounted on the machine that
 	// this attachment corresponds to.
 	Path string
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -123,7 +123,7 @@ type VolumeParams struct {
 	// presented with parameters for any due-to-be-attached volumes. If
 	// once the instance is created there are still unprovisioned volumes,
 	// the dynamic storage provisioner will take care of creating them.
-	Attachment *AttachmentParams
+	Attachment *VolumeAttachmentParams
 }
 
 // VolumeAttachmentParams is a set of parameters for volume attachment or
@@ -160,7 +160,7 @@ type AttachmentParams struct {
 // derived from one or more of user-specified storage constraints, a
 // storage pool definition, and charm storage metadata.
 type FilesystemParams struct {
-	// Tag is a unique name assigned by Juju for the requested filesystem.
+	// Tag is a unique tag assigned by Juju for the requested filesystem.
 	Tag names.FilesystemTag
 
 	// Size is the minimum size of the filesystem in MiB.
@@ -173,18 +173,13 @@ type FilesystemParams struct {
 	// The provider type for this filesystem.
 	Provider ProviderType
 
-	// The location at which the filesystem is mounted on the machine that
-	// this attachment corresponds to.
-	Location string
-
 	// Attachment identifies the machine that the filesystem should be
 	// mounted on.
-	Attachment *AttachmentParams
+	Attachment *FilesystemAttachmentParams
 }
 
 // FilesystemAttachmentParams is a set of parameters for filesystem attachment or
 // detachment.
-// TODO(wallworld) - not used yet; required when support for attaching filesystems is added.
 type FilesystemAttachmentParams struct {
 	AttachmentParams
 
@@ -192,7 +187,7 @@ type FilesystemAttachmentParams struct {
 	// should be attached/detached.
 	Filesystem names.FilesystemTag
 
-	// Location is the path at which the filesystem is mounted on the machine that
+	// Path is the path at which the filesystem is mounted on the machine that
 	// this attachment corresponds to.
-	Location string
+	Path string
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -23,10 +23,13 @@ type Provider interface {
 	// satisfying errors.IsNotSupported.
 	VolumeSource(environConfig *config.Config, providerConfig *Config) (VolumeSource, error)
 
-	// TODO(axw) define filesystem source. If the user requests a
-	// filesystem and that can be provided first-class, it should be
-	// done that way. Otherwise we create a volume and then manage a
-	// filesystem on that.
+	// FilesystemSource returns a FilesystemSource given the
+	// specified cloud and storage provider configurations.
+	//
+	// If the storage provider does not support creating filesystems
+	// as a first-class primitive, then FilesystemSource must return
+	// an error satisfying errors.IsNotSupported.
+	FilesystemSource(environConfig *config.Config, providerConfig *Config) (FilesystemSource, error)
 
 	// ValidateConfig validates the provided storage provider config,
 	// returning an error if it is invalid.
@@ -74,6 +77,22 @@ type VolumeSource interface {
 	// are detachable, and reject attempts to attach/detach on
 	// that basis.
 	DetachVolumes(params []VolumeAttachmentParams) error
+}
+
+// FilesystemSource provides an interface for creating, destroying and
+// describing filesystems in the environment. A FilesystemSource is
+// configured in a particular way, and corresponds to a storage "pool".
+type FilesystemSource interface {
+	// ValidateFilesystemParams validates the provided filesystem creation
+	// parameters, returning an error if they are invalid.
+	ValidateFilesystemParams(params FilesystemParams) error
+
+	// CreateFilesystems creates filesystems with the specified size, in MiB.
+	// If the filesystems are initially attached, then CreateFilesystems returns
+	// information about those attachments too.
+	CreateFilesystems(params []FilesystemParams) ([]Filesystem, []FilesystemAttachment, error)
+
+	// TODO(wallyworld) add support for attaching/detaching filesystems
 }
 
 // VolumeParams is a fully specified set of parameters for volume creation,
@@ -135,4 +154,45 @@ type AttachmentParams struct {
 	// that interact with the instances, such as EBS/EC2. The InstanceId
 	// field will be empty if the instance is not yet provisioned.
 	InstanceId instance.Id
+}
+
+// FilesystemParams is a fully specified set of parameters for filesystem creation,
+// derived from one or more of user-specified storage constraints, a
+// storage pool definition, and charm storage metadata.
+type FilesystemParams struct {
+	// Tag is a unique name assigned by Juju for the requested filesystem.
+	Tag names.FilesystemTag
+
+	// Size is the minimum size of the filesystem in MiB.
+	Size uint64
+
+	// Attributes is a set of provider-specific options for storage creation,
+	// as defined in a storage pool.
+	Attributes map[string]interface{}
+
+	// The provider type for this filesystem.
+	Provider ProviderType
+
+	// The location at which the filesystem is mounted on the machine that
+	// this attachment corresponds to.
+	Location string
+
+	// Attachment identifies the machine that the filesystem should be
+	// mounted on.
+	Attachment *AttachmentParams
+}
+
+// FilesystemAttachmentParams is a set of parameters for filesystem attachment or
+// detachment.
+// TODO(wallworld) - not used yet; required when support for attaching filesystems is added.
+type FilesystemAttachmentParams struct {
+	AttachmentParams
+
+	// Filesystem is a unique tag assigned by Juju for the filesystem that
+	// should be attached/detached.
+	Filesystem names.FilesystemTag
+
+	// Location is the path at which the filesystem is mounted on the machine that
+	// this attachment corresponds to.
+	Location string
 }

--- a/storage/provider/common.go
+++ b/storage/provider/common.go
@@ -8,6 +8,7 @@ import "github.com/juju/juju/storage"
 // CommonProviders returns the storage providers used by all environments.
 func CommonProviders() map[storage.ProviderType]storage.Provider {
 	return map[storage.ProviderType]storage.Provider{
-		LoopProviderType: &loopProvider{logAndExec},
+		LoopProviderType:   &loopProvider{logAndExec},
+		RootfsProviderType: &rootfsProvider{logAndExec},
 	}
 }

--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -24,5 +24,6 @@ func (s *providerCommonSuite) TestCommonProvidersExported(c *gc.C) {
 	}
 	c.Assert(common, jc.SameContents, []storage.ProviderType{
 		provider.LoopProviderType,
+		provider.RootfsProviderType,
 	})
 }

--- a/storage/provider/export_test.go
+++ b/storage/provider/export_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"os"
+	"time"
 
 	"github.com/juju/utils/set"
 
@@ -31,11 +32,45 @@ func (m *mockDirFuncs) mkDirAll(path string, perm os.FileMode) error {
 	return nil
 }
 
-func (m *mockDirFuncs) lstat(name string) (fi os.FileInfo, err error) {
-	if m.dirs.Contains(name) {
-		return nil, nil
+type mockFileInfo struct {
+	isDir bool
+}
+
+func (m *mockFileInfo) IsDir() bool {
+	return m.isDir
+}
+
+func (m *mockFileInfo) Name() string {
+	return ""
+}
+
+func (m *mockFileInfo) Size() int64 {
+	return 0
+}
+
+func (m *mockFileInfo) Mode() os.FileMode {
+	return 0
+}
+
+func (m *mockFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+func (m *mockFileInfo) Sys() interface{} {
+	return nil
+}
+
+func (m *mockDirFuncs) lstat(name string) (os.FileInfo, error) {
+	if name == "file" || m.dirs.Contains(name) {
+		return &mockFileInfo{name != "file"}, nil
 	}
 	return nil, os.ErrNotExist
+}
+
+func (m *mockDirFuncs) fileCount(name string) (int, error) {
+	if name == "/mnt/notempty" {
+		return 2, nil
+	}
+	return 0, nil
 }
 
 func RootfsFilesystemSource(storageDir string, run func(string, ...string) (string, error)) storage.FilesystemSource {

--- a/storage/provider/export_test.go
+++ b/storage/provider/export_test.go
@@ -3,7 +3,13 @@
 
 package provider
 
-import "github.com/juju/juju/storage"
+import (
+	"os"
+
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/storage"
+)
 
 func LoopVolumeSource(storageDir string, run func(string, ...string) (string, error)) storage.VolumeSource {
 	return &loopVolumeSource{run, storageDir}
@@ -11,4 +17,41 @@ func LoopVolumeSource(storageDir string, run func(string, ...string) (string, er
 
 func LoopProvider(run func(string, ...string) (string, error)) storage.Provider {
 	return &loopProvider{run}
+}
+
+var _ dirFuncs = (*mockDirFuncs)(nil)
+
+// mockDirFuncs stub out the real mkdir and lstat functions from stdlib.
+type mockDirFuncs struct {
+	dirs set.Strings
+}
+
+func (m *mockDirFuncs) mkDirAll(path string, perm os.FileMode) error {
+	m.dirs.Add(path)
+	return nil
+}
+
+func (m *mockDirFuncs) lstat(name string) (fi os.FileInfo, err error) {
+	if m.dirs.Contains(name) {
+		return nil, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func RootfsFilesystemSource(storageDir string, run func(string, ...string) (string, error)) storage.FilesystemSource {
+	return &rootfsFilesystemSource{
+		&mockDirFuncs{set.NewStrings()},
+		run,
+		storageDir,
+	}
+}
+
+// MountedDirs returns all the dirs which have been created during any CreateFilesystem calls
+// on the specified filesystem source..
+func MountedDirs(fsSource storage.FilesystemSource) set.Strings {
+	return fsSource.(*rootfsFilesystemSource).dirFuncs.(*mockDirFuncs).dirs
+}
+
+func RootfsProvider(run func(string, ...string) (string, error)) storage.Provider {
+	return &rootfsProvider{run}
 }

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -24,6 +24,7 @@ const (
 
 // loopProviders create volume sources which use loop devices.
 type loopProvider struct {
+	// run is a function type used for running commands on the local machine.
 	run runCommandFunc
 }
 
@@ -63,6 +64,14 @@ func (lp *loopProvider) VolumeSource(
 		return nil, errors.Annotate(err, "creating storage directory")
 	}
 	return &loopVolumeSource{lp.run, storageDir}, nil
+}
+
+// FilesystemSource is defined on the Provider interface.
+func (lp *loopProvider) FilesystemSource(
+	environConfig *config.Config,
+	providerConfig *storage.Config,
+) (storage.FilesystemSource, error) {
+	return nil, errors.NotSupportedf("filesystems")
 }
 
 // loopVolumeSource provides common functionality to handle

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -83,9 +83,11 @@ func (s *loopSuite) TestCreateVolumes(c *gc.C) {
 	volumes, volumeAttachments, err := source.CreateVolumes([]storage.VolumeParams{{
 		Tag:  names.NewVolumeTag("0"),
 		Size: 2,
-		Attachment: &storage.AttachmentParams{
-			Machine:    names.NewMachineTag("1"),
-			InstanceId: "instance-id",
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				Machine:    names.NewMachineTag("1"),
+				InstanceId: "instance-id",
+			},
 		},
 	}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -103,7 +105,7 @@ func (s *loopSuite) TestCreateVolumes(c *gc.C) {
 	})
 }
 
-func (s *loopSuite) xestCreateVolumesNoAttachment(c *gc.C) {
+func (s *loopSuite) TestCreateVolumesNoAttachment(c *gc.C) {
 	source := s.loopVolumeSource(c)
 	_, _, err := source.CreateVolumes([]storage.VolumeParams{{
 		Tag:  names.NewVolumeTag("0"),

--- a/storage/provider/package_test.go
+++ b/storage/provider/package_test.go
@@ -25,9 +25,9 @@ type mockCommand struct {
 	err    error
 }
 
-func (c *mockCommand) respond(result string, err error) {
-	c.result = result
-	c.err = err
+func (m *mockCommand) respond(result string, err error) {
+	m.result = result
+	m.err = err
 }
 
 func (m *mockRunCommand) expect(cmd string, args ...string) *mockCommand {

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -1,0 +1,175 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	RootfsProviderType = storage.ProviderType("rootfs")
+)
+
+// rootfsProviders create storage sources which provide access to filesystems.
+type rootfsProvider struct {
+	// run is a function type used for running commands on the local machine.
+	run runCommandFunc
+}
+
+var (
+	_ storage.Provider = (*rootfsProvider)(nil)
+)
+
+// ValidateConfig is defined on the Provider interface.
+func (p *rootfsProvider) ValidateConfig(cfg *storage.Config) error {
+	// Rootfs provider has no configuration.
+	return nil
+}
+
+// validateFullConfig validates a fully-constructed storage config,
+// combining the user-specified config and any internally specified
+// config.
+func (p *rootfsProvider) validateFullConfig(cfg *storage.Config) error {
+	if err := p.ValidateConfig(cfg); err != nil {
+		return err
+	}
+	storageDir, ok := cfg.ValueString(storage.ConfigStorageDir)
+	if !ok || storageDir == "" {
+		return errors.New("storage directory not specified")
+	}
+	return nil
+}
+
+// VolumeSource is defined on the Provider interface.
+func (p *rootfsProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
+	return nil, errors.NotSupportedf("volumes")
+}
+
+// FilesystemSource is defined on the Provider interface.
+func (p *rootfsProvider) FilesystemSource(environConfig *config.Config, sourceConfig *storage.Config) (storage.FilesystemSource, error) {
+	if err := p.validateFullConfig(sourceConfig); err != nil {
+		return nil, err
+	}
+	// storageDir is validated by validateFullConfig.
+	storageDir, _ := sourceConfig.ValueString(storage.ConfigStorageDir)
+
+	return &rootfsFilesystemSource{
+		&osDirFuncs{},
+		p.run,
+		storageDir,
+	}, nil
+}
+
+type rootfsFilesystemSource struct {
+	dirFuncs   dirFuncs
+	run        runCommandFunc
+	storageDir string
+}
+
+// dirFuncs is used to allow the real directory operations to
+// be stubbed out for testing.
+type dirFuncs interface {
+	mkDirAll(path string, perm os.FileMode) error
+	lstat(name string) (fi os.FileInfo, err error)
+}
+
+// The real directory related functions.
+type osDirFuncs struct{}
+
+func (*osDirFuncs) mkDirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (*osDirFuncs) lstat(name string) (fi os.FileInfo, err error) {
+	return os.Lstat(name)
+}
+
+var _ storage.FilesystemSource = (*rootfsFilesystemSource)(nil)
+
+// ValidateFilesystemParams is defined on the FilesystemSource interface.
+func (s *rootfsFilesystemSource) ValidateFilesystemParams(params storage.FilesystemParams) error {
+	// ValidateFilesystemParams may be called on a machine other than the
+	// machine where the filesystem will be mounted, so we cannot check
+	// available size until we get to CreateFilesystem.
+	if params.Attachment == nil {
+		return errors.NotSupportedf(
+			"creating filesystem without machine attachment",
+		)
+	}
+	return nil
+}
+
+// CreateFilesystems is defined on the FilesystemSource interface.
+func (s *rootfsFilesystemSource) CreateFilesystems(args []storage.FilesystemParams,
+) ([]storage.Filesystem, []storage.FilesystemAttachment, error) {
+	filesystems := make([]storage.Filesystem, 0, len(args))
+	filesystemAttachments := make([]storage.FilesystemAttachment, 0, len(args))
+	for _, arg := range args {
+		filesystem, filesystemAttachment, err := s.createFilesystem(arg)
+		if err != nil {
+			return nil, nil, errors.Annotate(err, "creating filesystem")
+		}
+		// If the filesystem exists, no need to record that we created it.
+		if filesystem != nil {
+			filesystems = append(filesystems, *filesystem)
+		}
+		filesystemAttachments = append(filesystemAttachments, filesystemAttachment)
+	}
+	return filesystems, filesystemAttachments, nil
+
+}
+
+func (s *rootfsFilesystemSource) createFilesystem(params storage.FilesystemParams) (*storage.Filesystem, storage.FilesystemAttachment, error) {
+	var filesystem *storage.Filesystem
+	var filesystemAttachment storage.FilesystemAttachment
+	if err := s.ValidateFilesystemParams(params); err != nil {
+		return filesystem, filesystemAttachment, errors.Trace(err)
+	}
+	location := params.Location
+	if location == "" {
+		location = filepath.Join(s.storageDir, params.Tag.Id())
+	}
+	filesystemAttachment = storage.FilesystemAttachment{
+		Filesystem: params.Tag,
+		Machine:    params.Attachment.Machine,
+		Location:   location,
+	}
+	if _, err := s.dirFuncs.lstat(location); !os.IsNotExist(err) {
+		// Filesystem already exists so no need to create it again.
+		return filesystem, filesystemAttachment, nil
+	}
+	if err := s.dirFuncs.mkDirAll(location, 0755); err != nil {
+		return filesystem, filesystemAttachment, errors.Annotate(err, "could not create directory")
+	}
+	dfOutput, err := s.run("df", "--output=size", location)
+	if err != nil {
+		os.Remove(location)
+		return filesystem, filesystemAttachment, errors.Annotate(err, "getting size")
+	}
+	lines := strings.SplitN(dfOutput, "\n", 2)
+	blocks, err := strconv.ParseUint(strings.TrimSpace(lines[1]), 10, 64)
+	if err != nil {
+		os.Remove(location)
+		return filesystem, filesystemAttachment, errors.Annotate(err, "getting size")
+	}
+	sizeInMiB := blocks / 1024
+	if sizeInMiB < params.Size {
+		os.Remove(location)
+		return filesystem, filesystemAttachment, errors.Errorf("filesystem is not big enough (%dM < %dM)", sizeInMiB, params.Size)
+	}
+
+	filesystem = &storage.Filesystem{
+		Tag:  params.Tag,
+		Size: sizeInMiB,
+	}
+	return filesystem, filesystemAttachment, nil
+}

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -1,0 +1,197 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"path/filepath"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&rootfsSuite{})
+
+type rootfsSuite struct {
+	testing.BaseSuite
+	storageDir string
+	commands   *mockRunCommand
+}
+
+func (s *rootfsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.storageDir = c.MkDir()
+}
+
+func (s *rootfsSuite) TearDownTest(c *gc.C) {
+	s.commands.assertDrained()
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *rootfsSuite) rootfsProvider(c *gc.C) storage.Provider {
+	s.commands = &mockRunCommand{c: c}
+	return provider.RootfsProvider(s.commands.run)
+}
+
+func (s *rootfsSuite) TestFilesystemSource(c *gc.C) {
+	p := s.rootfsProvider(c)
+	cfg, err := storage.NewConfig("name", provider.RootfsProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = p.FilesystemSource(nil, cfg)
+	c.Assert(err, gc.ErrorMatches, "storage directory not specified")
+	cfg, err = storage.NewConfig("name", provider.RootfsProviderType, map[string]interface{}{
+		"storage-dir": c.MkDir(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = p.FilesystemSource(nil, cfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *rootfsSuite) TestValidateConfig(c *gc.C) {
+	p := s.rootfsProvider(c)
+	cfg, err := storage.NewConfig("name", provider.RootfsProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.ValidateConfig(cfg)
+	// The rootfs provider does not have any user
+	// configuration, so an empty map will pass.
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *rootfsSuite) rootfsFilesystemSource(c *gc.C) storage.FilesystemSource {
+	s.commands = &mockRunCommand{c: c}
+	return provider.RootfsFilesystemSource(
+		s.storageDir,
+		s.commands.run,
+	)
+}
+
+func (s *rootfsSuite) TestCreateFilesystemsNoLocationSpecified(c *gc.C) {
+	source := s.rootfsFilesystemSource(c)
+	cmd := s.commands.expect("df", "--output=size", filepath.Join(s.storageDir, "foo"))
+	cmd.respond("1K-blocks\n2048", nil)
+
+	filesystems, filesystemAttachments, err := source.CreateFilesystems([]storage.FilesystemParams{{
+		Tag:  names.NewFilesystemTag("foo"),
+		Size: 2,
+		Attachment: &storage.AttachmentParams{
+			Machine:    names.NewMachineTag("1"),
+			InstanceId: "instance-id",
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	mountedDirs := provider.MountedDirs(source)
+	c.Assert(mountedDirs.Size(), gc.Equals, 1)
+	c.Assert(mountedDirs.Contains(filepath.Join(s.storageDir, "foo")), jc.IsTrue)
+	c.Assert(filesystems, gc.HasLen, 1)
+	c.Assert(filesystemAttachments, gc.HasLen, 1)
+	c.Assert(filesystems[0], gc.Equals, storage.Filesystem{
+		Tag:  names.NewFilesystemTag("foo"),
+		Size: 2,
+	})
+	c.Assert(filesystemAttachments[0], gc.Equals, storage.FilesystemAttachment{
+		Location:   filepath.Join(s.storageDir, "foo"),
+		Filesystem: names.NewFilesystemTag("foo"),
+		Machine:    names.NewMachineTag("1"),
+	})
+}
+
+func (s *rootfsSuite) TestCreateFilesystemsWithLocationSpecified(c *gc.C) {
+	source := s.rootfsFilesystemSource(c)
+	cmd := s.commands.expect("df", "--output=size", "/mnt/bar")
+	cmd.respond("1K-blocks\n2048", nil)
+
+	filesystems, filesystemAttachments, err := source.CreateFilesystems([]storage.FilesystemParams{{
+		Tag:      names.NewFilesystemTag("foo"),
+		Size:     2,
+		Location: "/mnt/bar",
+		Attachment: &storage.AttachmentParams{
+			Machine:    names.NewMachineTag("1"),
+			InstanceId: "instance-id",
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	mountedDirs := provider.MountedDirs(source)
+	c.Assert(mountedDirs.Size(), gc.Equals, 1)
+	c.Assert(mountedDirs.Contains("/mnt/bar"), jc.IsTrue)
+	c.Assert(filesystems, gc.HasLen, 1)
+	c.Assert(filesystemAttachments, gc.HasLen, 1)
+	c.Assert(filesystems[0], gc.Equals, storage.Filesystem{
+		Tag:  names.NewFilesystemTag("foo"),
+		Size: 2,
+	})
+	c.Assert(filesystemAttachments[0], gc.Equals, storage.FilesystemAttachment{
+		Location:   "/mnt/bar",
+		Filesystem: names.NewFilesystemTag("foo"),
+		Machine:    names.NewMachineTag("1"),
+	})
+}
+
+func (s *rootfsSuite) TestCreateFilesystemsAlreadyMounted(c *gc.C) {
+	source := s.rootfsFilesystemSource(c)
+	cmd := s.commands.expect("df", "--output=size", filepath.Join(s.storageDir, "foo"))
+	cmd.respond("1K-blocks\n2048", nil)
+
+	filesystems, filesystemAttachments, err := source.CreateFilesystems([]storage.FilesystemParams{
+		{
+			Tag:  names.NewFilesystemTag("foo"),
+			Size: 1,
+			Attachment: &storage.AttachmentParams{
+				Machine:    names.NewMachineTag("1"),
+				InstanceId: "instance-id1",
+			},
+		}, {
+			Tag:  names.NewFilesystemTag("foo"),
+			Size: 1,
+			Attachment: &storage.AttachmentParams{
+				Machine:    names.NewMachineTag("2"),
+				InstanceId: "instance-id2",
+			},
+		}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystems, gc.HasLen, 1)
+	c.Assert(filesystems[0], gc.Equals, storage.Filesystem{
+		Tag:  names.NewFilesystemTag("foo"),
+		Size: 2,
+	})
+	c.Assert(filesystemAttachments, jc.SameContents, []storage.FilesystemAttachment{
+		{
+			Location:   filepath.Join(s.storageDir, "foo"),
+			Filesystem: names.NewFilesystemTag("foo"),
+			Machine:    names.NewMachineTag("1"),
+		}, {
+			Location:   filepath.Join(s.storageDir, "foo"),
+			Filesystem: names.NewFilesystemTag("foo"),
+			Machine:    names.NewMachineTag("2"),
+		},
+	})
+}
+
+func (s *rootfsSuite) TestCreateFilesystemsNotEnoughSpace(c *gc.C) {
+	source := s.rootfsFilesystemSource(c)
+	cmd := s.commands.expect("df", "--output=size", filepath.Join(s.storageDir, "foo"))
+	cmd.respond("1K-blocks\n2048", nil)
+
+	_, _, err := source.CreateFilesystems([]storage.FilesystemParams{{
+		Tag:  names.NewFilesystemTag("foo"),
+		Size: 4,
+		Attachment: &storage.AttachmentParams{
+			Machine:    names.NewMachineTag("1"),
+			InstanceId: "instance-id",
+		},
+	}})
+	c.Assert(err, gc.ErrorMatches, ".* filesystem is not big enough \\(2M < 4M\\)")
+}
+
+func (s *rootfsSuite) TestCreateFilesystemsNoAttachment(c *gc.C) {
+	source := s.rootfsFilesystemSource(c)
+	_, _, err := source.CreateFilesystems([]storage.FilesystemParams{{
+		Tag:  names.NewFilesystemTag("foo"),
+		Size: 2,
+	}})
+	c.Assert(err, gc.ErrorMatches, ".* creating filesystem without machine attachment not supported")
+}

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -32,7 +32,7 @@ type VolumeAttachment struct {
 	// that this attachment corresponds to.
 	Volume names.VolumeTag
 
-	// MachineId is the unique tag assigned by Juju for the machine that
+	// Machine is the unique tag assigned by Juju for the machine that
 	// this attachment corresponds to.
 	Machine names.MachineTag
 

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -500,7 +500,7 @@ func constructStartInstanceParams(
 			v.Size,
 			storage.ProviderType(v.Provider),
 			v.Attributes,
-			&storage.AttachmentParams{machineTag, ""},
+			&storage.VolumeAttachmentParams{AttachmentParams: storage.AttachmentParams{machineTag, ""}},
 		}
 	}
 

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -500,7 +500,12 @@ func constructStartInstanceParams(
 			v.Size,
 			storage.ProviderType(v.Provider),
 			v.Attributes,
-			&storage.VolumeAttachmentParams{AttachmentParams: storage.AttachmentParams{machineTag, ""}},
+			&storage.VolumeAttachmentParams{
+				AttachmentParams: storage.AttachmentParams{
+					Machine: machineTag,
+				},
+				Volume: volumeTag,
+			},
 		}
 	}
 


### PR DESCRIPTION
Requires https://github.com/juju/names/pull/41

Add a rootfs storage provider (ported from storage feature branch with changes to accommodate new data model). When writing the tests, it was discovered that the current loop provider tests were broken. These were fixed as well. The issue is that a different gc.C is used in each and every test and is different from that used during test and suite set up. So the mockCommand struct needed to have the gc.C set in each test.

(Review request: http://reviews.vapour.ws/r/956/)