### PR TITLE
Skip TestUpgradeStepsStateServer on PPC64

### DIFF
--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -434,6 +434,7 @@ func (s *UpgradeSuite) TestJobsToTargets(c *gc.C) {
 
 func (s *UpgradeSuite) TestUpgradeStepsStateServer(c *gc.C) {
 	coretesting.SkipIfI386(c, "lp:1425569")
+	coretesting.SkipIfPPC64EL(c, "lp:1434555")
 
 	//TODO(bogdanteleaga): Fix this to behave properly
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1434555

The TestUpgradeStepsStateServer test is already skipped on I386. Also skip on PPC64

(Review request: http://reviews.vapour.ws/r/1262/)