### PR TITLE
storageprovisioner: attachments in API

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -369,6 +369,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeInfo, gc.Equals, state.VolumeInfo{
 		VolumeId: "vol-123",
+		Pool:     "loop-pool",
 		Size:     124,
 	})
 	stateVolumeAttachments, err := s.State.MachineVolumeAttachments(names.NewMachineTag("1"))

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -135,19 +135,31 @@ func VolumeAttachmentFromState(v state.VolumeAttachment) (params.VolumeAttachmen
 func VolumeAttachmentsToState(in []params.VolumeAttachment) (map[names.VolumeTag]state.VolumeAttachmentInfo, error) {
 	m := make(map[names.VolumeTag]state.VolumeAttachmentInfo)
 	for _, v := range in {
-		if v.VolumeTag == "" {
-			return nil, errors.New("Tag is empty")
-		}
-		volumeTag, err := names.ParseVolumeTag(v.VolumeTag)
+		_, volumeTag, info, err := VolumeAttachmentToState(v)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		m[volumeTag] = state.VolumeAttachmentInfo{
-			v.DeviceName,
-			v.ReadOnly,
-		}
+		m[volumeTag] = info
 	}
 	return m, nil
+}
+
+// VolumeAttachmentToState converts a storage.VolumeAttachment
+// to a state.VolumeAttachmentInfo.
+func VolumeAttachmentToState(in params.VolumeAttachment) (names.MachineTag, names.VolumeTag, state.VolumeAttachmentInfo, error) {
+	machineTag, err := names.ParseMachineTag(in.MachineTag)
+	if err != nil {
+		return names.MachineTag{}, names.VolumeTag{}, state.VolumeAttachmentInfo{}, err
+	}
+	volumeTag, err := names.ParseVolumeTag(in.VolumeTag)
+	if err != nil {
+		return names.MachineTag{}, names.VolumeTag{}, state.VolumeAttachmentInfo{}, err
+	}
+	info := state.VolumeAttachmentInfo{
+		in.DeviceName,
+		in.ReadOnly,
+	}
+	return machineTag, volumeTag, info, nil
 }
 
 // ParseMachineStorageIds parses the strings, returning machine attachment IDs.

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -106,6 +106,20 @@ func VolumeFromState(v state.Volume) (params.Volume, error) {
 	}, nil
 }
 
+// VolumeAttachmentFromState converts a state.VolumeAttachment to params.VolumeAttachment.
+func VolumeAttachmentFromState(v state.VolumeAttachment) (params.VolumeAttachment, error) {
+	info, err := v.Info()
+	if err != nil {
+		return params.VolumeAttachment{}, errors.Trace(err)
+	}
+	return params.VolumeAttachment{
+		v.Volume().String(),
+		v.Machine().String(),
+		info.DeviceName,
+		info.ReadOnly,
+	}, nil
+}
+
 // VolumeAttachmentsToState converts a slice of storage.VolumeAttachment to a
 // mapping of volume tags to state.VolumeAttachmentInfo.
 func VolumeAttachmentsToState(in []params.VolumeAttachment) (map[names.VolumeTag]state.VolumeAttachmentInfo, error) {

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -56,7 +56,7 @@ func VolumeParams(v state.Volume, poolManager poolmanager.PoolManager) (params.V
 		stateVolumeParams.Size,
 		string(providerType),
 		attrs,
-		"", // machine tag is set by the machine provisioner
+		nil, // attachment params set by the caller
 	}, nil
 }
 
@@ -87,6 +87,7 @@ func VolumeToState(v params.Volume) (names.VolumeTag, state.VolumeInfo, error) {
 	return volumeTag, state.VolumeInfo{
 		v.Serial,
 		v.Size,
+		"", // pool is set by state
 		v.VolumeId,
 	}, nil
 }

--- a/apiserver/diskformatter/diskformatter_test.go
+++ b/apiserver/diskformatter/diskformatter_test.go
@@ -400,6 +400,10 @@ func (a *mockVolumeAttachment) Machine() names.MachineTag {
 	return a.machine
 }
 
+func (a *mockVolumeAttachment) Life() state.Life {
+	return state.Alive
+}
+
 func (a *mockVolumeAttachment) Info() (state.VolumeAttachmentInfo, error) {
 	if a.info == nil {
 		return state.VolumeAttachmentInfo{}, errors.NotProvisionedf(

--- a/apiserver/diskmanager/diskmanager.go
+++ b/apiserver/diskmanager/diskmanager.go
@@ -85,6 +85,7 @@ func (d *DiskManagerAPI) SetMachineBlockDevices(args params.SetMachineBlockDevic
 			// the diskmanager publishing block devices and erroneously creating
 			// volumes.
 			err = d.st.SetMachineBlockDevices(tag.Id(), stateBlockDeviceInfo(arg.BlockDevices))
+			// TODO(axw) set volume/filesystem attachment info.
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -166,14 +166,11 @@ type VolumeAttachments struct {
 
 // VolumeParams holds the parameters for creating a storage volume.
 type VolumeParams struct {
-	VolumeTag  string                 `json:"volumetag"`
-	Size       uint64                 `json:"size"`
-	Provider   string                 `json:"provider"`
-	Attributes map[string]interface{} `json:"attributes,omitempty"`
-
-	// Machine is the tag of the machine that the volume should
-	// be initially attached to, if any.
-	MachineTag string `json:"machinetag,omitempty"`
+	VolumeTag  string                  `json:"volumetag"`
+	Size       uint64                  `json:"size"`
+	Provider   string                  `json:"provider"`
+	Attributes map[string]interface{}  `json:"attributes,omitempty"`
+	Attachment *VolumeAttachmentParams `json:"attachment,omitempty"`
 }
 
 // VolumeAttachmentParams holds the parameters for creating a volume

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -550,6 +550,12 @@ func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]params.VolumeP
 	if len(volumeAttachments) == 0 {
 		return nil, nil
 	}
+	instanceId, err := m.InstanceId()
+	if errors.IsNotProvisioned(err) {
+		instanceId = ""
+	} else if err != nil {
+		return nil, errors.Annotatef(err, "getting machine %q instance ID", m.Id())
+	}
 	poolManager := poolmanager.New(state.NewStateSettings(p.st))
 	allVolumeParams := make([]params.VolumeParams, 0, len(volumeAttachments))
 	for _, volumeAttachment := range volumeAttachments {
@@ -565,12 +571,6 @@ func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]params.VolumeP
 			continue
 		} else if err != nil {
 			return nil, errors.Annotatef(err, "getting volume %q parameters", volumeTag.Id())
-		}
-		instanceId, err := m.InstanceId()
-		if errors.IsNotProvisioned(err) {
-			instanceId = ""
-		} else if err != nil {
-			return nil, errors.Annotatef(err, "getting machine %q instance ID", m.Id())
 		}
 		// Not provisioned yet, so ask the cloud provisioner do it.
 		volumeParams.Attachment = &params.VolumeAttachmentParams{

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -566,8 +566,20 @@ func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]params.VolumeP
 		} else if err != nil {
 			return nil, errors.Annotatef(err, "getting volume %q parameters", volumeTag.Id())
 		}
+		instanceId, err := m.InstanceId()
+		if errors.IsNotProvisioned(err) {
+			instanceId = ""
+		} else if err != nil {
+			return nil, errors.Annotatef(err, "getting machine %q instance ID", m.Id())
+		}
 		// Not provisioned yet, so ask the cloud provisioner do it.
-		volumeParams.MachineTag = m.Tag().String()
+		volumeParams.Attachment = &params.VolumeAttachmentParams{
+			volumeTag.String(),
+			m.Tag().String(),
+			string(instanceId),
+			"", // volume not created yet, so has no volume ID.
+			volumeParams.Provider,
+		}
 		allVolumeParams = append(allVolumeParams, volumeParams)
 	}
 	return allVolumeParams, nil
@@ -591,27 +603,6 @@ func storageConfig(st *state.State, poolName string) (storage.ProviderType, map[
 		return "", nil, errors.Trace(err)
 	}
 	return p.Provider(), p.Attrs(), nil
-}
-
-// volumesToState converts a slice of storage.Volume to a mapping
-// of volume names to state.VolumeInfo.
-func volumesToState(in []params.Volume) (map[names.VolumeTag]state.VolumeInfo, error) {
-	m := make(map[names.VolumeTag]state.VolumeInfo)
-	for _, v := range in {
-		if v.VolumeTag == "" {
-			return nil, errors.New("Tag is empty")
-		}
-		volumeTag, err := names.ParseVolumeTag(v.VolumeTag)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		m[volumeTag] = state.VolumeInfo{
-			v.Serial,
-			v.Size,
-			v.VolumeId,
-		}
-	}
-	return m, nil
 }
 
 // volumeAttachmentsToState converts a slice of storage.VolumeAttachment to a

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -783,15 +783,25 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 				Volumes: []params.VolumeParams{{
 					VolumeTag:  "volume-" + placementMachine.Id() + "-0",
 					Size:       1000,
-					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
 					Attributes: map[string]interface{}{"foo": "bar"},
+					Attachment: &params.VolumeAttachmentParams{
+						MachineTag: placementMachine.Tag().String(),
+						VolumeTag:  "volume-" + placementMachine.Id() + "-0",
+						InstanceId: "i-am",
+						Provider:   "loop",
+					},
 				}, {
 					VolumeTag:  "volume-" + placementMachine.Id() + "-1",
 					Size:       2000,
-					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
 					Attributes: map[string]interface{}{"foo": "bar"},
+					Attachment: &params.VolumeAttachmentParams{
+						MachineTag: placementMachine.Tag().String(),
+						VolumeTag:  "volume-" + placementMachine.Id() + "-1",
+						InstanceId: "i-am",
+						Provider:   "loop",
+					},
 				}},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
@@ -805,7 +815,7 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 		vols := expected.Results[1].Result.Volumes
 		vols[0], vols[1] = vols[1], vols[0]
 	}
-	c.Assert(result, gc.DeepEquals, expected)
+	c.Assert(result, jc.DeepEquals, expected)
 }
 
 func (s *withoutStateServerSuite) TestStorageProviderFallbackToType(c *gc.C) {
@@ -828,7 +838,7 @@ func (s *withoutStateServerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 	result, err := s.provisioner.ProvisioningInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(result, gc.DeepEquals, params.ProvisioningInfoResults{
+	c.Assert(result, jc.DeepEquals, params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
 				Series:      "quantal",
@@ -839,9 +849,13 @@ func (s *withoutStateServerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 				Volumes: []params.VolumeParams{{
 					VolumeTag:  "volume-" + placementMachine.Id() + "-0",
 					Size:       1000,
-					MachineTag: placementMachine.Tag().String(),
 					Provider:   "loop",
 					Attributes: nil,
+					Attachment: &params.VolumeAttachmentParams{
+						MachineTag: placementMachine.Tag().String(),
+						VolumeTag:  "volume-" + placementMachine.Id() + "-0",
+						Provider:   "loop",
+					},
 				}},
 			}},
 		},
@@ -1193,7 +1207,7 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfo, err := volume.Info()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volumeInfo, gc.Equals, state.VolumeInfo{VolumeId: "vol-0", Size: 1234})
+	c.Assert(volumeInfo, gc.Equals, state.VolumeInfo{VolumeId: "vol-0", Pool: "loop-pool", Size: 1234})
 
 	// Verify the machine without requested volumes still has no volume
 	// attachments recorded in state.

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -18,6 +18,7 @@ type provisionerState interface {
 	WatchEnvironVolumeAttachments() state.StringsWatcher
 	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
 	WatchMachineVolumeAttachments(names.MachineTag) state.StringsWatcher
+	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	Volume(names.VolumeTag) (state.Volume, error)
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -22,6 +22,7 @@ type provisionerState interface {
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
 	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error
+	SetVolumeAttachmentInfo(names.MachineTag, names.VolumeTag, state.VolumeAttachmentInfo) error
 }
 
 type stateShim struct {

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -16,6 +16,7 @@ type provisionerState interface {
 	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
 	WatchMachineVolumeAttachments(names.MachineTag) state.StringsWatcher
 	Volume(names.VolumeTag) (state.Volume, error)
+	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
 	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error
 }

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -4,13 +4,16 @@
 package storageprovisioner
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 )
 
 type provisionerState interface {
 	state.EntityFinder
+	MachineInstanceId(names.MachineTag) (instance.Id, error)
 	WatchEnvironVolumes() state.StringsWatcher
 	WatchEnvironVolumeAttachments() state.StringsWatcher
 	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
@@ -23,4 +26,12 @@ type provisionerState interface {
 
 type stateShim struct {
 	*state.State
+}
+
+func (s stateShim) MachineInstanceId(tag names.MachineTag) (instance.Id, error) {
+	m, err := s.Machine(tag.Id())
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return m.InstanceId()
 }

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -259,7 +259,9 @@ func (s *StorageProvisionerAPI) VolumeParams(args params.Entities) (params.Volum
 			return params.VolumeParams{}, err
 		}
 		if len(volumeAttachments) == 1 {
-			volumeParams.MachineTag = volumeAttachments[0].Machine().String()
+			volumeParams.Attachment = &params.VolumeAttachmentParams{
+				MachineTag: volumeAttachments[0].Machine().String(),
+			}
 		}
 		return volumeParams, nil
 	}

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -433,6 +433,39 @@ func (s *provisionerSuite) TestLife(c *gc.C) {
 	})
 }
 
+func (s *provisionerSuite) TestAttachmentLife(c *gc.C) {
+	s.setupVolumes(c)
+	s.authorizer.EnvironManager = true
+
+	// TODO(axw) test filesystem attachment life
+	// TODO(axw) test Dying
+
+	results, err := s.api.AttachmentLife(params.MachineStorageIds{
+		Ids: []params.MachineStorageId{{
+			MachineTag:    "machine-0",
+			AttachmentTag: "volume-0-0",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "volume-1",
+		}, {
+			MachineTag:    "machine-2",
+			AttachmentTag: "volume-3",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "volume-42",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.LifeResults{
+		Results: []params.LifeResult{
+			{Life: params.Alive},
+			{Life: params.Alive},
+			{Life: params.Alive},
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+		},
+	})
+}
+
 func (s *provisionerSuite) TestEnsureDead(c *gc.C) {
 	s.setupVolumes(c)
 	args := params.Entities{Entities: []params.Entity{{"volume-0-0"}, {"volume-1"}, {"volume-42"}}}

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -185,9 +185,6 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 			AttachmentTag: "volume-2", // volume attachment not provisioned
 		}, {
 			MachineTag:    "machine-0",
-			AttachmentTag: "volume-1", // volume not provisioned
-		}, {
-			MachineTag:    "machine-0",
 			AttachmentTag: "volume-42",
 		}},
 	})
@@ -200,10 +197,6 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,
 				Message: `volume attachment "2" on "0" not provisioned`,
-			}},
-			{Error: &params.Error{
-				Code:    params.CodeNotProvisioned,
-				Message: `volume attachment "1" on "0" not provisioned`,
 			}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -162,7 +162,14 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.VolumeParamsResults{
 		Results: []params.VolumeParamsResult{
 			{Error: &params.Error{`volume "0/0" is already provisioned`, ""}},
-			{Result: params.VolumeParams{VolumeTag: "volume-1", Size: 2048, Provider: "environscoped", MachineTag: "machine-0"}},
+			{Result: params.VolumeParams{
+				VolumeTag: "volume-1",
+				Size:      2048,
+				Provider:  "environscoped",
+				Attachment: &params.VolumeAttachmentParams{
+					MachineTag: "machine-0",
+				},
+			}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},
 	})
@@ -188,7 +195,7 @@ func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
 	}
 	result, err := s.api.WatchVolumes(args)
 	c.Assert(err, jc.ErrorIsNil)
-	sort.Strings(result.Results[0].Changes)
+	sort.Strings(result.Results[1].Changes)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
 			{StringsWatcherId: "1", Changes: []string{"0/0"}},

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -27,6 +27,9 @@ type Filesystem interface {
 	// FilesystemTag returns the tag for the filesystem.
 	FilesystemTag() names.FilesystemTag
 
+	// Life returns the life of the filesystem.
+	Life() Life
+
 	// Storage returns the tag of the storage instance that this
 	// filesystem is assigned to, if any. If the filesystem is not
 	// assigned to a storage instance, an error satisfying
@@ -58,6 +61,9 @@ type FilesystemAttachment interface {
 
 	// Machine returns the tag of the related Machine.
 	Machine() names.MachineTag
+
+	// Life returns the life of the filesystem attachment.
+	Life() Life
 
 	// Info returns the filesystem attachment's FilesystemAttachmentInfo, or a
 	// NotProvisioned error if the attachment has not yet been made.
@@ -152,6 +158,11 @@ func (f *filesystem) FilesystemTag() names.FilesystemTag {
 	return names.NewFilesystemTag(f.doc.FilesystemId)
 }
 
+// Life is required to implement Filesystem.
+func (f *filesystem) Life() Life {
+	return f.doc.Life
+}
+
 // Storage is required to implement Filesystem.
 func (f *filesystem) Storage() (names.StorageTag, error) {
 	if f.doc.StorageId == "" {
@@ -193,6 +204,11 @@ func (f *filesystemAttachment) Filesystem() names.FilesystemTag {
 // Machine is required to implement FilesystemAttachment.
 func (f *filesystemAttachment) Machine() names.MachineTag {
 	return names.NewMachineTag(f.doc.Machine)
+}
+
+// Life is required to implement FilesystemAttachment.
+func (f *filesystemAttachment) Life() Life {
+	return f.doc.Life
 }
 
 // Info is required to implement FilesystemAttachment.

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -160,6 +160,7 @@ func (s *FilesystemStateSuite) TestFilesystemInfo(c *gc.C) {
 	filesystemInfo := state.FilesystemInfo{FilesystemId: "fs-123", Size: 456}
 	err = s.State.SetFilesystemInfo(filesystemTag, filesystemInfo)
 	c.Assert(err, jc.ErrorIsNil)
+	filesystemInfo.Pool = "loop-pool" // taken from params
 	s.assertFilesystemInfo(c, filesystemTag, filesystemInfo)
 	s.assertFilesystemAttachmentUnprovisioned(c, machineTag, filesystemTag)
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -949,12 +949,11 @@ func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
 	interfaces := []state.NetworkInterfaceInfo{
 		{MACAddress: "aa:bb:cc:dd:ee:ff", NetworkName: "net1", InterfaceName: "eth0", IsVirtual: false},
 	}
-	volumes := map[names.VolumeTag]state.VolumeInfo{
-		volumeTag: state.VolumeInfo{
-			VolumeId: "storage-123",
-			Size:     1234,
-		},
+	volumeInfo := state.VolumeInfo{
+		VolumeId: "storage-123",
+		Size:     1234,
 	}
+	volumes := map[names.VolumeTag]state.VolumeInfo{volumeTag: volumeInfo}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, networks, interfaces, volumes, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.machine.CheckProvisioned("fake_nonce"), jc.IsTrue)
@@ -977,7 +976,8 @@ func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	info, err := volume.Info()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info, gc.Equals, volumes[volumeTag])
+	volumeInfo.Pool = "loop-pool" // taken from params
+	c.Assert(info, gc.Equals, volumeInfo)
 }
 
 func (s *MachineSuite) TestMachineSetProvisionedWhenNotAlive(c *gc.C) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1225,7 +1225,7 @@ func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
 	volumeAttachments, err := s.State.MachineVolumeAttachments(m.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 2)
-	if volumeAttachments[0].Volume() == names.NewVolumeTag("1") {
+	if volumeAttachments[0].Volume() == names.NewVolumeTag(m.Id()+"/1") {
 		va := volumeAttachments
 		va[0], va[1] = va[1], va[0]
 	}

--- a/state/volume.go
+++ b/state/volume.go
@@ -58,6 +58,9 @@ type VolumeAttachment interface {
 
 	// Info returns the volume attachment's VolumeAttachmentInfo, or a
 	// NotProvisioned error if the attachment has not yet been made.
+	//
+	// TODO(axw) use a different error, rather than NotProvisioned
+	// (say, NotAttached or NotAssociated).
 	Info() (VolumeAttachmentInfo, error)
 
 	// Params returns the parameters for creating the volume attachment,

--- a/state/volume.go
+++ b/state/volume.go
@@ -115,6 +115,7 @@ type VolumeParams struct {
 type VolumeInfo struct {
 	Serial   string `bson:"serial,omitempty"`
 	Size     uint64 `bson:"size"`
+	Pool     string `bson:"pool"`
 	VolumeId string `bson:"volumeid"`
 }
 
@@ -470,7 +471,11 @@ func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error)
 		// If the volume has parameters, unset them when
 		// we set info for the first time, ensuring that
 		// params and info are mutually exclusive.
-		_, unsetParams := v.Params()
+		var unsetParams bool
+		if params, ok := v.Params(); ok {
+			info.Pool = params.Pool
+			unsetParams = true
+		}
 		ops := setVolumeInfoOps(tag, info, unsetParams)
 		return ops, nil
 	}

--- a/state/volume.go
+++ b/state/volume.go
@@ -23,13 +23,6 @@ type Volume interface {
 	// VolumeTag returns the tag for the volume.
 	VolumeTag() names.VolumeTag
 
-	// TODO(axw)
-	// Scope is the tag of the entity that the volume is scoped to.
-	// Volumes which are inherently bound to a machine (e.g. loop devices)
-	// are scoped to that machine; other volumes are scoped to the
-	// environment.
-	// Owner() names.Tag
-
 	// Life returns the life of the volume.
 	Life() Life
 
@@ -59,6 +52,9 @@ type VolumeAttachment interface {
 
 	// Machine returns the tag of the related Machine.
 	Machine() names.MachineTag
+
+	// Life returns the life of the volume attachment.
+	Life() Life
 
 	// Info returns the volume attachment's VolumeAttachmentInfo, or a
 	// NotProvisioned error if the attachment has not yet been made.
@@ -179,6 +175,11 @@ func (v *volumeAttachment) Volume() names.VolumeTag {
 // Machine is required to implement VolumeAttachment.
 func (v *volumeAttachment) Machine() names.MachineTag {
 	return names.NewMachineTag(v.doc.Machine)
+}
+
+// Life is required to implement VolumeAttachment.
+func (v *volumeAttachment) Life() Life {
+	return v.doc.Life
 }
 
 // Info is required to implement VolumeAttachment.

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -129,6 +129,7 @@ func (s *VolumeStateSuite) TestSetVolumeInfo(c *gc.C) {
 	volumeInfoSet := state.VolumeInfo{Size: 123}
 	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
+	volumeInfoSet.Pool = "loop-pool" // taken from params
 	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
 }
 
@@ -172,6 +173,7 @@ func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
 	volumeInfoSet := state.VolumeInfo{Size: 123}
 	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
+	volumeInfoSet.Pool = "loop-pool" // taken from params
 	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
 }
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -85,6 +85,10 @@ type VolumeSource interface {
 	// AttachVolumes attaches the volumes with the specified provider
 	// volume IDs to the instances with the corresponding index.
 	//
+	// AttachVolumes must be idempotent; it may be called even if the
+	// attachment already exists, to ensure that it exists, e.g. over
+	// machine restarts.
+	//
 	// TODO(axw) we need to validate attachment requests prior to
 	// recording in state. For example, the ec2 provider must reject
 	// an attempt to attach a volume to an instance if they are in
@@ -131,7 +135,8 @@ type VolumeParams struct {
 	Provider ProviderType
 
 	// Attributes is the set of provider-specific attributes to pass to
-	// the storage provider when creating the volume.
+	// the storage provider when creating the volume. Attributes is derived
+	// from the storage pool configuration.
 	Attributes map[string]interface{}
 
 	// Attachment identifies the machine that the volume should be attached
@@ -164,6 +169,10 @@ type VolumeAttachmentParams struct {
 // AttachmentParams describes the parameters for attaching a volume or
 // filesystem to a machine.
 type AttachmentParams struct {
+	// Provider is the name of the storage provider that is to be used to
+	// create the attachment.
+	Provider ProviderType
+
 	// Machine is the tag of the Juju machine that the storage should be
 	// attached to. Storage providers may use this to perform machine-
 	// specific operations, such as configuring access controls for the

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -488,12 +488,21 @@ func constructStartInstanceParams(
 		if err != nil {
 			return environs.StartInstanceParams{}, errors.Trace(err)
 		}
-		machineTag, err := names.ParseMachineTag(v.MachineTag)
+		if v.Attachment == nil {
+			return environs.StartInstanceParams{}, errors.Errorf("volume params missing attachment")
+		}
+		machineTag, err := names.ParseMachineTag(v.Attachment.MachineTag)
 		if err != nil {
 			return environs.StartInstanceParams{}, errors.Trace(err)
 		}
 		if machineTag != machine.Tag() {
-			return environs.StartInstanceParams{}, errors.Errorf("volume params has invalid machine tag")
+			return environs.StartInstanceParams{}, errors.Errorf("volume attachment params has invalid machine tag")
+		}
+		if v.Attachment.VolumeId != "" {
+			return environs.StartInstanceParams{}, errors.Errorf("volume attachment params specifies volume ID")
+		}
+		if v.Attachment.InstanceId != "" {
+			return environs.StartInstanceParams{}, errors.Errorf("volume attachment params specifies instance ID")
 		}
 		volumes[i] = storage.VolumeParams{
 			volumeTag,

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -33,7 +33,7 @@ type VolumeAccessor interface {
 	VolumeParams([]names.VolumeTag) ([]params.VolumeParamsResult, error)
 
 	// SetVolumeInfo records the details of newly provisioned volumes.
-	SetVolumeInfo([]params.Volume) (params.ErrorResults, error)
+	SetVolumeInfo([]params.Volume) ([]params.ErrorResult, error)
 }
 
 // LifecycleManager defines an interface used to allow a storage provisioner

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -89,24 +89,24 @@ func (v *mockVolumeAccessor) VolumeParams(volumes []names.VolumeTag) ([]params.V
 	return result, nil
 }
 
-func (v *mockVolumeAccessor) SetVolumeInfo(volumes []params.Volume) (params.ErrorResults, error) {
+func (v *mockVolumeAccessor) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, error) {
 	for _, vol := range volumes {
 		v.provisioned[vol.VolumeTag] = vol
 	}
 	// See if we have the expected volumes, using json serialisation to do the comparison.
 	jsonVolInfo, err := json.Marshal(volumes)
 	if err != nil {
-		return params.ErrorResults{Results: []params.ErrorResult{{Error: common.ServerError(err)}}}, nil
+		return []params.ErrorResult{{Error: common.ServerError(err)}}, nil
 	}
 	jsonExpectedInfo, err := json.Marshal(v.expectedVolumes)
 	if err != nil {
-		return params.ErrorResults{Results: []params.ErrorResult{{Error: common.ServerError(err)}}}, nil
+		return []params.ErrorResult{{Error: common.ServerError(err)}}, nil
 	}
 	// If we have what we expect, close the done channel.
 	if string(jsonVolInfo) == string(jsonExpectedInfo) {
 		close(v.done)
 	}
-	return params.ErrorResults{}, nil
+	return nil, nil
 }
 
 func newMockVolumeAccessor(changes <-chan []string, done chan struct{}, expectedVolumes []params.Volume) storageprovisioner.VolumeAccessor {

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider/registry"
 )
@@ -196,16 +195,14 @@ func volumeParamsFromParams(in params.VolumeParams) (storage.VolumeParams, error
 		return storage.VolumeParams{}, errors.Trace(err)
 	}
 	var attachment *storage.VolumeAttachmentParams
-	if in.MachineTag != "" {
-		machineTag, err := names.ParseMachineTag(in.MachineTag)
+	if in.Attachment != nil {
+		machineTag, err := names.ParseMachineTag(in.Attachment.MachineTag)
 		if err != nil {
 			return storage.VolumeParams{}, errors.Trace(err)
 		}
 		attachment = &storage.VolumeAttachmentParams{
 			AttachmentParams: storage.AttachmentParams{
 				Machine: machineTag,
-				// TODO(axw) we need to pass the instance ID over the API too.
-				InstanceId: instance.Id(""),
 			},
 			Volume: volumeTag,
 		}

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -180,7 +180,7 @@ func processAliveVolumes(ctx *context, tags []names.Tag, volumeResults []params.
 		if err != nil {
 			return errors.Annotate(err, "publishing volumes to state")
 		}
-		if err := errorResults.Combine(); err != nil {
+		if err := (params.ErrorResults{errorResults}.Combine()); err != nil {
 			return errors.Annotate(err, "publishing volumes to state")
 		}
 		// TODO(axw) record volume attachment info in state.

--- a/worker/uniter/storage/source.go
+++ b/worker/uniter/storage/source.go
@@ -92,7 +92,7 @@ func (s *storageSource) loop() error {
 		case _, ok := <-inChanges:
 			logger.Debugf("got storage attachment change")
 			if !ok {
-				return tomb.ErrDying
+				return watcher.EnsureErr(s.watcher)
 			}
 			inChanges = nil
 			outChanges = s.changes
@@ -119,7 +119,6 @@ func (s *storageSource) Changes() <-chan hook.SourceChange {
 // Stop is part of the hook.Source interface.
 func (s *storageSource) Stop() error {
 	s.tomb.Kill(nil)
-	watcher.Stop(s.watcher, &s.tomb)
 	return s.tomb.Wait()
 }
 


### PR DESCRIPTION
This branch adds support for handling attachments
in the storageprovisioner API. Mostly, only volumes
are supported at the moment. These changes will
enable the storage provisioner worker to watch
attachments and attach/detach volumes/machines.

(Review request: http://reviews.vapour.ws/r/1176/)