### PR TITLE
storage: handle ReadOnly storage

### DIFF
--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -120,6 +120,7 @@ func FilesystemAttachmentToState(in params.FilesystemAttachment) (names.MachineT
 	}
 	info := state.FilesystemAttachmentInfo{
 		in.MountPoint,
+		in.ReadOnly,
 	}
 	return machineTag, filesystemTag, info, nil
 }
@@ -134,6 +135,7 @@ func FilesystemAttachmentFromState(v state.FilesystemAttachment) (params.Filesys
 		v.Filesystem().String(),
 		v.Machine().String(),
 		info.MountPoint,
+		info.ReadOnly,
 	}, nil
 }
 

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -182,7 +182,7 @@ type VolumeAttachment struct {
 	VolumeTag  string `json:"volumetag"`
 	MachineTag string `json:"machinetag"`
 	DeviceName string `json:"devicename,omitempty"`
-	ReadOnly   bool   `json:"readonly"`
+	ReadOnly   bool   `json:"readonly,omitempty"`
 }
 
 // VolumeAttachments describes a set of storage volume attachments.
@@ -206,6 +206,7 @@ type VolumeAttachmentParams struct {
 	MachineTag string `json:"machinetag"`
 	InstanceId string `json:"instanceid,omitempty"`
 	Provider   string `json:"provider"`
+	ReadOnly   bool   `json:"readonly,omitempty"`
 }
 
 // VolumeAttachmentsResult holds the volume attachments for a single
@@ -287,6 +288,7 @@ type FilesystemAttachment struct {
 	FilesystemTag string `json:"filesystemtag"`
 	MachineTag    string `json:"machinetag"`
 	MountPoint    string `json:"mountpoint,omitempty"`
+	ReadOnly      bool   `json:"readonly,omitempty"`
 }
 
 // FilesystemAttachments describes a set of storage filesystem attachments.
@@ -312,6 +314,7 @@ type FilesystemAttachmentParams struct {
 	InstanceId    string `json:"instanceid,omitempty"`
 	Provider      string `json:"provider"`
 	MountPoint    string `json:"mountpoint,omitempty"`
+	ReadOnly      bool   `json:"readonly,omitempty"`
 }
 
 // FilesystemAttachmentResult holds the details of a single filesystem attachment,

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -182,7 +182,7 @@ type VolumeAttachment struct {
 	VolumeTag  string `json:"volumetag"`
 	MachineTag string `json:"machinetag"`
 	DeviceName string `json:"devicename,omitempty"`
-	ReadOnly   bool   `json:"readonly,omitempty"`
+	ReadOnly   bool   `json:"read-only,omitempty"`
 }
 
 // VolumeAttachments describes a set of storage volume attachments.
@@ -206,7 +206,7 @@ type VolumeAttachmentParams struct {
 	MachineTag string `json:"machinetag"`
 	InstanceId string `json:"instanceid,omitempty"`
 	Provider   string `json:"provider"`
-	ReadOnly   bool   `json:"readonly,omitempty"`
+	ReadOnly   bool   `json:"read-only,omitempty"`
 }
 
 // VolumeAttachmentsResult holds the volume attachments for a single
@@ -288,7 +288,7 @@ type FilesystemAttachment struct {
 	FilesystemTag string `json:"filesystemtag"`
 	MachineTag    string `json:"machinetag"`
 	MountPoint    string `json:"mountpoint,omitempty"`
-	ReadOnly      bool   `json:"readonly,omitempty"`
+	ReadOnly      bool   `json:"read-only,omitempty"`
 }
 
 // FilesystemAttachments describes a set of storage filesystem attachments.
@@ -314,7 +314,7 @@ type FilesystemAttachmentParams struct {
 	InstanceId    string `json:"instanceid,omitempty"`
 	Provider      string `json:"provider"`
 	MountPoint    string `json:"mountpoint,omitempty"`
-	ReadOnly      bool   `json:"readonly,omitempty"`
+	ReadOnly      bool   `json:"read-only,omitempty"`
 }
 
 // FilesystemAttachmentResult holds the details of a single filesystem attachment,

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -557,12 +557,19 @@ func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]params.VolumeP
 			// Leave dynamic storage to the storage provisioner.
 			continue
 		}
+		volumeAttachmentParams, ok := volumeAttachment.Params()
+		if !ok {
+			// Attachment is already provisioned; this is an insane
+			// state, so we should not proceed with the volume.
+			continue
+		}
 		// Not provisioned yet, so ask the cloud provisioner do it.
 		volumeParams.Attachment = &params.VolumeAttachmentParams{
 			volumeTag.String(),
 			m.Tag().String(),
 			"", // we're creating the machine, so it has no instance ID.
 			volumeParams.Provider,
+			volumeAttachmentParams.ReadOnly,
 		}
 		allVolumeParams = append(allVolumeParams, volumeParams)
 	}

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -561,7 +561,10 @@ func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]params.VolumeP
 		if !ok {
 			// Attachment is already provisioned; this is an insane
 			// state, so we should not proceed with the volume.
-			continue
+			return nil, errors.Errorf(
+				"volume %s already attached to machine %s",
+				volumeTag.Id(), m.Id(),
+			)
 		}
 		// Not provisioned yet, so ask the cloud provisioner do it.
 		volumeParams.Attachment = &params.VolumeAttachmentParams{

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -57,7 +57,7 @@ type VolumeInfo struct {
 	DeviceName string `yaml:"device,omitempty" json:"device,omitempty"`
 
 	// from params.VolumeAttachments
-	ReadOnly bool `yaml:"readonly" json:"readonly"`
+	ReadOnly bool `yaml:"read-only" json:"read-only"`
 
 	// from params.Volume. This is juju volume id.
 	Volume string `yaml:"volume,omitempty" json:"volume,omitempty"`

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -140,6 +140,7 @@ type FilesystemAttachmentInfo struct {
 	// machine. MountPoint may be empty, meaning that the filesystem is
 	// not mounted yet.
 	MountPoint string `bson:"mountpoint"`
+	ReadOnly   bool   `bson:"read-only"`
 }
 
 // FilesystemAttachmentParams records parameters for attaching a filesystem to a

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -37,4 +37,7 @@ type FilesystemAttachment struct {
 	// Path is the path at which the filesystem is mounted on the machine that
 	// this attachment corresponds to.
 	Path string
+
+	// ReadOnly indicates that the filesystem is mounted read-only.
+	ReadOnly bool
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -203,6 +203,9 @@ type AttachmentParams struct {
 	// that interact with the instances, such as EBS/EC2. The InstanceId
 	// field will be empty if the instance is not yet provisioned.
 	InstanceId instance.Id
+
+	// ReadOnly indicates that the storage should be attached as read-only.
+	ReadOnly bool
 }
 
 // FilesystemParams is a fully specified set of parameters for filesystem creation,

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -61,10 +61,11 @@ func (lp *loopProvider) VolumeSource(
 	}
 	// storageDir is validated by validateFullConfig.
 	storageDir, _ := sourceConfig.ValueString(storage.ConfigStorageDir)
-	if err := os.MkdirAll(storageDir, 0755); err != nil {
-		return nil, errors.Annotate(err, "creating storage directory")
-	}
-	return &loopVolumeSource{lp.run, storageDir}, nil
+	return &loopVolumeSource{
+		&osDirFuncs{lp.run},
+		lp.run,
+		storageDir,
+	}, nil
 }
 
 // FilesystemSource is defined on the Provider interface.
@@ -93,6 +94,7 @@ func (*loopProvider) Dynamic() bool {
 // loopVolumeSource provides common functionality to handle
 // loop devices for rootfs and host loop volume sources.
 type loopVolumeSource struct {
+	dirFuncs   dirFuncs
 	run        runCommandFunc
 	storageDir string
 }
@@ -115,6 +117,9 @@ func (lvs *loopVolumeSource) CreateVolumes(args []storage.VolumeParams) ([]stora
 func (lvs *loopVolumeSource) createVolume(params storage.VolumeParams) (storage.Volume, error) {
 	volumeId := params.Tag.String()
 	loopFilePath := lvs.volumeFilePath(volumeId)
+	if err := ensureDir(lvs.dirFuncs, filepath.Dir(loopFilePath)); err != nil {
+		return storage.Volume{}, errors.Trace(err)
+	}
 	if err := createBlockFile(lvs.run, loopFilePath, params.Size); err != nil {
 		return storage.Volume{}, errors.Annotate(err, "could not create block file")
 	}
@@ -192,7 +197,7 @@ func (lvs *loopVolumeSource) AttachVolumes(args []storage.VolumeAttachmentParams
 
 func (lvs *loopVolumeSource) attachVolume(arg storage.VolumeAttachmentParams) (storage.VolumeAttachment, error) {
 	loopFilePath := lvs.volumeFilePath(arg.VolumeId)
-	deviceName, err := attachLoopDevice(lvs.run, loopFilePath)
+	deviceName, err := attachLoopDevice(lvs.run, loopFilePath, arg.ReadOnly)
 	if err != nil {
 		os.Remove(loopFilePath)
 		return storage.VolumeAttachment{}, errors.Annotate(err, "attaching loop device")
@@ -201,6 +206,7 @@ func (lvs *loopVolumeSource) attachVolume(arg storage.VolumeAttachmentParams) (s
 		Volume:     arg.Volume,
 		Machine:    arg.Machine,
 		DeviceName: deviceName,
+		ReadOnly:   arg.ReadOnly,
 	}, nil
 }
 
@@ -224,10 +230,16 @@ func createBlockFile(run runCommandFunc, filePath string, sizeInMiB uint64) erro
 // attachLoopDevice attaches a loop device to the file with the
 // specified path, and returns the loop device's name (e.g. "loop0").
 // losetup will create additional loop devices as necessary.
-func attachLoopDevice(run runCommandFunc, filePath string) (loopDeviceName string, _ error) {
+func attachLoopDevice(run runCommandFunc, filePath string, readOnly bool) (loopDeviceName string, _ error) {
 	// -f automatically finds the first available loop-device.
+	// -r sets up a read-only loop-device.
 	// --show returns the loop device chosen on stdout.
-	stdout, err := run("losetup", "-f", "--show", filePath)
+	args := []string{"-f", "--show"}
+	if readOnly {
+		args = append(args, "-r")
+	}
+	args = append(args, filePath)
+	stdout, err := run("losetup", args...)
 	if err != nil {
 		return "", errors.Annotatef(err, "attaching loop device to %q", filePath)
 	}

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -77,7 +77,7 @@ func (s *loopSuite) TestScope(c *gc.C) {
 	c.Assert(p.Scope(), gc.Equals, storage.ScopeMachine)
 }
 
-func (s *loopSuite) loopVolumeSource(c *gc.C) storage.VolumeSource {
+func (s *loopSuite) loopVolumeSource(c *gc.C) (storage.VolumeSource, *provider.MockDirFuncs) {
 	s.commands = &mockRunCommand{c: c}
 	return provider.LoopVolumeSource(
 		s.storageDir,
@@ -86,7 +86,7 @@ func (s *loopSuite) loopVolumeSource(c *gc.C) storage.VolumeSource {
 }
 
 func (s *loopSuite) TestCreateVolumes(c *gc.C) {
-	source := s.loopVolumeSource(c)
+	source, _ := s.loopVolumeSource(c)
 	s.commands.expect("fallocate", "-l", "2MiB", filepath.Join(s.storageDir, "volume-0"))
 
 	volumes, volumeAttachments, err := source.CreateVolumes([]storage.VolumeParams{{
@@ -111,7 +111,7 @@ func (s *loopSuite) TestCreateVolumes(c *gc.C) {
 }
 
 func (s *loopSuite) TestCreateVolumesNoAttachment(c *gc.C) {
-	source := s.loopVolumeSource(c)
+	source, _ := s.loopVolumeSource(c)
 	s.commands.expect("fallocate", "-l", "2MiB", filepath.Join(s.storageDir, "volume-0"))
 	_, _, err := source.CreateVolumes([]storage.VolumeParams{{
 		Tag:  names.NewVolumeTag("0"),
@@ -122,7 +122,7 @@ func (s *loopSuite) TestCreateVolumesNoAttachment(c *gc.C) {
 }
 
 func (s *loopSuite) TestDestroyVolumes(c *gc.C) {
-	source := s.loopVolumeSource(c)
+	source, _ := s.loopVolumeSource(c)
 	fileName := filepath.Join(s.storageDir, "volume-0")
 	cmd := s.commands.expect("losetup", "-j", fileName)
 	cmd.respond("/dev/loop0: foo\n/dev/loop1: bar", nil)
@@ -138,7 +138,7 @@ func (s *loopSuite) TestDestroyVolumes(c *gc.C) {
 }
 
 func (s *loopSuite) TestDestroyVolumesDetachFails(c *gc.C) {
-	source := s.loopVolumeSource(c)
+	source, _ := s.loopVolumeSource(c)
 	fileName := filepath.Join(s.storageDir, "volume-0")
 	cmd := s.commands.expect("losetup", "-j", fileName)
 	cmd.respond("/dev/loop0: foo\n/dev/loop1: bar", nil)
@@ -151,41 +151,56 @@ func (s *loopSuite) TestDestroyVolumesDetachFails(c *gc.C) {
 }
 
 func (s *loopSuite) TestDestroyVolumesInvalidVolumeId(c *gc.C) {
-	source := s.loopVolumeSource(c)
+	source, _ := s.loopVolumeSource(c)
 	errs := source.DestroyVolumes([]string{"../super/important/stuff"})
 	c.Assert(errs, gc.HasLen, 1)
 	c.Assert(errs[0], gc.ErrorMatches, `.* invalid loop volume ID "\.\./super/important/stuff"`)
 }
 
 func (s *loopSuite) TestDescribeVolumes(c *gc.C) {
-	source := s.loopVolumeSource(c)
+	source, _ := s.loopVolumeSource(c)
 	_, err := source.DescribeVolumes([]string{"a", "b"})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
 func (s *loopSuite) TestAttachVolumes(c *gc.C) {
-	source := s.loopVolumeSource(c)
-	cmd := s.commands.expect("losetup", "-f", "--show", filepath.Join(s.storageDir, "vol-ume"))
-	cmd.respond("/dev/loop99", nil) // first available loop device
+	source, _ := s.loopVolumeSource(c)
+	cmd := s.commands.expect("losetup", "-f", "--show", filepath.Join(s.storageDir, "vol-ume0"))
+	cmd.respond("/dev/loop98", nil) // first available loop device
+	cmd = s.commands.expect("losetup", "-f", "--show", "-r", filepath.Join(s.storageDir, "vol-ume1"))
+	cmd.respond("/dev/loop99", nil)
 
 	volumeAttachments, err := source.AttachVolumes([]storage.VolumeAttachmentParams{{
 		Volume:   names.NewVolumeTag("0"),
-		VolumeId: "vol-ume",
+		VolumeId: "vol-ume0",
 		AttachmentParams: storage.AttachmentParams{
 			Machine:    names.NewMachineTag("0"),
 			InstanceId: "inst-ance",
+		},
+	}, {
+		Volume:   names.NewVolumeTag("1"),
+		VolumeId: "vol-ume1",
+		AttachmentParams: storage.AttachmentParams{
+			Machine:    names.NewMachineTag("0"),
+			InstanceId: "inst-ance",
+			ReadOnly:   true,
 		},
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, jc.DeepEquals, []storage.VolumeAttachment{{
 		Volume:     names.NewVolumeTag("0"),
 		Machine:    names.NewMachineTag("0"),
+		DeviceName: "loop98",
+	}, {
+		Volume:     names.NewVolumeTag("1"),
+		Machine:    names.NewMachineTag("0"),
 		DeviceName: "loop99",
+		ReadOnly:   true,
 	}})
 }
 
 func (s *loopSuite) TestDetachVolumes(c *gc.C) {
-	source := s.loopVolumeSource(c)
+	source, _ := s.loopVolumeSource(c)
 	err := source.DetachVolumes(nil)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -124,13 +124,14 @@ func (s *managedFilesystemSource) attachFilesystem(arg storage.FilesystemAttachm
 		return storage.FilesystemAttachment{}, errors.Trace(err)
 	}
 	devicePath := s.devicePath(blockDevice)
-	if err := mountFilesystem(s.run, s.dirFuncs, devicePath, arg.Path); err != nil {
+	if err := mountFilesystem(s.run, s.dirFuncs, devicePath, arg.Path, arg.ReadOnly); err != nil {
 		return storage.FilesystemAttachment{}, errors.Trace(err)
 	}
 	return storage.FilesystemAttachment{
 		arg.Filesystem,
 		arg.Machine,
 		arg.Path,
+		arg.ReadOnly,
 	}, nil
 }
 
@@ -151,13 +152,18 @@ func createFilesystem(run runCommandFunc, devicePath string) error {
 	return nil
 }
 
-func mountFilesystem(run runCommandFunc, dirFuncs dirFuncs, devicePath, mountPoint string) error {
+func mountFilesystem(run runCommandFunc, dirFuncs dirFuncs, devicePath, mountPoint string, readOnly bool) error {
 	logger.Debugf("attempting to mount filesystem on %q at %q", devicePath, mountPoint)
 	if err := dirFuncs.mkDirAll(mountPoint, 0755); err != nil {
 		return errors.Annotate(err, "creating mount point")
 	}
 	// TODO(axw) check if the mount already exists, and do nothing if so.
-	_, err := run("mount", devicePath, mountPoint)
+	var args []string
+	if readOnly {
+		args = append(args, "-o", "ro")
+	}
+	args = append(args, devicePath, mountPoint)
+	_, err := run("mount", args...)
 	if err != nil {
 		return errors.Annotate(err, "mount failed")
 	}

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -96,8 +96,21 @@ func (s *managedfsSuite) TestCreateFilesystemsNoBlockDevice(c *gc.C) {
 }
 
 func (s *managedfsSuite) TestAttachFilesystems(c *gc.C) {
+	s.testAttachFilesystems(c, false)
+}
+
+func (s *managedfsSuite) TestAttachFilesystemsReadOnly(c *gc.C) {
+	s.testAttachFilesystems(c, true)
+}
+
+func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly bool) {
 	source := s.initSource(c)
-	s.commands.expect("mount", "/dev/sda", "/in/the/place")
+	var args []string
+	if readOnly {
+		args = append(args, "-o", "ro")
+	}
+	args = append(args, "/dev/sda", "/in/the/place")
+	s.commands.expect("mount", args...)
 
 	s.blockDevices[names.NewVolumeTag("0")] = storage.BlockDevice{
 		DeviceName: "sda",
@@ -115,6 +128,7 @@ func (s *managedfsSuite) TestAttachFilesystems(c *gc.C) {
 		AttachmentParams: storage.AttachmentParams{
 			Machine:    names.NewMachineTag("0"),
 			InstanceId: "inst-ance",
+			ReadOnly:   readOnly,
 		},
 		Path: "/in/the/place",
 	}})
@@ -123,6 +137,7 @@ func (s *managedfsSuite) TestAttachFilesystems(c *gc.C) {
 		Filesystem: names.NewFilesystemTag("0/0"),
 		Machine:    names.NewMachineTag("0"),
 		Path:       "/in/the/place",
+		ReadOnly:   readOnly,
 	}})
 }
 

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -60,7 +60,6 @@ func (p *rootfsProvider) FilesystemSource(environConfig *config.Config, sourceCo
 	}
 	// storageDir is validated by validateFullConfig.
 	storageDir, _ := sourceConfig.ValueString(storage.ConfigStorageDir)
-
 	return &rootfsFilesystemSource{
 		&osDirFuncs{p.run},
 		p.run,

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -520,7 +520,8 @@ func constructStartInstanceParams(
 			v.Attributes,
 			&storage.VolumeAttachmentParams{
 				AttachmentParams: storage.AttachmentParams{
-					Machine: machineTag,
+					Machine:  machineTag,
+					ReadOnly: v.Attachment.ReadOnly,
 				},
 				Volume: volumeTag,
 			},

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -578,6 +578,7 @@ func filesystemAttachmentsFromStorage(in []storage.FilesystemAttachment) []param
 			f.Filesystem.String(),
 			f.Machine.String(),
 			f.Path,
+			f.ReadOnly,
 		}
 	}
 	return out
@@ -616,6 +617,7 @@ func filesystemAttachmentFromParams(in params.FilesystemAttachment) (storage.Fil
 		filesystemTag,
 		machineTag,
 		in.MountPoint,
+		in.ReadOnly,
 	}, nil
 }
 
@@ -655,6 +657,7 @@ func filesystemAttachmentParamsFromParams(in params.FilesystemAttachmentParams) 
 			Provider:   storage.ProviderType(in.Provider),
 			Machine:    machineTag,
 			InstanceId: instance.Id(in.InstanceId),
+			ReadOnly:   in.ReadOnly,
 		},
 		Filesystem: filesystemTag,
 		Path:       in.MountPoint,

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -199,6 +199,7 @@ func (v *mockVolumeAccessor) VolumeParams(volumes []names.VolumeTag) ([]params.V
 				MachineTag: "machine-1",
 				InstanceId: string(v.provisionedMachines["machine-1"]),
 				Provider:   "dummy",
+				ReadOnly:   tag.String() == "volume-1",
 			}
 			result = append(result, params.VolumeParamsResult{Result: volumeParams})
 		}
@@ -331,6 +332,7 @@ func (f *mockFilesystemAccessor) FilesystemAttachmentParams(ids []params.Machine
 				FilesystemTag: id.AttachmentTag,
 				InstanceId:    string(instanceId),
 				Provider:      "dummy",
+				ReadOnly:      true,
 			}})
 		}
 	}
@@ -432,9 +434,6 @@ func (p *dummyProvider) Dynamic() bool {
 }
 
 func (*dummyVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
-	//if params.Tag.Id() == needsInstanceVolumeId {
-	//	return storage.ErrVolumeNeedsInstance
-	//}
 	return nil
 }
 
@@ -456,6 +455,7 @@ func (*dummyVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storag
 				Volume:     p.Tag,
 				Machine:    p.Attachment.Machine,
 				DeviceName: "/dev/sda" + p.Tag.Id(),
+				ReadOnly:   p.Attachment.ReadOnly,
 			})
 		}
 	}
@@ -563,6 +563,7 @@ func (s *mockManagedFilesystemSource) AttachFilesystems(args []storage.Filesyste
 			Filesystem: arg.Filesystem,
 			Machine:    arg.Machine,
 			Path:       "/mnt/" + blockDevice.DeviceName,
+			ReadOnly:   arg.ReadOnly,
 		})
 	}
 	return filesystemAttachments, nil

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -83,6 +83,7 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 		VolumeTag:  "volume-1",
 		MachineTag: "machine-1",
 		DeviceName: "/dev/sda1",
+		ReadOnly:   true,
 	}, {
 		VolumeTag:  "volume-2",
 		MachineTag: "machine-1",
@@ -101,7 +102,7 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 	volumeAttachmentInfoSet := make(chan interface{})
 	volumeAccessor.setVolumeAttachmentInfo = func(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
 		defer close(volumeAttachmentInfoSet)
-		c.Assert(volumeAttachments, gc.DeepEquals, expectedVolumeAttachments)
+		c.Assert(volumeAttachments, jc.SameContents, expectedVolumeAttachments)
 		return nil, nil
 	}
 	lifecycleManager := &mockLifecycleManager{}
@@ -510,6 +511,7 @@ func (s *storageProvisionerSuite) TestAttachVolumeBackedFilesystem(c *gc.C) {
 		FilesystemTag: "filesystem-0-0",
 		MachineTag:    "machine-0",
 		MountPoint:    "/mnt/xvdf1",
+		ReadOnly:      true,
 	}})
 }
 

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -617,6 +617,7 @@ func volumeParamsFromParams(in params.VolumeParams) (storage.VolumeParams, error
 				Provider:   providerType,
 				Machine:    machineTag,
 				InstanceId: instance.Id(in.Attachment.InstanceId),
+				ReadOnly:   in.Attachment.ReadOnly,
 			},
 			Volume: volumeTag,
 		}
@@ -644,6 +645,7 @@ func volumeAttachmentParamsFromParams(in params.VolumeAttachmentParams) (storage
 			Provider:   storage.ProviderType(in.Provider),
 			Machine:    machineTag,
 			InstanceId: instance.Id(in.InstanceId),
+			ReadOnly:   in.ReadOnly,
 		},
 		Volume: volumeTag,
 	}, nil


### PR DESCRIPTION
Pass the read-only attribute through to storage
providers when creating attachments, and update
providers to honour the attribute.

There are some unrelated fixes to the loop and
tmps providers related to creating storage dirs.

Live tested with:
 - filesystem backed by EBS on ec2
 - filesystem backed by loop on local
 - loop on local (without filesystem)
 - tmpfs on local

(Review request: http://reviews.vapour.ws/r/1736/)