### PR TITLE
Fix for KVM containers not being addressable from the host network.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -24,7 +24,7 @@ github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T10:00:34Z
-github.com/juju/testing	git	59acbfa640360b9df5d5f9806e0be976f2e44951	2015-03-04T15:30:15Z
+github.com/juju/testing	git	c07aef9cb4f2ff1db7ddc9d43a0ea88eca39c9ea	2015-03-12T17:47:17Z
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	2014-09-25T11:49:22Z
 github.com/juju/utils	git	3efdaa3f15cc47ee83f6c03f640dc14f5915e289	2015-02-05T10:00:34Z
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -362,7 +362,6 @@ func (s *SetIPAndARPForwardingSuite) TestSuccess(c *gc.C) {
 	// contains both though.
 	fakeConfig := filepath.Join(c.MkDir(), "sysctl.conf")
 	testing.PatchExecutableAsEchoArgs(c, s, "sysctl")
-	expectKeyVal := fmt.Sprintf("%s=1", provisioner.ARPProxySysctlKey)
 	s.PatchValue(provisioner.SysctlConfig, fakeConfig)
 
 	err := provisioner.SetIPAndARPForwarding(true)
@@ -373,9 +372,11 @@ func (s *SetIPAndARPForwardingSuite) TestSuccess(c *gc.C) {
 		provisioner.ARPProxySysctlKey,
 	)
 	AssertFileContains(c, fakeConfig, expectConf)
+	expectKeyVal := fmt.Sprintf("%s=1", provisioner.IPForwardSysctlKey)
+	testing.AssertEchoArgs(c, "sysctl", "-w", expectKeyVal)
+	expectKeyVal = fmt.Sprintf("%s=1", provisioner.ARPProxySysctlKey)
 	testing.AssertEchoArgs(c, "sysctl", "-w", expectKeyVal)
 
-	expectKeyVal = fmt.Sprintf("%s=0", provisioner.ARPProxySysctlKey)
 	err = provisioner.SetIPAndARPForwarding(false)
 	c.Assert(err, jc.ErrorIsNil)
 	expectConf = fmt.Sprintf(
@@ -384,6 +385,9 @@ func (s *SetIPAndARPForwardingSuite) TestSuccess(c *gc.C) {
 		provisioner.ARPProxySysctlKey,
 	)
 	AssertFileContains(c, fakeConfig, expectConf)
+	expectKeyVal = fmt.Sprintf("%s=0", provisioner.IPForwardSysctlKey)
+	testing.AssertEchoArgs(c, "sysctl", "-w", expectKeyVal)
+	expectKeyVal = fmt.Sprintf("%s=0", provisioner.ARPProxySysctlKey)
 	testing.AssertEchoArgs(c, "sysctl", "-w", expectKeyVal)
 }
 

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -23,19 +23,21 @@ func GetRetryWatcher(p Provisioner) (watcher.NotifyWatcher, error) {
 }
 
 var (
-	ContainerManagerConfig = containerManagerConfig
-	GetToolsFinder         = &getToolsFinder
-	SysctlConfig           = &sysctlConfig
-	ResolvConf             = &resolvConf
-	LocalDNSServers        = localDNSServers
-	MustParseTemplate      = mustParseTemplate
-	RunTemplateCommand     = runTemplateCommand
-	IPTablesCheckSNAT      = &iptablesCheckSNAT
-	IPTablesAddSNAT        = &iptablesAddSNAT
-	NetInterfaces          = &netInterfaces
-	InterfaceAddrs         = &interfaceAddrs
-	DiscoverPrimaryNIC     = discoverPrimaryNIC
-	MaybeAllocateStaticIP  = maybeAllocateStaticIP
+	ContainerManagerConfig     = containerManagerConfig
+	GetToolsFinder             = &getToolsFinder
+	SysctlConfig               = &sysctlConfig
+	ResolvConf                 = &resolvConf
+	LocalDNSServers            = localDNSServers
+	MustParseTemplate          = mustParseTemplate
+	RunTemplateCommand         = runTemplateCommand
+	IptablesRules              = &iptablesRules
+	NetInterfaces              = &netInterfaces
+	InterfaceAddrs             = &interfaceAddrs
+	DiscoverPrimaryNIC         = discoverPrimaryNIC
+	MaybeAllocateStaticIP      = maybeAllocateStaticIP
+	MaybeOverrideDefaultLXCNet = maybeOverrideDefaultLXCNet
+	EtcDefaultLXCNetPath       = &etcDefaultLXCNetPath
+	EtcDefaultLXCNet           = etcDefaultLXCNet
 )
 
 const (

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -56,6 +56,18 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = kvm.DefaultKvmBridge
 	}
+
+	allocatedInfo, err := maybeAllocateStaticIP(
+		machineId, bridgeDevice, broker.api, args.NetworkInfo,
+	)
+	if err != nil {
+		// It's fine, just ignore it. The effect will be that the
+		// container won't have a static address configured.
+		logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+	} else {
+		args.NetworkInfo = allocatedInfo
+	}
+
 	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
 
 	series := args.Tools.OneSeries()

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -210,27 +210,40 @@ func localDNSServers() ([]network.Address, error) {
 	return addresses, nil
 }
 
-var (
+// ipRouteAdd is the command template to add a static route for
+// .ContainerIP using the .HostBridge device (usually lxcbr0).
+var ipRouteAdd = mustParseTemplate("ipRouteAdd", `
+ip route add {{.ContainerIP}} dev {{.HostBridge}}`[1:])
+
+type IptablesRule struct {
+	Table string
+	Chain string
+	Rule  string
+}
+
+var iptablesRules = map[string]IptablesRule{
 	// iptablesCheckSNAT is the command template to verify if a SNAT
 	// rule already exists for the host NIC named .HostIF (usually
 	// eth0) and source address .HostIP (usually eth0's address). We
 	// need to check whether the rule exists because we only want to
 	// add it once. Exit code 0 means the rule exists, 1 means it
 	// doesn't
-	iptablesCheckSNAT = mustParseTemplate("iptablesCheckSNAT", `
-iptables -t nat -C POSTROUTING -o {{.HostIF}} -j SNAT --to-source {{.HostIP}}`[1:])
-
-	// iptablesAddSNAT is the command template to add a SNAT rule for
-	// the host NIC named .HostIF (usually eth0) and source address
-	// .HostIP (usually eth0's address).
-	iptablesAddSNAT = mustParseTemplate("iptablesAddSNAT", `
-iptables -t nat -A POSTROUTING -o {{.HostIF}} -j SNAT --to-source {{.HostIP}}`[1:])
-
-	// ipRouteAdd is the command template to add a static route for
-	// .ContainerIP using the .HostBridge device (usually lxcbr0).
-	ipRouteAdd = mustParseTemplate("ipRouteAdd", `
-ip route add {{.ContainerIP}} dev {{.HostBridge}}`[1:])
-)
+	"iptablesSNAT": {
+		"nat",
+		"POSTROUTING",
+		"-o {{.HostIF}} -j SNAT --to-source {{.HostIP}}",
+	}, "iptablesForwardOut": {
+		// Ensure that we have ACCEPT rules that apply to the containers
+		// that we are creating so any DROP rules further down the chain
+		// don't disrupt wanted traffic.
+		"filter",
+		"FORWARD",
+		"-d {{.ContainerCIDR}} -o {{.HostBridge}} -j ACCEPT",
+	}, "iptablesForwardIn": {
+		"filter",
+		"FORWARD",
+		"-d {{.ContainerCIDR}} -i {{.HostBridge}} -j ACCEPT",
+	}}
 
 // mustParseTemplate works like template.Parse, but panics on error.
 func mustParseTemplate(name, source string) *template.Template {
@@ -239,6 +252,17 @@ func mustParseTemplate(name, source string) *template.Template {
 		panic(err.Error())
 	}
 	return templ
+}
+
+// mustExecTemplate works like template.Parse followed by template.Execute,
+// but panics on error.
+func mustExecTemplate(name, tmpl string, data interface{}) string {
+	t := mustParseTemplate(name, tmpl)
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		panic(err.Error())
+	}
+	return buf.String()
 }
 
 // runTemplateCommand executes the given template with the given data,
@@ -301,32 +325,40 @@ var setupRoutesAndIPTables = func(
 			return errors.Errorf("container IP %q must be set", containerIP)
 		}
 		data := struct {
-			HostIF      string
-			HostIP      string
-			HostBridge  string
-			ContainerIP string
-		}{primaryNIC, primaryAddr.Value, bridgeName, containerIP}
+			HostIF        string
+			HostIP        string
+			HostBridge    string
+			ContainerIP   string
+			ContainerCIDR string
+		}{primaryNIC, primaryAddr.Value, bridgeName, containerIP, iface.CIDR}
 
-		// Check if the iptables SNAT rule has been set and add it if not.
-		code, err := runTemplateCommand(iptablesCheckSNAT, true, data)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		switch code {
-		case 0:
-			// Rule does exist so just add the route.
-		case 1:
-			// Rule does not exist, add it.
-			_, err = runTemplateCommand(iptablesAddSNAT, false, data)
+		for name, rule := range iptablesRules {
+			check := mustExecTemplate("rule", "iptables -t {{.Table}} -C {{.Chain}} {{.Rule}}", rule)
+			t := mustParseTemplate(name+"Check", check)
+
+			code, err := runTemplateCommand(t, true, data)
 			if err != nil {
 				return errors.Trace(err)
 			}
-		default:
-			// Unexpected code - better report it.
-			return errors.Errorf("iptables failed with unexpected exit code %d", code)
+			switch code {
+			case 0:
+			// Rule does exist. Do nothing
+			case 1:
+				// Rule does not exist, add it. We insert the rule at the top of the list so it precedes any
+				// REJECT rules.
+				action := mustExecTemplate("action", "iptables -t {{.Table}} -I {{.Chain}} 1 {{.Rule}}", rule)
+				t = mustParseTemplate(name+"Add", action)
+				_, err = runTemplateCommand(t, false, data)
+				if err != nil {
+					return errors.Trace(err)
+				}
+			default:
+				// Unexpected code - better report it.
+				return errors.Errorf("iptables failed with unexpected exit code %d", code)
+			}
 		}
 
-		_, err = runTemplateCommand(ipRouteAdd, false, data)
+		_, err := runTemplateCommand(ipRouteAdd, false, data)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -499,13 +499,22 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesAddError(c *gc.C) {
 	gitjujutesting.PatchExecutable(c, s, "iptables", script)
 	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
 
+	fakeptablesRules := map[string]provisioner.IptablesRule{
+		"IPTablesSNAT": {
+			"nat",
+			"POSTROUTING",
+			"{{.HostIF}} {{.HostIP}}",
+		},
+	}
+	s.PatchValue(provisioner.IptablesRules, fakeptablesRules)
+
 	ifaceInfo := []network.InterfaceInfo{{
 		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
 	}}
 
 	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
 	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
-	c.Assert(err, gc.ErrorMatches, `command "iptables -t nat -A .*" failed with exit code 42`)
+	c.Assert(err, gc.ErrorMatches, `command "iptables -t nat -I .*" failed with exit code 42`)
 }
 
 func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPRouteError(c *gc.C) {
@@ -531,15 +540,16 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesAddsRuleIfMissing(c *gc.C) {
 	// same binary, we need to replace the iptables commands with
 	// separate ones. The check returns code=1 to trigger calling
 	// add.
-	fakeIPTablesCheck := provisioner.MustParseTemplate("iptablesCheckNAT", `
-iptables-check {{.HostIF}} {{.HostIP}} ; exit 1`[1:])
-	s.PatchValue(provisioner.IPTablesCheckSNAT, fakeIPTablesCheck)
-	fakeIPTablesAdd := provisioner.MustParseTemplate("iptablesAddSNAT", `
-iptables-add {{.HostIF}} {{.HostIP}}`[1:])
-	s.PatchValue(provisioner.IPTablesAddSNAT, fakeIPTablesAdd)
+	fakeptablesRules := map[string]provisioner.IptablesRule{
+		"IPTablesSNAT": {
+			"nat",
+			"POSTROUTING",
+			"{{.HostIF}} {{.HostIP}}",
+		},
+	}
+	s.PatchValue(provisioner.IptablesRules, fakeptablesRules)
 
-	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "iptables-check")
-	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "iptables-add")
+	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "iptables", 1, 0)
 	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "ip")
 
 	ifaceInfo := []network.InterfaceInfo{{
@@ -553,8 +563,8 @@ iptables-add {{.HostIF}} {{.HostIP}}`[1:])
 	// Now verify the expected commands - since check returns 1, add
 	// will be called before ip route add.
 
-	gitjujutesting.AssertEchoArgs(c, "iptables-check", "nic", "0.1.2.1")
-	gitjujutesting.AssertEchoArgs(c, "iptables-add", "nic", "0.1.2.1")
+	gitjujutesting.AssertEchoArgs(c, "iptables", "-t", "nat", "-C", "POSTROUTING", "nic", "0.1.2.1")
+	gitjujutesting.AssertEchoArgs(c, "iptables", "-t", "nat", "-I", "POSTROUTING", "1", "nic", "0.1.2.1")
 	gitjujutesting.AssertEchoArgs(c, "ip", "route", "add", "0.1.2.3", "dev", "bridge")
 }
 


### PR DESCRIPTION
* Try to allocate static IP to KVM containers.
 * Add forwarding rules to both LXC and KVM hosts to ensure that traffic gets to
   containers.
 * Use templates to create command strings.
 * Fixed up tests to match KVM changes.

(Review request: http://reviews.vapour.ws/r/1149/)