### PR TITLE
Temporary fix for LP-1438489

### DIFF
--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -130,9 +130,13 @@ func (st State) validate() (err error) {
 			return errors.New("unexpected action id")
 		}
 	case Continue:
+		// TODO(jw4) LP-1438489
+		// ModeContinue should no longer have a Hook, but until the upgrade is
+		// fixed we can't fail the validation if it does.
+		if hasHook {
+			logger.Errorf("unexpected hook info with Kind Continue")
+		}
 		switch {
-		case hasHook:
-			return errors.New("unexpected hook info with Kind Continue")
 		case hasCharm:
 			return errors.New("unexpected charm URL")
 		case hasActionId:

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -166,14 +166,16 @@ var stateTests = []struct {
 		},
 	},
 	// Continue operation.
+	/* TODO(jw4) LP-1438489
+	   {
+	       st: operation.State{
+	           Kind: operation.Continue,
+	           Step: operation.Pending,
+	           Hook: &hook.Info{Kind: hooks.ConfigChanged},
+	       },
+	       err: `unexpected hook info with Kind Continue`,
+	   },*/
 	{
-		st: operation.State{
-			Kind: operation.Continue,
-			Step: operation.Pending,
-			Hook: &hook.Info{Kind: hooks.ConfigChanged},
-		},
-		err: `unexpected hook info with Kind Continue`,
-	}, {
 		st: operation.State{
 			Kind:     operation.Continue,
 			Step:     operation.Pending,


### PR DESCRIPTION
Upgrades with the new Stopped semantics in the uniter operations file
are not working as expected, indirectly causing upgrades to fail / hang
in units.

This fix converts the new error about a Hook in ModeContinue to a logged
error instead of failing the operation state validation.  Once I figure
out how to upgrade units from machines properly I'll propose a better
fix.

NB. This fix does not cause any unexpected or new behaviour, just
removes unexpected new errors.

(Review request: http://reviews.vapour.ws/r/1411/)