### PR TITLE
service/systemd: fix env var format (1.24)

### DIFF
--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -202,7 +202,7 @@ func serializeService(conf common.Conf) []*unit.UnitOption {
 		unitOptions = append(unitOptions, &unit.UnitOption{
 			Section: "Service",
 			Name:    "Environment",
-			Value:   fmt.Sprintf(`"%q=%q"`, k, v),
+			Value:   fmt.Sprintf(`"%s=%s"`, k, v),
 		})
 	}
 

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -44,22 +44,6 @@ WantedBy=multi-user.target
 
 `
 
-type confStruct struct {
-	Unit struct {
-		Description string
-		After       []string
-	}
-	Service struct {
-		Type            string
-		ExecStart       string
-		RemainAfterExit bool
-		Restart         string
-	}
-	Install struct {
-		WantedBy string
-	}
-}
-
 const jujud = "/var/lib/juju/bin/jujud"
 
 var listCmdArg = exec.RunParams{
@@ -115,12 +99,21 @@ func (s *initSystemSuite) SetUpTest(c *gc.C) {
 	s.stub.Calls = nil
 }
 
-func (s *initSystemSuite) newConfStr(name, cmd string) string {
+func (s *initSystemSuite) newConfStr(name, cmd, env string) string {
 	tag := name[len("jujud-"):]
 	if cmd == "" {
 		cmd = jujud + " " + tag
 	}
-	return fmt.Sprintf(confStr[1:], tag, cmd)
+	result := fmt.Sprintf(confStr[1:], tag, cmd)
+	if env != "" {
+		r := "[Service]"
+		result = strings.Replace(
+			result, r,
+			fmt.Sprintf("%s\nEnvironment=%s", r, env),
+			1,
+		)
+	}
+	return result
 }
 
 func (s *initSystemSuite) addService(name, status string) {
@@ -156,7 +149,7 @@ func (s *initSystemSuite) checkCreateFileCall(c *gc.C, index int, filename, cont
 	if content == "" {
 		name := filename
 		filename = fmt.Sprintf("%s/init/%s/%s.service", s.dataDir, name, name)
-		content = s.newConfStr(name, "")
+		content = s.newConfStr(name, "", "")
 	}
 
 	call := s.stub.Calls[index]
@@ -674,7 +667,7 @@ func (s *initSystemSuite) TestInstall(c *gc.C) {
 	}, {
 		FuncName: "Close",
 	}})
-	s.checkCreateFileCall(c, 2, filename, s.newConfStr(s.name, ""), 0644)
+	s.checkCreateFileCall(c, 2, filename, s.newConfStr(s.name, "", ""), 0644)
 }
 
 func (s *initSystemSuite) TestInstallAlreadyInstalled(c *gc.C) {
@@ -695,17 +688,21 @@ func (s *initSystemSuite) TestInstallZombie(c *gc.C) {
 	s.addService("jujud-machine-0", "active")
 	s.addListResponse()
 	// We force the systemd API to return a slightly different conf.
-	// In this case we simply set Conf.Env, which s.conf does not set.
+	// In this case we simply set a different Conf.Env to s.conf's.
 	// This causes Service.Exists to return false.
-	s.setConf(c, common.Conf{
+	conf := common.Conf{
 		Desc:      s.conf.Desc,
 		ExecStart: s.conf.ExecStart,
 		Env:       map[string]string{"a": "b"},
-	})
+	}
+	s.setConf(c, conf)
 	s.addListResponse()
 	s.ch <- "done"
 
-	err := s.service.Install()
+	conf.Env["a"] = "c"
+	service, err := systemd.NewService(s.name, conf)
+	c.Assert(err, jc.ErrorIsNil)
+	err = service.Install()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c,
@@ -727,7 +724,9 @@ func (s *initSystemSuite) TestInstallZombie(c *gc.C) {
 		"EnableUnitFiles",
 		"Close",
 	)
-	s.checkCreateFileCall(c, 12, s.name, "", 0644)
+	filename := fmt.Sprintf("%s/init/%s/%s.service", s.dataDir, s.name, s.name)
+	content := s.newConfStr(s.name, "", `"a=c"`)
+	s.checkCreateFileCall(c, 12, filename, content, 0644)
 }
 
 func (s *initSystemSuite) TestInstallMultiline(c *gc.C) {
@@ -751,7 +750,7 @@ func (s *initSystemSuite) TestInstallMultiline(c *gc.C) {
 	)
 	s.checkCreateFileCall(c, 2, scriptPath, cmd, 0755)
 	filename := fmt.Sprintf("%s/init/%s/%s.service", s.dataDir, s.name, s.name)
-	content := s.newConfStr(s.name, scriptPath)
+	content := s.newConfStr(s.name, scriptPath, "")
 	s.checkCreateFileCall(c, 3, filename, content, 0644)
 }
 
@@ -775,7 +774,7 @@ func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
 	test := systemdtesting.WriteConfTest{
 		Service:  name,
 		DataDir:  s.dataDir,
-		Expected: s.newConfStr(name, ""),
+		Expected: s.newConfStr(name, "", ""),
 	}
 	test.CheckCommands(c, commands)
 }
@@ -795,7 +794,7 @@ func (s *initSystemSuite) TestInstallCommandsLogfile(c *gc.C) {
 		Service: name,
 		DataDir: s.dataDir,
 		Expected: strings.Replace(
-			s.newConfStr(name, ""),
+			s.newConfStr(name, "", ""),
 			"ExecStart=/var/lib/juju/bin/jujud machine-0",
 			"ExecStart=/tmp/init/jujud-machine-0/exec-start.sh",
 			-1),


### PR DESCRIPTION
On vivid, unit files' Environment entries are being formatted like so:
   Environment=""A"="B"" ""C"="D""

They should be formatted as:
   Environment="A=B" "C=D"

Fixes https://bugs.launchpad.net/juju-core/+bug/1449436

(Review request: http://reviews.vapour.ws/r/1513/)