### PR TITLE
Fix 1449277 Create Environ on EC2

### DIFF
--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -151,6 +151,11 @@ func (s *envManagerSuite) TestRestrictedProviderFields(c *gc.C) {
 			expected: []string{
 				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert", "rsyslog-ca-key",
 				"region", "auth-url", "auth-mode"},
+		}, {
+			provider: "ec2",
+			expected: []string{
+				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert", "rsyslog-ca-key",
+				"region", "access-key", "secret-key"},
 		},
 	} {
 		c.Logf("%d: %s provider", i, test.provider)

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -29,7 +29,7 @@ func (environProvider) BoilerplateConfig() string {
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (p environProvider) RestrictedConfigAttributes() []string {
-	return []string{"region"}
+	return []string{"region", "access-key", "secret-key"}
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.


### PR DESCRIPTION
Add a missing test case for restricted config attributes on EC2. Add
access-key and secret-key to restricted config attributes for EC2.

(Review request: http://reviews.vapour.ws/r/1506/)