### PR TITLE
Lighten log to Debugf

### DIFF
--- a/worker/uniter/charm/git_deployer.go
+++ b/worker/uniter/charm/git_deployer.go
@@ -199,7 +199,7 @@ func (d *gitDeployer) upgrade() error {
 func collectGitOrphans(dataPath string) {
 	current, err := symlink.Read(filepath.Join(dataPath, gitCurrentPath))
 	if os.IsNotExist(err) {
-		logger.Warningf("no current staging repo")
+		logger.Debugf("no current staging repo")
 	} else if err != nil {
 		logger.Warningf("cannot read current staging repo: %v", err)
 		return


### PR DESCRIPTION
https://bugs.launchpad.net/juju-core/+bug/1351099

The message is printed near the end of every juju log I have seen.  Seems the wrong thing to have (a Warning) at the end of every juju debug-log tail.