### PR TITLE
Remove Leader Election feature flag

### DIFF
--- a/feature/flags.go
+++ b/feature/flags.go
@@ -18,10 +18,6 @@ const JES = "jes"
 // and server-side functionality.
 const Storage = "storage"
 
-// LeaderElection is the name of the feature to enable leadership hooks
-// and hook tools.
-const LeaderElection = "leader-election"
-
 // LogErrorStack is a developer feature flag to have the LoggedErrorStack
 // function in the utils package write out the error stack as defined by the
 // errors package to the logger.  The ability to log the error stack is very

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -71,9 +71,7 @@ func allEnabledCommands() map[string]creator {
 	if featureflag.Enabled(feature.Storage) {
 		add(storageCommands)
 	}
-	if featureflag.Enabled(feature.LeaderElection) {
-		add(leaderCommands)
-	}
+	add(leaderCommands)
 	return all
 }
 

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -15,13 +15,11 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	corecharm "gopkg.in/juju/charm.v5-unstable"
 
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -1873,14 +1871,6 @@ func (s *UniterSuite) TestRebootFromJujuRun(c *gc.C) {
 }
 
 func (s *UniterSuite) TestLeadership(c *gc.C) {
-	// TODO(fwereade): 2015-03-07 bug XXXXXXXXXXXXX
-	// This is a really bad way to test the impact of feature flags, because it
-	// doesn't clean up after itself. We really want something in featureflags
-	// to help test these -- something like `WithFlags([]string, func())`?
-	// Regardless, there are way too many tests like this already and fixing
-	// that deserves its own CL.
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "leader-election")
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.runUniterTests(c, []uniterTest{
 		ut(
 			"leader-set works",


### PR DESCRIPTION
This is a small addition to what Kat-co had already done. Specifically, it just updates a test that was setting the feature flag so that it could test "leader-set" was working.

(Review request: http://reviews.vapour.ws/r/1377/)