### PR TITLE
metricsender/testing: New package that contains senders used in testing

### DIFF
--- a/apiserver/metricsender/metricsender_test.go
+++ b/apiserver/metricsender/metricsender_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/metricsender"
+	"github.com/juju/juju/apiserver/metricsender/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
@@ -22,7 +23,7 @@ type MetricSenderSuite struct {
 
 var _ = gc.Suite(&MetricSenderSuite{})
 
-var _ metricsender.MetricSender = (*metricsender.MockSender)(nil)
+var _ metricsender.MetricSender = (*testing.MockSender)(nil)
 
 var _ metricsender.MetricSender = (*metricsender.NopSender)(nil)
 
@@ -37,7 +38,7 @@ func (s *MetricSenderSuite) SetUpTest(c *gc.C) {
 // and checks that the 2 unsent metrics get sent and have their
 // sent field set to true.
 func (s *MetricSenderSuite) TestSendMetrics(c *gc.C) {
-	var sender metricsender.MockSender
+	var sender testing.MockSender
 	now := time.Now()
 	unsent1 := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Time: &now})
 	unsent2 := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Time: &now})
@@ -61,7 +62,7 @@ func (s *MetricSenderSuite) TestSendMetrics(c *gc.C) {
 // to send batches of 10 metrics. If we create 100 metrics 10 calls
 // will be made to the sender
 func (s *MetricSenderSuite) TestSendBulkMetrics(c *gc.C) {
-	var sender metricsender.MockSender
+	var sender testing.MockSender
 	now := time.Now()
 	for i := 0; i < 100; i++ {
 		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Time: &now})

--- a/apiserver/metricsender/testing/mocksender.go
+++ b/apiserver/metricsender/testing/mocksender.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package metricsender
+package testing
 
 import (
 	"github.com/juju/utils"

--- a/apiserver/metricsmanager/metricsmanager_test.go
+++ b/apiserver/metricsmanager/metricsmanager_test.go
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/metricsender"
+	"github.com/juju/juju/apiserver/metricsender/testing"
 	"github.com/juju/juju/apiserver/metricsmanager"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -117,7 +117,7 @@ func (s *metricsManagerSuite) TestCleanupArgsIndependent(c *gc.C) {
 }
 
 func (s *metricsManagerSuite) TestSendMetrics(c *gc.C) {
-	var sender metricsender.MockSender
+	var sender testing.MockSender
 	metricsmanager.PatchSender(&sender)
 	now := time.Now()
 	metric := state.Metric{"pings", "5", now}
@@ -161,7 +161,7 @@ func (s *metricsManagerSuite) TestSendArgsIndependent(c *gc.C) {
 }
 
 func (s *metricsManagerSuite) TestMeterStatusOnConsecutiveErrors(c *gc.C) {
-	var sender metricsender.ErrorSender
+	var sender testing.ErrorSender
 	sender.Err = errors.New("an error")
 	now := time.Now()
 	metric := state.Metric{"pings", "5", now}
@@ -180,7 +180,7 @@ func (s *metricsManagerSuite) TestMeterStatusOnConsecutiveErrors(c *gc.C) {
 }
 
 func (s *metricsManagerSuite) TestMeterStatusSuccessfulSend(c *gc.C) {
-	var sender metricsender.MockSender
+	var sender testing.MockSender
 	pastTime := time.Now().Add(-time.Second)
 	metric := state.Metric{"pings", "5", pastTime}
 	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &pastTime, Metrics: []state.Metric{metric}})
@@ -197,7 +197,7 @@ func (s *metricsManagerSuite) TestMeterStatusSuccessfulSend(c *gc.C) {
 }
 
 func (s *metricsManagerSuite) TestLastSuccessfulNotChangedIfNothingToSend(c *gc.C) {
-	var sender metricsender.MockSender
+	var sender testing.MockSender
 	metricsmanager.PatchSender(&sender)
 	args := params.Entities{Entities: []params.Entity{
 		{s.State.EnvironTag().String()},


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/1201/)