### PR TITLE
Add a systemd test for containers/lxc.shutdownInitCommands.

### DIFF
--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -77,11 +77,11 @@ func templateUserData(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	script, err := shutdownInitScript(initSystem)
+	cmds, err := shutdownInitCommands(initSystem)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	config.AddScripts(script)
+	config.AddScripts(strings.Join(cmds, "\n"))
 
 	renderer, err := corecloudinit.NewRenderer(series)
 	if err != nil {
@@ -126,7 +126,7 @@ auto eth0
 iface eth0 inet dhcp
 `
 
-func shutdownInitScript(initSystem string) (string, error) {
+func shutdownInitCommands(initSystem string) ([]string, error) {
 	// These files are removed just before the template shuts down.
 	cleanupOnShutdown := []string{
 		// We remove any dhclient lease files so there's no chance a
@@ -160,15 +160,14 @@ func shutdownInitScript(initSystem string) (string, error) {
 	}
 	svc, err := service.NewService(name, conf, initSystem)
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	cmds, err := svc.InstallCommands()
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-
-	return strings.Join(cmds, "\n"), nil
+	return cmds, nil
 }
 
 func AcquireTemplateLock(name, message string) (*container.Lock, error) {

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -138,7 +138,6 @@ func shutdownInitCommands(initSystem string) ([]string, error) {
 		// from cloned containers will be appended. It's better to
 		// keep clean logs for diagnosing issues / debugging.
 		"/var/log/cloud-init*.log",
-		"/var/log/upstart/*.log",
 	}
 
 	// Using EOC below as the template shutdown script is itself

--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -21,7 +21,7 @@ var (
 	PreferFastLXC           = preferFastLXC
 	InitProcessCgroupFile   = &initProcessCgroupFile
 	RuntimeGOOS             = &runtimeGOOS
-	ShutdownInitScript      = shutdownInitScript
+	ShutdownInitCommands    = shutdownInitCommands
 )
 
 func GetCreateWithCloneValue(mgr container.Manager) bool {

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -829,7 +829,7 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
 EOC
-  /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log /var/log/upstart/*.log
+  /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now
 end script
 
@@ -871,7 +871,7 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
 EOC
-  /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log /var/log/upstart/*.log
+  /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now`[1:],
 	}
 	test.CheckCommands(c, commands)

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -232,7 +232,7 @@ echo 'Bootstrapping Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
-cat >> /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
+cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-0
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
 `,
@@ -336,7 +336,7 @@ install -m 600 /dev/null '/var/lib/juju/agents/machine-99/agent\.conf'
 printf '%s\\n' '.*' > '/var/lib/juju/agents/machine-99/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-99'
 echo 'Starting Juju machine agent \(jujud-machine-99\)'.*
-cat >> /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
+cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-99
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 `,
@@ -379,7 +379,7 @@ mkdir -p '/var/lib/juju/agents/machine-2-lxc-1'
 install -m 600 /dev/null '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf'
 printf '%s\\n' '.*' > '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-2-lxc-1'
-cat >> /etc/init/jujud-machine-2-lxc-1\.conf << 'EOF'\\ndescription "juju agent for machine-2-lxc-1"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-2-lxc-1\.log\\n  chown syslog:syslog /var/log/juju/machine-2-lxc-1\.log\\n  chmod 0600 /var/log/juju/machine-2-lxc-1\.log\\n\\n  exec '/var/lib/juju/tools/machine-2-lxc-1/jujud' machine --data-dir '/var/lib/juju' --machine-id 2/lxc/1 --debug >> /var/log/juju/machine-2-lxc-1\.log 2>&1\\nend script\\nEOF\\n
+cat > /etc/init/jujud-machine-2-lxc-1\.conf << 'EOF'\\ndescription "juju agent for machine-2-lxc-1"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-2-lxc-1\.log\\n  chown syslog:syslog /var/log/juju/machine-2-lxc-1\.log\\n  chmod 0600 /var/log/juju/machine-2-lxc-1\.log\\n\\n  exec '/var/lib/juju/tools/machine-2-lxc-1/jujud' machine --data-dir '/var/lib/juju' --machine-id 2/lxc/1 --debug >> /var/log/juju/machine-2-lxc-1\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-2-lxc-1
 `,
 	}, {

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -7,8 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
@@ -789,64 +787,18 @@ func (s *initSystemSuite) TestInstallEmptyConf(c *gc.C) {
 
 func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
 	name := "jujud-machine-0"
-	s.dataDir = "/tmp/"
+	s.dataDir = "/tmp"
 	s.service.Dirname = "/tmp/init/jujud-machine-0"
 
 	commands, err := s.service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Check the write-conf command.
-	expected := s.newConfStr(name, "")
-	s.checkWriteConf(c, name, commands[1], expected)
-
-	// Check the remaining commands.
-	c.Check(commands[0], gc.Equals, "mkdir -p /tmp/init/jujud-machine-0")
-	c.Check(commands[2:], jc.DeepEquals, []string{
-		"/bin/systemctl link /tmp/init/jujud-machine-0/jujud-machine-0.service",
-		"/bin/systemctl daemon-reload",
-		"/bin/systemctl enable /tmp/init/jujud-machine-0/jujud-machine-0.service",
-	})
-}
-
-func (s *initSystemSuite) checkWriteConf(c *gc.C, name, cmd, expected string) (string, string) {
-	// This check must be done without regard to map order.
-
-	dirname := filepath.Join(s.dataDir, "init", name)
-	unitFile := filepath.Join(dirname, name+".service")
-
-	parse := func(lines []string) interface{} {
-		return parseConfSections(lines)
+	test := systemd.WriteConfTest{
+		Service:  name,
+		DataDir:  s.dataDir,
+		Expected: s.newConfStr(name, ""),
 	}
-	coretesting.CheckWriteFileCommand(c, cmd, unitFile, expected, parse)
-
-	return dirname, unitFile
-}
-
-// parseConfSections is a poor man's ini parser.
-func parseConfSections(lines []string) map[string][]string {
-	sections := make(map[string][]string)
-
-	var section string
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			if section != "" {
-				sort.Strings(sections[section])
-			}
-			section = line[1 : len(line)-1]
-			sections[section] = nil
-		} else {
-			sections[section] = append(sections[section], line)
-		}
-	}
-	if section != "" {
-		sort.Strings(sections[section])
-	}
-
-	return sections
+	test.CheckCommands(c, commands)
 }
 
 func (s *initSystemSuite) TestInstallCommandsLogfile(c *gc.C) {
@@ -860,18 +812,15 @@ func (s *initSystemSuite) TestInstallCommandsLogfile(c *gc.C) {
 	commands, err := service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Check the write-conf command.
-	expected := strings.Replace(
-		s.newConfStr(name, ""),
-		"ExecStart=/var/lib/juju/bin/jujud machine-0",
-		"ExecStart=/tmp/init/jujud-machine-0/exec-start.sh",
-		-1)
-	s.checkWriteConf(c, name, commands[3], expected)
-
-	// Check the remaining commands.
-	c.Check(commands[0], gc.Equals, "mkdir -p /tmp/init/jujud-machine-0")
-	c.Check(strings.Split(commands[1], "\n"), jc.DeepEquals, strings.Split(`
-cat > /tmp/init/jujud-machine-0/exec-start.sh << 'EOF'
+	test := systemd.WriteConfTest{
+		Service: name,
+		DataDir: s.dataDir,
+		Expected: strings.Replace(
+			s.newConfStr(name, ""),
+			"ExecStart=/var/lib/juju/bin/jujud machine-0",
+			"ExecStart=/tmp/init/jujud-machine-0/exec-start.sh",
+			-1),
+		Script: `
 #!/bin/bash
 
 touch /var/log/juju/machine-0.log
@@ -879,14 +828,9 @@ chown syslog:syslog /var/log/juju/machine-0.log
 chmod 0600 /var/log/juju/machine-0.log
 exec > /var/log/juju/machine-0.log
 exec 2>&1
-/var/lib/juju/bin/jujud machine-0
-EOF`[1:], "\n"))
-	c.Check(commands[2], gc.Equals, "chmod 0755 /tmp/init/jujud-machine-0/exec-start.sh")
-	c.Check(commands[4:], jc.DeepEquals, []string{
-		"/bin/systemctl link /tmp/init/jujud-machine-0/jujud-machine-0.service",
-		"/bin/systemctl daemon-reload",
-		"/bin/systemctl enable /tmp/init/jujud-machine-0/jujud-machine-0.service",
-	})
+/var/lib/juju/bin/jujud machine-0`[1:],
+	}
+	test.CheckCommands(c, commands)
 }
 
 func (s *initSystemSuite) TestInstallCommandsShutdown(c *gc.C) {
@@ -901,8 +845,10 @@ func (s *initSystemSuite) TestInstallCommandsShutdown(c *gc.C) {
 	commands, err := svc.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Check the write-conf command.
-	s.checkWriteConf(c, name, commands[1], `
+	test := systemd.WriteConfTest{
+		Service: name,
+		DataDir: s.dataDir,
+		Expected: `
 [Unit]
 Description=juju shutdown job
 After=syslog.target
@@ -914,15 +860,9 @@ Conflicts=cloud-final
 [Service]
 ExecStart=/sbin/shutdown -h now
 ExecStopPost=/bin/systemctl disable juju-shutdown-job.service
-`[1:])
-
-	// Check the remaining commands.
-	c.Check(commands[0], gc.Equals, "mkdir -p /tmp/init/juju-shutdown-job")
-	c.Check(commands[2:], jc.DeepEquals, []string{
-		"/bin/systemctl link /tmp/init/juju-shutdown-job/juju-shutdown-job.service",
-		"/bin/systemctl daemon-reload",
-		"/bin/systemctl enable /tmp/init/juju-shutdown-job/juju-shutdown-job.service",
-	})
+`[1:],
+	}
+	test.CheckCommands(c, commands)
 }
 
 func (s *initSystemSuite) TestInstallCommandsEmptyConf(c *gc.C) {

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -814,19 +814,10 @@ func (s *initSystemSuite) checkWriteConf(c *gc.C, name, cmd, expected string) (s
 	dirname := filepath.Join(s.dataDir, "init", name)
 	unitFile := filepath.Join(dirname, name+".service")
 
-	cmd = strings.TrimSpace(cmd)
-	lines := strings.Split(cmd, "\n")
-	header := lines[0]
-	footer := lines[len(lines)-1]
-	sections := parseConfSections(lines[1 : len(lines)-1])
-
-	// Check the cat portion.
-	c.Check(header, gc.Equals, "cat > "+unitFile+" << 'EOF'")
-	c.Check(footer, gc.Equals, "EOF")
-
-	// Check the conf portion.
-	expectedSections := parseConfSections(strings.Split(expected, "\n"))
-	c.Check(sections, jc.DeepEquals, expectedSections)
+	parse := func(lines []string) interface{} {
+		return parseConfSections(lines)
+	}
+	coretesting.CheckWriteFileCommand(c, cmd, unitFile, expected, parse)
 
 	return dirname, unitFile
 }

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -821,8 +821,6 @@ func (s *initSystemSuite) TestInstallCommandsLogfile(c *gc.C) {
 			"ExecStart=/tmp/init/jujud-machine-0/exec-start.sh",
 			-1),
 		Script: `
-#!/bin/bash
-
 touch /var/log/juju/machine-0.log
 chown syslog:syslog /var/log/juju/machine-0.log
 chmod 0600 /var/log/juju/machine-0.log

--- a/service/systemd/testing.go
+++ b/service/systemd/testing.go
@@ -1,0 +1,98 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+// WriteConfTest is used in tests to verify that the shell commands
+// to write a service conf to disk are correct.
+type WriteConfTest struct {
+	Service  string
+	DataDir  string
+	Expected string
+	Script   string
+}
+
+func (wct WriteConfTest) dirname() string {
+	return fmt.Sprintf("%s/init/%s", wct.DataDir, wct.Service)
+}
+
+func (wct WriteConfTest) filename() string {
+	return fmt.Sprintf("%[1]s/init/%[2]s/%[2]s.service", wct.DataDir, wct.Service)
+}
+
+func (wct WriteConfTest) scriptname() string {
+	return fmt.Sprintf("%s/init/%s/exec-start.sh", wct.DataDir, wct.Service)
+}
+
+// CheckCommands checks the given commands against the test's expectations.
+func (wct WriteConfTest) CheckCommands(c *gc.C, commands []string) {
+	c.Check(commands[0], gc.Equals, "mkdir -p "+wct.dirname())
+	commands = commands[1:]
+	if wct.Script != "" {
+		wct.checkWriteExecScript(c, commands[:2])
+		commands = commands[2:]
+	}
+	wct.checkWriteConf(c, commands)
+}
+
+func (wct WriteConfTest) checkWriteExecScript(c *gc.C, commands []string) {
+	testing.CheckWriteFileCommand(c, commands[0], wct.scriptname(), wct.Script, nil)
+
+	// Check the remaining commands.
+	c.Check(commands[1:], jc.DeepEquals, []string{
+		"chmod 0755 " + wct.scriptname(),
+	})
+}
+
+func (wct WriteConfTest) checkWriteConf(c *gc.C, commands []string) {
+	// This check must be done without regard to map order.
+	parse := func(lines []string) interface{} {
+		return parseConfSections(lines)
+	}
+	testing.CheckWriteFileCommand(c, commands[0], wct.filename(), wct.Expected, parse)
+
+	// Check the remaining commands.
+	c.Check(commands[1:], jc.DeepEquals, []string{
+		"/bin/systemctl link " + wct.filename(),
+		"/bin/systemctl daemon-reload",
+		"/bin/systemctl enable " + wct.filename(),
+	})
+}
+
+// parseConfSections is a poor man's ini parser.
+func parseConfSections(lines []string) map[string][]string {
+	sections := make(map[string][]string)
+
+	var section string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			if section != "" {
+				sort.Strings(sections[section])
+			}
+			section = line[1 : len(line)-1]
+			sections[section] = nil
+		} else {
+			sections[section] = append(sections[section], line)
+		}
+	}
+	if section != "" {
+		sort.Strings(sections[section])
+	}
+
+	return sections
+}

--- a/service/systemd/testing.go
+++ b/service/systemd/testing.go
@@ -47,7 +47,8 @@ func (wct WriteConfTest) CheckCommands(c *gc.C, commands []string) {
 }
 
 func (wct WriteConfTest) checkWriteExecScript(c *gc.C, commands []string) {
-	testing.CheckWriteFileCommand(c, commands[0], wct.scriptname(), wct.Script, nil)
+	script := "#!/bin/bash\n\n" + wct.Script
+	testing.CheckWriteFileCommand(c, commands[0], wct.scriptname(), script, nil)
 
 	// Check the remaining commands.
 	c.Check(commands[1:], jc.DeepEquals, []string{

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -270,7 +270,7 @@ func (s *Service) InstallCommands() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmd := fmt.Sprintf("cat >> %s << 'EOF'\n%sEOF\n", s.confPath(), conf)
+	cmd := fmt.Sprintf("cat > %s << 'EOF'\n%sEOF\n", s.confPath(), conf)
 	return []string{cmd}, nil
 }
 

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -235,7 +235,7 @@ func (s *UpstartSuite) assertInstall(c *gc.C, conf common.Conf, expectEnd string
 	cmds, err := s.service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmds, gc.DeepEquals, []string{
-		"cat >> " + expectPath + " << 'EOF'\n" + expectContent + "EOF\n",
+		"cat > " + expectPath + " << 'EOF'\n" + expectContent + "EOF\n",
 	})
 	cmds, err = s.service.StartCommands()
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/shell.go
+++ b/testing/shell.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+// CheckWriteFileCommand verifies that the given shell command
+// correctly writes the expected content to the given filename. The
+// provided parse function decomposes file content into structured data
+// that may be correctly compared regardless of ordering within the
+// content. If parse is nil then the content lines are used un-parsed.
+func CheckWriteFileCommand(c *gc.C, cmd, filename, expected string, parse func(lines []string) interface{}) {
+	if parse == nil {
+		parse = func(lines []string) interface{} {
+			return lines
+		}
+	}
+
+	lines := strings.Split(cmd, "\n")
+	header := lines[0]
+	footer := lines[len(lines)-1]
+	parsed := parse(lines[1 : len(lines)-1])
+
+	// Check the cat portion.
+	c.Check(header, gc.Equals, "cat > "+filename+" << 'EOF'")
+	c.Check(footer, gc.Equals, "EOF")
+
+	// Check the conf portion.
+	expectedParsed := parse(strings.Split(expected, "\n"))
+	c.Check(parsed, jc.DeepEquals, expectedParsed)
+}

--- a/testing/shell.go
+++ b/testing/shell.go
@@ -22,7 +22,7 @@ func CheckWriteFileCommand(c *gc.C, cmd, filename, expected string, parse func(l
 		}
 	}
 
-	lines := strings.Split(cmd, "\n")
+	lines := strings.Split(strings.TrimSpace(cmd), "\n")
 	header := lines[0]
 	footer := lines[len(lines)-1]
 	parsed := parse(lines[1 : len(lines)-1])


### PR DESCRIPTION
This will ensure that shell commands for the shutdown job are correctly generated under systemd.

(Review request: http://reviews.vapour.ws/r/1203/)