### PR TITLE
Provisioner handles maas interfaces with no associated subnet

### DIFF
--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -550,6 +550,15 @@ func (s *prepareSuite) TestErrorWhenNoNICSAvailable(c *gc.C) {
 	s.assertCall(c, args, nil, "cannot allocate addresses: no interfaces available")
 }
 
+func (s *prepareSuite) TestErrorWhenNNICWithNoSubnetAvailable(c *gc.C) {
+	// The magic "i-nic-no-subnet-" instance id prefix for the host
+	// causes the dummy provider to return a nic that has no associated
+	// subnet from NetworkInterfaces().
+	container := s.newCustomAPI(c, "i-nic-no-subnet-here", true, false)
+	args := s.makeArgs(container)
+	s.assertCall(c, args, nil, "cannot allocate addresses: no subnets available")
+}
+
 func (s *prepareSuite) TestSuccessWithSingleContainer(c *gc.C) {
 	container := s.newAPI(c, true, true)
 	args := s.makeArgs(container)

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -550,7 +550,7 @@ func (s *prepareSuite) TestErrorWhenNoNICSAvailable(c *gc.C) {
 	s.assertCall(c, args, nil, "cannot allocate addresses: no interfaces available")
 }
 
-func (s *prepareSuite) TestErrorWhenNNICWithNoSubnetAvailable(c *gc.C) {
+func (s *prepareSuite) TestErrorWithNICNoSubnetAvailable(c *gc.C) {
 	// The magic "i-nic-no-subnet-" instance id prefix for the host
 	// causes the dummy provider to return a nic that has no associated
 	// subnet from NetworkInterfaces().

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1028,10 +1028,14 @@ func (p *ProvisionerAPI) prepareAllocationNetwork(
 	}
 	logger.Tracef("interfaces for instance %q: %v", instId, interfaces)
 
-	subnetIds := make([]network.Id, len(interfaces))
+	subnetIds := []network.Id{}
 	subnetIdToInterface := make(map[network.Id]network.InterfaceInfo)
-	for i, iface := range interfaces {
-		subnetIds[i] = iface.ProviderSubnetId
+	for _, iface := range interfaces {
+		if iface.ProviderSubnetId == "" {
+			logger.Debugf("no subnet associated with interface %#v (skipping)", iface)
+			continue
+		}
+		subnetIds = append(subnetIds, iface.ProviderSubnetId)
 		subnetIdToInterface[iface.ProviderSubnetId] = iface
 	}
 	subnets, err := environ.Subnets(instId, subnetIds)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1128,18 +1128,16 @@ func (env *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceIn
 	} else if strings.HasPrefix(string(instId), "i-nic-no-subnet-") {
 		// Simulate a nic with no subnet on instances with id prefix
 		// "i-nic-no-subnet-"
-		info = []network.InterfaceInfo{
-			{
-				DeviceIndex:   0,
-				ProviderId:    network.Id("dummy-eth0"),
-				NetworkName:   "juju-public",
-				InterfaceName: "eth0",
-				MACAddress:    "aa:bb:cc:dd:ee:f0",
-				Disabled:      false,
-				NoAutoStart:   false,
-				ConfigType:    network.ConfigDHCP,
-			},
-		}
+		info = []network.InterfaceInfo{{
+			DeviceIndex:   0,
+			ProviderId:    network.Id("dummy-eth0"),
+			NetworkName:   "juju-public",
+			InterfaceName: "eth0",
+			MACAddress:    "aa:bb:cc:dd:ee:f0",
+			Disabled:      false,
+			NoAutoStart:   false,
+			ConfigType:    network.ConfigDHCP,
+		}}
 	}
 
 	estate.ops <- OpNetworkInterfaces{
@@ -1189,7 +1187,9 @@ func (env *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]netwo
 	if len(subnetIds) == 0 {
 		result = append([]network.SubnetInfo{}, allSubnets...)
 	}
-	if strings.HasPrefix(string(instId), "i-no-subnets-") || strings.HasPrefix(string(instId), "i-nic-no-subnet-") {
+	noSubnets := strings.HasPrefix(string(instId), "i-no-subnets")
+	noNICSubnets := strings.HasPrefix(string(instId), "i-nic-no-subnet-")
+	if noSubnets || noNICSubnets {
 		// Simulate no subnets available if the instance id has prefix
 		// "i-no-subnets-".
 		result = result[:0]

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1098,7 +1098,7 @@ func (env *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceIn
 	// and gateway.
 	info := make([]network.InterfaceInfo, 2)
 	for i, netName := range []string{"private", "public"} {
-		iface := network.InterfaceInfo{
+		info[i] = network.InterfaceInfo{
 			DeviceIndex:      i,
 			ProviderId:       network.Id(fmt.Sprintf("dummy-eth%d", i)),
 			ProviderSubnetId: network.Id("dummy-" + netName),
@@ -1120,7 +1120,6 @@ func (env *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceIn
 				network.ScopeUnknown,
 			),
 		}
-		info[i] = iface
 	}
 
 	if strings.HasPrefix(string(instId), "i-no-nics-") {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -289,18 +289,16 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 
 	// Test that with instance id prefix "i-nic-no-subnet-" we get a result
 	// with no associated subnet.
-	expectInfo = []network.InterfaceInfo{
-		{
-			DeviceIndex:   0,
-			ProviderId:    network.Id("dummy-eth0"),
-			NetworkName:   "juju-public",
-			InterfaceName: "eth0",
-			MACAddress:    "aa:bb:cc:dd:ee:f0",
-			Disabled:      false,
-			NoAutoStart:   false,
-			ConfigType:    network.ConfigDHCP,
-		},
-	}
+	expectInfo = []network.InterfaceInfo{{
+		DeviceIndex:   0,
+		ProviderId:    network.Id("dummy-eth0"),
+		NetworkName:   "juju-public",
+		InterfaceName: "eth0",
+		MACAddress:    "aa:bb:cc:dd:ee:f0",
+		Disabled:      false,
+		NoAutoStart:   false,
+		ConfigType:    network.ConfigDHCP,
+	}}
 	info, err = e.NetworkInterfaces("i-nic-no-subnet-here")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, gc.HasLen, 1)

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -287,6 +287,25 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 	c.Assert(info, gc.HasLen, 0)
 	assertInterfaces(c, e, opc, "i-no-nics-here", expectInfo[:0])
 
+	// Test that with instance id prefix "i-nic-no-subnet-" we get a result
+	// with no associated subnet.
+	expectInfo = []network.InterfaceInfo{
+		{
+			DeviceIndex:   0,
+			ProviderId:    network.Id("dummy-eth0"),
+			NetworkName:   "juju-public",
+			InterfaceName: "eth0",
+			MACAddress:    "aa:bb:cc:dd:ee:f0",
+			Disabled:      false,
+			NoAutoStart:   false,
+			ConfigType:    network.ConfigDHCP,
+		},
+	}
+	info, err = e.NetworkInterfaces("i-nic-no-subnet-here")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, gc.HasLen, 1)
+	assertInterfaces(c, e, opc, "i-nic-no-subnet-here", expectInfo)
+
 	// Test we can induce errors.
 	s.breakMethods(c, e, "NetworkInterfaces")
 	info, err = e.NetworkInterfaces("i-any")
@@ -347,12 +366,15 @@ func (s *suite) TestSubnets(c *gc.C) {
 	c.Assert(netInfo, jc.DeepEquals, expectInfo[1:])
 	assertSubnets(c, e, opc, "i-foo", ids[1:], expectInfo[1:])
 
-	// Test that using an instance id with prefix "i-no-subnets-"
+	// Test that using an instance id with prefix of either
+	// "i-no-subnets-" or "i-nic-no-subnet-"
 	// returns no results, regardless whether ids are given or not.
-	netInfo, err = e.Subnets("i-no-subnets-foo", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(netInfo, gc.HasLen, 0)
-	assertSubnets(c, e, opc, "i-no-subnets-foo", nil, expectInfo[:0])
+	for _, instId := range []instance.Id{"i-no-subnets-foo", "i-nic-no-subnet-foo"} {
+		netInfo, err = e.Subnets(instId, nil)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(netInfo, gc.HasLen, 0)
+		assertSubnets(c, e, opc, instId, nil, expectInfo[:0])
+	}
 
 	netInfo, err = e.Subnets("i-no-subnets-foo", ids)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
The maas implementation of NetworkInterfaces can have interfaces with no associated subnet. This used to cause the provisioner to call environ.Subnet with an empty id, which would fail.

(Review request: http://reviews.vapour.ws/r/1306/)