### PR TITLE
Charm url master

### DIFF
--- a/apiserver/storage/package_test.go
+++ b/apiserver/storage/package_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/storage"
@@ -353,6 +354,10 @@ func (m *mockStorageInstance) Tag() names.Tag {
 
 func (m *mockStorageInstance) StorageTag() names.StorageTag {
 	return m.storageTag.(names.StorageTag)
+}
+
+func (m *mockStorageInstance) CharmURL() *charm.URL {
+	panic("not implemented for test")
 }
 
 type mockStorageAttachment struct {

--- a/state/service.go
+++ b/state/service.go
@@ -674,9 +674,10 @@ func (s *Service) unitStorageOps(unitName string) (ops []txn.Op, numStorageAttac
 		return nil, -1, err
 	}
 	meta := charm.Meta()
+	url := charm.URL()
 	tag := names.NewUnitTag(unitName)
 	// TODO(wallyworld) - record constraints info in data model - size and pool name
-	ops, numStorageAttachments, err = createStorageOps(s.st, tag, meta, cons)
+	ops, numStorageAttachments, err = createStorageOps(s.st, tag, meta, url, cons)
 	if err != nil {
 		return nil, -1, errors.Trace(err)
 	}

--- a/state/storage.go
+++ b/state/storage.go
@@ -912,7 +912,7 @@ func defaultStoragePool(cfg *config.Config, kind storage.StorageKind) (string, e
 // AddStorage adds StorageConstraints to
 // given entity dynamically, one storage directive at a time.
 func (st *State) AddStorageForUnit(
-	charmMeta *charm.Meta, u *Unit,
+	ch *Charm, u *Unit,
 	name string, cons StorageConstraints,
 ) error {
 	all, err := u.StorageConstraints()
@@ -933,7 +933,7 @@ func (st *State) AddStorageForUnit(
 	}
 	completeCons, err := storageConstraintsWithDefaults(
 		conf,
-		charmMeta.Storage[name],
+		ch.Meta().Storage[name],
 		name, cons,
 	)
 	if err != nil {
@@ -945,11 +945,11 @@ func (st *State) AddStorageForUnit(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		err = st.validateUnitStorage(charmMeta, u, name, completeCons)
+		err = st.validateUnitStorage(ch.Meta(), u, name, completeCons)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ops, err := st.constructAddUnitStorageOps(charmMeta, u, name, completeCons)
+		ops, err := st.constructAddUnitStorageOps(ch.Meta(), u, name, ch.URL(), completeCons)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -985,13 +985,14 @@ func (st *State) validateUnitStorage(
 }
 
 func (st *State) constructAddUnitStorageOps(
-	charmMeta *charm.Meta, u *Unit, name string, cons StorageConstraints,
+	charmMeta *charm.Meta, u *Unit, name string, curl *charm.URL, cons StorageConstraints,
 ) ([]txn.Op, error) {
 	// Create storage db operations
 	storageOps, _, err := createStorageOps(
 		st,
 		u.Tag(),
 		charmMeta,
+		curl,
 		map[string]StorageConstraints{name: cons})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/storage.go
+++ b/state/storage.go
@@ -50,6 +50,9 @@ type StorageInstance interface {
 
 	// Life reports whether the storage instance is Alive, Dying or Dead.
 	Life() Life
+
+	// CharmURL returns the charm URL that this storage instance was created with.
+	CharmURL() *charm.URL
 }
 
 // StorageAttachment represents the state of a unit's attachment to a storage
@@ -113,6 +116,11 @@ func (s *storageInstance) Life() Life {
 	return s.doc.Life
 }
 
+// CharmURL returns the charm URL that this storage instance was created with.
+func (s *storageInstance) CharmURL() *charm.URL {
+	return s.doc.CharmURL
+}
+
 // storageInstanceDoc describes a charm storage instance.
 type storageInstanceDoc struct {
 	DocID   string `bson:"_id"`
@@ -124,6 +132,7 @@ type storageInstanceDoc struct {
 	Owner           string      `bson:"owner"`
 	StorageName     string      `bson:"storagename"`
 	AttachmentCount int         `bson:"attachmentcount"`
+	CharmURL        *charm.URL  `bson:"charmurl"`
 }
 
 type storageAttachment struct {
@@ -291,6 +300,7 @@ func createStorageOps(
 	st *State,
 	entity names.Tag,
 	charmMeta *charm.Meta,
+	curl *charm.URL,
 	cons map[string]StorageConstraints,
 ) (ops []txn.Op, numStorageAttachments int, err error) {
 
@@ -357,6 +367,7 @@ func createStorageOps(
 				Kind:        kind,
 				Owner:       owner,
 				StorageName: t.storageName,
+				CharmURL:    curl,
 			}
 			if unit, ok := entity.(names.UnitTag); ok {
 				doc.AttachmentCount = 1

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -44,14 +44,14 @@ func (s *StorageAddSuite) assertStorageCount(c *gc.C, expected int) {
 func (s *StorageAddSuite) TestAddStorageToUnit(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
 }
 
 func (s *StorageAddSuite) TestAddStorageWithCount(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+2)
 }
@@ -59,13 +59,13 @@ func (s *StorageAddSuite) TestAddStorageWithCount(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+2)
 
 	// Should not succeed as the number of storages after
 	// this call would be 11 whereas our upper limit is 10 here.
-	err = s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
+	err = s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified.*`)
 	s.assertStorageCount(c, s.originalStorageCount+2)
 }
@@ -77,7 +77,7 @@ func (s *StorageAddSuite) TestAddStorageExceedCount(c *gc.C) {
 	ch, _, err := service.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.AddStorageForUnit(ch.Meta(), u, "data", makeStorageCons("loop-pool", 1024, 1))
+	err = s.State.AddStorageForUnit(ch, u, "data", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block" store "data": at most 1 instances supported, 2 specified.*`)
 	s.assertStorageCount(c, 1)
 }
@@ -89,7 +89,7 @@ func (s *StorageAddSuite) TestAddStorageMinCount(c *gc.C) {
 	ch, _, err := service.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.AddStorageForUnit(ch.Meta(), u, "allecto", makeStorageCons("loop-pool", 1024, 1))
+	err = s.State.AddStorageForUnit(ch, u, "allecto", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, 2)
 }
@@ -97,7 +97,7 @@ func (s *StorageAddSuite) TestAddStorageMinCount(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", state.StorageConstraints{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
 }
@@ -105,7 +105,7 @@ func (s *StorageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageDiffPool(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
 }
@@ -113,7 +113,7 @@ func (s *StorageAddSuite) TestAddStorageDiffPool(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageDiffSize(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Size: 2048})
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", state.StorageConstraints{Size: 2048})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
 }
@@ -121,7 +121,7 @@ func (s *StorageAddSuite) TestAddStorageDiffSize(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi2up", state.StorageConstraints{Size: 2})
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "multi2up", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 2.0MB specified.*`)
 	s.assertStorageCount(c, s.originalStorageCount)
 }
@@ -129,7 +129,7 @@ func (s *StorageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageWrongName(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "furball", state.StorageConstraints{Size: 2})
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "furball", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm storage "furball" not found.*`)
 	s.assertStorageCount(c, s.originalStorageCount)
 }
@@ -137,7 +137,7 @@ func (s *StorageAddSuite) TestAddStorageWrongName(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageConcurrently(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 	addStorage := func() {
-		err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
+		err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", state.StorageConstraints{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
@@ -150,11 +150,11 @@ func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
 
 	count := 6
 	addStorage := func() {
-		err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+		err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+	err := s.State.AddStorageForUnit(s.charm, s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 15 specified.*`)
 
 	// Only "count" number of instances should have been added.

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -240,6 +240,7 @@ func (s *StorageStateSuite) assertStorageUnitsAdded(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			count[storageInstance.StorageName()]++
 			c.Assert(storageInstance.Kind(), gc.Equals, state.StorageKindBlock)
+			c.Assert(storageInstance.CharmURL(), gc.DeepEquals, ch.URL())
 		}
 		c.Assert(count, gc.DeepEquals, map[string]int{
 			"multi1to10": 1,


### PR DESCRIPTION
This is a forward port of storage creation with charm url.

Dynamically adding unit storage was changed to accept charm - instead of just charm metadata - to allow deduction of url and metadata.


(Review request: http://reviews.vapour.ws/r/1636/)