### PR TITLE
Add leadership settings when upgrading.

### DIFF
--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -71,6 +71,12 @@ func stateStepsFor123() []Step {
 			run: func(context Context) error {
 				return state.LowerCaseEnvUsersID(context.State())
 			},
+		}, &upgradeStep{
+			description: "add leadership settings documents for all services",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddLeadershipSettingsDocs(context.State())
+			},
 		},
 	)
 	return steps

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -31,6 +31,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 		"add name field to users and lowercase _id field",
 		"add life field to IP addresses",
 		"lower case _id of envUsers",
+		"add leadership settings documents for all services",
 	}
 	assertStateSteps(c, version.MustParse("1.23.0"), expected)
 }


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1447846)
(derived from https://github.com/mjs/juju/tree/1447846-hooks-dont-fire-after-upgrade-1.23)

Charm leadership (added in 1.23) relies on leadership settings stored in the database.  Without these settings hooks will not fire.  The settings were not being added during upgrades to 1.23.  This patch fixes that.

(Review request: http://reviews.vapour.ws/r/1490/)