### PR TITLE
Provisioner API add PrepareContainerInterfaceInfo() (server-side)

### DIFF
--- a/apiserver/provisioner/export_test.go
+++ b/apiserver/provisioner/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provisioner
+
+var (
+	AllocateAddrTo = &allocateAddrTo
+	SetAddrsTo     = &setAddrsTo
+	SetAddrState   = &setAddrState
+)

--- a/apiserver/provisioner/prepare_test.go
+++ b/apiserver/provisioner/prepare_test.go
@@ -1,0 +1,607 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provisioner_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/provisioner"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+// prepareSuite contains only tests around
+// PrepareContainerInterfaceInfo method.
+type prepareSuite struct {
+	provisionerSuite
+
+	provAPI *provisioner.ProvisionerAPI
+}
+
+var _ = gc.Suite(&prepareSuite{})
+
+func (s *prepareSuite) SetUpTest(c *gc.C) {
+	s.setUpTest(c, false)
+	// Reset any "broken" dummy provider methods.
+	s.breakEnvironMethods(c)
+}
+
+func (s *prepareSuite) newCustomAPI(c *gc.C, hostInstId instance.Id, addContainer bool) *state.Machine {
+	anAuthorizer := s.authorizer
+	anAuthorizer.EnvironManager = false
+	anAuthorizer.Tag = s.machines[0].Tag()
+	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources, anAuthorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(aProvisioner, gc.NotNil)
+	s.provAPI = aProvisioner
+
+	if hostInstId != "" {
+		err = s.machines[0].SetProvisioned(hostInstId, "fake_nonce", nil)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	if addContainer {
+		container, err := s.State.AddMachineInsideMachine(
+			state.MachineTemplate{
+				Series: "quantal",
+				Jobs:   []state.MachineJob{state.JobHostUnits},
+			},
+			s.machines[0].Id(),
+			instance.LXC,
+		)
+		c.Assert(err, jc.ErrorIsNil)
+		return container
+	}
+
+	return nil
+}
+
+func (s *prepareSuite) newAPI(c *gc.C, provisionHost, addContainer bool) *state.Machine {
+	var hostInstId instance.Id
+	if provisionHost {
+		hostInstId = "i-host"
+	}
+	return s.newCustomAPI(c, hostInstId, addContainer)
+}
+
+func (s *prepareSuite) makeArgs(machines ...*state.Machine) params.Entities {
+	args := params.Entities{Entities: make([]params.Entity, len(machines))}
+	for i, m := range machines {
+		args.Entities[i].Tag = m.Tag().String()
+	}
+	return args
+}
+
+func (s *prepareSuite) makeResults(cfgs ...[]params.NetworkConfig) *params.MachineNetworkConfigResults {
+	results := &params.MachineNetworkConfigResults{
+		Results: make([]params.MachineNetworkConfigResult, len(cfgs)),
+	}
+	for i, cfg := range cfgs {
+		results.Results[i].Config = cfg
+	}
+	return results
+}
+
+func (s *prepareSuite) makeErrors(errors ...*params.Error) *params.MachineNetworkConfigResults {
+	results := &params.MachineNetworkConfigResults{
+		Results: make([]params.MachineNetworkConfigResult, len(errors)),
+	}
+	for i, err := range errors {
+		results.Results[i].Error = err
+	}
+	return results
+}
+
+func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *params.MachineNetworkConfigResults, expectErr string) (error, []loggo.TestLogValues) {
+
+	// Capture the logs for later inspection.
+	logger := loggo.GetLogger("juju.apiserver.provisioner")
+	defer logger.SetLogLevel(logger.LogLevel())
+	logger.SetLogLevel(loggo.TRACE)
+	var tw loggo.TestWriter
+	c.Assert(loggo.RegisterWriter("test", &tw, loggo.TRACE), gc.IsNil)
+	defer loggo.RemoveWriter("test")
+
+	results, err := s.provAPI.PrepareContainerInterfaceInfo(args)
+	c.Logf("PrepareContainerInterfaceInfo returned: err=%v, results=%v", err, results)
+	c.Assert(results.Results, gc.HasLen, len(args.Entities))
+	if expectErr == "" {
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(expectResults, gc.NotNil)
+		c.Assert(results.Results, gc.HasLen, len(expectResults.Results))
+		// Check for any "regex:" prefixes first. Then replace
+		// addresses in expected with the actual ones, so we can use
+		// jc.DeepEquals on the whole result below.
+		for i, expect := range expectResults.Results {
+			cfg := results.Results[i].Config
+			c.Assert(cfg, gc.HasLen, len(expect.Config))
+			for j, expCfg := range expect.Config {
+				if strings.HasPrefix(expCfg.Address, "regex:") {
+					rex := strings.TrimPrefix(expCfg.Address, "regex:")
+					c.Assert(cfg[j].Address, gc.Matches, rex)
+					expectResults.Results[i].Config[j].Address = cfg[j].Address
+				}
+			}
+		}
+		c.Assert(results, jc.DeepEquals, *expectResults)
+	} else {
+		c.Assert(err, gc.ErrorMatches, expectErr)
+		if len(args.Entities) > 0 {
+			result := results.Results[0]
+			// Not using jc.ErrorIsNil below because
+			// (*params.Error)(nil) does not satisfy the error
+			// interface.
+			c.Assert(result.Error, gc.IsNil)
+			c.Assert(result.Config, gc.IsNil)
+		}
+	}
+	return err, tw.Log()
+}
+
+func (s *prepareSuite) breakEnvironMethods(c *gc.C, methods ...string) {
+	s.AssertConfigParameterUpdated(c, "broken", strings.Join(methods, " "))
+}
+
+func (s *prepareSuite) TestErrorWithNonProvisionedHost(c *gc.C) {
+	container := s.newAPI(c, false, true)
+	args := s.makeArgs(container)
+	s.assertCall(c, args, nil,
+		`cannot allocate addresses: host machine "0" not provisioned`,
+	)
+}
+
+func (s *prepareSuite) TestErrorWithProvisionedContainer(c *gc.C) {
+	container := s.newAPI(c, true, true)
+	err := container.SetProvisioned("i-foo", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	args := s.makeArgs(container)
+	s.assertCall(c, args, s.makeErrors(
+		apiservertesting.ServerError(
+			`container "0/lxc/0" already provisioned as "i-foo"`,
+		),
+	), "")
+}
+
+func (s *prepareSuite) TestErrorWithHostInsteadOfContainer(c *gc.C) {
+	s.newAPI(c, true, false)
+	args := s.makeArgs(s.machines[0])
+	s.assertCall(c, args, s.makeErrors(
+		apiservertesting.ServerError(
+			`cannot allocate address for "machine-0": not a container`,
+		),
+	), "")
+}
+
+func (s *prepareSuite) TestErrorsWithDifferentHosts(c *gc.C) {
+	s.newAPI(c, true, false)
+	args := s.makeArgs(s.machines[1], s.machines[2])
+	s.assertCall(c, args, s.makeErrors(
+		apiservertesting.ErrUnauthorized,
+		apiservertesting.ErrUnauthorized,
+	), "")
+}
+
+func (s *prepareSuite) TestErrorsWithContainersOnDifferentHost(c *gc.C) {
+	s.newAPI(c, true, false)
+	var containers []*state.Machine
+	for i := 0; i < 2; i++ {
+		container, err := s.State.AddMachineInsideMachine(
+			state.MachineTemplate{
+				Series: "quantal",
+				Jobs:   []state.MachineJob{state.JobHostUnits},
+			},
+			s.machines[1].Id(),
+			instance.LXC,
+		)
+		c.Assert(err, jc.ErrorIsNil)
+		containers = append(containers, container)
+	}
+	args := s.makeArgs(containers...)
+	s.assertCall(c, args, s.makeErrors(
+		apiservertesting.ErrUnauthorized,
+		apiservertesting.ErrUnauthorized,
+	), "")
+}
+
+func (s *prepareSuite) TestErrorsWithNonMachineOrInvalidTags(c *gc.C) {
+	s.newAPI(c, true, false)
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-wordpress-0"},
+		{Tag: "service-wordpress"},
+		{Tag: "network-foo"},
+		{Tag: "anything-invalid"},
+		{Tag: "42"},
+		{Tag: "machine-42"},
+		{Tag: ""},
+	}}
+
+	s.assertCall(c, args, s.makeErrors(
+		apiservertesting.ErrUnauthorized,
+		apiservertesting.ErrUnauthorized,
+		apiservertesting.ErrUnauthorized,
+		apiservertesting.ErrUnauthorized,
+		apiservertesting.ErrUnauthorized,
+		apiservertesting.ErrUnauthorized,
+		apiservertesting.ErrUnauthorized,
+	), "")
+}
+
+func (s *prepareSuite) fillSubnet(c *gc.C, numAllocated int) {
+	// Create the 0.10.0.0/24 subnet in state and pre-allocate up to
+	// numAllocated of the range. This ensures the tests will run
+	// quickly, rather than retrying potentiallu until the full /24
+	// range is exhausted.
+	subInfo := state.SubnetInfo{
+		ProviderId:        "dummy-private",
+		CIDR:              "0.10.0.0/24",
+		VLANTag:           0,
+		AllocatableIPLow:  "0.10.0.0",
+		AllocatableIPHigh: "0.10.0.10", // Intentionally use shorter range.
+	}
+	sub, err := s.BackingState.AddSubnet(subInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	for i := 0; i <= numAllocated; i++ {
+		addr := network.NewAddress(fmt.Sprintf("0.10.0.%d", i), network.ScopeUnknown)
+		ipaddr, err := s.BackingState.AddIPAddress(addr, sub.ID())
+		c.Check(err, jc.ErrorIsNil)
+		err = ipaddr.SetState(state.AddressStateAllocated)
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *prepareSuite) TestErrorWithEnvironMethodsFailing(c *gc.C) {
+	container := s.newAPI(c, true, true)
+	args := s.makeArgs(container)
+
+	s.fillSubnet(c, 10)
+
+	// NOTE: We're testing AllocateAddress and ReleaseAddress separately.
+	for i, test := range []struct {
+		method   string
+		err      string
+		errCheck func(error) bool
+	}{{
+		method: "NetworkInterfaces",
+		err:    "cannot allocate addresses: dummy.NetworkInterfaces is broken",
+	}, {
+		method: "Subnets",
+		err:    "cannot allocate addresses: dummy.Subnets is broken",
+	}, {
+		method:   "SupportsAddressAllocation",
+		err:      "cannot allocate addresses: address allocation on any available subnets is not supported",
+		errCheck: errors.IsNotSupported,
+	}} {
+		c.Logf("test %d: broken %q", i, test.method)
+		s.breakEnvironMethods(c, test.method)
+		var err error
+		if test.err != "" {
+			err, _ = s.assertCall(c, args, nil, test.err)
+		}
+		if test.errCheck != nil {
+			c.Check(err, jc.Satisfies, test.errCheck)
+		}
+	}
+}
+
+func (s *prepareSuite) TestRetryingOnAllocateAddressFailure(c *gc.C) {
+	// This test verifies the retrying logic when AllocateAddress
+	// and/or setAddrState return errors.
+
+	// Pre-allocate the first 5 addresses.
+	s.fillSubnet(c, 5)
+
+	// Now break AllocateAddress so it returns an error to verify the
+	// retry logic kicks in. Because it will always fail, the end
+	// result will always be an address exhaustion error.
+	s.breakEnvironMethods(c, "AllocateAddress")
+
+	container := s.newAPI(c, true, true)
+	args := s.makeArgs(container)
+
+	// Record each time setAddrState is called along with the address
+	// to verify the logs later.
+	var addresses []string
+	origSetAddrState := *provisioner.SetAddrState
+	s.PatchValue(provisioner.SetAddrState, func(ip *state.IPAddress, st state.AddressState) error {
+		c.Logf("setAddrState called for address %q, state %q", ip, st)
+		c.Assert(st, gc.Equals, state.AddressStateUnavailable)
+		addresses = append(addresses, ip.Value())
+
+		// Return an error every other call to test it's handled ok.
+		if len(addresses)%2 == 0 {
+			return errors.New("pow!")
+		}
+		return origSetAddrState(ip, st)
+	})
+
+	_, testLog := s.assertCall(c, args, s.makeErrors(apiservertesting.ServerError(
+		`failed to allocate an address for "0/lxc/0": `+
+			`allocatable IP addresses exhausted for subnet "0.10.0.0/24"`,
+	)), "")
+
+	// Verify the expected addresses, ignoring the order as the
+	// addresses are picked at random.
+	c.Assert(addresses, jc.SameContents, []string{
+		"0.10.0.6",
+		"0.10.0.7",
+		"0.10.0.8",
+		"0.10.0.9",
+		"0.10.0.10",
+	})
+
+	// Now verify the logs.
+	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
+		loggo.WARNING,
+		`allocating address ".+" on instance ".+" and subnet ".+" failed: ` +
+			`dummy.AllocateAddress is broken \(retrying\)`,
+	}, {
+		loggo.TRACE,
+		`setting address ".+" to "unavailable" and retrying`,
+	}, {
+		loggo.TRACE,
+		`picked new address ".+" on subnet ".+"`,
+	}, {
+		loggo.WARNING,
+		`allocating address ".+" on instance ".+" and subnet ".+" failed: ` +
+			`dummy.AllocateAddress is broken \(retrying\)`,
+	}, {
+		loggo.WARNING,
+		`cannot set address ".+" to "unavailable": pow! \(ignoring and retrying\)`,
+	}})
+}
+
+func (s *prepareSuite) TestReleaseAndCleanupWhenAllocateAndOrSetFail(c *gc.C) {
+	// This test verifies the retrying, releasing, and cleanup logic
+	// when AllocateAddress succeeds, but both ReleaseAddress and
+	// setAddrsTo fail, and allocateAddrTo either succeeds or fails.
+
+	// Pre-allocate the first 5 addresses.
+	s.fillSubnet(c, 5)
+
+	// Now break ReleaseAddress to test the how it's handled during
+	// the release/cleanup loop.
+	s.breakEnvironMethods(c, "ReleaseAddress")
+
+	container := s.newAPI(c, true, true)
+	args := s.makeArgs(container)
+
+	// Record each time allocateAddrTo, setAddrsTo, and setAddrState
+	// are called along with the addresses to verify the logs later.
+	var allocAttemptedAddrs, allocAddrsOK, setAddrs, releasedAddrs []string
+	s.PatchValue(provisioner.AllocateAddrTo, func(ip *state.IPAddress, m *state.Machine) error {
+		c.Logf("allocateAddrTo called for address %q, machine %q", ip, m)
+		c.Assert(m.Id(), gc.Equals, container.Id())
+		allocAttemptedAddrs = append(allocAttemptedAddrs, ip.Value())
+
+		// Succeed on every other call to give a chance to call
+		// setAddrsTo as well.
+		if len(allocAttemptedAddrs)%2 == 0 {
+			allocAddrsOK = append(allocAddrsOK, ip.Value())
+			return nil
+		}
+		return errors.New("crash!")
+	})
+	s.PatchValue(provisioner.SetAddrsTo, func(ip *state.IPAddress, m *state.Machine) error {
+		c.Logf("setAddrsTo called for address %q, machine %q", ip, m)
+		c.Assert(m.Id(), gc.Equals, container.Id())
+		setAddrs = append(setAddrs, ip.Value())
+		return errors.New("boom!")
+	})
+	s.PatchValue(provisioner.SetAddrState, func(ip *state.IPAddress, st state.AddressState) error {
+		c.Logf("setAddrState called for address %q, state %q", ip, st)
+		c.Assert(st, gc.Equals, state.AddressStateUnavailable)
+		releasedAddrs = append(releasedAddrs, ip.Value())
+		return nil
+	})
+
+	_, testLog := s.assertCall(c, args, s.makeErrors(apiservertesting.ServerError(
+		`failed to allocate an address for "0/lxc/0": `+
+			`allocatable IP addresses exhausted for subnet "0.10.0.0/24"`,
+	)), "")
+
+	// Verify the expected addresses, ignoring the order as the
+	// addresses are picked at random.
+	expectAddrs := []string{
+		"0.10.0.6",
+		"0.10.0.7",
+		"0.10.0.8",
+		"0.10.0.9",
+		"0.10.0.10",
+	}
+	// Verify that for each allocated address an attempt is made to
+	// assign it to the container by calling allocateAddrTo
+	// (successful or not doesn't matter).
+	c.Check(allocAttemptedAddrs, jc.SameContents, expectAddrs)
+
+	// Verify that for each allocated address an attempt is made to do
+	// release/cleanup by calling setAddrState(unavailable), after
+	// either allocateAddrTo or setAddrsTo fails.
+	c.Check(releasedAddrs, jc.SameContents, expectAddrs)
+
+	// Verify that for every allocateAddrTo call that passed, the
+	// corresponding setAddrsTo was also called.
+	c.Check(allocAddrsOK, jc.SameContents, setAddrs)
+
+	// Now verify the logs.
+	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
+		loggo.INFO,
+		`allocated address "public:.+" on instance "i-host" and subnet "dummy-private"`,
+	}, {
+		loggo.WARNING,
+		`failed to mark address ".+" as "allocated" to container ".*": crash! \(releasing and retrying\)`,
+	}, {
+		loggo.WARNING,
+		`failed to release address ".+" on instance "i-host" and subnet ".+": ` +
+			`dummy.ReleaseAddress is broken \(ignoring and retrying\)`,
+	}, {
+		loggo.INFO,
+		`allocated address "public:.+" on instance "i-host" and subnet "dummy-private"`,
+	}})
+}
+
+func (s *prepareSuite) TestReleaseAndRetryWhenSetOnlyFails(c *gc.C) {
+	// This test verifies the releasing, and cleanup, as well as
+	// retrying logic when AllocateAddress and allocateAddrTo succeed,
+	// but then both setAddrsTo and setAddrState fail.
+
+	// Pre-allocate the first 9 addresses, so the only address left
+	// will be 0.10.0.10.
+	s.fillSubnet(c, 9)
+
+	container := s.newAPI(c, true, true)
+	args := s.makeArgs(container)
+
+	s.PatchValue(provisioner.SetAddrsTo, func(ip *state.IPAddress, m *state.Machine) error {
+		c.Logf("setAddrsTo called for address %q, machine %q", ip, m)
+		c.Assert(m.Id(), gc.Equals, container.Id())
+		c.Assert(ip.Value(), gc.Equals, "0.10.0.10")
+		return errors.New("boom!")
+	})
+	s.PatchValue(provisioner.SetAddrState, func(ip *state.IPAddress, st state.AddressState) error {
+		c.Logf("setAddrState called for address %q, state %q", ip, st)
+		c.Assert(st, gc.Equals, state.AddressStateUnavailable)
+		c.Assert(ip.Value(), gc.Equals, "0.10.0.10")
+		return errors.New("pow!")
+	})
+
+	// After failing twice, we'll successfully release the address and retry to succeed.
+	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
+		ProviderId:       "dummy-eth0",
+		ProviderSubnetId: "dummy-private",
+		NetworkName:      "juju-private",
+		CIDR:             "0.10.0.0/24",
+		DeviceIndex:      0,
+		InterfaceName:    "eth0",
+		VLANTag:          0,
+		MACAddress:       "aa:bb:cc:dd:ee:f0",
+		Disabled:         false,
+		NoAutoStart:      false,
+		ConfigType:       "static",
+		Address:          "0.10.0.10",
+		DNSServers:       []string{"ns1.dummy", "ns2.dummy"},
+		GatewayAddress:   "0.10.0.2",
+		ExtraConfig:      nil,
+	}}), "")
+
+	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
+		loggo.INFO,
+		`allocated address "public:0.10.0.10" on instance "i-host" and subnet "dummy-private"`,
+	}, {
+		loggo.WARNING,
+		`failed to mark address ".+" as "allocated" to container ".*": boom! \(releasing and retrying\)`,
+	}, {
+		loggo.WARNING,
+		`cannot set address "public:0.10.0.10" to "unavailable": pow! \(ignoring and releasing\)`,
+	}, {
+		loggo.INFO,
+		`address "public:0.10.0.10" released; trying to allocate new`,
+	}})
+}
+
+func (s *prepareSuite) TestErrorWhenNoSubnetsAvailable(c *gc.C) {
+	// The magic "i-no-subnets-" instance id prefix for the host
+	// causes the dummy provider to return no results and no errors
+	// from Subnets().
+	container := s.newCustomAPI(c, "i-no-subnets-here", true)
+	args := s.makeArgs(container)
+	s.assertCall(c, args, nil, "cannot allocate addresses: no subnets available")
+}
+
+func (s *prepareSuite) TestErrorWhenNoAllocatableSubnetsAvailable(c *gc.C) {
+	// The magic "i-no-alloc-all" instance id for the host causes the
+	// dummy provider's Subnets() method to return all subnets without
+	// an allocatable range
+	container := s.newCustomAPI(c, "i-no-alloc-all", true)
+	args := s.makeArgs(container)
+	err, _ := s.assertCall(c, args, nil, "cannot allocate addresses: address allocation on any available subnets is not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (s *prepareSuite) TestErrorWhenNoNICSAvailable(c *gc.C) {
+	// The magic "i-no-nics-" instance id prefix for the host
+	// causes the dummy provider to return no results and no errors
+	// from NetworkInterfaces().
+	container := s.newCustomAPI(c, "i-no-nics-here", true)
+	args := s.makeArgs(container)
+	s.assertCall(c, args, nil, "cannot allocate addresses: no interfaces available")
+}
+
+func (s *prepareSuite) TestSuccessWithSingleContainer(c *gc.C) {
+	container := s.newAPI(c, true, true)
+	args := s.makeArgs(container)
+	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
+		ProviderId:       "dummy-eth0",
+		ProviderSubnetId: "dummy-private",
+		NetworkName:      "juju-private",
+		CIDR:             "0.10.0.0/24",
+		DeviceIndex:      0,
+		InterfaceName:    "eth0",
+		VLANTag:          0,
+		MACAddress:       "aa:bb:cc:dd:ee:f0",
+		Disabled:         false,
+		NoAutoStart:      false,
+		ConfigType:       "static",
+		Address:          "regex:0.10.0.[0-9]{1,3}", // we don't care about the actual value.
+		DNSServers:       []string{"ns1.dummy", "ns2.dummy"},
+		GatewayAddress:   "0.10.0.2",
+		ExtraConfig:      nil,
+	}}), "")
+
+	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
+		loggo.INFO,
+		`allocated address ".+" on instance "i-host" and subnet "dummy-private"`,
+	}, {
+		loggo.INFO,
+		`assigned address ".+" to container "0/lxc/0"`,
+	}})
+}
+
+func (s *prepareSuite) TestSuccessWhenFirstSubnetNotAllocatable(c *gc.C) {
+	// Using "i-no-alloc-0" for the host instance id will cause the
+	// dummy provider to change the Subnets() results to return no
+	// allocatable range for the first subnet (dummy-private), and
+	// also change its ProviderId to "noalloc-private", which in turn
+	// will cause SupportsAddressAllocation() to return false for it.
+	// We test here that we keep looking for other allocatable
+	// subnets.
+	container := s.newCustomAPI(c, "i-no-alloc-0", true)
+	args := s.makeArgs(container)
+	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
+		ProviderId:       "dummy-eth1",
+		ProviderSubnetId: "dummy-public",
+		NetworkName:      "juju-public",
+		CIDR:             "0.20.0.0/24",
+		DeviceIndex:      1,
+		InterfaceName:    "eth1",
+		VLANTag:          1,
+		MACAddress:       "aa:bb:cc:dd:ee:f1",
+		Disabled:         true,
+		NoAutoStart:      true,
+		ConfigType:       "static",
+		Address:          "regex:0.20.0.[0-9]{1,3}", // we don't care about the actual value.
+		DNSServers:       []string{"ns1.dummy", "ns2.dummy"},
+		GatewayAddress:   "0.20.0.2",
+		ExtraConfig:      nil,
+	}}), "")
+
+	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
+		loggo.TRACE,
+		`ignoring subnet "noalloc-private" - no allocatable range set`,
+	}, {
+		loggo.INFO,
+		`allocated address ".+" on instance "i-no-alloc-0" and subnet "dummy-public"`,
+	}, {
+		loggo.INFO,
+		`assigned address ".+" to container "0/lxc/0"`,
+	}})
+}

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -23,6 +25,8 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider/registry"
 )
+
+var logger = loggo.GetLogger("juju.apiserver.provisioner")
 
 func init() {
 	common.RegisterStandardFacade("Provisioner", 0, NewProvisionerAPI)
@@ -785,4 +789,347 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 		return result, watcher.EnsureErr(watch)
 	}
 	return result, nil
+}
+
+// PrepareContainerInterfaceInfo allocates an address and returns
+// information for configuring networking on a container. It accepts
+// container tags as arguments.
+func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (params.MachineNetworkConfigResults, error) {
+	result := params.MachineNetworkConfigResults{
+		Results: make([]params.MachineNetworkConfigResult, len(args.Entities)),
+	}
+	// Some preparations first.
+	environ, host, canAccess, err := p.prepareAllocationEnvironment()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	instId, err := host.InstanceId()
+	if err != nil && errors.IsNotProvisioned(err) {
+		// If the host machine is not provisioned yet, we have nothing
+		// to do. NotProvisionedf will append " not provisioned" to
+		// the message.
+		err = errors.NotProvisionedf("cannot allocate addresses: host machine %q", host)
+		return result, err
+	}
+	subnet, subnetInfo, interfaceInfo, err := p.prepareAllocationNetwork(environ, host, instId)
+	if err != nil {
+		return result, errors.Annotate(err, "cannot allocate addresses")
+	}
+	// Loop over the passed container tags.
+	for i, entity := range args.Entities {
+		tag, err := names.ParseMachineTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+
+		// The auth function (canAccess) checks that the machine is a
+		// top level machine (we filter those out next) or that the
+		// machine has the host as a parent.
+		container, err := p.getMachine(canAccess, tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		} else if !container.IsContainer() {
+			err = errors.Errorf("cannot allocate address for %q: not a container", tag)
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		} else if ciid, cerr := container.InstanceId(); cerr == nil {
+			// Since we want to configure and create NICs on the
+			// container before it starts, it must also be not
+			// provisioned yet.
+			err = errors.Errorf("container %q already provisioned as %q", container, ciid)
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		} else if cerr != nil && !errors.IsNotProvisioned(cerr) {
+			// Any other error needs to be reported.
+			result.Results[i].Error = common.ServerError(cerr)
+			continue
+		}
+
+		// Allocate and set address.
+		addr, err := p.allocateAddress(environ, subnet, host, container, instId)
+		if err != nil {
+			err = errors.Annotatef(err, "failed to allocate an address for %q", container)
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		// Store it on the machine, construct and set an interface result.
+		dnsServers := make([]string, len(interfaceInfo.DNSServers))
+		for i, dns := range interfaceInfo.DNSServers {
+			dnsServers[i] = dns.Value
+		}
+		// TODO(dimitern): Support allocating one address per NIC on
+		// the host, effectively creating the same number of NICs in
+		// the container.
+		result.Results[i] = params.MachineNetworkConfigResult{
+			Config: []params.NetworkConfig{{
+				DeviceIndex:      interfaceInfo.DeviceIndex,
+				MACAddress:       interfaceInfo.MACAddress,
+				CIDR:             subnetInfo.CIDR,
+				NetworkName:      interfaceInfo.NetworkName,
+				ProviderId:       string(interfaceInfo.ProviderId),
+				ProviderSubnetId: string(subnetInfo.ProviderId),
+				VLANTag:          interfaceInfo.VLANTag,
+				InterfaceName:    interfaceInfo.InterfaceName,
+				Disabled:         interfaceInfo.Disabled,
+				NoAutoStart:      interfaceInfo.NoAutoStart,
+				DNSServers:       dnsServers,
+				ConfigType:       string(network.ConfigStatic),
+				Address:          addr.Value(),
+				// container's gateway is the host's primary NIC's IP.
+				GatewayAddress: interfaceInfo.Address.Value,
+				ExtraConfig:    interfaceInfo.ExtraConfig,
+			}},
+		}
+	}
+	return result, nil
+}
+
+// prepareAllocationEnvironment retrieves the environment, host machine, and access
+// for the allocations.
+func (p *ProvisionerAPI) prepareAllocationEnvironment() (environs.NetworkingEnviron, *state.Machine, common.AuthFunc, error) {
+	cfg, err := p.st.EnvironConfig()
+	if err != nil {
+		return nil, nil, nil, errors.Annotate(err, "failed to get environment config")
+	}
+	environ, err := environs.New(cfg)
+	if err != nil {
+		return nil, nil, nil, errors.Annotate(err, "failed to construct an environment from config")
+	}
+	netEnviron, supported := environs.SupportsNetworking(environ)
+	if !supported {
+		// " not supported" will be appended to the message below.
+		return nil, nil, nil, errors.NotSupportedf("environment %q networking", cfg.Name())
+	}
+
+	canAccess, err := p.getAuthFunc()
+	if err != nil {
+		return nil, nil, nil, errors.Annotate(err, "cannot authenticate request")
+	}
+	hostAuthTag := p.authorizer.GetAuthTag()
+	if hostAuthTag == nil {
+		return nil, nil, nil, errors.Errorf("authenticated entity tag is nil")
+	}
+	hostTag, err := names.ParseMachineTag(hostAuthTag.String())
+	if err != nil {
+		return nil, nil, nil, errors.Trace(err)
+	}
+	host, err := p.getMachine(canAccess, hostTag)
+	if err != nil {
+		return nil, nil, nil, errors.Trace(err)
+	}
+	return netEnviron, host, canAccess, nil
+}
+
+// prepareAllocationNetwork retrieves the subnet, its info, and the interface info
+// for the allocations.
+func (p *ProvisionerAPI) prepareAllocationNetwork(
+	environ environs.NetworkingEnviron,
+	host *state.Machine,
+	instId instance.Id,
+) (
+	*state.Subnet,
+	network.SubnetInfo,
+	network.InterfaceInfo,
+	error,
+) {
+	var subnetInfo network.SubnetInfo
+	var interfaceInfo network.InterfaceInfo
+
+	interfaces, err := environ.NetworkInterfaces(instId)
+	if err != nil {
+		return nil, subnetInfo, interfaceInfo, errors.Trace(err)
+	} else if len(interfaces) == 0 {
+		return nil, subnetInfo, interfaceInfo, errors.Errorf("no interfaces available")
+	}
+	logger.Tracef("interfaces for instance %q: %v", instId, interfaces)
+
+	subnetIds := make([]network.Id, len(interfaces))
+	subnetIdToInterface := make(map[network.Id]network.InterfaceInfo)
+	for i, iface := range interfaces {
+		subnetIds[i] = iface.ProviderSubnetId
+		subnetIdToInterface[iface.ProviderSubnetId] = iface
+	}
+	subnets, err := environ.Subnets(instId, subnetIds)
+	if err != nil {
+		return nil, subnetInfo, interfaceInfo, errors.Trace(err)
+	} else if len(subnets) == 0 {
+		return nil, subnetInfo, interfaceInfo, errors.Errorf("no subnets available")
+	}
+	logger.Tracef("subnets for instance %q: %v", instId, subnets)
+
+	// TODO(mfoord): we need a better strategy for picking a subnet to
+	// allocate an address on. (dimitern): Right now we just pick the
+	// first subnet with allocatable range set. Instead, we should
+	// allocate an address per interface, assuming each interface is
+	// on a subnet with allocatable range set, and skipping those
+	// which do not have a range set.
+	var success bool
+	for _, sub := range subnets {
+		logger.Tracef("trying to allocate a static IP on subnet %q", sub.ProviderId)
+		if sub.AllocatableIPHigh == nil {
+			logger.Tracef("ignoring subnet %q - no allocatable range set", sub.ProviderId)
+			// this subnet has no allocatable IPs
+			continue
+		}
+		ok, err := environ.SupportsAddressAllocation(sub.ProviderId)
+		if err == nil && ok {
+			subnetInfo = sub
+			interfaceInfo = subnetIdToInterface[sub.ProviderId]
+			success = true
+			break
+		}
+		logger.Tracef(
+			"subnet %q supports address allocation: %v (error: %v)",
+			sub.ProviderId, ok, err,
+		)
+	}
+	if !success {
+		// " not supported" will be appended to the message below.
+		return nil, subnetInfo, interfaceInfo, errors.NotSupportedf(
+			"address allocation on any available subnets is",
+		)
+	}
+	subnet, err := p.createOrFetchStateSubnet(subnetInfo)
+
+	return subnet, subnetInfo, interfaceInfo, nil
+}
+
+// These are defined like this to allow mocking in tests.
+var (
+	allocateAddrTo = func(a *state.IPAddress, m *state.Machine) error {
+		// TODO(mfoord): populate proper interface ID (in state).
+		return a.AllocateTo(m.Id(), "")
+	}
+	setAddrsTo = func(a *state.IPAddress, m *state.Machine) error {
+		return m.SetAddresses(a.Address())
+	}
+	setAddrState = func(a *state.IPAddress, st state.AddressState) error {
+		return a.SetState(st)
+	}
+)
+
+// allocateAddress tries to pick an address out of the given subnet and
+// allocates it to the container.
+func (p *ProvisionerAPI) allocateAddress(
+	environ environs.NetworkingEnviron,
+	subnet *state.Subnet,
+	host, container *state.Machine,
+	instId instance.Id,
+) (*state.IPAddress, error) {
+
+	subnetId := network.Id(subnet.ProviderId())
+	for {
+		addr, err := subnet.PickNewAddress()
+		if err != nil {
+			return nil, err
+		}
+		logger.Tracef("picked new address %q on subnet %q", addr, subnetId)
+		// Attempt to allocate with environ.
+		err = environ.AllocateAddress(instId, subnetId, addr.Address())
+		if err != nil {
+			logger.Warningf(
+				"allocating address %q on instance %q and subnet %q failed: %v (retrying)",
+				addr, instId, subnetId, err,
+			)
+			// It's as good as unavailable for us, so mark it as
+			// such.
+			err = setAddrState(addr, state.AddressStateUnavailable)
+			if err != nil {
+				logger.Warningf(
+					"cannot set address %q to %q: %v (ignoring and retrying)",
+					addr, state.AddressStateUnavailable, err,
+				)
+				continue
+			}
+			logger.Tracef(
+				"setting address %q to %q and retrying",
+				addr, state.AddressStateUnavailable,
+			)
+			continue
+		}
+		logger.Infof(
+			"allocated address %q on instance %q and subnet %q",
+			addr, instId, subnetId,
+		)
+		err = p.setAllocatedOrRelease(addr, environ, instId, container, subnetId)
+		if err != nil {
+			// Something went wrong - retry.
+			continue
+		}
+		return addr, nil
+	}
+}
+
+// setAllocatedOrRelease tries to associate the newly allocated
+// address addr with the container. On failure it makes the best
+// effort to cleanup and release addr, logging issues along the way.
+func (p *ProvisionerAPI) setAllocatedOrRelease(
+	addr *state.IPAddress,
+	environ environs.NetworkingEnviron,
+	instId instance.Id,
+	container *state.Machine,
+	subnetId network.Id,
+) (err error) {
+	defer func() {
+		if errors.Cause(err) == nil {
+			// Success!
+			return
+		}
+		logger.Warningf(
+			"failed to mark address %q as %q to container %q: %v (releasing and retrying)",
+			addr, state.AddressStateAllocated, container, err,
+		)
+		// It's as good as unavailable for us, so mark it as
+		// such.
+		err = setAddrState(addr, state.AddressStateUnavailable)
+		if err != nil {
+			logger.Warningf(
+				"cannot set address %q to %q: %v (ignoring and releasing)",
+				addr, state.AddressStateUnavailable, err,
+			)
+		}
+		err = environ.ReleaseAddress(instId, subnetId, addr.Address())
+		if err == nil {
+			logger.Infof("address %q released; trying to allocate new", addr)
+			return
+		}
+		logger.Warningf(
+			"failed to release address %q on instance %q and subnet %q: %v (ignoring and retrying)",
+			addr, instId, subnetId, err,
+		)
+	}()
+
+	// Any errors returned below will trigger the release/cleanup
+	// steps above.
+	if err = allocateAddrTo(addr, container); err != nil {
+		return errors.Trace(err)
+	}
+	if err = setAddrsTo(addr, container); err != nil {
+		return errors.Trace(err)
+	}
+
+	logger.Infof("assigned address %q to container %q", addr, container)
+	return nil
+}
+
+func (p *ProvisionerAPI) createOrFetchStateSubnet(subnetInfo network.SubnetInfo) (*state.Subnet, error) {
+	stateSubnetInfo := state.SubnetInfo{
+		ProviderId:        string(subnetInfo.ProviderId),
+		CIDR:              subnetInfo.CIDR,
+		VLANTag:           subnetInfo.VLANTag,
+		AllocatableIPHigh: subnetInfo.AllocatableIPHigh.String(),
+		AllocatableIPLow:  subnetInfo.AllocatableIPLow.String(),
+	}
+	subnet, err := p.st.AddSubnet(stateSubnetInfo)
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			subnet, err = p.st.Subnet(subnetInfo.CIDR)
+		}
+		if err != nil {
+			return subnet, errors.Trace(err)
+		}
+	}
+	return subnet, nil
 }


### PR DESCRIPTION
New server-side Provisioner API method which allows allocating
and preparing the necessary network config for containers to
get provisioned with static IPs.

The process is fairly involved and includes several steps, but
after a few rounds of refactoring I think now it should be more
obvious and *much* better tested (almost complete coverage and
all of the important code paths are tested).

Extensively tested, however since it's not used yet there is no visible
impact of the new API method. Once this lands, a client-side API will
follow.

NOTE: Please, ignore all changes outside apiserver/provisioner/ - they come from the 2 parent PRs (#1631 and #1632) - RB link below has the correct diff.

(Review request: http://reviews.vapour.ws/r/973/)