### PR TITLE
State: Make username checks case insensitive

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -230,7 +230,7 @@ func (st *State) EnvironUUID() string {
 
 // userEnvNameIndex returns a string to be used as a userenvnameC unique index.
 func userEnvNameIndex(username, envName string) string {
-	return username + ":" + envName
+	return strings.ToLower(username) + ":" + envName
 }
 
 // EnsureEnvironmentRemoved returns an error if any multi-enviornment

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -79,10 +79,8 @@ func (s *StateSuite) TestIsStateServer(c *gc.C) {
 }
 
 func (s *StateSuite) TestUserEnvNameIndex(c *gc.C) {
-	username := "bob"
-	envName := "testing"
-	index := state.UserEnvNameIndex(username, envName)
-	c.Assert(index, gc.Equals, username+":"+envName)
+	index := state.UserEnvNameIndex("BoB", "testing")
+	c.Assert(index, gc.Equals, "bob:testing")
 }
 
 func (s *StateSuite) TestDocID(c *gc.C) {

--- a/state/user_internal_test.go
+++ b/state/user_internal_test.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/names"
+	gc "gopkg.in/check.v1"
+)
+
+type internalUserSuite struct {
+	internalStateSuite
+}
+
+var _ = gc.Suite(&internalUserSuite{})
+
+func (s *internalUserSuite) TestCreateInitialUserOp(c *gc.C) {
+	tag := names.NewUserTag("AdMiN")
+	op := createInitialUserOp(nil, tag, "abc")
+	c.Assert(op.Id, gc.Equals, "admin")
+
+	doc := op.Insert.(*userDoc)
+	c.Assert(doc.DocID, gc.Equals, "admin")
+	c.Assert(doc.Name, gc.Equals, "AdMiN")
+}
+
+func (s *internalUserSuite) TestCaseNameVsId(c *gc.C) {
+	user, err := s.state.AddUser(
+		"boB", "ignored", "ignored", "ignored")
+	c.Assert(err, gc.IsNil)
+	c.Assert(user.Name(), gc.Equals, "boB")
+	c.Assert(user.doc.DocID, gc.Equals, "bob")
+}

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -51,6 +51,12 @@ func stateStepsFor123() []Step {
 			run: func(context Context) error {
 				return state.AddUniqueOwnerEnvNameForEnvirons(context.State())
 			},
+		}, &upgradeStep{
+			description: "add name field to users and lowercase _id field",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddNameFieldLowerCaseIdOfUsers(context.State())
+			},
 		},
 	)
 	return steps

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -28,6 +28,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 		"migrate envuuid to env-uuid in envUsersC",
 		"move blocks from environment to state",
 		"insert userenvnameC doc for each environment",
+		"add name field to users and lowercase _id field",
 	}
 	assertStateSteps(c, version.MustParse("1.23.0"), expected)
 }


### PR DESCRIPTION
Add a new "name" field to  state.userDoc and migrate the value of
"_id" to it. Then lower case "_id". Ensure no more that one user can be
created with the same, case insensitive, name and that state.User() 
searches with a lowercased name. Update userenvnameC to
store a lower cased username.

(Review request: http://reviews.vapour.ws/r/1115/)