### PR TITLE
Avoid sending environment UUID and auth headers to the charm store.

### DIFF
--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -110,8 +110,7 @@ func retrieveLatestCharmInfo(deployedCharms map[string]*charm.URL, uuid string) 
 
 	// Do a bulk call to get the revision info for all charms.
 	logger.Infof("retrieving revision information for %d charms", len(curls))
-	store := charmrepo.LegacyStore.WithJujuAttrs("environment_uuid=" + uuid)
-	revInfo, err := store.Latest(curls...)
+	revInfo, err := charmrepo.LegacyStore.Latest(curls...)
 	if err != nil {
 		err = errors.Annotate(err, "finding charm revision info")
 		logger.Infof(err.Error())

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -117,15 +117,3 @@ func (s *charmVersionSuite) TestUpdateRevisions(c *gc.C) {
 	_, err = s.State.LatestPlaceholderCharm(curl)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
-
-func (s *charmVersionSuite) TestEnvironmentUUIDUsed(c *gc.C) {
-	s.AddMachine(c, "0", state.JobManageEnviron)
-	s.SetupScenario(c)
-	result, err := s.charmrevisionupdater.UpdateLatestRevisions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.IsNil)
-
-	env, err := s.State.Environment()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.Server.Metadata, gc.DeepEquals, []string{"environment_uuid=" + env.UUID()})
-}

--- a/apiserver/charms/client.go
+++ b/apiserver/charms/client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v5-unstable"
-	"gopkg.in/juju/charm.v5-unstable/charmrepo"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
@@ -51,8 +50,6 @@ func NewAPI(
 		authorizer: authorizer,
 	}, nil
 }
-
-var CharmStore charmrepo.Interface = charmrepo.LegacyStore
 
 // CharmInfo returns information about the requested charm.
 func (a *API) CharmInfo(args params.CharmInfo) (api.CharmInfo, error) {

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -266,7 +266,9 @@ func (c *Client) ServiceUnexpose(args params.ServiceUnexpose) error {
 	return svc.ClearExposed()
 }
 
-var CharmStore charmrepo.Interface = charmrepo.LegacyStore
+// charmStore gives access to the legacy charm store repository.
+// It is defined at top level for testing purposes.
+var charmStore charmrepo.Interface = charmrepo.LegacyStore
 
 func networkTagsToNames(tags []string) ([]string, error) {
 	netNames := make([]string, len(tags))
@@ -1257,8 +1259,8 @@ func (c *Client) AddCharm(args params.CharmURL) error {
 	if err != nil {
 		return err
 	}
-	config.SpecializeCharmRepo(CharmStore, envConfig)
-	downloadedCharm, err := CharmStore.Get(charmURL)
+	repo := config.SpecializeCharmRepo(charmStore, envConfig)
+	downloadedCharm, err := repo.Get(charmURL)
 	if err != nil {
 		return errors.Annotatef(err, "cannot download charm %q", charmURL.String())
 	}
@@ -1332,11 +1334,11 @@ func (c *Client) ResolveCharms(args params.ResolveCharms) (params.ResolveCharmRe
 	if err != nil {
 		return params.ResolveCharmResults{}, err
 	}
-	config.SpecializeCharmRepo(CharmStore, envConfig)
+	repo := config.SpecializeCharmRepo(charmStore, envConfig)
 
 	for _, ref := range args.References {
 		result := params.ResolveCharmResult{}
-		curl, err := c.resolveCharm(&ref, CharmStore)
+		curl, err := c.resolveCharm(&ref, repo)
 		if err != nil {
 			result.Error = err.Error()
 		} else {

--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -8,6 +8,7 @@ var (
 	RemoteParamsForMachine  = remoteParamsForMachine
 	GetAllUnitNames         = getAllUnitNames
 	NewStateStorage         = &newStateStorage
+	CharmStore              = &charmStore
 )
 
 var MachineJobFromParams = machineJobFromParams

--- a/cmd/juju/deploy.go
+++ b/cmd/juju/deploy.go
@@ -192,8 +192,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-
-	config.SpecializeCharmRepo(repo, conf)
+	repo = config.SpecializeCharmRepo(repo, conf)
 
 	curl, err = addCharmViaAPI(client, ctx, curl, repo)
 	if err != nil {

--- a/cmd/juju/upgradecharm.go
+++ b/cmd/juju/upgradecharm.go
@@ -137,7 +137,7 @@ func (c *UpgradeCharmCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	config.SpecializeCharmRepo(repo, conf)
+	repo = config.SpecializeCharmRepo(repo, conf)
 
 	// If no explicit revision was set with either SwitchURL
 	// or Revision flags, discover the latest.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,14 +21,14 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
-github.com/juju/jujusvg	git	6b752379060cf6f51e1febc74d74f0e3a7d72bbe	2015-03-23T15:51:10Z
+github.com/juju/jujusvg	git	516cc9eb29dbf6930344facc2231d51c42a5b815	2015-03-24T16:46:20Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
 github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07:57:36Z
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
 github.com/juju/replicaset	git	28850ac0132761f40fe77175130d542a22d42bb4	2015-03-26T01:44:18Z
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
-github.com/juju/testing	git	c07aef9cb4f2ff1db7ddc9d43a0ea88eca39c9ea	2015-03-12T17:47:17Z
+github.com/juju/testing	git	5565a3afddc96a8117eda88ac3b3a6428f874de7	2015-03-19T16:02:45Z
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	2014-09-25T11:49:22Z
 github.com/juju/utils	git	4a323da2a94607b1c4987d636cfe3139ef3a8262	2015-03-18T23:27:02Z
 github.com/juju/xml	git	91535ba18a6afd756e38a40c91fea0ed8e5dbaa6	2014-12-04T14:59:31Z
@@ -36,8 +36,8 @@ golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:2
 gopkg.in/amz.v3	git	661b136aa255ca3db33234fe91d8a223c847e831	2015-03-25T02:48:52Z
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	2014-08-27T13:58:41Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
-gopkg.in/juju/charm.v5-unstable	git	d7732cf451266e0cffe846422e4012f95cd06f28	2015-03-23T15:46:56Z
-gopkg.in/juju/charmstore.v4	git	8b8cf201739efa370d48c3a4ee3ef197b8e77147	2015-03-23T16:17:23Z
+gopkg.in/juju/charm.v5-unstable	git	62ddde8b7abac1db3ecd5d7d0536b67f7a4719bc	2015-03-25T11:14:56Z
+gopkg.in/juju/charmstore.v4	git	5b1da0427e8726978859afd389fe5e141ac6db7a	2015-03-25T11:39:57Z
 gopkg.in/macaroon-bakery.v0	git	4c0e0fae424e8d1bc71c0b0caca3cd2c32381dca	2015-01-27T17:01:29Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	2014-07-30T20:00:37Z

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -17,6 +17,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5-unstable/charmrepo"
 
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/environs/config"
@@ -872,20 +873,6 @@ var configTests = []configTest{
 		},
 		err: "uuid: expected uuid, got string\\(\"\"\\)",
 	},
-	authTokenConfigTest("token=value, tokensecret=value", true),
-	authTokenConfigTest("token=value, ", true),
-	authTokenConfigTest("token=value, \ttokensecret=value", true),
-	authTokenConfigTest("", true),
-	authTokenConfigTest("token=value, tokensecret=value, \t", true),
-	authTokenConfigTest("=", false),
-	authTokenConfigTest("tokenvalue", false),
-	authTokenConfigTest("token=value, sometoken=", false),
-	authTokenConfigTest("token==value", false),
-	authTokenConfigTest(" token=value", false),
-	authTokenConfigTest("=value", false),
-	authTokenConfigTest("token=value, =z", false),
-	authTokenConfigTest("token=value =z", false),
-	authTokenConfigTest("\t", false),
 	missingAttributeNoDefault("firewall-mode"),
 	missingAttributeNoDefault("development"),
 	missingAttributeNoDefault("ssl-hostname-verification"),
@@ -912,28 +899,6 @@ var configTests = []configTest{
 			"apt-mirror": "http://my.archive.ubuntu.com",
 		},
 	},
-}
-
-// authTokenConfigTest returns a config test that checks
-// that a configuration with the given auth token
-// will pass or fail, depending on the value of ok.
-func authTokenConfigTest(token string, ok bool) configTest {
-	var testName string
-	var err string
-
-	if ok {
-		testName = fmt.Sprintf("Valid auth token test: %q", token)
-	} else {
-		testName = fmt.Sprintf("Invalid auth token test: %q", token)
-		err = fmt.Sprintf("charm store auth token needs to be a set of key-value pairs, not %q", token)
-	}
-
-	return configTest{
-		about:       testName,
-		useDefaults: config.UseDefaults,
-		attrs:       sampleConfig.Merge(testing.Attrs{"charm-store-auth": token}),
-		err:         regexp.QuoteMeta(err),
-	}
 }
 
 func missingAttributeNoDefault(attrName string) configTest {
@@ -1348,7 +1313,6 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 		"bootstrap-retry-delay":     30,
 		"bootstrap-addresses-delay": 10,
 		"default-series":            testing.FakeDefaultSeries,
-		"charm-store-auth":          "token=auth",
 		"test-mode":                 false,
 	}
 	cfg, err := config.New(config.NoDefaults, attrs)
@@ -1804,6 +1768,50 @@ func (s *ConfigSuite) TestGenerateStateServerCertAndKey(c *gc.C) {
 			c.Assert(keyPEM, gc.Equals, "")
 		}
 	}
+}
+
+var specializeCharmRepoTests = []struct {
+	about    string
+	testMode bool
+	repo     charmrepo.Interface
+}{{
+	about: "test mode disabled, charm store",
+	repo:  &specializedCharmRepo{},
+}, {
+	about: "test mode disabled, local repo",
+	repo:  &charmrepo.LocalRepository{},
+}, {
+	about:    "test mode enabled, charm store",
+	testMode: true,
+	repo:     &specializedCharmRepo{},
+}, {
+	about:    "test mode enabled, local repo",
+	testMode: true,
+	repo:     &charmrepo.LocalRepository{},
+}}
+
+func (s *ConfigSuite) TestSpecializeCharmRepo(c *gc.C) {
+	for i, test := range specializeCharmRepoTests {
+		c.Logf("test %d: %s", i, test.about)
+		cfg := newTestConfig(c, testing.Attrs{"test-mode": test.testMode})
+		repo := config.SpecializeCharmRepo(test.repo, cfg)
+		if store, ok := repo.(*specializedCharmRepo); ok {
+			c.Assert(store.testMode, gc.Equals, test.testMode)
+			continue
+		}
+		// Just check that the original local repo has not been modified.
+		c.Assert(repo.(*charmrepo.LocalRepository), gc.Equals, test.repo)
+	}
+}
+
+type specializedCharmRepo struct {
+	*charmrepo.LegacyCharmStore
+	testMode bool
+}
+
+func (s *specializedCharmRepo) WithTestMode(testMode bool) charmrepo.Interface {
+	s.testMode = testMode
+	return s
 }
 
 func (s *ConfigSuite) TestLastestLtsSeriesFallback(c *gc.C) {


### PR DESCRIPTION
Those headers are not used by the legacy charm store server anyway.

Also fix charm store test mode: it was never enabled before, as
the legacy charm store did not implement the specializer interface.

(Review request: http://reviews.vapour.ws/r/1263/)