### PR TITLE
Add juju environment users command.

### DIFF
--- a/cmd/juju/environment/environment.go
+++ b/cmd/juju/environment/environment.go
@@ -39,6 +39,7 @@ func NewSuperCommand() cmd.Command {
 		environmentCmd.Register(envcmd.Wrap(&ShareCommand{}))
 		environmentCmd.Register(envcmd.Wrap(&UnshareCommand{}))
 		environmentCmd.Register(envcmd.Wrap(&CreateCommand{}))
+		environmentCmd.Register(envcmd.Wrap(&UsersCommand{}))
 	}
 	return environmentCmd
 }

--- a/cmd/juju/environment/environment_test.go
+++ b/cmd/juju/environment/environment_test.go
@@ -35,6 +35,7 @@ var expectedCommmandNames = []string{
 	"share",
 	"unset",
 	"unshare",
+	"users",
 }
 
 func (s *EnvironmentCommandSuite) TestHelpCommands(c *gc.C) {
@@ -47,7 +48,7 @@ func (s *EnvironmentCommandSuite) TestHelpCommands(c *gc.C) {
 
 	// Remove "share" for the first test because the feature is not
 	// enabled.
-	devFeatures := set.NewStrings("create", "share", "unshare")
+	devFeatures := set.NewStrings("create", "share", "unshare", "users")
 
 	// Remove features behind dev_flag for the first test since they are not
 	// enabled.

--- a/cmd/juju/environment/export_test.go
+++ b/cmd/juju/environment/export_test.go
@@ -51,3 +51,10 @@ func NewCreateCommand(api CreateEnvironmentAPI) *CreateCommand {
 		api: api,
 	}
 }
+
+// NewUsersCommand returns a UsersCommand with the api provided as specified.
+func NewUsersCommand(api UsersAPI) *UsersCommand {
+	return &UsersCommand{
+		api: api,
+	}
+}

--- a/cmd/juju/environment/users.go
+++ b/cmd/juju/environment/users.go
@@ -1,0 +1,124 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for infos.
+
+package environment
+
+import (
+	"bytes"
+	"fmt"
+	"text/tabwriter"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/user"
+)
+
+const ListCommandDoc = `List all users with access to the current environment`
+
+// UsersCommand shows all the users with access to the current environment.
+type UsersCommand struct {
+	envcmd.EnvCommandBase
+	out cmd.Output
+	api UsersAPI
+}
+
+// UserInfo defines the serialization behaviour of the user information.
+type UserInfo struct {
+	Username       string `yaml:"user-name" json:"user-name"`
+	DateCreated    string `yaml:"date-created" json:"date-created"`
+	LastConnection string `yaml:"last-connection" json:"last-connection"`
+}
+
+// UsersAPI defines the methods on the client API that the
+// users command calls.
+type UsersAPI interface {
+	Close() error
+	EnvironmentUserInfo() ([]params.EnvUserInfo, error)
+}
+
+func (c *UsersCommand) getAPI() (UsersAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	return c.NewAPIClient()
+}
+
+// Info implements Command.Info.
+func (c *UsersCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "users",
+		Purpose: "shows all users with access to the current environment",
+		Doc:     ListCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *UsersCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": c.formatTabular,
+	})
+}
+
+// Run implements Command.Run.
+func (c *UsersCommand) Run(ctx *cmd.Context) (err error) {
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	result, err := client.EnvironmentUserInfo()
+	if err != nil {
+		return err
+	}
+
+	return c.out.Write(ctx, c.apiUsersToUserInfoSlice(result))
+}
+
+func (c *UsersCommand) formatTabular(value interface{}) ([]byte, error) {
+	users, valueConverted := value.([]UserInfo)
+	if !valueConverted {
+		return nil, errors.Errorf("expected value of type %T, got %T", users, value)
+	}
+	var out bytes.Buffer
+	const (
+		// To format things into columns.
+		minwidth = 0
+		tabwidth = 1
+		padding  = 2
+		padchar  = ' '
+		flags    = 0
+	)
+	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	fmt.Fprintf(tw, "NAME\tDATE CREATED\tLAST CONNECTION\n")
+	for _, user := range users {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", user.Username, user.DateCreated, user.LastConnection)
+	}
+	tw.Flush()
+	return out.Bytes(), nil
+}
+
+func (c *UsersCommand) apiUsersToUserInfoSlice(users []params.EnvUserInfo) []UserInfo {
+	var output []UserInfo
+	var now = time.Now()
+	for _, info := range users {
+		outInfo := UserInfo{Username: info.UserName}
+		outInfo.DateCreated = user.UserFriendlyDuration(info.DateCreated, now)
+		if info.LastConnection != nil {
+			outInfo.LastConnection = user.UserFriendlyDuration(*info.LastConnection, now)
+		} else {
+			outInfo.LastConnection = "never connected"
+		}
+
+		output = append(output, outInfo)
+	}
+
+	return output
+}

--- a/cmd/juju/environment/users.go
+++ b/cmd/juju/environment/users.go
@@ -82,9 +82,10 @@ func (c *UsersCommand) Run(ctx *cmd.Context) (err error) {
 	return c.out.Write(ctx, c.apiUsersToUserInfoSlice(result))
 }
 
+// formatTabular takes an interface{} to adhere to the cmd.Formatter interface
 func (c *UsersCommand) formatTabular(value interface{}) ([]byte, error) {
-	users, valueConverted := value.([]UserInfo)
-	if !valueConverted {
+	users, ok := value.([]UserInfo)
+	if !ok {
 		return nil, errors.Errorf("expected value of type %T, got %T", users, value)
 	}
 	var out bytes.Buffer
@@ -107,12 +108,11 @@ func (c *UsersCommand) formatTabular(value interface{}) ([]byte, error) {
 
 func (c *UsersCommand) apiUsersToUserInfoSlice(users []params.EnvUserInfo) []UserInfo {
 	var output []UserInfo
-	var now = time.Now()
 	for _, info := range users {
 		outInfo := UserInfo{Username: info.UserName}
-		outInfo.DateCreated = user.UserFriendlyDuration(info.DateCreated, now)
+		outInfo.DateCreated = user.UserFriendlyDuration(info.DateCreated, time.Now())
 		if info.LastConnection != nil {
-			outInfo.LastConnection = user.UserFriendlyDuration(*info.LastConnection, now)
+			outInfo.LastConnection = user.UserFriendlyDuration(*info.LastConnection, time.Now())
 		} else {
 			outInfo.LastConnection = "never connected"
 		}

--- a/cmd/juju/environment/users_test.go
+++ b/cmd/juju/environment/users_test.go
@@ -1,0 +1,105 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for info.
+
+package environment_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/environment"
+	"github.com/juju/juju/testing"
+)
+
+type UsersCommandSuite struct {
+	testing.FakeJujuHomeSuite
+	fake *fakeEnvUsersClient
+}
+
+var _ = gc.Suite(&UsersCommandSuite{})
+
+type fakeEnvUsersClient struct {
+	users []params.EnvUserInfo
+}
+
+func (f *fakeEnvUsersClient) Close() error {
+	return nil
+}
+
+func (f *fakeEnvUsersClient) EnvironmentUserInfo() ([]params.EnvUserInfo, error) {
+	return f.users, nil
+}
+
+func (s *UsersCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+
+	last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
+	last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	userlist := []params.EnvUserInfo{
+		{
+			UserName:       "admin@local",
+			DisplayName:    "admin",
+			CreatedBy:      "admin@local",
+			DateCreated:    time.Date(2014, 7, 20, 9, 0, 0, 0, time.UTC),
+			LastConnection: &last1,
+		}, {
+			UserName:       "bob@local",
+			DisplayName:    "Bob",
+			CreatedBy:      "admin@local",
+			DateCreated:    time.Date(2015, 2, 15, 9, 0, 0, 0, time.UTC),
+			LastConnection: &last2,
+		}, {
+			UserName:    "charlie@ubuntu.com",
+			DisplayName: "Charlie",
+			CreatedBy:   "admin@local",
+			DateCreated: time.Date(2015, 2, 15, 9, 0, 0, 0, time.UTC),
+		},
+	}
+
+	s.fake = &fakeEnvUsersClient{users: userlist}
+}
+
+func (s *UsersCommandSuite) TestEnvUsers(c *gc.C) {
+	context, err := testing.RunCommand(c, environment.NewUsersCommand(s.fake))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, ""+
+		"NAME                DATE CREATED  LAST CONNECTION\n"+
+		"admin@local         2014-07-20    2015-03-20\n"+
+		"bob@local           2015-02-15    2015-03-01\n"+
+		"charlie@ubuntu.com  2015-02-15    never connected\n"+
+		"\n")
+}
+
+func (s *UsersCommandSuite) TestEnvUsersFormatJson(c *gc.C) {
+	context, err := testing.RunCommand(c, environment.NewUsersCommand(s.fake), "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "["+
+		`{"user-name":"admin@local","date-created":"2014-07-20","last-connection":"2015-03-20"},`+
+		`{"user-name":"bob@local","date-created":"2015-02-15","last-connection":"2015-03-01"},`+
+		`{"user-name":"charlie@ubuntu.com","date-created":"2015-02-15","last-connection":"never connected"}`+
+		"]\n")
+}
+
+func (s *UsersCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
+	context, err := testing.RunCommand(c, environment.NewUsersCommand(s.fake), "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, ""+
+		"- user-name: admin@local\n"+
+		"  date-created: 2014-07-20\n"+
+		"  last-connection: 2015-03-20\n"+
+		"- user-name: bob@local\n"+
+		"  date-created: 2015-02-15\n"+
+		"  last-connection: 2015-03-01\n"+
+		"- user-name: charlie@ubuntu.com\n"+
+		"  date-created: 2015-02-15\n"+
+		"  last-connection: never connected\n")
+}
+
+func (s *UsersCommandSuite) TestUnrecognizedArg(c *gc.C) {
+	_, err := testing.RunCommand(c, environment.NewUsersCommand(s.fake), "whoops")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+}

--- a/cmd/juju/environment/users_test.go
+++ b/cmd/juju/environment/users_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 type UsersCommandSuite struct {
-	testing.FakeJujuHomeSuite
 	fake *fakeEnvUsersClient
 }
 
@@ -34,8 +33,6 @@ func (f *fakeEnvUsersClient) EnvironmentUserInfo() ([]params.EnvUserInfo, error)
 }
 
 func (s *UsersCommandSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuHomeSuite.SetUpTest(c)
-
 	last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
 	last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
 

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -18,8 +18,6 @@ var (
 	GetConnectionCredentials = &getConnectionCredentials
 	// disable and enable
 	GetDisableUserAPI = &getDisableUserAPI
-
-	UserFriendlyDuration = userFriendlyDuration
 )
 
 // DisenableCommand is used for testing both Disable and Enable user commands.

--- a/cmd/juju/user/info.go
+++ b/cmd/juju/user/info.go
@@ -151,13 +151,13 @@ func (c *InfoCommandBase) apiUsersToUserInfoSlice(users []params.UserInfo) []Use
 		if c.exactTime {
 			outInfo.DateCreated = info.DateCreated.String()
 		} else {
-			outInfo.DateCreated = userFriendlyDuration(info.DateCreated, now)
+			outInfo.DateCreated = UserFriendlyDuration(info.DateCreated, now)
 		}
 		if info.LastConnection != nil {
 			if c.exactTime {
 				outInfo.LastConnection = info.LastConnection.String()
 			} else {
-				outInfo.LastConnection = userFriendlyDuration(*info.LastConnection, now)
+				outInfo.LastConnection = UserFriendlyDuration(*info.LastConnection, now)
 			}
 		} else {
 			outInfo.LastConnection = "never connected"
@@ -169,7 +169,9 @@ func (c *InfoCommandBase) apiUsersToUserInfoSlice(users []params.UserInfo) []Use
 	return output
 }
 
-func userFriendlyDuration(when, now time.Time) string {
+// UserFriendlyDuration translates a time in the past into a user
+// friendly string representation relative to the "now" time argument.
+func UserFriendlyDuration(when, now time.Time) string {
 	since := now.Sub(when)
 	// if over 24 hours ago, just say the date.
 	if since.Hours() >= 24 {

--- a/featuretests/cmd_juju_environment_test.go
+++ b/featuretests/cmd_juju_environment_test.go
@@ -76,3 +76,22 @@ func (s *cmdEnvironmentSuite) TestEnvironmentUnshareCmdStack(c *gc.C) {
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 	c.Assert(envuser, gc.IsNil)
 }
+
+func (s *cmdEnvironmentSuite) TestEnvironmentUsersCmd(c *gc.C) {
+	// Firstly share an environment with a user
+	username := "bar@ubuntuone"
+	context := runShare(c, []string{username})
+	user := names.NewUserTag(username)
+	envuser, err := s.State.EnvironmentUser(user)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(envuser, gc.NotNil)
+
+	context, err = testing.RunCommand(c, envcmd.Wrap(&cmdenvironment.UsersCommand{}))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, ""+
+		"NAME               DATE CREATED  LAST CONNECTION\n"+
+		"dummy-admin@local  just now      just now\n"+
+		"bar@ubuntuone      just now      never connected\n"+
+		"\n")
+
+}


### PR DESCRIPTION
This new command will list the users with access
to the current environment, along with the date
of their creation and the last connection time.

This command is placed behind the JES feature
flag as it is part of that work.

(Review request: http://reviews.vapour.ws/r/1368/)