### PR TITLE
apiserver/debuglog: Support a cat mode 

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -918,6 +918,9 @@ type DebugLogParams struct {
 	// Replay tells the server to start at the start of the log file rather
 	// than the end. If replay is true, backlog is ignored.
 	Replay bool
+
+	// Cat tells the server to just cat the file and close the connection.
+	Cat bool
 }
 
 // WatchDebugLog returns a ReadCloser that the caller can read the log
@@ -949,6 +952,9 @@ func (c *Client) WatchDebugLog(args DebugLogParams) (io.ReadCloser, error) {
 	}
 	if args.Level != loggo.UNSPECIFIED {
 		attrs.Set("level", fmt.Sprint(args.Level))
+	}
+	if args.Cat {
+		attrs.Set("cat", fmt.Sprint(args.Cat))
 	}
 	attrs["includeEntity"] = args.IncludeEntity
 	attrs["includeModule"] = args.IncludeModule

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -98,6 +98,11 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				socket.Close()
 				return
 			}
+			if req.URL.Query().Get("cat") != "" {
+				io.Copy(socket, logFile)
+				socket.Close()
+				return
+			}
 
 			stream.start(logFile, socket)
 			go func() {

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -129,6 +129,14 @@ func (s *debugLogSuite) TestReplayFromStart(c *gc.C) {
 	c.Assert(linesRead, jc.DeepEquals, logLines)
 }
 
+func (s *debugLogSuite) TestJustCat(c *gc.C) {
+	s.ensureLogFile(c)
+
+	reader := s.openWebsocket(c, url.Values{"cat": {"true"}})
+	s.assertLogFollowing(c, reader)
+	s.assertWebsocketClosed(c, reader)
+}
+
 func (s *debugLogSuite) TestBacklog(c *gc.C) {
 	s.writeLogLines(c, 10)
 

--- a/cmd/juju/debuglog.go
+++ b/cmd/juju/debuglog.go
@@ -56,6 +56,7 @@ func (c *DebugLogCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.UintVar(&c.params.Backlog, "lines", defaultLineCount, "")
 	f.UintVar(&c.params.Limit, "limit", 0, "show at most this many lines")
 	f.BoolVar(&c.params.Replay, "replay", false, "start filtering from the start")
+	f.BoolVar(&c.params.Cat, "cat", false, "don't tail the log, just cat")
 }
 
 func (c *DebugLogCommand) Init(args []string) error {


### PR DESCRIPTION
which returns the contents of the file then closes.

Fixes lp:1390585

I'm not sure this is the best approach - but it seems to work, I thought at the very least it would start a conversation.

(Review request: http://reviews.vapour.ws/r/1159/)