### PR TITLE
Fixed EC2 unbroke MAAS wrt lp:1442801

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
@@ -235,6 +236,11 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 			// We log the error, but it's safe to ignore as it's not
 			// critical.
 			logger.Debugf("address allocation not supported (%v)", err)
+		}
+		// AWS requires NAT in place in order for hosted containers to
+		// reach outside.
+		if config.Type() == provider.EC2 {
+			cfg[container.ConfigEnableNAT] = "true"
 		}
 	}
 

--- a/container/interface.go
+++ b/container/interface.go
@@ -18,6 +18,11 @@ const (
 	// supports networking.
 	ConfigIPForwarding = "ip-forwarding"
 
+	// ConfigEnableNAT, if set to a non-empty value, instructs the
+	// container manager to enable NAT for hosted containers. NAT is
+	// required for AWS, but should be disabled for MAAS.
+	ConfigEnableNAT = "enable-nat"
+
 	DefaultNamespace = "juju"
 )
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,6 +11,7 @@ const (
 	Joyent = "joyent"
 	Local  = "local"
 	MAAS   = "maas"
+	EC2    = "ec2"
 )
 
 // IsManual returns true iff the specified provider

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -37,6 +37,7 @@ type ContainerSetup struct {
 	config                agent.Config
 	initLock              *fslock.Lock
 	addressableContainers bool
+	enableNAT             bool
 
 	// Save the workerName so the worker thread can be stopped.
 	workerName string
@@ -247,6 +248,12 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		logger.Infof("enabled IP forwarding and ARP proxying for containers")
 	}
 
+	// Enable NAT if needed.
+	if nat := managerConfig.PopValue(container.ConfigEnableNAT); nat != "" {
+		cs.enableNAT = true
+		logger.Infof("enabling NAT for containers")
+	}
+
 	switch containerType {
 	case instance.LXC:
 		series, err := cs.machine.Series()
@@ -255,7 +262,13 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		}
 
 		initialiser = lxc.NewContainerInitialiser(series)
-		broker, err = NewLxcBroker(cs.provisioner, cs.config, managerConfig, cs.imageURLGetter)
+		broker, err = NewLxcBroker(
+			cs.provisioner,
+			cs.config,
+			managerConfig,
+			cs.imageURLGetter,
+			cs.enableNAT,
+		)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -268,7 +281,12 @@ func (cs *ContainerSetup) getContainerArtifacts(
 
 	case instance.KVM:
 		initialiser = kvm.NewContainerInitialiser()
-		broker, err = NewKvmBroker(cs.provisioner, cs.config, managerConfig)
+		broker, err = NewKvmBroker(
+			cs.provisioner,
+			cs.config,
+			managerConfig,
+			cs.enableNAT,
+		)
 		if err != nil {
 			logger.Errorf("failed to create new kvm broker")
 			return nil, nil, nil, err

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -251,7 +251,7 @@ func (s *ContainerSetupSuite) TestLxcContainerUsesImageURL(c *gc.C) {
 
 	brokerCalled := false
 	newlxcbroker := func(api provisioner.APICalls, agentConfig agent.Config, managerConfig container.ManagerConfig,
-		imageURLGetter container.ImageURLGetter) (environs.InstanceBroker, error) {
+		imageURLGetter container.ImageURLGetter, enableNAT bool) (environs.InstanceBroker, error) {
 		imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(imageURL, gc.Equals, "imageURL")

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -51,7 +51,7 @@ var SetIPAndARPForwarding func(bool) error
 
 // SetupRoutesAndIPTables calls the internal setupRoutesAndIPTables
 // and the restores the mocked one.
-var SetupRoutesAndIPTables func(string, network.Address, string, []network.InterfaceInfo) error
+var SetupRoutesAndIPTables func(string, network.Address, string, []network.InterfaceInfo, bool) error
 
 func init() {
 	// In order to isolate the host machine from the running tests,
@@ -69,7 +69,7 @@ func init() {
 		func(bool) error { return nil },
 	)
 	mockSetupRoutesAndIPTablesValue := reflect.ValueOf(
-		func(string, network.Address, string, []network.InterfaceInfo) error { return nil },
+		func(string, network.Address, string, []network.InterfaceInfo, bool) error { return nil },
 	)
 	switchValues := func(newValue, oldValue reflect.Value) {
 		newValue.Set(oldValue)
@@ -82,9 +82,9 @@ func init() {
 		defer switchValues(newSetIPAndARPForwardingValue, mockSetIPAndARPForwardingValue)
 		return setIPAndARPForwarding(v)
 	}
-	SetupRoutesAndIPTables = func(nic string, addr network.Address, bridge string, ifinfo []network.InterfaceInfo) error {
+	SetupRoutesAndIPTables = func(nic string, addr network.Address, bridge string, ifinfo []network.InterfaceInfo, enableNAT bool) error {
 		switchValues(newSetupRoutesAndIPTablesValue, oldSetupRoutesAndIPTablesValue)
 		defer switchValues(newSetupRoutesAndIPTablesValue, mockSetupRoutesAndIPTablesValue)
-		return setupRoutesAndIPTables(nic, addr, bridge, ifinfo)
+		return setupRoutesAndIPTables(nic, addr, bridge, ifinfo, enableNAT)
 	}
 }

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -22,6 +22,7 @@ func NewKvmBroker(
 	api APICalls,
 	agentConfig agent.Config,
 	managerConfig container.ManagerConfig,
+	enableNAT bool,
 ) (environs.InstanceBroker, error) {
 	manager, err := kvm.NewContainerManager(managerConfig)
 	if err != nil {
@@ -31,6 +32,7 @@ func NewKvmBroker(
 		manager:     manager,
 		api:         api,
 		agentConfig: agentConfig,
+		enableNAT:   enableNAT,
 	}, nil
 }
 
@@ -38,6 +40,7 @@ type kvmBroker struct {
 	manager     container.Manager
 	api         APICalls
 	agentConfig agent.Config
+	enableNAT   bool
 }
 
 // StartInstance is specified in the Broker interface.
@@ -58,7 +61,8 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}
 
 	allocatedInfo, err := maybeAllocateStaticIP(
-		machineId, bridgeDevice, broker.api, args.NetworkInfo,
+		machineId, bridgeDevice, broker.api,
+		args.NetworkInfo, broker.enableNAT,
 	)
 	if err != nil {
 		// It's fine, just ignore it. The effect will be that the

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -85,7 +85,7 @@ func (s *kvmBrokerSuite) SetUpTest(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, s.agentConfig, managerConfig)
+	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, s.agentConfig, managerConfig, false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -233,7 +233,7 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 	machineTag := names.NewMachineTag("0")
 	agentConfig := s.AgentConfigForTag(c, machineTag)
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig)
+	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig, false)
 	c.Assert(err, jc.ErrorIsNil)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
 	return provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker, toolsFinder)

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -44,8 +44,11 @@ var _ APICalls = (*apiprovisioner.State)(nil)
 var NewLxcBroker = newLxcBroker
 
 func newLxcBroker(
-	api APICalls, agentConfig agent.Config, managerConfig container.ManagerConfig,
+	api APICalls,
+	agentConfig agent.Config,
+	managerConfig container.ManagerConfig,
 	imageURLGetter container.ImageURLGetter,
+	enableNAT bool,
 ) (environs.InstanceBroker, error) {
 	manager, err := lxc.NewContainerManager(managerConfig, imageURLGetter)
 	if err != nil {
@@ -55,6 +58,7 @@ func newLxcBroker(
 		manager:     manager,
 		api:         api,
 		agentConfig: agentConfig,
+		enableNAT:   enableNAT,
 	}, nil
 }
 
@@ -62,6 +66,7 @@ type lxcBroker struct {
 	manager     container.Manager
 	api         APICalls
 	agentConfig agent.Config
+	enableNAT   bool
 }
 
 // StartInstance is specified in the Broker interface.
@@ -79,7 +84,8 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
 	allocatedInfo, err := maybeAllocateStaticIP(
-		machineId, bridgeDevice, broker.api, args.NetworkInfo,
+		machineId, bridgeDevice, broker.api,
+		args.NetworkInfo, broker.enableNAT,
 	)
 	if err != nil {
 		// It's fine, just ignore it. The effect will be that the
@@ -326,6 +332,7 @@ var setupRoutesAndIPTables = func(
 	primaryAddr network.Address,
 	bridgeName string,
 	ifaceInfo []network.InterfaceInfo,
+	enableNAT bool,
 ) error {
 
 	if primaryNIC == "" || primaryAddr.Value == "" || bridgeName == "" || len(ifaceInfo) == 0 {
@@ -374,18 +381,28 @@ var setupRoutesAndIPTables = func(
 		}
 
 		for name, rule := range iptablesRules {
+			if !enableNAT && name == "iptablesSNAT" {
+				// Do not add the SNAT rule if we shouldn't enable
+				// NAT.
+				continue
+			}
 			if err := addRuleIfDoesNotExist(name, rule); err != nil {
 				return err
 			}
 		}
 
-		// TODO(dooferlad): subnets should be a list of subnets in the EC2 VPC and
-		// should be empty for MAAS. See bug http://pad.lv/1443942
-		subnets := []string{data.HostIP + "/16"}
-		for _, subnet := range subnets {
-			data.SubnetCIDR = subnet
-			if err := addRuleIfDoesNotExist("skipSNAT", skipSNATRule); err != nil {
-				return err
+		// TODO(dooferlad): subnets should be a list of subnets in the
+		// EC2 VPC and should be empty for MAAS. See bug
+		// http://pad.lv/1443942
+		if enableNAT {
+			// Only add the following hack to allow AWS egress traffic
+			// for hosted containers to work.
+			subnets := []string{data.HostIP + "/16"}
+			for _, subnet := range subnets {
+				data.SubnetCIDR = subnet
+				if err := addRuleIfDoesNotExist("skipSNAT", skipSNATRule); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -462,6 +479,7 @@ func maybeAllocateStaticIP(
 	containerId, bridgeDevice string,
 	apiFacade APICalls,
 	ifaceInfo []network.InterfaceInfo,
+	enableNAT bool,
 ) (finalIfaceInfo []network.InterfaceInfo, err error) {
 	defer func() {
 		if err != nil {
@@ -510,7 +528,13 @@ func maybeAllocateStaticIP(
 		finalIfaceInfo[i].DNSServers = dnsServers
 		finalIfaceInfo[i].GatewayAddress = primaryAddr
 	}
-	err = setupRoutesAndIPTables(primaryNIC, primaryAddr, bridgeDevice, finalIfaceInfo)
+	err = setupRoutesAndIPTables(
+		primaryNIC,
+		primaryAddr,
+		bridgeDevice,
+		finalIfaceInfo,
+		enableNAT,
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Temporary fix to ensure addressable containers on EC2 work, while not
introducing regressions (see http://pad.lv/1442801) to MAAS
environments. The fix is only manually tested on AWS and MAAS and needed
to unblock 1.23.0 release. A proper solution will be implemented for
1.24.

(Review request: http://reviews.vapour.ws/r/1432/)