### PR TITLE
API: Fix #1435152, deploy local charm, non-state envion

### DIFF
--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -164,6 +164,11 @@ func (s *apiclientSuite) TestDialWebsocketStopped(c *gc.C) {
 	c.Assert(result, gc.IsNil)
 }
 
+func (s *apiclientSuite) TestServerRoot(c *gc.C) {
+	url := api.ServerRoot(s.APIState.Client())
+	c.Assert(url, gc.Matches, "https://localhost:[0-9]+")
+}
+
 func (*websocketSuite) TestSetUpWebsocketConfig(c *gc.C) {
 	conf, err := api.SetUpWebsocket("0.1.2.3:1234", "", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/client.go
+++ b/api/client.go
@@ -705,9 +705,12 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm) (*charm.URL, err
 		return nil, errors.Errorf("unknown charm type %T", ch)
 	}
 
-	// Prepare the upload request.
-	url := fmt.Sprintf("%s/charms?series=%s", c.st.serverRoot, curl.Series)
-	req, err := http.NewRequest("POST", url, archive)
+	endPoint, err := c.localCharmUploadEndpoint(curl.Series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	req, err := http.NewRequest("POST", endPoint, archive)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create upload request")
 	}
@@ -749,6 +752,32 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm) (*charm.URL, err
 	return charm.MustParseURL(jsonResponse.CharmURL), nil
 }
 
+func (c *Client) localCharmUploadEndpoint(series string) (string, error) {
+	var apiEndpoint string
+	if _, err := c.st.ServerTag(); err == nil {
+		envTag, err := c.st.EnvironTag()
+		if err != nil {
+			return "", errors.Annotate(err, "cannot get API endpoint address")
+		}
+
+		apiEndpoint = fmt.Sprintf("/environment/%s/charms", envTag.Id())
+	} else {
+		// If the server tag is not set, then the agent version is < 1.23. We
+		// use the old API endpoint for backwards compatibility.
+		apiEndpoint = "/charms"
+	}
+
+	// Prepare the upload request.
+	upURL := url.URL{
+		Scheme:   c.st.serverScheme,
+		Host:     c.st.Addr(),
+		Path:     apiEndpoint,
+		RawQuery: fmt.Sprintf("series=%s", series),
+	}
+
+	return upURL.String(), nil
+}
+
 // AddCharm adds the given charm URL (which must include revision) to
 // the environment, if it does not exist yet. Local charms are not
 // supported, only charm store URLs. See also AddLocalCharm() in the
@@ -780,8 +809,11 @@ func (c *Client) ResolveCharm(ref *charm.Reference) (*charm.URL, error) {
 func (c *Client) UploadTools(r io.Reader, vers version.Binary, additionalSeries ...string) (*tools.Tools, error) {
 	// Prepare the upload request.
 	url := fmt.Sprintf(
+		// TODO(waigani) This is going to be a problem in the future where we
+		// want to upload tools for a particular environment. The upload root
+		// will need to be something like: <serverRoot>/environment/<UUID/tools
 		"%s/tools?binaryVersion=%s&series=%s",
-		c.st.serverRoot,
+		c.st.serverRoot(),
 		vers,
 		strings.Join(additionalSeries, ","),
 	)

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -18,10 +18,16 @@ var (
 	NewHTTPClient       = &newHTTPClient
 )
 
-// SetServerRoot allows changing the URL to the internal API server
+// SetServerAddress allows changing the URL to the internal API server
 // that AddLocalCharm uses in order to test NotImplementedError.
-func SetServerRoot(c *Client, root string) {
-	c.st.serverRoot = root
+func SetServerAddress(c *Client, scheme, addr string) {
+	c.st.serverScheme = scheme
+	c.st.addr = addr
+}
+
+// ServerRoot is exported so that we can test the built URL.
+func ServerRoot(c *Client) string {
+	return c.st.serverRoot()
 }
 
 // PatchEnvironTag patches the value of the environment tag.
@@ -41,6 +47,7 @@ type TestingStateParams struct {
 	EnvironTag     string
 	APIHostPorts   [][]network.HostPort
 	FacadeVersions map[string][]int
+	ServerScheme   string
 	ServerRoot     string
 }
 
@@ -49,11 +56,12 @@ type TestingStateParams struct {
 // called on it. But it can be used for testing general behavior.
 func NewTestingState(params TestingStateParams) *State {
 	st := &State{
-		addr:           params.Address,
-		environTag:     params.EnvironTag,
-		hostPorts:      params.APIHostPorts,
-		facadeVersions: params.FacadeVersions,
-		serverRoot:     params.ServerRoot,
+		addr:              params.Address,
+		environTag:        params.EnvironTag,
+		hostPorts:         params.APIHostPorts,
+		facadeVersions:    params.FacadeVersions,
+		serverScheme:      params.ServerScheme,
+		serverRootAddress: params.ServerRoot,
 	}
 	return st
 }

--- a/api/http.go
+++ b/api/http.go
@@ -35,9 +35,9 @@ func (s *State) NewHTTPClient() *http.Client {
 
 // NewHTTPRequest returns a new API-supporting HTTP request based on State.
 func (s *State) NewHTTPRequest(method, path string) (*http.Request, error) {
-	baseURL, err := url.Parse(s.serverRoot)
+	baseURL, err := url.Parse(s.serverRoot())
 	if err != nil {
-		return nil, errors.Annotatef(err, "while parsing base URL (%s)", s.serverRoot)
+		return nil, errors.Annotatef(err, "while parsing base URL (%s)", s.serverRoot())
 	}
 
 	tag, err := s.EnvironTag()


### PR DESCRIPTION
Update the API client method AddLocalCharm to use the new environment
specific API endpoint. Add a test to ensure a local charm archive can
be uploaded to a non-state server environment.

(Review request: http://reviews.vapour.ws/r/1228/)