### PR TITLE
Fix 1384549: ensure-availability twice adds extra machines

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -820,6 +820,11 @@ func (st *State) ensureAvailabilityIntentions(info *StateServerInfo, placement [
 			}
 			continue
 		}
+		if !m.HasVote() && m.WantsVote() {
+			// voting is still being added to the server, so keep it around.
+			intent.maintain = append(intent.maintain, m)
+			continue
+		}
 		if m.WantsVote() {
 			// The machine wants to vote, so we simply set novote and allow it
 			// to run its course to have its vote removed by the worker that

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -829,7 +829,7 @@ func (s *assignCleanSuite) TestAssignToMachineNoneAvailable(c *gc.C) {
 	// Add two environ manager machines and check they are not chosen.
 	changes, err := s.State.EnsureAvailability(3, constraints.Value{}, "quantal", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes.Added, gc.HasLen, 3)
+	c.Assert(changes.Added, gc.HasLen, 2)
 
 	m, err = s.assignUnit(unit)
 	c.Assert(m, gc.IsNil)


### PR DESCRIPTION
If the server if it is not available, wants to vote but does not yet
have a a vote, then don't demote the server (previous behaviour).
Instead maintain the server as it is still being setup for HA.

Fix a test that expected 3 servers to be added when calling HA on a
single server setup (even though the comment makes it clear that only
2 should be added and 3 - 1 existing state server = 2 new servers).

(Review request: http://reviews.vapour.ws/r/1570/)