### PR TITLE
Update lxc config to allow mounting loop devices

### DIFF
--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -481,6 +481,7 @@ type ContainerConfig struct {
 	AptProxy                proxy.Settings
 	AptMirror               string
 	PreferIPv6              bool
+	AllowLXCLoopMounts      bool
 	*UpdateBehavior
 }
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -270,6 +270,7 @@ func (p *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
 	result.Proxy = config.ProxySettings()
 	result.AptProxy = config.AptProxySettings()
 	result.PreferIPv6 = config.PreferIPv6()
+	result.AllowLXCLoopMounts, _ = config.AllowLXCLoopMounts()
 
 	return result, nil
 }

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1297,7 +1297,8 @@ func (s *withoutStateServerSuite) TestContainerManagerConfigNoIPForwarding(c *gc
 
 func (s *withoutStateServerSuite) TestContainerConfig(c *gc.C) {
 	attrs := map[string]interface{}{
-		"http-proxy": "http://proxy.example.com:9000",
+		"http-proxy":            "http://proxy.example.com:9000",
+		"allow-lxc-loop-mounts": true,
 	}
 	err := s.State.UpdateEnvironConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1314,6 +1315,7 @@ func (s *withoutStateServerSuite) TestContainerConfig(c *gc.C) {
 	c.Check(results.Proxy, gc.DeepEquals, expectedProxy)
 	c.Check(results.AptProxy, gc.DeepEquals, expectedProxy)
 	c.Check(results.PreferIPv6, jc.IsTrue)
+	c.Check(results.AllowLXCLoopMounts, jc.IsTrue)
 }
 
 func (s *withoutStateServerSuite) TestSetSupportedContainers(c *gc.C) {

--- a/container/interface.go
+++ b/container/interface.go
@@ -33,7 +33,8 @@ type Manager interface {
 	CreateContainer(
 		machineConfig *cloudinit.MachineConfig,
 		series string,
-		network *NetworkConfig) (instance.Instance, *instance.HardwareCharacteristics, error)
+		network *NetworkConfig,
+		storage *StorageConfig) (instance.Instance, *instance.HardwareCharacteristics, error)
 
 	// DestroyContainer stops and destroyes the container identified by
 	// instance id.

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -104,6 +104,7 @@ func (manager *containerManager) CreateContainer(
 	machineConfig *cloudinit.MachineConfig,
 	series string,
 	networkConfig *container.NetworkConfig,
+	storageConfig *container.StorageConfig,
 ) (instance.Instance, *instance.HardwareCharacteristics, error) {
 
 	name := names.NewMachineTag(machineConfig.MachineId).String()

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -97,7 +97,7 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	err = environs.FinishMachineConfig(machineConfig, environConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
-	inst, hardware, err := manager.CreateContainer(machineConfig, "precise", network)
+	inst, hardware, err := manager.CreateContainer(machineConfig, "precise", network, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	expected := fmt.Sprintf("arch=%s cpu-cores=1 mem=512M root-disk=8192M", version.Current.Arch)

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -766,7 +766,14 @@ func mountHostLogDir(name, logDir string) error {
 func allowLoopbackBlockDevices(name string) error {
 	const allowLoopDevicesCfg = `
 lxc.aa_profile = lxc-container-default-with-mounting
-lxc.cgroup.devices.allow = b 7:* rwm
+lxc.cgroup.devices.allow = b 7:0 rwm
+lxc.cgroup.devices.allow = b 7:1 rwm
+lxc.cgroup.devices.allow = b 7:2 rwm
+lxc.cgroup.devices.allow = b 7:3 rwm
+lxc.cgroup.devices.allow = b 7:4 rwm
+lxc.cgroup.devices.allow = b 7:5 rwm
+lxc.cgroup.devices.allow = b 7:6 rwm
+lxc.cgroup.devices.allow = b 7:7 rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 `
 	return appendToContainerConfig(name, allowLoopDevicesCfg)

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -195,6 +195,7 @@ func (manager *containerManager) CreateContainer(
 	machineConfig *cloudinit.MachineConfig,
 	series string,
 	networkConfig *container.NetworkConfig,
+	storageConfig *container.StorageConfig,
 ) (inst instance.Instance, _ *instance.HardwareCharacteristics, err error) {
 	// Check our preconditions
 	if manager == nil {
@@ -203,6 +204,8 @@ func (manager *containerManager) CreateContainer(
 		panic("series not set")
 	} else if networkConfig == nil {
 		panic("networkConfig is nil")
+	} else if storageConfig == nil {
+		panic("storageConfig is nil")
 	}
 
 	// Log how long the start took
@@ -318,9 +321,11 @@ func (manager *containerManager) CreateContainer(
 	if err := mountHostLogDir(name, manager.logdir); err != nil {
 		return nil, nil, errors.Annotate(err, "failed to mount the directory to log to")
 	}
-	// Add config to allow loop devices to be mounted inside the container.
-	if err := allowLoopbackBlockDevices(name); err != nil {
-		return nil, nil, errors.Annotate(err, "failed to configure the container for loopback devices")
+	if storageConfig.AllowMount {
+		// Add config to allow loop devices to be mounted inside the container.
+		if err := allowLoopbackBlockDevices(name); err != nil {
+			return nil, nil, errors.Annotate(err, "failed to configure the container for loopback devices")
+		}
 	}
 	// Update the network settings inside the run-time config of the
 	// container (e.g. /var/lib/lxc/<name>/config) before starting it.

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -766,14 +766,7 @@ func mountHostLogDir(name, logDir string) error {
 func allowLoopbackBlockDevices(name string) error {
 	const allowLoopDevicesCfg = `
 lxc.aa_profile = lxc-container-default-with-mounting
-lxc.cgroup.devices.allow = b 7:0 rwm
-lxc.cgroup.devices.allow = b 7:1 rwm
-lxc.cgroup.devices.allow = b 7:2 rwm
-lxc.cgroup.devices.allow = b 7:3 rwm
-lxc.cgroup.devices.allow = b 7:4 rwm
-lxc.cgroup.devices.allow = b 7:5 rwm
-lxc.cgroup.devices.allow = b 7:6 rwm
-lxc.cgroup.devices.allow = b 7:7 rwm
+lxc.cgroup.devices.allow = b 7:* rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 `
 	return appendToContainerConfig(name, allowLoopDevicesCfg)

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -304,9 +304,9 @@ func (s *LxcSuite) TestUpdateContainerConfig(c *gc.C) {
 	extraLines := []string{
 		"  lxc.rootfs =  /some/thing  # else ",
 		"",
-		"  # just comment  ",
+		"  # just comment",
 		"lxc.network.vlan.id=42",
-		"something else  # ignore  ",
+		"something else  # ignore",
 		"lxc.network.type=veth",
 		"lxc.network.link = foo  # comment",
 		"lxc.network.hwaddr = bar",

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -342,7 +342,14 @@ lxc.network.mtu = 4321
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
 
 lxc.aa_profile = lxc-container-default-with-mounting
-lxc.cgroup.devices.allow = b 7:* rwm
+lxc.cgroup.devices.allow = b 7:0 rwm
+lxc.cgroup.devices.allow = b 7:1 rwm
+lxc.cgroup.devices.allow = b 7:2 rwm
+lxc.cgroup.devices.allow = b 7:3 rwm
+lxc.cgroup.devices.allow = b 7:4 rwm
+lxc.cgroup.devices.allow = b 7:5 rwm
+lxc.cgroup.devices.allow = b 7:6 rwm
+lxc.cgroup.devices.allow = b 7:7 rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 `, s.logDir) + strings.Join(extraLines, "\n") + "\n"
 
@@ -392,7 +399,14 @@ lxc.network.mtu = 4321
 
 
 lxc.aa_profile = lxc-container-default-with-mounting
-lxc.cgroup.devices.allow = b 7:* rwm
+lxc.cgroup.devices.allow = b 7:0 rwm
+lxc.cgroup.devices.allow = b 7:1 rwm
+lxc.cgroup.devices.allow = b 7:2 rwm
+lxc.cgroup.devices.allow = b 7:3 rwm
+lxc.cgroup.devices.allow = b 7:4 rwm
+lxc.cgroup.devices.allow = b 7:5 rwm
+lxc.cgroup.devices.allow = b 7:6 rwm
+lxc.cgroup.devices.allow = b 7:7 rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 lxc.rootfs = /foo/bar
 
@@ -1022,7 +1036,14 @@ lxc.start.auto = 1
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
 
 lxc.aa_profile = lxc-container-default-with-mounting
-lxc.cgroup.devices.allow = b 7:* rwm
+lxc.cgroup.devices.allow = b 7:0 rwm
+lxc.cgroup.devices.allow = b 7:1 rwm
+lxc.cgroup.devices.allow = b 7:2 rwm
+lxc.cgroup.devices.allow = b 7:3 rwm
+lxc.cgroup.devices.allow = b 7:4 rwm
+lxc.cgroup.devices.allow = b 7:5 rwm
+lxc.cgroup.devices.allow = b 7:6 rwm
+lxc.cgroup.devices.allow = b 7:7 rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 `, s.logDir)
 	c.Assert(string(config), gc.Equals, expected)

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -396,9 +396,9 @@ lxc.cgroup.devices.allow = b 7:* rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 lxc.rootfs = /foo/bar
 
-  # just comment  
+  # just comment
 lxc.network.vlan.id = 69
-something else  # ignore  
+something else  # ignore
 lxc.network.type = phys
 lxc.network.link = foo  # comment
 lxc.network.hwaddr = deadbeef

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -342,14 +342,7 @@ lxc.network.mtu = 4321
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
 
 lxc.aa_profile = lxc-container-default-with-mounting
-lxc.cgroup.devices.allow = b 7:0 rwm
-lxc.cgroup.devices.allow = b 7:1 rwm
-lxc.cgroup.devices.allow = b 7:2 rwm
-lxc.cgroup.devices.allow = b 7:3 rwm
-lxc.cgroup.devices.allow = b 7:4 rwm
-lxc.cgroup.devices.allow = b 7:5 rwm
-lxc.cgroup.devices.allow = b 7:6 rwm
-lxc.cgroup.devices.allow = b 7:7 rwm
+lxc.cgroup.devices.allow = b 7:* rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 `, s.logDir) + strings.Join(extraLines, "\n") + "\n"
 
@@ -399,14 +392,7 @@ lxc.network.mtu = 4321
 
 
 lxc.aa_profile = lxc-container-default-with-mounting
-lxc.cgroup.devices.allow = b 7:0 rwm
-lxc.cgroup.devices.allow = b 7:1 rwm
-lxc.cgroup.devices.allow = b 7:2 rwm
-lxc.cgroup.devices.allow = b 7:3 rwm
-lxc.cgroup.devices.allow = b 7:4 rwm
-lxc.cgroup.devices.allow = b 7:5 rwm
-lxc.cgroup.devices.allow = b 7:6 rwm
-lxc.cgroup.devices.allow = b 7:7 rwm
+lxc.cgroup.devices.allow = b 7:* rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 lxc.rootfs = /foo/bar
 
@@ -1036,14 +1022,7 @@ lxc.start.auto = 1
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
 
 lxc.aa_profile = lxc-container-default-with-mounting
-lxc.cgroup.devices.allow = b 7:0 rwm
-lxc.cgroup.devices.allow = b 7:1 rwm
-lxc.cgroup.devices.allow = b 7:2 rwm
-lxc.cgroup.devices.allow = b 7:3 rwm
-lxc.cgroup.devices.allow = b 7:4 rwm
-lxc.cgroup.devices.allow = b 7:5 rwm
-lxc.cgroup.devices.allow = b 7:6 rwm
-lxc.cgroup.devices.allow = b 7:7 rwm
+lxc.cgroup.devices.allow = b 7:* rwm
 lxc.cgroup.devices.allow = c 10:237 rwm
 `, s.logDir)
 	c.Assert(string(config), gc.Equals, expected)

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -337,6 +337,10 @@ lxc.network.mtu = 4321
 
 
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
+
+lxc.aa_profile = lxc-container-default-with-mounting
+lxc.cgroup.devices.allow = b 7:* rwm
+lxc.cgroup.devices.allow = c 10:237 rwm
 `, s.logDir) + strings.Join(extraLines, "\n") + "\n"
 
 	lxcConfContents, err := ioutil.ReadFile(configPath)
@@ -383,6 +387,10 @@ lxc.network.name = em1
 lxc.network.mtu = 4321
 
 
+
+lxc.aa_profile = lxc-container-default-with-mounting
+lxc.cgroup.devices.allow = b 7:* rwm
+lxc.cgroup.devices.allow = c 10:237 rwm
 lxc.rootfs = /foo/bar
 
   # just comment  
@@ -980,6 +988,10 @@ lxc.network.mtu = 4321
 
 lxc.start.auto = 1
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
+
+lxc.aa_profile = lxc-container-default-with-mounting
+lxc.cgroup.devices.allow = b 7:* rwm
+lxc.cgroup.devices.allow = c 10:237 rwm
 `, s.logDir)
 	c.Assert(string(config), gc.Equals, expected)
 	c.Assert(autostartLink, jc.DoesNotExist)

--- a/container/storage.go
+++ b/container/storage.go
@@ -11,7 +11,7 @@ import (
 )
 
 var ErrLoopMountNotAllowed = errors.New(`
-Mounting of loop devices inside LXC containers must be explicltly enabled using this environment config setting:
+Mounting of loop devices inside LXC containers must be explicitly enabled using this environment config setting:
   allow-lxc-loop-mounts=true
 `[1:])
 

--- a/container/storage.go
+++ b/container/storage.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package container
+
+import (
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+)
+
+// StorageConfig defines how the container will be configured to support
+// storage requirements.
+type StorageConfig struct {
+
+	// AllowMount is true is the container is required to allow
+	// mounting block devices.
+	AllowMount bool
+}
+
+// NewStorageConfig returns a StorageConfig used to specify the
+// configuration the container uses to support storage.
+func NewStorageConfig(volumes []storage.VolumeParams) *StorageConfig {
+	allowMount := false
+	// If there is a volume using a loop provider, then
+	// allow mount must be true.
+	for _, v := range volumes {
+		allowMount = v.Provider == provider.LoopProviderType
+		if allowMount {
+			break
+		}
+	}
+	// TODO(wallyworld) - add config for HostLoopProviderType
+	return &StorageConfig{allowMount}
+}

--- a/container/storage.go
+++ b/container/storage.go
@@ -4,9 +4,16 @@
 package container
 
 import (
+	"errors"
+
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 )
+
+var ErrLoopMountNotAllowed = errors.New(`
+Mounting of loop devices inside LXC containers must be explicltly enabled using this environment config setting:
+  allow-lxc-loop-mounts=true
+`[1:])
 
 // StorageConfig defines how the container will be configured to support
 // storage requirements.

--- a/container/storage.go
+++ b/container/storage.go
@@ -10,6 +10,9 @@ import (
 	"github.com/juju/juju/storage/provider"
 )
 
+// ErrLoopMountNotAllowed is used when loop devices are requested to be
+// mounted inside an LXC container, but this has not been allowed using
+// an environment config setting.
 var ErrLoopMountNotAllowed = errors.New(`
 Mounting of loop devices inside LXC containers must be explicitly enabled using this environment config setting:
   allow-lxc-loop-mounts=true

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -59,21 +59,23 @@ func CreateContainerWithMachineConfig(
 ) instance.Instance {
 
 	networkConfig := container.BridgeNetworkConfig("nic42", nil)
-	return CreateContainerWithMachineAndNetworkConfig(c, manager, machineConfig, networkConfig)
+	storageConfig := container.NewStorageConfig(nil)
+	return CreateContainerWithMachineAndNetworkAndStorageConfig(c, manager, machineConfig, networkConfig, storageConfig)
 }
 
-func CreateContainerWithMachineAndNetworkConfig(
+func CreateContainerWithMachineAndNetworkAndStorageConfig(
 	c *gc.C,
 	manager container.Manager,
 	machineConfig *cloudinit.MachineConfig,
 	networkConfig *container.NetworkConfig,
+	storageConfig *container.StorageConfig,
 ) instance.Instance {
 
 	if networkConfig != nil && len(networkConfig.Interfaces) > 0 {
 		name := "test-" + names.NewMachineTag(machineConfig.MachineId).String()
 		EnsureRootFSEtcNetwork(c, name)
 	}
-	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", networkConfig)
+	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", networkConfig, storageConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	c.Assert(hardware.String(), gc.Not(gc.Equals), "")
@@ -114,8 +116,9 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 	machineConfig.Config = envConfig
 
 	network := container.BridgeNetworkConfig("nic42", nil)
+	storage := container.NewStorageConfig(nil)
 
-	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", network)
+	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", network, storage)
 
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -150,6 +150,11 @@ const (
 	// The default block storage source.
 	StorageDefaultBlockSourceKey = "storage-default-block-source"
 
+	// For LXC containers, is the container allowed to mount block
+	// devices. A theoretical security issue, so must be explicitly
+	// allowed by the user.
+	AllowLXCLoopMounts = "allow-lxc-loop-mounts"
+
 	//
 	// Deprecated Settings Attributes
 	//
@@ -1124,6 +1129,13 @@ func (c *Config) StorageDefaultBlockSource() (string, bool) {
 	return bs, bs != ""
 }
 
+// AllowLXCLoopMounts returns whether loop devices are allowed
+// to be mounted inside lxc containers.
+func (c *Config) AllowLXCLoopMounts() (bool, bool) {
+	v, ok := c.defined[AllowLXCLoopMounts].(bool)
+	return v, ok
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1215,6 +1227,7 @@ var fields = schema.Fields{
 	PreventRemoveObjectKey:       schema.Bool(),
 	PreventAllChangesKey:         schema.Bool(),
 	StorageDefaultBlockSourceKey: schema.String(),
+	AllowLXCLoopMounts:           schema.Bool(),
 
 	// Deprecated fields, retain for backwards compatibility.
 	ToolsMetadataURLKey:    schema.String(),
@@ -1257,6 +1270,7 @@ var alwaysOptional = schema.Defaults{
 	"disable-network-management": schema.Omit,
 	AgentStreamKey:               schema.Omit,
 	SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
+	AllowLXCLoopMounts:           false,
 
 	// Storage related config.
 	// Environ providers will specify their own defaults.

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -197,12 +197,25 @@ var configTests = []configTest{
 			"lxc-clone":     true,
 		},
 	}, {
-		about:       "Allow LXC loop mounts",
+		about:       "Allow LXC loop mounts true",
 		useDefaults: config.UseDefaults,
 		attrs: testing.Attrs{
 			"type":                  "my-type",
 			"name":                  "my-name",
 			"allow-lxc-loop-mounts": "true",
+		},
+	}, {
+		about:       "Allow LXC loop mounts default",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":                  "my-type",
+			"name":                  "my-name",
+			"allow-lxc-loop-mounts": "false",
+		},
+		expected: testing.Attrs{
+			"type":                  "my-type",
+			"name":                  "my-name",
+			"allow-lxc-loop-mounts": false,
 		},
 	}, {
 		about:       "CA cert & key from path",

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -197,6 +197,14 @@ var configTests = []configTest{
 			"lxc-clone":     true,
 		},
 	}, {
+		about:       "Allow LXC loop mounts",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":                  "my-type",
+			"name":                  "my-name",
+			"allow-lxc-loop-mounts": "true",
+		},
+	}, {
 		about:       "CA cert & key from path",
 		useDefaults: config.UseDefaults,
 		attrs: testing.Attrs{
@@ -1345,6 +1353,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 	attrs["lxc-clone-aufs"] = false
 	attrs["prefer-ipv6"] = false
 	attrs["set-numa-control-policy"] = false
+	attrs["allow-lxc-loop-mounts"] = false
 
 	// Default firewall mode is instance
 	attrs["firewall-mode"] = string(config.FwInstance)

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -369,9 +369,9 @@ func (env *localEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	if err := environs.FinishMachineConfig(args.MachineConfig, env.config.Config); err != nil {
 		return nil, err
 	}
-	// TODO: evaluate the impact of setting the contstraints on the
+	// TODO: evaluate the impact of setting the constraints on the
 	// machineConfig for all machines rather than just state server nodes.
-	// This limiation is why the constraints are assigned directly here.
+	// This limitation is why the constraints are assigned directly here.
 	args.MachineConfig.Constraints = args.Constraints
 	args.MachineConfig.AgentEnvironment[agent.Namespace] = env.config.namespace()
 	inst, hardware, err := createContainer(env, args)
@@ -389,6 +389,11 @@ var createContainer = func(env *localEnviron, args environs.StartInstanceParams)
 	series := args.Tools.OneSeries()
 	network := container.BridgeNetworkConfig(env.config.networkBridge(), args.NetworkInfo)
 	storage := container.NewStorageConfig(args.Volumes)
+	allowLoopMounts, _ := env.config.AllowLXCLoopMounts()
+	isLXC := env.config.container() == instance.LXC
+	if isLXC && !allowLoopMounts && storage.AllowMount {
+		return nil, nil, container.ErrLoopMountNotAllowed
+	}
 	inst, hardware, err := env.containerManager.CreateContainer(args.MachineConfig, series, network, storage)
 	if err != nil {
 		return nil, nil, err

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -388,7 +388,8 @@ func (env *localEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 var createContainer = func(env *localEnviron, args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, error) {
 	series := args.Tools.OneSeries()
 	network := container.BridgeNetworkConfig(env.config.networkBridge(), args.NetworkInfo)
-	inst, hardware, err := env.containerManager.CreateContainer(args.MachineConfig, series, network)
+	storage := container.NewStorageConfig(args.Volumes)
+	inst, hardware, err := env.containerManager.CreateContainer(args.MachineConfig, series, network, storage)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/jujutest"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
@@ -34,6 +35,8 @@ import (
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -407,4 +410,22 @@ func (s *localJujuTestSuite) TestStateServerInstances(c *gc.C) {
 	instances, err = env.StateServerInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.DeepEquals, []instance.Id{"localhost"})
+}
+
+func (s *localJujuTestSuite) TestStateInstanceLoopMountsDisallowed(c *gc.C) {
+	env := s.testBootstrap(c, minimalConfig(c))
+
+	availableTools := coretools.List{&coretools.Tools{
+		Version: version.Current,
+		URL:     "http://testing.invalid/tools.tar.gz",
+	}}
+	mcfg, err := environs.NewMachineConfig("0", "ya", imagemetadata.ReleasedStream, version.Current.Series, true, nil, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = env.StartInstance(environs.StartInstanceParams{
+		MachineConfig: mcfg,
+		Tools:         availableTools,
+		Volumes:       []storage.VolumeParams{{Provider: provider.LoopProviderType}},
+	})
+	c.Assert(err, gc.Equals, container.ErrLoopMountNotAllowed)
 }

--- a/provider/local/export_test.go
+++ b/provider/local/export_test.go
@@ -79,16 +79,6 @@ func (inst *mockInstance) Id() instance.Id {
 
 type startInstanceFunc func(*localEnviron, environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, error)
 
-func PatchCreateContainer(s *testing.CleanupSuite, c *gc.C, expectedURL string) startInstanceFunc {
-	mockFunc := func(_ *localEnviron, args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, error) {
-		c.Assert(args.Tools, gc.HasLen, 1)
-		c.Assert(args.Tools[0].URL, gc.Equals, expectedURL)
-		return &mockInstance{id: "mock"}, nil, nil
-	}
-	s.PatchValue(&createContainer, mockFunc)
-	return mockFunc
-}
-
 func PatchServices(patchValue func(interface{}, interface{}), data *service.FakeServiceData) {
 	patchValue(&mongoRemoveService, func(namespace string) error {
 		data.AddCall("RemoveService", namespace)

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -84,7 +84,8 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	inst, hardware, err := broker.manager.CreateContainer(args.MachineConfig, series, network)
+	storage := container.NewStorageConfig(args.Volumes)
+	inst, hardware, err := broker.manager.CreateContainer(args.MachineConfig, series, network, storage)
 	if err != nil {
 		kvmLogger.Errorf("failed to start container: %v", err)
 		return nil, err

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -130,7 +130,8 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	inst, hardware, err := broker.manager.CreateContainer(args.MachineConfig, series, network)
+	storage := container.NewStorageConfig(args.Volumes)
+	inst, hardware, err := broker.manager.CreateContainer(args.MachineConfig, series, network, storage)
 	if err != nil {
 		lxcLogger.Errorf("failed to start container: %v", err)
 		return nil, err

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -914,12 +914,16 @@ type fakeAPI struct {
 var _ provisioner.APICalls = (*fakeAPI)(nil)
 
 func (f *fakeAPI) ContainerConfig() (params.ContainerConfig, error) {
-	return params.ContainerConfig{
+	p := params.ContainerConfig{
 		UpdateBehavior:          &params.UpdateBehavior{true, true},
 		ProviderType:            "fake",
 		AuthorizedKeys:          coretesting.FakeAuthKeys,
 		SSLHostnameVerification: true,
-		AllowLXCLoopMounts:      f.suite.allowLXCLoopMounts}, nil
+	}
+	if f.suite != nil {
+		p.AllowLXCLoopMounts = f.suite.allowLXCLoopMounts
+	}
+	return p, nil
 }
 
 func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) ([]network.InterfaceInfo, error) {


### PR DESCRIPTION
We use the "lxc-container-default-with-mounting" appamor profile to allow loop devices to be mounted.

(Review request: http://reviews.vapour.ws/r/1154/)