### PR TITLE
Operations changed over to new block implementation.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -814,8 +814,8 @@ func (c *Client) UploadTools(r io.Reader, vers version.Binary, additionalSeries 
 	}
 	if resp.StatusCode != http.StatusOK {
 		message := fmt.Sprintf("%s", bytes.TrimSpace(body))
-		if resp.StatusCode == http.StatusBadRequest && strings.Contains(message, "The operation has been blocked.") {
-			// Operation Blocked errors must contain correct Error Code
+		if resp.StatusCode == http.StatusBadRequest && strings.Contains(message, params.CodeOperationBlocked) {
+			// Operation Blocked errors must contain correct error code and message.
 			return nil, &params.Error{Code: params.CodeOperationBlocked, Message: message}
 		}
 		return nil, errors.Errorf("tools upload failed: %v (%s)", resp.StatusCode, message)

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	asct "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -32,6 +33,12 @@ func TestAll(t *stdtesting.T) {
 
 type baseSuite struct {
 	testing.JujuConnSuite
+	blockSwitch *asct.BlockSwitch
+}
+
+func (s *baseSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.blockSwitch = asct.NewBlockSwitch(s.APIState)
 }
 
 var _ = gc.Suite(&baseSuite{})

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -1120,14 +1120,7 @@ func (c *Client) EnvironmentGet() (params.EnvironmentConfigResults, error) {
 // set-environment CLI command.
 func (c *Client) EnvironmentSet(args params.EnvironmentSet) error {
 	if err := c.check.ChangeAllowed(); err != nil {
-		// if trying to change value for block-changes, we would want to let it go.
-		if v, present := args.Config[config.PreventAllChangesKey]; !present {
-			return errors.Trace(err)
-		} else if block, ok := v.(bool); ok && block {
-			// still want to block changes
-			return errors.Trace(err)
-		}
-		// else if block is false, we want to unblock changes
+		return errors.Trace(err)
 	}
 	// Make sure we don't allow changing agent-version.
 	checkAgentVersion := func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
+	asct "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
@@ -123,11 +124,11 @@ func (s *serverSuite) TestBlockEnsureAvailabilityDeprecated(c *gc.C) {
 	_, err := s.State.AddMachine("quantal", state.JobManageEnviron)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockEnsureAvailabilityDeprecated")
 
 	arg := params.StateServersSpecs{[]params.StateServersSpec{{NumStateServers: 3}}}
 	results, err := s.client.EnsureAvailability(arg)
-	c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+	asct.AssertErrorBlocked(c, err, "TestBlockEnsureAvailabilityDeprecated")
 	c.Assert(results.Results, gc.HasLen, 0)
 
 	machines, err := s.State.AllMachines() //there
@@ -326,13 +327,13 @@ func (s *serverSuite) TestSetEnvironAgentVersion(c *gc.C) {
 	c.Assert(agentVersion, gc.Equals, "9.8.7")
 }
 
-func (s *serverSuite) assertSetEnvironAgentVersionBlocked(c *gc.C, blocked bool) {
+func (s *serverSuite) assertSetEnvironAgentVersionBlocked(c *gc.C, blocked bool, msg string) {
 	args := params.SetEnvironAgentVersion{
 		Version: version.MustParse("9.8.7"),
 	}
 	err := s.client.SetEnvironAgentVersion(args)
 	if blocked {
-		c.Assert(errors.Cause(err), gc.Equals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		envConfig, err := s.State.EnvironConfig()
@@ -344,18 +345,18 @@ func (s *serverSuite) assertSetEnvironAgentVersionBlocked(c *gc.C, blocked bool)
 }
 
 func (s *serverSuite) TestBlockDestroySetEnvironAgentVersion(c *gc.C) {
-	s.blockDestroyEnvironment(c)
-	s.assertSetEnvironAgentVersionBlocked(c, false)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroySetEnvironAgentVersion")
+	s.assertSetEnvironAgentVersionBlocked(c, false, "TestBlockDestroySetEnvironAgentVersion")
 }
 
 func (s *serverSuite) TestBlockRemoveSetEnvironAgentVersion(c *gc.C) {
-	s.blockRemoveObject(c)
-	s.assertSetEnvironAgentVersionBlocked(c, false)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveSetEnvironAgentVersion")
+	s.assertSetEnvironAgentVersionBlocked(c, false, "TestBlockRemoveSetEnvironAgentVersion")
 }
 
 func (s *serverSuite) TestBlockChangesSetEnvironAgentVersion(c *gc.C) {
-	s.blockAllChanges(c)
-	s.assertSetEnvironAgentVersionBlocked(c, true)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesSetEnvironAgentVersion")
+	s.assertSetEnvironAgentVersionBlocked(c, true, "TestBlockChangesSetEnvironAgentVersion")
 }
 
 func (s *serverSuite) TestAbortCurrentUpgrade(c *gc.C) {
@@ -385,11 +386,11 @@ func (s *serverSuite) TestAbortCurrentUpgrade(c *gc.C) {
 	c.Assert(isUpgrading, jc.IsFalse)
 }
 
-func (s *serverSuite) assertAbortCurrentUpgradeBlocked(c *gc.C, blocked bool) {
+func (s *serverSuite) assertAbortCurrentUpgradeBlocked(c *gc.C, blocked bool, msg string) {
 	err := s.client.AbortCurrentUpgrade()
 
 	if blocked {
-		c.Assert(errors.Cause(err), gc.Equals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		isUpgrading, err := s.State.IsUpgrading()
@@ -419,20 +420,20 @@ func (s *serverSuite) setupAbortCurrentUpgradeBlocked(c *gc.C) {
 
 func (s *serverSuite) TestBlockDestroyAbortCurrentUpgrade(c *gc.C) {
 	s.setupAbortCurrentUpgradeBlocked(c)
-	s.blockDestroyEnvironment(c)
-	s.assertAbortCurrentUpgradeBlocked(c, false)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyAbortCurrentUpgrade")
+	s.assertAbortCurrentUpgradeBlocked(c, false, "TestBlockDestroyAbortCurrentUpgrade")
 }
 
 func (s *serverSuite) TestBlockRemoveAbortCurrentUpgrade(c *gc.C) {
 	s.setupAbortCurrentUpgradeBlocked(c)
-	s.blockRemoveObject(c)
-	s.assertAbortCurrentUpgradeBlocked(c, false)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveAbortCurrentUpgrade")
+	s.assertAbortCurrentUpgradeBlocked(c, false, "TestBlockRemoveAbortCurrentUpgrade")
 }
 
 func (s *serverSuite) TestBlockChangesAbortCurrentUpgrade(c *gc.C) {
 	s.setupAbortCurrentUpgradeBlocked(c)
-	s.blockAllChanges(c)
-	s.assertAbortCurrentUpgradeBlocked(c, true)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesAbortCurrentUpgrade")
+	s.assertAbortCurrentUpgradeBlocked(c, true, "TestBlockChangesAbortCurrentUpgrade")
 }
 
 var _ = gc.Suite(&clientSuite{})
@@ -523,14 +524,14 @@ func (s *clientSuite) TestClientServiceSet(c *gc.C) {
 	})
 }
 
-func (s *serverSuite) assertServiceSetBlocked(c *gc.C, blocked bool, dummy *state.Service) {
+func (s *serverSuite) assertServiceSetBlocked(c *gc.C, dummy *state.Service, blocked bool, msg string) {
 	err := s.client.ServiceSet(params.ServiceSet{
 		ServiceName: "dummy",
 		Options: map[string]string{
 			"title":    "foobar",
 			"username": validSetTestValue}})
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		settings, err := dummy.ConfigSettings()
@@ -543,20 +544,20 @@ func (s *serverSuite) assertServiceSetBlocked(c *gc.C, blocked bool, dummy *stat
 }
 func (s *serverSuite) TestBlockDestroyServiceSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockDestroyEnvironment(c)
-	s.assertServiceSetBlocked(c, false, dummy)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServiceSet")
+	s.assertServiceSetBlocked(c, dummy, false, "TestBlockDestroyServiceSet")
 }
 
 func (s *serverSuite) TestBlockRemoveServiceSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockRemoveObject(c)
-	s.assertServiceSetBlocked(c, false, dummy)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServiceSet")
+	s.assertServiceSetBlocked(c, dummy, false, "TestBlockRemoveServiceSet")
 }
 
 func (s *serverSuite) TestBlockChangesServiceSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockAllChanges(c)
-	s.assertServiceSetBlocked(c, true, dummy)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesServiceSet")
+	s.assertServiceSetBlocked(c, dummy, true, "TestBlockChangesServiceSet")
 }
 
 func (s *clientSuite) TestClientServerUnset(c *gc.C) {
@@ -602,13 +603,13 @@ func (s *serverSuite) setupServerUnsetBlocked(c *gc.C) *state.Service {
 	return dummy
 }
 
-func (s *serverSuite) assertServerUnsetBlocked(c *gc.C, blocked bool, dummy *state.Service) {
+func (s *serverSuite) assertServerUnsetBlocked(c *gc.C, dummy *state.Service, blocked bool, msg string) {
 	err := s.client.ServiceUnset(params.ServiceUnset{
 		ServiceName: "dummy",
 		Options:     []string{"username"},
 	})
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		settings, err := dummy.ConfigSettings()
@@ -621,20 +622,20 @@ func (s *serverSuite) assertServerUnsetBlocked(c *gc.C, blocked bool, dummy *sta
 
 func (s *serverSuite) TestBlockDestroyServerUnset(c *gc.C) {
 	dummy := s.setupServerUnsetBlocked(c)
-	s.blockDestroyEnvironment(c)
-	s.assertServerUnsetBlocked(c, false, dummy)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServerUnset")
+	s.assertServerUnsetBlocked(c, dummy, false, "TestBlockDestroyServerUnset")
 }
 
 func (s *serverSuite) TestBlockRemoveServerUnset(c *gc.C) {
 	dummy := s.setupServerUnsetBlocked(c)
-	s.blockRemoveObject(c)
-	s.assertServerUnsetBlocked(c, false, dummy)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServerUnset")
+	s.assertServerUnsetBlocked(c, dummy, false, "TestBlockRemoveServerUnset")
 }
 
 func (s *serverSuite) TestBlockChangesServerUnset(c *gc.C) {
 	dummy := s.setupServerUnsetBlocked(c)
-	s.blockAllChanges(c)
-	s.assertServerUnsetBlocked(c, true, dummy)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesServerUnset")
+	s.assertServerUnsetBlocked(c, dummy, true, "TestBlockChangesServerUnset")
 }
 
 func (s *clientSuite) TestClientServiceSetYAML(c *gc.C) {
@@ -658,10 +659,10 @@ func (s *clientSuite) TestClientServiceSetYAML(c *gc.C) {
 	})
 }
 
-func (s *clientSuite) assertServiceSetYAMLBlocked(c *gc.C, blocked bool, dummy *state.Service) {
+func (s *clientSuite) assertServiceSetYAMLBlocked(c *gc.C, dummy *state.Service, blocked bool, msg string) {
 	err := s.APIState.Client().ServiceSetYAML("dummy", "dummy:\n  title: foobar\n  username: user name\n")
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		settings, err := dummy.ConfigSettings()
@@ -675,20 +676,20 @@ func (s *clientSuite) assertServiceSetYAMLBlocked(c *gc.C, blocked bool, dummy *
 
 func (s *clientSuite) TestBlockDestroyServiceSetYAML(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockDestroyEnvironment(c)
-	s.assertServiceSetYAMLBlocked(c, false, dummy)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServiceSetYAML")
+	s.assertServiceSetYAMLBlocked(c, dummy, false, "TestBlockDestroyServiceSetYAML")
 }
 
 func (s *clientSuite) TestBlockRemoveServiceSetYAML(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockRemoveObject(c)
-	s.assertServiceSetYAMLBlocked(c, false, dummy)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServiceSetYAML")
+	s.assertServiceSetYAMLBlocked(c, dummy, false, "TestBlockRemoveServiceSetYAML")
 }
 
 func (s *clientSuite) TestBlockChangesServiceSetYAML(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockAllChanges(c)
-	s.assertServiceSetYAMLBlocked(c, true, dummy)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesServiceSetYAML")
+	s.assertServiceSetYAMLBlocked(c, dummy, true, "TestBlockChangesServiceSetYAML")
 }
 
 var clientAddServiceUnitsTests = []struct {
@@ -750,10 +751,10 @@ func (s *clientSuite) TestClientAddServiceUnits(c *gc.C) {
 	c.Assert(assignedMachine, gc.Equals, "0")
 }
 
-func (s *clientSuite) assertAddServiceUnitsBlocked(c *gc.C, blocked bool) {
+func (s *clientSuite) assertAddServiceUnitsBlocked(c *gc.C, blocked bool, msg string) {
 	units, err := s.APIState.Client().AddServiceUnits("dummy", 3, "")
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(units, gc.DeepEquals, []string{"dummy/0", "dummy/1", "dummy/2"})
@@ -769,20 +770,20 @@ func (s *clientSuite) assertAddServiceUnitsBlocked(c *gc.C, blocked bool) {
 
 func (s *clientSuite) TestBlockDestroyAddServiceUnits(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockDestroyEnvironment(c)
-	s.assertAddServiceUnitsBlocked(c, false)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyAddServiceUnits")
+	s.assertAddServiceUnitsBlocked(c, false, "TestBlockDestroyAddServiceUnits")
 }
 
 func (s *clientSuite) TestBlockRemoveAddServiceUnits(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockRemoveObject(c)
-	s.assertAddServiceUnitsBlocked(c, false)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveAddServiceUnits")
+	s.assertAddServiceUnitsBlocked(c, false, "TestBlockRemoveAddServiceUnits")
 }
 
 func (s *clientSuite) TestBlockChangeAddServiceUnits(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	s.blockAllChanges(c)
-	s.assertAddServiceUnitsBlocked(c, true)
+	s.blockSwitch.AllChanges(c, "TestBlockChangeAddServiceUnits")
+	s.assertAddServiceUnitsBlocked(c, true, "TestBlockChangeAddServiceUnits")
 }
 
 func (s *clientSuite) TestClientAddUnitToMachineNotFound(c *gc.C) {
@@ -1061,12 +1062,12 @@ func (s *clientSuite) setupServiceExpose(c *gc.C) {
 	c.Assert(svcs[1].IsExposed(), jc.IsTrue)
 }
 
-func (s *clientSuite) assertServiceExposeBlocked(c *gc.C, blocked bool) {
+func (s *clientSuite) assertServiceExposeBlocked(c *gc.C, blocked bool, msg string) {
 	for i, t := range serviceExposeTests {
 		c.Logf("test %d. %s", i, t.about)
 		err := s.APIState.Client().ServiceExpose(t.service)
 		if blocked {
-			c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+			asct.AssertErrorBlocked(c, err, msg)
 		} else {
 			if t.err != "" {
 				c.Assert(err, gc.ErrorMatches, t.err)
@@ -1082,20 +1083,20 @@ func (s *clientSuite) assertServiceExposeBlocked(c *gc.C, blocked bool) {
 
 func (s *clientSuite) TestBlockDestroyServiceExpose(c *gc.C) {
 	s.setupServiceExpose(c)
-	s.blockDestroyEnvironment(c)
-	s.assertServiceExposeBlocked(c, false)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServiceExpose")
+	s.assertServiceExposeBlocked(c, false, "TestBlockDestroyServiceExpose")
 }
 
 func (s *clientSuite) TestBlockRemoveServiceExpose(c *gc.C) {
 	s.setupServiceExpose(c)
-	s.blockRemoveObject(c)
-	s.assertServiceExposeBlocked(c, false)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServiceExpose")
+	s.assertServiceExposeBlocked(c, false, "TestBlockRemoveServiceExpose")
 }
 
 func (s *clientSuite) TestBlockChangesServiceExpose(c *gc.C) {
 	s.setupServiceExpose(c)
-	s.blockAllChanges(c)
-	s.assertServiceExposeBlocked(c, true)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesServiceExpose")
+	s.assertServiceExposeBlocked(c, true, "TestBlockChangesServiceExpose")
 }
 
 var serviceUnexposeTests = []struct {
@@ -1154,10 +1155,10 @@ func (s *clientSuite) setupServiceUnexpose(c *gc.C) *state.Service {
 	return svc
 }
 
-func (s *clientSuite) assertServiceUnexposeBlocked(c *gc.C, blocked bool, svc *state.Service) {
+func (s *clientSuite) assertServiceUnexposeBlocked(c *gc.C, svc *state.Service, blocked bool, msg string) {
 	err := s.APIState.Client().ServiceUnexpose("dummy-service")
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		svc.Refresh()
@@ -1169,20 +1170,20 @@ func (s *clientSuite) assertServiceUnexposeBlocked(c *gc.C, blocked bool, svc *s
 
 func (s *clientSuite) TestBlockDestroyServiceUnexpose(c *gc.C) {
 	svc := s.setupServiceUnexpose(c)
-	s.blockDestroyEnvironment(c)
-	s.assertServiceUnexposeBlocked(c, false, svc)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServiceUnexpose")
+	s.assertServiceUnexposeBlocked(c, svc, false, "TestBlockDestroyServiceUnexpose")
 }
 
 func (s *clientSuite) TestBlockRemoveServiceUnexpose(c *gc.C) {
 	svc := s.setupServiceUnexpose(c)
-	s.blockRemoveObject(c)
-	s.assertServiceUnexposeBlocked(c, false, svc)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServiceUnexpose")
+	s.assertServiceUnexposeBlocked(c, svc, false, "TestBlockRemoveServiceUnexpose")
 }
 
 func (s *clientSuite) TestBlockChangesServiceUnexpose(c *gc.C) {
 	svc := s.setupServiceUnexpose(c)
-	s.blockAllChanges(c)
-	s.assertServiceUnexposeBlocked(c, true, svc)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesServiceUnexpose")
+	s.assertServiceUnexposeBlocked(c, svc, true, "TestBlockChangesServiceUnexpose")
 }
 
 var serviceDestroyTests = []struct {
@@ -1347,10 +1348,10 @@ func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
 	return u
 }
 
-func (s *clientSuite) assertResolvedBlocked(c *gc.C, blocked bool, u *state.Unit) {
+func (s *clientSuite) assertResolvedBlocked(c *gc.C, u *state.Unit, blocked bool, msg string) {
 	err := s.APIState.Client().Resolved("wordpress/0", true)
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		// Freshen the unit's state.
@@ -1365,20 +1366,20 @@ func (s *clientSuite) assertResolvedBlocked(c *gc.C, blocked bool, u *state.Unit
 
 func (s *clientSuite) TestBlockDestroyUnitResolved(c *gc.C) {
 	u := s.setupResolved(c)
-	s.blockDestroyEnvironment(c)
-	s.assertResolvedBlocked(c, false, u)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyUnitResolved")
+	s.assertResolvedBlocked(c, u, false, "TestBlockDestroyUnitResolved")
 }
 
 func (s *clientSuite) TestBlockRemoveUnitResolved(c *gc.C) {
 	u := s.setupResolved(c)
-	s.blockRemoveObject(c)
-	s.assertResolvedBlocked(c, false, u)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveUnitResolved")
+	s.assertResolvedBlocked(c, u, false, "TestBlockRemoveUnitResolved")
 }
 
 func (s *clientSuite) TestBlockChangeUnitResolved(c *gc.C) {
 	u := s.setupResolved(c)
-	s.blockAllChanges(c)
-	s.assertResolvedBlocked(c, true, u)
+	s.blockSwitch.AllChanges(c, "TestBlockChangeUnitResolved")
+	s.assertResolvedBlocked(c, u, true, "TestBlockChangeUnitResolved")
 }
 
 func (s *clientSuite) TestClientServiceDeployCharmErrors(c *gc.C) {
@@ -1525,14 +1526,14 @@ func (s *clientSuite) setupServiceDeploy(c *gc.C, args string) (*charm.URL, char
 	return curl, bundle, cons
 }
 
-func (s *clientSuite) assertServiceDeployWithNetworksBlocked(c *gc.C, blocked bool, curl *charm.URL, bundle charm.Charm, cons constraints.Value) {
+func (s *clientSuite) assertServiceDeployWithNetworksBlocked(c *gc.C, blocked bool, msg string, curl *charm.URL, bundle charm.Charm, cons constraints.Value) {
 	err := s.APIState.Client().ServiceDeployWithNetworks(
 		curl.String(), "service", 3, "", cons, "",
 		[]string{"network-net1", "network-net2"},
 		nil,
 	)
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		service := s.assertPrincipalDeployed(c, "service", curl, false, bundle, cons)
@@ -1547,20 +1548,20 @@ func (s *clientSuite) assertServiceDeployWithNetworksBlocked(c *gc.C, blocked bo
 
 func (s *clientSuite) TestBlockDestroyServiceDeployWithNetworks(c *gc.C) {
 	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
-	s.blockDestroyEnvironment(c)
-	s.assertServiceDeployWithNetworksBlocked(c, false, curl, bundle, cons)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServiceDeployWithNetworks")
+	s.assertServiceDeployWithNetworksBlocked(c, false, "TestBlockDestroyServiceDeployWithNetworks", curl, bundle, cons)
 }
 
 func (s *clientSuite) TestBlockRemoveServiceDeployWithNetworks(c *gc.C) {
 	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
-	s.blockRemoveObject(c)
-	s.assertServiceDeployWithNetworksBlocked(c, false, curl, bundle, cons)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServiceDeployWithNetworks")
+	s.assertServiceDeployWithNetworksBlocked(c, false, "TestBlockRemoveServiceDeployWithNetworks", curl, bundle, cons)
 }
 
 func (s *clientSuite) TestBlockChangeServiceDeployWithNetworks(c *gc.C) {
 	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
-	s.blockAllChanges(c)
-	s.assertServiceDeployWithNetworksBlocked(c, true, curl, bundle, cons)
+	s.blockSwitch.AllChanges(c, "TestBlockChangeServiceDeployWithNetworks")
+	s.assertServiceDeployWithNetworksBlocked(c, true, "TestBlockChangeServiceDeployWithNetworks", curl, bundle, cons)
 }
 
 func (s *clientSuite) assertPrincipalDeployed(c *gc.C, serviceName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Service {
@@ -1603,12 +1604,12 @@ func (s *clientSuite) TestClientServiceDeployPrincipal(c *gc.C) {
 	s.assertPrincipalDeployed(c, "service", curl, false, bundle, mem4g)
 }
 
-func (s *clientSuite) assertServiceDeployPrincipalBlocked(c *gc.C, blocked bool, curl *charm.URL, bundle charm.Charm, mem4g constraints.Value) {
+func (s *clientSuite) assertServiceDeployPrincipalBlocked(c *gc.C, blocked bool, msg string, curl *charm.URL, bundle charm.Charm, mem4g constraints.Value) {
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service", 3, "", mem4g, "",
 	)
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertPrincipalDeployed(c, "service", curl, false, bundle, mem4g)
@@ -1617,20 +1618,20 @@ func (s *clientSuite) assertServiceDeployPrincipalBlocked(c *gc.C, blocked bool,
 
 func (s *clientSuite) TestBlockDestroyServiceDeployPrincipal(c *gc.C) {
 	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G")
-	s.blockDestroyEnvironment(c)
-	s.assertServiceDeployPrincipalBlocked(c, false, curl, bundle, cons)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServiceDeployPrincipal")
+	s.assertServiceDeployPrincipalBlocked(c, false, "TestBlockDestroyServiceDeployPrincipal", curl, bundle, cons)
 }
 
 func (s *clientSuite) TestBlockRemoveServiceDeployPrincipal(c *gc.C) {
 	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G")
-	s.blockRemoveObject(c)
-	s.assertServiceDeployPrincipalBlocked(c, false, curl, bundle, cons)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServiceDeployPrincipal")
+	s.assertServiceDeployPrincipalBlocked(c, false, "TestBlockRemoveServiceDeployPrincipal", curl, bundle, cons)
 }
 
 func (s *clientSuite) TestBlockChangesServiceDeployPrincipal(c *gc.C) {
 	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G")
-	s.blockAllChanges(c)
-	s.assertServiceDeployPrincipalBlocked(c, true, curl, bundle, cons)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesServiceDeployPrincipal")
+	s.assertServiceDeployPrincipalBlocked(c, true, "TestBlockChangesServiceDeployPrincipal", curl, bundle, cons)
 }
 
 func (s *clientSuite) TestClientServiceDeploySubordinate(c *gc.C) {
@@ -1773,12 +1774,12 @@ func (s *clientSuite) TestClientServiceUpdateSetCharm(c *gc.C) {
 }
 
 func (s *clientSuite) TestBlockDestroyServiceUpdate(c *gc.C) {
-	s.blockDestroyEnvironment(c)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServiceUpdate")
 	s.checkClientServiceUpdateSetCharm(c, false)
 }
 
 func (s *clientSuite) TestBlockRemoveServiceUpdate(c *gc.C) {
-	s.blockRemoveObject(c)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServiceUpdate")
 	s.checkClientServiceUpdateSetCharm(c, false)
 }
 
@@ -1790,7 +1791,7 @@ func (s *clientSuite) setupServiceUpdate(c *gc.C) {
 
 func (s *clientSuite) TestBlockChangeServiceUpdate(c *gc.C) {
 	s.setupServiceUpdate(c)
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockChangeServiceUpdate")
 	// Update the charm for the service.
 	args := params.ServiceUpdate{
 		ServiceName:   "service",
@@ -1798,7 +1799,7 @@ func (s *clientSuite) TestBlockChangeServiceUpdate(c *gc.C) {
 		ForceCharmUrl: false,
 	}
 	err := s.APIState.Client().ServiceUpdate(args)
-	c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+	asct.AssertErrorBlocked(c, err, "TestBlockChangeServiceUpdate")
 }
 
 func (s *clientSuite) TestClientServiceUpdateForceSetCharm(c *gc.C) {
@@ -1809,9 +1810,9 @@ func (s *clientSuite) TestBlockServiceUpdateForced(c *gc.C) {
 	s.setupServiceUpdate(c)
 
 	// block all changes. Force should ignore block :)
-	s.blockAllChanges(c)
-	s.blockDestroyEnvironment(c)
-	s.blockRemoveObject(c)
+	s.blockSwitch.AllChanges(c, "TestBlockServiceUpdateForced")
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockServiceUpdateForced")
+	s.blockSwitch.RemoveObject(c, "TestBlockServiceUpdateForced")
 
 	// Update the charm for the service.
 	args := params.ServiceUpdate{
@@ -2039,12 +2040,12 @@ func (s *clientSuite) setupServiceSetCharm(c *gc.C) {
 	addCharm(c, "wordpress")
 }
 
-func (s *clientSuite) assertServiceSetCharmBlocked(c *gc.C, blocked bool, force bool) {
+func (s *clientSuite) assertServiceSetCharmBlocked(c *gc.C, blocked, force bool, msg string) {
 	err := s.APIState.Client().ServiceSetCharm(
 		"service", "cs:precise/wordpress-3", force,
 	)
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		// Ensure that the charm is not marked as forced.
@@ -2058,20 +2059,20 @@ func (s *clientSuite) assertServiceSetCharmBlocked(c *gc.C, blocked bool, force 
 
 func (s *clientSuite) TestBlockDestroyServiceSetCharm(c *gc.C) {
 	s.setupServiceSetCharm(c)
-	s.blockDestroyEnvironment(c)
-	s.assertServiceSetCharmBlocked(c, false, false)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyServiceSetCharm")
+	s.assertServiceSetCharmBlocked(c, false, false, "TestBlockDestroyServiceSetCharm")
 }
 
 func (s *clientSuite) TestBlockRemoveServiceSetCharm(c *gc.C) {
 	s.setupServiceSetCharm(c)
-	s.blockRemoveObject(c)
-	s.assertServiceSetCharmBlocked(c, false, false)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveServiceSetCharm")
+	s.assertServiceSetCharmBlocked(c, false, false, "TestBlockRemoveServiceSetCharm")
 }
 
 func (s *clientSuite) TestBlockChangesServiceSetCharm(c *gc.C) {
 	s.setupServiceSetCharm(c)
-	s.blockAllChanges(c)
-	s.assertServiceSetCharmBlocked(c, true, false)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesServiceSetCharm")
+	s.assertServiceSetCharmBlocked(c, true, false, "TestBlockChangesServiceSetCharm")
 }
 
 func (s *clientSuite) TestClientServiceSetCharmForce(c *gc.C) {
@@ -2100,11 +2101,11 @@ func (s *clientSuite) TestBlockServiceSetCharmForce(c *gc.C) {
 	s.setupServiceSetCharm(c)
 
 	// block all changes
-	s.blockAllChanges(c)
-	s.blockRemoveObject(c)
-	s.blockDestroyEnvironment(c)
+	s.blockSwitch.AllChanges(c, "TestBlockServiceSetCharmForce")
+	s.blockSwitch.RemoveObject(c, "TestBlockServiceSetCharmForce")
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockServiceSetCharmForce")
 
-	s.assertServiceSetCharmBlocked(c, false, true)
+	s.assertServiceSetCharmBlocked(c, false, true, "TestBlockServiceSetCharmForce")
 }
 
 func (s *clientSuite) TestClientServiceSetCharmInvalidService(c *gc.C) {
@@ -2197,19 +2198,19 @@ func (s *clientSuite) TestSuccessfullyAddRelation(c *gc.C) {
 }
 
 func (s *clientSuite) TestBlockDestroyAddRelation(c *gc.C) {
-	s.blockDestroyEnvironment(c)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyAddRelation")
 	s.assertAddRelation(c, []string{"wordpress", "mysql"})
 }
 func (s *clientSuite) TestBlockRemoveAddRelation(c *gc.C) {
-	s.blockRemoveObject(c)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveAddRelation")
 	s.assertAddRelation(c, []string{"wordpress", "mysql"})
 }
 
 func (s *clientSuite) TestBlockChangesAddRelation(c *gc.C) {
 	s.setUpScenario(c)
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesAddRelation")
 	_, err := s.APIState.Client().AddRelation([]string{"wordpress", "mysql"}...)
-	c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+	asct.AssertErrorBlocked(c, err, "TestBlockChangesAddRelation")
 }
 
 func (s *clientSuite) TestSuccessfullyAddRelationSwapped(c *gc.C) {
@@ -2393,10 +2394,10 @@ func (s *clientSuite) setupSetServiceConstraints(c *gc.C) (*state.Service, const
 	return service, cons
 }
 
-func (s *clientSuite) assertSetServiceConstraints(c *gc.C, blocked bool, service *state.Service, cons constraints.Value) {
+func (s *clientSuite) assertSetServiceConstraints(c *gc.C, blocked bool, msg string, service *state.Service, cons constraints.Value) {
 	err := s.APIState.Client().SetServiceConstraints("dummy", cons)
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		// Ensure the constraints have been correctly updated.
@@ -2408,20 +2409,20 @@ func (s *clientSuite) assertSetServiceConstraints(c *gc.C, blocked bool, service
 
 func (s *clientSuite) TestBlockDestroySetServiceConstraints(c *gc.C) {
 	svc, cons := s.setupSetServiceConstraints(c)
-	s.blockDestroyEnvironment(c)
-	s.assertSetServiceConstraints(c, false, svc, cons)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroySetServiceConstraints")
+	s.assertSetServiceConstraints(c, false, "TestBlockDestroySetServiceConstraints", svc, cons)
 }
 
 func (s *clientSuite) TestBlockRemoveSetServiceConstraints(c *gc.C) {
 	svc, cons := s.setupSetServiceConstraints(c)
-	s.blockRemoveObject(c)
-	s.assertSetServiceConstraints(c, false, svc, cons)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveSetServiceConstraints")
+	s.assertSetServiceConstraints(c, false, "TestBlockRemoveSetServiceConstraints", svc, cons)
 }
 
 func (s *clientSuite) TestBlockChangesSetServiceConstraints(c *gc.C) {
 	svc, cons := s.setupSetServiceConstraints(c)
-	s.blockAllChanges(c)
-	s.assertSetServiceConstraints(c, true, svc, cons)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesSetServiceConstraints")
+	s.assertSetServiceConstraints(c, true, "TestBlockChangesSetServiceConstraints", svc, cons)
 }
 
 func (s *clientSuite) TestClientGetServiceConstraints(c *gc.C) {
@@ -2452,13 +2453,13 @@ func (s *clientSuite) TestClientSetEnvironmentConstraints(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, cons)
 }
 
-func (s *clientSuite) assertSetEnvironmentConstraintsBlocked(c *gc.C, blocked bool) {
+func (s *clientSuite) assertSetEnvironmentConstraintsBlocked(c *gc.C, blocked bool, msg string) {
 	// Set constraints for the environment.
 	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.APIState.Client().SetEnvironmentConstraints(cons)
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		// Ensure the constraints have been correctly updated.
@@ -2469,18 +2470,18 @@ func (s *clientSuite) assertSetEnvironmentConstraintsBlocked(c *gc.C, blocked bo
 }
 
 func (s *clientSuite) TestBlockDestroyClientSetEnvironmentConstraints(c *gc.C) {
-	s.blockDestroyEnvironment(c)
-	s.assertSetEnvironmentConstraintsBlocked(c, false)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyClientSetEnvironmentConstraints")
+	s.assertSetEnvironmentConstraintsBlocked(c, false, "TestBlockDestroyClientSetEnvironmentConstraints")
 }
 
 func (s *clientSuite) TestBlockRemoveClientSetEnvironmentConstraints(c *gc.C) {
-	s.blockRemoveObject(c)
-	s.assertSetEnvironmentConstraintsBlocked(c, false)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveClientSetEnvironmentConstraints")
+	s.assertSetEnvironmentConstraintsBlocked(c, false, "TestBlockRemoveClientSetEnvironmentConstraints")
 }
 
 func (s *clientSuite) TestBlockChangesClientSetEnvironmentConstraints(c *gc.C) {
-	s.blockAllChanges(c)
-	s.assertSetEnvironmentConstraintsBlocked(c, true)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesClientSetEnvironmentConstraints")
+	s.assertSetEnvironmentConstraintsBlocked(c, true, "TestBlockChangesClientSetEnvironmentConstraints")
 }
 
 func (s *clientSuite) TestClientGetEnvironmentConstraints(c *gc.C) {
@@ -2642,31 +2643,15 @@ func (s *serverSuite) TestClientEnvironmentSetImmutable(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `cannot change state-port from .* to 1`)
 }
 
-func (s *serverSuite) assertEnvironmentSetBlocked(c *gc.C, args map[string]interface{}) {
+func (s *serverSuite) assertEnvironmentSetBlocked(c *gc.C, args map[string]interface{}, msg string) {
 	err := s.client.EnvironmentSet(params.EnvironmentSet{args})
-	c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
-}
-
-func (s *serverSuite) assertEnvironmentSetNotBlocked(c *gc.C, args map[string]interface{}) {
-	err := s.client.EnvironmentSet(params.EnvironmentSet{args})
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertEnvValue(c, "some-key", "value")
+	asct.AssertErrorBlocked(c, err, msg)
 }
 
 func (s *serverSuite) TestBlockChangesClientEnvironmentSet(c *gc.C) {
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesClientEnvironmentSet")
 	args := map[string]interface{}{"some-key": "value"}
-	s.assertEnvironmentSetBlocked(c, args)
-
-	// Make sure just mentioning variable does not unblock env.
-	// Need right value to unblock properly.
-	args[config.PreventAllChangesKey] = true
-	s.assertEnvironmentSetBlocked(c, args)
-
-	// But make sure that can unblock block-changes with right value.
-	args[config.PreventAllChangesKey] = false
-	s.assertEnvironmentSetNotBlocked(c, args)
-	s.assertEnvValue(c, config.PreventAllChangesKey, false)
+	s.assertEnvironmentSetBlocked(c, args, "TestBlockChangesClientEnvironmentSet")
 }
 
 func (s *serverSuite) TestClientEnvironmentSetDeprecated(c *gc.C) {
@@ -2713,11 +2698,11 @@ func (s *serverSuite) TestClientEnvironmentUnset(c *gc.C) {
 func (s *serverSuite) TestBlockClientEnvironmentUnset(c *gc.C) {
 	err := s.State.UpdateEnvironConfig(map[string]interface{}{"abc": 123}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockClientEnvironmentUnset")
 
 	args := params.EnvironmentUnset{[]string{"abc"}}
 	err = s.client.EnvironmentUnset(args)
-	c.Assert(errors.Cause(err), gc.Equals, common.ErrOperationBlocked)
+	asct.AssertErrorBlocked(c, err, "TestBlockClientEnvironmentUnset")
 }
 
 func (s *serverSuite) TestClientEnvironmentUnsetMissing(c *gc.C) {
@@ -2782,7 +2767,7 @@ func (s *clientSuite) TestClientAddMachinesDefaultSeries(c *gc.C) {
 	}
 }
 
-func (s *clientSuite) assertAddMachinesBlocked(c *gc.C, blocked bool) {
+func (s *clientSuite) assertAddMachinesBlocked(c *gc.C, blocked bool, msg string) {
 	apiParams := make([]params.AddMachineParams, 3)
 	for i := 0; i < 3; i++ {
 		apiParams[i] = params.AddMachineParams{
@@ -2791,7 +2776,7 @@ func (s *clientSuite) assertAddMachinesBlocked(c *gc.C, blocked bool) {
 	}
 	machines, err := s.APIState.Client().AddMachines(apiParams)
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(len(machines), gc.Equals, 3)
@@ -2803,18 +2788,18 @@ func (s *clientSuite) assertAddMachinesBlocked(c *gc.C, blocked bool) {
 }
 
 func (s *clientSuite) TestBlockDestroyClientAddMachinesDefaultSeries(c *gc.C) {
-	s.blockDestroyEnvironment(c)
-	s.assertAddMachinesBlocked(c, false)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyClientAddMachinesDefaultSeries")
+	s.assertAddMachinesBlocked(c, false, "TestBlockDestroyClientAddMachinesDefaultSeries")
 }
 
 func (s *clientSuite) TestBlockRemoveClientAddMachinesDefaultSeries(c *gc.C) {
-	s.blockRemoveObject(c)
-	s.assertAddMachinesBlocked(c, false)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveClientAddMachinesDefaultSeries")
+	s.assertAddMachinesBlocked(c, false, "TestBlockRemoveClientAddMachinesDefaultSeries")
 }
 
 func (s *clientSuite) TestBlockChangesClientAddMachines(c *gc.C) {
-	s.blockAllChanges(c)
-	s.assertAddMachinesBlocked(c, true)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesClientAddMachines")
+	s.assertAddMachinesBlocked(c, true, "TestBlockChangesClientAddMachines")
 }
 
 func (s *clientSuite) TestClientAddMachinesWithSeries(c *gc.C) {
@@ -2854,37 +2839,6 @@ func (s *clientSuite) TestClientAddMachineInsideMachine(c *gc.C) {
 func (s *baseSuite) updateConfig(c *gc.C, key string, block bool) {
 	err := s.State.UpdateEnvironConfig(map[string]interface{}{key: block}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-// setBlockAllChanges blocks all operations that could change environment -
-// setting block-all-changes to true.
-func (s *baseSuite) setBlockAllChanges(c *gc.C, block bool) {
-	s.updateConfig(c, "block-all-changes", block)
-}
-
-func (s *baseSuite) blockAllChanges(c *gc.C) {
-	s.setBlockAllChanges(c, true)
-}
-
-// setBlockRemoveObject blocks all operations that remove
-// machines, services, units or relations -
-// setting block-remove-object to true.
-func (s *baseSuite) setBlockRemoveObject(c *gc.C, block bool) {
-	s.updateConfig(c, "block-remove-object", block)
-}
-
-func (s *baseSuite) blockRemoveObject(c *gc.C) {
-	s.setBlockRemoveObject(c, true)
-}
-
-// setBlockDestroyEnvironment blocks destroy-environment -
-// setting block-destroy-environment to true.
-func (s *baseSuite) setBlockDestroyEnvironment(c *gc.C, block bool) {
-	s.updateConfig(c, "block-destroy-environment", block)
-}
-
-func (s *baseSuite) blockDestroyEnvironment(c *gc.C) {
-	s.setBlockDestroyEnvironment(c, true)
 }
 
 func (s *clientSuite) TestClientAddMachinesWithConstraints(c *gc.C) {
@@ -3542,10 +3496,10 @@ func (s *clientSuite) setupRetryProvisioning(c *gc.C) *state.Machine {
 	return machine
 }
 
-func (s *clientSuite) assertRetryProvisioningBlocked(c *gc.C, blocked bool, machine *state.Machine) {
+func (s *clientSuite) assertRetryProvisioningBlocked(c *gc.C, machine *state.Machine, blocked bool, msg string) {
 	_, err := s.APIState.Client().RetryProvisioning(machine.Tag().(names.MachineTag))
 	if blocked {
-		c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+		asct.AssertErrorBlocked(c, err, msg)
 	} else {
 		c.Assert(err, jc.ErrorIsNil)
 		status, info, data, err := machine.Status()
@@ -3558,20 +3512,20 @@ func (s *clientSuite) assertRetryProvisioningBlocked(c *gc.C, blocked bool, mach
 
 func (s *clientSuite) TestBlockDestroyRetryProvisioning(c *gc.C) {
 	m := s.setupRetryProvisioning(c)
-	s.blockDestroyEnvironment(c)
-	s.assertRetryProvisioningBlocked(c, false, m)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyRetryProvisioning")
+	s.assertRetryProvisioningBlocked(c, m, false, "TestBlockDestroyRetryProvisioning")
 }
 
 func (s *clientSuite) TestBlockRemoveRetryProvisioning(c *gc.C) {
 	m := s.setupRetryProvisioning(c)
-	s.blockRemoveObject(c)
-	s.assertRetryProvisioningBlocked(c, false, m)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveRetryProvisioning")
+	s.assertRetryProvisioningBlocked(c, m, false, "TestBlockRemoveRetryProvisioning")
 }
 
 func (s *clientSuite) TestBlockChangesRetryProvisioning(c *gc.C) {
 	m := s.setupRetryProvisioning(c)
-	s.blockAllChanges(c)
-	s.assertRetryProvisioningBlocked(c, true, m)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesRetryProvisioning")
+	s.assertRetryProvisioningBlocked(c, m, true, "TestBlockChangesRetryProvisioning")
 }
 
 func (s *clientSuite) TestAPIHostPorts(c *gc.C) {
@@ -3644,19 +3598,16 @@ func (s *clientSuite) TestMachineJobFromParams(c *gc.C) {
 
 func (s *serverSuite) TestBlockServiceDestroy(c *gc.C) {
 	s.AddTestingService(c, "dummy-service", s.AddTestingCharm(c, "dummy"))
-	// block remove-objects
-	s.blockRemoveObject(c)
 
-	for i, t := range serviceDestroyTests {
-		c.Logf("test %d. %s", i, t.about)
-		err := s.APIState.Client().ServiceDestroy(t.service)
-		c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
-		// Tests may have invalid service names.
-		service, err := s.State.Service(t.service)
-		if err == nil {
-			// For valid service names, check that service is alive :-)
-			assertLife(c, service, state.Alive)
-		}
+	// block remove-objects
+	s.blockSwitch.RemoveObject(c, "TestBlockServiceDestroy")
+	err := s.APIState.Client().ServiceDestroy("dummy-service")
+	asct.AssertErrorBlocked(c, err, "TestBlockServiceDestroy")
+	// Tests may have invalid service names.
+	service, err := s.State.Service("dummy-service")
+	if err == nil {
+		// For valid service names, check that service is alive :-)
+		assertLife(c, service, state.Alive)
 	}
 }
 
@@ -3676,12 +3627,16 @@ func (s *clientSuite) assertDestroyMachineSuccess(c *gc.C, u *state.Unit, m0, m1
 	assertLife(c, m2, state.Dying)
 }
 
-func (s *clientSuite) assertBlockedErrorAndLiveliness(c *gc.C, err error,
+func (s *clientSuite) assertBlockedErrorAndLiveliness(
+	c *gc.C,
+	err error,
+	msg string,
 	living1 state.Living,
 	living2 state.Living,
 	living3 state.Living,
-	living4 state.Living) {
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	living4 state.Living,
+) {
+	asct.AssertErrorBlocked(c, err, msg)
 	assertLife(c, living1, state.Alive)
 	assertLife(c, living2, state.Alive)
 	assertLife(c, living3, state.Alive)
@@ -3690,29 +3645,29 @@ func (s *clientSuite) assertBlockedErrorAndLiveliness(c *gc.C, err error,
 
 func (s *clientSuite) TestBlockRemoveDestroyMachines(c *gc.C) {
 	m0, m1, m2, u := s.setupDestroyMachinesTest(c)
-	s.blockRemoveObject(c)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveDestroyMachines")
 	err := s.APIState.Client().DestroyMachines("0", "1", "2")
-	s.assertBlockedErrorAndLiveliness(c, err, m0, m1, m2, u)
+	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockRemoveDestroyMachines", m0, m1, m2, u)
 }
 
 func (s *clientSuite) TestBlockChangesDestroyMachines(c *gc.C) {
 	m0, m1, m2, u := s.setupDestroyMachinesTest(c)
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesDestroyMachines")
 	err := s.APIState.Client().DestroyMachines("0", "1", "2")
-	s.assertBlockedErrorAndLiveliness(c, err, m0, m1, m2, u)
+	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockChangesDestroyMachines", m0, m1, m2, u)
 }
 
 func (s *clientSuite) TestBlockDestoryDestroyMachines(c *gc.C) {
 	m0, m1, m2, u := s.setupDestroyMachinesTest(c)
-	s.blockDestroyEnvironment(c)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestoryDestroyMachines")
 	s.assertDestroyMachineSuccess(c, u, m0, m1, m2)
 }
 
 func (s *clientSuite) TestAnyBlockForceDestroyMachines(c *gc.C) {
 	// force bypasses all blocks
-	s.blockAllChanges(c)
-	s.blockDestroyEnvironment(c)
-	s.blockRemoveObject(c)
+	s.blockSwitch.AllChanges(c, "TestAnyBlockForceDestroyMachines")
+	s.blockSwitch.DestroyEnvironment(c, "TestAnyBlockForceDestroyMachines")
+	s.blockSwitch.RemoveObject(c, "TestAnyBlockForceDestroyMachines")
 	s.assertForceDestroyMachines(c)
 }
 
@@ -3778,21 +3733,21 @@ func (s *clientSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {
 }
 func (s *clientSuite) TestBlockChangesDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesDestroyPrincipalUnits")
 	err := s.APIState.Client().DestroyServiceUnits("wordpress/0", "wordpress/1")
-	s.assertBlockedErrorAndLiveliness(c, err, units[0], units[1], units[2], units[3])
+	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockChangesDestroyPrincipalUnits", units[0], units[1], units[2], units[3])
 }
 
 func (s *clientSuite) TestBlockRemoveDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
-	s.blockRemoveObject(c)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveDestroyPrincipalUnits")
 	err := s.APIState.Client().DestroyServiceUnits("wordpress/0", "wordpress/1")
-	s.assertBlockedErrorAndLiveliness(c, err, units[0], units[1], units[2], units[3])
+	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockRemoveDestroyPrincipalUnits", units[0], units[1], units[2], units[3])
 }
 
 func (s *clientSuite) TestBlockDestroyDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
-	s.blockDestroyEnvironment(c)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyDestroyPrincipalUnits")
 	err := s.APIState.Client().DestroyServiceUnits("wordpress/0", "wordpress/1")
 	c.Assert(err, jc.ErrorIsNil)
 	assertLife(c, units[0], state.Dying)
@@ -3825,16 +3780,16 @@ func (s *clientSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 	logging0, err := s.State.Unit("logging/0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.blockRemoveObject(c)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
 	err = s.APIState.Client().DestroyServiceUnits("logging/0")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockRemoveDestroySubordinateUnits")
 	assertLife(c, rel, state.Alive)
 	assertLife(c, wordpress0, state.Alive)
 	assertLife(c, logging0, state.Alive)
 
 	err = s.APIState.Client().DestroyServiceUnits("wordpress/0", "logging/0")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockRemoveDestroySubordinateUnits")
 	assertLife(c, wordpress0, state.Alive)
 	assertLife(c, logging0, state.Alive)
 	assertLife(c, rel, state.Alive)
@@ -3856,16 +3811,16 @@ func (s *clientSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 	logging0, err := s.State.Unit("logging/0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
 	err = s.APIState.Client().DestroyServiceUnits("logging/0")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockChangesDestroySubordinateUnits")
 	assertLife(c, rel, state.Alive)
 	assertLife(c, wordpress0, state.Alive)
 	assertLife(c, logging0, state.Alive)
 
 	err = s.APIState.Client().DestroyServiceUnits("wordpress/0", "logging/0")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockChangesDestroySubordinateUnits")
 	assertLife(c, wordpress0, state.Alive)
 	assertLife(c, logging0, state.Alive)
 	assertLife(c, rel, state.Alive)
@@ -3887,7 +3842,7 @@ func (s *clientSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
 	logging0, err := s.State.Unit("logging/0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.blockDestroyEnvironment(c)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
 	err = s.APIState.Client().DestroyServiceUnits("logging/0")
 	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate`)
@@ -3900,23 +3855,23 @@ func (s *clientSuite) TestBlockRemoveDestroyRelation(c *gc.C) {
 	endpoints := []string{"wordpress", "mysql"}
 	relation := s.setupRelationScenario(c, endpoints)
 	// block remove-objects
-	s.blockRemoveObject(c)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveDestroyRelation")
 	err := s.APIState.Client().DestroyRelation(endpoints...)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockRemoveDestroyRelation")
 	assertLife(c, relation, state.Alive)
 }
 
 func (s *clientSuite) TestBlockChangeDestroyRelation(c *gc.C) {
 	endpoints := []string{"wordpress", "mysql"}
 	relation := s.setupRelationScenario(c, endpoints)
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockChangeDestroyRelation")
 	err := s.APIState.Client().DestroyRelation(endpoints...)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockChangeDestroyRelation")
 	assertLife(c, relation, state.Alive)
 }
 
 func (s *clientSuite) TestBlockDestroyDestroyRelation(c *gc.C) {
-	s.blockDestroyEnvironment(c)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyDestroyRelation")
 	endpoints := []string{"wordpress", "mysql"}
 	s.assertDestroyRelation(c, endpoints)
 }

--- a/apiserver/client/destroy_test.go
+++ b/apiserver/client/destroy_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/params"
+	asct "github.com/juju/juju/apiserver/common/testing"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
@@ -159,31 +159,26 @@ func (s *destroyEnvironmentSuite) TestDestroyEnvironmentWithContainers(c *gc.C) 
 func (s *destroyEnvironmentSuite) TestBlockDestroyDestroyEnvironment(c *gc.C) {
 	// Setup environment
 	s.setUpInstances(c)
-	// lock environment: can't destroy locked environment
-	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-destroy-environment": true}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.APIState.Client().DestroyEnvironment()
-	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+	s.blockSwitch.DestroyEnvironment(c, "TestBlockDestroyDestroyEnvironment")
+	err := s.APIState.Client().DestroyEnvironment()
+	asct.AssertErrorBlocked(c, err, "TestBlockDestroyDestroyEnvironment")
 }
 
 func (s *destroyEnvironmentSuite) TestBlockRemoveDestroyEnvironment(c *gc.C) {
 	// Setup environment
 	s.setUpInstances(c)
-	// lock environment: can't destroy locked environment
-	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-remove-object": true}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.APIState.Client().DestroyEnvironment()
-	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+	s.blockSwitch.RemoveObject(c, "TestBlockRemoveDestroyEnvironment")
+	err := s.APIState.Client().DestroyEnvironment()
+	asct.AssertErrorBlocked(c, err, "TestBlockRemoveDestroyEnvironment")
 }
 
 func (s *destroyEnvironmentSuite) TestBlockChangesDestroyEnvironment(c *gc.C) {
 	// Setup environment
 	s.setUpInstances(c)
 	// lock environment: can't destroy locked environment
-	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-all-changes": true}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.APIState.Client().DestroyEnvironment()
-	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+	s.blockSwitch.AllChanges(c, "TestBlockChangesDestroyEnvironment")
+	err := s.APIState.Client().DestroyEnvironment()
+	asct.AssertErrorBlocked(c, err, "TestBlockChangesDestroyEnvironment")
 }
 
 type destroyTwoEnvironmentsSuite struct {

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -7,14 +7,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/exec"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/client"
-	"github.com/juju/juju/apiserver/common"
+	asct "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -50,14 +49,6 @@ func (s *runSuite) TestRemoteParamsForMachinePopulates(c *gc.C) {
 	// have an address to use.
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 	c.Assert(result.Host, gc.Equals, "")
-}
-
-// blockAllChanges blocks all operations that could change environment -
-// setting block-all-changes to true.
-// Asserts that no errors were encountered.
-func (s *runSuite) blockAllChanges(c *gc.C) {
-	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-all-changes": true}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *runSuite) TestRemoteParamsForMachinePopulatesWithAddress(c *gc.C) {
@@ -275,10 +266,9 @@ func (s *runSuite) TestBlockRunOnAllMachines(c *gc.C) {
 	s.mockSSH(c, echoInput)
 
 	// block all changes
-	s.blockAllChanges(c)
-	client := s.APIState.Client()
-	_, err := client.RunOnAllMachines("hostname", testing.LongWait)
-	c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+	s.blockSwitch.AllChanges(c, "TestBlockRunOnAllMachines")
+	_, err := s.APIState.Client().RunOnAllMachines("hostname", testing.LongWait)
+	asct.AssertErrorBlocked(c, err, "TestBlockRunOnAllMachines")
 }
 
 func (s *runSuite) TestRunMachineAndService(c *gc.C) {
@@ -347,7 +337,7 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 	client := s.APIState.Client()
 
 	// block all changes
-	s.blockAllChanges(c)
+	s.blockSwitch.AllChanges(c, "TestBlockRunMachineAndService")
 	_, err = client.Run(
 		params.RunParams{
 			Commands: "hostname",
@@ -355,5 +345,5 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 			Machines: []string{"0"},
 			Services: []string{"magic"},
 		})
-	c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+	asct.AssertErrorBlocked(c, err, "TestBlockRunMachineAndService")
 }

--- a/apiserver/common/block.go
+++ b/apiserver/common/block.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package common
@@ -6,55 +6,19 @@ package common
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
 )
 
-// isOperationBlocked determines if the operation should proceed
-// based on configuration parameters that prevent destroy, remove or change
-// operations.
-func isOperationBlocked(operation Operation, cfg *config.Config) bool {
-	allChanges := cfg.PreventAllChanges()
-	// If all changes are blocked, requesting operation makes no difference
-	if allChanges {
-		return true
-	}
-
-	allRemoves := cfg.PreventRemoveObject()
-	// This only matters for Destroy and Remove operations
-	if allRemoves && operation != ChangeOperation {
-		return true
-	}
-
-	allDestroys := cfg.PreventDestroyEnvironment()
-	if allDestroys && operation == DestroyOperation {
-		return true
-	}
-	return false
+type BlockGetter interface {
+	GetBlockForType(t state.BlockType) (state.Block, bool, error)
 }
-
-// Operation specifies operation type for enum benefit.
-// Operation type may be relevant for a group of commands.
-type Operation int8
-
-const (
-	// DestroyOperation type groups commands that destroy environment.
-	DestroyOperation Operation = iota
-
-	// RemoveOperation type groups commands
-	// that removes machine, service, unit or relation.
-	RemoveOperation
-
-	// ChangeOperation type groups commands that change environments -
-	// all adds, modifies, removes, etc.
-	ChangeOperation
-)
 
 // BlockChecker checks for current blocks if any.
 type BlockChecker struct {
-	getter EnvironConfigGetter
+	getter BlockGetter
 }
 
-func NewBlockChecker(s EnvironConfigGetter) *BlockChecker {
+func NewBlockChecker(s BlockGetter) *BlockChecker {
 	return &BlockChecker{s}
 }
 
@@ -62,32 +26,45 @@ func NewBlockChecker(s EnvironConfigGetter) *BlockChecker {
 // Change block prevents all operations that may change
 // current environment in any way from running successfully.
 func (c *BlockChecker) ChangeAllowed() error {
-	return c.checkBlock(ChangeOperation)
+	return c.checkBlock(state.ChangeBlock)
 }
 
 // RemoveAllowed checks if remove block is in place.
 // Remove block prevents removal of machine, service, unit
 // and relation from current environment.
 func (c *BlockChecker) RemoveAllowed() error {
-	return c.checkBlock(RemoveOperation)
+	if err := c.checkBlock(state.RemoveBlock); err != nil {
+		return err
+	}
+	// Check if change block has been enabled
+	return c.checkBlock(state.ChangeBlock)
 }
 
 // DestroyAllowed checks if destroy block is in place.
 // Destroy block prevents destruction of current environment.
 func (c *BlockChecker) DestroyAllowed() error {
-	return c.checkBlock(DestroyOperation)
+	if err := c.checkBlock(state.DestroyBlock); err != nil {
+		return err
+	}
+	// Check if remove block has been enabled
+	if err := c.checkBlock(state.RemoveBlock); err != nil {
+		return err
+	}
+	// Check if change block has been enabled
+	return c.checkBlock(state.ChangeBlock)
 }
 
 // checkBlock checks if specified operation must be blocked.
 // If it does, the method throws specific error that can be examined
 // to stop operation execution.
-func (c *BlockChecker) checkBlock(operation Operation) error {
-	cfg, err := c.getter.EnvironConfig()
+func (c *BlockChecker) checkBlock(blockType state.BlockType) error {
+	aBlock, isEnabled, err := c.getter.GetBlockForType(blockType)
+	//	fmt.Printf("\nLOOKING FOR %v > BLOCK(%+v) is enabled %t (%v)\n", blockType, aBlock, isEnabled, err)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if isOperationBlocked(operation, cfg) {
-		return ErrOperationBlocked
+	if isEnabled {
+		return ErrOperationBlocked(aBlock.Message())
 	}
 	return nil
 }

--- a/apiserver/common/block_test.go
+++ b/apiserver/common/block_test.go
@@ -5,194 +5,93 @@ package common_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
 
-type blocksSuite struct {
-	testing.FakeJujuHomeSuite
-	destroy, remove, change bool
-	cfg                     *config.Config
+type mockBlock struct {
+	t state.BlockType
+	m string
 }
 
-var _ = gc.Suite(&blocksSuite{})
+func (m mockBlock) Id() string { return "" }
 
-func (s *blocksSuite) TearDownTest(c *gc.C) {
-	s.destroy, s.remove, s.change = false, false, false
-}
+func (m mockBlock) Tag() (names.Tag, error) { return names.NewEnvironTag("mocktesting"), nil }
 
-func (s *blocksSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuHomeSuite.SetUpTest(c)
-	cfg, err := config.New(
-		config.UseDefaults,
-		map[string]interface{}{
-			"name": "block-env",
-			"type": "any-type",
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	s.cfg = cfg
-}
+func (m mockBlock) Type() state.BlockType { return m.t }
 
-func (s *blocksSuite) TestBlockOperationErrorDestroy(c *gc.C) {
-	// prevent destroy-environment
-	s.blockDestroys(c)
-	s.assertDestroyOperationBlocked(c, true)
-
-	// prevent remove-object
-	s.blockRemoves(c)
-	s.assertDestroyOperationBlocked(c, true)
-
-	// prevent all-changes
-	s.blockAllChanges(c)
-	s.assertDestroyOperationBlocked(c, true)
-}
-
-func (s *blocksSuite) TestBlockOperationErrorRemove(c *gc.C) {
-	// prevent destroy-environment
-	s.blockDestroys(c)
-	s.assertRemoveOperationBlocked(c, false)
-
-	// prevent remove-object
-	s.blockRemoves(c)
-	s.assertRemoveOperationBlocked(c, true)
-
-	// prevent all-changes
-	s.blockAllChanges(c)
-	s.assertRemoveOperationBlocked(c, true)
-}
-
-func (s *blocksSuite) TestBlockOperationErrorChange(c *gc.C) {
-	// prevent destroy-environment
-	s.blockDestroys(c)
-	s.assertChangeOperationBlocked(c, false)
-
-	// prevent remove-object
-	s.blockRemoves(c)
-	s.assertChangeOperationBlocked(c, false)
-
-	// prevent all-changes
-	s.blockAllChanges(c)
-	s.assertChangeOperationBlocked(c, true)
-}
-
-func (s *blocksSuite) blockDestroys(c *gc.C) {
-	s.destroy, s.remove, s.change = true, false, false
-}
-
-func (s *blocksSuite) blockRemoves(c *gc.C) {
-	s.remove, s.destroy, s.change = true, false, false
-}
-
-func (s *blocksSuite) blockAllChanges(c *gc.C) {
-	s.change, s.destroy, s.remove = true, false, false
-}
-
-func (s *blocksSuite) assertDestroyOperationBlocked(c *gc.C, value bool) {
-	s.assertOperationBlocked(c, common.DestroyOperation, value)
-}
-
-func (s *blocksSuite) assertRemoveOperationBlocked(c *gc.C, value bool) {
-	s.assertOperationBlocked(c, common.RemoveOperation, value)
-}
-
-func (s *blocksSuite) assertChangeOperationBlocked(c *gc.C, value bool) {
-	s.assertOperationBlocked(c, common.ChangeOperation, value)
-}
-
-func (s *blocksSuite) assertOperationBlocked(c *gc.C, operation common.Operation, value bool) {
-	c.Assert(common.IsOperationBlocked(operation, s.getCurrentConfig(c)), gc.Equals, value)
-}
-
-func (s *blocksSuite) getCurrentConfig(c *gc.C) *config.Config {
-	cfg, err := s.cfg.Apply(map[string]interface{}{
-		"block-destroy-environment": s.destroy,
-		"block-remove-object":       s.remove,
-		"block-all-changes":         s.change,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	return cfg
-}
+func (m mockBlock) Message() string { return m.m }
 
 type blockCheckerSuite struct {
-	blocksSuite
-	getter       *mockGetter
+	testing.FakeJujuHomeSuite
+	aBlock                  state.Block
+	destroy, remove, change state.Block
+
 	blockchecker *common.BlockChecker
 }
 
 var _ = gc.Suite(&blockCheckerSuite{})
 
 func (s *blockCheckerSuite) SetUpTest(c *gc.C) {
-	s.blocksSuite.SetUpTest(c)
-	s.getter = &mockGetter{
-		suite: s,
-		c:     c,
+	s.FakeJujuHomeSuite.SetUpTest(c)
+	s.destroy = mockBlock{t: state.DestroyBlock, m: "Mock BLOCK testing: DESTROY"}
+	s.remove = mockBlock{t: state.RemoveBlock, m: "Mock BLOCK testing: REMOVE"}
+	s.change = mockBlock{t: state.ChangeBlock, m: "Mock BLOCK testing: CHANGE"}
+	s.blockchecker = common.NewBlockChecker(s)
+}
+
+func (mock *blockCheckerSuite) GetBlockForType(t state.BlockType) (state.Block, bool, error) {
+	if mock.aBlock.Type() == t {
+		return mock.aBlock, true, nil
+	} else {
+		return nil, false, nil
 	}
-	s.blockchecker = common.NewBlockChecker(s.getter)
-}
-
-type mockGetter struct {
-	suite *blockCheckerSuite
-	c     *gc.C
-}
-
-func (mock *mockGetter) EnvironConfig() (*config.Config, error) {
-	return mock.suite.getCurrentConfig(mock.c), nil
 }
 
 func (s *blockCheckerSuite) TestDestroyBlockChecker(c *gc.C) {
-	s.blockDestroys(c)
-	s.assertDestroyBlocked(c)
+	s.aBlock = s.destroy
+	s.assertErrorBlocked(c, true, s.blockchecker.DestroyAllowed(), s.destroy.Message())
 
-	s.blockRemoves(c)
-	s.assertDestroyBlocked(c)
+	s.aBlock = s.remove
+	s.assertErrorBlocked(c, true, s.blockchecker.DestroyAllowed(), s.remove.Message())
 
-	s.blockAllChanges(c)
-	s.assertDestroyBlocked(c)
+	s.aBlock = s.change
+	s.assertErrorBlocked(c, true, s.blockchecker.DestroyAllowed(), s.change.Message())
 }
 
 func (s *blockCheckerSuite) TestRemoveBlockChecker(c *gc.C) {
-	s.blockDestroys(c)
-	s.assertRemoveBlocked(c, false)
+	s.aBlock = s.destroy
+	s.assertErrorBlocked(c, false, s.blockchecker.RemoveAllowed(), s.destroy.Message())
 
-	s.blockRemoves(c)
-	s.assertRemoveBlocked(c, true)
+	s.aBlock = s.remove
+	s.assertErrorBlocked(c, true, s.blockchecker.RemoveAllowed(), s.remove.Message())
 
-	s.blockAllChanges(c)
-	s.assertRemoveBlocked(c, true)
+	s.aBlock = s.change
+	s.assertErrorBlocked(c, true, s.blockchecker.RemoveAllowed(), s.change.Message())
 }
 
 func (s *blockCheckerSuite) TestChangeBlockChecker(c *gc.C) {
-	s.blockDestroys(c)
-	s.assertChangeBlocked(c, false)
+	s.aBlock = s.destroy
+	s.assertErrorBlocked(c, false, s.blockchecker.ChangeAllowed(), s.destroy.Message())
 
-	s.blockRemoves(c)
-	s.assertChangeBlocked(c, false)
+	s.aBlock = s.remove
+	s.assertErrorBlocked(c, false, s.blockchecker.ChangeAllowed(), s.remove.Message())
 
-	s.blockAllChanges(c)
-	s.assertChangeBlocked(c, true)
+	s.aBlock = s.change
+	s.assertErrorBlocked(c, true, s.blockchecker.ChangeAllowed(), s.change.Message())
 }
 
-func (s *blockCheckerSuite) assertDestroyBlocked(c *gc.C) {
-	c.Assert(errors.Cause(s.blockchecker.DestroyAllowed()), gc.Equals, common.ErrOperationBlocked)
-}
-
-func (s *blockCheckerSuite) assertRemoveBlocked(c *gc.C, blocked bool) {
+func (s *blockCheckerSuite) assertErrorBlocked(c *gc.C, blocked bool, err error, msg string) {
 	if blocked {
-		c.Assert(errors.Cause(s.blockchecker.RemoveAllowed()), gc.Equals, common.ErrOperationBlocked)
+		c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+		c.Assert(err, gc.ErrorMatches, msg)
 	} else {
-		c.Assert(errors.Cause(s.blockchecker.RemoveAllowed()), jc.ErrorIsNil)
-	}
-}
-
-func (s *blockCheckerSuite) assertChangeBlocked(c *gc.C, blocked bool) {
-	if blocked {
-		c.Assert(errors.Cause(s.blockchecker.ChangeAllowed()), gc.Equals, common.ErrOperationBlocked)
-	} else {
-		c.Assert(errors.Cause(s.blockchecker.ChangeAllowed()), jc.ErrorIsNil)
+		c.Assert(errors.Cause(err), jc.ErrorIsNil)
 	}
 }

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -75,9 +75,14 @@ var (
 	ErrTryAgain           = stderrors.New("try again")
 	ErrActionNotAvailable = stderrors.New("action no longer available")
 
-	ErrOperationBlocked = &params.Error{
-		Code:    params.CodeOperationBlocked,
-		Message: "The operation has been blocked.",
+	ErrOperationBlocked = func(msg string) *params.Error {
+		if msg == "" {
+			msg = "The operation has been blocked."
+		}
+		return &params.Error{
+			Code:    params.CodeOperationBlocked,
+			Message: msg,
+		}
 	}
 )
 

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -109,7 +109,7 @@ var errorTransformTests = []struct {
 	code:       params.CodeUpgradeInProgress,
 	helperFunc: params.IsCodeUpgradeInProgress,
 }, {
-	err:        common.ErrOperationBlocked,
+	err:        common.ErrOperationBlocked("test"),
 	code:       params.CodeOperationBlocked,
 	helperFunc: params.IsCodeOperationBlocked,
 }, {

--- a/apiserver/common/export_test.go
+++ b/apiserver/common/export_test.go
@@ -4,11 +4,10 @@
 package common
 
 var (
-	ValidateNewFacade  = validateNewFacade
-	WrapNewFacade      = wrapNewFacade
-	NilFacadeRecord    = facadeRecord{}
-	EnvtoolsFindTools  = &envtoolsFindTools
-	IsOperationBlocked = isOperationBlocked
+	ValidateNewFacade = validateNewFacade
+	WrapNewFacade     = wrapNewFacade
+	NilFacadeRecord   = facadeRecord{}
+	EnvtoolsFindTools = &envtoolsFindTools
 )
 
 type Patcher interface {

--- a/apiserver/common/testing/block.go
+++ b/apiserver/common/testing/block.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/block"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/multiwatcher"
+)
+
+type BlockSwitch struct {
+	ApiState *api.State
+	client   *block.Client
+}
+
+func NewBlockSwitch(st *api.State) *BlockSwitch {
+	return &BlockSwitch{
+		ApiState: st,
+		client:   block.NewClient(st),
+	}
+}
+
+// AssertSwitchBlockOn switches on desired block and
+// asserts that no errors were encountered.
+func (s BlockSwitch) assertSwitchBlockOn(c *gc.C, blockType multiwatcher.BlockType, msg string) {
+	c.Assert(
+		s.client.SwitchBlockOn(
+			fmt.Sprintf("%v", blockType),
+			msg),
+		gc.IsNil)
+}
+
+// BlockAllChanges blocks all operations that could change environment.
+func (s BlockSwitch) AllChanges(c *gc.C, msg string) {
+	s.assertSwitchBlockOn(c, multiwatcher.BlockChange, msg)
+}
+
+// BlockRemoveObject blocks all operations that remove
+// machines, services, units or relations.
+func (s BlockSwitch) RemoveObject(c *gc.C, msg string) {
+	s.assertSwitchBlockOn(c, multiwatcher.BlockRemove, msg)
+}
+
+// BlockDestroyEnvironment blocks destroy-environment.
+func (s BlockSwitch) DestroyEnvironment(c *gc.C, msg string) {
+	s.assertSwitchBlockOn(c, multiwatcher.BlockDestroy, msg)
+}
+
+// AssertErrorBlocked checks if given error is
+// related to switched block.
+func AssertErrorBlocked(c *gc.C, err error, msg string) {
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, msg)
+}

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -6,11 +6,11 @@ package highavailability_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	asct "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/highavailability"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -32,6 +32,8 @@ type clientSuite struct {
 	authoriser apiservertesting.FakeAuthorizer
 	haServer   *highavailability.HighAvailabilityAPI
 	pinger     *presence.Pinger
+
+	blockSwitch *asct.BlockSwitch
 }
 
 type Killer interface {
@@ -68,6 +70,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	// We have to ensure the agents are alive, or EnsureAvailability will
 	// create more to replace them.
 	s.pinger = s.setAgentPresence(c, "0")
+	s.blockSwitch = asct.NewBlockSwitch(s.APIState)
 }
 
 func (s *clientSuite) TearDownTest(c *gc.C) {
@@ -176,11 +179,10 @@ func (s *clientSuite) TestEnsureAvailabilityConstraints(c *gc.C) {
 
 func (s *clientSuite) TestBlockEnsureAvailability(c *gc.C) {
 	// Block all changes.
-	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-all-changes": true}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
+	s.blockSwitch.AllChanges(c, "TestBlockEnsureAvailability")
 
 	ensureAvailabilityResult, err := s.ensureAvailability(c, 3, constraints.MustParse("mem=4G"), defaultSeries, nil)
-	c.Assert(errors.Cause(err), gc.DeepEquals, common.ErrOperationBlocked)
+	asct.AssertErrorBlocked(c, err, "TestBlockEnsureAvailability")
 
 	c.Assert(ensureAvailabilityResult.Maintained, gc.HasLen, 0)
 	c.Assert(ensureAvailabilityResult.Added, gc.HasLen, 0)

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -47,7 +47,7 @@ type toolsDownloadHandler struct {
 func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	stateWrapper, err := h.validateEnvironUUID(r)
 	if err != nil {
-		h.sendError(w, http.StatusNotFound, err.Error())
+		h.sendExistingError(w, http.StatusNotFound, err)
 		return
 	}
 	defer stateWrapper.cleanup()
@@ -57,7 +57,7 @@ func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		tarball, err := h.processGet(r, stateWrapper.state)
 		if err != nil {
 			logger.Errorf("GET(%s) failed: %v", r.URL, err)
-			h.sendError(w, http.StatusBadRequest, err.Error())
+			h.sendExistingError(w, http.StatusBadRequest, err)
 			return
 		}
 		h.sendTools(w, http.StatusOK, tarball)
@@ -71,7 +71,7 @@ func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// on the state connection that is determined during the validation.
 	stateWrapper, err := h.validateEnvironUUID(r)
 	if err != nil {
-		h.sendError(w, http.StatusNotFound, err.Error())
+		h.sendExistingError(w, http.StatusNotFound, err)
 		return
 	}
 	defer stateWrapper.cleanup()
@@ -86,7 +86,7 @@ func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Add tools to storage.
 		agentTools, err := h.processPost(r, stateWrapper.state)
 		if err != nil {
-			h.sendError(w, http.StatusBadRequest, err.Error())
+			h.sendExistingError(w, http.StatusBadRequest, err)
 			return
 		}
 		h.sendJSON(w, http.StatusOK, &params.ToolsResult{Tools: agentTools})
@@ -107,10 +107,21 @@ func (h *toolsHandler) sendJSON(w http.ResponseWriter, statusCode int, response 
 	return nil
 }
 
-// sendError sends a JSON-encoded error response.
+// sendError sends a JSON-encoded error response using desired
+// error message.
 func (h *toolsHandler) sendError(w http.ResponseWriter, statusCode int, message string) {
 	logger.Debugf("sending error: %v %v", statusCode, message)
 	err := common.ServerError(errors.New(message))
+	if err := h.sendJSON(w, statusCode, &params.ToolsResult{Error: err}); err != nil {
+		logger.Errorf("failed to send error: %v", err)
+	}
+}
+
+// sendExistingError sends a JSON-encoded error response
+// for errors encountered during processing.
+func (h *toolsHandler) sendExistingError(w http.ResponseWriter, statusCode int, existing error) {
+	logger.Debugf("sending error: %v %v", statusCode, existing)
+	err := common.ServerError(existing)
 	if err := h.sendJSON(w, statusCode, &params.ToolsResult{Error: err}); err != nil {
 		logger.Errorf("failed to send error: %v", err)
 	}
@@ -209,7 +220,7 @@ func (h *toolsDownloadHandler) sendTools(w http.ResponseWriter, statusCode int, 
 	w.Header().Set("Content-Length", fmt.Sprint(len(tarball)))
 	w.WriteHeader(statusCode)
 	if _, err := w.Write(tarball); err != nil {
-		h.sendError(w, http.StatusBadRequest, fmt.Sprintf("failed to write tools: %v", err))
+		h.sendExistingError(w, http.StatusBadRequest, errors.Annotatef(err, "failed to write tools"))
 		return
 	}
 }

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	asct "github.com/juju/juju/apiserver/common/testing"
 	apihttp "github.com/juju/juju/apiserver/http"
 	"github.com/juju/juju/apiserver/params"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
+
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/toolstorage"
 	coretools "github.com/juju/juju/tools"
@@ -31,6 +33,8 @@ import (
 
 type toolsSuite struct {
 	authHttpSuite
+
+	blockSwitch *asct.BlockSwitch
 }
 
 var _ = gc.Suite(&toolsSuite{})
@@ -38,6 +42,11 @@ var _ = gc.Suite(&toolsSuite{})
 func (s *toolsSuite) SetUpSuite(c *gc.C) {
 	s.authHttpSuite.SetUpSuite(c)
 	s.archiveContentType = "application/x-tar-gz"
+}
+
+func (s *toolsSuite) SetUpTest(c *gc.C) {
+	s.authHttpSuite.SetUpTest(c)
+	s.blockSwitch = asct.NewBlockSwitch(s.APIState)
 }
 
 func (s *toolsSuite) TestToolsUploadedSecurely(c *gc.C) {
@@ -135,18 +144,18 @@ func (s *toolsSuite) TestUpload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uploadedData, gc.DeepEquals, expectedData)
 }
+
 func (s *toolsSuite) TestBlockUpload(c *gc.C) {
 	// Make some fake tools.
 	_, vers, toolPath := s.setupToolsForUpload(c)
 	// Block all changes.
-	err := s.State.UpdateEnvironConfig(map[string]interface{}{"block-all-changes": true}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
+	s.blockSwitch.AllChanges(c, "TestUpload")
 	// Now try uploading them.
 	resp, err := s.uploadRequest(
 		c, s.toolsURI(c, "?binaryVersion="+vers.String()), true, toolPath)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertErrorResponse(c, resp, http.StatusBadRequest, "The operation has been blocked.")
+	problem := s.assertErrorResponse(c, resp, http.StatusBadRequest, "TestUpload")
+	asct.AssertErrorBlocked(c, problem, "TestUpload")
 
 	// Check the contents.
 	storage, err := s.State.ToolsStorage()
@@ -403,11 +412,12 @@ func (s *toolsSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBody
 	c.Check(string(body), gc.Equals, expBody)
 }
 
-func (s *toolsSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
+func (s *toolsSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) error {
 	body := assertResponse(c, resp, expCode, apihttp.CTypeJSON)
 	err := jsonToolsResponse(c, body).Error
 	c.Assert(err, gc.NotNil)
 	c.Check(err, gc.ErrorMatches, expError)
+	return err
 }
 
 func jsonToolsResponse(c *gc.C, body []byte) (jsonResponse params.ToolsResult) {

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
+	asct "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/apiserver/usermanager"
@@ -23,6 +23,8 @@ type userManagerSuite struct {
 	usermanager *usermanager.UserManagerAPI
 	authorizer  apiservertesting.FakeAuthorizer
 	adminName   string
+
+	blockSwitch *asct.BlockSwitch
 }
 
 var _ = gc.Suite(&userManagerSuite{})
@@ -38,6 +40,8 @@ func (s *userManagerSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.usermanager, err = usermanager.NewUserManagerAPI(s.State, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
+
+	s.blockSwitch = asct.NewBlockSwitch(s.APIState)
 }
 
 func (s *userManagerSuite) TestNewUserManagerAPIRefusesNonClient(c *gc.C) {
@@ -79,10 +83,10 @@ func (s *userManagerSuite) TestBlockAddUser(c *gc.C) {
 			Password:    "password",
 		}}}
 
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.blockSwitch.AllChanges(c, "TestBlockAddUser")
 	result, err := s.usermanager.AddUser(args)
 	// Check that the call is blocked
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockAddUser")
 	c.Assert(result.Results, gc.HasLen, 1)
 	//check that user is not created
 	foobarTag := names.NewLocalUserTag("foobar")
@@ -164,10 +168,10 @@ func (s *userManagerSuite) TestBlockDisableUser(c *gc.C) {
 			{"not-a-tag"},
 		}}
 
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.blockSwitch.AllChanges(c, "TestBlockDisableUser")
 	_, err := s.usermanager.DisableUser(args)
 	// Check that the call is blocked
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockDisableUser")
 
 	err = alex.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
@@ -230,10 +234,10 @@ func (s *userManagerSuite) TestBlockEnableUser(c *gc.C) {
 			{"not-a-tag"},
 		}}
 
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.blockSwitch.AllChanges(c, "TestBlockEnableUser")
 	_, err := s.usermanager.EnableUser(args)
 	// Check that the call is blocked
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockEnableUser")
 
 	err = alex.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
@@ -417,10 +421,10 @@ func (s *userManagerSuite) TestBlockSetPassword(c *gc.C) {
 			Password: "new-password",
 		}}}
 
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.blockSwitch.AllChanges(c, "TestBlockSetPassword")
 	_, err := s.usermanager.SetPassword(args)
 	// Check that the call is blocked
-	c.Assert(errors.Cause(err), gc.ErrorMatches, common.ErrOperationBlocked.Error())
+	asct.AssertErrorBlocked(c, err, "TestBlockSetPassword")
 
 	err = alex.Refresh()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/addrelation_test.go
+++ b/cmd/juju/addrelation_test.go
@@ -11,13 +11,12 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
 
 type AddRelationSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&AddRelationSuite{})
@@ -171,7 +170,7 @@ func (s *AddRelationSuite) TestBlockAddRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockAddRelation")
 
 	for i, t := range addRelationTests {
 		c.Logf("test %d: %v", i, t.args)
@@ -183,7 +182,7 @@ func (s *AddRelationSuite) TestBlockAddRelation(c *gc.C) {
 
 			// msg is logged
 			stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-			c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+			c.Check(stripped, gc.Matches, ".*TestBlockAddRelation.*")
 		}
 	}
 }

--- a/cmd/juju/addunit_test.go
+++ b/cmd/juju/addunit_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 type AddUnitSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&AddUnitSuite{})
@@ -81,12 +81,13 @@ func (s *AddUnitSuite) TestBlockAddUnit(c *gc.C) {
 	s.setupService(c)
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockAddUnit")
+
 	c.Assert(runAddUnit(c, "some-service-name"), gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockAddUnit.*")
 }
 
 // assertForceMachine ensures that the result of assigning a unit with --to
@@ -129,7 +130,7 @@ func (s *AddUnitSuite) TestBlockForceMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	svc, _ := s.AssertService(c, "some-service-name", curl, 3, 0)
 	// Block operation: should be ignored :)
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockForceMachine")
 	s.assertForceMachine(c, svc, 3, 1, machine2.Id())
 	s.assertForceMachine(c, svc, 3, 2, machine.Id())
 }
@@ -175,12 +176,12 @@ func (s *AddUnitSuite) TestNonLocalCannotHostUnits(c *gc.C) {
 
 func (s *AddUnitSuite) TestBlockNonLocalCannotHostUnits(c *gc.C) {
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockNonLocalCannotHostUnits")
 	c.Assert(runAddUnit(c, "some-service-name", "--to", "0"), gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockNonLocalCannotHostUnits.*")
 }
 
 func (s *AddUnitSuite) TestCannotDeployToNonExistentMachine(c *gc.C) {
@@ -192,12 +193,12 @@ func (s *AddUnitSuite) TestCannotDeployToNonExistentMachine(c *gc.C) {
 func (s *AddUnitSuite) TestBlockCannotDeployToNonExistentMachine(c *gc.C) {
 	s.setupService(c)
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockCannotDeployToNonExistentMachine")
 	c.Assert(runAddUnit(c, "some-service-name", "--to", "42"), gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockCannotDeployToNonExistentMachine.*")
 }
 
 type AddUnitLocalSuite struct {

--- a/cmd/juju/authorizedkeys_test.go
+++ b/cmd/juju/authorizedkeys_test.go
@@ -15,7 +15,6 @@ import (
 	keymanagertesting "github.com/juju/juju/apiserver/keymanager/testing"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/juju/osenv"
-	jujutesting "github.com/juju/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	sshtesting "github.com/juju/juju/utils/ssh/testing"
@@ -84,7 +83,7 @@ func (s *AuthorizedKeysSuite) TestHelpImport(c *gc.C) {
 }
 
 type keySuiteBase struct {
-	jujutesting.JujuConnSuite
+	CmdBlockSuite
 }
 
 func (s *keySuiteBase) SetUpSuite(c *gc.C) {
@@ -179,13 +178,13 @@ func (s *AddKeySuite) TestBlockAddKey(c *gc.C) {
 
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockAddKey")
 	_, err := coretesting.RunCommand(c, envcmd.Wrap(&AddKeysCommand{}), key2, "invalid-key")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockAddKey.*")
 }
 
 func (s *AddKeySuite) TestAddKeyNonDefaultUser(c *gc.C) {
@@ -224,14 +223,14 @@ func (s *DeleteKeySuite) TestBlockDeleteKeys(c *gc.C) {
 	s.setAuthorizedKeys(c, key1, key2)
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockDeleteKeys")
 	_, err := coretesting.RunCommand(c, envcmd.Wrap(&DeleteKeysCommand{}),
 		sshtesting.ValidKeyTwo.Fingerprint, "invalid-key")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockDeleteKeys.*")
 }
 
 func (s *DeleteKeySuite) TestDeleteKeyNonDefaultUser(c *gc.C) {
@@ -273,13 +272,13 @@ func (s *ImportKeySuite) TestBlockImportKeys(c *gc.C) {
 	s.setAuthorizedKeys(c, key1)
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockImportKeys")
 	_, err := coretesting.RunCommand(c, envcmd.Wrap(&ImportKeysCommand{}), "lp:validuser", "invalid-key")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockImportKeys.*")
 }
 
 func (s *ImportKeySuite) TestImportKeyNonDefaultUser(c *gc.C) {

--- a/cmd/juju/block/block.go
+++ b/cmd/juju/block/block.go
@@ -1,144 +1,19 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package block
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
-
-	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/envcmd"
-	"github.com/juju/juju/environs/config"
 )
-
-var logger = loggo.GetLogger("juju.cmd.juju.block")
-
-// ProtectionCommand is a super for environment protection commands that block/unblock operations.
-type ProtectionCommand struct {
-	envcmd.EnvCommandBase
-	operation string
-	desc      string
-}
-
-// BlockClientAPI defines the client API methods that the protection command uses.
-type ClientAPI interface {
-	Close() error
-	EnvironmentSet(config map[string]interface{}) error
-}
-
-var getBlockClientAPI = func(p *ProtectionCommand) (ClientAPI, error) {
-	return p.NewAPIClient()
-}
-
-var (
-	// blockArgs has all valid operations that can be
-	// supplied to the command.
-	// These operations do not necessarily correspond to juju commands
-	// but are rather juju command groupings.
-	blockArgs = []string{"destroy-environment", "remove-object", "all-changes"}
-
-	// blockArgsFmt has formatted representation of block command valid arguments.
-	blockArgsFmt = fmt.Sprintf(strings.Join(blockArgs, " | "))
-
-	// blockBaseDoc common block doc
-	blockBaseDoc = `
-
-Juju allows to safeguard deployed environments from unintentional damage by preventing
-execution of operations that could alter environment.
-
-This is done by blocking certain commands from successful execution. Blocked commands
-must be manually unblocked to proceed.
-
-Some comands offer a --force option that can be used to bypass a block.
-
-Commands that can be %s are grouped based on logical operations as follows:
-
-destroy-environment includes command:
-    destroy-environment
-
-remove-object includes termination commands:
-    destroy-environment
-    remove-machine
-    remove-relation
-    remove-service
-    remove-unit
-
-all-changes includes all alteration commands
-    add-machine
-    add-relation
-    add-unit
-    authorised-keys add
-    authorised-keys delete
-    authorised-keys import
-    deploy
-    destroy-environment
-    ensure-availability
-    expose
-    remove-machine
-    remove-relation
-    remove-service
-    remove-unit
-    resolved
-    retry-provisioning
-    run
-    set
-    set-constraints
-    set-env
-    sync-tools
-    unexpose
-    unset
-    unset-env
-    upgrade-charm
-    upgrade-juju
-    user add
-    user change-password
-    user disable
-    user enable
-    %s
-`
-)
-
-// setBlockEnvironmentVariable sets desired environment variable to given value.
-func (p *ProtectionCommand) setBlockEnvironmentVariable(block bool) error {
-	client, err := getBlockClientAPI(p)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer client.Close()
-	attrs := map[string]interface{}{config.BlockKeyPrefix + p.operation: block}
-	return client.EnvironmentSet(attrs)
-}
-
-// assignValidOperation verifies that supplied operation is supported.
-func (p *ProtectionCommand) assignValidOperation(cmd string, args []string) error {
-	if len(args) != 1 {
-		return errors.Trace(errors.Errorf("must specify one of [%v] to %v", blockArgsFmt, cmd))
-	}
-	var err error
-	p.operation, err = p.obtainValidArgument(args[0])
-	return err
-}
-
-// obtainValidArgument returns polished argument:
-// it checks that the argument is a supported operation and
-// forces it into lower case for consistency.
-func (p *ProtectionCommand) obtainValidArgument(arg string) (string, error) {
-	for _, valid := range blockArgs {
-		if strings.EqualFold(valid, arg) {
-			return strings.ToLower(arg), nil
-		}
-	}
-	return "", errors.Trace(errors.Errorf("%q is not a valid argument: use one of [%v]", arg, blockArgsFmt))
-}
 
 // BlockCommand blocks specified operation.
 type BlockCommand struct {
 	ProtectionCommand
+	desc string
 }
 
 var (
@@ -177,70 +52,38 @@ func (c *BlockCommand) Info() *cmd.Info {
 // Init initializes the command.
 // Satisfying Command interface.
 func (c *BlockCommand) Init(args []string) error {
-	return c.assignValidOperation("block", args)
+	if err := c.assignValidOperation("block", args); err != nil {
+		return err
+	}
+
+	if len(args) > 2 {
+		return errors.Trace(errors.New("can only specify block type and its message"))
+	}
+
+	if len(args) == 2 {
+		c.desc = args[1]
+	}
+	return nil
 }
 
 // Run blocks commands from running successfully.
 // Satisfying Command interface.
 func (c *BlockCommand) Run(_ *cmd.Context) error {
-	return c.setBlockEnvironmentVariable(true)
-}
-
-// Block describes block type
-type Block int8
-
-const (
-	// BlockDestroy describes the block that
-	// blocks destroy- commands
-	BlockDestroy Block = iota
-
-	// BlockRemove describes the block that
-	// blocks remove- commands
-	BlockRemove
-
-	// BlockChange describes the block that
-	// blocks change commands
-	BlockChange
-)
-
-var blockedMessages = map[Block]string{
-	BlockDestroy: destroyMsg,
-	BlockRemove:  removeMsg,
-	BlockChange:  changeMsg,
-}
-
-// ProcessBlockedError ensures that correct and user-friendly message is
-// displayed to the user based on the block type.
-func ProcessBlockedError(err error, block Block) error {
-	if err == nil {
-		return nil
+	client, err := getBlockClientAPI(c)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	if params.IsCodeOperationBlocked(err) {
-		logger.Errorf(blockedMessages[block])
-		return cmd.ErrSilent
-	}
-	return err
+	defer client.Close()
+
+	return client.SwitchBlockOn(TranslateOperation(c.operation), c.desc)
 }
 
-var removeMsg = `
-All operations that remove (or delete or terminate) machines, services, units or
-relations have been blocked for the current environment.
-To unblock removal, run
+// BlockClientAPI defines the client API methods that block command uses.
+type BlockClientAPI interface {
+	Close() error
+	SwitchBlockOn(blockType, msg string) error
+}
 
-    juju unblock remove-object
-
-`
-var destroyMsg = `
-destroy-environment operation has been blocked for the current environment.
-To remove the block run
-
-    juju unblock destroy-environment
-
-`
-var changeMsg = `
-All operations that change environment have been blocked for the current environment.
-To unblock changes, run
-
-    juju unblock all-changes
-
-`
+var getBlockClientAPI = func(p *BlockCommand) (BlockClientAPI, error) {
+	return p.NewBlockAPI()
+}

--- a/cmd/juju/block/export_test.go
+++ b/cmd/juju/block/export_test.go
@@ -4,5 +4,26 @@
 package block
 
 var (
-	ClientGetter = &getBlockClientAPI
+	BlockClient   = &getBlockClientAPI
+	UnblockClient = &getUnblockClientAPI
 )
+
+type MockBlockClient struct {
+	BlockType string
+	Msg       string
+}
+
+func (c *MockBlockClient) Close() error {
+	return nil
+}
+
+func (c *MockBlockClient) SwitchBlockOn(blockType, msg string) error {
+	c.BlockType = blockType
+	c.Msg = msg
+	return nil
+}
+
+func (c *MockBlockClient) SwitchBlockOff(blockType string) error {
+	c.BlockType = blockType
+	return nil
+}

--- a/cmd/juju/block/package_test.go
+++ b/cmd/juju/block/package_test.go
@@ -8,7 +8,6 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/testing"
 )
 
@@ -18,7 +17,6 @@ func TestAll(t *stdtesting.T) {
 
 type ProtectionCommandSuite struct {
 	testing.FakeJujuHomeSuite
-	mockClient *mockClient
 }
 
 func (s *ProtectionCommandSuite) assertErrorMatches(c *gc.C, err error, expected string) {
@@ -26,25 +24,4 @@ func (s *ProtectionCommandSuite) assertErrorMatches(c *gc.C, err error, expected
 		err,
 		gc.ErrorMatches,
 		expected)
-}
-
-func (s *ProtectionCommandSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuHomeSuite.SetUpTest(c)
-	s.mockClient = &mockClient{}
-	s.PatchValue(block.ClientGetter, func(p *block.ProtectionCommand) (block.ClientAPI, error) {
-		return s.mockClient, nil
-	})
-}
-
-type mockClient struct {
-	cfg map[string]interface{}
-}
-
-func (c *mockClient) Close() error {
-	return nil
-}
-
-func (c *mockClient) EnvironmentSet(attrs map[string]interface{}) error {
-	c.cfg = attrs
-	return nil
 }

--- a/cmd/juju/block/protection.go
+++ b/cmd/juju/block/protection.go
@@ -1,0 +1,199 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package block
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	apiblock "github.com/juju/juju/api/block"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/state/multiwatcher"
+)
+
+var logger = loggo.GetLogger("juju.cmd.juju.block")
+
+// ProtectionCommand is a super for environment protection commands that block/unblock operations.
+type ProtectionCommand struct {
+	envcmd.EnvCommandBase
+	operation string
+}
+
+// NewBlockAPI returns a storage api for block.
+func (c *ProtectionCommand) NewBlockAPI() (*apiblock.Client, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, err
+	}
+	return apiblock.NewClient(root), nil
+}
+
+var TranslateOperation = func(operation string) string {
+	var bt multiwatcher.BlockType
+	switch strings.ToLower(operation) {
+	case "destroy-environment":
+		bt = multiwatcher.BlockDestroy
+	case "remove-object":
+		bt = multiwatcher.BlockRemove
+	case "all-changes":
+		bt = multiwatcher.BlockChange
+	default:
+		panic(fmt.Sprintf("unknown operation %v", operation))
+	}
+	return fmt.Sprintf("%v", bt)
+}
+
+var (
+	// blockArgs has all valid operations that can be
+	// supplied to the command.
+	// These operations do not necessarily correspond to juju commands
+	// but are rather juju command groupings.
+	blockArgs = []string{"destroy-environment", "remove-object", "all-changes"}
+
+	// blockArgsFmt has formatted representation of block command valid arguments.
+	blockArgsFmt = fmt.Sprintf(strings.Join(blockArgs, " | "))
+
+	// blockBaseDoc common block doc
+	blockBaseDoc = `
+
+Juju allows to safeguard deployed environments from unintentional damage by preventing
+execution of operations that could alter environment.
+
+This is done by blocking certain commands from successful execution. Blocked commands
+must be manually unblocked to proceed.
+
+Some comands offer a --force option that can be used to bypass a block.
+
+Commands that can be %s are grouped based on logical operations as follows:
+
+destroy-environment includes command:
+    destroy-environment
+
+remove-object includes termination commands:
+    destroy-environment
+    remove-machine
+    remove-relation
+    remove-service
+    remove-unit
+
+all-changes includes all alteration commands
+    add-machine
+    add-relation
+    add-unit
+    authorised-keys add
+    authorised-keys delete
+    authorised-keys import
+    deploy
+    destroy-environment
+    ensure-availability
+    expose
+    remove-machine
+    remove-relation
+    remove-service
+    remove-unit
+    resolved
+    retry-provisioning
+    run
+    set
+    set-constraints
+    set-env
+    sync-tools
+    unexpose
+    unset
+    unset-env
+    upgrade-charm
+    upgrade-juju
+    user add
+    user change-password
+    user disable
+    user enable
+    %s
+`
+)
+
+// assignValidOperation verifies that supplied operation is supported.
+func (p *ProtectionCommand) assignValidOperation(cmd string, args []string) error {
+	if len(args) < 1 {
+		return errors.Trace(errors.Errorf("must specify one of [%v] to %v", blockArgsFmt, cmd))
+	}
+	var err error
+	p.operation, err = p.obtainValidArgument(args[0])
+	return err
+}
+
+// obtainValidArgument returns polished argument:
+// it checks that the argument is a supported operation and
+// forces it into lower case for consistency.
+func (p *ProtectionCommand) obtainValidArgument(arg string) (string, error) {
+	for _, valid := range blockArgs {
+		if strings.EqualFold(valid, arg) {
+			return strings.ToLower(arg), nil
+		}
+	}
+	return "", errors.Trace(errors.Errorf("%q is not a valid argument: use one of [%v]", arg, blockArgsFmt))
+}
+
+// Block describes block type
+type Block int8
+
+const (
+	// BlockDestroy describes the block that
+	// blocks destroy- commands
+	BlockDestroy Block = iota
+
+	// BlockRemove describes the block that
+	// blocks remove- commands
+	BlockRemove
+
+	// BlockChange describes the block that
+	// blocks change commands
+	BlockChange
+)
+
+var blockedMessages = map[Block]string{
+	BlockDestroy: destroyMsg,
+	BlockRemove:  removeMsg,
+	BlockChange:  changeMsg,
+}
+
+// ProcessBlockedError ensures that correct and user-friendly message is
+// displayed to the user based on the block type.
+func ProcessBlockedError(err error, block Block) error {
+	if err == nil {
+		return nil
+	}
+	if params.IsCodeOperationBlocked(err) {
+		logger.Errorf("\n%v%v", err, blockedMessages[block])
+		return cmd.ErrSilent
+	}
+	return err
+}
+
+var removeMsg = `
+All operations that remove (or delete or terminate) machines, services, units or
+relations have been blocked for the current environment.
+To unblock removal, run
+
+    juju unblock remove-object
+
+`
+var destroyMsg = `
+destroy-environment operation has been blocked for the current environment.
+To remove the block run
+
+    juju unblock destroy-environment
+
+`
+var changeMsg = `
+All operations that change environment have been blocked for the current environment.
+To unblock changes, run
+
+    juju unblock all-changes
+
+`

--- a/cmd/juju/constraints_test.go
+++ b/cmd/juju/constraints_test.go
@@ -1,0 +1,170 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/constraints"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ConstraintsCommandsSuite struct {
+	CmdBlockSuite
+}
+
+var _ = gc.Suite(&ConstraintsCommandsSuite{})
+
+func runCmdLine(c *gc.C, com cmd.Command, args ...string) (code int, stdout, stderr string) {
+	ctx := coretesting.Context(c)
+	code = cmd.Main(com, ctx, args)
+	stdout = ctx.Stdout.(*bytes.Buffer).String()
+	stderr = ctx.Stderr.(*bytes.Buffer).String()
+	c.Logf("args:   %#v\ncode:   %d\nstdout: %q\nstderr: %q", args, code, stdout, stderr)
+	return
+}
+
+func uint64p(val uint64) *uint64 {
+	return &val
+}
+
+func assertSet(c *gc.C, args ...string) {
+	rcode, rstdout, rstderr := runCmdLine(c, envcmd.Wrap(&SetConstraintsCommand{}), args...)
+	c.Assert(rcode, gc.Equals, 0)
+	c.Assert(rstdout, gc.Equals, "")
+	c.Assert(rstderr, gc.Equals, "")
+}
+
+func assertSetBlocked(c *gc.C, args ...string) {
+	rcode, _, _ := runCmdLine(c, envcmd.Wrap(&SetConstraintsCommand{}), args...)
+	c.Assert(rcode, gc.Equals, 1)
+
+	// msg is logged
+	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
+	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+}
+
+func (s *ConstraintsCommandsSuite) TestSetEnviron(c *gc.C) {
+	// Set constraints.
+	assertSet(c, "mem=4G", "cpu-power=250")
+	cons, err := s.State.EnvironConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.DeepEquals, constraints.Value{
+		CpuPower: uint64p(250),
+		Mem:      uint64p(4096),
+	})
+
+	// Clear constraints.
+	assertSet(c)
+	cons, err = s.State.EnvironConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
+}
+
+func (s *ConstraintsCommandsSuite) TestBlockSetEnviron(c *gc.C) {
+	// Block operation
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockSetEnviron")
+	// Set constraints.
+	assertSetBlocked(c, "mem=4G", "cpu-power=250")
+}
+
+func (s *ConstraintsCommandsSuite) TestSetService(c *gc.C) {
+	svc := s.AddTestingService(c, "svc", s.AddTestingCharm(c, "dummy"))
+
+	// Set constraints.
+	assertSet(c, "-s", "svc", "mem=4G", "cpu-power=250")
+	cons, err := svc.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.DeepEquals, constraints.Value{
+		CpuPower: uint64p(250),
+		Mem:      uint64p(4096),
+	})
+
+	// Clear constraints.
+	assertSet(c, "-s", "svc")
+	cons, err = svc.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
+}
+
+func (s *ConstraintsCommandsSuite) TestBlockSetService(c *gc.C) {
+	s.AddTestingService(c, "svc", s.AddTestingCharm(c, "dummy"))
+
+	// Block operation
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockSetEnviron")
+	// Set constraints.
+	assertSetBlocked(c, "-s", "svc", "mem=4G", "cpu-power=250")
+}
+
+func assertSetError(c *gc.C, code int, stderr string, args ...string) {
+	rcode, rstdout, rstderr := runCmdLine(c, envcmd.Wrap(&SetConstraintsCommand{}), args...)
+	c.Assert(rcode, gc.Equals, code)
+	c.Assert(rstdout, gc.Equals, "")
+	c.Assert(rstderr, gc.Matches, "error: "+stderr+"\n")
+}
+
+func (s *ConstraintsCommandsSuite) TestSetErrors(c *gc.C) {
+	assertSetError(c, 2, `invalid service name "badname-0"`, "-s", "badname-0")
+	assertSetError(c, 2, `malformed constraint "="`, "=")
+	assertSetError(c, 2, `malformed constraint "="`, "-s", "s", "=")
+	assertSetError(c, 1, `service "missing" not found`, "-s", "missing")
+}
+
+func assertGet(c *gc.C, stdout string, args ...string) {
+	rcode, rstdout, rstderr := runCmdLine(c, envcmd.Wrap(&GetConstraintsCommand{}), args...)
+	c.Assert(rcode, gc.Equals, 0)
+	c.Assert(rstdout, gc.Equals, stdout)
+	c.Assert(rstderr, gc.Equals, "")
+}
+
+func (s *ConstraintsCommandsSuite) TestGetEnvironEmpty(c *gc.C) {
+	assertGet(c, "")
+}
+
+func (s *ConstraintsCommandsSuite) TestGetEnvironValues(c *gc.C) {
+	cons := constraints.Value{CpuCores: uint64p(64)}
+	err := s.State.SetEnvironConstraints(cons)
+	c.Assert(err, jc.ErrorIsNil)
+	assertGet(c, "cpu-cores=64\n")
+}
+
+func (s *ConstraintsCommandsSuite) TestGetServiceEmpty(c *gc.C) {
+	s.AddTestingService(c, "svc", s.AddTestingCharm(c, "dummy"))
+	assertGet(c, "", "svc")
+}
+
+func (s *ConstraintsCommandsSuite) TestGetServiceValues(c *gc.C) {
+	svc := s.AddTestingService(c, "svc", s.AddTestingCharm(c, "dummy"))
+	err := svc.SetConstraints(constraints.Value{CpuCores: uint64p(64)})
+	c.Assert(err, jc.ErrorIsNil)
+	assertGet(c, "cpu-cores=64\n", "svc")
+}
+
+func (s *ConstraintsCommandsSuite) TestGetFormats(c *gc.C) {
+	cons := constraints.Value{CpuCores: uint64p(64), CpuPower: uint64p(0)}
+	err := s.State.SetEnvironConstraints(cons)
+	c.Assert(err, jc.ErrorIsNil)
+	assertGet(c, "cpu-cores=64 cpu-power=\n", "--format", "constraints")
+	assertGet(c, "cpu-cores: 64\ncpu-power: 0\n", "--format", "yaml")
+	assertGet(c, `{"cpu-cores":64,"cpu-power":0}`+"\n", "--format", "json")
+}
+
+func assertGetError(c *gc.C, code int, stderr string, args ...string) {
+	rcode, rstdout, rstderr := runCmdLine(c, envcmd.Wrap(&GetConstraintsCommand{}), args...)
+	c.Assert(rcode, gc.Equals, code)
+	c.Assert(rstdout, gc.Equals, "")
+	c.Assert(rstderr, gc.Matches, "error: "+stderr+"\n")
+}
+
+func (s *ConstraintsCommandsSuite) TestGetErrors(c *gc.C) {
+	assertGetError(c, 2, `invalid service name "badname-0"`, "badname-0")
+	assertGetError(c, 2, `unrecognized args: \["blether"\]`, "goodname", "blether")
+	assertGetError(c, 1, `service "missing" not found`, "missing")
+}

--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 type DeploySuite struct {
-	testing.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&DeploySuite{})
@@ -85,14 +85,14 @@ func (s *DeploySuite) TestNoCharm(c *gc.C) {
 
 func (s *DeploySuite) TestBlockDeploy(c *gc.C) {
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockDeploy")
 	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
 	err := runDeploy(c, "local:dummy", "some-service-name")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockDeploy.*")
 }
 
 func (s *DeploySuite) TestCharmDir(c *gc.C) {

--- a/cmd/juju/destroyenvironment_test.go
+++ b/cmd/juju/destroyenvironment_test.go
@@ -16,13 +16,12 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type destroyEnvSuite struct {
-	testing.JujuConnSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&destroyEnvSuite{})
@@ -56,7 +55,9 @@ func (s *destroyEnvSuite) checkDestroyEnvironment(c *gc.C, blocked, force bool) 
 	//Setup environment
 	envName := "dummyenv"
 	s.startEnvironment(c, envName)
-	s.AssertConfigParameterUpdated(c, "block-destroy-environment", blocked)
+	if blocked {
+		s.AssertSwitchBlockOn(c, "destroy-environment", "checkDestroyEnvironment")
+	}
 	opc := make(chan dummy.Operation)
 	errc := make(chan error)
 	if force {

--- a/cmd/juju/environment/ensureavailability_test.go
+++ b/cmd/juju/environment/ensureavailability_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/environment"
@@ -99,13 +100,13 @@ func (s *EnsureAvailabilitySuite) TestEnsureAvailability(c *gc.C) {
 }
 
 func (s *EnsureAvailabilitySuite) TestBlockEnsureAvailability(c *gc.C) {
-	s.fake.err = &params.Error{Code: params.CodeOperationBlocked}
+	s.fake.err = common.ErrOperationBlocked("TestBlockEnsureAvailability")
 	_, err := s.runEnsureAvailability(c, "-n", "1")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockEnsureAvailability.*")
 }
 
 func (s *EnsureAvailabilitySuite) TestEnsureAvailabilityPlacementError(c *gc.C) {

--- a/cmd/juju/environment/retryprovisioning_test.go
+++ b/cmd/juju/environment/retryprovisioning_test.go
@@ -141,7 +141,7 @@ func (s *retryProvisioningSuite) TestRetryProvisioning(c *gc.C) {
 }
 
 func (s *retryProvisioningSuite) TestBlockRetryProvisioning(c *gc.C) {
-	s.fake.err = &params.Error{Code: params.CodeOperationBlocked}
+	s.fake.err = common.ErrOperationBlocked("TestBlockRetryProvisioning")
 	command := environment.NewRetryProvisioningCommand(s.fake)
 
 	for i, t := range resolvedMachineTests {
@@ -154,6 +154,6 @@ func (s *retryProvisioningSuite) TestBlockRetryProvisioning(c *gc.C) {
 		c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 		// msg is logged
 		stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-		c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+		c.Check(stripped, gc.Matches, ".*TestBlockRetryProvisioning.*")
 	}
 }

--- a/cmd/juju/environment/set_test.go
+++ b/cmd/juju/environment/set_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/environment"
 	"github.com/juju/juju/testing"
@@ -69,9 +69,9 @@ func (s *SetSuite) TestSettingKnownValue(c *gc.C) {
 }
 
 func (s *SetSuite) TestBlockedError(c *gc.C) {
-	s.fake.err = &params.Error{Code: params.CodeOperationBlocked}
+	s.fake.err = common.ErrOperationBlocked("TestBlockedError")
 	_, err := s.run(c, "special=extra")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged
-	c.Check(c.GetTestLog(), jc.Contains, "To unblock changes")
+	c.Check(c.GetTestLog(), jc.Contains, "TestBlockedError")
 }

--- a/cmd/juju/environment/unset_test.go
+++ b/cmd/juju/environment/unset_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/environment"
 	"github.com/juju/juju/testing"
@@ -51,9 +51,9 @@ func (s *UnsetSuite) TestUnsettingKnownValue(c *gc.C) {
 }
 
 func (s *UnsetSuite) TestBlockedError(c *gc.C) {
-	s.fake.err = &params.Error{Code: params.CodeOperationBlocked}
+	s.fake.err = common.ErrOperationBlocked("TestBlockedError")
 	_, err := s.run(c, "special")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged
-	c.Check(c.GetTestLog(), jc.Contains, "To unblock changes")
+	c.Check(c.GetTestLog(), jc.Contains, "TestBlockedError")
 }

--- a/cmd/juju/expose_test.go
+++ b/cmd/juju/expose_test.go
@@ -12,13 +12,12 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/cmd/envcmd"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
 
 type ExposeSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&ExposeSuite{})
@@ -58,11 +57,11 @@ func (s *ExposeSuite) TestBlockExpose(c *gc.C) {
 	s.AssertService(c, "some-service-name", curl, 1, 0)
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockExpose")
 
 	err = runExpose(c, "some-service-name")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockExpose.*")
 }

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/machine"
@@ -181,12 +182,12 @@ failed to create 2 machines
 }
 
 func (s *AddMachineSuite) TestBlockedError(c *gc.C) {
-	s.fake.addError = &params.Error{Code: params.CodeOperationBlocked}
+	s.fake.addError = common.ErrOperationBlocked("TestBlockedError")
 	_, err := s.run(c)
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockedError.*")
 }
 
 func (s *AddMachineSuite) TestServerIsPreJobManageNetworking(c *gc.C) {

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/testing"
@@ -92,23 +92,23 @@ func (s *RemoveMachineSuite) TestRemoveForce(c *gc.C) {
 }
 
 func (s *RemoveMachineSuite) TestBlockedError(c *gc.C) {
-	s.fake.removeError = &params.Error{Code: params.CodeOperationBlocked}
+	s.fake.removeError = common.ErrOperationBlocked("TestBlockedError")
 	_, err := s.run(c, "1")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(s.fake.forced, jc.IsFalse)
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Assert(stripped, gc.Matches, ".*To unblock removal.*")
+	c.Assert(stripped, gc.Matches, ".*TestBlockedError.*")
 }
 
 func (s *RemoveMachineSuite) TestForceBlockedError(c *gc.C) {
-	s.fake.removeError = &params.Error{Code: params.CodeOperationBlocked}
+	s.fake.removeError = common.ErrOperationBlocked("TestForceBlockedError")
 	_, err := s.run(c, "--force", "1")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(s.fake.forced, jc.IsTrue)
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Assert(stripped, gc.Matches, ".*To unblock removal.*")
+	c.Assert(stripped, gc.Matches, ".*TestForceBlockedError.*")
 }
 
 type fakeRemoveMachineAPI struct {

--- a/cmd/juju/package_test.go
+++ b/cmd/juju/package_test.go
@@ -9,7 +9,10 @@ import (
 
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api/block"
+	cmdblock "github.com/juju/juju/cmd/juju/block"
 	cmdtesting "github.com/juju/juju/cmd/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
 	_ "github.com/juju/juju/provider/dummy" // XXX Why?
 	"github.com/juju/juju/testing"
 )
@@ -29,4 +32,21 @@ func TestRunMain(t *stdtesting.T) {
 	if *cmdtesting.FlagRunMain {
 		Main(flag.Args())
 	}
+}
+
+type CmdBlockSuite struct {
+	jujutesting.RepoSuite
+	blockClient *block.Client
+}
+
+func (s *CmdBlockSuite) SetUpTest(c *gc.C) {
+	s.RepoSuite.SetUpTest(c)
+	s.blockClient = block.NewClient(s.APIState)
+	c.Assert(s.blockClient, gc.NotNil)
+}
+
+// AssertSwitchBlockOn switches on desired block and
+// asserts that no errors were encountered.
+func (s *CmdBlockSuite) AssertSwitchBlockOn(c *gc.C, blockType, msg string) {
+	c.Assert(s.blockClient.SwitchBlockOn(cmdblock.TranslateOperation(blockType), msg), gc.IsNil)
 }

--- a/cmd/juju/removerelation_test.go
+++ b/cmd/juju/removerelation_test.go
@@ -11,13 +11,12 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
 
 type RemoveRelationSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&RemoveRelationSuite{})
@@ -59,12 +58,12 @@ func (s *RemoveRelationSuite) TestBlockRemoveRelation(c *gc.C) {
 	s.setupRelationForRemove(c)
 
 	// block operation
-	s.AssertConfigParameterUpdated(c, "block-remove-object", true)
+	s.AssertSwitchBlockOn(c, "remove-object", "TestBlockRemoveRelation")
 	// Destroy a relation that exists.
 	err := runRemoveRelation(c, "logging", "riak")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock removal.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockRemoveRelation.*")
 }

--- a/cmd/juju/removeservice_test.go
+++ b/cmd/juju/removeservice_test.go
@@ -11,14 +11,13 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
 
 type RemoveServiceSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&RemoveServiceSuite{})
@@ -48,7 +47,7 @@ func (s *RemoveServiceSuite) TestBlockRemoveService(c *gc.C) {
 	s.setupTestService(c)
 
 	// block operation
-	s.AssertConfigParameterUpdated(c, "block-remove-object", true)
+	s.AssertSwitchBlockOn(c, "remove-object", "TestBlockRemoveService")
 	err := runRemoveService(c, "riak")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	riak, err := s.State.Service("riak")
@@ -57,7 +56,7 @@ func (s *RemoveServiceSuite) TestBlockRemoveService(c *gc.C) {
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock removal.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockRemoveService.*")
 }
 
 func (s *RemoveServiceSuite) TestFailure(c *gc.C) {

--- a/cmd/juju/removeunit_test.go
+++ b/cmd/juju/removeunit_test.go
@@ -13,14 +13,13 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/cmd/envcmd"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
 
 type RemoveUnitSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&RemoveUnitSuite{})
@@ -54,12 +53,12 @@ func (s *RemoveUnitSuite) TestBlockRemoveUnit(c *gc.C) {
 	svc := s.setupUnitForRemove(c)
 
 	// block operation
-	s.AssertConfigParameterUpdated(c, "block-remove-object", true)
+	s.AssertSwitchBlockOn(c, "remove-object", "TestBlockRemoveUnit")
 	err := runRemoveUnit(c, "dummy/0", "dummy/1")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	c.Assert(svc.Life(), gc.Equals, state.Alive)
 
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock removal.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockRemoveUnit.*")
 }

--- a/cmd/juju/resolved_test.go
+++ b/cmd/juju/resolved_test.go
@@ -11,14 +11,13 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
 
 type ResolvedSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&ResolvedSuite{})
@@ -117,10 +116,11 @@ func (s *ResolvedSuite) TestBlockResolved(c *gc.C) {
 	}
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockResolved")
+
 	err = runResolved(c, []string{"dummy/2"})
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockResolved.*")
 }

--- a/cmd/juju/run_test.go
+++ b/cmd/juju/run_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/utils/exec"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/testing"
@@ -272,7 +273,6 @@ func (s *RunSuite) TestBlockRunForMachineAndUnit(c *gc.C) {
 	mock := s.setupMockAPI()
 	// Block operation
 	mock.block = true
-	s.AssertConfigParameterUpdated(c, "block-all-changes", "true")
 	_, err := testing.RunCommand(c, envcmd.Wrap(&RunCommand{}),
 		"--format=json", "--machine=0", "--unit=unit/0", "hostname",
 		"-e blah",
@@ -441,10 +441,7 @@ func (m *mockRunAPI) RunOnAllMachines(commands string, timeout time.Duration) ([
 	var result []params.RunResult
 
 	if m.block {
-		return result, &params.Error{
-			Code:    params.CodeOperationBlocked,
-			Message: "The operation has been blocked.",
-		}
+		return result, common.ErrOperationBlocked("The operation has been blocked.")
 	}
 	sortedMachineIds := make([]string, 0, len(m.machines))
 	for machineId := range m.machines {
@@ -468,10 +465,7 @@ func (m *mockRunAPI) Run(runParams params.RunParams) ([]params.RunResult, error)
 	var result []params.RunResult
 
 	if m.block {
-		return result, &params.Error{
-			Code:    params.CodeOperationBlocked,
-			Message: "The operation has been blocked.",
-		}
+		return result, common.ErrOperationBlocked("The operation has been blocked.")
 	}
 	// Just add in ids that match in order.
 	for _, id := range runParams.Machines {

--- a/cmd/juju/set_test.go
+++ b/cmd/juju/set_test.go
@@ -17,13 +17,12 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/cmd/envcmd"
-	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type SetSuite struct {
-	testing.JujuConnSuite
+	CmdBlockSuite
 	svc *state.Service
 	dir string
 }
@@ -36,7 +35,7 @@ var (
 )
 
 func (s *SetSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
+	s.CmdBlockSuite.SetUpTest(c)
 	ch := s.AddTestingCharm(c, "dummy")
 	svc := s.AddTestingService(c, "dummy-service", ch)
 	s.svc = svc
@@ -125,7 +124,7 @@ func (s *SetSuite) TestSetConfig(c *gc.C) {
 
 func (s *SetSuite) TestBlockSetConfig(c *gc.C) {
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockSetConfig")
 	ctx := coretesting.ContextForDir(c, s.dir)
 	code := cmd.Main(envcmd.Wrap(&SetCommand{}), ctx, append([]string{"dummy-service"}, []string{
 		"--config",
@@ -134,7 +133,7 @@ func (s *SetSuite) TestBlockSetConfig(c *gc.C) {
 	c.Check(code, gc.Equals, 1)
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockSetConfig.*")
 }
 
 // assertSetSuccess sets configuration options and checks the expected settings.

--- a/cmd/juju/synctools_test.go
+++ b/cmd/juju/synctools_test.go
@@ -264,15 +264,14 @@ func (s *syncToolsSuite) TestAPIAdapterUploadTools(c *gc.C) {
 
 func (s *syncToolsSuite) TestAPIAdapterBlockUploadTools(c *gc.C) {
 	syncTools = func(sctx *sync.SyncContext) error {
-		return common.ErrOperationBlocked
+		// Block operation
+		return common.ErrOperationBlocked("TestAPIAdapterBlockUploadTools")
 	}
-	// Block operation
-	s.PatchEnvironment("block-all-changes", "true")
 	_, err := runSyncToolsCommand(c, "-e", "test-target", "--destination", c.MkDir(), "--stream", "released")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestAPIAdapterBlockUploadTools.*")
 }
 
 type fakeSyncToolsAPI struct {

--- a/cmd/juju/unexpose_test.go
+++ b/cmd/juju/unexpose_test.go
@@ -12,13 +12,12 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/cmd/envcmd"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
 
 type UnexposeSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 }
 
 var _ = gc.Suite(&UnexposeSuite{})
@@ -62,10 +61,10 @@ func (s *UnexposeSuite) TestBlockUnexpose(c *gc.C) {
 	s.AssertService(c, "some-service-name", curl, 1, 0)
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockUnexpose")
 	err = runExpose(c, "some-service-name")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockUnexpose.*")
 }

--- a/cmd/juju/unset_test.go
+++ b/cmd/juju/unset_test.go
@@ -13,13 +13,12 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/cmd/envcmd"
-	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type UnsetSuite struct {
-	testing.JujuConnSuite
+	CmdBlockSuite
 	svc *state.Service
 	dir string
 }
@@ -27,7 +26,7 @@ type UnsetSuite struct {
 var _ = gc.Suite(&UnsetSuite{})
 
 func (s *UnsetSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
+	s.CmdBlockSuite.SetUpTest(c)
 	ch := s.AddTestingCharm(c, "dummy")
 	svc := s.AddTestingService(c, "dummy-service", ch)
 	s.svc = svc
@@ -63,14 +62,14 @@ func (s *UnsetSuite) TestBlockUnset(c *gc.C) {
 	})
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockUnset")
 
 	ctx := coretesting.ContextForDir(c, s.dir)
 	code := cmd.Main(envcmd.Wrap(&UnsetCommand{}), ctx, append([]string{"dummy-service"}, []string{"username"}...))
 	c.Check(code, gc.Equals, 1)
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockUnset.*")
 }
 
 func (s *UnsetSuite) TestUnsetOptionMultipleAtOnceSuccess(c *gc.C) {

--- a/cmd/juju/upgradecharm_test.go
+++ b/cmd/juju/upgradecharm_test.go
@@ -99,7 +99,7 @@ func (s *UpgradeCharmErrorsSuite) TestInvalidRevision(c *gc.C) {
 }
 
 type UpgradeCharmSuccessSuite struct {
-	jujutesting.RepoSuite
+	CmdBlockSuite
 	path string
 	riak *state.Service
 }
@@ -107,7 +107,7 @@ type UpgradeCharmSuccessSuite struct {
 var _ = gc.Suite(&UpgradeCharmSuccessSuite{})
 
 func (s *UpgradeCharmSuccessSuite) SetUpTest(c *gc.C) {
-	s.RepoSuite.SetUpTest(c)
+	s.CmdBlockSuite.SetUpTest(c)
 	s.path = testcharms.Repo.ClonedDirPath(s.SeriesPath, "riak")
 	err := runDeploy(c, "local:riak", "riak")
 	c.Assert(err, jc.ErrorIsNil)
@@ -147,12 +147,12 @@ func (s *UpgradeCharmSuccessSuite) TestLocalRevisionUnchanged(c *gc.C) {
 
 func (s *UpgradeCharmSuccessSuite) TestBlockUpgradeCharm(c *gc.C) {
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockUpgradeCharm")
 	err := runUpgradeCharm(c, "riak")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockUpgradeCharm.*")
 }
 
 func (s *UpgradeCharmSuccessSuite) TestRespectsLocalRevisionWhenPossible(c *gc.C) {
@@ -196,12 +196,12 @@ func (s *UpgradeCharmSuccessSuite) TestBlockUpgradesWithBundle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockUpgradesWithBundle")
 	err = runUpgradeCharm(c, "riak")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
+	c.Check(stripped, gc.Matches, ".*TestBlockUpgradesWithBundle.*")
 }
 
 func (s *UpgradeCharmSuccessSuite) TestForcedUpgrade(c *gc.C) {
@@ -214,7 +214,7 @@ func (s *UpgradeCharmSuccessSuite) TestForcedUpgrade(c *gc.C) {
 
 func (s *UpgradeCharmSuccessSuite) TestBlockForcedUpgrade(c *gc.C) {
 	// Block operation
-	s.AssertConfigParameterUpdated(c, "block-all-changes", true)
+	s.AssertSwitchBlockOn(c, "all-changes", "TestBlockForcedUpgrade")
 	err := runUpgradeCharm(c, "riak", "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertUpgraded(c, 8, true)

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -14,7 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/testing"
@@ -209,10 +209,7 @@ type mockAddUserAPI struct {
 
 func (m *mockAddUserAPI) AddUser(username, displayname, password string) (names.UserTag, error) {
 	if m.blocked {
-		return names.UserTag{}, &params.Error{
-			Code:    params.CodeOperationBlocked,
-			Message: "The operation has been blocked.",
-		}
+		return names.UserTag{}, common.ErrOperationBlocked("The operation has been blocked.")
 	}
 
 	m.username = username

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -578,10 +578,3 @@ func (s *JujuConnSuite) AgentConfigForTag(c *gc.C, tag names.Tag) agent.ConfigSe
 	c.Assert(err, jc.ErrorIsNil)
 	return config
 }
-
-// AssertConfigParameterUpdated updates environment parameter and
-// asserts that no errors were encountered
-func (s *JujuConnSuite) AssertConfigParameterUpdated(c *gc.C, key string, value interface{}) {
-	err := s.BackingState.UpdateEnvironConfig(map[string]interface{}{key: value}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-}


### PR DESCRIPTION
This PR plugs commands and operations into a new implementation of blocks.
Despite its size, most of changes are mechanical. These files contains the most logic changes:

github.com/juju/juju/cmd/juju/block/block.go
github.com/juju/juju/apiserver/client/api_test.go
github.com/juju/juju/cmd/juju/block/block.go
github.com/juju/juju/apiserver/common/block.go
github.com/juju/juju/apiserver/common/testing/block.go
github.com/juju/juju/cmd/juju/block/block_test.go
github.com/juju/juju/apiserver/common/block_test.go
github.com/juju/juju/api/client.go
github.com/juju/juju/apiserver/client/client.go
github.com/juju/juju/apiserver/common/errors.go
github.com/juju/juju/cmd/juju/block/export_test.go
github.com/juju/juju/cmd/juju/package_test.go
github.com/juju/juju/cmd/juju/block/protection.go
github.com/juju/juju/apiserver/tools.go
github.com/juju/juju/cmd/juju/block/unblock.go
github.com/juju/juju/cmd/juju/upgradejuju_test.go
