### PR TITLE
state/meterstatus: Better errors for SetMeterStatus, remove NotAvailable

### DIFF
--- a/apiserver/metricsender/sender_test.go
+++ b/apiserver/metricsender/sender_test.go
@@ -182,7 +182,7 @@ func (s *SenderSuite) TestErrorCodes(c *gc.C) {
 // is in use metrics get sent
 func (s *SenderSuite) TestMeterStatus(c *gc.C) {
 	statusFunc := func(unitName string) (string, string, string) {
-		return unitName, "GREEN", ""
+		return unitName, "RED", ""
 	}
 
 	cleanup := s.startServer(c, testHandler(c, nil, statusFunc, 0))
@@ -192,7 +192,7 @@ func (s *SenderSuite) TestMeterStatus(c *gc.C) {
 
 	status, err := s.unit.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status.Code, gc.Equals, state.MeterNotSet)
+	c.Assert(status.Code, gc.Equals, state.MeterGreen)
 
 	var sender metricsender.DefaultSender
 	err = metricsender.SendMetrics(s.State, &sender, 10)
@@ -200,7 +200,7 @@ func (s *SenderSuite) TestMeterStatus(c *gc.C) {
 
 	status, err = s.unit.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status.Code, gc.Equals, state.MeterGreen)
+	c.Assert(status.Code, gc.Equals, state.MeterRed)
 }
 
 // TestMeterStatusInvalid checks that the metric sender deals with invalid
@@ -236,7 +236,7 @@ func (s *SenderSuite) TestMeterStatusInvalid(c *gc.C) {
 	for _, unit := range []*state.Unit{unit1, unit2, unit3} {
 		status, err := unit.GetMeterStatus()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(status.Code, gc.Equals, state.MeterNotSet)
+		c.Assert(status.Code, gc.Equals, state.MeterGreen)
 	}
 
 	var sender metricsender.DefaultSender
@@ -249,11 +249,11 @@ func (s *SenderSuite) TestMeterStatusInvalid(c *gc.C) {
 
 	status, err = unit2.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status.Code, gc.Equals, state.MeterNotSet)
+	c.Assert(status.Code, gc.Equals, state.MeterGreen)
 
 	status, err = unit3.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status.Code, gc.Equals, state.MeterNotSet)
+	c.Assert(status.Code, gc.Equals, state.MeterGreen)
 
 }
 

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -1269,14 +1269,18 @@ func (u *uniterBaseAPI) GetMeterStatus(args params.Entities) (params.MeterStatus
 			continue
 		}
 		err = common.ErrPerm
-		var status state.MeterStatus
+		var status *state.MeterStatus
 		if canAccess(unitTag) {
 			var unit *state.Unit
 			unit, err = u.getUnit(unitTag)
 			if err == nil {
 				status, err = unit.GetMeterStatus()
 			}
-			result.Results[i].Code = status.Code.String()
+			statusString, err := status.Code.String()
+			if err != nil {
+				return params.MeterStatusResults{}, errors.Trace(err)
+			}
+			result.Results[i].Code = statusString
 			result.Results[i].Info = status.Info
 		}
 		result.Results[i].Error = common.ServerError(err)

--- a/apiserver/uniter/uniter_base_test.go
+++ b/apiserver/uniter/uniter_base_test.go
@@ -2240,8 +2240,8 @@ func (s *uniterBaseSuite) testGetMeterStatus(c *gc.C, facade getMeterStatus) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].Code, gc.Equals, "NOT SET")
-	c.Assert(result.Results[0].Info, gc.Equals, "")
+	c.Assert(result.Results[0].Code, gc.Equals, "GREEN")
+	c.Assert(result.Results[0].Info, gc.Equals, "ok")
 
 	newCode := "GREEN"
 	newInfo := "All is ok."

--- a/state/service.go
+++ b/state/service.go
@@ -620,7 +620,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		},
 		createStatusOp(s.st, globalKey, unitStatusDoc),
 		createStatusOp(s.st, agentGlobalKey, agentStatusDoc),
-		createMeterStatusOp(s.st, globalKey, &meterStatusDoc{Code: MeterNotSet.String()}),
+		createMeterStatusOp(s.st, globalKey, &meterStatusDoc{Code: MeterNotSetString}),
 		{
 			C:      servicesC,
 			Id:     s.doc.DocID,

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -398,7 +398,7 @@ func CreateUnitMeterStatus(st *State) error {
 			continue
 		}
 		ops := []txn.Op{
-			createMeterStatusOp(st, unit.globalKey(), &meterStatusDoc{Code: MeterNotSet.String()}),
+			createMeterStatusOp(st, unit.globalKey(), &meterStatusDoc{Code: MeterNotSetString}),
 		}
 		if err = st.runRawTransaction(ops); err != nil {
 			upgradesLogger.Warningf("migration failed for unit %q: %v", unit, err)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1176,20 +1176,20 @@ func (s *upgradesSuite) TestAddEnvUUIDToMeterStatus(c *gc.C) {
 	coll, newIDs := s.checkAddEnvUUIDToCollection(c, AddEnvUUIDToMeterStatus, meterStatusC,
 		bson.M{
 			"_id":  "u#foo/0",
-			"code": MeterGreen.String(),
+			"code": MeterGreenString,
 		},
 		bson.M{
 			"_id":  "u#bar/0",
-			"code": MeterRed.String(),
+			"code": MeterRedString,
 		},
 	)
 
 	var newDoc meterStatusDoc
 	s.FindId(c, coll, newIDs[0], &newDoc)
-	c.Assert(newDoc.Code, gc.Equals, MeterGreen.String())
+	c.Assert(newDoc.Code, gc.Equals, MeterGreenString)
 
 	s.FindId(c, coll, newIDs[1], &newDoc)
-	c.Assert(newDoc.Code, gc.Equals, MeterRed.String())
+	c.Assert(newDoc.Code, gc.Equals, MeterRedString)
 }
 
 func (s *upgradesSuite) TestAddEnvUUIDToMeterStatusIdempotent(c *gc.C) {
@@ -1905,7 +1905,7 @@ func (s *upgradesSuite) TestCreateMeterStatuses(c *gc.C) {
 	for _, unit := range units {
 		status, err := unit.GetMeterStatus()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(status, gc.DeepEquals, MeterStatus{MeterNotSet, ""})
+		c.Assert(status, gc.DeepEquals, &MeterStatus{MeterGreen, "ok"})
 	}
 
 	// run migration again to make sure it's idempotent
@@ -1914,7 +1914,7 @@ func (s *upgradesSuite) TestCreateMeterStatuses(c *gc.C) {
 	for _, unit := range units {
 		status, err := unit.GetMeterStatus()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(status, gc.DeepEquals, MeterStatus{MeterNotSet, ""})
+		c.Assert(status, gc.DeepEquals, &MeterStatus{MeterGreen, "ok"})
 	}
 }
 


### PR DESCRIPTION
If the input is not a valid meter status return an error saying it was invalid. If it was a type that can't be set then report that

Remove the MeterNotAvailable state, errors and nils are returned now
When NotSet is combined with a colour the colour is always returned. This means NotSet should never reach a client

(Review request: http://reviews.vapour.ws/r/1326/)