### PR TITLE
Dynamically discover init system in the cloudinit script.

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -182,6 +183,19 @@ func (cfg *InstanceConfig) agentInfo() service.AgentInfo {
 
 func (cfg *InstanceConfig) ToolsDir(renderer shell.Renderer) string {
 	return cfg.agentInfo().ToolsDir(renderer)
+}
+
+// MachineAgentCommands returns the list of commands to install and
+// start the machine agent service for the instance.
+func (cfg *InstanceConfig) MachineAgentCommands(renderer shell.Renderer) ([]string, error) {
+	name := cfg.MachineAgentServiceName
+	conf := service.AgentConf(cfg.agentInfo(), renderer)
+	osName := strings.ToLower(cfg.Tools.Version.OS.String())
+	cmds, err := service.InstallServiceCommands(name, conf, osName)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
+	}
+	return cmds, nil
 }
 
 func (cfg *InstanceConfig) InitService(renderer shell.Renderer) (service.Service, error) {

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
-	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/state/multiwatcher"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -196,27 +195,6 @@ func (cfg *InstanceConfig) MachineAgentCommands(renderer shell.Renderer) ([]stri
 		return nil, errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
 	}
 	return cmds, nil
-}
-
-func (cfg *InstanceConfig) InitService(renderer shell.Renderer) (service.Service, error) {
-	conf := service.AgentConf(cfg.agentInfo(), renderer)
-
-	name := cfg.MachineAgentServiceName
-	initSystem, ok := cfg.initSystem()
-	if !ok {
-		return nil, errors.New("could not identify init system")
-	}
-	logger.Debugf("using init system %q for machine agent script", initSystem)
-	svc, err := newService(name, conf, initSystem)
-	return svc, errors.Trace(err)
-}
-
-func (cfg *InstanceConfig) initSystem() (string, bool) {
-	return service.VersionInitSystem(cfg.Tools.Version)
-}
-
-var newService = func(name string, conf common.Conf, initSystem string) (service.Service, error) {
-	return service.NewService(name, conf, initSystem)
 }
 
 func (cfg *InstanceConfig) AgentConfig(

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -96,7 +96,7 @@ func (c *baseConfigure) addAgentInfo(tag names.Tag) (agent.Config, error) {
 }
 
 func (c *baseConfigure) addMachineAgentToBoot() error {
-	svc, err := c.icfg.InitService(c.conf.ShellRenderer())
+	cmds, err := c.icfg.MachineAgentCommands(c.conf.ShellRenderer())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -106,17 +106,6 @@ func (c *baseConfigure) addMachineAgentToBoot() error {
 	// the init script.
 	toolsDir := c.icfg.ToolsDir(c.conf.ShellRenderer())
 	c.conf.AddScripts(c.toolsSymlinkCommand(toolsDir))
-
-	name := c.tag.String()
-	cmds, err := svc.InstallCommands()
-	if err != nil {
-		return errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
-	}
-	startCmds, err := svc.StartCommands()
-	if err != nil {
-		return errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
-	}
-	cmds = append(cmds, startCmds...)
 
 	svcName := c.icfg.MachineAgentServiceName
 	// TODO (gsamfira): This is temporary until we find a cleaner way to fix

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -235,8 +235,8 @@ echo 'Bootstrapping Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
-cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
-start jujud-machine-0
+init_system=\$\(.*\)
+case "\$init_system" in.*
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
 `,
 	}, {
@@ -339,8 +339,8 @@ cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-99'
 echo 'Starting Juju machine agent \(jujud-machine-99\)'.*
-cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
-start jujud-machine-99
+init_system=\$\(.*\)
+case "\$init_system" in.*
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 `,
 	}, {
@@ -382,8 +382,8 @@ mkdir -p '/var/lib/juju/agents/machine-2-lxc-1'
 cat > '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-2-lxc-1'
-cat > /etc/init/jujud-machine-2-lxc-1\.conf << 'EOF'\\ndescription "juju agent for machine-2-lxc-1"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-2-lxc-1\.log\\n  chown syslog:syslog /var/log/juju/machine-2-lxc-1\.log\\n  chmod 0600 /var/log/juju/machine-2-lxc-1\.log\\n\\n  exec '/var/lib/juju/tools/machine-2-lxc-1/jujud' machine --data-dir '/var/lib/juju' --machine-id 2/lxc/1 --debug >> /var/log/juju/machine-2-lxc-1\.log 2>&1\\nend script\\nEOF\\n
-start jujud-machine-2-lxc-1
+init_system=\$\(.*\)
+case "\$init_system" in.*
 `,
 	}, {
 		// hostname verification disabled.

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -651,8 +651,8 @@ func (s *LxcSuite) TestCreateContainer(c *gc.C) {
 		scripts = append(scripts, s.(string))
 	}
 
-	c.Assert(scripts[len(scripts)-3:], gc.DeepEquals, []string{
-		"start jujud-machine-1-lxc-0",
+	c.Assert(scripts[len(scripts)-3], jc.HasPrefix, `case "$init_system" in`)
+	c.Assert(scripts[len(scripts)-2:], gc.DeepEquals, []string{
 		"rm $bin/tools.tar.gz && rm $bin/juju2.3.4-quantal-amd64.sha256",
 		"ifconfig",
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -176,12 +176,10 @@ func listServicesCommand(initSystem string) (string, bool) {
 }
 
 // InstallServicesCommand composes the list of shell commands that install
-// and start the given service.
+// and start the given service on the given operating system.
 func InstallServiceCommands(name string, conf common.Conf, os string) ([]string, error) {
-	start := true
-
 	if os == "windows" {
-		cmds, err := installCommands(name, conf, InitSystemWindows, start)
+		cmds, err := installCommands(name, conf, InitSystemWindows)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -190,7 +188,7 @@ func InstallServiceCommands(name string, conf common.Conf, os string) ([]string,
 
 	candidates := make(map[string]string)
 	for _, initSystem := range linuxInitSystems {
-		cmds, err := installCommands(name, conf, initSystem, start)
+		cmds, err := installCommands(name, conf, initSystem)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -211,7 +209,7 @@ func InstallServiceCommands(name string, conf common.Conf, os string) ([]string,
 	return cmds, nil
 }
 
-func installCommands(name string, conf common.Conf, initSystem string, start bool) ([]string, error) {
+func installCommands(name string, conf common.Conf, initSystem string) ([]string, error) {
 	svc, err := NewService(name, conf, initSystem)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -221,9 +219,7 @@ func installCommands(name string, conf common.Conf, initSystem string, start boo
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if !start {
-		return cmds, nil
-	}
+	// Return here if we want to only install (i.e. skip starting).
 
 	startCmds, err := svc.StartCommands()
 	if err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -89,6 +89,76 @@ func (*serviceSuite) TestListServicesScript(c *gc.C) {
 	c.Check(strings.Split(script, "\n"), jc.DeepEquals, expected)
 }
 
+func (s *serviceSuite) TestInstallServiceCommandsLinux(c *gc.C) {
+	cmds, err := service.InstallServiceCommands(s.Name, s.Conf, "ubuntu")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(cmds, gc.HasLen, 2)
+	c.Check(cmds[0], jc.HasPrefix, "init_system=$(")
+	c.Check(cmds[1], jc.HasPrefix, "case \"$init_system\" in\nsystemd)\n")
+	c.Check(cmds[1], jc.Contains, "systemctl start")
+	c.Check(cmds[1], jc.Contains, "\nupstart)\n")
+	c.Check(cmds[1], jc.Contains, "start juju-agent-machine-0")
+	c.Check(cmds[1], gc.Not(jc.Contains), "windows")
+	// TODO(ericsnow) This is too specific...
+	c.Check(cmds[1], jc.DeepEquals, `
+if [[ $init_system == "systemd" ]]; then 
+  mkdir -p /var/lib/juju/init/juju-agent-machine-0
+  cat > /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service << 'EOF'
+[Unit]
+Description=some service
+After=syslog.target
+After=network.target
+After=systemd-user-sessions.service
+
+[Service]
+ExecStart=/bin/jujud machine 0
+RemainAfterExit=yes
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+
+
+EOF
+  /bin/systemctl link /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service
+  /bin/systemctl daemon-reload
+  /bin/systemctl enable /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service
+  /bin/systemctl start juju-agent-machine-0.service
+elif [[ $init_system == "upstart" ]]; then 
+  cat >> /etc/init/juju-agent-machine-0.conf << 'EOF'
+description "some service"
+author "Juju Team <juju@lists.ubuntu.com>"
+start on runlevel [2345]
+stop on runlevel [!2345]
+respawn
+normal exit 0
+
+
+script
+
+
+  exec /bin/jujud machine 0
+end script
+EOF
+
+  start juju-agent-machine-0
+else exit 1
+fi`[1:])
+}
+
+func (s *serviceSuite) TestInstallServiceCommandsWindows(c *gc.C) {
+	cmds, err := service.InstallServiceCommands(s.Name, s.Conf, "windows")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(cmds, gc.HasLen, 3)
+	for i := 0; i < 3; i++ {
+		c.Check(cmds[i], jc.Contains, "juju-agent-machine-0")
+	}
+	c.Check(cmds[0], jc.HasPrefix, "New-Service")
+	c.Check(cmds[2], jc.HasPrefix, "Start-Service")
+}
+
 func (s *serviceSuite) TestInstallAndStartOkay(c *gc.C) {
 	s.PatchAttempts(5)
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -100,51 +100,6 @@ func (s *serviceSuite) TestInstallServiceCommandsLinux(c *gc.C) {
 	c.Check(cmds[1], jc.Contains, "\nupstart)\n")
 	c.Check(cmds[1], jc.Contains, "start juju-agent-machine-0")
 	c.Check(cmds[1], gc.Not(jc.Contains), "windows")
-	// TODO(ericsnow) This is too specific...
-	c.Check(cmds[1], jc.DeepEquals, `
-if [[ $init_system == "systemd" ]]; then 
-  mkdir -p /var/lib/juju/init/juju-agent-machine-0
-  cat > /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service << 'EOF'
-[Unit]
-Description=some service
-After=syslog.target
-After=network.target
-After=systemd-user-sessions.service
-
-[Service]
-ExecStart=/bin/jujud machine 0
-RemainAfterExit=yes
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-
-
-EOF
-  /bin/systemctl link /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service
-  /bin/systemctl daemon-reload
-  /bin/systemctl enable /var/lib/juju/init/juju-agent-machine-0/juju-agent-machine-0.service
-  /bin/systemctl start juju-agent-machine-0.service
-elif [[ $init_system == "upstart" ]]; then 
-  cat >> /etc/init/juju-agent-machine-0.conf << 'EOF'
-description "some service"
-author "Juju Team <juju@lists.ubuntu.com>"
-start on runlevel [2345]
-stop on runlevel [!2345]
-respawn
-normal exit 0
-
-
-script
-
-
-  exec /bin/jujud machine 0
-end script
-EOF
-
-  start juju-agent-machine-0
-else exit 1
-fi`[1:])
 }
 
 func (s *serviceSuite) TestInstallServiceCommandsWindows(c *gc.C) {


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1450092)

Keying off the juju version doesn't work well for local provider. This patch resolves the issue by adding discovery to the cloudinit script.

(Review request: http://reviews.vapour.ws/r/1595/)