### PR TITLE
API: New api.client.EnvironmentUserInfo

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -543,6 +543,24 @@ func (c *Client) ShareEnvironment(users ...names.UserTag) error {
 	return result.Combine()
 }
 
+// EnvironmentUserInfo returns information on all users in the environment.
+func (c *Client) EnvironmentUserInfo() ([]params.EnvUserInfo, error) {
+	var results params.EnvUserInfoResults
+	err := c.facade.FacadeCall("EnvUserInfo", nil, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	info := []params.EnvUserInfo{}
+	for i, result := range results.Results {
+		if result.Result == nil {
+			return nil, errors.Errorf("unexpected nil result at position %d", i)
+		}
+		info = append(info, *result.Result)
+	}
+	return info, nil
+}
+
 // UnshareEnvironment removes access to the environment for the given users.
 func (c *Client) UnshareEnvironment(users ...names.UserTag) error {
 	var args params.ModifyEnvironUsers


### PR DESCRIPTION
Add a new method on the API client: EnvironmentUserInfo(). Test the
facade call. Add an end to end feature test to make sure API >
API server > State is hooked up.

(Review request: http://reviews.vapour.ws/r/1104/)