### PR TITLE
Fix service discovery on vivid.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -108,7 +108,7 @@ func discoverLocalInitSystem() (string, error) {
 	for _, check := range discoveryFuncs {
 		local, err := check.isRunning()
 		if err != nil {
-			return "", errors.Trace(err)
+			logger.Errorf("failed to find init system %q: %v", check.name, err)
 		}
 		if local {
 			logger.Debugf("discovered init system %q from local host", check.name)

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -110,6 +110,7 @@ func discoverLocalInitSystem() (string, error) {
 		if err != nil {
 			logger.Errorf("failed to find init system %q: %v", check.name, err)
 		}
+		// We expect that in error cases "local" will be false.
 		if local {
 			logger.Debugf("discovered init system %q from local host", check.name)
 			return check.name, nil

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -264,7 +264,7 @@ func (s *discoverySuite) TestVersionInitSystemNoLegacyUpstart(c *gc.C) {
 }
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirst(c *gc.C) {
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", true, nil),
 		service.NewDiscoveryCheck("initB", false, nil),
 	)
@@ -277,7 +277,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirst(c *gc.C) {
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemErrorFirst(c *gc.C) {
 	failure := errors.New("<failed>")
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, failure),
 		service.NewDiscoveryCheck("initB", true, nil),
 	)
@@ -290,7 +290,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemErrorFirst(c *gc.C) {
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirstError(c *gc.C) {
 	failure := errors.New("<failed>")
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", true, failure),
 		service.NewDiscoveryCheck("initB", false, nil),
 	)
@@ -302,7 +302,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirstError(c *gc.C) {
 }
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemMatchSecond(c *gc.C) {
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, nil),
 		service.NewDiscoveryCheck("initB", true, nil),
 	)
@@ -314,7 +314,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemMatchSecond(c *gc.C) {
 }
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemMatchNone(c *gc.C) {
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, nil),
 		service.NewDiscoveryCheck("initB", false, nil),
 	)
@@ -326,7 +326,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemMatchNone(c *gc.C) {
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemErrorMixed(c *gc.C) {
 	failure := errors.New("<failed>")
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, failure),
 		service.NewDiscoveryCheck("initB", false, nil),
 	)
@@ -339,7 +339,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemErrorMixed(c *gc.C) {
 func (s *discoverySuite) TestDiscoverLocalInitSystemErrorAll(c *gc.C) {
 	failureA := errors.New("<failed A>")
 	failureB := errors.New("<failed B>")
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, failureA),
 		service.NewDiscoveryCheck("initB", false, failureB),
 	)

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -4,6 +4,24 @@
 package service
 
 var (
-	DiscoverInitSystem    = discoverInitSystem
-	NewShellSelectCommand = newShellSelectCommand
+	DiscoverInitSystem      = discoverInitSystem
+	DiscoverLocalInitSystem = discoverLocalInitSystem
+	NewShellSelectCommand   = newShellSelectCommand
 )
+
+func NewDiscoveryCheck(name string, running bool, failure error) discoveryCheck {
+	return discoveryCheck{
+		name: name,
+		isRunning: func() (bool, error) {
+			return running, failure
+		},
+	}
+}
+
+type patcher interface {
+	PatchValue(interface{}, interface{})
+}
+
+func PatchDiscoveryFuncs(s patcher, checks ...discoveryCheck) {
+	s.PatchValue(&discoveryFuncs, checks)
+}

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -8,20 +8,3 @@ var (
 	DiscoverLocalInitSystem = discoverLocalInitSystem
 	NewShellSelectCommand   = newShellSelectCommand
 )
-
-func NewDiscoveryCheck(name string, running bool, failure error) discoveryCheck {
-	return discoveryCheck{
-		name: name,
-		isRunning: func() (bool, error) {
-			return running, failure
-		},
-	}
-}
-
-type patcher interface {
-	PatchValue(interface{}, interface{})
-}
-
-func PatchDiscoveryFuncs(s patcher, checks ...discoveryCheck) {
-	s.PatchValue(&discoveryFuncs, checks)
-}

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -29,27 +29,30 @@ var (
 
 // IsRunning returns whether or not upstart is the local init system.
 func IsRunning() (bool, error) {
-	if _, err := os.Stat(initctlPath); os.IsNotExist(err) {
-		return false, nil
-	} else if err != nil {
-		return false, errors.Trace(err)
-	}
+	// TODO(ericsnow) This function should be fixed to precisely match
+	// the equivalent shell script line in service/discovery.go.
 
 	cmd := exec.Command(initctlPath, "--system", "list")
-	switch err := cmd.Run().(type) {
-	case *exec.ExitError:
-		logger.Debugf("exec %q failed: %#v", initctlPath, err)
-		if err.Error() == "exit status 1" {
+	_, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+
+	msg := fmt.Sprintf("exec %q failed", initctlPath)
+	if os.IsNotExist(err) {
+		// Executable could not be found, go 1.3 and later
+		return false, nil
+	}
+	if execErr, ok := err.(*exec.Error); ok {
+		// Executable could not be found, go 1.2
+		if os.IsNotExist(execErr.Err) || execErr.Err == exec.ErrNotFound {
 			return false, nil
 		}
-		return false, errors.Trace(err)
-	default:
-		if err != nil {
-			logger.Debugf("exec %q failed: %#v", initctlPath, err)
-			return false, errors.Trace(err)
-		}
 	}
-	return true, nil
+	// Note: initctl will fail if upstart is installed but not running.
+	// The error message will be:
+	//   Name "com.ubuntu.Upstart" does not exist
+	return false, errors.Annotatef(err, msg)
 }
 
 // ListServices returns the name of all installed services on the

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/symlink"
 	gc "gopkg.in/check.v1"
 
@@ -374,18 +375,26 @@ const modeNotExecutable = 0400
 
 // createInitctl creates a dummy initctl which returns the given
 // exitcode and patches the upstart package to use it.
-func (s *IsRunningSuite) createInitctl(c *gc.C, exitcode int, mode os.FileMode) {
+func (s *IsRunningSuite) createInitctl(c *gc.C, stderr string, exitcode int, mode os.FileMode) {
 	path := filepath.Join(c.MkDir(), "initctl")
-	script := fmt.Sprintf(`#!/bin/sh
+	var body string
+	if stderr != "" {
+		// Write to stderr.
+		body = ">&2 echo " + utils.ShQuote(stderr)
+	}
+	script := fmt.Sprintf(`
+#!/usr/bin/env bash
+%s
 exit %d
-`, exitcode)
+`[1:], body, exitcode)
+	c.Logf(script)
 	err := ioutil.WriteFile(path, []byte(script), mode)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(upstart.InitctlPath, path)
 }
 
 func (s *IsRunningSuite) TestUpstartInstalled(c *gc.C) {
-	s.createInitctl(c, 0, modeExecutable)
+	s.createInitctl(c, "", 0, modeExecutable)
 
 	isUpstart, err := upstart.IsRunning()
 	c.Assert(isUpstart, jc.IsTrue)
@@ -401,16 +410,27 @@ func (s *IsRunningSuite) TestUpstartNotInstalled(c *gc.C) {
 }
 
 func (s *IsRunningSuite) TestUpstartInstalledButBroken(c *gc.C) {
+	const stderr = "<something broke>"
 	const errorCode = 99
-	s.createInitctl(c, errorCode, modeExecutable)
+	s.createInitctl(c, stderr, errorCode, modeExecutable)
 
 	isUpstart, err := upstart.IsRunning()
 	c.Assert(isUpstart, jc.IsFalse)
-	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("exit status %d", errorCode))
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*exit status %d", errorCode))
+}
+
+func (s *IsRunningSuite) TestUpstartInstalledButNotRunning(c *gc.C) {
+	const stderr = `Name "com.ubuntu.Upstart" does not exist`
+	const errorCode = 1
+	s.createInitctl(c, "", errorCode, modeExecutable)
+
+	isUpstart, err := upstart.IsRunning()
+	c.Assert(isUpstart, jc.IsFalse)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*exit status %d", errorCode))
 }
 
 func (s *IsRunningSuite) TestInitctlCantBeRun(c *gc.C) {
-	s.createInitctl(c, 0, modeNotExecutable)
+	s.createInitctl(c, "", 0, modeNotExecutable)
 
 	isUpstart, err := upstart.IsRunning()
 	c.Assert(isUpstart, jc.IsFalse)

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -422,7 +422,7 @@ func (s *IsRunningSuite) TestUpstartInstalledButBroken(c *gc.C) {
 func (s *IsRunningSuite) TestUpstartInstalledButNotRunning(c *gc.C) {
 	const stderr = `Name "com.ubuntu.Upstart" does not exist`
 	const errorCode = 1
-	s.createInitctl(c, "", errorCode, modeExecutable)
+	s.createInitctl(c, stderr, errorCode, modeExecutable)
 
 	isUpstart, err := upstart.IsRunning()
 	c.Assert(isUpstart, jc.IsFalse)


### PR DESCRIPTION
Currently init system discovery fails if any one of the individual checks results in an error.  This patch changes that to simply log the error and try the next init system.  I've also removed duplicate logging from upstart.IsRunning.

(Review request: http://reviews.vapour.ws/r/1470/)