### PR TITLE
Update juju/testing dependency for windows envvar case fix

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T10:00:34Z
-github.com/juju/testing	git	f1ccdbd59a031083676e23cdae08a8699a5dba15	2015-02-05T10:00:34Z
+github.com/juju/testing	git	c230cbad7c023a242f209d66c247d90a6c584460	2015-02-24T17:18:53Z
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	2014-09-25T11:49:22Z
 github.com/juju/utils	git	3efdaa3f15cc47ee83f6c03f640dc14f5915e289	2015-02-05T10:00:34Z
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z


### PR DESCRIPTION
Picks up the fix made to OsEnvSuite which is used by juju.

<https://github.com/juju/testing/pull/52>

The hope is this will fix some of the failing windows tests under CI.

(Review request: http://reviews.vapour.ws/r/999/)