### PR TITLE
state: use errors.Cause in IsNotAssigned

### DIFF
--- a/state/unit.go
+++ b/state/unit.go
@@ -977,7 +977,7 @@ func (e *NotAssignedError) Error() string {
 
 // IsNotAssigned verifies that err is an instance of NotAssignedError
 func IsNotAssigned(err error) bool {
-	_, ok := err.(*NotAssignedError)
+	_, ok := errors.Cause(err).(*NotAssignedError)
 	return ok
 }
 

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1059,15 +1059,15 @@ func (s *UnitSuite) TestOpenedPorts(c *gc.C) {
 	// Verify ports can be opened and closed only when the unit has
 	// assigned machine.
 	err := s.unit.OpenPort("tcp", 10)
-	c.Assert(errors.Cause(err), jc.Satisfies, state.IsNotAssigned)
+	c.Assert(err, jc.Satisfies, state.IsNotAssigned)
 	err = s.unit.OpenPorts("tcp", 10, 20)
-	c.Assert(errors.Cause(err), jc.Satisfies, state.IsNotAssigned)
+	c.Assert(err, jc.Satisfies, state.IsNotAssigned)
 	err = s.unit.ClosePort("tcp", 10)
-	c.Assert(errors.Cause(err), jc.Satisfies, state.IsNotAssigned)
+	c.Assert(err, jc.Satisfies, state.IsNotAssigned)
 	err = s.unit.ClosePorts("tcp", 10, 20)
-	c.Assert(errors.Cause(err), jc.Satisfies, state.IsNotAssigned)
+	c.Assert(err, jc.Satisfies, state.IsNotAssigned)
 	open, err := s.unit.OpenedPorts()
-	c.Assert(errors.Cause(err), jc.Satisfies, state.IsNotAssigned)
+	c.Assert(err, jc.Satisfies, state.IsNotAssigned)
 	c.Assert(open, gc.HasLen, 0)
 
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)


### PR DESCRIPTION
There was a change in PR 1707 that causes the
megawatcher to fail if the unit is not yet assigned to
a machine. The cause is that a call to errors.Cause was
removed in back-porting a fix from master, but
IsNotAssigned does not do this in 1.22 as it does on
master.

This branch changes IsNotAssigned to call errors.Cause.

Fixes https://bugs.launchpad.net/juju-core/+bug/1430049

(Review request: http://reviews.vapour.ws/r/1117/)