### PR TITLE
storageprovisioner: environ storage provisioner

### DIFF
--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/names"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 )
@@ -18,6 +19,8 @@ const storageProvisionerFacade = "StorageProvisioner"
 type State struct {
 	facade base.FacadeCaller
 	scope  names.Tag
+
+	*common.EnvironWatcher
 }
 
 // NewState creates a new client-side StorageProvisioner facade.
@@ -28,9 +31,11 @@ func NewState(caller base.APICaller, scope names.Tag) *State {
 	default:
 		panic(errors.Errorf("expected EnvironTag or MachineTag, got %T", scope))
 	}
+	facadeCaller := base.NewFacadeCaller(caller, storageProvisionerFacade)
 	return &State{
-		base.NewFacadeCaller(caller, storageProvisionerFacade),
+		facadeCaller,
 		scope,
+		common.NewEnvironWatcher(facadeCaller),
 	}
 }
 

--- a/api/storageprovisioner/provisioner_test.go
+++ b/api/storageprovisioner/provisioner_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/storageprovisioner"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -797,17 +796,7 @@ func (s *provisionerSuite) TestWatchForEnvironConfigChanges(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestEnvironConfig(c *gc.C) {
-	inputCfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":            "N. Vyron",
-		"type":            "fancy",
-		"uuid":            coretesting.EnvironmentTag.Id(),
-		"authorized-keys": coretesting.FakeAuthKeys,
-		"admin-secret":    coretesting.DefaultMongoPassword,
-		"ca-cert":         coretesting.CACert,
-		"ca-private-key":  coretesting.CAKey,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
+	inputCfg := coretesting.EnvironConfig(c)
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "StorageProvisioner")
 		c.Check(version, gc.Equals, 0)

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -13,6 +13,7 @@ import (
 
 type provisionerState interface {
 	state.EntityFinder
+	state.EnvironAccessor
 
 	MachineInstanceId(names.MachineTag) (instance.Id, error)
 

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -25,6 +25,7 @@ func init() {
 type StorageProvisionerAPI struct {
 	*common.LifeGetter
 	*common.DeadEnsurer
+	*common.EnvironWatcher
 
 	st                       provisionerState
 	settings                 poolmanager.SettingsManager
@@ -132,8 +133,10 @@ func NewStorageProvisionerAPI(st *state.State, resources *common.Resources, auth
 	stateInterface := getState(st)
 	settings := getSettingsManager(st)
 	return &StorageProvisionerAPI{
-		LifeGetter:               common.NewLifeGetter(stateInterface, getStorageEntityAuthFunc),
-		DeadEnsurer:              common.NewDeadEnsurer(stateInterface, getStorageEntityAuthFunc),
+		LifeGetter:     common.NewLifeGetter(stateInterface, getStorageEntityAuthFunc),
+		DeadEnsurer:    common.NewDeadEnsurer(stateInterface, getStorageEntityAuthFunc),
+		EnvironWatcher: common.NewEnvironWatcher(stateInterface, resources, authorizer),
+
 		st:                       stateInterface,
 		settings:                 settings,
 		resources:                resources,

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -720,10 +720,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 			storageDir := filepath.Join(agentConfig.DataDir(), "storage")
 			return newStorageWorker(storageDir, api, api, api), nil
 		})
-		// TODO(axw) enable environ storage provisioner when it
-		// ignores non-dynamic storage. Until then, we have a
-		// race condition.
-		if isEnvironManager && false {
+		if isEnvironManager {
 			runner.StartWorker("storageprovisioner-environ", func() (worker.Worker, error) {
 				api := st.StorageProvisioner(agentConfig.Environment())
 				return newStorageWorker("", api, api, api), nil

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -718,12 +718,12 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		runner.StartWorker("storageprovisioner-machine", func() (worker.Worker, error) {
 			api := st.StorageProvisioner(agentConfig.Tag())
 			storageDir := filepath.Join(agentConfig.DataDir(), "storage")
-			return newStorageWorker(storageDir, api, api, api), nil
+			return newStorageWorker(storageDir, api, api, api, api), nil
 		})
 		if isEnvironManager {
 			runner.StartWorker("storageprovisioner-environ", func() (worker.Worker, error) {
 				api := st.StorageProvisioner(agentConfig.Environment())
-				return newStorageWorker("", api, api, api), nil
+				return newStorageWorker("", api, api, api, api), nil
 			})
 		}
 	}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1229,6 +1229,7 @@ func (s *MachineSuite) testMachineAgentRunsMachineStorageWorker(c *gc.C, shouldR
 		_ storageprovisioner.VolumeAccessor,
 		_ storageprovisioner.FilesystemAccessor,
 		_ storageprovisioner.LifecycleManager,
+		_ storageprovisioner.EnvironAccessor,
 	) worker.Worker {
 		// storageDir is not empty for machine scoped storage provisioners
 		c.Assert(storageDir, gc.Not(gc.Equals), "")
@@ -1272,6 +1273,7 @@ func (s *MachineSuite) testMachineAgentRunsEnvironStorageWorkers(c *gc.C, should
 		_ storageprovisioner.VolumeAccessor,
 		_ storageprovisioner.FilesystemAccessor,
 		_ storageprovisioner.LifecycleManager,
+		_ storageprovisioner.EnvironAccessor,
 	) worker.Worker {
 		// storageDir is empty for environ storage provisioners
 		if storageDir == "" {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1253,8 +1253,7 @@ func (s *MachineSuite) testMachineAgentRunsMachineStorageWorker(c *gc.C, shouldR
 func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	// TODO(wallyworld) - worker is currently disabled even with feature flag
-	s.testMachineAgentRunsEnvironStorageWorkers(c, false, coretesting.LongWait)
+	s.testMachineAgentRunsEnvironStorageWorkers(c, true, coretesting.LongWait)
 }
 
 func (s *MachineSuite) testMachineAgentRunsEnvironStorageWorkers(c *gc.C, shouldRun bool, timeout time.Duration) {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/environs/config"
@@ -23,6 +24,10 @@ const (
 	ScopeEnviron Scope = iota
 	ScopeMachine
 )
+
+// ErrVolumeNeedsInstance is an error indicating that a volume cannot be
+// created because the related machine instance has not been provisioned.
+var ErrVolumeNeedsInstance = errors.New("need instance to provision volume")
 
 // Provider is an interface for obtaining storage sources.
 type Provider interface {
@@ -82,9 +87,11 @@ type VolumeSource interface {
 	// ValidateVolumeParams validates the provided volume creation
 	// parameters, returning an error if they are invalid.
 	//
-	// If the provider is incapable of provisioning volumes separately
-	// from machine instances (e.g. MAAS), then ValidateVolumeParams
-	// must return an error if params.Instance is non-empty.
+	// If the provider requires information about the machine instance to
+	// which the volume will be attached before, and the supplied instance
+	// ID is empty (i.e. the instance is not yet provisioned), then
+	// ErrVolumeNeedsInstance must be returned to indicate that the
+	// provisioner should call again when the instance has been provisioned.
 	ValidateVolumeParams(params VolumeParams) error
 
 	// AttachVolumes attaches volumes to machines.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -27,7 +27,7 @@ const (
 
 // ErrVolumeNeedsInstance is an error indicating that a volume cannot be
 // created because the related machine instance has not been provisioned.
-var ErrVolumeNeedsInstance = errors.New("need instance to provision volume")
+var ErrVolumeNeedsInstance = errors.New("need running instance to provision volume")
 
 // Provider is an interface for obtaining storage sources.
 type Provider interface {

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -116,6 +116,8 @@ func removeAttachments(ctx *context, ids []params.MachineStorageId) error {
 	return nil
 }
 
+var errNonDynamic = errors.New("non-dynamic storage provider")
+
 // volumeSource returns a volume source given a name, provider type,
 // environment config and storage directory.
 //
@@ -132,6 +134,9 @@ func volumeSource(
 	provider, sourceConfig, err := sourceParams(providerType, sourceName, baseStorageDir)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting storage source %q params", sourceName)
+	}
+	if !provider.Dynamic() {
+		return nil, errNonDynamic
 	}
 	source, err := provider.VolumeSource(environConfig, sourceConfig)
 	if err != nil {

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 const attachedVolumeId = "1"
+const needsInstanceVolumeId = "23"
 
 var dyingVolumeAttachmentId = params.MachineStorageId{
 	MachineTag:    "machine-0",
@@ -404,6 +405,9 @@ func (*dummyProvider) FilesystemSource(environConfig *config.Config, providerCon
 }
 
 func (*dummyVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
+	if params.Tag.Id() == needsInstanceVolumeId {
+		return storage.ErrVolumeNeedsInstance
+	}
 	return nil
 }
 

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -381,6 +381,7 @@ func (m *mockLifecycleManager) RemoveAttachments([]params.MachineStorageId) ([]p
 // Set up a dummy storage provider so we can stub out volume creation.
 type dummyProvider struct {
 	storage.Provider
+	dynamic bool
 
 	volumeSourceFunc func(*config.Config, *storage.Config) (storage.VolumeSource, error)
 }
@@ -402,6 +403,10 @@ func (p *dummyProvider) VolumeSource(environConfig *config.Config, providerConfi
 
 func (*dummyProvider) FilesystemSource(environConfig *config.Config, providerConfig *storage.Config) (storage.FilesystemSource, error) {
 	return &dummyFilesystemSource{}, nil
+}
+
+func (p *dummyProvider) Dynamic() bool {
+	return p.dynamic
 }
 
 func (*dummyVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -109,6 +109,18 @@ type LifecycleManager interface {
 	RemoveAttachments([]params.MachineStorageId) ([]params.ErrorResult, error)
 }
 
+// EnvironAccessor defines an interface used to enable a storage provisioner
+// worker to watch changes to and read environment config, to use when
+// provisioning storage.
+type EnvironAccessor interface {
+	// WatchForEnvironConfigChanges returns a watcher that will be notified
+	// whenever the environment config changes in state.
+	WatchForEnvironConfigChanges() (apiwatcher.NotifyWatcher, error)
+
+	// EnvironConfig returns the current environment config.
+	EnvironConfig() (*config.Config, error)
+}
+
 // NewStorageProvisioner returns a Worker which manages
 // provisioning (deprovisioning), and attachment (detachment)
 // of first-class volumes and filesystems.
@@ -122,12 +134,14 @@ func NewStorageProvisioner(
 	v VolumeAccessor,
 	f FilesystemAccessor,
 	l LifecycleManager,
+	e EnvironAccessor,
 ) worker.Worker {
 	w := &storageprovisioner{
 		storageDir:  storageDir,
 		volumes:     v,
 		filesystems: f,
 		life:        l,
+		environ:     e,
 	}
 	go func() {
 		defer w.tomb.Done()
@@ -142,6 +156,7 @@ type storageprovisioner struct {
 	volumes     VolumeAccessor
 	filesystems FilesystemAccessor
 	life        LifecycleManager
+	environ     EnvironAccessor
 }
 
 // Kill implements Worker.Kill().
@@ -155,35 +170,37 @@ func (w *storageprovisioner) Wait() error {
 }
 
 func (w *storageprovisioner) loop() error {
-	// TODO(axw) wait for and watch environ config.
-	var environConfig *config.Config
-	/*
-		var environConfigChanges <-chan struct{}
-		environWatcher, err := p.st.WatchForEnvironConfigChanges()
-		if err != nil {
-			return err
-		}
-		environConfigChanges = environWatcher.Changes()
-		defer watcher.Stop(environWatcher, &p.tomb)
-		p.environ, err = worker.WaitForEnviron(environWatcher, p.st, p.tomb.Dying())
-		if err != nil {
-			return err
-		}
-	*/
+	var environConfigChanges <-chan struct{}
+	var volumesWatcher apiwatcher.StringsWatcher
+	var volumesChanges <-chan []string
+	var volumeAttachmentsWatcher apiwatcher.MachineStorageIdsWatcher
+	var volumeAttachmentsChanges <-chan []params.MachineStorageId
 
-	volumesWatcher, err := w.volumes.WatchVolumes()
+	environConfigWatcher, err := w.environ.WatchForEnvironConfigChanges()
 	if err != nil {
-		return errors.Annotate(err, "watching volumes")
+		return errors.Annotate(err, "watching environ config")
 	}
-	defer watcher.Stop(volumesWatcher, &w.tomb)
-	volumesChanges := volumesWatcher.Changes()
+	defer watcher.Stop(environConfigWatcher, &w.tomb)
+	environConfigChanges = environConfigWatcher.Changes()
 
-	volumeAttachmentsWatcher, err := w.volumes.WatchVolumeAttachments()
-	if err != nil {
-		return errors.Annotate(err, "watching volume attachments")
+	// The other watchers are started dynamically; stop only if started.
+	defer w.maybeStopWatcher(volumesWatcher)
+	defer w.maybeStopWatcher(volumeAttachmentsWatcher)
+
+	startWatchers := func() error {
+		var err error
+		volumesWatcher, err = w.volumes.WatchVolumes()
+		if err != nil {
+			return errors.Annotate(err, "watching volumes")
+		}
+		volumeAttachmentsWatcher, err = w.volumes.WatchVolumeAttachments()
+		if err != nil {
+			return errors.Annotate(err, "watching volume attachments")
+		}
+		volumesChanges = volumesWatcher.Changes()
+		volumeAttachmentsChanges = volumeAttachmentsWatcher.Changes()
+		return nil
 	}
-	defer watcher.Stop(volumeAttachmentsWatcher, &w.tomb)
-	volumeAttachmentsChanges := volumeAttachmentsWatcher.Changes()
 
 	filesystemsWatcher, err := w.filesystems.WatchFilesystems()
 	if err != nil {
@@ -200,17 +217,32 @@ func (w *storageprovisioner) loop() error {
 	filesystemAttachmentsChanges := filesystemAttachmentsWatcher.Changes()
 
 	ctx := context{
-		environConfig: environConfig,
-		storageDir:    w.storageDir,
-		volumes:       w.volumes,
-		filesystems:   w.filesystems,
-		life:          w.life,
+		storageDir:  w.storageDir,
+		volumes:     w.volumes,
+		filesystems: w.filesystems,
+		life:        w.life,
 	}
 
 	for {
 		select {
 		case <-w.tomb.Dying():
 			return tomb.ErrDying
+		case _, ok := <-environConfigChanges:
+			if !ok {
+				return watcher.EnsureErr(volumesWatcher)
+			}
+			environConfig, err := w.environ.EnvironConfig()
+			if err != nil {
+				return errors.Annotate(err, "getting environ config")
+			}
+			if ctx.environConfig == nil {
+				// We've received the initial environ config,
+				// so we can begin provisioning storage.
+				if err := startWatchers(); err != nil {
+					return err
+				}
+			}
+			ctx.environConfig = environConfig
 		case changes, ok := <-volumesChanges:
 			if !ok {
 				return watcher.EnsureErr(volumesWatcher)
@@ -240,6 +272,12 @@ func (w *storageprovisioner) loop() error {
 				return errors.Trace(err)
 			}
 		}
+	}
+}
+
+func (p *storageprovisioner) maybeStopWatcher(w watcher.Stopper) {
+	if w != nil {
+		watcher.Stop(w, &p.tomb)
 	}
 }
 

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -167,7 +167,7 @@ func (s *storageProvisionerSuite) TestVolumeNeedsInstance(c *gc.C) {
 	volumeAccessor.volumesWatcher.changes <- []string{needsInstanceVolumeId}
 	environAccessor.watcher.changes <- struct{}{}
 	err := worker.Wait()
-	c.Assert(err, gc.ErrorMatches, `provisioning volumes: creating volumes: need instance to provision volume`)
+	c.Assert(err, gc.ErrorMatches, `provisioning volumes: creating volumes: need running instance to provision volume`)
 }
 
 func (s *storageProvisionerSuite) TestVolumeNonDynamic(c *gc.C) {

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -4,12 +4,16 @@
 package storageprovisioner_test
 
 import (
+	"errors"
 	"time"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider/registry"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/storageprovisioner"
@@ -17,14 +21,16 @@ import (
 
 type storageProvisionerSuite struct {
 	coretesting.BaseSuite
+	provider *dummyProvider
 }
 
 var _ = gc.Suite(&storageProvisionerSuite{})
 
-func (s *storageProvisionerSuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
-	registry.RegisterProvider("dummy", &dummyProvider{})
-	s.AddSuiteCleanup(func(*gc.C) {
+func (s *storageProvisionerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.provider = &dummyProvider{}
+	registry.RegisterProvider("dummy", s.provider)
+	s.AddCleanup(func(*gc.C) {
 		registry.RegisterProvider("dummy", nil)
 	})
 }
@@ -35,6 +41,7 @@ func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
 		newMockVolumeAccessor(),
 		newMockFilesystemAccessor(),
 		&mockLifecycleManager{},
+		newMockEnvironAccessor(c),
 	)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
@@ -76,15 +83,24 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 	lifecycleManager := &mockLifecycleManager{}
 
 	filesystemAccessor := newMockFilesystemAccessor()
+	environAccessor := newMockEnvironAccessor(c)
 
 	worker := storageprovisioner.NewStorageProvisioner(
-		"storage-dir", volumeAccessor, filesystemAccessor, lifecycleManager,
+		"storage-dir",
+		volumeAccessor,
+		filesystemAccessor,
+		lifecycleManager,
+		environAccessor,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
 
 	// The worker should create volumes according to ids "1" and "2".
 	volumeAccessor.volumesWatcher.changes <- []string{"1", "2"}
+	// ... but not until the environment config is available.
+	assertNoEvent(c, volumeInfoSet, "volume info set")
+	assertNoEvent(c, volumeAttachmentInfoSet, "volume attachment info set")
+	environAccessor.watcher.changes <- struct{}{}
 	waitChannel(c, volumeInfoSet, "waiting for volume info to be set")
 	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
 }
@@ -109,17 +125,24 @@ func (s *storageProvisionerSuite) TestFilesystemAdded(c *gc.C) {
 	}
 
 	lifecycleManager := &mockLifecycleManager{}
-
 	volumeAccessor := newMockVolumeAccessor()
+	environAccessor := newMockEnvironAccessor(c)
 
 	worker := storageprovisioner.NewStorageProvisioner(
-		"storage-dir", volumeAccessor, filesystemAccessor, lifecycleManager,
+		"storage-dir",
+		volumeAccessor,
+		filesystemAccessor,
+		lifecycleManager,
+		environAccessor,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
 
 	// The worker should create filesystems according to ids "1" and "2".
 	filesystemAccessor.filesystemsWatcher.changes <- []string{"1", "2"}
+	// ... but not until the environment config is available.
+	assertNoEvent(c, filesystemInfoSet, "filesystem info set")
+	environAccessor.watcher.changes <- struct{}{}
 	waitChannel(c, filesystemInfoSet, "waiting for filesystem info to be set")
 }
 
@@ -164,9 +187,14 @@ func (s *storageProvisionerSuite) TestVolumeAttachmentAdded(c *gc.C) {
 	}
 
 	filesystemAccessor := newMockFilesystemAccessor()
+	environAccessor := newMockEnvironAccessor(c)
 
 	worker := storageprovisioner.NewStorageProvisioner(
-		"storage-dir", volumeAccessor, filesystemAccessor, lifecycleManager,
+		"storage-dir",
+		volumeAccessor,
+		filesystemAccessor,
+		lifecycleManager,
+		environAccessor,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -180,6 +208,8 @@ func (s *storageProvisionerSuite) TestVolumeAttachmentAdded(c *gc.C) {
 	}, {
 		MachineTag: "machine-0", AttachmentTag: "volume-1",
 	}}
+	assertNoEvent(c, volumeAttachmentInfoSet, "volume attachment info set")
+	environAccessor.watcher.changes <- struct{}{}
 	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
 }
 
@@ -200,7 +230,6 @@ func (s *storageProvisionerSuite) TestFilesystemAttachmentAdded(c *gc.C) {
 		c.Assert(filesystemAttachments, gc.DeepEquals, expectedFilesystemAttachments)
 		return nil, nil
 	}
-	lifecycleManager := &mockLifecycleManager{}
 
 	// filesystem-1 and machine-1 are provisioned.
 	filesystemAccessor.provisionedFilesystems["filesystem-1"] = params.Filesystem{
@@ -223,10 +252,16 @@ func (s *storageProvisionerSuite) TestFilesystemAttachmentAdded(c *gc.C) {
 		FilesystemTag: "filesystem-1",
 	}
 
+	lifecycleManager := &mockLifecycleManager{}
 	volumeAccessor := newMockVolumeAccessor()
+	environAccessor := newMockEnvironAccessor(c)
 
 	worker := storageprovisioner.NewStorageProvisioner(
-		"storage-dir", volumeAccessor, filesystemAccessor, lifecycleManager,
+		"storage-dir",
+		volumeAccessor,
+		filesystemAccessor,
+		lifecycleManager,
+		environAccessor,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -240,7 +275,45 @@ func (s *storageProvisionerSuite) TestFilesystemAttachmentAdded(c *gc.C) {
 	}, {
 		MachineTag: "machine-0", AttachmentTag: "filesystem-1",
 	}}
+	// ... but not until the environment config is available.
+	assertNoEvent(c, filesystemAttachmentInfoSet, "filesystem attachment info set")
+	environAccessor.watcher.changes <- struct{}{}
 	waitChannel(c, filesystemAttachmentInfoSet, "waiting for filesystem attachments to be set")
+}
+
+func (s *storageProvisionerSuite) TestUpdateEnvironConfig(c *gc.C) {
+	volumeAccessor := newMockVolumeAccessor()
+	lifecycleManager := &mockLifecycleManager{}
+	filesystemAccessor := newMockFilesystemAccessor()
+	environAccessor := newMockEnvironAccessor(c)
+
+	s.provider.volumeSourceFunc = func(envConfig *config.Config, sourceConfig *storage.Config) (storage.VolumeSource, error) {
+		c.Assert(envConfig, gc.NotNil)
+		c.Assert(sourceConfig, gc.NotNil)
+		c.Assert(envConfig.AllAttrs()["foo"], gc.Equals, "bar")
+		return nil, errors.New("zinga")
+	}
+
+	worker := storageprovisioner.NewStorageProvisioner(
+		"storage-dir",
+		volumeAccessor,
+		filesystemAccessor,
+		lifecycleManager,
+		environAccessor,
+	)
+	defer worker.Wait()
+	defer worker.Kill()
+
+	newConfig, err := environAccessor.cfg.Apply(map[string]interface{}{"foo": "bar"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	environAccessor.watcher.changes <- struct{}{}
+	environAccessor.setConfig(newConfig)
+	environAccessor.watcher.changes <- struct{}{}
+	volumeAccessor.volumesWatcher.changes <- []string{"1", "2"}
+
+	err = worker.Wait()
+	c.Assert(err, gc.ErrorMatches, `provisioning volumes: creating volumes: getting volume source: getting storage source "dummy": zinga`)
 }
 
 func waitChannel(c *gc.C, ch <-chan struct{}, activity string) {
@@ -248,6 +321,14 @@ func waitChannel(c *gc.C, ch <-chan struct{}, activity string) {
 	case <-ch:
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out " + activity)
+	}
+}
+
+func assertNoEvent(c *gc.C, ch <-chan struct{}, event string) {
+	select {
+	case <-ch:
+		c.Fatalf("unexpected " + event)
+	case <-time.After(coretesting.ShortWait):
 	}
 }
 

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -4,8 +4,6 @@
 package storageprovisioner
 
 import (
-	"time"
-
 	"github.com/juju/errors"
 	"github.com/juju/names"
 
@@ -384,7 +382,6 @@ func createVolumes(
 			// is created. This requires that we watch machines.
 			//
 			// For now, rely on the worker bouncing to retry.
-			time.Sleep(5 * time.Second)
 			return nil, nil, err
 		default:
 			// TODO(axw) we should set an error status for params.Tag here.

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -30,6 +30,7 @@ func volumesChanged(ctx *context, changes []string) error {
 	// attachments until they're all gone. We need to watch
 	// attachments *anyway*, so we can probably integrate the two
 	// things.
+	logger.Debugf("volumes alive: %v, dying: %v, dead: %v", alive, dying, dead)
 	if err := ensureDead(ctx, dying); err != nil {
 		return errors.Annotate(err, "ensuring volumes dead")
 	}
@@ -403,7 +404,7 @@ func createVolumes(
 	return volumesFromStorage(allVolumes), volumeAttachmentsFromStorage(allVolumeAttachments), nil
 }
 
-// createVolumes creates volumes with the specified parameters.
+// createVolumeAttachments creates volume attachments with the specified parameters.
 func createVolumeAttachments(
 	environConfig *config.Config,
 	baseStorageDir string,


### PR DESCRIPTION
This branch introduces various changes in order
to enable the environ-scope storage provisioner.

 - The storage provisioner will ignore volumes
   related to non-dynamic storage providers
   (e.g. MAAS). The EBS provider is currently
   non-dynamic; this will change in another branch.

 - Introduce an error that storage providers can
   return from ValidateVolumeParams to indicate
   that an instance is required before the
   volume can be created. This will be used for
   non-persistent volumes, where the volume's
   lifetime is bound to that of the instance it
   will be attached to.

 - The storage provisioner checks for the above-
   mentioned error, and currently bounces the
   worker. We will later handle the error more
   elegantly by having the worker watch instances,
   and triggering the volume creation when the
   required instance is provisioned.

 - Introduce environ-config watching to the
   storage provisioner, so it can pass the environ
   config to environ-scope storage providers.

 - Enable the environ storage provisioner in the
   (environ manager) machine agent.

(Review request: http://reviews.vapour.ws/r/1258/)