### PR TITLE
Remove SNAT rule that made container traffic look like it was coming from its host

### DIFF
--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -85,7 +85,7 @@ func (s *serverSuite) TestStop(c *gc.C) {
 	// The client has not necessarily seen the server shutdown yet,
 	// so there are two possible errors.
 	if err != rpc.ErrShutdown && err != io.ErrUnexpectedEOF {
-		c.Fatalf("unexpected error from request: %#T, expected rpc.ErrShutdown or io.ErrUnexpectedEOF", err)
+		c.Fatalf("unexpected error from request: %T, expected rpc.ErrShutdown or io.ErrUnexpectedEOF", err)
 	}
 
 	// Check it can be stopped twice.

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -85,7 +85,7 @@ func (s *serverSuite) TestStop(c *gc.C) {
 	// The client has not necessarily seen the server shutdown yet,
 	// so there are two possible errors.
 	if err != rpc.ErrShutdown && err != io.ErrUnexpectedEOF {
-		c.Fatalf("unexpected error from request: %T, expected rpc.ErrShutdown or io.ErrUnexpectedEOF", err)
+		c.Fatalf("unexpected error from request: %#v, expected rpc.ErrShutdown or io.ErrUnexpectedEOF", err)
 	}
 
 	// Check it can be stopped twice.

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -232,11 +232,7 @@ var iptablesRules = map[string]IptablesRule{
 	// need to check whether the rule exists because we only want to
 	// add it once. Exit code 0 means the rule exists, 1 means it
 	// doesn't
-	"iptablesSNAT": {
-		"nat",
-		"POSTROUTING",
-		"-o {{.HostIF}} -j SNAT --to-source {{.HostIP}}",
-	}, "iptablesForwardOut": {
+	"iptablesForwardOut": {
 		// Ensure that we have ACCEPT rules that apply to the containers that
 		// we are creating so any DROP rules added by libvirt while setting
 		// up virbr0 further down the chain don't disrupt wanted traffic.


### PR DESCRIPTION
Also fixed go vet:
apiserver/server_test.go:88: unrecognized printf flag for verb 'T': '#'.
Replaced with %T.

(Review request: http://reviews.vapour.ws/r/1408/)