### PR TITLE
Revert pr #2359 due to cloud-init breakage

### DIFF
--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -96,7 +96,7 @@ func (c *baseConfigure) addAgentInfo(tag names.Tag) (agent.Config, error) {
 }
 
 func (c *baseConfigure) addMachineAgentToBoot() error {
-	cmds, err := c.icfg.MachineAgentCommands(c.conf.ShellRenderer())
+	svc, err := c.icfg.InitService(c.conf.ShellRenderer())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -106,6 +106,17 @@ func (c *baseConfigure) addMachineAgentToBoot() error {
 	// the init script.
 	toolsDir := c.icfg.ToolsDir(c.conf.ShellRenderer())
 	c.conf.AddScripts(c.toolsSymlinkCommand(toolsDir))
+
+	name := c.tag.String()
+	cmds, err := svc.InstallCommands()
+	if err != nil {
+		return errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
+	}
+	startCmds, err := svc.StartCommands()
+	if err != nil {
+		return errors.Annotatef(err, "cannot make cloud-init init script for the %s agent", name)
+	}
+	cmds = append(cmds, startCmds...)
 
 	svcName := c.icfg.MachineAgentServiceName
 	// TODO (gsamfira): This is temporary until we find a cleaner way to fix

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -235,8 +235,8 @@ echo 'Bootstrapping Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
-init_system=\$\(.*\)
-case "\$init_system" in.*
+cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
+start jujud-machine-0
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
 `,
 	}, {
@@ -339,8 +339,8 @@ cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-99'
 echo 'Starting Juju machine agent \(jujud-machine-99\)'.*
-init_system=\$\(.*\)
-case "\$init_system" in.*
+cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
+start jujud-machine-99
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 `,
 	}, {
@@ -382,8 +382,8 @@ mkdir -p '/var/lib/juju/agents/machine-2-lxc-1'
 cat > '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-2-lxc-1/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-2-lxc-1'
-init_system=\$\(.*\)
-case "\$init_system" in.*
+cat > /etc/init/jujud-machine-2-lxc-1\.conf << 'EOF'\\ndescription "juju agent for machine-2-lxc-1"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-2-lxc-1\.log\\n  chown syslog:syslog /var/log/juju/machine-2-lxc-1\.log\\n  chmod 0600 /var/log/juju/machine-2-lxc-1\.log\\n\\n  exec '/var/lib/juju/tools/machine-2-lxc-1/jujud' machine --data-dir '/var/lib/juju' --machine-id 2/lxc/1 --debug >> /var/log/juju/machine-2-lxc-1\.log 2>&1\\nend script\\nEOF\\n
+start jujud-machine-2-lxc-1
 `,
 	}, {
 		// hostname verification disabled.

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -651,8 +651,8 @@ func (s *LxcSuite) TestCreateContainer(c *gc.C) {
 		scripts = append(scripts, s.(string))
 	}
 
-	c.Assert(scripts[len(scripts)-3], jc.HasPrefix, `case "$init_system" in`)
-	c.Assert(scripts[len(scripts)-2:], gc.DeepEquals, []string{
+	c.Assert(scripts[len(scripts)-3:], gc.DeepEquals, []string{
+		"start jujud-machine-1-lxc-0",
 		"rm $bin/tools.tar.gz && rm $bin/juju2.3.4-quantal-amd64.sha256",
 		"ifconfig",
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -175,59 +175,6 @@ func listServicesCommand(initSystem string) (string, bool) {
 	}
 }
 
-// InstallServicesCommand composes the list of shell commands that install
-// and start the given service on the given operating system.
-func InstallServiceCommands(name string, conf common.Conf, os string) ([]string, error) {
-	if os == "windows" {
-		cmds, err := installCommands(name, conf, InitSystemWindows)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		return cmds, nil
-	}
-
-	candidates := make(map[string]string)
-	for _, initSystem := range linuxInitSystems {
-		cmds, err := installCommands(name, conf, initSystem)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		candidates[initSystem] = "\n  " + strings.Join(cmds, "\n  ")
-	}
-
-	handler := func(initSystem string) (string, bool) {
-		if cmds, ok := candidates[initSystem]; ok {
-			return cmds, true
-		}
-		return "", false
-	}
-	script := newShellSelectCommand("init_system", "exit 1", handler)
-	cmds := []string{
-		"init_system=$(" + DiscoverInitSystemScript() + ")",
-		script,
-	}
-	return cmds, nil
-}
-
-func installCommands(name string, conf common.Conf, initSystem string) ([]string, error) {
-	svc, err := NewService(name, conf, initSystem)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	cmds, err := svc.InstallCommands()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	// Return here if we want to only install (i.e. skip starting).
-
-	startCmds, err := svc.StartCommands()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return append(cmds, startCmds...), nil
-}
-
 // installStartRetryAttempts defines how much InstallAndStart retries
 // upon Start failures.
 var installStartRetryAttempts = utils.AttemptStrategy{

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -89,31 +89,6 @@ func (*serviceSuite) TestListServicesScript(c *gc.C) {
 	c.Check(strings.Split(script, "\n"), jc.DeepEquals, expected)
 }
 
-func (s *serviceSuite) TestInstallServiceCommandsLinux(c *gc.C) {
-	cmds, err := service.InstallServiceCommands(s.Name, s.Conf, "ubuntu")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(cmds, gc.HasLen, 2)
-	c.Check(cmds[0], jc.HasPrefix, "init_system=$(")
-	c.Check(cmds[1], jc.HasPrefix, "case \"$init_system\" in\nsystemd)\n")
-	c.Check(cmds[1], jc.Contains, "systemctl start")
-	c.Check(cmds[1], jc.Contains, "\nupstart)\n")
-	c.Check(cmds[1], jc.Contains, "start juju-agent-machine-0")
-	c.Check(cmds[1], gc.Not(jc.Contains), "windows")
-}
-
-func (s *serviceSuite) TestInstallServiceCommandsWindows(c *gc.C) {
-	cmds, err := service.InstallServiceCommands(s.Name, s.Conf, "windows")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(cmds, gc.HasLen, 3)
-	for i := 0; i < 3; i++ {
-		c.Check(cmds[i], jc.Contains, "juju-agent-machine-0")
-	}
-	c.Check(cmds[0], jc.HasPrefix, "New-Service")
-	c.Check(cmds[2], jc.HasPrefix, "Start-Service")
-}
-
 func (s *serviceSuite) TestInstallAndStartOkay(c *gc.C) {
 	s.PatchAttempts(5)
 


### PR DESCRIPTION
This change to doing init system discovery at cloud-init time
breaks deployment and windows tests.

This reverts commit 01bd454a5a375cc21507cc6e6695bdf0378707ad, reversing
changes made to 788839ea261dc67d6a329df946373958f798a511.

(Review request: http://reviews.vapour.ws/r/1727/)