### PR TITLE
Fixes bug 1436397

### DIFF
--- a/cmd/juju/storage/poollist_test.go
+++ b/cmd/juju/storage/poollist_test.go
@@ -127,6 +127,9 @@ func (s *poolListSuite) assertUnmarshalledOutput(c *gc.C, unmarshall unmarshalle
 	expected := s.expect(c,
 		[]string{providerA, providerB},
 		[]string{nameABC, nameXYZ})
+	// This comparison cannot rely on gc.DeepEquals as
+	// json.Unmarshal unmarshalls the number as a float64,
+	// rather than an int
 	s.assertSamePoolInfos(c, result, expected)
 }
 
@@ -138,6 +141,8 @@ func (s poolListSuite) assertSamePoolInfos(c *gc.C, one, two map[string]storage.
 		for ka, va := range a {
 			vb, okb := b[ka]
 			c.Assert(okb, jc.IsTrue)
+			// As some types may have been unmarshalled incorrectly, for example
+			// int versus float64, compare values' string representations
 			c.Assert(fmt.Sprintf("%v", va), jc.DeepEquals, fmt.Sprintf("%v", vb))
 		}
 	}

--- a/cmd/juju/storage/poollistformatters.go
+++ b/cmd/juju/storage/poollistformatters.go
@@ -46,11 +46,9 @@ func formatPoolsTabular(pools map[string]PoolInfo) ([]byte, error) {
 	for _, name := range poolNames {
 		pool := pools[name]
 		// order by key for deterministic return
-		keys := make([]string, len(pool.Attrs))
-		var i int
+		keys := make([]string, 0, len(pool.Attrs))
 		for key := range pool.Attrs {
-			keys[i] = key
-			i++
+			keys = append(keys, key)
 		}
 		sort.Strings(keys)
 		attrs := make([]string, len(pool.Attrs))

--- a/cmd/juju/storage/poollistformatters.go
+++ b/cmd/juju/storage/poollistformatters.go
@@ -45,11 +45,17 @@ func formatPoolsTabular(pools map[string]PoolInfo) ([]byte, error) {
 	sort.Strings(poolNames)
 	for _, name := range poolNames {
 		pool := pools[name]
-		attrs := make([]string, len(pool.Attrs))
+		// order by key for deterministic return
+		keys := make([]string, len(pool.Attrs))
 		var i int
-		for key, value := range pool.Attrs {
-			attrs[i] = fmt.Sprintf("%v=%v", key, value)
+		for key := range pool.Attrs {
+			keys[i] = key
 			i++
+		}
+		sort.Strings(keys)
+		attrs := make([]string, len(pool.Attrs))
+		for i, key := range keys {
+			attrs[i] = fmt.Sprintf("%v=%v", key, pool.Attrs[key])
 		}
 		print(name, pool.Provider, strings.Join(attrs, " "))
 	}


### PR DESCRIPTION
Bug https://bugs.launchpad.net/juju-core/+bug/1436397

Changed logic - for tabular output, attribute keys are sorted in alphabetical order.

Drive-by changes:
1. unexported test suite.
2. constructing test pools with more flexibility for attrs.

(Review request: http://reviews.vapour.ws/r/1285/)