### PR TITLE
worker/uniter/storage: implement Attachments

### DIFF
--- a/worker/uniter/storage/attachments.go
+++ b/worker/uniter/storage/attachments.go
@@ -7,9 +7,12 @@
 package storage
 
 import (
+	"os"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"gopkg.in/juju/charm.v4/hooks"
 
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
@@ -33,13 +36,27 @@ type StorageAccessor interface {
 	// UnitStorageAttachments returns details of all of the storage
 	// attachments for the unit with the specified tag.
 	UnitStorageAttachments(names.UnitTag) ([]params.StorageAttachment, error)
+
+	// EnsureStorageAttachmentDead ensures that the storage attachment
+	// with the specified unit and storage tags is Dead.
+	EnsureStorageAttachmentDead(names.StorageTag, names.UnitTag) error
+
+	// RemoveStorageAttachment removes that the storage attachment
+	// with the specified unit and storage tags. This method is only
+	// expected to succeed if the storage attachment is Dead.
+	RemoveStorageAttachment(names.StorageTag, names.UnitTag) error
 }
 
 // Attachments generates storage hooks in response to changes to
 // storage attachments, and provides access to information about
 // storage attachments to hooks.
 type Attachments struct {
-	hooks chan hook.Info
+	st              StorageAccessor
+	unitTag         names.UnitTag
+	abort           <-chan struct{}
+	hooks           chan hook.Info
+	storagers       map[names.StorageTag]*storager
+	storageStateDir string
 }
 
 // NewAttachments returns a new Attachments.
@@ -50,7 +67,12 @@ func NewAttachments(
 	abort <-chan struct{},
 ) (*Attachments, error) {
 	a := &Attachments{
-		hooks: make(chan hook.Info),
+		st:              st,
+		unitTag:         tag,
+		abort:           abort,
+		hooks:           make(chan hook.Info),
+		storagers:       make(map[names.StorageTag]*storager),
+		storageStateDir: storageStateDir,
 	}
 	if err := a.init(); err != nil {
 		return nil, err
@@ -61,7 +83,46 @@ func NewAttachments(
 // init processes the storage state directory and creates storagers
 // for the state files found.
 func (a *Attachments) init() error {
-	// TODO(axw) implement this in a follow-up.
+	if err := os.MkdirAll(a.storageStateDir, 0755); err != nil {
+		return errors.Annotate(err, "creating storage state dir")
+	}
+	// Query all remote, known storage attachments for the unit,
+	// so we can cull state files, and store current context.
+	attachments, err := a.st.UnitStorageAttachments(a.unitTag)
+	if err != nil {
+		return errors.Annotate(err, "getting unit attachments")
+	}
+	attachmentsByTag := make(map[names.StorageTag]*params.StorageAttachment)
+	for i, attachment := range attachments {
+		storageTag, err := names.ParseStorageTag(attachment.StorageTag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		attachmentsByTag[storageTag] = &attachments[i]
+	}
+	stateFiles, err := readAllStateFiles(a.storageStateDir)
+	if err != nil {
+		return errors.Annotate(err, "reading storage state dirs")
+	}
+	for storageTag, stateFile := range stateFiles {
+		_, ok := attachmentsByTag[storageTag]
+		if !ok {
+			if err := stateFile.Remove(); err != nil {
+				return errors.Trace(err)
+			}
+			continue
+		}
+		// Since there's a state file, we must previously have handled
+		// at least "storage-attached", so there is no possibility of
+		// short-circuiting the storage's removal.
+		if err := a.add(storageTag, stateFile); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	// Note: we ignore remote attachments that were not locally recorded;
+	// they will be picked up by UpdateStorage. We could handle it now, but
+	// we're going to have to refresh the attachment in response to the
+	// watcher anyway.
 	return nil
 }
 
@@ -73,7 +134,11 @@ func (a *Attachments) Hooks() <-chan hook.Info {
 
 // Stop stops all of the storagers.
 func (a *Attachments) Stop() error {
-	// TODO(axw) implement this in a follow-up.
+	for _, s := range a.storagers {
+		if err := s.Stop(); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	return nil
 }
 
@@ -81,26 +146,125 @@ func (a *Attachments) Stop() error {
 // storage attachments corresponding to the supplied storage tags,
 // sending storage hooks on the channel returned by Hooks().
 func (a *Attachments) UpdateStorage(tags []names.StorageTag) error {
-	// TODO(axw) implement this in a follow-up.
+	for _, storageTag := range tags {
+		if err := a.updateOneStorage(storageTag); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (a *Attachments) updateOneStorage(storageTag names.StorageTag) error {
+	// Fetch the attachment's remote state, so we know when we can
+	// stop the storager and possibly short-circuit the attachment's
+	// removal.
+	att, err := a.st.StorageAttachment(storageTag, a.unitTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	stateFile, err := readStateFile(a.storageStateDir, storageTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	storager := a.storagers[storageTag]
+
+	switch att.Life {
+	case params.Dying:
+		if stateFile.state.attached {
+			// Previously ran storage-attached, so we'll
+			// need to run a storage-detaching hook.
+			if storager == nil {
+				panic("missing storager for attached storage")
+			}
+			// TODO(axw) have storager watch both storage
+			// attachment and volume/filesystem attachment,
+			// else we need to force updates from here.
+			return nil
+		}
+		// Storage was not previously seen as Dying, so we can
+		// short-circuit the storage's death and removal.
+		if err := a.st.EnsureStorageAttachmentDead(storageTag, a.unitTag); err != nil {
+			return errors.Annotate(err, "ensuring storage is dead")
+		}
+		fallthrough
+	case params.Dead:
+		if storager != nil {
+			// Stopping the storager guarantees that no hooks will
+			// be delivered, which is a crucial requirement for
+			// short-circuiting.
+			if err := storager.Stop(); err != nil {
+				return errors.Trace(err)
+			}
+			delete(a.storagers, storageTag)
+		}
+		if err := a.st.RemoveStorageAttachment(storageTag, a.unitTag); err != nil {
+			return errors.Annotate(err, "removing storage")
+		}
+		return nil
+	}
+
+	if storager == nil {
+		return a.add(storageTag, stateFile)
+	}
+	return nil
+}
+
+// add creates a new storager for the specified storage tag.
+func (a *Attachments) add(storageTag names.StorageTag, stateFile *stateFile) error {
+	s, err := newStorager(a.st, a.unitTag, storageTag, stateFile, a.hooks)
+	if err != nil {
+		return errors.Annotatef(err, "watching storage %q", storageTag.Id())
+	}
+	a.storagers[storageTag] = s
+	logger.Debugf("watching storage %q", storageTag.Id())
 	return nil
 }
 
 // Storage returns the ContextStorage with the supplied tag if it was
 // found, and whether it was found.
 func (a *Attachments) Storage(tag names.StorageTag) (jujuc.ContextStorage, bool) {
-	// TODO(axw) implement this in a follow-up.
+	if s, ok := a.storagers[tag]; ok {
+		return s.Context()
+	}
 	return nil, false
 }
 
 // ValidateHook validates the hook against the current state.
 func (a *Attachments) ValidateHook(hi hook.Info) error {
-	// TODO(axw) implement this in a follow-up.
-	return errors.NotImplementedf("ValidateHook")
+	storager, err := a.storagerForHook(hi)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return storager.state.ValidateHook(hi)
 }
 
 // CommitHook persists the state change encoded in the supplied storage
 // hook, or returns an error if the hook is invalid given current state.
 func (a *Attachments) CommitHook(hi hook.Info) error {
-	// TODO(axw) implement this in a follow-up.
-	return errors.NotImplementedf("CommitHook")
+	storager, err := a.storagerForHook(hi)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := storager.CommitHook(hi); err != nil {
+		return err
+	}
+	if hi.Kind == hooks.StorageDetached {
+		// Progress storage attachment to Dead.
+		storageTag := names.NewStorageTag(hi.StorageId)
+		if err := a.st.EnsureStorageAttachmentDead(storageTag, a.unitTag); err != nil {
+			return errors.Annotate(err, "ensuring storage is dead")
+		}
+	}
+	return nil
+}
+
+func (a *Attachments) storagerForHook(hi hook.Info) (*storager, error) {
+	if !hi.Kind.IsStorage() {
+		return nil, errors.Errorf("not a storage hook: %#v", hi)
+	}
+	storager, ok := a.storagers[names.NewStorageTag(hi.StorageId)]
+	if !ok {
+		return nil, errors.Errorf("unknown storage %q", hi.StorageId)
+	}
+	return storager, nil
 }

--- a/worker/uniter/storage/attachments_test.go
+++ b/worker/uniter/storage/attachments_test.go
@@ -1,0 +1,394 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	corestorage "github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/storage"
+)
+
+type attachmentsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&attachmentsSuite{})
+
+func (s *attachmentsSuite) TestNewAttachments(c *gc.C) {
+	stateDir := filepath.Join(c.MkDir(), "nonexistent")
+	unitTag := names.NewUnitTag("mysql/0")
+	abort := make(chan struct{})
+	st := &mockStorageAccessor{
+		unitStorageAttachments: func(u names.UnitTag) ([]params.StorageAttachment, error) {
+			c.Assert(u, gc.Equals, unitTag)
+			return nil, nil
+		},
+	}
+
+	att, err := storage.NewAttachments(st, unitTag, stateDir, abort)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		err := att.Stop()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+	// state dir should have been created.
+	c.Assert(stateDir, jc.IsDirectory)
+}
+
+func (s *attachmentsSuite) TestNewAttachmentsInit(c *gc.C) {
+	stateDir := c.MkDir()
+	unitTag := names.NewUnitTag("mysql/0")
+	abort := make(chan struct{})
+
+	// Simulate remote state returning a single Alive storage attachment.
+	attachments := []params.StorageAttachment{{
+		StorageTag: "storage-data-0",
+		Life:       params.Alive,
+	}}
+	st := &mockStorageAccessor{
+		unitStorageAttachments: func(u names.UnitTag) ([]params.StorageAttachment, error) {
+			c.Assert(u, gc.Equals, unitTag)
+			return attachments, nil
+		},
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
+			return newMockNotifyWatcher(), nil
+		},
+	}
+
+	storageTag := names.NewStorageTag("data/0")
+	withAttachments := func(f func(*storage.Attachments)) {
+		att, err := storage.NewAttachments(st, unitTag, stateDir, abort)
+		c.Assert(err, jc.ErrorIsNil)
+		defer func() {
+			err := att.Stop()
+			c.Assert(err, jc.ErrorIsNil)
+		}()
+		f(att)
+	}
+
+	// No state files, so no storagers will be started.
+	var called int
+	withAttachments(func(att *storage.Attachments) {
+		called++
+		err := att.ValidateHook(hook.Info{
+			Kind:      hooks.StorageAttached,
+			StorageId: storageTag.Id(),
+		})
+		c.Assert(err, gc.ErrorMatches, `unknown storage "data/0"`)
+	})
+	c.Assert(called, gc.Equals, 1)
+
+	// Commit a storage-attached to local state and try again.
+	state0, err := storage.ReadStateFile(stateDir, storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	err = state0.CommitHook(hook.Info{Kind: hooks.StorageAttached, StorageId: "data/0"})
+	c.Assert(err, jc.ErrorIsNil)
+	// Create an extra one so we can make sure it gets removed.
+	state1, err := storage.ReadStateFile(stateDir, names.NewStorageTag("data/1"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = state1.CommitHook(hook.Info{Kind: hooks.StorageAttached, StorageId: "data/1"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	withAttachments(func(att *storage.Attachments) {
+		called++
+		err := att.ValidateHook(hook.Info{
+			Kind:      hooks.StorageDetached,
+			StorageId: storageTag.Id(),
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		err = att.ValidateHook(hook.Info{
+			Kind:      hooks.StorageAttached,
+			StorageId: "data/1",
+		})
+		c.Assert(err, gc.ErrorMatches, `unknown storage "data/1"`)
+	})
+	c.Assert(called, gc.Equals, 2)
+	c.Assert(filepath.Join(stateDir, "data-0"), jc.IsNonEmptyFile)
+	c.Assert(filepath.Join(stateDir, "data-1"), jc.DoesNotExist)
+}
+
+func (s *attachmentsSuite) TestAttachmentsUpdate(c *gc.C) {
+	stateDir := c.MkDir()
+	unitTag := names.NewUnitTag("mysql/0")
+	abort := make(chan struct{})
+
+	storageTag0 := names.NewStorageTag("data/0")
+	storageTag1 := names.NewStorageTag("data/1")
+	attachmentsByTag := map[names.StorageTag]*params.StorageAttachment{
+		storageTag0: {
+			StorageTag: storageTag0.String(),
+			UnitTag:    unitTag.String(),
+			Life:       params.Alive,
+			Kind:       params.StorageKindBlock,
+			Location:   "/dev/sdb",
+		},
+		storageTag1: {
+			StorageTag: storageTag1.String(),
+			UnitTag:    unitTag.String(),
+			Life:       params.Dying,
+			Kind:       params.StorageKindBlock,
+			Location:   "/dev/sdb",
+		},
+	}
+
+	st := &mockStorageAccessor{
+		unitStorageAttachments: func(u names.UnitTag) ([]params.StorageAttachment, error) {
+			c.Assert(u, gc.Equals, unitTag)
+			return nil, nil
+		},
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
+			w := newMockNotifyWatcher()
+			w.changes <- struct{}{}
+			return w, nil
+		},
+		storageAttachment: func(s names.StorageTag, u names.UnitTag) (params.StorageAttachment, error) {
+			att, ok := attachmentsByTag[s]
+			c.Assert(ok, jc.IsTrue)
+			return *att, nil
+		},
+		ensureDead: func(s names.StorageTag, u names.UnitTag) error {
+			c.Assert(s, gc.Equals, storageTag1)
+			return nil
+		},
+		remove: func(s names.StorageTag, u names.UnitTag) error {
+			c.Assert(s, gc.Equals, storageTag1)
+			return nil
+		},
+	}
+
+	att, err := storage.NewAttachments(st, unitTag, stateDir, abort)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		err := att.Stop()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+
+	// data/0 is initially unattached and untracked, so
+	// updating with Alive will cause a storager to be
+	// started and a storage-attached event to be emitted.
+	for i := 0; i < 2; i++ {
+		// Updating twice, to ensure idempotency.
+		err = att.UpdateStorage([]names.StorageTag{storageTag0})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	hi := waitOneHook(c, att.Hooks())
+	c.Assert(hi, gc.Equals, hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: storageTag0.Id(),
+	})
+
+	// data/1 is initially unattached and untracked, so
+	// updating with Dying will not cause a storager to
+	// be started.
+	err = att.UpdateStorage([]names.StorageTag{storageTag1})
+	c.Assert(err, jc.ErrorIsNil)
+	assertNoHooks(c, att.Hooks())
+
+	// Cause an Alive hook to be queued, but don't consume it;
+	// then update to Dying, and ensure no hooks are generated.
+	// Additionally, the storager should be stopped and no
+	// longer tracked.
+	attachmentsByTag[storageTag1].Life = params.Alive
+	err = att.UpdateStorage([]names.StorageTag{storageTag1})
+	c.Assert(err, jc.ErrorIsNil)
+	err = att.ValidateHook(hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: storageTag1.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	attachmentsByTag[storageTag1].Life = params.Dying
+	err = att.UpdateStorage([]names.StorageTag{storageTag1})
+	c.Assert(err, jc.ErrorIsNil)
+	assertNoHooks(c, att.Hooks())
+	err = att.ValidateHook(hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: storageTag1.Id(),
+	})
+	c.Assert(err, gc.ErrorMatches, `unknown storage "data/1"`)
+}
+
+func (s *attachmentsSuite) TestAttachmentsUpdateShortCircuitDeath(c *gc.C) {
+	stateDir := c.MkDir()
+	unitTag := names.NewUnitTag("mysql/0")
+	abort := make(chan struct{})
+
+	var ensuredDead, removed bool
+	storageTag := names.NewStorageTag("data/0")
+	attachment := params.StorageAttachment{
+		StorageTag: storageTag.String(),
+		UnitTag:    unitTag.String(),
+		Life:       params.Dying,
+	}
+	st := &mockStorageAccessor{
+		unitStorageAttachments: func(u names.UnitTag) ([]params.StorageAttachment, error) {
+			c.Assert(u, gc.Equals, unitTag)
+			return nil, nil
+		},
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
+			w := newMockNotifyWatcher()
+			return w, nil
+		},
+		storageAttachment: func(s names.StorageTag, u names.UnitTag) (params.StorageAttachment, error) {
+			return attachment, nil
+		},
+		ensureDead: func(s names.StorageTag, u names.UnitTag) error {
+			ensuredDead = true
+			c.Assert(s, gc.Equals, storageTag)
+			c.Assert(u, gc.Equals, unitTag)
+			return nil
+		},
+		remove: func(s names.StorageTag, u names.UnitTag) error {
+			removed = true
+			c.Assert(s, gc.Equals, storageTag)
+			c.Assert(u, gc.Equals, unitTag)
+			return nil
+		},
+	}
+
+	att, err := storage.NewAttachments(st, unitTag, stateDir, abort)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		err := att.Stop()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+	err = att.UpdateStorage([]names.StorageTag{storageTag})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ensuredDead, jc.IsTrue)
+	c.Assert(removed, jc.IsTrue)
+}
+
+func (s *attachmentsSuite) TestAttachmentsStorage(c *gc.C) {
+	stateDir := c.MkDir()
+	unitTag := names.NewUnitTag("mysql/0")
+	abort := make(chan struct{})
+
+	storageTag := names.NewStorageTag("data/0")
+	attachment := params.StorageAttachment{
+		StorageTag: storageTag.String(),
+		UnitTag:    unitTag.String(),
+		Life:       params.Alive,
+		Kind:       params.StorageKindBlock,
+		Location:   "/dev/sdb",
+	}
+
+	st := &mockStorageAccessor{
+		unitStorageAttachments: func(u names.UnitTag) ([]params.StorageAttachment, error) {
+			c.Assert(u, gc.Equals, unitTag)
+			return nil, nil
+		},
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
+			w := newMockNotifyWatcher()
+			w.changes <- struct{}{}
+			return w, nil
+		},
+		storageAttachment: func(s names.StorageTag, u names.UnitTag) (params.StorageAttachment, error) {
+			c.Assert(s, gc.Equals, storageTag)
+			return attachment, nil
+		},
+	}
+
+	att, err := storage.NewAttachments(st, unitTag, stateDir, abort)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		err := att.Stop()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+
+	// There should be no context for data/0 until a hook is queued.
+	_, ok := att.Storage(storageTag)
+	c.Assert(ok, jc.IsFalse)
+
+	err = att.UpdateStorage([]names.StorageTag{storageTag})
+	c.Assert(err, jc.ErrorIsNil)
+	hi := waitOneHook(c, att.Hooks())
+	c.Assert(hi, gc.Equals, hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: storageTag.Id(),
+	})
+
+	ctx, ok := att.Storage(storageTag)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(ctx, gc.NotNil)
+	c.Assert(ctx.Tag(), gc.Equals, storageTag)
+	c.Assert(ctx.Kind(), gc.Equals, corestorage.StorageKindBlock)
+	c.Assert(ctx.Location(), gc.Equals, "/dev/sdb")
+}
+
+func (s *attachmentsSuite) TestAttachmentsCommitHook(c *gc.C) {
+	stateDir := c.MkDir()
+	unitTag := names.NewUnitTag("mysql/0")
+	abort := make(chan struct{})
+
+	var ensuredDead bool
+	storageTag := names.NewStorageTag("data/0")
+	attachment := params.StorageAttachment{
+		StorageTag: storageTag.String(),
+		UnitTag:    unitTag.String(),
+		Life:       params.Alive,
+		Kind:       params.StorageKindBlock,
+		Location:   "/dev/sdb",
+	}
+	st := &mockStorageAccessor{
+		unitStorageAttachments: func(u names.UnitTag) ([]params.StorageAttachment, error) {
+			c.Assert(u, gc.Equals, unitTag)
+			return nil, nil
+		},
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
+			w := newMockNotifyWatcher()
+			w.changes <- struct{}{}
+			return w, nil
+		},
+		storageAttachment: func(s names.StorageTag, u names.UnitTag) (params.StorageAttachment, error) {
+			c.Assert(s, gc.Equals, storageTag)
+			return attachment, nil
+		},
+		ensureDead: func(s names.StorageTag, u names.UnitTag) error {
+			ensuredDead = true
+			c.Assert(s, gc.Equals, storageTag)
+			return nil
+		},
+	}
+
+	att, err := storage.NewAttachments(st, unitTag, stateDir, abort)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		err := att.Stop()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+	err = att.UpdateStorage([]names.StorageTag{storageTag})
+	c.Assert(err, jc.ErrorIsNil)
+
+	stateFile := filepath.Join(stateDir, "data-0")
+	c.Assert(stateFile, jc.DoesNotExist)
+
+	err = att.CommitHook(hook.Info{
+		Kind:      hooks.StorageAttached,
+		StorageId: storageTag.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	data, err := ioutil.ReadFile(stateFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "attached: true\n")
+
+	c.Assert(ensuredDead, jc.IsFalse)
+	err = att.CommitHook(hook.Info{
+		Kind:      hooks.StorageDetached,
+		StorageId: storageTag.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stateFile, jc.DoesNotExist)
+	c.Assert(ensuredDead, jc.IsTrue)
+}

--- a/worker/uniter/storage/storager.go
+++ b/worker/uniter/storage/storager.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type storager struct {
+	st         StorageAccessor
+	unitTag    names.UnitTag
+	storageTag names.StorageTag
+	state      *stateFile
+	source     *storageSource
+	sender     hook.Sender
+}
+
+// newStorager creates a new storager, watching for changes to the storage
+// attachment with the specified tags, and generating hooks on the output
+// channel.
+func newStorager(
+	st StorageAccessor,
+	unitTag names.UnitTag,
+	storageTag names.StorageTag,
+	state *stateFile,
+	hooks chan<- hook.Info,
+) (*storager, error) {
+	source, err := newStorageSource(st, unitTag, storageTag, state.attached)
+	if err != nil {
+		return nil, errors.Annotate(err, "creating storage event source")
+	}
+	sender := hook.NewSender(hooks, source)
+	return &storager{
+		st:         st,
+		unitTag:    unitTag,
+		storageTag: storageTag,
+		state:      state,
+		source:     source,
+		sender:     sender,
+	}, nil
+}
+
+func (s *storager) Stop() error {
+	if err := s.sender.Stop(); err != nil {
+		return errors.Annotate(err, "stopping storage event sender")
+	}
+	return s.source.Stop()
+}
+
+// Context returns the ContextStorage for the storage that this storager
+// corresponds to, and whether there is any context available yet. There
+// will be context beginning from when the first hook is queued.
+func (s *storager) Context() (jujuc.ContextStorage, bool) {
+	return s.source.Context()
+}
+
+// CommitHook persists the state change encoded in the supplied storage
+// hook, or returns an error if the hook is invalid given current state.
+func (s *storager) CommitHook(hi hook.Info) error {
+	return s.state.CommitHook(hi)
+}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -225,6 +225,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		return errors.Annotatef(err, "cannot create storage hook source")
 	}
 	u.storage = storageAttachments
+	u.addCleanup(storageAttachments.Stop)
 
 	deployer, err := charm.NewDeployer(
 		u.paths.State.CharmDir,


### PR DESCRIPTION
This branch implements the storage.Attachments
type, which is the entry-point into the uniter
storage subsystem. Attachments manages a
"storager" (like "relationer") for each active
storage attachment that it knows about, and
delegates CommitHook, ValidateHook and Storage
(storage context access) to those.

(Review request: http://reviews.vapour.ws/r/1127/)