### PR TITLE
ReturnCode and Stderr should be included on all exit codes.

### DIFF
--- a/cmd/juju/run.go
+++ b/cmd/juju/run.go
@@ -148,8 +148,6 @@ func ConvertRunResults(runResults []params.RunResult) interface{} {
 	var results = make([]interface{}, len(runResults))
 
 	for i, result := range runResults {
-		// We always want to have a string for stdout, but only show stderr,
-		// code and error if they are there.
 		values := make(map[string]interface{})
 		values["MachineId"] = result.MachineId
 		if result.UnitId != "" {
@@ -157,12 +155,10 @@ func ConvertRunResults(runResults []params.RunResult) interface{} {
 
 		}
 		storeOutput(values, "Stdout", result.Stdout)
-		if len(result.Stderr) > 0 {
-			storeOutput(values, "Stderr", result.Stderr)
-		}
-		if result.Code != 0 {
-			values["ReturnCode"] = result.Code
-		}
+		storeOutput(values, "Stderr", result.Stderr)
+
+		values["ReturnCode"] = result.Code
+
 		if result.Error != "" {
 			values["Error"] = result.Error
 		}

--- a/cmd/juju/run_test.go
+++ b/cmd/juju/run_test.go
@@ -168,8 +168,10 @@ func (s *RunSuite) TestConvertRunResults(c *gc.C) {
 		},
 		expected: []interface{}{
 			map[string]interface{}{
-				"MachineId": "1",
-				"Stdout":    "",
+				"MachineId":  "1",
+				"Stdout":     "",
+				"ReturnCode": 0,
+				"Stderr":     "",
 			}},
 	}, {
 		message: "other fields are copied if there",
@@ -209,6 +211,7 @@ func (s *RunSuite) TestConvertRunResults(c *gc.C) {
 				"Stdout":          "/w==",
 				"Stdout.encoding": "base64",
 				"Stderr":          "/g==",
+				"ReturnCode":      0,
 				"Stderr.encoding": "base64",
 			}},
 	}, {
@@ -220,16 +223,22 @@ func (s *RunSuite) TestConvertRunResults(c *gc.C) {
 		},
 		expected: []interface{}{
 			map[string]interface{}{
-				"MachineId": "1",
-				"Stdout":    "",
+				"ReturnCode": 0,
+				"MachineId":  "1",
+				"Stdout":     "",
+				"Stderr":     "",
 			},
 			map[string]interface{}{
-				"MachineId": "2",
-				"Stdout":    "",
+				"ReturnCode": 0,
+				"MachineId":  "2",
+				"Stdout":     "",
+				"Stderr":     "",
 			},
 			map[string]interface{}{
-				"MachineId": "3",
-				"Stdout":    "",
+				"ReturnCode": 0,
+				"MachineId":  "3",
+				"Stdout":     "",
+				"Stderr":     "",
 			},
 		},
 	}} {


### PR DESCRIPTION
For consistency ReturnCode and Stderr should be included on all exit codes.

Fixes LP: #1455284

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>