### PR TITLE
Send mongod log output to /var/log/juju/db.log instead of syslog (LP: #1349949).

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1253,6 +1253,7 @@ func (a *MachineAgent) ensureMongoAdminUser(agentConfig agent.Config) (added boo
 		DialInfo:  dialInfo,
 		Namespace: agentConfig.Value(agent.Namespace),
 		DataDir:   agentConfig.DataDir(),
+		LogDir:    agentConfig.LogDir(),
 		Port:      servingInfo.StatePort,
 		User:      stateInfo.Tag.String(),
 		Password:  stateInfo.Password,

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -191,6 +191,7 @@ func NewEnsureServerParams(agentConfig agent.Config) (mongo.EnsureServerParams, 
 		SystemIdentity: si.SystemIdentity,
 
 		DataDir:              agentConfig.DataDir(),
+		LogDir:               agentConfig.LogDir(),
 		Namespace:            agentConfig.Value(agent.Namespace),
 		OplogSize:            oplogSize,
 		SetNumaControlPolicy: numaCtlPolicy,

--- a/mongo/admin.go
+++ b/mongo/admin.go
@@ -29,6 +29,8 @@ type EnsureAdminUserParams struct {
 	Namespace string
 	// DataDir is the Juju data directory, used to start a --noauth server.
 	DataDir string
+	// LogDir is the Juju log directory, used to start a --noauth server.
+	LogDir string
 	// Port is the listening port of the Mongo server.
 	Port int
 	// User holds the user to log in to the mongo server as.
@@ -87,7 +89,7 @@ func EnsureAdminUser(p EnsureAdminUserParams) (added bool, err error) {
 
 	// Start mongod in --noauth mode.
 	logger.Debugf("starting mongo with --noauth")
-	cmd, err := noauthCommand(p.DataDir, p.Port)
+	cmd, err := noauthCommand(p.DataDir, p.LogDir, p.Port)
 	if err != nil {
 		return false, fmt.Errorf("failed to prepare mongod command: %v", err)
 	}

--- a/mongo/admin_test.go
+++ b/mongo/admin_test.go
@@ -64,14 +64,14 @@ func (s *adminSuite) TestEnsureAdminUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	gitjujutesting.AssertEchoArgs(c, "mongod",
 		"--noauth",
-		"--dbpath", "db",
+		"--dbpath", "'db'",
 		"--sslOnNormalPorts",
-		"--sslPEMKeyFile", "server.pem",
+		"--sslPEMKeyFile", "'server.pem'",
 		"--sslPEMKeyPassword", "ignored",
 		"--bind_ip", "127.0.0.1",
 		"--port", portString,
 		"--noprealloc",
-		"--syslog",
+		"--logpath", "'db.log'",
 		"--smallfiles",
 		"--journal",
 	)

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -4,6 +4,8 @@
 package mongo
 
 import (
+	"path/filepath"
+
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 )
@@ -17,7 +19,7 @@ var (
 	SharedSecretPath = sharedSecretPath
 	SSLKeyPath       = sslKeyPath
 
-	NewConf = newConf
+	NewServiceConf = newServiceConf
 
 	HostWordSize   = &hostWordSize
 	RuntimeGOOS    = &runtimeGOOS
@@ -31,6 +33,18 @@ var (
 	PreallocFileSizes = preallocFileSizes
 	PreallocFiles     = preallocFiles
 )
+
+func NewTestMongodOptions(dataDir string, numa bool) *mongodOptions {
+	return &mongodOptions{
+		dataDir:     dataDir,
+		dbDir:       dataDir,
+		logFile:     filepath.Join(dataDir, "db.log"),
+		mongoPath:   JujuMongodPath,
+		port:        1234,
+		oplogSizeMB: 1024,
+		wantNumaCtl: numa,
+	}
+}
 
 func PatchService(patchValue func(interface{}, interface{}), data *service.FakeServiceData) {
 	patchValue(&discoverService, func(name string) (mongoService, error) {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -315,36 +315,32 @@ func (s *MongoSuite) TestInstallMongodServiceExists(c *gc.C) {
 
 func (s *MongoSuite) TestNewServiceWithReplSet(c *gc.C) {
 	dataDir := c.MkDir()
-
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024, false)
+	conf := mongo.NewServiceConf(mongo.NewTestMongodOptions(dataDir, false))
 	c.Assert(strings.Contains(conf.ExecStart, "--replSet"), jc.IsTrue)
 }
 
 func (s *MongoSuite) TestNewServiceWithNumCtl(c *gc.C) {
 	dataDir := c.MkDir()
-
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024, true)
+	conf := mongo.NewServiceConf(mongo.NewTestMongodOptions(dataDir, true))
 	c.Assert(conf.ExtraScript, gc.Not(gc.Matches), "")
 }
 
 func (s *MongoSuite) TestNewServiceIPv6(c *gc.C) {
 	dataDir := c.MkDir()
-
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024, false)
+	conf := mongo.NewServiceConf(mongo.NewTestMongodOptions(dataDir, false))
 	c.Assert(strings.Contains(conf.ExecStart, "--ipv6"), jc.IsTrue)
 }
 
 func (s *MongoSuite) TestNewServiceWithJournal(c *gc.C) {
 	dataDir := c.MkDir()
-
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024, false)
+	conf := mongo.NewServiceConf(mongo.NewTestMongodOptions(dataDir, false))
 	c.Assert(conf.ExecStart, gc.Matches, `.* --journal.*`)
 }
 
 func (s *MongoSuite) TestNoAuthCommandWithJournal(c *gc.C) {
 	dataDir := c.MkDir()
 
-	cmd, err := mongo.NoauthCommand(dataDir, 1234)
+	cmd, err := mongo.NoauthCommand(dataDir, dataDir, 1234)
 	c.Assert(err, jc.ErrorIsNil)
 	var isJournalPresent bool
 	for _, value := range cmd.Args {


### PR DESCRIPTION
(Review request: http://reviews.vapour.ws/r/1093/)