### PR TITLE
Addressable Containers Feature Flag.

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
@@ -57,6 +58,7 @@ var _ = gc.Suite(&provisionerSuite{})
 
 func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 
 	var err error
 	s.machine, err = s.State.AddMachine("quantal", state.JobManageEnviron)

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -166,6 +166,15 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 	return err, tw.Log()
 }
 
+func (s *prepareSuite) TestErrorWitnNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags() // clear the flags.
+	container := s.newAPI(c, true, true)
+	args := s.makeArgs(container)
+	s.assertCall(c, args, &params.MachineNetworkConfigResults{},
+		`address allocation not supported`,
+	)
+}
+
 func (s *prepareSuite) TestErrorWithNonProvisionedHost(c *gc.C) {
 	container := s.newAPI(c, false, true)
 	args := s.makeArgs(container)
@@ -692,6 +701,15 @@ func (s *releaseSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 	return err
 }
 
+func (s *releaseSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags() // clear the flags.
+	s.newAPI(c, true, false)
+	args := s.makeArgs(s.machines[0])
+	s.assertCall(c, args, &params.ErrorResults{},
+		"address allocation not supported",
+	)
+}
+
 func (s *releaseSuite) TestErrorWithHostInsteadOfContainer(c *gc.C) {
 	s.newAPI(c, true, false)
 	args := s.makeArgs(s.machines[0])
@@ -782,7 +800,7 @@ func (s *releaseSuite) allocateAddresses(c *gc.C, containerId string, numAllocat
 	}
 }
 
-func (s *releaseSuite) TestReleaseContainerAddresses(c *gc.C) {
+func (s *releaseSuite) TestSuccess(c *gc.C) {
 	container := s.newAPI(c, true, true)
 	args := s.makeArgs(container)
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -775,12 +775,17 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 	return result, nil
 }
 
-// ReleaseContainerAddresses finds addresses allocated to a container and marks
-// them as Dead, to be released and removed. It accepts container tags as
-// arguments.
+// ReleaseContainerAddresses finds addresses allocated to a container
+// and marks them as Dead, to be released and removed. It accepts
+// container tags as arguments. If address allocation feature flag is
+// not enabled, it will return a NotSupported error.
 func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
+	}
+
+	if !environs.AddressAllocationEnabled() {
+		return result, errors.NotSupportedf("address allocation")
 	}
 
 	canAccess, err := p.getAuthFunc()
@@ -840,16 +845,16 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 // PrepareContainerInterfaceInfo allocates an address and returns
 // information for configuring networking on a container. It accepts
 // container tags as arguments. If the address allocation feature flag
-// is not enabled, it returns an error satisfying
-// errors.IsNotSupported().
+// is not enabled, it returns a NotSupported error.
 func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (params.MachineNetworkConfigResults, error) {
-	if !environs.AddressAllocationEnabled() {
-		return params.MachineNetworkConfigResults{}, errors.NotSupportedf("address allocation")
-	}
-
 	result := params.MachineNetworkConfigResults{
 		Results: make([]params.MachineNetworkConfigResult, len(args.Entities)),
 	}
+
+	if !environs.AddressAllocationEnabled() {
+		return result, errors.NotSupportedf("address allocation")
+	}
+
 	// Some preparations first.
 	environ, host, canAccess, err := p.prepareContainerAccessEnvironment()
 	if err != nil {

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -222,6 +222,23 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 	cfg := make(map[string]string)
 	cfg[container.ConfigName] = container.DefaultNamespace
 
+	switch args.Type {
+	case instance.LXC:
+		if useLxcClone, ok := config.LXCUseClone(); ok {
+			cfg["use-clone"] = fmt.Sprint(useLxcClone)
+		}
+		if useLxcCloneAufs, ok := config.LXCUseCloneAUFS(); ok {
+			cfg["use-aufs"] = fmt.Sprint(useLxcCloneAufs)
+		}
+	}
+
+	if !environs.AddressAllocationEnabled() {
+		// No need to even try checking the environ for support.
+		logger.Debugf("address allocation feature flag not enabled")
+		result.ManagerConfig = cfg
+		return result, nil
+	}
+
 	// Create an environment to verify networking support.
 	env, err := environs.New(config)
 	if err != nil {
@@ -240,15 +257,6 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 		}
 	}
 
-	switch args.Type {
-	case instance.LXC:
-		if useLxcClone, ok := config.LXCUseClone(); ok {
-			cfg["use-clone"] = fmt.Sprint(useLxcClone)
-		}
-		if useLxcCloneAufs, ok := config.LXCUseCloneAUFS(); ok {
-			cfg["use-aufs"] = fmt.Sprint(useLxcCloneAufs)
-		}
-	}
 	result.ManagerConfig = cfg
 	return result, nil
 }
@@ -831,8 +839,14 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 
 // PrepareContainerInterfaceInfo allocates an address and returns
 // information for configuring networking on a container. It accepts
-// container tags as arguments.
+// container tags as arguments. If the address allocation feature flag
+// is not enabled, it returns an error satisfying
+// errors.IsNotSupported().
 func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (params.MachineNetworkConfigResults, error) {
+	if !environs.AddressAllocationEnabled() {
+		return params.MachineNetworkConfigResults{}, errors.NotSupportedf("address allocation")
+	}
+
 	result := params.MachineNetworkConfigResults{
 		Results: make([]params.MachineNetworkConfigResult, len(args.Entities)),
 	}

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -20,6 +20,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -54,6 +55,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 
 func (s *provisionerSuite) setUpTest(c *gc.C, withStateServer bool) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 
 	// Reset previous machines (if any) and create 3 machines
 	// for the tests, plus an optional state server machine.

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -55,6 +55,9 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 
 func (s *provisionerSuite) setUpTest(c *gc.C, withStateServer bool) {
 	s.JujuConnSuite.SetUpTest(c)
+	// We're testing with address allocation on by default. There are
+	// separate tests to check the behavior when the flag is not
+	// enabled.
 	s.SetFeatureFlags(feature.AddressAllocation)
 
 	// Reset previous machines (if any) and create 3 machines
@@ -1310,6 +1313,16 @@ func (s *withoutStateServerSuite) TestContainerManagerConfig(c *gc.C) {
 	})
 }
 
+func (s *withoutStateServerSuite) TestContainerManagerConfigNoFeatureFlagNoIPForwarding(c *gc.C) {
+	s.SetFeatureFlags() // clear the flags.
+
+	cfg := s.getManagerConfig(c, instance.KVM)
+	c.Assert(cfg, jc.DeepEquals, map[string]string{
+		container.ConfigName: "juju",
+		// ConfigIPForwarding should be missing.
+	})
+}
+
 func (s *withoutStateServerSuite) TestContainerManagerConfigNoIPForwarding(c *gc.C) {
 	// Break dummy provider's SupportsAddressAllocation method to
 	// ensure ConfigIPForwarding is not set below.
@@ -1345,18 +1358,13 @@ func (s *withoutStateServerSuite) TestContainerConfig(c *gc.C) {
 }
 
 func (s *withoutStateServerSuite) TestSetSupportedContainers(c *gc.C) {
-	args := params.MachineContainersParams{
-		Params: []params.MachineContainers{
-			{
-				MachineTag:     "machine-0",
-				ContainerTypes: []instance.ContainerType{instance.LXC},
-			},
-			{
-				MachineTag:     "machine-1",
-				ContainerTypes: []instance.ContainerType{instance.LXC, instance.KVM},
-			},
-		},
-	}
+	args := params.MachineContainersParams{Params: []params.MachineContainers{{
+		MachineTag:     "machine-0",
+		ContainerTypes: []instance.ContainerType{instance.LXC},
+	}, {
+		MachineTag:     "machine-1",
+		ContainerTypes: []instance.ContainerType{instance.LXC, instance.KVM},
+	}}}
 	results, err := s.provisioner.SetSupportedContainers(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/version"
@@ -265,11 +266,19 @@ func shutdownInitCommands(initSystem string) ([]string, error) {
 	shutdownCmd := "/sbin/shutdown -h now"
 	name := "juju-template-restart"
 	desc := "juju shutdown job"
+
+	execStart := shutdownCmd
+	if environs.AddressAllocationEnabled() {
+		// Only do the cleanup and replacement of /e/n/i when address
+		// allocation feature flag is enabled.
+		execStart = replaceNetConfCmd + removeCmd + shutdownCmd
+	}
+
 	conf := common.Conf{
 		Desc:         desc,
 		Transient:    true,
 		AfterStopped: "cloud-final",
-		ExecStart:    replaceNetConfCmd + removeCmd + shutdownCmd,
+		ExecStart:    execStart,
 	}
 	svc, err := service.NewService(name, conf, initSystem)
 	if err != nil {

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/container"
 	containertesting "github.com/juju/juju/container/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/service"
 	systemdtesting "github.com/juju/juju/service/systemd/testing"
@@ -153,6 +154,7 @@ func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 }
 
 func (s *UserDataSuite) TestShutdownInitCommandsUpstart(c *gc.C) {
+	s.SetFeatureFlags(feature.AddressAllocation)
 	cmds, err := containerinit.ShutdownInitCommands(service.InitSystemUpstart)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -185,6 +187,7 @@ end script
 }
 
 func (s *UserDataSuite) TestShutdownInitCommandsSystemd(c *gc.C) {
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.PatchValue(&version.Current.Series, "vivid")
 	commands, err := containerinit.ShutdownInitCommands(service.InitSystemSystemd)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -383,7 +383,7 @@ var DataDir = agent.DefaultDataDir
 // may create a folder containing logs
 var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
 
-// DefaultBridgeName is the network bridge device namme used for LXC and KVM
+// DefaultBridgeName is the network bridge device name used for LXC and KVM
 // containers
 const DefaultBridgeName = "juju-br0"
 

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -383,6 +383,10 @@ var DataDir = agent.DefaultDataDir
 // may create a folder containing logs
 var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
 
+// DefaultBridgeName is the network bridge device namme used for LXC and KVM
+// containers
+const DefaultBridgeName = "juju-br0"
+
 // NewInstanceConfig sets up a basic machine configuration, for a
 // non-bootstrap node. You'll still need to supply more information,
 // but this takes care of the fixed entries and the ones that are

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -33,6 +33,7 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
 	"github.com/juju/juju/network"
@@ -87,6 +88,7 @@ more bogus content`
 
 func (s *LxcSuite) SetUpTest(c *gc.C) {
 	s.TestSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.logDir = c.MkDir()
 	loggo.GetLogger("juju.container.lxc").SetLogLevel(loggo.TRACE)
 	s.events = make(chan mock.Event, 25)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -93,7 +93,8 @@ type BootstrapParams struct {
 	AvailableTools tools.List
 
 	// ContainerBridgeName, if non-empty, overrides the default
-	// network bridge device to use for LXC and KVM containers.
+	// network bridge device to use for LXC and KVM containers. See
+	// also environs.DefaultBridgeName.
 	ContainerBridgeName string
 }
 

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -94,7 +94,7 @@ type BootstrapParams struct {
 
 	// ContainerBridgeName, if non-empty, overrides the default
 	// network bridge device to use for LXC and KVM containers. See
-	// also environs.DefaultBridgeName.
+	// also instancecfg.DefaultBridgeName.
 	ContainerBridgeName string
 }
 

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -4,6 +4,9 @@
 package environs
 
 import (
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
@@ -51,4 +54,10 @@ type NetworkingEnviron interface {
 func SupportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 	ne, ok := environ.(NetworkingEnviron)
 	return ne, ok
+}
+
+// AddressAllocationEnabled is a shortcut for checking if the
+// AddressAllocation feature flag is enabled.
+func AddressAllocationEnabled() bool {
+	return featureflag.Enabled(feature.AddressAllocation)
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -38,6 +38,11 @@ const EnvironmentsCacheFile = "env-cache"
 // instead of systemd for vivid and newer.
 const LegacyUpstart = "legacy-upstart"
 
+// AddressAllocation is used to indicate that LXC and KVM containers
+// on providers that support that (currently only MAAS and EC2) will
+// use statically allocated IP addresses.
+const AddressAllocation = "address-allocation"
+
 // DbLog is the the feature which has Juju's logs go to
 // MongoDB instead of to all-machines.log using rsyslog.
 const DbLog = "db-log"

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1037,6 +1037,10 @@ func (e *environ) Instances(ids []instance.Id) (insts []instance.Instance, err e
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error) {
+	if !environs.AddressAllocationEnabled() {
+		return false, errors.NotSupportedf("address allocation")
+	}
+
 	if err := env.checkBroken("SupportsAddressAllocation"); err != nil {
 		return false, err
 	}
@@ -1051,6 +1055,10 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given subnet.
 func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	if err := env.checkBroken("AllocateAddress"); err != nil {
 		return err
 	}
@@ -1074,6 +1082,10 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	if err := env.checkBroken("ReleaseAddress"); err != nil {
 		return err
 	}

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/jujutest"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -64,6 +65,7 @@ func (s *liveSuite) TearDownSuite(c *gc.C) {
 
 func (s *liveSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.MgoSuite.SetUpTest(c)
 	s.LiveTests.SetUpTest(c)
 }
@@ -93,6 +95,7 @@ func (s *suite) TearDownSuite(c *gc.C) {
 
 func (s *suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.MgoSuite.SetUpTest(c)
 	s.Tests.SetUpTest(c)
 }

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -9,6 +9,7 @@ import (
 	stdtesting "testing"
 	"time"
 
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -159,6 +160,14 @@ func (s *suite) TestSupportsAddressAllocation(c *gc.C) {
 	supported, err = e.SupportsAddressAllocation("any-id")
 	c.Assert(err, gc.ErrorMatches, `dummy\.SupportsAddressAllocation is broken`)
 	c.Assert(supported, jc.IsFalse)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	supported, err = e.SupportsAddressAllocation("any-id")
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(supported, jc.IsFalse)
 }
 
 func (s *suite) breakMethods(c *gc.C, e environs.NetworkingEnviron, names ...string) {
@@ -201,6 +210,13 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 	newAddress = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
 	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
 	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *suite) TestReleaseAddress(c *gc.C) {
@@ -233,6 +249,13 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 	address = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
 	err = e.ReleaseAddress(inst.Id(), subnetId, address)
 	c.Assert(err, gc.ErrorMatches, `dummy\.ReleaseAddress is broken`)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	err = e.ReleaseAddress(inst.Id(), subnetId, address)
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *suite) TestNetworkInterfaces(c *gc.C) {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -228,6 +228,9 @@ func (e *environ) SupportedArchitectures() ([]string, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
+	if !environs.AddressAllocationEnabled() {
+		return false, errors.NotSupportedf("address allocation")
+	}
 	_, hasDefaultVpc, err := e.defaultVpc()
 	if err != nil {
 		return false, errors.Trace(err)
@@ -740,6 +743,10 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
 func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
 
 	var nicId string
@@ -774,6 +781,10 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
 func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to release address %q from instance %q", addr, instId)
 
 	// If the instance ID is unknown the address has already been released

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -887,6 +887,31 @@ func (t *localServerSuite) TestSupportsAddressAllocationTrue(c *gc.C) {
 	c.Assert(result, jc.IsTrue)
 }
 
+func (t *localServerSuite) TestSupportsAddressAllocationWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	result, err := env.SupportsAddressAllocation("")
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(result, jc.IsFalse)
+}
+
+func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	err := env.AllocateAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	err := env.ReleaseAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
 func (t *localServerSuite) TestSupportsAddressAllocationCaches(c *gc.C) {
 	t.srv.ec2srv.SetInitialAttributes(map[string][]string{
 		"default-vpc": {"none"},

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/juju/testing"
@@ -183,6 +184,7 @@ func (t *localServerSuite) TearDownSuite(c *gc.C) {
 
 func (t *localServerSuite) SetUpTest(c *gc.C) {
 	t.BaseSuite.SetUpTest(c)
+	t.SetFeatureFlags(feature.AddressAllocation)
 	t.srv.startServer(c)
 	t.Tests.SetUpTest(c)
 	t.PatchValue(&version.Current, version.Binary{

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -125,13 +125,13 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 		// StartInstance.
 		logger.Infof(
 			"address allocation feature disabled; using %q bridge for all containers",
-			environs.DefaultBridgeName,
+			instancecfg.DefaultBridgeName,
 		)
-		args.ContainerBridgeName = environs.DefaultBridgeName
+		args.ContainerBridgeName = instancecfg.DefaultBridgeName
 	} else {
 		logger.Debugf(
-			"address allocation feature enabled; using static IPs for containers",
-			environs.DefaultBridgeName,
+			"address allocation feature enabled; using static IPs for containers: %q",
+			instancecfg.DefaultBridgeName,
 		)
 	}
 
@@ -898,7 +898,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		if args.InstanceConfig.AgentEnvironment == nil {
 			args.InstanceConfig.AgentEnvironment = make(map[string]string)
 		}
-		args.InstanceConfig.AgentEnvironment[agent.LxcBridge] = environs.DefaultBridgeName
+		args.InstanceConfig.AgentEnvironment[agent.LxcBridge] = instancecfg.DefaultBridgeName
 	}
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, environ.Config()); err != nil {
 		return nil, err
@@ -1073,7 +1073,7 @@ func setupJujuNetworking() (string, error) {
 	var buf bytes.Buffer
 	err := parsedTemplate.Execute(&buf, map[string]interface{}{
 		"Config": "/etc/network/interfaces",
-		"Bridge": environs.DefaultBridgeName,
+		"Bridge": instancecfg.DefaultBridgeName,
 	})
 	if err != nil {
 		return "", errors.Annotate(err, "bridge config template error")
@@ -1114,7 +1114,7 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, series st
 			if on, set := environ.Config().DisableNetworkManagement(); on && set {
 				logger.Infof(
 					"network management disabled - not using %q bridge for containers",
-					environs.DefaultBridgeName,
+					instancecfg.DefaultBridgeName,
 				)
 				break
 			}

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/juju/errors"
@@ -21,6 +23,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"launchpad.net/gomaasapi"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
@@ -115,6 +118,23 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (arch, series string, _ environs.BootstrapFinalizer, _ error) {
+	if !environs.AddressAllocationEnabled() {
+		// When address allocation is not enabled, we should use the
+		// default bridge for both LXC and KVM containers. The bridge
+		// is created as part of the userdata for every node during
+		// StartInstance.
+		logger.Infof(
+			"address allocation feature disabled; using %q bridge for all containers",
+			environs.DefaultBridgeName,
+		)
+		args.ContainerBridgeName = environs.DefaultBridgeName
+	} else {
+		logger.Debugf(
+			"address allocation feature enabled; using static IPs for containers",
+			environs.DefaultBridgeName,
+		)
+	}
+
 	result, series, finalizer, err := common.BootstrapInstance(ctx, env, args)
 	if err != nil {
 		return "", "", nil, err
@@ -213,6 +233,10 @@ func (env *maasEnviron) SupportedArchitectures() ([]string, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
+	if !environs.AddressAllocationEnabled() {
+		return false, errors.NotSupportedf("address allocation")
+	}
+
 	caps, err := env.getCapabilities()
 	if err != nil {
 		return false, errors.Annotatef(err, "getCapabilities failed")
@@ -867,6 +891,15 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	if err != nil {
 		return nil, err
 	}
+	// Override the network bridge to use for both LXC and KVM
+	// containers on the new instance, if address allocation feature
+	// flag is not enabled.
+	if !environs.AddressAllocationEnabled() {
+		if args.InstanceConfig.AgentEnvironment == nil {
+			args.InstanceConfig.AgentEnvironment = make(map[string]string)
+		}
+		args.InstanceConfig.AgentEnvironment[agent.LxcBridge] = environs.DefaultBridgeName
+	}
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, environ.Config()); err != nil {
 		return nil, err
 	}
@@ -998,6 +1031,56 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 	return &node, nil
 }
 
+const bridgeConfigTemplate = `
+# In case we already created the bridge, don't do it again.
+grep -q "iface {{.Bridge}} inet dhcp" && exit 0
+
+# Discover primary interface at run-time using the default route (if set)
+PRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)
+
+# If $PRIMARY_IFACE is empty, there's nothing to do.
+[ -z "$PRIMARY_IFACE" ] && exit 0
+
+# Change the config to make $PRIMARY_IFACE manual instead of DHCP,
+# then create the bridge and enslave $PRIMARY_IFACE into it.
+grep -q "iface ${PRIMARY_IFACE} inet dhcp" {{.Config}} && \
+sed -i "s/iface ${PRIMARY_IFACE} inet dhcp//" {{.Config}} && \
+cat >> {{.Config}} << EOF
+
+# Primary interface (defining the default route)
+iface ${PRIMARY_IFACE} inet manual
+
+# Bridge to use for LXC/KVM containers
+auto {{.Bridge}}
+iface {{.Bridge}} inet dhcp
+    bridge_ports ${PRIMARY_IFACE}
+EOF
+
+# Make the primary interface not auto-starting.
+grep -q "auto ${PRIMARY_IFACE}" {{.Config}} && \
+sed -i "s/auto ${PRIMARY_IFACE}//" {{.Config}}
+
+# Finally, stop $PRIMARY_IFACE and start the bridge instead.
+ifdown -v ${PRIMARY_IFACE} ; ifup -v {{.Bridge}}
+`
+
+// setupJujuNetworking returns a string representing the script to run
+// in order to prepare the Juju-specific networking config on a node.
+func setupJujuNetworking() (string, error) {
+	parsedTemplate := template.Must(
+		template.New("BridgeConfig").Parse(bridgeConfigTemplate),
+	)
+	var buf bytes.Buffer
+	err := parsedTemplate.Execute(&buf, map[string]interface{}{
+		"Config": "/etc/network/interfaces",
+		"Bridge": environs.DefaultBridgeName,
+	})
+	if err != nil {
+		return "", errors.Annotate(err, "bridge config template error")
+	}
+	return buf.String(), nil
+}
+
 // newCloudinitConfig creates a cloudinit.Config structure
 // suitable as a base for initialising a MAAS node.
 func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, series string) (cloudinit.CloudConfig, error) {
@@ -1022,6 +1105,26 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, series st
 	case version.Ubuntu:
 		cloudcfg.SetSystemUpdate(true)
 		cloudcfg.AddScripts("set -xe", runCmd)
+		// Only create the default bridge if we're not using static
+		// address allocation for containers.
+		if !environs.AddressAllocationEnabled() {
+			// Address allocated feature flag might be disabled, but
+			// DisableNetworkManagement can still disable the bridge
+			// creation.
+			if on, set := environ.Config().DisableNetworkManagement(); on && set {
+				logger.Infof(
+					"network management disabled - not using %q bridge for containers",
+					environs.DefaultBridgeName,
+				)
+				break
+			}
+			bridgeScript, err := setupJujuNetworking()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			cloudcfg.AddPackage("bridge-utils")
+			cloudcfg.AddRunCmd(bridgeScript)
+		}
 	}
 	return cloudcfg, nil
 }
@@ -1163,6 +1266,10 @@ func (environ *maasEnviron) Instances(ids []instance.Id) ([]instance.Instance, e
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
 func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) (err error) {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
 	var subnets []network.SubnetInfo
 
@@ -1210,6 +1317,10 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to release IP address %q from instance %q", addr, instId)
 	ipaddresses := environ.getMAASClient().GetSubObject("ipaddresses")
 	// This can return a 404 error if the address has already been released

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/provider/maas"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -42,6 +43,7 @@ func (s *environSuite) SetUpSuite(c *gc.C) {
 func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 }
 
 func (s *environSuite) TearDownTest(c *gc.C) {

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -218,7 +218,6 @@ func (*environSuite) TestNewCloudinitConfigWithFeatureFlag(c *gc.C) {
 }
 
 func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
-	s.SetFeatureFlags() // clear the flags.
 	cfg := getSimpleTestConfig(c, nil)
 	env, err := maas.NewEnviron(cfg)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -225,7 +225,7 @@ func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
 	testCase := func() {
 		cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "eth0", "quantal")
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(cloudcfg.AptUpdate(), jc.IsTrue)
+		c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
 		c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
 	}
 	// First test the default case (address allocation feature flag on).

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -201,7 +201,13 @@ var expectedCloudinitConfig = []string{
 	"mkdir -p '/var/lib/juju'\ncat > '/var/lib/juju/MAASmachine.txt' << 'EOF'\n'hostname: testing.invalid\n'\nEOF\nchmod 0755 '/var/lib/juju/MAASmachine.txt'",
 }
 
-func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
+var expectedCloudinitConfigWithBridge = []interface{}{
+	"set -xe",
+	"mkdir -p '/var/lib/juju'\ninstall -m 755 /dev/null '/var/lib/juju/MAASmachine.txt'\nprintf '%s\\n' ''\"'\"'hostname: testing.invalid\n'\"'\"'' > '/var/lib/juju/MAASmachine.txt'",
+	"\n# In case we already created the bridge, don't do it again.\ngrep -q \"iface juju-br0 inet dhcp\" && exit 0\n\n# Discover primary interface at run-time using the default route (if set)\nPRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)\n\n# If $PRIMARY_IFACE is empty, there's nothing to do.\n[ -z \"$PRIMARY_IFACE\" ] && exit 0\n\n# Change the config to make $PRIMARY_IFACE manual instead of DHCP,\n# then create the bridge and enslave $PRIMARY_IFACE into it.\ngrep -q \"iface ${PRIMARY_IFACE} inet dhcp\" /etc/network/interfaces && \\\nsed -i \"s/iface ${PRIMARY_IFACE} inet dhcp//\" /etc/network/interfaces && \\\ncat >> /etc/network/interfaces << EOF\n\n# Primary interface (defining the default route)\niface ${PRIMARY_IFACE} inet manual\n\n# Bridge to use for LXC/KVM containers\nauto juju-br0\niface juju-br0 inet dhcp\n    bridge_ports ${PRIMARY_IFACE}\nEOF\n\n# Make the primary interface not auto-starting.\ngrep -q \"auto ${PRIMARY_IFACE}\" /etc/network/interfaces && \\\nsed -i \"s/auto ${PRIMARY_IFACE}//\" /etc/network/interfaces\n\n# Finally, stop $PRIMARY_IFACE and start the bridge instead.\nifdown -v ${PRIMARY_IFACE} ; ifup -v juju-br0\n",
+}
+
+func (*environSuite) TestNewCloudinitConfigWithFeatureFlag(c *gc.C) {
 	cfg := getSimpleTestConfig(c, nil)
 	env, err := maas.NewEnviron(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -209,6 +215,25 @@ func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
+}
+
+func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags() // clear the flags.
+	cfg := getSimpleTestConfig(c, nil)
+	env, err := maas.NewEnviron(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	testCase := func() {
+		cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "eth0", "quantal")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(cloudcfg.AptUpdate(), jc.IsTrue)
+		c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
+	}
+	// First test the default case (address allocation feature flag on).
+	testCase()
+
+	// Now test with the flag off - expect the same.
+	s.SetFeatureFlags() // clear the flags.
+	testCase()
 }
 
 func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -44,6 +45,7 @@ func (s *providerSuite) SetUpSuite(c *gc.C) {
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 }
 
 func (s *providerSuite) TearDownTest(c *gc.C) {

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -31,6 +32,7 @@ type workerSuite struct {
 
 func (s *workerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	// Unbreak dummy provider methods.
 	s.AssertConfigParameterUpdated(c, "broken", "")
 

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/fslock"
 	"github.com/juju/utils/packaging/manager"
 	gc "gopkg.in/check.v1"
@@ -26,6 +27,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -48,7 +50,7 @@ type ContainerSetupSuite struct {
 var _ = gc.Suite(&ContainerSetupSuite{})
 
 func (s *ContainerSetupSuite) SetUpSuite(c *gc.C) {
-	//TODO(bogdanteleaga): Fix this on windows
+	// TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: Skipping container tests on windows")
 	}
@@ -69,7 +71,6 @@ func noImportance(err0, err1 error) bool {
 
 func (s *ContainerSetupSuite) SetUpTest(c *gc.C) {
 	s.CommonProvisionerSuite.SetUpTest(c)
-	s.SetFeatureFlags(feature.AddressAllocation)
 	aptCmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte{}, nil)
 	s.aptCmdChan = aptCmdChan
 
@@ -279,7 +280,7 @@ func (s *ContainerSetupSuite) TestContainerManagerConfigName(c *gc.C) {
 	expect("any-old-thing")
 }
 
-func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, ctype instance.ContainerType, packages [][]string) {
+func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, ctype instance.ContainerType, packages [][]string, addressable bool) {
 	// A noop worker callback.
 	startProvisionerWorker := func(runner worker.Runner, containerType instance.ContainerType,
 		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
@@ -305,14 +306,17 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, ctype instance
 
 	s.createContainer(c, m, ctype)
 
-	// After initialisation starts, but before running the
-	// initializer, lxc-net should be created if ctype is LXC, as the
-	// dummy provider supports static address allocation by default.
-	if ctype == instance.LXC {
-		AssertFileContains(c, s.fakeLXCNet, provisioner.EtcDefaultLXCNet)
-		defer os.Remove(s.fakeLXCNet)
-	} else {
-		c.Assert(s.fakeLXCNet, jc.DoesNotExist)
+	// Only feature-flagged addressable containers modify lxc-net.
+	if addressable {
+		// After initialisation starts, but before running the
+		// initializer, lxc-net should be created if ctype is LXC, as the
+		// dummy provider supports static address allocation by default.
+		if ctype == instance.LXC {
+			AssertFileContains(c, s.fakeLXCNet, provisioner.EtcDefaultLXCNet)
+			defer os.Remove(s.fakeLXCNet)
+		} else {
+			c.Assert(s.fakeLXCNet, jc.DoesNotExist)
+		}
 	}
 
 	for _, pack := range packages {
@@ -338,7 +342,7 @@ func (s *ContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 			[]string{"uvtool-libvirt"},
 			[]string{"uvtool"}}},
 	} {
-		s.assertContainerInitialised(c, test.ctype, test.packages)
+		s.assertContainerInitialised(c, test.ctype, test.packages, false)
 	}
 }
 
@@ -469,4 +473,30 @@ type toolsFinderFunc func(v version.Number, series string, arch *string) (tools.
 
 func (t toolsFinderFunc) FindTools(v version.Number, series string, arch *string) (tools.List, error) {
 	return t(v, series, arch)
+}
+
+// AddressableContainerSetupSuite only contains tests depending on the
+// address allocation feature flag being enabled.
+type AddressableContainerSetupSuite struct {
+	ContainerSetupSuite
+}
+
+var _ = gc.Suite(&AddressableContainerSetupSuite{})
+
+func (s *AddressableContainerSetupSuite) enableFeatureFlag() {
+	s.SetFeatureFlags(feature.AddressAllocation)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+}
+
+func (s *AddressableContainerSetupSuite) TestContainerInitialised(c *gc.C) {
+	for _, test := range []struct {
+		ctype    instance.ContainerType
+		packages []string
+	}{
+		{instance.LXC, []string{"--target-release", "precise-updates/cloud-tools", "lxc", "cloud-image-utils"}},
+		{instance.KVM, []string{"uvtool-libvirt", "uvtool"}},
+	} {
+		s.enableFeatureFlag()
+		s.assertContainerInitialised(c, test.ctype, test.packages, true)
+	}
 }

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -491,10 +491,10 @@ func (s *AddressableContainerSetupSuite) enableFeatureFlag() {
 func (s *AddressableContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 	for _, test := range []struct {
 		ctype    instance.ContainerType
-		packages []string
+		packages [][]string
 	}{
-		{instance.LXC, []string{"--target-release", "precise-updates/cloud-tools", "lxc", "cloud-image-utils"}},
-		{instance.KVM, []string{"uvtool-libvirt", "uvtool"}},
+		{instance.LXC, [][]string{{"--target-release", "precise-updates/cloud-tools", "lxc", "cloud-image-utils"}}},
+		{instance.KVM, [][]string{{"uvtool-libvirt", "uvtool"}}},
 	} {
 		s.enableFeatureFlag()
 		s.assertContainerInitialised(c, test.ctype, test.packages, true)

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/container"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/state"
@@ -68,6 +69,7 @@ func noImportance(err0, err1 error) bool {
 
 func (s *ContainerSetupSuite) SetUpTest(c *gc.C) {
 	s.CommonProvisionerSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	aptCmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte{}, nil)
 	s.aptCmdChan = aptCmdChan
 

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -493,8 +493,8 @@ func (s *AddressableContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 		ctype    instance.ContainerType
 		packages [][]string
 	}{
-		{instance.LXC, [][]string{{"--target-release", "precise-updates/cloud-tools", "lxc", "cloud-image-utils"}}},
-		{instance.KVM, [][]string{{"uvtool-libvirt", "uvtool"}}},
+		{instance.LXC, [][]string{{"--target-release", "precise-updates/cloud-tools", "lxc"}, {"--target-release", "precise-updates/cloud-tools", "cloud-image-utils"}}},
+		{instance.KVM, [][]string{{"uvtool-libvirt"}, {"uvtool"}}},
 	} {
 		s.enableFeatureFlag()
 		s.assertContainerInitialised(c, test.ctype, test.packages, true)

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -68,7 +68,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 		allocatedInfo, err := maybeAllocateStaticIP(
 			machineId, bridgeDevice, broker.api,
-			args.NetworkInfo, broker.enableNAT,
+			args.NetworkInfo,
 		)
 		if err != nil {
 			// It's fine, just ignore it. The effect will be that the

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -58,15 +58,25 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = kvm.DefaultKvmBridge
 	}
 
-	allocatedInfo, err := maybeAllocateStaticIP(
-		machineId, bridgeDevice, broker.api, args.NetworkInfo,
-	)
-	if err != nil {
-		// It's fine, just ignore it. The effect will be that the
-		// container won't have a static address configured.
-		logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+	if !environs.AddressAllocationEnabled() {
+		logger.Debugf(
+			"address allocation feature flag not enabled; using DHCP for container %q",
+			machineId,
+		)
 	} else {
-		args.NetworkInfo = allocatedInfo
+		logger.Debugf("trying to allocate static IP for container %q", machineId)
+
+		allocatedInfo, err := maybeAllocateStaticIP(
+			machineId, bridgeDevice, broker.api,
+			args.NetworkInfo, broker.enableNAT,
+		)
+		if err != nil {
+			// It's fine, just ignore it. The effect will be that the
+			// container won't have a static address configured.
+			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+		} else {
+			args.NetworkInfo = allocatedInfo
+		}
 	}
 
 	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -79,15 +79,24 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
-	allocatedInfo, err := maybeAllocateStaticIP(
-		machineId, bridgeDevice, broker.api, args.NetworkInfo,
-	)
-	if err != nil {
-		// It's fine, just ignore it. The effect will be that the
-		// container won't have a static address configured.
-		logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+	if !environs.AddressAllocationEnabled() {
+		logger.Debugf(
+			"address allocation feature flag not enabled; using DHCP for container %q",
+			machineId,
+		)
 	} else {
-		args.NetworkInfo = allocatedInfo
+		logger.Debugf("trying to allocate static IP for container %q", machineId)
+		allocatedInfo, err := maybeAllocateStaticIP(
+			machineId, bridgeDevice, broker.api,
+			args.NetworkInfo, broker.enableNAT,
+		)
+		if err != nil {
+			// It's fine, just ignore it. The effect will be that the
+			// container won't have a static address configured.
+			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+		} else {
+			args.NetworkInfo = allocatedInfo
+		}
 	}
 	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
 

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -88,7 +88,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		logger.Debugf("trying to allocate static IP for container %q", machineId)
 		allocatedInfo, err := maybeAllocateStaticIP(
 			machineId, bridgeDevice, broker.api,
-			args.NetworkInfo, broker.enableNAT,
+			args.NetworkInfo,
 		)
 		if err != nil {
 			// It's fine, just ignore it. The effect will be that the

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -29,6 +29,7 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
 	"github.com/juju/juju/juju/arch"
@@ -60,6 +61,7 @@ var _ = gc.Suite(&lxcBrokerSuite{})
 
 func (s *lxcSuite) SetUpTest(c *gc.C) {
 	s.TestSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	if runtime.GOOS == "windows" {
 		c.Skip("Skipping lxc tests on windows")
 	}


### PR DESCRIPTION
Forward-port PRs #2097 and #2103 from 1.23. Put addressable containers behind a feature flag.

(Review request: http://reviews.vapour.ws/r/1534/)