### PR TITLE
worker/storageprovisioner: create filesystems

### DIFF
--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -140,6 +140,30 @@ func volumeSource(
 	return source, nil
 }
 
+// filesystemSource returns a filesystem source given a name, provider type,
+// environment config and storage directory.
+//
+// TODO(axw) move this to the main storageprovisioner, and have
+// it watch for changes to storage source configurations, updating
+// a map in-between calls to the volume/filesystem/attachment
+// event handlers.
+func filesystemSource(
+	environConfig *config.Config,
+	baseStorageDir string,
+	sourceName string,
+	providerType storage.ProviderType,
+) (storage.FilesystemSource, error) {
+	provider, sourceConfig, err := sourceParams(providerType, sourceName, baseStorageDir)
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting storage source %q params", sourceName)
+	}
+	source, err := provider.FilesystemSource(environConfig, sourceConfig)
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting storage source %q", sourceName)
+	}
+	return source, nil
+}
+
 func sourceParams(providerType storage.ProviderType, sourceName, baseStorageDir string) (storage.Provider, *storage.Config, error) {
 	provider, err := registry.StorageProvider(providerType)
 	if err != nil {

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -80,7 +80,7 @@ func filesystemAttachmentsChanged(ctx *context, ids []params.MachineStorageId) e
 	if len(dead) != 0 {
 		// We should not see dead filesystem attachments;
 		// attachments go directly from Dying to removed.
-		logger.Debugf("unexpected dead filesystem attachments: %f", dead)
+		logger.Debugf("unexpected dead filesystem attachments: %v", dead)
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil
@@ -129,7 +129,7 @@ func processDeadFilesystems(ctx *context, tags []names.Tag, filesystemResults []
 	destroyed := make([]names.Tag, 0, len(tags))
 	for i, tag := range tags {
 		if err := errorResults[i]; err != nil {
-			logger.Errorf("destroying %s: %f", names.ReadableString(tag), err)
+			logger.Errorf("destroying %s: %v", names.ReadableString(tag), err)
 			continue
 		}
 		destroyed = append(destroyed, tag)
@@ -150,7 +150,7 @@ func processDyingFilesystemAttachments(
 	filesystemAttachments := make([]params.FilesystemAttachment, len(filesystemAttachmentResults))
 	for i, result := range filesystemAttachmentResults {
 		if result.Error != nil {
-			return errors.Annotatef(result.Error, "getting information for filesystem attachment %f", ids[i])
+			return errors.Annotatef(result.Error, "getting information for filesystem attachment %v", ids[i])
 		}
 		filesystemAttachments[i] = result.Result
 	}
@@ -164,7 +164,7 @@ func processDyingFilesystemAttachments(
 	detached := make([]params.MachineStorageId, 0, len(ids))
 	for i, id := range ids {
 		if err := errorResults[i]; err != nil {
-			logger.Errorf("detaching %f from %f: %f", ids[i].AttachmentTag, ids[i].MachineTag, err)
+			logger.Errorf("detaching %v from %v: %v", ids[i].AttachmentTag, ids[i].MachineTag, err)
 			continue
 		}
 		detached = append(detached, id)
@@ -263,7 +263,7 @@ func processAliveFilesystemAttachments(
 		}
 		if !params.IsCodeNotProvisioned(result.Error) {
 			return errors.Annotatef(
-				result.Error, "getting information for attachment %f", ids[i],
+				result.Error, "getting information for attachment %v", ids[i],
 			)
 		}
 		// The filesystem has not yet been provisioned, so record its tag

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -26,13 +26,12 @@ func filesystemsChanged(ctx *context, changes []string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// TODO(axw) wait for filesystems/filesystems to have no
-	// attachments first. We can then have the removal of the
-	// last attachment trigger the filesystem/filesystem's Life
-	// being transitioned to Dead.
-	// or watch the attachments until they're all gone. We need
-	// to watch attachments *anyway*, so we can probably integrate
-	// the two things.
+	// TODO(axw) wait for filesystems to have no attachments first.
+	// We can then have the removal of the last attachment trigger
+	// the filesystem's Life being transitioned to Dead, or watch
+	// the attachments until they're all gone. We need to watch
+	// attachments *anyway*, so we can probably integrate the two
+	// things.
 	if err := ensureDead(ctx, dying); err != nil {
 		return errors.Annotate(err, "ensuring filesystems dead")
 	}
@@ -294,6 +293,11 @@ func processAliveFilesystemAttachments(
 			// in the context, so that if when the filesystem is created
 			// the attachment isn't created with it, we can then try
 			// to attach.
+			logger.Debugf(
+				"waiting for filesystem (%q) or instance (%q) to be provisioned",
+				params.FilesystemId,
+				params.InstanceId,
+			)
 			continue
 		}
 		if params.Path == "" {

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -1,0 +1,494 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
+)
+
+// filesystemsChanged is called when the lifecycle states of the filesystems
+// with the provided IDs have been seen to have changed.
+func filesystemsChanged(ctx *context, changes []string) error {
+	tags := make([]names.Tag, len(changes))
+	for i, change := range changes {
+		tags[i] = names.NewFilesystemTag(change)
+	}
+	alive, dying, dead, err := storageEntityLife(ctx, tags)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// TODO(axw) wait for filesystems/filesystems to have no
+	// attachments first. We can then have the removal of the
+	// last attachment trigger the filesystem/filesystem's Life
+	// being transitioned to Dead.
+	// or watch the attachments until they're all gone. We need
+	// to watch attachments *anyway*, so we can probably integrate
+	// the two things.
+	if err := ensureDead(ctx, dying); err != nil {
+		return errors.Annotate(err, "ensuring filesystems dead")
+	}
+	// Once the entities are Dead, they can be removed from state
+	// after the corresponding cloud storage resources are removed.
+	dead = append(dead, dying...)
+	if len(alive)+len(dead) == 0 {
+		return nil
+	}
+
+	// Get filesystem information for alive and dead filesystems, so
+	// we can provision/deprovision.
+	filesystemTags := make([]names.FilesystemTag, 0, len(alive)+len(dead))
+	for _, tag := range alive {
+		filesystemTags = append(filesystemTags, tag.(names.FilesystemTag))
+	}
+	for _, tag := range dead {
+		filesystemTags = append(filesystemTags, tag.(names.FilesystemTag))
+	}
+	filesystemResults, err := ctx.filesystems.Filesystems(filesystemTags)
+	if err != nil {
+		return errors.Annotatef(err, "getting filesystem information")
+	}
+
+	// Deprovision "dead" filesystems, and then remove from state.
+	if err := processDeadFilesystems(ctx, dead, filesystemResults[len(alive):]); err != nil {
+		return errors.Annotate(err, "deprovisioning filesystems")
+	}
+
+	// Provision "alive" filesystems.
+	if err := processAliveFilesystems(ctx, alive, filesystemResults[:len(alive)]); err != nil {
+		return errors.Annotate(err, "provisioning filesystems")
+	}
+
+	return nil
+}
+
+// filesystemAttachmentsChanged is called when the lifecycle states of the filesystem
+// attachments with the provided IDs have been seen to have changed.
+func filesystemAttachmentsChanged(ctx *context, ids []params.MachineStorageId) error {
+	alive, dying, dead, err := attachmentLife(ctx, ids)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(dead) != 0 {
+		// We should not see dead filesystem attachments;
+		// attachments go directly from Dying to removed.
+		logger.Debugf("unexpected dead filesystem attachments: %f", dead)
+	}
+	if len(alive)+len(dying) == 0 {
+		return nil
+	}
+
+	// Get filesystem information for alive and dying filesystem attachments, so
+	// we can attach/detach.
+	ids = append(alive, dying...)
+	filesystemAttachmentResults, err := ctx.filesystems.FilesystemAttachments(ids)
+	if err != nil {
+		return errors.Annotatef(err, "getting filesystem attachment information")
+	}
+
+	// Deprovision Dying filesystem attachments.
+	dyingFilesystemAttachmentResults := filesystemAttachmentResults[len(alive):]
+	if err := processDyingFilesystemAttachments(ctx, dying, dyingFilesystemAttachmentResults); err != nil {
+		return errors.Annotate(err, "deprovisioning filesystem attachments")
+	}
+
+	// Provision Alive filesystem attachments.
+	aliveFilesystemAttachmentResults := filesystemAttachmentResults[:len(alive)]
+	if err := processAliveFilesystemAttachments(ctx, alive, aliveFilesystemAttachmentResults); err != nil {
+		return errors.Annotate(err, "provisioning filesystems")
+	}
+
+	return nil
+}
+
+// processDeadFilesystems processes the FilesystemResults for Dead filesystems,
+// deprovisioning filesystems and removing from state as necessary.
+func processDeadFilesystems(ctx *context, tags []names.Tag, filesystemResults []params.FilesystemResult) error {
+	filesystems := make([]params.Filesystem, len(filesystemResults))
+	for i, result := range filesystemResults {
+		if result.Error != nil {
+			return errors.Annotatef(result.Error, "getting filesystem information for filesystem %q", tags[i].Id())
+		}
+		filesystems[i] = result.Result
+	}
+	if len(filesystems) == 0 {
+		return nil
+	}
+	errorResults, err := destroyFilesystems(filesystems)
+	if err != nil {
+		return errors.Annotate(err, "destroying filesystems")
+	}
+	destroyed := make([]names.Tag, 0, len(tags))
+	for i, tag := range tags {
+		if err := errorResults[i]; err != nil {
+			logger.Errorf("destroying %s: %f", names.ReadableString(tag), err)
+			continue
+		}
+		destroyed = append(destroyed, tag)
+	}
+	if err := removeEntities(ctx, destroyed); err != nil {
+		return errors.Annotate(err, "removing filesystems from state")
+	}
+	return nil
+}
+
+// processDyingFilesystemAttachments processes the FilesystemAttachmentResults for
+// Dying filesystem attachments, detaching filesystems and updating state as necessary.
+func processDyingFilesystemAttachments(
+	ctx *context,
+	ids []params.MachineStorageId,
+	filesystemAttachmentResults []params.FilesystemAttachmentResult,
+) error {
+	filesystemAttachments := make([]params.FilesystemAttachment, len(filesystemAttachmentResults))
+	for i, result := range filesystemAttachmentResults {
+		if result.Error != nil {
+			return errors.Annotatef(result.Error, "getting information for filesystem attachment %f", ids[i])
+		}
+		filesystemAttachments[i] = result.Result
+	}
+	if len(filesystemAttachments) == 0 {
+		return nil
+	}
+	errorResults, err := detachFilesystems(filesystemAttachments)
+	if err != nil {
+		return errors.Annotate(err, "detaching filesystems")
+	}
+	detached := make([]params.MachineStorageId, 0, len(ids))
+	for i, id := range ids {
+		if err := errorResults[i]; err != nil {
+			logger.Errorf("detaching %f from %f: %f", ids[i].AttachmentTag, ids[i].MachineTag, err)
+			continue
+		}
+		detached = append(detached, id)
+	}
+	if err := removeAttachments(ctx, detached); err != nil {
+		return errors.Annotate(err, "removing attachments from state")
+	}
+	return nil
+}
+
+// processAliveFilesystems processes the FilesystemResults for Alive filesystems,
+// provisioning filesystems and setting the info in state as necessary.
+func processAliveFilesystems(ctx *context, tags []names.Tag, filesystemResults []params.FilesystemResult) error {
+	// Filter out the already-provisioned filesystems.
+	pending := make([]names.FilesystemTag, 0, len(tags))
+	for i, result := range filesystemResults {
+		if result.Error == nil {
+			// Filesystem is already provisioned: skip.
+			logger.Debugf("filesystem %q is already provisioned, nothing to do", tags[i].Id())
+			continue
+		}
+		if !params.IsCodeNotProvisioned(result.Error) {
+			return errors.Annotatef(
+				result.Error, "getting filesystem information for filesystem %q", tags[i].Id(),
+			)
+		}
+		// The filesystem has not yet been provisioned, so record its tag
+		// to enquire about parameters below.
+		pending = append(pending, tags[i].(names.FilesystemTag))
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	paramsResults, err := ctx.filesystems.FilesystemParams(pending)
+	if err != nil {
+		return errors.Annotate(err, "getting filesystem params")
+	}
+	filesystemParams := make([]storage.FilesystemParams, 0, len(paramsResults))
+	for _, result := range paramsResults {
+		if result.Error != nil {
+			return errors.Annotate(err, "getting filesystem parameters")
+		}
+		params, err := filesystemParamsFromParams(result.Result)
+		if err != nil {
+			return errors.Annotate(err, "getting filesystem parameters")
+		}
+		filesystemParams = append(filesystemParams, params)
+	}
+	filesystems, filesystemAttachments, err := createFilesystems(
+		ctx.environConfig, ctx.storageDir, filesystemParams,
+	)
+	if err != nil {
+		return errors.Annotate(err, "creating filesystems")
+	}
+	if len(filesystems) > 0 {
+		// TODO(axw) we need to be able to list filesystems in the provider,
+		// by environment, so that we can "harvest" them if they're
+		// unknown. This will take care of killing filesystems that we fail
+		// to record in state.
+		errorResults, err := ctx.filesystems.SetFilesystemInfo(filesystems)
+		if err != nil {
+			return errors.Annotate(err, "publishing filesystems to state")
+		}
+		for i, result := range errorResults {
+			if result.Error != nil {
+				return errors.Annotatef(
+					err, "publishing %s to state",
+					filesystems[i].FilesystemTag,
+				)
+			}
+		}
+		// Note: the storage provisioner that creates a filesystem is also
+		// responsible for creating the filesystem attachment. It is therefore
+		// safe to set the filesystem attachment info after the filesystem info,
+		// without leading to the possibility of concurrent, duplicate
+		// attachments.
+		if err := setFilesystemAttachmentInfo(ctx, filesystemAttachments); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// processAliveFilesystems processes the FilesystemAttachmentResults for Alive
+// filesystem attachments, attaching filesystems and setting the info in state
+// as necessary.
+func processAliveFilesystemAttachments(
+	ctx *context,
+	ids []params.MachineStorageId,
+	filesystemAttachmentResults []params.FilesystemAttachmentResult,
+) error {
+	// Filter out the already-attached.
+	//
+	// TODO(axw) record locally which filesystems have been attached this
+	// session, and issue a reattach each time we restart. We should
+	// limit this to machine-scoped filesystems to start with.
+	pending := make([]params.MachineStorageId, 0, len(ids))
+	for i, result := range filesystemAttachmentResults {
+		if result.Error == nil {
+			// Filesystem attachment is already provisioned: skip.
+			logger.Debugf(
+				"%s is already attached to %s, nothing to do",
+				ids[i].AttachmentTag, ids[i].MachineTag,
+			)
+			continue
+		}
+		if !params.IsCodeNotProvisioned(result.Error) {
+			return errors.Annotatef(
+				result.Error, "getting information for attachment %f", ids[i],
+			)
+		}
+		// The filesystem has not yet been provisioned, so record its tag
+		// to enquire about parameters below.
+		pending = append(pending, ids[i])
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	paramsResults, err := ctx.filesystems.FilesystemAttachmentParams(pending)
+	if err != nil {
+		return errors.Annotate(err, "getting filesystem params")
+	}
+	filesystemAttachmentParams := make([]storage.FilesystemAttachmentParams, 0, len(paramsResults))
+	for _, result := range paramsResults {
+		if result.Error != nil {
+			return errors.Annotate(err, "getting filesystem attachment parameters")
+		}
+		params, err := filesystemAttachmentParamsFromParams(result.Result)
+		if err != nil {
+			return errors.Annotate(err, "getting filesystem attachment parameters")
+		}
+		if params.FilesystemId == "" || params.InstanceId == "" {
+			// Don't attempt to attach to filesystems that haven't yet
+			// been provisioned.
+			//
+			// TODO(axw) we should store a set of pending attachments
+			// in the context, so that if when the filesystem is created
+			// the attachment isn't created with it, we can then try
+			// to attach.
+			continue
+		}
+		if params.Path == "" {
+			params.Path = filepath.Join(ctx.storageDir, params.Filesystem.Id())
+		}
+		filesystemAttachmentParams = append(filesystemAttachmentParams, params)
+	}
+	filesystemAttachments, err := createFilesystemAttachments(
+		ctx.environConfig, ctx.storageDir, filesystemAttachmentParams,
+	)
+	if err != nil {
+		return errors.Annotate(err, "creating filesystem attachments")
+	}
+	if err := setFilesystemAttachmentInfo(ctx, filesystemAttachments); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func setFilesystemAttachmentInfo(ctx *context, filesystemAttachments []params.FilesystemAttachment) error {
+	if len(filesystemAttachments) == 0 {
+		return nil
+	}
+	// TODO(axw) we need to be able to list filesystem attachments in the
+	// provider, by environment, so that we can "harvest" them if they're
+	// unknown. This will take care of killing filesystems that we fail to
+	// record in state.
+	errorResults, err := ctx.filesystems.SetFilesystemAttachmentInfo(filesystemAttachments)
+	if err != nil {
+		return errors.Annotate(err, "publishing filesystems to state")
+	}
+	for i, result := range errorResults {
+		if result.Error != nil {
+			return errors.Annotatef(
+				result.Error, "publishing attachment of %s to %s to state",
+				filesystemAttachments[i].FilesystemTag,
+				filesystemAttachments[i].MachineTag,
+			)
+		}
+	}
+	return nil
+}
+
+// createFilesystems creates filesystems with the specified parameters.
+func createFilesystems(
+	environConfig *config.Config,
+	baseStorageDir string,
+	params []storage.FilesystemParams,
+) ([]params.Filesystem, []params.FilesystemAttachment, error) {
+	// TODO(axw) later we may have multiple instantiations (sources)
+	// for a storage provider, e.g. multiple Ceph installations. For
+	// now we assume a single source for each provider type, with no
+	// configuration.
+	filesystemSources := make(map[string]storage.FilesystemSource)
+	paramsBySource := make(map[string][]storage.FilesystemParams)
+	for _, params := range params {
+		sourceName := string(params.Provider)
+		paramsBySource[sourceName] = append(paramsBySource[sourceName], params)
+		if _, ok := filesystemSources[sourceName]; ok {
+			continue
+		}
+		filesystemSource, err := filesystemSource(
+			environConfig, baseStorageDir, sourceName, params.Provider,
+		)
+		if err != nil {
+			return nil, nil, errors.Annotate(err, "getting filesystem source")
+		}
+		filesystemSources[sourceName] = filesystemSource
+	}
+	var allFilesystems []storage.Filesystem
+	var allFilesystemAttachments []storage.FilesystemAttachment
+	for sourceName, params := range paramsBySource {
+		filesystemSource := filesystemSources[sourceName]
+		filesystems, filesystemAttachments, err := filesystemSource.CreateFilesystems(params)
+		if err != nil {
+			return nil, nil, errors.Annotatef(err, "creating filesystems from source %q", sourceName)
+		}
+		allFilesystems = append(allFilesystems, filesystems...)
+		allFilesystemAttachments = append(allFilesystemAttachments, filesystemAttachments...)
+	}
+	return filesystemsFromStorage(allFilesystems), filesystemAttachmentsFromStorage(allFilesystemAttachments), nil
+}
+
+// createFilesystems creates filesystems with the specified parameters.
+func createFilesystemAttachments(
+	environConfig *config.Config,
+	baseStorageDir string,
+	params []storage.FilesystemAttachmentParams,
+) ([]params.FilesystemAttachment, error) {
+	// TODO(axw) later we may have multiple instantiations (sources)
+	// for a storage provider, e.g. multiple Ceph installations. For
+	// now we assume a single source for each provider type, with no
+	// configuration.
+	filesystemSources := make(map[string]storage.FilesystemSource)
+	paramsBySource := make(map[string][]storage.FilesystemAttachmentParams)
+	for _, params := range params {
+		sourceName := string(params.Provider)
+		paramsBySource[sourceName] = append(paramsBySource[sourceName], params)
+		if _, ok := filesystemSources[sourceName]; ok {
+			continue
+		}
+		filesystemSource, err := filesystemSource(
+			environConfig, baseStorageDir, sourceName, params.Provider,
+		)
+		if err != nil {
+			return nil, errors.Annotate(err, "getting filesystem source")
+		}
+		filesystemSources[sourceName] = filesystemSource
+	}
+	var allFilesystemAttachments []storage.FilesystemAttachment
+	for sourceName, params := range paramsBySource {
+		filesystemSource := filesystemSources[sourceName]
+		filesystemAttachments, err := filesystemSource.AttachFilesystems(params)
+		if err != nil {
+			return nil, errors.Annotatef(err, "attaching filesystems from source %q", sourceName)
+		}
+		allFilesystemAttachments = append(allFilesystemAttachments, filesystemAttachments...)
+	}
+	return filesystemAttachmentsFromStorage(allFilesystemAttachments), nil
+}
+
+func destroyFilesystems(filesystems []params.Filesystem) ([]error, error) {
+	panic("not implemented")
+}
+
+func detachFilesystems(attachments []params.FilesystemAttachment) ([]error, error) {
+	panic("not implemented")
+}
+
+func filesystemsFromStorage(in []storage.Filesystem) []params.Filesystem {
+	out := make([]params.Filesystem, len(in))
+	for i, f := range in {
+		out[i] = params.Filesystem{
+			f.Tag.String(),
+			f.FilesystemId,
+			f.Size,
+		}
+	}
+	return out
+}
+
+func filesystemAttachmentsFromStorage(in []storage.FilesystemAttachment) []params.FilesystemAttachment {
+	out := make([]params.FilesystemAttachment, len(in))
+	for i, f := range in {
+		out[i] = params.FilesystemAttachment{
+			f.Filesystem.String(),
+			f.Machine.String(),
+			f.Path,
+		}
+	}
+	return out
+}
+
+func filesystemParamsFromParams(in params.FilesystemParams) (storage.FilesystemParams, error) {
+	filesystemTag, err := names.ParseFilesystemTag(in.FilesystemTag)
+	if err != nil {
+		return storage.FilesystemParams{}, errors.Trace(err)
+	}
+	providerType := storage.ProviderType(in.Provider)
+	return storage.FilesystemParams{
+		filesystemTag,
+		in.Size,
+		providerType,
+		in.Attributes,
+		nil, // attachments done separately
+	}, nil
+}
+
+func filesystemAttachmentParamsFromParams(in params.FilesystemAttachmentParams) (storage.FilesystemAttachmentParams, error) {
+	machineTag, err := names.ParseMachineTag(in.MachineTag)
+	if err != nil {
+		return storage.FilesystemAttachmentParams{}, errors.Trace(err)
+	}
+	filesystemTag, err := names.ParseFilesystemTag(in.FilesystemTag)
+	if err != nil {
+		return storage.FilesystemAttachmentParams{}, errors.Trace(err)
+	}
+	return storage.FilesystemAttachmentParams{
+		AttachmentParams: storage.AttachmentParams{
+			Provider:   storage.ProviderType(in.Provider),
+			Machine:    machineTag,
+			InstanceId: instance.Id(in.InstanceId),
+		},
+		Filesystem:   filesystemTag,
+		FilesystemId: in.FilesystemId,
+		Path:         in.MountPoint,
+	}, nil
+}

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -89,6 +89,40 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
 }
 
+func (s *storageProvisionerSuite) TestFilesystemAdded(c *gc.C) {
+	expectedFilesystems := []params.Filesystem{{
+		FilesystemTag: "filesystem-1",
+		FilesystemId:  "id-1",
+		Size:          1024,
+	}, {
+		FilesystemTag: "filesystem-2",
+		FilesystemId:  "id-2",
+		Size:          1024,
+	}}
+
+	filesystemInfoSet := make(chan struct{})
+	filesystemAccessor := newMockFilesystemAccessor()
+	filesystemAccessor.setFilesystemInfo = func(filesystems []params.Filesystem) ([]params.ErrorResult, error) {
+		defer close(filesystemInfoSet)
+		c.Assert(filesystems, gc.DeepEquals, expectedFilesystems)
+		return nil, nil
+	}
+
+	lifecycleManager := &mockLifecycleManager{}
+
+	volumeAccessor := newMockVolumeAccessor()
+
+	worker := storageprovisioner.NewStorageProvisioner(
+		"storage-dir", volumeAccessor, filesystemAccessor, lifecycleManager,
+	)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+
+	// The worker should create filesystems according to ids "1" and "2".
+	filesystemAccessor.filesystemsWatcher.changes <- []string{"1", "2"}
+	waitChannel(c, filesystemInfoSet, "waiting for filesystem info to be set")
+}
+
 func (s *storageProvisionerSuite) TestVolumeAttachmentAdded(c *gc.C) {
 	// We should only get a single volume attachment, because it is the
 	// only combination where both machine and volume are already
@@ -147,6 +181,66 @@ func (s *storageProvisionerSuite) TestVolumeAttachmentAdded(c *gc.C) {
 		MachineTag: "machine-0", AttachmentTag: "volume-1",
 	}}
 	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
+}
+
+func (s *storageProvisionerSuite) TestFilesystemAttachmentAdded(c *gc.C) {
+	// We should only get a single filesystem attachment, because it is the
+	// only combination where both machine and filesystem are already
+	// provisioned, and the attachmenti s not.
+	expectedFilesystemAttachments := []params.FilesystemAttachment{{
+		FilesystemTag: "filesystem-1",
+		MachineTag:    "machine-1",
+		MountPoint:    "/srv/fs-123",
+	}}
+
+	filesystemAttachmentInfoSet := make(chan struct{})
+	filesystemAccessor := newMockFilesystemAccessor()
+	filesystemAccessor.setFilesystemAttachmentInfo = func(filesystemAttachments []params.FilesystemAttachment) ([]params.ErrorResult, error) {
+		defer close(filesystemAttachmentInfoSet)
+		c.Assert(filesystemAttachments, gc.DeepEquals, expectedFilesystemAttachments)
+		return nil, nil
+	}
+	lifecycleManager := &mockLifecycleManager{}
+
+	// filesystem-1 and machine-1 are provisioned.
+	filesystemAccessor.provisionedFilesystems["filesystem-1"] = params.Filesystem{
+		FilesystemTag: "filesystem-1",
+		FilesystemId:  "fs-123",
+	}
+	filesystemAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
+	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+
+	// machine-0/filesystem-1 attachment is already created.
+	//
+	// TODO(axw) later we should ensure that a reattachment occurs
+	// the first time the attachment is seen by the worker.
+	alreadyAttached := params.MachineStorageId{
+		MachineTag:    "machine-0",
+		AttachmentTag: "filesystem-1",
+	}
+	filesystemAccessor.provisionedAttachments[alreadyAttached] = params.FilesystemAttachment{
+		MachineTag:    "machine-0",
+		FilesystemTag: "filesystem-1",
+	}
+
+	volumeAccessor := newMockVolumeAccessor()
+
+	worker := storageprovisioner.NewStorageProvisioner(
+		"storage-dir", volumeAccessor, filesystemAccessor, lifecycleManager,
+	)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+
+	filesystemAccessor.attachmentsWatcher.changes <- []params.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "filesystem-1",
+	}, {
+		MachineTag: "machine-1", AttachmentTag: "filesystem-2",
+	}, {
+		MachineTag: "machine-2", AttachmentTag: "filesystem-1",
+	}, {
+		MachineTag: "machine-0", AttachmentTag: "filesystem-1",
+	}}
+	waitChannel(c, filesystemAttachmentInfoSet, "waiting for filesystem attachments to be set")
 }
 
 func waitChannel(c *gc.C, ch <-chan struct{}, activity string) {

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -246,9 +246,9 @@ func processAliveVolumes(ctx *context, tags []names.Tag, volumeResults []params.
 	return nil
 }
 
-// processAliveVolumes processes the VolumeAttachmentResults for Alive
-// volume attachments, attaching volumes and setting the info in state
-// as necessary.
+// processAliveVolumeAttachments processes the VolumeAttachmentResults
+// for Alive volume attachments, attaching volumes and setting the info
+// in state as necessary.
 func processAliveVolumeAttachments(
 	ctx *context,
 	ids []params.MachineStorageId,

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -24,13 +24,12 @@ func volumesChanged(ctx *context, changes []string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// TODO(axw) wait for volumes/filesystems to have no
-	// attachments first. We can then have the removal of the
-	// last attachment trigger the volume/filesystem's Life
-	// being transitioned to Dead.
-	// or watch the attachments until they're all gone. We need
-	// to watch attachments *anyway*, so we can probably integrate
-	// the two things.
+	// TODO(axw) wait for volumes to have no attachments first.
+	// We can then have the removal of the last attachment trigger
+	// the volume's Life being transitioned to Dead, or watch the
+	// attachments until they're all gone. We need to watch
+	// attachments *anyway*, so we can probably integrate the two
+	// things.
 	if err := ensureDead(ctx, dying); err != nil {
 		return errors.Annotate(err, "ensuring volumes dead")
 	}


### PR DESCRIPTION
This branch extends the storageprovisioner worker
to watch filesystems/attachments and create/attach
filesystems according to lifecycle state changes.

Requires PR #1901

(Review request: http://reviews.vapour.ws/r/1227/)