### PR TITLE
Some helpful logging.

### DIFF
--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -157,7 +157,7 @@ type stopper interface {
 
 // stop stops a stopper.
 func stop(c *gc.C, s stopper) {
-	c.Assert(s.Stop(), gc.IsNil)
+	c.Assert(s.Stop(), jc.ErrorIsNil)
 }
 
 func (s *CommonProvisionerSuite) startUnknownInstance(c *gc.C, id string) instance.Instance {
@@ -422,7 +422,7 @@ func (s *CommonProvisionerSuite) ensureAvailability(c *gc.C, n int) []*state.Mac
 
 func (s *ProvisionerSuite) TestProvisionerStartStop(c *gc.C) {
 	p := s.newEnvironProvisioner(c)
-	c.Assert(p.Stop(), gc.IsNil)
+	c.Assert(p.Stop(), jc.ErrorIsNil)
 }
 
 func (s *ProvisionerSuite) TestSimple(c *gc.C) {


### PR DESCRIPTION
utils.LoggedErrorStack checks to see if a feature flag is set, and if so, it logs out the error stack.  The function also passes through the error untouched.

This is very useful for those error returns that you as a developer really don't expect to fail, and when they do, you want to know why.  Since this is hidden behind a developer feature flag, it makes no difference to any existing or future live site.

(Review request: http://reviews.vapour.ws/r/1013/)