### PR TITLE
Add the basics of a storage provisioner

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -43,6 +43,7 @@ var facadeVersions = map[string]int{
 	"Rsyslog":              0,
 	"Service":              1,
 	"Storage":              1,
+	"StorageProvisioner":   1,
 	"StringsWatcher":       0,
 	"Upgrader":             0,
 	"Uniter":               2,

--- a/api/state.go
+++ b/api/state.go
@@ -254,6 +254,10 @@ func (st *State) DiskFormatter() (*diskformatter.State, error) {
 
 // StorageProvisioner returns a version of the state that provides
 // functionality required by the storageprovisioner worker.
+// The scope tag defines the type of storage that is provisioned, either
+// either attached directly to a specified machine (machine scoped),
+// or provisioned on the underlying cloud for use by any machine in a
+// specified environment (environ scoped).
 func (st *State) StorageProvisioner(scope names.Tag) *storageprovisioner.State {
 	return storageprovisioner.NewState(st, scope)
 }

--- a/api/state.go
+++ b/api/state.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/api/reboot"
 	"github.com/juju/juju/api/rsyslog"
+	"github.com/juju/juju/api/storageprovisioner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/apiserver/params"
@@ -249,6 +250,12 @@ func (st *State) DiskFormatter() (*diskformatter.State, error) {
 		return nil, errors.Errorf("expected MachineTag, got %#v", st.authTag)
 	}
 	return diskformatter.NewState(st, machineTag), nil
+}
+
+// StorageProvisioner returns a version of the state that provides
+// functionality required by the storageprovisioner worker.
+func (st *State) StorageProvisioner(scope names.Tag) *storageprovisioner.State {
+	return storageprovisioner.NewState(st, scope)
 }
 
 // Firewaller returns a version of the state that provides functionality

--- a/api/storageprovisioner/package_test.go
+++ b/api/storageprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -22,6 +22,8 @@ type State struct {
 
 // NewState creates a new client-side StorageProvisioner facade.
 func NewState(caller base.APICaller, scope names.Tag) *State {
+	// TODO(wallyworld) - validate that scope matches current environ
+	// if it is an environment tag.
 	return &State{
 		base.NewFacadeCaller(caller, storageProvisionerFacade),
 		scope,

--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -1,0 +1,159 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+)
+
+const storageProvisionerFacade = "StorageProvisioner"
+
+// State provides access to a storageprovisioner's view of the state.
+type State struct {
+	facade base.FacadeCaller
+	scope  names.Tag
+}
+
+// NewState creates a new client-side StorageProvisioner facade.
+func NewState(caller base.APICaller, scope names.Tag) *State {
+	return &State{
+		base.NewFacadeCaller(caller, storageProvisionerFacade),
+		scope,
+	}
+}
+
+// WatchVolumes watches for changes to volumes scoped to the
+// entity with the tag passed to NewState.
+func (st *State) WatchVolumes() (watcher.StringsWatcher, error) {
+	var results params.StringsWatchResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: st.scope.String()}},
+	}
+	err := st.facade.FacadeCall("WatchVolumes", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := watcher.NewStringsWatcher(st.facade.RawAPICaller(), result)
+	return w, nil
+}
+
+// Volumes returns details of volumes with the specified tags.
+func (st *State) Volumes(tags []names.VolumeTag) ([]params.VolumeResult, error) {
+	args := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		args.Entities[i].Tag = tag.String()
+	}
+	var results params.VolumeResults
+	err := st.facade.FacadeCall("Volumes", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != len(tags) {
+		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+	}
+	return results.Results, nil
+}
+
+// VolumeParams returns the parameters for creating the volumes
+// with the specified tags.
+func (st *State) VolumeParams(tags []names.VolumeTag) ([]params.VolumeParamsResult, error) {
+	args := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		args.Entities[i].Tag = tag.String()
+	}
+	var results params.VolumeParamsResults
+	err := st.facade.FacadeCall("VolumeParams", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != len(tags) {
+		panic(errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results)))
+	}
+	return results.Results, nil
+}
+
+// SetVolumeInfo records the details of newly provisioned volumes.
+func (st *State) SetVolumeInfo(volumes []params.Volume) (params.ErrorResults, error) {
+	args := params.Volumes{Volumes: volumes}
+	var results params.ErrorResults
+	err := st.facade.FacadeCall("SetVolumeInfo", args, &results)
+	if err != nil {
+		return results, err
+	}
+	if len(results.Results) != len(volumes) {
+		panic(errors.Errorf("expected %d result(s), got %d", len(volumes), len(results.Results)))
+	}
+	return results, nil
+}
+
+// Life requests the life cycle of the entities with the specified tags.
+func (st *State) Life(tags []names.Tag) ([]params.LifeResult, error) {
+	var results params.LifeResults
+	args := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		args.Entities[i].Tag = tag.String()
+	}
+	if err := st.facade.FacadeCall("Life", args, &results); err != nil {
+		return nil, err
+	}
+	if len(results.Results) != len(tags) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
+	}
+	return results.Results, nil
+}
+
+// EnsureDead progresses the entities with the specified tags to the Dead
+// life cycle state, if they are Alive or Dying.
+func (st *State) EnsureDead(tags []names.Tag) ([]params.ErrorResult, error) {
+	var results params.ErrorResults
+	args := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		args.Entities[i].Tag = tag.String()
+	}
+	if err := st.facade.FacadeCall("EnsureDead", args, &results); err != nil {
+		return nil, err
+	}
+	if len(results.Results) != len(tags) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
+	}
+	return results.Results, nil
+}
+
+// Remove removes the entities with the specified tags from state.
+func (st *State) Remove(tags []names.Tag) ([]params.ErrorResult, error) {
+	var results params.ErrorResults
+	args := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		args.Entities[i].Tag = tag.String()
+	}
+	if err := st.facade.FacadeCall("Remove", args, &results); err != nil {
+		return nil, err
+	}
+	if len(results.Results) != len(tags) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
+	}
+	return results.Results, nil
+}

--- a/api/storageprovisioner/provisioner_test.go
+++ b/api/storageprovisioner/provisioner_test.go
@@ -1,0 +1,372 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	"errors"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/storageprovisioner"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&provisionerSuite{})
+
+type provisionerSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "StorageProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchVolumes")
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
+		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
+			Results: []params.StringsWatchResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	_, err := st.WatchVolumes()
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *provisionerSuite) TestVolumes(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "StorageProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "Volumes")
+		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{"volume-100"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.VolumeResults{})
+		*(result.(*params.VolumeResults)) = params.VolumeResults{
+			Results: []params.VolumeResult{{
+				Result: params.Volume{
+					VolumeTag: "volume-100",
+					VolumeId:  "volume-id",
+					Serial:    "abc",
+					Size:      1024,
+				},
+			}},
+		}
+		callCount++
+		return nil
+	})
+
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	volumes, err := st.Volumes([]names.VolumeTag{names.NewVolumeTag("100")})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(callCount, gc.Equals, 1)
+	c.Assert(volumes, jc.DeepEquals, []params.VolumeResult{{
+		Result: params.Volume{
+			VolumeTag: "volume-100", VolumeId: "volume-id", Serial: "abc", Size: 1024,
+		},
+	}})
+}
+
+func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "StorageProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "VolumeParams")
+		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{"volume-100"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.VolumeParamsResults{})
+		*(result.(*params.VolumeParamsResults)) = params.VolumeParamsResults{
+			Results: []params.VolumeParamsResult{{
+				Result: params.VolumeParams{
+					VolumeTag:  "volume-100",
+					Size:       1024,
+					Provider:   "loop",
+					MachineTag: "machine-200",
+				},
+			}},
+		}
+		callCount++
+		return nil
+	})
+
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	volumeParams, err := st.VolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(callCount, gc.Equals, 1)
+	c.Assert(volumeParams, jc.DeepEquals, []params.VolumeParamsResult{{
+		Result: params.VolumeParams{
+			VolumeTag: "volume-100", Size: 1024, Provider: "loop", MachineTag: "machine-200",
+		},
+	}})
+}
+
+func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "StorageProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "SetVolumeInfo")
+		c.Check(arg, gc.DeepEquals, params.Volumes{
+			Volumes: []params.Volume{{VolumeTag: "volume-100", VolumeId: "123", Serial: "abc", Size: 1024}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{Error: nil}},
+		}
+		callCount++
+		return nil
+	})
+
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	volumes := []params.Volume{{VolumeTag: "volume-100", VolumeId: "123", Serial: "abc", Size: 1024}}
+	errorResults, err := st.SetVolumeInfo(volumes)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(callCount, gc.Equals, 1)
+	c.Assert(errorResults.OneError(), jc.ErrorIsNil)
+}
+
+func (s *provisionerSuite) testOpWithTags(
+	c *gc.C, opName string, apiCall func(*storageprovisioner.State, []names.Tag,
+	) (
+		[]params.ErrorResult, error,
+	)) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "StorageProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, opName)
+		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "volume-100"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{Error: nil}},
+		}
+		callCount++
+		return nil
+	})
+
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	volumes := []names.Tag{names.NewVolumeTag("100")}
+	errorResults, err := apiCall(st, volumes)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(callCount, gc.Equals, 1)
+	c.Assert(errorResults, jc.DeepEquals, []params.ErrorResult{{}})
+}
+
+func (s *provisionerSuite) TestRemove(c *gc.C) {
+	s.testOpWithTags(c, "Remove", func(st *storageprovisioner.State, tags []names.Tag) ([]params.ErrorResult, error) {
+		return st.Remove(tags)
+	})
+}
+
+func (s *provisionerSuite) TestEnsureDead(c *gc.C) {
+	s.testOpWithTags(c, "EnsureDead", func(st *storageprovisioner.State, tags []names.Tag) ([]params.ErrorResult, error) {
+		return st.EnsureDead(tags)
+	})
+}
+
+func (s *provisionerSuite) TestLife(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "StorageProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "Life")
+		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "volume-100"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
+		*(result.(*params.LifeResults)) = params.LifeResults{
+			Results: []params.LifeResult{{Life: params.Alive}},
+		}
+		callCount++
+		return nil
+	})
+
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	volumes := []names.Tag{names.NewVolumeTag("100")}
+	lifeResults, err := st.Life(volumes)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(callCount, gc.Equals, 1)
+	c.Assert(lifeResults, jc.DeepEquals, []params.LifeResult{{Life: params.Alive}})
+}
+
+func (s *provisionerSuite) testClientError(c *gc.C, apiCall func(*storageprovisioner.State) error) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("blargh")
+	})
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	err := apiCall(st)
+	c.Check(err, gc.ErrorMatches, "blargh")
+}
+
+func (s *provisionerSuite) TestWatchVolumesClientError(c *gc.C) {
+	s.testClientError(c, func(st *storageprovisioner.State) error {
+		_, err := st.WatchVolumes()
+		return err
+	})
+}
+
+func (s *provisionerSuite) TestVolumesClientError(c *gc.C) {
+	s.testClientError(c, func(st *storageprovisioner.State) error {
+		_, err := st.Volumes(nil)
+		return err
+	})
+}
+func (s *provisionerSuite) TestVolumeParamsClientError(c *gc.C) {
+	s.testClientError(c, func(st *storageprovisioner.State) error {
+		_, err := st.VolumeParams(nil)
+		return err
+	})
+}
+func (s *provisionerSuite) TestRemoveClientError(c *gc.C) {
+	s.testClientError(c, func(st *storageprovisioner.State) error {
+		_, err := st.Remove(nil)
+		return err
+	})
+}
+func (s *provisionerSuite) TestSetVolumeInfoClientError(c *gc.C) {
+	s.testClientError(c, func(st *storageprovisioner.State) error {
+		_, err := st.SetVolumeInfo(nil)
+		return err
+	})
+}
+
+func (s *provisionerSuite) TestEnsureDeadClientError(c *gc.C) {
+	s.testClientError(c, func(st *storageprovisioner.State) error {
+		_, err := st.EnsureDead(nil)
+		return err
+	})
+}
+
+func (s *provisionerSuite) TestLifeClientError(c *gc.C) {
+	s.testClientError(c, func(st *storageprovisioner.State) error {
+		_, err := st.Life(nil)
+		return err
+	})
+}
+
+func (s *provisionerSuite) TestWatchVolumesServerError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
+			Results: []params.StringsWatchResult{{
+				Error: &params.Error{Message: "MSG", Code: "621"},
+			}},
+		}
+		return nil
+	})
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	_, err := st.WatchVolumes()
+	c.Check(err, gc.ErrorMatches, "MSG")
+}
+
+func (s *provisionerSuite) TestVolumesServerError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.VolumeResults)) = params.VolumeResults{
+			Results: []params.VolumeResult{{
+				Error: &params.Error{Message: "MSG", Code: "621"},
+			}},
+		}
+		return nil
+	})
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	results, err := st.Volumes([]names.VolumeTag{names.NewVolumeTag("100")})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
+}
+func (s *provisionerSuite) TestVolumeParamsServerError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.VolumeParamsResults)) = params.VolumeParamsResults{
+			Results: []params.VolumeParamsResult{{
+				Error: &params.Error{Message: "MSG", Code: "621"},
+			}},
+		}
+		return nil
+	})
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	results, err := st.VolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
+}
+
+func (s *provisionerSuite) TestSetVolumeInfoServerError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "MSG", Code: "621"},
+			}},
+		}
+		return nil
+	})
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	results, err := st.SetVolumeInfo([]params.Volume{{
+		VolumeTag: names.NewVolumeTag("100").String(),
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Check(results.OneError(), gc.ErrorMatches, "MSG")
+}
+
+func (s *provisionerSuite) testServerError(c *gc.C, apiCall func(*storageprovisioner.State, []names.Tag) ([]params.ErrorResult, error)) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "MSG", Code: "621"},
+			}},
+		}
+		return nil
+	})
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	tags := []names.Tag{
+		names.NewVolumeTag("100"),
+	}
+	results, err := apiCall(st, tags)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
+}
+
+func (s *provisionerSuite) TestRemoveServerError(c *gc.C) {
+	s.testServerError(c, func(st *storageprovisioner.State, tags []names.Tag) ([]params.ErrorResult, error) {
+		return st.Remove(tags)
+	})
+}
+
+func (s *provisionerSuite) TestEnsureDeadServerError(c *gc.C) {
+	s.testServerError(c, func(st *storageprovisioner.State, tags []names.Tag) ([]params.ErrorResult, error) {
+		return st.EnsureDead(tags)
+	})
+}
+
+func (s *provisionerSuite) TestLifeServerError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.LifeResults)) = params.LifeResults{
+			Results: []params.LifeResult{{
+				Error: &params.Error{Message: "MSG", Code: "621"},
+			}},
+		}
+		return nil
+	})
+	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	tags := []names.Tag{
+		names.NewVolumeTag("100"),
+	}
+	results, err := st.Life(tags)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
+}

--- a/api/storageprovisioner/provisioner_test.go
+++ b/api/storageprovisioner/provisioner_test.go
@@ -140,10 +140,8 @@ func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
 }
 
 func (s *provisionerSuite) testOpWithTags(
-	c *gc.C, opName string, apiCall func(*storageprovisioner.State, []names.Tag,
-	) (
-		[]params.ErrorResult, error,
-	)) {
+	c *gc.C, opName string, apiCall func(*storageprovisioner.State, []names.Tag) ([]params.ErrorResult, error),
+) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "StorageProvisioner")

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/juju/juju/apiserver/rsyslog"
 	_ "github.com/juju/juju/apiserver/service"
 	_ "github.com/juju/juju/apiserver/storage"
+	_ "github.com/juju/juju/apiserver/storageprovisioner"
 	_ "github.com/juju/juju/apiserver/uniter"
 	_ "github.com/juju/juju/apiserver/upgrader"
 	_ "github.com/juju/juju/apiserver/usermanager"

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/network"
@@ -1517,7 +1518,7 @@ func (s *clientSuite) TestClientServiceDeployWithInvalidStoragePool(c *gc.C) {
 }
 
 func (s *clientSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	registry.RegisterProvider("hostloop", &mockStorageProvider{kind: storage.StorageKindBlock})
 	pm := poolmanager.New(state.NewStateSettings(s.State))
@@ -2962,7 +2963,7 @@ func (s *clientSuite) TestClientAddMachinesWithPlacement(c *gc.C) {
 }
 
 func (s *clientSuite) setupStoragePool(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -1,0 +1,125 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
+	"github.com/juju/juju/storage/provider/registry"
+	"github.com/juju/names"
+)
+
+type volumeAlreadyProvisionedError struct {
+	error
+}
+
+// IsVolumeAlreadyProvisioned returns true if the specified error
+// is caused by a volume already being provisioned.
+func IsVolumeAlreadyProvisioned(err error) bool {
+	_, ok := err.(*volumeAlreadyProvisionedError)
+	return ok
+}
+
+// VolumeParams returns the parameters for creating the given volume.
+func VolumeParams(v state.Volume, poolManager poolmanager.PoolManager) (params.VolumeParams, error) {
+	stateVolumeParams, ok := v.Params()
+	if !ok {
+		err := &volumeAlreadyProvisionedError{fmt.Errorf(
+			"volume %q is already provisioned", v.Tag().Id(),
+		)}
+		return params.VolumeParams{}, err
+	}
+
+	var providerType storage.ProviderType
+	var attrs map[string]interface{}
+	if pool, err := poolManager.Get(stateVolumeParams.Pool); errors.IsNotFound(err) {
+		// If not a storage pool, then maybe a provider type.
+		providerType = storage.ProviderType(stateVolumeParams.Pool)
+		if _, err1 := registry.StorageProvider(providerType); err1 != nil {
+			return params.VolumeParams{}, errors.Trace(err)
+		}
+	} else if err != nil {
+		return params.VolumeParams{}, errors.Annotate(err, "getting pool")
+	} else {
+		providerType = pool.Provider()
+		attrs = pool.Attrs()
+	}
+	return params.VolumeParams{
+		v.Tag().String(),
+		stateVolumeParams.Size,
+		string(providerType),
+		attrs,
+		"", // machine tag is set by the machine provisioner
+	}, nil
+}
+
+// VolumesToState converts a slice of params.Volume to a mapping
+// of volume tags to state.VolumeInfo.
+func VolumesToState(in []params.Volume) (map[names.VolumeTag]state.VolumeInfo, error) {
+	m := make(map[names.VolumeTag]state.VolumeInfo)
+	for _, v := range in {
+		tag, volumeInfo, err := VolumeToState(v)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		m[tag] = volumeInfo
+	}
+	return m, nil
+}
+
+// VolumeToState converts a params.Volume to state.VolumeInfo
+// and names.VolumeTag.
+func VolumeToState(v params.Volume) (names.VolumeTag, state.VolumeInfo, error) {
+	if v.VolumeTag == "" {
+		return names.VolumeTag{}, state.VolumeInfo{}, errors.New("Tag is empty")
+	}
+	volumeTag, err := names.ParseVolumeTag(v.VolumeTag)
+	if err != nil {
+		return names.VolumeTag{}, state.VolumeInfo{}, errors.Trace(err)
+	}
+	return volumeTag, state.VolumeInfo{
+		v.Serial,
+		v.Size,
+		v.VolumeId,
+	}, nil
+}
+
+// VolumeFromState converts a state.Volume to params.Volume.
+func VolumeFromState(v state.Volume) (params.Volume, error) {
+	info, err := v.Info()
+	if err != nil {
+		return params.Volume{}, errors.Trace(err)
+	}
+	return params.Volume{
+		v.VolumeTag().String(),
+		info.VolumeId,
+		info.Serial,
+		info.Size,
+	}, nil
+}
+
+// VolumeAttachmentsToState converts a slice of storage.VolumeAttachment to a
+// mapping of volume tags to state.VolumeAttachmentInfo.
+func VolumeAttachmentsToState(in []params.VolumeAttachment) (map[names.VolumeTag]state.VolumeAttachmentInfo, error) {
+	m := make(map[names.VolumeTag]state.VolumeAttachmentInfo)
+	for _, v := range in {
+		if v.VolumeTag == "" {
+			return nil, errors.New("Tag is empty")
+		}
+		volumeTag, err := names.ParseVolumeTag(v.VolumeTag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		m[volumeTag] = state.VolumeAttachmentInfo{
+			v.DeviceName,
+			v.ReadOnly,
+		}
+	}
+	return m, nil
+}

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider/registry"
-	"github.com/juju/names"
 )
 
 type volumeAlreadyProvisionedError struct {

--- a/apiserver/common/volumes_test.go
+++ b/apiserver/common/volumes_test.go
@@ -1,0 +1,63 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
+)
+
+type volumesSuite struct{}
+
+var _ = gc.Suite(&volumesSuite{})
+
+type fakeVolume struct {
+	state.Volume
+	tag         names.Tag
+	provisioned bool
+}
+
+func (v *fakeVolume) Tag() names.Tag {
+	return v.tag
+}
+
+func (v *fakeVolume) Params() (state.VolumeParams, bool) {
+	return state.VolumeParams{
+		Pool: "loop",
+		Size: 1024,
+	}, !v.provisioned
+}
+
+func (*volumesSuite) TestVolumeParamsAlreadyProvisioned(c *gc.C) {
+	tag := names.NewVolumeTag("100")
+	_, err := common.VolumeParams(&fakeVolume{tag: tag, provisioned: true}, nil)
+	c.Assert(err, jc.Satisfies, common.IsVolumeAlreadyProvisioned)
+}
+
+type fakePoolManager struct {
+	poolmanager.PoolManager
+}
+
+func (pm *fakePoolManager) Get(name string) (*storage.Config, error) {
+	return nil, errors.NotFoundf("pool")
+}
+
+func (*volumesSuite) TestVolumeParams(c *gc.C) {
+	tag := names.NewVolumeTag("100")
+	p, err := common.VolumeParams(&fakeVolume{tag: tag}, &fakePoolManager{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, jc.DeepEquals, params.VolumeParams{
+		VolumeTag: "volume-100",
+		Provider:  "loop",
+		Size:      1024,
+	})
+}

--- a/apiserver/diskformatter/diskformatter.go
+++ b/apiserver/diskformatter/diskformatter.go
@@ -160,6 +160,7 @@ func (a *DiskFormatterAPI) oneAttachedVolumes(tag names.MachineTag) ([]params.Vo
 				attachment.Volume().String(),
 				attachment.Machine().String(),
 				attachmentInfo.DeviceName,
+				attachmentInfo.ReadOnly,
 			})
 		}
 	}

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -131,6 +131,11 @@ type Volume struct {
 	Size uint64 `json:"size"`
 }
 
+// Volumes describes a set of storage volumes in the environment.
+type Volumes struct {
+	Volumes []Volume `json:"volumes"`
+}
+
 // VolumeAttachmentId identifies a volume attachment by the tags of the
 // related machine and volume.
 type VolumeAttachmentId struct {
@@ -148,6 +153,7 @@ type VolumeAttachment struct {
 	VolumeTag  string `json:"volumetag"`
 	MachineTag string `json:"machinetag"`
 	DeviceName string `json:"devicename,omitempty"`
+	ReadOnly   bool   `json:"readonly"`
 }
 
 // VolumeParams holds the parameters for creating a storage volume.
@@ -192,6 +198,28 @@ type VolumeAttachmentsResult struct {
 // a set of machines.
 type VolumeAttachmentsResults struct {
 	Results []VolumeAttachmentsResult `json:"results,omitempty"`
+}
+
+// VolumeResult holds information about a volume.
+type VolumeResult struct {
+	Result Volume `json:"result"`
+	Error  *Error `json:"error,omitempty"`
+}
+
+// VolumeResults holds information about multiple volumes.
+type VolumeResults struct {
+	Results []VolumeResult `json:"results,omitempty"`
+}
+
+// VolumeParamsResults holds provisioning parameters for a volume.
+type VolumeParamsResult struct {
+	Result VolumeParams `json:"result"`
+	Error  *Error       `json:"error,omitempty"`
+}
+
+// VolumeParamsResults holds provisioning parameters for multiple volumes.
+type VolumeParamsResults struct {
+	Results []VolumeParamsResult `json:"results,omitempty"`
 }
 
 // StorageShowResult holds information about a storage instance

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -744,9 +744,17 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 		Volumes: []state.MachineVolumeParams{
 			{Volume: state.VolumeParams{Size: 1000, Pool: "loop-pool"}},
 			{Volume: state.VolumeParams{Size: 2000, Pool: "loop-pool"}},
+			{Volume: state.VolumeParams{Size: 3000, Pool: "loop-pool"}},
 		},
 	}
 	placementMachine, err := s.State.AddOneMachine(template)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Provision volume 2 so that it is excluded from any ProvisioningInfo() results.
+	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
+	err = placementMachine.SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil, map[names.VolumeTag]state.VolumeInfo{
+		names.NewVolumeTag("2"): state.VolumeInfo{VolumeId: "123", Size: 1024},
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{

--- a/apiserver/storageprovisioner/package_test.go
+++ b/apiserver/storageprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -1,0 +1,22 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/state"
+)
+
+type provisionerState interface {
+	state.EntityFinder
+	WatchVolumes() state.StringsWatcher
+	Volume(names.VolumeTag) (state.Volume, error)
+	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
+	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error
+}
+
+type stateShim struct {
+	*state.State
+}

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -1,0 +1,251 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/storage/poolmanager"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.storageprovisioner")
+
+func init() {
+	common.RegisterStandardFacade("StorageProvisioner", 1, NewStorageProvisionerAPI)
+}
+
+// StorageProvisionerAPI provides access to the Provisioner API facade.
+type StorageProvisionerAPI struct {
+	*common.LifeGetter
+	*common.DeadEnsurer
+
+	st                 provisionerState
+	settings           poolmanager.SettingsManager
+	resources          *common.Resources
+	authorizer         common.Authorizer
+	getMachineAuthFunc common.GetAuthFunc
+	getVolumeAuthFunc  common.GetAuthFunc
+}
+
+var getState = func(st *state.State) provisionerState {
+	return stateShim{st}
+}
+
+var getSettingsManager = func(st *state.State) poolmanager.SettingsManager {
+	return state.NewStateSettings(st)
+}
+
+// NewStorageProvisionerAPI creates a new server-side StorageProvisionerAPI facade.
+func NewStorageProvisionerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*StorageProvisionerAPI, error) {
+	if !authorizer.AuthMachineAgent() {
+		return nil, common.ErrPerm
+	}
+	isEnvironManager := authorizer.AuthEnvironManager()
+	authEntityTag := authorizer.GetAuthTag()
+	getMachineAuthFunc := func() (common.AuthFunc, error) {
+		return func(tag names.Tag) bool {
+			switch tag := tag.(type) {
+			case names.EnvironTag:
+				// Environment managers can access all volumes
+				// scoped to the environment.
+				return isEnvironManager
+			case names.MachineTag:
+				if tag == authEntityTag {
+					// Machine agents can access volumes
+					// scoped to their own machine.
+					return true
+				}
+				parentId := state.ParentId(tag.Id())
+				if parentId == "" {
+					return false
+				}
+				// All containers with the authenticated
+				// machine as a parent are accessible by it.
+				return names.NewMachineTag(parentId) == authEntityTag
+			default:
+				return false
+			}
+		}, nil
+	}
+	getVolumeAuthFunc := func() (common.AuthFunc, error) {
+		return func(tag names.Tag) bool {
+			switch tag.(type) {
+			case names.VolumeTag:
+				// TODO(axw) volume tag should include machine
+				// scope, which we can then use for authentication
+				// and watching purposes.
+				return true
+			default:
+				return false
+			}
+		}, nil
+	}
+	stateInterface := getState(st)
+	settings := getSettingsManager(st)
+	return &StorageProvisionerAPI{
+		LifeGetter:         common.NewLifeGetter(stateInterface, getVolumeAuthFunc),
+		DeadEnsurer:        common.NewDeadEnsurer(stateInterface, getVolumeAuthFunc),
+		st:                 stateInterface,
+		settings:           settings,
+		resources:          resources,
+		authorizer:         authorizer,
+		getMachineAuthFunc: getMachineAuthFunc,
+		getVolumeAuthFunc:  getVolumeAuthFunc,
+	}, nil
+}
+
+// WatchVolumes watches for changes to volumes scoped to the
+// entity with the tag passed to NewState.
+func (s *StorageProvisionerAPI) WatchVolumes(args params.Entities) (params.StringsWatchResults, error) {
+	canAccess, err := s.getMachineAuthFunc()
+	if err != nil {
+		return params.StringsWatchResults{}, common.ServerError(common.ErrPerm)
+	}
+	results := params.StringsWatchResults{
+		Results: make([]params.StringsWatchResult, len(args.Entities)),
+	}
+	one := func(arg params.Entity) (string, []string, error) {
+		tag, err := names.ParseTag(arg.Tag)
+		if err != nil || !canAccess(tag) {
+			return "", nil, common.ErrPerm
+		}
+		// TODO(axw) record a scope for volumes, and watch
+		// only volumes in that scope.
+		w := s.st.WatchVolumes()
+		if changes, ok := <-w.Changes(); ok {
+			return s.resources.Register(w), changes, nil
+		}
+		return "", nil, watcher.EnsureErr(w)
+	}
+	for i, arg := range args.Entities {
+		var result params.StringsWatchResult
+		id, changes, err := one(arg)
+		if err != nil {
+			result.Error = common.ServerError(err)
+		} else {
+			result.StringsWatcherId = id
+			result.Changes = changes
+		}
+		results.Results[i] = result
+	}
+	return results, nil
+}
+
+// Volumes returns details of volumes with the specified tags.
+func (s *StorageProvisionerAPI) Volumes(args params.Entities) (params.VolumeResults, error) {
+	canAccess, err := s.getVolumeAuthFunc()
+	if err != nil {
+		return params.VolumeResults{}, common.ServerError(common.ErrPerm)
+	}
+	results := params.VolumeResults{
+		Results: make([]params.VolumeResult, len(args.Entities)),
+	}
+	one := func(arg params.Entity) (params.Volume, error) {
+		tag, err := names.ParseVolumeTag(arg.Tag)
+		if err != nil || !canAccess(tag) {
+			return params.Volume{}, common.ErrPerm
+		}
+		volume, err := s.st.Volume(tag)
+		if errors.IsNotFound(err) {
+			return params.Volume{}, common.ErrPerm
+		} else if err != nil {
+			return params.Volume{}, err
+		}
+		return common.VolumeFromState(volume)
+	}
+	for i, arg := range args.Entities {
+		var result params.VolumeResult
+		volume, err := one(arg)
+		if err != nil {
+			result.Error = common.ServerError(err)
+		} else {
+			result.Result = volume
+		}
+		results.Results[i] = result
+	}
+	return results, nil
+}
+
+// VolumeParams returns the parameters for creating the volumes
+// with the specified tags.
+func (s *StorageProvisionerAPI) VolumeParams(args params.Entities) (params.VolumeParamsResults, error) {
+	canAccess, err := s.getVolumeAuthFunc()
+	if err != nil {
+		return params.VolumeParamsResults{}, err
+	}
+	results := params.VolumeParamsResults{
+		Results: make([]params.VolumeParamsResult, len(args.Entities)),
+	}
+	poolManager := poolmanager.New(s.settings)
+	one := func(arg params.Entity) (params.VolumeParams, error) {
+		tag, err := names.ParseVolumeTag(arg.Tag)
+		if err != nil || !canAccess(tag) {
+			return params.VolumeParams{}, common.ErrPerm
+		}
+		volume, err := s.st.Volume(tag)
+		if errors.IsNotFound(err) {
+			return params.VolumeParams{}, common.ErrPerm
+		} else if err != nil {
+			return params.VolumeParams{}, err
+		}
+		volumeAttachments, err := s.st.VolumeAttachments(tag)
+		if err != nil {
+			return params.VolumeParams{}, err
+		}
+		volumeParams, err := common.VolumeParams(volume, poolManager)
+		if err != nil {
+			return params.VolumeParams{}, err
+		}
+		if len(volumeAttachments) == 1 {
+			volumeParams.MachineTag = volumeAttachments[0].Machine().String()
+		}
+		return volumeParams, nil
+	}
+	for i, arg := range args.Entities {
+		var result params.VolumeParamsResult
+		volumeParams, err := one(arg)
+		if err != nil {
+			result.Error = common.ServerError(err)
+		} else {
+			result.Result = volumeParams
+		}
+		results.Results[i] = result
+	}
+	return results, nil
+}
+
+// SetVolumeInfo records the details of newly provisioned volumes.
+func (s *StorageProvisionerAPI) SetVolumeInfo(args params.Volumes) (params.ErrorResults, error) {
+	canAccessVolume, err := s.getVolumeAuthFunc()
+	if err != nil {
+		return params.ErrorResults{}, err
+	}
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Volumes)),
+	}
+	one := func(arg params.Volume) error {
+		volumeTag, volumeInfo, err := common.VolumeToState(arg)
+		if err != nil {
+			return errors.Trace(err)
+		} else if !canAccessVolume(volumeTag) {
+			return common.ErrPerm
+		}
+		err = s.st.SetVolumeInfo(volumeTag, volumeInfo)
+		if errors.IsNotFound(err) {
+			return common.ErrPerm
+		}
+		return errors.Trace(err)
+	}
+	for i, arg := range args.Volumes {
+		err := one(arg)
+		results.Results[i].Error = common.ServerError(err)
+	}
+	return results, nil
+}

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -127,13 +127,13 @@ func (s *StorageProvisionerAPI) WatchVolumes(args params.Entities) (params.Strin
 	for i, arg := range args.Entities {
 		var result params.StringsWatchResult
 		id, changes, err := one(arg)
-		results.Results[i] = result
 		if err != nil {
 			result.Error = common.ServerError(err)
-			continue
+		} else {
+			result.StringsWatcherId = id
+			result.Changes = changes
 		}
-		result.StringsWatcherId = id
-		result.Changes = changes
+		results.Results[i] = result
 	}
 	return results, nil
 }

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -127,13 +127,13 @@ func (s *StorageProvisionerAPI) WatchVolumes(args params.Entities) (params.Strin
 	for i, arg := range args.Entities {
 		var result params.StringsWatchResult
 		id, changes, err := one(arg)
+		results.Results[i] = result
 		if err != nil {
 			result.Error = common.ServerError(err)
-		} else {
-			result.StringsWatcherId = id
-			result.Changes = changes
+			continue
 		}
-		results.Results[i] = result
+		result.StringsWatcherId = id
+		result.Changes = changes
 	}
 	return results, nil
 }

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -119,6 +119,8 @@ func (s *provisionerSuite) TestVolumeParamsEmptyArgs(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 0)
 }
 
+// TODO - add test for watching environ volumes when volume watcher
+// is properly implemented in state.
 func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
 	s.setupVolumes(c)
 	s.factory.MakeMachine(c, nil)

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -1,0 +1,177 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/storageprovisioner"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/instance"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+var _ = gc.Suite(&provisionerSuite{})
+
+type provisionerSuite struct {
+	// TODO(wallyworld) remove JujuConnSuite
+	jujutesting.JujuConnSuite
+
+	factory    *factory.Factory
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	api        *storageprovisioner.StorageProvisionerAPI
+}
+
+func (s *provisionerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.factory = factory.NewFactory(s.State)
+	s.resources = common.NewResources()
+	tag := names.NewMachineTag("0")
+	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
+	// Create the resource registry separately to track invocations to
+	// Register.
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	var err error
+	s.api, err = storageprovisioner.NewStorageProvisionerAPI(s.State, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
+	tag := names.NewUnitTag("mysql/0")
+	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
+	_, err := storageprovisioner.NewStorageProvisionerAPI(s.State, common.NewResources(), s.authorizer)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *provisionerSuite) setupVolumes(c *gc.C) {
+	s.factory.MakeMachine(c, &factory.MachineParams{
+		InstanceId: instance.Id("inst-id"),
+		Nonce:      "nonce",
+		Volumes: []state.MachineVolumeParams{
+			{Volume: state.VolumeParams{Pool: "loop", Size: 1024}},
+			{Volume: state.VolumeParams{Pool: "loop", Size: 2048}},
+		},
+	})
+	// Only provision the first volume.
+	err := s.State.SetVolumeInfo(names.NewVolumeTag("0"), state.VolumeInfo{
+		Serial:   "123",
+		VolumeId: "abc",
+		Size:     1024,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	// Make another machine for tests to use.
+	s.factory.MakeMachine(c, nil)
+}
+
+func (s *provisionerSuite) TestVolumes(c *gc.C) {
+	s.setupVolumes(c)
+	results, err := s.api.Volumes(params.Entities{
+		Entities: []params.Entity{{"volume-0"}, {"volume-1"}, {"volume-42"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.VolumeResults{
+		Results: []params.VolumeResult{
+			{Result: params.Volume{VolumeTag: "volume-0", VolumeId: "abc", Serial: "123", Size: 1024}},
+			{Error: common.ServerError(errors.NotProvisionedf(`volume "1"`))},
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestVolumesEmptyArgs(c *gc.C) {
+	results, err := s.api.Volumes(params.Entities{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 0)
+}
+
+func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
+	s.setupVolumes(c)
+	results, err := s.api.VolumeParams(params.Entities{
+		Entities: []params.Entity{{"volume-0"}, {"volume-1"}, {"volume-42"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.VolumeParamsResults{
+		Results: []params.VolumeParamsResult{
+			{Error: &params.Error{`volume "0" is already provisioned`, ""}},
+			{Result: params.VolumeParams{VolumeTag: "volume-1", Size: 2048, Provider: "loop", MachineTag: "machine-0"}},
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestVolumeParamsEmptyArgs(c *gc.C) {
+	results, err := s.api.VolumeParams(params.Entities{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 0)
+}
+
+func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
+	s.setupVolumes(c)
+	s.factory.MakeMachine(c, nil)
+	c.Assert(s.resources.Count(), gc.Equals, 0)
+
+	args := params.Entities{Entities: []params.Entity{{"machine-0"}, {"machine-1"}, {"machine-42"}}}
+	result, err := s.api.WatchVolumes(args)
+	c.Assert(err, jc.ErrorIsNil)
+	sort.Strings(result.Results[0].Changes)
+	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
+		Results: []params.StringsWatchResult{
+			{StringsWatcherId: "1", Changes: []string{"0", "1"}},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+
+	// Verify the resources were registered and stop them when done.
+	c.Assert(s.resources.Count(), gc.Equals, 1)
+	v0Watcher := s.resources.Get("1")
+	defer statetesting.AssertStop(c, v0Watcher)
+
+	// Check that the Watch has consumed the initial event ("returned" in
+	// the Watch call)
+	wc := statetesting.NewStringsWatcherC(c, s.State, v0Watcher.(state.StringsWatcher))
+	wc.AssertNoChange()
+}
+
+func (s *provisionerSuite) TestLife(c *gc.C) {
+	s.setupVolumes(c)
+	args := params.Entities{Entities: []params.Entity{{"volume-0"}, {"volume-1"}, {"volume-42"}}}
+	result, err := s.api.Life(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.LifeResults{
+		Results: []params.LifeResult{
+			{Life: params.Alive},
+			{Life: params.Alive},
+			{Error: common.ServerError(errors.NotFoundf(`volume "42"`))},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestEnsureDead(c *gc.C) {
+	s.setupVolumes(c)
+	args := params.Entities{Entities: []params.Entity{{"volume-0"}, {"volume-1"}, {"volume-42"}}}
+	result, err := s.api.EnsureDead(args)
+	c.Assert(err, jc.ErrorIsNil)
+	// TODO(wallyworld) - this test will be updated when EnsureDead is supported
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: common.ServerError(common.NotSupportedError(names.NewVolumeTag("0"), "ensuring death"))},
+			{Error: common.ServerError(common.NotSupportedError(names.NewVolumeTag("1"), "ensuring death"))},
+			{Error: common.ServerError(errors.NotFoundf(`volume "42"`))},
+		},
+	})
+}

--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
@@ -213,7 +214,7 @@ func (s *DeploySuite) TestStorageWithoutFeatureFlag(c *gc.C) {
 }
 
 func (s *DeploySuite) TestStorage(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{"foo": "bar"})

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/environs/manual"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/storage"
@@ -207,7 +208,7 @@ func (s *AddMachineSuite) TestAddMachineWithDisks(c *gc.C) {
 	_, err := s.run(c, "--disks", "2,1G", "--disks", "2G")
 	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: --disks")
 
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 
 	_, err = s.run(c, "--disks", "2,1G", "--disks", "2G")

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -650,7 +650,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	// TODO(wallyworld) - we don't want the storage workers running yet, even with feature flag.
 	// Will be enabled in a followup branch.
 	enableStorageWorkers := false
-	if featureflag.Enabled(feature.Storage) && enableStorageWorkers {
+	if featureflag.Enabled(feature.Storage) {
 		runner.StartWorker("diskmanager", func() (worker.Worker, error) {
 			api, err := st.DiskManager()
 			if err != nil {
@@ -665,16 +665,18 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 			}
 			return diskformatter.NewWorker(api), nil
 		})
-		runner.StartWorker("storageprovisioner-machine", func() (worker.Worker, error) {
-			api := st.StorageProvisioner(agentConfig.Tag())
-			storageDir := filepath.Join(agentConfig.DataDir(), "storage")
-			return newStorageWorker(storageDir, api, api), nil
-		})
-		if isEnvironManager {
-			runner.StartWorker("storageprovisioner-environ", func() (worker.Worker, error) {
-				api := st.StorageProvisioner(agentConfig.Environment())
-				return newStorageWorker("", api, api), nil
+		if enableStorageWorkers {
+			runner.StartWorker("storageprovisioner-machine", func() (worker.Worker, error) {
+				api := st.StorageProvisioner(agentConfig.Tag())
+				storageDir := filepath.Join(agentConfig.DataDir(), "storage")
+				return newStorageWorker(storageDir, api, api), nil
 			})
+			if isEnvironManager {
+				runner.StartWorker("storageprovisioner-environ", func() (worker.Worker, error) {
+					api := st.StorageProvisioner(agentConfig.Environment())
+					return newStorageWorker("", api, api), nil
+				})
+			}
 		}
 	}
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -647,8 +647,10 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	runner.StartWorker("rsyslog", func() (worker.Worker, error) {
 		return cmdutil.NewRsyslogConfigWorker(st.Rsyslog(), agentConfig, rsyslogMode)
 	})
-	// TODO(axw) stop checking feature flag once storage has graduated.
-	if featureflag.Enabled(feature.Storage) {
+	// TODO(wallyworld) - we don't want the storage workers running yet, even with feature flag.
+	// Will be enabled in a followup branch.
+	enableStorageWorkers := false
+	if featureflag.Enabled(feature.Storage) && enableStorageWorkers {
 		runner.StartWorker("diskmanager", func() (worker.Worker, error) {
 			api, err := st.DiskManager()
 			if err != nil {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1195,7 +1195,8 @@ func (s *MachineSuite) TestMachineAgentRunsMachineStorageWorker(c *gc.C) {
 
 	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	s.testMachineAgentRunsMachineStorageWorker(c, true, coretesting.LongWait)
+	// TODO(wallyworld) - worker is currently disabled even with feature flag
+	s.testMachineAgentRunsMachineStorageWorker(c, false, coretesting.LongWait)
 }
 
 func (s *MachineSuite) testMachineAgentRunsMachineStorageWorker(c *gc.C, shouldRun bool, timeout time.Duration) {
@@ -1230,7 +1231,8 @@ func (s *MachineSuite) testMachineAgentRunsMachineStorageWorker(c *gc.C, shouldR
 func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	s.testMachineAgentRunsEnvironStorageWorkers(c, true, coretesting.LongWait)
+	// TODO(wallyworld) - worker is currently disabled even with feature flag
+	s.testMachineAgentRunsEnvironStorageWorkers(c, false, coretesting.LongWait)
 }
 
 func (s *MachineSuite) testMachineAgentRunsEnvironStorageWorkers(c *gc.C, shouldRun bool, timeout time.Duration) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -42,6 +42,7 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
@@ -1127,7 +1128,7 @@ func (s *MachineSuite) TestMachineAgentRunsDiskManagerWorker(c *gc.C) {
 	// The disk manager should only run with the feature flag set.
 	s.testMachineAgentRunsDiskManagerWorker(c, false, coretesting.ShortWait)
 
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.testMachineAgentRunsDiskManagerWorker(c, true, coretesting.LongWait)
 }
@@ -1160,7 +1161,7 @@ func (s *MachineSuite) testMachineAgentRunsDiskManagerWorker(c *gc.C, shouldRun 
 }
 
 func (s *MachineSuite) TestDiskManagerWorkerUpdatesState(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 
 	expected := []storage.BlockDevice{{DeviceName: "whatever"}}
@@ -1192,7 +1193,7 @@ func (s *MachineSuite) TestMachineAgentRunsMachineStorageWorker(c *gc.C) {
 	// The storage worker should only run with the feature flag set.
 	s.testMachineAgentRunsMachineStorageWorker(c, false, coretesting.ShortWait)
 
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.testMachineAgentRunsMachineStorageWorker(c, true, coretesting.LongWait)
 }
@@ -1227,7 +1228,7 @@ func (s *MachineSuite) testMachineAgentRunsMachineStorageWorker(c *gc.C, shouldR
 }
 
 func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.testMachineAgentRunsEnvironStorageWorkers(c, true, coretesting.LongWait)
 }

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -95,31 +95,31 @@ func (e *ebsProvider) FilesystemSource(environConfig *config.Config, providerCon
 	return nil, errors.NotSupportedf("filesystems")
 }
 
-type ebsVolumeSoucre struct {
+type ebsVolumeSource struct {
 }
 
-var _ storage.VolumeSource = (*ebsVolumeSoucre)(nil)
+var _ storage.VolumeSource = (*ebsVolumeSource)(nil)
 
-func (v *ebsVolumeSoucre) CreateVolumes([]storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
+func (v *ebsVolumeSource) CreateVolumes([]storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
 	panic("not implemented")
 }
 
-func (v *ebsVolumeSoucre) DescribeVolumes(volIds []string) ([]storage.Volume, error) {
+func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.Volume, error) {
 	panic("not implemented")
 }
 
-func (v *ebsVolumeSoucre) DestroyVolumes(volIds []string) error {
+func (v *ebsVolumeSource) DestroyVolumes(volIds []string) []error {
 	panic("not implemented")
 }
 
-func (v *ebsVolumeSoucre) ValidateVolumeParams(params storage.VolumeParams) error {
+func (v *ebsVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
 	panic("not implemented")
 }
 
-func (v *ebsVolumeSoucre) AttachVolumes([]storage.VolumeAttachmentParams) ([]storage.VolumeAttachment, error) {
+func (v *ebsVolumeSource) AttachVolumes([]storage.VolumeAttachmentParams) ([]storage.VolumeAttachment, error) {
 	panic("not implemented")
 }
 
-func (v *ebsVolumeSoucre) DetachVolumes([]storage.VolumeAttachmentParams) error {
+func (v *ebsVolumeSource) DetachVolumes([]storage.VolumeAttachmentParams) error {
 	panic("not implemented")
 }

--- a/state/state.go
+++ b/state/state.go
@@ -714,6 +714,8 @@ func (st *State) FindEntity(tag names.Tag) (Entity, error) {
 		} else {
 			return st.Charm(url)
 		}
+	case names.VolumeTag:
+		return st.Volume(tag)
 	default:
 		return nil, errors.Errorf("unsupported tag %T", tag)
 	}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -171,6 +171,8 @@ func (st *State) WatchEnvironments() StringsWatcher {
 
 // WatchVolumes returns a StringsWatcher that notifies of changes to
 // the lifecycles of all volumes.
+// TODO(wallyworld) - this currently watches all volumes; we need separate
+// methods to watch environ and specific machine volumes.
 func (st *State) WatchVolumes() StringsWatcher {
 	return newLifecycleWatcher(st, volumesC, nil, nil, nil)
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -58,7 +58,7 @@ type VolumeSource interface {
 
 	// DestroyVolumes destroys the volumes with the specified provider
 	// volume IDs.
-	DestroyVolumes(volIds []string) error
+	DestroyVolumes(volIds []string) []error
 
 	// ValidateVolumeParams validates the provided volume creation
 	// parameters, returning an error if they are invalid.

--- a/storage/poolmanager/defaultpool_test.go
+++ b/storage/poolmanager/defaultpool_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -22,7 +23,7 @@ type defaultStoragePoolsSuite struct {
 var _ = gc.Suite(&defaultStoragePoolsSuite{})
 
 func (s *defaultStoragePoolsSuite) TestDefaultStoragePools(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 
 	p1, err := storage.NewConfig("pool1", storage.ProviderType("foo"), map[string]interface{}{"1": "2"})

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -131,8 +131,9 @@ func (s *loopSuite) TestDestroyVolumes(c *gc.C) {
 	err := ioutil.WriteFile(fileName, nil, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = source.DestroyVolumes([]string{"volume-0"})
-	c.Assert(err, jc.ErrorIsNil)
+	errs := source.DestroyVolumes([]string{"volume-0"})
+	c.Assert(errs, gc.HasLen, 1)
+	c.Assert(errs[0], jc.ErrorIsNil)
 }
 
 func (s *loopSuite) TestDestroyVolumesDetachFails(c *gc.C) {
@@ -143,14 +144,16 @@ func (s *loopSuite) TestDestroyVolumesDetachFails(c *gc.C) {
 	cmd = s.commands.expect("losetup", "-d", "/dev/loop0")
 	cmd.respond("", errors.New("oy"))
 
-	err := source.DestroyVolumes([]string{"volume-0"})
-	c.Assert(err, gc.ErrorMatches, `detaching loop device "loop0": oy`)
+	errs := source.DestroyVolumes([]string{"volume-0"})
+	c.Assert(errs, gc.HasLen, 1)
+	c.Assert(errs[0], gc.ErrorMatches, `detaching loop device "loop0": oy`)
 }
 
 func (s *loopSuite) TestDestroyVolumesInvalidVolumeId(c *gc.C) {
 	source := s.loopVolumeSource(c)
-	err := source.DestroyVolumes([]string{"../super/important/stuff"})
-	c.Assert(err, gc.ErrorMatches, `invalid loop volume ID "\.\./super/important/stuff"`)
+	errs := source.DestroyVolumes([]string{"../super/important/stuff"})
+	c.Assert(errs, gc.HasLen, 1)
+	c.Assert(errs[0], gc.ErrorMatches, `invalid loop volume ID "\.\./super/important/stuff"`)
 }
 
 func (s *loopSuite) TestDescribeVolumes(c *gc.C) {

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -146,14 +146,14 @@ func (s *loopSuite) TestDestroyVolumesDetachFails(c *gc.C) {
 
 	errs := source.DestroyVolumes([]string{"volume-0"})
 	c.Assert(errs, gc.HasLen, 1)
-	c.Assert(errs[0], gc.ErrorMatches, `detaching loop device "loop0": oy`)
+	c.Assert(errs[0], gc.ErrorMatches, `.* detaching loop device "loop0": oy`)
 }
 
 func (s *loopSuite) TestDestroyVolumesInvalidVolumeId(c *gc.C) {
 	source := s.loopVolumeSource(c)
 	errs := source.DestroyVolumes([]string{"../super/important/stuff"})
 	c.Assert(errs, gc.HasLen, 1)
-	c.Assert(errs[0], gc.ErrorMatches, `invalid loop volume ID "\.\./super/important/stuff"`)
+	c.Assert(errs[0], gc.ErrorMatches, `.* invalid loop volume ID "\.\./super/important/stuff"`)
 }
 
 func (s *loopSuite) TestDescribeVolumes(c *gc.C) {

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -25,7 +25,7 @@ type Volume struct {
 	// TODO(axw) record volume persistence
 }
 
-// VolumeAttachment decsribes machine-specific volume attachment information,
+// VolumeAttachment describes machine-specific volume attachment information,
 // including how the volume is exposed on the machine.
 type VolumeAttachment struct {
 	// Volume is the unique tag assigned by Juju for the volume
@@ -41,4 +41,7 @@ type VolumeAttachment struct {
 	// If the device name may change (e.g. on machine restart), then this
 	// field must be left blank.
 	DeviceName string
+
+	// ReadOnly signifies whether the volume is read only or writable.
+	ReadOnly bool
 }

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -71,6 +71,7 @@ type MachineParams struct {
 	InstanceId      instance.Id
 	Characteristics *instance.HardwareCharacteristics
 	Addresses       []network.Address
+	Volumes         []state.MachineVolumeParams
 }
 
 // ServiceParams is used when specifying parameters for a new service.
@@ -252,7 +253,12 @@ func (factory *Factory) MakeMachine(c *gc.C, params *MachineParams) *state.Machi
 // The machine and its password are returned.
 func (factory *Factory) MakeMachineReturningPassword(c *gc.C, params *MachineParams) (*state.Machine, string) {
 	params = factory.paramsFillDefaults(c, params)
-	machine, err := factory.st.AddMachine(params.Series, params.Jobs...)
+	machineTemplate := state.MachineTemplate{
+		Series:  params.Series,
+		Jobs:    params.Jobs,
+		Volumes: params.Volumes,
+	}
+	machine, err := factory.st.AddOneMachine(machineTemplate)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProvisioned(params.InstanceId, params.Nonce, params.Characteristics)
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/storage/provider/registry"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -209,12 +211,14 @@ func (s *factorySuite) TestMakeMachineNil(c *gc.C) {
 }
 
 func (s *factorySuite) TestMakeMachine(c *gc.C) {
+	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
 	series := "quantal"
 	jobs := []state.MachineJob{state.JobManageEnviron}
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	nonce := "some-nonce"
 	id := instance.Id("some-id")
+	volumes := []state.MachineVolumeParams{{Volume: state.VolumeParams{Size: 1024}}}
 
 	machine, pwd := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
 		Series:     series,
@@ -222,6 +226,7 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 		Password:   password,
 		Nonce:      nonce,
 		InstanceId: id,
+		Volumes:    volumes,
 	})
 	c.Assert(machine, gc.NotNil)
 	c.Assert(pwd, gc.Equals, password)
@@ -233,6 +238,16 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 	c.Assert(machineInstanceId, gc.Equals, id)
 	c.Assert(machine.CheckProvisioned(nonce), jc.IsTrue)
 	c.Assert(machine.PasswordValid(password), jc.IsTrue)
+
+	volume, err := s.State.Volume(names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	volParams, ok := volume.Params()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(volParams, jc.DeepEquals, state.VolumeParams{Pool: "loop", Size: 1024})
+	volAttachments, err := s.State.MachineVolumeAttachments(machine.Tag().(names.MachineTag))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volAttachments, gc.HasLen, 1)
+	c.Assert(volAttachments[0].Machine(), gc.Equals, machine.Tag())
 
 	saved, err := s.State.Machine(machine.Id())
 	c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -19,7 +20,7 @@ type steps123Suite struct {
 var _ = gc.Suite(&steps123Suite{})
 
 func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	expected := []string{
 		"add default storage pools",

--- a/upgrades/storage_test.go
+++ b/upgrades/storage_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/ec2"
@@ -23,7 +24,7 @@ type defaultStoragePoolsSuite struct {
 var _ = gc.Suite(&defaultStoragePoolsSuite{})
 
 func (s *defaultStoragePoolsSuite) TestDefaultStoragePools(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 
 	err := upgrades.AddDefaultStoragePools(s.State)

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -703,6 +703,7 @@ func volumeAttachmentsToApiserver(attachments []storage.VolumeAttachment) []para
 			a.Volume.String(),
 			a.Machine.String(),
 			a.DeviceName,
+			a.ReadOnly,
 		}
 	}
 	return result

--- a/worker/storageprovisioner/package_test.go
+++ b/worker/storageprovisioner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -1,0 +1,142 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"launchpad.net/tomb"
+
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/worker"
+)
+
+var logger = loggo.GetLogger("juju.worker.storageprovisioner")
+
+// VolumeAccessor defines an interface used to allow a storage provisioner
+// worker to perform volume related operations.
+type VolumeAccessor interface {
+	// WatchVolumes watches for changes to volumes scoped to the
+	// entity with the tag passed to NewState.
+	WatchVolumes() (apiwatcher.StringsWatcher, error)
+
+	// Volumes returns details of volumes with the specified tags.
+	Volumes([]names.VolumeTag) ([]params.VolumeResult, error)
+
+	// VolumeParams returns the parameters for creating the volumes
+	// with the specified tags.
+	VolumeParams([]names.VolumeTag) ([]params.VolumeParamsResult, error)
+
+	// SetVolumeInfo records the details of newly provisioned volumes.
+	SetVolumeInfo([]params.Volume) (params.ErrorResults, error)
+}
+
+// LifecycleManager defines an interface used to allow a storage provisioner
+// worker to perform volume lifecycle operations.
+type LifecycleManager interface {
+	// Life requests the life cycle of the entities with the specified tags.
+	Life([]names.Tag) ([]params.LifeResult, error)
+
+	// EnsureDead progresses the entities with the specified tags to the Dead
+	// life cycle state, if they are Alive or Dying.
+	EnsureDead([]names.Tag) ([]params.ErrorResult, error)
+
+	// Remove removes the entities with the specified tags from state.
+	Remove([]names.Tag) ([]params.ErrorResult, error)
+}
+
+// NewStorageProvisioner returns a Worker which manages
+// provisioning (deprovisioning), and attachment (detachment)
+// of first-class volumes and filesystems.
+//
+// Machine-scoped storage workers will be provided with
+// a storage directory, while environment-scoped workers
+// will not. If the directory path is non-empty, then it
+// will be passed to the storage source via its config.
+func NewStorageProvisioner(storageDir string, v VolumeAccessor, l LifecycleManager) worker.Worker {
+	w := &storageprovisioner{
+		storageDir: storageDir,
+		volumes:    v,
+		life:       l,
+	}
+	go func() {
+		defer w.tomb.Done()
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+type storageprovisioner struct {
+	tomb       tomb.Tomb
+	storageDir string
+	volumes    VolumeAccessor
+	life       LifecycleManager
+}
+
+// Kill implements Worker.Kill().
+func (w *storageprovisioner) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait implements Worker.Wait().
+func (w *storageprovisioner) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *storageprovisioner) loop() error {
+	// TODO(axw) wait for and watch environ config.
+	var environConfig *config.Config
+	/*
+		var environConfigChanges <-chan struct{}
+		environWatcher, err := p.st.WatchForEnvironConfigChanges()
+		if err != nil {
+			return err
+		}
+		environConfigChanges = environWatcher.Changes()
+		defer watcher.Stop(environWatcher, &p.tomb)
+		p.environ, err = worker.WaitForEnviron(environWatcher, p.st, p.tomb.Dying())
+		if err != nil {
+			return err
+		}
+	*/
+
+	volumesWatcher, err := w.volumes.WatchVolumes()
+	if err != nil {
+		return errors.Annotate(err, "watching volumes")
+	}
+	defer watcher.Stop(volumesWatcher, &w.tomb)
+	volumesChanges := volumesWatcher.Changes()
+
+	ctx := context{
+		environConfig: environConfig,
+		storageDir:    w.storageDir,
+		volumes:       w.volumes,
+		life:          w.life,
+	}
+
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case changes, ok := <-volumesChanges:
+			if !ok {
+				return watcher.EnsureErr(volumesWatcher)
+			}
+			if err := volumesChanged(&ctx, changes); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}
+
+type context struct {
+	environConfig *config.Config
+	storageDir    string
+	volumes       VolumeAccessor
+	life          LifecycleManager
+}

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -1,0 +1,210 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	gc "gopkg.in/check.v1"
+
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider/registry"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/storageprovisioner"
+)
+
+type storageProvisionerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&storageProvisionerSuite{})
+
+type mockStringsWatcher struct {
+	changes <-chan []string
+}
+
+func (*mockStringsWatcher) Stop() error {
+	return nil
+}
+
+func (*mockStringsWatcher) Err() error {
+	return nil
+}
+
+func (w *mockStringsWatcher) Changes() <-chan []string {
+	return w.changes
+}
+
+type mockVolumeAccessor struct {
+	mockStringsWatcher apiwatcher.StringsWatcher
+	provisioned        map[string]params.Volume
+	done               chan struct{}
+	// If SetVolumeInfo is called with expectedVolumes, then the
+	// volume creation s as expected and the done channel is closed.
+	expectedVolumes []params.Volume
+}
+
+func (w *mockVolumeAccessor) WatchVolumes() (apiwatcher.StringsWatcher, error) {
+	return w.mockStringsWatcher, nil
+}
+
+func (v *mockVolumeAccessor) Volumes(volumes []names.VolumeTag) ([]params.VolumeResult, error) {
+	var result []params.VolumeResult
+	for _, tag := range volumes {
+		if vol, ok := v.provisioned[tag.String()]; ok {
+			result = append(result, params.VolumeResult{Result: vol})
+		} else {
+			result = append(result, params.VolumeResult{
+				Error: common.ServerError(errors.NotProvisionedf("volume %q", tag.Id())),
+			})
+		}
+	}
+	return result, nil
+}
+
+func (v *mockVolumeAccessor) VolumeParams(volumes []names.VolumeTag) ([]params.VolumeParamsResult, error) {
+	var result []params.VolumeParamsResult
+	for _, tag := range volumes {
+		if _, ok := v.provisioned[tag.String()]; ok {
+			result = append(result, params.VolumeParamsResult{
+				Error: &params.Error{Message: "already provisioned"},
+			})
+		} else {
+			result = append(result, params.VolumeParamsResult{Result: params.VolumeParams{
+				VolumeTag: tag.String(),
+				Size:      1024,
+				Provider:  "dummy",
+			}})
+		}
+	}
+	return result, nil
+}
+
+func (v *mockVolumeAccessor) SetVolumeInfo(volumes []params.Volume) (params.ErrorResults, error) {
+	for _, vol := range volumes {
+		v.provisioned[vol.VolumeTag] = vol
+	}
+	// See if we have the expected volumes, using json serialisation to do the comparison.
+	jsonVolInfo, err := json.Marshal(volumes)
+	if err != nil {
+		return params.ErrorResults{Results: []params.ErrorResult{{Error: common.ServerError(err)}}}, nil
+	}
+	jsonExpectedInfo, err := json.Marshal(v.expectedVolumes)
+	if err != nil {
+		return params.ErrorResults{Results: []params.ErrorResult{{Error: common.ServerError(err)}}}, nil
+	}
+	// If we have what we expect, close the done channel.
+	if string(jsonVolInfo) == string(jsonExpectedInfo) {
+		close(v.done)
+	}
+	return params.ErrorResults{}, nil
+}
+
+func newMockVolumeAccessor(changes <-chan []string, done chan struct{}, expectedVolumes []params.Volume) storageprovisioner.VolumeAccessor {
+	return &mockVolumeAccessor{
+		&mockStringsWatcher{changes},
+		make(map[string]params.Volume),
+		done,
+		expectedVolumes,
+	}
+}
+
+type mockLifecycleManager struct {
+}
+
+func (m *mockLifecycleManager) Life(volumes []names.Tag) ([]params.LifeResult, error) {
+	var result []params.LifeResult
+	for _, tag := range volumes {
+		id, _ := strconv.Atoi(tag.Id())
+		if id <= 100 {
+			result = append(result, params.LifeResult{Life: params.Alive})
+		} else {
+			result = append(result, params.LifeResult{Life: params.Dying})
+		}
+	}
+	return result, nil
+}
+
+func (m *mockLifecycleManager) EnsureDead([]names.Tag) ([]params.ErrorResult, error) {
+	return nil, nil
+}
+
+func (m *mockLifecycleManager) Remove([]names.Tag) ([]params.ErrorResult, error) {
+	return nil, nil
+}
+
+func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
+	changes := make(chan []string)
+	worker := storageprovisioner.NewStorageProvisioner(
+		"dir", newMockVolumeAccessor(changes, nil, nil), &mockLifecycleManager{},
+	)
+	worker.Kill()
+	c.Assert(worker.Wait(), gc.IsNil)
+}
+
+// Set up a dummy storage provider so we can stub out volume creation.
+type dummyProvider struct {
+	storage.Provider
+}
+
+type dummyVolumeSource struct {
+	storage.VolumeSource
+}
+
+func (*dummyProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
+	return &dummyVolumeSource{}, nil
+}
+
+// CreateVolumes makes some volumes that we can check later to ensure things went as expected.
+func (*dummyVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
+	var volumes []storage.Volume
+	var volumeAttachments []storage.VolumeAttachment
+	for _, p := range params {
+		volumes = append(volumes, storage.Volume{
+			Tag:      p.Tag,
+			Size:     p.Size,
+			Serial:   "serial-" + p.Tag.Id(),
+			VolumeId: "id-" + p.Tag.Id(),
+		})
+		volumeAttachments = append(volumeAttachments, storage.VolumeAttachment{
+			Volume:     p.Tag,
+			Machine:    names.NewMachineTag("0"),
+			DeviceName: "/dev/sda" + p.Tag.Id(),
+		})
+	}
+	return volumes, volumeAttachments, nil
+}
+
+func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
+	registry.RegisterProvider(storage.ProviderType("dummy"), &dummyProvider{})
+	updated := make(chan struct{})
+	changes := make(chan []string)
+	expectedVolumes := []params.Volume{
+		{VolumeTag: "volume-1", VolumeId: "id-1", Serial: "serial-1", Size: 1024},
+		{VolumeTag: "volume-2", VolumeId: "id-2", Serial: "serial-2", Size: 1024},
+	}
+	worker := storageprovisioner.NewStorageProvisioner(
+		"storage-dir", newMockVolumeAccessor(changes, updated, expectedVolumes), &mockLifecycleManager{},
+	)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+
+	// The worker should create volumes according to ids "1" and "2".
+	changes <- []string{"1", "2"}
+	select {
+	case <-updated:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for volume change to be processd")
+	}
+}
+
+// TODO(wallyworld) - test destroying volumes when done

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -49,7 +49,7 @@ type mockVolumeAccessor struct {
 	provisioned        map[string]params.Volume
 	done               chan struct{}
 	// If SetVolumeInfo is called with expectedVolumes, then the
-	// volume creation s as expected and the done channel is closed.
+	// volume creation is as expected and the done channel is closed.
 	expectedVolumes []params.Volume
 }
 

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -1,0 +1,306 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider/registry"
+)
+
+func volumesChanged(ctx *context, changes []string) error {
+	tags := make([]names.Tag, len(changes))
+	for i, change := range changes {
+		tags[i] = names.NewVolumeTag(change)
+	}
+
+	lifeResults, err := ctx.life.Life(tags)
+	if err != nil {
+		return errors.Annotate(err, "getting volume lifecycle")
+	}
+	var alive, dying, dead []names.Tag
+	for i, result := range lifeResults {
+		if result.Error != nil {
+			return errors.Annotatef(result.Error, "failed to get life for volume %q", tags[i].Id())
+		}
+		switch result.Life {
+		case params.Alive:
+			alive = append(alive, tags[i])
+		case params.Dying:
+			dying = append(dying, tags[i])
+		case params.Dead:
+			dead = append(dead, tags[i])
+		default:
+			return errors.Errorf("invalid life cycle %v", result.Life)
+		}
+	}
+
+	// If we can, advance "dying" volumes to "dead".
+	if len(dying) > 0 {
+		// TODO(axw) wait for volumes to have no attachments first.
+		// We'll either have to retry periodically, or watch the
+		// volume attachments until they're all gone. We need to
+		// watch volume attachments *anyway*, so we can probably
+		// integrate the two things.
+		errorResults, err := ctx.life.EnsureDead(dying)
+		if err != nil {
+			return errors.Annotate(err, "ensuring volumes dead")
+		}
+		for i, result := range errorResults {
+			if result.Error != nil {
+				return errors.Annotatef(result.Error, "failed to ensure volume %q dead", dying[i].Id())
+			}
+			dead = append(dead, dying[i])
+		}
+	}
+
+	if len(alive)+len(dead) == 0 {
+		return nil
+	}
+
+	// Get volume information for alive and dead volumes, so
+	// we can provision/deprovision.
+	volumeTags := make([]names.VolumeTag, 0, len(alive)+len(dead))
+	for _, tag := range alive {
+		volumeTags = append(volumeTags, tag.(names.VolumeTag))
+	}
+	for _, tag := range dead {
+		volumeTags = append(volumeTags, tag.(names.VolumeTag))
+	}
+	volumeResults, err := ctx.volumes.Volumes(volumeTags)
+	if err != nil {
+		return errors.Annotatef(err, "getting volume information")
+	}
+
+	// Deprovision "dead" volumes, and then remove from state.
+	if err := processDeadVolumes(ctx, dead, volumeResults[len(alive):]); err != nil {
+		return errors.Annotate(err, "deprovisioning volumes")
+	}
+
+	// Provision "alive" volumes.
+	if err := processAliveVolumes(ctx, alive, volumeResults[:len(alive)]); err != nil {
+		return errors.Annotate(err, "provisioning volumes")
+	}
+
+	return nil
+}
+
+func processDeadVolumes(ctx *context, tags []names.Tag, volumeResults []params.VolumeResult) error {
+	volumes := make([]params.Volume, len(volumeResults))
+	for i, result := range volumeResults {
+		if result.Error != nil {
+			return errors.Annotatef(result.Error, "getting volume information for volume %q", tags[i].Id())
+		}
+		volumes[i] = result.Result
+	}
+	if len(volumes) == 0 {
+		return nil
+	}
+	errorResults, err := destroyVolumes(volumes)
+	if err != nil {
+		return errors.Annotate(err, "destroying volumes")
+	}
+	destroyed := make([]names.Tag, 0, len(volumes))
+	for i, err := range errorResults {
+		if err != nil {
+			logger.Errorf("destroying volume %q: %v", volumes[i].VolumeTag, err)
+			continue
+		}
+		destroyed = append(destroyed, tags[i])
+	}
+	if len(destroyed) > 0 {
+		errorResults, err := ctx.life.Remove(destroyed)
+		if err != nil {
+			return errors.Annotate(err, "removing volumes from state")
+		}
+		for i, result := range errorResults {
+			if result.Error != nil {
+				logger.Errorf("removing volume %q from state: %v", destroyed[i].Id(), result.Error)
+			}
+		}
+	}
+	return nil
+}
+
+func processAliveVolumes(ctx *context, tags []names.Tag, volumeResults []params.VolumeResult) error {
+	// Filter out the already-provisioned volumes.
+	pending := make([]names.VolumeTag, 0, len(tags))
+	for i, result := range volumeResults {
+		if result.Error == nil {
+			// Volume is already provisioned: skip.
+			logger.Debugf("volume %q is already provisioned, nothing to do", tags[i].Id())
+			continue
+		}
+		if !params.IsCodeNotProvisioned(result.Error) {
+			return errors.Annotatef(
+				result.Error, "getting volume information for volume %q", tags[i].Id(),
+			)
+		}
+		// The volume has not yet been provisioned, so record its tag
+		// to enquire about parameters below.
+		pending = append(pending, tags[i].(names.VolumeTag))
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	paramsResults, err := ctx.volumes.VolumeParams(pending)
+	if err != nil {
+		return errors.Annotate(err, "getting volume params")
+	}
+	volumeParams := make([]storage.VolumeParams, 0, len(paramsResults))
+	for _, result := range paramsResults {
+		if result.Error != nil {
+			return errors.Annotate(err, "getting volume parameters")
+		}
+		params, err := volumeParamsFromParams(result.Result)
+		if err != nil {
+			return errors.Annotate(err, "getting volume parameters")
+		}
+		volumeParams = append(volumeParams, params)
+	}
+	volumes, volumeAttachments, err := createVolumes(
+		ctx.environConfig, ctx.storageDir, volumeParams,
+	)
+	if err != nil {
+		return errors.Annotate(err, "creating volumes")
+	}
+	if len(volumes) > 0 {
+		// TODO(axw) we need to be able to list volumes in the provider,
+		// by environment, so that we can "harvest" them if they're
+		// unknown. This will take care of killing volumes that we fail
+		// to record in state.
+		errorResults, err := ctx.volumes.SetVolumeInfo(volumes)
+		if err != nil {
+			return errors.Annotate(err, "publishing volumes to state")
+		}
+		if err := errorResults.Combine(); err != nil {
+			return errors.Annotate(err, "publishing volumes to state")
+		}
+		// TODO(axw) record volume attachment info in state.
+		_ = volumeAttachments
+	}
+	return nil
+}
+
+func volumeParamsFromParams(in params.VolumeParams) (storage.VolumeParams, error) {
+	volumeTag, err := names.ParseVolumeTag(in.VolumeTag)
+	if err != nil {
+		return storage.VolumeParams{}, errors.Trace(err)
+	}
+	var attachment *storage.VolumeAttachmentParams
+	if in.MachineTag != "" {
+		machineTag, err := names.ParseMachineTag(in.MachineTag)
+		if err != nil {
+			return storage.VolumeParams{}, errors.Trace(err)
+		}
+		attachment = &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				Machine: machineTag,
+				// TODO(axw) we need to pass the instance ID over the API too.
+				InstanceId: instance.Id(""),
+			},
+			Volume: volumeTag,
+		}
+	}
+	return storage.VolumeParams{
+		volumeTag,
+		in.Size,
+		storage.ProviderType(in.Provider),
+		in.Attributes,
+		attachment,
+	}, nil
+}
+
+// createVolumes creates volumes with the specified parameters.
+func createVolumes(
+	environConfig *config.Config,
+	baseStorageDir string,
+	params []storage.VolumeParams,
+) ([]params.Volume, []params.VolumeAttachment, error) {
+	paramsByProvider := make(map[storage.ProviderType][]storage.VolumeParams)
+	for _, params := range params {
+		paramsByProvider[params.Provider] = append(paramsByProvider[params.Provider], params)
+	}
+	// TODO(axw) move this to the main storageprovisioner, and have it
+	// watch for changes to storage source configurations, updating
+	// a map in-between calls to the volume/filesystem/attachment
+	// event handlers.
+	volumeSources := make(map[string]storage.VolumeSource)
+	for providerType := range paramsByProvider {
+		provider, err := registry.StorageProvider(providerType)
+		if err != nil {
+			return nil, nil, errors.Annotatef(err, "getting storage provider %q", providerType)
+		}
+		// TODO(axw) once we have storage source configuration separate
+		// from pools, we need to pass it in here.
+		sourceName := string(providerType)
+		attrs := make(map[string]interface{})
+		if baseStorageDir != "" {
+			storageDir := filepath.Join(baseStorageDir, sourceName)
+			attrs[storage.ConfigStorageDir] = storageDir
+		}
+		sourceConfig, err := storage.NewConfig(sourceName, providerType, attrs)
+		if err != nil {
+			return nil, nil, errors.Annotatef(err, "getting storage source %q config", sourceName)
+		}
+		source, err := provider.VolumeSource(environConfig, sourceConfig)
+		if err != nil {
+			return nil, nil, errors.Annotatef(err, "getting storage source %q", sourceName)
+		}
+		volumeSources[sourceName] = source
+	}
+	var allVolumes []storage.Volume
+	var allVolumeAttachments []storage.VolumeAttachment
+	for providerType, params := range paramsByProvider {
+		// TODO(axw) we should be returning source source names in the
+		// storage params, rather than provider types.
+		sourceName := string(providerType)
+		volumeSource := volumeSources[sourceName]
+		volumes, volumeAttachments, err := volumeSource.CreateVolumes(params)
+		if err != nil {
+			return nil, nil, errors.Annotatef(err, "creating volumes from source %q", sourceName)
+		}
+		allVolumes = append(allVolumes, volumes...)
+		allVolumeAttachments = append(allVolumeAttachments, volumeAttachments...)
+	}
+	// TODO(axw) translate volumes/attachments to params
+	return volumesFromStorage(allVolumes), volumeAttachmentsFromStorage(allVolumeAttachments), nil
+}
+
+func destroyVolumes(volumes []params.Volume) ([]error, error) {
+	panic("not implemented")
+}
+
+func volumesFromStorage(in []storage.Volume) []params.Volume {
+	out := make([]params.Volume, len(in))
+	for i, v := range in {
+		out[i] = params.Volume{
+			v.Tag.String(),
+			v.VolumeId,
+			v.Serial,
+			v.Size,
+		}
+	}
+	return out
+}
+
+func volumeAttachmentsFromStorage(in []storage.VolumeAttachment) []params.VolumeAttachment {
+	out := make([]params.VolumeAttachment, len(in))
+	for i, v := range in {
+		out[i] = params.VolumeAttachment{
+			v.Volume.String(),
+			v.Machine.String(),
+			v.DeviceName,
+			v.ReadOnly,
+		}
+	}
+	return out
+}

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4/hooks"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/hook"
@@ -55,7 +56,7 @@ var validateTests = []struct {
 }
 
 func (s *InfoSuite) TestValidate(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	for i, t := range validateTests {
 		c.Logf("test %d", i)

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/juju/charm.v4/hooks"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -46,7 +47,7 @@ func (fakeTracker) ServiceName() string {
 }
 
 func (s *FactorySuite) SetUpTest(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.HookContextSuite.SetUpTest(c)
 	s.paths = NewRealPaths(c)
@@ -334,7 +335,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	rnr, err := factory.NewHookRunner(hook.Info{
 		Kind:      hooks.StorageAttached,

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -21,6 +21,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gnuflag"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/testing"
@@ -222,7 +223,7 @@ var newCommandTests = []struct {
 }
 
 func (s *NewCommandSuite) TestNewCommand(c *gc.C) {
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	ctx := s.GetHookContext(c, 0, "")
 	for _, t := range newCommandTests {

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
@@ -27,7 +28,7 @@ var _ = gc.Suite(&storageGetSuite{})
 
 func (s *storageGetSuite) SetUpTest(c *gc.C) {
 	s.ContextSuite.SetUpTest(c)
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 


### PR DESCRIPTION
This is a functional work in progress - a machine scoped storage provisioner can create volumes. The framework is also there for environment scoped storage provisioners to manage cloud based volumes. Deleting volumes is not supported yet etc.

Some driveby cleanup was also done.

(Review request: http://reviews.vapour.ws/r/1108/)