### PR TITLE
Tidying up the quick fix.

### DIFF
--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
+	"github.com/juju/juju/juju/arch"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -43,6 +44,7 @@ type lxcBrokerSuite struct {
 	lxcSuite
 	broker      environs.InstanceBroker
 	agentConfig agent.ConfigSetterWriter
+	realArch    string
 }
 
 var _ = gc.Suite(&lxcBrokerSuite{})
@@ -85,9 +87,14 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *lxcBrokerSuite) TearDownTest(c *gc.C) {
+	version.Current.Arch = s.realArch
+}
+
 func (s *lxcBrokerSuite) startInstance(c *gc.C, machineId string) instance.Instance {
 	machineNonce := "fake-nonce"
-	version.Current.Arch = "amd64"
+	s.realArch = version.Current.Arch
+	version.Current.Arch = arch.AMD64
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -44,7 +44,6 @@ type lxcBrokerSuite struct {
 	lxcSuite
 	broker      environs.InstanceBroker
 	agentConfig agent.ConfigSetterWriter
-	realArch    string
 }
 
 var _ = gc.Suite(&lxcBrokerSuite{})
@@ -87,14 +86,9 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *lxcBrokerSuite) TearDownTest(c *gc.C) {
-	version.Current.Arch = s.realArch
-}
-
 func (s *lxcBrokerSuite) startInstance(c *gc.C, machineId string) instance.Instance {
 	machineNonce := "fake-nonce"
-	s.realArch = version.Current.Arch
-	version.Current.Arch = arch.AMD64
+	s.PatchValue(&version.Current.Arch, arch.AMD64)
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)


### PR DESCRIPTION
Use arch.AMD64 constant instead of a string to patch version.Current.Arch.
Restore original version.Current.Arch at the end of each test.

(Review request: http://reviews.vapour.ws/r/980/)