### PR TITLE
cmd/jujud/agent: only attempt mongodb upgrade tasks if mongodb service is installed

### DIFF
--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -43,8 +43,10 @@ type patchingSuite interface {
 // out replicaset.CurrentConfig and cmdutil.EnsureMongoServer.
 func InstallFakeEnsureMongo(suite patchingSuite) *FakeEnsureMongo {
 	f := &FakeEnsureMongo{
+		ServiceInstalled:    true,
 		ReplicasetInitiated: true,
 	}
+	suite.PatchValue(&mongo.IsServiceInstalled, f.IsServiceInstalled)
 	suite.PatchValue(&replicaset.CurrentConfig, f.CurrentConfig)
 	suite.PatchValue(&cmdutil.EnsureMongoServer, f.EnsureMongo)
 	return f
@@ -61,7 +63,12 @@ type FakeEnsureMongo struct {
 	Info                state.StateServingInfo
 	InitiateParams      peergrouper.InitiateMongoParams
 	Err                 error
+	ServiceInstalled    bool
 	ReplicasetInitiated bool
+}
+
+func (f *FakeEnsureMongo) IsServiceInstalled(string) (bool, error) {
+	return f.ServiceInstalled, nil
 }
 
 func (f *FakeEnsureMongo) CurrentConfig(*mgo.Session) (*jujureplicaset.Config, error) {

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -67,6 +67,18 @@ var discoverService = func(name string) (mongoService, error) {
 	return service.DiscoverService(name, common.Conf{})
 }
 
+// IsServiceInstalled returns whether the MongoDB init service
+// configuration is present.
+var IsServiceInstalled = isServiceInstalled
+
+func isServiceInstalled(namespace string) (bool, error) {
+	svc, err := discoverService(ServiceName(namespace))
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return svc.Installed()
+}
+
 // RemoveService removes the mongoDB init service from this machine.
 func RemoveService(namespace string) error {
 	svc, err := discoverService(ServiceName(namespace))

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service/common"
+	svctesting "github.com/juju/juju/service/common/testing"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -53,4 +54,25 @@ func (s *serviceSuite) TestNewConf(c *gc.C) {
 	}
 	c.Check(conf, jc.DeepEquals, expected)
 	c.Check(strings.Fields(conf.ExecStart), jc.DeepEquals, strings.Fields(expected.ExecStart))
+}
+
+func (s *serviceSuite) TestIsServiceInstalledWhenInstalled(c *gc.C) {
+	namespace := "some-namespace"
+	svcData := svctesting.NewFakeServiceData()
+	svcData.InstalledNames.Add(mongo.ServiceName(namespace))
+	mongo.PatchService(s.PatchValue, svcData)
+
+	isInstalled, err := mongo.IsServiceInstalled(namespace)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isInstalled, jc.IsTrue)
+}
+
+func (s *serviceSuite) TestIsServiceInstalledWhenNotInstalled(c *gc.C) {
+	mongo.PatchService(s.PatchValue, svctesting.NewFakeServiceData())
+
+	isInstalled, err := mongo.IsServiceInstalled("some-namespace")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isInstalled, jc.IsFalse)
 }


### PR DESCRIPTION
When a new state server is added the mongodb init service won't be installed when jujud first starts. In this case don't attempt to add the mongo admin user or check the replicaset state - mongodb won't be running.

Fixes LP #1453805.

(Review request: http://reviews.vapour.ws/r/1654/)