### PR TITLE
Fix for doc id in unit meter status upgrade, related to bug LP:1438489.

### DIFF
--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -68,7 +68,7 @@ func (u *Unit) SetMeterStatus(codeRaw, info string) error {
 				Assert: isAliveDoc,
 			}, {
 				C:      meterStatusC,
-				Id:     u.st.docID(u.globalKey()),
+				Id:     u.st.docID(u.globalMeterStatusKey()),
 				Assert: txn.DocExists,
 				Update: bson.D{{"$set", bson.D{{"code", code}, {"info", info}}}},
 			}}, nil
@@ -111,7 +111,7 @@ func (u *Unit) getMeterStatusDoc() (*meterStatusDoc, error) {
 	meterStatuses, closer := u.st.getCollection(meterStatusC)
 	defer closer()
 	var status meterStatusDoc
-	err := meterStatuses.FindId(u.globalKey()).One(&status)
+	err := meterStatuses.FindId(u.globalMeterStatusKey()).One(&status)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/service.go
+++ b/state/service.go
@@ -593,6 +593,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	docID := s.st.docID(name)
 	globalKey := unitGlobalKey(name)
 	agentGlobalKey := unitAgentGlobalKey(name)
+	meterStatusGlobalKey := unitAgentGlobalKey(name)
 	udoc := &unitDoc{
 		DocID:                  docID,
 		Name:                   name,
@@ -620,7 +621,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		},
 		createStatusOp(s.st, globalKey, unitStatusDoc),
 		createStatusOp(s.st, agentGlobalKey, agentStatusDoc),
-		createMeterStatusOp(s.st, globalKey, &meterStatusDoc{Code: MeterNotSet}),
+		createMeterStatusOp(s.st, meterStatusGlobalKey, &meterStatusDoc{Code: MeterNotSet}),
 		{
 			C:      servicesC,
 			Id:     s.doc.DocID,
@@ -737,7 +738,7 @@ func (s *Service) removeUnitOps(u *Unit, asserts bson.D) ([]txn.Op, error) {
 		removeConstraintsOp(s.st, u.globalAgentKey()),
 		removeStatusOp(s.st, u.globalAgentKey()),
 		removeStatusOp(s.st, u.globalKey()),
-		removeMeterStatusOp(s.st, u.globalKey()),
+		removeMeterStatusOp(s.st, u.globalMeterStatusKey()),
 		annotationRemoveOp(s.st, u.globalKey()),
 		s.st.newCleanupOp(cleanupRemovedUnit, u.doc.Name),
 	)

--- a/state/unit.go
+++ b/state/unit.go
@@ -179,6 +179,11 @@ func (u *Unit) globalAgentKey() string {
 	return unitAgentGlobalKey(u.doc.Name)
 }
 
+// globalMeterStatusKey returns the global database key for the meter status of the unit.
+func (u *Unit) globalMeterStatusKey() string {
+	return unitAgentGlobalKey(u.doc.Name)
+}
+
 // globalKey returns the global database key for the unit.
 func (u *Unit) globalKey() string {
 	return unitGlobalKey(u.doc.Name)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -398,7 +398,7 @@ func CreateUnitMeterStatus(st *State) error {
 			continue
 		}
 		ops := []txn.Op{
-			createMeterStatusOp(st, unit.globalKey(), &meterStatusDoc{Code: MeterNotSet}),
+			createMeterStatusOp(st, unit.globalMeterStatusKey(), &meterStatusDoc{Code: MeterNotSet}),
 		}
 		if err = st.runRawTransaction(ops); err != nil {
 			upgradesLogger.Warningf("migration failed for unit %q: %v", unit, err)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1347,7 +1347,7 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 // WatchMeterStatus returns a watcher observing the changes to the unit's
 // meter status.
 func (u *Unit) WatchMeterStatus() NotifyWatcher {
-	return newEntityWatcher(u.st, meterStatusC, u.st.docID(u.globalKey()))
+	return newEntityWatcher(u.st, meterStatusC, u.st.docID(u.globalMeterStatusKey()))
 }
 
 func newEntityWatcher(st *State, collName string, key interface{}) NotifyWatcher {


### PR DESCRIPTION
Upgrade from 1.22 to 1.23 breaks unit meter status lookup due to changed globalKey function.

(Review request: http://reviews.vapour.ws/r/1420/)