### PR TITLE
Remove storage ff

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -364,7 +363,6 @@ func (c *Client) ServiceDeployWithNetworks(
 	cons constraints.Value,
 	toMachineSpec string,
 	networks []string,
-	storage map[string]storage.Constraints,
 ) error {
 	params := params.ServiceDeploy{
 		ServiceName:   serviceName,
@@ -374,7 +372,6 @@ func (c *Client) ServiceDeployWithNetworks(
 		Constraints:   cons,
 		ToMachineSpec: toMachineSpec,
 		Networks:      networks,
-		Storage:       storage,
 	}
 	return c.facade.FacadeCall("ServiceDeployWithNetworks", params, nil)
 }

--- a/api/client.go
+++ b/api/client.go
@@ -315,16 +315,6 @@ func (c *Client) AddMachines(machineParams []params.AddMachineParams) ([]params.
 	return results.Machines, err
 }
 
-// AddMachinesWithDisks adds new machines with the supplied parameters, creating any requested disks.
-func (c *Client) AddMachinesWithDisks(machineParams []params.AddMachineParams) ([]params.AddMachinesResult, error) {
-	args := params.AddMachines{
-		MachineParams: machineParams,
-	}
-	results := new(params.AddMachinesResults)
-	err := c.facade.FacadeCall("AddMachinesV3", args, results)
-	return results.Machines, err
-}
-
 // ProvisioningScript returns a shell script that, when run,
 // provisions a machine agent on the machine executing the script.
 func (c *Client) ProvisioningScript(args params.ProvisioningScriptParams) (script string, err error) {

--- a/api/client.go
+++ b/api/client.go
@@ -315,6 +315,16 @@ func (c *Client) AddMachines(machineParams []params.AddMachineParams) ([]params.
 	return results.Machines, err
 }
 
+// AddMachinesWithDisks adds new machines with the supplied parameters, creating any requested disks.
+func (c *Client) AddMachinesWithDisks(machineParams []params.AddMachineParams) ([]params.AddMachinesResult, error) {
+	args := params.AddMachines{
+		MachineParams: machineParams,
+	}
+	results := new(params.AddMachinesResults)
+	err := c.facade.FacadeCall("AddMachinesV3", args, results)
+	return results.Machines, err
+}
+
 // ProvisioningScript returns a shell script that, when run,
 // provisions a machine agent on the machine executing the script.
 func (c *Client) ProvisioningScript(args params.ProvisioningScriptParams) (script string, err error) {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -32,6 +32,7 @@ var facadeVersions = map[string]int{
 	"KeyUpdater":                   0,
 	"LeadershipService":            1,
 	"Logger":                       0,
+	"MachineManager":               1,
 	"Machiner":                     0,
 	"MetricsManager":               0,
 	"Networker":                    0,

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -19,7 +19,7 @@ var facadeVersions = map[string]int{
 	"Block":                        1,
 	"Charms":                       1,
 	"CharmRevisionUpdater":         0,
-	"Client":                       2,
+	"Client":                       0,
 	"Deployer":                     0,
 	"DiskManager":                  1,
 	"Environment":                  0,

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -19,7 +19,7 @@ var facadeVersions = map[string]int{
 	"Block":                        1,
 	"Charms":                       1,
 	"CharmRevisionUpdater":         0,
-	"Client":                       0,
+	"Client":                       2,
 	"Deployer":                     0,
 	"DiskManager":                  1,
 	"Environment":                  0,

--- a/api/facadeversions_test.go
+++ b/api/facadeversions_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&facadeVersionSuite{})
 
 func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *gc.C) {
 	// Enable feature flags so we can see them all.
-	devFeatures := []string{feature.JES, feature.Storage}
+	devFeatures := []string{feature.JES}
 	s.SetFeatureFlags(strings.Join(devFeatures, ","))
 	// The client side code doesn't want to directly import the server side
 	// code just to list out what versions are available. However, we do

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -1,0 +1,38 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+const machineManagerFacade = "MachineManager"
+
+// Client provides access to the machinemanager, used to add machines to state.
+type Client struct {
+	base.ClientFacade
+	facade base.FacadeCaller
+}
+
+// NewClient returns a new machinemanager client.
+func NewClient(st base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(st, machineManagerFacade)
+	return &Client{ClientFacade: frontend, facade: backend}
+}
+
+// AddMachines adds new machines with the supplied parameters, creating any requested disks.
+func (client *Client) AddMachines(machineParams []params.AddMachineParams) ([]params.AddMachinesResult, error) {
+	args := params.AddMachines{
+		MachineParams: machineParams,
+	}
+	results := new(params.AddMachinesResults)
+	err := client.facade.FacadeCall("AddMachines", args, results)
+	if len(results.Machines) != len(machineParams) {
+		return nil, errors.Errorf("expected %d result, got %d", len(machineParams), len(results.Machines))
+	}
+	return results.Machines, err
+}

--- a/api/machinemanager/machinemanager_test.go
+++ b/api/machinemanager/machinemanager_test.go
@@ -1,0 +1,118 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager_test
+
+import (
+	"errors"
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/machinemanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/storage"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&MachinemanagerSuite{})
+
+type MachinemanagerSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *MachinemanagerSuite) TestAddMachines(c *gc.C) {
+	apiResult := []params.AddMachinesResult{
+		{Machine: "machine-1", Error: nil},
+		{Machine: "machine-2", Error: nil},
+	}
+
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "MachineManager")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "AddMachines")
+		c.Check(arg, gc.DeepEquals, params.AddMachines{
+			MachineParams: []params.AddMachineParams{
+				{
+					Series: "trusty",
+					Disks:  []storage.Constraints{{Pool: "loop", Size: 1}},
+				},
+				{
+					Series: "precise",
+				},
+			},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.AddMachinesResults{})
+		*(result.(*params.AddMachinesResults)) = params.AddMachinesResults{
+			Machines: apiResult,
+		}
+		callCount++
+		return nil
+	})
+
+	st := machinemanager.NewClient(apiCaller)
+	machines := []params.AddMachineParams{{
+		Series: "trusty",
+		Disks:  []storage.Constraints{{Pool: "loop", Size: 1}},
+	}, {
+		Series: "precise",
+	}}
+	result, err := st.AddMachines(machines)
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, apiResult)
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *MachinemanagerSuite) TestAddMachinesClientError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("blargh")
+	})
+	st := machinemanager.NewClient(apiCaller)
+	_, err := st.AddMachines(nil)
+	c.Check(err, gc.ErrorMatches, "blargh")
+}
+
+func (s *MachinemanagerSuite) TestAddMachinesServerError(c *gc.C) {
+	apiResult := []params.AddMachinesResult{{
+		Error: &params.Error{Message: "MSG", Code: "621"},
+	}}
+
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.AddMachinesResults)) = params.AddMachinesResults{
+			Machines: apiResult,
+		}
+		return nil
+	})
+	st := machinemanager.NewClient(apiCaller)
+	machines := []params.AddMachineParams{{
+		Series: "trusty",
+	}}
+	results, err := st.AddMachines(machines)
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, apiResult)
+}
+
+func (s *MachinemanagerSuite) TestAddMachinesResultCountInvalid(c *gc.C) {
+	for _, n := range []int{0, 2} {
+		apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+			var results []params.AddMachinesResult
+			for i := 0; i < n; i++ {
+				results = append(results, params.AddMachinesResult{
+					Error: &params.Error{Message: "MSG", Code: "621"},
+				})
+			}
+			*(result.(*params.AddMachinesResults)) = params.AddMachinesResults{Machines: results}
+			return nil
+		})
+		st := machinemanager.NewClient(apiCaller)
+		machines := []params.AddMachineParams{{
+			Series: "trusty",
+		}}
+		_, err := st.AddMachines(machines)
+		c.Check(err, gc.ErrorMatches, fmt.Sprintf("expected 1 result, got %d", n))
+	}
+}

--- a/api/machinemanager/package_test.go
+++ b/api/machinemanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/service/client.go
+++ b/api/service/client.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/storage"
 )
 
 // Client allows access to the service API end point.
@@ -40,4 +42,39 @@ func (c *Client) SetMetricCredentials(service string, credentials []byte) error 
 		return errors.Trace(err)
 	}
 	return errors.Trace(results.OneError())
+}
+
+// ServiceDeploy obtains the charm, either locally or from
+// the charm store, and deploys it. It allows the specification of
+// requested networks that must be present on the machines where the
+// service is deployed. Another way to specify networks to include/exclude
+// is using constraints.
+func (c *Client) ServiceDeploy(
+	charmURL string,
+	serviceName string,
+	numUnits int,
+	configYAML string,
+	cons constraints.Value,
+	toMachineSpec string,
+	networks []string,
+	storage map[string]storage.Constraints,
+) error {
+	args := params.ServicesDeploy{
+		Services: []params.ServiceDeploy{{
+			ServiceName:   serviceName,
+			CharmUrl:      charmURL,
+			NumUnits:      numUnits,
+			ConfigYAML:    configYAML,
+			Constraints:   cons,
+			ToMachineSpec: toMachineSpec,
+			Networks:      networks,
+			Storage:       storage,
+		}},
+	}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("ServicesDeploy", args, &results)
+	if err != nil {
+		return err
+	}
+	return results.OneError()
 }

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -124,7 +124,7 @@ func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {
 }
 
 func (s *stateSuite) TestBestFacadeVersion(c *gc.C) {
-	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 2)
+	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 0)
 }
 
 func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -107,7 +107,7 @@ func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {
 	c.Check(allVersions, gc.Not(gc.HasLen), 0)
 	// For sanity checking, ensure that we have a v2 of the Client facade
 	c.Assert(allVersions["Client"], gc.Not(gc.HasLen), 0)
-	c.Check(allVersions["Client"][0], gc.Equals, 2)
+	c.Check(allVersions["Client"][0], gc.Equals, 0)
 }
 
 func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -105,9 +105,9 @@ func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {
 	// Now that we've logged in, AllFacadeVersions should be updated.
 	allVersions := apistate.AllFacadeVersions()
 	c.Check(allVersions, gc.Not(gc.HasLen), 0)
-	// For sanity checking, ensure that we have a v0 of the Client facade
+	// For sanity checking, ensure that we have a v2 of the Client facade
 	c.Assert(allVersions["Client"], gc.Not(gc.HasLen), 0)
-	c.Check(allVersions["Client"][0], gc.Equals, 0)
+	c.Check(allVersions["Client"][0], gc.Equals, 2)
 }
 
 func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {
@@ -124,7 +124,7 @@ func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {
 }
 
 func (s *stateSuite) TestBestFacadeVersion(c *gc.C) {
-	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 0)
+	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 2)
 }
 
 func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -573,7 +573,7 @@ func (s *loginSuite) TestLoginValidationSuccess(c *gc.C) {
 
 		// Ensure an API call that would be restricted during
 		// upgrades works after a normal login.
-		err := st.APICall("Client", 2, "", "DestroyEnvironment", nil, nil)
+		err := st.APICall("Client", 0, "", "DestroyEnvironment", nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	s.checkLoginWithValidator(c, validator, checker)
@@ -598,10 +598,10 @@ func (s *loginSuite) TestLoginValidationDuringUpgrade(c *gc.C) {
 		c.Assert(loginErr, gc.IsNil)
 
 		var statusResult api.Status
-		err := st.APICall("Client", 2, "", "FullStatus", params.StatusParams{}, &statusResult)
+		err := st.APICall("Client", 0, "", "FullStatus", params.StatusParams{}, &statusResult)
 		c.Assert(err, jc.ErrorIsNil)
 
-		err = st.APICall("Client", 2, "", "DestroyEnvironment", nil, nil)
+		err = st.APICall("Client", 0, "", "DestroyEnvironment", nil, nil)
 		c.Assert(err, gc.ErrorMatches, ".*upgrade in progress - Juju functionality is limited.*")
 	}
 	s.checkLoginWithValidator(c, validator, checker)

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -573,7 +573,7 @@ func (s *loginSuite) TestLoginValidationSuccess(c *gc.C) {
 
 		// Ensure an API call that would be restricted during
 		// upgrades works after a normal login.
-		err := st.APICall("Client", 0, "", "DestroyEnvironment", nil, nil)
+		err := st.APICall("Client", 2, "", "DestroyEnvironment", nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	s.checkLoginWithValidator(c, validator, checker)
@@ -598,10 +598,10 @@ func (s *loginSuite) TestLoginValidationDuringUpgrade(c *gc.C) {
 		c.Assert(loginErr, gc.IsNil)
 
 		var statusResult api.Status
-		err := st.APICall("Client", 0, "", "FullStatus", params.StatusParams{}, &statusResult)
+		err := st.APICall("Client", 2, "", "FullStatus", params.StatusParams{}, &statusResult)
 		c.Assert(err, jc.ErrorIsNil)
 
-		err = st.APICall("Client", 0, "", "DestroyEnvironment", nil, nil)
+		err = st.APICall("Client", 2, "", "DestroyEnvironment", nil, nil)
 		c.Assert(err, gc.ErrorMatches, ".*upgrade in progress - Juju functionality is limited.*")
 	}
 	s.checkLoginWithValidator(c, validator, checker)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/juju/juju/apiserver/keyupdater"
 	_ "github.com/juju/juju/apiserver/logger"
 	_ "github.com/juju/juju/apiserver/machine"
+	_ "github.com/juju/juju/apiserver/machinemanager"
 	_ "github.com/juju/juju/apiserver/metricsmanager"
 	_ "github.com/juju/juju/apiserver/networker"
 	_ "github.com/juju/juju/apiserver/provisioner"

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -19,9 +18,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
@@ -454,8 +451,6 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 }
 
 func (s *baseSuite) setupStoragePool(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -267,6 +267,8 @@ func (c *Client) ServiceUnexpose(args params.ServiceUnexpose) error {
 	return svc.ClearExposed()
 }
 
+// TODO - we really want to avoid this, which we can do by refactoring code requiring this
+// to use interfaces.
 // NewCharmStore instantiates a new charm store repository.
 // It is defined at top level for testing purposes.
 var NewCharmStore = charmrepo.NewCharmStore

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -588,6 +588,11 @@ func (c *Client) AddMachines(args params.AddMachines) (params.AddMachinesResults
 
 // AddMachinesV2 adds new machines with the supplied parameters.
 func (c *Client) AddMachinesV2(args params.AddMachines) (params.AddMachinesResults, error) {
+	return c.AddMachinesV3(args)
+}
+
+// AddMachinesV3 adds new machines with the supplied parameters.
+func (c *Client) AddMachinesV3(args params.AddMachines) (params.AddMachinesResults, error) {
 	results := params.AddMachinesResults{
 		Machines: make([]params.AddMachinesResult, len(args.MachineParams)),
 	}

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -31,7 +31,6 @@ import (
 	jjj "github.com/juju/juju/juju"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/multiwatcher"
 	statestorage "github.com/juju/juju/state/storage"
 	"github.com/juju/juju/version"
 )
@@ -660,7 +659,7 @@ func (c *Client) addOneMachine(p params.AddMachineParams) (*state.Machine, error
 		placementDirective = p.Placement.Directive
 	}
 
-	jobs, err := stateJobs(p.Jobs)
+	jobs, err := common.StateJobs(p.Jobs)
 	if err != nil {
 		return nil, err
 	}
@@ -681,18 +680,6 @@ func (c *Client) addOneMachine(p params.AddMachineParams) (*state.Machine, error
 		return c.api.state.AddMachineInsideMachine(template, p.ParentId, p.ContainerType)
 	}
 	return c.api.state.AddMachineInsideNewMachine(template, template, p.ContainerType)
-}
-
-func stateJobs(jobs []multiwatcher.MachineJob) ([]state.MachineJob, error) {
-	newJobs := make([]state.MachineJob, len(jobs))
-	for i, job := range jobs {
-		newJob, err := params.MachineJobFromParams(job)
-		if err != nil {
-			return nil, err
-		}
-		newJobs[i] = newJob
-	}
-	return newJobs, nil
 }
 
 // ProvisioningScript returns a shell script that, when run,

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2986,7 +2986,7 @@ func (s *clientSuite) TestClientAddMachinesWithDisks(c *gc.C) {
 	apiParams[2].Disks = []storage.Constraints{{Size: 1, Count: 2, Pool: "loop-pool"}}
 	apiParams[3].Disks = []storage.Constraints{{Size: 0, Count: 0}}
 	apiParams[4].Disks = []storage.Constraints{{Size: 0, Count: 1}}
-	machines, err := s.APIState.Client().AddMachines(apiParams)
+	machines, err := s.APIState.Client().AddMachinesWithDisks(apiParams)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 5)
 	c.Assert(machines[0].Machine, gc.Equals, "0")

--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -4,11 +4,9 @@
 package client
 
 var (
-	ParseSettingsCompatible = parseSettingsCompatible
-	RemoteParamsForMachine  = remoteParamsForMachine
-	GetAllUnitNames         = getAllUnitNames
-	NewStateStorage         = &newStateStorage
-	NewCharmStore           = &newCharmStore
+	RemoteParamsForMachine = remoteParamsForMachine
+	GetAllUnitNames        = getAllUnitNames
+	NewStateStorage        = &newStateStorage
 )
 
 var MachineJobFromParams = machineJobFromParams

--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -9,8 +9,6 @@ var (
 	NewStateStorage        = &newStateStorage
 )
 
-var MachineJobFromParams = machineJobFromParams
-
 // Filtering exports
 var (
 	MatchPortRanges = matchPortRanges

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -344,7 +344,7 @@ func opClientServiceDeploy(c *gc.C, st *api.State, mst *state.State) (func(), er
 }
 
 func opClientServiceDeployWithNetworks(c *gc.C, st *api.State, mst *state.State) (func(), error) {
-	err := st.Client().ServiceDeployWithNetworks("mad:bad/url-1", "x", 1, "", constraints.Value{}, "", nil, nil)
+	err := st.Client().ServiceDeployWithNetworks("mad:bad/url-1", "x", 1, "", constraints.Value{}, "", nil)
 	if err.Error() == `charm URL has invalid schema: "mad:bad/url-1"` {
 		err = nil
 	}

--- a/apiserver/common/export_test.go
+++ b/apiserver/common/export_test.go
@@ -4,10 +4,11 @@
 package common
 
 var (
-	ValidateNewFacade = validateNewFacade
-	WrapNewFacade     = wrapNewFacade
-	NilFacadeRecord   = facadeRecord{}
-	EnvtoolsFindTools = &envtoolsFindTools
+	MachineJobFromParams = machineJobFromParams
+	ValidateNewFacade    = validateNewFacade
+	WrapNewFacade        = wrapNewFacade
+	NilFacadeRecord      = facadeRecord{}
+	EnvtoolsFindTools    = &envtoolsFindTools
 )
 
 type Patcher interface {

--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/multiwatcher"
+)
+
+// StateJobs translates a slice of multiwatcher jobs to their equivalents in state.
+func StateJobs(jobs []multiwatcher.MachineJob) ([]state.MachineJob, error) {
+	newJobs := make([]state.MachineJob, len(jobs))
+	for i, job := range jobs {
+		newJob, err := machineJobFromParams(job)
+		if err != nil {
+			return nil, err
+		}
+		newJobs[i] = newJob
+	}
+	return newJobs, nil
+}
+
+// machineJobFromParams returns the job corresponding to multiwatcher.MachineJob.
+func machineJobFromParams(job multiwatcher.MachineJob) (state.MachineJob, error) {
+	switch job {
+	case multiwatcher.JobHostUnits:
+		return state.JobHostUnits, nil
+	case multiwatcher.JobManageEnviron:
+		return state.JobManageEnviron, nil
+	case multiwatcher.JobManageNetworking:
+		return state.JobManageNetworking, nil
+	case multiwatcher.JobManageStateDeprecated:
+		// Deprecated in 1.18.
+		return state.JobManageStateDeprecated, nil
+	default:
+		return -1, errors.Errorf("invalid machine job %q", job)
+	}
+}

--- a/apiserver/common/machine_test.go
+++ b/apiserver/common/machine_test.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/multiwatcher"
+)
+
+type machineSuite struct{}
+
+var _ = gc.Suite(&machineSuite{})
+
+func (s *machineSuite) TestMachineJobFromParams(c *gc.C) {
+	var tests = []struct {
+		name multiwatcher.MachineJob
+		want state.MachineJob
+		err  string
+	}{{
+		name: multiwatcher.JobHostUnits,
+		want: state.JobHostUnits,
+	}, {
+		name: multiwatcher.JobManageEnviron,
+		want: state.JobManageEnviron,
+	}, {
+		name: multiwatcher.JobManageNetworking,
+		want: state.JobManageNetworking,
+	}, {
+		name: multiwatcher.JobManageStateDeprecated,
+		want: state.JobManageStateDeprecated,
+	}, {
+		name: "invalid",
+		want: -1,
+		err:  `invalid machine job "invalid"`,
+	}}
+	for _, test := range tests {
+		got, err := common.MachineJobFromParams(test.name)
+		if err != nil {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+		c.Check(got, gc.Equals, test.want)
+	}
+}

--- a/apiserver/machinemanager/export_test.go
+++ b/apiserver/machinemanager/export_test.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager
+
+import "github.com/juju/juju/state"
+
+type StateInterface stateInterface
+
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}
+
+func PatchState(p Patcher, st StateInterface) {
+	p.PatchValue(&getState, func(*state.State) stateInterface {
+		return st
+	})
+}

--- a/apiserver/machinemanager/machinemanager.go
+++ b/apiserver/machinemanager/machinemanager.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/multiwatcher"
 )
 
 func init() {
@@ -135,7 +134,7 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		}
 	}
 
-	jobs, err := stateJobs(p.Jobs)
+	jobs, err := common.StateJobs(p.Jobs)
 	if err != nil {
 		return nil, err
 	}
@@ -157,16 +156,4 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		return mm.st.AddMachineInsideMachine(template, p.ParentId, p.ContainerType)
 	}
 	return mm.st.AddMachineInsideNewMachine(template, template, p.ContainerType)
-}
-
-func stateJobs(jobs []multiwatcher.MachineJob) ([]state.MachineJob, error) {
-	newJobs := make([]state.MachineJob, len(jobs))
-	for i, job := range jobs {
-		newJob, err := params.MachineJobFromParams(job)
-		if err != nil {
-			return nil, err
-		}
-		newJobs[i] = newJob
-	}
-	return newJobs, nil
 }

--- a/apiserver/machinemanager/machinemanager.go
+++ b/apiserver/machinemanager/machinemanager.go
@@ -1,0 +1,172 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/multiwatcher"
+)
+
+func init() {
+	common.RegisterStandardFacade("MachineManager", 1, NewMachineManagerAPI)
+}
+
+// MachineManagerAPI provides access to the MachineManager API facade.
+type MachineManagerAPI struct {
+	st         stateInterface
+	authorizer common.Authorizer
+	check      *common.BlockChecker
+}
+
+var getState = func(st *state.State) stateInterface {
+	return stateShim{st}
+}
+
+// NewMachineManagerAPI creates a new server-side MachineManager API facade.
+func NewMachineManagerAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*MachineManagerAPI, error) {
+
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
+
+	s := getState(st)
+	return &MachineManagerAPI{
+		st:         s,
+		authorizer: authorizer,
+		check:      common.NewBlockChecker(s),
+	}, nil
+}
+
+// AddMachines adds new machines with the supplied parameters.
+func (mm *MachineManagerAPI) AddMachines(args params.AddMachines) (params.AddMachinesResults, error) {
+	results := params.AddMachinesResults{
+		Machines: make([]params.AddMachinesResult, len(args.MachineParams)),
+	}
+	if err := mm.check.ChangeAllowed(); err != nil {
+		return results, errors.Trace(err)
+	}
+	for i, p := range args.MachineParams {
+		m, err := mm.addOneMachine(p)
+		results.Machines[i].Error = common.ServerError(err)
+		if err == nil {
+			results.Machines[i].Machine = m.Id()
+		}
+	}
+	return results, nil
+}
+
+func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Machine, error) {
+	if p.ParentId != "" && p.ContainerType == "" {
+		return nil, fmt.Errorf("parent machine specified without container type")
+	}
+	if p.ContainerType != "" && p.Placement != nil {
+		return nil, fmt.Errorf("container type and placement are mutually exclusive")
+	}
+	if p.Placement != nil {
+		// Extract container type and parent from container placement directives.
+		containerType, err := instance.ParseContainerType(p.Placement.Scope)
+		if err == nil {
+			p.ContainerType = containerType
+			p.ParentId = p.Placement.Directive
+			p.Placement = nil
+		}
+	}
+
+	if p.ContainerType != "" || p.Placement != nil {
+		// Guard against dubious client by making sure that
+		// the following attributes can only be set when we're
+		// not using placement.
+		p.InstanceId = ""
+		p.Nonce = ""
+		p.HardwareCharacteristics = instance.HardwareCharacteristics{}
+		p.Addrs = nil
+	}
+
+	if p.Series == "" {
+		conf, err := mm.st.EnvironConfig()
+		if err != nil {
+			return nil, err
+		}
+		p.Series = config.PreferredSeries(conf)
+	}
+
+	var placementDirective string
+	if p.Placement != nil {
+		env, err := mm.st.Environment()
+		if err != nil {
+			return nil, err
+		}
+		// For 1.21 we should support both UUID and name, and with 1.22
+		// just support UUID
+		if p.Placement.Scope != env.Name() && p.Placement.Scope != env.UUID() {
+			return nil, fmt.Errorf("invalid environment name %q", p.Placement.Scope)
+		}
+		placementDirective = p.Placement.Directive
+	}
+
+	volumes := make([]state.MachineVolumeParams, 0, len(p.Disks))
+	for _, cons := range p.Disks {
+		if cons.Count == 0 {
+			return nil, errors.Errorf("invalid volume params: count not specified")
+		}
+		// Pool and Size are validated by AddMachineX.
+		volumeParams := state.VolumeParams{
+			Pool: cons.Pool,
+			Size: cons.Size,
+		}
+		volumeAttachmentParams := state.VolumeAttachmentParams{}
+		for i := uint64(0); i < cons.Count; i++ {
+			volumes = append(volumes, state.MachineVolumeParams{
+				volumeParams, volumeAttachmentParams,
+			})
+		}
+	}
+
+	jobs, err := stateJobs(p.Jobs)
+	if err != nil {
+		return nil, err
+	}
+	template := state.MachineTemplate{
+		Series:      p.Series,
+		Constraints: p.Constraints,
+		Volumes:     volumes,
+		InstanceId:  p.InstanceId,
+		Jobs:        jobs,
+		Nonce:       p.Nonce,
+		HardwareCharacteristics: p.HardwareCharacteristics,
+		Addresses:               params.NetworkAddresses(p.Addrs),
+		Placement:               placementDirective,
+	}
+	if p.ContainerType == "" {
+		return mm.st.AddOneMachine(template)
+	}
+	if p.ParentId != "" {
+		return mm.st.AddMachineInsideMachine(template, p.ParentId, p.ContainerType)
+	}
+	return mm.st.AddMachineInsideNewMachine(template, template, p.ContainerType)
+}
+
+func stateJobs(jobs []multiwatcher.MachineJob) ([]state.MachineJob, error) {
+	newJobs := make([]state.MachineJob, len(jobs))
+	for i, job := range jobs {
+		newJob, err := params.MachineJobFromParams(job)
+		if err != nil {
+			return nil, err
+		}
+		newJobs[i] = newJob
+	}
+	return newJobs, nil
+}

--- a/apiserver/machinemanager/machinemanager_test.go
+++ b/apiserver/machinemanager/machinemanager_test.go
@@ -1,0 +1,170 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager_test
+
+import (
+	"errors"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/machinemanager"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/storage"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&MachineManagerSuite{})
+
+type MachineManagerSuite struct {
+	coretesting.BaseSuite
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	st         *mockState
+	api        *machinemanager.MachineManagerAPI
+}
+
+func (s *MachineManagerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.resources = common.NewResources()
+	tag := names.NewUserTag("admin")
+	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
+	s.st = &mockState{}
+	machinemanager.PatchState(s, s.st)
+
+	var err error
+	s.api, err = machinemanager.NewMachineManagerAPI(nil, nil, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MachineManagerSuite) TestAddMachines(c *gc.C) {
+	apiParams := make([]params.AddMachineParams, 2)
+	for i := range apiParams {
+		apiParams[i] = params.AddMachineParams{
+			Series: "trusty",
+			Jobs:   []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+		}
+	}
+	apiParams[0].Disks = []storage.Constraints{{Size: 1, Count: 2}, {Size: 2, Count: 1}}
+	apiParams[1].Disks = []storage.Constraints{{Size: 1, Count: 2, Pool: "three"}}
+	machines, err := s.api.AddMachines(params.AddMachines{MachineParams: apiParams})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines.Machines, gc.HasLen, 2)
+	c.Assert(s.st.calls, gc.Equals, 2)
+	c.Assert(s.st.machines, jc.DeepEquals, []state.MachineTemplate{
+		{
+			Series: "trusty",
+			Jobs:   []state.MachineJob{state.JobHostUnits},
+			Volumes: []state.MachineVolumeParams{
+				{
+					Volume:     state.VolumeParams{Pool: "", Size: 1},
+					Attachment: state.VolumeAttachmentParams{ReadOnly: false},
+				},
+				{
+					Volume:     state.VolumeParams{Pool: "", Size: 1},
+					Attachment: state.VolumeAttachmentParams{ReadOnly: false},
+				},
+				{
+					Volume:     state.VolumeParams{Pool: "", Size: 2},
+					Attachment: state.VolumeAttachmentParams{ReadOnly: false},
+				},
+			},
+		},
+		{
+			Series: "trusty",
+			Jobs:   []state.MachineJob{state.JobHostUnits},
+			Volumes: []state.MachineVolumeParams{
+				{
+					Volume:     state.VolumeParams{Pool: "three", Size: 1},
+					Attachment: state.VolumeAttachmentParams{ReadOnly: false},
+				},
+				{
+					Volume:     state.VolumeParams{Pool: "three", Size: 1},
+					Attachment: state.VolumeAttachmentParams{ReadOnly: false},
+				},
+			},
+		},
+	})
+}
+
+func (s *MachineManagerSuite) TestNewMachineManagerAPINonClient(c *gc.C) {
+	tag := names.NewUnitTag("mysql/0")
+	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: tag}
+	_, err := machinemanager.NewMachineManagerAPI(nil, nil, s.authorizer)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *MachineManagerSuite) TestAddMachinesStateError(c *gc.C) {
+	s.st.err = errors.New("boom")
+	results, err := s.api.AddMachines(params.AddMachines{
+		MachineParams: []params.AddMachineParams{{
+			Series: "trusty",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.AddMachinesResults{
+		Machines: []params.AddMachinesResult{{
+			Error: &params.Error{"boom", ""},
+		}},
+	})
+	c.Assert(s.st.calls, gc.Equals, 1)
+}
+
+type mockState struct {
+	calls    int
+	machines []state.MachineTemplate
+	err      error
+}
+
+func (st *mockState) AddOneMachine(template state.MachineTemplate) (*state.Machine, error) {
+	st.calls++
+	st.machines = append(st.machines, template)
+	m := state.Machine{}
+	return &m, st.err
+}
+
+func (st *mockState) GetBlockForType(t state.BlockType) (state.Block, bool, error) {
+	return &mockBlock{}, false, nil
+}
+
+func (st *mockState) EnvironConfig() (*config.Config, error) {
+	panic("not implemented")
+}
+
+func (st *mockState) Environment() (*state.Environment, error) {
+	panic("not implemented")
+}
+
+func (st *mockState) AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error) {
+	panic("not implemented")
+}
+
+func (st *mockState) AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (*state.Machine, error) {
+	panic("not implemented")
+}
+
+type mockBlock struct{}
+
+func (st *mockBlock) Id() string {
+	return "id"
+}
+
+func (st *mockBlock) Tag() (names.Tag, error) {
+	return names.ParseTag("machine-1")
+}
+
+func (st *mockBlock) Type() state.BlockType {
+	return state.ChangeBlock
+}
+
+func (st *mockBlock) Message() string {
+	return "not allowed"
+}

--- a/apiserver/machinemanager/package_test.go
+++ b/apiserver/machinemanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/machinemanager/state.go
+++ b/apiserver/machinemanager/state.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machinemanager
+
+import (
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+)
+
+type stateInterface interface {
+	EnvironConfig() (*config.Config, error)
+	Environment() (*state.Environment, error)
+	GetBlockForType(t state.BlockType) (state.Block, bool, error)
+	AddOneMachine(template state.MachineTemplate) (*state.Machine, error)
+	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
+	AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (*state.Machine, error)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) EnvironConfig() (*config.Config, error) {
+	return s.State.EnvironConfig()
+}
+
+func (s stateShim) Environment() (*state.Environment, error) {
+	return s.State.Environment()
+}
+
+func (s stateShim) GetBlockForType(t state.BlockType) (state.Block, bool, error) {
+	return s.State.GetBlockForType(t)
+}
+
+func (s stateShim) AddOneMachine(template state.MachineTemplate) (*state.Machine, error) {
+	return s.State.AddOneMachine(template)
+}
+
+func (s stateShim) AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error) {
+	return s.State.AddMachineInsideNewMachine(template, parentTemplate, containerType)
+}
+
+func (s stateShim) AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (*state.Machine, error) {
+	return s.State.AddMachineInsideMachine(template, parentId, containerType)
+}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -131,8 +131,6 @@ type AddMachineParams struct {
 
 	// Disks describes constraints for disks that must be attached to
 	// the machine when it is provisioned.
-	//
-	// NOTE: this is ignored unless the "storage" feature flag is enabled.
 	Disks []storage.Constraints `json:"Disks"`
 
 	// If Placement is non-nil, it contains a placement directive

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
@@ -120,23 +119,6 @@ type DestroyRelation struct {
 type AddCharmWithAuthorization struct {
 	URL                string
 	CharmStoreMacaroon *macaroon.Macaroon
-}
-
-// MachineJobFromParams returns the job corresponding to multiwatcher.MachineJob.
-func MachineJobFromParams(job multiwatcher.MachineJob) (state.MachineJob, error) {
-	switch job {
-	case multiwatcher.JobHostUnits:
-		return state.JobHostUnits, nil
-	case multiwatcher.JobManageEnviron:
-		return state.JobManageEnviron, nil
-	case multiwatcher.JobManageNetworking:
-		return state.JobManageNetworking, nil
-	case multiwatcher.JobManageStateDeprecated:
-		// Deprecated in 1.18.
-		return state.JobManageStateDeprecated, nil
-	default:
-		return -1, errors.Errorf("invalid machine job %q", job)
-	}
 }
 
 // AddMachineParams encapsulates the parameters used to create a new machine.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
@@ -119,6 +120,23 @@ type DestroyRelation struct {
 type AddCharmWithAuthorization struct {
 	URL                string
 	CharmStoreMacaroon *macaroon.Macaroon
+}
+
+// MachineJobFromParams returns the job corresponding to multiwatcher.MachineJob.
+func MachineJobFromParams(job multiwatcher.MachineJob) (state.MachineJob, error) {
+	switch job {
+	case multiwatcher.JobHostUnits:
+		return state.JobHostUnits, nil
+	case multiwatcher.JobManageEnviron:
+		return state.JobManageEnviron, nil
+	case multiwatcher.JobManageNetworking:
+		return state.JobManageNetworking, nil
+	case multiwatcher.JobManageStateDeprecated:
+		// Deprecated in 1.18.
+		return state.JobManageStateDeprecated, nil
+	default:
+		return -1, errors.Errorf("invalid machine job %q", job)
+	}
 }
 
 // AddMachineParams encapsulates the parameters used to create a new machine.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -188,6 +188,11 @@ type DestroyMachines struct {
 	Force        bool
 }
 
+// ServicesDeploy holds the parameters for deploying one or more services.
+type ServicesDeploy struct {
+	Services []ServiceDeploy
+}
+
 // ServiceDeploy holds the parameters for making the ServiceDeploy call.
 type ServiceDeploy struct {
 	ServiceName   string

--- a/apiserver/service/export_test.go
+++ b/apiserver/service/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+var ParseSettingsCompatible = parseSettingsCompatible

--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -5,14 +5,17 @@
 package service
 
 import (
-	"github.com/juju/loggo"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	jjj "github.com/juju/juju/juju"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 )
-
-var logger = loggo.GetLogger("juju.apiserver.service")
 
 func init() {
 	common.RegisterStandardFacade("Service", 1, NewAPI)
@@ -26,6 +29,7 @@ type Service interface {
 // API implements the service interface and is the concrete
 // implementation of the api end point.
 type API struct {
+	check      *common.BlockChecker
 	state      *state.State
 	authorizer common.Authorizer
 }
@@ -43,6 +47,7 @@ func NewAPI(
 	return &API{
 		state:      st,
 		authorizer: authorizer,
+		check:      common.NewBlockChecker(st),
 	}, nil
 }
 
@@ -66,4 +71,194 @@ func (api *API) SetMetricCredentials(args params.ServiceMetricCredentials) (para
 		}
 	}
 	return result, nil
+}
+
+// ServicesDeploy fetches the charms from the charm store and deploys them.
+func (api *API) ServicesDeploy(args params.ServicesDeploy) (params.ErrorResults, error) {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Services)),
+	}
+	if err := api.check.ChangeAllowed(); err != nil {
+		return result, errors.Trace(err)
+	}
+	owner := api.authorizer.GetAuthTag().String()
+	for i, arg := range args.Services {
+		err := DeployService(api.state, owner, arg)
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+// DeployService fetches the charm from the charm store and deploys it.
+// The logic has been factored out into a common function which is called by
+// both the legacy API on the client facade, as well as the new service facade.
+func DeployService(st *state.State, owner string, args params.ServiceDeploy) error {
+	curl, err := charm.ParseURL(args.CharmUrl)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if curl.Revision < 0 {
+		return errors.Errorf("charm url must include revision")
+	}
+
+	if args.ToMachineSpec != "" && names.IsValidMachine(args.ToMachineSpec) {
+		_, err = st.Machine(args.ToMachineSpec)
+		if err != nil {
+			return errors.Annotatef(err, `cannot deploy "%v" to machine %v`, args.ServiceName, args.ToMachineSpec)
+		}
+	}
+
+	// Try to find the charm URL in state first.
+	ch, err := st.Charm(curl)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	storageConstraints := args.Storage
+	if storageConstraints == nil {
+		storageConstraints = make(map[string]storage.Constraints)
+	}
+	// Validate the storage parameters against the charm metadata,
+	// and ensure there are no conflicting parameters.
+	if err := validateCharmStorage(args, ch); err != nil {
+		return err
+	}
+	// Handle stores with no corresponding constraints.
+	for store, charmStorage := range ch.Meta().Storage {
+		if _, ok := args.Storage[store]; ok {
+			// TODO(axw) if pool is not specified, we should set it to
+			// the environment's default pool.
+			continue
+		}
+		if charmStorage.Shared {
+			// TODO(axw) get the environment's default shared storage
+			// pool, and create constraints here.
+			return errors.Errorf(
+				"no constraints specified for shared charm storage %q",
+				store,
+			)
+		}
+		if charmStorage.CountMin <= 0 {
+			continue
+		}
+		if charmStorage.Type != charm.StorageFilesystem {
+			// TODO(axw) clarify what the rules are for "block" kind when
+			// no constraints are specified. For "filesystem" we use rootfs.
+			return errors.Errorf(
+				"no constraints specified for %v charm storage %q",
+				charmStorage.Type,
+				store,
+			)
+		}
+		storageConstraints[store] = storage.Constraints{
+			// The pool is the provider type since rootfs provider has no configuration.
+			Pool:  string(provider.RootfsProviderType),
+			Count: uint64(charmStorage.CountMin),
+		}
+	}
+
+	var settings charm.Settings
+	if len(args.ConfigYAML) > 0 {
+		settings, err = ch.Config().ParseSettingsYAML([]byte(args.ConfigYAML), args.ServiceName)
+	} else if len(args.Config) > 0 {
+		// Parse config in a compatible way (see function comment).
+		settings, err = parseSettingsCompatible(ch, args.Config)
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Convert network tags to names for any given networks.
+	requestedNetworks, err := networkTagsToNames(args.Networks)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	_, err = jjj.DeployService(st,
+		jjj.DeployServiceParams{
+			ServiceName: args.ServiceName,
+			// TODO(dfc) ServiceOwner should be a tag
+			ServiceOwner:   owner,
+			Charm:          ch,
+			NumUnits:       args.NumUnits,
+			ConfigSettings: settings,
+			Constraints:    args.Constraints,
+			ToMachineSpec:  args.ToMachineSpec,
+			Networks:       requestedNetworks,
+			Storage:        storageConstraints,
+		})
+	return err
+}
+
+// ServiceSetSettingsStrings updates the settings for the given service,
+// taking the configuration from a map of strings.
+func ServiceSetSettingsStrings(service *state.Service, settings map[string]string) error {
+	ch, _, err := service.Charm()
+	if err != nil {
+		return err
+	}
+	// Parse config in a compatible way (see function comment).
+	changes, err := parseSettingsCompatible(ch, settings)
+	if err != nil {
+		return err
+	}
+	return service.UpdateConfigSettings(changes)
+}
+
+func validateCharmStorage(args params.ServiceDeploy, ch *state.Charm) error {
+	if len(args.Storage) == 0 {
+		return nil
+	}
+	if len(args.ToMachineSpec) != 0 {
+		// TODO(axw) when we support dynamic disk provisioning, we can
+		// relax this. We will need to consult the storage provider to
+		// decide whether or not this is allowable.
+		return errors.New("cannot specify storage and machine placement")
+	}
+	// Remaining validation is done in state.AddService.
+	return nil
+}
+
+func networkTagsToNames(tags []string) ([]string, error) {
+	netNames := make([]string, len(tags))
+	for i, tag := range tags {
+		t, err := names.ParseNetworkTag(tag)
+		if err != nil {
+			return nil, err
+		}
+		netNames[i] = t.Id()
+	}
+	return netNames, nil
+}
+
+// parseSettingsCompatible parses setting strings in a way that is
+// compatible with the behavior before this CL based on the issue
+// http://pad.lv/1194945. Until then setting an option to an empty
+// string caused it to reset to the default value. We now allow
+// empty strings as actual values, but we want to preserve the API
+// behavior.
+func parseSettingsCompatible(ch *state.Charm, settings map[string]string) (charm.Settings, error) {
+	setSettings := map[string]string{}
+	unsetSettings := charm.Settings{}
+	// Split settings into those which set and those which unset a value.
+	for name, value := range settings {
+		if value == "" {
+			unsetSettings[name] = nil
+			continue
+		}
+		setSettings[name] = value
+	}
+	// Validate the settings.
+	changes, err := ch.Config().ParseSettingsStrings(setSettings)
+	if err != nil {
+		return nil, err
+	}
+	// Validate the unsettings and merge them into the changes.
+	unsetSettings, err = ch.Config().ValidateSettings(unsetSettings)
+	if err != nil {
+		return nil, err
+	}
+	for name := range unsetSettings {
+		changes[name] = nil
+	}
+	return changes, nil
 }

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -6,17 +6,27 @@ package service_test
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
 
+	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/service"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/constraints"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
+	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/storage/provider/registry"
+	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing/factory"
 )
 
 type serviceSuite struct {
 	jujutesting.JujuConnSuite
+	apiservertesting.CharmStoreSuite
+	commontesting.BlockHelper
 
 	serviceApi *service.API
 	service    *state.Service
@@ -27,8 +37,24 @@ var _ = gc.Suite(&serviceSuite{})
 
 var _ service.Service = (*service.API)(nil)
 
+func (s *serviceSuite) SetUpSuite(c *gc.C) {
+	s.CharmStoreSuite.SetUpSuite(c)
+	s.JujuConnSuite.SetUpSuite(c)
+}
+
+func (s *serviceSuite) TearDownSuite(c *gc.C) {
+	s.CharmStoreSuite.TearDownSuite(c)
+	s.JujuConnSuite.TearDownSuite(c)
+}
+
 func (s *serviceSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
+	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
+
+	s.CharmStoreSuite.Session = s.JujuConnSuite.Session
+	s.CharmStoreSuite.SetUpTest(c)
+
 	s.service = s.Factory.MakeService(c, nil)
 
 	s.authorizer = apiservertesting.FakeAuthorizer{
@@ -37,6 +63,11 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.serviceApi, err = service.NewAPI(s.State, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TearDownTest(c *gc.C) {
+	s.CharmStoreSuite.TearDownTest(c)
+	s.JujuConnSuite.TearDownTest(c)
 }
 
 func (s *serviceSuite) TestSetMetricCredentials(c *gc.C) {
@@ -108,4 +139,201 @@ func (s *serviceSuite) TestSetMetricCredentials(c *gc.C) {
 			}
 		}
 	}
+}
+
+func (s *serviceSuite) TestCompatibleSettingsParsing(c *gc.C) {
+	// Test the exported settings parsing in a compatible way.
+	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
+	svc, err := s.State.Service("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+	ch, _, err := svc.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.URL().String(), gc.Equals, "local:quantal/dummy-1")
+
+	// Empty string will be returned as nil.
+	options := map[string]string{
+		"title":    "foobar",
+		"username": "",
+	}
+	settings, err := service.ParseSettingsCompatible(ch, options)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, gc.DeepEquals, charm.Settings{
+		"title":    "foobar",
+		"username": nil,
+	})
+
+	// Illegal settings lead to an error.
+	options = map[string]string{
+		"yummy": "didgeridoo",
+	}
+	settings, err = service.ParseSettingsCompatible(ch, options)
+	c.Assert(err, gc.ErrorMatches, `unknown option "yummy"`)
+}
+
+func setupStoragePool(c *gc.C, st *state.State) {
+	pm := poolmanager.New(state.NewStateSettings(st))
+	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.UpdateEnvironConfig(map[string]interface{}{
+		"storage-default-block-source": "loop-pool",
+	}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) uploadCharm(c *gc.C, url, name string) (*charm.URL, charm.Charm) {
+	id := charm.MustParseReference(url)
+	promulgated := false
+	if id.User == "" {
+		id.User = "who"
+		promulgated = true
+	}
+	ch := testcharms.Repo.CharmArchive(c.MkDir(), name)
+	id = s.Srv.UploadCharm(c, ch, id, promulgated)
+	curl := (*charm.URL)(id)
+	err := s.APIState.Client().AddCharmWithAuthorization(curl, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	return curl, ch
+}
+
+func (s *serviceSuite) TestClientServiceDeployWithStorage(c *gc.C) {
+	setupStoragePool(c, s.State)
+	curl, ch := s.uploadCharm(c, "utopic/storage-block-10", "storage-block")
+	storageConstraints := map[string]storage.Constraints{
+		"data": {
+			Count: 1,
+			Size:  1024,
+			Pool:  "loop-pool",
+		},
+	}
+
+	var cons constraints.Value
+	args := params.ServiceDeploy{
+		ServiceName: "service",
+		CharmUrl:    curl.String(),
+		NumUnits:    1,
+		Constraints: cons,
+		Storage:     storageConstraints,
+	}
+	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+		Services: []params.ServiceDeploy{args}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{Error: nil}},
+	})
+	svc := apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "service", curl, false, ch, cons)
+	storageConstraintsOut, err := svc.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
+		"data": {
+			Count: 1,
+			Size:  1024,
+			Pool:  "loop-pool",
+		},
+	})
+}
+
+func (s *serviceSuite) TestClientServiceDeployWithInvalidStoragePool(c *gc.C) {
+	setupStoragePool(c, s.State)
+	curl, _ := s.uploadCharm(c, "utopic/storage-block-0", "storage-block")
+	storageConstraints := map[string]storage.Constraints{
+		"data": storage.Constraints{
+			Pool:  "foo",
+			Count: 1,
+			Size:  1024,
+		},
+	}
+
+	var cons constraints.Value
+	args := params.ServiceDeploy{
+		ServiceName: "service",
+		CharmUrl:    curl.String(),
+		NumUnits:    1,
+		Constraints: cons,
+		Storage:     storageConstraints,
+	}
+	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+		Services: []params.ServiceDeploy{args}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `.* pool "foo" not found`)
+}
+
+func (s *serviceSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C) {
+	registry.RegisterProvider("hostloop", &mockStorageProvider{kind: storage.StorageKindBlock})
+	pm := poolmanager.New(state.NewStateSettings(s.State))
+	_, err := pm.Create("host-loop-pool", provider.HostLoopProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	curl, _ := s.uploadCharm(c, "utopic/storage-block-0", "storage-block")
+	storageConstraints := map[string]storage.Constraints{
+		"data": storage.Constraints{
+			Pool:  "host-loop-pool",
+			Count: 1,
+			Size:  1024,
+		},
+	}
+
+	var cons constraints.Value
+	args := params.ServiceDeploy{
+		ServiceName: "service",
+		CharmUrl:    curl.String(),
+		NumUnits:    1,
+		Constraints: cons,
+		Storage:     storageConstraints,
+	}
+	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+		Services: []params.ServiceDeploy{args}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches,
+		`.*pool "host-loop-pool" uses storage provider "hostloop" which is not supported for environments of type "dummy"`)
+}
+
+func (s *serviceSuite) TestClientServiceDeployDefaultFilesystemStorage(c *gc.C) {
+	setupStoragePool(c, s.State)
+	curl, ch := s.uploadCharm(c, "trusty/storage-filesystem-1", "storage-filesystem")
+	var cons constraints.Value
+	args := params.ServiceDeploy{
+		ServiceName: "service",
+		CharmUrl:    curl.String(),
+		NumUnits:    1,
+		Constraints: cons,
+	}
+	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+		Services: []params.ServiceDeploy{args}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{Error: nil}},
+	})
+	svc := apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "service", curl, false, ch, cons)
+	storageConstraintsOut, err := svc.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
+		"data": {
+			Count: 1,
+			Size:  1024,
+			Pool:  "rootfs",
+		},
+	})
+}
+
+type mockStorageProvider struct {
+	storage.Provider
+	kind storage.StorageKind
+}
+
+func (m *mockStorageProvider) Scope() storage.Scope {
+	return storage.ScopeMachine
+}
+
+func (m *mockStorageProvider) Supports(k storage.StorageKind) bool {
+	return k == m.kind
+}
+
+func (m *mockStorageProvider) ValidateConfig(*storage.Config) error {
+	return nil
 }

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
@@ -18,7 +17,7 @@ import (
 )
 
 func init() {
-	common.RegisterStandardFacadeForFeature("Storage", 1, NewAPI, feature.Storage)
+	common.RegisterStandardFacade("Storage", 1, NewAPI)
 }
 
 // API implements the storage interface and is the concrete

--- a/apiserver/testing/fakecharmstore.go
+++ b/apiserver/testing/fakecharmstore.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"fmt"
+	"net/http"
+
+	gitjujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5/charmrepo"
+	"gopkg.in/juju/charmstore.v4"
+	"gopkg.in/juju/charmstore.v4/charmstoretesting"
+	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v0/bakerytest"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/apiserver/client"
+)
+
+type CharmStoreSuite struct {
+	gitjujutesting.CleanupSuite
+
+	Session *mgo.Session
+	// DischargeUser holds the identity of the user
+	// that the 3rd party caveat discharger will issue
+	// macaroons for. If it is empty, no caveats will be discharged.
+	DischargeUser string
+
+	discharger *bakerytest.Discharger
+	Srv        *charmstoretesting.Server
+}
+
+func (s *CharmStoreSuite) SetUpTest(c *gc.C) {
+	s.CleanupSuite.SetUpTest(c)
+
+	s.discharger = bakerytest.NewDischarger(nil, func(_ *http.Request, cond string, arg string) ([]checkers.Caveat, error) {
+		if s.DischargeUser == "" {
+			return nil, fmt.Errorf("discharge denied")
+		}
+		return []checkers.Caveat{
+			checkers.DeclaredCaveat("username", s.DischargeUser),
+		}, nil
+	})
+	s.Srv = charmstoretesting.OpenServer(c, s.Session, charmstore.ServerParams{
+		IdentityLocation: s.discharger.Location(),
+		PublicKeyLocator: s.discharger,
+	})
+	s.PatchValue(&charmrepo.CacheDir, c.MkDir())
+	s.PatchValue(&client.NewCharmStore, func(p charmrepo.NewCharmStoreParams) charmrepo.Interface {
+		p.URL = s.Srv.URL()
+		return charmrepo.NewCharmStore(p)
+	})
+}
+
+func (s *CharmStoreSuite) TearDownTest(c *gc.C) {
+	s.discharger.Close()
+	s.Srv.Close()
+	s.CleanupSuite.TearDownTest(c)
+}

--- a/apiserver/testing/service.go
+++ b/apiserver/testing/service.go
@@ -1,0 +1,50 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/state"
+)
+
+func AssertPrincipalServiceDeployed(c *gc.C, st *state.State, serviceName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Service {
+	service, err := st.Service(serviceName)
+	c.Assert(err, jc.ErrorIsNil)
+	charm, force, err := service.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(force, gc.Equals, forced)
+	c.Assert(charm.URL(), gc.DeepEquals, curl)
+	// When charms are read from state, storage properties are
+	// always deserialised as empty slices if empty or nil, so
+	// update bundle to match (bundle comes from parsing charm
+	// metadata yaml where nil means nil).
+	for name, bundleMeta := range bundle.Meta().Storage {
+		if bundleMeta.Properties == nil {
+			bundleMeta.Properties = []string{}
+			bundle.Meta().Storage[name] = bundleMeta
+		}
+	}
+	c.Assert(charm.Meta(), jc.DeepEquals, bundle.Meta())
+	c.Assert(charm.Config(), jc.DeepEquals, bundle.Config())
+
+	serviceCons, err := service.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(serviceCons, gc.DeepEquals, cons)
+	units, err := service.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, unit := range units {
+		mid, err := unit.AssignedMachineId()
+		c.Assert(err, jc.ErrorIsNil)
+		machine, err := st.Machine(mid)
+		c.Assert(err, jc.ErrorIsNil)
+		machineCons, err := machine.Constraints()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(machineCons, gc.DeepEquals, cons)
+	}
+	return service
+}

--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charm.v5/charmrepo"
@@ -27,9 +26,7 @@ import (
 	"github.com/juju/juju/cmd/juju/service"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/poolmanager"
@@ -218,14 +215,9 @@ func (s *DeploySuite) TestNetworks(c *gc.C) {
 	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cpu-cores=2 networks=net1,net0,^net3,^net4"))
 }
 
-func (s *DeploySuite) TestStorageWithoutFeatureFlag(c *gc.C) {
-	err := runDeploy(c, "local:storage-block", "--storage", "data=1G")
-	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: --storage")
-}
-
+// TODO(wallyworld) - add another test that deploy with storage fails for older environments
+// (need deploy client to be refactored to use API stub)
 func (s *DeploySuite) TestStorage(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -170,10 +170,6 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	if len(c.Disks) > 0 && client.BestAPIVersion() < 2 {
-		return errors.New("this version of Juju does not support adding machines with disks")
-	}
-
 	logger.Infof("load config")
 	var config *config.Config
 	if defaultStore, err := configstore.Default(); err != nil {

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -212,7 +212,7 @@ func (s *AddMachineSuite) TestAddMachineWithDisks(c *gc.C) {
 }
 
 func (s *AddMachineSuite) TestAddMachineWithDisksUnsupported(c *gc.C) {
-	s.fake.addError = &params.Error{"MachineNetworkConfig", params.CodeNotImplemented}
+	s.fake.addError = &params.Error{"AddMachineWithDisks", params.CodeNotImplemented}
 	_, err := s.run(c, "--disks", "2,1G", "--disks", "2G")
 	c.Assert(err, gc.ErrorMatches, "cannot add machines with disks: not supported by the API server")
 }

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -10,9 +10,10 @@ var (
 )
 
 // NewAddCommand returns an AddCommand with the api provided as specified.
-func NewAddCommand(api AddMachineAPI) *AddCommand {
+func NewAddCommand(api AddMachineAPI, mmApi MachineManagerAPI) *AddCommand {
 	return &AddCommand{
-		api: api,
+		api:               api,
+		machineManagerAPI: mmApi,
 	}
 }
 

--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
 	// Import the providers.
@@ -205,9 +204,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(wrapEnvCommand(&block.UnblockCommand{}))
 
 	// Manage storage
-	if featureflag.Enabled(feature.Storage) {
-		r.Register(storage.NewSuperCommand())
-	}
+	r.Register(storage.NewSuperCommand())
 }
 
 // envCmdWrapper is a struct that wraps an environment command and lets us handle

--- a/cmd/juju/main_test.go
+++ b/cmd/juju/main_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/service"
 	cmdtesting "github.com/juju/juju/cmd/testing"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
@@ -262,9 +261,8 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	// First check default commands, and then check commands that are
 	// activated by feature flags.
 
-	// remove "storage" for the first test because the feature is not
-	// enabled.
-	devFeatures := []string{feature.Storage}
+	// Here we can add feature flags for any commands we want to hide by default.
+	devFeatures := []string{}
 
 	// remove features behind dev_flag for the first test
 	// since they are not enabled.

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/proxy"
 	"github.com/juju/utils/set"
 	"github.com/juju/utils/symlink"
@@ -46,7 +45,6 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
-	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -1145,15 +1143,6 @@ func (s *MachineSuite) TestMachineAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineAgentRunsDiskManagerWorker(c *gc.C) {
-	// The disk manager should only run with the feature flag set.
-	s.testMachineAgentRunsDiskManagerWorker(c, false, coretesting.ShortWait)
-
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	s.testMachineAgentRunsDiskManagerWorker(c, true, coretesting.LongWait)
-}
-
-func (s *MachineSuite) testMachineAgentRunsDiskManagerWorker(c *gc.C, shouldRun bool, timeout time.Duration) {
 	// Start the machine agent.
 	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
 	a := s.newAgent(c, m)
@@ -1170,20 +1159,12 @@ func (s *MachineSuite) testMachineAgentRunsDiskManagerWorker(c *gc.C, shouldRun 
 	// Wait for worker to be started.
 	select {
 	case <-started:
-		if !shouldRun {
-			c.Fatalf("disk manager should not run without feature flag")
-		}
-	case <-time.After(timeout):
-		if shouldRun {
-			c.Fatalf("timeout while waiting for diskmanager worker to start")
-		}
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout while waiting for diskmanager worker to start")
 	}
 }
 
 func (s *MachineSuite) TestDiskManagerWorkerUpdatesState(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-
 	expected := []storage.BlockDevice{{DeviceName: "whatever"}}
 	s.PatchValue(&diskmanager.DefaultListBlockDevices, func() ([]storage.BlockDevice, error) {
 		return expected, nil
@@ -1210,15 +1191,6 @@ func (s *MachineSuite) TestDiskManagerWorkerUpdatesState(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineAgentRunsMachineStorageWorker(c *gc.C) {
-	// The storage worker should only run with the feature flag set.
-	s.testMachineAgentRunsMachineStorageWorker(c, false, coretesting.ShortWait)
-
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	s.testMachineAgentRunsMachineStorageWorker(c, true, coretesting.LongWait)
-}
-
-func (s *MachineSuite) testMachineAgentRunsMachineStorageWorker(c *gc.C, shouldRun bool, timeout time.Duration) {
 	// Start the machine agent.
 	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
 	a := s.newAgent(c, m)
@@ -1245,23 +1217,12 @@ func (s *MachineSuite) testMachineAgentRunsMachineStorageWorker(c *gc.C, shouldR
 	// Wait for worker to be started.
 	select {
 	case <-started:
-		if !shouldRun {
-			c.Fatalf("storage worker should not run without feature flag")
-		}
-	case <-time.After(timeout):
-		if shouldRun {
-			c.Fatalf("timeout while waiting for storage worker to start")
-		}
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout while waiting for storage worker to start")
 	}
 }
 
 func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	s.testMachineAgentRunsEnvironStorageWorkers(c, true, coretesting.LongWait)
-}
-
-func (s *MachineSuite) testMachineAgentRunsEnvironStorageWorkers(c *gc.C, shouldRun bool, timeout time.Duration) {
 	// Start the machine agent.
 	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
 	a := s.newAgent(c, m)
@@ -1301,14 +1262,9 @@ func (s *MachineSuite) testMachineAgentRunsEnvironStorageWorkers(c *gc.C, should
 	// Wait for worker to be started.
 	select {
 	case <-started:
-		if !shouldRun {
-			c.Fatalf("storage worker should not run without feature flag")
-		}
 		c.Assert(numWorkers, gc.Equals, 2)
-	case <-time.After(timeout):
-		if shouldRun {
-			c.Fatalf("timeout while waiting for storage worker to start")
-		}
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout while waiting for storage worker to start")
 	}
 }
 
@@ -1595,22 +1551,13 @@ func (s *MachineSuite) TestMachineAgentRestoreRequiresPrepare(c *gc.C) {
 }
 
 func (s *MachineSuite) TestNewEnvironmentStartsNewWorkers(c *gc.C) {
-	s.testNewEnvironmentStartsNewWorkers(c, perEnvSingularWorkers)
-}
-
-func (s *MachineSuite) TestNewEnvironmentStartsNewWorkersStorageEnabled(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	expect := make([]string, 0, len(perEnvSingularWorkers)+1)
+	expectedWorkers := make([]string, 0, len(perEnvSingularWorkers)+1)
 	for _, w := range perEnvSingularWorkers {
-		expect = append(expect, w)
+		expectedWorkers = append(expectedWorkers, w)
 		if w == "environ-provisioner" {
-			expect = append(expect, "environ-storageprovisioner")
+			expectedWorkers = append(expectedWorkers, "environ-storageprovisioner")
 		}
 	}
-	s.testNewEnvironmentStartsNewWorkers(c, expect)
-}
-
-func (s *MachineSuite) testNewEnvironmentStartsNewWorkers(c *gc.C, expectedWorkers []string) {
 	s.PatchValue(&watcher.Period, 100*time.Millisecond)
 
 	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -892,11 +892,11 @@ func (s *UpgradeSuite) attemptRestrictedAPIAsUser(c *gc.C, conf agent.Config) er
 
 	// this call should always work
 	var result api.Status
-	err = apiState.APICall("Client", 0, "", "FullStatus", nil, &result)
+	err = apiState.APICall("Client", 2, "", "FullStatus", nil, &result)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// this call should only work if API is not restricted
-	return apiState.APICall("Client", 0, "", "WatchAll", nil, nil)
+	return apiState.APICall("Client", 2, "", "WatchAll", nil, nil)
 }
 
 func canLoginToAPIAsMachine(c *gc.C, fromConf, toConf agent.Config) bool {

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -892,11 +892,11 @@ func (s *UpgradeSuite) attemptRestrictedAPIAsUser(c *gc.C, conf agent.Config) er
 
 	// this call should always work
 	var result api.Status
-	err = apiState.APICall("Client", 2, "", "FullStatus", nil, &result)
+	err = apiState.APICall("Client", 0, "", "FullStatus", nil, &result)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// this call should only work if API is not restricted
-	return apiState.APICall("Client", 2, "", "WatchAll", nil, nil)
+	return apiState.APICall("Client", 0, "", "WatchAll", nil, nil)
 }
 
 func canLoginToAPIAsMachine(c *gc.C, fromConf, toConf agent.Config) bool {

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -14,10 +14,6 @@ package feature
 // to the apiserver endpoints, api client and CLI commands.
 const JES = "jes"
 
-// Storage is the name of the feature to enable storage commands
-// and server-side functionality.
-const Storage = "storage"
-
 // LogErrorStack is a developer feature flag to have the LoggedErrorStack
 // function in the utils package write out the error stack as defined by the
 // errors package to the logger.  The ability to log the error stack is very

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/cmd/envcmd"
 	cmdstorage "github.com/juju/juju/cmd/juju/storage"
-	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/state"
@@ -68,8 +67,6 @@ type cmdStorageSuite struct {
 
 func (s *cmdStorageSuite) SetUpTest(c *gc.C) {
 	s.RepoSuite.SetUpTest(c)
-	s.SetFeatureFlags(feature.Storage)
-
 	setupTestStorageSupport(c, s.State)
 }
 

--- a/provider/cloudsigma/config.go
+++ b/provider/cloudsigma/config.go
@@ -94,7 +94,7 @@ func validateConfig(cfg *config.Config, old *environConfig) (*environConfig, err
 	}
 	for field := range configFields {
 		if newAttrs[field] == "" {
-			return nil, errors.Errorf("rs: must not be empty", field)
+			return nil, errors.Errorf("%s: must not be empty", field)
 		}
 	}
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/storage/provider/registry"
 )
 
 type CleanupSuite struct {
@@ -354,8 +356,9 @@ func (s *CleanupSuite) TestCleanupStorage(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
 	ch := s.AddTestingCharm(c, "storage-block")
+	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
 	storage := map[string]state.StorageConstraints{
-		"data": makeStorageCons("block", 1024, 1),
+		"data": makeStorageCons("loop", 1024, 1),
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
 	u, err := service.AddUnit()

--- a/state/storage.go
+++ b/state/storage.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
-	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/mgo.v2"
@@ -18,7 +17,6 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
@@ -681,10 +679,6 @@ func storageKind(storageType charm.StorageType) storage.StorageKind {
 }
 
 func validateStorageConstraints(st *State, allCons map[string]StorageConstraints, charmMeta *charm.Meta) error {
-	// TODO(axw) stop checking feature flag once storage has graduated.
-	if !featureflag.Enabled(feature.Storage) {
-		return nil
-	}
 	for name, cons := range allCons {
 		charmStorage, ok := charmMeta.Storage[name]
 		if !ok {
@@ -827,10 +821,6 @@ var ErrNoDefaultStoragePool = fmt.Errorf("no storage pool specifed and no defaul
 // addDefaultStorageConstraints fills in default constraint values, replacing any empty/missing values
 // in the specified constraints.
 func addDefaultStorageConstraints(st *State, allCons map[string]StorageConstraints, charmMeta *charm.Meta) error {
-	// TODO(axw) stop checking feature flag once storage has graduated.
-	if !featureflag.Enabled(feature.Storage) {
-		return nil
-	}
 	conf, err := st.EnvironConfig()
 	if err != nil {
 		return errors.Trace(err)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -6,13 +6,10 @@ package state_test
 import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
@@ -61,10 +58,6 @@ func (s *StorageStateSuiteBase) SetUpSuite(c *gc.C) {
 func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 
-	// This suite is all about storage, so enable the feature by default.
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-
 	// Create a default pool for block devices.
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
@@ -110,20 +103,6 @@ func (s *StorageStateSuite) storageInstanceExists(c *gc.C, tag names.StorageTag)
 
 func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
 	return state.StorageConstraints{Pool: pool, Size: size, Count: count}
-}
-
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsWithoutFeature(c *gc.C) {
-	// Disable the storage feature, and ensure we can deploy a service from
-	// a charm that defines storage, without specifying the storage constraints.
-	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "")
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-
-	ch := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	storageConstraints, err := service.StorageConstraints()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(storageConstraints, gc.HasLen, 0)
 }
 
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {

--- a/storage/poolmanager/defaultpool_test.go
+++ b/storage/poolmanager/defaultpool_test.go
@@ -5,11 +5,8 @@ package poolmanager_test
 
 import (
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -23,9 +20,6 @@ type defaultStoragePoolsSuite struct {
 var _ = gc.Suite(&defaultStoragePoolsSuite{})
 
 func (s *defaultStoragePoolsSuite) TestDefaultStoragePools(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-
 	p1, err := storage.NewConfig("pool1", storage.ProviderType("loop"), map[string]interface{}{"1": "2"})
 	p2, err := storage.NewConfig("pool2", storage.ProviderType("tmpfs"), map[string]interface{}{"3": "4"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -5,29 +5,21 @@ package upgrades
 
 import (
 	"github.com/juju/names"
-	"github.com/juju/utils/featureflag"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/uniter"
 )
 
 // stateStepsFor123 returns upgrade steps for Juju 1.23 that manipulate state directly.
 func stateStepsFor123() []Step {
-	var steps []Step
-	// TODO(axw) stop checking feature flag once storage has graduated.
-	if featureflag.Enabled(feature.Storage) {
-		steps = append(steps,
-			&upgradeStep{
-				description: "add default storage pools",
-				targets:     []Target{DatabaseMaster},
-				run: func(context Context) error {
-					return addDefaultStoragePools(context.State())
-				},
+	return []Step{
+		&upgradeStep{
+			description: "add default storage pools",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return addDefaultStoragePools(context.State())
 			},
-		)
-	}
-	steps = append(steps,
+		},
 		&upgradeStep{
 			description: "drop old mongo indexes",
 			targets:     []Target{DatabaseMaster},
@@ -72,8 +64,7 @@ func stateStepsFor123() []Step {
 				return state.LowerCaseEnvUsersID(context.State())
 			},
 		},
-	)
-	return steps
+	}
 }
 
 // stepsFor123 returns upgrade steps for Juju 1.23 that only need the API.

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -4,11 +4,8 @@
 package upgrades_test
 
 import (
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
@@ -20,8 +17,6 @@ type steps123Suite struct {
 var _ = gc.Suite(&steps123Suite{})
 
 func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	expected := []string{
 		"add default storage pools",
 		"drop old mongo indexes",

--- a/upgrades/storage_test.go
+++ b/upgrades/storage_test.go
@@ -5,11 +5,8 @@ package upgrades_test
 
 import (
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/state"
@@ -24,9 +21,6 @@ type defaultStoragePoolsSuite struct {
 var _ = gc.Suite(&defaultStoragePoolsSuite{})
 
 func (s *defaultStoragePoolsSuite) TestDefaultStoragePools(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-
 	err := upgrades.AddDefaultStoragePools(s.State)
 	settings := state.NewStateSettings(s.State)
 	err = poolmanager.AddDefaultStoragePools(settings)

--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -604,7 +604,7 @@ func (s *FilterSuite) TestStorageEvents(c *gc.C) {
 	storageCharm := s.AddTestingCharm(c, "storage-block2")
 	svc := s.AddTestingServiceWithStorage(c, "storage-block2", storageCharm, map[string]state.StorageConstraints{
 		"multi1to10": state.StorageConstraints{Pool: "loop", Size: 1024, Count: 1},
-		"multi2up":   state.StorageConstraints{Pool: "loop", Size: 1024, Count: 2},
+		"multi2up":   state.StorageConstraints{Pool: "loop", Size: 2048, Count: 2},
 	})
 	unit, err := svc.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -8,10 +8,7 @@ import (
 	"fmt"
 
 	"github.com/juju/names"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v5/hooks"
-
-	"github.com/juju/juju/feature"
 )
 
 // TODO(fwereade): move these definitions to juju/charm/hooks.
@@ -55,13 +52,10 @@ func (hi Info) Validate() error {
 	case hooks.Action:
 		return fmt.Errorf("hooks.Kind Action is deprecated")
 	case hooks.StorageAttached, hooks.StorageDetached:
-		// TODO: stop checking feature flag once storage has graduated.
-		if featureflag.Enabled(feature.Storage) {
-			if !names.IsValidStorage(hi.StorageId) {
-				return fmt.Errorf("invalid storage ID %q", hi.StorageId)
-			}
-			return nil
+		if !names.IsValidStorage(hi.StorageId) {
+			return fmt.Errorf("invalid storage ID %q", hi.StorageId)
 		}
+		return nil
 	// TODO(fwereade): define these in charm/hooks...
 	case LeaderElected, LeaderDeposed, LeaderSettingsChanged:
 		return nil

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -5,12 +5,9 @@ package hook_test
 
 import (
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5/hooks"
 
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/hook"
 )
@@ -56,8 +53,6 @@ var validateTests = []struct {
 }
 
 func (s *InfoSuite) TestValidate(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	for i, t := range validateTests {
 		c.Logf("test %d", i)
 		err := t.info.Validate()
@@ -67,11 +62,4 @@ func (s *InfoSuite) TestValidate(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		}
 	}
-}
-
-func (s *InfoSuite) TestStorageHooksRequireFeatureFlag(c *gc.C) {
-	err := hook.Info{Kind: hooks.StorageAttached}.Validate()
-	c.Assert(err, gc.ErrorMatches, `unknown hook kind "storage-attached"`)
-	err = hook.Info{Kind: hooks.StorageDetached}.Validate()
-	c.Assert(err, gc.ErrorMatches, `unknown hook kind "storage-detached"`)
 }

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -13,14 +13,11 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/fs"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5/hooks"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
@@ -47,8 +44,6 @@ func (fakeTracker) ServiceName() string {
 }
 
 func (s *FactorySuite) SetUpTest(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.HookContextSuite.SetUpTest(c)
 	s.paths = NewRealPaths(c)
 	s.membership = map[int][]string{}
@@ -335,8 +330,6 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	rnr, err := factory.NewHookRunner(hook.Info{
 		Kind:      hooks.StorageAttached,
 		StorageId: "data/0",

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -18,9 +18,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/exec"
-	"github.com/juju/utils/featureflag"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/sockets"
 )
 
@@ -68,9 +66,7 @@ func allEnabledCommands() map[string]creator {
 		}
 	}
 	add(baseCommands)
-	if featureflag.Enabled(feature.Storage) {
-		add(storageCommands)
-	}
+	add(storageCommands)
 	add(leaderCommands)
 	return all
 }

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -17,12 +17,9 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/exec"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
@@ -225,8 +222,6 @@ var newCommandTests = []struct {
 }
 
 func (s *NewCommandSuite) TestNewCommand(c *gc.C) {
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	ctx := s.GetHookContext(c, 0, "")
 	for _, t := range newCommandTests {
 		com, err := jujuc.NewCommand(ctx, cmdString(t.name))

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -10,12 +10,9 @@ import (
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -25,12 +22,6 @@ type storageGetSuite struct {
 }
 
 var _ = gc.Suite(&storageGetSuite{})
-
-func (s *storageGetSuite) SetUpTest(c *gc.C) {
-	s.ContextSuite.SetUpTest(c)
-	s.SetFeatureFlags(feature.Storage)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-}
 
 var (
 	storageAttributes = map[string]interface{}{


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1449367

Storage is now enabled without needed a feature flag.
To ensure backwards compatibility, a new bulk ServicesDeploy is added to the Service facade. The existing APIs in the Client facade have had the storage bits removed so that these are again the same as older Jujus. If storage is requested, deploy will attempt to use the new API, and will fail if not implemented.
A new AddMachinesV3 API has also been added. This follows the existing pattern already used for bumping the API to allow new add machine functionality. In this case, the V3 version of the API allows adding machines with disks.
A whole lot of refactoring has been done in the apiservices packages to allow common functionality to be shared between the Client and Service facades. It looks like a lot of changes but is mostly moving code around. Some old 1.16 compatability code was removed as part of the refactoring.

Testing included bootstrapping an older environment and checking that attempting to deploy a unit with storage refused.