### PR TITLE
storageprovisioner: handle volume attachments

### DIFF
--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -210,7 +210,7 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 		Entities: []params.Entity{{"volume-0-0"}, {"volume-1"}, {"volume-42"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, gc.DeepEquals, params.VolumeParamsResults{
+	c.Assert(results, jc.DeepEquals, params.VolumeParamsResults{
 		Results: []params.VolumeParamsResult{
 			{Error: &params.Error{`volume "0/0" is already provisioned`, ""}},
 			{Result: params.VolumeParams{
@@ -219,6 +219,9 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 				Provider:  "environscoped",
 				Attachment: &params.VolumeAttachmentParams{
 					MachineTag: "machine-0",
+					VolumeTag:  "volume-1",
+					Provider:   "environscoped",
+					InstanceId: "inst-id",
 				},
 			}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -668,7 +668,10 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 			storageDir := filepath.Join(agentConfig.DataDir(), "storage")
 			return newStorageWorker(storageDir, api, api), nil
 		})
-		if isEnvironManager {
+		// TODO(axw) enable environ storage provisioner when it
+		// ignores non-dynamic storage. Until then, we have a
+		// race condition.
+		if isEnvironManager && false {
 			runner.StartWorker("storageprovisioner-environ", func() (worker.Worker, error) {
 				api := st.StorageProvisioner(agentConfig.Environment())
 				return newStorageWorker("", api, api), nil

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1251,7 +1251,7 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	// TODO(wallyworld) - worker is currently disabled even with feature flag
-	s.testMachineAgentRunsEnvironStorageWorkers(c, true, coretesting.LongWait)
+	s.testMachineAgentRunsEnvironStorageWorkers(c, false, coretesting.LongWait)
 }
 
 func (s *MachineSuite) testMachineAgentRunsEnvironStorageWorkers(c *gc.C, shouldRun bool, timeout time.Duration) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1215,8 +1215,7 @@ func (s *MachineSuite) TestMachineAgentRunsMachineStorageWorker(c *gc.C) {
 
 	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	// TODO(wallyworld) - worker is currently disabled even with feature flag
-	s.testMachineAgentRunsMachineStorageWorker(c, false, coretesting.LongWait)
+	s.testMachineAgentRunsMachineStorageWorker(c, true, coretesting.LongWait)
 }
 
 func (s *MachineSuite) testMachineAgentRunsMachineStorageWorker(c *gc.C, shouldRun bool, timeout time.Duration) {
@@ -1252,7 +1251,7 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	// TODO(wallyworld) - worker is currently disabled even with feature flag
-	s.testMachineAgentRunsEnvironStorageWorkers(c, false, coretesting.LongWait)
+	s.testMachineAgentRunsEnvironStorageWorkers(c, true, coretesting.LongWait)
 }
 
 func (s *MachineSuite) testMachineAgentRunsEnvironStorageWorkers(c *gc.C, shouldRun bool, timeout time.Duration) {

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -1,0 +1,158 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider/registry"
+)
+
+// entityLife queries the lifecycle state of each specified
+// entity (volume or filesystem), and then partitions the tags
+// by them.
+func entityLife(ctx *context, tags []names.Tag) (alive, dying, dead []names.Tag, _ error) {
+	lifeResults, err := ctx.life.Life(tags)
+	if err != nil {
+		return nil, nil, nil, errors.Annotate(err, "getting storage entity life")
+	}
+	for i, result := range lifeResults {
+		if result.Error != nil {
+			return nil, nil, nil, errors.Annotatef(
+				result.Error, "getting life of %s",
+				names.ReadableString(tags[i]),
+			)
+		}
+		switch result.Life {
+		case params.Alive:
+			alive = append(alive, tags[i])
+		case params.Dying:
+			dying = append(dying, tags[i])
+		case params.Dead:
+			dead = append(dead, tags[i])
+		}
+	}
+	return alive, dying, dead, nil
+}
+
+// attachmentLife queries the lifecycle state of each specified
+// attachment, and then partitions the IDs by them.
+func attachmentLife(ctx *context, ids []params.MachineStorageId) (
+	alive, dying, dead []params.MachineStorageId, _ error,
+) {
+	lifeResults, err := ctx.life.AttachmentLife(ids)
+	if err != nil {
+		return nil, nil, nil, errors.Annotate(err, "getting machine attachment life")
+	}
+	for i, result := range lifeResults {
+		if result.Error != nil {
+			return nil, nil, nil, errors.Annotatef(
+				result.Error, "getting life of %s attached to %s",
+				ids[i].AttachmentTag, ids[i].MachineTag,
+			)
+		}
+		switch result.Life {
+		case params.Alive:
+			alive = append(alive, ids[i])
+		case params.Dying:
+			dying = append(dying, ids[i])
+		case params.Dead:
+			dead = append(dead, ids[i])
+		}
+	}
+	return alive, dying, dead, nil
+}
+
+// ensureDead ensures that each specified entity immediately becomes Dead
+// if it is not already Dead or removed.
+func ensureDead(ctx *context, tags []names.Tag) error {
+	errorResults, err := ctx.life.EnsureDead(tags)
+	if err != nil {
+		return errors.Annotate(err, "ensuring storage entities dead")
+	}
+	for i, result := range errorResults {
+		if result.Error != nil {
+			return errors.Annotatef(result.Error, "ensuring %s dead", names.ReadableString(tags[i]))
+		}
+	}
+	return nil
+}
+
+// removeEntities removes each specified Dead entity from state.
+func removeEntities(ctx *context, tags []names.Tag) error {
+	errorResults, err := ctx.life.Remove(tags)
+	if err != nil {
+		return errors.Annotate(err, "removing storage entities")
+	}
+	for i, result := range errorResults {
+		if result.Error != nil {
+			return errors.Annotatef(result.Error, "removing %s from state", names.ReadableString(tags[i]))
+		}
+	}
+	return nil
+}
+
+// removeAttachments removes each specified attachment from state.
+func removeAttachments(ctx *context, ids []params.MachineStorageId) error {
+	errorResults, err := ctx.life.RemoveAttachments(ids)
+	if err != nil {
+		return errors.Annotate(err, "removing attachments")
+	}
+	for i, result := range errorResults {
+		if result.Error != nil {
+			return errors.Annotatef(
+				result.Error, "removing attachment of %s to %s from state",
+				ids[i].AttachmentTag, ids[i].MachineTag,
+			)
+		}
+	}
+	return nil
+}
+
+// volumeSource returns a volume source given a name, provider type,
+// environment config and storage directory.
+//
+// TODO(axw) move this to the main storageprovisioner, and have
+// it watch for changes to storage source configurations, updating
+// a map in-between calls to the volume/filesystem/attachment
+// event handlers.
+func volumeSource(
+	environConfig *config.Config,
+	baseStorageDir string,
+	sourceName string,
+	providerType storage.ProviderType,
+) (storage.VolumeSource, error) {
+	provider, sourceConfig, err := sourceParams(providerType, sourceName, baseStorageDir)
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting storage source %q params", sourceName)
+	}
+	source, err := provider.VolumeSource(environConfig, sourceConfig)
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting storage source %q", sourceName)
+	}
+	return source, nil
+}
+
+func sourceParams(providerType storage.ProviderType, sourceName, baseStorageDir string) (storage.Provider, *storage.Config, error) {
+	provider, err := registry.StorageProvider(providerType)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "getting provider")
+	}
+	attrs := make(map[string]interface{})
+	if baseStorageDir != "" {
+		storageDir := filepath.Join(baseStorageDir, sourceName)
+		attrs[storage.ConfigStorageDir] = storageDir
+	}
+	sourceConfig, err := storage.NewConfig(sourceName, providerType, attrs)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "getting config")
+	}
+	return provider, sourceConfig, nil
+}

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -15,10 +15,10 @@ import (
 	"github.com/juju/juju/storage/provider/registry"
 )
 
-// entityLife queries the lifecycle state of each specified
-// entity (volume or filesystem), and then partitions the tags
-// by them.
-func entityLife(ctx *context, tags []names.Tag) (alive, dying, dead []names.Tag, _ error) {
+// storageEntityLife queries the lifecycle state of each specified
+// storage entity (volume or filesystem), and then partitions the
+// tags by them.
+func storageEntityLife(ctx *context, tags []names.Tag) (alive, dying, dead []names.Tag, _ error) {
 	lifeResults, err := ctx.life.Life(tags)
 	if err != nil {
 		return nil, nil, nil, errors.Annotate(err, "getting storage entity life")

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -1,0 +1,279 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	"strconv"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
+)
+
+const attachedVolumeId = "1"
+
+var dyingVolumeAttachmentId = params.MachineStorageId{
+	MachineTag:    "machine-0",
+	AttachmentTag: "volume-0",
+}
+
+var missingVolumeAttachmentId = params.MachineStorageId{
+	MachineTag:    "machine-3",
+	AttachmentTag: "volume-1",
+}
+
+type mockStringsWatcher struct {
+	changes chan []string
+}
+
+func (*mockStringsWatcher) Stop() error {
+	return nil
+}
+
+func (*mockStringsWatcher) Err() error {
+	return nil
+}
+
+func (w *mockStringsWatcher) Changes() <-chan []string {
+	return w.changes
+}
+
+type mockAttachmentsWatcher struct {
+	changes chan []params.MachineStorageId
+}
+
+func (*mockAttachmentsWatcher) Stop() error {
+	return nil
+}
+
+func (*mockAttachmentsWatcher) Err() error {
+	return nil
+}
+
+func (w *mockAttachmentsWatcher) Changes() <-chan []params.MachineStorageId {
+	return w.changes
+}
+
+type mockVolumeAccessor struct {
+	volumesWatcher         *mockStringsWatcher
+	attachmentsWatcher     *mockAttachmentsWatcher
+	provisionedMachines    map[string]instance.Id
+	provisionedVolumes     map[string]params.Volume
+	provisionedAttachments map[params.MachineStorageId]params.VolumeAttachment
+
+	setVolumeInfo           func([]params.Volume) ([]params.ErrorResult, error)
+	setVolumeAttachmentInfo func([]params.VolumeAttachment) ([]params.ErrorResult, error)
+}
+
+func (w *mockVolumeAccessor) WatchVolumes() (apiwatcher.StringsWatcher, error) {
+	return w.volumesWatcher, nil
+}
+
+func (w *mockVolumeAccessor) WatchVolumeAttachments() (apiwatcher.MachineStorageIdsWatcher, error) {
+	return w.attachmentsWatcher, nil
+}
+
+func (v *mockVolumeAccessor) Volumes(volumes []names.VolumeTag) ([]params.VolumeResult, error) {
+	var result []params.VolumeResult
+	for _, tag := range volumes {
+		if vol, ok := v.provisionedVolumes[tag.String()]; ok {
+			result = append(result, params.VolumeResult{Result: vol})
+		} else {
+			result = append(result, params.VolumeResult{
+				Error: common.ServerError(errors.NotProvisionedf("volume %q", tag.Id())),
+			})
+		}
+	}
+	return result, nil
+}
+
+func (v *mockVolumeAccessor) VolumeAttachments(ids []params.MachineStorageId) ([]params.VolumeAttachmentResult, error) {
+	var result []params.VolumeAttachmentResult
+	for _, id := range ids {
+		if att, ok := v.provisionedAttachments[id]; ok {
+			result = append(result, params.VolumeAttachmentResult{Result: att})
+		} else {
+			result = append(result, params.VolumeAttachmentResult{
+				Error: common.ServerError(errors.NotProvisionedf("volume attachment %v", id)),
+			})
+		}
+	}
+	return result, nil
+}
+
+func (v *mockVolumeAccessor) VolumeParams(volumes []names.VolumeTag) ([]params.VolumeParamsResult, error) {
+	var result []params.VolumeParamsResult
+	for _, tag := range volumes {
+		if _, ok := v.provisionedVolumes[tag.String()]; ok {
+			result = append(result, params.VolumeParamsResult{
+				Error: &params.Error{Message: "already provisioned"},
+			})
+		} else {
+			volumeParams := params.VolumeParams{
+				VolumeTag: tag.String(),
+				Size:      1024,
+				Provider:  "dummy",
+				Attributes: map[string]interface{}{
+					"persistent": tag.String() == "volume-1",
+				},
+			}
+			if tag.Id() == attachedVolumeId {
+				volumeParams.Attachment = &params.VolumeAttachmentParams{
+					VolumeTag:  tag.String(),
+					MachineTag: "machine-1",
+					Provider:   "dummy",
+				}
+			}
+			result = append(result, params.VolumeParamsResult{Result: volumeParams})
+		}
+	}
+	return result, nil
+}
+
+func (v *mockVolumeAccessor) VolumeAttachmentParams(ids []params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error) {
+	var result []params.VolumeAttachmentParamsResult
+	for _, id := range ids {
+		if _, ok := v.provisionedAttachments[id]; ok {
+			result = append(result, params.VolumeAttachmentParamsResult{
+				Error: &params.Error{Message: "already provisioned"},
+			})
+		} else {
+			instanceId, _ := v.provisionedMachines[id.MachineTag]
+			volume, _ := v.provisionedVolumes[id.AttachmentTag]
+			result = append(result, params.VolumeAttachmentParamsResult{Result: params.VolumeAttachmentParams{
+				MachineTag: id.MachineTag,
+				VolumeTag:  id.AttachmentTag,
+				InstanceId: string(instanceId),
+				VolumeId:   volume.VolumeId,
+				Provider:   "dummy",
+			}})
+		}
+	}
+	return result, nil
+}
+
+func (v *mockVolumeAccessor) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, error) {
+	return v.setVolumeInfo(volumes)
+}
+
+func (v *mockVolumeAccessor) SetVolumeAttachmentInfo(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
+	return v.setVolumeAttachmentInfo(volumeAttachments)
+}
+
+func newMockVolumeAccessor() *mockVolumeAccessor {
+	return &mockVolumeAccessor{
+		volumesWatcher:         &mockStringsWatcher{make(chan []string, 1)},
+		attachmentsWatcher:     &mockAttachmentsWatcher{make(chan []params.MachineStorageId, 1)},
+		provisionedMachines:    make(map[string]instance.Id),
+		provisionedVolumes:     make(map[string]params.Volume),
+		provisionedAttachments: make(map[params.MachineStorageId]params.VolumeAttachment),
+	}
+}
+
+type mockLifecycleManager struct {
+}
+
+func (m *mockLifecycleManager) Life(volumes []names.Tag) ([]params.LifeResult, error) {
+	var result []params.LifeResult
+	for _, tag := range volumes {
+		id, _ := strconv.Atoi(tag.Id())
+		if id <= 100 {
+			result = append(result, params.LifeResult{Life: params.Alive})
+		} else {
+			result = append(result, params.LifeResult{Life: params.Dying})
+		}
+	}
+	return result, nil
+}
+
+func (m *mockLifecycleManager) AttachmentLife(ids []params.MachineStorageId) ([]params.LifeResult, error) {
+	var result []params.LifeResult
+	for _, id := range ids {
+		switch id {
+		case dyingVolumeAttachmentId:
+			result = append(result, params.LifeResult{Life: params.Dying})
+		case missingVolumeAttachmentId:
+			result = append(result, params.LifeResult{
+				Error: common.ServerError(errors.NotFoundf("attachment %v", id)),
+			})
+		default:
+			result = append(result, params.LifeResult{Life: params.Alive})
+		}
+	}
+	return result, nil
+}
+
+func (m *mockLifecycleManager) EnsureDead([]names.Tag) ([]params.ErrorResult, error) {
+	return nil, nil
+}
+
+func (m *mockLifecycleManager) Remove([]names.Tag) ([]params.ErrorResult, error) {
+	return nil, nil
+}
+
+func (m *mockLifecycleManager) RemoveAttachments([]params.MachineStorageId) ([]params.ErrorResult, error) {
+	return nil, nil
+}
+
+// Set up a dummy storage provider so we can stub out volume creation.
+type dummyProvider struct {
+	storage.Provider
+}
+
+type dummyVolumeSource struct {
+	storage.VolumeSource
+}
+
+func (*dummyProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
+	return &dummyVolumeSource{}, nil
+}
+
+// CreateVolumes makes some volumes that we can check later to ensure things went as expected.
+func (*dummyVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
+	var volumes []storage.Volume
+	var volumeAttachments []storage.VolumeAttachment
+	for _, p := range params {
+		persistent, _ := p.Attributes["persistent"].(bool)
+		volumes = append(volumes, storage.Volume{
+			Tag:        p.Tag,
+			Size:       p.Size,
+			Serial:     "serial-" + p.Tag.Id(),
+			VolumeId:   "id-" + p.Tag.Id(),
+			Persistent: persistent,
+		})
+		if p.Attachment != nil {
+			volumeAttachments = append(volumeAttachments, storage.VolumeAttachment{
+				Volume:     p.Tag,
+				Machine:    p.Attachment.Machine,
+				DeviceName: "/dev/sda" + p.Tag.Id(),
+			})
+		}
+	}
+	return volumes, volumeAttachments, nil
+}
+
+// AttachVolumes attaches volumes to machines.
+func (*dummyVolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([]storage.VolumeAttachment, error) {
+	var volumeAttachments []storage.VolumeAttachment
+	for _, p := range params {
+		if p.VolumeId == "" {
+			panic("AttachVolumes called with unprovisioned volume")
+		}
+		if p.InstanceId == "" {
+			panic("AttachVolumes called with unprovisioned machine")
+		}
+		volumeAttachments = append(volumeAttachments, storage.VolumeAttachment{
+			Volume:     p.Volume,
+			Machine:    p.Machine,
+			DeviceName: "/dev/sda" + p.Volume.Id(),
+		})
+	}
+	return volumeAttachments, nil
+}

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -30,10 +30,9 @@ func (s *storageProvisionerSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
-	changes := make(chan []string)
 	worker := storageprovisioner.NewStorageProvisioner(
 		"dir",
-		newMockVolumeAccessor(changes, nil, nil),
+		newMockVolumeAccessor(),
 		&mockLifecycleManager{},
 	)
 	worker.Kill()

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -4,19 +4,12 @@
 package storageprovisioner_test
 
 import (
-	"encoding/json"
-	"strconv"
 	"time"
 
-	"github.com/juju/errors"
-	"github.com/juju/names"
 	gc "gopkg.in/check.v1"
 
-	apiwatcher "github.com/juju/juju/api/watcher"
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/storage"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage/provider/registry"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/storageprovisioner"
@@ -28,185 +21,131 @@ type storageProvisionerSuite struct {
 
 var _ = gc.Suite(&storageProvisionerSuite{})
 
-type mockStringsWatcher struct {
-	changes <-chan []string
-}
-
-func (*mockStringsWatcher) Stop() error {
-	return nil
-}
-
-func (*mockStringsWatcher) Err() error {
-	return nil
-}
-
-func (w *mockStringsWatcher) Changes() <-chan []string {
-	return w.changes
-}
-
-type mockVolumeAccessor struct {
-	mockStringsWatcher apiwatcher.StringsWatcher
-	provisioned        map[string]params.Volume
-	done               chan struct{}
-	// If SetVolumeInfo is called with expectedVolumes, then the
-	// volume creation is as expected and the done channel is closed.
-	expectedVolumes []params.Volume
-}
-
-func (w *mockVolumeAccessor) WatchVolumes() (apiwatcher.StringsWatcher, error) {
-	return w.mockStringsWatcher, nil
-}
-
-func (v *mockVolumeAccessor) Volumes(volumes []names.VolumeTag) ([]params.VolumeResult, error) {
-	var result []params.VolumeResult
-	for _, tag := range volumes {
-		if vol, ok := v.provisioned[tag.String()]; ok {
-			result = append(result, params.VolumeResult{Result: vol})
-		} else {
-			result = append(result, params.VolumeResult{
-				Error: common.ServerError(errors.NotProvisionedf("volume %q", tag.Id())),
-			})
-		}
-	}
-	return result, nil
-}
-
-func (v *mockVolumeAccessor) VolumeParams(volumes []names.VolumeTag) ([]params.VolumeParamsResult, error) {
-	var result []params.VolumeParamsResult
-	for _, tag := range volumes {
-		if _, ok := v.provisioned[tag.String()]; ok {
-			result = append(result, params.VolumeParamsResult{
-				Error: &params.Error{Message: "already provisioned"},
-			})
-		} else {
-			result = append(result, params.VolumeParamsResult{Result: params.VolumeParams{
-				VolumeTag:  tag.String(),
-				Size:       1024,
-				Provider:   "dummy",
-				Attributes: map[string]interface{}{"persistent": tag.String() == "volume-1"},
-			}})
-		}
-	}
-	return result, nil
-}
-
-func (v *mockVolumeAccessor) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, error) {
-	for _, vol := range volumes {
-		v.provisioned[vol.VolumeTag] = vol
-	}
-	// See if we have the expected volumes, using json serialisation to do the comparison.
-	jsonVolInfo, err := json.Marshal(volumes)
-	if err != nil {
-		return []params.ErrorResult{{Error: common.ServerError(err)}}, nil
-	}
-	jsonExpectedInfo, err := json.Marshal(v.expectedVolumes)
-	if err != nil {
-		return []params.ErrorResult{{Error: common.ServerError(err)}}, nil
-	}
-	// If we have what we expect, close the done channel.
-	if string(jsonVolInfo) == string(jsonExpectedInfo) {
-		close(v.done)
-	}
-	return nil, nil
-}
-
-func newMockVolumeAccessor(changes <-chan []string, done chan struct{}, expectedVolumes []params.Volume) storageprovisioner.VolumeAccessor {
-	return &mockVolumeAccessor{
-		&mockStringsWatcher{changes},
-		make(map[string]params.Volume),
-		done,
-		expectedVolumes,
-	}
-}
-
-type mockLifecycleManager struct {
-}
-
-func (m *mockLifecycleManager) Life(volumes []names.Tag) ([]params.LifeResult, error) {
-	var result []params.LifeResult
-	for _, tag := range volumes {
-		id, _ := strconv.Atoi(tag.Id())
-		if id <= 100 {
-			result = append(result, params.LifeResult{Life: params.Alive})
-		} else {
-			result = append(result, params.LifeResult{Life: params.Dying})
-		}
-	}
-	return result, nil
-}
-
-func (m *mockLifecycleManager) EnsureDead([]names.Tag) ([]params.ErrorResult, error) {
-	return nil, nil
-}
-
-func (m *mockLifecycleManager) Remove([]names.Tag) ([]params.ErrorResult, error) {
-	return nil, nil
+func (s *storageProvisionerSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	registry.RegisterProvider("dummy", &dummyProvider{})
+	s.AddSuiteCleanup(func(*gc.C) {
+		registry.RegisterProvider("dummy", nil)
+	})
 }
 
 func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
 	changes := make(chan []string)
 	worker := storageprovisioner.NewStorageProvisioner(
-		"dir", newMockVolumeAccessor(changes, nil, nil), &mockLifecycleManager{},
+		"dir",
+		newMockVolumeAccessor(changes, nil, nil),
+		&mockLifecycleManager{},
 	)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
 }
 
-// Set up a dummy storage provider so we can stub out volume creation.
-type dummyProvider struct {
-	storage.Provider
-}
-
-type dummyVolumeSource struct {
-	storage.VolumeSource
-}
-
-func (*dummyProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
-	return &dummyVolumeSource{}, nil
-}
-
-// CreateVolumes makes some volumes that we can check later to ensure things went as expected.
-func (*dummyVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
-	var volumes []storage.Volume
-	var volumeAttachments []storage.VolumeAttachment
-	for _, p := range params {
-		persistent, _ := p.Attributes["persistent"].(bool)
-		volumes = append(volumes, storage.Volume{
-			Tag:        p.Tag,
-			Size:       p.Size,
-			Serial:     "serial-" + p.Tag.Id(),
-			VolumeId:   "id-" + p.Tag.Id(),
-			Persistent: persistent,
-		})
-		volumeAttachments = append(volumeAttachments, storage.VolumeAttachment{
-			Volume:     p.Tag,
-			Machine:    names.NewMachineTag("0"),
-			DeviceName: "/dev/sda" + p.Tag.Id(),
-		})
-	}
-	return volumes, volumeAttachments, nil
-}
-
 func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
-	registry.RegisterProvider(storage.ProviderType("dummy"), &dummyProvider{})
-	updated := make(chan struct{})
-	changes := make(chan []string)
-	expectedVolumes := []params.Volume{
-		{VolumeTag: "volume-1", VolumeId: "id-1", Serial: "serial-1", Size: 1024, Persistent: true},
-		{VolumeTag: "volume-2", VolumeId: "id-2", Serial: "serial-2", Size: 1024},
+	expectedVolumes := []params.Volume{{
+		VolumeTag:  "volume-1",
+		VolumeId:   "id-1",
+		Serial:     "serial-1",
+		Size:       1024,
+		Persistent: true,
+	}, {
+		VolumeTag: "volume-2",
+		VolumeId:  "id-2",
+		Serial:    "serial-2",
+		Size:      1024,
+	}}
+	expectedVolumeAttachments := []params.VolumeAttachment{{
+		VolumeTag:  "volume-1",
+		MachineTag: "machine-1",
+		DeviceName: "/dev/sda1",
+	}}
+
+	volumeInfoSet := make(chan struct{})
+	volumeAccessor := newMockVolumeAccessor()
+	volumeAccessor.setVolumeInfo = func(volumes []params.Volume) ([]params.ErrorResult, error) {
+		defer close(volumeInfoSet)
+		c.Assert(volumes, gc.DeepEquals, expectedVolumes)
+		return nil, nil
 	}
-	worker := storageprovisioner.NewStorageProvisioner(
-		"storage-dir", newMockVolumeAccessor(changes, updated, expectedVolumes), &mockLifecycleManager{},
-	)
+
+	volumeAttachmentInfoSet := make(chan struct{})
+	volumeAccessor.setVolumeAttachmentInfo = func(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
+		defer close(volumeAttachmentInfoSet)
+		c.Assert(volumeAttachments, gc.DeepEquals, expectedVolumeAttachments)
+		return nil, nil
+	}
+	lifecycleManager := &mockLifecycleManager{}
+
+	worker := storageprovisioner.NewStorageProvisioner("storage-dir", volumeAccessor, lifecycleManager)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
 
 	// The worker should create volumes according to ids "1" and "2".
-	changes <- []string{"1", "2"}
+	volumeAccessor.volumesWatcher.changes <- []string{"1", "2"}
+	waitChannel(c, volumeInfoSet, "waiting for volume info to be set")
+	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
+}
+
+func (s *storageProvisionerSuite) TestVolumeAttachmentAdded(c *gc.C) {
+	// We should only get a single volume attachment, because it is the
+	// only combination where both machine and volume are already
+	// provisioned, and the attachmenti s not.
+	expectedVolumeAttachments := []params.VolumeAttachment{{
+		VolumeTag:  "volume-1",
+		MachineTag: "machine-1",
+		DeviceName: "/dev/sda1",
+	}}
+
+	volumeAttachmentInfoSet := make(chan struct{})
+	volumeAccessor := newMockVolumeAccessor()
+	volumeAccessor.setVolumeAttachmentInfo = func(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
+		defer close(volumeAttachmentInfoSet)
+		c.Assert(volumeAttachments, gc.DeepEquals, expectedVolumeAttachments)
+		return nil, nil
+	}
+	lifecycleManager := &mockLifecycleManager{}
+
+	// volume-1 and machine-1 are provisioned.
+	volumeAccessor.provisionedVolumes["volume-1"] = params.Volume{
+		VolumeTag: "volume-1",
+		VolumeId:  "vol-123",
+	}
+	volumeAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
+	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+
+	// machine-0/volume-1 attachment is already created.
+	//
+	// TODO(axw) later we should ensure that a reattachment occurs
+	// the first time the attachment is seen by the worker.
+	alreadyAttached := params.MachineStorageId{
+		MachineTag:    "machine-0",
+		AttachmentTag: "volume-1",
+	}
+	volumeAccessor.provisionedAttachments[alreadyAttached] = params.VolumeAttachment{
+		MachineTag: "machine-0",
+		VolumeTag:  "volume-1",
+	}
+
+	worker := storageprovisioner.NewStorageProvisioner("storage-dir", volumeAccessor, lifecycleManager)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+
+	volumeAccessor.attachmentsWatcher.changes <- []params.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "volume-1",
+	}, {
+		MachineTag: "machine-1", AttachmentTag: "volume-2",
+	}, {
+		MachineTag: "machine-2", AttachmentTag: "volume-1",
+	}, {
+		MachineTag: "machine-0", AttachmentTag: "volume-1",
+	}}
+	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
+}
+
+func waitChannel(c *gc.C, ch <-chan struct{}, activity string) {
 	select {
-	case <-updated:
+	case <-ch:
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for volume change to be processd")
+		c.Fatalf("timed out " + activity)
 	}
 }
 

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -20,7 +20,7 @@ func volumesChanged(ctx *context, changes []string) error {
 	for i, change := range changes {
 		tags[i] = names.NewVolumeTag(change)
 	}
-	alive, dying, dead, err := entityLife(ctx, tags)
+	alive, dying, dead, err := storageEntityLife(ctx, tags)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -4,63 +4,39 @@
 package storageprovisioner
 
 import (
-	"path/filepath"
-
 	"github.com/juju/errors"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/provider/registry"
 )
 
+// volumesChanged is called when the lifecycle states of the volumes
+// with the provided IDs have been seen to have changed.
 func volumesChanged(ctx *context, changes []string) error {
 	tags := make([]names.Tag, len(changes))
 	for i, change := range changes {
 		tags[i] = names.NewVolumeTag(change)
 	}
-
-	lifeResults, err := ctx.life.Life(tags)
+	alive, dying, dead, err := entityLife(ctx, tags)
 	if err != nil {
-		return errors.Annotate(err, "getting volume lifecycle")
+		return errors.Trace(err)
 	}
-	var alive, dying, dead []names.Tag
-	for i, result := range lifeResults {
-		if result.Error != nil {
-			return errors.Annotatef(result.Error, "failed to get life for volume %q", tags[i].Id())
-		}
-		switch result.Life {
-		case params.Alive:
-			alive = append(alive, tags[i])
-		case params.Dying:
-			dying = append(dying, tags[i])
-		case params.Dead:
-			dead = append(dead, tags[i])
-		default:
-			return errors.Errorf("invalid life cycle %v", result.Life)
-		}
+	// TODO(axw) wait for volumes/filesystems to have no
+	// attachments first. We can then have the removal of the
+	// last attachment trigger the volume/filesystem's Life
+	// being transitioned to Dead.
+	// or watch the attachments until they're all gone. We need
+	// to watch attachments *anyway*, so we can probably integrate
+	// the two things.
+	if err := ensureDead(ctx, dying); err != nil {
+		return errors.Annotate(err, "ensuring volumes dead")
 	}
-
-	// If we can, advance "dying" volumes to "dead".
-	if len(dying) > 0 {
-		// TODO(axw) wait for volumes to have no attachments first.
-		// We'll either have to retry periodically, or watch the
-		// volume attachments until they're all gone. We need to
-		// watch volume attachments *anyway*, so we can probably
-		// integrate the two things.
-		errorResults, err := ctx.life.EnsureDead(dying)
-		if err != nil {
-			return errors.Annotate(err, "ensuring volumes dead")
-		}
-		for i, result := range errorResults {
-			if result.Error != nil {
-				return errors.Annotatef(result.Error, "failed to ensure volume %q dead", dying[i].Id())
-			}
-			dead = append(dead, dying[i])
-		}
-	}
-
+	// Once the entities are Dead, they can be removed from state
+	// after the corresponding cloud storage resources are removed.
+	dead = append(dead, dying...)
 	if len(alive)+len(dead) == 0 {
 		return nil
 	}
@@ -92,6 +68,47 @@ func volumesChanged(ctx *context, changes []string) error {
 	return nil
 }
 
+// volumeAttachmentsChanged is called when the lifecycle states of the volume
+// attachments with the provided IDs have been seen to have changed.
+func volumeAttachmentsChanged(ctx *context, ids []params.MachineStorageId) error {
+	alive, dying, dead, err := attachmentLife(ctx, ids)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(dead) != 0 {
+		// We should not see dead volume attachments;
+		// attachments go directly from Dying to removed.
+		logger.Debugf("unexpected dead volume attachments: %v", dead)
+	}
+	if len(alive)+len(dying) == 0 {
+		return nil
+	}
+
+	// Get volume information for alive and dying volume attachments, so
+	// we can attach/detach.
+	ids = append(alive, dying...)
+	volumeAttachmentResults, err := ctx.volumes.VolumeAttachments(ids)
+	if err != nil {
+		return errors.Annotatef(err, "getting volume attachment information")
+	}
+
+	// Deprovision Dying volume attachments.
+	dyingVolumeAttachmentResults := volumeAttachmentResults[len(alive):]
+	if err := processDyingVolumeAttachments(ctx, dying, dyingVolumeAttachmentResults); err != nil {
+		return errors.Annotate(err, "deprovisioning volume attachments")
+	}
+
+	// Provision Alive volume attachments.
+	aliveVolumeAttachmentResults := volumeAttachmentResults[:len(alive)]
+	if err := processAliveVolumeAttachments(ctx, alive, aliveVolumeAttachmentResults); err != nil {
+		return errors.Annotate(err, "provisioning volumes")
+	}
+
+	return nil
+}
+
+// processDeadVolumes processes the VolumeResults for Dead volumes,
+// deprovisioning volumes and removing from state as necessary.
 func processDeadVolumes(ctx *context, tags []names.Tag, volumeResults []params.VolumeResult) error {
 	volumes := make([]params.Volume, len(volumeResults))
 	for i, result := range volumeResults {
@@ -107,28 +124,57 @@ func processDeadVolumes(ctx *context, tags []names.Tag, volumeResults []params.V
 	if err != nil {
 		return errors.Annotate(err, "destroying volumes")
 	}
-	destroyed := make([]names.Tag, 0, len(volumes))
-	for i, err := range errorResults {
-		if err != nil {
-			logger.Errorf("destroying volume %q: %v", volumes[i].VolumeTag, err)
+	destroyed := make([]names.Tag, 0, len(tags))
+	for i, tag := range tags {
+		if err := errorResults[i]; err != nil {
+			logger.Errorf("destroying %s: %v", names.ReadableString(tag), err)
 			continue
 		}
-		destroyed = append(destroyed, tags[i])
+		destroyed = append(destroyed, tag)
 	}
-	if len(destroyed) > 0 {
-		errorResults, err := ctx.life.Remove(destroyed)
-		if err != nil {
-			return errors.Annotate(err, "removing volumes from state")
-		}
-		for i, result := range errorResults {
-			if result.Error != nil {
-				logger.Errorf("removing volume %q from state: %v", destroyed[i].Id(), result.Error)
-			}
-		}
+	if err := removeEntities(ctx, destroyed); err != nil {
+		return errors.Annotate(err, "removing volumes from state")
 	}
 	return nil
 }
 
+// processDyingVolumeAttachments processes the VolumeAttachmentResults for
+// Dying volume attachments, detaching volumes and updating state as necessary.
+func processDyingVolumeAttachments(
+	ctx *context,
+	ids []params.MachineStorageId,
+	volumeAttachmentResults []params.VolumeAttachmentResult,
+) error {
+	volumeAttachments := make([]params.VolumeAttachment, len(volumeAttachmentResults))
+	for i, result := range volumeAttachmentResults {
+		if result.Error != nil {
+			return errors.Annotatef(result.Error, "getting information for volume attachment %v", ids[i])
+		}
+		volumeAttachments[i] = result.Result
+	}
+	if len(volumeAttachments) == 0 {
+		return nil
+	}
+	errorResults, err := detachVolumes(volumeAttachments)
+	if err != nil {
+		return errors.Annotate(err, "detaching volumes")
+	}
+	detached := make([]params.MachineStorageId, 0, len(ids))
+	for i, id := range ids {
+		if err := errorResults[i]; err != nil {
+			logger.Errorf("detaching %v from %v: %v", ids[i].AttachmentTag, ids[i].MachineTag, err)
+			continue
+		}
+		detached = append(detached, id)
+	}
+	if err := removeAttachments(ctx, detached); err != nil {
+		return errors.Annotate(err, "removing attachments from state")
+	}
+	return nil
+}
+
+// processAliveVolumes processes the VolumeResults for Alive volumes,
+// provisioning volumes and setting the info in state as necessary.
 func processAliveVolumes(ctx *context, tags []names.Tag, volumeResults []params.VolumeResult) error {
 	// Filter out the already-provisioned volumes.
 	pending := make([]names.VolumeTag, 0, len(tags))
@@ -180,40 +226,120 @@ func processAliveVolumes(ctx *context, tags []names.Tag, volumeResults []params.
 		if err != nil {
 			return errors.Annotate(err, "publishing volumes to state")
 		}
-		if err := (params.ErrorResults{errorResults}.Combine()); err != nil {
-			return errors.Annotate(err, "publishing volumes to state")
+		for i, result := range errorResults {
+			if result.Error != nil {
+				return errors.Annotatef(
+					err, "publishing %s to state",
+					volumes[i].VolumeTag,
+				)
+			}
 		}
-		// TODO(axw) record volume attachment info in state.
-		_ = volumeAttachments
+		// Note: the storage provisioner that creates a volume is also
+		// responsible for creating the volume attachment. It is therefore
+		// safe to set the volume attachment info after the volume info,
+		// without leading to the possibility of concurrent, duplicate
+		// attachments.
+		if err := setVolumeAttachmentInfo(ctx, volumeAttachments); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	return nil
 }
 
-func volumeParamsFromParams(in params.VolumeParams) (storage.VolumeParams, error) {
-	volumeTag, err := names.ParseVolumeTag(in.VolumeTag)
+// processAliveVolumes processes the VolumeAttachmentResults for Alive
+// volume attachments, attaching volumes and setting the info in state
+// as necessary.
+func processAliveVolumeAttachments(
+	ctx *context,
+	ids []params.MachineStorageId,
+	volumeAttachmentResults []params.VolumeAttachmentResult,
+) error {
+	// Filter out the already-attached.
+	//
+	// TODO(axw) record locally which volumes have been attached this
+	// session, and issue a reattach each time we restart. We should
+	// limit this to machine-scoped volumes to start with.
+	pending := make([]params.MachineStorageId, 0, len(ids))
+	for i, result := range volumeAttachmentResults {
+		if result.Error == nil {
+			// Volume attachment is already provisioned: skip.
+			logger.Debugf(
+				"%s is already attached to %s, nothing to do",
+				ids[i].AttachmentTag, ids[i].MachineTag,
+			)
+			continue
+		}
+		if !params.IsCodeNotProvisioned(result.Error) {
+			return errors.Annotatef(
+				result.Error, "getting information for attachment %v", ids[i],
+			)
+		}
+		// The volume has not yet been provisioned, so record its tag
+		// to enquire about parameters below.
+		pending = append(pending, ids[i])
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	paramsResults, err := ctx.volumes.VolumeAttachmentParams(pending)
 	if err != nil {
-		return storage.VolumeParams{}, errors.Trace(err)
+		return errors.Annotate(err, "getting volume params")
 	}
-	var attachment *storage.VolumeAttachmentParams
-	if in.Attachment != nil {
-		machineTag, err := names.ParseMachineTag(in.Attachment.MachineTag)
+	volumeAttachmentParams := make([]storage.VolumeAttachmentParams, 0, len(paramsResults))
+	for _, result := range paramsResults {
+		if result.Error != nil {
+			return errors.Annotate(err, "getting volume attachment parameters")
+		}
+		params, err := volumeAttachmentParamsFromParams(result.Result)
 		if err != nil {
-			return storage.VolumeParams{}, errors.Trace(err)
+			return errors.Annotate(err, "getting volume attachment parameters")
 		}
-		attachment = &storage.VolumeAttachmentParams{
-			AttachmentParams: storage.AttachmentParams{
-				Machine: machineTag,
-			},
-			Volume: volumeTag,
+		if params.VolumeId == "" || params.InstanceId == "" {
+			// Don't attempt to attach to volumes that haven't yet
+			// been provisioned.
+			//
+			// TODO(axw) we should store a set of pending attachments
+			// in the context, so that if when the volume is created
+			// the attachment isn't created with it, we can then try
+			// to attach.
+			continue
+		}
+		volumeAttachmentParams = append(volumeAttachmentParams, params)
+	}
+	volumeAttachments, err := createVolumeAttachments(
+		ctx.environConfig, ctx.storageDir, volumeAttachmentParams,
+	)
+	if err != nil {
+		return errors.Annotate(err, "creating volume attachments")
+	}
+	if err := setVolumeAttachmentInfo(ctx, volumeAttachments); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func setVolumeAttachmentInfo(ctx *context, volumeAttachments []params.VolumeAttachment) error {
+	if len(volumeAttachments) == 0 {
+		return nil
+	}
+	// TODO(axw) we need to be able to list volume attachments in the
+	// provider, by environment, so that we can "harvest" them if they're
+	// unknown. This will take care of killing volumes that we fail to
+	// record in state.
+	errorResults, err := ctx.volumes.SetVolumeAttachmentInfo(volumeAttachments)
+	if err != nil {
+		return errors.Annotate(err, "publishing volumes to state")
+	}
+	for i, result := range errorResults {
+		if result.Error != nil {
+			return errors.Annotatef(
+				result.Error, "publishing attachment of %s to %s to state",
+				volumeAttachments[i].VolumeTag,
+				volumeAttachments[i].MachineTag,
+			)
 		}
 	}
-	return storage.VolumeParams{
-		volumeTag,
-		in.Size,
-		storage.ProviderType(in.Provider),
-		in.Attributes,
-		attachment,
-	}, nil
+	return nil
 }
 
 // createVolumes creates volumes with the specified parameters.
@@ -222,44 +348,29 @@ func createVolumes(
 	baseStorageDir string,
 	params []storage.VolumeParams,
 ) ([]params.Volume, []params.VolumeAttachment, error) {
-	paramsByProvider := make(map[storage.ProviderType][]storage.VolumeParams)
-	for _, params := range params {
-		paramsByProvider[params.Provider] = append(paramsByProvider[params.Provider], params)
-	}
-	// TODO(axw) move this to the main storageprovisioner, and have it
-	// watch for changes to storage source configurations, updating
-	// a map in-between calls to the volume/filesystem/attachment
-	// event handlers.
+	// TODO(axw) later we may have multiple instantiations (sources)
+	// for a storage provider, e.g. multiple Ceph installations. For
+	// now we assume a single source for each provider type, with no
+	// configuration.
 	volumeSources := make(map[string]storage.VolumeSource)
-	for providerType := range paramsByProvider {
-		provider, err := registry.StorageProvider(providerType)
+	paramsBySource := make(map[string][]storage.VolumeParams)
+	for _, params := range params {
+		sourceName := string(params.Provider)
+		paramsBySource[sourceName] = append(paramsBySource[sourceName], params)
+		if _, ok := volumeSources[sourceName]; ok {
+			continue
+		}
+		volumeSource, err := volumeSource(
+			environConfig, baseStorageDir, sourceName, params.Provider,
+		)
 		if err != nil {
-			return nil, nil, errors.Annotatef(err, "getting storage provider %q", providerType)
+			return nil, nil, errors.Annotate(err, "getting volume source")
 		}
-		// TODO(axw) once we have storage source configuration separate
-		// from pools, we need to pass it in here.
-		sourceName := string(providerType)
-		attrs := make(map[string]interface{})
-		if baseStorageDir != "" {
-			storageDir := filepath.Join(baseStorageDir, sourceName)
-			attrs[storage.ConfigStorageDir] = storageDir
-		}
-		sourceConfig, err := storage.NewConfig(sourceName, providerType, attrs)
-		if err != nil {
-			return nil, nil, errors.Annotatef(err, "getting storage source %q config", sourceName)
-		}
-		source, err := provider.VolumeSource(environConfig, sourceConfig)
-		if err != nil {
-			return nil, nil, errors.Annotatef(err, "getting storage source %q", sourceName)
-		}
-		volumeSources[sourceName] = source
+		volumeSources[sourceName] = volumeSource
 	}
 	var allVolumes []storage.Volume
 	var allVolumeAttachments []storage.VolumeAttachment
-	for providerType, params := range paramsByProvider {
-		// TODO(axw) we should be returning source source names in the
-		// storage params, rather than provider types.
-		sourceName := string(providerType)
+	for sourceName, params := range paramsBySource {
 		volumeSource := volumeSources[sourceName]
 		volumes, volumeAttachments, err := volumeSource.CreateVolumes(params)
 		if err != nil {
@@ -268,11 +379,52 @@ func createVolumes(
 		allVolumes = append(allVolumes, volumes...)
 		allVolumeAttachments = append(allVolumeAttachments, volumeAttachments...)
 	}
-	// TODO(axw) translate volumes/attachments to params
 	return volumesFromStorage(allVolumes), volumeAttachmentsFromStorage(allVolumeAttachments), nil
 }
 
+// createVolumes creates volumes with the specified parameters.
+func createVolumeAttachments(
+	environConfig *config.Config,
+	baseStorageDir string,
+	params []storage.VolumeAttachmentParams,
+) ([]params.VolumeAttachment, error) {
+	// TODO(axw) later we may have multiple instantiations (sources)
+	// for a storage provider, e.g. multiple Ceph installations. For
+	// now we assume a single source for each provider type, with no
+	// configuration.
+	volumeSources := make(map[string]storage.VolumeSource)
+	paramsBySource := make(map[string][]storage.VolumeAttachmentParams)
+	for _, params := range params {
+		sourceName := string(params.Provider)
+		paramsBySource[sourceName] = append(paramsBySource[sourceName], params)
+		if _, ok := volumeSources[sourceName]; ok {
+			continue
+		}
+		volumeSource, err := volumeSource(
+			environConfig, baseStorageDir, sourceName, params.Provider,
+		)
+		if err != nil {
+			return nil, errors.Annotate(err, "getting volume source")
+		}
+		volumeSources[sourceName] = volumeSource
+	}
+	var allVolumeAttachments []storage.VolumeAttachment
+	for sourceName, params := range paramsBySource {
+		volumeSource := volumeSources[sourceName]
+		volumeAttachments, err := volumeSource.AttachVolumes(params)
+		if err != nil {
+			return nil, errors.Annotatef(err, "attaching volumes from source %q", sourceName)
+		}
+		allVolumeAttachments = append(allVolumeAttachments, volumeAttachments...)
+	}
+	return volumeAttachmentsFromStorage(allVolumeAttachments), nil
+}
+
 func destroyVolumes(volumes []params.Volume) ([]error, error) {
+	panic("not implemented")
+}
+
+func detachVolumes(attachments []params.VolumeAttachment) ([]error, error) {
 	panic("not implemented")
 }
 
@@ -301,4 +453,75 @@ func volumeAttachmentsFromStorage(in []storage.VolumeAttachment) []params.Volume
 		}
 	}
 	return out
+}
+
+func volumeParamsFromParams(in params.VolumeParams) (storage.VolumeParams, error) {
+	volumeTag, err := names.ParseVolumeTag(in.VolumeTag)
+	if err != nil {
+		return storage.VolumeParams{}, errors.Trace(err)
+	}
+	providerType := storage.ProviderType(in.Provider)
+
+	var attachment *storage.VolumeAttachmentParams
+	if in.Attachment != nil {
+		if in.Attachment.Provider != in.Provider {
+			return storage.VolumeParams{}, errors.Errorf(
+				"storage provider mismatch: volume (%q), attachment (%q)",
+				in.Provider, in.Attachment.Provider,
+			)
+		}
+		if in.Attachment.VolumeTag != in.VolumeTag {
+			return storage.VolumeParams{}, errors.Errorf(
+				"volume tag mismatch: volume (%q), attachment (%q)",
+				in.VolumeTag, in.Attachment.VolumeTag,
+			)
+		}
+		if in.Attachment.VolumeId != "" {
+			return storage.VolumeParams{}, errors.Errorf(
+				"unexpected volume ID %q in attachment params",
+				in.Attachment.VolumeId,
+			)
+		}
+		machineTag, err := names.ParseMachineTag(in.Attachment.MachineTag)
+		if err != nil {
+			return storage.VolumeParams{}, errors.Annotate(
+				err, "parsing attachment machine tag",
+			)
+		}
+		attachment = &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				Provider:   providerType,
+				Machine:    machineTag,
+				InstanceId: instance.Id(in.Attachment.InstanceId),
+			},
+			Volume: volumeTag,
+		}
+	}
+	return storage.VolumeParams{
+		volumeTag,
+		in.Size,
+		providerType,
+		in.Attributes,
+		attachment,
+	}, nil
+}
+
+func volumeAttachmentParamsFromParams(in params.VolumeAttachmentParams) (storage.VolumeAttachmentParams, error) {
+	machineTag, err := names.ParseMachineTag(in.MachineTag)
+	if err != nil {
+		return storage.VolumeAttachmentParams{}, errors.Trace(err)
+	}
+	volumeTag, err := names.ParseVolumeTag(in.VolumeTag)
+	if err != nil {
+		return storage.VolumeAttachmentParams{}, errors.Trace(err)
+	}
+	return storage.VolumeAttachmentParams{
+		AttachmentParams: storage.AttachmentParams{
+			Provider:   storage.ProviderType(in.Provider),
+			Machine:    machineTag,
+			InstanceId: instance.Id(in.InstanceId),
+		},
+		Volume:   volumeTag,
+		VolumeId: in.VolumeId,
+	}, nil
 }


### PR DESCRIPTION
The storage provisioner worker is updated to
watch volume attachments, and respond to their
lifecycle changes. The machine storage provisioner
is now enabled, but the environ storage provisioner
remains disabled until the dynamic-storage branch
lands and we can update the storage provisioner
to ignore non-dynamic storage.

(Review request: http://reviews.vapour.ws/r/1196/)