### PR TITLE
CMD: environment unshare

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -544,7 +544,7 @@ func (c *Client) ShareEnvironment(users ...names.UserTag) error {
 }
 
 // UnshareEnvironment removes access to the environment for the given users.
-func (c *Client) UnshareEnvironment(users []names.UserTag) error {
+func (c *Client) UnshareEnvironment(users ...names.UserTag) error {
 	var args params.ModifyEnvironUsers
 	for _, user := range users {
 		if &user != nil {
@@ -559,6 +559,13 @@ func (c *Client) UnshareEnvironment(users []names.UserTag) error {
 	err := c.facade.FacadeCall("ShareEnvironment", args, &result)
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	for i, r := range result.Results {
+		if r.Error != nil && r.Error.Code == params.CodeNotFound {
+			logger.Warningf("environment was not previously shared with user %s", users[i].Username())
+			result.Results[i].Error = nil
+		}
 	}
 	return result.Combine()
 }

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -980,7 +980,7 @@ func (c *Client) EnvironmentInfo() (api.EnvironmentInfo, error) {
 	return info, nil
 }
 
-// ShareEnvironment allows the given user(s) access to the environment.
+// ShareEnvironment manages allowing and denying the given user(s) access to the environment.
 func (c *Client) ShareEnvironment(args params.ModifyEnvironUsers) (result params.ErrorResults, err error) {
 	var createdBy names.UserTag
 	var ok bool

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -171,6 +171,25 @@ func (s *serverSuite) TestUnshareEnvironment(c *gc.C) {
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
+func (s *serverSuite) TestUnshareEnvironmentMissingUser(c *gc.C) {
+	user := names.NewUserTag("bob")
+	args := params.ModifyEnvironUsers{
+		Changes: []params.ModifyEnvironUser{{
+			UserTag: user.String(),
+			Action:  params.RemoveEnvUser,
+		}}}
+
+	result, err := s.client.ShareEnvironment(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.OneError(), gc.ErrorMatches, `could not unshare environment: env user "bob@local" does not exist: transaction aborted`)
+
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.NotNil)
+
+	_, err = s.State.EnvironmentUser(user)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
 func (s *serverSuite) TestShareEnvironmentAddLocalUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoEnvUser: true})
 	args := params.ModifyEnvironUsers{

--- a/cmd/juju/environment/environment.go
+++ b/cmd/juju/environment/environment.go
@@ -35,6 +35,7 @@ func NewSuperCommand() cmd.Command {
 
 	if featureflag.Enabled(feature.JES) {
 		environmentCmd.Register(envcmd.Wrap(&ShareCommand{}))
+		environmentCmd.Register(envcmd.Wrap(&UnshareCommand{}))
 		environmentCmd.Register(envcmd.Wrap(&CreateCommand{}))
 	}
 	return environmentCmd

--- a/cmd/juju/environment/environment_test.go
+++ b/cmd/juju/environment/environment_test.go
@@ -24,6 +24,7 @@ type EnvironmentCommandSuite struct {
 var _ = gc.Suite(&EnvironmentCommandSuite{})
 
 var expectedCommmandNames = []string{
+	"create",
 	"get",
 	"help",
 	"jenv",
@@ -31,6 +32,7 @@ var expectedCommmandNames = []string{
 	"set",
 	"share",
 	"unset",
+	"unshare",
 }
 
 func (s *EnvironmentCommandSuite) TestHelpCommands(c *gc.C) {
@@ -43,10 +45,10 @@ func (s *EnvironmentCommandSuite) TestHelpCommands(c *gc.C) {
 
 	// Remove "share" for the first test because the feature is not
 	// enabled.
-	devFeatures := set.NewStrings("share")
+	devFeatures := set.NewStrings("create", "share", "unshare")
 
-	// Remove features behind dev_flag for the first test
-	// since they are not enabled.
+	// Remove features behind dev_flag for the first test since they are not
+	// enabled.
 	cmdSet := set.NewStrings(expectedCommmandNames...).Difference(devFeatures)
 
 	// Test default commands.

--- a/cmd/juju/environment/export_test.go
+++ b/cmd/juju/environment/export_test.go
@@ -38,6 +38,13 @@ func NewShareCommand(api ShareEnvironmentAPI) *ShareCommand {
 	}
 }
 
+// NewUnshareCommand returns an unshareCommand with the api provided as specified.
+func NewUnshareCommand(api UnshareEnvironmentAPI) *UnshareCommand {
+	return &UnshareCommand{
+		api: api,
+	}
+}
+
 // NewCreateCommand returns a CreateCommand with the api provided as specified.
 func NewCreateCommand(api CreateEnvironmentAPI) *CreateCommand {
 	return &CreateCommand{

--- a/cmd/juju/environment/fakeenv_test.go
+++ b/cmd/juju/environment/fakeenv_test.go
@@ -27,10 +27,11 @@ func (s *fakeEnvSuite) SetUpTest(c *gc.C) {
 }
 
 type fakeEnvAPI struct {
-	values   map[string]interface{}
-	err      error
-	keys     []string
-	addUsers []names.UserTag
+	values      map[string]interface{}
+	err         error
+	keys        []string
+	addUsers    []names.UserTag
+	removeUsers []names.UserTag
 }
 
 func (f *fakeEnvAPI) Close() error {
@@ -53,5 +54,10 @@ func (f *fakeEnvAPI) EnvironmentUnset(keys ...string) error {
 
 func (f *fakeEnvAPI) ShareEnvironment(users ...names.UserTag) error {
 	f.addUsers = users
+	return f.err
+}
+
+func (f *fakeEnvAPI) UnshareEnvironment(users ...names.UserTag) error {
+	f.removeUsers = users
 	return f.err
 }

--- a/cmd/juju/environment/unshare.go
+++ b/cmd/juju/environment/unshare.go
@@ -1,0 +1,88 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environment
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/block"
+)
+
+const unshareEnvHelpDoc = `
+Deny a user access to an environment that was previously shared with them.
+
+Examples:
+ juju environment unshare joe
+     Deny local user "joe" access to the current environment
+
+ juju environment unshare user1 user2 user3@ubuntuone
+     Deny two local users and one remote user access to the current environment
+
+ juju environment unshare sam -e/--environment myenv
+     Deny local user "sam" access to the environment named "myenv"
+ `
+
+// UnshareCommand unshares an environment with the given user(s).
+type UnshareCommand struct {
+	envcmd.EnvCommandBase
+	cmd.CommandBase
+	envName string
+	api     UnshareEnvironmentAPI
+
+	// Users to unshare the environment with.
+	Users []names.UserTag
+}
+
+func (c *UnshareCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "unshare",
+		Args:    "<user> ...",
+		Purpose: "unshare the current environment with a user",
+		Doc:     strings.TrimSpace(unshareEnvHelpDoc),
+	}
+}
+
+func (c *UnshareCommand) Init(args []string) (err error) {
+	if len(args) == 0 {
+		return errors.New("no users specified")
+	}
+
+	for _, arg := range args {
+		if !names.IsValidUser(arg) {
+			return errors.Errorf("invalid username: %q", arg)
+		}
+		c.Users = append(c.Users, names.NewUserTag(arg))
+	}
+
+	return nil
+}
+
+func (c *UnshareCommand) getAPI() (UnshareEnvironmentAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	return c.NewAPIClient()
+}
+
+// UnshareEnvironmentAPI defines the API functions used by the environment
+// unshare command.
+type UnshareEnvironmentAPI interface {
+	Close() error
+	UnshareEnvironment(...names.UserTag) error
+}
+
+func (c *UnshareCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	return block.ProcessBlockedError(client.UnshareEnvironment(c.Users...), block.BlockChange)
+}

--- a/cmd/juju/environment/unshare_test.go
+++ b/cmd/juju/environment/unshare_test.go
@@ -1,0 +1,58 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environment_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/environment"
+	"github.com/juju/juju/testing"
+)
+
+type unshareSuite struct {
+	fakeEnvSuite
+}
+
+var _ = gc.Suite(&unshareSuite{})
+
+func (s *unshareSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	command := environment.NewUnshareCommand(s.fake)
+	return testing.RunCommand(c, envcmd.Wrap(command), args...)
+}
+
+func (s *unshareSuite) TestInit(c *gc.C) {
+	unshareCmd := &environment.UnshareCommand{}
+	err := testing.InitCommand(unshareCmd, []string{})
+	c.Assert(err, gc.ErrorMatches, "no users specified")
+
+	err = testing.InitCommand(unshareCmd, []string{"not valid/0"})
+	c.Assert(err, gc.ErrorMatches, `invalid username: "not valid/0"`)
+
+	err = testing.InitCommand(unshareCmd, []string{"bob@local", "sam"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(unshareCmd.Users[0], gc.Equals, names.NewUserTag("bob@local"))
+	c.Assert(unshareCmd.Users[1], gc.Equals, names.NewUserTag("sam"))
+}
+
+func (s *unshareSuite) TestPassesValues(c *gc.C) {
+	sam := names.NewUserTag("sam")
+	ralph := names.NewUserTag("ralph")
+
+	_, err := s.run(c, "sam", "ralph")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fake.removeUsers, jc.DeepEquals, []names.UserTag{sam, ralph})
+}
+
+func (s *unshareSuite) TestBlockUnShare(c *gc.C) {
+	s.fake.err = &params.Error{Code: params.CodeOperationBlocked}
+	_, err := s.run(c, "sam")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Check(c.GetTestLog(), jc.Contains, "To unblock changes")
+}

--- a/featuretests/api_environment_test.go
+++ b/featuretests/api_environment_test.go
@@ -4,6 +4,8 @@
 package featuretests
 
 import (
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/testing"
@@ -43,4 +45,23 @@ func (s *apiEnvironmentSuite) TestEnvironmentShare(c *gc.C) {
 	c.Assert(envUser.UserName(), gc.Equals, user.Username())
 	c.Assert(envUser.CreatedBy(), gc.Equals, s.AdminUserTag(c).Username())
 	c.Assert(envUser.LastConnection(), gc.IsNil)
+}
+
+func (s *apiEnvironmentSuite) TestEnvironmentUnshare(c *gc.C) {
+	// Firt share an environment with a user.
+	user := names.NewUserTag("foo@ubuntuone")
+	err := s.client.ShareEnvironment(user)
+	c.Assert(err, jc.ErrorIsNil)
+
+	envUser, err := s.State.EnvironmentUser(user)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(envUser, gc.NotNil)
+
+	// Then test unsharing the environment.
+	err = s.client.UnshareEnvironment(user)
+	c.Assert(err, jc.ErrorIsNil)
+
+	envUser, err = s.State.EnvironmentUser(user)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+	c.Assert(envUser, gc.IsNil)
 }

--- a/featuretests/cmd_juju_environment_test.go
+++ b/featuretests/cmd_juju_environment_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -48,4 +49,30 @@ func (s *cmdEnvironmentSuite) TestEnvironmentShareCmdStack(c *gc.C) {
 	c.Assert(envUser.UserName(), gc.Equals, user.Username())
 	c.Assert(envUser.CreatedBy(), gc.Equals, s.AdminUserTag(c).Username())
 	c.Assert(envUser.LastConnection(), gc.IsNil)
+}
+
+func runUnshare(c *gc.C, args []string) *cmd.Context {
+	context, err := testing.RunCommand(c, envcmd.Wrap(&cmdenvironment.UnshareCommand{}), args...)
+	c.Assert(err, jc.ErrorIsNil)
+	return context
+}
+
+func (s *cmdEnvironmentSuite) TestEnvironmentUnshareCmdStack(c *gc.C) {
+	// Firstly share an environment with a user
+	username := "bar@ubuntuone"
+	context := runShare(c, []string{username})
+	user := names.NewUserTag(username)
+	envuser, err := s.State.EnvironmentUser(user)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(envuser, gc.NotNil)
+
+	// Then test that the unshare command stack is hooked up
+	context = runUnshare(c, []string{username})
+	obtained := strings.Replace(testing.Stdout(context), "\n", "", -1)
+	expected := ""
+	c.Assert(obtained, gc.Equals, expected)
+
+	envuser, err = s.State.EnvironmentUser(user)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+	c.Assert(envuser, gc.IsNil)
 }


### PR DESCRIPTION
Add "juju environment unshare" sub-command and corresponding tests in
cmd, api and featuretests. When unshare is called on a user that has
not been added to an environment, the APIServer errors but the CLI
only logs a warning - as the desired outcome has still been reached:
the user does not have access to the environment.

(Review request: http://reviews.vapour.ws/r/1041/)

(Review request: http://reviews.vapour.ws/r/1078/)