### PR TITLE
Implemented list subcommand; refactored tests.

### DIFF
--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -4,12 +4,48 @@
 package params
 
 import (
+	"net"
+
 	"github.com/juju/juju/network"
 )
 
 // -----
 // Parameters field types.
 // -----
+
+// Subnet describes a single subnet within a network.
+type Subnet struct {
+	// CIDR of the subnet in IPv4 or IPv6 notation.
+	CIDR string `json:"CIDR"`
+
+	// ProviderId is the provider-specific subnet ID (if applicable).
+	ProviderId string `json:"ProviderId,omitempty`
+
+	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
+	// normal networks. It's defined by IEEE 802.1Q standard.
+	VLANTag int `json:"VLANTag"`
+
+	// Life is the subnet's life cycle value - Alive means the subnet
+	// is in use by one or more machines, Dying or Dead means the
+	// subnet is about to be removed.
+	Life Life `json:"Life"`
+
+	// SpaceTag is the Juju network space this subnet is associated
+	// with.
+	SpaceTag string `json:"SpaceTag"`
+
+	// Zones contain one or more availability zones this subnet is
+	// associated with.
+	Zones []string `json:"Zones"`
+
+	// StaticRangeLowIP (if available) is the lower bound of the
+	// subnet's static IP allocation range.
+	StaticRangeLowIP net.IP `json:"StaticRangeLowIP,omitempty"`
+
+	// StaticRangeHighIP (if available) is the higher bound of the
+	// subnet's static IP allocation range.
+	StaticRangeHighIP net.IP `json:"StaticRangeHighIP,omitempty"`
+}
 
 // Network describes a single network available on an instance.
 type Network struct {

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/names"
 )
 
 // AddCommand calls the API to add an existing subnet to Juju.
 type AddCommand struct {
 	SubnetCommandBase
 
-	CIDR      string
-	SpaceName string
+	CIDR  string
+	Space names.SpaceTag
 }
 
 const addCommandDoc = `
@@ -55,7 +56,7 @@ func (c *AddCommand) Init(args []string) error {
 	}
 
 	// Validate the space name.
-	c.SpaceName, err = c.ValidateSpace(args[1])
+	c.Space, err = c.ValidateSpace(args[1])
 	if err != nil {
 		return err
 	}
@@ -72,11 +73,11 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 	defer api.Close()
 
 	// Add the existing subnet.
-	err = api.AddSubnet(c.CIDR, c.SpaceName)
+	err = api.AddSubnet(c.CIDR, c.Space)
 	if err != nil {
 		return errors.Annotatef(err, "cannot add subnet %q", c.CIDR)
 	}
 
-	ctx.Infof("added subnet %q in space %q", c.CIDR, c.SpaceName)
+	ctx.Infof("added subnet %q in space %q", c.CIDR, c.Space.Id())
 	return nil
 }

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -5,6 +5,7 @@ package subnet_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -70,7 +71,7 @@ func (s *AddSuite) TestInit(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 		}
 		c.Check(command.CIDR, gc.Equals, test.expectCIDR)
-		c.Check(command.SpaceName, gc.Equals, test.expectSpace)
+		c.Check(command.Space.Id(), gc.Equals, test.expectSpace)
 
 		// No API calls should be recorded at this stage.
 		s.api.CheckCallNames(c)
@@ -86,7 +87,7 @@ func (s *AddSuite) TestRunWithIPv4CIDRSucceeds(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		"10.20.0.0/24", "myspace",
+		"10.20.0.0/24", names.NewSpaceTag("myspace"),
 	)
 }
 
@@ -99,7 +100,7 @@ func (s *AddSuite) TestRunWithIPv6CIDRSucceeds(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		"2001:db8::/32", "hyperspace",
+		"2001:db8::/32", names.NewSpaceTag("hyperspace"),
 	)
 }
 
@@ -114,7 +115,7 @@ func (s *AddSuite) TestRunWithExistingSubnetFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		"10.10.0.0/24", "space",
+		"10.10.0.0/24", names.NewSpaceTag("space"),
 	)
 }
 
@@ -129,7 +130,7 @@ func (s *AddSuite) TestRunWithNonExistingSpaceFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		"10.10.0.0/24", "space",
+		"10.10.0.0/24", names.NewSpaceTag("space"),
 	)
 }
 

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -80,6 +80,7 @@ func (s *AddSuite) TestInit(c *gc.C) {
 func (s *AddSuite) TestRunWithIPv4CIDRSucceeds(c *gc.C) {
 	s.AssertRunSucceeds(c,
 		`added subnet "10.20.0.0/24" in space "myspace"\n`,
+		"", // empty stdout.
 		"10.20.0.0/24", "myspace",
 	)
 
@@ -92,6 +93,7 @@ func (s *AddSuite) TestRunWithIPv4CIDRSucceeds(c *gc.C) {
 func (s *AddSuite) TestRunWithIPv6CIDRSucceeds(c *gc.C) {
 	s.AssertRunSucceeds(c,
 		`added subnet "2001:db8::/32" in space "hyperspace"\n`,
+		"", // empty stdout.
 		"2001:db8::/32", "hyperspace",
 	)
 

--- a/cmd/juju/subnet/create.go
+++ b/cmd/juju/subnet/create.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"github.com/juju/utils/set"
 )
 
@@ -18,7 +19,7 @@ type CreateCommand struct {
 	SubnetCommandBase
 
 	CIDR      string
-	SpaceName string
+	Space     names.SpaceTag
 	Zones     set.Strings
 	IsPublic  bool
 	IsPrivate bool
@@ -92,7 +93,7 @@ func (c *CreateCommand) Init(args []string) error {
 	}
 
 	// Validate the space name.
-	c.SpaceName, err = c.ValidateSpace(args[1])
+	c.Space, err = c.ValidateSpace(args[1])
 	if err != nil {
 		return err
 	}
@@ -161,7 +162,7 @@ func (c *CreateCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Create the new subnet.
-	err = api.CreateSubnet(c.CIDR, c.SpaceName, c.Zones.SortedValues(), c.IsPublic)
+	err = api.CreateSubnet(c.CIDR, c.Space, c.Zones.SortedValues(), c.IsPublic)
 	if err != nil {
 		return errors.Annotatef(err, "cannot create subnet %q", c.CIDR)
 	}
@@ -173,7 +174,7 @@ func (c *CreateCommand) Run(ctx *cmd.Context) error {
 	}
 	ctx.Infof(
 		"created a %s subnet %q in space %q with zones %s",
-		accessType, c.CIDR, c.SpaceName, zones,
+		accessType, c.CIDR, c.Space.Id(), zones,
 	)
 	return nil
 }

--- a/cmd/juju/subnet/create_test.go
+++ b/cmd/juju/subnet/create_test.go
@@ -5,6 +5,7 @@ package subnet_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -130,7 +131,7 @@ func (s *CreateSuite) TestInit(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 		}
 		c.Check(command.CIDR, gc.Equals, test.expectCIDR)
-		c.Check(command.SpaceName, gc.Equals, test.expectSpace)
+		c.Check(command.Space.Id(), gc.Equals, test.expectSpace)
 		c.Check(command.Zones.SortedValues(), jc.DeepEquals, test.expectZones)
 		c.Check(command.IsPublic, gc.Equals, test.expectPublic)
 		c.Check(command.IsPrivate, gc.Equals, test.expectPrivate)
@@ -149,7 +150,7 @@ func (s *CreateSuite) TestRunOneZoneSucceeds(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
 	s.api.CheckCall(c, 1, "CreateSubnet",
-		"10.20.0.0/24", "myspace", s.Strings("zone1"), false,
+		"10.20.0.0/24", names.NewSpaceTag("myspace"), s.Strings("zone1"), false,
 	)
 }
 
@@ -162,7 +163,7 @@ func (s *CreateSuite) TestRunWithPublicAndIPv6CIDRSucceeds(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
 	s.api.CheckCall(c, 1, "CreateSubnet",
-		"2001:db8::/32", "space", s.Strings("zone1"), true,
+		"2001:db8::/32", names.NewSpaceTag("space"), s.Strings("zone1"), true,
 	)
 }
 
@@ -177,7 +178,7 @@ func (s *CreateSuite) TestRunWithMultipleZonesSucceeds(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
 	s.api.CheckCall(c, 1, "CreateSubnet",
-		"10.20.0.0/24", "foo", s.Strings("zone1", "zone2"), false,
+		"10.20.0.0/24", names.NewSpaceTag("foo"), s.Strings("zone1", "zone2"), false,
 	)
 }
 
@@ -202,7 +203,7 @@ func (s *CreateSuite) TestRunWithExistingSubnetFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
 	s.api.CheckCall(c, 1, "CreateSubnet",
-		"10.10.0.0/24", "space", s.Strings("zone1"), false,
+		"10.10.0.0/24", names.NewSpaceTag("space"), s.Strings("zone1"), false,
 	)
 }
 
@@ -217,7 +218,7 @@ func (s *CreateSuite) TestRunWithNonExistingSpaceFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AllZones", "CreateSubnet", "Close")
 	s.api.CheckCall(c, 1, "CreateSubnet",
-		"10.10.0.0/24", "space", s.Strings("zone1"), false,
+		"10.10.0.0/24", names.NewSpaceTag("space"), s.Strings("zone1"), false,
 	)
 }
 

--- a/cmd/juju/subnet/create_test.go
+++ b/cmd/juju/subnet/create_test.go
@@ -143,6 +143,7 @@ func (s *CreateSuite) TestInit(c *gc.C) {
 func (s *CreateSuite) TestRunOneZoneSucceeds(c *gc.C) {
 	s.AssertRunSucceeds(c,
 		`created a private subnet "10.20.0.0/24" in space "myspace" with zones zone1\n`,
+		"", // empty stdout.
 		"10.20.0.0/24", "myspace", "zone1",
 	)
 
@@ -155,6 +156,7 @@ func (s *CreateSuite) TestRunOneZoneSucceeds(c *gc.C) {
 func (s *CreateSuite) TestRunWithPublicAndIPv6CIDRSucceeds(c *gc.C) {
 	s.AssertRunSucceeds(c,
 		`created a public subnet "2001:db8::/32" in space "space" with zones zone1\n`,
+		"", // empty stdout.
 		"2001:db8::/32", "space", "zone1", "--public",
 	)
 
@@ -169,6 +171,7 @@ func (s *CreateSuite) TestRunWithMultipleZonesSucceeds(c *gc.C) {
 		// The list of zones is sorted both when displayed and passed
 		// to CreateSubnet.
 		`created a private subnet "10.20.0.0/24" in space "foo" with zones zone1, zone2\n`,
+		"",                                      // empty stdout.
 		"10.20.0.0/24", "foo", "zone2", "zone1", // unsorted zones
 	)
 

--- a/cmd/juju/subnet/export_test.go
+++ b/cmd/juju/subnet/export_test.go
@@ -20,3 +20,13 @@ func NewRemoveCommand(api SubnetAPI) *RemoveCommand {
 	removeCmd.api = api
 	return removeCmd
 }
+
+func NewListCommand(api SubnetAPI) *ListCommand {
+	listCmd := &ListCommand{}
+	listCmd.api = api
+	return listCmd
+}
+
+func ListFormat(cmd *ListCommand) string {
+	return cmd.out.Name()
+}

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -1,0 +1,223 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnet
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/names"
+	"github.com/juju/utils/set"
+)
+
+// ListCommand calls the API to add an existing subnet to Juju.
+type ListCommand struct {
+	SubnetCommandBase
+
+	SpaceName string
+	ZoneName  string
+
+	out cmd.Output
+}
+
+const listCommandDoc = `
+Displays a list of all subnets known to Juju. Results can be filtered
+using the optional --space and/or --zone arguments to only display
+subnets associated with a given network space and/or availability zone.
+
+Like with other Juju commands, the output and its format can be changed  
+using the --format and --output (or -o) optional arguments. Supported
+output formats include "yaml" (default) and "json". To redirect the
+output to a file, use --output.
+`
+
+// Info is defined on the cmd.Command interface.
+func (c *ListCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "list",
+		Args:    "[--space <name>] [--zone <name>] [--format yaml|json] [--output <path>]",
+		Purpose: "list subnets known to Juju",
+		Doc:     strings.TrimSpace(listCommandDoc),
+	}
+}
+
+// SetFlags is defined on the cmd.Command interface.
+func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.SubnetCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+
+	f.StringVar(&c.SpaceName, "space", "", "filter results by space name")
+	f.StringVar(&c.ZoneName, "zone", "", "filter results by zone name")
+}
+
+// Init is defined on the cmd.Command interface. It checks the
+// arguments for sanity and sets up the command to run.
+func (c *ListCommand) Init(args []string) error {
+	// No arguments are accepted, just flags.
+	err := cmd.CheckEmpty(args)
+	if err != nil {
+		return err
+	}
+
+	// Validate space name, if given.
+	if c.SpaceName != "" {
+		c.SpaceName, err = c.ValidateSpace(c.SpaceName)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *ListCommand) Run(ctx *cmd.Context) error {
+	api, err := c.NewAPI()
+	if err != nil {
+		return errors.Annotate(err, "cannot connect to API server")
+	}
+	defer api.Close()
+
+	// Validate space and/or zone, if given to display a nicer error
+	// message.
+	if c.SpaceName != "" {
+		spaces, err := api.AllSpaces()
+		if err != nil {
+			return errors.Annotate(err, "cannot list spaces")
+		}
+		spacesSet := set.NewStrings(spaces...)
+		if !spacesSet.Contains(c.SpaceName) {
+			expected := strings.Join(spacesSet.SortedValues(), ", ")
+			return errors.Errorf(
+				"%q is not a known space; expected one of: %s",
+				c.SpaceName, expected,
+			)
+		}
+	}
+	if c.ZoneName != "" {
+		zones, err := api.AllZones()
+		if err != nil {
+			return errors.Annotate(err, "cannot list zones")
+		}
+		zonesSet := set.NewStrings(zones...)
+		if !zonesSet.Contains(c.ZoneName) {
+			expected := strings.Join(zonesSet.SortedValues(), ", ")
+			return errors.Errorf(
+				"%q is not a known zone; expected one of: %s",
+				c.ZoneName, expected,
+			)
+		}
+	}
+
+	// Get the list of subnets, filtering them as requested.
+	subnets, err := api.ListSubnets(c.SpaceName, c.ZoneName)
+	if err != nil {
+		return errors.Annotate(err, "cannot list subnets")
+	}
+
+	// Display a nicer message in case no subnets were found.
+	if len(subnets) == 0 {
+		if c.SpaceName != "" || c.ZoneName != "" {
+			ctx.Infof("no subnets found matching requested criteria")
+		} else {
+			ctx.Infof("no subnets to display")
+		}
+		return nil
+	}
+
+	// Construct the output list for displaying with the chosen
+	// format.
+	result := formattedList{
+		Subnets: make(map[string]formattedSubnet),
+	}
+	for _, sub := range subnets {
+		subResult := formattedSubnet{
+			ProviderId: sub.ProviderId,
+			Zones:      sub.Zones,
+		}
+
+		// Use the CIDR to determine the subnet type.
+		if ip, _, err := net.ParseCIDR(sub.CIDR); err != nil {
+			return errors.Errorf("subnet %q has invalid CIDR", sub.CIDR)
+		} else if ip.To4() != nil {
+			subResult.Type = typeIPv4
+		} else if ip.To16() != nil {
+			subResult.Type = typeIPv6
+		}
+		// Space must be valid, but verify anyway.
+		spaceTag, err := names.ParseSpaceTag(sub.SpaceTag)
+		if err != nil {
+			return errors.Annotatef(err, "subnet %q has invalid space", sub.CIDR)
+		}
+		subResult.Space = spaceTag.Id()
+
+		// Display correct status according to the life cycle value.
+		switch sub.Life {
+		case params.Alive:
+			subResult.Status = statusInUse
+		case params.Dying, params.Dead:
+			subResult.Status = statusTerminating
+		}
+
+		result.Subnets[sub.CIDR] = subResult
+	}
+
+	return c.out.Write(ctx, result)
+}
+
+const (
+	typeIPv4 = "ipv4"
+	typeIPv6 = "ipv6"
+
+	statusInUse       = "in-use"
+	statusTerminating = "terminating"
+)
+
+type formattedList struct {
+	Subnets map[string]formattedSubnet `json:"subnets" yaml:"subnets"`
+}
+
+// A goyaml bug means we can't declare these types locally to the
+// GetYAML methods.
+type formattedListNoMethods formattedList
+
+// MarshalJSON is defined on json.Marshaller.
+func (l formattedList) MarshalJSON() ([]byte, error) {
+	return json.Marshal(formattedListNoMethods(l))
+}
+
+// GetYAML is defined on yaml.Getter.
+func (l formattedList) GetYAML() (tag string, value interface{}) {
+	return "", formattedListNoMethods(l)
+}
+
+type formattedSubnet struct {
+	Type       string   `json:"type" yaml:"type"`
+	ProviderId string   `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
+	Status     string   `json:"status,omitempty" yaml:"status,omitempty"`
+	Space      string   `json:"space" yaml:"space"`
+	Zones      []string `json:"zones" yaml:"zones"`
+}
+
+// A goyaml bug means we can't declare these types locally to the
+// GetYAML methods.
+type formattedSubnetNoMethods formattedSubnet
+
+// MarshalJSON is defined on json.Marshaller.
+func (s formattedSubnet) MarshalJSON() ([]byte, error) {
+	return json.Marshal(formattedSubnetNoMethods(s))
+}
+
+// GetYAML is defined on yaml.Getter.
+func (s formattedSubnet) GetYAML() (tag string, value interface{}) {
+	return "", formattedSubnetNoMethods(s)
+}

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -228,7 +229,8 @@ func (s *ListSuite) TestRunWhenNoneMatchSucceeds(c *gc.C) {
 	)
 
 	s.api.CheckCallNames(c, "AllSpaces", "ListSubnets", "Close")
-	s.api.CheckCall(c, 1, "ListSubnets", "default", "")
+	tag := names.NewSpaceTag("default")
+	s.api.CheckCall(c, 1, "ListSubnets", &tag, "")
 }
 
 func (s *ListSuite) TestRunWhenNoSubnetsExistSucceeds(c *gc.C) {
@@ -240,7 +242,7 @@ func (s *ListSuite) TestRunWhenNoSubnetsExistSucceeds(c *gc.C) {
 	)
 
 	s.api.CheckCallNames(c, "ListSubnets", "Close")
-	s.api.CheckCall(c, 0, "ListSubnets", "", "")
+	s.api.CheckCall(c, 0, "ListSubnets", nil, "")
 }
 
 func (s *ListSuite) TestRunWithFilteringSucceeds(c *gc.C) {
@@ -267,7 +269,8 @@ subnets:
 	)
 
 	s.api.CheckCallNames(c, "AllSpaces", "ListSubnets", "Close")
-	s.api.CheckCall(c, 1, "ListSubnets", "public", "")
+	tag := names.NewSpaceTag("public")
+	s.api.CheckCall(c, 1, "ListSubnets", &tag, "")
 	s.api.Calls = s.api.Calls[0:0] // reset recorded calls.
 
 	// Now filter by zone.
@@ -278,7 +281,7 @@ subnets:
 	)
 
 	s.api.CheckCallNames(c, "AllZones", "ListSubnets", "Close")
-	s.api.CheckCall(c, 1, "ListSubnets", "", "zone1")
+	s.api.CheckCall(c, 1, "ListSubnets", nil, "zone1")
 	s.api.Calls = s.api.Calls[0:0] // reset recorded calls.
 
 	// Finally, filter by both space and zone.
@@ -289,7 +292,8 @@ subnets:
 	)
 
 	s.api.CheckCallNames(c, "AllSpaces", "AllZones", "ListSubnets", "Close")
-	s.api.CheckCall(c, 2, "ListSubnets", "public", "zone1")
+	tag = names.NewSpaceTag("public")
+	s.api.CheckCall(c, 2, "ListSubnets", &tag, "zone1")
 }
 
 func (s *ListSuite) TestRunWhenAllSpacesFails(c *gc.C) {
@@ -346,7 +350,7 @@ func (s *ListSuite) TestRunWhenListSubnetFails(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 
 	s.api.CheckCallNames(c, "ListSubnets", "Close")
-	s.api.CheckCall(c, 0, "ListSubnets", "", "")
+	s.api.CheckCall(c, 0, "ListSubnets", nil, "")
 }
 
 func (s *ListSuite) TestRunWhenASubnetHasInvalidCIDRFails(c *gc.C) {
@@ -358,7 +362,7 @@ func (s *ListSuite) TestRunWhenASubnetHasInvalidCIDRFails(c *gc.C) {
 	s.AssertRunFails(c, `subnet "invalid" has invalid CIDR`)
 
 	s.api.CheckCallNames(c, "ListSubnets", "Close")
-	s.api.CheckCall(c, 0, "ListSubnets", "", "")
+	s.api.CheckCall(c, 0, "ListSubnets", nil, "")
 }
 
 func (s *ListSuite) TestRunWhenASubnetHasInvalidSpaceFails(c *gc.C) {
@@ -370,7 +374,7 @@ func (s *ListSuite) TestRunWhenASubnetHasInvalidSpaceFails(c *gc.C) {
 	s.AssertRunFails(c, `subnet "10.20.0.0/24" has invalid space: "foo" is not a valid tag`)
 
 	s.api.CheckCallNames(c, "ListSubnets", "Close")
-	s.api.CheckCall(c, 0, "ListSubnets", "", "")
+	s.api.CheckCall(c, 0, "ListSubnets", nil, "")
 }
 
 func (s *ListSuite) TestRunAPIConnectFails(c *gc.C) {

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -1,0 +1,385 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnet_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/subnet"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ListSuite struct {
+	BaseSubnetSuite
+}
+
+var _ = gc.Suite(&ListSuite{})
+
+func (s *ListSuite) SetUpTest(c *gc.C) {
+	s.BaseSubnetSuite.SetUpTest(c)
+	s.command = subnet.NewListCommand(s.api)
+	c.Assert(s.command, gc.NotNil)
+}
+
+func (s *ListSuite) TestInit(c *gc.C) {
+	for i, test := range []struct {
+		about        string
+		args         []string
+		expectSpace  string
+		expectZone   string
+		expectFormat string
+		expectErr    string
+	}{{
+		about:        "too many arguments",
+		args:         s.Strings("foo", "bar"),
+		expectErr:    `unrecognized args: \["foo" "bar"\]`,
+		expectFormat: "yaml",
+	}, {
+		about:        "invalid space name",
+		args:         s.Strings("--space", "%inv$alid"),
+		expectErr:    `"%inv\$alid" is not a valid space name`,
+		expectFormat: "yaml",
+	}, {
+		about:        "valid space name",
+		args:         s.Strings("--space", "my-space"),
+		expectSpace:  "my-space",
+		expectFormat: "yaml",
+	}, {
+		about:        "both space and zone given",
+		args:         s.Strings("--zone", "zone1", "--space", "my-space"),
+		expectSpace:  "my-space",
+		expectZone:   "zone1",
+		expectFormat: "yaml",
+	}, {
+		about:        "invalid format",
+		args:         s.Strings("--format", "foo"),
+		expectErr:    `invalid value "foo" for flag --format: unknown format "foo"`,
+		expectFormat: "yaml",
+	}, {
+		about:        "invalid format (value is case-sensitive)",
+		args:         s.Strings("--format", "JSON"),
+		expectErr:    `invalid value "JSON" for flag --format: unknown format "JSON"`,
+		expectFormat: "yaml",
+	}, {
+		about:        "json format",
+		args:         s.Strings("--format", "json"),
+		expectFormat: "json",
+	}, {
+		about:        "yaml format",
+		args:         s.Strings("--format", "yaml"),
+		expectFormat: "yaml",
+	}, {
+		// --output and -o are tested separately in TestOutputFormats.
+		about:        "both --output and -o specified (latter overrides former)",
+		args:         s.Strings("--output", "foo", "-o", "bar"),
+		expectFormat: "yaml",
+	}} {
+		c.Logf("test #%d: %s", i, test.about)
+		// Create a new instance of the subcommand for each test, but
+		// since we're not running the command no need to use
+		// envcmd.Wrap().
+		command := subnet.NewListCommand(s.api)
+		err := coretesting.InitCommand(command, test.args)
+		if test.expectErr != "" {
+			c.Check(err, gc.ErrorMatches, test.expectErr)
+		} else {
+			c.Check(err, jc.ErrorIsNil)
+		}
+		c.Check(command.SpaceName, gc.Equals, test.expectSpace)
+		c.Check(command.ZoneName, gc.Equals, test.expectZone)
+		c.Check(subnet.ListFormat(command), gc.Equals, test.expectFormat)
+
+		// No API calls should be recorded at this stage.
+		s.api.CheckCallNames(c)
+	}
+}
+
+func (s *ListSuite) TestOutputFormats(c *gc.C) {
+	outDir := c.MkDir()
+	expectedYAML := `
+subnets:
+  10.10.0.0/16:
+    type: ipv4
+    status: terminating
+    space: vlan-42
+    zones:
+    - zone1
+  10.20.0.0/24:
+    type: ipv4
+    provider-id: subnet-foo
+    status: in-use
+    space: public
+    zones:
+    - zone1
+    - zone2
+  2001:db8::/32:
+    type: ipv6
+    provider-id: subnet-bar
+    status: terminating
+    space: dmz
+    zones:
+    - zone2
+`[1:]
+	expectedJSON := `{"subnets":{` +
+		`"10.10.0.0/16":{` +
+		`"type":"ipv4",` +
+		`"status":"terminating",` +
+		`"space":"vlan-42",` +
+		`"zones":["zone1"]},` +
+
+		`"10.20.0.0/24":{` +
+		`"type":"ipv4",` +
+		`"provider-id":"subnet-foo",` +
+		`"status":"in-use",` +
+		`"space":"public",` +
+		`"zones":["zone1","zone2"]},` +
+
+		`"2001:db8::/32":{` +
+		`"type":"ipv6",` +
+		`"provider-id":"subnet-bar",` +
+		`"status":"terminating",` +
+		`"space":"dmz",` +
+		`"zones":["zone2"]}}}
+`
+
+	assertAPICalls := func() {
+		// Verify the API calls and reset the recorded calls.
+		s.api.CheckCallNames(c, "ListSubnets", "Close")
+		s.api.Calls = s.api.Calls[0:0]
+	}
+	makeArgs := func(format string, extraArgs ...string) []string {
+		args := s.Strings(extraArgs...)
+		if format != "" {
+			args = append(args, "--format", format)
+		}
+		return args
+	}
+	assertOutput := func(format, expected string) {
+		outFile := filepath.Join(outDir, "output")
+		c.Assert(outFile, jc.DoesNotExist)
+		defer os.Remove(outFile)
+		// Check -o works.
+		args := makeArgs(format, "-o", outFile)
+		s.AssertRunSucceeds(c, "", "", args...)
+		assertAPICalls()
+
+		data, err := ioutil.ReadFile(outFile)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(string(data), gc.Equals, expected)
+
+		// Check the last output argument takes precedence when both
+		// -o and --output are given (and also that --output works the
+		// same as -o).
+		outFile1 := filepath.Join(outDir, "output1")
+		c.Assert(outFile1, jc.DoesNotExist)
+		defer os.Remove(outFile1)
+		outFile2 := filepath.Join(outDir, "output2")
+		c.Assert(outFile2, jc.DoesNotExist)
+		defer os.Remove(outFile2)
+		// Write something in outFile2 to verify its contents are
+		// overwritten.
+		err = ioutil.WriteFile(outFile2, []byte("some contents"), 0644)
+		c.Assert(err, jc.ErrorIsNil)
+
+		args = makeArgs(format, "-o", outFile1, "--output", outFile2)
+		s.AssertRunSucceeds(c, "", "", args...)
+		// Check only the last output file was used, and the output
+		// file was overwritten.
+		c.Assert(outFile1, jc.DoesNotExist)
+		data, err = ioutil.ReadFile(outFile2)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(string(data), gc.Equals, expected)
+		assertAPICalls()
+
+		// Finally, check without --output.
+		args = makeArgs(format)
+		s.AssertRunSucceeds(c, "", expected, args...)
+		assertAPICalls()
+	}
+
+	for i, test := range []struct {
+		format   string
+		expected string
+	}{
+		{"", expectedYAML}, // default format is YAML
+		{"yaml", expectedYAML},
+		{"json", expectedJSON},
+	} {
+		c.Logf("test #%d: format %q", i, test.format)
+		assertOutput(test.format, test.expected)
+	}
+}
+
+func (s *ListSuite) TestRunWhenNoneMatchSucceeds(c *gc.C) {
+	// Simulate no subnets are using the "default" space.
+	s.api.Subnets = s.api.Subnets[0:0]
+
+	s.AssertRunSucceeds(c,
+		`no subnets found matching requested criteria\n`,
+		"", // empty stdout.
+		"--space", "default",
+	)
+
+	s.api.CheckCallNames(c, "AllSpaces", "ListSubnets", "Close")
+	s.api.CheckCall(c, 1, "ListSubnets", "default", "")
+}
+
+func (s *ListSuite) TestRunWhenNoSubnetsExistSucceeds(c *gc.C) {
+	s.api.Subnets = s.api.Subnets[0:0]
+
+	s.AssertRunSucceeds(c,
+		`no subnets to display\n`,
+		"", // empty stdout.
+	)
+
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
+	s.api.CheckCall(c, 0, "ListSubnets", "", "")
+}
+
+func (s *ListSuite) TestRunWithFilteringSucceeds(c *gc.C) {
+	// Simulate one subnet is using the "public" space or "zone1".
+	s.api.Subnets = s.api.Subnets[0:1]
+
+	expected := `
+subnets:
+  10.20.0.0/24:
+    type: ipv4
+    provider-id: subnet-foo
+    status: in-use
+    space: public
+    zones:
+    - zone1
+    - zone2
+`[1:]
+
+	// Filter by space name first.
+	s.AssertRunSucceeds(c,
+		"", // empty stderr.
+		expected,
+		"--space", "public",
+	)
+
+	s.api.CheckCallNames(c, "AllSpaces", "ListSubnets", "Close")
+	s.api.CheckCall(c, 1, "ListSubnets", "public", "")
+	s.api.Calls = s.api.Calls[0:0] // reset recorded calls.
+
+	// Now filter by zone.
+	s.AssertRunSucceeds(c,
+		"", // empty stderr.
+		expected,
+		"--zone", "zone1",
+	)
+
+	s.api.CheckCallNames(c, "AllZones", "ListSubnets", "Close")
+	s.api.CheckCall(c, 1, "ListSubnets", "", "zone1")
+	s.api.Calls = s.api.Calls[0:0] // reset recorded calls.
+
+	// Finally, filter by both space and zone.
+	s.AssertRunSucceeds(c,
+		"", // empty stderr.
+		expected,
+		"--zone", "zone1", "--space", "public",
+	)
+
+	s.api.CheckCallNames(c, "AllSpaces", "AllZones", "ListSubnets", "Close")
+	s.api.CheckCall(c, 2, "ListSubnets", "public", "zone1")
+}
+
+func (s *ListSuite) TestRunWhenAllSpacesFails(c *gc.C) {
+	s.api.SetErrors(errors.NotValidf("foo"))
+
+	// Ensure the error cause is preserved.
+	err := s.AssertRunFails(c,
+		`cannot list spaces: foo not valid`,
+		"--space", "default",
+	)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+
+	s.api.CheckCallNames(c, "AllSpaces", "Close")
+}
+
+func (s *ListSuite) TestRunWithUnknownSpaceFails(c *gc.C) {
+	s.AssertRunFails(c,
+		// List of expected spaces is sorted.
+		`"foo" is not a known space; expected one of: default, dmz, public, vlan-42`,
+		"--space", "foo",
+	)
+
+	s.api.CheckCallNames(c, "AllSpaces", "Close")
+}
+
+func (s *ListSuite) TestRunWhenAllZonesFails(c *gc.C) {
+	s.api.SetErrors(errors.NotFoundf("bar"))
+
+	// Ensure the error cause is preserved.
+	err := s.AssertRunFails(c,
+		`cannot list zones: bar not found`,
+		"--zone", "zone1",
+	)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	s.api.CheckCallNames(c, "AllZones", "Close")
+}
+
+func (s *ListSuite) TestRunWithUnknownZoneFails(c *gc.C) {
+	s.AssertRunFails(c,
+		// List of expected zones is sorted.
+		`"bar" is not a known zone; expected one of: zone1, zone2`,
+		"--zone", "bar",
+	)
+
+	s.api.CheckCallNames(c, "AllZones", "Close")
+}
+
+func (s *ListSuite) TestRunWhenListSubnetFails(c *gc.C) {
+	s.api.SetErrors(errors.NotSupportedf("foo"))
+
+	// Ensure the error cause is preserved.
+	err := s.AssertRunFails(c, "cannot list subnets: foo not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
+	s.api.CheckCall(c, 0, "ListSubnets", "", "")
+}
+
+func (s *ListSuite) TestRunWhenASubnetHasInvalidCIDRFails(c *gc.C) {
+	// This cannot happen in practice, as CIDRs are validated before
+	// adding a subnet, but this test ensures 100% coverage.
+	s.api.Subnets = s.api.Subnets[0:1]
+	s.api.Subnets[0].CIDR = "invalid"
+
+	s.AssertRunFails(c, `subnet "invalid" has invalid CIDR`)
+
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
+	s.api.CheckCall(c, 0, "ListSubnets", "", "")
+}
+
+func (s *ListSuite) TestRunWhenASubnetHasInvalidSpaceFails(c *gc.C) {
+	// This cannot happen in practice, as space names are validated
+	// before adding a subnet, but this test ensures 100% coverage.
+	s.api.Subnets = s.api.Subnets[0:1]
+	s.api.Subnets[0].SpaceTag = "foo"
+
+	s.AssertRunFails(c, `subnet "10.20.0.0/24" has invalid space: "foo" is not a valid tag`)
+
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
+	s.api.CheckCall(c, 0, "ListSubnets", "", "")
+}
+
+func (s *ListSuite) TestRunAPIConnectFails(c *gc.C) {
+	// TODO(dimitern): Change this once API is implemented.
+	s.command = subnet.NewListCommand(nil)
+	s.AssertRunFails(c,
+		"cannot connect to API server: API not implemented yet!",
+	)
+
+	// No API calls recoreded.
+	s.api.CheckCallNames(c)
+}

--- a/cmd/juju/subnet/remove_test.go
+++ b/cmd/juju/subnet/remove_test.go
@@ -68,6 +68,7 @@ func (s *RemoveSuite) TestInit(c *gc.C) {
 func (s *RemoveSuite) TestRunWithIPv4CIDRSucceeds(c *gc.C) {
 	s.AssertRunSucceeds(c,
 		`marked subnet "10.20.0.0/16" for removal\n`,
+		"", // empty stdout.
 		"10.20.0.0/16",
 	)
 
@@ -78,6 +79,7 @@ func (s *RemoveSuite) TestRunWithIPv4CIDRSucceeds(c *gc.C) {
 func (s *RemoveSuite) TestRunWithIPv6CIDRSucceeds(c *gc.C) {
 	s.AssertRunSucceeds(c,
 		`marked subnet "2001:db8::/32" for removal\n`,
+		"", // empty stdout.
 		"2001:db8::/32",
 	)
 

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 )
 
@@ -23,6 +24,9 @@ type SubnetAPI interface {
 
 	// AllZones returns all availability zones known to Juju.
 	AllZones() ([]string, error)
+
+	// AllSpaces returns all Juju network spaces.
+	AllSpaces() ([]string, error)
 
 	// CreateSubnet creates a new Juju subnet.
 	CreateSubnet(subnetCIDR, spaceName string, zones []string, isPublic bool) error
@@ -35,6 +39,10 @@ type SubnetAPI interface {
 	// related entites are cleaned up. It will fail if the subnet is
 	// still in use by any machines.
 	RemoveSubnet(subnetCIDR string) error
+
+	// ListSubnets returns information about subnets known to Juju,
+	// optionally filtered by space and/or zone (both can be empty).
+	ListSubnets(withSpace, withZone string) ([]params.Subnet, error)
 }
 
 var logger = loggo.GetLogger("juju.cmd.juju.subnet")
@@ -55,6 +63,7 @@ func NewSuperCommand() cmd.Command {
 	subnetCmd.Register(envcmd.Wrap(&CreateCommand{}))
 	subnetCmd.Register(envcmd.Wrap(&AddCommand{}))
 	subnetCmd.Register(envcmd.Wrap(&RemoveCommand{}))
+	subnetCmd.Register(envcmd.Wrap(&ListCommand{}))
 
 	return subnetCmd
 }

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -26,13 +26,13 @@ type SubnetAPI interface {
 	AllZones() ([]string, error)
 
 	// AllSpaces returns all Juju network spaces.
-	AllSpaces() ([]string, error)
+	AllSpaces() ([]names.Tag, error)
 
 	// CreateSubnet creates a new Juju subnet.
-	CreateSubnet(subnetCIDR, spaceName string, zones []string, isPublic bool) error
+	CreateSubnet(subnetCIDR string, spaceTag names.SpaceTag, zones []string, isPublic bool) error
 
 	// AddSubnet adds an existing subnet to Juju.
-	AddSubnet(subnetCIDR, spaceName string) error
+	AddSubnet(subnetCIDR string, spaceTag names.SpaceTag) error
 
 	// RemoveSubnet marks an existing subnet as no longer used, which
 	// will cause it to get removed at some point after all its
@@ -42,7 +42,7 @@ type SubnetAPI interface {
 
 	// ListSubnets returns information about subnets known to Juju,
 	// optionally filtered by space and/or zone (both can be empty).
-	ListSubnets(withSpace, withZone string) ([]params.Subnet, error)
+	ListSubnets(withSpace *names.SpaceTag, withZone string) ([]params.Subnet, error)
 }
 
 var logger = loggo.GetLogger("juju.cmd.juju.subnet")
@@ -124,10 +124,10 @@ func (s *SubnetCommandBase) ValidateCIDR(given string) (string, error) {
 }
 
 // ValidateSpace parses given and returns an error if it's not a valid
-// space name, otherwise returns the parsed name and no error.
-func (s *SubnetCommandBase) ValidateSpace(given string) (string, error) {
+// space name, otherwise returns the parsed tag and no error.
+func (s *SubnetCommandBase) ValidateSpace(given string) (names.SpaceTag, error) {
 	if !names.IsValidSpace(given) {
-		return "", errors.Errorf("%q is not a valid space name", given)
+		return names.SpaceTag{}, errors.Errorf("%q is not a valid space name", given)
 	}
-	return given, nil
+	return names.NewSpaceTag(given), nil
 }

--- a/cmd/juju/subnet/subnet_test.go
+++ b/cmd/juju/subnet/subnet_test.go
@@ -17,6 +17,7 @@ var subcommandNames = []string{
 	"add",
 	"create",
 	"remove",
+	"list",
 	"help",
 }
 

--- a/cmd/juju/subnet/subnet_test.go
+++ b/cmd/juju/subnet/subnet_test.go
@@ -159,11 +159,11 @@ func (s *SubnetCommandBaseSuite) TestValidateSpace(c *gc.C) {
 		validated, err := s.baseCmd.ValidateSpace(test.input)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
-			c.Check(validated, gc.Equals, "")
+			c.Check(validated.Id(), gc.Equals, "")
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 			// When the input is valid it should stay the same.
-			c.Check(validated, gc.Equals, test.input)
+			c.Check(validated.Id(), gc.Equals, test.input)
 		}
 	}
 }


### PR DESCRIPTION
This introduces the last "juju subnet" subcommand - "list".
As a drive-by fix, subcommand tests were refactored and simplified,
and the API interface methods now take/return names.SpaceTag rather
than string where needed.

(Review request: http://reviews.vapour.ws/r/1390/)