### PR TITLE
Fixed lp:1424777 - add cloud-tools archive for precise compatible with

### DIFF
--- a/cloudinit/cloudinit_test.go
+++ b/cloudinit/cloudinit_test.go
@@ -245,7 +245,7 @@ var ctests = []struct {
 	{
 		"Packages with --target-release",
 		map[string]interface{}{"packages": []string{
-			"--target-release 'precise-updates/cloud-tools' 'mongodb-server'",
+			"--target-release precise-updates/cloud-tools mongodb-server",
 		}},
 		func(cfg *cloudinit.Config) {
 			cfg.AddPackageFromTargetRelease("mongodb-server", "precise-updates/cloud-tools")
@@ -389,7 +389,7 @@ func (S) TestPackages(c *gc.C) {
 	expectedPackages := []string{"a b c", "d!"}
 	c.Assert(cfg.Packages(), gc.DeepEquals, expectedPackages)
 	cfg.AddPackageFromTargetRelease("package", "series")
-	expectedPackages = append(expectedPackages, "--target-release 'series' 'package'")
+	expectedPackages = append(expectedPackages, "--target-release series package")
 	c.Assert(cfg.Packages(), gc.DeepEquals, expectedPackages)
 }
 

--- a/cloudinit/options.go
+++ b/cloudinit/options.go
@@ -145,7 +145,7 @@ func (cfg *Config) AddPackage(name string) {
 // the given release, passed to apt-get with the --target-release
 // argument.
 func (cfg *Config) AddPackageFromTargetRelease(packageName, targetRelease string) {
-	cfg.AddPackage(fmt.Sprintf("--target-release '%s' '%s'", targetRelease, packageName))
+	cfg.AddPackage(fmt.Sprintf("--target-release %s %s", targetRelease, packageName))
 }
 
 // Packages returns a list of packages that will be

--- a/cloudinit/sshinit/configure.go
+++ b/cloudinit/sshinit/configure.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 
@@ -212,7 +213,31 @@ func addPackageCommands(cfg *cloudinit.Config) ([]string, error) {
 		cmds = append(cmds, cloudinit.LogProgressCmd("Running apt-get upgrade"))
 		cmds = append(cmds, aptget+"upgrade")
 	}
-	for _, pkg := range cfg.Packages() {
+	pkgs := cfg.Packages()
+	skipNext := 0
+	for i, pkg := range pkgs {
+		if skipNext > 0 {
+			skipNext--
+			continue
+		}
+		// Make sure the cloud-init 0.6.3 hack (for precise) where
+		// --target-release and precise-updates/cloud-tools are
+		// specified as separate packages is converted to a single
+		// package argument below.
+		if pkg == "--target-release" {
+			// There has to be at least 2 more items - the target
+			// release (e.g. "precise-updates/cloud-tools") and the
+			// package name.
+			if i+2 >= len(pkgs) {
+				remaining := strings.Join(pkgs[:i], " ")
+				return nil, errors.Errorf(
+					"invalid package %q: expected --target-release <release> <package>",
+					remaining,
+				)
+			}
+			pkg = strings.Join(pkgs[i:i+2], " ")
+			skipNext = 2
+		}
 		cmds = append(cmds, cloudinit.LogProgressCmd("Installing package: %s", pkg))
 		cmd := fmt.Sprintf(aptget+"install %s", pkg)
 		cmds = append(cmds, cmd)

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -63,6 +63,14 @@ func templateUserData(
 	config.AddScripts(
 		"set -xe", // ensure we run all the scripts or abort.
 	)
+	// For LTS series which need support for the cloud-tools archive,
+	// we need to enable apt-get update regardless of the environ
+	// setting, otherwise provisioning will fail.
+	if series == "precise" && !enablePackageUpdates {
+		logger.Warningf("series %q requires cloud-tools archive: enabling updates", series)
+		enablePackageUpdates = true
+	}
+
 	config.AddSSHAuthorizedKeys(authorizedKeys)
 	if enablePackageUpdates {
 		cloudinit.MaybeAddCloudArchiveCloudTools(config, series)


### PR DESCRIPTION
old cloud-init

This addresses various related issues with provisioning precise
machines. See http://pad.lv/1424777 for details.

Makes installing packages from the cloud-tools archive for precise
compatible with cloud-init 0.6.3 in precise. Also works for newer
versions.

Live tested extensively:

 1. bootstrapping a local environment on a trusty amd64 machine
 2. add-machine --series [precise,quantal,raring,saucy,trusty,utopic,vivid]
 3. bootstrapping a local environment on precise, then 2.
 4. bootstrapping a manual environment on trusty, then another on
 precise.
 5. adding trusty and precise machines manually into 4.
 6. with maas - bootstrapping on trusty, adding a precise machine.
 7. upgrading from 1.22-beta4 to 1.23 tip in the environments from 1, 3.

(Review request: http://reviews.vapour.ws/r/998/)