### PR TITLE
Turn a bunch of simplestreams logging to Trace level logging.

### DIFF
--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -75,7 +75,7 @@ func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 	dataURL = utils.MakeFileURL(dataURL)
 	resp, err := client.Get(dataURL)
 	if err != nil {
-		logger.Debugf("Got error requesting %q: %v", dataURL, err)
+		logger.Tracef("Got error requesting %q: %v", dataURL, err)
 		return nil, dataURL, errors.NotFoundf("invalid URL %q", dataURL)
 	}
 	if resp.StatusCode == http.StatusNotFound {

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -290,7 +290,7 @@ func (s *simplestreamsSuite) TestFetchNoMatchingStream(c *gc.C) {
 	})
 	_, _, err := tools.Fetch(
 		[]simplestreams.DataSource{s.Source}, toolsConstraint, s.RequireSigned)
-	c.Assert(err, gc.ErrorMatches, `index file missing "content-download" data not found`)
+	c.Assert(err, gc.ErrorMatches, `"content-download" data not found`)
 }
 
 func (s *simplestreamsSuite) TestFetchWithMirror(c *gc.C) {

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -42,7 +42,7 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 	if filter.Arch != "" {
 		toolsConstraint.Arches = []string{filter.Arch}
 	} else {
-		logger.Debugf("no architecture specified when finding tools, looking for any")
+		logger.Tracef("no architecture specified when finding tools, looking for any")
 		toolsConstraint.Arches = arch.AllSupportedArches
 	}
 	// The old tools search allowed finding tools without needing to specify a series.
@@ -53,8 +53,8 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 	if filter.Series != "" {
 		seriesToSearch = []string{filter.Series}
 	} else {
-		logger.Debugf("no series specified when finding tools, looking for any")
 		seriesToSearch = version.SupportedSeries()
+		logger.Tracef("no series specified when finding tools, looking for %v", seriesToSearch)
 	}
 	toolsConstraint.Series = seriesToSearch
 	return toolsConstraint, nil


### PR DESCRIPTION
This drastically reduces the amount of logging information dumped by default.
In a failing test I had about 200 lines of simplestreams debug information before, which is now reduced to around 6. (It only reports on the URLs it was able to successfully read, and then it reports if it then discards those URLs because it doesn't contain the information it is looking for.)


(Review request: http://reviews.vapour.ws/r/1362/)