### PR TITLE
Check for provisional providers in the bootstrap command.

### DIFF
--- a/cmd/juju/bootstrap.go
+++ b/cmd/juju/bootstrap.go
@@ -176,13 +176,14 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		fmt.Fprintln(ctx.Stderr, "Use of --upload-series is obsolete. --upload-tools now expands to all supported series of the same operating system.")
 	}
 
-	if c.ConnectionName() == "" {
-		return fmt.Errorf("the name of the environment must be specified")
+	envName := c.ConnectionName()
+	if err := checkEnvName(envName); err != nil {
+		return errors.Trace(err)
 	}
 
 	environ, cleanup, err := environFromName(
 		ctx,
-		c.ConnectionName(),
+		envName,
 		"Bootstrap",
 		bootstrapFuncs.EnsureNotBootstrapped,
 	)
@@ -253,6 +254,15 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Annotate(err, "failed to bootstrap environment")
 	}
 	return c.SetBootstrapEndpointAddress(environ)
+}
+
+// handleFeatureFlags checks bootstrap-related feature flags.
+func checkEnvName(envName string) error {
+	if envName == "" {
+		return errors.Errorf("the name of the environment must be specified")
+	}
+
+	return nil
 }
 
 // handleBootstrapError is called to clean up if bootstrap fails.

--- a/cmd/juju/bootstrap.go
+++ b/cmd/juju/bootstrap.go
@@ -195,7 +195,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Errorf("the name of the environment must be specified")
 	}
 
-	if err := checkEnvName(envName); err != nil {
+	if err := checkProviderType(envName); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -274,12 +274,8 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	return c.SetBootstrapEndpointAddress(environ)
 }
 
-// checkEnvName validates the given environment name.
-func checkEnvName(envName string) error {
-	if envName == "" {
-		return errors.Errorf("the name of the environment must be specified")
-	}
-
+// checkProviderType ensures the provider type is okay.
+func checkProviderType(envName string) error {
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	for name, flag := range provisionalProviders {
 		if envName != name {

--- a/cmd/juju/bootstrap.go
+++ b/cmd/juju/bootstrap.go
@@ -296,14 +296,10 @@ func checkProviderType(envName string) error {
 	}
 
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	for provisional, flag := range provisionalProviders {
-		if envType != provisional {
-			continue
-		}
-		if !featureflag.Enabled(flag) {
-			msg := `the %q provider is provisional in this version of Juju. To use it anyway, set JUJU_DEV_FEATURE_FLAGS="%s" in your shell environment`
-			return errors.Errorf(msg, envType, flag)
-		}
+	flag, ok := provisionalProviders[envType]
+	if ok && !featureflag.Enabled(flag) {
+		msg := `the %q provider is provisional in this version of Juju. To use it anyway, set JUJU_DEV_FEATURE_FLAGS="%s" in your shell environment`
+		return errors.Errorf(msg, envType, flag)
 	}
 
 	return nil

--- a/cmd/juju/bootstrap.go
+++ b/cmd/juju/bootstrap.go
@@ -173,6 +173,10 @@ var getBootstrapFuncs = func() BootstrapInterface {
 	return &bootstrapFuncs{}
 }
 
+var getEnvName = func(c *BootstrapCommand) string {
+	return c.ConnectionName()
+}
+
 // Run connects to the environment specified on the command line and bootstraps
 // a juju in that environment if none already exists. If there is as yet no environments.yaml file,
 // the user is informed how to create one.
@@ -186,7 +190,11 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		fmt.Fprintln(ctx.Stderr, "Use of --upload-series is obsolete. --upload-tools now expands to all supported series of the same operating system.")
 	}
 
-	envName := c.ConnectionName()
+	envName := getEnvName(c)
+	if envName == "" {
+		return errors.Errorf("the name of the environment must be specified")
+	}
+
 	if err := checkEnvName(envName); err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -267,8 +267,10 @@ var bootstrapTests = []bootstrapTest{{
 	err:  `unrecognized args: \["anything" "else"\]`,
 }}
 
-func (s *BootstrapSuite) TestCheckEnvNameMissing(c *gc.C) {
-	err := checkEnvName("")
+func (s *BootstrapSuite) TestRunEnvNameMissing(c *gc.C) {
+	s.PatchValue(&getEnvName, func(*BootstrapCommand) string { return "" })
+
+	_, err := coretesting.RunCommand(c, envcmd.Wrap(&BootstrapCommand{}))
 
 	c.Check(err, gc.ErrorMatches, "the name of the environment must be specified")
 }

--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
@@ -270,6 +271,21 @@ func (s *BootstrapSuite) TestCheckEnvNameMissing(c *gc.C) {
 	err := checkEnvName("")
 
 	c.Check(err, gc.ErrorMatches, "the name of the environment must be specified")
+}
+
+func (s *BootstrapSuite) TestCheckEnvNameProvisional(c *gc.C) {
+	err := checkEnvName("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+
+	for name, flag := range provisionalProviders {
+		err := checkEnvName(name)
+		c.Check(err, gc.ErrorMatches, ".* provider is provisional .* set JUJU_DEV_FEATURE_FLAGS=.*")
+
+		err = os.Setenv(osenv.JujuFeatureFlagEnvKey, flag)
+		c.Assert(err, jc.ErrorIsNil)
+		err = checkEnvName(name)
+		c.Check(err, jc.ErrorIsNil)
+	}
 }
 
 func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {

--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -275,17 +275,17 @@ func (s *BootstrapSuite) TestRunEnvNameMissing(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "the name of the environment must be specified")
 }
 
-func (s *BootstrapSuite) TestCheckEnvNameProvisional(c *gc.C) {
-	err := checkEnvName("dummy")
+func (s *BootstrapSuite) TestCheckProviderProvisional(c *gc.C) {
+	err := checkProviderType("dummy")
 	c.Assert(err, jc.ErrorIsNil)
 
 	for name, flag := range provisionalProviders {
-		err := checkEnvName(name)
+		err := checkProviderType(name)
 		c.Check(err, gc.ErrorMatches, ".* provider is provisional .* set JUJU_DEV_FEATURE_FLAGS=.*")
 
 		err = os.Setenv(osenv.JujuFeatureFlagEnvKey, flag)
 		c.Assert(err, jc.ErrorIsNil)
-		err = checkEnvName(name)
+		err = checkProviderType(name)
 		c.Check(err, jc.ErrorIsNil)
 	}
 }

--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -266,6 +266,12 @@ var bootstrapTests = []bootstrapTest{{
 	err:  `unrecognized args: \["anything" "else"\]`,
 }}
 
+func (s *BootstrapSuite) TestCheckEnvNameMissing(c *gc.C) {
+	err := checkEnvName("")
+
+	c.Check(err, gc.ErrorMatches, "the name of the environment must be specified")
+}
+
 func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {
 	env := resetJujuHome(c, "devenv")
 	defaultSeriesVersion := version.Current

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -8,16 +8,13 @@ import (
 
 	"github.com/altoros/gosigma"
 	"github.com/juju/errors"
-	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/provider/common"
 )
 
@@ -101,12 +98,7 @@ func (env *environ) Config() *config.Config {
 // and setting the agent-version configuration attribute prior to
 // bootstrapping the environment.
 func (env *environ) Bootstrap(ctx environs.BootstrapContext, params environs.BootstrapParams) (string, string, environs.BootstrapFinalizer, error) {
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	if featureflag.Enabled(feature.CloudSigma) {
-
-		return common.Bootstrap(ctx, env, params)
-	}
-	return "", "", nil, errors.Errorf("Cloudsigma is currently in beta in this version of Juju. To enable anyway use JUJU_DEV_FEATURE_FLAGS=\"cloudsigma\"")
+	return common.Bootstrap(ctx, env, params)
 }
 
 func (e *environ) StateServerInstances() ([]instance.Id, error) {

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -13,10 +13,6 @@ var (
 	Provider environs.EnvironProvider = providerInstance
 )
 
-func init() {
-	environs.RegisterProvider(providerType, providerInstance)
-}
-
 func ExposeEnvFakeClient(env *environ) *fakeClient {
 	return env.client.connection.RoundTripper.(*fakeClient)
 }

--- a/provider/vsphere/init.go
+++ b/provider/vsphere/init.go
@@ -6,11 +6,7 @@
 package vsphere
 
 import (
-	"github.com/juju/utils/featureflag"
-
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
@@ -19,9 +15,6 @@ const (
 )
 
 func init() {
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	if featureflag.Enabled(feature.VSphereProvider) {
-		environs.RegisterProvider(providerType, providerInstance)
-		registry.RegisterEnvironStorageProviders(providerType)
-	}
+	environs.RegisterProvider(providerType, providerInstance)
+	registry.RegisterEnvironStorageProviders(providerType)
 }


### PR DESCRIPTION
Provisional providers are those we hide behind a feature flag.  The feature flag should apply only to bootstrap.  This patch pulls the logic to do so into the bootstrap command.  That way we fail as early as possible.  In the interest of reducing churn, the patch performs an extra environs.ConfigForName call (in the environType helper).  Ideally we would refactor code in the environs package to eliminate the need to do so.

(fixes https://bugs.launchpad.net/juju-core/+bug/1450146)

(Review request: http://reviews.vapour.ws/r/1494/)