### PR TITLE
typo in fmt string

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -770,7 +770,7 @@ func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.
 		_, err = ec2Inst.UnassignPrivateIPAddresses(nicId, []string{addr.Value})
 		logger.Tracef("UnassignPrivateIPAddresses(%q, %q) returned: %v", nicId, addr, err)
 		if err == nil {
-			logger.Tracef("released address % from instance %q, NIC %q", addr, instId, nicId)
+			logger.Tracef("released address %q from instance %q, NIC %q", addr, instId, nicId)
 			break
 		}
 	}


### PR DESCRIPTION
Fixes go vet warning:
```
go version go1.4.2
checking: go fmt ...
checking: go vet ...
provider/ec2/environ.go:773: arg addr for printf verb %f of wrong type: github.com/juju/juju/network.Address
error: failed to push some refs to 'git@github.com:johnweldon/juju'
```

(Review request: http://reviews.vapour.ws/r/1029/)