### PR TITLE
Add 'anything' to valid certificate server addresses for 1.20 client compatibility.

### DIFF
--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -100,12 +100,12 @@ func (c *CertificateUpdater) Handle() error {
 		return errors.Annotate(err, "cannot add CA private key to environment config")
 	}
 
-	// For backwards compatibility, we must include "juju-apiserver"
+	// For backwards compatibility, we must include "anything", "juju-apiserver"
 	// and "juju-mongodb" as hostnames as that is what clients specify
 	// as the hostname for verification (this certicate is used both
 	// for serving MongoDB and API server connections).  We also
 	// explicitly include localhost.
-	serverAddrs := []string{"localhost", "juju-apiserver", "juju-mongodb"}
+	serverAddrs := []string{"localhost", "juju-apiserver", "juju-mongodb", "anything"}
 	for _, addr := range addresses {
 		if addr.Value == "localhost" {
 			continue

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -139,7 +139,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	// also report "juju-mongodb" because these certicates are also
 	// used for serving MongoDB connections.
 	c.Assert(srvCert.DNSNames, gc.DeepEquals,
-		[]string{"localhost", "juju-apiserver", "juju-mongodb"})
+		[]string{"localhost", "juju-apiserver", "juju-mongodb", "anything"})
 }
 
 type mockStateServingGetterNoCAKey struct{}


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1454829

Juju 1.20 clients use "anything" as the server name in their TLS config when making secure connections to the Juju state server. The certificate generation from 1.22 onwards needs to account for this.

(Review request: http://reviews.vapour.ws/r/1719/)