### PR TITLE
Tweak order of writing unit and status records

### DIFF
--- a/state/service.go
+++ b/state/service.go
@@ -618,15 +618,15 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		EnvUUID:    s.st.EnvironUUID(),
 	}
 	ops := []txn.Op{
+		createStatusOp(s.st, globalKey, unitStatusDoc),
+		createStatusOp(s.st, agentGlobalKey, agentStatusDoc),
+		createMeterStatusOp(s.st, meterStatusGlobalKey, &meterStatusDoc{Code: MeterNotSet.String()}),
 		{
 			C:      unitsC,
 			Id:     docID,
 			Assert: txn.DocMissing,
 			Insert: udoc,
 		},
-		createStatusOp(s.st, globalKey, unitStatusDoc),
-		createStatusOp(s.st, agentGlobalKey, agentStatusDoc),
-		createMeterStatusOp(s.st, meterStatusGlobalKey, &meterStatusDoc{Code: MeterNotSet.String()}),
 		{
 			C:      servicesC,
 			Id:     s.doc.DocID,
@@ -735,16 +735,17 @@ func (s *Service) removeUnitOps(u *Unit, asserts bson.D) ([]txn.Op, error) {
 		{"charmurl", u.doc.CharmURL},
 		{"machineid", u.doc.MachineId},
 	}
-	ops = append(ops, txn.Op{
-		C:      unitsC,
-		Id:     u.doc.DocID,
-		Assert: append(observedFieldsMatch, asserts...),
-		Remove: true,
-	},
-		removeConstraintsOp(s.st, u.globalAgentKey()),
+	ops = append(ops,
+		txn.Op{
+			C:      unitsC,
+			Id:     u.doc.DocID,
+			Assert: append(observedFieldsMatch, asserts...),
+			Remove: true,
+		},
+		removeMeterStatusOp(s.st, u.globalMeterStatusKey()),
 		removeStatusOp(s.st, u.globalAgentKey()),
 		removeStatusOp(s.st, u.globalKey()),
-		removeMeterStatusOp(s.st, u.globalMeterStatusKey()),
+		removeConstraintsOp(s.st, u.globalAgentKey()),
 		annotationRemoveOp(s.st, u.globalKey()),
 		s.st.newCleanupOp(cleanupRemovedUnit, u.doc.Name),
 	)


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1451283

When adding units, if the unit record is added to the txn ops slice before the status records, then if could be possible for watchers to try and read the unit status and get a not found error if they saw the unit record and the status records didn't exist yet. So we need to tweak the order of the records in the slice to fix that.

(Review request: http://reviews.vapour.ws/r/1677/)