### PR TITLE
Properly handle an empty conf in systemd.Service.

### DIFF
--- a/service/common/conf.go
+++ b/service/common/conf.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/juju/errors"
@@ -48,6 +49,11 @@ type Conf struct {
 
 	// ExtraScript allows to insert script before command execution.
 	ExtraScript string
+}
+
+// IsZero determines whether or not the conf is a zero value.
+func (c Conf) IsZero() bool {
+	return reflect.DeepEqual(c, Conf{})
 }
 
 // Validate checks the conf's values for correctness.

--- a/service/common/conf_test.go
+++ b/service/common/conf_test.go
@@ -17,6 +17,23 @@ type confSuite struct {
 
 var _ = gc.Suite(&confSuite{})
 
+func (*confSuite) TestIsZeroTrue(c *gc.C) {
+	var conf common.Conf
+	isZero := conf.IsZero()
+
+	c.Check(isZero, jc.IsTrue)
+}
+
+func (*confSuite) TestIsZero(c *gc.C) {
+	conf := common.Conf{
+		Desc:      "some service",
+		ExecStart: "/path/to/some-command a b c",
+	}
+	isZero := conf.IsZero()
+
+	c.Check(isZero, jc.IsFalse)
+}
+
 func (*confSuite) TestValidateOkay(c *gc.C) {
 	conf := common.Conf{
 		Desc:      "some service",

--- a/service/common/service.go
+++ b/service/common/service.go
@@ -16,6 +16,11 @@ type Service struct {
 	Conf Conf
 }
 
+// NoConf checks whether or not Conf has been set.
+func (s Service) NoConf() bool {
+	return s.Conf.IsZero()
+}
+
 // Validate checks the service's values for correctness.
 func (s Service) Validate() error {
 	if s.Name == "" {

--- a/service/common/service_test.go
+++ b/service/common/service_test.go
@@ -17,6 +17,38 @@ type serviceSuite struct {
 
 var _ = gc.Suite(&serviceSuite{})
 
+func (*serviceSuite) TestNoConfMissing(c *gc.C) {
+	service := common.Service{
+		Name: "a-service",
+	}
+	noConf := service.NoConf()
+
+	c.Check(noConf, jc.IsTrue)
+}
+
+func (*serviceSuite) TestNoConfEmpty(c *gc.C) {
+	service := common.Service{
+		Name: "a-service",
+		Conf: common.Conf{},
+	}
+	noConf := service.NoConf()
+
+	c.Check(noConf, jc.IsTrue)
+}
+
+func (*serviceSuite) TestNoConfFalse(c *gc.C) {
+	service := common.Service{
+		Name: "a-service",
+		Conf: common.Conf{
+			Desc:      "some service",
+			ExecStart: "/path/to/some-command x y z",
+		},
+	}
+	noConf := service.NoConf()
+
+	c.Check(noConf, jc.IsFalse)
+}
+
 func (*serviceSuite) TestValidateOkay(c *gc.C) {
 	service := common.Service{
 		Name: "a-service",

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -185,13 +185,16 @@ func (s *Service) normalize(conf common.Conf) (common.Conf, []byte) {
 }
 
 func (s *Service) setConf(conf common.Conf) error {
-	normalConf, data := s.normalize(conf)
-	if err := s.validate(normalConf); err != nil {
-		return errors.Trace(err)
-	}
+	if !s.NoConf() {
+		normalConf, data := s.normalize(conf)
+		if err := s.validate(normalConf); err != nil {
+			return errors.Trace(err)
+		}
+		conf = normalConf
 
-	s.Service.Conf = normalConf
-	s.Script = data
+		s.Script = data
+	}
+	s.Service.Conf = conf
 	return nil
 }
 
@@ -211,6 +214,10 @@ func (s *Service) Installed() (bool, error) {
 
 // Exists implements Service.
 func (s *Service) Exists() (bool, error) {
+	if s.NoConf() {
+		return false, s.errorf(nil, "no conf expected")
+	}
+
 	same, err := s.check()
 	if err != nil {
 		return false, errors.Trace(err)
@@ -422,6 +429,10 @@ var removeAll = func(name string) error {
 
 // Install implements Service.
 func (s *Service) Install() error {
+	if s.NoConf() {
+		return s.errorf(nil, "missing conf")
+	}
+
 	err := s.install()
 	if errors.IsAlreadyExists(err) {
 		logger.Debugf("service %q already installed", s.Name())
@@ -516,6 +527,10 @@ var createFile = func(filename string, data []byte, perm os.FileMode) error {
 
 // InstallCommands implements Service.
 func (s *Service) InstallCommands() ([]string, error) {
+	if s.NoConf() {
+		return nil, s.errorf(nil, "missing conf")
+	}
+
 	name := s.Name()
 	dirname := "/tmp"
 

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -185,16 +185,18 @@ func (s *Service) normalize(conf common.Conf) (common.Conf, []byte) {
 }
 
 func (s *Service) setConf(conf common.Conf) error {
-	if !s.NoConf() {
-		normalConf, data := s.normalize(conf)
-		if err := s.validate(normalConf); err != nil {
-			return errors.Trace(err)
-		}
-		conf = normalConf
-
-		s.Script = data
+	if conf.IsZero() {
+		s.Service.Conf = conf
+		return nil
 	}
-	s.Service.Conf = conf
+
+	normalConf, data := s.normalize(conf)
+	if err := s.validate(normalConf); err != nil {
+		return errors.Trace(err)
+	}
+
+	s.Script = data
+	s.Service.Conf = normalConf
 	return nil
 }
 

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -393,6 +393,15 @@ func (s *initSystemSuite) TestExistsError(c *gc.C) {
 	s.stub.CheckCallNames(c, "RunCommand")
 }
 
+func (s *initSystemSuite) TestExistsEmptyConf(c *gc.C) {
+	s.service.Service.Conf = common.Conf{}
+
+	_, err := s.service.Exists()
+
+	c.Check(err, gc.ErrorMatches, `.*no conf expected.*`)
+	s.stub.CheckCalls(c, nil)
+}
+
 func (s *initSystemSuite) TestRunningTrue(c *gc.C) {
 	s.addService("jujud-machine-0", "active")
 	s.addService("something-else", "error")
@@ -699,6 +708,15 @@ func (s *initSystemSuite) TestInstallMultiline(c *gc.C) {
 	s.checkCreateFileCall(c, 3, filename, content, 0644)
 }
 
+func (s *initSystemSuite) TestInstallEmptyConf(c *gc.C) {
+	s.service.Service.Conf = common.Conf{}
+
+	err := s.service.Install()
+
+	c.Check(err, gc.ErrorMatches, `.*missing conf.*`)
+	s.stub.CheckCalls(c, nil)
+}
+
 func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
 	commands, err := s.service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
@@ -792,6 +810,15 @@ ExecStopPost=/bin/systemctl disable juju-shutdown-job.service`
 		"/bin/systemctl link /tmp/juju-shutdown-job.service",
 		"/bin/systemctl enable juju-shutdown-job.service",
 	})
+}
+
+func (s *initSystemSuite) TestInstallCommandsEmptyConf(c *gc.C) {
+	s.service.Service.Conf = common.Conf{}
+
+	_, err := s.service.InstallCommands()
+
+	c.Check(err, gc.ErrorMatches, `.*missing conf.*`)
+	s.stub.CheckCalls(c, nil)
 }
 
 func (s *initSystemSuite) TestStartCommands(c *gc.C) {

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -240,6 +240,21 @@ func (s *initSystemSuite) TestNewServiceLogfile(c *gc.C) {
 	})
 }
 
+func (s *initSystemSuite) TestNewServiceEmptyConf(c *gc.C) {
+	service, err := systemd.NewService(s.name, common.Conf{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(service, jc.DeepEquals, &systemd.Service{
+		Service: common.Service{
+			Name: s.name,
+		},
+		ConfName: s.name + ".service",
+		UnitName: s.name + ".service",
+		Dirname:  fmt.Sprintf("%s/init/%s", s.dataDir, s.name),
+	})
+	s.stub.CheckCalls(c, nil)
+}
+
 func (s *initSystemSuite) TestUpdateConfig(c *gc.C) {
 	s.conf.ExecStart = "/path/to/some/other/command"
 	c.Assert(s.service.Service.Conf.ExecStart, gc.Equals, jujud+" machine-0")
@@ -314,6 +329,20 @@ func (s *initSystemSuite) TestUpdateConfigLogfile(c *gc.C) {
 		Desc:      s.conf.Desc,
 		ExecStart: s.conf.ExecStart + " &> /var/log/juju/machine-0.log",
 	})
+}
+
+func (s *initSystemSuite) TestUpdateConfigEmpty(c *gc.C) {
+	s.service.UpdateConfig(common.Conf{})
+
+	c.Check(s.service, jc.DeepEquals, &systemd.Service{
+		Service: common.Service{
+			Name: s.name,
+		},
+		ConfName: s.name + ".service",
+		UnitName: s.name + ".service",
+		Dirname:  fmt.Sprintf("%s/init/%s", s.dataDir, s.name),
+	})
+	s.stub.CheckCalls(c, nil)
 }
 
 func (s *initSystemSuite) TestInstalledTrue(c *gc.C) {


### PR DESCRIPTION
Without this fix some spots in juju (e.g. `Destroy` in the local provider) will fail under systemd.

(Review request: http://reviews.vapour.ws/r/1099/)