### PR TITLE
worker/certupdater: add "juju-mongodb" to server certs

### DIFF
--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -100,10 +100,12 @@ func (c *CertificateUpdater) Handle() error {
 		return errors.Annotate(err, "cannot add CA private key to environment config")
 	}
 
-	// For backwards compatibility, we must include "juju-apiserver" as a
-	// hostname as that is what clients specify as the hostname for verification.
-	// We also explicitly include localhost.
-	serverAddrs := []string{"localhost", "juju-apiserver"}
+	// For backwards compatibility, we must include "juju-apiserver"
+	// and "juju-mongodb" as hostnames as that is what clients specify
+	// as the hostname for verification (this certicate is used both
+	// for serving MongoDB and API server connections).  We also
+	// explicitly include localhost.
+	serverAddrs := []string{"localhost", "juju-apiserver", "juju-mongodb"}
 	for _, addr := range addresses {
 		if addr.Value == "localhost" {
 			continue

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -134,9 +134,12 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 		c.Fatalf("timed out waiting for certificate to be updated")
 	}
 
-	// The server certificates must report "juju-apiserver" as a DNS name
-	// for backwards-compatibility with API clients.
-	c.Assert(srvCert.DNSNames, gc.DeepEquals, []string{"localhost", "juju-apiserver"})
+	// The server certificates must report "juju-apiserver" as a DNS
+	// name for backwards-compatibility with API clients. They must
+	// also report "juju-mongodb" because these certicates are also
+	// used for serving MongoDB connections.
+	c.Assert(srvCert.DNSNames, gc.DeepEquals,
+		[]string{"localhost", "juju-apiserver", "juju-mongodb"})
 }
 
 type mockStateServingGetterNoCAKey struct{}


### PR DESCRIPTION
The server certificate is used by both the API server and MongoDB and the mongodb client connections from Juju expect servers with a hostname of "juju-mongodb".

Fixes LP #1434680.

(Review request: http://reviews.vapour.ws/r/1226/)