### PR TITLE
Enable IP forwarding during container init if needed

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -226,9 +226,9 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 		return result, err
 	}
 	if netEnv, ok := environs.SupportsNetworking(env); ok {
-		// Passing subnetId "" below is interpreted by the provider as
-		// "does ANY subnet support this".
-		supported, err := netEnv.SupportsAddressAllocation("")
+		// Passing network.AnySubnet below should be interpreted by
+		// the provider as "does ANY subnet support this".
+		supported, err := netEnv.SupportsAddressAllocation(network.AnySubnet)
 		if err == nil && supported {
 			cfg[container.ConfigIPForwarding] = "true"
 		} else if err != nil {

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -219,6 +219,25 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 	}
 	cfg := make(map[string]string)
 	cfg[container.ConfigName] = container.DefaultNamespace
+
+	// Create an environment to verify networking support.
+	env, err := environs.New(config)
+	if err != nil {
+		return result, err
+	}
+	if netEnv, ok := environs.SupportsNetworking(env); ok {
+		// Passing subnetId "" below is interpreted by the provider as
+		// "does ANY subnet support this".
+		supported, err := netEnv.SupportsAddressAllocation("")
+		if err == nil && supported {
+			cfg[container.ConfigIPForwarding] = "true"
+		} else if err != nil {
+			// We log the error, but it's safe to ignore as it's not
+			// critical.
+			logger.Debugf("address allocation not supported (%v)", err)
+		}
+	}
+
 	switch args.Type {
 	case instance.LXC:
 		if useLxcClone, ok := config.LXCUseClone(); ok {

--- a/container/interface.go
+++ b/container/interface.go
@@ -9,8 +9,15 @@ import (
 )
 
 const (
-	ConfigName       = "name"
-	ConfigLogDir     = "log-dir"
+	ConfigName   = "name"
+	ConfigLogDir = "log-dir"
+
+	// ConfigIPForwarding, if set to a non-empty value, instructs the
+	// container manager to enable IP forwarding as part of the
+	// container initialization. Will be enabled if the enviroment
+	// supports networking.
+	ConfigIPForwarding = "ip-forwarding"
+
 	DefaultNamespace = "juju"
 )
 

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -28,8 +28,10 @@ type Networking interface {
 	NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error)
 
 	// SupportsAddressAllocation returns whether the given subnetId
-	// supports static IP address allocation using AllocateAddress
-	// and ReleaseAddress.
+	// supports static IP address allocation using AllocateAddress and
+	// ReleaseAddress. If subnetId is empty, the provider can decide
+	// whether it can return true or a false and an error (e.g.
+	// "subnetId must be set").
 	SupportsAddressAllocation(subnetId network.Id) (bool, error)
 }
 

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -29,9 +29,9 @@ type Networking interface {
 
 	// SupportsAddressAllocation returns whether the given subnetId
 	// supports static IP address allocation using AllocateAddress and
-	// ReleaseAddress. If subnetId is empty, the provider can decide
-	// whether it can return true or a false and an error (e.g.
-	// "subnetId must be set").
+	// ReleaseAddress. If subnetId is network.AnySubnet, the provider
+	// can decide whether it can return true or a false and an error
+	// (e.g. "subnetId must be set").
 	SupportsAddressAllocation(subnetId network.Id) (bool, error)
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -28,6 +28,11 @@ const (
 // Id defines a provider-specific network id.
 type Id string
 
+// AnySubnet when passed as a subnet id should be interpreted by the
+// providers as "the subnet id does not matter". It's up to the
+// provider how to handle this case - it might return an error.
+const AnySubnet Id = ""
+
 // SubnetInfo describes the bare minimum information for a subnet,
 // which the provider knows about but juju might not yet.
 type SubnetInfo struct {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -206,7 +206,7 @@ func (e *environ) SupportedArchitectures() ([]string, error) {
 }
 
 // SupportsAddressAllocation is specified on environs.Networking.
-func (e *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error) {
+func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
 	_, hasDefaultVpc, err := e.defaultVpc()
 	if err != nil {
 		return false, errors.Trace(err)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -217,7 +217,7 @@ func (env *maasEnviron) SupportedArchitectures() ([]string, error) {
 }
 
 // SupportsAddressAllocation is specified on environs.Networking.
-func (env *maasEnviron) SupportsAddressAllocation(subnetId network.Id) (bool, error) {
+func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
 	caps, err := env.getCapabilities()
 	if err != nil {
 		return false, errors.Annotatef(err, "getCapabilities failed")


### PR DESCRIPTION
Notable changes:

 * Provisioner API - ContainerManagerConfig method changed slightly to
   return a new ConfigIPForward value in the returned map, which is set
   only when the environment supports networking and address allocation.
 * During container initialization, when the LXC/KVM brokers are created
   for the first time, a new function - SetIPForwarding() is called
   depending on the contents of the manager config returned from the
   provisioner API (see above). This method enables IPv4 forwarding on
   the machine immediately and at next boot using sysctl.

Live tested on local (to ensure nothing is changed there as it should)
and EC2 (where it works).

(Review request: http://reviews.vapour.ws/r/1031/)