### PR TITLE
Fixed lp:1437266 - Bootstrap node occasionally panicing

### DIFF
--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -720,13 +720,38 @@ func (p *backingOpenedPorts) updated(st *State, store *multiwatcherStore, id int
 
 func (p *backingOpenedPorts) removed(st *State, store *multiwatcherStore, id interface{}) {
 	localID := st.localID(id.(string))
+	parentID, ok := backingEntityIdForOpenedPortsKey(localID)
+	if ok {
+		// id signals that a machine has been removed.
+		switch info := store.Get(parentID).(type) {
+		case nil:
+			// The parent info doesn't exist. This is unexpected because the port
+			// always refers to a machine. Anyway, ignore the ports for now.
+			return
+		case *multiwatcher.MachineInfo:
+			// Retrieve the units placed in the machine.
+			units, err := st.UnitsFor(info.Id)
+			if err != nil {
+				logger.Errorf("cannot retrieve units for %q: %v", info.Id, err)
+				return
+			}
+			// Update the ports on all units assigned to the machine.
+			for _, u := range units {
+				if err := updateUnitPorts(st, store, u); err != nil {
+					logger.Errorf("cannot update unit ports for %q: %v", u.Name(), err)
+				}
+			}
+		}
+		return
+	}
+	// id signals, that ports of one unit have been closed.
 	u, err := st.Unit(localID)
 	if err != nil {
-		panic(fmt.Errorf("cannot retrieve unit %q: %v", localID, err))
+		logger.Errorf("cannot retrieve unit %q: %v", localID, err)
+		return
 	}
-	err = updateUnitPorts(st, store, u)
-	if err != nil {
-		panic(fmt.Errorf("cannot update unit ports for %q: %v", localID, err))
+	if err = updateUnitPorts(st, store, u); err != nil {
+		logger.Errorf("cannot update unit ports for %q: %v", localID, err)
 	}
 }
 

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -1759,89 +1759,6 @@ func (s *storeManagerStateSuite) TestClosingPorts(c *gc.C) {
 	// Create all watcher state backing.
 	b := newAllWatcherStateBacking(s.state)
 	all := newStore()
-	// Check opened ports.
-	err = b.Changed(all, watcher.Change{
-		C:  "units",
-		Id: s.state.docID("wordpress/0"),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	entities := all.All()
-	substNilSinceTimeForEntities(c, entities)
-	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
-		&multiwatcher.UnitInfo{
-			Name:           "wordpress/0",
-			Service:        "wordpress",
-			Series:         "quantal",
-			MachineId:      "0",
-			PublicAddress:  "1.2.3.4",
-			PrivateAddress: "4.3.2.1",
-			Ports:          []network.Port{{"tcp", 12345}},
-			PortRanges:     []network.PortRange{{12345, 12345, "tcp"}},
-			Status:         "pending",
-			WorkloadStatus: multiwatcher.StatusInfo{
-				Current: "unknown",
-				Message: "Waiting for agent initialization to finish",
-				Data:    map[string]interface{}{},
-			},
-			AgentStatus: multiwatcher.StatusInfo{
-				Current: "allocating",
-				Data:    map[string]interface{}{},
-			},
-		},
-	})
-	// Close the ports.
-	err = u.ClosePorts("tcp", 12345, 12345)
-	c.Assert(err, jc.ErrorIsNil)
-	err = b.Changed(all, watcher.Change{
-		C:  openedPortsC,
-		Id: s.state.docID("wordpress/0"),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	entities = all.All()
-	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
-		&multiwatcher.UnitInfo{
-			Name:           "wordpress/0",
-			Service:        "wordpress",
-			Series:         "quantal",
-			MachineId:      "0",
-			PublicAddress:  "1.2.3.4",
-			PrivateAddress: "4.3.2.1",
-			Ports:          []network.Port{},
-			PortRanges:     []network.PortRange{},
-			Status:         "pending",
-			WorkloadStatus: multiwatcher.StatusInfo{
-				Current: "unknown",
-				Message: "Waiting for agent initialization to finish",
-				Data:    map[string]interface{}{},
-			},
-			AgentStatus: multiwatcher.StatusInfo{
-				Current: "allocating",
-				Data:    map[string]interface{}{},
-			},
-		},
-	})
-}
-
-// TestClosingPortsMachine tests the correct reporting of closing ports.
-func (s *storeManagerStateSuite) TestClosingPortsMachine(c *gc.C) {
-	defer s.Reset(c)
-	// Init the test environment.
-	wordpress := AddTestingService(c, s.state, "wordpress", AddTestingCharm(c, s.state, "wordpress"), s.owner)
-	u, err := wordpress.AddUnit()
-	c.Assert(err, jc.ErrorIsNil)
-	m, err := s.state.AddMachine("quantal", JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	err = u.AssignToMachine(m)
-	c.Assert(err, jc.ErrorIsNil)
-	publicAddress := network.NewScopedAddress("1.2.3.4", network.ScopePublic)
-	privateAddress := network.NewScopedAddress("4.3.2.1", network.ScopeCloudLocal)
-	err = m.SetAddresses(publicAddress, privateAddress)
-	c.Assert(err, jc.ErrorIsNil)
-	err = u.OpenPorts("tcp", 12345, 12345)
-	c.Assert(err, jc.ErrorIsNil)
-	// Create all watcher state backing.
-	b := newAllWatcherStateBacking(s.state)
-	all := newStore()
 	all.Update(&multiwatcher.MachineInfo{
 		Id: "0",
 	})
@@ -1878,7 +1795,7 @@ func (s *storeManagerStateSuite) TestClosingPortsMachine(c *gc.C) {
 			Id: "0",
 		},
 	})
-	// Close the ports and handle machine event..
+	// Close the ports.
 	err = u.ClosePorts("tcp", 12345, 12345)
 	c.Assert(err, jc.ErrorIsNil)
 	err = b.Changed(all, watcher.Change{

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -1820,13 +1820,98 @@ func (s *storeManagerStateSuite) TestClosingPorts(c *gc.C) {
 			},
 		},
 	})
-	// Try closing and updating with an invalid unit.
-	c.Assert(func() {
-		b.Changed(all, watcher.Change{
-			C:  openedPortsC,
-			Id: s.state.docID("unknown/42"),
-		})
-	}, gc.PanicMatches, `cannot retrieve unit "unknown/42": unit "unknown/42" not found`)
+}
+
+// TestClosingPortsMachine tests the correct reporting of closing ports.
+func (s *storeManagerStateSuite) TestClosingPortsMachine(c *gc.C) {
+	defer s.Reset(c)
+	// Init the test environment.
+	wordpress := AddTestingService(c, s.state, "wordpress", AddTestingCharm(c, s.state, "wordpress"), s.owner)
+	u, err := wordpress.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	m, err := s.state.AddMachine("quantal", JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.AssignToMachine(m)
+	c.Assert(err, jc.ErrorIsNil)
+	publicAddress := network.NewScopedAddress("1.2.3.4", network.ScopePublic)
+	privateAddress := network.NewScopedAddress("4.3.2.1", network.ScopeCloudLocal)
+	err = m.SetAddresses(publicAddress, privateAddress)
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.OpenPorts("tcp", 12345, 12345)
+	c.Assert(err, jc.ErrorIsNil)
+	// Create all watcher state backing.
+	b := newAllWatcherStateBacking(s.state)
+	all := newStore()
+	all.Update(&multiwatcher.MachineInfo{
+		Id: "0",
+	})
+	// Check opened ports.
+	err = b.Changed(all, watcher.Change{
+		C:  "units",
+		Id: s.state.docID("wordpress/0"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	entities := all.All()
+	substNilSinceTimeForEntities(c, entities)
+	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
+		&multiwatcher.UnitInfo{
+			Name:           "wordpress/0",
+			Service:        "wordpress",
+			Series:         "quantal",
+			MachineId:      "0",
+			PublicAddress:  "1.2.3.4",
+			PrivateAddress: "4.3.2.1",
+			Ports:          []network.Port{{"tcp", 12345}},
+			PortRanges:     []network.PortRange{{12345, 12345, "tcp"}},
+			Status:         "pending",
+			WorkloadStatus: multiwatcher.StatusInfo{
+				Current: "unknown",
+				Message: "Waiting for agent initialization to finish",
+				Data:    map[string]interface{}{},
+			},
+			AgentStatus: multiwatcher.StatusInfo{
+				Current: "allocating",
+				Data:    map[string]interface{}{},
+			},
+		},
+		&multiwatcher.MachineInfo{
+			Id: "0",
+		},
+	})
+	// Close the ports and handle machine event..
+	err = u.ClosePorts("tcp", 12345, 12345)
+	c.Assert(err, jc.ErrorIsNil)
+	err = b.Changed(all, watcher.Change{
+		C:  openedPortsC,
+		Id: s.state.docID("m#0#n#juju-public"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	entities = all.All()
+	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
+		&multiwatcher.UnitInfo{
+			Name:           "wordpress/0",
+			Service:        "wordpress",
+			Series:         "quantal",
+			MachineId:      "0",
+			PublicAddress:  "1.2.3.4",
+			PrivateAddress: "4.3.2.1",
+			Ports:          []network.Port{},
+			PortRanges:     []network.PortRange{},
+			Status:         "pending",
+			WorkloadStatus: multiwatcher.StatusInfo{
+				Current: "unknown",
+				Message: "Waiting for agent initialization to finish",
+				Data:    map[string]interface{}{},
+			},
+			AgentStatus: multiwatcher.StatusInfo{
+				Current: "allocating",
+				Data:    map[string]interface{}{},
+			},
+		},
+		&multiwatcher.MachineInfo{
+			Id: "0",
+		},
+	})
 }
 
 // TestSettings tests the correct reporting of unset service settings.


### PR DESCRIPTION
First implementation of `backingOpenedPorts.removed()` only handled unit IDs after the direct closing of ports. Now the eventing of machine IDs, e.g. after destroying services and machines, correctly too.

(Review request: http://reviews.vapour.ws/r/1681/)