### PR TITLE
Server-side Subnets API facade done and tested with 100% coverage

### DIFF
--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -448,3 +448,16 @@ type APIHostPortsResult struct {
 func (r APIHostPortsResult) NetworkHostsPorts() [][]network.HostPort {
 	return NetworkHostsPorts(r.Servers)
 }
+
+// ZoneResult holds the result of an API call that returns an
+// availability zone name and whether it's available for use.
+type ZoneResult struct {
+	Error     *Error
+	Name      string
+	Available bool
+}
+
+// ZoneResults holds multiple ZoneResult results
+type ZoneResults struct {
+	Results []ZoneResult
+}

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -452,12 +452,12 @@ func (r APIHostPortsResult) NetworkHostsPorts() [][]network.HostPort {
 // ZoneResult holds the result of an API call that returns an
 // availability zone name and whether it's available for use.
 type ZoneResult struct {
-	Error     *Error
-	Name      string
-	Available bool
+	Error     *Error `json:"Error"`
+	Name      string `json:"Name"`
+	Available bool   `json:"Available"`
 }
 
 // ZoneResults holds multiple ZoneResult results
 type ZoneResults struct {
-	Results []ZoneResult
+	Results []ZoneResult `json:"Results"`
 }

--- a/apiserver/subnets/package_test.go
+++ b/apiserver/subnets/package_test.go
@@ -1,0 +1,245 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnets_test
+
+import (
+	"fmt"
+	stdtesting "testing"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/subnets"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	providercommon "github.com/juju/juju/provider/common"
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+const (
+	StubProviderType     = "stub-provider"
+	StubEnvironName      = "stub-environ"
+	StubZonedEnvironName = "stub-zoned-environ"
+)
+
+var (
+	// SharedStub records all method calls to any of the stubs.
+	SharedStub = &testing.Stub{}
+
+	BackingInstance      = &StubBacking{Stub: SharedStub}
+	ProviderInstance     = &StubProvider{Stub: SharedStub}
+	EnvironInstance      = &StubEnviron{Stub: SharedStub}
+	ZonedEnvironInstance = &StubZonedEnviron{Stub: SharedStub}
+)
+
+func init() {
+	ProviderInstance.Zones = []providercommon.AvailabilityZone{
+		&FakeZone{"env-zone1", true},
+		&FakeZone{"env-zone2", false},
+	}
+	environs.RegisterProvider(StubProviderType, ProviderInstance)
+}
+
+// StubMethodCall is like testing.StubCall, but includes the receiver
+// as well.
+type StubMethodCall struct {
+	Receiver interface{}
+	FuncName string
+	Args     []interface{}
+}
+
+// BackingCall makes it easy to check method calls on BackingInstance.
+func BackingCall(name string, args ...interface{}) StubMethodCall {
+	return StubMethodCall{
+		Receiver: BackingInstance,
+		FuncName: name,
+		Args:     args,
+	}
+}
+
+// ProviderCall makes it easy to check method calls on ProviderInstance.
+func ProviderCall(name string, args ...interface{}) StubMethodCall {
+	return StubMethodCall{
+		Receiver: ProviderInstance,
+		FuncName: name,
+		Args:     args,
+	}
+}
+
+// EnvironCall makes it easy to check method calls on EnvironInstance.
+func EnvironCall(name string, args ...interface{}) StubMethodCall {
+	return StubMethodCall{
+		Receiver: EnvironInstance,
+		FuncName: name,
+		Args:     args,
+	}
+}
+
+// ZonedEnvironCall makes it easy to check method calls on
+// ZonedEnvironInstance.
+func ZonedEnvironCall(name string, args ...interface{}) StubMethodCall {
+	return StubMethodCall{
+		Receiver: ZonedEnvironInstance,
+		FuncName: name,
+		Args:     args,
+	}
+}
+
+// CheckMethodCalls works like testing.Stub.CheckCalls, but also
+// checks the receivers.
+func CheckMethodCalls(c *gc.C, stub *testing.Stub, calls ...StubMethodCall) {
+	if !c.Check(stub.Receivers, gc.HasLen, len(calls)) {
+		return
+	}
+	if !c.Check(stub.Calls, gc.HasLen, len(calls)) {
+		return
+	}
+	for i, call := range calls {
+		stub.CheckCall(c, i, call.FuncName, call.Args...)
+		c.Check(stub.Receivers[i], jc.DeepEquals, call.Receiver)
+	}
+}
+
+// FakeZone implements providercommon.AvailabilityZone for testing.
+type FakeZone struct {
+	name      string
+	available bool
+}
+
+var _ providercommon.AvailabilityZone = (*FakeZone)(nil)
+
+func (f *FakeZone) Name() string {
+	return f.name
+}
+
+func (f *FakeZone) Available() bool {
+	return f.available
+}
+
+// GoString implements fmt.GoStringer.
+func (f *FakeZone) GoString() string {
+	return fmt.Sprintf("&FakeZone{%q, %v}", f.name, f.available)
+}
+
+// ResetStub resets all recorded calls and errors of the given stub.
+func ResetStub(stub *testing.Stub) {
+	stub.Calls = stub.Calls[0:0]
+	stub.Receivers = stub.Receivers[0:0]
+	stub.DefaultError = nil
+	stub.SetErrors()
+}
+
+// StubBacking implements subnets.Backing and records calls to its
+// methods.
+type StubBacking struct {
+	*testing.Stub
+
+	EnvConfig *config.Config
+
+	Zones []providercommon.AvailabilityZone
+}
+
+var _ subnets.Backing = (*StubBacking)(nil)
+
+func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones bool) {
+	// This method should be called at the beginning of each test, so
+	// reset the recorded calls and errors.
+	ResetStub(sb.Stub)
+
+	// Make sure we use the stub provider.
+	extraAttrs := coretesting.Attrs{
+		"uuid": utils.MustNewUUID().String(),
+		"type": StubProviderType,
+		"name": envName,
+	}
+	sb.EnvConfig = coretesting.CustomEnvironConfig(c, extraAttrs)
+	sb.Zones = []providercommon.AvailabilityZone{}
+	if withZones {
+		sb.Zones = []providercommon.AvailabilityZone{
+			&FakeZone{"zone1", true},
+			&FakeZone{"zone2", false},
+			&FakeZone{"zone3", true},
+		}
+	}
+}
+
+func (sb *StubBacking) EnvironConfig() (*config.Config, error) {
+	sb.MethodCall(sb, "EnvironConfig")
+	if err := sb.NextErr(); err != nil {
+		return nil, err
+	}
+	return sb.EnvConfig, nil
+}
+
+func (sb *StubBacking) AvailabilityZones() ([]providercommon.AvailabilityZone, error) {
+	sb.MethodCall(sb, "AvailabilityZones")
+	if err := sb.NextErr(); err != nil {
+		return nil, err
+	}
+	return sb.Zones, nil
+}
+
+func (sb *StubBacking) SetAvailabilityZones(zones []providercommon.AvailabilityZone) error {
+	sb.MethodCall(sb, "SetAvailabilityZones", zones)
+	return sb.NextErr()
+}
+
+// StubProvider implements a subset of environs.EnvironProvider
+// methods used in tests.
+type StubProvider struct {
+	*testing.Stub
+
+	Zones []providercommon.AvailabilityZone
+
+	environs.EnvironProvider // panic on any not implemented method call.
+}
+
+var _ environs.EnvironProvider = (*StubProvider)(nil)
+
+func (sp *StubProvider) Open(cfg *config.Config) (environs.Environ, error) {
+	sp.MethodCall(sp, "Open", cfg)
+	if err := sp.NextErr(); err != nil {
+		return nil, err
+	}
+	switch cfg.Name() {
+	case StubEnvironName:
+		return EnvironInstance, nil
+	case StubZonedEnvironName:
+		return ZonedEnvironInstance, nil
+	}
+	panic("unexpected environment name: " + cfg.Name())
+}
+
+// StubEnviron is used in tests where environs.Environ is needed.
+type StubEnviron struct {
+	*testing.Stub
+
+	environs.Environ // panic on any not implemented method call
+}
+
+var _ environs.Environ = (*StubEnviron)(nil)
+
+// StubZonedEnviron is used in tests where providercommon.ZonedEnviron
+// is needed.
+type StubZonedEnviron struct {
+	*testing.Stub
+
+	providercommon.ZonedEnviron // panic on any not implemented method call
+}
+
+var _ providercommon.ZonedEnviron = (*StubZonedEnviron)(nil)
+
+func (se *StubZonedEnviron) AvailabilityZones() ([]providercommon.AvailabilityZone, error) {
+	se.MethodCall(se, "AvailabilityZones")
+	if err := se.NextErr(); err != nil {
+		return nil, err
+	}
+	return ProviderInstance.Zones, nil
+}

--- a/apiserver/subnets/subnets.go
+++ b/apiserver/subnets/subnets.go
@@ -39,11 +39,10 @@ type Backing interface {
 
 // API defines the methods the Subnets API facade implements.
 type API interface {
-	// AllZones returns all availability zones known to Juju. Each
-	// StringBoolResult's Result field contains the zone name, while
-	// the Ok field will be true unless the zone is unusable,
-	// unavailable, or deprecated.
-	AllZones() (params.StringBoolResults, error)
+	// AllZones returns all availability zones known to Juju. If a
+	// zone is unusable, unavailable, or deprecated the Available
+	// field will be false.
+	AllZones() (params.ZoneResults, error)
 }
 
 // internalAPI implements the API interface.
@@ -69,8 +68,8 @@ func NewAPI(backing Backing, resources *common.Resources, authorizer common.Auth
 }
 
 // AllZones is defined on the API interface.
-func (a *internalAPI) AllZones() (params.StringBoolResults, error) {
-	var results params.StringBoolResults
+func (a *internalAPI) AllZones() (params.ZoneResults, error) {
+	var results params.ZoneResults
 
 	// Try fetching cached zones first.
 	zones, err := a.backing.AvailabilityZones()
@@ -89,10 +88,10 @@ func (a *internalAPI) AllZones() (params.StringBoolResults, error) {
 		logger.Debugf("using cached list of known zones: %v", zones)
 	}
 
-	results.Results = make([]params.StringBoolResult, len(zones))
+	results.Results = make([]params.ZoneResult, len(zones))
 	for i, zone := range zones {
-		results.Results[i].Result = zone.Name()
-		results.Results[i].Ok = zone.Available()
+		results.Results[i].Name = zone.Name()
+		results.Results[i].Available = zone.Available()
 	}
 	return results, nil
 }

--- a/apiserver/subnets/subnets.go
+++ b/apiserver/subnets/subnets.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnets
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	providercommon "github.com/juju/juju/provider/common"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.subnets")
+
+func init() {
+	// TODO(dimitern): Uncomment once *state.State implements Backing.
+	//common.RegisterStandardFacade("Subnets", 1, NewAPI)
+}
+
+// Backing defines the methods needed by the API facade to store and
+// retrieve information from the underlying persistency layer (state
+// DB).
+type Backing interface {
+	// EnvironConfig returns the current environment config.
+	EnvironConfig() (*config.Config, error)
+
+	// AvailabilityZones returns all cached availability zones (i.e.
+	// not from the provider, but in state).
+	AvailabilityZones() ([]providercommon.AvailabilityZone, error)
+
+	// SetAvailabilityZones replaces the cached list of availability
+	// zones with the given zones.
+	SetAvailabilityZones(zones []providercommon.AvailabilityZone) error
+}
+
+// API defines the methods the Subnets API facade implements.
+type API interface {
+	// AllZones returns all availability zones known to Juju. Each
+	// StringBoolResult's Result field contains the zone name, while
+	// the Ok field will be true unless the zone is unusable,
+	// unavailable, or deprecated.
+	AllZones() (params.StringBoolResults, error)
+}
+
+// internalAPI implements the API interface.
+type internalAPI struct {
+	backing    Backing
+	resources  *common.Resources
+	authorizer common.Authorizer
+}
+
+var _ API = (*internalAPI)(nil)
+
+// NewAPI creates a new server-side Subnets API facade.
+func NewAPI(backing Backing, resources *common.Resources, authorizer common.Authorizer) (API, error) {
+	// Only clients can access the Subnets facade.
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
+	return &internalAPI{
+		backing:    backing,
+		resources:  resources,
+		authorizer: authorizer,
+	}, nil
+}
+
+// AllZones is defined on the API interface.
+func (a *internalAPI) AllZones() (params.StringBoolResults, error) {
+	var results params.StringBoolResults
+
+	// Try fetching cached zones first.
+	zones, err := a.backing.AvailabilityZones()
+	if err != nil {
+		return results, errors.Trace(err)
+	}
+	if len(zones) == 0 {
+		// This is likely the first time we're called.
+		// Fetch all zones from the provider and update.
+		zones, err = a.updateZones()
+		if err != nil {
+			return results, errors.Annotate(err, "cannot update known zones")
+		}
+		logger.Debugf("updated the list of known zones from the environment: %v", zones)
+	} else {
+		logger.Debugf("using cached list of known zones: %v", zones)
+	}
+
+	results.Results = make([]params.StringBoolResult, len(zones))
+	for i, zone := range zones {
+		results.Results[i].Result = zone.Name()
+		results.Results[i].Ok = zone.Available()
+	}
+	return results, nil
+}
+
+// zonedEnviron returns a providercommon.ZonedEnviron instance from
+// the current environment config. If the environment does not support
+// zones, an error satisfying errors.IsNotSupported() will be
+// returned.
+func (a *internalAPI) zonedEnviron() (providercommon.ZonedEnviron, error) {
+	envConfig, err := a.backing.EnvironConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting environment config")
+	}
+
+	env, err := environs.New(envConfig)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting environment")
+	}
+	if zonedEnv, ok := env.(providercommon.ZonedEnviron); ok {
+		return zonedEnv, nil
+	}
+	return nil, errors.NotSupportedf("availability zones")
+}
+
+// updateZones attempts to retrieve all availability zones from the
+// environment provider (if supported) and then updates the persisted
+// list of zones in state, returning them as well on success.
+func (a *internalAPI) updateZones() ([]providercommon.AvailabilityZone, error) {
+	zoned, err := a.zonedEnviron()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	zones, err := zoned.AvailabilityZones()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err := a.backing.SetAvailabilityZones(zones); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return zones, nil
+}

--- a/apiserver/subnets/subnets_test.go
+++ b/apiserver/subnets/subnets_test.go
@@ -1,0 +1,233 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package subnets_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/subnets"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	providercommon "github.com/juju/juju/provider/common"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type SubnetsSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+	facade     subnets.API
+}
+
+var _ = gc.Suite(&SubnetsSuite{})
+
+func (s *SubnetsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	BackingInstance.SetUp(c, StubZonedEnvironName, true)
+
+	s.resources = common.NewResources()
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag:            names.NewUserTag("admin"),
+		EnvironManager: false,
+	}
+
+	var err error
+	s.facade, err = subnets.NewAPI(BackingInstance, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.facade, gc.NotNil)
+}
+
+func (s *SubnetsSuite) TearDownTest(c *gc.C) {
+	if s.resources != nil {
+		s.resources.StopAll()
+	}
+	s.BaseSuite.TearDownTest(c)
+}
+
+// AssertAllZonesResult makes it easier to verify AllZones results.
+func (s *SubnetsSuite) AssertAllZonesResult(c *gc.C, got params.StringBoolResults, expected []providercommon.AvailabilityZone) {
+	results := make([]params.StringBoolResult, len(expected))
+	for i, zone := range expected {
+		results[i].Result = zone.Name()
+		results[i].Ok = zone.Available()
+	}
+	c.Assert(got, jc.DeepEquals, params.StringBoolResults{Results: results})
+}
+
+func (s *SubnetsSuite) TestNewAPI(c *gc.C) {
+	// Clients are allowed.
+	facade, err := subnets.NewAPI(BackingInstance, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(facade, gc.NotNil)
+	// No calls so far.
+	CheckMethodCalls(c, SharedStub)
+
+	// Agents are not allowed
+	agentAuthorizer := s.authorizer
+	agentAuthorizer.Tag = names.NewMachineTag("42")
+	facade, err = subnets.NewAPI(BackingInstance, s.resources, agentAuthorizer)
+	c.Assert(err, jc.DeepEquals, common.ErrPerm)
+	c.Assert(facade, gc.IsNil)
+	// No calls so far.
+	CheckMethodCalls(c, SharedStub)
+}
+
+func (s *SubnetsSuite) TestAllZonesWhenBackingAvailabilityZonesFails(c *gc.C) {
+	SharedStub.SetErrors(errors.NotSupportedf("zones"))
+
+	results, err := s.facade.AllZones()
+	c.Assert(err, gc.ErrorMatches, "zones not supported")
+	// Verify the cause is not obscured.
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+
+	CheckMethodCalls(c, SharedStub,
+		BackingCall("AvailabilityZones"),
+	)
+}
+
+func (s *SubnetsSuite) TestAllZonesUsesBackingZonesWhenAvailable(c *gc.C) {
+	results, err := s.facade.AllZones()
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertAllZonesResult(c, results, BackingInstance.Zones)
+
+	CheckMethodCalls(c, SharedStub,
+		BackingCall("AvailabilityZones"),
+	)
+}
+
+func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesUpdates(c *gc.C) {
+	BackingInstance.SetUp(c, StubZonedEnvironName, false)
+
+	results, err := s.facade.AllZones()
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertAllZonesResult(c, results, ProviderInstance.Zones)
+
+	CheckMethodCalls(c, SharedStub,
+		BackingCall("AvailabilityZones"),
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+		ZonedEnvironCall("AvailabilityZones"),
+		BackingCall("SetAvailabilityZones", ProviderInstance.Zones),
+	)
+}
+
+func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
+	BackingInstance.SetUp(c, StubZonedEnvironName, false)
+	SharedStub.SetErrors(
+		nil, // Backing.AvailabilityZones
+		nil, // Backing.EnvironConfig
+		nil, // Provider.Open
+		nil, // ZonedEnviron.AvailabilityZones
+		errors.NotSupportedf("setting"), // Backing.SetAvailabilityZones
+	)
+
+	results, err := s.facade.AllZones()
+	c.Assert(err, gc.ErrorMatches,
+		`cannot update known zones: setting not supported`,
+	)
+	// Verify the cause is not obscured.
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+
+	CheckMethodCalls(c, SharedStub,
+		BackingCall("AvailabilityZones"),
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+		ZonedEnvironCall("AvailabilityZones"),
+		BackingCall("SetAvailabilityZones", ProviderInstance.Zones),
+	)
+}
+
+func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc.C) {
+	BackingInstance.SetUp(c, StubZonedEnvironName, false)
+	SharedStub.SetErrors(
+		nil, // Backing.AvailabilityZones
+		nil, // Backing.EnvironConfig
+		nil, // Provider.Open
+		errors.NotValidf("foo"), // ZonedEnviron.AvailabilityZones
+	)
+
+	results, err := s.facade.AllZones()
+	c.Assert(err, gc.ErrorMatches,
+		`cannot update known zones: foo not valid`,
+	)
+	// Verify the cause is not obscured.
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+
+	CheckMethodCalls(c, SharedStub,
+		BackingCall("AvailabilityZones"),
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+		ZonedEnvironCall("AvailabilityZones"),
+	)
+}
+
+func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndEnvironConfigFails(c *gc.C) {
+	BackingInstance.SetUp(c, StubZonedEnvironName, false)
+	SharedStub.SetErrors(
+		nil, // Backing.AvailabilityZones
+		errors.NotFoundf("config"), // Backing.EnvironConfig
+	)
+
+	results, err := s.facade.AllZones()
+	c.Assert(err, gc.ErrorMatches,
+		`cannot update known zones: getting environment config: config not found`,
+	)
+	// Verify the cause is not obscured.
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+
+	CheckMethodCalls(c, SharedStub,
+		BackingCall("AvailabilityZones"),
+		BackingCall("EnvironConfig"),
+	)
+}
+
+func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
+	BackingInstance.SetUp(c, StubZonedEnvironName, false)
+	SharedStub.SetErrors(
+		nil, // Backing.AvailabilityZones
+		nil, // Backing.EnvironConfig
+		errors.NotValidf("config"), // Provider.Open
+	)
+
+	results, err := s.facade.AllZones()
+	c.Assert(err, gc.ErrorMatches,
+		`cannot update known zones: getting environment: config not valid`,
+	)
+	// Verify the cause is not obscured.
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+
+	CheckMethodCalls(c, SharedStub,
+		BackingCall("AvailabilityZones"),
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+	)
+}
+
+func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndZonesNotSupported(c *gc.C) {
+	BackingInstance.SetUp(c, StubEnvironName, false) // ZonedEnviron not supported
+
+	results, err := s.facade.AllZones()
+	c.Assert(err, gc.ErrorMatches,
+		`cannot update known zones: availability zones not supported`,
+	)
+	// Verify the cause is not obscured.
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+
+	CheckMethodCalls(c, SharedStub,
+		BackingCall("AvailabilityZones"),
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+	)
+}

--- a/apiserver/subnets/subnets_test.go
+++ b/apiserver/subnets/subnets_test.go
@@ -51,13 +51,13 @@ func (s *SubnetsSuite) TearDownTest(c *gc.C) {
 }
 
 // AssertAllZonesResult makes it easier to verify AllZones results.
-func (s *SubnetsSuite) AssertAllZonesResult(c *gc.C, got params.StringBoolResults, expected []providercommon.AvailabilityZone) {
-	results := make([]params.StringBoolResult, len(expected))
+func (s *SubnetsSuite) AssertAllZonesResult(c *gc.C, got params.ZoneResults, expected []providercommon.AvailabilityZone) {
+	results := make([]params.ZoneResult, len(expected))
 	for i, zone := range expected {
-		results[i].Result = zone.Name()
-		results[i].Ok = zone.Available()
+		results[i].Name = zone.Name()
+		results[i].Available = zone.Available()
 	}
-	c.Assert(got, jc.DeepEquals, params.StringBoolResults{Results: results})
+	c.Assert(got, jc.DeepEquals, params.ZoneResults{Results: results})
 }
 
 func (s *SubnetsSuite) TestNewAPI(c *gc.C) {
@@ -85,7 +85,7 @@ func (s *SubnetsSuite) TestAllZonesWhenBackingAvailabilityZonesFails(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "zones not supported")
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
-	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+	c.Assert(results, jc.DeepEquals, params.ZoneResults{})
 
 	CheckMethodCalls(c, SharedStub,
 		BackingCall("AvailabilityZones"),
@@ -134,7 +134,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 	)
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
-	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+	c.Assert(results, jc.DeepEquals, params.ZoneResults{})
 
 	CheckMethodCalls(c, SharedStub,
 		BackingCall("AvailabilityZones"),
@@ -160,7 +160,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 	)
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
-	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+	c.Assert(results, jc.DeepEquals, params.ZoneResults{})
 
 	CheckMethodCalls(c, SharedStub,
 		BackingCall("AvailabilityZones"),
@@ -183,7 +183,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndEnvironConfigFails(c *gc
 	)
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+	c.Assert(results, jc.DeepEquals, params.ZoneResults{})
 
 	CheckMethodCalls(c, SharedStub,
 		BackingCall("AvailabilityZones"),
@@ -205,7 +205,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 	)
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
-	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+	c.Assert(results, jc.DeepEquals, params.ZoneResults{})
 
 	CheckMethodCalls(c, SharedStub,
 		BackingCall("AvailabilityZones"),
@@ -223,7 +223,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndZonesNotSupported(c *gc.
 	)
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
-	c.Assert(results, jc.DeepEquals, params.StringBoolResults{})
+	c.Assert(results, jc.DeepEquals, params.ZoneResults{})
 
 	CheckMethodCalls(c, SharedStub,
 		BackingCall("AvailabilityZones"),


### PR DESCRIPTION
This implements a new server-side API facade "Subnets", with only one
method for now - AllZones(). Tested with stubed out state (Backing),
provider and environment interfaces - 100% coverage. Needed by the
CLI "subnets" command and its subcommands.

Not registered as a standard facade yet because *state.State does not
implement a couple of needed methods (which was the whole point of
not implementing new state methods before we know what the API needs).

Next step will be to propose the client-side facade version with tests.

(Review request: http://reviews.vapour.ws/r/1399/)