### PR TITLE
added `WaitLeader() Ticket` to leadership.Tracker

### DIFF
--- a/worker/leadership/interface.go
+++ b/worker/leadership/interface.go
@@ -16,24 +16,34 @@ type Ticket interface {
 	// for some period from the ticket request. The guaranteed duration depends
 	// upon the Tracker.
 	Wait() bool
+
+	// Ready returns a channel that will be closed when a result is available
+	// to Wait(), and is helpful for clients that want to select rather than
+	// block on long-waiting tickets.
+	Ready() <-chan struct{}
 }
 
 // Tracker allows clients to discover current leadership status by attempting to
 // claim it for themselves.
 type Tracker interface {
 
-	// ClaimLeader will return a Ticket which, when Wait()ed for, will return
-	// true if leadership is guaranteed for at least the tracker's duration from
-	// the time the ticket was issued.
-	ClaimLeader() Ticket
+	// ServiceName returns the name of the service for which leadership claims
+	// are made.
+	ServiceName() string
 
 	// ClaimDuration returns the duration for which a Ticket's true Wait result
 	// is guaranteed valid.
 	ClaimDuration() time.Duration
 
-	// ServiceName returns the name of the service for which leadership claims
-	// are made.
-	ServiceName() string
+	// ClaimLeader will return a Ticket which, when Wait()ed for, will return
+	// true if leadership is guaranteed for at least the tracker's duration from
+	// the time the ticket was issued. Leadership claims should be resolved
+	// relatively quickly.
+	ClaimLeader() Ticket
+
+	// WaitLeader will return a Ticket which, when Wait()ed for, will block
+	// until the tracker attains leadership.
+	WaitLeader() Ticket
 }
 
 // TrackerWorker embeds the Tracker and worker.Worker interfaces.

--- a/worker/uniter/runner/leader_test.go
+++ b/worker/uniter/runner/leader_test.go
@@ -324,3 +324,13 @@ type StubTicket bool
 func (ticket StubTicket) Wait() bool {
 	return bool(ticket)
 }
+
+func (ticket StubTicket) Ready() <-chan struct{} {
+	return alwaysReady
+}
+
+var alwaysReady = make(chan struct{})
+
+func init() {
+	close(alwaysReady)
+}


### PR DESCRIPTION
Should be suitable for triggering leader-elected in uniter mode funcs.

Also tweaked Ticket interface so we can use it in selects, and nobody has to Wait() for an unknown amount of time (unless they want to).

(Review request: http://reviews.vapour.ws/r/1086/)