### PR TITLE
worker/provisioner: use lxc host arch in FindTools

### DIFF
--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -136,14 +136,15 @@ func (cs *ContainerSetup) initialiseAndStartProvisioner(containerType instance.C
 	}()
 
 	logger.Debugf("setup and start provisioner for %s containers", containerType)
-	if initialiser, broker, err := cs.getContainerArtifacts(containerType); err != nil {
+	toolsFinder := getToolsFinder(cs.provisioner)
+	initialiser, broker, toolsFinder, err := cs.getContainerArtifacts(containerType, toolsFinder)
+	if err != nil {
 		return errors.Annotate(err, "initialising container infrastructure on host machine")
-	} else {
-		if err := cs.runInitialiser(containerType, initialiser); err != nil {
-			return errors.Annotate(err, "setting up container dependencies on host machine")
-		}
-		return StartProvisioner(cs.runner, containerType, cs.provisioner, cs.config, broker)
 	}
+	if err := cs.runInitialiser(containerType, initialiser); err != nil {
+		return errors.Annotate(err, "setting up container dependencies on host machine")
+	}
+	return StartProvisioner(cs.runner, containerType, cs.provisioner, cs.config, broker, toolsFinder)
 }
 
 // runInitialiser runs the container initialiser with the initialisation hook held.
@@ -162,38 +163,58 @@ func (cs *ContainerSetup) TearDown() error {
 	return nil
 }
 
-func (cs *ContainerSetup) getContainerArtifacts(containerType instance.ContainerType) (container.Initialiser, environs.InstanceBroker, error) {
+// getContainerArtifacts returns type-specific interfaces for
+// managing containers.
+//
+// The ToolsFinder passed in may be replaced or wrapped to
+// enforce container-specific constraints.
+func (cs *ContainerSetup) getContainerArtifacts(
+	containerType instance.ContainerType, toolsFinder ToolsFinder,
+) (
+	container.Initialiser,
+	environs.InstanceBroker,
+	ToolsFinder,
+	error,
+) {
 	var initialiser container.Initialiser
 	var broker environs.InstanceBroker
 
 	managerConfig, err := containerManagerConfig(containerType, cs.provisioner, cs.config)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	switch containerType {
 	case instance.LXC:
 		series, err := cs.machine.Series()
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		initialiser = lxc.NewContainerInitialiser(series)
 		broker, err = NewLxcBroker(cs.provisioner, cs.config, managerConfig, cs.imageURLGetter)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
+
+		// LXC containers must have the same architecture as the host.
+		// We should call through to the finder since the version of
+		// tools running on the host may not match, but we want to
+		// override the arch constraint with the arch of the host.
+		toolsFinder = hostArchToolsFinder{toolsFinder}
+
 	case instance.KVM:
 		initialiser = kvm.NewContainerInitialiser()
 		broker, err = NewKvmBroker(cs.provisioner, cs.config, managerConfig)
 		if err != nil {
 			logger.Errorf("failed to create new kvm broker")
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	default:
-		return nil, nil, fmt.Errorf("unknown container type: %v", containerType)
+		return nil, nil, nil, fmt.Errorf("unknown container type: %v", containerType)
 	}
-	return initialiser, broker, nil
+
+	return initialiser, broker, toolsFinder, nil
 }
 
 func containerManagerConfig(
@@ -226,13 +247,19 @@ var StartProvisioner = startProvisionerWorker
 
 // startProvisionerWorker kicks off a provisioner task responsible for creating containers
 // of the specified type on the machine.
-func startProvisionerWorker(runner worker.Runner, containerType instance.ContainerType,
-	provisioner *apiprovisioner.State, config agent.Config, broker environs.InstanceBroker) error {
+func startProvisionerWorker(
+	runner worker.Runner,
+	containerType instance.ContainerType,
+	provisioner *apiprovisioner.State,
+	config agent.Config,
+	broker environs.InstanceBroker,
+	toolsFinder ToolsFinder,
+) error {
 
 	workerName := fmt.Sprintf("%s-provisioner", containerType)
 	// The provisioner task is created after a container record has already been added to the machine.
 	// It will see that the container does not have an instance yet and create one.
 	return runner.StartWorker(workerName, func() (worker.Worker, error) {
-		return NewContainerProvisioner(containerType, provisioner, config, broker), nil
+		return NewContainerProvisioner(containerType, provisioner, config, broker, toolsFinder), nil
 	})
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -21,8 +21,10 @@ import (
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/provisioner"
@@ -134,7 +136,8 @@ func (s *ContainerSetupSuite) assertContainerProvisionerStarted(
 	// A stub worker callback to record what happens.
 	provisionerStarted := false
 	startProvisionerWorker := func(runner worker.Runner, containerType instance.ContainerType,
-		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker) error {
+		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
+		toolsFinder provisioner.ToolsFinder) error {
 		c.Assert(containerType, gc.Equals, ctype)
 		c.Assert(cfg.Tag(), gc.Equals, host.Tag())
 		provisionerStarted = true
@@ -167,7 +170,57 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 	}
 }
 
-func (s *ContainerSetupSuite) TestLxcContainerUesImageURL(c *gc.C) {
+func (s *ContainerSetupSuite) TestKvmContainerUsesConstraintsArch(c *gc.C) {
+	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
+	s.testContainerConstraintsArch(c, instance.LXC, arch.PPC64EL)
+}
+
+func (s *ContainerSetupSuite) TestLxcContainerUsesHostArch(c *gc.C) {
+	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
+	s.testContainerConstraintsArch(c, instance.KVM, arch.AMD64)
+}
+
+func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerType instance.ContainerType, expectArch string) {
+	var called bool
+	s.PatchValue(provisioner.GetToolsFinder, func(*apiprovisioner.State) provisioner.ToolsFinder {
+		return toolsFinderFunc(func(v version.Number, series string, arch *string) (tools.List, error) {
+			called = true
+			c.Assert(arch, gc.NotNil)
+			c.Assert(*arch, gc.Equals, expectArch)
+			result := version.Current
+			result.Number = v
+			result.Series = series
+			result.Arch = *arch
+			return tools.List{{Version: result}}, nil
+		})
+	})
+
+	s.PatchValue(&provisioner.StartProvisioner, func(runner worker.Runner, containerType instance.ContainerType,
+		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
+		toolsFinder provisioner.ToolsFinder) error {
+		amd64 := arch.AMD64
+		toolsFinder.FindTools(version.Current.Number, version.Current.Series, &amd64)
+		return nil
+	})
+
+	// create a machine to host the container.
+	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
+		Series:      coretesting.FakeDefaultSeries,
+		Jobs:        []state.MachineJob{state.JobHostUnits},
+		Constraints: s.defaultConstraints,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetSupportedContainers([]instance.ContainerType{containerType})
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetAgentVersion(version.Current)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.createContainer(c, m, containerType)
+	<-s.aptCmdChan
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *ContainerSetupSuite) TestLxcContainerUsesImageURL(c *gc.C) {
 	// create a machine to host the container.
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
 		Series:      coretesting.FakeDefaultSeries,
@@ -211,7 +264,8 @@ func (s *ContainerSetupSuite) TestContainerManagerConfigName(c *gc.C) {
 func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, ctype instance.ContainerType, packages []string) {
 	// A noop worker callback.
 	startProvisionerWorker := func(runner worker.Runner, containerType instance.ContainerType,
-		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker) error {
+		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
+		toolsFinder provisioner.ToolsFinder) error {
 		return nil
 	}
 	s.PatchValue(&provisioner.StartProvisioner, startProvisionerWorker)
@@ -273,4 +327,10 @@ func (s *ContainerSetupSuite) TestContainerInitLockError(c *gc.C) {
 	err = handler.Handle([]string{"0/lxc/0"})
 	c.Assert(err, gc.ErrorMatches, ".*failed to acquire initialization lock:.*")
 
+}
+
+type toolsFinderFunc func(v version.Number, series string, arch *string) (tools.List, error)
+
+func (t toolsFinderFunc) FindTools(v version.Number, series string, arch *string) (tools.List, error) {
+	return t(v, series, arch)
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -170,12 +170,16 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 	}
 }
 
-func (s *ContainerSetupSuite) TestKvmContainerUsesConstraintsArch(c *gc.C) {
+func (s *ContainerSetupSuite) TestLxcContainerUsesConstraintsArch(c *gc.C) {
+	// LXC should override the architecture in constraints with the
+	// host's architecture.
 	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
 	s.testContainerConstraintsArch(c, instance.LXC, arch.PPC64EL)
 }
 
-func (s *ContainerSetupSuite) TestLxcContainerUsesHostArch(c *gc.C) {
+func (s *ContainerSetupSuite) TestKvmContainerUsesHostArch(c *gc.C) {
+	// KVM should do what it's told, and use the architecture in
+	// constraints.
 	s.PatchValue(&version.Current.Arch, arch.PPC64EL)
 	s.testContainerConstraintsArch(c, instance.KVM, arch.AMD64)
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -214,7 +214,8 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
 	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	return provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker)
+	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
+	return provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker, toolsFinder)
 }
 
 func (s *kvmProvisionerSuite) TestProvisionerStartStop(c *gc.C) {

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -134,3 +134,13 @@ func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 func (broker *lxcBroker) AllInstances() (result []instance.Instance, err error) {
 	return broker.manager.ListContainers()
 }
+
+type hostArchToolsFinder struct {
+	f ToolsFinder
+}
+
+// FindTools is defined on the ToolsFinder interface.
+func (h hostArchToolsFinder) FindTools(v version.Number, series string, arch *string) (tools.List, error) {
+	// Override the arch constraint with the arch of the host.
+	return h.f.FindTools(v, series, &version.Current.Arch)
+}

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -289,7 +289,8 @@ func (s *lxcProvisionerSuite) newLxcProvisioner(c *gc.C) provisioner.Provisioner
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju", "use-clone": "false"}
 	broker, err := provisioner.NewLxcBroker(s.provisioner, agentConfig, managerConfig, &containertesting.MockURLGetter{})
 	c.Assert(err, jc.ErrorIsNil)
-	return provisioner.NewContainerProvisioner(instance.LXC, s.provisioner, agentConfig, broker)
+	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
+	return provisioner.NewContainerProvisioner(instance.LXC, s.provisioner, agentConfig, broker, toolsFinder)
 }
 
 func (s *lxcProvisionerSuite) TestProvisionerStartStop(c *gc.C) {

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -58,6 +58,7 @@ type provisioner struct {
 	st          *apiprovisioner.State
 	agentConfig agent.Config
 	broker      environs.InstanceBroker
+	toolsFinder ToolsFinder
 	tomb        tomb.Tomb
 }
 
@@ -141,7 +142,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		machineTag,
 		harvestMode,
 		p.st,
-		getToolsFinder(p.st),
+		p.toolsFinder,
 		machineWatcher,
 		retryWatcher,
 		p.broker,
@@ -160,6 +161,7 @@ func NewEnvironProvisioner(st *apiprovisioner.State, agentConfig agent.Config) P
 		provisioner: provisioner{
 			st:          st,
 			agentConfig: agentConfig,
+			toolsFinder: getToolsFinder(st),
 		},
 	}
 	p.Provisioner = p
@@ -239,14 +241,20 @@ func (p *environProvisioner) setConfig(environConfig *config.Config) error {
 // NewContainerProvisioner returns a new Provisioner. When new machines
 // are added to the state, it allocates instances from the environment
 // and allocates them to the new machines.
-func NewContainerProvisioner(containerType instance.ContainerType, st *apiprovisioner.State,
-	agentConfig agent.Config, broker environs.InstanceBroker) Provisioner {
+func NewContainerProvisioner(
+	containerType instance.ContainerType,
+	st *apiprovisioner.State,
+	agentConfig agent.Config,
+	broker environs.InstanceBroker,
+	toolsFinder ToolsFinder,
+) Provisioner {
 
 	p := &containerProvisioner{
 		provisioner: provisioner{
 			st:          st,
 			agentConfig: agentConfig,
 			broker:      broker,
+			toolsFinder: toolsFinder,
 		},
 		containerType: containerType,
 	}


### PR DESCRIPTION
(Backport of https://github.com/juju/juju/pull/1735)

When calling FindTools, LXC provisioners should
override the environment constraints with the
arch of the host machine.

Fixes https://bugs.launchpad.net/juju-core/+bug/1420049

(Review request: http://reviews.vapour.ws/r/1069/)