### PR TITLE
Patch version.Current.Arch to arch.AMD64 so tests pass on non-AMD64 hosts

### DIFF
--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -72,8 +72,12 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	archTools, err := args.Tools.Match(tools.Filter{
 		Arch: version.Current.Arch,
 	})
-	if err != nil {
-		return nil, errors.Annotate(err, "filtering tools")
+	if err == tools.ErrNoMatches {
+		return nil, errors.Errorf(
+			"need tools for arch %s, only found %s",
+			version.Current.Arch,
+			args.Tools.Arches(),
+		)
 	}
 
 	series := archTools.OneSeries()

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -4,8 +4,7 @@
 package provisioner
 
 import (
-	"errors"
-
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/agent"
@@ -14,6 +13,8 @@ import (
 	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/tools"
+	"github.com/juju/juju/version"
 )
 
 var lxcLogger = loggo.GetLogger("juju.provisioner.lxc")
@@ -64,9 +65,20 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}
 	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
 
-	series := args.Tools.OneSeries()
+	// The provisioner worker will provide all tools it knows about
+	// (after applying explicitly specified constraints), which may
+	// include tools for architectures other than the host's. We
+	// must constrain to the host's architecture for LXC.
+	archTools, err := args.Tools.Match(tools.Filter{
+		Arch: version.Current.Arch,
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "filtering tools")
+	}
+
+	series := archTools.OneSeries()
 	args.MachineConfig.MachineContainerType = instance.LXC
-	args.MachineConfig.Tools = args.Tools[0]
+	args.MachineConfig.Tools = archTools[0]
 
 	config, err := broker.api.ContainerConfig()
 	if err != nil {

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -101,6 +101,7 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 
 func (s *lxcBrokerSuite) machineConfig(c *gc.C, machineId string) *cloudinit.MachineConfig {
 	machineNonce := "fake-nonce"
+	// To isolate the tests from the host's architecture, we override it here.
 	s.PatchValue(&version.Current.Arch, arch.AMD64)
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
@@ -141,7 +142,8 @@ func (s *lxcBrokerSuite) TestStartInstance(c *gc.C) {
 func (s *lxcBrokerSuite) TestStartInstanceHostArch(c *gc.C) {
 	machineConfig := s.machineConfig(c, "1/lxc/0")
 
-	// Patch the host's arch, so the LXC broker will filter tools.
+	// Patch the host's arch, so the LXC broker will filter tools. We don't use PatchValue
+	// because machineConfig already has, so it will restore version.Current.Arch during TearDownTest
 	version.Current.Arch = arch.PPC64EL
 	possibleTools := coretools.List{&coretools.Tools{
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
@@ -162,7 +164,8 @@ func (s *lxcBrokerSuite) TestStartInstanceHostArch(c *gc.C) {
 func (s *lxcBrokerSuite) TestStartInstanceToolsArchNotFound(c *gc.C) {
 	machineConfig := s.machineConfig(c, "1/lxc/0")
 
-	// Patch the host's arch, so the LXC broker will filter tools.
+	// Patch the host's arch, so the LXC broker will filter tools. We don't use PatchValue
+	// because machineConfig already has, so it will restore version.Current.Arch during TearDownTest
 	version.Current.Arch = arch.PPC64EL
 	possibleTools := coretools.List{&coretools.Tools{
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
+	"github.com/juju/juju/juju/arch"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -99,6 +100,7 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 
 func (s *lxcBrokerSuite) startInstance(c *gc.C, machineId string) instance.Instance {
 	machineNonce := "fake-nonce"
+	s.PatchValue(&version.Current.Arch, arch.AMD64)
 	stateInfo := jujutesting.FakeStateInfo(machineId)
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -142,7 +142,7 @@ func (s *lxcBrokerSuite) TestStartInstanceHostArch(c *gc.C) {
 	machineConfig := s.machineConfig(c, "1/lxc/0")
 
 	// Patch the host's arch, so the LXC broker will filter tools.
-	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
+	version.Current.Arch = arch.PPC64EL
 	possibleTools := coretools.List{&coretools.Tools{
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
@@ -163,7 +163,7 @@ func (s *lxcBrokerSuite) TestStartInstanceToolsArchNotFound(c *gc.C) {
 	machineConfig := s.machineConfig(c, "1/lxc/0")
 
 	// Patch the host's arch, so the LXC broker will filter tools.
-	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
+	version.Current.Arch = arch.PPC64EL
 	possibleTools := coretools.List{&coretools.Tools{
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -132,6 +132,32 @@ func (s *lxcBrokerSuite) TestStartInstance(c *gc.C) {
 	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.link = lxcbr0")
 }
 
+func (s *lxcBrokerSuite) TestStartInstanceHostArch(c *gc.C) {
+	const machineId = "1/lxc/0"
+	stateInfo := jujutesting.FakeStateInfo(machineId)
+	apiInfo := jujutesting.FakeAPIInfo(machineId)
+	machineConfig, err := environs.NewMachineConfig(machineId, "fake-nonce", "released", "quantal", true, nil, stateInfo, apiInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	cons := constraints.Value{}
+
+	// Patch the host's arch, so the LXC broker will filter tools.
+	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
+	possibleTools := coretools.List{&coretools.Tools{
+		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+	}, {
+		Version: version.MustParseBinary("2.3.4-quantal-ppc64el"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-ppc64el.tgz",
+	}}
+	_, err = s.broker.StartInstance(environs.StartInstanceParams{
+		Constraints:   cons,
+		Tools:         possibleTools,
+		MachineConfig: machineConfig,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machineConfig.Tools.Version.Arch, gc.Equals, arch.PPC64EL)
+}
+
 func (s *lxcBrokerSuite) TestStartInstanceWithBridgeEnviron(c *gc.C) {
 	s.agentConfig.SetValue(agent.LxcBridge, "br0")
 	machineId := "1/lxc/0"


### PR DESCRIPTION
Fixes: lp:1420049

(Review request: http://reviews.vapour.ws/r/985/)