### PR TITLE
Remove unnecessary apt quoting

### DIFF
--- a/cloudinit/sshinit/configure.go
+++ b/cloudinit/sshinit/configure.go
@@ -214,11 +214,6 @@ func addPackageCommands(cfg *cloudinit.Config) ([]string, error) {
 	}
 	for _, pkg := range cfg.Packages() {
 		cmds = append(cmds, cloudinit.LogProgressCmd("Installing package: %s", pkg))
-		if !strings.Contains(pkg, "--target-release") {
-			// We only need to shquote the package name if it does not
-			// contain additional arguments.
-			pkg = utils.ShQuote(pkg)
-		}
 		cmd := fmt.Sprintf(aptget+"install %s", pkg)
 		cmds = append(cmds, cmd)
 	}


### PR DESCRIPTION
I don't know why we were quoting the apt-get package list. When more than one apt package is installed on the one command line, it fails. So removing the unnecessary quoting.

(Review request: http://reviews.vapour.ws/r/988/)