### PR TITLE
Actions in modehookerror :: Merge pull request #1914 from johnweldon/actions-in-modehookerror-1.23

### DIFF
--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -318,6 +318,10 @@ func ModeHookError(u *Uniter) (next Mode, err error) {
 				return nil, errors.Trace(err)
 			}
 			return ModeContinue, nil
+		case actionId := <-u.f.ActionEvents():
+			if err := u.runOperation(newActionOp(actionId)); err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 	}
 }

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -85,8 +85,19 @@ func (ra *runAction) Execute(state State) (*State, error) {
 // Commit is part of the Operation interface.
 func (ra *runAction) Commit(state State) (*State, error) {
 	return stateChange{
-		Kind: Continue,
+		Kind: continuationKind(state),
 		Step: Pending,
 		Hook: state.Hook,
 	}.apply(state), nil
+}
+
+// continuationKind determines what State Kind the operation
+// should return after Commit.
+func continuationKind(state State) Kind {
+	switch {
+	case state.Hook != nil:
+		return RunHook
+	default:
+		return Continue
+	}
 }

--- a/worker/uniter/operation/runaction_test.go
+++ b/worker/uniter/operation/runaction_test.go
@@ -97,8 +97,7 @@ func (s *RunActionSuite) TestPrepareSuccessCleanState(c *gc.C) {
 
 	newState, err := op.Prepare(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newState, gc.NotNil)
-	c.Assert(*newState, gc.DeepEquals, operation.State{
+	c.Assert(newState, jc.DeepEquals, &operation.State{
 		Kind:     operation.RunAction,
 		Step:     operation.Pending,
 		ActionId: &someActionId,
@@ -114,8 +113,7 @@ func (s *RunActionSuite) TestPrepareSuccessDirtyState(c *gc.C) {
 
 	newState, err := op.Prepare(overwriteState)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newState, gc.NotNil)
-	c.Assert(*newState, gc.DeepEquals, operation.State{
+	c.Assert(newState, jc.DeepEquals, &operation.State{
 		Kind:               operation.RunAction,
 		Step:               operation.Pending,
 		ActionId:           &someActionId,
@@ -204,8 +202,7 @@ func (s *RunActionSuite) TestExecuteSuccess(c *gc.C) {
 
 		newState, err := op.Execute(*midState)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(newState, gc.NotNil)
-		c.Assert(*newState, gc.DeepEquals, test.after)
+		c.Assert(newState, jc.DeepEquals, &test.after)
 		c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "running action some-action-name")
 		c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 		c.Assert(*runnerFactory.MockNewActionRunner.runner.MockRunAction.gotName, gc.Equals, "some-action-name")
@@ -224,10 +221,34 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 			Step: operation.Pending,
 		},
 	}, {
-		description: "preserves appropriate fields",
-		before:      overwriteState,
+		description: "preserves only appropriate fields, no hook",
+		before: operation.State{
+			Kind:               operation.Continue,
+			Step:               operation.Pending,
+			Started:            true,
+			CollectMetricsTime: 1234567,
+			CharmURL:           curl("cs:quantal/wordpress-2"),
+			ActionId:           &randomActionId,
+		},
 		after: operation.State{
 			Kind:               operation.Continue,
+			Step:               operation.Pending,
+			Started:            true,
+			CollectMetricsTime: 1234567,
+		},
+	}, {
+		description: "preserves only appropriate fields, with hook",
+		before: operation.State{
+			Kind:               operation.Continue,
+			Step:               operation.Pending,
+			Started:            true,
+			CollectMetricsTime: 1234567,
+			CharmURL:           curl("cs:quantal/wordpress-2"),
+			ActionId:           &randomActionId,
+			Hook:               &hook.Info{Kind: hooks.Install},
+		},
+		after: operation.State{
+			Kind:               operation.RunHook,
 			Step:               operation.Pending,
 			Hook:               &hook.Info{Kind: hooks.Install},
 			Started:            true,
@@ -242,7 +263,6 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		newState, err := op.Commit(test.before)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(*newState, gc.DeepEquals, test.after)
+		c.Assert(newState, jc.DeepEquals, &test.after)
 	}
 }

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -115,12 +115,10 @@ func (st State) validate() (err error) {
 		}
 	case RunAction:
 		switch {
-		case hasHook:
-			return errors.New("unexpected hook info with Kind RunAction")
-		case hasCharm:
-			return errors.New("unexpected charm URL")
 		case !hasActionId:
 			return errors.New("missing action id")
+		case hasCharm:
+			return errors.New("unexpected charm URL")
 		}
 	case RunHook:
 		switch {

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -81,6 +81,7 @@ var stateTests = []struct {
 		st: operation.State{
 			Kind:     operation.RunAction,
 			Step:     operation.Pending,
+			ActionId: &someActionId,
 			CharmURL: stcurl,
 		},
 		err: `unexpected charm URL`,
@@ -218,6 +219,6 @@ func (s *StateFileSuite) TestStates(c *gc.C) {
 		write()
 		st, err := file.Read()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(*st, gc.DeepEquals, t.st)
+		c.Assert(st, jc.DeepEquals, &t.st)
 	}
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1453,7 +1453,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			}}},
 			waitUnit{status: params.StatusActive},
 		), ut(
-			"actions are not attempted from ModeHookError and do not clear the error",
+			"actions may run from ModeHookError, but do not clear the error",
 			startupErrorWithCustomCharm{
 				badHook: "start",
 				customize: func(c *gc.C, ctx *context, path string) {
@@ -1465,19 +1465,20 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			waitUnit{
 				status: params.StatusError,
 				info:   `hook failed: "start"`,
-				data: map[string]interface{}{
-					"hook": "start",
-				},
+				data:   map[string]interface{}{"hook": "start"},
 			},
-			verifyNoActionResults{},
-			verifyWaiting{},
-			resolveError{state.ResolvedNoHooks},
-			waitUnit{status: params.StatusActive},
 			waitActionResults{[]actionResult{{
 				name:    "action-log",
 				results: map[string]interface{}{},
 				status:  params.ActionCompleted,
 			}}},
+			waitUnit{
+				status: params.StatusError,
+				info:   `hook failed: "start"`,
+				data:   map[string]interface{}{"hook": "start"},
+			},
+			verifyWaiting{},
+			resolveError{state.ResolvedNoHooks},
 			waitUnit{status: params.StatusActive},
 		),
 	})


### PR DESCRIPTION
[ Forward port from 1.23 to master ]

Run Actions in ModeHookError

Use non-nil Hook to signal returning to RunHook instead of Continue

- add/update tests to verify actions can safely run in ModeHookError
- runActionOperation preserves unknown state fields
- CharmURL field should not be dropped by runActionOperation
- non-nil Hook or CharmURL fields should not be a validation error with
  RunAction
- use jc.DeepEquals instead of deprecated gc.DeepEquals


(Review request: http://reviews.vapour.ws/r/1243/)