### PR TITLE
EC2: Set control-bucket default

### DIFF
--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -67,9 +67,10 @@ var configFields = schema.Fields{
 }
 
 var configDefaults = schema.Defaults{
-	"access-key": "",
-	"secret-key": "",
-	"region":     "us-east-1",
+	"access-key":     "",
+	"secret-key":     "",
+	"region":         "us-east-1",
+	"control-bucket": "",
 }
 
 type environConfig struct {


### PR DESCRIPTION
juju status on an unbootstrapped ec2 environ would complain about an
invalid control-bucket config attribute. This PR sets control-bucket
default to "".

(Review request: http://reviews.vapour.ws/r/1512/)