### PR TITLE
Storage config schema

### DIFF
--- a/provider/vsphere/ova_import_manager.go
+++ b/provider/vsphere/ova_import_manager.go
@@ -266,7 +266,7 @@ func (m *ovaImportManager) uploadImage(ofi ovaFileItem, basePath string) error {
 			curPercent := int(pr.Percentage())
 			if curPercent-lastPercent >= 10 {
 				lastPercent = curPercent
-				logger.Debugf("Progress: %d%", lastPercent)
+				logger.Debugf("Progress: %d%%", lastPercent)
 			}
 		}
 	}()

--- a/storage/poolmanager/poolmanager_test.go
+++ b/storage/poolmanager/poolmanager_test.go
@@ -115,7 +115,7 @@ func (s *poolSuite) TestCreateMissingType(c *gc.C) {
 
 func (s *poolSuite) TestCreateInvalidConfig(c *gc.C) {
 	_, err := s.poolManager.Create("testpool", storage.ProviderType("loop"), map[string]interface{}{"persistent": true})
-	c.Assert(err, gc.ErrorMatches, `machine scoped storage provider "testpool" does not support persistent storage`)
+	c.Assert(err, gc.ErrorMatches, `validating storage provider config: machine scoped storage provider "testpool" does not support persistent storage`)
 }
 
 func (s *poolSuite) TestDelete(c *gc.C) {

--- a/storage/provider/common.go
+++ b/storage/provider/common.go
@@ -20,10 +20,11 @@ func CommonProviders() map[storage.ProviderType]storage.Provider {
 	}
 }
 
-// ValidateConfig performs common provider config validation.
+// ValidateConfig performs storage provider config validation, including
+// any common validation.
 func ValidateConfig(p storage.Provider, cfg *storage.Config) error {
 	if p.Scope() == storage.ScopeMachine && cfg.IsPersistent() {
 		return errors.Errorf("machine scoped storage provider %q does not support persistent storage", cfg.Name())
 	}
-	return nil
+	return p.ValidateConfig(cfg)
 }

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -32,7 +32,7 @@ type loopProvider struct {
 var _ storage.Provider = (*loopProvider)(nil)
 
 // ValidateConfig is defined on the Provider interface.
-func (lp *loopProvider) ValidateConfig(cfg *storage.Config) error {
+func (*loopProvider) ValidateConfig(*storage.Config) error {
 	// Loop provider has no configuration.
 	return nil
 }


### PR DESCRIPTION
This branch introduces the use of juju/schema for storage pool config validation. The EBS and MAAS storage bits are updated, as well as common storage config.

We need to continue handling strings as well as lists of strings for things like MAAS tags, since in the CLI we don't don't have a structured format for specifying such values. We may later introduce a way of defining pools via YAML configuration, and that would certainly be possible through the API.

Unknown attributes are now ignored, rather than causing an error.

(Review request: http://reviews.vapour.ws/r/1701/)