### PR TITLE
testing/environ.go: testing environment uuid is now valid

### DIFF
--- a/environs/cloudinit/windows_userdata_test.go
+++ b/environs/cloudinit/windows_userdata_test.go
@@ -850,7 +850,7 @@ cacert: |
   -----END CERTIFICATE-----
 stateaddresses:
 - state-addr.testing.invalid:12345
-environment: environment-deadbeef-0bad-f00d-0000-4b1d0d06f00d
+environment: environment-deadbeef-0bad-400d-8000-4b1d0d06f00d
 apiaddresses:
 - state-addr.testing.invalid:54321
 oldpassword: arble

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -33,7 +33,7 @@ func init() {
 const FakeDefaultSeries = "trusty"
 
 // EnvironmentTag is a defined known valid UUID that can be used in testing.
-var EnvironmentTag = names.NewEnvironTag("deadbeef-0bad-f00d-0000-4b1d0d06f00d")
+var EnvironmentTag = names.NewEnvironTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
 
 // FakeConfig() returns an environment configuration for a
 // fake provider with all required attributes set.

--- a/testing/environ_test.go
+++ b/testing/environ_test.go
@@ -58,3 +58,7 @@ func (s *fakeHomeSuite) TestEnvironmentTagValid(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tag, gc.Equals, testing.EnvironmentTag)
 }
+
+func (s *fakeHomeSuite) TestEnvironUUIDValid(c *gc.C) {
+	c.Assert(utils.IsValidUUIDString(testing.EnvironmentTag.Id()), jc.IsTrue)
+}


### PR DESCRIPTION
The previous uuid was invalid.

> The 13th digit needs to be the number 4.
> Block 4 needs to start with a variant character that is 8,9,a,b.
(Review request: http://reviews.vapour.ws/r/1232/)