### PR TITLE
Fix lp:1454658 TestUseLumberjack fails on windows

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -288,7 +288,7 @@ type FakeConfig struct {
 }
 
 func (FakeConfig) LogDir() string {
-	return "/var/log/juju/"
+	return filepath.FromSlash("/var/log/juju/")
 }
 
 func (FakeConfig) Tag() names.Tag {
@@ -331,7 +331,7 @@ func (s *MachineSuite) TestUseLumberjack(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 	c.Check(l.MaxAge, gc.Equals, 0)
 	c.Check(l.MaxBackups, gc.Equals, 2)
-	c.Check(l.Filename, gc.Equals, "/var/log/juju/machine-42.log")
+	c.Check(l.Filename, gc.Equals, filepath.FromSlash("/var/log/juju/machine-42.log"))
 	c.Check(l.MaxSize, gc.Equals, 300)
 }
 

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -440,7 +440,7 @@ type FakeConfig struct {
 }
 
 func (FakeConfig) LogDir() string {
-	return "/var/log/juju/"
+	return filepath.FromSlash("/var/log/juju/")
 }
 
 func (FakeConfig) Tag() names.Tag {
@@ -476,7 +476,7 @@ func (s *UnitSuite) TestUseLumberjack(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 	c.Check(l.MaxAge, gc.Equals, 0)
 	c.Check(l.MaxBackups, gc.Equals, 2)
-	c.Check(l.Filename, gc.Equals, "/var/log/juju/machine-42.log")
+	c.Check(l.Filename, gc.Equals, filepath.FromSlash("/var/log/juju/machine-42.log"))
 	c.Check(l.MaxSize, gc.Equals, 300)
 }
 


### PR DESCRIPTION
Wrap file paths in filepath.FromSlash.

(Review request: http://reviews.vapour.ws/r/1684/)