### PR TITLE
Backport pr #2112 openstack error handling to 1.24

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -39,6 +39,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	f5c958d2b012da23a4600bad441f20b13ec262c4	2015-04-03T18:23:57Z
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
+gopkg.in/goose.v1	git	719ac401976ed29ed23ca348021553161b184afe	2015-04-28T15:30:43Z
 gopkg.in/juju/charm.v5	git	192aa737f07ab3411f59ff8f6c41d55bc8097521	2015-05-05T02:00:10Z
 gopkg.in/juju/charmstore.v4	git	ab64d50370f9c167a7cd55be8ea22c3842aae46d	2015-04-10T09:44:12Z
 gopkg.in/macaroon-bakery.v0	git	9593b80b01ba04b519769d045dffd6abd827d2fd	2015-04-10T07:46:55Z
@@ -50,6 +51,5 @@ gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:0
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20141121040613-ztm1q0iy9rune3zt	13
 launchpad.net/gomaasapi	bzr	ian.booth@canonical.com-20150113032002-n7hj4l5a9j9dzaa0	61
-gopkg.in/goose.v1	git	94313f948a11ebb7e75c72d85262efc7b0b3aa15	2015-04-09T10:29:48+02:00
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20141203072923-27pcp2hckqyezbfe	242
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -315,10 +315,6 @@ func EnsureGroup(e environs.Environ, name string, rules []nova.RuleInfo) (nova.S
 	return e.(*environ).ensureGroup(name, rules)
 }
 
-func CollectInstances(e environs.Environ, ids []instance.Id, out map[string]instance.Instance) []instance.Id {
-	return e.(*environ).collectInstances(ids, out)
-}
-
 // ImageMetadataStorage returns a Storage object pointing where the goose
 // infrastructure sets up its keystone entry for image metadata
 func ImageMetadataStorage(e environs.Environ) envstorage.Storage {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -646,32 +646,6 @@ func (s *localServerSuite) TestInstancesGatheringWithFloatingIP(c *gc.C) {
 	s.assertInstancesGathering(c, true)
 }
 
-func (s *localServerSuite) TestCollectInstances(c *gc.C) {
-	coretesting.SkipIfPPC64EL(c, "lp:1425242")
-
-	env := s.Prepare(c)
-	cleanup := s.srv.Service.Nova.RegisterControlPoint(
-		"addServer",
-		func(sc hook.ServiceControl, args ...interface{}) error {
-			details := args[0].(*nova.ServerDetail)
-			details.Status = "BUILD(networking)"
-			return nil
-		},
-	)
-	defer cleanup()
-	stateInst, _ := testing.AssertStartInstance(c, env, "100")
-	defer func() {
-		err := env.StopInstances(stateInst.Id())
-		c.Assert(err, jc.ErrorIsNil)
-	}()
-	found := make(map[string]instance.Instance)
-	missing := []instance.Id{stateInst.Id()}
-
-	resultMissing := openstack.CollectInstances(env, missing, found)
-
-	c.Assert(resultMissing, gc.DeepEquals, missing)
-}
-
 func (s *localServerSuite) TestInstancesBuildSpawning(c *gc.C) {
 	coretesting.SkipIfPPC64EL(c, "lp:1425242")
 
@@ -732,6 +706,40 @@ func (s *localServerSuite) TestInstancesShutoffSuspended(c *gc.C) {
 	c.Assert(instances, gc.HasLen, 2)
 	c.Assert(instances[0].Status(), gc.Equals, nova.StatusShutoff)
 	c.Assert(instances[1].Status(), gc.Equals, nova.StatusSuspended)
+}
+
+func (s *localServerSuite) TestInstancesErrorResponse(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
+	env := s.Prepare(c)
+	cleanup := s.srv.Service.Nova.RegisterControlPoint(
+		"server",
+		func(sc hook.ServiceControl, args ...interface{}) error {
+			return fmt.Errorf("strange error not instance")
+		},
+	)
+	defer cleanup()
+
+	instances, err := env.Instances([]instance.Id{"1"})
+	c.Check(instances, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "(?s).*strange error not instance.*")
+}
+
+func (s *localServerSuite) TestInstancesMultiErrorResponse(c *gc.C) {
+	coretesting.SkipIfPPC64EL(c, "lp:1425242")
+
+	env := s.Prepare(c)
+	cleanup := s.srv.Service.Nova.RegisterControlPoint(
+		"matchServers",
+		func(sc hook.ServiceControl, args ...interface{}) error {
+			return fmt.Errorf("strange error no instances")
+		},
+	)
+	defer cleanup()
+
+	instances, err := env.Instances([]instance.Id{"1", "2"})
+	c.Check(instances, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "(?s).*strange error no instances.*")
 }
 
 // TODO (wallyworld) - this test was copied from the ec2 provider.

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1134,43 +1134,48 @@ func (e *environ) StopInstances(ids ...instance.Id) error {
 	return common.RemoveStateInstances(e.Storage(), ids...)
 }
 
-// collectInstances tries to get information on each instance id in ids.
-// It fills the slots in the given map for known servers with status
-// either ACTIVE or BUILD. Returns a list of missing ids.
-func (e *environ) collectInstances(ids []instance.Id, out map[string]instance.Instance) []instance.Id {
-	var err error
-	serversById := make(map[string]nova.ServerDetail)
+func (e *environ) isAliveServer(server nova.ServerDetail) bool {
+	switch server.Status {
+	// HPCloud uses "BUILD(spawning)" as an intermediate BUILD state
+	// once networking is available.
+	case nova.StatusActive, nova.StatusBuild, nova.StatusBuildSpawning, nova.StatusShutoff, nova.StatusSuspended:
+		return true
+	}
+	return false
+}
+
+func (e *environ) listServers(ids []instance.Id) ([]nova.ServerDetail, error) {
+	wantedServers := make([]nova.ServerDetail, 0, len(ids))
 	if len(ids) == 1 {
-		// most common case - single instance
-		var server *nova.ServerDetail
-		server, err = e.nova().GetServer(string(ids[0]))
-		if server != nil {
-			serversById[server.Id] = *server
+		// Common case, single instance, may return NotFound
+		var maybeServer *nova.ServerDetail
+		maybeServer, err := e.nova().GetServer(string(ids[0]))
+		if err != nil {
+			return nil, err
 		}
-	} else {
-		var servers []nova.ServerDetail
-		servers, err = e.nova().ListServersDetail(e.machinesFilter())
-		for _, server := range servers {
-			serversById[server.Id] = server
+		// Only return server details if it is currently alive
+		if maybeServer != nil && e.isAliveServer(*maybeServer) {
+			wantedServers = append(wantedServers, *maybeServer)
 		}
+		return wantedServers, nil
 	}
+	// List all servers that may be in the environment
+	servers, err := e.nova().ListServersDetail(e.machinesFilter())
 	if err != nil {
-		return ids
+		return nil, err
 	}
-	var missing []instance.Id
+	// Create a set of the ids of servers that are wanted
+	idSet := make(map[string]struct{}, len(ids))
 	for _, id := range ids {
-		if server, found := serversById[string(id)]; found {
-			// HPCloud uses "BUILD(spawning)" as an intermediate BUILD states once networking is available.
-			switch server.Status {
-			case nova.StatusActive, nova.StatusBuild, nova.StatusBuildSpawning, nova.StatusShutoff, nova.StatusSuspended:
-				// TODO(wallyworld): lookup the flavor details to fill in the instance type data
-				out[string(id)] = &openstackInstance{e: e, serverDetail: &server}
-				continue
-			}
-		}
-		missing = append(missing, id)
+		idSet[string(id)] = struct{}{}
 	}
-	return missing
+	// Return only servers with the wanted ids that are currently alive
+	for _, server := range servers {
+		if _, ok := idSet[server.Id]; ok && e.isAliveServer(server) {
+			wantedServers = append(wantedServers, server)
+		}
+	}
+	return wantedServers, nil
 }
 
 // updateFloatingIPAddresses updates the instances with any floating IP address
@@ -1196,23 +1201,41 @@ func (e *environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	missing := ids
-	found := make(map[string]instance.Instance)
 	// Make a series of requests to cope with eventual consistency.
 	// Each request will attempt to add more instances to the requested
 	// set.
+	var foundServers []nova.ServerDetail
 	for a := shortAttempt.Start(); a.Next(); {
-		if missing = e.collectInstances(missing, found); len(missing) == 0 {
+		var err error
+		foundServers, err = e.listServers(ids)
+		if err != nil {
+			logger.Debugf("error listing servers: %v", err)
+			if !gooseerrors.IsNotFound(err) {
+				return nil, err
+			}
+		}
+		if len(foundServers) == len(ids) {
 			break
 		}
 	}
-	if len(found) == 0 {
+	logger.Tracef("%d/%d live servers found", len(foundServers), len(ids))
+	if len(foundServers) == 0 {
 		return nil, environs.ErrNoInstances
+	}
+
+	instsById := make(map[string]instance.Instance, len(foundServers))
+	for i, server := range foundServers {
+		// TODO(wallyworld): lookup the flavor details to fill in the
+		// instance type data
+		instsById[server.Id] = &openstackInstance{
+			e:            e,
+			serverDetail: &foundServers[i],
+		}
 	}
 
 	// Update the instance structs with any floating IP address that has been assigned to the instance.
 	if e.ecfg().useFloatingIP() {
-		if err := e.updateFloatingIPAddresses(found); err != nil {
+		if err := e.updateFloatingIPAddresses(instsById); err != nil {
 			return nil, err
 		}
 	}
@@ -1220,7 +1243,7 @@ func (e *environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
 	insts := make([]instance.Instance, len(ids))
 	var err error
 	for i, id := range ids {
-		if inst := found[string(id)]; inst != nil {
+		if inst := instsById[string(id)]; inst != nil {
 			insts[i] = inst
 		} else {
 			err = environs.ErrPartialInstances
@@ -1236,7 +1259,7 @@ func (e *environ) AllInstances() (insts []instance.Instance, err error) {
 	}
 	instsById := make(map[string]instance.Instance)
 	for _, server := range servers {
-		if server.Status == nova.StatusActive || server.Status == nova.StatusBuild {
+		if e.isAliveServer(server) {
 			var s = server
 			// TODO(wallyworld): lookup the flavor details to fill in the instance type data
 			instsById[s.Id] = &openstackInstance{e: e, serverDetail: &s}


### PR DESCRIPTION
Propogate errors when listing openstack instances.

Junks collectInstances function which is legacy from EC2
provider implementation and replaces with listServers,
which does much the same thing but without the incremental
building across attempts.

Bumps goose dependency to test error responses properly.

(Review request: http://reviews.vapour.ws/r/1665/)