### PR TITLE
Backport pr #2158 joyent package fix to 1.23

### DIFF
--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -32,6 +32,7 @@ var (
 	vTypeSmartmachine   = "smartmachine"
 	vTypeVirtualmachine = "kvm"
 	signedImageDataOnly = false
+	defaultCpuCores     = uint64(1)
 )
 
 type joyentCompute struct {
@@ -319,6 +320,14 @@ func (env *joyentEnviron) listInstanceTypes() ([]instances.InstanceType, error) 
 	}
 	allInstanceTypes := []instances.InstanceType{}
 	for _, pkg := range packages {
+		// ListPackages does not include the virt type of the package.
+		// However, Joyent says the smart packages have zero VCPUs.
+		var virtType *string
+		if pkg.VCPUs > 0 {
+			virtType = &vTypeVirtualmachine
+		} else {
+			virtType = &vTypeSmartmachine
+		}
 		instanceType := instances.InstanceType{
 			Id:       pkg.Id,
 			Name:     pkg.Name,
@@ -326,7 +335,7 @@ func (env *joyentEnviron) listInstanceTypes() ([]instances.InstanceType, error) 
 			Mem:      uint64(pkg.Memory),
 			CpuCores: uint64(pkg.VCPUs),
 			RootDisk: uint64(pkg.Disk * 1024),
-			VirtType: &vTypeVirtualmachine,
+			VirtType: virtType,
 		}
 		allInstanceTypes = append(allInstanceTypes, instanceType)
 	}
@@ -335,6 +344,10 @@ func (env *joyentEnviron) listInstanceTypes() ([]instances.InstanceType, error) 
 
 // FindInstanceSpec returns an InstanceSpec satisfying the supplied instanceConstraint.
 func (env *joyentEnviron) FindInstanceSpec(ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
+	// Require at least one VCPU so we get KVM rather than smart package.
+	if ic.Constraints.CpuCores == nil {
+		ic.Constraints.CpuCores = &defaultCpuCores
+	}
 	allInstanceTypes, err := env.listInstanceTypes()
 	if err != nil {
 		return nil, err

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -336,6 +336,17 @@ func (s *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {
 	c.Assert(sources, gc.HasLen, 0)
 }
 
+func (s *localServerSuite) TestFindInstanceSpec(c *gc.C) {
+	env := s.Prepare(c)
+	spec, err := joyent.FindInstanceSpec(env, "trusty", "amd64", "mem=4G")
+	c.Assert(err, gc.IsNil)
+	c.Assert(spec.InstanceType.VirtType, gc.NotNil)
+	c.Check(spec.Image.Arch, gc.Equals, "amd64")
+	c.Check(spec.Image.VirtType, gc.Equals, "kvm")
+	c.Check(*spec.InstanceType.VirtType, gc.Equals, "kvm")
+	c.Check(spec.InstanceType.CpuCores, gc.Equals, uint64(4))
+}
+
 func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 	env := s.Prepare(c)
 	// An error occurs if no suitable image is found.


### PR DESCRIPTION
Fix lp:1446264 by using joyent kvm packages only.

Currently the joyent provider does not distinguish between
kvm and smart package types, it just assumes all listed
packages are kvm. This causes CreateMachine to fail if it
happens to try combining a smart package with a kvm image.

Unfortunately, the Joyent ListPackages api does not include
the virt type, however according to the Joyent developers
only the kvm packages have VCPUs set to one or greater.

Change the joyent provider to correctly label the packages
virt type based on the number of vcpus, and constrain
InstanceSpec selection to kvm packages and images only.

(Review request: http://reviews.vapour.ws/r/1660/)