### PR TITLE
Added tests for addressable containers when feature flag is disabled

### DIFF
--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -132,9 +132,7 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 
 	results, err := s.provAPI.PrepareContainerInterfaceInfo(args)
 	c.Logf("PrepareContainerInterfaceInfo returned: err=%v, results=%v", err, results)
-	if err == nil {
-		c.Assert(results.Results, gc.HasLen, len(args.Entities))
-	}
+	c.Assert(results.Results, gc.HasLen, len(args.Entities))
 	if expectErr == "" {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(expectResults, gc.NotNil)
@@ -156,7 +154,7 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 		c.Assert(results, jc.DeepEquals, *expectResults)
 	} else {
 		c.Assert(err, gc.ErrorMatches, expectErr)
-		if len(args.Entities) > 0 && len(results.Results) > 0 {
+		if len(args.Entities) > 0 {
 			result := results.Results[0]
 			// Not using jc.ErrorIsNil below because
 			// (*params.Error)(nil) does not satisfy the error
@@ -684,9 +682,7 @@ func (s *releaseSuite) makeErrors(errors ...*params.Error) *params.ErrorResults 
 func (s *releaseSuite) assertCall(c *gc.C, args params.Entities, expectResults *params.ErrorResults, expectErr string) error {
 	results, err := s.provAPI.ReleaseContainerAddresses(args)
 	c.Logf("ReleaseContainerAddresses returned: err=%v, results=%v", err, results)
-	if err == nil {
-		c.Assert(results.Results, gc.HasLen, len(args.Entities))
-	}
+	c.Assert(results.Results, gc.HasLen, len(args.Entities))
 	if expectErr == "" {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(expectResults, gc.NotNil)
@@ -694,7 +690,7 @@ func (s *releaseSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 		c.Assert(results, jc.DeepEquals, *expectResults)
 	} else {
 		c.Assert(err, gc.ErrorMatches, expectErr)
-		if len(args.Entities) > 0 && len(results.Results) > 0 {
+		if len(args.Entities) > 0 {
 			result := results.Results[0]
 			// Not using jc.ErrorIsNil below because
 			// (*params.Error)(nil) does not satisfy the error

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -814,10 +814,15 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 	return result, nil
 }
 
-// ReleaseContainerAddresses finds addresses allocated to a container and marks
-// them as Dead, to be released and removed. It accepts container tags as
-// arguments.
+// ReleaseContainerAddresses finds addresses allocated to a container
+// and marks them as Dead, to be released and removed. It accepts
+// container tags as arguments. If address allocation feature flag is
+// not enabled, it will return a NotSupported error.
 func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params.ErrorResults, error) {
+	if !environs.AddressAllocationEnabled() {
+		return params.ErrorResults{}, errors.NotSupportedf("address allocation")
+	}
+
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -879,8 +884,7 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 // PrepareContainerInterfaceInfo allocates an address and returns
 // information for configuring networking on a container. It accepts
 // container tags as arguments. If the address allocation feature flag
-// is not enabled, it returns an error satisfying
-// errors.IsNotSupported().
+// is not enabled, it returns a NotSupported error.
 func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (params.MachineNetworkConfigResults, error) {
 	if !environs.AddressAllocationEnabled() {
 		return params.MachineNetworkConfigResults{}, errors.NotSupportedf("address allocation")

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -819,12 +819,12 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 // container tags as arguments. If address allocation feature flag is
 // not enabled, it will return a NotSupported error.
 func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params.ErrorResults, error) {
-	if !environs.AddressAllocationEnabled() {
-		return params.ErrorResults{}, errors.NotSupportedf("address allocation")
-	}
-
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
+	}
+
+	if !environs.AddressAllocationEnabled() {
+		return result, errors.NotSupportedf("address allocation")
 	}
 
 	canAccess, err := p.getAuthFunc()
@@ -886,13 +886,14 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 // container tags as arguments. If the address allocation feature flag
 // is not enabled, it returns a NotSupported error.
 func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (params.MachineNetworkConfigResults, error) {
-	if !environs.AddressAllocationEnabled() {
-		return params.MachineNetworkConfigResults{}, errors.NotSupportedf("address allocation")
-	}
-
 	result := params.MachineNetworkConfigResults{
 		Results: make([]params.MachineNetworkConfigResult, len(args.Entities)),
 	}
+
+	if !environs.AddressAllocationEnabled() {
+		return result, errors.NotSupportedf("address allocation")
+	}
+
 	// Some preparations first.
 	environ, host, canAccess, err := p.prepareContainerAccessEnvironment()
 	if err != nil {

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -54,6 +54,9 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 
 func (s *provisionerSuite) setUpTest(c *gc.C, withStateServer bool) {
 	s.JujuConnSuite.SetUpTest(c)
+	// We're testing with address allocation on by default. There are
+	// separate tests to check the behavior when the flag is not
+	// enabled.
 	s.SetFeatureFlags(feature.AddressAllocation)
 
 	// Reset previous machines (if any) and create 3 machines
@@ -1286,6 +1289,16 @@ func (s *withoutStateServerSuite) TestContainerManagerConfig(c *gc.C) {
 	})
 }
 
+func (s *withoutStateServerSuite) TestContainerManagerConfigNoFeatureFlagNoIPForwarding(c *gc.C) {
+	s.SetFeatureFlags() // clear the flags.
+
+	cfg := s.getManagerConfig(c, instance.KVM)
+	c.Assert(cfg, jc.DeepEquals, map[string]string{
+		container.ConfigName: "juju",
+		// ConfigIPForwarding should be missing.
+	})
+}
+
 func (s *withoutStateServerSuite) TestContainerManagerConfigNoIPForwarding(c *gc.C) {
 	// Break dummy provider's SupportsAddressAllocation method to
 	// ensure ConfigIPForwarding is not set below.
@@ -1319,18 +1332,13 @@ func (s *withoutStateServerSuite) TestContainerConfig(c *gc.C) {
 }
 
 func (s *withoutStateServerSuite) TestSetSupportedContainers(c *gc.C) {
-	args := params.MachineContainersParams{
-		Params: []params.MachineContainers{
-			{
-				MachineTag:     "machine-0",
-				ContainerTypes: []instance.ContainerType{instance.LXC},
-			},
-			{
-				MachineTag:     "machine-1",
-				ContainerTypes: []instance.ContainerType{instance.LXC, instance.KVM},
-			},
-		},
-	}
+	args := params.MachineContainersParams{Params: []params.MachineContainers{{
+		MachineTag:     "machine-0",
+		ContainerTypes: []instance.ContainerType{instance.LXC},
+	}, {
+		MachineTag:     "machine-1",
+		ContainerTypes: []instance.ContainerType{instance.LXC, instance.KVM},
+	}}}
 	results, err := s.provisioner.SetSupportedContainers(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -9,6 +9,7 @@ import (
 	stdtesting "testing"
 	"time"
 
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -159,6 +160,14 @@ func (s *suite) TestSupportsAddressAllocation(c *gc.C) {
 	supported, err = e.SupportsAddressAllocation("any-id")
 	c.Assert(err, gc.ErrorMatches, `dummy\.SupportsAddressAllocation is broken`)
 	c.Assert(supported, jc.IsFalse)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	supported, err = e.SupportsAddressAllocation("any-id")
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(supported, jc.IsFalse)
 }
 
 func (s *suite) breakMethods(c *gc.C, e environs.NetworkingEnviron, names ...string) {
@@ -201,6 +210,13 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 	newAddress = network.NewAddress("0.1.2.3", network.ScopeCloudLocal)
 	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
 	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *suite) TestReleaseAddress(c *gc.C) {
@@ -233,6 +249,13 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 	address = network.NewAddress("0.1.2.3", network.ScopeCloudLocal)
 	err = e.ReleaseAddress(inst.Id(), subnetId, address)
 	c.Assert(err, gc.ErrorMatches, `dummy\.ReleaseAddress is broken`)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	err = e.ReleaseAddress(inst.Id(), subnetId, address)
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *suite) TestNetworkInterfaces(c *gc.C) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -889,6 +889,31 @@ func (t *localServerSuite) TestSupportsAddressAllocationTrue(c *gc.C) {
 	c.Assert(result, jc.IsTrue)
 }
 
+func (t *localServerSuite) TestSupportsAddressAllocationWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	result, err := env.SupportsAddressAllocation("")
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(result, jc.IsFalse)
+}
+
+func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	err := env.AllocateAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	err := env.ReleaseAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
 func (t *localServerSuite) TestSupportsAddressAllocationCaches(c *gc.C) {
 	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
 		"default-vpc": {"none"},

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -201,7 +201,13 @@ var expectedCloudinitConfig = []interface{}{
 	"mkdir -p '/var/lib/juju'\ninstall -m 755 /dev/null '/var/lib/juju/MAASmachine.txt'\nprintf '%s\\n' ''\"'\"'hostname: testing.invalid\n'\"'\"'' > '/var/lib/juju/MAASmachine.txt'",
 }
 
-func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
+var expectedCloudinitConfigWithBridge = []interface{}{
+	"set -xe",
+	"mkdir -p '/var/lib/juju'\ninstall -m 755 /dev/null '/var/lib/juju/MAASmachine.txt'\nprintf '%s\\n' ''\"'\"'hostname: testing.invalid\n'\"'\"'' > '/var/lib/juju/MAASmachine.txt'",
+	"\n# In case we already created the bridge, don't do it again.\ngrep -q \"iface juju-br0 inet dhcp\" && exit 0\n\n# Discover primary interface at run-time using the default route (if set)\nPRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)\n\n# If $PRIMARY_IFACE is empty, there's nothing to do.\n[ -z \"$PRIMARY_IFACE\" ] && exit 0\n\n# Change the config to make $PRIMARY_IFACE manual instead of DHCP,\n# then create the bridge and enslave $PRIMARY_IFACE into it.\ngrep -q \"iface ${PRIMARY_IFACE} inet dhcp\" /etc/network/interfaces && \\\nsed -i \"s/iface ${PRIMARY_IFACE} inet dhcp//\" /etc/network/interfaces && \\\ncat >> /etc/network/interfaces << EOF\n\n# Primary interface (defining the default route)\niface ${PRIMARY_IFACE} inet manual\n\n# Bridge to use for LXC/KVM containers\nauto juju-br0\niface juju-br0 inet dhcp\n    bridge_ports ${PRIMARY_IFACE}\nEOF\n\n# Make the primary interface not auto-starting.\ngrep -q \"auto ${PRIMARY_IFACE}\" /etc/network/interfaces && \\\nsed -i \"s/auto ${PRIMARY_IFACE}//\" /etc/network/interfaces\n\n# Finally, stop $PRIMARY_IFACE and start the bridge instead.\nifdown -v ${PRIMARY_IFACE} ; ifup -v juju-br0\n",
+}
+
+func (*environSuite) TestNewCloudinitConfigWithFeatureFlag(c *gc.C) {
 	cfg := getSimpleTestConfig(c, nil)
 	env, err := maas.NewEnviron(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -211,15 +217,34 @@ func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
 }
 
-func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C) {
+func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags() // clear the flags.
+	cfg := getSimpleTestConfig(c, nil)
+	env, err := maas.NewEnviron(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "eth0", "quantal")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloudcfg.AptUpdate(), jc.IsTrue)
+	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfigWithBridge)
+}
+
+func (s *environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C) {
 	attrs := coretesting.Attrs{
 		"disable-network-management": true,
 	}
 	cfg := getSimpleTestConfig(c, attrs)
 	env, err := maas.NewEnviron(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "eth0", "quantal")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloudcfg.AptUpdate(), jc.IsTrue)
-	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
+	testCase := func() {
+		cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "eth0", "quantal")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(cloudcfg.AptUpdate(), jc.IsTrue)
+		c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
+	}
+	// First test the default case (address allocation feature flag on).
+	testCase()
+
+	// Now test with the flag off - expect the same.
+	s.SetFeatureFlags() // clear the flags.
+	testCase()
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/apt"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/fslock"
 	gc "gopkg.in/check.v1"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -48,7 +50,7 @@ type ContainerSetupSuite struct {
 var _ = gc.Suite(&ContainerSetupSuite{})
 
 func (s *ContainerSetupSuite) SetUpSuite(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
+	// TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: Skipping container tests on windows")
 	}
@@ -69,7 +71,6 @@ func noImportance(err0, err1 error) bool {
 
 func (s *ContainerSetupSuite) SetUpTest(c *gc.C) {
 	s.CommonProvisionerSuite.SetUpTest(c)
-	s.SetFeatureFlags(feature.AddressAllocation)
 	aptCmdChan := s.HookCommandOutput(&apt.CommandOutput, []byte{}, nil)
 	s.aptCmdChan = aptCmdChan
 
@@ -279,7 +280,7 @@ func (s *ContainerSetupSuite) TestContainerManagerConfigName(c *gc.C) {
 	expect("any-old-thing")
 }
 
-func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, ctype instance.ContainerType, packages []string) {
+func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, ctype instance.ContainerType, packages []string, addressable bool) {
 	// A noop worker callback.
 	startProvisionerWorker := func(runner worker.Runner, containerType instance.ContainerType,
 		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
@@ -305,14 +306,17 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, ctype instance
 
 	s.createContainer(c, m, ctype)
 
-	// After initialisation starts, but before running the
-	// initializer, lxc-net should be created if ctype is LXC, as the
-	// dummy provider supports static address allocation by default.
-	if ctype == instance.LXC {
-		AssertFileContains(c, s.fakeLXCNet, provisioner.EtcDefaultLXCNet)
-		defer os.Remove(s.fakeLXCNet)
-	} else {
-		c.Assert(s.fakeLXCNet, jc.DoesNotExist)
+	// Only feature-flagged addressable containers modify lxc-net.
+	if addressable {
+		// After initialisation starts, but before running the
+		// initializer, lxc-net should be created if ctype is LXC, as the
+		// dummy provider supports static address allocation by default.
+		if ctype == instance.LXC {
+			AssertFileContains(c, s.fakeLXCNet, provisioner.EtcDefaultLXCNet)
+			defer os.Remove(s.fakeLXCNet)
+		} else {
+			c.Assert(s.fakeLXCNet, jc.DoesNotExist)
+		}
 	}
 
 	cmd := <-s.aptCmdChan
@@ -333,7 +337,7 @@ func (s *ContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 		{instance.LXC, []string{"--target-release", "precise-updates/cloud-tools", "lxc", "cloud-image-utils"}},
 		{instance.KVM, []string{"uvtool-libvirt", "uvtool"}},
 	} {
-		s.assertContainerInitialised(c, test.ctype, test.packages)
+		s.assertContainerInitialised(c, test.ctype, test.packages, false)
 	}
 }
 
@@ -457,4 +461,30 @@ type toolsFinderFunc func(v version.Number, series string, arch *string) (tools.
 
 func (t toolsFinderFunc) FindTools(v version.Number, series string, arch *string) (tools.List, error) {
 	return t(v, series, arch)
+}
+
+// AddressableContainerSetupSuite only contains tests depending on the
+// address allocation feature flag being enabled.
+type AddressableContainerSetupSuite struct {
+	ContainerSetupSuite
+}
+
+var _ = gc.Suite(&AddressableContainerSetupSuite{})
+
+func (s *AddressableContainerSetupSuite) enableFeatureFlag() {
+	s.SetFeatureFlags(feature.AddressAllocation)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+}
+
+func (s *AddressableContainerSetupSuite) TestContainerInitialised(c *gc.C) {
+	for _, test := range []struct {
+		ctype    instance.ContainerType
+		packages []string
+	}{
+		{instance.LXC, []string{"--target-release", "precise-updates/cloud-tools", "lxc", "cloud-image-utils"}},
+		{instance.KVM, []string{"uvtool-libvirt", "uvtool"}},
+	} {
+		s.enableFeatureFlag()
+		s.assertContainerInitialised(c, test.ctype, test.packages, true)
+	}
 }


### PR DESCRIPTION
Follow-up to #2097 which brought new addressable containers under a
feature flag, but all tests had the flag enabled by default. With this
PR, more tests are added to verify the behavior when the
"address-allocation" feature flag is disabled.

(Review request: http://reviews.vapour.ws/r/1465/)