### PR TITLE
Merge pull request #2319 from perrito666/fix_1.22_1454599

### DIFF
--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -343,6 +343,10 @@ func (fw *Firewaller) reconcileInstances() error {
 			return err
 		}
 		instanceId, err := m.InstanceId()
+		if errors.IsNotProvisioned(err) {
+			logger.Warningf("Machine not yet provisioned: %v", err)
+			continue
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Added control for expected errors in firwaller (FIX 1454599)

Firewaller should not fail when a machine is not yet provisioned, if such is the case we should just log the occurence.

(Review request: http://reviews.vapour.ws/r/1680/)

(Review request: http://reviews.vapour.ws/r/1731/)