### PR TITLE
Allow pre-push hook to ignore go vet warnings

### DIFF
--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -2,7 +2,8 @@
 
 # This is called from pre-push.bash to do some verification checks on 
 # the Go code.  The script will exit non-zero if any of these tests
-# fail.
+# fail. However if environment variable IGNORE_VET_WARNINGS is a non-zero
+# length string, go vet warnings will not exit non-zero.
 
 set -e 
 
@@ -24,7 +25,7 @@ go tool vet \
     -printf \
     -rangeloops \
     -printfuncs 'ErrorContextf:1,notFoundf:0,badReqErrorf:0,Commitf:0,Snapshotf:0,Debugf:0,Infof:0,Warningf:0,Errorf:0,Criticalf:0,Tracef:0' \
-    .
+    . || [ -n "$IGNORE_VET_WARNINGS" ]
 
 
 echo "checking: go build ..."


### PR DESCRIPTION
 When using newer versions of Go, we sometimes see go vet warnings that
 are stricter than the warnings in Go 1.2 version of go vet.

 This tweak allows developers to continue using newer versions of go
 without disabling the pre-push hook by allowing the hook to ignore go
 vet warnings if the environment variable IGNORE_VET_WARNINGS has non
 zero length string value.

(Review request: http://reviews.vapour.ws/r/982/)