### PR TITLE
Improved scripts/find-bad-doc-comments.py

### DIFF
--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -153,6 +153,10 @@ func (st *State) FindTools(v version.Number, series string, arch *string) (tools
 // PrepareContainerInterfaceInfo returns the necessary information to
 // configure network interfaces of a container with allocated static
 // IP addresses.
+//
+// TODO(dimitern): Before we start using this, we need to rename both
+// the method and the network.InterfaceInfo type to be called
+// InterfaceConfig.
 func (st *State) PrepareContainerInterfaceInfo(containerTag names.MachineTag) ([]network.InterfaceInfo, error) {
 	var result params.MachineNetworkConfigResults
 	args := params.Entities{


### PR DESCRIPTION
Added --unexported and --tests flags, off by default, which control
which cases will be included when reporting issues.

Now when called without arguments it will report the most likely cases
that need fixing, rather than also including tests methods and
unexported functions (which hardly require proper doc comments anyway).

Drive-by fix - added a missed suggestion from #1649.

(Review request: http://reviews.vapour.ws/r/978/)