### PR TITLE
state/meterstatus: Let's not have the good case as the default value

### DIFF
--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -55,11 +55,11 @@ func MeterStatusFromString(str string) MeterStatusCode {
 
 // This const block defines the relative severities of the valid MeterStatusCodes in ascending order.
 const (
-	MeterGreen MeterStatusCode = iota
-	MeterNotSet
-	MeterAmber
+	MeterNotAvailable MeterStatusCode = iota
 	MeterRed
-	MeterNotAvailable
+	MeterAmber
+	MeterNotSet
+	MeterGreen
 )
 
 var (
@@ -170,7 +170,7 @@ func (u *Unit) GetMeterStatus() (MeterStatus, error) {
 }
 
 func combineMeterStatus(a, b MeterStatus) MeterStatus {
-	if a.Severity() > b.Severity() {
+	if a.Severity() < b.Severity() {
 		return a
 	}
 	return b


### PR DESCRIPTION
Previously the default value of MeterStatus (int: 0) equated to the good case (Green) Let's swap it around so the default value is also the worst case

(Review request: http://reviews.vapour.ws/r/1586/)