### PR TITLE
Disabled failing openstack provider tests on PPC64EL - 1.23

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -227,6 +227,8 @@ func (s *localServerSuite) TearDownTest(c *gc.C) {
 // If the bootstrap node is configured to require a public IP address,
 // bootstrapping fails if an address cannot be allocated.
 func (s *localServerSuite) TestBootstrapFailsWhenPublicIPError(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
 	cleanup := s.srv.Service.Nova.RegisterControlPoint(
 		"addFloatingIP",
 		func(sc hook.ServiceControl, args ...interface{}) error {
@@ -449,6 +451,8 @@ func (s *localServerSuite) TestStopInstance(c *gc.C) {
 // environment. If this is the case, the attempt to delete the instance's
 // security group fails but StopInstance succeeds.
 func (s *localServerSuite) TestStopInstanceSecurityGroupNotDeleted(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
 	// Force an error when a security group is deleted.
 	cleanup := s.srv.Service.Nova.RegisterControlPoint(
 		"removeSecurityGroup",
@@ -643,6 +647,8 @@ func (s *localServerSuite) TestInstancesGatheringWithFloatingIP(c *gc.C) {
 }
 
 func (s *localServerSuite) TestCollectInstances(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
 	env := s.Prepare(c)
 	cleanup := s.srv.Service.Nova.RegisterControlPoint(
 		"addServer",
@@ -667,6 +673,8 @@ func (s *localServerSuite) TestCollectInstances(c *gc.C) {
 }
 
 func (s *localServerSuite) TestInstancesBuildSpawning(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
 	env := s.Prepare(c)
 	// HP servers are available once they are BUILD(spawning).
 	cleanup := s.srv.Service.Nova.RegisterControlPoint(
@@ -692,6 +700,8 @@ func (s *localServerSuite) TestInstancesBuildSpawning(c *gc.C) {
 }
 
 func (s *localServerSuite) TestInstancesShutoffSuspended(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
 	env := s.Prepare(c)
 	cleanup := s.srv.Service.Nova.RegisterControlPoint(
 		"addServer",
@@ -1106,6 +1116,8 @@ func (s *localHTTPSServerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *localHTTPSServerSuite) TestMustDisableSSLVerify(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
 	// If you don't have ssl-hostname-verification set to false, then we
 	// fail to connect to the environment. Copy the attrs used by SetUp and
 	// force hostname verification.
@@ -1481,6 +1493,8 @@ func (t *localServerSuite) TestStartInstanceDistribution(c *gc.C) {
 }
 
 func (t *localServerSuite) TestStartInstancePicksValidZoneForHost(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
 	t.srv.Service.Nova.SetAvailabilityZones(
 		// bootstrap node will be on az1.
 		nova.AvailabilityZone{
@@ -1525,6 +1539,8 @@ func (t *localServerSuite) TestStartInstancePicksValidZoneForHost(c *gc.C) {
 }
 
 func (t *localServerSuite) TestStartInstanceWithUnknownAZError(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
 	t.srv.Service.Nova.SetAvailabilityZones(
 		// bootstrap node will be on az1.
 		nova.AvailabilityZone{

--- a/testing/base.go
+++ b/testing/base.go
@@ -4,7 +4,9 @@
 package testing
 
 import (
+	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/juju/loggo"
@@ -13,6 +15,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/wrench"
@@ -63,6 +66,15 @@ func (s *JujuOSEnvSuite) TearDownTest(c *gc.C) {
 	}
 	utils.SetHome(s.oldHomeEnv)
 	osenv.SetJujuHome(s.oldJujuHome)
+}
+
+// SkipIfPPC64 skips the test if the arch is PPC64EL and the compiler
+// is gccgo.
+func SkipIfPPC64EL(c *gc.C, bugID string) {
+	if runtime.Compiler == "gccgo" &&
+		arch.NormaliseArch(runtime.GOARCH) == arch.PPC64EL {
+		c.Skip(fmt.Sprintf("Test disabled on PPC64EL until fixed - see bug %s", bugID))
+	}
 }
 
 func (s *JujuOSEnvSuite) SetFeatureFlags(flag ...string) {


### PR DESCRIPTION
Forward port of #1678 to 1.23 (trunk).

See http://pad.lv/1425242/

(Review request: http://reviews.vapour.ws/r/1007/)