### PR TITLE
Stopped State for opState

### DIFF
--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -37,6 +37,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 func (s *steps123Suite) TestStepsFor123(c *gc.C) {
 	expected := []string{
 		"add environment UUID to agent config",
+		"add Stopped field to uniter state",
 	}
 	assertSteps(c, version.MustParse("1.23.0"), expected)
 }

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -104,7 +104,7 @@ func ModeContinue(u *Uniter) (next Mode, err error) {
 			logger.Infof("opState.Stopped == true; transition to ModeTerminating")
 			return ModeTerminating, nil
 		}
-		logger.Infof("continuing after hook")
+		logger.Infof("no operations in progress; waiting for changes")
 		return ModeAbide, nil
 	default:
 		return nil, errors.Errorf("unknown operation kind %v", opState.Kind)

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -100,10 +100,11 @@ func ModeContinue(u *Uniter) (next Mode, err error) {
 			creator = newSkipHookOp(*opState.Hook)
 		}
 	case operation.Continue:
-		logger.Infof("continuing after %q hook", opState.Hook.Kind)
-		if opState.Hook.Kind == hooks.Stop {
+		if opState.Stopped {
+			logger.Infof("opState.Stopped == true; transition to ModeTerminating")
 			return ModeTerminating, nil
 		}
+		logger.Infof("continuing after hook")
 		return ModeAbide, nil
 	default:
 		return nil, errors.Errorf("unknown operation kind %v", opState.Kind)

--- a/worker/uniter/operation/executor_test.go
+++ b/worker/uniter/operation/executor_test.go
@@ -75,7 +75,6 @@ func (s *NewExecutorSuite) TestNewExecutorValidFile(c *gc.C) {
 started: true
 op: continue
 opstep: pending
-hook: {kind: config-changed}
 `[1:], 0666}.Create(c, s.basePath)
 	executor, err := operation.NewExecutor(s.path("existing"), failGetInstallCharm)
 	c.Assert(err, jc.ErrorIsNil)
@@ -83,7 +82,6 @@ hook: {kind: config-changed}
 		Kind:    operation.Continue,
 		Step:    operation.Pending,
 		Started: true,
-		Hook:    &hook.Info{Kind: hooks.ConfigChanged},
 	})
 }
 
@@ -112,7 +110,6 @@ func justInstalledState() operation.State {
 	return operation.State{
 		Kind: operation.Continue,
 		Step: operation.Pending,
-		Hook: &hook.Info{Kind: hooks.ConfigChanged},
 	}
 }
 
@@ -202,8 +199,8 @@ func (s *ExecutorSuite) TestValidateStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op)
-	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": invalid operation state: missing hook info`)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, "missing hook info")
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": invalid operation state: missing hook info with Kind RunHook`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "missing hook info with Kind RunHook")
 
 	assertWroteState(c, statePath, initialState)
 	c.Assert(executor.State(), gc.DeepEquals, initialState)

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -114,32 +114,36 @@ func (rh *runHook) Commit(state State) (*State, error) {
 	}
 
 	change := stateChange{
-		Kind: RunHook,
-		Step: Queued,
+		Kind: Continue,
+		Step: Pending,
 	}
+
+	var hi *hook.Info = &hook.Info{Kind: hooks.ConfigChanged}
 	switch rh.info.Kind {
-	case hooks.UpgradeCharm:
-		change.Hook = &hook.Info{Kind: hooks.ConfigChanged}
 	case hooks.ConfigChanged:
-		if !state.Started {
-			change.Hook = &hook.Info{Kind: hooks.Start}
+		if state.Started {
 			break
 		}
+		hi.Kind = hooks.Start
 		fallthrough
-	default:
+	case hooks.UpgradeCharm:
 		change = stateChange{
-			Kind: Continue,
-			Step: Pending,
-			Hook: &rh.info,
+			Kind: RunHook,
+			Step: Queued,
+			Hook: hi,
 		}
 	}
 
 	newState := change.apply(state)
+
 	switch rh.info.Kind {
 	case hooks.Start:
 		newState.Started = true
+	case hooks.Stop:
+		newState.Stopped = true
 	case hooks.CollectMetrics:
 		newState.CollectMetricsTime = time.Now().Unix()
 	}
+
 	return newState, nil
 }

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -437,7 +437,6 @@ func (s *RunHookSuite) TestCommitSuccess_ConfigChanged_Preserve(c *gc.C) {
 				CollectMetricsTime: 1234567,
 				Kind:               operation.Continue,
 				Step:               operation.Pending,
-				Hook:               &hook.Info{Kind: hooks.ConfigChanged},
 			},
 		)
 	}
@@ -458,7 +457,6 @@ func (s *RunHookSuite) TestCommitSuccess_Start_SetStarted(c *gc.C) {
 				Started: true,
 				Kind:    operation.Continue,
 				Step:    operation.Pending,
-				Hook:    &hook.Info{Kind: hooks.Start},
 			},
 		)
 	}
@@ -480,39 +478,53 @@ func (s *RunHookSuite) TestCommitSuccess_Start_Preserve(c *gc.C) {
 				CollectMetricsTime: 1234567,
 				Kind:               operation.Continue,
 				Step:               operation.Pending,
-				Hook:               &hook.Info{Kind: hooks.Start},
 			},
 		)
 	}
 }
 
-func (s *RunHookSuite) testQueueHook_BlankSlate(c *gc.C, cause, effect hooks.Kind) {
+func (s *RunHookSuite) testQueueHook_BlankSlate(c *gc.C, cause hooks.Kind) {
 	for i, newHook := range []newHook{
 		(operation.Factory).NewRunHook,
 		(operation.Factory).NewRetryHook,
 		(operation.Factory).NewSkipHook,
 	} {
 		c.Logf("variant %d", i)
+		var hi *hook.Info
+		switch cause {
+		case hooks.UpgradeCharm:
+			hi = &hook.Info{Kind: hooks.ConfigChanged}
+		default:
+			hi = nil
+		}
 		s.testCommitSuccess(c,
 			newHook,
 			hook.Info{Kind: cause},
 			operation.State{},
 			operation.State{
-				Kind: operation.RunHook,
-				Step: operation.Queued,
-				Hook: &hook.Info{Kind: effect},
+				Kind:    operation.RunHook,
+				Step:    operation.Queued,
+				Stopped: cause == hooks.Stop,
+				Hook:    hi,
 			},
 		)
 	}
 }
 
-func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause, effect hooks.Kind) {
+func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause hooks.Kind) {
 	for i, newHook := range []newHook{
 		(operation.Factory).NewRunHook,
 		(operation.Factory).NewRetryHook,
 		(operation.Factory).NewSkipHook,
 	} {
 		c.Logf("variant %d", i)
+		var hi *hook.Info
+		switch cause {
+		case hooks.UpgradeCharm:
+			hi = &hook.Info{Kind: hooks.ConfigChanged}
+		default:
+			hi = nil
+		}
 		s.testCommitSuccess(c,
 			newHook,
 			hook.Info{Kind: cause},
@@ -520,8 +532,9 @@ func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause, effect hooks.Kind)
 			operation.State{
 				Kind:               operation.RunHook,
 				Step:               operation.Queued,
-				Hook:               &hook.Info{Kind: effect},
 				Started:            true,
+				Stopped:            cause == hooks.Stop,
+				Hook:               hi,
 				CollectMetricsTime: 1234567,
 			},
 		)
@@ -529,11 +542,11 @@ func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause, effect hooks.Kind)
 }
 
 func (s *RunHookSuite) TestQueueHook_UpgradeCharm_BlankSlate(c *gc.C) {
-	s.testQueueHook_BlankSlate(c, hooks.UpgradeCharm, hooks.ConfigChanged)
+	s.testQueueHook_BlankSlate(c, hooks.UpgradeCharm)
 }
 
 func (s *RunHookSuite) TestQueueHook_UpgradeCharm_Preserve(c *gc.C) {
-	s.testQueueHook_Preserve(c, hooks.UpgradeCharm, hooks.ConfigChanged)
+	s.testQueueHook_Preserve(c, hooks.UpgradeCharm)
 }
 
 func (s *RunHookSuite) testQueueNothing_BlankSlate(c *gc.C, hookInfo hook.Info) {
@@ -548,9 +561,9 @@ func (s *RunHookSuite) testQueueNothing_BlankSlate(c *gc.C, hookInfo hook.Info) 
 			hookInfo,
 			operation.State{},
 			operation.State{
-				Kind: operation.Continue,
-				Step: operation.Pending,
-				Hook: &hookInfo,
+				Kind:    operation.Continue,
+				Step:    operation.Pending,
+				Stopped: hookInfo.Kind == hooks.Stop,
 			},
 		)
 	}
@@ -570,8 +583,8 @@ func (s *RunHookSuite) testQueueNothing_Preserve(c *gc.C, hookInfo hook.Info) {
 			operation.State{
 				Kind:               operation.Continue,
 				Step:               operation.Pending,
-				Hook:               &hookInfo,
 				Started:            true,
+				Stopped:            hookInfo.Kind == hooks.Stop,
 				CollectMetricsTime: 1234567,
 			},
 		)
@@ -657,13 +670,11 @@ func (s *RunHookSuite) TestQueueNothing_RelationBroken_Preserve(c *gc.C) {
 }
 
 func (s *RunHookSuite) testCommitSuccess_CollectMetricsTime(c *gc.C, newHook newHook) {
-	hookInfo := hook.Info{Kind: hooks.CollectMetrics}
-
 	callbacks := &CommitHookCallbacks{
 		MockCommitHook: &MockCommitHook{},
 	}
 	factory := operation.NewFactory(nil, nil, callbacks, nil, nil)
-	op, err := newHook(factory, hookInfo)
+	op, err := newHook(factory, hook.Info{Kind: hooks.CollectMetrics})
 	c.Assert(err, jc.ErrorIsNil)
 
 	nowBefore := time.Now().Unix()
@@ -682,7 +693,6 @@ func (s *RunHookSuite) testCommitSuccess_CollectMetricsTime(c *gc.C, newHook new
 		Started: true,
 		Kind:    operation.Continue,
 		Step:    operation.Pending,
-		Hook:    &hookInfo,
 	})
 }
 

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -208,21 +208,3 @@ func (f *StateFile) Write(st *State) error {
 	}
 	return utils.WriteYaml(f.path, st)
 }
-
-// ReadUnsafe reads a State from the file, without verifying state
-// validity. If the file does not exist it returns ErrNoStateFile.
-func (f *StateFile) ReadUnsafe() (*State, error) {
-	var st State
-	if err := utils.ReadYaml(f.path, &st); err != nil {
-		if os.IsNotExist(err) {
-			return nil, ErrNoStateFile
-		}
-	}
-	return &st, nil
-}
-
-// WriteUnsafe stores the supplied state to the file, without
-// verifying the state validity.
-func (f *StateFile) WriteUnsafe(st *State) error {
-	return utils.WriteYaml(f.path, st)
-}

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -38,7 +38,6 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind: operation.Continue,
 			Step: operation.Step("dudelike"),
-			Hook: &hook.Info{Kind: hooks.ConfigChanged},
 		},
 		err: `unknown operation step "dudelike"`,
 	},
@@ -49,7 +48,7 @@ var stateTests = []struct {
 			Step: operation.Pending,
 			Hook: &hook.Info{Kind: hooks.ConfigChanged},
 		},
-		err: `unexpected hook info`,
+		err: `unexpected hook info with Kind Install`,
 	}, {
 		st: operation.State{
 			Kind: operation.Install,
@@ -76,14 +75,12 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind: operation.RunAction,
 			Step: operation.Pending,
-			Hook: &hook.Info{Kind: hooks.Install},
 		},
 		err: `missing action id`,
 	}, {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
-			Hook:     &hook.Info{Kind: hooks.Install},
 			CharmURL: stcurl,
 		},
 		err: `unexpected charm URL`,
@@ -91,7 +88,6 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
-			Hook:     &hook.Info{Kind: hooks.Install},
 			ActionId: &someActionId,
 		},
 	},
@@ -173,13 +169,13 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind: operation.Continue,
 			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
 		},
-		err: `missing hook info`,
+		err: `unexpected hook info with Kind Continue`,
 	}, {
 		st: operation.State{
 			Kind:     operation.Continue,
 			Step:     operation.Pending,
-			Hook:     relhook,
 			CharmURL: stcurl,
 		},
 		err: `unexpected charm URL`,
@@ -187,7 +183,6 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:     operation.Continue,
 			Step:     operation.Pending,
-			Hook:     relhook,
 			ActionId: &someActionId,
 		},
 		err: `unexpected action id`,
@@ -195,7 +190,6 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:               operation.Continue,
 			Step:               operation.Pending,
-			Hook:               relhook,
 			CollectMetricsTime: 98765432,
 			Leader:             true,
 		},

--- a/worker/uniter/upgrade123.go
+++ b/worker/uniter/upgrade123.go
@@ -11,8 +11,8 @@ import (
 )
 
 func AddStoppedFieldToUniterState(tag names.UnitTag, dataDir string) error {
-	logger.Tracef("entering upgrade step addStoppedFieldToUniterState")
-	defer logger.Tracef("leaving upgrade step addStoppedFieldToUniterState")
+	logger.Tracef("entering upgrade step AddStoppedFieldToUniterState")
+	defer logger.Tracef("leaving upgrade step AddStoppedFieldToUniterState")
 
 	statefile := getUniterStateFile(dataDir, tag)
 	state, err := statefile.ReadUnsafe()
@@ -20,7 +20,7 @@ func AddStoppedFieldToUniterState(tag names.UnitTag, dataDir string) error {
 	case nil:
 		return performUpgrade(statefile, state)
 	case operation.ErrNoStateFile:
-		logger.Errorf("no operations file found for unit %s, skipping", tag)
+		logger.Warningf("no uniter state file found for unit %s, skipping uniter upgrade step", tag)
 		return nil
 	default:
 		return err
@@ -35,12 +35,10 @@ func getUniterStateFile(dataDir string, tag names.UnitTag) *operation.StateFile 
 }
 
 func performUpgrade(statefile *operation.StateFile, state *operation.State) error {
-	if state.Kind == operation.Continue {
-		if state.Hook != nil && state.Hook.Kind == hooks.Stop {
-			state.Stopped = true
-			state.Hook = nil
-			return statefile.Write(state)
-		}
+	if state.Kind == operation.Continue && state.Hook != nil && state.Hook.Kind == hooks.Stop {
+		state.Stopped = true
+		state.Hook = nil
+		return statefile.Write(state)
 	}
 	return nil
 }

--- a/worker/uniter/upgrade123.go
+++ b/worker/uniter/upgrade123.go
@@ -1,0 +1,46 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"github.com/juju/names"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+func AddStoppedFieldToUniterState(tag names.UnitTag, dataDir string) error {
+	logger.Tracef("entering upgrade step addStoppedFieldToUniterState")
+	defer logger.Tracef("leaving upgrade step addStoppedFieldToUniterState")
+
+	statefile := getUniterStateFile(dataDir, tag)
+	state, err := statefile.ReadUnsafe()
+	switch err {
+	case nil:
+		return performUpgrade(statefile, state)
+	case operation.ErrNoStateFile:
+		logger.Errorf("no operations file found for unit %s, skipping", tag)
+		return nil
+	default:
+		return err
+	}
+
+}
+
+func getUniterStateFile(dataDir string, tag names.UnitTag) *operation.StateFile {
+	paths := NewPaths(dataDir, tag)
+	opsFile := paths.State.OperationsFile
+	return operation.NewStateFile(opsFile)
+}
+
+func performUpgrade(statefile *operation.StateFile, state *operation.State) error {
+	if state.Kind == operation.Continue {
+		if state.Hook != nil && state.Hook.Kind == hooks.Stop {
+			state.Stopped = true
+			state.Hook = nil
+			return statefile.Write(state)
+		}
+	}
+	return nil
+}

--- a/worker/uniter/upgrade123_test.go
+++ b/worker/uniter/upgrade123_test.go
@@ -6,7 +6,6 @@ package uniter_test
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -30,9 +29,6 @@ type upgradeStateContextSuite struct {
 var _ = gc.Suite(&upgradeStateContextSuite{})
 
 func (s *upgradeStateContextSuite) SetUpTest(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("No need to test upgrading state context windows")
-	}
 	s.datadir = c.MkDir()
 	s.statefile = nil
 	s.initializeContext(c, names.NewUnitTag("mysql/0"))

--- a/worker/uniter/upgrade123_test.go
+++ b/worker/uniter/upgrade123_test.go
@@ -1,0 +1,151 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/worker/uniter"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+type upgradeStateContextSuite struct {
+	datadir   string
+	unitTag   names.UnitTag
+	statefile *operation.StateFile
+}
+
+var _ = gc.Suite(&upgradeStateContextSuite{})
+
+func (s *upgradeStateContextSuite) SetUpTest(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("No need to test upgrading state context windows")
+	}
+	s.datadir = c.MkDir()
+	s.statefile = nil
+	s.initializeContext(c, names.NewUnitTag("mysql/0"))
+}
+
+func (s *upgradeStateContextSuite) TestContextUpgradeWithUnitTag(c *gc.C) {
+	given, expectUpgrade :=
+		&operation.State{
+			Kind: operation.Continue,
+			Step: operation.Pending,
+			Hook: &hook.Info{
+				Kind: hooks.Stop,
+			}},
+		&operation.State{
+			Kind:    operation.Continue,
+			Step:    operation.Pending,
+			Stopped: true}
+
+	s.confirmUpgrade(c, given, expectUpgrade)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeNoStopHookNoChange(c *gc.C) {
+	given := &operation.State{
+		Kind: operation.Continue,
+		Step: operation.Pending}
+	expectNoChange := given
+
+	s.confirmUpgrade(c, given, expectNoChange)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeRunHookNoChange(c *gc.C) {
+	given := &operation.State{
+		Kind: operation.RunHook,
+		Step: operation.Pending,
+		Hook: &hook.Info{
+			Kind: hooks.Stop,
+		}}
+	expectNoChange := given
+
+	s.confirmUpgrade(c, given, expectNoChange)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeInstallOpNoChange(c *gc.C) {
+	given := &operation.State{
+		Kind:     operation.Install,
+		Step:     operation.Pending,
+		CharmURL: &charm.URL{}}
+	expectNoChange := given
+
+	s.confirmUpgrade(c, given, expectNoChange)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeUpgradeOpNoChange(c *gc.C) {
+	given := &operation.State{
+		Kind:     operation.Upgrade,
+		Step:     operation.Pending,
+		CharmURL: &charm.URL{}}
+	expectNoChange := given
+
+	s.confirmUpgrade(c, given, expectNoChange)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeIdempotent(c *gc.C) {
+	given, expectUpgrade :=
+		&operation.State{
+			Kind: operation.Continue,
+			Step: operation.Pending,
+			Hook: &hook.Info{
+				Kind: hooks.Stop,
+			}},
+		&operation.State{
+			Kind:    operation.Continue,
+			Step:    operation.Pending,
+			Stopped: true}
+
+	s.confirmUpgradeIdempotent(c, given, expectUpgrade)
+}
+
+func (s *upgradeStateContextSuite) confirmUpgrade(c *gc.C, given, expect *operation.State) {
+	s.writeState(c, given)
+	s.applyUpgrade(c)
+	after := s.readState(c)
+	c.Assert(after, jc.DeepEquals, expect)
+}
+
+func (s *upgradeStateContextSuite) confirmUpgradeIdempotent(c *gc.C, given, expect *operation.State) {
+	s.writeState(c, given)
+	s.applyUpgrade(c)
+	after := s.readState(c)
+	c.Assert(after, jc.DeepEquals, expect)
+	s.applyUpgrade(c)
+	second := s.readState(c)
+	c.Assert(second, jc.DeepEquals, expect)
+}
+
+func (s *upgradeStateContextSuite) writeState(c *gc.C, state *operation.State) {
+	err := s.statefile.WriteUnsafe(state)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradeStateContextSuite) readState(c *gc.C) *operation.State {
+	state, err := s.statefile.Read()
+	c.Assert(err, jc.ErrorIsNil)
+	return state
+}
+
+func (s *upgradeStateContextSuite) applyUpgrade(c *gc.C) {
+	err := uniter.AddStoppedFieldToUniterState(s.unitTag, s.datadir)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradeStateContextSuite) initializeContext(c *gc.C, utag names.UnitTag) {
+	paths := uniter.NewPaths(s.datadir, utag)
+	opsfile := paths.State.OperationsFile
+	s.statefile = operation.NewStateFile(opsfile)
+	c.Assert(os.MkdirAll(filepath.Dir(opsfile), 0755), gc.IsNil)
+	s.unitTag = utag
+}


### PR DESCRIPTION
 Instead of switching on opState.Hook.Kind we have a top level
 opState.Stopped state (say that 10x fast) to indicate a Stop hook has run.

Add Upgrade Steps

 We need to also upgrade the uniter state.  Work in progress upgrade and
 tests.

(Review request: http://reviews.vapour.ws/r/1181/)