### PR TITLE
 error in logs: environment does not support networking 

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1093,9 +1093,8 @@ func (env *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceIn
 	estate.mu.Lock()
 	defer estate.mu.Unlock()
 
-	// Simulate 2 NICs - primary enabled, secondary disabled with VLAN
-	// tag 1; both configured using DHCP and having fake DNS servers
-	// and gateway.
+	// Simulate 3 NICs - primary and secondary enabled plus a disabled NIC.
+	// all configured using DHCP and having fake DNS servers and gateway.
 	info := make([]network.InterfaceInfo, 2)
 	for i, netName := range []string{"private", "public"} {
 		info[i] = network.InterfaceInfo{

--- a/worker/addresser/export_test.go
+++ b/worker/addresser/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package addresser
+
+var (
+	NewWorkerWithReleaser = newWorkerWithReleaser
+)

--- a/worker/addresser/worker.go
+++ b/worker/addresser/worker.go
@@ -50,10 +50,9 @@ func NewWorker(st stateAddresser) (worker.Worker, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	netEnviron, ok := environs.SupportsNetworking(environ)
-	if !ok {
-		return nil, errors.New("environment does not support networking")
-	}
+	// If netEnviron is nil the worker will start but won't do anything as
+	// no IP addresses will be created or destroyed.
+	netEnviron, _ := environs.SupportsNetworking(environ)
 	a := newWorkerWithReleaser(st, netEnviron)
 	return a, nil
 }
@@ -69,6 +68,9 @@ func newWorkerWithReleaser(st stateAddresser, releaser releaser) worker.Worker {
 
 // Handle is part of the StringsWorker interface.
 func (a *addresserHandler) Handle(ids []string) error {
+	if a.releaser == nil {
+		return nil
+	}
 	for _, id := range ids {
 		logger.Debugf("received notification about address %v", id)
 		addr, err := a.st.IPAddress(id)

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -214,3 +214,18 @@ func (s *workerSuite) TestErrorKillsWorker(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
+
+func (s *workerSuite) TestAddresserWithNoNetworkingEnviron(c *gc.C) {
+	opsChan := dummyListen()
+	w := addresser.NewWorkerWithReleaser(s.State, nil)
+	defer s.assertStop(c, w)
+
+	for {
+		select {
+		case <-opsChan:
+			c.Fatalf("unexpected release op")
+		case <-time.After(coretesting.ShortWait):
+			break
+		}
+	}
+}

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -225,7 +225,7 @@ func (s *workerSuite) TestAddresserWithNoNetworkingEnviron(c *gc.C) {
 		case <-opsChan:
 			c.Fatalf("unexpected release op")
 		case <-time.After(coretesting.ShortWait):
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
Fixes issue #1439364.

The addresser worker can handle being started with an environ that doesn't support networking.

(Review request: http://reviews.vapour.ws/r/1382/)