### PR TITLE
IP address lifecycle watcher and worker

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -852,5 +852,8 @@ func (s *provisionerSuite) TestReleaseContainerAddresses(c *gc.C) {
 
 	addresses, err := s.State.AllocatedIPAddresses(container.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addresses, jc.DeepEquals, []*state.IPAddress{})
+	c.Assert(addresses, gc.HasLen, 3)
+	for _, addr := range addresses {
+		c.Assert(addr.Life(), gc.Equals, state.Dead)
+	}
 }

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -240,13 +240,19 @@ func (s *prepareSuite) TestErrorsWithNonMachineOrInvalidTags(c *gc.C) {
 	}}
 
 	s.assertCall(c, args, s.makeErrors(
+		apiservertesting.ServerError(
+			`"unit-wordpress-0" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"service-wordpress" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"network-foo" is not a valid machine tag`),
+		apiservertesting.ServerError(
+			`"anything-invalid" is not a valid tag`),
+		apiservertesting.ServerError(
+			`"42" is not a valid tag`),
 		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
-		apiservertesting.ErrUnauthorized,
+		apiservertesting.ServerError(
+			`"" is not a valid tag`),
 	), "")
 }
 
@@ -682,7 +688,7 @@ func (s *releaseSuite) TestErrorWithHostInsteadOfContainer(c *gc.C) {
 	args := s.makeArgs(s.machines[0])
 	err := s.assertCall(c, args, s.makeErrors(
 		apiservertesting.ServerError(
-			`cannot release address for "machine-0": not a container`,
+			`cannot mark addresses for removal for "machine-0": not a container`,
 		),
 	), "")
 	c.Assert(err, jc.ErrorIsNil)
@@ -767,21 +773,6 @@ func (s *releaseSuite) allocateAddresses(c *gc.C, containerId string, numAllocat
 	}
 }
 
-func (s *releaseSuite) TestErrorWithFailingReleaseAddress(c *gc.C) {
-	container := s.newAPI(c, true, true)
-	args := s.makeArgs(container)
-
-	s.allocateAddresses(c, container.Id(), 2)
-	s.breakEnvironMethods(c, "ReleaseAddress")
-	err := s.assertCall(c, args, s.makeErrors(
-		apiservertesting.ServerError(
-			`failed to release all addresses for "machine-0-lxc-0": `+
-				`[dummy.ReleaseAddress is broken dummy.ReleaseAddress is broken]`,
-		),
-	), "")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *releaseSuite) TestReleaseContainerAddresses(c *gc.C) {
 	container := s.newAPI(c, true, true)
 	args := s.makeArgs(container)
@@ -791,5 +782,8 @@ func (s *releaseSuite) TestReleaseContainerAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	addresses, err := s.BackingState.AllocatedIPAddresses(container.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addresses, jc.DeepEquals, []*state.IPAddress{})
+	c.Assert(addresses, gc.HasLen, 2)
+	for _, addr := range addresses {
+		c.Assert(addr.Life(), gc.Equals, state.Dead)
+	}
 }

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -859,6 +859,15 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 				releaseErrors = append(releaseErrors, err)
 				continue
 			}
+
+			// TODO: (mfoord) Temporary fix until we have an
+			// address worker.
+			err = addr.EnsureDead()
+			if err != nil {
+				logger.Warningf("failed to remove address %v for container %q: %v", addr.Value, tag, err)
+				releaseErrors = append(releaseErrors, err)
+				continue
+			}
 			err = addr.Remove()
 			if err != nil {
 				logger.Warningf("failed to remove address %v for container %q: %v", addr.Value, tag, err)

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -800,22 +800,24 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 	return result, nil
 }
 
-// ReleaseContainerAddresses releases addresses allocated to a container. It
-// accepts container tags as arguments.
+// ReleaseContainerAddresses finds addresses allocated to a container and marks
+// them as Dead, to be released and removed. It accepts container tags as
+// arguments.
 func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
-	// Some preparations first.
-	environ, _, canAccess, err := p.prepareContainerAccessEnvironment()
-	if err != nil {
-		return result, err
-	}
 
+	canAccess, err := p.getAuthFunc()
+	if err != nil {
+		logger.Errorf("failed to get an authorisation function: %v", err)
+		return result, errors.Trace(err)
+	}
 	// Loop over the passed container tags.
 	for i, entity := range args.Entities {
 		tag, err := names.ParseMachineTag(entity.Tag)
 		if err != nil {
+			logger.Warningf("failed to parse machine tag %q: %v", entity.Tag, err)
 			result.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
@@ -825,17 +827,11 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 		// machine has the host as a parent.
 		container, err := p.getMachine(canAccess, tag)
 		if err != nil {
+			logger.Warningf("failed to get machine %q: %v", tag, err)
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		} else if !container.IsContainer() {
-			err = errors.Errorf("cannot release address for %q: not a container", tag)
-			result.Results[i].Error = common.ServerError(err)
-			continue
-		}
-
-		ciid, err := container.InstanceId()
-		if err != nil {
-			logger.Warningf("failed to get InstanceId for container %q: %v", tag, err)
+			err = errors.Errorf("cannot mark addresses for removal for %q: not a container", tag)
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
@@ -848,34 +844,17 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 			continue
 		}
 
-		releaseErrors := []error{}
+		deadErrors := []error{}
 		logger.Debugf("for container %q found addresses %v", tag, addresses)
 		for _, addr := range addresses {
-			err := environ.ReleaseAddress(ciid, network.Id(addr.SubnetId()), addr.Address())
-			if err != nil {
-				// Don't remove the address from state so we
-				// can retry releasing the address later.
-				logger.Warningf("failed to release address %v for container %q: %v", addr.Value, tag, err)
-				releaseErrors = append(releaseErrors, err)
-				continue
-			}
-
-			// TODO: (mfoord) Temporary fix until we have an
-			// address worker.
 			err = addr.EnsureDead()
 			if err != nil {
-				logger.Warningf("failed to remove address %v for container %q: %v", addr.Value, tag, err)
-				releaseErrors = append(releaseErrors, err)
+				deadErrors = append(deadErrors, err)
 				continue
 			}
-			err = addr.Remove()
-			if err != nil {
-				logger.Warningf("failed to remove address %v for container %q: %v", addr.Value, tag, err)
-				releaseErrors = append(releaseErrors, err)
-			}
 		}
-		if len(releaseErrors) != 0 {
-			err = errors.Errorf("failed to release all addresses for %q: %v", tag, releaseErrors)
+		if len(deadErrors) != 0 {
+			err = errors.Errorf("failed to mark all addresses for removal for %q: %v", tag, deadErrors)
 			result.Results[i].Error = common.ServerError(err)
 		}
 	}
@@ -911,7 +890,7 @@ func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (pa
 	for i, entity := range args.Entities {
 		tag, err := names.ParseMachineTag(entity.Tag)
 		if err != nil {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -60,6 +60,7 @@ import (
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/addresser"
 	"github.com/juju/juju/worker/apiaddressupdater"
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
@@ -1052,6 +1053,9 @@ func (a *MachineAgent) startEnvWorkers(
 	})
 	singularRunner.StartWorker("minunitsworker", func() (worker.Worker, error) {
 		return minunitsworker.NewMinUnitsWorker(st), nil
+	})
+	singularRunner.StartWorker("addresserworker", func() (worker.Worker, error) {
+		return addresser.NewWorker(st)
 	})
 
 	// Start workers that use an API connection.

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -240,6 +240,7 @@ type MachineSuite struct {
 var perEnvSingularWorkers = []string{
 	"cleaner",
 	"minunitsworker",
+	"addresserworker",
 	"environ-provisioner",
 	"charm-revision-updater",
 	"firewaller",

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -510,7 +510,8 @@ func (env *maasEnviron) getCapabilities() (set.Strings, error) {
 			if err, ok := err.(gomaasapi.ServerError); ok && err.StatusCode == 404 {
 				return caps, fmt.Errorf("MAAS does not support version info")
 			}
-			return caps, err
+		} else {
+			break
 		}
 	}
 	if err != nil {

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -211,7 +211,6 @@ func (i *IPAddress) SetState(newState AddressState) (err error) {
 			} else if err != nil {
 				return nil, err
 			}
-
 		}
 		return []txn.Op{{
 			C:      ipaddressesC,
@@ -247,7 +246,6 @@ func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
 			} else if err != nil {
 				return nil, err
 			}
-
 		}
 		return []txn.Op{{
 			C:      ipaddressesC,

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -5,6 +5,8 @@ package state
 
 import (
 	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
@@ -40,6 +42,11 @@ func (s AddressState) String() string {
 	return string(s)
 }
 
+// GoString implements fmt.GoStringer.
+func (i *IPAddress) GoString() string {
+	return i.String()
+}
+
 // IPAddress represents the state of an IP address.
 type IPAddress struct {
 	st  *State
@@ -49,6 +56,7 @@ type IPAddress struct {
 type ipaddressDoc struct {
 	DocID       string       `bson:"_id"`
 	EnvUUID     string       `bson:"env-uuid"`
+	Life        Life         `bson:"life"`
 	SubnetId    string       `bson:"subnetid,omitempty"`
 	MachineId   string       `bson:"machineid,omitempty"`
 	InterfaceId string       `bson:"interfaceid,omitempty"`
@@ -56,6 +64,11 @@ type ipaddressDoc struct {
 	Type        string       `bson:"type"`
 	Scope       string       `bson:"networkscope,omitempty"`
 	State       AddressState `bson:"state"`
+}
+
+// Life returns whether the IP address is Alive, Dying or Dead.
+func (i *IPAddress) Life() Life {
+	return i.doc.Life
 }
 
 // SubnetId returns the ID of the subnet the IP address is associated with. If
@@ -109,17 +122,73 @@ func (i *IPAddress) String() string {
 	return i.Address().String()
 }
 
+// EnsureDead sets the Life of the IP address to Dead, if it's Alive. It
+// does nothing otherwise.
+func (i *IPAddress) EnsureDead() (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot set address %q to dead", i)
+
+	if i.doc.Life == Dead {
+		return nil
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := i.Refresh(); err != nil {
+				// Address is either gone or
+				// another error occurred.
+				return nil, err
+			}
+			if i.Life() == Dead {
+				return nil, jujutxn.ErrNoOperations
+			}
+			return nil, errors.Errorf("unexpected life value: %s", i.Life().String())
+		}
+		return []txn.Op{{
+			C:      ipaddressesC,
+			Id:     i.doc.DocID,
+			Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
+			Assert: isAliveDoc,
+		}}, nil
+	}
+
+	err = i.st.run(buildTxn)
+	if err != nil {
+		return err
+	}
+
+	i.doc.Life = Dead
+	return nil
+}
+
 // Remove removes an existing IP address. Trying to remove a missing
 // address is not an error.
 func (i *IPAddress) Remove() (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot remove IP address %q", i)
 
-	ops := []txn.Op{{
-		C:      ipaddressesC,
-		Id:     i.doc.DocID,
-		Remove: true,
-	}}
-	return i.st.runTransaction(ops)
+	if i.doc.Life != Dead {
+		return errors.New("IP address is not dead")
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := i.Refresh(); errors.IsNotFound(err) {
+				return nil, jujutxn.ErrNoOperations
+			} else if err != nil {
+				return nil, err
+			}
+			if i.Life() != Dead {
+				return nil, errors.New("address is not dead")
+			}
+		}
+		return []txn.Op{{
+			C:      ipaddressesC,
+			Id:     i.doc.DocID,
+			Assert: isDeadDoc,
+			Remove: true,
+		}}, nil
+	}
+
+	return i.st.run(buildTxn)
 }
 
 // SetState sets the State of an IPAddress. Valid state transitions
@@ -130,19 +199,33 @@ func (i *IPAddress) SetState(newState AddressState) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set IP address %q to state %q", i, newState)
 
 	validStates := []AddressState{AddressStateUnknown, newState}
-	unknownOrSame := bson.D{{"state", bson.D{{"$in", validStates}}}}
-	ops := []txn.Op{{
-		C:      ipaddressesC,
-		Id:     i.doc.DocID,
-		Assert: unknownOrSame,
-		Update: bson.D{{"$set", bson.D{{"state", string(newState)}}}},
-	}}
-	if err = i.st.runTransaction(ops); err != nil {
-		return onAbort(
-			err,
-			errors.NotValidf("transition from %q", i.doc.State),
-		)
+	unknownOrSame := bson.DocElem{"state", bson.D{{"$in", validStates}}}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := i.Refresh(); errors.IsNotFound(err) {
+				return nil, err
+			} else if i.Life() == Dead {
+				return nil, errors.New("address is dead")
+			} else if i.State() != AddressStateUnknown {
+				return nil, errors.NotValidf("transition from %q", i.doc.State)
+			} else if err != nil {
+				return nil, err
+			}
+
+		}
+		return []txn.Op{{
+			C:      ipaddressesC,
+			Id:     i.doc.DocID,
+			Assert: append(isAliveDoc, unknownOrSame),
+			Update: bson.D{{"$set", bson.D{{"state", string(newState)}}}},
+		}}, nil
 	}
+
+	err = i.st.run(buildTxn)
+	if err != nil {
+		return err
+	}
+
 	i.doc.State = newState
 	return nil
 }
@@ -153,25 +236,54 @@ func (i *IPAddress) SetState(newState AddressState) (err error) {
 func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot allocate IP address %q to machine %q, interface %q", i, machineId, interfaceId)
 
-	ops := []txn.Op{{
-		C:      ipaddressesC,
-		Id:     i.doc.DocID,
-		Assert: bson.D{{"state", AddressStateUnknown}},
-		Update: bson.D{{"$set", bson.D{
-			{"machineid", machineId},
-			{"interfaceid", interfaceId},
-			{"state", string(AddressStateAllocated)},
-		}}},
-	}}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err := i.Refresh(); errors.IsNotFound(err) {
+				return nil, err
+			} else if i.Life() == Dead {
+				return nil, errors.New("address is dead")
+			} else if i.State() != AddressStateUnknown {
+				return nil, errors.Errorf("already allocated or unavailable")
+			} else if err != nil {
+				return nil, err
+			}
 
-	if err = i.st.runTransaction(ops); err != nil {
-		return onAbort(
-			err,
-			errors.Errorf("already allocated or unavailable"),
-		)
+		}
+		return []txn.Op{{
+			C:      ipaddressesC,
+			Id:     i.doc.DocID,
+			Assert: append(isAliveDoc, bson.DocElem{"state", AddressStateUnknown}),
+			Update: bson.D{{"$set", bson.D{
+				{"machineid", machineId},
+				{"interfaceid", interfaceId},
+				{"state", string(AddressStateAllocated)},
+			}}},
+		}}, nil
+	}
+
+	err = i.st.run(buildTxn)
+	if err != nil {
+		return err
 	}
 	i.doc.MachineId = machineId
 	i.doc.InterfaceId = interfaceId
 	i.doc.State = AddressStateAllocated
+	return nil
+}
+
+// Refresh refreshes the contents of the IPAddress from the underlying
+// state. It an error that satisfies errors.IsNotFound if the Subnet has
+// been removed.
+func (i *IPAddress) Refresh() error {
+	addresses, closer := i.st.getCollection(ipaddressesC)
+	defer closer()
+
+	err := addresses.FindId(i.doc.DocID).One(&i.doc)
+	if err == mgo.ErrNotFound {
+		return errors.NotFoundf("IP address %q", i)
+	}
+	if err != nil {
+		return errors.Annotatef(err, "cannot refresh IP address %q", i)
+	}
 	return nil
 }

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -42,11 +42,6 @@ func (s AddressState) String() string {
 	return string(s)
 }
 
-// GoString implements fmt.GoStringer.
-func (i *IPAddress) GoString() string {
-	return i.String()
-}
-
 // IPAddress represents the state of an IP address.
 type IPAddress struct {
 	st  *State
@@ -120,6 +115,11 @@ func (i *IPAddress) State() AddressState {
 // String implements fmt.Stringer.
 func (i *IPAddress) String() string {
 	return i.Address().String()
+}
+
+// GoString implements fmt.GoStringer.
+func (i *IPAddress) GoString() string {
+	return i.String()
 }
 
 // EnsureDead sets the Life of the IP address to Dead, if it's Alive. It

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -294,7 +294,7 @@ func (s *IPAddressSuite) TestDeadIPAddresses(c *gc.C) {
 		{"0.1.2.6", "wobble"},
 	}
 	for i, details := range addresses {
-		addr := network.NewAddress(details[0])
+		addr := network.NewAddress(details[0], network.ScopePublic)
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
 		err = ipAddr.AllocateTo(details[1], "wobble")

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -44,6 +46,7 @@ func (s *IPAddressSuite) TestAddIPAddress(c *gc.C) {
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertAddress(c, ipAddr, addr, state.AddressStateUnknown, "", "", "foobar")
+		c.Assert(ipAddr.Life(), gc.Equals, state.Alive)
 
 		// verify the address was stored in the state
 		ipAddr, err = s.State.IPAddress(test)
@@ -76,21 +79,64 @@ func (s *IPAddressSuite) TestIPAddressNotFound(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `IP address "0.1.2.3" not found`)
 }
 
-func (s *IPAddressSuite) TestRemove(c *gc.C) {
+func (s *IPAddressSuite) TestEnsureDeadRemove(c *gc.C) {
 	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Should not be able to remove an Alive IP address.
+	c.Assert(ipAddr.Life(), gc.Equals, state.Alive)
+	err = ipAddr.Remove()
+	msg := fmt.Sprintf("cannot remove IP address %q: IP address is not dead", ipAddr.String())
+	c.Assert(err, gc.ErrorMatches, msg)
+
+	err = ipAddr.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// EnsureDead twice should not be an error
+	err = ipAddr.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = ipAddr.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Doing it twice is also fine.
+	// Remove twice is also fine.
 	err = ipAddr.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.State.IPAddress("0.1.2.3")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(err, gc.ErrorMatches, `IP address "0.1.2.3" not found`)
+}
+
+func (s *IPAddressSuite) TestSetStateDead(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	copyIPAddr, err := s.State.IPAddress("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	err = copyIPAddr.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = ipAddr.SetState(state.AddressStateAllocated)
+	msg := fmt.Sprintf(`cannot set IP address %q to state "allocated": address is dead`, ipAddr.String())
+	c.Assert(err, gc.ErrorMatches, msg)
+}
+
+func (s *IPAddressSuite) TestAllocateToDead(c *gc.C) {
+	addr := network.NewAddress("0.1.2.3", network.ScopePublic)
+	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	copyIPAddr, err := s.State.IPAddress("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	err = copyIPAddr.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msg := fmt.Sprintf(`cannot allocate IP address %q to machine "foobar", interface "wibble": address is dead`, ipAddr.String())
+	err = ipAddr.AllocateTo("foobar", "wibble")
+	c.Assert(err, gc.ErrorMatches, msg)
 }
 
 func (s *IPAddressSuite) TestAddressStateString(c *gc.C) {
@@ -169,11 +215,13 @@ func (s *IPAddressSuite) TestSetState(c *gc.C) {
 		if test.err != "" {
 			c.Check(err, gc.ErrorMatches, test.err)
 			c.Check(err, jc.Satisfies, errors.IsNotValid)
+			c.Check(ipAddr.EnsureDead(), jc.ErrorIsNil)
 			c.Check(ipAddr.Remove(), jc.ErrorIsNil)
 			continue
 		}
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(ipAddr.State(), gc.Equals, test.changeTo)
+		c.Check(ipAddr.EnsureDead(), jc.ErrorIsNil)
 		c.Check(ipAddr.Remove(), jc.ErrorIsNil)
 	}
 }
@@ -236,4 +284,21 @@ func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
 	expected := []*state.IPAddress{addr1, addr2}
 	c.Assert(result, jc.SameContents, expected)
 
+}
+
+func (s *IPAddressSuite) TestRefresh(c *gc.C) {
+	rawAddr := network.NewAddress("0.1.2.3", network.ScopeUnknown)
+	addr, err := s.State.AddIPAddress(rawAddr, "foobar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrCopy, err := s.State.IPAddress(rawAddr.Value)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = addr.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(addrCopy.Life(), gc.Equals, state.Alive)
+	err = addrCopy.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addrCopy.Life(), gc.Equals, state.Dead)
 }

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -286,6 +286,36 @@ func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
 
 }
 
+func (s *IPAddressSuite) TestDeadIPAddresses(c *gc.C) {
+	addresses := [][]string{
+		{"0.1.2.3", "wibble"},
+		{"0.1.2.4", "wibble"},
+		{"0.1.2.5", "wobble"},
+		{"0.1.2.6", "wobble"},
+	}
+	for i, details := range addresses {
+		addr := network.NewAddress(details[0])
+		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+		c.Assert(err, jc.ErrorIsNil)
+		err = ipAddr.AllocateTo(details[1], "wobble")
+		c.Assert(err, jc.ErrorIsNil)
+		if i%2 == 0 {
+			err := ipAddr.EnsureDead()
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			c.Assert(ipAddr.Life(), gc.Equals, state.Alive)
+		}
+	}
+
+	ipAddresses, err := s.State.DeadIPAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	addr1, err := s.State.IPAddress("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	addr3, err := s.State.IPAddress("0.1.2.5")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddresses, jc.SameContents, []*state.IPAddress{addr1, addr3})
+}
+
 func (s *IPAddressSuite) TestRefresh(c *gc.C) {
 	rawAddr := network.NewAddress("0.1.2.3", network.ScopeUnknown)
 	addr, err := s.State.AddIPAddress(rawAddr, "foobar")

--- a/state/state.go
+++ b/state/state.go
@@ -1337,6 +1337,7 @@ func (st *State) AddIPAddress(addr network.Address, subnetid string) (ipaddress 
 	ipDoc := ipaddressDoc{
 		DocID:    addressID,
 		EnvUUID:  st.EnvironUUID(),
+		Life:     Alive,
 		State:    AddressStateUnknown,
 		SubnetId: subnetid,
 		Value:    addr.Value,

--- a/state/state.go
+++ b/state/state.go
@@ -1383,13 +1383,23 @@ func (st *State) IPAddress(value string) (*IPAddress, error) {
 
 // AllocatedIPAddresses returns all the allocated addresses for a machine
 func (st *State) AllocatedIPAddresses(machineId string) ([]*IPAddress, error) {
+	return st.fetchIPAddresses(bson.D{{"machineid", machineId}})
+}
+
+// DeadIPAddresses returns all IP addresses with a Life of Dead
+func (st *State) DeadIPAddresses() ([]*IPAddress, error) {
+	return st.fetchIPAddresses(bson.D{{"life", Dead}})
+}
+
+// fetchIPAddresses is a helper function for finding IP addresses
+func (st *State) fetchIPAddresses(query bson.D) ([]*IPAddress, error) {
 	addresses, closer := st.getCollection(ipaddressesC)
 	result := []*IPAddress{}
 	defer closer()
 	var doc struct {
 		Value string
 	}
-	iter := addresses.Find(bson.D{{"machineid", machineId}}).Iter()
+	iter := addresses.Find(query).Iter()
 	for iter.Next(&doc) {
 		addr, err := st.IPAddress(doc.Value)
 		if err != nil {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2143,7 +2143,7 @@ func (s *StateSuite) TestWatchIPAddresses(c *gc.C) {
 	wc.AssertChangeInSingleEvent()
 
 	// add an IP address
-	addr, err := s.State.AddIPAddress(network.NewAddress("0.1.2.3"), "foo")
+	addr, err := s.State.AddIPAddress(network.NewAddress("0.1.2.3", network.ScopePublic), "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent(addr.Value())
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2136,6 +2136,23 @@ func (s *StateSuite) TestSetUnsupportedConstraintsWarning(c *gc.C) {
 	c.Assert(econs, gc.DeepEquals, cons)
 }
 
+func (s *StateSuite) TestWatchIPAddresses(c *gc.C) {
+	w := s.State.WatchIPAddresses()
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, s.State, w)
+	wc.AssertChangeInSingleEvent()
+
+	// add an IP address
+	addr, err := s.State.AddIPAddress(network.NewAddress("0.1.2.3"), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent(addr.Value())
+
+	// Make it Dead: reported.
+	err = addr.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent(addr.Value())
+}
+
 func (s *StateSuite) TestWatchEnvironmentsBulkEvents(c *gc.C) {
 	// Alive environment...
 	alive, err := s.State.Environment()
@@ -2157,16 +2174,14 @@ func (s *StateSuite) TestWatchEnvironmentsBulkEvents(c *gc.C) {
 	w := s.State.WatchEnvironments()
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, s.State, w)
-	wc.AssertChange(alive.UUID(), dying.UUID())
-	wc.AssertNoChange()
+	wc.AssertChangeInSingleEvent(alive.UUID(), dying.UUID())
 
 	// Remove alive and dying and see changes reported.
 	err = state.RemoveEnvironment(s.State, dying.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 	err = alive.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange(alive.UUID(), dying.UUID())
-	wc.AssertNoChange()
+	wc.AssertChangeInSingleEvent(alive.UUID(), dying.UUID())
 }
 
 func (s *StateSuite) TestWatchEnvironmentsLifecycle(c *gc.C) {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -497,6 +497,7 @@ func AddLifeFieldOfIPAddresses(st *State) error {
 				life = Dead
 			}
 		}
+		logger.Debugf("setting life %q to address %q", life, address["value"])
 
 		ops = append(ops, txn.Op{
 			C:  ipaddressesC,
@@ -508,6 +509,7 @@ func AddLifeFieldOfIPAddresses(st *State) error {
 		address = nil
 	}
 	if err := iter.Err(); err != nil {
+		logger.Errorf("failed fetching IP addresses: %v", err)
 		return errors.Trace(err)
 	}
 	return st.runRawTransaction(ops)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2386,14 +2386,12 @@ func (s *upgradesSuite) addMachineWithLife(c *gc.C, machineID int, life Life) {
 		"instanceid": "foobar",
 		"life":       life,
 	}
-	ops := []txn.Op{
-		{
-			C:      machinesC,
-			Id:     machineID,
-			Assert: txn.DocMissing,
-			Insert: mDoc,
-		},
-	}
+	ops := []txn.Op{{
+		C:      machinesC,
+		Id:     machineID,
+		Assert: txn.DocMissing,
+		Insert: mDoc,
+	}}
 	err := s.state.runRawTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2379,3 +2379,129 @@ func countOldIndexes(c *gc.C, coll *mgo.Collection) (foundCount, oldCount int) {
 	}
 	return
 }
+
+func (s *upgradesSuite) addMachineWithLife(c *gc.C, machineID int, life Life) {
+	mDoc := bson.M{
+		"_id":        machineID,
+		"instanceid": "foobar",
+		"life":       life,
+	}
+	ops := []txn.Op{
+		{
+			C:      machinesC,
+			Id:     machineID,
+			Assert: txn.DocMissing,
+			Insert: mDoc,
+		},
+	}
+	err := s.state.runRawTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradesSuite) TestIPAddressesLife(c *gc.C) {
+	addresses, closer := s.state.getRawCollection(ipaddressesC)
+	defer closer()
+
+	s.addMachineWithLife(c, 1, Alive)
+	s.addMachineWithLife(c, 2, Alive)
+	s.addMachineWithLife(c, 3, Dead)
+
+	uuid := s.state.EnvironUUID()
+
+	err := addresses.Insert(
+		// this one should have Life set to Alive
+		bson.D{
+			{"_id", uuid + ":0.1.2.3"},
+			{"env-uuid", uuid},
+			{"subnetid", "foo"},
+			{"machineid", 1},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.3"},
+			{"state", ""},
+		},
+		// this one should be untouched
+		bson.D{
+			{"_id", uuid + ":0.1.2.4"},
+			{"env-uuid", uuid},
+			{"life", Dead},
+			{"subnetid", "foo"},
+			{"machineid", 2},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.4"},
+			{"state", ""},
+		},
+		// this one should be set to Dead as the machine is Dead
+		bson.D{
+			{"_id", uuid + ":0.1.2.5"},
+			{"env-uuid", uuid},
+			{"subnetid", "foo"},
+			{"machineid", 3},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.5"},
+			{"state", AddressStateAllocated},
+		},
+		// this one should be set to Dead as the machine is missing
+		bson.D{
+			{"_id", uuid + ":0.1.2.6"},
+			{"env-uuid", uuid},
+			{"subnetid", "foo"},
+			{"machineid", 4},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.6"},
+			{"state", AddressStateAllocated},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = AddLifeFieldOfIPAddresses(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ipAddr, err := s.state.IPAddress("0.1.2.4")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.Life(), gc.Equals, Dead)
+
+	ipAddr, err = s.state.IPAddress("0.1.2.5")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.Life(), gc.Equals, Dead)
+
+	ipAddr, err = s.state.IPAddress("0.1.2.6")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.Life(), gc.Equals, Dead)
+
+	doc := ipaddressDoc{}
+	err = addresses.FindId(uuid + ":0.1.2.3").One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(doc.Life, gc.Equals, Alive)
+}
+
+func (s *upgradesSuite) TestIPAddressLifeIdempotent(c *gc.C) {
+	addresses, closer := s.state.getRawCollection(ipaddressesC)
+	defer closer()
+
+	s.addMachineWithLife(c, 1, Alive)
+	uuid := s.state.EnvironUUID()
+
+	err := addresses.Insert(
+		// this one should have Life set to Alive
+		bson.D{
+			{"_id", uuid + ":0.1.2.3"},
+			{"env-uuid", uuid},
+			{"subnetid", "foo"},
+			{"machineid", 1},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.3"},
+			{"state", ""},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = AddLifeFieldOfIPAddresses(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+	err = AddLifeFieldOfIPAddresses(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	doc := ipaddressDoc{}
+	err = addresses.FindId(uuid + ":0.1.2.3").One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(doc.Life, gc.Equals, Alive)
+}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -169,6 +169,12 @@ func (st *State) WatchEnvironments() StringsWatcher {
 	return newLifecycleWatcher(st, environmentsC, nil, nil, nil)
 }
 
+// WatchIPAddresses returns a StringsWatcher that notifies of changes to the
+// lifecycles of IP addresses.
+func (st *State) WatchIPAddresses() StringsWatcher {
+	return newLifecycleWatcher(st, ipaddressesC, nil, nil, nil)
+}
+
 // WatchVolumes returns a StringsWatcher that notifies of changes to
 // the lifecycles of all volumes.
 // TODO(wallyworld) - this currently watches all volumes; we need separate

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -133,7 +133,7 @@ func hasString(changes []string, name string) bool {
 var _ Watcher = (*lifecycleWatcher)(nil)
 
 // lifecycleWatcher notifies about lifecycle changes for a set of entities of
-// the same kind. The first event emitted will contain the ids of all non-Dead
+// the same kind. The first event emitted will contain the ids of all
 // entities; subsequent events are emitted whenever one or more entities are
 // added, or change their lifecycle state. After an entity is found to be
 // Dead, no further event will include it.

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -60,6 +60,12 @@ func stateStepsFor123() []Step {
 				return state.AddNameFieldLowerCaseIdOfUsers(context.State())
 			},
 		}, &upgradeStep{
+			description: "add life field to IP addresses",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddLifeFieldOfIPAddresses(context.State())
+			},
+		}, &upgradeStep{
 			description: "lower case _id of envUsers",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -29,6 +29,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 		"move blocks from environment to state",
 		"insert userenvnameC doc for each environment",
 		"add name field to users and lowercase _id field",
+		"add life field to IP addresses",
 		"lower case _id of envUsers",
 	}
 	assertStateSteps(c, version.MustParse("1.23.0"), expected)

--- a/worker/addresser/package_test.go
+++ b/worker/addresser/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package addresser_test
+
+import (
+	stdtesting "testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	coretesting.MgoTestPackage(t)
+}

--- a/worker/addresser/worker.go
+++ b/worker/addresser/worker.go
@@ -1,0 +1,136 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package addresser
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	apiWatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+)
+
+var logger = loggo.GetLogger("juju.worker.addresser")
+
+type releaser interface {
+	// ReleaseAddress has the same signature as the same method in the
+	// environs.Networking interface.
+	ReleaseAddress(instance.Id, network.Id, network.Address) error
+}
+
+// stateAddresser defines the State methods used by the addresserHandler
+type stateAddresser interface {
+	DeadIPAddresses() ([]*state.IPAddress, error)
+	EnvironConfig() (*config.Config, error)
+	IPAddress(string) (*state.IPAddress, error)
+	Machine(string) (*state.Machine, error)
+	WatchIPAddresses() state.StringsWatcher
+}
+
+type addresserHandler struct {
+	st       stateAddresser
+	releaser releaser
+}
+
+// NewWorker returns a worker that keeps track of
+// IP address lifecycles, releaseing and removing Dead addresses.
+func NewWorker(st stateAddresser) (worker.Worker, error) {
+	config, err := st.EnvironConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	environ, err := environs.New(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	netEnviron, ok := environs.SupportsNetworking(environ)
+	if !ok {
+		return nil, errors.New("environment does not support networking")
+	}
+	a := newWorkerWithReleaser(st, netEnviron)
+	return a, nil
+}
+
+func newWorkerWithReleaser(st stateAddresser, releaser releaser) worker.Worker {
+	a := &addresserHandler{
+		st:       st,
+		releaser: releaser,
+	}
+	w := worker.NewStringsWorker(a)
+	return w
+}
+
+// Handle is part of the StringsWorker interface.
+func (a *addresserHandler) Handle(ids []string) error {
+	for _, id := range ids {
+		logger.Debugf("received notification about address %v", id)
+		addr, err := a.st.IPAddress(id)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				logger.Debugf("address %v was removed; skipping", id)
+				continue
+			}
+			return err
+		}
+		if addr.Life() != state.Dead {
+			logger.Debugf("address %v is not Dead (life %q); skipping", id, addr.Life())
+			continue
+		}
+		err = a.releaseIPAddress(addr)
+		if err != nil {
+			return err
+		}
+		logger.Debugf("address %v released", id)
+		err = addr.Remove()
+		if err != nil {
+			return err
+		}
+		logger.Debugf("address %v removed", id)
+	}
+	return nil
+}
+
+func (a *addresserHandler) releaseIPAddress(addr *state.IPAddress) (err error) {
+	defer errors.DeferredAnnotatef(&err, "failed to release address %v", addr.Value())
+	var machine *state.Machine
+	logger.Debugf("attempting to release dead address %#v", addr.Value())
+	machine, err = a.st.Machine(addr.MachineId())
+	if err != nil {
+		return errors.Annotatef(err, "cannot get allocated machine %q", addr.MachineId())
+	}
+
+	var instId instance.Id
+	instId, err = machine.InstanceId()
+	if err != nil {
+		return errors.Annotatef(err, "cannot get machine %q instance ID", addr.MachineId())
+	}
+
+	subnetId := network.Id(addr.SubnetId())
+	for attempt := common.ShortAttempt.Start(); attempt.Next(); {
+		err = a.releaser.ReleaseAddress(instId, subnetId, addr.Address())
+		if err == nil {
+			return nil
+		}
+	}
+	// Don't remove the address from state so we
+	// can retry releasing the address later.
+	logger.Warningf("cannot release address %q: %v (will retry)", addr.Value(), err)
+	return errors.Trace(err)
+}
+
+// SetUp is part of the StringsWorker interface.
+func (a *addresserHandler) SetUp() (apiWatcher.StringsWatcher, error) {
+	return a.st.WatchIPAddresses(), nil
+}
+
+// TearDown is part of the StringsWorker interface.
+func (a *addresserHandler) TearDown() error {
+	return nil
+}

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -48,7 +48,7 @@ func (s *workerSuite) createAddresses(c *gc.C) {
 		"0.1.2.3", "0.1.2.4", "0.1.2.5", "0.1.2.6",
 	}
 	for i, rawAddr := range addresses {
-		addr := network.NewAddress(rawAddr)
+		addr := network.NewAddress(rawAddr, network.ScopePublic)
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
 		err = ipAddr.AllocateTo(s.machine.Id(), "wobble")
@@ -85,7 +85,7 @@ func makeReleaseOp(digit int) dummy.OpReleaseAddress {
 		Env:        "dummyenv",
 		InstanceId: "foo",
 		SubnetId:   "foobar",
-		Address:    network.NewAddress(fmt.Sprintf("0.1.2.%d", digit)),
+		Address:    network.NewAddress(fmt.Sprintf("0.1.2.%d", digit), network.ScopePublic),
 	}
 }
 
@@ -132,7 +132,7 @@ func (s *workerSuite) TestWorkerIgnoresAliveAddresses(c *gc.C) {
 	s.waitForInitialDead(c)
 
 	// Add a new alive address.
-	addr := network.NewAddress("0.1.2.9")
+	addr := network.NewAddress("0.1.2.9", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	err = ipAddr.AllocateTo(s.machine.Id(), "wobble")

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -1,0 +1,206 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package addresser_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/addresser"
+)
+
+var _ = gc.Suite(&workerSuite{})
+
+type workerSuite struct {
+	testing.JujuConnSuite
+	machine *state.Machine
+}
+
+func (s *workerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	// Unbreak dummy provider methods.
+	s.AssertConfigParameterUpdated(c, "broken", "")
+
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	s.machine = machine
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.SetProvisioned("foo", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.createAddresses(c)
+	s.State.StartSync()
+}
+
+func (s *workerSuite) createAddresses(c *gc.C) {
+	addresses := []string{
+		"0.1.2.3", "0.1.2.4", "0.1.2.5", "0.1.2.6",
+	}
+	for i, rawAddr := range addresses {
+		addr := network.NewAddress(rawAddr)
+		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+		c.Assert(err, jc.ErrorIsNil)
+		err = ipAddr.AllocateTo(s.machine.Id(), "wobble")
+		c.Assert(err, jc.ErrorIsNil)
+		if i%2 == 1 {
+			// two of the addresses start out Dead
+			err = ipAddr.EnsureDead()
+			c.Assert(err, jc.ErrorIsNil)
+		}
+	}
+}
+
+func dummyListen() chan dummy.Operation {
+	opsChan := make(chan dummy.Operation, 10)
+	dummy.Listen(opsChan)
+	return opsChan
+}
+
+func waitForReleaseOp(c *gc.C, opsChan chan dummy.Operation) dummy.OpReleaseAddress {
+	var releaseOp dummy.OpReleaseAddress
+	var ok bool
+	select {
+	case op := <-opsChan:
+		releaseOp, ok = op.(dummy.OpReleaseAddress)
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout while expecting operation")
+	}
+	return releaseOp
+}
+
+func makeReleaseOp(digit int) dummy.OpReleaseAddress {
+	return dummy.OpReleaseAddress{
+		Env:        "dummyenv",
+		InstanceId: "foo",
+		SubnetId:   "foobar",
+		Address:    network.NewAddress(fmt.Sprintf("0.1.2.%d", digit)),
+	}
+}
+
+func (s *workerSuite) assertStop(c *gc.C, w worker.Worker) {
+	c.Assert(worker.Stop(w), jc.ErrorIsNil)
+}
+
+func (s *workerSuite) TestWorkerReleasesAlreadyDead(c *gc.C) {
+	// we start with two dead addresses
+	dead, err := s.State.DeadIPAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(dead, gc.HasLen, 2)
+
+	opsChan := dummyListen()
+
+	w, err := addresser.NewWorker(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	defer s.assertStop(c, w)
+	s.waitForInitialDead(c)
+
+	op1 := waitForReleaseOp(c, opsChan)
+	op2 := waitForReleaseOp(c, opsChan)
+	expected := []dummy.OpReleaseAddress{makeReleaseOp(4), makeReleaseOp(6)}
+	c.Assert([]dummy.OpReleaseAddress{op1, op2}, jc.SameContents, expected)
+}
+
+func (s *workerSuite) waitForInitialDead(c *gc.C) {
+	for a := common.ShortAttempt.Start(); a.Next(); {
+		dead, err := s.State.DeadIPAddresses()
+		c.Assert(err, jc.ErrorIsNil)
+		if len(dead) == 0 {
+			break
+		}
+		if !a.HasNext() {
+			c.Fatalf("timeout waiting for initial change (dead: %#v)", dead)
+		}
+	}
+}
+
+func (s *workerSuite) TestWorkerIgnoresAliveAddresses(c *gc.C) {
+	w, err := addresser.NewWorker(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	defer s.assertStop(c, w)
+	s.waitForInitialDead(c)
+
+	// Add a new alive address.
+	addr := network.NewAddress("0.1.2.9")
+	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+	c.Assert(err, jc.ErrorIsNil)
+	err = ipAddr.AllocateTo(s.machine.Id(), "wobble")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The worker must not kill this address.
+	for a := common.ShortAttempt.Start(); a.Next(); {
+		ipAddr, err := s.State.IPAddress("0.1.2.9")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(ipAddr.Life(), gc.Equals, state.Alive)
+	}
+}
+
+func (s *workerSuite) TestWorkerRemovesDeadAddress(c *gc.C) {
+	w, err := addresser.NewWorker(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	defer s.assertStop(c, w)
+	s.waitForInitialDead(c)
+	opsChan := dummyListen()
+
+	addr, err := s.State.IPAddress("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	err = addr.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Wait for ReleaseAddress attempt.
+	op := waitForReleaseOp(c, opsChan)
+	c.Assert(op, jc.DeepEquals, makeReleaseOp(3))
+
+	// The address should have been removed from state.
+	for a := common.ShortAttempt.Start(); a.Next(); {
+		_, err := s.State.IPAddress("0.1.2.3")
+		if errors.IsNotFound(err) {
+			break
+		}
+		if !a.HasNext() {
+			c.Fatalf("IP address not removed")
+		}
+	}
+}
+
+func (s *workerSuite) TestErrorKillsWorker(c *gc.C) {
+	s.AssertConfigParameterUpdated(c, "broken", "ReleaseAddress")
+	w, err := addresser.NewWorker(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	defer worker.Stop(w)
+
+	// The worker should have died with an error.
+
+	stopErr := make(chan error)
+	go func() {
+		w.Wait()
+		stopErr <- worker.Stop(w)
+	}()
+
+	select {
+	case err := <-stopErr:
+		msg := "failed to release address .*: dummy.ReleaseAddress is broken"
+		c.Assert(err, gc.ErrorMatches, msg)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("worker did not stop as expected")
+	}
+
+	// As we failed to release addresses they should not have been removed
+	// from state.
+	for _, digit := range []int{3, 4, 5, 6} {
+		rawAddr := fmt.Sprintf("0.1.2.%d", digit)
+		_, err := s.State.IPAddress(rawAddr)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}


### PR DESCRIPTION
A backport of the IP address watcher and worker to 1.23. This releases IP addresses for addressable containers.

(Review request: http://reviews.vapour.ws/r/1341/)