### PR TITLE
IP addresses are released on machine destruction

### DIFF
--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
 
@@ -54,6 +55,7 @@ type ipaddressDoc struct {
 	Life        Life         `bson:"life"`
 	SubnetId    string       `bson:"subnetid,omitempty"`
 	MachineId   string       `bson:"machineid,omitempty"`
+	InstanceId  string       `bson:"instanceid,omitempty"`
 	InterfaceId string       `bson:"interfaceid,omitempty"`
 	Value       string       `bson:"value"`
 	Type        string       `bson:"type"`
@@ -66,6 +68,11 @@ func (i *IPAddress) Life() Life {
 	return i.doc.Life
 }
 
+// Id returns the ID of the IP address.
+func (i *IPAddress) Id() string {
+	return i.doc.DocID
+}
+
 // SubnetId returns the ID of the subnet the IP address is associated with. If
 // the address is not associated with a subnet this returns "".
 func (i *IPAddress) SubnetId() string {
@@ -76,6 +83,14 @@ func (i *IPAddress) SubnetId() string {
 // the address is not associated with a machine this returns "".
 func (i *IPAddress) MachineId() string {
 	return i.doc.MachineId
+}
+
+// InstanceId returns the provider ID of the instance the IP address is
+// associated with. For a container this will be the ID of the host. If
+// the address is not associated with an instance this returns "" (the same as
+// instance.UnknownId).
+func (i *IPAddress) InstanceId() instance.Id {
+	return instance.Id(i.doc.InstanceId)
 }
 
 // InterfaceId returns the ID of the network interface the IP address is
@@ -143,12 +158,9 @@ func (i *IPAddress) EnsureDead() (err error) {
 			}
 			return nil, errors.Errorf("unexpected life value: %s", i.Life().String())
 		}
-		return []txn.Op{{
-			C:      ipaddressesC,
-			Id:     i.doc.DocID,
-			Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
-			Assert: isAliveDoc,
-		}}, nil
+		op := ensureIPAddressDeadOp(i)
+		op.Assert = isAliveDoc
+		return []txn.Op{op}, nil
 	}
 
 	err = i.st.run(buildTxn)
@@ -236,6 +248,21 @@ func (i *IPAddress) SetState(newState AddressState) (err error) {
 func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot allocate IP address %q to machine %q, interface %q", i, machineId, interfaceId)
 
+	var instId instance.Id
+	machine, err := i.st.Machine(machineId)
+	if err != nil {
+		return errors.Annotatef(err, "cannot get allocated machine %q", machineId)
+	} else {
+		instId, err = machine.InstanceId()
+
+		if errors.IsNotProvisioned(err) {
+			// The machine is not yet provisioned. The instance ID will be
+			// set on provisioning.
+			instId = instance.UnknownId
+		} else if err != nil {
+			return errors.Annotatef(err, "cannot get machine %q instance ID", machineId)
+		}
+	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := i.Refresh(); errors.IsNotFound(err) {
@@ -256,6 +283,7 @@ func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
 			Update: bson.D{{"$set", bson.D{
 				{"machineid", machineId},
 				{"interfaceid", interfaceId},
+				{"instanceid", instId},
 				{"state", string(AddressStateAllocated)},
 			}}},
 		}}, nil
@@ -268,6 +296,7 @@ func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
 	i.doc.MachineId = machineId
 	i.doc.InterfaceId = interfaceId
 	i.doc.State = AddressStateAllocated
+	i.doc.InstanceId = string(instId)
 	return nil
 }
 
@@ -286,4 +315,13 @@ func (i *IPAddress) Refresh() error {
 		return errors.Annotatef(err, "cannot refresh IP address %q", i)
 	}
 	return nil
+}
+
+func ensureIPAddressDeadOp(addr *IPAddress) txn.Op {
+	op := txn.Op{
+		C:      ipaddressesC,
+		Id:     addr.Id(),
+		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
+	}
+	return op
 }

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -291,7 +291,6 @@ func (s *IPAddressSuite) TestAddress(c *gc.C) {
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.Address(), jc.DeepEquals, addr)
-
 }
 
 func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
@@ -317,7 +316,6 @@ func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []*state.IPAddress{addr1, addr2}
 	c.Assert(result, jc.SameContents, expected)
-
 }
 
 func (s *IPAddressSuite) TestDeadIPAddresses(c *gc.C) {

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
@@ -37,6 +38,16 @@ func (s *IPAddressSuite) assertAddress(
 	c.Assert(ipAddr.State(), gc.Equals, ipState)
 	c.Assert(ipAddr.Address(), jc.DeepEquals, addr)
 	c.Assert(ipAddr.String(), gc.Equals, addr.String())
+	c.Assert(ipAddr.Id(), gc.Equals, s.State.EnvironUUID()+":"+addr.Value)
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.UnknownId)
+}
+
+func (s *IPAddressSuite) createMachine(c *gc.C) *state.Machine {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProvisioned("foo", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	return machine
 }
 
 func (s *IPAddressSuite) TestAddIPAddress(c *gc.C) {
@@ -125,6 +136,7 @@ func (s *IPAddressSuite) TestSetStateDead(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestAllocateToDead(c *gc.C) {
+	machine := s.createMachine(c)
 	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
@@ -134,9 +146,22 @@ func (s *IPAddressSuite) TestAllocateToDead(c *gc.C) {
 	err = copyIPAddr.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 
-	msg := fmt.Sprintf(`cannot allocate IP address %q to machine "foobar", interface "wibble": address is dead`, ipAddr.String())
-	err = ipAddr.AllocateTo("foobar", "wibble")
+	msg := fmt.Sprintf(`cannot allocate IP address %q to machine %q, interface "frogger": address is dead`, ipAddr.String(), machine.Id())
+	err = ipAddr.AllocateTo(machine.Id(), "frogger")
 	c.Assert(err, gc.ErrorMatches, msg)
+}
+
+func (s *IPAddressSuite) TestAllocateToProvisionedMachine(c *gc.C) {
+	machine := s.createMachine(c)
+
+	addr := network.NewAddress("0.1.2.3")
+	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = ipAddr.AllocateTo(machine.Id(), "fake")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.Id("foo"))
 }
 
 func (s *IPAddressSuite) TestAddressStateString(c *gc.C) {
@@ -227,31 +252,38 @@ func (s *IPAddressSuite) TestSetState(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestAllocateTo(c *gc.C) {
+	machine := s.createMachine(c)
+
 	addr := network.NewScopedAddress("0.1.2.3", network.ScopePublic)
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.State(), gc.Equals, state.AddressStateUnknown)
 	c.Assert(ipAddr.MachineId(), gc.Equals, "")
 	c.Assert(ipAddr.InterfaceId(), gc.Equals, "")
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.UnknownId)
 
-	err = ipAddr.AllocateTo("wibble", "wobble")
+	err = ipAddr.AllocateTo(machine.Id(), "wobble")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ipAddr.State(), gc.Equals, state.AddressStateAllocated)
-	c.Assert(ipAddr.MachineId(), gc.Equals, "wibble")
+	c.Assert(ipAddr.MachineId(), gc.Equals, machine.Id())
 	c.Assert(ipAddr.InterfaceId(), gc.Equals, "wobble")
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.Id("foo"))
 
 	freshCopy, err := s.State.IPAddress("0.1.2.3")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(freshCopy.State(), gc.Equals, state.AddressStateAllocated)
-	c.Assert(freshCopy.MachineId(), gc.Equals, "wibble")
+	c.Assert(freshCopy.MachineId(), gc.Equals, machine.Id())
 	c.Assert(freshCopy.InterfaceId(), gc.Equals, "wobble")
+	c.Assert(freshCopy.InstanceId(), gc.Equals, instance.Id("foo"))
 
 	// allocating twice should fail.
-	err = ipAddr.AllocateTo("m", "i")
-	c.Assert(err, gc.ErrorMatches,
-		`cannot allocate IP address "public:0.1.2.3" to machine "m", interface "i": `+
-			`already allocated or unavailable`,
-	)
+	machine2 := s.createMachine(c)
+	err = ipAddr.AllocateTo(machine2.Id(), "i")
+
+	msg := fmt.Sprintf(
+		`cannot allocate IP address "public:0.1.2.3" to machine %q, interface "i": `+
+			`already allocated or unavailable`, machine2.Id())
+	c.Assert(err, gc.ErrorMatches, msg)
 }
 
 func (s *IPAddressSuite) TestAddress(c *gc.C) {
@@ -263,10 +295,12 @@ func (s *IPAddressSuite) TestAddress(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
+	machine := s.createMachine(c)
+	machine2 := s.createMachine(c)
 	addresses := [][]string{
-		{"0.1.2.3", "wibble"},
-		{"0.1.2.4", "wibble"},
-		{"0.1.2.5", "wobble"},
+		{"0.1.2.3", machine.Id()},
+		{"0.1.2.4", machine.Id()},
+		{"0.1.2.5", machine2.Id()},
 	}
 	for _, details := range addresses {
 		addr := network.NewScopedAddress(details[0], network.ScopePublic)
@@ -275,7 +309,7 @@ func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
 		err = ipAddr.AllocateTo(details[1], "wobble")
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	result, err := s.State.AllocatedIPAddresses("wibble")
+	result, err := s.State.AllocatedIPAddresses(machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	addr1, err := s.State.IPAddress("0.1.2.3")
 	c.Assert(err, jc.ErrorIsNil)
@@ -287,17 +321,19 @@ func (s *IPAddressSuite) TestAllocatedIPAddresses(c *gc.C) {
 }
 
 func (s *IPAddressSuite) TestDeadIPAddresses(c *gc.C) {
-	addresses := [][]string{
-		{"0.1.2.3", "wibble"},
-		{"0.1.2.4", "wibble"},
-		{"0.1.2.5", "wobble"},
-		{"0.1.2.6", "wobble"},
+	machine := s.createMachine(c)
+
+	addresses := []string{
+		"0.1.2.3",
+		"0.1.2.4",
+		"0.1.2.5",
+		"0.1.2.6",
 	}
 	for i, details := range addresses {
-		addr := network.NewAddress(details[0])
+		addr := network.NewAddress(details)
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
-		err = ipAddr.AllocateTo(details[1], "wobble")
+		err = ipAddr.AllocateTo(machine.Id(), "wobble")
 		c.Assert(err, jc.ErrorIsNil)
 		if i%2 == 0 {
 			err := ipAddr.EnsureDead()

--- a/state/machine.go
+++ b/state/machine.go
@@ -678,6 +678,15 @@ func (m *Machine) Remove() (err error) {
 	ops = append(ops, ifacesOps...)
 	ops = append(ops, portsOps...)
 	ops = append(ops, removeContainerRefOps(m.st, m.Id())...)
+	ipAddresses, err := m.st.AllocatedIPAddresses(m.Id())
+	if err != nil {
+		return err
+	}
+	for _, address := range ipAddresses {
+		logger.Tracef("creating op to set IP addr %q to Dead", address.Value())
+		ops = append(ops, ensureIPAddressDeadOp(address))
+	}
+	logger.Tracef("removing machine %q", m.Id())
 	// The only abort conditions in play indicate that the machine has already
 	// been removed.
 	return onAbort(m.st.runTransaction(ops), nil)

--- a/state/machine.go
+++ b/state/machine.go
@@ -680,7 +680,7 @@ func (m *Machine) Remove() (err error) {
 	ops = append(ops, removeContainerRefOps(m.st, m.Id())...)
 	ipAddresses, err := m.st.AllocatedIPAddresses(m.Id())
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	for _, address := range ipAddresses {
 		logger.Tracef("creating op to set IP addr %q to Dead", address.Value())

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -386,6 +386,51 @@ func (s *MachineSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *MachineSuite) TestRemoveMarksAddressesAsDead(c *gc.C) {
+	err := s.machine.SetProvisioned("fake", "totally-fake", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	addr1, err := s.State.AddIPAddress(network.NewAddress("10.0.0.1"), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	err = addr1.AllocateTo(s.machine.Id(), "bar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	addr2, err := s.State.AddIPAddress(network.NewAddress("10.0.0.2"), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	err = addr2.AllocateTo(s.machine.Id(), "bar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	addr3, err := s.State.AddIPAddress(network.NewAddress("10.0.0.3"), "bar")
+	c.Assert(err, jc.ErrorIsNil)
+	err = addr3.AllocateTo(s.machine0.Id(), "bar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	addr4, err := s.State.AddIPAddress(network.NewAddress("10.0.0.4"), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	err = addr4.AllocateTo(s.machine.Id(), "bar")
+	c.Assert(err, jc.ErrorIsNil)
+	err = addr4.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = addr1.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr1.Life(), gc.Equals, state.Dead)
+	err = addr2.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr2.Life(), gc.Equals, state.Dead)
+	err = addr3.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr3.Life(), gc.Equals, state.Alive)
+	err = addr4.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr4.Life(), gc.Equals, state.Dead)
+}
+
 func (s *MachineSuite) TestHasVote(c *gc.C) {
 	c.Assert(s.machine.HasVote(), jc.IsFalse)
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2493,15 +2493,163 @@ func (s *upgradesSuite) TestIPAddressLifeIdempotent(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = AddLifeFieldOfIPAddresses(s.state)
+	err = AddInstanceIdFieldOfIPAddresses(s.state)
 	c.Assert(err, jc.ErrorIsNil)
-	err = AddLifeFieldOfIPAddresses(s.state)
+	before, err := s.state.IPAddress("0.1.2.3")
 	c.Assert(err, jc.ErrorIsNil)
+
+	err = AddInstanceIdFieldOfIPAddresses(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+	after, err := s.state.IPAddress("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(after, jc.DeepEquals, before)
+}
+
+func (s *upgradesSuite) TestIPAddressesInstanceId(c *gc.C) {
+	addresses, closer := s.state.getRawCollection(ipaddressesC)
+	defer closer()
+	instances, closer2 := s.state.getRawCollection(instanceDataC)
+	defer closer2()
+
+	s.addMachineWithLife(c, 1, Alive)
+	s.addMachineWithLife(c, 2, Alive)
+
+	uuid := s.state.EnvironUUID()
+
+	err := instances.Insert(
+		bson.D{
+			{"_id", uuid + ":1"},
+			{"env-uuid", uuid},
+			{"machineid", 1},
+			{"instanceid", "instance"},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = addresses.Insert(
+		// This address should have the instance ID set.
+		bson.D{
+			{"_id", uuid + ":0.1.2.3"},
+			{"env-uuid", uuid},
+			{"life", Alive},
+			{"subnetid", "foo"},
+			{"machineid", 1},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.3"},
+			{"state", AddressStateAllocated},
+		},
+		// This address won't have the instance ID set as there is no
+		// instance for machine 2.
+		bson.D{
+			{"_id", uuid + ":0.1.2.4"},
+			{"env-uuid", uuid},
+			{"life", Alive},
+			{"subnetid", "foo"},
+			{"machineid", 2},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.4"},
+			{"state", AddressStateAllocated},
+		},
+		// This address won't have the instance ID set because it isn't
+		// allocated.
+		bson.D{
+			{"_id", uuid + ":0.1.2.5"},
+			{"env-uuid", uuid},
+			{"life", Alive},
+			{"subnetid", "foo"},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.5"},
+			{"state", ""},
+		},
+		// This address won't have the instance ID set because the
+		// machine referenced doesn't exist.
+		bson.D{
+			{"_id", uuid + ":0.1.2.6"},
+			{"env-uuid", uuid},
+			{"life", Alive},
+			{"machineid", 3},
+			{"subnetid", "foo"},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.6"},
+			{"state", AddressStateAllocated},
+		},
+	)
+
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = AddInstanceIdFieldOfIPAddresses(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ipAddr, err := s.state.IPAddress("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.Id("instance"))
+
+	ipAddr, err = s.state.IPAddress("0.1.2.4")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.UnknownId)
+
+	ipAddr, err = s.state.IPAddress("0.1.2.5")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.UnknownId)
+
+	ipAddr, err = s.state.IPAddress("0.1.2.6")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.UnknownId)
 
 	doc := ipaddressDoc{}
 	err = addresses.FindId(uuid + ":0.1.2.3").One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(doc.Life, gc.Equals, Alive)
+	c.Assert(doc.InstanceId, gc.Equals, "instance")
+}
+
+func (s *upgradesSuite) TestIPAddressesInstanceIdIdempotent(c *gc.C) {
+	addresses, closer := s.state.getRawCollection(ipaddressesC)
+	defer closer()
+	instances, closer2 := s.state.getRawCollection(instanceDataC)
+	defer closer2()
+
+	s.addMachineWithLife(c, 1, Alive)
+	s.addMachineWithLife(c, 2, Alive)
+
+	uuid := s.state.EnvironUUID()
+
+	err := instances.Insert(
+		bson.D{
+			{"_id", uuid + ":1"},
+			{"env-uuid", uuid},
+			{"machineid", 1},
+			{"instanceid", "instance"},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = addresses.Insert(
+		// This address should have the instance ID set.
+		bson.D{
+			{"_id", uuid + ":0.1.2.3"},
+			{"env-uuid", uuid},
+			{"life", Alive},
+			{"subnetid", "foo"},
+			{"machineid", 1},
+			{"interfaceid", "bam"},
+			{"value", "0.1.2.3"},
+			{"state", AddressStateAllocated},
+		},
+	)
+
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = AddInstanceIdFieldOfIPAddresses(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// and repeat
+	err = AddInstanceIdFieldOfIPAddresses(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ipAddr, err := s.state.IPAddress("0.1.2.3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ipAddr.InstanceId(), gc.Equals, instance.Id("instance"))
 }
 
 func (s *upgradesSuite) prepareEnvsForLeadership(c *gc.C, envs map[string][]string) []string {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2521,7 +2521,7 @@ func (s *upgradesSuite) TestIPAddressesInstanceId(c *gc.C) {
 		bson.D{
 			{"_id", uuid + ":1"},
 			{"env-uuid", uuid},
-			{"machineid", 1},
+			{"machineid", "1"},
 			{"instanceid", "instance"},
 		},
 	)
@@ -2534,7 +2534,7 @@ func (s *upgradesSuite) TestIPAddressesInstanceId(c *gc.C) {
 			{"env-uuid", uuid},
 			{"life", Alive},
 			{"subnetid", "foo"},
-			{"machineid", 1},
+			{"machineid", "1"},
 			{"interfaceid", "bam"},
 			{"value", "0.1.2.3"},
 			{"state", AddressStateAllocated},
@@ -2546,7 +2546,7 @@ func (s *upgradesSuite) TestIPAddressesInstanceId(c *gc.C) {
 			{"env-uuid", uuid},
 			{"life", Alive},
 			{"subnetid", "foo"},
-			{"machineid", 2},
+			{"machineid", "2"},
 			{"interfaceid", "bam"},
 			{"value", "0.1.2.4"},
 			{"state", AddressStateAllocated},
@@ -2568,7 +2568,7 @@ func (s *upgradesSuite) TestIPAddressesInstanceId(c *gc.C) {
 			{"_id", uuid + ":0.1.2.6"},
 			{"env-uuid", uuid},
 			{"life", Alive},
-			{"machineid", 3},
+			{"machineid", "3"},
 			{"subnetid", "foo"},
 			{"interfaceid", "bam"},
 			{"value", "0.1.2.6"},
@@ -2618,7 +2618,7 @@ func (s *upgradesSuite) TestIPAddressesInstanceIdIdempotent(c *gc.C) {
 		bson.D{
 			{"_id", uuid + ":1"},
 			{"env-uuid", uuid},
-			{"machineid", 1},
+			{"machineid", "1"},
 			{"instanceid", "instance"},
 		},
 	)
@@ -2631,7 +2631,7 @@ func (s *upgradesSuite) TestIPAddressesInstanceIdIdempotent(c *gc.C) {
 			{"env-uuid", uuid},
 			{"life", Alive},
 			{"subnetid", "foo"},
-			{"machineid", 1},
+			{"machineid", "1"},
 			{"interfaceid", "bam"},
 			{"value", "0.1.2.3"},
 			{"state", AddressStateAllocated},

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -58,6 +58,12 @@ func stateStepsFor123() []Step {
 				return state.AddLifeFieldOfIPAddresses(context.State())
 			},
 		}, &upgradeStep{
+			description: "add instance id field to IP addresses",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddInstanceIdFieldOfIPAddresses(context.State())
+			},
+		}, &upgradeStep{
 			description: "lower case _id of envUsers",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -25,6 +25,7 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 		"insert userenvnameC doc for each environment",
 		"add name field to users and lowercase _id field",
 		"add life field to IP addresses",
+		"add instance id field to IP addresses",
 		"lower case _id of envUsers",
 		"add leadership settings documents for all services",
 	}

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -22,6 +22,12 @@ func stateStepsFor124() []Step {
 			run: func(context Context) error {
 				return state.MoveServiceUnitSeqToSequence(context.State())
 			},
+		}, &upgradeStep{
+			description: "add instance id field to IP addresses",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddInstanceIdFieldOfIPAddresses(context.State())
+			},
 		},
 	}
 }

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -20,6 +20,7 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 	expected := []string{
 		"add block device documents for existing machines",
 		"move service.UnitSeq to sequence collection",
+		"add instance id field to IP addresses",
 	}
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
 }

--- a/worker/addresser/worker.go
+++ b/worker/addresser/worker.go
@@ -101,25 +101,11 @@ func (a *addresserHandler) Handle(ids []string) error {
 
 func (a *addresserHandler) releaseIPAddress(addr *state.IPAddress) (err error) {
 	defer errors.DeferredAnnotatef(&err, "failed to release address %v", addr.Value())
-	var machine *state.Machine
 	logger.Debugf("attempting to release dead address %#v", addr.Value())
-
-	var instId instance.Id
-	machine, err = a.st.Machine(addr.MachineId())
-	if errors.IsNotFound(err) {
-		instId = instance.UnknownId
-	} else if err != nil {
-		return errors.Annotatef(err, "cannot get allocated machine %q", addr.MachineId())
-	} else {
-		instId, err = machine.InstanceId()
-		if err != nil {
-			return errors.Annotatef(err, "cannot get machine %q instance ID", addr.MachineId())
-		}
-	}
 
 	subnetId := network.Id(addr.SubnetId())
 	for attempt := common.ShortAttempt.Start(); attempt.Next(); {
-		err = a.releaser.ReleaseAddress(instId, subnetId, addr.Address())
+		err = a.releaser.ReleaseAddress(addr.InstanceId(), subnetId, addr.Address())
 		if err == nil {
 			return nil
 		}

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -27,7 +27,8 @@ var _ = gc.Suite(&workerSuite{})
 
 type workerSuite struct {
 	testing.JujuConnSuite
-	machine *state.Machine
+	machine  *state.Machine
+	machine2 *state.Machine
 }
 
 func (s *workerSuite) SetUpTest(c *gc.C) {
@@ -40,6 +41,12 @@ func (s *workerSuite) SetUpTest(c *gc.C) {
 	s.machine = machine
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.SetProvisioned("foo", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// this machine will be destroyed after address creation to test the
+	// handling of addresses for machines that have gone.
+	machine2, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	s.machine2 = machine2
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createAddresses(c)
@@ -55,17 +62,20 @@ func (s *workerSuite) createAddresses(c *gc.C) {
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
 		if i%2 == 1 {
-			// two of the addresses start out Dead
-			err = ipAddr.AllocateTo("dead-machine", "wobble")
-			c.Assert(err, jc.ErrorIsNil)
-			err = ipAddr.EnsureDead()
-			c.Assert(err, jc.ErrorIsNil)
+			err = ipAddr.AllocateTo(s.machine2.Id(), "wobble")
 		} else {
 			err = ipAddr.AllocateTo(s.machine.Id(), "wobble")
 			c.Assert(err, jc.ErrorIsNil)
 		}
 
 	}
+	// Two of the addresses start out allocated to this
+	// machine which we destroy to test the handling of
+	// addresses allocated to dead machines.
+	err := s.machine2.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine2.Remove()
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func dummyListen() chan dummy.Operation {
@@ -177,6 +187,51 @@ func (s *workerSuite) TestWorkerRemovesDeadAddress(c *gc.C) {
 	// The address should have been removed from state.
 	for a := common.ShortAttempt.Start(); a.Next(); {
 		_, err := s.State.IPAddress("0.1.2.3")
+		if errors.IsNotFound(err) {
+			break
+		}
+		if !a.HasNext() {
+			c.Fatalf("IP address not removed")
+		}
+	}
+}
+
+func (s *workerSuite) TestMachineRemovalTriggersWorker(c *gc.C) {
+	w, err := addresser.NewWorker(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	defer s.assertStop(c, w)
+	s.waitForInitialDead(c)
+	opsChan := dummyListen()
+
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProvisioned("foo", "really-fake", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.State.StartSync()
+
+	addr, err := s.State.AddIPAddress(network.NewAddress("0.1.2.9"), "foobar")
+	c.Assert(err, jc.ErrorIsNil)
+	err = addr.AllocateTo(machine.Id(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr.InstanceId(), gc.Equals, instance.Id("foo"))
+	s.State.StartSync()
+
+	err = machine.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = addr.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr.Life(), gc.Equals, state.Dead)
+
+	// Wait for ReleaseAddress attempt.
+	op := waitForReleaseOp(c, opsChan)
+	c.Assert(op, jc.DeepEquals, makeReleaseOp(9))
+
+	// The address should have been removed from state.
+	for a := common.ShortAttempt.Start(); a.Next(); {
+		_, err := s.State.IPAddress("0.1.2.9")
 		if errors.IsNotFound(err) {
 			break
 		}


### PR DESCRIPTION
This is a forward port of a branch already landed on 1.23.

IP addresses, for addressable containers, will be marked as dead when the machine they're allocated to is destroyed. This requires an upgrade step to add the instance id of the machine to the ip address as the instance data is no longer available once the machine is destroyed.

(Review request: http://reviews.vapour.ws/r/1715/)