### PR TITLE
revision updater: send the environment UUID to the charm store.

### DIFF
--- a/apiserver/charmrevisionupdater/updater.go
+++ b/apiserver/charmrevisionupdater/updater.go
@@ -115,6 +115,9 @@ func retrieveLatestCharmInfo(deployedCharms map[string]*charm.URL, uuid string) 
 	// Do a bulk call to get the revision info for all charms.
 	logger.Infof("retrieving revision information for %d charms", len(curls))
 	repo := NewCharmStore(charmrepo.NewCharmStoreParams{})
+	repo = repo.(*charmrepo.CharmStore).WithJujuAttrs(map[string]string{
+		"environment_uuid": uuid,
+	})
 	revInfo, err := repo.Latest(curls...)
 	if err != nil {
 		err = errors.Annotate(err, "finding charm revision info")

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -4,10 +4,14 @@
 package charmrevisionupdater_test
 
 import (
+	"net/http"
+	"net/http/httptest"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5-unstable"
+	"gopkg.in/juju/charm.v5-unstable/charmrepo"
 
 	"github.com/juju/juju/apiserver/charmrevisionupdater"
 	"github.com/juju/juju/apiserver/charmrevisionupdater/testing"
@@ -116,4 +120,31 @@ func (s *charmVersionSuite) TestUpdateRevisions(c *gc.C) {
 	curl = charm.MustParseURL("cs:quantal/mysql")
 	_, err = s.State.LatestPlaceholderCharm(curl)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *charmVersionSuite) TestEnvironmentUUIDUsed(c *gc.C) {
+	s.AddMachine(c, "0", state.JobManageEnviron)
+	s.SetupScenario(c)
+
+	// Set up a charm store server that stores the request header.
+	var header http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		header = r.Header
+		s.Server.Handler().ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	// Point the charm repo initializer to the testing server.
+	s.PatchValue(&charmrevisionupdater.NewCharmStore, func(p charmrepo.NewCharmStoreParams) charmrepo.Interface {
+		p.URL = srv.URL
+		return charmrepo.NewCharmStore(p)
+	})
+
+	result, err := s.charmrevisionupdater.UpdateLatestRevisions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(header.Get(charmrepo.JujuMetadataHTTPHeader), gc.Equals, "environment_uuid="+env.UUID())
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -37,9 +37,9 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	f5c958d2b012da23a4600bad441f20b13ec262c4	2015-04-03T18:23:57Z
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
-gopkg.in/juju/charm.v5-unstable	git	94319516e98abd496bbe497efba2686ef67a5b6b	2015-04-08T14:00:55Z
-gopkg.in/juju/charmstore.v4	git	d93a27d1012c9c3a34bcee50c9e3a380a05b00cf	2015-04-08T12:11:25Z
-gopkg.in/macaroon-bakery.v0	git	b5244190c2cd2252563b2a71dad05f0bf602a51c	2015-04-08T13:27:45Z
+gopkg.in/juju/charm.v5-unstable	git	6729786a6b4955f55f7153593334da872f332645	2015-04-09T13:09:47Z
+gopkg.in/juju/charmstore.v4	git	d82e6568ef6ad88daa860c2e0f5dae8eac4975de	2015-04-09T13:29:34Z
+gopkg.in/macaroon-bakery.v0	git	084ccc7c1f62d56a3943f7216b3d41d94871af24	2015-04-08T14:01:18Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	2014-07-30T20:00:37Z
 gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	2014-07-25T20:51:33Z


### PR DESCRIPTION
Restore sending the env UUID to the charm store, which was previously
removed in https://github.com/juju/juju/commit/61207aaf189b7328121b071cf271a34411a316bc
Now the feature is back in the revision updater and it uses the new
charm store repository implementation.

(Review request: http://reviews.vapour.ws/r/1404/)