### PR TITLE
Only prune txns when it would have an impact

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-2
 github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-29T20:12:23Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-06T07:00:34Z
 github.com/juju/testing	git	e35bf4acb97c4e7acda329bd7430f14ee968346b	2015-03-31T10:29:16Z
-github.com/juju/txn	git	c3617a3230b576d680f3e09d48d0f9374d540ffb	2015-05-20T05:20:05Z
+github.com/juju/txn	git	36f674919880bcef33a754d0874e11cd4af8002a	2015-05-21T03:02:55Z
 github.com/juju/utils	git	732e0c300dc0f35c597e788a4366372065c27b7c	2015-03-30T21:32:30Z
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T00:00:00Z

--- a/state/txns.go
+++ b/state/txns.go
@@ -51,11 +51,12 @@ func (st *State) ResumeTransactions() error {
 	return st.txnRunner(session).ResumeTransactions()
 }
 
-// PruneTransactions removes data for completed transactions.
-func (st *State) PruneTransactions() error {
+// MaybePruneTransactions removes data for completed transactions.
+func (st *State) MaybePruneTransactions() error {
 	session := st.db.Session.Copy()
 	defer session.Close()
-	return st.txnRunner(session).PruneTransactions()
+	// Prune txns only when txn count has doubled since last prune.
+	return st.txnRunner(session).MaybePruneTransactions(2.0)
 }
 
 func newMultiEnvRunner(envUUID string, db *mgo.Database) jujutxn.Runner {
@@ -100,9 +101,9 @@ func (r *multiEnvRunner) ResumeTransactions() error {
 	return r.rawRunner.ResumeTransactions()
 }
 
-// PruneTransactions is part of the jujutxn.Runner interface.
-func (r *multiEnvRunner) PruneTransactions() error {
-	return r.rawRunner.PruneTransactions()
+// MaybePruneTransactions is part of the jujutxn.Runner interface.
+func (r *multiEnvRunner) MaybePruneTransactions(pruneFactor float32) error {
+	return r.rawRunner.MaybePruneTransactions(pruneFactor)
 }
 
 func (r *multiEnvRunner) updateOps(ops []txn.Op) {

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -326,15 +326,15 @@ func (s *MultiEnvRunnerSuite) TestResumeTransactionsWithError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
-func (s *MultiEnvRunnerSuite) TestPruneTransactions(c *gc.C) {
-	err := s.multiEnvRunner.PruneTransactions()
+func (s *MultiEnvRunnerSuite) TestMaybePruneTransactions(c *gc.C) {
+	err := s.multiEnvRunner.MaybePruneTransactions(2.0)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.testRunner.pruneTransactionsCalled, jc.IsTrue)
 }
 
-func (s *MultiEnvRunnerSuite) TestPruneTransactionsWithError(c *gc.C) {
+func (s *MultiEnvRunnerSuite) TestMaybePruneTransactionsWithError(c *gc.C) {
 	s.testRunner.pruneTransactionsErr = errors.New("boom")
-	err := s.multiEnvRunner.PruneTransactions()
+	err := s.multiEnvRunner.MaybePruneTransactions(2.0)
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -369,7 +369,7 @@ func (r *recordingRunner) ResumeTransactions() error {
 	return r.resumeTransactionsErr
 }
 
-func (r *recordingRunner) PruneTransactions() error {
+func (r *recordingRunner) MaybePruneTransactions(float32) error {
 	r.pruneTransactionsCalled = true
 	return r.pruneTransactionsErr
 }

--- a/worker/txnpruner/txnpruner.go
+++ b/worker/txnpruner/txnpruner.go
@@ -16,7 +16,7 @@ var logger = loggo.GetLogger("juju.worker.txnpruner")
 // TransactionPruner defines the interface for types capable of
 // pruning transactions.
 type TransactionPruner interface {
-	PruneTransactions() error
+	MaybePruneTransactions() error
 }
 
 // New returns a worker which periodically prunes the data for
@@ -32,7 +32,7 @@ func New(tp TransactionPruner, interval time.Duration) worker.Worker {
 			select {
 			case <-timer.C:
 				logger.Debugf("starting transaction pruning")
-				err := tp.PruneTransactions()
+				err := tp.MaybePruneTransactions()
 				if err != nil {
 					return errors.Annotate(err, "pruning failed, txnpruner stopping")
 				}

--- a/worker/txnpruner/txnpruner_test.go
+++ b/worker/txnpruner/txnpruner_test.go
@@ -70,9 +70,9 @@ type fakeTransactionPruner struct {
 	pruneCh chan bool
 }
 
-// PruneTransactions implements the txnpruner.TransactionPruner
+// MaybePruneTransactions implements the txnpruner.TransactionPruner
 // interface.
-func (p *fakeTransactionPruner) PruneTransactions() error {
+func (p *fakeTransactionPruner) MaybePruneTransactions() error {
 	p.pruneCh <- true
 	return nil
 }


### PR DESCRIPTION
This change updates Juju to use the new MaybePruneTransactions Runner method from juju/txn. Transactions will now only be pruned if the transaction count has doubled since the last prune.

Part of the fix for LP #1453785

(Review request: http://reviews.vapour.ws/r/1743/)