### PR TITLE
Metrics - ignore duplicates.

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -869,8 +869,10 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatchPatch(c *gc.C) {
 			return nil
 		})
 
-	err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
+	results, err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[batch.UUID], gc.IsNil)
 	c.Assert(called, jc.IsTrue)
 }
 
@@ -893,8 +895,10 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatchFail(c *gc.C) {
 		Metrics:  metrics,
 	}
 
-	err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	results, err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[batch.UUID], gc.ErrorMatches, "permission denied")
 	c.Assert(called, jc.IsTrue)
 }
 
@@ -925,9 +929,11 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatchNotImplemented(c *gc.C) {
 		Metrics:  metrics,
 	}
 
-	err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
+	results, err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[batch.UUID], gc.IsNil)
 }
 
 func (s *unitMetricBatchesSuite) TestSendMetricBatch(c *gc.C) {
@@ -941,8 +947,10 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatch(c *gc.C) {
 		Metrics:  metrics,
 	}
 
-	err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
+	results, err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[batch.UUID], gc.IsNil)
 
 	batches, err := s.State.MetricBatches()
 	c.Assert(err, gc.IsNil)

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -578,15 +578,19 @@ func (ctx *HookContext) FlushContext(process string, ctxErr error) (err error) {
 		}
 		sendBatches = append(sendBatches, batchParam)
 	}
-	err = ctx.unit.AddMetricBatches(sendBatches)
+	results, err := ctx.unit.AddMetricBatches(sendBatches)
 	if err != nil {
+		// Do not return metric sending error.
 		logger.Errorf("%v", err)
-		return errors.Trace(err)
 	}
-	for _, batch := range sendBatches {
-		err = ctx.metricsReader.Remove(batch.UUID)
-		if err != nil {
-			return errors.Trace(err)
+	for batchUUID, resultErr := range results {
+		if resultErr == nil || resultErr == (*params.Error)(nil) || params.IsCodeAlreadyExists(resultErr) {
+			err = ctx.metricsReader.Remove(batchUUID)
+			if err != nil {
+				logger.Errorf("could not remove batch %q from spool: %v", batchUUID, err)
+			}
+		} else {
+			logger.Errorf("failed to send batch %q: %v", batchUUID, resultErr)
 		}
 	}
 	return ctxErr

--- a/worker/uniter/runner/export_test.go
+++ b/worker/uniter/runner/export_test.go
@@ -98,6 +98,17 @@ func PatchCachedStatus(ctx Context, status, info string, data map[string]interfa
 	}
 }
 
+// PatchMetricsReader patches the metrics reader used by the context with a new
+// object.
+func PatchMetricsReader(ctx Context, reader MetricsReader) func() {
+	hctx := ctx.(*HookContext)
+	oldReader := hctx.metricsReader
+	hctx.metricsReader = reader
+	return func() {
+		hctx.metricsReader = oldReader
+	}
+}
+
 func NewHookContext(
 	unit *uniter.Unit,
 	state *uniter.State,

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -108,6 +108,7 @@ type HookContextSuite struct {
 	uniter         *uniter.State
 	apiUnit        *uniter.Unit
 	meteredApiUnit *uniter.Unit
+	meteredCharm   *state.Charm
 	apiRelunits    map[int]*uniter.RelationUnit
 }
 
@@ -122,10 +123,10 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	s.service = s.AddTestingService(c, "u", sch)
 	s.unit = s.AddUnit(c, s.service)
 
-	meteredCharm := s.AddTestingCharm(c, "metered")
-	meteredService := s.AddTestingService(c, "m", meteredCharm)
+	s.meteredCharm = s.AddTestingCharm(c, "metered")
+	meteredService := s.AddTestingService(c, "m", s.meteredCharm)
 	meteredUnit := s.addUnit(c, meteredService)
-	err = meteredUnit.SetCharmURL(meteredCharm.URL())
+	err = meteredUnit.SetCharmURL(s.meteredCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
 	password, err := utils.RandomPassword()


### PR DESCRIPTION
In case the state server indicates that a metrics batch is a duplicate, the uniter will treat it as if the batch has been successfully sent.

(Review request: http://reviews.vapour.ws/r/1626/)