### PR TITLE
Fix the provisional provider test.

### DIFF
--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -292,6 +292,10 @@ func (s *BootstrapSuite) TestCheckProviderProvisional(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	for name, flag := range provisionalProviders {
+		// vsphere is disabled for gccgo. See lp:1440940.
+		if name == "vsphere" && runtime.Compiler == "gccgo" {
+			continue
+		}
 		c.Logf(" - trying %q -", name)
 		err := checkProviderType(name)
 		c.Check(err, gc.ErrorMatches, ".* provider is provisional .* set JUJU_DEV_FEATURE_FLAGS=.*")


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1451100)

The recently added provisional provider change broke under gccgo because we don't support vsphere there for the moment.  This patch fixes that.

(Review request: http://reviews.vapour.ws/r/1554/)