### PR TITLE
Fix maas tests on i386 and some drive by fixes

### DIFF
--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1411,7 +1411,7 @@ var nodeStorageAttrs = []map[string]interface{}{
 		"model":      "Samsung_SSD_850_EVO_250GB",
 		"block_size": 4096,
 		"serial":     "S21NNSAFC38075L",
-		"size":       250059350016,
+		"size":       25005935,
 	},
 	{
 		"name":       "sda",
@@ -1420,7 +1420,7 @@ var nodeStorageAttrs = []map[string]interface{}{
 		"model":      "Samsung_SSD_850_EVO_250GB",
 		"block_size": 4096,
 		"serial":     "XXXX",
-		"size":       250059350016,
+		"size":       25005935,
 	},
 	{
 		"name":       "sdc",
@@ -1429,14 +1429,14 @@ var nodeStorageAttrs = []map[string]interface{}{
 		"model":      "Samsung_SSD_850_EVO_250GB",
 		"block_size": 4096,
 		"serial":     "YYYYYYY",
-		"size":       250059350016,
+		"size":       25005935,
 	},
 }
 
 var storageConstraintAttrs = map[string]interface{}{
-	"1": "volume-1",
+	"1": "1",
 	"2": "root",
-	"3": "volume-3",
+	"3": "3",
 }
 
 func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
@@ -1455,13 +1455,13 @@ func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
 	c.Check(result.Volumes, jc.DeepEquals, []storage.Volume{
 		{
 			Tag:        names.NewVolumeTag("1"),
-			Size:       238475,
+			Size:       23,
 			VolumeId:   "volume-1",
 			HardwareId: "id_for_sda",
 		},
 		{
 			Tag:        names.NewVolumeTag("3"),
-			Size:       238475,
+			Size:       23,
 			VolumeId:   "volume-3",
 			HardwareId: "",
 		},

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1411,7 +1411,7 @@ var nodeStorageAttrs = []map[string]interface{}{
 		"model":      "Samsung_SSD_850_EVO_250GB",
 		"block_size": 4096,
 		"serial":     "S21NNSAFC38075L",
-		"size":       25005935,
+		"size":       uint64(250059350016),
 	},
 	{
 		"name":       "sda",
@@ -1420,7 +1420,7 @@ var nodeStorageAttrs = []map[string]interface{}{
 		"model":      "Samsung_SSD_850_EVO_250GB",
 		"block_size": 4096,
 		"serial":     "XXXX",
-		"size":       25005935,
+		"size":       uint64(250059350016),
 	},
 	{
 		"name":       "sdc",
@@ -1429,7 +1429,7 @@ var nodeStorageAttrs = []map[string]interface{}{
 		"model":      "Samsung_SSD_850_EVO_250GB",
 		"block_size": 4096,
 		"serial":     "YYYYYYY",
-		"size":       25005935,
+		"size":       uint64(250059350016),
 	},
 }
 
@@ -1455,13 +1455,13 @@ func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
 	c.Check(result.Volumes, jc.DeepEquals, []storage.Volume{
 		{
 			Tag:        names.NewVolumeTag("1"),
-			Size:       23,
+			Size:       238475,
 			VolumeId:   "volume-1",
 			HardwareId: "id_for_sda",
 		},
 		{
 			Tag:        names.NewVolumeTag("3"),
-			Size:       23,
+			Size:       238475,
 			VolumeId:   "volume-3",
 			HardwareId: "",
 		},

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -105,6 +105,7 @@ func buildMAASVolumeParameters(args []storage.VolumeParams) ([]volumeInfo, error
 		if len(tags) > 0 {
 			// We don't want any spaces in the tags;
 			// strip out any just in case.
+			// TODO(wallyworld) reject pool configuration if tags have spaces
 			tags = strings.Replace(tags, " ", "", -1)
 			info.tags = strings.Split(tags, ",")
 		}

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -64,14 +64,14 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 			Tag:        names.NewVolumeTag("1"),
 			HardwareId: "",
 			VolumeId:   "volume-1",
-			Size:       47,
+			Size:       476893,
 			Persistent: false,
 		},
 		{
 			Tag:        names.NewVolumeTag("2"),
 			HardwareId: "id_for_sdc",
 			VolumeId:   "volume-2",
-			Size:       23,
+			Size:       238764,
 			Persistent: false,
 		},
 	})
@@ -120,7 +120,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC38075L", 
-            "size": 25005935
+            "size": 250059350016
         }, 
         {
             "name": "sdb", 
@@ -133,7 +133,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_500GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC38076L", 
-            "size": 50005935
+            "size": 500059350016
         },
         {
             "name": "sdb", 
@@ -147,7 +147,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC38999L", 
-            "size": 25036243
+            "size": 250362438230
         },
         {
             "name": "sdd", 
@@ -161,7 +161,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC386666L", 
-            "size": 25036243
+            "size": 250362438230
         },
         {
             "name": "sde", 
@@ -175,7 +175,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC388888L", 
-            "size": 25036243
+            "size": 250362438230
         }
     ], 
     "constraint_map": {

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -30,8 +30,8 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersNoTags(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
-		{sizeInGB: 0}, //root disk
-		{"volume-1", 1954, nil},
+		{"root", 0, nil}, //root disk
+		{"1", 1954, nil},
 	})
 }
 
@@ -41,8 +41,8 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersWithTags(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
-		{sizeInGB: 0}, //root disk
-		{"volume-1", 1954, []string{"tag1", "tag2"}},
+		{"root", 0, nil}, //root disk
+		{"1", 1954, []string{"tag1", "tag2"}},
 	})
 }
 
@@ -64,14 +64,14 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 			Tag:        names.NewVolumeTag("1"),
 			HardwareId: "",
 			VolumeId:   "volume-1",
-			Size:       476893,
+			Size:       47,
 			Persistent: false,
 		},
 		{
 			Tag:        names.NewVolumeTag("2"),
 			HardwareId: "id_for_sdc",
 			VolumeId:   "volume-2",
-			Size:       238764,
+			Size:       23,
 			Persistent: false,
 		},
 	})
@@ -120,7 +120,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC38075L", 
-            "size": 250059350016
+            "size": 25005935
         }, 
         {
             "name": "sdb", 
@@ -133,7 +133,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_500GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC38076L", 
-            "size": 500059350016
+            "size": 50005935
         },
         {
             "name": "sdb", 
@@ -147,7 +147,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC38999L", 
-            "size": 250362438230
+            "size": 25036243
         },
         {
             "name": "sdd", 
@@ -161,7 +161,7 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC386666L", 
-            "size": 250362438230
+            "size": 25036243
         },
         {
             "name": "sde", 
@@ -175,14 +175,14 @@ var validVolumeJson = `
             "model": "Samsung_SSD_850_EVO_250GB", 
             "block_size": 4096, 
             "serial": "S21NNSAFC388888L", 
-            "size": 250362438230
+            "size": 25036243
         }
     ], 
     "constraint_map": {
         "1": "root",
-        "2": "volume-1",
-        "3": "volume-2",
-        "4": "volume-3"
+        "2": "1",
+        "3": "2",
+        "4": "3"
     }
 } 
 `[1:]

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -28,7 +28,7 @@ func setAgentStatus(u *Uniter, status params.Status, info string, data map[strin
 	}
 	u.lastReportedStatus = status
 	u.lastReportedMessage = info
-	logger.Debugf("[AGENT-STATUS] %s %s", status, info)
+	logger.Debugf("[AGENT-STATUS] %s: %s", status, info)
 	return u.unit.SetAgentStatus(status, info, data)
 }
 

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -227,7 +227,7 @@ func (ctx *HookContext) UnitStatus() (*jujuc.StatusInfo, error) {
 
 func (ctx *HookContext) SetUnitStatus(status jujuc.StatusInfo) error {
 	ctx.hasRunStatusSet = true
-	logger.Debugf("[WORKLOAD-STATUS] %s %s", status.Status, status.Info)
+	logger.Debugf("[WORKLOAD-STATUS] %s: %s", status.Status, status.Info)
 	return ctx.unit.SetUnitStatus(
 		params.Status(status.Status),
 		status.Info,


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1452745

Also, improve formatted on some log messages as a driveby.

Also, MAAS doesn't allow "-" in storage labels, so work around that issue.

(Review request: http://reviews.vapour.ws/r/1621/)