### PR TITLE
Forward Port: Merge pull request #2383 from natefinch/update-lumberjack

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -45,7 +45,7 @@ gopkg.in/juju/charmstore.v4	git	3a87b423c3eeb105b82bba2f87d593d1b5763845	2015-05
 gopkg.in/macaroon-bakery.v0	git	9593b80b01ba04b519769d045dffd6abd827d2fd	2015-04-10T07:46:55Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	2014-07-30T20:00:37Z
-gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	2014-07-25T20:51:33Z
+gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08-11T16:19:00Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13


### PR DESCRIPTION
update to newest lumberjack with bugfix

This updates our pointer to the tip of lumberjack, which gives us this bugfix: https://github.com/natefinch/lumberjack/commit/588a21fb0fa0ebdfde42670fa214576b6f0f22df

(Review request: http://reviews.vapour.ws/r/1744/)

(Review request: http://reviews.vapour.ws/r/1745/)