### PR TITLE
Fix 1428439 retry-provisioning fails on containers

### DIFF
--- a/cmd/juju/environment/retryprovisioning.go
+++ b/cmd/juju/environment/retryprovisioning.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/apiserver/params"
@@ -39,12 +40,15 @@ func (c *RetryProvisioningCommand) Info() *cmd.Info {
 
 func (c *RetryProvisioningCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("no machine specified")
+		return errors.Errorf("no machine specified")
 	}
 	c.Machines = make([]names.MachineTag, len(args))
 	for i, arg := range args {
 		if !names.IsValidMachine(arg) {
-			return fmt.Errorf("invalid machine %q", arg)
+			return errors.Errorf("invalid machine %q", arg)
+		}
+		if names.IsContainerMachine(arg) {
+			return errors.Errorf("invalid machine %q retry-provisioning does not support containers", arg)
 		}
 		c.Machines[i] = names.NewMachineTag(arg)
 	}

--- a/cmd/juju/environment/retryprovisioning_test.go
+++ b/cmd/juju/environment/retryprovisioning_test.go
@@ -116,6 +116,9 @@ var resolvedMachineTests = []struct {
 		args: []string{"1", "42"},
 		stdErr: `machine 1 is not in an error state` +
 			`machine 42 not found`,
+	}, {
+		args: []string{"0/lxc/0"},
+		err:  `invalid machine "0/lxc/0" retry-provisioning does not support containers`,
 	},
 }
 


### PR DESCRIPTION
According to Ian's comments, retry-provisioning should
not support being called with containers as arguments.
(see https://bugs.launchpad.net/juju-core/+bug/1428439/comments/1)
I added a check for containers in the arguments that fails
if the provided machine tag is a container.

(Review request: http://reviews.vapour.ws/r/1620/)