### PR TITLE
Drop the vivid/upstart special case.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -57,10 +57,6 @@ func VersionInitSystem(vers version.Binary) (string, bool) {
 		switch vers.Series {
 		case "precise", "quantal", "raring", "saucy", "trusty", "utopic":
 			return InitSystemUpstart, true
-		// TODO(ericsnow) Remove the vivid special-case once it starts
-		// booting with systemd.
-		case "vivid":
-			return InitSystemUpstart, true
 		case "":
 			return "", false
 		default:

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -146,11 +146,9 @@ var discoveryTests = []discoveryTest{{
 	series:   "utopic",
 	expected: service.InitSystemUpstart,
 }, {
-	// TODO(ericsnow) vivid should expect InitSystemSystemd once
-	// vivid switches over.
 	os:       version.Ubuntu,
 	series:   "vivid",
-	expected: service.InitSystemUpstart,
+	expected: service.InitSystemSystemd,
 }, {
 	os:       version.CentOS,
 	expected: "",


### PR DESCRIPTION
This should land as soon as vivid switches over to booting with systemd.

(Review request: http://reviews.vapour.ws/r/1101/)