### PR TITLE
Add a --file option to relation-set.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -13,7 +13,7 @@ github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-2
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	1591df2bf102f9cbeeb9145d22c6ccc29a6804ef	2015-03-30T-9:15:59Z
-github.com/juju/cmd	git	fbc7a395b6bd50238e56f485068d45964e25cd31	2015-03-27T15:48:43Z
+github.com/juju/cmd	git	31e7b27318ecf6f843433822ddecdaf6900a343f	2015-04-03T19:36:57Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z

--- a/worker/uniter/runner/jujuc/export_test.go
+++ b/worker/uniter/runner/jujuc/export_test.go
@@ -4,4 +4,12 @@
 
 package jujuc
 
+import (
+	"github.com/juju/cmd"
+)
+
 var CmdSuffix = cmdSuffix
+
+func HandleSettingsFile(c *RelationSetCommand, ctx *cmd.Context) error {
+	return c.handleSettingsFile(ctx)
+}

--- a/worker/uniter/runner/jujuc/relation-set.go
+++ b/worker/uniter/runner/jujuc/relation-set.go
@@ -23,10 +23,10 @@ are not allowed.
 
 The --file option should be used when one or more key-value pairs are
 too long to fit within the command length limit of the shell or
-operating system. The file should contain key-value pairs in the same
-format as on the commandline. They may also span multiple lines. Blank
-lines and lines starting with # are ignored. Settings in the file will
-be overridden by any duplicate key-value arguments.
+operating system. The file will contain one key-value pair per line
+in the same format as on the commandline. Blank lines and lines
+starting with # are ignored. Settings in the file will be overridden
+by any duplicate key-value arguments.
 `
 
 // RelationSetCommand implements the relation-set command.
@@ -87,7 +87,7 @@ func (c *RelationSetCommand) handleSettings(args []string) error {
 			if line == "" || line[0] == '#' {
 				continue
 			}
-			kvs = append(kvs, strings.Fields(line)...)
+			kvs = append(kvs, line) // We lose trailing whitespace...
 		}
 
 		settings, err = keyvalues.Parse(kvs, true)

--- a/worker/uniter/runner/jujuc/relation-set.go
+++ b/worker/uniter/runner/jujuc/relation-set.go
@@ -134,6 +134,18 @@ func (c *RelationSetCommand) Run(ctx *cmd.Context) (err error) {
 	if c.formatFlag != "" {
 		fmt.Fprintf(ctx.Stderr, "--format flag deprecated for command %q", c.Info().Name)
 	}
+
+	if c.settingsFile == "-" {
+		settings, err := c.readSettings(ctx.Stdin)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		for k, v := range c.Settings {
+			settings[k] = v
+		}
+		c.Settings = settings
+	}
+
 	r, found := c.ctx.Relation(c.RelationId)
 	if !found {
 		return fmt.Errorf("unknown relation id")

--- a/worker/uniter/runner/jujuc/relation-set.go
+++ b/worker/uniter/runner/jujuc/relation-set.go
@@ -82,15 +82,23 @@ func (c *RelationSetCommand) readSettings(in io.Reader) (map[string]string, erro
 
 	skipValidation := false // for debugging
 	if !skipValidation {
-		var invalidStr string
-		if err := goyaml.Unmarshal(data, &invalidStr); err != nil {
+		// Can this validation be done more simply or efficiently?
+
+		var scalar string
+		if err := goyaml.Unmarshal(data, &scalar); err != nil {
 			return nil, errors.Trace(err)
 		}
-		if invalidStr != "" {
-			return nil, errors.Errorf("expected YAML map, got %q", invalidStr)
+		if scalar != "" {
+			return nil, errors.Errorf("expected YAML map, got %q", scalar)
 		}
 
-		// TODO(ericsnow) Check for invalid non-str data too (e.g. sequence)?
+		var sequence []string
+		if err := goyaml.Unmarshal(data, &sequence); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(sequence) != 0 {
+			return nil, errors.Errorf("expected YAML map, got %#v", sequence)
+		}
 	}
 
 	kvs := make(map[string]string)

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -243,6 +243,11 @@ var relationSetInitTests = []relationSetInitTest{
 		content: "=haha",
 		err:     `expected "key=value", got "=haha"`,
 	}, {
+		summary:  "value with a space",
+		args:     []string{"--file", "spam"},
+		content:  "foo=foo: bar",
+		settings: map[string]string{"foo": "foo: bar"},
+	}, {
 		summary:  "a messy file",
 		args:     []string{"--file", "spam"},
 		content:  "  \n # a comment \n\n  \nfoo=bar  \nham=eggs\n\n good=bad\n",

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -249,15 +249,20 @@ var relationSetInitTests = []relationSetInitTest{
 		content:  "{}",
 		settings: map[string]string{},
 	}, {
-		summary: "an invalid file",
-		args:    []string{"--file", "spam"},
-		content: "haha",
-		err:     `expected YAML map, got "haha"`,
-	}, {
 		summary: "accidental same format as command-line",
 		args:    []string{"--file", "spam"},
 		content: "foo=bar ham=eggs good=bad",
 		err:     `expected YAML map, got .*`,
+	}, {
+		summary: "scalar instead of map",
+		args:    []string{"--file", "spam"},
+		content: "haha",
+		err:     `expected YAML map, got "haha"`,
+	}, {
+		summary: "sequence instead of map",
+		args:    []string{"--file", "spam"},
+		content: "[haha]",
+		err:     `expected YAML map, got \[]string{"haha"}`,
 	}, {
 		summary: "multiple maps",
 		args:    []string{"--file", "spam"},
@@ -273,6 +278,11 @@ var relationSetInitTests = []relationSetInitTest{
 		args:     []string{"--file", "spam"},
 		content:  "{foo: foo=bar, base64: YmFzZTY0IGV4YW1wbGU=}",
 		settings: map[string]string{"foo": "foo=bar", "base64": "YmFzZTY0IGV4YW1wbGU="},
+	}, {
+		summary:  "values with brackets",
+		args:     []string{"--file", "spam"},
+		content:  "{foo: '[x]', bar: '{y}'}",
+		settings: map[string]string{"foo": "[x]", "bar": "{y}"},
 	}, {
 		summary:  "a messy file",
 		args:     []string{"--file", "spam"},

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -5,6 +5,7 @@
 package jujuc_test
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -347,4 +348,21 @@ func (s *RelationSetSuite) TestRunDeprecationWarning(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(ctx), gc.Equals, "")
 	c.Assert(testing.Stderr(ctx), gc.Equals, "--format flag deprecated for command \"relation-set\"")
+}
+
+func (s *RelationSetSuite) TestRunStdin(c *gc.C) {
+	test := relationSetInitTest{
+		args:     []string{"--file", "-"},
+		settings: map[string]string{"foo": "bar"},
+	}
+	com, args := test.init(c, s)
+	err := testing.InitCommand(com, args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := testing.Context(c)
+	ctx.Stdin = bytes.NewBufferString("foo=bar")
+	err = com.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	test.check(c, com, nil)
 }

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -57,10 +57,10 @@ are not allowed.
 
 The --file option should be used when one or more key-value pairs are
 too long to fit within the command length limit of the shell or
-operating system. The file should contain key-value pairs in the same
-format as on the commandline. They may also span multiple lines. Blank
-lines and lines starting with # are ignored. Settings in the file will
-be overridden by any duplicate key-value arguments.
+operating system. The file will contain one key-value pair per line
+in the same format as on the commandline. Blank lines and lines
+starting with # are ignored. Settings in the file will be overridden
+by any duplicate key-value arguments.
 `[1:], t.expect))
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	}
@@ -247,6 +247,11 @@ var relationSetInitTests = []relationSetInitTest{
 		args:     []string{"--file", "spam"},
 		content:  "foo=foo: bar",
 		settings: map[string]string{"foo": "foo: bar"},
+	}, {
+		summary:  "accidental multiple settings on a line",
+		args:     []string{"--file", "spam"},
+		content:  "foo=bar ham=eggs good=bad",
+		settings: map[string]string{"foo": "bar ham=eggs good=bad"},
 	}, {
 		summary:  "a messy file",
 		args:     []string{"--file", "spam"},

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -43,7 +43,7 @@ usage: relation-set [options] key=value [key=value ...]
 purpose: set relation settings
 
 options:
---file (= "")
+--file  (= )
     file containing key-value pairs
 --format (= "")
     deprecated format flag

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -60,7 +60,8 @@ too long to fit within the command length limit of the shell or
 operating system. The file will contain one key-value pair per line
 in the same format as on the commandline. Blank lines and lines
 starting with # are ignored. Settings in the file will be overridden
-by any duplicate key-value arguments.
+by any duplicate key-value arguments. A value of "-" for the filename
+means "read from stdin".
 `[1:], t.expect))
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	}
@@ -97,7 +98,7 @@ func (t relationSetInitTest) filename() (string, int) {
 func (t relationSetInitTest) init(c *gc.C, s *RelationSetSuite) (cmd.Command, []string) {
 	args := make([]string, len(t.args))
 	copy(args, t.args)
-	if filename, i := t.filename(); filename != "" {
+	if filename, i := t.filename(); filename != "" && filename != "-" {
 		filename = filepath.Join(c.MkDir(), filename)
 		args[i] = filename
 		err := ioutil.WriteFile(filename, []byte(t.content), 0644)
@@ -279,6 +280,18 @@ func (s *RelationSetSuite) TestInit(c *gc.C) {
 
 		t.check(c, com, err)
 	}
+}
+
+func (s *RelationSetSuite) TestInitStdin(c *gc.C) {
+	test := relationSetInitTest{
+		args:     []string{"--file", "-"},
+		settings: map[string]string{},
+	}
+	com, args := test.init(c, s)
+
+	err := testing.InitCommand(com, args)
+
+	test.check(c, com, err)
 }
 
 // Tests start with a relation with the settings {"base": "value"}

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -250,6 +250,11 @@ var relationSetInitTests = []relationSetInitTest{
 		content:  "foo=foo: bar",
 		settings: map[string]string{"foo": "foo: bar"},
 	}, {
+		summary:  "value with an equal sign",
+		args:     []string{"--file", "spam"},
+		content:  "foo=foo=bar\nbase64=YmFzZTY0IGV4YW1wbGU=",
+		settings: map[string]string{"foo": "foo=bar", "base64": "YmFzZTY0IGV4YW1wbGU="},
+	}, {
 		summary:  "accidental multiple settings on a line",
 		args:     []string{"--file", "spam"},
 		content:  "foo=bar ham=eggs good=bad",


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1437366)

A setting can be too long for the shell to send to relation-set.  In that case users can now use the --file option.

(Review request: http://reviews.vapour.ws/r/1380/)