### PR TITLE
Correct juju/blobstore dependency (1.22)

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -8,7 +8,7 @@ github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
-github.com/juju/blobstore	git	876050295230a26520520c4e50699893403bb032	2015-03-29T20:37:01Z
+github.com/juju/blobstore	git	1591df2bf102f9cbeeb9145d22c6ccc29a6804ef	2015-03-30T09:15:59Z
 github.com/juju/cmd	git	fbc7a395b6bd50238e56f485068d45964e25cd31	2015-03-27T15:48:43Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	2014-07-18T03:59:30Z


### PR DESCRIPTION
The previous update referenced the commit from cherylj,
rather than the commit ID of the merge.

(Review request: http://reviews.vapour.ws/r/1343/)