### PR TITLE
Add storage per directive in state.

### DIFF
--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -230,6 +230,11 @@ func (s *serviceSuite) TestClientServiceDeployWithStorage(c *gc.C) {
 			Size:  1024,
 			Pool:  "loop-pool",
 		},
+		"allecto": {
+			Count: 0,
+			Size:  1024,
+			Pool:  "loop-pool",
+		},
 	})
 }
 

--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -236,6 +236,11 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 			Count: 1,
 			Size:  1024,
 		},
+		"allecto": {
+			Pool:  "loop-pool",
+			Count: 0,
+			Size:  1024,
+		},
 	})
 }
 

--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -237,7 +237,7 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 			Size:  1024,
 		},
 		"allecto": {
-			Pool:  "loop-pool",
+			Pool:  "loop",
 			Count: 0,
 			Size:  1024,
 		},

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1010,7 +1010,7 @@ func (s *assignCleanSuite) TestAssignUnitToMachineWorksWithMachine0(c *gc.C) {
 func (s *AssignSuite) TestAssignUnitWithStorageCleanAvailable(c *gc.C) {
 	cons, err := s.storageSvc.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.HasLen, 1)
+	c.Assert(cons, gc.HasLen, 2)
 
 	unit, err := s.storageSvc.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -35,7 +35,7 @@ func (s *FilesystemStateSuite) TestAddServiceNoPool(c *gc.C) {
 	}
 	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
 	// TODO(axw) implement support for default filesystem pool.
-	c.Assert(err, gc.ErrorMatches, `cannot add service "storage-filesystem": finding default stoage pool: no storage pool specifed and no default available`)
+	c.Assert(err, gc.ErrorMatches, `cannot add service "storage-filesystem": finding default pool for "data" storage: no storage pool specifed and no default available`)
 }
 
 func (s *FilesystemStateSuite) TestAddFilesystemWithoutBackingVolume(c *gc.C) {

--- a/state/interface.go
+++ b/state/interface.go
@@ -223,3 +223,14 @@ var (
 	_ GlobalEntity = (*Charm)(nil)
 	_ GlobalEntity = (*Environment)(nil)
 )
+
+// StorageEntity is an entity that may have storage associations.
+type StorageEntity interface {
+	StorageConstraints() (map[string]StorageConstraints, error)
+	Tag() names.Tag
+}
+
+var (
+	_ StorageEntity = (*Service)(nil)
+	_ StorageEntity = (*Unit)(nil)
+)

--- a/state/interface.go
+++ b/state/interface.go
@@ -223,14 +223,3 @@ var (
 	_ GlobalEntity = (*Charm)(nil)
 	_ GlobalEntity = (*Environment)(nil)
 )
-
-// StorageEntity is an entity that may have storage associations.
-type StorageEntity interface {
-	StorageConstraints() (map[string]StorageConstraints, error)
-	Tag() names.Tag
-}
-
-var (
-	_ StorageEntity = (*Service)(nil)
-	_ StorageEntity = (*Unit)(nil)
-)

--- a/state/storage.go
+++ b/state/storage.go
@@ -970,7 +970,6 @@ func (st *State) validateUnitStorage(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	cons.Count = cons.Count - currentCount
 	return nil
 }
 
@@ -1012,7 +1011,7 @@ func (st *State) countEntityStorageInstancesForName(
 	criteria := bson.D{{
 		"$and", []bson.D{
 			bson.D{{"owner", tag.String()}},
-			bson.D{{"storagename", bson.RegEx{name, ""}}},
+			bson.D{{"storagename", name}},
 		},
 	}}
 	result, err := storageCollection.Find(criteria).Count()

--- a/state/storage.go
+++ b/state/storage.go
@@ -908,6 +908,8 @@ func (st *State) AddStorageForUnit(
 	if err != nil {
 		return errors.Annotatef(err, "getting existing storage directives for %s", u.Tag().Id())
 	}
+
+	// Check storage name was declared.
 	_, exists := all[name]
 	if !exists {
 		return errors.NotFoundf("charm storage %q", name)
@@ -928,7 +930,11 @@ func (st *State) AddStorageForUnit(
 	}
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		err := st.validateUnitStorage(charmMeta, u, name, completeCons)
+		err := u.Refresh()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		err = st.validateUnitStorage(charmMeta, u, name, completeCons)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/storage.go
+++ b/state/storage.go
@@ -679,7 +679,7 @@ func storageKind(storageType charm.StorageType) storage.StorageKind {
 }
 
 func validateStorageConstraints(st *State, allCons map[string]StorageConstraints, charmMeta *charm.Meta) error {
-	err := validateStorageConstraintsAgainstCharmStorage(st, allCons, charmMeta)
+	err := validateStorageConstraintsAgainstCharm(st, allCons, charmMeta)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -693,7 +693,7 @@ func validateStorageConstraints(st *State, allCons map[string]StorageConstraints
 	return nil
 }
 
-func validateStorageConstraintsAgainstCharmStorage(
+func validateStorageConstraintsAgainstCharm(
 	st *State,
 	allCons map[string]StorageConstraints,
 	charmMeta *charm.Meta,
@@ -963,7 +963,7 @@ func (st *State) validateUnitStorage(
 	}
 	cons.Count = cons.Count + currentCount
 
-	err = validateStorageConstraintsAgainstCharmStorage(
+	err = validateStorageConstraintsAgainstCharm(
 		st,
 		map[string]StorageConstraints{name: cons},
 		charmMeta)

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -10,129 +10,138 @@ import (
 	"github.com/juju/juju/state"
 )
 
-func (s *StorageStateSuite) setupMultipleStoragesForAdd(c *gc.C) (*state.Charm, *state.Unit, int) {
+type StorageAddSuite struct {
+	StorageStateSuiteBase
+
+	charm                *state.Charm
+	unit                 *state.Unit
+	originalStorageCount int
+}
+
+var _ = gc.Suite(&StorageAddSuite{})
+
+func (s *StorageAddSuite) setupMultipleStoragesForAdd(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
-	ch := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons)
+	s.charm = s.AddTestingCharm(c, "storage-block2")
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", s.charm, nil, storageCons)
 	c.Assert(err, jc.ErrorIsNil)
-	u, err := service.AddUnit()
+	s.unit, err = service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
-	original, err := s.State.AllStorageInstances()
+	all, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
-	return ch, u, len(original)
+	s.originalStorageCount = len(all)
 }
 
-func (s *StorageStateSuite) assertStorageAddedDynamically(c *gc.C, original, expected int) {
-	final, err := s.State.AllStorageInstances()
+func (s *StorageAddSuite) assertStorageCount(c *gc.C, expected int) {
+	all, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(final)-original, gc.Equals, expected)
+	c.Assert(len(all), gc.Equals, expected)
 }
 
-func (s *StorageStateSuite) TestAddStorageToUnit(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageToUnit(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertStorageAddedDynamically(c, original, 1)
+	s.assertStorageCount(c, s.originalStorageCount+1)
 }
 
-func (s *StorageStateSuite) TestAddStorageWithCount(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
-
-	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+func (s *StorageAddSuite) TestAddStorageWithCount(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertStorageAddedDynamically(c, original, 2)
+	s.assertStorageCount(c, s.originalStorageCount+2)
 }
 
-func (s *StorageStateSuite) TestAddStorageMultipleCalls(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertStorageAddedDynamically(c, original, 2)
+	s.assertStorageCount(c, s.originalStorageCount+2)
 
 	// Should not succeed as the number of storages after
 	// this call would be 11 whereas our upper limit is 10 here.
-	err = s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
+	err = s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified.*`)
-	s.assertStorageAddedDynamically(c, original+2, 0)
+	s.assertStorageCount(c, s.originalStorageCount+2)
 }
 
-func (s *StorageStateSuite) TestAddStorageExceedCount(c *gc.C) {
+func (s *StorageAddSuite) TestAddStorageExceedCount(c *gc.C) {
 	service, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
-	s.assertStorageAddedDynamically(c, 0, 1)
+	s.assertStorageCount(c, 1)
 
 	ch, _, err := service.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.AddStorageForUnit(ch.Meta(), u, "data", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block" store "data": at most 1 instances supported, 2 specified.*`)
-	s.assertStorageAddedDynamically(c, 1, 0)
+	s.assertStorageCount(c, 1)
 }
 
-func (s *StorageStateSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{})
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertStorageAddedDynamically(c, original, 1)
+	s.assertStorageCount(c, s.originalStorageCount+1)
 }
 
-func (s *StorageStateSuite) TestAddStorageDiffPool(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageDiffPool(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertStorageAddedDynamically(c, original, 1)
+	s.assertStorageCount(c, s.originalStorageCount+1)
 }
 
-func (s *StorageStateSuite) TestAddStorageDiffSize(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageDiffSize(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{Size: 2048})
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Size: 2048})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertStorageAddedDynamically(c, original, 1)
+	s.assertStorageCount(c, s.originalStorageCount+1)
 }
 
-func (s *StorageStateSuite) TestAddStorageLessMinSize(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi2up", state.StorageConstraints{Size: 2})
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi2up", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 2.0MB specified.*`)
-	s.assertStorageAddedDynamically(c, original, 0)
+	s.assertStorageCount(c, s.originalStorageCount)
 }
 
-func (s *StorageStateSuite) TestAddStorageWrongName(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageWrongName(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(ch.Meta(), u, "furball", state.StorageConstraints{Size: 2})
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "furball", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm storage "furball" not found.*`)
-	s.assertStorageAddedDynamically(c, original, 0)
+	s.assertStorageCount(c, s.originalStorageCount)
 }
 
-func (s *StorageStateSuite) TestAddStorageConcurrently(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageConcurrently(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 	addStorage := func() {
-		s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{})
+		s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	addStorage()
 	// Only 1 should have been added
-	s.assertStorageAddedDynamically(c, original, 1)
+	s.assertStorageCount(c, s.originalStorageCount+1)
 }
 
-func (s *StorageStateSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
-	ch, u, original := s.setupMultipleStoragesForAdd(c)
+func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
 
 	count := 6
 	addStorage := func() {
-		s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+		s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	addStorage()
 	// Only "count" number of instances should have been added.
-	s.assertStorageAddedDynamically(c, original, count)
+	s.assertStorageCount(c, s.originalStorageCount+count)
 }

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -1,0 +1,159 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"fmt"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+)
+
+func (s *StorageStateSuite) setupMultipleStoragesForAdd(c *gc.C) (*state.Charm, *state.Unit, map[string]bool) {
+	storageCons := map[string]state.StorageConstraints{
+		"multi1to10": makeStorageCons("loop", 0, 3),
+	}
+	ch := s.AddTestingCharm(c, "storage-block2")
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons)
+	c.Assert(err, jc.ErrorIsNil)
+	u, err := service.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedStorages := map[string]bool{
+		"multi1to10/0": true,
+		"multi1to10/1": true,
+		"multi1to10/2": true,
+		"multi1to10/5": false, // will be created dynamically during this test
+		"multi2up/3":   true,
+		"multi2up/4":   true,
+	}
+	s.assertMultiStorageExists(c, expectedStorages)
+	return ch, u, expectedStorages
+}
+
+func (s *StorageStateSuite) TestAddStorageToUnit(c *gc.C) {
+	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorage(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, jc.ErrorIsNil)
+	expectedStorages["multi1to10/5"] = true
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) TestAddStorageWithCount(c *gc.C) {
+	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorage(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+	c.Assert(err, jc.ErrorIsNil)
+	expectedStorages["multi1to10/5"] = true
+	expectedStorages["multi1to10/6"] = true
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) assertMultiStorageExists(c *gc.C, all map[string]bool) {
+	for tag, exists := range all {
+		confirm := s.storageInstanceExists(c, names.NewStorageTag(tag))
+		c.Assert(exists, gc.Equals, confirm)
+	}
+}
+
+func (s *StorageStateSuite) TestAddStorageExceedCount(c *gc.C) {
+	service, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
+	expectedStorages := map[string]bool{
+		storageTag.Id(): true,
+		"data/1":        false, // will try to create in this test
+	}
+	s.assertMultiStorageExists(c, expectedStorages)
+
+	ch, _, err := service.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.AddStorage(ch.Meta(), u, "data", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block" store "data": at most 1 instances supported, 2 specified.*`)
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
+	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorage(ch.Meta(), u, "multi1to10", state.StorageConstraints{})
+	c.Assert(err, jc.ErrorIsNil)
+	expectedStorages["multi1to10/5"] = true
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) TestAddStorageDiffPool(c *gc.C) {
+	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorage(ch.Meta(), u, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
+	c.Assert(err, jc.ErrorIsNil)
+	expectedStorages["multi1to10/5"] = true
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) TestAddStorageDiffSize(c *gc.C) {
+	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorage(ch.Meta(), u, "multi1to10", state.StorageConstraints{Size: 2048})
+	c.Assert(err, jc.ErrorIsNil)
+	expectedStorages["multi1to10/5"] = true
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) TestAddStorageLessMinSize(c *gc.C) {
+	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorage(ch.Meta(), u, "multi2up", state.StorageConstraints{Size: 2})
+	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 2.0MB specified.*`)
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) TestAddStorageWrongName(c *gc.C) {
+	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorage(ch.Meta(), u, "furball", state.StorageConstraints{Size: 2})
+	c.Assert(err, gc.ErrorMatches, `.*storage "furball" on the charm not found.*`)
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) TestAddStorageConcurrently(c *gc.C) {
+	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	index := 4
+	addStorage := func() {
+		err := s.State.AddStorage(ch.Meta(), u, "multi1to10", state.StorageConstraints{})
+		c.Assert(err, jc.ErrorIsNil)
+		index++
+		expectedStorages[fmt.Sprintf("multi1to10/%d", index)] = true
+	}
+	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
+	addStorage()
+
+	c.Assert(expectedStorages, gc.HasLen, 7)
+	s.assertMultiStorageExists(c, expectedStorages)
+}
+
+func (s *StorageStateSuite) TestAddStorageToService(c *gc.C) {
+	storageCons := map[string]state.StorageConstraints{
+		"multi1to10": makeStorageCons("loop", 0, 3),
+	}
+	ch := s.AddTestingCharm(c, "storage-block2")
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Get all storage before add.
+	before, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.AddStorage(ch.Meta(), service, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Get all storage afters add.
+	after, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	// Can't add storage to service atm.
+	c.Assert(len(before), gc.Equals, len(after))
+}

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -141,8 +141,7 @@ func (s *StorageAddSuite) TestAddStorageConcurrently(c *gc.C) {
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	addStorage()
-	// Only 1 should have been added
-	s.assertStorageCount(c, s.originalStorageCount+1)
+	s.assertStorageCount(c, s.originalStorageCount+2)
 }
 
 func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
@@ -153,7 +152,9 @@ func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
 		s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
-	addStorage()
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 15 specified.*`)
+
 	// Only "count" number of instances should have been added.
 	s.assertStorageCount(c, s.originalStorageCount+count)
 }

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -137,7 +137,8 @@ func (s *StorageAddSuite) TestAddStorageWrongName(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageConcurrently(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 	addStorage := func() {
-		s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
+		err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
+		c.Assert(err, jc.ErrorIsNil)
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	addStorage()
@@ -149,7 +150,8 @@ func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
 
 	count := 6
 	addStorage := func() {
-		s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+		err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+		c.Assert(err, jc.ErrorIsNil)
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -4,16 +4,13 @@
 package state_test
 
 import (
-	"fmt"
-
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 )
 
-func (s *StorageStateSuite) setupMultipleStoragesForAdd(c *gc.C) (*state.Charm, *state.Unit, map[string]bool) {
+func (s *StorageStateSuite) setupMultipleStoragesForAdd(c *gc.C) (*state.Charm, *state.Unit, int) {
 	storageCons := map[string]state.StorageConstraints{
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
@@ -23,162 +20,119 @@ func (s *StorageStateSuite) setupMultipleStoragesForAdd(c *gc.C) (*state.Charm, 
 	u, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedStorages := map[string]bool{
-		"multi1to10/0": true,
-		"multi1to10/1": true,
-		"multi1to10/2": true,
-		"multi1to10/5": false, // will be created dynamically during this test
-		"multi2up/3":   true,
-		"multi2up/4":   true,
-	}
-	s.assertMultiStorageExists(c, expectedStorages)
-	return ch, u, expectedStorages
+	original, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	return ch, u, len(original)
+}
+
+func (s *StorageStateSuite) assertStorageAddedDynamically(c *gc.C, original, expected int) {
+	final, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(final)-original, gc.Equals, expected)
 }
 
 func (s *StorageStateSuite) TestAddStorageToUnit(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
 	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, jc.ErrorIsNil)
-	expectedStorages["multi1to10/5"] = true
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, original, 1)
 }
 
 func (s *StorageStateSuite) TestAddStorageWithCount(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
 	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
-	expectedStorages["multi1to10/5"] = true
-	expectedStorages["multi1to10/6"] = true
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, original, 2)
 }
 
 func (s *StorageStateSuite) TestAddStorageMultipleCalls(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
 	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
-	expectedStorages["multi1to10/5"] = true
-	expectedStorages["multi1to10/6"] = true
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, original, 2)
 
 	// Should not succeed as the number of storages after
 	// this call would be 11 whereas our upper limit is 10 here.
 	err = s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified.*`)
-	expectedStorages["multi1to10/7"] = false
-	expectedStorages["multi1to10/8"] = false
-	expectedStorages["multi1to10/9"] = false
-	expectedStorages["multi1to10/10"] = false
-	expectedStorages["multi1to10/11"] = false
-	expectedStorages["multi1to10/12"] = false
-	s.assertMultiStorageExists(c, expectedStorages)
-}
-
-func (s *StorageStateSuite) assertMultiStorageExists(c *gc.C, all map[string]bool) {
-	for tag, exists := range all {
-		confirm := s.storageInstanceExists(c, names.NewStorageTag(tag))
-		c.Assert(exists, gc.Equals, confirm)
-	}
+	s.assertStorageAddedDynamically(c, original+2, 0)
 }
 
 func (s *StorageStateSuite) TestAddStorageExceedCount(c *gc.C) {
-	service, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
-	expectedStorages := map[string]bool{
-		storageTag.Id(): true,
-		"data/1":        false, // will try to create in this test
-	}
-	s.assertMultiStorageExists(c, expectedStorages)
+	service, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
+	s.assertStorageAddedDynamically(c, 0, 1)
 
 	ch, _, err := service.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.AddStorageForUnit(ch.Meta(), u, "data", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block" store "data": at most 1 instances supported, 2 specified.*`)
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, 1, 0)
 }
 
 func (s *StorageStateSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
 	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{})
 	c.Assert(err, jc.ErrorIsNil)
-	expectedStorages["multi1to10/5"] = true
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, original, 1)
 }
 
 func (s *StorageStateSuite) TestAddStorageDiffPool(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
 	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
 	c.Assert(err, jc.ErrorIsNil)
-	expectedStorages["multi1to10/5"] = true
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, original, 1)
 }
 
 func (s *StorageStateSuite) TestAddStorageDiffSize(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
 	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{Size: 2048})
 	c.Assert(err, jc.ErrorIsNil)
-	expectedStorages["multi1to10/5"] = true
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, original, 1)
 }
 
 func (s *StorageStateSuite) TestAddStorageLessMinSize(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
 	err := s.State.AddStorageForUnit(ch.Meta(), u, "multi2up", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 2.0MB specified.*`)
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, original, 0)
 }
 
 func (s *StorageStateSuite) TestAddStorageWrongName(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
 	err := s.State.AddStorageForUnit(ch.Meta(), u, "furball", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm storage "furball" not found.*`)
-	s.assertMultiStorageExists(c, expectedStorages)
+	s.assertStorageAddedDynamically(c, original, 0)
 }
 
 func (s *StorageStateSuite) TestAddStorageConcurrently(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
-	index := 4
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 	addStorage := func() {
-		err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{})
-		c.Assert(err, jc.ErrorIsNil)
-		index++
-		expectedStorages[fmt.Sprintf("multi1to10/%d", index)] = true
+		s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{})
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	addStorage()
-
-	c.Assert(expectedStorages, gc.HasLen, 7)
-	s.assertMultiStorageExists(c, expectedStorages)
+	// Only 1 should have been added
+	s.assertStorageAddedDynamically(c, original, 1)
 }
 
 func (s *StorageStateSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
-	ch, u, expectedStorages := s.setupMultipleStoragesForAdd(c)
-	original, err := s.State.AllStorageInstances()
-	c.Assert(err, jc.ErrorIsNil)
+	ch, u, original := s.setupMultipleStoragesForAdd(c)
 
-	index := 4
 	count := 6
 	addStorage := func() {
-		err := s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{Count: uint64(count)})
-		c.Assert(err, jc.ErrorIsNil)
-		for i := 0; i < count; i++ {
-			index++
-			expectedStorages[fmt.Sprintf("multi1to10/%d", index)] = true
-		}
+		s.State.AddStorageForUnit(ch.Meta(), u, "multi1to10", state.StorageConstraints{Count: uint64(count)})
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	addStorage()
-
-	final, err := s.State.AllStorageInstances()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(len(final)-len(original), gc.Equals, count)
-	s.assertMultiStorageExists(c, expectedStorages)
+	// Only "count" number of instances should have been added.
+	s.assertStorageAddedDynamically(c, original, count)
 }

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -82,6 +82,18 @@ func (s *StorageAddSuite) TestAddStorageExceedCount(c *gc.C) {
 	s.assertStorageCount(c, 1)
 }
 
+func (s *StorageAddSuite) TestAddStorageMinCount(c *gc.C) {
+	service, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
+	s.assertStorageCount(c, 1)
+
+	ch, _, err := service.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.AddStorageForUnit(ch.Meta(), u, "allecto", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, 2)
+}
+
 func (s *StorageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -154,7 +154,8 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultPool(c *gc.C)
 		"data": makeStorageCons("", 2048, 1),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop-pool", 2048, 1),
+		"data":    makeStorageCons("loop-pool", 2048, 1),
+		"allecto": makeStorageCons("loop-pool", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
@@ -164,7 +165,8 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoUserDefaultPool(c 
 		"data": makeStorageCons("", 2048, 1),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop", 2048, 1),
+		"data":    makeStorageCons("loop", 2048, 1),
+		"allecto": makeStorageCons("loop", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "", storageCons, expectedCons)
 }
@@ -174,7 +176,8 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFallback(
 		"data": makeStorageCons("loop-pool", 0, 1),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop-pool", 1024, 1),
+		"data":    makeStorageCons("loop-pool", 1024, 1),
+		"allecto": makeStorageCons("loop-pool", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -90,6 +90,11 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 			Size:  1024,
 			Count: 1,
 		},
+		"allecto": state.StorageConstraints{
+			Pool:  "loop",
+			Size:  1024,
+			Count: 0,
+		},
 	})
 }
 
@@ -115,6 +120,11 @@ func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 			Pool:  "default-block",
 			Size:  1024,
 			Count: 1,
+		},
+		"allecto": state.StorageConstraints{
+			Pool:  "default-block",
+			Size:  1024,
+			Count: 0,
 		},
 	})
 }

--- a/testcharms/charm-repo/quantal/storage-block/metadata.yaml
+++ b/testcharms/charm-repo/quantal/storage-block/metadata.yaml
@@ -4,3 +4,7 @@ description: See above
 storage:
     data:
         type: block
+    allecto:
+        type: block
+        multiple:
+                range: 0+


### PR DESCRIPTION
This is the supporting functionality in state to allow storage to be added dynamically.

It has been discussed and decided that at this level, we will only be dealing with one storage directive (<name>=<storage constraints>).

Tests include default constraints population and constraints validations.

(Review request: http://reviews.vapour.ws/r/1498/)