### PR TITLE
Unit metrics batch storage API facade and client.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -35,6 +35,7 @@ var facadeVersions = map[string]int{
 	"Logger":                       0,
 	"Machiner":                     0,
 	"MetricsManager":               0,
+	"MetricStorage":                1,
 	"Networker":                    0,
 	"NotifyWatcher":                0,
 	"Pinger":                       0,

--- a/api/metricstorage/client.go
+++ b/api/metricstorage/client.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// metricstorage contains implementation for the API client accessing
+// the metricstorage API facade.
+package metricstorage
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// Client provides access to the metric storage api.
+type Client struct {
+	base.ClientFacade
+	st     *api.State
+	facade base.FacadeCaller
+	tag    names.UnitTag
+}
+
+// NewClient creates a new client for accessing the metricstorage api
+func NewClient(st *api.State, tag names.UnitTag) *Client {
+	frontend, backend := base.NewClientFacade(st, "MetricStorage")
+	return &Client{ClientFacade: frontend, st: st, facade: backend, tag: tag}
+}
+
+// AddMetricBatches stores the provided metric batches in state.
+func (c *Client) AddMetricBatches(batches []params.MetricBatch) error {
+	p := params.MetricBatchParams{
+		Batches: make([]params.MetricBatchParam, len(batches)),
+	}
+
+	for i, batch := range batches {
+		p.Batches[i].Tag = c.tag.String()
+		p.Batches[i].Batch = batch
+	}
+	results := new(params.ErrorResults)
+	err := c.facade.FacadeCall("AddMetricBatches", p, results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return results.Combine()
+}

--- a/api/metricstorage/client_test.go
+++ b/api/metricstorage/client_test.go
@@ -1,0 +1,145 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricstorage_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/metricstorage"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+type metricsManagerSuite struct {
+	jujutesting.JujuConnSuite
+
+	client  *metricstorage.Client
+	charm   *state.Charm
+	service *state.Service
+	unit    *state.Unit
+
+	stateAPI *api.State
+}
+
+var _ = gc.Suite(&metricsManagerSuite{})
+
+func (s *metricsManagerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.charm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	s.service = s.Factory.MakeService(c, &factory.ServiceParams{Charm: s.charm})
+	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Service: s.service, SetCharmURL: true})
+
+	password, err := utils.RandomPassword()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.unit.SetPassword(password)
+	c.Assert(err, jc.ErrorIsNil)
+	s.stateAPI = s.OpenAPIAs(c, s.unit.Tag(), password)
+
+	s.client = metricstorage.NewClient(s.stateAPI, s.unit.UnitTag())
+	c.Assert(s.client, gc.NotNil)
+}
+
+func (s *metricsManagerSuite) TestSendMetricBatchPatch(c *gc.C) {
+	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
+	uuid := utils.MustNewUUID().String()
+	batch := params.MetricBatch{
+		UUID:     uuid,
+		CharmURL: s.charm.URL().String(),
+		Created:  time.Now(),
+		Metrics:  metrics,
+	}
+
+	var called bool
+	metricstorage.PatchFacadeCall(s, s.client, func(request string, args, response interface{}) error {
+		called = true
+		c.Assert(request, gc.Equals, "AddMetricBatches")
+		c.Assert(args.(params.MetricBatchParams).Batches, gc.HasLen, 1)
+		c.Assert(args.(params.MetricBatchParams).Batches[0].Batch, gc.DeepEquals, batch)
+		result := response.(*params.ErrorResults)
+		result.Results = make([]params.ErrorResult, 1)
+		return nil
+	})
+
+	err := s.client.AddMetricBatches([]params.MetricBatch{batch})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *metricsManagerSuite) TestSendMetricBatchFail(c *gc.C) {
+	var called bool
+	metricstorage.PatchFacadeCall(s, s.client, func(request string, args, response interface{}) error {
+		called = true
+		c.Assert(request, gc.Equals, "AddMetricBatches")
+		result := response.(*params.ErrorResults)
+		result.Results = make([]params.ErrorResult, 1)
+		result.Results[0].Error = common.ServerError(common.ErrPerm)
+		return nil
+	})
+	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
+	uuid := utils.MustNewUUID().String()
+	batch := params.MetricBatch{
+		UUID:     uuid,
+		CharmURL: s.charm.URL().String(),
+		Created:  time.Now(),
+		Metrics:  metrics,
+	}
+
+	err := s.client.AddMetricBatches([]params.MetricBatch{batch})
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *metricsManagerSuite) TestSendMetricBatch(c *gc.C) {
+	uuid := utils.MustNewUUID().String()
+	now := time.Now().Round(time.Second).UTC()
+	metrics := []params.Metric{{"pings", "5", now}}
+	batch := params.MetricBatch{
+		UUID:     uuid,
+		CharmURL: s.charm.URL().String(),
+		Created:  now,
+		Metrics:  metrics,
+	}
+
+	err := s.client.AddMetricBatches([]params.MetricBatch{batch})
+	c.Assert(err, jc.ErrorIsNil)
+
+	batches, err := s.State.MetricBatches()
+	c.Assert(err, gc.IsNil)
+	c.Assert(batches, gc.HasLen, 1)
+	c.Assert(batches[0].UUID(), gc.Equals, uuid)
+	c.Assert(batches[0].Sent(), jc.IsFalse)
+	c.Assert(batches[0].CharmURL(), gc.Equals, s.charm.URL().String())
+	c.Assert(batches[0].Metrics(), gc.HasLen, 1)
+	c.Assert(batches[0].Metrics()[0].Key, gc.Equals, "pings")
+	c.Assert(batches[0].Metrics()[0].Key, gc.Equals, "pings")
+	c.Assert(batches[0].Metrics()[0].Value, gc.Equals, "5")
+}
+
+func (s *metricsManagerSuite) TestInvalidUnit(c *gc.C) {
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Service: s.service, SetCharmURL: true})
+
+	client := metricstorage.NewClient(s.stateAPI, unit.UnitTag())
+	c.Assert(client, gc.NotNil)
+
+	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
+	uuid := utils.MustNewUUID().String()
+	batch := params.MetricBatch{
+		UUID:     uuid,
+		CharmURL: s.charm.URL().String(),
+		Created:  time.Now(),
+		Metrics:  metrics,
+	}
+
+	err := client.AddMetricBatches([]params.MetricBatch{batch})
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+
+}

--- a/api/metricstorage/export_test.go
+++ b/api/metricstorage/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricstorage
+
+import (
+	"github.com/juju/juju/api/base/testing"
+)
+
+// PatchFacadeCall patches the State's facade such that
+// FacadeCall method calls are diverted to the provided
+// function.
+func PatchFacadeCall(p testing.Patcher, client *Client, f func(request string, params, response interface{}) error) {
+	testing.PatchFacadeCall(p, &client.facade, f)
+
+}

--- a/api/metricstorage/package_test.go
+++ b/api/metricstorage/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricstorage_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/juju/juju/apiserver/logger"
 	_ "github.com/juju/juju/apiserver/machine"
 	_ "github.com/juju/juju/apiserver/metricsmanager"
+	_ "github.com/juju/juju/apiserver/metricstorage"
 	_ "github.com/juju/juju/apiserver/networker"
 	_ "github.com/juju/juju/apiserver/provisioner"
 	_ "github.com/juju/juju/apiserver/reboot"

--- a/apiserver/metricstorage/metricstorage.go
+++ b/apiserver/metricstorage/metricstorage.go
@@ -1,0 +1,85 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package metricsstorage contains the implementation of an API endpoint
+// for storing metrics collected by the uniter in state.
+package metricstorage
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+var (
+	logger = loggo.GetLogger("juju.apiserver.metricstorage")
+)
+
+func init() {
+	common.RegisterStandardFacade("MetricStorage", 1, NewMetricStorageAPI)
+}
+
+// MetricStorageAPI is the implementation of the API endpoint.
+type MetricStorageAPI struct {
+	unit       *state.Unit
+	accessUnit common.GetAuthFunc
+}
+
+// NewMetricStorageAPI creates a new API endpoint.
+func NewMetricStorageAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*MetricStorageAPI, error) {
+	if !authorizer.AuthUnitAgent() {
+		return nil, common.ErrPerm
+	}
+
+	tag := authorizer.GetAuthTag()
+	if _, ok := tag.(names.UnitTag); ok {
+		unit, err := st.Unit(tag.Id())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		accessUnit := func() (common.AuthFunc, error) {
+			return authorizer.AuthOwner, nil
+		}
+		return &MetricStorageAPI{
+			unit:       unit,
+			accessUnit: accessUnit,
+		}, nil
+	}
+	return nil, errors.Errorf("expected names.UnitTag, got %T", tag)
+}
+
+// AddMetricBatches stores the provided metric batches.
+func (api *MetricStorageAPI) AddMetricBatches(args params.MetricBatchParams) (params.ErrorResults, error) {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Batches)),
+	}
+	canAccess, err := api.accessUnit()
+	if err != nil {
+		return params.ErrorResults{}, common.ErrPerm
+	}
+	for i, batch := range args.Batches {
+		tag, err := names.ParseUnitTag(batch.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		err = common.ErrPerm
+		if canAccess(tag) {
+			metrics := make([]state.Metric, len(batch.Batch.Metrics))
+			for j, metric := range batch.Batch.Metrics {
+				metrics[j] = state.Metric{
+					Key:   metric.Key,
+					Value: metric.Value,
+					Time:  metric.Time,
+				}
+			}
+			_, err = api.unit.AddMetrics(batch.Batch.UUID, batch.Batch.Created, batch.Batch.CharmURL, metrics)
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}

--- a/apiserver/metricstorage/metricstorage_test.go
+++ b/apiserver/metricstorage/metricstorage_test.go
@@ -1,0 +1,181 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricstorage_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/metricstorage"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+type metricStorageSuite struct {
+	jujutesting.JujuConnSuite
+
+	metricstorage *metricstorage.MetricStorageAPI
+	authorizer    apiservertesting.FakeAuthorizer
+	unit          *state.Unit
+	charm         *state.Charm
+	service       *state.Service
+}
+
+var _ = gc.Suite(&metricStorageSuite{})
+
+func (s *metricStorageSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	s.charm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	s.service = s.Factory.MakeService(c, &factory.ServiceParams{Charm: s.charm})
+	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Service: s.service, SetCharmURL: true})
+
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: s.unit.Tag(),
+	}
+	storage, err := metricstorage.NewMetricStorageAPI(s.State, nil, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.metricstorage = storage
+}
+
+func (s *metricStorageSuite) TestNewMetricsManagerAPIRefusesNonUnit(c *gc.C) {
+	tests := []struct {
+		tag           names.Tag
+		expectedError string
+	}{
+		{names.NewMachineTag("0"), "permission denied"},
+		{names.NewLocalUserTag("admin"), "permission denied"},
+		{s.unit.Tag(), ""},
+	}
+	for i, test := range tests {
+		c.Logf("test %d", i)
+
+		anAuthoriser := s.authorizer
+		anAuthoriser.Tag = test.tag
+		endPoint, err := metricstorage.NewMetricStorageAPI(s.State, nil, anAuthoriser)
+		if test.expectedError == "" {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(endPoint, gc.NotNil)
+		} else {
+			c.Assert(err, gc.ErrorMatches, test.expectedError)
+			c.Assert(endPoint, gc.IsNil)
+		}
+	}
+}
+
+func (s *metricStorageSuite) TestAddMetricsBatch(c *gc.C) {
+	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
+	uuid := utils.MustNewUUID().String()
+
+	result, err := s.metricstorage.AddMetricBatches(params.MetricBatchParams{
+		Batches: []params.MetricBatchParam{{
+			Tag: s.unit.Tag().String(),
+			Batch: params.MetricBatch{
+				UUID:     uuid,
+				CharmURL: s.charm.URL().String(),
+				Created:  time.Now(),
+				Metrics:  metrics,
+			}}}})
+
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{nil}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	batch, err := s.State.MetricBatch(uuid)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(batch.UUID(), gc.Equals, uuid)
+	c.Assert(batch.CharmURL(), gc.Equals, s.charm.URL().String())
+	c.Assert(batch.Unit(), gc.Equals, s.unit.Name())
+	storedMetrics := batch.Metrics()
+	c.Assert(storedMetrics, gc.HasLen, 1)
+	c.Assert(storedMetrics[0].Key, gc.Equals, metrics[0].Key)
+	c.Assert(storedMetrics[0].Value, gc.Equals, metrics[0].Value)
+}
+
+func (s *metricStorageSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
+	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
+	uuid := utils.MustNewUUID().String()
+
+	result, err := s.metricstorage.AddMetricBatches(params.MetricBatchParams{
+		Batches: []params.MetricBatchParam{{
+			Tag: s.unit.Tag().String(),
+			Batch: params.MetricBatch{
+				UUID:     uuid,
+				CharmURL: "",
+				Created:  time.Now(),
+				Metrics:  metrics,
+			}}}})
+
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{nil}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	batch, err := s.State.MetricBatch(uuid)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(batch.UUID(), gc.Equals, uuid)
+	c.Assert(batch.CharmURL(), gc.Equals, s.charm.URL().String())
+	c.Assert(batch.Unit(), gc.Equals, s.unit.Name())
+	storedMetrics := batch.Metrics()
+	c.Assert(storedMetrics, gc.HasLen, 1)
+	c.Assert(storedMetrics[0].Key, gc.Equals, metrics[0].Key)
+	c.Assert(storedMetrics[0].Value, gc.Equals, metrics[0].Value)
+}
+
+func (s *metricStorageSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
+	unit2 := s.Factory.MakeUnit(c, &factory.UnitParams{Service: s.service, SetCharmURL: true})
+
+	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
+	uuid := utils.MustNewUUID().String()
+
+	tests := []struct {
+		about  string
+		tag    string
+		expect string
+	}{{
+		about:  "different unit",
+		tag:    unit2.Tag().String(),
+		expect: "permission denied",
+	}, {
+		about:  "user tag",
+		tag:    names.NewLocalUserTag("admin").String(),
+		expect: `"user-admin@local" is not a valid unit tag`,
+	}, {
+		about:  "machine tag",
+		tag:    names.NewMachineTag("0").String(),
+		expect: `"machine-0" is not a valid unit tag`,
+	}}
+
+	for i, test := range tests {
+		c.Log("%d: %s", i, test.about)
+		result, err := s.metricstorage.AddMetricBatches(params.MetricBatchParams{
+			Batches: []params.MetricBatchParam{{
+				Tag: test.tag,
+				Batch: params.MetricBatch{
+					UUID:     uuid,
+					CharmURL: "",
+					Created:  time.Now(),
+					Metrics:  metrics,
+				}}}})
+
+		if test.expect == "" {
+			c.Assert(result.OneError(), jc.ErrorIsNil)
+		} else {
+			c.Assert(result.OneError(), gc.ErrorMatches, test.expect)
+		}
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = s.State.MetricBatch(uuid)
+		c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	}
+}

--- a/apiserver/metricstorage/package_test.go
+++ b/apiserver/metricstorage/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metricstorage_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -568,6 +568,25 @@ type MetricsParams struct {
 	Metrics []MetricsParam
 }
 
+// MetricBatch is a list of metrics with metadata.
+type MetricBatch struct {
+	UUID     string
+	CharmURL string
+	Created  time.Time
+	Metrics  []Metric
+}
+
+// MetricBatchParam contains a single metric batch.
+type MetricBatchParam struct {
+	Tag   string
+	Batch MetricBatch
+}
+
+// MetricBatchParams contains multiple metric batches.
+type MetricBatchParams struct {
+	Batches []MetricBatchParam
+}
+
 // MeterStatusResult holds unit meter status or error.
 type MeterStatusResult struct {
 	Code  string

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v5-unstable"
 
 	"github.com/juju/juju/apiserver/common"
@@ -1239,7 +1240,12 @@ func (u *uniterBaseAPI) AddMetrics(args params.MetricsParams) (params.ErrorResul
 						Time:  metric.Time,
 					}
 				}
-				_, err = unit.AddMetrics(time.Now(), metricBatch)
+				batchUUID, err := utils.NewUUID()
+				if err != nil {
+					result.Results[i].Error = common.ServerError(err)
+					continue
+				}
+				_, err = unit.AddMetrics(batchUUID.String(), time.Now(), "", metricBatch)
 			}
 		}
 		result.Results[i].Error = common.ServerError(err)

--- a/state/bench_test.go
+++ b/state/bench_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
@@ -87,7 +88,7 @@ func benchmarkAddMetrics(metricsPerBatch, batches int, c *gc.C) {
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
 		for n := 0; n < batches; n++ {
-			_, err := unit.AddMetrics(now, metrics)
+			_, err := unit.AddMetrics(utils.MustNewUUID().String(), now, "", metrics)
 			c.Assert(err, jc.ErrorIsNil)
 		}
 	}
@@ -113,7 +114,7 @@ func (*BenchmarkSuite) BenchmarkCleanupMetrics(c *gc.C) {
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
 		for i := 0; i < numberOfMetrics; i++ {
-			m, err := unit.AddMetrics(oldTime, []state.Metric{{}})
+			m, err := unit.AddMetrics(utils.MustNewUUID().String(), oldTime, "", []state.Metric{{}})
 			c.Assert(err, jc.ErrorIsNil)
 			err = m.SetSent()
 			c.Assert(err, jc.ErrorIsNil)

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v5-unstable"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -73,28 +72,33 @@ func (m *MetricBatch) validate() error {
 	return nil
 }
 
-// addMetric adds a new batch of metrics to the database.
-// A UUID for the metric will be generated and the new MetricBatch will be returned
-func (st *State) addMetrics(unitTag names.UnitTag, charmUrl *charm.URL, created time.Time, metrics []Metric, creds []byte) (*MetricBatch, error) {
-	if len(metrics) == 0 {
+// BatchParam contains the properties of the metrics batch used when creating a metrics
+// batch.
+type BatchParam struct {
+	UUID        string
+	CharmURL    *charm.URL
+	Created     time.Time
+	Metrics     []Metric
+	Credentials []byte
+}
+
+// addMetrics adds a new batch of metrics to the database.
+func (st *State) addMetrics(unitTag names.UnitTag, batch BatchParam) (*MetricBatch, error) {
+	if len(batch.Metrics) == 0 {
 		return nil, errors.New("cannot add a batch of 0 metrics")
-	}
-	uuid, err := utils.NewUUID()
-	if err != nil {
-		return nil, err
 	}
 
 	metric := &MetricBatch{
 		st: st,
 		doc: metricBatchDoc{
-			UUID:        uuid.String(),
+			UUID:        batch.UUID,
 			EnvUUID:     st.EnvironUUID(),
 			Unit:        unitTag.Id(),
-			CharmUrl:    charmUrl.String(),
+			CharmUrl:    batch.CharmURL.String(),
 			Sent:        false,
-			Created:     created,
-			Metrics:     metrics,
-			Credentials: creds,
+			Created:     batch.Created,
+			Metrics:     batch.Metrics,
+			Credentials: batch.Credentials,
 		}}
 	if err := metric.validate(); err != nil {
 		return nil, err
@@ -104,6 +108,13 @@ func (st *State) addMetrics(unitTag names.UnitTag, charmUrl *charm.URL, created 
 			notDead, err := isNotDead(st, unitsC, unitTag.Id())
 			if err != nil || !notDead {
 				return nil, errors.NotFoundf(unitTag.Id())
+			}
+			exists, err := st.MetricBatch(batch.UUID)
+			if exists != nil && err == nil {
+				return nil, errors.AlreadyExistsf("metrics batch UUID %q", batch.UUID)
+			}
+			if !errors.IsNotFound(err) {
+				return nil, errors.Trace(err)
 			}
 		}
 		ops := []txn.Op{{
@@ -118,7 +129,7 @@ func (st *State) addMetrics(unitTag names.UnitTag, charmUrl *charm.URL, created 
 		}}
 		return ops, nil
 	}
-	err = st.run(buildTxn)
+	err := st.run(buildTxn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
@@ -30,7 +31,7 @@ func (s *MetricSuite) SetUpTest(c *gc.C) {
 
 func (s *MetricSuite) TestAddNoMetrics(c *gc.C) {
 	now := state.NowToTheSecond()
-	_, err := s.unit.AddMetrics(now, []state.Metric{})
+	_, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{})
 	c.Assert(err, gc.ErrorMatches, "cannot add a batch of 0 metrics")
 }
 
@@ -38,7 +39,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	now := state.NowToTheSecond()
 	envUUID := s.State.EnvironUUID()
 	m := state.Metric{"pings", "5", now}
-	metricBatch, err := s.unit.AddMetrics(now, []state.Metric{m})
+	metricBatch, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metricBatch.Unit(), gc.Equals, "metered/0")
 	c.Assert(metricBatch.EnvUUID(), gc.Equals, envUUID)
@@ -85,7 +86,7 @@ func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 	assertUnitRemoved(c, s.unit)
 	now := state.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
-	_, err := s.unit.AddMetrics(now, []state.Metric{m})
+	_, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, gc.ErrorMatches, `metered/0 not found`)
 }
 
@@ -93,14 +94,14 @@ func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 	assertUnitDead(c, s.unit)
 	now := state.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
-	_, err := s.unit.AddMetrics(now, []state.Metric{m})
+	_, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, gc.ErrorMatches, `metered/0 not found`)
 }
 
 func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
 	now := state.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
-	added, err := s.unit.AddMetrics(now, []state.Metric{m})
+	added, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 	saved, err := s.State.MetricBatch(added.UUID())
 	c.Assert(err, jc.ErrorIsNil)
@@ -115,17 +116,17 @@ func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
 func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 	oldTime := time.Now().Add(-(time.Hour * 25))
 	m := state.Metric{"pings", "5", oldTime}
-	oldMetric1, err := s.unit.AddMetrics(oldTime, []state.Metric{m})
+	oldMetric1, err := s.unit.AddMetrics(utils.MustNewUUID().String(), oldTime, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 	oldMetric1.SetSent()
 
-	oldMetric2, err := s.unit.AddMetrics(oldTime, []state.Metric{m})
+	oldMetric2, err := s.unit.AddMetrics(utils.MustNewUUID().String(), oldTime, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 	oldMetric2.SetSent()
 
 	now := time.Now()
 	m = state.Metric{"pings", "5", now}
-	newMetric, err := s.unit.AddMetrics(now, []state.Metric{m})
+	newMetric, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 	newMetric.SetSent()
 	err = s.State.CleanupOldMetrics()
@@ -149,12 +150,12 @@ func (s *MetricSuite) TestCleanupNoMetrics(c *gc.C) {
 func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 	oldTime := time.Now().Add(-(time.Hour * 25))
 	m := state.Metric{"pings", "5", oldTime}
-	oldMetric, err := s.unit.AddMetrics(oldTime, []state.Metric{m})
+	oldMetric, err := s.unit.AddMetrics(utils.MustNewUUID().String(), oldTime, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 
 	now := time.Now()
 	m = state.Metric{"pings", "5", now}
-	newMetric, err := s.unit.AddMetrics(now, []state.Metric{m})
+	newMetric, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 	newMetric.SetSent()
 	err = s.State.CleanupOldMetrics()
@@ -170,7 +171,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 func (s *MetricSuite) TestMetricBatches(c *gc.C) {
 	now := state.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
-	_, err := s.unit.AddMetrics(now, []state.Metric{m})
+	_, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 	metricBatches, err := s.State.MetricBatches()
 	c.Assert(err, jc.ErrorIsNil)
@@ -181,12 +182,29 @@ func (s *MetricSuite) TestMetricBatches(c *gc.C) {
 	c.Assert(metricBatches[0].Metrics(), gc.HasLen, 1)
 }
 
+func (s *MetricSuite) TestMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
+	now := state.NowToTheSecond()
+	m := state.Metric{"pings", "5", now}
+	uuid := utils.MustNewUUID().String()
+	charmUrl := "cs:quantal/metered"
+	_, err := s.unit.AddMetrics(uuid, now, charmUrl, []state.Metric{m})
+	c.Assert(err, jc.ErrorIsNil)
+	metricBatches, err := s.State.MetricBatches()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metricBatches, gc.HasLen, 1)
+	c.Assert(metricBatches[0].Unit(), gc.Equals, "metered/0")
+	c.Assert(metricBatches[0].UUID(), gc.Equals, uuid)
+	c.Assert(metricBatches[0].CharmURL(), gc.Equals, charmUrl)
+	c.Assert(metricBatches[0].Sent(), jc.IsFalse)
+	c.Assert(metricBatches[0].Metrics(), gc.HasLen, 1)
+}
+
 func (s *MetricSuite) TestMetricCredentials(c *gc.C) {
 	now := state.NowToTheSecond()
 	m := state.Metric{"pings", "5", now}
 	err := s.service.SetMetricCredentials([]byte("hello there"))
 	c.Assert(err, gc.IsNil)
-	_, err = s.unit.AddMetrics(now, []state.Metric{m})
+	_, err = s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 	metricBatches, err := s.State.MetricBatches()
 	c.Assert(err, jc.ErrorIsNil)
@@ -316,7 +334,7 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 	}}
 	for i, t := range tests {
 		c.Logf("test %d: %s", i, t.about)
-		_, err := t.unit.AddMetrics(now, t.metrics)
+		_, err := t.unit.AddMetrics(utils.MustNewUUID().String(), now, "", t.metrics)
 		if t.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 		} else {
@@ -328,7 +346,7 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 func (s *MetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
 	now := state.NowToTheSecond().Add(-48 * time.Hour)
 	m := state.Metric{"pings", "5", now}
-	m1, err := s.unit.AddMetrics(now, []state.Metric{m})
+	m1, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := s.factory.MakeEnvironment(c, nil)
@@ -337,7 +355,7 @@ func (s *MetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
 	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
 	service := f.MakeService(c, &factory.ServiceParams{Charm: meteredCharm})
 	unit := f.MakeUnit(c, &factory.UnitParams{Service: service, SetCharmURL: true})
-	m2, err := unit.AddMetrics(now, []state.Metric{m})
+	m2, err := unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 
 	batches, err := s.State.MetricBatches()
@@ -367,4 +385,14 @@ func (s *MetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
 	batches, err = s.State.MetricBatches()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(batches, gc.HasLen, 0)
+}
+
+func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
+	now := state.NowToTheSecond()
+	mUUID := utils.MustNewUUID().String()
+	_, err := s.unit.AddMetrics(mUUID, now, "", []state.Metric{{"pings", "5", now}})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.unit.AddMetrics(mUUID, now, "", []state.Metric{{"pings", "10", now}})
+	c.Assert(err, gc.ErrorMatches, "metrics batch .* already exists")
 }

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -396,7 +396,10 @@ func (factory *Factory) MakeMetric(c *gc.C, params *MetricParams) *state.MetricB
 		params.Metrics = []state.Metric{{"pings", strconv.Itoa(uniqueInteger()), *params.Time}}
 	}
 
-	metric, err := params.Unit.AddMetrics(*params.Time, params.Metrics)
+	chURL, ok := params.Unit.CharmURL()
+	c.Assert(ok, gc.Equals, true)
+
+	metric, err := params.Unit.AddMetrics(utils.MustNewUUID().String(), *params.Time, chURL.String(), params.Metrics)
 	c.Assert(err, jc.ErrorIsNil)
 	if params.Sent {
 		err := metric.SetSent()


### PR DESCRIPTION
This newly introduced API facade and client will be used to send metrics from the uniter to state.

(Review request: http://reviews.vapour.ws/r/1097/)