### PR TITLE
filter: LeaderSettingsEvent methods

### DIFF
--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -1598,7 +1598,7 @@ func leadershipSettingsAccessorFactory(
 	// should support a native read of this format straight from
 	// state.
 	getSettings := func(serviceId string) (map[string]string, error) {
-		settings, err := st.ReadSettings(state.LeadershipSettingsDocId(serviceId))
+		settings, err := st.ReadLeadershipSettings(serviceId)
 		if err != nil {
 			return nil, err
 		}

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -268,7 +268,7 @@ func (s *uniterLeadershipSuite) TestSettingsChangeNotifier(c *gc.C) {
 	watcher, err := client.LeadershipSettings.WatchLeadershipSettings(s.serviceId)
 	c.Assert(err, gc.IsNil)
 
-	defer statetesting.AssertStop(watcher)
+	defer statetesting.AssertStop(c, watcher)
 
 	leadershipC := statetesting.NewNotifyWatcherC(c, s.BackingState, watcher)
 	// Inital event

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -291,7 +291,6 @@ func (s *uniterLeadershipSuite) TestSettingsChangeNotifier(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"bing": "bong"})
 	c.Assert(err, gc.IsNil)
-	// TODO: we may need the awful EvilSync here...
 	leadershipC.AssertOneChange()
 }
 

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -26,6 +26,7 @@ import (
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
@@ -264,41 +265,34 @@ func (s *uniterLeadershipSuite) TestSettingsChangeNotifier(c *gc.C) {
 	client := uniter.NewState(s.facadeCaller.RawAPICaller(), names.NewUnitTag(s.unitId))
 
 	// Listen for changes
-	readyForChanges := make(chan struct{})
-	sawChanges := make(chan struct{})
-	go func() {
-		watcher, err := client.LeadershipSettings.WatchLeadershipSettings(s.serviceId)
-		c.Assert(err, gc.IsNil)
-
-		// Ignore the initial event
-		<-watcher.Changes()
-		readyForChanges <- struct{}{}
-
-		if change, ok := <-watcher.Changes(); ok {
-			sawChanges <- change
-		} else {
-			c.Fatalf("watcher failed to send a change: %s", watcher.Err())
-		}
-	}()
-
-	select {
-	case <-readyForChanges:
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out")
-	}
-
-	c.Log("Writing changes...")
-	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"foo": "bar"})
+	watcher, err := client.LeadershipSettings.WatchLeadershipSettings(s.serviceId)
 	c.Assert(err, gc.IsNil)
 
-	c.Log("Waiting to see that watcher saw changes...")
-	notifyAsserter := coretesting.NotifyAsserterC{C: c, Chan: sawChanges}
-	notifyAsserter.AssertOneReceive()
+	defer statetesting.AssertStop(watcher)
 
+	leadershipC := statetesting.NewNotifyWatcherC(c, s.BackingState, watcher)
+	// Inital event
+	leadershipC.AssertOneChange()
+
+	// Make some changes
+	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"foo": "bar"})
+	c.Assert(err, gc.IsNil)
+	leadershipC.AssertOneChange()
+
+	// And check that the changes were actually applied
 	settings, err := client.LeadershipSettings.Read(s.serviceId)
 	c.Assert(err, gc.IsNil)
 
 	c.Check(settings["foo"], gc.Equals, "bar")
+
+	// Make a couple of changes, and then check that they have been
+	// coalesced into a single event
+	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"foo": "baz"})
+	c.Assert(err, gc.IsNil)
+	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"bing": "bong"})
+	c.Assert(err, gc.IsNil)
+	// TODO: we may need the awful EvilSync here...
+	leadershipC.AssertOneChange()
 }
 
 func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {

--- a/worker/uniter/filter/filter.go
+++ b/worker/uniter/filter/filter.go
@@ -113,21 +113,13 @@ func NewFilter(st *uniter.State, unitTag names.UnitTag) (Filter, error) {
 	f := &filter{
 		st:                    st,
 		outUnitDying:          make(chan struct{}),
-		outConfig:             nil,
 		outConfigOn:           make(chan struct{}),
-		outAction:             nil,
 		outActionOn:           make(chan string),
-		outLeaderSettings:     nil,
 		outLeaderSettingsOn:   make(chan struct{}),
-		outUpgrade:            nil,
 		outUpgradeOn:          make(chan *charm.URL),
-		outResolved:           nil,
 		outResolvedOn:         make(chan params.ResolvedMode),
-		outRelations:          nil,
 		outRelationsOn:        make(chan []int),
-		outMeterStatus:        nil,
 		outMeterStatusOn:      make(chan struct{}),
-		outStorage:            nil,
 		outStorageOn:          make(chan []names.StorageTag),
 		wantForcedUpgrade:     make(chan bool),
 		wantResolved:          make(chan struct{}),
@@ -405,7 +397,7 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 	}
 	defer watcher.Stop(leaderSettingsw, &f.tomb)
 
-	// Ignore external requests for leader settings behavioour until we see the first change.
+	// Ignore external requests for leader settings behaviour until we see the first change.
 	var discardLeaderSettings <-chan struct{}
 	var wantLeaderSettings <-chan bool
 	// By default we send all leaderSettings onwards.

--- a/worker/uniter/filter/filter.go
+++ b/worker/uniter/filter/filter.go
@@ -384,6 +384,11 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 		return err
 	}
 	defer watcher.Stop(storagew, &f.tomb)
+	leaderSettingsw, err := f.st.LeadershipSettings.WatchLeadershipSettings()
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop(leaderSettingsw, &f.tomb)
 
 	// Config events cannot be meaningfully discarded until one is available;
 	// once we receive the initial config and address changes, we unblock

--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -670,7 +670,7 @@ func (s *FilterSuite) TestLeaderSettingsEventsSendsChanges(c *gc.C) {
 	leaderSettingsC.AssertOneReceive()
 }
 
-func (s *FilterSuite) DONTTestWantLeaderSettingsEvents(c *gc.C) {
+func (s *FilterSuite) TestWantLeaderSettingsEvents(c *gc.C) {
 	f, err := filter.NewFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, f)
@@ -679,13 +679,17 @@ func (s *FilterSuite) DONTTestWantLeaderSettingsEvents(c *gc.C) {
 	// Supress the initial event
 	f.WantLeaderSettingsEvents(false)
 	leaderSettingsC.AssertNoReceive()
+	c.Logf("no receive after WantLeaderSettingsEvents(false)")
 	// Also suppresses actual changes
 	s.setLeaderSetting(c, "foo", "baz-1")
+	time.Sleep(200*time.Millisecond)
 	leaderSettingsC.AssertNoReceive()
+	c.Logf("no receive after applying changes with want=false")
 
 	// Reenabling the settings gives us an immediate change
 	f.WantLeaderSettingsEvents(true)
 	leaderSettingsC.AssertOneReceive()
+	c.Logf("receive after applying want=true")
 	// And also gives changes when actual changes are made
 	s.setLeaderSetting(c, "foo", "baz-2")
 	leaderSettingsC.AssertOneReceive()

--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -633,22 +633,23 @@ func (s *FilterSuite) TestStorageEvents(c *gc.C) {
 
 func (s *FilterSuite) setLeaderSetting(c *gc.C, key, value string) {
 	// s.wordpress is the service object
-	/// currentSettings, err := s.State.ReadLeadershipSettings(s.wordpress.Tag().Id())
-	/// c.Assert(err, jc.ErrorIsNil)
-	/// currentSettings.Update(map[string]interface{}{key: value})
-	/// _, err = currentSettings.Write()
-	/// c.Assert(err, jc.ErrorIsNil)
-	// This is how we would set LeadershipSettings if we are the Leader,
-	// but as we are not guaranteed to be leader and we just want to test
-	// them getting changed, we poke directly into state
-	err := s.uniter.LeadershipSettings.Merge(
-		s.wordpress.Tag().Id(),
-		map[string]string{key: value},
-		)
+	currentSettings, err := s.State.ReadLeadershipSettings(s.wordpress.Tag().Id())
 	c.Assert(err, jc.ErrorIsNil)
+	currentSettings.Update(map[string]interface{}{key: value})
+	_, err = currentSettings.Write()
+	c.Assert(err, jc.ErrorIsNil)
+	// This is how we would set LeadershipSettings if we are the Leader,
+	// but as we are not guaranteed to be leader and the API is properly
+	// running. But we just want to test them getting changed, we poke
+	// directly into state
+	/// err := s.uniter.LeadershipSettings.Merge(
+	/// 	s.wordpress.Tag().Id(),
+	/// 	map[string]string{key: value},
+	/// 	)
+	/// c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *FilterSuite) TestLeaderSettingsEventsSendsInitialChange(c *gc.C) {
+func (s *FilterSuite) TestLeaderSettingsEventsSendsChanges(c *gc.C) {
 	f, err := filter.NewFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, f)
@@ -669,7 +670,7 @@ func (s *FilterSuite) TestLeaderSettingsEventsSendsInitialChange(c *gc.C) {
 	leaderSettingsC.AssertOneReceive()
 }
 
-func (s *FilterSuite) TestWantLeaderSettingsEvents(c *gc.C) {
+func (s *FilterSuite) DONTTestWantLeaderSettingsEvents(c *gc.C) {
 	f, err := filter.NewFilter(s.uniter, s.unit.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, f)
@@ -703,6 +704,7 @@ func (s *FilterSuite) TestDiscardLeaderSettingsEvent(c *gc.C) {
 	// Discard the initial event
 	f.DiscardLeaderSettingsEvent()
 	leaderSettingsC.AssertNoReceive()
+
 	// However, it has not permanently disabled change events, another
 	// change still shows up
 	s.setLeaderSetting(c, "foo", "bing-1")

--- a/worker/uniter/filter/interface.go
+++ b/worker/uniter/filter/interface.go
@@ -89,4 +89,26 @@ type Filter interface {
 	// DiscardConfigEvent indicates that the filter should discard any pending
 	// config event.
 	DiscardConfigEvent()
+
+	// LeaderSettingsEvents returns a channel that will receive an event whenever
+	// there is a leader settings change. Events can be temporarily suspended by
+	// calling WantLeaderSettingsEvents(false), and then reenabled by calling
+	// WantLeaderSettingsEvents(true)
+	LeaderSettingsEvents() <-chan struct{}
+
+	// DiscardLeaderSettingsEvent can be called to discard any pending
+	// LeaderSettingsEvents. This is used by code that saw a LeaderSettings change,
+	// and has been prepping for a response. Just before they request the current
+	// LeaderSettings, they can discard any other pending changes, since they know
+	// they will be handling all changes that have occurred before right now.
+	DiscardLeaderSettingsEvent()
+
+	// WantLeaderSettingsEvents can be used to enable/disable events being sent on
+	// the LeaderSettingsEvents() channel. This is used when an agent notices that
+	// it is the leader, it wants to disable getting events for changes that it is
+	// generating. Calling this with sendEvents=false disables getting change
+	// events. Calling this with sendEvents=true will enable future changes, and
+	// queues up an immediate event so that the agent will refresh its information
+	// for any events it might have missed while it thought it was the leader.
+	WantLeaderSettingsEvents(sendEvents bool)
 }


### PR DESCRIPTION
Add LeaderSettingsEvent methods to uniter/filter.Filter.

Yes, Filter is ridiculous. No, this CL is not the place to address that.

(Review request: http://reviews.vapour.ws/r/1151/)