### PR TITLE
all: s/DiskTag/VolumeTag/g

### DIFF
--- a/api/diskformatter/diskformatter.go
+++ b/api/diskformatter/diskformatter.go
@@ -73,7 +73,7 @@ func (st *State) AttachedVolumes() ([]params.VolumeAttachment, error) {
 
 // VolumePreparationInfo returns the information required to format the
 // specified volumes.
-func (st *State) VolumePreparationInfo(tags []names.DiskTag) ([]params.VolumePreparationInfoResult, error) {
+func (st *State) VolumePreparationInfo(tags []names.VolumeTag) ([]params.VolumePreparationInfoResult, error) {
 	var results params.VolumePreparationInfoResults
 	args := params.VolumeAttachmentIds{
 		Ids: make([]params.VolumeAttachmentId, len(tags)),

--- a/api/diskformatter/diskformatter_test.go
+++ b/api/diskformatter/diskformatter_test.go
@@ -80,8 +80,8 @@ func (s *DiskFormatterSuite) TestVolumePreparationInfo(c *gc.C) {
 		c.Check(request, gc.Equals, "VolumePreparationInfo")
 		c.Check(arg, gc.DeepEquals, params.VolumeAttachmentIds{
 			Ids: []params.VolumeAttachmentId{
-				{MachineTag: "machine-0", VolumeTag: "disk-0"},
-				{MachineTag: "machine-0", VolumeTag: "disk-1"},
+				{MachineTag: "machine-0", VolumeTag: "volume-0"},
+				{MachineTag: "machine-0", VolumeTag: "volume-1"},
 			},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.VolumePreparationInfoResults{})
@@ -93,9 +93,9 @@ func (s *DiskFormatterSuite) TestVolumePreparationInfo(c *gc.C) {
 	})
 
 	st := diskformatter.NewState(apiCaller, names.NewMachineTag("0"))
-	results, err := st.VolumePreparationInfo([]names.DiskTag{
-		names.NewDiskTag("0"),
-		names.NewDiskTag("1"),
+	results, err := st.VolumePreparationInfo([]names.VolumeTag{
+		names.NewVolumeTag("0"),
+		names.NewVolumeTag("1"),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -298,12 +298,12 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 		IsVirtual:     false,
 	}}
 	volumes := []params.Volume{{
-		VolumeTag: "disk-0",
+		VolumeTag: "volume-0",
 		VolumeId:  "vol-123",
 		Size:      124,
 	}}
 	volumeAttachments := []params.VolumeAttachment{{
-		VolumeTag:  "disk-0",
+		VolumeTag:  "volume-0",
 		MachineTag: "machine-1",
 		DeviceName: "xvdf1",
 	}}
@@ -362,7 +362,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(actual, jc.SameContents, ifaces[:4]) // skip the rest as they are ignored.
 
 	// Now check volumes and volume attachments.
-	volume, err := s.State.Volume(names.NewDiskTag("0"))
+	volume, err := s.State.Volume(names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfo, err := volume.Info()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/diskformatter/diskformatter.go
+++ b/apiserver/diskformatter/diskformatter.go
@@ -201,7 +201,7 @@ func (a *DiskFormatterAPI) VolumePreparationInfo(args params.VolumeAttachmentIds
 		if err != nil || !canAccess(machineTag) {
 			return params.VolumePreparationInfo{}, common.ErrPerm
 		}
-		volumeTag, err := names.ParseDiskTag(id.VolumeTag)
+		volumeTag, err := names.ParseVolumeTag(id.VolumeTag)
 		if err != nil {
 			return params.VolumePreparationInfo{}, common.ErrPerm
 		}
@@ -217,7 +217,7 @@ func (a *DiskFormatterAPI) VolumePreparationInfo(args params.VolumeAttachmentIds
 
 func (a *DiskFormatterAPI) oneVolumePreparationInfo(
 	machineTag names.MachineTag,
-	volumeTag names.DiskTag,
+	volumeTag names.VolumeTag,
 	machineBlockDevices map[names.MachineTag][]state.BlockDeviceInfo,
 ) (params.VolumePreparationInfo, error) {
 	var result params.VolumePreparationInfo
@@ -273,7 +273,7 @@ func (a *DiskFormatterAPI) oneVolumePreparationInfo(
 // storage instance that the volume is assigned to.
 func (a *DiskFormatterAPI) attachedVolumeInfo(
 	machineTag names.MachineTag,
-	volumeTag names.DiskTag,
+	volumeTag names.VolumeTag,
 ) (*state.VolumeInfo, *state.VolumeAttachmentInfo, *names.StorageTag, error) {
 	volume, err := a.st.Volume(volumeTag)
 	if err != nil {

--- a/apiserver/diskformatter/diskformatter_test.go
+++ b/apiserver/diskformatter/diskformatter_test.go
@@ -47,7 +47,7 @@ func (s *DiskFormatterSuite) TestWatchAttachedVolumes(c *gc.C) {
 			{Tag: "machine-0"},
 			{Tag: "machine-1"},
 			{Tag: "unit-service-0"},
-			{Tag: "disk-1"},
+			{Tag: "volume-1"},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -66,9 +66,9 @@ func (s *DiskFormatterSuite) TestWatchAttachedVolumes(c *gc.C) {
 
 func (s *DiskFormatterSuite) TestAttachedVolumes(c *gc.C) {
 	machine0 := names.NewMachineTag("0")
-	volume0 := names.NewDiskTag("0")
-	volume1 := names.NewDiskTag("1")
-	volume2 := names.NewDiskTag("2")
+	volume0 := names.NewVolumeTag("0")
+	volume1 := names.NewVolumeTag("1")
+	volume2 := names.NewVolumeTag("2")
 
 	s.st.devices = map[names.MachineTag][]state.BlockDeviceInfo{
 		machine0: {{
@@ -79,7 +79,7 @@ func (s *DiskFormatterSuite) TestAttachedVolumes(c *gc.C) {
 		}},
 	}
 
-	s.st.volumes = map[names.DiskTag]*mockVolume{
+	s.st.volumes = map[names.VolumeTag]*mockVolume{
 		volume0: {
 			tag: volume0,
 			info: &state.VolumeInfo{
@@ -110,7 +110,7 @@ func (s *DiskFormatterSuite) TestAttachedVolumes(c *gc.C) {
 			{Tag: "machine-0"},
 			{Tag: "machine-1"},
 			{Tag: "unit-service-0"},
-			{Tag: "disk-1"},
+			{Tag: "volume-1"},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -148,10 +148,10 @@ func (s *DiskFormatterSuite) TestAttachedVolumes(c *gc.C) {
 
 func (s *DiskFormatterSuite) TestVolumePreparationInfo(c *gc.C) {
 	machine0 := names.NewMachineTag("0")
-	volume0 := names.NewDiskTag("0")
-	volume1 := names.NewDiskTag("1")
-	volume2 := names.NewDiskTag("2")
-	volume3 := names.NewDiskTag("3")
+	volume0 := names.NewVolumeTag("0")
+	volume1 := names.NewVolumeTag("1")
+	volume2 := names.NewVolumeTag("2")
+	volume3 := names.NewVolumeTag("3")
 	storagefs := names.NewStorageTag("fs/0")
 	storageblk := names.NewStorageTag("blk/0")
 
@@ -174,7 +174,7 @@ func (s *DiskFormatterSuite) TestVolumePreparationInfo(c *gc.C) {
 		storageblk: {kind: state.StorageKindBlock},
 	}
 
-	s.st.volumes = map[names.DiskTag]*mockVolume{
+	s.st.volumes = map[names.VolumeTag]*mockVolume{
 		volume0: {
 			tag:     volume0,
 			storage: storagefs,
@@ -220,11 +220,11 @@ func (s *DiskFormatterSuite) TestVolumePreparationInfo(c *gc.C) {
 
 	results, err := s.api.VolumePreparationInfo(params.VolumeAttachmentIds{
 		Ids: []params.VolumeAttachmentId{
-			{MachineTag: "machine-0", VolumeTag: "disk-0"},
-			{MachineTag: "machine-0", VolumeTag: "disk-1"},
-			{MachineTag: "machine-0", VolumeTag: "disk-2"},
-			{MachineTag: "machine-0", VolumeTag: "disk-3"},
-			{MachineTag: "machine-1", VolumeTag: "disk-0"},
+			{MachineTag: "machine-0", VolumeTag: "volume-0"},
+			{MachineTag: "machine-0", VolumeTag: "volume-1"},
+			{MachineTag: "machine-0", VolumeTag: "volume-2"},
+			{MachineTag: "machine-0", VolumeTag: "volume-3"},
+			{MachineTag: "machine-1", VolumeTag: "volume-0"},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -278,7 +278,7 @@ type mockState struct {
 	calls             []call
 	devices           map[names.MachineTag][]state.BlockDeviceInfo
 	storageInstances  map[names.StorageTag]*mockStorageInstance
-	volumes           map[names.DiskTag]*mockVolume
+	volumes           map[names.VolumeTag]*mockVolume
 	volumeAttachments []*mockVolumeAttachment
 }
 
@@ -314,7 +314,7 @@ func (st *mockState) StorageInstance(tag names.StorageTag) (state.StorageInstanc
 	return storageInstance, nil
 }
 
-func (st *mockState) Volume(tag names.DiskTag) (state.Volume, error) {
+func (st *mockState) Volume(tag names.VolumeTag) (state.Volume, error) {
 	st.recordCall("Volume", tag)
 	volume, ok := st.volumes[tag]
 	if !ok {
@@ -334,7 +334,7 @@ func (st *mockState) MachineVolumeAttachments(tag names.MachineTag) ([]state.Vol
 	return attachments, nil
 }
 
-func (st *mockState) VolumeAttachment(machine names.MachineTag, volume names.DiskTag) (state.VolumeAttachment, error) {
+func (st *mockState) VolumeAttachment(machine names.MachineTag, volume names.VolumeTag) (state.VolumeAttachment, error) {
 	st.recordCall("VolumeAttachment", machine, volume)
 	for _, att := range st.volumeAttachments {
 		if att.machine == machine && att.volume == volume {
@@ -356,7 +356,7 @@ func (w *mockNotifyWatcher) Changes() <-chan struct{} {
 type mockVolume struct {
 	state.Volume
 
-	tag     names.DiskTag
+	tag     names.VolumeTag
 	storage names.StorageTag
 	info    *state.VolumeInfo
 }
@@ -387,12 +387,12 @@ func (d *mockStorageInstance) Kind() state.StorageKind {
 }
 
 type mockVolumeAttachment struct {
-	volume  names.DiskTag
+	volume  names.VolumeTag
 	machine names.MachineTag
 	info    *state.VolumeAttachmentInfo
 }
 
-func (a *mockVolumeAttachment) Volume() names.DiskTag {
+func (a *mockVolumeAttachment) Volume() names.VolumeTag {
 	return a.volume
 }
 

--- a/apiserver/diskformatter/state.go
+++ b/apiserver/diskformatter/state.go
@@ -13,9 +13,9 @@ type stateInterface interface {
 	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 	MachineVolumeAttachments(names.MachineTag) ([]state.VolumeAttachment, error)
-	VolumeAttachment(names.MachineTag, names.DiskTag) (state.VolumeAttachment, error)
+	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
-	Volume(names.DiskTag) (state.Volume, error)
+	Volume(names.VolumeTag) (state.Volume, error)
 }
 
 var getState = func(st *state.State) stateInterface {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -319,7 +319,7 @@ type InstanceInfo struct {
 	Networks        []Network
 	Interfaces      []NetworkInterface
 	Volumes         []Volume
-	// TODO(axw) we should return map[names.DiskTag]VolumeAttachmentInfo
+	// TODO(axw) we should return map[names.VolumeTag]VolumeAttachmentInfo
 	// here, containing only the information regarding the attachment.
 	// The rest can be inferred from the context.
 	VolumeAttachments []VolumeAttachment

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -583,13 +583,13 @@ func storageConfig(st *state.State, poolName string) (storage.ProviderType, map[
 
 // volumesToState converts a slice of storage.Volume to a mapping
 // of volume names to state.VolumeInfo.
-func volumesToState(in []params.Volume) (map[names.DiskTag]state.VolumeInfo, error) {
-	m := make(map[names.DiskTag]state.VolumeInfo)
+func volumesToState(in []params.Volume) (map[names.VolumeTag]state.VolumeInfo, error) {
+	m := make(map[names.VolumeTag]state.VolumeInfo)
 	for _, v := range in {
 		if v.VolumeTag == "" {
 			return nil, errors.New("Tag is empty")
 		}
-		volumeTag, err := names.ParseDiskTag(v.VolumeTag)
+		volumeTag, err := names.ParseVolumeTag(v.VolumeTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -604,13 +604,13 @@ func volumesToState(in []params.Volume) (map[names.DiskTag]state.VolumeInfo, err
 
 // volumeAttachmentsToState converts a slice of storage.VolumeAttachment to a
 // mapping of volume names to state.VolumeAttachmentInfo.
-func volumeAttachmentsToState(in []params.VolumeAttachment) (map[names.DiskTag]state.VolumeAttachmentInfo, error) {
-	m := make(map[names.DiskTag]state.VolumeAttachmentInfo)
+func volumeAttachmentsToState(in []params.VolumeAttachment) (map[names.VolumeTag]state.VolumeAttachmentInfo, error) {
+	m := make(map[names.VolumeTag]state.VolumeAttachmentInfo)
 	for _, v := range in {
 		if v.VolumeTag == "" {
 			return nil, errors.New("Tag is empty")
 		}
-		volumeTag, err := names.ParseDiskTag(v.VolumeTag)
+		volumeTag, err := names.ParseVolumeTag(v.VolumeTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -775,13 +775,13 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Volumes: []params.VolumeParams{{
-					VolumeTag:  "disk-0",
+					VolumeTag:  "volume-0",
 					Size:       1000,
 					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
 					Attributes: map[string]interface{}{"foo": "bar"},
 				}, {
-					VolumeTag:  "disk-1",
+					VolumeTag:  "volume-1",
 					Size:       2000,
 					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
@@ -824,7 +824,7 @@ func (s *withoutStateServerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Volumes: []params.VolumeParams{{
-					VolumeTag:  "disk-0",
+					VolumeTag:  "volume-0",
 					Size:       1000,
 					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
@@ -1085,12 +1085,12 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		InstanceId: "i-am-also",
 		Nonce:      "fake",
 		Volumes: []params.Volume{{
-			VolumeTag: "disk-0",
+			VolumeTag: "volume-0",
 			VolumeId:  "vol-0",
 			Size:      1234,
 		}},
 		VolumeAttachments: []params.VolumeAttachment{{
-			VolumeTag:  "disk-0",
+			VolumeTag:  "volume-0",
 			MachineTag: volumesMachine.Tag().String(),
 			DeviceName: "sda",
 		}},

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,7 +15,7 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	995b906ce18b2726e9d284efbfa79bd7070ec8c8	2015-02-19T20:49:45Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
-github.com/juju/names	git	016a15ed41d730ea92e308f5c697294a39187c76	2015-01-20T11:23:30Z
+github.com/juju/names	git	6237024e4938fc3946d46d9e65039c959d260499	2015-02-20T04:54:01Z
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T10:00:34Z

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -82,8 +82,8 @@ func (*DisksSuite) TestBlockDeviceNamer(c *gc.C) {
 }
 
 func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
-	volume0 := names.NewDiskTag("0")
-	volume1 := names.NewDiskTag("1")
+	volume0 := names.NewVolumeTag("0")
+	volume1 := names.NewVolumeTag("1")
 	machine0 := names.NewMachineTag("0")
 
 	mapping, volumes, volumeAttachments, err := ec2.GetBlockDeviceMappings(
@@ -146,7 +146,7 @@ func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 }
 
 func (*DisksSuite) TestGetBlockDeviceMappingErrors(c *gc.C) {
-	volume0 := names.NewDiskTag("0")
+	volume0 := names.NewVolumeTag("0")
 	machine0 := names.NewMachineTag("0")
 
 	for _, test := range []struct {

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -64,7 +64,7 @@ type MachineTemplate struct {
 
 	// VolumeAttachments holds the parameters for attaching existing
 	// volumes to the machine.
-	VolumeAttachments map[names.DiskTag]VolumeAttachmentParams
+	VolumeAttachments map[names.VolumeTag]VolumeAttachmentParams
 
 	// Nonce holds a unique value that can be used to check
 	// if a new instance was really started for this machine.
@@ -470,7 +470,7 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	// attempting to create the volume until after the machine
 	// has been provisioned.
 	var volumeOps []txn.Op
-	attachmentParams := make(map[names.DiskTag]VolumeAttachmentParams)
+	attachmentParams := make(map[names.VolumeTag]VolumeAttachmentParams)
 	for _, v := range template.Volumes {
 		op, tag, err := st.addVolumeOp(v.Volume)
 		if err != nil {

--- a/state/machine.go
+++ b/state/machine.go
@@ -907,8 +907,8 @@ func (m *Machine) SetProvisioned(id instance.Id, nonce string, characteristics *
 func (m *Machine) SetInstanceInfo(
 	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
 	networks []NetworkInfo, interfaces []NetworkInterfaceInfo,
-	volumes map[names.DiskTag]VolumeInfo,
-	volumeAttachments map[names.DiskTag]VolumeAttachmentInfo,
+	volumes map[names.VolumeTag]VolumeInfo,
+	volumeAttachments map[names.VolumeTag]VolumeAttachmentInfo,
 ) error {
 
 	// Add the networks and interfaces first.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -916,7 +916,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	c.Assert(err, gc.ErrorMatches, `cannot add network interface "" to machine "1": MAC address must be not empty`)
 	assertNotProvisioned()
 
-	invalidVolumes := map[names.DiskTag]state.VolumeInfo{names.NewDiskTag("1065"): state.VolumeInfo{}}
+	invalidVolumes := map[names.VolumeTag]state.VolumeInfo{names.NewVolumeTag("1065"): state.VolumeInfo{}}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil)
 	c.Assert(err, gc.ErrorMatches, "cannot set provisioned volume info: already provisioned")
 	assertNotProvisioned()
@@ -924,7 +924,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	// TODO(axw) test invalid volume attachment
 }
 
-func (s *MachineSuite) addVolume(c *gc.C, params state.VolumeParams) names.DiskTag {
+func (s *MachineSuite) addVolume(c *gc.C, params state.VolumeParams) names.VolumeTag {
 	op, tag, err := state.AddVolumeOp(s.State, params)
 	c.Assert(err, jc.ErrorIsNil)
 	err = state.RunTransaction(s.State, []txn.Op{op})
@@ -948,7 +948,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
 	interfaces := []state.NetworkInterfaceInfo{
 		{MACAddress: "aa:bb:cc:dd:ee:ff", NetworkName: "net1", InterfaceName: "eth0", IsVirtual: false},
 	}
-	volumes := map[names.DiskTag]state.VolumeInfo{
+	volumes := map[names.VolumeTag]state.VolumeInfo{
 		volumeTag: state.VolumeInfo{
 			VolumeId: "storage-123",
 			Size:     1234,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1204,7 +1204,7 @@ func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
 	volumeAttachments, err := s.State.MachineVolumeAttachments(m.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 2)
-	if volumeAttachments[0].Volume() == names.NewDiskTag("1") {
+	if volumeAttachments[0].Volume() == names.NewVolumeTag("1") {
 		va := volumeAttachments
 		va[0], va[1] = va[1], va[0]
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1383,7 +1383,7 @@ func (u *Unit) AssignToNewMachine() (err error) {
 
 // newMachineVolumeParams returns parameters for creating volumes and volume
 // attachments for a new machine that the unit will be assigned to.
-func (u *Unit) newMachineVolumeParams() ([]MachineVolumeParams, map[names.DiskTag]VolumeAttachmentParams, error) {
+func (u *Unit) newMachineVolumeParams() ([]MachineVolumeParams, map[names.VolumeTag]VolumeAttachmentParams, error) {
 	storageAttachments, err := u.st.StorageAttachments(u.UnitTag())
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "getting storage attachments")
@@ -1406,7 +1406,7 @@ func (u *Unit) newMachineVolumeParams() ([]MachineVolumeParams, map[names.DiskTa
 	}
 
 	var volumes []MachineVolumeParams
-	volumeAttachments := make(map[names.DiskTag]VolumeAttachmentParams)
+	volumeAttachments := make(map[names.VolumeTag]VolumeAttachmentParams)
 	for _, storageAttachment := range storageAttachments {
 		// TODO(axw) consult storage provider to see if we need to request
 		// a volume for the storage instance. Otherwise create a Filesystem

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -57,7 +57,7 @@ func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
 
 	volume, err := s.State.StorageInstanceVolume(storageInstance.StorageTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volume.VolumeTag(), gc.Equals, names.NewDiskTag("0"))
+	c.Assert(volume.VolumeTag(), gc.Equals, names.NewVolumeTag("0"))
 	volumeStorageTag, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeStorageTag, gc.Equals, storageInstance.StorageTag())

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -81,7 +81,7 @@ type VolumeSource interface {
 // storage pool definition, and charm storage metadata.
 type VolumeParams struct {
 	// Tag is a unique tag name assigned by Juju for the requested volume.
-	Tag names.DiskTag
+	Tag names.VolumeTag
 
 	// Size is the minimum size of the volume in MiB.
 	Size uint64
@@ -114,7 +114,7 @@ type VolumeAttachmentParams struct {
 
 	// Volume is a unique tag assigned by Juju for the volume that
 	// should be attached/detached.
-	Volume names.DiskTag
+	Volume names.VolumeTag
 
 	// VolumeId is the unique provider-supplied ID for the volume that
 	// should be attached/detached.

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -135,7 +135,7 @@ func (lvs *loopVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.Volu
 // DestroyVolumes is defined on the VolumeSource interface.
 func (lvs *loopVolumeSource) DestroyVolumes(volumeIds []string) error {
 	for _, volumeId := range volumeIds {
-		if _, err := names.ParseDiskTag(volumeId); err != nil {
+		if _, err := names.ParseVolumeTag(volumeId); err != nil {
 			return errors.Errorf("invalid loop volume ID %q", volumeId)
 		}
 		loopFilePath := lvs.volumeFilePath(volumeId)

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -8,7 +8,7 @@ import "github.com/juju/names"
 // Volume describes a volume (disk, logical volume, etc.)
 type Volume struct {
 	// Name is a unique name assigned by Juju to the volume.
-	Tag names.DiskTag
+	Tag names.VolumeTag
 
 	// VolumeId is a unique provider-supplied ID for the volume.
 	// VolumeId is required to be unique for the lifetime of the
@@ -30,7 +30,7 @@ type Volume struct {
 type VolumeAttachment struct {
 	// Volume is the unique tag assigned by Juju for the volume
 	// that this attachment corresponds to.
-	Volume names.DiskTag
+	Volume names.VolumeTag
 
 	// MachineId is the unique tag assigned by Juju for the machine that
 	// this attachment corresponds to.

--- a/worker/diskformatter/diskformatter.go
+++ b/worker/diskformatter/diskformatter.go
@@ -36,7 +36,7 @@ type VolumeAccessor interface {
 	AttachedVolumes() ([]params.VolumeAttachment, error)
 	// VolumePreparationInfo returns information required to format the
 	// specified volumes.
-	VolumePreparationInfo([]names.DiskTag) ([]params.VolumePreparationInfoResult, error)
+	VolumePreparationInfo([]names.VolumeTag) ([]params.VolumePreparationInfoResult, error)
 }
 
 // NewWorker returns a new worker that creates filesystems on volumes
@@ -68,9 +68,9 @@ func (f *diskFormatter) Handle() error {
 		return errors.Annotate(err, "getting attached volumes")
 	}
 
-	tags := make([]names.DiskTag, len(attachments))
+	tags := make([]names.VolumeTag, len(attachments))
 	for i, info := range attachments {
-		tag, err := names.ParseDiskTag(info.VolumeTag)
+		tag, err := names.ParseVolumeTag(info.VolumeTag)
 		if err != nil {
 			return errors.Annotate(err, "parsing disk tag")
 		}

--- a/worker/diskformatter/diskformatter_test.go
+++ b/worker/diskformatter/diskformatter_test.go
@@ -26,10 +26,10 @@ type DiskFormatterWorkerSuite struct {
 
 func (s *DiskFormatterWorkerSuite) TestWorker(c *gc.C) {
 	volumeAttachments := []params.VolumeAttachment{
-		{VolumeTag: "disk-0"},
-		{VolumeTag: "disk-1"},
-		{VolumeTag: "disk-2"},
-		{VolumeTag: "disk-3"},
+		{VolumeTag: "volume-0"},
+		{VolumeTag: "volume-1"},
+		{VolumeTag: "volume-2"},
+		{VolumeTag: "volume-3"},
 	}
 
 	volumeFormattingInfoResults := []params.VolumePreparationInfoResult{{
@@ -59,12 +59,12 @@ func (s *DiskFormatterWorkerSuite) TestWorker(c *gc.C) {
 		attachedVolumes: func() ([]params.VolumeAttachment, error) {
 			return volumeAttachments, nil
 		},
-		volumeFormattingInfo: func(tags []names.DiskTag) ([]params.VolumePreparationInfoResult, error) {
-			expect := make([]names.DiskTag, len(volumeAttachments))
+		volumeFormattingInfo: func(tags []names.VolumeTag) ([]params.VolumePreparationInfoResult, error) {
+			expect := make([]names.VolumeTag, len(volumeAttachments))
 			for i, att := range volumeAttachments {
 				tag, err := names.ParseTag(att.VolumeTag)
 				c.Assert(err, jc.ErrorIsNil)
-				expect[i] = tag.(names.DiskTag)
+				expect[i] = tag.(names.VolumeTag)
 			}
 			c.Assert(tags, gc.DeepEquals, expect)
 			return volumeFormattingInfoResults, nil
@@ -94,10 +94,10 @@ func (s *DiskFormatterWorkerSuite) TestMakeDefaultFilesystem(c *gc.C) {
 	accessor := &mockVolumeAccessor{
 		attachedVolumes: func() ([]params.VolumeAttachment, error) {
 			return []params.VolumeAttachment{{
-				VolumeTag: "disk-0",
+				VolumeTag: "volume-0",
 			}}, nil
 		},
-		volumeFormattingInfo: func(tags []names.DiskTag) ([]params.VolumePreparationInfoResult, error) {
+		volumeFormattingInfo: func(tags []names.VolumeTag) ([]params.VolumePreparationInfoResult, error) {
 			return []params.VolumePreparationInfoResult{{
 				Result: params.VolumePreparationInfo{
 					NeedsFilesystem: true,
@@ -128,9 +128,9 @@ func (s *DiskFormatterWorkerSuite) TestAttachedVolumesError(c *gc.C) {
 func (s *DiskFormatterWorkerSuite) TestBlockDeviceStorageInstanceError(c *gc.C) {
 	accessor := &mockVolumeAccessor{
 		attachedVolumes: func() ([]params.VolumeAttachment, error) {
-			return []params.VolumeAttachment{{VolumeTag: "disk-0"}}, nil
+			return []params.VolumeAttachment{{VolumeTag: "volume-0"}}, nil
 		},
-		volumeFormattingInfo: func(tags []names.DiskTag) ([]params.VolumePreparationInfoResult, error) {
+		volumeFormattingInfo: func(tags []names.VolumeTag) ([]params.VolumePreparationInfoResult, error) {
 			return []params.VolumePreparationInfoResult{}, errors.New("VolumePreparationInfo failed")
 		},
 	}
@@ -142,9 +142,9 @@ func (s *DiskFormatterWorkerSuite) TestBlockDeviceStorageInstanceError(c *gc.C) 
 func (s *DiskFormatterWorkerSuite) TestCannotMakeFilesystem(c *gc.C) {
 	accessor := &mockVolumeAccessor{
 		attachedVolumes: func() ([]params.VolumeAttachment, error) {
-			return []params.VolumeAttachment{{VolumeTag: "disk-0"}}, nil
+			return []params.VolumeAttachment{{VolumeTag: "volume-0"}}, nil
 		},
-		volumeFormattingInfo: func(tags []names.DiskTag) ([]params.VolumePreparationInfoResult, error) {
+		volumeFormattingInfo: func(tags []names.VolumeTag) ([]params.VolumePreparationInfoResult, error) {
 			return []params.VolumePreparationInfoResult{{
 				Result: params.VolumePreparationInfo{
 					NeedsFilesystem: true,
@@ -163,7 +163,7 @@ func (s *DiskFormatterWorkerSuite) TestCannotMakeFilesystem(c *gc.C) {
 type mockVolumeAccessor struct {
 	changes              chan struct{}
 	attachedVolumes      func() ([]params.VolumeAttachment, error)
-	volumeFormattingInfo func([]names.DiskTag) ([]params.VolumePreparationInfoResult, error)
+	volumeFormattingInfo func([]names.VolumeTag) ([]params.VolumePreparationInfoResult, error)
 }
 
 func (m *mockVolumeAccessor) Changes() <-chan struct{} {
@@ -186,6 +186,6 @@ func (m *mockVolumeAccessor) AttachedVolumes() ([]params.VolumeAttachment, error
 	return m.attachedVolumes()
 }
 
-func (m *mockVolumeAccessor) VolumePreparationInfo(tags []names.DiskTag) ([]params.VolumePreparationInfoResult, error) {
+func (m *mockVolumeAccessor) VolumePreparationInfo(tags []names.VolumeTag) ([]params.VolumePreparationInfoResult, error) {
 	return m.volumeFormattingInfo(tags)
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -484,7 +484,7 @@ func constructStartInstanceParams(
 
 	volumes := make([]storage.VolumeParams, len(provisioningInfo.Volumes))
 	for i, v := range provisioningInfo.Volumes {
-		volumeTag, err := names.ParseDiskTag(v.VolumeTag)
+		volumeTag, err := names.ParseVolumeTag(v.VolumeTag)
 		if err != nil {
 			return environs.StartInstanceParams{}, errors.Trace(err)
 		}


### PR DESCRIPTION
Update to latest juju/names, which renames
DiskTag to VolumeTag, in line with how we
refer to said entities in Juju.

(Review request: http://reviews.vapour.ws/r/975/)