### PR TITLE
Leadership operations

### DIFF
--- a/worker/leadership/interface.go
+++ b/worker/leadership/interface.go
@@ -44,6 +44,10 @@ type Tracker interface {
 	// WaitLeader will return a Ticket which, when Wait()ed for, will block
 	// until the tracker attains leadership.
 	WaitLeader() Ticket
+
+	// WaitMinion will return a Ticket which, when Wait()ed for, will block
+	// until the tracker's future leadership can no longer be guaranteed.
+	WaitMinion() Ticket
 }
 
 // TrackerWorker embeds the Tracker and worker.Worker interfaces.

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -55,6 +55,11 @@ func (hi Info) Validate() error {
 			}
 			return nil
 		}
+	// TODO(fwereade): define these in charm/hooks...
+	case hooks.Kind("leader-elected"), hooks.Kind("leader-deposed"), hooks.Kind("leader-settings-changed"):
+		if featureflag.Enabled(feature.LeaderElection) {
+			return nil
+		}
 	}
 	return fmt.Errorf("unknown hook kind %q", hi.Kind)
 }

--- a/worker/uniter/operation/errors.go
+++ b/worker/uniter/operation/errors.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	ErrNoStateFile = errors.New("uniter state file does not exist")
-	ErrSkipExecute = errors.New("operation already executed")
-	ErrNeedsReboot = errors.New("reboot request issued")
-	ErrHookFailed  = errors.New("hook failed")
+	ErrNoStateFile            = errors.New("uniter state file does not exist")
+	ErrSkipExecute            = errors.New("operation already executed")
+	ErrNeedsReboot            = errors.New("reboot request issued")
+	ErrHookFailed             = errors.New("hook failed")
+	ErrCannotAcceptLeadership = errors.New("cannot accept leadership")
 )
 
 type deployConflictError struct {

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -176,3 +176,13 @@ func (f *factory) NewUpdateStorage(tags []names.StorageTag) (Operation, error) {
 		storageUpdater: f.storageUpdater,
 	}, nil
 }
+
+// NewResignLeadership is part of the Factory interface.
+func (f *factory) NewResignLeadership() (Operation, error) {
+	return &resignLeadership{}, nil
+}
+
+// NewAcceptLeadership is part of the Factory interface.
+func (f *factory) NewAcceptLeadership() (Operation, error) {
+	return &acceptLeadership{}, nil
+}

--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -212,8 +212,20 @@ func (s *FactorySuite) TestNewHookString_Skip(c *gc.C) {
 	c.Check(op.String(), gc.Equals, "clear resolved flag and skip run relation-joined (123; foo/22) hook")
 }
 
-func (s *FactorySuite) TestNewUpdateRelations(c *gc.C) {
+func (s *FactorySuite) TestNewUpdateRelationsString(c *gc.C) {
 	op, err := s.factory.NewUpdateRelations([]int{1, 2, 3})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(op.String(), gc.Equals, "update relations [1 2 3]")
+}
+
+func (s *FactorySuite) TestNewAcceptLeadershipString(c *gc.C) {
+	op, err := s.factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "accept leadership")
+}
+
+func (s *FactorySuite) TestNewResignLeadershipString(c *gc.C) {
+	op, err := s.factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "resign leadership")
 }

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -103,6 +103,14 @@ type Factory interface {
 	// NewUpdateStorage creates an operation to ensure the supplied storage
 	// tags are known and tracked.
 	NewUpdateStorage(tags []names.StorageTag) (Operation, error)
+
+	// NewAcceptLeadership creates an operation to ensure the uniter acts as
+	// service leader.
+	NewAcceptLeadership() (Operation, error)
+
+	// NewResignLeadership creates an operation to ensure the uniter does not
+	// act as service leader.
+	NewResignLeadership() (Operation, error)
 }
 
 // CommandArgs stores the arguments for a Command operation.

--- a/worker/uniter/operation/leader.go
+++ b/worker/uniter/operation/leader.go
@@ -12,10 +12,12 @@ import (
 
 type acceptLeadership struct{}
 
+// String is part of the Operation interface.
 func (al *acceptLeadership) String() string {
 	return "accept leadership"
 }
 
+// Prepare is part of the Operation interface.
 func (al *acceptLeadership) Prepare(state State) (*State, error) {
 	if err := al.checkState(state); err != nil {
 		return nil, err
@@ -23,10 +25,12 @@ func (al *acceptLeadership) Prepare(state State) (*State, error) {
 	return nil, ErrSkipExecute
 }
 
+// Execute is part of the Operation interface.
 func (al *acceptLeadership) Execute(state State) (*State, error) {
 	return nil, errors.New("prepare always errors; Execute is never valid")
 }
 
+// Commit is part of the Operation interface.
 func (al *acceptLeadership) Commit(state State) (*State, error) {
 	if err := al.checkState(state); err != nil {
 		return nil, err
@@ -57,10 +61,12 @@ func (al *acceptLeadership) checkState(state State) error {
 
 type resignLeadership struct{}
 
+// String is part of the Operation interface.
 func (rl *resignLeadership) String() string {
 	return "resign leadership"
 }
 
+// Prepare is part of the Operation interface.
 func (rl *resignLeadership) Prepare(state State) (*State, error) {
 	if !state.Leader {
 		// Nothing needs to be done -- state.Leader should only be set to
@@ -71,6 +77,7 @@ func (rl *resignLeadership) Prepare(state State) (*State, error) {
 	return nil, nil
 }
 
+// Execute is part of the Operation interface.
 func (rl *resignLeadership) Execute(state State) (*State, error) {
 	// TODO(fwereade): this hits a lot of interestingly intersecting problems.
 	//
@@ -106,6 +113,7 @@ func (rl *resignLeadership) Execute(state State) (*State, error) {
 	return nil, nil
 }
 
+// Commit is part of the Operation interface.
 func (rl *resignLeadership) Commit(state State) (*State, error) {
 	state.Leader = false
 	return &state, nil

--- a/worker/uniter/operation/leader.go
+++ b/worker/uniter/operation/leader.go
@@ -1,0 +1,112 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/worker/uniter/hook"
+)
+
+type acceptLeadership struct{}
+
+func (al *acceptLeadership) String() string {
+	return "accept leadership"
+}
+
+func (al *acceptLeadership) Prepare(state State) (*State, error) {
+	if err := al.checkState(state); err != nil {
+		return nil, err
+	}
+	return nil, ErrSkipExecute
+}
+
+func (al *acceptLeadership) Execute(state State) (*State, error) {
+	return nil, errors.New("prepare always errors; Execute is never valid")
+}
+
+func (al *acceptLeadership) Commit(state State) (*State, error) {
+	if err := al.checkState(state); err != nil {
+		return nil, err
+	}
+	if state.Leader {
+		// Nothing needs to be done -- leader is only set when queueing a
+		// leader-elected hook. Therefore, if leader is true, the appropriate
+		// hook must be either queued or already run.
+		return nil, nil
+	}
+	newState := stateChange{
+		Kind: RunHook,
+		Step: Queued,
+		Hook: &hook.Info{Kind: hooks.Kind("leader-elected")},
+	}.apply(state)
+	newState.Leader = true
+	return newState, nil
+}
+
+func (al *acceptLeadership) checkState(state State) error {
+	if state.Kind != Continue {
+		// We'll need to queue up a hook, and we can't do that without
+		// stomping on existing state.
+		return ErrCannotAcceptLeadership
+	}
+	return nil
+}
+
+type resignLeadership struct{}
+
+func (rl *resignLeadership) String() string {
+	return "resign leadership"
+}
+
+func (rl *resignLeadership) Prepare(state State) (*State, error) {
+	if !state.Leader {
+		// Nothing needs to be done -- state.Leader should only be set to
+		// false when committing the leader-deposed hook. This code is not
+		// helpful while Execute is a no-op, but it will become so.
+		return nil, ErrSkipExecute
+	}
+	return nil, nil
+}
+
+func (rl *resignLeadership) Execute(state State) (*State, error) {
+	// TODO(fwereade): this hits a lot of interestingly intersecting problems.
+	//
+	// 1) we can't yet create a sufficiently dumbed-down hook context for a
+	//    leader-deposed hook to run as specced. (This is the proximate issue,
+	//    and is sufficient to prevent us from implementing this op right.)
+	// 2) we want to write a state-file change, so this has to be an operation
+	//    (or, at least, it has to be serialized with all other operations).
+	//      * note that the change we write must *not* include the RunHook
+	//        operation for leader-deposed -- we want to run this at high
+	//        priority, in any possible state, and not to disturn what's
+	//        there other than to note that we no longer think we're leader.
+	// 3) the hook execution itself *might* not need to be serialized with
+	//    other operations, which is moot until we consider that:
+	// 4) we want to invoke this behaviour from elsewhere (ie when we don't
+	//    have an api connection available), but:
+	// 5) we can't get around the serialization requirement in (2).
+	//
+	// So. I *think* that the right approach is to implement a no-api uniter
+	// variant, that we run *instead of* the normal uniter when the API is
+	// unavailable, and replace with a real uniter when appropriate; this
+	// implies that we need to take care not to allow the implementations to
+	// diverge, but implementing them both as "uniters" is probably the best
+	// way to encourage logic-sharing and prevent that problem.
+	//
+	// In the short term, though, we can just run leader-deposed as soon as we
+	// can build the right environment. Not sure whether this particular type
+	// will still be justified, or whether it'll just be a plain old RunHook --
+	// I *think* it will stay, because the state-writing behaviour will stay
+	// very different (ie just write `.Leader = false` and don't step on pre-
+	// queued hooks).
+	logger.Warningf("we should run a leader-deposed hook here, but we can't yet")
+	return nil, nil
+}
+
+func (rl *resignLeadership) Commit(state State) (*State, error) {
+	state.Leader = false
+	return &state, nil
+}

--- a/worker/uniter/operation/leader_test.go
+++ b/worker/uniter/operation/leader_test.go
@@ -1,0 +1,181 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+type LeaderSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&LeaderSuite{})
+
+func (s *LeaderSuite) TestAcceptLeadership_Prepare_BadState(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Check(newState, gc.IsNil)
+	// accept is only valid in Continue mode, when we're sure nothing is queued
+	// or in progress.
+	c.Check(err, gc.Equals, operation.ErrCannotAcceptLeadership)
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Prepare_NotLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{Kind: operation.Continue})
+	c.Check(newState, gc.IsNil)
+	// *execute* is currently just a no-op -- all the meat happens in commit.
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Prepare_AlreadyLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{
+		Kind:   operation.Continue,
+		Leader: true,
+	})
+	c.Check(newState, gc.IsNil)
+	// *execute* is currently just a no-op -- all the meat happens in commit.
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Commit_NotLeader_BlankSlate(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+
+	newState, err := op.Commit(operation.State{
+		Kind: operation.Continue,
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(newState, gc.DeepEquals, &operation.State{
+		Kind:   operation.RunHook,
+		Step:   operation.Queued,
+		Hook:   &hook.Info{Kind: hooks.Kind("leader-elected")},
+		Leader: true,
+	})
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Commit_NotLeader_Preserve(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+
+	newState, err := op.Commit(operation.State{
+		Kind:               operation.Continue,
+		Started:            true,
+		CollectMetricsTime: 1234567,
+		Hook:               &hook.Info{Kind: hooks.Install},
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(newState, gc.DeepEquals, &operation.State{
+		Kind:               operation.RunHook,
+		Step:               operation.Queued,
+		Hook:               &hook.Info{Kind: hooks.Kind("leader-elected")},
+		Leader:             true,
+		Started:            true,
+		CollectMetricsTime: 1234567,
+	})
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Commit_AlreadyLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+
+	newState, err := op.Commit(operation.State{
+		Kind:   operation.Continue,
+		Leader: true,
+	})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Prepare_Leader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{Leader: true})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Prepare_NotLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Execute(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = op.Prepare(operation.State{Leader: true})
+	c.Check(err, jc.ErrorIsNil)
+
+	// Execute is a no-op (which logs that we should run leader-deposed)
+	newState, err := op.Execute(operation.State{})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Commit_ClearLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Commit(operation.State{Leader: true})
+	c.Check(newState, gc.DeepEquals, &operation.State{})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Commit_PreserveOthers(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Commit(overwriteState)
+	c.Check(newState, gc.DeepEquals, &overwriteState)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Commit_All(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	leaderState := overwriteState
+	leaderState.Leader = true
+	newState, err := op.Commit(leaderState)
+	c.Check(newState, gc.DeepEquals, &overwriteState)
+	c.Check(err, jc.ErrorIsNil)
+}

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -118,7 +118,7 @@ func (rh *runHook) Commit(state State) (*State, error) {
 		Step: Queued,
 	}
 	switch rh.info.Kind {
-	case hooks.Install, hooks.UpgradeCharm:
+	case hooks.UpgradeCharm:
 		change.Hook = &hook.Info{Kind: hooks.ConfigChanged}
 	case hooks.ConfigChanged:
 		if !state.Started {

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -528,14 +528,6 @@ func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause, effect hooks.Kind)
 	}
 }
 
-func (s *RunHookSuite) TestQueueHook_Install_BlankSlate(c *gc.C) {
-	s.testQueueHook_BlankSlate(c, hooks.Install, hooks.ConfigChanged)
-}
-
-func (s *RunHookSuite) TestQueueHook_Install_Preserve(c *gc.C) {
-	s.testQueueHook_Preserve(c, hooks.Install, hooks.ConfigChanged)
-}
-
 func (s *RunHookSuite) TestQueueHook_UpgradeCharm_BlankSlate(c *gc.C) {
 	s.testQueueHook_BlankSlate(c, hooks.UpgradeCharm, hooks.ConfigChanged)
 }
@@ -584,6 +576,18 @@ func (s *RunHookSuite) testQueueNothing_Preserve(c *gc.C, hookInfo hook.Info) {
 			},
 		)
 	}
+}
+
+func (s *RunHookSuite) TestQueueNothing_Install_BlankSlate(c *gc.C) {
+	s.testQueueNothing_BlankSlate(c, hook.Info{
+		Kind: hooks.Install,
+	})
+}
+
+func (s *RunHookSuite) TestQueueNothing_Install_Preserve(c *gc.C) {
+	s.testQueueNothing_Preserve(c, hook.Info{
+		Kind: hooks.Install,
+	})
 }
 
 func (s *RunHookSuite) TestQueueNothing_Stop_BlankSlate(c *gc.C) {

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -56,7 +56,7 @@ const (
 // state.
 type State struct {
 
-	// Leader indicates whether a leader-elected hook has started to run, and
+	// Leader indicates whether a leader-elected hook has been queued to run, and
 	// no more recent leader-deposed hook has completed.
 	Leader bool `yaml:"leader"`
 


### PR DESCRIPTION
Add a functional AcceptLeadership operation, and an adequate dummy ResignLeadership; also made leader hooks temporarily valid here. Nothing invoked yet.

(Review request: http://reviews.vapour.ws/r/1134/)