### PR TITLE
Prune completed transactions

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -81,6 +81,7 @@ import (
 	"github.com/juju/juju/worker/rsyslog"
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/terminationworker"
+	"github.com/juju/juju/worker/txnpruner"
 	"github.com/juju/juju/worker/upgrader"
 )
 
@@ -961,6 +962,9 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				// because we can't figure out how to do so without brutalising
 				// the transaction log.
 				return resumer.NewResumer(st), nil
+			})
+			a.startWorkerAfterUpgrade(singularRunner, "txnpruner", func() (worker.Worker, error) {
+				return txnpruner.New(st, time.Hour*2), nil
 			})
 			a.startWorkerAfterUpgrade(singularRunner, "minunitsworker", func() (worker.Worker, error) {
 				return minunitsworker.NewMinUnitsWorker(st), nil

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -574,6 +574,7 @@ func (s *MachineSuite) TestManageEnviron(c *gc.C) {
 		"firewaller",
 		"minunitsworker",
 		"resumer",
+		"txnpruner",
 	})
 }
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-2
 github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-29T20:12:23Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-06T07:00:34Z
 github.com/juju/testing	git	e35bf4acb97c4e7acda329bd7430f14ee968346b	2015-03-31T10:29:16Z
-github.com/juju/txn	git	2407a1fa094db5603f4718f11e1fafc8543273eb	2015-03-27T15:47:42Z
+github.com/juju/txn	git	c3617a3230b576d680f3e09d48d0f9374d540ffb	2015-05-20T05:20:05Z
 github.com/juju/utils	git	732e0c300dc0f35c597e788a4366372065c27b7c	2015-03-30T21:32:30Z
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T00:00:00Z

--- a/state/txns.go
+++ b/state/txns.go
@@ -51,6 +51,13 @@ func (st *State) ResumeTransactions() error {
 	return st.txnRunner(session).ResumeTransactions()
 }
 
+// PruneTransactions removes data for completed transactions.
+func (st *State) PruneTransactions() error {
+	session := st.db.Session.Copy()
+	defer session.Close()
+	return st.txnRunner(session).PruneTransactions()
+}
+
 func newMultiEnvRunner(envUUID string, db *mgo.Database) jujutxn.Runner {
 	return &multiEnvRunner{
 		rawRunner: jujutxn.NewRunner(jujutxn.RunnerParams{Database: db}),
@@ -71,7 +78,7 @@ func (r *multiEnvRunner) RunTransaction(ops []txn.Op) error {
 	return r.rawRunner.RunTransaction(ops)
 }
 
-// Run is part of the jujutxn.Run interface. Operations returned by
+// Run is part of the jujutxn.Runner interface. Operations returned by
 // the given "transactions" function that affect multi-environment
 // collections will be modified in-place to ensure correct interaction
 // with these collections.
@@ -88,9 +95,14 @@ func (r *multiEnvRunner) Run(transactions jujutxn.TransactionSource) error {
 	})
 }
 
-// Run is part of the jujutxn.Run interface.
+// ResumeTransactions is part of the jujutxn.Runner interface.
 func (r *multiEnvRunner) ResumeTransactions() error {
 	return r.rawRunner.ResumeTransactions()
+}
+
+// PruneTransactions is part of the jujutxn.Runner interface.
+func (r *multiEnvRunner) PruneTransactions() error {
+	return r.rawRunner.PruneTransactions()
 }
 
 func (r *multiEnvRunner) updateOps(ops []txn.Op) {

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -326,6 +326,18 @@ func (s *MultiEnvRunnerSuite) TestResumeTransactionsWithError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
+func (s *MultiEnvRunnerSuite) TestPruneTransactions(c *gc.C) {
+	err := s.multiEnvRunner.PruneTransactions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.testRunner.pruneTransactionsCalled, jc.IsTrue)
+}
+
+func (s *MultiEnvRunnerSuite) TestPruneTransactionsWithError(c *gc.C) {
+	s.testRunner.pruneTransactionsErr = errors.New("boom")
+	err := s.multiEnvRunner.PruneTransactions()
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
 // recordingRunner is fake transaction running that implements the
 // jujutxn.Runner interface. Instead of doing anything with a database
 // it simply records the transaction operations passed to it for later
@@ -338,6 +350,8 @@ type recordingRunner struct {
 	seenOps                  []txn.Op
 	resumeTransactionsCalled bool
 	resumeTransactionsErr    error
+	pruneTransactionsCalled  bool
+	pruneTransactionsErr     error
 }
 
 func (r *recordingRunner) RunTransaction(ops []txn.Op) error {
@@ -353,4 +367,9 @@ func (r *recordingRunner) Run(transactions jujutxn.TransactionSource) (err error
 func (r *recordingRunner) ResumeTransactions() error {
 	r.resumeTransactionsCalled = true
 	return r.resumeTransactionsErr
+}
+
+func (r *recordingRunner) PruneTransactions() error {
+	r.pruneTransactionsCalled = true
+	return r.pruneTransactionsErr
 }

--- a/worker/txnpruner/package_test.go
+++ b/worker/txnpruner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txnpruner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/txnpruner/txnpruner.go
+++ b/worker/txnpruner/txnpruner.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txnpruner
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/worker"
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.worker.txnpruner")
+
+// TransactionPruner defines the interface for types capable of
+// pruning transactions.
+type TransactionPruner interface {
+	PruneTransactions() error
+}
+
+// New returns a worker which periodically prunes the data for
+// completed transactions.
+func New(tp TransactionPruner, interval time.Duration) worker.Worker {
+	return worker.NewSimpleWorker(func(stopCh <-chan struct{}) error {
+		// Use a timer rather than a ticker because pruning could
+		// sometimes take a while and we don't want pruning attempts
+		// to occur back-to-back.
+		timer := time.NewTimer(interval)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				logger.Debugf("starting transaction pruning")
+				err := tp.PruneTransactions()
+				if err != nil {
+					return errors.Annotate(err, "pruning failed, txnpruner stopping")
+				}
+				logger.Debugf("transaction pruning done")
+				timer.Reset(interval)
+			case <-stopCh:
+				return nil
+			}
+		}
+		return nil
+	})
+}

--- a/worker/txnpruner/txnpruner_test.go
+++ b/worker/txnpruner/txnpruner_test.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txnpruner_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/txnpruner"
+)
+
+type TxnPrunerSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&TxnPrunerSuite{})
+
+func (s *TxnPrunerSuite) TestPrunes(c *gc.C) {
+	fakePruner := newFakeTransactionPruner()
+	interval := 10 * time.Millisecond
+	p := txnpruner.New(fakePruner, interval)
+	defer p.Kill()
+
+	var t0 time.Time
+	for i := 0; i < 5; i++ {
+		select {
+		case <-fakePruner.pruneCh:
+			t1 := time.Now()
+			if i > 0 {
+				// Check that pruning runs at the expected interval
+				// (but not the first time around as we don't know
+				// when the worker actually started).
+				c.Assert(t1.Sub(t0), jc.GreaterThan, interval)
+			}
+			t0 = t1
+		case <-time.After(testing.LongWait):
+			c.Fatal("timed out waiting for pruning to happen")
+		}
+	}
+}
+
+func (s *TxnPrunerSuite) TestStops(c *gc.C) {
+	success := make(chan bool)
+	check := func() {
+		p := txnpruner.New(newFakeTransactionPruner(), time.Minute)
+		p.Kill()
+		c.Assert(p.Wait(), jc.ErrorIsNil)
+		success <- true
+	}
+	go check()
+
+	select {
+	case <-success:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for worker to stop")
+	}
+}
+
+func newFakeTransactionPruner() *fakeTransactionPruner {
+	return &fakeTransactionPruner{
+		pruneCh: make(chan bool),
+	}
+}
+
+type fakeTransactionPruner struct {
+	pruneCh chan bool
+}
+
+// PruneTransactions implements the txnpruner.TransactionPruner
+// interface.
+func (p *fakeTransactionPruner) PruneTransactions() error {
+	p.pruneCh <- true
+	return nil
+}


### PR DESCRIPTION
This set of changes integrates the new txn pruning functionality in https://github.com/juju/txn/pull/10 into Juju. A new txnpruner worker for the master machine agent is introduced to call PruneTransactions periodically. 

Part of the fix for LP #1453785.

This PR can't land until the PR for juju/txns lands.



(Review request: http://reviews.vapour.ws/r/1720/)