### PR TITLE
state: fix env UUID migrations to not be sensitive to map ordering

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -816,14 +816,24 @@ func AddEnvUUIDToMachines(st *State) error {
 // AddEnvUUIDToOpenPorts prepends the environment UUID to the ID of
 // all openPorts docs and adds new "env-uuid" field.
 func AddEnvUUIDToOpenPorts(st *State) error {
-	setNewFields := func(b bson.M) error {
-		parts, err := extractPortsIdParts(b["_id"].(string))
+	setNewFields := func(d bson.D) (bson.D, error) {
+		id, err := readBsonDField(d, "_id")
 		if err != nil {
-			return errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
-		b["machine-id"] = parts[machineIdPart]
-		b["network-name"] = parts[networkNamePart]
-		return nil
+		parts, err := extractPortsIdParts(id.(string))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		d, err = addBsonDField(d, "machine-id", parts[machineIdPart])
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		d, err = addBsonDField(d, "network-name", parts[networkNamePart])
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return d, nil
 	}
 	return addEnvUUIDToEntityCollection(st, openedPortsC, setNewFields)
 }
@@ -971,19 +981,30 @@ func addEnvUUIDToEntityCollection(st *State, collName string, updates ...updateF
 	iter := coll.Find(bson.D{{"env-uuid", bson.D{{"$exists", false}}}}).Iter()
 	defer iter.Close()
 	ops := []txn.Op{}
-	var doc bson.M
+	var doc bson.D
 	for iter.Next(&doc) {
-		oldID := doc["_id"]
-		id := st.docID(fmt.Sprint(oldID))
+		oldID, err := readBsonDField(doc, "_id")
+		if err != nil {
+			return errors.Trace(err)
+		}
+		newID := st.docID(fmt.Sprint(oldID))
 
-		// collection specific updates
+		// Collection specific updates.
 		for _, update := range updates {
-			if err := update(doc); err != nil {
+			var err error
+			doc, err = update(doc)
+			if err != nil {
 				return errors.Trace(err)
 			}
 		}
-		doc["_id"] = id
-		doc["env-uuid"] = uuid
+
+		doc, err = addBsonDField(doc, "env-uuid", uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		// Note: there's no need to update _id on the document. Id
+		// from the txn.Op takes precedence.
 
 		ops = append(ops,
 			[]txn.Op{{
@@ -993,11 +1014,11 @@ func addEnvUUIDToEntityCollection(st *State, collName string, updates ...updateF
 				Remove: true,
 			}, {
 				C:      collName,
-				Id:     id,
+				Id:     newID,
 				Assert: txn.DocMissing,
 				Insert: doc,
 			}}...)
-		doc = nil // Force creation of new map for the next iteration
+		doc = nil // Force creation of new doc for the next iteration
 	}
 	if err = iter.Err(); err != nil {
 		return errors.Trace(err)
@@ -1005,14 +1026,42 @@ func addEnvUUIDToEntityCollection(st *State, collName string, updates ...updateF
 	return st.runRawTransaction(ops)
 }
 
-type updateFunc func(bson.M) error
+// readBsonDField returns the value of a given field in a bson.D.
+func readBsonDField(d bson.D, name string) (interface{}, error) {
+	for i := range d {
+		field := &d[i]
+		if field.Name == name {
+			return field.Value, nil
+		}
+	}
+	return nil, errors.NotFoundf("field %q", name)
+}
+
+// addBsonDField adds a new field to the end of a bson.D, returning
+// the updated bson.D.
+func addBsonDField(d bson.D, name string, value interface{}) (bson.D, error) {
+	for i := range d {
+		if d[i].Name == name {
+			return nil, errors.AlreadyExistsf("field %q", name)
+		}
+	}
+	return append(d, bson.DocElem{
+		Name:  name,
+		Value: value,
+	}), nil
+}
+
+type updateFunc func(bson.D) (bson.D, error)
 
 // setOldID returns an updateFunc which populates the doc's original ID
 // in the named field.
 func setOldID(name string) updateFunc {
-	return func(b bson.M) error {
-		b[name] = b["_id"]
-		return nil
+	return func(d bson.D) (bson.D, error) {
+		oldID, err := readBsonDField(d, "_id")
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return addBsonDField(d, name, oldID)
 	}
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2610,3 +2610,80 @@ func (s *upgradesSuite) TestAddLeadershipSettingsIdempotent(c *gc.C) {
 
 	c.Check(firstPassIDs, jc.SameContents, secondPassIDs)
 }
+
+func (s *upgradesSuite) TestEnvUUIDMigrationFieldOrdering(c *gc.C) {
+	// This tests a DB migration regression triggered by Go 1.3+'s
+	// randomised map iteration feature. See LP #1451674.
+	//
+	// Here we ensure that the addEnvUUIDToEntityCollection helper
+	// doesn't change the order of document fields. This is important
+	// because MongoDB comparisons and txn assertions will not work as
+	// expected if document field orders don't match.
+	//
+	// Several documents, each containing other documents in an array,
+	// are inserted and then read back out to ensure that field
+	// ordering hasn't changed.
+
+	type address struct {
+		Value       string `bson:"value"`
+		AddressType string `bson:"addresstype"`
+		NetworkName string `bson:"networkname"`
+		Scope       string `bson:"networkscope"`
+	}
+
+	type fakeMachineDoc struct {
+		DocID     string    `bson:"_id"`
+		Series    string    `bson:"series"`
+		Addresses []address `bson:"addresses"`
+	}
+
+	mdoc := fakeMachineDoc{
+		Series: "foo",
+		Addresses: []address{
+			{
+				Value:       "1.2.3.4",
+				AddressType: "local",
+				NetworkName: "foo",
+				Scope:       "bar",
+			},
+			{
+				Value:       "5.4.3.2",
+				AddressType: "meta",
+				NetworkName: "brie",
+				Scope:       "cheese",
+			},
+		},
+	}
+
+	machines, close := s.state.getRawCollection(machinesC)
+	defer close()
+	for i := 0; i < 20; i++ {
+		mdoc.DocID = fmt.Sprintf("%d", i)
+		err := machines.Insert(mdoc)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	err := addEnvUUIDToEntityCollection(s.state, machinesC, setOldID("machineid"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	var outDocs []bson.D
+	err = machines.Find(nil).All(&outDocs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedMachineFields := []string{"_id", "series", "addresses", "machineid", "env-uuid"}
+	expectedAddressFields := []string{"value", "addresstype", "networkname", "networkscope"}
+	for _, doc := range outDocs {
+		for i, fieldName := range expectedMachineFields {
+			c.Assert(doc[i].Name, gc.Equals, fieldName)
+		}
+
+		addresses := doc[2].Value.([]interface{})
+		c.Assert(addresses, gc.HasLen, 2)
+		for _, addressElem := range addresses {
+			address := addressElem.(bson.D)
+			for i, fieldName := range expectedAddressFields {
+				c.Assert(address[i].Name, gc.Equals, fieldName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
The migration helper now uses bson.D instead of bson.M.

Fixes LP #1451674.

(Review request: http://reviews.vapour.ws/r/1581/)