### PR TITLE
apiserver/client: avoid unnecessary Mongo query

### DIFF
--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -66,11 +66,7 @@ func NewClient(st *state.State, resources *common.Resources, authorizer common.A
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
-	env, err := st.Environment()
-	if err != nil {
-		return nil, err
-	}
-	urlGetter := common.NewToolsURLGetter(env.UUID(), st)
+	urlGetter := common.NewToolsURLGetter(st.EnvironUUID(), st)
 	return &Client{
 		api: &API{
 			state:        st,


### PR DESCRIPTION
Change NewClient to use State.EnvironUUID, instead
of State.Environment() and getting its UUID. The
former is cached in memory when State is opened.

(Review request: http://reviews.vapour.ws/r/1384/)