### PR TITLE
Fix service discovery on vivid.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -111,7 +111,7 @@ func discoverLocalInitSystem() (string, error) {
 	for _, check := range discoveryFuncs {
 		local, err := check.isRunning()
 		if err != nil {
-			return "", errors.Trace(err)
+			logger.Errorf("failed to find init system %q: %v", check.name, err)
 		}
 		if local {
 			logger.Debugf("discovered init system %q from local host", check.name)

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -113,6 +113,7 @@ func discoverLocalInitSystem() (string, error) {
 		if err != nil {
 			logger.Errorf("failed to find init system %q: %v", check.name, err)
 		}
+		// We expect that in error cases "local" will be false.
 		if local {
 			logger.Debugf("discovered init system %q from local host", check.name)
 			return check.name, nil

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -96,21 +96,26 @@ func versionInitSystem(vers version.Binary) (string, bool) {
 	}
 }
 
-var discoveryFuncs = map[string]func() (bool, error){
-	InitSystemSystemd: systemd.IsRunning,
-	InitSystemUpstart: upstart.IsRunning,
-	InitSystemWindows: windows.IsRunning,
+type discoveryCheck struct {
+	name      string
+	isRunning func() (bool, error)
+}
+
+var discoveryFuncs = []discoveryCheck{
+	{InitSystemUpstart, upstart.IsRunning},
+	{InitSystemSystemd, systemd.IsRunning},
+	{InitSystemWindows, windows.IsRunning},
 }
 
 func discoverLocalInitSystem() (string, error) {
-	for initName, isLocal := range discoveryFuncs {
-		local, err := isLocal()
+	for _, check := range discoveryFuncs {
+		local, err := check.isRunning()
 		if err != nil {
 			return "", errors.Trace(err)
 		}
 		if local {
-			logger.Debugf("discovered init system %q from local host", initName)
-			return initName, nil
+			logger.Debugf("discovered init system %q from local host", check.name)
+			return check.name, nil
 		}
 	}
 	return "", errors.NotFoundf("init system (based on local host)")

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -260,7 +260,7 @@ func (s *discoverySuite) TestVersionInitSystemNoLegacyUpstart(c *gc.C) {
 }
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirst(c *gc.C) {
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", true, nil),
 		service.NewDiscoveryCheck("initB", false, nil),
 	)
@@ -273,7 +273,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirst(c *gc.C) {
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemErrorFirst(c *gc.C) {
 	failure := errors.New("<failed>")
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, failure),
 		service.NewDiscoveryCheck("initB", true, nil),
 	)
@@ -286,7 +286,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemErrorFirst(c *gc.C) {
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirstError(c *gc.C) {
 	failure := errors.New("<failed>")
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", true, failure),
 		service.NewDiscoveryCheck("initB", false, nil),
 	)
@@ -298,7 +298,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirstError(c *gc.C) {
 }
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemMatchSecond(c *gc.C) {
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, nil),
 		service.NewDiscoveryCheck("initB", true, nil),
 	)
@@ -310,7 +310,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemMatchSecond(c *gc.C) {
 }
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemMatchNone(c *gc.C) {
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, nil),
 		service.NewDiscoveryCheck("initB", false, nil),
 	)
@@ -322,7 +322,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemMatchNone(c *gc.C) {
 
 func (s *discoverySuite) TestDiscoverLocalInitSystemErrorMixed(c *gc.C) {
 	failure := errors.New("<failed>")
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, failure),
 		service.NewDiscoveryCheck("initB", false, nil),
 	)
@@ -335,7 +335,7 @@ func (s *discoverySuite) TestDiscoverLocalInitSystemErrorMixed(c *gc.C) {
 func (s *discoverySuite) TestDiscoverLocalInitSystemErrorAll(c *gc.C) {
 	failureA := errors.New("<failed A>")
 	failureB := errors.New("<failed B>")
-	service.PatchDiscoveryFuncs(s,
+	s.PatchLocalDiscovery(
 		service.NewDiscoveryCheck("initA", false, failureA),
 		service.NewDiscoveryCheck("initB", false, failureB),
 	)

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -54,7 +54,7 @@ func (dt discoveryTest) log(c *gc.C) {
 }
 
 func (dt discoveryTest) disableLocalDiscovery(c *gc.C, s *discoverySuite) {
-	s.PatchLocalDiscovery(nil)
+	s.PatchLocalDiscoveryDisable()
 }
 
 func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
@@ -64,20 +64,7 @@ func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
 }
 
 func (dt discoveryTest) setLocal(c *gc.C, s *discoverySuite) {
-	noMatch := func() (bool, error) {
-		return false, nil
-	}
-	funcs := map[string]func() (bool, error){
-		service.InitSystemSystemd: noMatch,
-		service.InitSystemUpstart: noMatch,
-		service.InitSystemWindows: noMatch,
-	}
-	if dt.expected != "" {
-		funcs[dt.expected] = func() (bool, error) {
-			return true, nil
-		}
-	}
-	s.PatchLocalDiscovery(funcs)
+	s.PatchLocalDiscoveryNoMatch(dt.expected)
 }
 
 func (dt discoveryTest) setVersion(s *discoverySuite) version.Binary {

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -259,6 +259,92 @@ func (s *discoverySuite) TestVersionInitSystemNoLegacyUpstart(c *gc.C) {
 	test.checkInitSystem(c, initSystem, ok)
 }
 
+func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirst(c *gc.C) {
+	service.PatchDiscoveryFuncs(s,
+		service.NewDiscoveryCheck("initA", true, nil),
+		service.NewDiscoveryCheck("initB", false, nil),
+	)
+
+	name, err := service.DiscoverLocalInitSystem()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(name, gc.Equals, "initA")
+}
+
+func (s *discoverySuite) TestDiscoverLocalInitSystemErrorFirst(c *gc.C) {
+	failure := errors.New("<failed>")
+	service.PatchDiscoveryFuncs(s,
+		service.NewDiscoveryCheck("initA", false, failure),
+		service.NewDiscoveryCheck("initB", true, nil),
+	)
+
+	name, err := service.DiscoverLocalInitSystem()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(name, gc.Equals, "initB")
+}
+
+func (s *discoverySuite) TestDiscoverLocalInitSystemMatchFirstError(c *gc.C) {
+	failure := errors.New("<failed>")
+	service.PatchDiscoveryFuncs(s,
+		service.NewDiscoveryCheck("initA", true, failure),
+		service.NewDiscoveryCheck("initB", false, nil),
+	)
+
+	name, err := service.DiscoverLocalInitSystem()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(name, gc.Equals, "initA")
+}
+
+func (s *discoverySuite) TestDiscoverLocalInitSystemMatchSecond(c *gc.C) {
+	service.PatchDiscoveryFuncs(s,
+		service.NewDiscoveryCheck("initA", false, nil),
+		service.NewDiscoveryCheck("initB", true, nil),
+	)
+
+	name, err := service.DiscoverLocalInitSystem()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(name, gc.Equals, "initB")
+}
+
+func (s *discoverySuite) TestDiscoverLocalInitSystemMatchNone(c *gc.C) {
+	service.PatchDiscoveryFuncs(s,
+		service.NewDiscoveryCheck("initA", false, nil),
+		service.NewDiscoveryCheck("initB", false, nil),
+	)
+
+	_, err := service.DiscoverLocalInitSystem()
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *discoverySuite) TestDiscoverLocalInitSystemErrorMixed(c *gc.C) {
+	failure := errors.New("<failed>")
+	service.PatchDiscoveryFuncs(s,
+		service.NewDiscoveryCheck("initA", false, failure),
+		service.NewDiscoveryCheck("initB", false, nil),
+	)
+
+	_, err := service.DiscoverLocalInitSystem()
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *discoverySuite) TestDiscoverLocalInitSystemErrorAll(c *gc.C) {
+	failureA := errors.New("<failed A>")
+	failureB := errors.New("<failed B>")
+	service.PatchDiscoveryFuncs(s,
+		service.NewDiscoveryCheck("initA", false, failureA),
+		service.NewDiscoveryCheck("initB", false, failureB),
+	)
+
+	_, err := service.DiscoverLocalInitSystem()
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *discoverySuite) TestDiscoverInitSystemScript(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("not supported on windows")

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -4,6 +4,24 @@
 package service
 
 var (
-	DiscoverInitSystem    = discoverInitSystem
-	NewShellSelectCommand = newShellSelectCommand
+	DiscoverInitSystem      = discoverInitSystem
+	DiscoverLocalInitSystem = discoverLocalInitSystem
+	NewShellSelectCommand   = newShellSelectCommand
 )
+
+func NewDiscoveryCheck(name string, running bool, failure error) discoveryCheck {
+	return discoveryCheck{
+		name: name,
+		isRunning: func() (bool, error) {
+			return running, failure
+		},
+	}
+}
+
+type patcher interface {
+	PatchValue(interface{}, interface{})
+}
+
+func PatchDiscoveryFuncs(s patcher, checks ...discoveryCheck) {
+	s.PatchValue(&discoveryFuncs, checks)
+}

--- a/service/export_test.go
+++ b/service/export_test.go
@@ -8,20 +8,3 @@ var (
 	DiscoverLocalInitSystem = discoverLocalInitSystem
 	NewShellSelectCommand   = newShellSelectCommand
 )
-
-func NewDiscoveryCheck(name string, running bool, failure error) discoveryCheck {
-	return discoveryCheck{
-		name: name,
-		isRunning: func() (bool, error) {
-			return running, failure
-		},
-	}
-}
-
-type patcher interface {
-	PatchValue(interface{}, interface{})
-}
-
-func PatchDiscoveryFuncs(s patcher, checks ...discoveryCheck) {
-	s.PatchValue(&discoveryFuncs, checks)
-}

--- a/service/testing_test.go
+++ b/service/testing_test.go
@@ -101,7 +101,21 @@ func (s *BaseSuite) PatchVersion(vers version.Binary) {
 	s.PatchValue(&getVersion, s.Patched.GetVersion)
 }
 
-func (s *BaseSuite) PatchLocalDiscovery(funcs map[string]func() (bool, error)) {
+func (s *BaseSuite) PatchLocalDiscoveryDisable() {
+	s.PatchValue(&discoveryFuncs, nil)
+}
+
+func (s *BaseSuite) PatchLocalDiscoveryNoMatch(expected string) {
+	matchesFunc := func(matches bool) func() (bool, error) {
+		return func() (bool, error) {
+			return matches, nil
+		}
+	}
+	funcs := []discoveryCheck{
+		{InitSystemUpstart, matchesFunc(expected == InitSystemUpstart)},
+		{InitSystemSystemd, matchesFunc(expected == InitSystemSystemd)},
+		{InitSystemWindows, matchesFunc(expected == InitSystemWindows)},
+	}
 	s.PatchValue(&discoveryFuncs, funcs)
 }
 

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -43,9 +43,13 @@ func IsRunning() (bool, error) {
 	if err == nil {
 		return true, nil
 	}
+	if os.IsNotExist(err) {
+		// Executable could not be found, go 1.3 and later
+		return false, nil
+	}
 	if execErr, ok := err.(*exec.Error); ok {
-		if _, ok := execErr.Err.(*os.PathError); ok {
-			// Executable could not be found, or could not be executed.
+		// Executable could not be found, go 1.2
+		if os.IsNotExist(execErr.Err) || execErr.Err == exec.ErrNotFound {
 			return false, nil
 		}
 	}

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -43,6 +43,7 @@ func IsRunning() (bool, error) {
 	if err == nil {
 		return true, nil
 	}
+	logger.Debugf("exec %q failed: %#v", initctlPath, err)
 	if os.IsNotExist(err) {
 		// Executable could not be found, go 1.3 and later
 		return false, nil

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -38,23 +38,28 @@ func IsRunning() (bool, error) {
 	if runtime.GOOS == "windows" {
 		return false, nil
 	}
-	cmd := exec.Command(initctlPath, "--system", "list")
-	_, err := cmd.CombinedOutput()
-	if err == nil {
-		return true, nil
-	}
-	logger.Debugf("exec %q failed: %#v", initctlPath, err)
-	if os.IsNotExist(err) {
-		// Executable could not be found, go 1.3 and later
+
+	if _, err := os.Stat(initctlPath); os.IsNotExist(err) {
 		return false, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
 	}
-	if execErr, ok := err.(*exec.Error); ok {
-		// Executable could not be found, go 1.2
-		if os.IsNotExist(execErr.Err) || execErr.Err == exec.ErrNotFound {
+
+	cmd := exec.Command(initctlPath, "--system", "list")
+	switch err := cmd.Run().(type) {
+	case *exec.ExitError:
+		logger.Debugf("exec %q failed: %#v", initctlPath, err)
+		if err.Error() == "exit status 1" {
 			return false, nil
 		}
+		return false, errors.Trace(err)
+	default:
+		if err != nil {
+			logger.Debugf("exec %q failed: %#v", initctlPath, err)
+			return false, errors.Trace(err)
+		}
 	}
-	return false, errors.Trace(err)
+	return true, nil
 }
 
 // ListServices returns the name of all installed services on the

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/symlink"
 	gc "gopkg.in/check.v1"
 
@@ -373,18 +374,26 @@ const modeNotExecutable = 0400
 
 // createInitctl creates a dummy initctl which returns the given
 // exitcode and patches the upstart package to use it.
-func (s *IsRunningSuite) createInitctl(c *gc.C, exitcode int, mode os.FileMode) {
+func (s *IsRunningSuite) createInitctl(c *gc.C, stderr string, exitcode int, mode os.FileMode) {
 	path := filepath.Join(c.MkDir(), "initctl")
-	script := fmt.Sprintf(`#!/bin/sh
+	var body string
+	if stderr != "" {
+		// Write to stderr.
+		body = ">&2 echo " + utils.ShQuote(stderr)
+	}
+	script := fmt.Sprintf(`
+#!/usr/bin/env bash
+%s
 exit %d
-`, exitcode)
+`[1:], body, exitcode)
+	c.Logf(script)
 	err := ioutil.WriteFile(path, []byte(script), mode)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(upstart.InitctlPath, path)
 }
 
 func (s *IsRunningSuite) TestUpstartInstalled(c *gc.C) {
-	s.createInitctl(c, 0, modeExecutable)
+	s.createInitctl(c, "", 0, modeExecutable)
 
 	isUpstart, err := upstart.IsRunning()
 	c.Assert(isUpstart, jc.IsTrue)
@@ -400,16 +409,27 @@ func (s *IsRunningSuite) TestUpstartNotInstalled(c *gc.C) {
 }
 
 func (s *IsRunningSuite) TestUpstartInstalledButBroken(c *gc.C) {
+	const stderr = "<something broke>"
 	const errorCode = 99
-	s.createInitctl(c, errorCode, modeExecutable)
+	s.createInitctl(c, stderr, errorCode, modeExecutable)
 
 	isUpstart, err := upstart.IsRunning()
 	c.Assert(isUpstart, jc.IsFalse)
-	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("exit status %d", errorCode))
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*exit status %d", errorCode))
+}
+
+func (s *IsRunningSuite) TestUpstartInstalledButNotRunning(c *gc.C) {
+	const stderr = `Name "com.ubuntu.Upstart" does not exist`
+	const errorCode = 1
+	s.createInitctl(c, "", errorCode, modeExecutable)
+
+	isUpstart, err := upstart.IsRunning()
+	c.Assert(isUpstart, jc.IsFalse)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*exit status %d", errorCode))
 }
 
 func (s *IsRunningSuite) TestInitctlCantBeRun(c *gc.C) {
-	s.createInitctl(c, 0, modeNotExecutable)
+	s.createInitctl(c, "", 0, modeNotExecutable)
 
 	isUpstart, err := upstart.IsRunning()
 	c.Assert(isUpstart, jc.IsFalse)

--- a/service/upstart/upstart_test.go
+++ b/service/upstart/upstart_test.go
@@ -421,7 +421,7 @@ func (s *IsRunningSuite) TestUpstartInstalledButBroken(c *gc.C) {
 func (s *IsRunningSuite) TestUpstartInstalledButNotRunning(c *gc.C) {
 	const stderr = `Name "com.ubuntu.Upstart" does not exist`
 	const errorCode = 1
-	s.createInitctl(c, "", errorCode, modeExecutable)
+	s.createInitctl(c, stderr, errorCode, modeExecutable)
 
 	isUpstart, err := upstart.IsRunning()
 	c.Assert(isUpstart, jc.IsFalse)


### PR DESCRIPTION
Currently init system discovery fails if any one of the individual checks results in an error. This patch changes that to simply log the error and try the next init system. I've also removed duplicate logging from upstart.IsRunning.

(Review request: http://reviews.vapour.ws/r/1470/)