### PR TITLE
Improved ec2 provider networking methods

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -71,7 +71,8 @@ type environ struct {
 	cachedDefaultVpc *defaultVpc
 }
 
-var _ environs.Environ = (*environ)(nil)
+// Ensure EC2 provider supports environs.NetworkingEnviron.
+var _ environs.NetworkingEnviron = (*environ)(nil)
 var _ simplestreams.HasRegion = (*environ)(nil)
 var _ state.Prechecker = (*environ)(nil)
 var _ state.InstanceDistributor = (*environ)(nil)
@@ -699,6 +700,7 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 		if err == nil {
 			break
 		}
+		logger.Tracef("Instances(%q) returned: %v", instId, err)
 	}
 	if err != nil {
 		// either the instance doesn't exist or we couldn't get through to
@@ -707,10 +709,10 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 	}
 
 	if len(instancesResp.Reservations) == 0 {
-		return "", errors.New("unexpected AWS response: instance not found")
+		return "", errors.New("unexpected AWS response: reservation not found")
 	}
 	if len(instancesResp.Reservations[0].Instances) == 0 {
-		return "", errors.New("unexpected AWS response: reservation not found")
+		return "", errors.New("unexpected AWS response: instance not found")
 	}
 	if len(instancesResp.Reservations[0].Instances[0].NetworkInterfaces) == 0 {
 		return "", errors.New("unexpected AWS response: network interface not found")
@@ -719,82 +721,95 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 	return networkInterfaceId, nil
 }
 
-// AllocateAddress requests an address to be allocated for the
-// given instance on the given network. This is not implemented by the
-// EC2 provider yet.
-func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address) error {
+// AllocateAddress requests an address to be allocated for the given
+// instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
+func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
+
+	var nicId string
 	ec2Inst := e.ec2()
-	networkInterfaceId, err := e.fetchNetworkInterfaceId(ec2Inst, instId)
+	nicId, err = e.fetchNetworkInterfaceId(ec2Inst, instId)
 	if err != nil {
-		return errors.Annotatef(err, "failed to assign IP address %q to instance %q", addr, instId)
+		return errors.Trace(err)
 	}
 	for a := shortAttempt.Start(); a.Next(); {
-		err = AssignPrivateIPAddress(ec2Inst, networkInterfaceId, addr)
+		err = AssignPrivateIPAddress(ec2Inst, nicId, addr)
+		logger.Tracef("AssignPrivateIPAddresses(%q, %q) returned: %v", nicId, addr, err)
 		if err == nil {
+			logger.Tracef("allocated address % for instance %q, NIC %q", addr, instId, nicId)
 			break
 		}
 		if ec2Err, ok := err.(*ec2.Error); ok {
 			if ec2Err.Code == invalidParameterValue {
 				// Note: this Code is also used if we specify
 				// an IP address outside the subnet. Take care!
+				logger.Tracef("address %q not available for allocation", addr)
 				return environs.ErrIPAddressUnavailable
 			} else if ec2Err.Code == privateAddressLimitExceeded {
+				logger.Tracef("no more addresses available on the subnet")
 				return environs.ErrIPAddressesExhausted
 			}
 		}
 
 	}
-	if err != nil {
-		return errors.Annotatef(err, "failed to assign IP address %q to instance %q", addr, instId)
-	}
-	return nil
+	return err
 }
 
 // ReleaseAddress releases a specific address previously allocated with
-// AllocateAddress.
-func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) error {
+// AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
+func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	defer errors.DeferredAnnotatef(&err, "failed to release address %q from instance %q", addr, instId)
+
+	var nicId string
 	ec2Inst := e.ec2()
-	networkInterfaceId, err := e.fetchNetworkInterfaceId(ec2Inst, instId)
+	nicId, err = e.fetchNetworkInterfaceId(ec2Inst, instId)
 	if err != nil {
-		return errors.Annotatef(err, "failed to unassign IP address %q to instance %q", addr, instId)
+		return errors.Trace(err)
 	}
 	for a := shortAttempt.Start(); a.Next(); {
-		_, err = ec2Inst.UnassignPrivateIPAddresses(networkInterfaceId, []string{addr.Value})
+		_, err = ec2Inst.UnassignPrivateIPAddresses(nicId, []string{addr.Value})
+		logger.Tracef("UnassignPrivateIPAddresses(%q, %q) returned: %v", nicId, addr, err)
 		if err == nil {
+			logger.Tracef("released address % from instance %q, NIC %q", addr, instId, nicId)
 			break
 		}
-
 	}
-	if err != nil {
-		return errors.Annotatef(err, "failed to unassign IP address %q for instance %q", addr, instId)
-	}
-	return nil
+	return err
 }
 
-// NetworkInterfaces implements Environ.NetworkInterfaces.
+// NetworkInterfaces implements NetworkingEnviron.NetworkInterfaces.
 func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error) {
 	ec2Client := e.ec2()
 	var err error
 	var networkInterfacesResp *ec2.NetworkInterfacesResp
 	for a := shortAttempt.Start(); a.Next(); {
+		logger.Tracef("retrieving NICs for instance %q", instId)
 		filter := ec2.NewFilter()
 		filter.Add("attachment.instance-id", string(instId))
 		networkInterfacesResp, err = ec2Client.NetworkInterfaces(nil, filter)
-		if err == nil {
-			break
+		logger.Tracef("instance %q NICs: %#v (err: %v)", instId, networkInterfacesResp, err)
+		if err != nil {
+			logger.Warningf("failed to get instance %q interfaces: %v (retrying)", instId, err)
+			continue
 		}
+		if len(networkInterfacesResp.Interfaces) == 0 {
+			logger.Tracef("instance %q has no NIC attachment yet, retrying...", instId)
+			continue
+		}
+		logger.Tracef("found instance %q NICS: %#v", instId, networkInterfacesResp.Interfaces)
+		break
 	}
 	if err != nil {
 		// either the instance doesn't exist or we couldn't get through to
 		// the ec2 api
-		return nil, errors.Annotatef(err, "cannot get instance %v network interfaces", instId)
+		return nil, errors.Annotatef(err, "cannot get instance %q network interfaces", instId)
 	}
 	ec2Interfaces := networkInterfacesResp.Interfaces
 	result := make([]network.InterfaceInfo, len(ec2Interfaces))
 	for i, iface := range ec2Interfaces {
 		resp, err := ec2Client.Subnets([]string{iface.SubnetId}, nil)
 		if err != nil {
-			return nil, errors.Annotatef(err, "failed to retrieve subnet %v info", iface.SubnetId)
+			return nil, errors.Annotatef(err, "failed to retrieve subnet %q info", iface.SubnetId)
 		}
 		if len(resp.Subnets) != 1 {
 			return nil, errors.Errorf("expected 1 subnet, got %d", len(resp.Subnets))
@@ -810,11 +825,11 @@ func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo
 			ProviderId:       network.Id(iface.Id),
 			ProviderSubnetId: network.Id(iface.SubnetId),
 			VLANTag:          0, // Not supported on EC2.
-			// Not supported on EC2, so fake it.
+			// Getting the interface name is not supported on EC2, so fake it.
 			InterfaceName: fmt.Sprintf("eth%d", iface.Attachment.DeviceIndex),
 			Disabled:      false,
 			NoAutoStart:   false,
-			ConfigType:    network.ConfigUnknown,
+			ConfigType:    network.ConfigDHCP,
 			Address:       network.NewAddress(iface.PrivateIPAddress, network.ScopeCloudLocal),
 		}
 	}
@@ -822,7 +837,8 @@ func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo
 }
 
 // Subnets returns basic information about the specified subnets known
-// by the provider for the specified instance. subnetIds must not be empty.
+// by the provider for the specified instance. subnetIds must not be
+// empty. Implements NetworkingEnviron.Subnets.
 func (e *environ) Subnets(_ instance.Id, subnetIds []network.Id) ([]network.SubnetInfo, error) {
 	// At some point in the future an empty netIds may mean "fetch all subnets"
 	// but until that functionality is needed it's an error.
@@ -830,24 +846,25 @@ func (e *environ) Subnets(_ instance.Id, subnetIds []network.Id) ([]network.Subn
 		return nil, errors.Errorf("subnetIds must not be empty")
 	}
 	ec2Inst := e.ec2()
-	// TODO: (mfoord 2014-12-15) can we filter by instance ID here?
+	// We can't filter by instance id here, unfortunately.
 	resp, err := ec2Inst.Subnets(nil, nil)
 	if err != nil {
-		return nil, errors.Annotatef(err, "failed to retrieve subnet info")
+		return nil, errors.Annotatef(err, "failed to retrieve subnets")
 	}
 
-	netIdSet := make(map[string]bool)
-	for _, netId := range subnetIds {
-		netIdSet[string(netId)] = false
+	subIdSet := make(map[string]bool)
+	for _, subId := range subnetIds {
+		subIdSet[string(subId)] = false
 	}
 
 	var results []network.SubnetInfo
 	for _, subnet := range resp.Subnets {
-		_, ok := netIdSet[subnet.Id]
+		_, ok := subIdSet[subnet.Id]
 		if !ok {
+			logger.Tracef("subnet %q not in %v, skipping", subnet.Id, subnetIds)
 			continue
 		}
-		netIdSet[subnet.Id] = true
+		subIdSet[subnet.Id] = true
 
 		cidr := subnet.CIDRBlock
 		ip, ipnet, err := net.ParseCIDR(cidr)
@@ -861,7 +878,7 @@ func (e *environ) Subnets(_ instance.Id, subnetIds []network.Id) ([]network.Subn
 			logger.Warningf("skipping subnet %q, invalid IP: %v", cidr, err)
 			continue
 		}
-		// the first four addresses in a subnet are reserved, see
+		// First four addresses in a subnet are reserved, see
 		// http://goo.gl/rrWTIo
 		allocatableLow := network.DecimalToIPv4(start + 4)
 
@@ -869,27 +886,29 @@ func (e *environ) Subnets(_ instance.Id, subnetIds []network.Id) ([]network.Subn
 		zeros := bits - ones
 		numIPs := uint32(1) << uint32(zeros)
 		highIP := start + numIPs - 1
-		// the last address in a subnet is reserved
+		// The last address in a subnet is also reserved (see same
+		// ref).
 		allocatableHigh := network.DecimalToIPv4(highIP - 1)
 
-		// No VLANTag available
 		info := network.SubnetInfo{
 			CIDR:              cidr,
 			ProviderId:        network.Id(subnet.Id),
+			VLANTag:           0, // Not supported on EC2
 			AllocatableIPLow:  allocatableLow,
 			AllocatableIPHigh: allocatableHigh,
 		}
+		logger.Tracef("found subnet with info %#v", info)
 		results = append(results, info)
 	}
 
 	notFound := []string{}
-	for netId, found := range netIdSet {
+	for subId, found := range subIdSet {
 		if !found {
-			notFound = append(notFound, netId)
+			notFound = append(notFound, subId)
 		}
 	}
 	if len(notFound) != 0 {
-		return nil, errors.Errorf("failed to find the following subnets: %v", notFound)
+		return nil, errors.Errorf("failed to find the following subnet ids: %v", notFound)
 	}
 
 	return results, nil

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -814,7 +814,7 @@ func (t *localServerSuite) TestReleaseAddress(c *gc.C) {
 	// Releasing a second time tests that the first call actually released
 	// it plus tests the error handling of ReleaseAddress
 	err = env.ReleaseAddress(instId, "", addr)
-	msg := fmt.Sprintf("failed to unassign IP address \"%v\" for instance \"%v\".*", addr.Value, instId)
+	msg := fmt.Sprintf(`failed to release address "8\.0\.0\.4" from instance %q.*`, instId)
 	c.Assert(err, gc.ErrorMatches, msg)
 }
 
@@ -832,7 +832,7 @@ func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 		InterfaceName:    "eth0",
 		Disabled:         false,
 		NoAutoStart:      false,
-		ConfigType:       "",
+		ConfigType:       network.ConfigDHCP,
 		Address:          network.NewAddress("10.10.0.5", network.ScopeCloudLocal),
 	}}
 	c.Assert(interfaces, jc.DeepEquals, expectedInterfaces)
@@ -866,7 +866,7 @@ func (t *localServerSuite) TestSubnetsMissingSubnet(c *gc.C) {
 	env, _ := t.setUpInstanceWithDefaultVpc(c)
 
 	_, err := env.Subnets("", []network.Id{"subnet-0", "Missing"})
-	c.Assert(err, gc.ErrorMatches, "failed to find the following subnets: \\[Missing\\]")
+	c.Assert(err, gc.ErrorMatches, `failed to find the following subnet ids: \[Missing\]`)
 }
 
 func (t *localServerSuite) TestSupportsAddressAllocationTrue(c *gc.C) {


### PR DESCRIPTION
A few changes to error reporting, logging (including at TRACE level to
make debugging easier later), better compatibility with the way
PrepareContainerInterfaceInfo provisioner api expects the networking
methods to work (SupportsAddressAllocation, AllocateAddress, Subnets,
NetworkInterfaces, ReleaseAddress).

This is a required step towards finishing the addressable containers
features, along with the similar PR #1682 for the MAAS provider.

(Review request: http://reviews.vapour.ws/r/1016/)