### PR TITLE
Run Actions while the uniter is in ModeHookError

### DIFF
--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -313,6 +313,11 @@ func ModeHookError(u *Uniter) (next Mode, err error) {
 				return nil, errors.Trace(err)
 			}
 			return ModeContinue, nil
+		case action := <-u.f.ActionEvents():
+			if err := u.runOperation(newActionOp(action.ActionId)); err != nil {
+				return nil, errors.Trace(err)
+			}
+			continue
 		}
 	}
 }

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -76,6 +76,10 @@ type State struct {
 	// RunAction, it holds the running action.
 	ActionId *string `yaml:"action-id,omitempty"`
 
+	// ActionContinuation holds the Kind that the operation should return
+	// when the action is complete.
+	ActionContinuation Kind `yaml:"action-continuation,omitempty"`
+
 	// Charm describes the charm being deployed by an Install or Upgrade
 	// operation, and is otherwise blank.
 	CharmURL *charm.URL `yaml:"charm,omitempty"`
@@ -145,11 +149,12 @@ func (st State) CollectedMetricsAt() time.Time {
 
 // stateChange is useful for a variety of Operation implementations.
 type stateChange struct {
-	Kind     Kind
-	Step     Step
-	Hook     *hook.Info
-	ActionId *string
-	CharmURL *charm.URL
+	Kind               Kind
+	Step               Step
+	Hook               *hook.Info
+	ActionId           *string
+	ActionContinuation Kind
+	CharmURL           *charm.URL
 }
 
 func (change stateChange) apply(state State) *State {
@@ -157,6 +162,7 @@ func (change stateChange) apply(state State) *State {
 	state.Step = change.Step
 	state.Hook = change.Hook
 	state.ActionId = change.ActionId
+	state.ActionContinuation = change.ActionContinuation
 	state.CharmURL = change.CharmURL
 	return &state
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1451,7 +1451,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			}}},
 			waitUnit{status: params.StatusActive},
 		), ut(
-			"actions are not attempted from ModeHookError and do not clear the error",
+			"actions may run from ModeHookError, but do not clear the error",
 			startupErrorWithCustomCharm{
 				badHook: "start",
 				customize: func(c *gc.C, ctx *context, path string) {
@@ -1467,7 +1467,18 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 					"hook": "start",
 				},
 			},
-			verifyNoActionResults{},
+			waitActionResults{[]actionResult{{
+				name:    "action-log",
+				results: map[string]interface{}{},
+				status:  params.ActionCompleted,
+			}}},
+			waitUnit{
+				status: params.StatusError,
+				info:   `hook failed: "start"`,
+				data: map[string]interface{}{
+					"hook": "start",
+				},
+			},
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
 			waitUnit{status: params.StatusActive},


### PR DESCRIPTION
 Allow Actions to run while the unit is in hook error mode, without
 clearing the hook error.

(Review request: http://reviews.vapour.ws/r/992/)