### PR TITLE
Skip TestUniterUpgradeConflicts on ppc64

### DIFF
--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -872,6 +872,7 @@ func (s *UniterSuite) TestUniterDeployerConversion(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1448308")
 	//TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: currently does not work on windows")


### PR DESCRIPTION
Tracking bug lp:1448308 for this test skip.

(Review request: http://reviews.vapour.ws/r/1488/)