### PR TITLE
Fix 1454919 cleanup all jenvs on environ destroy

### DIFF
--- a/cmd/juju/destroyenvironment.go
+++ b/cmd/juju/destroyenvironment.go
@@ -164,7 +164,7 @@ func (c *DestroyEnvironmentCommand) Run(ctx *cmd.Context) (result error) {
 	if err := c.destroyEnv(apiclient); err != nil {
 		errors.Annotate(err, "cannot destroy environment")
 	}
-	return environs.DestroyInfo(c.envName, store)
+	return environs.DestroyAllEnvironInfo(info.UUID, store)
 }
 
 func (c *DestroyEnvironmentCommand) destroyEnv(apiclient *api.Client) (result error) {

--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -168,6 +168,11 @@ func (d *diskStore) ReadInfo(envName string) (EnvironInfo, error) {
 	return info, nil
 }
 
+// List implements Storage.List
+func (d *diskStore) Destroy(envUUID string) ([]string, error) {
+
+}
+
 func cacheFilename(dir string) string {
 	return filepath.Join(dir, "cache.yaml")
 }

--- a/environs/configstore/interface.go
+++ b/environs/configstore/interface.go
@@ -63,6 +63,9 @@ type Storage interface {
 	// List returns a slice of existing environment names that the Storage
 	// knows about.
 	List() ([]string, error)
+
+	// Destroy destroys all information assosiated with the given environment UUID
+	Destroy(envUUID string) error
 }
 
 // EnvironInfo holds information associated with an environment.

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -310,7 +310,12 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	e, err := environs.Prepare(cfg, ctx, store)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = store.ReadInfo(e.Config().Name())
+	info, err := store.ReadInfo(e.Config().Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	bobsEnv := store.CreateInfo("bob")
+	bobsEnv.SetAPIEndpoint(info.APIEndpoint())
+	err = bobsEnv.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = environs.Destroy(e, store)
@@ -321,6 +326,8 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	_, err = e.StateServerInstances()
 	c.Assert(err, gc.ErrorMatches, "environment has been destroyed")
 	_, err = store.ReadInfo(e.Config().Name())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = store.ReadInfo("bob")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 


### PR DESCRIPTION
Remove all environ config entries from the configstore who's API
environment UUID endpoint matches that of the environment just
destroyed.

(Review request: http://reviews.vapour.ws/r/1690/)