### PR TITLE
Merge pull request #1633 from wallyworld/apt-cloud-image-utils

### DIFF
--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -67,7 +67,7 @@ func templateUserData(
 	if enablePackageUpdates {
 		cloudinit.MaybeAddCloudArchiveCloudTools(config, series)
 	}
-	cloudinit.AddAptCommands(aptProxy, aptMirror, config, enablePackageUpdates, enableOSUpgrades)
+	cloudinit.AddAptCommands(series, aptProxy, aptMirror, config, enablePackageUpdates, enableOSUpgrades)
 	config.AddScripts(
 		fmt.Sprintf(
 			"printf '%%s\n' %s > %s",

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -185,6 +186,7 @@ const NonceFile = "nonce.txt"
 // packages, the request to do the apt-get update/upgrade on boot, and adds
 // the apt proxy and mirror settings if there are any.
 func AddAptCommands(
+	series string,
 	proxySettings proxy.Settings,
 	aptMirror string,
 	c *cloudinit.Config,
@@ -207,14 +209,24 @@ func AddAptCommands(
 	// If we're not doing an update, adding these packages is
 	// meaningless.
 	if addUpdateScripts {
-		c.AddPackage("curl")
-		c.AddPackage("cpu-checker")
-		// TODO(axw) 2014-07-02 #1277359
-		// Don't install bridge-utils in cloud-init;
-		// leave it to the networker worker.
-		c.AddPackage("bridge-utils")
-		c.AddPackage("rsyslog-gnutls")
-		c.AddPackage("cloud-image-utils")
+		requiredPackages := []string{
+			"curl",
+			"cpu-checker",
+			// TODO(axw) 2014-07-02 #1277359
+			// Don't install bridge-utils in cloud-init;
+			// leave it to the networker worker.
+			"bridge-utils",
+			"rsyslog-gnutls",
+			"cloud-utils",
+			"cloud-image-utils",
+		}
+
+		// The required packages need to come from the correct repo.
+		// For precise, that might require an explicit --target-release parameter.
+		aptGetInstallCommandList := apt.GetPreparePackages(requiredPackages, series)
+		for _, cmds := range aptGetInstallCommandList {
+			c.AddPackage(strings.Join(cmds, " "))
+		}
 	}
 
 	// Write out the apt proxy settings

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 
@@ -761,10 +762,12 @@ func checkPackage(c *gc.C, x map[interface{}]interface{}, pkg string, match bool
 	found := false
 	for _, p0 := range pkgs {
 		p := p0.(string)
-		hasTargetRelease := strings.Contains(p, "--target-release")
-		hasQuotedPkg := strings.Contains(p, "'"+pkg+"'")
-		if p == pkg || (hasTargetRelease && hasQuotedPkg) {
+		// p might be a space separate list of packages eg 'foo bar qed' so split them up
+		manyPkgs := set.NewStrings(strings.Split(p, " ")...)
+		hasPkg := manyPkgs.Contains(pkg)
+		if p == pkg || hasPkg {
 			found = true
+			break
 		}
 	}
 	switch {

--- a/environs/cloudinit/cloudinit_ubuntu.go
+++ b/environs/cloudinit/cloudinit_ubuntu.go
@@ -131,6 +131,7 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 	}
 
 	AddAptCommands(
+		w.mcfg.Series,
 		w.mcfg.AptProxySettings,
 		w.mcfg.AptMirror,
 		w.conf,

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/set"
 	"gopkg.in/amz.v2/aws"
 	amzec2 "gopkg.in/amz.v2/ec2"
 	"gopkg.in/amz.v2/ec2/ec2test"
@@ -1036,8 +1037,12 @@ func CheckPackage(c *gc.C, userDataMap map[interface{}]interface{}, pkg string, 
 	found := false
 	for _, p0 := range pkgs {
 		p := p0.(string)
-		if p == pkg {
+		// p might be a space separate list of packages eg 'foo bar qed' so split them up
+		manyPkgs := set.NewStrings(strings.Split(p, " ")...)
+		hasPkg := manyPkgs.Contains(pkg)
+		if p == pkg || hasPkg {
 			found = true
+			break
 		}
 	}
 	switch {


### PR DESCRIPTION
Ensure cloud-utils and cloud-image-utils are installed from precise cloud archive

For precise, cloud-utils and cloud-image-utils need to be installed from the cloud tools archive.
There was some existing apt infrastructure which could be tweaked to do what's needed.

Tested on AWS with precise, trusty and utopic.

(Review request: http://reviews.vapour.ws/r/963/)

(Review request: http://reviews.vapour.ws/r/966/)