### PR TITLE
worker/storageprovisioner: watch machines

### DIFF
--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -19,6 +19,7 @@ type provisionerState interface {
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 
 	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
+	WatchMachine(names.MachineTag) (state.NotifyWatcher, error)
 	WatchEnvironFilesystems() state.StringsWatcher
 	WatchEnvironFilesystemAttachments() state.StringsWatcher
 	WatchMachineFilesystems(names.MachineTag) state.StringsWatcher
@@ -52,4 +53,12 @@ func (s stateShim) MachineInstanceId(tag names.MachineTag) (instance.Id, error) 
 		return "", errors.Trace(err)
 	}
 	return m.InstanceId()
+}
+
+func (s stateShim) WatchMachine(tag names.MachineTag) (state.NotifyWatcher, error) {
+	m, err := s.Machine(tag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return m.Watch(), nil
 }

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -392,9 +392,10 @@ func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 				InstanceId: "inst-id",
 				Provider:   "environscoped",
 			}},
-			{Error: &params.Error{
-				Code:    params.CodeNotProvisioned,
-				Message: `machine 2 not provisioned`,
+			{Result: params.VolumeAttachmentParams{
+				MachineTag: "machine-2",
+				VolumeTag:  "volume-3",
+				Provider:   "environscoped",
 			}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},
@@ -436,9 +437,10 @@ func (s *provisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 				InstanceId:    "inst-id",
 				Provider:      "environscoped",
 			}},
-			{Error: &params.Error{
-				Code:    params.CodeNotProvisioned,
-				Message: `machine 2 not provisioned`,
+			{Result: params.FilesystemAttachmentParams{
+				MachineTag:    "machine-2",
+				FilesystemTag: "filesystem-3",
+				Provider:      "environscoped",
 			}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -722,7 +722,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		scope := agentConfig.Tag()
 		api := st.StorageProvisioner(scope)
 		storageDir := filepath.Join(agentConfig.DataDir(), "storage")
-		return newStorageWorker(scope, storageDir, api, api, api, api), nil
+		return newStorageWorker(scope, storageDir, api, api, api, api, api), nil
 	})
 
 	// Check if the network management is disabled.
@@ -1076,7 +1076,7 @@ func (a *MachineAgent) startEnvWorkers(
 	singularRunner.StartWorker("environ-storageprovisioner", func() (worker.Worker, error) {
 		scope := agentConfig.Environment()
 		api := apiSt.StorageProvisioner(scope)
-		return newStorageWorker(scope, "", api, api, api, api), nil
+		return newStorageWorker(scope, "", api, api, api, api, api), nil
 	})
 	singularRunner.StartWorker("charm-revision-updater", func() (worker.Worker, error) {
 		return charmrevisionworker.NewRevisionUpdateWorker(apiSt.CharmRevisionUpdater()), nil

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1294,6 +1294,7 @@ func (s *MachineSuite) TestMachineAgentRunsMachineStorageWorker(c *gc.C) {
 		_ storageprovisioner.FilesystemAccessor,
 		_ storageprovisioner.LifecycleManager,
 		_ storageprovisioner.EnvironAccessor,
+		_ storageprovisioner.MachineAccessor,
 	) worker.Worker {
 		c.Check(scope, gc.Equals, m.Tag())
 		// storageDir is not empty for machine scoped storage provisioners
@@ -1329,6 +1330,7 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 		_ storageprovisioner.FilesystemAccessor,
 		_ storageprovisioner.LifecycleManager,
 		_ storageprovisioner.EnvironAccessor,
+		_ storageprovisioner.MachineAccessor,
 	) worker.Worker {
 		// storageDir is empty for environ storage provisioners
 		if storageDir == "" {

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -99,9 +99,10 @@ func (s *ebsVolumeSuite) volumeSource(c *gc.C, cfg *storage.Config) storage.Volu
 	return vs
 }
 
-func (s *ebsVolumeSuite) assertCreateVolumes(c *gc.C, vs storage.VolumeSource, zone string) {
-	instanceIdRunning := s.srv.ec2srv.NewInstances(1, "m1.medium", imageId, ec2test.Running, nil)[0]
-
+func (s *ebsVolumeSuite) createVolumes(vs storage.VolumeSource, instanceId string) ([]storage.Volume, error) {
+	if instanceId == "" {
+		instanceId = s.srv.ec2srv.NewInstances(1, "m1.medium", imageId, ec2test.Running, nil)[0]
+	}
 	volume0 := names.NewVolumeTag("0")
 	volume1 := names.NewVolumeTag("1")
 	volume2 := names.NewVolumeTag("2")
@@ -110,18 +111,26 @@ func (s *ebsVolumeSuite) assertCreateVolumes(c *gc.C, vs storage.VolumeSource, z
 		Size:     10 * 1000,
 		Provider: ec2.EBS_ProviderType,
 		Attributes: map[string]interface{}{
-			"persistent":        true,
-			"availability-zone": zone,
-			"volume-type":       "io1",
-			"iops":              100,
+			"persistent":  true,
+			"volume-type": "io1",
+			"iops":        100,
+		},
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				InstanceId: instance.Id(instanceId),
+			},
 		},
 	}, {
 		Tag:      volume1,
 		Size:     20 * 1000,
 		Provider: ec2.EBS_ProviderType,
 		Attributes: map[string]interface{}{
-			"persistent":        true,
-			"availability-zone": zone,
+			"persistent": true,
+		},
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				InstanceId: instance.Id(instanceId),
+			},
 		},
 	}, {
 		Tag:      volume2,
@@ -129,25 +138,30 @@ func (s *ebsVolumeSuite) assertCreateVolumes(c *gc.C, vs storage.VolumeSource, z
 		Provider: ec2.EBS_ProviderType,
 		Attachment: &storage.VolumeAttachmentParams{
 			AttachmentParams: storage.AttachmentParams{
-				InstanceId: instance.Id(instanceIdRunning),
+				InstanceId: instance.Id(instanceId),
 			},
 		},
 	}}
 	vols, _, err := vs.CreateVolumes(params)
+	return vols, err
+}
+
+func (s *ebsVolumeSuite) assertCreateVolumes(c *gc.C, vs storage.VolumeSource, instanceId string) {
+	vols, err := s.createVolumes(vs, instanceId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 3)
 	c.Assert(vols, jc.SameContents, []storage.Volume{{
-		Tag:        volume0,
+		Tag:        names.NewVolumeTag("0"),
 		Size:       10240,
 		VolumeId:   "vol-0",
 		Persistent: true,
 	}, {
-		Tag:        volume1,
+		Tag:        names.NewVolumeTag("1"),
 		Size:       20480,
 		VolumeId:   "vol-1",
 		Persistent: true,
 	}, {
-		Tag:        volume2,
+		Tag:        names.NewVolumeTag("2"),
 		Size:       30720,
 		VolumeId:   "vol-2",
 		Persistent: false,
@@ -187,13 +201,13 @@ func (s volumeSorter) Less(i, j int) bool {
 
 func (s *ebsVolumeSuite) TestCreateVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	s.assertCreateVolumes(c, vs, "us-east-1")
+	s.assertCreateVolumes(c, vs, "")
 }
 
 func (s *ebsVolumeSuite) TestVolumeTypeAliases(c *gc.C) {
+	instanceIdRunning := s.srv.ec2srv.NewInstances(1, "m1.medium", imageId, ec2test.Running, nil)[0]
 	vs := s.volumeSource(c, nil)
 	ec2Client := ec2.StorageEC2(vs)
-	zone := "us-east-1"
 	aliases := [][2]string{
 		{"magnetic", "standard"},
 		{"ssd", "gp2"},
@@ -205,9 +219,12 @@ func (s *ebsVolumeSuite) TestVolumeTypeAliases(c *gc.C) {
 			Size:     10 * 1000,
 			Provider: ec2.EBS_ProviderType,
 			Attributes: map[string]interface{}{
-				"persistent":        true,
-				"availability-zone": zone,
-				"volume-type":       alias[0],
+				"volume-type": alias[0],
+			},
+			Attachment: &storage.VolumeAttachmentParams{
+				AttachmentParams: storage.AttachmentParams{
+					InstanceId: instance.Id(instanceIdRunning),
+				},
 			},
 		}}
 		if alias[1] == "io1" {
@@ -231,8 +248,12 @@ func (s *ebsVolumeSuite) TestVolumeTypeAliases(c *gc.C) {
 
 func (s *ebsVolumeSuite) TestDeleteVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	s.assertCreateVolumes(c, vs, "us-east-1")
-	vs.DestroyVolumes([]string{"vol-0"})
+	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
+	err := vs.DetachVolumes(params)
+	c.Assert(err, jc.ErrorIsNil)
+	errs := vs.DestroyVolumes([]string{"vol-0"})
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+
 	ec2Client := ec2.StorageEC2(vs)
 	ec2Vols, err := ec2Client.Volumes(nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -243,7 +264,7 @@ func (s *ebsVolumeSuite) TestDeleteVolumes(c *gc.C) {
 
 func (s *ebsVolumeSuite) TestVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	s.assertCreateVolumes(c, vs, "us-east-1")
+	s.assertCreateVolumes(c, vs, "")
 
 	vols, err := vs.DescribeVolumes([]string{"vol-0", "vol-1"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -274,28 +295,14 @@ func (s *ebsVolumeSuite) TestCreateVolumesErrors(c *gc.C) {
 		err    string
 	}{{
 		params: storage.VolumeParams{
-			Provider:   ec2.EBS_ProviderType,
-			Attachment: &storage.VolumeAttachmentParams{},
-		},
-		err: "need running instance to provision volume",
-	}, {
-		params: storage.VolumeParams{
 			Provider: ec2.EBS_ProviderType,
-			Attributes: map[string]interface{}{
-				"persistent":        false,
-				"availability-zone": "us-east-1",
-			},
-			Attachment: &attachmentParams,
-		},
-		err: "cannot specify availability zone for non-persistent volume",
-	}, {
-		params: storage.VolumeParams{
-			Provider: ec2.EBS_ProviderType,
-			Attributes: map[string]interface{}{
-				"persistent": true,
+			Attachment: &storage.VolumeAttachmentParams{
+				AttachmentParams: storage.AttachmentParams{
+					InstanceId: "woat",
+				},
 			},
 		},
-		err: "missing availability zone for persistent volume",
+		err: `querying instance details: instance "woat" not found \(InvalidInstanceID.NotFound\)`,
 	}, {
 		params: storage.VolumeParams{
 			Provider: ec2.EBS_ProviderType,
@@ -370,39 +377,32 @@ func (s *ebsVolumeSuite) TestCreateVolumesErrors(c *gc.C) {
 var imageId = "ami-ccf405a5" // Ubuntu Maverick, i386, EBS store
 
 func (s *ebsVolumeSuite) setupAttachVolumesTest(
-	c *gc.C, vs storage.VolumeSource, zone string, state awsec2.InstanceState,
+	c *gc.C, vs storage.VolumeSource, state awsec2.InstanceState,
 ) []storage.VolumeAttachmentParams {
 
-	s.assertCreateVolumes(c, vs, zone)
-	ids := s.srv.ec2srv.NewInstances(1, "m1.medium", imageId, state, nil)
+	instanceId := s.srv.ec2srv.NewInstances(1, "m1.medium", imageId, state, nil)[0]
+	s.assertCreateVolumes(c, vs, instanceId)
 
 	return []storage.VolumeAttachmentParams{{
 		Volume:   names.NewVolumeTag("0"),
 		VolumeId: "vol-0",
 		AttachmentParams: storage.AttachmentParams{
 			Machine:    names.NewMachineTag("1"),
-			InstanceId: instance.Id(ids[0]),
+			InstanceId: instance.Id(instanceId),
 		},
 	}}
 }
 
 func (s *ebsVolumeSuite) TestAttachVolumesNotRunning(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	params := s.setupAttachVolumesTest(c, vs, "us-east-1c", ec2test.Pending)
-	_, err := vs.AttachVolumes(params)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, ".* these instances are not running: i-4")
-}
-
-func (s *ebsVolumeSuite) TestAttachVolumesWrongZone(c *gc.C) {
-	vs := s.volumeSource(c, nil)
-	params := s.setupAttachVolumesTest(c, vs, "us-east-1", ec2test.Running)
-	_, err := vs.AttachVolumes(params)
-	c.Assert(err, gc.ErrorMatches, `.* volume availability zone "us-east-1" must match instance zone "us-east-1c" .*`)
+	instanceId := s.srv.ec2srv.NewInstances(1, "m1.medium", imageId, ec2test.Pending, nil)[0]
+	_, err := s.createVolumes(vs, instanceId)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, ".* these instances are not running: i-3")
 }
 
 func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	params := s.setupAttachVolumesTest(c, vs, "us-east-1c", ec2test.Running)
+	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
 	result, err := vs.AttachVolumes(params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
@@ -419,10 +419,11 @@ func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
 	c.Assert(ec2Vols.Volumes, gc.HasLen, 3)
 	sortBySize(ec2Vols.Volumes)
 	c.Assert(ec2Vols.Volumes[0].Attachments, jc.DeepEquals, []awsec2.VolumeAttachment{{
-		VolumeId:   "vol-0",
-		InstanceId: "i-4",
-		Device:     "/dev/sdf",
-		Status:     "attached",
+		VolumeId:            "vol-0",
+		InstanceId:          "i-3",
+		Device:              "/dev/sdf",
+		Status:              "attached",
+		DeleteOnTermination: true,
 	}})
 
 	// Test idempotency.
@@ -439,7 +440,7 @@ func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
 
 func (s *ebsVolumeSuite) TestDetachVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	params := s.setupAttachVolumesTest(c, vs, "us-east-1c", ec2test.Running)
+	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
 	_, err := vs.AttachVolumes(params)
 	c.Assert(err, jc.ErrorIsNil)
 	err = vs.DetachVolumes(params)

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -202,10 +202,6 @@ func (s *cinderVolumeSource) DestroyVolumes(volumeIds []string) []error {
 
 // ValidateVolumeParams implements storage.VolumeSource.
 func (s *cinderVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
-	// TODO(axw) this should move to the storageprovisioner.
-	if params.Attachment == nil || params.Attachment.InstanceId == "" {
-		return storage.ErrVolumeNeedsInstance
-	}
 	return nil
 }
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -4,7 +4,6 @@
 package storage
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/environs/config"
@@ -24,10 +23,6 @@ const (
 	ScopeEnviron Scope = iota
 	ScopeMachine
 )
-
-// ErrVolumeNeedsInstance is an error indicating that a volume cannot be
-// created because the related machine instance has not been provisioned.
-var ErrVolumeNeedsInstance = errors.New("need running instance to provision volume")
 
 // Provider is an interface for obtaining storage sources.
 type Provider interface {
@@ -86,12 +81,6 @@ type VolumeSource interface {
 
 	// ValidateVolumeParams validates the provided volume creation
 	// parameters, returning an error if they are invalid.
-	//
-	// If the provider requires information about the machine instance to
-	// which the volume will be attached before, and the supplied instance
-	// ID is empty (i.e. the instance is not yet provisioned), then
-	// ErrVolumeNeedsInstance must be returned to indicate that the
-	// provisioner should call again when the instance has been provisioned.
 	ValidateVolumeParams(params VolumeParams) error
 
 	// AttachVolumes attaches volumes to machines.

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -362,6 +362,9 @@ func processAliveFilesystemAttachments(
 		if err != nil {
 			return errors.Annotate(err, "getting filesystem attachment parameters")
 		}
+		if params.InstanceId == "" {
+			watchMachine(ctx, params.Machine)
+		}
 		ctx.pendingFilesystemAttachments[pending[i]] = params
 	}
 	return nil
@@ -392,7 +395,6 @@ func processPendingFilesystemAttachments(ctx *context) error {
 				continue
 			}
 		}
-		// TODO(axw) watch machines in storageprovisioner
 		if params.InstanceId == "" {
 			logger.Debugf("machine %v has not been provisioned yet", params.Machine.Id())
 			continue

--- a/worker/storageprovisioner/machines.go
+++ b/worker/storageprovisioner/machines.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state/watcher"
+)
+
+// watchMachine starts a machine watcher if there is not already one for the
+// specified tag. The watcher will notify the worker when the machine changes,
+// for example when it is provisioned.
+func watchMachine(ctx *context, tag names.MachineTag) {
+	_, ok := ctx.machines[tag]
+	if ok {
+		return
+	}
+	w := newMachineWatcher(ctx.machineAccessor, tag, ctx.machineChanges)
+	ctx.machines[tag] = w
+}
+
+// refreshMachine refreshes the specified machine's instance ID. If it is set,
+// then the machine watcher is stopped and pending entities' parameters are
+// updated. If the machine is not provisioned yet, this method is a no-op.
+func refreshMachine(ctx *context, tag names.MachineTag) error {
+	w, ok := ctx.machines[tag]
+	if !ok {
+		return errors.Errorf("machine %s is not being watched", tag.Id())
+	}
+	stopAndRemove := func() error {
+		if err := w.stop(); err != nil {
+			return errors.Annotate(err, "stopping machine watcher")
+		}
+		delete(ctx.machines, tag)
+		return nil
+	}
+	results, err := ctx.machineAccessor.InstanceIds([]names.MachineTag{tag})
+	if err != nil {
+		return errors.Annotate(err, "getting machine instance ID")
+	}
+	if err := results[0].Error; err != nil {
+		if params.IsCodeNotProvisioned(err) {
+			return nil
+		} else if params.IsCodeNotFound(err) {
+			// Machine is gone, so stop watching.
+			return stopAndRemove()
+		}
+		return errors.Annotate(err, "getting machine instance ID")
+	}
+	machineProvisioned(ctx, tag, instance.Id(results[0].Result))
+	// machine provisioning is the only thing we care about;
+	// stop the watcher.
+	return stopAndRemove()
+}
+
+// machineProvisioned is called when a watched machine is provisioned.
+func machineProvisioned(ctx *context, tag names.MachineTag, instanceId instance.Id) {
+	for _, params := range ctx.pendingVolumes {
+		if params.Attachment.Machine != tag || params.Attachment.InstanceId != "" {
+			continue
+		}
+		params.Attachment.InstanceId = instanceId
+	}
+	for id, params := range ctx.pendingVolumeAttachments {
+		if params.Machine != tag || params.InstanceId != "" {
+			continue
+		}
+		params.InstanceId = instanceId
+		ctx.pendingVolumeAttachments[id] = params
+	}
+	for id, params := range ctx.pendingFilesystemAttachments {
+		if params.Machine != tag || params.InstanceId != "" {
+			continue
+		}
+		params.InstanceId = instanceId
+		ctx.pendingFilesystemAttachments[id] = params
+	}
+}
+
+type machineWatcher struct {
+	tomb       tomb.Tomb
+	accessor   MachineAccessor
+	tag        names.MachineTag
+	instanceId instance.Id
+	out        chan<- names.MachineTag
+}
+
+func newMachineWatcher(
+	accessor MachineAccessor,
+	tag names.MachineTag,
+	out chan<- names.MachineTag,
+) *machineWatcher {
+	w := &machineWatcher{
+		accessor: accessor,
+		tag:      tag,
+		out:      out,
+	}
+	go func() {
+		defer w.tomb.Done()
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+func (mw *machineWatcher) stop() error {
+	mw.tomb.Kill(nil)
+	return mw.tomb.Wait()
+}
+
+func (mw *machineWatcher) loop() error {
+	w, err := mw.accessor.WatchMachine(mw.tag)
+	if err != nil {
+		return errors.Annotate(err, "watching machine")
+	}
+	logger.Debugf("watching machine %s", mw.tag.Id())
+	defer logger.Debugf("finished watching machine %s", mw.tag.Id())
+	var out chan<- names.MachineTag
+	for {
+		select {
+		case <-mw.tomb.Dying():
+			return tomb.ErrDying
+		case _, ok := <-w.Changes():
+			if !ok {
+				return watcher.EnsureErr(w)
+			}
+			out = mw.out
+		case out <- mw.tag:
+			out = nil
+		}
+	}
+}


### PR DESCRIPTION
When a volume or filesystem is to be attached to a machine, and the machine
is unprovisioned, then the storageprovisioner worker will now watch that
machine. When the machine is observed to have been provisioned, we will
update the parameters of the associated storage entities with the instance
ID and proceed to create them.

The Cinder and EBS providers are updated to expect an attachment in
CreateVolumes, and to ignore the availability-zone config attribute.

(Review request: http://reviews.vapour.ws/r/1734/)