### PR TITLE
uniter: add storage events to filter

### DIFF
--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -4,8 +4,6 @@
 package uniter
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"github.com/juju/names"
 
@@ -63,7 +61,7 @@ func (sa *StorageAccessor) WatchStorageAttachments(unitTag names.UnitTag) (watch
 		return nil, err
 	}
 	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {

--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -4,10 +4,13 @@
 package uniter
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -45,4 +48,27 @@ func (sa *StorageAccessor) StorageAttachments(unitTag names.Tag) ([]params.Stora
 		return nil, result.Error
 	}
 	return result.Result, nil
+}
+
+// WatchStorageAttachments starts a watcher for changes to storage
+// attachments related to the unit. The watcher will return the
+// IDs of the corresponding storage instances.
+func (sa *StorageAccessor) WatchStorageAttachments(unitTag names.UnitTag) (watcher.StringsWatcher, error) {
+	var results params.StringsWatchResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: unitTag.String()}},
+	}
+	err := sa.facade.FacadeCall("WatchStorageAttachments", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := watcher.NewStringsWatcher(sa.facade.RawAPICaller(), result)
+	return w, nil
 }

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -670,3 +670,9 @@ func (u *Unit) WatchMeterStatus() (watcher.NotifyWatcher, error) {
 	w := watcher.NewNotifyWatcher(u.st.facade.RawAPICaller(), result)
 	return w, nil
 }
+
+// WatchStorage returns a watcher for observing changes to the
+// unit's storage attachments.
+func (u *Unit) WatchStorage() (watcher.StringsWatcher, error) {
+	return u.st.WatchStorageAttachments(u.tag)
+}

--- a/apiserver/uniter/export_test.go
+++ b/apiserver/uniter/export_test.go
@@ -3,6 +3,18 @@
 
 package uniter
 
+import "github.com/juju/juju/apiserver/common"
+
 var (
 	GetZone = &getZone
 )
+
+type StorageStateInterface storageStateInterface
+
+func NewStorageAPI(
+	st StorageStateInterface,
+	resources *common.Resources,
+	accessUnit common.GetAuthFunc,
+) (*StorageAPI, error) {
+	return newStorageAPI(storageStateInterface(st), resources, accessUnit)
+}

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -13,6 +13,7 @@ type storageStateInterface interface {
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	StorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 	Unit(name string) (*state.Unit, error)
+	WatchStorageAttachments(names.UnitTag) state.StringsWatcher
 }
 
 type storageStateShim struct {

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
 
@@ -20,15 +19,15 @@ type StorageAPI struct {
 	accessUnit common.GetAuthFunc
 }
 
-// NewStorageAPI creates a new server-side Storage API facade.
-func NewStorageAPI(
-	st *state.State,
+// newStorageAPI creates a new server-side Storage API facade.
+func newStorageAPI(
+	st storageStateInterface,
 	resources *common.Resources,
 	accessUnit common.GetAuthFunc,
 ) (*StorageAPI, error) {
 
 	return &StorageAPI{
-		st:         getStorageState(st),
+		st:         st,
 		resources:  resources,
 		accessUnit: accessUnit,
 	}, nil

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -1,0 +1,74 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/uniter"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+type storageSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&storageSuite{})
+
+func (s *storageSuite) TestStorageAttachments(c *gc.C) {
+	resources := common.NewResources()
+	getCanAccess := func() (common.AuthFunc, error) {
+		return func(names.Tag) bool {
+			return true
+		}, nil
+	}
+	unitTag := names.NewUnitTag("mysql/0")
+	watcher := &mockStringsWatcher{
+		changes: make(chan []string, 1),
+	}
+	watcher.changes <- []string{"storage/0", "storage/1"}
+	state := &mockStorageState{
+		watchStorageAttachments: func(u names.UnitTag) state.StringsWatcher {
+			c.Assert(u, gc.DeepEquals, unitTag)
+			return watcher
+		},
+	}
+
+	storage, err := uniter.NewStorageAPI(state, resources, getCanAccess)
+	c.Assert(err, jc.ErrorIsNil)
+	watches, err := storage.WatchStorageAttachments(params.Entities{
+		Entities: []params.Entity{{unitTag.String()}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(watches, gc.DeepEquals, params.StringsWatchResults{
+		Results: []params.StringsWatchResult{{
+			StringsWatcherId: "1",
+			Changes:          []string{"storage/0", "storage/1"},
+		}},
+	})
+	c.Assert(resources.Get("1"), gc.Equals, watcher)
+}
+
+type mockStorageState struct {
+	uniter.StorageStateInterface
+	watchStorageAttachments func(names.UnitTag) state.StringsWatcher
+}
+
+func (m *mockStorageState) WatchStorageAttachments(u names.UnitTag) state.StringsWatcher {
+	return m.watchStorageAttachments(u)
+}
+
+type mockStringsWatcher struct {
+	state.StringsWatcher
+	changes chan []string
+}
+
+func (m *mockStringsWatcher) Changes() <-chan []string {
+	return m.changes
+}

--- a/apiserver/uniter/uniter_v2.go
+++ b/apiserver/uniter/uniter_v2.go
@@ -27,7 +27,7 @@ func NewUniterAPIV2(st *state.State, resources *common.Resources, authorizer com
 	if err != nil {
 		return nil, err
 	}
-	storageAPI, err := NewStorageAPI(st, resources, baseAPI.accessUnit)
+	storageAPI, err := newStorageAPI(getStorageState(st), resources, baseAPI.accessUnit)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/uniter/filter/interface.go
+++ b/worker/uniter/filter/interface.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/names"
 )
 
 // Filter is responsible for delivering events relevant to a unit agent in a
@@ -53,6 +54,10 @@ type Filter interface {
 	// RelationsEvents returns a channel that will receive the ids of all the service's
 	// relations whose Life status has changed.
 	RelationsEvents() <-chan []int
+
+	// StorageEvents returns a channel that will receive the tags of all the unit's
+	// associated storage instances whose Life status has changed.
+	StorageEvents() <-chan []names.StorageTag
 
 	// WantUpgradeEvent controls whether the filter will generate upgrade
 	// events for unforced service charm changes.

--- a/worker/uniter/filter/interface.go
+++ b/worker/uniter/filter/interface.go
@@ -4,11 +4,11 @@
 package filter
 
 import (
+	"github.com/juju/names"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/uniter/hook"
-	"github.com/juju/names"
 )
 
 // Filter is responsible for delivering events relevant to a unit agent in a


### PR DESCRIPTION
The uniter will now watch for storage attachment life cycle events. This
will be used later to trigger storage-* hooks.

(Review request: http://reviews.vapour.ws/r/977/)