### PR TITLE
add Leader field to uniter operation state

### DIFF
--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -55,6 +55,11 @@ const (
 // State defines the local persistent state of the uniter, excluding relation
 // state.
 type State struct {
+
+	// Leader indicates whether a leader-elected hook has started to run, and
+	// no more recent leader-deposed hook has completed.
+	Leader bool `yaml:"leader"`
+
 	// Started indicates whether the start hook has run.
 	Started bool `yaml:"started"`
 

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -197,6 +197,7 @@ var stateTests = []struct {
 			Step:               operation.Pending,
 			Hook:               relhook,
 			CollectMetricsTime: 98765432,
+			Leader:             true,
 		},
 	},
 }


### PR DESCRIPTION
This is so trivial as to be barely worth landing, but it's all I can do at the moment on this front. May as well.

(Review request: http://reviews.vapour.ws/r/1084/)