### PR TITLE
Metrics spool for store and forward of metrics in the uniter.

### DIFF
--- a/worker/uniter/paths.go
+++ b/worker/uniter/paths.go
@@ -48,6 +48,11 @@ func (paths Paths) GetJujucSocket() string {
 	return paths.Runtime.JujucServerSocket
 }
 
+// GetMetricsSpoolDir exists to satisfy the runner.Paths interface.
+func (paths Paths) GetMetricsSpoolDir() string {
+	return paths.State.MetricsSpoolDir
+}
+
 // RuntimePaths represents the set of paths that are relevant at runtime.
 type RuntimePaths struct {
 
@@ -85,6 +90,10 @@ type StatePaths struct {
 	// StorageDir holds storage-specific information about what the
 	// uniter is doing and/or has done.
 	StorageDir string
+
+	// MetricsSpoolDir acts as temporary storage for metrics being sent from
+	// the uniter to state.
+	MetricsSpoolDir string
 }
 
 // NewPaths returns the set of filesystem paths that the supplied unit should
@@ -114,12 +123,13 @@ func NewPaths(dataDir string, unitTag names.UnitTag) Paths {
 			JujucServerSocket: socket("agent", true),
 		},
 		State: StatePaths{
-			CharmDir:       join(baseDir, "charm"),
-			OperationsFile: join(stateDir, "uniter"),
-			RelationsDir:   join(stateDir, "relations"),
-			BundlesDir:     join(stateDir, "bundles"),
-			DeployerDir:    join(stateDir, "deployer"),
-			StorageDir:     join(stateDir, "storage"),
+			CharmDir:        join(baseDir, "charm"),
+			OperationsFile:  join(stateDir, "uniter"),
+			RelationsDir:    join(stateDir, "relations"),
+			BundlesDir:      join(stateDir, "bundles"),
+			DeployerDir:     join(stateDir, "deployer"),
+			StorageDir:      join(stateDir, "storage"),
+			MetricsSpoolDir: join(stateDir, "spool", "metrics"),
 		},
 	}
 }

--- a/worker/uniter/paths_test.go
+++ b/worker/uniter/paths_test.go
@@ -44,12 +44,13 @@ func (s *PathsSuite) TestWindows(c *gc.C) {
 			JujucServerSocket: `\\.\pipe\unit-some-service-323-agent`,
 		},
 		State: uniter.StatePaths{
-			CharmDir:       relAgent("charm"),
-			OperationsFile: relAgent("state", "uniter"),
-			RelationsDir:   relAgent("state", "relations"),
-			BundlesDir:     relAgent("state", "bundles"),
-			DeployerDir:    relAgent("state", "deployer"),
-			StorageDir:     relAgent("state", "storage"),
+			CharmDir:        relAgent("charm"),
+			OperationsFile:  relAgent("state", "uniter"),
+			RelationsDir:    relAgent("state", "relations"),
+			BundlesDir:      relAgent("state", "bundles"),
+			DeployerDir:     relAgent("state", "deployer"),
+			StorageDir:      relAgent("state", "storage"),
+			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})
 }
@@ -70,12 +71,13 @@ func (s *PathsSuite) TestOther(c *gc.C) {
 			JujucServerSocket: "@" + relAgent("agent.socket"),
 		},
 		State: uniter.StatePaths{
-			CharmDir:       relAgent("charm"),
-			OperationsFile: relAgent("state", "uniter"),
-			RelationsDir:   relAgent("state", "relations"),
-			BundlesDir:     relAgent("state", "bundles"),
-			DeployerDir:    relAgent("state", "deployer"),
-			StorageDir:     relAgent("state", "storage"),
+			CharmDir:        relAgent("charm"),
+			OperationsFile:  relAgent("state", "uniter"),
+			RelationsDir:    relAgent("state", "relations"),
+			BundlesDir:      relAgent("state", "bundles"),
+			DeployerDir:     relAgent("state", "deployer"),
+			StorageDir:      relAgent("state", "storage"),
+			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})
 }
@@ -87,10 +89,12 @@ func (s *PathsSuite) TestContextInterface(c *gc.C) {
 			JujucServerSocket: "/path/to/socket",
 		},
 		State: uniter.StatePaths{
-			CharmDir: "/path/to/charm",
+			CharmDir:        "/path/to/charm",
+			MetricsSpoolDir: "/path/to/spool/metrics",
 		},
 	}
 	c.Assert(paths.GetToolsDir(), gc.Equals, "/path/to/tools")
 	c.Assert(paths.GetCharmDir(), gc.Equals, "/path/to/charm")
 	c.Assert(paths.GetJujucSocket(), gc.Equals, "/path/to/socket")
+	c.Assert(paths.GetMetricsSpoolDir(), gc.Equals, "/path/to/spool/metrics")
 }

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -188,12 +188,25 @@ func (f *factory) NewHookRunner(hookInfo hook.Info) (Runner, error) {
 	}
 	// Metrics are only sent from the collect-metrics hook.
 	if hookInfo.Kind == hooks.CollectMetrics {
-		ctx.canAddMetrics = true
 		ch, err := f.getCharm()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		ctx.definedMetrics = ch.Metrics()
+
+		chURL, err := f.unit.CharmURL()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		ctx.metricsRecorder, err = NewJSONMetricsRecorder(f.paths.GetMetricsSpoolDir(), chURL.String())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ctx.metricsReader, err = NewJSONMetricsReader(f.paths.GetMetricsSpoolDir())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	ctx.id = f.newId(hookName)
 	runner := NewRunner(ctx, f.paths)
@@ -269,7 +282,7 @@ func (f *factory) coreContext() (*HookContext, error) {
 		serviceOwner:       f.ownerTag,
 		relations:          f.getContextRelations(),
 		relationId:         -1,
-		canAddMetrics:      false,
+		metricsRecorder:    nil,
 		definedMetrics:     nil,
 		pendingPorts:       make(map[PortRange]PortRangeInfo),
 		storage:            f.storage,

--- a/worker/uniter/runner/metrics.go
+++ b/worker/uniter/runner/metrics.go
@@ -1,0 +1,279 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"github.com/juju/utils/fslock"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+const spoolLockName string = "access"
+
+var lockTimeout = time.Second * 5
+
+// MetricsMetadata is used to store metadata for the current metric batch.
+type MetricsMetadata struct {
+	CharmURL string `json:"charmurl"`
+	UUID     string `json:"uuid"`
+}
+
+// JSONMetricsRecorder implements the MetricsRecorder interface
+// and writes metrics to a spool directory for store-and-forward.
+type JSONMetricsRecorder struct {
+	sync.Mutex
+
+	path string
+
+	file io.Closer
+	enc  *json.Encoder
+}
+
+// NewJSONMetricsRecorder creates a new JSON metrics recorder.
+// It checks if the metrics spool directory exists, if it does not - it is created. Then
+// it tries to find an unused metric batch UUID 3 times.
+func NewJSONMetricsRecorder(spoolDir string, charmURL string) (rec *JSONMetricsRecorder, rErr error) {
+	lock, err := fslock.NewLock(spoolDir, spoolLockName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := lock.LockWithTimeout(lockTimeout, "initializing recorder"); err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer func() {
+		err := lock.Unlock()
+		if err != nil && rErr == nil {
+			rErr = errors.Trace(err)
+			rec = nil
+		} else if err != nil {
+			rErr = errors.Annotatef(err, "failed to unlock spool directory %q", spoolDir)
+		}
+	}()
+
+	if err := checkSpoolDir(spoolDir); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	mbUUID, err := utils.NewUUID()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	metaFile := filepath.Join(spoolDir, fmt.Sprintf("%s.meta", mbUUID.String()))
+	dataFile := filepath.Join(spoolDir, mbUUID.String())
+	if _, err := os.Stat(metaFile); !os.IsNotExist(err) {
+		if err != nil {
+			return nil, errors.Annotatef(err, "failed to stat file %s", metaFile)
+		}
+		return nil, errors.Errorf("file %s already exists", metaFile)
+	}
+	if _, err := os.Stat(dataFile); err != nil && !os.IsNotExist(err) {
+		if err != nil {
+			return nil, errors.Annotatef(err, "failed to stat file %s", dataFile)
+		}
+		return nil, errors.Errorf("file %s already exists", dataFile)
+	}
+
+	if err := recordMetaData(metaFile, charmURL, mbUUID.String()); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	recorder := &JSONMetricsRecorder{
+		path: dataFile,
+	}
+	if err := recorder.open(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return recorder, nil
+}
+
+// Close implements the MetricsRecorder interface.
+func (m *JSONMetricsRecorder) Close() error {
+	m.Lock()
+	defer m.Unlock()
+	return errors.Trace(m.file.Close())
+}
+
+// AddMetric implements the MetricsRecorder interface.
+func (m *JSONMetricsRecorder) AddMetric(key, value string, created time.Time) error {
+	m.Lock()
+	defer m.Unlock()
+	return errors.Trace(m.enc.Encode(jujuc.Metric{Key: key, Value: value, Time: created}))
+}
+
+func (m *JSONMetricsRecorder) open() error {
+	dataWriter, err := os.Create(m.path)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	m.file = dataWriter
+	m.enc = json.NewEncoder(dataWriter)
+	return nil
+
+}
+
+func checkSpoolDir(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		err := os.MkdirAll(path, 0755)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func recordMetaData(path string, charmURL, UUID string) error {
+	metadata := MetricsMetadata{
+		CharmURL: charmURL,
+		UUID:     UUID,
+	}
+	metaWriter, err := os.Create(path)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer metaWriter.Close()
+	enc := json.NewEncoder(metaWriter)
+	err = enc.Encode(metadata)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// MetricsBatch stores the information relevant to a single metrics batch.
+type MetricsBatch struct {
+	CharmURL string         `json:"charmurl"`
+	UUID     string         `json:"uuid"`
+	Metrics  []jujuc.Metric `json:"metrics"`
+}
+
+// JSONMetricsReader reads metrics batches stored in the spool directory.
+type JSONMetricsReader struct {
+	dir  string
+	lock *fslock.Lock
+}
+
+// NewJSONMetricsReader creates a new JSON metrics reader for the specified spool directory.
+func NewJSONMetricsReader(spoolDir string) (*JSONMetricsReader, error) {
+	if _, err := os.Stat(spoolDir); err != nil {
+		return nil, errors.Annotatef(err, "failed to open spool directory %q", spoolDir)
+	}
+	lock, err := fslock.NewLock(spoolDir, spoolLockName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &JSONMetricsReader{
+		lock: lock,
+		dir:  spoolDir,
+	}, nil
+}
+
+// Open implements the MetricsReader interface.
+// Due to the way the batches are stored in the file system,
+// they will be returned in an arbitrary order. This does not affect the behavior.
+func (r *JSONMetricsReader) Open() ([]MetricsBatch, error) {
+	var batches []MetricsBatch
+
+	if err := r.lock.LockWithTimeout(lockTimeout, "reading"); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	walker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if info.IsDir() && path != r.dir {
+			return filepath.SkipDir
+		} else if !strings.HasSuffix(info.Name(), ".meta") {
+			return nil
+		}
+
+		batch, err := decodeBatch(path)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		batch.Metrics, err = decodeMetrics(filepath.Join(r.dir, batch.UUID))
+		if err != nil {
+			return errors.Trace(err)
+		}
+		batches = append(batches, batch)
+		return nil
+	}
+	if err := filepath.Walk(r.dir, walker); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return batches, nil
+}
+
+// Remove implements the MetricsReader interface.
+func (r *JSONMetricsReader) Remove(uuid string) error {
+	metaFile := filepath.Join(r.dir, fmt.Sprintf("%s.meta", uuid))
+	dataFile := filepath.Join(r.dir, uuid)
+	err := os.Remove(metaFile)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Trace(err)
+	}
+	err = os.Remove(dataFile)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// Close implements the MetricsReader interface.
+func (r *JSONMetricsReader) Close() error {
+	if r.lock.IsLockHeld() {
+		return r.lock.Unlock()
+	}
+	return nil
+}
+
+func decodeBatch(file string) (MetricsBatch, error) {
+	var batch MetricsBatch
+	f, err := os.Open(file)
+	if err != nil {
+		return MetricsBatch{}, errors.Trace(err)
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	err = dec.Decode(&batch)
+	if err != nil {
+		return MetricsBatch{}, errors.Trace(err)
+	}
+	return batch, nil
+}
+
+func decodeMetrics(file string) ([]jujuc.Metric, error) {
+	var metrics []jujuc.Metric
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	for {
+		var metric jujuc.Metric
+		err := dec.Decode(&metric)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics, nil
+}

--- a/worker/uniter/runner/metrics_test.go
+++ b/worker/uniter/runner/metrics_test.go
@@ -1,0 +1,137 @@
+// Copyright 2012-2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/runner"
+)
+
+type MetricsRecorderSuite struct {
+	testing.IsolationSuite
+
+	paths RealPaths
+}
+
+var _ = gc.Suite(&MetricsRecorderSuite{})
+
+func (s *MetricsRecorderSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.paths = NewRealPaths(c)
+	s.PatchValue(&runner.LockTimeout, jujutesting.ShortWait)
+}
+
+func (s *MetricsRecorderSuite) TestMetricRecorderInit(c *gc.C) {
+	w, err := runner.NewJSONMetricsRecorder(s.paths.GetMetricsSpoolDir(), "local:precise/wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.NotNil)
+	err = w.AddMetric("pings", "5", time.Now())
+	c.Assert(err, jc.ErrorIsNil)
+	err = w.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	r, err := runner.NewJSONMetricsReader(s.paths.GetMetricsSpoolDir())
+	c.Assert(err, jc.ErrorIsNil)
+	batches, err := r.Open()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(batches, gc.HasLen, 1)
+	batch := batches[0]
+	c.Assert(batch.CharmURL, gc.Equals, "local:precise/wordpress")
+	c.Assert(batch.UUID, gc.Not(gc.Equals), "")
+	c.Assert(batch.Metrics, gc.HasLen, 1)
+	c.Assert(batch.Metrics[0].Key, gc.Equals, "pings")
+	c.Assert(batch.Metrics[0].Value, gc.Equals, "5")
+
+	err = r.Close()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type MetricsReaderSuite struct {
+	paths RealPaths
+
+	w runner.MetricsRecorder
+}
+
+var _ = gc.Suite(&MetricsReaderSuite{})
+
+func (s *MetricsReaderSuite) SetUpTest(c *gc.C) {
+	s.paths = NewRealPaths(c)
+
+	var err error
+	s.w, err = runner.NewJSONMetricsRecorder(s.paths.GetMetricsSpoolDir(), "local:precise/wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.w.AddMetric("pings", "5", time.Now())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.w.Close()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MetricsReaderSuite) TestTwoSimultaneousReaders(c *gc.C) {
+	r, err := runner.NewJSONMetricsReader(s.paths.GetMetricsSpoolDir())
+	c.Assert(err, jc.ErrorIsNil)
+
+	r2, err := runner.NewJSONMetricsReader(c.MkDir())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r2, gc.NotNil)
+	err = r2.Close()
+	c.Assert(err, jc.ErrorIsNil)
+	err = r.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+}
+
+func (s *MetricsReaderSuite) TestBlockedReaders(c *gc.C) {
+	r, err := runner.NewJSONMetricsReader(s.paths.GetMetricsSpoolDir())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = r.Open()
+	c.Assert(err, jc.ErrorIsNil)
+
+	r2, err := runner.NewJSONMetricsReader(s.paths.GetMetricsSpoolDir())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = r2.Open()
+	c.Assert(err, gc.ErrorMatches, `lock timeout exceeded`)
+	err = r.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+}
+
+func (s *MetricsReaderSuite) TestUnblockedReaders(c *gc.C) {
+	r, err := runner.NewJSONMetricsReader(s.paths.GetMetricsSpoolDir())
+	c.Assert(err, jc.ErrorIsNil)
+	err = r.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	r2, err := runner.NewJSONMetricsReader(s.paths.GetMetricsSpoolDir())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r2, gc.NotNil)
+	err = r2.Close()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MetricsReaderSuite) TestRemoval(c *gc.C) {
+	r, err := runner.NewJSONMetricsReader(s.paths.GetMetricsSpoolDir())
+	c.Assert(err, jc.ErrorIsNil)
+
+	batches, err := r.Open()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, batch := range batches {
+		err := r.Remove(batch.UUID)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	err = r.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	batches, err = r.Open()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(batches, gc.HasLen, 0)
+	err = r.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+}

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -60,6 +60,10 @@ type Paths interface {
 	// to communicate back to the executing uniter process. It might be a
 	// filesystem path, or it might be abstract.
 	GetJujucSocket() string
+
+	// GetMetricsSpoolDir returns the path to a metrics spool dir, used
+	// to store metrics recorded during a single hook run.
+	GetMetricsSpoolDir() string
 }
 
 // NewRunner returns a Runner backed by the supplied context and paths.

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -48,11 +48,16 @@ func (MockEnvPaths) GetJujucSocket() string {
 	return "path-to-jujuc.socket"
 }
 
+func (MockEnvPaths) GetMetricsSpoolDir() string {
+	return "path-to-metrics-spool-dir"
+}
+
 // RealPaths implements Paths for tests that do touch the filesystem.
 type RealPaths struct {
-	tools  string
-	charm  string
-	socket string
+	tools        string
+	charm        string
+	socket       string
+	metricsspool string
 }
 
 func osDependentSockPath(c *gc.C) string {
@@ -65,10 +70,15 @@ func osDependentSockPath(c *gc.C) string {
 
 func NewRealPaths(c *gc.C) RealPaths {
 	return RealPaths{
-		tools:  c.MkDir(),
-		charm:  c.MkDir(),
-		socket: osDependentSockPath(c),
+		tools:        c.MkDir(),
+		charm:        c.MkDir(),
+		socket:       osDependentSockPath(c),
+		metricsspool: c.MkDir(),
 	}
+}
+
+func (p RealPaths) GetMetricsSpoolDir() string {
+	return p.metricsspool
 }
 
 func (p RealPaths) GetToolsDir() string {
@@ -226,7 +236,7 @@ func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int,
 
 	context, err := runner.NewHookContext(s.apiUnit, facade, "TestCtx", uuid,
 		"test-env-name", relid, remote, relctxs, apiAddrs, names.NewUserTag("owner"),
-		proxies, false, nil, nil, s.machine.Tag().(names.MachineTag))
+		proxies, false, nil, nil, s.machine.Tag().(names.MachineTag), NewRealPaths(c))
 	c.Assert(err, jc.ErrorIsNil)
 	return context
 }
@@ -248,7 +258,7 @@ func (s *HookContextSuite) getMeteredHookContext(c *gc.C, uuid string, relid int
 
 	context, err := runner.NewHookContext(s.meteredApiUnit, facade, "TestCtx", uuid,
 		"test-env-name", relid, remote, relctxs, apiAddrs, names.NewUserTag("owner"),
-		proxies, canAddMetrics, metrics, nil, s.machine.Tag().(names.MachineTag))
+		proxies, canAddMetrics, metrics, nil, s.machine.Tag().(names.MachineTag), NewRealPaths(c))
 	c.Assert(err, jc.ErrorIsNil)
 	return context
 }


### PR DESCRIPTION
Currently metrics are sent by the uniter during hook context finalization. If the api call to sent metrics from a unit returns an error, those metrics are lost. To work around this, metrics batches are now stored in a spoll directory, so in case of failure subsequent hook runs can pick up unsent metrics.

(Review request: http://reviews.vapour.ws/r/1070/)