### PR TITLE
Add managed filesystem source

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -713,12 +713,6 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 			storageDir := filepath.Join(agentConfig.DataDir(), "storage")
 			return newStorageWorker(storageDir, api, api, api, api), nil
 		})
-		if isEnvironManager {
-			runner.StartWorker("storageprovisioner-environ", func() (worker.Worker, error) {
-				api := st.StorageProvisioner(agentConfig.Environment())
-				return newStorageWorker("", api, api, api, api), nil
-			})
-		}
 	}
 
 	// Check if the network management is disabled.
@@ -1063,6 +1057,13 @@ func (a *MachineAgent) startEnvWorkers(
 	runner.StartWorker("metricmanagerworker", func() (worker.Worker, error) {
 		return metricworker.NewMetricsManager(getMetricAPI(apiSt))
 	})
+	if featureflag.Enabled(feature.Storage) {
+		singularRunner.StartWorker("environ-storageprovisioner", func() (worker.Worker, error) {
+			scope := agentConfig.Environment()
+			api := apiSt.StorageProvisioner(scope)
+			return newStorageWorker("", api, api, api, api), nil
+		})
+	}
 
 	// TODO(axw) 2013-09-24 bug #1229506
 	// Make another job to enable the firewaller. Not all

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1051,12 +1051,6 @@ func (a *MachineAgent) startEnvWorkers(
 	singularRunner.StartWorker("environ-provisioner", func() (worker.Worker, error) {
 		return provisioner.NewEnvironProvisioner(apiSt.Provisioner(), agentConfig), nil
 	})
-	singularRunner.StartWorker("charm-revision-updater", func() (worker.Worker, error) {
-		return charmrevisionworker.NewRevisionUpdateWorker(apiSt.CharmRevisionUpdater()), nil
-	})
-	runner.StartWorker("metricmanagerworker", func() (worker.Worker, error) {
-		return metricworker.NewMetricsManager(getMetricAPI(apiSt))
-	})
 	if featureflag.Enabled(feature.Storage) {
 		singularRunner.StartWorker("environ-storageprovisioner", func() (worker.Worker, error) {
 			scope := agentConfig.Environment()
@@ -1064,6 +1058,12 @@ func (a *MachineAgent) startEnvWorkers(
 			return newStorageWorker("", api, api, api, api), nil
 		})
 	}
+	singularRunner.StartWorker("charm-revision-updater", func() (worker.Worker, error) {
+		return charmrevisionworker.NewRevisionUpdateWorker(apiSt.CharmRevisionUpdater()), nil
+	})
+	runner.StartWorker("metricmanagerworker", func() (worker.Worker, error) {
+		return metricworker.NewMetricsManager(getMetricAPI(apiSt))
+	})
 
 	// TODO(axw) 2013-09-24 bug #1229506
 	// Make another job to enable the firewaller. Not all

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -243,7 +243,6 @@ var perEnvSingularWorkers = []string{
 	"minunitsworker",
 	"addresserworker",
 	"environ-provisioner",
-	"environ-storageprovisioner",
 	"charm-revision-updater",
 	"firewaller",
 }
@@ -1591,6 +1590,22 @@ func (s *MachineSuite) TestMachineAgentRestoreRequiresPrepare(c *gc.C) {
 }
 
 func (s *MachineSuite) TestNewEnvironmentStartsNewWorkers(c *gc.C) {
+	s.testNewEnvironmentStartsNewWorkers(c, perEnvSingularWorkers)
+}
+
+func (s *MachineSuite) TestNewEnvironmentStartsNewWorkersStorageEnabled(c *gc.C) {
+	s.SetFeatureFlags(feature.Storage)
+	expect := make([]string, 0, len(perEnvSingularWorkers)+1)
+	for _, w := range perEnvSingularWorkers {
+		expect = append(expect, w)
+		if w == "environ-provisioner" {
+			expect = append(expect, "environ-storageprovisioner")
+		}
+	}
+	s.testNewEnvironmentStartsNewWorkers(c, expect)
+}
+
+func (s *MachineSuite) testNewEnvironmentStartsNewWorkers(c *gc.C, expectedWorkers []string) {
 	s.PatchValue(&watcher.Period, 100*time.Millisecond)
 
 	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
@@ -1604,7 +1619,7 @@ func (s *MachineSuite) TestNewEnvironmentStartsNewWorkers(c *gc.C) {
 	// firewaller is the last worker started for a new environment.
 	r0 := s.singularRecord.nextRunner(c)
 	workers := r0.waitForWorker(c, "firewaller")
-	c.Assert(workers, jc.DeepEquals, perEnvSingularWorkers)
+	c.Assert(workers, jc.DeepEquals, expectedWorkers)
 
 	// Now create a new environment and see the workers start for it.
 	factory.NewFactory(s.State).MakeEnvironment(c, &factory.EnvParams{
@@ -1615,7 +1630,7 @@ func (s *MachineSuite) TestNewEnvironmentStartsNewWorkers(c *gc.C) {
 	}).Close()
 	r1 := s.singularRecord.nextRunner(c)
 	workers = r1.waitForWorker(c, "firewaller")
-	c.Assert(workers, jc.DeepEquals, perEnvSingularWorkers)
+	c.Assert(workers, jc.DeepEquals, expectedWorkers)
 }
 
 // MachineWithCharmsSuite provides infrastructure for tests which need to

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -243,6 +243,7 @@ var perEnvSingularWorkers = []string{
 	"minunitsworker",
 	"addresserworker",
 	"environ-provisioner",
+	"environ-storageprovisioner",
 	"charm-revision-updater",
 	"firewaller",
 }

--- a/storage/provider/export_test.go
+++ b/storage/provider/export_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/names"
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/storage"
@@ -21,6 +22,21 @@ func LoopVolumeSource(storageDir string, run func(string, ...string) (string, er
 
 func LoopProvider(run func(string, ...string) (string, error)) storage.Provider {
 	return &loopProvider{run}
+}
+
+func NewMockManagedFilesystemSource(
+	run func(string, ...string) (string, error),
+	volumeBlockDevices map[names.VolumeTag]storage.BlockDevice,
+	filesystems map[names.FilesystemTag]storage.Filesystem,
+) (storage.FilesystemSource, *MockDirFuncs) {
+	dirFuncs := &MockDirFuncs{
+		osDirFuncs{run},
+		set.NewStrings(),
+	}
+	return &managedFilesystemSource{
+		run, dirFuncs,
+		volumeBlockDevices, filesystems,
+	}, dirFuncs
 }
 
 var _ dirFuncs = (*MockDirFuncs)(nil)

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -1,0 +1,166 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/storage"
+)
+
+const (
+	// defaultFilesystemType is the default filesystem type
+	// to create for volume-backed managed filesystems.
+	defaultFilesystemType = "ext4"
+)
+
+// managedFilesystemSource is an implementation of storage.FilesystemSource
+// that manages filesystems on volumes attached to the host machine.
+//
+// managedFilesystemSource is expected to be called from a single goroutine.
+type managedFilesystemSource struct {
+	run                runCommandFunc
+	dirFuncs           dirFuncs
+	volumeBlockDevices map[names.VolumeTag]storage.BlockDevice
+	filesystems        map[names.FilesystemTag]storage.Filesystem
+}
+
+// NewManagedFilesystemSource returns a storage.FilesystemSource that manages
+// filesystems on block devices on the host machine.
+//
+// The parameters are maps that the caller will update with information about
+// block devices and filesystems created by the source. The caller must not
+// update the maps during calls to the source's methods.
+func NewManagedFilesystemSource(
+	volumeBlockDevices map[names.VolumeTag]storage.BlockDevice,
+	filesystems map[names.FilesystemTag]storage.Filesystem,
+) storage.FilesystemSource {
+	return &managedFilesystemSource{
+		logAndExec,
+		&osDirFuncs{logAndExec},
+		volumeBlockDevices, filesystems,
+	}
+}
+
+// ValidateFilesystemParams is defined on storage.FilesystemSource.
+func (s *managedFilesystemSource) ValidateFilesystemParams(arg storage.FilesystemParams) error {
+	if _, err := s.backingVolumeBlockDevice(arg.Volume); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (s *managedFilesystemSource) backingVolumeBlockDevice(v names.VolumeTag) (storage.BlockDevice, error) {
+	blockDevice, ok := s.volumeBlockDevices[v]
+	if !ok {
+		return storage.BlockDevice{}, errors.Errorf(
+			"backing-volume %s is not yet attached", v.Id(),
+		)
+	}
+	return blockDevice, nil
+}
+
+// CreateFilesystems is defined on storage.FilesystemSource.
+func (s *managedFilesystemSource) CreateFilesystems(args []storage.FilesystemParams) ([]storage.Filesystem, error) {
+	filesystems := make([]storage.Filesystem, len(args))
+	for i, arg := range args {
+		filesystem, err := s.createFilesystem(arg)
+		if err != nil {
+			return nil, errors.Annotatef(err, "creating filesystem %s", arg.Tag.Id())
+		}
+		filesystems[i] = filesystem
+	}
+	return filesystems, nil
+}
+
+func (s *managedFilesystemSource) createFilesystem(arg storage.FilesystemParams) (storage.Filesystem, error) {
+	blockDevice, err := s.backingVolumeBlockDevice(arg.Volume)
+	if err != nil {
+		return storage.Filesystem{}, errors.Trace(err)
+	}
+	devicePath := s.devicePath(blockDevice)
+	if err := createFilesystem(s.run, devicePath); err != nil {
+		return storage.Filesystem{}, errors.Trace(err)
+	}
+	return storage.Filesystem{
+		arg.Tag,
+		arg.Volume,
+		arg.Tag.String(),
+		blockDevice.Size,
+	}, nil
+}
+
+func (s *managedFilesystemSource) devicePath(dev storage.BlockDevice) string {
+	if dev.DeviceName != "" {
+		return path.Join("/dev", dev.DeviceName)
+	}
+	return path.Join("/dev/disk/by-id", dev.Serial)
+}
+
+// AttachFilesystems is defined on storage.FilesystemSource.
+func (s *managedFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.FilesystemAttachment, error) {
+	attachments := make([]storage.FilesystemAttachment, len(args))
+	for i, arg := range args {
+		attachment, err := s.attachFilesystem(arg)
+		if err != nil {
+			return nil, errors.Annotatef(err, "attaching filesystem %s", arg.Filesystem.Id())
+		}
+		attachments[i] = attachment
+	}
+	return attachments, nil
+}
+
+func (s *managedFilesystemSource) attachFilesystem(arg storage.FilesystemAttachmentParams) (storage.FilesystemAttachment, error) {
+	filesystem, ok := s.filesystems[arg.Filesystem]
+	if !ok {
+		return storage.FilesystemAttachment{}, errors.Errorf("filesystem %v is not yet provisioned", arg.Filesystem.Id())
+	}
+	blockDevice, err := s.backingVolumeBlockDevice(filesystem.Volume)
+	if err != nil {
+		return storage.FilesystemAttachment{}, errors.Trace(err)
+	}
+	devicePath := s.devicePath(blockDevice)
+	if err := mountFilesystem(s.run, s.dirFuncs, devicePath, arg.Path); err != nil {
+		return storage.FilesystemAttachment{}, errors.Trace(err)
+	}
+	return storage.FilesystemAttachment{
+		arg.Filesystem,
+		arg.Machine,
+		arg.Path,
+	}, nil
+}
+
+// DetachFilesystems is defined on storage.FilesystemSource.
+func (s *managedFilesystemSource) DetachFilesystems(args []storage.FilesystemAttachmentParams) error {
+	// TODO(axw)
+	return errors.NotImplementedf("DetachFilesystems")
+}
+
+func createFilesystem(run runCommandFunc, devicePath string) error {
+	logger.Debugf("attempting to create filesystem on %q", devicePath)
+	mkfscmd := "mkfs." + defaultFilesystemType
+	_, err := run(mkfscmd, devicePath)
+	if err != nil {
+		return errors.Annotatef(err, "%s failed (%q)", mkfscmd)
+	}
+	logger.Infof("created filesystem on %q", devicePath)
+	return nil
+}
+
+func mountFilesystem(run runCommandFunc, dirFuncs dirFuncs, devicePath, mountPoint string) error {
+	logger.Debugf("attempting to mount filesystem on %q at %q", devicePath, mountPoint)
+	if err := dirFuncs.mkDirAll(mountPoint, 0755); err != nil {
+		return errors.Annotate(err, "creating mount point")
+	}
+	// TODO(axw) check if the mount already exists, and do nothing if so.
+	_, err := run("mount", devicePath, mountPoint)
+	if err != nil {
+		return errors.Annotate(err, "mount failed")
+	}
+	logger.Infof("mounted filesystem on %q at %q", devicePath, mountPoint)
+	return nil
+}

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -1,0 +1,135 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&managedfsSuite{})
+
+type managedfsSuite struct {
+	testing.BaseSuite
+	storageDir   string
+	commands     *mockRunCommand
+	dirFuncs     *provider.MockDirFuncs
+	blockDevices map[names.VolumeTag]storage.BlockDevice
+	filesystems  map[names.FilesystemTag]storage.Filesystem
+}
+
+func (s *managedfsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.storageDir = c.MkDir()
+	s.blockDevices = make(map[names.VolumeTag]storage.BlockDevice)
+	s.filesystems = make(map[names.FilesystemTag]storage.Filesystem)
+}
+
+func (s *managedfsSuite) TearDownTest(c *gc.C) {
+	if s.commands != nil {
+		s.commands.assertDrained()
+	}
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *managedfsSuite) initSource(c *gc.C) storage.FilesystemSource {
+	s.commands = &mockRunCommand{c: c}
+	source, mockDirFuncs := provider.NewMockManagedFilesystemSource(
+		s.commands.run,
+		s.blockDevices,
+		s.filesystems,
+	)
+	s.dirFuncs = mockDirFuncs
+	return source
+}
+
+func (s *managedfsSuite) TestCreateFilesystems(c *gc.C) {
+	source := s.initSource(c)
+	s.commands.expect("mkfs.ext4", "/dev/sda")
+	s.commands.expect("mkfs.ext4", "/dev/disk/by-id/weetbix")
+
+	s.blockDevices[names.NewVolumeTag("0")] = storage.BlockDevice{
+		DeviceName: "sda",
+		Serial:     "capncrunch",
+		Size:       2,
+	}
+	s.blockDevices[names.NewVolumeTag("1")] = storage.BlockDevice{
+		Serial: "weetbix",
+		Size:   3,
+	}
+	filesystems, err := source.CreateFilesystems([]storage.FilesystemParams{{
+		Tag:    names.NewFilesystemTag("0/0"),
+		Volume: names.NewVolumeTag("0"),
+		Size:   2,
+	}, {
+		Tag:    names.NewFilesystemTag("0/1"),
+		Volume: names.NewVolumeTag("1"),
+		Size:   3,
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystems, jc.DeepEquals, []storage.Filesystem{{
+		Tag:          names.NewFilesystemTag("0/0"),
+		Volume:       names.NewVolumeTag("0"),
+		FilesystemId: "filesystem-0-0",
+		Size:         2,
+	}, {
+		Tag:          names.NewFilesystemTag("0/1"),
+		Volume:       names.NewVolumeTag("1"),
+		FilesystemId: "filesystem-0-1",
+		Size:         3,
+	}})
+}
+
+func (s *managedfsSuite) TestCreateFilesystemsNoBlockDevice(c *gc.C) {
+	source := s.initSource(c)
+	_, err := source.CreateFilesystems([]storage.FilesystemParams{{
+		Tag:    names.NewFilesystemTag("0/0"),
+		Volume: names.NewVolumeTag("0"),
+		Size:   2,
+	}})
+	c.Assert(err, gc.ErrorMatches, "creating filesystem 0/0: backing-volume 0 is not yet attached")
+}
+
+func (s *managedfsSuite) TestAttachFilesystems(c *gc.C) {
+	source := s.initSource(c)
+	s.commands.expect("mount", "/dev/sda", "/in/the/place")
+
+	s.blockDevices[names.NewVolumeTag("0")] = storage.BlockDevice{
+		DeviceName: "sda",
+		Serial:     "capncrunch",
+		Size:       2,
+	}
+	s.filesystems[names.NewFilesystemTag("0/0")] = storage.Filesystem{
+		Tag:    names.NewFilesystemTag("0/0"),
+		Volume: names.NewVolumeTag("0"),
+	}
+
+	filesystemAttachments, err := source.AttachFilesystems([]storage.FilesystemAttachmentParams{{
+		Filesystem:   names.NewFilesystemTag("0/0"),
+		FilesystemId: "filesystem-0-0",
+		AttachmentParams: storage.AttachmentParams{
+			Machine:    names.NewMachineTag("0"),
+			InstanceId: "inst-ance",
+		},
+		Path: "/in/the/place",
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystemAttachments, jc.DeepEquals, []storage.FilesystemAttachment{{
+		Filesystem: names.NewFilesystemTag("0/0"),
+		Machine:    names.NewMachineTag("0"),
+		Path:       "/in/the/place",
+	}})
+}
+
+func (s *managedfsSuite) TestDetachFilesystems(c *gc.C) {
+	source := s.initSource(c)
+	err := source.DetachFilesystems(nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+}

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -18,7 +18,6 @@ var _ = gc.Suite(&managedfsSuite{})
 
 type managedfsSuite struct {
 	testing.BaseSuite
-	storageDir   string
 	commands     *mockRunCommand
 	dirFuncs     *provider.MockDirFuncs
 	blockDevices map[names.VolumeTag]storage.BlockDevice
@@ -27,7 +26,6 @@ type managedfsSuite struct {
 
 func (s *managedfsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.storageDir = c.MkDir()
 	s.blockDevices = make(map[names.VolumeTag]storage.BlockDevice)
 	s.filesystems = make(map[names.FilesystemTag]storage.Filesystem)
 }


### PR DESCRIPTION
This branch introduces a filesystem source for "managed filesystems". A managed filesystem is one that Juju manages (creates, destroys, mounts, unmounts) directly on block devices attached to the host machine. We also refer to managed filesystems as "volume-backed filesystems".

The managed filesystem source is not used like other sources; there is no Provider that constructs it. Instead, the storage provisioner will (in a followup) construct a managed filesystem source directly. The reason is that this source requires more intimate knowledge of the host system, which is provided by the storage provisioner.

There is also a drive-by fix to the machine agent, making the environ-scoped storage provisioner "singular", and starting it in the correct place.

(Review request: http://reviews.vapour.ws/r/1360/)