### PR TITLE
cmd/juju/storage: add args to "pool create" usage

### DIFF
--- a/cmd/juju/storage/poolcreate.go
+++ b/cmd/juju/storage/poolcreate.go
@@ -82,6 +82,7 @@ func (c *PoolCreateCommand) Init(args []string) (err error) {
 func (c *PoolCreateCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create",
+		Args:    "<name> <provider> [<key>=<value> [<key>=<value>...]]",
 		Purpose: "create storage pool",
 		Doc:     PoolCreateCommandDoc,
 	}


### PR DESCRIPTION
Add the expected positional arguments for the pool
create subcommand's usage/help.

(Review request: http://reviews.vapour.ws/r/1518/)