### PR TITLE
Support test tags.

### DIFF
--- a/testing/base.go
+++ b/testing/base.go
@@ -23,6 +23,13 @@ import (
 
 var logger = loggo.GetLogger("juju.testing")
 
+// Suite registers the provided suite with the test runner, but only
+// if the base test tags was passed at the commandline, which it is
+// by default.
+func Suite(suite interface{}) {
+	SuiteTagged(suite, TagBase)
+}
+
 // JujuOSEnvSuite isolates the tests from Juju environment variables.
 // This is intended to be only used by existing suites, usually embedded in
 // BaseSuite and in FakeJujuHomeSuite. Eventually the tests relying on

--- a/testing/tags.go
+++ b/testing/tags.go
@@ -1,0 +1,100 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+// These are common tags used in juju tests.
+const (
+	TagBase       = "base"
+	TagSmall      = "small"
+	TagMedium     = "medium"
+	TagLarge      = "large"
+	TagSmoke      = "smoke"      // Fast sanity-check.
+	TagExternal   = "external"   // Uses external resources.
+	TagFunctional = "functional" // Does not use test doubles for low-level.
+	TagCloud      = "cloud"      // Interacts with a cloud provider.
+	TagVM         = "vm"         // Runs in a local VM (e.g. kvm).
+)
+
+var defaultTags = []string{
+	TagBase,
+}
+
+var jujuTags []string
+
+func init() {
+	smoke := flag.Bool("smoke", false, "Run the basic set of fast tests.")
+	raw := flag.String("juju-tags", "", "Tagged tests to run.")
+	flag.Parse()
+
+	jujuTags = strings.Split(*raw, ",")
+	if *smoke {
+		jujuTags = append(jujuTags, TagSmoke)
+	}
+	if len(jujuTags) == 0 {
+		jujuTags = defaultTags
+	}
+
+	// TOOD(ericsnow) support impllied tags (e.g. VM -> Large)?
+}
+
+// CheckTag determines whether or not any of the given tags were passed
+// in at the commandline.
+func CheckTag(tags ...string) bool {
+	return MatchTag(tags...) != ""
+}
+
+// MatchTag returns the first provided tag that matches the ones passed
+// in at the commandline.
+func MatchTag(tags ...string) string {
+	for _, tag := range tags {
+		for _, jujuTag := range jujuTags {
+			if tag == jujuTag {
+				return tag
+			}
+		}
+	}
+	return ""
+}
+
+// RegisterPackageTagged registers the package for testing if any of the
+// given tags were passed in at the commandline.
+func RegisterPackageTagged(t *testing.T, tags ...string) {
+	if CheckTag(tags...) {
+		gc.TestingT(t)
+	}
+}
+
+// SuiteTagged registers the suite with the test runner if any of the
+// given tags were passed in at the commandline.
+func SuiteTagged(suite interface{}, tags ...string) {
+	if CheckTag(tags...) {
+		gc.Suite(suite)
+	}
+}
+
+// RequireTag causes a test or suite to skip if none of the given tags
+// were passed in at the commandline.
+func RequireTag(c *gc.C, tags ...string) {
+	if !CheckTag(tags...) {
+		c.Skip(fmt.Sprintf("skipping due to no matching tags (%v)", tags))
+	}
+}
+
+// SkipTag causes a test or suite to skip if any of the given tags were
+// passed in at the commandline.
+func SkipTag(c *gc.C, tags ...string) {
+	matched := MatchTag(tags...)
+	if matched != "" {
+		c.Skip(fmt.Sprintf("skipping due to %q tag", matched))
+	}
+}


### PR DESCRIPTION
Supported tags can be defined per package, suite, or test.  A number of meaningful tags are provided.  Also a base suite registration func (a la gc.Suite) is added that requires the default tag, "base".

A commandline option for tests, "--juju-tags", has been added.  The comma-separated list of tags there will determine which tests are run (for tests that check).  Using testing tags would look something like this:

    go test ./service --juju-tags small

A special option, "--smoke", has been added as a convenience:

    go test ./service --smoke

(Review request: http://reviews.vapour.ws/r/1634/)