### PR TITLE
Storage add cli.

### DIFF
--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils/keyvalues"
-	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/storage"
@@ -82,11 +81,6 @@ func (c *AddCommand) Info() *cmd.Info {
 	}
 }
 
-// SetFlags implements Command.SetFlags.
-func (c *AddCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.StorageCommandBase.SetFlags(f)
-}
-
 // Run implements Command.Run.
 func (c *AddCommand) Run(ctx *cmd.Context) (err error) {
 	api, err := getStorageAddAPI(c)
@@ -101,29 +95,29 @@ func (c *AddCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	// If there are any failures, display them first.
-	// Then display all successes.
+	// Then display all added storage.
 	// If there are no failures, then there is no need to display all successes.
-	var success []string
+	var added []string
+
 	for i, one := range results {
 		us := storages[i]
-		msgPrefix := fmt.Sprintf("storage %q", us.StorageName)
 		if one.Error != nil {
-			err := errors.Annotatef(one.Error, "%v %v", failMsg, msgPrefix)
-			fmt.Fprintln(ctx.Stderr, err.Error())
+			fmt.Fprintf(ctx.Stderr, fail+": %v\n", us.StorageName, one.Error)
 			continue
 		}
-		success = append(success, successMsg+msgPrefix)
+		added = append(added, fmt.Sprintf(success, us.StorageName))
 	}
-	if len(success) < len(storages) {
-		fmt.Fprintf(ctx.Stderr, strings.Join(success, "\n"))
+	if len(added) < len(storages) {
+		fmt.Fprintf(ctx.Stderr, strings.Join(added, "\n"))
 	}
 	return nil
 }
 
 var (
 	getStorageAddAPI = (*AddCommand).getStorageAddAPI
-	successMsg       = "success: "
-	failMsg          = "fail:"
+	storageName      = "storage %q"
+	success          = "success: " + storageName
+	fail             = "fail: " + storageName
 )
 
 // StorageAddAPI defines the API methods that the storage commands use.

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -1,0 +1,154 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils/keyvalues"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/storage"
+)
+
+const AddCommandDoc = `
+Add storage instances to a unit dynamically.
+Specify a unit and a storage specification in the same format 
+as passed to juju deploy --storage=”...”.
+
+* note use of positional arguments
+
+options:
+-e, --environment (= "")
+    juju environment to operate in
+-o, --output (= "")
+    specify an output 
+<unit name> 
+    unit name
+<storage spec>
+    storage spec
+`
+
+// AddCommand adds unit storage instances dynamically.
+type AddCommand struct {
+	StorageCommandBase
+	unitTag string
+
+	// storageCons is a map of storage constraints, keyed on the storage name
+	// defined in charm storage metadata.
+	storageCons map[string]storage.Constraints
+}
+
+// Init implements Command.Init.
+func (c *AddCommand) Init(args []string) (err error) {
+	if len(args) < 2 {
+		return errors.New("storage add requires a unit and a storage directive")
+	}
+
+	u := args[0]
+	if !names.IsValidUnit(u) {
+		return errors.NotValidf("unit name %q", u)
+	}
+	c.unitTag = names.NewUnitTag(u).String()
+
+	options, err := keyvalues.Parse(args[1:], true)
+	if err != nil {
+		return err
+	}
+	c.storageCons = make(map[string]storage.Constraints, len(options))
+	for key, value := range options {
+		cons, err := storage.ParseConstraints(value)
+		if err != nil {
+			return errors.Annotatef(err, "cannot parse constraints for storage %q", key)
+		}
+		c.storageCons[key] = cons
+	}
+
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *AddCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "add",
+		Purpose: "adds unit storage dynamically",
+		Doc:     AddCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *AddCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.StorageCommandBase.SetFlags(f)
+}
+
+// Run implements Command.Run.
+func (c *AddCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := getStorageAddAPI(c)
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	storages := c.createStorageAddParams()
+	results, err := api.AddToUnit(storages)
+	if err != nil {
+		return err
+	}
+	// If there are any failures, display them first.
+	// Then display all successes.
+	// If there are no failures, then there is no need to display all successes.
+	var success []string
+	for i, one := range results {
+		us := storages[i]
+		msgPrefix := fmt.Sprintf("storage %q", us.StorageName)
+		if one.Error != nil {
+			err := errors.Annotatef(one.Error, "%v %v", failMsg, msgPrefix)
+			fmt.Fprintln(ctx.Stderr, err.Error())
+			continue
+		}
+		success = append(success, successMsg+msgPrefix)
+	}
+	if len(success) < len(storages) {
+		fmt.Fprintf(ctx.Stderr, strings.Join(success, "\n"))
+	}
+	return nil
+}
+
+var (
+	getStorageAddAPI = (*AddCommand).getStorageAddAPI
+	successMsg       = "success: "
+	failMsg          = "fail:"
+)
+
+// StorageAddAPI defines the API methods that the storage commands use.
+type StorageAddAPI interface {
+	Close() error
+	AddToUnit(storages []params.StorageAddParams) ([]params.ErrorResult, error)
+}
+
+func (c *AddCommand) getStorageAddAPI() (StorageAddAPI, error) {
+	return c.NewStorageAPI()
+}
+
+func (c *AddCommand) createStorageAddParams() []params.StorageAddParams {
+	all := make([]params.StorageAddParams, 0, len(c.storageCons))
+	for one, cons := range c.storageCons {
+		all = append(all,
+			params.StorageAddParams{
+				UnitTag:     c.unitTag,
+				StorageName: one,
+				Constraints: params.StorageConstraints{
+					cons.Pool,
+					&cons.Size,
+					&cons.Count,
+				},
+			})
+	}
+	return all
+}

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -16,23 +16,21 @@ import (
 	"github.com/juju/juju/storage"
 )
 
-const AddCommandDoc = `
+const (
+	addCommandDoc = `
 Add storage instances to a unit dynamically.
 Specify a unit and a storage specification in the same format 
 as passed to juju deploy --storage=”...”.
 
-* note use of positional arguments
-
-options:
--e, --environment (= "")
-    juju environment to operate in
--o, --output (= "")
-    specify an output 
-<unit name> 
-    unit name
-<storage spec>
-    storage spec
+Example:
+    juju storage add u/0 data=ebs,1024,3 
+    Add 3 ebs storage instances for "data" storage to unit u/0. 
 `
+	addCommandAgs = `
+<unit name> <storage directive> ...
+    where storage directive is <charm storage name=<storage constraints>
+`
+)
 
 // AddCommand adds unit storage instances dynamically.
 type AddCommand struct {
@@ -77,7 +75,8 @@ func (c *AddCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add",
 		Purpose: "adds unit storage dynamically",
-		Doc:     AddCommandDoc,
+		Doc:     addCommandDoc,
+		Args:    addCommandAgs,
 	}
 }
 

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/storage"
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
+)
+
+type AddSuite struct {
+	SubStorageSuite
+	mockAPI *mockAddAPI
+	args    []string
+}
+
+var _ = gc.Suite(&AddSuite{})
+
+func (s *AddSuite) SetUpTest(c *gc.C) {
+	s.SubStorageSuite.SetUpTest(c)
+
+	s.mockAPI = &mockAddAPI{}
+	s.PatchValue(storage.GetStorageAddAPI, func(c *storage.AddCommand) (storage.StorageAddAPI, error) {
+		return s.mockAPI, nil
+	})
+	s.args = nil
+}
+
+func (s *AddSuite) TestAddNoArgs(c *gc.C) {
+	s.assertAddErrorOutput(c, ".*storage add requires a unit and a storage directive.*")
+}
+
+func (s *AddSuite) TestAddOnlyUnit(c *gc.C) {
+	s.args = []string{"tst/123"}
+	s.assertAddErrorOutput(c, ".*storage add requires a unit and a storage directive.*")
+}
+
+func (s *AddSuite) TestAddNoConstraints(c *gc.C) {
+	s.args = []string{"tst/123", "data"}
+	s.assertAddErrorOutput(c, `.*expected "key=value", got "data".*`)
+}
+
+func (s *AddSuite) TestAddEmptyConstraints(c *gc.C) {
+	s.args = []string{"tst/123", "data="}
+	s.assertAddErrorOutput(c, ".*storage constraints require at least one field to be specified.*")
+}
+
+func (s *AddSuite) TestAddUnparseableConstraints(c *gc.C) {
+	s.args = []string{"tst/123", "data=-676"}
+	s.assertAddErrorOutput(c, `.*count must be greater than zero, got "-676".*`)
+}
+
+func runAdd(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, envcmd.Wrap(&storage.AddCommand{}), args...)
+}
+
+func (s *AddSuite) TestAddInvalidUnit(c *gc.C) {
+	s.args = []string{"tst-123", "data=676"}
+	s.assertAddErrorOutput(c, `.*unit name "tst-123" not valid.*`)
+}
+
+func (s *AddSuite) assertAddErrorOutput(c *gc.C, expected string) {
+	_, err := runAdd(c, s.args...)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, expected)
+}
+
+func (s *AddSuite) TestAddSuccess(c *gc.C) {
+	s.args = []string{"tst/123", "data=676"}
+	s.assertAddOutput(c, "", "")
+}
+
+func (s *AddSuite) TestAddOperationAborted(c *gc.C) {
+	s.args = []string{"tst/123", "data=676"}
+	s.mockAPI.abort = true
+	s.assertAddErrorOutput(c, ".*aborted.*")
+}
+
+func (s *AddSuite) TestAddFailure(c *gc.C) {
+	s.args = []string{"tst/123", "err=676"}
+	s.assertAddOutput(c, "", "fail: storage \"err\": test failure\n")
+}
+
+func (s *AddSuite) TestAddMixOrderPreserved(c *gc.C) {
+	expectedErr := `
+fail: storage "err": test failure
+success: storage "a"`[1:]
+
+	s.args = []string{"tst/123", "a=676", "err=676"}
+	s.assertAddOutput(c, "", expectedErr)
+
+	s.args = []string{"tst/123", "err=676", "a=676"}
+	s.assertAddOutput(c, "", expectedErr)
+}
+
+func (s *AddSuite) assertAddOutput(c *gc.C, expectedValid, expectedErr string) {
+	context, err := runAdd(c, s.args...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtainedErr := testing.Stderr(context)
+	c.Assert(obtainedErr, gc.Equals, expectedErr)
+
+	obtainedValid := testing.Stdout(context)
+	c.Assert(obtainedValid, gc.Equals, expectedValid)
+}
+
+type mockAddAPI struct {
+	abort bool
+}
+
+func (s mockAddAPI) Close() error {
+	return nil
+}
+
+func (s mockAddAPI) AddToUnit(storages []params.StorageAddParams) ([]params.ErrorResult, error) {
+	if s.abort {
+		return nil, errors.New("aborted")
+	}
+	result := make([]params.ErrorResult, len(storages))
+	for i, one := range storages {
+		if strings.HasPrefix(one.StorageName, "err") {
+			result[i].Error = common.ServerError(fmt.Errorf("test failure"))
+		}
+	}
+	return result, nil
+}

--- a/cmd/juju/storage/export_test.go
+++ b/cmd/juju/storage/export_test.go
@@ -11,4 +11,5 @@ var (
 	GetVolumeListAPI  = &getVolumeListAPI
 
 	ConvertToVolumeInfo = convertToVolumeInfo
+	GetStorageAddAPI    = &getStorageAddAPI
 )

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -24,7 +24,7 @@ options:
    specify output format (json|tabular|yaml)
 `
 
-// ListCommand attempts to release storage instance.
+// ListCommand returns storage instances.
 type ListCommand struct {
 	StorageCommandBase
 	out cmd.Output

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -41,6 +41,7 @@ func NewSuperCommand() cmd.Command {
 			})}
 	storagecmd.Register(envcmd.Wrap(&ShowCommand{}))
 	storagecmd.Register(envcmd.Wrap(&ListCommand{}))
+	storagecmd.Register(envcmd.Wrap(&AddCommand{}))
 	storagecmd.Register(NewPoolSuperCommand())
 	storagecmd.Register(NewVolumeSuperCommand())
 	return &storagecmd

--- a/cmd/juju/storage/storage_test.go
+++ b/cmd/juju/storage/storage_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 var expectedSubCommmandNames = []string{
+	"add",
 	"help",
 	"list",
 	"pool",

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -420,6 +420,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitSuccess(c *gc.C) {
 	u := createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 	before, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageExist(c, before, "data")
 
 	context := runAddToUnit(c, u, "allecto=1")
 	c.Assert(testing.Stdout(context), gc.Equals, "")
@@ -428,6 +429,18 @@ func (s *cmdStorageSuite) TestStorageAddToUnitSuccess(c *gc.C) {
 	after, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(after)-len(before), gc.Equals, 1)
+	s.assertStorageExist(c, after, "data", "allecto")
+}
+
+func (s *cmdStorageSuite) assertStorageExist(c *gc.C,
+	all []state.StorageInstance,
+	expected ...string) {
+
+	names := make([]string, len(all))
+	for i, one := range all {
+		names[i] = one.StorageName()
+	}
+	c.Assert(names, jc.SameContents, expected)
 }
 
 func (s *cmdStorageSuite) TestStorageAddToUnitFailure(c *gc.C) {

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -55,10 +55,7 @@ func createUnitWithStorage(c *gc.C, s *jujutesting.JujuConnSuite, poolName strin
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 
-	machineId, err := unit.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-
-	return machineId
+	return unit.Tag().Id()
 }
 
 type cmdStorageSuite struct {
@@ -411,4 +408,30 @@ MACHINE  UNIT             STORAGE  DEVICE  VOLUME  ID  SIZE
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 	c.Assert(testing.Stderr(context), gc.Equals, "")
+}
+
+func runAddToUnit(c *gc.C, args ...string) *cmd.Context {
+	context, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.AddCommand{}), args...)
+	c.Assert(err, jc.ErrorIsNil)
+	return context
+}
+
+func (s *cmdStorageSuite) TestStorageAddToUnitSuccess(c *gc.C) {
+	u := createUnitWithStorage(c, &s.JujuConnSuite, testPool)
+	before, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+
+	context := runAddToUnit(c, u, "allecto=1")
+	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(testing.Stderr(context), gc.Equals, "")
+
+	after, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(after)-len(before), gc.Equals, 1)
+}
+
+func (s *cmdStorageSuite) TestStorageAddToUnitFailure(c *gc.C) {
+	context := runAddToUnit(c, "fluffyunit/0", "allecto=1")
+	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(testing.Stderr(context), gc.Equals, "fail: storage \"allecto\": permission denied\n")
 }


### PR DESCRIPTION
We want to add storage instances to a unit dynamically.
This is a storage add command, `juju storage add <unit name> <charm storage name>=<disk constraints>`.
Feature tests ensure that the full "storage add" stack is reachable.


(Review request: http://reviews.vapour.ws/r/1712/)