### PR TITLE
+address-allocation ff: don't use SNAT for LXC/KVM on MAAS

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
@@ -254,6 +255,11 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 			// We log the error, but it's safe to ignore as it's not
 			// critical.
 			logger.Debugf("address allocation not supported (%v)", err)
+		}
+		// AWS requires NAT in place in order for hosted containers to
+		// reach outside.
+		if config.Type() == provider.EC2 {
+			cfg[container.ConfigEnableNAT] = "true"
 		}
 	}
 

--- a/container/interface.go
+++ b/container/interface.go
@@ -18,6 +18,11 @@ const (
 	// supports networking.
 	ConfigIPForwarding = "ip-forwarding"
 
+	// ConfigEnableNAT, if set to a non-empty value, instructs the
+	// container manager to enable NAT for hosted containers. NAT is
+	// required for AWS, but should be disabled for MAAS.
+	ConfigEnableNAT = "enable-nat"
+
 	DefaultNamespace = "juju"
 )
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,6 +11,7 @@ const (
 	Joyent = "joyent"
 	Local  = "local"
 	MAAS   = "maas"
+	EC2    = "ec2"
 )
 
 // IsManual returns true iff the specified provider

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -254,7 +254,7 @@ func (s *ContainerSetupSuite) TestLxcContainerUsesImageURL(c *gc.C) {
 
 	brokerCalled := false
 	newlxcbroker := func(api provisioner.APICalls, agentConfig agent.Config, managerConfig container.ManagerConfig,
-		imageURLGetter container.ImageURLGetter) (environs.InstanceBroker, error) {
+		imageURLGetter container.ImageURLGetter, enableNAT bool) (environs.InstanceBroker, error) {
 		imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(imageURL, gc.Equals, "imageURL")

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -51,7 +51,7 @@ var SetIPAndARPForwarding func(bool) error
 
 // SetupRoutesAndIPTables calls the internal setupRoutesAndIPTables
 // and the restores the mocked one.
-var SetupRoutesAndIPTables func(string, network.Address, string, []network.InterfaceInfo) error
+var SetupRoutesAndIPTables func(string, network.Address, string, []network.InterfaceInfo, bool) error
 
 func init() {
 	// In order to isolate the host machine from the running tests,
@@ -69,7 +69,7 @@ func init() {
 		func(bool) error { return nil },
 	)
 	mockSetupRoutesAndIPTablesValue := reflect.ValueOf(
-		func(string, network.Address, string, []network.InterfaceInfo) error { return nil },
+		func(string, network.Address, string, []network.InterfaceInfo, bool) error { return nil },
 	)
 	switchValues := func(newValue, oldValue reflect.Value) {
 		newValue.Set(oldValue)
@@ -82,9 +82,9 @@ func init() {
 		defer switchValues(newSetIPAndARPForwardingValue, mockSetIPAndARPForwardingValue)
 		return setIPAndARPForwarding(v)
 	}
-	SetupRoutesAndIPTables = func(nic string, addr network.Address, bridge string, ifinfo []network.InterfaceInfo) error {
+	SetupRoutesAndIPTables = func(nic string, addr network.Address, bridge string, ifinfo []network.InterfaceInfo, enableNAT bool) error {
 		switchValues(newSetupRoutesAndIPTablesValue, oldSetupRoutesAndIPTablesValue)
 		defer switchValues(newSetupRoutesAndIPTablesValue, mockSetupRoutesAndIPTablesValue)
-		return setupRoutesAndIPTables(nic, addr, bridge, ifinfo)
+		return setupRoutesAndIPTables(nic, addr, bridge, ifinfo, enableNAT)
 	}
 }

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -23,6 +23,7 @@ func NewKvmBroker(
 	api APICalls,
 	agentConfig agent.Config,
 	managerConfig container.ManagerConfig,
+	enableNAT bool,
 ) (environs.InstanceBroker, error) {
 	manager, err := kvm.NewContainerManager(managerConfig)
 	if err != nil {
@@ -32,6 +33,7 @@ func NewKvmBroker(
 		manager:     manager,
 		api:         api,
 		agentConfig: agentConfig,
+		enableNAT:   enableNAT,
 	}, nil
 }
 
@@ -39,6 +41,7 @@ type kvmBroker struct {
 	manager     container.Manager
 	api         APICalls
 	agentConfig agent.Config
+	enableNAT   bool
 }
 
 // StartInstance is specified in the Broker interface.
@@ -68,7 +71,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 		allocatedInfo, err := maybeAllocateStaticIP(
 			machineId, bridgeDevice, broker.api,
-			args.NetworkInfo,
+			args.NetworkInfo, broker.enableNAT,
 		)
 		if err != nil {
 			// It's fine, just ignore it. The effect will be that the

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -86,7 +86,7 @@ func (s *kvmBrokerSuite) SetUpTest(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, s.agentConfig, managerConfig)
+	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, s.agentConfig, managerConfig, false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -234,7 +234,7 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 	machineTag := names.NewMachineTag("0")
 	agentConfig := s.AgentConfigForTag(c, machineTag)
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig)
+	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig, false)
 	c.Assert(err, jc.ErrorIsNil)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
 	return provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker, toolsFinder)

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -105,7 +105,7 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 		"log-dir":            c.MkDir(),
 		"use-clone":          "false",
 	}
-	s.broker, err = provisioner.NewLxcBroker(&fakeAPI{c, s}, s.agentConfig, managerConfig, nil)
+	s.broker, err = provisioner.NewLxcBroker(&fakeAPI{c, s}, s.agentConfig, managerConfig, nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -514,6 +514,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesInvalidArgs(c *gc.C) {
 			test.primaryAddr,
 			test.bridgeName,
 			test.ifaceInfo,
+			false, // TODO(dimitern): Untested
 		)
 		c.Check(err, gc.ErrorMatches, test.expectErr)
 	}
@@ -529,7 +530,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesCheckError(c *gc.C) {
 	}}
 
 	addr := network.NewAddress("0.1.2.1")
-	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo, false)
 	c.Assert(err, gc.ErrorMatches, "iptables failed with unexpected exit code 42")
 }
 
@@ -555,7 +556,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesAddError(c *gc.C) {
 	}}
 
 	addr := network.NewAddress("0.1.2.1")
-	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo, false)
 	c.Assert(err, gc.ErrorMatches, `command "iptables -t nat -I .*" failed with exit code 42`)
 }
 
@@ -570,7 +571,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPRouteError(c *gc.C) {
 	}}
 
 	addr := network.NewAddress("0.1.2.1")
-	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo, false)
 	c.Assert(err, gc.ErrorMatches,
 		`command "ip route add 0.1.2.3 dev bridge" failed with exit code 123`,
 	)
@@ -599,7 +600,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesAddsRuleIfMissing(c *gc.C) {
 	}}
 
 	addr := network.NewAddress("0.1.2.1")
-	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now verify the expected commands - since check returns 1, add
@@ -739,13 +740,13 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 	// When ifaceInfo is not empty it shouldn't do anything and both
 	// the error and the result are nil.
 	ifaceInfo := []network.InterfaceInfo{{DeviceIndex: 0}}
-	result, err := provisioner.MaybeAllocateStaticIP("42", "bridge", &fakeAPI{c, nil}, ifaceInfo)
+	result, err := provisioner.MaybeAllocateStaticIP("42", "bridge", &fakeAPI{c, nil}, ifaceInfo, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.IsNil)
 
 	// When it's not empty, result should be populated as expected.
 	ifaceInfo = []network.InterfaceInfo{}
-	result, err = provisioner.MaybeAllocateStaticIP("42", "bridge", &fakeAPI{c, nil}, ifaceInfo)
+	result, err = provisioner.MaybeAllocateStaticIP("42", "bridge", &fakeAPI{c, nil}, ifaceInfo, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:    0,
@@ -862,7 +863,7 @@ func (s *lxcProvisionerSuite) newLxcProvisioner(c *gc.C) provisioner.Provisioner
 		"log-dir":            c.MkDir(),
 		"use-clone":          "false",
 	}
-	broker, err := provisioner.NewLxcBroker(s.provisioner, agentConfig, managerConfig, &containertesting.MockURLGetter{})
+	broker, err := provisioner.NewLxcBroker(s.provisioner, agentConfig, managerConfig, &containertesting.MockURLGetter{}, false)
 	c.Assert(err, jc.ErrorIsNil)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
 	return provisioner.NewContainerProvisioner(instance.LXC, s.provisioner, agentConfig, broker, toolsFinder)


### PR DESCRIPTION
When the address-allocation feature flag is enabled, and currently only
on EC2 when provisioning LXC or KVM containers, enable SNAT for outgoing
container traffic. MAAS does not need this and in fact it breaks certain
charms, relying on seeing ingress traffic from containers' IPs, not
their hosts' IPs. See also http://pad.lv/1443942 and http://pad.lv/1442801.

Forward-port of #2076 to 1.24, taking the address-allocation feature
flag introduced in 1.23 into account. Only live tested on MAAS and EC2.
Will add more tests in a follow-up.

(Review request: http://reviews.vapour.ws/r/1552/)