### PR TITLE
Implement status-get hook tool

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -70,6 +70,31 @@ func (u *Unit) SetUnitStatus(status params.Status, info string, data map[string]
 	return result.OneError()
 }
 
+// UnitStatus gets the status details of the unit.
+func (u *Unit) UnitStatus() (params.StatusResult, error) {
+	var results params.StatusResults
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: u.tag.String()},
+		},
+	}
+	err := u.st.facade.FacadeCall("UnitStatus", args, &results)
+	if err != nil {
+		if params.IsCodeNotImplemented(err) {
+			return params.StatusResult{}, errors.NotImplementedf("UnitStatus")
+		}
+		return params.StatusResult{}, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		panic(errors.Errorf("expected 1 result, got %d", len(results.Results)))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return params.StatusResult{}, result.Error
+	}
+	return result, nil
+}
+
 // SetAgentStatus sets the status of the unit agent.
 func (u *Unit) SetAgentStatus(status params.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -154,14 +154,6 @@ func (s *unitSuite) TestUnitStatus(c *gc.C) {
 	})
 }
 
-func (s *unitSuite) TestUnitStatusNotImplemented(c *gc.C) {
-	s.patchNewState(c, uniter.NewStateV1)
-
-	_, err := s.apiUnit.UnitStatus()
-	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
-	c.Assert(err.Error(), gc.Equals, "UnitStatus not implemented")
-}
-
 func (s *unitSuite) TestEnsureDead(c *gc.C) {
 	c.Assert(s.wordpressUnit.Life(), gc.Equals, state.Alive)
 

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -141,6 +141,27 @@ func (s *unitSuite) TestSetAgentStatusOldServer(c *gc.C) {
 	c.Assert(data, gc.HasLen, 0)
 }
 
+func (s *unitSuite) TestUnitStatus(c *gc.C) {
+	err := s.wordpressUnit.SetStatus(state.StatusError, "blah", map[string]interface{}{"foo": "bar"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := s.apiUnit.UnitStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StatusResult{
+		Status: params.StatusError,
+		Info:   "blah",
+		Data:   map[string]interface{}{"foo": "bar"},
+	})
+}
+
+func (s *unitSuite) TestUnitStatusNotImplemented(c *gc.C) {
+	s.patchNewState(c, uniter.NewStateV1)
+
+	_, err := s.apiUnit.UnitStatus()
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+	c.Assert(err.Error(), gc.Equals, "UnitStatus not implemented")
+}
+
 func (s *unitSuite) TestEnsureDead(c *gc.C) {
 	c.Assert(s.wordpressUnit.Life(), gc.Equals, state.Alive)
 

--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -1,0 +1,73 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+// StatusGetter implements a common Status method for use by
+// various facades.
+type StatusGetter struct {
+	st           state.EntityFinder
+	getcanAccess GetAuthFunc
+}
+
+// NewStatusGetter returns a new StatusGetter. The GetAuthFunc will be
+// used on each invocation of Status to determine current
+// permissions.
+func NewStatusGetter(st state.EntityFinder, getcanAccess GetAuthFunc) *StatusGetter {
+	return &StatusGetter{
+		st:           st,
+		getcanAccess: getcanAccess,
+	}
+}
+
+func (s *StatusGetter) getEntityStatus(tag names.Tag) params.StatusResult {
+	var result params.StatusResult
+	entity, err := s.st.FindEntity(tag)
+	if err != nil {
+		result.Error = ServerError(err)
+		return result
+	}
+	switch getter := entity.(type) {
+	case state.StatusGetter:
+		var st state.Status
+		st, result.Info, result.Data, err = getter.Status()
+		result.Status = params.Status(st)
+		result.Error = ServerError(err)
+	default:
+		result.Error = ServerError(NotSupportedError(tag, fmt.Sprintf("getting status, %T", getter)))
+	}
+	return result
+}
+
+// Status returns the status of each given entity.
+func (s *StatusGetter) Status(args params.Entities) (params.StatusResults, error) {
+	result := params.StatusResults{
+		Results: make([]params.StatusResult, len(args.Entities)),
+	}
+	canAccess, err := s.getcanAccess()
+	if err != nil {
+		return result, err
+	}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = ServerError(err)
+			continue
+		}
+		if !canAccess(tag) {
+			result.Results[i].Error = ServerError(ErrPerm)
+			continue
+		}
+		result.Results[i] = s.getEntityStatus(tag)
+	}
+	return result, nil
+}

--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -55,7 +55,7 @@ func (s *StatusGetter) Status(args params.Entities) (params.StatusResults, error
 	}
 	canAccess, err := s.getcanAccess()
 	if err != nil {
-		return result, err
+		return params.StatusResults{}, err
 	}
 	for i, entity := range args.Entities {
 		tag, err := names.ParseTag(entity.Tag)

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -55,6 +55,8 @@ func (*statusGetterSuite) TestStatus(c *gc.C) {
 			{"unit-x-5"},
 			{"unit-x-6"},
 			{"unit-x-7"},
+			{"machine-1"},
+			{"invalid"},
 		},
 	}
 	result, err := s.Status(args)
@@ -69,6 +71,8 @@ func (*statusGetterSuite) TestStatus(c *gc.C) {
 			{Status: "stopping", Info: "blah"},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ServerError(`"invalid" is not a valid tag`)},
 		},
 	})
 }

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -1,0 +1,86 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"fmt"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+)
+
+type statusGetterSuite struct{}
+
+var _ = gc.Suite(&statusGetterSuite{})
+
+var _ state.StatusGetter = new(fakeStatus)
+
+func (*statusGetterSuite) TestStatus(c *gc.C) {
+	st := &fakeState{
+		entities: map[names.Tag]entityWithError{
+			u("x/0"): &fakeStatus{status: state.StatusAllocating, info: "blah", err: fmt.Errorf("x0 fails")},
+			u("x/1"): &fakeStatus{status: state.StatusInstalling, info: "blah"},
+			u("x/2"): &fakeStatus{status: state.StatusActive, info: "foo"},
+			u("x/3"): &fakeStatus{status: state.StatusError, info: "some info", data: map[string]interface{}{"foo": "bar"}},
+			u("x/4"): &fakeStatus{fetchError: "x3 error"},
+			u("x/5"): &fakeStatus{status: state.StatusStopping, info: "blah"},
+		},
+	}
+	getCanModify := func() (common.AuthFunc, error) {
+		x0 := u("x/0")
+		x1 := u("x/1")
+		x2 := u("x/2")
+		x3 := u("x/3")
+		x4 := u("x/4")
+		x5 := u("x/5")
+		return func(tag names.Tag) bool {
+			return tag == x0 || tag == x1 || tag == x2 || tag == x3 || tag == x4 || tag == x5
+		}, nil
+	}
+	s := common.NewStatusGetter(st, getCanModify)
+	args := params.Entities{
+		Entities: []params.Entity{
+			{"unit-x-0"},
+			{"unit-x-1"},
+			{"unit-x-2"},
+			{"unit-x-3"},
+			{"unit-x-4"},
+			{"unit-x-5"},
+			{"unit-x-6"},
+			{"unit-x-7"},
+		},
+	}
+	result, err := s.Status(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StatusResults{
+		Results: []params.StatusResult{
+			{Status: "allocating", Info: "blah", Error: &params.Error{Message: "x0 fails"}},
+			{Status: "installing", Info: "blah"},
+			{Status: "active", Info: "foo"},
+			{Status: "error", Info: "some info", Data: map[string]interface{}{"foo": "bar"}},
+			{Error: &params.Error{Message: "x3 error"}},
+			{Status: "stopping", Info: "blah"},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}
+
+func (*statusGetterSuite) TestStatusError(c *gc.C) {
+	getCanModify := func() (common.AuthFunc, error) {
+		return nil, fmt.Errorf("pow")
+	}
+	s := common.NewStatusGetter(&fakeState{}, getCanModify)
+	args := params.Entities{
+		Entities: []params.Entity{{"x0"}},
+	}
+	_, err := s.Status(args)
+	c.Assert(err, gc.ErrorMatches, "pow")
+}

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -33,7 +33,7 @@ func (*statusGetterSuite) TestStatus(c *gc.C) {
 			u("x/5"): &fakeStatus{status: state.StatusStopping, info: "blah"},
 		},
 	}
-	getCanModify := func() (common.AuthFunc, error) {
+	getCanAccess := func() (common.AuthFunc, error) {
 		x0 := u("x/0")
 		x1 := u("x/1")
 		x2 := u("x/2")
@@ -44,7 +44,7 @@ func (*statusGetterSuite) TestStatus(c *gc.C) {
 			return tag == x0 || tag == x1 || tag == x2 || tag == x3 || tag == x4 || tag == x5
 		}, nil
 	}
-	s := common.NewStatusGetter(st, getCanModify)
+	s := common.NewStatusGetter(st, getCanAccess)
 	args := params.Entities{
 		Entities: []params.Entity{
 			{"unit-x-0"},
@@ -74,10 +74,10 @@ func (*statusGetterSuite) TestStatus(c *gc.C) {
 }
 
 func (*statusGetterSuite) TestStatusError(c *gc.C) {
-	getCanModify := func() (common.AuthFunc, error) {
+	getCanAccess := func() (common.AuthFunc, error) {
 		return nil, fmt.Errorf("pow")
 	}
-	s := common.NewStatusGetter(&fakeState{}, getCanModify)
+	s := common.NewStatusGetter(&fakeState{}, getCanAccess)
 	args := params.Entities{
 		Entities: []params.Entity{{"x0"}},
 	}

--- a/apiserver/common/setstatus_test.go
+++ b/apiserver/common/setstatus_test.go
@@ -20,9 +20,9 @@ type statusSetterSuite struct{}
 
 var _ = gc.Suite(&statusSetterSuite{})
 
-var _ state.StatusSetter = new(fakeStatusSetter)
+var _ state.StatusSetter = new(fakeStatus)
 
-type fakeStatusSetter struct {
+type fakeStatus struct {
 	state.Entity
 	status state.Status
 	info   string
@@ -31,18 +31,18 @@ type fakeStatusSetter struct {
 	fetchError
 }
 
-func (s *fakeStatusSetter) SetStatus(status state.Status, info string, data map[string]interface{}) error {
+func (s *fakeStatus) SetStatus(status state.Status, info string, data map[string]interface{}) error {
 	s.status = status
 	s.info = info
 	s.data = data
 	return s.err
 }
 
-func (s *fakeStatusSetter) Status() (status state.Status, info string, data map[string]interface{}, err error) {
-	return s.status, s.info, s.data, nil
+func (s *fakeStatus) Status() (status state.Status, info string, data map[string]interface{}, err error) {
+	return s.status, s.info, s.data, s.err
 }
 
-func (s *fakeStatusSetter) UpdateStatus(data map[string]interface{}) error {
+func (s *fakeStatus) UpdateStatus(data map[string]interface{}) error {
 	for k, v := range data {
 		s.data[k] = v
 	}
@@ -52,12 +52,12 @@ func (s *fakeStatusSetter) UpdateStatus(data map[string]interface{}) error {
 func (*statusSetterSuite) TestSetStatus(c *gc.C) {
 	st := &fakeState{
 		entities: map[names.Tag]entityWithError{
-			u("x/0"): &fakeStatusSetter{status: state.StatusAllocating, info: "blah", err: fmt.Errorf("x0 fails")},
-			u("x/1"): &fakeStatusSetter{status: state.StatusInstalling, info: "blah"},
-			u("x/2"): &fakeStatusSetter{status: state.StatusActive, info: "foo"},
-			u("x/3"): &fakeStatusSetter{status: state.StatusError, info: "some info"},
-			u("x/4"): &fakeStatusSetter{fetchError: "x3 error"},
-			u("x/5"): &fakeStatusSetter{status: state.StatusStopping, info: "blah"},
+			u("x/0"): &fakeStatus{status: state.StatusAllocating, info: "blah", err: fmt.Errorf("x0 fails")},
+			u("x/1"): &fakeStatus{status: state.StatusInstalling, info: "blah"},
+			u("x/2"): &fakeStatus{status: state.StatusActive, info: "foo"},
+			u("x/3"): &fakeStatus{status: state.StatusError, info: "some info"},
+			u("x/4"): &fakeStatus{fetchError: "x3 error"},
+			u("x/5"): &fakeStatus{status: state.StatusStopping, info: "blah"},
 		},
 	}
 	getCanModify := func() (common.AuthFunc, error) {
@@ -98,8 +98,8 @@ func (*statusSetterSuite) TestSetStatus(c *gc.C) {
 			{apiservertesting.ErrUnauthorized},
 		},
 	})
-	get := func(tag names.Tag) *fakeStatusSetter {
-		return st.entities[tag].(*fakeStatusSetter)
+	get := func(tag names.Tag) *fakeStatus {
+		return st.entities[tag].(*fakeStatus)
 	}
 	c.Assert(get(u("x/1")).status, gc.Equals, state.StatusActive)
 	c.Assert(get(u("x/1")).info, gc.Equals, "bar")
@@ -136,12 +136,12 @@ func (*statusSetterSuite) TestSetStatusNoArgsNoError(c *gc.C) {
 func (*statusSetterSuite) TestUpdateStatus(c *gc.C) {
 	st := &fakeState{
 		entities: map[names.Tag]entityWithError{
-			m("0"): &fakeStatusSetter{status: state.StatusAllocating, info: "blah", err: fmt.Errorf("x0 fails")},
-			m("1"): &fakeStatusSetter{status: state.StatusError, info: "foo", data: map[string]interface{}{"foo": "blah"}},
-			m("2"): &fakeStatusSetter{status: state.StatusError, info: "some info"},
-			m("3"): &fakeStatusSetter{fetchError: "x3 error"},
-			m("4"): &fakeStatusSetter{status: state.StatusActive},
-			m("5"): &fakeStatusSetter{status: state.StatusStopping, info: ""},
+			m("0"): &fakeStatus{status: state.StatusAllocating, info: "blah", err: fmt.Errorf("x0 fails")},
+			m("1"): &fakeStatus{status: state.StatusError, info: "foo", data: map[string]interface{}{"foo": "blah"}},
+			m("2"): &fakeStatus{status: state.StatusError, info: "some info"},
+			m("3"): &fakeStatus{fetchError: "x3 error"},
+			m("4"): &fakeStatus{status: state.StatusActive},
+			m("5"): &fakeStatus{status: state.StatusStopping, info: ""},
 		},
 	}
 	getCanModify := func() (common.AuthFunc, error) {
@@ -179,8 +179,8 @@ func (*statusSetterSuite) TestUpdateStatus(c *gc.C) {
 			{apiservertesting.ErrUnauthorized},
 		},
 	})
-	get := func(tag names.Tag) *fakeStatusSetter {
-		return st.entities[tag].(*fakeStatusSetter)
+	get := func(tag names.Tag) *fakeStatus {
+		return st.entities[tag].(*fakeStatus)
 	}
 	c.Assert(get(m("1")).status, gc.Equals, state.StatusError)
 	c.Assert(get(m("1")).info, gc.Equals, "foo")

--- a/apiserver/uniter/status.go
+++ b/apiserver/uniter/status.go
@@ -18,6 +18,7 @@ import (
 type StatusAPI struct {
 	agentSetter  *common.StatusSetter
 	unitSetter   *common.StatusSetter
+	unitGetter   *common.StatusGetter
 	getCanModify common.GetAuthFunc
 }
 
@@ -40,10 +41,12 @@ func (ua *unitAgentFinder) FindEntity(tag names.Tag) (state.Entity, error) {
 // NewStatusAPI creates a new server-side Status setter API facade.
 func NewStatusAPI(st *state.State, getCanModify common.GetAuthFunc) *StatusAPI {
 	unitSetter := common.NewStatusSetter(st, getCanModify)
+	unitGetter := common.NewStatusGetter(st, getCanModify)
 	agentSetter := common.NewStatusSetter(&unitAgentFinder{st}, getCanModify)
 	return &StatusAPI{
 		agentSetter:  agentSetter,
 		unitSetter:   unitSetter,
+		unitGetter:   unitGetter,
 		getCanModify: getCanModify,
 	}
 }
@@ -66,4 +69,9 @@ func (s *StatusAPI) SetAgentStatus(args params.SetStatus) (params.ErrorResults, 
 // of its agent.
 func (s *StatusAPI) SetUnitStatus(args params.SetStatus) (params.ErrorResults, error) {
 	return s.unitSetter.SetStatus(args)
+}
+
+// UnitStatus returns the workload status information for the unit.
+func (s *StatusAPI) xUnitStatus(args params.Entities) (params.StatusResults, error) {
+	return s.unitGetter.Status(args)
 }

--- a/apiserver/uniter/status.go
+++ b/apiserver/uniter/status.go
@@ -72,6 +72,6 @@ func (s *StatusAPI) SetUnitStatus(args params.SetStatus) (params.ErrorResults, e
 }
 
 // UnitStatus returns the workload status information for the unit.
-func (s *StatusAPI) xUnitStatus(args params.Entities) (params.StatusResults, error) {
+func (s *StatusAPI) UnitStatus(args params.Entities) (params.StatusResults, error) {
 	return s.unitGetter.Status(args)
 }

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -115,6 +115,8 @@ func (s *uniterV2Suite) TestUnitStatus(c *gc.C) {
 			{Tag: "unit-mysql-0"},
 			{Tag: "unit-wordpress-0"},
 			{Tag: "unit-foo-42"},
+			{Tag: "machine-1"},
+			{Tag: "invalid"},
 		}}
 	result, err := s.uniter.UnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -123,6 +125,8 @@ func (s *uniterV2Suite) TestUnitStatus(c *gc.C) {
 			{Error: apiservertesting.ErrUnauthorized},
 			{Status: params.StatusError, Info: "blah", Data: map[string]interface{}{"foo": "bar"}},
 			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ServerError(`"invalid" is not a valid tag`)},
 		},
 	})
 }

--- a/cmd/juju/helptool.go
+++ b/cmd/juju/helptool.go
@@ -76,6 +76,10 @@ func (dummyHookContext) OwnerTag() string {
 	return ""
 }
 
+func (dummyHookContext) UnitStatus() (*jujuc.StatusInfo, error) {
+	return &jujuc.StatusInfo{}, nil
+}
+
 type HelpToolCommand struct {
 	cmd.CommandBase
 	tool string

--- a/doc/charms-in-action.txt
+++ b/doc/charms-in-action.txt
@@ -123,6 +123,7 @@ All hooks can directly use the following tools:
   * relation-ids (list all relations using a given charm relation)
   * relation-list (list all units of a related service)
   * storage-get (get storage instance values)
+  * status-get (get unit workload status information)
 
 Within the context of a single hook execution, the above tools present a
 sandboxed view of the system with the following properties:

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -75,6 +75,9 @@ type HookContext struct {
 	// unitName is the human friendly name of the local unit.
 	unitName string
 
+	// status is the status of the local unit.
+	status *jujuc.StatusInfo
+
 	// relationId identifies the relation for which a relation hook is
 	// executing. If it is -1, the context is not running a relation hook;
 	// otherwise, its value must be a valid key into the relations map.
@@ -183,6 +186,22 @@ func (ctx *HookContext) Id() string {
 
 func (ctx *HookContext) UnitName() string {
 	return ctx.unitName
+}
+
+func (ctx *HookContext) UnitStatus() (*jujuc.StatusInfo, error) {
+	if ctx.status == nil {
+		var err error
+		status, err := ctx.unit.UnitStatus()
+		if err != nil {
+			return nil, err
+		}
+		ctx.status = &jujuc.StatusInfo{
+			Status: string(status.Status),
+			Info:   status.Info,
+			Data:   status.Data,
+		}
+	}
+	return ctx.status, nil
 }
 
 func (ctx *HookContext) PublicAddress() (string, bool) {

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -72,6 +72,14 @@ func (s *InterfaceSuite) TestAvailabilityZone(c *gc.C) {
 	c.Check(zone, gc.Equals, "a-zone")
 }
 
+func (s *InterfaceSuite) TestUnitStatus(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	status, err := ctx.UnitStatus()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(status.Status, gc.Equals, "maintenance")
+	c.Check(status.Data, gc.DeepEquals, map[string]interface{}{})
+}
+
 func (s *InterfaceSuite) TestUnitCaching(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
 	pr, ok := ctx.PrivateAddress()

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -75,6 +76,24 @@ func (s *InterfaceSuite) TestAvailabilityZone(c *gc.C) {
 func (s *InterfaceSuite) TestUnitStatus(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
 	status, err := ctx.UnitStatus()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(status.Status, gc.Equals, "maintenance")
+	c.Check(status.Data, gc.DeepEquals, map[string]interface{}{})
+}
+
+func (s *InterfaceSuite) TestUnitStatusCaching(c *gc.C) {
+	ctx := s.GetContext(c, -1, "")
+	status, err := ctx.UnitStatus()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(status.Status, gc.Equals, "maintenance")
+	c.Check(status.Data, gc.DeepEquals, map[string]interface{}{})
+
+	// Change remote state.
+	err = s.unit.SetStatus(state.StatusActive, "it works", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Local view is unchanged.
+	status, err = ctx.UnitStatus()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(status.Status, gc.Equals, "maintenance")
 	c.Check(status.Data, gc.DeepEquals, map[string]interface{}{})

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -33,8 +33,11 @@ const (
 // depend on to interact with the rest of the system.
 type Context interface {
 
-	// Unit returns the executing unit's name.
+	// UnitName returns the executing unit's name.
 	UnitName() string
+
+	// UnitStatus returns the executing unit's current status.
+	UnitStatus() (*StatusInfo, error)
 
 	// PublicAddress returns the executing unit's public address.
 	PublicAddress() (string, bool)

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -46,6 +46,7 @@ var baseCommands = map[string]creator{
 	"owner-get" + cmdSuffix:     NewOwnerGetCommand,
 	"add-metric" + cmdSuffix:    NewAddMetricCommand,
 	"juju-reboot" + cmdSuffix:   NewJujuRebootCommand,
+	"status-get" + cmdSuffix:    NewStatusGetCommand,
 }
 
 var storageCommands = map[string]creator{

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -218,6 +218,7 @@ var newCommandTests = []struct {
 	{"relation-set", ""},
 	{"unit-get", ""},
 	{"storage-get", ""},
+	{"status-get", ""},
 	// The error message contains .exe on Windows
 	{"random", "unknown command: random(.exe)?"},
 }

--- a/worker/uniter/runner/jujuc/status-get.go
+++ b/worker/uniter/runner/jujuc/status-get.go
@@ -25,8 +25,8 @@ func NewStatusGetCommand(ctx Context) cmd.Command {
 
 func (c *StatusGetCommand) Info() *cmd.Info {
 	doc := `
-If include-data is false (the default), then just the status value is printed.
-Otherwise, the status value and any associated data is printed.
+By default, only the status value is printed.
+If the --include-data flag is passed, the associated data are printed also.
 `
 	return &cmd.Info{
 		Name:    "status-get",
@@ -70,8 +70,8 @@ func (c *StatusGetCommand) Run(ctx *cmd.Context) error {
 		for k, v := range unitStatus.Data {
 			data[k] = v
 		}
-		statusDetails["data"] = data
-		statusDetails["info"] = unitStatus.Info
+		statusDetails["status-data"] = data
+		statusDetails["message"] = unitStatus.Info
 	}
 	c.out.Write(ctx, statusDetails)
 	return nil

--- a/worker/uniter/runner/jujuc/status-get.go
+++ b/worker/uniter/runner/jujuc/status-get.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+// StatusGetCommand implements the status-get command.
+type StatusGetCommand struct {
+	cmd.CommandBase
+	ctx         Context
+	includeData bool
+	out         cmd.Output
+}
+
+func NewStatusGetCommand(ctx Context) cmd.Command {
+	return &StatusGetCommand{ctx: ctx}
+}
+
+func (c *StatusGetCommand) Info() *cmd.Info {
+	doc := `
+If include-data is false (the default), then just the status value is printed.
+Otherwise, the status value and any associated data is printed.
+`
+	return &cmd.Info{
+		Name:    "status-get",
+		Args:    "[--include-data]",
+		Purpose: "print status information",
+		Doc:     doc,
+	}
+}
+
+func (c *StatusGetCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	f.BoolVar(&c.includeData, "include-data", false, "print all status data")
+}
+
+func (c *StatusGetCommand) Init(args []string) error {
+	return cmd.CheckEmpty(args)
+}
+
+// StatusInfo is a record of the status information for a unit's workload.
+type StatusInfo struct {
+	Status string
+	Info   string
+	Data   map[string]interface{}
+}
+
+func (c *StatusGetCommand) Run(ctx *cmd.Context) error {
+	unitStatus, err := c.ctx.UnitStatus()
+	if err != nil {
+		if errors.IsNotImplemented(err) {
+			return c.out.Write(ctx, params.StatusUnknown)
+		}
+		return errors.Annotatef(err, "finding workload status")
+	}
+	if !c.includeData && c.out.Name() == "smart" {
+		return c.out.Write(ctx, unitStatus.Status)
+	}
+	statusDetails := make(map[string]interface{})
+	statusDetails["status"] = unitStatus.Status
+	if c.includeData {
+		data := make(map[string]interface{})
+		for k, v := range unitStatus.Data {
+			data[k] = v
+		}
+		statusDetails["data"] = data
+		statusDetails["info"] = unitStatus.Info
+	}
+	c.out.Write(ctx, statusDetails)
+	return nil
+}

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -1,0 +1,114 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type statusGetSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&statusGetSuite{})
+
+func (s *statusGetSuite) SetUpTest(c *gc.C) {
+	s.ContextSuite.SetUpTest(c)
+}
+
+var (
+	statusAttributes = map[string]interface{}{
+		"status": "error",
+		"info":   "doing work",
+		"data":   map[string]interface{}{"foo": "bar"},
+	}
+)
+
+var statusGetTests = []struct {
+	args   []string
+	format int
+	out    interface{}
+}{
+	{[]string{"--format", "json", "--include-data"}, formatJson, statusAttributes},
+	{[]string{"--format", "yaml"}, formatYaml, map[string]interface{}{"status": "error"}},
+	{[]string{}, -1, "error\n"},
+}
+
+func (s *statusGetSuite) TestOutputFormatJustStatus(c *gc.C) {
+	for i, t := range statusGetTests {
+		c.Logf("test %d: %#v", i, t.args)
+		hctx := s.GetStatusHookContext(c)
+		com, err := jujuc.NewCommand(hctx, cmdString("status-get"))
+		c.Assert(err, jc.ErrorIsNil)
+		ctx := testing.Context(c)
+		code := cmd.Main(com, ctx, t.args)
+		c.Assert(code, gc.Equals, 0)
+		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+
+		var out interface{}
+		var outMap map[string]interface{}
+		switch t.format {
+		case formatYaml:
+			c.Check(goyaml.Unmarshal(bufferBytes(ctx.Stdout), &outMap), gc.IsNil)
+			out = outMap
+		case formatJson:
+			c.Check(json.Unmarshal(bufferBytes(ctx.Stdout), &outMap), gc.IsNil)
+			out = outMap
+		default:
+			out = string(bufferBytes(ctx.Stdout))
+		}
+		c.Check(out, gc.DeepEquals, t.out)
+	}
+}
+
+func (s *statusGetSuite) TestHelp(c *gc.C) {
+	hctx := s.GetStatusHookContext(c)
+	com, err := jujuc.NewCommand(hctx, cmdString("status-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, []string{"--help"})
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: status-get [options] [--include-data]
+purpose: print status information
+
+options:
+--format  (= smart)
+    specify output format (json|smart|yaml)
+--include-data  (= false)
+    print all status data
+-o, --output (= "")
+    specify an output file
+
+If include-data is false (the default), then just the status value is printed.
+Otherwise, the status value and any associated data is printed.
+`)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+}
+
+func (s *statusGetSuite) TestOutputPath(c *gc.C) {
+	hctx := s.GetStatusHookContext(c)
+	com, err := jujuc.NewCommand(hctx, cmdString("status-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, []string{"--format", "json", "--output", "some-file", "--include-data"})
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	var out map[string]interface{}
+	c.Assert(json.Unmarshal(content, &out), gc.IsNil)
+	c.Assert(out, gc.DeepEquals, statusAttributes)
+}

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -29,9 +29,9 @@ func (s *statusGetSuite) SetUpTest(c *gc.C) {
 
 var (
 	statusAttributes = map[string]interface{}{
-		"status": "error",
-		"info":   "doing work",
-		"data":   map[string]interface{}{"foo": "bar"},
+		"status":      "error",
+		"message":     "doing work",
+		"status-data": map[string]interface{}{"foo": "bar"},
 	}
 )
 
@@ -90,8 +90,8 @@ options:
 -o, --output (= "")
     specify an output file
 
-If include-data is false (the default), then just the status value is printed.
-Otherwise, the status value and any associated data is printed.
+By default, only the status value is printed.
+If the --include-data flag is passed, the associated data are printed also.
 `)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -93,6 +93,10 @@ func (s *ContextSuite) GetStorageHookContext(c *gc.C, storageId string) *Context
 	}
 }
 
+func (s *ContextSuite) GetStatusHookContext(c *gc.C) *Context {
+	return &Context{}
+}
+
 func setSettings(c *gc.C, ru *state.RelationUnit, settings map[string]interface{}) {
 	node, err := ru.Settings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -116,6 +120,7 @@ type Context struct {
 	shouldError    bool
 	storageTag     names.StorageTag
 	storage        map[names.StorageTag]*ContextStorage
+	status         jujuc.StatusInfo
 }
 
 func (c *Context) AddMetric(key, value string, created time.Time) error {
@@ -128,6 +133,16 @@ func (c *Context) AddMetric(key, value string, created time.Time) error {
 
 func (c *Context) UnitName() string {
 	return "u/0"
+}
+
+func (c *Context) UnitStatus() (*jujuc.StatusInfo, error) {
+	return &jujuc.StatusInfo{
+		Status: string(params.StatusError),
+		Info:   "doing work",
+		Data: map[string]interface{}{
+			"foo": "bar",
+		},
+	}, nil
 }
 
 func (c *Context) PublicAddress() (string, bool) {


### PR DESCRIPTION
This branch provides a status-get hook tool. It allows a unit to query for the status of the unit's workload. Part of https://docs.google.com/a/canonical.com/document/d/1SsHDxi58xgrim6VTKorqMn4GlzxPV9EFvu1ueBgnMlc

As part of this work, a common status getter was extracted for use in apiserver, to be shared between machines and units.

(Review request: http://reviews.vapour.ws/r/1252/)