### PR TITLE
Fix incorrect logging statement

### DIFF
--- a/apiserver/metricstorage/metricstorage_test.go
+++ b/apiserver/metricstorage/metricstorage_test.go
@@ -157,7 +157,7 @@ func (s *metricStorageSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
 	}}
 
 	for i, test := range tests {
-		c.Log("%d: %s", i, test.about)
+		c.Logf("%d: %s", i, test.about)
 		result, err := s.metricstorage.AddMetricBatches(params.MetricBatchParams{
 			Batches: []params.MetricBatchParam{{
 				Tag: test.tag,


### PR DESCRIPTION
Trivial typo that breaks newer go vet:

```
$ ./scripts/verify.bash
go version go1.4.2
checking: go fmt ...
checking: go vet ...
apiserver/metricstorage/metricstorage_test.go:160: possible formatting directive in Log call
```

(Review request: http://reviews.vapour.ws/r/1292/)