### PR TITLE
api: allow path & request headers to specified during Connect

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -4,6 +4,7 @@
 package api_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,13 +14,13 @@ import (
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/parallel"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
 
@@ -29,11 +30,51 @@ type apiclientSuite struct {
 
 var _ = gc.Suite(&apiclientSuite{})
 
-type websocketSuite struct {
-	coretesting.BaseSuite
+func (s *apiclientSuite) TestConnectToEnv(c *gc.C) {
+	info := s.APIInfo(c)
+	conn, err := api.Connect(info, "", nil, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer conn.Close()
+	assertConnAddrForEnv(c, conn, info.Addrs[0], s.State.EnvironUUID(), "/api")
 }
 
-var _ = gc.Suite(&websocketSuite{})
+func (s *apiclientSuite) TestConnectToEnvWithPathTail(c *gc.C) {
+	info := s.APIInfo(c)
+	conn, err := api.Connect(info, "/log", nil, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer conn.Close()
+	assertConnAddrForEnv(c, conn, info.Addrs[0], s.State.EnvironUUID(), "/log")
+}
+
+func (s *apiclientSuite) TestConnectToRoot(c *gc.C) {
+	info := s.APIInfo(c)
+	info.EnvironTag = names.NewEnvironTag("")
+	conn, err := api.Connect(info, "", nil, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer conn.Close()
+	assertConnAddrForRoot(c, conn, info.Addrs[0])
+}
+
+func (s *apiclientSuite) TestConnectWithHeader(c *gc.C) {
+	var seenCfg *websocket.Config
+	fakeNewDialer := func(cfg *websocket.Config, _ api.DialOpts) func(<-chan struct{}) (io.Closer, error) {
+		seenCfg = cfg
+		return func(<-chan struct{}) (io.Closer, error) {
+			return nil, errors.New("fake")
+		}
+	}
+	s.PatchValue(api.NewWebsocketDialerPtr, fakeNewDialer)
+
+	header := utils.BasicAuthHeader("foo", "bar")
+	api.Connect(s.APIInfo(c), "", header, api.DialOpts{}) // Return values not important here
+	c.Assert(seenCfg, gc.NotNil)
+	c.Assert(seenCfg.Header, gc.DeepEquals, header)
+}
+
+func (s *apiclientSuite) TestConnectRequiresTailStartsWithSlash(c *gc.C) {
+	_, err := api.Connect(s.APIInfo(c), "foo", nil, api.DialOpts{})
+	c.Assert(err, gc.ErrorMatches, `path tail must start with "/"`)
+}
 
 func (s *apiclientSuite) TestConnectPrefersLocalhostIfPresent(c *gc.C) {
 	// Create a socket that proxies to the API server though our localhost address.
@@ -66,10 +107,10 @@ func (s *apiclientSuite) TestConnectPrefersLocalhostIfPresent(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	expectedHostPort := fmt.Sprintf("localhost:%d", portNum)
 	info.Addrs = []string{"fakeAddress:1", "fakeAddress:1", expectedHostPort}
-	conn, err := api.Connect(info, api.DialOpts{})
+	conn, err := api.Connect(info, "/api", nil, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	assertConnAddr(c, conn, expectedHostPort)
+	assertConnAddrForEnv(c, conn, expectedHostPort, s.State.EnvironUUID(), "/api")
 }
 
 func (s *apiclientSuite) TestConnectMultiple(c *gc.C) {
@@ -96,19 +137,19 @@ func (s *apiclientSuite) TestConnectMultiple(c *gc.C) {
 	// Check that we can use the proxy to connect.
 	proxyAddr := listener.Addr().String()
 	info.Addrs = []string{proxyAddr}
-	conn, err := api.Connect(info, api.DialOpts{})
+	conn, err := api.Connect(info, "/api", nil, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
-	assertConnAddr(c, conn, proxyAddr)
+	assertConnAddrForEnv(c, conn, proxyAddr, s.State.EnvironUUID(), "/api")
 
 	// Now break Addrs[0], and ensure that Addrs[1]
 	// is successfully connected to.
 	info.Addrs = []string{proxyAddr, serverAddr}
 	listener.Close()
-	conn, err = api.Connect(info, api.DialOpts{})
+	conn, err = api.Connect(info, "/api", nil, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
-	assertConnAddr(c, conn, serverAddr)
+	assertConnAddrForEnv(c, conn, serverAddr, s.State.EnvironUUID(), "/api")
 }
 
 func (s *apiclientSuite) TestConnectMultipleError(c *gc.C) {
@@ -127,7 +168,7 @@ func (s *apiclientSuite) TestConnectMultipleError(c *gc.C) {
 	info := s.APIInfo(c)
 	addr := listener.Addr().String()
 	info.Addrs = []string{addr, addr, addr}
-	_, err = api.Connect(info, api.DialOpts{})
+	_, err = api.Connect(info, "/api", nil, api.DialOpts{})
 	c.Assert(err, gc.ErrorMatches, `unable to connect to "wss://.*/environment/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/api"`)
 }
 
@@ -147,10 +188,8 @@ func (s *apiclientSuite) TestOpen(c *gc.C) {
 	c.Assert(remoteVersion, gc.Equals, version.Current.Number)
 }
 
-func (s *apiclientSuite) TestOpenPassesEnvironTag(c *gc.C) {
+func (s *apiclientSuite) TestOpenHonorsEnvironTag(c *gc.C) {
 	info := s.APIInfo(c)
-	env, err := s.State.Environment()
-	c.Assert(err, jc.ErrorIsNil)
 
 	// TODO(jam): 2014-06-05 http://pad.lv/1326802
 	// we want to test this eventually, but for now s.APIInfo uses
@@ -160,12 +199,12 @@ func (s *apiclientSuite) TestOpenPassesEnvironTag(c *gc.C) {
 
 	// We start by ensuring we have an invalid tag, and Open should fail.
 	info.EnvironTag = names.NewEnvironTag("bad-tag")
-	_, err = api.Open(info, api.DialOpts{})
+	_, err := api.Open(info, api.DialOpts{})
 	c.Check(err, gc.ErrorMatches, `unknown environment: "bad-tag"`)
 	c.Check(params.ErrCode(err), gc.Equals, params.CodeNotFound)
 
 	// Now set it to the right tag, and we should succeed.
-	info.EnvironTag = env.EnvironTag()
+	info.EnvironTag = s.State.EnvironTag()
 	st, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
@@ -187,20 +226,10 @@ func (s *apiclientSuite) TestDialWebsocketStopped(c *gc.C) {
 	c.Assert(result, gc.IsNil)
 }
 
-func (*websocketSuite) TestSetUpWebsocketConfig(c *gc.C) {
-	conf, err := api.SetUpWebsocket("0.1.2.3:1234", "", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(conf.Location.String(), gc.Equals, "wss://0.1.2.3:1234/")
-	c.Check(conf.Origin.String(), gc.Equals, "http://localhost/")
+func assertConnAddrForEnv(c *gc.C, conn *websocket.Conn, addr, envUUID, tail string) {
+	c.Assert(conn.RemoteAddr(), gc.Matches, "^wss://"+addr+"/environment/"+envUUID+tail+"$")
 }
 
-func (*websocketSuite) TestSetUpWebsocketConfigHandlesEnvironUUID(c *gc.C) {
-	conf, err := api.SetUpWebsocket("0.1.2.3:1234", "dead-beef-1234", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(conf.Location.String(), gc.Equals, "wss://0.1.2.3:1234/environment/dead-beef-1234/api")
-	c.Check(conf.Origin.String(), gc.Equals, "http://localhost/")
-}
-
-func assertConnAddr(c *gc.C, conn *websocket.Conn, expectedAddr string) {
-	c.Assert(conn.RemoteAddr(), gc.Matches, "^wss://"+expectedAddr+"/.+")
+func assertConnAddrForRoot(c *gc.C, conn *websocket.Conn, addr string) {
+	c.Assert(conn.RemoteAddr(), gc.Matches, "^wss://"+addr+"/$")
 }

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 var (
-	NewWebsocketDialer  = newWebsocketDialer
-	WebsocketDialConfig = &websocketDialConfig
-	SetUpWebsocket      = setUpWebsocket
-	SlideAddressToFront = slideAddressToFront
-	BestVersion         = bestVersion
-	FacadeVersions      = &facadeVersions
-	NewHTTPClient       = &newHTTPClient
+	NewWebsocketDialer    = newWebsocketDialer
+	NewWebsocketDialerPtr = &newWebsocketDialer
+	WebsocketDialConfig   = &websocketDialConfig
+	SlideAddressToFront   = slideAddressToFront
+	BestVersion           = bestVersion
+	FacadeVersions        = &facadeVersions
+	NewHTTPClient         = &newHTTPClient
 )
 
 // SetServerRoot allows changing the URL to the internal API server


### PR DESCRIPTION
Further client API changes to support connections to the /log and /logsink APIs:

1. Connect now takes an optional API path tail and optional request headers to use when estalishing a websocket connection.

2. The API connection path is now calculated in just one place (the logic was across 2 funcs before).

3. Testing of API paths used during a connection is now down in every test, avoiding the need for the websocketSuite tests.

(Review request: http://reviews.vapour.ws/r/1207/)