### PR TITLE
Makefile added check for gocheck in non test code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,11 @@ install-etc:
 	@echo Installing bash completion
 	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-core /etc/bash_completion.d
 
+GOCHECK_COUNT="$(shell go list -f '{{join .Deps "\n"}}' github.com/juju/juju/... | grep -c "gopkg.in/check.v*")"
+check-deps:
+	@echo "$(GOCHECK_COUNT) instances of gocheck not in test code"
+
 .PHONY: build check install
 .PHONY: clean format simplify
 .PHONY: install-dependencies
+.PHONY: check-deps


### PR DESCRIPTION
There are a number of places in the code where gocheck ends up being imported in code that isn't tests code. We should start getting rid of places where this occurs. The first step is awareness

(Review request: http://reviews.vapour.ws/r/1460/)