### PR TITLE
Storage provider defaults

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
-	"github.com/juju/juju/storage/provider/registry"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -2956,10 +2955,10 @@ func (s *clientSuite) setupStoragePool(c *gc.C) {
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
-	registry.RegisterDefaultPool("dummy", storage.StorageKindBlock, "loop-pool")
-	s.AddCleanup(func(_ *gc.C) {
-		registry.RegisterDefaultPool("dummy", storage.StorageKindBlock, "")
-	})
+	err = s.State.UpdateEnvironConfig(map[string]interface{}{
+		"storage-default-block-source": "loop-pool",
+	}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *clientSuite) TestClientAddMachinesWithDisks(c *gc.C) {

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -26,10 +26,8 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
-	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
-	"github.com/juju/juju/storage/provider/registry"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -731,10 +729,10 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	registry.RegisterDefaultPool("dummy", storage.StorageKindBlock, "loop-pool")
-	defer func() {
-		registry.RegisterDefaultPool("dummy", storage.StorageKindBlock, "")
-	}()
+	err = s.State.UpdateEnvironConfig(map[string]interface{}{
+		"storage-default-block-source": "loop-pool",
+	}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("cpu-cores=123 mem=8G networks=^net3,^net4")
 	template := state.MachineTemplate{
@@ -990,10 +988,10 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	registry.RegisterDefaultPool("dummy", storage.StorageKindBlock, "loop-pool")
-	defer func() {
-		registry.RegisterDefaultPool("dummy", storage.StorageKindBlock, "")
-	}()
+	err = s.State.UpdateEnvironConfig(map[string]interface{}{
+		"storage-default-block-source": "loop-pool",
+	}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Provision machine 0 first.
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")

--- a/environs/config.go
+++ b/environs/config.go
@@ -52,6 +52,15 @@ func validateEnvironmentKind(rawEnviron map[string]interface{}) error {
 	return nil
 }
 
+// disallowedWithNew holds those attributes
+// that can not be set in an initial environment
+// config used to bootstrap (they must only be set
+// on a running environment where appropriate
+// validation can be performed).
+var disallowedWithBootstrap = []string{
+	config.StorageDefaultBlockSourceKey,
+}
+
 // Config returns the environment configuration for the environment
 // with the given name. If the configuration is not
 // found, an errors.NotFoundError is returned.
@@ -68,6 +77,13 @@ func (envs *Environs) Config(name string) (*config.Config, error) {
 	}
 	if err := validateEnvironmentKind(attrs); err != nil {
 		return nil, errors.Trace(err)
+	}
+
+	// Check that we don't have any disallowed fields in new configs used for bootstrap.
+	for _, attr := range disallowedWithBootstrap {
+		if _, ok := attrs[attr]; ok {
+			return nil, fmt.Errorf("attribute %q is not allowed in bootstrap configurations", attr)
+		}
 	}
 
 	// If deprecated config attributes are used, log warnings so the user can know

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1326,7 +1326,6 @@ var allowedWithDefaultsOnly = []string{
 	"ca-cert-path",
 	"ca-private-key-path",
 	"authorized-keys-path",
-	StorageDefaultBlockSourceKey,
 }
 
 // mandatoryWithoutDefaults holds those attributes

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -146,6 +146,9 @@ const (
 	// PreventAllChangesKey stores the value for this setting
 	PreventAllChangesKey = BlockKeyPrefix + "all-changes"
 
+	// The default block storage source.
+	StorageDefaultBlockSourceKey = "storage-default-block-source"
+
 	//
 	// Deprecated Settings Attributes
 	//
@@ -1094,6 +1097,11 @@ func (c *Config) DisableNetworkManagement() (bool, bool) {
 	return v, ok
 }
 
+func (c *Config) StorageDefaultBlockSource() (string, bool) {
+	bp := c.asString(StorageDefaultBlockSourceKey)
+	return bp, bp != ""
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1184,6 +1192,7 @@ var fields = schema.Fields{
 	PreventDestroyEnvironmentKey: schema.Bool(),
 	PreventRemoveObjectKey:       schema.Bool(),
 	PreventAllChangesKey:         schema.Bool(),
+	StorageDefaultBlockSourceKey: schema.String(),
 
 	// Deprecated fields, retain for backwards compatibility.
 	ToolsMetadataURLKey:    schema.String(),
@@ -1229,6 +1238,10 @@ var alwaysOptional = schema.Defaults{
 	PreventDestroyEnvironmentKey: DefaultPreventDestroyEnvironment,
 	PreventRemoveObjectKey:       DefaultPreventRemoveObject,
 	PreventAllChangesKey:         DefaultPreventAllChanges,
+
+	// Storage related config.
+	// Environ providers will specify their own defaults.
+	StorageDefaultBlockSourceKey: schema.Omit,
 
 	// Deprecated fields, retain for backwards compatibility.
 	ToolsMetadataURLKey:    "",

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1324,6 +1324,7 @@ var allowedWithDefaultsOnly = []string{
 	"ca-cert-path",
 	"ca-private-key-path",
 	"authorized-keys-path",
+	StorageDefaultBlockSourceKey,
 }
 
 // mandatoryWithoutDefaults holds those attributes

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1097,9 +1097,11 @@ func (c *Config) DisableNetworkManagement() (bool, bool) {
 	return v, ok
 }
 
+// StorageDefaultBlockSource returns the default block storage
+// source for the environment.
 func (c *Config) StorageDefaultBlockSource() (string, bool) {
-	bp := c.asString(StorageDefaultBlockSourceKey)
-	return bp, bp != ""
+	bs := c.asString(StorageDefaultBlockSourceKey)
+	return bs, bs != ""
 }
 
 // UnknownAttrs returns a copy of the raw configuration attributes

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -556,6 +556,14 @@ var configTests = []configTest{
 		},
 		err: `ssl-hostname-verification: expected bool, got string\("yes please"\)`,
 	}, {
+		about:       "default block storage source",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+			"storage-default-block-source": "block-source",
+		},
+	}, {
 		about: fmt.Sprintf(
 			"%s: %s",
 			"provisioner-harvest-mode",

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -556,14 +556,6 @@ var configTests = []configTest{
 		},
 		err: `ssl-hostname-verification: expected bool, got string\("yes please"\)`,
 	}, {
-		about:       "default block storage source",
-		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
-			"storage-default-block-source": "block-source",
-		},
-	}, {
 		about: fmt.Sprintf(
 			"%s: %s",
 			"provisioner-harvest-mode",
@@ -766,6 +758,16 @@ var configTests = []configTest{
 		about:       "No defaults: sample configuration",
 		useDefaults: config.NoDefaults,
 		attrs:       sampleConfig,
+	}, {
+		about:       "No defaults: with storage-default-block-source",
+		useDefaults: config.NoDefaults,
+		attrs:       sampleConfig.Merge(testing.Attrs{"storage-default-block-source": "ebs"}),
+		err:         `attribute "storage-default-block-source" is not allowed in configuration`,
+	}, {
+		about:       "Defaults: with storage-default-block-source",
+		useDefaults: config.UseDefaults,
+		attrs:       sampleConfig.Merge(testing.Attrs{"storage-default-block-source": "ebs"}),
+		err:         `attribute "storage-default-block-source" is not allowed in configuration`,
 	}, {
 		about:       "No defaults: with ca-cert-path",
 		useDefaults: config.NoDefaults,

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -759,16 +759,6 @@ var configTests = []configTest{
 		useDefaults: config.NoDefaults,
 		attrs:       sampleConfig,
 	}, {
-		about:       "No defaults: with storage-default-block-source",
-		useDefaults: config.NoDefaults,
-		attrs:       sampleConfig.Merge(testing.Attrs{"storage-default-block-source": "ebs"}),
-		err:         `attribute "storage-default-block-source" is not allowed in configuration`,
-	}, {
-		about:       "Defaults: with storage-default-block-source",
-		useDefaults: config.UseDefaults,
-		attrs:       sampleConfig.Merge(testing.Attrs{"storage-default-block-source": "ebs"}),
-		err:         `attribute "storage-default-block-source" is not allowed in configuration`,
-	}, {
 		about:       "No defaults: with ca-cert-path",
 		useDefaults: config.NoDefaults,
 		attrs:       sampleConfig.Merge(testing.Attrs{"ca-cert-path": "arble"}),

--- a/environs/config_test.go
+++ b/environs/config_test.go
@@ -307,6 +307,24 @@ func (*suite) TestBootstrapConfig(c *gc.C) {
 	c.Assert(cfg1.AllAttrs(), gc.DeepEquals, expect)
 }
 
+func (s *suite) TestDisallowedInBootstrap(c *gc.C) {
+	content := `
+environments:
+    dummy:
+        type: dummy
+        state-server: false
+`
+	for key, value := range map[string]interface{}{
+		"storage-default-block-source": "loop",
+	} {
+		envContent := fmt.Sprintf("%s\n        %s: %s", content, key, value)
+		envs, err := environs.ReadEnvironsBytes([]byte(envContent))
+		c.Check(err, jc.ErrorIsNil)
+		_, err = envs.Config("dummy")
+		c.Assert(err, gc.ErrorMatches, "attribute .* is not allowed in bootstrap configurations")
+	}
+}
+
 type dummyProvider struct {
 	environs.EnvironProvider
 }

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -110,6 +110,19 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Add EC2 specific defaults.
+	providerDefaults := make(map[string]interface{})
+
+	// Storage.
+	if _, ok := cfg.StorageDefaultBlockSource(); !ok {
+		providerDefaults[config.StorageDefaultBlockSourceKey] = EBS_ProviderType
+	}
+	if len(providerDefaults) > 0 {
+		if cfg, err = cfg.Apply(providerDefaults); err != nil {
+			return nil, err
+		}
+	}
 	ecfg := &environConfig{cfg, validated}
 
 	if ecfg.accessKey() == "" || ecfg.secretKey() == "" {

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -43,17 +43,18 @@ var testAuth = aws.Auth{"gopher", "long teeth"}
 // when mutated by the mutate function, or that the parse matches the
 // given error.
 type configTest struct {
-	config        map[string]interface{}
-	change        map[string]interface{}
-	expect        map[string]interface{}
-	region        string
-	cbucket       string
-	pbucket       string
-	pbucketRegion string
-	accessKey     string
-	secretKey     string
-	firewallMode  string
-	err           string
+	config             map[string]interface{}
+	change             map[string]interface{}
+	expect             map[string]interface{}
+	region             string
+	cbucket            string
+	pbucket            string
+	pbucketRegion      string
+	accessKey          string
+	secretKey          string
+	firewallMode       string
+	blockStorageSource string
+	err                string
 }
 
 type attrs map[string]interface{}
@@ -202,6 +203,14 @@ var configTests = []configTest{
 	}, {
 		config:       attrs{},
 		firewallMode: config.FwInstance,
+	}, {
+		config:             attrs{},
+		blockStorageSource: "ebs",
+	}, {
+		config: attrs{
+			"default-block-storage-source": "ebs-fast",
+		},
+		blockStorageSource: "ebs-fast",
 	}, {
 		config: attrs{
 			"firewall-mode": "instance",

--- a/provider/local/init.go
+++ b/provider/local/init.go
@@ -21,15 +21,4 @@ func init() {
 		providerType,
 		storageprovider.HostLoopProviderType,
 	)
-	// TODO(wallyworld) - implement when available
-	//	registry.RegisterDefaultPool(
-	//		provider.Local,
-	//		storage.StorageKindBlock,
-	//		storageprovider.LoopPool,
-	//	)
-	//	registry.RegisterDefaultPool(
-	//		provider.Local,
-	//		storage.StorageKindFilesystem,
-	//		storageprovider.RootfsPool,
-	//	)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1219,6 +1219,9 @@ func (st *State) AddService(
 	if _, err := st.EnvironmentUser(ownerTag); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if err := addDefaultStorageConstraints(st, storage, ch.Meta()); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if err := validateStorageConstraints(st, storage, ch.Meta()); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/storage.go
+++ b/state/storage.go
@@ -16,9 +16,11 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
+	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
@@ -678,6 +680,17 @@ func readStorageConstraints(st *State, key string) (map[string]StorageConstraint
 	return doc.Constraints, nil
 }
 
+func storageKind(storageType charm.StorageType) storage.StorageKind {
+	kind := storage.StorageKindUnknown
+	switch storageType {
+	case charm.StorageBlock:
+		kind = storage.StorageKindBlock
+	case charm.StorageFilesystem:
+		kind = storage.StorageKindFilesystem
+	}
+	return kind
+}
+
 func validateStorageConstraints(st *State, allCons map[string]StorageConstraints, charmMeta *charm.Meta) error {
 	// TODO(axw) stop checking feature flag once storage has graduated.
 	if !featureflag.Enabled(feature.Storage) {
@@ -707,30 +720,10 @@ func validateStorageConstraints(st *State, allCons map[string]StorageConstraints
 				charmMeta.Name, name, charmStorage.CountMax, cons.Count,
 			)
 		}
-		// TODO - use charm min size when available
-		if cons.Size == 0 {
-			// TODO(axw) this doesn't really belong in a validation
-			// method. We should separate setting defaults from
-			// validating, the latter of which should be non-modifying.
-			cons.Size = 1024
-		}
-		kind := storage.StorageKindUnknown
-		switch charmStorage.Type {
-		case charm.StorageBlock:
-			kind = storage.StorageKindBlock
-		case charm.StorageFilesystem:
-			kind = storage.StorageKindFilesystem
-		}
-		if poolName, err := validateStoragePool(st, cons.Pool, kind); err != nil {
-			if err == ErrNoDefaultStoragePool {
-				err = errors.Maskf(err, "no storage pool specified and no default available for %q storage", name)
-			}
+		kind := storageKind(charmStorage.Type)
+		if err := validateStoragePool(st, cons.Pool, kind); err != nil {
 			return err
-		} else {
-			cons.Pool = poolName
 		}
-		// Replace in case pool or size were updated.
-		allCons[name] = cons
 	}
 	// Ensure all stores have constraints specified. Defaults should have
 	// been set by this point, if the user didn't specify constraints.
@@ -742,26 +735,15 @@ func validateStorageConstraints(st *State, allCons map[string]StorageConstraints
 	return nil
 }
 
-// ErrNoDefaultStoragePool is returned when a storage pool is required but none
-// is specified nor available as a default.
-var ErrNoDefaultStoragePool = fmt.Errorf("no storage pool specifed and no default available")
-
-func validateStoragePool(st *State, poolName string, kind storage.StorageKind) (string, error) {
+func validateStoragePool(st *State, poolName string, kind storage.StorageKind) error {
+	if poolName == "" {
+		return errors.New("pool name is required")
+	}
 	conf, err := st.EnvironConfig()
 	if err != nil {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	}
 	envType := conf.Type()
-	// If no pool specified, use the default if registered.
-	if poolName == "" {
-		defaultPool, ok := registry.DefaultPool(envType, kind)
-		if ok {
-			logger.Infof("no storage pool specified, using default pool %q", defaultPool)
-			poolName = defaultPool
-		} else {
-			return "", ErrNoDefaultStoragePool
-		}
-	}
 	// Ensure the pool type is supported by the environment.
 	var providerType storage.ProviderType
 	pm := poolmanager.New(NewStateSettings(st))
@@ -770,20 +752,90 @@ func validateStoragePool(st *State, poolName string, kind storage.StorageKind) (
 	if errors.IsNotFound(err) {
 		providerType = storage.ProviderType(poolName)
 		if _, err1 := registry.StorageProvider(providerType); err1 != nil {
-			return "", errors.Trace(err)
+			return errors.Trace(err)
 		}
 	} else if err != nil {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	} else {
 		providerType = p.Provider()
 	}
 	if !registry.IsProviderSupported(envType, providerType) {
-		return "", errors.Errorf(
+		return errors.Errorf(
 			"pool %q uses storage provider %q which is not supported for environments of type %q",
 			poolName,
 			providerType,
 			envType,
 		)
 	}
-	return poolName, nil
+	return nil
+}
+
+// ErrNoDefaultStoragePool is returned when a storage pool is required but none
+// is specified nor available as a default.
+var ErrNoDefaultStoragePool = fmt.Errorf("no storage pool specifed and no default available")
+
+// addDefaultStorageConstraints fills in default constraint values, replacing any empty/missing values
+// in the specified constraints.
+func addDefaultStorageConstraints(st *State, allCons map[string]StorageConstraints, charmMeta *charm.Meta) error {
+	// TODO(axw) stop checking feature flag once storage has graduated.
+	if !featureflag.Enabled(feature.Storage) {
+		return nil
+	}
+	conf, err := st.EnvironConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	envType := conf.Type()
+
+	for name, cons := range allCons {
+		charmStorage, ok := charmMeta.Storage[name]
+		if !ok {
+			return errors.Errorf("charm %q has no store called %q", charmMeta.Name, name)
+		}
+		kind := storageKind(charmStorage.Type)
+		var err error
+		cons, err = storageConstraintsWithDefaults(conf, cons, envType, kind)
+		if err != nil {
+			if err == ErrNoDefaultStoragePool {
+				err = errors.Maskf(err, "no storage pool specified and no default available for %q storage", name)
+			}
+			return err
+		}
+		// Replace in case pool or size were updated.
+		allCons[name] = cons
+	}
+	return nil
+}
+
+// storageConstraintsWithDefaults returns a constraints derived from cons, with any defaults filled in.
+func storageConstraintsWithDefaults(cfg *config.Config, cons StorageConstraints, envType string, kind storage.StorageKind) (StorageConstraints, error) {
+	withDefaults := cons
+	if cons.Pool == "" {
+		poolName, err := defaultStoragePool(cfg, envType, kind)
+		if err != nil {
+			return withDefaults, errors.Annotatef(err, "finding default stoage pool")
+		}
+		withDefaults.Pool = poolName
+	}
+	// TODO - use charm min size when available
+	if cons.Size == 0 {
+		withDefaults.Size = 1024
+	}
+	return withDefaults, nil
+}
+
+// defaultStoragePool returns the default storage pool for the environment.
+// The default pool is either user specified, or one that is registered by the provider itself.
+func defaultStoragePool(cfg *config.Config, envType string, kind storage.StorageKind) (string, error) {
+	// First see if there's a user defined default pool.
+	defaultPool := ""
+	ok := false
+	switch kind {
+	case storage.StorageKindBlock:
+		defaultPool, ok = cfg.StorageDefaultBlockSource()
+		if !ok {
+			defaultPool = string(provider.LoopProviderType)
+		}
+	}
+	return defaultPool, nil
 }

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
-	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
@@ -84,7 +83,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsWithoutFeature(c *gc
 	c.Assert(storageConstraints, gc.HasLen, 0)
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraints(c *gc.C) {
+func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block2")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
 		return s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storage)
@@ -95,25 +94,65 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraints(c *gc.C) {
 	}
 	assertErr(nil, `.*no constraints specified for store.*`)
 
-	defer func() {
-		registry.RegisterDefaultPool("someprovider", storage.StorageKindBlock, "")
-	}()
 	storageCons := map[string]state.StorageConstraints{
-		"multi1to10": makeStorageCons("", 1024, 1),
+		"multi1to10": makeStorageCons("block", 1024, 1),
+		"multi2up":   makeStorageCons("block", 1024, 1),
 	}
-	assertErr(storageCons, `cannot add service "storage-block2": no storage pool specified and no default available .*`)
-	registry.RegisterDefaultPool("someprovider", storage.StorageKindBlock, "block")
-	storageCons["multi2up"] = makeStorageCons("", 1024, 1)
 	assertErr(storageCons, `cannot add service "storage-block2": charm "storage-block2" store "multi2up": 2 instances required, 1 specified`)
 	storageCons["multi2up"] = makeStorageCons("block", 1024, 2)
-	storageCons["multi1to10"] = makeStorageCons("", 1024, 11)
+	storageCons["multi1to10"] = makeStorageCons("block", 1024, 11)
 	assertErr(storageCons, `cannot add service "storage-block2": charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified`)
 	storageCons["multi1to10"] = makeStorageCons("ebs", 1024, 10)
 	assertErr(storageCons, `cannot add service "storage-block2": pool "ebs" not found`)
-	storageCons["multi1to10"] = makeStorageCons("", 1024, 10)
+	storageCons["multi1to10"] = makeStorageCons("block", 1024, 10)
 	_, err := addService(storageCons)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, pool string, cons, expect map[string]state.StorageConstraints) {
+	if pool != "" {
+		err := s.State.UpdateEnvironConfig(map[string]interface{}{
+			"storage-default-block-source": pool,
+		}, nil, nil)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	ch := s.AddTestingCharm(c, "storage-block")
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, cons)
+	c.Assert(err, jc.ErrorIsNil)
+	savedCons, err := service.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(savedCons, jc.DeepEquals, expect)
 	// TODO(wallyworld) - test pool name stored in data model
+}
+
+func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultPool(c *gc.C) {
+	storageCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("", 2048, 1),
+	}
+	expectedCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("block", 2048, 1),
+	}
+	s.assertAddServiceStorageConstraintsDefaults(c, "block", storageCons, expectedCons)
+}
+
+func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoUserDefaultPool(c *gc.C) {
+	storageCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("", 2048, 1),
+	}
+	expectedCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("loop", 2048, 1),
+	}
+	s.assertAddServiceStorageConstraintsDefaults(c, "", storageCons, expectedCons)
+}
+
+func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSize(c *gc.C) {
+	storageCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("block", 0, 1),
+	}
+	expectedCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("block", 1024, 1),
+	}
+	s.assertAddServiceStorageConstraintsDefaults(c, "block", storageCons, expectedCons)
 }
 
 func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
@@ -129,10 +168,11 @@ func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
 }
 
 func (s *StorageStateSuite) TestAddUnit(c *gc.C) {
-	registry.RegisterDefaultPool("someprovider", storage.StorageKindBlock, "block")
-	defer func() {
-		registry.RegisterDefaultPool("someprovider", storage.StorageKindBlock, "")
-	}()
+	err := s.State.UpdateEnvironConfig(map[string]interface{}{
+		"storage-default-block-source": "block",
+	}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Each unit added to the service will create storage instances
 	// to satisfy the service's storage constraints.
 	ch := s.AddTestingCharm(c, "storage-block2")

--- a/state/volume.go
+++ b/state/volume.go
@@ -279,10 +279,20 @@ func (st *State) addVolumeOp(params VolumeParams) (txn.Op, names.VolumeTag, erro
 }
 
 func (st *State) validateVolumeParams(params VolumeParams) error {
-	if poolName, err := validateStoragePool(st, params.Pool, storage.StorageKindBlock); err != nil {
+	conf, err := st.EnvironConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	envType := conf.Type()
+	if params.Pool == "" {
+		if poolName, err := defaultStoragePool(conf, envType, storage.StorageKindBlock); err != nil {
+			return err
+		} else {
+			params.Pool = poolName
+		}
+	}
+	if err := validateStoragePool(st, params.Pool, storage.StorageKindBlock); err != nil {
 		return err
-	} else {
-		params.Pool = poolName
 	}
 	if params.Size == 0 {
 		return errors.New("invalid size 0")

--- a/storage/provider/registry/providerregistry.go
+++ b/storage/provider/registry/providerregistry.go
@@ -80,25 +80,3 @@ func IsProviderSupported(envType string, providerType storage.ProviderType) bool
 	}
 	return false
 }
-
-type defaultStoragePool map[storage.StorageKind]string
-
-// defaultPools records the default block and filesystem pools to be
-// used for an environment, if none is specified by the user when deploying.
-var defaultPools map[string]defaultStoragePool = make(map[string]defaultStoragePool)
-
-// RegisterDefaultPool records the default pool for the storage kind and environment.
-// NOTE: the pool is not validated as to whether it exists, or if its type is
-// supported by the environment. This is expected to be done by the caller.
-func RegisterDefaultPool(envType string, kind storage.StorageKind, pool string) {
-	if _, ok := defaultPools[envType]; !ok {
-		defaultPools[envType] = make(defaultStoragePool)
-	}
-	defaultPools[envType][kind] = pool
-}
-
-// DefaultPool returns the default storage pool for the storage kind and environment.
-func DefaultPool(envType string, kind storage.StorageKind) (string, bool) {
-	pool, ok := defaultPools[envType][kind]
-	return pool, ok && pool != ""
-}

--- a/storage/provider/registry/providerregistry_test.go
+++ b/storage/provider/registry/providerregistry_test.go
@@ -78,19 +78,3 @@ func (s *providerRegistrySuite) TestRegisterEnvironProvidersMultipleCalls(c *gc.
 	c.Assert(registry.IsProviderSupported("ec2", ptypeFoo), jc.IsTrue)
 	c.Assert(registry.IsProviderSupported("ec2", ptypeBar), jc.IsTrue)
 }
-
-func (s *providerRegistrySuite) TestDefaultPool(c *gc.C) {
-	registry.RegisterDefaultPool("ec2", storage.StorageKindBlock, "ebs")
-	registry.RegisterDefaultPool("ec2", storage.StorageKindFilesystem, "nfs")
-	registry.RegisterDefaultPool("local", storage.StorageKindFilesystem, "nfs")
-	pool, ok := registry.DefaultPool("ec2", storage.StorageKindBlock)
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(pool, gc.Equals, "ebs")
-	pool, ok = registry.DefaultPool("ec2", storage.StorageKindFilesystem)
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(pool, gc.Equals, "nfs")
-	pool, ok = registry.DefaultPool("local", storage.StorageKindBlock)
-	c.Assert(ok, jc.IsFalse)
-	pool, ok = registry.DefaultPool("maas", storage.StorageKindBlock)
-	c.Assert(ok, jc.IsFalse)
-}


### PR DESCRIPTION
The previous provider registry is replaced by an environment config approach to setting the default storage providers. This PR supports setting defaults for block providers.

There's a common config setting use all env providers: storage-default-block-source
Each provider though sets a provider specific default eg for ec2, it will be "ebs".
The default config policy is omit, in which case "loop" provider is the fallback for all envs.

A followup PR will provide a CLI for setting the default storage source for an environment.
This will validate that the pool name exists etc. It will be disallowed to set the default storage source using env-set.


(Review request: http://reviews.vapour.ws/r/1024/)