### PR TITLE
service: predictable ListServicesCommand output

### DIFF
--- a/cmd/juju/environment/create.go
+++ b/cmd/juju/environment/create.go
@@ -125,7 +125,7 @@ func (c *CreateCommand) Run(ctx *cmd.Context) (err error) {
 		if err != nil {
 			e := info.Destroy()
 			if e != nil {
-				logger.Errorf("could not remove environment file: ", e)
+				logger.Errorf("could not remove environment file: %v", e)
 			}
 		}
 	}()

--- a/service/service.go
+++ b/service/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/service/systemd"
@@ -185,10 +186,17 @@ func ListServicesCommand() string {
 	// TODO(ericsnow) Allow passing in "initSystems ...string".
 	executables := linuxExecutables
 
+	// Sort executable names for predictable commands, simplifying testing.
+	sortedExecutables := make(set.Strings)
+	for executable := range executables {
+		sortedExecutables.Add(executable)
+	}
+
 	// TODO(ericsnow) build the command in a better way?
 
 	cmdAll := ""
-	for executable, initSystem := range executables {
+	for _, executable := range sortedExecutables.SortedValues() {
+		initSystem := executables[executable]
 		cmd, ok := listServicesCommand(initSystem)
 		if !ok {
 			continue


### PR DESCRIPTION
ListServicesCommand iterates over a map to generate a command. We were
previously relying on service listing commands being predictable, and this
new behaviour is not, since iterating over a map is pseudo-random. We
change the function to iterate over the sorted map keys instead.

Also:
    cmd/juju/environment: add missing formatting

(Review request: http://reviews.vapour.ws/r/1068/)