### PR TITLE
Do not use mgo.txn to update user last connection times

### DIFF
--- a/state/collections.go
+++ b/state/collections.go
@@ -51,6 +51,8 @@ type stateCollection interface {
 	Find(query interface{}) *mgo.Query
 	FindId(id interface{}) *mgo.Query
 	Insert(docs ...interface{}) error
+	Update(selector interface{}, update interface{}) error
+	UpdateId(id interface{}, update interface{}) error
 	Remove(sel interface{}) error
 	RemoveId(id interface{}) error
 	RemoveAll(sel interface{}) (*mgo.ChangeInfo, error)
@@ -163,6 +165,30 @@ func (c *envStateCollection) Find(query interface{}) *mgo.Query {
 // already.
 func (c *envStateCollection) FindId(id interface{}) *mgo.Query {
 	return c.Collection.FindId(c.mungeId(id))
+}
+
+// Update finds a single document matching the provided query document and
+// modifies it according to the update document.
+//
+// An "env-uuid" condition will always be added to the query to ensure
+// that only data for the environment being filtered on is returned.
+//
+// If a simple "_id" field selector is included in the query
+// (e.g. "{{"_id", "foo"}}" the relevant environment UUID prefix will
+// be added on to the id. Note that more complex selectors using the
+// "_id" field (e.g. using the $in operator) will not be modified. In
+// these cases it is up to the caller to add environment UUID
+// prefixes when necessary.
+func (c *envStateCollection) Update(query interface{}, update interface{}) error {
+	return c.Collection.Update(c.mungeQuery(query), update)
+}
+
+// UpdateId finds a single document by _id and modifies it according to the
+// update document. The id must be a string or bson.ObjectId. The environment
+// UUID will be automatically prefixed on to the id if it's a string and the
+// prefix isn't there already.
+func (c *envStateCollection) UpdateId(id interface{}, update interface{}) error {
+	return c.Collection.UpdateId(c.mungeId(id), update)
 }
 
 // Remove deletes a single document using the query provided. The

--- a/state/collections_test.go
+++ b/state/collections_test.go
@@ -103,6 +103,28 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 			},
 			expectedCount: 0,
 		},
+		{
+			label: "Update",
+			test: func() (int, error) {
+				err := coll.Update(bson.D{{"_id", "bar"}},
+					bson.D{{"$set", bson.D{{"displayname", "Updated Bar"}}}})
+				c.Assert(err, jc.ErrorIsNil)
+
+				return coll.Find(bson.D{{"displayname", "Updated Bar"}}).Count()
+			},
+			expectedCount: 1,
+		},
+		{
+			label: "UpdateId",
+			test: func() (int, error) {
+				err := coll.UpdateId("bar",
+					bson.D{{"$set", bson.D{{"displayname", "Updated Bar"}}}})
+				c.Assert(err, jc.ErrorIsNil)
+
+				return coll.Find(bson.D{{"displayname", "Updated Bar"}}).Count()
+			},
+			expectedCount: 1,
+		},
 	} {
 		c.Logf("test %d: %s", i, t.label)
 		collSnapshot.restore(c)
@@ -388,6 +410,26 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 				return 0, nil
 			},
 			expectedPanic: "query must either be bson.D or nil",
+		},
+		{
+			label: "Update",
+			test: func() (int, error) {
+				err := machines0.Update(bson.D{{"_id", m0.Id()}},
+					bson.D{{"$set", bson.D{{"update-field", "field value"}}}})
+				c.Assert(err, jc.ErrorIsNil)
+				return machines0.Find(bson.D{{"update-field", "field value"}}).Count()
+			},
+			expectedCount: 1,
+		},
+		{
+			label: "UpdateId",
+			test: func() (int, error) {
+				err := machines0.UpdateId(m0.Id(),
+					bson.D{{"$set", bson.D{{"update-field", "field value"}}}})
+				c.Assert(err, jc.ErrorIsNil)
+				return machines0.Find(bson.D{{"update-field", "field value"}}).Count()
+			},
+			expectedCount: 1,
 		},
 	} {
 		c.Logf("test %d: %s", i, t.label)

--- a/state/envuser.go
+++ b/state/envuser.go
@@ -76,14 +76,13 @@ func (e *EnvironmentUser) LastConnection() *time.Time {
 
 // UpdateLastConnection updates the last connection time of the environment user.
 func (e *EnvironmentUser) UpdateLastConnection() error {
+	envUsers, closer := e.st.getCollection(envUsersC)
+	defer closer()
+
 	timestamp := nowToTheSecond()
-	ops := []txn.Op{{
-		C:      envUsersC,
-		Id:     e.ID(),
-		Assert: txn.DocExists,
-		Update: bson.D{{"$set", bson.D{{"lastconnection", timestamp}}}},
-	}}
-	if err := e.st.runTransaction(ops); err != nil {
+	update := bson.D{{"$set", bson.D{{"lastconnection", timestamp}}}}
+
+	if err := envUsers.UpdateId(e.ID(), update); err != nil {
 		return errors.Annotatef(err, "cannot update last connection timestamp for envuser %q", e.ID())
 	}
 

--- a/state/envuser.go
+++ b/state/envuser.go
@@ -78,6 +78,10 @@ func (e *EnvironmentUser) LastConnection() *time.Time {
 func (e *EnvironmentUser) UpdateLastConnection() error {
 	envUsers, closer := e.st.getCollection(envUsersC)
 	defer closer()
+	// Update the safe mode of the underlying session to be not require
+	// write majority, nor sync to disk.
+	session := envUsers.Underlying().Database.Session
+	session.SetSafe(&mgo.Safe{})
 
 	timestamp := nowToTheSecond()
 	update := bson.D{{"$set", bson.D{{"lastconnection", timestamp}}}}

--- a/state/user.go
+++ b/state/user.go
@@ -221,6 +221,10 @@ var nowToTheSecond = func() time.Time { return time.Now().Round(time.Second).UTC
 func (u *User) UpdateLastLogin() error {
 	users, closer := u.st.getCollection(usersC)
 	defer closer()
+	// Update the safe mode of the underlying session to be not require
+	// write majority, nor sync to disk.
+	session := users.Underlying().Database.Session
+	session.SetSafe(&mgo.Safe{})
 
 	timestamp := nowToTheSecond()
 	update := bson.D{{"$set", bson.D{{"lastlogin", timestamp}}}}

--- a/state/user.go
+++ b/state/user.go
@@ -219,14 +219,13 @@ var nowToTheSecond = func() time.Time { return time.Now().Round(time.Second).UTC
 // UpdateLastLogin sets the LastLogin time of the user to be now (to the
 // nearest second).
 func (u *User) UpdateLastLogin() error {
+	users, closer := u.st.getCollection(usersC)
+	defer closer()
+
 	timestamp := nowToTheSecond()
-	ops := []txn.Op{{
-		C:      usersC,
-		Id:     u.Name(),
-		Assert: txn.DocExists,
-		Update: bson.D{{"$set", bson.D{{"lastlogin", timestamp}}}},
-	}}
-	if err := u.st.runTransaction(ops); err != nil {
+	update := bson.D{{"$set", bson.D{{"lastlogin", timestamp}}}}
+
+	if err := users.UpdateId(u.Name(), update); err != nil {
 		return errors.Annotatef(err, "cannot update last login timestamp for user %q", u.Name())
 	}
 


### PR DESCRIPTION
For both the User and EnvUser, use direct mongo updates to set the connection times.

(Review request: http://reviews.vapour.ws/r/1687/)