### PR TITLE
New service supercommand with get/set-constraints subcommands

### DIFF
--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/juju/environment"
 	"github.com/juju/juju/cmd/juju/machine"
+	"github.com/juju/juju/cmd/juju/service"
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/environs"
@@ -195,6 +196,9 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage state server availability
 	r.Register(wrapEnvCommand(&EnsureAvailabilityCommand{}))
+
+	// Manage and control services
+	r.Register(service.NewSuperCommand())
 
 	// Operation protection commands
 	r.Register(block.NewSuperBlockCommand())

--- a/cmd/juju/main_test.go
+++ b/cmd/juju/main_test.go
@@ -230,6 +230,7 @@ var commandNames = []string{
 	"retry-provisioning",
 	"run",
 	"scp",
+	"service",
 	"set",
 	"set-constraints",
 	"set-env", // alias for set-environment

--- a/cmd/juju/service/constraints.go
+++ b/cmd/juju/service/constraints.go
@@ -15,8 +15,8 @@ import (
 )
 
 const getConstraintsDoc = `
-service get-constraints returns a list of constraints that have been set on the
-specified service using juju service set-constraints.  You can also view constraints
+Shows the list of constraints that have been set on the specified service
+using juju service set-constraints.  You can also view constraints
 set for an environment by using juju environment get-constraints.
 
 Constraints set on a service are combined with environment constraints for
@@ -33,8 +33,8 @@ See Also:
 `
 
 const setConstraintsDoc = `
-service set-constraints sets machine constraints on specific service, which are
-used as the default constraints for all new machines provisioned by that service.
+Sets machine constraints on specific service, which are used as the
+default constraints for all new machines provisioned by that service.
 You can also set constraints on an environment by using
 juju environment set-constraints.
 

--- a/cmd/juju/service/constraints.go
+++ b/cmd/juju/service/constraints.go
@@ -1,0 +1,119 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/names"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/constraints"
+)
+
+const getConstraintsDoc = `
+service get-constraints returns a list of constraints that have been set on the
+specified service using juju service set-constraints.  You can also view constraints
+set for an environment by using juju environment get-constraints.
+
+Constraints set on a service are combined with environment constraints for
+commands (such as juju deploy) that provision machines for services.  Where
+environment and service constraints overlap, the service constraints take
+precedence.
+
+See Also:
+   juju help constraints
+   juju service help set-constraints
+   juju help deploy
+   juju machine help add
+   juju help add-unit
+`
+
+const setConstraintsDoc = `
+service set-constraints sets machine constraints on specific service, which are
+used as the default constraints for all new machines provisioned by that service.
+You can also set constraints on an environment by using
+juju environment set-constraints.
+
+Constraints set on a service are combined with environment constraints for
+commands (such as juju deploy) that provision machines for services.  Where
+environment and service constraints overlap, the service constraints take
+precedence.
+
+Example:
+
+    set-constraints wordpress mem=4G     (all new wordpress machines must have at least 4GB of RAM)
+
+See Also:
+   juju help constraints
+   juju service help get-constraints
+   juju help deploy
+   juju machine help add
+   juju help add-unit
+`
+
+// ServiceGetConstraintsCommand shows the constraints for a service.
+// It is just a wrapper for the common GetConstraintsCommand which
+// enforces that a service is specified.
+type ServiceGetConstraintsCommand struct {
+	common.GetConstraintsCommand
+}
+
+func (c *ServiceGetConstraintsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "get-constraints",
+		Args:    "<service>",
+		Purpose: "view constraints on a service",
+		Doc:     getConstraintsDoc,
+	}
+}
+
+func (c *ServiceGetConstraintsCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no service name specified")
+	}
+	if !names.IsValidService(args[0]) {
+		return fmt.Errorf("invalid service name %q", args[0])
+	}
+
+	c.ServiceName, args = args[0], args[1:]
+	return nil
+}
+
+// ServiceSetConstraintsCommand sets the constraints for a service.
+// It is just a wrapper for the common SetConstraintsCommand which
+// enforces that a service is specified.
+type ServiceSetConstraintsCommand struct {
+	common.SetConstraintsCommand
+}
+
+func (c *ServiceSetConstraintsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "set-constraints",
+		Args:    "<service> [key=[value] ...]",
+		Purpose: "set constraints on a service",
+		Doc:     setConstraintsDoc,
+	}
+}
+
+// SetFlags overrides SetFlags for SetConstraintsCommand since that
+// will register a flag to specify the service, and the flag is not
+// required with this service supercommand.
+func (c *ServiceSetConstraintsCommand) SetFlags(f *gnuflag.FlagSet) {}
+
+func (c *ServiceSetConstraintsCommand) Init(args []string) (err error) {
+	if len(args) == 0 {
+		return fmt.Errorf("no service name specified")
+	}
+	if !names.IsValidService(args[0]) {
+		return fmt.Errorf("invalid service name %q", args[0])
+	}
+
+	c.ServiceName, args = args[0], args[1:]
+
+	c.Constraints, err = constraints.Parse(args...)
+	return err
+}

--- a/cmd/juju/service/constraints_test.go
+++ b/cmd/juju/service/constraints_test.go
@@ -1,0 +1,81 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/service"
+	"github.com/juju/juju/testing"
+)
+
+type ServiceConstraintsCommandsSuite struct {
+	testing.FakeJujuHomeSuite
+}
+
+var _ = gc.Suite(&ServiceConstraintsCommandsSuite{})
+
+func (s *ServiceConstraintsCommandsSuite) TestSetInit(c *gc.C) {
+	for _, test := range []struct {
+		args []string
+		err  string
+	}{
+		{
+			args: []string{"--service", "mysql", "mem=4G"},
+			err:  `flag provided but not defined: --service`,
+		}, {
+			args: []string{"-s", "mysql", "mem=4G"},
+			err:  `flag provided but not defined: -s`,
+		}, {
+			args: []string{},
+			err:  `no service name specified`,
+		}, {
+			args: []string{"mysql", "="},
+			err:  `malformed constraint "="`,
+		}, {
+			args: []string{"cpu-power=250"},
+			err:  `invalid service name "cpu-power=250"`,
+		}, {
+			args: []string{"mysql", "cpu-power=250"},
+		},
+	} {
+		err := testing.InitCommand(&service.ServiceSetConstraintsCommand{}, test.args)
+		if test.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}
+
+func (s *ServiceConstraintsCommandsSuite) TestGetInit(c *gc.C) {
+	for _, test := range []struct {
+		args []string
+		err  string
+	}{
+		{
+			args: []string{"-s", "mysql"},
+			err:  `flag provided but not defined: -s`,
+		}, {
+			args: []string{"--service", "mysql"},
+			err:  `flag provided but not defined: --service`,
+		}, {
+			args: []string{},
+			err:  `no service name specified`,
+		}, {
+			args: []string{"mysql-0"},
+			err:  `invalid service name "mysql-0"`,
+		}, {
+			args: []string{"mysql"},
+		},
+	} {
+		err := testing.InitCommand(&service.ServiceGetConstraintsCommand{}, test.args)
+		if test.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}

--- a/cmd/juju/service/package_test.go
+++ b/cmd/juju/service/package_test.go
@@ -1,0 +1,17 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+// None of the tests in this package require mongo.
+// Full command integration tests are found in featuretests/cmdjuju_test.go
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/juju/service/service.go
+++ b/cmd/juju/service/service.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
+var logger = loggo.GetLogger("juju.cmd.juju.service")
+
+const commandDoc = `
+"juju service" provides commands to manage Juju services.
+`
+
+// NewSuperCommand creates the service supercommand and registers the
+// subcommands that it supports.
+func NewSuperCommand() cmd.Command {
+	environmentCmd := cmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name:        "service",
+		Doc:         commandDoc,
+		UsagePrefix: "juju",
+		Purpose:     "manage services",
+	})
+
+	environmentCmd.Register(envcmd.Wrap(&ServiceGetConstraintsCommand{}))
+	environmentCmd.Register(envcmd.Wrap(&ServiceSetConstraintsCommand{}))
+
+	return environmentCmd
+}

--- a/cmd/juju/service/service_test.go
+++ b/cmd/juju/service/service_test.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/service"
+	// Bring in the dummy provider definition.
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
+)
+
+type ServiceCommandSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ServiceCommandSuite{})
+
+var expectedCommmandNames = []string{
+	"get-constraints",
+	"help",
+	"set-constraints",
+}
+
+func (s *ServiceCommandSuite) TestHelp(c *gc.C) {
+	// Check the help output
+	ctx, err := testing.RunCommand(c, service.NewSuperCommand(), "--help")
+	c.Assert(err, jc.ErrorIsNil)
+	namesFound := testing.ExtractCommandsFromHelpOutput(ctx)
+	c.Assert(namesFound, gc.DeepEquals, expectedCommmandNames)
+}

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -78,3 +78,26 @@ func (s *cmdJujuSuite) TestEnsureAvailability(c *gc.C) {
 		"adding machines: 1, 2, 3\n"+
 			"demoting machines 0\n\n")
 }
+
+func (s *cmdJujuSuite) TestServiceSetConstraints(c *gc.C) {
+	svc := s.AddTestingService(c, "svc", s.AddTestingCharm(c, "dummy"))
+	_, err := runCommand(c, "service", "set-constraints", "svc", "mem=4G", "cpu-power=250")
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := svc.Constraints()
+	c.Assert(err, gc.IsNil)
+	c.Assert(cons, gc.DeepEquals, constraints.Value{
+		CpuPower: uint64p(250),
+		Mem:      uint64p(4096),
+	})
+}
+
+func (s *cmdJujuSuite) TestServiceGetConstraints(c *gc.C) {
+	svc := s.AddTestingService(c, "svc", s.AddTestingCharm(c, "dummy"))
+	err := svc.SetConstraints(constraints.Value{CpuCores: uint64p(64)})
+	c.Assert(err, jc.ErrorIsNil)
+
+	context, err := runCommand(c, "service", "get-constraints", "svc")
+	c.Assert(testing.Stdout(context), gc.Equals, "cpu-cores=64\n")
+	c.Assert(testing.Stderr(context), gc.Equals, "")
+}


### PR DESCRIPTION
This patch introduces a the new service supercommand under
juju.  The new service get/set-constraints subcommands are
also included.

As with the environment get/set-constraints subcommands,
the core functionality for get/set-constraints resides
in the juju/juju/cmd/juju/common directory, and implements
constraints commands for both environments and services.

The get/set-constraints subcommands for service only
need to enforce that only service constraints are set or
retrieved through those commands.

The behavior of service set-constraints was also modified
from the behavior of the top level set-constraints command
to not require a -s or --service flag for specifying the
service.  For consistency, both get and set expect that the
first argument passed in is the service name.

(Review request: http://reviews.vapour.ws/r/1061/)