### PR TITLE
Fixed lp:1437266 - Bootstrap node occasionally panicing

### DIFF
--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -702,12 +702,34 @@ func (p *backingOpenedPorts) updated(st *State, store *multiwatcherStore, id int
 func (p *backingOpenedPorts) removed(st *State, store *multiwatcherStore, id interface{}) {
 	localID := st.localID(id.(string))
 	u, err := st.Unit(localID)
-	if err != nil {
-		panic(fmt.Errorf("cannot retrieve unit %q: %v", localID, err))
+	if err == nil {
+		// Only one unit.
+		if err = updateUnitPorts(st, store, u); err != nil {
+			panic(fmt.Errorf("cannot update unit ports for %q: %v", localID, err))
+		}
+		return
 	}
-	err = updateUnitPorts(st, store, u)
-	if err != nil {
-		panic(fmt.Errorf("cannot update unit ports for %q: %v", localID, err))
+	parentID, ok := backingEntityIdForOpenedPortsKey(localID)
+	if !ok {
+		return
+	}
+	switch info := store.Get(parentID).(type) {
+	case nil:
+		// The parent info doesn't exist. This is unexpected because the port
+		// always refers to a machine. Anyway, ignore the ports for now.
+		return
+	case *multiwatcher.MachineInfo:
+		// Retrieve the units placed in the machine.
+		units, err := st.UnitsFor(info.Id)
+		if err != nil {
+			panic(fmt.Errorf("cannot retrieve units for %q: %v", info.Id, err))
+		}
+		// Update the ports on all units assigned to the machine.
+		for _, u := range units {
+			if err := updateUnitPorts(st, store, u); err != nil {
+				panic(fmt.Errorf("cannot update unit ports for %q: %v", u.Name(), err))
+			}
+		}
 	}
 }
 

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -1820,13 +1820,6 @@ func (s *storeManagerStateSuite) TestClosingPorts(c *gc.C) {
 			},
 		},
 	})
-	// Try closing and updating with an invalid unit.
-	c.Assert(func() {
-		b.Changed(all, watcher.Change{
-			C:  openedPortsC,
-			Id: s.state.docID("unknown/42"),
-		})
-	}, gc.PanicMatches, `cannot retrieve unit "unknown/42": unit "unknown/42" not found`)
 }
 
 // TestSettings tests the correct reporting of unset service settings.


### PR DESCRIPTION
Megawatcher handled closing ports in case of `destry-service` wrong. In the case the machine ID instead of the unit ID is passed.

(Review request: http://reviews.vapour.ws/r/1662/)