### PR TITLE
Actions no longer need hook.Info in filter

### DIFF
--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -24,7 +24,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/uniter/filter"
-	"github.com/juju/juju/worker/uniter/hook"
 )
 
 type FilterSuite struct {
@@ -429,8 +428,8 @@ func getAssertActionChange(actionC coretesting.ContentAsserterC) func(ids []stri
 		seen := make(map[string]int)
 		for _, id := range ids {
 			expected[id] += 1
-			event := actionC.AssertReceive().(*hook.Info)
-			seen[event.ActionId] += 1
+			actionId := actionC.AssertReceive().(string)
+			seen[actionId] += 1
 		}
 		actionC.C.Assert(seen, jc.DeepEquals, expected)
 

--- a/worker/uniter/filter/interface.go
+++ b/worker/uniter/filter/interface.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/worker/uniter/hook"
 )
 
 // Filter is responsible for delivering events relevant to a unit agent in a
@@ -49,7 +48,7 @@ type Filter interface {
 
 	// ActionEvents returns a channel that will receive a signal whenever the unit
 	// receives new Actions.
-	ActionEvents() <-chan *hook.Info
+	ActionEvents() <-chan string
 
 	// RelationsEvents returns a channel that will receive the ids of all the service's
 	// relations whose Life status has changed.

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -31,10 +31,6 @@ type Info struct {
 	// associated with RemoteUnit. It is only set when RemoteUnit is set.
 	ChangeVersion int64 `yaml:"change-version,omitempty"`
 
-	// ActionId is the state State.actions ID of the Action document to
-	// be retrieved by RunHook.
-	ActionId string `yaml:"action-id,omitempty"`
-
 	// StorageId is the ID of the storage instance relevant to the hook.
 	StorageId string `yaml:"storage-id,omitempty"`
 }
@@ -50,10 +46,7 @@ func (hi Info) Validate() error {
 	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken, hooks.CollectMetrics, hooks.MeterStatusChanged:
 		return nil
 	case hooks.Action:
-		if !names.IsValidAction(hi.ActionId) {
-			return fmt.Errorf("action id %q cannot be parsed as an action tag", hi.ActionId)
-		}
-		return nil
+		return fmt.Errorf("hooks.Kind Action is deprecated")
 	case hooks.StorageAttached, hooks.StorageDetached:
 		// TODO: stop checking feature flag once storage has graduated.
 		if featureflag.Enabled(feature.Storage) {

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -42,11 +42,7 @@ var validateTests = []struct {
 	{hook.Info{Kind: hooks.ConfigChanged}, ""},
 	{hook.Info{Kind: hooks.CollectMetrics}, ""},
 	{hook.Info{Kind: hooks.MeterStatusChanged}, ""},
-	{
-		hook.Info{Kind: hooks.Action},
-		`action id "" cannot be parsed as an action tag`,
-	},
-	{hook.Info{Kind: hooks.Action, ActionId: "badadded-0123-4567-89ab-cdef01234567"}, ""},
+	{hook.Info{Kind: hooks.Action}, "hooks.Kind Action is deprecated"},
 	{hook.Info{Kind: hooks.UpgradeCharm}, ""},
 	{hook.Info{Kind: hooks.Stop}, ""},
 	{hook.Info{Kind: hooks.RelationJoined, RemoteUnit: "x"}, ""},

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -121,8 +121,8 @@ func ModeTerminating(u *Uniter) (next Mode, err error) {
 		select {
 		case <-u.tomb.Dying():
 			return nil, tomb.ErrDying
-		case info := <-u.f.ActionEvents():
-			creator := newActionOp(info.ActionId)
+		case actionId := <-u.f.ActionEvents():
+			creator := newActionOp(actionId)
 			if err := u.runOperation(creator); err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -209,8 +209,8 @@ func modeAbideAliveLoop(u *Uniter) (Mode, error) {
 			return ModeUpgrading(curl), nil
 		case ids := <-u.f.RelationsEvents():
 			creator = newUpdateRelationsOp(ids)
-		case info := <-u.f.ActionEvents():
-			creator = newActionOp(info.ActionId)
+		case actionId := <-u.f.ActionEvents():
+			creator = newActionOp(actionId)
 		case <-u.f.ConfigEvents():
 			creator = newSimpleRunHookOp(hooks.ConfigChanged)
 		case <-u.f.MeterStatusEvents():
@@ -246,8 +246,8 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 		select {
 		case <-u.tomb.Dying():
 			return nil, tomb.ErrDying
-		case info := <-u.f.ActionEvents():
-			creator = newActionOp(info.ActionId)
+		case actionId := <-u.f.ActionEvents():
+			creator = newActionOp(actionId)
 		case <-u.f.ConfigEvents():
 			creator = newSimpleRunHookOp(hooks.ConfigChanged)
 		case hookInfo := <-u.relations.Hooks():

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -138,25 +138,6 @@ var stateTests = []struct {
 			Step: operation.Pending,
 			Hook: relhook,
 		},
-	}, {
-		st: operation.State{
-			Kind: operation.RunHook,
-			Step: operation.Pending,
-			Hook: &hook.Info{
-				Kind:     hooks.Action,
-				ActionId: "feedface-dead-4567-beef-123456789012",
-			},
-		},
-	}, {
-		st: operation.State{
-			Kind: operation.RunHook,
-			Step: operation.Pending,
-			Hook: &hook.Info{
-				Kind:     hooks.Action,
-				ActionId: "foo",
-			},
-		},
-		err: `action id "foo" cannot be parsed as an action tag`,
 	},
 	// Upgrade operation.
 	{


### PR DESCRIPTION
Originally Actions were a special form of Hook, but now they are more distinct and no longer rely on data in hook.Info.  We no longer need the action event in the filter to be a hook.Info struct, and changing clears the way for actions to be able to run cleanly when LastHook is nil

(Review request: http://reviews.vapour.ws/r/1035/)