### PR TITLE
Add status-history

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -189,7 +189,7 @@ func (c *Client) UnitStatusHistory(kind params.HistoryKind, unitName string, siz
 	err := c.facade.FacadeCall("UnitStatusHistory", args, &results)
 	if err != nil {
 		if params.IsCodeNotImplemented(err) {
-			return &UnitStatusHistory{}, errors.NotImplementedf("UnitStatus")
+			return &UnitStatusHistory{}, errors.NotImplementedf("UnitStatusHistory")
 		}
 		return &UnitStatusHistory{}, errors.Trace(err)
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -55,7 +55,7 @@ type AgentStatus struct {
 	Info    string
 	Data    map[string]interface{}
 	Since   *time.Time
-	Kind    string
+	Kind    params.HistoryKind
 	Version string
 	Life    string
 	Err     error
@@ -101,8 +101,8 @@ type ServiceStatus struct {
 	Status        AgentStatus
 }
 
-// UnitStatuses holds a slice of statuses.
-type UnitStatuses struct {
+// UnitStatusHistory holds a slice of statuses.
+type UnitStatusHistory struct {
 	Statuses []AgentStatus
 }
 
@@ -179,8 +179,8 @@ func (c *Client) Status(patterns []string) (*Status, error) {
 
 // UnitStatusHistory retrieves the last <size> results of <kind:combined|agent|workload> status
 // for <unitName> unit
-func (c *Client) UnitStatusHistory(kind, unitName string, size int) (*UnitStatuses, error) {
-	var results UnitStatuses
+func (c *Client) UnitStatusHistory(kind params.HistoryKind, unitName string, size int) (*UnitStatusHistory, error) {
+	var results UnitStatusHistory
 	args := params.StatusHistory{
 		Kind: kind,
 		Size: size,
@@ -189,9 +189,9 @@ func (c *Client) UnitStatusHistory(kind, unitName string, size int) (*UnitStatus
 	err := c.facade.FacadeCall("UnitStatusHistory", args, &results)
 	if err != nil {
 		if params.IsCodeNotImplemented(err) {
-			return &UnitStatuses{}, errors.NotImplementedf("UnitStatus")
+			return &UnitStatusHistory{}, errors.NotImplementedf("UnitStatus")
 		}
-		return &UnitStatuses{}, errors.Trace(err)
+		return &UnitStatusHistory{}, errors.Trace(err)
 	}
 	return &results, nil
 }

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -49,6 +49,7 @@ func (s sortableStatuses) Less(i, j int) bool {
 	return s[i].Since.Before(*s[j].Since)
 }
 
+// TODO(perrito666) this client method requires more testing, only its parts are unittested.
 // UnitStatusHistory returns a slice of past statuses for a given unit.
 func (c *Client) UnitStatusHistory(args params.StatusHistory) (api.UnitStatusHistory, error) {
 	size := args.Size - 1

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -347,9 +347,11 @@ type SetStatus struct {
 
 type HistoryKind string
 
-var KindCombined HistoryKind = "combined"
-var KindAgent HistoryKind = "agent"
-var KindWorkload HistoryKind = "workload"
+const (
+	KindCombined HistoryKind = "combined"
+	KindAgent    HistoryKind = "agent"
+	KindWorkload HistoryKind = "workload"
+)
 
 // StatusHistory holds the parameters to filter a status history query.
 type StatusHistory struct {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -345,6 +345,13 @@ type SetStatus struct {
 	Entities []EntityStatus
 }
 
+// StatusHistory holds the parameters to filter a status history query.
+type StatusHistory struct {
+	Kind string
+	Size int
+	Name string
+}
+
 // StatusResult holds an entity status, extra information, or an
 // error.
 type StatusResult struct {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -345,9 +345,15 @@ type SetStatus struct {
 	Entities []EntityStatus
 }
 
+type HistoryKind string
+
+var KindCombined HistoryKind = "combined"
+var KindAgent HistoryKind = "agent"
+var KindWorkload HistoryKind = "workload"
+
 // StatusHistory holds the parameters to filter a status history query.
 type StatusHistory struct {
-	Kind string
+	Kind HistoryKind
 	Size int
 	Name string
 }

--- a/cmd/juju/common.go
+++ b/cmd/juju/common.go
@@ -259,10 +259,10 @@ func (c *csClient) authorize(curl *charm.URL) (*macaroon.Macaroon, error) {
 
 // formatStatusTime returns a string with the local time
 // formatted in an arbitrary format used for status or
-// and localized tz or in utc timezone and format TFC3339
+// and localized tz or in utc timezone and format RFC3339
 // if u is specified.
-func formatStatusTime(t *time.Time, u bool) string {
-	if u {
+func formatStatusTime(t *time.Time, formatISO bool) string {
+	if formatISO {
 		// If requested, use ISO time format
 		return t.Format(time.RFC3339)
 	} else {

--- a/cmd/juju/common.go
+++ b/cmd/juju/common.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -254,4 +255,18 @@ func (c *csClient) authorize(curl *charm.URL) (*macaroon.Macaroon, error) {
 		return nil, errors.Trace(err)
 	}
 	return m, nil
+}
+
+// formatStatusTime returns a string with the local time
+// formatted in an arbitrary format used for status or
+// and localized tz or in utc timezone and format TFC3339
+// if u is specified.
+func formatStatusTime(t *time.Time, u bool) string {
+	if u {
+		// If requested, use ISO time format
+		return t.Format(time.RFC3339)
+	} else {
+		// Otherwise use local time.
+		return t.Local().Format("02 Jan 2006 15:04:05 MST")
+	}
 }

--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -131,6 +131,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(&SwitchCommand{})
 	r.Register(wrapEnvCommand(&EndpointCommand{}))
 	r.Register(wrapEnvCommand(&APIInfoCommand{}))
+	r.Register(wrapEnvCommand(&StatusHistoryCommand{}))
 
 	// Error resolution and debugging commands.
 	r.Register(wrapEnvCommand(&RunCommand{}))

--- a/cmd/juju/main_test.go
+++ b/cmd/juju/main_test.go
@@ -239,6 +239,7 @@ var commandNames = []string{
 	"ssh",
 	"stat", // alias for status
 	"status",
+	"status-history",
 	"storage",
 	"switch",
 	"sync-tools",

--- a/cmd/juju/status.go
+++ b/cmd/juju/status.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -433,16 +432,6 @@ func (sf *statusFormatter) formatService(name string, service api.ServiceStatus)
 	return out
 }
 
-func (sf *statusFormatter) formatTime(t *time.Time) string {
-	if sf.isoTime {
-		// If requested, use ISO time format
-		return t.Format(time.RFC3339)
-	} else {
-		// Otherwise use local time.
-		return t.Local().Format("02 Jan 2006 15:04:05 MST")
-	}
-}
-
 func (sf *statusFormatter) getServiceStatusInfo(service api.ServiceStatus) statusInfoContents {
 	info := statusInfoContents{
 		Err:     service.Status.Err,
@@ -451,7 +440,7 @@ func (sf *statusFormatter) getServiceStatusInfo(service api.ServiceStatus) statu
 		Version: service.Status.Version,
 	}
 	if service.Status.Since != nil {
-		info.Since = sf.formatTime(service.Status.Since)
+		info.Since = formatStatusTime(service.Status.Since, sf.isoTime)
 	}
 	return info
 }
@@ -493,7 +482,7 @@ func (sf *statusFormatter) getWorkloadStatusInfo(unit api.UnitStatus) statusInfo
 		Version: unit.Workload.Version,
 	}
 	if unit.Workload.Since != nil {
-		info.Since = sf.formatTime(unit.Workload.Since)
+		info.Since = formatStatusTime(unit.Workload.Since, sf.isoTime)
 	}
 	return info
 }
@@ -506,7 +495,7 @@ func (sf *statusFormatter) getAgentStatusInfo(unit api.UnitStatus) statusInfoCon
 		Version: unit.UnitAgent.Version,
 	}
 	if unit.UnitAgent.Since != nil {
-		info.Since = sf.formatTime(unit.UnitAgent.Since)
+		info.Since = formatStatusTime(unit.UnitAgent.Since, sf.isoTime)
 	}
 	return info
 }

--- a/cmd/juju/statushistory.go
+++ b/cmd/juju/statushistory.go
@@ -29,7 +29,7 @@ type StatusHistoryCommand struct {
 
 var statusHistoryDoc = `
 This command will report the history of status changes for
-a given unit past.
+a given unit.
 The statuses for the unit workload and/or agent are available.
 -type supports:
     agent: will show statuses for the unit's agent

--- a/cmd/juju/statushistory.go
+++ b/cmd/juju/statushistory.go
@@ -1,0 +1,113 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/envcmd"
+	"launchpad.net/gnuflag"
+)
+
+type StatusHistoryCommand struct {
+	envcmd.EnvCommandBase
+	out           cmd.Output
+	outputContent string
+	backlogSize   int
+	isoTime       bool
+	unitName      string
+}
+
+var statusHistoryDoc = `
+This command will report the history of status changes for
+a given unit up to 20 changes in the past.
+The statuses for the unit workload or agent are available.
+-type supports:
+    agent: will show last 20 statuses for the unit's agent
+    workload: will show last 20 statuses for the unit's workload
+    combined: will 20 entries for agent and workload statuses combined
+ and sorted by time of occurence.
+`
+
+func (c *StatusHistoryCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "status-history",
+		Args:    "[-n N] <unit>",
+		Purpose: "output last 20 statuses for a unit",
+		Doc:     statusHistoryDoc,
+	}
+}
+
+func (c *StatusHistoryCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.outputContent, "type", "combined", "type of statuses to be displayed [agent|workload|combined].")
+	f.IntVar(&c.backlogSize, "n", 20, "size of logs backlog.")
+	f.BoolVar(&c.isoTime, "utc", false, "display time as UTC in RFC3339 format")
+}
+
+func (c *StatusHistoryCommand) Init(args []string) error {
+	switch {
+	case len(args) > 1:
+		return errors.Errorf("unexpected arguments after unit name.")
+	case len(args) == 0:
+		return errors.Errorf("unit name is missing.")
+	default:
+		c.unitName = args[0]
+	}
+	return nil
+}
+
+func (c *StatusHistoryCommand) Run(ctx *cmd.Context) error {
+	apiclient, err := c.NewAPIClient()
+	if err != nil {
+		return fmt.Errorf(connectionError, c.ConnectionName(), err)
+	}
+	defer apiclient.Close()
+	var statuses *api.UnitStatuses
+	switch c.outputContent {
+	case "combined", "agent", "workload":
+		statuses, err = apiclient.UnitStatusHistory(c.outputContent, c.unitName, c.backlogSize)
+	default:
+		return errors.Errorf("unexpected status type %q", c.outputContent)
+	}
+	if err != nil {
+		if len(statuses.Statuses) == 0 {
+			return errors.Trace(err)
+		}
+		// Display any error, but continue to print status if some was returned
+		fmt.Fprintf(ctx.Stderr, "%v\n", err)
+	} else if len(statuses.Statuses) == 0 {
+		return errors.Errorf("unable to obtain status history")
+	}
+	table := [][]string{{"TIME", "TYPE", "STATUS", "MESSAGE"}}
+	lengths := []int{1, 1, 1, 1}
+	for _, v := range statuses.Statuses {
+		fields := []string{c.formatTime(v.Since), v.Kind, string(v.Status), v.Info}
+		for k, v := range fields {
+			if len(v) > lengths[k] {
+				lengths[k] = len(v)
+			}
+		}
+		table = append(table, fields)
+	}
+	f := fmt.Sprintf("%%-%ds\t%%-%ds\t%%-%ds\t%%-%ds\n", lengths[0], lengths[1], lengths[2], lengths[3])
+	for _, v := range table {
+		fmt.Printf(f, v[0], v[1], v[2], v[3])
+	}
+	return nil
+}
+
+func (c *StatusHistoryCommand) formatTime(t *time.Time) string {
+	if c.isoTime {
+		// If requested, use ISO time format
+		return t.Format(time.RFC3339)
+	} else {
+		// Otherwise use local time.
+		return t.Local().Format("02 Jan 2006 15:04:05 MST")
+	}
+}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -86,6 +86,7 @@ import (
 	"github.com/juju/juju/worker/resumer"
 	"github.com/juju/juju/worker/rsyslog"
 	"github.com/juju/juju/worker/singular"
+	"github.com/juju/juju/worker/statushistorypruner"
 	"github.com/juju/juju/worker/storageprovisioner"
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
@@ -978,6 +979,10 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 					return dblogpruner.New(st, dblogpruner.NewLogPruneParams()), nil
 				})
 			}
+			a.startWorkerAfterUpgrade(singularRunner, "statushistorypruner", func() (worker.Worker, error) {
+				return statushistorypruner.New(st, statushistorypruner.NewHistoryPrunerParams()), nil
+			})
+
 			a.startWorkerAfterUpgrade(singularRunner, "resumer", func() (worker.Worker, error) {
 				// The action of resumer is so subtle that it is not tested,
 				// because we can't figure out how to do so without brutalising

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -621,6 +621,16 @@ func (s *MachineSuite) TestManageEnvironDoesntRunDbLogPrunerByDefault(c *gc.C) {
 	c.Assert(started.Contains("dblogpruner"), jc.IsFalse)
 }
 
+func (s *MachineSuite) TestManageEnvironRunsStatusHistoryPruner(c *gc.C) {
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+
+	runner := s.singularRecord.nextRunner(c)
+	runner.waitForWorker(c, "statushistorypruner")
+}
+
 func (s *MachineSuite) TestManageEnvironCallsUseMultipleCPUs(c *gc.C) {
 	// If it has been enabled, the JobManageEnviron agent should call utils.UseMultipleCPUs
 	usefulVersion := version.Current

--- a/state/collections.go
+++ b/state/collections.go
@@ -88,6 +88,7 @@ var multiEnvCollections = set.NewStrings(
 	settingsC,
 	settingsrefsC,
 	statusesC,
+	statusesHistoryC,
 	storageAttachmentsC,
 	storageConstraintsC,
 	storageInstancesC,

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -377,13 +377,26 @@ func AssertHostPortConversion(c *gc.C, netHostPort network.HostPort) {
 
 type StatusDoc statusDoc
 
+func NewStatusDoc(s StatusDoc) statusDoc {
+	return statusDoc(s)
+}
+
 func NewHistoricalStatusDoc(s StatusDoc, key string) *historicalStatusDoc {
 	sdoc := statusDoc(s)
 	return newHistoricalStatusDoc(sdoc, key)
 }
 
 var StatusHistory = statusHistory
+var UpdateStatusHistory = updateStatusHistory
 
 func EraseUnitHistory(u *Unit) error {
 	return u.eraseHistory()
+}
+
+func UnitGlobalKey(u *Unit) string {
+	return u.globalKey()
+}
+
+func UnitAgentGlobalKey(u *UnitAgent) string {
+	return u.globalKey()
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -32,6 +32,7 @@ const (
 	UsersC             = usersC
 	BlockDevicesC      = blockDevicesC
 	StorageInstancesC  = storageInstancesC
+	StatusesHistoryC   = statusesHistoryC
 )
 
 var (
@@ -372,4 +373,17 @@ func AssertHostPortConversion(c *gc.C, netHostPort network.HostPort) {
 	hostsPorts := fromNetworkHostsPorts(netHostsPorts)
 	newNetHostsPorts := networkHostsPorts(hostsPorts)
 	c.Assert(netHostsPorts, gc.DeepEquals, newNetHostsPorts)
+}
+
+type StatusDoc statusDoc
+
+func NewHistoricalStatusDoc(s StatusDoc, key string) *historicalStatusDoc {
+	sdoc := statusDoc(s)
+	return newHistoricalStatusDoc(sdoc, key)
+}
+
+var StatusHistory = statusHistory
+
+func EraseUnitHistory(u *Unit) error {
+	return u.eraseHistory()
 }

--- a/state/open.go
+++ b/state/open.go
@@ -181,6 +181,7 @@ var indexes = []struct {
 	{storageAttachmentsC, []string{"env-uuid", "unitid"}, false, false},
 	{volumesC, []string{"env-uuid", "storageid"}, false, false},
 	{filesystemsC, []string{"env-uuid", "storageid"}, false, false},
+	{statusesHistoryC, []string{"env-uuid", "entityid"}, false, false},
 }
 
 // The capped collection used for transaction logs defaults to 10MB.

--- a/state/state.go
+++ b/state/state.go
@@ -73,6 +73,7 @@ const (
 	cleanupsC              = "cleanups"
 	annotationsC           = "annotations"
 	statusesC              = "statuses"
+	statusesHistoryC       = "statuseshistory"
 	stateServersC          = "stateServers"
 	openedPortsC           = "openedPorts"
 	metricsC               = "metrics"

--- a/state/status.go
+++ b/state/status.go
@@ -124,6 +124,8 @@ const (
 
 var errStatusNotFound = errors.NotFoundf("status")
 
+// IsStatusNotFound returns true if the provided error is
+// errStatusNotFound
 func IsStatusNotFound(e error) bool {
 	return e == errStatusNotFound
 }
@@ -551,7 +553,7 @@ func removeStatusOp(st *State, globalKey string) txn.Op {
 }
 
 // PruneStatusHistory removes status history entries until
-// only the maxLogsPerEntity newest records remain.
+// only the maxLogsPerEntity newest records per unit remain.
 func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
 	historyColl, closer := st.getCollection(statusesHistoryC)
 	defer closer()

--- a/state/status.go
+++ b/state/status.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/errors"
@@ -234,6 +235,72 @@ type statusDoc struct {
 	StatusInfo string
 	StatusData map[string]interface{}
 	Updated    *time.Time
+}
+
+type historicalStatusDoc struct {
+	EnvUUID    string `bson:"env-uuid"`
+	Status     Status
+	StatusInfo string
+	StatusData map[string]interface{}
+	Updated    *time.Time
+	StatusId   string
+}
+
+func newHistoricalStatusDoc(s statusDoc, id string) *historicalStatusDoc {
+	return &historicalStatusDoc{
+		EnvUUID:    s.EnvUUID,
+		Status:     s.Status,
+		StatusInfo: s.StatusInfo,
+		StatusData: s.StatusData,
+		Updated:    s.Updated,
+		StatusId:   id,
+	}
+}
+
+func setStatusHistory(globalKey string, st *State) error {
+	oldDoc, err := getStatus(st, globalKey)
+	if err == mgo.ErrNotFound {
+		logger.Debugf("there is no state for %q yet", globalKey)
+		return nil
+	}
+	if err != nil {
+		return errors.Annotate(err, "cannot obtain previous status")
+	}
+	hDoc := newHistoricalStatusDoc(oldDoc, globalKey)
+
+	h := txn.Op{
+		C:      statusesHistoryC,
+		Id:     fmt.Sprintf("%s%d", st.docID(globalKey), time.Now().UTC().UnixNano()),
+		Insert: hDoc,
+	}
+
+	err = st.runTransaction([]txn.Op{h})
+	return errors.Annotatef(err, "cannot update status history of unit agent %q", globalKey)
+}
+
+func statusHistory(size int, globalKey string, st *State) ([]StatusInfo, error) {
+	statusHistory, closer := st.getCollection(statusesHistoryC)
+	defer closer()
+
+	sInfo := []StatusInfo{}
+	results := []historicalStatusDoc{}
+	err := statusHistory.Find(bson.D{{"statusid", globalKey}}).Sort("-updated").Limit(size).All(&results)
+	if err == mgo.ErrNotFound {
+		return []StatusInfo{}, errors.NotFoundf("statusHistory")
+	}
+	if err != nil {
+		return []StatusInfo{}, errors.Annotatef(err, "cannot get status history for %q", globalKey)
+	}
+	for _, s := range results {
+		sInfo = append(sInfo, StatusInfo{
+			Status:  s.Status,
+			Message: s.StatusInfo,
+			Data:    s.StatusData,
+			Since:   s.Updated,
+		})
+	}
+	return sInfo, nil
+
 }
 
 type machineStatusDoc struct {
@@ -483,4 +550,58 @@ func removeStatusOp(st *State, globalKey string) txn.Op {
 		Id:     st.docID(globalKey),
 		Remove: true,
 	}
+}
+
+// PruneStatusHistory removes status history entries until
+// only the maxLogsPerEntity newest records remain.
+func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
+	historyColl, closer := st.getCollection(statusesHistoryC)
+	defer closer()
+	globalKeys, err := getEntitiesWithStatuses(historyColl)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, globalKey := range globalKeys {
+		keepUpTo, ok, err := getOldestTimeToKeep(historyColl, globalKey, maxLogsPerEntity)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !ok {
+			continue
+		}
+		_, err = historyColl.RemoveAll(bson.D{
+			{"statusid", globalKey},
+			{"updated", bson.M{"$lt": keepUpTo}},
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// getOldestTimeToKeep returns the update time for the oldest
+// status log to be kept.
+func getOldestTimeToKeep(coll stateCollection, globalKey string, size int) (*time.Time, bool, error) {
+	result := historicalStatusDoc{}
+	err := coll.Find(bson.D{{"statusid", globalKey}}).Sort("-updated").Limit(size).One(&result)
+	if err == mgo.ErrNotFound {
+		return &time.Time{}, false, nil
+	}
+	if err != nil {
+		return &time.Time{}, false, errors.Trace(err)
+	}
+	return result.Updated, true, nil
+
+}
+
+// getEntitiesWithStatuses returns the ids for all entities that
+// have history entries
+func getEntitiesWithStatuses(coll stateCollection) ([]string, error) {
+	var entityKeys []string
+	err := coll.Find(nil).Distinct("statusid", &entityKeys)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return entityKeys, nil
 }

--- a/state/status_test.go
+++ b/state/status_test.go
@@ -1,0 +1,64 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"fmt"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+)
+
+type HistoryPrunerSuite struct {
+	statetesting.StateSuite
+}
+
+func (s *HistoryPrunerSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+}
+
+func (s *HistoryPrunerSuite) TestPruneStatusHistory(c *gc.C) {
+	var oldDoc state.StatusDoc
+	var err error
+	st := s.State
+	globalKey := "BogusKey"
+	for changeno := 1; changeno <= 201; changeno++ {
+		oldDoc = state.StatusDoc{
+			Status:     "AGivenStatus",
+			StatusInfo: fmt.Sprintf("Status change %d", changeno),
+			StatusData: nil,
+		}
+		timestamp := state.NowToTheSecond()
+		oldDoc.Updated = &timestamp
+
+		hDoc := state.NewHistoricalStatusDoc(oldDoc, globalKey)
+
+		h := txn.Op{
+			C:      state.StatusesHistoryC,
+			Id:     fmt.Sprintf("%s%d", globalKey, time.Now().UTC().UnixNano()),
+			Insert: hDoc,
+		}
+
+		err = state.RunTransaction(st, []txn.Op{h})
+		c.Logf("Adding a history entry attempt n: %d", changeno)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	history, err := state.StatusHistory(500, globalKey, st)
+	c.Assert(history, gc.HasLen, 200)
+	c.Assert(history[0].Message, gc.Equals, "Status change 1")
+	c.Assert(history[199].Message, gc.Equals, "Status change 200")
+
+	err = state.PruneStatusHistory(st, 100)
+	c.Assert(err, jc.ErrorIsNil)
+	history, err = state.StatusHistory(500, globalKey, st)
+	c.Assert(history, gc.HasLen, 100)
+	c.Assert(history[0].Message, gc.Equals, "Status change 100")
+	c.Assert(history[99].Message, gc.Equals, "Status change 200")
+
+}

--- a/state/unit.go
+++ b/state/unit.go
@@ -313,11 +313,26 @@ func (u *Unit) Destroy() (err error) {
 		return nil, jujutxn.ErrNoOperations
 	}
 	if err = unit.st.run(buildTxn); err == nil {
+		if historyErr := unit.eraseHistory(); historyErr != nil {
+			logger.Errorf("cannot delete history for unit %q: %v", unit.globalKey(), err)
+		}
 		if err = unit.Refresh(); errors.IsNotFound(err) {
 			return nil
 		}
 	}
 	return err
+}
+
+func (u *Unit) eraseHistory() error {
+	unit, closer := u.st.getCollection(statusesHistoryC)
+	defer closer()
+	if _, err := unit.RemoveAll(bson.D{{"statusid", u.globalKey()}}); err != nil {
+		return err
+	}
+	if _, err := unit.RemoveAll(bson.D{{"statusid", u.globalAgentKey()}}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // unitAgentAllocating actually refers to the unit's agent.
@@ -807,6 +822,10 @@ func (u *Unit) AgentStatus() (StatusInfo, error) {
 	return agent.Status()
 }
 
+func (u *Unit) StatusHistory(size int) ([]StatusInfo, error) {
+	return statusHistory(size, u.globalKey(), u.st)
+}
+
 // Status returns the status of the unit.
 // This method relies on globalKey instead of globalAgentKey since it is part of
 // the effort to separate Unit from UnitAgent. Now the Status for UnitAgent is in
@@ -839,10 +858,17 @@ func (u *Unit) Status() (StatusInfo, error) {
 // the effort to separate Unit from UnitAgent. Now the SetStatus for UnitAgent is in
 // the UnitAgent struct.
 func (u *Unit) SetStatus(status Status, info string, data map[string]interface{}) error {
+	// TODO(perrito666) if status change fails this entry will be added
+	// and could cause repeated entries in history, a check should be done
+	if err := setStatusHistory(u.globalKey(), u.st); err != nil {
+		logger.Errorf("could not record status history before change to %q: %v", status, err)
+	}
+
 	doc, err := newUnitStatusDoc(status, info, data)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
+
 	ops := []txn.Op{{
 		C:      unitsC,
 		Id:     u.doc.DocID,
@@ -854,7 +880,6 @@ func (u *Unit) SetStatus(status Status, info string, data map[string]interface{}
 	if err != nil {
 		return fmt.Errorf("cannot set status of unit %q: %v", u, onAbort(err, ErrDead))
 	}
-
 	return nil
 }
 

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -651,10 +651,10 @@ func (s *UnitSuite) TestSetUnitStatusHistory(c *gc.C) {
 
 func (s *UnitSuite) TestGetUnitStatusHistory(c *gc.C) {
 	err := state.EraseUnitHistory(s.unit)
+	c.Assert(err, jc.ErrorIsNil)
 	globalKey := state.UnitGlobalKey(s.unit)
 	begin := state.NowToTheSecond()
 	c.Logf("will use %q as base time", begin)
-	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 100; i++ {
 		message := fmt.Sprintf("bogus message number %d", i)
 		c.Logf("fill status history, attempt: %d", i)

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -59,11 +59,13 @@ func (u *UnitAgent) Status() (StatusInfo, error) {
 // SetStatus sets the status of the unit agent. The optional values
 // allow to pass additional helpful status data.
 func (u *UnitAgent) SetStatus(status Status, info string, data map[string]interface{}) (err error) {
-	// TODO(perrito666) if status change fails this entry will be added
-	// and could cause repeated entries in history, a check should be done
-	if err := setStatusHistory(u.globalKey(), u.st); err != nil {
-		logger.Errorf("could not record status history before change to %q: %v", status, err)
+	oldDoc, err := getStatus(u.st, u.globalKey())
+	if IsStatusNotFound(err) {
+		logger.Debugf("there is no state for %q yet", u.globalKey())
+	} else if err != nil {
+		logger.Debugf("cannot get state for %q yet", u.globalKey())
 	}
+
 	doc, err := newUnitAgentStatusDoc(status, info, data)
 	if err != nil {
 		return errors.Trace(err)
@@ -76,9 +78,17 @@ func (u *UnitAgent) SetStatus(status Status, info string, data map[string]interf
 		return errors.Errorf("cannot set status of unit agent %q: %v", u, onAbort(err, ErrDead))
 	}
 
+	if oldDoc.Status != "" {
+		if err := updateStatusHistory(oldDoc, u.globalKey(), u.st); err != nil {
+			logger.Errorf("could not record status history before change to %q: %v", status, err)
+		}
+	}
+
 	return nil
 }
 
+// StatusHistory returns a slice of at most <size> StatusInfo items
+// representing past statuses for this agent.
 func (u *UnitAgent) StatusHistory(size int) ([]StatusInfo, error) {
 	return statusHistory(size, u.globalKey(), u.st)
 }

--- a/state/unitagent_test.go
+++ b/state/unitagent_test.go
@@ -4,7 +4,6 @@
 package state_test
 
 import (
-	"fmt"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -196,41 +195,10 @@ func (s *UnitAgentSuite) TestGetUnitAgentStatusHistory(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	agent := s.unit.Agent().(*state.UnitAgent)
 	globalKey := state.UnitAgentGlobalKey(agent)
-	begin := state.NowToTheSecond()
-	c.Logf("will use %q as base time", begin)
-	for i := 0; i < 100; i++ {
-		message := fmt.Sprintf("bogus message number %d", i)
-		c.Log("fill status history, attempt: %d", i)
-		updated := begin.Add(time.Duration(i) + time.Second)
-		statusDoc := state.StatusDoc{Status: state.StatusActive,
-			StatusInfo: message,
-			Updated:    &updated}
-		sdoc := state.NewStatusDoc(statusDoc)
-		err = state.UpdateStatusHistory(sdoc, globalKey, s.State)
-		c.Assert(err, jc.ErrorIsNil)
+	history := func(i int) ([]state.StatusInfo, error) {
+		return agent.StatusHistory(i)
 	}
-	h, err := agent.StatusHistory(100)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(h, gc.HasLen, 100)
-	c.Assert(h[0].Status, gc.Equals, state.StatusActive)
-	c.Assert(h[0].Message, gc.Equals, "bogus message number 0")
-	c.Assert(h[99].Status, gc.Equals, state.StatusActive)
-	c.Assert(h[99].Message, gc.Equals, "bogus message number 99")
-	h, err = agent.StatusHistory(200)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(h, gc.HasLen, 100)
-	c.Assert(h[0].Status, gc.Equals, state.StatusActive)
-	c.Assert(h[0].Message, gc.Equals, "bogus message number 0")
-	c.Assert(h[99].Status, gc.Equals, state.StatusActive)
-	c.Assert(h[99].Message, gc.Equals, "bogus message number 99")
-	h, err = agent.StatusHistory(50)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(h, gc.HasLen, 50)
-	c.Assert(h[0].Status, gc.Equals, state.StatusActive)
-	c.Assert(h[0].Message, gc.Equals, "bogus message number 0")
-	c.Assert(h[49].Status, gc.Equals, state.StatusActive)
-	c.Assert(h[49].Message, gc.Equals, "bogus message number 49")
-
+	testGetUnitStatusHistory(c, history, s.State, globalKey)
 }
 
 func (s *UnitAgentSuite) TestGetSetStatusDataMongo(c *gc.C) {

--- a/worker/statushistorypruner/worker.go
+++ b/worker/statushistorypruner/worker.go
@@ -36,6 +36,7 @@ type pruneWorker struct {
 	params *HistoryPrunerParams
 }
 
+// New returns a worker.Worker for history Pruner.
 func New(st *state.State, params *HistoryPrunerParams) worker.Worker {
 	w := &pruneWorker{
 		st:     st,

--- a/worker/statushistorypruner/worker.go
+++ b/worker/statushistorypruner/worker.go
@@ -45,6 +45,7 @@ func New(st *state.State, params *HistoryPrunerParams) worker.Worker {
 	return worker.NewSimpleWorker(w.loop)
 }
 
+// TODO(perrito666) Adda comprehensive test for the worker features
 func (w *pruneWorker) loop(stopCh <-chan struct{}) error {
 	p := w.params
 	for {

--- a/worker/statushistorypruner/worker.go
+++ b/worker/statushistorypruner/worker.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statushistorypruner
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+)
+
+// HistoryPrunerParams specifies how history logs should be prunned.
+type HistoryPrunerParams struct {
+	// TODO(perrito666) We might want to have some sort of limitation of the collection size too.
+	MaxLogsPerState int
+	PruneInterval   time.Duration
+}
+
+const DefaultMaxLogsPerState = 100
+const DefaultPruneInterval = 5 * time.Minute
+
+// NewHistoryPrunerParams returns a HistoryPrunerParams initialized with default parameter.
+func NewHistoryPrunerParams() *HistoryPrunerParams {
+	return &HistoryPrunerParams{
+		MaxLogsPerState: DefaultMaxLogsPerState,
+		PruneInterval:   DefaultPruneInterval,
+	}
+}
+
+type pruneWorker struct {
+	st     *state.State
+	params *HistoryPrunerParams
+}
+
+func New(st *state.State, params *HistoryPrunerParams) worker.Worker {
+	w := &pruneWorker{
+		st:     st,
+		params: params,
+	}
+	return worker.NewSimpleWorker(w.loop)
+}
+
+func (w *pruneWorker) loop(stopCh <-chan struct{}) error {
+	p := w.params
+	for {
+		select {
+		case <-stopCh:
+			return tomb.ErrDying
+		case <-time.After(p.PruneInterval):
+			err := state.PruneStatusHistory(w.st, p.MaxLogsPerState)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -146,7 +146,7 @@ func (rh *runHook) beforeHook() error {
 		logger.Errorf("error updating workload status before %v hook: %v", rh.info.Kind, err)
 		return err
 	}
-	return rh.callbacks.SetExecutingStatus(fmt.Sprintf("running %s hook", rh.info.Kind))
+	return nil
 }
 
 func (rh *runHook) afterHook(state State) (bool, error) {


### PR DESCRIPTION
This Pull Request adds the status-history command plus the necessary so units with their agents can set said history and a worker to prune old ones.
This work is done as part of the Health Status spec to provide better context to the users on the statuses of their services.

(Review request: http://reviews.vapour.ws/r/1472/)