### PR TITLE
Fix bug 1454697

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -103,6 +103,7 @@ var (
 	newCertificateUpdater    = certupdater.NewCertificateUpdater
 	reportOpenedState        = func(interface{}) {}
 	reportOpenedAPI          = func(interface{}) {}
+	reportClosedAPI          = func(interface{}) {}
 	getMetricAPI             = metricAPI
 )
 
@@ -270,6 +271,12 @@ func NewMachineAgent(
 	}
 }
 
+// APIStateUpgrader defines the methods on the Upgrader that
+// agents call.
+type APIStateUpgrader interface {
+	SetVersion(string, version.Binary) error
+}
+
 // MachineAgent is responsible for tying together all functionality
 // needed to orchestarte a Jujud instance which controls a machine.
 type MachineAgent struct {
@@ -288,6 +295,15 @@ type MachineAgent struct {
 
 	mongoInitMutex   sync.Mutex
 	mongoInitialized bool
+
+	apiStateUpgrader APIStateUpgrader
+}
+
+func (a *MachineAgent) getUpgrader(st *api.State) APIStateUpgrader {
+	if a.apiStateUpgrader != nil {
+		return a.apiStateUpgrader
+	}
+	return st.Upgrader()
 }
 
 // IsRestorePreparing returns bool representing if we are in restore mode
@@ -572,13 +588,20 @@ func (a *MachineAgent) stateStarter(stopch <-chan struct{}) error {
 
 // APIWorker returns a Worker that connects to the API and starts any
 // workers that need an API connection.
-func (a *MachineAgent) APIWorker() (worker.Worker, error) {
+func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 	agentConfig := a.CurrentConfig()
 	st, entity, err := OpenAPIState(agentConfig, a)
 	if err != nil {
 		return nil, err
 	}
 	reportOpenedAPI(st)
+
+	defer func() {
+		if err != nil {
+			st.Close()
+			reportClosedAPI(st)
+		}
+	}()
 
 	// Refresh the configuration, since it may have been updated after opening state.
 	agentConfig = a.CurrentConfig()
@@ -603,7 +626,8 @@ func (a *MachineAgent) APIWorker() (worker.Worker, error) {
 	// Before starting any workers, ensure we record the Juju version this machine
 	// agent is running.
 	currentTools := &coretools.Tools{Version: version.Current}
-	if err := st.Upgrader().SetVersion(agentConfig.Tag().String(), currentTools.Version); err != nil {
+	apiStateUpgrader := a.getUpgrader(st)
+	if err := apiStateUpgrader.SetVersion(agentConfig.Tag().String(), currentTools.Version); err != nil {
 		return nil, errors.Annotate(err, "cannot set machine agent version")
 	}
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -101,9 +102,9 @@ var (
 	newNetworker             = networker.NewNetworker
 	newFirewaller            = firewaller.NewFirewaller
 	newCertificateUpdater    = certupdater.NewCertificateUpdater
-	reportOpenedState        = func(interface{}) {}
-	reportOpenedAPI          = func(interface{}) {}
-	reportClosedAPI          = func(interface{}) {}
+	reportOpenedState        = func(io.Closer) {}
+	reportOpenedAPI          = func(io.Closer) {}
+	reportClosedAPI          = func(io.Closer) {}
 	getMetricAPI             = metricAPI
 )
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1469,6 +1469,7 @@ func (s *MachineSuite) TestMachineAgentAPIWorkerErrorClosesAPI(c *gc.C) {
 	s.AgentSuite.PatchValue(&reportClosedAPI, func(st io.Closer) {
 		select {
 		case closedAPI <- st:
+			close(closedAPI)
 		default:
 		}
 	})

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1458,6 +1458,28 @@ func (s *MachineSuite) TestMachineAgentRestoreRequiresPrepare(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "not in restore mode, cannot begin restoration")
 	c.Assert(a.IsRestoreRunning(), jc.IsFalse)
 }
+func (s *MachineSuite) TestMachineAgentAPIWorkerErrorClosesAPI(c *gc.C) {
+	// Start the machine agent.
+	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
+	a := s.newAgent(c, m)
+	a.apiStateUpgrader = &machineAgentUpgrader{}
+
+	closedAPI := false
+	s.AgentSuite.PatchValue(&reportClosedAPI, func(st interface{}) {
+		closedAPI = true
+	})
+
+	worker, err := a.APIWorker()
+	c.Assert(worker, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "cannot set machine agent version: test failure")
+	c.Assert(closedAPI, jc.IsTrue)
+}
+
+type machineAgentUpgrader struct{}
+
+func (m *machineAgentUpgrader) SetVersion(s string, v version.Binary) error {
+	return errors.New("test failure")
+}
 
 // MachineWithCharmsSuite provides infrastructure for tests which need to
 // work with charms.

--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"runtime"
 
 	"github.com/juju/cmd"
@@ -34,7 +35,7 @@ import (
 
 var (
 	agentLogger     = loggo.GetLogger("juju.jujud")
-	reportClosedAPI = func(interface{}) {}
+	reportClosedAPI = func(io.Closer) {}
 )
 
 // UnitAgent is a cmd.Command responsible for running a unit agent.

--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -17,6 +17,7 @@ import (
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/network"
@@ -31,18 +32,22 @@ import (
 	"github.com/juju/juju/worker/upgrader"
 )
 
-var agentLogger = loggo.GetLogger("juju.jujud")
+var (
+	agentLogger     = loggo.GetLogger("juju.jujud")
+	reportClosedAPI = func(interface{}) {}
+)
 
 // UnitAgent is a cmd.Command responsible for running a unit agent.
 type UnitAgent struct {
 	cmd.CommandBase
 	tomb tomb.Tomb
 	agentcmd.AgentConf
-	UnitName     string
-	runner       worker.Runner
-	setupLogging func(agent.Config) error
-	logToStdErr  bool
-	ctx          *cmd.Context
+	UnitName         string
+	runner           worker.Runner
+	setupLogging     func(agent.Config) error
+	logToStdErr      bool
+	ctx              *cmd.Context
+	apiStateUpgrader agentcmd.APIStateUpgrader
 }
 
 // NewUnitAgent creates a new UnitAgent value properly initialized.
@@ -50,6 +55,13 @@ func NewUnitAgent() *UnitAgent {
 	return &UnitAgent{
 		AgentConf: agentcmd.NewAgentConf(""),
 	}
+}
+
+func (a *UnitAgent) getUpgrader(st *api.State) agentcmd.APIStateUpgrader {
+	if a.apiStateUpgrader != nil {
+		return a.apiStateUpgrader
+	}
+	return st.Upgrader()
 }
 
 // Info returns usage information for the command.
@@ -123,7 +135,7 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 	return err
 }
 
-func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
+func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 	agentConfig := a.CurrentConfig()
 	dataDir := agentConfig.DataDir()
 	hookLock, err := cmdutil.HookExecutionLock(dataDir)
@@ -135,10 +147,18 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		return nil, err
 	}
 
+	defer func() {
+		if err != nil {
+			st.Close()
+			reportClosedAPI(st)
+		}
+	}()
+
 	// Before starting any workers, ensure we record the Juju version this unit
 	// agent is running.
 	currentTools := &tools.Tools{Version: version.Current}
-	if err := st.Upgrader().SetVersion(agentConfig.Tag().String(), currentTools.Version); err != nil {
+	apiStateUpgrader := a.getUpgrader(st)
+	if err := apiStateUpgrader.SetVersion(agentConfig.Tag().String(), currentTools.Version); err != nil {
 		return nil, errors.Annotate(err, "cannot set unit agent version")
 	}
 

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -396,6 +396,7 @@ func (s *UnitSuite) TestUnitAgentAPIWorkerErrorClosesAPI(c *gc.C) {
 	s.AgentSuite.PatchValue(&reportClosedAPI, func(st io.Closer) {
 		select {
 		case closedAPI <- st:
+			close(closedAPI)
 		default:
 		}
 	})

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -391,15 +392,25 @@ func (s *UnitSuite) TestUnitAgentAPIWorkerErrorClosesAPI(c *gc.C) {
 	a := s.newAgent(c, unit)
 	a.apiStateUpgrader = &unitAgentUpgrader{}
 
-	closedAPI := false
-	s.AgentSuite.PatchValue(&reportClosedAPI, func(st interface{}) {
-		closedAPI = true
+	closedAPI := make(chan io.Closer, 1)
+	s.AgentSuite.PatchValue(&reportClosedAPI, func(st io.Closer) {
+		select {
+		case closedAPI <- st:
+		default:
+		}
 	})
 
 	worker, err := a.APIWorkers()
+
+	select {
+	case closed := <-closedAPI:
+		c.Assert(closed, gc.NotNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("API not opened")
+	}
+
 	c.Assert(worker, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "cannot set unit agent version: test failure")
-	c.Assert(closedAPI, jc.IsTrue)
 }
 
 type unitAgentUpgrader struct{}

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -383,6 +384,28 @@ func (s *UnitSuite) TestUnitAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 		}
 	}
 	c.Fatalf("timeout while waiting for agent config to change")
+}
+
+func (s *UnitSuite) TestUnitAgentAPIWorkerErrorClosesAPI(c *gc.C) {
+	_, unit, _, _ := s.primeAgent(c)
+	a := s.newAgent(c, unit)
+	a.apiStateUpgrader = &unitAgentUpgrader{}
+
+	closedAPI := false
+	s.AgentSuite.PatchValue(&reportClosedAPI, func(st interface{}) {
+		closedAPI = true
+	})
+
+	worker, err := a.APIWorkers()
+	c.Assert(worker, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "cannot set unit agent version: test failure")
+	c.Assert(closedAPI, jc.IsTrue)
+}
+
+type unitAgentUpgrader struct{}
+
+func (u *unitAgentUpgrader) SetVersion(s string, v version.Binary) error {
+	return errors.New("test failure")
 }
 
 type runner interface {


### PR DESCRIPTION
Agents which use a close worker need to close the API they open
if their start functions fail.  This patch fixes the machine
and unit agents and mocks out the api state upgrader to simulate
the failure and test that the close occurs.

(Review request: http://reviews.vapour.ws/r/1740/)