### PR TITLE
CMD/JUJUD: Scope Env Storage Provisioner for Hosted environ

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1074,7 +1074,7 @@ func (a *MachineAgent) startEnvWorkers(
 		return provisioner.NewEnvironProvisioner(apiSt.Provisioner(), agentConfig), nil
 	})
 	singularRunner.StartWorker("environ-storageprovisioner", func() (worker.Worker, error) {
-		scope := agentConfig.Environment()
+		scope := st.EnvironTag()
 		api := apiSt.StorageProvisioner(scope)
 		return newStorageWorker(scope, "", api, api, api, api, api), nil
 	})


### PR DESCRIPTION
Storage volumes in hosted environments were unable to be watched,
because the scope of the storage worker was being set to that of the
state server instead of the hosted environment. This then lead to the
StorageProvisionerAPI ScopeAuthFunc denying the privilege to watch the
entity as the environTag passed in (erroneously state server) != the
hosted environTag.

Fix: Set scope to that of hosted environment in machine.go and add
test coverage.

(Review request: http://reviews.vapour.ws/r/1742/)