### PR TITLE
Fixed state Subnets and IPAddresses, improved tests

### DIFF
--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -17,18 +17,28 @@ import (
 type AddressState string
 
 const (
-	// AddressStateUnknown is the initial state an IP address is created with
+	// AddressStateUnknown is the initial state an IP address is
+	// created with.
 	AddressStateUnknown AddressState = ""
 
-	// AddressStateAllocated means that the IP address has successfully
-	// been allocated by the provider and is now in use.
+	// AddressStateAllocated means that the IP address has
+	// successfully been allocated by the provider and is now in use
+	// by an interface on a machine.
 	AddressStateAllocated AddressState = "allocated"
 
-	// AddressStateUnavailable means that allocating the address with the
-	// provider failed. We shouldn't use this address, nor should we
-	// attempt to allocate it again in the future.
-	AddressStateUnvailable AddressState = "unavailable"
+	// AddressStateUnavailable means that allocating the address with
+	// the provider failed. We shouldn't use this address, nor should
+	// we attempt to allocate it again in the future.
+	AddressStateUnavailable AddressState = "unavailable"
 )
+
+// String implements fmt.Stringer.
+func (s AddressState) String() string {
+	if s == AddressStateUnknown {
+		return "<unknown>"
+	}
+	return string(s)
+}
 
 // IPAddress represents the state of an IP address.
 type IPAddress struct {
@@ -94,9 +104,15 @@ func (i *IPAddress) State() AddressState {
 	return i.doc.State
 }
 
-// Remove removes a no-longer need IP address.
+// String implements fmt.Stringer.
+func (i *IPAddress) String() string {
+	return i.Address().String()
+}
+
+// Remove removes an existing IP address. Trying to remove a missing
+// address is not an error.
 func (i *IPAddress) Remove() (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot remove IP address %v", i)
+	defer errors.DeferredAnnotatef(&err, "cannot remove IP address %q", i)
 
 	ops := []txn.Op{{
 		C:      ipaddressesC,
@@ -106,10 +122,12 @@ func (i *IPAddress) Remove() (err error) {
 	return i.st.runTransaction(ops)
 }
 
-// SetState sets the State of an IPAddress. Valid state transitions are Unknown
-// to Allocated or Unavailable. Any other transition will fail.
+// SetState sets the State of an IPAddress. Valid state transitions
+// are Unknown to Allocated or Unavailable, as well as setting the
+// same state more than once. Any other transition will result in
+// returning an error satisfying errors.IsNotValid().
 func (i *IPAddress) SetState(newState AddressState) (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot set IP address %v to state %q", i, newState)
+	defer errors.DeferredAnnotatef(&err, "cannot set IP address %q to state %q", i, newState)
 
 	validStates := []AddressState{AddressStateUnknown, newState}
 	unknownOrSame := bson.D{{"state", bson.D{{"$in", validStates}}}}
@@ -119,20 +137,41 @@ func (i *IPAddress) SetState(newState AddressState) (err error) {
 		Assert: unknownOrSame,
 		Update: bson.D{{"$set", bson.D{{"state", string(newState)}}}},
 	}}
-	return i.st.runTransaction(ops)
+	if err = i.st.runTransaction(ops); err != nil {
+		return onAbort(
+			err,
+			errors.NotValidf("transition from %q", i.doc.State),
+		)
+	}
+	i.doc.State = newState
+	return nil
 }
 
-// AllocateTo sets the machine ID and interface ID of the IP address. It will
-// fail if the state is not AddressStateUnknown.
-func (i *IPAddress) AllocateTo(machineId string, interfaceId string) (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot allocate IP address %v to machine %q, interface %q", i, machineId, interfaceId)
+// AllocateTo sets the machine ID and interface ID of the IP address.
+// It will fail if the state is not AddressStateUnknown. On success,
+// the address state will also change to AddressStateAllocated.
+func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot allocate IP address %q to machine %q, interface %q", i, machineId, interfaceId)
 
 	ops := []txn.Op{{
 		C:      ipaddressesC,
 		Id:     i.doc.DocID,
-		Assert: bson.D{{"state", ""}},
-		Update: bson.D{{"$set", bson.D{{"machineid", machineId}, {"interfaceid", interfaceId}}}},
+		Assert: bson.D{{"state", AddressStateUnknown}},
+		Update: bson.D{{"$set", bson.D{
+			{"machineid", machineId},
+			{"interfaceid", interfaceId},
+			{"state", string(AddressStateAllocated)},
+		}}},
 	}}
 
-	return i.st.runTransaction(ops)
+	if err = i.st.runTransaction(ops); err != nil {
+		return onAbort(
+			err,
+			errors.Errorf("already allocated or unavailable"),
+		)
+	}
+	i.doc.MachineId = machineId
+	i.doc.InterfaceId = interfaceId
+	i.doc.State = AddressStateAllocated
+	return nil
 }

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -18,104 +18,196 @@ type IPAddressSuite struct {
 
 var _ = gc.Suite(&IPAddressSuite{})
 
+func (s *IPAddressSuite) assertAddress(
+	c *gc.C,
+	ipAddr *state.IPAddress,
+	addr network.Address,
+	ipState state.AddressState,
+	machineId, ifaceId, subnetId string,
+) {
+	c.Assert(ipAddr, gc.NotNil)
+	c.Assert(ipAddr.MachineId(), gc.Equals, machineId)
+	c.Assert(ipAddr.InterfaceId(), gc.Equals, ifaceId)
+	c.Assert(ipAddr.SubnetId(), gc.Equals, subnetId)
+	c.Assert(ipAddr.Value(), gc.Equals, addr.Value)
+	c.Assert(ipAddr.Type(), gc.Equals, addr.Type)
+	c.Assert(ipAddr.Scope(), gc.Equals, addr.Scope)
+	c.Assert(ipAddr.State(), gc.Equals, ipState)
+	c.Assert(ipAddr.Address(), jc.DeepEquals, addr)
+	c.Assert(ipAddr.String(), gc.Equals, addr.String())
+}
+
 func (s *IPAddressSuite) TestAddIPAddress(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
-	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
-	c.Assert(err, jc.ErrorIsNil)
+	for i, test := range []string{"0.1.2.3", "2001:db8::1"} {
+		c.Logf("test %d: %q", i, test)
+		addr := network.NewAddress(test, network.ScopePublic)
+		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+		c.Assert(err, jc.ErrorIsNil)
+		s.assertAddress(c, ipAddr, addr, state.AddressStateUnknown, "", "", "foobar")
 
-	assertAddress := func(ipAddr *state.IPAddress) {
-		c.Assert(ipAddr.Value(), gc.Equals, "192.168.1.0")
-		c.Assert(ipAddr.SubnetId(), gc.Equals, "foobar")
-		c.Assert(ipAddr.Type(), gc.Equals, addr.Type)
-		c.Assert(ipAddr.Scope(), gc.Equals, network.ScopePublic)
-		c.Assert(ipAddr.State(), gc.Equals, state.AddressStateUnknown)
+		// verify the address was stored in the state
+		ipAddr, err = s.State.IPAddress(test)
+		c.Assert(err, jc.ErrorIsNil)
+		s.assertAddress(c, ipAddr, addr, state.AddressStateUnknown, "", "", "foobar")
 	}
-	assertAddress(ipAddr)
-
-	// verify the address was stored in the state
-	ipAddr, err = s.State.IPAddress("192.168.1.0")
-	c.Assert(err, jc.ErrorIsNil)
-	assertAddress(ipAddr)
 }
 
 func (s *IPAddressSuite) TestAddIPAddressInvalid(c *gc.C) {
 	addr := network.Address{Value: "foo"}
 	_, err := s.State.AddIPAddress(addr, "foobar")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, `invalid IP address "foo"`)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err, gc.ErrorMatches, `cannot add IP address "foo": address not valid`)
 }
 
 func (s *IPAddressSuite) TestAddIPAddressAlreadyExists(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	_, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddIPAddress(addr, "foobar")
-	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsAlreadyExists)
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+	c.Assert(err, gc.ErrorMatches,
+		`cannot add IP address "public:0.1.2.3": address already exists`,
+	)
 }
 
 func (s *IPAddressSuite) TestIPAddressNotFound(c *gc.C) {
-	_, err := s.State.IPAddress("192.168.1.0")
-	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
+	_, err := s.State.IPAddress("0.1.2.3")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, `IP address "0.1.2.3" not found`)
 }
 
-func (s *IPAddressSuite) TestIPAddressRemove(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
+func (s *IPAddressSuite) TestRemove(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = ipAddr.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.IPAddress("192.168.1.0")
-	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
+	// Doing it twice is also fine.
+	err = ipAddr.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.IPAddress("0.1.2.3")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, `IP address "0.1.2.3" not found`)
 }
 
-func (s *IPAddressSuite) TestIPAddressSetState(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
+func (s *IPAddressSuite) TestAddressStateString(c *gc.C) {
+	for i, test := range []struct {
+		ipState state.AddressState
+		expect  string
+	}{{
+		state.AddressStateUnknown,
+		"<unknown>",
+	}, {
+		state.AddressStateAllocated,
+		"allocated",
+	}, {
+		state.AddressStateUnavailable,
+		"unavailable",
+	}} {
+		c.Logf("test %d: %q -> %q", i, test.ipState, test.expect)
+		c.Check(test.ipState.String(), gc.Equals, test.expect)
+	}
+}
+
+func (s *IPAddressSuite) TestSetState(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+
+	for i, test := range []struct {
+		initial, changeTo state.AddressState
+		err               string
+	}{{
+		initial:  state.AddressStateUnknown,
+		changeTo: state.AddressStateUnknown,
+	}, {
+		initial:  state.AddressStateUnknown,
+		changeTo: state.AddressStateAllocated,
+	}, {
+		initial:  state.AddressStateUnknown,
+		changeTo: state.AddressStateUnavailable,
+	}, {
+		initial:  state.AddressStateAllocated,
+		changeTo: state.AddressStateAllocated,
+	}, {
+		initial:  state.AddressStateUnavailable,
+		changeTo: state.AddressStateUnavailable,
+	}, {
+		initial:  state.AddressStateAllocated,
+		changeTo: state.AddressStateUnknown,
+		err: `cannot set IP address "public:0.1.2.3" to state "<unknown>": ` +
+			`transition from "allocated" not valid`,
+	}, {
+		initial:  state.AddressStateUnavailable,
+		changeTo: state.AddressStateUnknown,
+		err: `cannot set IP address "public:0.1.2.3" to state "<unknown>": ` +
+			`transition from "unavailable" not valid`,
+	}, {
+		initial:  state.AddressStateAllocated,
+		changeTo: state.AddressStateUnavailable,
+		err: `cannot set IP address "public:0.1.2.3" to state "unavailable": ` +
+			`transition from "allocated" not valid`,
+	}, {
+		initial:  state.AddressStateUnavailable,
+		changeTo: state.AddressStateAllocated,
+		err: `cannot set IP address "public:0.1.2.3" to state "allocated": ` +
+			`transition from "unavailable" not valid`,
+	}} {
+		c.Logf("test %d: %q -> %q ok:%v", i, test.initial, test.changeTo, test.err == "")
+		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+		c.Check(err, jc.ErrorIsNil)
+
+		// Initially, all addresses have AddressStateUnknown.
+		c.Assert(ipAddr.State(), gc.Equals, state.AddressStateUnknown)
+
+		if test.initial != state.AddressStateUnknown {
+			err = ipAddr.SetState(test.initial)
+			c.Check(err, jc.ErrorIsNil)
+		}
+		err = ipAddr.SetState(test.changeTo)
+		if test.err != "" {
+			c.Check(err, gc.ErrorMatches, test.err)
+			c.Check(err, jc.Satisfies, errors.IsNotValid)
+			c.Check(ipAddr.Remove(), jc.ErrorIsNil)
+			continue
+		}
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(ipAddr.State(), gc.Equals, test.changeTo)
+		c.Check(ipAddr.Remove(), jc.ErrorIsNil)
+	}
+}
+
+func (s *IPAddressSuite) TestAllocateTo(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.State(), gc.Equals, state.AddressStateUnknown)
-
-	err = ipAddr.SetState(state.AddressStateAllocated)
-	c.Assert(err, jc.ErrorIsNil)
-
-	freshCopy, err := s.State.IPAddress("192.168.1.0")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(freshCopy.State(), gc.Equals, state.AddressStateAllocated)
-
-	// setting the state to the same state is permitted
-	err = ipAddr.SetState(state.AddressStateAllocated)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// setting back to unknown isn't permitted
-	err = ipAddr.SetState(state.AddressStateUnknown)
-	c.Assert(err, gc.ErrorMatches, `cannot set IP address .* to state "".*`)
-}
-
-func (s *IPAddressSuite) TestIPAddressAllocateTo(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
-	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.MachineId(), gc.Equals, "")
 	c.Assert(ipAddr.InterfaceId(), gc.Equals, "")
 
 	err = ipAddr.AllocateTo("wibble", "wobble")
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.State(), gc.Equals, state.AddressStateAllocated)
+	c.Assert(ipAddr.MachineId(), gc.Equals, "wibble")
+	c.Assert(ipAddr.InterfaceId(), gc.Equals, "wobble")
 
-	freshCopy, err := s.State.IPAddress("192.168.1.0")
+	freshCopy, err := s.State.IPAddress("0.1.2.3")
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(freshCopy.State(), gc.Equals, state.AddressStateAllocated)
 	c.Assert(freshCopy.MachineId(), gc.Equals, "wibble")
 	c.Assert(freshCopy.InterfaceId(), gc.Equals, "wobble")
 
-	err = ipAddr.SetState(state.AddressStateAllocated)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// allocating should now fail
-	err = ipAddr.AllocateTo("wobble", "wibble")
-	c.Assert(err, gc.ErrorMatches, `cannot allocate IP address .* to machine "wobble", interface "wibble".*`)
+	// allocating twice should fail.
+	err = ipAddr.AllocateTo("m", "i")
+	c.Assert(err, gc.ErrorMatches,
+		`cannot allocate IP address "public:0.1.2.3" to machine "m", interface "i": `+
+			`already allocated or unavailable`,
+	)
 }
 
-func (s *IPAddressSuite) TestIPAddressAddress(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
+func (s *IPAddressSuite) TestAddress(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.Address(), jc.DeepEquals, addr)

--- a/state/state.go
+++ b/state/state.go
@@ -1280,14 +1280,16 @@ func (st *State) AddService(
 	return svc, nil
 }
 
-// AddIPAddress creates and returns a new IP address
+// AddIPAddress creates and returns a new IP address. It can return an
+// error satisfying IsNotValid() or IsAlreadyExists() when the addr
+// does not contain a valid IP, or when addr is already added.
 func (st *State) AddIPAddress(addr network.Address, subnetid string) (ipaddress *IPAddress, err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot add IP address %v", addr.Value)
+	defer errors.DeferredAnnotatef(&err, "cannot add IP address %q", addr)
 
 	// This checks for a missing value as well as invalid values
 	ip := net.ParseIP(addr.Value)
 	if ip == nil {
-		return nil, errors.Errorf("invalid IP address %q", addr.Value)
+		return nil, errors.NotValidf("address")
 	}
 
 	addressID := st.docID(addr.Value)
@@ -1313,9 +1315,7 @@ func (st *State) AddIPAddress(addr network.Address, subnetid string) (ipaddress 
 	switch err {
 	case txn.ErrAborted:
 		if _, err = st.IPAddress(addr.Value); err == nil {
-			return nil, errors.AlreadyExistsf("IP address %q", addr.Value)
-		} else if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.AlreadyExistsf("address")
 		}
 	case nil:
 		return ipaddress, nil
@@ -1341,7 +1341,7 @@ func (st *State) IPAddress(value string) (*IPAddress, error) {
 
 // AddSubnet creates and returns a new subnet
 func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot add subnet %v", args.CIDR)
+	defer errors.DeferredAnnotatef(&err, "cannot add subnet %q", args.CIDR)
 
 	subnetID := st.docID(args.CIDR)
 	subDoc := subnetDoc{
@@ -1382,7 +1382,7 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 		if err == nil {
 			return subnet, nil
 		}
-		return nil, errors.Annotatef(err, "ProviderId not unique %q", args.ProviderId)
+		return nil, errors.Errorf("ProviderId %q not unique", args.ProviderId)
 	}
 	return nil, errors.Trace(err)
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -68,18 +68,24 @@ func (s *Subnet) ID() string {
 	return s.doc.DocID
 }
 
-// EnsureDead sets the Life of the subnet to Dead
+// String implements fmt.Stringer.
+func (s *Subnet) String() string {
+	return s.CIDR()
+}
+
+// GoString implements fmt.GoStringer.
+func (s *Subnet) GoString() string {
+	return s.String()
+}
+
+// EnsureDead sets the Life of the subnet to Dead, if it's Alive. It
+// does nothing otherwise.
 func (s *Subnet) EnsureDead() (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot destroy subnet %v", s)
+	defer errors.DeferredAnnotatef(&err, "cannot set subnet %q to dead", s)
+
 	if s.doc.Life == Dead {
 		return nil
 	}
-
-	defer func() {
-		if err == nil {
-			s.doc.Life = Dead
-		}
-	}()
 
 	ops := []txn.Op{{
 		C:      subnetsC,
@@ -87,13 +93,19 @@ func (s *Subnet) EnsureDead() (err error) {
 		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 		Assert: isAliveDoc,
 	}}
-	return s.st.runTransaction(ops)
+	if err = s.st.runTransaction(ops); err != nil {
+		// Ignore ErrAborted if it happens, otherwise return err.
+		return onAbort(err, nil)
+	}
+	s.doc.Life = Dead
+	return nil
 }
 
 // Remove removes a dead subnet. If the subnet is not dead it returns an error.
 // It also removes any IP addresses associated with the subnet.
 func (s *Subnet) Remove() (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot destroy subnet %v", s)
+	defer errors.DeferredAnnotatef(&err, "cannot remove subnet %q", s)
+
 	if s.doc.Life != Dead {
 		return errors.New("subnet is not dead")
 	}
@@ -112,6 +124,9 @@ func (s *Subnet) Remove() (err error) {
 			Id:     doc.DocID,
 			Remove: true,
 		})
+	}
+	if err = iter.Close(); err != nil {
+		return errors.Annotate(err, "cannot read addresses")
 	}
 
 	ops = append(ops, txn.Op{
@@ -162,7 +177,7 @@ func (s *Subnet) Validate() error {
 	if s.doc.CIDR != "" {
 		_, mask, err = net.ParseCIDR(s.doc.CIDR)
 		if err != nil {
-			return errors.Annotatef(err, "invalid CIDR")
+			return errors.Trace(err)
 		}
 	} else {
 		return errors.Errorf("missing CIDR")
@@ -205,16 +220,17 @@ func (s *Subnet) Refresh() error {
 
 	err := subnets.FindId(s.doc.DocID).One(&s.doc)
 	if err == mgo.ErrNotFound {
-		return errors.NotFoundf("subnet %v", s)
+		return errors.NotFoundf("subnet %q", s)
 	}
 	if err != nil {
-		return errors.Errorf("cannot refresh subnet %v: %v", s, err)
+		return errors.Errorf("cannot refresh subnet %q: %v", s, err)
 	}
 	return nil
 }
 
 // PickNewAddress returns a new IPAddress that isn't in use for the subnet.
 // The address starts with AddressStateUnknown, for later allocation.
+// This will fail if the subnet is not alive.
 func (s *Subnet) PickNewAddress() (*IPAddress, error) {
 	for {
 		addr, err := s.attemptToPickNewAddress()
@@ -227,27 +243,31 @@ func (s *Subnet) PickNewAddress() (*IPAddress, error) {
 	}
 }
 
-// attemptToPickNewAddress will try to pick a new address. It can fail with
-// AlreadyExists due to a race condition between fetching the list of addresses
-// already in use and allocating a new one. It is called in a loop by
+// attemptToPickNewAddress will try to pick a new address. It can fail
+// with AlreadyExists due to a race condition between fetching the
+// list of addresses already in use and allocating a new one. If the
+// subnet is not alive, it will also fail. It is called in a loop by
 // PickNewAddress until it gets one or there are no more available!
 func (s *Subnet) attemptToPickNewAddress() (*IPAddress, error) {
+	if s.doc.Life != Alive {
+		return nil, errors.Errorf("cannot pick address: subnet %q is not alive", s)
+	}
 	high := s.doc.AllocatableIPHigh
 	low := s.doc.AllocatableIPLow
 	if low == "" || high == "" {
-		return nil, errors.Errorf("no allocatable IP addresses for subnet %v", s)
+		return nil, errors.Errorf("no allocatable IP addresses for subnet %q", s)
 	}
 
 	// convert low and high to decimals as the bounds
 	lowDecimal, err := network.IPv4ToDecimal(net.ParseIP(low))
 	if err != nil {
 		// these addresses are validated so should never happen
-		return nil, errors.Annotatef(err, "invalid AllocatableIPLow %q for subnet %v", low, s)
+		return nil, errors.Annotatef(err, "invalid AllocatableIPLow %q for subnet %q", low, s)
 	}
 	highDecimal, err := network.IPv4ToDecimal(net.ParseIP(high))
 	if err != nil {
 		// these addresses are validated so should never happen
-		return nil, errors.Annotatef(err, "invalid AllocatableIPHigh %q for subnet %v", high, s)
+		return nil, errors.Annotatef(err, "invalid AllocatableIPHigh %q for subnet %q", high, s)
 	}
 
 	// find all addresses for this subnet and convert them to decimals
@@ -268,12 +288,15 @@ func (s *Subnet) attemptToPickNewAddress() (*IPAddress, error) {
 		}
 		allocated[value] = true
 	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Annotatef(err, "cannot read addresses of subnet %q", s)
+	}
 
 	// Check that the number of addresses in use is less than the
 	// difference between low and high - i.e. we haven't exhausted all
 	// possible addresses.
 	if len(allocated) >= int(highDecimal-lowDecimal)+1 {
-		return nil, errors.Errorf("allocatable IP addresses exhausted for subnet %v", s)
+		return nil, errors.Errorf("allocatable IP addresses exhausted for subnet %q", s)
 	}
 
 	// pick a new random decimal between the low and high bounds that


### PR DESCRIPTION
This is a prerequisite 1 or 2 for implementing the server-side
PrepareContainerInterfaceInfo() provisioner API method to allow
allocating static IPs to containers at provisioning time.

Notable changes:
 * Added String() (GoString()) methods to state.Subnet and
 state.IPAddress to improve their representation in logs etc.
 * For the same reasons, added a String() method to the
 state.AddressState type.
 * IPAddress.SetState() now does not allow transitions between
 "unavailable" and "allocated" more explictly.
 * Fixed a typo - AddressStateUnvailable, reformatted most of the code
 to read better.
 * Better handling of txn.ErrAborted cases in a few places.
 * Subnets life cycle management is improved.
 * Much better test coverage - exhaustive testing of numerous corner
 cases which were not (well) covered before.
 * Better log messages (IMO).

(Review request: http://reviews.vapour.ws/r/961/)