### PR TITLE
Prune completed transactions

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -88,6 +88,7 @@ import (
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/storageprovisioner"
 	"github.com/juju/juju/worker/terminationworker"
+	"github.com/juju/juju/worker/txnpruner"
 	"github.com/juju/juju/worker/upgrader"
 )
 
@@ -997,6 +998,9 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				// because we can't figure out how to do so without brutalising
 				// the transaction log.
 				return resumer.NewResumer(st), nil
+			})
+			a.startWorkerAfterUpgrade(singularRunner, "txnpruner", func() (worker.Worker, error) {
+				return txnpruner.New(st, time.Hour*2), nil
 			})
 		case state.JobManageStateDeprecated:
 			// Legacy environments may set this, but we ignore it.

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -532,6 +532,7 @@ func (s *MachineSuite) TestManageEnviron(c *gc.C) {
 	// See state server runners start
 	r0 := s.singularRecord.nextRunner(c)
 	r0.waitForWorker(c, "resumer")
+	r0.waitForWorker(c, "txnpruner")
 
 	r1 := s.singularRecord.nextRunner(c)
 	lastWorker := perEnvSingularWorkers[len(perEnvSingularWorkers)-1]

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -24,7 +24,7 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-2
 github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-29T20:12:23Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T10:00:34Z
 github.com/juju/testing	git	1a2745b8ad91aec27962257280af7158b2cd9a7a	2015-04-10T20:58:14Z
-github.com/juju/txn	git	2407a1fa094db5603f4718f11e1fafc8543273eb	2015-03-27T15:47:42Z
+github.com/juju/txn	git	5c38fee875d088643ebe2074f308d79680578ba7	2015-05-21T12:30:32Z
 github.com/juju/utils	git	6436ed20810ed9490a94cc42db7041c8d7f5f996	2015-03-31T19:07:01Z
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T00:00:00Z

--- a/state/txns.go
+++ b/state/txns.go
@@ -75,6 +75,14 @@ func (st *State) ResumeTransactions() error {
 	return st.txnRunner(session).ResumeTransactions()
 }
 
+// MaybePruneTransactions removes data for completed transactions.
+func (st *State) MaybePruneTransactions() error {
+	session := st.db.Session.Copy()
+	defer session.Close()
+	// Prune txns only when txn count has doubled since last prune.
+	return st.txnRunner(session).MaybePruneTransactions(2.0)
+}
+
 func newMultiEnvRunner(envUUID string, db *mgo.Database, assertEnvAlive bool) jujutxn.Runner {
 	return &multiEnvRunner{
 		rawRunner:      jujutxn.NewRunner(jujutxn.RunnerParams{Database: db}),
@@ -97,7 +105,7 @@ func (r *multiEnvRunner) RunTransaction(ops []txn.Op) error {
 	return r.rawRunner.RunTransaction(ops)
 }
 
-// Run is part of the jujutxn.Run interface. Operations returned by
+// Run is part of the jujutxn.Runner interface. Operations returned by
 // the given "transactions" function that affect multi-environment
 // collections will be modified in-place to ensure correct interaction
 // with these collections.
@@ -114,9 +122,14 @@ func (r *multiEnvRunner) Run(transactions jujutxn.TransactionSource) error {
 	})
 }
 
-// Run is part of the jujutxn.Run interface.
+// ResumeTransactions is part of the jujutxn.Runner interface.
 func (r *multiEnvRunner) ResumeTransactions() error {
 	return r.rawRunner.ResumeTransactions()
+}
+
+// MaybePruneTransactions is part of the jujutxn.Runner interface.
+func (r *multiEnvRunner) MaybePruneTransactions(pruneFactor float32) error {
+	return r.rawRunner.MaybePruneTransactions(pruneFactor)
 }
 
 func (r *multiEnvRunner) updateOps(ops []txn.Op) []txn.Op {

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -368,6 +368,18 @@ func (s *MultiEnvRunnerSuite) TestResumeTransactionsWithError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
+func (s *MultiEnvRunnerSuite) TestMaybePruneTransactions(c *gc.C) {
+	err := s.multiEnvRunner.MaybePruneTransactions(2.0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.testRunner.pruneTransactionsCalled, jc.IsTrue)
+}
+
+func (s *MultiEnvRunnerSuite) TestMaybePruneTransactionsWithError(c *gc.C) {
+	s.testRunner.pruneTransactionsErr = errors.New("boom")
+	err := s.multiEnvRunner.MaybePruneTransactions(2.0)
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
 // recordingRunner is fake transaction running that implements the
 // jujutxn.Runner interface. Instead of doing anything with a database
 // it simply records the transaction operations passed to it for later
@@ -380,6 +392,8 @@ type recordingRunner struct {
 	seenOps                  []txn.Op
 	resumeTransactionsCalled bool
 	resumeTransactionsErr    error
+	pruneTransactionsCalled  bool
+	pruneTransactionsErr     error
 }
 
 func (r *recordingRunner) RunTransaction(ops []txn.Op) error {
@@ -395,4 +409,9 @@ func (r *recordingRunner) Run(transactions jujutxn.TransactionSource) (err error
 func (r *recordingRunner) ResumeTransactions() error {
 	r.resumeTransactionsCalled = true
 	return r.resumeTransactionsErr
+}
+
+func (r *recordingRunner) MaybePruneTransactions(float32) error {
+	r.pruneTransactionsCalled = true
+	return r.pruneTransactionsErr
 }

--- a/worker/txnpruner/package_test.go
+++ b/worker/txnpruner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txnpruner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/txnpruner/txnpruner.go
+++ b/worker/txnpruner/txnpruner.go
@@ -1,0 +1,42 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txnpruner
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/worker"
+)
+
+// TransactionPruner defines the interface for types capable of
+// pruning transactions.
+type TransactionPruner interface {
+	MaybePruneTransactions() error
+}
+
+// New returns a worker which periodically prunes the data for
+// completed transactions.
+func New(tp TransactionPruner, interval time.Duration) worker.Worker {
+	return worker.NewSimpleWorker(func(stopCh <-chan struct{}) error {
+		// Use a timer rather than a ticker because pruning could
+		// sometimes take a while and we don't want pruning attempts
+		// to occur back-to-back.
+		timer := time.NewTimer(interval)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				err := tp.MaybePruneTransactions()
+				if err != nil {
+					return errors.Annotate(err, "pruning failed, txnpruner stopping")
+				}
+				timer.Reset(interval)
+			case <-stopCh:
+				return nil
+			}
+		}
+		return nil
+	})
+}

--- a/worker/txnpruner/txnpruner_test.go
+++ b/worker/txnpruner/txnpruner_test.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txnpruner_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/txnpruner"
+)
+
+type TxnPrunerSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&TxnPrunerSuite{})
+
+func (s *TxnPrunerSuite) TestPrunes(c *gc.C) {
+	fakePruner := newFakeTransactionPruner()
+	interval := 10 * time.Millisecond
+	p := txnpruner.New(fakePruner, interval)
+	defer p.Kill()
+
+	var t0 time.Time
+	for i := 0; i < 5; i++ {
+		select {
+		case <-fakePruner.pruneCh:
+			t1 := time.Now()
+			if i > 0 {
+				// Check that pruning runs at the expected interval
+				// (but not the first time around as we don't know
+				// when the worker actually started).
+				c.Assert(t1.Sub(t0), jc.GreaterThan, interval)
+			}
+			t0 = t1
+		case <-time.After(testing.LongWait):
+			c.Fatal("timed out waiting for pruning to happen")
+		}
+	}
+}
+
+func (s *TxnPrunerSuite) TestStops(c *gc.C) {
+	success := make(chan bool)
+	check := func() {
+		p := txnpruner.New(newFakeTransactionPruner(), time.Minute)
+		p.Kill()
+		c.Assert(p.Wait(), jc.ErrorIsNil)
+		success <- true
+	}
+	go check()
+
+	select {
+	case <-success:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for worker to stop")
+	}
+}
+
+func newFakeTransactionPruner() *fakeTransactionPruner {
+	return &fakeTransactionPruner{
+		pruneCh: make(chan bool),
+	}
+}
+
+type fakeTransactionPruner struct {
+	pruneCh chan bool
+}
+
+// MaybePruneTransactions implements the txnpruner.TransactionPruner
+// interface.
+func (p *fakeTransactionPruner) MaybePruneTransactions() error {
+	p.pruneCh <- true
+	return nil
+}


### PR DESCRIPTION
This set of changes integrates the new txn pruning functionality in juju/txn into Juju. A new txnpruner worker for the master machine agent is introduced to call MaybePruneTransactions periodically. Transactions will be pruned if the transaction count has doubled since the last prune.

Fixes LP #1453785.


(Review request: http://reviews.vapour.ws/r/1746/)