### PR TITLE
When using blobstore to add/read images, retry in there's an i/o error

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -371,7 +371,9 @@ func (srv *Server) run(lis net.Listener) {
 	)
 	handleAll(mux, "/environment/:envuuid/api", http.HandlerFunc(srv.apiHandler))
 	handleAll(mux, "/environment/:envuuid/images/:kind/:series/:arch/:filename",
-		&imagesDownloadHandler{httpHandler{ssState: srv.state}},
+		&imagesDownloadHandler{
+			httpHandler: httpHandler{ssState: srv.state},
+			dataDir:     srv.dataDir},
 	)
 	// For backwards compatibility we register all the old paths
 	handleAll(mux, "/log",

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -11,9 +11,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/fslock"
 
 	"github.com/juju/juju/apiserver/common"
 	apihttp "github.com/juju/juju/apiserver/http"
@@ -22,11 +24,13 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/imagestorage"
+	"github.com/juju/juju/utils"
 )
 
 // imagesDownloadHandler handles image download through HTTPS in the API server.
 type imagesDownloadHandler struct {
 	httpHandler
+	dataDir string
 }
 
 func (h *imagesDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -79,15 +83,7 @@ func (h *imagesDownloadHandler) processGet(r *http.Request, resp http.ResponseWr
 	envuuid := r.URL.Query().Get(":envuuid")
 
 	// Get the image details from storage.
-	storage := st.ImageStorage()
-	metadata, imageReader, err := storage.Image(kind, series, arch)
-	// Not in storage, so go fetch it.
-	if errors.IsNotFound(err) {
-		metadata, imageReader, err = h.fetchAndCacheLxcImage(storage, envuuid, series, arch)
-		if err != nil {
-			return errors.Annotate(err, "error fetching and caching image")
-		}
-	}
+	metadata, imageReader, err := h.loadImage(st, envuuid, kind, series, arch)
 	if err != nil {
 		return errors.Annotate(err, "error getting image from storage")
 	}
@@ -105,14 +101,43 @@ func (h *imagesDownloadHandler) processGet(r *http.Request, resp http.ResponseWr
 	return nil
 }
 
-// fetchAndCacheLxcImage fetches an lxc image tarball from http://cloud-images.ubuntu.com
-// and caches it in the state blobstore.
-func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Storage, envuuid, series, arch string) (
+// loadImage loads an os image from the blobstore,
+// downloading and caching it if necessary.
+func (h *imagesDownloadHandler) loadImage(st *state.State, envuuid, kind, series, arch string) (
 	*imagestorage.Metadata, io.ReadCloser, error,
 ) {
+	// We want to ensure that if an image needs to be downloaded and cached,
+	// this only happens once.
+	imageIdent := fmt.Sprintf("image-%s-%s-%s-%s", envuuid, kind, series, arch)
+	lockDir := filepath.Join(h.dataDir, "locks")
+	lock, err := fslock.NewLock(lockDir, imageIdent)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	lock.Lock("fetch and cache image " + imageIdent)
+	defer lock.Unlock()
+	storage := st.ImageStorage()
+	metadata, imageReader, err := storage.Image(kind, series, arch)
+	// Not in storage, so go fetch it.
+	if errors.IsNotFound(err) {
+		err = h.fetchAndCacheLxcImage(storage, envuuid, series, arch)
+		if err != nil {
+			return nil, nil, errors.Annotate(err, "error fetching and caching image")
+		}
+		err = utils.NetworkOperationWitDefaultRetries(func() error {
+			metadata, imageReader, err = storage.Image(string(instance.LXC), series, arch)
+			return err
+		}, "streaming os image from blobstore")()
+	}
+	return metadata, imageReader, err
+}
+
+// fetchAndCacheLxcImage fetches an lxc image tarball from http://cloud-images.ubuntu.com
+// and caches it in the state blobstore.
+func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Storage, envuuid, series, arch string) error {
 	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch)
 	if err != nil {
-		return nil, nil, errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
+		return errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}
 
 	// Fetch the image checksum.
@@ -120,12 +145,12 @@ func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Stora
 	shafile := strings.Replace(imageURL, imageFilename, "SHA256SUMS", -1)
 	shaResp, err := http.Get(shafile)
 	if err != nil {
-		return nil, nil, errors.Annotatef(err, "cannot get sha256 data from %v", shafile)
+		return errors.Annotatef(err, "cannot get sha256 data from %v", shafile)
 	}
 	defer shaResp.Body.Close()
 	shaInfo, err := ioutil.ReadAll(shaResp.Body)
 	if err != nil {
-		return nil, nil, errors.Annotatef(err, "cannot read sha256 data from %v", shafile)
+		return errors.Annotatef(err, "cannot read sha256 data from %v", shafile)
 	}
 
 	// The sha file has lines like:
@@ -142,14 +167,14 @@ func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Stora
 		}
 	}
 	if checksum == "" {
-		return nil, nil, errors.Errorf("cannot find sha256 checksum for %v", imageFilename)
+		return errors.Errorf("cannot find sha256 checksum for %v", imageFilename)
 	}
 
 	// Fetch the image.
 	logger.Debugf("fetching LXC image from: %v", imageURL)
 	resp, err := http.Get(imageURL)
 	if err != nil {
-		return nil, nil, errors.Annotatef(err, "cannot get image from %v", imageURL)
+		return errors.Annotatef(err, "cannot get image from %v", imageURL)
 	}
 	logger.Debugf("lxc image has size: %v bytes", resp.ContentLength)
 	defer resp.Body.Close()
@@ -169,18 +194,22 @@ func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Stora
 	}
 
 	// Stream the image to storage.
-	err = storage.AddImage(rdr, metadata)
+	err = utils.NetworkOperationWitDefaultRetries(func() error {
+		return storage.AddImage(rdr, metadata)
+	}, "add os image to blobstore")()
 	if err != nil {
-		return nil, nil, err
+		return errors.Trace(err)
 	}
 	// Better check the downloaded image checksum.
 	downloadChecksum := fmt.Sprintf("%x", hash.Sum(nil))
 	if downloadChecksum != checksum {
-		if err := storage.DeleteImage(metadata); err != nil {
+		err = utils.NetworkOperationWitDefaultRetries(func() error {
+			return storage.DeleteImage(metadata)
+		}, "delete os image from blobstore")()
+		if err != nil {
 			logger.Errorf("checksum mismatch, failed to delete image from storage: %v", err)
 		}
-		return nil, nil, errors.Errorf("download checksum mismatch %s != %s", downloadChecksum, checksum)
+		return errors.Errorf("download checksum mismatch %s != %s", downloadChecksum, checksum)
 	}
-
-	return storage.Image(string(instance.LXC), series, arch)
+	return nil
 }

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -129,7 +129,10 @@ func (h *imagesDownloadHandler) loadImage(st *state.State, envuuid, kind, series
 			return err
 		}, "streaming os image from blobstore")()
 	}
-	return metadata, imageReader, err
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return metadata, imageReader, nil
 }
 
 // fetchAndCacheLxcImage fetches an lxc image tarball from http://cloud-images.ubuntu.com

--- a/utils/network.go
+++ b/utils/network.go
@@ -12,9 +12,14 @@ import (
 )
 
 var (
+	// The defaults below are best suited to retries associated
+	// with disk I/O timeouts, eg database operations.
+	// Use the NetworkOperationWithRetries() variant to explicitly
+	// use retry values better suited to different scenarios.
+
 	// DefaultNetworkOperationRetryDelay is the default time
 	// to wait between operation retries.
-	DefaultNetworkOperationRetryDelay = 1 * time.Minute
+	DefaultNetworkOperationRetryDelay = 30 * time.Second
 
 	// DefaultNetworkOperationAttempts is the default number
 	// of attempts before giving up.

--- a/utils/network.go
+++ b/utils/network.go
@@ -1,0 +1,51 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"net"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+)
+
+var (
+	// DefaultNetworkOperationRetryDelay is the default time
+	// to wait between operation retries.
+	DefaultNetworkOperationRetryDelay = 1 * time.Minute
+
+	// DefaultNetworkOperationAttempts is the default number
+	// of attempts before giving up.
+	DefaultNetworkOperationAttempts = 10
+)
+
+// NetworkOperationWithDefaultRetries calls the supplied function and if it returns a
+// network error which is temporary, will retry a number of times before giving up.
+// A default attempt strategy is used.
+func NetworkOperationWitDefaultRetries(networkOp func() error, description string) func() error {
+	attempt := utils.AttemptStrategy{
+		Delay: DefaultNetworkOperationRetryDelay,
+		Min:   DefaultNetworkOperationAttempts,
+	}
+	return NetworkOperationWithRetries(attempt, networkOp, description)
+}
+
+// NetworkOperationWithRetries calls the supplied function and if it returns a
+// network error which is temporary, will retry a number of times before giving up.
+func NetworkOperationWithRetries(strategy utils.AttemptStrategy, networkOp func() error, description string) func() error {
+	return func() error {
+		for a := strategy.Start(); a.Next(); {
+			err := networkOp()
+			if !a.HasNext() || err == nil {
+				return errors.Trace(err)
+			}
+			if networkErr, ok := errors.Cause(err).(net.Error); !ok || !networkErr.Temporary() {
+				return errors.Trace(err)
+			}
+			logger.Debugf("%q error, will retry: %v", description, err)
+		}
+		panic("unreachable")
+	}
+}

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -1,0 +1,103 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/utils"
+)
+
+type networkSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&networkSuite{})
+
+func (s *networkSuite) TestOpSuccess(c *gc.C) {
+	isCalled := false
+	f := func() error {
+		isCalled = true
+		return nil
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isCalled, jc.IsTrue)
+}
+
+func (s *networkSuite) TestOpFailureNoRetry(c *gc.C) {
+	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	netErr := &netError{false}
+	callCount := 0
+	f := func() error {
+		callCount += 1
+		return netErr
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(errors.Cause(err), gc.Equals, netErr)
+	c.Assert(callCount, gc.Equals, 1)
+}
+
+func (s *networkSuite) TestOpFailureRetries(c *gc.C) {
+	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	netErr := &netError{true}
+	callCount := 0
+	f := func() error {
+		callCount += 1
+		return netErr
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(errors.Cause(err), gc.Equals, netErr)
+	c.Assert(callCount, gc.Equals, 10)
+}
+
+func (s *networkSuite) TestOpNestedFailureRetries(c *gc.C) {
+	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	netErr := &netError{true}
+	callCount := 0
+	f := func() error {
+		callCount += 1
+		return errors.Annotate(errors.Trace(netErr), "create a wrapped error")
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(errors.Cause(err), gc.Equals, netErr)
+	c.Assert(callCount, gc.Equals, 10)
+}
+
+func (s *networkSuite) TestOpSucceedsAfterRetries(c *gc.C) {
+	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	netErr := &netError{true}
+	callCount := 0
+	f := func() error {
+		callCount += 1
+		if callCount == 5 {
+			return nil
+		}
+		return netErr
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(callCount, gc.Equals, 5)
+}
+
+type netError struct {
+	temporary bool
+}
+
+func (e *netError) Error() string {
+	return "network error"
+}
+
+func (e *netError) Temporary() bool {
+	return e.temporary
+}
+
+func (e *netError) Timeout() bool {
+	return false
+}

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -36,7 +36,7 @@ func (s *networkSuite) TestOpFailureNoRetry(c *gc.C) {
 	netErr := &netError{false}
 	callCount := 0
 	f := func() error {
-		callCount += 1
+		callCount++
 		return netErr
 	}
 	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
@@ -49,7 +49,7 @@ func (s *networkSuite) TestOpFailureRetries(c *gc.C) {
 	netErr := &netError{true}
 	callCount := 0
 	f := func() error {
-		callCount += 1
+		callCount++
 		return netErr
 	}
 	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
@@ -62,7 +62,7 @@ func (s *networkSuite) TestOpNestedFailureRetries(c *gc.C) {
 	netErr := &netError{true}
 	callCount := 0
 	f := func() error {
-		callCount += 1
+		callCount++
 		return errors.Annotate(errors.Trace(netErr), "create a wrapped error")
 	}
 	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
@@ -75,7 +75,7 @@ func (s *networkSuite) TestOpSucceedsAfterRetries(c *gc.C) {
 	netErr := &netError{true}
 	callCount := 0
 	f := func() error {
-		callCount += 1
+		callCount++
 		if callCount == 5 {
 			return nil
 		}


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1454676

We have a couple of issues when deployer is used to deploy a bundle and everything is done at once.
Firstly, I/O contention - fetching and storing the LXC image template in the blob store fails due to an I/O timeout. Some LXC containers do start, so Juju should just retry in such cases.
The other issue is that multiple downloads of the same image are allowed to occur - if a download for a given image is already in progress, any new requests should wait and use that image once the initial download completes.

So a helper is created that can be used to retry transient network operations that fail. This is just used here for loading/saving images to blob store, but can be used elsewhere when needed.
The other fix is to add a lock to the image fetching so that it only happens once. This reduces I/O contention on the blobstore, and fixes an obvious implementation inefficiency.

(Review request: http://reviews.vapour.ws/r/1709/)