### PR TITLE
Fix JUJU_CLI_VERSION warning

### DIFF
--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -247,11 +247,15 @@ func (c *EnvCommandBase) CompatVersion() int {
 	if c.compatVerson != nil {
 		return *c.compatVerson
 	}
+	compatVerson := 1
 	val := os.Getenv(osenv.JujuCLIVersion)
-	compatVerson, err := strconv.Atoi(val)
-	if err != nil {
-		logger.Warningf("invalid %s value: %v", osenv.JujuCLIVersion, val)
-		return 1
+	if val != "" {
+		vers, err := strconv.Atoi(val)
+		if err != nil {
+			logger.Warningf("invalid %s value: %v", osenv.JujuCLIVersion, val)
+		} else {
+			compatVerson = vers
+		}
 	}
 	c.compatVerson = &compatVerson
 	return *c.compatVerson

--- a/cmd/envcmd/environmentcommand_test.go
+++ b/cmd/envcmd/environmentcommand_test.go
@@ -27,6 +27,11 @@ type EnvironmentCommandSuite struct {
 	coretesting.FakeJujuHomeSuite
 }
 
+func (s *EnvironmentCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+	s.PatchEnvironment("JUJU_CLI_VERSION", "")
+}
+
 var _ = gc.Suite(&EnvironmentCommandSuite{})
 
 func Test(t *testing.T) { gc.TestingT(t) }


### PR DESCRIPTION
An erroneous warning was being logged when the JUJU_CLI_VERSION value was "". Now a warning is only printed is the value is bad and !""

(Review request: http://reviews.vapour.ws/r/1573/)