### PR TITLE
Fix last login to not use mgo.txt

### DIFF
--- a/state/collections_test.go
+++ b/state/collections_test.go
@@ -104,6 +104,28 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 			},
 			expectedCount: 0,
 		},
+		{
+			label: "Update",
+			test: func() (int, error) {
+				err := coll.Update(bson.D{{"_id", "bar"}},
+					bson.D{{"$set", bson.D{{"displayname", "Updated Bar"}}}})
+				c.Assert(err, jc.ErrorIsNil)
+
+				return coll.Find(bson.D{{"displayname", "Updated Bar"}}).Count()
+			},
+			expectedCount: 1,
+		},
+		{
+			label: "UpdateId",
+			test: func() (int, error) {
+				err := coll.UpdateId("bar",
+					bson.D{{"$set", bson.D{{"displayname", "Updated Bar"}}}})
+				c.Assert(err, jc.ErrorIsNil)
+
+				return coll.Find(bson.D{{"displayname", "Updated Bar"}}).Count()
+			},
+			expectedCount: 1,
+		},
 	} {
 		c.Logf("test %d: %s", i, t.label)
 		collSnapshot.restore(c)
@@ -406,6 +428,26 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 				return 0, nil
 			},
 			expectedPanic: "query must either be bson.D or nil",
+		},
+		{
+			label: "Update",
+			test: func() (int, error) {
+				err := machines0.Update(bson.D{{"_id", m0.Id()}},
+					bson.D{{"$set", bson.D{{"update-field", "field value"}}}})
+				c.Assert(err, jc.ErrorIsNil)
+				return machines0.Find(bson.D{{"update-field", "field value"}}).Count()
+			},
+			expectedCount: 1,
+		},
+		{
+			label: "UpdateId",
+			test: func() (int, error) {
+				err := machines0.UpdateId(m0.Id(),
+					bson.D{{"$set", bson.D{{"update-field", "field value"}}}})
+				c.Assert(err, jc.ErrorIsNil)
+				return machines0.Find(bson.D{{"update-field", "field value"}}).Count()
+			},
+			expectedCount: 1,
 		},
 	} {
 		c.Logf("test %d: %s", i, t.label)

--- a/state/user.go
+++ b/state/user.go
@@ -161,12 +161,18 @@ type userDoc struct {
 	Name        string `bson:"name"`
 	DisplayName string `bson:"displayname"`
 	// Removing users means they still exist, but are marked deactivated
-	Deactivated  bool       `bson:"deactivated"`
-	PasswordHash string     `bson:"passwordhash"`
-	PasswordSalt string     `bson:"passwordsalt"`
-	CreatedBy    string     `bson:"createdby"`
-	DateCreated  time.Time  `bson:"datecreated"`
-	LastLogin    *time.Time `bson:"lastlogin"`
+	Deactivated  bool      `bson:"deactivated"`
+	PasswordHash string    `bson:"passwordhash"`
+	PasswordSalt string    `bson:"passwordsalt"`
+	CreatedBy    string    `bson:"createdby"`
+	DateCreated  time.Time `bson:"datecreated"`
+	// LastLogin is updated by the apiserver whenever the user
+	// connects over the API. This update is not done using mgo.txn
+	// so this value could well change underneath a normal transaction
+	// and as such, it should NEVER appear in any transaction asserts.
+	// It is really informational only as far as everyone except the
+	// api server is concerned.
+	LastLogin *time.Time `bson:"lastlogin"`
 }
 
 // String returns "<name>@local" where <name> is the Name of the user.
@@ -235,14 +241,17 @@ var nowToTheSecond = func() time.Time { return time.Now().Round(time.Second).UTC
 // UpdateLastLogin sets the LastLogin time of the user to be now (to the
 // nearest second).
 func (u *User) UpdateLastLogin() error {
+	users, closer := u.st.getCollection(usersC)
+	defer closer()
+	// Update the safe mode of the underlying session to be not require
+	// write majority, nor sync to disk.
+	session := users.Underlying().Database.Session
+	session.SetSafe(&mgo.Safe{})
+
 	timestamp := nowToTheSecond()
-	ops := []txn.Op{{
-		C:      usersC,
-		Id:     u.Name(),
-		Assert: txn.DocExists,
-		Update: bson.D{{"$set", bson.D{{"lastlogin", timestamp}}}},
-	}}
-	if err := u.st.runTransaction(ops); err != nil {
+	update := bson.D{{"$set", bson.D{{"lastlogin", timestamp}}}}
+
+	if err := users.UpdateId(u.Name(), update); err != nil {
 		return errors.Annotatef(err, "cannot update last login timestamp for user %q", u.Name())
 	}
 


### PR DESCRIPTION
Forward port the 1.24 fix.

Extra comments have been added in the user and envUser structs in state.


(Review request: http://reviews.vapour.ws/r/1700/)