### PR TITLE
Fix jujud restart behavior under systemd.

### DIFF
--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -205,7 +205,7 @@ func serializeService(conf common.Conf) []*unit.UnitOption {
 		unitOptions = append(unitOptions, &unit.UnitOption{
 			Section: "Service",
 			Name:    "Restart",
-			Value:   "always",
+			Value:   "on-failure",
 		})
 	}
 

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -173,7 +173,8 @@ func serializeUnit(conf common.Conf) []*unit.UnitOption {
 func serializeService(conf common.Conf) []*unit.UnitOption {
 	var unitOptions []*unit.UnitOption
 
-	// TODO(ericsnow) Support "Type" (e.g. "forking")?
+	// TODO(ericsnow) Support "Type" (e.g. "forking")? For now we just
+	// use the default, "simple".
 
 	for k, v := range conf.Env {
 		unitOptions = append(unitOptions, &unit.UnitOption{
@@ -196,15 +197,6 @@ func serializeService(conf common.Conf) []*unit.UnitOption {
 			Section: "Service",
 			Name:    "ExecStart",
 			Value:   conf.ExecStart,
-		})
-	}
-
-	// TODO(ericsnow) This should key off Conf.RemainAfterExit, once added.
-	if !conf.Transient {
-		unitOptions = append(unitOptions, &unit.UnitOption{
-			Section: "Service",
-			Name:    "RemainAfterExit",
-			Value:   "yes",
 		})
 	}
 

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -34,7 +34,6 @@ After=systemd-user-sessions.service
 
 [Service]
 ExecStart=%s
-RemainAfterExit=yes
 Restart=always
 
 [Install]

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -34,7 +34,7 @@ After=systemd-user-sessions.service
 
 [Service]
 ExecStart=%s
-Restart=always
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1452511)

Using RemainAfterExit in juju's systemd unit configs is not correct.  This patch drops that directive.  It also changes the value used for the Restart directive ("on-failure" instead of "always) to match the upstart conf we've been using all along.

(Review request: http://reviews.vapour.ws/r/1616/)