### PR TITLE
Support a cache file for the configstore.

### DIFF
--- a/environs/configstore/cachefile.go
+++ b/environs/configstore/cachefile.go
@@ -1,0 +1,206 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package configstore
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/juju/errors"
+	goyaml "gopkg.in/yaml.v1"
+)
+
+// CacheFile represents the YAML structure of the file
+// $JUJU_HOME/environments/cache.yaml
+type CacheFile struct {
+	// Server maps the name of the server to the server-uuid
+	Server map[string]ServerUser `yaml:"server-user"`
+	// ServerData is a map of server-uuid to the data for that server.
+	ServerData map[string]ServerData `yaml:"server-data"`
+	// Environment maps the local name of the environment to the details
+	// for that environment
+	Environment map[string]EnvironmentData `yaml:"environment"`
+}
+
+// ServerUser represents a user on a server, but not an environment on that
+// server.  Used for server based commands like login, list and use.
+type ServerUser struct {
+	ServerUUID string `yaml:"server-uuid"`
+	User       string `yaml:"user"`
+}
+
+// ServerData holds the end point details for the API servers running
+// in the state server environment.
+type ServerData struct {
+	APIEndpoints    []string `yaml:"api-endpoints"`
+	ServerHostnames []string `yaml:"server-hostnames,omitempty"`
+	CACert          string   `yaml:"ca-cert"`
+	// Identities is a mapping of full username to credentials.
+	Identities      map[string]string      `yaml:"identities"`
+	BootstrapConfig map[string]interface{} `yaml:"bootstrap-config,omitempty"`
+}
+
+// EnvironmentData represents a single environment running in a Juju
+// Environment Server.
+type EnvironmentData struct {
+	ServerUser
+	EnvironmentUUID string `yaml:"env-uuid"`
+}
+
+// All synchronisation locking is expected to be done outside the
+// read and write methods.
+func readCacheFile(filename string) (CacheFile, error) {
+	data, err := ioutil.ReadFile(filename)
+	var content CacheFile
+	if err != nil {
+		if os.IsNotExist(err) {
+			// If the file doesn't exist, then we return an empty
+			// CacheFile.
+			return CacheFile{
+				Server:      make(map[string]ServerUser),
+				ServerData:  make(map[string]ServerData),
+				Environment: make(map[string]EnvironmentData),
+			}, nil
+		}
+		return content, err
+	}
+	if len(data) == 0 {
+		return CacheFile{
+			Server:      make(map[string]ServerUser),
+			ServerData:  make(map[string]ServerData),
+			Environment: make(map[string]EnvironmentData),
+		}, nil
+	}
+	if err := goyaml.Unmarshal(data, &content); err != nil {
+		return content, errors.Annotatef(err, "error unmarshalling %q", filename)
+	}
+	return content, nil
+}
+
+func writeCacheFile(filename string, content CacheFile) error {
+	data, err := goyaml.Marshal(content)
+	if err != nil {
+		return errors.Annotate(err, "cannot marshal cache file")
+	}
+	// We now use a fslock to sync reads and writes across the environment,
+	// so we don't need to use a temporary file any more.
+	flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	file, err := os.OpenFile(filename, flags, 0600)
+	if err != nil {
+		return errors.Annotate(err, "cannot open cache file")
+	}
+
+	_, err = file.Write(data)
+	file.Close()
+
+	// If there was an error writing, we annotate it, otherwise
+	// the annotation passes the nil through.
+	return errors.Annotate(err, "cannot write file")
+}
+
+func (cache CacheFile) readInfo(envName string) (*environInfo, error) {
+	info := &environInfo{
+		name:   envName,
+		source: sourceCache,
+	}
+	var srvData ServerData
+	if envData, ok := cache.Environment[envName]; ok {
+		srvData, ok = cache.ServerData[envData.ServerUUID]
+		if !ok {
+			return nil, errors.Errorf("missing server data for environment %q", envName)
+		}
+		info.user = envData.User
+		info.environmentUUID = envData.EnvironmentUUID
+		info.serverUUID = envData.ServerUUID
+	} else {
+		srvUser, ok := cache.Server[envName]
+		if !ok {
+			return nil, errors.NotFoundf("environment %q", envName)
+		}
+		srvData, ok = cache.ServerData[srvUser.ServerUUID]
+		if !ok {
+			return nil, errors.Errorf("missing server data for environment %q", envName)
+		}
+		info.user = srvUser.User
+		info.environmentUUID = srvUser.ServerUUID
+		info.serverUUID = srvUser.ServerUUID
+	}
+
+	info.credentials = srvData.Identities[info.user]
+	info.caCert = srvData.CACert
+	info.apiEndpoints = srvData.APIEndpoints
+	info.apiHostnames = srvData.ServerHostnames
+	if info.serverUUID == info.environmentUUID {
+		info.bootstrapConfig = srvData.BootstrapConfig
+	}
+	return info, nil
+}
+
+func (cache *CacheFile) updateInfo(info *environInfo) error {
+	// If the info is new, then check for name clashes.
+	if info.source == sourceCreated {
+		if _, found := cache.Environment[info.name]; found {
+			return ErrEnvironInfoAlreadyExists
+		}
+		if _, found := cache.Server[info.name]; found {
+			return ErrEnvironInfoAlreadyExists
+		}
+	}
+
+	// If the serverUUID and environmentUUID are the same, then
+	// add a name entry under the server.
+	serverUser := ServerUser{
+		User:       info.user,
+		ServerUUID: info.serverUUID,
+	}
+	if info.environmentUUID == info.serverUUID {
+		cache.Server[info.name] = serverUser
+	}
+
+	cache.Environment[info.name] = EnvironmentData{
+		ServerUser:      serverUser,
+		EnvironmentUUID: info.environmentUUID,
+	}
+
+	// Check to see if the cache file has some info for the server already.
+	serverData := cache.ServerData[info.serverUUID]
+	serverData.APIEndpoints = info.apiEndpoints
+	serverData.ServerHostnames = info.apiHostnames
+	serverData.CACert = info.caCert
+	if info.bootstrapConfig != nil {
+		serverData.BootstrapConfig = info.bootstrapConfig
+	}
+	if serverData.Identities == nil {
+		serverData.Identities = make(map[string]string)
+	}
+	serverData.Identities[info.user] = info.credentials
+	cache.ServerData[info.serverUUID] = serverData
+	return nil
+}
+
+func (cache *CacheFile) removeInfo(info *environInfo) error {
+	envUser, envFound := cache.Environment[info.name]
+	srvUser, srvFound := cache.Server[info.name]
+	if !envFound && !srvFound {
+		return errors.New("environment info has already been removed")
+	}
+	var serverUUID string
+	if envFound {
+		serverUUID = envUser.ServerUUID
+	} else {
+		serverUUID = srvUser.ServerUUID
+	}
+	delete(cache.Environment, info.name)
+	delete(cache.Server, info.name)
+	// Look to see if there are any other environments using the serverUUID.
+	// If there aren't, then we also clean up the server data, otherwise we
+	// need to leave the server data there.
+	for _, envUser := range cache.Environment {
+		if envUser.ServerUUID == serverUUID {
+			return nil
+		}
+	}
+	delete(cache.ServerData, serverUUID)
+	return nil
+}

--- a/environs/configstore/cachefile_test.go
+++ b/environs/configstore/cachefile_test.go
@@ -1,0 +1,251 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package configstore_test
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/juju/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/feature"
+)
+
+var _ = gc.Suite(&cacheFileInterfaceSuite{})
+
+type cacheFileInterfaceSuite struct {
+	interfaceSuite
+	dir   string
+	store configstore.Storage
+}
+
+func (s *cacheFileInterfaceSuite) SetUpTest(c *gc.C) {
+	s.interfaceSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.EnvironmentsCacheFile)
+	s.dir = c.MkDir()
+	s.NewStore = func(c *gc.C) configstore.Storage {
+		store, err := configstore.NewDisk(s.dir)
+		c.Assert(err, jc.ErrorIsNil)
+		return store
+	}
+	s.store = s.NewStore(c)
+}
+
+func (s *cacheFileInterfaceSuite) writeEnv(c *gc.C, name, envUUID, srvUUID, user, password string) configstore.EnvironInfo {
+	info := s.store.CreateInfo(name)
+	info.SetAPIEndpoint(configstore.APIEndpoint{
+		Addresses:   []string{"address1", "address2"},
+		Hostnames:   []string{"hostname1", "hostname2"},
+		CACert:      testing.CACert,
+		EnvironUUID: envUUID,
+		ServerUUID:  srvUUID,
+	})
+	info.SetAPICredentials(configstore.APICredentials{
+		User:     user,
+		Password: password,
+	})
+	err := info.Write()
+	c.Assert(err, jc.ErrorIsNil)
+	return info
+}
+
+func (s *cacheFileInterfaceSuite) TestServerUUIDWrite(c *gc.C) {
+	envUUID := testing.EnvironmentTag.Id()
+	info := s.writeEnv(c, "testing", envUUID, envUUID, "tester", "secret")
+
+	// Now make sure the cache file exists and the jenv doesn't
+	envDir := filepath.Join(s.dir, "environments")
+	filename := configstore.CacheFilename(envDir)
+	c.Assert(info.Location(), gc.Equals, fmt.Sprintf("file %q", filename))
+
+	cache := s.readCacheFile(c)
+	c.Assert(cache.Server, gc.HasLen, 1)
+	c.Assert(cache.ServerData, gc.HasLen, 1)
+	c.Assert(cache.Environment, gc.HasLen, 1)
+}
+
+func (s *cacheFileInterfaceSuite) TestServerEnvNameExists(c *gc.C) {
+	envUUID := testing.EnvironmentTag.Id()
+	s.writeEnv(c, "testing", envUUID, envUUID, "tester", "secret")
+
+	info := s.store.CreateInfo("testing")
+	// In order to trigger the writing to the cache file, we need to store
+	// a server uuid.
+	info.SetAPIEndpoint(configstore.APIEndpoint{
+		EnvironUUID: envUUID,
+		ServerUUID:  envUUID,
+	})
+	err := info.Write()
+	c.Assert(err, gc.ErrorMatches, "environment info already exists")
+}
+
+func (s *cacheFileInterfaceSuite) TestServerUUIDRead(c *gc.C) {
+	envUUID := testing.EnvironmentTag.Id()
+	s.writeEnv(c, "testing", envUUID, envUUID, "tester", "secret")
+
+	info, err := s.store.ReadInfo("testing")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.APICredentials(), jc.DeepEquals, configstore.APICredentials{
+		User:     "tester",
+		Password: "secret",
+	})
+	c.Assert(info.APIEndpoint(), jc.DeepEquals, configstore.APIEndpoint{
+		Addresses:   []string{"address1", "address2"},
+		Hostnames:   []string{"hostname1", "hostname2"},
+		CACert:      testing.CACert,
+		EnvironUUID: envUUID,
+		ServerUUID:  envUUID,
+	})
+}
+
+func (s *cacheFileInterfaceSuite) TestServerDetailsShared(c *gc.C) {
+	envUUID := testing.EnvironmentTag.Id()
+	s.writeEnv(c, "testing", envUUID, envUUID, "tester", "secret")
+	info := s.writeEnv(c, "second", "fake-uuid", envUUID, "tester", "new-secret")
+	endpoint := info.APIEndpoint()
+	endpoint.Addresses = []string{"address2", "address3"}
+	endpoint.Hostnames = []string{"hostname2", "hostname3"}
+	info.SetAPIEndpoint(endpoint)
+	err := info.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+	info, err = s.store.ReadInfo("testing")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.APICredentials(), jc.DeepEquals, configstore.APICredentials{
+		User:     "tester",
+		Password: "new-secret",
+	})
+	c.Assert(info.APIEndpoint(), jc.DeepEquals, configstore.APIEndpoint{
+		Addresses:   []string{"address2", "address3"},
+		Hostnames:   []string{"hostname2", "hostname3"},
+		CACert:      testing.CACert,
+		EnvironUUID: envUUID,
+		ServerUUID:  envUUID,
+	})
+
+	cache := s.readCacheFile(c)
+	c.Assert(cache.Server, gc.HasLen, 1)
+	c.Assert(cache.ServerData, gc.HasLen, 1)
+	c.Assert(cache.Environment, gc.HasLen, 2)
+}
+
+func (s *cacheFileInterfaceSuite) TestMigrateJENV(c *gc.C) {
+	envUUID := testing.EnvironmentTag.Id()
+	info := s.writeEnv(c, "testing", envUUID, "", "tester", "secret")
+	envDir := filepath.Join(s.dir, "environments")
+	jenvFilename := configstore.JENVFilename(envDir, "testing")
+	c.Assert(info.Location(), gc.Equals, fmt.Sprintf("file %q", jenvFilename))
+
+	// Add server details and write again will migrate the info to the
+	// cache file.
+	endpoint := info.APIEndpoint()
+	endpoint.ServerUUID = envUUID
+	info.SetAPIEndpoint(endpoint)
+	err := info.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(jenvFilename, jc.DoesNotExist)
+	cache := s.readCacheFile(c)
+
+	envInfo, ok := cache.Environment["testing"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(envInfo.User, gc.Equals, "tester")
+	c.Assert(envInfo.EnvironmentUUID, gc.Equals, envUUID)
+	c.Assert(envInfo.ServerUUID, gc.Equals, envUUID)
+	// Server entry also written.
+	srvInfo, ok := cache.Server["testing"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(srvInfo.User, gc.Equals, "tester")
+	c.Assert(srvInfo.ServerUUID, gc.Equals, envUUID)
+
+	readInfo, err := s.store.ReadInfo("testing")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(readInfo.APIEndpoint(), jc.DeepEquals, info.APIEndpoint())
+}
+
+func (s *cacheFileInterfaceSuite) readCacheFile(c *gc.C) configstore.CacheFile {
+	envDir := filepath.Join(s.dir, "environments")
+	filename := configstore.CacheFilename(envDir)
+	cache, err := configstore.ReadCacheFile(filename)
+	c.Assert(err, jc.ErrorIsNil)
+	return cache
+}
+
+func (s *cacheFileInterfaceSuite) TestExistingJENVBlocksNew(c *gc.C) {
+	envUUID := testing.EnvironmentTag.Id()
+	info := s.writeEnv(c, "testing", envUUID, "", "tester", "secret")
+	envDir := filepath.Join(s.dir, "environments")
+	jenvFilename := configstore.JENVFilename(envDir, "testing")
+	c.Assert(info.Location(), gc.Equals, fmt.Sprintf("file %q", jenvFilename))
+
+	info = s.store.CreateInfo("testing")
+	// In order to trigger the writing to the cache file, we need to store
+	// a server uuid.
+	info.SetAPIEndpoint(configstore.APIEndpoint{
+		EnvironUUID: envUUID,
+		ServerUUID:  envUUID,
+	})
+	err := info.Write()
+	c.Assert(err, gc.ErrorMatches, "environment info already exists")
+}
+
+func (s *cacheFileInterfaceSuite) TestList(c *gc.C) {
+	// List returns both JENV environments and the cache file environments.
+	s.writeEnv(c, "jenv-1", "fake-uuid1", "", "tester", "secret")
+	s.writeEnv(c, "jenv-2", "fake-uuid2", "", "tester", "secret")
+	s.writeEnv(c, "cache-1", "fake-uuid3", "fake-server", "tester", "secret")
+	s.writeEnv(c, "cache-2", "fake-uuid4", "fake-server", "tester", "secret")
+
+	environments, err := s.store.List()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(environments, jc.SameContents, []string{"jenv-1", "jenv-2", "cache-1", "cache-2"})
+
+	// Confirm that the sources are from where we'd expect.
+	envDir := filepath.Join(s.dir, "environments")
+	c.Assert(configstore.JENVFilename(envDir, "jenv-1"), jc.IsNonEmptyFile)
+	c.Assert(configstore.JENVFilename(envDir, "jenv-2"), jc.IsNonEmptyFile)
+	cache := s.readCacheFile(c)
+	names := make([]string, 0)
+	for name := range cache.Environment {
+		names = append(names, name)
+	}
+	c.Assert(names, jc.SameContents, []string{"cache-1", "cache-2"})
+}
+
+func (s *cacheFileInterfaceSuite) TestDestroy(c *gc.C) {
+	info := s.writeEnv(c, "cache-1", "fake-uuid", "fake-server", "tester", "secret")
+
+	err := info.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cache := s.readCacheFile(c)
+	c.Assert(cache.Server, gc.HasLen, 0)
+	c.Assert(cache.ServerData, gc.HasLen, 0)
+	c.Assert(cache.Environment, gc.HasLen, 0)
+}
+
+func (s *cacheFileInterfaceSuite) TestDestroyTwice(c *gc.C) {
+	info := s.writeEnv(c, "cache-1", "fake-uuid", "fake-server", "tester", "secret")
+
+	err := info.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = info.Destroy()
+	c.Assert(err, gc.ErrorMatches, "environment info has already been removed")
+}
+
+func (s *cacheFileInterfaceSuite) TestDestroyKeepsSharedData(c *gc.C) {
+	info := s.writeEnv(c, "cache-1", "fake-uuid1", "fake-server", "tester", "secret")
+	s.writeEnv(c, "cache-2", "fake-uuid2", "fake-server", "tester", "secret")
+
+	err := info.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cache := s.readCacheFile(c)
+	c.Assert(cache.Server, gc.HasLen, 0)
+	c.Assert(cache.ServerData, gc.HasLen, 1)
+	c.Assert(cache.Environment, gc.HasLen, 1)
+}

--- a/environs/configstore/export_test.go
+++ b/environs/configstore/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package configstore
+
+var (
+	CacheFilename = cacheFilename
+	JENVFilename  = jenvFilename
+	ReadCacheFile = readCacheFile
+)

--- a/environs/configstore/mem.go
+++ b/environs/configstore/mem.go
@@ -32,7 +32,7 @@ func (info *memInfo) clone() *memInfo {
 		newAttrs[name] = attr
 	}
 	info1.bootstrapConfig = newAttrs
-	info1.created = false
+	info1.source = sourceMem
 	return &info1
 }
 
@@ -52,7 +52,7 @@ func (m *memStore) CreateInfo(envName string) EnvironInfo {
 		store: m,
 		name:  envName,
 	}
-	info.created = true
+	info.source = sourceCreated
 	return info
 }
 
@@ -89,11 +89,11 @@ func (info *memInfo) Write() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !info.initialized && m.envs[info.name] != nil {
+	if !info.initialized() && m.envs[info.name] != nil {
 		return ErrEnvironInfoAlreadyExists
 	}
 
-	info.initialized = true
+	info.source = sourceMem
 	m.envs[info.name] = info.clone()
 	return nil
 }
@@ -103,7 +103,7 @@ func (info *memInfo) Destroy() error {
 	m := info.store
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if info.initialized {
+	if info.initialized() {
 		if m.envs[info.name] == nil {
 			return fmt.Errorf("environment info has already been removed")
 		}

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -30,6 +30,13 @@ const LeaderElection = "leader-election"
 // stack trace in the log output, but normal deployments never will.
 const LogErrorStack = "log-error-stack"
 
+// EnvironmentsCacheFile is the feature flag that guards the writing of the
+// new $JUJU_HOME/environments/cache.yaml file.  If this flag is set, new
+// environments will be written to the cache file rather than a JENV file.
+// As JENV files are updated, they are migrated to the cache file and the
+// JENV file removed.
+const EnvironmentsCacheFile = "env-cache"
+
 // LegacyUpstart is used to indicate that the version-based init system
 // discovery code (service.VersionInitSystem) should return upstart
 // instead of systemd for vivid and newer.


### PR DESCRIPTION
Writes to the new cache file are protected with a feature flag, so we can give it a workout over the 1.24 development cycle.

(Review request: http://reviews.vapour.ws/r/1124/)