### PR TITLE
Fixed lp:1442257 - lxc-default-mtu environ setting added

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -703,6 +703,30 @@ func (s *provisionerSuite) TestContainerManagerConfigPermissive(c *gc.C) {
 	})
 }
 
+func (s *provisionerSuite) TestContainerManagerConfigLXCDefaultMTU(c *gc.C) {
+	var resultConfig = map[string]string{
+		"lxc-default-mtu": "9000",
+	}
+	var called bool
+	provisioner.PatchFacadeCall(s, s.provisioner, func(request string, args, response interface{}) error {
+		called = true
+		c.Assert(request, gc.Equals, "ContainerManagerConfig")
+		expected := params.ContainerManagerConfigParams{
+			Type: instance.LXC,
+		}
+		c.Assert(args, gc.Equals, expected)
+		result := response.(*params.ContainerManagerConfig)
+		result.ManagerConfig = resultConfig
+		return nil
+	})
+
+	args := params.ContainerManagerConfigParams{Type: instance.LXC}
+	result, err := s.provisioner.ContainerManagerConfig(args)
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.ManagerConfig, jc.DeepEquals, resultConfig)
+}
+
 func (s *provisionerSuite) TestContainerConfig(c *gc.C) {
 	result, err := s.provisioner.ContainerConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -229,6 +229,10 @@ func (p *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerConf
 		if useLxcCloneAufs, ok := config.LXCUseCloneAUFS(); ok {
 			cfg["use-aufs"] = fmt.Sprint(useLxcCloneAufs)
 		}
+		if lxcDefaultMTU, ok := config.LXCDefaultMTU(); ok {
+			logger.Debugf("using default MTU %v for all LXC containers NICs", lxcDefaultMTU)
+			cfg[container.ConfigLXCDefaultMTU] = fmt.Sprintf("%d", lxcDefaultMTU)
+		}
 	}
 
 	if !environs.AddressAllocationEnabled() {

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
@@ -1271,7 +1272,7 @@ func (s *withoutStateServerSuite) TestWatchEnvironMachines(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{})
 }
 
-func (s *withoutStateServerSuite) getManagerConfig(c *gc.C, typ instance.ContainerType) map[string]string {
+func (s *provisionerSuite) getManagerConfig(c *gc.C, typ instance.ContainerType) map[string]string {
 	args := params.ContainerManagerConfigParams{Type: typ}
 	results, err := s.provisioner.ContainerManagerConfig(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1501,4 +1502,44 @@ func (s *withoutStateServerSuite) TestFindTools(c *gc.C) {
 			s.APIState.Addr(), coretesting.EnvironmentTag.Id(), tools.Version)
 		c.Assert(tools.URL, gc.Equals, url)
 	}
+}
+
+type lxcDefaultMTUSuite struct {
+	provisionerSuite
+}
+
+var _ = gc.Suite(&lxcDefaultMTUSuite{})
+
+func (s *lxcDefaultMTUSuite) SetUpTest(c *gc.C) {
+	// Because lxc-default-mtu is an immutable setting, we need to set
+	// it in the default config JujuConnSuite uses, before the
+	// environment is "created".
+	s.DummyConfig = dummy.SampleConfig()
+	s.DummyConfig["lxc-default-mtu"] = 9000
+	s.provisionerSuite.SetUpTest(c)
+
+	stateConfig, err := s.State.EnvironConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	value, ok := stateConfig.LXCDefaultMTU()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(value, gc.Equals, 9000)
+	c.Logf("environ config lxc-default-mtu set to %v", value)
+}
+
+func (s *lxcDefaultMTUSuite) TestContainerManagerConfigLXCDefaultMTU(c *gc.C) {
+	managerConfig := s.getManagerConfig(c, instance.LXC)
+	c.Assert(managerConfig, jc.DeepEquals, map[string]string{
+		container.ConfigName:          "juju",
+		container.ConfigLXCDefaultMTU: "9000",
+
+		"use-aufs":                   "false",
+		container.ConfigIPForwarding: "true",
+	})
+
+	// KVM instances are not affected.
+	managerConfig = s.getManagerConfig(c, instance.KVM)
+	c.Assert(managerConfig, jc.DeepEquals, map[string]string{
+		container.ConfigName:         "juju",
+		container.ConfigIPForwarding: "true",
+	})
 }

--- a/container/interface.go
+++ b/container/interface.go
@@ -23,6 +23,12 @@ const (
 	// required for AWS, but should be disabled for MAAS.
 	ConfigEnableNAT = "enable-nat"
 
+	// ConfigLXCDefaultMTU, if set to a positive integer (serialized
+	// as a string), will cause all network interfaces on all created
+	// LXC containers (not KVM instances) to use the given MTU
+	// setting.
+	ConfigLXCDefaultMTU = "lxc-default-mtu"
+
 	DefaultNamespace = "juju"
 )
 

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -63,7 +63,7 @@ func (s *KVMSuite) TestListInitiallyEmpty(c *gc.C) {
 
 func (s *KVMSuite) createRunningContainer(c *gc.C, name string) kvm.Container {
 	kvmContainer := s.ContainerFactory.New(name)
-	network := container.BridgeNetworkConfig("testbr0", nil)
+	network := container.BridgeNetworkConfig("testbr0", 0, nil)
 	c.Assert(kvmContainer.Start(kvm.StartParams{
 		Series:       "quantal",
 		Arch:         version.Current.Arch,

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -87,7 +87,7 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	machineConfig, err := environs.NewMachineConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	network := container.BridgeNetworkConfig("virbr0", nil)
+	network := container.BridgeNetworkConfig("virbr0", 0, nil)
 
 	machineConfig.Tools = &tools.Tools{
 		Version: version.MustParseBinary("2.3.4-foo-bar"),

--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -14,7 +14,6 @@ var (
 	ParseConfigLine         = parseConfigLine
 	UpdateContainerConfig   = updateContainerConfig
 	ReorderNetworkConfig    = reorderNetworkConfig
-	DiscoverHostNIC         = &discoverHostNIC
 	NetworkConfigTemplate   = networkConfigTemplate
 	RestartSymlink          = restartSymlink
 	ReleaseVersion          = &releaseVersion

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ const (
 // DefaultNetworkConfig returns a valid NetworkConfig to use the
 // defaultLxcBridge that is created by the lxc package.
 func DefaultNetworkConfig() *container.NetworkConfig {
-	return container.BridgeNetworkConfig(DefaultLxcBridge, nil)
+	return container.BridgeNetworkConfig(DefaultLxcBridge, 0, nil)
 }
 
 // FsCommandOutput calls cmd.Output, this is used as an overloading point so
@@ -870,14 +869,10 @@ func networkConfigTemplate(config container.NetworkConfig) string {
 	}
 	data := configData{
 		Link: config.Device,
+		MTU:  config.MTU,
 	}
-
-	primaryNIC, err := discoverHostNIC()
-	if err != nil {
-		logger.Warningf("cannot determine primary NIC MTU, not setting for container: %v", err)
-	} else if primaryNIC.MTU > 0 {
-		logger.Infof("setting MTU to %d for all container network interfaces", primaryNIC.MTU)
-		data.MTU = primaryNIC.MTU
+	if config.MTU > 0 {
+		logger.Infof("setting MTU to %v for all LXC network interfaces", config.MTU)
 	}
 
 	switch config.NetworkType {
@@ -945,39 +940,6 @@ func networkConfigTemplate(config container.NetworkConfig) string {
 		return ""
 	}
 	return buf.String()
-}
-
-// discoverHostNIC detects and returns the primary network interface
-// on the machine. Out of all interfaces, the first non-loopback
-// device which is up and has address is considered the primary.
-var discoverHostNIC = func() (net.Interface, error) {
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return net.Interface{}, errors.Annotatef(err, "cannot get network interfaces")
-	}
-	logger.Tracef("trying to discover primary network interface")
-	for _, iface := range interfaces {
-		if iface.Flags&net.FlagLoopback != 0 {
-			// Skip the loopback.
-			logger.Tracef("not using loopback interface %q", iface.Name)
-			continue
-		}
-		if iface.Flags&net.FlagUp != 0 {
-			// Possibly the primary, but ensure it has an address as
-			// well.
-			logger.Tracef("verifying interface %q has addresses", iface.Name)
-			addrs, err := iface.Addrs()
-			if err != nil {
-				return net.Interface{}, errors.Annotatef(err, "cannot get %q addresses", iface.Name)
-			}
-			if len(addrs) > 0 {
-				// We found it.
-				logger.Tracef("primary network interface is %q", iface.Name)
-				return iface, nil
-			}
-		}
-	}
-	return net.Interface{}, errors.Errorf("cannot detect the primary network interface")
 }
 
 func generateNetworkConfig(config *container.NetworkConfig) string {

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -6,7 +6,6 @@ package lxc_test
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
 	"github.com/juju/utils/proxy"
@@ -96,17 +94,6 @@ func (s *LxcSuite) SetUpTest(c *gc.C) {
 	s.TestSuite.ContainerFactory.AddListener(s.events)
 	s.PatchValue(&lxc.TemplateLockDir, c.MkDir())
 	s.PatchValue(&lxc.TemplateStopTimeout, 500*time.Millisecond)
-	fakeMAC, err := net.ParseMAC("aa:bb:cc:dd:ee:ff")
-	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(lxc.DiscoverHostNIC, func() (net.Interface, error) {
-		return net.Interface{
-			Index:        1,
-			MTU:          4321,
-			Name:         "eth0",
-			HardwareAddr: fakeMAC,
-			Flags:        net.FlagUp,
-		}, nil
-	})
 }
 
 func (s *LxcSuite) TearDownTest(c *gc.C) {
@@ -276,7 +263,7 @@ func (*LxcSuite) TestParseConfigLine(c *gc.C) {
 }
 
 func (s *LxcSuite) TestUpdateContainerConfig(c *gc.C) {
-	networkConfig := container.BridgeNetworkConfig("nic42", []network.InterfaceInfo{{
+	networkConfig := container.BridgeNetworkConfig("nic42", 4321, []network.InterfaceInfo{{
 		DeviceIndex:    0,
 		CIDR:           "0.1.2.0/20",
 		InterfaceName:  "eth0",
@@ -753,7 +740,7 @@ func (s *LxcSuite) createTemplate(c *gc.C) golxc.Container {
 	name := "juju-quantal-lxc-template"
 	ch := s.ensureTemplateStopped(name)
 	defer func() { <-ch }()
-	network := container.BridgeNetworkConfig("nic42", nil)
+	network := container.BridgeNetworkConfig("nic42", 4321, nil)
 	authorizedKeys := "authorized keys list"
 	aptProxy := proxy.Settings{}
 	aptMirror := "http://my.archive.ubuntu.com/ubuntu"
@@ -967,7 +954,6 @@ func (s *LxcSuite) TestCreateContainerNoRestartDir(c *gc.C) {
 lxc.network.type = veth
 lxc.network.link = nic42
 lxc.network.flags = up
-lxc.network.mtu = 4321
 
 lxc.start.auto = 1
 lxc.mount.entry = %s var/log/juju none defaults,bind 0 0
@@ -1045,57 +1031,57 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 	staticNICNoAutoWithGW := staticNIC
 	staticNICNoAutoWithGW.NoAutoStart = true
 
+	var lastTestLog string
 	allNICs := []network.InterfaceInfo{dhcpNIC, staticNIC, extraConfigNIC}
-	for _, test := range []struct {
+	for i, test := range []struct {
+		about             string
 		config            *container.NetworkConfig
-		mtu               int
 		nics              []network.InterfaceInfo
 		rendered          []string
 		logContains       string
 		logDoesNotContain string
 	}{{
+		about:  "empty config",
 		config: nil,
-		mtu:    0,
 		rendered: []string{
 			"lxc.network.type = veth",
 			"lxc.network.link = lxcbr0",
 			"lxc.network.flags = up",
 		},
 		logContains:       `WARNING juju.container.lxc network type missing, using the default "bridge" config`,
-		logDoesNotContain: `INFO juju.container.lxc setting MTU to 0 for all container network interfaces`,
+		logDoesNotContain: `INFO juju.container.lxc setting MTU to 0 for LXC network interfaces`,
 	}, {
+		about:  "default config",
 		config: lxc.DefaultNetworkConfig(),
-		mtu:    42,
 		rendered: []string{
 			"lxc.network.type = veth",
 			"lxc.network.link = lxcbr0",
 			"lxc.network.flags = up",
-			"lxc.network.mtu = 42",
 		},
-		logContains: `INFO juju.container.lxc setting MTU to 42 for all container network interfaces`,
+		logDoesNotContain: `INFO juju.container.lxc setting MTU to 0 for LXC network interfaces`,
 	}, {
-		config: container.BridgeNetworkConfig("foo", nil),
-		mtu:    1500,
+		about:  "bridge config with MTU 1500, device foo, no NICs",
+		config: container.BridgeNetworkConfig("foo", 1500, nil),
 		rendered: []string{
 			"lxc.network.type = veth",
 			"lxc.network.link = foo",
 			"lxc.network.flags = up",
 			"lxc.network.mtu = 1500",
 		},
-		logContains: `INFO juju.container.lxc setting MTU to 1500 for all container network interfaces`,
+		logContains: `INFO juju.container.lxc setting MTU to 1500 for all LXC network interfaces`,
 	}, {
-		config: container.PhysicalNetworkConfig("foo", nil),
-		mtu:    9000,
+		about:  "phys config with MTU 9000, device foo, no NICs",
+		config: container.PhysicalNetworkConfig("foo", 9000, nil),
 		rendered: []string{
 			"lxc.network.type = phys",
 			"lxc.network.link = foo",
 			"lxc.network.flags = up",
 			"lxc.network.mtu = 9000",
 		},
-		logContains: `INFO juju.container.lxc setting MTU to 9000 for all container network interfaces`,
+		logContains: `INFO juju.container.lxc setting MTU to 9000 for all LXC network interfaces`,
 	}, {
-		config: container.BridgeNetworkConfig("foo", allNICs),
-		mtu:    9000,
+		about:  "bridge config with MTU 8000, device foo, all NICs",
+		config: container.BridgeNetworkConfig("foo", 8000, allNICs),
 		nics:   allNICs,
 		rendered: []string{
 			"lxc.network.type = veth",
@@ -1103,7 +1089,7 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.flags = up",
 			"lxc.network.name = eth0",
 			"lxc.network.hwaddr = aa:bb:cc:dd:ee:f0",
-			"lxc.network.mtu = 9000",
+			"lxc.network.mtu = 8000",
 
 			"lxc.network.type = veth",
 			"lxc.network.link = foo",
@@ -1112,18 +1098,19 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.hwaddr = aa:bb:cc:dd:ee:f1",
 			"lxc.network.ipv4 = 0.1.2.3/32",
 			"lxc.network.ipv4.gateway = 0.1.2.1",
-			"lxc.network.mtu = 9000",
+			"lxc.network.mtu = 8000",
 
 			"lxc.network.type = vlan",
 			"lxc.network.vlan.id = 42",
 			"lxc.network.link = foo",
 			"lxc.network.name = eth2",
 			"lxc.network.hwaddr = aa:bb:cc:dd:ee:f2",
-			"lxc.network.mtu = 9000",
+			"lxc.network.mtu = 8000",
 		},
-		logContains: `INFO juju.container.lxc setting MTU to 9000 for all container network interfaces`,
+		logContains: `INFO juju.container.lxc setting MTU to 8000 for all LXC network interfaces`,
 	}, {
-		config: container.BridgeNetworkConfig("foo", []network.InterfaceInfo{staticNICNoCIDR}),
+		about:  "bridge config with MTU 0, device foo, staticNICNoCIDR",
+		config: container.BridgeNetworkConfig("foo", 0, []network.InterfaceInfo{staticNICNoCIDR}),
 		nics:   []network.InterfaceInfo{staticNICNoCIDR},
 		rendered: []string{
 			"lxc.network.type = veth",
@@ -1134,8 +1121,10 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.ipv4 = 0.1.2.3/32",
 			"lxc.network.ipv4.gateway = 0.1.2.1",
 		},
+		logDoesNotContain: `INFO juju.container.lxc setting MTU to 0 for all LXC network interfaces`,
 	}, {
-		config: container.BridgeNetworkConfig("foo", []network.InterfaceInfo{staticNICBadCIDR}),
+		about:  "bridge config with MTU 0, device foo, staticNICBadCIDR",
+		config: container.BridgeNetworkConfig("foo", 0, []network.InterfaceInfo{staticNICBadCIDR}),
 		nics:   []network.InterfaceInfo{staticNICBadCIDR},
 		rendered: []string{
 			"lxc.network.type = veth",
@@ -1147,7 +1136,8 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			"lxc.network.ipv4.gateway = 0.1.2.1",
 		},
 	}, {
-		config: container.BridgeNetworkConfig("foo", []network.InterfaceInfo{staticNICNoAutoWithGW}),
+		about:  "bridge config with MTU 0, device foo, staticNICNoAutoWithGW",
+		config: container.BridgeNetworkConfig("foo", 0, []network.InterfaceInfo{staticNICNoAutoWithGW}),
 		nics:   []network.InterfaceInfo{staticNICNoAutoWithGW},
 		rendered: []string{
 			"lxc.network.type = veth",
@@ -1158,14 +1148,7 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 		},
 		logContains: `WARNING juju.container.lxc not setting IPv4 gateway "0.1.2.1" for non-auto start interface "eth1"`,
 	}} {
-		restorer := gitjujutesting.PatchValue(lxc.DiscoverHostNIC, func() (net.Interface, error) {
-			return net.Interface{
-				Index: 1,
-				Name:  "eth0",
-				MTU:   test.mtu,
-				Flags: net.FlagUp,
-			}, nil
-		})
+		c.Logf("test #%d: %s", i, test.about)
 		config := lxc.GenerateNetworkConfig(test.config)
 		// Parse the config to drop comments and empty lines. This is
 		// needed to ensure the order of all settings match what we
@@ -1180,31 +1163,23 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 		}
 		c.Check(configLines, jc.DeepEquals, test.rendered)
 		if test.logContains != "" {
-			c.Check(c.GetTestLog(), jc.Contains, test.logContains)
+			log := strings.TrimPrefix(c.GetTestLog(), lastTestLog)
+			c.Check(log, jc.Contains, test.logContains)
 		}
 		if test.logDoesNotContain != "" {
-			c.Check(c.GetTestLog(), gc.Not(jc.Contains), test.logDoesNotContain)
+			log := strings.TrimPrefix(c.GetTestLog(), lastTestLog)
+			c.Check(log, gc.Not(jc.Contains), test.logDoesNotContain)
 		}
-		// TODO(dimitern) In a follow-up, test the generated user-date
+		// TODO(dimitern) In a follow-up, test the generated user-data
 		// honors the other settings.
-		restorer.Restore()
+		lastTestLog = c.GetTestLog()
 	}
 }
 
 func (*NetworkSuite) TestNetworkConfigTemplate(c *gc.C) {
-	restorer := gitjujutesting.PatchValue(lxc.DiscoverHostNIC, func() (net.Interface, error) {
-		return net.Interface{
-			Index: 1,
-			Name:  "eth0",
-			MTU:   4321,
-			Flags: net.FlagUp,
-		}, nil
-	})
-	defer restorer.Restore()
-
 	// Intentionally using an invalid type "foo" here to test it gets
 	// changed to the default "veth" and a warning is logged.
-	config := lxc.NetworkConfigTemplate(container.NetworkConfig{"foo", "bar", nil})
+	config := lxc.NetworkConfigTemplate(container.NetworkConfig{"foo", "bar", 4321, nil})
 	// In the past, the entire lxc.conf file was just networking. With
 	// the addition of the auto start, we now have to have better
 	// isolate this test. As such, we parse the conf template results
@@ -1223,15 +1198,12 @@ func (*NetworkSuite) TestNetworkConfigTemplate(c *gc.C) {
 		"lxc.network.mtu = 4321",
 	}
 	c.Assert(obtained, jc.DeepEquals, expected)
-	c.Assert(
-		c.GetTestLog(),
-		jc.Contains,
+	log := c.GetTestLog()
+	c.Assert(log, jc.Contains,
 		`WARNING juju.container.lxc unknown network type "foo", using the default "bridge" config`,
 	)
-	c.Assert(
-		c.GetTestLog(),
-		jc.Contains,
-		`INFO juju.container.lxc setting MTU to 4321 for all container network interfaces`,
+	c.Assert(log, jc.Contains,
+		`INFO juju.container.lxc setting MTU to 4321 for all LXC network interfaces`,
 	)
 }
 
@@ -1245,7 +1217,6 @@ func (s *LxcSuite) TestIsLXCSupportedOnHost(c *gc.C) {
 	supports, err := lxc.IsLXCSupported()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(supports, jc.IsTrue)
-
 }
 
 func (s *LxcSuite) TestIsLXCSupportedOnLXCContainer(c *gc.C) {
@@ -1258,7 +1229,6 @@ func (s *LxcSuite) TestIsLXCSupportedOnLXCContainer(c *gc.C) {
 	supports, err := lxc.IsLXCSupported()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(supports, jc.IsFalse)
-
 }
 
 func (s *LxcSuite) TestIsLXCSupportedMissingCgroupFile(c *gc.C) {

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -1161,14 +1161,13 @@ func (*NetworkSuite) TestGenerateNetworkConfig(c *gc.C) {
 			}
 			configLines = append(configLines, line)
 		}
+		currentLog := strings.TrimPrefix(c.GetTestLog(), lastTestLog)
 		c.Check(configLines, jc.DeepEquals, test.rendered)
 		if test.logContains != "" {
-			log := strings.TrimPrefix(c.GetTestLog(), lastTestLog)
-			c.Check(log, jc.Contains, test.logContains)
+			c.Check(currentLog, jc.Contains, test.logContains)
 		}
 		if test.logDoesNotContain != "" {
-			log := strings.TrimPrefix(c.GetTestLog(), lastTestLog)
-			c.Check(log, gc.Not(jc.Contains), test.logDoesNotContain)
+			c.Check(currentLog, gc.Not(jc.Contains), test.logDoesNotContain)
 		}
 		// TODO(dimitern) In a follow-up, test the generated user-data
 		// honors the other settings.

--- a/container/network.go
+++ b/container/network.go
@@ -18,6 +18,7 @@ const (
 type NetworkConfig struct {
 	NetworkType string
 	Device      string
+	MTU         int
 
 	Interfaces []network.InterfaceInfo
 }
@@ -25,17 +26,17 @@ type NetworkConfig struct {
 // BridgeNetworkConfig returns a valid NetworkConfig to use the
 // specified device as a network bridge for the container. It also
 // allows passing in specific configuration for the container's
-// network interfaces. If interfaces is nil the default configuration
-// is used for the respective container type.
-func BridgeNetworkConfig(device string, interfaces []network.InterfaceInfo) *NetworkConfig {
-	return &NetworkConfig{BridgeNetwork, device, interfaces}
+// network interfaces and default MTU to use. If interfaces is nil the
+// default configuration is used for the respective container type.
+func BridgeNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
+	return &NetworkConfig{BridgeNetwork, device, mtu, interfaces}
 }
 
 // PhysicalNetworkConfig returns a valid NetworkConfig to use the
 // specified device as the network device for the container. It also
 // allows passing in specific configuration for the container's
-// network interfaces. If interfaces is nil the default configuration
-// is used for the respective container type.
-func PhysicalNetworkConfig(device string, interfaces []network.InterfaceInfo) *NetworkConfig {
-	return &NetworkConfig{PhysicalNetwork, device, interfaces}
+// network interfaces and default MTU to use. If interfaces is nil the
+// default configuration is used for the respective container type.
+func PhysicalNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
+	return &NetworkConfig{PhysicalNetwork, device, mtu, interfaces}
 }

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -58,7 +58,7 @@ func CreateContainerWithMachineConfig(
 	machineConfig *cloudinit.MachineConfig,
 ) instance.Instance {
 
-	networkConfig := container.BridgeNetworkConfig("nic42", nil)
+	networkConfig := container.BridgeNetworkConfig("nic42", 0, nil)
 	return CreateContainerWithMachineAndNetworkConfig(c, manager, machineConfig, networkConfig)
 }
 
@@ -113,7 +113,7 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 	}
 	machineConfig.Config = envConfig
 
-	network := container.BridgeNetworkConfig("nic42", nil)
+	network := container.BridgeNetworkConfig("nic42", 0, nil)
 
 	inst, hardware, err := manager.CreateContainer(machineConfig, "quantal", network)
 

--- a/container/userdata_test.go
+++ b/container/userdata_test.go
@@ -73,20 +73,20 @@ func (s *UserDataSuite) TestGenerateNetworkConfig(c *gc.C) {
 	data, err := container.GenerateNetworkConfig(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.HasLen, 0)
-	netConfig := container.BridgeNetworkConfig("foo", nil)
+	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	data, err = container.GenerateNetworkConfig(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.HasLen, 0)
 
 	// Test with all interface types.
-	netConfig = container.BridgeNetworkConfig("foo", s.fakeInterfaces)
+	netConfig = container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
 	data, err = container.GenerateNetworkConfig(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.Equals, s.expectedNetConfig)
 }
 
 func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
-	netConfig := container.BridgeNetworkConfig("foo", s.fakeInterfaces)
+	netConfig := container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
 	cloudConf, err := container.NewCloudInitConfigWithNetworks(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	// We need to indent expectNetConfig to make it valid YAML,
@@ -106,7 +106,7 @@ bootcmd:
 }
 
 func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksNoConfig(c *gc.C) {
-	netConfig := container.BridgeNetworkConfig("foo", nil)
+	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	cloudConf, err := container.NewCloudInitConfigWithNetworks(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := "#cloud-config\n{}\n"
@@ -116,7 +116,7 @@ func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksNoConfig(c *gc.C) {
 func (s *UserDataSuite) TestCloudInitUserData(c *gc.C) {
 	machineConfig, err := containertesting.MockMachineConfig("1/lxc/0")
 	c.Assert(err, jc.ErrorIsNil)
-	networkConfig := container.BridgeNetworkConfig("foo", nil)
+	networkConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	data, err := container.CloudInitUserData(machineConfig, networkConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	// No need to test the exact contents here, as they are already

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -103,6 +103,9 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	} else if err != nil {
 		return err
 	}
+	if lxcMTU, ok := cfg.LXCDefaultMTU(); ok {
+		logger.Debugf("using MTU %v for all created LXC containers' network interfaces", lxcMTU)
+	}
 
 	// If we're uploading, we must override agent-version;
 	// if we're not uploading, we want to ensure we have an

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -88,6 +88,11 @@ const (
 	// Only prevent all-changes from running
 	// if user specifically requests it. Otherwise, let them run.
 	DefaultPreventAllChanges = false
+
+	// DefaultLXCDefaultMTU is the default value for "lxc-default-mtu"
+	// config setting. Only non-zero, positive integer values will
+	// have effect.
+	DefaultLXCDefaultMTU = 0
 )
 
 // TODO(katco-): Please grow this over time.
@@ -149,6 +154,11 @@ const (
 
 	// The default block storage source.
 	StorageDefaultBlockSourceKey = "storage-default-block-source"
+
+	// LXCDefaultMTU, when set to a positive integer, overrides the
+	// Machine Transmission Unit (MTU) setting of all network
+	// interfaces created for LXC containers. See also bug #1442257.
+	LXCDefaultMTU = "lxc-default-mtu"
 
 	//
 	// Deprecated Settings Attributes
@@ -620,6 +630,11 @@ func Validate(cfg, old *Config) error {
 				return fmt.Errorf("cannot clear agent-version")
 			}
 		}
+	}
+
+	// Check LXCDefaultMTU is a positive integer, when set.
+	if lxcDefaultMTU, ok := cfg.LXCDefaultMTU(); ok && lxcDefaultMTU < 0 {
+		return errors.Errorf("%s: expected positive integer, got %v", LXCDefaultMTU, lxcDefaultMTU)
 	}
 
 	cfg.defined = ProcessDeprecatedAttributes(cfg.defined)
@@ -1110,6 +1125,16 @@ func (c *Config) LXCUseCloneAUFS() (bool, bool) {
 	return v, ok
 }
 
+// LXCDefaultMTU reports whether the LXC provisioner should create a
+// containers with a specific MTU value for all network intefaces.
+func (c *Config) LXCDefaultMTU() (int, bool) {
+	v, ok := c.defined[LXCDefaultMTU].(int)
+	if !ok {
+		return DefaultLXCDefaultMTU, false
+	}
+	return v, ok
+}
+
 // DisableNetworkManagement reports whether Juju is allowed to
 // configure and manage networking inside the environment.
 func (c *Config) DisableNetworkManagement() (bool, bool) {
@@ -1206,6 +1231,7 @@ var fields = schema.Fields{
 	"proxy-ssh":                  schema.Bool(),
 	LxcClone:                     schema.Bool(),
 	"lxc-clone-aufs":             schema.Bool(),
+	LXCDefaultMTU:                schema.ForceInt(),
 	"prefer-ipv6":                schema.Bool(),
 	"enable-os-refresh-update":   schema.Bool(),
 	"enable-os-upgrade":          schema.Bool(),
@@ -1254,6 +1280,7 @@ var alwaysOptional = schema.Defaults{
 	AptFtpProxyKey:               schema.Omit,
 	"apt-mirror":                 schema.Omit,
 	LxcClone:                     schema.Omit,
+	LXCDefaultMTU:                schema.Omit,
 	"disable-network-management": schema.Omit,
 	AgentStreamKey:               schema.Omit,
 	SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
@@ -1366,6 +1393,7 @@ var immutableAttributes = []string{
 	"bootstrap-retry-delay",
 	"bootstrap-addresses-delay",
 	LxcClone,
+	LXCDefaultMTU,
 	"lxc-clone-aufs",
 	"syslog-port",
 	"prefer-ipv6",

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -197,6 +197,39 @@ var configTests = []configTest{
 			"lxc-clone":     true,
 		},
 	}, {
+		about:       "LXC default MTU not set",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+		},
+	}, {
+		about:       "LXC default MTU set explicitly",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":            "my-type",
+			"name":            "my-name",
+			"lxc-default-mtu": 9000,
+		},
+	}, {
+		about:       "LXC default MTU invalid (not a number)",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":            "my-type",
+			"name":            "my-name",
+			"lxc-default-mtu": "foo",
+		},
+		err: `lxc-default-mtu: expected number, got string\("foo"\)`,
+	}, {
+		about:       "LXC default MTU invalid (negative)",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":            "my-type",
+			"name":            "my-name",
+			"lxc-default-mtu": -42,
+		},
+		err: `lxc-default-mtu: expected positive integer, got -42`,
+	}, {
 		about:       "CA cert & key from path",
 		useDefaults: config.UseDefaults,
 		attrs: testing.Attrs{
@@ -1451,6 +1484,11 @@ var validationTests = []validationTest{{
 	old:   testing.Attrs{"lxc-clone-aufs": false},
 	new:   testing.Attrs{"lxc-clone-aufs": true},
 	err:   `cannot change lxc-clone-aufs from false to true`,
+}, {
+	about: "Cannot change lxc-default-mtu",
+	old:   testing.Attrs{"lxc-default-mtu": 9000},
+	new:   testing.Attrs{"lxc-default-mtu": 42},
+	err:   `cannot change lxc-default-mtu from 9000 to 42`,
 }, {
 	about: "Cannot change prefer-ipv6",
 	old:   testing.Attrs{"prefer-ipv6": false},

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -392,7 +392,7 @@ func (env *localEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 // Override for testing.
 var createContainer = func(env *localEnviron, args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, error) {
 	series := args.Tools.OneSeries()
-	network := container.BridgeNetworkConfig(env.config.networkBridge(), args.NetworkInfo)
+	network := container.BridgeNetworkConfig(env.config.networkBridge(), 0, args.NetworkInfo)
 	inst, hardware, err := env.containerManager.CreateContainer(args.MachineConfig, series, network)
 	if err != nil {
 		return nil, nil, err

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
@@ -254,7 +255,7 @@ func (s *ContainerSetupSuite) TestLxcContainerUsesImageURL(c *gc.C) {
 
 	brokerCalled := false
 	newlxcbroker := func(api provisioner.APICalls, agentConfig agent.Config, managerConfig container.ManagerConfig,
-		imageURLGetter container.ImageURLGetter, enableNAT bool) (environs.InstanceBroker, error) {
+		imageURLGetter container.ImageURLGetter, enableNAT bool, defaultMTU int) (environs.InstanceBroker, error) {
 		imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(imageURL, gc.Equals, "imageURL")
@@ -265,7 +266,6 @@ func (s *ContainerSetupSuite) TestLxcContainerUsesImageURL(c *gc.C) {
 	s.PatchValue(&provisioner.NewLxcBroker, newlxcbroker)
 	s.createContainer(c, m, instance.LXC)
 	c.Assert(brokerCalled, jc.IsTrue)
-
 }
 
 func (s *ContainerSetupSuite) TestContainerManagerConfigName(c *gc.C) {
@@ -487,4 +487,44 @@ func (s *AddressableContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 		s.enableFeatureFlag()
 		s.assertContainerInitialised(c, test.ctype, test.packages, true)
 	}
+}
+
+// LXCDefaultMTUSuite only contains tests depending on the
+// lxc-default-mtu environment setting being set explicitly.
+type LXCDefaultMTUSuite struct {
+	ContainerSetupSuite
+}
+
+var _ = gc.Suite(&LXCDefaultMTUSuite{})
+
+func (s *LXCDefaultMTUSuite) SetUpTest(c *gc.C) {
+	// Explicitly set lxc-default-mtu before JujuConnSuite constructs
+	// the environment, as the setting is immutable.
+	s.DummyConfig = dummy.SampleConfig()
+	s.DummyConfig["lxc-default-mtu"] = 9000
+	s.ContainerSetupSuite.SetUpTest(c)
+}
+
+func (s *LXCDefaultMTUSuite) TestDefaultMTUPropagatedToNewLXCBroker(c *gc.C) {
+	// create a machine to host the container.
+	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
+		Series:      coretesting.FakeDefaultSeries,
+		Jobs:        []state.MachineJob{state.JobHostUnits},
+		Constraints: s.defaultConstraints,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetSupportedContainers([]instance.ContainerType{instance.LXC, instance.KVM})
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetAgentVersion(version.Current)
+	c.Assert(err, jc.ErrorIsNil)
+
+	brokerCalled := false
+	newlxcbroker := func(api provisioner.APICalls, agentConfig agent.Config, managerConfig container.ManagerConfig, imageURLGetter container.ImageURLGetter, enableNAT bool, defaultMTU int) (environs.InstanceBroker, error) {
+		brokerCalled = true
+		c.Assert(defaultMTU, gc.Equals, 9000)
+		return nil, fmt.Errorf("lxc broker error")
+	}
+	s.PatchValue(&provisioner.NewLxcBroker, newlxcbroker)
+	s.createContainer(c, m, instance.LXC)
+	c.Assert(brokerCalled, jc.IsTrue)
 }

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -78,7 +78,8 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		}
 	}
 
-	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
+	// Unlike with LXC, we don't override the default MTU to use.
+	network := container.BridgeNetworkConfig(bridgeDevice, 0, args.NetworkInfo)
 
 	series := args.Tools.OneSeries()
 	args.MachineConfig.MachineContainerType = instance.KVM

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -101,7 +101,7 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 		"use-clone":          "false",
 	}
 	api := NewFakeAPI(c)
-	s.broker, err = provisioner.NewLxcBroker(&api, s.agentConfig, managerConfig, nil, false)
+	s.broker, err = provisioner.NewLxcBroker(&api, s.agentConfig, managerConfig, nil, false, 0)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -892,7 +892,7 @@ func (s *lxcProvisionerSuite) newLxcProvisioner(c *gc.C) provisioner.Provisioner
 		"log-dir":            c.MkDir(),
 		"use-clone":          "false",
 	}
-	broker, err := provisioner.NewLxcBroker(s.provisioner, agentConfig, managerConfig, &containertesting.MockURLGetter{}, false)
+	broker, err := provisioner.NewLxcBroker(s.provisioner, agentConfig, managerConfig, &containertesting.MockURLGetter{}, false, 0)
 	c.Assert(err, jc.ErrorIsNil)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
 	return provisioner.NewContainerProvisioner(instance.LXC, s.provisioner, agentConfig, broker, toolsFinder)


### PR DESCRIPTION
Removed the existing behavior implemented some time ago - the NICs of
LXC containers created by Juju inherit the MTU setting of their host's
primary NIC. Instead, Juju won't do anything specific for the MTU values
of LXC NICs, except when the new "lxc-default-mtu" environment setting
is explicitly specified as a positive integer value. Then it will be
used for all created LXC (but not KVM) instances and all their network
interfaces.

See bug http://pad.lv/1442257 for more info.

A few drive-by fixes to some of the tests done as well.

Live tested on MAAS with/without address-allocation feature flag.

(Review request: http://reviews.vapour.ws/r/1725/)