### PR TITLE
JES: current-system file and switch

### DIFF
--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -69,8 +69,14 @@ func (em *EnvironmentManagerAPI) authCheck(user, adminUser names.UserTag) error 
 	if !ok {
 		return errors.Errorf("auth tag should be a user, but isn't: %q", authTag.String())
 	}
-	logger.Tracef("comparing api user %q against owner %q and admin %q", apiUser, user, adminUser)
-	if apiUser == user || apiUser == adminUser {
+	// We can't just compare the UserTags themselves as the provider part
+	// may be unset, and gets replaced with 'local'. We must compare against
+	// the Username of the user tag.
+	apiUsername := apiUser.Username()
+	username := user.Username()
+	adminUsername := adminUser.Username()
+	logger.Tracef("comparing api user %q against owner %q and admin %q", apiUsername, username, adminUsername)
+	if apiUsername == username || apiUsername == adminUsername {
 		return nil
 	}
 	return common.ErrPerm

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -298,6 +298,16 @@ func (s *envManagerSuite) TestListEnvironmentsForSelf(c *gc.C) {
 	c.Assert(result.UserEnvironments, gc.HasLen, 0)
 }
 
+func (s *envManagerSuite) TestListEnvironmentsForSelfLocalUser(c *gc.C) {
+	// When the user's credentials cache stores the simple name, but the
+	// api server converts it to a fully qualified name.
+	user := names.NewUserTag("local-user")
+	s.setAPIUser(c, names.NewUserTag("local-user@local"))
+	result, err := s.envmanager.ListEnvironments(params.Entity{user.String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.UserEnvironments, gc.HasLen, 0)
+}
+
 func (s *envManagerSuite) checkEnvironmentMatches(c *gc.C, env params.Environment, expected *state.Environment) {
 	c.Check(env.Name, gc.Equals, expected.Name())
 	c.Check(env.UUID, gc.Equals, expected.UUID())

--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -42,6 +42,9 @@ func GetDefaultEnvironment() (string, error) {
 	if currentEnv := ReadCurrentEnvironment(); currentEnv != "" {
 		return currentEnv, nil
 	}
+	if currentSystem := ReadCurrentSystem(); currentSystem != "" {
+		return "", errors.Errorf("not operating on an environment, using system %q", currentSystem)
+	}
 	envs, err := environs.ReadEnvirons("")
 	if environs.IsNoEnv(err) {
 		// That's fine, not an error here.

--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -1,15 +1,11 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2013-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package envcmd
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -27,39 +23,10 @@ import (
 
 var logger = loggo.GetLogger("juju.cmd.envcmd")
 
-const CurrentEnvironmentFilename = "current-environment"
-
 // ErrNoEnvironmentSpecified is returned by commands that operate on
 // an environment if there is no current environment, no environment
 // has been explicitly specified, and there is no default environment.
 var ErrNoEnvironmentSpecified = errors.New("no environment specified")
-
-func getCurrentEnvironmentFilePath() string {
-	return filepath.Join(osenv.JujuHome(), CurrentEnvironmentFilename)
-}
-
-// Read the file $JUJU_HOME/current-environment and return the value stored
-// there.  If the file doesn't exist, or there is a problem reading the file,
-// an empty string is returned.
-func ReadCurrentEnvironment() string {
-	current, err := ioutil.ReadFile(getCurrentEnvironmentFilePath())
-	// The file not being there, or not readable isn't really an error for us
-	// here.  We treat it as "can't tell, so you get the default".
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(current))
-}
-
-// Write the envName to the file $JUJU_HOME/current-environment file.
-func WriteCurrentEnvironment(envName string) error {
-	path := getCurrentEnvironmentFilePath()
-	err := ioutil.WriteFile(path, []byte(envName+"\n"), 0644)
-	if err != nil {
-		return fmt.Errorf("unable to write to the environment file: %q, %s", path, err)
-	}
-	return nil
-}
 
 // GetDefaultEnvironment returns the name of the Juju default environment.
 // There is simple ordering for the default environment.  Firstly check the

--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -39,10 +39,14 @@ func GetDefaultEnvironment() (string, error) {
 	if defaultEnv := os.Getenv(osenv.JujuEnvEnvKey); defaultEnv != "" {
 		return defaultEnv, nil
 	}
-	if currentEnv := ReadCurrentEnvironment(); currentEnv != "" {
+	if currentEnv, err := ReadCurrentEnvironment(); err != nil {
+		return "", errors.Trace(err)
+	} else if currentEnv != "" {
 		return currentEnv, nil
 	}
-	if currentSystem := ReadCurrentSystem(); currentSystem != "" {
+	if currentSystem, err := ReadCurrentSystem(); err != nil {
+		return "", errors.Trace(err)
+	} else if currentSystem != "" {
 		return "", errors.Errorf("not operating on an environment, using system %q", currentSystem)
 	}
 	envs, err := environs.ReadEnvirons("")

--- a/cmd/envcmd/environmentcommand_test.go
+++ b/cmd/envcmd/environmentcommand_test.go
@@ -5,9 +5,7 @@ package envcmd_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
-	"testing"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
@@ -19,29 +17,15 @@ import (
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/juju/osenv"
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
 
 type EnvironmentCommandSuite struct {
-	coretesting.FakeJujuHomeSuite
+	testing.FakeJujuHomeSuite
 }
 
 var _ = gc.Suite(&EnvironmentCommandSuite{})
-
-func Test(t *testing.T) { gc.TestingT(t) }
-
-func (s *EnvironmentCommandSuite) TestReadCurrentEnvironmentUnset(c *gc.C) {
-	env := envcmd.ReadCurrentEnvironment()
-	c.Assert(env, gc.Equals, "")
-}
-
-func (s *EnvironmentCommandSuite) TestReadCurrentEnvironmentSet(c *gc.C) {
-	err := envcmd.WriteCurrentEnvironment("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	env := envcmd.ReadCurrentEnvironment()
-	c.Assert(env, gc.Equals, "fubar")
-}
 
 func (s *EnvironmentCommandSuite) TestGetDefaultEnvironment(c *gc.C) {
 	env, err := envcmd.GetDefaultEnvironment()
@@ -82,14 +66,6 @@ func (s *EnvironmentCommandSuite) TestGetDefaultEnvironmentBothSet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *EnvironmentCommandSuite) TestWriteAddsNewline(c *gc.C) {
-	err := envcmd.WriteCurrentEnvironment("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	current, err := ioutil.ReadFile(envcmd.GetCurrentEnvironmentFilePath())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(current), gc.Equals, "fubar\n")
-}
-
 func (*EnvironmentCommandSuite) TestErrorWritingFile(c *gc.C) {
 	// Can't write a file over a directory.
 	os.MkdirAll(envcmd.GetCurrentEnvironmentFilePath(), 0777)
@@ -104,15 +80,15 @@ func (s *EnvironmentCommandSuite) TestEnvironCommandInitExplicit(c *gc.C) {
 
 func (s *EnvironmentCommandSuite) TestEnvironCommandInitMultipleConfigs(c *gc.C) {
 	// Take environment name from the default.
-	coretesting.WriteEnvironments(c, coretesting.MultipleEnvConfig)
-	testEnsureEnvName(c, coretesting.SampleEnvName)
+	testing.WriteEnvironments(c, testing.MultipleEnvConfig)
+	testEnsureEnvName(c, testing.SampleEnvName)
 }
 
 func (s *EnvironmentCommandSuite) TestEnvironCommandInitSingleConfig(c *gc.C) {
 	// Take environment name from the one and only environment,
 	// even if it is not explicitly marked as default.
-	coretesting.WriteEnvironments(c, coretesting.SingleEnvConfigNoDefault)
-	testEnsureEnvName(c, coretesting.SampleEnvName)
+	testing.WriteEnvironments(c, testing.SingleEnvConfigNoDefault)
+	testEnsureEnvName(c, testing.SampleEnvName)
 }
 
 func (s *EnvironmentCommandSuite) TestEnvironCommandInitEnvFile(c *gc.C) {
@@ -131,7 +107,7 @@ func (s *EnvironmentCommandSuite) TestEnvironCommandInitNoEnvFile(c *gc.C) {
 
 func (s *EnvironmentCommandSuite) TestEnvironCommandInitMultipleConfigNoDefault(c *gc.C) {
 	// If there are multiple environments but no default, the connection name is empty.
-	coretesting.WriteEnvironments(c, coretesting.MultipleEnvConfigNoDefault)
+	testing.WriteEnvironments(c, testing.MultipleEnvConfigNoDefault)
 	testEnsureEnvName(c, "")
 }
 
@@ -170,7 +146,7 @@ func testEnsureEnvName(c *gc.C, expect string, args ...string) {
 }
 
 type ConnectionEndpointSuite struct {
-	coretesting.FakeJujuHomeSuite
+	testing.FakeJujuHomeSuite
 	store    configstore.Storage
 	endpoint configstore.APIEndpoint
 }

--- a/cmd/envcmd/environmentcommand_test.go
+++ b/cmd/envcmd/environmentcommand_test.go
@@ -66,13 +66,6 @@ func (s *EnvironmentCommandSuite) TestGetDefaultEnvironmentBothSet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (*EnvironmentCommandSuite) TestErrorWritingFile(c *gc.C) {
-	// Can't write a file over a directory.
-	os.MkdirAll(envcmd.GetCurrentEnvironmentFilePath(), 0777)
-	err := envcmd.WriteCurrentEnvironment("fubar")
-	c.Assert(err, gc.ErrorMatches, "unable to write to the environment file: .*")
-}
-
 func (s *EnvironmentCommandSuite) TestEnvironCommandInitExplicit(c *gc.C) {
 	// Take environment name from command line arg.
 	testEnsureEnvName(c, "explicit", "-e", "explicit")
@@ -96,6 +89,14 @@ func (s *EnvironmentCommandSuite) TestEnvironCommandInitEnvFile(c *gc.C) {
 	err := envcmd.WriteCurrentEnvironment("fubar")
 	c.Assert(err, jc.ErrorIsNil)
 	testEnsureEnvName(c, "fubar")
+}
+
+func (s *EnvironmentCommandSuite) TestEnvironCommandInitSystemFile(c *gc.C) {
+	// If there is a current-system file, error raised.
+	err := envcmd.WriteCurrentSystem("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = initTestCommand(c)
+	c.Assert(err, gc.ErrorMatches, `not operating on an environment, using system "fubar"`)
 }
 
 func (s *EnvironmentCommandSuite) TestEnvironCommandInitNoEnvFile(c *gc.C) {

--- a/cmd/envcmd/export_test.go
+++ b/cmd/envcmd/export_test.go
@@ -5,6 +5,7 @@ package envcmd
 
 var (
 	GetCurrentEnvironmentFilePath = getCurrentEnvironmentFilePath
+	GetCurrentSystemFilePath      = getCurrentSystemFilePath
 	GetConfigStore                = &getConfigStore
 	EndpointRefresher             = &endpointRefresher
 )

--- a/cmd/envcmd/files.go
+++ b/cmd/envcmd/files.go
@@ -15,16 +15,16 @@ import (
 )
 
 const (
-	currentEnvironmentFilename = "current-environment"
-	currentSystemFilename      = "current-system"
+	CurrentEnvironmentFilename = "current-environment"
+	CurrentSystemFilename      = "current-system"
 )
 
 func getCurrentEnvironmentFilePath() string {
-	return filepath.Join(osenv.JujuHome(), currentEnvironmentFilename)
+	return filepath.Join(osenv.JujuHome(), CurrentEnvironmentFilename)
 }
 
 func getCurrentSystemFilePath() string {
-	return filepath.Join(osenv.JujuHome(), currentSystemFilename)
+	return filepath.Join(osenv.JujuHome(), CurrentSystemFilename)
 }
 
 // Read the file $JUJU_HOME/current-environment and return the value stored

--- a/cmd/envcmd/files.go
+++ b/cmd/envcmd/files.go
@@ -64,6 +64,9 @@ func WriteCurrentEnvironment(envName string) error {
 	}
 	// If there is a current system file, remove it.
 	if err := os.Remove(getCurrentSystemFilePath()); err != nil && !os.IsNotExist(err) {
+		logger.Debugf("removing the current environment file due to %s", err)
+		// Best attempt to remove the file we just wrote.
+		os.Remove(path)
 		return err
 	}
 	return nil
@@ -74,10 +77,13 @@ func WriteCurrentSystem(systemName string) error {
 	path := getCurrentSystemFilePath()
 	err := ioutil.WriteFile(path, []byte(systemName+"\n"), 0644)
 	if err != nil {
-		return errors.Errorf("unable to write to the environment file: %q, %s", path, err)
+		return errors.Errorf("unable to write to the system file: %q, %s", path, err)
 	}
 	// If there is a current environment file, remove it.
 	if err := os.Remove(getCurrentEnvironmentFilePath()); err != nil && !os.IsNotExist(err) {
+		logger.Debugf("removing the current system file due to %s", err)
+		// Best attempt to remove the file we just wrote.
+		os.Remove(path)
 		return err
 	}
 	return nil

--- a/cmd/envcmd/files.go
+++ b/cmd/envcmd/files.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package envcmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/juju/osenv"
+)
+
+const (
+	currentEnvironmentFilename = "current-environment"
+	currentSystemFilename      = "current-system"
+)
+
+func getCurrentEnvironmentFilePath() string {
+	return filepath.Join(osenv.JujuHome(), currentEnvironmentFilename)
+}
+
+func getCurrentSystemFilePath() string {
+	return filepath.Join(osenv.JujuHome(), currentSystemFilename)
+}
+
+// Read the file $JUJU_HOME/current-environment and return the value stored
+// there.  If the file doesn't exist, or there is a problem reading the file,
+// an empty string is returned.
+func ReadCurrentEnvironment() string {
+	current, err := ioutil.ReadFile(getCurrentEnvironmentFilePath())
+	// The file not being there, or not readable isn't really an error for us
+	// here.  We treat it as "can't tell, so you get the default".
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(current))
+}
+
+// Read the file $JUJU_HOME/current-system and return the value stored
+// there.  If the file doesn't exist, or there is a problem reading the file,
+// an empty string is returned.
+//
+// probably want to add error returns...
+func ReadCurrentSystem() string {
+	current, err := ioutil.ReadFile(getCurrentSystemFilePath())
+	// The file not being there, or not readable isn't really an error for us
+	// here.  We treat it as "can't tell, so you get the default".
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(current))
+}
+
+// Write the envName to the file $JUJU_HOME/current-environment file.
+func WriteCurrentEnvironment(envName string) error {
+	path := getCurrentEnvironmentFilePath()
+	err := ioutil.WriteFile(path, []byte(envName+"\n"), 0644)
+	if err != nil {
+		return errors.Errorf("unable to write to the environment file: %q, %s", path, err)
+	}
+	// If there is a current system file, remove it.
+	if err := os.Remove(getCurrentSystemFilePath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// Write the systemName to the file $JUJU_HOME/current-system file.
+func WriteCurrentSystem(systemName string) error {
+	path := getCurrentSystemFilePath()
+	err := ioutil.WriteFile(path, []byte(systemName+"\n"), 0644)
+	if err != nil {
+		return errors.Errorf("unable to write to the environment file: %q, %s", path, err)
+	}
+	// If there is a current environment file, remove it.
+	if err := os.Remove(getCurrentEnvironmentFilePath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/cmd/envcmd/files_test.go
+++ b/cmd/envcmd/files_test.go
@@ -5,6 +5,7 @@ package envcmd_test
 
 import (
 	"io/ioutil"
+	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -73,4 +74,11 @@ func (s *filesSuite) TestWriteSystemRemovesEnvironmentFile(c *gc.C) {
 	err = envcmd.WriteCurrentSystem("baz")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envcmd.GetCurrentEnvironmentFilePath(), jc.DoesNotExist)
+}
+
+func (*filesSuite) TestErrorWritingFile(c *gc.C) {
+	// Can't write a file over a directory.
+	os.MkdirAll(envcmd.GetCurrentEnvironmentFilePath(), 0777)
+	err := envcmd.WriteCurrentEnvironment("fubar")
+	c.Assert(err, gc.ErrorMatches, "unable to write to the environment file: .*")
 }

--- a/cmd/envcmd/files_test.go
+++ b/cmd/envcmd/files_test.go
@@ -21,26 +21,30 @@ type filesSuite struct {
 var _ = gc.Suite(&filesSuite{})
 
 func (s *filesSuite) TestReadCurrentEnvironmentUnset(c *gc.C) {
-	env := envcmd.ReadCurrentEnvironment()
+	env, err := envcmd.ReadCurrentEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.Equals, "")
 }
 
 func (s *filesSuite) TestReadCurrentSystemUnset(c *gc.C) {
-	env := envcmd.ReadCurrentSystem()
+	env, err := envcmd.ReadCurrentSystem()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.Equals, "")
 }
 
 func (s *filesSuite) TestReadCurrentEnvironmentSet(c *gc.C) {
 	err := envcmd.WriteCurrentEnvironment("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	env := envcmd.ReadCurrentEnvironment()
+	env, err := envcmd.ReadCurrentEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.Equals, "fubar")
 }
 
 func (s *filesSuite) TestReadCurrentSystemSet(c *gc.C) {
 	err := envcmd.WriteCurrentSystem("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	env := envcmd.ReadCurrentSystem()
+	env, err := envcmd.ReadCurrentSystem()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.Equals, "fubar")
 }
 

--- a/cmd/envcmd/files_test.go
+++ b/cmd/envcmd/files_test.go
@@ -76,9 +76,16 @@ func (s *filesSuite) TestWriteSystemRemovesEnvironmentFile(c *gc.C) {
 	c.Assert(envcmd.GetCurrentEnvironmentFilePath(), jc.DoesNotExist)
 }
 
-func (*filesSuite) TestErrorWritingFile(c *gc.C) {
+func (*filesSuite) TestErrorWritingCurrentEnvironment(c *gc.C) {
 	// Can't write a file over a directory.
 	os.MkdirAll(envcmd.GetCurrentEnvironmentFilePath(), 0777)
 	err := envcmd.WriteCurrentEnvironment("fubar")
 	c.Assert(err, gc.ErrorMatches, "unable to write to the environment file: .*")
+}
+
+func (*filesSuite) TestErrorWritingCurrentSystem(c *gc.C) {
+	// Can't write a file over a directory.
+	os.MkdirAll(envcmd.GetCurrentSystemFilePath(), 0777)
+	err := envcmd.WriteCurrentSystem("fubar")
+	c.Assert(err, gc.ErrorMatches, "unable to write to the system file: .*")
 }

--- a/cmd/envcmd/files_test.go
+++ b/cmd/envcmd/files_test.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package envcmd_test
+
+import (
+	"io/ioutil"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/testing"
+)
+
+type filesSuite struct {
+	testing.FakeJujuHomeSuite
+}
+
+var _ = gc.Suite(&filesSuite{})
+
+func (s *filesSuite) TestReadCurrentEnvironmentUnset(c *gc.C) {
+	env := envcmd.ReadCurrentEnvironment()
+	c.Assert(env, gc.Equals, "")
+}
+
+func (s *filesSuite) TestReadCurrentSystemUnset(c *gc.C) {
+	env := envcmd.ReadCurrentSystem()
+	c.Assert(env, gc.Equals, "")
+}
+
+func (s *filesSuite) TestReadCurrentEnvironmentSet(c *gc.C) {
+	err := envcmd.WriteCurrentEnvironment("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	env := envcmd.ReadCurrentEnvironment()
+	c.Assert(env, gc.Equals, "fubar")
+}
+
+func (s *filesSuite) TestReadCurrentSystemSet(c *gc.C) {
+	err := envcmd.WriteCurrentSystem("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	env := envcmd.ReadCurrentSystem()
+	c.Assert(env, gc.Equals, "fubar")
+}
+
+func (s *filesSuite) TestWriteEnvironmentAddsNewline(c *gc.C) {
+	err := envcmd.WriteCurrentEnvironment("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	current, err := ioutil.ReadFile(envcmd.GetCurrentEnvironmentFilePath())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(current), gc.Equals, "fubar\n")
+}
+
+func (s *filesSuite) TestWriteSystemAddsNewline(c *gc.C) {
+	err := envcmd.WriteCurrentSystem("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	current, err := ioutil.ReadFile(envcmd.GetCurrentSystemFilePath())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(current), gc.Equals, "fubar\n")
+}
+
+func (s *filesSuite) TestWriteEnvironmentRemovesSystemFile(c *gc.C) {
+	err := envcmd.WriteCurrentSystem("baz")
+	c.Assert(err, jc.ErrorIsNil)
+	err = envcmd.WriteCurrentEnvironment("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(envcmd.GetCurrentSystemFilePath(), jc.DoesNotExist)
+}
+
+func (s *filesSuite) TestWriteSystemRemovesEnvironmentFile(c *gc.C) {
+	err := envcmd.WriteCurrentEnvironment("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	err = envcmd.WriteCurrentSystem("baz")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(envcmd.GetCurrentEnvironmentFilePath(), jc.DoesNotExist)
+}

--- a/cmd/envcmd/package_test.go
+++ b/cmd/envcmd/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package envcmd_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/envcmd/systemcommand.go
+++ b/cmd/envcmd/systemcommand.go
@@ -20,7 +20,8 @@ import (
 // explicitly specified, and there is no default system.
 var ErrNoSystemSpecified = errors.New("no system specified")
 
-// SystemCommand extends cmd.Command with a SetSystemName method.
+// SystemCommand is intended to be a base for all commands
+// that need to operate on systems as opposed to environments.
 type SystemCommand interface {
 	cmd.Command
 

--- a/cmd/envcmd/systemcommand.go
+++ b/cmd/envcmd/systemcommand.go
@@ -91,25 +91,11 @@ func (c *SysCommandBase) ConnectionCredentials() (configstore.APICredentials, er
 	if c.systemName == "" {
 		return emptyCreds, errors.Trace(ErrNoSystemSpecified)
 	}
-	info, err := connectionInfoForName(c.systemName)
+	info, err := ConnectionInfoForName(c.systemName)
 	if err != nil {
 		return emptyCreds, errors.Trace(err)
 	}
 	return info.APICredentials(), nil
-}
-
-// connectionInfoForName reads the environment information for the named
-// environment (systemName) and returns it.
-func connectionInfoForName(systemName string) (configstore.EnvironInfo, error) {
-	store, err := getConfigStore()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	info, err := store.ReadInfo(systemName)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return info, nil
 }
 
 // Wrap wraps the specified SystemCommand, returning a Command

--- a/cmd/envcmd/systemcommand_test.go
+++ b/cmd/envcmd/systemcommand_test.go
@@ -25,7 +25,8 @@ var _ = gc.Suite(&SystemCommandSuite{})
 func (s *SystemCommandSuite) TestSystemCommandInitMultipleConfigs(c *gc.C) {
 	// The environments.yaml file is ignored for system commands.
 	testing.WriteEnvironments(c, testing.MultipleEnvConfig)
-	testEnsureSystemName(c, "")
+	_, err := initTestSystemCommand(c)
+	c.Assert(err, gc.ErrorMatches, "no system specified")
 }
 
 func (s *SystemCommandSuite) TestSystemCommandInitNoEnvFile(c *gc.C) {
@@ -33,8 +34,8 @@ func (s *SystemCommandSuite) TestSystemCommandInitNoEnvFile(c *gc.C) {
 	// there.
 	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
-	c.Assert(err, jc.ErrorIsNil)
-	testEnsureSystemName(c, "")
+	_, err = initTestSystemCommand(c)
+	c.Assert(err, gc.ErrorMatches, "no system specified")
 }
 
 func (s *SystemCommandSuite) TestSystemCommandInitSystemFile(c *gc.C) {

--- a/cmd/envcmd/systemcommand_test.go
+++ b/cmd/envcmd/systemcommand_test.go
@@ -22,12 +22,6 @@ type SystemCommandSuite struct {
 
 var _ = gc.Suite(&SystemCommandSuite{})
 
-func (s *SystemCommandSuite) TestSystemCommandInitExplicit(c *gc.C) {
-	// Take system name from command line arg.
-	testEnsureSystemName(c, "explicit", "-s", "explicit")
-	testEnsureSystemName(c, "explicit", "--system", "explicit")
-}
-
 func (s *SystemCommandSuite) TestSystemCommandInitMultipleConfigs(c *gc.C) {
 	// The environments.yaml file is ignored for system commands.
 	testing.WriteEnvironments(c, testing.MultipleEnvConfig)
@@ -54,6 +48,15 @@ func (s *SystemCommandSuite) TestSystemCommandInitEnvFile(c *gc.C) {
 	err := envcmd.WriteCurrentEnvironment("fubar")
 	c.Assert(err, jc.ErrorIsNil)
 	testEnsureSystemName(c, "fubar")
+}
+
+func (s *SystemCommandSuite) TestSystemCommandInitExplicit(c *gc.C) {
+	// Take system name from command line arg, and it trumps the current-
+	// system file.
+	err := envcmd.WriteCurrentSystem("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	testEnsureSystemName(c, "explicit", "-s", "explicit")
+	testEnsureSystemName(c, "explicit", "--system", "explicit")
 }
 
 type testSystemCommand struct {

--- a/cmd/envcmd/systemcommand_test.go
+++ b/cmd/envcmd/systemcommand_test.go
@@ -1,0 +1,81 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package envcmd_test
+
+import (
+	"os"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/testing"
+)
+
+type SystemCommandSuite struct {
+	testing.FakeJujuHomeSuite
+}
+
+var _ = gc.Suite(&SystemCommandSuite{})
+
+func (s *SystemCommandSuite) TestSystemCommandInitExplicit(c *gc.C) {
+	// Take system name from command line arg.
+	testEnsureSystemName(c, "explicit", "-s", "explicit")
+	testEnsureSystemName(c, "explicit", "--system", "explicit")
+}
+
+func (s *SystemCommandSuite) TestSystemCommandInitMultipleConfigs(c *gc.C) {
+	// The environments.yaml file is ignored for system commands.
+	testing.WriteEnvironments(c, testing.MultipleEnvConfig)
+	testEnsureSystemName(c, "")
+}
+
+func (s *SystemCommandSuite) TestSystemCommandInitNoEnvFile(c *gc.C) {
+	// Since we ignore the environments.yaml file, we don't care if it isn't
+	// there.
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
+	err := os.Remove(envPath)
+	c.Assert(err, jc.ErrorIsNil)
+	testEnsureSystemName(c, "")
+}
+
+func (s *SystemCommandSuite) TestSystemCommandInitSystemFile(c *gc.C) {
+	// If there is a current-system file, use that.
+	err := envcmd.WriteCurrentSystem("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	testEnsureSystemName(c, "fubar")
+}
+func (s *SystemCommandSuite) TestSystemCommandInitEnvFile(c *gc.C) {
+	// If there is a current-environment file, use that.
+	err := envcmd.WriteCurrentEnvironment("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	testEnsureSystemName(c, "fubar")
+}
+
+type testSystemCommand struct {
+	envcmd.SysCommandBase
+}
+
+func (c *testSystemCommand) Info() *cmd.Info {
+	panic("should not be called")
+}
+
+func (c *testSystemCommand) Run(ctx *cmd.Context) error {
+	panic("should not be called")
+}
+
+func initTestSystemCommand(c *gc.C, args ...string) (*testSystemCommand, error) {
+	cmd := new(testSystemCommand)
+	wrapped := envcmd.WrapSystem(cmd)
+	return cmd, cmdtesting.InitCommand(wrapped, args)
+}
+
+func testEnsureSystemName(c *gc.C, expect string, args ...string) {
+	cmd, err := initTestSystemCommand(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.SystemName(), gc.Equals, expect)
+}

--- a/cmd/juju/environment/jenv_test.go
+++ b/cmd/juju/environment/jenv_test.go
@@ -230,7 +230,9 @@ func (*jenvSuite) TestSuccess(c *gc.C) {
 
 	// The default environment is now the newly imported one, and the output
 	// reflects the change.
-	c.Assert(envcmd.ReadCurrentEnvironment(), gc.Equals, "testing")
+	currEnv, err := envcmd.ReadCurrentEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(currEnv, gc.Equals, "testing")
 	c.Assert(testing.Stdout(ctx), gc.Equals, "erewhemos -> testing\n")
 
 	// Trying to import the jenv with the same name a second time raises an
@@ -244,7 +246,10 @@ func (*jenvSuite) TestSuccess(c *gc.C) {
 	ctx, err = testing.RunCommand(c, jenvCmd, f.Name(), "another")
 	c.Assert(err, jc.ErrorIsNil)
 	assertJenvContents(c, contents, "another")
-	c.Assert(envcmd.ReadCurrentEnvironment(), gc.Equals, "another")
+
+	currEnv, err = envcmd.ReadCurrentEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(currEnv, gc.Equals, "another")
 	c.Assert(testing.Stdout(ctx), gc.Equals, "testing -> another\n")
 }
 
@@ -264,7 +269,9 @@ func (*jenvSuite) TestSuccessCustomEnvironmentName(c *gc.C) {
 
 	// The default environment is now the newly imported one, and the output
 	// reflects the change.
-	c.Assert(envcmd.ReadCurrentEnvironment(), gc.Equals, "my-env")
+	currEnv, err := envcmd.ReadCurrentEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(currEnv, gc.Equals, "my-env")
 	c.Assert(testing.Stdout(ctx), gc.Equals, "erewhemos -> my-env\n")
 }
 

--- a/cmd/juju/switch.go
+++ b/cmd/juju/switch.go
@@ -24,7 +24,7 @@ type SwitchCommand struct {
 }
 
 var switchDoc = `
-Show or change the default juju environment name.
+Show or change the default juju environment or system name.
 
 If no command line parameters are passed, switch will output the current
 environment as defined by the file $JUJU_HOME/current-environment.
@@ -40,7 +40,7 @@ func (c *SwitchCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "switch",
 		Args:    "[environment name]",
-		Purpose: "show or change the default juju environment name",
+		Purpose: "show or change the default juju environment or system name",
 		Doc:     switchDoc,
 		Aliases: []string{"env"},
 	}

--- a/cmd/juju/switch.go
+++ b/cmd/juju/switch.go
@@ -117,9 +117,15 @@ func (c *SwitchCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	currentEnv := envcmd.ReadCurrentEnvironment()
+	currentEnv, err := envcmd.ReadCurrentEnvironment()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if currentEnv == "" {
-		currentEnv = envcmd.ReadCurrentSystem()
+		currentEnv, err = envcmd.ReadCurrentSystem()
+		if err != nil {
+			return errors.Trace(err)
+		}
 		if currentEnv == "" {
 			currentEnv = environments.Default
 		} else {

--- a/cmd/juju/switch_test.go
+++ b/cmd/juju/switch_test.go
@@ -44,7 +44,7 @@ func (*SwitchSimpleSuite) TestShowsDefault(c *gc.C) {
 	c.Assert(testing.Stdout(context), gc.Equals, "erewhemos\n")
 }
 
-func (s *SwitchSimpleSuite) TestCurrentEnvironmentHasPrecidence(c *gc.C) {
+func (s *SwitchSimpleSuite) TestCurrentEnvironmentHasPrecedence(c *gc.C) {
 	testing.WriteEnvironments(c, testing.MultipleEnvConfig)
 	envcmd.WriteCurrentEnvironment("fubar")
 	context, err := testing.RunCommand(c, &SwitchCommand{})
@@ -52,7 +52,7 @@ func (s *SwitchSimpleSuite) TestCurrentEnvironmentHasPrecidence(c *gc.C) {
 	c.Assert(testing.Stdout(context), gc.Equals, "fubar\n")
 }
 
-func (s *SwitchSimpleSuite) TestCurrentSystemHasPrecidence(c *gc.C) {
+func (s *SwitchSimpleSuite) TestCurrentSystemHasPrecedence(c *gc.C) {
 	testing.WriteEnvironments(c, testing.MultipleEnvConfig)
 	envcmd.WriteCurrentSystem("fubar")
 	context, err := testing.RunCommand(c, &SwitchCommand{})

--- a/cmd/juju/switch_test.go
+++ b/cmd/juju/switch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/feature"
 	_ "github.com/juju/juju/juju"
 	"github.com/juju/juju/testing"
 )
@@ -45,10 +46,18 @@ func (*SwitchSimpleSuite) TestShowsDefault(c *gc.C) {
 
 func (s *SwitchSimpleSuite) TestCurrentEnvironmentHasPrecidence(c *gc.C) {
 	testing.WriteEnvironments(c, testing.MultipleEnvConfig)
-	s.FakeHomeSuite.Home.AddFiles(c, gitjujutesting.TestFile{".juju/current-environment", "fubar"})
+	envcmd.WriteCurrentEnvironment("fubar")
 	context, err := testing.RunCommand(c, &SwitchCommand{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, "fubar\n")
+}
+
+func (s *SwitchSimpleSuite) TestCurrentSystemHasPrecidence(c *gc.C) {
+	testing.WriteEnvironments(c, testing.MultipleEnvConfig)
+	envcmd.WriteCurrentSystem("fubar")
+	context, err := testing.RunCommand(c, &SwitchCommand{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "fubar (system)\n")
 }
 
 func (*SwitchSimpleSuite) TestShowsJujuEnv(c *gc.C) {
@@ -74,6 +83,26 @@ func (*SwitchSimpleSuite) TestSettingWritesFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, "erewhemos -> erewhemos-2\n")
 	c.Assert(envcmd.ReadCurrentEnvironment(), gc.Equals, "erewhemos-2")
+}
+
+func (s *SwitchSimpleSuite) TestSettingWritesSystemFile(c *gc.C) {
+	// First set up a system in the config store.
+	s.SetFeatureFlags(feature.JES)
+	store, err := configstore.Default()
+	c.Assert(err, jc.ErrorIsNil)
+	info := store.CreateInfo("a-system")
+	info.SetAPIEndpoint(configstore.APIEndpoint{
+		Addresses:  []string{"localhost"},
+		CACert:     testing.CACert,
+		ServerUUID: "server-uuid",
+	})
+	err = info.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+	context, err := testing.RunCommand(c, &SwitchCommand{}, "a-system")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "erewhemos -> a-system\n")
+	c.Assert(envcmd.ReadCurrentSystem(), gc.Equals, "a-system")
 }
 
 func (*SwitchSimpleSuite) TestSettingToUnknown(c *gc.C) {

--- a/cmd/juju/switch_test.go
+++ b/cmd/juju/switch_test.go
@@ -82,7 +82,9 @@ func (*SwitchSimpleSuite) TestSettingWritesFile(c *gc.C) {
 	context, err := testing.RunCommand(c, &SwitchCommand{}, "erewhemos-2")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, "erewhemos -> erewhemos-2\n")
-	c.Assert(envcmd.ReadCurrentEnvironment(), gc.Equals, "erewhemos-2")
+	currentEnv, err := envcmd.ReadCurrentEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(currentEnv, gc.Equals, "erewhemos-2")
 }
 
 func (s *SwitchSimpleSuite) addTestSystem(c *gc.C) {
@@ -105,7 +107,9 @@ func (s *SwitchSimpleSuite) TestSettingWritesSystemFile(c *gc.C) {
 	context, err := testing.RunCommand(c, &SwitchCommand{}, "a-system")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, "erewhemos -> a-system (system)\n")
-	c.Assert(envcmd.ReadCurrentSystem(), gc.Equals, "a-system")
+	currSystem, err := envcmd.ReadCurrentSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(currSystem, gc.Equals, "a-system")
 }
 
 func (s *SwitchSimpleSuite) TestListWithSystem(c *gc.C) {

--- a/cmd/juju/system/environments.go
+++ b/cmd/juju/system/environments.go
@@ -14,15 +14,15 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
-	"github.com/juju/juju/cmd/syscmd"
 	"github.com/juju/juju/environs/configstore"
 )
 
 // EnvironmentsCommand returns the list of all the environments the
 // current user can access on the current system.
 type EnvironmentsCommand struct {
-	syscmd.SysCommandBase
+	envcmd.SysCommandBase
 	out       cmd.Output
 	user      string
 	listUUID  bool

--- a/cmd/juju/system/environments_test.go
+++ b/cmd/juju/system/environments_test.go
@@ -48,6 +48,9 @@ func (f *fakeEnvMgrAPIClient) ListEnvironments(user string) ([]params.UserEnviro
 func (s *EnvironmentsSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 
+	err := envcmd.WriteCurrentSystem("fake")
+	c.Assert(err, jc.ErrorIsNil)
+
 	last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
 	last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
 

--- a/cmd/juju/system/environments_test.go
+++ b/cmd/juju/system/environments_test.go
@@ -80,7 +80,7 @@ func (s *EnvironmentsSuite) SetUpTest(c *gc.C) {
 
 func (s *EnvironmentsSuite) newCommand() cmd.Command {
 	command := system.NewEnvironmentsCommand(s.api, s.creds)
-	return envcmd.Wrap(command)
+	return envcmd.WrapSystem(command)
 }
 
 func (s *EnvironmentsSuite) checkSuccess(c *gc.C, user string, args ...string) {

--- a/cmd/juju/system/environments_test.go
+++ b/cmd/juju/system/environments_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/system"
-	"github.com/juju/juju/cmd/syscmd"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/testing"
 )
@@ -80,7 +80,7 @@ func (s *EnvironmentsSuite) SetUpTest(c *gc.C) {
 
 func (s *EnvironmentsSuite) newCommand() cmd.Command {
 	command := system.NewEnvironmentsCommand(s.api, s.creds)
-	return syscmd.Wrap(command)
+	return envcmd.Wrap(command)
 }
 
 func (s *EnvironmentsSuite) checkSuccess(c *gc.C, user string, args ...string) {

--- a/cmd/juju/system/list.go
+++ b/cmd/juju/system/list.go
@@ -5,6 +5,7 @@ package system
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -50,6 +51,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "failed to list systems in config store")
 	}
 
+	sort.Strings(list)
 	for _, name := range list {
 		fmt.Fprintf(ctx.Stdout, "%s\n", name)
 	}

--- a/cmd/juju/system/system.go
+++ b/cmd/juju/system/system.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju/cmd/syscmd"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.system")
@@ -27,7 +27,7 @@ func NewSuperCommand() cmd.Command {
 	})
 
 	systemCmd.Register(&ListCommand{})
-	systemCmd.Register(syscmd.Wrap(&EnvironmentsCommand{}))
+	systemCmd.Register(envcmd.WrapSystem(&EnvironmentsCommand{}))
 
 	return systemCmd
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1072,7 +1072,7 @@ func (a *MachineAgent) startEnvWorkers(
 		return provisioner.NewEnvironProvisioner(apiSt.Provisioner(), agentConfig), nil
 	})
 	singularRunner.StartWorker("environ-storageprovisioner", func() (worker.Worker, error) {
-		scope := agentConfig.Environment()
+		scope := st.EnvironTag()
 		api := apiSt.StorageProvisioner(scope)
 		return newStorageWorker(scope, "", api, api, api, api), nil
 	})

--- a/environs/configstore/mem.go
+++ b/environs/configstore/mem.go
@@ -61,8 +61,11 @@ func (m *memStore) List() ([]string, error) {
 	var envs []string
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for name := range m.envs {
-		envs = append(envs, name)
+	for name, env := range m.envs {
+		api := env.APIEndpoint()
+		if api.ServerUUID == "" || api.EnvironUUID != "" {
+			envs = append(envs, name)
+		}
 	}
 	return envs, nil
 }
@@ -74,7 +77,9 @@ func (m *memStore) ListSystems() ([]string, error) {
 	defer m.mu.Unlock()
 	for name, env := range m.envs {
 		api := env.APIEndpoint()
-		if api.ServerUUID == "" || api.ServerUUID == api.EnvironUUID {
+		if api.ServerUUID == "" ||
+			api.ServerUUID == api.EnvironUUID ||
+			api.EnvironUUID == "" {
 			servers = append(servers, name)
 		}
 	}

--- a/featuretests/cmd_juju_system_test.go
+++ b/featuretests/cmd_juju_system_test.go
@@ -48,7 +48,8 @@ func (s *cmdSystemSuite) TestSystemListCommand(c *gc.C) {
 
 func (s *cmdSystemSuite) TestSystemEnvironmentsCommand(c *gc.C) {
 	s.createEnv(c, "new-env", false)
-	context, err := testing.RunCommand(c, envcmd.Wrap(&system.EnvironmentsCommand{}))
+	envcmd.WriteCurrentSystem("dummyenv")
+	context, err := testing.RunCommand(c, envcmd.WrapSystem(&system.EnvironmentsCommand{}))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
 		"NAME      OWNER                   LAST CONNECTION\n"+

--- a/featuretests/cmd_juju_system_test.go
+++ b/featuretests/cmd_juju_system_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/environmentmanager"
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/system"
-	"github.com/juju/juju/cmd/syscmd"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -48,7 +48,7 @@ func (s *cmdSystemSuite) TestSystemListCommand(c *gc.C) {
 
 func (s *cmdSystemSuite) TestSystemEnvironmentsCommand(c *gc.C) {
 	s.createEnv(c, "new-env", false)
-	context, err := testing.RunCommand(c, syscmd.Wrap(&system.EnvironmentsCommand{}))
+	context, err := testing.RunCommand(c, envcmd.Wrap(&system.EnvironmentsCommand{}))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
 		"NAME      OWNER                   LAST CONNECTION\n"+


### PR DESCRIPTION
This branch introduces the concept of a current-system.  This file is only going to be written to by juju switch, and juju login.  Other commands will always write the current environment file.

This allows juju to be operating on a system and not necessarily and environment.

Some manual testing is needed to be confident before a full review.

(Review request: http://reviews.vapour.ws/r/1735/)