### PR TITLE
Make a pinger test much less sensitive to slow hosts.

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -23,6 +23,7 @@ var (
 	MaxClientPingInterval = &maxClientPingInterval
 	MongoPingInterval     = &mongoPingInterval
 	NewTimer              = &newTimer
+	ResetTimer            = &resetTimer
 	NewBackups            = &newBackups
 	ParseLogLine          = parseLogLine
 	AgentMatchesFilter    = agentMatchesFilter

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -22,6 +22,7 @@ var (
 	NewPingTimeout        = newPingTimeout
 	MaxClientPingInterval = &maxClientPingInterval
 	MongoPingInterval     = &mongoPingInterval
+	NewTimer              = &newTimer
 	NewBackups            = &newBackups
 	ParseLogLine          = parseLogLine
 	AgentMatchesFilter    = agentMatchesFilter

--- a/apiserver/pinger.go
+++ b/apiserver/pinger.go
@@ -92,7 +92,7 @@ func (pt *pingTimeout) loop() error {
 			go pt.action()
 			return errors.New("ping timeout")
 		case <-pt.reset:
-			timer.Reset(pt.timeout)
+			resetTimer(timer, pt.timeout)
 		}
 	}
 }
@@ -100,6 +100,11 @@ func (pt *pingTimeout) loop() error {
 // newTimer is patched out during some tests.
 var newTimer = func(d time.Duration) *time.Timer {
 	return time.NewTimer(d)
+}
+
+// resetTimer is patched out during some tests.
+var resetTimer = func(timer *time.Timer, d time.Duration) bool {
+	return timer.Reset(d)
 }
 
 // nullPinger implements the pinger interface but just does nothing

--- a/apiserver/pinger.go
+++ b/apiserver/pinger.go
@@ -82,7 +82,7 @@ func (pt *pingTimeout) Stop() error {
 // loop waits for a reset signal, otherwise it performs
 // the initially passed action.
 func (pt *pingTimeout) loop() error {
-	timer := time.NewTimer(pt.timeout)
+	timer := newTimer(pt.timeout)
 	defer timer.Stop()
 	for {
 		select {
@@ -95,6 +95,11 @@ func (pt *pingTimeout) loop() error {
 			timer.Reset(pt.timeout)
 		}
 	}
+}
+
+// newTimer is patched out during some tests.
+var newTimer = func(d time.Duration) *time.Timer {
+	return time.NewTimer(d)
 }
 
 // nullPinger implements the pinger interface but just does nothing

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -95,6 +95,8 @@ func (s *pingerSuite) TestAgentConnectionShutsDownWithNoPing(c *gc.C) {
 }
 
 func (s *pingerSuite) TestAgentConnectionDelaysShutdownWithPing(c *gc.C) {
+	// We patch out NewTimer so that we can call Reset on the timer
+	// right before we check the failure case below.
 	var timer *time.Timer
 	s.PatchValue(apiserver.NewTimer, func(d time.Duration) *time.Timer {
 		timer = time.NewTimer(d)


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1408459)

Sometimes in CI TestAgentConnectionDelaysShutdownWithPing times out prematurely due possibly to slow hosts.  This patch makes that *much* less likely to happen.

This patch will also be applied to master.

(Review request: http://reviews.vapour.ws/r/1256/)