### PR TITLE
state/metricsmanager: Added new metricsmanager collection

### DIFF
--- a/apiserver/metricsender/mocksender.go
+++ b/apiserver/metricsender/mocksender.go
@@ -31,3 +31,14 @@ func (m *MockSender) Send(d []*wireformat.MetricBatch) (*wireformat.Response, er
 		EnvResponses: envResponses,
 	}, nil
 }
+
+// ErrorSender implements the metric sender interface and is used
+// to return errors during testing
+type ErrorSender struct {
+	Err error
+}
+
+// Send implements the Send interface returning errors specified in the ErrorSender.
+func (e *ErrorSender) Send(d []*wireformat.MetricBatch) (*wireformat.Response, error) {
+	return &wireformat.Response{}, e.Err
+}

--- a/apiserver/metricsmanager/metricsmanager.go
+++ b/apiserver/metricsmanager/metricsmanager.go
@@ -6,6 +6,8 @@
 package metricsmanager
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
@@ -38,6 +40,8 @@ type MetricsManager interface {
 type MetricsManagerAPI struct {
 	state *state.State
 
+	store *state.MetricsManager
+
 	accessEnviron common.GetAuthFunc
 }
 
@@ -63,9 +67,22 @@ func NewMetricsManagerAPI(
 		}, nil
 	}
 
+	var store *state.MetricsManager
+	var err error
+	store, err = st.GetMetricsManager()
+	if err != nil && err == state.MetricsManagerNotFoundError {
+		store, err = st.NewMetricsManager()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return &MetricsManagerAPI{
 		state:         st,
 		accessEnviron: accessEnviron,
+		store:         store,
 	}, nil
 }
 
@@ -129,7 +146,22 @@ func (api *MetricsManagerAPI) SendMetrics(args params.Entities) (params.ErrorRes
 		err = metricsender.SendMetrics(api.state, sender, maxBatchesPerSend)
 		if err != nil {
 			err = errors.Annotate(err, "failed to send metrics")
+			logger.Errorf(err.Error())
 			result.Results[i].Error = common.ServerError(err)
+			if incErr := api.store.IncrementConsecutiveErrors(); incErr != nil {
+				logger.Warningf("failed to increment error count with error %v, after sending error: %v", incErr, err)
+			}
+		} else {
+			if err := api.store.SetNoConsecutiveErrors(); err != nil {
+				err = errors.Annotate(err, "failed to reset consecutive errors count")
+				logger.Errorf(err.Error())
+				result.Results[i].Error = common.ServerError(err)
+			}
+			if err := api.store.SetMetricsManagerSuccessfulSend(time.Now()); err != nil {
+				err = errors.Annotate(err, "failed to set successful send time")
+				logger.Errorf(err.Error())
+				result.Results[i].Error = common.ServerError(err)
+			}
 		}
 	}
 	return result, nil

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -172,7 +172,7 @@ func (s *metricsManagerSuite) TestMeterStatusOnConsecutiveErrors(c *gc.C) {
 	}}
 	_, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
-	mm, err := s.State.GetMetricsManager()
+	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mm.ConsecutiveErrors(), gc.Equals, 1)
 }
@@ -188,7 +188,20 @@ func (s *metricsManagerSuite) TestMeterStatusSuccessfulSend(c *gc.C) {
 	}}
 	_, err := s.metricsmanager.SendMetrics(args)
 	c.Assert(err, jc.ErrorIsNil)
-	mm, err := s.State.GetMetricsManager()
+	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mm.LastSuccessfulSend().After(pastTime), jc.IsTrue)
+}
+
+func (s *metricsManagerSuite) TestLastSuccessfulNotSentIfNothingToSend(c *gc.C) {
+	var sender metricsender.MockSender
+	metricsmanager.PatchSender(&sender)
+	args := params.Entities{Entities: []params.Entity{
+		{s.State.EnvironTag().String()},
+	}}
+	_, err := s.metricsmanager.SendMetrics(args)
+	c.Assert(err, jc.ErrorIsNil)
+	mm, err := s.State.MetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.LastSuccessfulSend().Equal(time.Time{}), jc.IsTrue)
 }

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -159,3 +159,36 @@ func (s *metricsManagerSuite) TestSendArgsIndependent(c *gc.C) {
 	c.Assert(result.Results[0], gc.DeepEquals, params.ErrorResult{Error: expectedError})
 	c.Assert(result.Results[1], gc.DeepEquals, params.ErrorResult{Error: nil})
 }
+
+func (s *metricsManagerSuite) TestMeterStatusOnConsecutiveErrors(c *gc.C) {
+	var sender metricsender.ErrorSender
+	sender.Err = errors.New("an error")
+	now := time.Now()
+	metric := state.Metric{"pings", "5", now}
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: []state.Metric{metric}})
+	metricsmanager.PatchSender(&sender)
+	args := params.Entities{Entities: []params.Entity{
+		{s.State.EnvironTag().String()},
+	}}
+	_, err := s.metricsmanager.SendMetrics(args)
+	c.Assert(err, jc.ErrorIsNil)
+	mm, err := s.State.GetMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.ConsecutiveErrors(), gc.Equals, 1)
+}
+
+func (s *metricsManagerSuite) TestMeterStatusSuccessfulSend(c *gc.C) {
+	var sender metricsender.MockSender
+	pastTime := time.Now().Add(-time.Second)
+	metric := state.Metric{"pings", "5", pastTime}
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &pastTime, Metrics: []state.Metric{metric}})
+	metricsmanager.PatchSender(&sender)
+	args := params.Entities{Entities: []params.Entity{
+		{s.State.EnvironTag().String()},
+	}}
+	_, err := s.metricsmanager.SendMetrics(args)
+	c.Assert(err, jc.ErrorIsNil)
+	mm, err := s.State.GetMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.LastSuccessfulSend().After(pastTime), jc.IsTrue)
+}

--- a/state/metricsmanager.go
+++ b/state/metricsmanager.go
@@ -1,0 +1,188 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+var metricsManagerLogger = loggo.GetLogger("juju.state.metricsmanager")
+
+const (
+	defaultGracePeriod = 7 * 24 * time.Hour // 1 week in hours
+	metricsManagerKey  = "metricsManagerKey"
+)
+
+var (
+	MetricsManagerNotFoundError = errors.New("cannot create new metrics manager - only one allowed")
+)
+
+// MetricsManager stores data about the state of the metrics manager
+type MetricsManager struct {
+	st  *State
+	doc metricsManagerDoc
+}
+
+type metricsManagerDoc struct {
+	LastSuccessfulSend time.Time     `bson:"lastsuccessfulsend"`
+	ConsecutiveErrors  int           `bson:"consecutiveerrors"`
+	GracePeriod        time.Duration `bson:"graceperiod"`
+}
+
+// LastSuccessfulSend returns the time of the last successful send.
+func (m *MetricsManager) LastSuccessfulSend() time.Time {
+	return m.doc.LastSuccessfulSend
+}
+
+// ConsecutiveErrors returns the number of consecutive failures.
+func (m *MetricsManager) ConsecutiveErrors() int {
+	return m.doc.ConsecutiveErrors
+}
+
+// GracePeriodSeconds returns the current grace period.
+func (m *MetricsManager) GracePeriod() time.Duration {
+	return m.doc.GracePeriod
+}
+
+// NewMetricsManager returns a new MetricsManager
+// As only one can ever exist an error is returned if one already exists.
+func (st *State) NewMetricsManager() (*MetricsManager, error) {
+	mm := &MetricsManager{
+		st: st,
+		doc: metricsManagerDoc{
+			LastSuccessfulSend: time.Time{},
+			ConsecutiveErrors:  0,
+			GracePeriod:        defaultGracePeriod,
+		}}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			coll, closer := st.getCollection(metricsManagerC)
+			defer closer()
+			n, err := coll.Find(bson.D{{"_id", metricsManagerKey}}).Count()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if n > 0 {
+				return nil, MetricsManagerNotFoundError
+			}
+		}
+		return []txn.Op{{
+			C:      metricsManagerC,
+			Id:     metricsManagerKey,
+			Assert: txn.DocMissing,
+		}, {
+			C:      metricsManagerC,
+			Id:     metricsManagerKey,
+			Assert: txn.DocMissing,
+			Insert: mm.doc,
+		},
+		}, nil
+	}
+
+	err := st.run(buildTxn)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return mm, nil
+}
+
+// GetMetricsManager returns an existing metrics manager if one exists.
+func (st *State) GetMetricsManager() (*MetricsManager, error) {
+	coll, closer := st.getCollection(metricsManagerC)
+	defer closer()
+	n, err := coll.Find(bson.D{{"_id", metricsManagerKey}}).Count()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if n == 0 {
+		return nil, MetricsManagerNotFoundError
+	}
+	var doc metricsManagerDoc
+	err = coll.Find(bson.D{{"_id", metricsManagerKey}}).One(&doc)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &MetricsManager{st: st, doc: doc}, nil
+}
+
+func (m *MetricsManager) updateMetricsManagerOps(update bson.M) error {
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			coll, closer := m.st.getCollection(metricsManagerC)
+			defer closer()
+			n, err := coll.Find(bson.D{{"_id", metricsManagerKey}}).Count()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if n == 0 {
+				return nil, errors.New("no existing metrics manager object")
+			}
+		}
+		return []txn.Op{{
+			C:      metricsManagerC,
+			Id:     metricsManagerKey,
+			Assert: txn.DocExists,
+			Update: update,
+		}}, nil
+	}
+	return m.st.run(buildTxn)
+}
+
+// SetMetricsManagerSuccessfulSend sets the last successful send time to the input time.
+func (m *MetricsManager) SetMetricsManagerSuccessfulSend(t time.Time) error {
+	err := m.updateMetricsManagerOps(
+		bson.M{"$set": bson.M{"lastsuccessfulsend": t}},
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	m.doc.LastSuccessfulSend = t
+	return nil
+}
+
+// IncrementConsecutiveErrors adds 1 to the consecutive errors count.
+func (m *MetricsManager) IncrementConsecutiveErrors() error {
+	err := m.updateMetricsManagerOps(
+		bson.M{"$inc": bson.M{"consecutiveerrors": 1}},
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	m.doc.ConsecutiveErrors++
+	return nil
+}
+
+// SetNoConsecutiveErrors resets the consecutive errors back to 0.
+func (m *MetricsManager) SetNoConsecutiveErrors() error {
+	err := m.updateMetricsManagerOps(
+		bson.M{"$set": bson.M{"consecutiveerrors": 0}},
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	m.doc.ConsecutiveErrors = 0
+	return nil
+}
+
+func (m *MetricsManager) gracePeriodExceeded() bool {
+	now := time.Now()
+	t := m.LastSuccessfulSend().Add(m.GracePeriod())
+	return t.Before(now) || t.Equal(now)
+}
+
+// MeterStatus returns the overall state of the MetricsManager as a meter status summary.
+func (m *MetricsManager) MeterStatus() (code, info string) {
+	if m.ConsecutiveErrors() < 3 {
+		return "GREEN", "metrics manager state ok"
+	}
+	if m.gracePeriodExceeded() {
+		return "RED", "failed to send metrics to collector - exceeded grace period"
+	}
+	return "AMBER", "failed to send metrics to collector - still in grace period"
+}

--- a/state/metricsmanager_test.go
+++ b/state/metricsmanager_test.go
@@ -1,0 +1,96 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"time"
+
+	testing "github.com/juju/juju/state/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type metricsManagerSuite struct {
+	testing.StateSuite
+}
+
+var _ = gc.Suite(&metricsManagerSuite{})
+
+func (s *metricsManagerSuite) TestDefaultsWritten(c *gc.C) {
+	mm, err := s.State.NewMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.LastSuccessfulSend(), gc.DeepEquals, time.Time{})
+	c.Assert(mm.ConsecutiveErrors(), gc.Equals, 0)
+	c.Assert(mm.GracePeriod(), gc.Equals, 24*7*time.Hour)
+}
+
+func (s *metricsManagerSuite) TestCannotAddMultipleDocs(c *gc.C) {
+	_, err := s.State.NewMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.NewMetricsManager()
+	c.Assert(err, gc.ErrorMatches, "cannot create new metrics manager - only one allowed")
+}
+
+func (s *metricsManagerSuite) TestSetMetricsManagerSuccesfulSend(c *gc.C) {
+	mm, err := s.State.NewMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	now := time.Now().Round(time.Second)
+	err = mm.SetMetricsManagerSuccessfulSend(now)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.LastSuccessfulSend(), gc.DeepEquals, now)
+
+	m, err := s.State.GetMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.LastSuccessfulSend(), gc.DeepEquals, now)
+}
+
+func (s *metricsManagerSuite) TestIncrementConsecutiveErrors(c *gc.C) {
+	mm, err := s.State.NewMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.ConsecutiveErrors(), gc.Equals, 0)
+	err = mm.IncrementConsecutiveErrors()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.ConsecutiveErrors(), gc.Equals, 1)
+
+	m, err := s.State.GetMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.ConsecutiveErrors(), gc.Equals, 1)
+}
+
+func (s *metricsManagerSuite) TestSetNoConsecutiveErrors(c *gc.C) {
+	mm, err := s.State.NewMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	err = mm.IncrementConsecutiveErrors()
+	c.Assert(err, jc.ErrorIsNil)
+	err = mm.SetNoConsecutiveErrors()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mm.ConsecutiveErrors(), gc.Equals, 0)
+
+	m, err := s.State.GetMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.ConsecutiveErrors(), gc.Equals, 0)
+}
+
+func (s *metricsManagerSuite) TestMeterStatus(c *gc.C) {
+	mm, err := s.State.NewMetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	code, info := mm.MeterStatus()
+	c.Assert(code, gc.Equals, "GREEN")
+	c.Assert(info, gc.Equals, "metrics manager state ok")
+	now := time.Now()
+	err = mm.SetMetricsManagerSuccessfulSend(now)
+	c.Assert(err, jc.ErrorIsNil)
+	for i := 0; i < 3; i++ {
+		err := mm.IncrementConsecutiveErrors()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	code, info = mm.MeterStatus()
+	c.Assert(code, gc.Equals, "AMBER")
+	c.Assert(info, gc.Equals, "failed to send metrics to collector - still in grace period")
+	err = mm.SetMetricsManagerSuccessfulSend(now.Add(-(24 * 7 * time.Hour)))
+	c.Assert(err, jc.ErrorIsNil)
+	code, info = mm.MeterStatus()
+	c.Assert(code, gc.Equals, "RED")
+	c.Assert(info, gc.Equals, "failed to send metrics to collector - exceeded grace period")
+}

--- a/state/state.go
+++ b/state/state.go
@@ -76,6 +76,7 @@ const (
 	stateServersC          = "stateServers"
 	openedPortsC           = "openedPorts"
 	metricsC               = "metrics"
+	metricsManagerC        = "metricsmanager"
 	upgradeInfoC           = "upgradeInfo"
 	rebootC                = "reboot"
 	blockDevicesC          = "blockdevices"


### PR DESCRIPTION
Implemented storage for the metricsmanager.

apiserver/metricsmanager will update the state/metricsmanager.

At the moment MeterStatus isn't changed - but a MeterStatus function implemented in state/metricsmanager details how the metrics manager state can be summarised in this format

(Review request: http://reviews.vapour.ws/r/994/)