### PR TITLE
Add support for displaying service status

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -97,6 +97,7 @@ type ServiceStatus struct {
 	CanUpgradeTo  string
 	SubordinateTo []string
 	Units         map[string]UnitStatus
+	Status        AgentStatus
 }
 
 // UnitStatus holds status info about a unit.

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -228,6 +228,11 @@ var scenarioStatus = &api.Status{
 				"logging-dir": {"logging"},
 			},
 			SubordinateTo: []string{},
+			Status: api.AgentStatus{
+				Status: "error",
+				Info:   "blam",
+				Data:   map[string]interface{}{"remote-unit": "logging/0", "foo": "bar", "relation-id": "0"},
+			},
 			Units: map[string]api.UnitStatus{
 				"wordpress/0": {
 					Workload: api.AgentStatus{
@@ -237,6 +242,7 @@ var scenarioStatus = &api.Status{
 					},
 					UnitAgent: api.AgentStatus{
 						Status: "idle",
+						Data:   make(map[string]interface{}),
 					},
 					AgentState:     "error",
 					AgentStateInfo: "blam",

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -584,6 +584,7 @@ func clearSinceTimes(status *api.Status) {
 			}
 			service.Units[unitId] = unit
 		}
+		service.Status.Since = nil
 		status.Services[serviceId] = service
 	}
 	for id, machine := range status.Machines {

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -604,7 +604,7 @@ func processUnitAndAgentStatus(unit *state.Unit, status *api.UnitStatus) {
 			status.Workload.Status, status.UnitAgent.Status)
 	}
 	if status.AgentState == params.StatusError {
-		status.AgentStateInfo = status.UnitAgent.Info
+		status.AgentStateInfo = status.Workload.Info
 	}
 	status.AgentVersion = status.UnitAgent.Version
 	status.Life = status.UnitAgent.Life

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -503,6 +503,15 @@ func (context *statusContext) processService(service *state.Service) (status api
 	}
 	if service.IsPrincipal() {
 		status.Units = context.processUnits(context.units[service.Name()], serviceCharmURL.String())
+		serviceStatus, err := service.Status()
+		if err != nil {
+			status.Err = err
+			return
+		}
+		status.Status.Status = params.Status(serviceStatus.Status)
+		status.Status.Info = serviceStatus.Message
+		status.Status.Data = serviceStatus.Data
+		status.Status.Since = serviceStatus.Since
 	}
 	return status
 }
@@ -600,18 +609,6 @@ func processUnitAndAgentStatus(unit *state.Unit, status *api.UnitStatus) {
 	status.AgentVersion = status.UnitAgent.Version
 	status.Life = status.UnitAgent.Life
 	status.Err = status.UnitAgent.Err
-
-	// The current health spec says when a hook error occurs, the workload should
-	// be in error state, but the state model more correctly records the agent
-	// itself as being in error. So we'll do that model translation here.
-	if status.UnitAgent.Status == params.StatusError {
-		status.Workload.Status = status.UnitAgent.Status
-		status.Workload.Info = status.UnitAgent.Info
-		status.Workload.Data = status.UnitAgent.Data
-		status.UnitAgent.Status = params.StatusIdle
-		status.UnitAgent.Info = ""
-		status.UnitAgent.Data = nil
-	}
 
 	processUnitLost(unit, status)
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -775,6 +775,8 @@ func TranslateToLegacyAgentState(workloadStatus, agentStatus Status) (Status, bo
 		return StatusError, true
 	case StatusRebooting, StatusExecuting, StatusIdle, StatusLost, StatusFailed:
 		switch workloadStatus {
+		case StatusError:
+			return StatusError, true
 		case StatusTerminated:
 			return StatusStopped, true
 		case StatusMaintenance:

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -186,6 +186,7 @@ type serviceStatus struct {
 	CanUpgradeTo  string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`
 	Exposed       bool                  `json:"exposed" yaml:"exposed"`
 	Life          string                `json:"life,omitempty" yaml:"life,omitempty"`
+	StatusInfo    statusInfoContents    `json:"service-status,omitempty" yaml:"service-status,omitempty"`
 	Relations     map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
 	Networks      map[string][]string   `json:"networks,omitempty" yaml:"networks,omitempty"`
 	SubordinateTo []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
@@ -399,6 +400,7 @@ func (sf *statusFormatter) formatService(name string, service api.ServiceStatus)
 		CanUpgradeTo:  service.CanUpgradeTo,
 		SubordinateTo: service.SubordinateTo,
 		Units:         make(map[string]unitStatus),
+		StatusInfo:    sf.getServiceStatusInfo(service),
 	}
 	if len(service.Networks.Enabled) > 0 {
 		out.Networks["enabled"] = service.Networks.Enabled
@@ -410,6 +412,19 @@ func (sf *statusFormatter) formatService(name string, service api.ServiceStatus)
 		out.Units[k] = sf.formatUnit(m, name)
 	}
 	return out
+}
+
+func (sf *statusFormatter) getServiceStatusInfo(service api.ServiceStatus) statusInfoContents {
+	info := statusInfoContents{
+		Err:     service.Status.Err,
+		Current: service.Status.Status,
+		Message: service.Status.Info,
+		Version: service.Status.Version,
+	}
+	if service.Status.Since != nil {
+		info.Since = service.Status.Since.Local().Format(time.RFC822)
+	}
+	return info
 }
 
 func (sf *statusFormatter) formatUnit(unit api.UnitStatus, serviceName string) unitStatus {

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -414,6 +414,10 @@ func (sf *statusFormatter) formatService(name string, service api.ServiceStatus)
 	return out
 }
 
+func formatTime(t *time.Time) string {
+	return t.Local().Format(time.RFC822)
+}
+
 func (sf *statusFormatter) getServiceStatusInfo(service api.ServiceStatus) statusInfoContents {
 	info := statusInfoContents{
 		Err:     service.Status.Err,
@@ -422,7 +426,7 @@ func (sf *statusFormatter) getServiceStatusInfo(service api.ServiceStatus) statu
 		Version: service.Status.Version,
 	}
 	if service.Status.Since != nil {
-		info.Since = service.Status.Since.Local().Format(time.RFC822)
+		info.Since = formatTime(service.Status.Since)
 	}
 	return info
 }
@@ -464,7 +468,7 @@ func (sf *statusFormatter) getWorkloadStatusInfo(unit api.UnitStatus) statusInfo
 		Version: unit.Workload.Version,
 	}
 	if unit.Workload.Since != nil {
-		info.Since = unit.Workload.Since.Local().Format(time.RFC822)
+		info.Since = formatTime(unit.Workload.Since)
 	}
 	return info
 }
@@ -477,7 +481,7 @@ func (sf *statusFormatter) getAgentStatusInfo(unit api.UnitStatus) statusInfoCon
 		Version: unit.UnitAgent.Version,
 	}
 	if unit.UnitAgent.Since != nil {
-		info.Since = unit.UnitAgent.Since.Local().Format(time.RFC822)
+		info.Since = formatTime(unit.UnitAgent.Since)
 	}
 	return info
 }

--- a/cmd/juju/status_formatters.go
+++ b/cmd/juju/status_formatters.go
@@ -82,13 +82,13 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	units := make(map[string]unitStatus)
 
 	p("\n[Services]")
-	p("NAME\tEXPOSED\tCHARM")
+	p("NAME\tSTATUS\tEXPOSED\tCHARM")
 	for _, svcName := range sortStringsNaturally(stringKeysFromMap(fs.Services)) {
 		svc := fs.Services[svcName]
 		for un, u := range svc.Units {
 			units[un] = u
 		}
-		p(svcName, fmt.Sprintf("%t", svc.Exposed), svc.Charm)
+		p(svcName, svc.StatusInfo.Current, fmt.Sprintf("%t", svc.Exposed), svc.Charm)
 	}
 	tw.Flush()
 

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -211,12 +211,14 @@ var (
 		"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 	}
 	unexposedService = M{
-		"charm":   "cs:quantal/dummy-1",
-		"exposed": false,
+		"service-status": M{},
+		"charm":          "cs:quantal/dummy-1",
+		"exposed":        false,
 	}
 	exposedService = M{
-		"charm":   "cs:quantal/dummy-1",
-		"exposed": true,
+		"service-status": M{},
+		"charm":          "cs:quantal/dummy-1",
+		"exposed":        true,
 	}
 )
 
@@ -353,16 +355,18 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"networks-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": false,
+						"service-status": M{},
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        false,
 						"networks": M{
 							"enabled":  L{"net1", "net2"},
 							"disabled": L{"foo", "bar", "no", "good"},
 						},
 					},
 					"no-networks-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": false,
+						"service-status": M{},
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        false,
 						"networks": M{
 							"disabled": L{"mynet"},
 						},
@@ -557,6 +561,11 @@ var statusTests = []testCase{
 					"exposed-service": M{
 						"charm":   "cs:quantal/dummy-1",
 						"exposed": true,
+						"service-status": M{
+							"current": "error",
+							"message": "You Require More Vespene Gas",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -581,6 +590,10 @@ var statusTests = []testCase{
 					"dummy-service": M{
 						"charm":   "cs:quantal/dummy-1",
 						"exposed": false,
+						"service-status": M{
+							"current": "terminated",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -645,8 +658,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"exposed-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": true,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -669,8 +683,9 @@ var statusTests = []testCase{
 						},
 					},
 					"dummy-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": false,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        false,
+						"service-status": M{},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -702,8 +717,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": false,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        false,
+						"service-status": M{},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -734,8 +750,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"exposed-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": true,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -770,8 +787,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": false,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        false,
+						"service-status": M{},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -802,8 +820,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"exposed-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": true,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -839,8 +858,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": false,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        false,
+						"service-status": M{},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -859,8 +879,9 @@ var statusTests = []testCase{
 						},
 					},
 					"exposed-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": true,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -926,6 +947,7 @@ var statusTests = []testCase{
 						"relations": M{
 							"db": L{"mysql"},
 						},
+						"service-status": M{},
 						"units": M{
 							"wordpress/0": M{
 								"machine":          "1",
@@ -950,6 +972,7 @@ var statusTests = []testCase{
 						"relations": M{
 							"server": L{"wordpress"},
 						},
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1011,6 +1034,7 @@ var statusTests = []testCase{
 						"relations": M{
 							"db": L{"mysql"},
 						},
+						"service-status": M{},
 						"units": M{
 							"wordpress/0": M{
 								"machine":          "1",
@@ -1035,6 +1059,7 @@ var statusTests = []testCase{
 						"relations": M{
 							"server": L{"wordpress"},
 						},
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1074,9 +1099,10 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": false,
-						"life":    "dying",
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        false,
+						"life":           "dying",
+						"service-status": M{},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "0",
@@ -1120,8 +1146,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":   "cs:quantal/dummy-1",
-						"exposed": false,
+						"charm":          "cs:quantal/dummy-1",
+						"exposed":        false,
+						"service-status": M{},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "0",
@@ -1208,8 +1235,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"project": M{
-						"charm":   "cs:quantal/wordpress-3",
-						"exposed": true,
+						"charm":          "cs:quantal/wordpress-3",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"project/0": M{
 								"machine":     "1",
@@ -1231,8 +1259,9 @@ var statusTests = []testCase{
 						},
 					},
 					"mysql": M{
-						"charm":   "cs:quantal/mysql-1",
-						"exposed": true,
+						"charm":          "cs:quantal/mysql-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "2",
@@ -1253,8 +1282,9 @@ var statusTests = []testCase{
 						},
 					},
 					"varnish": M{
-						"charm":   "cs:quantal/varnish-1",
-						"exposed": true,
+						"charm":          "cs:quantal/varnish-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"varnish/0": M{
 								"machine":     "3",
@@ -1276,8 +1306,9 @@ var statusTests = []testCase{
 						},
 					},
 					"private": M{
-						"charm":   "cs:quantal/wordpress-3",
-						"exposed": true,
+						"charm":          "cs:quantal/wordpress-3",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"private/0": M{
 								"machine":     "4",
@@ -1346,8 +1377,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"riak": M{
-						"charm":   "cs:quantal/riak-7",
-						"exposed": true,
+						"charm":          "cs:quantal/riak-7",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"riak/0": M{
 								"machine":     "1",
@@ -1455,8 +1487,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"wordpress": M{
-						"charm":   "cs:quantal/wordpress-3",
-						"exposed": true,
+						"charm":          "cs:quantal/wordpress-3",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"wordpress/0": M{
 								"machine":     "1",
@@ -1492,8 +1525,9 @@ var statusTests = []testCase{
 						},
 					},
 					"mysql": M{
-						"charm":   "cs:quantal/mysql-1",
-						"exposed": true,
+						"charm":          "cs:quantal/mysql-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "2",
@@ -1555,8 +1589,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"wordpress": M{
-						"charm":   "cs:quantal/wordpress-3",
-						"exposed": true,
+						"charm":          "cs:quantal/wordpress-3",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"wordpress/0": M{
 								"machine":     "1",
@@ -1592,8 +1627,9 @@ var statusTests = []testCase{
 						},
 					},
 					"mysql": M{
-						"charm":   "cs:quantal/mysql-1",
-						"exposed": true,
+						"charm":          "cs:quantal/mysql-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "2",
@@ -1654,8 +1690,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"wordpress": M{
-						"charm":   "cs:quantal/wordpress-3",
-						"exposed": true,
+						"charm":          "cs:quantal/wordpress-3",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"wordpress/0": M{
 								"machine":     "1",
@@ -1747,8 +1784,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"mysql": M{
-						"charm":   "cs:quantal/mysql-1",
-						"exposed": true,
+						"charm":          "cs:quantal/mysql-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1807,8 +1845,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"mysql": M{
-						"charm":   "cs:quantal/mysql-1",
-						"exposed": true,
+						"charm":          "cs:quantal/mysql-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/1": M{
 								"machine":     "1/lxc/0",
@@ -1857,6 +1896,7 @@ var statusTests = []testCase{
 						"charm":          "cs:quantal/mysql-1",
 						"can-upgrade-to": "cs:quantal/mysql-23",
 						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1905,8 +1945,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"mysql": M{
-						"charm":   "local:quantal/mysql-1",
-						"exposed": true,
+						"charm":          "local:quantal/mysql-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1959,6 +2000,7 @@ var statusTests = []testCase{
 						"charm":          "cs:quantal/mysql-2",
 						"can-upgrade-to": "cs:quantal/mysql-23",
 						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -2008,8 +2050,9 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"mysql": M{
-						"charm":   "local:quantal/mysql-1",
-						"exposed": true,
+						"charm":          "local:quantal/mysql-1",
+						"exposed":        true,
+						"service-status": M{},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -2629,6 +2672,7 @@ func (s *StatusSuite) TestStatusWithPreRelationsServer(c *gc.C) {
 					"relations": M{
 						"server": L{"wordpress"},
 					},
+					"service-status": M{},
 					"units": M{
 						"mysql/0": M{
 							"machine":         "1",
@@ -2644,6 +2688,7 @@ func (s *StatusSuite) TestStatusWithPreRelationsServer(c *gc.C) {
 					"relations": M{
 						"db": L{"mysql"},
 					},
+					"service-status": M{},
 					"units": M{
 						"wordpress/0": M{
 							"machine":          "1",
@@ -2873,10 +2918,10 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 			"2          started         dummyenv-2.dns dummyenv-2 quantal arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M \n"+
 			"\n"+
 			"[Services] \n"+
-			"NAME       EXPOSED CHARM                  \n"+
-			"logging    true    cs:quantal/logging-1   \n"+
-			"mysql      true    cs:quantal/mysql-1     \n"+
-			"wordpress  true    cs:quantal/wordpress-3 \n"+
+			"NAME       STATUS      EXPOSED CHARM                  \n"+
+			"logging                true    cs:quantal/logging-1   \n"+
+			"mysql      maintenance true    cs:quantal/mysql-1     \n"+
+			"wordpress  active      true    cs:quantal/wordpress-3 \n"+
 			"\n"+
 			"[Units]     \n"+
 			"ID          WORKLOAD-STATE            AGENT-STATE VERSION MACHINE PORTS PUBLIC-ADDRESS \n"+

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -658,9 +658,13 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"exposed-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "error",
+							"message": "You Require More Vespene Gas",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -683,9 +687,12 @@ var statusTests = []testCase{
 						},
 					},
 					"dummy-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        false,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": false,
+						"service-status": M{
+							"current": "terminated",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -717,9 +724,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        false,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": false,
+						"service-status": M{
+							"current": "terminated",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -750,9 +760,13 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"exposed-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "error",
+							"message": "You Require More Vespene Gas",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -787,9 +801,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        false,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": false,
+						"service-status": M{
+							"current": "terminated",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -820,9 +837,13 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"exposed-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "error",
+							"message": "You Require More Vespene Gas",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -858,9 +879,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        false,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": false,
+						"service-status": M{
+							"current": "terminated",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "1",
@@ -879,9 +903,13 @@ var statusTests = []testCase{
 						},
 					},
 					"exposed-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "error",
+							"message": "You Require More Vespene Gas",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"exposed-service/0": M{
 								"machine":          "2",
@@ -947,7 +975,11 @@ var statusTests = []testCase{
 						"relations": M{
 							"db": L{"mysql"},
 						},
-						"service-status": M{},
+						"service-status": M{
+							"current": "error",
+							"message": "hook failed: some-relation-changed",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"wordpress/0": M{
 								"machine":          "1",
@@ -972,7 +1004,11 @@ var statusTests = []testCase{
 						"relations": M{
 							"server": L{"wordpress"},
 						},
-						"service-status": M{},
+						"service-status": M{
+							"current": "unknown",
+							"message": "Waiting for agent initialization to finish",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1034,7 +1070,11 @@ var statusTests = []testCase{
 						"relations": M{
 							"db": L{"mysql"},
 						},
-						"service-status": M{},
+						"service-status": M{
+							"current": "error",
+							"message": "hook failed: some-relation-changed",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"wordpress/0": M{
 								"machine":          "1",
@@ -1059,7 +1099,11 @@ var statusTests = []testCase{
 						"relations": M{
 							"server": L{"wordpress"},
 						},
-						"service-status": M{},
+						"service-status": M{
+							"current": "unknown",
+							"message": "Waiting for agent initialization to finish",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1099,10 +1143,14 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        false,
-						"life":           "dying",
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": false,
+						"life":    "dying",
+						"service-status": M{
+							"current": "unknown",
+							"message": "Waiting for agent initialization to finish",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "0",
@@ -1146,9 +1194,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"dummy-service": M{
-						"charm":          "cs:quantal/dummy-1",
-						"exposed":        false,
-						"service-status": M{},
+						"charm":   "cs:quantal/dummy-1",
+						"exposed": false,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"dummy-service/0": M{
 								"machine":     "0",
@@ -1235,9 +1286,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"project": M{
-						"charm":          "cs:quantal/wordpress-3",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/wordpress-3",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"project/0": M{
 								"machine":     "1",
@@ -1259,9 +1313,12 @@ var statusTests = []testCase{
 						},
 					},
 					"mysql": M{
-						"charm":          "cs:quantal/mysql-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/mysql-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "2",
@@ -1282,9 +1339,13 @@ var statusTests = []testCase{
 						},
 					},
 					"varnish": M{
-						"charm":          "cs:quantal/varnish-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/varnish-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "unknown",
+							"message": "Waiting for agent initialization to finish",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"varnish/0": M{
 								"machine":     "3",
@@ -1306,9 +1367,13 @@ var statusTests = []testCase{
 						},
 					},
 					"private": M{
-						"charm":          "cs:quantal/wordpress-3",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/wordpress-3",
+						"exposed": true,
+						"service-status": M{
+							"current": "unknown",
+							"message": "Waiting for agent initialization to finish",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"private/0": M{
 								"machine":     "4",
@@ -1377,9 +1442,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"riak": M{
-						"charm":          "cs:quantal/riak-7",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/riak-7",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"riak/0": M{
 								"machine":     "1",
@@ -1487,9 +1555,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"wordpress": M{
-						"charm":          "cs:quantal/wordpress-3",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/wordpress-3",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"wordpress/0": M{
 								"machine":     "1",
@@ -1525,9 +1596,12 @@ var statusTests = []testCase{
 						},
 					},
 					"mysql": M{
-						"charm":          "cs:quantal/mysql-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/mysql-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "2",
@@ -1565,8 +1639,9 @@ var statusTests = []testCase{
 						},
 					},
 					"logging": M{
-						"charm":   "cs:quantal/logging-1",
-						"exposed": true,
+						"charm":          "cs:quantal/logging-1",
+						"exposed":        true,
+						"service-status": M{},
 						"relations": M{
 							"logging-directory": L{"wordpress"},
 							"info":              L{"mysql"},
@@ -1589,9 +1664,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"wordpress": M{
-						"charm":          "cs:quantal/wordpress-3",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/wordpress-3",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"wordpress/0": M{
 								"machine":     "1",
@@ -1627,9 +1705,12 @@ var statusTests = []testCase{
 						},
 					},
 					"mysql": M{
-						"charm":          "cs:quantal/mysql-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/mysql-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "2",
@@ -1667,8 +1748,9 @@ var statusTests = []testCase{
 						},
 					},
 					"logging": M{
-						"charm":   "cs:quantal/logging-1",
-						"exposed": true,
+						"charm":          "cs:quantal/logging-1",
+						"exposed":        true,
+						"service-status": M{},
 						"relations": M{
 							"logging-directory": L{"wordpress"},
 							"info":              L{"mysql"},
@@ -1690,9 +1772,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"wordpress": M{
-						"charm":          "cs:quantal/wordpress-3",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/wordpress-3",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"wordpress/0": M{
 								"machine":     "1",
@@ -1728,8 +1813,9 @@ var statusTests = []testCase{
 						},
 					},
 					"logging": M{
-						"charm":   "cs:quantal/logging-1",
-						"exposed": true,
+						"charm":          "cs:quantal/logging-1",
+						"exposed":        true,
+						"service-status": M{},
 						"relations": M{
 							"logging-directory": L{"wordpress"},
 							"info":              L{"mysql"},
@@ -1784,9 +1870,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"mysql": M{
-						"charm":          "cs:quantal/mysql-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/mysql-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1845,9 +1934,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"mysql": M{
-						"charm":          "cs:quantal/mysql-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "cs:quantal/mysql-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/1": M{
 								"machine":     "1/lxc/0",
@@ -1896,7 +1988,11 @@ var statusTests = []testCase{
 						"charm":          "cs:quantal/mysql-1",
 						"can-upgrade-to": "cs:quantal/mysql-23",
 						"exposed":        true,
-						"service-status": M{},
+						"service-status": M{
+							"current": "unknown",
+							"message": "Waiting for agent initialization to finish",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -1945,9 +2041,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"mysql": M{
-						"charm":          "local:quantal/mysql-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "local:quantal/mysql-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -2000,7 +2099,10 @@ var statusTests = []testCase{
 						"charm":          "cs:quantal/mysql-2",
 						"can-upgrade-to": "cs:quantal/mysql-23",
 						"exposed":        true,
-						"service-status": M{},
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",
@@ -2050,9 +2152,12 @@ var statusTests = []testCase{
 				},
 				"services": M{
 					"mysql": M{
-						"charm":          "local:quantal/mysql-1",
-						"exposed":        true,
-						"service-status": M{},
+						"charm":   "local:quantal/mysql-1",
+						"exposed": true,
+						"service-status": M{
+							"current": "active",
+							"since":   "01 Apr 15 01:23 AEST",
+						},
 						"units": M{
 							"mysql/0": M{
 								"machine":     "1",

--- a/state/service.go
+++ b/state/service.go
@@ -29,7 +29,7 @@ type Service struct {
 }
 
 // serviceDoc represents the internal state of a service in MongoDB.
-// Note the correspondence with ServiceInfo in apiserver/
+// Note the correspondence with ServiceInfo in apiserver.
 type serviceDoc struct {
 	DocID             string     `bson:"_id"`
 	Name              string     `bson:"name"`

--- a/state/service.go
+++ b/state/service.go
@@ -29,7 +29,7 @@ type Service struct {
 }
 
 // serviceDoc represents the internal state of a service in MongoDB.
-// Note the correspondence with ServiceInfo in apiserver/params.
+// Note the correspondence with ServiceInfo in apiserver/
 type serviceDoc struct {
 	DocID             string     `bson:"_id"`
 	Name              string     `bson:"name"`
@@ -1033,4 +1033,59 @@ func settingsDecRefOps(st *State, serviceName string, curl *charm.URL) ([]txn.Op
 type settingsRefsDoc struct {
 	RefCount int
 	EnvUUID  string `bson:"env-uuid"`
+}
+
+// Status returns the status of the service.
+// Only unit leaders are allowed to set the status of the service.
+// If no status is recorded, then there are no unit leaders and the
+// status is derived from the unit status values.
+func (s *Service) Status() (StatusInfo, error) {
+	doc, err := getStatus(s.st, s.globalKey())
+	if errors.IsNotFound(err) && s.IsPrincipal() {
+		return s.deriveStatus()
+	}
+	if err != nil {
+		return StatusInfo{}, err
+	}
+	return StatusInfo{
+		Status:  doc.Status,
+		Message: doc.StatusInfo,
+		Data:    doc.StatusData,
+		Since:   doc.Updated,
+	}, nil
+}
+
+func (s *Service) deriveStatus() (StatusInfo, error) {
+	units, err := s.AllUnits()
+	if err != nil {
+		return StatusInfo{}, err
+	}
+	var result StatusInfo
+	for _, unit := range units {
+		currentSeverity := statusServerities[result.Status]
+		unitStatus, err := unit.Status()
+		if err != nil {
+			return StatusInfo{}, err
+		}
+		unitSeverity := statusServerities[unitStatus.Status]
+		if unitSeverity > currentSeverity {
+			result.Status = unitStatus.Status
+			result.Message = unitStatus.Message
+			result.Data = unitStatus.Data
+			result.Since = unitStatus.Since
+		}
+	}
+	return result, nil
+}
+
+// statusSeverities holds status values with a severity measure.
+// Status values with higher severity are used in preference to others.
+var statusServerities = map[Status]int{
+	StatusError:       100,
+	StatusBlocked:     90,
+	StatusWaiting:     80,
+	StatusMaintenance: 70,
+	StatusTerminated:  60,
+	StatusActive:      50,
+	StatusUnknown:     40,
 }

--- a/state/status.go
+++ b/state/status.go
@@ -428,6 +428,7 @@ func newServiceStatusDoc(who string, status Status, info string, data map[string
 // validateSet returns an error if the serviceStatusDoc does not represent a sane
 // SetStatus operation for a service.
 func (doc *serviceStatusDoc) validateSet() error {
+	// Valid service status values are the same as those for the unit.
 	if !unitStatusValid(doc.Status) {
 		return errors.Errorf("cannot set invalid status %q", doc.Status)
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1885,7 +1885,7 @@ func (u *Unit) Resolve(retryHooks bool) error {
 	// We currently check agent status to see if a unit is
 	// in error state. As the new Juju Health work is completed,
 	// this will change to checking the unit status.
-	statusInfo, err := u.AgentStatus()
+	statusInfo, err := u.Status()
 	if err != nil {
 		return err
 	}

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -571,7 +571,8 @@ func (s *UnitSuite) TestGetSetUnitAgentStatus(c *gc.C) {
 		"foo": "bar",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	statusInfo, err = s.unit.AgentStatus()
+	// Unit status reports errors.
+	statusInfo, err = s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "test-hook failed")
@@ -628,7 +629,8 @@ func (s *UnitSuite) TestGetSetStatusDataStandard(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	statusInfo, err := s.unit.AgentStatus()
+	// Unit status reports errors.
+	statusInfo, err := s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "test-hook failed")
@@ -654,7 +656,8 @@ func (s *UnitSuite) TestGetSetStatusDataMongo(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	statusInfo, err := s.unit.AgentStatus()
+	// Unit status reports errors.
+	statusInfo, err := s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "mongo")
@@ -682,7 +685,8 @@ func (s *UnitSuite) TestGetSetStatusDataChange(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	data["4th-key"] = 4.0
 
-	statusInfo, err := s.unit.AgentStatus()
+	// Unit status reports errors.
+	statusInfo, err := s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "test-hook failed")

--- a/state/unitagent_test.go
+++ b/state/unitagent_test.go
@@ -58,13 +58,20 @@ func (s *UnitAgentSuite) TestGetSetStatusWhileAlive(c *gc.C) {
 		"foo": "bar",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	statusInfo, err = agent.Status()
+	// Agent error is reported as unit error.
+	statusInfo, err = s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "test-hook failed")
 	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{
 		"foo": "bar",
 	})
+	// For agents, error is reported as idle.
+	statusInfo, err = agent.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusIdle)
+	c.Assert(statusInfo.Message, gc.Equals, "")
+	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{})
 }
 
 func (s *UnitAgentSuite) TestGetSetStatusWhileNotAlive(c *gc.C) {
@@ -99,7 +106,8 @@ func (s *UnitAgentSuite) TestGetSetStatusDataStandard(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	statusInfo, err := agent.Status()
+	// Agent error is reported as unit error.
+	statusInfo, err := s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "test-hook failed")
@@ -150,7 +158,8 @@ func (s *UnitAgentSuite) TestGetSetStatusDataMongo(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	statusInfo, err := agent.Status()
+	// Agent error is reported as unit error.
+	statusInfo, err := s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "mongo")
@@ -179,7 +188,8 @@ func (s *UnitAgentSuite) TestGetSetStatusDataChange(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	data["4th-key"] = 4.0
 
-	statusInfo, err := agent.Status()
+	// Agent error is reported as unit error.
+	statusInfo, err := s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "test-hook failed")

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -27,7 +27,7 @@ func setAgentStatus(u *Uniter, status params.Status, info string, data map[strin
 	}
 	u.lastReportedStatus = status
 	u.lastReportedMessage = info
-	logger.Infof("[AGENT-STATUS] %s %s", status, info)
+	logger.Debugf("[AGENT-STATUS] %s %s", status, info)
 	return u.unit.SetAgentStatus(status, info, data)
 }
 

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -27,6 +27,7 @@ func setAgentStatus(u *Uniter, status params.Status, info string, data map[strin
 	}
 	u.lastReportedStatus = status
 	u.lastReportedMessage = info
+	logger.Infof("[AGENT-STATUS] %s %s", status, info)
 	return u.unit.SetAgentStatus(status, info, data)
 }
 

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -143,7 +143,7 @@ func (rh *runHook) beforeHook() error {
 
 func (rh *runHook) afterHook(state State) (bool, error) {
 	ctx := rh.runner.Context()
-	hasRunStatusSet := ctx.HasExecutionSetUnitStatus()
+	hasRunStatusSet := ctx.HasExecutionSetUnitStatus() || state.StatusSet
 	var err error
 	switch rh.info.Kind {
 	case hooks.Stop:

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -79,6 +79,9 @@ func (rh *runHook) Execute(state State) (*State, error) {
 	if err := rh.callbacks.SetExecutingStatus(message); err != nil {
 		return nil, err
 	}
+	// The before hook may have updated unit status and we don't want that
+	// to count so reset it here before running the hook.
+	rh.runner.Context().ResetExecutionSetUnitStatus()
 
 	ranHook := true
 	step := Done

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -339,6 +339,10 @@ func (mock *MockContext) HasExecutionSetUnitStatus() bool {
 	return mock.setStatusCalled
 }
 
+func (mock *MockContext) ResetExecutionSetUnitStatus() {
+	mock.setStatusCalled = false
+}
+
 func (mock *MockContext) SetUnitStatus(status jujuc.StatusInfo) error {
 	mock.setStatusCalled = true
 	mock.status = status

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -227,6 +227,7 @@ func (ctx *HookContext) UnitStatus() (*jujuc.StatusInfo, error) {
 
 func (ctx *HookContext) SetUnitStatus(status jujuc.StatusInfo) error {
 	ctx.hasRunStatusSet = true
+	logger.Infof("[WORKLOAD-STATUS] %s %s", status.Status, status.Info)
 	return ctx.unit.SetUnitStatus(
 		params.Status(status.Status),
 		status.Info,

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -227,7 +227,7 @@ func (ctx *HookContext) UnitStatus() (*jujuc.StatusInfo, error) {
 
 func (ctx *HookContext) SetUnitStatus(status jujuc.StatusInfo) error {
 	ctx.hasRunStatusSet = true
-	logger.Infof("[WORKLOAD-STATUS] %s %s", status.Status, status.Info)
+	logger.Debugf("[WORKLOAD-STATUS] %s %s", status.Status, status.Info)
 	return ctx.unit.SetUnitStatus(
 		params.Status(status.Status),
 		status.Info,

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -239,6 +239,10 @@ func (ctx *HookContext) HasExecutionSetUnitStatus() bool {
 	return ctx.hasRunStatusSet
 }
 
+func (ctx *HookContext) ResetExecutionSetUnitStatus() {
+	ctx.hasRunStatusSet = false
+}
+
 func (ctx *HookContext) PublicAddress() (string, bool) {
 	return ctx.publicAddress, ctx.publicAddress != ""
 }

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -44,6 +44,7 @@ type Context interface {
 	SetProcess(process *os.Process)
 	FlushContext(badge string, failure error) error
 	HasExecutionSetUnitStatus() bool
+	ResetExecutionSetUnitStatus()
 }
 
 // Paths exposes the paths needed by Runner.

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -185,8 +185,9 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "install"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "install"`,
 				data: map[string]interface{}{
 					"hook": "install",
 				},
@@ -229,8 +230,9 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "start"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
 				},
@@ -257,24 +259,27 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "install"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "install"`,
 				data: map[string]interface{}{
 					"hook": "install",
 				},
 			},
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "config-changed"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
 				},
 			},
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "start"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
 				},
@@ -314,8 +319,9 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "config-changed"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
 				},
@@ -482,8 +488,9 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			createCharm{revision: 1, badHooks: []string{"upgrade-charm"}},
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "upgrade-charm"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
 				},
@@ -511,8 +518,9 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			createCharm{revision: 1, badHooks: []string{"upgrade-charm"}},
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "upgrade-charm"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
 				},
@@ -524,8 +532,9 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "upgrade-charm"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
 				},
@@ -672,8 +681,9 @@ func (s *UniterSuite) TestUniterErrorStateUpgrade(c *gc.C) {
 			createCharm{revision: 1},
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "start"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
 				},
@@ -707,8 +717,9 @@ func (s *UniterSuite) TestUniterErrorStateUpgrade(c *gc.C) {
 			// the charm has been downloaded and verified). However, it's still
 			// useful to wait until that point...
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "start"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
 				},
@@ -992,9 +1003,10 @@ func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
 			serveCharm{},
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   "upgrade failed",
-				charm:  1,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         "upgrade failed",
+				charm:        1,
 			},
 			verifyWaiting{},
 			verifyGitCharm{dirty: true},
@@ -1196,8 +1208,9 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			"hook error during join of a relation",
 			startupRelationError{"db-relation-joined"},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "db-relation-joined"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "db-relation-joined"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-joined",
 					"relation-id": 0,
@@ -1208,8 +1221,9 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			"hook error during change of a relation",
 			startupRelationError{"db-relation-changed"},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "db-relation-changed"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "db-relation-changed"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-changed",
 					"relation-id": 0,
@@ -1222,8 +1236,9 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			waitHooks{"db-relation-joined mysql/0 db:0", "db-relation-changed mysql/0 db:0"},
 			removeRelationUnit{"mysql/0"},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "db-relation-departed"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "db-relation-departed"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-departed",
 					"relation-id": 0,
@@ -1237,8 +1252,9 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			waitHooks{"db-relation-joined mysql/0 db:0", "db-relation-changed mysql/0 db:0"},
 			relationDying,
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "db-relation-broken"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "db-relation-broken"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-broken",
 					"relation-id": 0,
@@ -1625,8 +1641,9 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			},
 			addAction{"action-log", nil},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "start"`,
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
 				},
@@ -1637,9 +1654,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				status:  params.ActionCompleted,
 			}}},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   `hook failed: "start"`,
-				data:   map[string]interface{}{"hook": "start"},
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "start"`,
+				data:         map[string]interface{}{"hook": "start"},
 			},
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
@@ -1827,8 +1845,9 @@ func (s *UniterSuite) TestReboot(c *gc.C) {
 			startUniter{},
 			waitAddresses{},
 			waitUnitAgent{
-				status: params.StatusError,
-				info:   fmt.Sprintf(`hook failed: "install"`),
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         fmt.Sprintf(`hook failed: "install"`),
 			},
 		),
 	})

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -525,8 +525,9 @@ func (s startupErrorWithCustomCharm) step(c *gc.C, ctx *context) {
 	step(c, ctx, serveCharm{})
 	step(c, ctx, createUniter{})
 	step(c, ctx, waitUnitAgent{
-		status: params.StatusError,
-		info:   fmt.Sprintf(`hook failed: %q`, s.badHook),
+		statusGetter: unitStatusGetter,
+		status:       params.StatusError,
+		info:         fmt.Sprintf(`hook failed: %q`, s.badHook),
 	})
 	for _, hook := range []string{"install", "config-changed", "start"} {
 		if hook == s.badHook {
@@ -547,8 +548,9 @@ func (s startupError) step(c *gc.C, ctx *context) {
 	step(c, ctx, serveCharm{})
 	step(c, ctx, createUniter{})
 	step(c, ctx, waitUnitAgent{
-		status: params.StatusError,
-		info:   fmt.Sprintf(`hook failed: %q`, s.badHook),
+		statusGetter: unitStatusGetter,
+		status:       params.StatusError,
+		info:         fmt.Sprintf(`hook failed: %q`, s.badHook),
 	})
 	for _, hook := range []string{"install", "config-changed", "start"} {
 		if hook == s.badHook {
@@ -900,9 +902,10 @@ func (s startUpgradeError) step(c *gc.C, ctx *context) {
 		serveCharm{},
 		upgradeCharm{revision: 1},
 		waitUnitAgent{
-			status: params.StatusError,
-			info:   "upgrade failed",
-			charm:  1,
+			statusGetter: unitStatusGetter,
+			status:       params.StatusError,
+			info:         "upgrade failed",
+			charm:        1,
 		},
 		verifyWaiting{},
 		verifyCharm{attemptedRevision: 1},
@@ -919,9 +922,10 @@ type verifyWaitingUpgradeError struct {
 func (s verifyWaitingUpgradeError) step(c *gc.C, ctx *context) {
 	verifyCharmSteps := []stepper{
 		waitUnitAgent{
-			status: params.StatusError,
-			info:   "upgrade failed",
-			charm:  s.revision,
+			statusGetter: unitStatusGetter,
+			status:       params.StatusError,
+			info:         "upgrade failed",
+			charm:        s.revision,
 		},
 		verifyCharm{attemptedRevision: s.revision},
 	}
@@ -1514,9 +1518,10 @@ func (s startGitUpgradeError) step(c *gc.C, ctx *context) {
 		serveCharm{},
 		upgradeCharm{revision: 1},
 		waitUnitAgent{
-			status: params.StatusError,
-			info:   "upgrade failed",
-			charm:  1,
+			statusGetter: unitStatusGetter,
+			status:       params.StatusError,
+			info:         "upgrade failed",
+			charm:        1,
 		},
 		verifyWaiting{},
 		verifyGitCharm{dirty: true},


### PR DESCRIPTION
Service status is displayed. Service status can be set by a unit leader (not yet implemented), or, the fallback is to look at the status values of each unit and choose the worst.

Also, some refactoring of how unit vs agent error status is handled. It is now implemented in state so that the future megawatcher work is easier.

As a drive by, make some tweaks to the uniter.

(Review request: http://reviews.vapour.ws/r/1419/)