### PR TITLE
Implement much of the new backend health status work

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -99,19 +99,14 @@ type ServiceStatus struct {
 
 // UnitStatus holds status info about a unit.
 type UnitStatus struct {
-	// Workload and Agent have separate statuses since 1.23.
-	// but they store similar data so AgentStatus is used too.
-	// UnitAgent is created instead of using Agent since it was
-	// already used when changed from 1.18 to 1.19 to hold more
-	// data than the 3 Agent* values below.
-
-	// UnitAgent holds the status for A Unit's agent.
+	// UnitAgent holds the status for a unit's agent.
 	UnitAgent AgentStatus
 
 	// Workload holds the status for a unit's workload
 	Workload AgentStatus
 
-	// See the comment in MachineStatus regarding these fields.
+	// Until Juju 2.0, we need to continue to return legacy agent state values
+	// as top level struct attributes when the "FullStatus" API is called.
 	AgentState     params.Status
 	AgentStateInfo string
 	AgentVersion   string

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -117,7 +117,7 @@ func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 func (s *unitSuite) TestSetUnitStatusOldServer(c *gc.C) {
 	s.patchNewState(c, uniter.NewStateV1)
 
-	err := s.apiUnit.SetUnitStatus(params.StatusRunning, "blah", nil)
+	err := s.apiUnit.SetUnitStatus(params.StatusActive, "blah", nil)
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 	c.Assert(err.Error(), gc.Equals, "SetUnitStatus not implemented")
 }
@@ -142,15 +142,15 @@ func (s *unitSuite) TestSetAgentStatusOldServer(c *gc.C) {
 }
 
 func (s *unitSuite) TestUnitStatus(c *gc.C) {
-	err := s.wordpressUnit.SetStatus(state.StatusError, "blah", map[string]interface{}{"foo": "bar"})
+	err := s.wordpressUnit.SetStatus(state.StatusMaintenance, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := s.apiUnit.UnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StatusResult{
-		Status: params.StatusError,
+		Status: params.StatusMaintenance,
 		Info:   "blah",
-		Data:   map[string]interface{}{"foo": "bar"},
+		Data:   map[string]interface{}{},
 	})
 }
 

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -236,12 +236,11 @@ var scenarioStatus = &api.Status{
 						Data:   map[string]interface{}{"relation-id": "0"},
 					},
 					UnitAgent: api.AgentStatus{
-						Status: "allocating",
-						Info:   "",
-						Data:   make(map[string]interface{}),
+						Status: "idle",
 					},
-					AgentState: "error",
-					Machine:    "1",
+					AgentState:     "error",
+					AgentStateInfo: "blam",
+					Machine:        "1",
 					Subordinates: map[string]api.UnitStatus{
 						"logging/0": {
 							AgentState: "pending",
@@ -252,8 +251,7 @@ var scenarioStatus = &api.Status{
 							},
 							UnitAgent: api.AgentStatus{
 								Status: "allocating",
-								Info:   "",
-								Data:   make(map[string]interface{}),
+								Data:   map[string]interface{}{},
 							},
 						},
 					},
@@ -427,7 +425,8 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 				"remote-unit": "logging/0",
 				"foo":         "bar",
 			}
-			wu.SetStatus(state.StatusError, "blam", sd)
+			err := wu.SetAgentStatus(state.StatusError, "blam", sd)
+			c.Assert(err, jc.ErrorIsNil)
 		}
 
 		// Create the subordinate unit as a side-effect of entering
@@ -442,6 +441,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(deployer, gc.Equals, names.NewUnitTag(fmt.Sprintf("wordpress/%d", i)))
 		setDefaultPassword(c, lu)
+		s.setAgentPresence(c, wu)
 		add(lu)
 	}
 	return
@@ -456,5 +456,14 @@ func (s *baseSuite) setupStoragePool(c *gc.C) {
 	err = s.State.UpdateEnvironConfig(map[string]interface{}{
 		"storage-default-block-source": "loop-pool",
 	}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *baseSuite) setAgentPresence(c *gc.C, u *state.Unit) {
+	_, err := u.SetAgentPresence()
+	c.Assert(err, jc.ErrorIsNil)
+	s.State.StartSync()
+	s.BackingState.StartSync()
+	err = u.WaitAgentPresence(coretesting.LongWait)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -1464,7 +1464,7 @@ func (s *clientSuite) testClientUnitResolved(c *gc.C, retry bool, expectedResolv
 	s.setUpScenario(c)
 	u, err := s.State.Unit("wordpress/0")
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetStatus(state.StatusError, "gaaah", nil)
+	err = u.SetAgentStatus(state.StatusError, "gaaah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Code under test:
 	err = s.APIState.Client().Resolved("wordpress/0", retry)
@@ -1490,7 +1490,7 @@ func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
 	s.setUpScenario(c)
 	u, err := s.State.Unit("wordpress/0")
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetStatus(state.StatusError, "gaaah", nil)
+	err = u.SetAgentStatus(state.StatusError, "gaaah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return u
 }

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/tools"
 )
 
 // FullStatus gives the information needed for juju status over the api
@@ -325,10 +324,16 @@ func processMachines(idToMachines map[string][]*state.Machine) map[string]api.Ma
 
 func makeMachineStatus(machine *state.Machine) (status api.MachineStatus) {
 	status.Id = machine.Id()
-	status.Agent, status.AgentState, status.AgentStateInfo = processAgent(machine)
-	status.AgentVersion = status.Agent.Version
-	status.Life = status.Agent.Life
-	status.Err = status.Agent.Err
+	agentStatus, compatStatus := processMachine(machine)
+	status.Agent = agentStatus
+
+	// These legacy status values will be deprecated for Juju 2.0.
+	status.AgentState = compatStatus.Status
+	status.AgentStateInfo = compatStatus.Info
+	status.AgentVersion = compatStatus.Version
+	status.Life = compatStatus.Life
+	status.Err = compatStatus.Err
+
 	status.Series = machine.Series()
 	status.Jobs = paramsJobsFromJobs(machine.Jobs())
 	status.WantsVote = machine.WantsVote()
@@ -510,37 +515,33 @@ func (context *statusContext) processUnits(units map[string]*state.Unit, service
 	return unitsMap
 }
 
-func (context *statusContext) processUnit(unit *state.Unit, serviceCharm string) (status api.UnitStatus) {
-	status.PublicAddress, _ = unit.PublicAddress()
+func (context *statusContext) processUnit(unit *state.Unit, serviceCharm string) api.UnitStatus {
+	var result api.UnitStatus
+	result.PublicAddress, _ = unit.PublicAddress()
 	unitPorts, _ := unit.OpenedPorts()
 	for _, port := range unitPorts {
-		status.OpenedPorts = append(status.OpenedPorts, port.String())
+		result.OpenedPorts = append(result.OpenedPorts, port.String())
 	}
 	if unit.IsPrincipal() {
-		status.Machine, _ = unit.AssignedMachineId()
+		result.Machine, _ = unit.AssignedMachineId()
 	}
 	curl, _ := unit.CharmURL()
 	if serviceCharm != "" && curl != nil && curl.String() != serviceCharm {
-		status.Charm = curl.String()
+		result.Charm = curl.String()
 	}
-	status.UnitAgent, status.Workload, status.AgentState, status.AgentStateInfo = processUnitAgent(unit)
-
-	// Until Juju 2.0, we need to continue to display legacy status values.
-	status.AgentVersion = status.Workload.Version
-	status.Life = status.Workload.Life
-	status.Err = status.Workload.Err
+	processUnitAndAgentStatus(unit, &result)
 
 	if subUnits := unit.SubordinateNames(); len(subUnits) > 0 {
-		status.Subordinates = make(map[string]api.UnitStatus)
+		result.Subordinates = make(map[string]api.UnitStatus)
 		for _, name := range subUnits {
 			subUnit := context.unitByName(name)
 			// subUnit may be nil if subordinate was filtered out.
 			if subUnit != nil {
-				status.Subordinates[name] = context.processUnit(subUnit, serviceCharm)
+				result.Subordinates[name] = context.processUnit(subUnit, serviceCharm)
 			}
 		}
 	}
-	return
+	return result
 }
 
 func (context *statusContext) unitByName(name string) *state.Unit {
@@ -580,64 +581,71 @@ type lifer interface {
 	Life() state.Life
 }
 
-type stateAgent interface {
-	lifer
-	AgentPresence() (bool, error)
-	AgentTools() (*tools.Tools, error)
-	Status() (state.Status, string, map[string]interface{}, error)
-}
+// processUnitAndAgentStatus retrieves status information for both unit and unitAgents.
+func processUnitAndAgentStatus(unit *state.Unit, status *api.UnitStatus) {
+	status.UnitAgent, status.Workload = processUnitStatus(unit)
 
-// processUnitAgent retrieves status information for both unit and unitAgents.
-func processUnitAgent(unit *state.Unit) (agent api.AgentStatus,
-	workload api.AgentStatus,
-	compatStatus params.Status,
-	compatInfo string) {
+	// Legacy fields required until Juju 2.0.
+	// We only display pending, started, error, stopped.
+	status.AgentState = params.TranslateToLegacyAgentState(status.Workload.Status, status.UnitAgent.Status)
+	if status.AgentState == params.StatusError {
+		status.AgentStateInfo = status.UnitAgent.Info
+	}
+	status.AgentVersion = status.UnitAgent.Version
+	status.Life = status.UnitAgent.Life
+	status.Err = status.UnitAgent.Err
 
-	unitAgent := unit.Agent().(*state.UnitAgent)
+	// The current health spec says when a hook error occurs, the workload should
+	// be in error state, but the state model more correctly records the agent
+	// itself as being in error. So we'll do that model translation here.
+	if status.UnitAgent.Status == params.StatusError {
+		status.Workload.Status = status.UnitAgent.Status
+		status.Workload.Info = status.UnitAgent.Info
+		status.Workload.Data = status.UnitAgent.Data
+		status.UnitAgent.Status = params.StatusIdle
+		status.UnitAgent.Info = ""
+		status.UnitAgent.Data = nil
+	}
 
-	workload, _, _ = processAgent(unit)
-	processAgentStatus(&agent, unitAgent)
+	processUnitLost(unit, status)
 
-	compatStatus = params.TranslateToLegacyAgentState(workload.Status, agent.Status)
-	compatInfo = agent.Info
 	return
 }
 
-// processAgentStatus performs the common tasks for all Agent processors.
-func processAgentStatus(agent *api.AgentStatus, getter state.StatusGetter) {
+// makeStatusForEntity creates status information for machines, units.
+func makeStatusForEntity(agent *api.AgentStatus, getter state.StatusGetter) {
 	var st state.Status
 	st, agent.Info, agent.Data, agent.Err = getter.Status()
 	agent.Status = params.Status(st)
 	agent.Data = filterStatusData(agent.Data)
 }
 
-// processAgent retrieves version and status information from the given entity.
-func processAgent(entity stateAgent) (out api.AgentStatus, compatStatus params.Status, compatInfo string) {
-	out.Life = processLife(entity)
+// processMachine retrieves version and status information for the given machine.
+// It also returns deprecated legacy status information.
+func processMachine(machine *state.Machine) (out api.AgentStatus, compat api.AgentStatus) {
+	out.Life = processLife(machine)
 
-	if t, err := entity.AgentTools(); err == nil {
+	if t, err := machine.AgentTools(); err == nil {
 		out.Version = t.Version.Number.String()
 	}
 
-	processAgentStatus(&out, entity)
-	compatStatus = out.Status
-	compatInfo = out.Info
+	makeStatusForEntity(&out, machine)
+	compat = out
+
 	if out.Err != nil {
 		return
 	}
-	if out.Status == params.StatusPending || // Need to still check pending for existing deployments.
-		out.Status == params.StatusAllocating ||
-		out.Status == params.StatusInstalling {
-		// The status is allocating or installing - there's no point
+	if out.Status == params.StatusPending {
+		// The status is pending - there's no point
 		// in enquiring about the agent liveness.
 		return
 	}
-	agentAlive, err := entity.AgentPresence()
+	agentAlive, err := machine.AgentPresence()
 	if err != nil {
 		return
 	}
 
-	if entity.Life() != state.Dead && !agentAlive {
+	if machine.Life() != state.Dead && !agentAlive {
 		// The agent *should* be alive but is not. Set status to
 		// StatusDown and munge Info to indicate the previous status and
 		// info. This is unfortunately making presentation decisions
@@ -654,14 +662,56 @@ func processAgent(entity stateAgent) (out api.AgentStatus, compatStatus params.S
 		// seen by clients using a watcher because it didn't happen in
 		// State.
 		if out.Info != "" {
-			compatInfo = fmt.Sprintf("(%s: %s)", out.Status, out.Info)
+			compat.Info = fmt.Sprintf("(%s: %s)", out.Status, out.Info)
 		} else {
-			compatInfo = fmt.Sprintf("(%s)", out.Status)
+			compat.Info = fmt.Sprintf("(%s)", out.Status)
 		}
-		compatStatus = params.StatusDown
+		compat.Status = params.StatusDown
 	}
 
 	return
+}
+
+// processUnit retrieves version and status information for the given unit.
+func processUnitStatus(unit *state.Unit) (agentStatus, workloadStatus api.AgentStatus) {
+	// First determine the agent status information.
+	unitAgent := unit.Agent().(*state.UnitAgent)
+	makeStatusForEntity(&agentStatus, unitAgent)
+	agentStatus.Life = processLife(unit)
+	if t, err := unit.AgentTools(); err == nil {
+		agentStatus.Version = t.Version.Number.String()
+	}
+
+	// Second, determine the workload (unit) status.
+	makeStatusForEntity(&workloadStatus, unit)
+	return
+}
+
+// processUnitLost determines whether the given unit should be marked as lost.
+func processUnitLost(unit *state.Unit, status *api.UnitStatus) {
+	if status.UnitAgent.Status == params.StatusPending || // Need to still check pending for existing deployments.
+		status.UnitAgent.Status == params.StatusAllocating ||
+		status.UnitAgent.Status == params.StatusInstalling {
+		// The status is allocating or installing - there's no point
+		// in enquiring about the agent liveness.
+		return
+	}
+	agentAlive, err := unit.AgentPresence()
+	if err != nil {
+		return
+	}
+
+	if unit.Life() != state.Dead && !agentAlive {
+		// If the unit is in error, it would be bad to throw away
+		// the error information as when the agent reconnects, that
+		// error information would then be lost.
+		if status.Workload.Status != params.StatusError {
+			status.Workload.Status = params.StatusUnknown
+			status.Workload.Info = fmt.Sprintf("agent is lost, sorry! See 'juju status-history %s'", unit.Name())
+		}
+		status.UnitAgent.Status = params.StatusLost
+		status.UnitAgent.Info = "agent is not communicating with the server"
+	}
 }
 
 // filterStatusData limits what agent StatusData data is passed over

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -739,7 +739,7 @@ type Status multiwatcher.Status
 
 // TranslateLegacyAgentStatus returns the status value clients expect to see for
 // agent-state in versions prior to 1.24
-func TranslateToLegacyAgentState(in, agentStatus Status) Status {
+func TranslateToLegacyAgentState(workloadStatus, agentStatus Status) Status {
 	// Originally AgentState (a member of api.UnitStatus) could hold one of:
 	// StatusPending
 	// StatusInstalled
@@ -748,28 +748,25 @@ func TranslateToLegacyAgentState(in, agentStatus Status) Status {
 	// StatusError
 	// StatusDown
 	// For compatibility reasons we convert modern states (from V2 uniter) into
-	// three of the old ones: StatusPending, StatusStarted or StatusError.
-	// StatusMaintenance can be StatusPending before the start hook has been run
-	// we dont have enough information for that here so we go for started.
-	// TODO (perrito666) add more information to this function to make the conversion
-	// more accurate.
-	switch in {
-	case StatusWaiting, StatusUnknown:
-		if agentStatus == StatusIdle || agentStatus == StatusExecuting {
+	// four of the old ones: StatusPending, StatusStarted, StatusStopped, or StatusError.
+	switch agentStatus {
+	case StatusAllocating:
+		return StatusPending
+	case StatusError:
+		return StatusError
+	case StatusRebooting, StatusExecuting, StatusIdle, StatusLost, StatusFailed:
+		switch workloadStatus {
+		case StatusTerminated:
+			return StatusStopped
+		case StatusMaintenance:
+			// TODO(wallyworld): until we can query status history, returning Started
+			// is a resonable approximation.
+			return StatusStarted
+		default:
 			return StatusStarted
 		}
-		return StatusPending
-	case StatusMaintenance:
-		if agentStatus == StatusAllocating {
-			return StatusPending
-		}
-		return StatusStarted
-	case StatusActive, StatusBlocked:
-		return StatusStarted
-	case StatusTerminated:
-		return StatusStopped
 	}
-	return in
+	return ""
 }
 
 const (
@@ -835,16 +832,14 @@ const (
 	// The unit agent is downloading the charm and running the install hook.
 	StatusInstalling Status = "installing"
 
-	// The agent is actively participating in the environment.
-	StatusActive Status = "active"
-
 	// The unit is being destroyed; the agent will soon mark the unit as “dead”.
 	// In Juju 2.x this will describe the state of the agent rather than a unit.
 	StatusStopping Status = "stopping"
 )
 
 const (
-	// Status values specific to units
+	// Status values specific to services and units, reflecting the
+	// state of the software itself.
 
 	// The unit is not yet providing services, but is actively doing stuff
 	// in preparation for providing those services.
@@ -859,15 +854,6 @@ const (
 	// A unit-agent has finished calling install, config-changed, and start,
 	// but the charm has not called status-set yet.
 	StatusUnknown Status = "unknown"
-)
-
-const (
-	// Status values specific to services and units, reflecting the
-	// state of the software itself.
-
-	// The unit is installed and has no problems but is busy getting itself
-	// ready to provide services.
-	StatusBusy Status = "busy"
 
 	// The unit is unable to progress to an active state because a service to
 	// which it is related is not running.
@@ -878,5 +864,5 @@ const (
 
 	// The unit believes it is correctly offering all the services it has
 	// been asked to offer.
-	StatusRunning Status = "running"
+	StatusActive Status = "active"
 )

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -739,7 +739,7 @@ type Status multiwatcher.Status
 
 // TranslateLegacyAgentStatus returns the status value clients expect to see for
 // agent-state in versions prior to 1.24
-func TranslateToLegacyAgentState(workloadStatus, agentStatus Status) Status {
+func TranslateToLegacyAgentState(workloadStatus, agentStatus Status) (Status, bool) {
 	// Originally AgentState (a member of api.UnitStatus) could hold one of:
 	// StatusPending
 	// StatusInstalled
@@ -751,22 +751,22 @@ func TranslateToLegacyAgentState(workloadStatus, agentStatus Status) Status {
 	// four of the old ones: StatusPending, StatusStarted, StatusStopped, or StatusError.
 	switch agentStatus {
 	case StatusAllocating:
-		return StatusPending
+		return StatusPending, true
 	case StatusError:
-		return StatusError
+		return StatusError, true
 	case StatusRebooting, StatusExecuting, StatusIdle, StatusLost, StatusFailed:
 		switch workloadStatus {
 		case StatusTerminated:
-			return StatusStopped
+			return StatusStopped, true
 		case StatusMaintenance:
 			// TODO(wallyworld): until we can query status history, returning Started
 			// is a resonable approximation.
-			return StatusStarted
+			return StatusStarted, true
 		default:
-			return StatusStarted
+			return StatusStarted, true
 		}
 	}
-	return ""
+	return "", false
 }
 
 const (

--- a/apiserver/uniter/uniter_base_test.go
+++ b/apiserver/uniter/uniter_base_test.go
@@ -126,15 +126,15 @@ func (s *uniterBaseSuite) testSetStatus(
 		SetStatus(args params.SetStatus) (params.ErrorResults, error)
 	},
 ) {
-	err := s.wordpressUnit.SetAgentStatus(state.StatusIdle, "blah", nil)
+	err := s.wordpressUnit.SetAgentStatus(state.StatusExecuting, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetAgentStatus(state.StatusIdle, "foo", nil)
+	err = s.mysqlUnit.SetAgentStatus(state.StatusExecuting, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatus{
 			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: params.StatusLost, Info: "foobar"},
+			{Tag: "unit-wordpress-0", Status: params.StatusRebooting, Info: "foobar"},
 			{Tag: "unit-foo-42", Status: params.StatusActive, Info: "blah"},
 		}}
 	result, err := facade.SetStatus(args)
@@ -150,12 +150,12 @@ func (s *uniterBaseSuite) testSetStatus(
 	// Verify mysqlUnit - no change.
 	status, info, _, err := s.mysqlUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusIdle)
+	c.Assert(status, gc.Equals, state.StatusExecuting)
 	c.Assert(info, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
 	status, info, _, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusLost)
+	c.Assert(status, gc.Equals, state.StatusRebooting)
 	c.Assert(info, gc.Equals, "foobar")
 }
 
@@ -165,16 +165,16 @@ func (s *uniterBaseSuite) testSetAgentStatus(
 		SetAgentStatus(args params.SetStatus) (params.ErrorResults, error)
 	},
 ) {
-	err := s.wordpressUnit.SetAgentStatus(state.StatusIdle, "blah", nil)
+	err := s.wordpressUnit.SetAgentStatus(state.StatusExecuting, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetAgentStatus(state.StatusIdle, "foo", nil)
+	err = s.mysqlUnit.SetAgentStatus(state.StatusExecuting, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatus{
 			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: params.StatusLost, Info: "foobar"},
-			{Tag: "unit-foo-42", Status: params.StatusActive, Info: "blah"},
+			{Tag: "unit-wordpress-0", Status: params.StatusExecuting, Info: "foobar"},
+			{Tag: "unit-foo-42", Status: params.StatusRebooting, Info: "blah"},
 		}}
 	result, err := facade.SetAgentStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -189,12 +189,12 @@ func (s *uniterBaseSuite) testSetAgentStatus(
 	// Verify mysqlUnit - no change.
 	status, info, _, err := s.mysqlUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusIdle)
+	c.Assert(status, gc.Equals, state.StatusExecuting)
 	c.Assert(info, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
 	status, info, _, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusLost)
+	c.Assert(status, gc.Equals, state.StatusExecuting)
 	c.Assert(info, gc.Equals, "foobar")
 }
 
@@ -213,7 +213,7 @@ func (s *uniterBaseSuite) testSetUnitStatus(
 		Entities: []params.EntityStatus{
 			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
 			{Tag: "unit-wordpress-0", Status: params.StatusTerminated, Info: "foobar"},
-			{Tag: "unit-foo-42", Status: params.StatusRunning, Info: "blah"},
+			{Tag: "unit-foo-42", Status: params.StatusActive, Info: "blah"},
 		}}
 	result, err := facade.SetUnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -105,7 +105,7 @@ func (s *uniterV2Suite) TestSetUnitStatus(c *gc.C) {
 }
 
 func (s *uniterV2Suite) TestUnitStatus(c *gc.C) {
-	err := s.wordpressUnit.SetStatus(state.StatusError, "blah", map[string]interface{}{"foo": "bar"})
+	err := s.wordpressUnit.SetStatus(state.StatusMaintenance, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.mysqlUnit.SetStatus(state.StatusTerminated, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -123,7 +123,7 @@ func (s *uniterV2Suite) TestUnitStatus(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Status: params.StatusError, Info: "blah", Data: map[string]interface{}{"foo": "bar"}},
+			{Status: params.StatusMaintenance, Info: "blah", Data: map[string]interface{}{}},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ServerError(`"invalid" is not a valid tag`)},

--- a/cmd/juju/resolved_test.go
+++ b/cmd/juju/resolved_test.go
@@ -89,7 +89,7 @@ func (s *ResolvedSuite) TestResolved(c *gc.C) {
 	for _, name := range []string{"dummy/2", "dummy/3", "dummy/4"} {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
-		err = u.SetStatus(state.StatusError, "lol borken", nil)
+		err = u.SetAgentStatus(state.StatusError, "lol borken", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -117,7 +117,7 @@ func (s *ResolvedSuite) TestBlockResolved(c *gc.C) {
 	for _, name := range []string{"dummy/2", "dummy/3", "dummy/4"} {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
-		err = u.SetStatus(state.StatusError, "lol borken", nil)
+		err = u.SetAgentStatus(state.StatusError, "lol borken", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -204,19 +204,22 @@ func (s serviceStatus) GetYAML() (tag string, value interface{}) {
 }
 
 type unitStatus struct {
-	Err                error              `json:"-" yaml:",omitempty"`
-	Charm              string             `json:"upgrading-from,omitempty" yaml:"upgrading-from,omitempty"`
+	// New Juju Health Status fields.
 	WorkloadStatusInfo statusInfoContents `json:"workload-status,omitempty" yaml:"workload-status,omitempty"`
 	AgentStatusInfo    statusInfoContents `json:"agent-status,omitempty" yaml:"agent-status,omitempty"`
 
-	AgentState     params.Status         `json:"agent-state,omitempty" yaml:"agent-state,omitempty"`
-	AgentStateInfo string                `json:"agent-state-info,omitempty" yaml:"agent-state-info,omitempty"`
-	AgentVersion   string                `json:"agent-version,omitempty" yaml:"agent-version,omitempty"`
-	Life           string                `json:"life,omitempty" yaml:"life,omitempty"`
-	Machine        string                `json:"machine,omitempty" yaml:"machine,omitempty"`
-	OpenedPorts    []string              `json:"open-ports,omitempty" yaml:"open-ports,omitempty"`
-	PublicAddress  string                `json:"public-address,omitempty" yaml:"public-address,omitempty"`
-	Subordinates   map[string]unitStatus `json:"subordinates,omitempty" yaml:"subordinates,omitempty"`
+	// Legacy status fields, to be removed in Juju 2.0
+	AgentState     params.Status `json:"agent-state,omitempty" yaml:"agent-state,omitempty"`
+	AgentStateInfo string        `json:"agent-state-info,omitempty" yaml:"agent-state-info,omitempty"`
+	Err            error         `json:"-" yaml:",omitempty"`
+	AgentVersion   string        `json:"agent-version,omitempty" yaml:"agent-version,omitempty"`
+	Life           string        `json:"life,omitempty" yaml:"life,omitempty"`
+
+	Charm         string                `json:"upgrading-from,omitempty" yaml:"upgrading-from,omitempty"`
+	Machine       string                `json:"machine,omitempty" yaml:"machine,omitempty"`
+	OpenedPorts   []string              `json:"open-ports,omitempty" yaml:"open-ports,omitempty"`
+	PublicAddress string                `json:"public-address,omitempty" yaml:"public-address,omitempty"`
+	Subordinates  map[string]unitStatus `json:"subordinates,omitempty" yaml:"subordinates,omitempty"`
 }
 
 type statusInfoContents struct {
@@ -350,7 +353,7 @@ func (sf *statusFormatter) formatMachine(machine api.MachineStatus) machineStatu
 		agent := machine.Agent
 		out = machineStatus{
 			AgentState:     machine.AgentState,
-			AgentStateInfo: adjustInfoIfAgentDown(machine.AgentState, agent.Status, agent.Info),
+			AgentStateInfo: adjustInfoIfMachineAgentDown(machine.AgentState, agent.Status, agent.Info),
 			AgentVersion:   agent.Version,
 			Life:           agent.Life,
 			Err:            agent.Err,
@@ -402,20 +405,26 @@ func (sf *statusFormatter) formatService(name string, service api.ServiceStatus)
 }
 
 func (sf *statusFormatter) formatUnit(unit api.UnitStatus, serviceName string) unitStatus {
+	// TODO(Wallyworld) - this should be server side but we still need to support older servers.
+	sf.updateUnitStatusInfo(&unit, serviceName)
+
 	out := unitStatus{
-		Err:                unit.Err,
 		WorkloadStatusInfo: sf.getWorkloadStatusInfo(unit),
 		AgentStatusInfo:    sf.getAgentStatusInfo(unit),
-		AgentState:         unit.AgentState, // < 1.24 agent-state
-		AgentStateInfo:     sf.getUnitStatusInfo(unit, serviceName),
-		AgentVersion:       unit.AgentVersion,
-		Life:               unit.Life,
 		Machine:            unit.Machine,
 		OpenedPorts:        unit.OpenedPorts,
 		PublicAddress:      unit.PublicAddress,
 		Charm:              unit.Charm,
 		Subordinates:       make(map[string]unitStatus),
 	}
+
+	// These legacy fields will be dropped for Juju 2.0.
+	out.Err = unit.Err
+	out.AgentState = unit.AgentState
+	out.AgentStateInfo = unit.AgentStateInfo
+	out.Life = unit.Life
+	out.AgentVersion = unit.AgentVersion
+
 	for k, m := range unit.Subordinates {
 		out.Subordinates[k] = sf.formatUnit(m, serviceName)
 	}
@@ -438,22 +447,23 @@ func (sf *statusFormatter) getAgentStatusInfo(unit api.UnitStatus) statusInfoCon
 	}
 }
 
-func (sf *statusFormatter) getUnitStatusInfo(unit api.UnitStatus, serviceName string) string {
+func (sf *statusFormatter) updateUnitStatusInfo(unit *api.UnitStatus, serviceName string) {
+	// This logic has no business here but can't be moved until Juju 2.0.
+	statusInfo := unit.Workload.Info
 	if unit.Workload.Status == "" {
 		// Old server that doesn't support this field and others.
-		// Just return the info string as-is.
-		return unit.AgentStateInfo
+		// Just use the info string as-is.
+		statusInfo = unit.AgentStateInfo
 	}
-	statusInfo := unit.Workload.Info
 	if unit.Workload.Status == params.StatusError {
 		if relation, ok := sf.relations[getRelationIdFromData(unit)]; ok {
 			// Append the details of the other endpoint on to the status info string.
 			if ep, ok := findOtherEndpoint(relation.Endpoints, serviceName); ok {
-				statusInfo = statusInfo + " for " + ep.String()
+				unit.Workload.Info = statusInfo + " for " + ep.String()
+				unit.AgentStateInfo = unit.Workload.Info
 			}
 		}
 	}
-	return adjustInfoIfAgentDown(unit.AgentState, unit.Workload.Status, statusInfo)
 }
 
 func (sf *statusFormatter) formatNetwork(network api.NetworkStatus) networkStatus {
@@ -480,7 +490,7 @@ func makeHAStatus(hasVote, wantsVote bool) string {
 	return s
 }
 
-func getRelationIdFromData(unit api.UnitStatus) int {
+func getRelationIdFromData(unit *api.UnitStatus) int {
 	if relationId_, ok := unit.Workload.Data["relation-id"]; ok {
 		if relationId, ok := relationId_.(float64); ok {
 			return int(relationId)
@@ -504,11 +514,11 @@ func findOtherEndpoint(endpoints []api.EndpointStatus, serviceName string) (api.
 	return api.EndpointStatus{}, false
 }
 
-// adjustInfoIfAgentDown modifies the agent status info string if the
+// adjustInfoIfMachineAgentDown modifies the agent status info string if the
 // agent is down. The original status and info is included in
 // parentheses.
-func adjustInfoIfAgentDown(status, origStatus params.Status, info string) string {
-	if status == params.StatusDown || status == params.StatusFailed {
+func adjustInfoIfMachineAgentDown(status, origStatus params.Status, info string) string {
+	if status == params.StatusDown {
 		if info == "" {
 			return fmt.Sprintf("(%s)", origStatus)
 		}

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -521,9 +521,9 @@ var statusTests = []testCase{
 			},
 		},
 
-		addUnit{"dummy-service", "1"},
+		addAliveUnit{"dummy-service", "1"},
 		addAliveUnit{"exposed-service", "2"},
-		setUnitStatus{"exposed-service/0", state.StatusError, "You Require More Vespene Gas", nil},
+		setAgentStatus{"exposed-service/0", state.StatusError, "You Require More Vespene Gas", nil},
 		// Open multiple ports with different protocols,
 		// ensure they're sorted on protocol, then number.
 		openUnitPort{"exposed-service/0", "udp", 10},
@@ -562,7 +562,7 @@ var statusTests = []testCase{
 									"message": "You Require More Vespene Gas",
 								},
 								"agent-status": M{
-									"current": "allocating",
+									"current": "idle",
 								},
 								"open-ports": L{
 									"2/tcp", "3/tcp", "2/udp", "10/udp",
@@ -640,7 +640,7 @@ var statusTests = []testCase{
 								"agent-state":      "error",
 								"agent-state-info": "You Require More Vespene Gas",
 								"workload-status":  M{"current": "error", "message": "You Require More Vespene Gas"},
-								"agent-status":     M{"current": "allocating"},
+								"agent-status":     M{"current": "idle"},
 								"open-ports": L{
 									"2/tcp", "3/tcp", "2/udp", "10/udp",
 								},
@@ -710,7 +710,7 @@ var statusTests = []testCase{
 								"agent-state":      "error",
 								"agent-state-info": "You Require More Vespene Gas",
 								"workload-status":  M{"current": "error", "message": "You Require More Vespene Gas"},
-								"agent-status":     M{"current": "allocating"},
+								"agent-status":     M{"current": "idle"},
 								"open-ports": L{
 									"2/tcp", "3/tcp", "2/udp", "10/udp",
 								},
@@ -765,7 +765,7 @@ var statusTests = []testCase{
 								"agent-state":      "error",
 								"agent-state-info": "You Require More Vespene Gas",
 								"workload-status":  M{"current": "error", "message": "You Require More Vespene Gas"},
-								"agent-status":     M{"current": "allocating"},
+								"agent-status":     M{"current": "idle"},
 								"open-ports": L{
 									"2/tcp", "3/tcp", "2/udp", "10/udp",
 								},
@@ -809,7 +809,7 @@ var statusTests = []testCase{
 								"agent-state":      "error",
 								"agent-state-info": "You Require More Vespene Gas",
 								"workload-status":  M{"current": "error", "message": "You Require More Vespene Gas"},
-								"agent-status":     M{"current": "allocating"},
+								"agent-status":     M{"current": "idle"},
 								"open-ports": L{
 									"2/tcp", "3/tcp", "2/udp", "10/udp",
 								},
@@ -842,7 +842,7 @@ var statusTests = []testCase{
 
 		relateServices{"wordpress", "mysql"},
 
-		setUnitStatus{"wordpress/0", state.StatusError,
+		setAgentStatus{"wordpress/0", state.StatusError,
 			"hook failed: some-relation-changed",
 			map[string]interface{}{"relation-id": 0}},
 
@@ -866,8 +866,8 @@ var statusTests = []testCase{
 								"machine":          "1",
 								"agent-state":      "error",
 								"agent-state-info": "hook failed: some-relation-changed for mysql:server",
-								"workload-status":  M{"current": "error", "message": "hook failed: some-relation-changed"},
-								"agent-status":     M{"current": "allocating"},
+								"workload-status":  M{"current": "error", "message": "hook failed: some-relation-changed for mysql:server"},
+								"agent-status":     M{"current": "idle"},
 								"public-address":   "dummyenv-1.dns",
 							},
 						},
@@ -880,12 +880,11 @@ var statusTests = []testCase{
 						},
 						"units": M{
 							"mysql/0": M{
-								"machine":          "1",
-								"agent-state":      "pending",
-								"agent-state-info": "Waiting for agent initialization to finish",
-								"workload-status":  M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
-								"agent-status":     M{"current": "allocating"},
-								"public-address":   "dummyenv-1.dns",
+								"machine":         "1",
+								"agent-state":     "pending",
+								"workload-status": M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
+								"agent-status":    M{"current": "allocating"},
+								"public-address":  "dummyenv-1.dns",
 							},
 						},
 					},
@@ -906,7 +905,7 @@ var statusTests = []testCase{
 
 		addCharm{"wordpress"},
 		addService{name: "wordpress", charm: "wordpress"},
-		addUnit{"wordpress", "1"},
+		addAliveUnit{"wordpress", "1"},
 
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
@@ -914,7 +913,7 @@ var statusTests = []testCase{
 
 		relateServices{"wordpress", "mysql"},
 
-		setUnitStatus{"wordpress/0", state.StatusError,
+		setAgentStatus{"wordpress/0", state.StatusError,
 			"hook failed: some-relation-changed",
 			map[string]interface{}{"relation-id": 0}},
 
@@ -938,8 +937,8 @@ var statusTests = []testCase{
 								"machine":          "1",
 								"agent-state":      "error",
 								"agent-state-info": "hook failed: some-relation-changed for mysql:server",
-								"workload-status":  M{"current": "error", "message": "hook failed: some-relation-changed"},
-								"agent-status":     M{"current": "allocating"},
+								"workload-status":  M{"current": "error", "message": "hook failed: some-relation-changed for mysql:server"},
+								"agent-status":     M{"current": "idle"},
 								"public-address":   "dummyenv-1.dns",
 							},
 						},
@@ -952,12 +951,11 @@ var statusTests = []testCase{
 						},
 						"units": M{
 							"mysql/0": M{
-								"machine":          "1",
-								"agent-state":      "pending",
-								"agent-state-info": "Waiting for agent initialization to finish",
-								"workload-status":  M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
-								"agent-status":     M{"current": "allocating"},
-								"public-address":   "dummyenv-1.dns",
+								"machine":         "1",
+								"agent-state":     "pending",
+								"workload-status": M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
+								"agent-status":    M{"current": "allocating"},
+								"public-address":  "dummyenv-1.dns",
 							},
 						},
 					},
@@ -969,7 +967,7 @@ var statusTests = []testCase{
 		addCharm{"dummy"},
 		addService{name: "dummy-service", charm: "dummy"},
 		addMachine{machineId: "0", job: state.JobHostUnits},
-		addUnit{"dummy-service", "0"},
+		addAliveUnit{"dummy-service", "0"},
 		ensureDyingService{"dummy-service"},
 		expect{
 			"service shows life==dying",
@@ -988,11 +986,48 @@ var statusTests = []testCase{
 						"life":    "dying",
 						"units": M{
 							"dummy-service/0": M{
-								"machine":          "0",
-								"agent-state":      "pending",
-								"agent-state-info": "Waiting for agent initialization to finish",
-								"workload-status":  M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
-								"agent-status":     M{"current": "allocating"},
+								"machine":         "0",
+								"agent-state":     "pending",
+								"workload-status": M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
+								"agent-status":    M{"current": "allocating"},
+							},
+						},
+					},
+				},
+			},
+		},
+	), test(
+		"a unit where the agent is down shows as lost",
+		addCharm{"dummy"},
+		addService{name: "dummy-service", charm: "dummy"},
+		addMachine{machineId: "0", job: state.JobHostUnits},
+		startAliveMachine{"0"},
+		setMachineStatus{"0", state.StatusStarted, ""},
+		addUnit{"dummy-service", "0"},
+		setAgentStatus{"dummy-service/0", state.StatusIdle, "", nil},
+		setUnitStatus{"dummy-service/0", state.StatusActive, "", nil},
+		expect{
+			"unit shows that agent is lost",
+			M{
+				"environment": "dummyenv",
+				"machines": M{
+					"0": M{
+						"agent-state": "started",
+						"instance-id": "dummyenv-0",
+						"series":      "quantal",
+						"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+					},
+				},
+				"services": M{
+					"dummy-service": M{
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": false,
+						"units": M{
+							"dummy-service/0": M{
+								"machine":         "0",
+								"agent-state":     "started",
+								"workload-status": M{"current": "unknown", "message": "agent is lost, sorry! See 'juju status-history dummy-service/0'"},
+								"agent-status":    M{"current": "lost", "message": "agent is not communicating with the server"},
 							},
 						},
 					},
@@ -1019,6 +1054,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"project", "1"},
+		setAgentStatus{"project/0", state.StatusIdle, "", nil},
 		setUnitStatus{"project/0", state.StatusActive, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
@@ -1028,6 +1064,7 @@ var statusTests = []testCase{
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
+		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
 		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
 
 		addService{name: "varnish", charm: "varnish"},
@@ -1036,7 +1073,7 @@ var statusTests = []testCase{
 		setAddresses{"3", network.NewAddresses("dummyenv-3.dns")},
 		startAliveMachine{"3"},
 		setMachineStatus{"3", state.StatusStarted, ""},
-		addUnit{"varnish", "3"},
+		addAliveUnit{"varnish", "3"},
 
 		addService{name: "private", charm: "wordpress"},
 		setServiceExposed{"private", true},
@@ -1044,7 +1081,7 @@ var statusTests = []testCase{
 		setAddresses{"4", network.NewAddresses("dummyenv-4.dns")},
 		startAliveMachine{"4"},
 		setMachineStatus{"4", state.StatusStarted, ""},
-		addUnit{"private", "4"},
+		addAliveUnit{"private", "4"},
 
 		relateServices{"project", "mysql"},
 		relateServices{"project", "varnish"},
@@ -1070,7 +1107,7 @@ var statusTests = []testCase{
 								"machine":         "1",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"public-address":  "dummyenv-1.dns",
 							},
 						},
@@ -1087,7 +1124,7 @@ var statusTests = []testCase{
 								"machine":         "2",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"public-address":  "dummyenv-2.dns",
 							},
 						},
@@ -1100,12 +1137,11 @@ var statusTests = []testCase{
 						"exposed": true,
 						"units": M{
 							"varnish/0": M{
-								"machine":          "3",
-								"agent-state":      "pending",
-								"agent-state-info": "Waiting for agent initialization to finish",
-								"workload-status":  M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
-								"agent-status":     M{"current": "allocating"},
-								"public-address":   "dummyenv-3.dns",
+								"machine":         "3",
+								"agent-state":     "pending",
+								"workload-status": M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
+								"agent-status":    M{"current": "allocating"},
+								"public-address":  "dummyenv-3.dns",
 							},
 						},
 						"relations": M{
@@ -1117,12 +1153,11 @@ var statusTests = []testCase{
 						"exposed": true,
 						"units": M{
 							"private/0": M{
-								"machine":          "4",
-								"agent-state":      "pending",
-								"agent-state-info": "Waiting for agent initialization to finish",
-								"workload-status":  M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
-								"agent-status":     M{"current": "allocating"},
-								"public-address":   "dummyenv-4.dns",
+								"machine":         "4",
+								"agent-state":     "pending",
+								"workload-status": M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
+								"agent-status":    M{"current": "allocating"},
+								"public-address":  "dummyenv-4.dns",
 							},
 						},
 						"relations": M{
@@ -1148,18 +1183,21 @@ var statusTests = []testCase{
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"riak", "1"},
+		setAgentStatus{"riak/0", state.StatusIdle, "", nil},
 		setUnitStatus{"riak/0", state.StatusActive, "", nil},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("dummyenv-2.dns")},
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"riak", "2"},
+		setAgentStatus{"riak/1", state.StatusIdle, "", nil},
 		setUnitStatus{"riak/1", state.StatusActive, "", nil},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("dummyenv-3.dns")},
 		startAliveMachine{"3"},
 		setMachineStatus{"3", state.StatusStarted, ""},
 		addAliveUnit{"riak", "3"},
+		setAgentStatus{"riak/2", state.StatusIdle, "", nil},
 		setUnitStatus{"riak/2", state.StatusActive, "", nil},
 
 		expect{
@@ -1181,21 +1219,21 @@ var statusTests = []testCase{
 								"machine":         "1",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"public-address":  "dummyenv-1.dns",
 							},
 							"riak/1": M{
 								"machine":         "2",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"public-address":  "dummyenv-2.dns",
 							},
 							"riak/2": M{
 								"machine":         "3",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"public-address":  "dummyenv-3.dns",
 							},
 						},
@@ -1226,6 +1264,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
+		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
 		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
@@ -1235,6 +1274,7 @@ var statusTests = []testCase{
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
+		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
 		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
 
 		addService{name: "logging", charm: "logging"},
@@ -1248,8 +1288,9 @@ var statusTests = []testCase{
 		addSubordinate{"mysql/0", "logging"},
 
 		setUnitsAlive{"logging"},
+		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
 		setUnitStatus{"logging/0", state.StatusActive, "", nil},
-		setUnitStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
 
 		expect{
 			"multiples related peer units",
@@ -1269,12 +1310,12 @@ var statusTests = []testCase{
 								"machine":         "1",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"subordinates": M{
 									"logging/0": M{
 										"agent-state":     "started",
 										"workload-status": M{"current": "active"},
-										"agent-status":    M{"current": "allocating"},
+										"agent-status":    M{"current": "idle"},
 										"public-address":  "dummyenv-1.dns",
 									},
 								},
@@ -1294,13 +1335,13 @@ var statusTests = []testCase{
 								"machine":         "2",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"subordinates": M{
 									"logging/1": M{
 										"agent-state":      "error",
 										"agent-state-info": "somehow lost in all those logs",
 										"workload-status":  M{"current": "error", "message": "somehow lost in all those logs"},
-										"agent-status":     M{"current": "allocating"},
+										"agent-status":     M{"current": "idle"},
 										"public-address":   "dummyenv-2.dns",
 									},
 								},
@@ -1344,12 +1385,12 @@ var statusTests = []testCase{
 								"machine":         "1",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"subordinates": M{
 									"logging/0": M{
 										"agent-state":     "started",
 										"workload-status": M{"current": "active"},
-										"agent-status":    M{"current": "allocating"},
+										"agent-status":    M{"current": "idle"},
 										"public-address":  "dummyenv-1.dns",
 									},
 								},
@@ -1369,12 +1410,12 @@ var statusTests = []testCase{
 								"machine":         "2",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"subordinates": M{
 									"logging/1": M{
 										"agent-state":      "error",
 										"workload-status":  M{"current": "error", "message": "somehow lost in all those logs"},
-										"agent-status":     M{"current": "allocating"},
+										"agent-status":     M{"current": "idle"},
 										"agent-state-info": "somehow lost in all those logs",
 										"public-address":   "dummyenv-2.dns",
 									},
@@ -1418,12 +1459,12 @@ var statusTests = []testCase{
 								"machine":         "1",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"subordinates": M{
 									"logging/0": M{
 										"agent-state":     "started",
 										"workload-status": M{"current": "active"},
-										"agent-status":    M{"current": "allocating"},
+										"agent-status":    M{"current": "idle"},
 										"public-address":  "dummyenv-1.dns",
 									},
 								},
@@ -1463,6 +1504,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "1"},
+		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
 		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
 
 		// A container on machine 1.
@@ -1471,6 +1513,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1/lxc/0"},
 		setMachineStatus{"1/lxc/0", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "1/lxc/0"},
+		setAgentStatus{"mysql/1", state.StatusIdle, "", nil},
 		setUnitStatus{"mysql/1", state.StatusActive, "", nil},
 		addContainer{"1", "1/lxc/1", state.JobHostUnits},
 
@@ -1497,14 +1540,14 @@ var statusTests = []testCase{
 								"machine":         "1",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"public-address":  "dummyenv-1.dns",
 							},
 							"mysql/1": M{
 								"machine":         "1/lxc/0",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"public-address":  "dummyenv-2.dns",
 							},
 						},
@@ -1545,7 +1588,7 @@ var statusTests = []testCase{
 								"machine":         "1/lxc/0",
 								"agent-state":     "started",
 								"workload-status": M{"current": "active"},
-								"agent-status":    M{"current": "allocating"},
+								"agent-status":    M{"current": "idle"},
 								"public-address":  "dummyenv-2.dns",
 							},
 						},
@@ -1584,12 +1627,11 @@ var statusTests = []testCase{
 						"exposed":        true,
 						"units": M{
 							"mysql/0": M{
-								"machine":          "1",
-								"agent-state":      "pending",
-								"agent-state-info": "Waiting for agent initialization to finish",
-								"workload-status":  M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
-								"agent-status":     M{"current": "allocating"},
-								"public-address":   "dummyenv-1.dns",
+								"machine":         "1",
+								"agent-state":     "pending",
+								"workload-status": M{"current": "unknown", "message": "Waiting for agent initialization to finish"},
+								"agent-status":    M{"current": "allocating"},
+								"public-address":  "dummyenv-1.dns",
 							},
 						},
 					},
@@ -2357,6 +2399,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
+		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
 		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -2365,6 +2408,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
+		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
 		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
 		addService{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
@@ -2374,8 +2418,9 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addSubordinate{"wordpress/0", "logging"},
 		addSubordinate{"mysql/0", "logging"},
 		setUnitsAlive{"logging"},
+		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
 		setUnitStatus{"logging/0", state.StatusActive, "", nil},
-		setUnitStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
 	}
 	for _, s := range steps {
 		s.step(c, ctx)
@@ -2421,6 +2466,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
+		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
 		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
@@ -2430,6 +2476,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
+		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
 		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
 
 		addService{name: "logging", charm: "logging"},
@@ -2443,8 +2490,9 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addSubordinate{"mysql/0", "logging"},
 
 		setUnitsAlive{"logging"},
+		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
 		setUnitStatus{"logging/0", state.StatusActive, "", nil},
-		setUnitStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
 	}
 
 	ctx.run(c, steps)
@@ -2491,6 +2539,7 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 		startAliveMachine{"1"},
 		setMachineStatus{"1", state.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
+		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
 		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -2499,6 +2548,7 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 		startAliveMachine{"2"},
 		setMachineStatus{"2", state.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
+		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
 		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
 		addService{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
@@ -2508,8 +2558,9 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 		addSubordinate{"wordpress/0", "logging"},
 		addSubordinate{"mysql/0", "logging"},
 		setUnitsAlive{"logging"},
+		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
 		setUnitStatus{"logging/0", state.StatusActive, "", nil},
-		setUnitStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
 	}
 	for _, s := range steps {
 		s.step(c, ctx)
@@ -2605,6 +2656,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And a unit of "wordpress" is deployed to machine "1"
 		addAliveUnit{"wordpress", "1"},
 		// And the unit is started
+		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
 		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
 		// And a machine is started
 
@@ -2618,6 +2670,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And a unit of "mysql" is deployed to machine "2"
 		addAliveUnit{"mysql", "2"},
 		// And the unit is started
+		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
 		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
 		// And the "logging" service is added
 		addService{name: "logging", charm: "logging"},
@@ -2631,9 +2684,11 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		relateServices{"mysql", "logging"},
 		// And the "logging" service is a subordinate to unit 0 of the "wordpress" service
 		addSubordinate{"wordpress/0", "logging"},
+		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
 		setUnitStatus{"logging/0", state.StatusActive, "", nil},
 		// And the "logging" service is a subordinate to unit 0 of the "mysql" service
 		addSubordinate{"mysql/0", "logging"},
+		setAgentStatus{"logging/1", state.StatusIdle, "", nil},
 		setUnitStatus{"logging/1", state.StatusActive, "", nil},
 		setUnitsAlive{"logging"},
 	}
@@ -2648,9 +2703,9 @@ func (s *StatusSuite) TestFilterToStarted(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// Given unit 1 of the "logging" service has an error
-	setUnitStatus{"logging/1", state.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"logging/1", state.StatusError, "mock error", nil}.step(c, ctx)
 	// And unit 0 of the "mysql" service has an error
-	setUnitStatus{"mysql/0", state.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"mysql/0", state.StatusError, "mock error", nil}.step(c, ctx)
 	// When I run juju status --format oneline started
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "started")
 	c.Assert(string(stderr), gc.Equals, "")
@@ -2670,7 +2725,7 @@ func (s *StatusSuite) TestFilterToErrored(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// Given unit 1 of the "logging" service has an error
-	setUnitStatus{"logging/1", state.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"logging/1", state.StatusError, "mock error", nil}.step(c, ctx)
 	// When I run juju status --format oneline error
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "error")
 	c.Assert(stderr, gc.IsNil)

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -86,26 +86,24 @@ func (s *InterfaceSuite) TestUnitStatus(c *gc.C) {
 func (s *InterfaceSuite) TestSetUnitStatus(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
 	status := jujuc.StatusInfo{
-		Status: "error",
-		Info:   "not working",
-		Data:   map[string]interface{}{"foo": "bar"},
+		Status: "maintenance",
+		Info:   "doing work",
 	}
 	err := ctx.SetUnitStatus(status)
 	c.Check(err, jc.ErrorIsNil)
 	unitStatus, err := ctx.UnitStatus()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(unitStatus.Status, gc.Equals, "error")
-	c.Check(unitStatus.Info, gc.Equals, "not working")
-	c.Check(unitStatus.Data, gc.DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Check(unitStatus.Status, gc.Equals, "maintenance")
+	c.Check(unitStatus.Info, gc.Equals, "doing work")
+	c.Check(unitStatus.Data, gc.DeepEquals, map[string]interface{}{})
 }
 
 func (s *InterfaceSuite) TestSetUnitStatusUpdatesFlag(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
 	c.Assert(ctx.(runner.Context).HasExecutionSetUnitStatus(), jc.IsFalse)
 	status := jujuc.StatusInfo{
-		Status: "error",
-		Info:   "not working",
-		Data:   map[string]interface{}{"foo": "bar"},
+		Status: "maintenance",
+		Info:   "doing work",
 	}
 	err := ctx.SetUnitStatus(status)
 	c.Check(err, jc.ErrorIsNil)


### PR DESCRIPTION
Several pieces of work pertaining to the new health status spec are implemented. Much of the change is mechanical, due to status renames etc.

A few key changes:
- removal of superseded status values 
- status validation updates
(meaning tests had to be updated)
- can no longer set error status on unit - error status is set on agent
(we still show error as on unit when presenting the data, tested had to be updated)
- "lost" status implemented (so in some tests, units needed to be set to alive)
- restructure of juju status implementation to better separate machine from unit status (they are now quite different), and also legacy status

(Review request: http://reviews.vapour.ws/r/1354/)