### PR TITLE
juju status defaults to tabular (with ff), displays updated time for status

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -53,6 +53,7 @@ type AgentStatus struct {
 	Status  params.Status
 	Info    string
 	Data    map[string]interface{}
+	Since   *time.Time
 	Version string
 	Life    string
 	Err     error

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -68,20 +68,21 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, data, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusPending)
-	c.Assert(info, gc.Equals, "")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Assert(statusInfo.Message, gc.Equals, "")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	err = machine.SetStatus(params.StatusStarted, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, data, err = s.machine.Status()
+	statusInfo, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusStarted)
-	c.Assert(info, gc.Equals, "blah")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusStarted)
+	c.Assert(statusInfo.Message, gc.Equals, "blah")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
+	c.Assert(statusInfo.Since, gc.NotNil)
 }
 
 func (s *machinerSuite) TestEnsureDead(c *gc.C) {

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -109,9 +109,9 @@ func (s *provisionerSuite) TestGetSetStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, params.StatusStarted)
 	c.Assert(info, gc.Equals, "blah")
-	_, _, data, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 }
 
 func (s *provisionerSuite) TestGetSetStatusWithData(c *gc.C) {
@@ -125,9 +125,9 @@ func (s *provisionerSuite) TestGetSetStatusWithData(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, params.StatusError)
 	c.Assert(info, gc.Equals, "blah")
-	_, _, data, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(data, gc.DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{"foo": "bar"})
 }
 
 func (s *provisionerSuite) TestMachinesWithTransientErrors(c *gc.C) {

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -55,63 +55,65 @@ func (s *unitSuite) TestUnitAndUnitTag(c *gc.C) {
 }
 
 func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
-	status, info, data, err := s.wordpressUnit.AgentStatus()
+	statusInfo, err := s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusAllocating)
-	c.Assert(info, gc.Equals, "")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusAllocating)
+	c.Assert(statusInfo.Message, gc.Equals, "")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
-	unitStatus, unitInfo, unitData, err := s.wordpressUnit.Status()
+	unitStatusInfo, err := s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitStatus, gc.Equals, state.StatusUnknown)
-	c.Assert(unitInfo, gc.Equals, "Waiting for agent initialization to finish")
-	c.Assert(unitData, gc.HasLen, 0)
+	c.Assert(unitStatusInfo.Status, gc.Equals, state.StatusUnknown)
+	c.Assert(unitStatusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
+	c.Assert(unitStatusInfo.Data, gc.HasLen, 0)
 
 	err = s.apiUnit.SetAgentStatus(params.StatusIdle, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, data, err = s.wordpressUnit.AgentStatus()
+	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusIdle)
-	c.Assert(info, gc.Equals, "blah")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusIdle)
+	c.Assert(statusInfo.Message, gc.Equals, "blah")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
+	c.Assert(statusInfo.Since, gc.NotNil)
 
 	// Ensure that unit has not changed.
-	unitStatus, unitInfo, unitData, err = s.wordpressUnit.Status()
+	unitStatusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitStatus, gc.Equals, state.StatusUnknown)
-	c.Assert(unitInfo, gc.Equals, "Waiting for agent initialization to finish")
-	c.Assert(unitData, gc.HasLen, 0)
+	c.Assert(unitStatusInfo.Status, gc.Equals, state.StatusUnknown)
+	c.Assert(unitStatusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
+	c.Assert(unitStatusInfo.Data, gc.HasLen, 0)
 }
 
 func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
-	status, info, data, err := s.wordpressUnit.Status()
+	statusInfo, err := s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusUnknown)
-	c.Assert(info, gc.Equals, "Waiting for agent initialization to finish")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusUnknown)
+	c.Assert(statusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
-	agentStatus, agentInfo, agentData, err := s.wordpressUnit.AgentStatus()
+	agentStatusInfo, err := s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(agentStatus, gc.Equals, state.StatusAllocating)
-	c.Assert(agentInfo, gc.Equals, "")
-	c.Assert(agentData, gc.HasLen, 0)
+	c.Assert(agentStatusInfo.Status, gc.Equals, state.StatusAllocating)
+	c.Assert(agentStatusInfo.Message, gc.Equals, "")
+	c.Assert(agentStatusInfo.Data, gc.HasLen, 0)
 
 	err = s.apiUnit.SetUnitStatus(params.StatusActive, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, data, err = s.wordpressUnit.Status()
+	statusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusActive)
-	c.Assert(info, gc.Equals, "blah")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusActive)
+	c.Assert(statusInfo.Message, gc.Equals, "blah")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
+	c.Assert(statusInfo.Since, gc.NotNil)
 
 	// Ensure unit's agent has not changed.
-	agentStatus, agentInfo, agentData, err = s.wordpressUnit.AgentStatus()
+	agentStatusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(agentStatus, gc.Equals, state.StatusAllocating)
-	c.Assert(agentInfo, gc.Equals, "")
-	c.Assert(agentData, gc.HasLen, 0)
+	c.Assert(agentStatusInfo.Status, gc.Equals, state.StatusAllocating)
+	c.Assert(agentStatusInfo.Message, gc.Equals, "")
+	c.Assert(agentStatusInfo.Data, gc.HasLen, 0)
 }
 
 func (s *unitSuite) TestSetUnitStatusOldServer(c *gc.C) {
@@ -125,20 +127,20 @@ func (s *unitSuite) TestSetUnitStatusOldServer(c *gc.C) {
 func (s *unitSuite) TestSetAgentStatusOldServer(c *gc.C) {
 	s.patchNewState(c, uniter.NewStateV1)
 
-	status, info, data, err := s.wordpressUnit.Status()
+	statusInfo, err := s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusUnknown)
-	c.Assert(info, gc.Equals, "Waiting for agent initialization to finish")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusUnknown)
+	c.Assert(statusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	err = s.apiUnit.SetAgentStatus(params.StatusIdle, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, data, err = s.wordpressUnit.AgentStatus()
+	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusIdle)
-	c.Assert(info, gc.Equals, "blah")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusIdle)
+	c.Assert(statusInfo.Message, gc.Equals, "blah")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 }
 
 func (s *unitSuite) TestUnitStatus(c *gc.C) {
@@ -147,6 +149,8 @@ func (s *unitSuite) TestUnitStatus(c *gc.C) {
 
 	result, err := s.apiUnit.UnitStatus()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Since, gc.NotNil)
+	result.Since = nil
 	c.Assert(result, gc.DeepEquals, params.StatusResult{
 		Status: params.StatusMaintenance,
 		Info:   "blah",

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -3722,11 +3722,11 @@ func (s *clientSuite) TestRetryProvisioning(c *gc.C) {
 	_, err = s.APIState.Client().RetryProvisioning(machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, data, err := machine.Status()
+	statusInfo, err := machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
-	c.Assert(info, gc.Equals, "error")
-	c.Assert(data["transient"], jc.IsTrue)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Message, gc.Equals, "error")
+	c.Assert(statusInfo.Data["transient"], jc.IsTrue)
 }
 
 func (s *clientSuite) setupRetryProvisioning(c *gc.C) *state.Machine {
@@ -3740,11 +3740,11 @@ func (s *clientSuite) setupRetryProvisioning(c *gc.C) *state.Machine {
 func (s *clientSuite) assertRetryProvisioning(c *gc.C, machine *state.Machine) {
 	_, err := s.APIState.Client().RetryProvisioning(machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
-	status, info, data, err := machine.Status()
+	statusInfo, err := machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
-	c.Assert(info, gc.Equals, "error")
-	c.Assert(data["transient"], jc.IsTrue)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Message, gc.Equals, "error")
+	c.Assert(statusInfo.Data["transient"], jc.IsTrue)
 }
 
 func (s *clientSuite) assertRetryProvisioningBlocked(c *gc.C, machine *state.Machine, msg string) {

--- a/apiserver/client/filtering.go
+++ b/apiserver/client/filtering.go
@@ -138,23 +138,23 @@ func unitMatchUnitName(u *state.Unit, patterns []string) (bool, bool, error) {
 }
 
 func unitMatchAgentStatus(u *state.Unit, patterns []string) (bool, bool, error) {
-	status, _, _, err := u.AgentStatus()
+	statusInfo, err := u.AgentStatus()
 	if err != nil {
 		return false, false, err
 	}
-	return matchAgentStatus(patterns, status)
+	return matchAgentStatus(patterns, statusInfo.Status)
 }
 
 func unitMatchWorkloadStatus(u *state.Unit, patterns []string) (bool, bool, error) {
-	workloadStatus, _, _, err := u.Status()
+	workloadStatusInfo, err := u.Status()
 	if err != nil {
 		return false, false, err
 	}
-	agentStatus, _, _, err := u.AgentStatus()
+	agentStatusInfo, err := u.AgentStatus()
 	if err != nil {
 		return false, false, err
 	}
-	return matchWorkloadStatus(patterns, workloadStatus, agentStatus)
+	return matchWorkloadStatus(patterns, workloadStatusInfo.Status, agentStatusInfo.Status)
 }
 
 func unitMatchExposure(u *state.Unit, patterns []string) (bool, bool, error) {
@@ -233,11 +233,11 @@ func buildShimsForUnit(unitsFn func() ([]*state.Unit, error), patterns ...string
 
 func buildMachineMatcherShims(m *state.Machine, patterns []string) (shims []closurePredicate, _ error) {
 	// Look at machine status.
-	status, _, _, err := m.Status()
+	statusInfo, err := m.Status()
 	if err != nil {
 		return nil, err
 	}
-	shims = append(shims, func() (bool, bool, error) { return matchAgentStatus(patterns, status) })
+	shims = append(shims, func() (bool, bool, error) { return matchAgentStatus(patterns, statusInfo.Status) })
 
 	// Look at machine addresses. WARNING: Avoid the temptation to
 	// bring the append into the loop. The value we would close over

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -236,6 +236,7 @@ func opClientStatus(c *gc.C, st *api.State, mst *state.State) (func(), error) {
 		c.Check(status, gc.IsNil)
 		return func() {}, err
 	}
+	clearSinceTimes(status)
 	c.Assert(status, jc.DeepEquals, scenarioStatus)
 	return func() {}, nil
 }

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -620,10 +620,12 @@ func processUnitAndAgentStatus(unit *state.Unit, status *api.UnitStatus) {
 
 // makeStatusForEntity creates status information for machines, units.
 func makeStatusForEntity(agent *api.AgentStatus, getter state.StatusGetter) {
-	var st state.Status
-	st, agent.Info, agent.Data, agent.Err = getter.Status()
-	agent.Status = params.Status(st)
-	agent.Data = filterStatusData(agent.Data)
+	statusInfo, err := getter.Status()
+	agent.Err = err
+	agent.Status = params.Status(statusInfo.Status)
+	agent.Info = statusInfo.Message
+	agent.Data = filterStatusData(statusInfo.Data)
+	agent.Since = statusInfo.Since
 }
 
 // processMachine retrieves version and status information for the given machine.

--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -38,9 +38,11 @@ func (s *StatusGetter) getEntityStatus(tag names.Tag) params.StatusResult {
 	}
 	switch getter := entity.(type) {
 	case state.StatusGetter:
-		var st state.Status
-		st, result.Info, result.Data, err = getter.Status()
-		result.Status = params.Status(st)
+		statusInfo, err := getter.Status()
+		result.Status = params.Status(statusInfo.Status)
+		result.Info = statusInfo.Message
+		result.Data = statusInfo.Data
+		result.Since = statusInfo.Since
 		result.Error = ServerError(err)
 	default:
 		result.Error = ServerError(NotSupportedError(tag, fmt.Sprintf("getting status, %T", getter)))

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -61,6 +61,15 @@ func (*statusGetterSuite) TestStatus(c *gc.C) {
 	}
 	result, err := s.Status(args)
 	c.Assert(err, jc.ErrorIsNil)
+	// Zero out the updated timestamps so we can easily check the results.
+	for i, statusResult := range result.Results {
+		r := statusResult
+		if r.Status != "" {
+			c.Assert(r.Since, gc.NotNil)
+		}
+		r.Since = nil
+		result.Results[i] = r
+	}
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{Status: "allocating", Info: "blah", Error: &params.Error{Message: "x0 fails"}},

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -79,11 +79,11 @@ func (s *StatusSetter) updateEntityStatusData(tag names.Tag, data map[string]int
 	if !ok {
 		return NotSupportedError(tag, "getting status")
 	}
-	existingStatus, existingInfo, existingData, err := statusGetter.Status()
+	existingStatusInfo, err := statusGetter.Status()
 	if err != nil {
 		return err
 	}
-	newData := existingData
+	newData := existingStatusInfo.Data
 	if newData == nil {
 		newData = data
 	} else {
@@ -95,10 +95,10 @@ func (s *StatusSetter) updateEntityStatusData(tag names.Tag, data map[string]int
 	if !ok {
 		return NotSupportedError(tag, "updating status")
 	}
-	if len(newData) > 0 && existingStatus != state.StatusError {
+	if len(newData) > 0 && existingStatusInfo.Status != state.StatusError {
 		return fmt.Errorf("%s is not in an error state", names.ReadableString(tag))
 	}
-	return entity.SetStatus(existingStatus, existingInfo, newData)
+	return entity.SetStatus(existingStatusInfo.Status, existingStatusInfo.Message, newData)
 }
 
 // UpdateStatus updates the status data of each given entity.

--- a/apiserver/common/setstatus_test.go
+++ b/apiserver/common/setstatus_test.go
@@ -5,6 +5,7 @@ package common_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -24,10 +25,11 @@ var _ state.StatusSetter = new(fakeStatus)
 
 type fakeStatus struct {
 	state.Entity
-	status state.Status
-	info   string
-	data   map[string]interface{}
-	err    error
+	status  state.Status
+	info    string
+	data    map[string]interface{}
+	updated time.Time
+	err     error
 	fetchError
 }
 
@@ -35,11 +37,14 @@ func (s *fakeStatus) SetStatus(status state.Status, info string, data map[string
 	s.status = status
 	s.info = info
 	s.data = data
+	s.updated = time.Now()
 	return s.err
 }
 
-func (s *fakeStatus) Status() (status state.Status, info string, data map[string]interface{}, err error) {
-	return s.status, s.info, s.data, s.err
+func (s *fakeStatus) Status() (state.StatusInfo, error) {
+	return state.StatusInfo{
+		s.status, s.info, s.data, &s.updated,
+	}, s.err
 }
 
 func (s *fakeStatus) UpdateStatus(data map[string]interface{}) error {

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -75,15 +75,15 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 	})
 
 	// Verify machine 0 - no change.
-	status, info, _, err := s.machine0.Status()
+	statusInfo, err := s.machine0.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusStarted)
-	c.Assert(info, gc.Equals, "blah")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusStarted)
+	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	// ...machine 1 is fine though.
-	status, info, _, err = s.machine1.Status()
+	statusInfo, err = s.machine1.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
-	c.Assert(info, gc.Equals, "not really")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Message, gc.Equals, "not really")
 }
 
 func (s *machinerSuite) TestLife(c *gc.C) {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -354,6 +354,7 @@ type StatusResult struct {
 	Status Status
 	Info   string
 	Data   map[string]interface{}
+	Since  *time.Time
 }
 
 // StatusResults holds multiple status results.

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -300,12 +300,13 @@ func (p *ProvisionerAPI) MachinesWithTransientErrors() (params.StatusResults, er
 			continue
 		}
 		var result params.StatusResult
-		var st state.Status
-		st, result.Info, result.Data, err = machine.Status()
+		statusInfo, err := machine.Status()
 		if err != nil {
 			continue
 		}
-		result.Status = params.Status(st)
+		result.Status = params.Status(statusInfo.Status)
+		result.Info = statusInfo.Message
+		result.Data = statusInfo.Data
 		if result.Status != params.StatusError {
 			continue
 		}

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -450,11 +450,11 @@ func (s *withoutStateServerSuite) assertLife(c *gc.C, index int, expectLife stat
 func (s *withoutStateServerSuite) assertStatus(c *gc.C, index int, expectStatus state.Status, expectInfo string,
 	expectData map[string]interface{}) {
 
-	status, info, data, err := s.machines[index].Status()
+	statusInfo, err := s.machines[index].Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, expectStatus)
-	c.Assert(info, gc.Equals, expectInfo)
-	c.Assert(data, gc.DeepEquals, expectData)
+	c.Assert(statusInfo.Status, gc.Equals, expectStatus)
+	c.Assert(statusInfo.Message, gc.Equals, expectInfo)
+	c.Assert(statusInfo.Data, gc.DeepEquals, expectData)
 }
 
 func (s *withoutStateServerSuite) TestWatchContainers(c *gc.C) {
@@ -561,6 +561,15 @@ func (s *withoutStateServerSuite) TestStatus(c *gc.C) {
 	}}
 	result, err := s.provisioner.Status(args)
 	c.Assert(err, jc.ErrorIsNil)
+	// Zero out the updated timestamps so we can easily check the results.
+	for i, statusResult := range result.Results {
+		r := statusResult
+		if r.Status != "" {
+			c.Assert(r.Since, gc.NotNil)
+		}
+		r.Since = nil
+		result.Results[i] = r
+	}
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{Status: params.StatusStarted, Info: "blah", Data: map[string]interface{}{}},

--- a/apiserver/uniter/uniter_base_test.go
+++ b/apiserver/uniter/uniter_base_test.go
@@ -148,15 +148,15 @@ func (s *uniterBaseSuite) testSetStatus(
 	})
 
 	// Verify mysqlUnit - no change.
-	status, info, _, err := s.mysqlUnit.AgentStatus()
+	statusInfo, err := s.mysqlUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusExecuting)
-	c.Assert(info, gc.Equals, "foo")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusExecuting)
+	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
-	status, info, _, err = s.wordpressUnit.AgentStatus()
+	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusRebooting)
-	c.Assert(info, gc.Equals, "foobar")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusRebooting)
+	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
 func (s *uniterBaseSuite) testSetAgentStatus(
@@ -187,15 +187,15 @@ func (s *uniterBaseSuite) testSetAgentStatus(
 	})
 
 	// Verify mysqlUnit - no change.
-	status, info, _, err := s.mysqlUnit.AgentStatus()
+	statusInfo, err := s.mysqlUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusExecuting)
-	c.Assert(info, gc.Equals, "foo")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusExecuting)
+	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
-	status, info, _, err = s.wordpressUnit.AgentStatus()
+	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusExecuting)
-	c.Assert(info, gc.Equals, "foobar")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusExecuting)
+	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
 func (s *uniterBaseSuite) testSetUnitStatus(
@@ -226,15 +226,15 @@ func (s *uniterBaseSuite) testSetUnitStatus(
 	})
 
 	// Verify mysqlUnit - no change.
-	status, info, _, err := s.mysqlUnit.Status()
+	statusInfo, err := s.mysqlUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusTerminated)
-	c.Assert(info, gc.Equals, "foo")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusTerminated)
+	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
-	status, info, _, err = s.wordpressUnit.Status()
+	statusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusTerminated)
-	c.Assert(info, gc.Equals, "foobar")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusTerminated)
+	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
 func (s *uniterBaseSuite) testLife(

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -120,6 +120,15 @@ func (s *uniterV2Suite) TestUnitStatus(c *gc.C) {
 		}}
 	result, err := s.uniter.UnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
+	// Zero out the updated timestamps so we can easily check the results.
+	for i, statusResult := range result.Results {
+		r := statusResult
+		if r.Status != "" {
+			c.Assert(r.Since, gc.NotNil)
+		}
+		r.Since = nil
+		result.Results[i] = r
+	}
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{Error: apiservertesting.ErrUnauthorized},

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -449,7 +449,7 @@ func (sf *statusFormatter) getWorkloadStatusInfo(unit api.UnitStatus) statusInfo
 		Version: unit.Workload.Version,
 	}
 	if unit.Workload.Since != nil {
-		info.Since = unit.Workload.Since.Format(time.RFC822)
+		info.Since = unit.Workload.Since.Local().Format(time.RFC822)
 	}
 	return info
 }
@@ -462,7 +462,7 @@ func (sf *statusFormatter) getAgentStatusInfo(unit api.UnitStatus) statusInfoCon
 		Version: unit.UnitAgent.Version,
 	}
 	if unit.UnitAgent.Since != nil {
-		info.Since = unit.UnitAgent.Since.Format(time.RFC822)
+		info.Since = unit.UnitAgent.Since.Local().Format(time.RFC822)
 	}
 	return info
 }

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -6,14 +6,17 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/utils/featureflag"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/multiwatcher"
@@ -67,7 +70,11 @@ func (c *StatusCommand) Info() *cmd.Info {
 }
 
 func (c *StatusCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+	defaultFormat := "yaml"
+	if featureflag.Enabled(feature.NewStatus) {
+		defaultFormat = "tabular"
+	}
+	c.out.AddFlags(f, defaultFormat, map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
 		"short":   FormatOneline,
@@ -227,6 +234,7 @@ type statusInfoContents struct {
 	Current params.Status `json:"current,omitempty" yaml:"current,omitempty"`
 	Message string        `json:"message,omitempty" yaml:"message,omitempty"`
 	Since   string        `json:"since,omitempty" yaml:"since,omitempty"`
+	Version string        `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 type statusInfoContentsNoMarshal statusInfoContents
@@ -419,11 +427,13 @@ func (sf *statusFormatter) formatUnit(unit api.UnitStatus, serviceName string) u
 	}
 
 	// These legacy fields will be dropped for Juju 2.0.
-	out.Err = unit.Err
-	out.AgentState = unit.AgentState
-	out.AgentStateInfo = unit.AgentStateInfo
-	out.Life = unit.Life
-	out.AgentVersion = unit.AgentVersion
+	if !featureflag.Enabled(feature.NewStatus) || out.AgentStatusInfo.Current == "" {
+		out.Err = unit.Err
+		out.AgentState = unit.AgentState
+		out.AgentStateInfo = unit.AgentStateInfo
+		out.Life = unit.Life
+		out.AgentVersion = unit.AgentVersion
+	}
 
 	for k, m := range unit.Subordinates {
 		out.Subordinates[k] = sf.formatUnit(m, serviceName)
@@ -432,19 +442,29 @@ func (sf *statusFormatter) formatUnit(unit api.UnitStatus, serviceName string) u
 }
 
 func (sf *statusFormatter) getWorkloadStatusInfo(unit api.UnitStatus) statusInfoContents {
-	return statusInfoContents{
+	info := statusInfoContents{
 		Err:     unit.Workload.Err,
 		Current: unit.Workload.Status,
 		Message: unit.Workload.Info,
+		Version: unit.Workload.Version,
 	}
+	if unit.Workload.Since != nil {
+		info.Since = unit.Workload.Since.Format(time.RFC822)
+	}
+	return info
 }
 
 func (sf *statusFormatter) getAgentStatusInfo(unit api.UnitStatus) statusInfoContents {
-	return statusInfoContents{
+	info := statusInfoContents{
 		Err:     unit.UnitAgent.Err,
 		Current: unit.UnitAgent.Status,
 		Message: unit.UnitAgent.Info,
+		Version: unit.UnitAgent.Version,
 	}
+	if unit.UnitAgent.Since != nil {
+		info.Since = unit.UnitAgent.Since.Format(time.RFC822)
+	}
+	return info
 }
 
 func (sf *statusFormatter) updateUnitStatusInfo(unit *api.UnitStatus, serviceName string) {

--- a/cmd/juju/status_formatters.go
+++ b/cmd/juju/status_formatters.go
@@ -104,23 +104,6 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		)
 	}
 
-	pUnitInfo := func(u unitStatus, level int, info string) {
-		// We need to keep the tabular output nice and neat, so
-		// limit the size of the info message.
-		if len(info) > 25 {
-			info = info[:25] + "..."
-		}
-		p(
-			indent("", level*2, ""),
-			info,
-			"",
-			"",
-			"",
-			"",
-			"",
-		)
-	}
-
 	// See if we have new or old data; that determines what data we can display.
 	newStatus := false
 	for _, u := range units {
@@ -129,12 +112,30 @@ func FormatTabular(value interface{}) ([]byte, error) {
 			break
 		}
 	}
-	p("\n[Units]")
+	var header []string
 	if newStatus {
-		p("ID\tWORKLOAD-STATE\tAGENT-STATE\tVERSION\tMACHINE\tPORTS\tPUBLIC-ADDRESS")
+		header = []string{"ID", "WORKLOAD-STATE", "AGENT-STATE", "VERSION", "MACHINE", "PORTS", "PUBLIC-ADDRESS"}
 	} else {
-		p("ID\tSTATE\tVERSION\tMACHINE\tPORTS\tPUBLIC-ADDRESS")
+		header = []string{"ID", "STATE", "VERSION", "MACHINE", "PORTS", "PUBLIC-ADDRESS"}
 	}
+
+	pUnitInfo := func(u unitStatus, level int, info string) {
+		// We need to keep the tabular output nice and neat, so
+		// limit the size of the info message.
+		if len(info) > 25 {
+			info = info[:22] + "..."
+		}
+		columns := make([]interface{}, len(header))
+		columns[0] = indent("", level*2, "")
+		columns[1] = info
+		for i := 2; i < len(columns); i++ {
+			columns[i] = ""
+		}
+		p(columns...)
+	}
+
+	p("\n[Units]")
+	p(strings.Join(header, "\t"))
 	for _, name := range sortStringsNaturally(stringKeysFromMap(units)) {
 		u := units[name]
 		pUnit(name, u, 0)

--- a/cmd/juju/status_formatters.go
+++ b/cmd/juju/status_formatters.go
@@ -95,19 +95,58 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	pUnit := func(name string, u unitStatus, level int) {
 		p(
 			indent("", level*2, name),
-			u.AgentState,
-			u.AgentVersion,
+			u.WorkloadStatusInfo.Current,
+			u.AgentStatusInfo.Current,
+			u.AgentStatusInfo.Version,
 			u.Machine,
 			strings.Join(u.OpenedPorts, ","),
 			u.PublicAddress,
 		)
 	}
 
+	pUnitInfo := func(u unitStatus, level int, info string) {
+		// We need to keep the tabular output nice and neat, so
+		// limit the size of the info message.
+		if len(info) > 25 {
+			info = info[:25] + "..."
+		}
+		p(
+			indent("", level*2, ""),
+			info,
+			"",
+			"",
+			"",
+			"",
+			"",
+		)
+	}
+
+	// See if we have new or old data; that determines what data we can display.
+	newStatus := false
+	for _, u := range units {
+		if u.AgentStatusInfo.Current != "" {
+			newStatus = true
+			break
+		}
+	}
 	p("\n[Units]")
-	p("ID\tSTATE\tVERSION\tMACHINE\tPORTS\tPUBLIC-ADDRESS")
+	if newStatus {
+		p("ID\tWORKLOAD-STATE\tAGENT-STATE\tVERSION\tMACHINE\tPORTS\tPUBLIC-ADDRESS")
+	} else {
+		p("ID\tSTATE\tVERSION\tMACHINE\tPORTS\tPUBLIC-ADDRESS")
+	}
 	for _, name := range sortStringsNaturally(stringKeysFromMap(units)) {
 		u := units[name]
 		pUnit(name, u, 0)
+		// If we have new status data, we will display a little extra info for workload status if needed.
+		if newStatus {
+			switch u.WorkloadStatusInfo.Current {
+			case params.StatusMaintenance, params.StatusError:
+				if u.WorkloadStatusInfo.Message != "" {
+					pUnitInfo(u, 0, u.WorkloadStatusInfo.Message)
+				}
+			}
+		}
 		const indentationLevel = 1
 		recurseUnits(u, indentationLevel, pUnit)
 	}

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -2879,12 +2879,12 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 			"wordpress  true    cs:quantal/wordpress-3 \n"+
 			"\n"+
 			"[Units]     \n"+
-			"ID          WORKLOAD-STATE               AGENT-STATE VERSION MACHINE PORTS PUBLIC-ADDRESS \n"+
-			"mysql/0     maintenance                  idle        1.2.3   2             dummyenv-2.dns \n"+
-			"            installing all the things...                                                  \n"+
-			"  logging/1 error                        idle                              dummyenv-2.dns \n"+
-			"wordpress/0 active                       idle        1.2.3   1             dummyenv-1.dns \n"+
-			"  logging/0 active                       idle                              dummyenv-1.dns \n"+
+			"ID          WORKLOAD-STATE            AGENT-STATE VERSION MACHINE PORTS PUBLIC-ADDRESS \n"+
+			"mysql/0     maintenance               idle        1.2.3   2             dummyenv-2.dns \n"+
+			"            installing all the thi...                                                  \n"+
+			"  logging/1 error                     idle                              dummyenv-2.dns \n"+
+			"wordpress/0 active                    idle        1.2.3   1             dummyenv-1.dns \n"+
+			"  logging/0 active                    idle                              dummyenv-1.dns \n"+
 			"\n",
 	)
 }

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -156,9 +156,9 @@ func waitForUnitActive(stateConn *state.State, unit *state.Unit, c *gc.C) {
 		case <-time.After(coretesting.ShortWait):
 			err := unit.Refresh()
 			c.Assert(err, jc.ErrorIsNil)
-			st, info, data, err := unit.Status()
+			statusInfo, err := unit.Status()
 			c.Assert(err, jc.ErrorIsNil)
-			switch st {
+			switch statusInfo.Status {
 			case state.StatusMaintenance, state.StatusWaiting, state.StatusBlocked:
 				c.Logf("waiting...")
 				continue
@@ -171,11 +171,11 @@ func waitForUnitActive(stateConn *state.State, unit *state.Unit, c *gc.C) {
 				c.Logf("unknown but active!")
 				return
 			default:
-				c.Fatalf("unexpected status %s %s %v", st, info, data)
+				c.Fatalf("unexpected status %s %s %v", statusInfo.Status, statusInfo.Message, statusInfo.Data)
 			}
-			st, info, data, err = unit.AgentStatus()
+			statusInfo, err = unit.AgentStatus()
 			c.Assert(err, jc.ErrorIsNil)
-			switch st {
+			switch statusInfo.Status {
 			case state.StatusAllocating, state.StatusExecuting, state.StatusRebooting, state.StatusIdle:
 				c.Logf("waiting...")
 				continue
@@ -183,7 +183,7 @@ func waitForUnitActive(stateConn *state.State, unit *state.Unit, c *gc.C) {
 				stateConn.StartSync()
 				c.Logf("unit is still down")
 			default:
-				c.Fatalf("unexpected status %s %s %v", st, info, data)
+				c.Fatalf("unexpected status %s %s %v", statusInfo.Status, statusInfo.Message, statusInfo.Data)
 			}
 		}
 	}

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -45,3 +45,7 @@ const LegacyUpstart = "legacy-upstart"
 // DbLog is the the feature which has Juju's logs go to
 // MongoDB instead of to all-machines.log using rsyslog.
 const DbLog = "db-log"
+
+// NewStatus is the name of the feature to enable the new
+// juju status output.
+const NewStatus = "new-status"

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1539,29 +1539,29 @@ func (s *MachineSuite) TestGetSetStatusWhileAlive(c *gc.C) {
 	err = s.machine.SetStatus(state.Status("vliegkat"), "orville", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
 
-	status, info, data, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusPending)
-	c.Assert(info, gc.Equals, "")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Assert(statusInfo.Message, gc.Equals, "")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	err = s.machine.SetStatus(state.StatusStarted, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	status, info, data, err = s.machine.Status()
+	statusInfo, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusStarted)
-	c.Assert(info, gc.Equals, "")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusStarted)
+	c.Assert(statusInfo.Message, gc.Equals, "")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	err = s.machine.SetStatus(state.StatusError, "provisioning failed", map[string]interface{}{
 		"foo": "bar",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	status, info, data, err = s.machine.Status()
+	statusInfo, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
-	c.Assert(info, gc.Equals, "provisioning failed")
-	c.Assert(data, gc.DeepEquals, map[string]interface{}{
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Message, gc.Equals, "provisioning failed")
+	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{
 		"foo": "bar",
 	})
 }
@@ -1582,35 +1582,35 @@ func (s *MachineSuite) TestGetSetStatusWhileNotAlive(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetStatus(state.StatusStopped, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	status, info, data, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusStopped)
-	c.Assert(info, gc.Equals, "")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusStopped)
+	c.Assert(statusInfo.Message, gc.Equals, "")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	// When Dead set should fail, but get will work.
 	err = s.machine.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetStatus(state.StatusStarted, "not really", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set status of machine "1": not found or not alive`)
-	status, info, data, err = s.machine.Status()
+	statusInfo, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusStopped)
-	c.Assert(info, gc.Equals, "")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusStopped)
+	c.Assert(statusInfo.Message, gc.Equals, "")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetStatus(state.StatusStarted, "not really", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set status of machine "1": not found or not alive`)
-	_, _, _, err = s.machine.Status()
+	_, err = s.machine.Status()
 	c.Assert(err, gc.ErrorMatches, "status not found")
 }
 
 func (s *MachineSuite) TestGetSetStatusDataStandard(c *gc.C) {
 	err := s.machine.SetStatus(state.StatusStarted, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, _, _, err = s.machine.Status()
+	_, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Regular status setting with data.
@@ -1620,11 +1620,11 @@ func (s *MachineSuite) TestGetSetStatusDataStandard(c *gc.C) {
 		"3rd-key": true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	status, info, data, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
-	c.Assert(info, gc.Equals, "provisioning failed")
-	c.Assert(data, gc.DeepEquals, map[string]interface{}{
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Message, gc.Equals, "provisioning failed")
+	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{
 		"1st-key": "one",
 		"2nd-key": 2,
 		"3rd-key": true,
@@ -1634,7 +1634,7 @@ func (s *MachineSuite) TestGetSetStatusDataStandard(c *gc.C) {
 func (s *MachineSuite) TestGetSetStatusDataMongo(c *gc.C) {
 	err := s.machine.SetStatus(state.StatusStarted, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, _, _, err = s.machine.Status()
+	_, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Status setting with MongoDB special values.
@@ -1645,11 +1645,11 @@ func (s *MachineSuite) TestGetSetStatusDataMongo(c *gc.C) {
 		"group":         "group",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	status, info, data, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
-	c.Assert(info, gc.Equals, "mongo")
-	c.Assert(data, gc.DeepEquals, map[string]interface{}{
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Message, gc.Equals, "mongo")
+	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{
 		`{name: "Joe"}`: "$where",
 		"eval":          `eval(function(foo) { return foo; }, "bar")`,
 		"mapReduce":     "mapReduce",
@@ -1660,7 +1660,7 @@ func (s *MachineSuite) TestGetSetStatusDataMongo(c *gc.C) {
 func (s *MachineSuite) TestGetSetStatusDataChange(c *gc.C) {
 	err := s.machine.SetStatus(state.StatusStarted, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, _, _, err = s.machine.Status()
+	_, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Status setting and changing data afterwards.
@@ -1673,11 +1673,11 @@ func (s *MachineSuite) TestGetSetStatusDataChange(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	data["4th-key"] = 4.0
 
-	status, info, data, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
-	c.Assert(info, gc.Equals, "provisioning failed")
-	c.Assert(data, gc.DeepEquals, map[string]interface{}{
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Message, gc.Equals, "provisioning failed")
+	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{
 		"1st-key": "one",
 		"2nd-key": 2,
 		"3rd-key": true,
@@ -1687,11 +1687,11 @@ func (s *MachineSuite) TestGetSetStatusDataChange(c *gc.C) {
 	err = s.machine.SetStatus(state.StatusStarted, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, data, err = s.machine.Status()
+	statusInfo, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusStarted)
-	c.Assert(info, gc.Equals, "")
-	c.Assert(data, gc.HasLen, 0)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusStarted)
+	c.Assert(statusInfo.Message, gc.Equals, "")
+	c.Assert(statusInfo.Data, gc.HasLen, 0)
 }
 
 func (s *MachineSuite) TestSetAddresses(c *gc.C) {
@@ -2061,18 +2061,18 @@ func (s *MachineSuite) TestSetSupportedContainersSetsUnknownToError(c *gc.C) {
 	// A supported (kvm) container will have a pending status.
 	err = supportedContainer.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	status, info, data, err := supportedContainer.Status()
+	statusInfo, err := supportedContainer.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusPending)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
 
 	// An unsupported (lxc) container will have an error status.
 	err = container.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	status, info, data, err = container.Status()
+	statusInfo, err = container.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
-	c.Assert(info, gc.Equals, "unsupported container")
-	c.Assert(data, gc.DeepEquals, map[string]interface{}{"type": "lxc"})
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Message, gc.Equals, "unsupported container")
+	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{"type": "lxc"})
 }
 
 func (s *MachineSuite) TestSupportsNoContainersSetsAllToError(c *gc.C) {
@@ -2096,12 +2096,12 @@ func (s *MachineSuite) TestSupportsNoContainersSetsAllToError(c *gc.C) {
 	for _, container := range containers {
 		err = container.Refresh()
 		c.Assert(err, jc.ErrorIsNil)
-		status, info, data, err := container.Status()
+		statusInfo, err := container.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(status, gc.Equals, state.StatusError)
-		c.Assert(info, gc.Equals, "unsupported container")
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+		c.Assert(statusInfo.Message, gc.Equals, "unsupported container")
 		containerType := state.ContainerTypeFromId(container.Id())
-		c.Assert(data, gc.DeepEquals, map[string]interface{}{"type": string(containerType)})
+		c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{"type": string(containerType)})
 	}
 }
 

--- a/state/service.go
+++ b/state/service.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
+	"time"
 )
 
 // Service represents the state of a service.
@@ -603,13 +604,16 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		Principal:              principalName,
 		StorageAttachmentCount: numStorageAttachments,
 	}
+	now := time.Now()
 	agentStatusDoc := statusDoc{
 		Status:  StatusAllocating,
+		Updated: &now,
 		EnvUUID: s.st.EnvironUUID(),
 	}
 	unitStatusDoc := statusDoc{
 		Status:     StatusUnknown,
 		StatusInfo: "Waiting for agent initialization to finish",
+		Updated:    &now,
 		EnvUUID:    s.st.EnvironUUID(),
 	}
 	ops := []txn.Op{

--- a/state/service.go
+++ b/state/service.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -19,7 +20,6 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
-	"time"
 )
 
 // Service represents the state of a service.

--- a/state/status.go
+++ b/state/status.go
@@ -212,7 +212,7 @@ type StatusSetter interface {
 
 // StatusGetter represents a type whose status can be read.
 type StatusGetter interface {
-	Status() (statusInfo StatusInfo, err error)
+	Status() (StatusInfo, error)
 }
 
 // StatusInfo holds the status information for a machine, unit, service etc.

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -32,15 +32,17 @@ func (u *UnitAgent) String() string {
 }
 
 // Status returns the status of the unit.
-func (u *UnitAgent) Status() (status Status, info string, data map[string]interface{}, err error) {
+func (u *UnitAgent) Status() (StatusInfo, error) {
 	doc, err := getStatus(u.st, u.globalKey())
 	if err != nil {
-		return "", "", nil, errors.Trace(err)
+		return StatusInfo{}, errors.Trace(err)
 	}
-	status = doc.Status
-	info = doc.StatusInfo
-	data = doc.StatusData
-	return
+	return StatusInfo{
+		Status:  doc.Status,
+		Message: doc.StatusInfo,
+		Data:    doc.StatusData,
+		Since:   doc.Updated,
+	}, nil
 }
 
 // SetStatus sets the status of the unit agent. The optional values

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -356,11 +356,11 @@ func (m *testMachine) InstanceId() (instance.Id, error) {
 }
 
 // This is stubbed out for testing.
-var MachineStatus = func(m *testMachine) (status state.Status, info string, data map[string]interface{}, err error) {
-	return m.status, "", nil, nil
+var MachineStatus = func(m *testMachine) (state.StatusInfo, error) {
+	return state.StatusInfo{m.status, "", nil, nil}, nil
 }
 
-func (m *testMachine) Status() (status state.Status, info string, data map[string]interface{}, err error) {
+func (m *testMachine) Status() (state.StatusInfo, error) {
 	return MachineStatus(m)
 }
 

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -41,7 +41,7 @@ type machine interface {
 	String() string
 	Refresh() error
 	Life() state.Life
-	Status() (status state.Status, info string, data map[string]interface{}, err error)
+	Status() (state.StatusInfo, error)
 	IsManual() (bool, error)
 }
 
@@ -196,8 +196,10 @@ func machineLoop(context machineContext, m machine, changed <-chan struct{}) err
 			}
 			machineStatus := state.StatusPending
 			if err == nil {
-				if machineStatus, _, _, err = m.Status(); err != nil {
+				if statusInfo, err := m.Status(); err != nil {
 					logger.Warningf("cannot get current machine status for machine %v: %v", m.Id(), err)
+				} else {
+					machineStatus = statusInfo.Status
 				}
 			}
 			if len(instInfo.addresses) > 0 && instInfo.status != "" && machineStatus == state.StatusStarted {

--- a/worker/instancepoller/updater_test.go
+++ b/worker/instancepoller/updater_test.go
@@ -120,10 +120,10 @@ func (*updaterSuite) TestWatchMachinesWaitsForMachinePollers(c *gc.C) {
 
 func (s *updaterSuite) TestManualMachinesIgnored(c *gc.C) {
 	waitStatus := make(chan struct{})
-	s.PatchValue(&MachineStatus, func(m *testMachine) (status state.Status, info string, data map[string]interface{}, err error) {
+	s.PatchValue(&MachineStatus, func(m *testMachine) (state.StatusInfo, error) {
 		// Signal that we're in Status.
 		waitStatus <- struct{}{}
-		return state.StatusPending, "", map[string]interface{}{}, nil
+		return state.StatusInfo{state.StatusPending, "", map[string]interface{}{}, nil}, nil
 	})
 	m := &testMachine{
 		id:         "99",

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -78,10 +78,10 @@ func (s *MachinerSuite) waitMachineStatus(c *gc.C, m *state.Machine, expectStatu
 		case <-timeout:
 			c.Fatalf("timeout while waiting for machine status to change")
 		case <-time.After(10 * time.Millisecond):
-			status, _, _, err := m.Status()
+			statusInfo, err := m.Status()
 			c.Assert(err, jc.ErrorIsNil)
-			if status != expectStatus {
-				c.Logf("machine %q status is %s, still waiting", m, status)
+			if statusInfo.Status != expectStatus {
+				c.Logf("machine %q status is %s, still waiting", m, statusInfo.Status)
 				continue
 			}
 			return
@@ -121,10 +121,10 @@ func (s *MachinerSuite) TestRunStop(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestStartSetsStatus(c *gc.C) {
-	status, info, _, err := s.machine.Status()
+	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusPending)
-	c.Assert(info, gc.Equals, "")
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Assert(statusInfo.Message, gc.Equals, "")
 
 	mr := s.makeMachiner()
 	defer worker.Stop(mr)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -520,14 +520,14 @@ func (s *ProvisionerSuite) TestProvisionerSetsErrorStatusWhenNoToolsAreAvailable
 	t0 := time.Now()
 	for time.Since(t0) < coretesting.LongWait {
 		// And check the machine status is set to error.
-		status, info, _, err := m.Status()
+		statusInfo, err := m.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if status == state.StatusPending {
+		if statusInfo.Status == state.StatusPending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(status, gc.Equals, state.StatusError)
-		c.Assert(info, gc.Equals, "no matching tools available")
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+		c.Assert(statusInfo.Message, gc.Equals, "no matching tools available")
 		break
 	}
 
@@ -551,14 +551,14 @@ func (s *ProvisionerSuite) TestProvisionerSetsErrorStatusWhenStartInstanceFailed
 	t0 := time.Now()
 	for time.Since(t0) < coretesting.LongWait {
 		// And check the machine status is set to error.
-		status, info, _, err := m.Status()
+		statusInfo, err := m.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if status == state.StatusPending {
+		if statusInfo.Status == state.StatusPending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(status, gc.Equals, state.StatusError)
-		c.Assert(info, gc.Equals, brokenMsg)
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+		c.Assert(statusInfo.Message, gc.Equals, brokenMsg)
 		break
 	}
 
@@ -597,15 +597,15 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 	t0 := time.Now()
 	for time.Since(t0) < coretesting.LongWait {
 		// And check the machine status is set to error.
-		status, info, _, err := m.Status()
+		statusInfo, err := m.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if status == state.StatusPending {
+		if statusInfo.Status == state.StatusPending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(status, gc.Equals, state.StatusError)
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 		// check that the status matches the error message
-		c.Assert(info, gc.Equals, destroyError.Error())
+		c.Assert(statusInfo.Message, gc.Equals, destroyError.Error())
 		break
 	}
 
@@ -679,15 +679,15 @@ func (s *ProvisionerSuite) TestProvisionerFailStartInstanceWithInjectedNonRetrya
 	t0 := time.Now()
 	for time.Since(t0) < coretesting.LongWait {
 		// And check the machine status is set to error.
-		status, info, _, err := m.Status()
+		statusInfo, err := m.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if status == state.StatusPending {
+		if statusInfo.Status == state.StatusPending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(status, gc.Equals, state.StatusError)
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 		// check that the status matches the error message
-		c.Assert(info, gc.Equals, nonRetryableError.Error())
+		c.Assert(statusInfo.Message, gc.Equals, nonRetryableError.Error())
 		break
 	}
 }
@@ -790,14 +790,14 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithInvalidNetwork(c *gc.C) {
 	t0 := time.Now()
 	for time.Since(t0) < coretesting.LongWait {
 		// And check the machine status is set to error.
-		status, info, _, err := m.Status()
+		statusInfo, err := m.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if status == state.StatusPending {
+		if statusInfo.Status == state.StatusPending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(status, gc.Equals, state.StatusError)
-		c.Assert(info, gc.Matches, `invalid network name "\$\$invalid-net1"`)
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+		c.Assert(statusInfo.Message, gc.Matches, `invalid network name "\$\$invalid-net1"`)
 		break
 	}
 
@@ -895,14 +895,14 @@ func (s *ProvisionerSuite) TestSetInstanceInfoFailureSetsErrorStatusAndStopsInst
 	t0 := time.Now()
 	for time.Since(t0) < coretesting.LongWait {
 		// And check the machine status is set to error.
-		status, info, _, err := m.Status()
+		statusInfo, err := m.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		if status == state.StatusPending {
+		if statusInfo.Status == state.StatusPending {
 			time.Sleep(coretesting.ShortWait)
 			continue
 		}
-		c.Assert(status, gc.Equals, state.StatusError)
-		c.Assert(info, gc.Matches, `cannot record provisioning info for "dummyenv-0": cannot add network "bad-net1": invalid CIDR address: invalid`)
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+		c.Assert(statusInfo.Message, gc.Matches, `cannot record provisioning info for "dummyenv-0": cannot add network "bad-net1": invalid CIDR address: invalid`)
 		break
 	}
 	s.checkStopInstances(c, inst)
@@ -1318,9 +1318,9 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 	close(thatsAllFolks)
 
 	// Machine 4 is never provisioned.
-	status, _, _, err := m4.Status()
+	statusInfo, err := m4.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	_, err = m4.InstanceId()
 	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -605,18 +605,18 @@ func (s resolveError) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-type statusfunc func() (status state.Status, info string, data map[string]interface{}, err error)
+type statusfunc func() (state.StatusInfo, error)
 
 type statusfuncGetter func(ctx *context) statusfunc
 
 var unitStatusGetter = func(ctx *context) statusfunc {
-	return func() (status state.Status, info string, data map[string]interface{}, err error) {
+	return func() (state.StatusInfo, error) {
 		return ctx.unit.Status()
 	}
 }
 
 var agentStatusGetter = func(ctx *context) statusfunc {
-	return func() (status state.Status, info string, data map[string]interface{}, err error) {
+	return func() (state.StatusInfo, error) {
 		return ctx.unit.AgentStatus()
 	}
 }
@@ -657,25 +657,25 @@ func (s waitUnitAgent) step(c *gc.C, ctx *context) {
 				c.Logf("want unit charm %q, got %q; still waiting", curl(s.charm), got)
 				continue
 			}
-			status, info, data, err := s.statusGetter(ctx)()
+			statusInfo, err := s.statusGetter(ctx)()
 			c.Assert(err, jc.ErrorIsNil)
-			if string(status) != string(s.status) {
-				c.Logf("want unit status %q, got %q; still waiting", s.status, status)
+			if string(statusInfo.Status) != string(s.status) {
+				c.Logf("want unit status %q, got %q; still waiting", s.status, statusInfo.Status)
 				continue
 			}
-			if info != s.info {
-				c.Logf("want unit status info %q, got %q; still waiting", s.info, info)
+			if statusInfo.Message != s.info {
+				c.Logf("want unit status info %q, got %q; still waiting", s.info, statusInfo.Message)
 				continue
 			}
 			if s.data != nil {
-				if len(data) != len(s.data) {
-					c.Logf("want %d status data value(s), got %d; still waiting", len(s.data), len(data))
+				if len(statusInfo.Data) != len(s.data) {
+					c.Logf("want %d status data value(s), got %d; still waiting", len(s.data), len(statusInfo.Data))
 					continue
 				}
 				for key, value := range s.data {
-					if data[key] != value {
+					if statusInfo.Data[key] != value {
 						c.Logf("want status data value %q for key %q, got %q; still waiting",
-							value, key, data[key])
+							value, key, statusInfo.Data[key])
 						continue
 					}
 				}


### PR DESCRIPTION
The bulk of this PR is mechanical (see below).

We now record a "when updated" attribute for status records. This is display in juju status output. The Status() API was returning (status, info, data, error). Rather than add last-updated to the mix, I changed the API to return a StatusInfo struct. Hence all the rework.

The functional changes are that with a feature flag "new-status", the juju status command defaults to tabular output. I am experimenting a bit in order to get user feedback. The tabular display shows snippets from the error and maintenance messages (if any).

The yaml and json outputs include the "since" attribute.


(Review request: http://reviews.vapour.ws/r/1376/)