### PR TITLE
Inline the init system discovery script.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -115,8 +115,7 @@ func discoverLocalInitSystem() (string, error) {
 	return "", errors.NotFoundf("init system (based on local host)")
 }
 
-const discoverInitSystemScript = `#!/usr/bin/env bash
-
+const discoverInitSystemScript = `
 # Use guaranteed discovery mechanisms for known init systems.
 if [[ -d /run/systemd/system ]]; then
     echo -n systemd
@@ -134,23 +133,9 @@ exit 1
 // discovering the local init system. The script is quite specific to
 // bash, so it includes an explicit bash shbang.
 func DiscoverInitSystemScript() string {
-	dflt := "# Do nothing and continue."
-	caseStmt := newShellSelectCommand("1", dflt, func(name string) (string, bool) {
-		return fmt.Sprintf("echo -n %s\n    exit $?", name), true
-	})
-	caseStmt = "    " + strings.Replace(caseStmt, "\n", "\n    ", -1)
-	return fmt.Sprintf(discoverInitSystemScript, caseStmt)
-}
-
-// writeDiscoverInitSystemScript returns the list of shell commands that
-// will write the script to disk.
-func writeDiscoverInitSystemScript(filename string) []string {
 	renderer := shell.BashRenderer{}
-	script := DiscoverInitSystemScript()
-	cmds := renderer.WriteFile(filename, []byte(script))
-	perm := renderer.ScriptPermissions()
-	cmds = append(cmds, renderer.Chmod(filename, perm)...)
-	return cmds
+	data := renderer.RenderScript([]string{discoverInitSystemScript})
+	return string(data)
 }
 
 // shellCase is the template for a bash case statement, for use in

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -4,6 +4,7 @@
 package service_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -291,7 +292,13 @@ func (s *discoverySuite) TestDiscoverInitSystemScript(c *gc.C) {
 
 func (s *discoverySuite) newDiscoverInitSystemScript(c *gc.C) (string, string) {
 	filename := filepath.Join(c.MkDir(), "discover_init_system.sh")
-	commands := service.WriteDiscoverInitSystemScript(filename)
+	commands := []string{
+		fmt.Sprintf(`
+cat > %s << 'EOF'
+%s
+EOF`[1:], filename, service.DiscoverInitSystemScript()),
+		"chmod 0755 " + filename,
+	}
 	script := strings.Join(commands, "\n") + "\n"
 	return script, filename
 }

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -4,7 +4,6 @@
 package service
 
 var (
-	DiscoverInitSystem            = discoverInitSystem
-	NewShellSelectCommand         = newShellSelectCommand
-	WriteDiscoverInitSystemScript = writeDiscoverInitSystemScript
+	DiscoverInitSystem    = discoverInitSystem
+	NewShellSelectCommand = newShellSelectCommand
 )

--- a/service/service.go
+++ b/service/service.go
@@ -152,13 +152,13 @@ func ListServices() ([]string, error) {
 // ListServicesScript returns the commands that should be run to get
 // a list of service names on a host.
 func ListServicesScript() string {
-	const filename = "/tmp/discover_init_system.sh"
-	commands := writeDiscoverInitSystemScript(filename)
-	commands = append(commands, "init_system=$("+filename+")")
-	// If the init system is not identified then the script will
-	// "exit 1". This is correct since the script should fail if no
-	// init system can be identified.
-	commands = append(commands, newShellSelectCommand("init_system", "exit 1", listServicesCommand))
+	commands := []string{
+		"init_system=$(" + DiscoverInitSystemScript() + ")",
+		// If the init system is not identified then the script will
+		// "exit 1". This is correct since the script should fail if no
+		// init system can be identified.
+		newShellSelectCommand("init_system", "exit 1", listServicesCommand),
+	}
 	return strings.Join(commands, "\n")
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -69,13 +69,9 @@ func (s *serviceSuite) TestListServices(c *gc.C) {
 func (*serviceSuite) TestListServicesScript(c *gc.C) {
 	script := service.ListServicesScript()
 
-	expected := []string{
-		"cat > '/tmp/discover_init_system.sh' << 'EOF'",
-	}
-	expected = append(expected, strings.Split(service.DiscoverInitSystemScript(), "\n")...)
-	expected = append(expected, "EOF")
-	expected = append(expected, "chmod 0755 '/tmp/discover_init_system.sh'")
-	expected = append(expected, "init_system=$(/tmp/discover_init_system.sh)")
+	expected := strings.Split(service.DiscoverInitSystemScript(), "\n")
+	expected[0] = "init_system=$(" + expected[0]
+	expected[len(expected)-1] += ")"
 	expected = append(expected,
 		`case "$init_system" in`,
 		`systemd)`,


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1438748)

This eliminates the security concerns with a /tmp file.

(Review request: http://reviews.vapour.ws/r/1351/)