### PR TITLE
Fix for LP-1434741

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -187,9 +187,9 @@ func initLogsSession(st *State) (*mgo.Session, *mgo.Collection) {
 // bytes), excluding space used by indexes.
 func getCollectionMB(coll *mgo.Collection) (int, error) {
 	var result bson.M
-	err := coll.Database.Run(bson.M{
-		"collStats": coll.Name,
-		"scale":     humanize.MiByte,
+	err := coll.Database.Run(bson.D{
+		{"collStats", coll.Name},
+		{"scale", humanize.MiByte},
 	}, &result)
 	if err != nil {
 		return 0, errors.Trace(err)


### PR DESCRIPTION
PruneLogs was using `bson.M` to send a command to mgo.Database.Run()
which resulted in sometimes failing because Run() uses the first key it
finds as the command name.  mgo documentation of Database.Run()
specifies using `bson.D` or other order preserving struct for passing
commands to Run()

(Review request: http://reviews.vapour.ws/r/1222/)