### PR TITLE
logsink api endpoint

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -320,6 +320,11 @@ func (srv *Server) run(lis net.Listener) {
 			httpHandler: httpHandler{ssState: srv.state},
 			logDir:      srv.logDir},
 	)
+	handleAll(mux, "/environment/:envuuid/logsink",
+		&logSinkHandler{
+			httpHandler: httpHandler{ssState: srv.state},
+		},
+	)
 	handleAll(mux, "/environment/:envuuid/charms",
 		&charmsHandler{
 			httpHandler: httpHandler{ssState: srv.state},

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -19,10 +19,12 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/state"
@@ -320,11 +322,13 @@ func (srv *Server) run(lis net.Listener) {
 			httpHandler: httpHandler{ssState: srv.state},
 			logDir:      srv.logDir},
 	)
-	handleAll(mux, "/environment/:envuuid/logsink",
-		&logSinkHandler{
-			httpHandler: httpHandler{ssState: srv.state},
-		},
-	)
+	if featureflag.Enabled(feature.DbLog) {
+		handleAll(mux, "/environment/:envuuid/logsink",
+			&logSinkHandler{
+				httpHandler: httpHandler{ssState: srv.state},
+			},
+		)
+	}
 	handleAll(mux, "/environment/:envuuid/charms",
 		&charmsHandler{
 			httpHandler: httpHandler{ssState: srv.state},

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -52,7 +52,7 @@ func (s *authHttpSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCod
 	c.Check(jsonResponse(c, body).Error, gc.Matches, expError)
 }
 
-func (s *authHttpSuite) dialWebsocketFromURL(c *gc.C, server string, header http.Header) (*websocket.Conn, error) {
+func (s *authHttpSuite) dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket.Conn {
 	c.Logf("dialing %v", server)
 	config, err := websocket.NewConfig(server, "http://localhost/")
 	c.Assert(err, jc.ErrorIsNil)
@@ -60,7 +60,9 @@ func (s *authHttpSuite) dialWebsocketFromURL(c *gc.C, server string, header http
 	caCerts := x509.NewCertPool()
 	c.Assert(caCerts.AppendCertsFromPEM([]byte(testing.CACert)), jc.IsTrue)
 	config.TlsConfig = &tls.Config{RootCAs: caCerts, ServerName: "anything"}
-	return websocket.DialConfig(config)
+	conn, err := websocket.DialConfig(config)
+	c.Assert(err, jc.ErrorIsNil)
+	return conn
 }
 
 func (s *authHttpSuite) assertWebsocketClosed(c *gc.C, reader *bufio.Reader) {

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -1,0 +1,162 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"code.google.com/p/go.net/websocket"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	apihttp "github.com/juju/juju/apiserver/http"
+	"github.com/juju/juju/apiserver/params"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+// authHttpSuite provides helpers for testing HTTP "streaming" style APIs.
+type authHttpSuite struct {
+	jujutesting.JujuConnSuite
+	envUUID string
+}
+
+func (s *authHttpSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.envUUID = s.State.EnvironUUID()
+}
+
+func (s *authHttpSuite) baseURL(c *gc.C) *url.URL {
+	info := s.APIInfo(c)
+	return &url.URL{
+		Scheme: "https",
+		Host:   info.Addrs[0],
+		Path:   "",
+	}
+}
+
+func (s *authHttpSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
+	body := assertResponse(c, resp, expCode, apihttp.CTypeJSON)
+	c.Check(jsonResponse(c, body).Error, gc.Matches, expError)
+}
+
+func (s *authHttpSuite) dialWebsocketFromURL(c *gc.C, server string, header http.Header) (*websocket.Conn, error) {
+	c.Logf("dialing %v", server)
+	config, err := websocket.NewConfig(server, "http://localhost/")
+	c.Assert(err, jc.ErrorIsNil)
+	config.Header = header
+	caCerts := x509.NewCertPool()
+	c.Assert(caCerts.AppendCertsFromPEM([]byte(testing.CACert)), jc.IsTrue)
+	config.TlsConfig = &tls.Config{RootCAs: caCerts, ServerName: "anything"}
+	return websocket.DialConfig(config)
+}
+
+func (s *authHttpSuite) assertWebsocketClosed(c *gc.C, reader *bufio.Reader) {
+	_, err := reader.ReadByte()
+	c.Assert(err, gc.Equals, io.EOF)
+}
+
+func (s *authHttpSuite) makeURL(c *gc.C, scheme, path string, queryParams url.Values) *url.URL {
+	url := s.baseURL(c)
+	query := ""
+	if queryParams != nil {
+		query = queryParams.Encode()
+	}
+	url.Scheme = scheme
+	url.Path += path
+	url.RawQuery = query
+	return url
+}
+
+// userAuthHttpSuite extends authHttpSuite with helpers for testing
+// HTTP "streaming" style APIs which only accept user logins (not
+// agents).
+type userAuthHttpSuite struct {
+	authHttpSuite
+	userTag            names.UserTag
+	password           string
+	archiveContentType string
+}
+
+func (s *userAuthHttpSuite) SetUpTest(c *gc.C) {
+	s.authHttpSuite.SetUpTest(c)
+	s.password = "password"
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: s.password})
+	s.userTag = user.UserTag()
+}
+
+func (s *userAuthHttpSuite) sendRequest(c *gc.C, tag, password, method, uri, contentType string, body io.Reader) (*http.Response, error) {
+	c.Logf("sendRequest: %s", uri)
+	req, err := http.NewRequest(method, uri, body)
+	c.Assert(err, jc.ErrorIsNil)
+	if tag != "" && password != "" {
+		req.SetBasicAuth(tag, password)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return utils.GetNonValidatingHTTPClient().Do(req)
+}
+
+func (s *userAuthHttpSuite) setupOtherEnvironment(c *gc.C) *state.State {
+	envState := s.Factory.MakeEnvironment(c, nil)
+	s.AddCleanup(func(*gc.C) { envState.Close() })
+	user := s.Factory.MakeUser(c, nil)
+	_, err := envState.AddEnvironmentUser(user.UserTag(), s.userTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.userTag = user.UserTag()
+	s.password = "password"
+	s.envUUID = envState.EnvironUUID()
+	return envState
+}
+
+func (s *userAuthHttpSuite) authRequest(c *gc.C, method, uri, contentType string, body io.Reader) (*http.Response, error) {
+	return s.sendRequest(c, s.userTag.String(), s.password, method, uri, contentType, body)
+}
+
+func (s *userAuthHttpSuite) uploadRequest(c *gc.C, uri string, asZip bool, path string) (*http.Response, error) {
+	contentType := apihttp.CTypeRaw
+	if asZip {
+		contentType = s.archiveContentType
+	}
+
+	if path == "" {
+		return s.authRequest(c, "POST", uri, contentType, nil)
+	}
+
+	file, err := os.Open(path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer file.Close()
+	return s.authRequest(c, "POST", uri, contentType, file)
+}
+
+// assertJSONError checks the JSON encoded error returned by the log
+// and logsink APIs matches the expected value.
+func assertJSONError(c *gc.C, reader *bufio.Reader, expected string) {
+	errResult := readJSONErrorLine(c, reader)
+	c.Assert(errResult.Error, gc.NotNil)
+	c.Assert(errResult.Error.Message, gc.Matches, expected)
+}
+
+// readJSONErrorLine returns the error line returned by the log and
+// logsink APIS.
+func readJSONErrorLine(c *gc.C, reader *bufio.Reader) params.ErrorResult {
+	line, err := reader.ReadSlice('\n')
+	c.Assert(err, jc.ErrorIsNil)
+	var errResult params.ErrorResult
+	err = json.Unmarshal(line, &errResult)
+	c.Assert(err, jc.ErrorIsNil)
+	return errResult
+}

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -53,16 +53,21 @@ func (s *authHttpSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCod
 }
 
 func (s *authHttpSuite) dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket.Conn {
+	config := s.makeWebsocketConfigFromURL(c, server, header)
 	c.Logf("dialing %v", server)
+	conn, err := websocket.DialConfig(config)
+	c.Assert(err, jc.ErrorIsNil)
+	return conn
+}
+
+func (s *authHttpSuite) makeWebsocketConfigFromURL(c *gc.C, server string, header http.Header) *websocket.Config {
 	config, err := websocket.NewConfig(server, "http://localhost/")
 	c.Assert(err, jc.ErrorIsNil)
 	config.Header = header
 	caCerts := x509.NewCertPool()
 	c.Assert(caCerts.AppendCertsFromPEM([]byte(testing.CACert)), jc.IsTrue)
 	config.TlsConfig = &tls.Config{RootCAs: caCerts, ServerName: "anything"}
-	conn, err := websocket.DialConfig(config)
-	c.Assert(err, jc.ErrorIsNil)
-	return conn
+	return config
 }
 
 func (s *authHttpSuite) assertWebsocketClosed(c *gc.C, reader *bufio.Reader) {

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -39,7 +39,7 @@ func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 	defer stateWrapper.cleanup()
 
-	if err := stateWrapper.authenticate(req); err != nil {
+	if err := stateWrapper.authenticateUser(req); err != nil {
 		h.authError(resp, h)
 		return
 	}

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -28,12 +28,12 @@ import (
 )
 
 type baseBackupsSuite struct {
-	authHttpSuite
+	userAuthHttpSuite
 	fake *backupstesting.FakeBackups
 }
 
 func (s *baseBackupsSuite) SetUpTest(c *gc.C) {
-	s.authHttpSuite.SetUpTest(c)
+	s.userAuthHttpSuite.SetUpTest(c)
 
 	s.fake = &backupstesting.FakeBackups{}
 	s.PatchValue(apiserver.NewBackups,

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -52,7 +52,7 @@ func (h *charmsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "POST":
-		if err := stateWrapper.authenticate(r); err != nil {
+		if err := stateWrapper.authenticateUser(r); err != nil {
 			h.authError(w, h)
 			return
 		}

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -15,7 +14,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -23,90 +21,13 @@ import (
 
 	apihttp "github.com/juju/juju/apiserver/http"
 	"github.com/juju/juju/apiserver/params"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/testcharms"
-	"github.com/juju/juju/testing/factory"
 )
 
-type authHttpSuite struct {
-	jujutesting.JujuConnSuite
-	userTag            names.UserTag
-	password           string
-	archiveContentType string
-	envUUID            string
-}
-
-func (s *authHttpSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
-	s.password = "password"
-	user := s.Factory.MakeUser(c, &factory.UserParams{Password: s.password})
-	s.userTag = user.UserTag()
-	s.envUUID = s.State.EnvironUUID()
-}
-
-func (s *authHttpSuite) sendRequest(c *gc.C, tag, password, method, uri, contentType string, body io.Reader) (*http.Response, error) {
-	c.Logf("sendRequest: %s", uri)
-	req, err := http.NewRequest(method, uri, body)
-	c.Assert(err, jc.ErrorIsNil)
-	if tag != "" && password != "" {
-		req.SetBasicAuth(tag, password)
-	}
-	if contentType != "" {
-		req.Header.Set("Content-Type", contentType)
-	}
-	return utils.GetNonValidatingHTTPClient().Do(req)
-}
-
-func (s *authHttpSuite) baseURL(c *gc.C) *url.URL {
-	info := s.APIInfo(c)
-	return &url.URL{
-		Scheme: "https",
-		Host:   info.Addrs[0],
-		Path:   "",
-	}
-}
-
-func (s *authHttpSuite) setupOtherEnvironment(c *gc.C) *state.State {
-	envState := s.Factory.MakeEnvironment(c, nil)
-	s.AddCleanup(func(*gc.C) { envState.Close() })
-	user := s.Factory.MakeUser(c, nil)
-	_, err := envState.AddEnvironmentUser(user.UserTag(), s.userTag)
-	c.Assert(err, jc.ErrorIsNil)
-	s.userTag = user.UserTag()
-	s.password = "password"
-	s.envUUID = envState.EnvironUUID()
-	return envState
-}
-
-func (s *authHttpSuite) authRequest(c *gc.C, method, uri, contentType string, body io.Reader) (*http.Response, error) {
-	return s.sendRequest(c, s.userTag.String(), s.password, method, uri, contentType, body)
-}
-
-func (s *authHttpSuite) uploadRequest(c *gc.C, uri string, asZip bool, path string) (*http.Response, error) {
-	contentType := apihttp.CTypeRaw
-	if asZip {
-		contentType = s.archiveContentType
-	}
-
-	if path == "" {
-		return s.authRequest(c, "POST", uri, contentType, nil)
-	}
-
-	file, err := os.Open(path)
-	c.Assert(err, jc.ErrorIsNil)
-	defer file.Close()
-	return s.authRequest(c, "POST", uri, contentType, file)
-}
-
-func (s *authHttpSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
-	body := assertResponse(c, resp, expCode, apihttp.CTypeJSON)
-	c.Check(jsonResponse(c, body).Error, gc.Matches, expError)
-}
-
 type charmsSuite struct {
-	authHttpSuite
+	userAuthHttpSuite
 }
 
 var _ = gc.Suite(&charmsSuite{})
@@ -116,7 +37,7 @@ func (s *charmsSuite) SetUpSuite(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: Skipping this on windows for now")
 	}
-	s.authHttpSuite.SetUpSuite(c)
+	s.userAuthHttpSuite.SetUpSuite(c)
 	s.archiveContentType = "application/zip"
 }
 

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -64,7 +64,7 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			defer stateWrapper.cleanup()
 			// TODO (thumper): We need to work out how we are going to filter
 			// logging information based on environment.
-			if err := stateWrapper.authenticate(req); err != nil {
+			if err := stateWrapper.authenticateUser(req); err != nil {
 				h.sendError(socket, fmt.Errorf("auth failed: %v", err))
 				socket.Close()
 				return

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -116,7 +116,7 @@ func (s *debugLogSuite) TestReadFromEnvUUIDPath(c *gc.C) {
 }
 
 func (s *debugLogSuite) TestReadRejectsWrongEnvUUIDPath(c *gc.C) {
-	// Check that we cannot upload charms to https://host:port/BADENVUUID/charms
+	// Check that we cannot pull logs from https://host:port/BADENVUUID/charms
 	s.ensureLogFile(c)
 	reader := s.openWebsocketCustomPath(c, "/environment/dead-beef-123456/log")
 	s.assertErrorResponse(c, reader, `unknown environment: "dead-beef-123456"`)

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -41,8 +41,7 @@ func (s *debugLogSuite) TestWithHTTPS(c *gc.C) {
 }
 
 func (s *debugLogSuite) TestNoAuth(c *gc.C) {
-	conn, err := s.dialWebsocketInternal(c, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
+	conn := s.dialWebsocketInternal(c, nil, nil)
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
@@ -56,8 +55,7 @@ func (s *debugLogSuite) TestAgentLoginsRejected(c *gc.C) {
 	})
 	header := utils.BasicAuthHeader(m.Tag().String(), password)
 	header.Add("X-Juju-Nonce", "foo-nonce")
-	conn, err := s.dialWebsocketInternal(c, nil, header)
-	c.Assert(err, jc.ErrorIsNil)
+	conn := s.dialWebsocketInternal(c, nil, header)
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
@@ -294,8 +292,7 @@ func (s *debugLogSuite) TestFilter(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		// opens web socket
-		conn, err := s.dialWebsocket(c, test.filter)
-		c.Assert(err, jc.ErrorIsNil)
+		conn := s.dialWebsocket(c, test.filter)
 		reader := bufio.NewReader(conn)
 
 		s.assertLogFollowing(c, reader)
@@ -331,8 +328,7 @@ func (s *debugLogSuite) readLogLines(c *gc.C, reader *bufio.Reader, count int) (
 }
 
 func (s *debugLogSuite) openWebsocket(c *gc.C, values url.Values) *bufio.Reader {
-	conn, err := s.dialWebsocket(c, values)
-	c.Assert(err, jc.ErrorIsNil)
+	conn := s.dialWebsocket(c, values)
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
 	return bufio.NewReader(conn)
 }
@@ -341,8 +337,7 @@ func (s *debugLogSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Rea
 	server := s.logURL(c, "wss", nil)
 	server.Path = path
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
-	conn, err := s.dialWebsocketFromURL(c, server.String(), header)
-	c.Assert(err, jc.ErrorIsNil)
+	conn := s.dialWebsocketFromURL(c, server.String(), header)
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
 	return bufio.NewReader(conn)
 }
@@ -370,12 +365,12 @@ func (s *debugLogSuite) writeLogLines(c *gc.C, count int) {
 	}
 }
 
-func (s *debugLogSuite) dialWebsocketInternal(c *gc.C, queryParams url.Values, header http.Header) (*websocket.Conn, error) {
+func (s *debugLogSuite) dialWebsocketInternal(c *gc.C, queryParams url.Values, header http.Header) *websocket.Conn {
 	server := s.logURL(c, "wss", queryParams).String()
 	return s.dialWebsocketFromURL(c, server, header)
 }
 
-func (s *debugLogSuite) dialWebsocket(c *gc.C, queryParams url.Values) (*websocket.Conn, error) {
+func (s *debugLogSuite) dialWebsocket(c *gc.C, queryParams url.Values) *websocket.Conn {
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
 	return s.dialWebsocketInternal(c, queryParams, header)
 }

--- a/apiserver/httphandler.go
+++ b/apiserver/httphandler.go
@@ -71,32 +71,62 @@ func (h *httpHandler) validateEnvironUUID(r *http.Request) (*httpStateWrapper, e
 
 // authenticate parses HTTP basic authentication and authorizes the
 // request by looking up the provided tag and password against state.
-func (h *httpStateWrapper) authenticate(r *http.Request) error {
+func (h *httpStateWrapper) authenticate(r *http.Request) (names.Tag, error) {
 	parts := strings.Fields(r.Header.Get("Authorization"))
 	if len(parts) != 2 || parts[0] != "Basic" {
 		// Invalid header format or no header provided.
-		return errors.New("invalid request format")
+		return nil, errors.New("invalid request format")
 	}
 	// Challenge is a base64-encoded "tag:pass" string.
 	// See RFC 2617, Section 2.
 	challenge, err := base64.StdEncoding.DecodeString(parts[1])
 	if err != nil {
-		return errors.New("invalid request format")
+		return nil, errors.New("invalid request format")
 	}
 	tagPass := strings.SplitN(string(challenge), ":", 2)
 	if len(tagPass) != 2 {
-		return errors.New("invalid request format")
+		return nil, errors.New("invalid request format")
 	}
-	// Only allow users, not agents.
-	if _, err := names.ParseUserTag(tagPass[0]); err != nil {
-		return common.ErrBadCreds
+	// Ensure that a sensible tag was passed.
+	tag, err := names.ParseTag(tagPass[0])
+	if err != nil {
+		return nil, common.ErrBadCreds
 	}
 	// Ensure the credentials are correct.
 	_, err = checkCreds(h.state, params.LoginRequest{
 		AuthTag:     tagPass[0],
 		Credentials: tagPass[1],
+		Nonce:       r.Header.Get("X-Juju-Nonce"),
 	})
-	return err
+	return tag, err
+}
+
+func (h *httpStateWrapper) authenticateUser(r *http.Request) error {
+	tag, err := h.authenticate(r)
+	if err != nil {
+		return err
+	}
+	switch tag.(type) {
+	case names.UserTag:
+		return nil
+	default:
+		return common.ErrBadCreds
+	}
+}
+
+func (h *httpStateWrapper) authenticateAgent(r *http.Request) (names.Tag, error) {
+	tag, err := h.authenticate(r)
+	if err != nil {
+		return nil, err
+	}
+	switch tag.(type) {
+	case names.MachineTag:
+		return tag, nil
+	case names.UnitTag:
+		return tag, nil
+	default:
+		return nil, common.ErrBadCreds
+	}
 }
 
 func (h *httpStateWrapper) cleanup() {

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 type imageSuite struct {
-	authHttpSuite
+	userAuthHttpSuite
 	archiveContentType string
 	imageData          string
 	imageChecksum      string
@@ -36,7 +36,7 @@ type imageSuite struct {
 var _ = gc.Suite(&imageSuite{})
 
 func (s *imageSuite) SetUpSuite(c *gc.C) {
-	s.authHttpSuite.SetUpSuite(c)
+	s.userAuthHttpSuite.SetUpSuite(c)
 	s.archiveContentType = "application/x-tar-gz"
 	s.imageData = "abc"
 	s.imageChecksum = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -1,0 +1,107 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"code.google.com/p/go.net/websocket"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+type logSinkHandler struct {
+	httpHandler
+	st *state.State
+}
+
+// LogMessage is used to transmit log messages to the logsink API
+// endpoint.  Single character field names are used for serialisation
+// to keep the size down. These messages are going to be sent a lot.
+type LogMessage struct {
+	Time     time.Time   `json:"t"`
+	Module   string      `json:"m"`
+	Location string      `json:"l"`
+	Level    loggo.Level `json:"v"`
+	Message  string      `json:"x"`
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	server := websocket.Server{
+		Handler: func(socket *websocket.Conn) {
+			defer socket.Close()
+			// Validate before authenticate because the authentication is
+			// dependent on the state connection that is determined during the
+			// validation.
+			stateWrapper, err := h.validateEnvironUUID(req)
+			if err != nil {
+				if errErr := h.sendError(socket, err); errErr != nil {
+					// Log at DEBUG so that in a standard environment
+					// logs cant't fill up with auth errors for
+					// unauthenticated connections.
+					logger.Debugf("error sending logsink error: %v", errErr)
+				}
+				return
+			}
+			defer stateWrapper.cleanup()
+
+			tag, err := stateWrapper.authenticateAgent(req)
+			if err != nil {
+				if errErr := h.sendError(socket, errors.Errorf("auth failed: %v", err)); errErr != nil {
+					// DEBUG used as above.
+					logger.Debugf("error sending logsink error: %v", errErr)
+				}
+				return
+			}
+
+			// If we get to here, no more errors to report, so we report a nil
+			// error.  This way the first line of the socket is always a json
+			// formatted simple error.
+			if err := h.sendError(socket, nil); err != nil {
+				logger.Errorf("failed to send nil error at start of connection")
+				return
+			}
+
+			dbLogger := state.NewDbLogger(stateWrapper.state, tag)
+			defer dbLogger.Close()
+			var m LogMessage
+			for {
+				if err := websocket.JSON.Receive(socket, &m); err != nil {
+					if err != io.EOF {
+						logger.Errorf("error while receiving logs: %v", err)
+					}
+					break
+				}
+				if err := dbLogger.Log(m.Time, m.Module, m.Location, m.Level, m.Message); err != nil {
+					logger.Errorf("logging to DB failed: %v", err)
+					break
+				}
+			}
+		}}
+	server.ServeHTTP(w, req)
+}
+
+// sendError sends a JSON-encoded error response.
+func (h *logSinkHandler) sendError(w io.Writer, err error) error {
+	response := &params.ErrorResult{}
+	if err != nil {
+		response.Error = &params.Error{Message: err.Error()}
+	}
+	message, err := json.Marshal(response)
+	if err != nil {
+		// If we are having trouble marshalling the error, we are in big trouble.
+		logger.Errorf("failure to marshal SimpleError: %v", err)
+		return errors.Trace(err)
+	}
+	message = append(message, []byte("\n")...)
+	_, err = w.Write(message)
+	return errors.Trace(err)
+}

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -1,0 +1,196 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"bufio"
+	"net/http"
+	"net/url"
+	"time"
+
+	"code.google.com/p/go.net/websocket"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/apiserver"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type logsinkSuite struct {
+	authHttpSuite
+	machineTag names.Tag
+	password   string
+	nonce      string
+	logs       loggo.TestWriter
+}
+
+var _ = gc.Suite(&logsinkSuite{})
+
+func (s *logsinkSuite) SetUpTest(c *gc.C) {
+	s.authHttpSuite.SetUpTest(c)
+	s.nonce = "nonce"
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: s.nonce,
+	})
+	s.machineTag = m.Tag()
+	s.password = password
+
+	s.logs.Clear()
+	c.Assert(loggo.RegisterWriter("logsink-tests", &s.logs, loggo.INFO), jc.ErrorIsNil)
+}
+
+func (s *logsinkSuite) TestRejectsBadEnvironUUID(c *gc.C) {
+	reader := s.openWebsocketCustomPath(c, "/environment/does-not-exist/logsink")
+	assertJSONError(c, reader, `unknown environment: "does-not-exist"`)
+	s.assertWebsocketClosed(c, reader)
+}
+
+func (s *logsinkSuite) TestNoAuth(c *gc.C) {
+	s.checkAuthFails(c, nil, "invalid request format")
+}
+
+func (s *logsinkSuite) TestRejectsUserLogins(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "sekrit"})
+	header := utils.BasicAuthHeader(user.Tag().String(), "sekrit")
+	s.checkAuthFailsWithEntityError(c, header)
+}
+
+func (s *logsinkSuite) TestRejectsBadPassword(c *gc.C) {
+	header := utils.BasicAuthHeader(s.machineTag.String(), "wrong")
+	header.Add("X-Juju-Nonce", s.nonce)
+	s.checkAuthFailsWithEntityError(c, header)
+}
+
+func (s *logsinkSuite) TestRejectsIncorrectNonce(c *gc.C) {
+	header := utils.BasicAuthHeader(s.machineTag.String(), s.password)
+	header.Add("X-Juju-Nonce", "wrong")
+	s.checkAuthFails(c, header, "machine 0 not provisioned")
+}
+
+func (s *logsinkSuite) checkAuthFailsWithEntityError(c *gc.C, header http.Header) {
+	s.checkAuthFails(c, header, "invalid entity name or password")
+}
+
+func (s *logsinkSuite) checkAuthFails(c *gc.C, header http.Header, message string) {
+	conn, err := s.dialWebsocketInternal(c, header)
+	c.Assert(err, jc.ErrorIsNil)
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	assertJSONError(c, reader, "auth failed: "+message)
+	s.assertWebsocketClosed(c, reader)
+}
+
+func (s *logsinkSuite) TestLogging(c *gc.C) {
+	conn, err := s.dialWebsocket(c)
+	c.Assert(err, jc.ErrorIsNil)
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	// Read back the nil error, indicating that all is well.
+	errResult := readJSONErrorLine(c, reader)
+	c.Assert(errResult.Error, gc.IsNil)
+
+	t0 := time.Now().Truncate(time.Millisecond)
+	err = websocket.JSON.Send(conn, &apiserver.LogMessage{
+		Time:     t0,
+		Module:   "some.where",
+		Location: "foo.go:42",
+		Level:    loggo.INFO,
+		Message:  "all is well",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	t1 := t0.Add(time.Second)
+	err = websocket.JSON.Send(conn, &apiserver.LogMessage{
+		Time:     t1,
+		Module:   "else.where",
+		Location: "bar.go:99",
+		Level:    loggo.ERROR,
+		Message:  "oh noes",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Wait for the log documents to be written to the DB.
+	logsColl := s.State.MongoSession().DB("logs").C("logs")
+	var docs []bson.M
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		err := logsColl.Find(nil).Sort("t").All(&docs)
+		c.Assert(err, jc.ErrorIsNil)
+		if len(docs) == 2 {
+			break
+		}
+		if len(docs) >= 2 {
+			c.Fatalf("saw more log documents than expected")
+		}
+		if !a.HasNext() {
+			c.Fatalf("timed out waiting for log writes")
+		}
+	}
+
+	// Check the recorded logs are correct.
+	c.Assert(docs[0]["t"], gc.Equals, t0)
+	c.Assert(docs[0]["e"], gc.Equals, s.State.EnvironUUID())
+	c.Assert(docs[0]["n"], gc.Equals, s.machineTag.String())
+	c.Assert(docs[0]["m"], gc.Equals, "some.where")
+	c.Assert(docs[0]["l"], gc.Equals, "foo.go:42")
+	c.Assert(docs[0]["v"], gc.Equals, int(loggo.INFO))
+	c.Assert(docs[0]["x"], gc.Equals, "all is well")
+
+	c.Assert(docs[1]["t"], gc.Equals, t1)
+	c.Assert(docs[1]["e"], gc.Equals, s.State.EnvironUUID())
+	c.Assert(docs[1]["n"], gc.Equals, s.machineTag.String())
+	c.Assert(docs[1]["m"], gc.Equals, "else.where")
+	c.Assert(docs[1]["l"], gc.Equals, "bar.go:99")
+	c.Assert(docs[1]["v"], gc.Equals, int(loggo.ERROR))
+	c.Assert(docs[1]["x"], gc.Equals, "oh noes")
+
+	// Close connection.
+	err = conn.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure that no error is logged when the connection is closed
+	// normally.
+	shortAttempt := &utils.AttemptStrategy{
+		Total: coretesting.ShortWait,
+		Delay: 2 * time.Millisecond,
+	}
+	for a := shortAttempt.Start(); a.Next(); {
+		for _, log := range s.logs.Log() {
+			c.Assert(log, jc.LessThan, loggo.ERROR)
+		}
+	}
+}
+
+func (s *logsinkSuite) dialWebsocket(c *gc.C) (*websocket.Conn, error) {
+	return s.dialWebsocketInternal(c, s.makeAuthHeader())
+}
+
+func (s *logsinkSuite) dialWebsocketInternal(c *gc.C, header http.Header) (*websocket.Conn, error) {
+	server := s.logsinkURL(c, "wss").String()
+	return s.dialWebsocketFromURL(c, server, header)
+}
+
+func (s *logsinkSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Reader {
+	server := s.logsinkURL(c, "wss")
+	server.Path = path
+	conn, err := s.dialWebsocketFromURL(c, server.String(), s.makeAuthHeader())
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(_ *gc.C) { conn.Close() })
+	return bufio.NewReader(conn)
+}
+
+func (s *logsinkSuite) logsinkURL(c *gc.C, scheme string) *url.URL {
+	return s.makeURL(c, scheme, "/environment/"+s.State.EnvironUUID()+"/logsink", nil)
+}
+
+func (s *logsinkSuite) makeAuthHeader() http.Header {
+	header := utils.BasicAuthHeader(s.machineTag.String(), s.password)
+	header.Add("X-Juju-Nonce", s.nonce)
+	return header
+}

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -78,8 +78,7 @@ func (s *logsinkSuite) checkAuthFailsWithEntityError(c *gc.C, header http.Header
 }
 
 func (s *logsinkSuite) checkAuthFails(c *gc.C, header http.Header, message string) {
-	conn, err := s.dialWebsocketInternal(c, header)
-	c.Assert(err, jc.ErrorIsNil)
+	conn := s.dialWebsocketInternal(c, header)
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 	assertJSONError(c, reader, "auth failed: "+message)
@@ -87,8 +86,7 @@ func (s *logsinkSuite) checkAuthFails(c *gc.C, header http.Header, message strin
 }
 
 func (s *logsinkSuite) TestLogging(c *gc.C) {
-	conn, err := s.dialWebsocket(c)
-	c.Assert(err, jc.ErrorIsNil)
+	conn := s.dialWebsocket(c)
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
@@ -97,7 +95,7 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	c.Assert(errResult.Error, gc.IsNil)
 
 	t0 := time.Now().Truncate(time.Millisecond)
-	err = websocket.JSON.Send(conn, &apiserver.LogMessage{
+	err := websocket.JSON.Send(conn, &apiserver.LogMessage{
 		Time:     t0,
 		Module:   "some.where",
 		Location: "foo.go:42",
@@ -167,11 +165,11 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	}
 }
 
-func (s *logsinkSuite) dialWebsocket(c *gc.C) (*websocket.Conn, error) {
+func (s *logsinkSuite) dialWebsocket(c *gc.C) *websocket.Conn {
 	return s.dialWebsocketInternal(c, s.makeAuthHeader())
 }
 
-func (s *logsinkSuite) dialWebsocketInternal(c *gc.C, header http.Header) (*websocket.Conn, error) {
+func (s *logsinkSuite) dialWebsocketInternal(c *gc.C, header http.Header) *websocket.Conn {
 	server := s.logsinkURL(c, "wss").String()
 	return s.dialWebsocketFromURL(c, server, header)
 }
@@ -179,8 +177,7 @@ func (s *logsinkSuite) dialWebsocketInternal(c *gc.C, header http.Header) (*webs
 func (s *logsinkSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Reader {
 	server := s.logsinkURL(c, "wss")
 	server.Path = path
-	conn, err := s.dialWebsocketFromURL(c, server.String(), s.makeAuthHeader())
-	c.Assert(err, jc.ErrorIsNil)
+	conn := s.dialWebsocketFromURL(c, server.String(), s.makeAuthHeader())
 	s.AddCleanup(func(_ *gc.C) { conn.Close() })
 	return bufio.NewReader(conn)
 }

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -76,7 +76,7 @@ func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer stateWrapper.cleanup()
 
-	if err := stateWrapper.authenticate(r); err != nil {
+	if err := stateWrapper.authenticateUser(r); err != nil {
 		h.authError(w, h)
 		return
 	}

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -32,19 +32,19 @@ import (
 )
 
 type toolsSuite struct {
-	authHttpSuite
+	userAuthHttpSuite
 	commontesting.BlockHelper
 }
 
 var _ = gc.Suite(&toolsSuite{})
 
 func (s *toolsSuite) SetUpSuite(c *gc.C) {
-	s.authHttpSuite.SetUpSuite(c)
+	s.userAuthHttpSuite.SetUpSuite(c)
 	s.archiveContentType = "application/x-tar-gz"
 }
 
 func (s *toolsSuite) SetUpTest(c *gc.C) {
-	s.authHttpSuite.SetUpTest(c)
+	s.userAuthHttpSuite.SetUpTest(c)
 	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
 	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -19,3 +19,7 @@ const Storage = "storage"
 // failure.  This means that the developers with this flag set will see the
 // stack trace in the log output, but normal deployments never will.
 const LogErrorStack = "log-error-stack"
+
+// DbLog is the the feature which has Juju's logs go to
+// MongoDB instead of to all-machines.log using rsyslog.
+const DbLog = "db-log"

--- a/testing/base.go
+++ b/testing/base.go
@@ -30,9 +30,10 @@ var logger = loggo.GetLogger("juju.testing")
 // github.com/juju/testing, and this suite will be removed.
 // Do not use JujuOSEnvSuite when writing new tests.
 type JujuOSEnvSuite struct {
-	oldJujuHome    string
-	oldHomeEnv     string
-	oldEnvironment map[string]string
+	oldJujuHome         string
+	oldHomeEnv          string
+	oldEnvironment      map[string]string
+	initialFeatureFlags string
 }
 
 func (s *JujuOSEnvSuite) SetUpSuite(c *gc.C) {
@@ -53,11 +54,12 @@ func (s *JujuOSEnvSuite) SetUpTest(c *gc.C) {
 		os.Setenv(name, "")
 	}
 	s.oldHomeEnv = utils.Home()
-	utils.SetHome("")
-	// Update the feature flag set to be empty (given we have just set the
-	// environment value to the empty string)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.oldJujuHome = osenv.SetJujuHome("")
+	utils.SetHome("")
+
+	// Update the feature flag set to be the requested initial set.
+	os.Setenv(osenv.JujuFeatureFlagEnvKey, s.initialFeatureFlags)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *JujuOSEnvSuite) TearDownTest(c *gc.C) {
@@ -82,6 +84,12 @@ func SkipIfI386(c *gc.C, bugID string) {
 	if arch.NormaliseArch(runtime.GOARCH) == arch.I386 {
 		c.Skip(fmt.Sprintf("Test disabled on I386 until fixed - see bug %s", bugID))
 	}
+}
+
+// SetInitialFeatureFlags sets the feature flags to be in effect for
+// the next call to SetUpTest.
+func (s *JujuOSEnvSuite) SetInitialFeatureFlags(flags ...string) {
+	s.initialFeatureFlags = strings.Join(flags, ",")
 }
 
 func (s *JujuOSEnvSuite) SetFeatureFlags(flag ...string) {


### PR DESCRIPTION
These changes implement a new API endpoint (`/environment/:uuid/logsink`) which will be used by agents to send logs to the JES for recording in MongoDB. The endpoint is hidden behind a new feature flag.

These changes also include signficant refactoring so that the logsink endpoint can share infrastructure with the logs endpoint (debuglog).



(Review request: http://reviews.vapour.ws/r/1052/)