### PR TITLE
Working addressable LXC containers on both MAAS and EC2

### DIFF
--- a/container/userdata.go
+++ b/container/userdata.go
@@ -58,7 +58,7 @@ iface lo inet loopback{{define "static"}}
 auto {{.InterfaceName}}{{end}}
 iface {{.InterfaceName}} inet static
     address {{.Address.Value}}
-    netmask 255.255.255.0{{if gt (len .DNSServers) 0}}
+    netmask {{.CIDR}}{{if gt (len .DNSServers) 0}}
     dns-nameservers{{range $dns := .DNSServers}} {{$dns.Value}}{{end}}{{end}}
     pre-up ip route add {{.GatewayAddress.Value}} dev {{.InterfaceName}}
     pre-up ip route add default via {{.GatewayAddress.Value}}

--- a/container/userdata.go
+++ b/container/userdata.go
@@ -58,7 +58,7 @@ iface lo inet loopback{{define "static"}}
 auto {{.InterfaceName}}{{end}}
 iface {{.InterfaceName}} inet static
     address {{.Address.Value}}
-    netmask 255.255.255.255{{if gt (len .DNSServers) 0}}
+    netmask 255.255.255.0{{if gt (len .DNSServers) 0}}
     dns-nameservers{{range $dns := .DNSServers}} {{$dns.Value}}{{end}}{{end}}
     pre-up ip route add {{.GatewayAddress.Value}} dev {{.InterfaceName}}
     pre-up ip route add default via {{.GatewayAddress.Value}}

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -60,7 +60,7 @@ bootcmd:
   auto eth0
   iface eth0 inet static
       address 0.1.2.3
-      netmask 255.255.255.255
+      netmask 255.255.255.0
       dns-nameservers ns1.invalid ns2.invalid
       pre-up ip route add 0.1.2.1 dev eth0
       pre-up ip route add default via 0.1.2.1

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -33,6 +33,7 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
 	ifaces := []network.InterfaceInfo{{
 		InterfaceName:  "eth0",
+		CIDR:           "0.1.2.0/24",
 		ConfigType:     network.ConfigStatic,
 		NoAutoStart:    false,
 		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
@@ -60,7 +61,7 @@ bootcmd:
   auto eth0
   iface eth0 inet static
       address 0.1.2.3
-      netmask 255.255.255.0
+      netmask 0.1.2.0/24
       dns-nameservers ns1.invalid ns2.invalid
       pre-up ip route add 0.1.2.1 dev eth0
       pre-up ip route add default via 0.1.2.1

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -34,10 +34,6 @@ var DataDir = agent.DefaultDataDir
 // may create a folder containing logs
 var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
 
-// DefaultBridgeName is the network bridge device name used for LXC
-// and KVM containers.
-const DefaultBridgeName = "juju-br0"
-
 // NewMachineConfig sets up a basic machine configuration, for a
 // non-bootstrap node. You'll still need to supply more information,
 // but this takes care of the fixed entries and the ones that are

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -93,8 +93,7 @@ type BootstrapParams struct {
 	AvailableTools tools.List
 
 	// ContainerBridgeName, if non-empty, overrides the default
-	// network bridge device to use for LXC and KVM containers. See
-	// environs.DefaultBridgeName.
+	// network bridge device to use for LXC and KVM containers.
 	ContainerBridgeName string
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -16,6 +16,11 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"github.com/juju/utils/set"
+	"gopkg.in/mgo.v2/bson"
+	"launchpad.net/gomaasapi"
+
 	"github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -27,10 +32,6 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
-	"github.com/juju/utils"
-	"github.com/juju/utils/set"
-	"gopkg.in/mgo.v2/bson"
-	"launchpad.net/gomaasapi"
 )
 
 const (

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -197,23 +197,6 @@ func (*environSuite) TestNewEnvironSetsConfig(c *gc.C) {
 var expectedCloudinitConfig = []interface{}{
 	"set -xe",
 	"mkdir -p '/var/lib/juju'\ninstall -m 755 /dev/null '/var/lib/juju/MAASmachine.txt'\nprintf '%s\\n' ''\"'\"'hostname: testing.invalid\n'\"'\"'' > '/var/lib/juju/MAASmachine.txt'",
-	"ifdown eth0",
-	`cat >> /etc/network/interfaces << EOF
-
-iface eth0 inet manual
-
-auto juju-br0
-iface juju-br0 inet dhcp
-    bridge_ports eth0
-EOF
-grep -q 'iface eth0 inet dhcp' /etc/network/interfaces && \
-sed -i 's/iface eth0 inet dhcp//' /etc/network/interfaces`,
-	"ifup juju-br0",
-}
-
-var expectedCloudinitConfigWithoutNetworking = []interface{}{
-	"set -xe",
-	"mkdir -p '/var/lib/juju'\ninstall -m 755 /dev/null '/var/lib/juju/MAASmachine.txt'\nprintf '%s\\n' ''\"'\"'hostname: testing.invalid\n'\"'\"'' > '/var/lib/juju/MAASmachine.txt'",
 }
 
 func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
@@ -236,5 +219,5 @@ func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C
 	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "eth0", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudcfg.AptUpdate(), jc.IsTrue)
-	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfigWithoutNetworking)
+	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
 }

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -786,9 +786,9 @@ func (suite *environSuite) TestGetNetworkMACs(c *gc.C) {
 
 func (suite *environSuite) TestGetInstanceNetworks(c *gc.C) {
 	suite.getNetwork("test_network", 123, 321)
-	test_instance := suite.getInstance("instance_for_network")
+	testInstance := suite.getInstance("instance_for_network")
 	suite.testMAASObject.TestServer.ConnectNodeToNetwork("instance_for_network", "test_network")
-	networks, err := suite.makeEnviron().getInstanceNetworks(test_instance)
+	networks, err := suite.makeEnviron().getInstanceNetworks(testInstance)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(networks, gc.DeepEquals, []networkDetails{
 		{Name: "test_network", IP: "192.168.123.1", Mask: "255.255.255.0", VLANTag: 321,
@@ -861,7 +861,7 @@ func (suite *environSuite) TestGetInstanceNetworkInterfaces(c *gc.C) {
 }
 
 func (suite *environSuite) TestSetupNetworks(c *gc.C) {
-	test_instance := suite.getInstance("node1")
+	testInstance := suite.getInstance("node1")
 	templateInterfaces := map[string]ifaceInfo{
 		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
 		"aa:bb:cc:dd:ee:f1": {1, "eth0", true},
@@ -878,7 +878,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 	suite.getNetwork("WLAN", 1, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
-		test_instance,
+		testInstance,
 		set.NewStrings("WLAN"), // Disable WLAN only.
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -929,7 +929,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 
 // The same test, but now "Virt" network does not have matched MAC address
 func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
-	test_instance := suite.getInstance("node1")
+	testInstance := suite.getInstance("node1")
 	templateInterfaces := map[string]ifaceInfo{
 		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
 		"aa:bb:cc:dd:ee:f1": {1, "eth0", false},
@@ -944,7 +944,7 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	suite.getNetwork("Virt", 3, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f3")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
-		test_instance,
+		testInstance,
 		set.NewStrings(), // All enabled.
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -965,7 +965,7 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 
 // The same test, but now no networks have matched MAC
 func (suite *environSuite) TestSetupNetworksNoMatch(c *gc.C) {
-	test_instance := suite.getInstance("node1")
+	testInstance := suite.getInstance("node1")
 	templateInterfaces := map[string]ifaceInfo{
 		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
 		"aa:bb:cc:dd:ee:f1": {1, "eth0", false},
@@ -978,7 +978,7 @@ func (suite *environSuite) TestSetupNetworksNoMatch(c *gc.C) {
 	suite.getNetwork("Virt", 3, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f3")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
-		test_instance,
+		testInstance,
 		set.NewStrings(), // All enabled.
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1002,7 +1002,7 @@ func (suite *environSuite) TestSupportsAddressAllocation(c *gc.C) {
 }
 
 func (suite *environSuite) createSubnets(c *gc.C, duplicates bool) instance.Instance {
-	test_instance := suite.getInstance("node1")
+	testInstance := suite.getInstance("node1")
 	templateInterfaces := map[string]ifaceInfo{
 		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
 		"aa:bb:cc:dd:ee:f1": {1, "eth0", false},
@@ -1086,13 +1086,13 @@ func (suite *environSuite) createSubnets(c *gc.C, duplicates bool) instance.Inst
 	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-0", jsonText2)
 	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-1", jsonText3)
 	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-1", jsonText4)
-	return test_instance
+	return testInstance
 }
 
 func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
-	test_instance := suite.createSubnets(c, false)
+	testInstance := suite.createSubnets(c, false)
 
-	netInfo, err := suite.makeEnviron().NetworkInterfaces(test_instance.Id())
+	netInfo, err := suite.makeEnviron().NetworkInterfaces(testInstance.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedInfo := []network.InterfaceInfo{{
@@ -1140,9 +1140,9 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 }
 
 func (suite *environSuite) TestSubnets(c *gc.C) {
-	test_instance := suite.createSubnets(c, false)
+	testInstance := suite.createSubnets(c, false)
 
-	netInfo, err := suite.makeEnviron().Subnets(test_instance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
+	netInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedInfo := []network.SubnetInfo{
@@ -1153,21 +1153,21 @@ func (suite *environSuite) TestSubnets(c *gc.C) {
 }
 
 func (suite *environSuite) TestSubnetsNoNetIds(c *gc.C) {
-	test_instance := suite.createSubnets(c, false)
-	_, err := suite.makeEnviron().Subnets(test_instance.Id(), []network.Id{})
+	testInstance := suite.createSubnets(c, false)
+	_, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{})
 	c.Assert(err, gc.ErrorMatches, "netIds must not be empty")
 }
 
 func (suite *environSuite) TestSubnetsMissingNetwork(c *gc.C) {
-	test_instance := suite.createSubnets(c, false)
-	_, err := suite.makeEnviron().Subnets(test_instance.Id(), []network.Id{"WLAN", "Missing"})
+	testInstance := suite.createSubnets(c, false)
+	_, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"WLAN", "Missing"})
 	c.Assert(err, gc.ErrorMatches, "failed to find the following subnets: \\[Missing\\]")
 }
 
 func (suite *environSuite) TestSubnetsNoDuplicates(c *gc.C) {
-	test_instance := suite.createSubnets(c, true)
+	testInstance := suite.createSubnets(c, true)
 
-	netInfo, err := suite.makeEnviron().Subnets(test_instance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
+	netInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedInfo := []network.SubnetInfo{
@@ -1178,12 +1178,12 @@ func (suite *environSuite) TestSubnetsNoDuplicates(c *gc.C) {
 }
 
 func (suite *environSuite) TestAllocateAddress(c *gc.C) {
-	test_instance := suite.createSubnets(c, false)
+	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
 	// note that the default test server always succeeds if we provide a
 	// valid instance id and net id
-	err := env.AllocateAddress(test_instance.Id(), "LAN", network.Address{Value: "192.168.2.1"})
+	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1197,14 +1197,14 @@ func (suite *environSuite) TestAllocateAddressInvalidInstance(c *gc.C) {
 }
 
 func (suite *environSuite) TestAllocateAddressMissingSubnet(c *gc.C) {
-	test_instance := suite.createSubnets(c, false)
+	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
-	err := env.AllocateAddress(test_instance.Id(), "bar", network.Address{Value: "192.168.2.1"})
+	err := env.AllocateAddress(testInstance.Id(), "bar", network.Address{Value: "192.168.2.1"})
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "failed to find the following subnets: \\[bar\\]")
 }
 
 func (suite *environSuite) TestAllocateAddressIPAddressUnavailable(c *gc.C) {
-	test_instance := suite.createSubnets(c, false)
+	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
 	reserveIPAddress := func(ipaddresses gomaasapi.MAASObject, cidr string, addr network.Address) error {
@@ -1213,9 +1213,9 @@ func (suite *environSuite) TestAllocateAddressIPAddressUnavailable(c *gc.C) {
 	suite.PatchValue(&ReserveIPAddress, reserveIPAddress)
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
-	err := env.AllocateAddress(test_instance.Id(), "LAN", ipAddress)
+	err := env.AllocateAddress(testInstance.Id(), "LAN", ipAddress)
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
-	expected := fmt.Sprintf("failed to allocate address %q for instance %q.*", ipAddress, test_instance.Id())
+	expected := fmt.Sprintf("failed to allocate address %q for instance %q.*", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
 }
 
@@ -1228,20 +1228,20 @@ func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 }
 
 func (suite *environSuite) TestReleaseAddress(c *gc.C) {
-	test_instance := suite.createSubnets(c, false)
+	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
-	err := env.AllocateAddress(test_instance.Id(), "LAN", network.Address{Value: "192.168.2.1"})
+	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
-	err = env.ReleaseAddress(test_instance.Id(), "bar", ipAddress)
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// by releasing again we can test that the first release worked, *and*
 	// the error handling of ReleaseError
-	err = env.ReleaseAddress(test_instance.Id(), "bar", ipAddress)
-	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q.*", ipAddress, test_instance.Id())
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress)
+	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q.*", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
 }
 

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -46,7 +46,7 @@ var SetIPForwarding func(bool) error
 
 // SetupRoutesAndIPTables calls the internal setupRoutesAndIPTables
 // and the restores the mocked one.
-var SetupRoutesAndIPTables func(string, string, []network.InterfaceInfo) error
+var SetupRoutesAndIPTables func(string, network.Address, string, []network.InterfaceInfo) error
 
 func init() {
 	// In order to isolate the host machine from the running tests,
@@ -64,7 +64,7 @@ func init() {
 		func(bool) error { return nil },
 	)
 	mockSetupRoutesAndIPTablesValue := reflect.ValueOf(
-		func(string, string, []network.InterfaceInfo) error { return nil },
+		func(string, network.Address, string, []network.InterfaceInfo) error { return nil },
 	)
 	switchValues := func(newValue, oldValue reflect.Value) {
 		newValue.Set(oldValue)
@@ -77,9 +77,9 @@ func init() {
 		defer switchValues(newSetIPForwardingValue, mockSetIPForwardingValue)
 		return setIPForwarding(v)
 	}
-	SetupRoutesAndIPTables = func(nic, bridge string, ifinfo []network.InterfaceInfo) error {
+	SetupRoutesAndIPTables = func(nic string, addr network.Address, bridge string, ifinfo []network.InterfaceInfo) error {
 		switchValues(newSetupRoutesAndIPTablesValue, oldSetupRoutesAndIPTablesValue)
 		defer switchValues(newSetupRoutesAndIPTablesValue, mockSetupRoutesAndIPTablesValue)
-		return setupRoutesAndIPTables(nic, bridge, ifinfo)
+		return setupRoutesAndIPTables(nic, addr, bridge, ifinfo)
 	}
 }

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -4,15 +4,26 @@
 package provisioner
 
 import (
+	"bufio"
+	"bytes"
+	"net"
+	"os"
+	"strings"
+	"text/template"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"github.com/juju/utils/exec"
 
 	"github.com/juju/juju/agent"
+	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -23,7 +34,10 @@ var _ environs.InstanceBroker = (*lxcBroker)(nil)
 
 type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
+	PrepareContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 }
+
+var _ APICalls = (*apiprovisioner.State)(nil)
 
 // Override for testing.
 var NewLxcBroker = newLxcBroker
@@ -62,6 +76,16 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
 	if bridgeDevice == "" {
 		bridgeDevice = lxc.DefaultLxcBridge
+	}
+	allocatedInfo, err := maybeAllocateStaticIP(
+		machineId, bridgeDevice, broker.api, args.NetworkInfo,
+	)
+	if err != nil {
+		// It's fine, just ignore it. The effect will be that the
+		// container won't have a static address configured.
+		logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+	} else {
+		args.NetworkInfo = allocatedInfo
 	}
 	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
 
@@ -143,4 +167,259 @@ type hostArchToolsFinder struct {
 func (h hostArchToolsFinder) FindTools(v version.Number, series string, arch *string) (tools.List, error) {
 	// Override the arch constraint with the arch of the host.
 	return h.f.FindTools(v, series, &version.Current.Arch)
+}
+
+// resolvConf is the full path to the resolv.conf file on the local
+// system. Defined here so it can be overriden for testing.
+var resolvConf = "/etc/resolv.conf"
+
+// localDNSServers parses the /etc/resolv.conf file (if available) and
+// extracts all nameservers addresses, returning them.
+func localDNSServers() ([]network.Address, error) {
+	file, err := os.Open(resolvConf)
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Annotatef(err, "cannot open %q", resolvConf)
+	}
+	defer file.Close()
+
+	var addresses []network.Address
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") {
+			// Skip comments.
+			continue
+		}
+		if strings.HasPrefix(line, "nameserver") {
+			address := strings.TrimPrefix(line, "nameserver")
+			// Drop comments after the address, if any.
+			if strings.Contains(address, "#") {
+				address = address[:strings.Index(address, "#")]
+			}
+			address = strings.TrimSpace(address)
+			addresses = append(addresses, network.NewAddress(address, network.ScopeUnknown))
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Annotatef(err, "cannot read DNS servers from %q", resolvConf)
+	}
+	return addresses, nil
+}
+
+var (
+	// iptablesCheckSNAT is the command template to verify if a SNAT
+	// rule already exists for the host NIC named .HostIF (usually
+	// eth0) and source address .HostIP (usually eth0's address). We
+	// need to check whether the rule exists because we only want to
+	// add it once. Exit code 0 means the rule exists, 1 means it
+	// doesn't
+	iptablesCheckSNAT = mustParseTemplate("iptablesCheckSNAT", `
+iptables -t nat -C POSTROUTING -o {{.HostIF}} -j SNAT --to-source {{.HostIP}}`[1:])
+
+	// iptablesAddSNAT is the command template to add a SNAT rule for
+	// the host NIC named .HostIF (usually eth0) and source address
+	// .HostIP (usually eth0's address).
+	iptablesAddSNAT = mustParseTemplate("iptablesAddSNAT", `
+iptables -t nat -A POSTROUTING -o {{.HostIF}} -j SNAT --to-source {{.HostIP}}`[1:])
+
+	// ipRouteAdd is the command template to add a static route for
+	// .ContainerIP using the .HostBridge device (usually lxcbr0).
+	ipRouteAdd = mustParseTemplate("ipRouteAdd", `
+ip route add {{.ContainerIP}} dev {{.HostBridge}}`[1:])
+)
+
+// mustParseTemplate works like template.Parse, but panics on error.
+func mustParseTemplate(name, source string) *template.Template {
+	templ, err := template.New(name).Parse(source)
+	if err != nil {
+		panic(err.Error())
+	}
+	return templ
+}
+
+// runTemplateCommand executes the given template with the given data,
+// which generates a command to execute. If exitNonZeroOK is true, no
+// error is returned if the exit code is not 0, otherwise an error is
+// returned.
+func runTemplateCommand(t *template.Template, exitNonZeroOK bool, data interface{}) (
+	exitCode int, err error,
+) {
+	// Clone the template to ensure the original won't be changed.
+	cloned, err := t.Clone()
+	if err != nil {
+		return -1, errors.Annotatef(err, "cannot clone command template %q", t.Name())
+	}
+	var buf bytes.Buffer
+	if err := cloned.Execute(&buf, data); err != nil {
+		return -1, errors.Annotatef(err, "cannot execute command template %q", t.Name())
+	}
+	command := buf.String()
+	logger.Debugf("running command %q", command)
+	result, err := exec.RunCommands(exec.RunParams{Commands: command})
+	if err != nil {
+		return -1, errors.Annotatef(err, "cannot run command %q", command)
+	}
+	exitCode = result.Code
+	stdout := string(result.Stdout)
+	stderr := string(result.Stderr)
+	logger.Debugf(
+		"command %q returned code=%d, stdout=%q, stderr=%q",
+		command, exitCode, stdout, stderr,
+	)
+	if exitCode != 0 {
+		if exitNonZeroOK {
+			return exitCode, nil
+		}
+		return exitCode, errors.Errorf(
+			"command %q failed with exit code %d",
+			command, exitCode,
+		)
+	}
+	return 0, nil
+}
+
+// setupRoutesAndIPTables sets up on the host machine the needed
+// iptables rules and static routes for an addressable container.
+var setupRoutesAndIPTables = func(primaryNIC, bridgeName string, ifaceInfo []network.InterfaceInfo) error {
+
+	if primaryNIC == "" || bridgeName == "" || len(ifaceInfo) == 0 {
+		return errors.Errorf("primaryNIC, bridgeName, and ifaceInfo must be all set")
+	}
+
+	for _, iface := range ifaceInfo {
+		hostIP := iface.GatewayAddress.Value
+		containerIP := iface.Address.Value
+		if hostIP == "" || containerIP == "" {
+			return errors.Errorf(
+				"host IP %q and container IP %q must be both set",
+				hostIP, containerIP,
+			)
+		}
+		data := struct {
+			HostIF      string
+			HostIP      string
+			HostBridge  string
+			ContainerIP string
+		}{primaryNIC, hostIP, bridgeName, containerIP}
+
+		// Check if the iptables SNAT rule has been set and add it if not.
+		code, err := runTemplateCommand(iptablesCheckSNAT, true, data)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		switch code {
+		case 0:
+			// Rule does exist so just add the route.
+		case 1:
+			// Rule does not exist, add it.
+			_, err = runTemplateCommand(iptablesAddSNAT, false, data)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		default:
+			// Unexpected code - better report it.
+			return errors.Errorf("iptables failed with unexpected exit code %d", code)
+		}
+
+		_, err = runTemplateCommand(ipRouteAdd, false, data)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	logger.Infof("successfully configured iptables and routes for container interfaces")
+
+	return nil
+}
+
+var (
+	netInterfaces  = net.Interfaces
+	interfaceAddrs = (*net.Interface).Addrs
+)
+
+// discoverPrimaryNIC returns the name of the first network interface
+// on the machine which is up and has address.
+func discoverPrimaryNIC() (string, error) {
+	interfaces, err := netInterfaces()
+	if err != nil {
+		return "", errors.Annotatef(err, "cannot get network interfaces")
+	}
+	logger.Tracef("trying to discover primary network interface")
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			// Skip the loopback.
+			logger.Tracef("not using loopback interface %q", iface.Name)
+			continue
+		}
+		if iface.Flags&net.FlagUp != 0 {
+			// Possibly the primary, but ensure it has an address as
+			// well.
+			logger.Tracef("verifying interface %q has addresses", iface.Name)
+			addrs, err := interfaceAddrs(&iface)
+			if err != nil {
+				return "", errors.Annotatef(err, "cannot get %q addresses", iface.Name)
+			}
+			if len(addrs) > 0 {
+				// We found it.
+				logger.Tracef("primary network interface is %q", iface.Name)
+				return iface.Name, nil
+			}
+		}
+	}
+	return "", errors.Errorf("cannot detect the primary network interface")
+}
+
+// maybeAllocateStaticIP tries to allocate a static IP address for the
+// given containerId using the provisioner API. If it fails, it's not
+// critical - just a warning, and it won't cause StartInstance to
+// fail.
+func maybeAllocateStaticIP(
+	containerId, bridgeDevice string,
+	apiFacade APICalls,
+	ifaceInfo []network.InterfaceInfo,
+) (finalIfaceInfo []network.InterfaceInfo, err error) {
+	defer func() {
+		if err != nil {
+			logger.Warningf(
+				"failed allocating a static IP for container %q: %v",
+				containerId, err,
+			)
+		}
+	}()
+
+	if len(ifaceInfo) != 0 {
+		// When we already have interface info, don't overwrite it.
+		return nil, nil
+	}
+	logger.Debugf("trying to allocate a static IP for container %q", containerId)
+
+	var primaryNIC string
+	primaryNIC, err = discoverPrimaryNIC()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	finalIfaceInfo, err = apiFacade.PrepareContainerInterfaceInfo(names.NewMachineTag(containerId))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Debugf("PrepareContainerInterfaceInfo returned %#v", finalIfaceInfo)
+
+	// Populate ConfigType and DNSServers as needed.
+	var dnsServers []network.Address
+	dnsServers, err = localDNSServers()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for i, _ := range finalIfaceInfo {
+		finalIfaceInfo[i].ConfigType = network.ConfigStatic
+		finalIfaceInfo[i].DNSServers = dnsServers
+	}
+	err = setupRoutesAndIPTables(primaryNIC, bridgeDevice, finalIfaceInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return finalIfaceInfo, nil
 }

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -6,6 +6,7 @@ package provisioner
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -414,6 +415,9 @@ func maybeAllocateStaticIP(
 		return nil, errors.Trace(err)
 	}
 	for i, _ := range finalIfaceInfo {
+		// The interface name on the container depends on the device
+		// index.
+		finalIfaceInfo[i].InterfaceName = fmt.Sprintf("eth%d", finalIfaceInfo[i].DeviceIndex)
 		finalIfaceInfo[i].ConfigType = network.ConfigStatic
 		finalIfaceInfo[i].DNSServers = dnsServers
 	}

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -4,14 +4,18 @@
 package provisioner_test
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path/filepath"
 	"runtime"
+	"text/template"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
@@ -29,6 +33,7 @@ import (
 	instancetest "github.com/juju/juju/instance/testing"
 	"github.com/juju/juju/juju/arch"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
@@ -234,6 +239,381 @@ func (s *lxcBrokerSuite) lxcRemovedContainerDir(inst instance.Instance) string {
 	return filepath.Join(s.RemovedDir, string(inst.Id()))
 }
 
+func (s *lxcBrokerSuite) TestLocalDNSServers(c *gc.C) {
+	fakeConf := filepath.Join(c.MkDir(), "resolv.conf")
+	s.PatchValue(provisioner.ResolvConf, fakeConf)
+
+	// If config is missing, that's OK.
+	dnses, err := provisioner.LocalDNSServers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(dnses, gc.HasLen, 0)
+
+	// Enter some data in fakeConf.
+	data := `
+ anything else is ignored
+  # comments are ignored
+  nameserver  0.1.2.3  # that's parsed
+search foo # ignored
+nameserver 8.8.8.8
+nameserver example.com # comment after is ok
+`
+	err = ioutil.WriteFile(fakeConf, []byte(data), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	dnses, err = provisioner.LocalDNSServers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(dnses, jc.DeepEquals, network.NewAddresses(
+		"0.1.2.3", "8.8.8.8", "example.com",
+	))
+}
+
+func (s *lxcBrokerSuite) TestMustParseTemplate(c *gc.C) {
+	f := func() { provisioner.MustParseTemplate("", "{{invalid}") }
+	c.Assert(f, gc.PanicMatches, `template: :1: function "invalid" not defined`)
+
+	tmpl := provisioner.MustParseTemplate("name", "X={{.X}}")
+	c.Assert(tmpl, gc.NotNil)
+	c.Assert(tmpl.Name(), gc.Equals, "name")
+
+	var buf bytes.Buffer
+	err := tmpl.Execute(&buf, struct{ X string }{"42"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(buf.String(), gc.Equals, "X=42")
+}
+
+func (s *lxcBrokerSuite) TestRunTemplateCommand(c *gc.C) {
+	for i, test := range []struct {
+		source        string
+		exitNonZeroOK bool
+		data          interface{}
+		exitCode      int
+		expectErr     string
+	}{{
+		source:        "echo {{.Name}}",
+		exitNonZeroOK: false,
+		data:          struct{ Name string }{"foo"},
+		exitCode:      0,
+	}, {
+		source:        "exit {{.Code}}",
+		exitNonZeroOK: false,
+		data:          struct{ Code int }{123},
+		exitCode:      123,
+		expectErr:     `command "exit 123" failed with exit code 123`,
+	}, {
+		source:        "exit {{.Code}}",
+		exitNonZeroOK: true,
+		data:          struct{ Code int }{56},
+		exitCode:      56,
+	}, {
+		source:        "exit 42",
+		exitNonZeroOK: true,
+		exitCode:      42,
+	}, {
+		source:        "some-invalid-command",
+		exitNonZeroOK: false,
+		exitCode:      127, // returned by bash.
+		expectErr:     `command "some-invalid-command" failed with exit code 127`,
+	}} {
+		c.Logf("test %d: %q -> %d", i, test.source, test.exitCode)
+		t, err := template.New(fmt.Sprintf("test %d", i)).Parse(test.source)
+		if !c.Check(err, jc.ErrorIsNil, gc.Commentf("parsing %q", test.source)) {
+			continue
+		}
+		exitCode, err := provisioner.RunTemplateCommand(t, test.exitNonZeroOK, test.data)
+		if test.expectErr != "" {
+			c.Check(err, gc.ErrorMatches, test.expectErr)
+		} else {
+			c.Check(err, jc.ErrorIsNil)
+		}
+		c.Check(exitCode, gc.Equals, test.exitCode)
+	}
+}
+
+func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesInvalidArgs(c *gc.C) {
+	// Isolate the test from the host machine.
+	gitjujutesting.PatchExecutableThrowError(c, s, "iptables", 42)
+	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
+
+	// Check that all the arguments are verified to be non-empty.
+	expectStartupErr := "primaryNIC, bridgeName, and ifaceInfo must be all set"
+	emptyIfaceInfo := []network.InterfaceInfo{}
+	for i, test := range []struct {
+		primaryNIC string
+		bridgeName string
+		ifaceInfo  []network.InterfaceInfo
+		expectErr  string
+	}{{
+		primaryNIC: "",
+		bridgeName: "",
+		ifaceInfo:  nil,
+		expectErr:  expectStartupErr,
+	}, {
+		primaryNIC: "nic",
+		bridgeName: "",
+		ifaceInfo:  nil,
+		expectErr:  expectStartupErr,
+	}, {
+		primaryNIC: "",
+		bridgeName: "bridge",
+		ifaceInfo:  nil,
+		expectErr:  expectStartupErr,
+	}, {
+		primaryNIC: "nic",
+		bridgeName: "bridge",
+		ifaceInfo:  nil,
+		expectErr:  expectStartupErr,
+	}, {
+		primaryNIC: "",
+		bridgeName: "",
+		ifaceInfo:  emptyIfaceInfo,
+		expectErr:  expectStartupErr,
+	}, {
+		primaryNIC: "nic",
+		bridgeName: "",
+		ifaceInfo:  emptyIfaceInfo,
+		expectErr:  expectStartupErr,
+	}, {
+		primaryNIC: "",
+		bridgeName: "bridge",
+		ifaceInfo:  emptyIfaceInfo,
+		expectErr:  expectStartupErr,
+	}, {
+		primaryNIC: "nic",
+		bridgeName: "bridge",
+		ifaceInfo:  emptyIfaceInfo,
+		expectErr:  expectStartupErr,
+	}, {
+		primaryNIC: "nic",
+		bridgeName: "bridge",
+		// No Address or GatewayAddress set.
+		ifaceInfo: []network.InterfaceInfo{{DeviceIndex: 0}},
+		expectErr: `host IP "" and container IP "" must be both set`,
+	}, {
+		primaryNIC: "nic",
+		bridgeName: "bridge",
+		// Has Address but no GatewayAddress set.
+		ifaceInfo: []network.InterfaceInfo{{
+			Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		}},
+		expectErr: `host IP "" and container IP "0.1.2.3" must be both set`,
+	}, {
+		primaryNIC: "nic",
+		bridgeName: "bridge",
+		// Has GatewayAddress but no Address set.
+		ifaceInfo: []network.InterfaceInfo{{
+			GatewayAddress: network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		}},
+		expectErr: `host IP "0.1.2.3" and container IP "" must be both set`,
+	}} {
+		c.Logf(
+			"test %d: primaryNIC=%q, bridge=%q, ifaceInfo=%v",
+			i, test.primaryNIC, test.bridgeName, test.ifaceInfo,
+		)
+		err := provisioner.SetupRoutesAndIPTables(test.primaryNIC, test.bridgeName, test.ifaceInfo)
+		c.Assert(err, gc.ErrorMatches, test.expectErr)
+	}
+}
+
+func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesCheckError(c *gc.C) {
+	// Isolate the test from the host machine.
+	gitjujutesting.PatchExecutableThrowError(c, s, "iptables", 42)
+	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
+
+	ifaceInfo := []network.InterfaceInfo{{
+		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+	}}
+
+	err := provisioner.SetupRoutesAndIPTables("nic", "bridge", ifaceInfo)
+	c.Assert(err, gc.ErrorMatches, "iptables failed with unexpected exit code 42")
+}
+
+func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesAddError(c *gc.C) {
+	// Isolate the test from the host machine. Patch iptables with a
+	// script which returns code=1 for the check but fails when adding
+	// the rule.
+	script := `if [[ "$3" == "-C" ]]; then exit 1; else exit 42; fi`
+	gitjujutesting.PatchExecutable(c, s, "iptables", script)
+	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
+
+	ifaceInfo := []network.InterfaceInfo{{
+		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+	}}
+
+	err := provisioner.SetupRoutesAndIPTables("nic", "bridge", ifaceInfo)
+	c.Assert(err, gc.ErrorMatches, `command "iptables -t nat -A .*" failed with exit code 42`)
+}
+
+func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPRouteError(c *gc.C) {
+	// Isolate the test from the host machine.
+	// Returning code=0 from iptables means
+	gitjujutesting.PatchExecutableThrowError(c, s, "iptables", 0)
+	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
+
+	ifaceInfo := []network.InterfaceInfo{{
+		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+	}}
+
+	err := provisioner.SetupRoutesAndIPTables("nic", "bridge", ifaceInfo)
+	c.Assert(err, gc.ErrorMatches,
+		`command "ip route add 0.1.2.3 dev bridge" failed with exit code 123`,
+	)
+}
+
+func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesAddsRuleIfMissing(c *gc.C) {
+	// Isolate the test from the host machine. Because PatchExecutable
+	// does not allow us to assert on subsequent executions of the
+	// same binary, we need to replace the iptables commands with
+	// separate ones. The check returns code=1 to trigger calling
+	// add.
+	fakeIPTablesCheck := provisioner.MustParseTemplate("iptablesCheckNAT", `
+iptables-check {{.HostIF}} {{.HostIP}} ; exit 1`[1:])
+	s.PatchValue(provisioner.IPTablesCheckSNAT, fakeIPTablesCheck)
+	fakeIPTablesAdd := provisioner.MustParseTemplate("iptablesAddSNAT", `
+iptables-add {{.HostIF}} {{.HostIP}}`[1:])
+	s.PatchValue(provisioner.IPTablesAddSNAT, fakeIPTablesAdd)
+
+	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "iptables-check")
+	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "iptables-add")
+	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "ip")
+
+	ifaceInfo := []network.InterfaceInfo{{
+		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+	}}
+
+	err := provisioner.SetupRoutesAndIPTables("nic", "bridge", ifaceInfo)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now verify the expected commands - since check returns 1, add
+	// will be called before ip route add.
+
+	gitjujutesting.AssertEchoArgs(c, "iptables-check", "nic", "0.1.2.1")
+	gitjujutesting.AssertEchoArgs(c, "iptables-add", "nic", "0.1.2.1")
+	gitjujutesting.AssertEchoArgs(c, "ip", "route", "add", "0.1.2.3", "dev", "bridge")
+}
+
+func (s *lxcBrokerSuite) TestDiscoverPrimaryNICNetInterfacesError(c *gc.C) {
+	s.PatchValue(provisioner.NetInterfaces, func() ([]net.Interface, error) {
+		return nil, errors.New("boom!")
+	})
+
+	nic, err := provisioner.DiscoverPrimaryNIC()
+	c.Assert(err, gc.ErrorMatches, "cannot get network interfaces: boom!")
+	c.Assert(nic, gc.Equals, "")
+}
+
+func (s *lxcBrokerSuite) TestDiscoverPrimaryNICInterfaceAddrsError(c *gc.C) {
+	s.PatchValue(provisioner.NetInterfaces, func() ([]net.Interface, error) {
+		return []net.Interface{{
+			Index: 0,
+			Name:  "fake",
+			Flags: net.FlagUp,
+		}}, nil
+	})
+	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
+		return nil, errors.New("boom!")
+	})
+
+	nic, err := provisioner.DiscoverPrimaryNIC()
+	c.Assert(err, gc.ErrorMatches, `cannot get "fake" addresses: boom!`)
+	c.Assert(nic, gc.Equals, "")
+}
+
+func (s *lxcBrokerSuite) TestDiscoverPrimaryNICInterfaceNotFound(c *gc.C) {
+	s.PatchValue(provisioner.NetInterfaces, func() ([]net.Interface, error) {
+		return nil, nil
+	})
+
+	nic, err := provisioner.DiscoverPrimaryNIC()
+	c.Assert(err, gc.ErrorMatches, "cannot detect the primary network interface")
+	c.Assert(nic, gc.Equals, "")
+}
+
+type fakeAddr struct{}
+
+func (f *fakeAddr) Network() string { return "net" }
+func (f *fakeAddr) String() string  { return "fakeAddr" }
+
+var _ net.Addr = (*fakeAddr)(nil)
+
+func (s *lxcBrokerSuite) TestDiscoverPrimaryNICSuccess(c *gc.C) {
+	s.PatchValue(provisioner.NetInterfaces, func() ([]net.Interface, error) {
+		return []net.Interface{{
+			Index: 0,
+			Name:  "lo",
+			Flags: net.FlagUp | net.FlagLoopback, // up but loopback - ignored.
+		}, {
+			Index: 1,
+			Name:  "if0",
+			Flags: net.FlagPointToPoint, // not up - ignored.
+		}, {
+			Index: 2,
+			Name:  "if1",
+			Flags: net.FlagUp, // up but no addresses - ignored.
+		}, {
+			Index: 3,
+			Name:  "if2",
+			Flags: net.FlagUp, // up and has addresses - returned.
+		}}, nil
+	})
+	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
+		// We should be called only for the last two NICs. The first
+		// one (if1) won't have addresses, only the last one (if2).
+		c.Assert(i, gc.NotNil)
+		c.Assert(i.Name, gc.Matches, "if[12]")
+		if i.Name == "if2" {
+			return []net.Addr{&fakeAddr{}}, nil
+		}
+		// For if1 we return no addresses.
+		return nil, nil
+	})
+
+	nic, err := provisioner.DiscoverPrimaryNIC()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(nic, gc.Equals, "if2")
+}
+
+func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
+	// All the pieces used by this func are separately tested, we just
+	// test the integration between them.
+	s.PatchValue(provisioner.NetInterfaces, func() ([]net.Interface, error) {
+		return []net.Interface{{
+			Index: 0,
+			Name:  "eth0",
+			Flags: net.FlagUp,
+		}}, nil
+	})
+	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
+		return []net.Addr{&fakeAddr{}}, nil
+	})
+	fakeResolvConf := filepath.Join(c.MkDir(), "resolv.conf")
+	err := ioutil.WriteFile(fakeResolvConf, []byte("nameserver ns1.dummy\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(provisioner.ResolvConf, fakeResolvConf)
+
+	// When ifaceInfo is not empty it shouldn't do anything and both
+	// the error and the result are nil.
+	ifaceInfo := []network.InterfaceInfo{{DeviceIndex: 0}}
+	result, err := provisioner.MaybeAllocateStaticIP("42", "bridge", &fakeAPI{c}, ifaceInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.IsNil)
+
+	// When it's not empty, result should be populated as expected.
+	ifaceInfo = []network.InterfaceInfo{}
+	result, err = provisioner.MaybeAllocateStaticIP("42", "bridge", &fakeAPI{c}, ifaceInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, []network.InterfaceInfo{{
+		DeviceIndex:    0,
+		ConfigType:     network.ConfigStatic,
+		DNSServers:     network.NewAddresses("ns1.dummy"),
+		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+	}})
+}
+
 type lxcProvisionerSuite struct {
 	CommonProvisionerSuite
 	lxcSuite
@@ -373,7 +753,11 @@ func (s *lxcProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 	s.waitRemoved(c, container)
 }
 
-type fakeAPI struct{}
+type fakeAPI struct {
+	c *gc.C
+}
+
+var _ provisioner.APICalls = (*fakeAPI)(nil)
 
 func (*fakeAPI) ContainerConfig() (params.ContainerConfig, error) {
 	return params.ContainerConfig{
@@ -381,4 +765,15 @@ func (*fakeAPI) ContainerConfig() (params.ContainerConfig, error) {
 		ProviderType:            "fake",
 		AuthorizedKeys:          coretesting.FakeAuthKeys,
 		SSLHostnameVerification: true}, nil
+}
+
+func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) ([]network.InterfaceInfo, error) {
+	if f.c != nil {
+		f.c.Assert(tag.String(), gc.Equals, "machine-42")
+	}
+	return []network.InterfaceInfo{{
+		DeviceIndex:    0,
+		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+	}}, nil
 }

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -335,82 +335,124 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesInvalidArgs(c *gc.C) {
 	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
 
 	// Check that all the arguments are verified to be non-empty.
-	expectStartupErr := "primaryNIC, bridgeName, and ifaceInfo must be all set"
+	expectStartupErr := "primaryNIC, primaryAddr, bridgeName, and ifaceInfo must be all set"
 	emptyIfaceInfo := []network.InterfaceInfo{}
 	for i, test := range []struct {
-		primaryNIC string
-		bridgeName string
-		ifaceInfo  []network.InterfaceInfo
-		expectErr  string
+		primaryNIC  string
+		primaryAddr network.Address
+		bridgeName  string
+		ifaceInfo   []network.InterfaceInfo
+		expectErr   string
 	}{{
-		primaryNIC: "",
-		bridgeName: "",
-		ifaceInfo:  nil,
-		expectErr:  expectStartupErr,
+		primaryNIC:  "",
+		primaryAddr: network.Address{},
+		bridgeName:  "",
+		ifaceInfo:   nil,
+		expectErr:   expectStartupErr,
 	}, {
-		primaryNIC: "nic",
-		bridgeName: "",
-		ifaceInfo:  nil,
-		expectErr:  expectStartupErr,
+		primaryNIC:  "nic",
+		primaryAddr: network.Address{},
+		bridgeName:  "",
+		ifaceInfo:   nil,
+		expectErr:   expectStartupErr,
 	}, {
-		primaryNIC: "",
-		bridgeName: "bridge",
-		ifaceInfo:  nil,
-		expectErr:  expectStartupErr,
+		primaryNIC:  "",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "",
+		ifaceInfo:   nil,
+		expectErr:   expectStartupErr,
 	}, {
-		primaryNIC: "nic",
-		bridgeName: "bridge",
-		ifaceInfo:  nil,
-		expectErr:  expectStartupErr,
+		primaryNIC:  "",
+		primaryAddr: network.Address{},
+		bridgeName:  "bridge",
+		ifaceInfo:   nil,
+		expectErr:   expectStartupErr,
 	}, {
-		primaryNIC: "",
-		bridgeName: "",
-		ifaceInfo:  emptyIfaceInfo,
-		expectErr:  expectStartupErr,
+		primaryNIC:  "nic",
+		primaryAddr: network.Address{},
+		bridgeName:  "bridge",
+		ifaceInfo:   nil,
+		expectErr:   expectStartupErr,
 	}, {
-		primaryNIC: "nic",
-		bridgeName: "",
-		ifaceInfo:  emptyIfaceInfo,
-		expectErr:  expectStartupErr,
+		primaryNIC:  "nic",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "",
+		ifaceInfo:   nil,
+		expectErr:   expectStartupErr,
 	}, {
-		primaryNIC: "",
-		bridgeName: "bridge",
-		ifaceInfo:  emptyIfaceInfo,
-		expectErr:  expectStartupErr,
+		primaryNIC:  "",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "bridge",
+		ifaceInfo:   nil,
+		expectErr:   expectStartupErr,
 	}, {
-		primaryNIC: "nic",
-		bridgeName: "bridge",
-		ifaceInfo:  emptyIfaceInfo,
-		expectErr:  expectStartupErr,
+		primaryNIC:  "nic",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "bridge",
+		ifaceInfo:   nil,
+		expectErr:   expectStartupErr,
 	}, {
-		primaryNIC: "nic",
-		bridgeName: "bridge",
-		// No Address or GatewayAddress set.
+		primaryNIC:  "",
+		primaryAddr: network.Address{},
+		bridgeName:  "",
+		ifaceInfo:   emptyIfaceInfo,
+		expectErr:   expectStartupErr,
+	}, {
+		primaryNIC:  "nic",
+		primaryAddr: network.Address{},
+		bridgeName:  "",
+		ifaceInfo:   emptyIfaceInfo,
+		expectErr:   expectStartupErr,
+	}, {
+		primaryNIC:  "",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "",
+		ifaceInfo:   emptyIfaceInfo,
+		expectErr:   expectStartupErr,
+	}, {
+		primaryNIC:  "",
+		primaryAddr: network.Address{},
+		bridgeName:  "bridge",
+		ifaceInfo:   emptyIfaceInfo,
+		expectErr:   expectStartupErr,
+	}, {
+		primaryNIC:  "nic",
+		primaryAddr: network.Address{},
+		bridgeName:  "bridge",
+		ifaceInfo:   emptyIfaceInfo,
+		expectErr:   expectStartupErr,
+	}, {
+		primaryNIC:  "nic",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "",
+		ifaceInfo:   emptyIfaceInfo,
+		expectErr:   expectStartupErr,
+	}, {
+		primaryNIC:  "",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "bridge",
+		ifaceInfo:   emptyIfaceInfo,
+		expectErr:   expectStartupErr,
+	}, {
+		primaryNIC:  "nic",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "bridge",
+		ifaceInfo:   emptyIfaceInfo,
+		expectErr:   expectStartupErr,
+	}, {
+		primaryNIC:  "nic",
+		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		bridgeName:  "bridge",
+		// No Address set.
 		ifaceInfo: []network.InterfaceInfo{{DeviceIndex: 0}},
-		expectErr: `host IP "" and container IP "" must be both set`,
-	}, {
-		primaryNIC: "nic",
-		bridgeName: "bridge",
-		// Has Address but no GatewayAddress set.
-		ifaceInfo: []network.InterfaceInfo{{
-			Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		}},
-		expectErr: `host IP "" and container IP "0.1.2.3" must be both set`,
-	}, {
-		primaryNIC: "nic",
-		bridgeName: "bridge",
-		// Has GatewayAddress but no Address set.
-		ifaceInfo: []network.InterfaceInfo{{
-			GatewayAddress: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		}},
-		expectErr: `host IP "0.1.2.3" and container IP "" must be both set`,
+		expectErr: `container IP "" must be set`,
 	}} {
 		c.Logf(
-			"test %d: primaryNIC=%q, bridge=%q, ifaceInfo=%v",
-			i, test.primaryNIC, test.bridgeName, test.ifaceInfo,
+			"test %d: primaryNIC=%q, primaryAddr=%q, bridge=%q, ifaceInfo=%v",
+			i, test.primaryNIC, test.primaryAddr.Value, test.bridgeName, test.ifaceInfo,
 		)
-		err := provisioner.SetupRoutesAndIPTables(test.primaryNIC, test.bridgeName, test.ifaceInfo)
-		c.Assert(err, gc.ErrorMatches, test.expectErr)
+		err := provisioner.SetupRoutesAndIPTables(test.primaryNIC, test.primaryAddr, test.bridgeName, test.ifaceInfo)
+		c.Check(err, gc.ErrorMatches, test.expectErr)
 	}
 }
 
@@ -420,11 +462,11 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesCheckError(c *gc.C) {
 	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
 
 	ifaceInfo := []network.InterfaceInfo{{
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
 	}}
 
-	err := provisioner.SetupRoutesAndIPTables("nic", "bridge", ifaceInfo)
+	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
 	c.Assert(err, gc.ErrorMatches, "iptables failed with unexpected exit code 42")
 }
 
@@ -437,11 +479,11 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesAddError(c *gc.C) {
 	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
 
 	ifaceInfo := []network.InterfaceInfo{{
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
 	}}
 
-	err := provisioner.SetupRoutesAndIPTables("nic", "bridge", ifaceInfo)
+	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
 	c.Assert(err, gc.ErrorMatches, `command "iptables -t nat -A .*" failed with exit code 42`)
 }
 
@@ -452,11 +494,11 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPRouteError(c *gc.C) {
 	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
 
 	ifaceInfo := []network.InterfaceInfo{{
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
 	}}
 
-	err := provisioner.SetupRoutesAndIPTables("nic", "bridge", ifaceInfo)
+	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
 	c.Assert(err, gc.ErrorMatches,
 		`command "ip route add 0.1.2.3 dev bridge" failed with exit code 123`,
 	)
@@ -480,11 +522,11 @@ iptables-add {{.HostIF}} {{.HostIP}}`[1:])
 	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "ip")
 
 	ifaceInfo := []network.InterfaceInfo{{
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
 	}}
 
-	err := provisioner.SetupRoutesAndIPTables("nic", "bridge", ifaceInfo)
+	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now verify the expected commands - since check returns 1, add
@@ -500,9 +542,10 @@ func (s *lxcBrokerSuite) TestDiscoverPrimaryNICNetInterfacesError(c *gc.C) {
 		return nil, errors.New("boom!")
 	})
 
-	nic, err := provisioner.DiscoverPrimaryNIC()
+	nic, addr, err := provisioner.DiscoverPrimaryNIC()
 	c.Assert(err, gc.ErrorMatches, "cannot get network interfaces: boom!")
 	c.Assert(nic, gc.Equals, "")
+	c.Assert(addr, jc.DeepEquals, network.Address{})
 }
 
 func (s *lxcBrokerSuite) TestDiscoverPrimaryNICInterfaceAddrsError(c *gc.C) {
@@ -517,9 +560,28 @@ func (s *lxcBrokerSuite) TestDiscoverPrimaryNICInterfaceAddrsError(c *gc.C) {
 		return nil, errors.New("boom!")
 	})
 
-	nic, err := provisioner.DiscoverPrimaryNIC()
+	nic, addr, err := provisioner.DiscoverPrimaryNIC()
 	c.Assert(err, gc.ErrorMatches, `cannot get "fake" addresses: boom!`)
 	c.Assert(nic, gc.Equals, "")
+	c.Assert(addr, jc.DeepEquals, network.Address{})
+}
+
+func (s *lxcBrokerSuite) TestDiscoverPrimaryNICInvalidAddr(c *gc.C) {
+	s.PatchValue(provisioner.NetInterfaces, func() ([]net.Interface, error) {
+		return []net.Interface{{
+			Index: 0,
+			Name:  "fake",
+			Flags: net.FlagUp,
+		}}, nil
+	})
+	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
+		return []net.Addr{&fakeAddr{}}, nil
+	})
+
+	nic, addr, err := provisioner.DiscoverPrimaryNIC()
+	c.Assert(err, gc.ErrorMatches, `cannot parse address "fakeAddr": invalid CIDR address: fakeAddr`)
+	c.Assert(nic, gc.Equals, "")
+	c.Assert(addr, jc.DeepEquals, network.Address{})
 }
 
 func (s *lxcBrokerSuite) TestDiscoverPrimaryNICInterfaceNotFound(c *gc.C) {
@@ -527,15 +589,21 @@ func (s *lxcBrokerSuite) TestDiscoverPrimaryNICInterfaceNotFound(c *gc.C) {
 		return nil, nil
 	})
 
-	nic, err := provisioner.DiscoverPrimaryNIC()
+	nic, addr, err := provisioner.DiscoverPrimaryNIC()
 	c.Assert(err, gc.ErrorMatches, "cannot detect the primary network interface")
 	c.Assert(nic, gc.Equals, "")
+	c.Assert(addr, jc.DeepEquals, network.Address{})
 }
 
-type fakeAddr struct{}
+type fakeAddr struct{ value string }
 
 func (f *fakeAddr) Network() string { return "net" }
-func (f *fakeAddr) String() string  { return "fakeAddr" }
+func (f *fakeAddr) String() string {
+	if f.value != "" {
+		return f.value
+	}
+	return "fakeAddr"
+}
 
 var _ net.Addr = (*fakeAddr)(nil)
 
@@ -565,15 +633,16 @@ func (s *lxcBrokerSuite) TestDiscoverPrimaryNICSuccess(c *gc.C) {
 		c.Assert(i, gc.NotNil)
 		c.Assert(i.Name, gc.Matches, "if[12]")
 		if i.Name == "if2" {
-			return []net.Addr{&fakeAddr{}}, nil
+			return []net.Addr{&fakeAddr{"0.1.2.3/24"}}, nil
 		}
 		// For if1 we return no addresses.
 		return nil, nil
 	})
 
-	nic, err := provisioner.DiscoverPrimaryNIC()
+	nic, addr, err := provisioner.DiscoverPrimaryNIC()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(nic, gc.Equals, "if2")
+	c.Assert(addr, jc.DeepEquals, network.NewAddress("0.1.2.3", network.ScopeUnknown))
 }
 
 func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
@@ -587,7 +656,7 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 		}}, nil
 	})
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
-		return []net.Addr{&fakeAddr{}}, nil
+		return []net.Addr{&fakeAddr{"0.1.2.1/24"}}, nil
 	})
 	fakeResolvConf := filepath.Join(c.MkDir(), "resolv.conf")
 	err := ioutil.WriteFile(fakeResolvConf, []byte("nameserver ns1.dummy\n"), 0644)
@@ -607,6 +676,7 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:    0,
+		CIDR:           "0.1.2.0/24",
 		ConfigType:     network.ConfigStatic,
 		InterfaceName:  "eth0", // generated from the device index.
 		DNSServers:     network.NewAddresses("ns1.dummy"),
@@ -774,6 +844,7 @@ func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) ([]network
 	}
 	return []network.InterfaceInfo{{
 		DeviceIndex:    0,
+		CIDR:           "0.1.2.0/24",
 		InterfaceName:  "dummy0",
 		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
 		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -582,7 +582,7 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 	s.PatchValue(provisioner.NetInterfaces, func() ([]net.Interface, error) {
 		return []net.Interface{{
 			Index: 0,
-			Name:  "eth0",
+			Name:  "fake0",
 			Flags: net.FlagUp,
 		}}, nil
 	})
@@ -608,6 +608,7 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:    0,
 		ConfigType:     network.ConfigStatic,
+		InterfaceName:  "eth0", // generated from the device index.
 		DNSServers:     network.NewAddresses("ns1.dummy"),
 		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
 		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
@@ -773,6 +774,7 @@ func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) ([]network
 	}
 	return []network.InterfaceInfo{{
 		DeviceIndex:    0,
+		InterfaceName:  "dummy0",
 		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
 		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
 	}}, nil


### PR DESCRIPTION
A lot of changes for one PR, but since the 1.23 feature freeze is almost
here, I'd rather land this and later improve upon it.

 * LXC broker calls PrepareContainerInterfaceInfo() before the container
   is started to try and allocate a static IP for it. If it fails, it's
   not fatal - just continues as before.
 * MAAS provider - juju-br0 is no longer created for nodes during
   initial boot. This is because LXC containers now use static IPs and
   the DHCP magic around the bridge is not needed. This *does* break KVM
   containers for MAAS (they're no longer addressable), but a fix for
   this will come in a follow-up.
 * In addition to enabling IP forwarding on the host at container initialization now ARP proxying (net.ipv4.conf.all.proxy_arp) is also enabled as it was needed for MAAS (otherwise containers on other nodes could not connect to the API server).
 * Container userdata generated for with static address configuration
   needed to change slightly (netmask 255.255.255.255 does not allow
   containers on other hosts to talk to the state server).
 * A lot of tests added inside the LXC broker suite for the new
   functionality - more than 88% coverage in total (a lot more for the
   new methods).

Few other drive-by fixes after a *lot* of live tests on MAAS and EC2.

Known limitations/issues (will be addressed in follow-ups as tech-dept bug fixes):
 * iptables rules and ip routes are lost after the host reboots.
 * allocated addresses are not released when stopping the container.
 * kvm containers on MAAS are not addressable anymore (due to not using juju-br0 anymore).
 * when lxc-clone is true, it does not work - the template container creation needs to be modified to also use a static IP and release it when done.

(Review request: http://reviews.vapour.ws/r/1072/)