### PR TITLE
Fix lp:1446264 by using joyent kvm packages only

### DIFF
--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -336,6 +336,17 @@ func (s *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {
 	c.Assert(sources, gc.HasLen, 0)
 }
 
+func (s *localServerSuite) TestFindInstanceSpec(c *gc.C) {
+	env := s.Prepare(c)
+	spec, err := joyent.FindInstanceSpec(env, "trusty", "amd64", "mem=4G")
+	c.Assert(err, gc.IsNil)
+	c.Assert(spec.InstanceType.VirtType, gc.NotNil)
+	c.Check(spec.Image.Arch, gc.Equals, "amd64")
+	c.Check(spec.Image.VirtType, gc.Equals, "kvm")
+	c.Check(*spec.InstanceType.VirtType, gc.Equals, "kvm")
+	c.Check(spec.InstanceType.CpuCores, gc.Equals, uint64(4))
+}
+
 func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 	env := s.Prepare(c)
 	// An error occurs if no suitable image is found.


### PR DESCRIPTION
Currently the joyent provider does not distinguish between
kvm and smart package types, it just assumes all listed
packages are kvm. This causes CreateMachine to fail if it
happens to try combining a smart package with a kvm image.

Unfortunately, the Joyent ListPackages api does not include
the virt type, however according to the Joyent developers
only the kvm packages have VCPUs set to one or greater.

Change the joyent provider to correctly label the packages
virt type based on the number of vcpus, and constrain
InstanceSpec selection to kvm packages and images only.

(Review request: http://reviews.vapour.ws/r/1519/)