### PR TITLE
Tie vivid to upstart, not systemd.

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -123,7 +123,7 @@ func VersionInitSystem(vers version.Binary) (string, bool) {
 			// vivid and later
 			// TODO(ericsnow) Disabled for lp-1427210.
 			//return InitSystemSystemd, true
-			return "", false
+			return InitSystemUpstart, true
 		}
 		// TODO(ericsnow) Support other OSes, like version.CentOS.
 	default:

--- a/service/service.go
+++ b/service/service.go
@@ -119,11 +119,13 @@ func VersionInitSystem(vers version.Binary) (string, bool) {
 		switch vers.Series {
 		case "precise", "quantal", "raring", "saucy", "trusty", "utopic":
 			return InitSystemUpstart, true
+		// TODO(ericsnow) the explicit vivid case should be removed once
+		// vivid switches over to systemd (for PID 1).
+		case "vivid":
+			return InitSystemUpstart, true
 		default:
 			// vivid and later
-			// TODO(ericsnow) Disabled for lp-1427210.
-			//return InitSystemSystemd, true
-			return InitSystemUpstart, true
+			return InitSystemSystemd, true
 		}
 		// TODO(ericsnow) Support other OSes, like version.CentOS.
 	default:


### PR DESCRIPTION
We were under the impression that vivid was running systemd (as PID 1).  Apparently that is currently not the case.

(Review request: http://reviews.vapour.ws/r/1057/)