### PR TITLE
fix joyent so it'll let you specify just a private key

### DIFF
--- a/provider/joyent/config.go
+++ b/provider/joyent/config.go
@@ -118,6 +118,17 @@ var configDefaults = schema.Defaults{
 	privateKey:     schema.Omit,
 }
 
+var requiredFields = []string{
+	sdcUrl,
+	mantaUrl,
+	algorithm,
+	sdcUser,
+	sdcKeyId,
+	mantaUser,
+	mantaKeyId,
+	// privatekey and privatekeypath are handled separately
+}
+
 var configSecretFields = []string{
 	sdcUser,
 	sdcKeyId,
@@ -195,7 +206,7 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 	}
 
 	// Check for missing fields.
-	for field := range configFields {
+	for _, field := range requiredFields {
 		if nilOrEmptyString(envConfig.attrs[field]) {
 			return nil, fmt.Errorf("%s: must not be empty", field)
 		}

--- a/provider/joyent/config_test.go
+++ b/provider/joyent/config_test.go
@@ -84,14 +84,16 @@ func (s *ConfigSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-var newConfigTests = []struct {
+type configtest struct {
 	info    string
 	insert  coretesting.Attrs
 	remove  []string
 	envVars map[string]string
 	expect  coretesting.Attrs
 	err     string
-}{{
+}
+
+var newConfigTests = []configtest{{
 	info:   "sdc-user is required",
 	remove: []string{"sdc-user"},
 	err:    ".* cannot get sdc-user value from environment variable .*",
@@ -226,31 +228,40 @@ var newConfigTests = []struct {
 	info:   "unknown field is not touched",
 	insert: coretesting.Attrs{"unknown-field": 12345},
 	expect: coretesting.Attrs{"unknown-field": 12345},
+}, {
+	info:   "can specify just private-key",
+	remove: []string{"private-key-path"},
+	insert: coretesting.Attrs{"private-key": "foo"},
 }}
 
 func (s *ConfigSuite) TestNewEnvironConfig(c *gc.C) {
 	for i, test := range newConfigTests {
-		c.Logf("test %d: %s", i, test.info)
-		for k, v := range test.envVars {
-			os.Setenv(k, v)
+		doTest(s, i, test, c)
+	}
+}
+
+func doTest(s *ConfigSuite, i int, test configtest, c *gc.C) {
+	c.Logf("test %d: %s", i, test.info)
+	for k, v := range test.envVars {
+		os.Setenv(k, v)
+		defer os.Setenv(k, "")
+	}
+	attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
+	attrs["private-key"] = s.privateKeyData
+	testConfig := newConfig(c, attrs)
+	environ, err := environs.New(testConfig)
+	if test.err == "" {
+		c.Check(err, jc.ErrorIsNil)
+		if err != nil {
+			return
 		}
-		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
-		attrs["private-key"] = s.privateKeyData
-		testConfig := newConfig(c, attrs)
-		environ, err := environs.New(testConfig)
-		if test.err == "" {
-			c.Check(err, jc.ErrorIsNil)
-			if err != nil {
-				continue
-			}
-			attrs := environ.Config().AllAttrs()
-			for field, value := range test.expect {
-				c.Check(attrs[field], gc.Equals, value)
-			}
-		} else {
-			c.Check(environ, gc.IsNil)
-			c.Check(err, gc.ErrorMatches, test.err)
+		attrs := environ.Config().AllAttrs()
+		for field, value := range test.expect {
+			c.Check(attrs[field], gc.Equals, value)
 		}
+	} else {
+		c.Check(environ, gc.IsNil)
+		c.Check(err, gc.ErrorMatches, test.err)
 	}
 }
 


### PR DESCRIPTION
fix joyent so it'll let you specify just a private key without a key path.  This fixes https://bugs.launchpad.net/juju-core/+bug/1429186. Also wrote a test to actually check that this is allowed, and fixed the table driven tests that were fubared because no one was clearing out environment variables after setting them.

(Review request: http://reviews.vapour.ws/r/1098/)