### PR TITLE
Add --wait flag to `juju action fetch`

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -135,8 +135,7 @@ func getActionTagByPrefix(api APIClient, prefix string) (names.ActionTag, error)
 		return tag, errors.Errorf("identifier %q matched multiple actions %v", prefix, actiontags)
 	}
 
-	tag = actiontags[0]
-	return tag, nil
+	return actiontags[0], nil
 }
 
 // getActionTags converts a slice of params.Entity to a slice of names.ActionTag, and

--- a/cmd/juju/action/fetch.go
+++ b/cmd/juju/action/fetch.go
@@ -4,7 +4,7 @@
 package action
 
 import (
-	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/juju/cmd"
@@ -20,16 +20,24 @@ type FetchCommand struct {
 	out         cmd.Output
 	requestedId string
 	fullSchema  bool
+	wait        string
 }
 
 const fetchDoc = `
 Show the results returned by an action with the given ID.  A partial ID may
-also be used.
+also be used.  To block until the result is known completed or failed, use
+the --wait flag with a duration, as in --wait 5s or --wait 1h.  Use --wait 0
+to wait indefinitely.  If units are left off, seconds are assumed.
+
+The default behavior without --wait is to immediately check and return; if
+the results are "pending" then only the available information will be
+displayed.  This is also the behavior when any negative time is given.
 `
 
 // Set up the output.
 func (c *FetchCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	f.StringVar(&c.wait, "wait", "-1s", "wait for results")
 }
 
 func (c *FetchCommand) Info() *cmd.Info {
@@ -56,39 +64,119 @@ func (c *FetchCommand) Init(args []string) error {
 
 // Run issues the API call to get Actions by ID.
 func (c *FetchCommand) Run(ctx *cmd.Context) error {
+	// Check whether units were left off our time string.
+	r := regexp.MustCompile("[a-zA-Z]")
+	matches := r.FindStringSubmatch(c.wait[len(c.wait)-1:])
+	// If any match, we have units.  Otherwise, we don't; assume seconds.
+	if len(matches) == 0 {
+		c.wait = c.wait + "s"
+	}
+
+	waitDur, err := time.ParseDuration(c.wait)
+	if err != nil {
+		return err
+	}
+
 	api, err := c.NewActionAPIClient()
 	if err != nil {
 		return err
 	}
 	defer api.Close()
 
-	actionTag, err := getActionTagByPrefix(api, c.requestedId)
+	// tick every two seconds, to delay the loop timer.
+	tick := time.NewTimer(2 * time.Second)
+	wait := time.NewTimer(0 * time.Second)
+
+	switch {
+	case waitDur.Nanoseconds() < 0:
+		// Negative duration signals immediate return.  All is well.
+	case waitDur.Nanoseconds() == 0:
+		// Zero duration signals indefinite wait.  Discard the tick.
+		wait = time.NewTimer(0 * time.Second)
+		_ = <-wait.C
+	default:
+		// Otherwise, start an ordinary timer.
+		wait = time.NewTimer(waitDur)
+	}
+
+	result, err := timerLoop(api, c.requestedId, wait, tick)
 	if err != nil {
 		return err
+	}
+
+	return c.out.Write(ctx, formatActionResult(result))
+}
+
+// timerLoop loops indefinitely to query the given API, until "wait" times
+// out, using the "tick" timer to delay the API queries.  It writes the
+// result to the given output.
+func timerLoop(api APIClient, requestedId string, wait, tick *time.Timer) (params.ActionResult, error) {
+	var (
+		result params.ActionResult
+		err    error
+	)
+
+	// Loop over results until we get "failed" or "completed".  Wait for
+	// timer, and reset it each time.
+	for {
+		result, err = fetchResult(api, requestedId)
+		if err != nil {
+			return result, err
+		}
+
+		// Whether or not we're waiting for a result, if a non
+		// pending result arrives, we're done.
+		if result.Status != params.ActionPending {
+			return result, nil
+		}
+
+		// Block until a tick happens, or the timeout arrives.
+		select {
+		case _ = <-wait.C:
+			return result, nil
+
+		case _ = <-tick.C:
+			tick.Reset(2 * time.Second)
+		}
+	}
+}
+
+// fetchResult queries the given API for the given Action ID prefix, and
+// makes sure the results are acceptable, returning an error if they are not.
+func fetchResult(api APIClient, requestedId string) (params.ActionResult, error) {
+	none := params.ActionResult{}
+
+	actionTag, err := getActionTagByPrefix(api, requestedId)
+	if err != nil {
+		return none, err
 	}
 
 	actions, err := api.Actions(params.Entities{
 		Entities: []params.Entity{{actionTag.String()}},
 	})
 	if err != nil {
-		return err
+		return none, err
 	}
 	actionResults := actions.Results
 	numActionResults := len(actionResults)
 	if numActionResults == 0 {
-		return c.out.Write(ctx, fmt.Sprintf("no results for action %s", c.requestedId))
+		return none, errors.Errorf("no results for action %s", requestedId)
 	}
 	if numActionResults != 1 {
-		return errors.Errorf("too many results for action %s", c.requestedId)
+		return none, errors.Errorf("too many results for action %s", requestedId)
 	}
 
 	result := actionResults[0]
 	if result.Error != nil {
-		return result.Error
+		return none, result.Error
 	}
-	return c.out.Write(ctx, formatActionResult(result))
+
+	return result, nil
 }
 
+// formatActionResult removes empty values from the given ActionResult and
+// inserts the remaining ones in a map[string]interface{} for cmd.Output to
+// write in an easy-to-read format.
 func formatActionResult(result params.ActionResult) map[string]interface{} {
 	response := map[string]interface{}{"status": result.Status}
 	if result.Message != "" {

--- a/cmd/juju/action/fetch_test.go
+++ b/cmd/juju/action/fetch_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/names"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -37,7 +36,6 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 	tests := []struct {
 		should      string
 		args        []string
-		expectTag   names.ActionTag
 		expectError string
 	}{{
 		should:      "fail with missing arg",
@@ -50,7 +48,6 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 	}}
 
 	for i, t := range tests {
-
 		c.Logf("test %d: it should %s: juju actions fetch %s", i,
 			t.should, strings.Join(t.args, " "))
 		err := testing.InitCommand(&action.FetchCommand{}, t.args)
@@ -62,36 +59,67 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 
 func (s *FetchSuite) TestRun(c *gc.C) {
 	tests := []struct {
-		should          string
-		withTags        params.FindTagsResults
-		withAPIResponse []params.ActionResult
-		withAPIError    string
-		expectedErr     string
-		expectedOutput  string
+		should            string
+		withClientWait    string
+		withClientQueryID string
+		withAPIDelay      time.Duration
+		withTags          params.FindTagsResults
+		withAPIResponse   []params.ActionResult
+		withAPIError      string
+		expectedErr       string
+		expectedOutput    string
 	}{{
-		should:       "pass api error through properly",
-		withAPIError: "api call error",
-		expectedErr:  "api call error",
+		should:         "handle wait-time formatting errors",
+		withClientWait: "not-a-duration-at-all",
+		expectedErr:    "time: invalid duration not-a-duration-at-all",
 	}, {
-		should:          "fail with no results",
-		withTags:        tagsForIdPrefix(validActionId),
-		withAPIResponse: []params.ActionResult{},
-		expectedErr:     `actions for identifier "` + validActionId + `" not found`,
+		should:            "timeout if result never comes",
+		withClientWait:    "3s",
+		withAPIDelay:      6 * time.Second,
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
+		withAPIResponse:   []params.ActionResult{{}},
+		expectedOutput: `
+status: pending
+timing:
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+  started: 2015-02-14 08:15:00 +0000 UTC
+`[1:],
 	}, {
-		should:          "error correctly with multiple results",
-		withTags:        tagsForIdPrefix(validActionId, validActionTagString),
-		withAPIResponse: []params.ActionResult{{}, {}},
-		expectedErr:     "too many results for action " + validActionId,
+		should:            "pass api error through properly",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
+		withAPIError:      "api call error",
+		expectedErr:       "api call error",
 	}, {
-		should:   "pass through an error from the API server",
-		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		should:            "fail with no tag matches",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId),
+		expectedErr:       `actions for identifier "` + validActionId + `" not found`,
+	}, {
+		should:            "fail with no results",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
+		withAPIResponse:   []params.ActionResult{},
+		expectedErr:       "no results for action " + validActionId,
+	}, {
+		should:            "error correctly with multiple results",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
+		withAPIResponse:   []params.ActionResult{{}, {}},
+		expectedErr:       "too many results for action " + validActionId,
+	}, {
+		should:            "pass through an error from the API server",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Error: common.ServerError(errors.New("an apiserver error")),
 		}},
 		expectedErr: "an apiserver error",
 	}, {
-		should:   "pretty-print action output",
-		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		should:            "pretty-print action output",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Status:  "complete",
 			Message: "oh dear",
@@ -116,8 +144,9 @@ timing:
   started: 2015-02-14 08:15:00 +0000 UTC
 `[1:],
 	}, {
-		should:   "pretty-print action output with no completed time",
-		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		should:            "pretty-print action output with no completed time",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Status: "pending",
 			Output: map[string]interface{}{
@@ -138,8 +167,9 @@ timing:
   started: 2015-02-14 08:15:00 +0000 UTC
 `[1:],
 	}, {
-		should:   "pretty-print action output with no enqueued time",
-		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		should:            "pretty-print action output with no enqueued time",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Status: "pending",
 			Output: map[string]interface{}{
@@ -160,8 +190,9 @@ timing:
   started: 2015-02-14 08:15:00 +0000 UTC
 `[1:],
 	}, {
-		should:   "pretty-print action output with no started time",
-		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		should:            "pretty-print action output with no started time",
+		withClientQueryID: validActionId,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Status: "pending",
 			Output: map[string]interface{}{
@@ -181,23 +212,59 @@ timing:
   completed: 2015-02-14 08:15:30 +0000 UTC
   enqueued: 2015-02-14 08:13:00 +0000 UTC
 `[1:],
+	}, {
+		should:            "set an appropriate timer and wait, get a result",
+		withClientQueryID: validActionId,
+		withClientWait:    "7s",
+		withAPIDelay:      4 * time.Second,
+		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
+		withAPIResponse: []params.ActionResult{{
+			Status: "completed",
+			Output: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
+		}},
+		expectedOutput: `
+results:
+  foo:
+    bar: baz
+status: completed
+timing:
+  completed: 2015-02-14 08:15:30 +0000 UTC
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+`[1:],
 	}}
 
 	for i, t := range tests {
 		c.Logf("test %d: should %s", i, t.should)
 		testRunHelper(
 			c, s,
-			makeFakeClient(t.withTags, t.withAPIResponse, t.withAPIError),
+			makeFakeClient(
+				t.withAPIDelay,
+				t.withTags,
+				t.withAPIResponse,
+				t.withAPIError),
 			t.expectedErr,
 			t.expectedOutput,
+			t.withClientWait,
+			t.withClientQueryID,
 		)
 	}
 }
 
-func testRunHelper(c *gc.C, s *FetchSuite, client *fakeAPIClient, expectedErr, expectedOutput string) {
+func testRunHelper(c *gc.C, s *FetchSuite, client *fakeAPIClient, expectedErr, expectedOutput, wait, query string) {
 	unpatch := s.BaseActionSuite.patchAPIClient(client)
 	defer unpatch()
-	ctx, err := testing.RunCommand(c, &action.FetchCommand{}, validActionId)
+	args := []string{query}
+	if wait != "" {
+		args = append(args, "--wait")
+		args = append(args, wait)
+	}
+	ctx, err := testing.RunCommand(c, &action.FetchCommand{}, args...)
 	if expectedErr != "" {
 		c.Check(err, gc.ErrorMatches, expectedErr)
 	} else {
@@ -206,8 +273,15 @@ func testRunHelper(c *gc.C, s *FetchSuite, client *fakeAPIClient, expectedErr, e
 	}
 }
 
-func makeFakeClient(tags params.FindTagsResults, response []params.ActionResult, errStr string) *fakeAPIClient {
+func makeFakeClient(
+	delay time.Duration,
+	tags params.FindTagsResults,
+	response []params.ActionResult,
+	errStr string,
+) *fakeAPIClient {
 	client := &fakeAPIClient{
+		delay:            time.NewTimer(delay),
+		timeout:          time.NewTimer(10 * time.Second),
 		actionTagMatches: tags,
 		actionResults:    response,
 	}

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -4,9 +4,11 @@
 package action_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/juju/cmd"
 	jujutesting "github.com/juju/testing"
@@ -108,9 +110,9 @@ var someCharmActions = &charm.Actions{
 // and 0..n given tags. This is useful for stubbing out the API and
 // ensuring that the API returns expected tags for a given id prefix.
 func tagsForIdPrefix(prefix string, tags ...string) params.FindTagsResults {
-	var entities []params.Entity
-	for _, t := range tags {
-		entities = append(entities, params.Entity{Tag: t})
+	entities := make([]params.Entity, len(tags))
+	for i, t := range tags {
+		entities[i] = params.Entity{Tag: t}
 	}
 	return params.FindTagsResults{Matches: map[string][]params.Entity{prefix: entities}}
 }
@@ -127,6 +129,8 @@ func setupValueFile(c *gc.C, dir, filename, value string) string {
 }
 
 type fakeAPIClient struct {
+	delay              *time.Timer
+	timeout            *time.Timer
 	actionResults      []params.ActionResult
 	enqueuedActions    params.Actions
 	actionsByReceivers []params.ActionsByReceiver
@@ -181,9 +185,31 @@ func (c *fakeAPIClient) ServiceCharmActions(params.Entity) (*charm.Actions, erro
 }
 
 func (c *fakeAPIClient) Actions(args params.Entities) (params.ActionResults, error) {
-	return params.ActionResults{
-		Results: c.actionResults,
-	}, c.apiErr
+	// If the test supplies a delay time too long, we'll return an error
+	// to prevent the test hanging.  If the given wait is up, then return
+	// the results; otherwise, return a pending status.
+
+	// First, wait for a split second to avoid timer problems.
+	tmp := time.NewTimer(0 * time.Second)
+	_ = <-tmp.C
+
+	select {
+	case _ = <-c.delay.C:
+		// The API delay timer is up.  Pass pre-canned results back.
+		return params.ActionResults{Results: c.actionResults}, c.apiErr
+	case _ = <-c.timeout.C:
+		// Timeout to prevent tests from hanging.
+		return params.ActionResults{}, errors.New("test timed out before wait time")
+	default:
+		// Timeout should only be nonzero in case we want to test
+		// pending behavior with a --wait flag on FetchCommand.
+		return params.ActionResults{Results: []params.ActionResult{{
+			Status:   params.ActionPending,
+			Output:   map[string]interface{}{},
+			Started:  time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+			Enqueued: time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+		}}}, nil
+	}
 }
 
 func (c *fakeAPIClient) FindActionTagsByPrefix(arg params.FindTags) (params.FindTagsResults, error) {

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -5,6 +5,7 @@ package action_test
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
@@ -70,7 +71,13 @@ func (s *StatusSuite) TestRun(c *gc.C) {
 }
 
 func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
-	fakeClient := &fakeAPIClient{actionTagMatches: tc.tags, actionResults: tc.results}
+	fakeClient := makeFakeClient(
+		0*time.Second, // No API delay
+		tc.tags,
+		tc.results,
+		"", // No API error
+	)
+
 	restore := s.patchAPIClient(fakeClient)
 	defer restore()
 


### PR DESCRIPTION
Add the --wait string flag to `juju action fetch`.  See updated help doc
for `juju action fetch` for more detail.  Defaults to -1s meaning
immediate return; 0 means indefinite wait; otherwise, assume seconds, or
parse a time.Duration.

(Review request: http://reviews.vapour.ws/r/1111/)