### PR TITLE
mongo: don't treat apt-get failures as fatal

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -184,8 +184,13 @@ func EnsureServer(args EnsureServerParams) error {
 		}
 	}
 
-	if err := aptGetInstallMongod(args.SetNumaControlPolicy); err != nil {
-		return fmt.Errorf("cannot install mongod: %v", err)
+	err := aptGetInstallMongod(args.SetNumaControlPolicy)
+	if err != nil {
+		// This isn't treated as fatal because the Juju MongoDB
+		// package is likely to be already installed anyway. There
+		// could just be a temporary issue with apt-get and we don't
+		// want this to stop jujud from starting(LP #1441904).
+		logger.Errorf("cannot install/upgrade mongod (will proceed anyway): %v", err)
 	}
 	mongoPath, err := Path()
 	if err != nil {


### PR DESCRIPTION
If installation/upgrade of Juju's MongoDB package fails, continue anyway as it's likely a workable package is already installed. Problems with apt-get shouldn't prevent jujud from starting.

Fixes LP #1441904.

(Review request: http://reviews.vapour.ws/r/1544/)