### PR TITLE
Disable systemd support in juju.

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -121,7 +121,9 @@ func VersionInitSystem(vers version.Binary) (string, bool) {
 			return InitSystemUpstart, true
 		default:
 			// vivid and later
-			return InitSystemSystemd, true
+			// TODO(ericsnow) Disabled for lp-1427210.
+			//return InitSystemSystemd, true
+			return "", false
 		}
 		// TODO(ericsnow) Support other OSes, like version.CentOS.
 	default:
@@ -164,11 +166,12 @@ var linuxExecutables = map[string]string{
 	// Note that some systems link /sbin/init to whatever init system
 	// is supported, so in the future we may need some other way to
 	// identify upstart uniquely.
-	"/sbin/init":           InitSystemUpstart,
-	"/sbin/upstart":        InitSystemUpstart,
-	"/sbin/systemd":        InitSystemSystemd,
-	"/bin/systemd":         InitSystemSystemd,
-	"/lib/systemd/systemd": InitSystemSystemd,
+	"/sbin/init":    InitSystemUpstart,
+	"/sbin/upstart": InitSystemUpstart,
+	// TODO(ericsnow) Disabled for lp-1427210.
+	//"/sbin/systemd":        InitSystemSystemd,
+	//"/bin/systemd":         InitSystemSystemd,
+	//"/lib/systemd/systemd": InitSystemSystemd,
 }
 
 // TODO(ericsnow) Is it too much to cat once for each executable?

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -51,14 +51,16 @@ func (*serviceSuite) TestListServicesCommand(c *gc.C) {
 
 	line := `if [[ "$(cat /proc/1/cmdline)" == "%s" ]]; then %s`
 	upstart := `sudo initctl list | awk '{print $1}' | sort | uniq`
-	systemd := `/bin/systemctl list-unit-files --no-legend --no-page -t service` +
-		` | grep -o -P '^\w[\S]*(?=\.service)'`
+	// TODO(ericsnow) Disabled for lp-1427210.
+	//systemd := `/bin/systemctl list-unit-files --no-legend --no-page -t service` +
+	//	` | grep -o -P '^\w[\S]*(?=\.service)'`
 	c.Check(cmd, gc.Equals, strings.Join([]string{
 		fmt.Sprintf(line, "/sbin/init", upstart),
 		"el" + fmt.Sprintf(line, "/sbin/upstart", upstart),
-		"el" + fmt.Sprintf(line, "/sbin/systemd", systemd),
-		"el" + fmt.Sprintf(line, "/bin/systemd", systemd),
-		"el" + fmt.Sprintf(line, "/lib/systemd/systemd", systemd),
+		// TODO(ericsnow) Disabled for lp-1427210.
+		//"el" + fmt.Sprintf(line, "/sbin/systemd", systemd),
+		//"el" + fmt.Sprintf(line, "/bin/systemd", systemd),
+		//"el" + fmt.Sprintf(line, "/lib/systemd/systemd", systemd),
 		"else exit 1",
 		"fi",
 	}, "\n"))


### PR DESCRIPTION
In the interest of unblocking CI, this patch temporarily disables systemd support in juju.

(Review request: http://reviews.vapour.ws/r/1056/)