### PR TITLE
state: add scope to volume/filesystem IDs

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -298,12 +298,12 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 		IsVirtual:     false,
 	}}
 	volumes := []params.Volume{{
-		VolumeTag: "volume-0",
+		VolumeTag: "volume-1-0",
 		VolumeId:  "vol-123",
 		Size:      124,
 	}}
 	volumeAttachments := []params.VolumeAttachment{{
-		VolumeTag:  "volume-0",
+		VolumeTag:  "volume-1-0",
 		MachineTag: "machine-1",
 		DeviceName: "xvdf1",
 	}}
@@ -362,7 +362,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(actual, jc.SameContents, ifaces[:4]) // skip the rest as they are ignored.
 
 	// Now check volumes and volume attachments.
-	volume, err := s.State.Volume(names.NewVolumeTag("0"))
+	volume, err := s.State.Volume(names.NewVolumeTag("1/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfo, err := volume.Info()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -753,7 +753,7 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 	// Provision volume 2 so that it is excluded from any ProvisioningInfo() results.
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
 	err = placementMachine.SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil, map[names.VolumeTag]state.VolumeInfo{
-		names.NewVolumeTag("2"): state.VolumeInfo{VolumeId: "123", Size: 1024},
+		names.NewVolumeTag(placementMachine.Id() + "/2"): state.VolumeInfo{VolumeId: "123", Size: 1024},
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -781,13 +781,13 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Volumes: []params.VolumeParams{{
-					VolumeTag:  "volume-0",
+					VolumeTag:  "volume-" + placementMachine.Id() + "-0",
 					Size:       1000,
 					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
 					Attributes: map[string]interface{}{"foo": "bar"},
 				}, {
-					VolumeTag:  "volume-1",
+					VolumeTag:  "volume-" + placementMachine.Id() + "-1",
 					Size:       2000,
 					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
@@ -837,7 +837,7 @@ func (s *withoutStateServerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Volumes: []params.VolumeParams{{
-					VolumeTag:  "volume-0",
+					VolumeTag:  "volume-" + placementMachine.Id() + "-0",
 					Size:       1000,
 					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
@@ -1098,12 +1098,12 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		InstanceId: "i-am-also",
 		Nonce:      "fake",
 		Volumes: []params.Volume{{
-			VolumeTag: "volume-0",
+			VolumeTag: "volume-" + volumesMachine.Id() + "-0",
 			VolumeId:  "vol-0",
 			Size:      1234,
 		}},
 		VolumeAttachments: []params.VolumeAttachment{{
-			VolumeTag:  "volume-0",
+			VolumeTag:  "volume-" + volumesMachine.Id() + "-0",
 			MachineTag: volumesMachine.Tag().String(),
 			DeviceName: "sda",
 		}},

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -11,7 +11,8 @@ import (
 
 type provisionerState interface {
 	state.EntityFinder
-	WatchVolumes() state.StringsWatcher
+	WatchEnvironVolumes() state.StringsWatcher
+	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
 	Volume(names.VolumeTag) (state.Volume, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
 	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -26,12 +26,12 @@ type StorageProvisionerAPI struct {
 	*common.LifeGetter
 	*common.DeadEnsurer
 
-	st                 provisionerState
-	settings           poolmanager.SettingsManager
-	resources          *common.Resources
-	authorizer         common.Authorizer
-	getMachineAuthFunc common.GetAuthFunc
-	getVolumeAuthFunc  common.GetAuthFunc
+	st                provisionerState
+	settings          poolmanager.SettingsManager
+	resources         *common.Resources
+	authorizer        common.Authorizer
+	getScopeAuthFunc  common.GetAuthFunc
+	getVolumeAuthFunc common.GetAuthFunc
 }
 
 var getState = func(st *state.State) provisionerState {
@@ -47,28 +47,34 @@ func NewStorageProvisionerAPI(st *state.State, resources *common.Resources, auth
 	if !authorizer.AuthMachineAgent() {
 		return nil, common.ErrPerm
 	}
-	isEnvironManager := authorizer.AuthEnvironManager()
-	authEntityTag := authorizer.GetAuthTag()
-	getMachineAuthFunc := func() (common.AuthFunc, error) {
+	canAccessVolumeMachine := func(tag names.MachineTag) bool {
+		authEntityTag := authorizer.GetAuthTag()
+		if tag == authEntityTag {
+			// Machine agents can access volumes
+			// scoped to their own machine.
+			return true
+		}
+		parentId := state.ParentId(tag.Id())
+		if parentId == "" {
+			return false
+		}
+		// All containers with the authenticated
+		// machine as a parent are accessible by it.
+		return names.NewMachineTag(parentId) == authEntityTag
+	}
+	getScopeAuthFunc := func() (common.AuthFunc, error) {
 		return func(tag names.Tag) bool {
 			switch tag := tag.(type) {
 			case names.EnvironTag:
 				// Environment managers can access all volumes
 				// scoped to the environment.
-				return isEnvironManager
+				//
+				// TODO(axw) allow watching volumes in alternative
+				// environments? Need to check with thumper.
+				isEnvironManager := authorizer.AuthEnvironManager()
+				return isEnvironManager && tag == st.EnvironTag()
 			case names.MachineTag:
-				if tag == authEntityTag {
-					// Machine agents can access volumes
-					// scoped to their own machine.
-					return true
-				}
-				parentId := state.ParentId(tag.Id())
-				if parentId == "" {
-					return false
-				}
-				// All containers with the authenticated
-				// machine as a parent are accessible by it.
-				return names.NewMachineTag(parentId) == authEntityTag
+				return canAccessVolumeMachine(tag)
 			default:
 				return false
 			}
@@ -76,12 +82,13 @@ func NewStorageProvisionerAPI(st *state.State, resources *common.Resources, auth
 	}
 	getVolumeAuthFunc := func() (common.AuthFunc, error) {
 		return func(tag names.Tag) bool {
-			switch tag.(type) {
+			switch tag := tag.(type) {
 			case names.VolumeTag:
-				// TODO(axw) volume tag should include machine
-				// scope, which we can then use for authentication
-				// and watching purposes.
-				return true
+				machineTag, ok := names.VolumeMachine(tag)
+				if ok {
+					return canAccessVolumeMachine(machineTag)
+				}
+				return authorizer.AuthEnvironManager()
 			default:
 				return false
 			}
@@ -90,21 +97,21 @@ func NewStorageProvisionerAPI(st *state.State, resources *common.Resources, auth
 	stateInterface := getState(st)
 	settings := getSettingsManager(st)
 	return &StorageProvisionerAPI{
-		LifeGetter:         common.NewLifeGetter(stateInterface, getVolumeAuthFunc),
-		DeadEnsurer:        common.NewDeadEnsurer(stateInterface, getVolumeAuthFunc),
-		st:                 stateInterface,
-		settings:           settings,
-		resources:          resources,
-		authorizer:         authorizer,
-		getMachineAuthFunc: getMachineAuthFunc,
-		getVolumeAuthFunc:  getVolumeAuthFunc,
+		LifeGetter:        common.NewLifeGetter(stateInterface, getVolumeAuthFunc),
+		DeadEnsurer:       common.NewDeadEnsurer(stateInterface, getVolumeAuthFunc),
+		st:                stateInterface,
+		settings:          settings,
+		resources:         resources,
+		authorizer:        authorizer,
+		getScopeAuthFunc:  getScopeAuthFunc,
+		getVolumeAuthFunc: getVolumeAuthFunc,
 	}, nil
 }
 
 // WatchVolumes watches for changes to volumes scoped to the
 // entity with the tag passed to NewState.
 func (s *StorageProvisionerAPI) WatchVolumes(args params.Entities) (params.StringsWatchResults, error) {
-	canAccess, err := s.getMachineAuthFunc()
+	canAccess, err := s.getScopeAuthFunc()
 	if err != nil {
 		return params.StringsWatchResults{}, common.ServerError(common.ErrPerm)
 	}
@@ -116,9 +123,12 @@ func (s *StorageProvisionerAPI) WatchVolumes(args params.Entities) (params.Strin
 		if err != nil || !canAccess(tag) {
 			return "", nil, common.ErrPerm
 		}
-		// TODO(axw) record a scope for volumes, and watch
-		// only volumes in that scope.
-		w := s.st.WatchVolumes()
+		var w state.StringsWatcher
+		if tag, ok := tag.(names.MachineTag); ok {
+			w = s.st.WatchMachineVolumes(tag)
+		} else {
+			w = s.st.WatchEnvironVolumes()
+		}
 		if changes, ok := <-w.Changes(); ok {
 			return s.resources.Register(w), changes, nil
 		}

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -67,6 +67,11 @@ func (e *ebsProvider) Supports(k storage.StorageKind) bool {
 	return k == storage.StorageKindBlock
 }
 
+// Scope is defined on the Provider interface.
+func (e *ebsProvider) Scope() storage.Scope {
+	return storage.ScopeEnviron
+}
+
 func TranslateUserEBSOptions(userOptions map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 	for k, v := range userOptions {

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -484,7 +484,7 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 
 	// Create filesystems and filesystem attachments.
 	for _, f := range template.Filesystems {
-		ops, filesystemTag, volumeTag, err := st.addFilesystemOps(f.Filesystem)
+		ops, filesystemTag, volumeTag, err := st.addFilesystemOps(f.Filesystem, mdoc.Id)
 		if err != nil {
 			return nil, txn.Op{}, errors.Trace(err)
 		}
@@ -502,7 +502,7 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	// attempting to create the volume until after the machine
 	// has been provisioned.
 	for _, v := range template.Volumes {
-		op, tag, err := st.addVolumeOp(v.Volume)
+		op, tag, err := st.addVolumeOp(v.Volume, mdoc.Id)
 		if err != nil {
 			return nil, txn.Op{}, errors.Trace(err)
 		}

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -110,7 +110,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 }
 
 func (s *FilesystemStateSuite) TestWatchFilesystemAttachment(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "filesystem")
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "loop-pool")
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 	assignedMachineId, err := u.AssignedMachineId()
@@ -143,7 +143,7 @@ func (s *FilesystemStateSuite) TestWatchFilesystemAttachment(c *gc.C) {
 }
 
 func (s *FilesystemStateSuite) TestFilesystemInfo(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "filesystem")
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "loop-pool")
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 	assignedMachineId, err := u.AssignedMachineId()

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -68,7 +68,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 
 	filesystem, err := s.State.StorageInstanceFilesystem(storageInstance.StorageTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(filesystem.FilesystemTag(), gc.Equals, names.NewFilesystemTag("0"))
+	c.Assert(filesystem.FilesystemTag(), gc.Equals, names.NewFilesystemTag("0/0"))
 	filesystemStorageTag, err := filesystem.Storage()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(filesystemStorageTag, gc.Equals, storageInstance.StorageTag())
@@ -80,7 +80,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 	volume, err := s.State.StorageInstanceVolume(storageInstance.StorageTag())
 	if withVolume {
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(volume.VolumeTag(), gc.Equals, names.NewVolumeTag("0"))
+		c.Assert(volume.VolumeTag(), gc.Equals, names.NewVolumeTag("0/0"))
 		volumeStorageTag, err := volume.StorageInstance()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(volumeStorageTag, gc.Equals, storageInstance.StorageTag())

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -924,8 +924,8 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	// TODO(axw) test invalid volume attachment
 }
 
-func (s *MachineSuite) addVolume(c *gc.C, params state.VolumeParams) names.VolumeTag {
-	op, tag, err := state.AddVolumeOp(s.State, params)
+func (s *MachineSuite) addVolume(c *gc.C, params state.VolumeParams, machineId string) names.VolumeTag {
+	op, tag, err := state.AddVolumeOp(s.State, params, machineId)
 	c.Assert(err, jc.ErrorIsNil)
 	err = state.RunTransaction(s.State, []txn.Op{op})
 	c.Assert(err, jc.ErrorIsNil)
@@ -939,7 +939,8 @@ func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
 	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
 
 	// Must create the requested block device prior to SetInstanceInfo.
-	volumeTag := s.addVolume(c, state.VolumeParams{Size: 1000, Pool: "loop-pool"})
+	volumeTag := s.addVolume(c, state.VolumeParams{Size: 1000, Pool: "loop-pool"}, "123")
+	c.Assert(volumeTag, gc.Equals, names.NewVolumeTag("123/0"))
 
 	c.Assert(s.machine.CheckProvisioned("fake_nonce"), jc.IsFalse)
 	networks := []state.NetworkInfo{

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
@@ -27,6 +29,24 @@ var _ = gc.Suite(&StorageStateSuite{})
 
 type StorageStateSuiteBase struct {
 	ConnSuite
+}
+
+func (s *StorageStateSuiteBase) SetUpSuite(c *gc.C) {
+	s.ConnSuite.SetUpSuite(c)
+
+	registry.RegisterProvider("environscoped", &dummy.StorageProvider{
+		StorageScope: storage.ScopeEnviron,
+	})
+	registry.RegisterProvider("machinescoped", &dummy.StorageProvider{
+		StorageScope: storage.ScopeMachine,
+	})
+	registry.RegisterEnvironStorageProviders(
+		"someprovider", "environscoped", "machinescoped",
+	)
+	s.AddSuiteCleanup(func(c *gc.C) {
+		registry.RegisterProvider("environscoped", nil)
+		registry.RegisterProvider("machinescoped", nil)
+	})
 }
 
 func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
@@ -43,12 +63,12 @@ func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
 	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
 }
 
-func (s *StorageStateSuiteBase) setupSingleStorage(c *gc.C, kind string) (*state.Service, *state.Unit, names.StorageTag) {
+func (s *StorageStateSuiteBase) setupSingleStorage(c *gc.C, kind, pool string) (*state.Service, *state.Unit, names.StorageTag) {
 	// There are test charms called "storage-block" and
 	// "storage-filesystem" which are what you'd expect.
 	ch := s.AddTestingCharm(c, "storage-"+kind)
 	storage := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop-pool", 1024, 1),
+		"data": makeStorageCons(pool, 1024, 1),
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
 	unit, err := service.AddUnit()
@@ -226,7 +246,7 @@ func (s *StorageStateSuite) TestAddUnit(c *gc.C) {
 }
 
 func (s *StorageStateSuite) TestUnitEnsureDead(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "block")
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	// destroying a unit with storage attachments is fine; this is what
 	// will trigger the death and removal of storage attachments.
 	err := u.Destroy()
@@ -251,7 +271,7 @@ func (s *StorageStateSuite) TestUnitEnsureDead(c *gc.C) {
 }
 
 func (s *StorageStateSuite) TestRemoveStorageAttachmentsRemovesDyingInstance(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "block")
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
 	// Mark the storage instance as Dying, so that it will be removed
 	// when the last attachment is removed.
@@ -271,7 +291,7 @@ func (s *StorageStateSuite) TestRemoveStorageAttachmentsRemovesDyingInstance(c *
 }
 
 func (s *StorageStateSuite) TestConcurrentDestroyStorageInstanceRemoveStorageAttachmentsRemovesInstance(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "block")
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		err := s.State.EnsureStorageAttachmentDead(storageTag, u.UnitTag())
@@ -291,7 +311,7 @@ func (s *StorageStateSuite) TestConcurrentDestroyStorageInstanceRemoveStorageAtt
 }
 
 func (s *StorageStateSuite) TestConcurrentRemoveStorageAttachment(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "block")
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
 	err := s.State.DestroyStorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
@@ -313,7 +333,7 @@ func (s *StorageStateSuite) TestConcurrentRemoveStorageAttachment(c *gc.C) {
 }
 
 func (s *StorageStateSuite) TestRemoveAliveStorageAttachmentError(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "block")
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
 	err := s.State.RemoveStorageAttachment(storageTag, u.UnitTag())
 	c.Assert(err, gc.ErrorMatches, "cannot remove storage attachment data/0:storage-block/0: storage attachment is not dead")
@@ -325,7 +345,7 @@ func (s *StorageStateSuite) TestRemoveAliveStorageAttachmentError(c *gc.C) {
 }
 
 func (s *StorageStateSuite) TestConcurrentDestroyInstanceRemoveStorageAttachmentsRemovesInstance(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "block")
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		// Concurrently mark the storage instance as Dying,
@@ -347,7 +367,7 @@ func (s *StorageStateSuite) TestConcurrentDestroyInstanceRemoveStorageAttachment
 }
 
 func (s *StorageStateSuite) TestConcurrentDestroyStorageInstance(c *gc.C) {
-	_, _, storageTag := s.setupSingleStorage(c, "block")
+	_, _, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		err := s.State.DestroyStorageInstance(storageTag)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -38,7 +38,7 @@ func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
 
 	volume, err := s.State.StorageInstanceVolume(storageInstance.StorageTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volume.VolumeTag(), gc.Equals, names.NewVolumeTag("0"))
+	c.Assert(volume.VolumeTag(), gc.Equals, names.NewVolumeTag("0/0"))
 	volumeStorageTag, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeStorageTag, gc.Equals, storageInstance.StorageTag())

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -24,7 +24,7 @@ type VolumeStateSuite struct {
 var _ = gc.Suite(&VolumeStateSuite{})
 
 func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
-	_, unit, _ := s.setupSingleStorage(c, "block")
+	_, unit, _ := s.setupSingleStorage(c, "block", "loop-pool")
 	err := s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 	assignedMachineId, err := unit.AssignedMachineId()
@@ -117,7 +117,7 @@ func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestSetVolumeInfo(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "block")
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -176,7 +176,7 @@ func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
-	_, u, storageTag := s.setupSingleStorage(c, "block")
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 	assignedMachineId, err := u.AssignedMachineId()
@@ -204,6 +204,63 @@ func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
 	err = s.State.SetVolumeInfo(volumeTag, state.VolumeInfo{VolumeId: "vol-123"})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
+}
+
+func (s *VolumeStateSuite) TestWatchEnvironVolumes(c *gc.C) {
+	service := s.setupMixedScopeStorageService(c)
+	addUnit := func() {
+		u, err := service.AddUnit()
+		c.Assert(err, jc.ErrorIsNil)
+		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	addUnit()
+
+	w := s.State.WatchEnvironVolumes()
+	defer testing.AssertStop(c, w)
+	wc := testing.NewStringsWatcherC(c, s.State, w)
+	wc.AssertChangeInSingleEvent("0") // initial
+	wc.AssertNoChange()
+
+	addUnit()
+	wc.AssertChangeInSingleEvent("3")
+	wc.AssertNoChange()
+
+	// TODO(axw) respond to Dying/Dead when we have
+	// the means to progress Volume lifecycle.
+}
+
+func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
+	service := s.setupMixedScopeStorageService(c)
+	addUnit := func() {
+		u, err := service.AddUnit()
+		c.Assert(err, jc.ErrorIsNil)
+		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	addUnit()
+
+	w := s.State.WatchMachineVolumes(names.NewMachineTag("0"))
+	defer testing.AssertStop(c, w)
+	wc := testing.NewStringsWatcherC(c, s.State, w)
+	wc.AssertChangeInSingleEvent("0/1", "0/2") // initial
+	wc.AssertNoChange()
+
+	addUnit()
+	// no change, since we're only interested in the one machine.
+	wc.AssertNoChange()
+
+	// TODO(axw) respond to Dying/Dead when we have
+	// the means to progress Volume lifecycle.
+}
+
+func (s *VolumeStateSuite) setupMixedScopeStorageService(c *gc.C) *state.Service {
+	storageCons := map[string]state.StorageConstraints{
+		"multi1to10": makeStorageCons("environscoped", 1024, 1),
+		"multi2up":   makeStorageCons("machinescoped", 2048, 2),
+	}
+	ch := s.AddTestingCharm(c, "storage-block2")
+	return s.AddTestingServiceWithStorage(c, "storage-block2", ch, storageCons)
 }
 
 func (s *VolumeStateSuite) assertVolumeUnprovisioned(c *gc.C, tag names.VolumeTag) {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -16,7 +16,7 @@ type ProviderType string
 // Scope defines the scope of the storage that a provider manages.
 // Machine-scoped storage must be managed from within the machine,
 // whereas environment-level storage must be managed by an environment
-// manager.
+// storage provisioner.
 type Scope int
 
 const (

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -13,6 +13,17 @@ import (
 // ProviderType uniquely identifies a storage provider, such as "ebs" or "loop".
 type ProviderType string
 
+// Scope defines the scope of the storage that a provider manages.
+// Machine-scoped storage must be managed from within the machine,
+// whereas environment-level storage must be managed by an environment
+// manager.
+type Scope int
+
+const (
+	ScopeEnviron Scope = iota
+	ScopeMachine
+)
+
 // Provider is an interface for obtaining storage sources.
 type Provider interface {
 	// VolumeSource returns a VolumeSource given the specified cloud
@@ -37,6 +48,9 @@ type Provider interface {
 	// be used for creating filesystem storage; Juju will request a
 	// volume from the provider and then manage the filesystem itself.
 	Supports(kind StorageKind) bool
+
+	// Scope returns the scope of storage managed by this provider.
+	Scope() Scope
 
 	// ValidateConfig validates the provided storage provider config,
 	// returning an error if it is invalid.

--- a/storage/provider/dummy/provider.go
+++ b/storage/provider/dummy/provider.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dummy
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/storage"
+)
+
+// StorageProvider is an implementation of storage.Provider, suitable for testing.
+// Each method's default behaviour may be overridden by setting the corresponding
+// Func field.
+type StorageProvider struct {
+	// StorageScope defines the scope of storage managed by this provider.
+	StorageScope storage.Scope
+
+	// VolumeSourceFunc will be called by VolumeSource, if non-nil;
+	// otherwise VolumeSource will return a NotSupported error.
+	VolumeSourceFunc func(*config.Config, *storage.Config) (storage.VolumeSource, error)
+
+	// FilesystemSourceFunc will be called by FilesystemSource, if non-nil;
+	// otherwise FilesystemSource will return a NotSupported error.
+	FilesystemSourceFunc func(*config.Config, *storage.Config) (storage.FilesystemSource, error)
+
+	// ValidateConfigFunc will be called by ValidateConfig, if non-nil;
+	// otherwise ValidateConfig returns nil.
+	ValidateConfigFunc func(*storage.Config) error
+
+	// SupportsFunc will be called by Supports, if non-nil; otherwise,
+	// Supports returns true.
+	SupportsFunc func(kind storage.StorageKind) bool
+}
+
+// VolumeSource is defined on storage.Provider.
+func (p *StorageProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
+	if p.VolumeSourceFunc != nil {
+		return p.VolumeSourceFunc(environConfig, providerConfig)
+	}
+	return nil, errors.NotSupportedf("volumes")
+}
+
+// FilesystemSource is defined on storage.Provider.
+func (p *StorageProvider) FilesystemSource(environConfig *config.Config, providerConfig *storage.Config) (storage.FilesystemSource, error) {
+	if p.FilesystemSourceFunc != nil {
+		return p.FilesystemSourceFunc(environConfig, providerConfig)
+	}
+	return nil, errors.NotSupportedf("filesystems")
+}
+
+// ValidateConfig is defined on storage.Provider.
+func (p *StorageProvider) ValidateConfig(providerConfig *storage.Config) error {
+	if p.ValidateConfigFunc != nil {
+		return p.ValidateConfigFunc(providerConfig)
+	}
+	return nil
+}
+
+// Supports is defined on storage.Provider.
+func (p *StorageProvider) Supports(kind storage.StorageKind) bool {
+	if p.SupportsFunc != nil {
+		return p.SupportsFunc(kind)
+	}
+	return true
+}
+
+// Scope is defined on storage.Provider.
+func (p *StorageProvider) Scope() storage.Scope {
+	return p.StorageScope
+}

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -80,6 +80,11 @@ func (*loopProvider) Supports(k storage.StorageKind) bool {
 	return k == storage.StorageKindBlock
 }
 
+// Scope is defined on the Provider interface.
+func (*loopProvider) Scope() storage.Scope {
+	return storage.ScopeMachine
+}
+
 // loopVolumeSource provides common functionality to handle
 // loop devices for rootfs and host loop volume sources.
 type loopVolumeSource struct {

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -72,6 +72,11 @@ func (s *loopSuite) TestSupports(c *gc.C) {
 	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsFalse)
 }
 
+func (s *loopSuite) TestScope(c *gc.C) {
+	p := s.loopProvider(c)
+	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
+}
+
 func (s *loopSuite) loopVolumeSource(c *gc.C) storage.VolumeSource {
 	s.commands = &mockRunCommand{c: c}
 	return provider.LoopVolumeSource(

--- a/storage/provider/registry/providerregistry.go
+++ b/storage/provider/registry/providerregistry.go
@@ -19,7 +19,15 @@ import (
 var providers = make(map[storage.ProviderType]storage.Provider)
 
 // RegisterProvider registers a new storage provider of the given type.
+//
+// If the provider is nil, then any previously registered provider with
+// the same type will be unregistered; this is purely available for
+// testing.
 func RegisterProvider(providerType storage.ProviderType, p storage.Provider) {
+	if p == nil {
+		delete(providers, providerType)
+		return
+	}
 	if providers[providerType] != nil {
 		panic(errors.Errorf("juju: duplicate storage provider type %q", providerType))
 	}

--- a/storage/provider/registry/providerregistry_test.go
+++ b/storage/provider/registry/providerregistry_test.go
@@ -32,6 +32,20 @@ func (s *providerRegistrySuite) TestRegisterProvider(c *gc.C) {
 	c.Assert(p, gc.Equals, p1)
 }
 
+func (s *providerRegistrySuite) TestUnregisterProvider(c *gc.C) {
+	ptype := storage.ProviderType("foo")
+
+	// No-op, since there's nothing registered yet.
+	registry.RegisterProvider(ptype, nil)
+
+	// Register and then unregister, ensure that the provider cannot
+	// be accessed.
+	registry.RegisterProvider(ptype, &mockProvider{})
+	registry.RegisterProvider(ptype, nil)
+	_, err := registry.StorageProvider(storage.ProviderType("foo"))
+	c.Assert(err, gc.ErrorMatches, `storage provider "foo" not found`)
+}
+
 func (s *providerRegistrySuite) TestNoSuchProvider(c *gc.C) {
 	_, err := registry.StorageProvider(storage.ProviderType("foo"))
 	c.Assert(err, gc.ErrorMatches, `storage provider "foo" not found`)

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -74,6 +74,11 @@ func (*rootfsProvider) Supports(k storage.StorageKind) bool {
 	return k == storage.StorageKindFilesystem
 }
 
+// Scope is defined on the Provider interface.
+func (*rootfsProvider) Scope() storage.Scope {
+	return storage.ScopeMachine
+}
+
 type rootfsFilesystemSource struct {
 	dirFuncs   dirFuncs
 	run        runCommandFunc

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -67,6 +67,11 @@ func (s *rootfsSuite) TestSupports(c *gc.C) {
 	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsTrue)
 }
 
+func (s *rootfsSuite) TestScope(c *gc.C) {
+	p := s.rootfsProvider(c)
+	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
+}
+
 func (s *rootfsSuite) rootfsFilesystemSource(c *gc.C) storage.FilesystemSource {
 	s.commands = &mockRunCommand{c: c}
 	return provider.RootfsFilesystemSource(

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -72,6 +72,11 @@ func (*tmpfsProvider) Supports(k storage.StorageKind) bool {
 	return k == storage.StorageKindFilesystem
 }
 
+// Scope is defined on the Provider interface.
+func (*tmpfsProvider) Scope() storage.Scope {
+	return storage.ScopeMachine
+}
+
 type tmpfsFilesystemSource struct {
 	dirFuncs   dirFuncs
 	run        runCommandFunc

--- a/storage/provider/tmpfs_test.go
+++ b/storage/provider/tmpfs_test.go
@@ -67,6 +67,11 @@ func (s *tmpfsSuite) TestSupports(c *gc.C) {
 	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsTrue)
 }
 
+func (s *tmpfsSuite) TestScope(c *gc.C) {
+	p := s.tmpfsProvider(c)
+	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
+}
+
 func (s *tmpfsSuite) tmpfsFilesystemSource(c *gc.C) storage.FilesystemSource {
 	s.commands = &mockRunCommand{c: c}
 	return provider.TmpfsFilesystemSource(

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -239,7 +239,7 @@ func (s *factorySuite) TestMakeMachine(c *gc.C) {
 	c.Assert(machine.CheckProvisioned(nonce), jc.IsTrue)
 	c.Assert(machine.PasswordValid(password), jc.IsTrue)
 
-	volume, err := s.State.Volume(names.NewVolumeTag("0"))
+	volume, err := s.State.Volume(names.NewVolumeTag(machine.Id() + "/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	volParams, ok := volume.Params()
 	c.Assert(ok, jc.IsTrue)


### PR DESCRIPTION
When creating a volume or filesystem ID, we now enquire about the scope
from the storage provider and, if it's machine-scoped, encode that in the
ID.

We also introduce WatchEnvironVolumes and WatchMachineVolumes. The former
watches environ-scoped volumes for lifecycle changes, while the latter
watches volumes scoped to a specific machine.

(Review request: http://reviews.vapour.ws/r/1128/)