### PR TITLE
Add new health status values for units and services to megawatcher

### DIFF
--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -67,9 +67,13 @@ var marshalTestCases = []struct {
 				"hello": "goodbye",
 				"foo":   false,
 			},
+			Status: multiwatcher.StatusInfo{
+				Current: multiwatcher.Status("active"),
+				Message: "all good",
+			},
 		},
 	},
-	json: `["service","change",{"CharmURL": "cs:quantal/name","Name":"Benji","Exposed":true,"Life":"dying","OwnerTag":"test-owner","MinUnits":42,"Constraints":{"arch":"armhf", "mem": 1024},"Config": {"hello":"goodbye","foo":false},"Subordinate":false}]`,
+	json: `["service","change",{"CharmURL": "cs:quantal/name","Name":"Benji","Exposed":true,"Life":"dying","OwnerTag":"test-owner","MinUnits":42,"Constraints":{"arch":"armhf", "mem": 1024},"Config": {"hello":"goodbye","foo":false},"Subordinate":false,"Status":{"Current":"active", "Message":"all good", "Version": "", "Err": null, "Data": null, "Since": null}}]`,
 }, {
 	about: "UnitInfo Delta",
 	value: multiwatcher.Delta{
@@ -92,9 +96,16 @@ var marshalTestCases = []struct {
 			MachineId:      "1",
 			Status:         "error",
 			StatusInfo:     "foo",
+			WorkloadStatus: multiwatcher.StatusInfo{
+				Current: multiwatcher.Status("active"),
+				Message: "all good",
+			},
+			AgentStatus: multiwatcher.StatusInfo{
+				Current: multiwatcher.Status("idle"),
+			},
 		},
 	},
-	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "PortRanges": [{"FromPort": 80, "ToPort": 80, "Protocol": "http"}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "Subordinate": false}]`,
+	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "PortRanges": [{"FromPort": 80, "ToPort": 80, "Protocol": "http"}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "WorkloadStatus":{"Current":"active", "Message":"all good", "Version": "", "Err": null, "Data": null, "Since": null}, "AgentStatus":{"Current":"idle", "Message":"", "Version": "", "Err": null, "Data": null, "Since": null}, "Subordinate": false}]`,
 }, {
 	about: "RelationInfo Delta",
 	value: multiwatcher.Delta{
@@ -144,7 +155,7 @@ func (s *MarshalSuite) TestDeltaMarshalJSON(c *gc.C) {
 		var expected interface{}
 		err = json.Unmarshal([]byte(t.json), &expected)
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(unmarshalledOutput, gc.DeepEquals, expected)
+		c.Check(unmarshalledOutput, jc.DeepEquals, expected)
 	}
 }
 

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -139,6 +139,22 @@ func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange,
 	return portRanges, compatiblePorts, nil
 }
 
+func unitAndAgentStatus(st *State, name string) (unitStatus, agentStatus *StatusInfo, err error) {
+	unit, err := st.Unit(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	unitStatusResult, err := unit.Status()
+	if err != nil {
+		return nil, nil, err
+	}
+	agentStatusResult, err := unit.AgentStatus()
+	if err != nil {
+		return nil, nil, err
+	}
+	return &unitStatusResult, &agentStatusResult, nil
+}
+
 func (u *backingUnit) updated(st *State, store *multiwatcherStore, id interface{}) error {
 	info := &multiwatcher.UnitInfo{
 		Name:        u.Name,
@@ -154,13 +170,41 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id interface{
 	if oldInfo == nil {
 		// We're adding the entry for the first time,
 		// so fetch the associated unit status and opened ports.
-		sdoc, err := getStatus(st, unitAgentGlobalKey(u.Name))
+		unitStatus, agentStatus, err := unitAndAgentStatus(st, u.Name)
 		if err != nil {
 			return err
 		}
-		info.Status = multiwatcher.Status(sdoc.Status)
-		info.Status = translateLegacyUnitAgentStatus(info.Status)
-		info.StatusInfo = sdoc.StatusInfo
+		// Unit and workload status.
+		info.WorkloadStatus = multiwatcher.StatusInfo{
+			Current: multiwatcher.Status(unitStatus.Status),
+			Message: unitStatus.Message,
+			Data:    unitStatus.Data,
+			Since:   unitStatus.Since,
+		}
+		if u.Tools != nil {
+			info.AgentStatus.Version = u.Tools.Version.Number.String()
+		}
+		info.AgentStatus = multiwatcher.StatusInfo{
+			Current: multiwatcher.Status(agentStatus.Status),
+			Message: agentStatus.Message,
+			Data:    agentStatus.Data,
+			Since:   agentStatus.Since,
+		}
+		// Legacy status info.
+		if unitStatus.Status == StatusError {
+			info.Status = multiwatcher.Status(unitStatus.Status)
+			info.StatusInfo = unitStatus.Message
+			info.StatusData = unitStatus.Data
+		} else {
+			info.Status = multiwatcher.Status(agentStatus.Status)
+			info.Status = translateLegacyUnitAgentStatus(info.Status)
+			info.StatusInfo = agentStatus.Message
+			info.StatusData = agentStatus.Data
+		}
+		if len(info.StatusData) == 0 {
+			info.StatusData = nil
+		}
+
 		portRanges, compatiblePorts, err := getUnitPortRangesAndPorts(st, u.Name)
 		if err != nil {
 			return errors.Trace(err)
@@ -171,8 +215,12 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id interface{
 	} else {
 		// The entry already exists, so preserve the current status and ports.
 		oldInfo := oldInfo.(*multiwatcher.UnitInfo)
+		// Legacy status.
 		info.Status = oldInfo.Status
 		info.StatusInfo = oldInfo.StatusInfo
+		// Unit and workload status.
+		info.AgentStatus = oldInfo.AgentStatus
+		info.WorkloadStatus = oldInfo.WorkloadStatus
 		info.Ports = oldInfo.Ports
 		info.PortRanges = oldInfo.PortRanges
 	}
@@ -235,14 +283,30 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id inter
 	oldInfo := store.Get(info.EntityId())
 	needConfig := false
 	if oldInfo == nil {
+		key := serviceGlobalKey(svc.Name)
 		// We're adding the entry for the first time,
 		// so fetch the associated child documents.
-		c, err := readConstraints(st, serviceGlobalKey(svc.Name))
+		c, err := readConstraints(st, key)
 		if err != nil {
 			return err
 		}
 		info.Constraints = c
 		needConfig = true
+		// Fetch the status.
+		service, err := st.Service(svc.Name)
+		if err != nil {
+			return err
+		}
+		serviceStatus, err := service.Status()
+		if err != nil {
+			return err
+		}
+		info.Status = multiwatcher.StatusInfo{
+			Current: multiwatcher.Status(serviceStatus.Status),
+			Message: serviceStatus.Message,
+			Data:    serviceStatus.Data,
+			Since:   serviceStatus.Since,
+		}
 	} else {
 		// The entry already exists, so preserve the current status.
 		oldInfo := oldInfo.(*multiwatcher.ServiceInfo)
@@ -413,10 +477,16 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id interfac
 		return nil
 	case *multiwatcher.UnitInfo:
 		newInfo := *info
-		newInfo.Status = multiwatcher.Status(s.Status)
-		newInfo.Status = translateLegacyUnitAgentStatus(newInfo.Status)
-		newInfo.StatusInfo = s.StatusInfo
-		newInfo.StatusData = s.StatusData
+		if err := s.updatedUnitStatus(st, store, id.(string), &newInfo); err != nil {
+			return err
+		}
+		info0 = &newInfo
+	case *multiwatcher.ServiceInfo:
+		newInfo := *info
+		newInfo.Status.Current = multiwatcher.Status(s.Status)
+		newInfo.Status.Message = s.StatusInfo
+		newInfo.Status.Data = s.StatusData
+		newInfo.Status.Since = s.Updated
 		info0 = &newInfo
 	case *multiwatcher.MachineInfo:
 		newInfo := *info
@@ -428,6 +498,53 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id interfac
 		panic(fmt.Errorf("status for unexpected entity with id %q; type %T", id, info))
 	}
 	store.Update(info0)
+	return nil
+}
+
+func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, id string, newInfo *multiwatcher.UnitInfo) error {
+	// Legacy status info - display the agent status or any error.
+	if !strings.HasSuffix(id, "#charm") || s.Status == StatusError {
+		newInfo.Status = multiwatcher.Status(s.Status)
+		newInfo.Status = translateLegacyUnitAgentStatus(newInfo.Status)
+		newInfo.StatusInfo = s.StatusInfo
+		newInfo.StatusData = s.StatusData
+	}
+	// Unit or workload status.
+	if strings.HasSuffix(id, "#charm") || s.Status == StatusError {
+		newInfo.WorkloadStatus.Current = multiwatcher.Status(s.Status)
+		newInfo.WorkloadStatus.Message = s.StatusInfo
+		newInfo.WorkloadStatus.Data = s.StatusData
+		newInfo.WorkloadStatus.Since = s.Updated
+	} else {
+		newInfo.AgentStatus.Current = multiwatcher.Status(s.Status)
+		newInfo.AgentStatus.Message = s.StatusInfo
+		newInfo.AgentStatus.Data = s.StatusData
+		newInfo.AgentStatus.Since = s.Updated
+	}
+
+	// A change in a unit's status might also affect it's service.
+	service, err := st.Service(newInfo.Service)
+	if err != nil {
+		return err
+	}
+	serviceId, ok := backingEntityIdForGlobalKey(service.globalKey())
+	if !ok {
+		return nil
+	}
+	serviceInfo := store.Get(serviceId)
+	if serviceInfo == nil {
+		return nil
+	}
+	status, err := service.Status()
+	if err != nil {
+		return err
+	}
+	newServiceInfo := *serviceInfo.(*multiwatcher.ServiceInfo)
+	newServiceInfo.Status.Current = multiwatcher.Status(status.Status)
+	newServiceInfo.Status.Message = status.Message
+	newServiceInfo.Status.Data = status.Data
+	newServiceInfo.Status.Since = status.Since
+	store.Update(&newServiceInfo)
 	return nil
 }
 

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -142,15 +142,15 @@ func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange,
 func unitAndAgentStatus(st *State, name string) (unitStatus, agentStatus *StatusInfo, err error) {
 	unit, err := st.Unit(name)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Trace(err)
 	}
 	unitStatusResult, err := unit.Status()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Trace(err)
 	}
 	agentStatusResult, err := unit.AgentStatus()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Trace(err)
 	}
 	return &unitStatusResult, &agentStatusResult, nil
 }
@@ -288,18 +288,18 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id inter
 		// so fetch the associated child documents.
 		c, err := readConstraints(st, key)
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		info.Constraints = c
 		needConfig = true
 		// Fetch the status.
 		service, err := st.Service(svc.Name)
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		serviceStatus, err := service.Status()
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		info.Status = multiwatcher.StatusInfo{
 			Current: multiwatcher.Status(serviceStatus.Status),
@@ -325,7 +325,7 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id inter
 		var err error
 		info.Config, _, err = readSettingsDoc(st, serviceSettingsKey(svc.Name, svc.CharmURL))
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 	store.Update(info)
@@ -525,7 +525,7 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 	// A change in a unit's status might also affect it's service.
 	service, err := st.Service(newInfo.Service)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	serviceId, ok := backingEntityIdForGlobalKey(service.globalKey())
 	if !ok {
@@ -537,7 +537,7 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 	}
 	status, err := service.Status()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	newServiceInfo := *serviceInfo.(*multiwatcher.ServiceInfo)
 	newServiceInfo.Status.Current = multiwatcher.Status(status.Status)

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -144,6 +144,15 @@ func (i *MachineInfo) EntityId() EntityId {
 	}
 }
 
+type StatusInfo struct {
+	Err     error
+	Current Status
+	Message string
+	Since   *time.Time
+	Version string
+	Data    map[string]interface{}
+}
+
 type ServiceInfo struct {
 	Name        string `bson:"_id"`
 	Exposed     bool
@@ -154,6 +163,7 @@ type ServiceInfo struct {
 	Constraints constraints.Value
 	Config      map[string]interface{}
 	Subordinate bool
+	Status      StatusInfo
 }
 
 func (i *ServiceInfo) EntityId() EntityId {
@@ -173,10 +183,14 @@ type UnitInfo struct {
 	MachineId      string
 	Ports          []network.Port
 	PortRanges     []network.PortRange
-	Status         Status
-	StatusInfo     string
-	StatusData     map[string]interface{}
 	Subordinate    bool
+	// The following 3 status values are deprecated.
+	Status     Status
+	StatusInfo string
+	StatusData map[string]interface{}
+	// Workload and agent state are modelled separately.
+	WorkloadStatus StatusInfo
+	AgentStatus    StatusInfo
 }
 
 func (i *UnitInfo) EntityId() EntityId {

--- a/state/service.go
+++ b/state/service.go
@@ -1042,7 +1042,7 @@ type settingsRefsDoc struct {
 // status is derived from the unit status values.
 func (s *Service) Status() (StatusInfo, error) {
 	doc, err := getStatus(s.st, s.globalKey())
-	if errors.IsNotFound(err) && s.IsPrincipal() {
+	if errors.IsNotFound(err) {
 		return s.deriveStatus()
 	}
 	if err != nil {


### PR DESCRIPTION
The megawatcher backing docs for unit and service have been extended to include the new workload and agent status data. The old legacy agent state data is retained. This allows exiting clients and the GUI to continue to work, and new versions of the GUI etc can be extended to use the new attributes.

(Review request: http://reviews.vapour.ws/r/1471/)