### PR TITLE
storage: distinguish dynamic/non-dynamic storage

### DIFF
--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -27,7 +27,8 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage/poolmanager"
-	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/storage/provider/dummy"
+	"github.com/juju/juju/storage/provider/registry"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -726,12 +727,12 @@ func (s *withoutStateServerSuite) TestDistributionGroupMachineAgentAuth(c *gc.C)
 }
 
 func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
+	registry.RegisterProvider("static", &dummy.StorageProvider{IsDynamic: false})
+	defer registry.RegisterProvider("static", nil)
+	registry.RegisterEnvironStorageProviders("dummy", "static")
+
 	pm := poolmanager.New(state.NewStateSettings(s.State))
-	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{"foo": "bar"})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.UpdateEnvironConfig(map[string]interface{}{
-		"storage-default-block-source": "loop-pool",
-	}, nil, nil)
+	_, err := pm.Create("static-pool", "static", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("cpu-cores=123 mem=8G networks=^net3,^net4")
@@ -742,19 +743,11 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 		Placement:         "valid",
 		RequestedNetworks: []string{"net1", "net2"},
 		Volumes: []state.MachineVolumeParams{
-			{Volume: state.VolumeParams{Size: 1000, Pool: "loop-pool"}},
-			{Volume: state.VolumeParams{Size: 2000, Pool: "loop-pool"}},
-			{Volume: state.VolumeParams{Size: 3000, Pool: "loop-pool"}},
+			{Volume: state.VolumeParams{Size: 1000, Pool: "static-pool"}},
+			{Volume: state.VolumeParams{Size: 2000, Pool: "static-pool"}},
 		},
 	}
 	placementMachine, err := s.State.AddOneMachine(template)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Provision volume 2 so that it is excluded from any ProvisioningInfo() results.
-	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
-	err = placementMachine.SetInstanceInfo("i-am", "fake_nonce", &hwChars, nil, nil, map[names.VolumeTag]state.VolumeInfo{
-		names.NewVolumeTag(placementMachine.Id() + "/2"): state.VolumeInfo{VolumeId: "123", Size: 1024},
-	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -781,26 +774,24 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Volumes: []params.VolumeParams{{
-					VolumeTag:  "volume-" + placementMachine.Id() + "-0",
+					VolumeTag:  "volume-0",
 					Size:       1000,
-					Provider:   "loop",
+					Provider:   "static",
 					Attributes: map[string]interface{}{"foo": "bar"},
 					Attachment: &params.VolumeAttachmentParams{
 						MachineTag: placementMachine.Tag().String(),
-						VolumeTag:  "volume-" + placementMachine.Id() + "-0",
-						InstanceId: "i-am",
-						Provider:   "loop",
+						VolumeTag:  "volume-0",
+						Provider:   "static",
 					},
 				}, {
-					VolumeTag:  "volume-" + placementMachine.Id() + "-1",
+					VolumeTag:  "volume-1",
 					Size:       2000,
-					Provider:   "loop",
+					Provider:   "static",
 					Attributes: map[string]interface{}{"foo": "bar"},
 					Attachment: &params.VolumeAttachmentParams{
 						MachineTag: placementMachine.Tag().String(),
-						VolumeTag:  "volume-" + placementMachine.Id() + "-1",
-						InstanceId: "i-am",
-						Provider:   "loop",
+						VolumeTag:  "volume-1",
+						Provider:   "static",
 					},
 				}},
 			}},
@@ -819,14 +810,20 @@ func (s *withoutStateServerSuite) TestProvisioningInfo(c *gc.C) {
 }
 
 func (s *withoutStateServerSuite) TestStorageProviderFallbackToType(c *gc.C) {
+	registry.RegisterProvider("dynamic", &dummy.StorageProvider{IsDynamic: true})
+	defer registry.RegisterProvider("dynamic", nil)
+	registry.RegisterProvider("static", &dummy.StorageProvider{IsDynamic: false})
+	defer registry.RegisterProvider("static", nil)
+	registry.RegisterEnvironStorageProviders("dummy", "dynamic", "static")
+
 	template := state.MachineTemplate{
 		Series:            "quantal",
 		Jobs:              []state.MachineJob{state.JobHostUnits},
 		Placement:         "valid",
 		RequestedNetworks: []string{"net1", "net2"},
 		Volumes: []state.MachineVolumeParams{
-			// No pool called "loop" exists but there is a "loop" provider type.
-			{Volume: state.VolumeParams{Size: 1000, Pool: "loop"}},
+			{Volume: state.VolumeParams{Size: 1000, Pool: "dynamic"}},
+			{Volume: state.VolumeParams{Size: 1000, Pool: "static"}},
 		},
 	}
 	placementMachine, err := s.State.AddOneMachine(template)
@@ -847,14 +844,14 @@ func (s *withoutStateServerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Volumes: []params.VolumeParams{{
-					VolumeTag:  "volume-" + placementMachine.Id() + "-0",
+					VolumeTag:  "volume-1",
 					Size:       1000,
-					Provider:   "loop",
+					Provider:   "static",
 					Attributes: nil,
 					Attachment: &params.VolumeAttachmentParams{
 						MachineTag: placementMachine.Tag().String(),
-						VolumeTag:  "volume-" + placementMachine.Id() + "-0",
-						Provider:   "loop",
+						VolumeTag:  "volume-1",
+						Provider:   "static",
 					},
 				}},
 			}},
@@ -881,7 +878,7 @@ func (s *withoutStateServerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 
 	// Only machine 0 and containers therein can be accessed.
 	results, err := aProvisioner.ProvisioningInfo(args)
-	c.Assert(results, gc.DeepEquals, params.ProvisioningInfoResults{
+	c.Assert(results, jc.DeepEquals, params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
 				Series:   "quantal",
@@ -1014,11 +1011,15 @@ func (s *withoutStateServerSuite) TestSetProvisioned(c *gc.C) {
 }
 
 func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
+	registry.RegisterProvider("static", &dummy.StorageProvider{IsDynamic: false})
+	defer registry.RegisterProvider("static", nil)
+	registry.RegisterEnvironStorageProviders("dummy", "static")
+
 	pm := poolmanager.New(state.NewStateSettings(s.State))
-	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{"foo": "bar"})
+	_, err := pm.Create("static-pool", "static", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.UpdateEnvironConfig(map[string]interface{}{
-		"storage-default-block-source": "loop-pool",
+		"storage-default-block-source": "static-pool",
 	}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1112,12 +1113,12 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		InstanceId: "i-am-also",
 		Nonce:      "fake",
 		Volumes: []params.Volume{{
-			VolumeTag: "volume-" + volumesMachine.Id() + "-0",
+			VolumeTag: "volume-0",
 			VolumeId:  "vol-0",
 			Size:      1234,
 		}},
 		VolumeAttachments: []params.VolumeAttachment{{
-			VolumeTag:  "volume-" + volumesMachine.Id() + "-0",
+			VolumeTag:  "volume-0",
 			MachineTag: volumesMachine.Tag().String(),
 			DeviceName: "sda",
 		}},
@@ -1207,7 +1208,7 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfo, err := volume.Info()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volumeInfo, gc.Equals, state.VolumeInfo{VolumeId: "vol-0", Pool: "loop-pool", Size: 1234})
+	c.Assert(volumeInfo, gc.Equals, state.VolumeInfo{VolumeId: "vol-0", Pool: "static-pool", Size: 1234})
 
 	// Verify the machine without requested volumes still has no volume
 	// attachments recorded in state.

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -73,6 +73,14 @@ func (e *ebsProvider) Scope() storage.Scope {
 	return storage.ScopeEnviron
 }
 
+// Dynamic is defined on the Provider interface.
+func (e *ebsProvider) Dynamic() bool {
+	// TODO(axw) this should be changed to true when support for dynamic
+	// provisioning has been implemented for EBS. At that point, we need
+	// to remove the block device mapping code.
+	return false
+}
+
 func TranslateUserEBSOptions(userOptions map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 	for k, v := range userOptions {

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -500,11 +500,6 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	}
 
 	// Create volumes and volume attachments.
-	//
-	// TODO(axw) created volumes must record the attachment
-	// immediately, to prevent the storage provisioner from
-	// attempting to create the volume until after the machine
-	// has been provisioned.
 	for _, v := range template.Volumes {
 		op, tag, err := st.addVolumeOp(v.Volume, mdoc.Id)
 		if err != nil {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -52,6 +52,11 @@ type Provider interface {
 	// Scope returns the scope of storage managed by this provider.
 	Scope() Scope
 
+	// Dynamic reports whether or not the storage provider is capable
+	// of dynamic storage provisioning. Non-dynamic storage must be
+	// created at the time a machine is provisioned.
+	Dynamic() bool
+
 	// ValidateConfig validates the provided storage provider config,
 	// returning an error if it is invalid.
 	ValidateConfig(*Config) error

--- a/storage/provider/dummy/provider.go
+++ b/storage/provider/dummy/provider.go
@@ -9,12 +9,18 @@ import (
 	"github.com/juju/juju/storage"
 )
 
+var _ storage.Provider = (*StorageProvider)(nil)
+
 // StorageProvider is an implementation of storage.Provider, suitable for testing.
 // Each method's default behaviour may be overridden by setting the corresponding
 // Func field.
 type StorageProvider struct {
 	// StorageScope defines the scope of storage managed by this provider.
 	StorageScope storage.Scope
+
+	// IsDynamic defines whether or not the provider reports that it supports
+	// dynamic provisioning.
+	IsDynamic bool
 
 	// VolumeSourceFunc will be called by VolumeSource, if non-nil;
 	// otherwise VolumeSource will return a NotSupported error.
@@ -68,4 +74,9 @@ func (p *StorageProvider) Supports(kind storage.StorageKind) bool {
 // Scope is defined on storage.Provider.
 func (p *StorageProvider) Scope() storage.Scope {
 	return p.StorageScope
+}
+
+// Dynamic is defined on storage.Provider.
+func (p *StorageProvider) Dynamic() bool {
+	return p.IsDynamic
 }

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -85,6 +85,11 @@ func (*loopProvider) Scope() storage.Scope {
 	return storage.ScopeMachine
 }
 
+// Dynamic is defined on the Provider interface.
+func (*loopProvider) Dynamic() bool {
+	return true
+}
+
 // loopVolumeSource provides common functionality to handle
 // loop devices for rootfs and host loop volume sources.
 type loopVolumeSource struct {

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -79,6 +79,11 @@ func (*rootfsProvider) Scope() storage.Scope {
 	return storage.ScopeMachine
 }
 
+// Dynamic is defined on the Provider interface.
+func (*rootfsProvider) Dynamic() bool {
+	return true
+}
+
 type rootfsFilesystemSource struct {
 	dirFuncs   dirFuncs
 	run        runCommandFunc

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -77,6 +77,11 @@ func (*tmpfsProvider) Scope() storage.Scope {
 	return storage.ScopeMachine
 }
 
+// Dynamic is defined on the Provider interface.
+func (*tmpfsProvider) Dynamic() bool {
+	return true
+}
+
 type tmpfsFilesystemSource struct {
 	dirFuncs   dirFuncs
 	run        runCommandFunc


### PR DESCRIPTION
Storage providers can now indicate that they only support provisioning
storage at machine-provisioning time; i.e. they are non-dynamic. The
EC2/EBS storage provider is currently classified so, but only until dynamic
provisioning is implemented. When the MAAS and host-loop storage
provisioners are implemented, they will be non-dynamic.

The TODO in the state package has been removed, as this branch eliminates
the race condition. A follow-up will modify the storage provisioner so
that it ignores non-dynamic storage.

(Review request: http://reviews.vapour.ws/r/1193/)