### PR TITLE
backport http://reviews.vapour.ws/r/1706/ to 1.22

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils"
 	"github.com/juju/utils/parallel"
+	"golang.org/x/net/websocket"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cert"

--- a/api/client.go
+++ b/api/client.go
@@ -16,11 +16,11 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils"
+	"golang.org/x/net/websocket"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/juju/api/base"

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -15,11 +15,11 @@ import (
 	"net/url"
 	"strings"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -14,11 +14,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/bmizerany/pat"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils"
+	"golang.org/x/net/websocket"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/common"

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -15,10 +15,10 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/tailer"
+	"golang.org/x/net/websocket"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/params"

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -16,9 +16,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"code.google.com/p/go.net/websocket"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -13,10 +13,10 @@ import (
 	stdtesting "testing"
 	"time"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"

--- a/cmd/juju/addrelation_test.go
+++ b/cmd/juju/addrelation_test.go
@@ -4,9 +4,10 @@
 package main
 
 import (
+	"strings"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/juju/cmd/envcmd"

--- a/cmd/juju/authorizedkeys_add.go
+++ b/cmd/juju/authorizedkeys_add.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 	"fmt"
+
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/cmd"

--- a/cmd/juju/authorizedkeys_delete.go
+++ b/cmd/juju/authorizedkeys_delete.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 	"fmt"
+
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/cmd"

--- a/cmd/juju/authorizedkeys_import.go
+++ b/cmd/juju/authorizedkeys_import.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 	"fmt"
+
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/cmd"

--- a/cmd/juju/block/block_test.go
+++ b/cmd/juju/block/block_test.go
@@ -4,8 +4,9 @@
 package block_test
 
 import (
-	gc "gopkg.in/check.v1"
 	"strings"
+
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"

--- a/cmd/juju/block/package_test.go
+++ b/cmd/juju/block/package_test.go
@@ -4,8 +4,9 @@
 package block_test
 
 import (
-	gc "gopkg.in/check.v1"
 	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/testing"

--- a/cmd/juju/expose_test.go
+++ b/cmd/juju/expose_test.go
@@ -8,12 +8,13 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 
+	"strings"
+
 	"github.com/juju/cmd"
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
-	"strings"
 )
 
 type ExposeSuite struct {

--- a/cmd/juju/resolved_test.go
+++ b/cmd/juju/resolved_test.go
@@ -4,9 +4,10 @@
 package main
 
 import (
+	"strings"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"strings"
 
 	"github.com/juju/cmd"
 

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	"fmt"
+
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	apirsyslog "github.com/juju/juju/api/rsyslog"

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,7 +1,6 @@
 bitbucket.org/kardianos/osext	hg	44140c5fc69ecf1102c5ef451d73cd98ef59b178	14
 bitbucket.org/kardianos/service	hg	d2fd4f8afd23d9b5d57250b8d3f0bc0c8bf363ec	58
 code.google.com/p/go.crypto	hg	aa2644fe4aa50e3b38d75187b4799b1f0c9ddcef	212
-code.google.com/p/go.net	hg	c17ad62118ea511e1051721b429779fa40bddc74	116
 code.google.com/p/winsvc	hg	d6f79143ccd1138cc9d86c9fc75b1d6f8b1b95fb	10
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
 github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
@@ -23,6 +22,7 @@ github.com/juju/testing	git	e35bf4acb97c4e7acda329bd7430f14ee968346b	2015-03-31T
 github.com/juju/txn	git	2407a1fa094db5603f4718f11e1fafc8543273eb	2015-03-27T15:47:42Z
 github.com/juju/utils	git	732e0c300dc0f35c597e788a4366372065c27b7c	2015-03-30T21:32:30Z
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
+golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T00:00:00Z
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	2014-08-27T13:58:41Z
 gopkg.in/juju/charm.v4	git	bda488208a9b58565a532d8eb5589bedd2897616	2015-03-30T15:28:11Z
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	2014-07-30T20:00:37Z

--- a/lease/lease_test.go
+++ b/lease/lease_test.go
@@ -4,10 +4,11 @@
 package lease
 
 import (
-	coretesting "github.com/juju/juju/testing"
-	gc "gopkg.in/check.v1"
 	"testing"
 	"time"
+
+	coretesting "github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { gc.TestingT(t) }

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"code.google.com/p/go.net/websocket"
 	jc "github.com/juju/testing/checkers"
+	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/rpc"

--- a/rpc/jsoncodec/conn.go
+++ b/rpc/jsoncodec/conn.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 // NewWebsocket returns an rpc codec that uses the given websocket


### PR DESCRIPTION
As 1.22 was using the obsolute code.google.com/p/go.net repository
this change was not as simple as updating the revisions of x/net/websocket.

These changes were made my using sed to remove the code.google.com/p/go.net
entries, then running goimports -w . over juju. The other refactorings to the
import statements and groupings are entirely machine generated. I don't care
enough to twiddle with them, at least they are consistent with whatever
goimports thinks is sensible, and that is ok with me.

(Review request: http://reviews.vapour.ws/r/1711/)