### PR TITLE
Remove incomplete gccgo linker error workaround

### DIFF
--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -1,11 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// TODO(dimitern) Disabled on gccgo (PPC64 in particular) due
-// to build failures. See bug http://pad.lv/1425788.
-
-// +build !gccgo
-
 package featuretests
 
 import (


### PR DESCRIPTION
The workaround for bug 1425788 is incomplete on trunk as though one problem file is build-flag skipped, the test init is no longer skipped, resulting in a build failure.

As for now the gccgo linker error doesn't seem to be currently triggering, remove the build skip.

(Review request: http://reviews.vapour.ws/r/1439/)