### PR TITLE
worker/uniter/storage: implement hook source

### DIFF
--- a/worker/uniter/storage/export_test.go
+++ b/worker/uniter/storage/export_test.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type State interface {
+	hook.Committer
+	hook.Validator
+}
+
+type StorageHookQueue interface {
+	Empty() bool
+	Next() hook.Info
+	Pop()
+	Update(attachment params.StorageAttachment) error
+	Context() (jujuc.ContextStorage, bool)
+}
+
+func NewStorageHookQueue(
+	unitTag names.UnitTag,
+	storageTag names.StorageTag,
+	attached bool,
+) StorageHookQueue {
+	return &storageHookQueue{
+		unitTag:    unitTag,
+		storageTag: storageTag,
+		attached:   attached,
+	}
+}
+
+func NewStorageSource(
+	st StorageAccessor,
+	unitTag names.UnitTag,
+	storageTag names.StorageTag,
+	attached bool,
+) (hook.Source, error) {
+	source, err := newStorageSource(st, unitTag, storageTag, attached)
+	return source, err
+}

--- a/worker/uniter/storage/mock_test.go
+++ b/worker/uniter/storage/mock_test.go
@@ -1,0 +1,98 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"time"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/hook"
+)
+
+type mockStorageAccessor struct {
+	watchStorageAttachment func(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
+	storageAttachment      func(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
+	unitStorageAttachments func(names.UnitTag) ([]params.StorageAttachment, error)
+	ensureDead             func(names.StorageTag, names.UnitTag) error
+	remove                 func(names.StorageTag, names.UnitTag) error
+}
+
+func (m *mockStorageAccessor) WatchStorageAttachment(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
+	return m.watchStorageAttachment(s, u)
+}
+
+func (m *mockStorageAccessor) StorageAttachment(s names.StorageTag, u names.UnitTag) (params.StorageAttachment, error) {
+	return m.storageAttachment(s, u)
+}
+
+func (m *mockStorageAccessor) UnitStorageAttachments(u names.UnitTag) ([]params.StorageAttachment, error) {
+	return m.unitStorageAttachments(u)
+}
+
+func (m *mockStorageAccessor) EnsureStorageAttachmentDead(s names.StorageTag, u names.UnitTag) error {
+	return m.ensureDead(s, u)
+}
+
+func (m *mockStorageAccessor) RemoveStorageAttachment(s names.StorageTag, u names.UnitTag) error {
+	return m.remove(s, u)
+}
+
+type mockNotifyWatcher struct {
+	tomb    tomb.Tomb
+	changes chan struct{}
+}
+
+func newMockNotifyWatcher() *mockNotifyWatcher {
+	m := &mockNotifyWatcher{
+		changes: make(chan struct{}, 1),
+	}
+	go func() {
+		<-m.tomb.Dying()
+		close(m.changes)
+		m.tomb.Kill(tomb.ErrDying)
+		m.tomb.Done()
+	}()
+	return m
+}
+
+func (m *mockNotifyWatcher) Changes() <-chan struct{} {
+	return m.changes
+}
+
+func (m *mockNotifyWatcher) Stop() error {
+	m.tomb.Kill(nil)
+	return m.tomb.Wait()
+}
+
+func (m *mockNotifyWatcher) Err() error {
+	return m.tomb.Err()
+}
+
+func assertNoHooks(c *gc.C, hooks <-chan hook.Info) {
+	select {
+	case <-hooks:
+		c.Fatal("unexpected hook")
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+func waitOneHook(c *gc.C, hooks <-chan hook.Info) hook.Info {
+	var hi hook.Info
+	var ok bool
+	select {
+	case hi, ok = <-hooks:
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for hook")
+	}
+	assertNoHooks(c, hooks)
+	return hi
+}

--- a/worker/uniter/storage/source.go
+++ b/worker/uniter/storage/source.go
@@ -1,0 +1,226 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"gopkg.in/juju/charm.v4/hooks"
+	"launchpad.net/tomb"
+
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+// storageSource is a hook source that generates storage hooks for
+// a single storage attachment.
+type storageSource struct {
+	tomb tomb.Tomb
+
+	*storageHookQueue
+	st      StorageAccessor
+	watcher apiwatcher.NotifyWatcher
+	changes chan hook.SourceChange
+}
+
+// storageHookQueue implements a subset of hook.Source, separated from
+// storageSource for simpler testing.
+type storageHookQueue struct {
+	unitTag    names.UnitTag
+	storageTag names.StorageTag
+
+	// attached records whether or not the storage-attached
+	// hook has been executed.
+	attached bool
+
+	// hookInfo is the next hook.Info to return, if non-nil.
+	hookInfo *hook.Info
+
+	// context contains the details of the storage attachment.
+	context *contextStorage
+}
+
+// newStorageSource creates a hook source that watches for changes to,
+// and generates storage hooks for, a single storage attachment.
+func newStorageSource(
+	st StorageAccessor,
+	unitTag names.UnitTag,
+	storageTag names.StorageTag,
+	attached bool,
+) (*storageSource, error) {
+	w, err := st.WatchStorageAttachment(storageTag, unitTag)
+	if err != nil {
+		return nil, errors.Annotate(err, "watching storage attachment")
+	}
+	s := &storageSource{
+		storageHookQueue: &storageHookQueue{
+			unitTag:    unitTag,
+			storageTag: storageTag,
+			attached:   attached,
+		},
+		st:      st,
+		watcher: w,
+		changes: make(chan hook.SourceChange),
+	}
+	go func() {
+		defer s.tomb.Done()
+		defer watcher.Stop(w, &s.tomb)
+		s.tomb.Kill(s.loop())
+	}()
+	return s, nil
+}
+
+func (s *storageSource) loop() error {
+	defer close(s.changes)
+
+	var inChanges <-chan struct{}
+	var outChanges chan<- hook.SourceChange
+	var outChange hook.SourceChange
+	ready := make(chan struct{}, 1)
+	ready <- struct{}{}
+	for {
+		select {
+		case <-s.tomb.Dying():
+			return tomb.ErrDying
+		case <-ready:
+			inChanges = s.watcher.Changes()
+		case _, ok := <-inChanges:
+			logger.Debugf("got storage attachment change")
+			if !ok {
+				return tomb.ErrDying
+			}
+			inChanges = nil
+			outChanges = s.changes
+			outChange = func() error {
+				defer func() {
+					ready <- struct{}{}
+				}()
+				logger.Debugf("processing storage source change")
+				return s.update()
+			}
+		case outChanges <- outChange:
+			logger.Debugf("sent storage source change")
+			outChanges = nil
+			outChange = nil
+		}
+	}
+}
+
+// Changes is part of the hook.Source interface.
+func (s *storageSource) Changes() <-chan hook.SourceChange {
+	return s.changes
+}
+
+// Stop is part of the hook.Source interface.
+func (s *storageSource) Stop() error {
+	s.tomb.Kill(nil)
+	watcher.Stop(s.watcher, &s.tomb)
+	return s.tomb.Wait()
+}
+
+// update is called when hook.SourceChanges are applied.
+func (s *storageSource) update() error {
+	attachment, err := s.st.StorageAttachment(s.storageTag, s.unitTag)
+	if params.IsCodeNotFound(err) {
+		// The storage attachment was removed from state, which
+		// implies that the storage has been detached already.
+		logger.Debugf("storage attachment %q not found", s.storageTag.Id())
+		return nil
+	} else if params.IsCodeNotProvisioned(err) {
+		logger.Debugf("storage attachment %q not provisioned yet", s.storageTag.Id())
+		return nil
+	} else if err != nil {
+		logger.Debugf("error refreshing storage details: %v", err)
+		return errors.Annotate(err, "refreshing storage details")
+	}
+	return s.storageHookQueue.Update(attachment)
+}
+
+// Empty is part of the hook.Source interface.
+func (s *storageHookQueue) Empty() bool {
+	return s.hookInfo == nil
+}
+
+// Next is part of the hook.Source interface.
+func (s *storageHookQueue) Next() hook.Info {
+	if s.Empty() {
+		panic("source is empty")
+	}
+	return *s.hookInfo
+}
+
+// Pop is part of the hook.Source interface.
+func (s *storageHookQueue) Pop() {
+	if s.Empty() {
+		panic("source is empty")
+	}
+	if s.hookInfo.Kind == hooks.StorageAttached {
+		s.attached = true
+	}
+	s.hookInfo = nil
+}
+
+// Update updates the hook queue with the freshly acquired information about
+// the storage attachment.
+func (s *storageHookQueue) Update(attachment params.StorageAttachment) error {
+	switch attachment.Life {
+	case params.Alive:
+		if s.attached {
+			// Storage attachments currently do not change
+			// (apart from lifecycle) after being provisioned.
+			// We don't process unprovisioned storage here,
+			// so there's nothing to do.
+			return nil
+		}
+	case params.Dying:
+		if !s.attached {
+			// Nothing to do: attachment is dying, but
+			// the storage-attached hook has not been
+			// consumed.
+			s.hookInfo = nil
+			return nil
+		}
+	case params.Dead:
+		// Storage must been Dying to become Dead;
+		// no further action is required.
+		return nil
+	}
+
+	// Set the storage context when the first hook is generated
+	// for this storager. Later, when we need to handle changing
+	// storage, we'll need to have a cache in the runner like
+	// we have for relations.
+	if s.context == nil {
+		s.context = &contextStorage{
+			tag:      s.storageTag,
+			kind:     storage.StorageKind(attachment.Kind),
+			location: attachment.Location,
+		}
+	}
+
+	if s.hookInfo == nil {
+		s.hookInfo = &hook.Info{
+			StorageId: s.storageTag.Id(),
+		}
+	}
+	if attachment.Life == params.Alive {
+		s.hookInfo.Kind = hooks.StorageAttached
+	} else {
+		// TODO(axw) this should be Detaching, not Detached.
+		s.hookInfo.Kind = hooks.StorageDetached
+	}
+	logger.Debugf("queued hook: %v", s.hookInfo)
+	return nil
+}
+
+func (s *storageHookQueue) Context() (jujuc.ContextStorage, bool) {
+	if s.context != nil {
+		return s.context, true
+	}
+	return nil, false
+}

--- a/worker/uniter/storage/source.go
+++ b/worker/uniter/storage/source.go
@@ -218,6 +218,9 @@ func (s *storageHookQueue) Update(attachment params.StorageAttachment) error {
 	return nil
 }
 
+// Context returns the ContextStorage for the storage that this hook queue
+// corresponds to, and whether there is any context available yet. There
+// will be context beginning from when the first hook is queued.
 func (s *storageHookQueue) Context() (jujuc.ContextStorage, bool) {
 	if s.context != nil {
 		return s.context, true

--- a/worker/uniter/storage/source_test.go
+++ b/worker/uniter/storage/source_test.go
@@ -1,0 +1,230 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"time"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	corestorage "github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/storage"
+)
+
+const initiallyUnattached = false
+const initiallyAttached = true
+
+type storageHookQueueSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&storageHookQueueSuite{})
+
+func newHookQueue(attached bool) storage.StorageHookQueue {
+	return storage.NewStorageHookQueue(
+		names.NewUnitTag("mysql/0"),
+		names.NewStorageTag("data/0"),
+		attached,
+	)
+}
+
+func updateHookQueue(c *gc.C, q storage.StorageHookQueue, life params.Life) {
+	err := q.Update(params.StorageAttachment{
+		Life:     life,
+		Kind:     params.StorageKindBlock,
+		Location: "/dev/sdb",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueAttachedHook(c *gc.C) {
+	q := newHookQueue(initiallyUnattached)
+	updateHookQueue(c, q, params.Alive)
+	c.Assert(q.Empty(), jc.IsFalse)
+	c.Assert(q.Next(), gc.Equals, hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: "data/0",
+	})
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueAlreadyAttached(c *gc.C) {
+	q := newHookQueue(initiallyAttached)
+	updateHookQueue(c, q, params.Alive)
+	// Already attached, so no hooks should have been queued.
+	c.Assert(q.Empty(), jc.IsTrue)
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueAttachedDetach(c *gc.C) {
+	q := newHookQueue(initiallyAttached)
+	updateHookQueue(c, q, params.Dying)
+	c.Assert(q.Empty(), jc.IsFalse)
+	c.Assert(q.Next(), gc.Equals, hook.Info{
+		Kind:      hooks.StorageDetached,
+		StorageId: "data/0",
+	})
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueUnattachedDetach(c *gc.C) {
+	q := newHookQueue(initiallyUnattached)
+	updateHookQueue(c, q, params.Dying)
+	// the storage wasn't attached, so Dying short-circuits.
+	c.Assert(q.Empty(), jc.IsTrue)
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueAttachedUnconsumedDetach(c *gc.C) {
+	q := newHookQueue(initiallyUnattached)
+	updateHookQueue(c, q, params.Alive)
+	c.Assert(q.Next(), gc.Equals, hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: "data/0",
+	})
+	// don't consume the storage-attached hook; it should then be unqueued
+	updateHookQueue(c, q, params.Dying)
+	// since the storage-attached hook wasn't consumed, Dying short-circuits.
+	c.Assert(q.Empty(), jc.IsTrue)
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueAttachDetach(c *gc.C) {
+	q := newHookQueue(initiallyUnattached)
+	updateHookQueue(c, q, params.Alive)
+	q.Pop()
+	updateHookQueue(c, q, params.Dying)
+	c.Assert(q.Empty(), jc.IsFalse)
+	c.Assert(q.Next(), gc.Equals, hook.Info{
+		Kind:      hooks.StorageDetached,
+		StorageId: "data/0",
+	})
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueDead(c *gc.C) {
+	q := newHookQueue(initiallyAttached)
+	updateHookQueue(c, q, params.Dying)
+	q.Pop()
+	updateHookQueue(c, q, params.Dead)
+	// Dead does not cause any hook to be queued.
+	c.Assert(q.Empty(), jc.IsTrue)
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueContext(c *gc.C) {
+	q := newHookQueue(initiallyUnattached)
+	_, ok := q.Context()
+	c.Assert(ok, jc.IsFalse)
+
+	err := q.Update(params.StorageAttachment{
+		Life:     params.Alive,
+		Kind:     params.StorageKindFilesystem,
+		Location: "/srv",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(q.Empty(), jc.IsFalse)
+
+	ctx, ok := q.Context()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(ctx, gc.NotNil)
+	c.Assert(ctx.Tag(), gc.Equals, names.NewStorageTag("data/0"))
+	c.Assert(ctx.Kind(), gc.Equals, corestorage.StorageKindFilesystem)
+	c.Assert(ctx.Location(), gc.Equals, "/srv")
+}
+
+func (s *storageHookQueueSuite) TestStorageHookQueueEmpty(c *gc.C) {
+	q := newHookQueue(initiallyAttached)
+	c.Assert(q.Empty(), jc.IsTrue)
+	c.Assert(q.Next, gc.PanicMatches, "source is empty")
+	c.Assert(q.Pop, gc.PanicMatches, "source is empty")
+}
+
+func (s *storageHookQueueSuite) TestStorageSourceStop(c *gc.C) {
+	unitTag := names.NewUnitTag("mysql/0")
+	storageTag := names.NewStorageTag("data/0")
+
+	// Simulate remote state returning a single Alive storage attachment.
+	st := &mockStorageAccessor{
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
+			return newMockNotifyWatcher(), nil
+		},
+	}
+
+	const initiallyUnattached = false
+	source, err := storage.NewStorageSource(st, unitTag, storageTag, initiallyUnattached)
+	c.Assert(err, jc.ErrorIsNil)
+	err = source.Stop()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *storageHookQueueSuite) TestStorageSourceUpdateErrors(c *gc.C) {
+	unitTag := names.NewUnitTag("mysql/0")
+	storageTag := names.NewStorageTag("data/0")
+
+	// Simulate remote state returning a single Alive storage attachment.
+	var calls int
+	w := newMockNotifyWatcher()
+	st := &mockStorageAccessor{
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
+			return w, nil
+		},
+		storageAttachment: func(s names.StorageTag, u names.UnitTag) (params.StorageAttachment, error) {
+			calls++
+			switch calls {
+			case 1:
+				return params.StorageAttachment{}, &params.Error{Code: params.CodeNotFound}
+			case 2:
+				return params.StorageAttachment{}, &params.Error{Code: params.CodeNotProvisioned}
+			case 3:
+				// This error should cause the source to stop with an error.
+				return params.StorageAttachment{}, &params.Error{
+					Code:    params.CodeUnauthorized,
+					Message: "unauthorized",
+				}
+			}
+			panic("unexpected call to StorageAttachment")
+		},
+	}
+
+	const initiallyUnattached = false
+	source, err := storage.NewStorageSource(st, unitTag, storageTag, initiallyUnattached)
+	c.Assert(err, jc.ErrorIsNil)
+
+	assertNoSourceChange := func() {
+		select {
+		case <-source.Changes():
+			c.Fatal("unexpected source change")
+		case <-time.After(testing.ShortWait):
+		}
+	}
+	waitSourceChange := func() hook.SourceChange {
+		select {
+		case ch, ok := <-source.Changes():
+			c.Assert(ok, jc.IsTrue)
+			assertNoSourceChange()
+			return ch
+		case <-time.After(testing.LongWait):
+			c.Fatal("timed out waiting for source change")
+			panic("unreachable")
+		}
+	}
+
+	assertNoSourceChange()
+
+	// First change is "NotFound": not an error.
+	w.changes <- struct{}{}
+	change := waitSourceChange()
+	c.Assert(change(), jc.ErrorIsNil)
+
+	// Second change is "NotProvisioned": not an error.
+	w.changes <- struct{}{}
+	change = waitSourceChange()
+	c.Assert(change(), jc.ErrorIsNil)
+
+	// Third change is "Unauthorized": this *is* an error.
+	w.changes <- struct{}{}
+	change = waitSourceChange()
+	c.Assert(change(), gc.ErrorMatches, "refreshing storage details: unauthorized")
+}


### PR DESCRIPTION
This branch introduces the storage hook source,
an implementation of worker/uniter/hook.Source.
The hook source watches storage attachments and
queues storage hooks in response to interesting
changes (unprovisioned->provisioned, alive->dying).

(Review request: http://reviews.vapour.ws/r/1113/)