### PR TITLE
Stick the init system discovery script under the juju data dir instead of in /tmp.

### DIFF
--- a/environs/manual/fakessh_test.go
+++ b/environs/manual/fakessh_test.go
@@ -150,7 +150,8 @@ func (r fakeSSH) install(c *gc.C) testing.Restorer {
 	if r.Provisioned {
 		checkProvisionedOutput = "/etc/init/jujud-machine-0.conf"
 	}
-	listCmd := service.ListServicesScript()
+	listCmd, err := service.ListServicesScript("trusty")
+	c.Assert(err, jc.ErrorIsNil)
 	add(listCmd, checkProvisionedOutput, r.CheckProvisionedExitCode)
 	if r.InitUbuntuUser {
 		add("", nil, 0)

--- a/environs/manual/init_test.go
+++ b/environs/manual/init_test.go
@@ -115,7 +115,8 @@ func (s *initialisationSuite) TestDetectHardwareCharacteristics(c *gc.C) {
 }
 
 func (s *initialisationSuite) TestCheckProvisioned(c *gc.C) {
-	listCmd := service.ListServicesScript()
+	listCmd, err := service.ListServicesScript("trusty")
+	c.Assert(err, jc.ErrorIsNil)
 	defer installFakeSSH(c, listCmd, "", 0)()
 	provisioned, err := manual.CheckProvisioned("example.com")
 	c.Assert(err, jc.ErrorIsNil)

--- a/service/common/managed.go
+++ b/service/common/managed.go
@@ -4,7 +4,7 @@
 package common
 
 import (
-	"path/filepath"
+	"strings"
 
 	"github.com/juju/errors"
 
@@ -12,19 +12,27 @@ import (
 	"github.com/juju/juju/version"
 )
 
-// ManagedDir returns the path to the directory from which init system
-// files will be managed for the given OS series.
-func ManagedDir(series string) (string, error) {
+// Managed returns a path based at the directory from which init system
+// files will be managed for the given OS series. The provided path
+// elements, if any, are joined to that directory path.
+func Managed(series string, elem ...string) (string, error) {
 	dataDir, err := paths.DataDir(version.Current.Series)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+	parts := append([]string{dataDir, "init"}, elem...)
+
 	// TODO(ericsnow) Use a renderer?
-	return filepath.Join(dataDir, "init"), nil
+	sep := "/"
+	if !strings.Contains(dataDir, "/") {
+		sep = "\\"
+	}
+	return strings.Join(parts, sep), nil
 }
 
-// ManagedDir returns the path to the directory from which init system
-// files will be managed for the local host.
-func LocalManagedDir() (string, error) {
-	return ManagedDir(version.Current.Series)
+// LocalManaged returns a path based at the directory from which init
+// system files will be managed for the local host. The provided path
+// elements, if any, are joined to that directory path.
+func LocalManaged(elem ...string) (string, error) {
+	return Managed(version.Current.Series, elem...)
 }

--- a/service/common/managed.go
+++ b/service/common/managed.go
@@ -1,0 +1,30 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"path/filepath"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/version"
+)
+
+// ManagedDir returns the path to the directory from which init system
+// files will be managed for the given OS series.
+func ManagedDir(series string) (string, error) {
+	dataDir, err := paths.DataDir(version.Current.Series)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	// TODO(ericsnow) Use a renderer?
+	return filepath.Join(dataDir, "init"), nil
+}
+
+// ManagedDir returns the path to the directory from which init system
+// files will be managed for the local host.
+func LocalManagedDir() (string, error) {
+	return ManagedDir(version.Current.Series)
+}

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -226,14 +227,22 @@ fi
 exit 1
 `
 
+func discoveryScriptFilename(series string) (string, error) {
+	const scriptName = "discover_init_system.sh"
+	return resolveManaged(series, scriptName)
+}
+
+var resolveManaged = common.Managed
+
 func writeDiscoverInitSystemScript(filename string) []string {
 	// TODO(ericsnow) Use utils.shell.Renderer.WriteScript.
 	return []string{
+		fmt.Sprintf("mkdir -p %s", path.Dir(filename)),
 		fmt.Sprintf(`
 cat > %s << 'EOF'
 %s
 EOF`[1:], filename, DiscoverInitSystemScript),
-		"chmod 0755 " + filename,
+		fmt.Sprintf("chmod 0755 %s", filename),
 	}
 }
 

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -6,5 +6,8 @@ package service
 var (
 	DiscoverInitSystem            = discoverInitSystem
 	NewShellSelectCommand         = newShellSelectCommand
+	DiscoveryScriptFilename       = discoveryScriptFilename
 	WriteDiscoverInitSystemScript = writeDiscoverInitSystemScript
+
+	ResolveManaged = &resolveManaged
 )

--- a/service/service.go
+++ b/service/service.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -154,12 +155,15 @@ func ListServices() ([]string, error) {
 
 // ListServicesScript returns the commands that should be run to get
 // a list of service names on a host.
-func ListServicesScript() string {
-	const filename = "/tmp/discover_init_system.sh"
+func ListServicesScript(series string) (string, error) {
+	filename, err := discoveryScriptFilename(series)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 	commands := writeDiscoverInitSystemScript(filename)
-	commands = append(commands, "init_system=$("+filename+")")
+	commands = append(commands, fmt.Sprintf("init_system=$(%s)", filename))
 	commands = append(commands, newShellSelectCommand("init_system", listServicesCommand))
-	return strings.Join(commands, "\n")
+	return strings.Join(commands, "\n"), nil
 }
 
 func listServicesCommand(initSystem string) (string, bool) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -67,15 +67,17 @@ func (s *serviceSuite) TestListServices(c *gc.C) {
 }
 
 func (*serviceSuite) TestListServicesScript(c *gc.C) {
-	script := service.ListServicesScript()
+	script, err := service.ListServicesScript("trusty")
+	c.Assert(err, jc.ErrorIsNil)
 
 	expected := []string{
-		"cat > /tmp/discover_init_system.sh << 'EOF'",
+		"mkdir -p /var/lib/juju/init",
+		"cat > /var/lib/juju/init/discover_init_system.sh << 'EOF'",
 	}
 	expected = append(expected, strings.Split(service.DiscoverInitSystemScript, "\n")...)
 	expected = append(expected, "EOF")
-	expected = append(expected, "chmod 0755 /tmp/discover_init_system.sh")
-	expected = append(expected, "init_system=$(/tmp/discover_init_system.sh)")
+	expected = append(expected, "chmod 0755 /var/lib/juju/init/discover_init_system.sh")
+	expected = append(expected, "init_system=$(/var/lib/juju/init/discover_init_system.sh)")
 	expected = append(expected, []string{
 		`if [[ $init_system == "systemd" ]]; then ` +
 			`/bin/systemctl list-unit-files --no-legend --no-page -t service` +

--- a/service/systemd/export_test.go
+++ b/service/systemd/export_test.go
@@ -15,8 +15,8 @@ type patcher interface {
 	PatchValue(interface{}, interface{})
 }
 
-func PatchFindDataDir(patcher patcher, dataDir string) {
-	patcher.PatchValue(&findDataDir, func() (string, error) {
+func PatchFindManagedDir(patcher patcher, dataDir string) {
+	patcher.PatchValue(&findManagedDir, func() (string, error) {
 		return dataDir, nil
 	})
 }

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -14,9 +14,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/service/common"
-	"github.com/juju/juju/version"
 )
 
 var (
@@ -79,11 +77,11 @@ type Service struct {
 // NewService returns a new value that implements Service for systemd.
 func NewService(name string, conf common.Conf) (*Service, error) {
 	confName := name + ".service"
-	dataDir, err := findDataDir()
+	managedDir, err := findManagedDir()
 	if err != nil {
-		return nil, errors.Annotatef(err, "failed to find juju data dir for service %q", name)
+		return nil, errors.Annotatef(err, "failed to find juju managed init dir for service %q", name)
 	}
-	dirname := path.Join(dataDir, "init", name)
+	dirname := path.Join(managedDir, name)
 
 	service := &Service{
 		Service: common.Service{
@@ -102,8 +100,8 @@ func NewService(name string, conf common.Conf) (*Service, error) {
 	return service, nil
 }
 
-var findDataDir = func() (string, error) {
-	return paths.DataDir(version.Current.Series)
+var findManagedDir = func() (string, error) {
+	return common.LocalManagedDir()
 }
 
 // dbusAPI exposes all the systemd API methods needed by juju.

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -101,7 +101,7 @@ func NewService(name string, conf common.Conf) (*Service, error) {
 }
 
 var findManagedDir = func() (string, error) {
-	return common.LocalManagedDir()
+	return common.LocalManaged()
 }
 
 // dbusAPI exposes all the systemd API methods needed by juju.


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1438748)

This resolves a security vulnerability concern from some Ubuntu folks.

(Review request: http://reviews.vapour.ws/r/1349/)