### PR TITLE
Fix map-ordering bug in MongoDB cmd execution.

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -187,9 +187,9 @@ func initLogsSession(st *State) (*mgo.Session, *mgo.Collection) {
 // bytes), excluding space used by indexes.
 func getCollectionMB(coll *mgo.Collection) (int, error) {
 	var result bson.M
-	err := coll.Database.Run(bson.M{
-		"collStats": coll.Name,
-		"scale":     humanize.MiByte,
+	err := coll.Database.Run(bson.D{
+		{"collStats", coll.Name},
+		{"scale", humanize.MiByte},
 	}, &result)
 	if err != nil {
 		return 0, errors.Trace(err)


### PR DESCRIPTION
~~Made some drive-by s/bson.M/bson.D/ replacements as well.
In general, bson.D is preferrable as it is more lightweight.
However, in the case of executing a command,~~ using a bson.M
is incorrect because of the random map key ordering.

(Review request: http://reviews.vapour.ws/r/1238/)