### PR TITLE
bson.D bikeshedding

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -187,9 +187,9 @@ func initLogsSession(st *State) (*mgo.Session, *mgo.Collection) {
 // bytes), excluding space used by indexes.
 func getCollectionMB(coll *mgo.Collection) (int, error) {
 	var result bson.M
-	err := coll.Database.Run(bson.M{
-		"collStats": coll.Name,
-		"scale":     humanize.MiByte,
+	err := coll.Database.Run(bson.D{
+		{"collStats", coll.Name},
+		{"scale", humanize.MiByte},
 	}, &result)
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -143,7 +143,7 @@ func (s *LogsSuite) TestPruneLogsBySize(c *gc.C) {
 	// Ensure that the latest log records are still there.
 	assertLatestTs := func(st *state.State) {
 		var doc bson.M
-		err := s.logsColl.Find(bson.M{"e": st.EnvironUUID()}).Sort("-t").One(&doc)
+		err := s.logsColl.Find(bson.D{{"e", st.EnvironUUID()}}).Sort("-t").One(&doc)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(doc["t"].(time.Time), gc.Equals, now)
 	}
@@ -163,7 +163,7 @@ func (s *LogsSuite) generateLogs(c *gc.C, st *state.State, now time.Time, count 
 }
 
 func (s *LogsSuite) countLogs(c *gc.C, st *state.State) int {
-	count, err := s.logsColl.Find(bson.M{"e": st.EnvironUUID()}).Count()
+	count, err := s.logsColl.Find(bson.D{{"e", st.EnvironUUID()}}).Count()
 	c.Assert(err, jc.ErrorIsNil)
 	return count
 }


### PR DESCRIPTION
Use bson.D instead of bson.M for various bson structure constants. Followup to #1915.

(Review request: http://reviews.vapour.ws/r/1240/)