### PR TITLE
Inadvertent Sprintf %s of function vs. string

### DIFF
--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -174,7 +174,7 @@ func (s *Service) Install() error {
 		return err
 	}
 	if s.Installed() {
-		return errors.New(fmt.Sprintf("Service %s already installed", s.Name))
+		return errors.New(fmt.Sprintf("Service %s already installed", s.Service.Name))
 	}
 
 	logger.Infof("Installing Service %v", s.Name)


### PR DESCRIPTION
Recent changes made s.Name a function rather than a field.

 This fixes warning:

 go version go1.4.2
 checking: go fmt ...
 checking: go vet ...
 service/windows/service.go:177: arg s.Name for printf verb %s of wrong type: func() string
 error: failed to push some refs to 'git@github.com:johnweldon/juju'

(Review request: http://reviews.vapour.ws/r/1034/)