### PR TITLE
Refactoring of api.Open()

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -184,9 +184,8 @@ func Connect(info *Info, opts DialOpts) (*websocket.Conn, error) {
 	if info.EnvironTag.Id() != "" {
 		environUUID = info.EnvironTag.Id()
 	}
-	// Dial all addresses at reasonable intervals.
-	try := parallel.NewTry(0, nil)
-	defer try.Kill()
+
+	// If they exist, only use localhost addresses.
 	var addrs []string
 	for _, addr := range info.Addrs {
 		if strings.HasPrefix(addr, "localhost:") {
@@ -197,6 +196,10 @@ func Connect(info *Info, opts DialOpts) (*websocket.Conn, error) {
 	if len(addrs) == 0 {
 		addrs = info.Addrs
 	}
+
+	// Dial all addresses at reasonable intervals.
+	try := parallel.NewTry(0, nil)
+	defer try.Kill()
 	for _, addr := range addrs {
 		err := dialWebsocket(addr, environUUID, opts, pool, try)
 		if err == parallel.ErrStopped {


### PR DESCRIPTION
The code that establishes a websocket connection to one of the API servers as been extracted out of Open into a separate Connect func. Most of the tests for Open were actually exercising this part of
the function so they have been adjusted to match. Connect will soon be used by the database logging worker.

Also: use the errors package more

Also: Rearrange and document API connection logic to make it easier to follow

(Review request: http://reviews.vapour.ws/r/1179/)