### PR TITLE
Add a feature flag for using upstart under vivid.

### DIFF
--- a/feature/flags.go
+++ b/feature/flags.go
@@ -29,3 +29,8 @@ const LeaderElection = "leader-election"
 // failure.  This means that the developers with this flag set will see the
 // stack trace in the log output, but normal deployments never will.
 const LogErrorStack = "log-error-stack"
+
+// LegacyUpstart is used to indicate that the version-based init system
+// discovery code (service.VersionInitSystem) should return upstart
+// instead of systemd for vivid and newer.
+const LegacyUpstart = "legacy-upstart"

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/featureflag"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/version"
 )
@@ -66,7 +68,11 @@ func VersionInitSystem(vers version.Binary) (string, bool) {
 				return "", false
 			}
 			// vivid and later
-			return InitSystemSystemd, true
+			if featureflag.Enabled(feature.LegacyUpstart) {
+				return InitSystemUpstart, true
+			} else {
+				return InitSystemSystemd, true
+			}
 		}
 		// TODO(ericsnow) Support other OSes, like version.CentOS.
 	default:

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -70,9 +70,8 @@ func VersionInitSystem(vers version.Binary) (string, bool) {
 			// vivid and later
 			if featureflag.Enabled(feature.LegacyUpstart) {
 				return InitSystemUpstart, true
-			} else {
-				return InitSystemSystemd, true
 			}
+			return InitSystemSystemd, true
 		}
 		// TODO(ericsnow) Support other OSes, like version.CentOS.
 	default:


### PR DESCRIPTION
There is the possibility of a vivid host running upstart.  This has a material impact on CI, where we will likely have 2 vivid bots running (systemd/upstart respectively).  This patch allows users to force the discovery fallback  for vivid to upstart (as well as for "remote" hosts, e.g. in cloud init and in the LXC clonetemplate code).

One thing the patch does not do is allow for any granularity.  So the fallback behavior and the "remote" behavior will be the same, even if for instance the cloud image is vivid running systemd but the bootstrap host is vivid running upstart.  This is an unlikely situation which we can address later if it presents a problem.

(Review request: http://reviews.vapour.ws/r/1121/)