### PR TITLE
Use direct checks to discover init system rather than inferring from PID1.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -2,9 +2,6 @@ package service
 
 import (
 	"fmt"
-	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/juju/errors"
@@ -13,6 +10,9 @@ import (
 
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/service/common"
+	"github.com/juju/juju/service/systemd"
+	"github.com/juju/juju/service/upstart"
+	"github.com/juju/juju/service/windows"
 	"github.com/juju/juju/version"
 )
 
@@ -95,135 +95,35 @@ func versionInitSystem(vers version.Binary) (string, bool) {
 	}
 }
 
-// These exist to allow patching during tests.
-var (
-	runtimeOS    = func() string { return runtime.GOOS }
-	evalSymlinks = filepath.EvalSymlinks
-	psPID1       = func() ([]byte, error) {
-		cmd := exec.Command("/bin/ps", "-p", "1", "-o", "cmd", "--no-headers")
-		return cmd.Output()
-	}
-
-	initExecutable = func() (string, error) {
-		psOutput, err := psPID1()
-		if err != nil {
-			return "", errors.Annotate(err, "failed to identify init system using ps")
-		}
-		return strings.Fields(string(psOutput))[0], nil
-	}
-)
+var discoveryFuncs = map[string]func() (bool, error){
+	InitSystemSystemd: systemd.IsLocal,
+	InitSystemUpstart: upstart.IsLocal,
+	InitSystemWindows: windows.IsLocal,
+}
 
 func discoverLocalInitSystem() (string, error) {
-	if runtimeOS() == "windows" {
-		return InitSystemWindows, nil
+	for initName, isLocal := range discoveryFuncs {
+		local, err := isLocal()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		if local {
+			logger.Debugf("discovered init system %q from local host", initName)
+			return initName, nil
+		}
 	}
-
-	executable, err := initExecutable()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	initName, ok := identifyInitSystem(executable)
-	if !ok {
-		return "", errors.NotFoundf("init system (based on %q)", executable)
-	}
-	logger.Debugf("discovered init system %q from executable %q", initName, executable)
-	return initName, nil
-}
-
-func identifyInitSystem(executable string) (string, bool) {
-	initSystem, ok := identifyExecutable(executable)
-	if ok {
-		return initSystem, true
-	}
-
-	// First fall back to following symlinks (if any).
-	resolved, err := evalSymlinks(executable)
-	if err != nil {
-		logger.Errorf("failed to find %q: %v", executable, err)
-		return "", false
-	}
-	executable = resolved
-	initSystem, ok = identifyExecutable(executable)
-	if ok {
-		return initSystem, true
-	}
-
-	// Fall back to checking the "version" text.
-	cmd := exec.Command(executable, "--version")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		logger.Errorf(`"%s --version" failed (%v): %s`, executable, err, out)
-		return "", false
-	}
-
-	verText := string(out)
-	switch {
-	case strings.Contains(verText, "upstart"):
-		return InitSystemUpstart, true
-	case strings.Contains(verText, "systemd"):
-		return InitSystemSystemd, true
-	}
-
-	// uh-oh
-	return "", false
-}
-
-func identifyExecutable(executable string) (string, bool) {
-	switch {
-	case strings.Contains(executable, "upstart"):
-		return InitSystemUpstart, true
-	case strings.Contains(executable, "systemd"):
-		return InitSystemSystemd, true
-	default:
-		return "", false
-	}
+	return "", errors.NotFoundf("init system (based on local host)")
 }
 
 const discoverInitSystemScript = `#!/usr/bin/env bash
 
-function checkInitSystem() {
-    # Match the init system name from the arg.
-    %s
-    case "$1" in
-    *"systemd"*)
-        echo -n systemd
-        exit $?
-        ;;
-    *"upstart"*)
-        echo -n upstart
-        exit $?
-        ;;
-    *)
-        # Do nothing and continue.
-        ;;
-    esac
-}
-
-# Find the executable.
-executable=$(ps -p 1 -o cmd --no-headers | awk '{print $1}')
-if [[ $? -ne 0 ]]; then
-    exit 1
-fi
-
-# Check the executable.
-checkInitSystem "$executable"
-
-# First fall back to following symlinks.
-if [[ -L $executable ]]; then
-    linked=$(readlink -f "$executable")
-    if [[ $? -eq 0 ]]; then
-        executable=$linked
-
-        # Check the linked executable.
-        checkInitSystem "$linked"
-    fi
-fi
-
-# Fall back to checking the "version" text.
-verText=$("${executable}" --version)
-if [[ $? -eq 0 ]]; then
-    checkInitSystem "$verText"
+# Use guaranteed discovery mechanisms for known init systems.
+if [[ -d /run/systemd/system ]]; then
+    echo -n systemd
+    exit 0
+elif /sbin/initctl --system list 2>&1 > /dev/null; then
+    echo -n upstart
+    exit 0
 fi
 
 # uh-oh

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -96,9 +96,9 @@ func versionInitSystem(vers version.Binary) (string, bool) {
 }
 
 var discoveryFuncs = map[string]func() (bool, error){
-	InitSystemSystemd: systemd.IsLocal,
-	InitSystemUpstart: upstart.IsLocal,
-	InitSystemWindows: windows.IsLocal,
+	InitSystemSystemd: systemd.IsRunning,
+	InitSystemUpstart: upstart.IsRunning,
+	InitSystemWindows: windows.IsRunning,
 }
 
 func discoverLocalInitSystem() (string, error) {

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -38,8 +38,6 @@ const unknownExecutable = "/sbin/unknown/init/system"
 type discoveryTest struct {
 	os       version.OSType
 	series   string
-	exec     string
-	link     string
 	expected string
 }
 
@@ -50,43 +48,12 @@ func (dt discoveryTest) version() version.Binary {
 	}
 }
 
-func (dt discoveryTest) goos() string {
-	switch dt.os {
-	case version.Windows:
-		return "windows"
-	default:
-		return "non-windows"
-	}
-}
-
-func (dt discoveryTest) executable(c *gc.C) string {
-	if dt.exec != "" {
-		return dt.exec
-	}
-
-	switch dt.expected {
-	case service.InitSystemUpstart:
-		return "/sbin/upstart"
-	case service.InitSystemSystemd:
-		return "/lib/systemd/systemd"
-	case service.InitSystemWindows:
-		return unknownExecutable
-	case "":
-		return unknownExecutable
-	default:
-		c.Errorf("unknown expected init system %q", dt.expected)
-		return unknownExecutable
-	}
-}
-
 func (dt discoveryTest) log(c *gc.C) {
-	c.Logf(" - testing {%q, %q, %q, %q}...", dt.os, dt.series, dt.exec, dt.link)
+	c.Logf(" - testing {%q, %q}...", dt.os, dt.series)
 }
 
 func (dt discoveryTest) disableLocalDiscovery(c *gc.C, s *discoverySuite) {
-	s.PatchGOOS("<another OS>")
-	s.PatchPid1File(c, unknownExecutable, "")
-	s.Patched.NotASymlink = unknownExecutable
+	s.PatchLocalDiscovery(nil)
 }
 
 func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
@@ -95,17 +62,21 @@ func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
 	})
 }
 
-func (dt discoveryTest) setLocal(c *gc.C, s *discoverySuite) string {
-	s.PatchGOOS(dt.goos())
-	exec := dt.executable(c)
-	if dt.link != "" {
-		s.PatchLink(c, exec)
-		exec = dt.link
-	} else {
-		s.Patched.NotASymlink = exec
+func (dt discoveryTest) setLocal(c *gc.C, s *discoverySuite) {
+	noMatch := func() (bool, error) {
+		return false, nil
 	}
-	verText := "..." + dt.expected + "..."
-	return s.PatchPid1File(c, exec, verText)
+	funcs := map[string]func() (bool, error){
+		service.InitSystemSystemd: noMatch,
+		service.InitSystemUpstart: noMatch,
+		service.InitSystemWindows: noMatch,
+	}
+	if dt.expected != "" {
+		funcs[dt.expected] = func() (bool, error) {
+			return true, nil
+		}
+	}
+	s.PatchLocalDiscovery(funcs)
 }
 
 func (dt discoveryTest) setVersion(s *discoverySuite) version.Binary {
@@ -167,22 +138,12 @@ var discoveryTests = []discoveryTest{{
 	expected: service.InitSystemUpstart,
 }, {
 	os:       version.Ubuntu,
-	series:   "precise",
-	link:     "/sbin/init",
-	expected: service.InitSystemUpstart,
-}, {
-	os:       version.Ubuntu,
 	series:   "utopic",
 	expected: service.InitSystemUpstart,
 }, {
 	os:       version.Ubuntu,
 	series:   "vivid",
 	expected: maybeSystemd,
-}, {
-	os:       version.Ubuntu,
-	series:   "vivid",
-	link:     "/sbin/init",
-	expected: service.InitSystemSystemd,
 }, {
 	os:       version.CentOS,
 	expected: "",
@@ -239,22 +200,6 @@ func (s *discoverySuite) TestDiscoverServiceLocalHost(c *gc.C) {
 
 	svc, err := service.DiscoverService(s.name, s.conf)
 	c.Assert(err, jc.ErrorIsNil)
-
-	test.checkService(c, svc, err, s.name, s.conf)
-}
-
-func (s *discoverySuite) TestDiscoverServiceGeneric(c *gc.C) {
-	test := discoveryTest{
-		os:       version.Ubuntu,
-		series:   "trusty",
-		link:     "/sbin/init",
-		expected: service.InitSystemUpstart,
-	}
-
-	test.setLocal(c, s)
-	test.disableVersionDiscovery(s)
-
-	svc, err := service.DiscoverService(s.name, s.conf)
 
 	test.checkService(c, svc, err, s.name, s.conf)
 }

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -27,6 +27,17 @@ var (
 	cmds     = commands{renderer, executable}
 )
 
+// IsLocal returns whether or not this is the local init system.
+func IsLocal() (bool, error) {
+	if _, err := os.Stat("/run/systemd/system"); err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, errors.Trace(err)
+	}
+}
+
 // ListServices returns the list of installed service names.
 func ListServices() ([]string, error) {
 	// TODO(ericsnow) conn.ListUnits misses some inactive units, so we

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -27,8 +27,8 @@ var (
 	cmds     = commands{renderer, executable}
 )
 
-// IsLocal returns whether or not this is the local init system.
-func IsLocal() (bool, error) {
+// IsRunning returns whether or not systemd is the local init system.
+func IsRunning() (bool, error) {
 	if _, err := os.Stat("/run/systemd/system"); err == nil {
 		return true, nil
 	} else if os.IsNotExist(err) {

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -31,8 +31,8 @@ var (
 	renderer = &shell.BashRenderer{}
 )
 
-// IsLocal returns whether or not this is the local init system.
-func IsLocal() (bool, error) {
+// IsRunning returns whether or not upstart is the local init system.
+func IsRunning() (bool, error) {
 	cmd := exec.Command("/sbin/initctl", "--system", "list")
 	_, err := cmd.CombinedOutput()
 	if err == nil {

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -31,6 +31,19 @@ var (
 	renderer = &shell.BashRenderer{}
 )
 
+// IsLocal returns whether or not this is the local init system.
+func IsLocal() (bool, error) {
+	cmd := exec.Command("/sbin/initctl", "--system", "list")
+	_, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+	if err == exec.ErrNotFound || err.Error() == "exit status 1" {
+		return false, nil
+	}
+	return false, errors.Trace(err)
+}
+
 // ListServices returns the name of all installed services on the
 // local host.
 func ListServices() ([]string, error) {

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -23,8 +23,8 @@ var (
 	renderer = &shell.PowershellRenderer{}
 )
 
-// IsLocal returns whether or not this is the local init system.
-func IsLocal() (bool, error) {
+// IsRunning returns whether or not windows is the local init system.
+func IsRunning() (bool, error) {
 	return runtime.GOOS == "windows", nil
 }
 

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -6,6 +6,7 @@ package windows
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/juju/errors"
@@ -21,6 +22,11 @@ var (
 
 	renderer = &shell.PowershellRenderer{}
 )
+
+// IsLocal returns whether or not this is the local init system.
+func IsLocal() (bool, error) {
+	return runtime.GOOS == "windows", nil
+}
 
 // ListServices returns the name of all installed services on the
 // local host.


### PR DESCRIPTION
(related to https://bugs.launchpad.net/juju-core/+bug/1438748)

While I would rather avoid embedding such specific init system knowledge into juju, the feedback I got was pretty emphatic that we should not be using PID 1 to discover the init system.

(Review request: http://reviews.vapour.ws/r/1350/)