### PR TITLE
Render correct bash scripts for init system discovery.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -202,7 +202,7 @@ checkInitSystem "$executable"
 
 # First fall back to following symlinks.
 if [[ -L $executable ]]; then
-    linked=$(readlink "$executable")
+    linked=$(readlink -f "$executable")
     if [[ $? ]]; then
         executable=$linked
 

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -193,7 +193,7 @@ function checkInitSystem() {
 
 # Find the executable.
 executable=$(cat /proc/1/cmdline | awk -F"\0" '{print $1}')
-if [[ ! $? ]]; then
+if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
@@ -203,7 +203,7 @@ checkInitSystem "$executable"
 # First fall back to following symlinks.
 if [[ -L $executable ]]; then
     linked=$(readlink -f "$executable")
-    if [[ $? ]]; then
+    if [[ $? -eq 0 ]]; then
         executable=$linked
 
         # Check the linked executable.
@@ -213,7 +213,7 @@ fi
 
 # Fall back to checking the "version" text.
 verText=$("${executable}" --version)
-if [[ $? ]]; then
+if [[ $? -eq 0 ]]; then
     checkInitSystem "$verText"
 fi
 

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -232,7 +232,7 @@ EOF`[1:], filename, DiscoverInitSystemScript),
 	}
 }
 
-const caseLine = "%sif [[ $%s == %q ]]; then %s\n"
+const caseLine = "%sif [[ $%s == \"%s\" ]]; then %s\n"
 
 // newShellSelectCommand creates a bash if statement with an if
 // (or elif) clause for each of the executables in linuxExecutables.

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -202,7 +202,7 @@ checkInitSystem "$executable"
 
 # First fall back to following symlinks.
 if [[ -L $executable ]]; then
-    linked=$(readlink "$(executable)")
+    linked=$(readlink "$executable")
     if [[ $? ]]; then
         executable=$linked
 

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -182,10 +182,10 @@ func identifyExecutable(executable string) (string, bool) {
 const DiscoverInitSystemScript = `#!/usr/bin/env bash
 
 function checkInitSystem() {
-    if [[ $@ == *"systemd"* ]]; then
+    if [[ $1 == *"systemd"* ]]; then
         echo -n systemd
         exit $?
-    elif [[ $@ == *"upstart"* ]]; then
+    elif [[ $1 == *"upstart"* ]]; then
         echo -n upstart
         exit $?
     fi
@@ -198,7 +198,7 @@ if [[ ! $? ]]; then
 fi
 
 # Check the executable.
-checkInitSystem $executable
+checkInitSystem "$executable"
 
 # First fall back to following symlinks.
 if [[ -L $executable ]]; then
@@ -207,14 +207,14 @@ if [[ -L $executable ]]; then
         executable=$linked
 
         # Check the linked executable.
-        checkInitSystem $linked
+        checkInitSystem "$linked"
     fi
 fi
 
 # Fall back to checking the "version" text.
 verText=$("${executable}" --version)
 if [[ $? ]]; then
-    checkInitSystem $verText
+    checkInitSystem "$verText"
 fi
 
 # uh-oh

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -232,25 +232,25 @@ EOF`[1:], filename, DiscoverInitSystemScript),
 	}
 }
 
-const caseLine = "%sif [[ $init_system == %q ]]; then %s\n"
+const caseLine = "%sif [[ $%s == %q ]]; then %s\n"
 
 // newShellSelectCommand creates a bash if statement with an if
 // (or elif) clause for each of the executables in linuxExecutables.
 // The body of each clause comes from calling the provided handler with
 // the init system name. If the handler does not support the args then
 // it returns a false "ok" value.
-func newShellSelectCommand(discoverScript string, handler func(string) (string, bool)) string {
+func newShellSelectCommand(envVarName string, handler func(string) (string, bool)) string {
 	// TODO(ericsnow) Build the command in a better way?
 	// TODO(ericsnow) Use a case statement?
 
-	prefix := "init_system=$(" + discoverScript + ") "
+	prefix := ""
 	lines := ""
 	for _, initSystem := range linuxInitSystems {
 		cmd, ok := handler(initSystem)
 		if !ok {
 			continue
 		}
-		lines += fmt.Sprintf(caseLine, prefix, initSystem, cmd)
+		lines += fmt.Sprintf(caseLine, prefix, envVarName, initSystem, cmd)
 
 		if prefix != "el" {
 			prefix = "el"

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -5,10 +5,13 @@ package service_test
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/exec"
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
@@ -306,4 +309,25 @@ func (s *discoverySuite) TestVersionInitSystemNoLegacyUpstart(c *gc.C) {
 	initSystem, ok := service.VersionInitSystem(vers)
 
 	test.checkInitSystem(c, initSystem, ok)
+}
+
+func (s *discoverySuite) TestDiscoverInitSystemScript(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("not supported on windows")
+	}
+
+	filename := filepath.Join(c.MkDir(), "discover_init_system.sh")
+	commands := service.WriteDiscoverInitSystemScript(filename)
+	script := strings.Join(commands, "\n")
+	script += "\n" + filename
+	response, err := exec.RunCommands(exec.RunParams{
+		Commands: script,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	initSystem, err := service.DiscoverInitSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(response.Code, gc.Equals, 0)
+	c.Check(string(response.Stdout), gc.Equals, initSystem)
+	c.Check(string(response.Stderr), gc.Equals, "")
 }

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -344,9 +344,11 @@ func (s *discoverySuite) TestNewShellSelectCommand(c *gc.C) {
 
 	script, filename := s.newDiscoverInitSystemScript(c)
 	handler := func(initSystem string) (string, bool) {
-		return "echo " + initSystem, true
+		return "echo -n " + initSystem, true
 	}
-	script += service.NewShellSelectCommand(filename, handler)
+	script += "init_system=$(" + filename + ")\n"
+	script += service.NewShellSelectCommand("init_system", handler)
+	c.Logf(script)
 	response, err := exec.RunCommands(exec.RunParams{
 		Commands: script,
 	})

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -1,0 +1,9 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+var (
+	DiscoverInitSystem            = discoverInitSystem
+	WriteDiscoverInitSystemScript = writeDiscoverInitSystemScript
+)

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -5,5 +5,6 @@ package service
 
 var (
 	DiscoverInitSystem            = discoverInitSystem
+	NewShellSelectCommand         = newShellSelectCommand
 	WriteDiscoverInitSystemScript = writeDiscoverInitSystemScript
 )

--- a/service/service.go
+++ b/service/service.go
@@ -154,7 +154,8 @@ func ListServices() ([]string, error) {
 func ListServicesScript() string {
 	const filename = "/tmp/discover_init_system.sh"
 	commands := writeDiscoverInitSystemScript(filename)
-	commands = append(commands, newShellSelectCommand(filename, listServicesCommand))
+	commands = append(commands, "init_system=$("+filename+")")
+	commands = append(commands, newShellSelectCommand("init_system", listServicesCommand))
 	return strings.Join(commands, "\n")
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -74,9 +74,9 @@ func (*serviceSuite) TestListServicesScript(c *gc.C) {
 	expected = append(expected, strings.Split(service.DiscoverInitSystemScript, "\n")...)
 	expected = append(expected, "EOF")
 	expected = append(expected, "chmod 0755 /tmp/discover_init_system.sh")
+	expected = append(expected, "init_system=$(/tmp/discover_init_system.sh)")
 	expected = append(expected, []string{
-		"init_system=$(/tmp/discover_init_system.sh) " +
-			`if [[ $init_system == "systemd" ]]; then ` +
+		`if [[ $init_system == "systemd" ]]; then ` +
 			`/bin/systemctl list-unit-files --no-legend --no-page -t service` +
 			` | grep -o -P '^\w[\S]*(?=\.service)'`,
 		`elif [[ $init_system == "upstart" ]]; then ` +


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1433254)

The bash scripts used for init system discovery had syntactic and semantic errors. This patch fixes those errors and adds tests to verify that the bash scripts execute properly.

(Review request: http://reviews.vapour.ws/r/1190/)