### PR TITLE
Disable pinger tests on i386

### DIFF
--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -1,6 +1,11 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// TODO(wallyworld) bug http://pad.lv/1408459
+// Re-enable tests for i386 when these tests are fixed to work on that architecture.
+
+// +build !386
+
 package apiserver_test
 
 import (


### PR DESCRIPTION
As discussed with Curtis, these tests will be re-enabled once the suite can pass reliably on i386.

(Review request: http://reviews.vapour.ws/r/1003/)