### PR TITLE
Dynamically discover init system in the cloudinit script.

### DIFF
--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -641,8 +641,8 @@ func (s *LxcSuite) TestCreateContainer(c *gc.C) {
 		scripts = append(scripts, s.(string))
 	}
 
-	c.Assert(scripts[len(scripts)-3:], gc.DeepEquals, []string{
-		"start jujud-machine-1-lxc-0",
+	c.Assert(scripts[len(scripts)-3], jc.HasPrefix, `if [[ $init_system == "`)
+	c.Assert(scripts[len(scripts)-2:], gc.DeepEquals, []string{
 		"rm $bin/tools.tar.gz && rm $bin/juju2.3.4-quantal-amd64.sha256",
 		"ifconfig",
 	})

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
-	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/state/multiwatcher"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -285,32 +284,6 @@ func (cfg *MachineConfig) machineAgentCommands() ([]string, string, error) {
 		return nil, "", errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
 	}
 	return cmds, toolsDir, nil
-}
-
-func (cfg *MachineConfig) initService() (service.Service, string, error) {
-	conf, toolsDir := service.MachineAgentConf(
-		cfg.MachineId,
-		cfg.DataDir,
-		cfg.LogDir,
-		strings.ToLower(cfg.Tools.Version.OS.String()),
-	)
-
-	name := cfg.MachineAgentServiceName
-	initSystem, ok := cfg.initSystem()
-	if !ok {
-		return nil, "", errors.New("could not identify init system")
-	}
-	logger.Debugf("using init system %q for machine agent script", initSystem)
-	svc, err := newService(name, conf, initSystem)
-	return svc, toolsDir, errors.Trace(err)
-}
-
-func (cfg *MachineConfig) initSystem() (string, bool) {
-	return service.VersionInitSystem(cfg.Tools.Version)
-}
-
-var newService = func(name string, conf common.Conf, initSystem string) (service.Service, error) {
-	return service.NewService(name, conf, initSystem)
 }
 
 func (cfg *MachineConfig) dataFile(name string) string {

--- a/environs/cloudinit/cloudinit.go
+++ b/environs/cloudinit/cloudinit.go
@@ -270,6 +270,23 @@ func AddAptCommands(
 	}
 }
 
+func (cfg *MachineConfig) machineAgentCommands() ([]string, string, error) {
+	osName := strings.ToLower(cfg.Tools.Version.OS.String())
+	conf, toolsDir := service.MachineAgentConf(
+		cfg.MachineId,
+		cfg.DataDir,
+		cfg.LogDir,
+		osName,
+	)
+
+	name := cfg.MachineAgentServiceName
+	cmds, err := service.InstallServiceCommands(name, conf, osName)
+	if err != nil {
+		return nil, "", errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
+	}
+	return cmds, toolsDir, nil
+}
+
 func (cfg *MachineConfig) initService() (service.Service, string, error) {
 	conf, toolsDir := service.MachineAgentConf(
 		cfg.MachineId,

--- a/environs/cloudinit/cloudinit_configure.go
+++ b/environs/cloudinit/cloudinit_configure.go
@@ -100,7 +100,7 @@ func (c *baseConfigure) Render() ([]byte, error) {
 }
 
 func (c *baseConfigure) addMachineAgentToBoot(name string) error {
-	svc, toolsDir, err := c.mcfg.initService()
+	cmds, toolsDir, err := c.mcfg.machineAgentCommands()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -109,16 +109,6 @@ func (c *baseConfigure) addMachineAgentToBoot(name string) error {
 	// directory, so it can upgrade itself without needing to change
 	// the init script.
 	c.conf.AddScripts(c.toolsSymlinkCommand(toolsDir))
-
-	cmds, err := svc.InstallCommands()
-	if err != nil {
-		return errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
-	}
-	startCmds, err := svc.StartCommands()
-	if err != nil {
-		return errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
-	}
-	cmds = append(cmds, startCmds...)
 
 	svcName := c.mcfg.MachineAgentServiceName
 	c.conf.AddRunCmd(cloudinit.LogProgressCmd("Starting Juju machine agent (%s)", svcName))

--- a/environs/cloudinit/cloudinit_test.go
+++ b/environs/cloudinit/cloudinit_test.go
@@ -232,8 +232,8 @@ echo 'Bootstrapping Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
-cat >> /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
-start jujud-machine-0
+init_system=\$\(.*\)
+if \[\[ \$init_system == ".*
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
 `,
 	}, {
@@ -336,8 +336,8 @@ install -m 600 /dev/null '/var/lib/juju/agents/machine-99/agent\.conf'
 printf '%s\\n' '.*' > '/var/lib/juju/agents/machine-99/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-99'
 echo 'Starting Juju machine agent \(jujud-machine-99\)'.*
-cat >> /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
-start jujud-machine-99
+init_system=\$\(.*\)
+if \[\[ \$init_system == ".*
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 `,
 	}, {
@@ -379,8 +379,8 @@ mkdir -p '/var/lib/juju/agents/machine-2-lxc-1'
 install -m 600 /dev/null '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf'
 printf '%s\\n' '.*' > '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-2-lxc-1'
-cat >> /etc/init/jujud-machine-2-lxc-1\.conf << 'EOF'\\ndescription "juju agent for machine-2-lxc-1"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-2-lxc-1\.log\\n  chown syslog:syslog /var/log/juju/machine-2-lxc-1\.log\\n  chmod 0600 /var/log/juju/machine-2-lxc-1\.log\\n\\n  exec '/var/lib/juju/tools/machine-2-lxc-1/jujud' machine --data-dir '/var/lib/juju' --machine-id 2/lxc/1 --debug >> /var/log/juju/machine-2-lxc-1\.log 2>&1\\nend script\\nEOF\\n
-start jujud-machine-2-lxc-1
+init_system=\$\(.*\)
+if \[\[ \$init_system == ".*
 `,
 	}, {
 		// hostname verification disabled.

--- a/service/service.go
+++ b/service/service.go
@@ -175,6 +175,63 @@ func listServicesCommand(initSystem string) (string, bool) {
 	}
 }
 
+// InstallServicesCommand composes the list of shell commands that install
+// and start the given service.
+func InstallServiceCommands(name string, conf common.Conf, os string) ([]string, error) {
+	start := true
+
+	if os == "windows" {
+		cmds, err := installCommands(name, conf, InitSystemWindows, start)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return cmds, nil
+	}
+
+	candidates := make(map[string]string)
+	for _, initSystem := range linuxInitSystems {
+		cmds, err := installCommands(name, conf, initSystem, start)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		candidates[initSystem] = "\n  " + strings.Join(cmds, "\n  ")
+	}
+
+	handler := func(initSystem string) (string, bool) {
+		if cmds, ok := candidates[initSystem]; ok {
+			return cmds, true
+		}
+		return "", false
+	}
+	script := newShellSelectCommand("init_system", handler)
+	cmds := []string{
+		"init_system=$(" + DiscoverInitSystemScript + ")",
+		script,
+	}
+	return cmds, nil
+}
+
+func installCommands(name string, conf common.Conf, initSystem string, start bool) ([]string, error) {
+	svc, err := NewService(name, conf, initSystem)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cmds, err := svc.InstallCommands()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !start {
+		return cmds, nil
+	}
+
+	startCmds, err := svc.StartCommands()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return append(cmds, startCmds...), nil
+}
+
 // installStartRetryAttempts defines how much InstallAndStart retries
 // upon Start failures.
 var installStartRetryAttempts = utils.AttemptStrategy{

--- a/service/service.go
+++ b/service/service.go
@@ -176,12 +176,10 @@ func listServicesCommand(initSystem string) (string, bool) {
 }
 
 // InstallServicesCommand composes the list of shell commands that install
-// and start the given service.
+// and start the given service on the given operating system.
 func InstallServiceCommands(name string, conf common.Conf, os string) ([]string, error) {
-	start := true
-
 	if os == "windows" {
-		cmds, err := installCommands(name, conf, InitSystemWindows, start)
+		cmds, err := installCommands(name, conf, InitSystemWindows)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -190,7 +188,7 @@ func InstallServiceCommands(name string, conf common.Conf, os string) ([]string,
 
 	candidates := make(map[string]string)
 	for _, initSystem := range linuxInitSystems {
-		cmds, err := installCommands(name, conf, initSystem, start)
+		cmds, err := installCommands(name, conf, initSystem)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -211,7 +209,7 @@ func InstallServiceCommands(name string, conf common.Conf, os string) ([]string,
 	return cmds, nil
 }
 
-func installCommands(name string, conf common.Conf, initSystem string, start bool) ([]string, error) {
+func installCommands(name string, conf common.Conf, initSystem string) ([]string, error) {
 	svc, err := NewService(name, conf, initSystem)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -221,9 +219,7 @@ func installCommands(name string, conf common.Conf, initSystem string, start boo
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if !start {
-		return cmds, nil
-	}
+	// Return here if we want to only install (i.e. skip starting).
 
 	startCmds, err := svc.StartCommands()
 	if err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -84,6 +84,76 @@ func (*serviceSuite) TestListServicesScript(c *gc.C) {
 	c.Check(strings.Split(script, "\n"), jc.DeepEquals, expected)
 }
 
+func (s *serviceSuite) TestInstallServiceCommandsLinux(c *gc.C) {
+	cmds, err := service.InstallServiceCommands(s.Name, s.Conf, "ubuntu")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(cmds, gc.HasLen, 2)
+	c.Check(cmds[0], jc.HasPrefix, "init_system=$(")
+	c.Check(cmds[1], jc.Contains, `if [[ $init_system == "systemd" ]]; then`)
+	c.Check(cmds[1], jc.Contains, "systemctl start")
+	c.Check(cmds[1], jc.Contains, `if [[ $init_system == "upstart" ]]; then`)
+	c.Check(cmds[1], jc.Contains, "start juju-agent-machine-0")
+	c.Check(cmds[1], gc.Not(jc.Contains), "windows")
+	// TODO(ericsnow) This is too specific...
+	c.Check(cmds[1], jc.DeepEquals, `
+if [[ $init_system == "systemd" ]]; then 
+  mkdir -p /var/lib/juju/init/juju-agent-machine-0
+  cat > /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service << 'EOF'
+[Unit]
+Description=some service
+After=syslog.target
+After=network.target
+After=systemd-user-sessions.service
+
+[Service]
+ExecStart=/bin/jujud machine 0
+RemainAfterExit=yes
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+
+
+EOF
+  /bin/systemctl link /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service
+  /bin/systemctl daemon-reload
+  /bin/systemctl enable /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service
+  /bin/systemctl start juju-agent-machine-0.service
+elif [[ $init_system == "upstart" ]]; then 
+  cat >> /etc/init/juju-agent-machine-0.conf << 'EOF'
+description "some service"
+author "Juju Team <juju@lists.ubuntu.com>"
+start on runlevel [2345]
+stop on runlevel [!2345]
+respawn
+normal exit 0
+
+
+script
+
+
+  exec /bin/jujud machine 0
+end script
+EOF
+
+  start juju-agent-machine-0
+else exit 1
+fi`[1:])
+}
+
+func (s *serviceSuite) TestInstallServiceCommandsWindows(c *gc.C) {
+	cmds, err := service.InstallServiceCommands(s.Name, s.Conf, "windows")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(cmds, gc.HasLen, 3)
+	for i := 0; i < 3; i++ {
+		c.Check(cmds[i], jc.Contains, "juju-agent-machine-0")
+	}
+	c.Check(cmds[0], jc.HasPrefix, "New-Service")
+	c.Check(cmds[2], jc.HasPrefix, "Start-Service")
+}
+
 func (s *serviceSuite) TestInstallAndStartOkay(c *gc.C) {
 	s.PatchAttempts(5)
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -95,51 +95,6 @@ func (s *serviceSuite) TestInstallServiceCommandsLinux(c *gc.C) {
 	c.Check(cmds[1], jc.Contains, `if [[ $init_system == "upstart" ]]; then`)
 	c.Check(cmds[1], jc.Contains, "start juju-agent-machine-0")
 	c.Check(cmds[1], gc.Not(jc.Contains), "windows")
-	// TODO(ericsnow) This is too specific...
-	c.Check(cmds[1], jc.DeepEquals, `
-if [[ $init_system == "systemd" ]]; then 
-  mkdir -p /var/lib/juju/init/juju-agent-machine-0
-  cat > /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service << 'EOF'
-[Unit]
-Description=some service
-After=syslog.target
-After=network.target
-After=systemd-user-sessions.service
-
-[Service]
-ExecStart=/bin/jujud machine 0
-RemainAfterExit=yes
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-
-
-EOF
-  /bin/systemctl link /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service
-  /bin/systemctl daemon-reload
-  /bin/systemctl enable /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service
-  /bin/systemctl start juju-agent-machine-0.service
-elif [[ $init_system == "upstart" ]]; then 
-  cat >> /etc/init/juju-agent-machine-0.conf << 'EOF'
-description "some service"
-author "Juju Team <juju@lists.ubuntu.com>"
-start on runlevel [2345]
-stop on runlevel [!2345]
-respawn
-normal exit 0
-
-
-script
-
-
-  exec /bin/jujud machine 0
-end script
-EOF
-
-  start juju-agent-machine-0
-else exit 1
-fi`[1:])
 }
 
 func (s *serviceSuite) TestInstallServiceCommandsWindows(c *gc.C) {


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1450092)

Keying off the juju version doesn't work well for local provider.  This patch resolves the issue by adding discovery to the cloudinit script.

(Review request: http://reviews.vapour.ws/r/1595/)