### PR TITLE
Add Life methods to IPAddress

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -859,6 +859,9 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 				releaseErrors = append(releaseErrors, err)
 				continue
 			}
+
+			// TODO: (mfoord) Temporary fix until we have an
+			// address worker.
 			err = addr.EnsureDead()
 			if err != nil {
 				logger.Warningf("failed to remove address %v for container %q: %v", addr.Value, tag, err)

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -859,6 +859,12 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 				releaseErrors = append(releaseErrors, err)
 				continue
 			}
+			err = addr.EnsureDead()
+			if err != nil {
+				logger.Warningf("failed to remove address %v for container %q: %v", addr.Value, tag, err)
+				releaseErrors = append(releaseErrors, err)
+				continue
+			}
 			err = addr.Remove()
 			if err != nil {
 				logger.Warningf("failed to remove address %v for container %q: %v", addr.Value, tag, err)

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -283,7 +283,7 @@ func (i *IPAddress) Refresh() error {
 		return errors.NotFoundf("IP address %q", i)
 	}
 	if err != nil {
-		return errors.Errorf("cannot refresh IP address %q: %v", i, err)
+		return errors.Annotatef(err, "cannot refresh IP address %q", i)
 	}
 	return nil
 }

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -5,12 +5,12 @@ package state
 
 import (
 	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/network"
-	jujutxn "github.com/juju/txn"
 )
 
 // AddressState represents the states an IP address can be in. They are created

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -125,7 +125,7 @@ func (i *IPAddress) EnsureDead() (err error) {
 	}
 
 	ops := []txn.Op{{
-		C:      subnetsC,
+		C:      ipaddressesC,
 		Id:     i.doc.DocID,
 		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 		Assert: isAliveDoc,

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -156,6 +156,7 @@ func (i *IPAddress) Remove() (err error) {
 	ops := []txn.Op{{
 		C:      ipaddressesC,
 		Id:     i.doc.DocID,
+		Assert: isDeadDoc,
 		Remove: true,
 	}}
 	return i.st.runTransaction(ops)
@@ -224,10 +225,10 @@ func (i *IPAddress) Refresh() error {
 
 	err := addresses.FindId(i.doc.DocID).One(&i.doc)
 	if err == mgo.ErrNotFound {
-		return errors.NotFoundf("subnet %q", i)
+		return errors.NotFoundf("IP address %q", i)
 	}
 	if err != nil {
-		return errors.Errorf("cannot refresh subnet %q: %v", i, err)
+		return errors.Errorf("cannot refresh IP address %q: %v", i, err)
 	}
 	return nil
 }

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -206,7 +206,7 @@ func (i *IPAddress) SetState(newState AddressState) (err error) {
 				return nil, err
 			} else if i.Life() == Dead {
 				return nil, errors.New("address is dead")
-			} else if err == txn.ErrAborted {
+			} else if i.State() != AddressStateUnknown {
 				return nil, errors.NotValidf("transition from %q", i.doc.State)
 			} else if err != nil {
 				return nil, err
@@ -242,7 +242,7 @@ func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
 				return nil, err
 			} else if i.Life() == Dead {
 				return nil, errors.New("address is dead")
-			} else if err == txn.ErrAborted {
+			} else if i.State() != AddressStateUnknown {
 				return nil, errors.Errorf("already allocated or unavailable")
 			} else if err != nil {
 				return nil, err

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -46,6 +46,7 @@ func (s *IPAddressSuite) TestAddIPAddress(c *gc.C) {
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertAddress(c, ipAddr, addr, state.AddressStateUnknown, "", "", "foobar")
+		c.Assert(ipAddr.Life(), gc.Equals, state.Alive)
 
 		// verify the address was stored in the state
 		ipAddr, err = s.State.IPAddress(test)
@@ -78,7 +79,7 @@ func (s *IPAddressSuite) TestIPAddressNotFound(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `IP address "0.1.2.3" not found`)
 }
 
-func (s *IPAddressSuite) TestRemove(c *gc.C) {
+func (s *IPAddressSuite) TestEnsureDeadRemove(c *gc.C) {
 	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,10 +92,15 @@ func (s *IPAddressSuite) TestRemove(c *gc.C) {
 
 	err = ipAddr.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
+
+	// EnsureDead twice should not be an error
+	err = ipAddr.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
 	err = ipAddr.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Doing it twice is also fine.
+	// Remove twice is also fine.
 	err = ipAddr.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -174,6 +174,7 @@ func (s *IPAddressSuite) TestSetState(c *gc.C) {
 		}
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(ipAddr.State(), gc.Equals, test.changeTo)
+		c.Check(ipAddr.EnsureDead(), jc.ErrorIsNil)
 		c.Check(ipAddr.Remove(), jc.ErrorIsNil)
 	}
 }

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -84,7 +84,7 @@ func (s *IPAddressSuite) TestEnsureDeadRemove(c *gc.C) {
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 
-	// should not be able to remove an Alive IP address
+	// Should not be able to remove an Alive IP address.
 	c.Assert(ipAddr.Life(), gc.Equals, state.Alive)
 	err = ipAddr.Remove()
 	msg := fmt.Sprintf("cannot remove IP address %q: IP address is not dead", ipAddr)

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -255,3 +255,20 @@ func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
 	c.Assert(result, jc.SameContents, expected)
 
 }
+
+func (s *IPAddressSuite) TestRefresh(c *gc.C) {
+	rawAddr := network.NewAddress("0.1.2.3", network.ScopeUnknown)
+	addr, err := s.State.AddIPAddress(rawAddr, "foobar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrCopy, err := s.State.IPAddress(rawAddr.Value)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = addr.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(addrCopy.Life(), gc.Equals, state.Alive)
+	err = addrCopy.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addrCopy.Life(), gc.Equals, state.Dead)
+}

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -87,7 +87,7 @@ func (s *IPAddressSuite) TestEnsureDeadRemove(c *gc.C) {
 	// Should not be able to remove an Alive IP address.
 	c.Assert(ipAddr.Life(), gc.Equals, state.Alive)
 	err = ipAddr.Remove()
-	msg := fmt.Sprintf("cannot remove IP address %q: IP address is not dead", ipAddr)
+	msg := fmt.Sprintf("cannot remove IP address %q: IP address is not dead", ipAddr.String())
 	c.Assert(err, gc.ErrorMatches, msg)
 
 	err = ipAddr.EnsureDead()

--- a/state/state.go
+++ b/state/state.go
@@ -1338,6 +1338,7 @@ func (st *State) AddIPAddress(addr network.Address, subnetid string) (ipaddress 
 	ipDoc := ipaddressDoc{
 		DocID:    addressID,
 		EnvUUID:  st.EnvironUUID(),
+		Life:     Alive,
 		State:    AddressStateUnknown,
 		SubnetId: subnetid,
 		Value:    addr.Value,


### PR DESCRIPTION
This adds the methods Life and EnsureDead to IPAddress. Remove requires the IPAddress to be Dead before removal. This is a precursor to having an address worker responsible for removing IP addresses.

Upgrade step needed to add Life: Alive to existing IPAddresses.

(Review request: http://reviews.vapour.ws/r/1160/)