### PR TITLE
worker/diskmanager: ignore non-{disk,loop} devices (master)

### DIFF
--- a/worker/diskmanager/lsblk.go
+++ b/worker/diskmanager/lsblk.go
@@ -23,9 +23,10 @@ import (
 var pairsRE = regexp.MustCompile(`([A-Z]+)=(?:"(.*?)")`)
 
 const (
-	// partitionType is the value of the TYPE column
-	// in lsblk output for partitions.
-	partitionType = "part"
+	// values for the TYPE column that we care about
+
+	typeDisk = "disk"
+	typeLoop = "loop"
 )
 
 func init() {
@@ -90,10 +91,13 @@ func listBlockDevices() ([]storage.BlockDevice, error) {
 			}
 		}
 
-		// Partitions may not be used, as there is no guarantee that the
-		// partition will remain available (and we don't model hierarchy).
-		if deviceType == partitionType {
-			logger.Debugf("ignoring partition: %+v", dev)
+		// We may later want to expand this, e.g. to handle lvm,
+		// dmraid, crypt, etc., but this is enough to cover bases
+		// for now.
+		switch deviceType {
+		case typeDisk, typeLoop:
+		default:
+			logger.Tracef("ignoring %q type device: %+v", deviceType, dev)
 			continue
 		}
 

--- a/worker/diskmanager/lsblk_test.go
+++ b/worker/diskmanager/lsblk_test.go
@@ -37,11 +37,11 @@ func (s *ListBlockDevicesSuite) TestListBlockDevices(c *gc.C) {
 	})
 	testing.PatchExecutable(c, s, "lsblk", `#!/bin/bash --norc
 cat <<EOF
-KNAME="sda" SIZE="240057409536" LABEL="" UUID=""
-KNAME="sda1" SIZE="254803968" LABEL="" UUID="7a62bd85-a350-4c09-8944-5b99bf2080c6" MOUNTPOINT="/tmp"
-KNAME="sda2" SIZE="1024" LABEL="boot" UUID=""
-KNAME="sdb" SIZE="32017047552" LABEL="" UUID=""
-KNAME="sdb1" SIZE="32015122432" LABEL="media" UUID="2c1c701d-f2ce-43a4-b345-33e2e39f9503" FSTYPE="ext4"
+KNAME="sda" SIZE="240057409536" LABEL="" UUID="" TYPE="disk"
+KNAME="sda1" SIZE="254803968" LABEL="" UUID="7a62bd85-a350-4c09-8944-5b99bf2080c6" MOUNTPOINT="/tmp" TYPE="disk"
+KNAME="sda2" SIZE="1024" LABEL="boot" UUID="" TYPE="disk"
+KNAME="sdb" SIZE="32017047552" LABEL="" UUID="" TYPE="disk"
+KNAME="sdb1" SIZE="32015122432" LABEL="media" UUID="2c1c701d-f2ce-43a4-b345-33e2e39f9503" FSTYPE="ext4" TYPE="disk"
 EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()
@@ -84,7 +84,7 @@ func (s *ListBlockDevicesSuite) TestListBlockDevicesBlockDeviceInUseError(c *gc.
 	})
 	testing.PatchExecutable(c, s, "lsblk", `#!/bin/bash --norc
 cat <<EOF
-KNAME="sda" SIZE="240057409536" LABEL="" UUID=""
+KNAME="sda" SIZE="240057409536" LABEL="" UUID="" TYPE="disk"
 EOF`)
 
 	// If the in-use check errors, the block device will be marked "in use"
@@ -103,8 +103,8 @@ func (s *ListBlockDevicesSuite) TestListBlockDevicesLsblkBadOutput(c *gc.C) {
 	// be logged and ignored (Size will be set to zero).
 	testing.PatchExecutable(c, s, "lsblk", `#!/bin/bash --norc
 cat <<EOF
-KNAME="sda" SIZE="eleventy" LABEL="" UUID=""
-KNAME="sdb" SIZE="1048576" LABEL="" UUID="" BOB="DOBBS"
+KNAME="sda" SIZE="eleventy" LABEL="" UUID="" TYPE="disk"
+KNAME="sdb" SIZE="1048576" LABEL="" UUID="" BOB="DOBBS" TYPE="disk"
 EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()
@@ -124,8 +124,8 @@ func (s *ListBlockDevicesSuite) TestListBlockDevicesDeviceNotExist(c *gc.C) {
 	})
 	testing.PatchExecutable(c, s, "lsblk", `#!/bin/bash --norc
 cat <<EOF
-KNAME="sda" SIZE="240057409536" LABEL="" UUID=""
-KNAME="sdb" SIZE="32017047552" LABEL="" UUID=""
+KNAME="sda" SIZE="240057409536" LABEL="" UUID="" TYPE="disk"
+KNAME="sdb" SIZE="32017047552" LABEL="" UUID="" TYPE="disk"
 EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()
@@ -133,11 +133,14 @@ EOF`)
 	c.Assert(devices, gc.HasLen, 0)
 }
 
-func (s *ListBlockDevicesSuite) TestListBlockDevicesDevicePartitions(c *gc.C) {
+func (s *ListBlockDevicesSuite) TestListBlockDevicesDeviceFiltering(c *gc.C) {
 	testing.PatchExecutable(c, s, "lsblk", `#!/bin/bash --norc
 cat <<EOF
 KNAME="sda" SIZE="240057409536" LABEL="" UUID="" TYPE="disk"
 KNAME="sda1" SIZE="254803968" LABEL="" UUID="" TYPE="part"
+KNAME="loop0" SIZE="254803968" LABEL="" UUID="" TYPE="loop"
+KNAME="sr0" SIZE="254803968" LABEL="" UUID="" TYPE="rom"
+KNAME="whatever" SIZE="254803968" LABEL="" UUID="" TYPE="lvm"
 EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()
@@ -145,5 +148,8 @@ EOF`)
 	c.Assert(devices, gc.DeepEquals, []storage.BlockDevice{{
 		DeviceName: "sda",
 		Size:       228936,
+	}, {
+		DeviceName: "loop0",
+		Size:       243,
 	}})
 }

--- a/worker/diskmanager/lsblk_test.go
+++ b/worker/diskmanager/lsblk_test.go
@@ -145,7 +145,7 @@ EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()
 	c.Assert(err, gc.IsNil)
-	c.Assert(devices, gc.DeepEquals, []storage.BlockDevice{{
+	c.Assert(devices, jc.SameContents, []storage.BlockDevice{{
 		DeviceName: "sda",
 		Size:       228936,
 	}, {


### PR DESCRIPTION
Forward port from 1.24.

We currently only care about "disk" and "loop" type block devices. Filter
out all others until we know that we need them. This is a periodic worker,
so there is no harm in filtering out now and adding them in later.

Fixes https://bugs.launchpad.net/juju-core/+bug/1454481

(Review request: http://reviews.vapour.ws/r/1697/)