### PR TITLE
cmd/jujud/agent: only attempt mongodb upgrade tasks if mongodb service is installed

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1244,38 +1244,47 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 	// required when upgrading from a pre-HA-capable
 	// environment. These calls won't do anything if the thing they
 	// need to set up has already been done.
-
-	if _, err := a.ensureMongoAdminUser(agentConfig); err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := a.ensureMongoSharedSecret(agentConfig); err != nil {
-		return errors.Trace(err)
-	}
-	agentConfig = a.CurrentConfig() // ensureMongoSharedSecret may have updated the config
-
-	mongoInfo, ok := agentConfig.MongoInfo()
-	if !ok {
-		return errors.New("unable to retrieve mongo info to check replicaset")
-	}
-
-	haveReplicaset, err := isReplicasetConfigured(mongoInfo)
-	if err != nil {
-		return errors.Annotate(err, "error while checking replicaset")
-	}
-
-	// If the replicaset is to be initialised the machine addresses
-	// need to be retrieved *before* MongoDB is restarted with the
-	// --replset option (in EnsureMongoServer). Once MongoDB is
-	// started with --replset it won't respond to queries until the
-	// replicaset is initiated.
+	var needReplicasetInit = false
 	var machineAddrs []network.Address
-	if !haveReplicaset {
-		logger.Infof("replicaset not yet configured")
 
-		machineAddrs, err = getMachineAddresses(agentConfig)
-		if err != nil {
+	mongoInstalled, err := mongo.IsServiceInstalled(agentConfig.Value(agent.Namespace))
+	if err != nil {
+		return errors.Annotate(err, "error while checking if mongodb service is installed")
+	}
+
+	if mongoInstalled {
+		logger.Debugf("mongodb service is installed")
+
+		if _, err := a.ensureMongoAdminUser(agentConfig); err != nil {
 			return errors.Trace(err)
+		}
+
+		if err := a.ensureMongoSharedSecret(agentConfig); err != nil {
+			return errors.Trace(err)
+		}
+		agentConfig = a.CurrentConfig() // ensureMongoSharedSecret may have updated the config
+
+		mongoInfo, ok := agentConfig.MongoInfo()
+		if !ok {
+			return errors.New("unable to retrieve mongo info to check replicaset")
+		}
+
+		needReplicasetInit, err = isReplicasetInitNeeded(mongoInfo)
+		if err != nil {
+			return errors.Annotate(err, "error while checking replicaset")
+		}
+
+		// If the replicaset is to be initialised the machine addresses
+		// need to be retrieved *before* MongoDB is restarted with the
+		// --replset option (in EnsureMongoServer). Once MongoDB is
+		// started with --replset it won't respond to queries until the
+		// replicaset is initiated.
+		if needReplicasetInit {
+			logger.Infof("replicaset not yet configured")
+			machineAddrs, err = getMachineAddresses(agentConfig)
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 
@@ -1288,11 +1297,15 @@ func (a *MachineAgent) ensureMongoServer(agentConfig agent.Config) (err error) {
 		return err
 	}
 
-	// Create the replicaset it hasn't been set up yet.
-	if !haveReplicaset {
+	// Initiate the replicaset if required.
+	if needReplicasetInit {
 		servingInfo, ok := agentConfig.StateServingInfo()
 		if !ok {
 			return stateWorkerServingConfigErr
+		}
+		mongoInfo, ok := agentConfig.MongoInfo()
+		if !ok {
+			return errors.New("unable to retrieve mongo info to initiate replicaset")
 		}
 		if err := initiateReplicaSet(mongoInfo, servingInfo.StatePort, machineAddrs); err != nil {
 			return err
@@ -1376,9 +1389,9 @@ func (a *MachineAgent) ensureMongoSharedSecret(agentConfig agent.Config) error {
 	return nil
 }
 
-// isReplicasetConfigured returns true if the replicaset has been
-// successfully initiated.
-func isReplicasetConfigured(mongoInfo *mongo.MongoInfo) (bool, error) {
+// isReplicasetInitNeeded returns true if the replicaset needs to be
+// initiated.
+func isReplicasetInitNeeded(mongoInfo *mongo.MongoInfo) (bool, error) {
 	dialInfo, err := mongo.DialInfo(mongoInfo.Info, mongo.DefaultDialOpts())
 	if err != nil {
 		return false, errors.Annotate(err, "cannot generate dial info to check replicaset")
@@ -1395,11 +1408,11 @@ func isReplicasetConfigured(mongoInfo *mongo.MongoInfo) (bool, error) {
 	cfg, err := replicaset.CurrentConfig(session)
 	if err != nil {
 		logger.Debugf("couldn't retrieve replicaset config (not fatal): %v", err)
-		return false, nil
+		return true, nil
 	}
 	numMembers := len(cfg.Members)
 	logger.Debugf("replicaset member count: %d", numMembers)
-	return numMembers > 0, nil
+	return numMembers < 1, nil
 }
 
 // getMachineAddresses connects to state to determine the machine's

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1482,6 +1482,7 @@ func (s *MachineSuite) TestMachineAgentUpgradeMongo(c *gc.C) {
 	err = s.State.MongoSession().DB("admin").RemoveUser(m.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.fakeEnsureMongo.ServiceInstalled = true
 	s.fakeEnsureMongo.ReplicasetInitiated = false
 
 	s.AgentSuite.PatchValue(&ensureMongoAdminUser, func(p mongo.EnsureAdminUserParams) (bool, error) {
@@ -1619,6 +1620,25 @@ func (s *MachineSuite) TestReplicasetAlreadyInitiated(c *gc.C) {
 		c.Skip("state servers on windows aren't supported")
 	}
 
+	s.fakeEnsureMongo.ReplicasetInitiated = true
+
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	agentConfig := a.CurrentConfig()
+
+	err := a.ensureMongoServer(agentConfig)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)
+	c.Assert(s.fakeEnsureMongo.InitiateCount, gc.Equals, 0)
+}
+
+func (s *MachineSuite) TestReplicasetInitForNewStateServer(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("state servers on windows aren't supported")
+	}
+
+	s.fakeEnsureMongo.ServiceInstalled = false
 	s.fakeEnsureMongo.ReplicasetInitiated = true
 
 	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -39,8 +39,10 @@ type patchingSuite interface {
 // out replicaset.CurrentConfig and cmdutil.EnsureMongoServer.
 func InstallFakeEnsureMongo(suite patchingSuite) *FakeEnsureMongo {
 	f := &FakeEnsureMongo{
+		ServiceInstalled:    true,
 		ReplicasetInitiated: true,
 	}
+	suite.PatchValue(&mongo.IsServiceInstalled, f.IsServiceInstalled)
 	suite.PatchValue(&replicaset.CurrentConfig, f.CurrentConfig)
 	suite.PatchValue(&cmdutil.EnsureMongoServer, f.EnsureMongo)
 	return f
@@ -57,7 +59,12 @@ type FakeEnsureMongo struct {
 	Info                state.StateServingInfo
 	InitiateParams      peergrouper.InitiateMongoParams
 	Err                 error
+	ServiceInstalled    bool
 	ReplicasetInitiated bool
+}
+
+func (f *FakeEnsureMongo) IsServiceInstalled(string) (bool, error) {
+	return f.ServiceInstalled, nil
 }
 
 func (f *FakeEnsureMongo) CurrentConfig(*mgo.Session) (*replicaset.Config, error) {

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -67,6 +67,18 @@ var discoverService = func(name string) (mongoService, error) {
 	return service.DiscoverService(name, common.Conf{})
 }
 
+// IsServiceInstalled returns whether the MongoDB init service
+// configuration is present.
+var IsServiceInstalled = isServiceInstalled
+
+func isServiceInstalled(namespace string) (bool, error) {
+	svc, err := discoverService(ServiceName(namespace))
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return svc.Installed()
+}
+
 // RemoveService removes the mongoDB init service from this machine.
 func RemoveService(namespace string) error {
 	svc, err := discoverService(ServiceName(namespace))

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service/common"
+	svctesting "github.com/juju/juju/service/common/testing"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -53,4 +54,25 @@ func (s *serviceSuite) TestNewConf(c *gc.C) {
 	}
 	c.Check(conf, jc.DeepEquals, expected)
 	c.Check(strings.Fields(conf.ExecStart), jc.DeepEquals, strings.Fields(expected.ExecStart))
+}
+
+func (s *serviceSuite) TestIsServiceInstalledWhenInstalled(c *gc.C) {
+	namespace := "some-namespace"
+	svcData := svctesting.NewFakeServiceData()
+	svcData.InstalledNames.Add(mongo.ServiceName(namespace))
+	mongo.PatchService(s.PatchValue, svcData)
+
+	isInstalled, err := mongo.IsServiceInstalled(namespace)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isInstalled, jc.IsTrue)
+}
+
+func (s *serviceSuite) TestIsServiceInstalledWhenNotInstalled(c *gc.C) {
+	mongo.PatchService(s.PatchValue, svctesting.NewFakeServiceData())
+
+	isInstalled, err := mongo.IsServiceInstalled("some-namespace")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isInstalled, jc.IsFalse)
 }


### PR DESCRIPTION
When a new state server is added the mongodb init service won't be installed when jujud first starts. In this case don't attempt to add the mongo admin user or check the replicaset state - mongodb won't be running.

Fixes LP #1453805.

(Review request: http://reviews.vapour.ws/r/1655/)