### PR TITLE
Follow symlinks when discovering init system from PID 1.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -44,9 +44,7 @@ func discoverInitSystem() (string, error) {
 		versionInitName, ok := VersionInitSystem(jujuVersion)
 		if !ok {
 			// The key error is the one from discoverLocalInitSystem so
-			// that is what we return. However, we at least log the
-			// failed fallback attempt.
-			logger.Errorf("could not identify init system from %v", jujuVersion)
+			// that is what we return.
 			return "", errors.Trace(err)
 		}
 		initName = versionInitName
@@ -60,6 +58,16 @@ func discoverInitSystem() (string, error) {
 // version info. If one cannot be identified then false if returned
 // for the second return value.
 func VersionInitSystem(vers version.Binary) (string, bool) {
+	initName, ok := versionInitSystem(vers)
+	if !ok {
+		logger.Errorf("could not identify init system from juju version info (%#v)", vers)
+		return "", false
+	}
+	logger.Debugf("discovered init system %q from juju version info (%#v)", initName, vers)
+	return initName, true
+}
+
+func versionInitSystem(vers version.Binary) (string, bool) {
 	switch vers.OS {
 	case version.Windows:
 		return InitSystemWindows, true

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -150,6 +150,9 @@ func identifyInitSystem(executable string, followLink bool) (string, bool) {
 		return "", false
 	} else if err != nil {
 		logger.Errorf("failed to find %q: %v", executable, err)
+		if followLink {
+			return "", false
+		}
 		// The stat check is just an optimization so we go on anyway.
 	}
 

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -145,11 +145,12 @@ func identifyInitSystem(executable string) (string, bool) {
 	}
 
 	// First fall back to following symlinks (if any).
-	executable, err := evalSymlinks(executable)
+	resolved, err := evalSymlinks(executable)
 	if err != nil {
 		logger.Errorf("failed to find %q: %v", executable, err)
 		return "", false
 	}
+	executable = resolved
 	initSystem, ok = identifyExecutable(executable)
 	if ok {
 		return initSystem, true

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -145,7 +145,7 @@ func identifyInitSystem(executable string, followLink bool) (string, bool) {
 		return initSystem, true
 	}
 
-	finfo, err := osLstat(executable)
+	fInfo, err := osLstat(executable)
 	if os.IsNotExist(err) {
 		return "", false
 	} else if err != nil {
@@ -154,7 +154,7 @@ func identifyInitSystem(executable string, followLink bool) (string, bool) {
 	}
 
 	// First fall back to following symlinks.
-	if followLink && (finfo.Mode()&os.ModeSymlink) != 0 {
+	if followLink && (fInfo.Mode()&os.ModeSymlink) != 0 {
 		linked, err := osReadlink(executable)
 		if err != nil {
 			logger.Errorf("could not follow link %q (%v)", executable, err)

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -103,7 +103,7 @@ const pid1 = "/proc/1/cmdline"
 var (
 	runtimeOS    = func() string { return runtime.GOOS }
 	pid1Filename = func() string { return pid1 }
-	osStat       = os.Stat
+	osLstat      = os.Lstat
 	osReadlink   = os.Readlink
 
 	initExecutable = func() (string, error) {
@@ -145,7 +145,7 @@ func identifyInitSystem(executable string, followLink bool) (string, bool) {
 		return initSystem, true
 	}
 
-	finfo, err := osStat(executable)
+	finfo, err := osLstat(executable)
 	if os.IsNotExist(err) {
 		return "", false
 	} else if err != nil {

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -103,6 +103,8 @@ const pid1 = "/proc/1/cmdline"
 var (
 	runtimeOS    = func() string { return runtime.GOOS }
 	pid1Filename = func() string { return pid1 }
+	osStat       = os.Stat
+	osReadlink   = os.Readlink
 
 	initExecutable = func() (string, error) {
 		pid1File := pid1Filename()
@@ -128,7 +130,8 @@ func discoverLocalInitSystem() (string, error) {
 		return "", errors.Trace(err)
 	}
 
-	initName, ok := identifyInitSystem(executable)
+	followLink := true
+	initName, ok := identifyInitSystem(executable, followLink)
 	if !ok {
 		return "", errors.NotFoundf("init system (based on %q)", executable)
 	}
@@ -136,20 +139,34 @@ func discoverLocalInitSystem() (string, error) {
 	return initName, nil
 }
 
-func identifyInitSystem(executable string) (string, bool) {
+func identifyInitSystem(executable string, followLink bool) (string, bool) {
 	initSystem, ok := identifyExecutable(executable)
 	if ok {
 		return initSystem, true
 	}
 
-	if _, err := os.Stat(executable); os.IsNotExist(err) {
+	finfo, err := osStat(executable)
+	if os.IsNotExist(err) {
 		return "", false
 	} else if err != nil {
 		logger.Errorf("failed to find %q: %v", executable, err)
 		// The stat check is just an optimization so we go on anyway.
 	}
 
-	// TODO(ericsnow) First fall back to following symlinks?
+	// First fall back to following symlinks.
+	if followLink && (finfo.Mode()&os.ModeSymlink) != 0 {
+		linked, err := osReadlink(executable)
+		if err != nil {
+			logger.Errorf("could not follow link %q (%v)", executable, err)
+			// TODO(ericsnow) Try checking the version anyway?
+			return "", false
+		}
+		// We do not follow any more links since we want to avoid
+		// infinite recursion and it's unlikely the original link
+		// points to another link.
+		followLink = false
+		return identifyInitSystem(linked, followLink)
+	}
 
 	// Fall back to checking the "version" text.
 	cmd := exec.Command(executable, "--version")

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -39,6 +39,7 @@ type discoveryTest struct {
 	os       version.OSType
 	series   string
 	exec     string
+	link     string
 	expected string
 }
 
@@ -79,12 +80,13 @@ func (dt discoveryTest) executable(c *gc.C) string {
 }
 
 func (dt discoveryTest) log(c *gc.C) {
-	c.Logf("testing {%q, %q, %q}...", dt.os, dt.series, dt.exec)
+	c.Logf(" - testing {%q, %q, %q, %q}...", dt.os, dt.series, dt.exec, dt.link)
 }
 
 func (dt discoveryTest) disableLocalDiscovery(c *gc.C, s *discoverySuite) {
 	s.PatchGOOS("<another OS>")
 	s.PatchPid1File(c, unknownExecutable, "")
+	s.UnpatchLink(c)
 }
 
 func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
@@ -95,6 +97,13 @@ func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
 
 func (dt discoveryTest) setLocal(c *gc.C, s *discoverySuite) string {
 	s.PatchGOOS(dt.goos())
+	exec := dt.executable(c)
+	if dt.link != "" {
+		s.PatchLink(c, exec)
+		exec = dt.link
+	} else {
+		s.UnpatchLink(c)
+	}
 	verText := "..." + dt.expected + "..."
 	return s.PatchPid1File(c, dt.executable(c), verText)
 }
@@ -158,12 +167,22 @@ var discoveryTests = []discoveryTest{{
 	expected: service.InitSystemUpstart,
 }, {
 	os:       version.Ubuntu,
+	series:   "precise",
+	link:     "/sbin/init",
+	expected: service.InitSystemUpstart,
+}, {
+	os:       version.Ubuntu,
 	series:   "utopic",
 	expected: service.InitSystemUpstart,
 }, {
 	os:       version.Ubuntu,
 	series:   "vivid",
 	expected: maybeSystemd,
+}, {
+	os:       version.Ubuntu,
+	series:   "vivid",
+	link:     "/sbin/init",
+	expected: service.InitSystemSystemd,
 }, {
 	os:       version.CentOS,
 	expected: "",
@@ -233,7 +252,7 @@ func (s *discoverySuite) TestDiscoverServiceGeneric(c *gc.C) {
 	test := discoveryTest{
 		os:       version.Ubuntu,
 		series:   "trusty",
-		exec:     "/sbin/init",
+		link:     "/sbin/init",
 		expected: service.InitSystemUpstart,
 	}
 

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -86,7 +86,7 @@ func (dt discoveryTest) log(c *gc.C) {
 func (dt discoveryTest) disableLocalDiscovery(c *gc.C, s *discoverySuite) {
 	s.PatchGOOS("<another OS>")
 	s.PatchPid1File(c, unknownExecutable, "")
-	s.UnpatchLink(c)
+	s.Patched.NotASymlink = unknownExecutable
 }
 
 func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
@@ -102,10 +102,10 @@ func (dt discoveryTest) setLocal(c *gc.C, s *discoverySuite) string {
 		s.PatchLink(c, exec)
 		exec = dt.link
 	} else {
-		s.UnpatchLink(c)
+		s.Patched.NotASymlink = exec
 	}
 	verText := "..." + dt.expected + "..."
-	return s.PatchPid1File(c, dt.executable(c), verText)
+	return s.PatchPid1File(c, exec, verText)
 }
 
 func (dt discoveryTest) setVersion(s *discoverySuite) version.Binary {

--- a/service/testing_test.go
+++ b/service/testing_test.go
@@ -74,9 +74,9 @@ func (s *Stub) DiscoverService(name string) (Service, error) {
 	return s.Service, s.NextErr()
 }
 
-// Stat stubs out os.Stat.
-func (s *Stub) Stat(filename string) (os.FileInfo, error) {
-	s.AddCall("Stat", filename)
+// LStat stubs out os.LStat.
+func (s *Stub) Lstat(filename string) (os.FileInfo, error) {
+	s.AddCall("Lstat", filename)
 
 	return s.FileInfo, s.NextErr()
 }
@@ -176,7 +176,7 @@ func (s *BaseSuite) PatchPid1File(c *gc.C, executable, verText string) string {
 
 func (s *BaseSuite) PatchLink(c *gc.C, linked string) {
 	s.Patched.FileInfo = &StubSymlinkInfo{}
-	s.PatchValue(&osStat, s.Patched.Stat)
+	s.PatchValue(&osLstat, s.Patched.Lstat)
 
 	s.Patched.Linked = linked
 	s.PatchValue(&osReadlink, s.Patched.Readlink)


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1432421)

Sometimes PID 1 is running from a "/sbin/init" symlink to the actual init system binary. In some cases the "--version" option cannot be used directly on the symlink. So we follow the symlink before trying that.

(Review request: http://reviews.vapour.ws/r/1172/)