### PR TITLE
Use the --journal option for mongodump and mongorestore.

### DIFF
--- a/cmd/plugins/juju-backup/juju-backup
+++ b/cmd/plugins/juju-backup/juju-backup
@@ -89,7 +89,7 @@ remote_cmd() {
 	next_step 'Backing up mongo database'
 	execute 'Stopping mongo' stop juju-db
 	trap "start juju-db" 0		# ensure it starts again on failure
-	execute 'Backing up mongo' $MONGODUMP --dbpath $LIBJUJU/db
+	execute 'Backing up mongo' $MONGODUMP --journal --dbpath $LIBJUJU/db
 	execute 'Backing up environ config' $MONGOEXPORT \
 		--dbpath $LIBJUJU/db \
 		--db juju \

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -141,6 +141,7 @@ func NewDBDumper(info *DBInfo) (DBDumper, error) {
 func (md *mongoDumper) options(dumpDir string) []string {
 	options := []string{
 		"--ssl",
+		"--journal",
 		"--authenticationDatabase", "admin",
 		"--host", md.Address,
 		"--username", md.Username,
@@ -227,9 +228,9 @@ func mongoRestoreArgsForVersion(ver version.Number, dumpPath string) ([]string, 
 	dbDir := filepath.Join(agent.DefaultDataDir, "db")
 	switch {
 	case ver.Major == 1 && ver.Minor < 22:
-		return []string{"--drop", "--dbpath", dbDir, dumpPath}, nil
+		return []string{"--drop", "--journal", "--dbpath", dbDir, dumpPath}, nil
 	case ver.Major == 1 && ver.Minor >= 22:
-		return []string{"--drop", "--oplogReplay", "--dbpath", dbDir, dumpPath}, nil
+		return []string{"--drop", "--journal", "--oplogReplay", "--dbpath", dbDir, dumpPath}, nil
 	default:
 		return nil, errors.Errorf("this backup file is incompatible with the current version of juju")
 	}

--- a/state/backups/db_restore_test.go
+++ b/state/backups/db_restore_test.go
@@ -29,22 +29,28 @@ func (s *mongoRestoreSuite) TestMongoRestoreArgsForVersion(c *gc.C) {
 	versionNumber.Minor = 21
 	args, err := backups.MongoRestoreArgsForVersion(versionNumber, "/some/fake/path")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(args, gc.HasLen, 4)
-	c.Assert(args[0], gc.Equals, "--drop")
-	c.Assert(args[1], gc.Equals, "--dbpath")
-	c.Assert(args[2], jc.SamePath, dir)
-	c.Assert(args[3], gc.Equals, "/some/fake/path")
+	c.Assert(args, gc.HasLen, 5)
+	c.Assert(args[0:5], jc.DeepEquals, []string{
+		"--drop",
+		"--journal",
+		"--dbpath",
+		dir,
+		"/some/fake/path",
+	})
 
 	versionNumber.Major = 1
 	versionNumber.Minor = 22
 	args, err = backups.MongoRestoreArgsForVersion(versionNumber, "/some/fake/path")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(args, gc.HasLen, 5)
-	c.Assert(args[0], gc.Equals, "--drop")
-	c.Assert(args[1], gc.Equals, "--oplogReplay")
-	c.Assert(args[2], gc.Equals, "--dbpath")
-	c.Assert(args[3], jc.SamePath, dir)
-	c.Assert(args[4], gc.Equals, "/some/fake/path")
+	c.Assert(args, gc.HasLen, 6)
+	c.Assert(args[0:6], jc.DeepEquals, []string{
+		"--drop",
+		"--journal",
+		"--oplogReplay",
+		"--dbpath",
+		dir,
+		"/some/fake/path",
+	})
 
 	versionNumber.Major = 0
 	versionNumber.Minor = 0


### PR DESCRIPTION
This is a backport from master.

Fixes LP bug #1423936

(https://bugs.launchpad.net/juju-core/+bug/1423936)

juju-db daemon uses explicit journal, so is required
to pass --journal to restore/dump utilities.

(Review request: http://reviews.vapour.ws/r/1088/)