### PR TITLE
Add APIs for watching/querying storage attachments

### DIFF
--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -22,11 +22,11 @@ func NewStorageAccessor(facade base.FacadeCaller) *StorageAccessor {
 	return &StorageAccessor{facade}
 }
 
-// StorageAttachments returns the storage instances attached to a unit.
-func (sa *StorageAccessor) StorageAttachments(unitTag names.Tag) ([]params.StorageAttachment, error) {
+// UnitStorageAttachments returns the storage instances attached to a unit.
+func (sa *StorageAccessor) UnitStorageAttachments(unitTag names.UnitTag) ([]params.StorageAttachment, error) {
 	if sa.facade.BestAPIVersion() < 2 {
-		// StorageAttachments() was introduced in UniterAPIV2.
-		return nil, errors.NotImplementedf("StorageAttachments() (need V2+)")
+		// UnitStorageAttachments() was introduced in UniterAPIV2.
+		return nil, errors.NotImplementedf("UnitStorageAttachments() (need V2+)")
 	}
 	args := params.Entities{
 		Entities: []params.Entity{
@@ -34,7 +34,7 @@ func (sa *StorageAccessor) StorageAttachments(unitTag names.Tag) ([]params.Stora
 		},
 	}
 	var results params.StorageAttachmentsResults
-	err := sa.facade.FacadeCall("StorageAttachments", args, &results)
+	err := sa.facade.FacadeCall("UnitStorageAttachments", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -48,13 +48,66 @@ func (sa *StorageAccessor) StorageAttachments(unitTag names.Tag) ([]params.Stora
 	return result.Result, nil
 }
 
-// WatchStorageAttachments starts a watcher for changes to storage
+// WatchUnitStorageAttachments starts a watcher for changes to storage
 // attachments related to the unit. The watcher will return the
 // IDs of the corresponding storage instances.
-func (sa *StorageAccessor) WatchStorageAttachments(unitTag names.UnitTag) (watcher.StringsWatcher, error) {
+func (sa *StorageAccessor) WatchUnitStorageAttachments(unitTag names.UnitTag) (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: unitTag.String()}},
+	}
+	err := sa.facade.FacadeCall("WatchUnitStorageAttachments", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := watcher.NewStringsWatcher(sa.facade.RawAPICaller(), result)
+	return w, nil
+}
+
+// StorageAttachment returns the storage attachment with the specified
+// unit and storage tags.
+func (sa *StorageAccessor) StorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) (params.StorageAttachment, error) {
+	if sa.facade.BestAPIVersion() < 2 {
+		// StorageAttachment() was introduced in UniterAPIV2.
+		return params.StorageAttachment{}, errors.NotImplementedf("StorageAttachment() (need V2+)")
+	}
+	args := params.StorageAttachmentIds{
+		Ids: []params.StorageAttachmentId{{
+			StorageTag: storageTag.String(),
+			UnitTag:    unitTag.String(),
+		}},
+	}
+	var results params.StorageAttachmentResults
+	err := sa.facade.FacadeCall("StorageAttachments", args, &results)
+	if err != nil {
+		return params.StorageAttachment{}, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return params.StorageAttachment{}, result.Error
+	}
+	return result.Result, nil
+}
+
+// WatchStorageAttachments start a watcher for changes to the storage
+// attachment with the specified unit and storage tags.
+func (sa *StorageAccessor) WatchStorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) (watcher.NotifyWatcher, error) {
+	var results params.NotifyWatchResults
+	args := params.StorageAttachmentIds{
+		Ids: []params.StorageAttachmentId{{
+			StorageTag: storageTag.String(),
+			UnitTag:    unitTag.String(),
+		}},
 	}
 	err := sa.facade.FacadeCall("WatchStorageAttachments", args, &results)
 	if err != nil {
@@ -67,6 +120,6 @@ func (sa *StorageAccessor) WatchStorageAttachments(unitTag names.UnitTag) (watch
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	w := watcher.NewStringsWatcher(sa.facade.RawAPICaller(), result)
+	w := watcher.NewNotifyWatcher(sa.facade.RawAPICaller(), result)
 	return w, nil
 }

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -21,7 +21,7 @@ type storageSuite struct {
 	coretesting.BaseSuite
 }
 
-func (s *storageSuite) TestStorageAttachments(c *gc.C) {
+func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	storageAttachments := []params.StorageAttachment{{
 		StorageTag: "storage-whatever-0",
 		OwnerTag:   "service-mysql",
@@ -35,7 +35,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 		c.Check(objType, gc.Equals, "Uniter")
 		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "StorageAttachments")
+		c.Check(request, gc.Equals, "UnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
 			Entities: []params.Entity{{Tag: "unit-mysql-0"}},
 		})
@@ -50,7 +50,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 	})
 
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	attachments, err := st.StorageAttachments(names.NewUnitTag("mysql/0"))
+	attachments, err := st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
 	c.Assert(attachments, gc.DeepEquals, storageAttachments)
@@ -64,7 +64,9 @@ func (s *storageSuite) TestStorageAttachmentResultCountMismatch(c *gc.C) {
 		return nil
 	})
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	c.Assert(func() { st.StorageAttachments(names.NewUnitTag("mysql/0")) }, gc.PanicMatches, "expected 1 result, got 2")
+	c.Assert(func() {
+		st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
+	}, gc.PanicMatches, "expected 1 result, got 2")
 }
 
 func (s *storageSuite) TestAPIErrors(c *gc.C) {
@@ -72,17 +74,17 @@ func (s *storageSuite) TestAPIErrors(c *gc.C) {
 		return errors.New("bad")
 	})
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	_, err := st.StorageAttachments(names.NewUnitTag("mysql/0"))
+	_, err := st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "bad")
 }
 
-func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
+func (s *storageSuite) TestWatchUnitStorageAttachments(c *gc.C) {
 	var called bool
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")
 		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "WatchStorageAttachments")
+		c.Check(request, gc.Equals, "WatchUnitStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.Entities{
 			Entities: []params.Entity{{Tag: "unit-mysql-0"}},
 		})
@@ -97,7 +99,74 @@ func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
 	})
 
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	_, err := st.WatchStorageAttachments(names.NewUnitTag("mysql/0"))
+	_, err := st.WatchUnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(called, jc.IsTrue)
+}
+
+func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Uniter")
+		c.Check(version, gc.Equals, 2)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchStorageAttachments")
+		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
+			Ids: []params.StorageAttachmentId{{
+				StorageTag: "storage-data-0",
+				UnitTag:    "unit-mysql-0",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.NotifyWatchResults{})
+		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		called = true
+		return nil
+	})
+
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	_, err := st.WatchStorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(called, jc.IsTrue)
+}
+
+func (s *storageSuite) TestStorageAttachments(c *gc.C) {
+	storageAttachment := params.StorageAttachment{
+		StorageTag: "storage-whatever-0",
+		OwnerTag:   "service-mysql",
+		UnitTag:    "unit-mysql-0",
+		Kind:       params.StorageKindBlock,
+		Location:   "/dev/sda",
+	}
+
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Uniter")
+		c.Check(version, gc.Equals, 2)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "StorageAttachments")
+		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
+			Ids: []params.StorageAttachmentId{{
+				StorageTag: "storage-data-0",
+				UnitTag:    "unit-mysql-0",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.StorageAttachmentResults{})
+		*(result.(*params.StorageAttachmentResults)) = params.StorageAttachmentResults{
+			Results: []params.StorageAttachmentResult{{
+				Result: storageAttachment,
+			}},
+		}
+		called = true
+		return nil
+	})
+
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	attachment, err := st.StorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(called, jc.IsTrue)
+	c.Assert(attachment, gc.DeepEquals, storageAttachment)
 }

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -674,5 +674,5 @@ func (u *Unit) WatchMeterStatus() (watcher.NotifyWatcher, error) {
 // WatchStorage returns a watcher for observing changes to the
 // unit's storage attachments.
 func (u *Unit) WatchStorage() (watcher.StringsWatcher, error) {
-	return u.st.WatchStorageAttachments(u.tag)
+	return u.st.WatchUnitStorageAttachments(u.tag)
 }

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -81,6 +81,19 @@ type StorageAttachment struct {
 
 	Kind     StorageKind
 	Location string
+	Life     Life
+}
+
+// StorageAttachmentId identifies a storage attachment by the tags of the
+// related unit and storage instance.
+type StorageAttachmentId struct {
+	StorageTag string `json:"storagetag"`
+	UnitTag    string `json:"unittag"`
+}
+
+// StorageAttachmentIds holds a set of storage attachment identifiers.
+type StorageAttachmentIds struct {
+	Ids []StorageAttachmentId `json:"ids"`
 }
 
 // StorageAttachmentsResult holds the result of an API call to retrieve details
@@ -94,6 +107,19 @@ type StorageAttachmentsResult struct {
 // of multiple units' attached storage instances.
 type StorageAttachmentsResults struct {
 	Results []StorageAttachmentsResult `json:"results,omitempty"`
+}
+
+// StorageAttachmentResult holds the result of an API call to retrieve details
+// of a storage attachment.
+type StorageAttachmentResult struct {
+	Result StorageAttachment `json:"result"`
+	Error  *Error            `json:"error,omitempty"`
+}
+
+// StorageAttachmentResults holds the result of an API call to retrieve details
+// of multiple storage attachments.
+type StorageAttachmentResults struct {
+	Results []StorageAttachmentResult `json:"results,omitempty"`
 }
 
 // Volume describes a storage volume in the environment.

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -12,8 +12,10 @@ import (
 type storageStateInterface interface {
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	StorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
+	StorageAttachment(names.StorageTag, names.UnitTag) (state.StorageAttachment, error)
 	Unit(name string) (*state.Unit, error)
 	WatchStorageAttachments(names.UnitTag) state.StringsWatcher
+	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
 }
 
 type storageStateShim struct {

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
 
@@ -33,8 +34,8 @@ func newStorageAPI(
 	}, nil
 }
 
-// StorageAttachments returns the storage attachments for a collection of units.
-func (s *StorageAPI) StorageAttachments(args params.Entities) (params.StorageAttachmentsResults, error) {
+// UnitStorageAttachments returns the storage attachments for a collection of units.
+func (s *StorageAPI) UnitStorageAttachments(args params.Entities) (params.StorageAttachmentsResults, error) {
 	canAccess, err := s.accessUnit()
 	if err != nil {
 		return params.StorageAttachmentsResults{}, err
@@ -65,30 +66,74 @@ func (s *StorageAPI) getOneUnitStorageAttachments(canAccess common.AuthFunc, uni
 	}
 	var result []params.StorageAttachment
 	for _, stateStorageAttachment := range stateStorageAttachments {
-		info, err := stateStorageAttachment.Info()
+		storageAttachment, err := s.fromStateStorageAttachment(stateStorageAttachment)
 		if errors.IsNotProvisioned(err) {
 			// don't return unprovisioned storage attachments
 			continue
 		} else if err != nil {
 			return nil, err
 		}
-		stateStorageInstance, err := s.st.StorageInstance(stateStorageAttachment.StorageInstance())
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, params.StorageAttachment{
-			stateStorageAttachment.StorageInstance().String(),
-			stateStorageInstance.Owner().String(),
-			unitTag,
-			params.StorageKind(stateStorageInstance.Kind()),
-			info.Location,
-		})
+		result = append(result, storageAttachment)
 	}
 	return result, nil
 }
 
-// WatchStorageAttachments creates storage attachment watchers for a collection of units.
-func (s *StorageAPI) WatchStorageAttachments(args params.Entities) (params.StringsWatchResults, error) {
+func (s *StorageAPI) fromStateStorageAttachment(stateStorageAttachment state.StorageAttachment) (params.StorageAttachment, error) {
+	info, err := stateStorageAttachment.Info()
+	if err != nil {
+		return params.StorageAttachment{}, err
+	}
+	stateStorageInstance, err := s.st.StorageInstance(stateStorageAttachment.StorageInstance())
+	if err != nil {
+		return params.StorageAttachment{}, err
+	}
+	return params.StorageAttachment{
+		stateStorageAttachment.StorageInstance().String(),
+		stateStorageInstance.Owner().String(),
+		stateStorageAttachment.Unit().String(),
+		params.StorageKind(stateStorageInstance.Kind()),
+		info.Location,
+		params.Life(stateStorageAttachment.Life().String()),
+	}, nil
+}
+
+// StorageAttachments returns the storage attachments with the specified tags.
+func (s *StorageAPI) StorageAttachments(args params.StorageAttachmentIds) (params.StorageAttachmentResults, error) {
+	canAccess, err := s.accessUnit()
+	if err != nil {
+		return params.StorageAttachmentResults{}, err
+	}
+	result := params.StorageAttachmentResults{
+		Results: make([]params.StorageAttachmentResult, len(args.Ids)),
+	}
+	for i, id := range args.Ids {
+		storageAttachment, err := s.getOneStorageAttachment(canAccess, id)
+		if err == nil {
+			result.Results[i].Result = storageAttachment
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+func (s *StorageAPI) getOneStorageAttachment(canAccess common.AuthFunc, id params.StorageAttachmentId) (params.StorageAttachment, error) {
+	unitTag, err := names.ParseUnitTag(id.UnitTag)
+	if err != nil || !canAccess(unitTag) {
+		return params.StorageAttachment{}, common.ErrPerm
+	}
+	storageTag, err := names.ParseStorageTag(id.StorageTag)
+	if err != nil {
+		return params.StorageAttachment{}, err
+	}
+	stateStorageAttachment, err := s.st.StorageAttachment(storageTag, unitTag)
+	if errors.IsNotFound(err) {
+		return params.StorageAttachment{}, err
+	}
+	return s.fromStateStorageAttachment(stateStorageAttachment)
+}
+
+// WatchUnitStorageAttachments creates storage attachment watchers for a collection of units.
+func (s *StorageAPI) WatchUnitStorageAttachments(args params.Entities) (params.StringsWatchResults, error) {
 	canAccess, err := s.accessUnit()
 	if err != nil {
 		return params.StringsWatchResults{}, err
@@ -117,6 +162,43 @@ func (s *StorageAPI) watchOneUnitStorageAttachments(tag string, canAccess func(n
 		return params.StringsWatchResult{
 			StringsWatcherId: s.resources.Register(watch),
 			Changes:          changes,
+		}, nil
+	}
+	return nothing, watcher.EnsureErr(watch)
+}
+
+func (s *StorageAPI) WatchStorageAttachments(args params.StorageAttachmentIds) (params.NotifyWatchResults, error) {
+	canAccess, err := s.accessUnit()
+	if err != nil {
+		return params.NotifyWatchResults{}, err
+	}
+	results := params.NotifyWatchResults{
+		Results: make([]params.NotifyWatchResult, len(args.Ids)),
+	}
+	for i, id := range args.Ids {
+		result, err := s.watchOneStorageAttachment(id, canAccess)
+		if err == nil {
+			results.Results[i] = result
+		}
+		results.Results[i].Error = common.ServerError(err)
+	}
+	return results, nil
+}
+
+func (s *StorageAPI) watchOneStorageAttachment(id params.StorageAttachmentId, canAccess func(names.Tag) bool) (params.NotifyWatchResult, error) {
+	nothing := params.NotifyWatchResult{}
+	unitTag, err := names.ParseUnitTag(id.UnitTag)
+	if err != nil || !canAccess(unitTag) {
+		return nothing, common.ErrPerm
+	}
+	storageTag, err := names.ParseStorageTag(id.StorageTag)
+	if err != nil {
+		return nothing, err
+	}
+	watch := s.st.WatchStorageAttachment(storageTag, unitTag)
+	if _, ok := <-watch.Changes(); ok {
+		return params.NotifyWatchResult{
+			NotifyWatcherId: s.resources.Register(watch),
 		}, nil
 	}
 	return nothing, watcher.EnsureErr(watch)

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -167,6 +167,7 @@ func (s *StorageAPI) watchOneUnitStorageAttachments(tag string, canAccess func(n
 	return nothing, watcher.EnsureErr(watch)
 }
 
+// WatchUnitStorageAttachments creates watchers for a collection of storage attachments.
 func (s *StorageAPI) WatchStorageAttachments(args params.StorageAttachmentIds) (params.NotifyWatchResults, error) {
 	canAccess, err := s.accessUnit()
 	if err != nil {

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -63,7 +63,7 @@ func (s *uniterV2Suite) TestStorageAttachments(c *gc.C) {
 	uniter, err := st.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
 
-	attachments, err := uniter.StorageAttachments(unit.Tag())
+	attachments, err := uniter.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attachments, gc.DeepEquals, []params.StorageAttachment{{
 		StorageTag: "storage-data-0",
@@ -71,6 +71,7 @@ func (s *uniterV2Suite) TestStorageAttachments(c *gc.C) {
 		UnitTag:    unit.Tag().String(),
 		Kind:       params.StorageKindBlock,
 		Location:   "outerspace",
+		Life:       "alive",
 	}})
 }
 

--- a/state/storage.go
+++ b/state/storage.go
@@ -440,6 +440,15 @@ func (st *State) StorageAttachments(unit names.UnitTag) ([]StorageAttachment, er
 	return storageAttachments, nil
 }
 
+// StorageAttachment returns the StorageAttachment wit hthe specified tags.
+func (st *State) StorageAttachment(storage names.StorageTag, unit names.UnitTag) (StorageAttachment, error) {
+	att, err := st.storageAttachment(storage, unit)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return att, nil
+}
+
 func (st *State) storageAttachment(storage names.StorageTag, unit names.UnitTag) (*storageAttachment, error) {
 	coll, closer := st.getCollection(storageAttachmentsC)
 	defer closer()

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -323,6 +323,19 @@ func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {
 	wc.AssertNoChange()
 }
 
+func (s *StorageStateSuite) TestWatchStorageAttachment(c *gc.C) {
+	_, u, storageTag := s.setupSingleStorage(c)
+
+	w := s.State.WatchStorageAttachment(storageTag, u.UnitTag())
+	defer testing.AssertStop(c, w)
+	wc := testing.NewNotifyWatcherC(c, s.State, w)
+	wc.AssertOneChange()
+
+	err := s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+}
+
 // TODO(axw) StorageAttachments can't be added to Dying StorageInstance
 // TODO(axw) StorageInstance without attachments is removed by Destroy
 // TODO(axw) StorageInstance becomes Dying when Unit becomes Dying

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1308,6 +1308,11 @@ func (st *State) WatchAPIHostPorts() NotifyWatcher {
 	return newEntityWatcher(st, stateServersC, apiHostPortsKey)
 }
 
+func (st *State) WatchStorageAttachment(storage names.StorageTag, unit names.UnitTag) NotifyWatcher {
+	docID := st.docID(storageAttachmentId(unit.Id(), storage.Id()))
+	return newEntityWatcher(st, storageAttachmentsC, docID)
+}
+
 // WatchConfigSettings returns a watcher for observing changes to the
 // unit's service configuration settings. The unit must have a charm URL
 // set before this method is called, and the returned watcher will be

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -334,7 +334,7 @@ func (f *factory) updateContext(ctx *HookContext) (err error) {
 }
 
 func (f *factory) updateStorage(ctx *HookContext) (err error) {
-	ctx.storageAttachments, err = f.state.StorageAttachments(f.unit.Tag())
+	ctx.storageAttachments, err = f.state.UnitStorageAttachments(f.unit.Tag())
 	return err
 }
 

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -316,6 +316,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 		UnitTag:    unit.Tag().String(),
 		Kind:       params.StorageKindBlock,
 		Location:   "outerspace",
+		Life:       "alive",
 	})
 	s.AssertNotActionContext(c, ctx)
 	s.AssertNotRelationContext(c, ctx)

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -126,6 +126,7 @@ func (c *Context) HookStorageAttachment() (*params.StorageAttachment, bool) {
 		"unit-service-0",
 		params.StorageKindBlock,
 		"/dev/sda",
+		"alive",
 	}, true
 }
 


### PR DESCRIPTION
We already have support in state and the uniter API
for watching the lifecycle states of all storage
attachments for a unit; we now need to be able to
react to non-lifecycle state changes to specific
storage attachments. The uniter will make use of
this function in ~exactly the same way as it does
for relation units, to trigger storage hooks.

(Review request: http://reviews.vapour.ws/r/1019/)