### PR TITLE
Fix bug #1439204, close a file when we are done reading it.

### DIFF
--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -882,6 +882,7 @@ func (s *metadataHelperSuite) TestWriteMetadataLegacyIndex(c *gc.C) {
 	stor, _ := s.writeMetadataMultipleStream(c)
 	// Read back the legacy index
 	rdr, err := stor.Get("tools/streams/v1/index.json")
+	defer rdr.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	data, err := ioutil.ReadAll(rdr)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
We had a test that was reading a file but never closing the handle.
If you prefer instead of defer we could just rdr.Close() immediately after ioutil.ReadAll(), but using defer means the file closes even if an assertion fails.


(Review request: http://reviews.vapour.ws/r/1363/)