### PR TITLE
Merge pull request #2178 from wallyworld/juju-v2-option

### DIFF
--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -103,6 +104,10 @@ type EnvCommandBase struct {
 	// to specify an environment in multiple ways, and not always referencing
 	// a file on disk based on the EnvName or the environemnts.yaml file.
 	envName string
+
+	// compatVersion defines the minimum CLI version
+	// that this command should be compatible with.
+	compatVerson *int
 }
 
 func (c *EnvCommandBase) SetEnvName(envName string) {
@@ -234,6 +239,22 @@ func (c *EnvCommandBase) ConnectionWriter() (ConnectionWriter, error) {
 		return nil, errors.Trace(ErrNoEnvironmentSpecified)
 	}
 	return ConnectionInfoForName(c.envName)
+}
+
+// CompatVersion returns the minimum CLI version
+// that this command should be compatible with.
+func (c *EnvCommandBase) CompatVersion() int {
+	if c.compatVerson != nil {
+		return *c.compatVerson
+	}
+	val := os.Getenv(osenv.JujuCLIVersion)
+	compatVerson, err := strconv.Atoi(val)
+	if err != nil {
+		logger.Warningf("invalid %s value: %v", osenv.JujuCLIVersion, val)
+		return 1
+	}
+	c.compatVerson = &compatVerson
+	return *c.compatVerson
 }
 
 // ConnectionName returns the name of the connection if there is one.

--- a/cmd/envcmd/environmentcommand_test.go
+++ b/cmd/envcmd/environmentcommand_test.go
@@ -145,6 +145,26 @@ func (s *EnvironmentCommandSuite) TestBootstrapContextNoVerify(c *gc.C) {
 	c.Assert(ctx.ShouldVerifyCredentials(), jc.IsFalse)
 }
 
+func (s *EnvironmentCommandSuite) TestCompatVersion(c *gc.C) {
+	s.PatchEnvironment(osenv.JujuCLIVersion, "2")
+	cmd, err := initTestCommand(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.CompatVersion(), gc.Equals, 2)
+}
+
+func (s *EnvironmentCommandSuite) TestCompatVersionDefault(c *gc.C) {
+	cmd, err := initTestCommand(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.CompatVersion(), gc.Equals, 1)
+}
+
+func (s *EnvironmentCommandSuite) TestCompatVersionInvalid(c *gc.C) {
+	s.PatchEnvironment(osenv.JujuCLIVersion, "invalid")
+	cmd, err := initTestCommand(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.CompatVersion(), gc.Equals, 1)
+}
+
 type testCommand struct {
 	envcmd.EnvCommandBase
 }

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 	goyaml "gopkg.in/yaml.v1"
@@ -24,7 +23,6 @@ import (
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
@@ -3062,9 +3060,8 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	)
 }
 
-func (s *StatusSuite) TestStatusWithFormatTabularFeatureFlag(c *gc.C) {
-	s.SetFeatureFlags(feature.NewStatus)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+func (s *StatusSuite) TestStatusV2(c *gc.C) {
+	s.PatchEnvironment(osenv.JujuCLIVersion, "2")
 	s.testStatusWithFormatTabular(c, true)
 }
 

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -38,10 +38,6 @@ const LegacyUpstart = "legacy-upstart"
 // MongoDB instead of to all-machines.log using rsyslog.
 const DbLog = "db-log"
 
-// NewStatus is the name of the feature to enable the new
-// juju status output.
-const NewStatus = "new-status"
-
 // CloudSigma enables the CloudSigma provider.
 const CloudSigma = "cloudsigma"
 

--- a/juju/osenv/vars.go
+++ b/juju/osenv/vars.go
@@ -16,14 +16,22 @@ const (
 	JujuRepositoryEnvKey    = "JUJU_REPOSITORY"
 	JujuLoggingConfigEnvKey = "JUJU_LOGGING_CONFIG"
 	JujuFeatureFlagEnvKey   = "JUJU_DEV_FEATURE_FLAGS"
+
 	// TODO(thumper): 2013-09-02 bug 1219630
 	// As much as I'd like to remove JujuContainerType now, it is still
 	// needed as MAAS still needs it at this stage, and we can't fix
 	// everything at once.
 	JujuContainerTypeEnvKey = "JUJU_CONTAINER_TYPE"
+
 	// JujuStatusIsoTimeEnvKey is the env var which if true, will cause status
 	// timestamps to be written in RFC3339 format.
 	JujuStatusIsoTimeEnvKey = "JUJU_STATUS_ISO_TIME"
+
+	// JujuCLIVersion is a numeric value (1, 2, 3 etc) representing
+	// the oldest CLI version which should be adhered to.
+	// This includes args and output.
+	// Default is 1.
+	JujuCLIVersion = "JUJU_CLI_VERSION"
 )
 
 // FeatureFlags returns a map that can be merged with os.Environ.


### PR DESCRIPTION
Add option to set the CLI compatible version and use with juju status

We want users to be able to use the new health status output, but we need to retain compatibility with Juju 1.x scripts. So we use a new env var JUJU_CLI_VERSION which allows the user to define the minimum CLI version for which we want Juju to be compatible. The default is 1. If the user exports JUJU_CLI_VERSION=2 then they get the new 2.0 status by default. This can be extended to other commands.

(Review request: http://reviews.vapour.ws/r/1540/)

(Review request: http://reviews.vapour.ws/r/1562/)