### PR TITLE
Add storage support to MAAS storage provider

### DIFF
--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -73,6 +73,20 @@ func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Co
 	if err != nil {
 		return nil, err
 	}
+
+	// Add MAAS specific defaults.
+	providerDefaults := make(map[string]interface{})
+
+	// Storage.
+	if _, ok := cfg.StorageDefaultBlockSource(); !ok {
+		providerDefaults[config.StorageDefaultBlockSourceKey] = MAAS_ProviderType
+	}
+	if len(providerDefaults) > 0 {
+		if cfg, err = cfg.Apply(providerDefaults); err != nil {
+			return nil, err
+		}
+	}
+
 	if oldCfg != nil {
 		oldAttrs := oldCfg.UnknownAttrs()
 		validMaasAgentName := false

--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -79,7 +79,7 @@ func (prov maasEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Co
 
 	// Storage.
 	if _, ok := cfg.StorageDefaultBlockSource(); !ok {
-		providerDefaults[config.StorageDefaultBlockSourceKey] = MAAS_ProviderType
+		providerDefaults[config.StorageDefaultBlockSourceKey] = maasStorageProviderType
 	}
 	if len(providerDefaults) > 0 {
 		if cfg, err = cfg.Apply(providerDefaults); err != nil {

--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -87,6 +87,16 @@ func (*configSuite) TestChecksWellFormedMaasOAuth(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, ".*malformed maas-oauth.*")
 }
 
+func (*configSuite) TestBlockStorageProviderDefault(c *gc.C) {
+	ecfg, err := newConfig(map[string]interface{}{
+		"maas-server": "http://maas.testing.invalid/maas/",
+		"maas-oauth":  "consumer-key:resource-token:resource-secret",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	src, _ := ecfg.StorageDefaultBlockSource()
+	c.Assert(src, gc.Equals, "maas")
+}
+
 func (*configSuite) TestValidateUpcallsEnvironsConfigValidate(c *gc.C) {
 	// The base Validate() function will not allow an environment to
 	// change its name.  Trigger that error so as to prove that the

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
+	"github.com/juju/names"
 )
 
 const (
@@ -970,16 +971,17 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		}
 	}
 
-	resultVolumes, err := inst.volumes()
+	resultVolumes, resultAttachments, err := inst.volumes(names.NewMachineTag(args.InstanceConfig.MachineId))
 	if err != nil {
 		return nil, err
 	}
 
 	return &environs.StartInstanceResult{
-		Instance:    inst,
-		Hardware:    hc,
-		NetworkInfo: networkInfo,
-		Volumes:     resultVolumes,
+		Instance:          inst,
+		Hardware:          hc,
+		NetworkInfo:       networkInfo,
+		Volumes:           resultVolumes,
+		VolumeAttachments: resultAttachments,
 	}, nil
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -971,7 +971,14 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		}
 	}
 
-	resultVolumes, resultAttachments, err := inst.volumes(names.NewMachineTag(args.InstanceConfig.MachineId))
+	requestedVolumes := make([]names.VolumeTag, len(args.Volumes))
+	for i, v := range args.Volumes {
+		requestedVolumes[i] = v.Tag
+	}
+	resultVolumes, resultAttachments, err := inst.volumes(
+		names.NewMachineTag(args.InstanceConfig.MachineId),
+		requestedVolumes,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -652,16 +652,22 @@ func addVolumes(params url.Values, volumes []volumeInfo) {
 	if len(volumes) == 0 {
 		return
 	}
+	// Requests for specific values are passed to the acquire URL
+	// as a storage URL parameter of the form:
+	// [volume-name:]sizeinGB[tag,...]
+	// See http://maas.ubuntu.com/docs/api.html#nodes
+
+	// eg storage=root:0(ssd),data:20(magnetic,5400rpm),45
 	makeVolumeParams := func(v volumeInfo) string {
-		var parts []string
+		var params string
 		if v.name != "" {
-			parts = []string{v.name + ":"}
+			params = v.name + ":"
 		}
-		parts = append(parts, strconv.FormatUint(v.sizeInGiB, 10))
+		params += fmt.Sprintf("%d", v.sizeInGB)
 		if len(v.tags) > 0 {
-			parts = append(parts, fmt.Sprintf("(%s)", strings.Join(v.tags, ",")))
+			params += fmt.Sprintf("(%s)", strings.Join(v.tags, ","))
 		}
-		return strings.Join(parts, "")
+		return params
 	}
 	var volParms []string
 	for _, v := range volumes {

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -443,8 +443,8 @@ func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeTags(c *gc.C)
 
 func (suite *environSuite) TestAcquireNodeStorage(c *gc.C) {
 	for i, test := range []struct {
-		volumes []volumeInfo
-		expcted string
+		volumes  []volumeInfo
+		expected string
 	}{
 		{
 			nil,
@@ -478,7 +478,7 @@ func (suite *environSuite) TestAcquireNodeStorage(c *gc.C) {
 		requestValues := suite.testMAASObject.TestServer.NodeOperationRequestValues()
 		nodeRequestValues, found := requestValues["node0"]
 		c.Check(found, jc.IsTrue)
-		c.Check(nodeRequestValues[0].Get("storage"), gc.Equals, test.expcted)
+		c.Check(nodeRequestValues[0].Get("storage"), gc.Equals, test.expected)
 		suite.testMAASObject.TestServer.Clear()
 	}
 }
@@ -1422,11 +1422,21 @@ var nodeStorageAttrs = []map[string]interface{}{
 		"serial":     "XXXX",
 		"size":       250059350016,
 	},
+	{
+		"name":       "sdc",
+		"id":         3,
+		"path":       "/dev/sdc",
+		"model":      "Samsung_SSD_850_EVO_250GB",
+		"block_size": 4096,
+		"serial":     "YYYYYYY",
+		"size":       250059350016,
+	},
 }
 
 var storageConstraintAttrs = map[string]interface{}{
 	"1": "volume-1",
 	"2": "root",
+	"3": "volume-3",
 }
 
 func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
@@ -1438,6 +1448,7 @@ func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
 	})
 	params := environs.StartInstanceParams{Volumes: []storage.VolumeParams{
 		{Tag: names.NewVolumeTag("1"), Size: 2000000},
+		{Tag: names.NewVolumeTag("3"), Size: 2000000},
 	}}
 	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1445,8 +1456,14 @@ func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
 		{
 			Tag:        names.NewVolumeTag("1"),
 			Size:       238475,
-			VolumeId:   "/dev/disk/by-id/id_for_sda",
-			HardwareId: "S21NNSAFC38075L",
+			VolumeId:   "volume-1",
+			HardwareId: "id_for_sda",
+		},
+		{
+			Tag:        names.NewVolumeTag("3"),
+			Size:       238475,
+			VolumeId:   "volume-3",
+			HardwareId: "sdc",
 		},
 	})
 }

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1452,7 +1452,7 @@ func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
 	}}
 	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Volumes, jc.DeepEquals, []storage.Volume{
+	c.Check(result.Volumes, jc.DeepEquals, []storage.Volume{
 		{
 			Tag:        names.NewVolumeTag("1"),
 			Size:       238475,
@@ -1463,7 +1463,21 @@ func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
 			Tag:        names.NewVolumeTag("3"),
 			Size:       238475,
 			VolumeId:   "volume-3",
-			HardwareId: "sdc",
+			HardwareId: "",
+		},
+	})
+	c.Assert(result.VolumeAttachments, jc.DeepEquals, []storage.VolumeAttachment{
+		{
+			Volume:     names.NewVolumeTag("1"),
+			DeviceName: "",
+			Machine:    names.NewMachineTag("1"),
+			ReadOnly:   false,
+		},
+		{
+			Volume:     names.NewVolumeTag("3"),
+			DeviceName: "sdc",
+			Machine:    names.NewMachineTag("1"),
+			ReadOnly:   false,
 		},
 	})
 }

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
@@ -27,13 +28,14 @@ import (
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
-	"github.com/juju/juju/environs/storage"
+	envstorage "github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
@@ -305,7 +307,7 @@ func (suite *environSuite) TestAcquireNode(c *gc.C) {
 	env := suite.makeEnviron()
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
 
-	_, err := env.acquireNode("", "", constraints.Value{}, nil, nil)
+	_, err := env.acquireNode("", "", constraints.Value{}, nil, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 	operations := suite.testMAASObject.TestServer.NodeOperations()
@@ -323,7 +325,7 @@ func (suite *environSuite) TestAcquireNodeByName(c *gc.C) {
 	env := suite.makeEnviron()
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
 
-	_, err := env.acquireNode("host0", "", constraints.Value{}, nil, nil)
+	_, err := env.acquireNode("host0", "", constraints.Value{}, nil, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 	operations := suite.testMAASObject.TestServer.NodeOperations()
@@ -344,7 +346,7 @@ func (suite *environSuite) TestAcquireNodeTakesConstraintsIntoAccount(c *gc.C) {
 	)
 	constraints := constraints.Value{Arch: stringp("arm"), Mem: uint64p(1024)}
 
-	_, err := env.acquireNode("", "", constraints, nil, nil)
+	_, err := env.acquireNode("", "", constraints, nil, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 	requestValues := suite.testMAASObject.TestServer.NodeOperationRequestValues()
@@ -412,7 +414,7 @@ func (suite *environSuite) TestAcquireNodePassedAgentName(c *gc.C) {
 	env := suite.makeEnviron()
 	suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
 
-	_, err := env.acquireNode("", "", constraints.Value{}, nil, nil)
+	_, err := env.acquireNode("", "", constraints.Value{}, nil, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 	requestValues := suite.testMAASObject.TestServer.NodeOperationRequestValues()
@@ -428,7 +430,7 @@ func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeTags(c *gc.C)
 	_, err := env.acquireNode(
 		"", "",
 		constraints.Value{Tags: &[]string{"tag1", "^tag2", "tag3", "^tag4"}},
-		nil, nil,
+		nil, nil, nil,
 	)
 
 	c.Check(err, jc.ErrorIsNil)
@@ -437,6 +439,48 @@ func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeTags(c *gc.C)
 	c.Assert(found, jc.IsTrue)
 	c.Assert(nodeValues[0].Get("tags"), gc.Equals, "tag1,tag3")
 	c.Assert(nodeValues[0].Get("not_tags"), gc.Equals, "tag2,tag4")
+}
+
+func (suite *environSuite) TestAcquireNodeStorage(c *gc.C) {
+	for i, test := range []struct {
+		volumes []volumeInfo
+		expcted string
+	}{
+		{
+			nil,
+			"",
+		},
+		{
+			[]volumeInfo{{"volume-1", 1234, nil}},
+			"volume-1:1234",
+		},
+		{
+			[]volumeInfo{{"", 1234, []string{"tag1", "tag2"}}},
+			"1234(tag1,tag2)",
+		},
+		{
+			[]volumeInfo{{"volume-1", 1234, []string{"tag1", "tag2"}}},
+			"volume-1:1234(tag1,tag2)",
+		},
+		{
+			[]volumeInfo{
+				{"volume-1", 1234, []string{"tag1", "tag2"}},
+				{"volume-2", 4567, []string{"tag1", "tag3"}},
+			},
+			"volume-1:1234(tag1,tag2),volume-2:4567(tag1,tag3)",
+		},
+	} {
+		c.Logf("test %d", i)
+		env := suite.makeEnviron()
+		suite.testMAASObject.TestServer.NewNode(`{"system_id": "node0", "hostname": "host0"}`)
+		_, err := env.acquireNode("", "", constraints.Value{}, nil, nil, test.volumes)
+		c.Check(err, jc.ErrorIsNil)
+		requestValues := suite.testMAASObject.TestServer.NodeOperationRequestValues()
+		nodeRequestValues, found := requestValues["node0"]
+		c.Check(found, jc.IsTrue)
+		c.Check(nodeRequestValues[0].Get("storage"), gc.Equals, test.expcted)
+		suite.testMAASObject.TestServer.Clear()
+	}
 }
 
 var testValues = []struct {
@@ -635,7 +679,7 @@ func (suite *environSuite) TestDestroy(c *gc.C) {
 	c.Check(operations, gc.DeepEquals, []string{"release"})
 	c.Check(suite.testMAASObject.TestServer.OwnedNodes()["test1"], jc.IsFalse)
 	// Files have been cleaned up.
-	listing, err := storage.List(stor, "")
+	listing, err := envstorage.List(stor, "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(listing, gc.DeepEquals, []string{})
 }
@@ -1356,6 +1400,55 @@ func (s *environSuite) TestStartInstanceConstraints(c *gc.C) {
 	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*result.Hardware.Mem, gc.Equals, uint64(8192))
+}
+
+var nodeStorageAttrs = []map[string]interface{}{
+	{
+		"name":       "sdb",
+		"id":         1,
+		"id_path":    "/dev/disk/by-id/id_for_sda",
+		"path":       "/dev/sdb",
+		"model":      "Samsung_SSD_850_EVO_250GB",
+		"block_size": 4096,
+		"serial":     "S21NNSAFC38075L",
+		"size":       250059350016,
+	},
+	{
+		"name":       "sda",
+		"id":         2,
+		"path":       "/dev/sda",
+		"model":      "Samsung_SSD_850_EVO_250GB",
+		"block_size": 4096,
+		"serial":     "XXXX",
+		"size":       250059350016,
+	},
+}
+
+var storageConstraintAttrs = map[string]interface{}{
+	"1": "volume-1",
+	"2": "root",
+}
+
+func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
+	env := s.bootstrap(c)
+	s.newNode(c, "thenode1", "host1", map[string]interface{}{
+		"memory":                  8192,
+		"physicalblockdevice_set": nodeStorageAttrs,
+		"constraint_map":          storageConstraintAttrs,
+	})
+	params := environs.StartInstanceParams{Volumes: []storage.VolumeParams{
+		{Tag: names.NewVolumeTag("1"), Size: 2000000},
+	}}
+	result, err := testing.StartInstanceWithParams(env, "1", params, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Volumes, jc.DeepEquals, []storage.Volume{
+		{
+			Tag:        names.NewVolumeTag("1"),
+			Size:       238475,
+			VolumeId:   "/dev/disk/by-id/id_for_sda",
+			HardwareId: "S21NNSAFC38075L",
+		},
+	})
 }
 
 func (s *environSuite) TestGetAvailabilityZones(c *gc.C) {

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 var (
-	ShortAttempt = &shortAttempt
-	APIVersion   = apiVersion
+	ShortAttempt            = &shortAttempt
+	APIVersion              = apiVersion
+	MaasStorageProviderType = maasStorageProviderType
 )
 
 func MAASAgentName(env environs.Environ) string {

--- a/provider/maas/init.go
+++ b/provider/maas/init.go
@@ -16,7 +16,7 @@ func init() {
 	environs.RegisterProvider(providerType, maasEnvironProvider{})
 
 	//Register the MAAS specific storage providers.
-	registry.RegisterProvider(MAAS_ProviderType, &maasStorageProvider{})
+	registry.RegisterProvider(maasStorageProviderType, &maasStorageProvider{})
 
-	registry.RegisterEnvironStorageProviders(providerType, MAAS_ProviderType)
+	registry.RegisterEnvironStorageProviders(providerType, maasStorageProviderType)
 }

--- a/provider/maas/init.go
+++ b/provider/maas/init.go
@@ -15,5 +15,8 @@ const (
 func init() {
 	environs.RegisterProvider(providerType, maasEnvironProvider{})
 
-	registry.RegisterEnvironStorageProviders(providerType)
+	//Register the MAAS specific storage providers.
+	registry.RegisterProvider(MAAS_ProviderType, &maasStorageProvider{})
+
+	registry.RegisterEnvironStorageProviders(providerType, MAAS_ProviderType)
 }

--- a/provider/maas/init_test.go
+++ b/provider/maas/init_test.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/maas"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider/registry"
+	"github.com/juju/juju/testing"
+)
+
+type providerSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&providerSuite{})
+
+func (*providerSuite) TestMAASProviderRegistered(c *gc.C) {
+	p, err := registry.StorageProvider(maas.MAAS_ProviderType)
+	c.Assert(err, jc.ErrorIsNil)
+	_, ok := p.(storage.Provider)
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (*providerSuite) TestSupportedProviders(c *gc.C) {
+	supported := []storage.ProviderType{maas.MAAS_ProviderType}
+	for _, providerType := range supported {
+		ok := registry.IsProviderSupported("maas", providerType)
+		c.Assert(ok, jc.IsTrue)
+	}
+}

--- a/provider/maas/init_test.go
+++ b/provider/maas/init_test.go
@@ -20,14 +20,14 @@ type providerSuite struct {
 var _ = gc.Suite(&providerSuite{})
 
 func (*providerSuite) TestMAASProviderRegistered(c *gc.C) {
-	p, err := registry.StorageProvider(maas.MAAS_ProviderType)
+	p, err := registry.StorageProvider(maas.MaasStorageProviderType)
 	c.Assert(err, jc.ErrorIsNil)
 	_, ok := p.(storage.Provider)
 	c.Assert(ok, jc.IsTrue)
 }
 
 func (*providerSuite) TestSupportedProviders(c *gc.C) {
-	supported := []storage.ProviderType{maas.MAAS_ProviderType}
+	supported := []storage.ProviderType{maas.MaasStorageProviderType}
 	for _, providerType := range supported {
 		ok := registry.IsProviderSupported("maas", providerType)
 		c.Assert(ok, jc.IsTrue)

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -1,0 +1,167 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	// RootDiskTag is the tag recognised by MAAS as being for
+	// the root disk.
+	RootDiskTag = "root"
+
+	// TagsAttribute is the name of the pool attribute used
+	// to specify tag values for requested volumes.
+	TagsAttribute = "tags"
+)
+
+type volumeInfo struct {
+	name      string
+	sizeInGiB uint64
+	tags      []string
+}
+
+// buildMAASVolumeParameters creates the MAAS volume information to include
+// in a request to acquire a MAAS node, based on the supplied storage parameters.
+func buildMAASVolumeParameters(args []storage.VolumeParams) ([]volumeInfo, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+	volumes := make([]volumeInfo, len(args))
+	// TODO(wallyworld) - allow root volume to be specified in volume args.
+	var rootVolume *volumeInfo
+	for i, v := range args {
+		info := volumeInfo{
+			name: v.Tag.String(),
+			// MAAS expects GB, Juju works in GiB.
+			sizeInGiB: common.MiBToGiB(uint64(v.Size)) * (humanize.GiByte / humanize.GByte),
+		}
+		var tags string
+		if len(v.Attributes) > 0 {
+			tags = v.Attributes[TagsAttribute].(string)
+		}
+		if len(tags) > 0 {
+			// We don't want any spaces in the tags;
+			// strip out any just in case.
+			tags = strings.Replace(tags, " ", "", 0)
+			info.tags = strings.Split(tags, ",")
+		}
+		volumes[i] = info
+	}
+	if rootVolume == nil {
+		rootVolume = &volumeInfo{sizeInGiB: 0}
+	}
+	// For now, the root disk size can't be specified.
+	if rootVolume.sizeInGiB > 0 {
+		return nil, errors.New("root volume size cannot be specified")
+	}
+	// Root disk always goes first.
+	volumesResult := []volumeInfo{*rootVolume}
+	volumesResult = append(volumesResult, volumes...)
+	return volumesResult, nil
+}
+
+// volumes creates the storage volumes corresponding to the
+// volume info associated with a MAAS node.
+func (mi *maasInstance) volumes() ([]storage.Volume, error) {
+	var result []storage.Volume
+
+	deviceInfo, ok := mi.getMaasObject().GetMap()["physicalblockdevice_set"]
+	// Older MAAS servers don't support storage.
+	if !ok || deviceInfo.IsNil() {
+		return result, nil
+	}
+
+	tagsMap, ok := mi.getMaasObject().GetMap()["constraint_map"]
+	if !ok || tagsMap.IsNil() {
+		return nil, errors.NotFoundf("constraint map field")
+	}
+
+	devices, err := deviceInfo.GetArray()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, d := range devices {
+		deviceAttrs, err := d.GetMap()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		// id in devices list is numeric
+		id, err := deviceAttrs["id"].GetFloat64()
+		if err != nil {
+			return nil, errors.Annotate(err, "invalid device id")
+		}
+		// id in constraint_map field is a string
+		idKey := strconv.Itoa(int(id))
+		// deviceTag is the volume tag passed
+		// into the acquire node call as part
+		// of the storage constraints parameter.
+		deviceTags, err := tagsMap.GetMap()
+		if err != nil {
+			return nil, errors.Annotate(err, "invalid constraint map value")
+		}
+
+		// Device Tag.
+		deviceTagValue, ok := deviceTags[idKey]
+		if !ok {
+			return nil, errors.Errorf("missing volume tag for id %q", idKey)
+		}
+		deviceTag, err := deviceTagValue.GetString()
+		if err != nil {
+			return nil, errors.Annotate(err, "invalid device tag")
+		}
+		// We don't explicitly allow the root volume to be specified yet.
+		if deviceTag == RootDiskTag {
+			continue
+		}
+
+		// Volume Tag.
+		volumeTag, err := names.ParseVolumeTag(deviceTag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		// HardwareId.
+		hardwareId, err := deviceAttrs["serial"].GetString()
+		if err != nil {
+			return nil, errors.Annotate(err, "invalid device serial")
+		}
+
+		// VolumeId.
+		// First try for id_path.
+		deviceId, err := deviceAttrs["id_path"].GetString()
+		if err != nil {
+			// On VMAAS, id_path not available so try for path instead.
+			deviceId, err = deviceAttrs["path"].GetString()
+			if err != nil {
+				return nil, errors.Annotate(err, "invalid device path")
+			}
+		}
+
+		// Size.
+		sizeinGB, err := deviceAttrs["size"].GetFloat64()
+		if err != nil {
+			return nil, errors.Annotate(err, "invalid device size")
+		}
+
+		vol := storage.Volume{
+			Tag:        volumeTag,
+			VolumeId:   deviceId,
+			HardwareId: hardwareId,
+			Size:       uint64(sizeinGB / humanize.MiByte),
+			Persistent: false,
+		}
+		result = append(result, vol)
+	}
+	return result, nil
+}

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -1,0 +1,134 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/storage"
+)
+
+type volumeSuite struct {
+	providerSuite
+}
+
+var _ = gc.Suite(&volumeSuite{})
+
+func (s *volumeSuite) TestBuildMAASVolumeParametersNoVolumes(c *gc.C) {
+	vInfo, err := buildMAASVolumeParameters(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vInfo, gc.HasLen, 0)
+}
+
+func (s *volumeSuite) TestBuildMAASVolumeParametersNoTags(c *gc.C) {
+	vInfo, err := buildMAASVolumeParameters([]storage.VolumeParams{
+		{Tag: names.NewVolumeTag("1"), Size: 2000000},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
+		{sizeInGiB: 0}, //root disk
+		{"volume-1", 1954, nil},
+	})
+}
+
+func (s *volumeSuite) TestBuildMAASVolumeParametersWithTags(c *gc.C) {
+	vInfo, err := buildMAASVolumeParameters([]storage.VolumeParams{
+		{Tag: names.NewVolumeTag("1"), Size: 2000000, Attributes: map[string]interface{}{"tags": "tag1,tag2"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
+		{sizeInGiB: 0}, //root disk
+		{"volume-1", 1954, []string{"tag1", "tag2"}},
+	})
+}
+
+func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
+	obj := s.testMAASObject.TestServer.NewNode(validVolumeJson)
+	instance := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	volumes, err := instance.volumes()
+	c.Assert(err, jc.ErrorIsNil)
+	// Expect 2 volumes - root volume is ignored.
+	c.Assert(volumes, gc.HasLen, 2)
+	c.Assert(volumes, jc.DeepEquals, []storage.Volume{
+		{
+			// This volume has no id_path, so we default to path.
+			Tag:        names.NewVolumeTag("1"),
+			HardwareId: "S21NNSAFC38076L",
+			VolumeId:   "/dev/sdb",
+			Size:       476893,
+			Persistent: false,
+		},
+		{
+			Tag:        names.NewVolumeTag("2"),
+			HardwareId: "S21NNSAFC38999L",
+			VolumeId:   "/dev/disk/by-id/id_for_sdc",
+			Size:       238764,
+			Persistent: false,
+		},
+	})
+}
+
+func (s *volumeSuite) TestInstanceVolumesOldMass(c *gc.C) {
+	obj := s.testMAASObject.TestServer.NewNode(`{"system_id": "node0"}`)
+	instance := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	volumes, err := instance.volumes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumes, gc.HasLen, 0)
+}
+
+var validVolumeJson = `
+{
+    "system_id": "node0",
+    "physicalblockdevice_set": [
+        {
+            "name": "sda", 
+            "tags": [
+                "ssd", 
+                "sata"
+            ],
+            "id": 1, 
+            "id_path": "/dev/disk/by-id/id_for_sda", 
+            "path": "/dev/sda", 
+            "model": "Samsung_SSD_850_EVO_250GB", 
+            "block_size": 4096, 
+            "serial": "S21NNSAFC38075L", 
+            "size": 250059350016
+        }, 
+        {
+            "name": "sdb", 
+            "tags": [
+                "ssd", 
+                "sata"
+            ], 
+            "id": 2, 
+            "path": "/dev/sdb", 
+            "model": "Samsung_SSD_850_EVO_500GB", 
+            "block_size": 4096, 
+            "serial": "S21NNSAFC38076L", 
+            "size": 500059350016
+        },
+        {
+            "name": "sdb", 
+            "tags": [
+                "ssd", 
+                "sata"
+            ], 
+            "id": 3, 
+            "id_path": "/dev/disk/by-id/id_for_sdc",
+            "path": "/dev/sdc", 
+            "model": "Samsung_SSD_850_EVO_250GB", 
+            "block_size": 4096, 
+            "serial": "S21NNSAFC38999L", 
+            "size": 250362438230
+        }
+    ], 
+    "constraint_map": {
+        "1": "root",
+        "2": "volume-1",
+        "3": "volume-2"
+    }
+} 
+`[1:]

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
 )
 
 type volumeSuite struct {
@@ -132,3 +133,30 @@ var validVolumeJson = `
     }
 } 
 `[1:]
+
+type storageProviderSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&storageProviderSuite{})
+
+func (*storageProviderSuite) TestValidateConfigInvalidConfig(c *gc.C) {
+	p := maasStorageProvider{}
+	cfg, err := storage.NewConfig("foo", MAAS_ProviderType, map[string]interface{}{
+		"invalid": "config",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.ValidateConfig(cfg)
+	c.Assert(err, gc.ErrorMatches, `unknown provider config option "invalid"`)
+}
+
+func (s *storageProviderSuite) TestSupports(c *gc.C) {
+	p := maasStorageProvider{}
+	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsTrue)
+	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsFalse)
+}
+
+func (s *storageProviderSuite) TestScope(c *gc.C) {
+	p := maasStorageProvider{}
+	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
+}

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -30,7 +30,7 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersNoTags(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
-		{sizeInGiB: 0}, //root disk
+		{sizeInGB: 0}, //root disk
 		{"volume-1", 1954, nil},
 	})
 }
@@ -41,7 +41,7 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersWithTags(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
-		{sizeInGiB: 0}, //root disk
+		{sizeInGB: 0}, //root disk
 		{"volume-1", 1954, []string{"tag1", "tag2"}},
 	})
 }
@@ -57,15 +57,15 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 		{
 			// This volume has no id_path, so we default to path.
 			Tag:        names.NewVolumeTag("1"),
-			HardwareId: "S21NNSAFC38076L",
-			VolumeId:   "/dev/sdb",
+			HardwareId: "sdb",
+			VolumeId:   "volume-1",
 			Size:       476893,
 			Persistent: false,
 		},
 		{
 			Tag:        names.NewVolumeTag("2"),
-			HardwareId: "S21NNSAFC38999L",
-			VolumeId:   "/dev/disk/by-id/id_for_sdc",
+			HardwareId: "id_for_sdc",
+			VolumeId:   "volume-2",
 			Size:       238764,
 			Persistent: false,
 		},
@@ -142,7 +142,7 @@ var _ = gc.Suite(&storageProviderSuite{})
 
 func (*storageProviderSuite) TestValidateConfigInvalidConfig(c *gc.C) {
 	p := maasStorageProvider{}
-	cfg, err := storage.NewConfig("foo", MAAS_ProviderType, map[string]interface{}{
+	cfg, err := storage.NewConfig("foo", maasStorageProviderType, map[string]interface{}{
 		"invalid": "config",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -158,5 +158,5 @@ func (s *storageProviderSuite) TestSupports(c *gc.C) {
 
 func (s *storageProviderSuite) TestScope(c *gc.C) {
 	p := maasStorageProvider{}
-	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
+	c.Assert(p.Scope(), gc.Equals, storage.ScopeEnviron)
 }

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -50,7 +50,10 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(validVolumeJson)
 	instance := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
 	mTag := names.NewMachineTag("1")
-	volumes, attachments, err := instance.volumes(mTag)
+	volumes, attachments, err := instance.volumes(mTag, []names.VolumeTag{
+		names.NewVolumeTag("1"),
+		names.NewVolumeTag("2"),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	// Expect 2 volumes - root volume is ignored.
 	c.Assert(volumes, gc.HasLen, 2)
@@ -92,7 +95,10 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 func (s *volumeSuite) TestInstanceVolumesOldMass(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(`{"system_id": "node0"}`)
 	instance := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
-	volumes, attachments, err := instance.volumes(names.NewMachineTag("1"))
+	volumes, attachments, err := instance.volumes(names.NewMachineTag("1"), []names.VolumeTag{
+		names.NewVolumeTag("1"),
+		names.NewVolumeTag("2"),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumes, gc.HasLen, 0)
 	c.Assert(attachments, gc.HasLen, 0)
@@ -142,12 +148,27 @@ var validVolumeJson = `
             "block_size": 4096, 
             "serial": "S21NNSAFC38999L", 
             "size": 250362438230
+        },
+        {
+            "name": "sdd", 
+            "tags": [
+                "ssd", 
+                "sata"
+            ], 
+            "id": 4, 
+            "id_path": "/dev/disk/by-id/id_for_sdd",
+            "path": "/dev/sdc", 
+            "model": "Samsung_SSD_850_EVO_250GB", 
+            "block_size": 4096, 
+            "serial": "S21NNSAFC386666L", 
+            "size": 250362438230
         }
     ], 
     "constraint_map": {
         "1": "root",
         "2": "volume-1",
-        "3": "volume-2"
+        "3": "volume-2",
+        "4": "volume-3"
     }
 } 
 `[1:]


### PR DESCRIPTION
Extend the MAAS provider to acquire nodes with any requested storage.

(Review request: http://reviews.vapour.ws/r/1587/)