### PR TITLE
Use a better approach to shell-based discovery of the init system.

### DIFF
--- a/environs/manual/fakessh_test.go
+++ b/environs/manual/fakessh_test.go
@@ -150,7 +150,8 @@ func (r fakeSSH) install(c *gc.C) testing.Restorer {
 	if r.Provisioned {
 		checkProvisionedOutput = "/etc/init/jujud-machine-0.conf"
 	}
-	add(service.ListServicesCommand(), checkProvisionedOutput, r.CheckProvisionedExitCode)
+	listCmd := strings.Join(service.ListServicesScript(), "\n")
+	add(listCmd, checkProvisionedOutput, r.CheckProvisionedExitCode)
 	if r.InitUbuntuUser {
 		add("", nil, 0)
 	}

--- a/environs/manual/fakessh_test.go
+++ b/environs/manual/fakessh_test.go
@@ -150,7 +150,7 @@ func (r fakeSSH) install(c *gc.C) testing.Restorer {
 	if r.Provisioned {
 		checkProvisionedOutput = "/etc/init/jujud-machine-0.conf"
 	}
-	listCmd := strings.Join(service.ListServicesScript(), "\n")
+	listCmd := service.ListServicesScript()
 	add(listCmd, checkProvisionedOutput, r.CheckProvisionedExitCode)
 	if r.InitUbuntuUser {
 		add("", nil, 0)

--- a/environs/manual/init.go
+++ b/environs/manual/init.go
@@ -34,7 +34,7 @@ var CheckProvisioned = checkProvisioned
 func checkProvisioned(host string) (bool, error) {
 	logger.Infof("Checking if %s is already provisioned", host)
 
-	script := strings.Join(service.ListServicesScript(), "\n")
+	script := service.ListServicesScript()
 
 	cmd := ssh.Command("ubuntu@"+host, []string{"/bin/bash"}, nil)
 	var stdout, stderr bytes.Buffer

--- a/environs/manual/init.go
+++ b/environs/manual/init.go
@@ -34,7 +34,7 @@ var CheckProvisioned = checkProvisioned
 func checkProvisioned(host string) (bool, error) {
 	logger.Infof("Checking if %s is already provisioned", host)
 
-	script := strings.Join(service.ListServicesCommand(), "\n")
+	script := strings.Join(service.ListServicesScript(), "\n")
 
 	cmd := ssh.Command("ubuntu@"+host, []string{"/bin/bash"}, nil)
 	var stdout, stderr bytes.Buffer

--- a/environs/manual/init.go
+++ b/environs/manual/init.go
@@ -34,7 +34,7 @@ var CheckProvisioned = checkProvisioned
 func checkProvisioned(host string) (bool, error) {
 	logger.Infof("Checking if %s is already provisioned", host)
 
-	script := service.ListServicesCommand()
+	script := strings.Join(service.ListServicesCommand(), "\n")
 
 	cmd := ssh.Command("ubuntu@"+host, []string{"/bin/bash"}, nil)
 	var stdout, stderr bytes.Buffer

--- a/environs/manual/init_test.go
+++ b/environs/manual/init_test.go
@@ -115,25 +115,26 @@ func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
 }
 
 func (s *initialisationSuite) TestCheckProvisioned(c *gc.C) {
-	defer installFakeSSH(c, service.ListServicesCommand(), "", 0)()
+	listCmd := strings.Join(service.ListServicesScript(), "\n")
+	defer installFakeSSH(c, listCmd, "", 0)()
 	provisioned, err := manual.CheckProvisioned("example.com")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provisioned, jc.IsFalse)
 
-	defer installFakeSSH(c, service.ListServicesCommand(), "juju...", 0)()
+	defer installFakeSSH(c, listCmd, "juju...", 0)()
 	provisioned, err = manual.CheckProvisioned("example.com")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provisioned, jc.IsTrue)
 
 	// stderr should not affect result.
-	defer installFakeSSH(c, service.ListServicesCommand(), []string{"", "non-empty-stderr"}, 0)()
+	defer installFakeSSH(c, listCmd, []string{"", "non-empty-stderr"}, 0)()
 	provisioned, err = manual.CheckProvisioned("example.com")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provisioned, jc.IsFalse)
 
 	// if the script fails for whatever reason, then checkProvisioned
 	// will return an error. stderr will be included in the error message.
-	defer installFakeSSH(c, service.ListServicesCommand(), []string{"non-empty-stdout", "non-empty-stderr"}, 255)()
+	defer installFakeSSH(c, listCmd, []string{"non-empty-stdout", "non-empty-stderr"}, 255)()
 	_, err = manual.CheckProvisioned("example.com")
 	c.Assert(err, gc.ErrorMatches, "subprocess encountered error code 255 \\(non-empty-stderr\\)")
 }

--- a/environs/manual/init_test.go
+++ b/environs/manual/init_test.go
@@ -115,7 +115,7 @@ func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
 }
 
 func (s *initialisationSuite) TestCheckProvisioned(c *gc.C) {
-	listCmd := strings.Join(service.ListServicesScript(), "\n")
+	listCmd := service.ListServicesScript()
 	defer installFakeSSH(c, listCmd, "", 0)()
 	provisioned, err := manual.CheckProvisioned("example.com")
 	c.Assert(err, jc.ErrorIsNil)

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -173,6 +173,16 @@ func identifyExecutable(executable string) (string, bool) {
 // discovering the local init system.
 const DiscoverInitSystemScript = `#!/usr/bin/env bash
 
+function checkInitSystem() {
+    if [[ $1 == *"systemd"* ]]; then
+        echo -n systemd
+        exit $?
+    elif [[ $1 == *"upstart"* ]]; then
+        echo -n upstart
+        exit $?
+    fi
+}
+
 # Find the executable.
 executable=$(cat /proc/1/cmdline | awk -F"\0" '{print $1}')
 if [[ $? ]]; then
@@ -180,13 +190,7 @@ if [[ $? ]]; then
 fi
 
 # Check the executable.
-if [[ $executable == *"systemd"* ]]; then
-    echo -n systemd
-    exit $?
-elif [[ $executable == *"upstart"* ]]; then
-    echo -n upstart
-    exit $?
-fi
+checkInitSystem($executable)
 
 # First fall back to following symlinks.
 if [[ -L $executable ]]; then
@@ -196,13 +200,7 @@ if [[ -L $executable ]]; then
     fi
 
     # Check the linked executable.
-    if [[ $executable == *"systemd"* ]]; then
-        echo -n systemd
-        exit $?
-    elif [[ $executable == *"upstart"* ]]; then
-        echo -n upstart
-        exit $?
-    fi
+    checkInitSystem($executable)
 fi
 
 # Fall back to checking the "version" text.
@@ -210,13 +208,7 @@ verText=$("${executable}" --version)
 if [[ $? ]]; then
     exit 1
 else
-    if [[ $verText == *"systemd"* ]]; then
-        echo -n systemd
-        exit $?
-    elif [[ $verText == *"upstart"* ]]; then
-        echo -n upstart
-        exit $?
-    fi
+    checkInitSystem($verText)
 fi
 
 # uh-oh

--- a/service/service.go
+++ b/service/service.go
@@ -20,10 +20,17 @@ var (
 
 // These are the names of the init systems regognized by juju.
 const (
-	InitSystemWindows = "windows"
-	InitSystemUpstart = "upstart"
 	InitSystemSystemd = "systemd"
+	InitSystemUpstart = "upstart"
+	InitSystemWindows = "windows"
 )
+
+// linuxInitSystems lists the names of the init systems that juju might
+// find on a linux host.
+var linuxInitSystems = []string{
+	InitSystemSystemd,
+	InitSystemUpstart,
+}
 
 // ServiceActions represents the actions that may be requested for
 // an init system service.
@@ -141,10 +148,13 @@ func ListServices() ([]string, error) {
 	}
 }
 
-// ListServicesCommand returns the command that should be run to get
+// ListServicesScript returns the commands that should be run to get
 // a list of service names on a host.
-func ListServicesCommand() string {
-	return newShellSelectCommand(listServicesCommand)
+func ListServicesScript() []string {
+	filename := "/tmp/discover_init_system.sh"
+	commands := writeDiscoverInitSystemScript(filename)
+	commands = append(commands, newShellSelectCommand(filename, listServicesCommand))
+	return commands
 }
 
 func listServicesCommand(initSystem string) (string, bool) {

--- a/service/service.go
+++ b/service/service.go
@@ -152,7 +152,7 @@ func ListServices() ([]string, error) {
 // ListServicesScript returns the commands that should be run to get
 // a list of service names on a host.
 func ListServicesScript() string {
-	filename := "/tmp/discover_init_system.sh"
+	const filename = "/tmp/discover_init_system.sh"
 	commands := writeDiscoverInitSystemScript(filename)
 	commands = append(commands, newShellSelectCommand(filename, listServicesCommand))
 	return strings.Join(commands, "\n")

--- a/service/service.go
+++ b/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -150,11 +151,11 @@ func ListServices() ([]string, error) {
 
 // ListServicesScript returns the commands that should be run to get
 // a list of service names on a host.
-func ListServicesScript() []string {
+func ListServicesScript() string {
 	filename := "/tmp/discover_init_system.sh"
 	commands := writeDiscoverInitSystemScript(filename)
 	commands = append(commands, newShellSelectCommand(filename, listServicesCommand))
-	return commands
+	return strings.Join(commands, "\n")
 }
 
 func listServicesCommand(initSystem string) (string, bool) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -68,15 +68,12 @@ func (s *serviceSuite) TestListServices(c *gc.C) {
 func (*serviceSuite) TestListServicesScript(c *gc.C) {
 	script := service.ListServicesScript()
 
-	// Add the write lines.
 	expected := []string{
 		"cat > /tmp/discover_init_system.sh << 'EOF'",
 	}
 	expected = append(expected, strings.Split(service.DiscoverInitSystemScript, "\n")...)
 	expected = append(expected, "EOF")
-	// Add the chmod line.
 	expected = append(expected, "chmod 0755 /tmp/discover_init_system.sh")
-	// Add the switch lines.
 	expected = append(expected, []string{
 		"init_system=$(/tmp/discover_init_system.sh) " +
 			`if [[ $init_system == "systemd" ]]; then ` +


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1432421)

The existing approach simply hard-coded a mapping of PID 1 executable to init system.  However, this doesn't work when PID 1 is running via a symlink (e.g. /sbin/init).  This patch addresses that by using a separate script based on the discovery mechanism in discoverLocalInitSystem.

(Review request: http://reviews.vapour.ws/r/1173/)