### PR TITLE
Only log rpc request params and response body at trace level

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -197,29 +197,29 @@ func (s *loginV0Suite) TestLoginSetsLogIdentifier(c *gc.C) {
 		// RequestId starts at 2 here, because we've already attempted a v1 Login.
 		// This is the fallback to v0 Login.
 		`<- \[[0-9A-F]+\] <unknown> {"RequestId":2,"Type":"Admin","Request":"Login",` +
-			`"Params":{"AuthTag":"machine-0","Password":"[^"]*","Nonce":"fake_nonce"}` +
+			`"Params":"'params redacted'"` +
 			`}`,
 		// Now that we are logged in, we see the entity's tag
 		// [0-9.µumns] is to handle timestamps that are ns, µs, ms, or s
 		// long, though we expect it to be in the 'ms' range.
 		// Note: Go1.4 produces µs; Go1.3 produces us.
 		`-> \[[0-9A-F]+\] machine-0 [0-9.µumns]+ {"RequestId":2,"Response":.*} Admin\[""\].Login`,
-		`<- \[[0-9A-F]+\] machine-0 {"RequestId":3,"Type":"Machiner","Request":"Life","Params":{"Entities":\[{"Tag":"machine-0"}\]}}`,
-		`-> \[[0-9A-F]+\] machine-0 [0-9.µumns]+ {"RequestId":3,"Response":{"Results":\[{"Life":"alive","Error":null}\]}} Machiner\[""\]\.Life`,
+		`<- \[[0-9A-F]+\] machine-0 {"RequestId":3,"Type":"Machiner","Request":"Life","Params":"'params redacted'"}`,
+		`-> \[[0-9A-F]+\] machine-0 [0-9.µumns]+ {"RequestId":3,"Response":"'body redacted'"} Machiner\[""\]\.Life`,
 	})
 }
 
 func (s *loginV1Suite) TestLoginSetsLogIdentifier(c *gc.C) {
 	s.runLoginSetsLogIdentifier(c, []string{
 		`<- \[[0-9A-F]+\] <unknown> {"RequestId":1,"Type":"Admin","Version":1,"Request":"Login",` +
-			`"Params":{"auth-tag":"machine-0","credentials":"[^"]*","nonce":"fake_nonce"}` +
+			`"Params":"'params redacted'"` +
 			`}`,
 		// Now that we are logged in, we see the entity's tag
 		// [0-9.umns] is to handle timestamps that are ns, us, ms, or s
 		// long, though we expect it to be in the 'ms' range.
 		`-> \[[0-9A-F]+\] machine-0 [0-9.]+[µumn]?s {"RequestId":1,"Response":.*} Admin\[""\].Login`,
-		`<- \[[0-9A-F]+\] machine-0 {"RequestId":2,"Type":"Machiner","Request":"Life","Params":{"Entities":\[{"Tag":"machine-0"}\]}}`,
-		`-> \[[0-9A-F]+\] machine-0 [0-9.µumns]+ {"RequestId":2,"Response":{"Results":\[{"Life":"alive","Error":null}\]}} Machiner\[""\]\.Life`,
+		`<- \[[0-9A-F]+\] machine-0 {"RequestId":2,"Type":"Machiner","Request":"Life","Params":"'params redacted'"}`,
+		`-> \[[0-9A-F]+\] machine-0 [0-9.µumns]+ {"RequestId":2,"Response":"'body redacted'"} Machiner\[""\]\.Life`,
 	})
 }
 

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -262,14 +262,21 @@ func (n *requestNotifier) ServerRequest(hdr *rpc.Header, body interface{}) {
 		return
 	}
 	// TODO(rog) 2013-10-11 remove secrets from some requests.
-	logger.Debugf("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
+	// Until secrets are removed, we only log the body of the requests at trace level
+	// which is below the default level of debug.
+	logger.Debugf("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, "'params redacted'"))
+	logger.Tracef("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
 }
 
 func (n *requestNotifier) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}, timeSpent time.Duration) {
 	if req.Type == "Pinger" && req.Action == "Ping" {
 		return
 	}
-	logger.Debugf("-> [%X] %s %s %s %s[%q].%s", n.id, n.tag(), timeSpent, jsoncodec.DumpRequest(hdr, body), req.Type, req.Id, req.Action)
+	// TODO(rog) 2013-10-11 remove secrets from some responses.
+	// Until secrets are removed, we only log the body of the requests at trace level
+	// which is below the default level of debug.
+	logger.Debugf("-> [%X] %s %s %s %s[%q].%s", n.id, n.tag(), timeSpent, jsoncodec.DumpRequest(hdr, "'body redacted'"), req.Type, req.Id, req.Action)
+	logger.Tracef("-> [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
 }
 
 func (n *requestNotifier) join(req *http.Request) {


### PR DESCRIPTION
We can't easily remove credentials for rpc request params and responses. By default, logging is initially at debug level which causes credential to leak. So we change the rpc logging to still log the rpc metadata at debug level, bt also add in trace level debugging of the unredacted data.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1423272