### PR TITLE
Do not build the vsphere provider under GCCGo.

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_instance_test.go
+++ b/provider/vsphere/environ_instance_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_instance_test.go
+++ b/provider/vsphere/environ_instance_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/fake_methods_test.go
+++ b/provider/vsphere/fake_methods_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/fake_methods_test.go
+++ b/provider/vsphere/fake_methods_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/init.go
+++ b/provider/vsphere/init.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/init.go
+++ b/provider/vsphere/init.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/init_gccgo.go
+++ b/provider/vsphere/init_gccgo.go
@@ -3,6 +3,10 @@
 
 // +build gccgo
 
+// This file exists so that this package will remain importable under
+// GCCGo. In particular, see provider/all/all.go. All other files in
+// this package do not build under GCCGo (see lp:1440940).
+
 package vsphere
 
 const (

--- a/provider/vsphere/init_gccgo.go
+++ b/provider/vsphere/init_gccgo.go
@@ -1,17 +1,13 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build gccgo go1.2
+
 // +build !gccgo
 // +build !go1.2 go1.3
 
-package vsphere_test
+package vsphere
 
-import (
-	"testing"
-
-	gc "gopkg.in/check.v1"
+const (
+	providerType = "vsphere"
 )
-
-func TestPackage(t *testing.T) {
-	gc.TestingT(t)
-}

--- a/provider/vsphere/init_gccgo.go
+++ b/provider/vsphere/init_gccgo.go
@@ -1,10 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// +build gccgo go1.2
-
-// +build !gccgo
-// +build !go1.2 go1.3
+// +build gccgo
 
 package vsphere
 

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/ovf_import_manager.go
+++ b/provider/vsphere/ovf_import_manager.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/ovf_import_manager.go
+++ b/provider/vsphere/ovf_import_manager.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/package_test.go
+++ b/provider/vsphere/package_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere_test
 
 import (

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere_test
 

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -2,7 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // +build !gccgo
-// +build !go1.2 go1.3
 
 package vsphere
 

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -1,6 +1,9 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !gccgo
+// +build !go1.2 go1.3
+
 package vsphere
 
 import (


### PR DESCRIPTION
The vsphere provider introduced a dependency that triggers a bug under GCCGo.  See https://bugs.launchpad.net/juju-core/+bug/1440940.  Until that is resolved, we simply to do build the provider under GCCGo.

(Review request: http://reviews.vapour.ws/r/1510/)