### PR TITLE
State: Upgrade step to lower-case _id of envUser

### DIFF
--- a/state/envuser_internal_test.go
+++ b/state/envuser_internal_test.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type internalEnvUserSuite struct {
+	internalStateSuite
+}
+
+var _ = gc.Suite(&internalEnvUserSuite{})
+
+func (s *internalEnvUserSuite) TestCreateEnvUserOpAndDoc(c *gc.C) {
+	tag := names.NewUserTag("UserName")
+	op, doc := createEnvUserOpAndDoc("ignored", tag, names.NewUserTag("ignored"), "ignored")
+
+	c.Assert(op.Id, gc.Equals, "username@local")
+	c.Assert(doc.ID, gc.Equals, "username@local")
+	c.Assert(doc.UserName, gc.Equals, "UserName@local")
+}
+
+func (s *internalEnvUserSuite) TestCaseUserNameVsId(c *gc.C) {
+	env, err := s.state.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	user, err := s.state.AddEnvironmentUser(names.NewUserTag("Bob@RandomProvider"), env.Owner())
+	c.Assert(err, gc.IsNil)
+	c.Assert(user.UserName(), gc.Equals, "Bob@RandomProvider")
+	c.Assert(user.doc.ID, gc.Equals, s.state.docID("bob@randomprovider"))
+}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -485,6 +485,7 @@ func AddNameFieldLowerCaseIdOfUsers(st *State) error {
 			}, txn.Op{
 				C:      usersC,
 				Id:     user["_id"],
+				Assert: txn.DocMissing,
 				Insert: user,
 			})
 		} else {
@@ -495,6 +496,39 @@ func AddNameFieldLowerCaseIdOfUsers(st *State) error {
 				Update: bson.D{{"$set", bson.D{
 					{"name", user["name"]},
 				}}},
+			})
+		}
+		user = nil
+	}
+	if err := iter.Err(); err != nil {
+		return errors.Trace(err)
+	}
+	return st.runRawTransaction(ops)
+}
+
+func LowerCaseEnvUsersID(st *State) error {
+	users, closer := st.getRawCollection(envUsersC)
+	defer closer()
+
+	var ops []txn.Op
+	var user bson.M
+	iter := users.Find(nil).Iter()
+	defer iter.Close()
+	for iter.Next(&user) {
+		oldId := user["_id"].(string)
+		newId := strings.ToLower(oldId)
+
+		if oldId != newId {
+			user["_id"] = newId
+			ops = append(ops, txn.Op{
+				C:      envUsersC,
+				Id:     oldId,
+				Remove: true,
+			}, txn.Op{
+				C:      envUsersC,
+				Id:     user["_id"],
+				Assert: txn.DocMissing,
+				Insert: user,
 			})
 		}
 		user = nil

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -57,6 +57,12 @@ func stateStepsFor123() []Step {
 			run: func(context Context) error {
 				return state.AddNameFieldLowerCaseIdOfUsers(context.State())
 			},
+		}, &upgradeStep{
+			description: "lower case _id of envUsers",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.LowerCaseEnvUsersID(context.State())
+			},
 		},
 	)
 	return steps

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -29,6 +29,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 		"move blocks from environment to state",
 		"insert userenvnameC doc for each environment",
 		"add name field to users and lowercase _id field",
+		"lower case _id of envUsers",
 	}
 	assertStateSteps(c, version.MustParse("1.23.0"), expected)
 }


### PR DESCRIPTION
Add an upgrade step (targeting 1.23) which lower cases the envUserDoc "_id" field. 
Ensure no more than one envUser can be created with the same, case insensitive,
name and that state.EnvironmentUser() lookups are case insensitive.

Manually tested upgrade from 1.21 to 1.23.

(Review request: http://reviews.vapour.ws/r/1143/)