### PR TITLE
LP: #1407727, prevent invalid network names from panicking provisioner.

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -925,6 +925,13 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 				NetworkName: netName,
 				CIDR:        "invalid",
 			}
+		} else if strings.HasPrefix(netName, "invalid-") {
+			// Simulate we didn't get correct information for the network.
+			networkInfo[i] = network.InterfaceInfo{
+				ProviderId:  network.Id(netName),
+				NetworkName: "$$" + netName,
+				CIDR:        "invalid",
+			}
 		} else {
 			networkInfo[i] = network.InterfaceInfo{
 				ProviderId:    network.Id(netName),

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -926,11 +926,11 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 				CIDR:        "invalid",
 			}
 		} else if strings.HasPrefix(netName, "invalid-") {
-			// Simulate we didn't get correct information for the network.
+			// Simulate we got invalid information for the network.
 			networkInfo[i] = network.InterfaceInfo{
 				ProviderId:  network.Id(netName),
 				NetworkName: "$$" + netName,
-				CIDR:        "invalid",
+				CIDR:        fmt.Sprintf("0.%d.2.0/24", i+1),
 			}
 		} else {
 			networkInfo[i] = network.InterfaceInfo{

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -565,12 +565,15 @@ func (task *provisionerTask) setErrorStatus(message string, machine *apiprovisio
 }
 
 func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.InterfaceInfo) (
-	networks []params.Network, ifaces []params.NetworkInterface) {
+	networks []params.Network, ifaces []params.NetworkInterface, err error) {
 	if len(networkInfo) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	visitedNetworks := set.NewStrings()
 	for _, info := range networkInfo {
+		if !names.IsValidNetwork(info.NetworkName) {
+			return nil, nil, errors.Errorf("invalid network name %q", info.NetworkName)
+		}
 		networkTag := names.NewNetworkTag(info.NetworkName).String()
 		if !visitedNetworks.Contains(networkTag) {
 			networks = append(networks, params.Network{
@@ -589,7 +592,7 @@ func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.I
 			Disabled:      info.Disabled,
 		})
 	}
-	return networks, ifaces
+	return networks, ifaces, nil
 }
 
 func (task *provisionerTask) startMachine(
@@ -618,7 +621,10 @@ func (task *provisionerTask) startMachine(
 	inst := result.Instance
 	hardware := result.Hardware
 	nonce := startInstanceParams.MachineConfig.MachineNonce
-	networks, ifaces := task.prepareNetworkAndInterfaces(result.NetworkInfo)
+	networks, ifaces, err := task.prepareNetworkAndInterfaces(result.NetworkInfo)
+	if err != nil {
+		return task.setErrorStatus("cannot prepare network for machine %q: %v", machine, err)
+	}
 	volumes := volumesToApiserver(result.Volumes)
 	volumeAttachments := volumeAttachmentsToApiserver(result.VolumeAttachments)
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -716,7 +716,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForContainers(c *gc.C) {
 
 func (s *ProvisionerSuite) TestProvisioningMachinesWithRequestedNetworks(c *gc.C) {
 	p := s.newEnvironProvisioner(c)
-	defer stop(c, p)
+	defer p.Stop()
 
 	// Add and provision a machine with networks specified.
 	requestedNetworks := []string{"net1", "net2"}
@@ -760,6 +760,24 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithRequestedNetworks(c *gc.C
 	c.Assert(m.EnsureDead(), gc.IsNil)
 	s.checkStopInstances(c, inst)
 	s.waitRemoved(c, m)
+}
+
+func (s *ProvisionerSuite) TestProvisioningMachinesWithInvalidNetwork(c *gc.C) {
+	s.newEnvironProvisioner(c)
+
+	// Add and provision a machine with networks specified.
+	networks := []string{"invalid-net1"}
+	expectNetworkInfo := []network.InterfaceInfo{
+		{ProviderId: "invalid-net1", NetworkName: "$$invalid-net1", CIDR: "invalid"},
+	}
+	m, err := s.addMachineWithRequestedNetworks(networks, constraints.Value{})
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStartInstanceCustom(
+		c, m, "pork", constraints.Value{},
+		networks, expectNetworkInfo, false,
+		nil, false,
+	)
+	c.Assert(m.EnsureDead(), gc.IsNil)
 }
 
 func (s *ProvisionerSuite) TestSetInstanceInfoFailureSetsErrorStatusAndStopsInstanceButKeepsGoing(c *gc.C) {


### PR DESCRIPTION
Discovered this when looking at https://bugs.launchpad.net/juju-core/+bug/1407727.

This PR handles invalid network names in the machine provisioner by setting task error status instead of panicking.