### PR TITLE
Implement service.Service for systemd.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -6,6 +6,8 @@ code.google.com/p/goauth2	hg	afe77d958c701557ec5dc56f6936fcc194d15520	80
 code.google.com/p/google-api-go-client	hg	6ddfebb10ece847f1ae09c701834f1b15abbd8b2	135
 code.google.com/p/winsvc	hg	d6f79143ccd1138cc9d86c9fc75b1d6f8b1b95fb	10
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
+github.com/coreos/go-systemd	git	2d21675230a81a503f4363f4aa3490af06d52bb8	2015-01-26T19:09:17Z
+github.com/godbus/dbus	git	88765d85c0fdadcd98a54e30694fa4e4f5b51133	2015-01-22T18:02:51Z
 github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z

--- a/service/service.go
+++ b/service/service.go
@@ -161,6 +161,9 @@ func ListServices(initDir string) ([]string, error) {
 }
 
 var linuxExecutables = map[string]string{
+	// Note that some systems link /sbin/init to whatever init system
+	// is supported, so in the future we may need some other way to
+	// identify upstart uniquely.
 	"/sbin/init":           InitSystemUpstart,
 	"/sbin/upstart":        InitSystemUpstart,
 	"/sbin/systemd":        InitSystemSystemd,

--- a/service/service.go
+++ b/service/service.go
@@ -22,6 +22,9 @@ const (
 var _ Service = (*upstart.Service)(nil)
 var _ Service = (*windows.Service)(nil)
 
+// TODO(ericsnow) bug #1426461
+// Running, Installed, and Exists should return errors.
+
 // Service represents a service in the init system running on a host.
 type Service interface {
 	// Name returns the service's name.

--- a/service/service.go
+++ b/service/service.go
@@ -84,7 +84,10 @@ func NewService(name string, conf common.Conf, initSystem string) (Service, erro
 		return upstart.NewService(name, conf), nil
 	case InitSystemSystemd:
 		svc, err := systemd.NewService(name, conf)
-		return svc, errors.Trace(err)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return svc, nil
 	default:
 		return nil, errors.NotFoundf("init system %q", initSystem)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -79,7 +79,8 @@ func NewService(name string, conf common.Conf, initSystem string) (Service, erro
 	case InitSystemUpstart:
 		return upstart.NewService(name, conf), nil
 	case InitSystemSystemd:
-		return systemd.NewService(name, conf), nil
+		svc, err := systemd.NewService(name, conf)
+		return svc, errors.Trace(err)
 	default:
 		return nil, errors.NotFoundf("init system %q", initSystem)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -68,8 +68,9 @@ type Service interface {
 	InstallCommands() ([]string, error)
 }
 
-// TODO(ericsnow) Eliminate the need to pass an empty conf here for
-// most service methods.
+// TODO(ericsnow) bug #1426458
+// Eliminate the need to pass an empty conf for most service methods
+// and several helper functions.
 
 // NewService returns a new Service based on the provided info.
 func NewService(name string, conf common.Conf, initSystem string) (Service, error) {

--- a/service/service.go
+++ b/service/service.go
@@ -153,8 +153,11 @@ func ListServices(initDir string) ([]string, error) {
 }
 
 var linuxExecutables = map[string]string{
-	"/sbin/init":    InitSystemUpstart,
-	"/sbin/systemd": InitSystemSystemd,
+	"/sbin/init":           InitSystemUpstart,
+	"/sbin/upstart":        InitSystemUpstart,
+	"/sbin/systemd":        InitSystemSystemd,
+	"/bin/systemd":         InitSystemSystemd,
+	"/lib/systemd/systemd": InitSystemSystemd,
 }
 
 // TODO(ericsnow) Is it too much to cat once for each executable?

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -50,6 +50,8 @@ func (*serviceSuite) TestListServicesCommand(c *gc.C) {
 	c.Check(cmd, gc.Equals, ""+
 		`if [[ "$(cat /proc/1/cmdline)" == "/sbin/init" ]]; then `+
 		`sudo initctl list | awk '{print $1}' | sort | uniq`+"\n"+
+		`elif [[ "$(cat /proc/1/cmdline)" == "/sbin/systemd" ]]; then `+
+		`systemctl --no-page -t service -a | awk -F'.' '{print $1}'`+"\n"+
 		`else exit 1`+"\n"+
 		`fi`)
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -50,7 +50,13 @@ func (*serviceSuite) TestListServicesCommand(c *gc.C) {
 	c.Check(cmd, gc.Equals, ""+
 		`if [[ "$(cat /proc/1/cmdline)" == "/sbin/init" ]]; then `+
 		`sudo initctl list | awk '{print $1}' | sort | uniq`+"\n"+
+		`elif [[ "$(cat /proc/1/cmdline)" == "/sbin/upstart" ]]; then `+
+		`sudo initctl list | awk '{print $1}' | sort | uniq`+"\n"+
 		`elif [[ "$(cat /proc/1/cmdline)" == "/sbin/systemd" ]]; then `+
+		`systemctl --no-page -t service -a | awk -F'.' '{print $1}'`+"\n"+
+		`elif [[ "$(cat /proc/1/cmdline)" == "/bin/systemd" ]]; then `+
+		`systemctl --no-page -t service -a | awk -F'.' '{print $1}'`+"\n"+
+		`elif [[ "$(cat /proc/1/cmdline)" == "/lib/systemd/systemd" ]]; then `+
 		`systemctl --no-page -t service -a | awk -F'.' '{print $1}'`+"\n"+
 		`else exit 1`+"\n"+
 		`fi`)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -51,8 +51,8 @@ func (*serviceSuite) TestListServicesCommand(c *gc.C) {
 
 	line := `if [[ "$(cat /proc/1/cmdline)" == "%s" ]]; then %s`
 	upstart := `sudo initctl list | awk '{print $1}' | sort | uniq`
-	systemd := `systemctl --no-legend --no-page -t service -a` +
-		` | grep -o -P '^\w[-\w]*(?=\.service)'`
+	systemd := `/bin/systemctl list-unit-files --no-legend --no-page -t service` +
+		` | grep -o -P '^\w[\S]*(?=\.service)'`
 	c.Check(cmd, gc.Equals, strings.Join([]string{
 		fmt.Sprintf(line, "/sbin/init", upstart),
 		"el" + fmt.Sprintf(line, "/sbin/upstart", upstart),

--- a/service/systemd/cmdline.go
+++ b/service/systemd/cmdline.go
@@ -91,11 +91,16 @@ func (cl Cmdline) ListAll() ([]string, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return strings.Split(strings.TrimSpace(out), "\n"), nil
+	out = strings.TrimSpace(out)
+
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
 }
 
 func (Cmdline) runCommand(cmd string) (string, error) {
-	resp, err := exec.RunCommands(exec.RunParams{
+	resp, err := runCommands(exec.RunParams{
 		Commands: executable + " " + cmd,
 	})
 	if err != nil {
@@ -111,4 +116,8 @@ func (Cmdline) runCommand(cmd string) (string, error) {
 		)
 	}
 	return out, nil
+}
+
+var runCommands = func(args exec.RunParams) (*exec.ExecResponse, error) {
+	return exec.RunCommands(args)
 }

--- a/service/systemd/cmdline.go
+++ b/service/systemd/cmdline.go
@@ -13,67 +13,75 @@ import (
 
 const executable = "/bin/systemctl"
 
-type commands struct{}
+type commands struct {
+	binary string
+}
 
-// TODO(ericsnow) Always prepend `executable` to commands?
+func (c commands) resolve(args string) string {
+	binary := c.binary
+	if binary == "" {
+		binary = executable
+	}
+	return binary + " " + args
+}
 
-func (commands) listAll() string {
+func (c commands) listAll() string {
 	// We can't just use the same command as listRunning (with an extra
 	// "--all" because it misses some inactive units.
 	args := `list-unit-files --no-legend --no-page -t service` +
 		` | grep -o -P '^\w[\S]*(?=\.service)'`
-	return args
+	return c.resolve(args)
 }
 
-func (commands) listRunning() string {
+func (c commands) listRunning() string {
 	args := `--no-legend --no-page -t service` +
 		` | grep -o -P '^\w[\S]*(?=\.service)'`
-	return args
+	return c.resolve(args)
 }
 
-func (commands) activeStatus(name string) string {
+func (c commands) activeStatus(name string) string {
 	args := fmt.Sprintf("is-active %s.service || exit 0", name)
-	return args
+	return c.resolve(args)
 }
 
-func (commands) loadStatus(name string) string {
+func (c commands) loadStatus(name string) string {
 	args := fmt.Sprintf("is-enabled %s.service || exit 0", name)
-	return args
+	return c.resolve(args)
 }
 
-func (commands) start(name string) string {
+func (c commands) start(name string) string {
 	args := fmt.Sprintf("start %s.service", name)
-	return args
+	return c.resolve(args)
 }
 
-func (commands) stop(name string) string {
+func (c commands) stop(name string) string {
 	args := fmt.Sprintf("stop %s.service", name)
-	return args
+	return c.resolve(args)
 }
 
-func (commands) link(name, dirname string) string {
+func (c commands) link(name, dirname string) string {
 	args := fmt.Sprintf("link %s/%s.service", dirname, name)
-	return args
+	return c.resolve(args)
 }
 
-func (commands) enable(name string) string {
+func (c commands) enable(name string) string {
 	args := fmt.Sprintf("enable %s.service", name)
-	return args
+	return c.resolve(args)
 }
 
-func (commands) disable(name string) string {
+func (c commands) disable(name string) string {
 	args := fmt.Sprintf("disable %s.service", name)
-	return args
+	return c.resolve(args)
 }
 
-func (commands) conf(name string) string {
+func (c commands) conf(name string) string {
 	args := fmt.Sprintf("cat %s.service", name)
-	return args
+	return c.resolve(args)
 }
 
-func (commands) writeConf(name, dirname, data string) string {
-	args := fmt.Sprintf("cat >> %s/%s.service << 'EOF'\n%sEOF", dirname, name, data)
-	return args
+func (c commands) writeFile(name, dirname string, data []byte) string {
+	cmd := fmt.Sprintf("cat >> %s/%s.service << 'EOF'\n%sEOF", dirname, name, data)
+	return cmd
 }
 
 // Cmdline exposes the core operations of interacting with systemd units.
@@ -85,9 +93,9 @@ type Cmdline struct {
 
 // ListAll returns the names of all enabled systemd units.
 func (cl Cmdline) ListAll() ([]string, error) {
-	args := cl.commands.listAll()
+	cmd := cl.commands.listAll()
 
-	out, err := cl.runCommand(args)
+	out, err := cl.runCommand(cmd)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -101,7 +109,7 @@ func (cl Cmdline) ListAll() ([]string, error) {
 
 func (Cmdline) runCommand(cmd string) (string, error) {
 	resp, err := runCommands(exec.RunParams{
-		Commands: executable + " " + cmd,
+		Commands: cmd,
 	})
 	if err != nil {
 		return "", errors.Trace(err)

--- a/service/systemd/cmdline.go
+++ b/service/systemd/cmdline.go
@@ -1,0 +1,114 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/exec"
+)
+
+const executable = "/bin/systemctl"
+
+type commands struct{}
+
+// TODO(ericsnow) Always prepend `executable` to commands?
+
+func (commands) listAll() string {
+	// We can't just use the same command as listRunning (with an extra
+	// "--all" because it misses some inactive units.
+	args := `list-unit-files --no-legend --no-page -t service` +
+		` | grep -o -P '^\w[\S]*(?=\.service)'`
+	return args
+}
+
+func (commands) listRunning() string {
+	args := `--no-legend --no-page -t service` +
+		` | grep -o -P '^\w[\S]*(?=\.service)'`
+	return args
+}
+
+func (commands) activeStatus(name string) string {
+	args := fmt.Sprintf("is-active %s.service || exit 0", name)
+	return args
+}
+
+func (commands) loadStatus(name string) string {
+	args := fmt.Sprintf("is-enabled %s.service || exit 0", name)
+	return args
+}
+
+func (commands) start(name string) string {
+	args := fmt.Sprintf("start %s.service", name)
+	return args
+}
+
+func (commands) stop(name string) string {
+	args := fmt.Sprintf("stop %s.service", name)
+	return args
+}
+
+func (commands) link(name, dirname string) string {
+	args := fmt.Sprintf("link %s/%s.service", dirname, name)
+	return args
+}
+
+func (commands) enable(name string) string {
+	args := fmt.Sprintf("enable %s.service", name)
+	return args
+}
+
+func (commands) disable(name string) string {
+	args := fmt.Sprintf("disable %s.service", name)
+	return args
+}
+
+func (commands) conf(name string) string {
+	args := fmt.Sprintf("cat %s.service", name)
+	return args
+}
+
+func (commands) writeConf(name, dirname, data string) string {
+	args := fmt.Sprintf("cat >> %s/%s.service << 'EOF'\n%sEOF", dirname, name, data)
+	return args
+}
+
+// Cmdline exposes the core operations of interacting with systemd units.
+type Cmdline struct {
+	commands commands
+}
+
+// TODO(ericsnow) Support more commands (Status, Start, Install, Conf, etc.).
+
+// ListAll returns the names of all enabled systemd units.
+func (cl Cmdline) ListAll() ([]string, error) {
+	args := cl.commands.listAll()
+
+	out, err := cl.runCommand(args)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return strings.Split(strings.TrimSpace(out), "\n"), nil
+}
+
+func (Cmdline) runCommand(cmd string) (string, error) {
+	resp, err := exec.RunCommands(exec.RunParams{
+		Commands: executable + " " + cmd,
+	})
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	out := string(resp.Stdout)
+
+	if resp.Code != 0 {
+		return out, errors.Errorf(
+			"error executing %q: %s",
+			executable,
+			strings.Replace(string(resp.Stderr), "\n", "; ", -1),
+		)
+	}
+	return out, nil
+}

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -282,7 +282,6 @@ func deserializeOptions(opts []*unit.UnitOption) (common.Conf, error) {
 			default:
 				return conf, errors.NotSupportedf("Service directive %q", uo.Name)
 			}
-
 		case "Install":
 			switch uo.Name {
 			case "WantedBy":

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -82,9 +82,8 @@ func validate(name string, conf common.Conf) error {
 	return nil
 }
 
-// serialize serializes the provided Conf for the named service. The
-// resulting data will be in the prefered format for consumption by
-// the init system.
+// serialize returns the data that should be written to disk for the
+// provided Conf, rendered in the systemd unit file format.
 func serialize(name string, conf common.Conf) ([]byte, error) {
 	if err := validate(name, conf); err != nil {
 		return nil, errors.Trace(err)

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -32,6 +32,9 @@ var limitMap = map[string]string{
 	"stack":      "LimitSTACK",
 }
 
+// normalize adjusts the conf to more standardized content and
+// returns a new Conf with that updated content. It also returns the
+// content of any script file that should accompany the conf.
 func normalize(conf common.Conf, scriptPath string) (common.Conf, []byte) {
 	var data []byte
 

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -62,12 +62,17 @@ func validate(name string, conf common.Conf) error {
 	if name == "" {
 		return errors.NotValidf("missing service name")
 	}
+
 	if conf.ExecStart == "" {
-		return errors.NotValidf("missing cmd")
+		return errors.NotValidf("missing ExecStart")
+	} else if !strings.HasPrefix(conf.ExecStart, "/") {
+		return errors.NotValidf("relative path in ExecStart")
 	}
+
 	if conf.ExtraScript != "" {
 		return errors.NotValidf("unexpected ExtraScript")
 	}
+
 	if conf.Out != "" && conf.Out != "syslog" {
 		return errors.NotValidf("conf.Out value %q (Options are syslog)", conf.Out)
 	}
@@ -92,6 +97,10 @@ func validate(name string, conf common.Conf) error {
 	if conf.ExecStopPost != "" {
 		// TODO(ericsnow) This needs to be sorted out.
 		return errors.NotSupportedf("Conf.ExecStopPost")
+
+		if !strings.HasPrefix(conf.ExecStopPost, "/") {
+			return errors.NotValidf("relative path in ExecStopPost")
+		}
 	}
 
 	return nil

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -73,8 +73,8 @@ func validate(name string, conf common.Conf) error {
 		return errors.NotValidf("unexpected ExtraScript")
 	}
 
-	if conf.Out != "" && conf.Out != "syslog" {
-		return errors.NotValidf("conf.Out value %q (Options are syslog)", conf.Out)
+	if conf.Output != "" && conf.Output != "syslog" {
+		return errors.NotValidf("conf.Output value %q (Options are syslog)", conf.Output)
 	}
 	// We ignore Desc and InitDir.
 
@@ -156,16 +156,16 @@ func serializeService(conf common.Conf) []*unit.UnitOption {
 		Value:   "forking",
 	})
 
-	if conf.Out != "" {
+	if conf.Output != "" {
 		unitOptions = append(unitOptions, &unit.UnitOption{
 			Section: "Service",
 			Name:    "StandardOutput",
-			Value:   conf.Out,
+			Value:   conf.Output,
 		})
 		unitOptions = append(unitOptions, &unit.UnitOption{
 			Section: "Service",
 			Name:    "StandardError",
-			Value:   conf.Out,
+			Value:   conf.Output,
 		})
 	}
 
@@ -249,7 +249,7 @@ func deserializeOptions(opts []*unit.UnitOption) (common.Conf, error) {
 			case uo.Name == "StandardError", uo.Name == "StandardOutput":
 				// TODO(wwitzel3) We serialize Standard(Error|Output)
 				// to the same thing, but we should probably make sure they match
-				conf.Out = uo.Value
+				conf.Output = uo.Value
 			case uo.Name == "Environment":
 				if conf.Env == nil {
 					conf.Env = make(map[string]string)

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -194,7 +194,7 @@ func serializeInstall(conf common.Conf) []*unit.UnitOption {
 	return unitOptions
 }
 
-// deserialize parses the provided data (in the init system's prefered
+// deserialize parses the provided data (in the systemd unit file
 // format) and populates a new Conf with the result.
 func deserialize(data []byte) (common.Conf, error) {
 	opts, err := unit.Deserialize(bytes.NewBuffer(data))

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -195,12 +195,15 @@ func serializeInstall(conf common.Conf) []*unit.UnitOption {
 // deserialize parses the provided data (in the init system's prefered
 // format) and populates a new Conf with the result.
 func deserialize(data []byte) (common.Conf, error) {
-	var conf common.Conf
-
 	opts, err := unit.Deserialize(bytes.NewBuffer(data))
 	if err != nil {
-		return conf, errors.Trace(err)
+		return common.Conf{}, errors.Trace(err)
 	}
+	return deserializeOptions(opts)
+}
+
+func deserializeOptions(opts []*unit.UnitOption) (common.Conf, error) {
+	var conf common.Conf
 
 	for _, uo := range opts {
 		switch uo.Section {
@@ -268,6 +271,6 @@ func deserialize(data []byte) (common.Conf, error) {
 		}
 	}
 
-	err = validate("<>", conf)
+	err := validate("<>", conf)
 	return conf, errors.Trace(err)
 }

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -1,0 +1,273 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/coreos/go-systemd/unit"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/service/common"
+)
+
+var limitMap = map[string]string{
+	"as":         "LimitAS",
+	"core":       "LimitCORE",
+	"cpu":        "LimitCPU",
+	"data":       "LimitDATA",
+	"fsize":      "LimitFSIZE",
+	"memlock":    "LimitMEMLOCK",
+	"msgqueue":   "LimitMSGQUEUE",
+	"nice":       "LimitNICE",
+	"nofile":     "LimitNOFILE",
+	"nproc":      "LimitNPROC",
+	"rss":        "LimitRSS",
+	"rtprio":     "LimitRTPRIO",
+	"sigpending": "LimitSIGPENDING",
+	"stack":      "LimitSTACK",
+}
+
+func normalize(conf common.Conf, scriptPath string) (common.Conf, []byte) {
+	var data []byte
+
+	if conf.ExtraScript != "" {
+		conf.Cmd = conf.ExtraScript + "\n" + conf.Cmd
+		conf.ExtraScript = ""
+	}
+	if strings.Contains(conf.Cmd, "\n") {
+		data = []byte(conf.Cmd)
+		conf.Cmd = scriptPath
+	}
+
+	if len(conf.Env) == 0 {
+		conf.Env = nil
+	}
+
+	if len(conf.Limit) == 0 {
+		conf.Limit = nil
+	}
+
+	return conf, data
+}
+
+func validate(name string, conf common.Conf) error {
+	if name == "" {
+		return errors.NotValidf("missing service name")
+	}
+	if conf.Cmd == "" {
+		return errors.NotValidf("missing cmd")
+	}
+	if conf.ExtraScript != "" {
+		return errors.NotValidf("unexpected ExtraScript")
+	}
+	if conf.Out != "" && conf.Out != "syslog" {
+		return errors.NotValidf("conf.Out value %q (Options are syslog)", conf.Out)
+	}
+	// We ignore Desc and InitDir.
+
+	for k := range conf.Limit {
+		if _, ok := limitMap[k]; !ok {
+			return errors.NotValidf("conf.Limit key %q", k)
+		}
+	}
+
+	return nil
+}
+
+// serialize serializes the provided Conf for the named service. The
+// resulting data will be in the prefered format for consumption by
+// the init system.
+func serialize(name string, conf common.Conf) ([]byte, error) {
+	if err := validate(name, conf); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var unitOptions []*unit.UnitOption
+	unitOptions = append(unitOptions, serializeUnit(conf)...)
+	unitOptions = append(unitOptions, serializeService(conf)...)
+	unitOptions = append(unitOptions, serializeInstall(conf)...)
+
+	data, err := ioutil.ReadAll(unit.Serialize(unitOptions))
+	return data, errors.Trace(err)
+}
+
+func serializeUnit(conf common.Conf) []*unit.UnitOption {
+	var unitOptions []*unit.UnitOption
+
+	unitOptions = append(unitOptions, &unit.UnitOption{
+		Section: "Unit",
+		Name:    "Description",
+		Value:   conf.Desc,
+	})
+
+	after := []string{
+		"syslog.target",
+		"network.target",
+		"systemd-user-sessions.service",
+	}
+	for _, name := range after {
+		unitOptions = append(unitOptions, &unit.UnitOption{
+			Section: "Unit",
+			Name:    "After",
+			Value:   name,
+		})
+	}
+
+	return unitOptions
+}
+
+func serializeService(conf common.Conf) []*unit.UnitOption {
+	var unitOptions []*unit.UnitOption
+
+	unitOptions = append(unitOptions, &unit.UnitOption{
+		Section: "Service",
+		Name:    "Type",
+		Value:   "forking",
+	})
+
+	if conf.Out != "" {
+		unitOptions = append(unitOptions, &unit.UnitOption{
+			Section: "Service",
+			Name:    "StandardOutput",
+			Value:   conf.Out,
+		})
+		unitOptions = append(unitOptions, &unit.UnitOption{
+			Section: "Service",
+			Name:    "StandardError",
+			Value:   conf.Out,
+		})
+	}
+
+	for k, v := range conf.Env {
+		unitOptions = append(unitOptions, &unit.UnitOption{
+			Section: "Service",
+			Name:    "Environment",
+			Value:   fmt.Sprintf(`"%q=%q"`, k, v),
+		})
+	}
+
+	for k, v := range conf.Limit {
+		unitOptions = append(unitOptions, &unit.UnitOption{
+			Section: "Service",
+			Name:    limitMap[k],
+			Value:   v,
+		})
+	}
+
+	unitOptions = append(unitOptions, &unit.UnitOption{
+		Section: "Service",
+		Name:    "ExecStart",
+		Value:   conf.Cmd,
+	})
+
+	unitOptions = append(unitOptions, &unit.UnitOption{
+		Section: "Service",
+		Name:    "RemainAfterExit",
+		Value:   "yes",
+	})
+
+	unitOptions = append(unitOptions, &unit.UnitOption{
+		Section: "Service",
+		Name:    "Restart",
+		Value:   "always",
+	})
+
+	return unitOptions
+}
+
+func serializeInstall(conf common.Conf) []*unit.UnitOption {
+	var unitOptions []*unit.UnitOption
+
+	unitOptions = append(unitOptions, &unit.UnitOption{
+		Section: "Install",
+		Name:    "WantedBy",
+		Value:   "multi-user.target",
+	})
+
+	return unitOptions
+}
+
+// deserialize parses the provided data (in the init system's prefered
+// format) and populates a new Conf with the result.
+func deserialize(data []byte) (common.Conf, error) {
+	var conf common.Conf
+
+	opts, err := unit.Deserialize(bytes.NewBuffer(data))
+	if err != nil {
+		return conf, errors.Trace(err)
+	}
+
+	for _, uo := range opts {
+		switch uo.Section {
+		case "Unit":
+			switch uo.Name {
+			case "Description":
+				conf.Desc = uo.Value
+			case "After":
+				// Do nothing until we support it in common.Conf.
+			default:
+				return conf, errors.NotSupportedf("Unit directive %q", uo.Name)
+			}
+		case "Service":
+			switch {
+			case uo.Name == "ExecStart":
+				conf.Cmd = uo.Value
+			case uo.Name == "StandardError", uo.Name == "StandardOutput":
+				// TODO(wwitzel3) We serialize Standard(Error|Output)
+				// to the same thing, but we should probably make sure they match
+				conf.Out = uo.Value
+			case uo.Name == "Environment":
+				if conf.Env == nil {
+					conf.Env = make(map[string]string)
+				}
+				var value = uo.Value
+				if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+					value = value[1 : len(value)-1]
+				}
+				parts := strings.SplitN(value, "=", 2)
+				if len(parts) != 2 {
+					return conf, errors.NotValidf("service environment value %q", uo.Value)
+				}
+				conf.Env[parts[0]] = parts[1]
+			case strings.HasPrefix(uo.Name, "Limit"):
+				if conf.Limit == nil {
+					conf.Limit = make(map[string]string)
+				}
+				for k, v := range limitMap {
+					if v == uo.Name {
+						conf.Limit[k] = v
+						break
+					}
+				}
+			case uo.Name == "Type":
+				// Do nothing until we support it in common.Conf.
+			case uo.Name == "RemainAfterExit":
+				// Do nothing until we support it in common.Conf.
+			case uo.Name == "Restart":
+				// Do nothing until we support it in common.Conf.
+			default:
+				return conf, errors.NotSupportedf("Service directive %q", uo.Name)
+			}
+
+		case "Install":
+			switch uo.Name {
+			case "WantedBy":
+				if uo.Value != "multi-user.target" {
+					return conf, errors.NotValidf("unit target %q", uo.Value)
+				}
+			default:
+				return conf, errors.NotSupportedf("Install directive %q", uo.Name)
+			}
+		default:
+			return conf, errors.NotSupportedf("section %q", uo.Name)
+		}
+	}
+
+	err = validate("<>", conf)
+	return conf, errors.Trace(err)
+}

--- a/service/systemd/dbus.go
+++ b/service/systemd/dbus.go
@@ -46,7 +46,7 @@ func parseProperties(props map[string]interface{}, unitType string) []*unit.Unit
 
 	var parseProperty func(string, interface{}) []*unit.UnitOption
 	switch unitType {
-	case "Unit", "":
+	case "Unit":
 		parseProperty = parseUnitProperty
 	case "Service":
 		parseProperty = parseServiceProperty

--- a/service/systemd/dbus.go
+++ b/service/systemd/dbus.go
@@ -22,108 +22,139 @@ var installProperties = []string{
 func getUnitOptions(conn dbusAPI, name, unitType string) ([]*unit.UnitOption, error) {
 	var opts []*unit.UnitOption
 
-	// See:
-	//  http://dbus.freedesktop.org/doc/dbus-specification.html#basic-types
-	//  http://www.freedesktop.org/wiki/Software/systemd/dbus/
-
 	// Extract the generic properties first.
 	props, err := conn.GetUnitProperties(name)
 	if err != nil {
 		return opts, errors.Trace(err)
 	}
-	for key, value := range props {
-		section := "Unit"
-		for _, installKey := range installProperties {
-			if key == installKey {
-				section = "Install"
-				break
-			}
-		}
+	opts = parseProperties(props, "Unit")
 
-		// We only support the values we need.
-		var strValues []string
-		switch key {
-		case "Description":
-			strValue, _ := value.(string)
-			strValues = append(strValues, strValue)
-		}
-
-		for _, strValue := range strValues {
-			opt := &unit.UnitOption{
-				Section: section,
-				Name:    key,
-				Value:   strValue,
-			}
-			opts = append(opts, opt)
-		}
-	}
-
+	// Extract the unit type properties.
 	props, err = conn.GetUnitTypeProperties(name, unitType)
 	if err != nil {
 		return opts, errors.Trace(err)
 	}
+	typeOpts := parseProperties(props, unitType)
+
+	return append(opts, typeOpts...), nil
+}
+
+func parseProperties(props map[string]interface{}, unitType string) []*unit.UnitOption {
+	// See:
+	//  http://dbus.freedesktop.org/doc/dbus-specification.html#basic-types
+	//  http://www.freedesktop.org/wiki/Software/systemd/dbus/
+
+	var parseProperty func(string, interface{}) []*unit.UnitOption
+	switch unitType {
+	case "Unit", "":
+		parseProperty = parseUnitProperty
+	case "Service":
+		parseProperty = parseServiceProperty
+	default:
+		return nil
+	}
+
+	var opts []*unit.UnitOption
 	for key, value := range props {
-		// We only support the values we need.
-		var strValues []string
-		switch {
-		case key == "ExecStart":
-			if parts, ok := value.([]interface{}); ok {
-				if len(parts) < 2 {
-					continue
-				}
-				cmd, ok := parts[0].(string)
-				if !ok {
-					continue
-				}
-				args, ok := parts[1].([]interface{})
-				if !ok {
-					continue
-				}
-				for _, arg := range args {
-					strArg, ok := arg.(string)
-					if !ok {
-						cmd = ""
-						break
-					}
-					cmd += " " + strArg
-				}
+		opts = append(opts, parseProperty(key, value)...)
+	}
+	return opts
+}
 
-				if cmd != "" {
-					strValues = append(strValues, cmd)
-				}
-			}
-		case key == "StandardOutput":
-			if strValue, ok := value.(string); ok {
-				strValues = append(strValues, strValue)
-			}
-		case key == "StandardError":
-			if strValue, ok := value.(string); ok {
-				strValues = append(strValues, strValue)
-			}
-		case key == "Environment":
-			if envValues, ok := value.([]interface{}); ok {
-				for _, val := range envValues {
-					if strValue, ok := val.(string); ok {
-						strValues = append(strValues, strValue)
-					}
-				}
-			}
-		case strings.HasPrefix(key, "Limit"):
-			if intValue, ok := value.(uint64); ok {
-				strValue := strconv.FormatUint(intValue, 10)
-				strValues = append(strValues, strValue)
-			}
-		}
+func parseUnitProperty(name string, value interface{}) []*unit.UnitOption {
+	var opts []*unit.UnitOption
 
-		for _, strValue := range strValues {
-			opt := &unit.UnitOption{
-				Section: unitType,
-				Name:    key,
-				Value:   strValue,
-			}
-			opts = append(opts, opt)
+	section := "Unit"
+	for _, installKey := range installProperties {
+		if name == installKey {
+			section = "Install"
+			break
 		}
 	}
 
-	return opts, nil
+	// We only support the values we need.
+	var strValues []string
+	switch name {
+	case "Description":
+		strValue, _ := value.(string)
+		strValues = append(strValues, strValue)
+	}
+
+	for _, strValue := range strValues {
+		opt := &unit.UnitOption{
+			Section: section,
+			Name:    name,
+			Value:   strValue,
+		}
+		opts = append(opts, opt)
+	}
+
+	return opts
+}
+
+func parseServiceProperty(name string, value interface{}) []*unit.UnitOption {
+	var opts []*unit.UnitOption
+
+	// We only support the values we need.
+	var strValues []string
+	switch {
+	case name == "ExecStart":
+		if parts, ok := value.([]interface{}); ok {
+			if len(parts) < 2 {
+				return nil
+			}
+			cmd, ok := parts[0].(string)
+			if !ok {
+				return nil
+			}
+			args, ok := parts[1].([]interface{})
+			if !ok {
+				return nil
+			}
+			for _, arg := range args {
+				strArg, ok := arg.(string)
+				if !ok {
+					cmd = ""
+					break
+				}
+				cmd += " " + strArg
+			}
+
+			if cmd != "" {
+				strValues = append(strValues, cmd)
+			}
+		}
+	case name == "StandardOutput":
+		if strValue, ok := value.(string); ok {
+			strValues = append(strValues, strValue)
+		}
+	case name == "StandardError":
+		if strValue, ok := value.(string); ok {
+			strValues = append(strValues, strValue)
+		}
+	case name == "Environment":
+		if envValues, ok := value.([]interface{}); ok {
+			for _, val := range envValues {
+				if strValue, ok := val.(string); ok {
+					strValues = append(strValues, strValue)
+				}
+			}
+		}
+	case strings.HasPrefix(name, "Limit"):
+		if intValue, ok := value.(uint64); ok {
+			strValue := strconv.FormatUint(intValue, 10)
+			strValues = append(strValues, strValue)
+		}
+	}
+
+	for _, strValue := range strValues {
+		opt := &unit.UnitOption{
+			Section: "Service",
+			Name:    name,
+			Value:   strValue,
+		}
+		opts = append(opts, opt)
+	}
+
+	return opts
 }

--- a/service/systemd/dbus.go
+++ b/service/systemd/dbus.go
@@ -1,0 +1,129 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/coreos/go-systemd/unit"
+	"github.com/juju/errors"
+)
+
+var installProperties = []string{
+	"Alias",
+	"WantedBy",
+	"RequiredBy",
+	"Also",
+	"DefaultInstance",
+}
+
+func getUnitOptions(conn dbusAPI, name, unitType string) ([]*unit.UnitOption, error) {
+	var opts []*unit.UnitOption
+
+	// See:
+	//  http://dbus.freedesktop.org/doc/dbus-specification.html#basic-types
+	//  http://www.freedesktop.org/wiki/Software/systemd/dbus/
+
+	// Extract the generic properties first.
+	props, err := conn.GetUnitProperties(name)
+	if err != nil {
+		return opts, errors.Trace(err)
+	}
+	for key, value := range props {
+		section := "Unit"
+		for _, installKey := range installProperties {
+			if key == installKey {
+				section = "Install"
+				break
+			}
+		}
+
+		// We only support the values we need.
+		var strValues []string
+		switch key {
+		case "Description":
+			strValue, _ := value.(string)
+			strValues = append(strValues, strValue)
+		}
+
+		for _, strValue := range strValues {
+			opt := &unit.UnitOption{
+				Section: section,
+				Name:    key,
+				Value:   strValue,
+			}
+			opts = append(opts, opt)
+		}
+	}
+
+	props, err = conn.GetUnitTypeProperties(name, unitType)
+	if err != nil {
+		return opts, errors.Trace(err)
+	}
+	for key, value := range props {
+		// We only support the values we need.
+		var strValues []string
+		switch {
+		case key == "ExecStart":
+			if parts, ok := value.([]interface{}); ok {
+				if len(parts) < 2 {
+					continue
+				}
+				cmd, ok := parts[0].(string)
+				if !ok {
+					continue
+				}
+				args, ok := parts[1].([]interface{})
+				if !ok {
+					continue
+				}
+				for _, arg := range args {
+					strArg, ok := arg.(string)
+					if !ok {
+						cmd = ""
+						break
+					}
+					cmd += " " + strArg
+				}
+
+				if cmd != "" {
+					strValues = append(strValues, cmd)
+				}
+			}
+		case key == "StandardOutput":
+			if strValue, ok := value.(string); ok {
+				strValues = append(strValues, strValue)
+			}
+		case key == "StandardError":
+			if strValue, ok := value.(string); ok {
+				strValues = append(strValues, strValue)
+			}
+		case key == "Environment":
+			if envValues, ok := value.([]interface{}); ok {
+				for _, val := range envValues {
+					if strValue, ok := val.(string); ok {
+						strValues = append(strValues, strValue)
+					}
+				}
+			}
+		case strings.HasPrefix(key, "Limit"):
+			if intValue, ok := value.(uint64); ok {
+				strValue := strconv.FormatUint(intValue, 10)
+				strValues = append(strValues, strValue)
+			}
+		}
+
+		for _, strValue := range strValues {
+			opt := &unit.UnitOption{
+				Section: unitType,
+				Name:    key,
+				Value:   strValue,
+			}
+			opts = append(opts, opt)
+		}
+	}
+
+	return opts, nil
+}

--- a/service/systemd/dbus.go
+++ b/service/systemd/dbus.go
@@ -11,6 +11,9 @@ import (
 	"github.com/juju/errors"
 )
 
+// This is the exhaustive list of property names of the "Unit" dbus
+// object that map to unit "Install" section directives. All other
+// valid "Unit" properties map to "Unit" section directives.
 var installProperties = []string{
 	"Alias",
 	"WantedBy",
@@ -19,6 +22,12 @@ var installProperties = []string{
 	"DefaultInstance",
 }
 
+// getUnitOptions is a surrogate for a helper that has been requested
+// upstream (https://github.com/coreos/go-systemd/issues/78). It gets
+// the unit options (i.e. unit directives) via the provided dbus
+// connection for the given service name (including the .service suffix)
+// and unit type (e.g. Unit, Service).  The options can then be
+// converted into a common.Conf or into a unit file.
 func getUnitOptions(conn dbusAPI, name, unitType string) ([]*unit.UnitOption, error) {
 	var opts []*unit.UnitOption
 
@@ -39,6 +48,11 @@ func getUnitOptions(conn dbusAPI, name, unitType string) ([]*unit.UnitOption, er
 	return append(opts, typeOpts...), nil
 }
 
+// parseProperties converts the provided dbus properties into the
+// corresponding systemd unit options (section + directive + value).
+// The unit type (e.g. Unit, Service) indicates which set of properties
+// to expect and with which unit section to associate them. Note that
+// not all systemd dbus properties have a corresponding unit option.
 func parseProperties(props map[string]interface{}, unitType string) []*unit.UnitOption {
 	// See:
 	//  http://dbus.freedesktop.org/doc/dbus-specification.html#basic-types
@@ -61,6 +75,10 @@ func parseProperties(props map[string]interface{}, unitType string) []*unit.Unit
 	return opts
 }
 
+// parseUnitProperty converts a single property from the "Unit" dbus
+// object into zero or more corresponding unit options with the section
+// set to "Unit" or "Install" (depending on the name). Any unsupported
+// property names are simply ignored.
 func parseUnitProperty(name string, value interface{}) []*unit.UnitOption {
 	var opts []*unit.UnitOption
 
@@ -92,6 +110,10 @@ func parseUnitProperty(name string, value interface{}) []*unit.UnitOption {
 	return opts
 }
 
+// parseServiceProperty converts a single property from the "Service"
+// dbus object into zero or more corresponding unit options with the
+// section set to "Service". Any unsupported property names are simply
+// ignored.
 func parseServiceProperty(name string, value interface{}) []*unit.UnitOption {
 	var opts []*unit.UnitOption
 

--- a/service/systemd/export_test.go
+++ b/service/systemd/export_test.go
@@ -36,3 +36,9 @@ func PatchFileOps(patcher patcher, stub *testing.Stub) *StubFileOps {
 	patcher.PatchValue(&createFile, fops.CreateFile)
 	return fops
 }
+
+func PatchExec(patcher patcher, stub *testing.Stub) *StubExec {
+	exec := &StubExec{Stub: stub}
+	patcher.PatchValue(&runCommands, exec.RunCommand)
+	return exec
+}

--- a/service/systemd/export_test.go
+++ b/service/systemd/export_test.go
@@ -1,0 +1,38 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"github.com/juju/testing"
+)
+
+type patcher interface {
+	PatchValue(interface{}, interface{})
+}
+
+func PatchFindDataDir(patcher patcher, dataDir string) {
+	patcher.PatchValue(&findDataDir, func() (string, error) {
+		return dataDir, nil
+	})
+}
+
+func PatchNewChan(patcher patcher) chan string {
+	ch := make(chan string, 1)
+	patcher.PatchValue(&newChan, func() chan string { return ch })
+	return ch
+}
+
+func PatchNewConn(patcher patcher, stub *testing.Stub) *StubDbusAPI {
+	conn := &StubDbusAPI{Stub: stub}
+	patcher.PatchValue(&newConn, func() (dbusAPI, error) { return conn, nil })
+	return conn
+}
+
+func PatchFileOps(patcher patcher, stub *testing.Stub) *StubFileOps {
+	fops := &StubFileOps{Stub: stub}
+	patcher.PatchValue(&removeAll, fops.RemoveAll)
+	patcher.PatchValue(&mkdirAll, fops.MkdirAll)
+	patcher.PatchValue(&createFile, fops.CreateFile)
+	return fops
+}

--- a/service/systemd/package_test.go
+++ b/service/systemd/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -21,6 +21,16 @@ import (
 
 // ListServices returns the list of installed service names.
 func ListServices() ([]string, error) {
+	// TODO(ericsnow) conn.ListUnits misses some inactive units, so we
+	// would need conn.ListUnitFiles. Such a method has been requested.
+	// (see https://github.com/coreos/go-systemd/issues/76). In the
+	// meantime we use systemctl at the shell to list the services.
+	names, err := Cmdline{}.ListAll()
+	return names, errors.Trace(err)
+	//return listServices()
+}
+
+func listServices() ([]string, error) {
 	conn, err := newConn()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -51,14 +51,16 @@ func ListCommand() string {
 // Service provides visibility into and control over a systemd service.
 type Service struct {
 	Name     string
+	ConfName string
+	UnitName string
 	Conf     common.Conf
 	Dirname  string
-	ConfName string
 	Script   []byte
 }
 
 // NewService returns a new value that implements Service for systemd.
 func NewService(name string, conf common.Conf) (*Service, error) {
+	confName := name + ".service"
 	dataDir, err := findDataDir()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -67,8 +69,9 @@ func NewService(name string, conf common.Conf) (*Service, error) {
 
 	service := &Service{
 		Name:     name,
+		ConfName: confName,
+		UnitName: confName,
 		Dirname:  dirname,
-		ConfName: name + ".service",
 	}
 
 	if err := service.setConf(conf); err != nil {

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -18,7 +18,6 @@ import (
 
 // ListServices returns the list of installed service names.
 func ListServices() ([]string, error) {
-	// TODO(ericsnow) Limit to just juju-managed?
 	conn, err := newConn()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -24,9 +24,12 @@ func ListServices() ([]string, error) {
 	// would need conn.ListUnitFiles. Such a method has been requested.
 	// (see https://github.com/coreos/go-systemd/issues/76). In the
 	// meantime we use systemctl at the shell to list the services.
+	// Once that is addressed upstread we can just call listServices here.
 	names, err := Cmdline{}.ListAll()
-	return names, errors.Trace(err)
-	//return listServices()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return names, nil
 }
 
 func listServices() ([]string, error) {
@@ -88,7 +91,7 @@ func NewService(name string, conf common.Conf) (*Service, error) {
 	}
 
 	if err := service.setConf(conf); err != nil {
-		return service, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	return service, nil

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -46,7 +46,8 @@ func ListServices() ([]string, error) {
 
 // ListCommand returns a command that will list the services on a host.
 func ListCommand() string {
-	return "systemctl --no-page -t service -a | awk -F'.' '{print $1}'"
+	return `systemctl --no-legend --no-page -t service -a` +
+		` | grep -o -P '^\w[-\w]*(?=\.service)'`
 }
 
 // Service provides visibility into and control over a systemd service.

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -231,7 +231,6 @@ func (s *Service) Start() error {
 		return errors.Trace(err)
 	}
 
-	// TODO(ericsnow) Add timeout support?
 	status := <-statusCh
 	if status != "done" {
 		return errors.Errorf("failed to start service %s", s.Service.Name)
@@ -258,7 +257,6 @@ func (s *Service) Stop() error {
 		return errors.Trace(err)
 	}
 
-	// TODO(ericsnow) Add timeout support?
 	status := <-statusCh
 	if status != "done" {
 		return errors.Errorf("failed to stop service %s", s.Service.Name)

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -373,9 +373,6 @@ var createFile = func(filename string, data []byte, perm os.FileMode) error {
 
 // InstallCommands implements Service.
 func (s *Service) InstallCommands() ([]string, error) {
-	//remote := NewService(s.Service.Name, s.Service.Conf)
-	//remote.Dirname = ioutil.TempDir("", "juju-systemd-remote-")
-
 	data, err := serialize(s.UnitName, s.Service.Conf)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -56,8 +56,7 @@ func listServices() ([]string, error) {
 
 // ListCommand returns a command that will list the services on a host.
 func ListCommand() string {
-	return `systemctl --no-legend --no-page -t service -a` +
-		` | grep -o -P '^\w[-\w]*(?=\.service)'`
+	return commands{}.listAll()
 }
 
 // Service provides visibility into and control over a systemd service.

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -34,11 +34,11 @@ func ListServices() ([]string, error) {
 
 	var services []string
 	for _, unit := range units {
-		// TODO(ericsnow) Will the unit names really always end with .service?
-		if !strings.HasSuffix(unit.Name, ".service") {
+		name := unit.Name
+		if !strings.HasSuffix(name, ".service") {
 			continue
 		}
-		name := strings.TrimSuffix(unit.Name, ".service")
+		name = strings.TrimSuffix(name, ".service")
 		services = append(services, name)
 	}
 	return services, nil
@@ -287,9 +287,8 @@ func (s *Service) Remove() error {
 	}
 	defer conn.Close()
 
-	// TODO(ericsnow) We may need the original file name (or make sure
-	// the unit conf is on the systemd search path.
-	_, err = conn.DisableUnitFiles([]string{s.UnitName}, false)
+	runtime := false
+	_, err = conn.DisableUnitFiles([]string{s.UnitName}, runtime)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -244,11 +244,21 @@ func (s *Service) Start() error {
 		return errors.Trace(err)
 	}
 
-	status := <-statusCh
-	if status != "done" {
-		return errors.Errorf("failed to start service %s", s.Service.Name)
+	if err := s.wait("start", statusCh); err != nil {
+		return errors.Trace(err)
 	}
 
+	return nil
+}
+
+func (s *Service) wait(op string, statusCh chan string) error {
+	status := <-statusCh
+
+	// TODO(ericsnow) Other status values *may* be okay. See:
+	//  https://godoc.org/github.com/coreos/go-systemd/dbus#Conn.StartUnit
+	if status != "done" {
+		return errors.Errorf("failed to %s service %s", op, s.Service.Name)
+	}
 	return nil
 }
 
@@ -270,9 +280,8 @@ func (s *Service) Stop() error {
 		return errors.Trace(err)
 	}
 
-	status := <-statusCh
-	if status != "done" {
-		return errors.Errorf("failed to stop service %s", s.Service.Name)
+	if err := s.wait("stop", statusCh); err != nil {
+		return errors.Trace(err)
 	}
 
 	return err

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -1,0 +1,296 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/coreos/go-systemd/dbus"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/service/common"
+	"github.com/juju/juju/version"
+)
+
+// ListServices returns the list of installed service names.
+func ListServices() ([]string, error) {
+	// TODO(ericsnow) Limit to just juju-managed?
+	conn, err := newConn()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer conn.Close()
+
+	units, err := conn.ListUnits()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var services []string
+	for _, unit := range units {
+		services = append(services, unit.Name)
+	}
+	return services, nil
+}
+
+// ListCommand returns a command that will list the services on a host.
+func ListCommand() string {
+	return "systemctl --no-page -t service -a | awk -F'.' '{print $1}'"
+}
+
+// Service provides visibility into and control over a systemd service.
+type Service struct {
+	Name     string
+	Conf     common.Conf
+	Dirname  string
+	ConfName string
+	Script   []byte
+}
+
+// NewService returns a new value that implements Service for systemd.
+func NewService(name string, conf common.Conf) (*Service, error) {
+	dataDir, err := findDataDir()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	dirname := path.Join(dataDir, "init", name)
+
+	service := &Service{
+		Name:     name,
+		Dirname:  dirname,
+		ConfName: name + ".service",
+	}
+
+	if err := service.setConf(conf); err != nil {
+		return service, errors.Trace(err)
+	}
+
+	return service, nil
+}
+
+var findDataDir = func() (string, error) {
+	return paths.DataDir(version.Current.Series)
+}
+
+// dbusAPI exposes all the systemd API methods needed by juju.
+type dbusAPI interface {
+	Close()
+	ListUnits() ([]dbus.UnitStatus, error)
+	StartUnit(name string, mode string, ch chan<- string) (int, error)
+	StopUnit(name string, mode string, ch chan<- string) (int, error)
+	EnableUnitFiles(files []string, runtime bool, force bool) (bool, []dbus.EnableUnitFileChange, error)
+	DisableUnitFiles(files []string, runtime bool) ([]dbus.DisableUnitFileChange, error)
+}
+
+var newConn = func() (dbusAPI, error) {
+	return dbus.New()
+}
+
+var newChan = func() chan string {
+	return make(chan string)
+}
+
+// UpdateConfig implements Service.
+func (s *Service) UpdateConfig(conf common.Conf) {
+	s.setConf(conf) // We ignore any error (i.e. when validation fails).
+}
+
+func (s *Service) setConf(conf common.Conf) error {
+	scriptPath := path.Join(s.Dirname, "exec-start.sh")
+
+	normalConf, data := normalize(conf, scriptPath)
+	if err := validate(s.Name, normalConf); err != nil {
+		return errors.Trace(err)
+	}
+
+	s.Conf = normalConf
+	s.Script = data
+	return nil
+}
+
+// Installed implements Service.
+func (s *Service) Installed() bool {
+	names, err := ListServices()
+	if err != nil {
+		return false
+	}
+	for _, name := range names {
+		if name == s.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// Exists implements Service.
+func (s *Service) Exists() bool {
+	// TODO(ericsnow) Finish!
+	panic("not finished")
+
+	// This may involve conn.GetUnitProperties...
+	return false
+}
+
+// Running implements Service.
+func (s *Service) Running() bool {
+	conn, err := newConn()
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	units, err := conn.ListUnits()
+	if err != nil {
+		return false
+	}
+
+	for _, unit := range units {
+		if unit.Name == s.Name {
+			return unit.LoadState == "loaded" && unit.ActiveState == "active"
+		}
+	}
+	return false
+}
+
+// Start implements Service.
+func (s *Service) Start() error {
+	conn, err := newConn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer conn.Close()
+
+	statusCh := newChan()
+	_, err = conn.StartUnit(s.ConfName, "fail", statusCh)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// TODO(ericsnow) Add timeout support?
+	status := <-statusCh
+	if status != "done" {
+		return errors.Errorf("failed to start service %s", s.Name)
+	}
+
+	return nil
+}
+
+// Stop implements Service.
+func (s *Service) Stop() error {
+	conn, err := newConn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer conn.Close()
+
+	statusCh := newChan()
+	_, err = conn.StopUnit(s.ConfName, "fail", statusCh)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// TODO(ericsnow) Add timeout support?
+	status := <-statusCh
+	if status != "done" {
+		return errors.Errorf("failed to stop service %s", s.Name)
+	}
+
+	return err
+}
+
+// StopAndRemove implements Service.
+func (s *Service) StopAndRemove() error {
+	if err := s.Stop(); err != nil {
+		return errors.Trace(err)
+	}
+	err := s.Remove()
+	return errors.Trace(err)
+}
+
+// Remove implements Service.
+func (s *Service) Remove() error {
+	conn, err := newConn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer conn.Close()
+
+	// TODO(ericsnow) We may need the original file name (or make sure
+	// the unit conf is on the systemd search path.
+	_, err = conn.DisableUnitFiles([]string{s.ConfName}, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := removeAll(s.Dirname); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+var removeAll = func(name string) error {
+	return os.RemoveAll(name)
+}
+
+// Install implements Service.
+func (s *Service) Install() error {
+	filename, err := s.writeConf()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	conn, err := newConn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer conn.Close()
+
+	// TODO(ericsnow) We may need to use conn.LinkUnitFiles either
+	// instead of or in conjunction with EnableUnitFiles.
+	_, _, err = conn.EnableUnitFiles([]string{filename}, false, true)
+	return errors.Trace(err)
+}
+
+func (s *Service) writeConf() (string, error) {
+	data, err := serialize(s.ConfName, s.Conf)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	if err := mkdirAll(s.Dirname); err != nil {
+		return "", errors.Trace(err)
+	}
+	filename := path.Join(s.Dirname, s.ConfName)
+
+	if s.Script != nil {
+		scriptPath := s.Conf.Cmd
+		if err := createFile(scriptPath, s.Script, 0755); err != nil {
+			return filename, errors.Trace(err)
+		}
+	}
+
+	if err := createFile(filename, data, 0644); err != nil {
+		return filename, errors.Trace(err)
+	}
+
+	return filename, nil
+}
+
+var mkdirAll = func(dirname string) error {
+	return os.MkdirAll(dirname, 0755)
+}
+
+var createFile = func(filename string, data []byte, perm os.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
+}
+
+// InstallCommands implements Service.
+func (s *Service) InstallCommands() ([]string, error) {
+	// TODO(ericsnow) Finish.
+	panic("not finished")
+}

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -549,6 +549,13 @@ func (s *initSystemSuite) TestInstall(c *gc.C) {
 			os.FileMode(0644),
 		},
 	}, {
+		FuncName: "LinkUnitFiles",
+		Args: []interface{}{
+			[]string{filename},
+			false,
+			true,
+		},
+	}, {
 		FuncName: "EnableUnitFiles",
 		Args: []interface{}{
 			[]string{filename},
@@ -605,6 +612,7 @@ func (s *initSystemSuite) TestInstallZombie(c *gc.C) {
 		"Close",
 		"MkdirAll",
 		"CreateFile",
+		"LinkUnitFiles",
 		"EnableUnitFiles",
 		"Close",
 	)
@@ -626,6 +634,7 @@ func (s *initSystemSuite) TestInstallMultiline(c *gc.C) {
 		"MkdirAll",
 		"CreateFile",
 		"CreateFile",
+		"LinkUnitFiles",
 		"EnableUnitFiles",
 		"Close",
 	)

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -93,9 +93,7 @@ func (s *initSystemSuite) newConfStr(name, cmd string) string {
 	return fmt.Sprintf(confStr[1:], tag, cmd)
 }
 
-// TODO(ericsnow) Rename addUnit to addService.
-
-func (s *initSystemSuite) addUnit(name, status string) {
+func (s *initSystemSuite) addService(name, status string) {
 	tag := name[len("jujud-"):]
 	desc := "juju agent for " + tag
 	s.conn.AddService(name, desc, status)
@@ -148,10 +146,10 @@ func (s *initSystemSuite) checkCreateFileCall(c *gc.C, index int, filename, cont
 }
 
 func (s *initSystemSuite) TestListServices(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
-	s.addUnit("something-else", "error")
-	s.addUnit("jujud-unit-wordpress-0", "active")
-	s.addUnit("another", "inactive")
+	s.addService("jujud-machine-0", "active")
+	s.addService("something-else", "error")
+	s.addService("jujud-unit-wordpress-0", "active")
+	s.addService("another", "inactive")
 
 	names, err := systemd.ListServices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -240,9 +238,9 @@ func (s *initSystemSuite) TestUpdateConfigMultiline(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestInstalledTrue(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
-	s.addUnit("something-else", "error")
-	s.addUnit("juju-mongod", "active")
+	s.addService("jujud-machine-0", "active")
+	s.addService("something-else", "error")
+	s.addService("juju-mongod", "active")
 
 	installed := s.service.Installed()
 
@@ -251,7 +249,7 @@ func (s *initSystemSuite) TestInstalledTrue(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestInstalledFalse(c *gc.C) {
-	s.addUnit("something-else", "error")
+	s.addService("something-else", "error")
 
 	installed := s.service.Installed()
 
@@ -260,9 +258,9 @@ func (s *initSystemSuite) TestInstalledFalse(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestInstalledError(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
-	s.addUnit("something-else", "error")
-	s.addUnit("juju-mongod", "active")
+	s.addService("jujud-machine-0", "active")
+	s.addService("something-else", "error")
+	s.addService("juju-mongod", "active")
 	failure := errors.New("<failed>")
 	s.stub.SetErrors(failure)
 
@@ -316,9 +314,9 @@ func (s *initSystemSuite) TestExistsError(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestRunningTrue(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
-	s.addUnit("something-else", "error")
-	s.addUnit("juju-mongod", "active")
+	s.addService("jujud-machine-0", "active")
+	s.addService("something-else", "error")
+	s.addService("juju-mongod", "active")
 
 	running := s.service.Running()
 
@@ -327,9 +325,9 @@ func (s *initSystemSuite) TestRunningTrue(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestRunningFalse(c *gc.C) {
-	s.addUnit("jujud-machine-0", "inactive")
-	s.addUnit("something-else", "error")
-	s.addUnit("juju-mongod", "active")
+	s.addService("jujud-machine-0", "inactive")
+	s.addService("something-else", "error")
+	s.addService("juju-mongod", "active")
 
 	running := s.service.Running()
 
@@ -338,7 +336,7 @@ func (s *initSystemSuite) TestRunningFalse(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestRunningNotEnabled(c *gc.C) {
-	s.addUnit("something-else", "active")
+	s.addService("something-else", "active")
 
 	running := s.service.Running()
 
@@ -347,9 +345,9 @@ func (s *initSystemSuite) TestRunningNotEnabled(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestRunningError(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
-	s.addUnit("something-else", "error")
-	s.addUnit("juju-mongod", "active")
+	s.addService("jujud-machine-0", "active")
+	s.addService("something-else", "error")
+	s.addService("juju-mongod", "active")
 	failure := errors.New("<failed>")
 	s.stub.SetErrors(failure)
 
@@ -360,7 +358,7 @@ func (s *initSystemSuite) TestRunningError(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestStart(c *gc.C) {
-	s.addUnit("jujud-machine-0", "inactive")
+	s.addService("jujud-machine-0", "inactive")
 	s.ch <- "done"
 
 	err := s.service.Start()
@@ -387,7 +385,7 @@ func (s *initSystemSuite) TestStart(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestStartAlreadyRunning(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
+	s.addService("jujud-machine-0", "active")
 	s.ch <- "done" // just in case
 
 	err := s.service.Start()
@@ -411,7 +409,7 @@ func (s *initSystemSuite) TestStartNotInstalled(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestStop(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
+	s.addService("jujud-machine-0", "active")
 	s.ch <- "done"
 
 	err := s.service.Stop()
@@ -434,7 +432,7 @@ func (s *initSystemSuite) TestStop(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestStopNotRunning(c *gc.C) {
-	s.addUnit("jujud-machine-0", "inactive")
+	s.addService("jujud-machine-0", "inactive")
 	s.ch <- "done" // just in case
 
 	err := s.service.Stop()
@@ -453,7 +451,7 @@ func (s *initSystemSuite) TestStopNotInstalled(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestStopAndRemove(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
+	s.addService("jujud-machine-0", "active")
 	s.ch <- "done"
 
 	err := s.service.StopAndRemove()
@@ -473,7 +471,7 @@ func (s *initSystemSuite) TestStopAndRemove(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestRemove(c *gc.C) {
-	s.addUnit("jujud-machine-0", "inactive")
+	s.addService("jujud-machine-0", "inactive")
 
 	err := s.service.Remove()
 	c.Assert(err, jc.ErrorIsNil)
@@ -547,7 +545,7 @@ func (s *initSystemSuite) TestInstall(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestInstallAlreadyInstalled(c *gc.C) {
-	s.addUnit("jujud-machine-0", "inactive")
+	s.addService("jujud-machine-0", "inactive")
 	s.setConf(s.conf)
 
 	err := s.service.Install()
@@ -563,7 +561,7 @@ func (s *initSystemSuite) TestInstallAlreadyInstalled(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestInstallZombie(c *gc.C) {
-	s.addUnit("jujud-machine-0", "active")
+	s.addService("jujud-machine-0", "active")
 	s.setConf(common.Conf{
 		Desc: s.conf.Desc,
 		Cmd:  s.conf.Cmd,

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -177,9 +177,10 @@ func (s *initSystemSuite) TestNewService(c *gc.C) {
 
 	c.Check(service, jc.DeepEquals, &systemd.Service{
 		Name:     s.name,
+		ConfName: s.name + ".service",
+		UnitName: s.name + ".service",
 		Conf:     s.conf,
 		Dirname:  fmt.Sprintf("%s/init/%s", s.dataDir, s.name),
-		ConfName: s.name + ".service",
 	})
 	s.stub.CheckCalls(c, nil)
 }
@@ -192,9 +193,10 @@ func (s *initSystemSuite) TestUpdateConfig(c *gc.C) {
 
 	c.Check(s.service, jc.DeepEquals, &systemd.Service{
 		Name:     s.name,
+		ConfName: s.name + ".service",
+		UnitName: s.name + ".service",
 		Conf:     s.conf,
 		Dirname:  fmt.Sprintf("%s/init/%s", s.dataDir, s.name),
-		ConfName: s.name + ".service",
 	})
 	s.stub.CheckCalls(c, nil)
 }
@@ -206,14 +208,15 @@ func (s *initSystemSuite) TestUpdateConfigExtraScript(c *gc.C) {
 
 	dirname := fmt.Sprintf("%s/init/%s", s.dataDir, s.name)
 	c.Check(s.service, jc.DeepEquals, &systemd.Service{
-		Name: s.name,
+		Name:     s.name,
+		UnitName: s.name + ".service",
+		ConfName: s.name + ".service",
 		Conf: common.Conf{
 			Desc: s.conf.Desc,
 			Cmd:  dirname + "/exec-start.sh",
 		},
-		Dirname:  dirname,
-		ConfName: s.name + ".service",
-		Script:   []byte("<some other command>\njujud machine-0"),
+		Dirname: dirname,
+		Script:  []byte("<some other command>\njujud machine-0"),
 	})
 	s.stub.CheckCalls(c, nil)
 }
@@ -225,14 +228,15 @@ func (s *initSystemSuite) TestUpdateConfigMultiline(c *gc.C) {
 
 	dirname := fmt.Sprintf("%s/init/%s", s.dataDir, s.name)
 	c.Check(s.service, jc.DeepEquals, &systemd.Service{
-		Name: s.name,
+		Name:     s.name,
+		UnitName: s.name + ".service",
+		ConfName: s.name + ".service",
 		Conf: common.Conf{
 			Desc: s.conf.Desc,
 			Cmd:  dirname + "/exec-start.sh",
 		},
-		Dirname:  dirname,
-		ConfName: s.name + ".service",
-		Script:   []byte("a\nb\nc"),
+		Dirname: dirname,
+		Script:  []byte("a\nb\nc"),
 	})
 	s.stub.CheckCalls(c, nil)
 }

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -1,0 +1,691 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/service/common"
+	"github.com/juju/juju/service/systemd"
+	coretesting "github.com/juju/juju/testing"
+)
+
+const confStr = `
+[Unit]
+Description=juju agent for %s
+After=syslog.target
+After=network.target
+After=systemd-user-sessions.service
+
+[Service]
+Type=forking
+ExecStart=%s
+RemainAfterExit=yes
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+
+`
+
+type initSystemSuite struct {
+	coretesting.BaseSuite
+
+	dataDir string
+	ch      chan string
+	stub    *testing.Stub
+	conn    *systemd.StubDbusAPI
+	fops    *systemd.StubFileOps
+
+	name    string
+	tag     names.Tag
+	conf    common.Conf
+	confStr string
+	service *systemd.Service
+}
+
+var _ = gc.Suite(&initSystemSuite{})
+
+func (s *initSystemSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	// Patch things out.
+	s.dataDir = c.MkDir()
+	systemd.PatchFindDataDir(s, s.dataDir)
+	s.ch = systemd.PatchNewChan(s)
+
+	s.stub = &testing.Stub{}
+	s.conn = systemd.PatchNewConn(s, s.stub)
+	s.fops = systemd.PatchFileOps(s, s.stub)
+	c.Logf("%+v", s.fops)
+
+	// Set up the service.
+	tagStr := "machine-0"
+	tag, err := names.ParseTag(tagStr)
+	c.Assert(err, jc.ErrorIsNil)
+	s.tag = tag
+	s.name = "jujud-" + tagStr
+	s.conf = common.Conf{
+		Desc: "juju agent for " + tagStr,
+		Cmd:  "jujud " + tagStr,
+	}
+	s.service, err = systemd.NewService(s.name, s.conf)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Reset any incidental calls.
+	s.stub.Calls = nil
+}
+
+func (s *initSystemSuite) newConfStr(name, cmd string) string {
+	tag := name[len("jujud-"):]
+	if cmd == "" {
+		cmd = "jujud " + tag
+	}
+	return fmt.Sprintf(confStr[1:], tag, cmd)
+}
+
+func (s *initSystemSuite) addUnit(name, status string) {
+	tag := name[len("jujud-"):]
+	desc := "juju agent for " + tag
+	s.conn.AddUnit(name, desc, status)
+}
+
+func (s *initSystemSuite) checkCreateFileCall(c *gc.C, index int, filename, content string, perm os.FileMode) {
+	if content == "" {
+		name := filename
+		filename = fmt.Sprintf("%s/init/%s/%s.service", s.dataDir, name, name)
+		content = s.newConfStr(name, "")
+	}
+
+	call := s.stub.Calls[index]
+	if !c.Check(call.FuncName, gc.Equals, "CreateFile") {
+		return
+	}
+	if !c.Check(call.Args, gc.HasLen, 3) {
+		return
+	}
+
+	callFilename, callData, callPerm := call.Args[0], call.Args[1], call.Args[2]
+	c.Check(callFilename, gc.Equals, filename)
+	c.Check(string(callData.([]byte)), gc.Equals, content)
+	c.Check(callPerm, gc.Equals, perm)
+}
+
+func (s *initSystemSuite) TestListServices(c *gc.C) {
+	s.addUnit("jujud-machine-0", "active")
+	s.addUnit("something-else", "error")
+	s.addUnit("jujud-unit-wordpress-0", "active")
+	s.addUnit("another", "inactive")
+
+	names, err := systemd.ListServices()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(names, jc.SameContents, []string{
+		"jujud-machine-0",
+		"something-else",
+		"jujud-unit-wordpress-0",
+		"another",
+	})
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestListServicesEmpty(c *gc.C) {
+	names, err := systemd.ListServices()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(names, gc.HasLen, 0)
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestNewService(c *gc.C) {
+	service, err := systemd.NewService(s.name, s.conf)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(service, jc.DeepEquals, &systemd.Service{
+		Name:     s.name,
+		Conf:     s.conf,
+		Dirname:  fmt.Sprintf("%s/init/%s", s.dataDir, s.name),
+		ConfName: s.name + ".service",
+	})
+	s.stub.CheckCalls(c, nil)
+}
+
+func (s *initSystemSuite) TestUpdateConfig(c *gc.C) {
+	s.conf.Cmd = "<some other command>"
+	c.Assert(s.service.Conf.Cmd, gc.Equals, "jujud machine-0")
+
+	s.service.UpdateConfig(s.conf)
+
+	c.Check(s.service, jc.DeepEquals, &systemd.Service{
+		Name:     s.name,
+		Conf:     s.conf,
+		Dirname:  fmt.Sprintf("%s/init/%s", s.dataDir, s.name),
+		ConfName: s.name + ".service",
+	})
+	s.stub.CheckCalls(c, nil)
+}
+
+func (s *initSystemSuite) TestUpdateConfigExtraScript(c *gc.C) {
+	s.conf.ExtraScript = "<some other command>"
+
+	s.service.UpdateConfig(s.conf)
+
+	dirname := fmt.Sprintf("%s/init/%s", s.dataDir, s.name)
+	c.Check(s.service, jc.DeepEquals, &systemd.Service{
+		Name: s.name,
+		Conf: common.Conf{
+			Desc: s.conf.Desc,
+			Cmd:  dirname + "/exec-start.sh",
+		},
+		Dirname:  dirname,
+		ConfName: s.name + ".service",
+		Script:   []byte("<some other command>\njujud machine-0"),
+	})
+	s.stub.CheckCalls(c, nil)
+}
+
+func (s *initSystemSuite) TestUpdateConfigMultiline(c *gc.C) {
+	s.conf.Cmd = "a\nb\nc"
+
+	s.service.UpdateConfig(s.conf)
+
+	dirname := fmt.Sprintf("%s/init/%s", s.dataDir, s.name)
+	c.Check(s.service, jc.DeepEquals, &systemd.Service{
+		Name: s.name,
+		Conf: common.Conf{
+			Desc: s.conf.Desc,
+			Cmd:  dirname + "/exec-start.sh",
+		},
+		Dirname:  dirname,
+		ConfName: s.name + ".service",
+		Script:   []byte("a\nb\nc"),
+	})
+	s.stub.CheckCalls(c, nil)
+}
+
+func (s *initSystemSuite) TestInstalledTrue(c *gc.C) {
+	s.addUnit("jujud-machine-0", "active")
+	s.addUnit("something-else", "error")
+	s.addUnit("juju-mongod", "active")
+
+	installed := s.service.Installed()
+
+	c.Check(installed, jc.IsTrue)
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestInstalledFalse(c *gc.C) {
+	s.addUnit("something-else", "error")
+
+	installed := s.service.Installed()
+
+	c.Check(installed, jc.IsFalse)
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestInstalledError(c *gc.C) {
+	s.addUnit("jujud-machine-0", "active")
+	s.addUnit("something-else", "error")
+	s.addUnit("juju-mongod", "active")
+	failure := errors.New("<failed>")
+	s.stub.SetErrors(failure)
+
+	installed := s.service.Installed()
+
+	c.Check(installed, jc.IsFalse)
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestExistsTrue(c *gc.C) {
+	// TODO(ericsnow) Finish!
+}
+
+func (s *initSystemSuite) TestExistsFalse(c *gc.C) {
+	// TODO(ericsnow) Finish!
+}
+
+func (s *initSystemSuite) TestExistsError(c *gc.C) {
+	// TODO(ericsnow) Finish!
+}
+
+func (s *initSystemSuite) TestRunningTrue(c *gc.C) {
+	s.addUnit("jujud-machine-0", "active")
+	s.addUnit("something-else", "error")
+	s.addUnit("juju-mongod", "active")
+
+	running := s.service.Running()
+
+	c.Check(running, jc.IsTrue)
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestRunningFalse(c *gc.C) {
+	s.addUnit("jujud-machine-0", "inactive")
+	s.addUnit("something-else", "error")
+	s.addUnit("juju-mongod", "active")
+
+	running := s.service.Running()
+
+	c.Check(running, jc.IsFalse)
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestRunningNotEnabled(c *gc.C) {
+	s.addUnit("something-else", "active")
+
+	running := s.service.Running()
+
+	c.Check(running, jc.IsFalse)
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestRunningError(c *gc.C) {
+	s.addUnit("jujud-machine-0", "active")
+	s.addUnit("something-else", "error")
+	s.addUnit("juju-mongod", "active")
+	failure := errors.New("<failed>")
+	s.stub.SetErrors(failure)
+
+	running := s.service.Running()
+
+	c.Check(running, jc.IsFalse)
+	s.stub.CheckCallNames(c, "ListUnits", "Close")
+}
+
+func (s *initSystemSuite) TestStart(c *gc.C) {
+	s.ch <- "done"
+
+	err := s.service.Start()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "StartUnit", "Close")
+}
+
+func (s *initSystemSuite) TestStop(c *gc.C) {
+	s.ch <- "done"
+
+	err := s.service.Stop()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "StopUnit", "Close")
+}
+
+func (s *initSystemSuite) TestStopAndRemove(c *gc.C) {
+	s.ch <- "done"
+
+	err := s.service.StopAndRemove()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "StopUnit", "Close", "DisableUnitFiles", "RemoveAll", "Close")
+}
+
+func (s *initSystemSuite) TestRemove(c *gc.C) {
+	err := s.service.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "DisableUnitFiles", "RemoveAll", "Close")
+}
+
+func (s *initSystemSuite) TestInstall(c *gc.C) {
+	err := s.service.Install()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "MkdirAll", "CreateFile", "EnableUnitFiles", "Close")
+	s.checkCreateFileCall(c, 1, s.name, "", 0644)
+}
+
+func (s *initSystemSuite) TestInstallMultiline(c *gc.C) {
+	scriptPath := fmt.Sprintf("%s/init/%s/exec-start.sh", s.dataDir, s.name)
+	cmd := "a\nb\nc"
+	s.service.Conf.Cmd = scriptPath
+	s.service.Script = []byte(cmd)
+
+	err := s.service.Install()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "MkdirAll", "CreateFile", "CreateFile", "EnableUnitFiles", "Close")
+	s.checkCreateFileCall(c, 1, scriptPath, cmd, 0755)
+	filename := fmt.Sprintf("%s/init/%s/%s.service", s.dataDir, s.name, s.name)
+	content := s.newConfStr(s.name, scriptPath)
+	s.checkCreateFileCall(c, 2, filename, content, 0644)
+}
+
+func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
+	// TODO(ericsnow) Finish.
+}
+
+///////////////////////////////////////////////////////////
+
+/*
+func (s *initSystemSuite) TestInitSystemStart(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "inactive")
+	s.ch <- "done"
+
+	err := s.init.Start(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "ListUnits", "Close", "StartUnit", "Close")
+}
+
+func (s *initSystemSuite) TestInitSystemStartAlreadyRunning(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "active")
+
+	err := s.init.Start(name)
+
+	c.Check(err, jc.Satisfies, errors.IsAlreadyExists)
+}
+
+func (s *initSystemSuite) TestInitSystemStartNotEnabled(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	err := s.init.Start(name)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *initSystemSuite) TestInitSystemStop(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "active")
+	s.ch <- "done"
+
+	err := s.init.Stop(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "ListUnits", "Close", "StopUnit", "Close")
+}
+
+func (s *initSystemSuite) TestInitSystemStopNotRunning(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "inactive")
+
+	err := s.init.Stop(name)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *initSystemSuite) TestInitSystemStopNotEnabled(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	err := s.init.Stop(name)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *initSystemSuite) TestInitSystemEnable(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	filename := "/var/lib/juju/init/" + name + "/systemd.conf"
+	err := s.init.Enable(name, filename)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "ListUnits",
+	}, {
+		FuncName: "Close",
+	}, {
+		FuncName: "EnableUnitFiles",
+		Args: []interface{}{
+			[]string{filename},
+			false,
+			true,
+		},
+	}, {
+		FuncName: "Close",
+	}})
+}
+
+func (s *initSystemSuite) TestInitSystemEnableAlreadyEnabled(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "inactive")
+
+	filename := "/var/lib/juju/init/" + name + "/systemd.conf"
+	err := s.init.Enable(name, filename)
+
+	c.Check(err, jc.Satisfies, errors.IsAlreadyExists)
+}
+
+func (s *initSystemSuite) TestInitSystemDisable(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "inactive")
+
+	err := s.init.Disable(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	filename := "/var/lib/juju/init/" + name + "/systemd.conf"
+	s.stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "ListUnits",
+	}, {
+		FuncName: "Close",
+	}, {
+		FuncName: "DisableUnitFiles",
+		Args: []interface{}{
+			[]string{filename},
+			false,
+		},
+	}, {
+		FuncName: "Close",
+	}})
+}
+
+func (s *initSystemSuite) TestInitSystemDisableNotEnabled(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+
+	err := s.init.Disable(name)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *initSystemSuite) TestInitSystemIsEnabledTrue(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "inactive")
+
+	enabled, err := s.init.IsEnabled(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(enabled, jc.IsTrue)
+
+	s.stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "ListUnits",
+	}, {
+		FuncName: "Close",
+	}})
+}
+
+func (s *initSystemSuite) TestInitSystemIsEnabledFalse(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+
+	enabled, err := s.init.IsEnabled(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(enabled, jc.IsFalse)
+}
+
+func (s *initSystemSuite) TestInitSystemInfoRunning(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "active")
+
+	info, err := s.init.Info(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(info, jc.DeepEquals, &initsystems.ServiceInfo{
+		Name:        name,
+		Description: "juju agent for unit-wordpress-0",
+		Status:      "active",
+	})
+
+	s.stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "ListUnits",
+	}, {
+		FuncName: "Close",
+	}})
+}
+
+func (s *initSystemSuite) TestInitSystemInfoNotRunning(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "inactive")
+
+	info, err := s.init.Info(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(info, jc.DeepEquals, &initsystems.ServiceInfo{
+		Name:        name,
+		Description: "juju agent for unit-wordpress-0",
+		Status:      "inactive",
+	})
+}
+
+func (s *initSystemSuite) TestInitSystemInfoNotEnabled(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	_, err := s.init.Info(name)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *initSystemSuite) TestInitSystemConf(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	s.addUnit(name, "inactive")
+
+	conf, err := s.init.Conf(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(conf, jc.DeepEquals, common.Conf{
+		Desc: `juju agent for unit-wordpress-0`,
+		Cmd:  "jujud unit-wordpress-0",
+	})
+
+	s.stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "ListUnits",
+	}, {
+		FuncName: "Close",
+	}})
+}
+
+func (s *initSystemSuite) TestInitSystemConfNotEnabled(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+
+	_, err := s.init.Conf(name)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *initSystemSuite) TestInitSystemValidate(c *gc.C) {
+	confName, err := s.init.Validate("jujud-machine-0", s.conf)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(confName, gc.Equals, "jujud-machine-0.service")
+	s.stub.CheckCalls(c, nil)
+}
+
+func (s *initSystemSuite) TestInitSystemValidateFull(c *gc.C) {
+	s.conf.Env = map[string]string{
+		"x": "y",
+	}
+	s.conf.Limit = map[string]string{
+		"nofile": "10",
+	}
+	s.conf.Out = "syslog"
+
+	_, err := s.init.Validate("jujud-machine-0", s.conf)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCalls(c, nil)
+}
+
+func (s *initSystemSuite) TestInitSystemValidateInvalid(c *gc.C) {
+	s.conf.Cmd = ""
+
+	_, err := s.init.Validate("jujud-machine-0", s.conf)
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *initSystemSuite) TestInitSystemValidateInvalidOut(c *gc.C) {
+	s.conf.Out = "/var/log/juju/machine-0.log"
+
+	_, err := s.init.Validate("jujud-machine-0", s.conf)
+
+	expected := errors.NotValidf("Out")
+	c.Check(errors.Cause(err), gc.FitsTypeOf, expected)
+}
+
+func (s *initSystemSuite) TestInitSystemValidateInvalidLimit(c *gc.C) {
+	s.conf.Limit = map[string]string{
+		"x": "y",
+	}
+
+	_, err := s.init.Validate("jujud-machine-0", s.conf)
+
+	expected := errors.NotValidf("Limit")
+	c.Check(errors.Cause(err), gc.FitsTypeOf, expected)
+}
+
+func (s *initSystemSuite) TestInitSystemSerialize(c *gc.C) {
+	data, err := s.init.Serialize("jujud-machine-0", s.conf)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(string(data), gc.Equals, s.confStr)
+
+	s.stub.CheckCalls(c, nil)
+}
+
+func (s *initSystemSuite) TestInitSystemSerializeUnsupported(c *gc.C) {
+	tag := "unit-wordpress-0"
+	name := "jujud-unit-wordpress-0"
+	conf := common.Conf{
+		Desc: "juju agent for " + tag,
+		Cmd:  "jujud " + tag,
+		Out:  "/var/log/juju/" + tag,
+	}
+	_, err := s.init.Serialize(name, conf)
+
+	expected := errors.NotValidf("Out")
+	c.Check(errors.Cause(err), gc.FitsTypeOf, expected)
+}
+
+func (s *initSystemSuite) TestInitSystemDeserialize(c *gc.C) {
+	name := "jujud-unit-wordpress-0"
+	data := s.newConfStr(name)
+	conf, err := s.init.Deserialize([]byte(data), name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(conf, jc.DeepEquals, common.Conf{
+		Desc: "juju agent for unit-wordpress-0",
+		Cmd:  "jujud unit-wordpress-0",
+	})
+
+	s.stub.CheckCalls(c, nil)
+}
+
+func (s *initSystemSuite) TestInitSystemDeserializeUnsupported(c *gc.C) {
+	name := "jujud-machine-0"
+	data := `
+[Unit]
+Description=juju agent for machine-0
+After=syslog.target
+After=network.target
+After=systemd-user-sessions.service
+
+[Service]
+Type=forking
+StandardOutput=/var/log/juju/machine-0.log
+ExecStart=jujud machine-0
+RemainAfterExit=yes
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+
+`[1:]
+	_, err := s.init.Deserialize([]byte(data), name)
+
+	expected := errors.NotValidf("Out")
+	c.Check(errors.Cause(err), gc.FitsTypeOf, expected)
+}
+*/

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -678,7 +678,9 @@ func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
 
 	content := s.newConfStr("jujud-machine-0", "")
 	c.Check(commands, jc.DeepEquals, []string{
-		"cat >> /tmp/jujud-machine-0.service << 'EOF'\n" + content + "EOF\n",
-		"systemd start /tmp/jujud-machine-0.service",
+		"cat >> /tmp/jujud-machine-0.service << 'EOF'\n" + content + "EOF",
+		"/bin/systemctl link /tmp/jujud-machine-0.service",
+		"/bin/systemctl enable jujud-machine-0.service",
+		"/bin/systemctl start jujud-machine-0.service",
 	})
 }

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -141,8 +141,8 @@ func (s *initSystemSuite) setConf(conf common.Conf) {
 		panic("not supported yet")
 	}
 
-	s.conn.SetProperty("Service", "StandardOutput", conf.Out)
-	s.conn.SetProperty("Service", "StandardError", conf.Out)
+	s.conn.SetProperty("Service", "StandardOutput", conf.Output)
+	s.conn.SetProperty("Service", "StandardError", conf.Output)
 }
 
 func (s *initSystemSuite) checkCreateFileCall(c *gc.C, index int, filename, content string, perm os.FileMode) {
@@ -328,7 +328,7 @@ func (s *initSystemSuite) TestExistsFalse(c *gc.C) {
 	s.setConf(common.Conf{
 		Desc:      s.conf.Desc,
 		ExecStart: s.conf.ExecStart,
-		Out:       "syslog",
+		Output:    "syslog",
 	})
 
 	exists := s.service.Exists()
@@ -619,7 +619,7 @@ func (s *initSystemSuite) TestInstallZombie(c *gc.C) {
 	s.setConf(common.Conf{
 		Desc:      s.conf.Desc,
 		ExecStart: s.conf.ExecStart,
-		Out:       "syslog",
+		Output:    "syslog",
 	})
 	s.ch <- "done"
 

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -122,7 +122,6 @@ func (s *initSystemSuite) addListResponse() {
 
 func (s *initSystemSuite) setConf(conf common.Conf) {
 	s.conn.SetProperty("", "Description", conf.Desc)
-
 	s.conn.SetProperty("Service", "Description", conf.Desc)
 
 	parts := strings.Fields(conf.ExecStart)

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -624,5 +624,12 @@ func (s *initSystemSuite) TestInstallMultiline(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
-	// TODO(ericsnow) Finish.
+	commands, err := s.service.InstallCommands()
+	c.Assert(err, jc.ErrorIsNil)
+
+	content := s.newConfStr("jujud-machine-0", "")
+	c.Check(commands, jc.DeepEquals, []string{
+		"cat >> /tmp/jujud-machine-0.service << 'EOF'\n" + content + "EOF\n",
+		"systemd start /tmp/jujud-machine-0.service",
+	})
 }

--- a/service/systemd/stubdbusapi_test.go
+++ b/service/systemd/stubdbusapi_test.go
@@ -14,7 +14,7 @@ type StubDbusAPI struct {
 	Units []dbus.UnitStatus
 }
 
-func (fda *StubDbusAPI) AddUnit(name, desc, status string) {
+func (fda *StubDbusAPI) AddService(name, desc, status string) {
 	active := ""
 	load := "loaded"
 	if status == "error" {
@@ -24,7 +24,7 @@ func (fda *StubDbusAPI) AddUnit(name, desc, status string) {
 	}
 
 	unit := dbus.UnitStatus{
-		Name:        name,
+		Name:        name + ".service",
 		Description: desc,
 		ActiveState: active,
 		LoadState:   load,
@@ -33,7 +33,7 @@ func (fda *StubDbusAPI) AddUnit(name, desc, status string) {
 }
 
 func (fda *StubDbusAPI) ListUnits() ([]dbus.UnitStatus, error) {
-	fda.Stub.AddCall("ListUnits", nil)
+	fda.Stub.AddCall("ListUnits")
 
 	return fda.Units, fda.NextErr()
 }
@@ -57,16 +57,13 @@ func (fda *StubDbusAPI) EnableUnitFiles(files []string, runtime bool, force bool
 }
 
 func (fda *StubDbusAPI) DisableUnitFiles(files []string, runtime bool) ([]dbus.DisableUnitFileChange, error) {
-	fda.Stub.AddCall("DisableUnitFiles", []interface{}{
-		files,
-		runtime,
-	})
+	fda.Stub.AddCall("DisableUnitFiles", files, runtime)
 
 	return nil, fda.NextErr()
 }
 
 func (fda *StubDbusAPI) Close() {
-	fda.Stub.AddCall("Close", nil)
+	fda.Stub.AddCall("Close")
 
 	fda.Stub.NextErr() // We don't return the error (just pop it off).
 }

--- a/service/systemd/stubdbusapi_test.go
+++ b/service/systemd/stubdbusapi_test.go
@@ -34,6 +34,25 @@ func (fda *StubDbusAPI) AddService(name, desc, status string) {
 	fda.Units = append(fda.Units, unit)
 }
 
+func (fda *StubDbusAPI) SetProperty(unitType, name string, value interface{}) {
+	if unitType == "" {
+		unitType = "Unit"
+	}
+
+	switch unitType {
+	case "Unit":
+		if fda.Props == nil {
+			fda.Props = make(map[string]interface{})
+		}
+		fda.Props[name] = value
+	default:
+		if fda.TypeProps == nil {
+			fda.TypeProps = make(map[string]interface{})
+		}
+		fda.TypeProps[name] = value
+	}
+}
+
 func (fda *StubDbusAPI) ListUnits() ([]dbus.UnitStatus, error) {
 	fda.Stub.AddCall("ListUnits")
 

--- a/service/systemd/stubdbusapi_test.go
+++ b/service/systemd/stubdbusapi_test.go
@@ -1,0 +1,72 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"github.com/coreos/go-systemd/dbus"
+	"github.com/juju/testing"
+)
+
+type StubDbusAPI struct {
+	*testing.Stub
+
+	Units []dbus.UnitStatus
+}
+
+func (fda *StubDbusAPI) AddUnit(name, desc, status string) {
+	active := ""
+	load := "loaded"
+	if status == "error" {
+		load = status
+	} else {
+		active = status
+	}
+
+	unit := dbus.UnitStatus{
+		Name:        name,
+		Description: desc,
+		ActiveState: active,
+		LoadState:   load,
+	}
+	fda.Units = append(fda.Units, unit)
+}
+
+func (fda *StubDbusAPI) ListUnits() ([]dbus.UnitStatus, error) {
+	fda.Stub.AddCall("ListUnits", nil)
+
+	return fda.Units, fda.NextErr()
+}
+
+func (fda *StubDbusAPI) StartUnit(name string, mode string, ch chan<- string) (int, error) {
+	fda.Stub.AddCall("StartUnit", name, mode, ch)
+
+	return 0, fda.NextErr()
+}
+
+func (fda *StubDbusAPI) StopUnit(name string, mode string, ch chan<- string) (int, error) {
+	fda.Stub.AddCall("StopUnit", name, mode, ch)
+
+	return 0, fda.NextErr()
+}
+
+func (fda *StubDbusAPI) EnableUnitFiles(files []string, runtime bool, force bool) (bool, []dbus.EnableUnitFileChange, error) {
+	fda.Stub.AddCall("EnableUnitFiles", files, runtime, force)
+
+	return false, nil, fda.NextErr()
+}
+
+func (fda *StubDbusAPI) DisableUnitFiles(files []string, runtime bool) ([]dbus.DisableUnitFileChange, error) {
+	fda.Stub.AddCall("DisableUnitFiles", []interface{}{
+		files,
+		runtime,
+	})
+
+	return nil, fda.NextErr()
+}
+
+func (fda *StubDbusAPI) Close() {
+	fda.Stub.AddCall("Close", nil)
+
+	fda.Stub.NextErr() // We don't return the error (just pop it off).
+}

--- a/service/systemd/stubdbusapi_test.go
+++ b/service/systemd/stubdbusapi_test.go
@@ -11,7 +11,9 @@ import (
 type StubDbusAPI struct {
 	*testing.Stub
 
-	Units []dbus.UnitStatus
+	Units     []dbus.UnitStatus
+	Props     map[string]interface{}
+	TypeProps map[string]interface{}
 }
 
 func (fda *StubDbusAPI) AddService(name, desc, status string) {
@@ -60,6 +62,18 @@ func (fda *StubDbusAPI) DisableUnitFiles(files []string, runtime bool) ([]dbus.D
 	fda.Stub.AddCall("DisableUnitFiles", files, runtime)
 
 	return nil, fda.NextErr()
+}
+
+func (fda *StubDbusAPI) GetUnitProperties(unit string) (map[string]interface{}, error) {
+	fda.Stub.AddCall("GetUnitProperties", unit)
+
+	return fda.Props, fda.NextErr()
+}
+
+func (fda *StubDbusAPI) GetUnitTypeProperties(unit, unitType string) (map[string]interface{}, error) {
+	fda.Stub.AddCall("GetUnitTypeProperties", unit, unitType)
+
+	return fda.TypeProps, fda.NextErr()
 }
 
 func (fda *StubDbusAPI) Close() {

--- a/service/systemd/stubdbusapi_test.go
+++ b/service/systemd/stubdbusapi_test.go
@@ -71,6 +71,12 @@ func (fda *StubDbusAPI) StopUnit(name string, mode string, ch chan<- string) (in
 	return 0, fda.NextErr()
 }
 
+func (fda *StubDbusAPI) LinkUnitFiles(files []string, runtime bool, force bool) ([]dbus.LinkUnitFileChange, error) {
+	fda.Stub.AddCall("LinkUnitFiles", files, runtime, force)
+
+	return nil, fda.NextErr()
+}
+
 func (fda *StubDbusAPI) EnableUnitFiles(files []string, runtime bool, force bool) (bool, []dbus.EnableUnitFileChange, error) {
 	fda.Stub.AddCall("EnableUnitFiles", files, runtime, force)
 

--- a/service/systemd/stubexec_test.go
+++ b/service/systemd/stubexec_test.go
@@ -26,5 +26,9 @@ func (se *StubExec) RunCommand(args exec.RunParams) (*exec.ExecResponse, error) 
 		response = se.Responses[0]
 		se.Responses = se.Responses[1:]
 	}
-	return &response, se.NextErr()
+	err := se.NextErr()
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
 }

--- a/service/systemd/stubexec_test.go
+++ b/service/systemd/stubexec_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"github.com/juju/testing"
+	"github.com/juju/utils/exec"
+)
+
+type StubExec struct {
+	*testing.Stub
+
+	Responses []exec.ExecResponse
+}
+
+func (se *StubExec) SetResponses(resp ...exec.ExecResponse) {
+	se.Responses = resp
+}
+
+func (se *StubExec) RunCommand(args exec.RunParams) (*exec.ExecResponse, error) {
+	se.AddCall("RunCommand", args)
+
+	var response exec.ExecResponse
+	if len(se.Responses) > 0 {
+		response = se.Responses[0]
+		se.Responses = se.Responses[1:]
+	}
+	return &response, se.NextErr()
+}

--- a/service/systemd/stubfileops_test.go
+++ b/service/systemd/stubfileops_test.go
@@ -1,0 +1,32 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"os"
+
+	"github.com/juju/testing"
+)
+
+type StubFileOps struct {
+	*testing.Stub
+}
+
+func (sfo *StubFileOps) RemoveAll(name string) error {
+	sfo.AddCall("RemoveAll", name)
+
+	return sfo.NextErr()
+}
+
+func (sfo *StubFileOps) MkdirAll(dirname string) error {
+	sfo.AddCall("MkdirAll", dirname)
+
+	return sfo.NextErr()
+}
+
+func (sfo *StubFileOps) CreateFile(filename string, data []byte, perm os.FileMode) error {
+	sfo.AddCall("CreateFile", filename, data, perm)
+
+	return sfo.NextErr()
+}


### PR DESCRIPTION
An implementation of service.Service for systemd is necessary to support systemd in juju.  A follow-up patch will use this implementation in the various places in juju that currently directly use just upstart.  The discovery code in service.NewService will facilitate selecting the init system.

(Review request: http://reviews.vapour.ws/r/983/)