### PR TITLE
Fixed lp:1425807 - functional-ha-backup CI job failure due to backup/restore changes

### DIFF
--- a/cmd/plugins/juju-backup/juju-backup
+++ b/cmd/plugins/juju-backup/juju-backup
@@ -2,7 +2,7 @@
 
 DEPNOTICE='DEPRECATED: Use "juju backups create" instead of "juju backup".'
 
-if [ $1 == "--help" ]; then
+if [ "$1" == "--help" ]; then
 	echo "juju backup"
 	echo ""
 	echo $DEPNOTICE
@@ -11,7 +11,7 @@ if [ $1 == "--help" ]; then
 	exit 0
 fi
 
-if [ $1 == "--description" ]; then
+if [ "$1" == "--description" ]; then
 	echo $DEPNOTICE
 	exit 0
 fi


### PR DESCRIPTION
The culprit most likely is the combination of #1667 (redirecting juju
restore to juju backups restore) and mostly #1596 - causing an early
"exit 1" due to missing quotes around a bash if block, thus confusing
the CI job to think restore (expectedly) failed earlier.

(Review request: http://reviews.vapour.ws/r/1021/)