### PR TITLE
Add action params InsertDefaults call to AddAction

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -13,7 +13,7 @@ github.com/juju/cmd	git	cda28f523779603ba0cb7808e1b84c9dd076d37b	2015-02-10T12:0
 github.com/juju/errors	git	9cc96a010cd2b0d9df6dcb034e56f7581a787e86	2015-02-10T03:35:25Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
-github.com/juju/gojsonschema	git	b3824dadac133b3158aacdef4954069bb2b9b2a3	2015-02-04T19:46:39Z
+github.com/juju/gojsonschema	git	995b906ce18b2726e9d284efbfa79bd7070ec8c8	2015-02-19T20:49:45Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
 github.com/juju/names	git	016a15ed41d730ea92e308f5c697294a39187c76	2015-01-20T11:23:30Z
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
@@ -25,7 +25,7 @@ github.com/juju/utils	git	3efdaa3f15cc47ee83f6c03f640dc14f5915e289	2015-02-05T10
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
 gopkg.in/amz.v2	git	852014c69ce6838f8709317b7e435d537d3c51de	2015-01-20T08:32:32Z
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	2014-08-27T13:58:41Z
-gopkg.in/juju/charm.v4	git	9a8fafb6c82e105313e94158985adc65ce89cce9	2015-02-04T19:47:14Z
+gopkg.in/juju/charm.v4	git	83a8d0dcae192db1157ae334c654cdea83f3b8e9	2015-02-19T20:51:22Z
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	2014-07-30T20:00:37Z
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	2014-07-25T20:51:33Z
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08-11T16:19:00Z

--- a/state/unit.go
+++ b/state/unit.go
@@ -1720,7 +1720,12 @@ func (u *Unit) AddAction(name string, payload map[string]interface{}) (*Action, 
 	if !ok {
 		return nil, errors.Errorf("action %q not defined on unit %q", name, u.Name())
 	}
+	// Reject bad payloads before attempting to insert defaults.
 	err = spec.ValidateParams(payload)
+	if err != nil {
+		return nil, err
+	}
+	err = spec.InsertDefaults(payload)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
state/unit.AddAction now inserts default values after the params have
been validated against the schema; this order was chosen to avoid
attempting to insert default values in an incorrectly constructed params
map.

Note that much more rigorous testing is done in the packages adding
this functionality.  This simply exercises the expected behaviors.

(Review request: http://reviews.vapour.ws/r/957/)