### PR TITLE
Various tests fixes for windows

### DIFF
--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -63,7 +63,10 @@ func UnpackTools(dataDir string, tools *coretools.Tools, r io.Reader) (err error
 	if err != nil {
 		return err
 	}
-	defer os.Remove(f.Name())
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
 	// TODO(wallyworld) - 2013-09-24 bug=1229512
 	// When we can ensure all tools records have valid checksums recorded,
 	// we can remove this test short circuit.

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -97,7 +97,10 @@ func (s *charmsSuite) TestUploadFailsWithInvalidZip(c *gc.C) {
 	// Create an empty file.
 	tempFile, err := ioutil.TempFile(c.MkDir(), "charm")
 	c.Assert(err, jc.ErrorIsNil)
-
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	}()
 	// Pretend we upload a zip by setting the Content-Type, so we can
 	// check the error at extraction time later.
 	resp, err := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), true, tempFile.Name())
@@ -142,8 +145,10 @@ func (s *charmsSuite) TestUploadRespectsLocalRevision(c *gc.C) {
 	// Now bundle the dir.
 	tempFile, err := ioutil.TempFile(c.MkDir(), "charm")
 	c.Assert(err, jc.ErrorIsNil)
-	defer tempFile.Close()
-	defer os.Remove(tempFile.Name())
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	}()
 	err = dir.ArchiveTo(tempFile)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -232,8 +237,10 @@ func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
 	dir.Path = rootDir
 	tempFile, err := ioutil.TempFile(c.MkDir(), "charm")
 	c.Assert(err, jc.ErrorIsNil)
-	defer tempFile.Close()
-	defer os.Remove(tempFile.Name())
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	}()
 	err = dir.ArchiveTo(tempFile)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/environment/create_test.go
+++ b/cmd/juju/environment/create_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v1"
 	"io/ioutil"
@@ -163,7 +164,8 @@ func (s *createSuite) TestConfigFileFormatError(c *gc.C) {
 
 func (s *createSuite) TestConfigFileDoesntExist(c *gc.C) {
 	_, err := s.run(c, "test", "--config", "missing-file")
-	c.Assert(err, gc.ErrorMatches, `open .* no such file or directory`)
+	errMsg := ".*" + utils.NoSuchFileErrRegexp
+	c.Assert(err, gc.ErrorMatches, errMsg)
 }
 
 func (s *createSuite) TestConfigValuePrecedence(c *gc.C) {

--- a/cmd/plugins/local/main_test.go
+++ b/cmd/plugins/local/main_test.go
@@ -1,6 +1,8 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !windows
+
 package local_test
 
 import (

--- a/cmd/plugins/local/package_test.go
+++ b/cmd/plugins/local/package_test.go
@@ -1,6 +1,8 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !windows
+
 package local_test
 
 import (

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -34,6 +34,13 @@ import (
 	"github.com/juju/juju/version"
 )
 
+var (
+	jujuLogDir         = path.Join(logDir, "juju")
+	logDir             = must(paths.LogDir("precise"))
+	dataDir            = must(paths.DataDir("precise"))
+	cloudInitOutputLog = path.Join(logDir, "cloud-init-output.log")
+)
+
 // Use local suite since this file lives in the ec2 package
 // for testing internals.
 type cloudinitSuite struct {
@@ -89,8 +96,8 @@ func minimalMachineConfig(tweakers ...func(cloudinit.MachineConfig)) cloudinit.M
 			EnvironTag: testing.EnvironmentTag,
 		},
 		Constraints:             envConstraints,
-		DataDir:                 environs.DataDir,
-		LogDir:                  agent.DefaultLogDir,
+		DataDir:                 dataDir,
+		LogDir:                  logDir,
 		Jobs:                    allMachineJobs,
 		CloudInitOutputLog:      cloudInitOutputLog,
 		InstanceId:              "i-bootstrap",
@@ -127,11 +134,6 @@ var stateServingInfo = &params.StateServingInfo{
 	StatePort:    37017,
 	APIPort:      17070,
 }
-
-var jujuLogDir = path.Join(logDir, "juju")
-var logDir = must(paths.LogDir("precise"))
-var dataDir = must(paths.DataDir("precise"))
-var cloudInitOutputLog = path.Join(logDir, "cloud-init-output.log")
 
 // Each test gives a cloudinit config - we check the
 // output to see if it looks correct.
@@ -992,8 +994,8 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 			EnvironTag: testing.EnvironmentTag,
 		},
 		Config:                  minimalConfig(c),
-		DataDir:                 environs.DataDir,
-		LogDir:                  agent.DefaultLogDir,
+		DataDir:                 dataDir,
+		LogDir:                  logDir,
 		Jobs:                    normalMachineJobs,
 		CloudInitOutputLog:      cloudInitOutputLog,
 		InstanceId:              "i-bootstrap",

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -365,7 +365,7 @@ func (s *MongoSuite) TestRemoveService(c *gc.C) {
 		c.Check(s.data.Removed[0].Name(), gc.Equals, "juju-db-namespace")
 		c.Check(s.data.Removed[0].Conf(), jc.DeepEquals, common.Conf{})
 	}
-	s.data.CheckCallNames(c, "Stop", "Remove")
+	s.data.CheckCallNames(c, "Installed", "Stop", "Remove")
 }
 
 func (s *MongoSuite) TestQuantalAptAddRepo(c *gc.C) {

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -73,6 +73,15 @@ func RemoveService(namespace string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	isInstalled, err := svc.Installed()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// No need to error if you try to remove a service that does not exist.
+	// The desired state reflects the actual state.
+	if !isInstalled {
+		return nil
+	}
 	if err := svc.Stop(); err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/azure/customdata_test.go
+++ b/provider/azure/customdata_test.go
@@ -11,7 +11,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
@@ -36,8 +35,11 @@ func must(s string, err error) string {
 	return s
 }
 
-var logDir = must(paths.LogDir("precise"))
-var cloudInitOutputLog = path.Join(logDir, "cloud-init-output.log")
+var (
+	logDir             = must(paths.LogDir("precise"))
+	dataDir            = must(paths.DataDir("precise"))
+	cloudInitOutputLog = path.Join(logDir, "cloud-init-output.log")
+)
 
 // makeMachineConfig produces a valid cloudinit machine config.
 func makeMachineConfig(c *gc.C) *cloudinit.MachineConfig {
@@ -46,8 +48,8 @@ func makeMachineConfig(c *gc.C) *cloudinit.MachineConfig {
 	return &cloudinit.MachineConfig{
 		MachineId:    machineId,
 		MachineNonce: "gxshasqlnng",
-		DataDir:      environs.DataDir,
-		LogDir:       agent.DefaultLogDir,
+		DataDir:      dataDir,
+		LogDir:       logDir,
 		Jobs: []multiwatcher.MachineJob{
 			multiwatcher.JobManageEnviron,
 			multiwatcher.JobHostUnits,

--- a/service/agent.go
+++ b/service/agent.go
@@ -76,7 +76,10 @@ func UnitAgentConf(unitName, dataDir, logDir, os, containerType string) (common.
 	if os == "" {
 		os = runtime.GOOS
 	}
-
+	var renderer cloudinit.Renderer = &cloudinit.UbuntuRenderer{}
+	if os == "windows" {
+		renderer = &cloudinit.WindowsRenderer{}
+	}
 	unitID := "unit-" + strings.Replace(unitName, "/", "-", -1)
 
 	toolsDir := tools.ToolsDir(dataDir, unitID)
@@ -86,9 +89,9 @@ func UnitAgentConf(unitName, dataDir, logDir, os, containerType string) (common.
 	}
 
 	cmd := strings.Join([]string{
-		jujudPath,
+		renderer.FromSlash(jujudPath),
 		"unit",
-		"--data-dir", utils.ShQuote(dataDir),
+		"--data-dir", utils.ShQuote(renderer.FromSlash(dataDir)),
 		"--unit-name", unitName,
 		"--debug",
 	}, " ")
@@ -109,7 +112,7 @@ func UnitAgentConf(unitName, dataDir, logDir, os, containerType string) (common.
 	conf := common.Conf{
 		Desc:      fmt.Sprintf("juju unit agent for %s", unitName),
 		ExecStart: cmd,
-		Logfile:   logFile,
+		Logfile:   renderer.FromSlash(logFile),
 		Env:       envVars,
 		Timeout:   agentServiceTimeout,
 	}

--- a/service/agent_test.go
+++ b/service/agent_test.go
@@ -38,9 +38,9 @@ func (*agentSuite) TestMachineAgentConfLocal(c *gc.C) {
 	// mixed up during the call.
 	dataDir := c.MkDir()
 	logDir := c.MkDir()
-	conf, toolsDir := service.MachineAgentConf("0", dataDir, logDir, "")
+	conf, toolsDir := service.MachineAgentConf("0", dataDir, logDir, runtime.GOOS)
 
-	c.Check(toolsDir, gc.Equals, filepath.Join(dataDir, "tools", "machine-0"))
+	c.Check(toolsDir, jc.SamePath, filepath.Join(dataDir, "tools", "machine-0"))
 	cmd := strings.Join([]string{
 		quote + filepath.Join(toolsDir, "jujud"+cmdSuffix) + quote,
 		"machine",
@@ -113,7 +113,7 @@ func (*agentSuite) TestMachineAgentConfWindows(c *gc.C) {
 func (*agentSuite) TestUnitAgentConf(c *gc.C) {
 	dataDir := c.MkDir()
 	logDir := c.MkDir()
-	conf, toolsDir := service.UnitAgentConf("wordpress/0", dataDir, logDir, "", "cont")
+	conf, toolsDir := service.UnitAgentConf("wordpress/0", dataDir, logDir, runtime.GOOS, "cont")
 
 	c.Check(toolsDir, gc.Equals, path.Join(dataDir, "tools", "unit-wordpress-0"))
 	cmd := strings.Join([]string{

--- a/service/systemd/export_test.go
+++ b/service/systemd/export_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package systemd

--- a/service/systemd/export_test.go
+++ b/service/systemd/export_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
 
 package systemd
 

--- a/service/systemd/package_test.go
+++ b/service/systemd/package_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package systemd_test

--- a/service/systemd/package_test.go
+++ b/service/systemd/package_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
 
 package systemd_test
 

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package systemd_test

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
 
 package systemd_test
 

--- a/service/systemd/stubdbusapi_test.go
+++ b/service/systemd/stubdbusapi_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package systemd

--- a/service/systemd/stubdbusapi_test.go
+++ b/service/systemd/stubdbusapi_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
 
 package systemd
 

--- a/service/systemd/stubexec_test.go
+++ b/service/systemd/stubexec_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package systemd

--- a/service/systemd/stubexec_test.go
+++ b/service/systemd/stubexec_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
 
 package systemd
 

--- a/service/systemd/stubfileops_test.go
+++ b/service/systemd/stubfileops_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package systemd

--- a/service/systemd/stubfileops_test.go
+++ b/service/systemd/stubfileops_test.go
@@ -1,5 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
 
 package systemd
 

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -1,5 +1,6 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
 
 package upstart_test
 

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -1,5 +1,6 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package upstart_test

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -114,7 +114,7 @@ func (s *Service) Installed() (bool, error) {
 		// There is no reason for windows to return an error
 		// if the service is installed. It does throw an error
 		// if we try to get the status of a non existent service
-		// This module will soon be replaced with a native alternative
+		// TODO (gsamfira): This module will soon be replaced with a native alternative
 		// removing the exec calls.
 		logger.Debugf("Service status query returned: %s", err)
 		return false, nil

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -111,7 +111,13 @@ func (s *Service) Running() (bool, error) {
 func (s *Service) Installed() (bool, error) {
 	_, err := s.Status()
 	if err != nil {
-		return false, errors.Trace(err)
+		// There is no reason for windows to return an error
+		// if the service is installed. It does throw an error
+		// if we try to get the status of a non existent service
+		// This module will soon be replaced with a native alternative
+		// removing the exec calls.
+		logger.Debugf("Service status query returned: %s", err)
+		return false, nil
 	}
 	return true, nil
 }

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -116,7 +116,6 @@ func (s *Service) Installed() (bool, error) {
 		// if we try to get the status of a non existent service
 		// TODO (gsamfira): This module will soon be replaced with a native alternative
 		// removing the exec calls.
-		logger.Debugf("Service status query returned: %s", err)
 		return false, nil
 	}
 	return true, nil

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -1,5 +1,6 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
 
 package provisioner_test
 

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -1,5 +1,6 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 // +build !windows
 
 package provisioner_test


### PR DESCRIPTION
This branch makes tests pass on windows again. Fixes include changing some tests to use proper path detection based on series/os and one change that will get replaced as soon as I get a chance to propose the refactor of the windows service module.

I am aware that its ugly at the moment, but I do have a proper module in the works, that will replace this sad implementation I made (tests included).

(Review request: http://reviews.vapour.ws/r/1119/)