### PR TITLE
Fix go vet warnings with go1.4.1 version of go vet

### DIFF
--- a/apiserver/provisioner/prepare_test.go
+++ b/apiserver/provisioner/prepare_test.go
@@ -313,7 +313,7 @@ func (s *prepareSuite) TestRetryingOnAllocateAddressFailure(c *gc.C) {
 	var addresses []string
 	origSetAddrState := *provisioner.SetAddrState
 	s.PatchValue(provisioner.SetAddrState, func(ip *state.IPAddress, st state.AddressState) error {
-		c.Logf("setAddrState called for address %q, state %q", ip, st)
+		c.Logf("setAddrState called for address %q, state %q", ip.String(), st)
 		c.Assert(st, gc.Equals, state.AddressStateUnavailable)
 		addresses = append(addresses, ip.Value())
 
@@ -379,7 +379,7 @@ func (s *prepareSuite) TestReleaseAndCleanupWhenAllocateAndOrSetFail(c *gc.C) {
 	// are called along with the addresses to verify the logs later.
 	var allocAttemptedAddrs, allocAddrsOK, setAddrs, releasedAddrs []string
 	s.PatchValue(provisioner.AllocateAddrTo, func(ip *state.IPAddress, m *state.Machine) error {
-		c.Logf("allocateAddrTo called for address %q, machine %q", ip, m)
+		c.Logf("allocateAddrTo called for address %q, machine %q", ip.String(), m)
 		c.Assert(m.Id(), gc.Equals, container.Id())
 		allocAttemptedAddrs = append(allocAttemptedAddrs, ip.Value())
 
@@ -392,13 +392,13 @@ func (s *prepareSuite) TestReleaseAndCleanupWhenAllocateAndOrSetFail(c *gc.C) {
 		return errors.New("crash!")
 	})
 	s.PatchValue(provisioner.SetAddrsTo, func(ip *state.IPAddress, m *state.Machine) error {
-		c.Logf("setAddrsTo called for address %q, machine %q", ip, m)
+		c.Logf("setAddrsTo called for address %q, machine %q", ip.String(), m)
 		c.Assert(m.Id(), gc.Equals, container.Id())
 		setAddrs = append(setAddrs, ip.Value())
 		return errors.New("boom!")
 	})
 	s.PatchValue(provisioner.SetAddrState, func(ip *state.IPAddress, st state.AddressState) error {
-		c.Logf("setAddrState called for address %q, state %q", ip, st)
+		c.Logf("setAddrState called for address %q, state %q", ip.String(), st)
 		c.Assert(st, gc.Equals, state.AddressStateUnavailable)
 		releasedAddrs = append(releasedAddrs, ip.Value())
 		return nil
@@ -462,13 +462,13 @@ func (s *prepareSuite) TestReleaseAndRetryWhenSetOnlyFails(c *gc.C) {
 	args := s.makeArgs(container)
 
 	s.PatchValue(provisioner.SetAddrsTo, func(ip *state.IPAddress, m *state.Machine) error {
-		c.Logf("setAddrsTo called for address %q, machine %q", ip, m)
+		c.Logf("setAddrsTo called for address %q, machine %q", ip.String(), m)
 		c.Assert(m.Id(), gc.Equals, container.Id())
 		c.Assert(ip.Value(), gc.Equals, "0.10.0.10")
 		return errors.New("boom!")
 	})
 	s.PatchValue(provisioner.SetAddrState, func(ip *state.IPAddress, st state.AddressState) error {
-		c.Logf("setAddrState called for address %q, state %q", ip, st)
+		c.Logf("setAddrState called for address %q, state %q", ip.String(), st)
 		c.Assert(st, gc.Equals, state.AddressStateUnavailable)
 		c.Assert(ip.Value(), gc.Equals, "0.10.0.10")
 		return errors.New("pow!")

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1025,13 +1025,13 @@ func (p *ProvisionerAPI) allocateAddress(
 		if err != nil {
 			return nil, err
 		}
-		logger.Tracef("picked new address %q on subnet %q", addr, subnetId)
+		logger.Tracef("picked new address %q on subnet %q", addr.String(), subnetId)
 		// Attempt to allocate with environ.
 		err = environ.AllocateAddress(instId, subnetId, addr.Address())
 		if err != nil {
 			logger.Warningf(
 				"allocating address %q on instance %q and subnet %q failed: %v (retrying)",
-				addr, instId, subnetId, err,
+				addr.String(), instId, subnetId, err,
 			)
 			// It's as good as unavailable for us, so mark it as
 			// such.
@@ -1039,19 +1039,19 @@ func (p *ProvisionerAPI) allocateAddress(
 			if err != nil {
 				logger.Warningf(
 					"cannot set address %q to %q: %v (ignoring and retrying)",
-					addr, state.AddressStateUnavailable, err,
+					addr.String(), state.AddressStateUnavailable, err,
 				)
 				continue
 			}
 			logger.Tracef(
 				"setting address %q to %q and retrying",
-				addr, state.AddressStateUnavailable,
+				addr.String(), state.AddressStateUnavailable,
 			)
 			continue
 		}
 		logger.Infof(
 			"allocated address %q on instance %q and subnet %q",
-			addr, instId, subnetId,
+			addr.String(), instId, subnetId,
 		)
 		err = p.setAllocatedOrRelease(addr, environ, instId, container, subnetId)
 		if err != nil {
@@ -1079,7 +1079,7 @@ func (p *ProvisionerAPI) setAllocatedOrRelease(
 		}
 		logger.Warningf(
 			"failed to mark address %q as %q to container %q: %v (releasing and retrying)",
-			addr, state.AddressStateAllocated, container, err,
+			addr.String(), state.AddressStateAllocated, container, err,
 		)
 		// It's as good as unavailable for us, so mark it as
 		// such.
@@ -1087,17 +1087,17 @@ func (p *ProvisionerAPI) setAllocatedOrRelease(
 		if err != nil {
 			logger.Warningf(
 				"cannot set address %q to %q: %v (ignoring and releasing)",
-				addr, state.AddressStateUnavailable, err,
+				addr.String(), state.AddressStateUnavailable, err,
 			)
 		}
 		err = environ.ReleaseAddress(instId, subnetId, addr.Address())
 		if err == nil {
-			logger.Infof("address %q released; trying to allocate new", addr)
+			logger.Infof("address %q released; trying to allocate new", addr.String())
 			return
 		}
 		logger.Warningf(
 			"failed to release address %q on instance %q and subnet %q: %v (ignoring and retrying)",
-			addr, instId, subnetId, err,
+			addr.String(), instId, subnetId, err,
 		)
 	}()
 
@@ -1110,7 +1110,7 @@ func (p *ProvisionerAPI) setAllocatedOrRelease(
 		return errors.Trace(err)
 	}
 
-	logger.Infof("assigned address %q to container %q", addr, container)
+	logger.Infof("assigned address %q to container %q", addr.String(), container)
 	return nil
 }
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -273,7 +273,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Make sure the jenv file has the local host ports.
-	c.Log("\n\n%#v\n\n", s.APIState.APIHostPorts())
+	c.Logf("\n\n%#v\n\n", s.APIState.APIHostPorts())
 
 	s.Environ = environ
 


### PR DESCRIPTION
Go version 1.4 uses an updated version of `go vet` that finds warnings that Go version 1.2.1 doesn't find.

This PR cleans up a couple logging calls that the newer `go vet` finds troublesome.


Fixes output of go vet with go1.4.1 : http://paste.ubuntu.com/10372604/

```
    go version go1.4.1
    checking: go fmt ...
    checking: go vet ...
    apiserver/provisioner/provisioner.go:1028: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1032: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1040: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1046: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1052: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1080: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1088: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1095: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1098: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/provisioner.go:1113: arg addr for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/prepare_test.go:316: arg ip for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/prepare_test.go:382: arg ip for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/prepare_test.go:395: arg ip for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/prepare_test.go:401: arg ip for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/prepare_test.go:465: arg ip for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    apiserver/provisioner/prepare_test.go:471: arg ip for printf verb %q of wrong type: *github.com/juju/juju/state.IPAddress
    juju/testing/conn.go:276: possible formatting directive in Log call
```

(Review request: http://reviews.vapour.ws/r/981/)