### PR TITLE
apiserver/meterstatus: Wrap meterstatus returns into API friendly

### DIFF
--- a/apiserver/meterstatus/meterstatus.go
+++ b/apiserver/meterstatus/meterstatus.go
@@ -1,0 +1,30 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package meterstatus provides functions for getting meterstatus information
+// about units.
+package meterstatus
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/state"
+)
+
+// MeterStatusWrapper takes a MeterStatus and converts it into an 'api friendly' where
+// Not Set and Not Available (which are important distinctions in state) are converted
+// into Amber and Red respecitvely in the api.
+func MeterStatusWrapper(getter func() (state.MeterStatus, error)) (state.MeterStatus, error) {
+	status, err := getter()
+	if err != nil {
+		return state.MeterStatus{}, errors.Trace(err)
+	}
+	if status.Code == state.MeterNotSet {
+		return state.MeterStatus{state.MeterAmber, "not set"}, nil
+	}
+	if status.Code == state.MeterNotAvailable {
+
+		return state.MeterStatus{state.MeterRed, "not available"}, nil
+	}
+	return status, nil
+}

--- a/apiserver/meterstatus/meterstatus.go
+++ b/apiserver/meterstatus/meterstatus.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// MeterStatusWrapper takes a MeterStatus and converts it into an 'api friendly' where
+// MeterStatusWrapper takes a MeterStatus and converts it into an 'api friendly' form where
 // Not Set and Not Available (which are important distinctions in state) are converted
 // into Amber and Red respecitvely in the api.
 func MeterStatusWrapper(getter func() (state.MeterStatus, error)) (state.MeterStatus, error) {

--- a/apiserver/meterstatus/meterstatus_test.go
+++ b/apiserver/meterstatus/meterstatus_test.go
@@ -1,0 +1,75 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus_test
+
+import (
+	"errors"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/meterstatus"
+	"github.com/juju/juju/state"
+)
+
+type meterStatusSuite struct{}
+
+var _ = gc.Suite(&meterStatusSuite{})
+
+func (s *meterStatusSuite) TestError(c *gc.C) {
+	_, err := meterstatus.MeterStatusWrapper(ErrorGetter)
+	c.Assert(err, gc.ErrorMatches, "an error")
+}
+
+func (s *meterStatusSuite) TestNotAvailable(c *gc.C) {
+	status, err := meterstatus.MeterStatusWrapper(NotAvailableGetter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Code, gc.Equals, state.MeterRed)
+	c.Assert(status.Info, gc.Equals, "not available")
+}
+
+func (s *meterStatusSuite) TestNotSet(c *gc.C) {
+	status, err := meterstatus.MeterStatusWrapper(NotSetGetter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Code, gc.Equals, state.MeterAmber)
+	c.Assert(status.Info, gc.Equals, "not set")
+}
+
+func (s *meterStatusSuite) TestColour(c *gc.C) {
+	status, err := meterstatus.MeterStatusWrapper(RedGetter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Code, gc.Equals, state.MeterRed)
+	c.Assert(status.Info, gc.Equals, "info")
+	status, err = meterstatus.MeterStatusWrapper(GreenGetter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Code, gc.Equals, state.MeterGreen)
+	c.Assert(status.Info, gc.Equals, "info")
+	status, err = meterstatus.MeterStatusWrapper(AmberGetter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Code, gc.Equals, state.MeterAmber)
+	c.Assert(status.Info, gc.Equals, "info")
+}
+
+func ErrorGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{}, errors.New("an error")
+}
+
+func NotAvailableGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterNotAvailable, ""}, nil
+}
+
+func NotSetGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterNotSet, ""}, nil
+}
+
+func RedGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterRed, "info"}, nil
+}
+
+func GreenGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterGreen, "info"}, nil
+}
+func AmberGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterAmber, "info"}, nil
+}

--- a/apiserver/meterstatus/package_test.go
+++ b/apiserver/meterstatus/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	leadershipapiserver "github.com/juju/juju/apiserver/leadership"
+	"github.com/juju/juju/apiserver/meterstatus"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/leadership"
 	"github.com/juju/juju/lease"
@@ -1231,7 +1232,7 @@ func (u *uniterBaseAPI) GetMeterStatus(args params.Entities) (params.MeterStatus
 			var unit *state.Unit
 			unit, err = u.getUnit(unitTag)
 			if err == nil {
-				status, err = unit.GetMeterStatus()
+				status, err = meterstatus.MeterStatusWrapper(unit.GetMeterStatus)
 			}
 			result.Results[i].Code = status.Code.String()
 			result.Results[i].Info = status.Info

--- a/apiserver/uniter/uniter_base_test.go
+++ b/apiserver/uniter/uniter_base_test.go
@@ -2171,8 +2171,8 @@ func (s *uniterBaseSuite) testGetMeterStatus(c *gc.C, facade getMeterStatus) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].Code, gc.Equals, "NOT SET")
-	c.Assert(result.Results[0].Info, gc.Equals, "")
+	c.Assert(result.Results[0].Code, gc.Equals, "AMBER")
+	c.Assert(result.Results[0].Info, gc.Equals, "not set")
 
 	newCode := "GREEN"
 	newInfo := "All is ok."


### PR DESCRIPTION
NotSet and NotAvailable meterstatus codes are not longer sent out over the api

(Review request: http://reviews.vapour.ws/r/1631/)