### PR TITLE
Start the addresser worker and Provisioner API changes

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -853,5 +853,8 @@ func (s *provisionerSuite) TestReleaseContainerAddresses(c *gc.C) {
 
 	addresses, err := s.State.AllocatedIPAddresses(container.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addresses, jc.DeepEquals, []*state.IPAddress{})
+	c.Assert(addresses, gc.HasLen, 3)
+	for _, addr := range addresses {
+		c.Assert(addr.Life(), gc.Equals, state.Dead)
+	}
 }

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -758,21 +758,6 @@ func (s *releaseSuite) allocateAddresses(c *gc.C, containerId string, numAllocat
 	}
 }
 
-func (s *releaseSuite) TestErrorWithFailingReleaseAddress(c *gc.C) {
-	container := s.newAPI(c, true, true)
-	args := s.makeArgs(container)
-
-	s.allocateAddresses(c, container.Id(), 2)
-	s.breakEnvironMethods(c, "ReleaseAddress")
-	err := s.assertCall(c, args, s.makeErrors(
-		apiservertesting.ServerError(
-			`failed to release all addresses for "machine-0-lxc-0": `+
-				`[dummy.ReleaseAddress is broken dummy.ReleaseAddress is broken]`,
-		),
-	), "")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *releaseSuite) TestReleaseContainerAddresses(c *gc.C) {
 	container := s.newAPI(c, true, true)
 	args := s.makeArgs(container)
@@ -782,5 +767,8 @@ func (s *releaseSuite) TestReleaseContainerAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	addresses, err := s.BackingState.AllocatedIPAddresses(container.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addresses, jc.DeepEquals, []*state.IPAddress{})
+	c.Assert(addresses, gc.HasLen, 2)
+	for _, addr := range addresses {
+		c.Assert(addr.Life(), gc.Equals, state.Dead)
+	}
 }

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -247,13 +247,12 @@ func (s *prepareSuite) TestErrorsWithNonMachineOrInvalidTags(c *gc.C) {
 		apiservertesting.ServerError(
 			`"network-foo" is not a valid machine tag`),
 		apiservertesting.ServerError(
-			`"anything-invalid" is not a valid machine tag`),
+			`"anything-invalid" is not a valid tag`),
 		apiservertesting.ServerError(
-			`"42" is not a valid machine tag`),
+			`"42" is not a valid tag`),
+		apiservertesting.ErrUnauthorized,
 		apiservertesting.ServerError(
-			`"machine-42" is not a valid machine tag`),
-		apiservertesting.ServerError(
-			`"" is not a valid machine tag`),
+			`"" is not a valid tag`),
 	), "")
 }
 

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -673,7 +673,7 @@ func (s *releaseSuite) TestErrorWithHostInsteadOfContainer(c *gc.C) {
 	args := s.makeArgs(s.machines[0])
 	err := s.assertCall(c, args, s.makeErrors(
 		apiservertesting.ServerError(
-			`cannot release address for "machine-0": not a container`,
+			`cannot mark addresses for removal for "machine-0": not a container`,
 		),
 	), "")
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -240,13 +240,20 @@ func (s *prepareSuite) TestErrorsWithNonMachineOrInvalidTags(c *gc.C) {
 	}}
 
 	s.assertCall(c, args, s.makeErrors(
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
+		apiservertesting.ServerError(
+			`"unit-wordpress-0" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"service-wordpress" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"network-foo" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"anything-invalid" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"42" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"machine-42" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"" is not a valid machine tag`),
 	), "")
 }
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -885,7 +885,7 @@ func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (pa
 	for i, entity := range args.Entities {
 		tag, err := names.ParseMachineTag(entity.Tag)
 		if err != nil {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -824,7 +824,6 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		} else if !container.IsContainer() {
-			logger.Warningf("cannot mark addresses for removal for %q: not a container", tag)
 			err = errors.Errorf("cannot mark addresses for removal for %q: not a container", tag)
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -843,7 +842,6 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 		for _, addr := range addresses {
 			err = addr.EnsureDead()
 			if err != nil {
-				logger.Warningf("failed to mark address %v for container %q for removal: %v", addr.Value, tag, err)
 				deadErrors = append(deadErrors, err)
 				continue
 			}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -60,6 +60,7 @@ import (
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/addresser"
 	"github.com/juju/juju/worker/apiaddressupdater"
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
@@ -1055,6 +1056,9 @@ func (a *MachineAgent) startEnvWorkers(
 	})
 	singularRunner.StartWorker("minunitsworker", func() (worker.Worker, error) {
 		return minunitsworker.NewMinUnitsWorker(st), nil
+	})
+	singularRunner.StartWorker("addresserworker", func() (worker.Worker, error) {
+		return addresser.NewWorker(st)
 	})
 
 	// Start workers that use an API connection.

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -241,6 +241,7 @@ type MachineSuite struct {
 var perEnvSingularWorkers = []string{
 	"cleaner",
 	"minunitsworker",
+	"addresserworker",
 	"environ-provisioner",
 	"charm-revision-updater",
 	"firewaller",


### PR DESCRIPTION
The addresser worker is started as a singular worker on the state server. 

The provisioner ReleaseContainerAddresses api method no longer directly releases / removes addresses. Instead it marks them as Dead, for the addresser to clean up.

(Review request: http://reviews.vapour.ws/r/1290/)