### PR TITLE
storageprovisioner: apiserver-side filesystem bits

### DIFF
--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -4,9 +4,23 @@
 package common
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
+
+// FilesystemFromState converts a state.Filesystem to params.Filesystem.
+func FilesystemFromState(v state.Filesystem) (params.Filesystem, error) {
+	info, err := v.Info()
+	if err != nil {
+		return params.Filesystem{}, errors.Trace(err)
+	}
+	return params.Filesystem{
+		v.FilesystemTag().String(),
+		info.FilesystemId,
+		info.Size,
+	}, nil
+}
 
 // ParseFilesystemAttachmentIds parses the strings, returning machine storage IDs.
 func ParseFilesystemAttachmentIds(stringIds []string) ([]params.MachineStorageId, error) {

--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/poolmanager"
-	"github.com/juju/names"
 )
 
 type filesystemAlreadyProvisionedError struct {

--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -4,10 +4,47 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage/poolmanager"
 )
+
+type filesystemAlreadyProvisionedError struct {
+	error
+}
+
+// IsFilesystemAlreadyProvisioned returns true if the specified error
+// is caused by a filesystem already being provisioned.
+func IsFilesystemAlreadyProvisioned(err error) bool {
+	_, ok := err.(*filesystemAlreadyProvisionedError)
+	return ok
+}
+
+// FilesystemParams returns the parameters for creating the given filesystem.
+func FilesystemParams(v state.Filesystem, poolManager poolmanager.PoolManager) (params.FilesystemParams, error) {
+	stateFilesystemParams, ok := v.Params()
+	if !ok {
+		err := &filesystemAlreadyProvisionedError{fmt.Errorf(
+			"filesystem %q is already provisioned", v.Tag().Id(),
+		)}
+		return params.FilesystemParams{}, err
+	}
+
+	providerType, cfg, err := StoragePoolConfig(stateFilesystemParams.Pool, poolManager)
+	if err != nil {
+		return params.FilesystemParams{}, errors.Trace(err)
+	}
+	return params.FilesystemParams{
+		v.Tag().String(),
+		stateFilesystemParams.Size,
+		string(providerType),
+		cfg.Attrs(),
+		nil, // attachment params set by the caller
+	}, nil
+}
 
 // FilesystemFromState converts a state.Filesystem to params.Filesystem.
 func FilesystemFromState(v state.Filesystem) (params.Filesystem, error) {

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -32,6 +32,8 @@ type provisionerState interface {
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
 
+	SetFilesystemInfo(names.FilesystemTag, state.FilesystemInfo) error
+	SetFilesystemAttachmentInfo(names.MachineTag, names.FilesystemTag, state.FilesystemAttachmentInfo) error
 	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error
 	SetVolumeAttachmentInfo(names.MachineTag, names.VolumeTag, state.VolumeAttachmentInfo) error
 }

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -13,12 +13,14 @@ import (
 
 type provisionerState interface {
 	state.EntityFinder
+	WatchEnvironFilesystemAttachments() state.StringsWatcher
+	WatchMachineFilesystemAttachments(names.MachineTag) state.StringsWatcher
+	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	MachineInstanceId(names.MachineTag) (instance.Id, error)
 	WatchEnvironVolumes() state.StringsWatcher
 	WatchEnvironVolumeAttachments() state.StringsWatcher
 	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
 	WatchMachineVolumeAttachments(names.MachineTag) state.StringsWatcher
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	Volume(names.VolumeTag) (state.Volume, error)
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -13,7 +13,9 @@ import (
 
 type provisionerState interface {
 	state.EntityFinder
+	WatchEnvironFilesystems() state.StringsWatcher
 	WatchEnvironFilesystemAttachments() state.StringsWatcher
+	WatchMachineFilesystems(names.MachineTag) state.StringsWatcher
 	WatchMachineFilesystemAttachments(names.MachineTag) state.StringsWatcher
 	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	MachineInstanceId(names.MachineTag) (instance.Id, error)

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -13,19 +13,25 @@ import (
 
 type provisionerState interface {
 	state.EntityFinder
+
+	MachineInstanceId(names.MachineTag) (instance.Id, error)
+
 	WatchEnvironFilesystems() state.StringsWatcher
 	WatchEnvironFilesystemAttachments() state.StringsWatcher
 	WatchMachineFilesystems(names.MachineTag) state.StringsWatcher
 	WatchMachineFilesystemAttachments(names.MachineTag) state.StringsWatcher
-	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
-	MachineInstanceId(names.MachineTag) (instance.Id, error)
 	WatchEnvironVolumes() state.StringsWatcher
 	WatchEnvironVolumeAttachments() state.StringsWatcher
 	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
 	WatchMachineVolumeAttachments(names.MachineTag) state.StringsWatcher
+
+	Filesystem(names.FilesystemTag) (state.Filesystem, error)
+	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
+
 	Volume(names.VolumeTag) (state.Volume, error)
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
+
 	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error
 	SetVolumeAttachmentInfo(names.MachineTag, names.VolumeTag, state.VolumeAttachmentInfo) error
 }

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -296,6 +296,25 @@ func (s *provisionerSuite) TestVolumeParamsEmptyArgs(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 0)
 }
 
+func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
+	s.setupFilesystems(c)
+	results, err := s.api.FilesystemParams(params.Entities{
+		Entities: []params.Entity{{"filesystem-0-0"}, {"filesystem-1"}, {"filesystem-42"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.FilesystemParamsResults{
+		Results: []params.FilesystemParamsResult{
+			{Error: &params.Error{`filesystem "0/0" is already provisioned`, ""}},
+			{Result: params.FilesystemParams{
+				FilesystemTag: "filesystem-1",
+				Size:          2048,
+				Provider:      "environscoped",
+			}},
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+		},
+	})
+}
+
 func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 	s.setupVolumes(c)
 	s.authorizer.EnvironManager = true

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -172,6 +172,16 @@ func (st *State) WatchEnvironments() StringsWatcher {
 // WatchEnvironVolumes returns a StringsWatcher that notifies of changes to
 // the lifecycles of all environment-scoped volumes.
 func (st *State) WatchEnvironVolumes() StringsWatcher {
+	return st.watchEnvironMachineStorage(volumesC)
+}
+
+// WatchEnvironFilesystems returns a StringsWatcher that notifies of changes
+// to the lifecycles of all environment-scoped filesystems.
+func (st *State) WatchEnvironFilesystems() StringsWatcher {
+	return st.watchEnvironMachineStorage(filesystemsC)
+}
+
+func (st *State) watchEnvironMachineStorage(collection string) StringsWatcher {
 	pattern := fmt.Sprintf("^%s$", st.docID(names.NumberSnippet))
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
 	filter := func(id interface{}) bool {
@@ -181,12 +191,22 @@ func (st *State) WatchEnvironVolumes() StringsWatcher {
 		}
 		return !strings.Contains(k, "/")
 	}
-	return newLifecycleWatcher(st, volumesC, members, filter, nil)
+	return newLifecycleWatcher(st, collection, members, filter, nil)
 }
 
 // WatchMachineVolumes returns a StringsWatcher that notifies of changes to
 // the lifecycles of all volumes scoped to the specified machine.
 func (st *State) WatchMachineVolumes(m names.MachineTag) StringsWatcher {
+	return st.watchMachineStorage(m, volumesC)
+}
+
+// WatchMachineFilesystems returns a StringsWatcher that notifies of changes
+// to the lifecycles of all filesystems scoped to the specified machine.
+func (st *State) WatchMachineFilesystems(m names.MachineTag) StringsWatcher {
+	return st.watchMachineStorage(m, filesystemsC)
+}
+
+func (st *State) watchMachineStorage(m names.MachineTag, collection string) StringsWatcher {
 	pattern := fmt.Sprintf("^%s/%s$", st.docID(m.Id()), names.NumberSnippet)
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
 	prefix := m.Id() + "/"
@@ -197,7 +217,7 @@ func (st *State) WatchMachineVolumes(m names.MachineTag) StringsWatcher {
 		}
 		return strings.HasPrefix(k, prefix)
 	}
-	return newLifecycleWatcher(st, volumesC, members, filter, nil)
+	return newLifecycleWatcher(st, collection, members, filter, nil)
 }
 
 // WatchEnvironVolumeAttachments returns a StringsWatcher that notifies of

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -72,6 +72,7 @@ type MachineParams struct {
 	Characteristics *instance.HardwareCharacteristics
 	Addresses       []network.Address
 	Volumes         []state.MachineVolumeParams
+	Filesystems     []state.MachineFilesystemParams
 }
 
 // ServiceParams is used when specifying parameters for a new service.
@@ -259,9 +260,10 @@ func (factory *Factory) MakeMachine(c *gc.C, params *MachineParams) *state.Machi
 func (factory *Factory) MakeMachineReturningPassword(c *gc.C, params *MachineParams) (*state.Machine, string) {
 	params = factory.paramsFillDefaults(c, params)
 	machineTemplate := state.MachineTemplate{
-		Series:  params.Series,
-		Jobs:    params.Jobs,
-		Volumes: params.Volumes,
+		Series:      params.Series,
+		Jobs:        params.Jobs,
+		Volumes:     params.Volumes,
+		Filesystems: params.Filesystems,
 	}
 	machine, err := factory.st.AddOneMachine(machineTemplate)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This branch adds the server-side parts reuqired by
the storageprovisioner worker to watch and manipulate
filesystems.

(Review request: http://reviews.vapour.ws/r/1211/)