### PR TITLE
  Addresser worker handles IP addresses with no machine

### DIFF
--- a/instance/instance.go
+++ b/instance/instance.go
@@ -17,6 +17,9 @@ import (
 // instance (physical or virtual machine allocated in the provider).
 type Id string
 
+// UnknownId can be used to explicitly specify the instance ID does not matter.
+const UnknownId Id = ""
+
 // Instance represents the the realization of a machine in state.
 type Instance interface {
 	// Id returns a provider-generated identifier for the Instance.

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -774,6 +774,13 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
 	defer errors.DeferredAnnotatef(&err, "failed to release address %q from instance %q", addr, instId)
 
+	// If the instance ID is unknown the address has already been released
+	// and we can ignore this request.
+	if instId == instance.UnknownId {
+		logger.Debugf("release address %q with an unknown instance ID is a no-0op (ignoring)", addr.Value)
+		return nil
+	}
+
 	var nicId string
 	ec2Inst := e.ec2()
 	nicId, err = e.fetchNetworkInterfaceId(ec2Inst, instId)

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -777,7 +777,7 @@ func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.
 	// If the instance ID is unknown the address has already been released
 	// and we can ignore this request.
 	if instId == instance.UnknownId {
-		logger.Debugf("release address %q with an unknown instance ID is a no-0op (ignoring)", addr.Value)
+		logger.Debugf("release address %q with an unknown instance ID is a no-op (ignoring)", addr.Value)
 		return nil
 	}
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -814,6 +814,16 @@ func (t *localServerSuite) TestReleaseAddress(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, msg)
 }
 
+func (t *localServerSuite) TestReleaseAddressUnknownInstance(c *gc.C) {
+	env, _ := t.setUpInstanceWithDefaultVpc(c)
+
+	// We should be able to release an address with an unknown instance id
+	// without it being allocated.
+	addr := network.Address{Value: "8.0.0.4"}
+	err := env.ReleaseAddress(instance.UnknownId, "", addr)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
 	interfaces, err := env.NetworkInterfaces(instId)

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -51,13 +52,17 @@ func (s *workerSuite) createAddresses(c *gc.C) {
 		addr := network.NewAddress(rawAddr)
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
-		err = ipAddr.AllocateTo(s.machine.Id(), "wobble")
-		c.Assert(err, jc.ErrorIsNil)
 		if i%2 == 1 {
 			// two of the addresses start out Dead
+			err = ipAddr.AllocateTo("dead-machine", "wobble")
+			c.Assert(err, jc.ErrorIsNil)
 			err = ipAddr.EnsureDead()
 			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			err = ipAddr.AllocateTo(s.machine.Id(), "wobble")
+			c.Assert(err, jc.ErrorIsNil)
 		}
+
 	}
 }
 
@@ -109,6 +114,11 @@ func (s *workerSuite) TestWorkerReleasesAlreadyDead(c *gc.C) {
 	op1 := waitForReleaseOp(c, opsChan)
 	op2 := waitForReleaseOp(c, opsChan)
 	expected := []dummy.OpReleaseAddress{makeReleaseOp(4), makeReleaseOp(6)}
+
+	// The machines are dead, so ReleaseAddress should be called with
+	// instance.UnknownId.
+	expected[0].InstanceId = instance.UnknownId
+	expected[1].InstanceId = instance.UnknownId
 	c.Assert([]dummy.OpReleaseAddress{op1, op2}, jc.SameContents, expected)
 }
 


### PR DESCRIPTION
Forward port of the fix on 1.23. 

The upgrade step that adds the Life field to IP addresses detects addresses with a missing machine as already dead and sets their Life to Dead. The addresser worker was unable to release these addresses as the call to ReleaseAddress requires an instance Id.

For ec2 this isn't a problem as an "already dead" instance will have released its IP addresses anyway. For MAAS we don't need the instance id to release the address. ReleaseAddress now accepts instance.UnknownId to indicate that the instance id is unknown. For ec2 this makes ReleaseAddress a no-op. MAAS is unaffected as it wasn't using the instance id anyway (except for error reporting).

(Review request: http://reviews.vapour.ws/r/1358/)