### PR TITLE
storage: rename Serial to HardwareId

### DIFF
--- a/api/storageprovisioner/provisioner_test.go
+++ b/api/storageprovisioner/provisioner_test.go
@@ -164,10 +164,10 @@ func (s *provisionerSuite) TestVolumes(c *gc.C) {
 		*(result.(*params.VolumeResults)) = params.VolumeResults{
 			Results: []params.VolumeResult{{
 				Result: params.Volume{
-					VolumeTag: "volume-100",
-					VolumeId:  "volume-id",
-					Serial:    "abc",
-					Size:      1024,
+					VolumeTag:  "volume-100",
+					VolumeId:   "volume-id",
+					HardwareId: "abc",
+					Size:       1024,
 				},
 			}},
 		}
@@ -181,7 +181,7 @@ func (s *provisionerSuite) TestVolumes(c *gc.C) {
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(volumes, jc.DeepEquals, []params.VolumeResult{{
 		Result: params.Volume{
-			VolumeTag: "volume-100", VolumeId: "volume-id", Serial: "abc", Size: 1024,
+			VolumeTag: "volume-100", VolumeId: "volume-id", HardwareId: "abc", Size: 1024,
 		},
 	}})
 }
@@ -260,7 +260,7 @@ func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 	blockDeviceResults := []params.BlockDeviceResult{{
 		Result: storage.BlockDevice{
 			DeviceName: "xvdf1",
-			Serial:     "kjlaksjdlasjdklasd123123",
+			HardwareId: "kjlaksjdlasjdklasd123123",
 			Size:       1024,
 		},
 	}}
@@ -478,7 +478,7 @@ func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "SetVolumeInfo")
 		c.Check(arg, gc.DeepEquals, params.Volumes{
-			Volumes: []params.Volume{{VolumeTag: "volume-100", VolumeId: "123", Serial: "abc", Size: 1024, Persistent: true}},
+			Volumes: []params.Volume{{VolumeTag: "volume-100", VolumeId: "123", HardwareId: "abc", Size: 1024, Persistent: true}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
@@ -489,7 +489,7 @@ func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
 	})
 
 	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	volumes := []params.Volume{{VolumeTag: "volume-100", VolumeId: "123", Serial: "abc", Size: 1024, Persistent: true}}
+	volumes := []params.Volume{{VolumeTag: "volume-100", VolumeId: "123", HardwareId: "abc", Size: 1024, Persistent: true}}
 	errorResults, err := st.SetVolumeInfo(volumes)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)

--- a/apiserver/common/blockdevices.go
+++ b/apiserver/common/blockdevices.go
@@ -15,7 +15,7 @@ func BlockDeviceFromState(in state.BlockDeviceInfo) storage.BlockDevice {
 		in.DeviceName,
 		in.Label,
 		in.UUID,
-		in.Serial,
+		in.HardwareId,
 		in.Size,
 		in.FilesystemType,
 		in.InUse,
@@ -31,8 +31,8 @@ func MatchingBlockDevice(
 	attachmentInfo state.VolumeAttachmentInfo,
 ) (*state.BlockDeviceInfo, bool) {
 	for _, dev := range blockDevices {
-		if volumeInfo.Serial != "" {
-			if volumeInfo.Serial == dev.Serial {
+		if volumeInfo.HardwareId != "" {
+			if volumeInfo.HardwareId == dev.HardwareId {
 				return &dev, true
 			}
 		} else if attachmentInfo.DeviceName == dev.DeviceName {

--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -163,8 +163,8 @@ func volumeAttachmentDevicePath(
 	volumeInfo state.VolumeInfo,
 	volumeAttachmentInfo state.VolumeAttachmentInfo,
 ) (string, error) {
-	if volumeInfo.Serial != "" {
-		return path.Join("/dev/disk/by-id", volumeInfo.Serial), nil
+	if volumeInfo.HardwareId != "" {
+		return path.Join("/dev/disk/by-id", volumeInfo.HardwareId), nil
 	} else if volumeAttachmentInfo.DeviceName != "" {
 		return path.Join("/dev", volumeAttachmentInfo.DeviceName), nil
 	}

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -95,7 +95,7 @@ func VolumeToState(v params.Volume) (names.VolumeTag, state.VolumeInfo, error) {
 		return names.VolumeTag{}, state.VolumeInfo{}, errors.Trace(err)
 	}
 	return volumeTag, state.VolumeInfo{
-		v.Serial,
+		v.HardwareId,
 		v.Size,
 		"", // pool is set by state
 		v.VolumeId,
@@ -112,7 +112,7 @@ func VolumeFromState(v state.Volume) (params.Volume, error) {
 	return params.Volume{
 		v.VolumeTag().String(),
 		info.VolumeId,
-		info.Serial,
+		info.HardwareId,
 		info.Size,
 		info.Persistent,
 	}, nil

--- a/apiserver/diskmanager/diskmanager.go
+++ b/apiserver/diskmanager/diskmanager.go
@@ -99,7 +99,7 @@ func stateBlockDeviceInfo(devices []storage.BlockDevice) []state.BlockDeviceInfo
 			dev.DeviceName,
 			dev.Label,
 			dev.UUID,
-			dev.Serial,
+			dev.HardwareId,
 			dev.Size,
 			dev.FilesystemType,
 			dev.InUse,

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -151,9 +151,9 @@ type MachineStorageIds struct {
 
 // Volume describes a storage volume in the environment.
 type Volume struct {
-	VolumeTag string `json:"volumetag"`
-	VolumeId  string `json:"volumeid"`
-	Serial    string `json:"serial"`
+	VolumeTag  string `json:"volumetag"`
+	VolumeId   string `json:"volumeid"`
+	HardwareId string `json:"hwid"`
 	// Size is the size of the volume in MiB.
 	Size       uint64 `json:"size"`
 	Persistent bool   `json:"persistent"`
@@ -448,8 +448,8 @@ type VolumeInstance struct {
 	// VolumeId is a unique provider-supplied ID for the volume.
 	VolumeId string `json:"volumeid"`
 
-	// Serial is the volume's serial number.
-	Serial string `json:"serial,omitempty"`
+	// HardwareId is the volume's hardware ID.
+	HardwareId string `json:"hwid,omitempty"`
 
 	// Size is the size of the volume in MiB.
 	Size uint64 `json:"size"`

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -153,7 +153,7 @@ type MachineStorageIds struct {
 type Volume struct {
 	VolumeTag  string `json:"volumetag"`
 	VolumeId   string `json:"volumeid"`
-	HardwareId string `json:"hwid"`
+	HardwareId string `json:"hardwareid,omitempty"`
 	// Size is the size of the volume in MiB.
 	Size       uint64 `json:"size"`
 	Persistent bool   `json:"persistent"`
@@ -449,7 +449,7 @@ type VolumeInstance struct {
 	VolumeId string `json:"volumeid"`
 
 	// HardwareId is the volume's hardware ID.
-	HardwareId string `json:"hwid,omitempty"`
+	HardwareId string `json:"hardwareid,omitempty"`
 
 	// Size is the size of the volume in MiB.
 	Size uint64 `json:"size"`

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -442,7 +442,7 @@ func (a *API) convertStateVolumeToParams(st state.Volume) (params.VolumeInstance
 		}
 	}
 	if info, err := st.Info(); err == nil {
-		volume.Serial = info.Serial
+		volume.HardwareId = info.HardwareId
 		volume.Size = info.Size
 		volume.Persistent = info.Persistent
 		volume.VolumeId = info.VolumeId

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -91,16 +91,16 @@ func (s *provisionerSuite) setupVolumes(c *gc.C) {
 	})
 	// Only provision the first and third volumes.
 	err := s.State.SetVolumeInfo(names.NewVolumeTag("0/0"), state.VolumeInfo{
-		Serial:     "123",
+		HardwareId: "123",
 		VolumeId:   "abc",
 		Size:       1024,
 		Persistent: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.SetVolumeInfo(names.NewVolumeTag("2"), state.VolumeInfo{
-		Serial:   "456",
-		VolumeId: "def",
-		Size:     4096,
+		HardwareId: "456",
+		VolumeId:   "def",
+		Size:       4096,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -171,7 +171,7 @@ func (s *provisionerSuite) TestVolumesMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.VolumeResults{
 		Results: []params.VolumeResult{
-			{Result: params.Volume{VolumeTag: "volume-0-0", VolumeId: "abc", Serial: "123", Size: 1024, Persistent: true}},
+			{Result: params.Volume{VolumeTag: "volume-0-0", VolumeId: "abc", HardwareId: "123", Size: 1024, Persistent: true}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},
@@ -195,7 +195,7 @@ func (s *provisionerSuite) TestVolumesEnviron(c *gc.C) {
 		Results: []params.VolumeResult{
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 			{Error: common.ServerError(errors.NotProvisionedf(`volume "1"`))},
-			{Result: params.Volume{VolumeTag: "volume-2", VolumeId: "def", Serial: "456", Size: 4096}},
+			{Result: params.Volume{VolumeTag: "volume-2", VolumeId: "def", HardwareId: "456", Size: 4096}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},
 	})
@@ -783,7 +783,7 @@ func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 	err = machine0.SetMachineBlockDevices(state.BlockDeviceInfo{
 		DeviceName: "sda",
 		Size:       123,
-		Serial:     "123", // matches volume-0/0
+		HardwareId: "123", // matches volume-0/0
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -802,7 +802,7 @@ func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 			{Result: storage.BlockDevice{
 				DeviceName: "sda",
 				Size:       123,
-				Serial:     "123",
+				HardwareId: "123",
 			}},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -45,7 +45,7 @@ type VolumeInfo struct {
 	VolumeId string `yaml:"id" json:"id"`
 
 	// from params.Volume
-	Serial string `yaml:"serial" json:"serial"`
+	HardwareId string `yaml:"hwid" json:"hwid"`
 
 	// from params.Volume
 	Size uint64 `yaml:"size" json:"size"`
@@ -124,7 +124,7 @@ func addOneToAll(machineId, unitId, storageId string, item VolumeInfo, all map[s
 
 func createInfo(volume params.VolumeInstance) (info VolumeInfo, unit, storage string) {
 	info.VolumeId = volume.VolumeId
-	info.Serial = volume.Serial
+	info.HardwareId = volume.HardwareId
 	info.Size = volume.Size
 	info.Persistent = volume.Persistent
 

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -45,7 +45,7 @@ type VolumeInfo struct {
 	VolumeId string `yaml:"id" json:"id"`
 
 	// from params.Volume
-	HardwareId string `yaml:"hwid" json:"hwid"`
+	HardwareId string `yaml:"hardwareid" json:"hardwareid"`
 
 	// from params.Volume
 	Size uint64 `yaml:"size" json:"size"`

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -15,6 +15,7 @@ import (
 	goyaml "gopkg.in/yaml.v1"
 
 	"fmt"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
@@ -202,7 +203,7 @@ func (s *volumeListSuite) assertSameVolumeInfos(c *gc.C, one, two map[string]map
 				info2, ok := units2[storageKey]
 				c.Assert(ok, jc.IsTrue)
 				propertyCompare(info1.VolumeId, info2.VolumeId)
-				propertyCompare(info1.Serial, info2.Serial)
+				propertyCompare(info1.HardwareId, info2.HardwareId)
 				propertyCompare(info1.Size, info2.Size)
 				propertyCompare(info1.Persistent, info2.Persistent)
 				propertyCompare(info1.DeviceName, info2.DeviceName)
@@ -294,7 +295,7 @@ func (s mockVolumeListAPI) createTestVolume(id string, persistent bool, storagei
 	result := params.VolumeInstance{
 		VolumeTag:  tag.String(),
 		VolumeId:   "provider-supplied-" + tag.Id(),
-		Serial:     "serial blah blah",
+		HardwareId: "serial blah blah",
 		Persistent: persistent,
 		Size:       uint64(1024),
 	}

--- a/doc/storage-model.txt
+++ b/doc/storage-model.txt
@@ -74,7 +74,7 @@ namespace juju.juju.state <<Database>> {
 
 	class BlockDevice {
 		DeviceName : string
-		Serial : string
+		HardwareId : string
 		Size : int
 		FilesystemType : string
 	}

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -34,7 +34,7 @@ type BlockDeviceInfo struct {
 	DeviceName     string `bson:"devicename"`
 	Label          string `bson:"label,omitempty"`
 	UUID           string `bson:"uuid,omitempty"`
-	HardwareId     string `bson:"hwid,omitempty"`
+	HardwareId     string `bson:"hardwareid,omitempty"`
 	Size           uint64 `bson:"size"`
 	FilesystemType string `bson:"fstype,omitempty"`
 	InUse          bool   `bson:"inuse"`

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -34,7 +34,7 @@ type BlockDeviceInfo struct {
 	DeviceName     string `bson:"devicename"`
 	Label          string `bson:"label,omitempty"`
 	UUID           string `bson:"uuid,omitempty"`
-	Serial         string `bson:"serial,omitempty"`
+	HardwareId     string `bson:"hwid,omitempty"`
 	Size           uint64 `bson:"size"`
 	FilesystemType string `bson:"fstype,omitempty"`
 	InUse          bool   `bson:"inuse"`

--- a/state/volume.go
+++ b/state/volume.go
@@ -112,7 +112,7 @@ type VolumeParams struct {
 
 // VolumeInfo describes information about a volume.
 type VolumeInfo struct {
-	Serial     string `bson:"serial,omitempty"`
+	HardwareId string `bson:"hwid,omitempty"`
 	Size       uint64 `bson:"size"`
 	Pool       string `bson:"pool"`
 	VolumeId   string `bson:"volumeid"`

--- a/state/volume.go
+++ b/state/volume.go
@@ -112,7 +112,7 @@ type VolumeParams struct {
 
 // VolumeInfo describes information about a volume.
 type VolumeInfo struct {
-	HardwareId string `bson:"hwid,omitempty"`
+	HardwareId string `bson:"hardwareid,omitempty"`
 	Size       uint64 `bson:"size"`
 	Pool       string `bson:"pool"`
 	VolumeId   string `bson:"volumeid"`

--- a/storage/blockdevice.go
+++ b/storage/blockdevice.go
@@ -28,7 +28,7 @@ type BlockDevice struct {
 	// these properties, so HardwareId may be empty. This is used to identify
 	// a block device if it is available, in preference to UUID or device
 	// name, as the hardware ID is immutable.
-	HardwareId string `yaml:"hwid,omitempty"`
+	HardwareId string `yaml:"hardwareid,omitempty"`
 
 	// Size is the size of the block device, in MiB.
 	Size uint64 `yaml:"size"`

--- a/storage/blockdevice.go
+++ b/storage/blockdevice.go
@@ -23,11 +23,12 @@ type BlockDevice struct {
 	// differ in format to the standard v4 UUIDs.
 	UUID string `yaml:"uuid,omitempty"`
 
-	// Serial is the block device's serial number. Not all block devices
-	// have a serial number. This is used to identify a block device if
-	// it is available, in preference to UUID or device name, as the serial
-	// is immutable.
-	Serial string `yaml:"serial,omitempty"`
+	// HardwareId is the block device's hardware ID, which is composed of
+	// a serial number, vendor and model name. Not all block devices have
+	// these properties, so HardwareId may be empty. This is used to identify
+	// a block device if it is available, in preference to UUID or device
+	// name, as the hardware ID is immutable.
+	HardwareId string `yaml:"hwid,omitempty"`
 
 	// Size is the size of the block device, in MiB.
 	Size uint64 `yaml:"size"`

--- a/storage/path.go
+++ b/storage/path.go
@@ -15,13 +15,11 @@ const (
 )
 
 // BlockDevicePath returns the path to a block device, or an error if a path
-// cannot be determined. The path is based on the serial, if available,
+// cannot be determined. The path is based on the hardware ID, if available,
 // otherwise the device name.
 func BlockDevicePath(device BlockDevice) (string, error) {
-	if device.Serial != "" {
-		// TODO(axw) rename Serial; by-id is a combination of vendor,
-		// model and serial.
-		return filepath.Join(diskByID, device.Serial), nil
+	if device.HardwareId != "" {
+		return filepath.Join(diskByID, device.HardwareId), nil
 	}
 	if device.DeviceName != "" {
 		return filepath.Join(diskByDeviceName, device.DeviceName), nil

--- a/storage/path_test.go
+++ b/storage/path_test.go
@@ -16,7 +16,7 @@ var _ = gc.Suite(&BlockDevicePathSuite{})
 
 func (s *BlockDevicePathSuite) TestBlockDevicePathSerial(c *gc.C) {
 	testBlockDevicePath(c, storage.BlockDevice{
-		Serial:     "SPR_OSUM_123",
+		HardwareId: "SPR_OSUM_123",
 		DeviceName: "name",
 	}, "/dev/disk/by-id/SPR_OSUM_123")
 }

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -98,7 +98,7 @@ func (s *managedFilesystemSource) devicePath(dev storage.BlockDevice) string {
 	if dev.DeviceName != "" {
 		return path.Join("/dev", dev.DeviceName)
 	}
-	return path.Join("/dev/disk/by-id", dev.Serial)
+	return path.Join("/dev/disk/by-id", dev.HardwareId)
 }
 
 // AttachFilesystems is defined on storage.FilesystemSource.

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -55,12 +55,12 @@ func (s *managedfsSuite) TestCreateFilesystems(c *gc.C) {
 
 	s.blockDevices[names.NewVolumeTag("0")] = storage.BlockDevice{
 		DeviceName: "sda",
-		Serial:     "capncrunch",
+		HardwareId: "capncrunch",
 		Size:       2,
 	}
 	s.blockDevices[names.NewVolumeTag("1")] = storage.BlockDevice{
-		Serial: "weetbix",
-		Size:   3,
+		HardwareId: "weetbix",
+		Size:       3,
 	}
 	filesystems, err := source.CreateFilesystems([]storage.FilesystemParams{{
 		Tag:    names.NewFilesystemTag("0/0"),
@@ -101,7 +101,7 @@ func (s *managedfsSuite) TestAttachFilesystems(c *gc.C) {
 
 	s.blockDevices[names.NewVolumeTag("0")] = storage.BlockDevice{
 		DeviceName: "sda",
-		Serial:     "capncrunch",
+		HardwareId: "capncrunch",
 		Size:       2,
 	}
 	s.filesystems[names.NewFilesystemTag("0/0")] = storage.Filesystem{

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -15,9 +15,9 @@ type Volume struct {
 	// volume, but may be reused.
 	VolumeId string
 
-	// Serial is the volume's serial number. Not all volumes have a serial
-	// number, so this may be left blank.
-	Serial string
+	// HardwareId is the volume's hardware ID. Not all volumes have
+	// a hardware ID, so this may be left blank.
+	HardwareId string
 
 	// Size is the size of the volume, in MiB.
 	Size uint64

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -695,7 +695,7 @@ func volumesToApiserver(volumes []storage.Volume) []params.Volume {
 		result[i] = params.Volume{
 			v.Tag.String(),
 			v.VolumeId,
-			v.Serial,
+			v.HardwareId,
 			v.Size,
 			v.Persistent,
 		}

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -448,7 +448,7 @@ func (*dummyVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storag
 		volumes = append(volumes, storage.Volume{
 			Tag:        p.Tag,
 			Size:       p.Size,
-			Serial:     "serial-" + p.Tag.Id(),
+			HardwareId: "serial-" + p.Tag.Id(),
 			VolumeId:   "id-" + p.Tag.Id(),
 			Persistent: persistent,
 		})

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -69,14 +69,14 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 	expectedVolumes := []params.Volume{{
 		VolumeTag:  "volume-1",
 		VolumeId:   "id-1",
-		Serial:     "serial-1",
+		HardwareId: "serial-1",
 		Size:       1024,
 		Persistent: true,
 	}, {
-		VolumeTag: "volume-2",
-		VolumeId:  "id-2",
-		Serial:    "serial-2",
-		Size:      1024,
+		VolumeTag:  "volume-2",
+		VolumeId:   "id-2",
+		HardwareId: "serial-2",
+		Size:       1024,
 	}}
 	expectedVolumeAttachments := []params.VolumeAttachment{{
 		VolumeTag:  "volume-1",

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -509,7 +509,7 @@ func volumesFromStorage(in []storage.Volume) []params.Volume {
 		out[i] = params.Volume{
 			v.Tag.String(),
 			v.VolumeId,
-			v.Serial,
+			v.HardwareId,
 			v.Size,
 			v.Persistent,
 		}
@@ -538,7 +538,7 @@ func volumeFromParams(in params.Volume) (storage.Volume, error) {
 	return storage.Volume{
 		volumeTag,
 		in.VolumeId,
-		in.Serial,
+		in.HardwareId,
 		in.Size,
 		in.Persistent,
 	}, nil


### PR DESCRIPTION
Before it's too late.

(Serial was not really the serial, but a combination of serial,
model and vendor. The combination makes up the value used to
identify disks in /dev/disks/by-id/.)

(Review request: http://reviews.vapour.ws/r/1517/)