### PR TITLE
state: allow Machine.SetPassword to work pre env UUID migration

### DIFF
--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -528,6 +528,30 @@ func (s *MachineSuite) TestSetPassword(c *gc.C) {
 	})
 }
 
+func (s *MachineSuite) TestSetPasswordPreEnvUUID(c *gc.C) {
+	// Ensure that SetPassword works for machines even when the env
+	// UUID upgrade migrations haven't run yet.
+	type oldMachineDoc struct {
+		Id     string `bson:"_id"`
+		Series string
+	}
+	s.machines.Insert(&oldMachineDoc{"99", "quantal"})
+
+	m, err := s.State.Machine("99")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Set the password and make sure it sticks.
+	c.Assert(m.PasswordValid(goodPassword), jc.IsFalse)
+	err = m.SetPassword(goodPassword)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.PasswordValid(goodPassword), jc.IsTrue)
+
+	// Check a newly-fetched entity has the same password.
+	err = m.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.PasswordValid(goodPassword), jc.IsTrue)
+}
+
 func (s *MachineSuite) TestSetAgentCompatPassword(c *gc.C) {
 	e, err := s.State.Machine(s.machine.Id())
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state.go
+++ b/state/state.go
@@ -635,6 +635,14 @@ func machineIdLessThan(id1, id2 string) bool {
 
 // Machine returns the machine with the given id.
 func (st *State) Machine(id string) (*Machine, error) {
+	mdoc, err := st.getMachineDoc(id)
+	if err != nil {
+		return nil, err
+	}
+	return newMachine(st, mdoc), nil
+}
+
+func (st *State) getMachineDoc(id string) (*machineDoc, error) {
 	machinesCollection, closer := st.getRawCollection(machinesC)
 	defer closer()
 
@@ -655,7 +663,7 @@ func (st *State) Machine(id string) (*Machine, error) {
 		if mdoc.Id == "" {
 			mdoc.Id = mdoc.DocID
 		}
-		return newMachine(st, mdoc), nil
+		return mdoc, nil
 	case mgo.ErrNotFound:
 		return nil, errors.NotFoundf("machine %s", id)
 	default:


### PR DESCRIPTION
Machine.SetPassword would fail if called before the env UUID migration for the machine collection has been run. This was breaking upgrades from 1.18 to 1.23.

This change also unified the was State.Machine and Machine.Refresh retrieve machine documents. This means that Machine.Refresh now also works before the env UUID migration has been applied to the machines collection.

Fixes LP #1451297.

(Review request: http://reviews.vapour.ws/r/1560/)