### PR TITLE
Don't check the service conf executables on windows.

### DIFF
--- a/service/agent_test.go
+++ b/service/agent_test.go
@@ -144,7 +144,7 @@ func (*agentSuite) TestShutdownAfterConf(c *gc.C) {
 		AfterStopped: "spam",
 		ExecStart:    "/sbin/shutdown -h now",
 	})
-	c.Check(conf.Validate(), jc.ErrorIsNil)
+	c.Check(conf.Validate(""), jc.ErrorIsNil)
 }
 
 func (*agentSuite) TestShutdownAfterConfMissingServiceName(c *gc.C) {

--- a/service/common/conf.go
+++ b/service/common/conf.go
@@ -65,16 +65,16 @@ func (c Conf) IsZero() bool {
 }
 
 // Validate checks the conf's values for correctness.
-func (c Conf) Validate() error {
+func (c Conf) Validate(os string) error {
 	if c.Desc == "" {
 		return errors.New("missing Desc")
 	}
 
-	if err := c.checkExecStart(); err != nil {
+	if err := c.checkExecStart(os); err != nil {
 		return errors.Trace(err)
 	}
 
-	if err := c.checkExecStopPost(); err != nil {
+	if err := c.checkExecStopPost(os); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -107,9 +107,12 @@ func Unquote(str string) string {
 	return str
 }
 
-func (c Conf) checkExecStart() error {
+func (c Conf) checkExecStart(os string) error {
 	if c.ExecStart == "" {
 		return errors.New("missing ExecStart")
+	}
+	if os == "windows" {
+		return nil
 	}
 
 	path := executable(c.ExecStart)
@@ -120,8 +123,11 @@ func (c Conf) checkExecStart() error {
 	return nil
 }
 
-func (c Conf) checkExecStopPost() error {
+func (c Conf) checkExecStopPost(os string) error {
 	if c.ExecStopPost == "" {
+		return nil
+	}
+	if os == "windows" {
 		return nil
 	}
 

--- a/service/common/conf_test.go
+++ b/service/common/conf_test.go
@@ -39,7 +39,7 @@ func (*confSuite) TestValidateOkay(c *gc.C) {
 		Desc:      "some service",
 		ExecStart: "/path/to/some-command a b c",
 	}
-	err := conf.Validate()
+	err := conf.Validate("")
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -49,7 +49,7 @@ func (*confSuite) TestValidateSingleQuotedExecutable(c *gc.C) {
 		Desc:      "some service",
 		ExecStart: "'/path/to/some-command' a b c",
 	}
-	err := conf.Validate()
+	err := conf.Validate("")
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -59,7 +59,7 @@ func (*confSuite) TestValidateDoubleQuotedExecutable(c *gc.C) {
 		Desc:      "some service",
 		ExecStart: `"/path/to/some-command" a b c`,
 	}
-	err := conf.Validate()
+	err := conf.Validate("")
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -69,7 +69,7 @@ func (*confSuite) TestValidatePartiallyQuotedExecutable(c *gc.C) {
 		Desc:      "some service",
 		ExecStart: "'/path/to/some-command a b c'",
 	}
-	err := conf.Validate()
+	err := conf.Validate("")
 
 	c.Check(err, gc.ErrorMatches, `.*relative path in ExecStart \(.*`)
 }
@@ -78,7 +78,7 @@ func (*confSuite) TestValidateMissingDesc(c *gc.C) {
 	conf := common.Conf{
 		ExecStart: "/path/to/some-command a b c",
 	}
-	err := conf.Validate()
+	err := conf.Validate("")
 
 	c.Check(err, gc.ErrorMatches, ".*missing Desc.*")
 }
@@ -87,7 +87,7 @@ func (*confSuite) TestValidateMissingExecStart(c *gc.C) {
 	conf := common.Conf{
 		Desc: "some service",
 	}
-	err := conf.Validate()
+	err := conf.Validate("")
 
 	c.Check(err, gc.ErrorMatches, ".*missing ExecStart.*")
 }
@@ -97,7 +97,7 @@ func (*confSuite) TestValidateRelativeExecStart(c *gc.C) {
 		Desc:      "some service",
 		ExecStart: "some-command a b c",
 	}
-	err := conf.Validate()
+	err := conf.Validate("")
 
 	c.Check(err, gc.ErrorMatches, `.*relative path in ExecStart \(.*`)
 }
@@ -108,7 +108,17 @@ func (*confSuite) TestValidateRelativeExecStopPost(c *gc.C) {
 		ExecStart:    "/path/to/some-command a b c",
 		ExecStopPost: "some-other-command a b c",
 	}
-	err := conf.Validate()
+	err := conf.Validate("")
 
 	c.Check(err, gc.ErrorMatches, `.*relative path in ExecStopPost \(.*`)
+}
+
+func (*confSuite) TestValidateWindowsExecStart(c *gc.C) {
+	conf := common.Conf{
+		Desc:      "some service",
+		ExecStart: `C:\some-command a b c`,
+	}
+	err := conf.Validate("windows")
+
+	c.Check(err, jc.ErrorIsNil)
 }

--- a/service/common/service.go
+++ b/service/common/service.go
@@ -22,12 +22,12 @@ func (s Service) NoConf() bool {
 }
 
 // Validate checks the service's values for correctness.
-func (s Service) Validate() error {
+func (s Service) Validate(os string) error {
 	if s.Name == "" {
 		return errors.New("missing Name")
 	}
 
-	if err := s.Conf.Validate(); err != nil {
+	if err := s.Conf.Validate(os); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/service/common/service_test.go
+++ b/service/common/service_test.go
@@ -57,7 +57,7 @@ func (*serviceSuite) TestValidateOkay(c *gc.C) {
 			ExecStart: "/path/to/some-command x y z",
 		},
 	}
-	err := service.Validate()
+	err := service.Validate("")
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -69,7 +69,7 @@ func (*serviceSuite) TestValidateMissingName(c *gc.C) {
 			ExecStart: "/path/to/some-command x y z",
 		},
 	}
-	err := service.Validate()
+	err := service.Validate("")
 
 	c.Check(err, gc.ErrorMatches, ".*missing Name.*")
 }
@@ -81,7 +81,7 @@ func (*serviceSuite) TestValidateMissingDesc(c *gc.C) {
 			ExecStart: "/path/to/some-command x y z",
 		},
 	}
-	err := service.Validate()
+	err := service.Validate("")
 
 	c.Check(err, gc.ErrorMatches, ".*missing Desc.*")
 }
@@ -93,7 +93,7 @@ func (*serviceSuite) TestValidateMissingExecStart(c *gc.C) {
 			Desc: "some service",
 		},
 	}
-	err := service.Validate()
+	err := service.Validate("")
 
 	c.Check(err, gc.ErrorMatches, ".*missing ExecStart.*")
 }

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -92,7 +92,7 @@ func validate(name string, conf common.Conf) error {
 		return errors.NotValidf("missing service name")
 	}
 
-	if err := conf.Validate(); err != nil {
+	if err := conf.Validate(""); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -111,7 +111,7 @@ func (s *Service) confPath() string {
 
 // Validate returns an error if the service is not adequately defined.
 func (s *Service) Validate() error {
-	if err := s.Service.Validate(); err != nil {
+	if err := s.Service.Validate(""); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -75,7 +75,7 @@ func (s Service) Conf() common.Conf {
 
 // Validate checks the service for invalid values.
 func (s Service) Validate() error {
-	if err := s.Service.Validate(); err != nil {
+	if err := s.Service.Validate("windows"); err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
The current behavior causes tests to fail under Windows.  This patch fixes that.

(Review request: http://reviews.vapour.ws/r/1728/)