### PR TITLE
Machine blockdevices doc upgrade

### DIFF
--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -101,6 +101,7 @@ func createMachineBlockDevicesOp(machineId string) txn.Op {
 		C:      blockDevicesC,
 		Id:     machineId,
 		Insert: &blockDevicesDoc{Machine: machineId},
+		Assert: txn.DocMissing,
 	}
 }
 

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -78,9 +78,6 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 		if !blockDevicesChanged(oldInfo, newInfo) {
 			return nil, jujutxn.ErrNoOperations
 		}
-		// TODO(axw) before the storage feature can come off,
-		// we need to add an upgrade step to add a block
-		// devices doc to existing machines.
 		ops := []txn.Op{{
 			C:      machinesC,
 			Id:     machineId,

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1263,12 +1263,12 @@ func AddDefaultBlockDevicesDocs(st *State) error {
 		}
 
 		for _, machine := range machines {
-			// The error from this is intentionally ignored as the
-			// transaction will fail if the machine already has a
-			// block devices doc.
-			envSt.runTransaction([]txn.Op{
+			// If a txn fails because the doc already exists, that's ok.
+			if err := envSt.runTransaction([]txn.Op{
 				createMachineBlockDevicesOp(machine.Id()),
-			})
+			}); err != nil && err != txn.ErrAborted {
+				return err
+			}
 		}
 	}
 	return nil

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2610,3 +2610,110 @@ func (s *upgradesSuite) TestAddLeadershipSettingsIdempotent(c *gc.C) {
 
 	c.Check(firstPassIDs, jc.SameContents, secondPassIDs)
 }
+
+func (s *upgradesSuite) prepareEnvsForMachineBlockDevices(c *gc.C, envs map[string][]string) []string {
+	environments, closer := s.state.getRawCollection(environmentsC)
+	defer closer()
+	addEnvironment := func(envUUID string) {
+		err := environments.Insert(bson.M{
+			"_id": envUUID,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	var expectedDocIDs []string
+	machines, closer := s.state.getRawCollection(machinesC)
+	defer closer()
+	addMachine := func(envUUID, id string) {
+		err := machines.Insert(bson.M{
+			"_id":       envUUID + ":" + id,
+			"env-uuid":  envUUID,
+			"machineid": id,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		expectedDocIDs = append(expectedDocIDs, envUUID+":"+id)
+	}
+
+	// Use the helpers to set up the environments.
+	for envUUID, machines := range envs {
+		if envUUID == "" {
+			envUUID = s.state.EnvironUUID()
+		} else {
+			addEnvironment(envUUID)
+		}
+		for _, mId := range machines {
+			addMachine(envUUID, mId)
+		}
+	}
+
+	return expectedDocIDs
+}
+
+func (s *upgradesSuite) readBlockDeviceIDs(c *gc.C, coll string) []string {
+	blockDevices, closer := s.state.getRawCollection(coll)
+	defer closer()
+	var docs []bson.M
+	err := blockDevices.Find(nil).All(&docs)
+	c.Assert(err, jc.ErrorIsNil)
+	var actualDocIDs []string
+	for _, doc := range docs {
+		actualDocIDs = append(actualDocIDs, doc["_id"].(string))
+	}
+	return actualDocIDs
+}
+
+func (s *upgradesSuite) TestAddBlockDevicesDocs(c *gc.C) {
+	expectedDocIDs := s.prepareEnvsForMachineBlockDevices(c, map[string][]string{
+		"": []string{"1", "2"},
+		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"1"},
+		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"1"},
+	})
+
+	err := AddDefaultBlockDevicesDocs(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	actualDocIDs := s.readBlockDeviceIDs(c, blockDevicesC)
+	c.Assert(actualDocIDs, jc.SameContents, expectedDocIDs)
+}
+
+func (s *upgradesSuite) TestAddBlockDevicesDocsFresh(c *gc.C) {
+	err := AddDefaultBlockDevicesDocs(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	actualDocIDs := s.readBlockDeviceIDs(c, blockDevicesC)
+	c.Assert(actualDocIDs, gc.HasLen, 0)
+}
+
+func (s *upgradesSuite) TestAddBlockDevicesDocsMultipleEmpty(c *gc.C) {
+	s.prepareEnvsForMachineBlockDevices(c, map[string][]string{
+		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": nil,
+		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": nil,
+	})
+
+	err := AddDefaultBlockDevicesDocs(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	actualDocIDs := s.readBlockDeviceIDs(c, blockDevicesC)
+	c.Assert(actualDocIDs, gc.HasLen, 0)
+}
+
+func (s *upgradesSuite) TestAddBlockDevicesDocsIdempotent(c *gc.C) {
+	s.prepareEnvsForMachineBlockDevices(c, map[string][]string{
+		"": []string{"1", "2"},
+		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"1"},
+		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"1"},
+	})
+
+	originalIDs := s.readBlockDeviceIDs(c, blockDevicesC)
+	c.Assert(originalIDs, gc.HasLen, 0)
+
+	err := AddDefaultBlockDevicesDocs(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+	firstPassIDs := s.readBlockDeviceIDs(c, blockDevicesC)
+
+	err = AddDefaultBlockDevicesDocs(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+	secondPassIDs := s.readBlockDeviceIDs(c, blockDevicesC)
+
+	c.Assert(firstPassIDs, jc.SameContents, secondPassIDs)
+}

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -31,6 +31,10 @@ var stateUpgradeOperations = func() []Operation {
 			version.MustParse("1.23.0"),
 			stateStepsFor123(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.24.0"),
+			stateStepsFor124(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -1,0 +1,21 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import "github.com/juju/juju/state"
+
+// stateStepsFor124 returns upgrade steps for Juju 1.24 that manipulate state directly.
+func stateStepsFor124() []Step {
+	var steps []Step
+	steps = append(steps,
+		&upgradeStep{
+			description: "add block device documents for existing machines",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddDefaultBlockDevicesDocs(context.State())
+			},
+		},
+	)
+	return steps
+}

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
+)
+
+type steps124Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps124Suite{})
+
+func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
+	expected := []string{
+		"add block device documents for existing machines",
+	}
+	assertStateSteps(c, version.MustParse("1.24.0"), expected)
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -666,7 +666,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.23.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0"})
 }
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1449302

When upgrading to 1.24, empty block devices records are created for existing machines.

(Review request: http://reviews.vapour.ws/r/1516/)