### PR TITLE
worker/provisioner: use lxc host arch in FindTools

### DIFF
--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -177,12 +177,16 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 	}
 }
 
-func (s *ContainerSetupSuite) TestKvmContainerUsesConstraintsArch(c *gc.C) {
+func (s *ContainerSetupSuite) TestLxcContainerUsesConstraintsArch(c *gc.C) {
+	// LXC should override the architecture in constraints with the
+	// host's architecture.
 	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
 	s.testContainerConstraintsArch(c, instance.LXC, arch.PPC64EL)
 }
 
-func (s *ContainerSetupSuite) TestLxcContainerUsesHostArch(c *gc.C) {
+func (s *ContainerSetupSuite) TestKvmContainerUsesHostArch(c *gc.C) {
+	// KVM should do what it's told, and use the architecture in
+	// constraints.
 	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
 	s.testContainerConstraintsArch(c, instance.KVM, arch.AMD64)
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -235,7 +235,8 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
 	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	return provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker)
+	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
+	return provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker, toolsFinder)
 }
 
 func (s *kvmProvisionerSuite) TestProvisionerStartStop(c *gc.C) {

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -134,3 +134,13 @@ func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 func (broker *lxcBroker) AllInstances() (result []instance.Instance, err error) {
 	return broker.manager.ListContainers()
 }
+
+type hostArchToolsFinder struct {
+	f ToolsFinder
+}
+
+// FindTools is defined on the ToolsFinder interface.
+func (h hostArchToolsFinder) FindTools(v version.Number, series string, arch *string) (tools.List, error) {
+	// Override the arch constraint with the arch of the host.
+	return h.f.FindTools(v, series, &version.Current.Arch)
+}

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -319,7 +319,8 @@ func (s *lxcProvisionerSuite) newLxcProvisioner(c *gc.C) provisioner.Provisioner
 	}
 	broker, err := provisioner.NewLxcBroker(s.provisioner, agentConfig, managerConfig, &containertesting.MockURLGetter{})
 	c.Assert(err, jc.ErrorIsNil)
-	return provisioner.NewContainerProvisioner(instance.LXC, s.provisioner, agentConfig, broker)
+	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
+	return provisioner.NewContainerProvisioner(instance.LXC, s.provisioner, agentConfig, broker, toolsFinder)
 }
 
 func (s *lxcProvisionerSuite) TestProvisionerStartStop(c *gc.C) {

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -59,6 +59,7 @@ type provisioner struct {
 	st          *apiprovisioner.State
 	agentConfig agent.Config
 	broker      environs.InstanceBroker
+	toolsFinder ToolsFinder
 	tomb        tomb.Tomb
 }
 
@@ -142,7 +143,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		machineTag,
 		harvestMode,
 		p.st,
-		getToolsFinder(p.st),
+		p.toolsFinder,
 		machineWatcher,
 		retryWatcher,
 		p.broker,
@@ -161,6 +162,7 @@ func NewEnvironProvisioner(st *apiprovisioner.State, agentConfig agent.Config) P
 		provisioner: provisioner{
 			st:          st,
 			agentConfig: agentConfig,
+			toolsFinder: getToolsFinder(st),
 		},
 	}
 	p.Provisioner = p
@@ -240,14 +242,20 @@ func (p *environProvisioner) setConfig(environConfig *config.Config) error {
 // NewContainerProvisioner returns a new Provisioner. When new machines
 // are added to the state, it allocates instances from the environment
 // and allocates them to the new machines.
-func NewContainerProvisioner(containerType instance.ContainerType, st *apiprovisioner.State,
-	agentConfig agent.Config, broker environs.InstanceBroker) Provisioner {
+func NewContainerProvisioner(
+	containerType instance.ContainerType,
+	st *apiprovisioner.State,
+	agentConfig agent.Config,
+	broker environs.InstanceBroker,
+	toolsFinder ToolsFinder,
+) Provisioner {
 
 	p := &containerProvisioner{
 		provisioner: provisioner{
 			st:          st,
 			agentConfig: agentConfig,
 			broker:      broker,
+			toolsFinder: toolsFinder,
 		},
 		containerType: containerType,
 	}


### PR DESCRIPTION
When calling FindTools, LXC provisioners should
override the environment constraints with the
arch of the host machine.

Fixes https://bugs.launchpad.net/juju-core/+bug/1420049

(Review request: http://reviews.vapour.ws/r/1065/)