### PR TITLE
Add login v2. Stop serving the environment at the root of the API.

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -144,7 +144,7 @@ func (s *apiclientSuite) TestOpen(c *gc.C) {
 
 	remoteVersion, versionSet := st.ServerVersion()
 	c.Assert(versionSet, jc.IsTrue)
-	c.Assert(removeVersion, gc.Equals, version.Cuurrent.Number)
+	c.Assert(remoteVersion, gc.Equals, version.Current.Number)
 }
 
 func (s *apiclientSuite) TestOpenPassesEnvironTag(c *gc.C) {

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type apiclientSuite struct {
@@ -140,6 +141,10 @@ func (s *apiclientSuite) TestOpen(c *gc.C) {
 	envTag, err := st.EnvironTag()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envTag, gc.Equals, s.State.EnvironTag())
+
+	remoteVersion, versionSet := st.ServerVersion()
+	c.Assert(versionSet, jc.IsTrue)
+	c.Assert(removeVersion, gc.Equals, version.Cuurrent.Number)
 }
 
 func (s *apiclientSuite) TestOpenPassesEnvironTag(c *gc.C) {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -361,8 +361,6 @@ func (s *clientSuite) TestParamsEncoded(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	connectURL := connectURLFromReader(c, reader)
-
-	c.Assert(connectURL.Path, gc.Matches, "/log")
 	values := connectURL.Query()
 	c.Assert(values, jc.DeepEquals, url.Values{
 		"includeEntity": params.IncludeEntity,
@@ -382,7 +380,7 @@ func (s *clientSuite) TestDebugLogRootPath(c *gc.C) {
 	// If the server is old, we log at "/log"
 	info := s.APIInfo(c)
 	info.EnvironTag = names.NewEnvironTag("")
-	apistate, err := api.Open(info, api.DialOpts{})
+	apistate, err := api.OpenWithVersion(info, api.DialOpts{}, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	defer apistate.Close()
 	reader, err := apistate.Client().WatchDebugLog(api.DebugLogParams{})
@@ -404,8 +402,7 @@ func (s *clientSuite) TestDebugLogAtUUIDLogPath(c *gc.C) {
 	reader, err := apistate.Client().WatchDebugLog(api.DebugLogParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	connectURL := connectURLFromReader(c, reader)
-	c.ExpectFailure("debug log always goes to /log for compatibility http://pad.lv/1326799")
-	c.Assert(connectURL.Path, gc.Matches, fmt.Sprintf("/%s/log", environ.UUID()))
+	c.Assert(connectURL.Path, gc.Matches, fmt.Sprintf("/environment/%s/log", environ.UUID()))
 }
 
 func (s *clientSuite) TestOpenUsesEnvironUUIDPaths(c *gc.C) {

--- a/api/state.go
+++ b/api/state.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/leadership"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/version"
 )
 
 // Login authenticates as the entity with the given name and password.
@@ -39,12 +40,38 @@ import (
 // method is usually called automatically by Open. The machine nonce
 // should be empty unless logging in as a machine agent.
 func (st *State) Login(tag, password, nonce string) error {
-	err := st.loginV1(tag, password, nonce)
+	err := st.loginV2(tag, password, nonce)
 	if params.IsCodeNotImplemented(err) {
-		// TODO (cmars): remove fallback once we can drop v0 compatibility
-		return st.loginV0(tag, password, nonce)
+		err = st.loginV1(tag, password, nonce)
+		if params.IsCodeNotImplemented(err) {
+			// TODO (cmars): remove fallback once we can drop v0 compatibility
+			return st.loginV0(tag, password, nonce)
+		}
 	}
 	return err
+}
+
+func (st *State) loginV2(tag, password, nonce string) error {
+	var result params.LoginResultV1
+	request := &params.LoginRequest{
+		AuthTag:     tag,
+		Credentials: password,
+		Nonce:       nonce,
+	}
+	err := st.APICall("Admin", 2, "", "Login", request, &result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	servers := params.NetworkHostsPorts(result.Servers)
+	err = st.setLoginResult(tag, result.EnvironTag, result.ServerTag, servers, result.Facades)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	st.serverVersion, err = version.Parse(result.ServerVersion)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 func (st *State) loginV1(tag, password, nonce string) error {
@@ -317,4 +344,12 @@ func (st *State) CharmRevisionUpdater() *charmrevisionupdater.State {
 // Rsyslog returns access to the Rsyslog API
 func (st *State) Rsyslog() *rsyslog.State {
 	return rsyslog.NewState(st)
+}
+
+// ServerVersion holds the version of the API server that we are connected to.
+// It is possible that this version is Zero if the server does not report this
+// during login. The second result argument indicates if the version number is
+// set.
+func (st *State) ServerVersion() (version.Number, bool) {
+	return st.serverVersion, st.serverVersion != version.Zero
 }

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -44,6 +44,11 @@ var _ = gc.Suite(&loginSuite{
 	},
 })
 
+func (s *baseLoginSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
+}
+
 type loginV0Suite struct {
 	loginSuite
 }
@@ -99,14 +104,8 @@ func (s *baseLoginSuite) setupServerForEnvironment(c *gc.C, envTag names.Environ
 }
 
 func (s *baseLoginSuite) setupMachineAndServer(c *gc.C) (*api.Info, func()) {
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", "fake_nonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetPassword(password)
-	c.Assert(err, jc.ErrorIsNil)
+	machine, password := s.Factory.MakeMachineReturningPassword(
+		c, &factory.MachineParams{Nonce: "fake_nonce"})
 	info, cleanup := s.setupServerWithValidator(c, nil)
 	info.Tag = machine.Tag()
 	info.Password = password
@@ -193,67 +192,31 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 }
 
 func (s *loginV0Suite) TestLoginSetsLogIdentifier(c *gc.C) {
-	s.runLoginSetsLogIdentifier(c, []string{
-		// RequestId starts at 2 here, because we've already attempted a v1 Login.
-		// This is the fallback to v0 Login.
-		`<- \[[0-9A-F]+\] <unknown> {"RequestId":2,"Type":"Admin","Request":"Login",` +
-			`"Params":"'params redacted'"` +
-			`}`,
-		// Now that we are logged in, we see the entity's tag
-		// [0-9.µumns] is to handle timestamps that are ns, µs, ms, or s
-		// long, though we expect it to be in the 'ms' range.
-		// Note: Go1.4 produces µs; Go1.3 produces us.
-		`-> \[[0-9A-F]+\] machine-0 [0-9.µumns]+ {"RequestId":2,"Response":.*} Admin\[""\].Login`,
-		`<- \[[0-9A-F]+\] machine-0 {"RequestId":3,"Type":"Machiner","Request":"Life","Params":"'params redacted'"}`,
-		`-> \[[0-9A-F]+\] machine-0 [0-9.µumns]+ {"RequestId":3,"Response":"'body redacted'"} Machiner\[""\]\.Life`,
-	})
+	s.runLoginSetsLogIdentifier(c)
 }
 
 func (s *loginV1Suite) TestLoginSetsLogIdentifier(c *gc.C) {
-	s.runLoginSetsLogIdentifier(c, []string{
-		`<- \[[0-9A-F]+\] <unknown> {"RequestId":1,"Type":"Admin","Version":1,"Request":"Login",` +
-			`"Params":"'params redacted'"` +
-			`}`,
-		// Now that we are logged in, we see the entity's tag
-		// [0-9.umns] is to handle timestamps that are ns, us, ms, or s
-		// long, though we expect it to be in the 'ms' range.
-		`-> \[[0-9A-F]+\] machine-0 [0-9.]+[µumn]?s {"RequestId":1,"Response":.*} Admin\[""\].Login`,
-		`<- \[[0-9A-F]+\] machine-0 {"RequestId":2,"Type":"Machiner","Request":"Life","Params":"'params redacted'"}`,
-		`-> \[[0-9A-F]+\] machine-0 [0-9.µumns]+ {"RequestId":2,"Response":"'body redacted'"} Machiner\[""\]\.Life`,
-	})
+	s.runLoginSetsLogIdentifier(c)
 }
 
-func (s *baseLoginSuite) runLoginSetsLogIdentifier(c *gc.C, expected []string) {
+func (s *baseLoginSuite) runLoginSetsLogIdentifier(c *gc.C) {
 	info, cleanup := s.setupServerWithValidator(c, nil)
 	defer cleanup()
 
-	machineInState, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	err = machineInState.SetProvisioned("foo", "fake_nonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
-	c.Assert(err, jc.ErrorIsNil)
-	err = machineInState.SetPassword(password)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineInState.Tag(), gc.Equals, names.NewMachineTag("0"))
+	machine, password := s.Factory.MakeMachineReturningPassword(
+		c, &factory.MachineParams{Nonce: "fake_nonce"})
 
-	var tw loggo.TestWriter
-	c.Assert(loggo.RegisterWriter("login-tester", &tw, loggo.DEBUG), gc.IsNil)
-	defer loggo.RemoveWriter("login-tester")
-
-	// TODO(dfc) this should be a Tag
-	info.Tag = machineInState.Tag()
+	info.Tag = machine.Tag()
 	info.Password = password
 	info.Nonce = "fake_nonce"
 
 	apiConn, err := api.Open(info, fastDialOpts)
 	c.Assert(err, jc.ErrorIsNil)
 	defer apiConn.Close()
-	apiMachine, err := apiConn.Machiner().Machine(machineInState.Tag().(names.MachineTag))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apiMachine.Tag(), gc.Equals, machineInState.Tag())
 
-	c.Assert(tw.Log(), jc.LogMatches, expected)
+	apiMachine, err := apiConn.Machiner().Machine(machine.MachineTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(apiMachine.Tag(), gc.Equals, machine.Tag())
 }
 
 func (s *loginSuite) TestLoginAddrs(c *gc.C) {

--- a/apiserver/adminv0.go
+++ b/apiserver/adminv0.go
@@ -1,0 +1,66 @@
+// Copyright 2013, 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// adminApiV0 implements the API that a client first sees when connecting to
+// the API. We start serving a different API once the user has logged in.
+type adminApiV0 struct {
+	admin *adminV0
+}
+
+type adminV0 struct {
+	*admin
+}
+
+func newAdminApiV0(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{} {
+	return &adminApiV0{
+		admin: &adminV0{
+			&admin{
+				srv:         srv,
+				root:        root,
+				reqNotifier: reqNotifier,
+			},
+		},
+	}
+}
+
+// Admin returns an object that provides API access to methods that can be
+// called even when not authenticated.
+func (r *adminApiV0) Admin(id string) (*adminV0, error) {
+	if id != "" {
+		// Safeguard id for possible future use.
+		return nil, common.ErrBadId
+	}
+	return r.admin, nil
+}
+
+// Login logs in with the provided credentials.  All subsequent requests on the
+// connection will act as the authenticated user.
+func (a *adminV0) Login(c params.Creds) (params.LoginResult, error) {
+	var fail params.LoginResult
+
+	resultV1, err := a.doLogin(params.LoginRequest{
+		AuthTag:     c.AuthTag,
+		Credentials: c.Password,
+		Nonce:       c.Nonce,
+	}, 0)
+	if err != nil {
+		return fail, err
+	}
+
+	resultV0 := params.LoginResult{
+		Servers:    resultV1.Servers,
+		EnvironTag: resultV1.EnvironTag,
+		Facades:    resultV1.Facades,
+	}
+	if resultV1.UserInfo != nil {
+		resultV0.LastConnection = resultV1.UserInfo.LastConnection
+	}
+	return resultV0, nil
+}

--- a/apiserver/adminv1.go
+++ b/apiserver/adminv1.go
@@ -1,3 +1,6 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package apiserver
 
 import (
@@ -40,5 +43,5 @@ func (r *adminApiV1) Admin(id string) (*adminV1, error) {
 // Login logs in with the provided credentials.  All subsequent requests on the
 // connection will act as the authenticated user.
 func (a *adminV1) Login(req params.LoginRequest) (params.LoginResultV1, error) {
-	return a.doLogin(req)
+	return a.doLogin(req, 1)
 }

--- a/apiserver/adminv2.go
+++ b/apiserver/adminv2.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type adminApiV2 struct {
+	*admin
+}
+
+func newAdminApiV2(srv *Server, root *apiHandler, reqNotifier *requestNotifier) interface{} {
+	return &adminApiV2{
+		&admin{
+			srv:         srv,
+			root:        root,
+			reqNotifier: reqNotifier,
+		},
+	}
+}
+
+// Admin returns an object that provides API access to methods that can be
+// called even when not authenticated.
+func (r *adminApiV2) Admin(id string) (*adminApiV2, error) {
+	if id != "" {
+		// Safeguard id for possible future use.
+		return nil, common.ErrBadId
+	}
+	return r, nil
+}
+
+// Login logs in with the provided credentials.  All subsequent requests on the
+// connection will act as the authenticated user.
+func (a *adminApiV2) Login(req params.LoginRequest) (params.LoginResultV1, error) {
+	return a.doLogin(req, 2)
+}

--- a/apiserver/adminv2_test.go
+++ b/apiserver/adminv2_test.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"github.com/juju/juju/api"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+)
+
+type loginV2Suite struct {
+	loginSuite
+}
+
+var _ = gc.Suite(&loginV2Suite{
+	loginSuite{
+		baseLoginSuite{
+			setAdminApi: func(srv *apiserver.Server) {
+				apiserver.SetAdminApiVersions(srv, 0, 1, 2)
+			},
+		},
+	},
+})
+
+func (s *loginV2Suite) TestClientLoginToEnvironment(c *gc.C) {
+	_, cleanup := s.setupServerWithValidator(c, nil)
+	defer cleanup()
+
+	info := s.APIInfo(c)
+	apiState, err := api.Open(info, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer apiState.Close()
+
+	client := apiState.Client()
+	_, err = client.GetEnvironmentConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *loginV2Suite) TestClientLoginToServer(c *gc.C) {
+	_, cleanup := s.setupServerWithValidator(c, nil)
+	defer cleanup()
+
+	info := s.APIInfo(c)
+	info.EnvironTag = names.EnvironTag{}
+	apiState, err := api.Open(info, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer apiState.Close()
+
+	client := apiState.Client()
+	_, err = client.GetEnvironmentConstraints()
+	c.Assert(err, gc.ErrorMatches, `logged in to server, no environment, "Client" not supported`)
+}
+
+func (s *loginV2Suite) TestClientLoginToRootOldClient(c *gc.C) {
+	_, cleanup := s.setupServerWithValidator(c, nil)
+	defer cleanup()
+
+	info := s.APIInfo(c)
+	info.EnvironTag = names.EnvironTag{}
+	apiState, err := api.OpenWithVersion(info, api.DialOpts{}, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	defer apiState.Close()
+
+	client := apiState.Client()
+	_, err = client.GetEnvironmentConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -76,7 +76,7 @@ func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 		state: srvSt,
 		tag:   names.NewMachineTag("0"),
 	}
-	h, err := newApiHandler(srv, st, nil, nil)
+	h, err := newApiHandler(srv, st, nil, nil, st.EnvironUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	return h, h.getResources()
 }
@@ -86,6 +86,13 @@ func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Re
 func TestingUpgradingRoot(st *state.State) rpc.MethodFinder {
 	r := TestingApiRoot(st)
 	return newUpgradingRoot(r)
+}
+
+// TestingRestrictedApiHandler returns a restricted srvRoot as if accessed
+// from the root of the API path with a recent (verison > 1) login.
+func TestingRestrictedApiHandler(st *state.State) rpc.MethodFinder {
+	r := TestingApiRoot(st)
+	return newRestrictedRoot(r)
 }
 
 type preFacadeAdminApi struct{}
@@ -139,6 +146,8 @@ func SetAdminApiVersions(srv *Server, versions ...int) {
 			factories[n] = newAdminApiV0
 		case 1:
 			factories[n] = newAdminApiV1
+		case 2:
+			factories[n] = newAdminApiV2
 		default:
 			panic(fmt.Errorf("unknown admin API version %d", n))
 		}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -611,6 +611,10 @@ type LoginResultV1 struct {
 	// Facades describes all the available API facade versions to the
 	// authenticated client.
 	Facades []FacadeVersions `json:"facades"`
+
+	// ServerVersion is the string representation of the server version
+	// if the server supports it.
+	ServerVersion string `json:"server-version,omitempty"`
 }
 
 // StateServersSpec contains arguments for

--- a/apiserver/restricted_root.go
+++ b/apiserver/restricted_root.go
@@ -1,0 +1,38 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/rpcreflect"
+)
+
+// restrictedRoot restricts API calls to the environment manager and
+// user manager when accessed through the root path on the API server.
+type restrictedRoot struct {
+	rpc.MethodFinder
+}
+
+// newRestrictedRoot returns a new restrictedRoot.
+func newRestrictedRoot(finder rpc.MethodFinder) *restrictedRoot {
+	return &restrictedRoot{finder}
+}
+
+var restrictedRootNames = set.NewStrings(
+	"EnvironmentManager",
+	"UserManager",
+)
+
+// FindMethod returns a not supported error if the rootName is not one
+// of the facades available at the server root when there is no active
+// environment.
+func (r *restrictedRoot) FindMethod(rootName string, version int, methodName string) (rpcreflect.MethodCaller, error) {
+	if !restrictedRootNames.Contains(rootName) {
+		return nil, errors.NotSupportedf("logged in to server, no environment, %q", rootName)
+	}
+	return r.MethodFinder.FindMethod(rootName, version, methodName)
+}

--- a/apiserver/restricted_root_test.go
+++ b/apiserver/restricted_root_test.go
@@ -1,0 +1,66 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/testing"
+)
+
+type restrictedRootSuite struct {
+	testing.BaseSuite
+
+	root rpc.MethodFinder
+}
+
+var _ = gc.Suite(&restrictedRootSuite{})
+
+func (r *restrictedRootSuite) SetUpTest(c *gc.C) {
+	r.BaseSuite.SetUpTest(c)
+	r.SetFeatureFlags(feature.JES)
+	r.root = apiserver.TestingRestrictedApiHandler(nil)
+}
+
+func (r *restrictedRootSuite) assertMethodAllowed(c *gc.C, rootName string, version int, method string) {
+	caller, err := r.root.FindMethod(rootName, version, method)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(caller, gc.NotNil)
+}
+
+func (r *restrictedRootSuite) TestFindAllowedMethod(c *gc.C) {
+	r.assertMethodAllowed(c, "EnvironmentManager", 1, "CreateEnvironment")
+	r.assertMethodAllowed(c, "EnvironmentManager", 1, "ListEnvironments")
+
+	r.assertMethodAllowed(c, "UserManager", 0, "AddUser")
+	r.assertMethodAllowed(c, "UserManager", 0, "SetPassword")
+	r.assertMethodAllowed(c, "UserManager", 0, "UserInfo")
+}
+
+func (r *restrictedRootSuite) TestFindDisallowedMethod(c *gc.C) {
+	caller, err := r.root.FindMethod("Client", 0, "Status")
+
+	c.Assert(err, gc.ErrorMatches, `logged in to server, no environment, "Client" not supported`)
+	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictedRootSuite) TestFindNonExistentMethod(c *gc.C) {
+	caller, err := r.root.FindMethod("EnvironmentManager", 1, "Bar")
+
+	c.Assert(err, gc.ErrorMatches, `no such request - method EnvironmentManager\(1\).Bar is not implemented`)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictedRootSuite) TestFindMethodNonExistentVersion(c *gc.C) {
+	caller, err := r.root.FindMethod("UserManager", 99999999, "AddUser")
+
+	c.Assert(err, gc.ErrorMatches, `unknown version \(99999999\) of interface "UserManager"`)
+	c.Assert(caller, gc.IsNil)
+}

--- a/apiserver/restricted_root_test.go
+++ b/apiserver/restricted_root_test.go
@@ -51,6 +51,13 @@ func (r *restrictedRootSuite) TestFindDisallowedMethod(c *gc.C) {
 	c.Assert(caller, gc.IsNil)
 }
 
+func (r *restrictedRootSuite) TestNonExistentFacade(c *gc.C) {
+	caller, err := r.root.FindMethod("NonExistent", 0, "Method")
+
+	c.Assert(err, gc.ErrorMatches, `unknown object type "NonExistent"`)
+	c.Assert(caller, gc.IsNil)
+}
+
 func (r *restrictedRootSuite) TestFindNonExistentMethod(c *gc.C) {
 	caller, err := r.root.FindMethod("EnvironmentManager", 1, "Bar")
 

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -47,17 +47,23 @@ type apiHandler struct {
 	rpcConn    *rpc.Conn
 	resources  *common.Resources
 	entity     state.Entity
+	// An empty envUUID means that the user has logged in through the
+	// root of the API server rather than the /environment/:env-uuid/api
+	// path, logins processed with v2 or later will only offer the
+	// user manager and environment manager api endpoints from here.
+	envUUID string
 }
 
 var _ = (*apiHandler)(nil)
 
 // newApiHandler returns a new apiHandler.
-func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier) (*apiHandler, error) {
+func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, envUUID string) (*apiHandler, error) {
 	r := &apiHandler{
 		state:      st,
 		closeState: st.EnvironUUID() != srv.state.EnvironUUID(),
 		resources:  common.NewResources(),
 		rpcConn:    rpcConn,
+		envUUID:    envUUID,
 	}
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -30,6 +29,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/presence"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 func TestAll(t *stdtesting.T) {
@@ -57,34 +57,29 @@ func (s *serverSuite) TestStop(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer srv.Stop()
 
-	stm, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	err = stm.SetProvisioned("foo", "fake_nonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
-	c.Assert(err, jc.ErrorIsNil)
-	err = stm.SetPassword(password)
-	c.Assert(err, jc.ErrorIsNil)
+	machine, password := s.Factory.MakeMachineReturningPassword(
+		c, &factory.MachineParams{Nonce: "fake_nonce"})
 
 	// Note we can't use openAs because we're not connecting to
 	apiInfo := &api.Info{
-		Tag:      stm.Tag(),
-		Password: password,
-		Nonce:    "fake_nonce",
-		Addrs:    []string{srv.Addr()},
-		CACert:   coretesting.CACert,
+		Tag:        machine.Tag(),
+		Password:   password,
+		Nonce:      "fake_nonce",
+		Addrs:      []string{srv.Addr()},
+		CACert:     coretesting.CACert,
+		EnvironTag: s.State.EnvironTag(),
 	}
 	st, err := api.Open(apiInfo, fastDialOpts)
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
-	_, err = st.Machiner().Machine(stm.Tag().(names.MachineTag))
+	_, err = st.Machiner().Machine(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = srv.Stop()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = st.Machiner().Machine(stm.Tag().(names.MachineTag))
+	_, err = st.Machiner().Machine(machine.MachineTag())
 	// The client has not necessarily seen the server shutdown yet,
 	// so there are two possible errors.
 	if err != rpc.ErrShutdown && err != io.ErrUnexpectedEOF {
@@ -124,22 +119,17 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 	port, err := strconv.Atoi(portString)
 	c.Assert(err, jc.ErrorIsNil)
 
-	stm, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	err = stm.SetProvisioned("foo", "fake_nonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
-	c.Assert(err, jc.ErrorIsNil)
-	err = stm.SetPassword(password)
-	c.Assert(err, jc.ErrorIsNil)
+	machine, password := s.Factory.MakeMachineReturningPassword(
+		c, &factory.MachineParams{Nonce: "fake_nonce"})
 
 	// Now connect twice - using IPv4 and IPv6 endpoints.
 	apiInfo := &api.Info{
-		Tag:      stm.Tag(),
-		Password: password,
-		Nonce:    "fake_nonce",
-		Addrs:    []string{net.JoinHostPort("127.0.0.1", portString)},
-		CACert:   coretesting.CACert,
+		Tag:        machine.Tag(),
+		Password:   password,
+		Nonce:      "fake_nonce",
+		Addrs:      []string{net.JoinHostPort("127.0.0.1", portString)},
+		CACert:     coretesting.CACert,
+		EnvironTag: s.State.EnvironTag(),
 	}
 	ipv4State, err := api.Open(apiInfo, fastDialOpts)
 	c.Assert(err, jc.ErrorIsNil)
@@ -149,7 +139,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 		{{network.NewAddress("127.0.0.1", network.ScopeMachineLocal), port}},
 	})
 
-	_, err = ipv4State.Machiner().Machine(stm.Tag().(names.MachineTag))
+	_, err = ipv4State.Machiner().Machine(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiInfo.Addrs = []string{net.JoinHostPort("::1", portString)}
@@ -161,7 +151,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 		{{network.NewAddress("::1", network.ScopeMachineLocal), port}},
 	})
 
-	_, err = ipv6State.Machiner().Machine(stm.Tag().(names.MachineTag))
+	_, err = ipv6State.Machiner().Machine(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -171,19 +161,14 @@ func (s *serverSuite) TestOpenAsMachineErrors(c *gc.C) {
 		c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
 		c.Assert(err, gc.ErrorMatches, `machine \d+ not provisioned`)
 	}
-	stm, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	err = stm.SetProvisioned("foo", "fake_nonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
-	c.Assert(err, jc.ErrorIsNil)
-	err = stm.SetPassword(password)
-	c.Assert(err, jc.ErrorIsNil)
+
+	machine, password := s.Factory.MakeMachineReturningPassword(
+		c, &factory.MachineParams{Nonce: "fake_nonce"})
 
 	// This does almost exactly the same as OpenAPIAsMachine but checks
 	// for failures instead.
 	info := s.APIInfo(c)
-	info.Tag = stm.Tag()
+	info.Tag = machine.Tag()
 	info.Password = password
 	info.Nonce = "invalid-nonce"
 	st, err := api.Open(info, fastDialOpts)
@@ -221,14 +206,8 @@ func (s *serverSuite) TestMachineLoginStartsPinger(c *gc.C) {
 	// This is the same steps as OpenAPIAsNewMachine but we need to assert
 	// the agent is not alive before we actually open the API.
 	// Create a new machine to verify "agent alive" behavior.
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned("foo", "fake_nonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetPassword(password)
-	c.Assert(err, jc.ErrorIsNil)
+	machine, password := s.Factory.MakeMachineReturningPassword(
+		c, &factory.MachineParams{Nonce: "fake_nonce"})
 
 	// Not alive yet.
 	s.assertAlive(c, machine, false)
@@ -252,13 +231,7 @@ func (s *serverSuite) TestMachineLoginStartsPinger(c *gc.C) {
 
 func (s *serverSuite) TestUnitLoginStartsPinger(c *gc.C) {
 	// Create a new service and unit to verify "agent alive" behavior.
-	service := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	unit, err := service.AddUnit()
-	c.Assert(err, jc.ErrorIsNil)
-	password, err := utils.RandomPassword()
-	c.Assert(err, jc.ErrorIsNil)
-	err = unit.SetPassword(password)
-	c.Assert(err, jc.ErrorIsNil)
+	unit, password := s.Factory.MakeUnitReturningPassword(c, nil)
 
 	// Not alive yet.
 	s.assertAlive(c, unit, false)

--- a/doc/logging-in-to-the-apiserver.txt
+++ b/doc/logging-in-to-the-apiserver.txt
@@ -1,0 +1,92 @@
+Logging in to the API Server
+============================
+
+This document is being written because every time I need to look at how
+logging in to the API server works, I have to step through all the code and
+remind myself. Once I have done that, everything seems obvious and not worth
+writing down... until next time I need to think about the login process.
+
+Intended work is to add the ability to have a user log in to the root of the
+API server in order to get access to the environment manager and user manager
+facades. This allows the user to change their password, create environments
+and list the environments that they are able to connect to.
+
+The intended way that this is going to work is that the API client code will
+attempt to login to the server using a versioned login command. There is
+already a login-v1 that introduced new return values and a reauth request
+field. We will build on that behaviour to add a login-v2. If and only if the
+version 2 login is used the facades that are available at the apiserver will
+be restricted.  Logging in using version 1 or the original will continue to
+act as if you are logging into the state server environment - the original one
+and only environment that would exist before the Juju Environment Server work.
+
+This work then needs to look at the API connection workflow from both ends,
+the API client side, and the server side.
+
+apiserver.Server
+----------------
+
+apiserver.go
+
+Server struct has a map of adminApiFactories. This currently has keys of
+0 and 1.  We will need to add a 2 here.
+
+The Server instance is created with NewServer, and listens on the API port.
+
+The incoming socket connection is handled inside the (*Server).run method.
+ - "/environment/:envuuid/api" -> srv.apiHandler
+ - "/" -> srv.apiHandler
+
+The apiHandler creates a go routine for handling the socket connection, and
+extracts the envuuid from the path, and calls the (*Server).serveConn method.
+
+serveConn validates the environment UUID and gets an appropiate *state.State
+for the environment specified.  An empty environment UUID is treated as the
+state server environment here.  One thing that will need to change is passing
+through whether or not we were given an environment UUID, as this is the last
+place that cares, but we will need to know later when the appropriate login
+method is called. The various admin API instances are created here and passed
+through to the newAnonRoot object.  This is passed in as the method finder for
+the websocket connection.
+
+root.go
+
+newAnonRoot only responds to calls on the "Admin" rootName.  The version of
+the FindMethod is used to determine whether the version 0 or 1 login API is
+used.
+
+The Login methods on the adminV0 and adminV1 instances call into the doLogin
+method.  It is here where we want to wrap the authedApi with something that
+limits the rootName objects that can be called.  In order to do this, we need
+to pass the envUUID from the path (remember this is either a valid uuid or the
+empty string), and the version of the login command used.
+
+In order to get the envuuid from the path into the Login method, we need to
+capture it in *Server.serveConn, where it is passed in as an argument.  We
+should pass it through to the newApiHandler function and store it on the
+apiHandler struct.  This handler is passed through as an arg to the
+newAnonRoot, and to the factory methods for the admin APIs.
+
+
+Implementation Notes:
+
+The login process for both v0 and v1 logins are handled in the method *admin.doLogin (in admin.go).  The method *Conn.ServeFinder on the *rpc.Conn attribute of the apiHandler is initially given the anonymous root here:
+
+```go
+func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifier, envUUID string) error {
+	// ...
+		conn.ServeFinder(newAnonRoot(h, adminApis), serverError)
+	// ...
+```
+
+If login is successful, the doLogin method changes out the method finder that is used for the RPC connection just before the end of the return statement at the end of the method.
+
+```go
+	// a *admin
+	//
+	// root is `*apiHander` from the admin struct.
+	a.root.rpcConn.ServeFinder(authedApi, serverError)
+```
+
+In order to supply a restricted api at the root, the doLogin method will need to take a version number.  Just before we replace the method finder for the RPC connection, we check the version number and the envUUID of the api handler, and wrap the authedApi in a restricted root method finder implemented in a similar manner to the upgradingRoot method finder.
+

--- a/doc/logging-in-to-the-apiserver.txt
+++ b/doc/logging-in-to-the-apiserver.txt
@@ -70,7 +70,9 @@ newAnonRoot, and to the factory methods for the admin APIs.
 
 Implementation Notes:
 
-The login process for both v0 and v1 logins are handled in the method *admin.doLogin (in admin.go).  The method *Conn.ServeFinder on the *rpc.Conn attribute of the apiHandler is initially given the anonymous root here:
+The login process for both v0 and v1 logins are handled in the method
+*admin.doLogin (in admin.go).  The method *Conn.ServeFinder on the *rpc.Conn
+attribute of the apiHandler is initially given the anonymous root here:
 
 ```go
 func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifier, envUUID string) error {
@@ -79,7 +81,9 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifie
 	// ...
 ```
 
-If login is successful, the doLogin method changes out the method finder that is used for the RPC connection just before the end of the return statement at the end of the method.
+If login is successful, the doLogin method changes out the method finder that
+is used for the RPC connection just before the end of the return statement at
+the end of the method.
 
 ```go
 	// a *admin
@@ -88,5 +92,9 @@ If login is successful, the doLogin method changes out the method finder that is
 	a.root.rpcConn.ServeFinder(authedApi, serverError)
 ```
 
-In order to supply a restricted api at the root, the doLogin method will need to take a version number.  Just before we replace the method finder for the RPC connection, we check the version number and the envUUID of the api handler, and wrap the authedApi in a restricted root method finder implemented in a similar manner to the upgradingRoot method finder.
+In order to supply a restricted api at the root, the doLogin method will need
+to take a version number.  Just before we replace the method finder for the
+RPC connection, we check the version number and the envUUID of the api
+handler, and wrap the authedApi in a restricted root method finder implemented
+in a similar manner to the upgradingRoot method finder.
 


### PR DESCRIPTION
This change set has a bunch of mostly related changes.

I added a ServerVersion to the login response. This is set for the version two login.

The creation of some machines and units in tests were simplified to use the factory.

The api package gains a new exported method: OpenWithVersion that allows specifying the version of the Login to use. This is only used in tests and allows the client to pretend to be older.

