### PR TITLE
Run Actions in ModeHookError 

### DIFF
--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -417,6 +417,10 @@ func ModeHookError(u *Uniter) (next Mode, err error) {
 				return nil, errors.Trace(err)
 			}
 			return ModeContinue, nil
+		case actionId := <-u.f.ActionEvents():
+			if err := u.runOperation(newActionOp(actionId)); err != nil {
+				return nil, errors.Trace(err)
+			}
 		case <-leaderDeposed:
 			// This should trigger at most once -- we can't reaccept leadership while
 			// in an error state.

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -54,6 +54,7 @@ func (ra *runAction) Prepare(state State) (*State, error) {
 		Step:     Pending,
 		ActionId: &ra.actionId,
 		Hook:     state.Hook,
+		CharmURL: state.CharmURL,
 	}.apply(state), nil
 }
 
@@ -78,15 +79,21 @@ func (ra *runAction) Execute(state State) (*State, error) {
 		Step:     Done,
 		ActionId: &ra.actionId,
 		Hook:     state.Hook,
+		CharmURL: state.CharmURL,
 	}.apply(state), nil
 }
 
 // Commit preserves the recorded hook, and returns a neutral state.
 // Commit is part of the Operation interface.
 func (ra *runAction) Commit(state State) (*State, error) {
+	kind := Continue
+	if state.Hook != nil {
+		kind = RunHook
+	}
 	return stateChange{
-		Kind: Continue,
-		Step: Pending,
-		Hook: state.Hook,
+		Kind:     kind,
+		Step:     Pending,
+		Hook:     state.Hook,
+		CharmURL: state.CharmURL,
 	}.apply(state), nil
 }

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -54,7 +54,6 @@ func (ra *runAction) Prepare(state State) (*State, error) {
 		Step:     Pending,
 		ActionId: &ra.actionId,
 		Hook:     state.Hook,
-		CharmURL: state.CharmURL,
 	}.apply(state), nil
 }
 
@@ -79,7 +78,6 @@ func (ra *runAction) Execute(state State) (*State, error) {
 		Step:     Done,
 		ActionId: &ra.actionId,
 		Hook:     state.Hook,
-		CharmURL: state.CharmURL,
 	}.apply(state), nil
 }
 
@@ -91,9 +89,8 @@ func (ra *runAction) Commit(state State) (*State, error) {
 		kind = RunHook
 	}
 	return stateChange{
-		Kind:     kind,
-		Step:     Pending,
-		Hook:     state.Hook,
-		CharmURL: state.CharmURL,
+		Kind: kind,
+		Step: Pending,
+		Hook: state.Hook,
 	}.apply(state), nil
 }

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -84,13 +84,20 @@ func (ra *runAction) Execute(state State) (*State, error) {
 // Commit preserves the recorded hook, and returns a neutral state.
 // Commit is part of the Operation interface.
 func (ra *runAction) Commit(state State) (*State, error) {
-	kind := Continue
-	if state.Hook != nil {
-		kind = RunHook
-	}
 	return stateChange{
-		Kind: kind,
+		Kind: continuationKind(state),
 		Step: Pending,
 		Hook: state.Hook,
 	}.apply(state), nil
+}
+
+// continuationKind determines what State Kind the operation
+// should return after Commit.
+func continuationKind(state State) Kind {
+	switch {
+	case state.Hook != nil:
+		return RunHook
+	default:
+		return Continue
+	}
 }

--- a/worker/uniter/operation/runaction_test.go
+++ b/worker/uniter/operation/runaction_test.go
@@ -121,7 +121,6 @@ func (s *RunActionSuite) TestPrepareSuccessDirtyState(c *gc.C) {
 		ActionId:           &someActionId,
 		Started:            true,
 		CollectMetricsTime: 1234567,
-		CharmURL:           curl("cs:quantal/wordpress-2"),
 		Hook:               &hook.Info{Kind: hooks.Install},
 	})
 	c.Assert(*runnerFactory.MockNewActionRunner.gotActionId, gc.Equals, someActionId)
@@ -185,7 +184,6 @@ func (s *RunActionSuite) TestExecuteSuccess(c *gc.C) {
 			Step:               operation.Done,
 			ActionId:           &someActionId,
 			Hook:               &hook.Info{Kind: hooks.Install},
-			CharmURL:           curl("cs:quantal/wordpress-2"),
 			Started:            true,
 			CollectMetricsTime: 1234567,
 		},
@@ -226,7 +224,7 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 			Step: operation.Pending,
 		},
 	}, {
-		description: "preserves appropriate fields no hook",
+		description: "preserves only appropriate fields, no hook",
 		before: operation.State{
 			Kind:               operation.Continue,
 			Step:               operation.Pending,
@@ -238,12 +236,11 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 		after: operation.State{
 			Kind:               operation.Continue,
 			Step:               operation.Pending,
-			CharmURL:           curl("cs:quantal/wordpress-2"),
 			Started:            true,
 			CollectMetricsTime: 1234567,
 		},
 	}, {
-		description: "preserves appropriate fields with hook",
+		description: "preserves only appropriate fields, with hook",
 		before: operation.State{
 			Kind:               operation.Continue,
 			Step:               operation.Pending,
@@ -257,7 +254,6 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 			Kind:               operation.RunHook,
 			Step:               operation.Pending,
 			Hook:               &hook.Info{Kind: hooks.Install},
-			CharmURL:           curl("cs:quantal/wordpress-2"),
 			Started:            true,
 			CollectMetricsTime: 1234567,
 		},

--- a/worker/uniter/operation/runaction_test.go
+++ b/worker/uniter/operation/runaction_test.go
@@ -97,8 +97,7 @@ func (s *RunActionSuite) TestPrepareSuccessCleanState(c *gc.C) {
 
 	newState, err := op.Prepare(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newState, gc.NotNil)
-	c.Assert(*newState, jc.DeepEquals, operation.State{
+	c.Assert(newState, jc.DeepEquals, &operation.State{
 		Kind:     operation.RunAction,
 		Step:     operation.Pending,
 		ActionId: &someActionId,
@@ -114,8 +113,7 @@ func (s *RunActionSuite) TestPrepareSuccessDirtyState(c *gc.C) {
 
 	newState, err := op.Prepare(overwriteState)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newState, gc.NotNil)
-	c.Assert(*newState, jc.DeepEquals, operation.State{
+	c.Assert(newState, jc.DeepEquals, &operation.State{
 		Kind:               operation.RunAction,
 		Step:               operation.Pending,
 		ActionId:           &someActionId,
@@ -204,8 +202,7 @@ func (s *RunActionSuite) TestExecuteSuccess(c *gc.C) {
 
 		newState, err := op.Execute(*midState)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(newState, gc.NotNil)
-		c.Assert(*newState, jc.DeepEquals, test.after)
+		c.Assert(newState, jc.DeepEquals, &test.after)
 		c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "running action some-action-name")
 		c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 		c.Assert(*runnerFactory.MockNewActionRunner.runner.MockRunAction.gotName, gc.Equals, "some-action-name")
@@ -266,7 +263,6 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		newState, err := op.Commit(test.before)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(*newState, jc.DeepEquals, test.after)
+		c.Assert(newState, jc.DeepEquals, &test.after)
 	}
 }

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -117,6 +117,8 @@ func (st State) validate() (err error) {
 		switch {
 		case !hasActionId:
 			return errors.New("missing action id")
+		case hasCharm:
+			return errors.New("unexpected charm URL")
 		}
 	case RunHook:
 		switch {

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -115,10 +115,6 @@ func (st State) validate() (err error) {
 		}
 	case RunAction:
 		switch {
-		case hasHook:
-			return errors.New("unexpected hook info with Kind RunAction")
-		case hasCharm:
-			return errors.New("unexpected charm URL")
 		case !hasActionId:
 			return errors.New("missing action id")
 		}

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -81,6 +81,7 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
+			ActionId: &someActionId,
 			CharmURL: stcurl,
 		},
 		err: `unexpected charm URL`,
@@ -218,6 +219,6 @@ func (s *StateFileSuite) TestStates(c *gc.C) {
 		write()
 		st, err := file.Read()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(*st, jc.DeepEquals, t.st)
+		c.Assert(st, jc.DeepEquals, &t.st)
 	}
 }

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -81,14 +81,14 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
-			CharmURL: stcurl,
+			ActionId: &someActionId,
 		},
-		err: `unexpected charm URL`,
 	}, {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
 			ActionId: &someActionId,
+			CharmURL: stcurl,
 		},
 	},
 	// RunHook operation.
@@ -218,6 +218,6 @@ func (s *StateFileSuite) TestStates(c *gc.C) {
 		write()
 		st, err := file.Read()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(*st, gc.DeepEquals, t.st)
+		c.Assert(*st, jc.DeepEquals, t.st)
 	}
 }

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -81,14 +81,14 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
-			ActionId: &someActionId,
+			CharmURL: stcurl,
 		},
+		err: `unexpected charm URL`,
 	}, {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
 			ActionId: &someActionId,
-			CharmURL: stcurl,
 		},
 	},
 	// RunHook operation.

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1454,7 +1454,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			}}},
 			waitUnit{status: params.StatusActive},
 		), ut(
-			"actions are not attempted from ModeHookError and do not clear the error",
+			"actions may run from ModeHookError, but do not clear the error",
 			startupErrorWithCustomCharm{
 				badHook: "start",
 				customize: func(c *gc.C, ctx *context, path string) {
@@ -1466,11 +1466,18 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			waitUnit{
 				status: params.StatusError,
 				info:   `hook failed: "start"`,
-				data: map[string]interface{}{
-					"hook": "start",
-				},
+				data:   map[string]interface{}{"hook": "start"},
 			},
-			verifyNoActionResults{},
+			waitActionResults{[]actionResult{{
+				name:    "action-log",
+				results: map[string]interface{}{},
+				status:  params.ActionCompleted,
+			}}},
+			waitUnit{
+				status: params.StatusError,
+				info:   `hook failed: "start"`,
+				data:   map[string]interface{}{"hook": "start"},
+			},
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
 			waitUnit{status: params.StatusActive},

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1481,12 +1481,6 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
 			waitUnit{status: params.StatusActive},
-			waitActionResults{[]actionResult{{
-				name:    "action-log",
-				results: map[string]interface{}{},
-				status:  params.ActionCompleted,
-			}}},
-			waitUnit{status: params.StatusActive},
 		),
 	})
 }


### PR DESCRIPTION
Use non-nil Hook to signal returning to RunHook instead of Continue

- add/update tests to verify actions can safely run in ModeHookError
- runActionOperation preserves unknown state fields
- CharmURL field should not be dropped by runActionOperation
- non-nil Hook or CharmURL fields should not be a validation error with
  RunAction
- use jc.DeepEquals instead of deprecated gc.DeepEquals


[third time's a "charm" :)]


(Review request: http://reviews.vapour.ws/r/1237/)