### PR TITLE
Cleanup after a failed deployment with storage

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -979,11 +979,8 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		return nil, err
 	}
 	if len(resultVolumes) != len(requestedVolumes) {
-		errToReturn := errors.New("the version of MAAS being used does not support Juju storage")
-		if err := environ.StopInstances(inst.Id()); err != nil {
-			logger.Warningf("error stopping instance %q after aborted deployment: %v", inst.Id(), err)
-		}
-		return nil, errToReturn
+		err = errors.New("the version of MAAS being used does not support Juju storage")
+		return nil, err
 	}
 
 	return &environs.StartInstanceResult{

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -978,6 +978,13 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	if err != nil {
 		return nil, err
 	}
+	if len(resultVolumes) != len(requestedVolumes) {
+		errToReturn := errors.New("the version of MAAS being used does not support Juju storage")
+		if err := environ.StopInstances(inst.Id()); err != nil {
+			logger.Warningf("error stopping instance %q after aborted deployment: %v", inst.Id(), err)
+		}
+		return nil, errToReturn
+	}
 
 	return &environs.StartInstanceResult{
 		Instance:          inst,


### PR DESCRIPTION
If a charm is deployed with MAAS storage on an older MAAS, an error is returned and the acquired node is stopped.

(Review request: http://reviews.vapour.ws/r/1625/)