### PR TITLE
Tweak default storage provider selection

### DIFF
--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -406,7 +406,12 @@ func (st *State) filesystemParamsWithDefaults(params FilesystemParams) (Filesyst
 	if err != nil {
 		return FilesystemParams{}, errors.Trace(err)
 	}
-	poolName, err := defaultStoragePool(envConfig, storage.StorageKindFilesystem)
+	cons := StorageConstraints{
+		Pool:  params.Pool,
+		Size:  params.Size,
+		Count: 1,
+	}
+	poolName, err := defaultStoragePool(envConfig, storage.StorageKindFilesystem, cons)
 	if err != nil {
 		return FilesystemParams{}, errors.Annotate(err, "getting default filesystem storage pool")
 	}

--- a/state/storage.go
+++ b/state/storage.go
@@ -902,7 +902,8 @@ func defaultStoragePool(cfg *config.Config, kind storage.StorageKind, cons Stora
 	case storage.StorageKindBlock:
 		loopPool := string(provider.LoopProviderType)
 		// No constraints at all
-		if cons.Size == 0 && cons.Count == 0 {
+		emptyConstraints := StorageConstraints{}
+		if cons == emptyConstraints {
 			return loopPool, nil
 		}
 		// Either size or count specified, use env default.

--- a/state/storage.go
+++ b/state/storage.go
@@ -870,13 +870,23 @@ func storageConstraintsWithDefaults(
 	storageName string,
 ) (StorageConstraints, error) {
 	withDefaults := cons
-	if cons.Pool == "" {
+
+	// If no pool or size are specified, we default to the loop provider.
+	if cons.Pool == "" && cons.Size == 0 {
+		withDefaults.Pool = string(provider.LoopProviderType)
+	}
+
+	// If just size is specified, we use the default storage for the environment.
+	if withDefaults.Pool == "" {
 		poolName, err := defaultStoragePool(cfg, kind)
 		if err != nil {
 			return withDefaults, errors.Annotatef(err, "finding default pool for %q storage", storageName)
 		}
 		withDefaults.Pool = poolName
 	}
+
+	// If no size is specified, we default to the min size specified by the
+	// charm, or 1GiB.
 	if cons.Size == 0 {
 		if charmStorage.MinimumSize > 0 {
 			withDefaults.Size = charmStorage.MinimumSize

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -176,6 +176,16 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 	// TODO(wallyworld) - test pool name stored in data model
 }
 
+func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoPoolOrSize(c *gc.C) {
+	storageCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("", 0, 1),
+	}
+	expectedCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("loop", 1024, 1),
+	}
+	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+}
+
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultPool(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 2048, 1),

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -176,12 +176,22 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 	// TODO(wallyworld) - test pool name stored in data model
 }
 
-func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoPoolOrSize(c *gc.C) {
+func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoConstraintsUsed(c *gc.C) {
+	storageCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("", 0, 0),
+	}
+	expectedCons := map[string]state.StorageConstraints{
+		"data": makeStorageCons("loop", 1024, 1),
+	}
+	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
+}
+
+func (s *StorageStateSuite) TestAddServiceStorageConstraintsJustCount(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 0, 1),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop", 1024, 1),
+		"data": makeStorageCons("loop-pool", 1024, 1),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }

--- a/state/volume.go
+++ b/state/volume.go
@@ -361,7 +361,12 @@ func (st *State) volumeParamsWithDefaults(params VolumeParams) (VolumeParams, er
 	if err != nil {
 		return VolumeParams{}, errors.Trace(err)
 	}
-	poolName, err := defaultStoragePool(envConfig, storage.StorageKindBlock)
+	cons := StorageConstraints{
+		Pool:  params.Pool,
+		Size:  params.Size,
+		Count: 1,
+	}
+	poolName, err := defaultStoragePool(envConfig, storage.StorageKindBlock, cons)
 	if err != nil {
 		return VolumeParams{}, errors.Annotate(err, "getting default block storage pool")
 	}


### PR DESCRIPTION
It's possible to define a default block provider in env config, eg

storage-default-block-source: ebs

If no pool is specified, this default is always used, regardless of whether size is specified. We want to tweak that so that:
- if no size or pool is specified: provider = loop, size = charm minimum (or 1GiB)
- if size but no pool: provider = env default (or loop)

(Review request: http://reviews.vapour.ws/r/1598/)