### PR TITLE
network.NewScopedAddress and a few simplifications

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -419,6 +419,8 @@ func (s *State) ServerTag() (names.EnvironTag, error) {
 // be invoked both within and outside the environment (think
 // private clouds).
 func (s *State) APIHostPorts() [][]network.HostPort {
+	// NOTE: We're making a copy of s.hostPorts before returning it,
+	// for safety.
 	hostPorts := make([][]network.HostPort, len(s.hostPorts))
 	for i, server := range s.hostPorts {
 		hostPorts[i] = append([]network.HostPort{}, server...)

--- a/api/deployer/deployer_test.go
+++ b/api/deployer/deployer_test.go
@@ -47,7 +47,7 @@ var _ = gc.Suite(&deployerSuite{})
 func (s *deployerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.stateAPI, s.machine = s.OpenAPIAsNewMachine(c, state.JobManageEnviron, state.JobHostUnits)
-	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create the needed services and relate them.
@@ -229,7 +229,7 @@ func (s *deployerSuite) TestUnitSetPassword(c *gc.C) {
 }
 
 func (s *deployerSuite) TestStateAddresses(c *gc.C) {
-	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	stateAddresses, err := s.State.Addresses()

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -42,7 +42,7 @@ func (s *machinerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	m, err := s.State.AddMachine("quantal", state.JobManageEnviron)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetAddresses(network.NewAddress("10.0.0.1", network.ScopeUnknown))
+	err = m.SetAddresses(network.NewAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.st, s.machine = s.OpenAPIAsNewMachine(c)

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -199,9 +199,9 @@ func (st *State) PrepareContainerInterfaceInfo(containerTag names.MachineTag) ([
 			Disabled:         netInfo.Disabled,
 			NoAutoStart:      netInfo.NoAutoStart,
 			ConfigType:       network.InterfaceConfigType(netInfo.ConfigType),
-			Address:          network.NewAddress(netInfo.Address, network.ScopeUnknown),
+			Address:          network.NewAddress(netInfo.Address),
 			DNSServers:       network.NewAddresses(netInfo.DNSServers...),
-			GatewayAddress:   network.NewAddress(netInfo.GatewayAddress, network.ScopeUnknown),
+			GatewayAddress:   network.NewAddress(netInfo.GatewayAddress),
 			ExtraConfig:      netInfo.ExtraConfig,
 		}
 	}

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -69,7 +69,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAsMachine(c, s.machine.Tag(), password, "fake_nonce")
 	c.Assert(s.st, gc.NotNil)
-	err = s.machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err = s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create the provisioner API facade.
@@ -580,7 +580,7 @@ func (s *provisionerSuite) TestWatchEnvironMachines(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestStateAddresses(c *gc.C) {
-	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	stateAddresses, err := s.State.Addresses()
@@ -803,7 +803,7 @@ func (s *provisionerSuite) TestPrepareContainerInterfaceInfo(c *gc.C) {
 		// it's chosen randomly.
 		Address:        network.Address{},
 		DNSServers:     network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress: network.NewAddress("0.10.0.2", network.ScopeUnknown),
+		GatewayAddress: network.NewAddress("0.10.0.2"),
 		ExtraConfig:    nil,
 	}}
 	ifaceInfo, err := s.provisioner.PrepareContainerInterfaceInfo(container.MachineTag())
@@ -834,7 +834,7 @@ func (s *provisionerSuite) TestReleaseContainerAddresses(c *gc.C) {
 	sub, err := s.State.AddSubnet(subInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 3; i++ {
-		addr := network.NewAddress(fmt.Sprintf("0.10.0.%d", i), network.ScopeUnknown)
+		addr := network.NewAddress(fmt.Sprintf("0.10.0.%d", i))
 		ipaddr, err := s.State.AddIPAddress(addr, sub.ID())
 		c.Check(err, jc.ErrorIsNil)
 		err = ipaddr.AllocateTo(container.Id(), "")

--- a/api/rsyslog/rsyslog_test.go
+++ b/api/rsyslog/rsyslog_test.go
@@ -30,7 +30,7 @@ func (s *rsyslogSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
 	s.st, s.machine = s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
-	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create the rsyslog API facade

--- a/api/state.go
+++ b/api/state.go
@@ -207,12 +207,8 @@ func addAddress(servers [][]network.HostPort, addr string) ([][]network.HostPort
 	if err != nil {
 		return nil, err
 	}
-	hostPort := network.HostPort{
-		Address: network.NewAddress(host, network.ScopeUnknown),
-		Port:    port,
-	}
 	result := make([][]network.HostPort, 0, len(servers)+1)
-	result = append(result, []network.HostPort{hostPort})
+	result = append(result, network.NewHostPorts(port, host))
 	result = append(result, servers...)
 	return result, nil
 }

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -60,19 +60,17 @@ func (s *stateSuite) TestAPIHostPortsAlwaysIncludesTheConnection(c *gc.C) {
 	// the other addresses, but always see this one as well.
 	info := s.APIInfo(c)
 	// We intentionally set this to invalid values
-	badValue := network.HostPort{network.Address{
-		Value:       "0.1.2.3",
-		Type:        network.IPv4Address,
-		NetworkName: "",
-		Scope:       network.ScopeMachineLocal,
-	}, 1234}
-	badServer := []network.HostPort{badValue}
+	badServer := network.NewHostPorts(1234, "0.1.2.3")
+	badServer[0].Scope = network.ScopeMachineLocal
 	s.State.SetAPIHostPorts([][]network.HostPort{badServer})
 	apistate, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer apistate.Close()
 	hostports := apistate.APIHostPorts()
-	c.Check(hostports, gc.DeepEquals, [][]network.HostPort{serverhostports, badServer})
+	c.Check(hostports, gc.DeepEquals, [][]network.HostPort{
+		serverhostports,
+		badServer,
+	})
 }
 
 func (s *stateSuite) TestLoginSetsEnvironTag(c *gc.C) {
@@ -157,7 +155,9 @@ func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {
 		NetworkName: "",
 		Scope:       network.ScopeMachineLocal,
 	}, 9012}
-	serverExtra := []network.HostPort{extraAddress, goodAddress, extraAddress2}
+	serverExtra := []network.HostPort{
+		extraAddress, goodAddress, extraAddress2,
+	}
 	current := [][]network.HostPort{badServer, serverExtra}
 	s.State.SetAPIHostPorts(current)
 	apistate, err := api.Open(info, api.DialOpts{})
@@ -166,42 +166,26 @@ func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {
 	hostports := apistate.APIHostPorts()
 	// We should have rotate the server we connected to as the first item,
 	// and the address of that server as the first address
-	sortedServer := []network.HostPort{goodAddress, extraAddress, extraAddress2}
+	sortedServer := []network.HostPort{
+		goodAddress, extraAddress, extraAddress2,
+	}
 	expected := [][]network.HostPort{sortedServer, badServer}
 	c.Check(hostports, gc.DeepEquals, expected)
 }
 
-var exampleHostPorts = []network.HostPort{
-	{
-		Address: network.Address{
-			Value:       "0.1.2.3",
-			Type:        network.IPv4Address,
-			NetworkName: "",
-			Scope:       network.ScopeUnknown,
-		}, Port: 1234,
-	}, {
-		Address: network.Address{
-			Value:       "0.1.2.4",
-			Type:        network.IPv4Address,
-			NetworkName: "",
-			Scope:       network.ScopeUnknown,
-		}, Port: 5678,
-	}, {
-		Address: network.Address{
-			Value:       "0.1.2.1",
-			Type:        network.IPv4Address,
-			NetworkName: "",
-			Scope:       network.ScopeUnknown,
-		}, Port: 9012,
-	}, {
-		Address: network.Address{
-			Value:       "0.1.9.1",
-			Type:        network.IPv4Address,
-			NetworkName: "",
-			Scope:       network.ScopeUnknown,
-		}, Port: 8888,
-	},
-}
+var exampleHostPorts = []network.HostPort{{
+	Address: network.NewAddress("0.1.2.3"),
+	Port:    1234,
+}, {
+	Address: network.NewAddress("0.1.2.4"),
+	Port:    5678,
+}, {
+	Address: network.NewAddress("0.1.2.1"),
+	Port:    9012,
+}, {
+	Address: network.NewAddress("0.1.9.1"),
+	Port:    8888,
+}}
 
 func (s *slideSuite) TestSlideToFrontNoOp(c *gc.C) {
 	servers := [][]network.HostPort{

--- a/api/testing/apiaddresser.go
+++ b/api/testing/apiaddresser.go
@@ -33,10 +33,9 @@ type APIAddresserFacade interface {
 }
 
 func (s *APIAddresserTests) TestAPIAddresses(c *gc.C) {
-	hostPorts := [][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		Port:    1234,
-	}}}
+	hostPorts := [][]network.HostPort{
+		network.NewHostPorts(1234, "0.1.2.3"),
+	}
 
 	err := s.state.SetAPIHostPorts(hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
@@ -47,21 +46,15 @@ func (s *APIAddresserTests) TestAPIAddresses(c *gc.C) {
 }
 
 func (s *APIAddresserTests) TestAPIHostPorts(c *gc.C) {
-	expectServerAddrs := [][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.24", network.ScopeUnknown),
-		Port:    999,
-	}, {
-		Address: network.NewAddress("example.com", network.ScopeUnknown),
-		Port:    1234,
-	}}, {{
-		Address: network.Address{
-			Value:       "2001:DB8::1",
-			Type:        network.IPv6Address,
-			NetworkName: "someNetwork",
-			Scope:       network.ScopeCloudLocal,
-		},
-		Port: 999,
-	}}}
+	ipv6Addr := network.NewScopedAddress(
+		"2001:DB8::1", network.ScopeCloudLocal,
+	)
+	ipv6Addr.NetworkName = "someNetwork"
+	expectServerAddrs := [][]network.HostPort{
+		network.NewHostPorts(999, "0.1.2.24"),
+		network.NewHostPorts(1234, "example.com"),
+		network.AddressesWithPort([]network.Address{ipv6Addr}, 999),
+	}
 
 	err := s.state.SetAPIHostPorts(expectServerAddrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,10 +71,9 @@ func (s *APIAddresserTests) TestCACert(c *gc.C) {
 }
 
 func (s *APIAddresserTests) TestWatchAPIHostPorts(c *gc.C) {
-	expectServerAddrs := [][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		Port:    1234,
-	}}}
+	expectServerAddrs := [][]network.HostPort{
+		network.NewHostPorts(1234, "0.1.2.3"),
+	}
 	err := s.state.SetAPIHostPorts(expectServerAddrs)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -98,7 +98,9 @@ func (s *relationUnitSuite) TestPrivateAddress(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `"unit-wordpress-0" has no private address set`)
 
 	// Set an address and try again.
-	err = s.wordpressMachine.SetAddresses(network.NewAddress("1.2.3.4", network.ScopeCloudLocal))
+	err = s.wordpressMachine.SetAddresses(
+		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	address, err = apiRelUnit.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -296,7 +296,9 @@ func (s *unitSuite) TestPublicAddress(c *gc.C) {
 	address, err := s.apiUnit.PublicAddress()
 	c.Assert(err, gc.ErrorMatches, `"unit-wordpress-0" has no public address set`)
 
-	err = s.wordpressMachine.SetAddresses(network.NewAddress("1.2.3.4", network.ScopePublic))
+	err = s.wordpressMachine.SetAddresses(
+		network.NewScopedAddress("1.2.3.4", network.ScopePublic),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	address, err = s.apiUnit.PublicAddress()
@@ -308,7 +310,9 @@ func (s *unitSuite) TestPrivateAddress(c *gc.C) {
 	address, err := s.apiUnit.PrivateAddress()
 	c.Assert(err, gc.ErrorMatches, `"unit-wordpress-0" has no private address set`)
 
-	err = s.wordpressMachine.SetAddresses(network.NewAddress("1.2.3.4", network.ScopeCloudLocal))
+	err = s.wordpressMachine.SetAddresses(
+		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	address, err = s.apiUnit.PrivateAddress()
@@ -620,14 +624,14 @@ func (s *unitSuite) TestWatchAddresses(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Update config a couple of times, check a single event.
-	err = s.wordpressMachine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err = s.wordpressMachine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.wordpressMachine.SetAddresses(network.NewAddress("0.1.2.4", network.ScopeUnknown))
+	err = s.wordpressMachine.SetAddresses(network.NewAddress("0.1.2.4"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Non-change is not reported.
-	err = s.wordpressMachine.SetAddresses(network.NewAddress("0.1.2.4", network.ScopeUnknown))
+	err = s.wordpressMachine.SetAddresses(network.NewAddress("0.1.2.4"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -234,10 +234,7 @@ func (s *loginSuite) TestLoginAddrs(c *gc.C) {
 	connectedAddrPort, err := strconv.Atoi(connectedAddrPortString)
 	c.Assert(err, jc.ErrorIsNil)
 	connectedAddrHostPorts := [][]network.HostPort{
-		{{
-			network.NewAddress(connectedAddrHost, network.ScopeUnknown),
-			connectedAddrPort,
-		}},
+		network.NewHostPorts(connectedAddrPort, connectedAddrHost),
 	}
 	c.Assert(hostPorts, gc.DeepEquals, connectedAddrHostPorts)
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2718,8 +2718,8 @@ func (s *clientSuite) TestClientPublicAddressMachine(c *gc.C) {
 	// address is returned.
 	m1, err := s.State.Machine("1")
 	c.Assert(err, jc.ErrorIsNil)
-	cloudLocalAddress := network.NewAddress("cloudlocal", network.ScopeCloudLocal)
-	publicAddress := network.NewAddress("public", network.ScopePublic)
+	cloudLocalAddress := network.NewScopedAddress("cloudlocal", network.ScopeCloudLocal)
+	publicAddress := network.NewScopedAddress("public", network.ScopePublic)
 	err = m1.SetAddresses(cloudLocalAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := s.APIState.Client().PublicAddress("1")
@@ -2735,7 +2735,7 @@ func (s *clientSuite) TestClientPublicAddressUnit(c *gc.C) {
 	s.setUpScenario(c)
 
 	m1, err := s.State.Machine("1")
-	publicAddress := network.NewAddress("public", network.ScopePublic)
+	publicAddress := network.NewScopedAddress("public", network.ScopePublic)
 	err = m1.SetAddresses(publicAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := s.APIState.Client().PublicAddress("wordpress/0")
@@ -2760,8 +2760,8 @@ func (s *clientSuite) TestClientPrivateAddress(c *gc.C) {
 	// address if no cloud-local one is available.
 	m1, err := s.State.Machine("1")
 	c.Assert(err, jc.ErrorIsNil)
-	cloudLocalAddress := network.NewAddress("cloudlocal", network.ScopeCloudLocal)
-	publicAddress := network.NewAddress("public", network.ScopePublic)
+	cloudLocalAddress := network.NewScopedAddress("cloudlocal", network.ScopeCloudLocal)
+	publicAddress := network.NewScopedAddress("public", network.ScopePublic)
 	err = m1.SetAddresses(publicAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := s.APIState.Client().PrivateAddress("1")
@@ -2777,7 +2777,7 @@ func (s *clientSuite) TestClientPrivateAddressUnit(c *gc.C) {
 	s.setUpScenario(c)
 
 	m1, err := s.State.Machine("1")
-	privateAddress := network.NewAddress("private", network.ScopeCloudLocal)
+	privateAddress := network.NewScopedAddress("private", network.ScopeCloudLocal)
 	err = m1.SetAddresses(privateAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := s.APIState.Client().PrivateAddress("wordpress/0")
@@ -3241,7 +3241,7 @@ func (s *clientSuite) TestClientAddMachinesSomeErrors(c *gc.C) {
 
 func (s *clientSuite) TestClientAddMachinesWithInstanceIdSomeErrors(c *gc.C) {
 	apiParams := make([]params.AddMachineParams, 3)
-	addrs := []network.Address{network.NewAddress("1.2.3.4", network.ScopeUnknown)}
+	addrs := network.NewAddresses("1.2.3.4")
 	hc := instance.MustParseHardware("mem=4G")
 	for i := 0; i < 3; i++ {
 		apiParams[i] = params.AddMachineParams{

--- a/apiserver/client/machineconfig_test.go
+++ b/apiserver/client/machineconfig_test.go
@@ -31,7 +31,7 @@ type machineConfigSuite struct {
 var _ = gc.Suite(&machineConfigSuite{})
 
 func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
-	addrs := []network.Address{network.NewAddress("1.2.3.4", network.ScopeUnknown)}
+	addrs := network.NewAddresses("1.2.3.4")
 	hc := instance.MustParseHardware("mem=4G arch=amd64")
 	apiParams := params.AddMachineParams{
 		Jobs:       []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
@@ -103,7 +103,7 @@ func (s *machineConfigSuite) TestMachineConfigNoArch(c *gc.C) {
 
 func (s *machineConfigSuite) TestMachineConfigNoTools(c *gc.C) {
 	s.PatchValue(&envtools.DefaultBaseURL, "")
-	addrs := []network.Address{network.NewAddress("1.2.3.4", network.ScopeUnknown)}
+	addrs := network.NewAddresses("1.2.3.4")
 	hc := instance.MustParseHardware("mem=4G arch=amd64")
 	apiParams := params.AddMachineParams{
 		Series:     "quantal",

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -34,7 +34,7 @@ func (s *runSuite) addMachine(c *gc.C) *state.Machine {
 
 func (s *runSuite) addMachineWithAddress(c *gc.C, address string) *state.Machine {
 	machine := s.addMachine(c)
-	machine.SetAddresses(network.NewAddress(address, network.ScopeUnknown))
+	machine.SetAddresses(network.NewAddress(address))
 	return machine
 }
 
@@ -69,7 +69,7 @@ func (s *runSuite) addUnit(c *gc.C, service *state.Service) *state.Unit {
 	c.Assert(err, jc.ErrorIsNil)
 	machine, err := s.State.Machine(mId)
 	c.Assert(err, jc.ErrorIsNil)
-	machine.SetAddresses(network.NewAddress("10.3.2.1", network.ScopeUnknown))
+	machine.SetAddresses(network.NewAddress("10.3.2.1"))
 	return unit
 }
 

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -77,13 +77,10 @@ func (fakeAddresses) EnvironUUID() string {
 }
 
 func (fakeAddresses) APIHostPorts() ([][]network.HostPort, error) {
-	return [][]network.HostPort{{{
-		Address: network.NewAddress("apiaddresses", network.ScopeUnknown),
-		Port:    1,
-	}}, {{
-		Address: network.NewAddress("apiaddresses", network.ScopeUnknown),
-		Port:    2,
-	}}}, nil
+	return [][]network.HostPort{
+		network.NewHostPorts(1, "apiaddresses"),
+		network.NewHostPorts(2, "apiaddresses"),
+	}, nil
 }
 
 func (fakeAddresses) WatchAPIHostPorts() state.NotifyWatcher {

--- a/apiserver/deployer/deployer_test.go
+++ b/apiserver/deployer/deployer_test.go
@@ -299,7 +299,7 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 }
 
 func (s *deployerSuite) TestStateAddresses(c *gc.C) {
-	err := s.machine0.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := s.machine0.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addresses, err := s.State.Addresses()
@@ -313,11 +313,9 @@ func (s *deployerSuite) TestStateAddresses(c *gc.C) {
 }
 
 func (s *deployerSuite) TestAPIAddresses(c *gc.C) {
-	hostPorts := [][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		Port:    1234,
-	}}}
-
+	hostPorts := [][]network.HostPort{
+		network.NewHostPorts(1234, "0.1.2.3"),
+	}
 	err := s.State.SetAPIHostPorts(hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -155,10 +155,7 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(s.machine0.Addresses(), gc.HasLen, 0)
 	c.Assert(s.machine1.Addresses(), gc.HasLen, 0)
 
-	addresses := []network.Address{
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-		network.NewAddress("8.8.8.8", network.ScopeUnknown),
-	}
+	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
 
 	args := params.SetMachinesAddresses{MachineAddresses: []params.MachineAddresses{
 		{Tag: "machine-1", Addresses: params.FromNetworkAddresses(addresses)},
@@ -179,10 +176,7 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	err = s.machine1.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := []network.Address{
-		network.NewAddress("8.8.8.8", network.ScopeUnknown),
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-	}
+	expectedAddresses := network.NewAddresses("8.8.8.8", "127.0.0.1")
 	c.Assert(s.machine1.MachineAddresses(), gc.DeepEquals, expectedAddresses)
 	err = s.machine0.Refresh()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -265,7 +265,7 @@ func (s *prepareSuite) fillSubnet(c *gc.C, numAllocated int) {
 	sub, err := s.BackingState.AddSubnet(subInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i <= numAllocated; i++ {
-		addr := network.NewAddress(fmt.Sprintf("0.10.0.%d", i), network.ScopeUnknown)
+		addr := network.NewAddress(fmt.Sprintf("0.10.0.%d", i))
 		ipaddr, err := s.BackingState.AddIPAddress(addr, sub.ID())
 		c.Check(err, jc.ErrorIsNil)
 		err = ipaddr.SetState(state.AddressStateAllocated)
@@ -750,7 +750,7 @@ func (s *releaseSuite) allocateAddresses(c *gc.C, containerId string, numAllocat
 	sub, err := s.BackingState.AddSubnet(subInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < numAllocated; i++ {
-		addr := network.NewAddress(fmt.Sprintf("0.10.0.%d", i), network.ScopeUnknown)
+		addr := network.NewAddress(fmt.Sprintf("0.10.0.%d", i))
 		ipaddr, err := s.BackingState.AddIPAddress(addr, sub.ID())
 		c.Check(err, jc.ErrorIsNil)
 		err = ipaddr.AllocateTo(containerId, "")

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1427,11 +1427,9 @@ func (s *withStateServerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *withStateServerSuite) TestAPIAddresses(c *gc.C) {
-	hostPorts := [][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		Port:    1234,
-	}}}
-
+	hostPorts := [][]network.HostPort{
+		network.NewHostPorts(1234, "0.1.2.3"),
+	}
 	err := s.State.SetAPIHostPorts(hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/rsyslog/rsyslog_test.go
+++ b/apiserver/rsyslog/rsyslog_test.go
@@ -55,7 +55,7 @@ func verifyRsyslogCACert(c *gc.C, st *apirsyslog.State, expectedCA, expectedKey 
 
 func (s *rsyslogSuite) TestSetRsyslogCert(c *gc.C) {
 	st, m := s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
-	err := m.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := m.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.Rsyslog().SetRsyslogCert(coretesting.CACert, coretesting.CAKey)
@@ -65,7 +65,7 @@ func (s *rsyslogSuite) TestSetRsyslogCert(c *gc.C) {
 
 func (s *rsyslogSuite) TestSetRsyslogCertNil(c *gc.C) {
 	st, m := s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
-	err := m.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := m.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.Rsyslog().SetRsyslogCert("", "")
@@ -75,7 +75,7 @@ func (s *rsyslogSuite) TestSetRsyslogCertNil(c *gc.C) {
 
 func (s *rsyslogSuite) TestSetRsyslogCertInvalid(c *gc.C) {
 	st, m := s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
-	err := m.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := m.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.Rsyslog().SetRsyslogCert(string(pem.EncodeToMemory(&pem.Block{
@@ -90,7 +90,7 @@ func (s *rsyslogSuite) TestSetRsyslogCertPerms(c *gc.C) {
 	// create a machine-0 so we have an addresss to log to
 	m, err := s.State.AddMachine("trusty", state.JobManageEnviron)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err = m.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	unitState, _ := s.OpenAPIAsNewMachine(c, state.JobHostUnits)

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -136,7 +136,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 	defer ipv4State.Close()
 	c.Assert(ipv4State.Addr(), gc.Equals, net.JoinHostPort("127.0.0.1", portString))
 	c.Assert(ipv4State.APIHostPorts(), jc.DeepEquals, [][]network.HostPort{
-		{{network.NewAddress("127.0.0.1", network.ScopeMachineLocal), port}},
+		network.NewHostPorts(port, "127.0.0.1"),
 	})
 
 	_, err = ipv4State.Machiner().Machine(machine.MachineTag())
@@ -148,7 +148,7 @@ func (s *serverSuite) TestAPIServerCanListenOnBothIPv4AndIPv6(c *gc.C) {
 	defer ipv6State.Close()
 	c.Assert(ipv6State.Addr(), gc.Equals, net.JoinHostPort("::1", portString))
 	c.Assert(ipv6State.APIHostPorts(), jc.DeepEquals, [][]network.HostPort{
-		{{network.NewAddress("::1", network.ScopeMachineLocal), port}},
+		network.NewHostPorts(port, "::1"),
 	})
 
 	_, err = ipv6State.Machiner().Machine(machine.MachineTag())

--- a/cmd/juju/scp_unix_test.go
+++ b/cmd/juju/scp_unix_test.go
@@ -124,7 +124,7 @@ func (s *SCPSuite) TestSCPCommand(c *gc.C) {
 	srv = s.AddTestingService(c, "ipv6-svc", dummyCharm)
 	s.addUnit(srv, m[3], c)
 	// Simulate machine 3 has a public IPv6 address.
-	ipv6Addr := network.NewAddress("2001:db8::1", network.ScopePublic)
+	ipv6Addr := network.NewScopedAddress("2001:db8::1", network.ScopePublic)
 	err = m[3].SetAddresses(ipv6Addr)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/ssh_test.go
+++ b/cmd/juju/ssh_test.go
@@ -220,8 +220,14 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 }
 
 func (s *SSHCommonSuite) setAddresses(m *state.Machine, c *gc.C) {
-	addrPub := network.NewAddress(fmt.Sprintf("dummyenv-%s.dns", m.Id()), network.ScopePublic)
-	addrPriv := network.NewAddress(fmt.Sprintf("dummyenv-%s.internal", m.Id()), network.ScopeCloudLocal)
+	addrPub := network.NewScopedAddress(
+		fmt.Sprintf("dummyenv-%s.dns", m.Id()),
+		network.ScopePublic,
+	)
+	addrPriv := network.NewScopedAddress(
+		fmt.Sprintf("dummyenv-%s.internal", m.Id()),
+		network.ScopeCloudLocal,
+	)
 	err := m.SetAddresses(addrPub, addrPriv)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -253,8 +253,8 @@ var statusTests = []testCase{
 
 		startAliveMachine{"0"},
 		setAddresses{"0", []network.Address{
-			network.NewAddress("10.0.0.1", network.ScopeUnknown),
-			network.NewAddress("dummyenv-0.dns", network.ScopePublic),
+			network.NewAddress("10.0.0.1"),
+			network.NewScopedAddress("dummyenv-0.dns", network.ScopePublic),
 		}},
 		expect{
 			"simulate the PA starting an instance in response to the state change",
@@ -311,8 +311,8 @@ var statusTests = []testCase{
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		setAddresses{"0", []network.Address{
-			network.NewAddress("10.0.0.1", network.ScopeUnknown),
-			network.NewAddress("dummyenv-0.dns", network.ScopePublic),
+			network.NewAddress("10.0.0.1"),
+			network.NewScopedAddress("dummyenv-0.dns", network.ScopePublic),
 		}},
 		addCharm{"dummy"},
 		addService{
@@ -380,8 +380,8 @@ var statusTests = []testCase{
 		"instance with different hardware characteristics",
 		addMachine{machineId: "0", cons: machineCons, job: state.JobManageEnviron},
 		setAddresses{"0", []network.Address{
-			network.NewAddress("10.0.0.1", network.ScopeUnknown),
-			network.NewAddress("dummyenv-0.dns", network.ScopePublic),
+			network.NewAddress("10.0.0.1"),
+			network.NewScopedAddress("dummyenv-0.dns", network.ScopePublic),
 		}},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
@@ -462,7 +462,7 @@ var statusTests = []testCase{
 	), test(
 		"add two services and expose one, then add 2 more machines and some units",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addCharm{"dummy"},
@@ -498,11 +498,11 @@ var statusTests = []testCase{
 		},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		setAddresses{"2", []network.Address{network.NewAddress("dummyenv-2.dns", network.ScopeUnknown)}},
+		setAddresses{"2", network.NewAddresses("dummyenv-2.dns")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		expect{
@@ -576,10 +576,10 @@ var statusTests = []testCase{
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		startMachine{"3"},
 		// Simulate some status with info, while the agent is down.
-		setAddresses{"3", []network.Address{network.NewAddress("dummyenv-3.dns", network.ScopeUnknown)}},
+		setAddresses{"3", network.NewAddresses("dummyenv-3.dns")},
 		setMachineStatus{"3", state.StatusStopped, "Really?"},
 		addMachine{machineId: "4", job: state.JobHostUnits},
-		setAddresses{"4", []network.Address{network.NewAddress("dummyenv-4.dns", network.ScopeUnknown)}},
+		setAddresses{"4", network.NewAddresses("dummyenv-4.dns")},
 		startAliveMachine{"4"},
 		setMachineStatus{"4", state.StatusError, "Beware the red toys"},
 		ensureDyingUnit{"dummy-service/0"},
@@ -796,12 +796,12 @@ var statusTests = []testCase{
 	), test(
 		"a unit with a hook relation error",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 
@@ -863,12 +863,12 @@ var statusTests = []testCase{
 	), test(
 		"a unit with a hook relation error when the agent is down",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 
@@ -965,7 +965,7 @@ var statusTests = []testCase{
 	test(
 		"complex scenario with multiple related services",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addCharm{"wordpress"},
@@ -975,7 +975,7 @@ var statusTests = []testCase{
 		addService{name: "project", charm: "wordpress"},
 		setServiceExposed{"project", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"project", "1"},
@@ -984,7 +984,7 @@ var statusTests = []testCase{
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		setAddresses{"2", []network.Address{network.NewAddress("dummyenv-2.dns", network.ScopeUnknown)}},
+		setAddresses{"2", network.NewAddresses("dummyenv-2.dns")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
@@ -993,7 +993,7 @@ var statusTests = []testCase{
 		addService{name: "varnish", charm: "varnish"},
 		setServiceExposed{"varnish", true},
 		addMachine{machineId: "3", job: state.JobHostUnits},
-		setAddresses{"3", []network.Address{network.NewAddress("dummyenv-3.dns", network.ScopeUnknown)}},
+		setAddresses{"3", network.NewAddresses("dummyenv-3.dns")},
 		startAliveMachine{"3"},
 		setMachineStatus{"3", state.StatusStarted, ""},
 		addUnit{"varnish", "3"},
@@ -1001,7 +1001,7 @@ var statusTests = []testCase{
 		addService{name: "private", charm: "wordpress"},
 		setServiceExposed{"private", true},
 		addMachine{machineId: "4", job: state.JobHostUnits},
-		setAddresses{"4", []network.Address{network.NewAddress("dummyenv-4.dns", network.ScopeUnknown)}},
+		setAddresses{"4", network.NewAddresses("dummyenv-4.dns")},
 		startAliveMachine{"4"},
 		setMachineStatus{"4", state.StatusStarted, ""},
 		addUnit{"private", "4"},
@@ -1085,7 +1085,7 @@ var statusTests = []testCase{
 	), test(
 		"simple peer scenario",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addCharm{"riak"},
@@ -1094,19 +1094,19 @@ var statusTests = []testCase{
 		addService{name: "riak", charm: "riak"},
 		setServiceExposed{"riak", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"riak", "1"},
 		setUnitStatus{"riak/0", state.StatusActive, "", nil},
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		setAddresses{"2", []network.Address{network.NewAddress("dummyenv-2.dns", network.ScopeUnknown)}},
+		setAddresses{"2", network.NewAddresses("dummyenv-2.dns")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"riak", "2"},
 		setUnitStatus{"riak/1", state.StatusActive, "", nil},
 		addMachine{machineId: "3", job: state.JobHostUnits},
-		setAddresses{"3", []network.Address{network.NewAddress("dummyenv-3.dns", network.ScopeUnknown)}},
+		setAddresses{"3", network.NewAddresses("dummyenv-3.dns")},
 		startAliveMachine{"3"},
 		setMachineStatus{"3", state.StatusStarted, ""},
 		addAliveUnit{"riak", "3"},
@@ -1156,7 +1156,7 @@ var statusTests = []testCase{
 	test(
 		"one service with one subordinate service",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addCharm{"wordpress"},
@@ -1166,7 +1166,7 @@ var statusTests = []testCase{
 		addService{name: "wordpress", charm: "wordpress"},
 		setServiceExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
@@ -1175,7 +1175,7 @@ var statusTests = []testCase{
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		setAddresses{"2", []network.Address{network.NewAddress("dummyenv-2.dns", network.ScopeUnknown)}},
+		setAddresses{"2", network.NewAddresses("dummyenv-2.dns")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
@@ -1375,7 +1375,7 @@ var statusTests = []testCase{
 	test(
 		"machines with containers",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addCharm{"mysql"},
@@ -1383,7 +1383,7 @@ var statusTests = []testCase{
 		setServiceExposed{"mysql", true},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "1"},
@@ -1391,7 +1391,7 @@ var statusTests = []testCase{
 
 		// A container on machine 1.
 		addContainer{"1", "1/lxc/0", state.JobHostUnits},
-		setAddresses{"1/lxc/0", []network.Address{network.NewAddress("dummyenv-2.dns", network.ScopeUnknown)}},
+		setAddresses{"1/lxc/0", network.NewAddresses("dummyenv-2.dns")},
 		startAliveMachine{"1/lxc/0"},
 		setMachineStatus{"1/lxc/0", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "1/lxc/0"},
@@ -1400,7 +1400,7 @@ var statusTests = []testCase{
 
 		// A nested container.
 		addContainer{"1/lxc/0", "1/lxc/0/lxc/0", state.JobHostUnits},
-		setAddresses{"1/lxc/0/lxc/0", []network.Address{network.NewAddress("dummyenv-3.dns", network.ScopeUnknown)}},
+		setAddresses{"1/lxc/0/lxc/0", network.NewAddresses("dummyenv-3.dns")},
 		startAliveMachine{"1/lxc/0/lxc/0"},
 		setMachineStatus{"1/lxc/0/lxc/0", state.StatusStarted, ""},
 
@@ -1474,11 +1474,11 @@ var statusTests = []testCase{
 	), test(
 		"service with out of date charm",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addCharm{"mysql"},
@@ -1514,11 +1514,11 @@ var statusTests = []testCase{
 	), test(
 		"unit with out of date charm",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addCharm{"mysql"},
@@ -1556,11 +1556,11 @@ var statusTests = []testCase{
 	), test(
 		"service and unit with out of date charms",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addCharm{"mysql"},
@@ -1600,11 +1600,11 @@ var statusTests = []testCase{
 	), test(
 		"service with local charm not shown as out of date",
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addCharm{"mysql"},
@@ -2232,7 +2232,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 	defer s.resetContext(c, ctx)
 	steps := []stepper{
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("localhost", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("localhost")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addCharm{"wordpress"},
@@ -2241,7 +2241,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addService{name: "wordpress", charm: "wordpress"},
 		setServiceExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("localhost", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("localhost")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
@@ -2249,7 +2249,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		setAddresses{"2", []network.Address{network.NewAddress("10.0.0.1", network.ScopeUnknown)}},
+		setAddresses{"2", network.NewAddresses("10.0.0.1")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
@@ -2295,7 +2295,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 	defer s.resetContext(c, ctx)
 	steps := []stepper{
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addCharm{"wordpress"},
@@ -2305,7 +2305,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addService{name: "wordpress", charm: "wordpress"},
 		setServiceExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
@@ -2314,7 +2314,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		setAddresses{"2", []network.Address{network.NewAddress("dummyenv-2.dns", network.ScopeUnknown)}},
+		setAddresses{"2", network.NewAddresses("dummyenv-2.dns")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
@@ -2366,7 +2366,7 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 	defer s.resetContext(c, ctx)
 	steps := []stepper{
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		addCharm{"wordpress"},
@@ -2375,7 +2375,7 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 		addService{name: "wordpress", charm: "wordpress"},
 		setServiceExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
@@ -2383,7 +2383,7 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
-		setAddresses{"2", []network.Address{network.NewAddress("dummyenv-2.dns", network.ScopeUnknown)}},
+		setAddresses{"2", network.NewAddresses("dummyenv-2.dns")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
@@ -2435,7 +2435,7 @@ func (s *StatusSuite) TestStatusWithNilStatusApi(c *gc.C) {
 	defer s.resetContext(c, ctx)
 	steps := []stepper{
 		addMachine{machineId: "0", job: state.JobManageEnviron},
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 	}
@@ -2473,7 +2473,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		startAliveMachine{"0"},
 		setMachineStatus{"0", state.StatusStarted, ""},
 		// And the machine's address is "dummyenv-0.dns"
-		setAddresses{"0", []network.Address{network.NewAddress("dummyenv-0.dns", network.ScopeUnknown)}},
+		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		// And the "wordpress" charm is available
 		addCharm{"wordpress"},
 		addService{name: "wordpress", charm: "wordpress"},
@@ -2489,7 +2489,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		// And the machine's address is "dummyenv-1.dns"
-		setAddresses{"1", []network.Address{network.NewAddress("dummyenv-1.dns", network.ScopeUnknown)}},
+		setAddresses{"1", network.NewAddresses("dummyenv-1.dns")},
 		// And a unit of "wordpress" is deployed to machine "1"
 		addAliveUnit{"wordpress", "1"},
 		// And the unit is started
@@ -2502,7 +2502,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		// And the machine's address is "dummyenv-2.dns"
-		setAddresses{"2", []network.Address{network.NewAddress("dummyenv-2.dns", network.ScopeUnknown)}},
+		setAddresses{"2", network.NewAddresses("dummyenv-2.dns")},
 		// And a unit of "mysql" is deployed to machine "2"
 		addAliveUnit{"mysql", "2"},
 		// And the unit is started
@@ -2639,9 +2639,9 @@ func (s *StatusSuite) TestFilterOnSubnet(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// Given the address for machine "1" is "localhost"
-	setAddresses{"1", []network.Address{network.NewAddress("localhost", network.ScopeUnknown)}}.step(c, ctx)
+	setAddresses{"1", network.NewAddresses("localhost")}.step(c, ctx)
 	// And the address for machine "2" is "10.0.0.1"
-	setAddresses{"2", []network.Address{network.NewAddress("10.0.0.1", network.ScopeUnknown)}}.step(c, ctx)
+	setAddresses{"2", network.NewAddresses("10.0.0.1")}.step(c, ctx)
 	// When I run juju status --format oneline 127.0.0.1
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "127.0.0.1")
 	c.Assert(stderr, gc.IsNil)
@@ -2661,9 +2661,9 @@ func (s *StatusSuite) TestFilterOnPorts(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// Given the address for machine "1" is "localhost"
-	setAddresses{"1", []network.Address{network.NewAddress("localhost", network.ScopeUnknown)}}.step(c, ctx)
+	setAddresses{"1", network.NewAddresses("localhost")}.step(c, ctx)
 	// And the address for machine "2" is "10.0.0.1"
-	setAddresses{"2", []network.Address{network.NewAddress("10.0.0.1", network.ScopeUnknown)}}.step(c, ctx)
+	setAddresses{"2", network.NewAddresses("10.0.0.1")}.step(c, ctx)
 	openUnitPort{"wordpress/0", "tcp", 80}.step(c, ctx)
 	// When I run juju status --format oneline 80/tcp
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "80/tcp")

--- a/cmd/juju/upgradejuju_test.go
+++ b/cmd/juju/upgradejuju_test.go
@@ -422,10 +422,9 @@ func (s *UpgradeJujuSuite) Reset(c *gc.C) {
 	s.PatchValue(&sync.BuildToolsTarball, toolstesting.GetMockBuildTools(c))
 
 	// Set API host ports so FindTools works.
-	hostPorts := [][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		Port:    1234,
-	}}}
+	hostPorts := [][]network.HostPort{
+		network.NewHostPorts(1234, "0.1.2.3"),
+	}
 	err = s.State.SetAPIHostPorts(hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -163,10 +163,9 @@ func (s *AgentSuite) TearDownSuite(c *gc.C) {
 func (s *AgentSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	// Set API host ports so FindTools/Tools API calls succeed.
-	hostPorts := [][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		Port:    1234,
-	}}}
+	hostPorts := [][]network.HostPort{
+		network.NewHostPorts(1234, "0.1.2.3"),
+	}
 	err := s.State.SetAPIHostPorts(hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&proxyupdater.New, func(*apienvironment.Facade, bool) worker.Worker {
@@ -178,13 +177,13 @@ func (s *AgentSuite) primeAPIHostPorts(c *gc.C) {
 	apiInfo := s.APIInfo(c)
 
 	c.Assert(apiInfo.Addrs, gc.HasLen, 1)
-	hostPort, err := agenttesting.ParseHostPort(apiInfo.Addrs[0])
+	hostPorts, err := network.ParseHostPorts(apiInfo.Addrs[0])
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.SetAPIHostPorts([][]network.HostPort{{hostPort}})
+	err = s.State.SetAPIHostPorts([][]network.HostPort{hostPorts})
 	c.Assert(err, jc.ErrorIsNil)
 
-	logger.Debugf("api host ports primed %#v", hostPort)
+	logger.Debugf("api host ports primed %#v", hostPorts)
 }
 
 // primeStateAgent writes the configuration file and tools with version vers

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -418,9 +418,7 @@ func patchDeployContext(c *gc.C, st *state.State) (*fakeContext, func()) {
 }
 
 func (s *commonMachineSuite) setFakeMachineAddresses(c *gc.C, machine *state.Machine) {
-	addrs := []network.Address{
-		network.NewAddress("0.1.2.3", network.ScopeUnknown),
-	}
+	addrs := network.NewAddresses("0.1.2.3")
 	err := machine.SetAddresses(addrs...)
 	c.Assert(err, jc.ErrorIsNil)
 	// Set the addresses in the environ instance as well so that if the instance poller
@@ -554,7 +552,7 @@ func (s *MachineSuite) TestManageEnvironRunsInstancePoller(c *gc.C) {
 	m, instId := s.waitProvisioned(c, units[0])
 	insts, err := s.Environ.Instances([]instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
-	addrs := []network.Address{network.NewAddress("1.2.3.4", network.ScopeUnknown)}
+	addrs := network.NewAddresses("1.2.3.4")
 	dummy.SetInstanceAddresses(insts[0], addrs)
 	dummy.SetInstanceStatus(insts[0], "running")
 

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -4,9 +4,6 @@
 package testing
 
 import (
-	"fmt"
-	"net"
-	"strconv"
 	"time"
 
 	"github.com/juju/cmd"
@@ -106,27 +103,13 @@ func (s *AgentSuite) primeAPIHostPorts(c *gc.C) {
 	apiInfo := s.APIInfo(c)
 
 	c.Assert(apiInfo.Addrs, gc.HasLen, 1)
-	hostPort, err := ParseHostPort(apiInfo.Addrs[0])
+	hostPorts, err := network.ParseHostPorts(apiInfo.Addrs[0])
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.SetAPIHostPorts([][]network.HostPort{{hostPort}})
+	err = s.State.SetAPIHostPorts([][]network.HostPort{hostPorts})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Logf("api host ports primed %#v", hostPort)
-}
-
-func ParseHostPort(s string) (network.HostPort, error) {
-	addr, port, err := net.SplitHostPort(s)
-	if err != nil {
-		return network.HostPort{}, err
-	}
-	portNum, err := strconv.Atoi(port)
-	if err != nil {
-		return network.HostPort{}, fmt.Errorf("bad port number %q", port)
-	}
-	addrs := network.NewAddresses(addr)
-	hostPorts := network.AddressesWithPort(addrs, portNum)
-	return hostPorts[0], nil
+	c.Logf("api host ports primed %#v", hostPorts)
 }
 
 // InitAgent initialises the given agent command with additional

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -282,8 +282,8 @@ func (s *LxcSuite) TestUpdateContainerConfig(c *gc.C) {
 		CIDR:           "0.1.2.0/20",
 		InterfaceName:  "eth0",
 		MACAddress:     "aa:bb:cc:dd:ee:f0",
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		Address:        network.NewAddress("0.1.2.3"),
+		GatewayAddress: network.NewAddress("0.1.2.1"),
 	}, {
 		DeviceIndex:   1,
 		InterfaceName: "eth1",
@@ -1094,8 +1094,8 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 		CIDR:           "0.1.2.0/20", // used to infer the subnet mask.
 		MACAddress:     "aa:bb:cc:dd:ee:f1",
 		InterfaceName:  "eth1",
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		Address:        network.NewAddress("0.1.2.3"),
+		GatewayAddress: network.NewAddress("0.1.2.1"),
 		// The rest is passed to cloud-init.
 		ConfigType: network.ConfigStatic,
 		DNSServers: network.NewAddresses("ns1.invalid", "ns2.invalid"),

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -36,9 +36,9 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 		CIDR:           "0.1.2.0/24",
 		ConfigType:     network.ConfigStatic,
 		NoAutoStart:    false,
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		Address:        network.NewAddress("0.1.2.3"),
 		DNSServers:     network.NewAddresses("ns1.invalid", "ns2.invalid"),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		GatewayAddress: network.NewAddress("0.1.2.1"),
 	}, {
 		InterfaceName: "eth1",
 		ConfigType:    network.ConfigDHCP,

--- a/environs/utils.go
+++ b/environs/utils.go
@@ -102,7 +102,9 @@ func APIInfo(env Environ) (*api.Info, error) {
 		return nil, errors.New("config has no CACert")
 	}
 	apiPort := config.APIPort()
-	apiAddrs := network.HostPortsToStrings(network.AddressesWithPort(addrs, apiPort))
+	apiAddrs := network.HostPortsToStrings(
+		network.AddressesWithPort(addrs, apiPort),
+	)
 	uuid, uuidSet := config.UUID()
 	if !uuidSet {
 		return nil, errors.New("config has no UUID")

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -342,18 +342,18 @@ func mockedAPIState(flags mockedStateFlags) *mockAPIState {
 
 	apiHostPorts := [][]network.HostPort{}
 	if hasHostPort {
-		ipv4Address := network.NewAddress("0.1.2.3", network.ScopeUnknown)
-		ipv6Address := network.NewAddress("2001:db8::1", network.ScopeUnknown)
+		var apiAddrs []network.Address
+		ipv4Address := network.NewAddress("0.1.2.3")
+		ipv6Address := network.NewAddress("2001:db8::1")
 		if preferIPv6 {
 			addr = net.JoinHostPort(ipv6Address.Value, "1234")
-			apiHostPorts = [][]network.HostPort{
-				network.AddressesWithPort([]network.Address{ipv6Address, ipv4Address}, 1234),
-			}
+			apiAddrs = append(apiAddrs, ipv6Address, ipv4Address)
 		} else {
 			addr = net.JoinHostPort(ipv4Address.Value, "1234")
-			apiHostPorts = [][]network.HostPort{
-				network.AddressesWithPort([]network.Address{ipv4Address, ipv6Address}, 1234),
-			}
+			apiAddrs = append(apiAddrs, ipv4Address, ipv6Address)
+		}
+		apiHostPorts = [][]network.HostPort{
+			network.AddressesWithPort(apiAddrs, 1234),
 		}
 	}
 	environTag := ""
@@ -1220,10 +1220,7 @@ func (s *CacheAPIEndpointsSuite) nextHostPorts(host string, types ...network.Add
 			addr = fmt.Sprintf("fc00::%d", s.resolveSeq+num6)
 			num6++
 		}
-		result[i] = network.HostPort{
-			Address: network.NewAddress(addr, network.ScopeUnknown),
-			Port:    1234,
-		}
+		result[i] = network.NewHostPorts(1234, addr)[0]
 	}
 	s.resolveSeq += num4 + num6
 	s.gocheckC.Logf("resolving %q as %v", host, result)

--- a/juju/testing/utils.go
+++ b/juju/testing/utils.go
@@ -21,13 +21,12 @@ import (
 func AddStateServerMachine(c *gc.C, st *state.State) *state.Machine {
 	machine, err := st.AddMachine("quantal", state.JobManageEnviron)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err = machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	hostPorts := [][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		Port:    1234,
-	}}}
+	hostPorts := [][]network.HostPort{
+		network.NewHostPorts(1234, "0.1.2.3"),
+	}
 	err = st.SetAPIHostPorts(hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/network/address.go
+++ b/network/address.go
@@ -107,10 +107,37 @@ func (a Address) GoString() string {
 	return a.String()
 }
 
-// NewAddresses is a convenience function to create addresses from a string slice
+// NewAddress creates a new Address, deriving its type from the value
+// and using ScopeUnknown as scope. It's a shortcut to calling
+// NewScopedAddress(value, ScopeUnknown).
+func NewAddress(value string) Address {
+	return NewScopedAddress(value, ScopeUnknown)
+}
+
+// NewScopedAddress creates a new Address, deriving its type from the
+// value.
+//
+// If the specified scope is ScopeUnknown, then NewScopedAddress will
+// attempt derive the scope based on reserved IP address ranges.
+// Because passing ScopeUnknown is fairly common, NewAddress() above
+// does exactly that.
+func NewScopedAddress(value string, scope Scope) Address {
+	addr := Address{
+		Value: value,
+		Type:  DeriveAddressType(value),
+		Scope: scope,
+	}
+	if scope == ScopeUnknown {
+		addr.Scope = deriveScope(addr)
+	}
+	return addr
+}
+
+// NewAddresses is a convenience function to create addresses from a
+// string slice.
 func NewAddresses(inAddresses ...string) (outAddresses []Address) {
 	for _, address := range inAddresses {
-		outAddresses = append(outAddresses, NewAddress(address, ScopeUnknown))
+		outAddresses = append(outAddresses, NewAddress(address))
 	}
 	return outAddresses
 }
@@ -174,22 +201,6 @@ func deriveScope(addr Address) Scope {
 		return ScopePublic
 	}
 	return addr.Scope
-}
-
-// NewAddress creates a new Address, deriving its type from the value.
-//
-// If the specified scope is ScopeUnknown, then NewAddress will
-// attempt derive the scope based on reserved IP address ranges.
-func NewAddress(value string, scope Scope) Address {
-	addr := Address{
-		Value: value,
-		Type:  DeriveAddressType(value),
-		Scope: scope,
-	}
-	if scope == ScopeUnknown {
-		addr.Scope = deriveScope(addr)
-	}
-	return addr
 }
 
 // SelectPublicAddress picks one address from a slice that would be

--- a/network/hostport.go
+++ b/network/hostport.go
@@ -53,7 +53,7 @@ func NewHostPorts(port int, addresses ...string) []HostPort {
 	hps := make([]HostPort, len(addresses))
 	for i, addr := range addresses {
 		hps[i] = HostPort{
-			Address: NewAddress(addr, ScopeUnknown),
+			Address: NewAddress(addr),
 			Port:    port,
 		}
 	}
@@ -75,7 +75,7 @@ func ParseHostPorts(hostPorts ...string) ([]HostPort, error) {
 			return nil, errors.Annotatef(err, "cannot parse %q port", hp)
 		}
 		hps[i] = HostPort{
-			Address: NewAddress(host, ScopeUnknown),
+			Address: NewAddress(host),
 			Port:    numPort,
 		}
 	}
@@ -166,7 +166,7 @@ func ResolveOrDropHostnames(hps []HostPort) []HostPort {
 			if ip == nil {
 				continue
 			}
-			addr := NewAddress(ip.String(), ScopeUnknown)
+			addr := NewAddress(ip.String())
 			if !uniqueAddrs.Contains(addr.Value) {
 				result = append(result, HostPort{Address: addr, Port: hp.Port})
 				uniqueAddrs.Add(addr.Value)

--- a/network/hostport_test.go
+++ b/network/hostport_test.go
@@ -274,9 +274,9 @@ func (*HostPortSuite) TestParseHostPortsSuccess(c *gc.C) {
 	}, {
 		args: []string{"[fc00::1]:1234", "127.0.0.1:4321", "example.com:42"},
 		expect: []network.HostPort{
-			{network.NewAddress("fc00::1", network.ScopeUnknown), 1234},
-			{network.NewAddress("127.0.0.1", network.ScopeUnknown), 4321},
-			{network.NewAddress("example.com", network.ScopeUnknown), 42},
+			{network.NewAddress("fc00::1"), 1234},
+			{network.NewAddress("127.0.0.1"), 4321},
+			{network.NewAddress("example.com"), 42},
 		},
 	}} {
 		c.Logf("test %d: args %v", i, test.args)
@@ -290,10 +290,10 @@ func (*HostPortSuite) TestAddressesWithPortAndHostsWithoutPort(c *gc.C) {
 	addrs := network.NewAddresses("0.1.2.3", "0.2.4.6")
 	hps := network.AddressesWithPort(addrs, 999)
 	c.Assert(hps, jc.DeepEquals, []network.HostPort{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3"),
 		Port:    999,
 	}, {
-		Address: network.NewAddress("0.2.4.6", network.ScopeUnknown),
+		Address: network.NewAddress("0.2.4.6"),
 		Port:    999,
 	}})
 	c.Assert(network.HostsWithoutPort(hps), jc.DeepEquals, addrs)
@@ -385,43 +385,43 @@ var netAddrTests = []struct {
 	port   int
 	expect string
 }{{
-	addr:   network.NewAddress("0.1.2.3", network.ScopeUnknown),
+	addr:   network.NewAddress("0.1.2.3"),
 	port:   99,
 	expect: "0.1.2.3:99",
 }, {
-	addr:   network.NewAddress("2001:DB8::1", network.ScopeUnknown),
+	addr:   network.NewAddress("2001:DB8::1"),
 	port:   100,
 	expect: "[2001:DB8::1]:100",
 }, {
-	addr:   network.NewAddress("172.16.0.1", network.ScopeUnknown),
+	addr:   network.NewAddress("172.16.0.1"),
 	port:   52,
 	expect: "172.16.0.1:52",
 }, {
-	addr:   network.NewAddress("fc00::2", network.ScopeUnknown),
+	addr:   network.NewAddress("fc00::2"),
 	port:   1111,
 	expect: "[fc00::2]:1111",
 }, {
-	addr:   network.NewAddress("example.com", network.ScopeUnknown),
+	addr:   network.NewAddress("example.com"),
 	port:   9999,
 	expect: "example.com:9999",
 }, {
-	addr:   network.NewAddress("example.com", network.ScopePublic),
+	addr:   network.NewScopedAddress("example.com", network.ScopePublic),
 	port:   1234,
 	expect: "example.com:1234",
 }, {
-	addr:   network.NewAddress("169.254.1.2", network.ScopeUnknown),
+	addr:   network.NewAddress("169.254.1.2"),
 	port:   123,
 	expect: "169.254.1.2:123",
 }, {
-	addr:   network.NewAddress("fe80::222", network.ScopeUnknown),
+	addr:   network.NewAddress("fe80::222"),
 	port:   321,
 	expect: "[fe80::222]:321",
 }, {
-	addr:   network.NewAddress("127.0.0.2", network.ScopeUnknown),
+	addr:   network.NewAddress("127.0.0.2"),
 	port:   121,
 	expect: "127.0.0.2:121",
 }, {
-	addr:   network.NewAddress("::1", network.ScopeUnknown),
+	addr:   network.NewAddress("::1"),
 	port:   111,
 	expect: "[::1]:111",
 }}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -27,9 +27,9 @@ func (s *InterfaceInfoSuite) SetUpTest(c *gc.C) {
 		{VLANTag: 0, DeviceIndex: 1, InterfaceName: "eth1"},
 		{VLANTag: 42, DeviceIndex: 2, InterfaceName: "br2"},
 		{ConfigType: network.ConfigDHCP, NoAutoStart: true},
-		{Address: network.NewAddress("0.1.2.3", network.ScopeUnknown)},
+		{Address: network.NewAddress("0.1.2.3")},
 		{DNSServers: network.NewAddresses("1.1.1.1", "2.2.2.2")},
-		{GatewayAddress: network.NewAddress("4.3.2.1", network.ScopeUnknown)},
+		{GatewayAddress: network.NewAddress("4.3.2.1")},
 		{ExtraConfig: map[string]string{
 			"foo": "bar",
 			"baz": "nonsense",
@@ -58,9 +58,9 @@ func (s *InterfaceInfoSuite) TestIsVLAN(c *gc.C) {
 func (s *InterfaceInfoSuite) TestAdditionalFields(c *gc.C) {
 	c.Check(s.info[3].ConfigType, gc.Equals, network.ConfigDHCP)
 	c.Check(s.info[3].NoAutoStart, jc.IsTrue)
-	c.Check(s.info[4].Address, jc.DeepEquals, network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	c.Check(s.info[4].Address, jc.DeepEquals, network.NewAddress("0.1.2.3"))
 	c.Check(s.info[5].DNSServers, jc.DeepEquals, network.NewAddresses("1.1.1.1", "2.2.2.2"))
-	c.Check(s.info[6].GatewayAddress, jc.DeepEquals, network.NewAddress("4.3.2.1", network.ScopeUnknown))
+	c.Check(s.info[6].GatewayAddress, jc.DeepEquals, network.NewAddress("4.3.2.1"))
 	c.Check(s.info[7].ExtraConfig, jc.DeepEquals, map[string]string{
 		"foo": "bar",
 		"baz": "nonsense",

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -242,7 +242,7 @@ func (i *interruptOnDial) Addresses() ([]network.Address, error) {
 	} else {
 		i.interrupted <- os.Interrupt
 	}
-	return []network.Address{network.NewAddress(i.name, network.ScopeUnknown)}, nil
+	return network.NewAddresses(i.name), nil
 }
 
 func (s *BootstrapSuite) TestWaitSSHKilledWaitingForDial(c *gc.C) {
@@ -270,11 +270,7 @@ func (ac *addressesChange) Refresh() error {
 }
 
 func (ac *addressesChange) Addresses() ([]network.Address, error) {
-	var addrs []network.Address
-	for _, addr := range ac.addrs[0] {
-		addrs = append(addrs, network.NewAddress(addr, network.ScopeUnknown))
-	}
-	return addrs, nil
+	return network.NewAddresses(ac.addrs[0]...), nil
 }
 
 func (s *BootstrapSuite) TestWaitSSHRefreshAddresses(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -872,7 +872,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	idString := fmt.Sprintf("%s-%d", e.name, estate.maxId)
 	addrs := network.NewAddresses(idString+".dns", "127.0.0.1")
 	if estate.preferIPv6 {
-		addrs = append(addrs, network.NewAddress(fmt.Sprintf("fc00::%x", estate.maxId+1), network.ScopeUnknown))
+		addrs = append(addrs, network.NewAddress(fmt.Sprintf("fc00::%x", estate.maxId+1)))
 	}
 	logger.Debugf("StartInstance addresses: %v", addrs)
 	i := &dummyInstance{
@@ -1125,12 +1125,10 @@ func (env *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceIn
 			ConfigType:       network.ConfigDHCP,
 			Address: network.NewAddress(
 				fmt.Sprintf("0.%d.0.%d", (i+1)*10, estate.maxAddr+2),
-				network.ScopeUnknown,
 			),
 			DNSServers: network.NewAddresses("ns1.dummy", "ns2.dummy"),
 			GatewayAddress: network.NewAddress(
 				fmt.Sprintf("0.%d.0.1", (i+1)*10),
-				network.ScopeUnknown,
 			),
 		}
 	}

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -183,19 +183,19 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 	dummy.Listen(opc)
 
 	// Test allocating a couple of addresses.
-	newAddress := network.NewAddress("0.1.2.1", network.ScopeCloudLocal)
+	newAddress := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
 	err := e.AllocateAddress(inst.Id(), subnetId, newAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress)
 
-	newAddress = network.NewAddress("0.1.2.2", network.ScopeCloudLocal)
+	newAddress = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
 	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress)
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "AllocateAddress")
-	newAddress = network.NewAddress("0.1.2.3", network.ScopeCloudLocal)
+	newAddress = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
 	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
 	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
 }
@@ -215,19 +215,19 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 	dummy.Listen(opc)
 
 	// Release a couple of addresses.
-	address := network.NewAddress("0.1.2.1", network.ScopeCloudLocal)
+	address := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
 	err := e.ReleaseAddress(inst.Id(), subnetId, address)
 	c.Assert(err, jc.ErrorIsNil)
 	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address)
 
-	address = network.NewAddress("0.1.2.2", network.ScopeCloudLocal)
+	address = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
 	err = e.ReleaseAddress(inst.Id(), subnetId, address)
 	c.Assert(err, jc.ErrorIsNil)
 	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address)
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "ReleaseAddress")
-	address = network.NewAddress("0.1.2.3", network.ScopeCloudLocal)
+	address = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
 	err = e.ReleaseAddress(inst.Id(), subnetId, address)
 	c.Assert(err, gc.ErrorMatches, `dummy\.ReleaseAddress is broken`)
 }
@@ -254,9 +254,9 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       network.ConfigDHCP,
-		Address:          network.NewAddress("0.10.0.2", network.ScopeUnknown),
+		Address:          network.NewAddress("0.10.0.2"),
 		DNSServers:       network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress:   network.NewAddress("0.10.0.1", network.ScopeUnknown),
+		GatewayAddress:   network.NewAddress("0.10.0.1"),
 		ExtraConfig:      nil,
 	}, {
 		ProviderId:       "dummy-eth1",
@@ -270,9 +270,9 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		Disabled:         true,
 		NoAutoStart:      true,
 		ConfigType:       network.ConfigDHCP,
-		Address:          network.NewAddress("0.20.0.2", network.ScopeUnknown),
+		Address:          network.NewAddress("0.20.0.2"),
 		DNSServers:       network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress:   network.NewAddress("0.20.0.1", network.ScopeUnknown),
+		GatewayAddress:   network.NewAddress("0.20.0.1"),
 		ExtraConfig:      nil,
 	}}
 	info, err := e.NetworkInterfaces("i-42")

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -855,7 +855,7 @@ func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo
 			Disabled:      false,
 			NoAutoStart:   false,
 			ConfigType:    network.ConfigDHCP,
-			Address:       network.NewAddress(iface.PrivateIPAddress, network.ScopeCloudLocal),
+			Address:       network.NewScopedAddress(iface.PrivateIPAddress, network.ScopeCloudLocal),
 		}
 	}
 	return result, nil

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -831,7 +831,7 @@ func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       network.ConfigDHCP,
-		Address:          network.NewAddress("10.10.0.5", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("10.10.0.5", network.ScopeCloudLocal),
 	}}
 	c.Assert(interfaces, jc.DeepEquals, expectedInterfaces)
 }

--- a/provider/joyent/instance.go
+++ b/provider/joyent/instance.go
@@ -32,7 +32,7 @@ func (inst *joyentInstance) Refresh() error {
 func (inst *joyentInstance) Addresses() ([]network.Address, error) {
 	addresses := make([]network.Address, 0, len(inst.machine.IPs))
 	for _, ip := range inst.machine.IPs {
-		address := network.NewAddress(ip, network.ScopeUnknown)
+		address := network.NewAddress(ip)
 		if ip == inst.machine.PrimaryIP {
 			address.Scope = network.ScopePublic
 		} else {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1266,7 +1266,7 @@ func (environ *maasEnviron) NetworkInterfaces(instId instance.Id) ([]network.Int
 			mask := net.IPMask(net.ParseIP(details.Mask))
 			cidr := net.IPNet{net.ParseIP(details.IP), mask}
 			ifaceInfo.CIDR = cidr.String()
-			ifaceInfo.Address = network.NewAddress(cidr.IP.String(), network.ScopeUnknown)
+			ifaceInfo.Address = network.NewAddress(cidr.IP.String())
 		} else {
 			logger.Debugf("no subnet information for MAC address %q, instance %q", serial, instId)
 		}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1107,7 +1107,7 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
 		GatewayAddress:   network.Address{},
-		Address:          network.NewAddress("192.168.1.1", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("192.168.1.1", network.ScopeCloudLocal),
 	}, {
 		DeviceIndex:      1,
 		MACAddress:       "aa:bb:cc:dd:ee:f1",
@@ -1120,7 +1120,7 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
 		GatewayAddress:   network.Address{},
-		Address:          network.NewAddress("192.168.2.1", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("192.168.2.1", network.ScopeCloudLocal),
 	}, {
 		DeviceIndex:      2,
 		MACAddress:       "aa:bb:cc:dd:ee:f2",
@@ -1133,7 +1133,7 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
 		GatewayAddress:   network.Address{},
-		Address:          network.NewAddress("192.168.3.1", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("192.168.3.1", network.ScopeCloudLocal),
 	}}
 	network.SortInterfaceInfo(netInfo)
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -75,23 +75,20 @@ func (mi *maasInstance) Addresses() ([]network.Address, error) {
 	if err != nil {
 		return nil, err
 	}
-	host := network.Address{name, network.HostName, "", network.ScopePublic}
-	addrs := []network.Address{host}
 	// MAAS prefers to use the dns name for intra-node communication.
-	// When Juju looks up the address to use for communicating between nodes, it looks
-	// up the address bu scope. So we add a cloud local address for that purpose.
-	cloudHost := network.Address{name, network.HostName, "", network.ScopeCloudLocal}
-	addrs = append(addrs, cloudHost)
+	// When Juju looks up the address to use for communicating between
+	// nodes, it looks up the address by scope. So we add a cloud
+	// local address for that purpose.
+	addrs := network.NewAddresses(name, name)
+	addrs[0].Scope = network.ScopePublic
+	addrs[1].Scope = network.ScopeCloudLocal
 
+	// Append any remaining IP addresses after the preferred ones.
 	ips, err := mi.ipAddresses()
 	if err != nil {
 		return nil, err
 	}
-
-	for _, ip := range ips {
-		a := network.NewAddress(ip, network.ScopeUnknown)
-		addrs = append(addrs, a)
-	}
+	addrs = append(addrs, network.NewAddresses(ips...)...)
 
 	return addrs, nil
 }

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -72,10 +72,10 @@ func (s *instanceTest) TestAddresses(c *gc.C) {
 	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
 
 	expected := []network.Address{
-		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopePublic},
-		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopeCloudLocal},
-		network.NewAddress("1.2.3.4", network.ScopeUnknown),
-		network.NewAddress("fe80::d806:dbff:fe23:1199", network.ScopeUnknown),
+		network.NewScopedAddress("testing.invalid", network.ScopePublic),
+		network.NewScopedAddress("testing.invalid", network.ScopeCloudLocal),
+		network.NewAddress("1.2.3.4"),
+		network.NewAddress("fe80::d806:dbff:fe23:1199"),
 	}
 
 	addr, err := inst.Addresses()

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -462,7 +462,7 @@ func (inst *openstackInstance) Addresses() ([]network.Address, error) {
 func convertNovaAddresses(publicIP string, addresses map[string][]nova.IPAddress) []network.Address {
 	var machineAddresses []network.Address
 	if publicIP != "" {
-		publicAddr := network.NewAddress(publicIP, network.ScopePublic)
+		publicAddr := network.NewScopedAddress(publicIP, network.ScopePublic)
 		publicAddr.NetworkName = "public"
 		machineAddresses = append(machineAddresses, publicAddr)
 	}
@@ -484,7 +484,7 @@ func convertNovaAddresses(publicIP string, addresses map[string][]nova.IPAddress
 			if address.Version == 6 {
 				addrtype = network.IPv6Address
 			}
-			machineAddr := network.NewAddress(address.Address, networkScope)
+			machineAddr := network.NewScopedAddress(address.Address, networkScope)
 			machineAddr.NetworkName = netName
 			if machineAddr.Type != addrtype {
 				logger.Warningf("derived address type %v, nova reports %v", machineAddr.Type, addrtype)

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -18,14 +18,22 @@ type AddressSuite struct{}
 var _ = gc.Suite(&AddressSuite{})
 
 func (s *AddressSuite) TestAddressConversion(c *gc.C) {
-	netAddress := network.Address{"0.0.0.0", network.IPv4Address,
-		"net", network.ScopeUnknown}
+	netAddress := network.Address{
+		Value:       "0.0.0.0",
+		Type:        network.IPv4Address,
+		NetworkName: "net",
+		Scope:       network.ScopeUnknown,
+	}
 	state.AssertAddressConversion(c, netAddress)
 }
 
 func (s *AddressSuite) TestHostPortConversion(c *gc.C) {
-	netAddress := network.Address{"0.0.0.0", network.IPv4Address,
-		"net", network.ScopeUnknown}
+	netAddress := network.Address{
+		Value:       "0.0.0.0",
+		Type:        network.IPv4Address,
+		NetworkName: "net",
+		Scope:       network.ScopeUnknown,
+	}
 	netHostPort := network.HostPort{netAddress, 4711}
 	state.AssertHostPortConversion(c, netHostPort)
 }

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -72,13 +72,10 @@ func (b *backups) Restore(backupId string, args RestoreArgs) error {
 	}
 	// The machine tag might have changed, we update it.
 	agentConfig.SetValue("tag", args.NewInstTag.String())
-	APIHostPort := network.HostPort{
-		Address: network.Address{
-			Value: args.PrivateAddress,
-			Type:  network.DeriveAddressType(args.PrivateAddress),
-		},
-		Port: ssi.APIPort}
-	agentConfig.SetAPIHostPorts([][]network.HostPort{{APIHostPort}})
+	apiHostPorts := [][]network.HostPort{
+		network.NewHostPorts(ssi.APIPort, args.PrivateAddress),
+	}
+	agentConfig.SetAPIHostPorts(apiHostPorts)
 	if err := agentConfig.Write(); err != nil {
 		return errors.Annotate(err, "cannot write new agent configuration")
 	}

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -97,7 +97,7 @@ func (i *IPAddress) Value() string {
 
 // Address returns the network.Address represent the IP address
 func (i *IPAddress) Address() network.Address {
-	return network.NewAddress(i.doc.Value, i.Scope())
+	return network.NewScopedAddress(i.doc.Value, i.Scope())
 }
 
 // Type returns the type of the IP address. The IP address will have a type of

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -42,7 +42,7 @@ func (s *IPAddressSuite) assertAddress(
 func (s *IPAddressSuite) TestAddIPAddress(c *gc.C) {
 	for i, test := range []string{"0.1.2.3", "2001:db8::1"} {
 		c.Logf("test %d: %q", i, test)
-		addr := network.NewAddress(test, network.ScopePublic)
+		addr := network.NewScopedAddress(test, network.ScopePublic)
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertAddress(c, ipAddr, addr, state.AddressStateUnknown, "", "", "foobar")
@@ -63,7 +63,7 @@ func (s *IPAddressSuite) TestAddIPAddressInvalid(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestAddIPAddressAlreadyExists(c *gc.C) {
-	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 	_, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddIPAddress(addr, "foobar")
@@ -80,7 +80,7 @@ func (s *IPAddressSuite) TestIPAddressNotFound(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestEnsureDeadRemove(c *gc.C) {
-	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -110,7 +110,7 @@ func (s *IPAddressSuite) TestEnsureDeadRemove(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestSetStateDead(c *gc.C) {
-	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -125,7 +125,7 @@ func (s *IPAddressSuite) TestSetStateDead(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestAllocateToDead(c *gc.C) {
-	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -159,7 +159,7 @@ func (s *IPAddressSuite) TestAddressStateString(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestSetState(c *gc.C) {
-	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 
 	for i, test := range []struct {
 		initial, changeTo state.AddressState
@@ -227,7 +227,7 @@ func (s *IPAddressSuite) TestSetState(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestAllocateTo(c *gc.C) {
-	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.State(), gc.Equals, state.AddressStateUnknown)
@@ -255,7 +255,7 @@ func (s *IPAddressSuite) TestAllocateTo(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestAddress(c *gc.C) {
-	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.Address(), jc.DeepEquals, addr)
@@ -269,7 +269,7 @@ func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
 		{"0.1.2.5", "wobble"},
 	}
 	for _, details := range addresses {
-		addr := network.NewAddress(details[0], network.ScopePublic)
+		addr := network.NewScopedAddress(details[0], network.ScopePublic)
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
 		err = ipAddr.AllocateTo(details[1], "wobble")
@@ -287,7 +287,7 @@ func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestRefresh(c *gc.C) {
-	rawAddr := network.NewAddress("0.1.2.3", network.ScopeUnknown)
+	rawAddr := network.NewAddress("0.1.2.3")
 	addr, err := s.State.AddIPAddress(rawAddr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1699,19 +1699,13 @@ func (s *MachineSuite) TestSetAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	addresses := []network.Address{
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-		network.NewAddress("8.8.8.8", network.ScopeUnknown),
-	}
+	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
 	err = machine.SetAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := []network.Address{
-		network.NewAddress("8.8.8.8", network.ScopeUnknown),
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-	}
+	expectedAddresses := network.NewAddresses("8.8.8.8", "127.0.0.1")
 	c.Assert(machine.Addresses(), jc.DeepEquals, expectedAddresses)
 }
 
@@ -1740,21 +1734,18 @@ func (s *MachineSuite) TestSetAddressesWithContainers(c *gc.C) {
 
 	// When setting all addresses the subnet addresses have to be
 	// filtered out.
-	addresses := []network.Address{
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-		network.NewAddress("8.8.8.8", network.ScopeUnknown),
-		ipAddr1.Address(),
-		ipAddr2.Address(),
-	}
+	addresses := network.NewAddresses(
+		"127.0.0.1",
+		"8.8.8.8",
+		ipAddr1.Value(),
+		ipAddr2.Value(),
+	)
 	err = machine.SetAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := []network.Address{
-		network.NewAddress("8.8.8.8", network.ScopeUnknown),
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-	}
+	expectedAddresses := network.NewAddresses("8.8.8.8", "127.0.0.1")
 	c.Assert(machine.Addresses(), jc.DeepEquals, expectedAddresses)
 }
 
@@ -1786,19 +1777,13 @@ func (s *MachineSuite) TestSetAddressesOnContainer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// When setting all addresses the subnet address has to accepted.
-	addresses := []network.Address{
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-		ipAddr.Address(),
-	}
+	addresses := network.NewAddresses("127.0.0.1", ipAddr.Value())
 	err = container.SetAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = container.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := []network.Address{
-		ipAddr.Address(),
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-	}
+	expectedAddresses := network.NewAddresses(ipAddr.Value(), "127.0.0.1")
 	c.Assert(container.Addresses(), jc.DeepEquals, expectedAddresses)
 }
 
@@ -1807,19 +1792,13 @@ func (s *MachineSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	addresses := []network.Address{
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-		network.NewAddress("8.8.8.8", network.ScopeUnknown),
-	}
+	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
 	err = machine.SetMachineAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := []network.Address{
-		network.NewAddress("8.8.8.8", network.ScopeUnknown),
-		network.NewAddress("127.0.0.1", network.ScopeUnknown),
-	}
+	expectedAddresses := network.NewAddresses("8.8.8.8", "127.0.0.1")
 	c.Assert(machine.MachineAddresses(), jc.DeepEquals, expectedAddresses)
 }
 
@@ -1910,8 +1889,8 @@ func (s *MachineSuite) TestSetAddressesConcurrentChangeDifferent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	addr0 := network.NewAddress("127.0.0.1", network.ScopeUnknown)
-	addr1 := network.NewAddress("8.8.8.8", network.ScopeUnknown)
+	addr0 := network.NewAddress("127.0.0.1")
+	addr1 := network.NewAddress("8.8.8.8")
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		machine, err := s.State.Machine(machine.Id())
@@ -1933,8 +1912,8 @@ func (s *MachineSuite) TestSetAddressesConcurrentChangeEqual(c *gc.C) {
 	revno0, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
 
-	addr0 := network.NewAddress("127.0.0.1", network.ScopeUnknown)
-	addr1 := network.NewAddress("8.8.8.8", network.ScopeUnknown)
+	addr0 := network.NewAddress("127.0.0.1")
+	addr1 := network.NewAddress("8.8.8.8")
 
 	var revno1 int64
 	defer state.SetBeforeHooks(c, s.State, func() {

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -170,7 +170,7 @@ func (s *storeManagerStateSuite) setUpScenario(c *gc.C, st *State, units int) (e
 	c.Assert(err, jc.ErrorIsNil)
 	hc, err := m.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetAddresses(network.NewAddress("example.com", network.ScopeUnknown))
+	err = m.SetAddresses(network.NewAddress("example.com"))
 	c.Assert(err, jc.ErrorIsNil)
 	add(&multiwatcher.MachineInfo{
 		Id:                      "0",
@@ -1197,8 +1197,8 @@ func (s *storeManagerStateSuite) TestChangeUnits(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPort("tcp", 12345)
 			c.Assert(err, jc.ErrorIsNil)
-			publicAddress := network.NewAddress("public", network.ScopePublic)
-			privateAddress := network.NewAddress("private", network.ScopeCloudLocal)
+			publicAddress := network.NewScopedAddress("public", network.ScopePublic)
+			privateAddress := network.NewScopedAddress("private", network.ScopeCloudLocal)
 			err = m.SetAddresses(publicAddress, privateAddress)
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.SetAgentStatus(StatusError, "failure", nil)
@@ -1338,8 +1338,8 @@ func (s *storeManagerStateSuite) TestChangeUnitsNonNilPorts(c *gc.C) {
 		}
 		if flag&openPorts != 0 {
 			// Add a network to the machine and open a port.
-			publicAddress := network.NewAddress("1.2.3.4", network.ScopePublic)
-			privateAddress := network.NewAddress("4.3.2.1", network.ScopeCloudLocal)
+			publicAddress := network.NewScopedAddress("1.2.3.4", network.ScopePublic)
+			privateAddress := network.NewScopedAddress("4.3.2.1", network.ScopeCloudLocal)
 			err = m.SetAddresses(publicAddress, privateAddress)
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPort("tcp", 12345)
@@ -1455,8 +1455,8 @@ func (s *storeManagerStateSuite) TestClosingPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
-	publicAddress := network.NewAddress("1.2.3.4", network.ScopePublic)
-	privateAddress := network.NewAddress("4.3.2.1", network.ScopeCloudLocal)
+	publicAddress := network.NewScopedAddress("1.2.3.4", network.ScopePublic)
+	privateAddress := network.NewScopedAddress("4.3.2.1", network.ScopeCloudLocal)
 	err = m.SetAddresses(publicAddress, privateAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.OpenPorts("tcp", 12345, 12345)

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -877,7 +877,10 @@ func (s *WatchScopeSuite) TestPeer(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		machine, err := s.State.Machine(mId)
 		c.Assert(err, jc.ErrorIsNil)
-		privateAddr := network.NewAddress(fmt.Sprintf("riak%d.example.com", i), network.ScopeCloudLocal)
+		privateAddr := network.NewScopedAddress(
+			fmt.Sprintf("riak%d.example.com", i),
+			network.ScopeCloudLocal,
+		)
 		machine.SetAddresses(privateAddr)
 		ru, err := rel.Unit(unit)
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4203,10 +4203,9 @@ func (s *StateSuite) TestWatchAPIHostPorts(c *gc.C) {
 	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
 	wc.AssertOneChange()
 
-	err := s.State.SetAPIHostPorts([][]network.HostPort{{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		Port:    99,
-	}}})
+	err := s.State.SetAPIHostPorts([][]network.HostPort{
+		network.NewHostPorts(99, "0.1.2.3"),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertOneChange()
@@ -4232,27 +4231,27 @@ func (s *StateSuite) TestWatchMachineAddresses(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Set machine addresses: reported.
-	err = machine.SetMachineAddresses(network.NewAddress("abc", network.ScopeUnknown))
+	err = machine.SetMachineAddresses(network.NewAddress("abc"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Set provider addresses eclipsing machine addresses: reported.
-	err = machine.SetAddresses(network.NewAddress("abc", network.ScopePublic))
+	err = machine.SetAddresses(network.NewScopedAddress("abc", network.ScopePublic))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Set same machine eclipsed by provider addresses: not reported.
-	err = machine.SetMachineAddresses(network.NewAddress("abc", network.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(network.NewScopedAddress("abc", network.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
 	// Set different machine addresses: reported.
-	err = machine.SetMachineAddresses(network.NewAddress("def", network.ScopeUnknown))
+	err = machine.SetMachineAddresses(network.NewAddress("def"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Set different provider addresses: reported.
-	err = machine.SetMachineAddresses(network.NewAddress("def", network.ScopePublic))
+	err = machine.SetMachineAddresses(network.NewScopedAddress("def", network.ScopePublic))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -304,7 +304,7 @@ func (s *Subnet) attemptToPickNewAddress() (*IPAddress, error) {
 
 	// convert it back to a dotted-quad
 	newIP := network.DecimalToIPv4(newDecimal)
-	newAddr := network.NewAddress(newIP.String(), network.ScopeUnknown)
+	newAddr := network.NewAddress(newIP.String())
 
 	// and create a new IPAddress from it and return it
 	return s.st.AddIPAddress(newAddr, s.ID())

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -175,9 +175,15 @@ func (s *SubnetSuite) TestSubnetRemoveKillsAddresses(c *gc.C) {
 	subnet, err := s.State.AddSubnet(subnetInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddIPAddress(network.NewAddress("192.168.1.0", ""), subnet.ID())
+	_, err = s.State.AddIPAddress(
+		network.NewAddress("192.168.1.0"),
+		subnet.ID(),
+	)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddIPAddress(network.NewAddress("192.168.1.1", ""), subnet.ID())
+	_, err = s.State.AddIPAddress(
+		network.NewAddress("192.168.1.1"),
+		subnet.ID(),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = subnet.EnsureDead()
@@ -250,7 +256,7 @@ func (s *SubnetSuite) TestPickNewAddressWhenSubnetIsDead(c *gc.C) {
 
 func (s *SubnetSuite) TestPickNewAddressAddressesExhausted(c *gc.C) {
 	subnet := s.getSubnetForAddressPicking(c, "192.168.1.0")
-	addr := network.NewAddress("192.168.1.0", network.ScopeUnknown)
+	addr := network.NewAddress("192.168.1.0")
 	_, err := s.State.AddIPAddress(addr, subnet.ID())
 
 	_, err = subnet.PickNewAddress()
@@ -268,7 +274,7 @@ func (s *SubnetSuite) TestPickNewAddressOneAddress(c *gc.C) {
 func (s *SubnetSuite) TestPickNewAddressSkipsAllocated(c *gc.C) {
 	subnet := s.getSubnetForAddressPicking(c, "192.168.1.1")
 
-	addr := network.NewAddress("192.168.1.0", network.ScopeUnknown)
+	addr := network.NewAddress("192.168.1.0")
 	_, err := s.State.AddIPAddress(addr, subnet.ID())
 
 	ipAddr, err := subnet.PickNewAddress()

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -215,8 +215,8 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	c.Check(address, gc.Equals, "")
 	c.Assert(ok, jc.IsFalse)
 
-	public := network.NewAddress("8.8.8.8", network.ScopePublic)
-	private := network.NewAddress("127.0.0.1", network.ScopeCloudLocal)
+	public := network.NewScopedAddress("8.8.8.8", network.ScopePublic)
+	private := network.NewScopedAddress("127.0.0.1", network.ScopeCloudLocal)
 
 	err = machine.SetAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -232,9 +232,9 @@ func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	publicProvider := network.NewAddress("8.8.8.8", network.ScopePublic)
-	privateProvider := network.NewAddress("127.0.0.1", network.ScopeCloudLocal)
-	privateMachine := network.NewAddress("127.0.0.2", network.ScopeUnknown)
+	publicProvider := network.NewScopedAddress("8.8.8.8", network.ScopePublic)
+	privateProvider := network.NewScopedAddress("127.0.0.1", network.ScopeCloudLocal)
+	privateMachine := network.NewAddress("127.0.0.2")
 
 	err = machine.SetAddresses(privateProvider)
 	c.Assert(err, jc.ErrorIsNil)
@@ -272,8 +272,8 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	c.Check(address, gc.Equals, "")
 	c.Assert(ok, jc.IsFalse)
 
-	public := network.NewAddress("8.8.8.8", network.ScopePublic)
-	private := network.NewAddress("127.0.0.1", network.ScopeCloudLocal)
+	public := network.NewScopedAddress("8.8.8.8", network.ScopePublic)
+	private := network.NewScopedAddress("127.0.0.1", network.ScopeCloudLocal)
 
 	err = machine.SetAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -79,7 +79,7 @@ func setMachineAddresses(m *machiner.Machine) error {
 		default:
 			continue
 		}
-		address := network.NewAddress(ip.String(), network.ScopeUnknown)
+		address := network.NewAddress(ip.String())
 		// Filter out link-local addresses as we cannot reliably use them.
 		if address.Scope == network.ScopeLinkLocal {
 			continue

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -190,9 +190,9 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(mr.Wait(), gc.Equals, worker.ErrTerminateAgent)
 	c.Assert(s.machine.Refresh(), gc.IsNil)
 	c.Assert(s.machine.MachineAddresses(), jc.DeepEquals, []network.Address{
-		network.NewAddress("2001:db8::1", network.ScopeUnknown),
-		network.NewAddress("10.0.0.1", network.ScopeCloudLocal),
-		network.NewAddress("::1", network.ScopeMachineLocal),
-		network.NewAddress("127.0.0.1", network.ScopeMachineLocal),
+		network.NewAddress("2001:db8::1"),
+		network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewScopedAddress("::1", network.ScopeMachineLocal),
+		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
 	})
 }

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -207,7 +207,7 @@ func localDNSServers() ([]network.Address, error) {
 				address = address[:strings.Index(address, "#")]
 			}
 			address = strings.TrimSpace(address)
-			addresses = append(addresses, network.NewAddress(address, network.ScopeUnknown))
+			addresses = append(addresses, network.NewAddress(address))
 		}
 	}
 
@@ -418,7 +418,7 @@ func discoverPrimaryNIC() (string, network.Address, error) {
 				addr = ip.String()
 
 				logger.Tracef("primary network interface is %q, address %q", iface.Name, addr)
-				return iface.Name, network.NewAddress(addr, network.ScopeUnknown), nil
+				return iface.Name, network.NewAddress(addr), nil
 			}
 		}
 	}

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -400,7 +400,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesInvalidArgs(c *gc.C) {
 	}, {
 		about:       "all but primaryAddr empty",
 		primaryNIC:  "",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "",
 		ifaceInfo:   nil,
 		expectErr:   expectStartupErr,
@@ -421,21 +421,21 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesInvalidArgs(c *gc.C) {
 	}, {
 		about:       "all but primaryNIC and primaryAddr empty",
 		primaryNIC:  "nic",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "",
 		ifaceInfo:   nil,
 		expectErr:   expectStartupErr,
 	}, {
 		about:       "all but primaryAddr and bridgeName empty",
 		primaryNIC:  "",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "bridge",
 		ifaceInfo:   nil,
 		expectErr:   expectStartupErr,
 	}, {
 		about:       "all set except ifaceInfo",
 		primaryNIC:  "nic",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "bridge",
 		ifaceInfo:   nil,
 		expectErr:   expectStartupErr,
@@ -456,7 +456,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesInvalidArgs(c *gc.C) {
 	}, {
 		about:       "all but primaryAddr empty (ifaceInfo set but empty)",
 		primaryNIC:  "",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "",
 		ifaceInfo:   emptyIfaceInfo,
 		expectErr:   expectStartupErr,
@@ -477,28 +477,28 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesInvalidArgs(c *gc.C) {
 	}, {
 		about:       "just bridgeName is empty and ifaceInfo set but empty",
 		primaryNIC:  "nic",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "",
 		ifaceInfo:   emptyIfaceInfo,
 		expectErr:   expectStartupErr,
 	}, {
 		about:       "just primaryNIC is empty and ifaceInfo set but empty",
 		primaryNIC:  "",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "bridge",
 		ifaceInfo:   emptyIfaceInfo,
 		expectErr:   expectStartupErr,
 	}, {
 		about:       "all set except ifaceInfo, which is set but empty",
 		primaryNIC:  "nic",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "bridge",
 		ifaceInfo:   emptyIfaceInfo,
 		expectErr:   expectStartupErr,
 	}, {
 		about:       "all set, but ifaceInfo has empty Address",
 		primaryNIC:  "nic",
-		primaryAddr: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		primaryAddr: network.NewAddress("0.1.2.1"),
 		bridgeName:  "bridge",
 		// No Address set.
 		ifaceInfo: []network.InterfaceInfo{{DeviceIndex: 0}},
@@ -521,10 +521,10 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesCheckError(c *gc.C) {
 	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
 
 	ifaceInfo := []network.InterfaceInfo{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3"),
 	}}
 
-	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
+	addr := network.NewAddress("0.1.2.1")
 	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
 	c.Assert(err, gc.ErrorMatches, "iptables failed with unexpected exit code 42")
 }
@@ -547,10 +547,10 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesAddError(c *gc.C) {
 	s.PatchValue(provisioner.IptablesRules, fakeptablesRules)
 
 	ifaceInfo := []network.InterfaceInfo{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3"),
 	}}
 
-	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
+	addr := network.NewAddress("0.1.2.1")
 	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
 	c.Assert(err, gc.ErrorMatches, `command "iptables -t nat -I .*" failed with exit code 42`)
 }
@@ -562,10 +562,10 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPRouteError(c *gc.C) {
 	gitjujutesting.PatchExecutableThrowError(c, s, "ip", 123)
 
 	ifaceInfo := []network.InterfaceInfo{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3"),
 	}}
 
-	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
+	addr := network.NewAddress("0.1.2.1")
 	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
 	c.Assert(err, gc.ErrorMatches,
 		`command "ip route add 0.1.2.3 dev bridge" failed with exit code 123`,
@@ -591,10 +591,10 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesAddsRuleIfMissing(c *gc.C) {
 	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "ip")
 
 	ifaceInfo := []network.InterfaceInfo{{
-		Address: network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		Address: network.NewAddress("0.1.2.3"),
 	}}
 
-	addr := network.NewAddress("0.1.2.1", network.ScopeUnknown)
+	addr := network.NewAddress("0.1.2.1")
 	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -711,7 +711,7 @@ func (s *lxcBrokerSuite) TestDiscoverPrimaryNICSuccess(c *gc.C) {
 	nic, addr, err := provisioner.DiscoverPrimaryNIC()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(nic, gc.Equals, "if2")
-	c.Assert(addr, jc.DeepEquals, network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	c.Assert(addr, jc.DeepEquals, network.NewAddress("0.1.2.3"))
 }
 
 func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
@@ -750,8 +750,8 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 		InterfaceName:  "eth0", // generated from the device index.
 		MACAddress:     provisioner.MACAddressTemplate,
 		DNSServers:     network.NewAddresses("ns1.dummy"),
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		Address:        network.NewAddress("0.1.2.3"),
+		GatewayAddress: network.NewAddress("0.1.2.1"),
 	}})
 }
 
@@ -945,7 +945,7 @@ func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) ([]network
 		MACAddress:     "aa:bb:cc:dd:ee:ff",
 		CIDR:           "0.1.2.0/24",
 		InterfaceName:  "dummy0",
-		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
-		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
+		Address:        network.NewAddress("0.1.2.3"),
+		GatewayAddress: network.NewAddress("0.1.2.1"),
 	}}, nil
 }

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -75,7 +75,7 @@ func (s *RsyslogSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(rsyslog.RsyslogConfDir, c.MkDir())
 
 	s.st, s.machine = s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
-	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err := s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/worker/rsyslog/rsyslog_test.go
+++ b/worker/rsyslog/rsyslog_test.go
@@ -66,7 +66,7 @@ func (s *RsyslogSuite) TestTearDown(c *gc.C) {
 
 func (s *RsyslogSuite) TestRsyslogCert(c *gc.C) {
 	st, m := s.st, s.machine
-	err := s.machine.SetAddresses(network.NewAddress("example.com", network.ScopeUnknown))
+	err := s.machine.SetAddresses(network.NewAddress("example.com"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"})

--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -294,7 +294,7 @@ func (s *FilterSuite) TestConfigEvents(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, f)
 
-	err = s.machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err = s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Test no changes before the charm URL is set.
@@ -329,7 +329,7 @@ func (s *FilterSuite) TestConfigEvents(c *gc.C) {
 	configC.AssertNoReceive()
 
 	// Change the addresses of the unit's assigned machine; new event received.
-	err = s.machine.SetAddresses(network.NewAddress("0.1.2.4", network.ScopeUnknown))
+	err = s.machine.SetAddresses(network.NewAddress("0.1.2.4"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.BackingState.StartSync()
 	configC.AssertOneReceive()
@@ -354,7 +354,7 @@ func (s *FilterSuite) TestInitialAddressEventIgnored(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, f)
 
-	err = s.machine.SetAddresses(network.NewAddress("0.1.2.3", network.ScopeUnknown))
+	err = s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We should not get any config-change events until
@@ -382,7 +382,7 @@ func (s *FilterSuite) TestConfigAndAddressEvents(c *gc.C) {
 	// Changing the machine addresses should also result in
 	// a config-change event.
 	err = s.machine.SetAddresses(
-		network.NewAddress("0.1.2.3", network.ScopeUnknown),
+		network.NewAddress("0.1.2.3"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -405,9 +405,7 @@ func (s *FilterSuite) TestConfigAndAddressEventsDiscarded(c *gc.C) {
 	configC.AssertNoReceive()
 
 	// Change the machine addresses.
-	err = s.machine.SetAddresses(
-		network.NewAddress("0.1.2.3", network.ScopeUnknown),
-	)
+	err = s.machine.SetAddresses(network.NewAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Set the charm URL to trigger config events.

--- a/worker/uniter/relationer_test.go
+++ b/worker/uniter/relationer_test.go
@@ -82,8 +82,9 @@ func (s *RelationerSuite) AddRelationUnit(c *gc.C, name string) (*state.Relation
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
-	privateAddr := network.NewAddress(
-		strings.Replace(name, "/", "-", 1)+".testing.invalid", network.ScopeCloudLocal)
+	privateAddr := network.NewScopedAddress(
+		strings.Replace(name, "/", "-", 1)+".testing.invalid", network.ScopeCloudLocal,
+	)
 	err = machine.SetAddresses(privateAddr)
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := s.rel.Unit(u)
@@ -411,7 +412,7 @@ func (s *RelationerImplicitSuite) TestImplicitRelationer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetAddresses(network.NewAddress("blah", network.ScopeCloudLocal))
+	err = machine.SetAddresses(network.NewScopedAddress("blah", network.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
 	eps, err := s.State.InferEndpoints("logging", "mysql")

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -85,7 +85,8 @@ func (s *InterfaceSuite) TestUnitCaching(c *gc.C) {
 
 	// Change remote state.
 	err := s.machine.SetAddresses(
-		network.NewAddress("blah.testing.invalid", network.ScopePublic))
+		network.NewScopedAddress("blah.testing.invalid", network.ScopePublic),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local view is unchanged.

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -185,7 +185,7 @@ func (s *HookContextSuite) addUnit(c *gc.C, svc *state.Service) *state.Unit {
 func (s *HookContextSuite) AddUnit(c *gc.C, svc *state.Service) *state.Unit {
 	unit := s.addUnit(c, svc)
 	name := strings.Replace(unit.Name(), "/", "-", 1)
-	privateAddr := network.NewAddress(name+".testing.invalid", network.ScopeCloudLocal)
+	privateAddr := network.NewScopedAddress(name+".testing.invalid", network.ScopeCloudLocal)
 	err := s.machine.SetAddresses(privateAddr)
 	c.Assert(err, jc.ErrorIsNil)
 	return unit


### PR DESCRIPTION
I don't know about you, but I'm sick of having to write
network.NewAddress("0.1.2.3", network.ScopeUnknown) every
time. So I've renamed NewAddress to NewScopedAddress and
added a new NewAddress implementation that internally calls
NewScopedAddress(value, ScopeUnknown). Changed across the
code base, reducing the line lengths and counts considerably
in some cases. Also, a few other drive-by fixes were done,
mostly to simplify tests (e.g. using the pre-existing helpers
in the network package for handling [][]network.HostPort).

No actual changes were made to the logic anywhere: 90% of the
changes are mechanical search/replace, the rest are carefully
replacing more complicated code with simpler but equivalent one,
taking advantage of the network package helpers.

All unit tests still pass.

(Review request: http://reviews.vapour.ws/r/1219/)