### PR TITLE
port HA --to work from master to 1.23

### DIFF
--- a/api/machiner/machiner.go
+++ b/api/machiner/machiner.go
@@ -4,6 +4,7 @@
 package machiner
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/api/base"
@@ -38,7 +39,7 @@ func (st *State) machineLife(tag names.MachineTag) (params.Life, error) {
 func (st *State) Machine(tag names.MachineTag) (*Machine, error) {
 	life, err := st.machineLife(tag)
 	if err != nil {
-		return nil, err
+		return nil, errors.Annotate(err, "can't get life for machine")
 	}
 	return &Machine{
 		tag:  tag,

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -54,7 +54,7 @@ func (s *machinerSuite) SetUpTest(c *gc.C) {
 
 func (s *machinerSuite) TestMachineAndMachineTag(c *gc.C) {
 	machine, err := s.machiner.Machine(names.NewMachineTag("42"))
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(err, gc.ErrorMatches, ".*permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(machine, gc.IsNil)
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -156,7 +156,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			defer st.Close()
 
 			_, err = st.Machiner().Machine(names.NewMachineTag("0"))
-			c.Assert(err, gc.ErrorMatches, `unknown object type "Machiner"`)
+			c.Assert(err, gc.ErrorMatches, `.*unknown object type "Machiner"`)
 
 			// Since these are user login tests, the nonce is empty.
 			err = st.Login(t.tag, t.password, "")
@@ -164,7 +164,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			c.Assert(params.ErrCode(err), gc.Equals, t.code)
 
 			_, err = st.Machiner().Machine(names.NewMachineTag("0"))
-			c.Assert(err, gc.ErrorMatches, `unknown object type "Machiner"`)
+			c.Assert(err, gc.ErrorMatches, `.*unknown object type "Machiner"`)
 		}()
 	}
 }
@@ -182,14 +182,14 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	u := s.Factory.MakeUser(c, &factory.UserParams{Password: password, Disabled: true})
 
 	_, err = st.Client().Status([]string{})
-	c.Assert(err, gc.ErrorMatches, `unknown object type "Client"`)
+	c.Assert(err, gc.ErrorMatches, `.*unknown object type "Client"`)
 
 	// Since these are user login tests, the nonce is empty.
 	err = st.Login(u.Tag().String(), password, "")
 	c.Assert(err, gc.ErrorMatches, "invalid entity name or password")
 
 	_, err = st.Client().Status([]string{})
-	c.Assert(err, gc.ErrorMatches, `unknown object type "Client"`)
+	c.Assert(err, gc.ErrorMatches, `.*unknown object type "Client"`)
 }
 
 func (s *loginV0Suite) TestLoginSetsLogIdentifier(c *gc.C) {
@@ -675,7 +675,7 @@ func (s *baseLoginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.Lo
 
 	// Ensure not already logged in.
 	_, err := st.Machiner().Machine(names.NewMachineTag("0"))
-	c.Assert(err, gc.ErrorMatches, `unknown object type "Machiner"`)
+	c.Assert(err, gc.ErrorMatches, `*.unknown object type "Machiner"`)
 
 	adminUser := s.AdminUserTag(c)
 	// Since these are user login tests, the nonce is empty.

--- a/apiserver/highavailability/highavailability.go
+++ b/apiserver/highavailability/highavailability.go
@@ -73,6 +73,7 @@ func stateServersChanges(change state.StateServersChanges) params.StateServersCh
 		Removed:    machineIdsToTags(change.Removed...),
 		Promoted:   machineIdsToTags(change.Promoted...),
 		Demoted:    machineIdsToTags(change.Demoted...),
+		Converted:  machineIdsToTags(change.Converted...),
 	}
 }
 

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -33,7 +33,7 @@ type clientSuite struct {
 	resources  *common.Resources
 	authoriser apiservertesting.FakeAuthorizer
 	haServer   *highavailability.HighAvailabilityAPI
-	pinger     *presence.Pinger
+	pingers    []*presence.Pinger
 
 	commontesting.BlockHelper
 }
@@ -71,13 +71,15 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// We have to ensure the agents are alive, or EnsureAvailability will
 	// create more to replace them.
-	s.pinger = s.setAgentPresence(c, "0")
+	s.pingers = []*presence.Pinger{s.setAgentPresence(c, "0")}
 	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
 	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
 }
 
 func (s *clientSuite) TearDownTest(c *gc.C) {
-	assertKill(c, s.pinger)
+	for _, pinger := range s.pingers {
+		assertKill(c, pinger)
+	}
 	s.JujuConnSuite.TearDownTest(c)
 }
 
@@ -132,6 +134,7 @@ func (s *clientSuite) TestEnsureAvailabilitySeries(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err = s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
@@ -151,6 +154,7 @@ func (s *clientSuite) TestEnsureAvailabilitySeries(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0", "machine-1", "machine-2"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-3", "machine-4"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	c.Assert(err, jc.ErrorIsNil)
 	machines, err = s.State.AllMachines()
@@ -169,6 +173,7 @@ func (s *clientSuite) TestEnsureAvailabilityConstraints(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err := s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
@@ -195,6 +200,7 @@ func (s *clientSuite) TestBlockEnsureAvailability(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.HasLen, 0)
 	c.Assert(ensureAvailabilityResult.Added, gc.HasLen, 0)
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err := s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
@@ -208,6 +214,7 @@ func (s *clientSuite) TestEnsureAvailabilityPlacement(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err := s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
@@ -226,6 +233,36 @@ func (s *clientSuite) TestEnsureAvailabilityPlacement(c *gc.C) {
 	}
 }
 
+func (s *clientSuite) TestEnsureAvailabilityPlacementTo(c *gc.C) {
+	_, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	s.pingers = append(s.pingers, s.setAgentPresence(c, "1"))
+
+	_, err = s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	s.pingers = append(s.pingers, s.setAgentPresence(c, "2"))
+
+	placement := []string{"1", "2"}
+	ensureAvailabilityResult, err := s.ensureAvailability(c, 3, emptyCons, defaultSeries, placement)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0"})
+	c.Assert(ensureAvailabilityResult.Added, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.DeepEquals, []string{"machine-1", "machine-2"})
+
+	machines, err := s.State.AllMachines()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.HasLen, 3)
+	expectedCons := []constraints.Value{{}, {}, {}}
+	expectedPlacement := []string{"", "", ""}
+	for i, m := range machines {
+		cons, err := m.Constraints()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(cons, gc.DeepEquals, expectedCons[i])
+		c.Check(m.Placement(), gc.Equals, expectedPlacement[i])
+	}
+}
+
 func (s *clientSuite) TestEnsureAvailability0Preserves(c *gc.C) {
 	// A value of 0 says either "if I'm not HA, make me HA" or "preserve my
 	// current HA settings".
@@ -234,6 +271,7 @@ func (s *clientSuite) TestEnsureAvailability0Preserves(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err := s.State.AllMachines()
 	c.Assert(machines, gc.HasLen, 3)
@@ -248,6 +286,7 @@ func (s *clientSuite) TestEnsureAvailability0Preserves(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0", "machine-1"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-3"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err = s.State.AllMachines()
 	c.Assert(machines, gc.HasLen, 4)
@@ -260,6 +299,7 @@ func (s *clientSuite) TestEnsureAvailability0Preserves5(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2", "machine-3", "machine-4"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err := s.State.AllMachines()
 	c.Assert(machines, gc.HasLen, 5)
@@ -278,6 +318,7 @@ func (s *clientSuite) TestEnsureAvailability0Preserves5(c *gc.C) {
 		"machine-2", "machine-3"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-5"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err = s.State.AllMachines()
 	c.Assert(machines, gc.HasLen, 6)
@@ -293,6 +334,7 @@ func (s *clientSuite) TestEnsureAvailabilityErrors(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.DeepEquals, []string{"machine-0"})
 	c.Assert(ensureAvailabilityResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	_, err = s.ensureAvailability(c, 1, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches, "failed to create new state server machines: cannot reduce state server count")
@@ -311,6 +353,7 @@ func (s *clientSuite) TestEnsureAvailabilityHostedEnvErrors(c *gc.C) {
 	c.Assert(ensureAvailabilityResult.Maintained, gc.HasLen, 0)
 	c.Assert(ensureAvailabilityResult.Added, gc.HasLen, 0)
 	c.Assert(ensureAvailabilityResult.Removed, gc.HasLen, 0)
+	c.Assert(ensureAvailabilityResult.Converted, gc.HasLen, 0)
 
 	machines, err := st2.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -7,16 +7,20 @@ package machine
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/multiwatcher"
 )
 
 func init() {
 	common.RegisterStandardFacade("Machiner", 0, NewMachinerAPI)
 }
+
+var logger = loggo.GetLogger("juju.apiserver.machine")
 
 // MachinerAPI implements the API used by the machiner worker.
 type MachinerAPI struct {
@@ -52,6 +56,7 @@ func NewMachinerAPI(st *state.State, resources *common.Resources, authorizer com
 		st:                 st,
 		auth:               authorizer,
 		getCanModify:       getCanModify,
+		getCanRead:         getCanRead,
 	}, nil
 }
 
@@ -91,4 +96,42 @@ func (api *MachinerAPI) SetMachineAddresses(args params.SetMachinesAddresses) (p
 		results.Results[i].Error = common.ServerError(err)
 	}
 	return results, nil
+}
+
+// Jobs returns the jobs assigned to the given entities.
+func (api *MachinerAPI) Jobs(args params.Entities) (params.JobsResults, error) {
+	result := params.JobsResults{
+		Results: make([]params.JobsResult, len(args.Entities)),
+	}
+
+	canRead, err := api.getCanRead()
+	if err != nil {
+		return result, err
+	}
+
+	for i, agent := range args.Entities {
+		tag, err := names.ParseMachineTag(agent.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+
+		if !canRead(tag) {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+
+		machine, err := api.getMachine(tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		machineJobs := machine.Jobs()
+		jobs := make([]multiwatcher.MachineJob, len(machineJobs))
+		for i, job := range machineJobs {
+			jobs[i] = job.ToParams()
+		}
+		result.Results[i].Jobs = jobs
+	}
+	return result, nil
 }

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -14,6 +14,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
 )
 
@@ -187,6 +188,24 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	err = s.machine0.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.machine0.MachineAddresses(), gc.HasLen, 0)
+}
+
+func (s *machinerSuite) TestJobs(c *gc.C) {
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "machine-1"},
+		{Tag: "machine-0"},
+		{Tag: "machine-42"},
+	}}
+
+	result, err := s.machiner.Jobs(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.JobsResults{
+		Results: []params.JobsResult{
+			{Jobs: []multiwatcher.MachineJob{multiwatcher.JobHostUnits}},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
 }
 
 func (s *machinerSuite) TestWatch(c *gc.C) {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -586,6 +586,17 @@ type RsyslogConfigResults struct {
 	Results []RsyslogConfigResult
 }
 
+// JobsResult holds the jobs for a machine that are returned by a call to Jobs.
+type JobsResult struct {
+	Jobs  []multiwatcher.MachineJob `json:"Jobs"`
+	Error *Error                    `json:"Error"`
+}
+
+// JobsResults holds the result of a call to Jobs.
+type JobsResults struct {
+	Results []JobsResult `json:"Results"`
+}
+
 // DistributionGroupResult contains the result of
 // the DistributionGroup provisioner API call.
 type DistributionGroupResult struct {
@@ -698,6 +709,7 @@ type StateServersChanges struct {
 	Removed    []string `json:"removed,omitempty"`
 	Promoted   []string `json:"promoted,omitempty"`
 	Demoted    []string `json:"demoted,omitempty"`
+	Converted  []string `json:"converted,omitempty"`
 }
 
 // FindToolsParams defines parameters for the FindTools method.

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"code.google.com/p/go.net/websocket"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -85,10 +86,11 @@ func (s *serverSuite) TestStop(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = st.Machiner().Machine(stm.Tag().(names.MachineTag))
+	err = errors.Cause(err)
 	// The client has not necessarily seen the server shutdown yet,
 	// so there are two possible errors.
 	if err != rpc.ErrShutdown && err != io.ErrUnexpectedEOF {
-		c.Fatalf("unexpected error from request: %v", err)
+		c.Fatalf("unexpected error from request: %#T, expected rpc.ErrShutdown or io.ErrUnexpectedEOF", err)
 	}
 
 	// Check it can be stopped twice.

--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -171,7 +171,13 @@ func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.
 		return nil, nil, err
 	}
 
-	if usedOldPassword {
+	if !usedOldPassword {
+		// Call set password with the current password.  If we've recently
+		// become a state server, this will fix up our credentials in mongo.
+		if err := entity.SetPassword(info.Password); err != nil {
+			return nil, nil, errors.Annotate(err, "can't reset agent password")
+		}
+	} else {
 		// We succeeded in connecting with the fallback
 		// password, so we need to create a new password
 		// for the future.
@@ -179,19 +185,8 @@ func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.
 		if err != nil {
 			return nil, nil, err
 		}
-		// Change the configuration *before* setting the entity
-		// password, so that we avoid the possibility that
-		// we might successfully change the entity's
-		// password but fail to write the configuration,
-		// thus locking us out completely.
-		if err := a.ChangeConfig(func(c agent.ConfigSetter) error {
-			c.SetPassword(newPassword)
-			c.SetOldPassword(info.Password)
-			return nil
-		}); err != nil {
-			return nil, nil, err
-		}
-		if err := entity.SetPassword(newPassword); err != nil {
+		err = setAgentPassword(newPassword, info.Password, a, entity)
+		if err != nil {
 			return nil, nil, err
 		}
 
@@ -205,6 +200,22 @@ func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.
 	}
 
 	return st, entity, err
+}
+
+func setAgentPassword(newPw, oldPw string, a Agent, entity *apiagent.Entity) error {
+	// Change the configuration *before* setting the entity
+	// password, so that we avoid the possibility that
+	// we might successfully change the entity's
+	// password but fail to write the configuration,
+	// thus locking us out completely.
+	if err := a.ChangeConfig(func(c agent.ConfigSetter) error {
+		c.SetPassword(newPw)
+		c.SetOldPassword(oldPw)
+		return nil
+	}); err != nil {
+		return err
+	}
+	return entity.SetPassword(newPw)
 }
 
 // OpenAPIStateUsingInfo opens the API using the given API

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -707,11 +707,11 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 			return worker.NewNotifyWorker(conv2state.New(st.Machiner(), a)), nil
 		})
 	}
-	
+
 	// TODO(wallyworld) - we don't want the storage workers running yet, even with feature flag.
 	// Will be enabled in a followup branch.
 	enableStorageWorkers := false
-S
+
 	if featureflag.Enabled(feature.Storage) {
 		runner.StartWorker("diskmanager", func() (worker.Worker, error) {
 			api, err := st.DiskManager()

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -618,7 +618,7 @@ func (st *State) EnsureAvailability(
 			return nil, errors.New("cannot reduce state server count")
 		}
 
-		intent, err := st.ensureAvailabilityIntentions(currentInfo)
+		intent, err := st.ensureAvailabilityIntentions(currentInfo, placement)
 		if err != nil {
 			return nil, err
 		}
@@ -636,11 +636,18 @@ func (st *State) EnsureAvailability(
 			intent.promote = intent.promote[:n]
 		}
 		voteCount += len(intent.promote)
+
+		if n := desiredStateServerCount - voteCount; n < len(intent.convert) {
+			intent.convert = intent.convert[:n]
+		}
+		voteCount += len(intent.convert)
+
 		intent.newCount = desiredStateServerCount - voteCount
-		logger.Infof("%d new machines; promoting %v", intent.newCount, intent.promote)
+
+		logger.Infof("%d new machines; promoting %v; converting %v", intent.newCount, intent.promote, intent.convert)
 
 		var ops []txn.Op
-		ops, change, err = st.ensureAvailabilityIntentionOps(intent, currentInfo, cons, series, placement)
+		ops, change, err = st.ensureAvailabilityIntentionOps(intent, currentInfo, cons, series)
 		return ops, err
 	}
 	if err := st.run(buildTxn); err != nil {
@@ -657,6 +664,7 @@ type StateServersChanges struct {
 	Maintained []string
 	Promoted   []string
 	Demoted    []string
+	Converted  []string
 }
 
 // ensureAvailabilityIntentionOps returns operations to fulfil the desired intent.
@@ -665,7 +673,6 @@ func (st *State) ensureAvailabilityIntentionOps(
 	currentInfo *StateServerInfo,
 	cons constraints.Value,
 	series string,
-	placement []string,
 ) ([]txn.Op, StateServersChanges, error) {
 	var ops []txn.Op
 	var change StateServersChanges
@@ -677,16 +684,20 @@ func (st *State) ensureAvailabilityIntentionOps(
 		ops = append(ops, demoteStateServerOps(m)...)
 		change.Demoted = append(change.Demoted, m.doc.Id)
 	}
+	for _, m := range intent.convert {
+		ops = append(ops, convertStateServerOps(m)...)
+		change.Converted = append(change.Converted, m.doc.Id)
+	}
 	// Use any placement directives that have been provided
 	// when adding new machines, until the directives have
 	// been all used up. Set up a helper function to do the
 	// work required.
 	placementCount := 0
 	getPlacement := func() string {
-		if placementCount >= len(placement) {
+		if placementCount >= len(intent.placement) {
 			return ""
 		}
-		result := placement[placementCount]
+		result := intent.placement[placementCount]
 		placementCount++
 		return result
 	}
@@ -744,8 +755,10 @@ var stateServerAvailable = func(m *Machine) (bool, error) {
 }
 
 type ensureAvailabilityIntent struct {
-	newCount                          int
-	promote, maintain, demote, remove []*Machine
+	newCount  int
+	placement []string
+
+	promote, maintain, demote, remove, convert []*Machine
 }
 
 // ensureAvailabilityIntentions returns what we would like
@@ -754,8 +767,40 @@ type ensureAvailabilityIntent struct {
 //   demoting unavailable, voting machines;
 //   removing unavailable, non-voting, non-vote-holding machines;
 //   gathering available, non-voting machines that may be promoted;
-func (st *State) ensureAvailabilityIntentions(info *StateServerInfo) (*ensureAvailabilityIntent, error) {
+func (st *State) ensureAvailabilityIntentions(info *StateServerInfo, placement []string) (*ensureAvailabilityIntent, error) {
 	var intent ensureAvailabilityIntent
+	for _, s := range placement {
+		// TODO(natefinch): unscoped placements shouldn't ever get here (though
+		// they do currently).  We should fix up the CLI to always add a scope
+		// to placements and then we can remove the need to deal with unscoped
+		// placements.
+		p, err := instance.ParsePlacement(s)
+		if err == instance.ErrPlacementScopeMissing {
+			intent.placement = append(intent.placement, s)
+			continue
+		}
+		if err == nil && p.Scope == instance.MachineScope {
+			// TODO(natefinch) add env provider policy to check if conversion is
+			// possible (e.g. cannot be supported by Azure in HA mode).
+
+			if names.IsContainerMachine(p.Directive) {
+				return nil, errors.New("container placement directives not supported")
+			}
+
+			m, err := st.Machine(p.Directive)
+			if err != nil {
+				return nil, errors.Annotatef(err, "can't find machine for placement directive %q", s)
+			}
+			if m.IsManager() {
+				return nil, errors.Errorf("machine for placement directive %q is already a state server", s)
+			}
+			intent.convert = append(intent.convert, m)
+			intent.placement = append(intent.placement, s)
+			continue
+		}
+		return nil, errors.Errorf("unsupported placement directive %q", s)
+	}
+
 	for _, mid := range info.MachineIds {
 		m, err := st.Machine(mid)
 		if err != nil {
@@ -790,8 +835,28 @@ func (st *State) ensureAvailabilityIntentions(info *StateServerInfo) (*ensureAva
 			intent.remove = append(intent.remove, m)
 		}
 	}
-	logger.Infof("initial intentions: promote %v; maintain %v; demote %v; remove %v", intent.promote, intent.maintain, intent.demote, intent.remove)
+	logger.Infof("initial intentions: promote %v; maintain %v; demote %v; remove %v; convert: %v",
+		intent.promote, intent.maintain, intent.demote, intent.remove, intent.convert)
 	return &intent, nil
+}
+
+func convertStateServerOps(m *Machine) []txn.Op {
+	return []txn.Op{{
+		C:  machinesC,
+		Id: m.doc.DocID,
+		Update: bson.D{
+			{"$addToSet", bson.D{{"jobs", JobManageEnviron}}},
+			{"$set", bson.D{{"novote", false}}},
+		},
+		Assert: bson.D{{"jobs", bson.D{{"$nin", []MachineJob{JobManageEnviron}}}}},
+	}, {
+		C:  stateServersC,
+		Id: environGlobalKey,
+		Update: bson.D{
+			{"$addToSet", bson.D{{"votingmachineids", m.doc.Id}}},
+			{"$addToSet", bson.D{{"machineids", m.doc.Id}}},
+		},
+	}}
 }
 
 func promoteStateServerOps(m *Machine) []txn.Op {

--- a/worker/conv2state/converter.go
+++ b/worker/conv2state/converter.go
@@ -1,0 +1,96 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package conv2state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	apimachiner "github.com/juju/juju/api/machiner"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/worker"
+)
+
+var logger = loggo.GetLogger("juju.worker.conv2state")
+
+// New returns a new notify watch handler that will convert the given machine &
+// agent to a state server.
+func New(m *apimachiner.State, agent Agent) worker.NotifyWatchHandler {
+	return &converter{machiner: wrapper{m}, agent: agent}
+}
+
+// converter is a NotifyWatchHandler that converts a unit hosting machine to a
+// state machine.
+type converter struct {
+	agent    Agent
+	machiner machiner
+	machine  machine
+}
+
+// Agent is an interface that can have its password set and be told to restart.
+type Agent interface {
+	Restart() error
+	Tag() names.Tag
+}
+
+// machiner is a type that creates machines from a tag.
+type machiner interface {
+	Machine(tag names.MachineTag) (machine, error)
+}
+
+// machine is a type that has a list of jobs and can be watched.
+type machine interface {
+	Jobs() (*params.JobsResult, error)
+	Watch() (watcher.NotifyWatcher, error)
+}
+
+// wrapper is a wrapper around api/machiner.State to match the (local) machiner
+// interface.
+type wrapper struct {
+	m *apimachiner.State
+}
+
+// Machines implements machiner.Machine and returns a machine from the wrapper
+// api/machiner.
+func (w wrapper) Machine(tag names.MachineTag) (machine, error) {
+	m, err := w.m.Machine(tag)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// SetUp implements NotifyWatchHandler's SetUp method. It returns a watcher that
+// checks for changes to the current machine.
+func (c *converter) SetUp() (watcher.NotifyWatcher, error) {
+	m, err := c.machiner.Machine(c.agent.Tag().(names.MachineTag))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c.machine = m
+	return m.Watch()
+}
+
+// Handle implements NotifyWatchHandler's Handle method.  If the change means
+// that the machine is now expected to manage the environment, we change its
+// password (to set its password in mongo) and restart the agent.
+func (c *converter) Handle() error {
+	results, err := c.machine.Jobs()
+	if err != nil {
+		return errors.Annotate(err, "can't get jobs for machine")
+	}
+	if !multiwatcher.AnyJobNeedsState(results.Jobs...) {
+		return nil
+	}
+
+	return errors.Trace(c.agent.Restart())
+}
+
+// TearDown implements NotifyWatchHandler's TearDown method.
+func (c *converter) TearDown() error {
+	return nil
+}

--- a/worker/conv2state/converter_test.go
+++ b/worker/conv2state/converter_test.go
@@ -1,0 +1,128 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package conv2state
+
+import (
+	stderrs "errors"
+	"testing"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/multiwatcher"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&Suite{})
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type Suite struct {
+	coretesting.BaseSuite
+}
+
+func (Suite) TestSetUp(c *gc.C) {
+	a := &fakeAgent{tag: names.NewMachineTag("1")}
+	m := &fakeMachine{}
+	mr := &fakeMachiner{m: m}
+	conv := converter{machiner: mr, agent: a}
+	w, err := conv.SetUp()
+	c.Assert(err, gc.IsNil)
+	c.Assert(conv.machine, gc.Equals, m)
+	c.Assert(mr.gotTag, gc.Equals, a.tag.(names.MachineTag))
+	c.Assert(w, gc.Equals, m.w)
+}
+
+func (Suite) TestSetupMachinerErr(c *gc.C) {
+	a := &fakeAgent{tag: names.NewMachineTag("1")}
+	mr := &fakeMachiner{err: stderrs.New("foo")}
+	conv := converter{machiner: mr, agent: a}
+	w, err := conv.SetUp()
+	c.Assert(errors.Cause(err), gc.Equals, mr.err)
+	c.Assert(mr.gotTag, gc.Equals, a.tag.(names.MachineTag))
+	c.Assert(w, gc.IsNil)
+}
+
+func (Suite) TestSetupWatchErr(c *gc.C) {
+	a := &fakeAgent{tag: names.NewMachineTag("1")}
+	m := &fakeMachine{watchErr: stderrs.New("foo")}
+	mr := &fakeMachiner{m: m}
+	conv := &converter{machiner: mr, agent: a}
+	w, err := conv.SetUp()
+	c.Assert(errors.Cause(err), gc.Equals, m.watchErr)
+	c.Assert(mr.gotTag, gc.Equals, a.tag.(names.MachineTag))
+	c.Assert(w, gc.IsNil)
+}
+
+func (s Suite) TestHandle(c *gc.C) {
+	a := &fakeAgent{tag: names.NewMachineTag("1")}
+	jobs := []multiwatcher.MachineJob{multiwatcher.JobHostUnits, multiwatcher.JobManageEnviron}
+	m := &fakeMachine{
+		jobs: &params.JobsResult{Jobs: jobs},
+	}
+	mr := &fakeMachiner{m: m}
+	conv := &converter{machiner: mr, agent: a}
+	_, err := conv.SetUp()
+	c.Assert(err, gc.IsNil)
+	err = conv.Handle()
+	c.Assert(err, gc.IsNil)
+	c.Assert(a.didRestart, jc.IsTrue)
+}
+
+func (s Suite) TestHandleNoManageEnviron(c *gc.C) {
+	a := &fakeAgent{tag: names.NewMachineTag("1")}
+	jobs := []multiwatcher.MachineJob{multiwatcher.JobHostUnits}
+	m := &fakeMachine{
+		jobs: &params.JobsResult{Jobs: jobs},
+	}
+	mr := &fakeMachiner{m: m}
+	conv := &converter{machiner: mr, agent: a}
+	_, err := conv.SetUp()
+	c.Assert(err, gc.IsNil)
+	err = conv.Handle()
+	c.Assert(err, gc.IsNil)
+	c.Assert(a.didRestart, jc.IsFalse)
+}
+
+func (Suite) TestHandleJobsError(c *gc.C) {
+	a := &fakeAgent{tag: names.NewMachineTag("1")}
+	jobs := []multiwatcher.MachineJob{multiwatcher.JobHostUnits, multiwatcher.JobManageEnviron}
+	m := &fakeMachine{
+		jobs:    &params.JobsResult{Jobs: jobs},
+		jobsErr: errors.New("foo"),
+	}
+	mr := &fakeMachiner{m: m}
+	conv := &converter{machiner: mr, agent: a}
+	_, err := conv.SetUp()
+	c.Assert(err, gc.IsNil)
+	err = conv.Handle()
+	c.Assert(errors.Cause(err), gc.Equals, m.jobsErr)
+	c.Assert(a.didRestart, jc.IsFalse)
+}
+
+func (s Suite) TestHandleRestartError(c *gc.C) {
+	a := &fakeAgent{
+		tag:        names.NewMachineTag("1"),
+		restartErr: errors.New("foo"),
+	}
+	jobs := []multiwatcher.MachineJob{multiwatcher.JobHostUnits, multiwatcher.JobManageEnviron}
+	m := &fakeMachine{
+		jobs: &params.JobsResult{Jobs: jobs},
+	}
+	mr := &fakeMachiner{m: m}
+	conv := &converter{machiner: mr, agent: a}
+	_, err := conv.SetUp()
+	c.Assert(err, gc.IsNil)
+	err = conv.Handle()
+	c.Assert(errors.Cause(err), gc.Equals, a.restartErr)
+
+	// We set this to true whenver the function is called, even though we're
+	// returning an error from it.
+	c.Assert(a.didRestart, jc.IsTrue)
+}

--- a/worker/conv2state/fakes_test.go
+++ b/worker/conv2state/fakes_test.go
@@ -1,0 +1,69 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package conv2state
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type fakeMachiner struct {
+	m      machine
+	err    error
+	gotTag names.MachineTag
+}
+
+func (f *fakeMachiner) Machine(tag names.MachineTag) (machine, error) {
+	f.gotTag = tag
+	return f.m, f.err
+}
+
+type fakeMachine struct {
+	jobs     *params.JobsResult
+	jobsErr  error
+	watchErr error
+	w        fakeWatcher
+}
+
+func (f fakeMachine) Jobs() (*params.JobsResult, error) {
+	return f.jobs, f.jobsErr
+}
+
+func (f fakeMachine) Watch() (watcher.NotifyWatcher, error) {
+	if f.watchErr == nil {
+		return f.w, nil
+	}
+	return nil, f.watchErr
+}
+
+type fakeWatcher struct{}
+
+func (fakeWatcher) Changes() <-chan struct{} {
+	return nil
+}
+
+func (fakeWatcher) Stop() error {
+	return nil
+}
+
+func (fakeWatcher) Err() error {
+	return nil
+}
+
+type fakeAgent struct {
+	tag        names.Tag
+	restartErr error
+	didRestart bool
+}
+
+func (f *fakeAgent) Restart() error {
+	f.didRestart = true
+	return f.restartErr
+}
+
+func (f fakeAgent) Tag() names.Tag {
+	return f.tag
+}


### PR DESCRIPTION
backport of implement targeting existing machines for ensure-availability #1962

Special thanks to katco for getting me the right cherry-pick command to make this possible.


(Review request: http://reviews.vapour.ws/r/1414/)