### PR TITLE
Fixed lp:1426394 and lp:1391066

### DIFF
--- a/worker/uniter/filter/filter.go
+++ b/worker/uniter/filter/filter.go
@@ -468,7 +468,6 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 		case f.outConfig <- nothing:
 			filterLogger.Debugf("sent config event")
 			f.outConfig = nil
-			seenConfigChange = false
 		case f.outAction <- f.nextAction:
 			f.nextAction = f.getNextAction()
 			filterLogger.Debugf("sent action event")
@@ -487,8 +486,6 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 		// Handle explicit requests.
 		case curl := <-f.setCharm:
 			filterLogger.Debugf("changing charm to %q", curl)
-			configChanges = nil
-			seenConfigChange = false
 			// We need to restart the config watcher after setting the
 			// charm, because service config settings are distinct for
 			// different service charms.

--- a/worker/uniter/filter/filter.go
+++ b/worker/uniter/filter/filter.go
@@ -468,6 +468,7 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 		case f.outConfig <- nothing:
 			filterLogger.Debugf("sent config event")
 			f.outConfig = nil
+			seenConfigChange = false
 		case f.outAction <- f.nextAction:
 			f.nextAction = f.getNextAction()
 			filterLogger.Debugf("sent action event")
@@ -486,6 +487,8 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 		// Handle explicit requests.
 		case curl := <-f.setCharm:
 			filterLogger.Debugf("changing charm to %q", curl)
+			configChanges = nil
+			seenConfigChange = false
 			// We need to restart the config watcher after setting the
 			// charm, because service config settings are distinct for
 			// different service charms.


### PR DESCRIPTION
Intermittent test failures occur in the uniter/filter suite, most
commonly: TestConfigEvents and TestConfigAndAddressEventsDiscarded but
some other tests also fail (TestActionsEvents, TestMeterStatusEvents). The 
common cause I think is a race condition around state and apiserver watchers
used by the filter and in the test. There's no easy solution to this except refactoring
the filter and its tests to use mockable watchers so the sequence of checked events
can be deterministic.

What I did was to improve and fix a few of the filter tests which were making
incorrect or insufficient assumptions. In a few places the checks made by the
tests were relaxed a bit to ensure tests pass more reliably in stressful conditions,
while still running quickly and covering the usual cases the filter cares about.
Also improved the testing asserters used to test the watchers.

I've tested this with the following command, run inside worker/uniter/filter:
time go test -c && for i in `seq 50`; do ./filter.test & sleep 0.01; done

Before the fix, even with 'seq 10' above I was able to reliably
reproduce one or more issues. Now with 50 mongods and filter.test my
machine lags considerably, but I cannot reliably reproduce the original
failures anymore (or very rarely - 1-3 out of 50). Considering the heavy
load my machine was under during that test, I believe it makes the run
time conditions very similar to the underpowered CI VMs.

(Review request: http://reviews.vapour.ws/r/1118/)