### PR TITLE
Fixed lp:1424669 - api/networker tests fail to build on ppc64

### DIFF
--- a/api/networker/export_test.go
+++ b/api/networker/export_test.go
@@ -10,6 +10,7 @@ import (
 // PatchFacadeCall patches the State's facade such that
 // FacadeCall method calls are diverted to the provided
 // function.
-func PatchFacadeCall(p testing.Patcher, st *State, f func(request string, params, response interface{}) error) {
-	testing.PatchFacadeCall(p, &st.facade, f)
+func PatchFacadeCall(p testing.Patcher, st State, f func(request string, params, response interface{}) error) {
+	st0 := st.(*state) // *state is the only implementation of State.
+	testing.PatchFacadeCall(p, &st0.facade, f)
 }

--- a/api/networker/networker_test.go
+++ b/api/networker/networker_test.go
@@ -36,7 +36,7 @@ type networkerSuite struct {
 	nestedContainerIfaces []state.NetworkInterfaceInfo
 
 	st        *api.State
-	networker *networker.State
+	networker networker.State
 }
 
 var _ = gc.Suite(&networkerSuite{})

--- a/api/state.go
+++ b/api/state.go
@@ -194,7 +194,7 @@ func (st *State) Machiner() *machiner.State {
 
 // Networker returns a version of the state that provides functionality
 // required by the networker worker.
-func (st *State) Networker() *networker.State {
+func (st *State) Networker() networker.State {
 	return networker.NewState(st)
 }
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1309,7 +1309,7 @@ func (s *MachineSuite) TestMachineAgentNetworkerMode(c *gc.C) {
 
 		modeCh := make(chan bool, 1)
 		s.AgentSuite.PatchValue(&newNetworker, func(
-			st *apinetworker.State,
+			st apinetworker.State,
 			conf agent.Config,
 			intrusiveMode bool,
 			configBaseDir string,

--- a/worker/networker/networker.go
+++ b/worker/networker/networker.go
@@ -34,7 +34,7 @@ const DefaultConfigBaseDir = "/etc/network"
 type Networker struct {
 	tomb tomb.Tomb
 
-	st  *apinetworker.State
+	st  apinetworker.State
 	tag names.MachineTag
 
 	// isVLANSupportInstalled is set to true when the VLAN kernel
@@ -80,7 +80,7 @@ var _ worker.Worker = (*Networker)(nil)
 // configuration. If there is no <configBasePath>/interfaces file, an
 // error is returned.
 func NewNetworker(
-	st *apinetworker.State,
+	st apinetworker.State,
 	agentConfig agent.Config,
 	intrusiveMode bool,
 	configBaseDir string,

--- a/worker/networker/networker_test.go
+++ b/worker/networker/networker_test.go
@@ -41,7 +41,7 @@ type networkerSuite struct {
 	lastCommands          chan []string
 
 	apiState  *api.State
-	apiFacade *apinetworker.State
+	apiFacade apinetworker.State
 }
 
 var _ = gc.Suite(&networkerSuite{})
@@ -411,7 +411,7 @@ func (s *networkerSuite) executeCommandsHook(c *gc.C, commands []string) error {
 
 func (s *networkerSuite) newCustomNetworker(
 	c *gc.C,
-	facade *apinetworker.State,
+	facade apinetworker.State,
 	machineId string,
 	intrusiveMode bool,
 	initInterfaces bool,


### PR DESCRIPTION
The "trick" I found that fixes the issue is to export the *State type in
the api/networker package as interface.

Tested on both amd64 (gc compiler) and ppc64el (gccgo compiler)
machines.

(Review request: http://reviews.vapour.ws/r/986/)