### PR TITLE
avoid unnecessary Environ creation

### DIFF
--- a/apiserver/common/environwatcher.go
+++ b/apiserver/common/environwatcher.go
@@ -70,11 +70,11 @@ func (e *EnvironWatcher) EnvironConfig() (params.EnvironConfigResult, error) {
 		// Delete the code below and mark the bug as fixed,
 		// once it's live tested on MAAS and 1.16 compatibility
 		// is dropped.
-		env, err := environs.New(config)
+		provider, err := environs.Provider(config.Type())
 		if err != nil {
 			return result, err
 		}
-		secretAttrs, err := env.Provider().SecretAttrs(config)
+		secretAttrs, err := provider.SecretAttrs(config)
 		for k := range secretAttrs {
 			allAttrs[k] = "not available"
 		}


### PR DESCRIPTION
Independent of the wooly justification below, this does less work for the same effect... but!

I believe this code was the (pen)ultimate cause of the intermittent machine-agent test failures in which it would complain about missing tools. In particular, it was *not* resolved by moving the Upgrader.SetVersion call out of the worker; AFAICS that just tweaked the timing characteristics and indirectly made us more likely to call EnvironConfig at a time when the dummy provider was safe to use. (The ultimate cause was, ofc, the dummy provider itself...)

The upgrader changes are coming in a future CL, because they're a bit bound up with some other changes I'm making.

(Review request: http://reviews.vapour.ws/r/1479/)