### PR TITLE
Fixed lp:1433116 - int overflow on i386 in dblogpruner

### DIFF
--- a/worker/dblogpruner/worker.go
+++ b/worker/dblogpruner/worker.go
@@ -21,7 +21,7 @@ type LogPruneParams struct {
 }
 
 const DefaultMaxLogAge = 3 * 24 * time.Hour
-const DefaultMaxCollectionBytes = 4 * 1024 * 1024 * 1024
+const DefaultMaxCollectionBytes = int(uint32(4*1024*1024*1024 - 1))
 const DefaultPruneInterval = 5 * time.Minute
 
 // NewLogPruneParams returns a LogPruneParams initialised with default

--- a/worker/dblogpruner/worker.go
+++ b/worker/dblogpruner/worker.go
@@ -30,18 +30,13 @@ const (
 
 var DefaultMaxCollectionBytes int
 
-const (
+func init() {
 	// See bug #1433116 - to avoid i386 overflow we have different
 	// defaults for i386 and other (64-bit) architectures.
-	defaultMaxCollectionBytesInt64 = 4 * 1024 * 1024 * 1024
-	defaultMaxCollectionBytesInt32 = math.MaxInt32
-)
-
-func init() {
 	if arch.NormaliseArch(runtime.GOARCH) == arch.I386 {
-		DefaultMaxCollectionBytes = defaultMaxCollectionBytesInt32
+		DefaultMaxCollectionBytes = math.MaxInt32
 	} else {
-		DefaultMaxCollectionBytes = defaultMaxCollectionBytesInt64
+		DefaultMaxCollectionBytes = 4 * 1024 * 1024 * 1024
 	}
 }
 

--- a/worker/dblogpruner/worker.go
+++ b/worker/dblogpruner/worker.go
@@ -20,9 +20,13 @@ type LogPruneParams struct {
 	PruneInterval      time.Duration
 }
 
-const DefaultMaxLogAge = 3 * 24 * time.Hour
-const DefaultMaxCollectionBytes = int(uint32(4*1024*1024*1024 - 1))
-const DefaultPruneInterval = 5 * time.Minute
+const (
+	DefaultMaxLogAge = 3 * 24 * time.Hour
+	// See bug #1433116 - explictly casting to uint32 and then back to
+	// avoid overflowing on i386.
+	DefaultMaxCollectionBytes = int(uint32(4*1024*1024*1024 - 1))
+	DefaultPruneInterval      = 5 * time.Minute
+)
 
 // NewLogPruneParams returns a LogPruneParams initialised with default
 // values.


### PR DESCRIPTION
Separate defaults for log collection limit - 2GB for i386, 4GB for other arches. Should fix bug http://pad.lv/1433116 on i386.

(Review request: http://reviews.vapour.ws/r/1188/)