### PR TITLE
Stopped State for opState (merge from PR #1855)

### DIFF
--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -4,10 +4,12 @@
 package upgrades
 
 import (
+	"github.com/juju/names"
 	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/uniter"
 )
 
 // stateStepsFor123 returns upgrade steps form Juju 1.23 that manipulate state directly.
@@ -81,6 +83,19 @@ func stepsFor123() []Step {
 			description: "add environment UUID to agent config",
 			targets:     []Target{AllMachines},
 			run:         addEnvironmentUUIDToAgentConfig,
+		},
+		&upgradeStep{
+			description: "add Stopped field to uniter state",
+			targets:     []Target{AllMachines},
+			run: func(context Context) error {
+				config := context.AgentConfig()
+				tag, ok := config.Tag().(names.UnitTag)
+				if !ok {
+					// not a Unit; skipping
+					return nil
+				}
+				return uniter.AddStoppedFieldToUniterState(tag, config.DataDir())
+			},
 		},
 	}
 }

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -38,6 +38,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 func (s *steps123Suite) TestStepsFor123(c *gc.C) {
 	expected := []string{
 		"add environment UUID to agent config",
+		"add Stopped field to uniter state",
 	}
 	assertSteps(c, version.MustParse("1.23.0"), expected)
 }

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -64,10 +64,11 @@ func ModeContinue(u *Uniter) (next Mode, err error) {
 			creator = newSkipHookOp(*opState.Hook)
 		}
 	case operation.Continue:
-		logger.Infof("continuing after %q hook", opState.Hook.Kind)
-		if opState.Hook.Kind == hooks.Stop {
+		if opState.Stopped {
+			logger.Infof("opState.Stopped == true; transition to ModeTerminating")
 			return ModeTerminating, nil
 		}
+		logger.Infof("no operations in progress; waiting for changes")
 		return ModeAbide, nil
 	default:
 		return nil, errors.Errorf("unknown operation kind %v", opState.Kind)

--- a/worker/uniter/operation/executor_test.go
+++ b/worker/uniter/operation/executor_test.go
@@ -75,7 +75,6 @@ func (s *NewExecutorSuite) TestNewExecutorValidFile(c *gc.C) {
 started: true
 op: continue
 opstep: pending
-hook: {kind: config-changed}
 `[1:], 0666}.Create(c, s.basePath)
 	executor, err := operation.NewExecutor(s.path("existing"), failGetInstallCharm)
 	c.Assert(err, jc.ErrorIsNil)
@@ -83,7 +82,6 @@ hook: {kind: config-changed}
 		Kind:    operation.Continue,
 		Step:    operation.Pending,
 		Started: true,
-		Hook:    &hook.Info{Kind: hooks.ConfigChanged},
 	})
 }
 
@@ -112,7 +110,6 @@ func justInstalledState() operation.State {
 	return operation.State{
 		Kind: operation.Continue,
 		Step: operation.Pending,
-		Hook: &hook.Info{Kind: hooks.ConfigChanged},
 	}
 }
 
@@ -202,8 +199,8 @@ func (s *ExecutorSuite) TestValidateStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op)
-	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": invalid operation state: missing hook info`)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, "missing hook info")
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": invalid operation state: missing hook info with Kind RunHook`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "missing hook info with Kind RunHook")
 
 	assertWroteState(c, statePath, initialState)
 	c.Assert(executor.State(), gc.DeepEquals, initialState)

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -437,7 +437,6 @@ func (s *RunHookSuite) TestCommitSuccess_ConfigChanged_Preserve(c *gc.C) {
 				CollectMetricsTime: 1234567,
 				Kind:               operation.Continue,
 				Step:               operation.Pending,
-				Hook:               &hook.Info{Kind: hooks.ConfigChanged},
 			},
 		)
 	}
@@ -458,7 +457,6 @@ func (s *RunHookSuite) TestCommitSuccess_Start_SetStarted(c *gc.C) {
 				Started: true,
 				Kind:    operation.Continue,
 				Step:    operation.Pending,
-				Hook:    &hook.Info{Kind: hooks.Start},
 			},
 		)
 	}
@@ -480,39 +478,53 @@ func (s *RunHookSuite) TestCommitSuccess_Start_Preserve(c *gc.C) {
 				CollectMetricsTime: 1234567,
 				Kind:               operation.Continue,
 				Step:               operation.Pending,
-				Hook:               &hook.Info{Kind: hooks.Start},
 			},
 		)
 	}
 }
 
-func (s *RunHookSuite) testQueueHook_BlankSlate(c *gc.C, cause, effect hooks.Kind) {
+func (s *RunHookSuite) testQueueHook_BlankSlate(c *gc.C, cause hooks.Kind) {
 	for i, newHook := range []newHook{
 		(operation.Factory).NewRunHook,
 		(operation.Factory).NewRetryHook,
 		(operation.Factory).NewSkipHook,
 	} {
 		c.Logf("variant %d", i)
+		var hi *hook.Info
+		switch cause {
+		case hooks.UpgradeCharm:
+			hi = &hook.Info{Kind: hooks.ConfigChanged}
+		default:
+			hi = nil
+		}
 		s.testCommitSuccess(c,
 			newHook,
 			hook.Info{Kind: cause},
 			operation.State{},
 			operation.State{
-				Kind: operation.RunHook,
-				Step: operation.Queued,
-				Hook: &hook.Info{Kind: effect},
+				Kind:    operation.RunHook,
+				Step:    operation.Queued,
+				Stopped: cause == hooks.Stop,
+				Hook:    hi,
 			},
 		)
 	}
 }
 
-func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause, effect hooks.Kind) {
+func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause hooks.Kind) {
 	for i, newHook := range []newHook{
 		(operation.Factory).NewRunHook,
 		(operation.Factory).NewRetryHook,
 		(operation.Factory).NewSkipHook,
 	} {
 		c.Logf("variant %d", i)
+		var hi *hook.Info
+		switch cause {
+		case hooks.UpgradeCharm:
+			hi = &hook.Info{Kind: hooks.ConfigChanged}
+		default:
+			hi = nil
+		}
 		s.testCommitSuccess(c,
 			newHook,
 			hook.Info{Kind: cause},
@@ -520,28 +532,21 @@ func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause, effect hooks.Kind)
 			operation.State{
 				Kind:               operation.RunHook,
 				Step:               operation.Queued,
-				Hook:               &hook.Info{Kind: effect},
 				Started:            true,
+				Stopped:            cause == hooks.Stop,
+				Hook:               hi,
 				CollectMetricsTime: 1234567,
 			},
 		)
 	}
 }
 
-func (s *RunHookSuite) TestQueueHook_Install_BlankSlate(c *gc.C) {
-	s.testQueueHook_BlankSlate(c, hooks.Install, hooks.ConfigChanged)
-}
-
-func (s *RunHookSuite) TestQueueHook_Install_Preserve(c *gc.C) {
-	s.testQueueHook_Preserve(c, hooks.Install, hooks.ConfigChanged)
-}
-
 func (s *RunHookSuite) TestQueueHook_UpgradeCharm_BlankSlate(c *gc.C) {
-	s.testQueueHook_BlankSlate(c, hooks.UpgradeCharm, hooks.ConfigChanged)
+	s.testQueueHook_BlankSlate(c, hooks.UpgradeCharm)
 }
 
 func (s *RunHookSuite) TestQueueHook_UpgradeCharm_Preserve(c *gc.C) {
-	s.testQueueHook_Preserve(c, hooks.UpgradeCharm, hooks.ConfigChanged)
+	s.testQueueHook_Preserve(c, hooks.UpgradeCharm)
 }
 
 func (s *RunHookSuite) testQueueNothing_BlankSlate(c *gc.C, hookInfo hook.Info) {
@@ -556,9 +561,9 @@ func (s *RunHookSuite) testQueueNothing_BlankSlate(c *gc.C, hookInfo hook.Info) 
 			hookInfo,
 			operation.State{},
 			operation.State{
-				Kind: operation.Continue,
-				Step: operation.Pending,
-				Hook: &hookInfo,
+				Kind:    operation.Continue,
+				Step:    operation.Pending,
+				Stopped: hookInfo.Kind == hooks.Stop,
 			},
 		)
 	}
@@ -578,12 +583,24 @@ func (s *RunHookSuite) testQueueNothing_Preserve(c *gc.C, hookInfo hook.Info) {
 			operation.State{
 				Kind:               operation.Continue,
 				Step:               operation.Pending,
-				Hook:               &hookInfo,
 				Started:            true,
+				Stopped:            hookInfo.Kind == hooks.Stop,
 				CollectMetricsTime: 1234567,
 			},
 		)
 	}
+}
+
+func (s *RunHookSuite) TestQueueNothing_Install_BlankSlate(c *gc.C) {
+	s.testQueueNothing_BlankSlate(c, hook.Info{
+		Kind: hooks.Install,
+	})
+}
+
+func (s *RunHookSuite) TestQueueNothing_Install_Preserve(c *gc.C) {
+	s.testQueueNothing_Preserve(c, hook.Info{
+		Kind: hooks.Install,
+	})
 }
 
 func (s *RunHookSuite) TestQueueNothing_Stop_BlankSlate(c *gc.C) {
@@ -653,13 +670,11 @@ func (s *RunHookSuite) TestQueueNothing_RelationBroken_Preserve(c *gc.C) {
 }
 
 func (s *RunHookSuite) testCommitSuccess_CollectMetricsTime(c *gc.C, newHook newHook) {
-	hookInfo := hook.Info{Kind: hooks.CollectMetrics}
-
 	callbacks := &CommitHookCallbacks{
 		MockCommitHook: &MockCommitHook{},
 	}
 	factory := operation.NewFactory(nil, nil, callbacks, nil, nil)
-	op, err := newHook(factory, hookInfo)
+	op, err := newHook(factory, hook.Info{Kind: hooks.CollectMetrics})
 	c.Assert(err, jc.ErrorIsNil)
 
 	nowBefore := time.Now().Unix()
@@ -678,7 +693,6 @@ func (s *RunHookSuite) testCommitSuccess_CollectMetricsTime(c *gc.C, newHook new
 		Started: true,
 		Kind:    operation.Continue,
 		Step:    operation.Pending,
-		Hook:    &hookInfo,
 	})
 }
 

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -63,6 +63,9 @@ type State struct {
 	// Started indicates whether the start hook has run.
 	Started bool `yaml:"started"`
 
+	// Stopped indicates whether the stop hook has run.
+	Stopped bool `yaml:"stopped"`
+
 	// Kind indicates the current operation.
 	Kind Kind `yaml:"op"`
 
@@ -100,34 +103,41 @@ func (st State) validate() (err error) {
 	switch st.Kind {
 	case Install:
 		if hasHook {
-			return errors.New("unexpected hook info")
+			return errors.New("unexpected hook info with Kind Install")
 		}
 		fallthrough
 	case Upgrade:
-		if !hasCharm {
+		switch {
+		case !hasCharm:
 			return errors.New("missing charm URL")
-		} else if hasActionId {
+		case hasActionId:
 			return errors.New("unexpected action id")
 		}
 	case RunAction:
-		if !hasHook {
-			return errors.New("missing hook info")
-		} else if hasCharm {
+		switch {
+		case hasHook:
+			return errors.New("unexpected hook info with Kind RunAction")
+		case hasCharm:
 			return errors.New("unexpected charm URL")
-		} else if !hasActionId {
+		case !hasActionId:
 			return errors.New("missing action id")
 		}
 	case RunHook:
-		if hasActionId {
+		switch {
+		case !hasHook:
+			return errors.New("missing hook info with Kind RunHook")
+		case hasCharm:
+			return errors.New("unexpected charm URL")
+		case hasActionId:
 			return errors.New("unexpected action id")
 		}
-		fallthrough
 	case Continue:
-		if !hasHook {
-			return errors.New("missing hook info")
-		} else if hasCharm {
+		switch {
+		case hasHook:
+			return errors.New("unexpected hook info with Kind Continue")
+		case hasCharm:
 			return errors.New("unexpected charm URL")
-		} else if hasActionId {
+		case hasActionId:
 			return errors.New("unexpected action id")
 		}
 	default:

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -38,7 +38,6 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind: operation.Continue,
 			Step: operation.Step("dudelike"),
-			Hook: &hook.Info{Kind: hooks.ConfigChanged},
 		},
 		err: `unknown operation step "dudelike"`,
 	},
@@ -49,7 +48,7 @@ var stateTests = []struct {
 			Step: operation.Pending,
 			Hook: &hook.Info{Kind: hooks.ConfigChanged},
 		},
-		err: `unexpected hook info`,
+		err: `unexpected hook info with Kind Install`,
 	}, {
 		st: operation.State{
 			Kind: operation.Install,
@@ -76,14 +75,12 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind: operation.RunAction,
 			Step: operation.Pending,
-			Hook: &hook.Info{Kind: hooks.Install},
 		},
 		err: `missing action id`,
 	}, {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
-			Hook:     &hook.Info{Kind: hooks.Install},
 			CharmURL: stcurl,
 		},
 		err: `unexpected charm URL`,
@@ -91,7 +88,6 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
-			Hook:     &hook.Info{Kind: hooks.Install},
 			ActionId: &someActionId,
 		},
 	},
@@ -173,13 +169,13 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind: operation.Continue,
 			Step: operation.Pending,
+			Hook: &hook.Info{Kind: hooks.ConfigChanged},
 		},
-		err: `missing hook info`,
+		err: `unexpected hook info with Kind Continue`,
 	}, {
 		st: operation.State{
 			Kind:     operation.Continue,
 			Step:     operation.Pending,
-			Hook:     relhook,
 			CharmURL: stcurl,
 		},
 		err: `unexpected charm URL`,
@@ -187,7 +183,6 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:     operation.Continue,
 			Step:     operation.Pending,
-			Hook:     relhook,
 			ActionId: &someActionId,
 		},
 		err: `unexpected action id`,
@@ -195,7 +190,6 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:               operation.Continue,
 			Step:               operation.Pending,
-			Hook:               relhook,
 			CollectMetricsTime: 98765432,
 			Leader:             true,
 		},

--- a/worker/uniter/upgrade123.go
+++ b/worker/uniter/upgrade123.go
@@ -1,0 +1,57 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"os"
+
+	"github.com/juju/names"
+	"github.com/juju/utils"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+func AddStoppedFieldToUniterState(tag names.UnitTag, dataDir string) error {
+	logger.Tracef("entering upgrade step AddStoppedFieldToUniterState")
+	defer logger.Tracef("leaving upgrade step AddStoppedFieldToUniterState")
+
+	opsFile := getUniterStateFile(dataDir, tag)
+	state, err := readUnsafe(opsFile)
+	switch err {
+	case nil:
+		return performUpgrade(opsFile, state)
+	case operation.ErrNoStateFile:
+		logger.Warningf("no uniter state file found for unit %s, skipping uniter upgrade step", tag)
+		return nil
+	default:
+		return err
+	}
+
+}
+
+func getUniterStateFile(dataDir string, tag names.UnitTag) string {
+	paths := NewPaths(dataDir, tag)
+	return paths.State.OperationsFile
+}
+
+func performUpgrade(opsFile string, state *operation.State) error {
+	statefile := operation.NewStateFile(opsFile)
+	if state.Kind == operation.Continue && state.Hook != nil && state.Hook.Kind == hooks.Stop {
+		state.Stopped = true
+		state.Hook = nil
+		return statefile.Write(state)
+	}
+	return nil
+}
+
+func readUnsafe(opsfile string) (*operation.State, error) {
+	var st operation.State
+	if err := utils.ReadYaml(opsfile, &st); err != nil {
+		if os.IsNotExist(err) {
+			return nil, operation.ErrNoStateFile
+		}
+	}
+	return &st, nil
+}

--- a/worker/uniter/upgrade123_test.go
+++ b/worker/uniter/upgrade123_test.go
@@ -1,0 +1,191 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+	"gopkg.in/juju/charm.v4/hooks"
+
+	"github.com/juju/juju/worker/uniter"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+type upgradeStateContextSuite struct {
+	datadir         string
+	unitTag         names.UnitTag
+	uniterStateFile string
+	statefile       *operation.StateFile
+}
+
+var _ = gc.Suite(&upgradeStateContextSuite{})
+
+func (s *upgradeStateContextSuite) SetUpTest(c *gc.C) {
+	s.datadir = c.MkDir()
+	s.statefile = nil
+	s.initializeContext(c, names.NewUnitTag("mysql/0"))
+}
+
+func (s *upgradeStateContextSuite) TestContextUpgradeWithUnitTag(c *gc.C) {
+	given, expectUpgrade :=
+		&oldState{
+			Kind: operation.Continue,
+			Step: operation.Pending,
+			Hook: &hook.Info{
+				Kind: hooks.Stop,
+			}},
+		&operation.State{
+			Kind:    operation.Continue,
+			Step:    operation.Pending,
+			Stopped: true}
+
+	s.confirmUpgrade(c, given, expectUpgrade)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeNoStopHookNoChange(c *gc.C) {
+	given, expectNoChange := &oldState{
+		Kind: operation.Continue,
+		Step: operation.Pending,
+	}, &operation.State{
+		Kind: operation.Continue,
+		Step: operation.Pending,
+	}
+
+	s.confirmUpgrade(c, given, expectNoChange)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeRunHookNoChange(c *gc.C) {
+	given, expectNoChange := &oldState{
+		Kind: operation.RunHook,
+		Step: operation.Pending,
+		Hook: &hook.Info{
+			Kind: hooks.Stop,
+		},
+	}, &operation.State{
+		Kind: operation.RunHook,
+		Step: operation.Pending,
+		Hook: &hook.Info{
+			Kind: hooks.Stop,
+		},
+	}
+
+	s.confirmUpgrade(c, given, expectNoChange)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeInstallOpNoChange(c *gc.C) {
+	given, expectNoChange := &oldState{
+		Kind:     operation.Install,
+		Step:     operation.Pending,
+		CharmURL: &charm.URL{},
+	}, &operation.State{
+		Kind:     operation.Install,
+		Step:     operation.Pending,
+		CharmURL: &charm.URL{},
+	}
+
+	s.confirmUpgrade(c, given, expectNoChange)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeUpgradeOpNoChange(c *gc.C) {
+	given, expectNoChange := &oldState{
+		Kind:     operation.Upgrade,
+		Step:     operation.Pending,
+		CharmURL: &charm.URL{},
+	}, &operation.State{
+		Kind:     operation.Upgrade,
+		Step:     operation.Pending,
+		CharmURL: &charm.URL{},
+	}
+
+	s.confirmUpgrade(c, given, expectNoChange)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeIdempotent(c *gc.C) {
+	given, expectUpgrade :=
+		&oldState{
+			Kind: operation.Continue,
+			Step: operation.Pending,
+			Hook: &hook.Info{
+				Kind: hooks.Stop,
+			}},
+		&operation.State{
+			Kind:    operation.Continue,
+			Step:    operation.Pending,
+			Stopped: true}
+
+	s.confirmUpgradeIdempotent(c, given, expectUpgrade)
+}
+
+func (s *upgradeStateContextSuite) TestUpgradeMissingStateFile(c *gc.C) {
+	s.confirmUniterStateFileMissing(c)
+	s.confirmUpgradeNoErrors(c)
+	s.confirmUniterStateFileMissing(c)
+}
+
+func (s *upgradeStateContextSuite) confirmUpgrade(c *gc.C, given *oldState, expect *operation.State) {
+	s.writeOldState(c, given)
+
+	s.confirmUpgradeNoErrors(c)
+	s.confirmUniterStateFileMatches(c, expect)
+}
+
+func (s *upgradeStateContextSuite) confirmUpgradeIdempotent(c *gc.C, given *oldState, expect *operation.State) {
+	s.writeOldState(c, given)
+
+	s.confirmUpgradeNoErrors(c)
+	s.confirmUniterStateFileMatches(c, expect)
+
+	s.confirmUpgradeNoErrors(c)
+	s.confirmUniterStateFileMatches(c, expect)
+}
+
+func (s *upgradeStateContextSuite) writeOldState(c *gc.C, state *oldState) {
+	err := utils.WriteYaml(s.uniterStateFile, state)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradeStateContextSuite) readState(c *gc.C) *operation.State {
+	state, err := s.statefile.Read()
+	c.Assert(err, jc.ErrorIsNil)
+	return state
+}
+
+func (s *upgradeStateContextSuite) confirmUpgradeNoErrors(c *gc.C) {
+	err := uniter.AddStoppedFieldToUniterState(s.unitTag, s.datadir)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradeStateContextSuite) confirmUniterStateFileMatches(c *gc.C, expect *operation.State) {
+	after := s.readState(c)
+	c.Assert(after, jc.DeepEquals, expect)
+}
+
+func (s *upgradeStateContextSuite) confirmUniterStateFileMissing(c *gc.C) {
+	_, err := s.statefile.Read()
+	c.Assert(err, gc.ErrorMatches, "uniter state file does not exist")
+}
+
+func (s *upgradeStateContextSuite) initializeContext(c *gc.C, utag names.UnitTag) {
+	paths := uniter.NewPaths(s.datadir, utag)
+	s.uniterStateFile = paths.State.OperationsFile
+	s.statefile = operation.NewStateFile(s.uniterStateFile)
+	c.Assert(os.MkdirAll(filepath.Dir(s.uniterStateFile), 0755), gc.IsNil)
+	s.unitTag = utag
+}
+
+// oldState is a surrogate type to imitate the relevant parts of the
+// pre-1.23 operation.State struct.
+type oldState struct {
+	Kind     operation.Kind `yaml:"op"`
+	Step     operation.Step `yaml:"opstep"`
+	Hook     *hook.Info     `yaml:"hook,omitempty"`
+	CharmURL *charm.URL     `yaml:"charm,omitempty"`
+}


### PR DESCRIPTION
 [Cherry-pick PR #1855 that was against 1.23, and has been reviewed there]

 Instead of switching on opState.Hook.Kind we have a top level
 opState.Stopped state to indicate a Stop hook has run.

 Also, add upgrade steps to migrate previous uniter state versions to
 this version.

 Changes from review feedback:

 - only accept UnitTag in upgrade method
 - log error at Errorf level
 - don't use switch in simple case
 - added test for idempotency

(Review request: http://reviews.vapour.ws/r/1221/)