### PR TITLE
Remove cmd/juju import in featuretests/cmdjuju_test.go

### DIFF
--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -9,18 +9,14 @@
 package featuretests
 
 import (
-	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	// TODO(dimitern): Don't import a main package into a library
-	// package, pulling in main() along with it.
-	cmdjuju "github.com/juju/juju/cmd/juju"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/constraints"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
 )
 
 // cmdJujuSuite tests the connectivity of juju commands.  These tests
@@ -35,17 +31,9 @@ func uint64p(val uint64) *uint64 {
 	return &val
 }
 
-func runCommand(c *gc.C, commands ...string) (*cmd.Context, error) {
-	context := testing.Context(c)
-	juju := cmdjuju.NewJujuCommand(context)
-	if err := testing.InitCommand(juju, commands); err != nil {
-		return context, err
-	}
-	return context, juju.Run(context)
-}
-
 func (s *cmdJujuSuite) TestSetConstraints(c *gc.C) {
-	_, err := runCommand(c, "set-constraints", "mem=4G", "cpu-power=250")
+	_, err := testing.RunCommand(c, envcmd.Wrap(&common.SetConstraintsCommand{}),
+		"mem=4G", "cpu-power=250")
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons, err := s.State.EnvironConstraints()
@@ -61,20 +49,7 @@ func (s *cmdJujuSuite) TestGetConstraints(c *gc.C) {
 	err := svc.SetConstraints(constraints.Value{CpuCores: uint64p(64)})
 	c.Assert(err, jc.ErrorIsNil)
 
-	context, err := runCommand(c, "get-constraints", "svc")
+	context, err := testing.RunCommand(c, envcmd.Wrap(&common.GetConstraintsCommand{}), "svc")
 	c.Assert(testing.Stdout(context), gc.Equals, "cpu-cores=64\n")
 	c.Assert(testing.Stderr(context), gc.Equals, "")
-}
-
-func (s *cmdJujuSuite) TestEnsureAvailability(c *gc.C) {
-	s.Factory.MakeMachine(c, &factory.MachineParams{
-		Jobs: []state.MachineJob{state.JobManageEnviron},
-	})
-	ctx, err := runCommand(c, "ensure-availability", "-n", "3")
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Machine 0 is demoted because it hasn't reported its presence
-	c.Assert(testing.Stdout(ctx), gc.Equals,
-		"adding machines: 1, 2, 3\n"+
-			"demoting machines 0\n\n")
 }


### PR DESCRIPTION
featuretests/cmdjuju_test.go imported a main package which
would sometimes lead to this error in testing:

cmdjuju_test.go:18: can't find import: "github.com/juju/juju/cmd/juju"

This patch modifies the tests to remove the dependency on
that package.

(Review request: http://reviews.vapour.ws/r/1081/)