### PR TITLE
state/watcher: Added metrics manager watcher and a way of combining watchers

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -744,7 +744,7 @@ func (s *unitSuite) TestWatchMeterStatus(c *gc.C) {
 	wc := statetesting.NewNotifyWatcherC(c, s.BackingState, w)
 
 	// Initial event.
-	wc.AssertChanges(2) //Shouldn't have to do this?
+	wc.AssertOneChange()
 
 	err = s.wordpressUnit.SetMeterStatus("GREEN", "ok")
 	c.Assert(err, jc.ErrorIsNil)
@@ -757,16 +757,16 @@ func (s *unitSuite) TestWatchMeterStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
-	mm, err := s.State.NewMetricsManager()
+	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
-	err = mm.SetMetricsManagerSuccessfulSend(time.Now())
+	err = mm.SetLastSuccessfulSend(time.Now())
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 3; i++ {
 		err := mm.IncrementConsecutiveErrors()
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	code, _ := mm.MeterStatus()
-	c.Assert(code, gc.Equals, "AMBER") // Confirm meter status has changed
+	c.Assert(code, gc.Equals, state.MeterAmber) // Confirm meter status has changed
 	wc.AssertOneChange()
 
 	statetesting.AssertStop(c, w)

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -100,6 +100,19 @@ func (c NotifyWatcherC) AssertOneChange() {
 	c.AssertNoChange()
 }
 
+func (c NotifyWatcherC) AssertChanges(n int) {
+	c.State.StartSync()
+	for i := 0; i < n; i++ {
+		select {
+		case _, ok := <-c.Watcher.Changes():
+			c.Assert(ok, jc.IsTrue)
+		case <-time.After(testing.LongWait):
+			c.Fatalf("watcher did not send change")
+		}
+	}
+	c.AssertNoChange()
+}
+
 func (c NotifyWatcherC) AssertClosed() {
 	select {
 	case _, ok := <-c.Watcher.Changes():

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -100,19 +100,6 @@ func (c NotifyWatcherC) AssertOneChange() {
 	c.AssertNoChange()
 }
 
-func (c NotifyWatcherC) AssertChanges(n int) {
-	c.State.StartSync()
-	for i := 0; i < n; i++ {
-		select {
-		case _, ok := <-c.Watcher.Changes():
-			c.Assert(ok, jc.IsTrue)
-		case <-time.After(testing.LongWait):
-			c.Fatalf("watcher did not send change")
-		}
-	}
-	c.AssertNoChange()
-}
-
 func (c NotifyWatcherC) AssertClosed() {
 	select {
 	case _, ok := <-c.Watcher.Changes():


### PR DESCRIPTION
The meter status of a unit now depends on the meter status for the metrics manager. This change combines watchers for these collections into a single watcher

(Review request: http://reviews.vapour.ws/r/1045/)