### PR TITLE
Fixed lp:1445063 - non-FQDN in maas not resolvable from containers

### DIFF
--- a/container/userdata.go
+++ b/container/userdata.go
@@ -57,7 +57,8 @@ iface lo inet loopback{{define "static"}}
 {{.InterfaceName | printf "# interface %q"}}{{if not .NoAutoStart}}
 auto {{.InterfaceName}}{{end}}
 iface {{.InterfaceName}} inet manual{{if gt (len .DNSServers) 0}}
-    dns-nameservers{{range $dns := .DNSServers}} {{$dns.Value}}{{end}}{{end}}
+    dns-nameservers{{range $dns := .DNSServers}} {{$dns.Value}}{{end}}{{end}}{{if gt (len .DNSSearch) 0}}
+    dns-search {{.DNSSearch}}{{end}}
     pre-up ip address add {{.Address.Value}}/32 dev {{.InterfaceName}} &> /dev/null || true
     up ip route replace {{.GatewayAddress.Value}} dev {{.InterfaceName}}
     up ip route replace default via {{.GatewayAddress.Value}}

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -38,6 +38,7 @@ func (s *UserDataSuite) SetUpTest(c *gc.C) {
 		NoAutoStart:    false,
 		Address:        network.NewAddress("0.1.2.3", network.ScopeUnknown),
 		DNSServers:     network.NewAddresses("ns1.invalid", "ns2.invalid"),
+		DNSSearch:      "foo.bar",
 		GatewayAddress: network.NewAddress("0.1.2.1", network.ScopeUnknown),
 	}, {
 		InterfaceName: "eth1",
@@ -53,6 +54,7 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet manual
     dns-nameservers ns1.invalid ns2.invalid
+    dns-search foo.bar
     pre-up ip address add 0.1.2.3/32 dev eth0 &> /dev/null || true
     up ip route replace 0.1.2.1 dev eth0
     up ip route replace default via 0.1.2.1

--- a/network/network.go
+++ b/network/network.go
@@ -129,6 +129,10 @@ type InterfaceInfo struct {
 	// interface.
 	DNSServers []Address
 
+	// DNSSearch contains the default DNS domain to use for
+	// non-FQDN lookups.
+	DNSSearch string
+
 	// Gateway address, if set, defines the default gateway to
 	// configure for this network interface. For containers this
 	// usually is (one of) the host address(es).

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -181,17 +181,19 @@ func (h hostArchToolsFinder) FindTools(v version.Number, series string, arch *st
 var resolvConf = "/etc/resolv.conf"
 
 // localDNSServers parses the /etc/resolv.conf file (if available) and
-// extracts all nameservers addresses, returning them.
-func localDNSServers() ([]network.Address, error) {
+// extracts all nameservers addresses, and the default search domain
+// and returns them.
+func localDNSServers() ([]network.Address, string, error) {
 	file, err := os.Open(resolvConf)
 	if os.IsNotExist(err) {
-		return nil, nil
+		return nil, "", nil
 	} else if err != nil {
-		return nil, errors.Annotatef(err, "cannot open %q", resolvConf)
+		return nil, "", errors.Annotatef(err, "cannot open %q", resolvConf)
 	}
 	defer file.Close()
 
 	var addresses []network.Address
+	var searchDomain string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -208,12 +210,20 @@ func localDNSServers() ([]network.Address, error) {
 			address = strings.TrimSpace(address)
 			addresses = append(addresses, network.NewAddress(address, network.ScopeUnknown))
 		}
+		if strings.HasPrefix(line, "search") {
+			searchDomain = strings.TrimPrefix(line, "search")
+			// Drop comments after the domain, if any.
+			if strings.Contains(searchDomain, "#") {
+				searchDomain = searchDomain[:strings.Index(searchDomain, "#")]
+			}
+			searchDomain = strings.TrimSpace(searchDomain)
+		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, errors.Annotatef(err, "cannot read DNS servers from %q", resolvConf)
+		return nil, "", errors.Annotatef(err, "cannot read DNS servers from %q", resolvConf)
 	}
-	return addresses, nil
+	return addresses, searchDomain, nil
 }
 
 // ipRouteAdd is the command template to add a static route for
@@ -511,7 +521,8 @@ func maybeAllocateStaticIP(
 
 	// Populate ConfigType and DNSServers as needed.
 	var dnsServers []network.Address
-	dnsServers, err = localDNSServers()
+	var searchDomain string
+	dnsServers, searchDomain, err = localDNSServers()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -526,6 +537,7 @@ func maybeAllocateStaticIP(
 		finalIfaceInfo[i].MACAddress = MACAddressTemplate
 		finalIfaceInfo[i].ConfigType = network.ConfigStatic
 		finalIfaceInfo[i].DNSServers = dnsServers
+		finalIfaceInfo[i].DNSSearch = searchDomain
 		finalIfaceInfo[i].GatewayAddress = primaryAddr
 	}
 	err = setupRoutesAndIPTables(


### PR DESCRIPTION
Live tested on UOSCI (OpenStack on MAAS) and AWS.