### PR TITLE
leadership 1.23 -> master

### DIFF
--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -565,7 +565,7 @@ func (s *prepareSuite) TestErrorWhenNoNICSAvailable(c *gc.C) {
 	s.assertCall(c, args, nil, "cannot allocate addresses: no interfaces available")
 }
 
-func (s *prepareSuite) TestErrorWithNicNoSubnetAvailable(c *gc.C) {
+func (s *prepareSuite) TestErrorWithNICNoSubnetAvailable(c *gc.C) {
 	// The magic "i-nic-no-subnet-" instance id prefix for the host
 	// causes the dummy provider to return a nic that has no associated
 	// subnet from NetworkInterfaces().

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -1560,7 +1560,7 @@ func leadershipSettingsAccessorFactory(
 	// should support a native read of this format straight from
 	// state.
 	getSettings := func(serviceId string) (map[string]string, error) {
-		settings, err := st.ReadSettings(state.LeadershipSettingsDocId(serviceId))
+		settings, err := st.ReadLeadershipSettings(serviceId)
 		if err != nil {
 			return nil, err
 		}

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/lxc"
-
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/instance"

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -18,10 +18,6 @@ const JES = "jes"
 // and server-side functionality.
 const Storage = "storage"
 
-// LeaderElection is the name of the feature to enable leadership hooks
-// and hook tools.
-const LeaderElection = "leader-election"
-
 // LogErrorStack is a developer feature flag to have the LoggedErrorStack
 // function in the utils package write out the error stack as defined by the
 // errors package to the logger.  The ability to log the error stack is very

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -26,6 +26,7 @@ import (
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
@@ -264,41 +265,33 @@ func (s *uniterLeadershipSuite) TestSettingsChangeNotifier(c *gc.C) {
 	client := uniter.NewState(s.facadeCaller.RawAPICaller(), names.NewUnitTag(s.unitId))
 
 	// Listen for changes
-	readyForChanges := make(chan struct{})
-	sawChanges := make(chan struct{})
-	go func() {
-		watcher, err := client.LeadershipSettings.WatchLeadershipSettings(s.serviceId)
-		c.Assert(err, gc.IsNil)
-
-		// Ignore the initial event
-		<-watcher.Changes()
-		readyForChanges <- struct{}{}
-
-		if change, ok := <-watcher.Changes(); ok {
-			sawChanges <- change
-		} else {
-			c.Fatalf("watcher failed to send a change: %s", watcher.Err())
-		}
-	}()
-
-	select {
-	case <-readyForChanges:
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out")
-	}
-
-	c.Log("Writing changes...")
-	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"foo": "bar"})
+	watcher, err := client.LeadershipSettings.WatchLeadershipSettings(s.serviceId)
 	c.Assert(err, gc.IsNil)
 
-	c.Log("Waiting to see that watcher saw changes...")
-	notifyAsserter := coretesting.NotifyAsserterC{C: c, Chan: sawChanges}
-	notifyAsserter.AssertOneReceive()
+	defer statetesting.AssertStop(c, watcher)
 
+	leadershipC := statetesting.NewNotifyWatcherC(c, s.BackingState, watcher)
+	// Inital event
+	leadershipC.AssertOneChange()
+
+	// Make some changes
+	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"foo": "bar"})
+	c.Assert(err, gc.IsNil)
+	leadershipC.AssertOneChange()
+
+	// And check that the changes were actually applied
 	settings, err := client.LeadershipSettings.Read(s.serviceId)
 	c.Assert(err, gc.IsNil)
 
 	c.Check(settings["foo"], gc.Equals, "bar")
+
+	// Make a couple of changes, and then check that they have been
+	// coalesced into a single event
+	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"foo": "baz"})
+	c.Assert(err, gc.IsNil)
+	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"bing": "bong"})
+	c.Assert(err, gc.IsNil)
+	leadershipC.AssertOneChange()
 }
 
 func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {

--- a/worker/leadership/interface.go
+++ b/worker/leadership/interface.go
@@ -44,6 +44,10 @@ type Tracker interface {
 	// WaitLeader will return a Ticket which, when Wait()ed for, will block
 	// until the tracker attains leadership.
 	WaitLeader() Ticket
+
+	// WaitMinion will return a Ticket which, when Wait()ed for, will block
+	// until the tracker's future leadership can no longer be guaranteed.
+	WaitMinion() Ticket
 }
 
 // TrackerWorker embeds the Tracker and worker.Worker interfaces.

--- a/worker/leadership/tracker.go
+++ b/worker/leadership/tracker.go
@@ -25,11 +25,13 @@ type tracker struct {
 	duration    time.Duration
 	isMinion    bool
 
-	claimLease   chan struct{}
-	renewLease   <-chan time.Time
-	claimTickets chan chan bool
-	waitTickets  chan chan bool
-	waiting      []chan bool
+	claimLease        chan struct{}
+	renewLease        <-chan time.Time
+	claimTickets      chan chan bool
+	waitLeaderTickets chan chan bool
+	waitMinionTickets chan chan bool
+	waitingLeader     []chan bool
+	waitingMinion     []chan bool
 }
 
 // NewTrackerWorker returns a TrackerWorker that attempts to claim and retain
@@ -44,21 +46,40 @@ func NewTrackerWorker(tag names.UnitTag, leadership leadership.LeadershipManager
 	unitName := tag.Id()
 	serviceName, _ := names.UnitService(unitName)
 	t := &tracker{
-		unitName:     unitName,
-		serviceName:  serviceName,
-		leadership:   leadership,
-		duration:     duration,
-		claimTickets: make(chan chan bool),
-		waitTickets:  make(chan chan bool),
+		unitName:          unitName,
+		serviceName:       serviceName,
+		leadership:        leadership,
+		duration:          duration,
+		claimTickets:      make(chan chan bool),
+		waitLeaderTickets: make(chan chan bool),
+		waitMinionTickets: make(chan chan bool),
 	}
 	go func() {
 		defer t.tomb.Done()
 		defer func() {
-			for _, ticketCh := range t.waiting {
+			for _, ticketCh := range t.waitingLeader {
+				close(ticketCh)
+			}
+			for _, ticketCh := range t.waitingMinion {
 				close(ticketCh)
 			}
 		}()
-		t.tomb.Kill(t.loop())
+		err := t.loop()
+		// TODO: jam 2015-04-02 is this the most elegant way to make
+		// sure we shutdown cleanly? Essentially the lowest level sees
+		// that we are dying, and propagates an ErrDying up to us so
+		// that we shut down, which we then are passing back into
+		// Tomb.Kill().
+		// Tomb.Kill() special cases the exact object ErrDying, and has
+		// no idea about errors.Cause and the general errors.Trace
+		// mechanisms that we use.
+		// So we explicitly unwrap before calling tomb.Kill() else
+		// tomb.Stop() thinks that we have a genuine error.
+		switch cause := errors.Cause(err); cause {
+		case tomb.ErrDying:
+			err = cause
+		}
+		t.tomb.Kill(err)
 	}()
 	return t
 }
@@ -90,7 +111,12 @@ func (t *tracker) ClaimLeader() Ticket {
 
 // WaitLeader is part of the Tracker interface.
 func (t *tracker) WaitLeader() Ticket {
-	return t.submit(t.waitTickets)
+	return t.submit(t.waitLeaderTickets)
+}
+
+// WaitMinion is part of the Tracker interface.
+func (t *tracker) WaitMinion() Ticket {
+	return t.submit(t.waitMinionTickets)
 }
 
 func (t *tracker) loop() error {
@@ -119,9 +145,14 @@ func (t *tracker) loop() error {
 			if err := t.resolveClaim(ticketCh); err != nil {
 				return errors.Trace(err)
 			}
-		case ticketCh := <-t.waitTickets:
+		case ticketCh := <-t.waitLeaderTickets:
 			logger.Infof("%s got wait request for %s leadership", t.unitName, t.serviceName)
-			if err := t.resolveWait(ticketCh); err != nil {
+			if err := t.resolveWaitLeader(ticketCh); err != nil {
+				return errors.Trace(err)
+			}
+		case ticketCh := <-t.waitMinionTickets:
+			logger.Infof("%s got wait request for %s leadership loss", t.unitName, t.serviceName)
+			if err := t.resolveWaitMinion(ticketCh); err != nil {
 				return errors.Trace(err)
 			}
 		}
@@ -153,9 +184,10 @@ func (t *tracker) setLeader(untilTime time.Time) error {
 	t.claimLease = nil
 	t.renewLease = time.After(renewTime.Sub(time.Now()))
 
-	for len(t.waiting) > 0 {
+	for len(t.waitingLeader) > 0 {
+		logger.Infof("notifying %s ticket of impending %s leadership", t.unitName, t.serviceName)
 		var ticketCh chan bool
-		ticketCh, t.waiting = t.waiting[0], t.waiting[1:]
+		ticketCh, t.waitingLeader = t.waitingLeader[0], t.waitingLeader[1:]
 		defer close(ticketCh)
 		if err := t.sendTrue(ticketCh); err != nil {
 			return errors.Trace(err)
@@ -186,6 +218,16 @@ func (t *tracker) setMinion() error {
 			// around that...)
 		}()
 	}
+
+	for len(t.waitingMinion) > 0 {
+		logger.Infof("notifying %s ticket of impending loss of %s leadership", t.unitName, t.serviceName)
+		var ticketCh chan bool
+		ticketCh, t.waitingMinion = t.waitingMinion[0], t.waitingMinion[1:]
+		defer close(ticketCh)
+		if err := t.sendTrue(ticketCh); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	return nil
 }
 
@@ -195,7 +237,7 @@ func (t *tracker) isLeader() (bool, error) {
 		// Last time we looked, we were leader.
 		select {
 		case <-t.tomb.Dying():
-			return false, tomb.ErrDying
+			return false, errors.Trace(tomb.ErrDying)
 		case <-t.renewLease:
 			logger.Infof("%s renewing lease for %s leadership", t.unitName, t.serviceName)
 			t.renewLease = nil
@@ -224,12 +266,12 @@ func (t *tracker) resolveClaim(ticketCh chan bool) error {
 	return t.sendTrue(ticketCh)
 }
 
-// resolveWait will send true on the supplied channel if leadership can be
+// resolveWaitLeader will send true on the supplied channel if leadership can be
 // guaranteed for the tracker's duration. It will then close the channel. If
 // leadership cannot be guaranteed, the channel is left untouched until either
 // the termination of the tracker or the next invocation of setLeader; at which
 // point true is sent if applicable, and the channel is closed.
-func (t *tracker) resolveWait(ticketCh chan bool) error {
+func (t *tracker) resolveWaitLeader(ticketCh chan bool) error {
 	var dontClose bool
 	defer func() {
 		if !dontClose {
@@ -245,9 +287,32 @@ func (t *tracker) resolveWait(ticketCh chan bool) error {
 	}
 
 	logger.Infof("waiting for %s to attain %s leadership", t.unitName, t.serviceName)
-	t.waiting = append(t.waiting, ticketCh)
+	t.waitingLeader = append(t.waitingLeader, ticketCh)
 	dontClose = true
 	return nil
+}
+
+// resolveWaitMinion will close the supplied channel as soon as leadership cannot
+// be guaranteed beyond the tracker's duration.
+func (t *tracker) resolveWaitMinion(ticketCh chan bool) error {
+	var dontClose bool
+	defer func() {
+		if !dontClose {
+			close(ticketCh)
+		}
+	}()
+
+	if leader, err := t.isLeader(); err != nil {
+		return errors.Trace(err)
+	} else if leader {
+		logger.Infof("waiting for %s to lose %s leadership", t.unitName, t.serviceName)
+		t.waitingMinion = append(t.waitingMinion, ticketCh)
+		dontClose = true
+	} else {
+		logger.Infof("reporting %s leadership loss for %s", t.serviceName, t.unitName)
+	}
+	return nil
+
 }
 
 func (t *tracker) sendTrue(ticketCh chan bool) error {

--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -13,8 +13,9 @@ func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
 }
 
 var (
-	ActiveMetricsTimer = &activeMetricsTimer
-	IdleWaitTime       = &idleWaitTime
+	ActiveMetricsTimer  = &activeMetricsTimer
+	IdleWaitTime        = &idleWaitTime
+	LeadershipGuarantee = &leadershipGuarantee
 )
 
 // manualTicker will be used to generate collect-metrics events

--- a/worker/uniter/filter/filter.go
+++ b/worker/uniter/filter/filter.go
@@ -34,28 +34,35 @@ type filter struct {
 	// The out* chans, when set to the corresponding out*On chan (rather than
 	// nil) indicate that an event of the appropriate type is ready to send
 	// to the client.
-	outConfig        chan struct{}
-	outConfigOn      chan struct{}
-	outAction        chan string
-	outActionOn      chan string
-	outUpgrade       chan *charm.URL
-	outUpgradeOn     chan *charm.URL
-	outResolved      chan params.ResolvedMode
-	outResolvedOn    chan params.ResolvedMode
-	outRelations     chan []int
-	outRelationsOn   chan []int
-	outMeterStatus   chan struct{}
-	outMeterStatusOn chan struct{}
-	outStorage       chan []names.StorageTag
-	outStorageOn     chan []names.StorageTag
+	outConfig           chan struct{}
+	outConfigOn         chan struct{}
+	outAction           chan string
+	outActionOn         chan string
+	outLeaderSettings   chan struct{}
+	outLeaderSettingsOn chan struct{}
+	outUpgrade          chan *charm.URL
+	outUpgradeOn        chan *charm.URL
+	outResolved         chan params.ResolvedMode
+	outResolvedOn       chan params.ResolvedMode
+	outRelations        chan []int
+	outRelationsOn      chan []int
+	outMeterStatus      chan struct{}
+	outMeterStatusOn    chan struct{}
+	outStorage          chan []names.StorageTag
+	outStorageOn        chan []names.StorageTag
 	// The want* chans are used to indicate that the filter should send
 	// events if it has them available.
-	wantForcedUpgrade chan bool
-	wantResolved      chan struct{}
+	wantForcedUpgrade  chan bool
+	wantResolved       chan struct{}
+	wantLeaderSettings chan bool
 
 	// discardConfig is used to indicate that any pending config event
 	// should be discarded.
 	discardConfig chan struct{}
+
+	// discardLeaderSettings is used to indicate any pending Leader
+	// Settings event should be discarded.
+	discardLeaderSettings chan struct{}
 
 	// setCharm is used to request that the unit's charm URL be set to
 	// a new value. This must be done in the filter's goroutine, so
@@ -104,29 +111,25 @@ type filter struct {
 // supplied unit.
 func NewFilter(st *uniter.State, unitTag names.UnitTag) (Filter, error) {
 	f := &filter{
-		st:                st,
-		outUnitDying:      make(chan struct{}),
-		outConfig:         nil,
-		outConfigOn:       make(chan struct{}),
-		outAction:         nil,
-		outActionOn:       make(chan string),
-		outUpgrade:        nil,
-		outUpgradeOn:      make(chan *charm.URL),
-		outResolved:       nil,
-		outResolvedOn:     make(chan params.ResolvedMode),
-		outRelations:      nil,
-		outRelationsOn:    make(chan []int),
-		outMeterStatus:    nil,
-		outMeterStatusOn:  make(chan struct{}),
-		outStorage:        nil,
-		outStorageOn:      make(chan []names.StorageTag),
-		wantForcedUpgrade: make(chan bool),
-		wantResolved:      make(chan struct{}),
-		discardConfig:     make(chan struct{}),
-		setCharm:          make(chan *charm.URL),
-		didSetCharm:       make(chan struct{}),
-		clearResolved:     make(chan struct{}),
-		didClearResolved:  make(chan struct{}),
+		st:                    st,
+		outUnitDying:          make(chan struct{}),
+		outConfigOn:           make(chan struct{}),
+		outActionOn:           make(chan string),
+		outLeaderSettingsOn:   make(chan struct{}),
+		outUpgradeOn:          make(chan *charm.URL),
+		outResolvedOn:         make(chan params.ResolvedMode),
+		outRelationsOn:        make(chan []int),
+		outMeterStatusOn:      make(chan struct{}),
+		outStorageOn:          make(chan []names.StorageTag),
+		wantForcedUpgrade:     make(chan bool),
+		wantResolved:          make(chan struct{}),
+		wantLeaderSettings:    make(chan bool),
+		discardConfig:         make(chan struct{}),
+		discardLeaderSettings: make(chan struct{}),
+		setCharm:              make(chan *charm.URL),
+		didSetCharm:           make(chan struct{}),
+		clearResolved:         make(chan struct{}),
+		didClearResolved:      make(chan struct{}),
 	}
 	go func() {
 		defer f.tomb.Done()
@@ -263,6 +266,40 @@ func (f *filter) ClearResolved() error {
 	}
 }
 
+// LeaderSettingsEvents returns a channel that will receive an event whenever
+// there is a leader settings change. Events can be temporarily suspended by
+// calling WantLeaderSettingsEvents(false), and then reenabled by calling
+// WantLeaderSettingsEvents(true)
+func (f *filter) LeaderSettingsEvents() <-chan struct{} {
+	return f.outLeaderSettingsOn
+}
+
+// DiscardLeaderSettingsEvent can be called to discard any pending
+// LeaderSettingsEvents. This is used by code that saw a LeaderSettings change,
+// and has been prepping for a response. Just before they request the current
+// LeaderSettings, they can discard any other pending changes, since they know
+// they will be handling all changes that have occurred before right now.
+func (f *filter) DiscardLeaderSettingsEvent() {
+	select {
+	case <-f.tomb.Dying():
+	case f.discardLeaderSettings <- nothing:
+	}
+}
+
+// WantLeaderSettingsEvents can be used to enable/disable events being sent on
+// the LeaderSettingsEvents() channel. This is used when an agent notices that
+// it is the leader, it wants to disable getting events for changes that it is
+// generating. Calling this with sendEvents=false disables getting change
+// events. Calling this with sendEvents=true will enable future changes, and
+// queues up an immediate event so that the agent will refresh its information
+// for any events it might have missed while it thought it was the leader.
+func (f *filter) WantLeaderSettingsEvents(sendEvents bool) {
+	select {
+	case <-f.tomb.Dying():
+	case f.wantLeaderSettings <- sendEvents:
+	}
+}
+
 // DiscardConfigEvent indicates that the filter should discard any pending
 // config event.
 func (f *filter) DiscardConfigEvent() {
@@ -354,6 +391,17 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 		return err
 	}
 	defer watcher.Stop(storagew, &f.tomb)
+	leaderSettingsw, err := f.st.LeadershipSettings.WatchLeadershipSettings(f.service.Tag().Id())
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop(leaderSettingsw, &f.tomb)
+
+	// Ignore external requests for leader settings behaviour until we see the first change.
+	var discardLeaderSettings <-chan struct{}
+	var wantLeaderSettings <-chan bool
+	// By default we send all leaderSettings onwards.
+	sendLeaderSettings := true
 
 	// Config events cannot be meaningfully discarded until one is available;
 	// once we receive the initial config and address changes, we unblock
@@ -457,6 +505,20 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 				tags[i] = tag
 			}
 			f.storageChanged(tags)
+		case _, ok = <-leaderSettingsw.Changes():
+			filterLogger.Debugf("got leader settings change: ok=%t", ok)
+			if !ok {
+				return watcher.EnsureErr(leaderSettingsw)
+			}
+			if sendLeaderSettings {
+				// only send the leader settings changed event
+				// if it hasn't been explicitly disabled
+				f.outLeaderSettings = f.outLeaderSettingsOn
+			} else {
+				filterLogger.Debugf("not sending leader settings change (want=false)")
+			}
+			discardLeaderSettings = f.discardLeaderSettings
+			wantLeaderSettings = f.wantLeaderSettings
 
 		// Send events on active out chans.
 		case f.outUpgrade <- f.upgrade:
@@ -468,6 +530,9 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 		case f.outConfig <- nothing:
 			filterLogger.Debugf("sent config event")
 			f.outConfig = nil
+		case f.outLeaderSettings <- nothing:
+			filterLogger.Debugf("sent leader settings event")
+			f.outLeaderSettings = nil
 		case f.outAction <- f.nextAction:
 			f.nextAction = f.getNextAction()
 			filterLogger.Debugf("sent action event")
@@ -533,6 +598,17 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 			if f.resolved != params.ResolvedNone {
 				f.outResolved = f.outResolvedOn
 			}
+		case sendEvents := <-wantLeaderSettings:
+			filterLogger.Debugf("want leader settings event: %t", sendEvents)
+			sendLeaderSettings = sendEvents
+			if sendEvents {
+				// go ahead and send an event right now,
+				// they're waiting for us
+				f.outLeaderSettings = f.outLeaderSettingsOn
+			} else {
+				// Make sure we don't have a pending event
+				f.outLeaderSettings = nil
+			}
 		case <-f.clearResolved:
 			filterLogger.Debugf("resolved event handled")
 			f.outResolved = nil
@@ -550,6 +626,9 @@ func (f *filter) loop(unitTag names.UnitTag) (err error) {
 		case <-discardConfig:
 			filterLogger.Debugf("discarded config event")
 			f.outConfig = nil
+		case <-discardLeaderSettings:
+			filterLogger.Debugf("discarded leader settings event")
+			f.outLeaderSettings = nil
 		}
 	}
 }

--- a/worker/uniter/filter/interface.go
+++ b/worker/uniter/filter/interface.go
@@ -89,4 +89,26 @@ type Filter interface {
 	// DiscardConfigEvent indicates that the filter should discard any pending
 	// config event.
 	DiscardConfigEvent()
+
+	// LeaderSettingsEvents returns a channel that will receive an event whenever
+	// there is a leader settings change. Events can be temporarily suspended by
+	// calling WantLeaderSettingsEvents(false), and then reenabled by calling
+	// WantLeaderSettingsEvents(true)
+	LeaderSettingsEvents() <-chan struct{}
+
+	// DiscardLeaderSettingsEvent can be called to discard any pending
+	// LeaderSettingsEvents. This is used by code that saw a LeaderSettings change,
+	// and has been prepping for a response. Just before they request the current
+	// LeaderSettings, they can discard any other pending changes, since they know
+	// they will be handling all changes that have occurred before right now.
+	DiscardLeaderSettingsEvent()
+
+	// WantLeaderSettingsEvents can be used to enable/disable events being sent on
+	// the LeaderSettingsEvents() channel. This is used when an agent notices that
+	// it is the leader, it wants to disable getting events for changes that it is
+	// generating. Calling this with sendEvents=false disables getting change
+	// events. Calling this with sendEvents=true will enable future changes, and
+	// queues up an immediate event so that the agent will refresh its information
+	// for any events it might have missed while it thought it was the leader.
+	WantLeaderSettingsEvents(sendEvents bool)
 }

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -14,6 +14,13 @@ import (
 	"github.com/juju/juju/feature"
 )
 
+// TODO(fwereade): move these definitions to juju/charm/hooks.
+const (
+	LeaderElected         hooks.Kind = "leader-elected"
+	LeaderDeposed         hooks.Kind = "leader-deposed"
+	LeaderSettingsChanged hooks.Kind = "leader-settings-changed"
+)
+
 // Info holds details required to execute a hook. Not all fields are
 // relevant to all Kind values.
 type Info struct {
@@ -55,6 +62,9 @@ func (hi Info) Validate() error {
 			}
 			return nil
 		}
+	// TODO(fwereade): define these in charm/hooks...
+	case LeaderElected, LeaderDeposed, LeaderSettingsChanged:
+		return nil
 	}
 	return fmt.Errorf("unknown hook kind %q", hi.Kind)
 }

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -345,7 +345,6 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 		// can then report minionhood at all times, and thus prevent the is-leader
 		// and leader-set hook tools from acting in a correct but misleading way
 		// (ie continuing to act as though leader after leader-deposed has run).
-		// tool from returning true but misleading reports of leadership while dying.
 	}
 	for {
 		if len(u.relations.GetInfo()) == 0 {

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 )
 
@@ -76,7 +77,37 @@ func ModeContinue(u *Uniter) (next Mode, err error) {
 		return nil, errors.Trace(err)
 	}
 
+	// Check for any leadership change, and enact it if possible.
+	logger.Infof("checking leadership status")
+	// If we've already accepted leadership, we don't need to do it again.
+	canAcceptLeader := !opState.Leader
+	select {
+	// If the unit's shutting down, we shouldn't accept it.
+	case <-u.f.UnitDying():
+		canAcceptLeader = false
+	default:
+		// If we're in an unexpected mode (eg pending hook) we shouldn't try either.
+		if opState.Kind != operation.Continue {
+			canAcceptLeader = false
+		}
+	}
+
+	// NOTE: the Wait() looks scary, but a ClaimLeadership ticket should always
+	// complete quickly; worst-case is API latency time, but it's designed that
+	// it should be vanishingly rare to hit that code path.
+	isLeader := u.leadershipTracker.ClaimLeader().Wait()
 	var creator creator
+	switch {
+	case isLeader && canAcceptLeader:
+		creator = newAcceptLeadershipOp()
+	case opState.Leader && !isLeader:
+		creator = newResignLeadershipOp()
+	}
+	if creator != nil {
+		return continueAfter(u, creator)
+	}
+	logger.Infof("leadership status is up-to-date")
+
 	switch opState.Kind {
 	case operation.RunAction:
 		// TODO(fwereade): we *should* handle interrupted actions, and make sure
@@ -179,6 +210,7 @@ func ModeTerminating(u *Uniter) (next Mode, err error) {
 // * charm upgrade requests
 // * relation changes
 // * unit death
+// * acquisition or loss of service leadership
 func ModeAbide(u *Uniter) (next Mode, err error) {
 	defer modeContext("ModeAbide", &err)()
 	opState := u.operationState()
@@ -188,6 +220,14 @@ func ModeAbide(u *Uniter) (next Mode, err error) {
 	if err := u.deployer.Fix(); err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	if !opState.Leader && !u.ranLeaderSettingsChanged {
+		creator := newSimpleRunHookOp(hook.LeaderSettingsChanged)
+		if err := u.runOperation(creator); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
 	if !u.ranConfigChanged {
 		return continueAfter(u, newSimpleRunHookOp(hooks.ConfigChanged))
 	}
@@ -221,7 +261,20 @@ var idleWaitTime = 2 * time.Second
 // modeAbideAliveLoop handles all state changes for ModeAbide when the unit
 // is in an Alive state.
 func modeAbideAliveLoop(u *Uniter) (Mode, error) {
+	var leaderElected, leaderDeposed <-chan struct{}
 	for {
+		// We expect one or none of these vars to be non-nil; and if none
+		// are, we set the one that should trigger when our leadership state
+		// differs from what we have recorded locally.
+		if leaderElected == nil && leaderDeposed == nil {
+			if u.operationState().Leader {
+				logger.Infof("waiting to lose leadership")
+				leaderDeposed = u.leadershipTracker.WaitMinion().Ready()
+			} else {
+				logger.Infof("waiting to gain leadership")
+				leaderElected = u.leadershipTracker.WaitLeader().Ready()
+			}
+		}
 		lastCollectMetrics := time.Unix(u.operationState().CollectMetricsTime, 0)
 		collectMetricsSignal := u.collectMetricsAt(
 			time.Now(), lastCollectMetrics, metricsPollInterval,
@@ -255,6 +308,15 @@ func modeAbideAliveLoop(u *Uniter) (Mode, error) {
 			creator = newRunHookOp(hookInfo)
 		case hookInfo := <-u.storage.Hooks():
 			creator = newRunHookOp(hookInfo)
+		case <-leaderElected:
+			// This operation queues a hook, better to let ModeContinue pick up
+			// after it than to duplicate queued-hook handling here.
+			return continueAfter(u, newAcceptLeadershipOp())
+		case <-leaderDeposed:
+			leaderDeposed = nil
+			creator = newResignLeadershipOp()
+		case <-u.f.LeaderSettingsEvents():
+			creator = newSimpleRunHookOp(hook.LeaderSettingsChanged)
 		}
 		if err := u.runOperation(creator); err != nil {
 			return nil, errors.Trace(err)
@@ -274,6 +336,17 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 	if err := u.relations.SetDying(); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if u.operationState().Leader {
+		if err := u.runOperation(newResignLeadershipOp()); err != nil {
+			return nil, errors.Trace(err)
+		}
+		// TODO(fwereade): we ought to inform the tracker that we're shutting down
+		// (and no longer wish to continue renewing our lease) so that the tracker
+		// can then report minionhood at all times, and thus prevent the is-leader
+		// and leader-set hook tools from acting in a correct but misleading way
+		// (ie continuing to act as though leader after leader-deposed has run).
+		// tool from returning true but misleading reports of leadership while dying.
+	}
 	for {
 		if len(u.relations.GetInfo()) == 0 {
 			return continueAfter(u, newSimpleRunHookOp(hooks.Stop))
@@ -286,6 +359,8 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 			creator = newActionOp(actionId)
 		case <-u.f.ConfigEvents():
 			creator = newSimpleRunHookOp(hooks.ConfigChanged)
+		case <-u.f.LeaderSettingsEvents():
+			creator = newSimpleRunHookOp(hook.LeaderSettingsChanged)
 		case hookInfo := <-u.relations.Hooks():
 			creator = newRunHookOp(hookInfo)
 		}
@@ -298,12 +373,14 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 // ModeHookError is responsible for watching and responding to:
 // * user resolution of hook errors
 // * forced charm upgrade requests
+// * loss of service leadership
 func ModeHookError(u *Uniter) (next Mode, err error) {
 	defer modeContext("ModeHookError", &err)()
 	opState := u.operationState()
 	if opState.Kind != operation.RunHook || opState.Step != operation.Pending {
 		return nil, errors.Errorf("insane uniter state: %#v", u.operationState())
 	}
+
 	// Create error information for status.
 	hookInfo := *opState.Hook
 	hookName := string(hookInfo.Kind)
@@ -321,8 +398,14 @@ func ModeHookError(u *Uniter) (next Mode, err error) {
 	}
 	statusData["hook"] = hookName
 	statusMessage := fmt.Sprintf("hook failed: %q", hookName)
+
+	// Run the select loop.
 	u.f.WantResolvedEvent()
 	u.f.WantUpgradeEvent(true)
+	var leaderDeposed <-chan struct{}
+	if opState.Leader {
+		leaderDeposed = u.leadershipTracker.WaitMinion().Ready()
+	}
 	for {
 		// The spec says we should set the workload status to Error, but that's crazy talk.
 		// It's the agent itself that should be in Error state. So we'll ensure the model is
@@ -355,6 +438,13 @@ func ModeHookError(u *Uniter) (next Mode, err error) {
 			return ModeContinue, nil
 		case actionId := <-u.f.ActionEvents():
 			if err := u.runOperation(newActionOp(actionId)); err != nil {
+				return nil, errors.Trace(err)
+			}
+		case <-leaderDeposed:
+			// This should trigger at most once -- we can't reaccept leadership while
+			// in an error state.
+			leaderDeposed = nil
+			if err := u.runOperation(newResignLeadershipOp()); err != nil {
 				return nil, errors.Trace(err)
 			}
 		}
@@ -395,7 +485,7 @@ func ModeConflicted(curl *charm.URL) Mode {
 func modeContext(name string, err *error) func() {
 	logger.Infof("%s starting", name)
 	return func() {
-		logger.Debugf("%s exiting", name)
+		logger.Infof("%s exiting", name)
 		*err = errors.Annotatef(*err, name)
 	}
 }

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -67,6 +67,8 @@ func (opc *operationCallbacks) PrepareHook(hi hook.Info) (string, error) {
 		// set the status to "preparing storage".
 	case hi.Kind == hooks.ConfigChanged:
 		opc.u.f.DiscardConfigEvent()
+	case hi.Kind == hook.LeaderSettingsChanged:
+		opc.u.f.DiscardLeaderSettingsEvent()
 	}
 	return name, nil
 }
@@ -80,6 +82,8 @@ func (opc *operationCallbacks) CommitHook(hi hook.Info) error {
 		return opc.u.storage.CommitHook(hi)
 	case hi.Kind == hooks.ConfigChanged:
 		opc.u.ranConfigChanged = true
+	case hi.Kind == hook.LeaderSettingsChanged:
+		opc.u.ranLeaderSettingsChanged = true
 	}
 	return nil
 }

--- a/worker/uniter/op_plumbing.go
+++ b/worker/uniter/op_plumbing.go
@@ -93,3 +93,15 @@ func newUpdateStorageOp(tags []names.StorageTag) creator {
 		return factory.NewUpdateStorage(tags)
 	}
 }
+
+func newAcceptLeadershipOp() creator {
+	return func(factory operation.Factory) (operation.Operation, error) {
+		return factory.NewAcceptLeadership()
+	}
+}
+
+func newResignLeadershipOp() creator {
+	return func(factory operation.Factory) (operation.Operation, error) {
+		return factory.NewResignLeadership()
+	}
+}

--- a/worker/uniter/operation/errors.go
+++ b/worker/uniter/operation/errors.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	ErrNoStateFile = errors.New("uniter state file does not exist")
-	ErrSkipExecute = errors.New("operation already executed")
-	ErrNeedsReboot = errors.New("reboot request issued")
-	ErrHookFailed  = errors.New("hook failed")
+	ErrNoStateFile            = errors.New("uniter state file does not exist")
+	ErrSkipExecute            = errors.New("operation already executed")
+	ErrNeedsReboot            = errors.New("reboot request issued")
+	ErrHookFailed             = errors.New("hook failed")
+	ErrCannotAcceptLeadership = errors.New("cannot accept leadership")
 )
 
 type deployConflictError struct {

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -176,3 +176,13 @@ func (f *factory) NewUpdateStorage(tags []names.StorageTag) (Operation, error) {
 		storageUpdater: f.storageUpdater,
 	}, nil
 }
+
+// NewResignLeadership is part of the Factory interface.
+func (f *factory) NewResignLeadership() (Operation, error) {
+	return &resignLeadership{}, nil
+}
+
+// NewAcceptLeadership is part of the Factory interface.
+func (f *factory) NewAcceptLeadership() (Operation, error) {
+	return &acceptLeadership{}, nil
+}

--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -212,8 +212,20 @@ func (s *FactorySuite) TestNewHookString_Skip(c *gc.C) {
 	c.Check(op.String(), gc.Equals, "clear resolved flag and skip run relation-joined (123; foo/22) hook")
 }
 
-func (s *FactorySuite) TestNewUpdateRelations(c *gc.C) {
+func (s *FactorySuite) TestNewUpdateRelationsString(c *gc.C) {
 	op, err := s.factory.NewUpdateRelations([]int{1, 2, 3})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(op.String(), gc.Equals, "update relations [1 2 3]")
+}
+
+func (s *FactorySuite) TestNewAcceptLeadershipString(c *gc.C) {
+	op, err := s.factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "accept leadership")
+}
+
+func (s *FactorySuite) TestNewResignLeadershipString(c *gc.C) {
+	op, err := s.factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "resign leadership")
 }

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -103,6 +103,14 @@ type Factory interface {
 	// NewUpdateStorage creates an operation to ensure the supplied storage
 	// tags are known and tracked.
 	NewUpdateStorage(tags []names.StorageTag) (Operation, error)
+
+	// NewAcceptLeadership creates an operation to ensure the uniter acts as
+	// service leader.
+	NewAcceptLeadership() (Operation, error)
+
+	// NewResignLeadership creates an operation to ensure the uniter does not
+	// act as service leader.
+	NewResignLeadership() (Operation, error)
 }
 
 // CommandArgs stores the arguments for a Command operation.

--- a/worker/uniter/operation/leader.go
+++ b/worker/uniter/operation/leader.go
@@ -1,0 +1,119 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker/uniter/hook"
+)
+
+type acceptLeadership struct{}
+
+// String is part of the Operation interface.
+func (al *acceptLeadership) String() string {
+	return "accept leadership"
+}
+
+// Prepare is part of the Operation interface.
+func (al *acceptLeadership) Prepare(state State) (*State, error) {
+	if err := al.checkState(state); err != nil {
+		return nil, err
+	}
+	return nil, ErrSkipExecute
+}
+
+// Execute is part of the Operation interface.
+func (al *acceptLeadership) Execute(state State) (*State, error) {
+	return nil, errors.New("prepare always errors; Execute is never valid")
+}
+
+// Commit is part of the Operation interface.
+func (al *acceptLeadership) Commit(state State) (*State, error) {
+	if err := al.checkState(state); err != nil {
+		return nil, err
+	}
+	if state.Leader {
+		// Nothing needs to be done -- leader is only set when queueing a
+		// leader-elected hook. Therefore, if leader is true, the appropriate
+		// hook must be either queued or already run.
+		return nil, nil
+	}
+	newState := stateChange{
+		Kind: RunHook,
+		Step: Queued,
+		Hook: &hook.Info{Kind: hook.LeaderElected},
+	}.apply(state)
+	newState.Leader = true
+	return newState, nil
+}
+
+func (al *acceptLeadership) checkState(state State) error {
+	if state.Kind != Continue {
+		// We'll need to queue up a hook, and we can't do that without
+		// stomping on existing state.
+		return ErrCannotAcceptLeadership
+	}
+	return nil
+}
+
+type resignLeadership struct{}
+
+// String is part of the Operation interface.
+func (rl *resignLeadership) String() string {
+	return "resign leadership"
+}
+
+// Prepare is part of the Operation interface.
+func (rl *resignLeadership) Prepare(state State) (*State, error) {
+	if !state.Leader {
+		// Nothing needs to be done -- state.Leader should only be set to
+		// false when committing the leader-deposed hook. This code is not
+		// helpful while Execute is a no-op, but it will become so.
+		return nil, ErrSkipExecute
+	}
+	return nil, nil
+}
+
+// Execute is part of the Operation interface.
+func (rl *resignLeadership) Execute(state State) (*State, error) {
+	// TODO(fwereade): this hits a lot of interestingly intersecting problems.
+	//
+	// 1) we can't yet create a sufficiently dumbed-down hook context for a
+	//    leader-deposed hook to run as specced. (This is the proximate issue,
+	//    and is sufficient to prevent us from implementing this op right.)
+	// 2) we want to write a state-file change, so this has to be an operation
+	//    (or, at least, it has to be serialized with all other operations).
+	//      * note that the change we write must *not* include the RunHook
+	//        operation for leader-deposed -- we want to run this at high
+	//        priority, in any possible state, and not to disturn what's
+	//        there other than to note that we no longer think we're leader.
+	// 3) the hook execution itself *might* not need to be serialized with
+	//    other operations, which is moot until we consider that:
+	// 4) we want to invoke this behaviour from elsewhere (ie when we don't
+	//    have an api connection available), but:
+	// 5) we can't get around the serialization requirement in (2).
+	//
+	// So. I *think* that the right approach is to implement a no-api uniter
+	// variant, that we run *instead of* the normal uniter when the API is
+	// unavailable, and replace with a real uniter when appropriate; this
+	// implies that we need to take care not to allow the implementations to
+	// diverge, but implementing them both as "uniters" is probably the best
+	// way to encourage logic-sharing and prevent that problem.
+	//
+	// In the short term, though, we can just run leader-deposed as soon as we
+	// can build the right environment. Not sure whether this particular type
+	// will still be justified, or whether it'll just be a plain old RunHook --
+	// I *think* it will stay, because the state-writing behaviour will stay
+	// very different (ie just write `.Leader = false` and don't step on pre-
+	// queued hooks).
+	logger.Warningf("we should run a leader-deposed hook here, but we can't yet")
+	return nil, nil
+}
+
+// Commit is part of the Operation interface.
+func (rl *resignLeadership) Commit(state State) (*State, error) {
+	state.Leader = false
+	return &state, nil
+}

--- a/worker/uniter/operation/leader_test.go
+++ b/worker/uniter/operation/leader_test.go
@@ -1,0 +1,181 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5/hooks"
+
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+type LeaderSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&LeaderSuite{})
+
+func (s *LeaderSuite) TestAcceptLeadership_Prepare_BadState(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Check(newState, gc.IsNil)
+	// accept is only valid in Continue mode, when we're sure nothing is queued
+	// or in progress.
+	c.Check(err, gc.Equals, operation.ErrCannotAcceptLeadership)
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Prepare_NotLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{Kind: operation.Continue})
+	c.Check(newState, gc.IsNil)
+	// *execute* is currently just a no-op -- all the meat happens in commit.
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Prepare_AlreadyLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{
+		Kind:   operation.Continue,
+		Leader: true,
+	})
+	c.Check(newState, gc.IsNil)
+	// *execute* is currently just a no-op -- all the meat happens in commit.
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Commit_NotLeader_BlankSlate(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+
+	newState, err := op.Commit(operation.State{
+		Kind: operation.Continue,
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(newState, gc.DeepEquals, &operation.State{
+		Kind:   operation.RunHook,
+		Step:   operation.Queued,
+		Hook:   &hook.Info{Kind: hook.LeaderElected},
+		Leader: true,
+	})
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Commit_NotLeader_Preserve(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+
+	newState, err := op.Commit(operation.State{
+		Kind:               operation.Continue,
+		Started:            true,
+		CollectMetricsTime: 1234567,
+		Hook:               &hook.Info{Kind: hooks.Install},
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(newState, gc.DeepEquals, &operation.State{
+		Kind:               operation.RunHook,
+		Step:               operation.Queued,
+		Hook:               &hook.Info{Kind: hook.LeaderElected},
+		Leader:             true,
+		Started:            true,
+		CollectMetricsTime: 1234567,
+	})
+}
+
+func (s *LeaderSuite) TestAcceptLeadership_Commit_AlreadyLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Prepare(operation.State{Kind: operation.Continue})
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+
+	newState, err := op.Commit(operation.State{
+		Kind:   operation.Continue,
+		Leader: true,
+	})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Prepare_Leader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{Leader: true})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Prepare_NotLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, gc.Equals, operation.ErrSkipExecute)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Execute(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = op.Prepare(operation.State{Leader: true})
+	c.Check(err, jc.ErrorIsNil)
+
+	// Execute is a no-op (which logs that we should run leader-deposed)
+	newState, err := op.Execute(operation.State{})
+	c.Check(newState, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Commit_ClearLeader(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Commit(operation.State{Leader: true})
+	c.Check(newState, gc.DeepEquals, &operation.State{})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Commit_PreserveOthers(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Commit(overwriteState)
+	c.Check(newState, gc.DeepEquals, &overwriteState)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_Commit_All(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+
+	leaderState := overwriteState
+	leaderState.Leader = true
+	newState, err := op.Commit(leaderState)
+	c.Check(newState, gc.DeepEquals, &overwriteState)
+	c.Check(err, jc.ErrorIsNil)
+}

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -56,7 +56,7 @@ const (
 // state.
 type State struct {
 
-	// Leader indicates whether a leader-elected hook has started to run, and
+	// Leader indicates whether a leader-elected hook has been queued to run, and
 	// no more recent leader-deposed hook has completed.
 	Leader bool `yaml:"leader"`
 

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -71,9 +71,7 @@ func allEnabledCommands() map[string]creator {
 	if featureflag.Enabled(feature.Storage) {
 		add(storageCommands)
 	}
-	if featureflag.Enabled(feature.LeaderElection) {
-		add(leaderCommands)
-	}
+	add(leaderCommands)
 	return all
 }
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -76,7 +76,8 @@ type Uniter struct {
 	hookLock    *fslock.Lock
 	runListener *RunListener
 
-	ranConfigChanged bool
+	ranLeaderSettingsChanged bool
+	ranConfigChanged         bool
 
 	// The execution observer is only used in tests at this stage. Should this
 	// need to be extended, perhaps a list of observers would be needed.
@@ -156,6 +157,9 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	// Stop the uniter if either of these components fails.
 	go func() { u.tomb.Kill(leadershipTracker.Wait()) }()
 	go func() { u.tomb.Kill(u.f.Wait()) }()
+
+	// Start handling leader settings events, or not, as appropriate.
+	u.f.WantLeaderSettingsEvents(!u.operationState().Leader)
 
 	// Run modes until we encounter an error.
 	mode := ModeContinue
@@ -391,5 +395,15 @@ func (u *Uniter) runOperation(creator creator) error {
 	if err != nil {
 		return errors.Annotatef(err, "cannot create operation")
 	}
+	before := u.operationState()
+	defer func() {
+		// Check that if we lose leadership as a result of this
+		// operation, we want to start getting leader settings events,
+		// or if we gain leadership we want to stop receiving those
+		// events.
+		if after := u.operationState(); before.Leader != after.Leader {
+			u.f.WantLeaderSettingsEvents(before.Leader)
+		}
+	}()
 	return u.operationExecutor.Run(op)
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -15,13 +15,11 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	corecharm "gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -177,7 +175,7 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"config-changed", "start"},
+			waitHooks{"leader-elected", "config-changed", "start"},
 		), ut(
 			"install hook fail and retry",
 			startupError{"install"},
@@ -200,7 +198,7 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 			waitUnitAgent{
 				status: params.StatusIdle,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		),
 	})
 }
@@ -255,7 +253,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 	s.runUniterTests(c, []uniterTest{
 		ut(
 			"resolved is cleared before moving on to next hook",
-			createCharm{badHooks: []string{"install", "config-changed", "start"}},
+			createCharm{badHooks: []string{"install", "leader-elected", "config-changed", "start"}},
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
@@ -264,6 +262,15 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 				info:         `hook failed: "install"`,
 				data: map[string]interface{}{
 					"hook": "install",
+				},
+			},
+			resolveError{state.ResolvedNoHooks},
+			waitUnitAgent{
+				statusGetter: unitStatusGetter,
+				status:       params.StatusError,
+				info:         `hook failed: "leader-elected"`,
+				data: map[string]interface{}{
+					"hook": "leader-elected",
 				},
 			},
 			resolveError{state.ResolvedNoHooks},
@@ -348,7 +355,7 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			waitUnitAgent{
 				status: params.StatusIdle,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			assertYaml{"charm/config.out", map[string]interface{}{
 				"blog-title": "My Title",
 			}},
@@ -391,7 +398,7 @@ func (s *UniterSuite) TestUniterHookSynchronisation(c *gc.C) {
 			verifyHookSyncLockLocked,
 			releaseHookSyncLock,
 			waitUnitAgent{status: params.StatusIdle},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		),
 	})
 }
@@ -606,7 +613,7 @@ func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 
 			createCharm{
 				revision: 1,
@@ -989,7 +996,7 @@ func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyGitCharm{dirty: true},
 
 			createCharm{
@@ -1089,7 +1096,10 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 			"simple joined/changed/departed",
 			quickStartRelation{},
 			addRelationUnit{},
-			waitHooks{"db-relation-joined mysql/1 db:0", "db-relation-changed mysql/1 db:0"},
+			waitHooks{
+				"db-relation-joined mysql/1 db:0",
+				"db-relation-changed mysql/1 db:0",
+			},
 			changeRelationUnit{"mysql/0"},
 			waitHooks{"db-relation-changed mysql/0 db:0"},
 			removeRelationUnit{"mysql/1"},
@@ -1099,7 +1109,10 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 			"relation becomes dying; unit is not last remaining member",
 			quickStartRelation{},
 			relationDying,
-			waitHooks{"db-relation-departed mysql/0 db:0", "db-relation-broken db:0"},
+			waitHooks{
+				"db-relation-departed mysql/0 db:0",
+				"db-relation-broken db:0",
+			},
 			verifyRunning{},
 			relationState{life: state.Dying},
 			removeRelationUnit{"mysql/0"},
@@ -1120,7 +1133,11 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 			"service becomes dying while in a relation",
 			quickStartRelation{},
 			serviceDying,
-			waitHooks{"db-relation-departed mysql/0 db:0", "db-relation-broken db:0", "stop"},
+			waitHooks{
+				"db-relation-departed mysql/0 db:0",
+				"db-relation-broken db:0",
+				"stop",
+			},
 			waitUniterDead{},
 			relationState{life: state.Dying},
 			removeRelationUnit{"mysql/0"},
@@ -1129,7 +1146,12 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 			"unit becomes dying while in a relation",
 			quickStartRelation{},
 			unitDying,
-			waitHooks{"db-relation-departed mysql/0 db:0", "db-relation-broken db:0", "stop"},
+			waitHooks{
+				"leader-settings-changed",
+				"db-relation-departed mysql/0 db:0",
+				"db-relation-broken db:0",
+				"stop",
+			},
 			waitUniterDead{},
 			relationState{life: state.Alive},
 			removeRelationUnit{"mysql/0"},
@@ -1174,7 +1196,7 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			addRelation{waitJoin: true},
 			stopUniter{},
 			custom{func(c *gc.C, ctx *context) {
@@ -1291,7 +1313,7 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			metricsTick{},
 			waitHooks{"collect-metrics"},
@@ -1369,7 +1391,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			addAction{"action-log", nil},
 			waitActionResults{[]actionResult{{
@@ -1400,7 +1422,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			addAction{"action-log-fail", nil},
 			waitActionResults{[]actionResult{{
@@ -1433,7 +1455,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			addAction{"action-log-fail-error", nil},
 			waitActionResults{[]actionResult{{
@@ -1467,7 +1489,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			addAction{
 				name:   "snapshot",
@@ -1510,7 +1532,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			addAction{
 				name:   "snapshot",
@@ -1544,7 +1566,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			addAction{"snapshot", map[string]interface{}{"outfile": "foo.bar"}},
 			waitActionResults{[]actionResult{{
@@ -1579,7 +1601,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			waitActionResults{[]actionResult{{
 				name:    "action-log",
@@ -1616,7 +1638,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
 			addAction{"action-log", nil},
 			waitActionResults{[]actionResult{{
@@ -1806,7 +1828,7 @@ func (s *UniterSuite) TestReboot(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"config-changed", "start"},
+			waitHooks{"leader-elected", "config-changed", "start"},
 		), ut(
 			"test that juju-reboot --now kills hook and exits",
 			createCharm{
@@ -1830,7 +1852,7 @@ func (s *UniterSuite) TestReboot(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"install", "config-changed", "start"},
+			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		), ut(
 			"test juju-reboot will not happen if hook errors out",
 			createCharm{
@@ -1892,20 +1914,52 @@ func (s *UniterSuite) TestRebootFromJujuRun(c *gc.C) {
 }
 
 func (s *UniterSuite) TestLeadership(c *gc.C) {
-	// TODO(fwereade): 2015-03-07 bug XXXXXXXXXXXXX
-	// This is a really bad way to test the impact of feature flags, because it
-	// doesn't clean up after itself. We really want something in featureflags
-	// to help test these -- something like `WithFlags([]string, func())`?
-	// Regardless, there are way too many tests like this already and fixing
-	// that deserves its own CL.
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "leader-election")
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.runUniterTests(c, []uniterTest{
 		ut(
-			"leader-set works",
+			"hook tools when leader",
 			quickStart{},
-			runCommands{fmt.Sprintf("leader-set foo=bar baz=qux")},
+			runCommands{"leader-set foo=bar baz=qux"},
 			verifyLeaderSettings{"foo": "bar", "baz": "qux"},
+		), ut(
+			"hook tools when not leader",
+			quickStart{minion: true},
+			runCommands{`if [ $(is-leader) != "False" ]; then exit -1; fi`},
+		), ut(
+			"leader-elected triggers when elected",
+			quickStart{minion: true},
+			forceLeader{},
+			waitHooks{"leader-elected"},
+		), ut(
+			"leader-settings-changed triggers when leader settings change",
+			quickStart{minion: true},
+			setLeaderSettings{"ping": "pong"},
+			waitHooks{"leader-settings-changed"},
+		), ut(
+			"leader-settings-changed triggers when bounced",
+			quickStart{minion: true},
+			verifyRunning{minion: true},
+		), ut(
+			"leader-settings-changed triggers when deposed (while stopped)",
+			quickStart{},
+			stopUniter{},
+			forceMinion{},
+			verifyRunning{minion: true},
+		),
+	})
+}
+
+func (s *UniterSuite) TestLeadershipUnexpectedDepose(c *gc.C) {
+	s.PatchValue(uniter.LeadershipGuarantee, coretesting.ShortWait)
+	s.runUniterTests(c, []uniterTest{
+		ut(
+			// NOTE: this is a strange and ugly test, intended to detect what
+			// *would* happen if the uniter suddenly failed to renew its lease;
+			// it depends on an artificially shortened tracker refresh time to
+			// run in a reasonable amount of time.
+			"leader-settings-changed triggers when deposed (while running)",
+			quickStart{},
+			forceMinion{},
+			waitHooks{"leader-settings-changed"},
 		),
 	})
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -142,9 +142,9 @@ func (ctx *context) apiLogin(c *gc.C) {
 	c.Assert(st, gc.NotNil)
 	c.Logf("API: login as %q successful", ctx.unit.Tag())
 	ctx.api, err = st.Uniter()
-	ctx.leader = st.LeadershipManager()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.api, gc.NotNil)
+	ctx.leader = leadership.NewLeadershipManager(lease.Manager())
 }
 
 func (ctx *context) writeExplicitHook(c *gc.C, path string, contents string) {
@@ -287,15 +287,32 @@ type createCharm struct {
 	customize func(*gc.C, *context, string)
 }
 
-var charmHooks = []string{
-	"install", "start", "config-changed", "upgrade-charm", "stop",
-	"db-relation-joined", "db-relation-changed", "db-relation-departed",
-	"db-relation-broken", "meter-status-changed", "collect-metrics",
+var (
+	baseCharmHooks = []string{
+		"install", "start", "config-changed", "upgrade-charm", "stop",
+		"db-relation-joined", "db-relation-changed", "db-relation-departed",
+		"db-relation-broken", "meter-status-changed", "collect-metrics",
+	}
+	leaderCharmHooks = []string{
+		"leader-elected", "leader-deposed", "leader-settings-changed",
+	}
+)
+
+func startupHooks(minion bool) []string {
+	leaderHook := "leader-elected"
+	if minion {
+		leaderHook = "leader-settings-changed"
+	}
+	return []string{"install", leaderHook, "config-changed", "start"}
 }
 
 func (s createCharm) step(c *gc.C, ctx *context) {
 	base := testcharms.Repo.ClonedDirPath(c.MkDir(), "wordpress")
-	for _, name := range charmHooks {
+
+	allCharmHooks := baseCharmHooks
+	allCharmHooks = append(allCharmHooks, leaderCharmHooks...)
+
+	for _, name := range allCharmHooks {
 		path := filepath.Join(base, "hooks", name)
 		good := true
 		for _, bad := range s.badHooks {
@@ -367,11 +384,16 @@ func (csau createServiceAndUnit) step(c *gc.C, ctx *context) {
 	ctx.apiLogin(c)
 }
 
-type createUniter struct{}
+type createUniter struct {
+	minion bool
+}
 
-func (createUniter) step(c *gc.C, ctx *context) {
+func (s createUniter) step(c *gc.C, ctx *context) {
 	step(c, ctx, ensureStateWorker{})
 	step(c, ctx, createServiceAndUnit{})
+	if s.minion {
+		step(c, ctx, forceMinion{})
+	}
 	step(c, ctx, startUniter{})
 	step(c, ctx, waitAddresses{})
 }
@@ -487,6 +509,10 @@ type stopUniter struct {
 
 func (s stopUniter) step(c *gc.C, ctx *context) {
 	u := ctx.uniter
+	if u == nil {
+		c.Logf("uniter not started, skipping stopUniter{}")
+		return
+	}
 	ctx.uniter = nil
 	err := u.Stop()
 	if s.err == "" {
@@ -504,12 +530,19 @@ func (s verifyWaiting) step(c *gc.C, ctx *context) {
 	step(c, ctx, waitHooks{})
 }
 
-type verifyRunning struct{}
+type verifyRunning struct {
+	minion bool
+}
 
 func (s verifyRunning) step(c *gc.C, ctx *context) {
 	step(c, ctx, stopUniter{})
 	step(c, ctx, startUniter{})
-	step(c, ctx, waitHooks{"config-changed"})
+	var hooks []string
+	if s.minion {
+		hooks = append(hooks, "leader-settings-changed")
+	}
+	hooks = append(hooks, "config-changed")
+	step(c, ctx, waitHooks(hooks))
 }
 
 type startupErrorWithCustomCharm struct {
@@ -529,7 +562,7 @@ func (s startupErrorWithCustomCharm) step(c *gc.C, ctx *context) {
 		status:       params.StatusError,
 		info:         fmt.Sprintf(`hook failed: %q`, s.badHook),
 	})
-	for _, hook := range []string{"install", "config-changed", "start"} {
+	for _, hook := range startupHooks(false) {
 		if hook == s.badHook {
 			step(c, ctx, waitHooks{"fail-" + hook})
 			break
@@ -552,7 +585,7 @@ func (s startupError) step(c *gc.C, ctx *context) {
 		status:       params.StatusError,
 		info:         fmt.Sprintf(`hook failed: %q`, s.badHook),
 	})
-	for _, hook := range []string{"install", "config-changed", "start"} {
+	for _, hook := range startupHooks(false) {
 		if hook == s.badHook {
 			step(c, ctx, waitHooks{"fail-" + hook})
 			break
@@ -562,14 +595,16 @@ func (s startupError) step(c *gc.C, ctx *context) {
 	step(c, ctx, verifyCharm{})
 }
 
-type quickStart struct{}
+type quickStart struct {
+	minion bool
+}
 
 func (s quickStart) step(c *gc.C, ctx *context) {
 	step(c, ctx, createCharm{})
 	step(c, ctx, serveCharm{})
-	step(c, ctx, createUniter{})
+	step(c, ctx, createUniter{minion: s.minion})
 	step(c, ctx, waitUnitAgent{status: params.StatusIdle})
-	step(c, ctx, waitHooks{"install", "config-changed", "start"})
+	step(c, ctx, waitHooks(startupHooks(s.minion)))
 	step(c, ctx, verifyCharm{})
 }
 
@@ -592,7 +627,7 @@ func (s startupRelationError) step(c *gc.C, ctx *context) {
 	step(c, ctx, serveCharm{})
 	step(c, ctx, createUniter{})
 	step(c, ctx, waitUnitAgent{status: params.StatusIdle})
-	step(c, ctx, waitHooks{"install", "config-changed", "start"})
+	step(c, ctx, waitHooks(startupHooks(false)))
 	step(c, ctx, verifyCharm{})
 	step(c, ctx, addRelation{})
 	step(c, ctx, addRelationUnit{})
@@ -895,7 +930,7 @@ func (s startUpgradeError) step(c *gc.C, ctx *context) {
 		waitUnitAgent{
 			status: params.StatusIdle,
 		},
-		waitHooks{"install", "config-changed", "start"},
+		waitHooks(startupHooks(false)),
 		verifyCharm{},
 
 		createCharm{revision: 1},
@@ -1364,10 +1399,65 @@ func (waitContextWaitGroup) step(c *gc.C, ctx *context) {
 	ctx.wg.Wait()
 }
 
+const otherLeader = "some-other-unit/123"
+
+type forceMinion struct{}
+
+func (forceMinion) step(c *gc.C, ctx *context) {
+	// TODO(fwereade): this is designed to work when the uniter is still running,
+	// which is... unexpected, because the uniter's running a tracker that will
+	// do its best to maintain leadership. But... it's possible for us to make it
+	// resign by going via the lease manager directly, and we can be confident
+	// that the uniter's tracker *will* see the problem when it fails to renew.
+	// This lets us test the uniter's behaviour under bizarre/adverse conditions
+	// (in addition to working just fine when the uniter's not running).
+	for i := 0; i < 3; i++ {
+		c.Logf("deposing local unit (attempt %d)", i)
+		err := ctx.leader.ReleaseLeadership(ctx.svc.Name(), ctx.unit.Name())
+		c.Assert(err, jc.ErrorIsNil)
+		c.Logf("promoting other unit (attempt %d)", i)
+		err = ctx.leader.ClaimLeadership(ctx.svc.Name(), otherLeader, coretesting.LongWait)
+		if err == nil {
+			return
+		} else if err != leadership.ErrClaimDenied {
+			c.Assert(err, jc.ErrorIsNil)
+		}
+	}
+	c.Fatalf("failed to promote a different leader")
+}
+
+type forceLeader struct{}
+
+func (forceLeader) step(c *gc.C, ctx *context) {
+	c.Logf("deposing other unit")
+	err := ctx.leader.ReleaseLeadership(ctx.svc.Name(), otherLeader)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("promoting local unit")
+	err = ctx.leader.ClaimLeadership(ctx.svc.Name(), ctx.unit.Name(), coretesting.LongWait)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type setLeaderSettings map[string]string
+
+func (s setLeaderSettings) step(c *gc.C, ctx *context) {
+	// We do this directly on State, not the API, so we don't have to worry
+	// about getting an API conn for whatever unit's meant to be leader.
+	settings, err := ctx.st.ReadLeadershipSettings(ctx.svc.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	for key := range settings.Map() {
+		settings.Delete(key)
+	}
+	for key, value := range s {
+		settings.Set(key, value)
+	}
+	_, err = settings.Write()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 type verifyLeaderSettings map[string]string
 
 func (verify verifyLeaderSettings) step(c *gc.C, ctx *context) {
-	actual, err := ctx.api.LeadershipSettings.Read("u")
+	actual, err := ctx.api.LeadershipSettings.Read(ctx.svc.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actual, jc.DeepEquals, map[string]string(verify))
 }
@@ -1505,7 +1595,7 @@ func (s startGitUpgradeError) step(c *gc.C, ctx *context) {
 		waitUnitAgent{
 			status: params.StatusIdle,
 		},
-		waitHooks{"install", "config-changed", "start"},
+		waitHooks(startupHooks(false)),
 		verifyGitCharm{dirty: true},
 
 		createCharm{


### PR DESCRIPTION
This is entirely mechanical, apart from:

  * UniterSuite.TestLeadership, which now checks for all the possible orders the (unrelated) hooks could plausibly run in
  * s/Nic/NIC/ in one unrelated test name

(Review request: http://reviews.vapour.ws/r/1461/)