### PR TITLE
Allow server only writes to cachefile

### DIFF
--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -318,7 +318,7 @@ func (info *environInfo) Write() error {
 	// If the source was the cache file, then always write there to
 	// avoid stale data in the cache file.
 	if info.source == sourceCache ||
-		(featureflag.Enabled(feature.EnvironmentsCacheFile) && info.serverUUID != "") {
+		(featureflag.Enabled(feature.JES) && info.serverUUID != "") {
 		if err := info.ensureNoJENV(); info.source == sourceCreated && err != nil {
 			return errors.Trace(err)
 		}

--- a/environs/configstore/interface_test.go
+++ b/environs/configstore/interface_test.go
@@ -63,7 +63,7 @@ func (s *interfaceSuite) TestList(c *gc.C) {
 	s.createInitialisedEnvironment(c, store, "enva", "")
 	s.createInitialisedEnvironment(c, store, "envb", "")
 
-	s.SetFeatureFlags(feature.EnvironmentsCacheFile)
+	s.SetFeatureFlags(feature.JES)
 	s.createInitialisedEnvironment(c, store, "envc", "envc")
 
 	environs, err := store.List()
@@ -76,7 +76,7 @@ func (s *interfaceSuite) TestListSystems(c *gc.C) {
 	s.createInitialisedEnvironment(c, store, "enva", "")
 	s.createInitialisedEnvironment(c, store, "envb", "")
 
-	s.SetFeatureFlags(feature.EnvironmentsCacheFile)
+	s.SetFeatureFlags(feature.JES)
 	s.createInitialisedEnvironment(c, store, "envc", "envc")
 	s.createInitialisedEnvironment(c, store, "envd", "envc")
 

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -12,6 +12,11 @@ package feature
 
 // JES stands for Juju Environment Server and controls access
 // to the apiserver endpoints, api client and CLI commands.
+// It also guards the writing of the new
+// $JUJU_HOME/environments/cache.yaml file.  If this flag is
+// set, new environments will be written to the cache file
+// rather than a JENV file. As JENV files are updated, they
+// are migrated to the cache file and the JENV file removed.
 const JES = "jes"
 
 // LogErrorStack is a developer feature flag to have the LoggedErrorStack
@@ -21,13 +26,6 @@ const JES = "jes"
 // failure.  This means that the developers with this flag set will see the
 // stack trace in the log output, but normal deployments never will.
 const LogErrorStack = "log-error-stack"
-
-// EnvironmentsCacheFile is the feature flag that guards the writing of the
-// new $JUJU_HOME/environments/cache.yaml file.  If this flag is set, new
-// environments will be written to the cache file rather than a JENV file.
-// As JENV files are updated, they are migrated to the cache file and the
-// JENV file removed.
-const EnvironmentsCacheFile = "env-cache"
 
 // LegacyUpstart is used to indicate that the version-based init system
 // discovery code (service.VersionInitSystem) should return upstart


### PR DESCRIPTION
This patch updates logic in the cachefile
config store to allow server-only writes.
This can happen when a user uses the login
command for a server where they will not
be placed in an environment.

This patch also consolidates the JES and
EnvironmentsCacheFile feature flag as the
work done under the JES flag will depend
on the cache file.

(Review request: http://reviews.vapour.ws/r/1591/)