### PR TITLE
Fixed lp:1431134 - container addressability fixes with lxc-clone

### DIFF
--- a/container/export_test.go
+++ b/container/export_test.go
@@ -4,9 +4,8 @@
 package container
 
 var (
-	NetworkInterfacesFile          = &networkInterfacesFile
-	NewCloudInitConfigWithNetworks = newCloudInitConfigWithNetworks
-	CloudInitUserData              = cloudInitUserData
+	NetworkInterfacesFile = &networkInterfacesFile
+	CloudInitUserData     = cloudInitUserData
 )
 
 // IsLocked is used just to see if the local lock instance is locked, and

--- a/container/kvm/initialisation.go
+++ b/container/kvm/initialisation.go
@@ -46,7 +46,7 @@ You could try running 'kvm-ok' yourself as root to get the full rationale as to
 why it isn't supported, or potentially some BIOS settings to change to enable
 KVM support.`
 
-const neetToInstallKVMOk = `kvm-ok is not installed. Please install the cpu-checker package.
+const needToInstallKVMOk = `kvm-ok is not installed. Please install the cpu-checker package.
     sudo apt-get install cpu-checker`
 
 const missingKVMDeps = `Some required packages are missing for KVM to work:
@@ -63,7 +63,7 @@ func VerifyKVMEnabled() error {
 	supported, err := IsKVMSupported()
 	if err != nil {
 		// Missing the kvm-ok package.
-		return fmt.Errorf(neetToInstallKVMOk)
+		return fmt.Errorf(needToInstallKVMOk)
 	}
 	if !supported {
 		return fmt.Errorf(kvmNotSupported)

--- a/container/lxc/initialisation.go
+++ b/container/lxc/initialisation.go
@@ -32,8 +32,9 @@ func (ci *containerInitialiser) Initialise() error {
 	return ensureDependencies(ci.series)
 }
 
-// ensureDependencies creates a set of install packages using AptGetPreparePackages
-// and runs each set of packages through AptGetInstall
+// ensureDependencies creates a set of install packages using
+// apt.GetPreparePackages and runs each set of packages through
+// apt.GetInstall.
 func ensureDependencies(series string) error {
 	var err error
 	aptGetInstallCommandList := apt.GetPreparePackages(requiredPackages, series)

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -350,7 +350,7 @@ func (manager *containerManager) CreateContainer(
 			if err != nil {
 				return nil, nil, errors.Annotatef(err, "failed to generate %q", interfacesFile)
 			}
-			if err := utils.AtomicWriteFile(interfacesFile, data, 0644); err != nil {
+			if err := utils.AtomicWriteFile(interfacesFile, []byte(data), 0644); err != nil {
 				return nil, nil, errors.Annotatef(err, "cannot write generated %q", interfacesFile)
 			}
 			logger.Tracef("pre-rendered network config in %q", interfacesFile)

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -324,7 +324,7 @@ lxc.network.link = nic42
 lxc.network.flags = up
 lxc.network.name = eth0
 lxc.network.hwaddr = aa:bb:cc:dd:ee:f0
-lxc.network.ipv4 = 0.1.2.3/20
+lxc.network.ipv4 = 0.1.2.3/32
 lxc.network.ipv4.gateway = 0.1.2.1
 lxc.network.mtu = 4321
 
@@ -371,7 +371,7 @@ lxc.network.type = bar
 lxc.network.flags = up
 lxc.network.name = em0
 lxc.network.hwaddr = ff:ee:dd:cc:bb:aa
-lxc.network.ipv4 = 0.1.2.3/20
+lxc.network.ipv4 = 0.1.2.3/32
 lxc.network.ipv4.gateway = 0.1.2.1
 lxc.network.mtu = 1234
 
@@ -765,6 +765,7 @@ func (s *LxcSuite) createTemplate(c *gc.C) golxc.Container {
 		true,
 		true,
 		&containertesting.MockURLGetter{},
+		false,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(template.Name(), gc.Equals, name)
@@ -797,17 +798,38 @@ lxc.network.mtu = 4321
 }
 
 func (s *LxcSuite) TestShutdownInitScript(c *gc.C) {
-	script, err := lxc.ShutdownInitScript(service.InitSystemUpstart)
+	script, err := lxc.ShutdownInitScript(false, service.InitSystemUpstart)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(script, gc.Equals, `
+	c.Check(script, jc.DeepEquals, `
 cat >> /etc/init/juju-template-restart.conf << 'EOF'
 description "juju shutdown job"
 author "Juju Team <juju@lists.ubuntu.com>"
 start on stopped cloud-final
 
 script
-  /sbin/shutdown -h now
+  /bin/sh -c 'rm -fr /etc/network/interfaces /var/lib/dhcp/dhclient* /var/log/cloud-init*.log /var/log/upstart/*.log ; shutdown -h now'
+end script
+
+post-stop script
+  rm /etc/init/juju-template-restart.conf
+end script
+
+EOF
+`[1:])
+
+	// With AUFS /etc/network/interfaces should not be removed.
+	script, err = lxc.ShutdownInitScript(true, service.InitSystemUpstart)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(script, jc.DeepEquals, `
+cat >> /etc/init/juju-template-restart.conf << 'EOF'
+description "juju shutdown job"
+author "Juju Team <juju@lists.ubuntu.com>"
+start on stopped cloud-final
+
+script
+  /bin/sh -c 'rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log /var/log/upstart/*.log ; shutdown -h now'
 end script
 
 post-stop script
@@ -1097,7 +1119,7 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.flags = up",
 			"lxc.network.name = eth1",
 			"lxc.network.hwaddr = aa:bb:cc:dd:ee:f1",
-			"lxc.network.ipv4 = 0.1.2.3/20",
+			"lxc.network.ipv4 = 0.1.2.3/32",
 			"lxc.network.ipv4.gateway = 0.1.2.1",
 			"lxc.network.mtu = 9000",
 
@@ -1118,10 +1140,9 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.flags = up",
 			"lxc.network.name = eth1",
 			"lxc.network.hwaddr = aa:bb:cc:dd:ee:f1",
-			"lxc.network.ipv4 = 0.1.2.3/24",
+			"lxc.network.ipv4 = 0.1.2.3/32",
 			"lxc.network.ipv4.gateway = 0.1.2.1",
 		},
-		logContains: `WARNING juju.container.lxc invalid CIDR "" for interface "eth1", using /24 as fallback`,
 	}, {
 		config: container.BridgeNetworkConfig("foo", []network.InterfaceInfo{staticNICBadCIDR}),
 		nics:   []network.InterfaceInfo{staticNICBadCIDR},
@@ -1131,10 +1152,9 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.flags = up",
 			"lxc.network.name = eth1",
 			"lxc.network.hwaddr = aa:bb:cc:dd:ee:f1",
-			"lxc.network.ipv4 = 0.1.2.3/24",
+			"lxc.network.ipv4 = 0.1.2.3/32",
 			"lxc.network.ipv4.gateway = 0.1.2.1",
 		},
-		logContains: `WARNING juju.container.lxc invalid CIDR "bad" for interface "eth1", using /24 as fallback`,
 	}, {
 		config: container.BridgeNetworkConfig("foo", []network.InterfaceInfo{staticNICNoAutoWithGW}),
 		nics:   []network.InterfaceInfo{staticNICNoAutoWithGW},
@@ -1143,7 +1163,7 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.link = foo",
 			"lxc.network.name = eth1",
 			"lxc.network.hwaddr = aa:bb:cc:dd:ee:f1",
-			"lxc.network.ipv4 = 0.1.2.3/20",
+			"lxc.network.ipv4 = 0.1.2.3/32",
 		},
 		logContains: `WARNING juju.container.lxc not setting IPv4 gateway "0.1.2.1" for non-auto start interface "eth1"`,
 	}} {

--- a/container/userdata.go
+++ b/container/userdata.go
@@ -56,14 +56,14 @@ auto lo
 iface lo inet loopback{{define "static"}}
 {{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
 auto {{.InterfaceName}}{{end}}
-iface {{.InterfaceName}} inet static
-    address {{.Address.Value}}
-    netmask {{.CIDR}}{{if gt (len .DNSServers) 0}}
+iface {{.InterfaceName}} inet manual{{if gt (len .DNSServers) 0}}
     dns-nameservers{{range $dns := .DNSServers}} {{$dns.Value}}{{end}}{{end}}
-    pre-up ip route add {{.GatewayAddress.Value}} dev {{.InterfaceName}}
-    pre-up ip route add default via {{.GatewayAddress.Value}}
-    post-down ip route del default via {{.GatewayAddress.Value}}
-    post-down ip route del {{.GatewayAddress.Value}} dev {{.InterfaceName}}
+    pre-up ip address add {{.Address.Value}}/32 dev {{.InterfaceName}} &> /dev/null || true
+    up ip route replace {{.GatewayAddress.Value}} dev {{.InterfaceName}}
+    up ip route replace default via {{.GatewayAddress.Value}}
+    down ip route del default via {{.GatewayAddress.Value}} &> /dev/null || true
+    down ip route del {{.GatewayAddress.Value}} dev {{.InterfaceName}} &> /dev/null || true
+    post-down ip address del {{.Address.Value}}/32 dev {{.InterfaceName}} &> /dev/null || true
 {{end}}{{define "dhcp"}}
 {{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
 auto {{.InterfaceName}}{{end}}
@@ -73,30 +73,42 @@ iface {{.InterfaceName}} inet dhcp
 
 var networkInterfacesFile = "/etc/network/interfaces"
 
-// newCloudInitConfigWithNetworks creates a cloud-init config which
-// might include per-interface networking config if
-// networkConfig.Interfaces is not empty.
-func newCloudInitConfigWithNetworks(networkConfig *NetworkConfig) (*coreCloudinit.Config, error) {
-	cloudConfig := coreCloudinit.New()
+// GenerateNetworkConfig renders a network config for one or more
+// network interfaces, using the given non-nil networkConfig
+// containing a non-empty Interfaces field.
+func GenerateNetworkConfig(networkConfig *NetworkConfig) ([]byte, error) {
 	if networkConfig == nil || len(networkConfig.Interfaces) == 0 {
 		// Don't generate networking config.
-		logger.Tracef("no cloud-init network config to generate")
-		return cloudConfig, nil
+		logger.Tracef("no network config to generate")
+		return nil, nil
 	}
 
 	// Render the config first.
 	tmpl, err := template.New("config").Parse(networkConfigTemplate)
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot parse cloud-init network config template")
+		return nil, errors.Annotate(err, "cannot parse network config template")
 	}
 
 	var buf bytes.Buffer
 	if err = tmpl.Execute(&buf, networkConfig.Interfaces); err != nil {
-		return nil, errors.Annotate(err, "cannot render cloud-init network config")
+		return nil, errors.Annotate(err, "cannot render network config")
+	}
+
+	return buf.Bytes(), nil
+}
+
+// NewCloudInitConfigWithNetworks creates a cloud-init config which
+// might include per-interface networking config if both networkConfig
+// is not nil and its Interfaces field is not empty.
+func NewCloudInitConfigWithNetworks(networkConfig *NetworkConfig) (*coreCloudinit.Config, error) {
+	cloudConfig := coreCloudinit.New()
+	config, err := GenerateNetworkConfig(networkConfig)
+	if err != nil || config == nil {
+		return cloudConfig, errors.Trace(err)
 	}
 
 	// Now add it to cloud-init as a file created early in the boot process.
-	cloudConfig.AddBootTextFile(networkInterfacesFile, buf.String(), 0644)
+	cloudConfig.AddBootTextFile(networkInterfacesFile, string(config), 0644)
 	return cloudConfig, nil
 }
 
@@ -104,7 +116,7 @@ func cloudInitUserData(
 	machineConfig *cloudinit.MachineConfig,
 	networkConfig *NetworkConfig,
 ) ([]byte, error) {
-	cloudConfig, err := newCloudInitConfigWithNetworks(networkConfig)
+	cloudConfig, err := NewCloudInitConfigWithNetworks(networkConfig)
 	udata, err := cloudinit.NewUserdataConfig(machineConfig, cloudConfig)
 	if err != nil {
 		return nil, err

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -5,9 +5,11 @@ package container_test
 
 import (
 	"path/filepath"
+	"strings"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/container"
@@ -20,6 +22,8 @@ type UserDataSuite struct {
 	testing.BaseSuite
 
 	networkInterfacesFile string
+	fakeInterfaces        []network.InterfaceInfo
+	expectNetConfig       string
 }
 
 var _ = gc.Suite(&UserDataSuite{})
@@ -27,11 +31,7 @@ var _ = gc.Suite(&UserDataSuite{})
 func (s *UserDataSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.networkInterfacesFile = filepath.Join(c.MkDir(), "interfaces")
-	s.PatchValue(container.NetworkInterfacesFile, s.networkInterfacesFile)
-}
-
-func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
-	ifaces := []network.InterfaceInfo{{
+	s.fakeInterfaces = []network.InterfaceInfo{{
 		InterfaceName:  "eth0",
 		CIDR:           "0.1.2.0/24",
 		ConfigType:     network.ConfigStatic,
@@ -44,32 +44,61 @@ func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
 		ConfigType:    network.ConfigDHCP,
 		NoAutoStart:   true,
 	}}
-	netConfig := container.BridgeNetworkConfig("foo", ifaces)
+	s.expectNetConfig = `
+# loopback interface
+auto lo
+iface lo inet loopback
+
+# interface "eth0"
+auto eth0
+iface eth0 inet manual
+    dns-nameservers ns1.invalid ns2.invalid
+    pre-up ip address add 0.1.2.3/32 dev eth0 &> /dev/null || true
+    up ip route replace 0.1.2.1 dev eth0
+    up ip route replace default via 0.1.2.1
+    down ip route del default via 0.1.2.1 &> /dev/null || true
+    down ip route del 0.1.2.1 dev eth0 &> /dev/null || true
+    post-down ip address del 0.1.2.3/32 dev eth0 &> /dev/null || true
+
+# interface "eth1"
+iface eth1 inet dhcp
+`
+
+	s.PatchValue(container.NetworkInterfacesFile, s.networkInterfacesFile)
+}
+
+func (s *UserDataSuite) TestGenerateNetworkConfig(c *gc.C) {
+	// No config or no interfaces - no error, but also noting to generate.
+	data, err := container.GenerateNetworkConfig(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.IsNil)
+	netConfig := container.BridgeNetworkConfig("foo", nil)
+	data, err = container.GenerateNetworkConfig(netConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.IsNil)
+
+	// Test with all interface types.
+	netConfig = container.BridgeNetworkConfig("foo", s.fakeInterfaces)
+	data, err = container.GenerateNetworkConfig(netConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, s.expectNetConfig)
+}
+
+func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
+	netConfig := container.BridgeNetworkConfig("foo", s.fakeInterfaces)
 	cloudConf, err := container.NewCloudInitConfigWithNetworks(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
+	// We need to indent expectNetConfig to make it valid YAML,
+	// dropping the last new line and using unindented blank lines.
+	lines := strings.Split(s.expectNetConfig, "\n")
+	indentedNetConfig := strings.Join(lines[:len(lines)-1], "\n  ")
+	indentedNetConfig = strings.Replace(indentedNetConfig, "\n  \n", "\n\n", -1)
 	expected := `
 #cloud-config
 bootcmd:
 - install -D -m 644 /dev/null '`[1:] + s.networkInterfacesFile + `'
 - |-
-  printf '%s\n' '
-  # loopback interface
-  auto lo
-  iface lo inet loopback
-
-  # interface "eth0"
-  auto eth0
-  iface eth0 inet static
-      address 0.1.2.3
-      netmask 0.1.2.0/24
-      dns-nameservers ns1.invalid ns2.invalid
-      pre-up ip route add 0.1.2.1 dev eth0
-      pre-up ip route add default via 0.1.2.1
-      post-down ip route del default via 0.1.2.1
-      post-down ip route del 0.1.2.1 dev eth0
-
-  # interface "eth1"
-  iface eth1 inet dhcp
+  printf '%s\n' '` + indentedNetConfig + `
   ' > '` + s.networkInterfacesFile + `'
 `
 	assertUserData(c, cloudConf, expected)
@@ -100,4 +129,13 @@ func assertUserData(c *gc.C, cloudConf *cloudinit.Config, expected string) {
 	data, err := renderer.Render(cloudConf)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, expected)
+	// Make sure it's valid YAML as well.
+	out := make(map[string]interface{})
+	err = yaml.Unmarshal(data, &out)
+	c.Assert(err, jc.ErrorIsNil)
+	if len(cloudConf.BootCmds()) > 0 {
+		c.Assert(out["bootcmd"], jc.DeepEquals, cloudConf.BootCmds())
+	} else {
+		c.Assert(out["bootcmd"], gc.IsNil)
+	}
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -279,39 +279,39 @@ func (env *maasEnviron) getNodegroupInterfaces(nodegroups []string) map[string][
 		interfacesObject := nodegroupsObject.GetSubObject(uuid).GetSubObject("interfaces")
 		interfacesResult, err := interfacesObject.CallGet("list", nil)
 		if err != nil {
-			logger.Warningf("could not fetch nodegroup-interfaces for nodegroup %v: %v", uuid, err)
+			logger.Debugf("cannot list interfaces for nodegroup %v: %v", uuid, err)
 			continue
 		}
 		interfaces, err := interfacesResult.GetArray()
 		if err != nil {
-			logger.Warningf("could not fetch nodegroup-interfaces for nodegroup %v: %v", uuid, err)
+			logger.Debugf("cannot get interfaces for nodegroup %v: %v", uuid, err)
 			continue
 		}
 		for _, interfaceResult := range interfaces {
 			nic, err := interfaceResult.GetMap()
 			if err != nil {
-				logger.Warningf("could not fetch interface %v for nodegroup %v: %v", nic, uuid, err)
+				logger.Debugf("cannot get interface %v for nodegroup %v: %v", nic, uuid, err)
 				continue
 			}
 			ip, err := nic["ip"].GetString()
 			if err != nil {
-				logger.Warningf("could not fetch interface %v for nodegroup %v: %v", nic, uuid, err)
+				logger.Debugf("cannot get interface IP %v for nodegroup %v: %v", nic, uuid, err)
 				continue
 			}
 			static_low, err := nic["static_ip_range_low"].GetString()
 			if err != nil {
-				logger.Warningf("could not fetch static IP range lower bound for interface %v on nodegroup %v: %v", nic, uuid, err)
+				logger.Debugf("cannot get static IP range lower bound for interface %v on nodegroup %v: %v", nic, uuid, err)
 				continue
 			}
 			static_high, err := nic["static_ip_range_high"].GetString()
 			if err != nil {
-				logger.Warningf("could not fetch static IP range higher bound for interface %v on nodegroup %v: %v", nic, uuid, err)
+				logger.Infof("cannot get static IP range higher bound for interface %v on nodegroup %v: %v", nic, uuid, err)
 				continue
 			}
 			static_low_ip := net.ParseIP(static_low)
 			static_high_ip := net.ParseIP(static_high)
 			if static_low_ip == nil || static_high_ip == nil {
-				logger.Warningf("invalid IP in static range for interface %v on nodegroup %v: %q %q", nic, uuid, static_low_ip, static_high_ip)
+				logger.Debugf("invalid IP in static range for interface %v on nodegroup %v: %q %q", nic, uuid, static_low_ip, static_high_ip)
 				continue
 			}
 			nodegroupsInterfacesMap[ip] = []net.IP{static_low_ip, static_high_ip}
@@ -749,11 +749,11 @@ func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisa
 	var interfaceInfo []network.InterfaceInfo
 	for _, info := range tempInterfaceInfo {
 		if info.ProviderId == "" || info.NetworkName == "" || info.CIDR == "" {
-			logger.Warningf("ignoring network interface %q: missing network information", info.InterfaceName)
+			logger.Infof("ignoring interface %q: missing subnet info", info.InterfaceName)
 			continue
 		}
 		if info.MACAddress == "" || info.InterfaceName == "" {
-			logger.Warningf("ignoring network %q: missing network interface information", info.ProviderId)
+			logger.Infof("ignoring subnet %q: missing interface info", info.ProviderId)
 			continue
 		}
 		interfaceInfo = append(interfaceInfo, info)
@@ -1167,7 +1167,7 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 		return errors.Trace(err)
 	}
 	if len(subnets) != 1 {
-		return errors.Errorf("could not find network matching %v", subnetId)
+		return errors.Errorf("could not find subnet matching %q", subnetId)
 	}
 	foundSub := subnets[0]
 	logger.Tracef("found subnet %#v", foundSub)
@@ -1226,8 +1226,7 @@ func (environ *maasEnviron) NetworkInterfaces(instId instance.Id) ([]network.Int
 	inst := instances[0]
 	interfaces, _, err := environ.getInstanceNetworkInterfaces(inst)
 	if err != nil {
-		errors.Annotatef(err, "failed to get instance %q network interfaces", instId)
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "failed to get instance %q network interfaces", instId)
 	}
 
 	networks, err := environ.getInstanceNetworks(inst)
@@ -1312,7 +1311,7 @@ func (environ *maasEnviron) Subnets(instId instance.Id, subnetIds []network.Id) 
 	// At some point in the future an empty netIds may mean "fetch all subnets"
 	// but until that functionality is needed it's an error.
 	if len(subnetIds) == 0 {
-		return nil, errors.Errorf("netIds must not be empty")
+		return nil, errors.Errorf("subnetIds must not be empty")
 	}
 	instances, err := environ.acquiredInstances([]instance.Id{instId})
 	if err != nil {
@@ -1381,7 +1380,7 @@ func (environ *maasEnviron) Subnets(instId instance.Id, subnetIds []network.Id) 
 		// Verify we filled-in everything for all networks
 		// and drop incomplete records.
 		if subnetInfo.ProviderId == "" || subnetInfo.CIDR == "" {
-			logger.Warningf("ignoring subnet  %q: missing information (%#v)", subnet.Name, subnetInfo)
+			logger.Infof("ignoring subnet  %q: missing information (%#v)", subnet.Name, subnetInfo)
 			continue
 		}
 

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1155,7 +1155,7 @@ func (suite *environSuite) TestSubnets(c *gc.C) {
 func (suite *environSuite) TestSubnetsNoNetIds(c *gc.C) {
 	testInstance := suite.createSubnets(c, false)
 	_, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{})
-	c.Assert(err, gc.ErrorMatches, "netIds must not be empty")
+	c.Assert(err, gc.ErrorMatches, "subnetIds must not be empty")
 }
 
 func (suite *environSuite) TestSubnetsMissingNetwork(c *gc.C) {

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -49,7 +49,7 @@ func ListCommand() string {
 	return `sudo initctl list | awk '{print $1}' | sort | uniq`
 }
 
-var startedRE = regexp.MustCompile(`^.* start/running, process (\d+)\n$`)
+var startedRE = regexp.MustCompile(`^.* start/running(?:, process (\d+))?\n$`)
 
 // Service provides visibility into and control over an upstart service.
 type Service struct {

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -73,7 +73,11 @@ func (s *UpstartSuite) StoppedStatus(c *gc.C) {
 	s.MakeTool(c, "status", `echo "some-service stop/waiting"`)
 }
 
-func (s *UpstartSuite) RunningStatus(c *gc.C) {
+func (s *UpstartSuite) RunningStatusNoProcessID(c *gc.C) {
+	s.MakeTool(c, "status", `echo "some-service start/running"`)
+}
+
+func (s *UpstartSuite) RunningStatusWithProcessID(c *gc.C) {
 	s.MakeTool(c, "status", `echo "some-service start/running, process 123"`)
 }
 
@@ -126,14 +130,19 @@ func (s *UpstartSuite) TestRunning(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(running, jc.IsFalse)
 
-	s.RunningStatus(c)
+	s.RunningStatusNoProcessID(c)
+	running, err = s.service.Running()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(running, jc.IsTrue)
+
+	s.RunningStatusWithProcessID(c)
 	running, err = s.service.Running()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(running, jc.IsTrue)
 }
 
 func (s *UpstartSuite) TestStart(c *gc.C) {
-	s.RunningStatus(c)
+	s.RunningStatusWithProcessID(c)
 	s.MakeTool(c, "start", "exit 99")
 	c.Assert(s.service.Start(), jc.ErrorIsNil)
 	s.StoppedStatus(c)
@@ -146,7 +155,7 @@ func (s *UpstartSuite) TestStop(c *gc.C) {
 	s.StoppedStatus(c)
 	s.MakeTool(c, "stop", "exit 99")
 	c.Assert(s.service.Stop(), jc.ErrorIsNil)
-	s.RunningStatus(c)
+	s.RunningStatusWithProcessID(c)
 	c.Assert(s.service.Stop(), gc.ErrorMatches, ".*exit status 99.*")
 	s.MakeTool(c, "stop", "exit 0")
 	c.Assert(s.service.Stop(), jc.ErrorIsNil)
@@ -161,6 +170,7 @@ func (s *UpstartSuite) TestRemoveMissing(c *gc.C) {
 func (s *UpstartSuite) TestRemoveStopped(c *gc.C) {
 	s.goodInstall(c)
 	s.StoppedStatus(c)
+
 	err := s.service.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -171,7 +181,7 @@ func (s *UpstartSuite) TestRemoveStopped(c *gc.C) {
 
 func (s *UpstartSuite) TestStopRunning(c *gc.C) {
 	s.goodInstall(c)
-	s.RunningStatus(c)
+	s.RunningStatusWithProcessID(c)
 	s.MakeTool(c, "stop", "exit 99")
 	filename := filepath.Join(upstart.InitDir, "some-service.conf")
 	err := s.service.Stop()

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -23,19 +23,22 @@ func GetRetryWatcher(p Provisioner) (watcher.NotifyWatcher, error) {
 }
 
 var (
-	ContainerManagerConfig = containerManagerConfig
-	GetToolsFinder         = &getToolsFinder
-	SysctlConfig           = &sysctlConfig
-	ResolvConf             = &resolvConf
-	LocalDNSServers        = localDNSServers
-	MustParseTemplate      = mustParseTemplate
-	RunTemplateCommand     = runTemplateCommand
-	IPTablesCheckSNAT      = &iptablesCheckSNAT
-	IPTablesAddSNAT        = &iptablesAddSNAT
-	NetInterfaces          = &netInterfaces
-	InterfaceAddrs         = &interfaceAddrs
-	DiscoverPrimaryNIC     = discoverPrimaryNIC
-	MaybeAllocateStaticIP  = maybeAllocateStaticIP
+	ContainerManagerConfig     = containerManagerConfig
+	GetToolsFinder             = &getToolsFinder
+	SysctlConfig               = &sysctlConfig
+	ResolvConf                 = &resolvConf
+	LocalDNSServers            = localDNSServers
+	MustParseTemplate          = mustParseTemplate
+	RunTemplateCommand         = runTemplateCommand
+	IPTablesCheckSNAT          = &iptablesCheckSNAT
+	IPTablesAddSNAT            = &iptablesAddSNAT
+	NetInterfaces              = &netInterfaces
+	InterfaceAddrs             = &interfaceAddrs
+	DiscoverPrimaryNIC         = discoverPrimaryNIC
+	MaybeAllocateStaticIP      = maybeAllocateStaticIP
+	MaybeOverrideDefaultLXCNet = maybeOverrideDefaultLXCNet
+	EtcDefaultLXCNetPath       = &etcDefaultLXCNetPath
+	EtcDefaultLXCNet           = etcDefaultLXCNet
 )
 
 const (

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -785,7 +785,7 @@ func (s *lxcProvisionerSuite) expectStopped(c *gc.C, instId string) {
 		c.Assert(event.Action, gc.Equals, mock.Destroyed)
 		c.Assert(event.InstanceId, gc.Equals, instId)
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timeout while waiting the mock container get destroyed")
+		c.Fatalf("timeout while waiting the mock container to get destroyed")
 	}
 }
 

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -112,6 +112,8 @@ func (s *lxcBrokerSuite) machineConfig(c *gc.C, machineId string) *cloudinit.Mac
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
+	// Ensure the <rootfs>/etc/network path exists.
+	containertesting.EnsureRootFSEtcNetwork(c, "juju-"+names.NewMachineTag(machineId).String())
 	return machineConfig
 }
 
@@ -700,6 +702,7 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 		CIDR:           "0.1.2.0/24",
 		ConfigType:     network.ConfigStatic,
 		InterfaceName:  "eth0", // generated from the device index.
+		MACAddress:     provisioner.MACAddressTemplate,
 		DNSServers:     network.NewAddresses("ns1.dummy"),
 		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
 		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
@@ -740,15 +743,26 @@ func (s *lxcProvisionerSuite) expectStarted(c *gc.C, machine *state.Machine) str
 	// indefinitely quite often on i386.
 	coretesting.SkipIfI386(c, "lp:1425569")
 
+	var event mock.Event
 	s.State.StartSync()
-	event := <-s.events
-	c.Assert(event.Action, gc.Equals, mock.Created)
-	argsSet := set.NewStrings(event.TemplateArgs...)
-	c.Assert(argsSet.Contains("imageURL"), jc.IsTrue)
-	event = <-s.events
-	c.Assert(event.Action, gc.Equals, mock.Started)
-	err := machine.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case event = <-s.events:
+		c.Assert(event.Action, gc.Equals, mock.Created)
+		argsSet := set.NewStrings(event.TemplateArgs...)
+		c.Assert(argsSet.Contains("imageURL"), jc.IsTrue)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout while waiting the mock container to get created")
+	}
+
+	select {
+	case event = <-s.events:
+		c.Assert(event.Action, gc.Equals, mock.Started)
+		err := machine.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout while waiting the mock container to start")
+	}
+
 	s.waitInstanceId(c, machine, instance.Id(event.InstanceId))
 	return event.InstanceId
 }
@@ -759,11 +773,20 @@ func (s *lxcProvisionerSuite) expectStopped(c *gc.C, instId string) {
 	coretesting.SkipIfI386(c, "lp:1425569")
 
 	s.State.StartSync()
-	event := <-s.events
-	c.Assert(event.Action, gc.Equals, mock.Stopped)
-	event = <-s.events
-	c.Assert(event.Action, gc.Equals, mock.Destroyed)
-	c.Assert(event.InstanceId, gc.Equals, instId)
+	select {
+	case event := <-s.events:
+		c.Assert(event.Action, gc.Equals, mock.Stopped)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout while waiting the mock container to stop")
+	}
+
+	select {
+	case event := <-s.events:
+		c.Assert(event.Action, gc.Equals, mock.Destroyed)
+		c.Assert(event.InstanceId, gc.Equals, instId)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout while waiting the mock container get destroyed")
+	}
 }
 
 func (s *lxcProvisionerSuite) expectNoEvents(c *gc.C) {
@@ -837,6 +860,8 @@ func (s *lxcProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 	defer stop(c, p)
 
 	container := s.addContainer(c)
+	name := "juju-" + container.Tag().String()
+	containertesting.EnsureRootFSEtcNetwork(c, name)
 	instId := s.expectStarted(c, container)
 
 	// ...and removed, along with the machine, when the machine is Dead.
@@ -865,6 +890,7 @@ func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) ([]network
 	}
 	return []network.InterfaceInfo{{
 		DeviceIndex:    0,
+		MACAddress:     "aa:bb:cc:dd:ee:ff",
 		CIDR:           "0.1.2.0/24",
 		InterfaceName:  "dummy0",
 		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),


### PR DESCRIPTION
Fixes to container addressability after a lot of live tests on MASS and
EC2. Along with the main changes a few drive-by fixes were done as well.

Notable changes:

 * generated static network config for containers now uses more
   resilient set of rules, which also work in case of race conditions
   between init jobs dealing with networking events.
 * just before installing the lxc package during initial container
   setup, the /etc/default/lxc-net file is overridden with a slightly
   modified version of the original, which makes the DHCP leases for
   10.0.3.x addresses (given away by dnsmasq listening on lxcbr0) with
   infinite duration. Necessary to guarantee stable statically assigned
   IPs. With the default lease time of 1h, the DHCP-allocated addresses
   overwrite the static ones when the former are renewed.
 * shutdown job for template containers used for cloning now cleans up
   /etc/network/interfaces rendered inside the template rootfs, along
   with dhclient lease files and some startup logs.
 * pre-rendering /etc/network/interfaces before lxc-start (for normal
   containers and cloned ones) to speed-up initial boot. NOTE: Does not
   work with lxc-clone-aufs: true, but it's not pre-rendered in this
   case for now.
 * generated lxc.conf uses the proper netmask (/32 - the same as the one
   used in /etc/network/interfaces.
 * demoted a few warning logs to debug logs in the MAAS provider, as
   they were not so important and were just spamming the logs.
 * service/upstart: Running() now also works for jobs without PIDs
 * few possible bad assumptions in worker/provisioner tests were
   fixed (expectStarted and expectStopped could hang the way they were
   written)
 * fixed a typo in kvm-broker.go

Tested: make check & exhaustive live tests on MAAS and EC2 with a
permutation of all possible values for "series", "lxc-clone", and
"lxc-clone-aufs".

(Review request: http://reviews.vapour.ws/r/1144/)