### PR TITLE
Ensure the resolve command checks the agent status not the unit status

### DIFF
--- a/cmd/juju/resolved_test.go
+++ b/cmd/juju/resolved_test.go
@@ -89,7 +89,7 @@ func (s *ResolvedSuite) TestResolved(c *gc.C) {
 	for _, name := range []string{"dummy/2", "dummy/3", "dummy/4"} {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
-		err = u.SetStatus(state.StatusError, "lol borken", nil)
+		err = u.SetAgentStatus(state.StatusError, "lol borken", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -1855,7 +1855,7 @@ func (u *Unit) RunningActions() ([]*Action, error) {
 // whether to attempt to reexecute previous failed hooks or to continue
 // as if they had succeeded before.
 func (u *Unit) Resolve(retryHooks bool) error {
-	status, _, _, err := u.Status()
+	status, _, _, err := u.AgentStatus()
 	if err != nil {
 		return err
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1855,6 +1855,9 @@ func (u *Unit) RunningActions() ([]*Action, error) {
 // whether to attempt to reexecute previous failed hooks or to continue
 // as if they had succeeded before.
 func (u *Unit) Resolve(retryHooks bool) error {
+	// We currently check agent status to see if a unit is
+	// in error state. As the new Juju Health work is completed,
+	// this will change to checking the unit status.
 	status, _, _, err := u.AgentStatus()
 	if err != nil {
 		return err

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -526,7 +526,7 @@ func (s *UnitSuite) TestRefresh(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *UnitSuite) TestGetSetStatusWhileAlive(c *gc.C) {
+func (s *UnitSuite) TestGetSetUnitStatusWhileAlive(c *gc.C) {
 	err := s.unit.SetStatus(state.StatusError, "", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set status "error" without info`)
 	err = s.unit.SetStatus(state.Status("vliegkat"), "orville", nil)
@@ -559,7 +559,27 @@ func (s *UnitSuite) TestGetSetStatusWhileAlive(c *gc.C) {
 	})
 }
 
-func (s *UnitSuite) TestGetSetStatusWhileNotAlive(c *gc.C) {
+func (s *UnitSuite) TestSetAgentStatus(c *gc.C) {
+	err := s.unit.SetAgentStatus(state.StatusActive, "foo", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	status, info, data, err := s.unit.Agent().(*state.UnitAgent).Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.Equals, state.StatusActive)
+	c.Assert(info, gc.Equals, "foo")
+	c.Assert(data, gc.HasLen, 0)
+}
+
+func (s *UnitSuite) TestGetAgentStatus(c *gc.C) {
+	err := s.unit.Agent().(*state.UnitAgent).SetStatus(state.StatusActive, "foo", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	status, info, data, err := s.unit.AgentStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.Equals, state.StatusActive)
+	c.Assert(info, gc.Equals, "foo")
+	c.Assert(data, gc.HasLen, 0)
+}
+
+func (s *UnitSuite) TestGetSetUnitStatusWhileNotAlive(c *gc.C) {
 	err := s.unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.SetStatus(state.StatusRunning, "not really", nil)
@@ -1001,7 +1021,7 @@ func (s *UnitSuite) TestResolve(c *gc.C) {
 	err = s.unit.Resolve(true)
 	c.Assert(err, gc.ErrorMatches, `unit "wordpress/0" is not in an error state`)
 
-	err = s.unit.SetStatus(state.StatusError, "gaaah", nil)
+	err = s.unit.SetAgentStatus(state.StatusError, "gaaah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.Resolve(false)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
A small tweak to fix the juju resolved  command.
Also add a couple of extra tests not directly related to fix but useful nonetheless.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1424069

(Review request: http://reviews.vapour.ws/r/1109/)