### PR TITLE
storage: don't panic listing with multiple storage

### DIFF
--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -13,7 +13,7 @@ import (
 type storageAccess interface {
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	AllStorageInstances() ([]state.StorageInstance, error)
-	StorageAttachments(unit names.UnitTag) ([]state.StorageAttachment, error)
+	StorageAttachments(names.StorageTag) ([]state.StorageAttachment, error)
 	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
 	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -152,9 +152,9 @@ func (s *storageSuite) TestStorageListInstanceError(c *gc.C) {
 }
 
 func (s *storageSuite) TestStorageListAttachmentError(c *gc.C) {
-	s.state.storageInstanceAttachments = func(unit names.UnitTag) ([]state.StorageAttachment, error) {
+	s.state.storageInstanceAttachments = func(tag names.StorageTag) ([]state.StorageAttachment, error) {
 		s.calls = append(s.calls, storageInstanceAttachmentsCall)
-		c.Assert(unit, gc.DeepEquals, s.unitTag)
+		c.Assert(tag, gc.DeepEquals, s.storageTag)
 		return []state.StorageAttachment{}, errors.Errorf("list test error")
 	}
 
@@ -252,7 +252,7 @@ func (s *storageSuite) TestStorageListFilesystemAttachmentError(c *gc.C) {
 func (s *storageSuite) createTestStorageInfoWithError(code, msg string) params.StorageInfo {
 	wanted := s.createTestStorageInfo()
 	wanted.Error = &params.Error{Code: code,
-		Message: fmt.Sprintf("getting attachments for owner unit-mysql-0: %v", msg)}
+		Message: fmt.Sprintf("getting attachments for storage data/0: %v", msg)}
 	return wanted
 }
 
@@ -297,9 +297,9 @@ func (s *storageSuite) constructState(c *gc.C) *mockState {
 			c.Assert(sTag, gc.DeepEquals, s.storageTag)
 			return mockInstance, nil
 		},
-		storageInstanceAttachments: func(unit names.UnitTag) ([]state.StorageAttachment, error) {
+		storageInstanceAttachments: func(tag names.StorageTag) ([]state.StorageAttachment, error) {
 			s.calls = append(s.calls, storageInstanceAttachmentsCall)
-			c.Assert(unit, gc.DeepEquals, s.unitTag)
+			c.Assert(tag, gc.DeepEquals, s.storageTag)
 			return []state.StorageAttachment{storageInstanceAttachment}, nil
 		},
 		storageInstanceFilesystem: func(sTag names.StorageTag) (state.Filesystem, error) {
@@ -369,7 +369,7 @@ func (s *storageSuite) TestShowStorage(c *gc.C) {
 		OwnerTag:   s.unitTag.String(),
 		Kind:       params.StorageKindFilesystem,
 		UnitTag:    s.unitTag.String(),
-		Status:     "attached",
+		Status:     "pending",
 	}
 	c.Assert(one.Result, gc.DeepEquals, expected)
 }
@@ -383,7 +383,7 @@ func (s *storageSuite) TestShowStorageInvalidId(c *gc.C) {
 	c.Assert(found.Results, gc.HasLen, 1)
 
 	instance := found.Results[0]
-	c.Assert(errors.Cause(instance.Error), gc.ErrorMatches, ".*permission denied.*")
+	c.Assert(instance.Error, gc.ErrorMatches, `"foo" is not a valid tag`)
 
 	expected := params.StorageDetails{Kind: params.StorageKindUnknown}
 	c.Assert(instance.Result, gc.DeepEquals, expected)
@@ -393,7 +393,7 @@ type mockState struct {
 	storageInstance     func(names.StorageTag) (state.StorageInstance, error)
 	allStorageInstances func() ([]state.StorageInstance, error)
 
-	storageInstanceAttachments func(unit names.UnitTag) ([]state.StorageAttachment, error)
+	storageInstanceAttachments func(names.StorageTag) ([]state.StorageAttachment, error)
 
 	unitAssignedMachine func(u names.UnitTag) (names.MachineTag, error)
 
@@ -415,8 +415,8 @@ func (st *mockState) AllStorageInstances() ([]state.StorageInstance, error) {
 	return st.allStorageInstances()
 }
 
-func (st *mockState) StorageAttachments(unit names.UnitTag) ([]state.StorageAttachment, error) {
-	return st.storageInstanceAttachments(unit)
+func (st *mockState) StorageAttachments(tag names.StorageTag) ([]state.StorageAttachment, error) {
+	return st.storageInstanceAttachments(tag)
 }
 
 func (st *mockState) UnitAssignedMachine(unit names.UnitTag) (names.MachineTag, error) {

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -89,24 +89,24 @@ func (s *storageSuite) TestStorageListEmpty(c *gc.C) {
 }
 
 func (s *storageSuite) TestStorageList(c *gc.C) {
-	_, err := s.api.List()
+	found, err := s.api.List()
 	c.Assert(err, jc.ErrorIsNil)
 
-	//	expectedCalls := []string{
-	//		allStorageInstancesCall,
-	//		storageInstanceAttachmentsCall,
-	//		unitAssignedMachineCall,
-	//		storageInstanceCall,
-	//		storageInstanceFilesystemCall,
-	//		storageInstanceFilesystemAttachmentCall,
-	//	}
-	//	s.assertCalls(c, expectedCalls)
-	//
-	//	c.Assert(found.Results, gc.HasLen, 1)
-	//	wantedDetails := s.createTestStorageInfo()
-	//	wantedDetails.UnitTag = s.unitTag.String()
-	//	wantedDetails.Status = "attached"
-	//	s.assertInstanceInfoError(c, found.Results[0], wantedDetails, "")
+	expectedCalls := []string{
+		allStorageInstancesCall,
+		storageInstanceVolumeCall,
+		storageInstanceAttachmentsCall,
+		unitAssignedMachineCall,
+		storageInstanceCall,
+		storageInstanceFilesystemCall,
+		storageInstanceFilesystemAttachmentCall,
+	}
+	s.assertCalls(c, expectedCalls)
+
+	c.Assert(found.Results, gc.HasLen, 1)
+	wantedDetails := s.createTestStorageInfo()
+	wantedDetails.UnitTag = s.unitTag.String()
+	s.assertInstanceInfoError(c, found.Results[0], wantedDetails, "")
 }
 
 func (s *storageSuite) TestStorageListError(c *gc.C) {
@@ -327,7 +327,6 @@ func (s *storageSuite) constructState(c *gc.C) *mockState {
 }
 
 func (s *storageSuite) assertCalls(c *gc.C, expectedCalls []string) {
-	c.Assert(s.calls, gc.HasLen, len(expectedCalls))
 	c.Assert(s.calls, jc.SameContents, expectedCalls)
 }
 

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -16,7 +16,7 @@ type storageStateInterface interface {
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
-	StorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
+	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 	StorageAttachment(names.StorageTag, names.UnitTag) (state.StorageAttachment, error)
 	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
 	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -58,7 +58,7 @@ func (s *StorageAPI) getOneUnitStorageAttachments(canAccess common.AuthFunc, uni
 	if err != nil || !canAccess(tag) {
 		return nil, common.ErrPerm
 	}
-	stateStorageAttachments, err := s.st.StorageAttachments(tag)
+	stateStorageAttachments, err := s.st.UnitStorageAttachments(tag)
 	if errors.IsNotFound(err) {
 		return nil, common.ErrPerm
 	} else if err != nil {

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -98,7 +98,7 @@ storage-block/0:
   data/0:
     storage: data
     kind: block
-    status: attached
+    status: pending
     persistent: false
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -113,7 +113,7 @@ storage-block/0:
   data/0:
     storage: data
     kind: block
-    status: attached
+    status: pending
     persistent: false
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -142,8 +142,8 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 	context := runList(c)
 	expected := `
 [Storage]       
-UNIT            ID     LOCATION STATUS   PERSISTENT 
-storage-block/0 data/0          attached false      
+UNIT            ID     LOCATION STATUS  PERSISTENT 
+storage-block/0 data/0          pending false      
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -155,8 +155,8 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	context := runList(c)
 	expected := `
 [Storage]       
-UNIT            ID     LOCATION STATUS   PERSISTENT 
-storage-block/0 data/0          attached true       
+UNIT            ID     LOCATION STATUS  PERSISTENT 
+storage-block/0 data/0          pending true       
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -177,7 +177,7 @@ storage-block/0:
   data/0:
     storage: data
     kind: block
-    status: attached
+    status: pending
     persistent: true
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -187,13 +187,12 @@ func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPersistentPool)
 
 	context := runShow(c, []string{"data/0"})
-	// TODO(wallyworld) - status should be pending below but there's a bug in apiserver/storage
 	expected := `
 storage-block/0:
   data/0:
     storage: data
     kind: block
-    status: attached
+    status: pending
     persistent: true
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1014,7 +1014,7 @@ func (s *AssignSuite) TestAssignUnitWithStorageCleanAvailable(c *gc.C) {
 
 	unit, err := s.storageSvc.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	storageAttachments, err := s.State.StorageAttachments(unit.UnitTag())
+	storageAttachments, err := s.State.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageAttachments, gc.HasLen, 1)
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -377,14 +377,14 @@ func (s *CleanupSuite) TestCleanupStorage(c *gc.C) {
 	si, err = s.State.StorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(si.Life(), gc.Equals, state.Dying)
-	sa, err := s.State.StorageAttachments(u.UnitTag())
+	sa, err := s.State.UnitStorageAttachments(u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sa, gc.HasLen, 1)
 	c.Assert(sa[0].Life(), gc.Equals, state.Alive)
 	s.assertCleanupRuns(c)
 
 	// After running the cleanup, the attachment should be dying.
-	sa, err = s.State.StorageAttachments(u.UnitTag())
+	sa, err = s.State.UnitStorageAttachments(u.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sa, gc.HasLen, 1)
 	c.Assert(sa[0].Life(), gc.Equals, state.Dying)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -59,7 +59,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 	assignedMachineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 
-	storageAttachments, err := s.State.StorageAttachments(unit.UnitTag())
+	storageAttachments, err := s.State.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageAttachments, gc.HasLen, 1)
 	storageInstance, err := s.State.StorageInstance(storageAttachments[0].StorageInstance())

--- a/state/unit.go
+++ b/state/unit.go
@@ -1405,7 +1405,7 @@ type storageParams struct {
 // and volume/filesystem attachments for a new machine that the unit will be
 // assigned to.
 func (u *Unit) newMachineStorageParams() (*storageParams, error) {
-	storageAttachments, err := u.st.StorageAttachments(u.UnitTag())
+	storageAttachments, err := u.st.UnitStorageAttachments(u.UnitTag())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting storage attachments")
 	}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -32,7 +32,7 @@ func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
 	assignedMachineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 
-	storageAttachments, err := s.State.StorageAttachments(unit.UnitTag())
+	storageAttachments, err := s.State.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageAttachments, gc.HasLen, 1)
 	storageInstance, err := s.State.StorageInstance(storageAttachments[0].StorageInstance())

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -294,7 +294,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	s.machine = nil // allocate a new machine
 	unit := s.AddUnit(c, service)
 
-	storageAttachments, err := s.State.StorageAttachments(unit.UnitTag())
+	storageAttachments, err := s.State.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageAttachments, gc.HasLen, 1)
 	storageTag := storageAttachments[0].StorageInstance()


### PR DESCRIPTION
"juju storage list" is panicking when there are
multiple storage instances/attachments for a unit.
The cause is the inappropriate use of
State.UnitStorageAttachments (was State.StorageAttachments)
for getting attachments for a storage instance.

This branch renames State.StorageAttachments to
State.UnitStorageAttachments, and adds a new
State.StorageAttachments that returns all storage
attachments for a specific storage instance.

I've also fixed improper storage status in one
case; there is more work to do there.

(Review request: http://reviews.vapour.ws/r/1185/)