### PR TITLE
state: tidied up newState

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -194,7 +194,7 @@ func GetPasswordHash(e Authenticator) string {
 }
 
 func init() {
-	logSize = logSizeTests
+	txnLogSize = txnLogSizeTests
 }
 
 // TxnRevno returns the txn-revno field of the document

--- a/state/open.go
+++ b/state/open.go
@@ -184,8 +184,8 @@ var indexes = []struct {
 // It's tweaked in export_test.go to 1MB to avoid the overhead of
 // creating and deleting the large file repeatedly in tests.
 var (
-	logSize      = 10000000
-	logSizeTests = 1000000
+	txnLogSize      = 10000000
+	txnLogSizeTests = 1000000
 )
 
 func maybeUnauthorized(err error, msg string) error {
@@ -229,27 +229,27 @@ func newState(session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (
 	}
 
 	db := session.DB("juju")
+
+	// Create collections used to track client-side transactions (mgo/txn).
+	txnLog := db.C(txnLogC)
+	txnLogInfo := mgo.CollectionInfo{Capped: true, MaxBytes: txnLogSize}
+	err := txnLog.Create(&txnLogInfo)
+	if isCollectionExistsError(err) {
+		return nil, maybeUnauthorized(err, "cannot create transaction log collection")
+	}
+	txns := db.C(txnsC)
+	err = txns.Create(new(mgo.CollectionInfo))
+	if isCollectionExistsError(err) {
+		return nil, maybeUnauthorized(err, "cannot create transaction collection")
+	}
+
+	// Create and set up State.
 	st := &State{
 		mongoInfo: mongoInfo,
 		policy:    policy,
 		db:        db,
+		watcher:   watcher.New(txnLog),
 	}
-	st.LeasePersistor = NewLeasePersistor(leaseC, st.runTransaction, st.getCollection)
-	log := db.C(txnLogC)
-	logInfo := mgo.CollectionInfo{Capped: true, MaxBytes: logSize}
-	// The lack of error code for this error was reported upstream:
-	//     https://jira.mongodb.org/browse/SERVER-6992
-	err := log.Create(&logInfo)
-	if err != nil && err.Error() != "collection already exists" {
-		return nil, maybeUnauthorized(err, "cannot create log collection")
-	}
-	txns := db.C(txnsC)
-	err = txns.Create(&mgo.CollectionInfo{})
-	if err != nil && err.Error() != "collection already exists" {
-		return nil, maybeUnauthorized(err, "cannot create transaction collection")
-	}
-
-	st.watcher = watcher.New(log)
 	defer func() {
 		if resultErr != nil {
 			if err := st.watcher.Stop(); err != nil {
@@ -257,7 +257,9 @@ func newState(session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (
 			}
 		}
 	}()
+	st.LeasePersistor = NewLeasePersistor(leaseC, st.runTransaction, st.getCollection)
 
+	// Create DB indexes.
 	for _, item := range indexes {
 		index := mgo.Index{Key: item.key, Unique: item.unique, Sparse: item.sparse}
 		if err := db.C(item.collection).EnsureIndex(index); err != nil {
@@ -266,6 +268,12 @@ func newState(session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (
 	}
 
 	return st, nil
+}
+
+func isCollectionExistsError(err error) bool {
+	// The lack of error code for this error was reported upstream:
+	//     https://jira.mongodb.org/browse/SERVER-6992
+	return err != nil && err.Error() != "collection already exists"
 }
 
 // MongoConnectionInfo returns information for connecting to mongo


### PR DESCRIPTION
The newState func has been cleaned up to make it easier to follow.

Specifically:

1. More logical ordering. The collections used by mgo/txn are set up first before State is created.
2. Extracted out the check for the "collection already exists" error to it's own function.
3. Renamed the logSize constant to txnLogSize to avoid confusion with other kinds of logging.

(Review request: http://reviews.vapour.ws/r/1062/)