### PR TITLE
version.Current.Arch fixed to amd64 in tests

### DIFF
--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -87,6 +87,7 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 
 func (s *lxcBrokerSuite) startInstance(c *gc.C, machineId string) instance.Instance {
 	machineNonce := "fake-nonce"
+	version.Current.Arch = "amd64"
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)


### PR DESCRIPTION
Patching version.Current.Arch to "amd64" in order to make tests pass on non-amd64 hosts.
Fixes: 1423950

(Review request: http://reviews.vapour.ws/r/972/)