### PR TITLE
Revert "Run Actions in ModeHookError"

### DIFF
--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -122,7 +122,7 @@ func ModeTerminating(u *Uniter) (next Mode, err error) {
 		case <-u.tomb.Dying():
 			return nil, tomb.ErrDying
 		case info := <-u.f.ActionEvents():
-			creator := newActionOp(info.ActionId, operation.Continue)
+			creator := newActionOp(info.ActionId)
 			if err := u.runOperation(creator); err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -210,7 +210,7 @@ func modeAbideAliveLoop(u *Uniter) (Mode, error) {
 		case ids := <-u.f.RelationsEvents():
 			creator = newUpdateRelationsOp(ids)
 		case info := <-u.f.ActionEvents():
-			creator = newActionOp(info.ActionId, operation.Continue)
+			creator = newActionOp(info.ActionId)
 		case <-u.f.ConfigEvents():
 			creator = newSimpleRunHookOp(hooks.ConfigChanged)
 		case <-u.f.MeterStatusEvents():
@@ -247,7 +247,7 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 		case <-u.tomb.Dying():
 			return nil, tomb.ErrDying
 		case info := <-u.f.ActionEvents():
-			creator = newActionOp(info.ActionId, operation.Continue)
+			creator = newActionOp(info.ActionId)
 		case <-u.f.ConfigEvents():
 			creator = newSimpleRunHookOp(hooks.ConfigChanged)
 		case hookInfo := <-u.relations.Hooks():
@@ -313,11 +313,6 @@ func ModeHookError(u *Uniter) (next Mode, err error) {
 				return nil, errors.Trace(err)
 			}
 			return ModeContinue, nil
-		case action := <-u.f.ActionEvents():
-			if err := u.runOperation(newActionOp(action.ActionId, operation.RunHook)); err != nil {
-				return nil, errors.Trace(err)
-			}
-			continue
 		}
 	}
 }

--- a/worker/uniter/op_plumbing.go
+++ b/worker/uniter/op_plumbing.go
@@ -75,9 +75,9 @@ func newCommandsOp(args operation.CommandArgs, sendResponse operation.CommandRes
 	}
 }
 
-func newActionOp(actionId string, resume operation.Kind) creator {
+func newActionOp(actionId string) creator {
 	return func(factory operation.Factory) (operation.Operation, error) {
-		return factory.NewAction(actionId, resume)
+		return factory.NewAction(actionId)
 	}
 }
 

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -125,7 +125,7 @@ func (f *factory) NewSkipHook(hookInfo hook.Info) (Operation, error) {
 }
 
 // NewAction is part of the Factory interface.
-func (f *factory) NewAction(actionId string, continuation Kind) (Operation, error) {
+func (f *factory) NewAction(actionId string) (Operation, error) {
 	if !names.IsValidAction(actionId) {
 		return nil, errors.Errorf("invalid action id %q", actionId)
 	}
@@ -133,7 +133,6 @@ func (f *factory) NewAction(actionId string, continuation Kind) (Operation, erro
 		actionId:      actionId,
 		callbacks:     f.callbacks,
 		runnerFactory: f.runnerFactory,
-		continuation:  continuation,
 	}, nil
 }
 

--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -82,13 +82,13 @@ func (s *FactorySuite) TestNewResolvedUpgradeString(c *gc.C) {
 }
 
 func (s *FactorySuite) TestNewActionError(c *gc.C) {
-	op, err := s.factory.NewAction("lol-something", operation.Continue)
+	op, err := s.factory.NewAction("lol-something")
 	c.Check(op, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, `invalid action id "lol-something"`)
 }
 
 func (s *FactorySuite) TestNewActionString(c *gc.C) {
-	op, err := s.factory.NewAction(someActionId, operation.Continue)
+	op, err := s.factory.NewAction(someActionId)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(op.String(), gc.Equals, "run action "+someActionId)
 }

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -87,10 +87,8 @@ type Factory interface {
 	// mark the supplied hook as completed successfully.
 	NewSkipHook(hookInfo hook.Info) (Operation, error)
 
-	// NewAction creates an operation to execute the supplied action. continuation is
-	// the operation.Kind that the action should set the opState to on successful
-	// completion.
-	NewAction(actionId string, continuation Kind) (Operation, error)
+	// NewAction creates an operation to execute the supplied action.
+	NewAction(actionId string) (Operation, error)
 
 	// NewCommands creates an operation to execute the supplied script in the
 	// indicated relation context, and pass the results back over the supplied

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -19,8 +19,6 @@ type runAction struct {
 
 	name   string
 	runner runner.Runner
-
-	continuation Kind
 }
 
 // String is part of the Operation interface.
@@ -87,7 +85,7 @@ func (ra *runAction) Execute(state State) (*State, error) {
 // Commit is part of the Operation interface.
 func (ra *runAction) Commit(state State) (*State, error) {
 	return stateChange{
-		Kind: ra.continuation,
+		Kind: Continue,
 		Step: Pending,
 		Hook: state.Hook,
 	}.apply(state), nil

--- a/worker/uniter/operation/runaction_test.go
+++ b/worker/uniter/operation/runaction_test.go
@@ -30,7 +30,7 @@ func (s *RunActionSuite) TestPrepareErrorBadActionAndFailSucceeds(c *gc.C) {
 		MockFailAction: &MockFailAction{err: errors.New("squelch")},
 	}
 	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil)
-	op, err := factory.NewAction(someActionId, operation.Continue)
+	op, err := factory.NewAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(operation.State{})
@@ -50,7 +50,7 @@ func (s *RunActionSuite) TestPrepareErrorBadActionAndFailErrors(c *gc.C) {
 		MockFailAction: &MockFailAction{},
 	}
 	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil)
-	op, err := factory.NewAction(someActionId, operation.Continue)
+	op, err := factory.NewAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(operation.State{})
@@ -66,7 +66,7 @@ func (s *RunActionSuite) TestPrepareErrorActionNotAvailable(c *gc.C) {
 		MockNewActionRunner: &MockNewActionRunner{err: runner.ErrActionNotAvailable},
 	}
 	factory := operation.NewFactory(nil, runnerFactory, nil, nil)
-	op, err := factory.NewAction(someActionId, operation.Continue)
+	op, err := factory.NewAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(operation.State{})
@@ -80,7 +80,7 @@ func (s *RunActionSuite) TestPrepareErrorOther(c *gc.C) {
 		MockNewActionRunner: &MockNewActionRunner{err: errors.New("foop")},
 	}
 	factory := operation.NewFactory(nil, runnerFactory, nil, nil)
-	op, err := factory.NewAction(someActionId, operation.Continue)
+	op, err := factory.NewAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(operation.State{})
@@ -92,7 +92,7 @@ func (s *RunActionSuite) TestPrepareErrorOther(c *gc.C) {
 func (s *RunActionSuite) TestPrepareSuccessCleanState(c *gc.C) {
 	runnerFactory := NewRunActionRunnerFactory(errors.New("should not call"))
 	factory := operation.NewFactory(nil, runnerFactory, nil, nil)
-	op, err := factory.NewAction(someActionId, operation.Continue)
+	op, err := factory.NewAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(operation.State{})
@@ -109,7 +109,7 @@ func (s *RunActionSuite) TestPrepareSuccessCleanState(c *gc.C) {
 func (s *RunActionSuite) TestPrepareSuccessDirtyState(c *gc.C) {
 	runnerFactory := NewRunActionRunnerFactory(errors.New("should not call"))
 	factory := operation.NewFactory(nil, runnerFactory, nil, nil)
-	op, err := factory.NewAction(someActionId, operation.Continue)
+	op, err := factory.NewAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(overwriteState)
@@ -132,7 +132,7 @@ func (s *RunActionSuite) TestExecuteLockError(c *gc.C) {
 		MockAcquireExecutionLock: &MockAcquireExecutionLock{err: errors.New("plonk")},
 	}
 	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil)
-	op, err := factory.NewAction(someActionId, operation.Continue)
+	op, err := factory.NewAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Prepare(operation.State{})
 	c.Assert(newState, gc.NotNil)
@@ -150,7 +150,7 @@ func (s *RunActionSuite) TestExecuteRunError(c *gc.C) {
 		MockAcquireExecutionLock: &MockAcquireExecutionLock{},
 	}
 	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil)
-	op, err := factory.NewAction(someActionId, operation.Continue)
+	op, err := factory.NewAction(someActionId)
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Prepare(operation.State{})
 	c.Assert(newState, gc.NotNil)
@@ -196,7 +196,7 @@ func (s *RunActionSuite) TestExecuteSuccess(c *gc.C) {
 			MockAcquireExecutionLock: &MockAcquireExecutionLock{},
 		}
 		factory := operation.NewFactory(nil, runnerFactory, callbacks, nil)
-		op, err := factory.NewAction(someActionId, operation.Continue)
+		op, err := factory.NewAction(someActionId)
 		c.Assert(err, jc.ErrorIsNil)
 		midState, err := op.Prepare(test.before)
 		c.Assert(midState, gc.NotNil)
@@ -220,14 +220,14 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 	}{{
 		description: "empty state",
 		after: operation.State{
-			Kind: operation.RunHook,
+			Kind: operation.Continue,
 			Step: operation.Pending,
 		},
 	}, {
 		description: "preserves appropriate fields",
 		before:      overwriteState,
 		after: operation.State{
-			Kind:               operation.RunHook,
+			Kind:               operation.Continue,
 			Step:               operation.Pending,
 			Hook:               &hook.Info{Kind: hooks.Install},
 			Started:            true,
@@ -238,7 +238,7 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 	for i, test := range stateChangeTests {
 		c.Logf("test %d: %s", i, test.description)
 		factory := operation.NewFactory(nil, nil, nil, nil)
-		op, err := factory.NewAction(someActionId, operation.RunHook)
+		op, err := factory.NewAction(someActionId)
 		c.Assert(err, jc.ErrorIsNil)
 
 		newState, err := op.Commit(test.before)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1451,7 +1451,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			}}},
 			waitUnit{status: params.StatusActive},
 		), ut(
-			"actions can run from ModeHookError, but do not clear the error",
+			"actions are not attempted from ModeHookError and do not clear the error",
 			startupErrorWithCustomCharm{
 				badHook: "start",
 				customize: func(c *gc.C, ctx *context, path string) {
@@ -1467,18 +1467,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 					"hook": "start",
 				},
 			},
-			waitActionResults{[]actionResult{{
-				name:    "action-log",
-				results: map[string]interface{}{},
-				status:  params.ActionCompleted,
-			}}},
-			waitUnit{
-				status: params.StatusError,
-				info:   `hook failed: "start"`,
-				data: map[string]interface{}{
-					"hook": "start",
-				},
-			},
+			verifyNoActionResults{},
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
 			waitUnit{status: params.StatusActive},


### PR DESCRIPTION
Revert per @fwereade - this isn't the right way to accomplish maintaining state across uniter restarts.

(Review request: http://reviews.vapour.ws/r/970/)