### PR TITLE
Add new system super command.

### DIFF
--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/cmd/juju/service"
 	"github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/cmd/juju/system"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
@@ -207,6 +208,11 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	// Manage storage
 	if featureflag.Enabled(feature.Storage) {
 		r.Register(storage.NewSuperCommand())
+	}
+
+	// Manage systems
+	if featureflag.Enabled(feature.JES) {
+		r.Register(system.NewSuperCommand())
 	}
 }
 

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system
+
+import (
+	"github.com/juju/juju/environs/configstore"
+)
+
+// NewListCommand returns a ListCommand with the configstore provided as specified.
+func NewListCommand(cfgStore configstore.Storage) *ListCommand {
+	return &ListCommand{
+		cfgStore: cfgStore,
+	}
+}

--- a/cmd/juju/system/list.go
+++ b/cmd/juju/system/list.go
@@ -12,18 +12,21 @@ import (
 	"github.com/juju/juju/environs/configstore"
 )
 
+// ListCommand returns the list of all systems the user is
+// currently logged in to on the current machine.
 type ListCommand struct {
 	cmd.CommandBase
 	cfgStore configstore.Storage
 }
 
-var switchDoc = `List all the systems logged in to on the current machine`
+var listDoc = `List all the systems logged in to on the current machine`
 
+// Info implements Command.Info
 func (c *ListCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Purpose: "list all systems logged in to on the current machine",
-		Doc:     switchDoc,
+		Doc:     listDoc,
 	}
 }
 
@@ -34,6 +37,7 @@ func (c *ListCommand) getConfigstore() (configstore.Storage, error) {
 	return configstore.Default()
 }
 
+// Run implements Command.Run
 func (c *ListCommand) Run(ctx *cmd.Context) error {
 	store, err := c.getConfigstore()
 
@@ -41,7 +45,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "failed to get config store")
 	}
 
-	list, err := store.ListServers()
+	list, err := store.ListSystems()
 	if err != nil {
 		return errors.Annotate(err, "failed to list systems in config store")
 	}

--- a/cmd/juju/system/list.go
+++ b/cmd/juju/system/list.go
@@ -1,0 +1,54 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/environs/configstore"
+)
+
+type ListCommand struct {
+	cmd.CommandBase
+	cfgStore configstore.Storage
+}
+
+var switchDoc = `List all the systems logged in to on the current machine`
+
+func (c *ListCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "list",
+		Purpose: "list all systems logged in to on the current machine",
+		Doc:     switchDoc,
+	}
+}
+
+func (c *ListCommand) getConfigstore() (configstore.Storage, error) {
+	if c.cfgStore != nil {
+		return c.cfgStore, nil
+	}
+	return configstore.Default()
+}
+
+func (c *ListCommand) Run(ctx *cmd.Context) error {
+	store, err := c.getConfigstore()
+
+	if err != nil {
+		return errors.Annotate(err, "failed to get config store")
+	}
+
+	list, err := store.ListServers()
+	if err != nil {
+		return errors.Annotate(err, "failed to list systems in config store")
+	}
+
+	for _, name := range list {
+		fmt.Fprintf(ctx.Stdout, "%s\n", name)
+	}
+
+	return nil
+}

--- a/cmd/juju/system/list_test.go
+++ b/cmd/juju/system/list_test.go
@@ -1,0 +1,95 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/system"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/testing"
+)
+
+type ListSuite struct {
+	testing.FakeJujuHomeSuite
+	store configstore.Storage
+}
+
+var _ = gc.Suite(&ListSuite{})
+
+type errorStore struct {
+	err error
+}
+
+func (errorStore) CreateInfo(envName string) configstore.EnvironInfo {
+	panic("CreateInfo not implemented")
+}
+
+func (errorStore) List() ([]string, error) {
+	panic("List not implemented")
+}
+
+func (e errorStore) ListServers() ([]string, error) {
+	return nil, e.err
+}
+
+func (errorStore) ReadInfo(envName string) (configstore.EnvironInfo, error) {
+	panic("ReadInfo not implemented")
+}
+
+func (s *ListSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.JES)
+	s.store = configstore.NewMem()
+
+	var envList = []struct {
+		name       string
+		serverUUID string
+		envUUID    string
+	}{
+		{
+			name:       "test1",
+			serverUUID: "test1-uuid",
+			envUUID:    "test1-uuid",
+		}, {
+			name:       "test2",
+			serverUUID: "test1-uuid",
+			envUUID:    "test2-uuid",
+		}, {
+			name:    "test3",
+			envUUID: "test3-uuid",
+		},
+	}
+	for _, env := range envList {
+		info := s.store.CreateInfo(env.name)
+		info.SetAPIEndpoint(configstore.APIEndpoint{
+			Addresses:   []string{"localhost"},
+			CACert:      testing.CACert,
+			EnvironUUID: env.envUUID,
+			ServerUUID:  env.serverUUID,
+		})
+		err := info.Write()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *ListSuite) TestSystemList(c *gc.C) {
+	context, err := testing.RunCommand(c, system.NewListCommand(s.store))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "test1\ntest3\n")
+}
+
+func (s *ListSuite) TestUnrecognizedArg(c *gc.C) {
+	_, err := testing.RunCommand(c, system.NewListCommand(s.store), "whoops")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+}
+
+func (s *ListSuite) TestListServersError(c *gc.C) {
+	s.store = errorStore{err: errors.New("cannot read info")}
+	_, err := testing.RunCommand(c, system.NewListCommand(s.store))
+	c.Assert(err, gc.ErrorMatches, "failed to list systems in config store: cannot read info")
+}

--- a/cmd/juju/system/list_test.go
+++ b/cmd/juju/system/list_test.go
@@ -33,7 +33,7 @@ func (errorStore) List() ([]string, error) {
 	panic("List not implemented")
 }
 
-func (e errorStore) ListServers() ([]string, error) {
+func (e errorStore) ListSystems() ([]string, error) {
 	return nil, e.err
 }
 
@@ -88,7 +88,7 @@ func (s *ListSuite) TestUnrecognizedArg(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 }
 
-func (s *ListSuite) TestListServersError(c *gc.C) {
+func (s *ListSuite) TestListSystemsError(c *gc.C) {
 	s.store = errorStore{err: errors.New("cannot read info")}
 	_, err := testing.RunCommand(c, system.NewListCommand(s.store))
 	c.Assert(err, gc.ErrorMatches, "failed to list systems in config store: cannot read info")

--- a/cmd/juju/system/package_test.go
+++ b/cmd/juju/system/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/juju/system/system.go
+++ b/cmd/juju/system/system.go
@@ -1,0 +1,30 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.cmd.juju.system")
+
+const commandDoc = `
+"juju system" provides commands to manage Juju systems.
+`
+
+// NewSuperCommand creates the system supercommand and registers the
+// subcommands that it supports.
+func NewSuperCommand() cmd.Command {
+	systemCmd := cmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name:        "system",
+		Doc:         commandDoc,
+		UsagePrefix: "juju",
+		Purpose:     "manage systems",
+	})
+
+	systemCmd.Register(&ListCommand{})
+
+	return systemCmd
+}

--- a/cmd/juju/system/system_test.go
+++ b/cmd/juju/system/system_test.go
@@ -1,0 +1,31 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/system"
+	"github.com/juju/juju/testing"
+)
+
+type SystemCommandSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&SystemCommandSuite{})
+
+var expectedCommmandNames = []string{
+	"help",
+	"list",
+}
+
+func (s *SystemCommandSuite) TestHelp(c *gc.C) {
+	// Check the help output
+	ctx, err := testing.RunCommand(c, system.NewSuperCommand(), "--help")
+	c.Assert(err, jc.ErrorIsNil)
+	namesFound := testing.ExtractCommandsFromHelpOutput(ctx)
+	c.Assert(namesFound, gc.DeepEquals, expectedCommmandNames)
+}

--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -145,8 +145,8 @@ func (d *diskStore) List() ([]string, error) {
 	return envs, nil
 }
 
-// ListServers implements Storage.ListServers
-func (d *diskStore) ListServers() ([]string, error) {
+// ListSystems implements Storage.ListSystems
+func (d *diskStore) ListSystems() ([]string, error) {
 	// List both jenv files and cache entries.  Record
 	// results in a set to avoid repeat entries.
 	servers := set.NewStrings()

--- a/environs/configstore/disk_test.go
+++ b/environs/configstore/disk_test.go
@@ -54,8 +54,8 @@ func (s *diskInterfaceSuite) TearDownTest(c *gc.C) {
 	entries, err := ioutil.ReadDir(storePath(s.dir, ""))
 	c.Assert(err, jc.ErrorIsNil)
 	for _, entry := range entries {
-		if !strings.HasSuffix(entry.Name(), ".jenv") {
-			c.Errorf("found possible stray temp file %q", entry.Name())
+		if !strings.HasSuffix(entry.Name(), ".jenv") && !strings.HasSuffix(entry.Name(), ".yaml") {
+			c.Errorf("found possible stray temp file %s, %q", s.dir, entry.Name())
 		}
 	}
 	s.interfaceSuite.TearDownTest(c)

--- a/environs/configstore/disk_test.go
+++ b/environs/configstore/disk_test.go
@@ -54,7 +54,7 @@ func (s *diskInterfaceSuite) TearDownTest(c *gc.C) {
 	entries, err := ioutil.ReadDir(storePath(s.dir, ""))
 	c.Assert(err, jc.ErrorIsNil)
 	for _, entry := range entries {
-		if !strings.HasSuffix(entry.Name(), ".jenv") && !strings.HasSuffix(entry.Name(), ".yaml") {
+		if !strings.HasSuffix(entry.Name(), ".jenv") && entry.Name() != "cache.yaml" {
 			c.Errorf("found possible stray temp file %s, %q", s.dir, entry.Name())
 		}
 	}

--- a/environs/configstore/interface.go
+++ b/environs/configstore/interface.go
@@ -64,9 +64,9 @@ type Storage interface {
 	// knows about.
 	List() ([]string, error)
 
-	// ListServers returns a slice of existing server names that the Storage
+	// ListSystems returns a slice of existing server names that the Storage
 	// knows about.
-	ListServers() ([]string, error)
+	ListSystems() ([]string, error)
 }
 
 // EnvironInfo holds information associated with an environment.

--- a/environs/configstore/interface.go
+++ b/environs/configstore/interface.go
@@ -48,7 +48,7 @@ type APICredentials struct {
 	Password string
 }
 
-// Storage stores environment configuration data.
+// Storage stores environment and server configuration data.
 type Storage interface {
 	// ReadInfo reads information associated with
 	// the environment with the given name.
@@ -63,6 +63,10 @@ type Storage interface {
 	// List returns a slice of existing environment names that the Storage
 	// knows about.
 	List() ([]string, error)
+
+	// ListServers returns a slice of existing server names that the Storage
+	// knows about.
+	ListServers() ([]string, error)
 }
 
 // EnvironInfo holds information associated with an environment.

--- a/environs/configstore/interface_test.go
+++ b/environs/configstore/interface_test.go
@@ -71,7 +71,7 @@ func (s *interfaceSuite) TestList(c *gc.C) {
 	c.Assert(environs, jc.SameContents, []string{"enva", "envb", "envc"})
 }
 
-func (s *interfaceSuite) TestListServers(c *gc.C) {
+func (s *interfaceSuite) TestListSystems(c *gc.C) {
 	store := s.NewStore(c)
 	s.createInitialisedEnvironment(c, store, "enva", "")
 	s.createInitialisedEnvironment(c, store, "envb", "")
@@ -80,7 +80,7 @@ func (s *interfaceSuite) TestListServers(c *gc.C) {
 	s.createInitialisedEnvironment(c, store, "envc", "envc")
 	s.createInitialisedEnvironment(c, store, "envd", "envc")
 
-	environs, err := store.ListServers()
+	environs, err := store.ListSystems()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(environs, jc.SameContents, []string{"enva", "envb", "envc"})
 }

--- a/environs/configstore/mem.go
+++ b/environs/configstore/mem.go
@@ -67,8 +67,8 @@ func (m *memStore) List() ([]string, error) {
 	return envs, nil
 }
 
-// ListServers implements Storage.ListServers
-func (m *memStore) ListServers() ([]string, error) {
+// ListSystems implements Storage.ListSystems
+func (m *memStore) ListSystems() ([]string, error) {
 	var servers []string
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/environs/configstore/mem.go
+++ b/environs/configstore/mem.go
@@ -67,6 +67,20 @@ func (m *memStore) List() ([]string, error) {
 	return envs, nil
 }
 
+// ListServers implements Storage.ListServers
+func (m *memStore) ListServers() ([]string, error) {
+	var servers []string
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, env := range m.envs {
+		api := env.APIEndpoint()
+		if api.ServerUUID == "" || api.ServerUUID == api.EnvironUUID {
+			servers = append(servers, name)
+		}
+	}
+	return servers, nil
+}
+
 // ReadInfo implements Storage.ReadInfo.
 func (m *memStore) ReadInfo(envName string) (EnvironInfo, error) {
 	m.mu.Lock()

--- a/featuretests/cmd_juju_system_test.go
+++ b/featuretests/cmd_juju_system_test.go
@@ -1,0 +1,29 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/system"
+	"github.com/juju/juju/feature"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing"
+)
+
+type cmdSystemSuite struct {
+	jujutesting.RepoSuite
+}
+
+func (s *cmdSystemSuite) SetUpTest(c *gc.C) {
+	s.RepoSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.JES)
+}
+
+func (s *cmdSystemSuite) TestEnvironmentShareCmdStack(c *gc.C) {
+	context, err := testing.RunCommand(c, &system.ListCommand{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "dummyenv\n")
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -31,6 +31,7 @@ func init() {
 	gc.Suite(&apiCharmsSuite{})
 	gc.Suite(&cmdEnvironmentSuite{})
 	gc.Suite(&cmdStorageSuite{})
+	gc.Suite(&cmdSystemSuite{})
 }
 
 func Test(t *testing.T) {

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -813,6 +813,10 @@ func (*storageWithWriteNotify) List() ([]string, error) {
 	panic("List not implemented")
 }
 
+func (*storageWithWriteNotify) ListServers() ([]string, error) {
+	panic("ListServers not implemented")
+}
+
 func (s *storageWithWriteNotify) ReadInfo(envName string) (configstore.EnvironInfo, error) {
 	info, err := s.store.ReadInfo(envName)
 	if err != nil {

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -813,8 +813,8 @@ func (*storageWithWriteNotify) List() ([]string, error) {
 	panic("List not implemented")
 }
 
-func (*storageWithWriteNotify) ListServers() ([]string, error) {
-	panic("ListServers not implemented")
+func (*storageWithWriteNotify) ListSystems() ([]string, error) {
+	panic("ListSystems not implemented")
 }
 
 func (s *storageWithWriteNotify) ReadInfo(envName string) (configstore.EnvironInfo, error) {


### PR DESCRIPTION
This patch does three things:
1 - Adds the new system super command

2 - Adds the system list subcommand, as well as the
new ListServers function into the config store.

3 - Fixes a bug with EnvironInfo.Write where we should
always write out to the cache file if the environ info
was created with a cache file.  This is necessary since
we will always be read the cache file first for config
info.

(Review request: http://reviews.vapour.ws/r/1462/)