### PR TITLE
Fix ha restore1.23

### DIFF
--- a/state/backups/backups.go
+++ b/state/backups/backups.go
@@ -99,7 +99,7 @@ type Backups interface {
 	Remove(id string) error
 
 	// Restore updates juju's state to the contents of the backup archive.
-	Restore(backupId string, args RestoreArgs) error
+	Restore(backupId string, args RestoreArgs) (string, error)
 }
 
 type backups struct {

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -142,5 +142,5 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (string, error) {
 	// the client can reconnect and determine if we where succesful.
 	err = info.SetStatus(state.RestoreFinished)
 
-	return backupMachine.Tag().String(), errors.Annotate(err, "failed to set status to finished")
+	return backupMachine.String(), errors.Annotate(err, "failed to set status to finished")
 }

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -51,9 +51,9 @@ func (b *backups) Restore(backupId string, args RestoreArgs) error {
 		return errors.Annotate(err, "cannot obtain system files from backup")
 	}
 
-	if err := updateBackupMachineTag(backupMachine, args.NewInstTag); err != nil {
-		return errors.Annotate(err, "cannot update paths to reflect current machine id")
-	}
+	//if err := updateBackupMachineTag(backupMachine, args.NewInstTag); err != nil {
+	//	return errors.Annotate(err, "cannot update paths to reflect current machine id")
+	//}
 
 	var agentConfig agent.ConfigSetterWriter
 	// The path for the config file might change if the tag changed
@@ -62,7 +62,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) error {
 	if err != nil {
 		return errors.Annotate(err, "cannot determine DataDir for the restored machine")
 	}
-	agentConfigFile := agent.ConfigPath(datadir, args.NewInstTag)
+	agentConfigFile := agent.ConfigPath(datadir, backupMachine)
 	if agentConfig, err = agent.ReadConfig(agentConfigFile); err != nil {
 		return errors.Annotate(err, "cannot load agent config from disk")
 	}
@@ -71,7 +71,6 @@ func (b *backups) Restore(backupId string, args RestoreArgs) error {
 		return errors.Errorf("cannot determine state serving info")
 	}
 	// The machine tag might have changed, we update it.
-	agentConfig.SetValue("tag", args.NewInstTag.String())
 	APIHostPort := network.HostPort{
 		Address: network.Address{
 			Value: args.PrivateAddress,
@@ -117,7 +116,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) error {
 	}
 	defer st.Close()
 
-	machine, err := st.Machine(args.NewInstTag.Id())
+	machine, err := st.Machine(backupMachine.Id())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/backups/backups_nonlinux.go
+++ b/state/backups/backups_nonlinux.go
@@ -11,6 +11,6 @@ import (
 
 // Restore satisfies the Backups interface on non-Linux OSes (e.g.
 // windows, darwin).
-func (*backups) Restore(_ string, _ RestoreArgs) error {
+func (*backups) Restore(_ string, _ RestoreArgs) (string, error) {
 	return errors.Errorf("backups supported only on Linux")
 }

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -238,6 +238,22 @@ func mongoRestoreArgsForVersion(ver version.Number, dumpPath string) ([]string, 
 var restorePath = paths.MongorestorePath
 var restoreArgsForVersion = mongoRestoreArgsForVersion
 
+// startService starts the provided service.
+func startService(srv service.Service) error {
+	return srv.Start()
+}
+
+// startMongoService is for testing purposes.
+var startMongoService = startService
+
+// stopService is just for testing purposes.
+func stopService(srv service.Service) error {
+	return srv.Stop()
+}
+
+// stopMongoService is just for testing purposes.
+var stopMongoService = stopService
+
 // placeNewMongo tries to use mongorestore to replace an existing
 // mongo with the dump in newMongoDumpPath returns an error if its not possible.
 func placeNewMongo(newMongoDumpPath string, ver version.Number) error {
@@ -256,7 +272,7 @@ func placeNewMongo(newMongoDumpPath string, ver version.Number) error {
 		return errors.Annotate(err, "cannot get mongo service")
 	}
 
-	if err := mongodService.Stop(); err != nil {
+	if err := stopMongoService(mongodService); err != nil {
 		return errors.Annotate(err, "cannot start mongo service")
 	}
 
@@ -265,7 +281,7 @@ func placeNewMongo(newMongoDumpPath string, ver version.Number) error {
 		return errors.Annotate(err, "failed to restore database dump")
 	}
 
-	if err := mongodService.Start(); err != nil {
+	if err := stopMongoService(mongodService); err != nil {
 		return errors.Annotate(err, "failed to start mongo")
 	}
 

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -168,3 +168,5 @@ var PlaceNewMongo = placeNewMongo
 var MongoRestoreArgsForVersion = mongoRestoreArgsForVersion
 var RestorePath = &restorePath
 var RestoreArgsForVersion = &restoreArgsForVersion
+var StartMongoService = &startMongoService
+var StopMongoService = &stopMongoService

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -255,13 +255,16 @@ func updateBackupMachineTag(oldTag, newTag names.Tag) error {
 	if oldTagString == newTagString {
 		return nil
 	}
-	oldTagPath := path.Join(agent.DefaultDataDir, oldTagString)
-	newTagPath := path.Join(agent.DefaultDataDir, newTagString)
+	// TODO(perrito666) create an authoritative source for agents dir.
+	oldTagPath := path.Join(agent.DefaultDataDir, "agents", oldTagString)
+	newTagPath := path.Join(agent.DefaultDataDir, "agents", newTagString)
 
 	oldToolsDir := tools.ToolsDir(agent.DefaultDataDir, oldTagString)
 	oldLink, err := filepath.EvalSymlinks(oldToolsDir)
 
-	os.Rename(oldTagPath, newTagPath)
+	if err := os.Rename(oldTagPath, newTagPath); err != nil {
+		return errors.Annotatef(err, "could not rename %q into %q", oldTagPath, newTagPath)
+	}
 	newToolsDir := tools.ToolsDir(agent.DefaultDataDir, newTagString)
 	newToolsPath := strings.Replace(oldLink, oldTagPath, newTagPath, -1)
 	err = symlink.Replace(newToolsDir, newToolsPath)

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -221,7 +221,7 @@ func (r *RestoreSuite) TestUpdateMongoEntries(c *gc.C) {
 	dialInfo := server.DialInfo()
 	mgoAddr := server.Addr()
 	dialInfo.Addrs = []string{mgoAddr}
-	err = updateMongoEntries("1234", "0", "0", dialInfo)
+	err = updateMongoEntries("1234", "0", dialInfo)
 	c.Assert(err, gc.ErrorMatches, "cannot update machine 0 instance information: not found")
 
 	session := server.MustDial()
@@ -235,7 +235,7 @@ func (r *RestoreSuite) TestUpdateMongoEntries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 0)
 
-	err = updateMongoEntries("1234", "0", "0", dialInfo)
+	err = updateMongoEntries("1234", "0", dialInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	query = session.DB("juju").C("machines").Find(bson.M{"machineid": "0", "instanceid": "1234"})

--- a/state/backups/testing/fakes.go
+++ b/state/backups/testing/fakes.go
@@ -96,11 +96,11 @@ func (b *FakeBackups) Remove(id string) error {
 }
 
 // Restore restores a machine to a backed up status.
-func (b *FakeBackups) Restore(bkpId string, args backups.RestoreArgs) error {
+func (b *FakeBackups) Restore(bkpId string, args backups.RestoreArgs) (string, error) {
 	b.Calls = append(b.Calls, "Restore")
 	b.PrivateAddr = args.PrivateAddress
 	b.InstanceId = args.NewInstId
-	return errors.Trace(b.Error)
+	return "", errors.Trace(b.Error)
 }
 
 // TODO(ericsnow) FakeStorage should probably move over to the utils repo.


### PR DESCRIPTION
Restore failed in cases where the backup was produced by machines other than 0, this is now fixed.
Restore was invoking "initctl" command and now uses services.Service to run mongod and jujud.

(Review request: http://reviews.vapour.ws/r/1216/)