### PR TITLE
cmd/juju: assert err value is not nil before inspecting

### DIFF
--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -153,6 +153,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) (restore gitjujutestin
 	// Check for remaining operations/errors.
 	if test.err != "" {
 		err := <-errc
+		c.Assert(err, gc.NotNil)
 		stripped := strings.Replace(err.Error(), "\n", "", -1)
 		c.Check(stripped, gc.Matches, test.err)
 		return restore


### PR DESCRIPTION
Check that the error returned is not nil before trying to inspect it. The code expects the error to not be nil, so fail the test if it is nil (rather than panicing)

Spotted when this code failed my build

http://juju-ci.vapour.ws:8080/job/github-merge-juju/3245/console

(Review request: http://reviews.vapour.ws/r/1682/)