### PR TITLE
state: storage fixes

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -511,12 +511,12 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 		})
 	}
 
-	if len(filesystemOps) > 0 {
+	if len(fsAttachments) > 0 {
 		attachmentOps := createMachineFilesystemAttachmentsOps(mdoc.Id, fsAttachments)
 		prereqOps = append(prereqOps, filesystemOps...)
 		prereqOps = append(prereqOps, attachmentOps...)
 	}
-	if len(volumeOps) > 0 {
+	if len(volumeAttachments) > 0 {
 		attachmentOps := createMachineVolumeAttachmentsOps(mdoc.Id, volumeAttachments)
 		prereqOps = append(prereqOps, volumeOps...)
 		prereqOps = append(prereqOps, attachmentOps...)

--- a/state/storage.go
+++ b/state/storage.go
@@ -746,18 +746,18 @@ func validateStoragePool(
 	}
 
 	// Ensure the storage provider supports the specified kind.
-	var kindSupported bool
-	switch kind {
-	case storage.StorageKindFilesystem:
-		// Filesystems can be created if either filesystem or block
-		// storage are supported.
+	kindSupported := provider.Supports(kind)
+	if !kindSupported && kind == storage.StorageKindFilesystem {
+		// Filesystems can be created if either filesystem
+		// or block storage are supported.
 		if provider.Supports(storage.StorageKindBlock) {
 			kindSupported = true
-			break
+			// The filesystem is to be backed by a volume,
+			// so the filesystem must be managed on the
+			// machine. Skip the scope-check below by
+			// setting the pointer to nil.
+			machineId = nil
 		}
-		fallthrough
-	default:
-		kindSupported = provider.Supports(kind)
 	}
 	if !kindSupported {
 		return errors.Errorf("%q provider does not support %q storage", providerType, kind)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -41,12 +41,20 @@ func (s *StorageStateSuiteBase) SetUpSuite(c *gc.C) {
 	registry.RegisterProvider("machinescoped", &dummy.StorageProvider{
 		StorageScope: storage.ScopeMachine,
 	})
+	registry.RegisterProvider("environscoped-block", &dummy.StorageProvider{
+		StorageScope: storage.ScopeEnviron,
+		SupportsFunc: func(k storage.StorageKind) bool {
+			return k == storage.StorageKindBlock
+		},
+	})
 	registry.RegisterEnvironStorageProviders(
 		"someprovider", "environscoped", "machinescoped",
+		"environscoped-block",
 	)
 	s.AddSuiteCleanup(func(c *gc.C) {
 		registry.RegisterProvider("environscoped", nil)
 		registry.RegisterProvider("machinescoped", nil)
+		registry.RegisterProvider("environscoped-block", nil)
 	})
 }
 

--- a/state/volume.go
+++ b/state/volume.go
@@ -517,29 +517,7 @@ func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error)
 				return nil, err
 			}
 		}
-		ops := setVolumeInfoOps(tag, info, unsetParams)
-
-		// If there's a filesystem destined for the volume,
-		// set the filesystem info.
-		f, err := st.VolumeFilesystem(tag)
-		if err == nil {
-			filesystemInfo := FilesystemInfo{
-				info.Size,
-				info.Pool,
-				// FilesystemId is set to "" for
-				// filesystems backed by volumes.
-				"",
-			}
-			filesystemOps := setFilesystemInfoOps(
-				f.FilesystemTag(),
-				filesystemInfo,
-				unsetParams,
-			)
-			ops = append(ops, filesystemOps...)
-		} else if !errors.IsNotFound(err) {
-			return nil, errors.Trace(err)
-		}
-		return ops, nil
+		return setVolumeInfoOps(tag, info, unsetParams), nil
 	}
 	return st.run(buildTxn)
 }


### PR DESCRIPTION
This branch fixes several issues relating to storage in state:
 - Volume-backed filesystems are now always machine-scoped,
   regardless of the backing volume's scope.
 - We now create volume attachments when creating volume-backed
   filesystems.
 - Setting volume info will no longer set info for filesystems
   on the volume. The storage provisioner will set the filesystem
   info independently.

(Review request: http://reviews.vapour.ws/r/1335/)