### PR TITLE
Use the new charmstore API v4.

### DIFF
--- a/apiserver/charmrevisionupdater/testing/suite.go
+++ b/apiserver/charmrevisionupdater/testing/suite.go
@@ -10,60 +10,60 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5-unstable"
 	"gopkg.in/juju/charm.v5-unstable/charmrepo"
-	charmtesting "gopkg.in/juju/charm.v5-unstable/testing"
 	"gopkg.in/juju/charmstore.v4"
+	charmstoretesting "gopkg.in/juju/charmstore.v4/testing"
 
+	"github.com/juju/juju/apiserver/charmrevisionupdater"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 )
 
-// TODO frankban: this is done so that transitive testing dependencies are
-// included in the dependency file by godeps. We will use charmstore.NewServer
-// soon, but for the time being, this allows godeps to work properly.
-var _ = charmstore.NewServer
-
 // CharmSuite provides infrastructure to set up and perform tests associated
-// with charm versioning. A mock charm store is created using some known charms
-// used for testing.
+// with charm versioning. A testing charm store server is created and populated
+// with some known charms used for testing.
 type CharmSuite struct {
 	jcSuite *jujutesting.JujuConnSuite
 
-	Server *charmtesting.MockStore
+	Server *charmstoretesting.Server
 	charms map[string]*state.Charm
 }
 
 func (s *CharmSuite) SetUpSuite(c *gc.C, jcSuite *jujutesting.JujuConnSuite) {
 	s.jcSuite = jcSuite
-	s.Server = charmtesting.NewMockStore(c, testcharms.Repo, map[string]int{
-		"cs:quantal/mysql":     23,
-		"cs:quantal/dummy":     24,
-		"cs:quantal/riak":      25,
-		"cs:quantal/wordpress": 26,
-		"cs:quantal/logging":   27,
-		"cs:quantal/borken":    28,
-	})
 }
 
-func (s *CharmSuite) TearDownSuite(c *gc.C) {
-	s.Server.Close()
-}
+func (s *CharmSuite) TearDownSuite(c *gc.C) {}
 
 func (s *CharmSuite) SetUpTest(c *gc.C) {
+	s.Server = charmstoretesting.OpenServer(c, s.jcSuite.Session, charmstore.ServerParams{
+		AuthUsername: "test-user",
+		AuthPassword: "test-password",
+	})
+	urls := []string{
+		"~who/quantal/mysql-23",
+		"~who/quantal/dummy-24",
+		"~who/quantal/riak-25",
+		"~who/quantal/wordpress-26",
+		"~who/quantal/logging-27",
+	}
+	for _, url := range urls {
+		id := charm.MustParseReference(url)
+		ch := testcharms.Repo.CharmArchive(c.MkDir(), id.Name)
+		s.Server.UploadCharm(c, ch, id, true)
+	}
 	s.jcSuite.PatchValue(&charmrepo.CacheDir, c.MkDir())
-	s.jcSuite.PatchValue(&charmrepo.LegacyStore, &charmrepo.LegacyCharmStore{BaseURL: s.Server.Address()})
-	s.Server.Downloads = nil
-	s.Server.Authorizations = nil
-	s.Server.Metadata = nil
+	// Patch the charm repo initializer function: it is replaced with a charm
+	// store repo pointing to the testing server.
+	s.jcSuite.PatchValue(&charmrevisionupdater.NewCharmStore, func(p charmrepo.NewCharmStoreParams) charmrepo.Interface {
+		p.URL = s.Server.URL()
+		return charmrepo.NewCharmStore(p)
+	})
 	s.charms = make(map[string]*state.Charm)
 }
 
 func (s *CharmSuite) TearDownTest(c *gc.C) {
-}
-
-// UpdateStoreRevision sets the revision of the specified charm to rev.
-func (s *CharmSuite) UpdateStoreRevision(ch string, rev int) {
-	s.Server.UpdateStoreRevision(ch, rev)
+	s.Server.Close()
 }
 
 // AddMachine adds a new machine to state.

--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -94,6 +94,10 @@ func fetchAllDeployedCharms(st *state.State) (map[string]*charm.URL, error) {
 	return deployedCharms, nil
 }
 
+// NewCharmStore instantiates a new charm store repository.
+// It is defined at top level for testing purposes.
+var NewCharmStore = charmrepo.NewCharmStore
+
 // retrieveLatestCharmInfo looks up the charm store to return the charm URLs for the
 // latest revision of the deployed charms.
 func retrieveLatestCharmInfo(deployedCharms map[string]*charm.URL, uuid string) ([]*charm.URL, error) {
@@ -110,7 +114,8 @@ func retrieveLatestCharmInfo(deployedCharms map[string]*charm.URL, uuid string) 
 
 	// Do a bulk call to get the revision info for all charms.
 	logger.Infof("retrieving revision information for %d charms", len(curls))
-	revInfo, err := charmrepo.LegacyStore.Latest(curls...)
+	repo := NewCharmStore(charmrepo.NewCharmStoreParams{})
+	revInfo, err := repo.Latest(curls...)
 	if err != nil {
 		err = errors.Annotate(err, "finding charm revision info")
 		logger.Infof(err.Error())

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -266,9 +266,9 @@ func (c *Client) ServiceUnexpose(args params.ServiceUnexpose) error {
 	return svc.ClearExposed()
 }
 
-// charmStore gives access to the legacy charm store repository.
+// newCharmStore instantiates a new charm store repository.
 // It is defined at top level for testing purposes.
-var charmStore charmrepo.Interface = charmrepo.LegacyStore
+var newCharmStore = charmrepo.NewCharmStore
 
 func networkTagsToNames(tags []string) ([]string, error) {
 	netNames := make([]string, len(tags))
@@ -1259,10 +1259,12 @@ func (c *Client) AddCharm(args params.CharmURL) error {
 	if err != nil {
 		return err
 	}
-	repo := config.SpecializeCharmRepo(charmStore, envConfig)
+	repo := config.SpecializeCharmRepo(
+		newCharmStore(charmrepo.NewCharmStoreParams{}),
+		envConfig)
 	downloadedCharm, err := repo.Get(charmURL)
 	if err != nil {
-		return errors.Annotatef(err, "cannot download charm %q", charmURL.String())
+		return errors.Mask(err)
 	}
 
 	// Open it and calculate the SHA256 hash.
@@ -1334,7 +1336,9 @@ func (c *Client) ResolveCharms(args params.ResolveCharms) (params.ResolveCharmRe
 	if err != nil {
 		return params.ResolveCharmResults{}, err
 	}
-	repo := config.SpecializeCharmRepo(charmStore, envConfig)
+	repo := config.SpecializeCharmRepo(
+		newCharmStore(charmrepo.NewCharmStoreParams{}),
+		envConfig)
 
 	for _, ref := range args.References {
 		result := params.ResolveCharmResult{}

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5-unstable"
-	charmtesting "gopkg.in/juju/charm.v5-unstable/testing"
+	"gopkg.in/juju/charm.v5-unstable/charmrepo"
+	"gopkg.in/juju/charmstore.v4"
+	charmstoretesting "gopkg.in/juju/charmstore.v4/testing"
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/agent"
@@ -50,10 +52,6 @@ import (
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
 )
-
-type clientSuite struct {
-	baseSuite
-}
 
 type Killer interface {
 	Kill() error
@@ -559,6 +557,10 @@ func (s *serverSuite) TestBlockChangesAbortCurrentUpgrade(c *gc.C) {
 	s.setupAbortCurrentUpgradeBlocked(c)
 	s.BlockAllChanges(c, "TestBlockChangesAbortCurrentUpgrade")
 	s.assertAbortCurrentUpgradeBlocked(c, "TestBlockChangesAbortCurrentUpgrade")
+}
+
+type clientSuite struct {
+	baseSuite
 }
 
 var _ = gc.Suite(&clientSuite{})
@@ -1528,13 +1530,58 @@ func (s *clientSuite) TestBlockChangeUnitResolved(c *gc.C) {
 	s.assertResolvedBlocked(c, u, "TestBlockChangeUnitResolved")
 }
 
-func (s *clientSuite) TestClientServiceDeployCharmErrors(c *gc.C) {
-	s.makeMockCharmStore()
+type clientRepoSuite struct {
+	baseSuite
+	srv *charmstoretesting.Server
+}
+
+var _ = gc.Suite(&clientRepoSuite{})
+
+func (s *clientRepoSuite) SetUpTest(c *gc.C) {
+	s.baseSuite.SetUpTest(c)
+	s.srv = charmstoretesting.OpenServer(c, s.Session, charmstore.ServerParams{
+		AuthUsername: "test-user",
+		AuthPassword: "test-password",
+	})
+	s.PatchValue(&charmrepo.CacheDir, c.MkDir())
+	s.PatchValue(client.NewCharmStore, func(p charmrepo.NewCharmStoreParams) charmrepo.Interface {
+		p.URL = s.srv.URL()
+		return charmrepo.NewCharmStore(p)
+	})
+}
+
+func (s *clientRepoSuite) TearDownTest(c *gc.C) {
+	s.srv.Close()
+	s.baseSuite.TearDownTest(c)
+}
+
+func (s *clientRepoSuite) uploadCharm(c *gc.C, url, name string) (*charm.URL, charm.Charm) {
+	id := charm.MustParseReference(url)
+	promulgated := false
+	if id.User == "" {
+		id.User = "who"
+		promulgated = true
+	}
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), name)
+	id = s.srv.UploadCharm(c, ch, id, promulgated)
+	return (*charm.URL)(id), ch
+}
+
+func (s *clientRepoSuite) assertUploaded(c *gc.C, storage statestorage.Storage, storagePath, expectedSHA256 string) {
+	reader, _, err := storage.Get(storagePath)
+	c.Assert(err, jc.ErrorIsNil)
+	defer reader.Close()
+	downloadedSHA256, _, err := utils.ReadSHA256(reader)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(downloadedSHA256, gc.Equals, expectedSHA256)
+}
+
+func (s *clientRepoSuite) TestClientServiceDeployCharmErrors(c *gc.C) {
 	for url, expect := range map[string]string{
 		"wordpress":                   "charm url series is not resolved",
 		"cs:wordpress":                "charm url series is not resolved",
 		"cs:precise/wordpress":        "charm url must include revision",
-		"cs:precise/wordpress-999999": `cannot download charm ".*": charm not found in mock store: cs:precise/wordpress-999999`,
+		"cs:precise/wordpress-999999": `cannot retrieve charm "cs:precise/wordpress-999999": charm not found`,
 	} {
 		c.Logf("test %s", url)
 		err := s.APIState.Client().ServiceDeploy(
@@ -1546,9 +1593,8 @@ func (s *clientSuite) TestClientServiceDeployCharmErrors(c *gc.C) {
 	}
 }
 
-func (s *clientSuite) TestClientServiceDeployWithNetworks(c *gc.C) {
-	s.makeMockCharmStore()
-	curl, bundle := addCharm(c, "dummy")
+func (s *clientRepoSuite) TestClientServiceDeployWithNetworks(c *gc.C) {
+	curl, ch := s.uploadCharm(c, "precise/dummy-0", "dummy")
 	cons := constraints.MustParse("mem=4G networks=^net3")
 
 	// Check for invalid network tags handling.
@@ -1565,7 +1611,7 @@ func (s *clientSuite) TestClientServiceDeployWithNetworks(c *gc.C) {
 		nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	service := s.assertPrincipalDeployed(c, "service", curl, false, bundle, cons)
+	service := s.assertPrincipalDeployed(c, "service", curl, false, ch, cons)
 
 	networks, err := service.Networks()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1575,18 +1621,17 @@ func (s *clientSuite) TestClientServiceDeployWithNetworks(c *gc.C) {
 	c.Assert(serviceCons, gc.DeepEquals, cons)
 }
 
-func (s *clientSuite) TestClientServiceDeployWithStorage(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceDeployWithStorage(c *gc.C) {
 	s.setupStoragePool(c)
 	s.testClientServiceDeployWithStorage(c, true)
 }
 
-func (s *clientSuite) TestClientServiceDeployWithStorageWithoutFeature(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceDeployWithStorageWithoutFeature(c *gc.C) {
 	s.testClientServiceDeployWithStorage(c, false)
 }
 
-func (s *clientSuite) testClientServiceDeployWithStorage(c *gc.C, expectConstraints bool) {
-	s.makeMockCharmStore()
-	curl, bundle := addCharm(c, "storage-block")
+func (s *clientRepoSuite) testClientServiceDeployWithStorage(c *gc.C, expectConstraints bool) {
+	curl, ch := s.uploadCharm(c, "utopic/storage-block-10", "storage-block")
 	storageConstraints := map[string]storage.Constraints{
 		"data": {
 			Count: 1,
@@ -1601,7 +1646,7 @@ func (s *clientSuite) testClientServiceDeployWithStorage(c *gc.C, expectConstrai
 		storageConstraints,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	service := s.assertPrincipalDeployed(c, "service", curl, false, bundle, cons)
+	service := s.assertPrincipalDeployed(c, "service", curl, false, ch, cons)
 	storageConstraintsOut, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1618,10 +1663,9 @@ func (s *clientSuite) testClientServiceDeployWithStorage(c *gc.C, expectConstrai
 	}
 }
 
-func (s *clientSuite) TestClientServiceDeployWithInvalidStoragePool(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceDeployWithInvalidStoragePool(c *gc.C) {
 	s.setupStoragePool(c)
-	s.makeMockCharmStore()
-	curl, _ := addCharm(c, "storage-block")
+	curl, _ := s.uploadCharm(c, "utopic/storage-block-0", "storage-block")
 	storageConstraints := map[string]storage.Constraints{
 		"data": storage.Constraints{
 			Pool:  "foo",
@@ -1638,7 +1682,7 @@ func (s *clientSuite) TestClientServiceDeployWithInvalidStoragePool(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.* pool "foo" not found`)
 }
 
-func (s *clientSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C) {
 	s.SetFeatureFlags(feature.Storage)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	registry.RegisterProvider("hostloop", &mockStorageProvider{kind: storage.StorageKindBlock})
@@ -1646,8 +1690,7 @@ func (s *clientSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C)
 	_, err := pm.Create("host-loop-pool", provider.HostLoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.makeMockCharmStore()
-	curl, _ := addCharm(c, "storage-block")
+	curl, _ := s.uploadCharm(c, "utopic/storage-block-0", "storage-block")
 	storageConstraints := map[string]storage.Constraints{
 		"data": storage.Constraints{
 			Pool:  "host-loop-pool",
@@ -1666,14 +1709,13 @@ func (s *clientSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C)
 		`.*pool "host-loop-pool" uses storage provider "hostloop" which is not supported for environments of type "dummy"`)
 }
 
-func (s *clientSuite) TestClientServiceDeployDefaultFilesystemStorage(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceDeployDefaultFilesystemStorage(c *gc.C) {
 	s.setupStoragePool(c)
-	s.makeMockCharmStore()
-	curl, bundle := addCharm(c, "storage-filesystem")
+	curl, ch := s.uploadCharm(c, "trusty/storage-filesystem-1", "storage-filesystem")
 	var cons constraints.Value
 	err := s.APIState.Client().ServiceDeployWithNetworks(curl.String(), "service", 1, "", cons, "", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	service := s.assertPrincipalDeployed(c, "service", curl, false, bundle, cons)
+	service := s.assertPrincipalDeployed(c, "service", curl, false, ch, cons)
 	storageConstraintsOut, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
@@ -1685,21 +1727,20 @@ func (s *clientSuite) TestClientServiceDeployDefaultFilesystemStorage(c *gc.C) {
 	})
 }
 
-func (s *clientSuite) setupServiceDeploy(c *gc.C, args string) (*charm.URL, charm.Charm, constraints.Value) {
-	s.makeMockCharmStore()
-	curl, bundle := addCharm(c, "dummy")
+func (s *clientRepoSuite) setupServiceDeploy(c *gc.C, args string) (*charm.URL, charm.Charm, constraints.Value) {
+	curl, ch := s.uploadCharm(c, "precise/dummy-42", "dummy")
 	cons := constraints.MustParse(args)
-	return curl, bundle, cons
+	return curl, ch, cons
 }
 
-func (s *clientSuite) assertServiceDeployWithNetworks(c *gc.C, curl *charm.URL, bundle charm.Charm, cons constraints.Value) {
+func (s *clientRepoSuite) assertServiceDeployWithNetworks(c *gc.C, curl *charm.URL, ch charm.Charm, cons constraints.Value) {
 	err := s.APIState.Client().ServiceDeployWithNetworks(
 		curl.String(), "service", 3, "", cons, "",
 		[]string{"network-net1", "network-net2"},
 		nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	service := s.assertPrincipalDeployed(c, "service", curl, false, bundle, cons)
+	service := s.assertPrincipalDeployed(c, "service", curl, false, ch, cons)
 	networks, err := service.Networks()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(networks, gc.DeepEquals, []string{"net1", "net2"})
@@ -1708,7 +1749,7 @@ func (s *clientSuite) assertServiceDeployWithNetworks(c *gc.C, curl *charm.URL, 
 	c.Assert(serviceCons, gc.DeepEquals, cons)
 }
 
-func (s *clientSuite) assertServiceDeployWithNetworksBlocked(c *gc.C, msg string, curl *charm.URL, bundle charm.Charm, cons constraints.Value) {
+func (s *clientRepoSuite) assertServiceDeployWithNetworksBlocked(c *gc.C, msg string, curl *charm.URL, cons constraints.Value) {
 	err := s.APIState.Client().ServiceDeployWithNetworks(
 		curl.String(), "service", 3, "", cons, "",
 		[]string{"network-net1", "network-net2"},
@@ -1717,25 +1758,25 @@ func (s *clientSuite) assertServiceDeployWithNetworksBlocked(c *gc.C, msg string
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *clientSuite) TestBlockDestroyServiceDeployWithNetworks(c *gc.C) {
-	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
+func (s *clientRepoSuite) TestBlockDestroyServiceDeployWithNetworks(c *gc.C) {
+	curl, ch, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
 	s.BlockDestroyEnvironment(c, "TestBlockDestroyServiceDeployWithNetworks")
-	s.assertServiceDeployWithNetworks(c, curl, bundle, cons)
+	s.assertServiceDeployWithNetworks(c, curl, ch, cons)
 }
 
-func (s *clientSuite) TestBlockRemoveServiceDeployWithNetworks(c *gc.C) {
-	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
+func (s *clientRepoSuite) TestBlockRemoveServiceDeployWithNetworks(c *gc.C) {
+	curl, ch, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
 	s.BlockRemoveObject(c, "TestBlockRemoveServiceDeployWithNetworks")
-	s.assertServiceDeployWithNetworks(c, curl, bundle, cons)
+	s.assertServiceDeployWithNetworks(c, curl, ch, cons)
 }
 
-func (s *clientSuite) TestBlockChangeServiceDeployWithNetworks(c *gc.C) {
-	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
+func (s *clientRepoSuite) TestBlockChangeServiceDeployWithNetworks(c *gc.C) {
+	curl, _, cons := s.setupServiceDeploy(c, "mem=4G networks=^net3")
 	s.BlockAllChanges(c, "TestBlockChangeServiceDeployWithNetworks")
-	s.assertServiceDeployWithNetworksBlocked(c, "TestBlockChangeServiceDeployWithNetworks", curl, bundle, cons)
+	s.assertServiceDeployWithNetworksBlocked(c, "TestBlockChangeServiceDeployWithNetworks", curl, cons)
 }
 
-func (s *clientSuite) assertPrincipalDeployed(c *gc.C, serviceName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Service {
+func (s *clientRepoSuite) assertPrincipalDeployed(c *gc.C, serviceName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Service {
 	service, err := s.State.Service(serviceName)
 	c.Assert(err, jc.ErrorIsNil)
 	charm, force, err := service.Charm()
@@ -1772,55 +1813,53 @@ func (s *clientSuite) assertPrincipalDeployed(c *gc.C, serviceName string, curl 
 	return service
 }
 
-func (s *clientSuite) TestClientServiceDeployPrincipal(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceDeployPrincipal(c *gc.C) {
 	// TODO(fwereade): test ToMachineSpec directly on srvClient, when we
 	// manage to extract it as a package and can thus do it conveniently.
-	s.makeMockCharmStore()
-	curl, bundle := addCharm(c, "dummy")
+	curl, ch := s.uploadCharm(c, "trusty/dummy-1", "dummy")
 	mem4g := constraints.MustParse("mem=4G")
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service", 3, "", mem4g, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertPrincipalDeployed(c, "service", curl, false, bundle, mem4g)
+	s.assertPrincipalDeployed(c, "service", curl, false, ch, mem4g)
 }
 
-func (s *clientSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, bundle charm.Charm, mem4g constraints.Value) {
+func (s *clientRepoSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, ch charm.Charm, mem4g constraints.Value) {
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service", 3, "", mem4g, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertPrincipalDeployed(c, "service", curl, false, bundle, mem4g)
+	s.assertPrincipalDeployed(c, "service", curl, false, ch, mem4g)
 }
 
-func (s *clientSuite) assertServiceDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, bundle charm.Charm, mem4g constraints.Value) {
+func (s *clientRepoSuite) assertServiceDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, mem4g constraints.Value) {
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service", 3, "", mem4g, "",
 	)
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *clientSuite) TestBlockDestroyServiceDeployPrincipal(c *gc.C) {
+func (s *clientRepoSuite) TestBlockDestroyServiceDeployPrincipal(c *gc.C) {
 	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G")
 	s.BlockDestroyEnvironment(c, "TestBlockDestroyServiceDeployPrincipal")
 	s.assertServiceDeployPrincipal(c, curl, bundle, cons)
 }
 
-func (s *clientSuite) TestBlockRemoveServiceDeployPrincipal(c *gc.C) {
+func (s *clientRepoSuite) TestBlockRemoveServiceDeployPrincipal(c *gc.C) {
 	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G")
 	s.BlockRemoveObject(c, "TestBlockRemoveServiceDeployPrincipal")
 	s.assertServiceDeployPrincipal(c, curl, bundle, cons)
 }
 
-func (s *clientSuite) TestBlockChangesServiceDeployPrincipal(c *gc.C) {
-	curl, bundle, cons := s.setupServiceDeploy(c, "mem=4G")
+func (s *clientRepoSuite) TestBlockChangesServiceDeployPrincipal(c *gc.C) {
+	curl, _, cons := s.setupServiceDeploy(c, "mem=4G")
 	s.BlockAllChanges(c, "TestBlockChangesServiceDeployPrincipal")
-	s.assertServiceDeployPrincipalBlocked(c, "TestBlockChangesServiceDeployPrincipal", curl, bundle, cons)
+	s.assertServiceDeployPrincipalBlocked(c, "TestBlockChangesServiceDeployPrincipal", curl, cons)
 }
 
-func (s *clientSuite) TestClientServiceDeploySubordinate(c *gc.C) {
-	s.makeMockCharmStore()
-	curl, bundle := addCharm(c, "logging")
+func (s *clientRepoSuite) TestClientServiceDeploySubordinate(c *gc.C) {
+	curl, ch := s.uploadCharm(c, "utopic/logging-47", "logging")
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service-name", 0, "", constraints.Value{}, "",
 	)
@@ -1830,19 +1869,18 @@ func (s *clientSuite) TestClientServiceDeploySubordinate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(force, jc.IsFalse)
 	c.Assert(charm.URL(), gc.DeepEquals, curl)
-	c.Assert(charm.Meta(), gc.DeepEquals, bundle.Meta())
-	c.Assert(charm.Config(), gc.DeepEquals, bundle.Config())
+	c.Assert(charm.Meta(), gc.DeepEquals, ch.Meta())
+	c.Assert(charm.Config(), gc.DeepEquals, ch.Config())
 
 	units, err := service.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 0)
 }
 
-func (s *clientSuite) TestClientServiceDeployConfig(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceDeployConfig(c *gc.C) {
 	// TODO(fwereade): test Config/ConfigYAML handling directly on srvClient.
 	// Can't be done cleanly until it's extracted similarly to Machiner.
-	s.makeMockCharmStore()
-	curl, _ := addCharm(c, "dummy")
+	curl, _ := s.uploadCharm(c, "precise/dummy-0", "dummy")
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service-name", 1, "service-name:\n  username: fred", constraints.Value{}, "",
 	)
@@ -1854,11 +1892,10 @@ func (s *clientSuite) TestClientServiceDeployConfig(c *gc.C) {
 	c.Assert(settings, gc.DeepEquals, charm.Settings{"username": "fred"})
 }
 
-func (s *clientSuite) TestClientServiceDeployConfigError(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceDeployConfigError(c *gc.C) {
 	// TODO(fwereade): test Config/ConfigYAML handling directly on srvClient.
 	// Can't be done cleanly until it's extracted similarly to Machiner.
-	s.makeMockCharmStore()
-	curl, _ := addCharm(c, "dummy")
+	curl, _ := s.uploadCharm(c, "precise/dummy-0", "dummy")
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service-name", 1, "service-name:\n  skill-level: fred", constraints.Value{}, "",
 	)
@@ -1867,9 +1904,8 @@ func (s *clientSuite) TestClientServiceDeployConfigError(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *clientSuite) TestClientServiceDeployToMachine(c *gc.C) {
-	s.makeMockCharmStore()
-	curl, bundle := addCharm(c, "dummy")
+func (s *clientRepoSuite) TestClientServiceDeployToMachine(c *gc.C) {
+	curl, ch := s.uploadCharm(c, "precise/dummy-0", "dummy")
 
 	machine, err := s.State.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1884,8 +1920,8 @@ func (s *clientSuite) TestClientServiceDeployToMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(force, jc.IsFalse)
 	c.Assert(charm.URL(), gc.DeepEquals, curl)
-	c.Assert(charm.Meta(), gc.DeepEquals, bundle.Meta())
-	c.Assert(charm.Config(), gc.DeepEquals, bundle.Config())
+	c.Assert(charm.Meta(), gc.DeepEquals, ch.Meta())
+	c.Assert(charm.Config(), gc.DeepEquals, ch.Config())
 
 	units, err := service.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1905,9 +1941,8 @@ func (s *clientSuite) TestClientServiceDeployToMachineNotFound(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `service "service-name" not found`)
 }
 
-func (s *clientSuite) TestClientServiceDeployServiceOwner(c *gc.C) {
-	s.makeMockCharmStore()
-	curl, _ := addCharm(c, "dummy")
+func (s *clientRepoSuite) TestClientServiceDeployServiceOwner(c *gc.C) {
+	curl, _ := s.uploadCharm(c, "precise/dummy-0", "dummy")
 
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "password"})
 	s.APIState = s.OpenAPIAs(c, user.Tag(), "password")
@@ -1922,18 +1957,17 @@ func (s *clientSuite) TestClientServiceDeployServiceOwner(c *gc.C) {
 	c.Assert(service.GetOwnerTag(), gc.Equals, user.Tag().String())
 }
 
-func (s *clientSuite) deployServiceForTests(c *gc.C) {
-	curl, _ := addCharm(c, "dummy")
+func (s *clientRepoSuite) deployServiceForTests(c *gc.C) {
+	curl, _ := s.uploadCharm(c, "precise/dummy-1", "dummy")
 	err := s.APIState.Client().ServiceDeploy(curl.String(),
 		"service", 1, "", constraints.Value{}, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *clientSuite) checkClientServiceUpdateSetCharm(c *gc.C, forceCharmUrl bool) {
-	s.makeMockCharmStore()
+func (s *clientRepoSuite) checkClientServiceUpdateSetCharm(c *gc.C, forceCharmUrl bool) {
 	s.deployServiceForTests(c)
-	addCharm(c, "wordpress")
+	s.uploadCharm(c, "precise/wordpress-3", "wordpress")
 
 	// Update the charm for the service.
 	args := params.ServiceUpdate{
@@ -1953,27 +1987,26 @@ func (s *clientSuite) checkClientServiceUpdateSetCharm(c *gc.C, forceCharmUrl bo
 	c.Assert(force, gc.Equals, forceCharmUrl)
 }
 
-func (s *clientSuite) TestClientServiceUpdateSetCharm(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceUpdateSetCharm(c *gc.C) {
 	s.checkClientServiceUpdateSetCharm(c, false)
 }
 
-func (s *clientSuite) TestBlockDestroyServiceUpdate(c *gc.C) {
+func (s *clientRepoSuite) TestBlockDestroyServiceUpdate(c *gc.C) {
 	s.BlockDestroyEnvironment(c, "TestBlockDestroyServiceUpdate")
 	s.checkClientServiceUpdateSetCharm(c, false)
 }
 
-func (s *clientSuite) TestBlockRemoveServiceUpdate(c *gc.C) {
+func (s *clientRepoSuite) TestBlockRemoveServiceUpdate(c *gc.C) {
 	s.BlockRemoveObject(c, "TestBlockRemoveServiceUpdate")
 	s.checkClientServiceUpdateSetCharm(c, false)
 }
 
-func (s *clientSuite) setupServiceUpdate(c *gc.C) {
-	s.makeMockCharmStore()
+func (s *clientRepoSuite) setupServiceUpdate(c *gc.C) {
 	s.deployServiceForTests(c)
-	addCharm(c, "wordpress")
+	s.uploadCharm(c, "precise/wordpress-3", "wordpress")
 }
 
-func (s *clientSuite) TestBlockChangeServiceUpdate(c *gc.C) {
+func (s *clientRepoSuite) TestBlockChangeServiceUpdate(c *gc.C) {
 	s.setupServiceUpdate(c)
 	s.BlockAllChanges(c, "TestBlockChangeServiceUpdate")
 	// Update the charm for the service.
@@ -1986,11 +2019,11 @@ func (s *clientSuite) TestBlockChangeServiceUpdate(c *gc.C) {
 	s.AssertBlocked(c, err, "TestBlockChangeServiceUpdate")
 }
 
-func (s *clientSuite) TestClientServiceUpdateForceSetCharm(c *gc.C) {
+func (s *clientRepoSuite) TestClientServiceUpdateForceSetCharm(c *gc.C) {
 	s.checkClientServiceUpdateSetCharm(c, true)
 }
 
-func (s *clientSuite) TestBlockServiceUpdateForced(c *gc.C) {
+func (s *clientRepoSuite) TestBlockServiceUpdateForced(c *gc.C) {
 	s.setupServiceUpdate(c)
 
 	// block all changes. Force should ignore block :)
@@ -2016,14 +2049,13 @@ func (s *clientSuite) TestBlockServiceUpdateForced(c *gc.C) {
 	c.Assert(force, jc.IsTrue)
 }
 
-func (s *clientSuite) TestClientServiceUpdateSetCharmErrors(c *gc.C) {
-	s.makeMockCharmStore()
+func (s *clientRepoSuite) TestClientServiceUpdateSetCharmErrors(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	for charmUrl, expect := range map[string]string{
 		"wordpress":                   "charm url series is not resolved",
 		"cs:wordpress":                "charm url series is not resolved",
 		"cs:precise/wordpress":        "charm url must include revision",
-		"cs:precise/wordpress-999999": `cannot download charm ".*": charm not found in mock store: cs:precise/wordpress-999999`,
+		"cs:precise/wordpress-999999": `cannot retrieve charm "cs:precise/wordpress-999999": charm not found`,
 	} {
 		c.Logf("test %s", charmUrl)
 		args := params.ServiceUpdate{
@@ -2125,10 +2157,9 @@ func (s *clientSuite) TestClientServiceUpdateSetConstraints(c *gc.C) {
 	c.Assert(obtained, gc.DeepEquals, cons)
 }
 
-func (s *clientSuite) TestClientServiceUpdateAllParams(c *gc.C) {
-	s.makeMockCharmStore()
+func (s *clientRepoSuite) TestClientServiceUpdateAllParams(c *gc.C) {
 	s.deployServiceForTests(c)
-	addCharm(c, "wordpress")
+	s.uploadCharm(c, "precise/wordpress-3", "wordpress")
 
 	// Update all the service attributes.
 	minUnits := 3
@@ -2192,14 +2223,13 @@ func (s *clientSuite) TestClientServiceUpdateInvalidService(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `service "no-such-service" not found`)
 }
 
-func (s *clientSuite) TestClientServiceSetCharm(c *gc.C) {
-	s.makeMockCharmStore()
-	curl, _ := addCharm(c, "dummy")
+func (s *clientRepoSuite) TestClientServiceSetCharm(c *gc.C) {
+	curl, _ := s.uploadCharm(c, "precise/dummy-0", "dummy")
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service", 3, "", constraints.Value{}, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	addCharm(c, "wordpress")
+	s.uploadCharm(c, "precise/wordpress-3", "wordpress")
 	err = s.APIState.Client().ServiceSetCharm(
 		"service", "cs:precise/wordpress-3", false,
 	)
@@ -2214,17 +2244,16 @@ func (s *clientSuite) TestClientServiceSetCharm(c *gc.C) {
 	c.Assert(force, jc.IsFalse)
 }
 
-func (s *clientSuite) setupServiceSetCharm(c *gc.C) {
-	s.makeMockCharmStore()
-	curl, _ := addCharm(c, "dummy")
+func (s *clientRepoSuite) setupServiceSetCharm(c *gc.C) {
+	curl, _ := s.uploadCharm(c, "precise/dummy-0", "dummy")
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service", 3, "", constraints.Value{}, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	addCharm(c, "wordpress")
+	s.uploadCharm(c, "precise/wordpress-3", "wordpress")
 }
 
-func (s *clientSuite) assertServiceSetCharm(c *gc.C, force bool) {
+func (s *clientRepoSuite) assertServiceSetCharm(c *gc.C, force bool) {
 	err := s.APIState.Client().ServiceSetCharm(
 		"service", "cs:precise/wordpress-3", force,
 	)
@@ -2237,39 +2266,38 @@ func (s *clientSuite) assertServiceSetCharm(c *gc.C, force bool) {
 	c.Assert(charm.URL().String(), gc.Equals, "cs:precise/wordpress-3")
 }
 
-func (s *clientSuite) assertServiceSetCharmBlocked(c *gc.C, force bool, msg string) {
+func (s *clientRepoSuite) assertServiceSetCharmBlocked(c *gc.C, force bool, msg string) {
 	err := s.APIState.Client().ServiceSetCharm(
 		"service", "cs:precise/wordpress-3", force,
 	)
 	s.AssertBlocked(c, err, msg)
 }
 
-func (s *clientSuite) TestBlockDestroyServiceSetCharm(c *gc.C) {
+func (s *clientRepoSuite) TestBlockDestroyServiceSetCharm(c *gc.C) {
 	s.setupServiceSetCharm(c)
 	s.BlockDestroyEnvironment(c, "TestBlockDestroyServiceSetCharm")
 	s.assertServiceSetCharm(c, false)
 }
 
-func (s *clientSuite) TestBlockRemoveServiceSetCharm(c *gc.C) {
+func (s *clientRepoSuite) TestBlockRemoveServiceSetCharm(c *gc.C) {
 	s.setupServiceSetCharm(c)
 	s.BlockRemoveObject(c, "TestBlockRemoveServiceSetCharm")
 	s.assertServiceSetCharm(c, false)
 }
 
-func (s *clientSuite) TestBlockChangesServiceSetCharm(c *gc.C) {
+func (s *clientRepoSuite) TestBlockChangesServiceSetCharm(c *gc.C) {
 	s.setupServiceSetCharm(c)
 	s.BlockAllChanges(c, "TestBlockChangesServiceSetCharm")
 	s.assertServiceSetCharmBlocked(c, false, "TestBlockChangesServiceSetCharm")
 }
 
-func (s *clientSuite) TestClientServiceSetCharmForce(c *gc.C) {
-	s.makeMockCharmStore()
-	curl, _ := addCharm(c, "dummy")
+func (s *clientRepoSuite) TestClientServiceSetCharmForce(c *gc.C) {
+	curl, _ := s.uploadCharm(c, "precise/dummy-0", "dummy")
 	err := s.APIState.Client().ServiceDeploy(
 		curl.String(), "service", 3, "", constraints.Value{}, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	addCharm(c, "wordpress")
+	s.uploadCharm(c, "precise/wordpress-3", "wordpress")
 	err = s.APIState.Client().ServiceSetCharm(
 		"service", "cs:precise/wordpress-3", true,
 	)
@@ -2284,7 +2312,7 @@ func (s *clientSuite) TestClientServiceSetCharmForce(c *gc.C) {
 	c.Assert(force, jc.IsTrue)
 }
 
-func (s *clientSuite) TestBlockServiceSetCharmForce(c *gc.C) {
+func (s *clientRepoSuite) TestBlockServiceSetCharmForce(c *gc.C) {
 	s.setupServiceSetCharm(c)
 
 	// block all changes
@@ -2296,22 +2324,20 @@ func (s *clientSuite) TestBlockServiceSetCharmForce(c *gc.C) {
 }
 
 func (s *clientSuite) TestClientServiceSetCharmInvalidService(c *gc.C) {
-	s.makeMockCharmStore()
 	err := s.APIState.Client().ServiceSetCharm(
 		"badservice", "cs:precise/wordpress-3", true,
 	)
 	c.Assert(err, gc.ErrorMatches, `service "badservice" not found`)
 }
 
-func (s *clientSuite) TestClientServiceSetCharmErrors(c *gc.C) {
-	s.makeMockCharmStore()
+func (s *clientRepoSuite) TestClientServiceSetCharmErrors(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	for url, expect := range map[string]string{
 		// TODO(fwereade,Makyo) make these errors consistent one day.
 		"wordpress":                   "charm url series is not resolved",
 		"cs:wordpress":                "charm url series is not resolved",
 		"cs:precise/wordpress":        "charm url must include revision",
-		"cs:precise/wordpress-999999": `cannot download charm ".*": charm not found in mock store: cs:precise/wordpress-999999`,
+		"cs:precise/wordpress-999999": `cannot retrieve charm "cs:precise/wordpress-999999": charm not found`,
 	} {
 		c.Logf("test %s", url)
 		err := s.APIState.Client().ServiceSetCharm(
@@ -2319,25 +2345,6 @@ func (s *clientSuite) TestClientServiceSetCharmErrors(c *gc.C) {
 		)
 		c.Check(err, gc.ErrorMatches, expect)
 	}
-}
-
-func (s *clientSuite) makeMockCharmStore() (store *charmtesting.MockCharmStore) {
-	mockStore := charmtesting.NewMockCharmStore()
-	s.PatchValue(client.CharmStore, mockStore)
-	return mockStore
-}
-
-func addCharm(c *gc.C, name string) (*charm.URL, charm.Charm) {
-	return addSeriesCharm(c, "precise", name)
-}
-
-func addSeriesCharm(c *gc.C, series, name string) (*charm.URL, charm.Charm) {
-	bundle := testcharms.Repo.CharmArchive(c.MkDir(), name)
-	scurl := fmt.Sprintf("cs:%s/%s-%d", series, name, bundle.Revision())
-	curl := charm.MustParseURL(scurl)
-	err := (*client.CharmStore).(*charmtesting.MockCharmStore).SetCharm(curl, bundle)
-	c.Assert(err, jc.ErrorIsNil)
-	return curl, bundle
 }
 
 func (s *clientSuite) checkEndpoints(c *gc.C, endpoints map[string]charm.Relation) {
@@ -3081,18 +3088,6 @@ func (s *clientSuite) TestClientAddMachinesWithPlacement(c *gc.C) {
 	c.Assert(m.Placement(), gc.DeepEquals, apiParams[3].Placement.Directive)
 }
 
-func (s *clientSuite) setupStoragePool(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	pm := poolmanager.New(state.NewStateSettings(s.State))
-	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.UpdateEnvironConfig(map[string]interface{}{
-		"storage-default-block-source": "loop-pool",
-	}, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *clientSuite) TestClientAddMachinesWithDisks(c *gc.C) {
 	s.setupStoragePool(c)
 	apiParams := make([]params.AddMachineParams, 5)
@@ -3405,36 +3400,50 @@ func (s *clientSuite) TestProvisioningScriptDisablePackageCommands(c *gc.C) {
 	c.Check(script, gc.Not(jc.Contains), "apt-get upgrade")
 }
 
-func (s *clientSuite) TestClientSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *gc.C) {
-	store := s.makeMockCharmStore()
+type testModeCharmRepo struct {
+	*charmrepo.CharmStore
+	testMode bool
+}
+
+// WithTestMode returns a repository Interface where test mode is enabled.
+func (s *testModeCharmRepo) WithTestMode() charmrepo.Interface {
+	s.testMode = true
+	return s.CharmStore.WithTestMode()
+}
+
+func (s *clientRepoSuite) TestClientSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *gc.C) {
+	repo := &testModeCharmRepo{}
+	s.PatchValue(client.NewCharmStore, func(p charmrepo.NewCharmStoreParams) charmrepo.Interface {
+		p.URL = s.srv.URL()
+		repo.CharmStore = charmrepo.NewCharmStore(p).(*charmrepo.CharmStore)
+		return repo
+	})
 	attrs := map[string]interface{}{"test-mode": true}
 	err := s.State.UpdateEnvironConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that the store's test mode is enabled when calling ServiceDeploy.
-	curl, _ := addCharm(c, "dummy")
+	curl, _ := s.uploadCharm(c, "trusty/dummy-1", "dummy")
 	err = s.APIState.Client().ServiceDeploy(
 		curl.String(), "service", 3, "", constraints.Value{}, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(store.TestMode(), jc.IsTrue)
+	c.Assert(repo.testMode, jc.IsTrue)
 
 	// Check that the store's test mode is enabled when calling ServiceSetCharm.
-	curl, _ = addCharm(c, "wordpress")
+	curl, _ = s.uploadCharm(c, "trusty/wordpress-2", "wordpress")
 	err = s.APIState.Client().ServiceSetCharm(
 		"service", curl.String(), false,
 	)
-	c.Assert(store.TestMode(), jc.IsTrue)
+	c.Assert(repo.testMode, jc.IsTrue)
 
 	// Check that the store's test mode is enabled when calling AddCharm.
-	curl, _ = addCharm(c, "riak")
+	curl, _ = s.uploadCharm(c, "utopic/riak-42", "riak")
 	err = s.APIState.Client().AddCharm(curl)
-	c.Assert(store.TestMode(), jc.IsTrue)
+	c.Assert(repo.testMode, jc.IsTrue)
 }
 
-func (s *clientSuite) TestAddCharm(c *gc.C) {
-	s.makeMockCharmStore()
-
+func (s *clientRepoSuite) TestAddCharm(c *gc.C) {
 	var blobs blobs
 	s.PatchValue(client.NewStateStorage, func(uuid string, session *mgo.Session) statestorage.Storage {
 		storage := statestorage.NewStorage(uuid, session)
@@ -3465,7 +3474,7 @@ func (s *clientSuite) TestAddCharm(c *gc.C) {
 	c.Assert(blobs.m, gc.HasLen, 0)
 
 	// Now try adding another charm completely.
-	curl, _ = addCharm(c, "wordpress")
+	curl, _ = s.uploadCharm(c, "precise/wordpress-3", "wordpress")
 	err = client.AddCharm(curl)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -3476,31 +3485,68 @@ func (s *clientSuite) TestAddCharm(c *gc.C) {
 	s.assertUploaded(c, storage, sch.StoragePath(), sch.BundleSha256())
 }
 
-var resolveCharmCases = []struct {
-	schema, defaultSeries, charmName string
-	parseErr                         string
-	resolveErr                       string
-}{
-	{"cs", "precise", "wordpress", "", ""},
-	{"cs", "trusty", "wordpress", "", ""},
-	{"cs", "", "wordpress", "", `charm url series is not resolved`},
-	{"cs", "trusty", "", `charm URL has invalid charm name: "cs:"`, ""},
-	{"local", "trusty", "wordpress", "", `only charm store charm references are supported, with cs: schema`},
-	{"cs", "precise", "hl3", "", ""},
-	{"cs", "trusty", "hl3", "", ""},
-	{"cs", "", "hl3", "", `charm url series is not resolved`},
-}
+var resolveCharmTests = []struct {
+	about      string
+	url        string
+	resolved   string
+	parseErr   string
+	resolveErr string
+}{{
+	about:    "wordpress resolved",
+	url:      "cs:wordpress",
+	resolved: "cs:trusty/wordpress",
+}, {
+	about:    "mysql resolved",
+	url:      "cs:mysql",
+	resolved: "cs:precise/mysql",
+}, {
+	about:    "riak resolved",
+	url:      "cs:riak",
+	resolved: "cs:trusty/riak",
+}, {
+	about:    "fully qualified char reference",
+	url:      "cs:utopic/riak-5",
+	resolved: "cs:utopic/riak-5",
+}, {
+	about:    "charm with series and no revision",
+	url:      "cs:precise/wordpress",
+	resolved: "cs:precise/wordpress",
+}, {
+	about:      "fully qualified reference not found",
+	url:        "cs:utopic/riak-42",
+	resolveErr: `cannot resolve charm URL "cs:utopic/riak-42": charm not found`,
+}, {
+	about:      "reference not found",
+	url:        "cs:no-such",
+	resolveErr: `cannot resolve charm URL "cs:no-such": charm not found`,
+}, {
+	about:    "invalid charm name",
+	url:      "cs:",
+	parseErr: `charm URL has invalid charm name: "cs:"`,
+}, {
+	about:      "local charm",
+	url:        "local:wordpress",
+	resolveErr: `only charm store charm references are supported, with cs: schema`,
+}}
 
-func (s *clientSuite) TestResolveCharm(c *gc.C) {
-	store := s.makeMockCharmStore()
+func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
+	// Add some charms to be resolved later.
+	for _, url := range []string{
+		"precise/wordpress-1",
+		"trusty/wordpress-2",
+		"precise/mysql-3",
+		"trusty/riak-4",
+		"utopic/riak-5",
+	} {
+		s.uploadCharm(c, url, "wordpress")
+	}
 
-	for i, test := range resolveCharmCases {
-		c.Logf("test %d: %#v", i, test)
-		// Mock charm store will use this to resolve a charm reference.
-		store.SetDefaultSeries(test.defaultSeries)
+	// Run the tests.
+	for i, test := range resolveCharmTests {
+		c.Logf("test %d: %s", i, test.about)
 
 		client := s.APIState.Client()
-		ref, err := charm.ParseReference(fmt.Sprintf("%s:%s", test.schema, test.charmName))
+		ref, err := charm.ParseReference(test.url)
 		if test.parseErr == "" {
 			if !c.Check(err, jc.ErrorIsNil) {
 				continue
@@ -3510,18 +3556,15 @@ func (s *clientSuite) TestResolveCharm(c *gc.C) {
 			c.Check(err, gc.ErrorMatches, test.parseErr)
 			continue
 		}
-		c.Check(ref.String(), gc.Equals, fmt.Sprintf("%s:%s", test.schema, test.charmName))
 
 		curl, err := client.ResolveCharm(ref)
-		if err == nil {
-			c.Assert(curl, gc.NotNil)
-			// Only cs: schema should make it through here
-			c.Check(curl.String(), gc.Equals, fmt.Sprintf("cs:%s/%s", test.defaultSeries, test.charmName))
-			c.Check(test.resolveErr, gc.Equals, "")
-		} else {
-			c.Check(curl, gc.IsNil)
-			c.Check(err, gc.ErrorMatches, test.resolveErr)
+		if test.resolveErr == "" {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(curl.String(), gc.Equals, test.resolved)
+			continue
 		}
+		c.Check(err, gc.ErrorMatches, test.resolveErr)
+		c.Check(curl, gc.IsNil)
 	}
 }
 
@@ -3580,9 +3623,7 @@ func (s *recordingStorage) Remove(path string) error {
 	return nil
 }
 
-func (s *clientSuite) TestAddCharmConcurrently(c *gc.C) {
-	s.makeMockCharmStore()
-
+func (s *clientRepoSuite) TestAddCharmConcurrently(c *gc.C) {
 	var putBarrier sync.WaitGroup
 	var blobs blobs
 	s.PatchValue(client.NewStateStorage, func(uuid string, session *mgo.Session) statestorage.Storage {
@@ -3591,7 +3632,7 @@ func (s *clientSuite) TestAddCharmConcurrently(c *gc.C) {
 	})
 
 	client := s.APIState.Client()
-	curl, _ := addCharm(c, "wordpress")
+	curl, _ := s.uploadCharm(c, "trusty/wordpress-3", "wordpress")
 
 	// Try adding the same charm concurrently from multiple goroutines
 	// to test no "duplicate key errors" are reported (see lp bug
@@ -3635,11 +3676,9 @@ func (s *clientSuite) TestAddCharmConcurrently(c *gc.C) {
 	s.assertUploaded(c, storage, sch.StoragePath(), sch.BundleSha256())
 }
 
-func (s *clientSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
-	s.makeMockCharmStore()
-
+func (s *clientRepoSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 	client := s.APIState.Client()
-	curl, _ := addCharm(c, "wordpress")
+	curl, _ := s.uploadCharm(c, "trusty/wordpress-42", "wordpress")
 
 	// Add a placeholder with the same charm URL.
 	err := s.State.AddStoreCharmPlaceholder(curl)
@@ -3658,15 +3697,6 @@ func (s *clientSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 	c.Assert(sch.URL(), jc.DeepEquals, curl)
 	c.Assert(sch.IsPlaceholder(), jc.IsFalse)
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
-}
-
-func (s *clientSuite) assertUploaded(c *gc.C, storage statestorage.Storage, storagePath, expectedSHA256 string) {
-	reader, _, err := storage.Get(storagePath)
-	c.Assert(err, jc.ErrorIsNil)
-	defer reader.Close()
-	downloadedSHA256, _, err := utils.ReadSHA256(reader)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(downloadedSHA256, gc.Equals, expectedSHA256)
 }
 
 func (s *clientSuite) TestRetryProvisioning(c *gc.C) {

--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -8,7 +8,7 @@ var (
 	RemoteParamsForMachine  = remoteParamsForMachine
 	GetAllUnitNames         = getAllUnitNames
 	NewStateStorage         = &newStateStorage
-	CharmStore              = &charmStore
+	NewCharmStore           = &newCharmStore
 )
 
 var MachineJobFromParams = machineJobFromParams

--- a/cmd/juju/common.go
+++ b/cmd/juju/common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v5-unstable"
+	"gopkg.in/juju/charm.v5-unstable/charmrepo"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/envcmd"
@@ -125,3 +126,7 @@ func resolveCharmURL(url string, client *api.Client, conf *config.Config) (*char
 	logger.Errorf("The series is not specified in the environment (default-series) or with the charm. Did you mean:\n\t%s", &possibleURL)
 	return nil, fmt.Errorf("cannot resolve series for charm: %q", ref)
 }
+
+// newCharmStoreParams holds the parameters used to instantiate a new charm
+// store repo. It is defined here for testing purposes.
+var newCharmStoreParams = charmrepo.NewCharmStoreParams{}

--- a/cmd/juju/deploy.go
+++ b/cmd/juju/deploy.go
@@ -188,7 +188,10 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	repo, err := charmrepo.LegacyInferRepository(curl.Reference(), ctx.AbsPath(c.RepoPath))
+	repo, err := charmrepo.InferRepository(
+		curl.Reference(),
+		newCharmStoreParams,
+		ctx.AbsPath(c.RepoPath))
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/upgradecharm.go
+++ b/cmd/juju/upgradecharm.go
@@ -133,7 +133,10 @@ func (c *UpgradeCharmCommand) Run(ctx *cmd.Context) error {
 		newURL = oldURL.WithRevision(c.Revision)
 	}
 
-	repo, err := charmrepo.LegacyInferRepository(newURL.Reference(), ctx.AbsPath(c.RepoPath))
+	repo, err := charmrepo.InferRepository(
+		newURL.Reference(),
+		newCharmStoreParams,
+		ctx.AbsPath(c.RepoPath))
 	if err != nil {
 		return err
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
-github.com/juju/jujusvg	git	516cc9eb29dbf6930344facc2231d51c42a5b815	2015-03-24T16:46:20Z
+github.com/juju/jujusvg	git	4496f32c383bd5fbb5e455eb95a9b31d8833cebe	2015-03-27T16:01:02Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
 github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07:57:36Z
 github.com/juju/ratelimit	git	f9f36d11773655c0485207f0ad30dc2655f69d56	2014-04-10T13:47:08Z
@@ -36,8 +36,8 @@ google.golang.org/api	git	0d3983fb069cb6651353fc44c5cb604e263f2a93	2014-12-10T23
 gopkg.in/amz.v3	git	661b136aa255ca3db33234fe91d8a223c847e831	2015-03-25T02:48:52Z
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	2014-08-27T13:58:41Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
-gopkg.in/juju/charm.v5-unstable	git	62ddde8b7abac1db3ecd5d7d0536b67f7a4719bc	2015-03-25T11:14:56Z
-gopkg.in/juju/charmstore.v4	git	5b1da0427e8726978859afd389fe5e141ac6db7a	2015-03-25T11:39:57Z
+gopkg.in/juju/charm.v5-unstable	git	bea01bf218c7373c38e3b00defec0a90e2518229	2015-03-27T18:29:47Z
+gopkg.in/juju/charmstore.v4	git	30ed90ccad14396a7c2198790886654f2a52f5a3	2015-03-30T08:39:06Z
 gopkg.in/macaroon-bakery.v0	git	4c0e0fae424e8d1bc71c0b0caca3cd2c32381dca	2015-01-27T17:01:29Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	2014-07-30T20:00:37Z

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1419,10 +1419,12 @@ func (cfg *Config) GenerateStateServerCertAndKey(hostAddresses []string) (string
 // It returns a charm repository with test mode enabled if applicable.
 func SpecializeCharmRepo(repo charmrepo.Interface, cfg *Config) charmrepo.Interface {
 	type specializer interface {
-		WithTestMode(testMode bool) charmrepo.Interface
+		WithTestMode() charmrepo.Interface
 	}
 	if store, ok := repo.(specializer); ok {
-		return store.WithTestMode(cfg.TestMode())
+		if cfg.TestMode() {
+			return store.WithTestMode()
+		}
 	}
 	return repo
 }

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1805,12 +1805,12 @@ func (s *ConfigSuite) TestSpecializeCharmRepo(c *gc.C) {
 }
 
 type specializedCharmRepo struct {
-	*charmrepo.LegacyCharmStore
+	*charmrepo.CharmStore
 	testMode bool
 }
 
-func (s *specializedCharmRepo) WithTestMode(testMode bool) charmrepo.Interface {
-	s.testMode = testMode
+func (s *specializedCharmRepo) WithTestMode() charmrepo.Interface {
+	s.testMode = true
 	return s
 }
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -547,7 +547,10 @@ func (s *JujuConnSuite) AddTestingCharm(c *gc.C, name string) *state.Charm {
 	ch := testcharms.Repo.CharmDir(name)
 	ident := fmt.Sprintf("%s-%d", ch.Meta().Name, ch.Revision())
 	curl := charm.MustParseURL("local:quantal/" + ident)
-	repo, err := charmrepo.LegacyInferRepository(curl.Reference(), testcharms.Repo.Path())
+	repo, err := charmrepo.InferRepository(
+		curl.Reference(),
+		charmrepo.NewCharmStoreParams{},
+		testcharms.Repo.Path())
 	c.Assert(err, jc.ErrorIsNil)
 	sch, err := PutCharm(s.State, curl, repo, false)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/charmrevisionworker/revisionupdater_test.go
+++ b/worker/charmrevisionworker/revisionupdater_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/charmrevisionupdater/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/charmrevisionworker"
 )
@@ -107,7 +108,9 @@ func (s *RevisionUpdateSuite) TestVersionUpdateRunsPeriodically(c *gc.C) {
 	c.Assert(s.checkCharmRevision(c, 23), jc.IsTrue)
 
 	// Make some changes
-	s.UpdateStoreRevision("cs:quantal/mysql", 24)
+	id := charm.MustParseReference("~who/quantal/mysql-24")
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), id.Name)
+	s.Server.UploadCharm(c, ch, id, true)
 	// Check the results of the latest changes.
 	c.Assert(s.checkCharmRevision(c, 24), jc.IsTrue)
 }


### PR DESCRIPTION
Switch to using the new charm store with the v4 API.
Avoid using the legacy mock store when testing the interaction
between juju-core and the charm store.

The only bit still depending on the legacy charm store is
the juju publish command, that will be handled later.

(Review request: http://reviews.vapour.ws/r/1324/)