### PR TITLE
worker/uniter/storage: persistent local state

### DIFF
--- a/worker/uniter/storage/attachments.go
+++ b/worker/uniter/storage/attachments.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// Package storage contains the storage subsystem for the uniter, responding
+// to changes in storage attachments (lifecycle, volume/filesystem details)
+// by queuing hooks and managing the storage attachments' lifecycle.
 package storage
 
 import (

--- a/worker/uniter/storage/export_test.go
+++ b/worker/uniter/storage/export_test.go
@@ -24,6 +24,32 @@ type StorageHookQueue interface {
 	Context() (jujuc.ContextStorage, bool)
 }
 
+func StateAttached(s State) bool {
+	return s.(*stateFile).attached
+}
+
+func ValidateHook(tag names.StorageTag, attached bool, hi hook.Info) error {
+	st := &state{tag, attached}
+	return st.ValidateHook(hi)
+}
+
+func ReadStateFile(dirPath string, tag names.StorageTag) (d State, err error) {
+	state, err := readStateFile(dirPath, tag)
+	return state, err
+}
+
+func ReadAllStateFiles(dirPath string) (map[names.StorageTag]State, error) {
+	files, err := readAllStateFiles(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	states := make(map[names.StorageTag]State)
+	for tag, f := range files {
+		states[tag] = f
+	}
+	return states, nil
+}
+
 func NewStorageHookQueue(
 	unitTag names.UnitTag,
 	storageTag names.StorageTag,

--- a/worker/uniter/storage/state.go
+++ b/worker/uniter/storage/state.go
@@ -1,0 +1,156 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/worker/uniter/hook"
+)
+
+// state describes the state of a storage attachment.
+type state struct {
+	// storage is the tag of the storage attachment.
+	storage names.StorageTag
+
+	// attached records the uniter's knowledge of the
+	// storage attachment state.
+	attached bool
+}
+
+// ValidateHook returns an error if the supplied hook.Info does not represent
+// a valid change to the storage state. Hooks must always be validated
+// against the current state before they are run, to ensure that the system
+// meets its guarantees about hook execution order.
+func (s *state) ValidateHook(hi hook.Info) (err error) {
+	defer errors.DeferredAnnotatef(&err, "inappropriate %q hook for storage %q", hi.Kind, s.storage.Id())
+	if hi.StorageId != s.storage.Id() {
+		return fmt.Errorf("expected storage %q, got storage %q", s.storage.Id(), hi.StorageId)
+	}
+	switch hi.Kind {
+	case hooks.StorageAttached:
+		if s.attached {
+			return errors.New("storage already attached")
+		}
+	case hooks.StorageDetached: // TODO(axw) this should be "detaching"
+		if !s.attached {
+			return errors.New("storage not attached")
+		}
+	}
+	return nil
+}
+
+// stateFile is a filesystem-backed representation of the state of a
+// storage attachment. Concurrent modifications to the underlying state
+// file will have undefined consequences.
+type stateFile struct {
+	// path identifies the directory holding persistent state.
+	path string
+
+	// state is the cached state of the directory, which is guaranteed
+	// to be synchronized with the true state so long as no concurrent
+	// changes are made to the directory.
+	state
+}
+
+// readStateFile loads a stateFile from the subdirectory of dirPath named
+// for the supplied storage tag. If the directory does not exist, no error
+// is returned,
+func readStateFile(dirPath string, tag names.StorageTag) (d *stateFile, err error) {
+	filename := strings.Replace(tag.Id(), "/", "-", -1)
+	d = &stateFile{
+		filepath.Join(dirPath, filename),
+		state{storage: tag},
+	}
+	defer errors.DeferredAnnotatef(&err, "cannot load storage %q state from %q", tag.Id(), d.path)
+	if _, err := os.Stat(d.path); os.IsNotExist(err) {
+		return d, nil
+	} else if err != nil {
+		return nil, err
+	}
+	var info diskInfo
+	if err := utils.ReadYaml(d.path, &info); err != nil {
+		return nil, errors.Errorf("invalid storage state file %q: %v", d.path, err)
+	}
+	if info.Attached == nil {
+		return nil, errors.Errorf("invalid storage state file %q: missing 'attached'", d.path)
+	}
+	d.state.attached = *info.Attached
+	return d, nil
+}
+
+// readAllStateFiles loads and returns every stateFile persisted inside
+// the supplied dirPath. If dirPath does not exist, no error is returned.
+func readAllStateFiles(dirPath string) (files map[names.StorageTag]*stateFile, err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot load storage state from %q", dirPath)
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	fis, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	files = make(map[names.StorageTag]*stateFile)
+	for _, fi := range fis {
+		if fi.IsDir() {
+			continue
+		}
+		storageId := strings.Replace(fi.Name(), "-", "/", -1)
+		if !names.IsValidStorage(storageId) {
+			continue
+		}
+		tag := names.NewStorageTag(storageId)
+		f, err := readStateFile(dirPath, tag)
+		if err != nil {
+			return nil, err
+		}
+		files[tag] = f
+	}
+	return files, nil
+}
+
+// CommitHook atomically writes to disk the storage state change in hi.
+// It must be called after the respective hook was executed successfully.
+// CommitHook doesn't validate hi but guarantees that successive writes
+// of the same hi are idempotent.
+func (d *stateFile) CommitHook(hi hook.Info) (err error) {
+	defer errors.DeferredAnnotatef(&err, "failed to write %q hook info for %q on state directory", hi.Kind, hi.StorageId)
+	if hi.Kind == hooks.StorageDetached { // TODO(axw) should be detaching
+		return d.Remove()
+	}
+	attached := true
+	di := diskInfo{&attached}
+	if err := utils.WriteYaml(d.path, &di); err != nil {
+		return err
+	}
+	// If write was successful, update own state.
+	d.state.attached = true
+	return nil
+}
+
+// Remove removes the directory if it exists and is empty.
+func (d *stateFile) Remove() error {
+	if err := os.Remove(d.path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	// If atomic delete succeeded, update own state.
+	d.state.attached = false
+	return nil
+}
+
+// diskInfo defines the storage attachment data serialization.
+type diskInfo struct {
+	Attached *bool `yaml:"attached,omitempty"`
+}

--- a/worker/uniter/storage/state.go
+++ b/worker/uniter/storage/state.go
@@ -4,7 +4,6 @@
 package storage
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -35,7 +34,7 @@ type state struct {
 func (s *state) ValidateHook(hi hook.Info) (err error) {
 	defer errors.DeferredAnnotatef(&err, "inappropriate %q hook for storage %q", hi.Kind, s.storage.Id())
 	if hi.StorageId != s.storage.Id() {
-		return fmt.Errorf("expected storage %q, got storage %q", s.storage.Id(), hi.StorageId)
+		return errors.Errorf("expected storage %q, got storage %q", s.storage.Id(), hi.StorageId)
 	}
 	switch hi.Kind {
 	case hooks.StorageAttached:
@@ -65,7 +64,7 @@ type stateFile struct {
 
 // readStateFile loads a stateFile from the subdirectory of dirPath named
 // for the supplied storage tag. If the directory does not exist, no error
-// is returned,
+// is returned.
 func readStateFile(dirPath string, tag names.StorageTag) (d *stateFile, err error) {
 	filename := strings.Replace(tag.Id(), "/", "-", -1)
 	d = &stateFile{

--- a/worker/uniter/storage/state_test.go
+++ b/worker/uniter/storage/state_test.go
@@ -1,0 +1,201 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/storage"
+)
+
+type stateSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&stateSuite{})
+
+func writeFile(c *gc.C, path string, content string) {
+	err := ioutil.WriteFile(path, []byte(content), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func assertFileNotExist(c *gc.C, path string) {
+	_, err := os.Stat(path)
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+}
+
+func (s *stateSuite) TestReadAllStateFiles(c *gc.C) {
+	dir := c.MkDir()
+	writeFile(c, filepath.Join(dir, "data-0"), "attached: true")
+	// We don't currently ever write a file with attached=false,
+	// but test it for coverage in case of required changes.
+	writeFile(c, filepath.Join(dir, "data-1"), "attached: false")
+
+	states, err := storage.ReadAllStateFiles(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(states, gc.HasLen, 2)
+
+	state, ok := states[names.NewStorageTag("data/0")]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(storage.StateAttached(state), jc.IsTrue)
+
+	state, ok = states[names.NewStorageTag("data/1")]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(storage.StateAttached(state), jc.IsFalse)
+}
+
+func (s *stateSuite) TestReadAllStateFilesJunk(c *gc.C) {
+	dir := c.MkDir()
+	writeFile(c, filepath.Join(dir, "data-0"), "attached: true")
+	// data-extra-1 is not a valid storage ID, so it will
+	// be ignored by ReadAllStateFiles.
+	writeFile(c, filepath.Join(dir, "data-extra-1"), "attached: false")
+	// subdirs are ignored.
+	err := os.Mkdir(filepath.Join(dir, "data-1"), 0755)
+	c.Assert(err, jc.ErrorIsNil)
+
+	states, err := storage.ReadAllStateFiles(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(states, gc.HasLen, 1)
+	_, ok := states[names.NewStorageTag("data/0")]
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *stateSuite) TestReadAllStateFilesOneBadApple(c *gc.C) {
+	dir := c.MkDir()
+	writeFile(c, filepath.Join(dir, "data-0"), "rubbish")
+	_, err := storage.ReadAllStateFiles(dir)
+	c.Assert(err, gc.ErrorMatches, `cannot load storage state from ".*": cannot load storage "data/0" state from ".*": invalid storage state file ".*": missing 'attached'`)
+}
+
+func (s *stateSuite) TestReadAllStateFilesDirNotExist(c *gc.C) {
+	dir := filepath.Join(c.MkDir(), "doesnotexist")
+	states, err := storage.ReadAllStateFiles(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(states, gc.HasLen, 0)
+}
+
+func (s *stateSuite) TestReadAllStateFilesDirEmpty(c *gc.C) {
+	dir := c.MkDir()
+	states, err := storage.ReadAllStateFiles(dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(states, gc.HasLen, 0)
+}
+
+func (s *stateSuite) TestReadStateFileFileNotExist(c *gc.C) {
+	dir := c.MkDir()
+	state, err := storage.ReadStateFile(dir, names.NewStorageTag("data/0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(state, gc.NotNil)
+
+	data, err := ioutil.ReadFile(filepath.Join(dir, "data-0"))
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+
+	err = state.CommitHook(hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: "data-0",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	data, err = ioutil.ReadFile(filepath.Join(dir, "data-0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "attached: true\n")
+}
+
+func (s *stateSuite) TestReadStateFileDirNotExist(c *gc.C) {
+	dir := filepath.Join(c.MkDir(), "doesnotexist")
+	state, err := storage.ReadStateFile(dir, names.NewStorageTag("data/0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(state, gc.NotNil)
+
+	// CommitHook will fail if the directory does not exist. The uniter
+	// must ensure the directory is created before committing any hooks
+	// to the storage state.
+	err = state.CommitHook(hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: "data-0",
+	})
+	c.Assert(errors.Cause(err), jc.Satisfies, os.IsNotExist)
+}
+
+func (s *stateSuite) TestReadStateFileBadFormat(c *gc.C) {
+	dir := c.MkDir()
+	writeFile(c, filepath.Join(dir, "data-0"), "!@#")
+	_, err := storage.ReadStateFile(dir, names.NewStorageTag("data/0"))
+	c.Assert(err, gc.ErrorMatches, `cannot load storage "data/0" state from ".*": invalid storage state file ".*": YAML error: did not find expected whitespace or line break`)
+
+	writeFile(c, filepath.Join(dir, "data-0"), "icantbelieveitsnotattached: true\n")
+	_, err = storage.ReadStateFile(dir, names.NewStorageTag("data/0"))
+	c.Assert(err, gc.ErrorMatches, `cannot load storage "data/0" state from ".*": invalid storage state file ".*": missing 'attached'`)
+}
+
+func (s *stateSuite) TestCommitHook(c *gc.C) {
+	dir := c.MkDir()
+	state, err := storage.ReadStateFile(dir, names.NewStorageTag("data/0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(state, gc.NotNil)
+	stateFile := filepath.Join(dir, "data-0")
+
+	// CommitHook must be idempotent, so test each operation
+	// twice in a row.
+
+	for i := 0; i < 2; i++ {
+		err := state.CommitHook(hook.Info{
+			Kind:      hooks.StorageAttached,
+			StorageId: "data-0",
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(stateFile, jc.IsNonEmptyFile)
+	}
+
+	for i := 0; i < 2; i++ {
+		err := state.CommitHook(hook.Info{
+			Kind:      hooks.StorageDetached,
+			StorageId: "data-0",
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(stateFile, jc.DoesNotExist)
+	}
+}
+
+func (s *stateSuite) TestValidateHook(c *gc.C) {
+	const unattached = false
+	const attached = true
+
+	err := storage.ValidateHook(
+		names.NewStorageTag("data/0"), unattached,
+		hook.Info{Kind: hooks.StorageAttached, StorageId: "data/1"},
+	)
+	c.Assert(err, gc.ErrorMatches, `inappropriate "storage-attached" hook for storage "data/0": expected storage "data/0", got storage "data/1"`)
+
+	validate := func(attached bool, kind hooks.Kind) error {
+		return storage.ValidateHook(
+			names.NewStorageTag("data/0"), attached,
+			hook.Info{Kind: kind, StorageId: "data/0"},
+		)
+	}
+	assertValidates := func(attached bool, kind hooks.Kind) {
+		err := validate(attached, kind)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	assertValidateFails := func(attached bool, kind hooks.Kind, expect string) {
+		err := validate(attached, kind)
+		c.Assert(err, gc.ErrorMatches, expect)
+	}
+
+	assertValidates(false, hooks.StorageAttached)
+	assertValidates(true, hooks.StorageDetached)
+	assertValidateFails(false, hooks.StorageDetached, `inappropriate "storage-detached" hook for storage "data/0": storage not attached`)
+	assertValidateFails(true, hooks.StorageAttached, `inappropriate "storage-attached" hook for storage "data/0": storage already attached`)
+}


### PR DESCRIPTION
This branch introduces the storage "state file",
a YAML, file-based persistent local state for
storage attachments in the uniter. The storage
subsystem of the uniter will use this to maintain
knowledge of storage across restarts so that it
can generate storage hooks in the correct order.

(Review request: http://reviews.vapour.ws/r/1112/)