### PR TITLE
Fix relative paths in init system confs

### DIFF
--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -91,7 +91,7 @@ func shutdownInitScript(initSystem string) (string, error) {
 		Desc:         "Juju lxc template shutdown job",
 		Transient:    true,
 		AfterStopped: "cloud-final",
-		ExecStart:    "shutdown -h now",
+		ExecStart:    "/sbin/shutdown -h now",
 	}
 	svc, err := service.NewService(name, conf, initSystem)
 	if err != nil {

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/service"
-	"github.com/juju/juju/service/common"
 )
 
 var (
@@ -87,12 +86,11 @@ func containerInitSystem() string {
 
 func shutdownInitScript(initSystem string) (string, error) {
 	name := "juju-template-restart"
-	conf := common.Conf{
-		Desc:         "Juju lxc template shutdown job",
-		Transient:    true,
-		AfterStopped: "cloud-final",
-		ExecStart:    "/sbin/shutdown -h now",
+	conf, err := service.ShutdownAfterConf("cloud-final")
+	if err != nil {
+		return "", errors.Trace(err)
 	}
+
 	svc, err := service.NewService(name, conf, initSystem)
 	if err != nil {
 		return "", errors.Trace(err)

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -807,7 +807,7 @@ author "Juju Team <juju@lists.ubuntu.com>"
 start on stopped cloud-final
 
 script
-  shutdown -h now
+  /sbin/shutdown -h now
 end script
 
 post-stop script

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -802,7 +802,7 @@ func (s *LxcSuite) TestShutdownInitScript(c *gc.C) {
 
 	c.Check(script, gc.Equals, `
 cat >> /etc/init/juju-template-restart.conf << 'EOF'
-description "Juju lxc template shutdown job"
+description "juju shutdown job"
 author "Juju Team <juju@lists.ubuntu.com>"
 start on stopped cloud-final
 

--- a/service/agent.go
+++ b/service/agent.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/agent/tools"
@@ -110,4 +111,23 @@ func UnitAgentConf(unitName, dataDir, logDir, os, containerType string) (common.
 	}
 
 	return conf, toolsDir
+}
+
+// ShutdownAfterConf builds a service conf that will cause the host to
+// shut down after the named service stops.
+func ShutdownAfterConf(serviceName string) (common.Conf, error) {
+	if serviceName == "" {
+		return common.Conf{}, errors.New(`missing "after" service name`)
+	}
+	desc := "juju shutdown job"
+	return shutdownAfterConf(serviceName, desc), nil
+}
+
+func shutdownAfterConf(serviceName, desc string) common.Conf {
+	return common.Conf{
+		Desc:         desc,
+		Transient:    true,
+		AfterStopped: serviceName,
+		ExecStart:    "/sbin/shutdown -h now",
+	}
 }

--- a/service/agent_test.go
+++ b/service/agent_test.go
@@ -128,3 +128,22 @@ func (*agentSuite) TestUnitAgentConf(c *gc.C) {
 		Env:       env,
 	})
 }
+
+func (*agentSuite) TestShutdownAfterConf(c *gc.C) {
+	conf, err := service.ShutdownAfterConf("spam")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(conf, jc.DeepEquals, common.Conf{
+		Desc:         "juju shutdown job",
+		Transient:    true,
+		AfterStopped: "spam",
+		ExecStart:    "/sbin/shutdown -h now",
+	})
+	c.Check(conf.Validate(), jc.ErrorIsNil)
+}
+
+func (*agentSuite) TestShutdownAfterConfMissingServiceName(c *gc.C) {
+	_, err := service.ShutdownAfterConf("")
+
+	c.Check(err, gc.ErrorMatches, `.*missing "after" service name.*`)
+}

--- a/service/common/conf.go
+++ b/service/common/conf.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 )
 
@@ -29,11 +31,13 @@ type Conf struct {
 	// Currently not used on Windows.
 	Limit map[string]string
 
-	// ExecStart is the command (with arguments) that will be run.
+	// ExecStart is the command (with arguments) that will be run. The
+	// path to the executable must be absolute.
 	// The command will be restarted if it exits with a non-zero exit code.
 	ExecStart string
 
 	// ExecStopPost is the command that will be run after the service stops.
+	// The path to the executable must be absolute.
 	ExecStopPost string
 
 	// Output, if set, indicates where the service's output should be
@@ -60,8 +64,57 @@ func (c Conf) Validate() error {
 		return errors.New("missing Desc")
 	}
 
+	if err := c.checkExecStart(); err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := c.checkExecStopPost(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+func executable(cmd string) string {
+	path := strings.Fields(cmd)[0]
+	return unquote(path)
+}
+
+func unquote(str string) string {
+	first, last := string(str[0]), string(str[len(str)-1])
+
+	if first == `"` && last == `"` {
+		return str[1 : len(str)-1]
+	}
+
+	if first == "'" && last == "'" {
+		return str[1 : len(str)-1]
+	}
+
+	return str
+}
+
+func (c Conf) checkExecStart() error {
 	if c.ExecStart == "" {
 		return errors.New("missing ExecStart")
+	}
+
+	path := executable(c.ExecStart)
+	if !strings.HasPrefix(path, "/") {
+		return errors.NotValidf("relative path in ExecStart (%s)", path)
+	}
+
+	return nil
+}
+
+func (c Conf) checkExecStopPost() error {
+	if c.ExecStopPost == "" {
+		return nil
+	}
+
+	path := executable(c.ExecStopPost)
+	if !strings.HasPrefix(path, "/") {
+		return errors.NotValidf("relative path in ExecStopPost (%s)", path)
 	}
 
 	return nil

--- a/service/common/conf_test.go
+++ b/service/common/conf_test.go
@@ -27,6 +27,36 @@ func (*confSuite) TestValidateOkay(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
+func (*confSuite) TestValidateSingleQuotedExecutable(c *gc.C) {
+	conf := common.Conf{
+		Desc:      "some service",
+		ExecStart: "'/path/to/some-command' a b c",
+	}
+	err := conf.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (*confSuite) TestValidateDoubleQuotedExecutable(c *gc.C) {
+	conf := common.Conf{
+		Desc:      "some service",
+		ExecStart: `"/path/to/some-command" a b c`,
+	}
+	err := conf.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (*confSuite) TestValidatePartiallyQuotedExecutable(c *gc.C) {
+	conf := common.Conf{
+		Desc:      "some service",
+		ExecStart: "'/path/to/some-command a b c'",
+	}
+	err := conf.Validate()
+
+	c.Check(err, gc.ErrorMatches, `.*relative path in ExecStart \(.*`)
+}
+
 func (*confSuite) TestValidateMissingDesc(c *gc.C) {
 	conf := common.Conf{
 		ExecStart: "/path/to/some-command a b c",

--- a/service/common/conf_test.go
+++ b/service/common/conf_test.go
@@ -20,7 +20,7 @@ var _ = gc.Suite(&confSuite{})
 func (*confSuite) TestValidateOkay(c *gc.C) {
 	conf := common.Conf{
 		Desc:      "some service",
-		ExecStart: "<do something>",
+		ExecStart: "/path/to/some-command a b c",
 	}
 	err := conf.Validate()
 
@@ -29,7 +29,7 @@ func (*confSuite) TestValidateOkay(c *gc.C) {
 
 func (*confSuite) TestValidateMissingDesc(c *gc.C) {
 	conf := common.Conf{
-		ExecStart: "<do something>",
+		ExecStart: "/path/to/some-command a b c",
 	}
 	err := conf.Validate()
 
@@ -43,4 +43,25 @@ func (*confSuite) TestValidateMissingExecStart(c *gc.C) {
 	err := conf.Validate()
 
 	c.Check(err, gc.ErrorMatches, ".*missing ExecStart.*")
+}
+
+func (*confSuite) TestValidateRelativeExecStart(c *gc.C) {
+	conf := common.Conf{
+		Desc:      "some service",
+		ExecStart: "some-command a b c",
+	}
+	err := conf.Validate()
+
+	c.Check(err, gc.ErrorMatches, `.*relative path in ExecStart \(.*`)
+}
+
+func (*confSuite) TestValidateRelativeExecStopPost(c *gc.C) {
+	conf := common.Conf{
+		Desc:         "some service",
+		ExecStart:    "/path/to/some-command a b c",
+		ExecStopPost: "some-other-command a b c",
+	}
+	err := conf.Validate()
+
+	c.Check(err, gc.ErrorMatches, `.*relative path in ExecStopPost \(.*`)
 }

--- a/service/common/service_test.go
+++ b/service/common/service_test.go
@@ -22,7 +22,7 @@ func (*serviceSuite) TestValidateOkay(c *gc.C) {
 		Name: "a-service",
 		Conf: common.Conf{
 			Desc:      "some service",
-			ExecStart: "<do something>",
+			ExecStart: "/path/to/some-command x y z",
 		},
 	}
 	err := service.Validate()
@@ -34,7 +34,7 @@ func (*serviceSuite) TestValidateMissingName(c *gc.C) {
 	service := common.Service{
 		Conf: common.Conf{
 			Desc:      "some service",
-			ExecStart: "<do something>",
+			ExecStart: "/path/to/some-command x y z",
 		},
 	}
 	err := service.Validate()
@@ -46,7 +46,7 @@ func (*serviceSuite) TestValidateMissingDesc(c *gc.C) {
 	service := common.Service{
 		Name: "a-service",
 		Conf: common.Conf{
-			ExecStart: "<do something>",
+			ExecStart: "/path/to/some-command x y z",
 		},
 	}
 	err := service.Validate()

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -28,7 +28,7 @@ func (*serviceSuite) TestDiscoverService(c *gc.C) {
 	name := "a-service"
 	conf := common.Conf{
 		Desc:      "some service",
-		ExecStart: "<do something>",
+		ExecStart: "/path/to/some-command",
 	}
 	svc, err := service.DiscoverService(name, conf)
 	c.Assert(err, jc.ErrorIsNil)

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -63,10 +63,13 @@ func validate(name string, conf common.Conf) error {
 		return errors.NotValidf("missing service name")
 	}
 
-	if conf.ExecStart == "" {
-		return errors.NotValidf("missing ExecStart")
-	} else if !strings.HasPrefix(conf.ExecStart, "/") {
-		return errors.NotValidf("relative path in ExecStart")
+	if conf.ExecStopPost != "" {
+		// TODO(ericsnow) This needs to be sorted out.
+		return errors.NotSupportedf("Conf.ExecStopPost")
+	}
+
+	if err := conf.Validate(); err != nil {
+		return errors.Trace(err)
 	}
 
 	if conf.ExtraScript != "" {
@@ -92,15 +95,6 @@ func validate(name string, conf common.Conf) error {
 	if conf.AfterStopped != "" {
 		// TODO(ericsnow) This needs to be sorted out.
 		return errors.NotSupportedf("Conf.AfterStopped")
-	}
-
-	if conf.ExecStopPost != "" {
-		// TODO(ericsnow) This needs to be sorted out.
-		return errors.NotSupportedf("Conf.ExecStopPost")
-
-		if !strings.HasPrefix(conf.ExecStopPost, "/") {
-			return errors.NotValidf("relative path in ExecStopPost")
-		}
 	}
 
 	return nil

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -47,7 +47,7 @@ func (s *UpstartSuite) SetUpTest(c *gc.C) {
 		"some-service",
 		common.Conf{
 			Desc:      "some service",
-			ExecStart: "some command",
+			ExecStart: "/path/to/some-command",
 		},
 	)
 }
@@ -105,7 +105,7 @@ func (s *UpstartSuite) TestExists(c *gc.C) {
 
 func (s *UpstartSuite) TestExistsNonEmpty(c *gc.C) {
 	s.goodInstall(c)
-	s.service.Service.Conf.ExecStart = "something else"
+	s.service.Service.Conf.ExecStart = "/path/to/other-command"
 	c.Assert(s.service.Exists(), jc.IsFalse)
 }
 
@@ -196,7 +196,7 @@ func (s *UpstartSuite) TestInstallErrors(c *gc.C) {
 	check("missing Desc")
 	s.service.Service.Conf.Desc = "this is an upstart service"
 	check("missing ExecStart")
-	s.service.Service.Conf.ExecStart = "<a command>"
+	s.service.Service.Conf.ExecStart = "/a/command"
 	check("missing InitDir")
 }
 
@@ -211,7 +211,7 @@ normal exit 0
 func (s *UpstartSuite) dummyConf(c *gc.C) common.Conf {
 	return common.Conf{
 		Desc:      "this is an upstart service",
-		ExecStart: "do something",
+		ExecStart: "/path/to/some-command x y z",
 		InitDir:   s.initDir,
 	}
 }
@@ -242,19 +242,45 @@ func (s *UpstartSuite) assertInstall(c *gc.C, conf common.Conf, expectEnd string
 
 func (s *UpstartSuite) TestInstallSimple(c *gc.C) {
 	conf := s.dummyConf(c)
-	s.assertInstall(c, conf, "\n\nscript\n\n\n  exec do something\nend script\n")
+	s.assertInstall(c, conf, `
+
+script
+
+
+  exec /path/to/some-command x y z
+end script
+`)
 }
 
 func (s *UpstartSuite) TestInstallExtraScript(c *gc.C) {
 	conf := s.dummyConf(c)
 	conf.ExtraScript = "extra lines of script"
-	s.assertInstall(c, conf, "\n\nscript\nextra lines of script\n\n  exec do something\nend script\n")
+	s.assertInstall(c, conf, `
+
+script
+extra lines of script
+
+  exec /path/to/some-command x y z
+end script
+`)
 }
 
 func (s *UpstartSuite) TestInstallOutput(c *gc.C) {
 	conf := s.dummyConf(c)
 	conf.Output = "/some/output/path"
-	s.assertInstall(c, conf, "\n\nscript\n\n\n  # Ensure log files are properly protected\n  touch /some/output/path\n  chown syslog:syslog /some/output/path\n  chmod 0600 /some/output/path\n\n  exec do something >> /some/output/path 2>&1\nend script\n")
+	s.assertInstall(c, conf, `
+
+script
+
+
+  # Ensure log files are properly protected
+  touch /some/output/path
+  chown syslog:syslog /some/output/path
+  chmod 0600 /some/output/path
+
+  exec /path/to/some-command x y z >> /some/output/path 2>&1
+end script
+`)
 }
 
 func (s *UpstartSuite) TestInstallEnv(c *gc.C) {
@@ -267,7 +293,7 @@ env QUX="ping pong"
 script
 
 
-  exec do something
+  exec /path/to/some-command x y z
 end script
 `)
 }
@@ -282,7 +308,7 @@ limit nproc 20000 20000
 script
 
 
-  exec do something
+  exec /path/to/some-command x y z
 end script
 `)
 }


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1427210)

The patch to add systemd support to juju did not take into account that executable paths may be quoted.  This patch addresses the situation.

(Review request: http://reviews.vapour.ws/r/1047/)