### PR TITLE
Fix CI Blocker 1430791

### DIFF
--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -71,6 +71,19 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 	c.Assert(keyExists, jc.IsFalse)
 }
 
+func (s *upgradesSuite) TestUserTagNameFallsBackToId(c *gc.C) {
+	// Make old style user without name field set.
+	user := User{
+		st: s.state,
+		doc: userDoc{
+			DocID: "BoB",
+		},
+	}
+
+	tag := user.UserTag()
+	c.Assert(tag.Name(), gc.Equals, "BoB")
+}
+
 func (s *upgradesSuite) TestAddNameFieldLowerCaseIdOfUsers(c *gc.C) {
 	s.addCaseSensitiveUsers(c, [][]string{
 		{"BoB", "Bob the Builder"},

--- a/state/user.go
+++ b/state/user.go
@@ -201,7 +201,13 @@ func (u *User) Tag() names.Tag {
 
 // UserTag returns the Tag for the User.
 func (u *User) UserTag() names.UserTag {
-	return names.NewLocalUserTag(u.doc.Name)
+	name := u.doc.Name
+	if name == "" {
+		// TODO(waigani) This is a hack for upgrades to 1.23. Once we are no
+		// longer tied to 1.23, we can confidently always use u.doc.Name.
+		name = u.doc.DocID
+	}
+	return names.NewLocalUserTag(name)
 }
 
 // LastLogin returns when this User last connected through the API in UTC.


### PR DESCRIPTION
Make state.User.UserTag() fall back to "_id" field if "name" field
empty. This should only ever happen during an upgrade to 1.23.

(Review request: http://reviews.vapour.ws/r/1133/)