### PR TITLE
uniter: watch unprovisioned storage attachments

### DIFF
--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -96,7 +96,6 @@ func (sa *StorageAccessor) WatchUnitStorageAttachments(unitTag names.UnitTag) (w
 // unit and storage tags.
 func (sa *StorageAccessor) StorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) (params.StorageAttachment, error) {
 	if sa.facade.BestAPIVersion() < 2 {
-		// StorageAttachment() was introduced in UniterAPIV2.
 		return params.StorageAttachment{}, errors.NotImplementedf("StorageAttachment() (need V2+)")
 	}
 	args := params.StorageAttachmentIds{
@@ -118,6 +117,24 @@ func (sa *StorageAccessor) StorageAttachment(storageTag names.StorageTag, unitTa
 		return params.StorageAttachment{}, result.Error
 	}
 	return result.Result, nil
+}
+
+// StorageAttachmentLife returns the lifecycle state of the storage attachments
+// with the specified IDs.
+func (sa *StorageAccessor) StorageAttachmentLife(ids []params.StorageAttachmentId) ([]params.LifeResult, error) {
+	if sa.facade.BestAPIVersion() < 2 {
+		return nil, errors.NotImplementedf("StorageAttachmentLife() (need V2+)")
+	}
+	args := params.StorageAttachmentIds{ids}
+	var results params.LifeResults
+	err := sa.facade.FacadeCall("StorageAttachmentLife", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(ids) {
+		panic(errors.Errorf("expected %d results, got %d", len(ids), len(results.Results)))
+	}
+	return results.Results, nil
 }
 
 // WatchStorageAttachments starts a watcher for changes to the info

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -2056,6 +2056,18 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 			verifyStorageDetached{},
 			waitUniterDead{},
 		), ut(
+			"test that delay-provisioned storage does not block forever",
+			createCharm{customize: appendStorageMetadata},
+			serveCharm{},
+			ensureStateWorker{},
+			createServiceAndUnit{},
+			startUniter{},
+			// no hooks should be run, as storage isn't provisioned
+			waitHooks{},
+			provisionStorage{},
+			waitHooks{"wp-content-storage-attached"},
+			waitHooks(startupHooks(false)),
+		), ut(
 			"test that unprovisioned storage does not block unit termination",
 			createCharm{customize: appendStorageMetadata},
 			serveCharm{},


### PR DESCRIPTION
My recent change to storage hook ordering broke
the watching of unprovisioned storage attachments.
This branches fixes it by changing how we react
to UpdateStorage being called. We no longer call
the "StorageAttachments" API to get full storage
attachments, which require them to be provisioned,
but instead call a new "StorageAttachmentLife"
to just get the lifecycle state, which is all we
require, and doesn't care about provisioned state.

Fixes https://bugs.launchpad.net/juju-core/+bug/1452207

(Review request: http://reviews.vapour.ws/r/1596/)