### PR TITLE
Adds all certs from /etc/juju/certs.d to the cert pool.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -217,12 +217,10 @@ func Connect(info *Info, pathTail string, header http.Header, opts DialOpts) (*w
 		return nil, errors.New(`path tail must start with "/"`)
 	}
 
-	pool := x509.NewCertPool()
-	xcert, err := cert.ParseCert(info.CACert)
+	pool, err := CreateCertPool(info.CACert)
 	if err != nil {
 		return nil, errors.Annotate(err, "cert pool creation failed")
 	}
-	pool.AddCert(xcert)
 
 	// If they exist, only use localhost addresses.
 	var addrs []string

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/net/websocket"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cert"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"

--- a/api/certpool.go
+++ b/api/certpool.go
@@ -18,6 +18,9 @@ import (
 
 var certDir = filepath.FromSlash(paths.MustSucceed(paths.CertDir(version.Current.Series)))
 
+// CreateCertPool creates a new x509.CertPool and adds in the caCert passed
+// in.  All certs from the cert directory (/etc/juju/cert.d on ubuntu) are
+// also added.
 func CreateCertPool(caCert string) (*x509.CertPool, error) {
 
 	pool := x509.NewCertPool()
@@ -31,7 +34,7 @@ func CreateCertPool(caCert string) (*x509.CertPool, error) {
 
 	count := processCertDir(pool)
 	if count >= 0 {
-		logger.Tracef("added %d certs to the pool from %s", count, certDir)
+		logger.Debugf("added %d certs to the pool from %s", count, certDir)
 	}
 
 	return pool, nil

--- a/api/certpool.go
+++ b/api/certpool.go
@@ -1,0 +1,79 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cert"
+	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/version"
+)
+
+var certDir = filepath.FromSlash(paths.MustSucceed(paths.CertDir(version.Current.Series)))
+
+func CreateCertPool(caCert string) (*x509.CertPool, error) {
+
+	pool := x509.NewCertPool()
+	if caCert != "" {
+		xcert, err := cert.ParseCert(caCert)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		pool.AddCert(xcert)
+	}
+
+	count := processCertDir(pool)
+	if count >= 0 {
+		logger.Tracef("added %d certs to the pool from %s", count, certDir)
+	}
+
+	return pool, nil
+}
+
+// processCertDir iterates through the certDir looking for *.pem files.
+// Each pem file is read in turn and added to the pool.  A count of the number
+// of successful certificates processed is returned.
+func processCertDir(pool *x509.CertPool) (count int) {
+	fileInfo, err := os.Stat(certDir)
+	if os.IsNotExist(err) {
+		logger.Tracef("cert dir %q does not exist", certDir)
+		return -1
+	}
+	if err != nil {
+		logger.Infof("unexpected error reading cert dir: %s", err)
+		return -1
+	}
+	if !fileInfo.IsDir() {
+		logger.Infof("cert dir %q is not a directory", certDir)
+		return -1
+	}
+
+	matches, err := filepath.Glob(filepath.Join(certDir, "*.pem"))
+	if err != nil {
+		logger.Infof("globbing files failed: %s", err)
+		return -1
+	}
+
+	for _, match := range matches {
+		data, err := ioutil.ReadFile(match)
+		if err != nil {
+			logger.Infof("error reading %q: %v", match, err)
+			continue
+		}
+		certificate, err := cert.ParseCert(string(data))
+		if err != nil {
+			logger.Infof("error parsing cert %q: %v", match, err)
+			continue
+		}
+		pool.AddCert(certificate)
+		count++
+	}
+	return count
+}

--- a/api/certpool_test.go
+++ b/api/certpool_test.go
@@ -1,0 +1,144 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/cert"
+	"github.com/juju/juju/testing"
+)
+
+type certPoolSuite struct {
+	testing.BaseSuite
+	logs *certLogs
+}
+
+var _ = gc.Suite(&certPoolSuite{})
+
+func (s *certPoolSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.logs = &certLogs{}
+	loggo.GetLogger("juju.api").SetLogLevel(loggo.TRACE)
+	loggo.RegisterWriter("api-certs", s.logs, loggo.TRACE)
+}
+
+func (*certPoolSuite) TestCreateCertPoolNoCert(c *gc.C) {
+	pool, err := api.CreateCertPool("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pool.Subjects(), gc.HasLen, 0)
+}
+
+func (*certPoolSuite) TestCreateCertPoolTestCert(c *gc.C) {
+	pool, err := api.CreateCertPool(testing.CACert)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pool.Subjects(), gc.HasLen, 1)
+}
+
+func (s *certPoolSuite) TestCreateCertPoolNoDir(c *gc.C) {
+	certDir := filepath.Join(c.MkDir(), "missing")
+	s.PatchValue(api.CertDir, certDir)
+
+	pool, err := api.CreateCertPool("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pool.Subjects(), gc.HasLen, 0)
+
+	c.Assert(s.logs.messages, gc.HasLen, 1)
+	// The directory not existing is likely to happen a lot, so it is only
+	// logged out at trace to help be explicit in the case where detailed
+	// debugging is needed.
+	c.Assert(s.logs.messages[0], gc.Matches, `TRACE cert dir ".*" does not exist`)
+}
+
+func (s *certPoolSuite) TestCreateCertPoolNotADir(c *gc.C) {
+	certDir := filepath.Join(c.MkDir(), "missing")
+	s.PatchValue(api.CertDir, certDir)
+	// Make the certDir a file instead...
+	c.Assert(ioutil.WriteFile(certDir, []byte("blah"), 0644), jc.ErrorIsNil)
+
+	pool, err := api.CreateCertPool("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pool.Subjects(), gc.HasLen, 0)
+
+	c.Assert(s.logs.messages, gc.HasLen, 1)
+	c.Assert(s.logs.messages[0], gc.Matches, `INFO cert dir ".*" is not a directory`)
+}
+
+func (s *certPoolSuite) TestCreateCertPoolEmptyDir(c *gc.C) {
+	certDir := c.MkDir()
+	s.PatchValue(api.CertDir, certDir)
+
+	pool, err := api.CreateCertPool("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pool.Subjects(), gc.HasLen, 0)
+	c.Assert(s.logs.messages, gc.HasLen, 1)
+	c.Assert(s.logs.messages[0], gc.Matches, `TRACE added 0 certs to the pool from .*`)
+}
+
+func (s *certPoolSuite) TestCreateCertPoolLoadsPEMFiles(c *gc.C) {
+	certDir := c.MkDir()
+	s.PatchValue(api.CertDir, certDir)
+	s.addCert(c, filepath.Join(certDir, "first.pem"))
+	s.addCert(c, filepath.Join(certDir, "second.pem"))
+	s.addCert(c, filepath.Join(certDir, "third.pem"))
+
+	pool, err := api.CreateCertPool("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pool.Subjects(), gc.HasLen, 3)
+	c.Assert(s.logs.messages, gc.HasLen, 1)
+	c.Assert(s.logs.messages[0], gc.Matches, `TRACE added 3 certs to the pool from .*`)
+}
+
+func (s *certPoolSuite) TestCreateCertPoolLoadsOnlyPEMFiles(c *gc.C) {
+	certDir := c.MkDir()
+	s.PatchValue(api.CertDir, certDir)
+	s.addCert(c, filepath.Join(certDir, "first.pem"))
+	c.Assert(ioutil.WriteFile(filepath.Join(certDir, "second.cert"), []byte("blah"), 0644), jc.ErrorIsNil)
+
+	pool, err := api.CreateCertPool("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pool.Subjects(), gc.HasLen, 1)
+	c.Assert(s.logs.messages, gc.HasLen, 1)
+	c.Assert(s.logs.messages[0], gc.Matches, `TRACE added 1 certs to the pool from .*`)
+}
+
+func (s *certPoolSuite) TestCreateCertPoolLogsBadCerts(c *gc.C) {
+	certDir := c.MkDir()
+	s.PatchValue(api.CertDir, certDir)
+	c.Assert(ioutil.WriteFile(filepath.Join(certDir, "broken.pem"), []byte("blah"), 0644), jc.ErrorIsNil)
+
+	pool, err := api.CreateCertPool("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pool.Subjects(), gc.HasLen, 0)
+	c.Assert(s.logs.messages, gc.HasLen, 2)
+	c.Assert(s.logs.messages[0], gc.Matches, `INFO error parsing cert ".*broken.pem": .*`)
+	c.Assert(s.logs.messages[1], gc.Matches, `TRACE added 0 certs to the pool from .*`)
+}
+
+func (s *certPoolSuite) addCert(c *gc.C, filename string) {
+	expiry := time.Now().UTC().AddDate(10, 0, 0)
+	pem, _, err := cert.NewCA("random env name", expiry)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(filename, []byte(pem), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type certLogs struct {
+	messages []string
+}
+
+func (c *certLogs) Write(level loggo.Level, name, filename string, line int, timestamp time.Time, message string) {
+	if strings.HasSuffix(filename, "certpool.go") {
+		c.messages = append(c.messages, fmt.Sprintf("%s %s", level, message))
+	}
+}

--- a/api/certpool_test.go
+++ b/api/certpool_test.go
@@ -82,7 +82,7 @@ func (s *certPoolSuite) TestCreateCertPoolEmptyDir(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pool.Subjects(), gc.HasLen, 0)
 	c.Assert(s.logs.messages, gc.HasLen, 1)
-	c.Assert(s.logs.messages[0], gc.Matches, `TRACE added 0 certs to the pool from .*`)
+	c.Assert(s.logs.messages[0], gc.Matches, `DEBUG added 0 certs to the pool from .*`)
 }
 
 func (s *certPoolSuite) TestCreateCertPoolLoadsPEMFiles(c *gc.C) {
@@ -96,7 +96,7 @@ func (s *certPoolSuite) TestCreateCertPoolLoadsPEMFiles(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pool.Subjects(), gc.HasLen, 3)
 	c.Assert(s.logs.messages, gc.HasLen, 1)
-	c.Assert(s.logs.messages[0], gc.Matches, `TRACE added 3 certs to the pool from .*`)
+	c.Assert(s.logs.messages[0], gc.Matches, `DEBUG added 3 certs to the pool from .*`)
 }
 
 func (s *certPoolSuite) TestCreateCertPoolLoadsOnlyPEMFiles(c *gc.C) {
@@ -109,7 +109,7 @@ func (s *certPoolSuite) TestCreateCertPoolLoadsOnlyPEMFiles(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pool.Subjects(), gc.HasLen, 1)
 	c.Assert(s.logs.messages, gc.HasLen, 1)
-	c.Assert(s.logs.messages[0], gc.Matches, `TRACE added 1 certs to the pool from .*`)
+	c.Assert(s.logs.messages[0], gc.Matches, `DEBUG added 1 certs to the pool from .*`)
 }
 
 func (s *certPoolSuite) TestCreateCertPoolLogsBadCerts(c *gc.C) {
@@ -122,7 +122,7 @@ func (s *certPoolSuite) TestCreateCertPoolLogsBadCerts(c *gc.C) {
 	c.Assert(pool.Subjects(), gc.HasLen, 0)
 	c.Assert(s.logs.messages, gc.HasLen, 2)
 	c.Assert(s.logs.messages[0], gc.Matches, `INFO error parsing cert ".*broken.pem": .*`)
-	c.Assert(s.logs.messages[1], gc.Matches, `TRACE added 0 certs to the pool from .*`)
+	c.Assert(s.logs.messages[1], gc.Matches, `DEBUG added 0 certs to the pool from .*`)
 }
 
 func (s *certPoolSuite) addCert(c *gc.C, filename string) {

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 var (
+	CertDir               = &certDir
 	NewWebsocketDialer    = newWebsocketDialer
 	NewWebsocketDialerPtr = &newWebsocketDialer
 	WebsocketDialConfig   = &websocketDialConfig

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -17,6 +17,7 @@ const (
 	logDir
 	dataDir
 	jujuRun
+	certDir
 )
 
 var nixVals = map[osVarType]string{
@@ -24,6 +25,7 @@ var nixVals = map[osVarType]string{
 	logDir:  "/var/log",
 	dataDir: "/var/lib/juju",
 	jujuRun: "/usr/bin/juju-run",
+	certDir: "/etc/juju/certs.d",
 }
 
 var winVals = map[osVarType]string{
@@ -31,6 +33,7 @@ var winVals = map[osVarType]string{
 	logDir:  "C:/Juju/log",
 	dataDir: "C:/Juju/lib/juju",
 	jujuRun: "C:/Juju/bin/juju-run.exe",
+	certDir: "C:/Juju/certs",
 }
 
 // osVal will lookup the value of the key valname
@@ -66,6 +69,13 @@ func LogDir(series string) (string, error) {
 // DataDir returns a filesystem path to the folder used by juju to
 // store tools, charms, locks, etc
 func DataDir(series string) (string, error) {
+	return osVal(series, dataDir)
+}
+
+// CertDir returns a filesystem path to the folder used by juju to
+// store certificates that are added by default to the Juju client
+// api certificate pool.
+func CertDir(series string) (string, error) {
 	return osVal(series, dataDir)
 }
 


### PR DESCRIPTION
This feature is likely to be used when there is an agreed central JES system that users can log in to without having to supply their own CA certificate.

(Review request: http://reviews.vapour.ws/r/1657/)