### PR TITLE
Addressable containers with static IPs now under a feature flag

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
@@ -57,6 +58,7 @@ var _ = gc.Suite(&provisionerSuite{})
 
 func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 
 	var err error
 	s.machine, err = s.State.AddMachine("quantal", state.JobManageEnviron)

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -231,7 +231,7 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 		}
 	}
 
-	if err := environs.AddressAllocationEnabled(); err != nil {
+	if !environs.AddressAllocationEnabled() {
 		// No need to even try checking the environ for support.
 		logger.Debugf("address allocation feature flag not enabled")
 		result.ManagerConfig = cfg
@@ -878,10 +878,12 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 
 // PrepareContainerInterfaceInfo allocates an address and returns
 // information for configuring networking on a container. It accepts
-// container tags as arguments.
+// container tags as arguments. If the address allocation feature flag
+// is not enabled, it returns an error satisfying
+// errors.IsNotSupported().
 func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (params.MachineNetworkConfigResults, error) {
-	if err := environs.AddressAllocationEnabled(); err != nil {
-		return params.MachineNetworkConfigResults{}, err
+	if !environs.AddressAllocationEnabled() {
+		return params.MachineNetworkConfigResults{}, errors.NotSupportedf("address allocation")
 	}
 
 	result := params.MachineNetworkConfigResults{

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -20,6 +20,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -53,6 +54,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 
 func (s *provisionerSuite) setUpTest(c *gc.C, withStateServer bool) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 
 	// Reset previous machines (if any) and create 3 machines
 	// for the tests, plus an optional state server machine.

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -19,6 +19,7 @@ import (
 
 	corecloudinit "github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudinit"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
@@ -152,11 +153,19 @@ func shutdownInitScript(initSystem string) (string, error) {
 	shutdownCmd := "/sbin/shutdown -h now"
 	name := "juju-template-restart"
 	desc := "juju shutdown job"
+
+	execStart := shutdownCmd
+	if err := environs.AddressAllocationEnabled(); err == nil {
+		// Only do the cleanup and replacement of /e/n/i when address
+		// allocation feature flag is enabled.
+		execStart = replaceNetConfCmd + removeCmd + shutdownCmd
+	}
+
 	conf := common.Conf{
 		Desc:         desc,
 		Transient:    true,
 		AfterStopped: "cloud-final",
-		ExecStart:    replaceNetConfCmd + removeCmd + shutdownCmd,
+		ExecStart:    execStart,
 	}
 	svc, err := service.NewService(name, conf, initSystem)
 	if err != nil {

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -155,7 +155,7 @@ func shutdownInitScript(initSystem string) (string, error) {
 	desc := "juju shutdown job"
 
 	execStart := shutdownCmd
-	if err := environs.AddressAllocationEnabled(); err == nil {
+	if environs.AddressAllocationEnabled() {
 		// Only do the cleanup and replacement of /e/n/i when address
 		// allocation feature flag is enabled.
 		execStart = replaceNetConfCmd + removeCmd + shutdownCmd

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -33,6 +33,7 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
 	"github.com/juju/juju/network"
@@ -88,6 +89,7 @@ more bogus content`
 
 func (s *LxcSuite) SetUpTest(c *gc.C) {
 	s.TestSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.logDir = c.MkDir()
 	loggo.GetLogger("juju.container.lxc").SetLogLevel(loggo.TRACE)
 	s.events = make(chan mock.Event, 25)

--- a/environs/cloudinit.go
+++ b/environs/cloudinit.go
@@ -34,6 +34,10 @@ var DataDir = agent.DefaultDataDir
 // may create a folder containing logs
 var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
 
+// DefaultBridgeName is the network bridge device name used for LXC
+// and KVM containers.
+const DefaultBridgeName = "juju-br0"
+
 // NewMachineConfig sets up a basic machine configuration, for a
 // non-bootstrap node. You'll still need to supply more information,
 // but this takes care of the fixed entries and the ones that are

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -93,7 +93,8 @@ type BootstrapParams struct {
 	AvailableTools tools.List
 
 	// ContainerBridgeName, if non-empty, overrides the default
-	// network bridge device to use for LXC and KVM containers.
+	// network bridge device to use for LXC and KVM containers. See
+	// also environs.DefaultBridgeName.
 	ContainerBridgeName string
 }
 

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -4,11 +4,11 @@
 package environs
 
 import (
-	"github.com/juju/errors"
+	"github.com/juju/utils/featureflag"
+
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/utils/featureflag"
 )
 
 // Networking interface defines methods that environments
@@ -57,11 +57,7 @@ func SupportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 }
 
 // AddressAllocationEnabled is a shortcut for checking if the
-// AddressAllocation feature flag is enabled. If not it returns an
-// error satifying errors.IsNotSupported.
-func AddressAllocationEnabled() error {
-	if !featureflag.Enabled(feature.AddressAllocation) {
-		return errors.NotSupportedf("address allocation")
-	}
-	return nil
+// AddressAllocation feature flag is enabled.
+func AddressAllocationEnabled() bool {
+	return featureflag.Enabled(feature.AddressAllocation)
 }

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -4,8 +4,11 @@
 package environs
 
 import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/utils/featureflag"
 )
 
 // Networking interface defines methods that environments
@@ -51,4 +54,14 @@ type NetworkingEnviron interface {
 func SupportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 	ne, ok := environ.(NetworkingEnviron)
 	return ne, ok
+}
+
+// AddressAllocationEnabled is a shortcut for checking if the
+// AddressAllocation feature flag is enabled. If not it returns an
+// error satifying errors.IsNotSupported.
+func AddressAllocationEnabled() error {
+	if !featureflag.Enabled(feature.AddressAllocation) {
+		return errors.NotSupportedf("address allocation")
+	}
+	return nil
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -30,3 +30,8 @@ const LogErrorStack = "log-error-stack"
 // discovery code (service.VersionInitSystem) should return upstart
 // instead of systemd for vivid and newer.
 const LegacyUpstart = "legacy-upstart"
+
+// AddressAllocation is used to indicate that LXC and KVM containers
+// on providers that support that (currently only MAAS and EC2) will
+// use statically allocated IP addresses.
+const AddressAllocation = "address-allocation"

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1024,6 +1024,10 @@ func (e *environ) Instances(ids []instance.Id) (insts []instance.Instance, err e
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error) {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return false, err
+	}
+
 	if err := env.checkBroken("SupportsAddressAllocation"); err != nil {
 		return false, err
 	}
@@ -1038,6 +1042,10 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given subnet.
 func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return err
+	}
+
 	if err := env.checkBroken("AllocateAddress"); err != nil {
 		return err
 	}
@@ -1061,6 +1069,10 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return err
+	}
+
 	if err := env.checkBroken("ReleaseAddress"); err != nil {
 		return err
 	}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1024,8 +1024,8 @@ func (e *environ) Instances(ids []instance.Id) (insts []instance.Instance, err e
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error) {
-	if err := environs.AddressAllocationEnabled(); err != nil {
-		return false, err
+	if !environs.AddressAllocationEnabled() {
+		return false, errors.NotSupportedf("address allocation")
 	}
 
 	if err := env.checkBroken("SupportsAddressAllocation"); err != nil {
@@ -1042,8 +1042,8 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given subnet.
 func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
-	if err := environs.AddressAllocationEnabled(); err != nil {
-		return err
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
 	}
 
 	if err := env.checkBroken("AllocateAddress"); err != nil {
@@ -1069,8 +1069,8 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
-	if err := environs.AddressAllocationEnabled(); err != nil {
-		return err
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
 	}
 
 	if err := env.checkBroken("ReleaseAddress"); err != nil {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/jujutest"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -64,6 +65,7 @@ func (s *liveSuite) TearDownSuite(c *gc.C) {
 
 func (s *liveSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.MgoSuite.SetUpTest(c)
 	s.LiveTests.SetUpTest(c)
 }
@@ -93,6 +95,7 @@ func (s *suite) TearDownSuite(c *gc.C) {
 
 func (s *suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.MgoSuite.SetUpTest(c)
 	s.Tests.SetUpTest(c)
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -218,6 +218,9 @@ func (e *environ) SupportedArchitectures() ([]string, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return false, err
+	}
 	_, hasDefaultVpc, err := e.defaultVpc()
 	if err != nil {
 		return false, errors.Trace(err)
@@ -741,6 +744,10 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
 func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return err
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
 
 	var nicId string
@@ -775,6 +782,10 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
 func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return err
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to release address %q from instance %q", addr, instId)
 
 	// If the instance ID is unknown the address has already been released

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -218,8 +218,8 @@ func (e *environ) SupportedArchitectures() ([]string, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
-	if err := environs.AddressAllocationEnabled(); err != nil {
-		return false, err
+	if !environs.AddressAllocationEnabled() {
+		return false, errors.NotSupportedf("address allocation")
 	}
 	_, hasDefaultVpc, err := e.defaultVpc()
 	if err != nil {
@@ -744,8 +744,8 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
 func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
-	if err := environs.AddressAllocationEnabled(); err != nil {
-		return err
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
@@ -782,8 +782,8 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
 func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
-	if err := environs.AddressAllocationEnabled(); err != nil {
-		return err
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to release address %q from instance %q", addr, instId)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/juju/testing"
@@ -185,6 +186,7 @@ func (t *localServerSuite) TearDownSuite(c *gc.C) {
 
 func (t *localServerSuite) SetUpTest(c *gc.C) {
 	t.BaseSuite.SetUpTest(c)
+	t.SetFeatureFlags(feature.AddressAllocation)
 	t.srv.startServer(c)
 	t.Tests.SetUpTest(c)
 	t.PatchValue(&version.Current, version.Binary{

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1054,6 +1054,10 @@ iface {{.Bridge}} inet dhcp
     bridge_ports ${PRIMARY_IFACE}
 EOF
 
+# Make the primary interface not auto-starting.
+grep -q "auto ${PRIMARY_IFACE}" {{.Config}} && \
+sed -i "s/auto ${PRIMARY_IFACE}//" {{.Config}}
+
 # Finally, stop $PRIMARY_IFACE and start the bridge instead.
 ifdown -v ${PRIMARY_IFACE} ; ifup -v {{.Bridge}}
 `

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/juju/errors"
@@ -21,6 +23,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"launchpad.net/gomaasapi"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudinit"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -113,6 +116,23 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (arch, series string, _ environs.BootstrapFinalizer, _ error) {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		// When address allocation is not enabled, we should use the
+		// default bridge for both LXC and KVM containers. The bridge
+		// is created as part of the userdata for every node during
+		// StartInstance.
+		logger.Infof(
+			"address allocation feature disabled; using %q bridge for all containers",
+			environs.DefaultBridgeName,
+		)
+		args.ContainerBridgeName = environs.DefaultBridgeName
+	} else {
+		logger.Debugf(
+			"address allocation feature enabled; using static IPs for containers",
+			environs.DefaultBridgeName,
+		)
+	}
+
 	result, series, finalizer, err := common.BootstrapInstance(ctx, env, args)
 	if err != nil {
 		return "", "", nil, err
@@ -211,6 +231,10 @@ func (env *maasEnviron) SupportedArchitectures() ([]string, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return false, err
+	}
+
 	caps, err := env.getCapabilities()
 	if err != nil {
 		return false, errors.Annotatef(err, "getCapabilities failed")
@@ -865,6 +889,15 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	if err != nil {
 		return nil, err
 	}
+	// Override the network bridge to use for both LXC and KVM
+	// containers on the new instance, if address allocation feature
+	// flag is not enabled.
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		if args.MachineConfig.AgentEnvironment == nil {
+			args.MachineConfig.AgentEnvironment = make(map[string]string)
+		}
+		args.MachineConfig.AgentEnvironment[agent.LxcBridge] = environs.DefaultBridgeName
+	}
 	if err := environs.FinishMachineConfig(args.MachineConfig, environ.Config()); err != nil {
 		return nil, err
 	}
@@ -996,6 +1029,52 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 	return &node, nil
 }
 
+const bridgeConfigTemplate = `
+# In case we already created the bridge, don't do it again.
+grep -q "iface {{.Bridge}} inet dhcp" && exit 0
+
+# Discover primary interface at run-time using the default route (if set)
+PRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)
+
+# If $PRIMARY_IFACE is empty, there's nothing to do.
+[ -z "$PRIMARY_IFACE" ] && exit 0
+
+# Change the config to make $PRIMARY_IFACE manual instead of DHCP,
+# then create the bridge and enslave $PRIMARY_IFACE into it.
+grep -q "iface ${PRIMARY_IFACE} inet dhcp" {{.Config}} && \
+sed -i "s/iface ${PRIMARY_IFACE} inet dhcp//" {{.Config}} && \
+cat >> {{.Config}} << EOF
+
+# Primary interface (defining the default route)
+iface ${PRIMARY_IFACE} inet manual
+
+# Bridge to use for LXC/KVM containers
+auto {{.Bridge}}
+iface {{.Bridge}} inet dhcp
+    bridge_ports ${PRIMARY_IFACE}
+EOF
+
+# Finally, stop $PRIMARY_IFACE and start the bridge instead.
+ifdown -v ${PRIMARY_IFACE} ; ifup -v {{.Bridge}}
+`
+
+// setupJujuNetworking returns a string representing the script to run
+// in order to prepare the Juju-specific networking config on a node.
+func setupJujuNetworking() (string, error) {
+	parsedTemplate := template.Must(
+		template.New("BridgeConfig").Parse(bridgeConfigTemplate),
+	)
+	var buf bytes.Buffer
+	err := parsedTemplate.Execute(&buf, map[string]interface{}{
+		"Config": "/etc/network/interfaces",
+		"Bridge": environs.DefaultBridgeName,
+	})
+	if err != nil {
+		return "", errors.Annotate(err, "bridge config template error")
+	}
+	return buf.String(), nil
+}
+
 // newCloudinitConfig creates a cloudinit.Config structure
 // suitable as a base for initialising a MAAS node.
 func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, series string) (*cloudinit.Config, error) {
@@ -1018,6 +1097,26 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, series st
 	case version.Ubuntu:
 		cloudcfg.SetAptUpdate(true)
 		cloudcfg.AddScripts("set -xe", runCmd)
+		// Only create the default bridge if we're not using static
+		// address allocation for containers.
+		if err := environs.AddressAllocationEnabled(); err != nil {
+			// Address allocated feature flag might be disabled, but
+			// DisableNetworkManagement can still disable the bridge
+			// creation.
+			if on, set := environ.Config().DisableNetworkManagement(); on && set {
+				logger.Infof(
+					"network management disabled - not using %q bridge for containers",
+					environs.DefaultBridgeName,
+				)
+				break
+			}
+			bridgeScript, err := setupJujuNetworking()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			cloudcfg.AddPackage("bridge-utils")
+			cloudcfg.AddRunCmd(bridgeScript)
+		}
 	}
 	return cloudcfg, nil
 }
@@ -1159,6 +1258,10 @@ func (environ *maasEnviron) Instances(ids []instance.Id) ([]instance.Instance, e
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
 func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) (err error) {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return err
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
 	var subnets []network.SubnetInfo
 
@@ -1206,6 +1309,10 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		return err
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to release IP address %q from instance %q", addr, instId)
 	ipaddresses := environ.getMAASClient().GetSubObject("ipaddresses")
 	// This can return a 404 error if the address has already been released

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/provider/maas"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -42,6 +43,7 @@ func (s *environSuite) SetUpSuite(c *gc.C) {
 func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 }
 
 func (s *environSuite) TearDownTest(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -44,6 +45,7 @@ func (s *providerSuite) SetUpSuite(c *gc.C) {
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 }
 
 func (s *providerSuite) TearDownTest(c *gc.C) {

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -31,6 +32,7 @@ type workerSuite struct {
 
 func (s *workerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	// Unbreak dummy provider methods.
 	s.AssertConfigParameterUpdated(c, "broken", "")
 

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -190,19 +190,23 @@ func (cs *ContainerSetup) runInitialiser(containerType instance.ContainerType, i
 	}
 	defer cs.initLock.Unlock()
 
-	// In order to guarantee stable statically assigned IP addresses
-	// for LXC containers, we need to install a custom version of
-	// /etc/default/lxc-net before we install the lxc package. The
-	// custom version of lxc-net is almost the same as the original,
-	// but the defined LXC_DHCP_RANGE (used by dnsmasq to give away
-	// 10.0.3.x addresses to containers bound to lxcbr0) has infinite
-	// lease time. This is necessary, because with the default lease
-	// time of 1h, dhclient running inside each container will request
-	// a renewal from dnsmasq and replace our statically configured IP
-	// address within an hour after starting the container.
-	err := maybeOverrideDefaultLXCNet(containerType, cs.addressableContainers)
-	if err != nil {
-		return errors.Trace(err)
+	// Only tweak default LXC network config when address allocation
+	// feature flag is enabled.
+	if err := environs.AddressAllocationEnabled(); err == nil {
+		// In order to guarantee stable statically assigned IP addresses
+		// for LXC containers, we need to install a custom version of
+		// /etc/default/lxc-net before we install the lxc package. The
+		// custom version of lxc-net is almost the same as the original,
+		// but the defined LXC_DHCP_RANGE (used by dnsmasq to give away
+		// 10.0.3.x addresses to containers bound to lxcbr0) has infinite
+		// lease time. This is necessary, because with the default lease
+		// time of 1h, dhclient running inside each container will request
+		// a renewal from dnsmasq and replace our statically configured IP
+		// address within an hour after starting the container.
+		err := maybeOverrideDefaultLXCNet(containerType, cs.addressableContainers)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	if err := initialiser.Initialise(); err != nil {

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -192,7 +192,7 @@ func (cs *ContainerSetup) runInitialiser(containerType instance.ContainerType, i
 
 	// Only tweak default LXC network config when address allocation
 	// feature flag is enabled.
-	if err := environs.AddressAllocationEnabled(); err == nil {
+	if environs.AddressAllocationEnabled() {
 		// In order to guarantee stable statically assigned IP addresses
 		// for LXC containers, we need to install a custom version of
 		// /etc/default/lxc-net before we install the lxc package. The

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/container"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/state"
@@ -68,6 +69,7 @@ func noImportance(err0, err1 error) bool {
 
 func (s *ContainerSetupSuite) SetUpTest(c *gc.C) {
 	s.CommonProvisionerSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	aptCmdChan := s.HookCommandOutput(&apt.CommandOutput, []byte{}, nil)
 	s.aptCmdChan = aptCmdChan
 

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -60,7 +60,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = kvm.DefaultKvmBridge
 	}
 
-	if err := environs.AddressAllocationEnabled(); err != nil {
+	if !environs.AddressAllocationEnabled() {
 		logger.Debugf(
 			"address allocation feature flag not enabled; using DHCP for container %q",
 			machineId,

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -60,16 +60,25 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = kvm.DefaultKvmBridge
 	}
 
-	allocatedInfo, err := maybeAllocateStaticIP(
-		machineId, bridgeDevice, broker.api,
-		args.NetworkInfo, broker.enableNAT,
-	)
-	if err != nil {
-		// It's fine, just ignore it. The effect will be that the
-		// container won't have a static address configured.
-		logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+	if err := environs.AddressAllocationEnabled(); err != nil {
+		logger.Debugf(
+			"address allocation feature flag not enabled; using DHCP for container %q",
+			machineId,
+		)
 	} else {
-		args.NetworkInfo = allocatedInfo
+		logger.Debugf("trying to allocate static IP for container %q", machineId)
+
+		allocatedInfo, err := maybeAllocateStaticIP(
+			machineId, bridgeDevice, broker.api,
+			args.NetworkInfo, broker.enableNAT,
+		)
+		if err != nil {
+			// It's fine, just ignore it. The effect will be that the
+			// container won't have a static address configured.
+			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+		} else {
+			args.NetworkInfo = allocatedInfo
+		}
 	}
 
 	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -83,7 +83,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
-	if err := environs.AddressAllocationEnabled(); err != nil {
+	if !environs.AddressAllocationEnabled() {
 		logger.Debugf(
 			"address allocation feature flag not enabled; using DHCP for container %q",
 			machineId,


### PR DESCRIPTION
NOTE: Live-tested only, but using multiple setups. Unit tests will come in a follow-up,
as this is a critical fix for 15.04.

For the MAAS provider, we are reintroducing the legacy 1.22 behavior of
having juju-br0 bridge created on each node and used by both LXC and KVM
containers on that node.

When an environment is bootstrapped from a machine where the environment
variable JUJU_DEV_FEATURE_FLAGS is set to "address-allocation" (or its
value includes the flag, when multiple flags are specified in a comma-
separated list), the new addressable containers with statically
allocated IP addresses is enabled on both MAAS and EC2. For MAAS this
means the juju-br0 bridge won't be created.

In contrast with 1.22, the primary network interface on the host is
discovered at by checking which device is on the default route. Unline
in 1.22, where we only used the lshw dump for the respective node
available via the MAAS API, to determine the primary device, now we do
it at run-time so it's much more accurate and closer to reality. Then,
the juju-br0 is created and the primary host interface is enslaved into
it.

Live tested with multiple configs on MAAS 1.7.2, 1.8.0-beta2, and EC2
with both precise and trusty, and the feature flag enabled and disabled.

(Review request: http://reviews.vapour.ws/r/1459/)