### PR TITLE
mongo: don't treat apt-get failures as fatal

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -186,7 +186,12 @@ func EnsureServer(args EnsureServerParams) error {
 	}
 
 	if err := installMongod(args.SetNumaControlPolicy); err != nil {
-		return fmt.Errorf("cannot install mongod: %v", err)
+		// This isn't treated as fatal because the Juju MongoDB
+		// package is likely to be already installed anyway. There
+		// could just be a temporary issue with apt-get/yum/whatever
+		// and we don't want this to stop jujud from starting.
+		// (LP #1441904)
+		logger.Errorf("cannot install/upgrade mongod (will proceed anyway): %v", err)
 	}
 	mongoPath, err := Path()
 	if err != nil {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -16,6 +16,7 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -294,6 +295,43 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 	}
 }
 
+func (s *MongoSuite) TestMongoAptGetFails(c *gc.C) {
+	s.PatchValue(&version.Current.Series, "trusty")
+
+	// Any exit code from apt-get that isn't 0 or 100 will be treated
+	// as unexpected, skipping the normal retry loop. failCmd causes
+	// the command to exit with 1.
+	binDir := c.MkDir()
+	s.PatchEnvPathPrepend(binDir)
+	failCmd(filepath.Join(binDir, "apt-get"))
+
+	// Set the mongodb service as installed but not running.
+	namespace := "namespace"
+	s.data.SetStatus(mongo.ServiceName(namespace), "installed")
+
+	var tw loggo.TestWriter
+	c.Assert(loggo.RegisterWriter("test-writer", &tw, loggo.ERROR), jc.ErrorIsNil)
+	defer loggo.RemoveWriter("test-writer")
+
+	dataDir := c.MkDir()
+	err := mongo.EnsureServer(makeEnsureServerParams(dataDir, namespace))
+
+	// Even though apt-get failed, EnsureServer should continue and
+	// not return the error - even though apt-get failed, the Juju
+	// mongodb package is most likely already installed.
+	// The error should be logged however.
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(tw.Log(), jc.LogMatches, []jc.SimpleMessage{
+		{loggo.ERROR, `packaging command failed: .+`},
+		{loggo.ERROR, `cannot install/upgrade mongod \(will proceed anyway\): packaging command failed`},
+	})
+
+	// Verify that EnsureServer continued and started the mongodb service.
+	c.Check(s.data.Installed, gc.HasLen, 0)
+	s.data.CheckCallNames(c, "Installed", "Exists", "Running", "Start")
+}
+
 func (s *MongoSuite) TestInstallMongodServiceExists(c *gc.C) {
 	output := mockShellCommand(c, &s.CleanupSuite, "apt-get")
 	dataDir := c.MkDir()
@@ -379,11 +417,19 @@ func (s *MongoSuite) TestQuantalAptAddRepo(c *gc.C) {
 	failCmd(filepath.Join(dir, "add-apt-repository"))
 	mockShellCommand(c, &s.CleanupSuite, "apt-get")
 
+	var tw loggo.TestWriter
+	c.Assert(loggo.RegisterWriter("test-writer", &tw, loggo.ERROR), jc.ErrorIsNil)
+	defer loggo.RemoveWriter("test-writer")
+
 	// test that we call add-apt-repository only for quantal
-	// (and that if it fails, we return the error)
+	// (and that if it fails, we log the error)
 	s.PatchValue(&version.Current.Series, "quantal")
 	err := mongo.EnsureServer(makeEnsureServerParams(dir, ""))
-	c.Assert(err, gc.ErrorMatches, "cannot install mongod: packaging command failed: exit status 1.*")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(tw.Log(), jc.LogMatches, []jc.SimpleMessage{
+		{loggo.ERROR, `cannot install/upgrade mongod \(will proceed anyway\): packaging command failed`},
+	})
 
 	s.PatchValue(&manager.RunCommandWithRetry, func(string) (string, int, error) {
 		return "", 0, nil


### PR DESCRIPTION
If installation/upgrade of Juju's MongoDB package fails, continue anyway as it's likely a workable package is already installed. Problems with the packaging system shouldn't prevent jujud
from starting.

Fixes LP #1441904.

(Review request: http://reviews.vapour.ws/r/1546/)