### PR TITLE
{api,apiserver}/uniter: EnsureDead, Remove storage

### DIFF
--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -123,3 +123,40 @@ func (sa *StorageAccessor) WatchStorageAttachment(storageTag names.StorageTag, u
 	w := watcher.NewNotifyWatcher(sa.facade.RawAPICaller(), result)
 	return w, nil
 }
+
+// EnsureStorageAttachmentDead ensures that the storage attachment
+// with the specified unit and storage tags is Dead.
+func (sa *StorageAccessor) EnsureStorageAttachmentDead(storageTag names.StorageTag, unitTag names.UnitTag) error {
+	return sa.ensureDeadOrRemoveStorageAttachment("EnsureStorageAttachmentsDead", storageTag, unitTag)
+}
+
+// RemoveStorageAttachment removes the storage attachment with the
+// specified unit and storage tags from state. This method is only
+// expected to succeed if the storage attachment is Dead.
+func (sa *StorageAccessor) RemoveStorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) error {
+	return sa.ensureDeadOrRemoveStorageAttachment("RemoveStorageAttachments", storageTag, unitTag)
+}
+
+func (sa *StorageAccessor) ensureDeadOrRemoveStorageAttachment(
+	method string, storageTag names.StorageTag, unitTag names.UnitTag,
+) error {
+	var results params.ErrorResults
+	args := params.StorageAttachmentIds{
+		Ids: []params.StorageAttachmentId{{
+			StorageTag: storageTag.String(),
+			UnitTag:    unitTag.String(),
+		}},
+	}
+	err := sa.facade.FacadeCall(method, args, &results)
+	if err != nil {
+		return err
+	}
+	if len(results.Results) != 1 {
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -170,3 +170,55 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 	c.Check(called, jc.IsTrue)
 	c.Assert(attachment, gc.DeepEquals, storageAttachment)
 }
+
+func (s *storageSuite) TestEnsureStorageAttachmentDead(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Uniter")
+		c.Check(version, gc.Equals, 2)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "EnsureStorageAttachmentsDead")
+		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
+			Ids: []params.StorageAttachmentId{{
+				StorageTag: "storage-data-0",
+				UnitTag:    "unit-mysql-0",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "yessirilikeit"},
+			}},
+		}
+		return nil
+	})
+
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	err := st.EnsureStorageAttachmentDead(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
+	c.Check(err, gc.ErrorMatches, "yessirilikeit")
+}
+
+func (s *storageSuite) TestRemoveStorageAttachment(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Uniter")
+		c.Check(version, gc.Equals, 2)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RemoveStorageAttachments")
+		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
+			Ids: []params.StorageAttachmentId{{
+				StorageTag: "storage-data-0",
+				UnitTag:    "unit-mysql-0",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "yoink"},
+			}},
+		}
+		return nil
+	})
+
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	err := st.RemoveStorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
+	c.Check(err, gc.ErrorMatches, "yoink")
+}

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -11,6 +11,8 @@ import (
 )
 
 type storageStateInterface interface {
+	EnsureStorageAttachmentDead(names.StorageTag, names.UnitTag) error
+	RemoveStorageAttachment(names.StorageTag, names.UnitTag) error
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)


### PR DESCRIPTION
This branch adds the EnsureStorageAttachmentsDead
and RemoveStorageAttachments methods to the uniter
API, server and client. These methods will be used
by the uniter to manage the lifecycle of storage
attachments.

(Review request: http://reviews.vapour.ws/r/1114/)