### PR TITLE
Change liveSource to always cleanup cleanly

### DIFF
--- a/testing/channel.go
+++ b/testing/channel.go
@@ -94,7 +94,6 @@ func (a *ContentAsserterC) recv(timeout time.Duration) (val interface{}, ok, tim
 	}})
 	switch which {
 	case 0:
-		a.C.Assert(ok, jc.IsTrue)
 		return v.Interface(), ok, false
 	case 1:
 		return nil, false, true

--- a/testing/channel_test.go
+++ b/testing/channel_test.go
@@ -1,0 +1,23 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+type contentAsserterSuite struct{}
+
+var _ = gc.Suite(&contentAsserterSuite{})
+
+func (s *contentAsserterSuite) TestContentAsserterC(c *gc.C) {
+	ch := make(chan string, 1)
+	contentC := testing.ContentAsserterC{C:c, Chan:ch}
+	contentC.AssertNoReceive()
+	close(ch)
+	contentC.AssertClosed()
+}
+

--- a/worker/uniter/relation/hookqueue_test.go
+++ b/worker/uniter/relation/hookqueue_test.go
@@ -4,6 +4,7 @@
 package relation_test
 
 import (
+	"sync"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -166,7 +167,7 @@ func (s *HookQueueSuite) TestAliveHookQueue(c *gc.C) {
 		c.Logf("test %d: %s", i, t.summary)
 		out := make(chan hook.Info)
 		in := make(chan multiwatcher.RelationUnitsChange)
-		ruw := &RUW{in, false}
+		ruw := &RUW{in: in, stopped: false}
 		q := relation.NewAliveHookQueue(t.initial, out, ruw)
 		for i, step := range t.steps {
 			c.Logf("  step %d", i)
@@ -216,6 +217,7 @@ func (s *HookQueueSuite) TestDyingHookQueue(c *gc.C) {
 type RUW struct {
 	in      chan multiwatcher.RelationUnitsChange
 	stopped bool
+	m       sync.Mutex
 }
 
 func (w *RUW) Changes() <-chan multiwatcher.RelationUnitsChange {
@@ -223,6 +225,8 @@ func (w *RUW) Changes() <-chan multiwatcher.RelationUnitsChange {
 }
 
 func (w *RUW) Stop() error {
+	w.m.Lock()
+	defer w.m.Unlock()
 	// Stop() should be idempotent, but close(chan) is not, so guard it.
 	if !w.stopped {
 		close(w.in)

--- a/worker/uniter/relation/hookqueue_test.go
+++ b/worker/uniter/relation/hookqueue_test.go
@@ -223,7 +223,10 @@ func (w *RUW) Changes() <-chan multiwatcher.RelationUnitsChange {
 }
 
 func (w *RUW) Stop() error {
-	close(w.in)
+	// Stop() should be idempotent, but close(chan) is not, so guard it.
+	if !w.stopped {
+		close(w.in)
+	}
 	w.stopped = true
 	return nil
 }

--- a/worker/uniter/relation/livesource.go
+++ b/worker/uniter/relation/livesource.go
@@ -167,7 +167,6 @@ func (q *liveSource) Changes() <-chan hook.SourceChange {
 
 // Stop cleans up the liveSource's resources and stops sending changes.
 func (q *liveSource) Stop() error {
-	q.tomb.Kill(q.watcher.Stop())
 	return q.tomb.Wait()
 }
 

--- a/worker/uniter/relation/livesource.go
+++ b/worker/uniter/relation/livesource.go
@@ -10,8 +10,8 @@ import (
 	"gopkg.in/juju/charm.v4/hooks"
 	"launchpad.net/tomb"
 
-	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/worker/uniter/hook"
 )
 
@@ -38,7 +38,7 @@ type liveSource struct {
 	changedPending string
 
 	started bool
-	tomb tomb.Tomb
+	tomb    tomb.Tomb
 	watcher RelationUnitsWatcher
 	changes chan hook.SourceChange
 }
@@ -64,7 +64,6 @@ type unitInfo struct {
 	// unit's next hook.
 	prev, next *unitInfo
 }
-
 
 // NewLiveHookSource returns a new HookSource that aggregates the values
 // obtained from the w watcher and generates the hooks that must be executed

--- a/worker/uniter/relation/livesource.go
+++ b/worker/uniter/relation/livesource.go
@@ -90,6 +90,7 @@ func NewLiveHookSource(initial *State, w RelationUnitsWatcher) hook.Source {
 	}
 	go func() {
 		defer q.tomb.Done()
+		defer watcher.Stop(q.watcher, &q.tomb)
 		q.tomb.Kill(q.loop())
 	}()
 	return q

--- a/worker/uniter/relation/livesource_test.go
+++ b/worker/uniter/relation/livesource_test.go
@@ -7,10 +7,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/worker/uniter/relation"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/relation"
 )
 
 type LiveSourceSuite struct{}
@@ -20,7 +20,7 @@ var _ = gc.Suite(&LiveSourceSuite{})
 func (s *LiveSourceSuite) TestLiveHookSource(c *gc.C) {
 	for i, t := range aliveHookQueueTests {
 		c.Logf("test %d: %s", i, t.summary)
-		ruw := &RUW{make(chan multiwatcher.RelationUnitsChange), false}
+		ruw := &RUW{in: make(chan multiwatcher.RelationUnitsChange), stopped: false}
 		q := relation.NewLiveHookSource(t.initial, ruw)
 		for i, step := range t.steps {
 			c.Logf("  step %d", i)
@@ -37,7 +37,7 @@ func (s *LiveSourceSuite) TestLiveHookSourceTeardownEvenWhenUnclean(c *gc.C) {
 	// should still teardown (and close its changes channel) even if the
 	// function is never called.
 	initialState := &relation.State{21345, nil, ""}
-	ruw := &RUW{make(chan multiwatcher.RelationUnitsChange, 1), false}
+	ruw := &RUW{in: make(chan multiwatcher.RelationUnitsChange, 1), stopped: false}
 	source := relation.NewLiveHookSource(initialState, ruw)
 	sourceChanges := source.Changes()
 	sourceC := coretesting.ContentAsserterC{C: c, Chan: sourceChanges}

--- a/worker/uniter/relation/livesource_test.go
+++ b/worker/uniter/relation/livesource_test.go
@@ -41,7 +41,6 @@ func (s *LiveSourceSuite) TestLiveHookSourceTeardownEvenWhenUnclean(c *gc.C) {
 	source := relation.NewLiveHookSource(initialState, ruw)
 	sourceChanges := source.Changes()
 	sourceC := coretesting.ContentAsserterC{C: c, Chan: sourceChanges}
-	sourceC.AssertNoReceive()
 	ruw.in <- multiwatcher.RelationUnitsChange{}
 	sourceChange := sourceC.AssertOneReceive()
 	// assert that it has the right type, but don't actually call it


### PR DESCRIPTION
While looking through the code, we noticed that liveSource was using a WaitGroup that depended on
the function it passed over the channel being called.
However, it is possible for the source to be asked to Stop before that ever gets called, so the goroutine shouldn't just hang forever.

This changes NewLiveHookSource so that it uses the standard 'loop' paradigm, and plays games with select over an input channel instead of using a waitgroup.

This also found a bug in ContentAsserterC.AssertClosed [didn't work as it always was asserting content was received in the wrong place] and RUW.Stop() [couldn't be called multiple times].


(Review request: http://reviews.vapour.ws/r/959/)