### PR TITLE
Run afterHook logic even if a hook is missing

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -793,10 +793,13 @@ func canBeLost(status *api.UnitStatus) bool {
 	case params.StatusExecuting:
 		return status.UnitAgent.Info != operation.RunningHookMessage(string(hooks.Install))
 	}
-	return true
+	// TODO(wallyworld) - use status history to see if start hook has run.
+	isInstalled := status.Workload.Status != params.StatusMaintenance || status.Workload.Info != "installing charm software"
+	return isInstalled
 }
 
 // processUnitLost determines whether the given unit should be marked as lost.
+// TODO(wallyworld) - move this to state and the canBeLost() code can be simplified.
 func processUnitLost(unit *state.Unit, status *api.UnitStatus) {
 	if !canBeLost(status) {
 		// The status is allocating or installing - there's no point

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -49,6 +49,7 @@ var (
 	PickAddress            = &pickAddress
 	AddVolumeOp            = (*State).addVolumeOp
 	CombineMeterStatus     = combineMeterStatus
+	NewStatusNotFound      = newStatusNotFound
 )
 
 type (

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1604,7 +1604,7 @@ func (s *MachineSuite) TestGetSetStatusWhileNotAlive(c *gc.C) {
 	err = s.machine.SetStatus(state.StatusStarted, "not really", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set status of machine "1": not found or not alive`)
 	_, err = s.machine.Status()
-	c.Assert(err, gc.ErrorMatches, "status not found")
+	c.Assert(err, gc.ErrorMatches, `status for key "m#1" not found`)
 }
 
 func (s *MachineSuite) TestGetSetStatusDataStandard(c *gc.C) {

--- a/state/status.go
+++ b/state/status.go
@@ -121,16 +121,27 @@ const (
 	StatusActive Status = "active"
 )
 
-type statusNotFoundError error
+type statusNotFoundError struct {
+	error
+}
+
+// Cause implements errors.causer
+func (e *statusNotFoundError) Cause() error {
+	return e.error
+}
 
 func newStatusNotFound(key string) error {
-	return statusNotFoundError(errors.NotFoundf("status for key %q", key))
+	return &statusNotFoundError{errors.NotFoundf("status for key %q", key)}
 }
 
 // IsStatusNotFound returns true if the provided error is
 // statusNotFoundError
-func IsStatusNotFound(e error) bool {
-	_, ok := e.(statusNotFoundError)
+func IsStatusNotFound(err error) bool {
+	if _, ok := err.(*statusNotFoundError); ok {
+		return true
+	}
+	err = errors.Cause(err)
+	_, ok := err.(*statusNotFoundError)
 	return ok
 }
 

--- a/state/status_test.go
+++ b/state/status_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"errors"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -97,4 +98,10 @@ func (s *statusSuite) TestTranslateLegacyAgentState(c *gc.C) {
 		c.Check(ok, jc.IsTrue)
 		c.Check(legacy, gc.Equals, test.expected)
 	}
+}
+
+func (s *statusSuite) TestStatusNotFoundError(c *gc.C) {
+	err := state.NewStatusNotFound("foo")
+	c.Assert(state.IsStatusNotFound(err), jc.IsTrue)
+	c.Assert(errors.New("foo"), jc.IsFalse)
 }

--- a/state/status_test.go
+++ b/state/status_test.go
@@ -4,9 +4,9 @@
 package state_test
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/txn"
@@ -103,5 +103,7 @@ func (s *statusSuite) TestTranslateLegacyAgentState(c *gc.C) {
 func (s *statusSuite) TestStatusNotFoundError(c *gc.C) {
 	err := state.NewStatusNotFound("foo")
 	c.Assert(state.IsStatusNotFound(err), jc.IsTrue)
-	c.Assert(errors.New("foo"), jc.IsFalse)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+	c.Assert(err.Error(), gc.Equals, `status for key "foo" not found`)
+	c.Assert(state.IsStatusNotFound(errors.New("foo")), jc.IsFalse)
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -705,14 +705,14 @@ func (s *UnitSuite) TestGetSetUnitStatusWhileNotAlive(c *gc.C) {
 	err = s.unit.SetStatus(state.StatusActive, "not really", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set status of unit "wordpress/0": not found or dead`)
 	_, err = s.unit.Status()
-	c.Assert(err, gc.ErrorMatches, "status not found")
+	c.Assert(err, gc.ErrorMatches, `status for key "u#wordpress/0" not found`)
 
 	err = s.unit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.SetStatus(state.StatusActive, "not really", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set status of unit "wordpress/0": not found or dead`)
 	_, err = s.unit.Status()
-	c.Assert(err, gc.ErrorMatches, "status not found")
+	c.Assert(err, gc.ErrorMatches, `status for key "u#wordpress/0" not found`)
 }
 
 func (s *UnitSuite) TestGetSetStatusDataStandard(c *gc.C) {

--- a/state/unitagent_test.go
+++ b/state/unitagent_test.go
@@ -81,14 +81,14 @@ func (s *UnitAgentSuite) TestGetSetStatusWhileNotAlive(c *gc.C) {
 	err = agent.SetStatus(state.StatusIdle, "not really", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set status of unit agent "wordpress/0": not found or dead`)
 	_, err = agent.Status()
-	c.Assert(err, gc.ErrorMatches, "status not found")
+	c.Assert(err, gc.ErrorMatches, `status for key "u#wordpress/0" not found`)
 
 	err = s.unit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = agent.SetStatus(state.StatusIdle, "not really", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set status of unit agent "wordpress/0": not found or dead`)
 	_, err = agent.Status()
-	c.Assert(err, gc.ErrorMatches, "status not found")
+	c.Assert(err, gc.ErrorMatches, `status for key "u#wordpress/0" not found`)
 }
 
 func (s *UnitAgentSuite) TestGetSetStatusDataStandard(c *gc.C) {

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -151,6 +151,9 @@ func (rh *runHook) beforeHook() error {
 	return nil
 }
 
+// afterHook runs after a hook completes, or after a hook that is
+// not implemented by the charm is expected to have run if it were
+// implemented.
 func (rh *runHook) afterHook(state State) (bool, error) {
 	ctx := rh.runner.Context()
 	hasRunStatusSet := ctx.HasExecutionSetUnitStatus() || state.StatusSet

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -109,17 +109,19 @@ func (rh *runHook) Execute(state State) (*State, error) {
 		return nil, ErrHookFailed
 	}
 
-	var hasRunStatusSet bool
-	var afterHookErr error
 	if ranHook {
 		logger.Infof("ran %q hook", rh.name)
 		rh.callbacks.NotifyHookCompleted(rh.name, rh.runner.Context())
-		if hasRunStatusSet, afterHookErr = rh.afterHook(state); afterHookErr != nil {
-			return nil, afterHookErr
-		}
 	} else {
 		logger.Infof("skipped %q hook (missing)", rh.name)
 	}
+
+	var hasRunStatusSet bool
+	var afterHookErr error
+	if hasRunStatusSet, afterHookErr = rh.afterHook(state); afterHookErr != nil {
+		return nil, afterHookErr
+	}
+
 	return stateChange{
 		Kind:            RunHook,
 		Step:            step,


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1450917

If a hook is missing, the afterHook() logic was not being run. This was bad if the Start hook was the missing hook, as it meant a legacy charm which does not set its own status never transitioned out of installing.

Driveby improvement to the status not found error (to aide debugging) and a tweak to the status lost logic (which really needs to be moved, but now now).

(Review request: http://reviews.vapour.ws/r/1553/)