### PR TITLE
Fix systemd test for map order.

### DIFF
--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -820,7 +820,8 @@ func (s *initSystemSuite) TestInstallCommandsShutdown(c *gc.C) {
 	c.Check(footer, gc.Equals, "EOF")
 
 	// Check the conf portion.
-	content := `[Unit]
+	content := `
+[Unit]
 Description=juju shutdown job
 After=syslog.target
 After=network.target
@@ -830,8 +831,9 @@ Conflicts=cloud-final
 
 [Service]
 ExecStart=/sbin/shutdown -h now
-ExecStopPost=/bin/systemctl disable juju-shutdown-job.service`
-	expected := parseConfSections(strings.Split(content, "\n"))
+ExecStopPost=/bin/systemctl disable juju-shutdown-job.service
+`
+	expected := parseConfSections(strings.Split(content[1:], "\n"))
 	c.Check(sections, jc.DeepEquals, expected)
 
 	// Check the remaining commands.

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -791,6 +791,9 @@ func parseConfSections(lines []string) map[string][]string {
 			sections[section] = append(sections[section], line)
 		}
 	}
+	if section != "" {
+		sort.Strings(sections[section])
+	}
 
 	return sections
 }


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1429853)

The offending helper function failed to sort the lines in the last section of the ini file.  This patch fixes that.

(Review request: http://reviews.vapour.ws/r/1105/)