### PR TITLE
Addressable Containers Feature Flag.

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
@@ -57,6 +58,10 @@ var _ = gc.Suite(&provisionerSuite{})
 
 func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	// We're testing with address allocation on by default. There are
+	// separate tests to check the behavior when the flag is not
+	// enabled.
+	s.SetFeatureFlags(feature.AddressAllocation)
 
 	var err error
 	s.machine, err = s.State.AddMachine("quantal", state.JobManageEnviron)
@@ -78,6 +83,21 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 
 	s.EnvironWatcherTests = apitesting.NewEnvironWatcherTests(s.provisioner, s.BackingState, apitesting.HasSecrets)
 	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.provisioner, s.BackingState)
+}
+
+func (s *provisionerSuite) TestPrepareContainerInterfaceInfoNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags() // clear the flag
+	ifaceInfo, err := s.provisioner.PrepareContainerInterfaceInfo(names.NewMachineTag("42"))
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(ifaceInfo, gc.HasLen, 0)
+}
+
+func (s *provisionerSuite) TestReleaseContainerAddressNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags() // clear the flag
+	err := s.provisioner.ReleaseContainerAddresses(names.NewMachineTag("42"))
+	c.Assert(err, gc.ErrorMatches,
+		`cannot release static addresses for "42": address allocation not supported`,
+	)
 }
 
 func (s *provisionerSuite) TestMachineTagAndId(c *gc.C) {

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -166,6 +166,15 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 	return err, tw.Log()
 }
 
+func (s *prepareSuite) TestErrorWitnNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags() // clear the flags.
+	container := s.newAPI(c, true, true)
+	args := s.makeArgs(container)
+	s.assertCall(c, args, &params.MachineNetworkConfigResults{},
+		`address allocation not supported`,
+	)
+}
+
 func (s *prepareSuite) TestErrorWithNonProvisionedHost(c *gc.C) {
 	container := s.newAPI(c, false, true)
 	args := s.makeArgs(container)
@@ -692,6 +701,15 @@ func (s *releaseSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 	return err
 }
 
+func (s *releaseSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags() // clear the flags.
+	s.newAPI(c, true, false)
+	args := s.makeArgs(s.machines[0])
+	s.assertCall(c, args, &params.ErrorResults{},
+		"address allocation not supported",
+	)
+}
+
 func (s *releaseSuite) TestErrorWithHostInsteadOfContainer(c *gc.C) {
 	s.newAPI(c, true, false)
 	args := s.makeArgs(s.machines[0])
@@ -782,7 +800,7 @@ func (s *releaseSuite) allocateAddresses(c *gc.C, containerId string, numAllocat
 	}
 }
 
-func (s *releaseSuite) TestReleaseContainerAddresses(c *gc.C) {
+func (s *releaseSuite) TestSuccess(c *gc.C) {
 	container := s.newAPI(c, true, true)
 	args := s.makeArgs(container)
 

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/version"
@@ -270,11 +271,19 @@ func shutdownInitCommands(initSystem string) ([]string, error) {
 	shutdownCmd := "/sbin/shutdown -h now"
 	name := "juju-template-restart"
 	desc := "juju shutdown job"
+
+	execStart := shutdownCmd
+	if environs.AddressAllocationEnabled() {
+		// Only do the cleanup and replacement of /e/n/i when address
+		// allocation feature flag is enabled.
+		execStart = replaceNetConfCmd + removeCmd + shutdownCmd
+	}
+
 	conf := common.Conf{
 		Desc:         desc,
 		Transient:    true,
 		AfterStopped: "cloud-final",
-		ExecStart:    replaceNetConfCmd + removeCmd + shutdownCmd,
+		ExecStart:    execStart,
 	}
 	svc, err := service.NewService(name, conf, initSystem)
 	if err != nil {

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/container"
 	containertesting "github.com/juju/juju/container/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/service"
 	systemdtesting "github.com/juju/juju/service/systemd/testing"
@@ -155,6 +156,7 @@ func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 }
 
 func (s *UserDataSuite) TestShutdownInitCommandsUpstart(c *gc.C) {
+	s.SetFeatureFlags(feature.AddressAllocation)
 	cmds, err := containerinit.ShutdownInitCommands(service.InitSystemUpstart)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -187,6 +189,7 @@ end script
 }
 
 func (s *UserDataSuite) TestShutdownInitCommandsSystemd(c *gc.C) {
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.PatchValue(&version.Current.Series, "vivid")
 	commands, err := containerinit.ShutdownInitCommands(service.InitSystemSystemd)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -387,6 +387,10 @@ var DataDir = agent.DefaultDataDir
 // may create a folder containing logs
 var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
 
+// DefaultBridgeName is the network bridge device namme used for LXC and KVM
+// containers
+const DefaultBridgeName = "juju-br0"
+
 // NewInstanceConfig sets up a basic machine configuration, for a
 // non-bootstrap node. You'll still need to supply more information,
 // but this takes care of the fixed entries and the ones that are

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -33,6 +33,7 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
 	"github.com/juju/juju/network"
@@ -87,6 +88,7 @@ more bogus content`
 
 func (s *LxcSuite) SetUpTest(c *gc.C) {
 	s.TestSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.logDir = c.MkDir()
 	loggo.GetLogger("juju.container.lxc").SetLogLevel(loggo.TRACE)
 	s.events = make(chan mock.Event, 25)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -93,7 +93,8 @@ type BootstrapParams struct {
 	AvailableTools tools.List
 
 	// ContainerBridgeName, if non-empty, overrides the default
-	// network bridge device to use for LXC and KVM containers.
+	// network bridge device to use for LXC and KVM containers. See
+	// also instancecfg.DefaultBridgeName.
 	ContainerBridgeName string
 }
 

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -4,6 +4,9 @@
 package environs
 
 import (
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
@@ -51,4 +54,10 @@ type NetworkingEnviron interface {
 func SupportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 	ne, ok := environ.(NetworkingEnviron)
 	return ne, ok
+}
+
+// AddressAllocationEnabled is a shortcut for checking if the
+// AddressAllocation feature flag is enabled.
+func AddressAllocationEnabled() bool {
+	return featureflag.Enabled(feature.AddressAllocation)
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -34,6 +34,11 @@ const EnvironmentsCacheFile = "env-cache"
 // instead of systemd for vivid and newer.
 const LegacyUpstart = "legacy-upstart"
 
+// AddressAllocation is used to indicate that LXC and KVM containers
+// on providers that support that (currently only MAAS and EC2) will
+// use statically allocated IP addresses.
+const AddressAllocation = "address-allocation"
+
 // DbLog is the the feature which has Juju's logs go to
 // MongoDB instead of to all-machines.log using rsyslog.
 const DbLog = "db-log"

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1037,6 +1037,10 @@ func (e *environ) Instances(ids []instance.Id) (insts []instance.Instance, err e
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error) {
+	if !environs.AddressAllocationEnabled() {
+		return false, errors.NotSupportedf("address allocation")
+	}
+
 	if err := env.checkBroken("SupportsAddressAllocation"); err != nil {
 		return false, err
 	}
@@ -1051,6 +1055,10 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given subnet.
 func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	if err := env.checkBroken("AllocateAddress"); err != nil {
 		return err
 	}
@@ -1074,6 +1082,10 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	if err := env.checkBroken("ReleaseAddress"); err != nil {
 		return err
 	}

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -9,6 +9,7 @@ import (
 	stdtesting "testing"
 	"time"
 
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -18,6 +19,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/jujutest"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -64,6 +66,7 @@ func (s *liveSuite) TearDownSuite(c *gc.C) {
 
 func (s *liveSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.MgoSuite.SetUpTest(c)
 	s.LiveTests.SetUpTest(c)
 }
@@ -93,6 +96,7 @@ func (s *suite) TearDownSuite(c *gc.C) {
 
 func (s *suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	s.MgoSuite.SetUpTest(c)
 	s.Tests.SetUpTest(c)
 }
@@ -156,6 +160,14 @@ func (s *suite) TestSupportsAddressAllocation(c *gc.C) {
 	supported, err = e.SupportsAddressAllocation("any-id")
 	c.Assert(err, gc.ErrorMatches, `dummy\.SupportsAddressAllocation is broken`)
 	c.Assert(supported, jc.IsFalse)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	supported, err = e.SupportsAddressAllocation("any-id")
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(supported, jc.IsFalse)
 }
 
 func (s *suite) breakMethods(c *gc.C, e environs.NetworkingEnviron, names ...string) {
@@ -198,6 +210,13 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 	newAddress = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
 	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
 	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress)
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *suite) TestReleaseAddress(c *gc.C) {
@@ -230,6 +249,13 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 	address = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
 	err = e.ReleaseAddress(inst.Id(), subnetId, address)
 	c.Assert(err, gc.ErrorMatches, `dummy\.ReleaseAddress is broken`)
+
+	// Finally, test the method respects the feature flag when
+	// disabled.
+	s.SetFeatureFlags() // clear the flags.
+	err = e.ReleaseAddress(inst.Id(), subnetId, address)
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *suite) TestNetworkInterfaces(c *gc.C) {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -221,6 +221,9 @@ func (e *environ) SupportedArchitectures() ([]string, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
+	if !environs.AddressAllocationEnabled() {
+		return false, errors.NotSupportedf("address allocation")
+	}
 	_, hasDefaultVpc, err := e.defaultVpc()
 	if err != nil {
 		return false, errors.Trace(err)
@@ -733,6 +736,10 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
 func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
 
 	var nicId string
@@ -767,6 +774,10 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
 func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+	if !environs.AddressAllocationEnabled() {
+		return errors.NotSupportedf("address allocation")
+	}
+
 	defer errors.DeferredAnnotatef(&err, "failed to release address %q from instance %q", addr, instId)
 
 	// If the instance ID is unknown the address has already been released

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/juju/testing"
@@ -183,6 +184,7 @@ func (t *localServerSuite) TearDownSuite(c *gc.C) {
 
 func (t *localServerSuite) SetUpTest(c *gc.C) {
 	t.BaseSuite.SetUpTest(c)
+	t.SetFeatureFlags(feature.AddressAllocation)
 	t.srv.startServer(c)
 	t.Tests.SetUpTest(c)
 	t.PatchValue(&version.Current, version.Binary{
@@ -883,6 +885,31 @@ func (t *localServerSuite) TestSupportsAddressAllocationTrue(c *gc.C) {
 	result, err := env.SupportsAddressAllocation("")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.IsTrue)
+}
+
+func (t *localServerSuite) TestSupportsAddressAllocationWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	result, err := env.SupportsAddressAllocation("")
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(result, jc.IsFalse)
+}
+
+func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	err := env.AllocateAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
+	t.SetFeatureFlags() // clear the flags.
+	env := t.prepareEnviron(c)
+	err := env.ReleaseAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (t *localServerSuite) TestSupportsAddressAllocationCaches(c *gc.C) {

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/provider/maas"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -42,6 +43,7 @@ func (s *environSuite) SetUpSuite(c *gc.C) {
 func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 }
 
 func (s *environSuite) TearDownTest(c *gc.C) {
@@ -199,7 +201,11 @@ var expectedCloudinitConfig = []string{
 	"mkdir -p '/var/lib/juju'\ncat > '/var/lib/juju/MAASmachine.txt' << 'EOF'\n'hostname: testing.invalid\n'\nEOF\nchmod 0755 '/var/lib/juju/MAASmachine.txt'",
 }
 
-func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
+var expectedCloudinitConfigWithBridge = []string{
+	"set -xe",
+	"mkdir -p '/var/lib/juju'\ncat > '/var/lib/juju/MAASmachine.txt' << 'EOF'\n'hostname: testing.invalid\n'\nEOF\nchmod 0755 '/var/lib/juju/MAASmachine.txt'", "\n# In case we already created the bridge, don't do it again.\ngrep -q \"iface juju-br0 inet dhcp\" && exit 0\n\n# Discover primary interface at run-time using the default route (if set)\nPRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)\n\n# If $PRIMARY_IFACE is empty, there's nothing to do.\n[ -z \"$PRIMARY_IFACE\" ] && exit 0\n\n# Change the config to make $PRIMARY_IFACE manual instead of DHCP,\n# then create the bridge and enslave $PRIMARY_IFACE into it.\ngrep -q \"iface ${PRIMARY_IFACE} inet dhcp\" /etc/network/interfaces && \\\nsed -i \"s/iface ${PRIMARY_IFACE} inet dhcp//\" /etc/network/interfaces && \\\ncat >> /etc/network/interfaces << EOF\n\n# Primary interface (defining the default route)\niface ${PRIMARY_IFACE} inet manual\n\n# Bridge to use for LXC/KVM containers\nauto juju-br0\niface juju-br0 inet dhcp\n    bridge_ports ${PRIMARY_IFACE}\nEOF\n\n# Make the primary interface not auto-starting.\ngrep -q \"auto ${PRIMARY_IFACE}\" /etc/network/interfaces && \\\nsed -i \"s/auto ${PRIMARY_IFACE}//\" /etc/network/interfaces\n\n# Finally, stop $PRIMARY_IFACE and start the bridge instead.\nifdown -v ${PRIMARY_IFACE} ; ifup -v juju-br0\n"}
+
+func (*environSuite) TestNewCloudinitConfigWithFeatureFlag(c *gc.C) {
 	cfg := getSimpleTestConfig(c, nil)
 	env, err := maas.NewEnviron(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -207,6 +213,24 @@ func (*environSuite) TestNewCloudinitConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
 	c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedCloudinitConfig)
+}
+
+func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
+	cfg := getSimpleTestConfig(c, nil)
+	env, err := maas.NewEnviron(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	testCase := func(expectedConfig []string) {
+		cloudcfg, err := maas.NewCloudinitConfig(env, "testing.invalid", "eth0", "quantal")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(cloudcfg.SystemUpdate(), jc.IsTrue)
+		c.Assert(cloudcfg.RunCmds(), jc.DeepEquals, expectedConfig)
+	}
+	// First test the default case (address allocation feature flag on).
+	testCase(expectedCloudinitConfig)
+
+	// Now test with the flag off.
+	s.SetFeatureFlags() // clear the flags.
+	testCase(expectedCloudinitConfigWithBridge)
 }
 
 func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -44,6 +45,7 @@ func (s *providerSuite) SetUpSuite(c *gc.C) {
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 }
 
 func (s *providerSuite) TearDownTest(c *gc.C) {

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -31,6 +32,7 @@ type workerSuite struct {
 
 func (s *workerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	// Unbreak dummy provider methods.
 	s.AssertConfigParameterUpdated(c, "broken", "")
 

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -79,15 +79,24 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
-	allocatedInfo, err := maybeAllocateStaticIP(
-		machineId, bridgeDevice, broker.api, args.NetworkInfo,
-	)
-	if err != nil {
-		// It's fine, just ignore it. The effect will be that the
-		// container won't have a static address configured.
-		logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+	if !environs.AddressAllocationEnabled() {
+		logger.Debugf(
+			"address allocation feature flag not enabled; using DHCP for container %q",
+			machineId,
+		)
 	} else {
-		args.NetworkInfo = allocatedInfo
+		logger.Debugf("trying to allocate static IP for container %q", machineId)
+		allocatedInfo, err := maybeAllocateStaticIP(
+			machineId, bridgeDevice, broker.api,
+			args.NetworkInfo,
+		)
+		if err != nil {
+			// It's fine, just ignore it. The effect will be that the
+			// container won't have a static address configured.
+			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+		} else {
+			args.NetworkInfo = allocatedInfo
+		}
 	}
 	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
 

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -29,6 +29,7 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
 	"github.com/juju/juju/juju/arch"
@@ -60,6 +61,7 @@ var _ = gc.Suite(&lxcBrokerSuite{})
 
 func (s *lxcSuite) SetUpTest(c *gc.C) {
 	s.TestSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.AddressAllocation)
 	if runtime.GOOS == "windows" {
 		c.Skip("Skipping lxc tests on windows")
 	}


### PR DESCRIPTION
Forward-port PRs #2097 and #2103 from 1.23. Put addressable containers behind a feature flag.

(Review request: http://reviews.vapour.ws/r/1550/)