### PR TITLE
 Fix early return in `juju action fetch`

### DIFF
--- a/cmd/juju/action/fetch.go
+++ b/cmd/juju/action/fetch.go
@@ -124,9 +124,11 @@ func timerLoop(api APIClient, requestedId string, wait, tick *time.Timer) (param
 			return result, err
 		}
 
-		// Whether or not we're waiting for a result, if a non
-		// pending result arrives, we're done.
-		if result.Status != params.ActionPending {
+		// Whether or not we're waiting for a result, if a completed
+		// result arrives, we're done.
+		switch result.Status {
+		case params.ActionRunning, params.ActionPending:
+		default:
 			return result, nil
 		}
 

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -189,9 +189,8 @@ func (c *fakeAPIClient) Actions(args params.Entities) (params.ActionResults, err
 	// to prevent the test hanging.  If the given wait is up, then return
 	// the results; otherwise, return a pending status.
 
-	// First, wait for a split second to avoid timer problems.
-	tmp := time.NewTimer(0 * time.Second)
-	_ = <-tmp.C
+	// First, sync.
+	_ = <-time.NewTimer(0 * time.Second).C
 
 	select {
 	case _ = <-c.delay.C:

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -73,6 +73,7 @@ func (s *StatusSuite) TestRun(c *gc.C) {
 func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
 	fakeClient := makeFakeClient(
 		0*time.Second, // No API delay
+		5*time.Second, // 5 second test timeout
 		tc.tags,
 		tc.results,
 		"", // No API error


### PR DESCRIPTION
Juju action fetch no longer returns when action status changes from
"pending" to "running".

(Review request: http://reviews.vapour.ws/r/1120/)