### PR TITLE
Revert pull request #2124 natefinch/fix-win-env

### DIFF
--- a/juju/osenv/export_test.go
+++ b/juju/osenv/export_test.go
@@ -3,9 +3,5 @@
 
 package osenv
 
-var (
-	JujuHomeWin   = jujuHomeWin
-	JujuHomeLinux = jujuHomeLinux
-	MergeEnvUnix  = mergeEnvUnix
-	MergeEnvWin   = mergeEnvWin
-)
+var JujuHomeWin = jujuHomeWin
+var JujuHomeLinux = jujuHomeLinux

--- a/juju/osenv/vars.go
+++ b/juju/osenv/vars.go
@@ -3,12 +3,7 @@
 
 package osenv
 
-import (
-	"runtime"
-	"strings"
-
-	"github.com/juju/utils/featureflag"
-)
+import "github.com/juju/utils/featureflag"
 
 const (
 	JujuEnvEnvKey           = "JUJU_ENV"
@@ -42,44 +37,8 @@ func MergeEnvironment(current, newValues map[string]string) map[string]string {
 	if current == nil {
 		current = make(map[string]string)
 	}
-	if runtime.GOOS == "windows" {
-		return mergeEnvWin(current, newValues)
-	}
-	return mergeEnvUnix(current, newValues)
-}
-
-// mergeEnvUnix merges the two evironment variable lists in a case sensitive way.
-func mergeEnvUnix(current, newValues map[string]string) map[string]string {
 	for key, value := range newValues {
 		current[key] = value
-	}
-	return current
-}
-
-// mergeEnvWin merges the two environment variable lists in a case insensitive,
-// but case preserving way.  Thus, if FOO=bar is set, and newValues has foo=baz,
-// then the resultant map will contain FOO=baz.
-func mergeEnvWin(current, newValues map[string]string) map[string]string {
-	uppers := make(map[string]string, len(current))
-	news := map[string]string{}
-	for k, v := range current {
-		uppers[strings.ToUpper(k)] = v
-	}
-
-	for k, v := range newValues {
-		up := strings.ToUpper(k)
-		if _, ok := uppers[up]; ok {
-			uppers[up] = v
-		} else {
-			news[k] = v
-		}
-	}
-
-	for k := range current {
-		current[k] = uppers[strings.ToUpper(k)]
-	}
-	for k, v := range news {
-		current[k] = v
 	}
 	return current
 }

--- a/juju/osenv/vars_test.go
+++ b/juju/osenv/vars_test.go
@@ -45,32 +45,18 @@ func (s *varsSuite) TestBlankJujuHomeEnvVar(c *gc.C) {
 
 func (s *varsSuite) TestMergeEnvironment(c *gc.C) {
 	c.Check(osenv.MergeEnvironment(nil, nil), gc.HasLen, 0)
+	initial := map[string]string{"a": "foo", "b": "bar"}
 	newValues := map[string]string{"a": "baz", "c": "omg"}
-	created := osenv.MergeEnvironment(nil, newValues)
 	expected := map[string]string{"a": "baz", "c": "omg"}
+
+	created := osenv.MergeEnvironment(nil, newValues)
 	c.Check(created, jc.DeepEquals, expected)
 	// Show that the map returned isn't the one passed in.
 	newValues["d"] = "another"
 	c.Check(created, jc.DeepEquals, expected)
-}
 
-func (s *varsSuite) TestMergeEnvWin(c *gc.C) {
-	initial := map[string]string{"a": "foo", "b": "bar", "foo": "val"}
-	newValues := map[string]string{"a": "baz", "c": "omg", "FOO": "val2", "d": "another"}
-
-	created := osenv.MergeEnvWin(initial, newValues)
-	expected := map[string]string{"a": "baz", "b": "bar", "c": "omg", "foo": "val2", "d": "another"}
-	// The returned value is the inital map.
-	c.Check(created, jc.DeepEquals, expected)
-	c.Check(initial, jc.DeepEquals, expected)
-}
-
-func (s *varsSuite) TestMergeEnvUnix(c *gc.C) {
-	initial := map[string]string{"a": "foo", "b": "bar"}
-	newValues := map[string]string{"a": "baz", "c": "omg", "d": "another"}
-
-	created := osenv.MergeEnvUnix(initial, newValues)
-	expected := map[string]string{"a": "baz", "b": "bar", "c": "omg", "d": "another"}
+	created = osenv.MergeEnvironment(initial, newValues)
+	expected = map[string]string{"a": "baz", "b": "bar", "c": "omg", "d": "another"}
 	// The returned value is the inital map.
 	c.Check(created, jc.DeepEquals, expected)
 	c.Check(initial, jc.DeepEquals, expected)

--- a/worker/uniter/runner/env.go
+++ b/worker/uniter/runner/env.go
@@ -61,46 +61,25 @@ func windowsEnv(paths Paths) []string {
 // or having missing environment variables, may lead to standard go packages not working
 // (os.TempDir relies on $env:TEMP), and powershell erroring out
 // TODO(fwereade, gsamfira): this is copy/pasted from utils/exec.
-// This is only used on windows, so it is safe to do in a case insensitive way.
-func mergeWindowsEnvironment(newEnv []string) []string {
-	if newEnv == nil {
+func mergeEnvironment(env []string) []string {
+	if env == nil {
 		return nil
 	}
+	m := map[string]string{}
+	var tmpEnv []string
+	for _, val := range os.Environ() {
+		varSplit := strings.SplitN(val, "=", 2)
+		m[varSplit[0]] = varSplit[1]
+	}
 
-	env := os.Environ()
-
-	// this whole rigamarole is so that we retain the case of existing
-	// environment variables, while being case insensitive about overwriting
-	// their values.
-
-	orig := make(map[string]string, len(env))
-	uppers := make(map[string]string, len(env))
-	news := map[string]string{}
-
-	tmpEnv := make([]string, 0, len(env))
 	for _, val := range env {
 		varSplit := strings.SplitN(val, "=", 2)
-		k := varSplit[0]
-		uppers[strings.ToUpper(k)] = varSplit[1]
-		orig[k] = varSplit[1]
+		m[varSplit[0]] = varSplit[1]
 	}
 
-	for _, val := range newEnv {
-		varSplit := strings.SplitN(val, "=", 2)
-		k := varSplit[0]
-		if _, ok := uppers[strings.ToUpper(k)]; ok {
-			uppers[k] = varSplit[1]
-		} else {
-			news[k] = varSplit[1]
-		}
+	for key, val := range m {
+		tmpEnv = append(tmpEnv, key+"="+val)
 	}
 
-	for k, _ := range orig {
-		tmpEnv = append(tmpEnv, k+"="+uppers[strings.ToUpper(k)])
-	}
-
-	for k, v := range news {
-		tmpEnv = append(tmpEnv, k+"="+v)
-	}
 	return tmpEnv
 }

--- a/worker/uniter/runner/env_test.go
+++ b/worker/uniter/runner/env_test.go
@@ -6,8 +6,8 @@ package runner_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
-	"strings"
 
 	"github.com/juju/names"
 	envtesting "github.com/juju/testing"
@@ -26,6 +26,10 @@ type MergeEnvSuite struct {
 var _ = gc.Suite(&MergeEnvSuite{})
 
 func (e *MergeEnvSuite) TestMergeEnviron(c *gc.C) {
+	//TODO(bogdanteleaga): Fix this on windows
+	if runtime.GOOS == "windows" {
+		c.Skip("bug 1403084: There are some problems regarding os.Environ() on windows")
+	}
 	// environment does not get fully cleared on Windows
 	// when using testing.IsolationSuite
 	origEnv := os.Environ()
@@ -34,25 +38,11 @@ func (e *MergeEnvSuite) TestMergeEnviron(c *gc.C) {
 		"DUMMYVAR2=bar",
 		"NEWVAR=ImNew",
 	}
-	expectEnv := make([]string, 0, len(origEnv)+len(extraExpected))
-
-	// os.Environ prepends some garbage on Windows that we need to strip out.
-	// All the garbage starts and ends with = (for example "=C:=").
-	for _, v := range origEnv {
-		if !(strings.HasPrefix(v, "=") && strings.HasSuffix(v, "=")) {
-			expectEnv = append(expectEnv, v)
-		}
-	}
-	expectEnv = append(expectEnv, extraExpected...)
+	expectEnv := append(origEnv, extraExpected...)
 	os.Setenv("DUMMYVAR2", "ChangeMe")
 	os.Setenv("DUMMYVAR", "foo")
 
-	newEnv := make([]string, 0, len(expectEnv))
-	for _, v := range runner.MergeWindowsEnvironment([]string{"DUMMYVAR2=bar", "NEWVAR=ImNew"}) {
-		if !(strings.HasPrefix(v, "=") && strings.HasSuffix(v, "=")) {
-			newEnv = append(newEnv, v)
-		}
-	}
+	newEnv := runner.MergeEnvironment([]string{"DUMMYVAR2=bar", "NEWVAR=ImNew"})
 	c.Assert(expectEnv, jc.SameContents, newEnv)
 }
 

--- a/worker/uniter/runner/export_test.go
+++ b/worker/uniter/runner/export_test.go
@@ -16,14 +16,14 @@ import (
 )
 
 var (
-	MergeWindowsEnvironment = mergeWindowsEnvironment
-	SearchHook              = searchHook
-	HookCommand             = hookCommand
-	LookPath                = lookPath
-	ValidatePortRange       = validatePortRange
-	TryOpenPorts            = tryOpenPorts
-	TryClosePorts           = tryClosePorts
-	LockTimeout             = lockTimeout
+	MergeEnvironment  = mergeEnvironment
+	SearchHook        = searchHook
+	HookCommand       = hookCommand
+	LookPath          = lookPath
+	ValidatePortRange = validatePortRange
+	TryOpenPorts      = tryOpenPorts
+	TryClosePorts     = tryClosePorts
+	LockTimeout       = lockTimeout
 )
 
 func RunnerPaths(rnr Runner) Paths {

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -133,7 +133,7 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string) e
 		// TODO(fwereade): somehow consolidate with utils/exec?
 		// We don't do this on the other code path, which uses exec.RunCommands,
 		// because that already has handling for windows environment requirements.
-		env = mergeWindowsEnvironment(env)
+		env = mergeEnvironment(env)
 	}
 
 	debugctx := debug.NewHooksContext(runner.context.UnitName())


### PR DESCRIPTION
Fixes lp:1450919 as the branch regressed the environment variable handling.

This reverts commit 61795e6f44894bc1e6f14be1fd23bb3c2d905041, reversing
changes made to 0a5fdc69bfc51382238bb529e18ca11a0c9b5b72.

(Review request: http://reviews.vapour.ws/r/1567/)