### PR TITLE
dummy provider networking testability improvements

### DIFF
--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -71,8 +71,12 @@ type NetworkConfig struct {
 	// once spaces are introduced.
 	NetworkName string `json:"NetworkName"`
 
-	// ProviderId is a provider-specific network id.
+	// ProviderId is a provider-specific network interface id.
 	ProviderId string `json:"ProviderId"`
+
+	// ProviderSubnetId is a provider-specific subnet id, to which the
+	// interface is attached to.
+	ProviderSubnetId string `json:"ProviderSubnetId"`
 
 	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
 	// normal networks. It's defined by IEEE 802.1Q standard.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -178,10 +178,11 @@ type OpNetworkInterfaces struct {
 	Info       []network.InterfaceInfo
 }
 
-// TODO(dimitern) Rename this to OpSubnets and add InstanceId field.
-type OpListNetworks struct {
-	Env  string
-	Info []network.SubnetInfo
+type OpSubnets struct {
+	Env        string
+	InstanceId instance.Id
+	SubnetIds  []network.Id
+	Info       []network.SubnetInfo
 }
 
 type OpStartInstance struct {
@@ -1016,6 +1017,14 @@ func (e *environ) Instances(ids []instance.Id) (insts []instance.Instance, err e
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error) {
+	if err := env.checkBroken("SupportsAddressAllocation"); err != nil {
+		return false, err
+	}
+	// Any subnetId starting with "noalloc-" will cause this to return
+	// false, so it can be used in tests.
+	if strings.HasPrefix(string(subnetId), "noalloc-") {
+		return false, nil
+	}
 	return true, nil
 }
 
@@ -1084,25 +1093,32 @@ func (env *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceIn
 	info := make([]network.InterfaceInfo, 2)
 	for i, netName := range []string{"private", "public"} {
 		info[i] = network.InterfaceInfo{
-			ProviderId:    network.Id("dummy-" + netName),
-			NetworkName:   "juju-" + netName,
-			CIDR:          fmt.Sprintf("0.%d.2.0/24", i+1),
-			InterfaceName: fmt.Sprintf("eth%d", i),
-			VLANTag:       i,
-			MACAddress:    fmt.Sprintf("aa:bb:cc:dd:ee:f%d", i),
-			Disabled:      i%2 != 0,
-			NoAutoStart:   i%2 != 0,
-			ConfigType:    network.ConfigDHCP,
+			DeviceIndex:      i,
+			ProviderId:       network.Id(fmt.Sprintf("dummy-eth%d", i)),
+			ProviderSubnetId: network.Id("dummy-" + netName),
+			NetworkName:      "juju-" + netName,
+			CIDR:             fmt.Sprintf("0.%d.0.0/24", (i+1)*10),
+			InterfaceName:    fmt.Sprintf("eth%d", i),
+			VLANTag:          i,
+			MACAddress:       fmt.Sprintf("aa:bb:cc:dd:ee:f%d", i),
+			Disabled:         i%2 != 0,
+			NoAutoStart:      i%2 != 0,
+			ConfigType:       network.ConfigDHCP,
 			Address: network.NewAddress(
-				fmt.Sprintf("0.%d.2.%d", i+1, estate.maxAddr+1),
+				fmt.Sprintf("0.%d.0.%d", (i+1)*10, estate.maxAddr+2),
 				network.ScopeUnknown,
 			),
 			DNSServers: network.NewAddresses("ns1.dummy", "ns2.dummy"),
 			GatewayAddress: network.NewAddress(
-				fmt.Sprintf("0.%d.2.1", i+1),
+				fmt.Sprintf("0.%d.0.1", (i+1)*10),
 				network.ScopeUnknown,
 			),
 		}
+	}
+
+	if strings.HasPrefix(string(instId), "i-no-nics-") {
+		// Simulate no NICs on instances with id prefix "i-no-nics-".
+		info = info[:0]
 	}
 
 	estate.ops <- OpNetworkInterfaces{
@@ -1110,11 +1126,12 @@ func (env *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceIn
 		InstanceId: instId,
 		Info:       info,
 	}
+
 	return info, nil
 }
 
 // Subnets implements environs.Environ.Subnets.
-func (env *environ) Subnets(_ instance.Id, _ []network.Id) ([]network.SubnetInfo, error) {
+func (env *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]network.SubnetInfo, error) {
 	if err := env.checkBroken("Subnets"); err != nil {
 		return nil, err
 	}
@@ -1126,16 +1143,86 @@ func (env *environ) Subnets(_ instance.Id, _ []network.Id) ([]network.SubnetInfo
 	estate.mu.Lock()
 	defer estate.mu.Unlock()
 
-	// TODO(dimitern) Populate AllocatableIPLow/High below.
-	netInfo := []network.SubnetInfo{
-		{CIDR: "0.10.0.0/8", ProviderId: "dummy-private"},
-		{CIDR: "0.20.0.0/24", ProviderId: "dummy-public"},
+	allSubnets := []network.SubnetInfo{{
+		CIDR:              "0.10.0.0/24",
+		ProviderId:        "dummy-private",
+		AllocatableIPLow:  net.ParseIP("0.10.0.0"),
+		AllocatableIPHigh: net.ParseIP("0.10.0.255"),
+	}, {
+		CIDR:              "0.20.0.0/24",
+		ProviderId:        "dummy-public",
+		AllocatableIPLow:  net.ParseIP("0.20.0.0"),
+		AllocatableIPHigh: net.ParseIP("0.20.0.255"),
+	}}
+
+	// Filter result by ids, if given.
+	var result []network.SubnetInfo
+	for _, subId := range subnetIds {
+		switch subId {
+		case "dummy-private":
+			result = append(result, allSubnets[0])
+		case "dummy-public":
+			result = append(result, allSubnets[1])
+		}
 	}
-	estate.ops <- OpListNetworks{
-		Env:  env.name,
-		Info: netInfo,
+	if len(subnetIds) == 0 {
+		result = append([]network.SubnetInfo{}, allSubnets...)
 	}
-	return netInfo, nil
+	if strings.HasPrefix(string(instId), "i-no-subnets-") {
+		// Simulate no subnets available if the instance id has prefix
+		// "i-no-subnets-".
+		result = result[:0]
+	}
+	if len(result) == 0 {
+		// No results, so just return them now.
+		estate.ops <- OpSubnets{
+			Env:        env.name,
+			InstanceId: instId,
+			SubnetIds:  subnetIds,
+			Info:       result,
+		}
+		return result, nil
+	}
+
+	makeNoAlloc := func(info network.SubnetInfo) network.SubnetInfo {
+		// Remove the allocatable range and change the provider id
+		// prefix.
+		pid := string(info.ProviderId)
+		pid = strings.TrimPrefix(pid, "dummy-")
+		info.ProviderId = network.Id("noalloc-" + pid)
+		info.AllocatableIPLow = nil
+		info.AllocatableIPHigh = nil
+		return info
+	}
+	if strings.HasPrefix(string(instId), "i-no-alloc-") {
+		iid := strings.TrimPrefix(string(instId), "i-no-alloc-")
+		lastIdx := len(result) - 1
+		if strings.HasPrefix(iid, "all") {
+			// Simulate all subnets have no allocatable ranges set.
+			for i := range result {
+				result[i] = makeNoAlloc(result[i])
+			}
+		} else if idx, err := strconv.Atoi(iid); err == nil {
+			// Simulate only the subnet with index idx in the result
+			// have no allocatable range set.
+			if idx < 0 || idx > lastIdx {
+				err = errors.Errorf("index %d out of range; expected 0..%d", idx, lastIdx)
+				return nil, err
+			}
+			result[idx] = makeNoAlloc(result[idx])
+		} else {
+			err = errors.Errorf("invalid index %q; expected int", iid)
+			return nil, err
+		}
+	}
+
+	estate.ops <- OpSubnets{
+		Env:        env.name,
+		InstanceId: instId,
+		SubnetIds:  subnetIds,
+		Info:       result,
+	}
+	return result, nil
 }
 
 func (e *environ) AllInstances() ([]instance.Instance, error) {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -4,6 +4,8 @@
 package dummy_test
 
 import (
+	"net"
+	"strings"
 	stdtesting "testing"
 	"time"
 
@@ -131,6 +133,41 @@ func (s *suite) TestAvailabilityZone(c *gc.C) {
 	c.Check(hwc.AvailabilityZone, gc.IsNil)
 }
 
+func (s *suite) TestSupportsAddressAllocation(c *gc.C) {
+	e := s.bootstrapTestEnviron(c, false)
+	defer func() {
+		err := e.Destroy()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+
+	// By default, it's supported.
+	supported, err := e.SupportsAddressAllocation("any-id")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(supported, jc.IsTrue)
+
+	// Any subnet id with prefix "noalloc-" simulates address
+	// allocation is not supported.
+	supported, err = e.SupportsAddressAllocation("noalloc-foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(supported, jc.IsFalse)
+
+	// Test we can induce an error for SupportsAddressAllocation.
+	s.breakMethods(c, e, "SupportsAddressAllocation")
+	supported, err = e.SupportsAddressAllocation("any-id")
+	c.Assert(err, gc.ErrorMatches, `dummy\.SupportsAddressAllocation is broken`)
+	c.Assert(supported, jc.IsFalse)
+}
+
+func (s *suite) breakMethods(c *gc.C, e environs.NetworkingEnviron, names ...string) {
+	cfg := e.Config()
+	brokenCfg, err := cfg.Apply(map[string]interface{}{
+		"broken": strings.Join(names, " "),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = e.SetConfig(brokenCfg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *suite) TestAllocateAddress(c *gc.C) {
 	e := s.bootstrapTestEnviron(c, false)
 	defer func() {
@@ -145,16 +182,22 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 	opc := make(chan dummy.Operation, 200)
 	dummy.Listen(opc)
 
+	// Test allocating a couple of addresses.
 	newAddress := network.NewAddress("0.1.2.1", network.ScopeCloudLocal)
 	err := e.AllocateAddress(inst.Id(), subnetId, newAddress)
 	c.Assert(err, jc.ErrorIsNil)
-
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress)
 
 	newAddress = network.NewAddress("0.1.2.2", network.ScopeCloudLocal)
 	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress)
+
+	// Test we can induce errors.
+	s.breakMethods(c, e, "AllocateAddress")
+	newAddress = network.NewAddress("0.1.2.3", network.ScopeCloudLocal)
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
+	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
 }
 
 func (s *suite) TestReleaseAddress(c *gc.C) {
@@ -171,16 +214,22 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 	opc := make(chan dummy.Operation, 200)
 	dummy.Listen(opc)
 
+	// Release a couple of addresses.
 	address := network.NewAddress("0.1.2.1", network.ScopeCloudLocal)
 	err := e.ReleaseAddress(inst.Id(), subnetId, address)
 	c.Assert(err, jc.ErrorIsNil)
-
 	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address)
 
 	address = network.NewAddress("0.1.2.2", network.ScopeCloudLocal)
 	err = e.ReleaseAddress(inst.Id(), subnetId, address)
 	c.Assert(err, jc.ErrorIsNil)
 	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address)
+
+	// Test we can induce errors.
+	s.breakMethods(c, e, "ReleaseAddress")
+	address = network.NewAddress("0.1.2.3", network.ScopeCloudLocal)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address)
+	c.Assert(err, gc.ErrorMatches, `dummy\.ReleaseAddress is broken`)
 }
 
 func (s *suite) TestNetworkInterfaces(c *gc.C) {
@@ -194,38 +243,55 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 	dummy.Listen(opc)
 
 	expectInfo := []network.InterfaceInfo{{
-		ProviderId:     "dummy-private",
-		NetworkName:    "juju-private",
-		CIDR:           "0.1.2.0/24",
-		InterfaceName:  "eth0",
-		VLANTag:        0,
-		MACAddress:     "aa:bb:cc:dd:ee:f0",
-		Disabled:       false,
-		NoAutoStart:    false,
-		ConfigType:     network.ConfigDHCP,
-		Address:        network.NewAddress("0.1.2.1", network.ScopeUnknown),
-		DNSServers:     network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
-		ExtraConfig:    nil,
+		ProviderId:       "dummy-eth0",
+		ProviderSubnetId: "dummy-private",
+		NetworkName:      "juju-private",
+		CIDR:             "0.10.0.0/24",
+		DeviceIndex:      0,
+		InterfaceName:    "eth0",
+		VLANTag:          0,
+		MACAddress:       "aa:bb:cc:dd:ee:f0",
+		Disabled:         false,
+		NoAutoStart:      false,
+		ConfigType:       network.ConfigDHCP,
+		Address:          network.NewAddress("0.10.0.2", network.ScopeUnknown),
+		DNSServers:       network.NewAddresses("ns1.dummy", "ns2.dummy"),
+		GatewayAddress:   network.NewAddress("0.10.0.1", network.ScopeUnknown),
+		ExtraConfig:      nil,
 	}, {
-		ProviderId:     "dummy-public",
-		NetworkName:    "juju-public",
-		CIDR:           "0.2.2.0/24",
-		InterfaceName:  "eth1",
-		VLANTag:        1,
-		MACAddress:     "aa:bb:cc:dd:ee:f1",
-		Disabled:       true,
-		NoAutoStart:    true,
-		ConfigType:     network.ConfigDHCP,
-		Address:        network.NewAddress("0.2.2.1", network.ScopeUnknown),
-		DNSServers:     network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress: network.NewAddress("0.2.2.1", network.ScopeUnknown),
-		ExtraConfig:    nil,
+		ProviderId:       "dummy-eth1",
+		ProviderSubnetId: "dummy-public",
+		NetworkName:      "juju-public",
+		CIDR:             "0.20.0.0/24",
+		DeviceIndex:      1,
+		InterfaceName:    "eth1",
+		VLANTag:          1,
+		MACAddress:       "aa:bb:cc:dd:ee:f1",
+		Disabled:         true,
+		NoAutoStart:      true,
+		ConfigType:       network.ConfigDHCP,
+		Address:          network.NewAddress("0.20.0.2", network.ScopeUnknown),
+		DNSServers:       network.NewAddresses("ns1.dummy", "ns2.dummy"),
+		GatewayAddress:   network.NewAddress("0.20.0.1", network.ScopeUnknown),
+		ExtraConfig:      nil,
 	}}
-	info, err := e.NetworkInterfaces(instance.Id("i-42"))
+	info, err := e.NetworkInterfaces("i-42")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, expectInfo)
-	assertInterfaces(c, e, opc, instance.Id("i-42"), expectInfo)
+	assertInterfaces(c, e, opc, "i-42", expectInfo)
+
+	// Test that with instance id prefix "i-no-nics-" no results are
+	// returned.
+	info, err = e.NetworkInterfaces("i-no-nics-here")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, gc.HasLen, 0)
+	assertInterfaces(c, e, opc, "i-no-nics-here", expectInfo[:0])
+
+	// Test we can induce errors.
+	s.breakMethods(c, e, "NetworkInterfaces")
+	info, err = e.NetworkInterfaces("i-any")
+	c.Assert(err, gc.ErrorMatches, `dummy\.NetworkInterfaces is broken`)
+	c.Assert(info, gc.HasLen, 0)
 }
 
 func (s *suite) TestSubnets(c *gc.C) {
@@ -238,14 +304,103 @@ func (s *suite) TestSubnets(c *gc.C) {
 	opc := make(chan dummy.Operation, 200)
 	dummy.Listen(opc)
 
-	expectInfo := []network.SubnetInfo{
-		{CIDR: "0.10.0.0/8", ProviderId: "dummy-private"},
-		{CIDR: "0.20.0.0/24", ProviderId: "dummy-public"},
+	expectInfo := []network.SubnetInfo{{
+		CIDR:              "0.10.0.0/24",
+		ProviderId:        "dummy-private",
+		AllocatableIPLow:  net.ParseIP("0.10.0.0"),
+		AllocatableIPHigh: net.ParseIP("0.10.0.255"),
+	}, {
+		CIDR:              "0.20.0.0/24",
+		ProviderId:        "dummy-public",
+		AllocatableIPLow:  net.ParseIP("0.20.0.0"),
+		AllocatableIPHigh: net.ParseIP("0.20.0.255"),
+	}}
+	// Prepare a version of the above with no allocatable range to
+	// test the magic "i-no-alloc-" prefix below.
+	noallocInfo := make([]network.SubnetInfo, len(expectInfo))
+	for i, exp := range expectInfo {
+		pid := string(exp.ProviderId)
+		pid = strings.TrimPrefix(pid, "dummy-")
+		noallocInfo[i].ProviderId = network.Id("noalloc-" + pid)
+		noallocInfo[i].AllocatableIPLow = nil
+		noallocInfo[i].AllocatableIPHigh = nil
+		noallocInfo[i].CIDR = exp.CIDR
 	}
-	netInfo, err := e.Subnets("", []network.Id{"dummy-private", "dummy-public"})
+
+	ids := []network.Id{"dummy-private", "dummy-public", "foo-bar"}
+	netInfo, err := e.Subnets("i-foo", ids)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(netInfo, jc.DeepEquals, expectInfo)
-	assertSubnets(c, e, opc, expectInfo)
+	assertSubnets(c, e, opc, "i-foo", ids, expectInfo)
+
+	// Test filtering by id(s).
+	netInfo, err = e.Subnets("i-foo", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(netInfo, jc.DeepEquals, expectInfo)
+	assertSubnets(c, e, opc, "i-foo", nil, expectInfo)
+	netInfo, err = e.Subnets("i-foo", ids[0:1])
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(netInfo, jc.DeepEquals, expectInfo[0:1])
+	assertSubnets(c, e, opc, "i-foo", ids[0:1], expectInfo[0:1])
+	netInfo, err = e.Subnets("i-foo", ids[1:])
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(netInfo, jc.DeepEquals, expectInfo[1:])
+	assertSubnets(c, e, opc, "i-foo", ids[1:], expectInfo[1:])
+
+	// Test that using an instance id with prefix "i-no-subnets-"
+	// returns no results, regardless whether ids are given or not.
+	netInfo, err = e.Subnets("i-no-subnets-foo", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(netInfo, gc.HasLen, 0)
+	assertSubnets(c, e, opc, "i-no-subnets-foo", nil, expectInfo[:0])
+
+	netInfo, err = e.Subnets("i-no-subnets-foo", ids)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(netInfo, gc.HasLen, 0)
+	assertSubnets(c, e, opc, "i-no-subnets-foo", ids, expectInfo[:0])
+
+	// Test the behavior with "i-no-alloc-" instance id prefix.
+	// When # is "all", all returned subnets have no allocatable range
+	// set and have provider ids with "noalloc-" prefix.
+	netInfo, err = e.Subnets("i-no-alloc-all", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(netInfo, jc.DeepEquals, noallocInfo)
+	assertSubnets(c, e, opc, "i-no-alloc-all", nil, noallocInfo)
+
+	// When # is an integer, the #-th subnet in result has no
+	// allocatable range set and a provider id prefix "noalloc-".
+	netInfo, err = e.Subnets("i-no-alloc-0", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	expectResult := []network.SubnetInfo{noallocInfo[0], expectInfo[1]}
+	c.Assert(netInfo, jc.DeepEquals, expectResult)
+	assertSubnets(c, e, opc, "i-no-alloc-0", nil, expectResult)
+
+	netInfo, err = e.Subnets("i-no-alloc-1", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	expectResult = []network.SubnetInfo{expectInfo[0], noallocInfo[1]}
+	c.Assert(netInfo, jc.DeepEquals, expectResult)
+	assertSubnets(c, e, opc, "i-no-alloc-1", nil, expectResult)
+
+	// For the last case above, also test the error returned when # is
+	// not integer or it's out of range of the results (including when
+	// filtering by ids is applied).
+	netInfo, err = e.Subnets("i-no-alloc-foo", nil)
+	c.Assert(err, gc.ErrorMatches, `invalid index "foo"; expected int`)
+	c.Assert(netInfo, gc.HasLen, 0)
+
+	netInfo, err = e.Subnets("i-no-alloc-1", ids[:1])
+	c.Assert(err, gc.ErrorMatches, `index 1 out of range; expected 0..0`)
+	c.Assert(netInfo, gc.HasLen, 0)
+
+	netInfo, err = e.Subnets("i-no-alloc-2", ids)
+	c.Assert(err, gc.ErrorMatches, `index 2 out of range; expected 0..1`)
+	c.Assert(netInfo, gc.HasLen, 0)
+
+	// Test we can induce errors.
+	s.breakMethods(c, e, "Subnets")
+	netInfo, err = e.Subnets("i-any", nil)
+	c.Assert(err, gc.ErrorMatches, `dummy\.Subnets is broken`)
+	c.Assert(netInfo, gc.HasLen, 0)
 }
 
 func (s *suite) TestPreferIPv6On(c *gc.C) {
@@ -324,13 +479,22 @@ func assertInterfaces(c *gc.C, e environs.Environ, opc chan dummy.Operation, exp
 	}
 }
 
-func assertSubnets(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInfo []network.SubnetInfo) {
+func assertSubnets(
+	c *gc.C,
+	e environs.Environ,
+	opc chan dummy.Operation,
+	instId instance.Id,
+	subnetIds []network.Id,
+	expectInfo []network.SubnetInfo,
+) {
 	select {
 	case op := <-opc:
-		netOp, ok := op.(dummy.OpListNetworks)
+		netOp, ok := op.(dummy.OpSubnets)
 		if !ok {
 			c.Fatalf("unexpected op: %#v", op)
 		}
+		c.Check(netOp.InstanceId, gc.Equals, instId)
+		c.Check(netOp.SubnetIds, jc.DeepEquals, subnetIds)
 		c.Check(netOp.Info, jc.DeepEquals, expectInfo)
 		return
 	case <-time.After(testing.ShortWait):

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -17,18 +17,28 @@ import (
 type AddressState string
 
 const (
-	// AddressStateUnknown is the initial state an IP address is created with
+	// AddressStateUnknown is the initial state an IP address is
+	// created with.
 	AddressStateUnknown AddressState = ""
 
-	// AddressStateAllocated means that the IP address has successfully
-	// been allocated by the provider and is now in use.
+	// AddressStateAllocated means that the IP address has
+	// successfully been allocated by the provider and is now in use
+	// by an interface on a machine.
 	AddressStateAllocated AddressState = "allocated"
 
-	// AddressStateUnavailable means that allocating the address with the
-	// provider failed. We shouldn't use this address, nor should we
-	// attempt to allocate it again in the future.
-	AddressStateUnvailable AddressState = "unavailable"
+	// AddressStateUnavailable means that allocating the address with
+	// the provider failed. We shouldn't use this address, nor should
+	// we attempt to allocate it again in the future.
+	AddressStateUnavailable AddressState = "unavailable"
 )
+
+// String implements fmt.Stringer.
+func (s AddressState) String() string {
+	if s == AddressStateUnknown {
+		return "<unknown>"
+	}
+	return string(s)
+}
 
 // IPAddress represents the state of an IP address.
 type IPAddress struct {
@@ -94,9 +104,15 @@ func (i *IPAddress) State() AddressState {
 	return i.doc.State
 }
 
-// Remove removes a no-longer need IP address.
+// String implements fmt.Stringer.
+func (i *IPAddress) String() string {
+	return i.Address().String()
+}
+
+// Remove removes an existing IP address. Trying to remove a missing
+// address is not an error.
 func (i *IPAddress) Remove() (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot remove IP address %v", i)
+	defer errors.DeferredAnnotatef(&err, "cannot remove IP address %q", i)
 
 	ops := []txn.Op{{
 		C:      ipaddressesC,
@@ -106,10 +122,12 @@ func (i *IPAddress) Remove() (err error) {
 	return i.st.runTransaction(ops)
 }
 
-// SetState sets the State of an IPAddress. Valid state transitions are Unknown
-// to Allocated or Unavailable. Any other transition will fail.
+// SetState sets the State of an IPAddress. Valid state transitions
+// are Unknown to Allocated or Unavailable, as well as setting the
+// same state more than once. Any other transition will result in
+// returning an error satisfying errors.IsNotValid().
 func (i *IPAddress) SetState(newState AddressState) (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot set IP address %v to state %q", i, newState)
+	defer errors.DeferredAnnotatef(&err, "cannot set IP address %q to state %q", i, newState)
 
 	validStates := []AddressState{AddressStateUnknown, newState}
 	unknownOrSame := bson.D{{"state", bson.D{{"$in", validStates}}}}
@@ -119,20 +137,41 @@ func (i *IPAddress) SetState(newState AddressState) (err error) {
 		Assert: unknownOrSame,
 		Update: bson.D{{"$set", bson.D{{"state", string(newState)}}}},
 	}}
-	return i.st.runTransaction(ops)
+	if err = i.st.runTransaction(ops); err != nil {
+		return onAbort(
+			err,
+			errors.NotValidf("transition from %q", i.doc.State),
+		)
+	}
+	i.doc.State = newState
+	return nil
 }
 
-// AllocateTo sets the machine ID and interface ID of the IP address. It will
-// fail if the state is not AddressStateUnknown.
-func (i *IPAddress) AllocateTo(machineId string, interfaceId string) (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot allocate IP address %v to machine %q, interface %q", i, machineId, interfaceId)
+// AllocateTo sets the machine ID and interface ID of the IP address.
+// It will fail if the state is not AddressStateUnknown. On success,
+// the address state will also change to AddressStateAllocated.
+func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot allocate IP address %q to machine %q, interface %q", i, machineId, interfaceId)
 
 	ops := []txn.Op{{
 		C:      ipaddressesC,
 		Id:     i.doc.DocID,
-		Assert: bson.D{{"state", ""}},
-		Update: bson.D{{"$set", bson.D{{"machineid", machineId}, {"interfaceid", interfaceId}}}},
+		Assert: bson.D{{"state", AddressStateUnknown}},
+		Update: bson.D{{"$set", bson.D{
+			{"machineid", machineId},
+			{"interfaceid", interfaceId},
+			{"state", string(AddressStateAllocated)},
+		}}},
 	}}
 
-	return i.st.runTransaction(ops)
+	if err = i.st.runTransaction(ops); err != nil {
+		return onAbort(
+			err,
+			errors.Errorf("already allocated or unavailable"),
+		)
+	}
+	i.doc.MachineId = machineId
+	i.doc.InterfaceId = interfaceId
+	i.doc.State = AddressStateAllocated
+	return nil
 }

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -18,104 +18,196 @@ type IPAddressSuite struct {
 
 var _ = gc.Suite(&IPAddressSuite{})
 
+func (s *IPAddressSuite) assertAddress(
+	c *gc.C,
+	ipAddr *state.IPAddress,
+	addr network.Address,
+	ipState state.AddressState,
+	machineId, ifaceId, subnetId string,
+) {
+	c.Assert(ipAddr, gc.NotNil)
+	c.Assert(ipAddr.MachineId(), gc.Equals, machineId)
+	c.Assert(ipAddr.InterfaceId(), gc.Equals, ifaceId)
+	c.Assert(ipAddr.SubnetId(), gc.Equals, subnetId)
+	c.Assert(ipAddr.Value(), gc.Equals, addr.Value)
+	c.Assert(ipAddr.Type(), gc.Equals, addr.Type)
+	c.Assert(ipAddr.Scope(), gc.Equals, addr.Scope)
+	c.Assert(ipAddr.State(), gc.Equals, ipState)
+	c.Assert(ipAddr.Address(), jc.DeepEquals, addr)
+	c.Assert(ipAddr.String(), gc.Equals, addr.String())
+}
+
 func (s *IPAddressSuite) TestAddIPAddress(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
-	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
-	c.Assert(err, jc.ErrorIsNil)
+	for i, test := range []string{"0.1.2.3", "2001:db8::1"} {
+		c.Logf("test %d: %q", i, test)
+		addr := network.NewAddress(test, network.ScopePublic)
+		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+		c.Assert(err, jc.ErrorIsNil)
+		s.assertAddress(c, ipAddr, addr, state.AddressStateUnknown, "", "", "foobar")
 
-	assertAddress := func(ipAddr *state.IPAddress) {
-		c.Assert(ipAddr.Value(), gc.Equals, "192.168.1.0")
-		c.Assert(ipAddr.SubnetId(), gc.Equals, "foobar")
-		c.Assert(ipAddr.Type(), gc.Equals, addr.Type)
-		c.Assert(ipAddr.Scope(), gc.Equals, network.ScopePublic)
-		c.Assert(ipAddr.State(), gc.Equals, state.AddressStateUnknown)
+		// verify the address was stored in the state
+		ipAddr, err = s.State.IPAddress(test)
+		c.Assert(err, jc.ErrorIsNil)
+		s.assertAddress(c, ipAddr, addr, state.AddressStateUnknown, "", "", "foobar")
 	}
-	assertAddress(ipAddr)
-
-	// verify the address was stored in the state
-	ipAddr, err = s.State.IPAddress("192.168.1.0")
-	c.Assert(err, jc.ErrorIsNil)
-	assertAddress(ipAddr)
 }
 
 func (s *IPAddressSuite) TestAddIPAddressInvalid(c *gc.C) {
 	addr := network.Address{Value: "foo"}
 	_, err := s.State.AddIPAddress(addr, "foobar")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, `invalid IP address "foo"`)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err, gc.ErrorMatches, `cannot add IP address "foo": address not valid`)
 }
 
 func (s *IPAddressSuite) TestAddIPAddressAlreadyExists(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	_, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddIPAddress(addr, "foobar")
-	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsAlreadyExists)
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+	c.Assert(err, gc.ErrorMatches,
+		`cannot add IP address "public:0.1.2.3": address already exists`,
+	)
 }
 
 func (s *IPAddressSuite) TestIPAddressNotFound(c *gc.C) {
-	_, err := s.State.IPAddress("192.168.1.0")
-	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
+	_, err := s.State.IPAddress("0.1.2.3")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, `IP address "0.1.2.3" not found`)
 }
 
-func (s *IPAddressSuite) TestIPAddressRemove(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
+func (s *IPAddressSuite) TestRemove(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = ipAddr.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.IPAddress("192.168.1.0")
-	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
+	// Doing it twice is also fine.
+	err = ipAddr.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.IPAddress("0.1.2.3")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, `IP address "0.1.2.3" not found`)
 }
 
-func (s *IPAddressSuite) TestIPAddressSetState(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
+func (s *IPAddressSuite) TestAddressStateString(c *gc.C) {
+	for i, test := range []struct {
+		ipState state.AddressState
+		expect  string
+	}{{
+		state.AddressStateUnknown,
+		"<unknown>",
+	}, {
+		state.AddressStateAllocated,
+		"allocated",
+	}, {
+		state.AddressStateUnavailable,
+		"unavailable",
+	}} {
+		c.Logf("test %d: %q -> %q", i, test.ipState, test.expect)
+		c.Check(test.ipState.String(), gc.Equals, test.expect)
+	}
+}
+
+func (s *IPAddressSuite) TestSetState(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+
+	for i, test := range []struct {
+		initial, changeTo state.AddressState
+		err               string
+	}{{
+		initial:  state.AddressStateUnknown,
+		changeTo: state.AddressStateUnknown,
+	}, {
+		initial:  state.AddressStateUnknown,
+		changeTo: state.AddressStateAllocated,
+	}, {
+		initial:  state.AddressStateUnknown,
+		changeTo: state.AddressStateUnavailable,
+	}, {
+		initial:  state.AddressStateAllocated,
+		changeTo: state.AddressStateAllocated,
+	}, {
+		initial:  state.AddressStateUnavailable,
+		changeTo: state.AddressStateUnavailable,
+	}, {
+		initial:  state.AddressStateAllocated,
+		changeTo: state.AddressStateUnknown,
+		err: `cannot set IP address "public:0.1.2.3" to state "<unknown>": ` +
+			`transition from "allocated" not valid`,
+	}, {
+		initial:  state.AddressStateUnavailable,
+		changeTo: state.AddressStateUnknown,
+		err: `cannot set IP address "public:0.1.2.3" to state "<unknown>": ` +
+			`transition from "unavailable" not valid`,
+	}, {
+		initial:  state.AddressStateAllocated,
+		changeTo: state.AddressStateUnavailable,
+		err: `cannot set IP address "public:0.1.2.3" to state "unavailable": ` +
+			`transition from "allocated" not valid`,
+	}, {
+		initial:  state.AddressStateUnavailable,
+		changeTo: state.AddressStateAllocated,
+		err: `cannot set IP address "public:0.1.2.3" to state "allocated": ` +
+			`transition from "unavailable" not valid`,
+	}} {
+		c.Logf("test %d: %q -> %q ok:%v", i, test.initial, test.changeTo, test.err == "")
+		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+		c.Check(err, jc.ErrorIsNil)
+
+		// Initially, all addresses have AddressStateUnknown.
+		c.Assert(ipAddr.State(), gc.Equals, state.AddressStateUnknown)
+
+		if test.initial != state.AddressStateUnknown {
+			err = ipAddr.SetState(test.initial)
+			c.Check(err, jc.ErrorIsNil)
+		}
+		err = ipAddr.SetState(test.changeTo)
+		if test.err != "" {
+			c.Check(err, gc.ErrorMatches, test.err)
+			c.Check(err, jc.Satisfies, errors.IsNotValid)
+			c.Check(ipAddr.Remove(), jc.ErrorIsNil)
+			continue
+		}
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(ipAddr.State(), gc.Equals, test.changeTo)
+		c.Check(ipAddr.Remove(), jc.ErrorIsNil)
+	}
+}
+
+func (s *IPAddressSuite) TestAllocateTo(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.State(), gc.Equals, state.AddressStateUnknown)
-
-	err = ipAddr.SetState(state.AddressStateAllocated)
-	c.Assert(err, jc.ErrorIsNil)
-
-	freshCopy, err := s.State.IPAddress("192.168.1.0")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(freshCopy.State(), gc.Equals, state.AddressStateAllocated)
-
-	// setting the state to the same state is permitted
-	err = ipAddr.SetState(state.AddressStateAllocated)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// setting back to unknown isn't permitted
-	err = ipAddr.SetState(state.AddressStateUnknown)
-	c.Assert(err, gc.ErrorMatches, `cannot set IP address .* to state "".*`)
-}
-
-func (s *IPAddressSuite) TestIPAddressAllocateTo(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
-	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.MachineId(), gc.Equals, "")
 	c.Assert(ipAddr.InterfaceId(), gc.Equals, "")
 
 	err = ipAddr.AllocateTo("wibble", "wobble")
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.State(), gc.Equals, state.AddressStateAllocated)
+	c.Assert(ipAddr.MachineId(), gc.Equals, "wibble")
+	c.Assert(ipAddr.InterfaceId(), gc.Equals, "wobble")
 
-	freshCopy, err := s.State.IPAddress("192.168.1.0")
+	freshCopy, err := s.State.IPAddress("0.1.2.3")
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(freshCopy.State(), gc.Equals, state.AddressStateAllocated)
 	c.Assert(freshCopy.MachineId(), gc.Equals, "wibble")
 	c.Assert(freshCopy.InterfaceId(), gc.Equals, "wobble")
 
-	err = ipAddr.SetState(state.AddressStateAllocated)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// allocating should now fail
-	err = ipAddr.AllocateTo("wobble", "wibble")
-	c.Assert(err, gc.ErrorMatches, `cannot allocate IP address .* to machine "wobble", interface "wibble".*`)
+	// allocating twice should fail.
+	err = ipAddr.AllocateTo("m", "i")
+	c.Assert(err, gc.ErrorMatches,
+		`cannot allocate IP address "public:0.1.2.3" to machine "m", interface "i": `+
+			`already allocated or unavailable`,
+	)
 }
 
-func (s *IPAddressSuite) TestIPAddressAddress(c *gc.C) {
-	addr := network.NewAddress("192.168.1.0", network.ScopePublic)
+func (s *IPAddressSuite) TestAddress(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.Address(), jc.DeepEquals, addr)

--- a/state/state.go
+++ b/state/state.go
@@ -1280,14 +1280,16 @@ func (st *State) AddService(
 	return svc, nil
 }
 
-// AddIPAddress creates and returns a new IP address
+// AddIPAddress creates and returns a new IP address. It can return an
+// error satisfying IsNotValid() or IsAlreadyExists() when the addr
+// does not contain a valid IP, or when addr is already added.
 func (st *State) AddIPAddress(addr network.Address, subnetid string) (ipaddress *IPAddress, err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot add IP address %v", addr.Value)
+	defer errors.DeferredAnnotatef(&err, "cannot add IP address %q", addr)
 
 	// This checks for a missing value as well as invalid values
 	ip := net.ParseIP(addr.Value)
 	if ip == nil {
-		return nil, errors.Errorf("invalid IP address %q", addr.Value)
+		return nil, errors.NotValidf("address")
 	}
 
 	addressID := st.docID(addr.Value)
@@ -1313,9 +1315,7 @@ func (st *State) AddIPAddress(addr network.Address, subnetid string) (ipaddress 
 	switch err {
 	case txn.ErrAborted:
 		if _, err = st.IPAddress(addr.Value); err == nil {
-			return nil, errors.AlreadyExistsf("IP address %q", addr.Value)
-		} else if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.AlreadyExistsf("address")
 		}
 	case nil:
 		return ipaddress, nil
@@ -1341,7 +1341,7 @@ func (st *State) IPAddress(value string) (*IPAddress, error) {
 
 // AddSubnet creates and returns a new subnet
 func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot add subnet %v", args.CIDR)
+	defer errors.DeferredAnnotatef(&err, "cannot add subnet %q", args.CIDR)
 
 	subnetID := st.docID(args.CIDR)
 	subDoc := subnetDoc{
@@ -1382,7 +1382,7 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 		if err == nil {
 			return subnet, nil
 		}
-		return nil, errors.Annotatef(err, "ProviderId not unique %q", args.ProviderId)
+		return nil, errors.Errorf("ProviderId %q not unique", args.ProviderId)
 	}
 	return nil, errors.Trace(err)
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -68,18 +68,24 @@ func (s *Subnet) ID() string {
 	return s.doc.DocID
 }
 
-// EnsureDead sets the Life of the subnet to Dead
+// String implements fmt.Stringer.
+func (s *Subnet) String() string {
+	return s.CIDR()
+}
+
+// GoString implements fmt.GoStringer.
+func (s *Subnet) GoString() string {
+	return s.String()
+}
+
+// EnsureDead sets the Life of the subnet to Dead, if it's Alive. It
+// does nothing otherwise.
 func (s *Subnet) EnsureDead() (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot destroy subnet %v", s)
+	defer errors.DeferredAnnotatef(&err, "cannot set subnet %q to dead", s)
+
 	if s.doc.Life == Dead {
 		return nil
 	}
-
-	defer func() {
-		if err == nil {
-			s.doc.Life = Dead
-		}
-	}()
 
 	ops := []txn.Op{{
 		C:      subnetsC,
@@ -87,13 +93,19 @@ func (s *Subnet) EnsureDead() (err error) {
 		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 		Assert: isAliveDoc,
 	}}
-	return s.st.runTransaction(ops)
+	if err = s.st.runTransaction(ops); err != nil {
+		// Ignore ErrAborted if it happens, otherwise return err.
+		return onAbort(err, nil)
+	}
+	s.doc.Life = Dead
+	return nil
 }
 
 // Remove removes a dead subnet. If the subnet is not dead it returns an error.
 // It also removes any IP addresses associated with the subnet.
 func (s *Subnet) Remove() (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot destroy subnet %v", s)
+	defer errors.DeferredAnnotatef(&err, "cannot remove subnet %q", s)
+
 	if s.doc.Life != Dead {
 		return errors.New("subnet is not dead")
 	}
@@ -112,6 +124,9 @@ func (s *Subnet) Remove() (err error) {
 			Id:     doc.DocID,
 			Remove: true,
 		})
+	}
+	if err = iter.Close(); err != nil {
+		return errors.Annotate(err, "cannot read addresses")
 	}
 
 	ops = append(ops, txn.Op{
@@ -162,7 +177,7 @@ func (s *Subnet) Validate() error {
 	if s.doc.CIDR != "" {
 		_, mask, err = net.ParseCIDR(s.doc.CIDR)
 		if err != nil {
-			return errors.Annotatef(err, "invalid CIDR")
+			return errors.Trace(err)
 		}
 	} else {
 		return errors.Errorf("missing CIDR")
@@ -205,16 +220,17 @@ func (s *Subnet) Refresh() error {
 
 	err := subnets.FindId(s.doc.DocID).One(&s.doc)
 	if err == mgo.ErrNotFound {
-		return errors.NotFoundf("subnet %v", s)
+		return errors.NotFoundf("subnet %q", s)
 	}
 	if err != nil {
-		return errors.Errorf("cannot refresh subnet %v: %v", s, err)
+		return errors.Errorf("cannot refresh subnet %q: %v", s, err)
 	}
 	return nil
 }
 
 // PickNewAddress returns a new IPAddress that isn't in use for the subnet.
 // The address starts with AddressStateUnknown, for later allocation.
+// This will fail if the subnet is not alive.
 func (s *Subnet) PickNewAddress() (*IPAddress, error) {
 	for {
 		addr, err := s.attemptToPickNewAddress()
@@ -227,27 +243,31 @@ func (s *Subnet) PickNewAddress() (*IPAddress, error) {
 	}
 }
 
-// attemptToPickNewAddress will try to pick a new address. It can fail with
-// AlreadyExists due to a race condition between fetching the list of addresses
-// already in use and allocating a new one. It is called in a loop by
+// attemptToPickNewAddress will try to pick a new address. It can fail
+// with AlreadyExists due to a race condition between fetching the
+// list of addresses already in use and allocating a new one. If the
+// subnet is not alive, it will also fail. It is called in a loop by
 // PickNewAddress until it gets one or there are no more available!
 func (s *Subnet) attemptToPickNewAddress() (*IPAddress, error) {
+	if s.doc.Life != Alive {
+		return nil, errors.Errorf("cannot pick address: subnet %q is not alive", s)
+	}
 	high := s.doc.AllocatableIPHigh
 	low := s.doc.AllocatableIPLow
 	if low == "" || high == "" {
-		return nil, errors.Errorf("no allocatable IP addresses for subnet %v", s)
+		return nil, errors.Errorf("no allocatable IP addresses for subnet %q", s)
 	}
 
 	// convert low and high to decimals as the bounds
 	lowDecimal, err := network.IPv4ToDecimal(net.ParseIP(low))
 	if err != nil {
 		// these addresses are validated so should never happen
-		return nil, errors.Annotatef(err, "invalid AllocatableIPLow %q for subnet %v", low, s)
+		return nil, errors.Annotatef(err, "invalid AllocatableIPLow %q for subnet %q", low, s)
 	}
 	highDecimal, err := network.IPv4ToDecimal(net.ParseIP(high))
 	if err != nil {
 		// these addresses are validated so should never happen
-		return nil, errors.Annotatef(err, "invalid AllocatableIPHigh %q for subnet %v", high, s)
+		return nil, errors.Annotatef(err, "invalid AllocatableIPHigh %q for subnet %q", high, s)
 	}
 
 	// find all addresses for this subnet and convert them to decimals
@@ -268,12 +288,15 @@ func (s *Subnet) attemptToPickNewAddress() (*IPAddress, error) {
 		}
 		allocated[value] = true
 	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Annotatef(err, "cannot read addresses of subnet %q", s)
+	}
 
 	// Check that the number of addresses in use is less than the
 	// difference between low and high - i.e. we haven't exhausted all
 	// possible addresses.
 	if len(allocated) >= int(highDecimal-lowDecimal)+1 {
-		return nil, errors.Errorf("allocatable IP addresses exhausted for subnet %v", s)
+		return nil, errors.Errorf("allocatable IP addresses exhausted for subnet %q", s)
 	}
 
 	// pick a new random decimal between the low and high bounds that


### PR DESCRIPTION
This is a prerequisite 2 of 2 for implementing the server-side
PrepareContainerInterfaceInfo() provisioner API method to allow
allocating static IPs for containers at provisioning time.
Based on #1631, which needs to land first.

Notable changes:
 * Added params.NetworkConfig.ProviderSubnetId field, needed to specify
 which subnet a NIC is on.
 * All environ.Networking methods implemented by the dummy
 provider (AllocateAddress, ReleaseAddress, SupportsAddressAllocation,
 Subnets, and NetworkInterfaces) now support inducing errors using the
 "broken" environment setting (as usual for other dummy methods).
 * The "canned" results returned by Subnets() and NetworkInterfaces()
 are more consistent and complete.
 * The internal operations (e.g. OpSubnets, OpAllocateAddress, etc.)
 sent over the dummy provider's channel are consistent and complete.
 * Subnets() and NetworkInterfaces() support special instance id
 arguments to tweak the returned results, allowing detailed testing.
 * Filtering support added where needed.
 * Better tests and error messages / logging.

NOTE: Please, ignore all changes outside provider/dummy/ and apiserver/params/ - they come from the parent PR - RB link below has the correct diff.

(Review request: http://reviews.vapour.ws/r/962/)