### PR TITLE
state: adjust error message check to be compatible with go 1.5

### DIFF
--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -727,7 +727,7 @@ var addNetworkInterfaceErrorsTests = []struct {
 }, {
 	state.NetworkInterfaceInfo{"invalid", "eth1", "net1", false, false},
 	nil,
-	`cannot add network interface "eth1" to machine "2": invalid MAC address: invalid`,
+	`cannot add network interface "eth1" to machine "2": invalid MAC address.*`,
 }, {
 	state.NetworkInterfaceInfo{"aa:bb:cc:dd:ee:f0", "eth1", "net1", false, false},
 	nil,


### PR DESCRIPTION
Error message has changed slightly between 1.4 and 1.5. Adjust the errorMatches string to accept both forms.

(Review request: http://reviews.vapour.ws/r/1688/)