### PR TITLE
Ensure cloud-utils and cloud-image-utils are installed from precise cloud archive 

### DIFF
--- a/cloudinit/options.go
+++ b/cloudinit/options.go
@@ -145,7 +145,11 @@ func (cfg *Config) AddPackage(name string) {
 // the given release, passed to apt-get with the --target-release
 // argument.
 func (cfg *Config) AddPackageFromTargetRelease(packageName, targetRelease string) {
-	cfg.AddPackage(fmt.Sprintf("--target-release '%s' '%s'", targetRelease, packageName))
+	if targetRelease == "" {
+		cfg.AddPackage(packageName)
+	} else {
+		cfg.AddPackage(fmt.Sprintf("--target-release '%s' '%s'", targetRelease, packageName))
+	}
 }
 
 // Packages returns a list of packages that will be

--- a/cloudinit/options.go
+++ b/cloudinit/options.go
@@ -145,11 +145,7 @@ func (cfg *Config) AddPackage(name string) {
 // the given release, passed to apt-get with the --target-release
 // argument.
 func (cfg *Config) AddPackageFromTargetRelease(packageName, targetRelease string) {
-	if targetRelease == "" {
-		cfg.AddPackage(packageName)
-	} else {
-		cfg.AddPackage(fmt.Sprintf("--target-release '%s' '%s'", targetRelease, packageName))
-	}
+	cfg.AddPackage(fmt.Sprintf("--target-release '%s' '%s'", targetRelease, packageName))
 }
 
 // Packages returns a list of packages that will be

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -67,7 +67,7 @@ func templateUserData(
 	if enablePackageUpdates {
 		cloudinit.MaybeAddCloudArchiveCloudTools(config, series)
 	}
-	cloudinit.AddAptCommands(aptProxy, aptMirror, config, enablePackageUpdates, enableOSUpgrades)
+	cloudinit.AddAptCommands(series, aptProxy, aptMirror, config, enablePackageUpdates, enableOSUpgrades)
 	config.AddScripts(
 		fmt.Sprintf(
 			"printf '%%s\n' %s > %s",

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -209,16 +209,21 @@ func AddAptCommands(
 	// If we're not doing an update, adding these packages is
 	// meaningless.
 	if addUpdateScripts {
-		c.AddPackage("curl")
-		c.AddPackage("cpu-checker")
-		// TODO(axw) 2014-07-02 #1277359
-		// Don't install bridge-utils in cloud-init;
-		// leave it to the networker worker.
-		c.AddPackage("bridge-utils")
-		c.AddPackage("rsyslog-gnutls")
+		requiredPackages := []string{
+			"curl",
+			"cpu-checker",
+			// TODO(axw) 2014-07-02 #1277359
+			// Don't install bridge-utils in cloud-init;
+			// leave it to the networker worker.
+			"bridge-utils",
+			"rsyslog-gnutls",
+			"cloud-utils",
+			"cloud-image-utils",
+		}
 
-		// These cloud packages need to possibly come from the cloud-tools archive for precise.
-		aptGetInstallCommandList := apt.GetPreparePackages([]string{"cloud-utils", "cloud-image-utils"}, series)
+		// These cloud packages need to possibly come from the correct repo.
+		// For precise, that might require an explicit --target-release parameter.
+		aptGetInstallCommandList := apt.GetPreparePackages(requiredPackages, series)
 		for _, cmds := range aptGetInstallCommandList {
 			c.AddPackage(strings.Join(cmds, " "))
 		}

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -221,7 +221,7 @@ func AddAptCommands(
 			"cloud-image-utils",
 		}
 
-		// These cloud packages need to possibly come from the correct repo.
+		// The required packages need to come from the correct repo.
 		// For precise, that might require an explicit --target-release parameter.
 		aptGetInstallCommandList := apt.GetPreparePackages(requiredPackages, series)
 		for _, cmds := range aptGetInstallCommandList {

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 
@@ -751,10 +752,12 @@ func checkPackage(c *gc.C, x map[interface{}]interface{}, pkg string, match bool
 	found := false
 	for _, p0 := range pkgs {
 		p := p0.(string)
-		hasTargetRelease := strings.Contains(p, "--target-release")
-		hasQuotedPkg := strings.Contains(p, "'"+pkg+"'")
-		if p == pkg || (hasTargetRelease && hasQuotedPkg) {
+		// p might be a space separate list of packages eg 'foo bar qed' so split them up
+		manyPkgs := set.NewStrings(strings.Split(p, " ")...)
+		hasPkg := manyPkgs.Contains(pkg)
+		if p == pkg || hasPkg {
 			found = true
+			break
 		}
 	}
 	switch {

--- a/environs/cloudinit/cloudinit_ubuntu.go
+++ b/environs/cloudinit/cloudinit_ubuntu.go
@@ -131,6 +131,7 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 	}
 
 	AddAptCommands(
+		w.mcfg.Series,
 		w.mcfg.AptProxySettings,
 		w.mcfg.AptMirror,
 		w.conf,

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 	"launchpad.net/goamz/aws"
@@ -973,8 +974,12 @@ func CheckPackage(c *gc.C, userDataMap map[interface{}]interface{}, pkg string, 
 	found := false
 	for _, p0 := range pkgs {
 		p := p0.(string)
-		if p == pkg {
+		// p might be a space separate list of packages eg 'foo bar qed' so split them up
+		manyPkgs := set.NewStrings(strings.Split(p, " ")...)
+		hasPkg := manyPkgs.Contains(pkg)
+		if p == pkg || hasPkg {
 			found = true
+			break
 		}
 	}
 	switch {


### PR DESCRIPTION
For precise, cloud-utils and cloud-image-utils need to be installed from the cloud tools archive.
There was some existing apt infrastructure which could be tweaked to do what's needed.

Tested on AWS with precise, trusty and utopic.

(Review request: http://reviews.vapour.ws/r/963/)