### PR TITLE
Port 1.24 bugs

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -371,7 +371,9 @@ func (srv *Server) run(lis net.Listener) {
 	)
 	handleAll(mux, "/environment/:envuuid/api", http.HandlerFunc(srv.apiHandler))
 	handleAll(mux, "/environment/:envuuid/images/:kind/:series/:arch/:filename",
-		&imagesDownloadHandler{httpHandler{ssState: srv.state}},
+		&imagesDownloadHandler{
+			httpHandler: httpHandler{ssState: srv.state},
+			dataDir:     srv.dataDir},
 	)
 	// For backwards compatibility we register all the old paths
 	handleAll(mux, "/log",

--- a/utils/network.go
+++ b/utils/network.go
@@ -1,0 +1,56 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"net"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+)
+
+var (
+	// The defaults below are best suited to retries associated
+	// with disk I/O timeouts, eg database operations.
+	// Use the NetworkOperationWithRetries() variant to explicitly
+	// use retry values better suited to different scenarios.
+
+	// DefaultNetworkOperationRetryDelay is the default time
+	// to wait between operation retries.
+	DefaultNetworkOperationRetryDelay = 30 * time.Second
+
+	// DefaultNetworkOperationAttempts is the default number
+	// of attempts before giving up.
+	DefaultNetworkOperationAttempts = 10
+)
+
+// NetworkOperationWithDefaultRetries calls the supplied function and if it returns a
+// network error which is temporary, will retry a number of times before giving up.
+// A default attempt strategy is used.
+func NetworkOperationWitDefaultRetries(networkOp func() error, description string) func() error {
+	attempt := utils.AttemptStrategy{
+		Delay: DefaultNetworkOperationRetryDelay,
+		Min:   DefaultNetworkOperationAttempts,
+	}
+	return NetworkOperationWithRetries(attempt, networkOp, description)
+}
+
+// NetworkOperationWithRetries calls the supplied function and if it returns a
+// network error which is temporary, will retry a number of times before giving up.
+func NetworkOperationWithRetries(strategy utils.AttemptStrategy, networkOp func() error, description string) func() error {
+	return func() error {
+		for a := strategy.Start(); a.Next(); {
+			err := networkOp()
+			if !a.HasNext() || err == nil {
+				return errors.Trace(err)
+			}
+			if networkErr, ok := errors.Cause(err).(net.Error); !ok || !networkErr.Temporary() {
+				return errors.Trace(err)
+			}
+			logger.Debugf("%q error, will retry: %v", description, err)
+		}
+		panic("unreachable")
+	}
+}

--- a/utils/network_test.go
+++ b/utils/network_test.go
@@ -1,0 +1,103 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/utils"
+)
+
+type networkSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&networkSuite{})
+
+func (s *networkSuite) TestOpSuccess(c *gc.C) {
+	isCalled := false
+	f := func() error {
+		isCalled = true
+		return nil
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isCalled, jc.IsTrue)
+}
+
+func (s *networkSuite) TestOpFailureNoRetry(c *gc.C) {
+	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	netErr := &netError{false}
+	callCount := 0
+	f := func() error {
+		callCount++
+		return netErr
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(errors.Cause(err), gc.Equals, netErr)
+	c.Assert(callCount, gc.Equals, 1)
+}
+
+func (s *networkSuite) TestOpFailureRetries(c *gc.C) {
+	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	netErr := &netError{true}
+	callCount := 0
+	f := func() error {
+		callCount++
+		return netErr
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(errors.Cause(err), gc.Equals, netErr)
+	c.Assert(callCount, gc.Equals, 10)
+}
+
+func (s *networkSuite) TestOpNestedFailureRetries(c *gc.C) {
+	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	netErr := &netError{true}
+	callCount := 0
+	f := func() error {
+		callCount++
+		return errors.Annotate(errors.Trace(netErr), "create a wrapped error")
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(errors.Cause(err), gc.Equals, netErr)
+	c.Assert(callCount, gc.Equals, 10)
+}
+
+func (s *networkSuite) TestOpSucceedsAfterRetries(c *gc.C) {
+	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	netErr := &netError{true}
+	callCount := 0
+	f := func() error {
+		callCount++
+		if callCount == 5 {
+			return nil
+		}
+		return netErr
+	}
+	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(callCount, gc.Equals, 5)
+}
+
+type netError struct {
+	temporary bool
+}
+
+func (e *netError) Error() string {
+	return "network error"
+}
+
+func (e *netError) Temporary() bool {
+	return e.temporary
+}
+
+func (e *netError) Timeout() bool {
+	return false
+}

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -100,12 +100,12 @@ func (c *CertificateUpdater) Handle() error {
 		return errors.Annotate(err, "cannot add CA private key to environment config")
 	}
 
-	// For backwards compatibility, we must include "juju-apiserver"
+	// For backwards compatibility, we must include "anything", "juju-apiserver"
 	// and "juju-mongodb" as hostnames as that is what clients specify
 	// as the hostname for verification (this certicate is used both
 	// for serving MongoDB and API server connections).  We also
 	// explicitly include localhost.
-	serverAddrs := []string{"localhost", "juju-apiserver", "juju-mongodb"}
+	serverAddrs := []string{"localhost", "juju-apiserver", "juju-mongodb", "anything"}
 	for _, addr := range addresses {
 		if addr.Value == "localhost" {
 			continue

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -139,7 +139,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	// also report "juju-mongodb" because these certicates are also
 	// used for serving MongoDB connections.
 	c.Assert(srvCert.DNSNames, gc.DeepEquals,
-		[]string{"localhost", "juju-apiserver", "juju-mongodb"})
+		[]string{"localhost", "juju-apiserver", "juju-mongodb", "anything"})
 }
 
 type mockStateServingGetterNoCAKey struct{}


### PR DESCRIPTION
Forward port 2 bug fixes as per below.

Merge pull request #2347 from wallyworld/robust-lxc-images …

When using blobstore to add/read images, retry in there's an i/o error

Fixes: https://bugs.launchpad.net/juju-core/+bug/1454676

We have a couple of issues when deployer is used to deploy a bundle and everything is done at once.
Firstly, I/O contention - fetching and storing the LXC image template in the blob store fails due to an I/O timeout. Some LXC containers do start, so Juju should just retry in such cases.
The other issue is that multiple downloads of the same image are allowed to occur - if a download for a given image is already in progress, any new requests should wait and use that image once the initial download completes.

So a helper is created that can be used to retry transient network operations that fail. This is just used here for loading/saving images to blob store, but can be used elsewhere when needed.
The other fix is to add a lock to the image fetching so that it only happens once. This reduces I/O contention on the blobstore, and fixes an obvious implementation inefficiency.

(Review request: http://reviews.vapour.ws/r/1709/)

Merge pull request #2363 from wallyworld/1.20-client-compatible-1.24 …

Add 'anything' to valid certificate server addresses for 1.20 client compatibility.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1454829

Juju 1.20 clients use "anything" as the server name in their TLS config when making secure connections to the Juju state server. The certificate generation from 1.22 onwards needs to account for this.

(Review request: http://reviews.vapour.ws/r/1719/)

(Review request: http://reviews.vapour.ws/r/1721/)

(Review request: http://reviews.vapour.ws/r/1722/)