### PR TITLE
provider/gce: Fix bug with minDiskSize

### DIFF
--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -154,7 +154,7 @@ func (s *environBrokerSuite) TestGetHardwareCharacteristics(c *gc.C) {
 	c.Check(*hwc.CpuCores, gc.Equals, uint64(1))
 	c.Check(*hwc.CpuPower, gc.Equals, uint64(275))
 	c.Check(*hwc.Mem, gc.Equals, uint64(3750))
-	c.Check(*hwc.RootDisk, gc.Equals, uint64(5120))
+	c.Check(*hwc.RootDisk, gc.Equals, uint64(15360))
 }
 
 func (s *environBrokerSuite) TestAllInstances(c *gc.C) {

--- a/provider/gce/google/conn_instance_test.go
+++ b/provider/gce/google/conn_instance_test.go
@@ -92,7 +92,7 @@ func (s *instanceSuite) TestConnectionAddInstanceAPI(c *gc.C) {
 		Mode:       "READ_WRITE",
 		AutoDelete: true,
 		InitializeParams: &compute.AttachedDiskInitializeParams{
-			DiskSizeGb:  5,
+			DiskSizeGb:  15,
 			SourceImage: "some/image/path",
 		},
 	}}

--- a/provider/gce/google/disk.go
+++ b/provider/gce/google/disk.go
@@ -27,7 +27,6 @@ const (
 // the image size. See gceapi messsage.
 //
 // gceapi: Requested disk size cannot be smaller than the image size (10 GB)
-
 const MinDiskSizeGB uint64 = 10
 
 // DiskSpec holds all the data needed to request a new disk on GCE.

--- a/provider/gce/google/disk.go
+++ b/provider/gce/google/disk.go
@@ -23,9 +23,12 @@ const (
 // GCE disks.
 //
 // Note: GCE does not currently have an official minimum disk size.
-// However, a size of 0 is not viable so we use the next lowest
-// value.
-const MinDiskSizeGB uint64 = 1
+// However, in testing we found the minimum size to be 10 GB due to
+// the image size. See gceapi messsage.
+//
+// gceapi: Requested disk size cannot be smaller than the image size (10 GB)
+
+const MinDiskSizeGB uint64 = 10
 
 // DiskSpec holds all the data needed to request a new disk on GCE.
 // Some fields are used only for attached disks (i.e. in association

--- a/provider/gce/google/disk_test.go
+++ b/provider/gce/google/disk_test.go
@@ -33,14 +33,14 @@ func (s *diskSuite) TestDiskSpecTooSmallTrue(c *gc.C) {
 func (s *diskSuite) TestDiskSpecSizeGB(c *gc.C) {
 	size := s.DiskSpec.SizeGB()
 
-	c.Check(size, gc.Equals, uint64(5))
+	c.Check(size, gc.Equals, uint64(15))
 }
 
 func (s *diskSuite) TestDiskSpecSizeGBMin(c *gc.C) {
 	s.DiskSpec.SizeHintGB = 0
 	size := s.DiskSpec.SizeGB()
 
-	c.Check(size, gc.Equals, uint64(1))
+	c.Check(size, gc.Equals, uint64(10))
 }
 
 type attachedInfo struct {

--- a/provider/gce/google/instance_test.go
+++ b/provider/gce/google/instance_test.go
@@ -39,7 +39,7 @@ func (s *instanceSuite) TestNewInstanceNoSpec(c *gc.C) {
 func (s *instanceSuite) TestInstanceRootDiskGB(c *gc.C) {
 	size := s.Instance.RootDiskGB()
 
-	c.Check(size, gc.Equals, uint64(5))
+	c.Check(size, gc.Equals, uint64(15))
 }
 
 func (s *instanceSuite) TestInstanceRootDiskGBNilSpec(c *gc.C) {

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -52,7 +52,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.FakeConn = fake
 
 	s.DiskSpec = DiskSpec{
-		SizeHintGB: 5,
+		SizeHintGB: 15,
 		ImageURL:   "some/image/path",
 		Boot:       true,
 		Scratch:    false,
@@ -65,7 +65,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 		Mode:       "READ_WRITE",
 		AutoDelete: true,
 		InitializeParams: &compute.AttachedDiskInitializeParams{
-			DiskSizeGb:  1,
+			DiskSizeGb:  10,
 			SourceImage: "some/image/path",
 		},
 	}

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -80,7 +80,7 @@ func (s *BaseSuiteUnpatched) initEnv(c *gc.C) {
 
 func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	diskSpec := google.DiskSpec{
-		SizeHintGB: 5,
+		SizeHintGB: 15,
 		ImageURL:   "some/image/path",
 		Boot:       true,
 		Scratch:    false,


### PR DESCRIPTION
Back port of fix from https://github.com/juju/juju/pull/1801

Was discovered and fixed in master. That is the reason it was a back port instead of a forward port.

(Review request: http://reviews.vapour.ws/r/1161/)