### PR TITLE
APIServer Run method doesn't validates if Machines, Services or Units are present on the request.

### DIFF
--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -87,6 +87,11 @@ func (c *Client) Run(run params.RunParams) (results params.RunResults, err error
 	if err := c.check.ChangeAllowed(); err != nil {
 		return params.RunResults{}, errors.Trace(err)
 	}
+
+	if len(run.Machines) == 0 && len(run.Services) == 0 && len(run.Units) == 0 {
+		return params.RunResults{}, errors.Errorf("you must specify a target - either machines, services or units")
+	}
+
 	units, err := getAllUnitNames(c.api.state, run.Units, run.Services)
 	if err != nil {
 		return results, err

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -317,6 +317,18 @@ func (s *runSuite) TestRunMachineAndService(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, expectedResults)
 }
 
+func (s *runSuite) TestRunMachineAndServiceNoTarget(c *gc.C) {
+	client := s.APIState.Client()
+	results, err := client.Run(
+		params.RunParams{
+			Commands: "hostname",
+			Timeout:  testing.LongWait,
+		})
+
+	c.Assert(err, gc.NotNil)
+	c.Assert(results, gc.HasLen, 0)
+}
+
 func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 	// Make three machines.
 	s.addMachineWithAddress(c, "10.3.2.1")


### PR DESCRIPTION
Fixes LP: #1456343

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>

(Review request: http://reviews.vapour.ws/r/1717/)