### PR TITLE
storageprovisioner: complete filesystem API

### DIFF
--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -89,6 +89,23 @@ func FilesystemFromState(v state.Filesystem) (params.Filesystem, error) {
 	}, nil
 }
 
+// FilesystemAttachmentToState converts a storage.FilesystemAttachment
+// to a state.FilesystemAttachmentInfo.
+func FilesystemAttachmentToState(in params.FilesystemAttachment) (names.MachineTag, names.FilesystemTag, state.FilesystemAttachmentInfo, error) {
+	machineTag, err := names.ParseMachineTag(in.MachineTag)
+	if err != nil {
+		return names.MachineTag{}, names.FilesystemTag{}, state.FilesystemAttachmentInfo{}, err
+	}
+	filesystemTag, err := names.ParseFilesystemTag(in.FilesystemTag)
+	if err != nil {
+		return names.MachineTag{}, names.FilesystemTag{}, state.FilesystemAttachmentInfo{}, err
+	}
+	info := state.FilesystemAttachmentInfo{
+		in.MountPoint,
+	}
+	return machineTag, filesystemTag, info, nil
+}
+
 // ParseFilesystemAttachmentIds parses the strings, returning machine storage IDs.
 func ParseFilesystemAttachmentIds(stringIds []string) ([]params.MachineStorageId, error) {
 	ids := make([]params.MachineStorageId, len(stringIds))

--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -106,6 +106,19 @@ func FilesystemAttachmentToState(in params.FilesystemAttachment) (names.MachineT
 	return machineTag, filesystemTag, info, nil
 }
 
+// FilesystemAttachmentFromState converts a state.FilesystemAttachment to params.FilesystemAttachment.
+func FilesystemAttachmentFromState(v state.FilesystemAttachment) (params.FilesystemAttachment, error) {
+	info, err := v.Info()
+	if err != nil {
+		return params.FilesystemAttachment{}, errors.Trace(err)
+	}
+	return params.FilesystemAttachment{
+		v.Filesystem().String(),
+		v.Machine().String(),
+		info.MountPoint,
+	}, nil
+}
+
 // ParseFilesystemAttachmentIds parses the strings, returning machine storage IDs.
 func ParseFilesystemAttachmentIds(stringIds []string) ([]params.MachineStorageId, error) {
 	ids := make([]params.MachineStorageId, len(stringIds))

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -316,8 +316,8 @@ type FilesystemAttachmentParams struct {
 	MachineTag    string `json:"machinetag"`
 	InstanceId    string `json:"instanceid,omitempty"`
 	FilesystemId  string `json:"filesystemid,omitempty"`
-	MountPoint    string `json:"mountpoint,omitempty"`
 	Provider      string `json:"provider"`
+	MountPoint    string `json:"mountpoint,omitempty"`
 }
 
 // FilesystemAttachmentResult holds the details of a single filesystem attachment,

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -367,6 +367,35 @@ func (s *StorageProvisionerAPI) VolumeAttachments(args params.MachineStorageIds)
 	return results, nil
 }
 
+// FilesystemAttachments returns details of filesystem attachments with the specified IDs.
+func (s *StorageProvisionerAPI) FilesystemAttachments(args params.MachineStorageIds) (params.FilesystemAttachmentResults, error) {
+	canAccess, err := s.getAttachmentAuthFunc()
+	if err != nil {
+		return params.FilesystemAttachmentResults{}, common.ServerError(common.ErrPerm)
+	}
+	results := params.FilesystemAttachmentResults{
+		Results: make([]params.FilesystemAttachmentResult, len(args.Ids)),
+	}
+	one := func(arg params.MachineStorageId) (params.FilesystemAttachment, error) {
+		filesystemAttachment, err := s.oneFilesystemAttachment(arg, canAccess)
+		if err != nil {
+			return params.FilesystemAttachment{}, err
+		}
+		return common.FilesystemAttachmentFromState(filesystemAttachment)
+	}
+	for i, arg := range args.Ids {
+		var result params.FilesystemAttachmentResult
+		filesystemAttachment, err := one(arg)
+		if err != nil {
+			result.Error = common.ServerError(err)
+		} else {
+			result.Result = filesystemAttachment
+		}
+		results.Results[i] = result
+	}
+	return results, nil
+}
+
 // VolumeParams returns the parameters for creating the volumes
 // with the specified tags.
 func (s *StorageProvisionerAPI) VolumeParams(args params.Entities) (params.VolumeParamsResults, error) {
@@ -531,6 +560,77 @@ func (s *StorageProvisionerAPI) VolumeAttachmentParams(
 	return results, nil
 }
 
+// FilesystemAttachmentParams returns the parameters for creating the filesystem
+// attachments with the specified IDs.
+func (s *StorageProvisionerAPI) FilesystemAttachmentParams(
+	args params.MachineStorageIds,
+) (params.FilesystemAttachmentParamsResults, error) {
+	canAccess, err := s.getAttachmentAuthFunc()
+	if err != nil {
+		return params.FilesystemAttachmentParamsResults{}, common.ServerError(common.ErrPerm)
+	}
+	results := params.FilesystemAttachmentParamsResults{
+		Results: make([]params.FilesystemAttachmentParamsResult, len(args.Ids)),
+	}
+	poolManager := poolmanager.New(s.settings)
+	one := func(arg params.MachineStorageId) (params.FilesystemAttachmentParams, error) {
+		filesystemAttachment, err := s.oneFilesystemAttachment(arg, canAccess)
+		if err != nil {
+			return params.FilesystemAttachmentParams{}, err
+		}
+		instanceId, err := s.st.MachineInstanceId(filesystemAttachment.Machine())
+		if err != nil {
+			// Can't attach a filesystem to a machine that
+			// hasn't been provisioned yet.
+			return params.FilesystemAttachmentParams{}, err
+		}
+		filesystem, err := s.st.Filesystem(filesystemAttachment.Filesystem())
+		if err != nil && !errors.IsNotProvisioned(err) {
+			return params.FilesystemAttachmentParams{}, err
+		}
+		filesystemInfo, err := filesystem.Info()
+		if err != nil {
+			// Can't attach a filesystem that hasn't been
+			// provisioned yet.
+			return params.FilesystemAttachmentParams{}, err
+		}
+		providerType, _, err := common.StoragePoolConfig(filesystemInfo.Pool, poolManager)
+		if err != nil {
+			return params.FilesystemAttachmentParams{}, errors.Trace(err)
+		}
+		filesystemAttachmentParams, ok := filesystemAttachment.Params()
+		if !ok {
+			return params.FilesystemAttachmentParams{}, errors.Errorf(
+				"filesystem %q is already attached to machine %q",
+				filesystemAttachment.Filesystem().Id(),
+				filesystemAttachment.Machine().Id(),
+			)
+		}
+		return params.FilesystemAttachmentParams{
+			filesystemAttachment.Filesystem().String(),
+			filesystemAttachment.Machine().String(),
+			string(instanceId),
+			filesystemInfo.FilesystemId,
+			string(providerType),
+			// TODO(axw) dealias MountPoint. We now have
+			// Path, MountPoint and Location in different
+			// parts of the codebase.
+			filesystemAttachmentParams.Location,
+		}, nil
+	}
+	for i, arg := range args.Ids {
+		var result params.FilesystemAttachmentParamsResult
+		filesystemAttachment, err := one(arg)
+		if err != nil {
+			result.Error = common.ServerError(err)
+		} else {
+			result.Result = filesystemAttachment
+		}
+		results.Results[i] = result
+	}
+	return results, nil
+}
+
 func (s *StorageProvisionerAPI) oneVolumeAttachment(
 	id params.MachineStorageId, canAccessMachine func(names.MachineTag, names.Tag) bool,
 ) (state.VolumeAttachment, error) {
@@ -552,6 +652,29 @@ func (s *StorageProvisionerAPI) oneVolumeAttachment(
 		return nil, err
 	}
 	return volumeAttachment, nil
+}
+
+func (s *StorageProvisionerAPI) oneFilesystemAttachment(
+	id params.MachineStorageId, canAccessMachine func(names.MachineTag, names.Tag) bool,
+) (state.FilesystemAttachment, error) {
+	machineTag, err := names.ParseMachineTag(id.MachineTag)
+	if err != nil {
+		return nil, err
+	}
+	filesystemTag, err := names.ParseFilesystemTag(id.AttachmentTag)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccessMachine(machineTag, filesystemTag) {
+		return nil, common.ErrPerm
+	}
+	filesystemAttachment, err := s.st.FilesystemAttachment(machineTag, filesystemTag)
+	if errors.IsNotFound(err) {
+		return nil, common.ErrPerm
+	} else if err != nil {
+		return nil, err
+	}
+	return filesystemAttachment, nil
 }
 
 // SetVolumeInfo records the details of newly provisioned volumes.

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -391,6 +391,40 @@ func (s *provisionerSuite) TestSetVolumeAttachmentInfo(c *gc.C) {
 	})
 }
 
+func (s *provisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
+	s.setupFilesystems(c)
+	s.authorizer.EnvironManager = true
+
+	results, err := s.api.SetFilesystemAttachmentInfo(params.FilesystemAttachments{
+		FilesystemAttachments: []params.FilesystemAttachment{{
+			MachineTag:    "machine-0",
+			FilesystemTag: "filesystem-0-0",
+			MountPoint:    "/srv/a",
+		}, {
+			MachineTag:    "machine-0",
+			FilesystemTag: "filesystem-1",
+			MountPoint:    "/srv/b",
+		}, {
+			MachineTag:    "machine-2",
+			FilesystemTag: "filesystem-3",
+			MountPoint:    "/srv/c",
+		}, {
+			MachineTag:    "machine-0",
+			FilesystemTag: "filesystem-42",
+			MountPoint:    "/srv/d",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{},
+			{}, // TODO(axw) this should fail, since filesystem is not provisioned
+			{}, // TODO(axw) this should fail, since machine is not provisioned
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+		},
+	})
+}
+
 func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
 	s.setupVolumes(c)
 	s.factory.MakeMachine(c, nil)

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -123,11 +123,14 @@ func (s *provisionerSuite) setupVolumes(c *gc.C) {
 func (s *provisionerSuite) setupFilesystems(c *gc.C) {
 	s.factory.MakeMachine(c, &factory.MachineParams{
 		InstanceId: instance.Id("inst-id"),
-		Filesystems: []state.MachineFilesystemParams{
-			{Filesystem: state.FilesystemParams{Pool: "machinescoped", Size: 1024}},
-			{Filesystem: state.FilesystemParams{Pool: "environscoped", Size: 2048}},
-			{Filesystem: state.FilesystemParams{Pool: "environscoped", Size: 4096}},
-		},
+		Filesystems: []state.MachineFilesystemParams{{
+			Filesystem: state.FilesystemParams{Pool: "machinescoped", Size: 1024},
+			Attachment: state.FilesystemAttachmentParams{Location: "/srv"},
+		}, {
+			Filesystem: state.FilesystemParams{Pool: "environscoped", Size: 2048},
+		}, {
+			Filesystem: state.FilesystemParams{Pool: "environscoped", Size: 4096},
+		}},
 	})
 
 	// Only provision the first and third filesystems.
@@ -265,6 +268,46 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 	})
 }
 
+func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
+	s.setupFilesystems(c)
+	s.authorizer.EnvironManager = false
+
+	err := s.State.SetFilesystemAttachmentInfo(
+		names.NewMachineTag("0"),
+		names.NewFilesystemTag("0/0"),
+		state.FilesystemAttachmentInfo{MountPoint: "/srv"},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := s.api.FilesystemAttachments(params.MachineStorageIds{
+		Ids: []params.MachineStorageId{{
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-0-0",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-2", // filesystem attachment not provisioned
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-42",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.FilesystemAttachmentResults{
+		Results: []params.FilesystemAttachmentResult{
+			{Result: params.FilesystemAttachment{
+				FilesystemTag: "filesystem-0-0",
+				MachineTag:    "machine-0",
+				MountPoint:    "/srv",
+			}},
+			{Error: &params.Error{
+				Code:    params.CodeNotProvisioned,
+				Message: `filesystem attachment "2" on "0" not provisioned`,
+			}},
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+		},
+	})
+}
+
 func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 	s.setupVolumes(c)
 	results, err := s.api.VolumeParams(params.Entities{
@@ -347,6 +390,49 @@ func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,
 				Message: `volume "1" not provisioned`,
+			}},
+			{Error: &params.Error{
+				Code:    params.CodeNotProvisioned,
+				Message: `machine 2 not provisioned`,
+			}},
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
+	s.setupFilesystems(c)
+	s.authorizer.EnvironManager = true
+
+	results, err := s.api.FilesystemAttachmentParams(params.MachineStorageIds{
+		Ids: []params.MachineStorageId{{
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-0-0",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-1",
+		}, {
+			MachineTag:    "machine-2",
+			AttachmentTag: "filesystem-3",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-42",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.FilesystemAttachmentParamsResults{
+		Results: []params.FilesystemAttachmentParamsResult{
+			{Result: params.FilesystemAttachmentParams{
+				MachineTag:    "machine-0",
+				FilesystemTag: "filesystem-0-0",
+				InstanceId:    "inst-id",
+				FilesystemId:  "abc",
+				Provider:      "machinescoped",
+				MountPoint:    "/srv",
+			}},
+			{Error: &params.Error{
+				Code:    params.CodeNotProvisioned,
+				Message: `filesystem "1" not provisioned`,
 			}},
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -529,6 +529,8 @@ func (st *State) SetFilesystemAttachmentInfo(
 ) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set info for filesystem attachment %s:%s", filesystemTag.Id(), machineTag.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
+		// TODO(axw) attempting to set filesystem attachment info for a
+		// filesystem that hasn't been provisioned should fail.
 		fsa, err := st.FilesystemAttachment(machineTag, filesystemTag)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/state/volume.go
+++ b/state/volume.go
@@ -444,6 +444,8 @@ func setMachineVolumeAttachmentInfo(st *State, machineId string, attachments map
 func (st *State) SetVolumeAttachmentInfo(machineTag names.MachineTag, volumeTag names.VolumeTag, info VolumeAttachmentInfo) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set info for volume attachment %s:%s", volumeTag.Id(), machineTag.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
+		// TODO(axw) attempting to set volume attachment info for a
+		// volume that hasn't been provisioned should fail.
 		va, err := st.VolumeAttachment(machineTag, volumeTag)
 		if err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
This branch adds the remaining filesystem-related
methods to the storageprovisioner API server facade.

(Review request: http://reviews.vapour.ws/r/1212/)