### PR TITLE
Added environment provider types as pools when listing.

### DIFF
--- a/apiserver/storage/poollist_test.go
+++ b/apiserver/storage/poollist_test.go
@@ -51,7 +51,15 @@ func (s *poolSuite) TestListManyResults(c *gc.C) {
 	s.createPools(c, 2)
 	pools, err := s.api.ListPools(params.StoragePoolFilter{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pools.Results, gc.HasLen, 2)
+
+	expected := []params.StoragePool{
+		params.StoragePool{Name: "testpool0", Provider: "loop"},
+		params.StoragePool{Name: "testpool1", Provider: "loop"},
+		params.StoragePool{Name: "dummy", Provider: "dummy"},
+		params.StoragePool{Name: "loop", Provider: "loop"},
+		params.StoragePool{Name: "rootfs", Provider: "rootfs"},
+		params.StoragePool{Name: "tmpfs", Provider: "tmpfs"}}
+	c.Assert(pools.Results, gc.DeepEquals, expected)
 }
 
 func (s *poolSuite) TestListByName(c *gc.C) {
@@ -74,12 +82,16 @@ func (s *poolSuite) TestListByType(c *gc.C) {
 	s.baseStorageSuite.pools[poolName], err =
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
+
 	pools, err := s.api.ListPools(params.StoragePoolFilter{
 		Providers: []string{tstType}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pools.Results, gc.HasLen, 1)
-	c.Assert(pools.Results[0].Provider, gc.DeepEquals, tstType)
-	c.Assert(pools.Results[0].Name, gc.DeepEquals, poolName)
+	c.Assert(pools.Results, gc.HasLen, 2)
+
+	expected := []params.StoragePool{
+		params.StoragePool{Name: "rayofsunshine", Provider: "tmpfs"},
+		params.StoragePool{Name: "tmpfs", Provider: "tmpfs"}}
+	c.Assert(pools.Results, gc.DeepEquals, expected)
 }
 
 func (s *poolSuite) TestListByNameAndTypeAnd(c *gc.C) {
@@ -114,7 +126,12 @@ func (s *poolSuite) TestListByNamesOr(c *gc.C) {
 			fmt.Sprintf("%v%v", tstName, 0),
 		}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(pools.Results) < len(s.pools), jc.IsTrue)
+
+	expected := []params.StoragePool{
+		params.StoragePool{Name: "testpool0", Provider: "loop"},
+		params.StoragePool{Name: "testpool1", Provider: "loop"},
+	}
+	c.Assert(pools.Results, gc.DeepEquals, expected)
 }
 
 func (s *poolSuite) TestListByTypesOr(c *gc.C) {
@@ -129,13 +146,27 @@ func (s *poolSuite) TestListByTypesOr(c *gc.C) {
 	pools, err := s.api.ListPools(params.StoragePoolFilter{
 		Providers: []string{tstType, string(provider.LoopProviderType)}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(pools.Results) <= len(s.pools), jc.IsTrue)
+
+	expected := []params.StoragePool{
+		params.StoragePool{Name: "testpool0", Provider: "loop"},
+		params.StoragePool{Name: "testpool1", Provider: "loop"},
+		params.StoragePool{Name: "rayofsunshine", Provider: "tmpfs"},
+		params.StoragePool{Name: "loop", Provider: "loop"},
+		params.StoragePool{Name: "tmpfs", Provider: "tmpfs"},
+	}
+	c.Assert(pools.Results, gc.DeepEquals, expected)
 }
 
 func (s *poolSuite) TestListNoPools(c *gc.C) {
 	pools, err := s.api.ListPools(params.StoragePoolFilter{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pools.Results, gc.HasLen, 0)
+
+	expected := []params.StoragePool{
+		params.StoragePool{Name: "dummy", Provider: "dummy"},
+		params.StoragePool{Name: "loop", Provider: "loop"},
+		params.StoragePool{Name: "rootfs", Provider: "rootfs"},
+		params.StoragePool{Name: "tmpfs", Provider: "tmpfs"}}
+	c.Assert(pools.Results, gc.DeepEquals, expected)
 }
 
 func (s *poolSuite) TestListFilterEmpty(c *gc.C) {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -343,7 +343,7 @@ func (a *API) allProviders() ([]storage.ProviderType, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "getting env name")
 	}
-	if providers, ok := registry.ListEnvProvider(envName); ok {
+	if providers, ok := registry.EnvironStorageProviders(envName); ok {
 		return providers, nil
 	}
 	return nil, nil

--- a/cmd/juju/storage/pool.go
+++ b/cmd/juju/storage/pool.go
@@ -41,7 +41,7 @@ type PoolCommandBase struct {
 // PoolInfo defines the serialization behaviour of the storage pool information.
 type PoolInfo struct {
 	Provider string                 `yaml:"provider" json:"provider"`
-	Attrs    map[string]interface{} `yaml:"attrs" json:"attrs"`
+	Attrs    map[string]interface{} `yaml:"attrs,omitempty" json:"attrs,omitempty"`
 }
 
 func formatPoolInfo(all []params.StoragePool) map[string]PoolInfo {

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -212,6 +212,14 @@ block-persistent:
   provider: ebs
   attrs:
     persistent: true
+ebs:
+  provider: ebs
+loop:
+  provider: loop
+rootfs:
+  provider: rootfs
+tmpfs:
+  provider: tmpfs
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 }
@@ -222,6 +230,10 @@ func (s *cmdStorageSuite) TestListPoolsTabular(c *gc.C) {
 NAME              PROVIDER  ATTRS
 block             loop      it=works
 block-persistent  ebs       persistent=true
+ebs               ebs       
+loop              loop      
+rootfs            rootfs    
+tmpfs             tmpfs     
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -255,6 +267,8 @@ block-persistent:
   provider: ebs
   attrs:
     persistent: true
+ebs:
+  provider: ebs
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 }
@@ -268,7 +282,11 @@ func (s *cmdStorageSuite) registerTmpProviderType(c *gc.C) {
 func (s *cmdStorageSuite) TestListPoolsProviderNoMatch(c *gc.C) {
 	s.registerTmpProviderType(c)
 	context := runPoolList(c, "--provider", string(provider.TmpfsProviderType))
-	c.Assert(testing.Stdout(context), gc.Equals, "")
+	expected := `
+tmpfs:
+  provider: tmpfs
+`[1:]
+	c.Assert(testing.Stdout(context), gc.Equals, expected)
 }
 
 func (s *cmdStorageSuite) TestListPoolsProviderUnregistered(c *gc.C) {

--- a/storage/provider/registry/providerregistry.go
+++ b/storage/provider/registry/providerregistry.go
@@ -77,7 +77,7 @@ func RegisterEnvironStorageProviders(envType string, providers ...storage.Provid
 
 // Returns true is provider is supported for the environment.
 func IsProviderSupported(envType string, providerType storage.ProviderType) bool {
-	providerTypes, ok := ListEnvProvider(envType)
+	providerTypes, ok := EnvironStorageProviders(envType)
 	if !ok {
 		return false
 	}
@@ -89,8 +89,9 @@ func IsProviderSupported(envType string, providerType storage.ProviderType) bool
 	return false
 }
 
-// ListEnvProvider returna provider types for the environment.
-func ListEnvProvider(envType string) ([]storage.ProviderType, bool) {
+// EnvironStorageProviders returns storage provider types
+// for the specified environment.
+func EnvironStorageProviders(envType string) ([]storage.ProviderType, bool) {
 	providerTypes, ok := supportedEnvironProviders[envType]
 	if !ok {
 		return nil, false

--- a/storage/provider/registry/providerregistry.go
+++ b/storage/provider/registry/providerregistry.go
@@ -77,7 +77,7 @@ func RegisterEnvironStorageProviders(envType string, providers ...storage.Provid
 
 // Returns true is provider is supported for the environment.
 func IsProviderSupported(envType string, providerType storage.ProviderType) bool {
-	providerTypes, ok := supportedEnvironProviders[envType]
+	providerTypes, ok := ListEnvProvider(envType)
 	if !ok {
 		return false
 	}
@@ -87,4 +87,13 @@ func IsProviderSupported(envType string, providerType storage.ProviderType) bool
 		}
 	}
 	return false
+}
+
+// ListEnvProvider returna provider types for the environment.
+func ListEnvProvider(envType string) ([]storage.ProviderType, bool) {
+	providerTypes, ok := supportedEnvironProviders[envType]
+	if !ok {
+		return nil, false
+	}
+	return providerTypes, true
 }

--- a/storage/provider/registry/providerregistry_test.go
+++ b/storage/provider/registry/providerregistry_test.go
@@ -94,7 +94,7 @@ func (s *providerRegistrySuite) TestRegisterEnvironProvidersMultipleCalls(c *gc.
 }
 
 func (s *providerRegistrySuite) TestListEnvProviderUnknownEnv(c *gc.C) {
-	all, exists := registry.ListEnvProvider("fluffy")
+	all, exists := registry.EnvironStorageProviders("fluffy")
 	c.Assert(exists, jc.IsFalse)
 	c.Assert(all, gc.IsNil)
 }
@@ -102,7 +102,7 @@ func (s *providerRegistrySuite) TestListEnvProviderUnknownEnv(c *gc.C) {
 func (s *providerRegistrySuite) TestListEnvProviderKnownEnv(c *gc.C) {
 	ptypeFoo := storage.ProviderType("foo")
 	registry.RegisterEnvironStorageProviders("ec2", ptypeFoo)
-	all, exists := registry.ListEnvProvider("ec2")
+	all, exists := registry.EnvironStorageProviders("ec2")
 	c.Assert(exists, jc.IsTrue)
 	c.Assert(len(all) > 0, jc.IsTrue)
 

--- a/storage/provider/registry/providerregistry_test.go
+++ b/storage/provider/registry/providerregistry_test.go
@@ -92,3 +92,26 @@ func (s *providerRegistrySuite) TestRegisterEnvironProvidersMultipleCalls(c *gc.
 	c.Assert(registry.IsProviderSupported("ec2", ptypeFoo), jc.IsTrue)
 	c.Assert(registry.IsProviderSupported("ec2", ptypeBar), jc.IsTrue)
 }
+
+func (s *providerRegistrySuite) TestListEnvProviderUnknownEnv(c *gc.C) {
+	all, exists := registry.ListEnvProvider("fluffy")
+	c.Assert(exists, jc.IsFalse)
+	c.Assert(all, gc.IsNil)
+}
+
+func (s *providerRegistrySuite) TestListEnvProviderKnownEnv(c *gc.C) {
+	ptypeFoo := storage.ProviderType("foo")
+	registry.RegisterEnvironStorageProviders("ec2", ptypeFoo)
+	all, exists := registry.ListEnvProvider("ec2")
+	c.Assert(exists, jc.IsTrue)
+	c.Assert(len(all) > 0, jc.IsTrue)
+
+	found := false
+	for _, one := range all {
+		if one == ptypeFoo {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, jc.IsTrue)
+}


### PR DESCRIPTION
Juju allows a user to use a provider type name when requesting storage. This is interpreted as a pool of that type but with no config.

This PR changes "pool list" to return a union of environment provider names and pools. Items from this list can then be used to request storage as per above. 

(Review request: http://reviews.vapour.ws/r/1604/)