### PR TITLE
cmd/juju/subnet: Supercommand and create implemented

### DIFF
--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/cmd/juju/service"
 	"github.com/juju/juju/cmd/juju/space"
 	"github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
@@ -212,6 +213,9 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage spaces
 	r.Register(space.NewSuperCommand())
+
+	// Manage subnets
+	r.Register(subnet.NewSuperCommand())
 }
 
 // envCmdWrapper is a struct that wraps an environment command and lets us handle

--- a/cmd/juju/main_test.go
+++ b/cmd/juju/main_test.go
@@ -241,6 +241,7 @@ var commandNames = []string{
 	"stat", // alias for status
 	"status",
 	"storage",
+	"subnet",
 	"switch",
 	"sync-tools",
 	"terminate-machine", // alias for destroy-machine

--- a/cmd/juju/subnet/create.go
+++ b/cmd/juju/subnet/create.go
@@ -1,0 +1,191 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnet
+
+import (
+	"net"
+	"strings"
+
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils/set"
+)
+
+// CreateCommand calls the API to create a new subnet.
+type CreateCommand struct {
+	SubnetCommandBase
+
+	CIDR      string
+	SpaceName string
+	Zones     set.Strings
+	IsPublic  bool
+	IsPrivate bool
+
+	flagSet *gnuflag.FlagSet
+}
+
+const createCommandDoc = `
+Creates a new subnet with a given CIDR, associated with an existing Juju
+network space, and attached to one or more availablility zones. Desired
+access for the subnet can be specified using the mutually exclusive flags
+--private and --public.
+
+When --private is specified (or no flags are given, as this is the default),
+the created subnet will not allow access from outside the environment and
+the available address range is only cloud-local.
+
+When --public is specified, the created subnet will support "shadow addresses"
+(see "juju help glossary" for the full definition of the term). This means
+all machines inside the subnet will have cloud-local addresses configured,
+but there will also be a shadow address configured for each machine, so that
+the machines can be accessed from outside the environment (similarly to the
+automatic public IP addresses supported with AWS VPCs).
+
+This command is only supported on clouds which support creating new subnets
+dynamically (i.e. Software Defined Networking or SDN). If you want to make
+an existing subnet available for Juju to use, rather than creating a new
+one, use the "juju subnet add" command.
+
+Some clouds allow a subnet to span multiple zones, but others do not. It is
+an error to try creating a subnet spanning more than one zone if it is not
+supported.
+`
+
+// Info is defined on the cmd.Command interface.
+func (c *CreateCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "create",
+		Args:    "<CIDR> <space> <zone1> [<zone2> <zone3> ...] [--public|--private]",
+		Purpose: "create a new subnet",
+		Doc:     strings.TrimSpace(createCommandDoc),
+	}
+}
+
+func (c *CreateCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.SubnetCommandBase.SetFlags(f)
+	f.BoolVar(&c.IsPublic, "public", false, "enable public access with shadow addresses")
+	f.BoolVar(&c.IsPrivate, "private", true, "disable public access with shadow addresses")
+
+	// Because SetFlags is called before Parse, we cannot
+	// use f.Visit() here to check both flags were not
+	// specified at once. So we store the flag set and
+	// defer the check to Init().
+	c.flagSet = f
+}
+
+// Init is defined on the cmd.Command interface. It checks the
+// arguments for sanity and sets up the command to run.
+func (c *CreateCommand) Init(args []string) error {
+	// Validate given CIDR.
+	switch len(args) {
+	case 0:
+		return errors.New("CIDR is required")
+	case 1:
+		return errors.New("space name is required")
+	case 2:
+		return errors.New("at least one zone is required")
+	}
+
+	givenCIDR := args[0]
+	_, ipNet, err := net.ParseCIDR(givenCIDR)
+	if err != nil {
+		logger.Debugf("cannot parse %q: %v", givenCIDR, err)
+		return errors.Errorf("%q is not a valid CIDR", givenCIDR)
+	}
+	if ipNet.String() != givenCIDR {
+		expected := ipNet.String()
+		return errors.Errorf("%q is not correctly specified, expected %q", givenCIDR, expected)
+	}
+	c.CIDR = givenCIDR
+
+	// Validate the space name.
+	givenSpace := args[1]
+	if !names.IsValidSpace(givenSpace) {
+		return errors.Errorf("%q is not a valid space name", givenSpace)
+	}
+	c.SpaceName = givenSpace
+
+	// Validate any given zones.
+	c.Zones = set.NewStrings()
+	for _, zone := range args[2:] {
+		if c.Zones.Contains(zone) {
+			return errors.Errorf("duplicate zone %q specified", zone)
+		}
+		c.Zones.Add(zone)
+	}
+
+	// Ensure --public and --private are not both specified.
+	// TODO(dimitern): This is a really awkward way to handle
+	// mutually exclusive bool flags and needs to be factored
+	// out in a helper if another command needs to do it.
+	var publicSet, privateSet bool
+	c.flagSet.Visit(func(flag *gnuflag.Flag) {
+		switch flag.Name {
+		case "public":
+			publicSet = true
+		case "private":
+			privateSet = true
+		}
+	})
+	switch {
+	case publicSet && privateSet:
+		return errors.Errorf("cannot specify both --public and --private")
+	case publicSet:
+		c.IsPrivate = false
+	case privateSet:
+		c.IsPublic = false
+	}
+
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *CreateCommand) Run(ctx *cmd.Context) error {
+	api, err := c.NewAPI()
+	if err != nil {
+		return errors.Annotate(err, "cannot connect to API server")
+	}
+	defer api.Close()
+
+	if !c.Zones.IsEmpty() {
+		// Fetch all zones to validate the given zones.
+		zones, err := api.AllZones()
+		if err != nil {
+			return errors.Annotate(err, "cannot fetch availability zones")
+		}
+
+		// Find which of the given CIDRs match existing ones.
+		validZones := set.NewStrings()
+		for _, zone := range zones {
+			validZones.Add(zone)
+		}
+		diff := c.Zones.Difference(validZones)
+
+		if !diff.IsEmpty() {
+			// Some given zones are missing.
+			zones := strings.Join(diff.SortedValues(), ", ")
+			return errors.Errorf("unknown zones specified: %s", zones)
+		}
+	}
+
+	// Create the new subnet.
+	err = api.CreateSubnet(c.CIDR, c.SpaceName, c.Zones.SortedValues(), c.IsPublic)
+	if err != nil {
+		return errors.Annotatef(err, "cannot create subnet %q", c.CIDR)
+	}
+
+	zones := strings.Join(c.Zones.SortedValues(), ", ")
+	accessType := "private"
+	if c.IsPublic {
+		accessType = "public"
+	}
+	ctx.Infof(
+		"created a %s subnet %q in space %q with zones %s",
+		accessType, c.CIDR, c.SpaceName, zones,
+	)
+	return nil
+}

--- a/cmd/juju/subnet/create_test.go
+++ b/cmd/juju/subnet/create_test.go
@@ -1,0 +1,259 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnet_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/subnet"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type CreateSuite struct {
+	BaseSubnetSuite
+}
+
+var _ = gc.Suite(&CreateSuite{})
+
+func (s *CreateSuite) SetUpTest(c *gc.C) {
+	s.BaseSubnetSuite.SetUpTest(c)
+	s.command = subnet.NewCreateCommand(s.api)
+	c.Assert(s.command, gc.NotNil)
+}
+
+func (s *CreateSuite) TestInit(c *gc.C) {
+	for i, test := range []struct {
+		about         string
+		args          []string
+		expectCIDR    string
+		expectSpace   string
+		expectZones   []string
+		expectPublic  bool
+		expectPrivate bool
+		expectErr     string
+	}{{
+		about:         "no arguments",
+		expectErr:     "CIDR is required",
+		expectPrivate: true,
+	}, {
+		about:         "only a subnet argument (invalid)",
+		args:          s.Strings("foo"),
+		expectPrivate: true,
+		expectErr:     "space name is required",
+	}, {
+		about:         "no zone arguments (both CIDR and space are invalid)",
+		args:          s.Strings("foo", "%invalid"),
+		expectPrivate: true,
+		expectErr:     "at least one zone is required",
+	}, {
+		about:         "invalid CIDR",
+		args:          s.Strings("foo", "space", "zone"),
+		expectPrivate: true,
+		expectErr:     `"foo" is not a valid CIDR`,
+	}, {
+		about:         "incorrectly specified CIDR",
+		args:          s.Strings("5.4.3.2/10", "space", "zone"),
+		expectPrivate: true,
+		expectErr:     `"5.4.3.2/10" is not correctly specified, expected "5.0.0.0/10"`,
+	}, {
+		about:         "invalid space name - using invalid characters",
+		args:          s.Strings("10.10.0.0/24", "%inv$alid", "zone"),
+		expectCIDR:    "10.10.0.0/24",
+		expectPrivate: true,
+		expectErr:     `"%inv\$alid" is not a valid space name`,
+	}, {
+		about:         "invalid space name - using underscores",
+		args:          s.Strings("10.10.0.0/24", "42_space", "zone"),
+		expectCIDR:    "10.10.0.0/24",
+		expectPrivate: true,
+		expectErr:     `"42_space" is not a valid space name`,
+	}, {
+		about:         "duplicate zones specified",
+		args:          s.Strings("10.10.0.0/24", "myspace", "zone1", "zone2", "zone1"),
+		expectCIDR:    "10.10.0.0/24",
+		expectSpace:   "myspace",
+		expectZones:   s.Strings("zone1", "zone2"),
+		expectPrivate: true,
+		expectErr:     `duplicate zone "zone1" specified`,
+	}, {
+		about:         "both --public and --private specified",
+		args:          s.Strings("10.1.0.0/16", "new-space", "zone", "--public", "--private"),
+		expectCIDR:    "10.1.0.0/16",
+		expectSpace:   "new-space",
+		expectZones:   s.Strings("zone"),
+		expectErr:     `cannot specify both --public and --private`,
+		expectPublic:  true,
+		expectPrivate: true,
+	}, {
+		about:         "--public specified",
+		args:          s.Strings("10.1.0.0/16", "new-space", "zone", "--public"),
+		expectCIDR:    "10.1.0.0/16",
+		expectSpace:   "new-space",
+		expectZones:   s.Strings("zone"),
+		expectPublic:  true,
+		expectPrivate: false,
+		expectErr:     "",
+	}, {
+		about:         "--private explicitly specified",
+		args:          s.Strings("10.1.0.0/16", "new-space", "zone", "--private"),
+		expectCIDR:    "10.1.0.0/16",
+		expectSpace:   "new-space",
+		expectZones:   s.Strings("zone"),
+		expectPublic:  false,
+		expectPrivate: true,
+		expectErr:     "",
+	}, {
+		about:         "--private specified out of order",
+		args:          s.Strings("2001:db8::/32", "--private", "space", "zone"),
+		expectCIDR:    "2001:db8::/32",
+		expectSpace:   "space",
+		expectZones:   s.Strings("zone"),
+		expectPublic:  false,
+		expectPrivate: true,
+		expectErr:     "",
+	}, {
+		about:         "--public specified twice",
+		args:          s.Strings("--public", "2001:db8::/32", "--public", "space", "zone"),
+		expectCIDR:    "2001:db8::/32",
+		expectSpace:   "space",
+		expectZones:   s.Strings("zone"),
+		expectPublic:  true,
+		expectPrivate: false,
+		expectErr:     "",
+	}} {
+		c.Logf("test #%d: %s", i, test.about)
+		// Create a new instance of the subcommand for each test, but
+		// since we're not running the command no need to use
+		// envcmd.Wrap().
+		command := subnet.NewCreateCommand(s.api)
+		err := coretesting.InitCommand(command, test.args)
+		if test.expectErr != "" {
+			c.Check(err, gc.ErrorMatches, test.expectErr)
+		} else {
+			c.Check(err, jc.ErrorIsNil)
+		}
+		c.Check(command.CIDR, gc.Equals, test.expectCIDR)
+		c.Check(command.SpaceName, gc.Equals, test.expectSpace)
+		c.Check(command.Zones.SortedValues(), jc.DeepEquals, test.expectZones)
+		c.Check(command.IsPublic, gc.Equals, test.expectPublic)
+		c.Check(command.IsPrivate, gc.Equals, test.expectPrivate)
+		// No API calls should be recorded at this stage.
+		s.api.CheckCallNames(c)
+	}
+}
+
+func (s *CreateSuite) TestRunOneZoneSucceeds(c *gc.C) {
+	stdout, stderr, err := s.RunSubCommand(
+		c, "10.20.0.0/24", "myspace", "zone1",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Matches,
+		`created a private subnet "10.20.0.0/24" in space "myspace" with zones zone1\n`,
+	)
+	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
+	s.api.CheckCall(c, 1, "CreateSubnet",
+		"10.20.0.0/24", "myspace", s.Strings("zone1"), false,
+	)
+}
+
+func (s *CreateSuite) TestRunWithPublicAndIPv6CIDRSucceeds(c *gc.C) {
+	stdout, stderr, err := s.RunSubCommand(
+		c, "2001:db8::/32", "space", "zone1", "--public",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Matches,
+		`created a public subnet "2001:db8::/32" in space "space" with zones zone1\n`,
+	)
+	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
+	s.api.CheckCall(c, 1, "CreateSubnet",
+		"2001:db8::/32", "space", s.Strings("zone1"), true,
+	)
+}
+
+func (s *CreateSuite) TestRunWithMultipleZonesSucceeds(c *gc.C) {
+	stdout, stderr, err := s.RunSubCommand(
+		c, "10.20.0.0/24", "foo", "zone2", "zone1",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stdout, gc.Equals, "")
+	// The list of zones is sorted both when displayed and passed to
+	// CreateSubnet.
+	c.Assert(stderr, gc.Matches,
+		`created a private subnet "10.20.0.0/24" in space "foo" with zones zone1, zone2\n`,
+	)
+	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
+	s.api.CheckCall(c, 1, "CreateSubnet",
+		"10.20.0.0/24", "foo", s.Strings("zone1", "zone2"), false,
+	)
+}
+
+func (s *CreateSuite) TestRunWithAllZonesErrorFails(c *gc.C) {
+	s.api.SetErrors(errors.New("boom"))
+
+	stdout, stderr, err := s.RunSubCommand(c, "10.10.0.0/24", "space", "zone1")
+	c.Assert(err, gc.ErrorMatches,
+		`cannot fetch availability zones: boom`,
+	)
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+	s.api.CheckCallNames(c, "AllZones", "Close")
+}
+
+func (s *CreateSuite) TestRunWithExistingSubnetFails(c *gc.C) {
+	s.api.SetErrors(nil, errors.AlreadyExistsf("subnet %q", "10.10.0.0/24"))
+
+	stdout, stderr, err := s.RunSubCommand(c, "10.10.0.0/24", "space", "zone1")
+	c.Assert(err, gc.ErrorMatches,
+		`cannot create subnet "10.10.0.0/24": subnet "10.10.0.0/24" already exists`,
+	)
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
+	s.api.CheckCall(c, 1, "CreateSubnet",
+		"10.10.0.0/24", "space", s.Strings("zone1"), false,
+	)
+}
+
+func (s *CreateSuite) TestRunWithNonExistingSpaceFails(c *gc.C) {
+	s.api.SetErrors(nil, errors.NotFoundf("space %q", "space"))
+
+	stdout, stderr, err := s.RunSubCommand(c, "10.10.0.0/24", "space", "zone1")
+	c.Assert(err, gc.ErrorMatches,
+		`cannot create subnet "10.10.0.0/24": space "space" not found`,
+	)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
+	s.api.CheckCall(c, 1, "CreateSubnet",
+		"10.10.0.0/24", "space", s.Strings("zone1"), false,
+	)
+}
+
+func (s *CreateSuite) TestRunWithUnknownZonesFails(c *gc.C) {
+	stdout, stderr, err := s.RunSubCommand(
+		c, "10.30.30.0/24", "space", "no-zone", "zone1", "foo",
+	)
+	// The list of unknown zones is sorted.
+	c.Assert(err, gc.ErrorMatches, "unknown zones specified: foo, no-zone")
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+	s.api.CheckCallNames(c, "AllZones", "Close")
+}
+
+func (s *CreateSuite) TestRunAPIConnectFails(c *gc.C) {
+	// TODO(dimitern): Change this once API is implemented.
+	s.command = subnet.NewCreateCommand(nil)
+	stdout, stderr, err := s.RunSubCommand(c, "10.10.0.0/24", "space", "zone1")
+	c.Assert(err, gc.ErrorMatches, "cannot connect to API server: API not implemented yet!")
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+	// No API calls recoreded.
+	s.api.CheckCallNames(c)
+}

--- a/cmd/juju/subnet/export_test.go
+++ b/cmd/juju/subnet/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnet
+
+func NewCreateCommand(api SubnetAPI) *CreateCommand {
+	createCmd := &CreateCommand{}
+	createCmd.api = api
+	return createCmd
+}

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -1,0 +1,150 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnet_test
+
+import (
+	"regexp"
+	stdtesting "testing"
+
+	"github.com/juju/cmd"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/subnet"
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+// BaseSubnetSuite is used for embedding in other suites.
+type BaseSubnetSuite struct {
+	coretesting.FakeJujuHomeSuite
+	coretesting.BaseSuite
+
+	superCmd cmd.Command
+	command  cmd.Command
+	api      *StubAPI
+}
+
+var _ = gc.Suite(&BaseSubnetSuite{})
+
+func (s *BaseSubnetSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.FakeJujuHomeSuite.SetUpTest(c)
+
+	s.superCmd = subnet.NewSuperCommand()
+	c.Assert(s.superCmd, gc.NotNil)
+
+	s.api = NewStubAPI()
+	c.Assert(s.api, gc.NotNil)
+
+	// All subcommand suites embedding this one should initialize
+	// s.command immediately after calling this method!
+}
+
+// RunSuperCommand executes the super command passing any args and
+// returning the stdout and stderr output as strings, as well as any
+// error. If s.command is set, the subcommand's name will be passed as
+// first argument.
+func (s *BaseSubnetSuite) RunSuperCommand(c *gc.C, args ...string) (string, string, error) {
+	if s.command != nil {
+		args = append([]string{s.command.Info().Name}, args...)
+	}
+	ctx, err := coretesting.RunCommand(c, s.superCmd, args...)
+	if ctx != nil {
+		return coretesting.Stdout(ctx), coretesting.Stderr(ctx), err
+	}
+	return "", "", err
+}
+
+// RunSubCommand executes the s.command subcommand passing any args
+// and returning the stdout and stderr output as strings, as well as
+// any error.
+func (s *BaseSubnetSuite) RunSubCommand(c *gc.C, args ...string) (string, string, error) {
+	if s.command == nil {
+		panic("subcommand is nil")
+	}
+	ctx, err := coretesting.RunCommand(c, s.command, args...)
+	if ctx != nil {
+		return coretesting.Stdout(ctx), coretesting.Stderr(ctx), err
+	}
+	return "", "", err
+}
+
+// TestHelp runs the command with --help as argument and verifies the
+// output.
+func (s *BaseSubnetSuite) TestHelp(c *gc.C) {
+	stderr, stdout, err := s.RunSuperCommand(c, "--help")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Not(gc.Equals), "")
+
+	// If s.command is set, use it instead of s.superCmd.
+	cmdInfo := s.superCmd.Info()
+	var expected string
+	if s.command != nil {
+		// Subcommands embed EnvCommandBase and have an extra
+		// "[options]" prepended before the args.
+		cmdInfo = s.command.Info()
+		expected = "(?sm).*^usage: juju subnet " +
+			regexp.QuoteMeta(cmdInfo.Name) +
+			` \[options\] ` + regexp.QuoteMeta(cmdInfo.Args) + ".+"
+	} else {
+		expected = "(?sm).*^usage: juju subnet " +
+			regexp.QuoteMeta(cmdInfo.Args) + ".+"
+	}
+	c.Check(cmdInfo, gc.NotNil)
+	c.Check(stderr, gc.Matches, expected)
+
+	expected = "(?sm).*^purpose: " + regexp.QuoteMeta(cmdInfo.Purpose) + "$.*"
+	c.Check(stderr, gc.Matches, expected)
+
+	expected = "(?sm).*^" + regexp.QuoteMeta(cmdInfo.Doc) + "$.*"
+	c.Check(stderr, gc.Matches, expected)
+}
+
+// Strings is makes tests taking a slice of strings slightly easier to
+// write: e.g. s.Strings("foo", "bar") vs. []string{"foo", "bar"}.
+func (s *BaseSubnetSuite) Strings(values ...string) []string {
+	return values
+}
+
+// StubAPI defines a testing stub for the SubnetAPI interface.
+type StubAPI struct {
+	*testing.Stub
+
+	Zones []string
+}
+
+var _ subnet.SubnetAPI = (*StubAPI)(nil)
+
+// NewStubAPI creates a StubAPI suitable for passing to
+// subnet.New*Command().
+func NewStubAPI() *StubAPI {
+	return &StubAPI{
+		Stub:  &testing.Stub{},
+		Zones: []string{"zone1", "zone2"},
+	}
+}
+
+func (sa *StubAPI) Close() error {
+	sa.MethodCall(sa, "Close")
+	return sa.NextErr()
+}
+
+func (sa *StubAPI) AllZones() ([]string, error) {
+	sa.MethodCall(sa, "AllZones")
+	if err := sa.NextErr(); err != nil {
+		return nil, err
+	}
+	return sa.Zones, nil
+}
+
+func (sa *StubAPI) CreateSubnet(subnetCIDR, spaceName string, zones []string, isPublic bool) error {
+	sa.MethodCall(sa, "CreateSubnet", subnetCIDR, spaceName, zones, isPublic)
+	return sa.NextErr()
+}

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnet
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
+// SubnetAPI defines the necessary API methods needed by the subnet
+// subcommands.
+type SubnetAPI interface {
+	io.Closer
+
+	// AllZones returns all availability zones known to Juju.
+	AllZones() ([]string, error)
+
+	// CreateSubnet creates a new Juju subnet.
+	CreateSubnet(subnetCIDR, spaceName string, zones []string, isPublic bool) error
+}
+
+var logger = loggo.GetLogger("juju.cmd.juju.subnet")
+
+const commandDoc = `
+"juju subnet" provides commands to manage Juju subnets.
+`
+
+// NewSuperCommand creates the "subnet" supercommand and registers the
+// subcommands that it supports.
+func NewSuperCommand() cmd.Command {
+	subnetCmd := cmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name:        "subnet",
+		Doc:         strings.TrimSpace(commandDoc),
+		UsagePrefix: "juju",
+		Purpose:     "manage subnets",
+	})
+	subnetCmd.Register(envcmd.Wrap(&CreateCommand{}))
+
+	return subnetCmd
+}
+
+// SubnetCommandBase is the base type embedded into all subnet
+// subcommands.
+type SubnetCommandBase struct {
+	envcmd.EnvCommandBase
+	api SubnetAPI
+}
+
+// NewAPI returns a SubnetAPI for the root api endpoint that the
+// environment command returns.
+func (c *SubnetCommandBase) NewAPI() (SubnetAPI, error) {
+	// TODO(dimitern): Change this once the API is implemented.
+
+	if c.api != nil {
+		// Already created.
+		return c.api, nil
+	}
+
+	return nil, errors.New("API not implemented yet!")
+}

--- a/cmd/juju/subnet/subnet_test.go
+++ b/cmd/juju/subnet/subnet_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnet_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+var subcommandNames = []string{
+	"create",
+	"help",
+}
+
+type SubnetCommandSuite struct {
+	BaseSubnetSuite
+}
+
+var _ = gc.Suite(&SubnetCommandSuite{})
+
+func (s *SubnetCommandSuite) TestHelpSubcommands(c *gc.C) {
+	ctx, err := coretesting.RunCommand(c, s.superCmd, "--help")
+	c.Assert(err, jc.ErrorIsNil)
+
+	namesFound := coretesting.ExtractCommandsFromHelpOutput(ctx)
+	c.Assert(namesFound, jc.SameContents, subcommandNames)
+}


### PR DESCRIPTION
Introducing the "juju subnet" supercommand and the first subcommand
"create", which will be used to manage subnets in Juju. This includes
only the CLI args parsing and testing with a stub API.

(Review request: http://reviews.vapour.ws/r/1339/)