### PR TITLE
Really fix local bootstrap issue on vivid

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -93,21 +93,26 @@ func versionInitSystem(vers version.Binary) (string, bool) {
 	}
 }
 
-var discoveryFuncs = map[string]func() (bool, error){
-	InitSystemSystemd: systemd.IsRunning,
-	InitSystemUpstart: upstart.IsRunning,
-	InitSystemWindows: windows.IsRunning,
+type discoveryCheck struct {
+	name      string
+	isRunning func() (bool, error)
+}
+
+var discoveryFuncs = []discoveryCheck{
+	{InitSystemUpstart, upstart.IsRunning},
+	{InitSystemSystemd, systemd.IsRunning},
+	{InitSystemWindows, windows.IsRunning},
 }
 
 func discoverLocalInitSystem() (string, error) {
-	for initName, isLocal := range discoveryFuncs {
-		local, err := isLocal()
+	for _, check := range discoveryFuncs {
+		local, err := check.isRunning()
 		if err != nil {
 			return "", errors.Trace(err)
 		}
 		if local {
-			logger.Debugf("discovered init system %q from local host", initName)
-			return initName, nil
+			logger.Debugf("discovered init system %q from local host", check.name)
+			return check.name, nil
 		}
 	}
 	return "", errors.NotFoundf("init system (based on local host)")

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -54,7 +54,7 @@ func (dt discoveryTest) log(c *gc.C) {
 }
 
 func (dt discoveryTest) disableLocalDiscovery(c *gc.C, s *discoverySuite) {
-	s.PatchLocalDiscovery(nil)
+	s.PatchLocalDiscoveryDisable()
 }
 
 func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
@@ -64,20 +64,7 @@ func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
 }
 
 func (dt discoveryTest) setLocal(c *gc.C, s *discoverySuite) {
-	noMatch := func() (bool, error) {
-		return false, nil
-	}
-	funcs := map[string]func() (bool, error){
-		service.InitSystemSystemd: noMatch,
-		service.InitSystemUpstart: noMatch,
-		service.InitSystemWindows: noMatch,
-	}
-	if dt.expected != "" {
-		funcs[dt.expected] = func() (bool, error) {
-			return true, nil
-		}
-	}
-	s.PatchLocalDiscovery(funcs)
+	s.PatchLocalDiscoveryNoMatch(dt.expected)
 }
 
 func (dt discoveryTest) setVersion(s *discoverySuite) version.Binary {

--- a/service/testing_test.go
+++ b/service/testing_test.go
@@ -101,7 +101,21 @@ func (s *BaseSuite) PatchVersion(vers version.Binary) {
 	s.PatchValue(&getVersion, s.Patched.GetVersion)
 }
 
-func (s *BaseSuite) PatchLocalDiscovery(funcs map[string]func() (bool, error)) {
+func (s *BaseSuite) PatchLocalDiscoveryDisable() {
+	s.PatchValue(&discoveryFuncs, nil)
+}
+
+func (s *BaseSuite) PatchLocalDiscoveryNoMatch(expected string) {
+	matchesFunc := func(matches bool) func() (bool, error) {
+		return func() (bool, error) {
+			return matches, nil
+		}
+	}
+	funcs := []discoveryCheck{
+		{InitSystemUpstart, matchesFunc(expected == InitSystemUpstart)},
+		{InitSystemSystemd, matchesFunc(expected == InitSystemSystemd)},
+		{InitSystemWindows, matchesFunc(expected == InitSystemWindows)},
+	}
 	s.PatchValue(&discoveryFuncs, funcs)
 }
 

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -34,6 +34,7 @@ func IsRunning() (bool, error) {
 	if err == nil {
 		return true, nil
 	}
+	logger.Debugf("exec %q failed: %#v", initctlPath, err)
 	if os.IsNotExist(err) {
 		// Executable could not be found, go 1.3 and later
 		return false, nil

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -34,9 +34,13 @@ func IsRunning() (bool, error) {
 	if err == nil {
 		return true, nil
 	}
+	if os.IsNotExist(err) {
+		// Executable could not be found, go 1.3 and later
+		return false, nil
+	}
 	if execErr, ok := err.(*exec.Error); ok {
-		if _, ok := execErr.Err.(*os.PathError); ok {
-			// Executable could not be found, or could not be executed.
+		// Executable could not be found, go 1.2
+		if os.IsNotExist(execErr.Err) || execErr.Err == exec.ErrNotFound {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
The return error types returned in os.exec varies between go 1.2 and go 1.3 varying in whether a wrapping exec.Error is returned when the executable does not exist.

Finally fix lp:1443440 by correctly handling upstart not existing. Also as an addition, use a deterministic ordering when discovering services, to avoid the debugging pain around this.

(Review request: http://reviews.vapour.ws/r/1454/)