### PR TITLE
Fix juju-run on CentOS

### DIFF
--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -23,7 +23,7 @@ var nixVals = map[osVarType]string{
 	tmpDir:  "/tmp",
 	logDir:  "/var/log",
 	dataDir: "/var/lib/juju",
-	jujuRun: "/usr/local/bin/juju-run",
+	jujuRun: "/usr/bin/juju-run",
 }
 
 var winVals = map[osVarType]string{


### PR DESCRIPTION
Small patch that fixes juju-run on CentOS. /usr/local/bin is not by default in $PATH on CentOS

(Review request: http://reviews.vapour.ws/r/1456/)