### PR TITLE
Increment 1.22 for a .4 release.

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "1.22.3"
+#define MyAppVersion "1.22.4"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.ubuntu.com/"
 #define MyAppExeName "juju.exe"

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "1.22.3"
+const version = "1.22.4"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
CI will not test a released version. It knows that 1.22.3 is released and to release a replacement is either a malicious trojan or a careless mistake that will break deployments because of checksum mismatches.

(Review request: http://reviews.vapour.ws/r/1713/)