### PR TITLE
New juju environment get/set-constraints subcommand

### DIFF
--- a/cmd/juju/environment/constraints.go
+++ b/cmd/juju/environment/constraints.go
@@ -1,0 +1,89 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environment
+
+import (
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/constraints"
+)
+
+const getConstraintsDoc = `
+environment get-constraints returns a list of constraints that have been set on the
+environment using juju environment set-constraints.  You can also view constraints
+set for a specific service by using juju service get-constraints <service>.
+
+See Also:
+   juju help constraints
+   juju environment help set-constraints
+`
+
+const setConstraintsDoc = `
+set-constraints sets machine constraints on the system, which are used as the
+default constraints for all new machines provisioned in the environment (unless
+overridden).  You can also set constraints on a specific service by using
+juju service set-constraints.
+
+Constraints set on a service are combined with environment constraints for
+commands (such as juju deploy) that provision machines for services.  Where
+environment and service constraints overlap, the service constraints take
+precedence.
+
+Example:
+
+   juju environment set-constraints mem=8G                         (all new machines in the environment must have at least 8GB of RAM)
+
+See Also:
+   juju help constraints
+   juju environment help get-constraints
+   juju help deploy
+   juju machine help add
+   juju help add-unit
+`
+
+// EnvGetConstraintsCommand shows the constraints for an environment.
+// It is just a wrapper for the common GetConstraintsCommand and
+// enforces that no service arguments are passed in.
+type EnvGetConstraintsCommand struct {
+	common.GetConstraintsCommand
+}
+
+func (c *EnvGetConstraintsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "get-constraints",
+		Purpose: "view constraints on the environment",
+		Doc:     getConstraintsDoc,
+	}
+}
+
+func (c *EnvGetConstraintsCommand) Init(args []string) error {
+	return cmd.CheckEmpty(args)
+}
+
+// EnvSetConstraintsCommand sets the constraints for an environment.
+// It is just a wrapper for the common SetConstraintsCommand and
+// enforces that no service arguments are passed in.
+type EnvSetConstraintsCommand struct {
+	common.SetConstraintsCommand
+}
+
+func (c *EnvSetConstraintsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "set-constraints",
+		Args:    "[key=[value] ...]",
+		Purpose: "set constraints on the environment",
+		Doc:     setConstraintsDoc,
+	}
+}
+
+// SetFlags overrides SetFlags for SetConstraintsCommand since that
+// will register a flag to specify the service.
+func (c *EnvSetConstraintsCommand) SetFlags(f *gnuflag.FlagSet) {}
+
+func (c *EnvSetConstraintsCommand) Init(args []string) (err error) {
+	c.Constraints, err = constraints.Parse(args...)
+	return err
+}

--- a/cmd/juju/environment/constraints.go
+++ b/cmd/juju/environment/constraints.go
@@ -12,18 +12,26 @@ import (
 )
 
 const getConstraintsDoc = `
-environment get-constraints returns a list of constraints that have been set on the
-environment using juju environment set-constraints.  You can also view constraints
+Shows a list of constraints that have been set on the environment
+using juju environment set-constraints.  You can also view constraints
 set for a specific service by using juju service get-constraints <service>.
+
+Constraints set on a service are combined with environment constraints for
+commands (such as juju deploy) that provision machines for services.  Where
+environment and service constraints overlap, the service constraints take
+precedence.
 
 See Also:
    juju help constraints
    juju environment help set-constraints
+   juju help deploy
+   juju machine help add
+   juju help add-unit
 `
 
 const setConstraintsDoc = `
-set-constraints sets machine constraints on the system, which are used as the
-default constraints for all new machines provisioned in the environment (unless
+Sets machine constraints on the environment, which are used as the default
+constraints for all new machines provisioned in the environment (unless
 overridden).  You can also set constraints on a specific service by using
 juju service set-constraints.
 

--- a/cmd/juju/environment/constraints_test.go
+++ b/cmd/juju/environment/constraints_test.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environment_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/environment"
+	"github.com/juju/juju/testing"
+)
+
+type EnvConstraintsCommandsSuite struct {
+	testing.FakeJujuHomeSuite
+}
+
+var _ = gc.Suite(&EnvConstraintsCommandsSuite{})
+
+func (s *EnvConstraintsCommandsSuite) TestSetInit(c *gc.C) {
+	for _, test := range []struct {
+		args []string
+		err  string
+	}{
+		{
+			args: []string{"-s", "mysql"},
+			err:  "flag provided but not defined: -s",
+		}, {
+			args: []string{"="},
+			err:  `malformed constraint "="`,
+		}, {
+			args: []string{"cpu-power=250"},
+		},
+	} {
+		err := testing.InitCommand(&environment.EnvSetConstraintsCommand{}, test.args)
+		if test.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}
+
+func (s *EnvConstraintsCommandsSuite) TestGetInit(c *gc.C) {
+	for _, test := range []struct {
+		args []string
+		err  string
+	}{
+		{
+			args: []string{"-s", "mysql"},
+			err:  "flag provided but not defined: -s",
+		}, {
+			args: []string{"mysql"},
+			err:  `unrecognized args: \["mysql"\]`,
+		}, {
+			args: []string{},
+		},
+	} {
+		err := testing.InitCommand(&environment.EnvGetConstraintsCommand{}, test.args)
+		if test.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}

--- a/cmd/juju/environment/environment.go
+++ b/cmd/juju/environment/environment.go
@@ -32,6 +32,9 @@ func NewSuperCommand() cmd.Command {
 	environmentCmd.Register(envcmd.Wrap(&UnsetCommand{}))
 	environmentCmd.Register(&JenvCommand{})
 	environmentCmd.Register(envcmd.Wrap(&RetryProvisioningCommand{}))
+	environmentCmd.Register(envcmd.Wrap(&EnvSetConstraintsCommand{}))
+	environmentCmd.Register(envcmd.Wrap(&EnvGetConstraintsCommand{}))
+
 	if featureflag.Enabled(feature.JES) {
 		environmentCmd.Register(envcmd.Wrap(&CreateCommand{}))
 	}

--- a/cmd/juju/environment/environment_test.go
+++ b/cmd/juju/environment/environment_test.go
@@ -21,10 +21,12 @@ var _ = gc.Suite(&EnvironmentCommandSuite{})
 
 var expectedCommmandNames = []string{
 	"get",
+	"get-constraints",
 	"help",
 	"jenv",
 	"retry-provisioning",
 	"set",
+	"set-constraints",
 	"unset",
 }
 

--- a/cmd/juju/environment_test.go
+++ b/cmd/juju/environment_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -98,4 +99,30 @@ func (s *EnvironmentSuite) TestCreate(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(testing.Stdout(context), gc.Equals, "")
 	c.Check(testing.Stderr(context), gc.Equals, "")
+}
+
+func uint64p(val uint64) *uint64 {
+	return &val
+}
+
+func (s *EnvironmentSuite) TestGetConstraints(c *gc.C) {
+	cons := constraints.Value{CpuPower: uint64p(250)}
+	err := s.State.SetEnvironConstraints(cons)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx, err := s.RunEnvironmentCommand(c, "get-constraints")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(testing.Stdout(ctx), gc.Equals, "cpu-power=250\n")
+}
+
+func (s *EnvironmentSuite) TestSetConstraints(c *gc.C) {
+	_, err := s.RunEnvironmentCommand(c, "set-constraints", "mem=4G", "cpu-power=250")
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := s.State.EnvironConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.DeepEquals, constraints.Value{
+		CpuPower: uint64p(250),
+		Mem:      uint64p(4096),
+	})
 }


### PR DESCRIPTION
The core functionality for get/set-constraints resides
in the juju/juju/cmd/juju/common directory, and implements
constraints commands for both environments and services.

The get/set-constraints subcommands for environment only
need to enforce that service constraints are not set or
retrieved through that command.

The docs for these subcommands reference the soon-to-be-
created service supercommand, which will be in a separate
patch later this week.

(Review request: http://reviews.vapour.ws/r/1049/)