### PR TITLE
Ignore reported volumes that aren't in constraints map

### DIFF
--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -179,7 +179,8 @@ func (mi *maasInstance) volumes(
 		// Device Label.
 		deviceLabelValue, ok := deviceLabels[idKey]
 		if !ok {
-			return nil, nil, errors.Errorf("missing volume label for id %q", idKey)
+			logger.Debugf("acquire maas node: missing volume label for id %q", idKey)
+			continue
 		}
 		deviceLabel, err := deviceLabelValue.GetString()
 		if err != nil {

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -157,10 +157,24 @@ var validVolumeJson = `
             ], 
             "id": 4, 
             "id_path": "/dev/disk/by-id/id_for_sdd",
-            "path": "/dev/sdc", 
+            "path": "/dev/sdd", 
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC386666L", 
+            "size": 250362438230
+        },
+        {
+            "name": "sde", 
+            "tags": [
+                "ssd", 
+                "sata"
+            ], 
+            "id": 666, 
+            "id_path": "/dev/disk/by-id/id_for_sde",
+            "path": "/dev/sde", 
+            "model": "Samsung_SSD_850_EVO_250GB", 
+            "block_size": 4096, 
+            "serial": "S21NNSAFC388888L", 
             "size": 250362438230
         }
     ], 


### PR DESCRIPTION
A small tweak to allow Juju to ignore unrecognised MAAS volume labels.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1452725

(Review request: http://reviews.vapour.ws/r/1611/)