### PR TITLE
Compute storage (attachment) info on demand

### DIFF
--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -1,0 +1,138 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+)
+
+// StorageInterface is an interface for obtaining information about storage
+// instances and related entities.
+type StorageInterface interface {
+	StorageInstance(names.StorageTag) (state.StorageInstance, error)
+	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
+	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
+	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+}
+
+// StorageAttachmentInfo returns the StorageAttachmentInfo for the specified
+// StorageAttachment by gathering information from related entities (volumes,
+// filesystems).
+func StorageAttachmentInfo(st StorageInterface, att state.StorageAttachment) (*storage.StorageAttachmentInfo, error) {
+	unitTag := att.Unit()
+	machineTag, err := st.UnitAssignedMachine(unitTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	storageInstance, err := st.StorageInstance(att.StorageInstance())
+	if err != nil {
+		return nil, errors.Annotate(err, "getting storage instance")
+	}
+	switch storageInstance.Kind() {
+	case state.StorageKindBlock:
+		return volumeStorageAttachmentInfo(st, storageInstance, machineTag)
+	case state.StorageKindFilesystem:
+		return nil, errors.NotSupportedf("filesystem storage")
+	default:
+		// TODO(axw) handle filesystem kind once
+		// the state.Filesystem branch lands.
+		return nil, errors.Errorf("invalid storage kind %v", storageInstance.Kind())
+	}
+}
+
+func volumeStorageAttachmentInfo(
+	st StorageInterface,
+	storageInstance state.StorageInstance,
+	machineTag names.MachineTag,
+) (*storage.StorageAttachmentInfo, error) {
+	storageTag := storageInstance.StorageTag()
+	volume, err := st.StorageInstanceVolume(storageTag)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting volume")
+	}
+	volumeInfo, err := volume.Info()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting volume info")
+	}
+	volumeAttachment, err := st.VolumeAttachment(machineTag, volume.VolumeTag())
+	if err != nil {
+		return nil, errors.Annotate(err, "getting volume attachment")
+	}
+	volumeAttachmentInfo, err := volumeAttachment.Info()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting volume attachment info")
+	}
+	devicePath, err := volumeAttachmentDevicePath(
+		volumeInfo,
+		volumeAttachmentInfo,
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &storage.StorageAttachmentInfo{devicePath}, nil
+}
+
+func WatchStorageAttachment(st StorageInterface, storageTag names.StorageTag, unitTag names.UnitTag) (state.NotifyWatcher, error) {
+	storageInstance, err := s.st.StorageInstance(storageTag)
+	if err != nil {
+		return nothing, errors.Trace(err)
+	}
+	machineTag, err := s.st.UnitAssignedMachine(unitTag)
+	if err != nil {
+		return nothing, errors.Trace(err)
+	}
+	var watch state.NotifyWatcher
+	switch storageInstance.Kind() {
+	case state.StorageKindBlock:
+		volume, err := s.st.StorageInstanceVolume(storageTag)
+		if err != nil {
+			return nothing, errors.Trace(err)
+		}
+		watch := s.st.WatchVolumeAttachment(machineTag, volume.VolumeTag())
+	default:
+		panic("!")
+	}
+}
+
+// MatchingBlockDevice finds the block device that matches the
+// provided volume info and volume attachment info.
+func MatchingBlockDevice(
+	blockDevices []state.BlockDeviceInfo,
+	volumeInfo state.VolumeInfo,
+	attachmentInfo state.VolumeAttachmentInfo,
+) (*state.BlockDeviceInfo, bool) {
+	for _, dev := range blockDevices {
+		if volumeInfo.Serial != "" {
+			if volumeInfo.Serial == dev.Serial {
+				return &dev, true
+			}
+		} else if attachmentInfo.DeviceName == dev.DeviceName {
+			return &dev, true
+		}
+	}
+	return nil, false
+}
+
+var errNoDevicePath = errors.New("cannot determine device path: no serial or persistent device name")
+
+// volumeAttachmentDevicePath returns the absolute device path for
+// a volume attachment. The value is only meaningful in the context
+// of the machine that the volume is attached to.
+func volumeAttachmentDevicePath(
+	volumeInfo state.VolumeInfo,
+	volumeAttachmentInfo state.VolumeAttachmentInfo,
+) (string, error) {
+	if volumeInfo.Serial != "" {
+		return path.Join("/dev/disk/by-id", volumeInfo.Serial), nil
+	} else if volumeAttachmentInfo.DeviceName != "" {
+		return path.Join("/dev", volumeAttachmentInfo.DeviceName), nil
+	}
+	return "", errNoDevicePath
+}

--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -16,24 +16,43 @@ import (
 // StorageInterface is an interface for obtaining information about storage
 // instances and related entities.
 type StorageInterface interface {
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
+	// StorageInstance returns the state.StorageInstance corresponding
+	// to the specified storage tag.
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
+
+	// StorageInstanceFilesystem returns the state.Filesystem assigned
+	// to the storage instance with the specified storage tag.
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
+
+	// StorageInstanceVolume returns the state.Volume assigned to the
+	// storage instance with the specified storage tag.
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
-	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
+
+	// FilesystemAttachment returns the state.FilesystemAttachment
+	// corresponding to the identified machine and filesystem.
+	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
+
+	// VolumeAttachment returns the state.VolumeAttachment corresponding
+	// to the identified machine and volume.
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+
+	// WatchFilesystemAttachment watches for changes to the filesystem
+	// attachment corresponding to the identfified machien and filesystem.
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
+
+	// WatchVolumeAttachment watches for changes to the volume attachment
+	// corresponding to the identfified machien and volume.
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 }
 
 // StorageAttachmentInfo returns the StorageAttachmentInfo for the specified
 // StorageAttachment by gathering information from related entities (volumes,
 // filesystems).
-func StorageAttachmentInfo(st StorageInterface, att state.StorageAttachment) (*storage.StorageAttachmentInfo, error) {
-	machineTag, err := st.UnitAssignedMachine(att.Unit())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+func StorageAttachmentInfo(
+	st StorageInterface,
+	att state.StorageAttachment,
+	machineTag names.MachineTag,
+) (*storage.StorageAttachmentInfo, error) {
 	storageInstance, err := st.StorageInstance(att.StorageInstance())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting storage instance")
@@ -105,11 +124,11 @@ func filesystemStorageAttachmentInfo(
 // WatchStorageAttachmentInfo returns a state.NotifyWatcher that reacts to changes
 // to the VolumeAttachmentInfo or FilesystemAttachmentInfo corresponding to the tags
 // specified.
-func WatchStorageAttachmentInfo(st StorageInterface, storageTag names.StorageTag, unitTag names.UnitTag) (state.NotifyWatcher, error) {
-	machineTag, err := st.UnitAssignedMachine(unitTag)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+func WatchStorageAttachmentInfo(
+	st StorageInterface,
+	storageTag names.StorageTag,
+	machineTag names.MachineTag,
+) (state.NotifyWatcher, error) {
 	storageInstance, err := st.StorageInstance(storageTag)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting storage instance")

--- a/apiserver/diskmanager/diskmanager.go
+++ b/apiserver/diskmanager/diskmanager.go
@@ -102,6 +102,7 @@ func stateBlockDeviceInfo(devices []storage.BlockDevice) []state.BlockDeviceInfo
 			dev.Size,
 			dev.FilesystemType,
 			dev.InUse,
+			dev.MountPoint,
 		}
 	}
 	return result

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -639,6 +639,7 @@ func volumeAttachmentsToState(in []params.VolumeAttachment) (map[names.VolumeTag
 		}
 		m[volumeTag] = state.VolumeAttachmentInfo{
 			v.DeviceName,
+			false, // not read-only
 		}
 	}
 	return m, nil

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -11,14 +11,16 @@ import (
 )
 
 type storageStateInterface interface {
-	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
+	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
+	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 	StorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 	StorageAttachment(names.StorageTag, names.UnitTag) (state.StorageAttachment, error)
 	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	WatchStorageAttachments(names.UnitTag) state.StringsWatcher
+	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 }
 

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -4,18 +4,22 @@
 package uniter
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/state"
 )
 
 type storageStateInterface interface {
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
+	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 	StorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 	StorageAttachment(names.StorageTag, names.UnitTag) (state.StorageAttachment, error)
-	Unit(name string) (*state.Unit, error)
+	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
+	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	WatchStorageAttachments(names.UnitTag) state.StringsWatcher
-	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
+	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 }
 
 type storageStateShim struct {
@@ -24,4 +28,16 @@ type storageStateShim struct {
 
 var getStorageState = func(st *state.State) storageStateInterface {
 	return storageStateShim{st}
+}
+
+func (s storageStateShim) UnitAssignedMachine(tag names.UnitTag) (names.MachineTag, error) {
+	unit, err := s.Unit(tag.Id())
+	if err != nil {
+		return names.MachineTag{}, errors.Trace(err)
+	}
+	mid, err := unit.AssignedMachineId()
+	if err != nil {
+		return names.MachineTag{}, errors.Trace(err)
+	}
+	return names.NewMachineTag(mid), nil
 }

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -11,13 +11,13 @@ import (
 )
 
 type storageStateInterface interface {
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 	StorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 	StorageAttachment(names.StorageTag, names.UnitTag) (state.StorageAttachment, error)
 	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
+	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	WatchStorageAttachments(names.UnitTag) state.StringsWatcher
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
@@ -32,6 +32,9 @@ var getStorageState = func(st *state.State) storageStateInterface {
 	return storageStateShim{st}
 }
 
+// UnitAssignedMachine returns the tag of the machine that the unit
+// is assigned to, or an error if the unit cannot be obtained or is
+// not assigned to a machine.
 func (s storageStateShim) UnitAssignedMachine(tag names.UnitTag) (names.MachineTag, error) {
 	unit, err := s.Unit(tag.Id())
 	if err != nil {

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -132,7 +132,9 @@ func (s *StorageAPI) getOneStorageAttachment(canAccess common.AuthFunc, id param
 	return s.fromStateStorageAttachment(stateStorageAttachment)
 }
 
-// WatchUnitStorageAttachments creates storage attachment watchers for a collection of units.
+// WatchUnitStorageAttachments creates watchers for a collection of units,
+// each of which can be used to watch for lifecycle changes to the corresponding
+// unit's storage attachments.
 func (s *StorageAPI) WatchUnitStorageAttachments(args params.Entities) (params.StringsWatchResults, error) {
 	canAccess, err := s.accessUnit()
 	if err != nil {
@@ -167,8 +169,10 @@ func (s *StorageAPI) watchOneUnitStorageAttachments(tag string, canAccess func(n
 	return nothing, watcher.EnsureErr(watch)
 }
 
-// WatchUnitStorageAttachments creates watchers for a collection of storage attachments.
-func (s *StorageAPI) WatchStorageAttachments(args params.StorageAttachmentIds) (params.NotifyWatchResults, error) {
+// WatchStorageAttachmentInfos creates watchers for a collection of storage
+// attachments, each of which can be used to watch changes to storage
+// attachment info.
+func (s *StorageAPI) WatchStorageAttachmentInfos(args params.StorageAttachmentIds) (params.NotifyWatchResults, error) {
 	canAccess, err := s.accessUnit()
 	if err != nil {
 		return params.NotifyWatchResults{}, err
@@ -201,7 +205,7 @@ func (s *StorageAPI) watchOneStorageAttachment(id params.StorageAttachmentId, ca
 	if err != nil {
 		return nothing, err
 	}
-	watch, err := common.WatchStorageAttachment(s.st, storageTag, unitTag)
+	watch, err := common.WatchStorageAttachmentInfo(s.st, storageTag, unitTag)
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -79,22 +79,25 @@ func (s *StorageAPI) getOneUnitStorageAttachments(canAccess common.AuthFunc, uni
 }
 
 func (s *StorageAPI) fromStateStorageAttachment(stateStorageAttachment state.StorageAttachment) (params.StorageAttachment, error) {
-	info, err := stateStorageAttachment.Info()
-	if err != nil {
-		return params.StorageAttachment{}, err
-	}
-	stateStorageInstance, err := s.st.StorageInstance(stateStorageAttachment.StorageInstance())
-	if err != nil {
-		return params.StorageAttachment{}, err
-	}
-	return params.StorageAttachment{
-		stateStorageAttachment.StorageInstance().String(),
-		stateStorageInstance.Owner().String(),
-		stateStorageAttachment.Unit().String(),
-		params.StorageKind(stateStorageInstance.Kind()),
-		info.Location,
-		params.Life(stateStorageAttachment.Life().String()),
-	}, nil
+	/*
+		info, err := stateStorageAttachment.Info()
+		if err != nil {
+			return params.StorageAttachment{}, err
+		}
+		stateStorageInstance, err := s.st.StorageInstance(stateStorageAttachment.StorageInstance())
+		if err != nil {
+			return params.StorageAttachment{}, err
+		}
+		return params.StorageAttachment{
+			stateStorageAttachment.StorageInstance().String(),
+			stateStorageInstance.Owner().String(),
+			stateStorageAttachment.Unit().String(),
+			params.StorageKind(stateStorageInstance.Kind()),
+			info.Location,
+			params.Life(stateStorageAttachment.Life().String()),
+		}, nil
+	*/
+	panic("unimplemented")
 }
 
 // StorageAttachments returns the storage attachments with the specified tags.

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -79,7 +79,11 @@ func (s *StorageAPI) getOneUnitStorageAttachments(canAccess common.AuthFunc, uni
 }
 
 func (s *StorageAPI) fromStateStorageAttachment(stateStorageAttachment state.StorageAttachment) (params.StorageAttachment, error) {
-	info, err := common.StorageAttachmentInfo(s.st, stateStorageAttachment)
+	machineTag, err := s.st.UnitAssignedMachine(stateStorageAttachment.Unit())
+	if err != nil {
+		return params.StorageAttachment{}, err
+	}
+	info, err := common.StorageAttachmentInfo(s.st, stateStorageAttachment, machineTag)
 	if err != nil {
 		return params.StorageAttachment{}, err
 	}
@@ -205,7 +209,11 @@ func (s *StorageAPI) watchOneStorageAttachment(id params.StorageAttachmentId, ca
 	if err != nil {
 		return nothing, err
 	}
-	watch, err := common.WatchStorageAttachmentInfo(s.st, storageTag, unitTag)
+	machineTag, err := s.st.UnitAssignedMachine(unitTag)
+	if err != nil {
+		return nothing, err
+	}
+	watch, err := common.WatchStorageAttachmentInfo(s.st, storageTag, machineTag)
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -64,14 +64,30 @@ func (s *storageSuite) TestWatchStorageAttachment(c *gc.C) {
 	}
 	unitTag := names.NewUnitTag("mysql/0")
 	storageTag := names.NewStorageTag("data/0")
+	machineTag := names.NewMachineTag("66")
+	volumeTag := names.NewVolumeTag("104")
+	volume := &mockVolume{tag: volumeTag}
+	storageInstance := &mockStorageInstance{kind: state.StorageKindBlock}
 	watcher := &mockNotifyWatcher{
 		changes: make(chan struct{}, 1),
 	}
 	watcher.changes <- struct{}{}
 	state := &mockStorageState{
-		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) state.NotifyWatcher {
+		storageInstance: func(s names.StorageTag) (state.StorageInstance, error) {
 			c.Assert(s, gc.DeepEquals, storageTag)
+			return storageInstance, nil
+		},
+		storageInstanceVolume: func(s names.StorageTag) (state.Volume, error) {
+			c.Assert(s, gc.DeepEquals, storageTag)
+			return volume, nil
+		},
+		unitAssignedMachine: func(u names.UnitTag) (names.MachineTag, error) {
 			c.Assert(u, gc.DeepEquals, unitTag)
+			return machineTag, nil
+		},
+		watchVolumeAttachment: func(m names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
+			c.Assert(m, gc.DeepEquals, machineTag)
+			c.Assert(v, gc.DeepEquals, volumeTag)
 			return watcher
 		},
 	}
@@ -95,16 +111,31 @@ func (s *storageSuite) TestWatchStorageAttachment(c *gc.C) {
 
 type mockStorageState struct {
 	uniter.StorageStateInterface
+	storageInstance         func(names.StorageTag) (state.StorageInstance, error)
+	storageInstanceVolume   func(names.StorageTag) (state.Volume, error)
+	unitAssignedMachine     func(names.UnitTag) (names.MachineTag, error)
 	watchStorageAttachments func(names.UnitTag) state.StringsWatcher
-	watchStorageAttachment  func(names.StorageTag, names.UnitTag) state.NotifyWatcher
+	watchVolumeAttachment   func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+}
+
+func (m *mockStorageState) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {
+	return m.storageInstance(s)
+}
+
+func (m *mockStorageState) StorageInstanceVolume(s names.StorageTag) (state.Volume, error) {
+	return m.storageInstanceVolume(s)
+}
+
+func (m *mockStorageState) UnitAssignedMachine(u names.UnitTag) (names.MachineTag, error) {
+	return m.unitAssignedMachine(u)
 }
 
 func (m *mockStorageState) WatchStorageAttachments(u names.UnitTag) state.StringsWatcher {
 	return m.watchStorageAttachments(u)
 }
 
-func (m *mockStorageState) WatchStorageAttachment(s names.StorageTag, u names.UnitTag) state.NotifyWatcher {
-	return m.watchStorageAttachment(s, u)
+func (m *mockStorageState) WatchVolumeAttachment(mtag names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
+	return m.watchVolumeAttachment(mtag, v)
 }
 
 type mockStringsWatcher struct {
@@ -123,4 +154,22 @@ type mockNotifyWatcher struct {
 
 func (m *mockNotifyWatcher) Changes() <-chan struct{} {
 	return m.changes
+}
+
+type mockVolume struct {
+	state.Volume
+	tag names.VolumeTag
+}
+
+func (m *mockVolume) VolumeTag() names.VolumeTag {
+	return m.tag
+}
+
+type mockStorageInstance struct {
+	state.StorageInstance
+	kind state.StorageKind
+}
+
+func (m *mockStorageInstance) Kind() state.StorageKind {
+	return m.kind
 }

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -38,6 +38,7 @@ type BlockDeviceInfo struct {
 	Size           uint64 `bson:"size"`
 	FilesystemType string `bson:"fstype,omitempty"`
 	InUse          bool   `bson:"inuse"`
+	MountPoint     string `bson:"mountpoint,omitempty"`
 }
 
 // WatchBlockDevices returns a new NotifyWatcher watching for

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -397,12 +397,10 @@ func (st *State) SetFilesystemInfo(tag names.FilesystemTag, info FilesystemInfo)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		var unsetParams bool
-		if _, ok := fs.Params(); ok {
-			// filesystem has parameters, unset them when
-			// we set info for the first time.
-			unsetParams = true
-		}
+		// If the filesystem has parameters, unset them
+		// when we set info for the first time, ensuring
+		// that params and info are mutually exclusive.
+		_, unsetParams := fs.Params()
 		ops := setFilesystemInfoOps(tag, info, unsetParams)
 		return ops, nil
 	}
@@ -440,12 +438,10 @@ func (st *State) SetFilesystemAttachmentInfo(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		var unsetParams bool
-		if _, ok := fsa.Params(); ok {
-			// filesystem attachment has parameters, unset them
-			// when we set info for the first time.
-			unsetParams = true
-		}
+		// If the filesystem attachment has parameters, unset them
+		// when we set info for the first time, ensuring that params
+		// and info are mutually exclusive.
+		_, unsetParams := fsa.Params()
 		ops := setFilesystemAttachmentInfoOps(machineTag, filesystemTag, info, unsetParams)
 		return ops, nil
 	}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -918,7 +918,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 
 	invalidVolumes := map[names.VolumeTag]state.VolumeInfo{names.NewVolumeTag("1065"): state.VolumeInfo{}}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil)
-	c.Assert(err, gc.ErrorMatches, "cannot set provisioned volume info: already provisioned")
+	c.Assert(err, gc.ErrorMatches, `cannot set info for volume \"1065\": volume \"1065\" not found`)
 	assertNotProvisioned()
 
 	// TODO(axw) test invalid volume attachment

--- a/state/storage.go
+++ b/state/storage.go
@@ -47,11 +47,6 @@ type StorageInstance interface {
 
 	// Life reports whether the storage instance is Alive, Dying or Dead.
 	Life() Life
-
-	// Info returns the storage instance's StorageInstanceInfo, or a
-	// NotProvisioned error if the storage instance has not yet been
-	// provisioned.
-	Info() (StorageInstanceInfo, error)
 }
 
 // StorageAttachment represents the state of a unit's attachment to a storage
@@ -68,11 +63,6 @@ type StorageAttachment interface {
 
 	// Life reports whether the storage attachment is Alive, Dying or Dead.
 	Life() Life
-
-	// Info returns the storage attachments's StorageAttachmentInfo, or
-	// a NotProvisioned error if the storage attachment has not yet been
-	// made.
-	Info() (StorageAttachmentInfo, error)
 }
 
 // StorageKind defines the type of a store: whether it is a block device
@@ -120,13 +110,6 @@ func (s *storageInstance) Life() Life {
 	return s.doc.Life
 }
 
-func (s *storageInstance) Info() (StorageInstanceInfo, error) {
-	if s.doc.Info == nil {
-		return StorageInstanceInfo{}, errors.NotProvisionedf("storage instance %q", s.doc.Id)
-	}
-	return *s.doc.Info, nil
-}
-
 // storageInstanceDoc describes a charm storage instance.
 type storageInstanceDoc struct {
 	DocID   string `bson:"_id"`
@@ -137,16 +120,7 @@ type storageInstanceDoc struct {
 	Life            Life        `bson:"life"`
 	Owner           string      `bson:"owner"`
 	StorageName     string      `bson:"storagename"`
-	BlockDevices    []string    `bson:"blockdevices,omitempty"`
 	AttachmentCount int         `bson:"attachmentcount"`
-
-	Info *StorageInstanceInfo `bson:"info,omitempty"`
-}
-
-// StorageInstanceInfo records information about the storage instance,
-// such as the provisioned size.
-type StorageInstanceInfo struct {
-	Size uint64 `bson:"size"`
 }
 
 type storageAttachment struct {
@@ -165,15 +139,6 @@ func (s *storageAttachment) Life() Life {
 	return s.doc.Life
 }
 
-func (s *storageAttachment) Info() (StorageAttachmentInfo, error) {
-	if s.doc.Info == nil {
-		return StorageAttachmentInfo{}, errors.NotProvisionedf(
-			"storage %q on unit %q", s.doc.StorageInstance, s.doc.Unit,
-		)
-	}
-	return *s.doc.Info, nil
-}
-
 // storageAttachmentDoc describes a unit's attachment to a charm storage
 // instance.
 type storageAttachmentDoc struct {
@@ -183,20 +148,6 @@ type storageAttachmentDoc struct {
 	Unit            string `bson:"unitid"`
 	StorageInstance string `bson:"storageid"`
 	Life            Life   `bson:"life"`
-
-	Info *StorageAttachmentInfo `bson:"info"`
-}
-
-// StorageAttachmentInfo describes unit-specific information about the
-// storage attachment, such as the location where a filesystem is mounted
-// path to a block device.
-type StorageAttachmentInfo struct {
-	// Location is the location of the storage instance,
-	// e.g. the mount point.
-	Location string `bson:"location"`
-
-	// ReadOnly reports whether the attachment is read-only.
-	ReadOnly bool `bson:"read-only"`
 }
 
 // newStorageInstanceId returns a unique storage instance name. The name
@@ -597,20 +548,6 @@ func removeStorageAttachmentOps(s *storageAttachment, si *storageInstance) ([]tx
 	}
 	ops = append(ops, decrefOp)
 	return ops, nil
-}
-
-// SetStorageAttachmentInfo sets the storage attachment information for the
-// storage attachment relating to the specified storage instance and unit.
-func (st *State) SetStorageAttachmentInfo(
-	storage names.StorageTag, unit names.UnitTag, info StorageAttachmentInfo,
-) error {
-	ops := []txn.Op{{
-		C:      storageAttachmentsC,
-		Id:     storageAttachmentId(unit.Id(), storage.Id()),
-		Assert: txn.DocExists,
-		Update: bson.D{{"$set", bson.D{{"info", &info}}}},
-	}}
-	return st.runTransaction(ops)
 }
 
 // removeStorageInstancesOps returns the transaction operations to remove all

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -378,19 +378,6 @@ func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {
 	wc.AssertNoChange()
 }
 
-func (s *StorageStateSuite) TestWatchStorageAttachment(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c)
-
-	w := s.State.WatchStorageAttachment(storageTag, u.UnitTag())
-	defer testing.AssertStop(c, w)
-	wc := testing.NewNotifyWatcherC(c, s.State, w)
-	wc.AssertOneChange()
-
-	err := s.State.DestroyStorageAttachment(storageTag, u.UnitTag())
-	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertOneChange()
-}
-
 // TODO(axw) StorageAttachments can't be added to Dying StorageInstance
 // TODO(axw) StorageInstance without attachments is removed by Destroy
 // TODO(axw) StorageInstance becomes Dying when Unit becomes Dying

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -4,7 +4,6 @@
 package state_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/featureflag"
@@ -211,8 +210,6 @@ func (s *StorageStateSuite) TestAddUnit(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			count[storageInstance.StorageName()]++
 			c.Assert(storageInstance.Kind(), gc.Equals, state.StorageKindBlock)
-			_, err = storageInstance.Info()
-			c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 		}
 		c.Assert(count, gc.DeepEquals, map[string]int{
 			"multi1to10": 1,

--- a/state/volume.go
+++ b/state/volume.go
@@ -351,9 +351,7 @@ func setMachineVolumeAttachmentInfo(st *State, machineId string, attachments map
 }
 
 // SetVolumeAttachmentInfo sets the VolumeAttachmentInfo for the specified
-// volume attachment. If the volume is assigned to a block-kind storage
-// instance, identify each storage attachment relating to units assigned
-// to the machine, and update their info as well.
+// volume attachment.
 func (st *State) SetVolumeAttachmentInfo(machineTag names.MachineTag, volumeTag names.VolumeTag, info VolumeAttachmentInfo) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set info for volume attachment %s:%s", volumeTag.Id(), machineTag.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -403,9 +401,7 @@ func setProvisionedVolumeInfo(st *State, volumes map[names.VolumeTag]VolumeInfo)
 	return nil
 }
 
-// SetVolumeInfo sets the VolumeInfo for the specified volume. If the volume
-// is assigned to a block-kind storage instance, that storage instance's
-// info will be updated as well.
+// SetVolumeInfo sets the VolumeInfo for the specified volume.
 func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set info for volume %q", tag.Id())
 	// TODO(axw) we should reject info without VolumeId set; can't do this

--- a/state/volume.go
+++ b/state/volume.go
@@ -359,12 +359,10 @@ func (st *State) SetVolumeAttachmentInfo(machineTag names.MachineTag, volumeTag 
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		var unsetParams bool
-		if _, ok := va.Params(); ok {
-			// volume attachment has parameters, unset them
-			// when we set info for the first time.
-			unsetParams = true
-		}
+		// If the volume attachment has parameters, unset them
+		// when we set info for the first time, ensuring that
+		// params and info are mutually exclusive.
+		_, unsetParams := va.Params()
 		ops := setVolumeAttachmentInfoOps(machineTag, volumeTag, info, unsetParams)
 		return ops, nil
 	}
@@ -411,12 +409,10 @@ func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		var unsetParams bool
-		if _, ok := v.Params(); ok {
-			// volume has parameters, unset them when
-			// we set info for the first time.
-			unsetParams = true
-		}
+		// If the volume has parameters, unset them when
+		// we set info for the first time, ensuring that
+		// params and info are mutually exclusive.
+		_, unsetParams := v.Params()
 		ops := setVolumeInfoOps(tag, info, unsetParams)
 		return ops, nil
 	}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -7,51 +7,21 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
-	"github.com/juju/juju/storage/provider/registry"
 )
 
 type VolumeStateSuite struct {
-	ConnSuite
+	StorageStateSuiteBase
 }
 
 var _ = gc.Suite(&VolumeStateSuite{})
-
-func (s *VolumeStateSuite) SetUpTest(c *gc.C) {
-	s.ConnSuite.SetUpTest(c)
-
-	// This suite is all about storage, so enable the feature by default.
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	pm := poolmanager.New(state.NewStateSettings(s.State))
-	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
-	c.Assert(err, jc.ErrorIsNil)
-	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
-}
-
-func (s *VolumeStateSuite) setupSingleStorage(c *gc.C, kind string) (*state.Service, *state.Unit, names.StorageTag) {
-	// There are test charms called "storage-block" and
-	// "storage-filesystem" which are what you'd expect.
-	ch := s.AddTestingCharm(c, "storage-"+kind)
-	storage := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop-pool", 1024, 1),
-	}
-	service := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
-	unit, err := service.AddUnit()
-	c.Assert(err, jc.ErrorIsNil)
-	storageTag := names.NewStorageTag("data/0")
-	return service, unit, storageTag
-}
 
 func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
 	_, unit, _ := s.setupSingleStorage(c, "block")

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/poolmanager"
@@ -36,15 +38,23 @@ func (s *VolumeStateSuite) SetUpTest(c *gc.C) {
 	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
 }
 
-func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
-	ch := s.AddTestingCharm(c, "storage-block")
+func (s *VolumeStateSuite) setupSingleStorage(c *gc.C, kind string) (*state.Service, *state.Unit, names.StorageTag) {
+	// There are test charms called "storage-block" and
+	// "storage-filesystem" which are what you'd expect.
+	ch := s.AddTestingCharm(c, "storage-"+kind)
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop-pool", 1024, 1),
 	}
-	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
+	service := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
 	unit, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
+	storageTag := names.NewStorageTag("data/0")
+	return service, unit, storageTag
+}
+
+func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "block")
+	err := s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 	assignedMachineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -133,4 +143,82 @@ func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 			Count: 1,
 		},
 	})
+}
+
+func (s *VolumeStateSuite) TestSetVolumeInfo(c *gc.C) {
+	_, u, storageTag := s.setupSingleStorage(c, "block")
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume, err := s.State.StorageInstanceVolume(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	volumeTag := volume.VolumeTag()
+	s.assertVolumeUnprovisioned(c, volumeTag)
+
+	volumeInfoSet := state.VolumeInfo{Size: 123}
+	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
+}
+
+func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
+	oneJob := []state.MachineJob{state.JobHostUnits}
+	cons := constraints.MustParse("mem=4G")
+	hc := instance.MustParseHardware("mem=2G")
+
+	volumeParams := state.VolumeParams{
+		Pool: "loop-pool",
+		Size: 123,
+	}
+	machineTemplate := state.MachineTemplate{
+		Series:                  "precise",
+		Constraints:             cons,
+		HardwareCharacteristics: hc,
+		InstanceId:              "inst-id",
+		Nonce:                   "nonce",
+		Jobs:                    oneJob,
+		Volumes: []state.MachineVolumeParams{{
+			Volume: volumeParams,
+		}},
+	}
+	machines, err := s.State.AddMachines(machineTemplate)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.HasLen, 1)
+	m, err := s.State.Machine(machines[0].Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumeAttachments, err := s.State.MachineVolumeAttachments(m.MachineTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumeAttachments, gc.HasLen, 1)
+	volumeTag := volumeAttachments[0].Volume()
+
+	volume, err := s.State.Volume(volumeTag)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = volume.StorageInstance()
+	c.Assert(err, jc.Satisfies, errors.IsNotAssigned)
+
+	s.assertVolumeUnprovisioned(c, volumeTag)
+	volumeInfoSet := state.VolumeInfo{Size: 123}
+	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
+}
+
+func (s *VolumeStateSuite) assertVolumeUnprovisioned(c *gc.C, tag names.VolumeTag) {
+	volume, err := s.State.Volume(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = volume.Info()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	_, ok := volume.Params()
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *VolumeStateSuite) assertVolumeInfo(c *gc.C, tag names.VolumeTag, expect state.VolumeInfo) {
+	volume, err := s.State.Volume(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	info, err := volume.Info()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, expect)
+	_, ok := volume.Params()
+	c.Assert(ok, jc.IsFalse)
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1312,7 +1312,7 @@ func (st *State) WatchAPIHostPorts() NotifyWatcher {
 // to a volume attachment.
 func (st *State) WatchVolumeAttachment(m names.MachineTag, v names.VolumeTag) NotifyWatcher {
 	id := volumeAttachmentId(m.Id(), v.Id())
-	return newEntityWatcher(st, volumeAttachmentsC, id)
+	return newEntityWatcher(st, volumeAttachmentsC, st.docID(id))
 }
 
 // WatchConfigSettings returns a watcher for observing changes to the

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1308,11 +1308,6 @@ func (st *State) WatchAPIHostPorts() NotifyWatcher {
 	return newEntityWatcher(st, stateServersC, apiHostPortsKey)
 }
 
-func (st *State) WatchStorageAttachment(storage names.StorageTag, unit names.UnitTag) NotifyWatcher {
-	docID := st.docID(storageAttachmentId(unit.Id(), storage.Id()))
-	return newEntityWatcher(st, storageAttachmentsC, docID)
-}
-
 // WatchConfigSettings returns a watcher for observing changes to the
 // unit's service configuration settings. The unit must have a charm URL
 // set before this method is called, and the returned watcher will be

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1315,6 +1315,13 @@ func (st *State) WatchVolumeAttachment(m names.MachineTag, v names.VolumeTag) No
 	return newEntityWatcher(st, volumeAttachmentsC, st.docID(id))
 }
 
+// WatchFilesystemAttachment returns a watcher for observing changes
+// to a filesystem attachment.
+func (st *State) WatchFilesystemAttachment(m names.MachineTag, f names.FilesystemTag) NotifyWatcher {
+	id := filesystemAttachmentId(m.Id(), f.Id())
+	return newEntityWatcher(st, filesystemAttachmentsC, st.docID(id))
+}
+
 // WatchConfigSettings returns a watcher for observing changes to the
 // unit's service configuration settings. The unit must have a charm URL
 // set before this method is called, and the returned watcher will be

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1308,6 +1308,13 @@ func (st *State) WatchAPIHostPorts() NotifyWatcher {
 	return newEntityWatcher(st, stateServersC, apiHostPortsKey)
 }
 
+// WatchVolumeAttachment returns a watcher for observing changes
+// to a volume attachment.
+func (st *State) WatchVolumeAttachment(m names.MachineTag, v names.VolumeTag) NotifyWatcher {
+	id := volumeAttachmentId(m.Id(), v.Id())
+	return newEntityWatcher(st, volumeAttachmentsC, id)
+}
+
 // WatchConfigSettings returns a watcher for observing changes to the
 // unit's service configuration settings. The unit must have a charm URL
 // set before this method is called, and the returned watcher will be

--- a/storage/blockdevice.go
+++ b/storage/blockdevice.go
@@ -38,4 +38,7 @@ type BlockDevice struct {
 
 	// InUse indicates that the block device is in use (e.g. mounted).
 	InUse bool `yaml:"inuse"`
+
+	// MountPoint is the path at which the block devices is mounted.
+	MountPoint string `yaml:"mountpoint,omitempty"`
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -35,3 +35,13 @@ type StorageInstance struct {
 	// Kind is the kind of the datastore (block device, filesystem).
 	Kind StorageKind
 }
+
+// StorageAttachmentInfo provides unit-specific information about a storage
+// instance. StorageAttachmentInfo is based on either a volume attachment
+// or a filesystem attachment, depending on its kind.
+type StorageAttachmentInfo struct {
+	// Location is the storage attachment's location: the mount point
+	// for a filesystem-kind storage attachment, and the device path
+	// for a block-kind.
+	Location string
+}


### PR DESCRIPTION
In state we no longer store info against a storage instance or
attachment, instead we compute that information based on the related
volume or filesystem (attachment). Similarly, we no longer provide
a means of watching individual storage attachments, but instead
provide a means of watching individual volume or filesystem
attachments.

The uniter will watch the lifecycle states of all storage attachments,
and will then watch individual volume or filesystem attachments;
the API presented to the uniter only guarantees updates to the
attachment info will yield notifications.

The state package has grown additional support for filesystems
so that we can normalise both volume and filesystem info to storage
info.

(Review request: http://reviews.vapour.ws/r/1071/)