### PR TITLE
utils/syslog: set $ActionQueueMaxDiskSpace (1.24)

### DIFF
--- a/utils/syslog/config.go
+++ b/utils/syslog/config.go
@@ -57,6 +57,7 @@ $ActionQueueType LinkedList
 $ActionQueueFileName {{logfileName}}{{namespace}}_{{$i}}
 $ActionResumeRetryCount -1
 $ActionQueueSaveOnShutdown on
+$ActionQueueMaxDiskSpace 512M
 $DefaultNetstreamDriver gtls
 $DefaultNetstreamDriverCAFile {{tlsCACertPath}}
 $ActionSendStreamDriverAuthMode anon
@@ -125,6 +126,7 @@ $ActionQueueType LinkedList
 $ActionQueueFileName {{logfileName}}{{namespace}}_{{$i}}
 $ActionResumeRetryCount -1
 $ActionQueueSaveOnShutdown on
+$ActionQueueMaxDiskSpace 512M
 $DefaultNetstreamDriver gtls
 $DefaultNetstreamDriverCAFile {{tlsCACertPath}}
 $ActionSendStreamDriverAuthMode anon

--- a/utils/syslog/testing/syslogconf.go
+++ b/utils/syslog/testing/syslogconf.go
@@ -27,6 +27,7 @@ $ActionQueueType LinkedList
 $ActionQueueFileName {{.MachineTag}}{{.Namespace}}_0
 $ActionResumeRetryCount -1
 $ActionQueueSaveOnShutdown on
+$ActionQueueMaxDiskSpace 512M
 $DefaultNetstreamDriver gtls
 $DefaultNetstreamDriverCAFile /var/log/juju{{.Namespace}}/ca-cert.pem
 $ActionSendStreamDriverAuthMode anon
@@ -115,6 +116,7 @@ $ActionQueueType LinkedList
 $ActionQueueFileName {{.MachineTag}}{{.Namespace}}_0
 $ActionResumeRetryCount -1
 $ActionQueueSaveOnShutdown on
+$ActionQueueMaxDiskSpace 512M
 $DefaultNetstreamDriver gtls
 $DefaultNetstreamDriverCAFile {{.LogDir}}/ca-cert.pem
 $ActionSendStreamDriverAuthMode anon


### PR DESCRIPTION
(Forward port from 1.22)

We must set $ActionQueueMaxDiskSpace in the rsyslog
config, or else the disk-assisted queue can grow as
large as the disk. We set it to 512M, to match the
maximum size of all-machines.log.

Fixes https://bugs.launchpad.net/juju-core/+bug/1453801

(Review request: http://reviews.vapour.ws/r/1674/)