### PR TITLE
API: Fix LP-1435152, deploy local charm, non-state envion

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -74,9 +74,12 @@ type State struct {
 	tag      string
 	password string
 
-	// serverRoot holds the cached API server address and port we used
-	// to login, with a https:// prefix.
-	serverRoot string
+	// serverRootAddress holds the cached API server address and port used
+	// to login.
+	serverRootAddress string
+
+	// serverScheme is the URI scheme of the API Server
+	serverScheme string
 
 	// certPool holds the cert pool that is used to authenticate the tls
 	// connections to the API.
@@ -158,10 +161,11 @@ func open(info *Info, opts DialOpts, loginFunc func(st *State, tag, pwd, nonce s
 	client := rpc.NewConn(jsoncodec.NewWebsocket(conn), nil)
 	client.Start()
 	st := &State{
-		client:     client,
-		conn:       conn,
-		addr:       conn.Config().Location.Host,
-		serverRoot: "https://" + conn.Config().Location.Host,
+		client:            client,
+		conn:              conn,
+		addr:              conn.Config().Location.Host,
+		serverScheme:      "https",
+		serverRootAddress: conn.Config().Location.Host,
 		// why are the contents of the tag (username and password) written into the
 		// state structure BEFORE login ?!?
 		tag:      toString(info.Tag),
@@ -445,4 +449,10 @@ func (s *State) AllFacadeVersions() map[string][]int {
 // reports to us, with the versions that our client knows how to use.
 func (s *State) BestFacadeVersion(facade string) int {
 	return bestVersion(facadeVersions[facade], s.facadeVersions[facade])
+}
+
+// serverRoot returns the cached API server address and port used
+// to login, prefixed with "<URI scheme>://" (usually https).
+func (s *State) serverRoot() string {
+	return s.serverScheme + "://" + s.serverRootAddress
 }

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -217,6 +217,11 @@ func (s *apiclientSuite) TestOpenHonorsEnvironTag(c *gc.C) {
 	st.Close()
 }
 
+func (s *apiclientSuite) TestServerRoot(c *gc.C) {
+	url := api.ServerRoot(s.APIState.Client())
+	c.Assert(url, gc.Matches, "https://localhost:[0-9]+")
+}
+
 func (s *apiclientSuite) TestDialWebsocketStopped(c *gc.C) {
 	stopped := make(chan struct{})
 	f := api.NewWebsocketDialer(nil, api.DialOpts{})

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -18,10 +18,16 @@ var (
 	NewHTTPClient         = &newHTTPClient
 )
 
-// SetServerRoot allows changing the URL to the internal API server
+// SetServerAddress allows changing the URL to the internal API server
 // that AddLocalCharm uses in order to test NotImplementedError.
-func SetServerRoot(c *Client, root string) {
-	c.st.serverRoot = root
+func SetServerAddress(c *Client, scheme, addr string) {
+	c.st.serverScheme = scheme
+	c.st.addr = addr
+}
+
+// ServerRoot is exported so that we can test the built URL.
+func ServerRoot(c *Client) string {
+	return c.st.serverRoot()
 }
 
 // PatchEnvironTag patches the value of the environment tag.
@@ -41,6 +47,7 @@ type TestingStateParams struct {
 	EnvironTag     string
 	APIHostPorts   [][]network.HostPort
 	FacadeVersions map[string][]int
+	ServerScheme   string
 	ServerRoot     string
 }
 
@@ -49,11 +56,12 @@ type TestingStateParams struct {
 // called on it. But it can be used for testing general behavior.
 func NewTestingState(params TestingStateParams) *State {
 	st := &State{
-		addr:           params.Address,
-		environTag:     params.EnvironTag,
-		hostPorts:      params.APIHostPorts,
-		facadeVersions: params.FacadeVersions,
-		serverRoot:     params.ServerRoot,
+		addr:              params.Address,
+		environTag:        params.EnvironTag,
+		hostPorts:         params.APIHostPorts,
+		facadeVersions:    params.FacadeVersions,
+		serverScheme:      params.ServerScheme,
+		serverRootAddress: params.ServerRoot,
 	}
 	return st
 }

--- a/api/http.go
+++ b/api/http.go
@@ -35,9 +35,9 @@ func (s *State) NewHTTPClient() *http.Client {
 
 // NewHTTPRequest returns a new API-supporting HTTP request based on State.
 func (s *State) NewHTTPRequest(method, path string) (*http.Request, error) {
-	baseURL, err := url.Parse(s.serverRoot)
+	baseURL, err := url.Parse(s.serverRoot())
 	if err != nil {
-		return nil, errors.Annotatef(err, "while parsing base URL (%s)", s.serverRoot)
+		return nil, errors.Annotatef(err, "while parsing base URL (%s)", s.serverRoot())
 	}
 
 	tag, err := s.EnvironTag()


### PR DESCRIPTION
Update the API client method AddLocalCharm to use the new environment
specific API endpoint. Add a test to ensure a local charm archive can
be uploaded to a non-state server environment. Split
api.Client.State.serverRoot into scheme and address, allowing scheme
to be mocked to "http" for testing.

(Review request: http://reviews.vapour.ws/r/1293/)