### PR TITLE
Various storage improvements

### DIFF
--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -39,6 +39,7 @@ func NewState(caller base.APICaller, scope names.Tag) *State {
 	}
 }
 
+// WatchBlockDevices watches for changes to the specified machine's block devices.
 func (st *State) WatchBlockDevices(m names.MachineTag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{

--- a/apiserver/common/blockdevices.go
+++ b/apiserver/common/blockdevices.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+)
+
+// BlockDeviceFromState translates a state.BlockDeviceInfo to a
+// storage.BlockDevice.
+func BlockDeviceFromState(in state.BlockDeviceInfo) storage.BlockDevice {
+	return storage.BlockDevice{
+		in.DeviceName,
+		in.Label,
+		in.UUID,
+		in.Serial,
+		in.Size,
+		in.FilesystemType,
+		in.InUse,
+		in.MountPoint,
+	}
+}
+
+// MatchingBlockDevice finds the block device that matches the
+// provided volume info and volume attachment info.
+func MatchingBlockDevice(
+	blockDevices []state.BlockDeviceInfo,
+	volumeInfo state.VolumeInfo,
+	attachmentInfo state.VolumeAttachmentInfo,
+) (*state.BlockDeviceInfo, bool) {
+	for _, dev := range blockDevices {
+		if volumeInfo.Serial != "" {
+			if volumeInfo.Serial == dev.Serial {
+				return &dev, true
+			}
+		} else if attachmentInfo.DeviceName == dev.DeviceName {
+			return &dev, true
+		}
+	}
+	return nil, false
+}

--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -26,11 +26,11 @@ func IsFilesystemAlreadyProvisioned(err error) bool {
 }
 
 // FilesystemParams returns the parameters for creating the given filesystem.
-func FilesystemParams(v state.Filesystem, poolManager poolmanager.PoolManager) (params.FilesystemParams, error) {
-	stateFilesystemParams, ok := v.Params()
+func FilesystemParams(f state.Filesystem, poolManager poolmanager.PoolManager) (params.FilesystemParams, error) {
+	stateFilesystemParams, ok := f.Params()
 	if !ok {
 		err := &filesystemAlreadyProvisionedError{fmt.Errorf(
-			"filesystem %q is already provisioned", v.Tag().Id(),
+			"filesystem %q is already provisioned", f.Tag().Id(),
 		)}
 		return params.FilesystemParams{}, err
 	}
@@ -39,13 +39,23 @@ func FilesystemParams(v state.Filesystem, poolManager poolmanager.PoolManager) (
 	if err != nil {
 		return params.FilesystemParams{}, errors.Trace(err)
 	}
-	return params.FilesystemParams{
-		v.Tag().String(),
+	result := params.FilesystemParams{
+		f.Tag().String(),
+		"", // volume tag
 		stateFilesystemParams.Size,
 		string(providerType),
 		cfg.Attrs(),
 		nil, // attachment params set by the caller
-	}, nil
+	}
+
+	volumeTag, err := f.Volume()
+	if err == nil {
+		result.VolumeTag = volumeTag.String()
+	} else if err != state.ErrNoBackingVolume {
+		return params.FilesystemParams{}, errors.Trace(err)
+	}
+
+	return result, nil
 }
 
 // FilesystemsToState converts a slice of params.Filesystem to a mapping

--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -154,25 +154,6 @@ func WatchStorageAttachmentInfo(
 	return nil, errors.Errorf("invalid storage kind %v", storageInstance.Kind())
 }
 
-// MatchingBlockDevice finds the block device that matches the
-// provided volume info and volume attachment info.
-func MatchingBlockDevice(
-	blockDevices []state.BlockDeviceInfo,
-	volumeInfo state.VolumeInfo,
-	attachmentInfo state.VolumeAttachmentInfo,
-) (*state.BlockDeviceInfo, bool) {
-	for _, dev := range blockDevices {
-		if volumeInfo.Serial != "" {
-			if volumeInfo.Serial == dev.Serial {
-				return &dev, true
-			}
-		} else if attachmentInfo.DeviceName == dev.DeviceName {
-			return &dev, true
-		}
-	}
-	return nil, false
-}
-
 var errNoDevicePath = errors.New("cannot determine device path: no serial or persistent device name")
 
 // volumeAttachmentDevicePath returns the absolute device path for

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -303,6 +303,7 @@ type FilesystemAttachments struct {
 // FilesystemParams holds the parameters for creating a storage filesystem.
 type FilesystemParams struct {
 	FilesystemTag string                      `json:"filesystemtag"`
+	VolumeTag     string                      `json:"volumetag,omitempty"`
 	Size          uint64                      `json:"size"`
 	Provider      string                      `json:"provider"`
 	Attributes    map[string]interface{}      `json:"attributes,omitempty"`

--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -16,7 +16,9 @@ type provisionerState interface {
 	state.EnvironAccessor
 
 	MachineInstanceId(names.MachineTag) (instance.Id, error)
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 
+	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
 	WatchEnvironFilesystems() state.StringsWatcher
 	WatchEnvironFilesystemAttachments() state.StringsWatcher
 	WatchMachineFilesystems(names.MachineTag) state.StringsWatcher
@@ -25,6 +27,7 @@ type provisionerState interface {
 	WatchEnvironVolumeAttachments() state.StringsWatcher
 	WatchMachineVolumes(names.MachineTag) state.StringsWatcher
 	WatchMachineVolumeAttachments(names.MachineTag) state.StringsWatcher
+	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 
 	Filesystem(names.FilesystemTag) (state.Filesystem, error)
 	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -160,6 +160,7 @@ func NewStorageProvisionerAPI(st *state.State, resources *common.Resources, auth
 	}, nil
 }
 
+// WatchBlockDevices watches for changes to the specified machines' block devices.
 func (s *StorageProvisionerAPI) WatchBlockDevices(args params.Entities) (params.NotifyWatchResults, error) {
 	canAccess, err := s.getMachineAuthFunc()
 	if err != nil {

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -384,12 +384,13 @@ func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 				MachineTag: "machine-0",
 				VolumeTag:  "volume-0-0",
 				InstanceId: "inst-id",
-				VolumeId:   "abc",
 				Provider:   "machinescoped",
 			}},
-			{Error: &params.Error{
-				Code:    params.CodeNotProvisioned,
-				Message: `volume "1" not provisioned`,
+			{Result: params.VolumeAttachmentParams{
+				MachineTag: "machine-0",
+				VolumeTag:  "volume-1",
+				InstanceId: "inst-id",
+				Provider:   "environscoped",
 			}},
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,
@@ -426,13 +427,14 @@ func (s *provisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 				MachineTag:    "machine-0",
 				FilesystemTag: "filesystem-0-0",
 				InstanceId:    "inst-id",
-				FilesystemId:  "abc",
 				Provider:      "machinescoped",
 				MountPoint:    "/srv",
 			}},
-			{Error: &params.Error{
-				Code:    params.CodeNotProvisioned,
-				Message: `filesystem "1" not provisioned`,
+			{Result: params.FilesystemAttachmentParams{
+				MachineTag:    "machine-0",
+				FilesystemTag: "filesystem-1",
+				InstanceId:    "inst-id",
+				Provider:      "environscoped",
 			}},
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,
@@ -723,6 +725,90 @@ func (s *provisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 	wc.AssertNoChange()
 	wc = statetesting.NewStringsWatcherC(c, s.State, v1Watcher.(state.StringsWatcher))
 	wc.AssertNoChange()
+}
+
+func (s *provisionerSuite) TestWatchBlockDevices(c *gc.C) {
+	s.factory.MakeMachine(c, nil)
+	c.Assert(s.resources.Count(), gc.Equals, 0)
+
+	args := params.Entities{Entities: []params.Entity{
+		{"machine-0"},
+		{"service-mysql"},
+		{"machine-1"},
+		{"machine-42"}},
+	}
+	results, err := s.api.WatchBlockDevices(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{
+			{NotifyWatcherId: "1"},
+			{Error: &params.Error{Message: `"service-mysql" is not a valid machine tag`}},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+
+	// Verify the resources were registered and stop them when done.
+	c.Assert(s.resources.Count(), gc.Equals, 1)
+	watcher := s.resources.Get("1")
+	defer statetesting.AssertStop(c, watcher)
+
+	// Check that the Watch has consumed the initial event.
+	wc := statetesting.NewNotifyWatcherC(c, s.State, watcher.(state.NotifyWatcher))
+	wc.AssertNoChange()
+
+	m, err := s.State.Machine("0")
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetMachineBlockDevices(state.BlockDeviceInfo{
+		DeviceName: "sda",
+		Size:       123,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+}
+
+func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
+	s.setupVolumes(c)
+	s.factory.MakeMachine(c, nil)
+
+	err := s.State.SetVolumeAttachmentInfo(
+		names.NewMachineTag("0"),
+		names.NewVolumeTag("0/0"),
+		state.VolumeAttachmentInfo{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	machine0, err := s.State.Machine("0")
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine0.SetMachineBlockDevices(state.BlockDeviceInfo{
+		DeviceName: "sda",
+		Size:       123,
+		Serial:     "123", // matches volume-0/0
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.MachineStorageIds{Ids: []params.MachineStorageId{
+		{MachineTag: "machine-0", AttachmentTag: "volume-0-0"},
+		{MachineTag: "machine-0", AttachmentTag: "volume-0-1"},
+		{MachineTag: "machine-0", AttachmentTag: "volume-0-2"},
+		{MachineTag: "machine-1", AttachmentTag: "volume-1"},
+		{MachineTag: "service-mysql", AttachmentTag: "volume-1"},
+	}}
+	results, err := s.api.VolumeBlockDevices(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.BlockDeviceResults{
+		Results: []params.BlockDeviceResult{
+			{Result: storage.BlockDevice{
+				DeviceName: "sda",
+				Size:       123,
+				Serial:     "123",
+			}},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: &params.Error{Message: `"service-mysql" is not a valid machine tag`}},
+		},
+	})
 }
 
 func (s *provisionerSuite) TestLife(c *gc.C) {

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -792,6 +792,7 @@ func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 		{MachineTag: "machine-0", AttachmentTag: "volume-0-1"},
 		{MachineTag: "machine-0", AttachmentTag: "volume-0-2"},
 		{MachineTag: "machine-1", AttachmentTag: "volume-1"},
+		{MachineTag: "machine-42", AttachmentTag: "volume-42"},
 		{MachineTag: "service-mysql", AttachmentTag: "volume-1"},
 	}}
 	results, err := s.api.VolumeBlockDevices(args)
@@ -803,6 +804,7 @@ func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 				Size:       123,
 				Serial:     "123",
 			}},
+			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -39,8 +39,6 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/systemd"
-	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -288,7 +286,9 @@ func (s *LxcSuite) TestUpdateContainerConfig(c *gc.C) {
 		DeviceIndex:   1,
 		InterfaceName: "eth1",
 	}})
-	storageConfig := container.NewStorageConfig([]storage.VolumeParams{{Provider: provider.LoopProviderType}})
+	storageConfig := &container.StorageConfig{
+		AllowMount: true,
+	}
 
 	manager := s.makeManager(c, "test")
 	machineConfig, err := containertesting.MockMachineConfig("1/lxc/0")
@@ -1029,7 +1029,7 @@ func (s *LxcSuite) TestCreateContainerWithBlockStorage(c *gc.C) {
 	manager := s.makeManager(c, "test")
 	machineConfig, err := containertesting.MockMachineConfig("1/lxc/0")
 	c.Assert(err, jc.ErrorIsNil)
-	storageConfig := container.NewStorageConfig([]storage.VolumeParams{{Provider: provider.LoopProviderType}})
+	storageConfig := &container.StorageConfig{AllowMount: true}
 	networkConfig := container.BridgeNetworkConfig("nic42", nil)
 	instance := containertesting.CreateContainerWithMachineAndNetworkAndStorageConfig(c, manager, machineConfig, networkConfig, storageConfig)
 	name := string(instance.Id())

--- a/container/storage.go
+++ b/container/storage.go
@@ -3,12 +3,7 @@
 
 package container
 
-import (
-	"errors"
-
-	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/provider"
-)
+import "errors"
 
 // ErrLoopMountNotAllowed is used when loop devices are requested to be
 // mounted inside an LXC container, but this has not been allowed using
@@ -25,20 +20,4 @@ type StorageConfig struct {
 	// AllowMount is true is the container is required to allow
 	// mounting block devices.
 	AllowMount bool
-}
-
-// NewStorageConfig returns a StorageConfig used to specify the
-// configuration the container uses to support storage.
-func NewStorageConfig(volumes []storage.VolumeParams) *StorageConfig {
-	allowMount := false
-	// If there is a volume using a loop provider, then
-	// allow mount must be true.
-	for _, v := range volumes {
-		allowMount = v.Provider == provider.LoopProviderType
-		if allowMount {
-			break
-		}
-	}
-	// TODO(wallyworld) - add config for HostLoopProviderType
-	return &StorageConfig{allowMount}
 }

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -59,7 +59,7 @@ func CreateContainerWithMachineConfig(
 ) instance.Instance {
 
 	networkConfig := container.BridgeNetworkConfig("nic42", nil)
-	storageConfig := container.NewStorageConfig(nil)
+	storageConfig := &container.StorageConfig{}
 	return CreateContainerWithMachineAndNetworkAndStorageConfig(c, manager, machineConfig, networkConfig, storageConfig)
 }
 
@@ -116,7 +116,7 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 	machineConfig.Config = envConfig
 
 	network := container.BridgeNetworkConfig("nic42", nil)
-	storage := container.NewStorageConfig(nil)
+	storage := &container.StorageConfig{}
 
 	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", network, storage)
 

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -391,11 +391,10 @@ func (env *localEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 var createContainer = func(env *localEnviron, args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, error) {
 	series := args.Tools.OneSeries()
 	network := container.BridgeNetworkConfig(env.config.networkBridge(), args.NetworkInfo)
-	storage := container.NewStorageConfig(args.Volumes)
 	allowLoopMounts, _ := env.config.AllowLXCLoopMounts()
 	isLXC := env.config.container() == instance.LXC
-	if isLXC && !allowLoopMounts && storage.AllowMount {
-		return nil, nil, container.ErrLoopMountNotAllowed
+	storage := &container.StorageConfig{
+		AllowMount: !isLXC || allowLoopMounts,
 	}
 	inst, hardware, err := env.containerManager.CreateContainer(args.MachineConfig, series, network, storage)
 	if err != nil {

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/jujutest"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
@@ -35,8 +34,6 @@ import (
 	"github.com/juju/juju/service/common"
 	svctesting "github.com/juju/juju/service/common/testing"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/provider"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -410,22 +407,4 @@ func (s *localJujuTestSuite) TestStateServerInstances(c *gc.C) {
 	instances, err = env.StateServerInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.DeepEquals, []instance.Id{"localhost"})
-}
-
-func (s *localJujuTestSuite) TestStateInstanceLoopMountsDisallowed(c *gc.C) {
-	env := s.testBootstrap(c, minimalConfig(c))
-
-	availableTools := coretools.List{&coretools.Tools{
-		Version: version.Current,
-		URL:     "http://testing.invalid/tools.tar.gz",
-	}}
-	mcfg, err := environs.NewMachineConfig("0", "ya", imagemetadata.ReleasedStream, version.Current.Series, true, nil, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = env.StartInstance(environs.StartInstanceParams{
-		MachineConfig: mcfg,
-		Tools:         availableTools,
-		Volumes:       []storage.VolumeParams{{Provider: provider.LoopProviderType}},
-	})
-	c.Assert(err, gc.Equals, container.ErrLoopMountNotAllowed)
 }

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -11,6 +11,9 @@ type Filesystem struct {
 	// Tag is a unique name assigned by Juju to the filesystem.
 	Tag names.FilesystemTag
 
+	// Volume is the tag of the volume that backs the filesystem, if any.
+	Volume names.VolumeTag
+
 	// FilesystemId is a unique provider-supplied ID for the filesystem.
 	// FilesystemId is required to be unique for the lifetime of the
 	// filesystem, but may be reused.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -223,6 +223,9 @@ type FilesystemParams struct {
 	// Tag is a unique tag assigned by Juju for the requested filesystem.
 	Tag names.FilesystemTag
 
+	// Volume is the tag of the volume that backs the filesystem, if any.
+	Volume names.VolumeTag
+
 	// Size is the minimum size of the filesystem in MiB.
 	Size uint64
 

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -169,9 +169,9 @@ func (s *rootfsFilesystemSource) createFilesystem(params storage.FilesystemParam
 		return filesystem, errors.Errorf("filesystem is not big enough (%dM < %dM)", sizeInMiB, params.Size)
 	}
 	filesystem = storage.Filesystem{
-		params.Tag,
-		params.Tag.Id(), // FilesystemId
-		sizeInMiB,
+		Tag:          params.Tag,
+		FilesystemId: params.Tag.Id(),
+		Size:         sizeInMiB,
 	}
 	return filesystem, nil
 }

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -96,8 +96,10 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	storage := container.NewStorageConfig(args.Volumes)
-	inst, hardware, err := broker.manager.CreateContainer(args.MachineConfig, series, network, storage)
+	storageConfig := &container.StorageConfig{
+		AllowMount: true,
+	}
+	inst, hardware, err := broker.manager.CreateContainer(args.MachineConfig, series, network, storageConfig)
 	if err != nil {
 		kvmLogger.Errorf("failed to start container: %v", err)
 		return nil, err

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -114,11 +114,8 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		lxcLogger.Errorf("failed to get container config: %v", err)
 		return nil, err
 	}
-
-	// If loop mounts are to be used, check that they are allowed.
-	storage := container.NewStorageConfig(args.Volumes)
-	if !config.AllowLXCLoopMounts && storage.AllowMount {
-		return nil, container.ErrLoopMountNotAllowed
+	storageConfig := &container.StorageConfig{
+		AllowMount: config.AllowLXCLoopMounts,
 	}
 
 	if err := environs.PopulateMachineConfig(
@@ -137,7 +134,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	inst, hardware, err := broker.manager.CreateContainer(args.MachineConfig, series, network, storage)
+	inst, hardware, err := broker.manager.CreateContainer(args.MachineConfig, series, network, storageConfig)
 	if err != nil {
 		lxcLogger.Errorf("failed to start container: %v", err)
 		return nil, err

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -498,9 +498,6 @@ func constructStartInstanceParams(
 		if machineTag != machine.Tag() {
 			return environs.StartInstanceParams{}, errors.Errorf("volume attachment params has invalid machine tag")
 		}
-		if v.Attachment.VolumeId != "" {
-			return environs.StartInstanceParams{}, errors.Errorf("volume attachment params specifies volume ID")
-		}
 		if v.Attachment.InstanceId != "" {
 			return environs.StartInstanceParams{}, errors.Errorf("volume attachment params specifies instance ID")
 		}

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -454,9 +454,17 @@ func filesystemParamsFromParams(in params.FilesystemParams) (storage.FilesystemP
 	if err != nil {
 		return storage.FilesystemParams{}, errors.Trace(err)
 	}
+	var volumeTag names.VolumeTag
+	if in.VolumeTag != "" {
+		volumeTag, err = names.ParseVolumeTag(in.VolumeTag)
+		if err != nil {
+			return storage.FilesystemParams{}, errors.Trace(err)
+		}
+	}
 	providerType := storage.ProviderType(in.Provider)
 	return storage.FilesystemParams{
 		filesystemTag,
+		volumeTag,
 		in.Size,
 		providerType,
 		in.Attributes,


### PR DESCRIPTION
API:
 - add backing-volume tag to filesystem params
 - add methods to storageprovisioner API for watching and retrieving block device info. This will be used in upcoming changes to the storageprovisioner worker for managing volume-backed filesystems.
 - preliminary work to remove VolumeId and FilesystemId from attachment params. It will be up to the storageprovisioner worker to track and match dependencies (based on tags only), and pass IDs to the storage provider as necessary.

LXC:
 - the loop provider is now "dynamic", and so its volumes are never passed to StartInstance. Thus, we must not predicate enabling LXC loop mounts on the presence of loop-provider volumes. We now only check whether or not environ config allows loop mounts (applies to LXC only).

Loop storage provider:
 - the loop storage provider is updated to separate attachment from creation. This enables idempotent attachment via the storageprovisioner worker, so that loop-provider volumes are reattached after machine restarts.

(Review request: http://reviews.vapour.ws/r/1338/)