### PR TITLE
Handle logins at the server level properly.

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -74,7 +74,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 	if err != nil || kind != names.UserTagKind {
 		// Users are not rate limited, all other entities are
 		if !a.srv.limiter.Acquire() {
-			logger.Debugf("rate limiting, try again later")
+			logger.Debugf("rate limiting for agent %s", req.AuthTag)
 			return fail, common.ErrTryAgain
 		}
 		defer a.srv.limiter.Release()

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -6,6 +6,7 @@ package apiserver
 import (
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -45,9 +46,9 @@ func DelayLogins() (nextChan chan struct{}, cleanup func()) {
 	cleanup = func() {
 		doCheckCreds = checkCreds
 	}
-	delayedCheckCreds := func(st *state.State, c params.LoginRequest) (state.Entity, error) {
+	delayedCheckCreds := func(st *state.State, c params.LoginRequest, lookForEnvUser bool) (state.Entity, *time.Time, error) {
 		<-nextChan
-		return checkCreds(st, c)
+		return checkCreds(st, c, lookForEnvUser)
 	}
 	doCheckCreds = delayedCheckCreds
 	return

--- a/apiserver/httphandler.go
+++ b/apiserver/httphandler.go
@@ -92,12 +92,11 @@ func (h *httpStateWrapper) authenticate(r *http.Request) (names.Tag, error) {
 	if err != nil {
 		return nil, common.ErrBadCreds
 	}
-	// Ensure the credentials are correct.
-	_, err = checkCreds(h.state, params.LoginRequest{
+	_, _, err = checkCreds(h.state, params.LoginRequest{
 		AuthTag:     tagPass[0],
 		Credentials: tagPass[1],
 		Nonce:       r.Header.Get("X-Juju-Nonce"),
-	})
+	}, true)
 	return tag, err
 }
 


### PR DESCRIPTION
The apiserver was not correctly handling logins at the root of the API when the user did not have access to the state server environment.

(Review request: http://reviews.vapour.ws/r/1280/)