### PR TITLE
state: update handling of storage lifecycle

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 )
@@ -22,6 +23,7 @@ const (
 	cleanupRemovedUnit                 cleanupKind = "removedUnit"
 	cleanupServicesForDyingEnvironment cleanupKind = "services"
 	cleanupForceDestroyedMachine       cleanupKind = "machine"
+	cleanupAttachmentsForDyingStorage  cleanupKind = "storageAttachments"
 )
 
 // cleanupDoc represents a potentially large set of documents that should be
@@ -84,6 +86,8 @@ func (st *State) Cleanup() error {
 			err = st.cleanupServicesForDyingEnvironment()
 		case cleanupForceDestroyedMachine:
 			err = st.cleanupForceDestroyedMachine(doc.Prefix)
+		case cleanupAttachmentsForDyingStorage:
+			err = st.cleanupAttachmentsForDyingStorage(doc.Prefix)
 		default:
 			err = fmt.Errorf("unknown cleanup kind %q", doc.Kind)
 		}
@@ -329,4 +333,32 @@ func (st *State) obliterateUnit(unitName string) error {
 		return err
 	}
 	return unit.Remove()
+}
+
+// cleanupAttachmentsForDyingStorage sets all storage attachments related
+// to the specified storage instance to Dying, if they are not already Dying
+// or Dead. It's expected to be used when a storage instance is destroyed.
+func (st *State) cleanupAttachmentsForDyingStorage(storageId string) error {
+	storageTag := names.NewStorageTag(storageId)
+
+	// This won't miss attachments, because a Dying service cannot have
+	// attachments added to it. But we do have to remove the attachments
+	// themselves via individual transactions, because they could be in
+	// any state at all.
+	coll, closer := st.getCollection(storageAttachmentsC)
+	defer closer()
+
+	var doc storageAttachmentDoc
+	fields := bson.D{{"unitid", 1}}
+	iter := coll.Find(bson.D{{"storageinstanceid", storageId}}).Select(fields).Iter()
+	for iter.Next(&doc) {
+		unitTag := names.NewUnitTag(doc.Unit)
+		if err := st.DestroyStorageAttachment(storageTag, unitTag); err != nil {
+			return errors.Annotate(err, "destroying storage attachment")
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Annotate(err, "cannot read storage attachment document")
+	}
+	return nil
 }

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -364,6 +364,7 @@ func (s *CleanupSuite) TestCleanupStorage(c *gc.C) {
 	// check no cleanups
 	s.assertDoesNotNeedCleanup(c)
 
+	// this tag matches the storage instance created for the unit above.
 	storageTag := names.NewStorageTag("data/0")
 
 	si, err := s.State.StorageInstance(storageTag)

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
@@ -344,6 +345,48 @@ func (s *CleanupSuite) TestCleanupActions(c *gc.C) {
 	actions, err = unit.PendingActions()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(actions), gc.Equals, 0)
+
+	// check no cleanups
+	s.assertDoesNotNeedCleanup(c)
+}
+
+func (s *CleanupSuite) TestCleanupStorage(c *gc.C) {
+	s.assertDoesNotNeedCleanup(c)
+
+	ch := s.AddTestingCharm(c, "storage-block")
+	storage := map[string]state.StorageConstraints{
+		"data": makeStorageCons("block", 1024, 1),
+	}
+	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
+	u, err := service.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// check no cleanups
+	s.assertDoesNotNeedCleanup(c)
+
+	storageTag := names.NewStorageTag("data/0")
+
+	si, err := s.State.StorageInstance(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(si.Life(), gc.Equals, state.Alive)
+
+	// destroy storage instance and run cleanups
+	err = s.State.DestroyStorageInstance(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	si, err = s.State.StorageInstance(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(si.Life(), gc.Equals, state.Dying)
+	sa, err := s.State.StorageAttachments(u.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sa, gc.HasLen, 1)
+	c.Assert(sa[0].Life(), gc.Equals, state.Alive)
+	s.assertCleanupRuns(c)
+
+	// After running the cleanup, the attachment should be dying.
+	sa, err = s.State.StorageAttachments(u.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sa, gc.HasLen, 1)
+	c.Assert(sa[0].Life(), gc.Equals, state.Dying)
 
 	// check no cleanups
 	s.assertDoesNotNeedCleanup(c)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -30,6 +30,7 @@ const (
 	UnitsC             = unitsC
 	UsersC             = usersC
 	BlockDevicesC      = blockDevicesC
+	StorageInstancesC  = storageInstancesC
 )
 
 var (

--- a/state/open.go
+++ b/state/open.go
@@ -173,6 +173,8 @@ var indexes = []struct {
 	{ipaddressesC, []string{"env-uuid", "state"}, false, false},
 	{ipaddressesC, []string{"env-uuid", "subnetid"}, false, false},
 	{storageInstancesC, []string{"env-uuid", "owner"}, false, false},
+	{storageAttachmentsC, []string{"env-uuid", "storageinstanceid"}, false, false},
+	{storageAttachmentsC, []string{"env-uuid", "unitid"}, false, false},
 }
 
 // The capped collection used for transaction logs defaults to 10MB.

--- a/state/service.go
+++ b/state/service.go
@@ -585,7 +585,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	}
 
 	// Create instances of the charm's declared stores.
-	storageInstanceOps, storageInstanceIds, err := s.unitStorageInstanceOps(name)
+	storageOps, storageAttachments, err := s.unitStorageOps(name)
 	if err != nil {
 		return "", nil, errors.Trace(err)
 	}
@@ -594,14 +594,14 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	globalKey := unitGlobalKey(name)
 	agentGlobalKey := unitAgentGlobalKey(name)
 	udoc := &unitDoc{
-		DocID:            docID,
-		Name:             name,
-		EnvUUID:          s.doc.EnvUUID,
-		Service:          s.doc.Name,
-		Series:           s.doc.Series,
-		Life:             Alive,
-		Principal:        principalName,
-		StorageInstances: storageInstanceIds,
+		DocID:                  docID,
+		Name:                   name,
+		EnvUUID:                s.doc.EnvUUID,
+		Service:                s.doc.Name,
+		Series:                 s.doc.Series,
+		Life:                   Alive,
+		Principal:              principalName,
+		StorageAttachmentCount: len(storageAttachments),
 	}
 	agentStatusDoc := statusDoc{
 		Status:  StatusAllocating,
@@ -628,7 +628,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 			Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
 		},
 	}
-	ops = append(ops, storageInstanceOps...)
+	ops = append(ops, storageOps...)
 
 	if s.doc.Subordinate {
 		ops = append(ops, txn.Op{
@@ -653,9 +653,9 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	return name, ops, nil
 }
 
-// createUnitStorageInstanceOps returns transactions operations for
-// creating storage instances for a new unit.
-func (s *Service) unitStorageInstanceOps(unitName string) (ops []txn.Op, storageInstanceIds []string, err error) {
+// unitStorageOps returns operations for creating storage
+// instances and attachments for a new unit.
+func (s *Service) unitStorageOps(unitName string) (ops []txn.Op, storageAttachments []names.StorageTag, err error) {
 	cons, err := s.StorageConstraints()
 	if err != nil {
 		return nil, nil, err
@@ -667,13 +667,11 @@ func (s *Service) unitStorageInstanceOps(unitName string) (ops []txn.Op, storage
 	meta := charm.Meta()
 	tag := names.NewUnitTag(unitName)
 	// TODO(wallyworld) - record constraints info in data model - size and pool name
-	ops, storageInstanceIds, err = createStorageInstanceOps(s.st, tag, meta, cons)
+	ops, storageAttachments, err = createStorageOps(s.st, tag, meta, cons)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	attachmentOps := createStorageAttachmentOps(tag, storageInstanceIds)
-	ops = append(ops, attachmentOps...)
-	return ops, storageInstanceIds, nil
+	return ops, storageAttachments, nil
 }
 
 // SCHEMACHANGE

--- a/state/storage.go
+++ b/state/storage.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/featureflag"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -40,6 +42,9 @@ type StorageInstance interface {
 	// but identifies the group that the instances belong to.
 	StorageName() string
 
+	// Life reports whether the storage instance is Alive, Dying or Dead.
+	Life() Life
+
 	// Info returns the storage instance's StorageInstanceInfo, or a
 	// NotProvisioned error if the storage instance has not yet been
 	// provisioned.
@@ -57,6 +62,9 @@ type StorageAttachment interface {
 
 	// Unit returns the tag of the corresponding unit.
 	Unit() names.UnitTag
+
+	// Life reports whether the storage attachment is Alive, Dying or Dead.
+	Life() Life
 
 	// Info returns the storage attachments's StorageAttachmentInfo, or
 	// a NotProvisioned error if the storage attachment has not yet been
@@ -105,6 +113,10 @@ func (s *storageInstance) StorageName() string {
 	return s.doc.StorageName
 }
 
+func (s *storageInstance) Life() Life {
+	return s.doc.Life
+}
+
 func (s *storageInstance) Info() (StorageInstanceInfo, error) {
 	if s.doc.Info == nil {
 		return StorageInstanceInfo{}, errors.NotProvisionedf("storage instance %q", s.doc.Id)
@@ -117,12 +129,13 @@ type storageInstanceDoc struct {
 	DocID   string `bson:"_id"`
 	EnvUUID string `bson:"env-uuid"`
 
-	Id           string      `bson:"id"`
-	Kind         StorageKind `bson:"storagekind"`
-	Life         Life        `bson:"life"`
-	Owner        string      `bson:"owner"`
-	StorageName  string      `bson:"storagename"`
-	BlockDevices []string    `bson:"blockdevices,omitempty"`
+	Id              string      `bson:"id"`
+	Kind            StorageKind `bson:"storagekind"`
+	Life            Life        `bson:"life"`
+	Owner           string      `bson:"owner"`
+	StorageName     string      `bson:"storagename"`
+	BlockDevices    []string    `bson:"blockdevices,omitempty"`
+	AttachmentCount int         `bson:"attachmentcount"`
 
 	Info *StorageInstanceInfo `bson:"info,omitempty"`
 }
@@ -143,6 +156,10 @@ func (s *storageAttachment) StorageInstance() names.StorageTag {
 
 func (s *storageAttachment) Unit() names.UnitTag {
 	return names.NewUnitTag(s.doc.Unit)
+}
+
+func (s *storageAttachment) Life() Life {
+	return s.doc.Life
 }
 
 func (s *storageAttachment) Info() (StorageAttachmentInfo, error) {
@@ -196,6 +213,11 @@ func storageAttachmentId(unit string, storageInstanceId string) string {
 
 // StorageInstance returns the StorageInstance with the specified tag.
 func (st *State) StorageInstance(tag names.StorageTag) (StorageInstance, error) {
+	s, err := st.storageInstance(tag)
+	return s, err
+}
+
+func (st *State) storageInstance(tag names.StorageTag) (*storageInstance, error) {
 	storageInstances, cleanup := st.getCollection(storageInstancesC)
 	defer cleanup()
 
@@ -209,21 +231,98 @@ func (st *State) StorageInstance(tag names.StorageTag) (StorageInstance, error) 
 	return &s, nil
 }
 
-// RemoveStorageInstance removes the storage instance with the specified tag.
-func (st *State) RemoveStorageInstance(tag names.StorageTag) error {
-	// TODO(axw) ensure we cannot remove storage instance while
-	// there are attachments outstanding.
-	ops := []txn.Op{{
-		C:      storageInstancesC,
-		Id:     tag.Id(),
-		Remove: true,
-	}}
-	return st.runTransaction(ops)
+// DestroyStorageInstance ensures that the storage instance and all its
+// attachments will be removed at some point; if the storage instance has
+// no attachments, it will be removed immediately.
+func (st *State) DestroyStorageInstance(tag names.StorageTag) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot destroy storage %q", tag.Id())
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		s, err := st.storageInstance(tag)
+		if errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		switch ops, err := st.destroyStorageInstanceOps(s); err {
+		case errAlreadyDying:
+			return nil, jujutxn.ErrNoOperations
+		case nil:
+			return ops, nil
+		default:
+			return nil, errors.Trace(err)
+		}
+		return nil, jujutxn.ErrTransientFailure
+	}
+	return st.run(buildTxn)
 }
 
-// createStorageInstanceOps returns txn.Ops for creating storage instances.
+func (st *State) destroyStorageInstanceOps(s *storageInstance) ([]txn.Op, error) {
+	if s.doc.Life == Dying {
+		return nil, errAlreadyDying
+	}
+	if s.doc.AttachmentCount == 0 {
+		// There are no attachments remaining, so we can
+		// remove the storage instance immediately.
+		hasNoAttachments := bson.D{{"attachmentcount", 0}}
+		assert := append(hasNoAttachments, isAliveDoc...)
+		return removeStorageInstanceOps(s.StorageTag(), assert), nil
+	}
+	// There are still attachments: the storage instance will be removed
+	// when the last attachment is removed. We schedule a cleanup to destroy
+	// attachments.
+	notLastRefs := bson.D{
+		{"life", Alive},
+		{"attachmentcount", bson.D{{"$gt", 0}}},
+	}
+	update := bson.D{{"$set", bson.D{{"life", Dying}}}}
+	ops := []txn.Op{
+		st.newCleanupOp(cleanupAttachmentsForDyingStorage, s.doc.Id),
+		{
+			C:      storageInstancesC,
+			Id:     s.doc.Id,
+			Assert: notLastRefs,
+			Update: update,
+		},
+	}
+	return ops, nil
+}
+
+// RemoveStorageInstance removes the storage instance with the specified tag.
+func (st *State) RemoveStorageInstance(tag names.StorageTag) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot remove storage %q", tag.Id())
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		s, err := st.storageInstance(tag)
+		if errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if s.doc.Life != Dead {
+			return nil, errors.New("storage is not dead")
+		}
+		if s.doc.AttachmentCount != 0 {
+			return nil, errors.New("storage has attachments")
+		}
+		hasNoAttachments := bson.D{{"attachmentcount", 0}}
+		assert := append(hasNoAttachments, isDeadDoc...)
+		return removeStorageInstanceOps(tag, assert), nil
+	}
+	return st.run(buildTxn)
+}
+
+func removeStorageInstanceOps(tag names.StorageTag, assert bson.D) []txn.Op {
+	return []txn.Op{{
+		C:      storageInstancesC,
+		Id:     tag.Id(),
+		Assert: assert,
+		Remove: true,
+	}}
+}
+
+// createStorageOps returns txn.Ops for creating storage instances
+// and attachments for the newly created unit or service.
 //
-// The owner tag identifies the entity that owns the storage instance:
+// The entity tag identifies the entity that owns the storage instance
 // either a unit or a service. Shared storage instances are owned by a
 // service, and non-shared storage instances are owned by a unit.
 //
@@ -235,12 +334,12 @@ func (st *State) RemoveStorageInstance(tag names.StorageTag) error {
 // instances to be created, keyed on the storage name. These constraints
 // will be correlated with the charm storage metadata for validation
 // and supplementing.
-func createStorageInstanceOps(
+func createStorageOps(
 	st *State,
-	ownerTag names.Tag,
+	entity names.Tag,
 	charmMeta *charm.Meta,
 	cons map[string]StorageConstraints,
-) (ops []txn.Op, storageInstanceIds []string, err error) {
+) (ops []txn.Op, storageAttachments []names.StorageTag, err error) {
 
 	type template struct {
 		storageName string
@@ -248,22 +347,31 @@ func createStorageInstanceOps(
 		cons        StorageConstraints
 	}
 
-	includeShared := false
-	switch ownerTag.(type) {
+	createdShared := false
+	switch entity := entity.(type) {
 	case names.ServiceTag:
-		includeShared = true
+		createdShared = true
 	case names.UnitTag:
 	default:
-		return nil, nil, errors.Errorf("expected service or unit tag, got %T", ownerTag)
+		return nil, nil, errors.Errorf("expected service or unit tag, got %T", entity)
+	}
+
+	// Create storage instances in order of name, to simplify testing.
+	storageNames := set.NewStrings()
+	for name := range cons {
+		storageNames.Add(name)
 	}
 
 	templates := make([]template, 0, len(cons))
-	for store, cons := range cons {
+	for _, store := range storageNames.SortedValues() {
+		cons := cons[store]
 		charmStorage, ok := charmMeta.Storage[store]
 		if !ok {
 			return nil, nil, errors.NotFoundf("charm storage %q", store)
 		}
-		if !includeShared && charmStorage.Shared {
+		if createdShared != charmStorage.Shared {
+			// services only get shared storage instances,
+			// units only get non-shared storage instances.
 			continue
 		}
 		templates = append(templates, template{
@@ -273,10 +381,10 @@ func createStorageInstanceOps(
 		})
 	}
 
-	ops = make([]txn.Op, 0, len(templates))
-	storageInstanceIds = make([]string, 0, len(templates))
+	ops = make([]txn.Op, 0, len(templates)*2)
+	storageAttachments = make([]names.StorageTag, 0, len(templates))
 	for _, t := range templates {
-		owner := ownerTag.String()
+		owner := entity.String()
 		var kind StorageKind
 		switch t.meta.Type {
 		case charm.StorageBlock:
@@ -292,38 +400,50 @@ func createStorageInstanceOps(
 			if err != nil {
 				return nil, nil, errors.Annotate(err, "cannot generate storage instance name")
 			}
+			doc := &storageInstanceDoc{
+				Id:          id,
+				Kind:        kind,
+				Owner:       owner,
+				StorageName: t.storageName,
+			}
+			if unit, ok := entity.(names.UnitTag); ok {
+				doc.AttachmentCount = 1
+				storage := names.NewStorageTag(id)
+				ops = append(ops, createStorageAttachmentOp(storage, unit))
+				storageAttachments = append(storageAttachments, storage)
+			}
 			ops = append(ops, txn.Op{
 				C:      storageInstancesC,
 				Id:     id,
 				Assert: txn.DocMissing,
-				Insert: &storageInstanceDoc{
-					Id:          id,
-					Kind:        kind,
-					Owner:       owner,
-					StorageName: t.storageName,
-				},
+				Insert: doc,
 			})
-			storageInstanceIds = append(storageInstanceIds, id)
 		}
 	}
-	return ops, storageInstanceIds, nil
+
+	// TODO(axw) create storage attachments for each shared storage
+	// instance owned by the service.
+	//
+	// TODO(axw) prevent creation of shared storage after service
+	// creation, because the only sane time to add storage attachments
+	// is when units are added to said service.
+
+	return ops, storageAttachments, nil
 }
 
-// createStorageAttachmentOps returns txn.Ops for creating storage attachments.
-func createStorageAttachmentOps(unit names.UnitTag, storageInstanceIds []string) []txn.Op {
-	ops := make([]txn.Op, len(storageInstanceIds))
-	for i, storageInstanceId := range storageInstanceIds {
-		ops[i] = txn.Op{
-			C:      storageAttachmentsC,
-			Id:     storageAttachmentId(unit.Id(), storageInstanceId),
-			Assert: txn.DocMissing,
-			Insert: &storageAttachmentDoc{
-				Unit:            unit.Id(),
-				StorageInstance: storageInstanceId,
-			},
-		}
+// createStorageAttachmentOps returns a txn.Op for creating a storage attachment.
+// The caller is responsible for updating the attachmentcount field of the storage
+// instance.
+func createStorageAttachmentOp(storage names.StorageTag, unit names.UnitTag) txn.Op {
+	return txn.Op{
+		C:      storageAttachmentsC,
+		Id:     storageAttachmentId(unit.Id(), storage.Id()),
+		Assert: txn.DocMissing,
+		Insert: &storageAttachmentDoc{
+			Unit:            unit.Id(),
+			StorageInstance: storage.Id(),
+		},
 	}
-	return ops
 }
 
 // StorageAttachments returns the StorageAttachments for the specified unit.
@@ -340,6 +460,150 @@ func (st *State) StorageAttachments(unit names.UnitTag) ([]StorageAttachment, er
 		storageAttachments[i] = &storageAttachment{doc}
 	}
 	return storageAttachments, nil
+}
+
+func (st *State) storageAttachment(storage names.StorageTag, unit names.UnitTag) (*storageAttachment, error) {
+	coll, closer := st.getCollection(storageAttachmentsC)
+	defer closer()
+	var s storageAttachment
+	if err := coll.FindId(storageAttachmentId(unit.Id(), storage.Id())).One(&s.doc); err != nil {
+		return nil, errors.Annotatef(err, "cannot get storage attachment %s/%s", storage.Id(), unit.Id())
+	}
+	return &s, nil
+}
+
+// DestroyStorageAttachment ensures that the storage attachment will be
+// removed at some point.
+func (st *State) DestroyStorageAttachment(storage names.StorageTag, unit names.UnitTag) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot destroy storage attachment %s/%s", storage.Id(), unit.Id())
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		s, err := st.storageAttachment(storage, unit)
+		if errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if s.doc.Life == Dying {
+			return nil, jujutxn.ErrNoOperations
+		}
+		return destroyStorageAttachmentOps(s), nil
+	}
+	return st.run(buildTxn)
+}
+
+func destroyStorageAttachmentOps(s *storageAttachment) []txn.Op {
+	ops := []txn.Op{{
+		C:      storageAttachmentsC,
+		Id:     storageAttachmentId(s.doc.Unit, s.doc.StorageInstance),
+		Assert: isAliveDoc,
+		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
+	}}
+	return ops
+}
+
+// EnsureStorageAttachmentDead ensures that the storage attachment is Dead
+// if it exists at all, doing nothing if it does not exist.
+func (st *State) EnsureStorageAttachmentDead(storage names.StorageTag, unit names.UnitTag) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot ensure death of storage attachment %s:%s", storage.Id(), unit.Id())
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		s, err := st.storageAttachment(storage, unit)
+		if errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if s.doc.Life == Dead {
+			return nil, jujutxn.ErrNoOperations
+		}
+		return ensureStorageAttachmentDeadOps(s), nil
+	}
+	return st.run(buildTxn)
+}
+
+func ensureStorageAttachmentDeadOps(s *storageAttachment) []txn.Op {
+	ops := []txn.Op{{
+		C:      storageAttachmentsC,
+		Id:     storageAttachmentId(s.doc.Unit, s.doc.StorageInstance),
+		Assert: notDeadDoc,
+		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
+	}}
+	return ops
+}
+
+// Remove removes the storage attachment from state, and may remove its storage
+// instance as well, if the storage instance is Dying and no other references to
+// it exist. It will fail if the storage attachment is not Dead.
+func (st *State) RemoveStorageAttachment(storage names.StorageTag, unit names.UnitTag) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot remove storage attachment %s:%s", storage.Id(), unit.Id())
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		s, err := st.storageAttachment(storage, unit)
+		if errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		inst, err := st.storageInstance(storage)
+		if errors.IsNotFound(err) {
+			// This implies that the attachment was removed
+			// after the call to st.storageAttachment.
+			return nil, jujutxn.ErrNoOperations
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops, err := removeStorageAttachmentOps(s, inst)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
+	}
+	return st.run(buildTxn)
+}
+
+func removeStorageAttachmentOps(s *storageAttachment, si *storageInstance) ([]txn.Op, error) {
+	if s.doc.Life != Dead {
+		return nil, errors.New("storage attachment is not dead")
+	}
+	ops := []txn.Op{{
+		C:      storageAttachmentsC,
+		Id:     storageAttachmentId(s.doc.Unit, s.doc.StorageInstance),
+		Assert: isDeadDoc,
+		Remove: true,
+	}, {
+		C:      unitsC,
+		Id:     s.doc.Unit,
+		Assert: txn.DocExists,
+		Update: bson.D{{"$inc", bson.D{{"storageattachmentcount", -1}}}},
+	}}
+	if si.doc.Life == Dying && si.doc.AttachmentCount == 1 {
+		hasLastRef := bson.D{{"life", Dying}, {"attachmentcount", 1}}
+		ops = append(ops, removeStorageInstanceOps(si.StorageTag(), hasLastRef)...)
+		return ops, nil
+	}
+	decrefOp := txn.Op{
+		C:      storageInstancesC,
+		Id:     si.doc.Id,
+		Update: bson.D{{"$inc", bson.D{{"attachmentcount", -1}}}},
+	}
+	if si.doc.Life == Alive {
+		// This may be the last reference, but the storage instance is
+		// still alive. The storage instance will be removed when its
+		// Destroy method is called, if it has no attachments.
+		decrefOp.Assert = bson.D{
+			{"life", Alive},
+			{"attachmentcount", bson.D{{"$gt", 0}}},
+		}
+	} else {
+		// If it's not the last reference when we checked, we want to
+		// allow for concurrent attachment removals but want to ensure
+		// that we don't drop to zero without removing the storage
+		// instance.
+		decrefOp.Assert = bson.D{
+			{"life", Dying},
+			{"attachmentcount", bson.D{{"$gt", 1}}},
+		}
+	}
+	ops = append(ops, decrefOp)
+	return ops, nil
 }
 
 // SetStorageAttachmentInfo sets the storage attachment information for the

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -150,6 +150,9 @@ type lifecycleWatcher struct {
 	members bson.D
 	// filter is used to exclude events not affecting interesting entities.
 	filter func(interface{}) bool
+	// transform, if non-nil, is used to transform a document ID immediately
+	// prior to emitting to the out channel.
+	transform func(string) string
 	// life holds the most recent known life states of interesting entities.
 	life map[string]Life
 }
@@ -163,19 +166,39 @@ func collFactory(st *State, collName string) func() (stateCollection, func()) {
 // WatchEnvironments returns a StringsWatcher that notifies of changes
 // to the lifecycles of all environments.
 func (st *State) WatchEnvironments() StringsWatcher {
-	return newLifecycleWatcher(st, environmentsC, nil, nil)
+	return newLifecycleWatcher(st, environmentsC, nil, nil, nil)
 }
 
 // WatchVolumes returns a StringsWatcher that notifies of changes to
 // the lifecycles of all volumes.
 func (st *State) WatchVolumes() StringsWatcher {
-	return newLifecycleWatcher(st, volumesC, nil, nil)
+	return newLifecycleWatcher(st, volumesC, nil, nil, nil)
 }
 
 // WatchServices returns a StringsWatcher that notifies of changes to
 // the lifecycles of the services in the environment.
 func (st *State) WatchServices() StringsWatcher {
-	return newLifecycleWatcher(st, servicesC, nil, st.isForStateEnv)
+	return newLifecycleWatcher(st, servicesC, nil, st.isForStateEnv, nil)
+}
+
+// WatchStorageAttachments returns a StringsWatcher that notifies of
+// changes to the lifecycles of all storage instances attached to the
+// specified unit.
+func (st *State) WatchStorageAttachments(unit names.UnitTag) StringsWatcher {
+	members := bson.D{{"unitid", unit.Id()}}
+	prefix := unitGlobalKey(unit.Id()) + "#"
+	filter := func(id interface{}) bool {
+		k, err := st.strictLocalID(id.(string))
+		if err != nil {
+			return false
+		}
+		return strings.HasPrefix(k, prefix)
+	}
+	tr := func(id string) string {
+		// Transform storage attachment document ID to storage ID.
+		return id[len(prefix):]
+	}
+	return newLifecycleWatcher(st, storageAttachmentsC, members, filter, tr)
 }
 
 // WatchUnits returns a StringsWatcher that notifies of changes to the
@@ -190,7 +213,7 @@ func (s *Service) WatchUnits() StringsWatcher {
 		}
 		return strings.HasPrefix(unitName, prefix)
 	}
-	return newLifecycleWatcher(s.st, unitsC, members, filter)
+	return newLifecycleWatcher(s.st, unitsC, members, filter, nil)
 }
 
 // WatchRelations returns a StringsWatcher that notifies of changes to the
@@ -208,7 +231,7 @@ func (s *Service) WatchRelations() StringsWatcher {
 	}
 
 	members := bson.D{{"endpoints.servicename", s.doc.Name}}
-	return newLifecycleWatcher(s.st, relationsC, members, filter)
+	return newLifecycleWatcher(s.st, relationsC, members, filter, nil)
 }
 
 // WatchEnvironMachines returns a StringsWatcher that notifies of changes to
@@ -225,7 +248,7 @@ func (st *State) WatchEnvironMachines() StringsWatcher {
 		}
 		return !strings.Contains(k, "/")
 	}
-	return newLifecycleWatcher(st, machinesC, members, filter)
+	return newLifecycleWatcher(st, machinesC, members, filter, nil)
 }
 
 // WatchContainers returns a StringsWatcher that notifies of changes to the
@@ -253,16 +276,23 @@ func (m *Machine) containersWatcher(isChildRegexp string) StringsWatcher {
 		}
 		return compiled.MatchString(k)
 	}
-	return newLifecycleWatcher(m.st, machinesC, members, filter)
+	return newLifecycleWatcher(m.st, machinesC, members, filter, nil)
 }
 
-func newLifecycleWatcher(st *State, collName string, members bson.D, filter func(key interface{}) bool) StringsWatcher {
+func newLifecycleWatcher(
+	st *State,
+	collName string,
+	members bson.D,
+	filter func(key interface{}) bool,
+	transform func(id string) string,
+) StringsWatcher {
 	w := &lifecycleWatcher{
 		commonWatcher: commonWatcher{st: st},
 		coll:          collFactory(st, collName),
 		collName:      collName,
 		members:       members,
 		filter:        filter,
+		transform:     transform,
 		life:          make(map[string]Life),
 		out:           make(chan []string),
 	}
@@ -381,6 +411,12 @@ func (w *lifecycleWatcher) loop() error {
 	}
 	out := w.out
 	for {
+		values := ids.Values()
+		if w.transform != nil {
+			for i, v := range values {
+				values[i] = w.transform(v)
+			}
+		}
 		select {
 		case <-w.tomb.Dying():
 			return tomb.ErrDying
@@ -397,7 +433,7 @@ func (w *lifecycleWatcher) loop() error {
 			if !ids.IsEmpty() {
 				out = w.out
 			}
-		case out <- ids.Values():
+		case out <- values:
 			ids = make(set.Strings)
 			out = nil
 		}


### PR DESCRIPTION
Storage instances now track the number of associated
storage attachments. A storage instance's removal is
now prevented while there are storage attachments.

Destroying a storage instance will now trigger a cleanup
to destroy associated storage attachments. If there are
none, we short-circuit the storage instance's removal.

Units now track storage attachments rather than instances,
so that units are required to cleanly detach from storage
before being allowed to die.

We introduce a new watcher for storage attachment life
cycle events. Since storage attachments are not entities
in their own right, we introduce a "transform" function
on the lifecycle-watcher helper that transforms document
IDs immediately prior to emitting them to the user; we
use this to extract storage IDs from storage attachment
document IDs.

(Review request: http://reviews.vapour.ws/r/969/)