### PR TITLE
Don't issue stop hook until all storage detached (1.24)

### DIFF
--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -124,22 +124,10 @@ func (sa *StorageAccessor) WatchStorageAttachment(storageTag names.StorageTag, u
 	return w, nil
 }
 
-// EnsureStorageAttachmentDead ensures that the storage attachment
-// with the specified unit and storage tags is Dead.
-func (sa *StorageAccessor) EnsureStorageAttachmentDead(storageTag names.StorageTag, unitTag names.UnitTag) error {
-	return sa.ensureDeadOrRemoveStorageAttachment("EnsureStorageAttachmentsDead", storageTag, unitTag)
-}
-
 // RemoveStorageAttachment removes the storage attachment with the
 // specified unit and storage tags from state. This method is only
 // expected to succeed if the storage attachment is Dead.
 func (sa *StorageAccessor) RemoveStorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) error {
-	return sa.ensureDeadOrRemoveStorageAttachment("RemoveStorageAttachments", storageTag, unitTag)
-}
-
-func (sa *StorageAccessor) ensureDeadOrRemoveStorageAttachment(
-	method string, storageTag names.StorageTag, unitTag names.UnitTag,
-) error {
 	var results params.ErrorResults
 	args := params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{{
@@ -147,7 +135,7 @@ func (sa *StorageAccessor) ensureDeadOrRemoveStorageAttachment(
 			UnitTag:    unitTag.String(),
 		}},
 	}
-	err := sa.facade.FacadeCall(method, args, &results)
+	err := sa.facade.FacadeCall("RemoveStorageAttachments", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -99,7 +99,7 @@ func (sa *StorageAccessor) StorageAttachment(storageTag names.StorageTag, unitTa
 	return result.Result, nil
 }
 
-// WatchStorageAttachmentInfos starts a watcher for changes to the info
+// WatchStorageAttachments starts a watcher for changes to the info
 // of the storage attachment with the specified unit and storage tags.
 func (sa *StorageAccessor) WatchStorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
@@ -109,7 +109,7 @@ func (sa *StorageAccessor) WatchStorageAttachment(storageTag names.StorageTag, u
 			UnitTag:    unitTag.String(),
 		}},
 	}
-	err := sa.facade.FacadeCall("WatchStorageAttachmentInfos", args, &results)
+	err := sa.facade.FacadeCall("WatchStorageAttachments", args, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -171,32 +171,6 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 	c.Assert(attachment, gc.DeepEquals, storageAttachment)
 }
 
-func (s *storageSuite) TestEnsureStorageAttachmentDead(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "Uniter")
-		c.Check(version, gc.Equals, 2)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "EnsureStorageAttachmentsDead")
-		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
-			Ids: []params.StorageAttachmentId{{
-				StorageTag: "storage-data-0",
-				UnitTag:    "unit-mysql-0",
-			}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{
-				Error: &params.Error{Message: "yessirilikeit"},
-			}},
-		}
-		return nil
-	})
-
-	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	err := st.EnsureStorageAttachmentDead(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
-	c.Check(err, gc.ErrorMatches, "yessirilikeit")
-}
-
 func (s *storageSuite) TestRemoveStorageAttachment(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Uniter")

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -110,7 +110,7 @@ func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
 		c.Check(objType, gc.Equals, "Uniter")
 		c.Check(version, gc.Equals, 2)
 		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "WatchStorageAttachmentInfos")
+		c.Check(request, gc.Equals, "WatchStorageAttachments")
 		c.Check(arg, gc.DeepEquals, params.StorageAttachmentIds{
 			Ids: []params.StorageAttachmentId{{
 				StorageTag: "storage-data-0",

--- a/apiserver/common/environwatcher_test.go
+++ b/apiserver/common/environwatcher_test.go
@@ -39,7 +39,7 @@ func (*fakeEnvironAccessor) WatchForEnvironConfigChanges() state.NotifyWatcher {
 	changes := make(chan struct{}, 1)
 	// Simulate initial event.
 	changes <- struct{}{}
-	return &fakeNotifyWatcher{changes}
+	return &fakeNotifyWatcher{changes: changes}
 }
 
 func (f *fakeEnvironAccessor) EnvironConfig() (*config.Config, error) {

--- a/apiserver/common/export_test.go
+++ b/apiserver/common/export_test.go
@@ -3,6 +3,8 @@
 
 package common
 
+import "github.com/juju/juju/state"
+
 var (
 	MachineJobFromParams = machineJobFromParams
 	ValidateNewFacade    = validateNewFacade
@@ -27,4 +29,9 @@ type Versions versions
 
 func DescriptionFromVersions(name string, vers Versions) FacadeDescription {
 	return descriptionFromVersions(name, versions(vers))
+}
+
+func NewMultiNotifyWatcher(w ...state.NotifyWatcher) state.NotifyWatcher {
+	mw := newMultiNotifyWatcher(w...)
+	return mw
 }

--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -129,10 +129,10 @@ func filesystemStorageAttachmentInfo(
 	}, nil
 }
 
-// WatchStorageAttachmentInfo returns a state.NotifyWatcher that reacts to changes
+// WatchStorageAttachment returns a state.NotifyWatcher that reacts to changes
 // to the VolumeAttachmentInfo or FilesystemAttachmentInfo corresponding to the tags
 // specified.
-func WatchStorageAttachmentInfo(
+func WatchStorageAttachment(
 	st StorageInterface,
 	storageTag names.StorageTag,
 	machineTag names.MachineTag,

--- a/apiserver/storage/package_test.go
+++ b/apiserver/storage/package_test.go
@@ -203,6 +203,7 @@ type mockState struct {
 	storageInstanceVolumeAttachment     func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	storageInstanceFilesystem           func(names.StorageTag) (state.Filesystem, error)
 	storageInstanceFilesystemAttachment func(m names.MachineTag, f names.FilesystemTag) (state.FilesystemAttachment, error)
+	watchStorageAttachment              func(names.StorageTag, names.UnitTag) state.NotifyWatcher
 	watchFilesystemAttachment           func(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	watchVolumeAttachment               func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	envName                             string
@@ -242,6 +243,10 @@ func (st *mockState) StorageInstanceVolume(s names.StorageTag) (state.Volume, er
 
 func (st *mockState) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
 	return st.storageInstanceVolumeAttachment(m, v)
+}
+
+func (st *mockState) WatchStorageAttachment(s names.StorageTag, u names.UnitTag) state.NotifyWatcher {
+	return st.watchStorageAttachment(s, u)
 }
 
 func (st *mockState) WatchFilesystemAttachment(mtag names.MachineTag, f names.FilesystemTag) state.NotifyWatcher {

--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -35,6 +35,9 @@ type storageAccess interface {
 	// VolumeAttachment is required for storage functionality.
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 
+	// WatchStorageAttachment is required for storage functionality.
+	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
+
 	// WatchFilesystemAttachment is required for storage functionality.
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -11,7 +11,6 @@ import (
 )
 
 type storageStateInterface interface {
-	EnsureStorageAttachmentDead(names.StorageTag, names.UnitTag) error
 	RemoveStorageAttachment(names.StorageTag, names.UnitTag) error
 	StorageInstance(names.StorageTag) (state.StorageInstance, error)
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
@@ -22,6 +21,7 @@ type storageStateInterface interface {
 	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	WatchStorageAttachments(names.UnitTag) state.StringsWatcher
+	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 }

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -213,7 +213,7 @@ func (s *StorageAPI) watchOneStorageAttachment(id params.StorageAttachmentId, ca
 	if err != nil {
 		return nothing, err
 	}
-	watch, err := common.WatchStorageAttachmentInfo(s.st, storageTag, machineTag)
+	watch, err := common.WatchStorageAttachmentInfo(s.st, storageTag, machineTag, unitTag)
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}
@@ -223,40 +223,6 @@ func (s *StorageAPI) watchOneStorageAttachment(id params.StorageAttachmentId, ca
 		}, nil
 	}
 	return nothing, watcher.EnsureErr(watch)
-}
-
-// EnsureStorageAttachmentsDead ensures that the specified storage
-// attachments are made to be Dead, if they are Alive or Dying.
-func (s *StorageAPI) EnsureStorageAttachmentsDead(args params.StorageAttachmentIds) (params.ErrorResults, error) {
-	canAccess, err := s.accessUnit()
-	if err != nil {
-		return params.ErrorResults{}, err
-	}
-	results := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(args.Ids)),
-	}
-	for i, id := range args.Ids {
-		err := s.ensureOneStorageAttachmentDead(id, canAccess)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(err)
-		}
-	}
-	return results, nil
-}
-
-func (s *StorageAPI) ensureOneStorageAttachmentDead(id params.StorageAttachmentId, canAccess func(names.Tag) bool) error {
-	unitTag, err := names.ParseUnitTag(id.UnitTag)
-	if err != nil {
-		return err
-	}
-	if !canAccess(unitTag) {
-		return common.ErrPerm
-	}
-	storageTag, err := names.ParseStorageTag(id.StorageTag)
-	if err != nil {
-		return err
-	}
-	return s.st.EnsureStorageAttachmentDead(storageTag, unitTag)
 }
 
 // RemoveStorageAttachments removes the specified storage

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -173,10 +173,10 @@ func (s *StorageAPI) watchOneUnitStorageAttachments(tag string, canAccess func(n
 	return nothing, watcher.EnsureErr(watch)
 }
 
-// WatchStorageAttachmentInfos creates watchers for a collection of storage
+// WatchStorageAttachments creates watchers for a collection of storage
 // attachments, each of which can be used to watch changes to storage
 // attachment info.
-func (s *StorageAPI) WatchStorageAttachmentInfos(args params.StorageAttachmentIds) (params.NotifyWatchResults, error) {
+func (s *StorageAPI) WatchStorageAttachments(args params.StorageAttachmentIds) (params.NotifyWatchResults, error) {
 	canAccess, err := s.accessUnit()
 	if err != nil {
 		return params.NotifyWatchResults{}, err
@@ -213,7 +213,7 @@ func (s *StorageAPI) watchOneStorageAttachment(id params.StorageAttachmentId, ca
 	if err != nil {
 		return nothing, err
 	}
-	watch, err := common.WatchStorageAttachmentInfo(s.st, storageTag, machineTag, unitTag)
+	watch, err := common.WatchStorageAttachment(s.st, storageTag, machineTag, unitTag)
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -124,7 +124,6 @@ func (s *storageSuite) TestWatchStorageAttachmentVolume(c *gc.C) {
 			NotifyWatcherId: "1",
 		}},
 	})
-	//c.Assert(resources.Get("1"), gc.Equals, watcher)
 	c.Assert(calls, gc.DeepEquals, []string{
 		"UnitAssignedMachine",
 		"StorageInstance",
@@ -200,7 +199,6 @@ func (s *storageSuite) TestWatchStorageAttachmentFilesystem(c *gc.C) {
 			NotifyWatcherId: "1",
 		}},
 	})
-	//c.Assert(resources.Get("1"), gc.Equals, watcher)
 	c.Assert(calls, gc.DeepEquals, []string{
 		"UnitAssignedMachine",
 		"StorageInstance",

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -70,10 +71,14 @@ func (s *storageSuite) TestWatchStorageAttachmentVolume(c *gc.C) {
 	volumeTag := names.NewVolumeTag("104")
 	volume := &mockVolume{tag: volumeTag}
 	storageInstance := &mockStorageInstance{kind: state.StorageKindBlock}
-	watcher := &mockNotifyWatcher{
+	storageWatcher := &mockNotifyWatcher{
 		changes: make(chan struct{}, 1),
 	}
-	watcher.changes <- struct{}{}
+	storageWatcher.changes <- struct{}{}
+	volumeWatcher := &mockNotifyWatcher{
+		changes: make(chan struct{}, 1),
+	}
+	volumeWatcher.changes <- struct{}{}
 	var calls []string
 	state := &mockStorageState{
 		storageInstance: func(s names.StorageTag) (state.StorageInstance, error) {
@@ -91,11 +96,17 @@ func (s *storageSuite) TestWatchStorageAttachmentVolume(c *gc.C) {
 			c.Assert(u, gc.DeepEquals, unitTag)
 			return machineTag, nil
 		},
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) state.NotifyWatcher {
+			calls = append(calls, "WatchStorageAttachment")
+			c.Assert(s, gc.DeepEquals, storageTag)
+			c.Assert(u, gc.DeepEquals, unitTag)
+			return storageWatcher
+		},
 		watchVolumeAttachment: func(m names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
 			calls = append(calls, "WatchVolumeAttachment")
 			c.Assert(m, gc.DeepEquals, machineTag)
 			c.Assert(v, gc.DeepEquals, volumeTag)
-			return watcher
+			return volumeWatcher
 		},
 	}
 
@@ -113,12 +124,13 @@ func (s *storageSuite) TestWatchStorageAttachmentVolume(c *gc.C) {
 			NotifyWatcherId: "1",
 		}},
 	})
-	c.Assert(resources.Get("1"), gc.Equals, watcher)
+	//c.Assert(resources.Get("1"), gc.Equals, watcher)
 	c.Assert(calls, gc.DeepEquals, []string{
 		"UnitAssignedMachine",
 		"StorageInstance",
 		"StorageInstanceVolume",
 		"WatchVolumeAttachment",
+		"WatchStorageAttachment",
 	})
 }
 
@@ -135,10 +147,14 @@ func (s *storageSuite) TestWatchStorageAttachmentFilesystem(c *gc.C) {
 	filesystemTag := names.NewFilesystemTag("104")
 	filesystem := &mockFilesystem{tag: filesystemTag}
 	storageInstance := &mockStorageInstance{kind: state.StorageKindFilesystem}
-	watcher := &mockNotifyWatcher{
+	storageWatcher := &mockNotifyWatcher{
 		changes: make(chan struct{}, 1),
 	}
-	watcher.changes <- struct{}{}
+	storageWatcher.changes <- struct{}{}
+	filesystemWatcher := &mockNotifyWatcher{
+		changes: make(chan struct{}, 1),
+	}
+	filesystemWatcher.changes <- struct{}{}
 	var calls []string
 	state := &mockStorageState{
 		storageInstance: func(s names.StorageTag) (state.StorageInstance, error) {
@@ -156,11 +172,17 @@ func (s *storageSuite) TestWatchStorageAttachmentFilesystem(c *gc.C) {
 			c.Assert(u, gc.DeepEquals, unitTag)
 			return machineTag, nil
 		},
+		watchStorageAttachment: func(s names.StorageTag, u names.UnitTag) state.NotifyWatcher {
+			calls = append(calls, "WatchStorageAttachment")
+			c.Assert(s, gc.DeepEquals, storageTag)
+			c.Assert(u, gc.DeepEquals, unitTag)
+			return storageWatcher
+		},
 		watchFilesystemAttachment: func(m names.MachineTag, f names.FilesystemTag) state.NotifyWatcher {
 			calls = append(calls, "WatchFilesystemAttachment")
 			c.Assert(m, gc.DeepEquals, machineTag)
 			c.Assert(f, gc.DeepEquals, filesystemTag)
-			return watcher
+			return filesystemWatcher
 		},
 	}
 
@@ -178,22 +200,14 @@ func (s *storageSuite) TestWatchStorageAttachmentFilesystem(c *gc.C) {
 			NotifyWatcherId: "1",
 		}},
 	})
-	c.Assert(resources.Get("1"), gc.Equals, watcher)
+	//c.Assert(resources.Get("1"), gc.Equals, watcher)
 	c.Assert(calls, gc.DeepEquals, []string{
 		"UnitAssignedMachine",
 		"StorageInstance",
 		"StorageInstanceFilesystem",
 		"WatchFilesystemAttachment",
+		"WatchStorageAttachment",
 	})
-}
-
-func (s *storageSuite) TestEnsureStorageAttachmentsDead(c *gc.C) {
-	setMock := func(st *mockStorageState, f func(s names.StorageTag, u names.UnitTag) error) {
-		st.ensureDead = f
-	}
-	s.testEnsureDeadOrRemoveStorageAttachments(
-		c, setMock, (*uniter.StorageAPI).EnsureStorageAttachmentsDead,
-	)
 }
 
 func (s *storageSuite) TestRemoveStorageAttachments(c *gc.C) {
@@ -267,18 +281,14 @@ func (s *storageSuite) testEnsureDeadOrRemoveStorageAttachments(
 type mockStorageState struct {
 	uniter.StorageStateInterface
 	remove                    func(names.StorageTag, names.UnitTag) error
-	ensureDead                func(names.StorageTag, names.UnitTag) error
 	storageInstance           func(names.StorageTag) (state.StorageInstance, error)
 	storageInstanceFilesystem func(names.StorageTag) (state.Filesystem, error)
 	storageInstanceVolume     func(names.StorageTag) (state.Volume, error)
 	unitAssignedMachine       func(names.UnitTag) (names.MachineTag, error)
 	watchStorageAttachments   func(names.UnitTag) state.StringsWatcher
+	watchStorageAttachment    func(names.StorageTag, names.UnitTag) state.NotifyWatcher
 	watchFilesystemAttachment func(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	watchVolumeAttachment     func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
-}
-
-func (m *mockStorageState) EnsureStorageAttachmentDead(s names.StorageTag, u names.UnitTag) error {
-	return m.ensureDead(s, u)
 }
 
 func (m *mockStorageState) RemoveStorageAttachment(s names.StorageTag, u names.UnitTag) error {
@@ -305,6 +315,10 @@ func (m *mockStorageState) WatchStorageAttachments(u names.UnitTag) state.String
 	return m.watchStorageAttachments(u)
 }
 
+func (m *mockStorageState) WatchStorageAttachment(s names.StorageTag, u names.UnitTag) state.NotifyWatcher {
+	return m.watchStorageAttachment(s, u)
+}
+
 func (m *mockStorageState) WatchFilesystemAttachment(mtag names.MachineTag, f names.FilesystemTag) state.NotifyWatcher {
 	return m.watchFilesystemAttachment(mtag, f)
 }
@@ -323,8 +337,25 @@ func (m *mockStringsWatcher) Changes() <-chan []string {
 }
 
 type mockNotifyWatcher struct {
-	state.NotifyWatcher
+	tomb    tomb.Tomb
 	changes chan struct{}
+}
+
+func (m *mockNotifyWatcher) Stop() error {
+	m.Kill()
+	return m.Wait()
+}
+
+func (m *mockNotifyWatcher) Kill() {
+	m.tomb.Kill(nil)
+}
+
+func (m *mockNotifyWatcher) Wait() error {
+	return m.tomb.Wait()
+}
+
+func (m *mockNotifyWatcher) Err() error {
+	return m.tomb.Err()
 }
 
 func (m *mockNotifyWatcher) Changes() <-chan struct{} {

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -112,7 +112,7 @@ func (s *storageSuite) TestWatchStorageAttachmentVolume(c *gc.C) {
 
 	storage, err := uniter.NewStorageAPI(state, resources, getCanAccess)
 	c.Assert(err, jc.ErrorIsNil)
-	watches, err := storage.WatchStorageAttachmentInfos(params.StorageAttachmentIds{
+	watches, err := storage.WatchStorageAttachments(params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{{
 			StorageTag: storageTag.String(),
 			UnitTag:    unitTag.String(),
@@ -188,7 +188,7 @@ func (s *storageSuite) TestWatchStorageAttachmentFilesystem(c *gc.C) {
 
 	storage, err := uniter.NewStorageAPI(state, resources, getCanAccess)
 	c.Assert(err, jc.ErrorIsNil)
-	watches, err := storage.WatchStorageAttachmentInfos(params.StorageAttachmentIds{
+	watches, err := storage.WatchStorageAttachments(params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{{
 			StorageTag: storageTag.String(),
 			UnitTag:    unitTag.String(),

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -352,7 +352,42 @@ func (s *CleanupSuite) TestCleanupActions(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 }
 
-func (s *CleanupSuite) TestCleanupStorage(c *gc.C) {
+func (s *CleanupSuite) TestCleanupStorageAttachments(c *gc.C) {
+	s.assertDoesNotNeedCleanup(c)
+
+	ch := s.AddTestingCharm(c, "storage-block")
+	storage := map[string]state.StorageConstraints{
+		"data": makeStorageCons("block", 1024, 1),
+	}
+	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
+	u, err := service.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// check no cleanups
+	s.assertDoesNotNeedCleanup(c)
+
+	// this tag matches the storage instance created for the unit above.
+	storageTag := names.NewStorageTag("data/0")
+
+	sa, err := s.State.StorageAttachment(storageTag, u.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sa.Life(), gc.Equals, state.Alive)
+
+	// destroy unit and run cleanups; the attachment should be marked dying
+	err = u.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertCleanupRuns(c)
+
+	// After running the cleanup, the attachment should be dying.
+	sa, err = s.State.StorageAttachment(storageTag, u.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sa.Life(), gc.Equals, state.Dying)
+
+	// check no cleanups
+	s.assertDoesNotNeedCleanup(c)
+}
+
+func (s *CleanupSuite) TestCleanupStorageInstances(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
 	ch := s.AddTestingCharm(c, "storage-block")

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -24,6 +24,11 @@ type CleanupSuite struct {
 
 var _ = gc.Suite(&CleanupSuite{})
 
+func (s *CleanupSuite) SetUpSuite(c *gc.C) {
+	s.ConnSuite.SetUpSuite(c)
+	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
+}
+
 func (s *CleanupSuite) TestCleanupDyingServiceUnits(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
@@ -357,7 +362,7 @@ func (s *CleanupSuite) TestCleanupStorageAttachments(c *gc.C) {
 
 	ch := s.AddTestingCharm(c, "storage-block")
 	storage := map[string]state.StorageConstraints{
-		"data": makeStorageCons("block", 1024, 1),
+		"data": makeStorageCons("loop", 1024, 1),
 	}
 	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, storage)
 	u, err := service.AddUnit()

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -35,7 +35,7 @@ func (s *FilesystemStateSuite) TestAddServiceNoPool(c *gc.C) {
 	}
 	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
 	// TODO(axw) implement support for default filesystem pool.
-	c.Assert(err, gc.ErrorMatches, `cannot add service "storage-filesystem": finding default stoage pool: no storage pool specifed and no default available`)
+	c.Assert(err, gc.ErrorMatches, `cannot add service "storage-filesystem": finding default pool for "data" storage: no storage pool specifed and no default available`)
 }
 
 func (s *FilesystemStateSuite) TestAddFilesystemWithoutBackingVolume(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -1253,6 +1253,9 @@ func (st *State) AddService(
 	if _, err := st.EnvironmentUser(ownerTag); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if storage == nil {
+		storage = make(map[string]StorageConstraints)
+	}
 	if err := addDefaultStorageConstraints(st, storage, ch.Meta()); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -66,13 +66,17 @@ type NotifyWatcher interface {
 // the behaviour of any watcher that uses a <-chan struct{}.
 type NotifyWatcherC struct {
 	*gc.C
-	State   *state.State
+	State   SyncStarter
 	Watcher NotifyWatcher
+}
+
+type SyncStarter interface {
+	StartSync()
 }
 
 // NewNotifyWatcherC returns a NotifyWatcherC that checks for aggressive
 // event coalescence.
-func NewNotifyWatcherC(c *gc.C, st *state.State, w NotifyWatcher) NotifyWatcherC {
+func NewNotifyWatcherC(c *gc.C, st SyncStarter, w NotifyWatcher) NotifyWatcherC {
 	return NotifyWatcherC{
 		C:       c,
 		State:   st,

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -70,6 +70,9 @@ type NotifyWatcherC struct {
 	Watcher NotifyWatcher
 }
 
+// SyncStarter is an interface that watcher checkers will use to ensure
+// that changes to the watched object have been synchronized. This is
+// primarily implemented by state.State.
 type SyncStarter interface {
 	StartSync()
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1355,14 +1355,6 @@ func (w *settingsWatcher) loop(key string) (err error) {
 	}
 }
 
-// entityWatcher generates an event when a document in the db changes
-type entityWatcher struct {
-	commonWatcher
-	out chan struct{}
-}
-
-var _ Watcher = (*entityWatcher)(nil)
-
 // WatchHardwareCharacteristics returns a watcher for observing changes to a machine's hardware characteristics.
 func (m *Machine) WatchHardwareCharacteristics() NotifyWatcher {
 	return newEntityWatcher(m.st, instanceDataC, m.doc.DocID)
@@ -1418,6 +1410,13 @@ func (st *State) WatchAPIHostPorts() NotifyWatcher {
 	return newEntityWatcher(st, stateServersC, apiHostPortsKey)
 }
 
+// WatchStorageAttachment returns a watcher for observing changes
+// to a storage attachment.
+func (st *State) WatchStorageAttachment(s names.StorageTag, u names.UnitTag) NotifyWatcher {
+	id := storageAttachmentId(u.Id(), s.Id())
+	return newEntityWatcher(st, storageAttachmentsC, st.docID(id))
+}
+
 // WatchVolumeAttachment returns a watcher for observing changes
 // to a volume attachment.
 func (st *State) WatchVolumeAttachment(m names.MachineTag, v names.VolumeTag) NotifyWatcher {
@@ -1471,6 +1470,8 @@ type docWatcher struct {
 	out chan struct{}
 }
 
+var _ Watcher = (*docWatcher)(nil)
+
 type docKey struct {
 	coll string
 	key  interface{}
@@ -1490,7 +1491,7 @@ func newDocWatcher(st *State, docKeys []docKey) NotifyWatcher {
 	return w
 }
 
-// Changes returns the event channel for the entityWatcher.
+// Changes returns the event channel for the docWatcher.
 func (w *docWatcher) Changes() <-chan struct{} {
 	return w.out
 }

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -347,7 +347,7 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 		// (ie continuing to act as though leader after leader-deposed has run).
 	}
 	for {
-		if len(u.relations.GetInfo()) == 0 {
+		if len(u.relations.GetInfo()) == 0 && u.storage.Empty() {
 			return continueAfter(u, newSimpleRunHookOp(hooks.Stop))
 		}
 		var creator creator
@@ -361,6 +361,8 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 		case <-u.f.LeaderSettingsEvents():
 			creator = newSimpleRunHookOp(hook.LeaderSettingsChanged)
 		case hookInfo := <-u.relations.Hooks():
+			creator = newRunHookOp(hookInfo)
+		case hookInfo := <-u.storage.Hooks():
 			creator = newRunHookOp(hookInfo)
 		}
 		if err := u.runOperation(creator); err != nil {

--- a/worker/uniter/storage/mock_test.go
+++ b/worker/uniter/storage/mock_test.go
@@ -21,7 +21,6 @@ type mockStorageAccessor struct {
 	watchStorageAttachment func(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
 	storageAttachment      func(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
 	unitStorageAttachments func(names.UnitTag) ([]params.StorageAttachment, error)
-	ensureDead             func(names.StorageTag, names.UnitTag) error
 	remove                 func(names.StorageTag, names.UnitTag) error
 }
 
@@ -35,10 +34,6 @@ func (m *mockStorageAccessor) StorageAttachment(s names.StorageTag, u names.Unit
 
 func (m *mockStorageAccessor) UnitStorageAttachments(u names.UnitTag) ([]params.StorageAttachment, error) {
 	return m.unitStorageAttachments(u)
-}
-
-func (m *mockStorageAccessor) EnsureStorageAttachmentDead(s names.StorageTag, u names.UnitTag) error {
-	return m.ensureDead(s, u)
 }
 
 func (m *mockStorageAccessor) RemoveStorageAttachment(s names.StorageTag, u names.UnitTag) error {

--- a/worker/uniter/storage/storager.go
+++ b/worker/uniter/storage/storager.go
@@ -45,6 +45,7 @@ func newStorager(
 	}, nil
 }
 
+// Stop stops the storager from generating or sending any more hook events.
 func (s *storager) Stop() error {
 	if err := s.sender.Stop(); err != nil {
 		return errors.Annotate(err, "stopping storage event sender")

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -76,9 +76,8 @@ func (s *UniterSuite) SetUpTest(c *gc.C) {
 	s.ticker = uniter.NewManualTicker()
 	s.PatchValue(uniter.ActiveMetricsTimer, s.ticker.ReturnTimer)
 	s.PatchValue(uniter.IdleWaitTime, 1*time.Millisecond)
-	// The storage feature will disappear shortly. In the mean time,
-	// we ensure that all scenarios operate correctly with storage
-	// enabled.
+	// The storage feature flag will disappear shortly. In the mean time,
+	// we ensure that all scenarios operate correctly with storage enabled.
 	s.JujuConnSuite.SetFeatureFlags(feature.Storage)
 }
 

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -76,9 +75,6 @@ func (s *UniterSuite) SetUpTest(c *gc.C) {
 	s.ticker = uniter.NewManualTicker()
 	s.PatchValue(uniter.ActiveMetricsTimer, s.ticker.ReturnTimer)
 	s.PatchValue(uniter.IdleWaitTime, 1*time.Millisecond)
-	// The storage feature flag will disappear shortly. In the mean time,
-	// we ensure that all scenarios operate correctly with storage enabled.
-	s.JujuConnSuite.SetFeatureFlags(feature.Storage)
 }
 
 func (s *UniterSuite) TearDownTest(c *gc.C) {

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -296,6 +296,9 @@ var (
 	leaderCharmHooks = []string{
 		"leader-elected", "leader-deposed", "leader-settings-changed",
 	}
+	storageCharmHooks = []string{
+		"wp-content-storage-attached", "wp-content-storage-detached",
+	}
 )
 
 func startupHooks(minion bool) []string {
@@ -311,6 +314,7 @@ func (s createCharm) step(c *gc.C, ctx *context) {
 
 	allCharmHooks := baseCharmHooks
 	allCharmHooks = append(allCharmHooks, leaderCharmHooks...)
+	allCharmHooks = append(allCharmHooks, storageCharmHooks...)
 
 	for _, name := range allCharmHooks {
 		path := filepath.Join(base, "hooks", name)
@@ -1619,4 +1623,56 @@ func (s startGitUpgradeError) step(c *gc.C, ctx *context) {
 	for _, s_ := range steps {
 		step(c, ctx, s_)
 	}
+}
+
+type provisionStorage struct{}
+
+func (s provisionStorage) step(c *gc.C, ctx *context) {
+	storageAttachments, err := ctx.st.UnitStorageAttachments(ctx.unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 1)
+
+	filesystem, err := ctx.st.StorageInstanceFilesystem(storageAttachments[0].StorageInstance())
+	c.Assert(err, jc.ErrorIsNil)
+
+	filesystemInfo := state.FilesystemInfo{
+		Size:         1024,
+		FilesystemId: "fs-id",
+	}
+	err = ctx.st.SetFilesystemInfo(filesystem.FilesystemTag(), filesystemInfo)
+	c.Assert(err, jc.ErrorIsNil)
+
+	machineId, err := ctx.unit.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+
+	filesystemAttachmentInfo := state.FilesystemAttachmentInfo{
+		MountPoint: "/srv/wordpress/content",
+	}
+	err = ctx.st.SetFilesystemAttachmentInfo(
+		names.NewMachineTag(machineId),
+		filesystem.FilesystemTag(),
+		filesystemAttachmentInfo,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type destroyStorageAttachment struct{}
+
+func (s destroyStorageAttachment) step(c *gc.C, ctx *context) {
+	storageAttachments, err := ctx.st.UnitStorageAttachments(ctx.unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 1)
+	err = ctx.st.DestroyStorageAttachment(
+		storageAttachments[0].StorageInstance(),
+		ctx.unit.UnitTag(),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type verifyStorageDetached struct{}
+
+func (s verifyStorageDetached) step(c *gc.C, ctx *context) {
+	storageAttachments, err := ctx.st.UnitStorageAttachments(ctx.unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 0)
 }


### PR DESCRIPTION
When a unit is destroyed, we now destroy its storage
attachments (i.e. set to Dying) in a cleanup. The uniter
watches for these changes and generates storage-detached
hooks. Once a storage-detached hook is committed, the
corresponding storage attachment is removed from state.

The uniter now waits for all storage to be detached before
terminating. This gives charms an opportunity to clean up
before stopping/uninstalling, and we can now destroy units
which use storage.

This change introduces a new watcher in the apiserver/common
package which can be used to combine multiple notify
watchers into one. This is used to watch storage attachments
along with their underlying volume or filesystem attachments.

There is some minor shuffling of code from apiserver/client
to state, relating to storage constraint defaults.

(Review request: http://reviews.vapour.ws/r/1527/)