### PR TITLE
Inline the init system discovery script.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -133,17 +133,6 @@ fi
 exit 1
 `
 
-func writeDiscoverInitSystemScript(filename string) []string {
-	// TODO(ericsnow) Use utils.shell.Renderer.WriteScript.
-	return []string{
-		fmt.Sprintf(`
-cat > %s << 'EOF'
-%s
-EOF`[1:], filename, DiscoverInitSystemScript),
-		"chmod 0755 " + filename,
-	}
-}
-
 const caseLine = "%sif [[ $%s == \"%s\" ]]; then %s\n"
 
 // newShellSelectCommand creates a bash if statement with an if

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -4,6 +4,7 @@
 package service_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -296,7 +297,13 @@ func (s *discoverySuite) TestDiscoverInitSystemScript(c *gc.C) {
 
 func (s *discoverySuite) newDiscoverInitSystemScript(c *gc.C) (string, string) {
 	filename := filepath.Join(c.MkDir(), "discover_init_system.sh")
-	commands := service.WriteDiscoverInitSystemScript(filename)
+	commands := []string{
+		fmt.Sprintf(`
+cat > %s << 'EOF'
+%s
+EOF`[1:], filename, service.DiscoverInitSystemScript),
+		"chmod 0755 " + filename,
+	}
 	script := strings.Join(commands, "\n") + "\n"
 	return script, filename
 }

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -4,7 +4,6 @@
 package service
 
 var (
-	DiscoverInitSystem            = discoverInitSystem
-	NewShellSelectCommand         = newShellSelectCommand
-	WriteDiscoverInitSystemScript = writeDiscoverInitSystemScript
+	DiscoverInitSystem    = discoverInitSystem
+	NewShellSelectCommand = newShellSelectCommand
 )

--- a/service/service.go
+++ b/service/service.go
@@ -155,10 +155,10 @@ func ListServices() ([]string, error) {
 // ListServicesScript returns the commands that should be run to get
 // a list of service names on a host.
 func ListServicesScript() string {
-	const filename = "/tmp/discover_init_system.sh"
-	commands := writeDiscoverInitSystemScript(filename)
-	commands = append(commands, "init_system=$("+filename+")")
-	commands = append(commands, newShellSelectCommand("init_system", listServicesCommand))
+	commands := []string{
+		"init_system=$(" + DiscoverInitSystemScript + ")",
+		newShellSelectCommand("init_system", listServicesCommand),
+	}
 	return strings.Join(commands, "\n")
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -69,13 +69,9 @@ func (s *serviceSuite) TestListServices(c *gc.C) {
 func (*serviceSuite) TestListServicesScript(c *gc.C) {
 	script := service.ListServicesScript()
 
-	expected := []string{
-		"cat > /tmp/discover_init_system.sh << 'EOF'",
-	}
-	expected = append(expected, strings.Split(service.DiscoverInitSystemScript, "\n")...)
-	expected = append(expected, "EOF")
-	expected = append(expected, "chmod 0755 /tmp/discover_init_system.sh")
-	expected = append(expected, "init_system=$(/tmp/discover_init_system.sh)")
+	expected := strings.Split(service.DiscoverInitSystemScript, "\n")
+	expected[0] = "init_system=$(" + expected[0]
+	expected[len(expected)-1] += ")"
 	expected = append(expected, []string{
 		`if [[ $init_system == "systemd" ]]; then ` +
 			`/bin/systemctl list-unit-files --no-legend --no-page -t service` +


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1438748)

This eliminates the security concerns with a /tmp file.

(Review request: http://reviews.vapour.ws/r/1351/)