### PR TITLE
State: Ensure user cannot have two environments with same name

### DIFF
--- a/state/environ.go
+++ b/state/environ.go
@@ -122,7 +122,24 @@ func (st *State) NewEnvironment(cfg *config.Config, owner names.UserTag) (_ *Env
 	}
 	err = newState.runTransactionNoEnvAliveAssert(ops)
 	if err == txn.ErrAborted {
-		err = errors.New("environment already exists")
+
+		// We have a  unique key restriction on the "owner" and "name" fields,
+		// which will cause the insert to fail if there is another record with
+		// the same "owner" and "name" in the collection. If the txn is
+		// aborted, check if it is due to the unique key restriction.
+		environments, closer := st.getCollection(environmentsC)
+		defer closer()
+		envCount, countErr := environments.Find(bson.D{
+			{"owner", owner.Username()},
+			{"name", cfg.Name()}},
+		).Count()
+		if countErr != nil {
+			err = errors.Trace(countErr)
+		} else if envCount > 0 {
+			err = errors.AlreadyExistsf("environment %q for %s", cfg.Name(), owner.Username())
+		} else {
+			err = errors.New("environment already exists")
+		}
 	}
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -130,7 +147,7 @@ func (st *State) NewEnvironment(cfg *config.Config, owner names.UserTag) (_ *Env
 
 	newEnv, err := newState.Environment()
 	if err != nil {
-		return nil, nil, errors.Annotate(err, "could not load new environment")
+		return nil, nil, errors.Trace(err)
 	}
 
 	return newEnv, newState, nil
@@ -204,7 +221,6 @@ func (e *Environment) globalKey() string {
 func (e *Environment) Refresh() error {
 	environments, closer := e.st.getCollection(environmentsC)
 	defer closer()
-
 	return e.refresh(environments.FindId(e.UUID()))
 }
 
@@ -378,6 +394,17 @@ func createEnvironmentOp(st *State, owner names.UserTag, name, uuid, server stri
 		Id:     uuid,
 		Assert: txn.DocMissing,
 		Insert: doc,
+	}
+}
+
+// createUniqueOwnerEnvNameOp returns the operation needed to create
+// an userenvnameC document with the given owner and environment name.
+func createUniqueOwnerEnvNameOp(owner names.UserTag, envName string) txn.Op {
+	return txn.Op{
+		C:      userenvnameC,
+		Id:     userEnvNameIndex(owner.Username(), envName),
+		Assert: txn.DocMissing,
+		Insert: bson.M{},
 	}
 }
 

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -39,6 +41,40 @@ func (s *EnvironSuite) TestNewEnvironmentNonExistentLocalUser(c *gc.C) {
 
 	_, _, err := s.State.NewEnvironment(cfg, owner)
 	c.Assert(err, gc.ErrorMatches, `cannot create environment: user "non-existent" not found`)
+}
+
+func (s *EnvironSuite) TestNewEnvironmentSameUserSameNameFails(c *gc.C) {
+	cfg, _ := s.createTestEnvConfig(c)
+	owner := s.factory.MakeUser(c, nil).UserTag()
+
+	// Create the first environment.
+	_, st1, err := s.State.NewEnvironment(cfg, owner)
+	c.Assert(err, jc.ErrorIsNil)
+	defer st1.Close()
+
+	// Attempt to create another environment with a different UUID but the
+	// same owner and name as the first.
+	newUUID, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg2 := testing.CustomEnvironConfig(c, testing.Attrs{
+		"name": cfg.Name(),
+		"uuid": newUUID.String(),
+	})
+	_, _, err = s.State.NewEnvironment(cfg2, owner)
+	errMsg := fmt.Sprintf("environment %q for %s already exists", cfg2.Name(), owner.Username())
+	c.Assert(err, gc.ErrorMatches, errMsg)
+	c.Assert(errors.IsAlreadyExists(err), jc.IsTrue)
+
+	// Remove the first environment.
+	err = st1.RemoveAllEnvironDocs()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// We should now be able to create the other environment.
+	env2, st2, err := s.State.NewEnvironment(cfg2, owner)
+	c.Assert(err, jc.ErrorIsNil)
+	defer st2.Close()
+	c.Assert(env2, gc.NotNil)
+	c.Assert(st2, gc.NotNil)
 }
 
 func (s *EnvironSuite) TestNewEnvironment(c *gc.C) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -272,6 +272,10 @@ func GetAllUpgradeInfos(st *State) ([]*UpgradeInfo, error) {
 	return out, nil
 }
 
+func UserEnvNameIndex(username, envName string) string {
+	return userEnvNameIndex(username, envName)
+}
+
 func DocID(st *State, id string) string {
 	return st.docID(id)
 }

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -59,7 +59,7 @@ func (s *storeManagerStateSuite) newState(c *gc.C) *State {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	cfg := testing.CustomEnvironConfig(c, testing.Attrs{
-		"name": "testenv",
+		"name": "newtestenv",
 		"uuid": uuid.String(),
 	})
 	_, st, err := s.state.NewEnvironment(cfg, s.owner)

--- a/state/open.go
+++ b/state/open.go
@@ -145,6 +145,7 @@ func (st *State) envSetupOps(cfg *config.Config, envUUID, serverUUID string, own
 		createConstraintsOp(st, environGlobalKey, constraints.Value{}),
 		createSettingsOp(st, environGlobalKey, cfg.AllAttrs()),
 		createEnvironmentOp(st, owner, cfg.Name(), envUUID, serverUUID),
+		createUniqueOwnerEnvNameOp(owner, cfg.Name()),
 		envUserOp,
 	}
 	return ops, nil

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -449,6 +450,44 @@ func AddEnvUUIDToEnvUsersDoc(st *State) error {
 				},
 			})
 		}
+	}
+	if err := iter.Err(); err != nil {
+		return errors.Trace(err)
+	}
+	return st.runRawTransaction(ops)
+}
+
+func AddUniqueOwnerEnvNameForEnvirons(st *State) error {
+	environs, closer := st.getCollection(environmentsC)
+	defer closer()
+
+	ownerEnvNameMap := map[string]set.Strings{}
+	ensureDoesNotExist := func(owner, envName string) error {
+		if _, ok := ownerEnvNameMap[owner]; ok {
+			if ownerEnvNameMap[owner].Contains(envName) {
+				return errors.AlreadyExistsf("environment %q for %s", envName, owner)
+			}
+			ownerEnvNameMap[owner].Add(envName)
+		} else {
+			ownerEnvNameMap[owner] = set.NewStrings(envName)
+		}
+		return nil
+	}
+
+	var ops []txn.Op
+	var env environmentDoc
+	iter := environs.Find(nil).Iter()
+	defer iter.Close()
+	for iter.Next(&env) {
+		if err := ensureDoesNotExist(env.Owner, env.Name); err != nil {
+			return err
+		}
+
+		ops = append(ops, txn.Op{
+			C:      userenvnameC,
+			Id:     userEnvNameIndex(env.Owner, env.Name),
+			Insert: bson.M{},
+		})
 	}
 	if err := iter.Err(); err != nil {
 		return errors.Trace(err)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
@@ -68,6 +69,89 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, keyExists := userMap["_id_"]
 	c.Assert(keyExists, jc.IsFalse)
+}
+
+func (s *upgradesSuite) TestAddUniqueOwnerEnvNameForEnvirons(c *gc.C) {
+	s.userEnvNameSetup(c, [][]string{
+		{"bob", "bobsenv"},
+		{"sam@remote", "samsenv"},
+	})
+
+	err := AddUniqueOwnerEnvNameForEnvirons(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertUserEnvNameObtained(c,
+		"test-admin@local:testenv",
+		"bob@local:bobsenv",
+		"sam@remote:samsenv",
+	)
+}
+
+func (s *upgradesSuite) TestAddUniqueOwnerEnvNameForEnvironsErrors(c *gc.C) {
+	s.userEnvNameSetup(c, [][]string{
+		{"bob", "bobsenv"},
+		{"bob", "bobsenv"},
+	})
+
+	err := AddUniqueOwnerEnvNameForEnvirons(s.state)
+	c.Assert(err, gc.ErrorMatches, `environment "bobsenv" for bob@local already exists`)
+	c.Assert(errors.IsAlreadyExists(err), jc.IsTrue)
+
+	// we expect the userenvname doc for the server environ as it was inserted
+	// when the environment was initialized.
+	s.assertUserEnvNameObtained(c, "test-admin@local:testenv")
+}
+
+func (s *upgradesSuite) TestAddUniqueOwnerEnvNameForEnvironsIdempotent(c *gc.C) {
+	s.userEnvNameSetup(c, [][]string{
+		{"bob", "bobsenv"},
+		{"sam@remote", "samsenv"},
+	})
+
+	err := AddUniqueOwnerEnvNameForEnvirons(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+	err = AddUniqueOwnerEnvNameForEnvirons(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertUserEnvNameObtained(c,
+		"bob@local:bobsenv",
+		"sam@remote:samsenv",
+		"test-admin@local:testenv",
+	)
+}
+
+// userEnvNameSetup adds an environmentsC doc for each {"owner", "envName"} arg.
+func (s *upgradesSuite) userEnvNameSetup(c *gc.C, userEnvNamePairs [][]string) {
+	var ops []txn.Op
+	for _, userEnvNamePair := range userEnvNamePairs {
+		uuid, err := utils.NewUUID()
+		c.Assert(err, jc.ErrorIsNil)
+		ops = append(ops, createEnvironmentOp(
+			s.state,
+			names.NewUserTag(userEnvNamePair[0]),
+			userEnvNamePair[1],
+			uuid.String(),
+			s.state.EnvironUUID(),
+		))
+	}
+	err := s.state.runRawTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// assertUserEnvNameObtained asserts that all (and no more) expectedIds are found in
+// the userenvnameC collection.
+func (s *upgradesSuite) assertUserEnvNameObtained(c *gc.C, expectedIds ...string) {
+	var obtained []bson.M
+	userenvname, closer := s.state.getCollection(userenvnameC)
+	defer closer()
+	err := userenvname.Find(nil).All(&obtained)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var obtainedIds []string
+	for _, userEnvName := range obtained {
+		obtainedIds = append(obtainedIds, userEnvName["_id"].(string))
+	}
+	c.Assert(obtainedIds, jc.SameContents, expectedIds)
 }
 
 func (s *upgradesSuite) TestAddStateUsersToEnviron(c *gc.C) {

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -45,6 +45,12 @@ func stateStepsFor123() []Step {
 			run: func(context Context) error {
 				return moveBlocksFromEnvironToState(context)
 			},
+		}, &upgradeStep{
+			description: "insert userenvnameC doc for each environment",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddUniqueOwnerEnvNameForEnvirons(context.State())
+			},
 		},
 	)
 	return steps

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -26,6 +26,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 		"drop old mongo indexes",
 		"migrate envuuid to env-uuid in envUsersC",
 		"move blocks from environment to state",
+		"insert userenvnameC doc for each environment",
 	}
 	assertStateSteps(c, version.MustParse("1.23.0"), expected)
 }


### PR DESCRIPTION
Add a new collection, userenvnameC, to use in a txn op which places a
unique key restraint on the "owner" and "name" fields of
environmentsC. Update state.NewEnvironment(): if an environment cannot
be found after insertion check if it is because of the unique key.

Ensure the userenvnameC doc is added and removed with the environment.
Add an upgrade step to add an userenvnameC doc for each existing 
environment.

(Review request: http://reviews.vapour.ws/r/1092/)