### PR TITLE
state/service: Unit names are unique across service names lp:1174610

### DIFF
--- a/state/service_test.go
+++ b/state/service_test.go
@@ -325,7 +325,7 @@ func (s *ServiceSuite) TestSetCharmWithDyingService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ServiceSuite) TestUniqueUnitIds(c *gc.C) {
+func (s *ServiceSuite) TestSequenceUnitIdsAfterDestroy(c *gc.C) {
 	unit, err := s.mysql.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Name(), gc.Equals, "mysql/0")
@@ -334,6 +334,15 @@ func (s *ServiceSuite) TestUniqueUnitIds(c *gc.C) {
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	s.mysql = s.AddTestingService(c, "mysql", s.charm)
+	unit, err = s.mysql.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.Name(), gc.Equals, "mysql/1")
+}
+
+func (s *ServiceSuite) TestSequenceUnitIds(c *gc.C) {
+	unit, err := s.mysql.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.Name(), gc.Equals, "mysql/0")
 	unit, err = s.mysql.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Name(), gc.Equals, "mysql/1")

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -325,6 +325,20 @@ func (s *ServiceSuite) TestSetCharmWithDyingService(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *ServiceSuite) TestUniqueUnitIds(c *gc.C) {
+	unit, err := s.mysql.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.Name(), gc.Equals, "mysql/0")
+	err = unit.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.mysql.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	s.mysql = s.AddTestingService(c, "mysql", s.charm)
+	unit, err = s.mysql.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.Name(), gc.Equals, "mysql/1")
+}
+
 func (s *ServiceSuite) TestSetCharmWhenDead(c *gc.C) {
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
 

--- a/state/upgrade_test.go
+++ b/state/upgrade_test.go
@@ -687,6 +687,16 @@ func (s *UpgradeSuite) TestClearUpgradeInfo(c *gc.C) {
 	s.assertUpgrading(c, true)
 }
 
+func (s *UpgradeSuite) TestServiceUnitSeqToSequence(c *gc.C) {
+	v123 := vers("1.2.3")
+	v124 := vers("1.2.4")
+
+	s.assertUpgrading(c, false)
+	_, err := s.State.EnsureUpgradeInfo(s.serverIdA, v123, v124)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertUpgrading(c, true)
+}
+
 func (s *UpgradeSuite) setToFinishing(c *gc.C, info *state.UpgradeInfo) {
 	err := info.SetStatus(state.UpgradeRunning)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2705,7 +2705,6 @@ func (s *upgradesSuite) TestAddBlockDevicesDocsIdempotent(c *gc.C) {
 	c.Assert(firstPassIDs, jc.SameContents, secondPassIDs)
 }
 
-<<<<<<< HEAD
 func (s *upgradesSuite) TestEnvUUIDMigrationFieldOrdering(c *gc.C) {
 	// This tests a DB migration regression triggered by Go 1.3+'s
 	// randomised map iteration feature. See LP #1451674.
@@ -2789,6 +2788,7 @@ func (s *upgradesSuite) TestMoveServiceUnitSeqToSequence(c *gc.C) {
 
 	err := svcC.Insert(
 		bson.D{
+			{"_id", s.state.docID("my-service")},
 			{"unitseq", 7},
 			{"env-uuid", s.state.EnvironUUID()},
 			{"name", "my-service"},
@@ -2799,6 +2799,11 @@ func (s *upgradesSuite) TestMoveServiceUnitSeqToSequence(c *gc.C) {
 	count, err := s.state.sequence("service-my-service")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(count, gc.Equals, 7)
+
+	var result map[string]interface{}
+	err = svcC.Find(nil).Select(bson.M{"unitseq": 1}).One(&result)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result["unitseq"], gc.Equals, nil)
 }
 
 func (s *upgradesSuite) TestMoveServiceNotUnitSeq(c *gc.C) {

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -3,19 +3,26 @@
 
 package upgrades
 
-import "github.com/juju/juju/state"
+import (
+	"github.com/juju/juju/state"
+)
 
 // stateStepsFor124 returns upgrade steps for Juju 1.24 that manipulate state directly.
 func stateStepsFor124() []Step {
-	var steps []Step
-	steps = append(steps,
+	return []Step{
 		&upgradeStep{
 			description: "add block device documents for existing machines",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return state.AddDefaultBlockDevicesDocs(context.State())
+			}},
+		&upgradeStep{
+			description: "move service.UnitSeq to sequence collection",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MoveServiceUnitSeqToSequence(context.State())
 			},
 		},
-	)
+	}
 	return steps
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -24,5 +24,4 @@ func stateStepsFor124() []Step {
 			},
 		},
 	}
-	return steps
 }

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -19,6 +19,7 @@ var _ = gc.Suite(&steps124Suite{})
 func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 	expected := []string{
 		"add block device documents for existing machines",
+		"move service.UnitSeq to sequence collection",
 	}
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
 }


### PR DESCRIPTION
The latest attempt at solving: https://bugs.launchpad.net/juju-core/+bug/1174610

Previously the following sequence would take place
```
juju deploy foobar (one unit: foobar/0)
juju destroy-service foobar
juju deploy foobar (one unit: foobar/0)
```

This pr makes the second deploy result in a single unit foobar/1.

Or stated another way: Unit names are now unique per service name.

This was achieved by removing UnitSeq from the service collection and using the global sequences collection to store the unit number.

(Review request: http://reviews.vapour.ws/r/1425/)