### PR TITLE
More persistent storage work

### DIFF
--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -57,6 +57,7 @@ func (s *storageMockSuite) TestShow(c *gc.C) {
 						Result: params.StorageDetails{
 							StorageTag: twoTag.String(),
 							Status:     "attached",
+							Persistent: true,
 						},
 					},
 					params.StorageDetailsResult{Error: common.ServerError(errors.New(msg))},
@@ -133,6 +134,7 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 						params.StorageDetails{
 							StorageTag: twoTag.String(),
 							Status:     "attached",
+							Persistent: true,
 						},
 						nil,
 					},
@@ -155,7 +157,8 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 		params.StorageInfo{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1000",
-				Status:     "attached"},
+				Status:     "attached",
+				Persistent: true},
 			nil},
 	}
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -4088,6 +4088,10 @@ type mockStorageProvider struct {
 	kind storage.StorageKind
 }
 
+func (m *mockStorageProvider) Scope() storage.Scope {
+	return storage.ScopeMachine
+}
+
 func (m *mockStorageProvider) Supports(k storage.StorageKind) bool {
 	return k == m.kind
 }

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -63,7 +63,7 @@ func StoragePoolConfig(name string, poolManager poolmanager.PoolManager) (storag
 		if _, err1 := registry.StorageProvider(providerType); err1 != nil {
 			return "", nil, errors.Trace(err)
 		}
-		return providerType, nil, nil
+		return providerType, &storage.Config{}, nil
 	} else if err != nil {
 		return "", nil, errors.Annotatef(err, "getting pool %q", name)
 	}

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -37,7 +37,7 @@ func VolumeParams(v state.Volume, poolManager poolmanager.PoolManager) (params.V
 		return params.VolumeParams{}, err
 	}
 
-	providerType, attrs, err := StoragePoolConfig(stateVolumeParams.Pool, poolManager)
+	providerType, cfg, err := StoragePoolConfig(stateVolumeParams.Pool, poolManager)
 	if err != nil {
 		return params.VolumeParams{}, errors.Trace(err)
 	}
@@ -45,17 +45,17 @@ func VolumeParams(v state.Volume, poolManager poolmanager.PoolManager) (params.V
 		v.Tag().String(),
 		stateVolumeParams.Size,
 		string(providerType),
-		attrs,
+		cfg.Attrs(),
 		nil, // attachment params set by the caller
 	}, nil
 }
 
 // StoragePoolConfig returns the storage provider type and
-// configuration attributes for a named storage pool. If
-// there is no such pool with the specified name, but it
-// identifies a storage provider, then that type will be
-// returned with a nil configuration.
-func StoragePoolConfig(name string, poolManager poolmanager.PoolManager) (storage.ProviderType, map[string]interface{}, error) {
+// configuration for a named storage pool. If there is no
+// such pool with the specified name, but it identifies a
+// storage provider, then that type will be returned with a
+// nil configuration.
+func StoragePoolConfig(name string, poolManager poolmanager.PoolManager) (storage.ProviderType, *storage.Config, error) {
 	pool, err := poolManager.Get(name)
 	if errors.IsNotFound(err) {
 		// If not a storage pool, then maybe a provider type.
@@ -67,7 +67,7 @@ func StoragePoolConfig(name string, poolManager poolmanager.PoolManager) (storag
 	} else if err != nil {
 		return "", nil, errors.Annotatef(err, "getting pool %q", name)
 	}
-	return pool.Provider(), pool.Attrs(), nil
+	return pool.Provider(), pool, nil
 }
 
 // VolumesToState converts a slice of params.Volume to a mapping

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -295,6 +295,9 @@ type StorageDetails struct {
 
 	// Location holds location for provisioned attached instances.
 	Location string `json:"location,omitempty"`
+
+	// Persistent indicates whether the storage is persistent or not.
+	Persistent bool `json:"persistent"`
 }
 
 // StorageDetailsResult holds information about a storage instance

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage/poolmanager"
 )
 
 func init() {
@@ -20,13 +21,15 @@ func init() {
 // API implements the storage interface and is the concrete
 // implementation of the api end point.
 type API struct {
-	storage    storageAccess
-	authorizer common.Authorizer
+	storage     storageAccess
+	poolManager poolmanager.PoolManager
+	authorizer  common.Authorizer
 }
 
 // createAPI returns a new storage API facade.
 func createAPI(
 	st storageAccess,
+	pm poolmanager.PoolManager,
 	resources *common.Resources,
 	authorizer common.Authorizer,
 ) (*API, error) {
@@ -35,8 +38,9 @@ func createAPI(
 	}
 
 	return &API{
-		storage:    st,
-		authorizer: authorizer,
+		storage:     st,
+		poolManager: pm,
+		authorizer:  authorizer,
 	}, nil
 }
 
@@ -46,7 +50,11 @@ func NewAPI(
 	resources *common.Resources,
 	authorizer common.Authorizer,
 ) (*API, error) {
-	return createAPI(getState(st), resources, authorizer)
+	return createAPI(getState(st), poolManager(st), resources, authorizer)
+}
+
+func poolManager(st *state.State) poolmanager.PoolManager {
+	return poolmanager.New(state.NewStateSettings(st))
 }
 
 // Show retrieves and returns detailed information about desired storage
@@ -77,7 +85,11 @@ func (api *API) List() (params.StorageInfosResult, error) {
 	}
 	var infos []params.StorageInfo
 	for _, stateInstance := range stateInstances {
-		instance := createParamsStorageInstance(stateInstance)
+		persistent, err := api.isPersistent(stateInstance.StorageTag())
+		if err != nil {
+			return params.StorageInfosResult{}, err
+		}
+		instance := createParamsStorageInstance(stateInstance, persistent)
 
 		// It is possible to encounter errors here related to getting individual
 		// storage details such as getting attachments, getting machine from the unit,
@@ -152,6 +164,7 @@ func (api *API) createParamsStorageAttachment(si params.StorageDetails, sa state
 	result.OwnerTag = si.OwnerTag
 	result.Kind = si.Kind
 	result.Status = "attached"
+	result.Persistent = si.Persistent
 
 	// This is only for provisioned attachments
 	machineTag, err := api.storage.UnitAssignedMachine(sa.Unit())
@@ -189,15 +202,41 @@ func (api *API) getStorageInstance(tag string) (bool, params.StorageDetails, *pa
 		}
 		return false, nothing, serverError(common.ErrPerm)
 	}
-	return true, createParamsStorageInstance(stateInstance), nil
+	persistent, err := api.isPersistent(aTag)
+	if err != nil {
+		return false, nothing, serverError(err)
+	}
+	return true, createParamsStorageInstance(stateInstance, persistent), nil
 }
 
-func createParamsStorageInstance(si state.StorageInstance) params.StorageDetails {
+func createParamsStorageInstance(si state.StorageInstance, persistent bool) params.StorageDetails {
 	result := params.StorageDetails{
 		OwnerTag:   si.Owner().String(),
 		StorageTag: si.Tag().String(),
 		Kind:       params.StorageKind(si.Kind()),
 		Status:     "pending",
+		Persistent: persistent,
 	}
 	return result
+}
+
+func (api *API) isPersistent(tag names.StorageTag) (bool, error) {
+	volume, err := api.storage.StorageInstanceVolume(tag)
+	if err != nil {
+		return false, common.ErrPerm
+	}
+	// If the volume is not provisioned, we read its config attributes.
+	if params, ok := volume.Params(); ok {
+		_, cfg, err := common.StoragePoolConfig(params.Pool, api.poolManager)
+		if err != nil {
+			return false, err
+		}
+		return cfg.IsPersistent(), nil
+	}
+	// If the volume is provisioned, we look at its provisioning info.
+	info, err := volume.Info()
+	if err != nil {
+		return false, err
+	}
+	return info.Persistent, nil
 }

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -43,12 +43,12 @@ func (s *ListSuite) TestList(c *gc.C) {
 		// Default format is tabular
 		`
 [Storage]    
-UNIT         ID          LOCATION STATUS  
-postgresql/0 db-dir/1100          pending 
-transcode/0  db-dir/1000          pending 
-transcode/0  db-dir/1100          pending 
-transcode/0  shared-fs/0          pending 
-transcode/1  shared-fs/0          pending 
+UNIT         ID          LOCATION STATUS  PERSISTENT 
+postgresql/0 db-dir/1100          pending false      
+transcode/0  db-dir/1000          pending true       
+transcode/0  db-dir/1100          pending false      
+transcode/0  shared-fs/0          pending false      
+transcode/1  shared-fs/0          pending false      
 
 `[1:],
 		"",
@@ -65,24 +65,29 @@ postgresql/0:
     storage: db-dir
     kind: filesystem
     status: pending
+    persistent: false
 transcode/0:
   db-dir/1000:
     storage: db-dir
     kind: block
     status: pending
+    persistent: true
   db-dir/1100:
     storage: db-dir
     kind: filesystem
     status: pending
+    persistent: false
   shared-fs/0:
     storage: shared-fs
     kind: unknown
     status: pending
+    persistent: false
 transcode/1:
   shared-fs/0:
     storage: shared-fs
     kind: unknown
     status: pending
+    persistent: false
 `[1:],
 		"",
 	)
@@ -96,14 +101,14 @@ func (s *ListSuite) TestListOwnerStorageIdSort(c *gc.C) {
 		// Default format is tabular
 		`
 [Storage]    
-UNIT         ID          LOCATION STATUS  
-postgresql/0 db-dir/1100          pending 
-transcode/0  db-dir/1000          pending 
-transcode/0  db-dir/1100          pending 
-transcode/0  shared-fs/0          pending 
-transcode/0  shared-fs/5          pending 
-transcode/1  db-dir/1000          pending 
-transcode/1  shared-fs/0          pending 
+UNIT         ID          LOCATION STATUS  PERSISTENT 
+postgresql/0 db-dir/1100          pending false      
+transcode/0  db-dir/1000          pending true       
+transcode/0  db-dir/1100          pending false      
+transcode/0  shared-fs/0          pending false      
+transcode/0  shared-fs/5          pending false      
+transcode/1  db-dir/1000          pending true       
+transcode/1  shared-fs/0          pending false      
 
 `[1:],
 		`
@@ -156,6 +161,7 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 			Kind:       params.StorageKindUnknown,
 			Location:   "there",
 			Status:     "provisioned",
+			Persistent: true,
 		}, nil}}
 
 	if chaos {
@@ -184,6 +190,7 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 				UnitTag:    "unit-transcode-1",
 				Kind:       params.StorageKindFilesystem,
 				Status:     "attached",
+				Persistent: true,
 			}, nil}
 		results = append(results, last)
 		results = append(results, second)
@@ -232,6 +239,7 @@ func getTestInstances(chaos bool) []params.StorageInfo {
 				UnitTag:    "unit-transcode-0",
 				Kind:       params.StorageKindBlock,
 				Status:     "pending",
+				Persistent: true,
 			}, nil}}
 
 	if chaos {
@@ -256,6 +264,7 @@ func getTestInstances(chaos bool) []params.StorageInfo {
 				UnitTag:    "unit-transcode-1",
 				Kind:       params.StorageKindFilesystem,
 				Status:     "pending",
+				Persistent: true,
 			}, nil}
 		zero := params.StorageInfo{
 			params.StorageDetails{

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -30,7 +30,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 		fmt.Fprintln(tw)
 	}
 	p("[Storage]")
-	p("UNIT\tID\tLOCATION\tSTATUS")
+	p("UNIT\tID\tLOCATION\tSTATUS\tPERSISTENT")
 
 	// First sort by units
 	units := make([]string, 0, len(storageInfo))
@@ -50,7 +50,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 
 		for _, storageId := range storageIds {
 			info := all[storageId]
-			p(unit, storageId, info.Location, info.Status)
+			p(unit, storageId, info.Location, info.Status, info.Persistent)
 		}
 	}
 	tw.Flush()

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -61,11 +61,13 @@ postgresql/0:
     storage: shared-fs
     kind: block
     status: pending
+    persistent: false
 transcode/0:
   shared-fs/0:
     storage: shared-fs
     kind: filesystem
     status: attached
+    persistent: false
     location: a location
 `[1:],
 	)
@@ -80,7 +82,7 @@ func (s *ShowSuite) TestShowJSON(c *gc.C) {
 	s.assertValidShow(
 		c,
 		[]string{"shared-fs/0", "--format", "json"},
-		`{"postgresql/0":{"shared-fs/0":{"storage":"shared-fs","kind":"block","status":"pending"}},"transcode/0":{"shared-fs/0":{"storage":"shared-fs","kind":"filesystem","status":"attached","location":"a location"}}}
+		`{"postgresql/0":{"shared-fs/0":{"storage":"shared-fs","kind":"block","status":"pending","persistent":false}},"transcode/0":{"shared-fs/0":{"storage":"shared-fs","kind":"filesystem","status":"attached","persistent":false,"location":"a location"}}}
 `,
 	)
 }
@@ -95,15 +97,18 @@ postgresql/0:
     storage: db-dir
     kind: block
     status: pending
+    persistent: true
   shared-fs/0:
     storage: shared-fs
     kind: block
     status: pending
+    persistent: false
 transcode/0:
   shared-fs/0:
     storage: shared-fs
     kind: filesystem
     status: attached
+    persistent: false
     location: a location
 `[1:],
 	)
@@ -136,6 +141,9 @@ func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetails, err
 			UnitTag:    "unit-postgresql-0",
 			Kind:       params.StorageKindBlock,
 			Status:     "pending",
+		}
+		if i == 1 {
+			all[i].Persistent = true
 		}
 	}
 	for _, tag := range tags {

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -65,6 +65,7 @@ type StorageInfo struct {
 	StorageName string `yaml:"storage" json:"storage"`
 	Kind        string `yaml:"kind" json:"kind"`
 	Status      string `yaml:"status,omitempty" json:"status,omitempty"`
+	Persistent  bool   `yaml:"persistent" json:"persistent"`
 	Location    string `yaml:"location,omitempty" json:"location,omitempty"`
 }
 
@@ -94,6 +95,7 @@ func formatStorageDetails(storages []params.StorageDetails) (map[string]map[stri
 			Kind:        one.Kind.String(),
 			Status:      one.Status,
 			Location:    one.Location,
+			Persistent:  one.Persistent,
 		}
 		unit := unitTag.Id()
 		unitColl, ok := output[unit]

--- a/state/environ.go
+++ b/state/environ.go
@@ -384,6 +384,15 @@ func (e *Environment) ensureDestroyable() error {
 		return errors.Trace(err)
 	}
 
+	// If there are any persistent volumes, the environment can't be destroyed.
+	volumes, err := e.st.PersistentVolumes()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(volumes) > 0 {
+		return ErrPersistentVolumesExist
+	}
+
 	// If this is not the state server environment, it can be destroyed
 	if e.doc.UUID != e.doc.ServerUUID {
 		return nil

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -291,5 +291,6 @@ func (s *EnvironSuite) TestDestroyEnvironmentWithPersistentVolumesFails(c *gc.C)
 
 	env, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)
+	// TODO(wallyworld) when we can destroy/remove volume, ensure env can then be destroyed
 	c.Assert(errors.Cause(env.Destroy()), gc.Equals, state.ErrPersistentVolumesExist)
 }

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -13,7 +13,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage/poolmanager"
+	"github.com/juju/juju/storage/provider/registry"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -260,4 +263,33 @@ func assertObtainedUsersMatchExpectedUsers(c *gc.C, obtainedUsers, expectedUsers
 		c.Assert(obtained.DisplayName(), gc.Equals, expectedUsers[i].DisplayName())
 		c.Assert(obtained.CreatedBy(), gc.Equals, expectedUsers[i].CreatedBy())
 	}
+}
+
+func (s *EnvironSuite) TestDestroyEnvironmentWithPersistentVolumesFails(c *gc.C) {
+	// Create a persistent volume.
+	// TODO(wallyworld) - consider moving this to factory
+	registry.RegisterEnvironStorageProviders("someprovider", ec2.EBS_ProviderType)
+	pm := poolmanager.New(state.NewStateSettings(s.State))
+	_, err := pm.Create("persistent-block", ec2.EBS_ProviderType, map[string]interface{}{"persistent": "true"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ch := s.AddTestingCharm(c, "storage-block2")
+	storage := map[string]state.StorageConstraints{
+		"multi1to10": makeStorageCons("persistent-block", 1024, 1),
+	}
+	service := s.AddTestingServiceWithStorage(c, "storage-block2", ch, storage)
+	unit, err := service.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume1, err := s.State.StorageInstanceVolume(names.NewStorageTag("multi1to10/0"))
+	c.Assert(err, jc.ErrorIsNil)
+	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
+	err = s.State.SetVolumeInfo(volume1.VolumeTag(), volumeInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errors.Cause(env.Destroy()), gc.Equals, state.ErrPersistentVolumesExist)
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -25,6 +25,11 @@ import (
 	"github.com/juju/juju/storage/provider/registry"
 )
 
+var ErrPersistentVolumesExist = errors.New(`
+Environment cannot be destroyed until all persistent volumes have been destroyed.
+Run "juju storage list" to display persistent storage volumes.
+`[1:])
+
 // StorageInstance represents the state of a unit or service-wide storage
 // instance in the environment.
 type StorageInstance interface {

--- a/storage/config.go
+++ b/storage/config.go
@@ -59,8 +59,11 @@ func (c *Config) Provider() ProviderType {
 }
 
 // Attrs returns the configuration attributes for a storage source.
-func (c *Config) Attrs() map[string]interface{} {
-	attrs := make(map[string]interface{})
+func (c *Config) Attrs() (attrs map[string]interface{}) {
+	if c.attrs == nil {
+		return attrs
+	}
+	attrs = make(map[string]interface{})
 	for k, v := range c.attrs {
 		attrs[k] = v
 	}

--- a/storage/poolmanager/poolmanager.go
+++ b/storage/poolmanager/poolmanager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
@@ -61,6 +62,11 @@ func (pm *poolManager) Create(name string, providerType storage.ProviderType, at
 	if err != nil {
 		return nil, err
 	}
+	// Perform common validation.
+	if err := provider.ValidateConfig(p, cfg); err != nil {
+		return nil, err
+	}
+	// Perform provider specific validation.
 	if err := p.ValidateConfig(cfg); err != nil {
 		return nil, err
 	}

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -33,7 +33,8 @@ var _ storage.Provider = (*loopProvider)(nil)
 
 // ValidateConfig is defined on the Provider interface.
 func (lp *loopProvider) ValidateConfig(cfg *storage.Config) error {
-	return ValidateConfig(lp, cfg)
+	// Loop provider has no configuration.
+	return nil
 }
 
 // validateFullConfig validates a fully-constructed storage config,

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -66,14 +66,6 @@ func (s *loopSuite) TestValidateConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *loopSuite) TestPersistentNotAllowed(c *gc.C) {
-	p := s.loopProvider(c)
-	cfg, err := storage.NewConfig("name", provider.LoopProviderType, map[string]interface{}{"persistent": true})
-	c.Assert(err, jc.ErrorIsNil)
-	err = p.ValidateConfig(cfg)
-	c.Assert(err, gc.ErrorMatches, `machine scoped storage provider "name" does not support persistent storage`)
-}
-
 func (s *loopSuite) TestSupports(c *gc.C) {
 	p := s.loopProvider(c)
 	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsTrue)

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -31,7 +31,8 @@ var (
 
 // ValidateConfig is defined on the Provider interface.
 func (p *rootfsProvider) ValidateConfig(cfg *storage.Config) error {
-	return ValidateConfig(p, cfg)
+	// Rootfs provider has no configuration.
+	return nil
 }
 
 // validateFullConfig validates a fully-constructed storage config,

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -61,14 +61,6 @@ func (s *rootfsSuite) TestValidateConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *rootfsSuite) TestPersistentNotAllowed(c *gc.C) {
-	p := s.rootfsProvider(c)
-	cfg, err := storage.NewConfig("name", provider.RootfsProviderType, map[string]interface{}{"persistent": true})
-	c.Assert(err, jc.ErrorIsNil)
-	err = p.ValidateConfig(cfg)
-	c.Assert(err, gc.ErrorMatches, `machine scoped storage provider "name" does not support persistent storage`)
-}
-
 func (s *rootfsSuite) TestSupports(c *gc.C) {
 	p := s.rootfsProvider(c)
 	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsFalse)

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -29,7 +29,8 @@ var (
 
 // ValidateConfig is defined on the Provider interface.
 func (p *tmpfsProvider) ValidateConfig(cfg *storage.Config) error {
-	return ValidateConfig(p, cfg)
+	// Tmpfs provider has no configuration.
+	return nil
 }
 
 // validateFullConfig validates a fully-constructed storage config,

--- a/storage/provider/tmpfs_test.go
+++ b/storage/provider/tmpfs_test.go
@@ -61,14 +61,6 @@ func (s *tmpfsSuite) TestValidateConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *tmpfsSuite) TestPersistentNotAllowed(c *gc.C) {
-	p := s.tmpfsProvider(c)
-	cfg, err := storage.NewConfig("name", provider.TmpfsProviderType, map[string]interface{}{"persistent": true})
-	c.Assert(err, jc.ErrorIsNil)
-	err = p.ValidateConfig(cfg)
-	c.Assert(err, gc.ErrorMatches, `machine scoped storage provider "name" does not support persistent storage`)
-}
-
 func (s *tmpfsSuite) TestSupports(c *gc.C) {
 	p := s.tmpfsProvider(c)
 	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsFalse)


### PR DESCRIPTION
A few changes:

- expose persistent attribute to storage list/show commands
-make persistent volumes always illegal for machine scoped providers
- prevent env destroy if persistent volumes exist

(Review request: http://reviews.vapour.ws/r/1186/)