### PR TITLE
Restore old 1.16 behavior when deploying a service

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -25,9 +25,9 @@ import (
 	ziputil "github.com/juju/utils/zip"
 	"gopkg.in/juju/charm.v5"
 
-	"github.com/juju/juju/apiserver/client"
 	apihttp "github.com/juju/juju/apiserver/http"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/service"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 )
@@ -359,7 +359,7 @@ func (h *charmsHandler) repackageAndUploadCharm(st *state.State, archive *charm.
 	bundleSHA256 := hex.EncodeToString(hash.Sum(nil))
 
 	// Store the charm archive in environment storage.
-	return client.StoreCharmArchive(
+	return service.StoreCharmArchive(
 		st,
 		curl,
 		archive,

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -5,20 +5,12 @@ package client
 
 import (
 	"fmt"
-	"io"
-	"net/url"
-	"os"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v5"
-	"gopkg.in/juju/charm.v5/charmrepo"
-	"gopkg.in/juju/charmstore.v4/csclient"
-	"gopkg.in/macaroon-bakery.v0/httpbakery"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
@@ -31,7 +23,6 @@ import (
 	jjj "github.com/juju/juju/juju"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	statestorage "github.com/juju/juju/state/storage"
 	"github.com/juju/juju/version"
 )
 
@@ -39,11 +30,7 @@ func init() {
 	common.RegisterStandardFacade("Client", 0, NewClient)
 }
 
-var (
-	logger = loggo.GetLogger("juju.apiserver.client")
-
-	newStateStorage = statestorage.NewStorage
-)
+var logger = loggo.GetLogger("juju.apiserver.client")
 
 type API struct {
 	state     *state.State
@@ -265,12 +252,6 @@ func (c *Client) ServiceUnexpose(args params.ServiceUnexpose) error {
 	}
 	return svc.ClearExposed()
 }
-
-// TODO - we really want to avoid this, which we can do by refactoring code requiring this
-// to use interfaces.
-// NewCharmStore instantiates a new charm store repository.
-// It is defined at top level for testing purposes.
-var NewCharmStore = charmrepo.NewCharmStore
 
 // ServiceDeploy fetches the charm from the charm store and deploys it.
 // AddCharm or AddLocalCharm should be called to add the charm
@@ -997,7 +978,7 @@ func destroyErr(desc string, ids, errs []string) error {
 }
 
 func (c *Client) AddCharm(args params.CharmURL) error {
-	return c.AddCharmWithAuthorization(params.AddCharmWithAuthorization{
+	return service.AddCharmWithAuthorization(c.api.state, params.AddCharmWithAuthorization{
 		URL: args.URL,
 	})
 }
@@ -1009,168 +990,13 @@ func (c *Client) AddCharm(args params.CharmURL) error {
 // The authorization macaroon, args.CharmStoreMacaroon, may be
 // omitted, in which case this call is equivalent to AddCharm.
 func (c *Client) AddCharmWithAuthorization(args params.AddCharmWithAuthorization) error {
-	charmURL, err := charm.ParseURL(args.URL)
-	if err != nil {
-		return err
-	}
-	if charmURL.Schema != "cs" {
-		return fmt.Errorf("only charm store charm URLs are supported, with cs: schema")
-	}
-	if charmURL.Revision < 0 {
-		return fmt.Errorf("charm URL must include revision")
-	}
-
-	// First, check if a pending or a real charm exists in state.
-	stateCharm, err := c.api.state.PrepareStoreCharmUpload(charmURL)
-	if err != nil {
-		return err
-	}
-	if stateCharm.IsUploaded() {
-		// Charm already in state (it was uploaded already).
-		return nil
-	}
-
-	// Get the charm and its information from the store.
-	envConfig, err := c.api.state.EnvironConfig()
-	if err != nil {
-		return err
-	}
-	csURL, err := url.Parse(csclient.ServerURL)
-	if err != nil {
-		return err
-	}
-	csParams := charmrepo.NewCharmStoreParams{
-		URL:        csURL.String(),
-		HTTPClient: httpbakery.NewHTTPClient(),
-	}
-	if args.CharmStoreMacaroon != nil {
-		// Set the provided charmstore authorizing macaroon
-		// as a cookie in the HTTP client.
-		// TODO discharge any third party caveats in the macaroon.
-		ms := []*macaroon.Macaroon{args.CharmStoreMacaroon}
-		httpbakery.SetCookie(csParams.HTTPClient.Jar, csURL, ms)
-	}
-	repo := config.SpecializeCharmRepo(
-		NewCharmStore(csParams),
-		envConfig,
-	)
-	downloadedCharm, err := repo.Get(charmURL)
-	if err != nil {
-		cause := errors.Cause(err)
-		if httpbakery.IsDischargeError(cause) || httpbakery.IsInteractionError(cause) {
-			return errors.NewUnauthorized(err, "")
-		}
-		return errors.Trace(err)
-	}
-
-	// Open it and calculate the SHA256 hash.
-	downloadedBundle, ok := downloadedCharm.(*charm.CharmArchive)
-	if !ok {
-		return errors.Errorf("expected a charm archive, got %T", downloadedCharm)
-	}
-	archive, err := os.Open(downloadedBundle.Path)
-	if err != nil {
-		return errors.Annotate(err, "cannot read downloaded charm")
-	}
-	defer archive.Close()
-	bundleSHA256, size, err := utils.ReadSHA256(archive)
-	if err != nil {
-		return errors.Annotate(err, "cannot calculate SHA256 hash of charm")
-	}
-	if _, err := archive.Seek(0, 0); err != nil {
-		return errors.Annotate(err, "cannot rewind charm archive")
-	}
-
-	// Store the charm archive in environment storage.
-	return StoreCharmArchive(
-		c.api.state,
-		charmURL,
-		downloadedCharm,
-		archive,
-		size,
-		bundleSHA256,
-	)
+	return service.AddCharmWithAuthorization(c.api.state, args)
 }
 
-// StoreCharmArchive stores a charm archive in environment storage.
-func StoreCharmArchive(st *state.State, curl *charm.URL, ch charm.Charm, r io.Reader, size int64, sha256 string) error {
-	storage := newStateStorage(st.EnvironUUID(), st.MongoSession())
-	storagePath, err := charmArchiveStoragePath(curl)
-	if err != nil {
-		return errors.Annotate(err, "cannot generate charm archive name")
-	}
-	if err := storage.Put(storagePath, r, size); err != nil {
-		return errors.Annotate(err, "cannot add charm to storage")
-	}
-
-	// Now update the charm data in state and mark it as no longer pending.
-	_, err = st.UpdateUploadedCharm(ch, curl, storagePath, sha256)
-	if err != nil {
-		alreadyUploaded := err == state.ErrCharmRevisionAlreadyModified ||
-			errors.Cause(err) == state.ErrCharmRevisionAlreadyModified ||
-			state.IsCharmAlreadyUploadedError(err)
-		if err := storage.Remove(storagePath); err != nil {
-			if alreadyUploaded {
-				logger.Errorf("cannot remove duplicated charm archive from storage: %v", err)
-			} else {
-				logger.Errorf("cannot remove unsuccessfully recorded charm archive from storage: %v", err)
-			}
-		}
-		if alreadyUploaded {
-			// Somebody else managed to upload and update the charm in
-			// state before us. This is not an error.
-			return nil
-		}
-	}
-	return nil
-}
-
+// ResolveCharm resolves the best available charm URLs with series, for charm
+// locations without a series specified.
 func (c *Client) ResolveCharms(args params.ResolveCharms) (params.ResolveCharmResults, error) {
-	var results params.ResolveCharmResults
-
-	envConfig, err := c.api.state.EnvironConfig()
-	if err != nil {
-		return params.ResolveCharmResults{}, err
-	}
-	repo := config.SpecializeCharmRepo(
-		NewCharmStore(charmrepo.NewCharmStoreParams{}),
-		envConfig)
-
-	for _, ref := range args.References {
-		result := params.ResolveCharmResult{}
-		curl, err := c.resolveCharm(&ref, repo)
-		if err != nil {
-			result.Error = err.Error()
-		} else {
-			result.URL = curl
-		}
-		results.URLs = append(results.URLs, result)
-	}
-	return results, nil
-}
-
-func (c *Client) resolveCharm(ref *charm.Reference, repo charmrepo.Interface) (*charm.URL, error) {
-	if ref.Schema != "cs" {
-		return nil, fmt.Errorf("only charm store charm references are supported, with cs: schema")
-	}
-
-	// Resolve the charm location with the repository.
-	curl, err := repo.Resolve(ref)
-	if err != nil {
-		return nil, err
-	}
-	return curl.WithRevision(ref.Revision), nil
-}
-
-// charmArchiveStoragePath returns a string that is suitable as a
-// storage path, using a random UUID to avoid colliding with concurrent
-// uploads.
-func charmArchiveStoragePath(curl *charm.URL) (string, error) {
-	uuid, err := utils.NewUUID()
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("charms/%s-%s", curl.String(), uuid), nil
+	return service.ResolveCharms(c.api.state, args)
 }
 
 // RetryProvisioning marks a provisioning error as transient on the machines.

--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -6,7 +6,6 @@ package client
 var (
 	RemoteParamsForMachine = remoteParamsForMachine
 	GetAllUnitNames        = getAllUnitNames
-	NewStateStorage        = &newStateStorage
 )
 
 // Filtering exports

--- a/apiserver/service/charmstore.go
+++ b/apiserver/service/charmstore.go
@@ -1,0 +1,203 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package service contains api calls for accessing service functionality.
+package service
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"gopkg.in/juju/charm.v5"
+	"gopkg.in/juju/charm.v5/charmrepo"
+	"gopkg.in/juju/charmstore.v4/csclient"
+	"gopkg.in/macaroon-bakery.v0/httpbakery"
+	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
+)
+
+// TODO - we really want to avoid this, which we can do by refactoring code requiring this
+// to use interfaces.
+// NewCharmStore instantiates a new charm store repository.
+// It is defined at top level for testing purposes.
+var NewCharmStore = charmrepo.NewCharmStore
+
+// AddCharmWithAuthorization adds the given charm URL (which must include revision) to
+// the environment, if it does not exist yet. Local charms are not
+// supported, only charm store URLs. See also AddLocalCharm().
+//
+// The authorization macaroon, args.CharmStoreMacaroon, may be
+// omitted, in which case this call is equivalent to AddCharm.
+func AddCharmWithAuthorization(st *state.State, args params.AddCharmWithAuthorization) error {
+	charmURL, err := charm.ParseURL(args.URL)
+	if err != nil {
+		return err
+	}
+	if charmURL.Schema != "cs" {
+		return fmt.Errorf("only charm store charm URLs are supported, with cs: schema")
+	}
+	if charmURL.Revision < 0 {
+		return fmt.Errorf("charm URL must include revision")
+	}
+
+	// First, check if a pending or a real charm exists in state.
+	stateCharm, err := st.PrepareStoreCharmUpload(charmURL)
+	if err != nil {
+		return err
+	}
+	if stateCharm.IsUploaded() {
+		// Charm already in state (it was uploaded already).
+		return nil
+	}
+
+	// Get the charm and its information from the store.
+	envConfig, err := st.EnvironConfig()
+	if err != nil {
+		return err
+	}
+	csURL, err := url.Parse(csclient.ServerURL)
+	if err != nil {
+		return err
+	}
+	csParams := charmrepo.NewCharmStoreParams{
+		URL:        csURL.String(),
+		HTTPClient: httpbakery.NewHTTPClient(),
+	}
+	if args.CharmStoreMacaroon != nil {
+		// Set the provided charmstore authorizing macaroon
+		// as a cookie in the HTTP client.
+		// TODO discharge any third party caveats in the macaroon.
+		ms := []*macaroon.Macaroon{args.CharmStoreMacaroon}
+		httpbakery.SetCookie(csParams.HTTPClient.Jar, csURL, ms)
+	}
+	repo := config.SpecializeCharmRepo(
+		NewCharmStore(csParams),
+		envConfig,
+	)
+	downloadedCharm, err := repo.Get(charmURL)
+	if err != nil {
+		cause := errors.Cause(err)
+		if httpbakery.IsDischargeError(cause) || httpbakery.IsInteractionError(cause) {
+			return errors.NewUnauthorized(err, "")
+		}
+		return errors.Trace(err)
+	}
+
+	// Open it and calculate the SHA256 hash.
+	downloadedBundle, ok := downloadedCharm.(*charm.CharmArchive)
+	if !ok {
+		return errors.Errorf("expected a charm archive, got %T", downloadedCharm)
+	}
+	archive, err := os.Open(downloadedBundle.Path)
+	if err != nil {
+		return errors.Annotate(err, "cannot read downloaded charm")
+	}
+	defer archive.Close()
+	bundleSHA256, size, err := utils.ReadSHA256(archive)
+	if err != nil {
+		return errors.Annotate(err, "cannot calculate SHA256 hash of charm")
+	}
+	if _, err := archive.Seek(0, 0); err != nil {
+		return errors.Annotate(err, "cannot rewind charm archive")
+	}
+
+	// Store the charm archive in environment storage.
+	return StoreCharmArchive(
+		st,
+		charmURL,
+		downloadedCharm,
+		archive,
+		size,
+		bundleSHA256,
+	)
+}
+
+// StoreCharmArchive stores a charm archive in environment storage.
+func StoreCharmArchive(st *state.State, curl *charm.URL, ch charm.Charm, r io.Reader, size int64, sha256 string) error {
+	storage := newStateStorage(st.EnvironUUID(), st.MongoSession())
+	storagePath, err := charmArchiveStoragePath(curl)
+	if err != nil {
+		return errors.Annotate(err, "cannot generate charm archive name")
+	}
+	if err := storage.Put(storagePath, r, size); err != nil {
+		return errors.Annotate(err, "cannot add charm to storage")
+	}
+
+	// Now update the charm data in state and mark it as no longer pending.
+	_, err = st.UpdateUploadedCharm(ch, curl, storagePath, sha256)
+	if err != nil {
+		alreadyUploaded := err == state.ErrCharmRevisionAlreadyModified ||
+			errors.Cause(err) == state.ErrCharmRevisionAlreadyModified ||
+			state.IsCharmAlreadyUploadedError(err)
+		if err := storage.Remove(storagePath); err != nil {
+			if alreadyUploaded {
+				logger.Errorf("cannot remove duplicated charm archive from storage: %v", err)
+			} else {
+				logger.Errorf("cannot remove unsuccessfully recorded charm archive from storage: %v", err)
+			}
+		}
+		if alreadyUploaded {
+			// Somebody else managed to upload and update the charm in
+			// state before us. This is not an error.
+			return nil
+		}
+	}
+	return nil
+}
+
+// charmArchiveStoragePath returns a string that is suitable as a
+// storage path, using a random UUID to avoid colliding with concurrent
+// uploads.
+func charmArchiveStoragePath(curl *charm.URL) (string, error) {
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("charms/%s-%s", curl.String(), uuid), nil
+}
+
+// ResolveCharm resolves the best available charm URLs with series, for charm
+// locations without a series specified.
+func ResolveCharms(st *state.State, args params.ResolveCharms) (params.ResolveCharmResults, error) {
+	var results params.ResolveCharmResults
+
+	envConfig, err := st.EnvironConfig()
+	if err != nil {
+		return params.ResolveCharmResults{}, err
+	}
+	repo := config.SpecializeCharmRepo(
+		NewCharmStore(charmrepo.NewCharmStoreParams{}),
+		envConfig)
+
+	for _, ref := range args.References {
+		result := params.ResolveCharmResult{}
+		curl, err := resolveCharm(&ref, repo)
+		if err != nil {
+			result.Error = err.Error()
+		} else {
+			result.URL = curl
+		}
+		results.URLs = append(results.URLs, result)
+	}
+	return results, nil
+}
+
+func resolveCharm(ref *charm.Reference, repo charmrepo.Interface) (*charm.URL, error) {
+	if ref.Schema != "cs" {
+		return nil, fmt.Errorf("only charm store charm references are supported, with cs: schema")
+	}
+
+	// Resolve the charm location with the repository.
+	curl, err := repo.Resolve(ref)
+	if err != nil {
+		return nil, err
+	}
+	return curl.WithRevision(ref.Revision), nil
+}

--- a/apiserver/service/charmstore.go
+++ b/apiserver/service/charmstore.go
@@ -1,7 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package service contains api calls for accessing service functionality.
 package service
 
 import (

--- a/apiserver/service/export_test.go
+++ b/apiserver/service/export_test.go
@@ -3,4 +3,7 @@
 
 package service
 
-var ParseSettingsCompatible = parseSettingsCompatible
+var (
+	ParseSettingsCompatible = parseSettingsCompatible
+	NewStateStorage         = &newStateStorage
+)

--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -1,12 +1,12 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package service contains api calls for accessing service functionality.
+// Package service contains api calls for functionality
+// related to deploying and managing services and their
+// related charms.
 package service
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
@@ -121,19 +121,15 @@ func DeployService(st *state.State, owner string, args params.ServiceDeploy) err
 	if errors.IsNotFound(err) {
 		// Clients written to expect 1.16 compatibility require this next block.
 		if curl.Schema != "cs" {
-			return fmt.Errorf(`charm url has unsupported schema %q`, curl.Schema)
+			return errors.Errorf(`charm url has unsupported schema %q`, curl.Schema)
 		}
-		err = AddCharmWithAuthorization(st, params.AddCharmWithAuthorization{
+		if err = AddCharmWithAuthorization(st, params.AddCharmWithAuthorization{
 			URL: args.CharmUrl,
-		})
-		if err != nil {
-			return errors.Trace(err)
+		}); err == nil {
+			ch, err = st.Charm(curl)
 		}
-		ch, err = st.Charm(curl)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	} else if err != nil {
+	}
+	if err != nil {
 		return errors.Trace(err)
 	}
 

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -4,9 +4,18 @@
 package service_test
 
 import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
+	"gopkg.in/juju/charmstore.v4/csclient"
+	"gopkg.in/macaroon.v1"
+	"gopkg.in/mgo.v2"
 
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
@@ -15,6 +24,7 @@ import (
 	"github.com/juju/juju/constraints"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	statestorage "github.com/juju/juju/state/storage"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
@@ -180,24 +190,9 @@ func setupStoragePool(c *gc.C, st *state.State) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) uploadCharm(c *gc.C, url, name string) (*charm.URL, charm.Charm) {
-	id := charm.MustParseReference(url)
-	promulgated := false
-	if id.User == "" {
-		id.User = "who"
-		promulgated = true
-	}
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), name)
-	id = s.Srv.UploadCharm(c, ch, id, promulgated)
-	curl := (*charm.URL)(id)
-	err := s.APIState.Client().AddCharmWithAuthorization(curl, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	return curl, ch
-}
-
 func (s *serviceSuite) TestClientServiceDeployWithStorage(c *gc.C) {
 	setupStoragePool(c, s.State)
-	curl, ch := s.uploadCharm(c, "utopic/storage-block-10", "storage-block")
+	curl, ch := s.UploadCharm(c, "utopic/storage-block-10", "storage-block")
 	storageConstraints := map[string]storage.Constraints{
 		"data": {
 			Count: 1,
@@ -235,7 +230,7 @@ func (s *serviceSuite) TestClientServiceDeployWithStorage(c *gc.C) {
 
 func (s *serviceSuite) TestClientServiceDeployWithInvalidStoragePool(c *gc.C) {
 	setupStoragePool(c, s.State)
-	curl, _ := s.uploadCharm(c, "utopic/storage-block-0", "storage-block")
+	curl, _ := s.UploadCharm(c, "utopic/storage-block-0", "storage-block")
 	storageConstraints := map[string]storage.Constraints{
 		"data": storage.Constraints{
 			Pool:  "foo",
@@ -266,7 +261,7 @@ func (s *serviceSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C
 	_, err := pm.Create("host-loop-pool", provider.HostLoopProviderType, map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, _ := s.uploadCharm(c, "utopic/storage-block-0", "storage-block")
+	curl, _ := s.UploadCharm(c, "utopic/storage-block-0", "storage-block")
 	storageConstraints := map[string]storage.Constraints{
 		"data": storage.Constraints{
 			Pool:  "host-loop-pool",
@@ -294,7 +289,7 @@ func (s *serviceSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C
 
 func (s *serviceSuite) TestClientServiceDeployDefaultFilesystemStorage(c *gc.C) {
 	setupStoragePool(c, s.State)
-	curl, ch := s.uploadCharm(c, "trusty/storage-filesystem-1", "storage-filesystem")
+	curl, ch := s.UploadCharm(c, "trusty/storage-filesystem-1", "storage-filesystem")
 	var cons constraints.Value
 	args := params.ServiceDeploy{
 		ServiceName: "service",
@@ -321,6 +316,177 @@ func (s *serviceSuite) TestClientServiceDeployDefaultFilesystemStorage(c *gc.C) 
 	})
 }
 
+// TODO(wallyworld) - the following charm tests have been moved from the apiserver/client
+// package in order to use the fake charm store testing infrastructure. They are legacy tests
+// written to use the api client instead of the apiserver logic. They need to be rewritten and
+// feature tests added.
+
+func (s *serviceSuite) TestAddCharm(c *gc.C) {
+	var blobs blobs
+	s.PatchValue(service.NewStateStorage, func(uuid string, session *mgo.Session) statestorage.Storage {
+		storage := statestorage.NewStorage(uuid, session)
+		return &recordingStorage{Storage: storage, blobs: &blobs}
+	})
+
+	client := s.APIState.Client()
+	// First test the sanity checks.
+	err := client.AddCharm(&charm.URL{Name: "nonsense"})
+	c.Assert(err, gc.ErrorMatches, `charm URL has invalid schema: ":nonsense-0"`)
+	err = client.AddCharm(charm.MustParseURL("local:precise/dummy"))
+	c.Assert(err, gc.ErrorMatches, "only charm store charm URLs are supported, with cs: schema")
+	err = client.AddCharm(charm.MustParseURL("cs:precise/wordpress"))
+	c.Assert(err, gc.ErrorMatches, "charm URL must include revision")
+
+	// Add a charm, without uploading it to storage, to
+	// check that AddCharm does not try to do it.
+	charmDir := testcharms.Repo.CharmDir("dummy")
+	ident := fmt.Sprintf("%s-%d", charmDir.Meta().Name, charmDir.Revision())
+	curl := charm.MustParseURL("cs:quantal/" + ident)
+	sch, err := s.State.AddCharm(charmDir, curl, "", ident+"-sha256")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// AddCharm should see the charm in state and not upload it.
+	err = client.AddCharm(sch.URL())
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(blobs.m, gc.HasLen, 0)
+
+	// Now try adding another charm completely.
+	curl, _ = s.UploadCharm(c, "precise/wordpress-3", "wordpress")
+	err = client.AddCharm(curl)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Verify it's in state and it got uploaded.
+	storage := statestorage.NewStorage(s.State.EnvironUUID(), s.State.MongoSession())
+	sch, err = s.State.Charm(curl)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertUploaded(c, storage, sch.StoragePath(), sch.BundleSha256())
+}
+
+func (s *serviceSuite) TestAddCharmWithAuthorization(c *gc.C) {
+	// Upload a new charm to the charm store.
+	curl, _ := s.UploadCharm(c, "cs:~restricted/precise/wordpress-3", "wordpress")
+
+	// Change permissions on the new charm such that only bob
+	// can read from it.
+	s.DischargeUser = "restricted"
+	err := s.Srv.NewClient().Put("/"+curl.Path()+"/meta/perm/read", []string{"bob"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Try to add a charm to the environment without authorization.
+	s.DischargeUser = ""
+	err = s.APIState.Client().AddCharm(curl)
+	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: cannot get discharge from ".*": third party refused discharge: cannot discharge: discharge denied`)
+
+	tryAs := func(user string) error {
+		client := csclient.New(csclient.Params{
+			URL: s.Srv.URL(),
+		})
+		s.DischargeUser = user
+		var m *macaroon.Macaroon
+		err = client.Get("/delegatable-macaroon", &m)
+		c.Assert(err, gc.IsNil)
+
+		return service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	}
+	// Try again with authorization for the wrong user.
+	err = tryAs("joe")
+	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: unauthorized: access denied for user "joe"`)
+
+	// Try again with the correct authorization this time.
+	err = tryAs("bob")
+	c.Assert(err, gc.IsNil)
+
+	// Verify that it has actually been uploaded.
+	_, err = s.State.Charm(curl)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *serviceSuite) TestAddCharmConcurrently(c *gc.C) {
+	var putBarrier sync.WaitGroup
+	var blobs blobs
+	s.PatchValue(service.NewStateStorage, func(uuid string, session *mgo.Session) statestorage.Storage {
+		storage := statestorage.NewStorage(uuid, session)
+		return &recordingStorage{Storage: storage, blobs: &blobs, putBarrier: &putBarrier}
+	})
+
+	client := s.APIState.Client()
+	curl, _ := s.UploadCharm(c, "trusty/wordpress-3", "wordpress")
+
+	// Try adding the same charm concurrently from multiple goroutines
+	// to test no "duplicate key errors" are reported (see lp bug
+	// #1067979) and also at the end only one charm document is
+	// created.
+
+	var wg sync.WaitGroup
+	// We don't add them 1-by-1 because that would allow each goroutine to
+	// finish separately without actually synchronizing between them
+	putBarrier.Add(10)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+
+			c.Assert(client.AddCharm(curl), gc.IsNil, gc.Commentf("goroutine %d", index))
+			sch, err := s.State.Charm(curl)
+			c.Assert(err, gc.IsNil, gc.Commentf("goroutine %d", index))
+			c.Assert(sch.URL(), jc.DeepEquals, curl, gc.Commentf("goroutine %d", index))
+		}(i)
+	}
+	wg.Wait()
+
+	blobs.Lock()
+
+	c.Assert(blobs.m, gc.HasLen, 10)
+
+	// Verify there is only a single uploaded charm remains and it
+	// contains the correct data.
+	sch, err := s.State.Charm(curl)
+	c.Assert(err, jc.ErrorIsNil)
+	storagePath := sch.StoragePath()
+	c.Assert(blobs.m[storagePath], jc.IsTrue)
+	for path, exists := range blobs.m {
+		if path != storagePath {
+			c.Assert(exists, jc.IsFalse)
+		}
+	}
+
+	storage := statestorage.NewStorage(s.State.EnvironUUID(), s.State.MongoSession())
+	s.assertUploaded(c, storage, sch.StoragePath(), sch.BundleSha256())
+}
+
+func (s *serviceSuite) assertUploaded(c *gc.C, storage statestorage.Storage, storagePath, expectedSHA256 string) {
+	reader, _, err := storage.Get(storagePath)
+	c.Assert(err, jc.ErrorIsNil)
+	defer reader.Close()
+	downloadedSHA256, _, err := utils.ReadSHA256(reader)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(downloadedSHA256, gc.Equals, expectedSHA256)
+}
+
+func (s *serviceSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
+	client := s.APIState.Client()
+	curl, _ := s.UploadCharm(c, "trusty/wordpress-42", "wordpress")
+
+	// Add a placeholder with the same charm URL.
+	err := s.State.AddStoreCharmPlaceholder(curl)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.Charm(curl)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	// Now try to add the charm, which will convert the placeholder to
+	// a pending charm.
+	err = client.AddCharm(curl)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make sure the document's flags were reset as expected.
+	sch, err := s.State.Charm(curl)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sch.URL(), jc.DeepEquals, curl)
+	c.Assert(sch.IsPlaceholder(), jc.IsFalse)
+	c.Assert(sch.IsUploaded(), jc.IsTrue)
+}
+
 type mockStorageProvider struct {
 	storage.Provider
 	kind storage.StorageKind
@@ -335,5 +501,60 @@ func (m *mockStorageProvider) Supports(k storage.StorageKind) bool {
 }
 
 func (m *mockStorageProvider) ValidateConfig(*storage.Config) error {
+	return nil
+}
+
+type blobs struct {
+	sync.Mutex
+	m map[string]bool // maps path to added (true), or deleted (false)
+}
+
+// Add adds a path to the list of known paths.
+func (b *blobs) Add(path string) {
+	b.Lock()
+	defer b.Unlock()
+	b.check()
+	b.m[path] = true
+}
+
+// Remove marks a path as deleted, even if it was not previously Added.
+func (b *blobs) Remove(path string) {
+	b.Lock()
+	defer b.Unlock()
+	b.check()
+	b.m[path] = false
+}
+
+func (b *blobs) check() {
+	if b.m == nil {
+		b.m = make(map[string]bool)
+	}
+}
+
+type recordingStorage struct {
+	statestorage.Storage
+	putBarrier *sync.WaitGroup
+	blobs      *blobs
+}
+
+func (s *recordingStorage) Put(path string, r io.Reader, size int64) error {
+	if s.putBarrier != nil {
+		// This goroutine has gotten to Put() so mark it Done() and
+		// wait for the other goroutines to get to this point.
+		s.putBarrier.Done()
+		s.putBarrier.Wait()
+	}
+	if err := s.Storage.Put(path, r, size); err != nil {
+		return errors.Trace(err)
+	}
+	s.blobs.Add(path)
+	return nil
+}
+
+func (s *recordingStorage) Remove(path string) error {
+	if err := s.Storage.Remove(path); err != nil {
+		return errors.Trace(err)
+	}
+	s.blobs.Remove(path)
 	return nil
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1450912

The actual code changes are small - restoring a dozen or so lines of code to DeployService. The bulk of the remaining changes are refactoring tests and test infrastructure since the deploy logic had been moved off the client facade onto the service facade. The tests can only run with a single fake charm store so some rework was needed to make everything fit together.

(Review request: http://reviews.vapour.ws/r/1556/)