### PR TITLE
Updated help topics / glossary to include Subnet and Shadow Address

### DIFF
--- a/cmd/juju/help_topics.go
+++ b/cmd/juju/help_topics.go
@@ -553,7 +553,7 @@ Shadow Address
 
   It is common to arrange for addresses on the Internet that translate to
   private (cloud-local) addresses. For example, if connection to an IP address
-  on the internet will be tunnelled "magically" to a particular address on an
+  on the internet will be tunnelled transparently to a particular address on an
   RFC 1918 network, then that Internet IP address is an Internet shadow address
   for the private address.
 

--- a/cmd/juju/help_topics.go
+++ b/cmd/juju/help_topics.go
@@ -547,6 +547,45 @@ Service Unit
 Service Unit Agent
   Software which manages all the lifecycle of a single Service Unit.
 
+Shadow Address
+  An address on a different network which translates to a particular address
+  on this network. In other words, a "public shadow" of a "private" address.
+
+  It is common to arrange for addresses on the Internet that translate to
+  private (cloud-local) addresses. For example, if connection to an IP address
+  on the internet will be tunnelled "magically" to a particular address on an
+  RFC 1918 network, then that Internet IP address is an Internet shadow address
+  for the private address.
+
+  Shadow addresses in Juju enable modeling concepts like the Amazon "elastic IP"
+  or "automatic public IP" addresses or OpenStack's "floating IP" addresses.
+  All of these concepts have one thing in common - a shadow address is not
+  configured directly on the machine that's using it (i.e. it is "invisible"
+  to the machine itself). Shadow addresses are configured and managed using the
+  underlying cloud infrastructure API.
+
+Subnet
+  A broadcast address range identified by a Classless Inter-Domain Routing (CIDR)
+  range, like 10.1.2.0/24 or 2001:db8::/32. All defined subnets known to and
+  usable by Juju need to have non-overlapping CIDR ranges.
+
+  Juju can use existing subnets available on the cloud infrastructure (e.g.
+  networks in MAAS or subnets in Amazon VPC), but they need to be "added" to
+  Juju (see "juju subnet add --help"). For cloud substrates that support SDN
+  (Software-Defined Networking) features (e.g. Amazon VPC, OpenStack), Juju can
+  also create new subnets using the cloud infrastructure API (see "juju subnet
+  create --help").
+
+  Each subnet is always in one and only one "space". Subnets are associated
+  with at least one availability zone, but may span multiple availability
+  zones, if the underlying infrastructure supports that.
+
+  Subnets can be in use (when any services or machines are on them), or not.
+  Removing a subnet in use is not supported, as it could cause connectivity
+  issues. Also, subnets can have "public" or "private" access. When a subnet
+  has "public" access it means the subnet is configured to support Shadow
+  Addresses (see above). "Private" access is the default and means no access
+  from outside an environment is allowed.
 `
 
 const helpLogging = `

--- a/cmd/juju/subnet/remove.go
+++ b/cmd/juju/subnet/remove.go
@@ -19,14 +19,20 @@ type RemoveCommand struct {
 }
 
 const removeCommandDoc = `
-Removes an existing and unused subnet from Juju. It does not delete
-the subnet from the cloud substrate (i.e. it is not the opposite of
-"juju subnet create").
+Marks an existing and unused subnet for removal. Depending on what features
+the cloud infrastructure supports, this command will either delete the
+subnet using the cloud API (if supported, e.g. in Amazon VPC) or just
+remove the subnet entity from Juju's database (with non-SDN substrates,
+e.g. MAAS). In other words "remove" acts like the opposite of "create"
+(if supported) or "add" (if "create" is not supported).
 
 If any machines are still using the subnet, it cannot be removed and
 an error is returned instead. If the subnet is not in use, it will be
 marked for removal, but it will not be removed from the Juju database
 until all related entites are cleaned up (e.g. allocated addresses).
+Just before ultimately removing the subnet from the Juju database, and
+if the infrastructure supports it, the subnet will be also deleted from
+the underlying substrate.
 `
 
 // Info is defined on the cmd.Command interface.

--- a/cmd/juju/subnet/remove.go
+++ b/cmd/juju/subnet/remove.go
@@ -19,8 +19,8 @@ type RemoveCommand struct {
 }
 
 const removeCommandDoc = `
-Marks an existing and unused subnet for removal. Depending on what features
-the cloud infrastructure supports, this command will either delete the
+Marks an existing subnet for removal. Depending on what features the
+cloud infrastructure supports, this command will either delete the
 subnet using the cloud API (if supported, e.g. in Amazon VPC) or just
 remove the subnet entity from Juju's database (with non-SDN substrates,
 e.g. MAAS). In other words "remove" acts like the opposite of "create"
@@ -30,9 +30,6 @@ If any machines are still using the subnet, it cannot be removed and
 an error is returned instead. If the subnet is not in use, it will be
 marked for removal, but it will not be removed from the Juju database
 until all related entites are cleaned up (e.g. allocated addresses).
-Just before ultimately removing the subnet from the Juju database, and
-if the infrastructure supports it, the subnet will be also deleted from
-the underlying substrate.
 `
 
 // Info is defined on the cmd.Command interface.

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -48,7 +48,13 @@ type SubnetAPI interface {
 var logger = loggo.GetLogger("juju.cmd.juju.subnet")
 
 const commandDoc = `
-"juju subnet" provides commands to manage Juju subnets.
+"juju subnet" provides commands to manage Juju subnets. In Juju, a subnet
+is a logical address range, a subdivision of a network, defined by the
+subnet's Classless Inter-Domain Routing (CIDR) range, like 10.10.0.0/24 or
+2001:db8::/32. Subnets have two kinds of supported access: "public" (using
+shadow addresses) or "private" (using cloud-local addresses, this is the
+default). For more information about subnets and shadow addresses, please
+refer to Juju's glossary help topics ("juju help glossary").
 `
 
 // NewSuperCommand creates the "subnet" supercommand and registers the


### PR DESCRIPTION
Last step of implementing the "subnet" supercommand and related CLI
subcommands. Updated the glossary and help topics to describe better
what is a subnet and how Juju uses it, and what is a shadow address.

As a drive-by fix, the "subnet remove" subcommand's help doc was also
updated to better reflect the network model description (i.e. remove can
delete the subnet if supported, not just from the state DB).

Depends on #2037 (the only changes are in subnet.go and help_topics.go).

(Review request: http://reviews.vapour.ws/r/1393/)