### PR TITLE
New dblogpruner worker

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -63,6 +63,7 @@ import (
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/charmrevisionworker"
 	"github.com/juju/juju/worker/cleaner"
+	"github.com/juju/juju/worker/dblogpruner"
 	"github.com/juju/juju/worker/deployer"
 	"github.com/juju/juju/worker/diskformatter"
 	"github.com/juju/juju/worker/diskmanager"
@@ -901,12 +902,19 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			a.startWorkerAfterUpgrade(runner, "certupdater", func() (worker.Worker, error) {
 				return newCertificateUpdater(m, agentConfig, st, stateServingSetter, certChangedChan), nil
 			})
+
+			if featureflag.Enabled(feature.DbLog) {
+				a.startWorkerAfterUpgrade(singularRunner, "dblogpruner", func() (worker.Worker, error) {
+					return dblogpruner.New(st, dblogpruner.NewLogPruneParams()), nil
+				})
+			}
 			a.startWorkerAfterUpgrade(singularRunner, "resumer", func() (worker.Worker, error) {
 				// The action of resumer is so subtle that it is not tested,
 				// because we can't figure out how to do so without brutalising
 				// the transaction log.
 				return resumer.NewResumer(st), nil
 			})
+
 		case state.JobManageStateDeprecated:
 			// Legacy environments may set this, but we ignore it.
 		default:

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -42,6 +42,7 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
@@ -603,6 +604,31 @@ func (s *MachineSuite) TestManageEnvironRunsPeergrouper(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for peergrouper worker to be started")
 	}
+}
+
+func (s *MachineSuite) TestManageEnvironRunsDbLogPrunerIfFeatureFlagEnabled(c *gc.C) {
+	s.SetFeatureFlags(feature.DbLog)
+
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+
+	runner := s.singularRecord.nextRunner(c)
+	runner.waitForWorker(c, "dblogpruner")
+}
+
+func (s *MachineSuite) TestManageEnvironDoesntRunDbLogPrunerByDefault(c *gc.C) {
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+
+	// Wait for the resumer to be started. This is started just after
+	// dblogpruner would be started.
+	runner := s.singularRecord.nextRunner(c)
+	started := set.NewStrings(runner.waitForWorker(c, "resumer")...)
+	c.Assert(started.Contains("dblogpruner"), jc.IsFalse)
 }
 
 func (s *MachineSuite) TestManageEnvironCallsUseMultipleCPUs(c *gc.C) {

--- a/state/logs.go
+++ b/state/logs.go
@@ -127,15 +127,12 @@ func PruneLogs(st *State, minLogTime time.Time, maxLogsBytes int) error {
 		if err != nil {
 			return errors.Annotate(err, "log count query failed")
 		}
-
-		// Determine how many logs to remove for the environment. The
-		// oldest 1% (at least 100) will be removed. The minimum,
-		// ensures that the target logs collection size is reached
-		// more quickly, avoiding excessive cycles through this loop.
-		toRemove := int(float64(count) * 0.01)
-		if toRemove < 100 {
-			toRemove = 100
+		if count < 5000 {
+			break // Pruning is not worthwhile
 		}
+
+		// Remove the oldest 1% of log records for the environment.
+		toRemove := int(float64(count) * 0.01)
 
 		// Find the threshold timestammp to start removing from.
 		// NOTE: this assumes that there are no more logs being added
@@ -159,7 +156,6 @@ func PruneLogs(st *State, minLogTime time.Time, maxLogsBytes int) error {
 		if err != nil {
 			return errors.Annotate(err, "log pruning failed")
 		}
-
 		pruneCounts[envUUID] += removeInfo.Removed
 	}
 

--- a/worker/dblogpruner/worker.go
+++ b/worker/dblogpruner/worker.go
@@ -1,0 +1,64 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dblogpruner
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+)
+
+// LogPruneParams specifies varies values that control how logs are
+// pruned.
+type LogPruneParams struct {
+	MaxLogAge          time.Duration
+	MaxCollectionBytes int
+	PruneInterval      time.Duration
+}
+
+// NewLogPruneParams returns a LogPruneParams initialised with default
+// values.
+func NewLogPruneParams() *LogPruneParams {
+	return &LogPruneParams{
+		MaxLogAge:          3 * 24 * time.Hour,
+		MaxCollectionBytes: 4 * 1024 * 1024 * 1024,
+		PruneInterval:      5 * time.Minute,
+	}
+}
+
+// New returns a worker which periodically wakes up to remove old log
+// entries stored in MongoDB. This worker is intended to run just
+// once, on the MongoDB master.
+func New(st *state.State, params *LogPruneParams) worker.Worker {
+	w := &pruneWorker{
+		st:     st,
+		params: params,
+	}
+	return worker.NewSimpleWorker(w.loop)
+}
+
+type pruneWorker struct {
+	st     *state.State
+	params *LogPruneParams
+}
+
+func (w *pruneWorker) loop(stopCh <-chan struct{}) error {
+	p := w.params
+	for {
+		select {
+		case <-stopCh:
+			return tomb.ErrDying
+		case <-time.After(p.PruneInterval):
+			minLogTime := time.Now().Add(-p.MaxLogAge)
+			err := state.PruneLogs(w.st, minLogTime, p.MaxCollectionBytes)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}

--- a/worker/dblogpruner/worker_test.go
+++ b/worker/dblogpruner/worker_test.go
@@ -1,0 +1,113 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dblogpruner_test
+
+import (
+	stdtesting "testing"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dblogpruner"
+)
+
+func TestPackage(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}
+
+var _ = gc.Suite(&suite{})
+
+type suite struct {
+	statetesting.StateSuite
+	pruner   worker.Worker
+	logsColl *mgo.Collection
+}
+
+func (s *suite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+	s.logsColl = s.State.MongoSession().DB("logs").C("logs")
+}
+
+func (s *suite) StartWorker(c *gc.C, maxLogAge time.Duration, maxCollectionBytes int) {
+	params := &dblogpruner.LogPruneParams{
+		MaxLogAge:          maxLogAge,
+		MaxCollectionBytes: maxCollectionBytes,
+		PruneInterval:      time.Millisecond, // Speed up pruning interval for testing
+	}
+	s.pruner = dblogpruner.New(s.State, params)
+	s.AddCleanup(func(*gc.C) {
+		s.pruner.Kill()
+		c.Assert(s.pruner.Wait(), jc.ErrorIsNil)
+	})
+}
+
+func (s *suite) TestPrunesOldLogs(c *gc.C) {
+	maxLogAge := 24 * time.Hour
+	noPrune := int(1e9)
+	s.StartWorker(c, maxLogAge, noPrune)
+
+	now := time.Now()
+	addLogsToPrune := func(count int) {
+		// Add messages beyond the prune threshold.
+		tPrune := now.Add(-maxLogAge - 1)
+		s.addLogs(c, tPrune, "prune", count)
+	}
+	addLogsToKeep := func(count int) {
+		// Add messages within the prune threshold.
+		s.addLogs(c, now, "keep", count)
+	}
+	for i := 0; i < 10; i++ {
+		addLogsToKeep(5)
+		addLogsToPrune(5)
+	}
+
+	// Wait for all logs with the message "prune" to be removed.
+	for attempt := testing.LongAttempt.Start(); attempt.Next(); {
+		pruneRemaining, err := s.logsColl.Find(bson.M{"x": "prune"}).Count()
+		c.Assert(err, jc.ErrorIsNil)
+		if pruneRemaining == 0 {
+			// All the "keep" messages shoudl still be there.
+			keepCount, err := s.logsColl.Find(bson.M{"x": "keep"}).Count()
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(keepCount, gc.Equals, 50)
+			return
+		}
+	}
+	c.Fatal("pruning didn't happen as expected")
+}
+
+func (s *suite) TestPrunesLogsBySize(c *gc.C) {
+	s.addLogs(c, time.Now(), "stuff", 6000)
+
+	noPrune := 999 * time.Hour
+	s.StartWorker(c, noPrune, 250000)
+
+	for attempt := testing.LongAttempt.Start(); attempt.Next(); {
+		count, err := s.logsColl.Count()
+		c.Assert(err, jc.ErrorIsNil)
+		if count < 5000 {
+			return
+		}
+	}
+	c.Fatal("pruning didn't happen as expected")
+}
+
+func (s *suite) addLogs(c *gc.C, t0 time.Time, text string, count int) {
+	dbLogger := state.NewDbLogger(s.State, names.NewMachineTag("0"))
+	defer dbLogger.Close()
+
+	for offset := 0; offset < count; offset++ {
+		t := t0.Add(-time.Duration(offset) * time.Second)
+		dbLogger.Log(t, "some.module", "foo.go:42", loggo.INFO, text)
+	}
+}


### PR DESCRIPTION
**state: change log pruning behaviour for small size thresholds**

The previous implementation could unintentionally error out when the collection size threshold was (unrealistically) low.

Pruning will now just stop if there's less than 5000 log records for the environment with the most logs. This avoid the error condition and avoids unnecessary cycling through the pruning loop.

---

**worker/dblogpruner: new worker to prune logs stored in the DB**

---

**cmd/jujud: run the dblogpruner worker**

...when the DbLog feature is enabled.

(Review request: http://reviews.vapour.ws/r/1107/)