### PR TITLE
Do not build the vsphere provider under GCCGo.

### DIFF
--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -375,9 +375,9 @@ func (s *ConstraintsSuite) TestIncludeExcludeAndHaveNetworks(c *gc.C) {
 
 func (s *ConstraintsSuite) TestInvalidNetworks(c *gc.C) {
 	invalidNames := []string{
-		"%ne$t", "^net#2", "_", "tcp:ip",
+		"%ne$t", "^net#2", "+", "tcp:ip",
 		"^^mynet", "^^^^^^^^", "net^x",
-		"-foo", "net/3", "^net_4", "&#!",
+		"&-foo", "net/3", "^net=4", "&#!",
 	}
 	for _, name := range invalidNames {
 		con, err := constraints.Parse("networks=" + name)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/jujusvg	git	28683402583926ce903491c14a07cdc5cb371adb	2015-04-10T08:55:05Z
 github.com/juju/loggo	git	6d22922ff98aac6608b8a58191bd6b2e1dac3fca	2015-03-30T01:06:43Z
-github.com/juju/names	git	2b65d264b29346482c291c854168295f350cf323	2015-03-30T01:03:07Z
+github.com/juju/names	git	a597dd52044cc5a702844642b5cb6e09870422db	2015-04-28T12:56:57Z
 github.com/juju/persistent-cookiejar	git	beee02cb39231c7ad4a01a677fc54c48d2b46b08	2015-04-09T09:48:35Z
 github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-30T01:41:32Z
 github.com/juju/replicaset	git	a5137dd3d7a1495ef2dd32cfbac616654913cf49	2015-04-02T14:41:36Z

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_instance_test.go
+++ b/provider/vsphere/environ_instance_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_instance_test.go
+++ b/provider/vsphere/environ_instance_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/fake_methods_test.go
+++ b/provider/vsphere/fake_methods_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/fake_methods_test.go
+++ b/provider/vsphere/fake_methods_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/init.go
+++ b/provider/vsphere/init.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/init.go
+++ b/provider/vsphere/init.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/init_gccgo.go
+++ b/provider/vsphere/init_gccgo.go
@@ -3,6 +3,10 @@
 
 // +build gccgo
 
+// This file exists so that this package will remain importable under
+// GCCGo. In particular, see provider/all/all.go. All other files in
+// this package do not build under GCCGo (see lp:1440940).
+
 package vsphere
 
 const (

--- a/provider/vsphere/init_gccgo.go
+++ b/provider/vsphere/init_gccgo.go
@@ -1,17 +1,13 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build gccgo go1.2
+
 // +build !gccgo
 // +build !go1.2 go1.3
 
-package vsphere_test
+package vsphere
 
-import (
-	"testing"
-
-	gc "gopkg.in/check.v1"
+const (
+	providerType = "vsphere"
 )
-
-func TestPackage(t *testing.T) {
-	gc.TestingT(t)
-}

--- a/provider/vsphere/init_gccgo.go
+++ b/provider/vsphere/init_gccgo.go
@@ -1,10 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// +build gccgo go1.2
-
-// +build !gccgo
-// +build !go1.2 go1.3
+// +build gccgo
 
 package vsphere
 

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/ovf_import_manager.go
+++ b/provider/vsphere/ovf_import_manager.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/ovf_import_manager.go
+++ b/provider/vsphere/ovf_import_manager.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/package_test.go
+++ b/provider/vsphere/package_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1654,8 +1654,8 @@ var addNetworkErrorsTests = []struct {
 	state.NetworkInfo{"", "provider-id", "0.3.1.0/24", 0},
 	`cannot add network "": name must be not empty`,
 }, {
-	state.NetworkInfo{"-invalid-", "provider-id", "0.3.1.0/24", 0},
-	`cannot add network "-invalid-": invalid name`,
+	state.NetworkInfo{"$-invalid-", "provider-id", "0.3.1.0/24", 0},
+	`cannot add network "\$-invalid-": invalid name`,
 }, {
 	state.NetworkInfo{"net2", "", "0.3.1.0/24", 0},
 	`cannot add network "net2": provider id must be not empty`,


### PR DESCRIPTION
The vsphere provider introduced a dependency that triggers a bug under GCCGo.  See https://bugs.launchpad.net/juju-core/+bug/1440940.  Until that is resolved, we simply to do build the provider under GCCGo.

(Review request: http://reviews.vapour.ws/r/1510/)