### PR TITLE
some test fixes

### DIFF
--- a/worker/notifyworker_test.go
+++ b/worker/notifyworker_test.go
@@ -26,23 +26,30 @@ type notifyWorkerSuite struct {
 
 var _ = gc.Suite(&notifyWorkerSuite{})
 
-func (s *notifyWorkerSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+func newNotifyHandlerWorker(c *gc.C, setupError, handlerError, teardownError error) (*notifyHandler, worker.Worker) {
 	nh := &notifyHandler{
-		actions: nil,
-		handled: make(chan struct{}, 1),
+		actions:       nil,
+		handled:       make(chan struct{}, 1),
+		setupError:    setupError,
+		teardownError: teardownError,
+		handlerError:  handlerError,
 		watcher: &testNotifyWatcher{
 			changes: make(chan struct{}),
 		},
 		setupDone: make(chan struct{}),
 	}
-	s.actor = nh
-	s.worker = worker.NewNotifyWorker(s.actor)
+	w := worker.NewNotifyWorker(nh)
 	select {
 	case <-nh.setupDone:
 	case <-time.After(coretesting.ShortWait):
 		c.Error("Failed waiting for notifyHandler.Setup to be called during SetUpTest")
 	}
+	return nh, w
+}
+
+func (s *notifyWorkerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.actor, s.worker = newNotifyHandlerWorker(c, nil, nil, nil)
 }
 
 func (s *notifyWorkerSuite) TearDownTest(c *gc.C) {
@@ -246,15 +253,7 @@ func (s *notifyWorkerSuite) TestChangesTriggerHandler(c *gc.C) {
 func (s *notifyWorkerSuite) TestSetUpFailureStopsWithTearDown(c *gc.C) {
 	// Stop the worker and SetUp again, this time with an error
 	s.stopWorker(c)
-	actor := &notifyHandler{
-		actions:    nil,
-		handled:    make(chan struct{}, 1),
-		setupError: fmt.Errorf("my special error"),
-		watcher: &testNotifyWatcher{
-			changes: make(chan struct{}),
-		},
-	}
-	w := worker.NewNotifyWorker(actor)
+	actor, w := newNotifyHandlerWorker(c, fmt.Errorf("my special error"), nil, nil)
 	err := waitShort(c, w)
 	c.Check(err, gc.ErrorMatches, "my special error")
 	// TearDown is not called on SetUp error.
@@ -280,15 +279,7 @@ func (s *notifyWorkerSuite) TestCleanRunNoticesTearDownError(c *gc.C) {
 
 func (s *notifyWorkerSuite) TestHandleErrorStopsWorkerAndWatcher(c *gc.C) {
 	s.stopWorker(c)
-	actor := &notifyHandler{
-		actions:      nil,
-		handled:      make(chan struct{}, 1),
-		handlerError: fmt.Errorf("my handling error"),
-		watcher: &testNotifyWatcher{
-			changes: make(chan struct{}),
-		},
-	}
-	w := worker.NewNotifyWorker(actor)
+	actor, w := newNotifyHandlerWorker(c, nil, fmt.Errorf("my handling error"), nil)
 	actor.watcher.TriggerChange(c)
 	waitForHandledNotify(c, actor.handled)
 	err := waitShort(c, w)

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -228,7 +228,7 @@ func (w *storageprovisioner) loop() error {
 		if err != nil {
 			return errors.Annotate(err, "watching volumes")
 		}
-		filesystemsWatcher, err := w.filesystems.WatchFilesystems()
+		filesystemsWatcher, err = w.filesystems.WatchFilesystems()
 		if err != nil {
 			return errors.Annotate(err, "watching filesystems")
 		}
@@ -236,7 +236,7 @@ func (w *storageprovisioner) loop() error {
 		if err != nil {
 			return errors.Annotate(err, "watching volume attachments")
 		}
-		filesystemAttachmentsWatcher, err := w.filesystems.WatchFilesystemAttachments()
+		filesystemAttachmentsWatcher, err = w.filesystems.WatchFilesystemAttachments()
 		if err != nil {
 			return errors.Annotate(err, "watching filesystem attachments")
 		}
@@ -278,7 +278,7 @@ func (w *storageprovisioner) loop() error {
 			return tomb.ErrDying
 		case _, ok := <-environConfigChanges:
 			if !ok {
-				return watcher.EnsureErr(volumesWatcher)
+				return watcher.EnsureErr(environConfigWatcher)
 			}
 			environConfig, err := w.environ.EnvironConfig()
 			if err != nil {


### PR DESCRIPTION
The worker tests were pure race conditions that I'm surprised ever worked anywhere with any reliability.  The storage provisioner code was buggy unintentional shadowing and a copy/paste error.  Together they made for tests that failed very reliably on my machine, as well as on the landing bot, evidently. 

(Review request: http://reviews.vapour.ws/r/1405/)