### PR TITLE
Bug #1439447 - Don't use proxy when downloading tools from bootstrap node.

### DIFF
--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -220,7 +220,7 @@ chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-precise-amd64'
 mkdir -p \$bin
 echo 'Fetching tools.*
-curl .* -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-precise-amd64\.tgz'
+curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-precise-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-precise-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-precise-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
@@ -272,7 +272,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
 		inexactMatch: true,
 		expectScripts: `
 bin='/var/lib/juju/tools/1\.2\.3-raring-amd64'
-curl .* -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz'
+curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-raring-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-raring-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 printf %s '{"version":"1\.2\.3-raring-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
@@ -326,7 +326,7 @@ chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
 mkdir -p \$bin
 echo 'Fetching tools.*
-curl .* --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/tools/1\.2\.3-quantal-amd64'
+curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/tools/1\.2\.3-quantal-amd64'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-quantal-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-quantal-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
@@ -417,7 +417,7 @@ start jujud-machine-2-lxc-1
 		},
 		inexactMatch: true,
 		expectScripts: `
-curl .* --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/tools/1\.2\.3-quantal-amd64'
+curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/tools/1\.2\.3-quantal-amd64'
 `,
 	}, {
 		// empty contraints.

--- a/environs/cloudinit/cloudinit_ubuntu.go
+++ b/environs/cloudinit/cloudinit_ubuntu.go
@@ -188,7 +188,7 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 			}
 
 			// Don't go through the proxy when downloading tools from the state servers
-			curlCommand += " --noproxy \"*\""
+			curlCommand += ` --noproxy "*"`
 
 			// Our API server certificates are unusable by curl (invalid subject name),
 			// so we must disable certificate validation. It doesn't actually

--- a/environs/cloudinit/cloudinit_ubuntu.go
+++ b/environs/cloudinit/cloudinit_ubuntu.go
@@ -186,6 +186,10 @@ func (w *ubuntuConfigure) ConfigureJuju() error {
 				url := fmt.Sprintf("https://%s/tools/%s", addr, w.mcfg.Tools.Version)
 				urls = append(urls, url)
 			}
+
+			// Don't go through the proxy when downloading tools from the state servers
+			curlCommand += " --noproxy \"*\""
+
 			// Our API server certificates are unusable by curl (invalid subject name),
 			// so we must disable certificate validation. It doesn't actually
 			// matter, because there is no sensitive information being transmitted


### PR DESCRIPTION
Fixes bug #1439447

(Review request: http://reviews.vapour.ws/r/1397/)