### PR TITLE
Use ps instead of /proc to get the init system executable.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -205,7 +205,7 @@ function checkInitSystem() {
 }
 
 # Find the executable.
-executable=$(cat /proc/1/cmdline | awk -F"\0" '{print $1}')
+executable=$(ps -p 1 -o cmd --no-headers | awk '{print $1}')
 if [[ $? -ne 0 ]]; then
     exit 1
 fi

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -96,27 +94,21 @@ func versionInitSystem(vers version.Binary) (string, bool) {
 	}
 }
 
-// pid1 is the path to the "file" that contains the path to the init
-// system executable on linux.
-const pid1 = "/proc/1/cmdline"
-
 // These exist to allow patching during tests.
 var (
 	runtimeOS    = func() string { return runtime.GOOS }
-	pid1Filename = func() string { return pid1 }
 	evalSymlinks = filepath.EvalSymlinks
+	psPID1       = func() ([]byte, error) {
+		cmd := exec.Command("/bin/ps", "-p", "1", "-o", "cmd", "--no-headers")
+		return cmd.Output()
+	}
 
 	initExecutable = func() (string, error) {
-		pid1File := pid1Filename()
-		data, err := ioutil.ReadFile(pid1File)
-		if os.IsNotExist(err) {
-			return "", errors.NotFoundf("init system (via %q)", pid1File)
-		}
+		psOutput, err := psPID1()
 		if err != nil {
-			return "", errors.Annotatef(err, "failed to identify init system (via %q)", pid1File)
+			return "", errors.Annotate(err, "failed to identify init system using ps")
 		}
-		executable := strings.Split(string(data), "\x00")[0]
-		return executable, nil
+		return strings.Fields(string(psOutput))[0], nil
 	}
 )
 

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -367,7 +367,6 @@ func (s *discoverySuite) TestNewShellSelectCommand(c *gc.C) {
 	}
 	script += "init_system=$(" + filename + ")\n"
 	script += service.NewShellSelectCommand("init_system", handler)
-	c.Logf(script)
 	response, err := exec.RunCommands(exec.RunParams{
 		Commands: script,
 	})

--- a/service/testing_test.go
+++ b/service/testing_test.go
@@ -24,12 +24,12 @@ import (
 type Stub struct {
 	*testing.Stub
 
-	Version      version.Binary
-	GOOS         string
-	PID1Filename string
-	Executable   string
-	Service      Service
-	NotASymlink  string
+	Version     version.Binary
+	GOOS        string
+	PSOutput    string
+	Executable  string
+	Service     Service
+	NotASymlink string
 }
 
 // GetVersion stubs out .
@@ -50,13 +50,11 @@ func (s *Stub) GetOS() string {
 	return s.GOOS
 }
 
-// GetPID1Filename stubs out /proc/1/cmdline.
-func (s *Stub) GetPID1Filename() string {
+// PsPid1 stubs out ps -p 1 ...
+func (s *Stub) PsPid1() ([]byte, error) {
 	s.AddCall("GetPID1Filename")
 
-	// Pop the next error off the queue, even though we don't use it.
-	s.NextErr()
-	return s.PID1Filename
+	return []byte(s.PSOutput), s.NextErr()
 }
 
 // GetInitSystemExecutable stubs out the contents of /proc/1/cmdline.
@@ -156,13 +154,8 @@ func (s *BaseSuite) PatchPid1File(c *gc.C, executable, verText string) string {
 		s.writeExecutable(c, exeName, verText)
 	}
 
-	// Now write the actual fake /proc/1/cmdline file.
-	filename := filepath.Join(s.Dirname, "pid1cmdline")
-	err := ioutil.WriteFile(filename, []byte(exeName), 0644)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.Patched.PID1Filename = filename
-	s.PatchValue(&pid1Filename, s.Patched.GetPID1Filename)
+	s.Patched.PSOutput = exeName
+	s.PatchValue(&psPID1, s.Patched.PsPid1)
 	return exeName
 }
 


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1433566)

Older versions of awk cannot handle the null character as a record separator.

(Review request: http://reviews.vapour.ws/r/1204/)