### PR TITLE
Use the fixed shell.Renderer.RedirectOutput.

### DIFF
--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -873,6 +873,6 @@ values:
 
 "@
 cmd.exe /C mklink /D C:\Juju\lib\juju\tools\machine-10 1.2.3-win8-amd64
-New-Service -Credential $jujuCreds -Name 'jujud-machine-10' -DisplayName 'juju agent for machine-10' '''C:\Juju\lib\juju\tools\machine-10\jujud.exe'' machine --data-dir ''C:\Juju\lib\juju'' --machine-id 10 --debug'
+New-Service -Credential $jujuCreds -Name 'jujud-machine-10' -DisplayName 'juju agent for machine-10' '"C:\Juju\lib\juju\tools\machine-10\jujud.exe" machine --data-dir "C:\Juju\lib\juju" --machine-id 10 --debug'
 cmd.exe /C sc config 'jujud-machine-10' start=delayed-auto
 Start-Service 'jujud-machine-10'`

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -29,7 +29,7 @@ github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-30T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	a3720f880a5787622a21fbf718a3ac9d551dbe9c	2015-04-10T20:58:11Z
 github.com/juju/txn	git	2407a1fa094db5603f4718f11e1fafc8543273eb	2015-03-27T20:47:42Z
-github.com/juju/utils	git	74de2af2d82f17a3e8d12c9aa50af256c9a74ab9	2015-04-16T15:03:20Z
+github.com/juju/utils	git	4a0d9395ff427578c988ffc7709a17dd4608231e	2015-05-08T17:09:17Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	7dbad50ab5b31073856416cdcfeb2796d682f844	2015-03-20T03:46:21Z

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -42,12 +42,6 @@ type confRenderer interface {
 	shell.ScriptRenderer
 }
 
-func redirectOutput(cr confRenderer, filename string) []string {
-	// TODO(ericsnow) This should be fixed in utils/shell.
-	cmd := cr.RedirectOutput(filename)[0]
-	return []string{strings.Replace(cmd, ">", ">>", -1)}
-}
-
 func syslogUserGroup() (string, string) {
 	var user, group string
 	switch version.Current.OS {
@@ -76,7 +70,7 @@ func normalize(name string, conf common.Conf, scriptPath string, renderer confRe
 		user, group := syslogUserGroup()
 		cmds = append(cmds, renderer.Chown(filename, user, group)...)
 		cmds = append(cmds, renderer.Chmod(filename, 0600)...)
-		cmds = append(cmds, redirectOutput(renderer, filename)...)
+		cmds = append(cmds, renderer.RedirectOutput(filename)...)
 		cmds = append(cmds, renderer.RedirectFD("out", "err")...)
 		cmds = append(cmds,
 			"",


### PR DESCRIPTION
A previous patch put a workaround hack in place. This patch fixes it.

(Review request: http://reviews.vapour.ws/r/1632/)