### PR TITLE
Add missing methods to api.httpSuite.

### DIFF
--- a/api/http_test.go
+++ b/api/http_test.go
@@ -22,6 +22,16 @@ type httpSuite struct {
 
 var _ = gc.Suite(&httpSuite{})
 
+func (s *httpSuite) SetUpSuite(c *gc.C) {
+	s.HTTPSuite.SetUpSuite(c)
+	s.JujuConnSuite.SetUpSuite(c)
+}
+
+func (s *httpSuite) TearDownSuite(c *gc.C) {
+	s.HTTPSuite.TearDownSuite(c)
+	s.JujuConnSuite.TearDownSuite(c)
+}
+
 func (s *httpSuite) SetUpTest(c *gc.C) {
 	s.HTTPSuite.SetUpTest(c)
 	s.JujuConnSuite.SetUpTest(c)
@@ -32,6 +42,11 @@ func (s *httpSuite) SetUpTest(c *gc.C) {
 			return s.Fake
 		},
 	)
+}
+
+func (s *httpSuite) TearDownTest(c *gc.C) {
+	s.HTTPSuite.TearDownTest(c)
+	s.JujuConnSuite.TearDownTest(c)
 }
 
 func (s *httpSuite) TestNewHTTPRequestSuccess(c *gc.C) {


### PR DESCRIPTION
I noticed in passing that the suite type in question was missing 3 of the methods it needs to properly handle embedding two other suite types.  This patch fixes that.

(Review request: http://reviews.vapour.ws/r/1152/)