### PR TITLE
Refactoring of replicaset initiation

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -103,6 +103,7 @@ var (
 	// intercept calls to the functions.
 	useMultipleCPUs          = utils.UseMultipleCPUs
 	maybeInitiateMongoServer = peergrouper.MaybeInitiateMongoServer
+	replicasetCurrentConfig  = replicaset.CurrentConfig
 	ensureMongoAdminUser     = mongo.EnsureAdminUser
 	newSingularRunner        = singular.New
 	peergrouperNew           = peergrouper.New
@@ -1223,6 +1224,8 @@ func (a *MachineAgent) limitLoginsDuringUpgrade(req params.LoginRequest) error {
 	}
 }
 
+var stateWorkerServingConfigErr = errors.New("state worker started with no state serving info")
+
 // ensureMongoServer ensures that mongo is installed and running,
 // and ready for opening a state connection.
 func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
@@ -1238,55 +1241,47 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 		}
 	}()
 
-	servingInfo, ok := agentConfig.StateServingInfo()
+	// Many of the steps here, such as adding the state server to the
+	// admin DB and initiating the replicaset, are once-only actions,
+	// required when upgrading from a pre-HA-capable
+	// environment. These calls won't do anything if the thing they
+	// need to set up has already been done.
+
+	if _, err := a.ensureMongoAdminUser(agentConfig); err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := a.ensureMongoSharedSecret(agentConfig); err != nil {
+		return errors.Trace(err)
+	}
+	agentConfig = a.CurrentConfig() // ensureMongoSharedSecret may have updated the config
+
+	mongoInfo, ok := agentConfig.MongoInfo()
 	if !ok {
-		return fmt.Errorf("state worker was started with no state serving info")
+		return errors.New("unable to retrieve mongo info to check replicaset")
 	}
 
-	// When upgrading from a pre-HA-capable environment,
-	// we must add machine-0 to the admin database and
-	// initiate its replicaset.
-	//
-	// TODO(axw) remove this when we no longer need
-	// to upgrade from pre-HA-capable environments.
-	var shouldInitiateMongoServer bool
-	var addrs []network.Address
-	if isPreHAVersion(a.previousAgentVersion) {
-		_, err := a.ensureMongoAdminUser(agentConfig)
-		if err != nil {
-			return err
-		}
-		if servingInfo.SharedSecret == "" {
-			servingInfo.SharedSecret, err = mongo.GenerateSharedSecret()
-			if err != nil {
-				return err
-			}
-			if err = a.ChangeConfig(func(config agent.ConfigSetter) error {
-				config.SetStateServingInfo(servingInfo)
-				return nil
-			}); err != nil {
-				return err
-			}
-			agentConfig = a.CurrentConfig()
-		}
-		// Note: we set Direct=true in the mongo options because it's
-		// possible that we've previously upgraded the mongo server's
-		// configuration to form a replicaset, but failed to initiate it.
-		st, m, err := openState(agentConfig, mongo.DialOpts{Direct: true})
-		if err != nil {
-			return err
-		}
-		ssi := cmdutil.ParamsStateServingInfoToStateStateServingInfo(servingInfo)
-		if err := st.SetStateServingInfo(ssi); err != nil {
-			st.Close()
-			return fmt.Errorf("cannot set state serving info: %v", err)
-		}
-		st.Close()
-		addrs = m.Addresses()
-		shouldInitiateMongoServer = true
+	haveReplicaset, err := isReplicasetConfigured(mongoInfo)
+	if err != nil {
+		return errors.Annotate(err, "error while checking replicaset")
 	}
 
-	// ensureMongoServer installs/upgrades the init config as necessary.
+	// If the replicaset is to be initialised the machine addresses
+	// need to be retrieved *before* MongoDB is restarted with the
+	// --replset option (in EnsureMongoServer). Once MongoDB is
+	// started with --replset it won't respond to queries until the
+	// replicaset is initiated.
+	var machineAddrs []network.Address
+	if !haveReplicaset {
+		logger.Infof("replicaset not yet configured")
+
+		machineAddrs, err = getMachineAddresses(agentConfig)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// EnsureMongoServer installs/upgrades the init config as necessary.
 	ensureServerParams, err := cmdutil.NewEnsureServerParams(agentConfig)
 	if err != nil {
 		return err
@@ -1294,45 +1289,30 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 	if err := cmdutil.EnsureMongoServer(ensureServerParams); err != nil {
 		return err
 	}
-	if !shouldInitiateMongoServer {
-		return nil
+
+	// Create the replicaset it hasn't been set up yet.
+	if !haveReplicaset {
+		servingInfo, ok := agentConfig.StateServingInfo()
+		if !ok {
+			return stateWorkerServingConfigErr
+		}
+		if err := initiateReplicaSet(mongoInfo, servingInfo.StatePort, machineAddrs); err != nil {
+			return err
+		}
 	}
 
-	// Initiate the replicaset for upgraded environments.
-	//
-	// TODO(axw) remove this when we no longer need
-	// to upgrade from pre-HA-capable environments.
-	stateInfo, ok := agentConfig.MongoInfo()
-	if !ok {
-		return fmt.Errorf("state worker was started with no state serving info")
-	}
-	dialInfo, err := mongo.DialInfo(stateInfo.Info, mongo.DefaultDialOpts())
-	if err != nil {
-		return err
-	}
-	peerAddr := mongo.SelectPeerAddress(addrs)
-	if peerAddr == "" {
-		return fmt.Errorf("no appropriate peer address found in %q", addrs)
-	}
-	if err := maybeInitiateMongoServer(peergrouper.InitiateMongoParams{
-		DialInfo:       dialInfo,
-		MemberHostPort: net.JoinHostPort(peerAddr, fmt.Sprint(servingInfo.StatePort)),
-		// TODO(dfc) InitiateMongoParams should take a Tag
-		User:     stateInfo.Tag.String(),
-		Password: stateInfo.Password,
-	}); err != nil && err != peergrouper.ErrReplicaSetAlreadyInitiated {
-		return err
-	}
 	return nil
 }
 
+// ensureMongoAdminUser ensures that the machine's mongo user is in
+// the admin DB.
 func (a *MachineAgent) ensureMongoAdminUser(agentConfig agent.Config) (added bool, err error) {
-	stateInfo, ok1 := agentConfig.MongoInfo()
+	mongoInfo, ok1 := agentConfig.MongoInfo()
 	servingInfo, ok2 := agentConfig.StateServingInfo()
 	if !ok1 || !ok2 {
-		return false, fmt.Errorf("no state serving info configuration")
+		return false, stateWorkerServingConfigErr
 	}
-	dialInfo, err := mongo.DialInfo(stateInfo.Info, mongo.DefaultDialOpts())
+	dialInfo, err := mongo.DialInfo(mongoInfo.Info, mongo.DefaultDialOpts())
 	if err != nil {
 		return false, err
 	}
@@ -1345,13 +1325,118 @@ func (a *MachineAgent) ensureMongoAdminUser(agentConfig agent.Config) (added boo
 		Namespace: agentConfig.Value(agent.Namespace),
 		DataDir:   agentConfig.DataDir(),
 		Port:      servingInfo.StatePort,
-		User:      stateInfo.Tag.String(),
-		Password:  stateInfo.Password,
+		User:      mongoInfo.Tag.String(),
+		Password:  mongoInfo.Password,
 	})
 }
 
-func isPreHAVersion(v version.Number) bool {
-	return v.Compare(version.MustParse("1.19.0")) < 0
+// ensureMongoSharedSecret generates a MongoDB shared secret if
+// required, updating the agent's config and state.
+func (a *MachineAgent) ensureMongoSharedSecret(agentConfig agent.Config) error {
+	servingInfo, ok := agentConfig.StateServingInfo()
+	if !ok {
+		return stateWorkerServingConfigErr
+	}
+
+	if servingInfo.SharedSecret != "" {
+		return nil // Already done
+	}
+
+	logger.Infof("state serving info has no shared secret - generating")
+
+	var err error
+	servingInfo.SharedSecret, err = mongo.GenerateSharedSecret()
+	if err != nil {
+		return err
+	}
+	logger.Debugf("updating state serving info in agent config")
+	if err = a.ChangeConfig(func(config agent.ConfigSetter) error {
+		config.SetStateServingInfo(servingInfo)
+		return nil
+	}); err != nil {
+		return err
+	}
+	agentConfig = a.CurrentConfig()
+
+	logger.Debugf("updating state serving info in state")
+
+	// Note: we set Direct=true in the mongo options because it's
+	// possible that we've previously upgraded the mongo server's
+	// configuration to form a replicaset, but failed to initiate it.
+	st, _, err := openState(agentConfig, mongo.DialOpts{Direct: true})
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+
+	ssi := cmdutil.ParamsStateServingInfoToStateStateServingInfo(servingInfo)
+	if err := st.SetStateServingInfo(ssi); err != nil {
+		return errors.Errorf("cannot set state serving info: %v", err)
+	}
+
+	logger.Infof("shared secret updated in state serving info")
+	return nil
+}
+
+// isReplicasetConfigured returns true if the replicaset has been
+// successfully initiated.
+func isReplicasetConfigured(mongoInfo *mongo.MongoInfo) (bool, error) {
+	dialInfo, err := mongo.DialInfo(mongoInfo.Info, mongo.DefaultDialOpts())
+	if err != nil {
+		return false, errors.Annotate(err, "cannot generate dial info to check replicaset")
+	}
+	dialInfo.Username = mongoInfo.Tag.String()
+	dialInfo.Password = mongoInfo.Password
+
+	session, err := mgo.DialWithInfo(dialInfo)
+	if err != nil {
+		return false, errors.Annotate(err, "cannot dial mongo to check replicaset")
+	}
+	defer session.Close()
+
+	cfg, err := replicasetCurrentConfig(session)
+	if err != nil {
+		logger.Debugf("couldn't retrieve replicaset config (not fatal): %v", err)
+		return false, nil
+	}
+	numMembers := len(cfg.Members)
+	logger.Debugf("replicaset member count: %d", numMembers)
+	return numMembers > 0, nil
+}
+
+// getMachineAddresses connects to state to determine the machine's
+// network addresses.
+func getMachineAddresses(agentConfig agent.Config) ([]network.Address, error) {
+	logger.Debugf("opening state to get machine addresses")
+	st, m, err := openState(agentConfig, mongo.DialOpts{Direct: true})
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to open state to retrieve machine addresses")
+	}
+	defer st.Close()
+	return m.Addresses(), nil
+}
+
+// initiateReplicaSet connects to MongoDB and sets up the replicaset.
+func initiateReplicaSet(mongoInfo *mongo.MongoInfo, statePort int, machineAddrs []network.Address) error {
+	peerAddr := mongo.SelectPeerAddress(machineAddrs)
+	if peerAddr == "" {
+		return errors.Errorf("no appropriate peer address found in %q", machineAddrs)
+	}
+
+	dialInfo, err := mongo.DialInfo(mongoInfo.Info, mongo.DefaultDialOpts())
+	if err != nil {
+		return errors.Annotate(err, "cannot generate dial info to initiate replicaset")
+	}
+
+	if err := maybeInitiateMongoServer(peergrouper.InitiateMongoParams{
+		DialInfo:       dialInfo,
+		MemberHostPort: net.JoinHostPort(peerAddr, fmt.Sprint(statePort)),
+		User:           mongoInfo.Tag.String(), // TODO(dfc) InitiateMongoParams should take a Tag
+		Password:       mongoInfo.Password,
+	}); err != nil && err != peergrouper.ErrReplicaSetAlreadyInitiated {
+		return err
+	}
+	return nil
 }
 
 func openState(agentConfig agent.Config, dialOpts mongo.DialOpts) (_ *state.State, _ *state.Machine, err error) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -134,7 +134,9 @@ func (s *commonMachineSuite) SetUpTest(c *gc.C) {
 	})
 
 	s.fakeEnsureMongo = agenttesting.FakeEnsure{}
+	s.fakeEnsureMongo.ReplicasetInitiated = true
 	s.AgentSuite.PatchValue(&cmdutil.EnsureMongoServer, s.fakeEnsureMongo.FakeEnsureMongo)
+	s.AgentSuite.PatchValue(&replicasetCurrentConfig, s.fakeEnsureMongo.FakeCurrentConfig)
 	s.AgentSuite.PatchValue(&maybeInitiateMongoServer, s.fakeEnsureMongo.FakeInitiateMongo)
 }
 
@@ -1483,6 +1485,8 @@ func (s *MachineSuite) TestMachineAgentUpgradeMongo(c *gc.C) {
 	err = s.State.MongoSession().DB("admin").RemoveUser(m.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.fakeEnsureMongo.ReplicasetInitiated = false
+
 	s.AgentSuite.PatchValue(&ensureMongoAdminUser, func(p mongo.EnsureAdminUserParams) (bool, error) {
 		err := s.State.MongoSession().DB("admin").AddUser(p.User, p.Password, false)
 		c.Assert(err, jc.ErrorIsNil)
@@ -1593,6 +1597,42 @@ func (s *MachineSuite) TestNewEnvironmentStartsNewWorkers(c *gc.C) {
 	r1 := s.singularRecord.nextRunner(c)
 	workers = r1.waitForWorker(c, "firewaller")
 	c.Assert(workers, jc.DeepEquals, expectedWorkers)
+}
+
+func (s *MachineSuite) TestReplicasetInitiation(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("state servers on windows aren't supported")
+	}
+
+	s.fakeEnsureMongo.ReplicasetInitiated = false
+
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	agentConfig := a.CurrentConfig()
+
+	err := a.ensureMongoServer(agentConfig)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)
+	c.Assert(s.fakeEnsureMongo.InitiateCount, gc.Equals, 1)
+}
+
+func (s *MachineSuite) TestReplicasetAlreadyInitiated(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("state servers on windows aren't supported")
+	}
+
+	s.fakeEnsureMongo.ReplicasetInitiated = true
+
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	agentConfig := a.CurrentConfig()
+
+	err := a.ensureMongoServer(agentConfig)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)
+	c.Assert(s.fakeEnsureMongo.InitiateCount, gc.Equals, 0)
 }
 
 // MachineWithCharmsSuite provides infrastructure for tests which need to

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -95,7 +95,7 @@ func TestPackage(t *testing.T) {
 type commonMachineSuite struct {
 	singularRecord *singularRunnerRecord
 	lxctesting.TestSuite
-	fakeEnsureMongo agenttesting.FakeEnsure
+	fakeEnsureMongo *agenttesting.FakeEnsureMongo
 	AgentSuite
 }
 
@@ -133,11 +133,8 @@ func (s *commonMachineSuite) SetUpTest(c *gc.C) {
 		return newDummyWorker(), nil
 	})
 
-	s.fakeEnsureMongo = agenttesting.FakeEnsure{}
-	s.fakeEnsureMongo.ReplicasetInitiated = true
-	s.AgentSuite.PatchValue(&cmdutil.EnsureMongoServer, s.fakeEnsureMongo.FakeEnsureMongo)
-	s.AgentSuite.PatchValue(&replicasetCurrentConfig, s.fakeEnsureMongo.FakeCurrentConfig)
-	s.AgentSuite.PatchValue(&maybeInitiateMongoServer, s.fakeEnsureMongo.FakeInitiateMongo)
+	s.fakeEnsureMongo = agenttesting.InstallFakeEnsureMongo(s)
+	s.AgentSuite.PatchValue(&maybeInitiateMongoServer, s.fakeEnsureMongo.InitiateMongo)
 }
 
 func fakeCmd(path string) {

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -7,9 +7,12 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/replicaset"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
@@ -28,14 +31,26 @@ import (
 )
 
 type FakeEnsure struct {
-	EnsureCount    int
-	InitiateCount  int
-	DataDir        string
-	Namespace      string
-	OplogSize      int
-	Info           state.StateServingInfo
-	InitiateParams peergrouper.InitiateMongoParams
-	Err            error
+	EnsureCount         int
+	InitiateCount       int
+	DataDir             string
+	Namespace           string
+	OplogSize           int
+	Info                state.StateServingInfo
+	InitiateParams      peergrouper.InitiateMongoParams
+	Err                 error
+	ReplicasetInitiated bool
+}
+
+func (f *FakeEnsure) FakeCurrentConfig(*mgo.Session) (*replicaset.Config, error) {
+	if f.ReplicasetInitiated {
+		// Return a dummy replicaset config that's good enough to
+		// indicate that the replicaset is initiated.
+		return &replicaset.Config{
+			Members: []replicaset.Member{{}},
+		}, nil
+	}
+	return nil, errors.NotFoundf("replicaset")
 }
 
 func (f *FakeEnsure) FakeEnsureMongo(args mongo.EnsureServerParams) error {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -24,7 +24,7 @@ github.com/juju/loggo	git	6d22922ff98aac6608b8a58191bd6b2e1dac3fca	2015-03-30T01
 github.com/juju/names	git	a597dd52044cc5a702844642b5cb6e09870422db	2015-04-28T12:56:57Z
 github.com/juju/persistent-cookiejar	git	beee02cb39231c7ad4a01a677fc54c48d2b46b08	2015-04-09T09:48:35Z
 github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-30T01:41:32Z
-github.com/juju/replicaset	git	a5137dd3d7a1495ef2dd32cfbac616654913cf49	2015-04-02T14:41:36Z
+github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-04-08T04:21:43Z
 github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-30T01:12:23Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	a3720f880a5787622a21fbf718a3ac9d551dbe9c	2015-04-10T20:58:11Z

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -49,12 +48,8 @@ func (s *leadershipSuite) SetUpTest(c *gc.C) {
 	defer file.Close()
 	s.AgentSuite.PatchValue(&agentcmd.JujuRun, file.Name())
 
-	if runtime.GOOS == "windows" {
-		s.AgentSuite.PatchValue(&agentcmd.EnableJournaling, false)
-	}
-
-	fakeEnsureMongo := agenttesting.FakeEnsure{}
-	s.AgentSuite.PatchValue(&cmdutil.EnsureMongoServer, fakeEnsureMongo.FakeEnsureMongo)
+	agenttesting.InstallFakeEnsureMongo(s)
+	s.PatchValue(&agentcmd.ProductionMongoWriteConcern, false)
 
 	// Create a machine to manage the environment.
 	stateServer, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
@@ -294,13 +289,8 @@ func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 	file, _ := ioutil.TempFile("", "juju-run")
 	defer file.Close()
 	s.AgentSuite.PatchValue(&agentcmd.JujuRun, file.Name())
-
-	if runtime.GOOS == "windows" {
-		s.AgentSuite.PatchValue(&agentcmd.EnableJournaling, false)
-	}
-
-	fakeEnsureMongo := agenttesting.FakeEnsure{}
-	s.AgentSuite.PatchValue(&cmdutil.EnsureMongoServer, fakeEnsureMongo.FakeEnsureMongo)
+	agenttesting.InstallFakeEnsureMongo(s)
+	s.PatchValue(&agentcmd.ProductionMongoWriteConcern, false)
 
 	s.factory = factory.NewFactory(s.State)
 

--- a/worker/peergrouper/initiate.go
+++ b/worker/peergrouper/initiate.go
@@ -62,20 +62,17 @@ func InitiateMongoServer(p InitiateMongoParams, force bool) error {
 	}
 
 	// Initiate may fail while mongo is initialising, so we retry until
-	// we succssfully populate the replicaset config.
+	// we successfully populate the replicaset config.
 	var err error
 	for attempt := initiateAttemptStrategy.Start(); attempt.Next(); {
 		err = attemptInitiateMongoServer(p.DialInfo, p.MemberHostPort, force)
-		if err == nil {
+		if err == nil || err == ErrReplicaSetAlreadyInitiated {
 			logger.Infof("replica set initiated")
-			return nil
+			return err
 		}
 		if attempt.HasNext() {
 			logger.Debugf("replica set initiation failed, will retry: %v", err)
 		}
-	}
-	if err == ErrReplicaSetAlreadyInitiated {
-		return err
 	}
 	return errors.Annotatef(err, "cannot initiate replica set")
 }


### PR DESCRIPTION
**cmd/jujud/agent: refactoring replicaset initiation**

Instead of deciding whether to do replicaset initiation based on the previous agent version (which can't be relied on in all cases - see the ticket), initiate the replicaset if it hasn't been done yet. This approach is now also taken for other DB upgrade related tasks such as adding the admin user and generating the shared secret.

Also added some basic tests for replicaset initiating as there were none.

Fixes LP #1441913.

**worker/peergrouper: avoid unnecessary replicaset initiate attempts**

InitiateMongoServer kept trying to initiate the replicaset when it was
already initiated. The retry loop is now exited early if the
replicaset is already up.

This also reduces the peergrouper tests run time from ~2 mins to a few
seconds!

(Review request: http://reviews.vapour.ws/r/1602/)