### PR TITLE
provider/openstack: wait for volume provisioning

### DIFF
--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -81,8 +81,14 @@ func (s *cinderVolumeSourceSuite) TestCreateVolume(c *gc.C) {
 				Name: "volume-123",
 			})
 			return &cinder.Volume{
-				ID:   mockVolId,
-				Size: providedSize / 1024,
+				ID: mockVolId,
+			}, nil
+		},
+		getVolume: func(volumeId string) (*cinder.Volume, error) {
+			return &cinder.Volume{
+				ID:     volumeId,
+				Size:   providedSize / 1024,
+				Status: "available",
 			}, nil
 		},
 		attachVolume: func(serverId, volId, mountPoint string) (*nova.VolumeAttachment, error) {
@@ -306,6 +312,7 @@ func (s *cinderVolumeSourceSuite) TestCreateVolumeCleanupDestroys(c *gc.C) {
 }
 
 type mockAdapter struct {
+	getVolume             func(string) (*cinder.Volume, error)
 	getVolumesSimple      func() ([]cinder.Volume, error)
 	deleteVolume          func(string) error
 	createVolume          func(cinder.CreateVolumeVolumeParams) (*cinder.Volume, error)
@@ -313,6 +320,16 @@ type mockAdapter struct {
 	volumeStatusNotifier  func(string, string, int, time.Duration) <-chan error
 	detachVolume          func(string, string) error
 	listVolumeAttachments func(string) ([]nova.VolumeAttachment, error)
+}
+
+func (ma *mockAdapter) GetVolume(volumeId string) (*cinder.Volume, error) {
+	if ma.getVolume != nil {
+		return ma.getVolume(volumeId)
+	}
+	return &cinder.Volume{
+		ID:     volumeId,
+		Status: "available",
+	}, nil
 }
 
 func (ma *mockAdapter) GetVolumesSimple() ([]cinder.Volume, error) {
@@ -341,15 +358,6 @@ func (ma *mockAdapter) AttachVolume(serverId, volumeId, mountPoint string) (*nov
 		return ma.attachVolume(serverId, volumeId, mountPoint)
 	}
 	return nil, errors.NotImplementedf("AttachVolume")
-}
-
-func (ma *mockAdapter) VolumeStatusNotifier(volId, status string, numAttempts int, waitDur time.Duration) <-chan error {
-	if ma.volumeStatusNotifier != nil {
-		return ma.volumeStatusNotifier(volId, status, numAttempts, waitDur)
-	}
-	emptyChan := make(chan error)
-	close(emptyChan)
-	return emptyChan
 }
 
 func (ma *mockAdapter) DetachVolume(serverId, attachmentId string) error {

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -37,6 +37,7 @@ func init() {
 var (
 	ShortAttempt   = &shortAttempt
 	StorageAttempt = &storageAttempt
+	CinderAttempt  = &cinderAttempt
 )
 
 // MetadataStorage returns a Storage instance which is used to store simplestreams metadata for tests.


### PR DESCRIPTION
When we issue a CreateVolume to Cinder, Cinder will
(or may?) return incomplete information about the
volume, lacking status or size, for example. We must
wait for the volume to transition to or past "creating",
so it has a size that we can record in state.

Fixes https://bugs.launchpad.net/bugs/1450740

(Review request: http://reviews.vapour.ws/r/1638/)