### PR TITLE
Fixes LP bug #1423936

### DIFF
--- a/cmd/plugins/juju-backup/juju-backup
+++ b/cmd/plugins/juju-backup/juju-backup
@@ -16,7 +16,7 @@ fi
 ##############################
 # Fall back to the old plugin.
 
-remote_cmd() {	
+remote_cmd() {
 	LIBJUJU=/var/lib/juju
 
 	# usage: execute message cmd [arg...]
@@ -36,7 +36,7 @@ remote_cmd() {
 		}
 		echo SUCCESS
 	}
-	
+
 	next_step() {
 		echo
 		echo '**************************************************************'
@@ -57,7 +57,7 @@ remote_cmd() {
 	# Mongo requires that a locale is set
 	export LC_ALL=C
 
-	# Prefer jujud-mongodb binaries if available 
+	# Prefer jujud-mongodb binaries if available
 	export MONGODUMP=mongodump
 	if [ -f /usr/lib/juju/bin/mongodump ]; then
 		export MONGODUMP=/usr/lib/juju/bin/mongodump;
@@ -73,7 +73,7 @@ remote_cmd() {
 	next_step 'Backing up mongo database'
 	execute 'Stopping mongo' stop juju-db
 	trap "start juju-db" 0		# ensure it starts again on failure
-	execute 'Backing up mongo' $MONGODUMP --dbpath $LIBJUJU/db
+	execute 'Backing up mongo' $MONGODUMP --journal --dbpath $LIBJUJU/db
 	execute 'Backing up environ config' $MONGOEXPORT \
 		--dbpath $LIBJUJU/db \
 		--db juju \
@@ -115,7 +115,7 @@ remote_cmd() {
 	execute 'Performing tar' tar -czf juju-backup.tgz juju-backup
 	rm -r juju-backup
 	execute 'Changing ownership of backup archive to ubuntu' chown -R ubuntu.ubuntu juju-backup*
-	
+
 	echo
 	echo Juju backup finished.
 	echo

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -136,6 +136,7 @@ func NewDBDumper(info *DBInfo) (DBDumper, error) {
 func (md *mongoDumper) options(dumpDir string) []string {
 	options := []string{
 		"--ssl",
+		"--journal",
 		"--authenticationDatabase", "admin",
 		"--host", md.Address,
 		"--username", md.Username,


### PR DESCRIPTION
This is a 1.22 backport for fixing LP: #1423936 

juju-db daemon uses explicit journal, so is required to pass --journal to restore/dump utilities.


(Review request: http://reviews.vapour.ws/r/1242/)