### PR TITLE
Fix `juju action do` default value insertion for nil maps

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -18,7 +18,7 @@ github.com/juju/cmd	git	cda28f523779603ba0cb7808e1b84c9dd076d37b	2015-02-10T12:0
 github.com/juju/errors	git	9cc96a010cd2b0d9df6dcb034e56f7581a787e86	2015-02-10T03:35:25Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
-github.com/juju/gojsonschema	git	995b906ce18b2726e9d284efbfa79bd7070ec8c8	2015-02-19T20:49:45Z
+github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
 github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07:57:36Z
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
@@ -30,7 +30,7 @@ github.com/juju/utils	git	3efdaa3f15cc47ee83f6c03f640dc14f5915e289	2015-02-05T10
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
 gopkg.in/amz.v3	git	d448c1511e15faa59e0606a07cb2e88da55b3e47	2015-03-02T07:27:58Z
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	2014-08-27T13:58:41Z
-gopkg.in/juju/charm.v4	git	c9dacb8f7647108fd1837666145fc3ea05eb9e26	2015-03-03T11:49:15Z
+gopkg.in/juju/charm.v4	git	ab30b5b47c6274f9085cd55fc7c44a19e263e899	2015-03-12T18:03:31Z
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	2014-07-30T20:00:37Z
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	2014-07-25T20:51:33Z
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08-11T16:19:00Z

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -225,6 +225,20 @@ act:
 			"val": "somestr",
 		},
 	}, {
+		should: "insert a default value when an empty map is passed",
+		params: map[string]interface{}{},
+		schema: "simple",
+		expectedParams: map[string]interface{}{
+			"val": "somestr",
+		},
+	}, {
+		should: "insert a default value when a nil map is passed",
+		params: nil,
+		schema: "simple",
+		expectedParams: map[string]interface{}{
+			"val": "somestr",
+		},
+	}, {
 		should: "insert a nested default value",
 		params: map[string]interface{}{"foo": "bar"},
 		schema: "complicated",
@@ -243,7 +257,7 @@ act:
 		// is tested in the gojsonschema package.
 		action, err := u.AddAction("act", t.params)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(action.Parameters(), jc.DeepEquals, t.expectedParams)
+		c.Check(action.Parameters(), jc.DeepEquals, t.expectedParams)
 	}
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -1765,7 +1765,8 @@ func (u *Unit) UnassignFromMachine() (err error) {
 type ActionSpecsByName map[string]charm.ActionSpec
 
 // AddAction adds a new Action of type name and using arguments payload to
-// this Unit, and returns its ID.
+// this Unit, and returns its ID.  Note that the use of spec.InsertDefaults
+// mutates payload.
 func (u *Unit) AddAction(name string, payload map[string]interface{}) (*Action, error) {
 	if len(name) == 0 {
 		return nil, errors.New("no action name given")
@@ -1783,11 +1784,11 @@ func (u *Unit) AddAction(name string, payload map[string]interface{}) (*Action, 
 	if err != nil {
 		return nil, err
 	}
-	err = spec.InsertDefaults(payload)
+	payloadWithDefaults, err := spec.InsertDefaults(payload)
 	if err != nil {
 		return nil, err
 	}
-	return u.st.EnqueueAction(u.Tag(), name, payload)
+	return u.st.EnqueueAction(u.Tag(), name, payloadWithDefaults)
 }
 
 // ActionSpecs gets the ActionSpec map for the Unit's charm.


### PR DESCRIPTION
Now, if the given params map is nil, a new one is created and used for
inserting default values, if any.  Also test for this edge case.

(Review request: http://reviews.vapour.ws/r/1158/)

cf. https://github.com/juju/juju/pull/1811