### PR TITLE
Merge pull request #1616 from dimitern/lp-1416928-filter-lxcbr0-addresse...

### DIFF
--- a/agent/export_test.go
+++ b/agent/export_test.go
@@ -51,4 +51,7 @@ func ConfigFileExists(config Config) bool {
 	return err == nil
 }
 
-var MachineJobFromParams = machineJobFromParams
+var (
+	MachineJobFromParams = machineJobFromParams
+	IsLocalEnv           = &isLocalEnv
+)

--- a/network/network.go
+++ b/network/network.go
@@ -4,9 +4,12 @@
 package network
 
 import (
+	"bufio"
 	"fmt"
 	"net"
 	"sort"
+	"os"
+	"strings"
 
 	"github.com/juju/loggo"
 )
@@ -179,4 +182,100 @@ type PreferIPv6Getter interface {
 func InitializeFromConfig(config PreferIPv6Getter) {
 	globalPreferIPv6 = config.PreferIPv6()
 	logger.Infof("setting prefer-ipv6 to %v", globalPreferIPv6)
+}
+
+// LXCNetDefaultConfig is the location of the default network config
+// of the lxc package. It's exported to allow cross-package testing.
+var LXCNetDefaultConfig = "/etc/default/lxc-net"
+
+// InterfaceByNameAddrs returns the addresses for the given interface
+// name. It's exported to facilitate cross-package testing.
+var InterfaceByNameAddrs = func(name string) ([]net.Addr, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return iface.Addrs()
+}
+
+// FilterLXCAddresses tries to discover the default lxc bridge name
+// and all of its addresses, then filters those addresses out of the
+// given ones and returns the result. Any errors encountered during
+// this process are logged, but not considered fatal. See LP bug
+// #1416928.
+func FilterLXCAddresses(addresses []Address) []Address {
+	file, err := os.Open(LXCNetDefaultConfig)
+	if os.IsNotExist(err) {
+		// No lxc-net config found, nothing to do.
+		logger.Debugf("no lxc bridge addresses to filter for machine")
+		return addresses
+	} else if err != nil {
+		// Just log it, as it's not fatal.
+		logger.Warningf("cannot open %q: %v", LXCNetDefaultConfig, err)
+		return addresses
+	}
+	defer file.Close()
+
+	filterAddrs := func(bridgeName string, addrs []net.Addr) []Address {
+		// Filter out any bridge addresses.
+		filtered := make([]Address, 0, len(addresses))
+		for _, addr := range addresses {
+			found := false
+			for _, ifaceAddr := range addrs {
+				// First check if this is a CIDR, as
+				// net.InterfaceAddrs might return this instead of
+				// a plain IP.
+				ip, ipNet, err := net.ParseCIDR(ifaceAddr.String())
+				if err != nil {
+					// It's not a CIDR, try parsing as IP.
+					ip = net.ParseIP(ifaceAddr.String())
+				}
+				if ip == nil {
+					logger.Debugf("cannot parse %q as IP, ignoring", ifaceAddr)
+					continue
+				}
+				// Filter by CIDR if known or single IP otherwise.
+				if ipNet != nil && ipNet.Contains(net.ParseIP(addr.Value)) ||
+					ip.String() == addr.Value {
+					found = true
+					logger.Debugf("filtering %q address %s for machine", bridgeName, ifaceAddr.String())
+				}
+			}
+			if !found {
+				logger.Debugf("not filtering address %s for machine", addr)
+				filtered = append(filtered, addr)
+			}
+		}
+		logger.Debugf("addresses after filtering: %v", filtered)
+		return filtered
+	}
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "#"):
+			// Skip comments.
+		case strings.HasPrefix(line, "LXC_BRIDGE"):
+			// Extract <name> from LXC_BRIDGE="<name>".
+			parts := strings.Split(line, `"`)
+			if len(parts) < 2 {
+				logger.Debugf("ignoring invalid line '%s' in %q", line, LXCNetDefaultConfig)
+				continue
+			}
+			bridgeName := strings.TrimSpace(parts[1])
+			// Discover all addresses of bridgeName interface.
+			addrs, err := InterfaceByNameAddrs(bridgeName)
+			if err != nil {
+				logger.Warningf("cannot get %q addresses: %v (ignoring)", bridgeName, err)
+				continue
+			}
+			logger.Debugf("%q has addresses %v", bridgeName, addrs)
+			return filterAddrs(bridgeName, addrs)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		logger.Warningf("failed to read %q: %v (ignoring)", LXCNetDefaultConfig, err)
+	}
+	return addresses
 }

--- a/network/network.go
+++ b/network/network.go
@@ -7,8 +7,8 @@ import (
 	"bufio"
 	"fmt"
 	"net"
-	"sort"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/juju/loggo"

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -4,6 +4,10 @@
 package network_test
 
 import (
+	"io/ioutil"
+	"net"
+	"path/filepath"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -98,4 +102,45 @@ func (*NetworkSuite) TestInitializeFromConfig(c *gc.C) {
 	})
 	network.InitializeFromConfig(envConfig)
 	c.Check(network.GetPreferIPv6(), jc.IsFalse)
+}
+
+func (s *NetworkSuite) TestFilterLXCAddresses(c *gc.C) {
+	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
+	netConf := []byte(`
+  # comments ignored
+LXC_BR= ignored
+LXC_ADDR = "fooo"
+ LXC_BRIDGE = " foobar " # detected, spaces stripped
+anything else ignored
+LXC_BRIDGE="ignored"`[1:])
+	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+		c.Assert(name, gc.Equals, "foobar")
+		return []net.Addr{
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+			// Try a CIDR 10.0.3.5/24 as well.
+			&net.IPNet{IP: net.IPv4(10, 0, 3, 5), Mask: net.IPv4Mask(255, 255, 255, 0)},
+		}, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
+
+	inputAddresses := network.NewAddresses(
+		"127.0.0.1",
+		"2001:db8::1",
+		"10.0.0.1",
+		"10.0.3.1", // filtered (directly as IP)
+		"10.0.3.3", // filtered (by the 10.0.3.5/24 CIDR)
+		"10.0.3.5", // filtered (directly)
+		"10.0.3.4", // filtered (directly)
+		"192.168.123.42",
+	)
+	filteredAddresses := network.NewAddresses(
+		"127.0.0.1",
+		"2001:db8::1",
+		"10.0.0.1",
+		"192.168.123.42",
+	)
+	c.Assert(network.FilterLXCAddresses(inputAddresses), jc.DeepEquals, filteredAddresses)
 }

--- a/worker/apiaddressupdater/apiaddressupdater_test.go
+++ b/worker/apiaddressupdater/apiaddressupdater_test.go
@@ -4,6 +4,9 @@
 package apiaddressupdater_test
 
 import (
+	"io/ioutil"
+	"net"
+	"path/filepath"
 	stdtesting "testing"
 	"time"
 
@@ -31,6 +34,11 @@ func (s *APIAddressUpdaterSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	err := s.State.SetAPIHostPorts(nil)
 	c.Assert(err, jc.ErrorIsNil)
+	// By default mock these to better isolate the test from the real machine.
+	s.PatchValue(&network.InterfaceByNameAddrs, func(string) ([]net.Addr, error) {
+		return nil, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, "")
 }
 
 type apiAddressSetter struct {
@@ -86,7 +94,7 @@ func (s *APIAddressUpdaterSuite) TestAddressChange(c *gc.C) {
 	// and then the updated value.
 	select {
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for SetAPIHostPorts to be called first")
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called initially")
 	case servers := <-setter.servers:
 		c.Assert(servers, gc.HasLen, 0)
 	}
@@ -95,8 +103,82 @@ func (s *APIAddressUpdaterSuite) TestAddressChange(c *gc.C) {
 	s.BackingState.StartSync()
 	select {
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for SetAPIHostPorts to be called second")
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called after update")
 	case servers := <-setter.servers:
 		c.Assert(servers, gc.DeepEquals, updatedServers)
+	}
+}
+
+func (s *APIAddressUpdaterSuite) TestLXCBridgeAddressesFiltering(c *gc.C) {
+	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
+	netConf := []byte(`
+  # comments ignored
+LXC_BR= ignored
+LXC_ADDR = "fooo"
+LXC_BRIDGE="foobar" # detected
+anything else ignored
+LXC_BRIDGE="ignored"`[1:])
+	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+		c.Assert(name, gc.Equals, "foobar")
+		return []net.Addr{
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
+			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+		}, nil
+	})
+	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
+
+	initialServers := [][]network.HostPort{
+		network.NewHostPorts(1234, "localhost", "127.0.0.1"),
+		network.NewHostPorts(
+			4321,
+			"10.0.3.1", // filtered
+			"10.0.3.3", // not filtered (not a lxc bridge address)
+		),
+		network.NewHostPorts(4242, "10.0.3.4"), // filtered
+	}
+	err = s.State.SetAPIHostPorts(initialServers)
+	c.Assert(err, jc.ErrorIsNil)
+
+	setter := &apiAddressSetter{servers: make(chan [][]network.HostPort, 1)}
+	st, _ := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
+	worker := apiaddressupdater.NewAPIAddressUpdater(st.Machiner(), setter)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+	s.BackingState.StartSync()
+	updatedServers := [][]network.HostPort{
+		network.NewHostPorts(1234, "localhost", "127.0.0.1"),
+		network.NewHostPorts(
+			4001,
+			"10.0.3.1", // filtered
+			"10.0.3.3", // not filtered (not a lxc bridge address)
+		),
+		network.NewHostPorts(4200, "10.0.3.4"), // filtered
+	}
+	// SetAPIHostPorts should be called with the initial value, and
+	// then the updated value, but filtering occurs in both cases.
+	select {
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called initially")
+	case servers := <-setter.servers:
+		c.Assert(servers, gc.HasLen, 2)
+		c.Assert(servers, jc.DeepEquals, [][]network.HostPort{
+			network.NewHostPorts(1234, "localhost", "127.0.0.1"),
+			network.NewHostPorts(4321, "10.0.3.3"),
+		})
+	}
+	err = s.State.SetAPIHostPorts(updatedServers)
+	c.Assert(err, gc.IsNil)
+	s.BackingState.StartSync()
+	select {
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for SetAPIHostPorts to be called after update")
+	case servers := <-setter.servers:
+		c.Assert(servers, gc.HasLen, 2)
+		c.Assert(servers, jc.DeepEquals, [][]network.HostPort{
+			network.NewHostPorts(1234, "localhost", "127.0.0.1"),
+			network.NewHostPorts(4001, "10.0.3.3"),
+		})
 	}
 }

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -89,6 +89,8 @@ func setMachineAddresses(m *machiner.Machine) error {
 	if len(hostAddresses) == 0 {
 		return nil
 	}
+	// Filter out any LXC bridge addresses.
+	hostAddresses = network.FilterLXCAddresses(hostAddresses)
 	logger.Infof("setting addresses for %v to %q", m.Tag(), hostAddresses)
 	return m.SetMachineAddresses(hostAddresses)
 }


### PR DESCRIPTION
Fixed lp:1416928 - ignore lxcbr0 addresses on machine-0 for non-local environments

The address(es) of the LXC bridge device is detected and filtered before
setting API hosts:ports (on bootstrap and when changes are detected by
the apiaddressesupdater) and also when updating machine addresses
discovered from the machiner locally. This means that bootstrapping on
a machine with the lxc package installed (i.e. having lxcbr0) or
installing the lxc package later won't cause the state or API addresses
to change and include the lxcbr0 address(es), which are unusable in all
but local environments.

Foreport of #1616 

See http://pad.lv/1416928 for more info.

(Review request: http://reviews.vapour.ws/r/960/)