### PR TITLE
worker/uniter: storage before install/upgrade

### DIFF
--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -22,12 +22,9 @@ type storageSuite struct {
 }
 
 func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
-	storageAttachments := []params.StorageAttachment{{
+	storageAttachmentIds := []params.StorageAttachmentId{{
 		StorageTag: "storage-whatever-0",
-		OwnerTag:   "service-mysql",
 		UnitTag:    "unit-mysql-0",
-		Kind:       params.StorageKindBlock,
-		Location:   "/dev/sda",
 	}}
 
 	var called bool
@@ -39,10 +36,10 @@ func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 		c.Check(arg, gc.DeepEquals, params.Entities{
 			Entities: []params.Entity{{Tag: "unit-mysql-0"}},
 		})
-		c.Assert(result, gc.FitsTypeOf, &params.StorageAttachmentsResults{})
-		*(result.(*params.StorageAttachmentsResults)) = params.StorageAttachmentsResults{
-			Results: []params.StorageAttachmentsResult{{
-				Result: storageAttachments,
+		c.Assert(result, gc.FitsTypeOf, &params.StorageAttachmentIdsResults{})
+		*(result.(*params.StorageAttachmentIdsResults)) = params.StorageAttachmentIdsResults{
+			Results: []params.StorageAttachmentIdsResult{{
+				Result: params.StorageAttachmentIds{storageAttachmentIds},
 			}},
 		}
 		called = true
@@ -50,10 +47,10 @@ func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 	})
 
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	attachments, err := st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
+	attachmentIds, err := st.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
-	c.Assert(attachments, gc.DeepEquals, storageAttachments)
+	c.Assert(attachmentIds, gc.DeepEquals, storageAttachmentIds)
 }
 
 func (s *storageSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
@@ -82,8 +79,8 @@ func (s *storageSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
 
 func (s *storageSuite) TestStorageAttachmentResultCountMismatch(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.StorageAttachmentsResults)) = params.StorageAttachmentsResults{
-			[]params.StorageAttachmentsResult{{}, {}},
+		*(result.(*params.StorageAttachmentIdsResults)) = params.StorageAttachmentIdsResults{
+			[]params.StorageAttachmentIdsResult{{}, {}},
 		}
 		return nil
 	})

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -108,6 +108,19 @@ type StorageAttachmentIds struct {
 	Ids []StorageAttachmentId `json:"ids"`
 }
 
+// StorageAttachmentIdsResult holds the result of an API call to retrieve the
+// IDs of a unit's attached storage instances.
+type StorageAttachmentIdsResult struct {
+	Result StorageAttachmentIds `json:"result"`
+	Error  *Error               `json:"error,omitempty"`
+}
+
+// StorageAttachmentIdsResult holds the result of an API call to retrieve the
+// IDs of multiple units attached storage instances.
+type StorageAttachmentIdsResults struct {
+	Results []StorageAttachmentIdsResult `json:"results,omitempty"`
+}
+
 // StorageAttachmentsResult holds the result of an API call to retrieve details
 // of a unit's attached storage instances.
 type StorageAttachmentsResult struct {

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -16,6 +16,7 @@ type storageStateInterface interface {
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
+	DestroyUnitStorageAttachments(names.UnitTag) error
 	StorageAttachment(names.StorageTag, names.UnitTag) (state.StorageAttachment, error)
 	UnitAssignedMachine(names.UnitTag) (names.MachineTag, error)
 	FilesystemAttachment(names.MachineTag, names.FilesystemTag) (state.FilesystemAttachment, error)

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -81,13 +81,9 @@ func (s *uniterV2Suite) TestStorageAttachments(c *gc.C) {
 
 	attachments, err := uniter.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(attachments, gc.DeepEquals, []params.StorageAttachment{{
+	c.Assert(attachments, gc.DeepEquals, []params.StorageAttachmentId{{
 		StorageTag: "storage-data-0",
-		OwnerTag:   unit.Tag().String(),
 		UnitTag:    unit.Tag().String(),
-		Kind:       params.StorageKindBlock,
-		Location:   "/dev/xvdf1",
-		Life:       "alive",
 	}})
 }
 

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -362,6 +362,9 @@ func modeAbideDyingLoop(u *Uniter) (next Mode, err error) {
 		// and leader-set hook tools from acting in a correct but misleading way
 		// (ie continuing to act as though leader after leader-deposed has run).
 	}
+	if err := u.storage.SetDying(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	for {
 		if len(u.relations.GetInfo()) == 0 && u.storage.Empty() {
 			return continueAfter(u, newSimpleRunHookOp(hooks.Stop))

--- a/worker/uniter/storage/mock_test.go
+++ b/worker/uniter/storage/mock_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 type mockStorageAccessor struct {
-	watchStorageAttachment func(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
-	storageAttachment      func(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
-	unitStorageAttachments func(names.UnitTag) ([]params.StorageAttachment, error)
-	remove                 func(names.StorageTag, names.UnitTag) error
+	watchStorageAttachment        func(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
+	storageAttachment             func(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
+	unitStorageAttachments        func(names.UnitTag) ([]params.StorageAttachmentId, error)
+	destroyUnitStorageAttachments func(names.UnitTag) error
+	remove                        func(names.StorageTag, names.UnitTag) error
 }
 
 func (m *mockStorageAccessor) WatchStorageAttachment(s names.StorageTag, u names.UnitTag) (watcher.NotifyWatcher, error) {
@@ -32,8 +33,12 @@ func (m *mockStorageAccessor) StorageAttachment(s names.StorageTag, u names.Unit
 	return m.storageAttachment(s, u)
 }
 
-func (m *mockStorageAccessor) UnitStorageAttachments(u names.UnitTag) ([]params.StorageAttachment, error) {
+func (m *mockStorageAccessor) UnitStorageAttachments(u names.UnitTag) ([]params.StorageAttachmentId, error) {
 	return m.unitStorageAttachments(u)
+}
+
+func (m *mockStorageAccessor) DestroyUnitStorageAttachments(u names.UnitTag) error {
+	return m.destroyUnitStorageAttachments(u)
 }
 
 func (m *mockStorageAccessor) RemoveStorageAttachment(s names.StorageTag, u names.UnitTag) error {

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -2019,10 +2019,10 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			provisionStorage{},
 			startUniter{},
 			waitAddresses{},
+			waitHooks{"wp-content-storage-attached"},
 			waitHooks(startupHooks(false)),
 			// TODO(axw) 2015-04-28 #1449390
 			// storage-attached should come before install.
-			waitHooks{"wp-content-storage-attached"},
 		), ut(
 			"test that storage-detaching is called before stop",
 			createCharm{customize: appendStorageMetadata},
@@ -2032,8 +2032,8 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			provisionStorage{},
 			startUniter{},
 			waitAddresses{},
-			waitHooks(startupHooks(false)),
 			waitHooks{"wp-content-storage-attached"},
+			waitHooks(startupHooks(false)),
 			unitDying,
 			waitHooks{"leader-settings-changed"},
 			// "stop" hook is not called until storage is detached
@@ -2060,5 +2060,9 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			verifyStorageDetached{},
 			waitUniterDead{},
 		),
+		// TODO(axw) test that storage-attached is run for new
+		// storage attachments before upgrade-charm is run. This
+		// requires additions to state to add storage when a charm
+		// is upgraded.
 	})
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -2035,8 +2035,6 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			unitDying,
 			waitHooks{"leader-settings-changed"},
 			// "stop" hook is not called until storage is detached
-			waitHooks{},
-			destroyStorageAttachment{},
 			waitHooks{"wp-content-storage-detaching", "stop"},
 			verifyStorageDetached{},
 			waitUniterDead{},
@@ -2063,17 +2061,13 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			serveCharm{},
 			ensureStateWorker{},
 			createServiceAndUnit{},
-			// destroy the storage before the uniter starts,
-			// to ensure it does not block the uniter from
-			// terminating.
-			destroyStorageAttachment{},
 			startUniter{},
 			// no hooks should be run, as storage isn't provisioned
 			waitHooks{},
 			unitDying,
 			// TODO(axw) should we really be running startup hooks
 			// when the unit is dying?
-			waitHooks(startupHooks(false)),
+			waitHooks(startupHooks(true)),
 			waitHooks{"stop"},
 			waitUniterDead{},
 		),


### PR DESCRIPTION
Ensure that storage attachments are ready before
running a charm's install or upgrade-charm hooks,
so that those hooks may use said storage.

Fixes https://bugs.launchpad.net/juju-core/+bug/1449390

(Review request: http://reviews.vapour.ws/r/1561/)