### PR TITLE
Fix win env 1.24

### DIFF
--- a/juju/osenv/export_test.go
+++ b/juju/osenv/export_test.go
@@ -3,5 +3,9 @@
 
 package osenv
 
-var JujuHomeWin = jujuHomeWin
-var JujuHomeLinux = jujuHomeLinux
+var (
+	JujuHomeWin   = jujuHomeWin
+	JujuHomeLinux = jujuHomeLinux
+	MergeEnvUnix  = mergeEnvUnix
+	MergeEnvWin   = mergeEnvWin
+)

--- a/juju/osenv/vars.go
+++ b/juju/osenv/vars.go
@@ -3,7 +3,12 @@
 
 package osenv
 
-import "github.com/juju/utils/featureflag"
+import (
+	"runtime"
+	"strings"
+
+	"github.com/juju/utils/featureflag"
+)
 
 const (
 	JujuEnvEnvKey           = "JUJU_ENV"
@@ -45,8 +50,44 @@ func MergeEnvironment(current, newValues map[string]string) map[string]string {
 	if current == nil {
 		current = make(map[string]string)
 	}
+	if runtime.GOOS == "windows" {
+		return mergeEnvWin(current, newValues)
+	}
+	return mergeEnvUnix(current, newValues)
+}
+
+// mergeEnvUnix merges the two evironment variable lists in a case sensitive way.
+func mergeEnvUnix(current, newValues map[string]string) map[string]string {
 	for key, value := range newValues {
 		current[key] = value
+	}
+	return current
+}
+
+// mergeEnvWin merges the two environment variable lists in a case insensitive,
+// but case preserving way.  Thus, if FOO=bar is set, and newValues has foo=baz,
+// then the resultant map will contain FOO=baz.
+func mergeEnvWin(current, newValues map[string]string) map[string]string {
+	uppers := make(map[string]string, len(current))
+	news := map[string]string{}
+	for k, v := range current {
+		uppers[strings.ToUpper(k)] = v
+	}
+
+	for k, v := range newValues {
+		up := strings.ToUpper(k)
+		if _, ok := uppers[up]; ok {
+			uppers[up] = v
+		} else {
+			news[k] = v
+		}
+	}
+
+	for k := range current {
+		current[k] = uppers[strings.ToUpper(k)]
+	}
+	for k, v := range news {
+		current[k] = v
 	}
 	return current
 }

--- a/juju/osenv/vars_test.go
+++ b/juju/osenv/vars_test.go
@@ -45,18 +45,32 @@ func (s *varsSuite) TestBlankJujuHomeEnvVar(c *gc.C) {
 
 func (s *varsSuite) TestMergeEnvironment(c *gc.C) {
 	c.Check(osenv.MergeEnvironment(nil, nil), gc.HasLen, 0)
-	initial := map[string]string{"a": "foo", "b": "bar"}
 	newValues := map[string]string{"a": "baz", "c": "omg"}
-	expected := map[string]string{"a": "baz", "c": "omg"}
-
 	created := osenv.MergeEnvironment(nil, newValues)
+	expected := map[string]string{"a": "baz", "c": "omg"}
 	c.Check(created, jc.DeepEquals, expected)
 	// Show that the map returned isn't the one passed in.
 	newValues["d"] = "another"
 	c.Check(created, jc.DeepEquals, expected)
+}
 
-	created = osenv.MergeEnvironment(initial, newValues)
-	expected = map[string]string{"a": "baz", "b": "bar", "c": "omg", "d": "another"}
+func (s *varsSuite) TestMergeEnvWin(c *gc.C) {
+	initial := map[string]string{"a": "foo", "b": "bar", "foo": "val"}
+	newValues := map[string]string{"a": "baz", "c": "omg", "FOO": "val2", "d": "another"}
+
+	created := osenv.MergeEnvWin(initial, newValues)
+	expected := map[string]string{"a": "baz", "b": "bar", "c": "omg", "foo": "val2", "d": "another"}
+	// The returned value is the inital map.
+	c.Check(created, jc.DeepEquals, expected)
+	c.Check(initial, jc.DeepEquals, expected)
+}
+
+func (s *varsSuite) TestMergeEnvUnix(c *gc.C) {
+	initial := map[string]string{"a": "foo", "b": "bar"}
+	newValues := map[string]string{"a": "baz", "c": "omg", "d": "another"}
+
+	created := osenv.MergeEnvUnix(initial, newValues)
+	expected := map[string]string{"a": "baz", "b": "bar", "c": "omg", "d": "another"}
 	// The returned value is the inital map.
 	c.Check(created, jc.DeepEquals, expected)
 	c.Check(initial, jc.DeepEquals, expected)

--- a/worker/uniter/runner/env.go
+++ b/worker/uniter/runner/env.go
@@ -61,25 +61,44 @@ func windowsEnv(paths Paths) []string {
 // or having missing environment variables, may lead to standard go packages not working
 // (os.TempDir relies on $env:TEMP), and powershell erroring out
 // TODO(fwereade, gsamfira): this is copy/pasted from utils/exec.
-func mergeEnvironment(env []string) []string {
-	if env == nil {
-		return nil
-	}
-	m := map[string]string{}
-	var tmpEnv []string
-	for _, val := range os.Environ() {
-		varSplit := strings.SplitN(val, "=", 2)
-		m[varSplit[0]] = varSplit[1]
+// This is only used on windows, so it is safe to do in a case insensitive way.
+func mergeWindowsEnvironment(newEnv, env []string) []string {
+	if len(newEnv) == 0 {
+		return env
 	}
 
+	// this whole rigamarole is so that we retain the case of existing
+	// environment variables, while being case insensitive about overwriting
+	// their values.
+
+	orig := make(map[string]string, len(env))
+	uppers := make(map[string]string, len(env))
+	news := map[string]string{}
+
+	tmpEnv := make([]string, 0, len(env))
 	for _, val := range env {
 		varSplit := strings.SplitN(val, "=", 2)
-		m[varSplit[0]] = varSplit[1]
+		k := varSplit[0]
+		uppers[strings.ToUpper(k)] = varSplit[1]
+		orig[k] = varSplit[1]
 	}
 
-	for key, val := range m {
-		tmpEnv = append(tmpEnv, key+"="+val)
+	for _, val := range newEnv {
+		varSplit := strings.SplitN(val, "=", 2)
+		k := varSplit[0]
+		if _, ok := uppers[strings.ToUpper(k)]; ok {
+			uppers[strings.ToUpper(k)] = varSplit[1]
+		} else {
+			news[k] = varSplit[1]
+		}
 	}
 
+	for k, _ := range orig {
+		tmpEnv = append(tmpEnv, k+"="+uppers[strings.ToUpper(k)])
+	}
+
+	for k, v := range news {
+		tmpEnv = append(tmpEnv, k+"="+v)
+	}
 	return tmpEnv
 }

--- a/worker/uniter/runner/export_test.go
+++ b/worker/uniter/runner/export_test.go
@@ -16,14 +16,14 @@ import (
 )
 
 var (
-	MergeEnvironment  = mergeEnvironment
-	SearchHook        = searchHook
-	HookCommand       = hookCommand
-	LookPath          = lookPath
-	ValidatePortRange = validatePortRange
-	TryOpenPorts      = tryOpenPorts
-	TryClosePorts     = tryClosePorts
-	LockTimeout       = lockTimeout
+	MergeWindowsEnvironment = mergeWindowsEnvironment
+	SearchHook              = searchHook
+	HookCommand             = hookCommand
+	LookPath                = lookPath
+	ValidatePortRange       = validatePortRange
+	TryOpenPorts            = tryOpenPorts
+	TryClosePorts           = tryClosePorts
+	LockTimeout             = lockTimeout
 )
 
 func RunnerPaths(rnr Runner) Paths {

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -133,7 +133,7 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string) e
 		// TODO(fwereade): somehow consolidate with utils/exec?
 		// We don't do this on the other code path, which uses exec.RunCommands,
 		// because that already has handling for windows environment requirements.
-		env = mergeEnvironment(env)
+		env = mergeWindowsEnvironment(env, os.Environ())
 	}
 
 	debugctx := debug.NewHooksContext(runner.context.UnitName())


### PR DESCRIPTION
re-implement the windows environment variable case insensitivity fix, this time with better tests. This is mostly a copy of PR #2124, with a couple tweaks. This re-fixes https://bugs.launchpad.net/juju-core/+bug/1446871

(Review request: http://reviews.vapour.ws/r/1582/)