### PR TITLE
Ensure cloud-image-utils is installed

### DIFF
--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -214,6 +214,7 @@ func AddAptCommands(
 		// leave it to the networker worker.
 		c.AddPackage("bridge-utils")
 		c.AddPackage("rsyslog-gnutls")
+		c.AddPackage("cloud-image-utils")
 	}
 
 	// Write out the apt proxy settings


### PR DESCRIPTION
Without cloud-image-utils, we can't start lxc containers since lxc image caching breaks.

(Review request: http://reviews.vapour.ws/r/958/)