### PR TITLE
worker/logsender: implemented BufferedLogWriter

### DIFF
--- a/worker/logsender/bufferedlogwriter.go
+++ b/worker/logsender/bufferedlogwriter.go
@@ -1,0 +1,117 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENSE file for details.
+
+package logsender
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/utils/deque"
+)
+
+// LogRecord represents a log message in an agent which is to be
+// transmitted to the JES.
+type LogRecord struct {
+	Time     time.Time
+	Module   string
+	Location string // e.g. "foo.go:42"
+	Level    loggo.Level
+	Message  string
+
+	// Number of messages dropped after this one due to buffer limit.
+	DroppedAfter int
+}
+
+// LogRecordCh defines the channel type used to send log message
+// structs within the unit and machine agents.
+type LogRecordCh chan *LogRecord
+
+// BufferedLogWriter is a loggo.Writer which buffers log messages in
+// memory. These messages are retrieved by reading from the channel
+// returned by the Logs method.
+//
+// Up to maxLen log messages will be buffered. If this limit is
+// exceeded, the oldest records will be automatically discarded.
+type BufferedLogWriter struct {
+	maxLen int
+	in     LogRecordCh
+	out    LogRecordCh
+}
+
+// NewBufferedLogWriter returns a new BufferedLogWriter which will
+// cache up to maxLen log messages.
+func NewBufferedLogWriter(maxLen int) *BufferedLogWriter {
+	w := &BufferedLogWriter{
+		maxLen: maxLen,
+		in:     make(LogRecordCh),
+		out:    make(LogRecordCh),
+	}
+	go w.loop()
+	return w
+}
+
+func (w *BufferedLogWriter) loop() {
+	buffer := deque.New()
+	var outCh LogRecordCh // Output channel - set when there's something to send.
+	var outRec *LogRecord // Next LogRecord to send to the output channel.
+
+	for {
+		// If there's something in the buffer and there's nothing
+		// queued up to send, set up the next LogRecord to send.
+		if outCh == nil {
+			if item, haveItem := buffer.PopFront(); haveItem {
+				outRec = item.(*LogRecord)
+				outCh = w.out
+			}
+		}
+
+		select {
+		case inRec, ok := <-w.in:
+			if !ok {
+				// Input channel has been closed; finish up.
+				close(w.out)
+				return
+			}
+
+			buffer.PushBack(inRec)
+
+			if buffer.Len() > w.maxLen {
+				// The buffer has exceeded the limit - discard the
+				// next LogRecord from the front of the queue.
+				buffer.PopFront()
+				outRec.DroppedAfter++
+			}
+
+		case outCh <- outRec:
+			outCh = nil // Signal that send happened.
+		}
+	}
+
+}
+
+// Write sends a new log message to the writer. This implements the loggo.Writer interface.
+func (w *BufferedLogWriter) Write(level loggo.Level, module, filename string, line int, ts time.Time, message string) {
+	w.in <- &LogRecord{
+		Time:     ts,
+		Module:   module,
+		Location: fmt.Sprintf("%s:%d", filepath.Base(filename), line),
+		Level:    level,
+		Message:  message,
+	}
+}
+
+// Logs returns a channel which emits log messages that have been sent
+// to the BufferedLogWriter instance.
+func (w *BufferedLogWriter) Logs() LogRecordCh {
+	return w.out
+}
+
+// Close cleans up the BufferedLogWriter instance. The output channel
+// returned by the Logs method will be closed and any further Write
+// calls will panic.
+func (w *BufferedLogWriter) Close() {
+	close(w.in)
+}

--- a/worker/logsender/bufferedlogwriter_test.go
+++ b/worker/logsender/bufferedlogwriter_test.go
@@ -1,0 +1,149 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENSE file for details.
+
+package logsender_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/logsender"
+)
+
+const maxLen = 6
+
+type bufferedLogWriterSuite struct {
+	coretesting.BaseSuite
+	writer      *logsender.BufferedLogWriter
+	shouldClose bool
+}
+
+var _ = gc.Suite(&bufferedLogWriterSuite{})
+
+func (s *bufferedLogWriterSuite) SetUpTest(c *gc.C) {
+	s.writer = logsender.NewBufferedLogWriter(maxLen)
+	s.shouldClose = true
+}
+
+func (s *bufferedLogWriterSuite) TearDownTest(c *gc.C) {
+	if s.shouldClose {
+		s.writer.Close()
+	}
+}
+
+func (s *bufferedLogWriterSuite) TestOne(c *gc.C) {
+	s.writeAndReceive(c)
+}
+
+func (s *bufferedLogWriterSuite) TestMultiple(c *gc.C) {
+	for i := 0; i < 10; i++ {
+		s.writeAndReceive(c)
+	}
+}
+
+func (s *bufferedLogWriterSuite) TestBuffering(c *gc.C) {
+	// Write several log message before attempting to read them out.
+	const numMessages = 5
+	now := time.Now()
+	for i := 0; i < numMessages; i++ {
+		s.writer.Write(
+			loggo.Level(i),
+			fmt.Sprintf("module%d", i),
+			fmt.Sprintf("filename%d", i),
+			i, // line number
+			now.Add(time.Duration(i)),
+			fmt.Sprintf("message%d", i),
+		)
+	}
+
+	for i := 0; i < numMessages; i++ {
+		c.Assert(*s.receiveOne(c), gc.DeepEquals, logsender.LogRecord{
+			Time:     now.Add(time.Duration(i)),
+			Module:   fmt.Sprintf("module%d", i),
+			Location: fmt.Sprintf("filename%d:%d", i, i),
+			Level:    loggo.Level(i),
+			Message:  fmt.Sprintf("message%d", i),
+		})
+	}
+}
+
+func (s *bufferedLogWriterSuite) TestLimiting(c *gc.C) {
+	write := func(msgNum int) {
+		s.writer.Write(loggo.INFO, "module", "filename", 42, time.Now(), fmt.Sprintf("log%d", msgNum))
+	}
+
+	expect := func(msgNum, dropped int) {
+		rec := s.receiveOne(c)
+		c.Assert(rec.Message, gc.Equals, fmt.Sprintf("log%d", msgNum))
+		c.Assert(rec.DroppedAfter, gc.Equals, dropped)
+	}
+
+	// Write more logs than the buffer allows.
+	for i := 0; i < maxLen+3; i++ {
+		write(i)
+	}
+
+	// Read some logs from the writer.
+
+	// Even though logs have been dropped, log 0 is still seen
+	// first. This is useful because means the time range for dropped
+	// logs can be observed.
+	expect(0, 2) // logs 1 and 2 dropped here
+	expect(3, 0)
+	expect(4, 0)
+
+	// Now write more logs, again exceeding the limit.
+	for i := maxLen + 3; i < maxLen+3+maxLen; i++ {
+		write(i)
+	}
+
+	// Read all the remaining logs off.
+	expect(5, 3) // logs 6, 7 and 8 logs dropped here
+	for i := 9; i < maxLen+3+maxLen; i++ {
+		expect(i, 0)
+	}
+}
+
+func (s *bufferedLogWriterSuite) TestClose(c *gc.C) {
+	s.writer.Close()
+	s.shouldClose = false // Prevent the usual teardown (calling Close twice will panic)
+
+	// Output channel closing means the bufferedLogWriterSuite loop
+	// has finished.
+	select {
+	case _, ok := <-s.writer.Logs():
+		c.Assert(ok, jc.IsFalse)
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for output channel to close")
+	}
+
+	// Further Write attempts should fail.
+	c.Assert(func() { s.writeAndReceive(c) }, gc.PanicMatches, ".+ send on closed channel")
+}
+
+func (s *bufferedLogWriterSuite) writeAndReceive(c *gc.C) {
+	now := time.Now()
+	s.writer.Write(loggo.INFO, "module", "filename", 99, now, "message")
+	c.Assert(*s.receiveOne(c), gc.DeepEquals, logsender.LogRecord{
+		Time:     now,
+		Module:   "module",
+		Location: "filename:99",
+		Level:    loggo.INFO,
+		Message:  "message",
+	})
+}
+
+func (s *bufferedLogWriterSuite) receiveOne(c *gc.C) *logsender.LogRecord {
+	select {
+	case rec := <-s.writer.Logs():
+		return rec
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for log record")
+	}
+	panic("should never get here")
+}

--- a/worker/logsender/package_test.go
+++ b/worker/logsender/package_test.go
@@ -1,4 +1,4 @@
-package logsender
+package logsender_test
 
 import (
 	stdtesting "testing"

--- a/worker/logsender/worker.go
+++ b/worker/logsender/worker.go
@@ -5,7 +5,6 @@ package logsender
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -18,21 +17,11 @@ import (
 	"github.com/juju/juju/worker"
 )
 
-// LogRecord represents a log message in an agent which is to be
-// transmitted to the JES.
-type LogRecord struct {
-	Time     time.Time
-	Module   string
-	Location string
-	Level    loggo.Level
-	Message  string
-}
-
 var logger = loggo.GetLogger("juju.worker.logsender")
 
 // New starts a logsender worker which reads log message structs from
 // a channel and sends them to the JES via the logsink API.
-func New(logs chan *LogRecord, apiInfo *api.Info) worker.Worker {
+func New(logs LogRecordCh, apiInfo *api.Info) worker.Worker {
 	loop := func(stop <-chan struct{}) error {
 		logger.Debugf("starting logsender worker")
 

--- a/worker/logsender/worker_test.go
+++ b/worker/logsender/worker_test.go
@@ -20,14 +20,14 @@ import (
 	"github.com/juju/juju/worker/logsender"
 )
 
-type Suite struct {
+type workerSuite struct {
 	jujutesting.JujuConnSuite
 	apiInfo *api.Info
 }
 
-var _ = gc.Suite(&Suite{})
+var _ = gc.Suite(&workerSuite{})
 
-func (s *Suite) SetUpTest(c *gc.C) {
+func (s *workerSuite) SetUpTest(c *gc.C) {
 	s.SetInitialFeatureFlags(feature.DbLog)
 	s.JujuConnSuite.SetUpTest(c)
 
@@ -41,7 +41,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	s.apiInfo.Nonce = nonce
 }
 
-func (s *Suite) TestLogSending(c *gc.C) {
+func (s *workerSuite) TestLogSending(c *gc.C) {
 	const logCount = 5
 	logsCh := make(chan *logsender.LogRecord, logCount)
 


### PR DESCRIPTION
BufferedLogWriter is a loggo.Writer that caches log messages for later retrieval. It will be used to feed the logsender worker.

Also: 
* fixed package in package_test
* renamed the suite in worker_test to be more specific
* defined a type alias for "chan *LogRecord".

(Review request: http://reviews.vapour.ws/r/1457/)