### PR TITLE
Fix an isolation issue in the upstart tests.

### DIFF
--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -169,7 +169,7 @@ func (s *Service) existsAndSame() (exists, same bool, conf []byte, err error) {
 func (s *Service) Running() (bool, error) {
 	cmd := exec.Command("status", "--system", s.Service.Name)
 	out, err := cmd.CombinedOutput()
-	logger.Tracef("Running out: %q", out)
+	logger.Tracef("Running \"status --system %s\": %q", s.Service.Name, out)
 	if err == nil {
 		return startedRE.Match(out), nil
 	}

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju/service/common"
 )
@@ -22,6 +23,8 @@ import (
 var InitDir = "/etc/init"
 
 var servicesRe = regexp.MustCompile("^([a-zA-Z0-9-_:]+)\\.conf$")
+
+var logger = loggo.GetLogger("juju.service.upstart")
 
 // ListServices returns the name of all installed services on the
 // local host.
@@ -166,6 +169,7 @@ func (s *Service) existsAndSame() (exists, same bool, conf []byte, err error) {
 func (s *Service) Running() (bool, error) {
 	cmd := exec.Command("status", "--system", s.Service.Name)
 	out, err := cmd.CombinedOutput()
+	logger.Tracef("Running out: %q", out)
 	if err == nil {
 		return startedRE.Match(out), nil
 	}

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -233,6 +233,7 @@ func (s *UpstartSuite) assertInstall(c *gc.C, conf common.Conf, expectEnd string
 		"start some-service",
 	})
 
+	s.MakeTool(c, "status", `echo "some-service stop/waiting"`)
 	s.MakeTool(c, "start", "exit 99")
 	err = svc.Install()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Start() calls Running() which calls 'status'.

I had an executable in my path called 'status'.

(Review request: http://reviews.vapour.ws/r/1123/)