### PR TITLE
Merge pull request #2155 from wallyworld/machine-blockrecord-upgrade

### DIFF
--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -78,9 +78,6 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 		if !blockDevicesChanged(oldInfo, newInfo) {
 			return nil, jujutxn.ErrNoOperations
 		}
-		// TODO(axw) before the storage feature can come off,
-		// we need to add an upgrade step to add a block
-		// devices doc to existing machines.
 		ops := []txn.Op{{
 			C:      machinesC,
 			Id:     machineId,
@@ -101,6 +98,7 @@ func createMachineBlockDevicesOp(machineId string) txn.Op {
 		C:      blockDevicesC,
 		Id:     machineId,
 		Insert: &blockDevicesDoc{Machine: machineId},
+		Assert: txn.DocMissing,
 	}
 }
 

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -31,6 +31,10 @@ var stateUpgradeOperations = func() []Operation {
 			version.MustParse("1.23.0"),
 			stateStepsFor123(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.24.0"),
+			stateStepsFor124(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -1,0 +1,21 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import "github.com/juju/juju/state"
+
+// stateStepsFor124 returns upgrade steps for Juju 1.24 that manipulate state directly.
+func stateStepsFor124() []Step {
+	var steps []Step
+	steps = append(steps,
+		&upgradeStep{
+			description: "add block device documents for existing machines",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddDefaultBlockDevicesDocs(context.State())
+			},
+		},
+	)
+	return steps
+}

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
+)
+
+type steps124Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps124Suite{})
+
+func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
+	expected := []string{
+		"add block device documents for existing machines",
+	}
+	assertStateSteps(c, version.MustParse("1.24.0"), expected)
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -666,7 +666,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.23.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0"})
 }
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {


### PR DESCRIPTION
Machine blockdevices doc upgrade

Fixes: https://bugs.launchpad.net/juju-core/+bug/1449302

When upgrading to 1.24, empty block devices records are created for existing machines.

(Review request: http://reviews.vapour.ws/r/1516/)

(Review request: http://reviews.vapour.ws/r/1524/)