### PR TITLE
Fix 1447392 SSH init fixes

### DIFF
--- a/cloudconfig/sshinit/configure.go
+++ b/cloudconfig/sshinit/configure.go
@@ -6,9 +6,9 @@ package sshinit
 
 import (
 	"io"
+	"strings"
 
 	"github.com/juju/loggo"
-	"github.com/juju/utils"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/utils/ssh"
@@ -58,14 +58,8 @@ func RunConfigureScript(script string, params ConfigureParams) error {
 	if client == nil {
 		client = ssh.DefaultClient
 	}
-	options := &ssh.Options{}
-	switch params.Series {
-	case "centos7":
-		options.EnablePTY()
-	default:
-		options = nil
-	}
-	cmd := ssh.Command(params.Host, []string{"sudo", "/bin/bash -c " + utils.ShQuote(script)}, options)
+	cmd := ssh.Command(params.Host, []string{"sudo", "/bin/bash"}, nil)
+	cmd.Stdin = strings.NewReader(script)
 	cmd.Stderr = params.ProgressWriter
 	return cmd.Run()
 }

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -99,6 +99,7 @@ func (w *unixConfigure) ConfigureBasic() error {
 		w.conf.AddScripts(script)
 		w.conf.AddScripts("systemctl stop firewalld")
 		w.conf.AddScripts("systemctl disable firewalld")
+		w.conf.AddScripts(`sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers`)
 	}
 	w.conf.SetOutput(cloudinit.OutAll, "| tee -a "+w.icfg.CloudInitOutputLog, "")
 	// Create a file in a well-defined location containing the machine's


### PR DESCRIPTION
Reverted ssh init to its previous state and disabled requiretty for sudo on CentOS. Besides fixing the bug this also gives us proper logging in the terminal that juju bootstrap.

Partially depends on https://github.com/juju/utils/pull/128

(Review request: http://reviews.vapour.ws/r/1475/)