### PR TITLE
Merge pull request #2303 from natefinch/fix-1452285-1.24

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -191,6 +191,11 @@ type ConfigSetterOnly interface {
 	SetStateServingInfo(info params.StateServingInfo)
 }
 
+// LogFileName returns the filename for the Agent's log file.
+func LogFilename(c Config) string {
+	return filepath.Join(c.LogDir(), c.Tag().String()+".log")
+}
+
 type ConfigMutator func(ConfigSetter) error
 
 type ConfigWriter interface {

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -104,7 +104,7 @@ func (s *apiOpenSuite) TestOpenAPIStateWaitsProvisionedGivesUp(c *gc.C) {
 	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min+1)
 }
 
-type acCreator func() (cmd.Command, *AgentConf)
+type acCreator func() (cmd.Command, AgentConf)
 
 // CheckAgentCommand is a utility function for verifying that common agent
 // options are handled by a Command; it returns an instance of that
@@ -114,7 +114,7 @@ func CheckAgentCommand(c *gc.C, create acCreator, args []string) cmd.Command {
 	err := coretesting.InitCommand(com, args)
 	dataDir, err := paths.DataDir(version.Current.Series)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(conf.DataDir, gc.Equals, dataDir)
+	c.Assert(conf.DataDir(), gc.Equals, dataDir)
 	badArgs := append(args, "--data-dir", "")
 	com, _ = create()
 	err = coretesting.InitCommand(com, badArgs)
@@ -123,7 +123,7 @@ func CheckAgentCommand(c *gc.C, create acCreator, args []string) cmd.Command {
 	args = append(args, "--data-dir", "jd")
 	com, conf = create()
 	c.Assert(coretesting.InitCommand(com, args), gc.IsNil)
-	c.Assert(conf.DataDir, gc.Equals, "jd")
+	c.Assert(conf.DataDir(), gc.Equals, "jd")
 	return com
 }
 

--- a/cmd/jujud/agent/agentconf_test.go
+++ b/cmd/jujud/agent/agentconf_test.go
@@ -21,8 +21,8 @@ type agentConfSuite struct {
 func (s *agentConfSuite) TestChangeConfigSuccess(c *gc.C) {
 	mcsw := &mockConfigSetterWriter{}
 
-	conf := AgentConf{
-		DataDir: c.MkDir(),
+	conf := agentConf{
+		dataDir: c.MkDir(),
 		_config: mcsw,
 	}
 
@@ -37,8 +37,8 @@ func (s *agentConfSuite) TestChangeConfigSuccess(c *gc.C) {
 func (s *agentConfSuite) TestChangeConfigMutateFailure(c *gc.C) {
 	mcsw := &mockConfigSetterWriter{}
 
-	conf := AgentConf{
-		DataDir: c.MkDir(),
+	conf := agentConf{
+		dataDir: c.MkDir(),
 		_config: mcsw,
 	}
 
@@ -55,8 +55,8 @@ func (s *agentConfSuite) TestChangeConfigWriteFailure(c *gc.C) {
 		WriteError: errors.New("boom"),
 	}
 
-	conf := AgentConf{
-		DataDir: c.MkDir(),
+	conf := agentConf{
+		dataDir: c.MkDir(),
 		_config: mcsw,
 	}
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -160,11 +160,13 @@ type AgentConfigWriter interface {
 // command-line arguments and instantiating and running a
 // MachineAgent.
 func NewMachineAgentCmd(
+	ctx *cmd.Context,
 	machineAgentFactory func(string) *MachineAgent,
 	agentInitializer AgentInitializer,
 	configFetcher AgentConfigWriter,
 ) cmd.Command {
 	return &machineAgentCmd{
+		ctx:                 ctx,
 		machineAgentFactory: machineAgentFactory,
 		agentInitializer:    agentInitializer,
 		currentConfig:       configFetcher,
@@ -178,6 +180,7 @@ type machineAgentCmd struct {
 	agentInitializer    AgentInitializer
 	currentConfig       AgentConfigWriter
 	machineAgentFactory func(string) *MachineAgent
+	ctx                 *cmd.Context
 
 	// This group is for debugging purposes.
 	logToStdErr bool
@@ -212,15 +215,15 @@ func (a *machineAgentCmd) Init(args []string) error {
 		return errors.Annotate(err, "cannot read agent configuration")
 	}
 	agentConfig := a.currentConfig.CurrentConfig()
-	filename := filepath.Join(agentConfig.LogDir(), agentConfig.Tag().String()+".log")
 
-	log := &lumberjack.Logger{
-		Filename:   filename,
+	// the context's stderr is set as the loggo writer in github.com/juju/cmd/logging.go
+	a.ctx.Stderr = &lumberjack.Logger{
+		Filename:   agent.LogFilename(agentConfig),
 		MaxSize:    300, // megabytes
 		MaxBackups: 2,
 	}
 
-	return cmdutil.SwitchProcessToRollingLogs(log)
+	return nil
 }
 
 // Run instantiates a MachineAgent and runs it.

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -25,6 +25,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charm.v5/charmrepo"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -60,6 +61,7 @@ import (
 	sshtesting "github.com/juju/juju/utils/ssh/testing"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/apiaddressupdater"
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/deployer"
@@ -208,16 +210,17 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 
 // newAgent returns a new MachineAgent instance
 func (s *commonMachineSuite) newAgent(c *gc.C, m *state.Machine) *MachineAgent {
-	agentConf := AgentConf{DataDir: s.DataDir()}
+	agentConf := agentConf{dataDir: s.DataDir()}
 	agentConf.ReadConfig(names.NewMachineTag(m.Id()).String())
 	machineAgentFactory := MachineAgentFactoryFn(&agentConf, &agentConf)
 	return machineAgentFactory(m.Id())
 }
 
 func (s *MachineSuite) TestParseSuccess(c *gc.C) {
-	create := func() (cmd.Command, *AgentConf) {
-		agentConf := AgentConf{DataDir: s.DataDir()}
+	create := func() (cmd.Command, AgentConf) {
+		agentConf := agentConf{dataDir: s.DataDir()}
 		a := NewMachineAgentCmd(
+			nil,
 			MachineAgentFactoryFn(&agentConf, &agentConf),
 			&agentConf,
 			&agentConf,
@@ -260,14 +263,14 @@ func (s *MachineSuite) TestParseNonsense(c *gc.C) {
 		{},
 		{"--machine-id", "-4004"},
 	} {
-		var agentConf AgentConf
+		var agentConf agentConf
 		err := ParseAgentCommand(&machineAgentCmd{agentInitializer: &agentConf}, args)
 		c.Assert(err, gc.ErrorMatches, "--machine-id option must be set, and expects a non-negative integer")
 	}
 }
 
 func (s *MachineSuite) TestParseUnknown(c *gc.C) {
-	var agentConf AgentConf
+	var agentConf agentConf
 	a := &machineAgentCmd{agentInitializer: &agentConf}
 	err := ParseAgentCommand(a, []string{"--machine-id", "42", "blistering barnacles"})
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["blistering barnacles"\]`)
@@ -278,6 +281,83 @@ func (s *MachineSuite) TestRunInvalidMachineId(c *gc.C) {
 	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
 	err := s.newAgent(c, m).Run(nil)
 	c.Assert(err, gc.ErrorMatches, "some error")
+}
+
+type FakeConfig struct {
+	agent.Config
+}
+
+func (FakeConfig) LogDir() string {
+	return "/var/log/juju/"
+}
+
+func (FakeConfig) Tag() names.Tag {
+	return names.NewMachineTag("42")
+}
+
+type FakeAgentConfig struct {
+	AgentConfigWriter
+	apiaddressupdater.APIAddressSetter
+	AgentInitializer
+}
+
+func (FakeAgentConfig) ReadConfig(string) error { return nil }
+
+func (FakeAgentConfig) CurrentConfig() agent.Config {
+	return FakeConfig{}
+}
+
+func (FakeAgentConfig) CheckArgs([]string) error { return nil }
+
+func (s *MachineSuite) TestUseLumberjack(c *gc.C) {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+
+	agentConf := FakeAgentConfig{}
+
+	a := NewMachineAgentCmd(
+		ctx,
+		MachineAgentFactoryFn(agentConf, agentConf),
+		agentConf,
+		agentConf,
+	)
+	// little hack to set the data that Init expects to already be set
+	a.(*machineAgentCmd).machineId = "42"
+
+	err = a.Init(nil)
+	c.Assert(err, gc.IsNil)
+
+	l, ok := ctx.Stderr.(*lumberjack.Logger)
+	c.Assert(ok, jc.IsTrue)
+	c.Check(l.MaxAge, gc.Equals, 0)
+	c.Check(l.MaxBackups, gc.Equals, 2)
+	c.Check(l.Filename, gc.Equals, "/var/log/juju/machine-42.log")
+	c.Check(l.MaxSize, gc.Equals, 300)
+}
+
+func (s *MachineSuite) TestDontUseLumberjack(c *gc.C) {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+
+	agentConf := FakeAgentConfig{}
+
+	a := NewMachineAgentCmd(
+		ctx,
+		MachineAgentFactoryFn(agentConf, agentConf),
+		agentConf,
+		agentConf,
+	)
+	// little hack to set the data that Init expects to already be set
+	a.(*machineAgentCmd).machineId = "42"
+
+	// set the value that normally gets set by the flag parsing
+	a.(*machineAgentCmd).logToStdErr = true
+
+	err = a.Init(nil)
+	c.Assert(err, gc.IsNil)
+
+	_, ok := ctx.Stderr.(*lumberjack.Logger)
+	c.Assert(ok, jc.IsFalse)
 }
 
 func (s *MachineSuite) TestRunStop(c *gc.C) {

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -61,6 +61,13 @@ type BootstrapCommand struct {
 	ImageMetadataDir string
 }
 
+// NewBootstrapCommand returns a new BootstrapCommand that has been initialized.
+func NewBootstrapCommand() *BootstrapCommand {
+	return &BootstrapCommand{
+		AgentConf: agentcmd.NewAgentConf(""),
+	}
+}
+
 // Info returns a decription of the command.
 func (c *BootstrapCommand) Info() *cmd.Info {
 	return &cmd.Info{

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -179,7 +179,7 @@ func (s *BootstrapSuite) initBootstrapCommand(c *gc.C, jobs []multiwatcher.Machi
 	err = machineConf.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
-	cmd = &BootstrapCommand{}
+	cmd = NewBootstrapCommand()
 
 	err = testing.InitCommand(cmd, append([]string{"--data-dir", s.dataDir}, args...))
 	return machineConf, cmd, err

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -116,16 +116,19 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 		Doc:  jujudDoc,
 	})
 	jujud.Log.Factory = &writerFactory{}
-	jujud.Register(&BootstrapCommand{})
+	jujud.Register(NewBootstrapCommand())
 
 	// TODO(katco-): AgentConf type is doing too much. The
 	// MachineAgent type has called out the seperate concerns; the
 	// AgentConf should be split up to follow suite.
-	var agentConf agentcmd.AgentConf
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(&agentConf, &agentConf)
-	jujud.Register(agentcmd.NewMachineAgentCmd(machineAgentFactory, &agentConf, &agentConf))
+	agentConf := agentcmd.NewAgentConf("")
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf)
+	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
 
-	jujud.Register(&UnitAgent{})
+	a := NewUnitAgent()
+	a.ctx = ctx
+	jujud.Register(a)
+
 	code = cmd.Main(jujud, ctx, args[1:])
 	return code, nil
 }

--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 	"runtime"
 
 	"github.com/juju/cmd"
@@ -44,6 +43,14 @@ type UnitAgent struct {
 	runner       worker.Runner
 	setupLogging func(agent.Config) error
 	logToStdErr  bool
+	ctx          *cmd.Context
+}
+
+// NewUnitAgent creates a new UnitAgent value properly initialized.
+func NewUnitAgent() *UnitAgent {
+	return &UnitAgent{
+		AgentConf: agentcmd.NewAgentConf(""),
+	}
 }
 
 // Info returns usage information for the command.
@@ -72,6 +79,22 @@ func (a *UnitAgent) Init(args []string) error {
 		return err
 	}
 	a.runner = worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant)
+
+	if !a.logToStdErr {
+		if err := a.ReadConfig(a.Tag().String()); err != nil {
+			return err
+		}
+		agentConfig := a.CurrentConfig()
+
+		// the writer in ctx.stderr gets set as the loggo writer in github.com/juju/cmd/logging.go
+		a.ctx.Stderr = &lumberjack.Logger{
+			Filename:   agent.LogFilename(agentConfig),
+			MaxSize:    300, // megabytes
+			MaxBackups: 2,
+		}
+
+	}
+
 	return nil
 }
 
@@ -89,19 +112,6 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 	}
 	agentConfig := a.CurrentConfig()
 
-	if !a.logToStdErr {
-		filename := filepath.Join(agentConfig.LogDir(), agentConfig.Tag().String()+".log")
-
-		log := &lumberjack.Logger{
-			Filename:   filename,
-			MaxSize:    300, // megabytes
-			MaxBackups: 2,
-		}
-
-		if err := cmdutil.SwitchProcessToRollingLogs(log); err != nil {
-			return err
-		}
-	}
 	agentLogger.Infof("unit agent %v start (%s [%s])", a.Tag().String(), version.Current, runtime.Compiler)
 	if flags := featureflag.String(); flags != "" {
 		logger.Warningf("developer feature flags enabled: %s", flags)

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
@@ -97,7 +98,7 @@ func (s *UnitSuite) primeAgent(c *gc.C) (*state.Machine, *state.Unit, agent.Conf
 }
 
 func (s *UnitSuite) newAgent(c *gc.C, unit *state.Unit) *UnitAgent {
-	a := &UnitAgent{}
+	a := NewUnitAgent()
 	s.InitAgent(c, a, "--unit-name", unit.Name(), "--log-to-stderr=true")
 	err := a.ReadConfig(unit.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
@@ -105,19 +106,20 @@ func (s *UnitSuite) newAgent(c *gc.C, unit *state.Unit) *UnitAgent {
 }
 
 func (s *UnitSuite) TestParseSuccess(c *gc.C) {
-	a := &UnitAgent{}
+	a := NewUnitAgent()
 	err := coretesting.InitCommand(a, []string{
 		"--data-dir", "jd",
 		"--unit-name", "w0rd-pre55/1",
+		"--log-to-stderr",
 	})
 
 	c.Assert(err, gc.IsNil)
-	c.Check(a.AgentConf.DataDir, gc.Equals, "jd")
+	c.Check(a.AgentConf.DataDir(), gc.Equals, "jd")
 	c.Check(a.UnitName, gc.Equals, "w0rd-pre55/1")
 }
 
 func (s *UnitSuite) TestParseMissing(c *gc.C) {
-	uc := &UnitAgent{}
+	uc := NewUnitAgent()
 	err := coretesting.InitCommand(uc, []string{
 		"--data-dir", "jc",
 	})
@@ -133,13 +135,13 @@ func (s *UnitSuite) TestParseNonsense(c *gc.C) {
 		{"--unit-name", "wordpress/wild/9"},
 		{"--unit-name", "20/20"},
 	} {
-		err := coretesting.InitCommand(&UnitAgent{}, append(args, "--data-dir", "jc"))
+		err := coretesting.InitCommand(NewUnitAgent(), append(args, "--data-dir", "jc"))
 		c.Check(err, gc.ErrorMatches, `--unit-name option expects "<service>/<n>" argument`)
 	}
 }
 
 func (s *UnitSuite) TestParseUnknown(c *gc.C) {
-	err := coretesting.InitCommand(&UnitAgent{}, []string{
+	err := coretesting.InitCommand(NewUnitAgent(), []string{
 		"--unit-name", "wordpress/1",
 		"thundering typhoons",
 	})
@@ -431,4 +433,70 @@ func newDummyWorker() worker.Worker {
 		<-stop
 		return nil
 	})
+}
+
+type FakeConfig struct {
+	agent.Config
+}
+
+func (FakeConfig) LogDir() string {
+	return "/var/log/juju/"
+}
+
+func (FakeConfig) Tag() names.Tag {
+	return names.NewMachineTag("42")
+}
+
+type FakeAgentConfig struct {
+	agentcmd.AgentConf
+}
+
+func (FakeAgentConfig) ReadConfig(string) error { return nil }
+
+func (FakeAgentConfig) CurrentConfig() agent.Config {
+	return FakeConfig{}
+}
+
+func (FakeAgentConfig) CheckArgs([]string) error { return nil }
+
+func (s *UnitSuite) TestUseLumberjack(c *gc.C) {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+
+	a := UnitAgent{
+		AgentConf: FakeAgentConfig{},
+		ctx:       ctx,
+		UnitName:  "mysql/25",
+	}
+
+	err = a.Init(nil)
+	c.Assert(err, gc.IsNil)
+
+	l, ok := ctx.Stderr.(*lumberjack.Logger)
+	c.Assert(ok, jc.IsTrue)
+	c.Check(l.MaxAge, gc.Equals, 0)
+	c.Check(l.MaxBackups, gc.Equals, 2)
+	c.Check(l.Filename, gc.Equals, "/var/log/juju/machine-42.log")
+	c.Check(l.MaxSize, gc.Equals, 300)
+}
+
+func (s *UnitSuite) TestDontUseLumberjack(c *gc.C) {
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, gc.IsNil)
+
+	a := UnitAgent{
+		AgentConf: FakeAgentConfig{},
+		ctx:       ctx,
+		UnitName:  "mysql/25",
+
+		// this is what would get set by the CLI flags to tell us not to log to
+		// the file.
+		logToStdErr: true,
+	}
+
+	err = a.Init(nil)
+	c.Assert(err, gc.IsNil)
+
+	_, ok := ctx.Stderr.(*lumberjack.Logger)
+	c.Assert(ok, jc.IsFalse)
 }

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/fslock"
-	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/juju/juju/agent"
 	apirsyslog "github.com/juju/juju/api/rsyslog"
@@ -141,14 +140,6 @@ var ConnectionIsDead = func(logger loggo.Logger, conn Pinger) bool {
 		return true
 	}
 	return false
-}
-
-// SwitchProcessToRollingLogs switches the processes's logging to
-// rolling logs provided by the given logger.
-func SwitchProcessToRollingLogs(logger *lumberjack.Logger) error {
-	writer := loggo.NewSimpleWriter(logger, &loggo.DefaultFormatter{})
-	_, err := loggo.ReplaceDefaultWriter(writer)
-	return err
 }
 
 // NewEnsureServerParams creates an EnsureServerParams from an agent

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -89,8 +89,8 @@ func (s *leadershipSuite) SetUpTest(c *gc.C) {
 	)
 
 	// Create & start a machine agent so the tests have something to call into.
-	agentConf := agentcmd.AgentConf{DataDir: s.DataDir()}
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(&agentConf, &agentConf)
+	agentConf := agentcmd.NewAgentConf(s.DataDir())
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf)
 	s.machineAgent = machineAgentFactory(stateServer.Id())
 
 	// See comment in createMockJujudExecutable
@@ -333,8 +333,8 @@ func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 	)
 
 	// Create & start a machine agent so the tests have something to call into.
-	agentConf := agentcmd.AgentConf{DataDir: s.DataDir()}
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(&agentConf, &agentConf)
+	agentConf := agentcmd.NewAgentConf(s.DataDir())
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf)
 	s.machineAgent = machineAgentFactory(stateServer.Id())
 
 	// See comment in createMockJujudExecutable


### PR DESCRIPTION
Forward port of pull request #2303 from natefinch/fix-1452285-1.24

revamp log rotation

This fixes https://bugs.launchpad.net/juju-core/+bug/1452285

The problem was that we had moved the log rotation code earlier in the startup code, and then other code overwrote what loggo used as a default writer.  This code consolidates the loggo-modification code to a single place, so we don't have to worry about that anymore.


(Review request: http://reviews.vapour.ws/r/1668/)