### PR TITLE
Actions 'status' command now handles multiple results

### DIFF
--- a/cmd/juju/action/action_test.go
+++ b/cmd/juju/action/action_test.go
@@ -48,7 +48,7 @@ func (s *ActionCommandSuite) checkHelpSubCommands(c *gc.C, ctx *cmd.Context) {
 		{"do", "queue an action for execution"},
 		{"fetch", "show results of an action by ID"},
 		{"help", "show help on a command or other topic"},
-		{"status", "show results of an action by ID"},
+		{"status", "show results of all actions filtered by optional ID prefix"},
 	}
 
 	// Check that we have registered all the sub commands by

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-var logger = loggo.GetLogger("juju.cmd.action.common")
+var logger = loggo.GetLogger("juju.cmd.juju.action")
 
 // conform ensures all keys of any nested maps are strings.  This is
 // necessary because YAML unmarshals map[interface{}]interface{} in nested
@@ -114,7 +114,7 @@ func getActionTagsFromPrefix(api APIClient, prefix string) ([]names.ActionTag, e
 
 	results, rejects := getActionTags(matches)
 	if len(rejects) > 0 {
-		logger.Debugf("FindActionTagsByPrefix for prefix %q found invalid tags %v", prefix, rejects)
+		logger.Errorf("FindActionTagsByPrefix for prefix %q found invalid tags %v", prefix, rejects)
 	}
 	return results, nil
 }

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -98,8 +98,8 @@ func displayActionResult(result params.ActionResult, ctx *cmd.Context, out cmd.O
 	return nil
 }
 
-// getActionTagFromPrefix uses the APIClient to get all ActionTags matching a prefix.
-func getActionTagsFromPrefix(api APIClient, prefix string) ([]names.ActionTag, error) {
+// getActionTagByPrefix uses the APIClient to get all ActionTags matching a prefix.
+func getActionTagsByPrefix(api APIClient, prefix string) ([]names.ActionTag, error) {
 	results := []names.ActionTag{}
 
 	tags, err := api.FindActionTagsByPrefix(params.FindTags{Prefixes: []string{prefix}})
@@ -119,10 +119,10 @@ func getActionTagsFromPrefix(api APIClient, prefix string) ([]names.ActionTag, e
 	return results, nil
 }
 
-// getActionTagFromPrefix uses the APIClient to get an ActionTag from a prefix.
-func getActionTagFromPrefix(api APIClient, prefix string) (names.ActionTag, error) {
+// getActionTagByPrefix uses the APIClient to get an ActionTag from a prefix.
+func getActionTagByPrefix(api APIClient, prefix string) (names.ActionTag, error) {
 	tag := names.ActionTag{}
-	actiontags, err := getActionTagsFromPrefix(api, prefix)
+	actiontags, err := getActionTagsByPrefix(api, prefix)
 	if err != nil {
 		return tag, err
 	}

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -6,11 +6,14 @@ package action
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/apiserver/params"
 )
+
+var logger = loggo.GetLogger("juju.cmd.action.common")
 
 // conform ensures all keys of any nested maps are strings.  This is
 // necessary because YAML unmarshals map[interface{}]interface{} in nested
@@ -95,22 +98,37 @@ func displayActionResult(result params.ActionResult, ctx *cmd.Context, out cmd.O
 	return nil
 }
 
+// getActionTagFromPrefix uses the APIClient to get all ActionTags matching a prefix.
+func getActionTagsFromPrefix(api APIClient, prefix string) ([]names.ActionTag, error) {
+	results := []names.ActionTag{}
+
+	tags, err := api.FindActionTagsByPrefix(params.FindTags{Prefixes: []string{prefix}})
+	if err != nil {
+		return results, err
+	}
+
+	matches, ok := tags.Matches[prefix]
+	if !ok || len(matches) < 1 {
+		return results, nil
+	}
+
+	results, rejects := getActionTags(matches)
+	if len(rejects) > 0 {
+		logger.Debugf("FindActionTagsByPrefix for prefix %q found invalid tags %v", prefix, rejects)
+	}
+	return results, nil
+}
+
 // getActionTagFromPrefix uses the APIClient to get an ActionTag from a prefix.
 func getActionTagFromPrefix(api APIClient, prefix string) (names.ActionTag, error) {
 	tag := names.ActionTag{}
-	tags, err := api.FindActionTagsByPrefix(params.FindTags{Prefixes: []string{prefix}})
+	actiontags, err := getActionTagsFromPrefix(api, prefix)
 	if err != nil {
 		return tag, err
 	}
 
-	results, ok := tags.Matches[prefix]
-	if !ok || len(results) < 1 {
+	if len(actiontags) < 1 {
 		return tag, errors.Errorf("actions for identifier %q not found", prefix)
-	}
-
-	actiontags, rejects := getActionTags(results)
-	if len(rejects) > 0 {
-		return tag, errors.Errorf("identifier %q got unrecognized entity tags %v", prefix, rejects)
 	}
 
 	if len(actiontags) > 1 {

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -3,7 +3,11 @@
 
 package action
 
-import "github.com/juju/names"
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+)
 
 var (
 	NewActionAPIClient = &newAPIClient
@@ -35,4 +39,8 @@ func (c *DoCommand) KeyValueDoArgs() [][]string {
 
 func (c *DoCommand) ParseStrings() bool {
 	return c.parseStrings
+}
+
+func ActionResultsToMap(results []params.ActionResult) map[string]interface{} {
+	return resultsToMap(results)
 }

--- a/cmd/juju/action/fetch.go
+++ b/cmd/juju/action/fetch.go
@@ -62,7 +62,7 @@ func (c *FetchCommand) Run(ctx *cmd.Context) error {
 	}
 	defer api.Close()
 
-	actionTag, err := getActionTagFromPrefix(api, c.requestedId)
+	actionTag, err := getActionTagByPrefix(api, c.requestedId)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -6,6 +6,7 @@ package action
 import (
 	"github.com/juju/cmd"
 	errors "github.com/juju/errors"
+	"github.com/juju/names"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
@@ -16,6 +17,7 @@ type StatusCommand struct {
 	ActionCommandBase
 	out         cmd.Output
 	requestedId string
+	all         bool
 }
 
 const statusDoc = `
@@ -39,7 +41,9 @@ func (c *StatusCommand) Info() *cmd.Info {
 func (c *StatusCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
-		return errors.New("no action ID specified")
+		c.all = true
+		c.requestedId = ""
+		return nil
 	case 1:
 		c.requestedId = args[0]
 		return nil
@@ -55,32 +59,65 @@ func (c *StatusCommand) Run(ctx *cmd.Context) error {
 	}
 	defer api.Close()
 
-	actionTag, err := getActionTagFromPrefix(api, c.requestedId)
+	actionTags, err := getActionTagsFromPrefix(api, c.requestedId)
 	if err != nil {
 		return err
 	}
 
-	actions, err := api.Actions(params.Entities{
-		Entities: []params.Entity{{actionTag.String()}},
-	})
+	if len(actionTags) < 1 {
+		if c.all {
+			return errors.Errorf("no actions found")
+		} else {
+			return errors.Errorf("no actions found matching prefix %q", c.requestedId)
+		}
+	}
+
+	entities := []params.Entity{}
+	for _, tag := range actionTags {
+		entities = append(entities, params.Entity{tag.String()})
+	}
+
+	actions, err := api.Actions(params.Entities{Entities: entities})
 	if err != nil {
 		return err
 	}
-	actionResults := actions.Results
-	numActionResults := len(actionResults)
-	if numActionResults == 0 {
-		return errors.Errorf("identifier %q matched action %q, but found no results", c.requestedId, actionTag.Id())
-	}
-	if numActionResults != 1 {
-		return errors.Errorf("too many results for action %s", actionTag.Id())
+
+	if len(actions.Results) < 1 {
+		return errors.Errorf("identifier %q matched action(s) %v, but found no results", c.requestedId, actionTags)
 	}
 
-	result := actionResults[0]
+	return c.out.Write(ctx, resultsToMap(actions.Results))
+}
+
+func resultsToMap(results []params.ActionResult) map[string]interface{} {
+	items := []map[string]interface{}{}
+	for _, item := range results {
+		items = append(items, resultToMap(item))
+	}
+	return map[string]interface{}{"actions": items}
+}
+
+func resultToMap(result params.ActionResult) map[string]interface{} {
+	item := map[string]interface{}{}
 	if result.Error != nil {
-		return result.Error
+		item["error"] = result.Error.Error()
 	}
-	return c.out.Write(ctx, map[string]interface{}{
-		"id":     actionTag.Id(),
-		"status": result.Status,
-	})
+	if result.Action != nil {
+		atag, err := names.ParseActionTag(result.Action.Tag)
+		if err != nil {
+			item["id"] = result.Action.Tag
+		} else {
+			item["id"] = atag.Id()
+		}
+
+		rtag, err := names.ParseUnitTag(result.Action.Receiver)
+		if err != nil {
+			item["unit"] = result.Action.Receiver
+		} else {
+			item["unit"] = rtag.Id()
+		}
+
+	}
+	item["status"] = result.Status
+	return item
 }

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -17,11 +17,10 @@ type StatusCommand struct {
 	ActionCommandBase
 	out         cmd.Output
 	requestedId string
-	all         bool
 }
 
 const statusDoc = `
-Show the status of an Action by ID.
+Show the status of Actions matching given ID, partial ID prefix, or all Actions if no ID is supplied.
 `
 
 // Set up the output.
@@ -32,8 +31,8 @@ func (c *StatusCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *StatusCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "status",
-		Args:    "<action ID>",
-		Purpose: "show results of an action by ID",
+		Args:    "[<action ID>|<action ID prefix>]",
+		Purpose: "show results of all actions filtered by optional ID prefix",
 		Doc:     statusDoc,
 	}
 }
@@ -41,7 +40,6 @@ func (c *StatusCommand) Info() *cmd.Info {
 func (c *StatusCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
-		c.all = true
 		c.requestedId = ""
 		return nil
 	case 1:
@@ -65,7 +63,7 @@ func (c *StatusCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if len(actionTags) < 1 {
-		if c.all {
+		if len(c.requestedId) == 0 {
 			return errors.Errorf("no actions found")
 		} else {
 			return errors.Errorf("no actions found matching prefix %q", c.requestedId)

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -57,7 +57,7 @@ func (c *StatusCommand) Run(ctx *cmd.Context) error {
 	}
 	defer api.Close()
 
-	actionTags, err := getActionTagsFromPrefix(api, c.requestedId)
+	actionTags, err := getActionTagsByPrefix(api, c.requestedId)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -6,6 +6,7 @@ package action_test
 import (
 	"bytes"
 
+	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -36,25 +37,24 @@ func (s *StatusSuite) TestRun(c *gc.C) {
 	fakeid2 := prefix + "-0001-4000-8000-feedfacebeef"
 	faketag := "action-" + fakeid
 	faketag2 := "action-" + fakeid2
-	fakestatus := "bloobered"
 
 	args := []string{prefix}
-	result := []params.ActionResult{{Status: fakestatus}}
+	result1 := []params.ActionResult{{Status: "some-random-status"}}
+	result2 := []params.ActionResult{{Status: "a status"}, {Status: "another status"}}
 
-	errNotSpecified := "no action ID specified"
-	errNotFound := `actions for identifier "` + prefix + `" not found`
-	errNotRecognized := `identifier "` + prefix + `" got unrecognized entity tags .*`
-	errMultipleMatches := `identifier "` + prefix + `" matched multiple actions .*`
-	errNoResults := `identifier "` + prefix + `" matched action "` + fakeid + `", but found no results`
+	errNotFound := "no actions found"
+	errNotFoundForPrefix := `no actions found matching prefix "` + prefix + `"`
+	errFoundTagButNoResults := `identifier "` + prefix + `" matched action\(s\) \[.*\], but found no results`
 
 	tests := []statusTestCase{
-		{expectError: errNotSpecified},
-		{args: args, expectError: errNotFound},
-		{args: args, expectError: errNotFound, tags: tagsForIdPrefix(prefix)},
-		{args: args, expectError: errNotRecognized, tags: tagsForIdPrefix(prefix, "bb", "bc")},
-		{args: args, expectError: errMultipleMatches, tags: tagsForIdPrefix(prefix, faketag, faketag2)},
-		{args: args, expectError: errNoResults, tags: tagsForIdPrefix(prefix, faketag)},
-		{args: args, tags: tagsForIdPrefix(prefix, faketag), results: result},
+		{expectError: errNotFound},
+		{args: args, expectError: errNotFoundForPrefix},
+		{args: args, expectError: errNotFoundForPrefix, tags: tagsForIdPrefix(prefix)},
+		{args: args, expectError: errNotFoundForPrefix, tags: tagsForIdPrefix(prefix, "bb", "bc")},
+		{args: args, expectError: errFoundTagButNoResults, tags: tagsForIdPrefix(prefix, faketag, faketag2)},
+		{args: args, expectError: errFoundTagButNoResults, tags: tagsForIdPrefix(prefix, faketag)},
+		{args: args, tags: tagsForIdPrefix(prefix, faketag), results: result1},
+		{args: args, tags: tagsForIdPrefix(prefix, faketag, faketag2), results: result2},
 	}
 
 	for _, test := range tests {
@@ -75,8 +75,9 @@ func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
 		c.Check(err, gc.ErrorMatches, tc.expectError)
 	}
 	if len(tc.results) > 0 {
-		expected := "id: .*\nstatus: " + tc.results[0].Status + "\n"
-		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Matches, expected)
+		buf, err := cmd.DefaultFormatters["yaml"](action.ActionResultsToMap(tc.results))
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, string(buf)+"\n")
 		c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
 	}
 }

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -38,7 +38,9 @@ func (s *StatusSuite) TestRun(c *gc.C) {
 	faketag := "action-" + fakeid
 	faketag2 := "action-" + fakeid2
 
-	args := []string{prefix}
+	emptyArgs := []string{}
+	emptyPrefixArgs := []string{}
+	prefixArgs := []string{prefix}
 	result1 := []params.ActionResult{{Status: "some-random-status"}}
 	result2 := []params.ActionResult{{Status: "a status"}, {Status: "another status"}}
 
@@ -48,16 +50,21 @@ func (s *StatusSuite) TestRun(c *gc.C) {
 
 	tests := []statusTestCase{
 		{expectError: errNotFound},
-		{args: args, expectError: errNotFoundForPrefix},
-		{args: args, expectError: errNotFoundForPrefix, tags: tagsForIdPrefix(prefix)},
-		{args: args, expectError: errNotFoundForPrefix, tags: tagsForIdPrefix(prefix, "bb", "bc")},
-		{args: args, expectError: errFoundTagButNoResults, tags: tagsForIdPrefix(prefix, faketag, faketag2)},
-		{args: args, expectError: errFoundTagButNoResults, tags: tagsForIdPrefix(prefix, faketag)},
-		{args: args, tags: tagsForIdPrefix(prefix, faketag), results: result1},
-		{args: args, tags: tagsForIdPrefix(prefix, faketag, faketag2), results: result2},
+		{args: emptyArgs, expectError: errNotFound},
+		{args: emptyArgs, tags: tagsForIdPrefix("", faketag, faketag2), results: result2},
+		{args: emptyPrefixArgs, expectError: errNotFound},
+		{args: emptyPrefixArgs, tags: tagsForIdPrefix("", faketag, faketag2), results: result2},
+		{args: prefixArgs, expectError: errNotFoundForPrefix},
+		{args: prefixArgs, expectError: errNotFoundForPrefix, tags: tagsForIdPrefix(prefix)},
+		{args: prefixArgs, expectError: errNotFoundForPrefix, tags: tagsForIdPrefix(prefix, "bb", "bc")},
+		{args: prefixArgs, expectError: errFoundTagButNoResults, tags: tagsForIdPrefix(prefix, faketag, faketag2)},
+		{args: prefixArgs, expectError: errFoundTagButNoResults, tags: tagsForIdPrefix(prefix, faketag)},
+		{args: prefixArgs, tags: tagsForIdPrefix(prefix, faketag), results: result1},
+		{args: prefixArgs, tags: tagsForIdPrefix(prefix, faketag, faketag2), results: result2},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
+		c.Logf("iteration %d, test case %+v", i, test)
 		s.runTestCase(c, test)
 	}
 }


### PR DESCRIPTION
If no prefix is given then all actions are returned.
If a prefix matches more than one Action, all will be returned.

Added unit to the output, to show which unit an action ran on.

(Review request: http://reviews.vapour.ws/r/1085/)