### PR TITLE
Use new charm storage metadata minimum size

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -1620,6 +1620,16 @@ func (s *clientSuite) assertPrincipalDeployed(c *gc.C, serviceName string, curl 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(force, gc.Equals, forced)
 	c.Assert(charm.URL(), gc.DeepEquals, curl)
+	// When charms are read from state, storage properties are
+	// always deserialised as empty slices if empty or nil, so
+	// update bundle to match (bundle comes from parsing charm
+	// metadata yaml where nil means nil).
+	for name, bundleMeta := range bundle.Meta().Storage {
+		if bundleMeta.Properties == nil {
+			bundleMeta.Properties = []string{}
+			bundle.Meta().Storage[name] = bundleMeta
+		}
+	}
 	c.Assert(charm.Meta(), gc.DeepEquals, bundle.Meta())
 	c.Assert(charm.Config(), gc.DeepEquals, bundle.Config())
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -7,6 +7,7 @@ code.google.com/p/google-api-go-client	hg	6ddfebb10ece847f1ae09c701834f1b15abbd8
 code.google.com/p/winsvc	hg	d6f79143ccd1138cc9d86c9fc75b1d6f8b1b95fb	10
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
 github.com/coreos/go-systemd	git	2d21675230a81a503f4363f4aa3490af06d52bb8	2015-01-26T19:09:17Z
+github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
 github.com/godbus/dbus	git	88765d85c0fdadcd98a54e30694fa4e4f5b51133	2015-01-22T18:02:51Z
 github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
@@ -29,7 +30,7 @@ github.com/juju/utils	git	3efdaa3f15cc47ee83f6c03f640dc14f5915e289	2015-02-05T10
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
 gopkg.in/amz.v3	git	bc7a71d636cdceb31e7d01c9c77e94b750ab56b2	2015-03-02T07:27:58Z
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	2014-08-27T13:58:41Z
-gopkg.in/juju/charm.v4	git	83a8d0dcae192db1157ae334c654cdea83f3b8e9	2015-02-19T20:51:22Z
+gopkg.in/juju/charm.v4	git	c9dacb8f7647108fd1837666145fc3ea05eb9e26	2015-03-03T11:49:15Z
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	2014-07-30T20:00:37Z
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	2014-07-25T20:51:33Z
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08-11T16:19:00Z

--- a/state/storage.go
+++ b/state/storage.go
@@ -840,10 +840,7 @@ func addDefaultStorageConstraints(st *State, allCons map[string]StorageConstrain
 		allCons = make(map[string]StorageConstraints)
 	}
 	for name, charmStorage := range charmMeta.Storage {
-		cons, ok := allCons[name]
-		if !ok {
-			cons = StorageConstraints{}
-		}
+		cons := allCons[name]
 		kind := storageKind(charmStorage.Type)
 		var err error
 		cons, err = storageConstraintsWithDefaults(conf, kind, charmStorage, cons)

--- a/testcharms/charm-repo/quantal/storage-block2/metadata.yaml
+++ b/testcharms/charm-repo/quantal/storage-block2/metadata.yaml
@@ -10,3 +10,4 @@ storage:
         type: block
         multiple:
                 range: 2-
+        minimum-size: 2G


### PR DESCRIPTION
Now that charm storage metadata has minimums-zie, we can use it to fill in default storage constraint values and also validate.
In implementing this, an error was discovered and fixed in the default constraint population.

(Review request: http://reviews.vapour.ws/r/1066/)