### PR TITLE
all: fix declared by not used error in tests

### DIFF
--- a/api/block/client_test.go
+++ b/api/block/client_test.go
@@ -51,6 +51,7 @@ func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
 		})
 	blockClient := block.NewClient(apiCaller)
 	err := blockClient.SwitchBlockOn(blockType, msg)
+	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -72,6 +73,7 @@ func (s *blockMockSuite) TestSwitchBlockOnError(c *gc.C) {
 		})
 	blockClient := block.NewClient(apiCaller)
 	err := blockClient.SwitchBlockOn("", "")
+	c.Assert(called, jc.IsTrue)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
 }
 
@@ -104,6 +106,7 @@ func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
 		})
 	blockClient := block.NewClient(apiCaller)
 	err := blockClient.SwitchBlockOff(blockType)
+	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -125,6 +128,7 @@ func (s *blockMockSuite) TestSwitchBlockOffError(c *gc.C) {
 		})
 	blockClient := block.NewClient(apiCaller)
 	err := blockClient.SwitchBlockOff("")
+	c.Assert(called, jc.IsTrue)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
 }
 

--- a/state/backups/db_restore_test.go
+++ b/state/backups/db_restore_test.go
@@ -92,6 +92,7 @@ func (s *mongoRestoreSuite) TestPlaceNewMongo(c *gc.C) {
 	s.PatchValue(backups.RestoreArgsForVersion, restoreArgsForVersion)
 
 	err := backups.PlaceNewMongo("fakemongopath", ver)
+	c.Assert(restorePathCalled, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(argsVersion, gc.DeepEquals, ver)
 	c.Assert(newMongoDumpPath, gc.Equals, "fakemongopath")


### PR DESCRIPTION
gccgo is stricter than gc in this respect and discovered some unused
variables which were obviously supposed to be hooked up to tests.

This approach isn't actually thread safe, but as the rest of the tests
in this suite also commit the same crimes, it feels like the lesser evil
to fix the test and unblock gccgo.

Change-Id: Id49cc6d1c289a1cbf170f03acd0488774f70a702

(Review request: http://reviews.vapour.ws/r/1337/)