### PR TITLE
kvm: properly set the hostname

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -141,6 +141,10 @@ func cloudInitUserData(
 	// logged in the host.
 	cloudConfig.AddRunCmd("ifconfig")
 
+	if instanceConfig.ContainerHostname != "" {
+		cloudConfig.SetAttr("hostname", instanceConfig.ContainerHostname)
+	}
+
 	data, err := cloudConfig.RenderYAML()
 	if err != nil {
 		return nil, err

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -141,8 +141,8 @@ func cloudInitUserData(
 	// logged in the host.
 	cloudConfig.AddRunCmd("ifconfig")
 
-	if instanceConfig.ContainerHostname != "" {
-		cloudConfig.SetAttr("hostname", instanceConfig.ContainerHostname)
+	if instanceConfig.MachineContainerHostname != "" {
+		cloudConfig.SetAttr("hostname", instanceConfig.MachineContainerHostname)
 	}
 
 	data, err := cloudConfig.RenderYAML()

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -100,6 +100,10 @@ type InstanceConfig struct {
 	// is.  If the instance is not a container, then the type is "".
 	MachineContainerType instance.ContainerType
 
+	// MachineContainerHostname specifies the hostname to be used with the
+	// cloud config for the instance. If this is not set, hostname uses the default.
+	MachineContainerHostname string
+
 	// Networks holds a list of networks the instances should be on.
 	Networks []string
 
@@ -166,10 +170,6 @@ type InstanceConfig struct {
 	// instances. If enabled, the OS will perform any upgrades
 	// available as part of its provisioning.
 	EnableOSUpgrade bool
-
-	// ContainerHostname is used to set the hostname for cloud config. Allowing
-	// containers to override the default "ubuntu" hostname.
-	ContainerHostname string
 }
 
 func (cfg *InstanceConfig) agentInfo() service.AgentInfo {

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -166,6 +166,10 @@ type InstanceConfig struct {
 	// instances. If enabled, the OS will perform any upgrades
 	// available as part of its provisioning.
 	EnableOSUpgrade bool
+
+	// ContainerHostname is used to set the hostname for cloud config. Allowing
+	// containers to override the default "ubuntu" hostname.
+	ContainerHostname string
 }
 
 func (cfg *InstanceConfig) agentInfo() service.AgentInfo {

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -113,8 +113,8 @@ func (manager *containerManager) CreateContainer(
 		name = fmt.Sprintf("%s-%s", manager.name, name)
 	}
 
-	// Set the ContainerHostname to match the name returned by virsh list
-	instanceConfig.ContainerHostname = name
+	// Set the MachineContainerHostname to match the name returned by virsh list
+	instanceConfig.MachineContainerHostname = name
 
 	// Note here that the kvmObjectFacotry only returns a valid container
 	// object, and doesn't actually construct the underlying kvm container on

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -112,6 +112,10 @@ func (manager *containerManager) CreateContainer(
 	if manager.name != "" {
 		name = fmt.Sprintf("%s-%s", manager.name, name)
 	}
+
+	// Set the ContainerHostname to match the name returned by virsh list
+	instanceConfig.ContainerHostname = name
+
 	// Note here that the kvmObjectFacotry only returns a valid container
 	// object, and doesn't actually construct the underlying kvm container on
 	// disk.


### PR DESCRIPTION
Allows you to set an explict ContainerHostname on the InstanceConfig. If set, this will be used to set the hostname attribute for the cloud config.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1326091

(Review request: http://reviews.vapour.ws/r/1503/)