### PR TITLE
state: set FilesystemInfo from VolumeInfo

### DIFF
--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -459,7 +459,7 @@ func (st *State) SetFilesystemInfo(tag names.FilesystemTag, info FilesystemInfo)
 				return nil, err
 			}
 			if err := validateFilesystemInfoChange(info, oldInfo); err != nil {
-				return nil, errors.Annotate(err, "validating info change")
+				return nil, err
 			}
 		}
 		ops := setFilesystemInfoOps(tag, info, unsetParams)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -98,7 +98,7 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoImmutable(c *gc.C) {
 	// either. Callers are expected to get the existing info and
 	// update it, leaving immutable values intact.
 	err = s.State.SetFilesystemInfo(filesystem.FilesystemTag(), filesystemInfoSet)
-	c.Assert(err, gc.ErrorMatches, `cannot set info for filesystem "0/0": validating info change: cannot change pool from "loop-pool" to ""`)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for filesystem "0/0": cannot change pool from "loop-pool" to ""`)
 
 	filesystemInfoSet.Pool = "loop-pool"
 	s.assertFilesystemInfo(c, filesystemTag, filesystemInfoSet)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -46,7 +46,79 @@ func (s *FilesystemStateSuite) TestAddFilesystemWithBackingVolume(c *gc.C) {
 	s.addUnitWithFilesystem(c, "loop", true)
 }
 
-func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withVolume bool) {
+func (s *FilesystemStateSuite) TestSetVolumeInfoSetsFilesystemInfo(c *gc.C) {
+	filesystemAttachment := s.addUnitWithFilesystem(c, "loop", true)
+	filesystem, err := s.State.Filesystem(filesystemAttachment.Filesystem())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = filesystem.Info()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+
+	volumeTag, err := filesystem.Volume()
+	c.Assert(err, jc.ErrorIsNil)
+	volume, err := s.State.Volume(volumeTag)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = volume.Info()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+
+	// Set the volume's info multiple times; each time we should update
+	// the info of the filesystem on the volume.
+	for _, size := range []uint64{1024, 2048} {
+		err := s.State.SetVolumeInfo(volumeTag, state.VolumeInfo{
+			Size:     size,
+			Pool:     "loop",
+			VolumeId: "vol-123",
+		})
+		c.Assert(err, jc.ErrorIsNil)
+
+		filesystem, err := s.State.Filesystem(filesystem.FilesystemTag())
+		c.Assert(err, jc.ErrorIsNil)
+		filesystemInfo, err := filesystem.Info()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(filesystemInfo, gc.Equals, state.FilesystemInfo{
+			Size: size,
+			Pool: "loop",
+		})
+	}
+}
+
+func (s *FilesystemStateSuite) TestSetFilesystemInfoImmutable(c *gc.C) {
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "loop-pool")
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+	filesystem, err := s.State.StorageInstanceFilesystem(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	filesystemTag := filesystem.FilesystemTag()
+
+	filesystemInfoSet := state.FilesystemInfo{Size: 123}
+	err = s.State.SetFilesystemInfo(filesystem.FilesystemTag(), filesystemInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The first call to SetFilesystemInfo takes the pool name from
+	// the params; the second does not, but it must not change
+	// either. Callers are expected to get the existing info and
+	// update it, leaving immutable values intact.
+	err = s.State.SetFilesystemInfo(filesystem.FilesystemTag(), filesystemInfoSet)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for filesystem "0/0": validating info change: cannot change pool from "loop-pool" to ""`)
+
+	filesystemInfoSet.Pool = "loop-pool"
+	s.assertFilesystemInfo(c, filesystemTag, filesystemInfoSet)
+}
+
+func (s *FilesystemStateSuite) TestVolumeFilesystem(c *gc.C) {
+	filesystemAttachment := s.addUnitWithFilesystem(c, "loop", true)
+	filesystem, err := s.State.Filesystem(filesystemAttachment.Filesystem())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = filesystem.Info()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+
+	volumeTag, err := filesystem.Volume()
+	c.Assert(err, jc.ErrorIsNil)
+	filesystem, err = s.State.VolumeFilesystem(volumeTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystem.FilesystemTag(), gc.Equals, filesystemAttachment.Filesystem())
+}
+
+func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withVolume bool) state.FilesystemAttachment {
 	ch := s.AddTestingCharm(c, "storage-filesystem")
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(pool, 1024, 1),
@@ -105,8 +177,9 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 	_, ok = filesystemAttachments[0].Params()
 	c.Assert(ok, jc.IsTrue)
 
-	_, err = s.State.FilesystemAttachment(machine.MachineTag(), filesystem.FilesystemTag())
+	att, err := s.State.FilesystemAttachment(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
+	return att
 }
 
 func (s *FilesystemStateSuite) TestWatchFilesystemAttachment(c *gc.C) {

--- a/state/volume.go
+++ b/state/volume.go
@@ -507,7 +507,7 @@ func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error)
 				return nil, err
 			}
 			if err := validateVolumeInfoChange(info, oldInfo); err != nil {
-				return nil, errors.Annotate(err, "validating info change")
+				return nil, err
 			}
 		}
 		ops := setVolumeInfoOps(tag, info, unsetParams)

--- a/state/volume.go
+++ b/state/volume.go
@@ -500,11 +500,57 @@ func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error)
 		if params, ok := v.Params(); ok {
 			info.Pool = params.Pool
 			unsetParams = true
+		} else {
+			// Ensure immutable properties do not change.
+			oldInfo, err := v.Info()
+			if err != nil {
+				return nil, err
+			}
+			if err := validateVolumeInfoChange(info, oldInfo); err != nil {
+				return nil, errors.Annotate(err, "validating info change")
+			}
 		}
 		ops := setVolumeInfoOps(tag, info, unsetParams)
+
+		// If there's a filesystem destined for the volume,
+		// set the filesystem info.
+		f, err := st.VolumeFilesystem(tag)
+		if err == nil {
+			filesystemInfo := FilesystemInfo{
+				info.Size,
+				info.Pool,
+				// FilesystemId is set to "" for
+				// filesystems backed by volumes.
+				"",
+			}
+			filesystemOps := setFilesystemInfoOps(
+				f.FilesystemTag(),
+				filesystemInfo,
+				unsetParams,
+			)
+			ops = append(ops, filesystemOps...)
+		} else if !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
 		return ops, nil
 	}
 	return st.run(buildTxn)
+}
+
+func validateVolumeInfoChange(newInfo, oldInfo VolumeInfo) error {
+	if newInfo.Pool != oldInfo.Pool {
+		return errors.Errorf(
+			"cannot change pool from %q to %q",
+			oldInfo.Pool, newInfo.Pool,
+		)
+	}
+	if newInfo.VolumeId != oldInfo.VolumeId {
+		return errors.Errorf(
+			"cannot change volume ID from %q to %q",
+			oldInfo.VolumeId, newInfo.VolumeId,
+		)
+	}
+	return nil
 }
 
 func setVolumeInfoOps(tag names.VolumeTag, info VolumeInfo, unsetParams bool) []txn.Op {

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -196,7 +196,7 @@ func (s *VolumeStateSuite) TestSetVolumeInfoImmutable(c *gc.C) {
 	// either. Callers are expected to get the existing info and
 	// update it, leaving immutable values intact.
 	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
-	c.Assert(err, gc.ErrorMatches, `cannot set info for volume "0/0": validating info change: cannot change pool from "loop-pool" to ""`)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for volume "0/0": cannot change pool from "loop-pool" to ""`)
 
 	volumeInfoSet.Pool = "loop-pool"
 	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -179,6 +179,29 @@ func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
 	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
 }
 
+func (s *VolumeStateSuite) TestSetVolumeInfoImmutable(c *gc.C) {
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+	volume, err := s.State.StorageInstanceVolume(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	volumeTag := volume.VolumeTag()
+
+	volumeInfoSet := state.VolumeInfo{Size: 123}
+	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The first call to SetVolumeInfo takes the pool name from
+	// the params; the second does not, but it must not change
+	// either. Callers are expected to get the existing info and
+	// update it, leaving immutable values intact.
+	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for volume "0/0": validating info change: cannot change pool from "loop-pool" to ""`)
+
+	volumeInfoSet.Pool = "loop-pool"
+	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
+}
+
 func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)


### PR DESCRIPTION
When setting the VolumeInfo for a volume that
backs a filesystem, set the corresponding
filesystem's FilesystemInfo.

Also, update SetVolumeInfo and SetFilesystemInfo
to validate changes to info after the initial
update, so we can catch attempts to change
immutable values.

(Review request: http://reviews.vapour.ws/r/1198/)