### PR TITLE
state: permit placement with dynamic storage

### DIFF
--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -133,12 +133,6 @@ func DeployService(st *state.State, owner string, args params.ServiceDeploy) err
 		return errors.Trace(err)
 	}
 
-	// Validate the storage parameters against the charm metadata,
-	// and ensure there are no conflicting parameters.
-	if err := validateCharmStorage(args, ch); err != nil {
-		return err
-	}
-
 	var settings charm.Settings
 	if len(args.ConfigYAML) > 0 {
 		settings, err = ch.Config().ParseSettingsYAML([]byte(args.ConfigYAML), args.ServiceName)
@@ -184,20 +178,6 @@ func ServiceSetSettingsStrings(service *state.Service, settings map[string]strin
 		return err
 	}
 	return service.UpdateConfigSettings(changes)
-}
-
-func validateCharmStorage(args params.ServiceDeploy, ch *state.Charm) error {
-	if len(args.Storage) == 0 {
-		return nil
-	}
-	if len(args.ToMachineSpec) != 0 {
-		// TODO(axw) when we support dynamic disk provisioning, we can
-		// relax this. We will need to consult the storage provider to
-		// decide whether or not this is allowable.
-		return errors.New("cannot specify storage and machine placement")
-	}
-	// Remaining validation is done in state.AddService.
-	return nil
 }
 
 func networkTagsToNames(tags []string) ([]string, error) {

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -9,8 +9,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
+	"github.com/juju/juju/storage/provider/dummy"
+	"github.com/juju/juju/storage/provider/registry"
 )
 
 type FilesystemStateSuite struct {
@@ -343,6 +346,39 @@ func (s *FilesystemStateSuite) TestParseFilesystemAttachmentIdError(c *gc.C) {
 	assertError("0", `invalid filesystem attachment ID "0"`)
 	assertError("0:foo", `invalid filesystem attachment ID "0:foo"`)
 	assertError("bar:0", `invalid filesystem attachment ID "bar:0"`)
+}
+
+func (s *FilesystemStateSuite) TestAssignToMachine(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "loop-pool")
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+	filesystemAttachments, err := s.State.MachineFilesystemAttachments(machine.MachineTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystemAttachments, gc.HasLen, 1)
+}
+
+func (s *FilesystemStateSuite) TestAssignToMachineErrors(c *gc.C) {
+	registry.RegisterProvider("static", &dummy.StorageProvider{
+		IsDynamic: false,
+	})
+	registry.RegisterEnvironStorageProviders("someprovider", "static")
+	defer registry.RegisterProvider("static", nil)
+
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "static")
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(machine)
+	c.Assert(err, gc.ErrorMatches, `cannot assign unit "storage-filesystem/0" to machine 0: static storage provider does not support dynamic storage`)
+
+	container, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	}, machine.Id(), instance.LXC)
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(container)
+	c.Assert(err, gc.ErrorMatches, `cannot assign unit "storage-filesystem/0" to machine 0/lxc/0: adding storage to lxc container not supported`)
 }
 
 func (s *FilesystemStateSuite) assertFilesystemUnprovisioned(c *gc.C, tag names.FilesystemTag) {

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -30,6 +30,19 @@ func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
 	_, unit, _ := s.setupSingleStorage(c, "block", "loop-pool")
 	err := s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
+	s.assertMachineVolume(c, unit)
+}
+
+func (s *VolumeStateSuite) TestAssignToMachine(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "block", "loop-pool")
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertMachineVolume(c, unit)
+}
+
+func (s *VolumeStateSuite) assertMachineVolume(c *gc.C, unit *state.Unit) {
 	assignedMachineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
With this change, we will allow adding units
with storage to existing machines (i.e. with
placement), as long as (a) the storage is
"dynamic", and (b) the target machine is not
a container.

Tested live with the local provider.

(Review request: http://reviews.vapour.ws/r/1606/)