### PR TITLE
storage: separate volume/filesystem info from ID

### DIFF
--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -183,7 +183,7 @@ func (m *Machine) DistributionGroup() ([]instance.Id, error) {
 func (m *Machine) SetInstanceInfo(
 	id instance.Id, nonce string, characteristics *instance.HardwareCharacteristics,
 	networks []params.Network, interfaces []params.NetworkInterface, volumes []params.Volume,
-	volumeAttachments []params.VolumeAttachment,
+	volumeAttachments map[string]params.VolumeAttachmentInfo,
 ) error {
 	var result params.ErrorResults
 	args := params.InstancesInfo{

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -320,14 +320,16 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	}}
 	volumes := []params.Volume{{
 		VolumeTag: "volume-1-0",
-		VolumeId:  "vol-123",
-		Size:      124,
+		Info: params.VolumeInfo{
+			VolumeId: "vol-123",
+			Size:     124,
+		},
 	}}
-	volumeAttachments := []params.VolumeAttachment{{
-		VolumeTag:  "volume-1-0",
-		MachineTag: "machine-1",
-		DeviceName: "xvdf1",
-	}}
+	volumeAttachments := map[string]params.VolumeAttachmentInfo{
+		"volume-1-0": {
+			DeviceName: "xvdf1",
+		},
+	}
 
 	err = apiMachine.SetInstanceInfo(
 		"i-will", "fake_nonce", &hwChars, networks, ifaces, volumes, volumeAttachments,

--- a/api/storageprovisioner/provisioner_test.go
+++ b/api/storageprovisioner/provisioner_test.go
@@ -164,10 +164,12 @@ func (s *provisionerSuite) TestVolumes(c *gc.C) {
 		*(result.(*params.VolumeResults)) = params.VolumeResults{
 			Results: []params.VolumeResult{{
 				Result: params.Volume{
-					VolumeTag:  "volume-100",
-					VolumeId:   "volume-id",
-					HardwareId: "abc",
-					Size:       1024,
+					VolumeTag: "volume-100",
+					Info: params.VolumeInfo{
+						VolumeId:   "volume-id",
+						HardwareId: "abc",
+						Size:       1024,
+					},
 				},
 			}},
 		}
@@ -181,7 +183,12 @@ func (s *provisionerSuite) TestVolumes(c *gc.C) {
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(volumes, jc.DeepEquals, []params.VolumeResult{{
 		Result: params.Volume{
-			VolumeTag: "volume-100", VolumeId: "volume-id", HardwareId: "abc", Size: 1024,
+			VolumeTag: "volume-100",
+			Info: params.VolumeInfo{
+				VolumeId:   "volume-id",
+				HardwareId: "abc",
+				Size:       1024,
+			},
 		},
 	}})
 }
@@ -199,8 +206,10 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 			Results: []params.FilesystemResult{{
 				Result: params.Filesystem{
 					FilesystemTag: "filesystem-100",
-					FilesystemId:  "filesystem-id",
-					Size:          1024,
+					Info: params.FilesystemInfo{
+						FilesystemId: "filesystem-id",
+						Size:         1024,
+					},
 				},
 			}},
 		}
@@ -214,7 +223,11 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(filesystems, jc.DeepEquals, []params.FilesystemResult{{
 		Result: params.Filesystem{
-			FilesystemTag: "filesystem-100", FilesystemId: "filesystem-id", Size: 1024,
+			FilesystemTag: "filesystem-100",
+			Info: params.FilesystemInfo{
+				FilesystemId: "filesystem-id",
+				Size:         1024,
+			},
 		},
 	}})
 }
@@ -224,7 +237,9 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 		Result: params.VolumeAttachment{
 			MachineTag: "machine-100",
 			VolumeTag:  "volume-100",
-			DeviceName: "xvdf1",
+			Info: params.VolumeAttachmentInfo{
+				DeviceName: "xvdf1",
+			},
 		},
 	}}
 
@@ -295,7 +310,9 @@ func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
 		Result: params.FilesystemAttachment{
 			MachineTag:    "machine-100",
 			FilesystemTag: "filesystem-100",
-			MountPoint:    "/srv",
+			Info: params.FilesystemAttachmentInfo{
+				MountPoint: "/srv",
+			},
 		},
 	}}
 
@@ -478,7 +495,15 @@ func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "SetVolumeInfo")
 		c.Check(arg, gc.DeepEquals, params.Volumes{
-			Volumes: []params.Volume{{VolumeTag: "volume-100", VolumeId: "123", HardwareId: "abc", Size: 1024, Persistent: true}},
+			Volumes: []params.Volume{{
+				VolumeTag: "volume-100",
+				Info: params.VolumeInfo{
+					VolumeId:   "123",
+					HardwareId: "abc",
+					Size:       1024,
+					Persistent: true,
+				},
+			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
@@ -489,7 +514,12 @@ func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
 	})
 
 	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	volumes := []params.Volume{{VolumeTag: "volume-100", VolumeId: "123", HardwareId: "abc", Size: 1024, Persistent: true}}
+	volumes := []params.Volume{{
+		VolumeTag: "volume-100",
+		Info: params.VolumeInfo{
+			VolumeId: "123", HardwareId: "abc", Size: 1024, Persistent: true,
+		},
+	}}
 	errorResults, err := st.SetVolumeInfo(volumes)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
@@ -506,7 +536,11 @@ func (s *provisionerSuite) TestSetFilesystemInfo(c *gc.C) {
 		c.Check(request, gc.Equals, "SetFilesystemInfo")
 		c.Check(arg, gc.DeepEquals, params.Filesystems{
 			Filesystems: []params.Filesystem{{
-				FilesystemTag: "filesystem-100", FilesystemId: "123", Size: 1024,
+				FilesystemTag: "filesystem-100",
+				Info: params.FilesystemInfo{
+					FilesystemId: "123",
+					Size:         1024,
+				},
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
@@ -519,7 +553,11 @@ func (s *provisionerSuite) TestSetFilesystemInfo(c *gc.C) {
 
 	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
 	filesystems := []params.Filesystem{{
-		FilesystemTag: "filesystem-100", FilesystemId: "123", Size: 1024,
+		FilesystemTag: "filesystem-100",
+		Info: params.FilesystemInfo{
+			FilesystemId: "123",
+			Size:         1024,
+		},
 	}}
 	errorResults, err := st.SetFilesystemInfo(filesystems)
 	c.Check(err, jc.ErrorIsNil)
@@ -530,7 +568,11 @@ func (s *provisionerSuite) TestSetFilesystemInfo(c *gc.C) {
 
 func (s *provisionerSuite) TestSetVolumeAttachmentInfo(c *gc.C) {
 	volumeAttachments := []params.VolumeAttachment{{
-		VolumeTag: "volume-100", MachineTag: "machine-200", DeviceName: "xvdf1",
+		VolumeTag:  "volume-100",
+		MachineTag: "machine-200",
+		Info: params.VolumeAttachmentInfo{
+			DeviceName: "xvdf1",
+		},
 	}}
 
 	var callCount int
@@ -560,7 +602,9 @@ func (s *provisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
 	filesystemAttachments := []params.FilesystemAttachment{{
 		FilesystemTag: "filesystem-100",
 		MachineTag:    "machine-200",
-		MountPoint:    "/srv",
+		Info: params.FilesystemAttachmentInfo{
+			MountPoint: "/srv",
+		},
 	}}
 
 	var callCount int

--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -80,9 +80,9 @@ func FilesystemToState(v params.Filesystem) (names.FilesystemTag, state.Filesyst
 		return names.FilesystemTag{}, state.FilesystemInfo{}, errors.Trace(err)
 	}
 	return filesystemTag, state.FilesystemInfo{
-		v.Size,
+		v.Info.Size,
 		"", // pool is set by state
-		v.FilesystemId,
+		v.Info.FilesystemId,
 	}, nil
 }
 
@@ -95,8 +95,10 @@ func FilesystemFromState(f state.Filesystem) (params.Filesystem, error) {
 	result := params.Filesystem{
 		f.FilesystemTag().String(),
 		"",
-		info.FilesystemId,
-		info.Size,
+		params.FilesystemInfo{
+			info.FilesystemId,
+			info.Size,
+		},
 	}
 	volumeTag, err := f.Volume()
 	if err == nil {
@@ -119,8 +121,8 @@ func FilesystemAttachmentToState(in params.FilesystemAttachment) (names.MachineT
 		return names.MachineTag{}, names.FilesystemTag{}, state.FilesystemAttachmentInfo{}, err
 	}
 	info := state.FilesystemAttachmentInfo{
-		in.MountPoint,
-		in.ReadOnly,
+		in.Info.MountPoint,
+		in.Info.ReadOnly,
 	}
 	return machineTag, filesystemTag, info, nil
 }
@@ -134,8 +136,10 @@ func FilesystemAttachmentFromState(v state.FilesystemAttachment) (params.Filesys
 	return params.FilesystemAttachment{
 		v.Filesystem().String(),
 		v.Machine().String(),
-		info.MountPoint,
-		info.ReadOnly,
+		params.FilesystemAttachmentInfo{
+			info.MountPoint,
+			info.ReadOnly,
+		},
 	}, nil
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -320,10 +320,9 @@ type InstanceInfo struct {
 	Networks        []Network
 	Interfaces      []NetworkInterface
 	Volumes         []Volume
-	// TODO(axw) we should return map[names.VolumeTag]VolumeAttachmentInfo
-	// here, containing only the information regarding the attachment.
-	// The rest can be inferred from the context.
-	VolumeAttachments []VolumeAttachment
+	// VolumeAttachments is a mapping from volume tag to
+	// volume attachment info.
+	VolumeAttachments map[string]VolumeAttachmentInfo
 }
 
 // InstancesInfo holds the parameters for making a SetInstanceInfo

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -162,9 +162,14 @@ type MachineStorageIds struct {
 	Ids []MachineStorageId `json:"ids"`
 }
 
-// Volume describes a storage volume in the environment.
+// Volume identifies and describes a storage volume in the environment.
 type Volume struct {
-	VolumeTag  string `json:"volumetag"`
+	VolumeTag string     `json:"volumetag"`
+	Info      VolumeInfo `json:"info"`
+}
+
+// Volume describes a storage volume in the environment.
+type VolumeInfo struct {
 	VolumeId   string `json:"volumeid"`
 	HardwareId string `json:"hardwareid,omitempty"`
 	// Size is the size of the volume in MiB.
@@ -177,10 +182,15 @@ type Volumes struct {
 	Volumes []Volume `json:"volumes"`
 }
 
-// VolumeAttachment describes a volume attachment.
+// VolumeAttachment identifies and describes a volume attachment.
 type VolumeAttachment struct {
-	VolumeTag  string `json:"volumetag"`
-	MachineTag string `json:"machinetag"`
+	VolumeTag  string               `json:"volumetag"`
+	MachineTag string               `json:"machinetag"`
+	Info       VolumeAttachmentInfo `json:"info"`
+}
+
+// VolumeAttachmentInfo describes a volume attachment.
+type VolumeAttachmentInfo struct {
 	DeviceName string `json:"devicename,omitempty"`
 	ReadOnly   bool   `json:"read-only,omitempty"`
 }
@@ -269,11 +279,16 @@ type VolumeAttachmentParamsResults struct {
 	Results []VolumeAttachmentParamsResult `json:"results,omitempty"`
 }
 
-// Filesystem describes a storage filesystem in the environment.
+// Filesystem identifies and describes a storage filesystem in the environment.
 type Filesystem struct {
-	FilesystemTag string `json:"filesystemtag"`
-	VolumeTag     string `json:"volumetag,omitempty"`
-	FilesystemId  string `json:"filesystemid"`
+	FilesystemTag string         `json:"filesystemtag"`
+	VolumeTag     string         `json:"volumetag,omitempty"`
+	Info          FilesystemInfo `json:"info"`
+}
+
+// Filesystem describes a storage filesystem in the environment.
+type FilesystemInfo struct {
+	FilesystemId string `json:"filesystemid"`
 	// Size is the size of the filesystem in MiB.
 	Size uint64 `json:"size"`
 }
@@ -283,12 +298,17 @@ type Filesystems struct {
 	Filesystems []Filesystem `json:"filesystems"`
 }
 
-// FilesystemAttachment describes a filesystem attachment.
+// FilesystemAttachment identifies and describes a filesystem attachment.
 type FilesystemAttachment struct {
-	FilesystemTag string `json:"filesystemtag"`
-	MachineTag    string `json:"machinetag"`
-	MountPoint    string `json:"mountpoint,omitempty"`
-	ReadOnly      bool   `json:"read-only,omitempty"`
+	FilesystemTag string                   `json:"filesystemtag"`
+	MachineTag    string                   `json:"machinetag"`
+	Info          FilesystemAttachmentInfo `json:"info"`
+}
+
+// FilesystemAttachmentInfo describes a filesystem attachment.
+type FilesystemAttachmentInfo struct {
+	MountPoint string `json:"mountpoint,omitempty"`
+	ReadOnly   bool   `json:"read-only,omitempty"`
 }
 
 // FilesystemAttachments describes a set of storage filesystem attachments.

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -622,8 +622,8 @@ func volumeAttachmentsToState(in []params.VolumeAttachment) (map[names.VolumeTag
 			return nil, errors.Trace(err)
 		}
 		m[volumeTag] = state.VolumeAttachmentInfo{
-			v.DeviceName,
-			false, // not read-only
+			v.Info.DeviceName,
+			v.Info.ReadOnly,
 		}
 	}
 	return m, nil
@@ -756,7 +756,7 @@ func (p *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Erro
 		if err != nil {
 			return err
 		}
-		volumeAttachments, err := common.VolumeAttachmentsToState(arg.VolumeAttachments)
+		volumeAttachments, err := common.VolumeAttachmentInfosToState(arg.VolumeAttachments)
 		if err != nil {
 			return err
 		}

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1129,14 +1129,16 @@ func (s *withoutStateServerSuite) TestSetInstanceInfo(c *gc.C) {
 		Nonce:      "fake",
 		Volumes: []params.Volume{{
 			VolumeTag: "volume-0",
-			VolumeId:  "vol-0",
-			Size:      1234,
+			Info: params.VolumeInfo{
+				VolumeId: "vol-0",
+				Size:     1234,
+			},
 		}},
-		VolumeAttachments: []params.VolumeAttachment{{
-			VolumeTag:  "volume-0",
-			MachineTag: volumesMachine.Tag().String(),
-			DeviceName: "sda",
-		}},
+		VolumeAttachments: map[string]params.VolumeAttachmentInfo{
+			"volume-0": {
+				DeviceName: "sda",
+			},
+		},
 	},
 		{Tag: "machine-42"},
 		{Tag: "unit-foo-0"},

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -509,8 +509,10 @@ func convertStateVolumeAttachmentToParams(attachment state.VolumeAttachment) par
 		VolumeTag:  attachment.Volume().String(),
 		MachineTag: attachment.Machine().String()}
 	if info, err := attachment.Info(); err == nil {
-		result.DeviceName = info.DeviceName
-		result.ReadOnly = info.ReadOnly
+		result.Info = params.VolumeAttachmentInfo{
+			info.DeviceName,
+			info.ReadOnly,
+		}
 	}
 	return result
 }

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -171,7 +171,15 @@ func (s *provisionerSuite) TestVolumesMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.VolumeResults{
 		Results: []params.VolumeResult{
-			{Result: params.Volume{VolumeTag: "volume-0-0", VolumeId: "abc", HardwareId: "123", Size: 1024, Persistent: true}},
+			{Result: params.Volume{
+				VolumeTag: "volume-0-0",
+				Info: params.VolumeInfo{
+					VolumeId:   "abc",
+					HardwareId: "123",
+					Size:       1024,
+					Persistent: true,
+				},
+			}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},
@@ -195,7 +203,14 @@ func (s *provisionerSuite) TestVolumesEnviron(c *gc.C) {
 		Results: []params.VolumeResult{
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 			{Error: common.ServerError(errors.NotProvisionedf(`volume "1"`))},
-			{Result: params.Volume{VolumeTag: "volume-2", VolumeId: "def", HardwareId: "456", Size: 4096}},
+			{Result: params.Volume{
+				VolumeTag: "volume-2",
+				Info: params.VolumeInfo{
+					VolumeId:   "def",
+					HardwareId: "456",
+					Size:       4096,
+				},
+			}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},
 	})
@@ -224,7 +239,13 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 		Results: []params.FilesystemResult{
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 			{Error: common.ServerError(errors.NotProvisionedf(`filesystem "1"`))},
-			{Result: params.Filesystem{FilesystemTag: "filesystem-2", FilesystemId: "def", Size: 4096}},
+			{Result: params.Filesystem{
+				FilesystemTag: "filesystem-2",
+				Info: params.FilesystemInfo{
+					FilesystemId: "def",
+					Size:         4096,
+				},
+			}},
 			{Error: &params.Error{"permission denied", "unauthorized access"}},
 		},
 	})
@@ -257,7 +278,11 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.VolumeAttachmentResults{
 		Results: []params.VolumeAttachmentResult{
 			{Result: params.VolumeAttachment{
-				VolumeTag: "volume-0-0", MachineTag: "machine-0", DeviceName: "xvdf1",
+				VolumeTag:  "volume-0-0",
+				MachineTag: "machine-0",
+				Info: params.VolumeAttachmentInfo{
+					DeviceName: "xvdf1",
+				},
 			}},
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,
@@ -297,7 +322,9 @@ func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
 			{Result: params.FilesystemAttachment{
 				FilesystemTag: "filesystem-0-0",
 				MachineTag:    "machine-0",
-				MountPoint:    "/srv",
+				Info: params.FilesystemAttachmentInfo{
+					MountPoint: "/srv",
+				},
 			}},
 			{Error: &params.Error{
 				Code:    params.CodeNotProvisioned,
@@ -455,19 +482,27 @@ func (s *provisionerSuite) TestSetVolumeAttachmentInfo(c *gc.C) {
 		VolumeAttachments: []params.VolumeAttachment{{
 			MachineTag: "machine-0",
 			VolumeTag:  "volume-0-0",
-			DeviceName: "sda",
+			Info: params.VolumeAttachmentInfo{
+				DeviceName: "sda",
+			},
 		}, {
 			MachineTag: "machine-0",
 			VolumeTag:  "volume-1",
-			DeviceName: "sdb",
+			Info: params.VolumeAttachmentInfo{
+				DeviceName: "sdb",
+			},
 		}, {
 			MachineTag: "machine-2",
 			VolumeTag:  "volume-3",
-			DeviceName: "sdc",
+			Info: params.VolumeAttachmentInfo{
+				DeviceName: "sdc",
+			},
 		}, {
 			MachineTag: "machine-0",
 			VolumeTag:  "volume-42",
-			DeviceName: "sdd",
+			Info: params.VolumeAttachmentInfo{
+				DeviceName: "sdd",
+			},
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -489,19 +524,27 @@ func (s *provisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
 		FilesystemAttachments: []params.FilesystemAttachment{{
 			MachineTag:    "machine-0",
 			FilesystemTag: "filesystem-0-0",
-			MountPoint:    "/srv/a",
+			Info: params.FilesystemAttachmentInfo{
+				MountPoint: "/srv/a",
+			},
 		}, {
 			MachineTag:    "machine-0",
 			FilesystemTag: "filesystem-1",
-			MountPoint:    "/srv/b",
+			Info: params.FilesystemAttachmentInfo{
+				MountPoint: "/srv/b",
+			},
 		}, {
 			MachineTag:    "machine-2",
 			FilesystemTag: "filesystem-3",
-			MountPoint:    "/srv/c",
+			Info: params.FilesystemAttachmentInfo{
+				MountPoint: "/srv/c",
+			},
 		}, {
 			MachineTag:    "machine-0",
 			FilesystemTag: "filesystem-42",
-			MountPoint:    "/srv/d",
+			Info: params.FilesystemAttachmentInfo{
+				MountPoint: "/srv/d",
+			},
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -100,8 +100,8 @@ func convertVolumeAttachments(item params.VolumeItem, all map[string]map[string]
 			return errors.Trace(err)
 		}
 		info, unit, storage := createInfo(item.Volume)
-		info.DeviceName = one.DeviceName
-		info.ReadOnly = one.ReadOnly
+		info.DeviceName = one.Info.DeviceName
+		info.ReadOnly = one.Info.ReadOnly
 
 		addOneToAll(machine, unit, storage, info, all)
 	}

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -312,10 +312,12 @@ func (s mockVolumeListAPI) createTestAttachment(volumeTag, machine string, reado
 	result := params.VolumeAttachment{
 		VolumeTag:  volumeTag,
 		MachineTag: names.NewMachineTag(machine).String(),
-		ReadOnly:   readonly,
+		Info: params.VolumeAttachmentInfo{
+			ReadOnly: readonly,
+		},
 	}
 	if s.fillDeviceName {
-		result.DeviceName = "testdevice"
+		result.Info.DeviceName = "testdevice"
 	}
 	return result
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -958,9 +958,11 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	for i, v := range args.Volumes {
 		persistent, _ := v.Attributes[storage.Persistent].(bool)
 		volumes[i] = storage.Volume{
-			Tag:        names.NewVolumeTag(strconv.Itoa(i + 1)),
-			Size:       v.Size,
-			Persistent: persistent,
+			Tag: names.NewVolumeTag(strconv.Itoa(i + 1)),
+			VolumeInfo: storage.VolumeInfo{
+				Size:       v.Size,
+				Persistent: persistent,
+			},
 		}
 	}
 	estate.insts[i.id] = i

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -302,19 +302,16 @@ func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []stor
 }
 
 // DescribeVolumes is specified on the storage.VolumeSource interface.
-func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.Volume, error) {
+func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.VolumeInfo, error) {
 	resp, err := v.ec2.Volumes(volIds, nil)
 	if err != nil {
 		return nil, err
 	}
-	vols := make([]storage.Volume, len(resp.Volumes))
+	vols := make([]storage.VolumeInfo, len(resp.Volumes))
 	for i, vol := range resp.Volumes {
-		vols[i] = storage.Volume{
-			// TODO(wallyworld) - fill in tag when interface is fixed
-			VolumeInfo: storage.VolumeInfo{
-				Size:     gibToMib(uint64(vol.Size)),
-				VolumeId: vol.Id,
-			},
+		vols[i] = storage.VolumeInfo{
+			Size:     gibToMib(uint64(vol.Size)),
+			VolumeId: vol.Id,
 		}
 		for _, attachment := range vol.Attachments {
 			if !attachment.DeleteOnTermination {

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -263,13 +263,15 @@ func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []stor
 		}
 		volumeId := resp.Id
 		volumes = append(volumes, storage.Volume{
-			Tag:      p.Tag,
-			VolumeId: volumeId,
-			Size:     gibToMib(uint64(resp.Size)),
-			// TODO(axw) Later, when we handle destruction of
-			// volumes within Juju, we should not mark any
-			// EBS volumes as persistent.
-			Persistent: persistent,
+			p.Tag,
+			storage.VolumeInfo{
+				VolumeId: volumeId,
+				Size:     gibToMib(uint64(resp.Size)),
+				// TODO(axw) Later, when we handle destruction of
+				// volumes within Juju, we should not mark any
+				// EBS volumes as persistent.
+				Persistent: persistent,
+			},
 		})
 
 		nextDeviceName := blockDeviceNamer(instances[instId])
@@ -289,9 +291,11 @@ func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []stor
 			return nil, nil, errors.Annotatef(err, "binding termination of %v to %v", resp.Volume.Id, instId)
 		}
 		volumeAttachments = append(volumeAttachments, storage.VolumeAttachment{
-			Volume:     p.Tag,
-			Machine:    p.Attachment.Machine,
-			DeviceName: actualDeviceName,
+			p.Tag,
+			p.Attachment.Machine,
+			storage.VolumeAttachmentInfo{
+				DeviceName: actualDeviceName,
+			},
 		})
 	}
 	return volumes, volumeAttachments, nil
@@ -307,8 +311,10 @@ func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.Volume, er
 	for i, vol := range resp.Volumes {
 		vols[i] = storage.Volume{
 			// TODO(wallyworld) - fill in tag when interface is fixed
-			Size:     gibToMib(uint64(vol.Size)),
-			VolumeId: vol.Id,
+			VolumeInfo: storage.VolumeInfo{
+				Size:     gibToMib(uint64(vol.Size)),
+				VolumeId: vol.Id,
+			},
 		}
 		for _, attachment := range vol.Attachments {
 			if !attachment.DeleteOnTermination {
@@ -394,9 +400,11 @@ func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentP
 		}
 		attached = append(attached, params)
 		attachments = append(attachments, storage.VolumeAttachment{
-			Volume:     params.Volume,
-			Machine:    params.Machine,
-			DeviceName: deviceName,
+			params.Volume,
+			params.Machine,
+			storage.VolumeAttachmentInfo{
+				DeviceName: deviceName,
+			},
 		})
 	}
 	return attachments, nil

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -275,16 +275,12 @@ func (s *ebsVolumeSuite) TestVolumes(c *gc.C) {
 	vols, err := vs.DescribeVolumes([]string{"vol-0", "vol-1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 2)
-	c.Assert(vols, jc.SameContents, []storage.Volume{{
-		VolumeInfo: storage.VolumeInfo{
-			Size:     10240,
-			VolumeId: "vol-0",
-		},
+	c.Assert(vols, jc.SameContents, []storage.VolumeInfo{{
+		Size:     10240,
+		VolumeId: "vol-0",
 	}, {
-		VolumeInfo: storage.VolumeInfo{
-			Size:     20480,
-			VolumeId: "vol-1",
-		},
+		Size:     20480,
+		VolumeId: "vol-1",
 	}})
 }
 

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -151,20 +151,26 @@ func (s *ebsVolumeSuite) assertCreateVolumes(c *gc.C, vs storage.VolumeSource, i
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 3)
 	c.Assert(vols, jc.SameContents, []storage.Volume{{
-		Tag:        names.NewVolumeTag("0"),
-		Size:       10240,
-		VolumeId:   "vol-0",
-		Persistent: true,
+		names.NewVolumeTag("0"),
+		storage.VolumeInfo{
+			Size:       10240,
+			VolumeId:   "vol-0",
+			Persistent: true,
+		},
 	}, {
-		Tag:        names.NewVolumeTag("1"),
-		Size:       20480,
-		VolumeId:   "vol-1",
-		Persistent: true,
+		names.NewVolumeTag("1"),
+		storage.VolumeInfo{
+			Size:       20480,
+			VolumeId:   "vol-1",
+			Persistent: true,
+		},
 	}, {
-		Tag:        names.NewVolumeTag("2"),
-		Size:       30720,
-		VolumeId:   "vol-2",
-		Persistent: false,
+		names.NewVolumeTag("2"),
+		storage.VolumeInfo{
+			Size:       30720,
+			VolumeId:   "vol-2",
+			Persistent: false,
+		},
 	}})
 	ec2Client := ec2.StorageEC2(vs)
 	ec2Vols, err := ec2Client.Volumes(nil, nil)
@@ -270,11 +276,15 @@ func (s *ebsVolumeSuite) TestVolumes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 2)
 	c.Assert(vols, jc.SameContents, []storage.Volume{{
-		Size:     10240,
-		VolumeId: "vol-0",
+		VolumeInfo: storage.VolumeInfo{
+			Size:     10240,
+			VolumeId: "vol-0",
+		},
 	}, {
-		Size:     20480,
-		VolumeId: "vol-1",
+		VolumeInfo: storage.VolumeInfo{
+			Size:     20480,
+			VolumeId: "vol-1",
+		},
 	}})
 }
 
@@ -407,10 +417,12 @@ func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Assert(result[0], gc.Equals, storage.VolumeAttachment{
-		Volume:     names.NewVolumeTag("0"),
-		Machine:    names.NewMachineTag("1"),
-		DeviceName: "xvdf",
-		ReadOnly:   false,
+		names.NewVolumeTag("0"),
+		names.NewMachineTag("1"),
+		storage.VolumeAttachmentInfo{
+			DeviceName: "xvdf",
+			ReadOnly:   false,
+		},
 	})
 
 	ec2Client := ec2.StorageEC2(vs)
@@ -431,10 +443,12 @@ func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	c.Assert(result[0], gc.Equals, storage.VolumeAttachment{
-		Volume:     names.NewVolumeTag("0"),
-		Machine:    names.NewMachineTag("1"),
-		DeviceName: "xvdf",
-		ReadOnly:   false,
+		names.NewVolumeTag("0"),
+		names.NewMachineTag("1"),
+		storage.VolumeAttachmentInfo{
+			DeviceName: "xvdf",
+			ReadOnly:   false,
+		},
 	})
 }
 

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1454,30 +1454,38 @@ func (s *environSuite) TestStartInstanceStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Volumes, jc.DeepEquals, []storage.Volume{
 		{
-			Tag:        names.NewVolumeTag("1"),
-			Size:       238475,
-			VolumeId:   "volume-1",
-			HardwareId: "id_for_sda",
+			names.NewVolumeTag("1"),
+			storage.VolumeInfo{
+				Size:       238475,
+				VolumeId:   "volume-1",
+				HardwareId: "id_for_sda",
+			},
 		},
 		{
-			Tag:        names.NewVolumeTag("3"),
-			Size:       238475,
-			VolumeId:   "volume-3",
-			HardwareId: "",
+			names.NewVolumeTag("3"),
+			storage.VolumeInfo{
+				Size:       238475,
+				VolumeId:   "volume-3",
+				HardwareId: "",
+			},
 		},
 	})
 	c.Assert(result.VolumeAttachments, jc.DeepEquals, []storage.VolumeAttachment{
 		{
-			Volume:     names.NewVolumeTag("1"),
-			DeviceName: "",
-			Machine:    names.NewMachineTag("1"),
-			ReadOnly:   false,
+			names.NewVolumeTag("1"),
+			names.NewMachineTag("1"),
+			storage.VolumeAttachmentInfo{
+				DeviceName: "",
+				ReadOnly:   false,
+			},
 		},
 		{
-			Volume:     names.NewVolumeTag("3"),
-			DeviceName: "sdc",
-			Machine:    names.NewMachineTag("1"),
-			ReadOnly:   false,
+			names.NewVolumeTag("3"),
+			names.NewMachineTag("1"),
+			storage.VolumeAttachmentInfo{
+				DeviceName: "sdc",
+				ReadOnly:   false,
+			},
 		},
 	})
 }

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -256,19 +256,23 @@ func (mi *maasInstance) volumes(
 
 		volumeTag := names.NewVolumeTag(deviceLabel)
 		vol := storage.Volume{
-			Tag:        volumeTag,
-			VolumeId:   volumeTag.String(),
-			HardwareId: hardwareId,
-			Size:       uint64(sizeinBytes / humanize.MiByte),
-			Persistent: false,
+			volumeTag,
+			storage.VolumeInfo{
+				VolumeId:   volumeTag.String(),
+				HardwareId: hardwareId,
+				Size:       uint64(sizeinBytes / humanize.MiByte),
+				Persistent: false,
+			},
 		}
 		volumes = append(volumes, vol)
 
 		attachment := storage.VolumeAttachment{
-			Volume:     volumeTag,
-			DeviceName: deviceName,
-			Machine:    mTag,
-			ReadOnly:   false,
+			volumeTag,
+			mTag,
+			storage.VolumeAttachmentInfo{
+				DeviceName: deviceName,
+				ReadOnly:   false,
+			},
 		}
 		attachments = append(attachments, attachment)
 	}

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -87,33 +87,41 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 	c.Check(volumes, jc.DeepEquals, []storage.Volume{
 		{
 			// This volume has no id_path.
-			Tag:        names.NewVolumeTag("1"),
-			HardwareId: "",
-			VolumeId:   "volume-1",
-			Size:       476893,
-			Persistent: false,
+			names.NewVolumeTag("1"),
+			storage.VolumeInfo{
+				HardwareId: "",
+				VolumeId:   "volume-1",
+				Size:       476893,
+				Persistent: false,
+			},
 		},
 		{
-			Tag:        names.NewVolumeTag("2"),
-			HardwareId: "id_for_sdc",
-			VolumeId:   "volume-2",
-			Size:       238764,
-			Persistent: false,
+			names.NewVolumeTag("2"),
+			storage.VolumeInfo{
+				HardwareId: "id_for_sdc",
+				VolumeId:   "volume-2",
+				Size:       238764,
+				Persistent: false,
+			},
 		},
 	})
 	c.Assert(attachments, jc.DeepEquals, []storage.VolumeAttachment{
 		{
-			Volume:     names.NewVolumeTag("1"),
-			DeviceName: "sdb",
-			Machine:    mTag,
-			ReadOnly:   false,
+			names.NewVolumeTag("1"),
+			mTag,
+			storage.VolumeAttachmentInfo{
+				DeviceName: "sdb",
+				ReadOnly:   false,
+			},
 		},
 		// Device name not set because there's a hardware id in the volume.
 		{
-			Volume:     names.NewVolumeTag("2"),
-			DeviceName: "",
-			Machine:    mTag,
-			ReadOnly:   false,
+			names.NewVolumeTag("2"),
+			mTag,
+			storage.VolumeAttachmentInfo{
+				DeviceName: "",
+				ReadOnly:   false,
+			},
 		},
 	})
 }

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -242,9 +242,11 @@ func (s *cinderVolumeSource) attachVolume(arg storage.VolumeAttachmentParams) (s
 		}
 	}
 	return storage.VolumeAttachment{
-		Machine:    arg.Machine,
-		Volume:     arg.Volume,
-		DeviceName: novaAttachment.Device[len("/dev/"):],
+		arg.Volume,
+		arg.Machine,
+		storage.VolumeAttachmentInfo{
+			DeviceName: novaAttachment.Device[len("/dev/"):],
+		},
 	}, nil
 }
 
@@ -290,12 +292,14 @@ func (s *cinderVolumeSource) DetachVolumes(args []storage.VolumeAttachmentParams
 
 func cinderToJujuVolume(tag names.VolumeTag, volume *cinder.Volume) storage.Volume {
 	return storage.Volume{
-		VolumeId: volume.ID,
-		Size:     uint64(volume.Size * 1024),
-		Tag:      tag,
-		// TODO(axw) there is currently no way to mark a volume as
-		// "delete on termination", so all volumes are persistent.
-		Persistent: true,
+		tag,
+		storage.VolumeInfo{
+			VolumeId: volume.ID,
+			Size:     uint64(volume.Size * 1024),
+			// TODO(axw) there is currently no way to mark a volume as
+			// "delete on termination", so all volumes are persistent.
+			Persistent: true,
+		},
 	}
 }
 

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -63,9 +63,11 @@ func (s *cinderVolumeSourceSuite) TestAttachVolumes(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(attachments, jc.DeepEquals, []storage.VolumeAttachment{{
-		Volume:     mockVolumeTag,
-		Machine:    mockMachineTag,
-		DeviceName: "sda",
+		mockVolumeTag,
+		mockMachineTag,
+		storage.VolumeAttachmentInfo{
+			DeviceName: "sda",
+		},
 	}})
 }
 
@@ -127,15 +129,19 @@ func (s *cinderVolumeSourceSuite) TestCreateVolume(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(volumes, jc.DeepEquals, []storage.Volume{{
-		VolumeId:   mockVolId,
-		Tag:        mockVolumeTag,
-		Size:       providedSize,
-		Persistent: true,
+		mockVolumeTag,
+		storage.VolumeInfo{
+			VolumeId:   mockVolId,
+			Size:       providedSize,
+			Persistent: true,
+		},
 	}})
 	c.Check(attachments, jc.DeepEquals, []storage.VolumeAttachment{{
-		Volume:     mockVolumeTag,
-		Machine:    mockMachineTag,
-		DeviceName: "sda",
+		mockVolumeTag,
+		mockMachineTag,
+		storage.VolumeAttachmentInfo{
+			DeviceName: "sda",
+		},
 	}})
 
 	// should have been 3 calls to GetVolume: twice initially
@@ -157,9 +163,11 @@ func (s *cinderVolumeSourceSuite) TestDescribeVolumes(c *gc.C) {
 	volumes, err := volSource.DescribeVolumes([]string{mockVolId})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(volumes, jc.DeepEquals, []storage.Volume{{
-		VolumeId:   mockVolId,
-		Size:       mockVolSize,
-		Persistent: true,
+		VolumeInfo: storage.VolumeInfo{
+			VolumeId:   mockVolId,
+			Size:       mockVolSize,
+			Persistent: true,
+		},
 	}})
 }
 

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -162,12 +162,10 @@ func (s *cinderVolumeSourceSuite) TestDescribeVolumes(c *gc.C) {
 	volSource := openstack.NewCinderVolumeSource(mockAdapter)
 	volumes, err := volSource.DescribeVolumes([]string{mockVolId})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(volumes, jc.DeepEquals, []storage.Volume{{
-		VolumeInfo: storage.VolumeInfo{
-			VolumeId:   mockVolId,
-			Size:       mockVolSize,
-			Persistent: true,
-		},
+	c.Check(volumes, jc.DeepEquals, []storage.VolumeInfo{{
+		VolumeId:   mockVolId,
+		Size:       mockVolSize,
+		Persistent: true,
 	}})
 }
 

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -5,8 +5,8 @@ package storage
 
 import "github.com/juju/names"
 
-// Filesystem describes a filesystem, either
-// local or remote (NFS, Ceph etc).
+// Filesystem identifies and describes a filesystem, either local or remote
+// (NFS, Ceph etc).
 type Filesystem struct {
 	// Tag is a unique name assigned by Juju to the filesystem.
 	Tag names.FilesystemTag
@@ -14,6 +14,11 @@ type Filesystem struct {
 	// Volume is the tag of the volume that backs the filesystem, if any.
 	Volume names.VolumeTag
 
+	FilesystemInfo
+}
+
+// Filesystem describes a filesystem, either local or remote (NFS, Ceph etc).
+type FilesystemInfo struct {
 	// FilesystemId is a unique provider-supplied ID for the filesystem.
 	// FilesystemId is required to be unique for the lifetime of the
 	// filesystem, but may be reused.
@@ -34,8 +39,14 @@ type FilesystemAttachment struct {
 	// this attachment corresponds to.
 	Machine names.MachineTag
 
-	// Path is the path at which the filesystem is mounted on the machine that
-	// this attachment corresponds to.
+	FilesystemAttachmentInfo
+}
+
+// FilesystemAttachmentInfo describes machine-specific filesystem attachment
+// information, including how the filesystem is exposed on the machine.
+type FilesystemAttachmentInfo struct {
+	// Path is the path at which the filesystem is mounted on the machine
+	// that this attachment corresponds to.
 	Path string
 
 	// ReadOnly indicates that the filesystem is mounted read-only.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -73,7 +73,7 @@ type VolumeSource interface {
 
 	// DescribeVolumes returns the properties of the volumes with the
 	// specified provider volume IDs.
-	DescribeVolumes(volIds []string) ([]Volume, error)
+	DescribeVolumes(volIds []string) ([]VolumeInfo, error)
 
 	// DestroyVolumes destroys the volumes with the specified provider
 	// volume IDs.

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -124,9 +124,11 @@ func (lvs *loopVolumeSource) createVolume(params storage.VolumeParams) (storage.
 		return storage.Volume{}, errors.Annotate(err, "could not create block file")
 	}
 	return storage.Volume{
-		Tag:      params.Tag,
-		VolumeId: volumeId,
-		Size:     params.Size,
+		params.Tag,
+		storage.VolumeInfo{
+			VolumeId: volumeId,
+			Size:     params.Size,
+		},
 	}, nil
 }
 
@@ -203,10 +205,12 @@ func (lvs *loopVolumeSource) attachVolume(arg storage.VolumeAttachmentParams) (s
 		return storage.VolumeAttachment{}, errors.Annotate(err, "attaching loop device")
 	}
 	return storage.VolumeAttachment{
-		Volume:     arg.Volume,
-		Machine:    arg.Machine,
-		DeviceName: deviceName,
-		ReadOnly:   arg.ReadOnly,
+		arg.Volume,
+		arg.Machine,
+		storage.VolumeAttachmentInfo{
+			DeviceName: deviceName,
+			ReadOnly:   arg.ReadOnly,
+		},
 	}, nil
 }
 

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -137,7 +137,7 @@ func (lvs *loopVolumeSource) volumeFilePath(volumeId string) string {
 }
 
 // DescribeVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.Volume, error) {
+func (lvs *loopVolumeSource) DescribeVolumes(volumeIds []string) ([]storage.VolumeInfo, error) {
 	// TODO(axw) implement this when we need it.
 	return nil, errors.NotImplementedf("DescribeVolumes")
 }

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -104,9 +104,11 @@ func (s *loopSuite) TestCreateVolumes(c *gc.C) {
 	// volume attachments always deferred to AttachVolumes
 	c.Assert(volumeAttachments, gc.HasLen, 0)
 	c.Assert(volumes[0], gc.Equals, storage.Volume{
-		Tag:      names.NewVolumeTag("0"),
-		VolumeId: "volume-0",
-		Size:     2,
+		names.NewVolumeTag("0"),
+		storage.VolumeInfo{
+			VolumeId: "volume-0",
+			Size:     2,
+		},
 	})
 }
 
@@ -188,14 +190,18 @@ func (s *loopSuite) TestAttachVolumes(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, jc.DeepEquals, []storage.VolumeAttachment{{
-		Volume:     names.NewVolumeTag("0"),
-		Machine:    names.NewMachineTag("0"),
-		DeviceName: "loop98",
+		names.NewVolumeTag("0"),
+		names.NewMachineTag("0"),
+		storage.VolumeAttachmentInfo{
+			DeviceName: "loop98",
+		},
 	}, {
-		Volume:     names.NewVolumeTag("1"),
-		Machine:    names.NewMachineTag("0"),
-		DeviceName: "loop99",
-		ReadOnly:   true,
+		names.NewVolumeTag("1"),
+		names.NewMachineTag("0"),
+		storage.VolumeAttachmentInfo{
+			DeviceName: "loop99",
+			ReadOnly:   true,
+		},
 	}})
 }
 

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -89,8 +89,10 @@ func (s *managedFilesystemSource) createFilesystem(arg storage.FilesystemParams)
 	return storage.Filesystem{
 		arg.Tag,
 		arg.Volume,
-		arg.Tag.String(),
-		blockDevice.Size,
+		storage.FilesystemInfo{
+			arg.Tag.String(),
+			blockDevice.Size,
+		},
 	}, nil
 }
 
@@ -130,8 +132,10 @@ func (s *managedFilesystemSource) attachFilesystem(arg storage.FilesystemAttachm
 	return storage.FilesystemAttachment{
 		arg.Filesystem,
 		arg.Machine,
-		arg.Path,
-		arg.ReadOnly,
+		storage.FilesystemAttachmentInfo{
+			arg.Path,
+			arg.ReadOnly,
+		},
 	}, nil
 }
 

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -73,15 +73,19 @@ func (s *managedfsSuite) TestCreateFilesystems(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(filesystems, jc.DeepEquals, []storage.Filesystem{{
-		Tag:          names.NewFilesystemTag("0/0"),
-		Volume:       names.NewVolumeTag("0"),
-		FilesystemId: "filesystem-0-0",
-		Size:         2,
+		names.NewFilesystemTag("0/0"),
+		names.NewVolumeTag("0"),
+		storage.FilesystemInfo{
+			FilesystemId: "filesystem-0-0",
+			Size:         2,
+		},
 	}, {
-		Tag:          names.NewFilesystemTag("0/1"),
-		Volume:       names.NewVolumeTag("1"),
-		FilesystemId: "filesystem-0-1",
-		Size:         3,
+		names.NewFilesystemTag("0/1"),
+		names.NewVolumeTag("1"),
+		storage.FilesystemInfo{
+			FilesystemId: "filesystem-0-1",
+			Size:         3,
+		},
 	}})
 }
 
@@ -134,10 +138,12 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly bool) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(filesystemAttachments, jc.DeepEquals, []storage.FilesystemAttachment{{
-		Filesystem: names.NewFilesystemTag("0/0"),
-		Machine:    names.NewMachineTag("0"),
-		Path:       "/in/the/place",
-		ReadOnly:   readOnly,
+		names.NewFilesystemTag("0/0"),
+		names.NewMachineTag("0"),
+		storage.FilesystemAttachmentInfo{
+			Path:     "/in/the/place",
+			ReadOnly: readOnly,
+		},
 	}})
 }
 

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -168,9 +168,12 @@ func (s *rootfsFilesystemSource) createFilesystem(params storage.FilesystemParam
 		return filesystem, errors.Errorf("filesystem is not big enough (%dM < %dM)", sizeInMiB, params.Size)
 	}
 	filesystem = storage.Filesystem{
-		Tag:          params.Tag,
-		FilesystemId: params.Tag.Id(),
-		Size:         sizeInMiB,
+		params.Tag,
+		names.VolumeTag{},
+		storage.FilesystemInfo{
+			FilesystemId: params.Tag.Id(),
+			Size:         sizeInMiB,
+		},
 	}
 	return filesystem, nil
 }
@@ -199,9 +202,11 @@ func (s *rootfsFilesystemSource) attachFilesystem(arg storage.FilesystemAttachme
 		return storage.FilesystemAttachment{}, err
 	}
 	return storage.FilesystemAttachment{
-		Filesystem: arg.Filesystem,
-		Machine:    arg.Machine,
-		Path:       mountPoint,
+		arg.Filesystem,
+		arg.Machine,
+		storage.FilesystemAttachmentInfo{
+			Path: mountPoint,
+		},
 	}, nil
 }
 

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -105,13 +105,17 @@ func (s *rootfsSuite) TestCreateFilesystems(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(filesystems, jc.DeepEquals, []storage.Filesystem{{
-		Tag:          names.NewFilesystemTag("6"),
-		FilesystemId: "6",
-		Size:         2,
+		Tag: names.NewFilesystemTag("6"),
+		FilesystemInfo: storage.FilesystemInfo{
+			FilesystemId: "6",
+			Size:         2,
+		},
 	}, {
-		Tag:          names.NewFilesystemTag("7"),
-		FilesystemId: "7",
-		Size:         4,
+		Tag: names.NewFilesystemTag("7"),
+		FilesystemInfo: storage.FilesystemInfo{
+			FilesystemId: "7",
+			Size:         4,
+		},
 	}})
 }
 
@@ -184,7 +188,9 @@ func (s *rootfsSuite) TestAttachFilesystemsBind(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, []storage.FilesystemAttachment{{
 		Filesystem: names.NewFilesystemTag("6"),
-		Path:       "/srv",
+		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+			Path: "/srv",
+		},
 	}})
 }
 
@@ -203,7 +209,9 @@ func (s *rootfsSuite) TestAttachFilesystemsBound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, []storage.FilesystemAttachment{{
 		Filesystem: names.NewFilesystemTag("6"),
-		Path:       "/srv",
+		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+			Path: "/srv",
+		},
 	}})
 }
 
@@ -253,7 +261,9 @@ func (s *rootfsSuite) TestAttachFilesystemsBindSameFSEmptyDir(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, []storage.FilesystemAttachment{{
 		Filesystem: names.NewFilesystemTag("6"),
-		Path:       "/srv",
+		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+			Path: "/srv",
+		},
 	}})
 }
 
@@ -305,6 +315,8 @@ func (s *rootfsSuite) TestAttachFilesystemsBindSameFSNonEmptyDirClaimed(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, []storage.FilesystemAttachment{{
 		Filesystem: names.NewFilesystemTag("6"),
-		Path:       "/srv/666",
+		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+			Path: "/srv/666",
+		},
 	}})
 }

--- a/storage/provider/tmpfs_test.go
+++ b/storage/provider/tmpfs_test.go
@@ -96,8 +96,10 @@ func (s *tmpfsSuite) TestCreateFilesystems(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(filesystems, jc.DeepEquals, []storage.Filesystem{{
-		Tag:  names.NewFilesystemTag("6"),
-		Size: 2,
+		Tag: names.NewFilesystemTag("6"),
+		FilesystemInfo: storage.FilesystemInfo{
+			Size: 2,
+		},
 	}})
 }
 
@@ -116,11 +118,15 @@ func (s *tmpfsSuite) TestCreateFilesystemsHugePages(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(filesystems, jc.DeepEquals, []storage.Filesystem{{
-		Tag:  names.NewFilesystemTag("1"),
-		Size: 32,
+		Tag: names.NewFilesystemTag("1"),
+		FilesystemInfo: storage.FilesystemInfo{
+			Size: 32,
+		},
 	}, {
-		Tag:  names.NewFilesystemTag("2"),
-		Size: 16,
+		Tag: names.NewFilesystemTag("2"),
+		FilesystemInfo: storage.FilesystemInfo{
+			Size: 16,
+		},
 	}})
 }
 
@@ -165,7 +171,9 @@ func (s *tmpfsSuite) TestAttachFilesystemsAlreadyMounted(c *gc.C) {
 	}})
 	c.Assert(attachments, jc.DeepEquals, []storage.FilesystemAttachment{{
 		Filesystem: names.NewFilesystemTag("123"),
-		Path:       "exists",
+		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+			Path: "exists",
+		},
 	}})
 }
 
@@ -193,8 +201,10 @@ func (s *tmpfsSuite) TestAttachFilesystemsMountReadOnly(c *gc.C) {
 	c.Assert(attachments, jc.DeepEquals, []storage.FilesystemAttachment{{
 		Filesystem: names.NewFilesystemTag("1"),
 		Machine:    names.NewMachineTag("2"),
-		Path:       "/var/lib/juju/storage/fs/foo",
-		ReadOnly:   true,
+		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+			Path:     "/var/lib/juju/storage/fs/foo",
+			ReadOnly: true,
+		},
 	}})
 }
 

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -5,11 +5,16 @@ package storage
 
 import "github.com/juju/names"
 
-// Volume describes a volume (disk, logical volume, etc.)
+// Volume identifies and describes a volume (disk, logical volume, etc.)
 type Volume struct {
 	// Name is a unique name assigned by Juju to the volume.
 	Tag names.VolumeTag
 
+	VolumeInfo
+}
+
+// VolumeInfo describes a volume (disk, logical volume etc.)
+type VolumeInfo struct {
 	// VolumeId is a unique provider-supplied ID for the volume.
 	// VolumeId is required to be unique for the lifetime of the
 	// volume, but may be reused.
@@ -27,8 +32,9 @@ type Volume struct {
 	Persistent bool
 }
 
-// VolumeAttachment describes machine-specific volume attachment information,
-// including how the volume is exposed on the machine.
+// VolumeAttachment identifies and describes machine-specific volume
+// attachment information, including how the volume is exposed on the
+// machine.
 type VolumeAttachment struct {
 	// Volume is the unique tag assigned by Juju for the volume
 	// that this attachment corresponds to.
@@ -38,6 +44,12 @@ type VolumeAttachment struct {
 	// this attachment corresponds to.
 	Machine names.MachineTag
 
+	VolumeAttachmentInfo
+}
+
+// VolumeAttachmentInfo describes machine-specific volume attachment
+// information, including how the volume is exposed on the machine.
+type VolumeAttachmentInfo struct {
 	// DeviceName is the volume's OS-specific device name (e.g. "sdb").
 	//
 	// If the device name may change (e.g. on machine restart), then this

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -720,21 +720,21 @@ func volumesToApiserver(volumes []storage.Volume) []params.Volume {
 	for i, v := range volumes {
 		result[i] = params.Volume{
 			v.Tag.String(),
-			v.VolumeId,
-			v.HardwareId,
-			v.Size,
-			v.Persistent,
+			params.VolumeInfo{
+				v.VolumeId,
+				v.HardwareId,
+				v.Size,
+				v.Persistent,
+			},
 		}
 	}
 	return result
 }
 
-func volumeAttachmentsToApiserver(attachments []storage.VolumeAttachment) []params.VolumeAttachment {
-	result := make([]params.VolumeAttachment, len(attachments))
-	for i, a := range attachments {
-		result[i] = params.VolumeAttachment{
-			a.Volume.String(),
-			a.Machine.String(),
+func volumeAttachmentsToApiserver(attachments []storage.VolumeAttachment) map[string]params.VolumeAttachmentInfo {
+	result := make(map[string]params.VolumeAttachmentInfo)
+	for _, a := range attachments {
+		result[a.Volume.String()] = params.VolumeAttachmentInfo{
 			a.DeviceName,
 			a.ReadOnly,
 		}

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -851,12 +851,16 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithRequestedVolumes(c *gc.C)
 	}}
 	cons := constraints.MustParse(s.defaultConstraints.String(), "networks=^net3,^net4")
 	expectVolumeInfo := []storage.Volume{{
-		Tag:  names.NewVolumeTag("1"),
-		Size: 1024,
+		names.NewVolumeTag("1"),
+		storage.VolumeInfo{
+			Size: 1024,
+		},
 	}, {
-		Tag:        names.NewVolumeTag("2"),
-		Size:       2048,
-		Persistent: true,
+		names.NewVolumeTag("2"),
+		storage.VolumeInfo{
+			Size:       2048,
+			Persistent: true,
+		},
 	}}
 	m, err := s.addMachineWithRequestedVolumes(requestedVolumes, cons)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -603,8 +603,10 @@ func filesystemFromParams(in params.Filesystem) (storage.Filesystem, error) {
 	return storage.Filesystem{
 		filesystemTag,
 		volumeTag,
-		in.Info.FilesystemId,
-		in.Info.Size,
+		storage.FilesystemInfo{
+			in.Info.FilesystemId,
+			in.Info.Size,
+		},
 	}, nil
 }
 
@@ -620,8 +622,10 @@ func filesystemAttachmentFromParams(in params.FilesystemAttachment) (storage.Fil
 	return storage.FilesystemAttachment{
 		filesystemTag,
 		machineTag,
-		in.Info.MountPoint,
-		in.Info.ReadOnly,
+		storage.FilesystemAttachmentInfo{
+			in.Info.MountPoint,
+			in.Info.ReadOnly,
+		},
 	}, nil
 }
 

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -560,8 +560,10 @@ func filesystemsFromStorage(in []storage.Filesystem) []params.Filesystem {
 		paramsFilesystem := params.Filesystem{
 			f.Tag.String(),
 			"",
-			f.FilesystemId,
-			f.Size,
+			params.FilesystemInfo{
+				f.FilesystemId,
+				f.Size,
+			},
 		}
 		if f.Volume != (names.VolumeTag{}) {
 			paramsFilesystem.VolumeTag = f.Volume.String()
@@ -577,8 +579,10 @@ func filesystemAttachmentsFromStorage(in []storage.FilesystemAttachment) []param
 		out[i] = params.FilesystemAttachment{
 			f.Filesystem.String(),
 			f.Machine.String(),
-			f.Path,
-			f.ReadOnly,
+			params.FilesystemAttachmentInfo{
+				f.Path,
+				f.ReadOnly,
+			},
 		}
 	}
 	return out
@@ -599,8 +603,8 @@ func filesystemFromParams(in params.Filesystem) (storage.Filesystem, error) {
 	return storage.Filesystem{
 		filesystemTag,
 		volumeTag,
-		in.FilesystemId,
-		in.Size,
+		in.Info.FilesystemId,
+		in.Info.Size,
 	}, nil
 }
 
@@ -616,8 +620,8 @@ func filesystemAttachmentFromParams(in params.FilesystemAttachment) (storage.Fil
 	return storage.FilesystemAttachment{
 		filesystemTag,
 		machineTag,
-		in.MountPoint,
-		in.ReadOnly,
+		in.Info.MountPoint,
+		in.Info.ReadOnly,
 	}, nil
 }
 

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -444,18 +444,22 @@ func (*dummyVolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storag
 	for _, p := range params {
 		persistent, _ := p.Attributes["persistent"].(bool)
 		volumes = append(volumes, storage.Volume{
-			Tag:        p.Tag,
-			Size:       p.Size,
-			HardwareId: "serial-" + p.Tag.Id(),
-			VolumeId:   "id-" + p.Tag.Id(),
-			Persistent: persistent,
+			p.Tag,
+			storage.VolumeInfo{
+				Size:       p.Size,
+				HardwareId: "serial-" + p.Tag.Id(),
+				VolumeId:   "id-" + p.Tag.Id(),
+				Persistent: persistent,
+			},
 		})
 		if p.Attachment != nil {
 			volumeAttachments = append(volumeAttachments, storage.VolumeAttachment{
-				Volume:     p.Tag,
-				Machine:    p.Attachment.Machine,
-				DeviceName: "/dev/sda" + p.Tag.Id(),
-				ReadOnly:   p.Attachment.ReadOnly,
+				p.Tag,
+				p.Attachment.Machine,
+				storage.VolumeAttachmentInfo{
+					DeviceName: "/dev/sda" + p.Tag.Id(),
+					ReadOnly:   p.Attachment.ReadOnly,
+				},
 			})
 		}
 	}
@@ -473,9 +477,11 @@ func (*dummyVolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams)
 			panic("AttachVolumes called with unprovisioned machine")
 		}
 		volumeAttachments = append(volumeAttachments, storage.VolumeAttachment{
-			Volume:     p.Volume,
-			Machine:    p.Machine,
-			DeviceName: "/dev/sda" + p.Volume.Id(),
+			p.Volume,
+			p.Machine,
+			storage.VolumeAttachmentInfo{
+				DeviceName: "/dev/sda" + p.Volume.Id(),
+			},
 		})
 	}
 	return volumeAttachments, nil
@@ -490,9 +496,11 @@ func (*dummyFilesystemSource) CreateFilesystems(params []storage.FilesystemParam
 	var filesystems []storage.Filesystem
 	for _, p := range params {
 		filesystems = append(filesystems, storage.Filesystem{
-			Tag:          p.Tag,
-			Size:         p.Size,
-			FilesystemId: "id-" + p.Tag.Id(),
+			Tag: p.Tag,
+			FilesystemInfo: storage.FilesystemInfo{
+				Size:         p.Size,
+				FilesystemId: "id-" + p.Tag.Id(),
+			},
 		})
 	}
 	return filesystems, nil
@@ -509,9 +517,11 @@ func (*dummyFilesystemSource) AttachFilesystems(params []storage.FilesystemAttac
 			panic("AttachFilesystems called with unprovisioned machine")
 		}
 		filesystemAttachments = append(filesystemAttachments, storage.FilesystemAttachment{
-			Filesystem: p.Filesystem,
-			Machine:    p.Machine,
-			Path:       "/srv/" + p.FilesystemId,
+			p.Filesystem,
+			p.Machine,
+			storage.FilesystemAttachmentInfo{
+				Path: "/srv/" + p.FilesystemId,
+			},
 		})
 	}
 	return filesystemAttachments, nil
@@ -534,9 +544,11 @@ func (s *mockManagedFilesystemSource) CreateFilesystems(args []storage.Filesyste
 			return nil, errors.Errorf("filesystem %v's backing-volume is not attached", arg.Tag.Id())
 		}
 		filesystems = append(filesystems, storage.Filesystem{
-			Tag:          arg.Tag,
-			Size:         blockDevice.Size,
-			FilesystemId: blockDevice.DeviceName,
+			Tag: arg.Tag,
+			FilesystemInfo: storage.FilesystemInfo{
+				Size:         blockDevice.Size,
+				FilesystemId: blockDevice.DeviceName,
+			},
 		})
 	}
 	return filesystems, nil
@@ -560,10 +572,12 @@ func (s *mockManagedFilesystemSource) AttachFilesystems(args []storage.Filesyste
 			return nil, errors.Errorf("filesystem %v's backing-volume is not attached", filesystem.Tag.Id())
 		}
 		filesystemAttachments = append(filesystemAttachments, storage.FilesystemAttachment{
-			Filesystem: arg.Filesystem,
-			Machine:    arg.Machine,
-			Path:       "/mnt/" + blockDevice.DeviceName,
-			ReadOnly:   arg.ReadOnly,
+			arg.Filesystem,
+			arg.Machine,
+			storage.FilesystemAttachmentInfo{
+				Path:     "/mnt/" + blockDevice.DeviceName,
+				ReadOnly: arg.ReadOnly,
+			},
 		})
 	}
 	return filesystemAttachments, nil

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -68,26 +68,34 @@ func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
 
 func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 	expectedVolumes := []params.Volume{{
-		VolumeTag:  "volume-1",
-		VolumeId:   "id-1",
-		HardwareId: "serial-1",
-		Size:       1024,
-		Persistent: true,
+		VolumeTag: "volume-1",
+		Info: params.VolumeInfo{
+			VolumeId:   "id-1",
+			HardwareId: "serial-1",
+			Size:       1024,
+			Persistent: true,
+		},
 	}, {
-		VolumeTag:  "volume-2",
-		VolumeId:   "id-2",
-		HardwareId: "serial-2",
-		Size:       1024,
+		VolumeTag: "volume-2",
+		Info: params.VolumeInfo{
+			VolumeId:   "id-2",
+			HardwareId: "serial-2",
+			Size:       1024,
+		},
 	}}
 	expectedVolumeAttachments := []params.VolumeAttachment{{
 		VolumeTag:  "volume-1",
 		MachineTag: "machine-1",
-		DeviceName: "/dev/sda1",
-		ReadOnly:   true,
+		Info: params.VolumeAttachmentInfo{
+			DeviceName: "/dev/sda1",
+			ReadOnly:   true,
+		},
 	}, {
 		VolumeTag:  "volume-2",
 		MachineTag: "machine-1",
-		DeviceName: "/dev/sda2",
+		Info: params.VolumeAttachmentInfo{
+			DeviceName: "/dev/sda2",
+		},
 	}}
 
 	volumeInfoSet := make(chan interface{})
@@ -136,12 +144,16 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 func (s *storageProvisionerSuite) TestFilesystemAdded(c *gc.C) {
 	expectedFilesystems := []params.Filesystem{{
 		FilesystemTag: "filesystem-1",
-		FilesystemId:  "id-1",
-		Size:          1024,
+		Info: params.FilesystemInfo{
+			FilesystemId: "id-1",
+			Size:         1024,
+		},
 	}, {
 		FilesystemTag: "filesystem-2",
-		FilesystemId:  "id-2",
-		Size:          1024,
+		Info: params.FilesystemInfo{
+			FilesystemId: "id-2",
+			Size:         1024,
+		},
 	}}
 
 	filesystemInfoSet := make(chan interface{})
@@ -250,7 +262,9 @@ func (s *storageProvisionerSuite) TestVolumeAttachmentAdded(c *gc.C) {
 	expectedVolumeAttachments := []params.VolumeAttachment{{
 		VolumeTag:  "volume-1",
 		MachineTag: "machine-1",
-		DeviceName: "/dev/sda1",
+		Info: params.VolumeAttachmentInfo{
+			DeviceName: "/dev/sda1",
+		},
 	}}
 
 	volumeAttachmentInfoSet := make(chan interface{})
@@ -265,7 +279,9 @@ func (s *storageProvisionerSuite) TestVolumeAttachmentAdded(c *gc.C) {
 	// volume-1, machine-0, and machine-1 are provisioned.
 	volumeAccessor.provisionedVolumes["volume-1"] = params.Volume{
 		VolumeTag: "volume-1",
-		VolumeId:  "vol-123",
+		Info: params.VolumeInfo{
+			VolumeId: "vol-123",
+		},
 	}
 	volumeAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
 	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
@@ -321,7 +337,9 @@ func (s *storageProvisionerSuite) TestFilesystemAttachmentAdded(c *gc.C) {
 	expectedFilesystemAttachments := []params.FilesystemAttachment{{
 		FilesystemTag: "filesystem-1",
 		MachineTag:    "machine-1",
-		MountPoint:    "/srv/fs-123",
+		Info: params.FilesystemAttachmentInfo{
+			MountPoint: "/srv/fs-123",
+		},
 	}}
 
 	filesystemAttachmentInfoSet := make(chan interface{})
@@ -335,7 +353,9 @@ func (s *storageProvisionerSuite) TestFilesystemAttachmentAdded(c *gc.C) {
 	// filesystem-1 and machine-1 are provisioned.
 	filesystemAccessor.provisionedFilesystems["filesystem-1"] = params.Filesystem{
 		FilesystemTag: "filesystem-1",
-		FilesystemId:  "fs-123",
+		Info: params.FilesystemInfo{
+			FilesystemId: "fs-123",
+		},
 	}
 	filesystemAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
 	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
@@ -430,8 +450,10 @@ func (s *storageProvisionerSuite) TestCreateVolumeBackedFilesystem(c *gc.C) {
 	).([]params.Filesystem)
 	c.Assert(filesystemInfo, jc.DeepEquals, []params.Filesystem{{
 		FilesystemTag: "filesystem-0-0",
-		FilesystemId:  "xvdf1",
-		Size:          123,
+		Info: params.FilesystemInfo{
+			FilesystemId: "xvdf1",
+			Size:         123,
+		},
 	}})
 
 	// If we now attach the block device for volume 0/1 and trigger the
@@ -451,8 +473,10 @@ func (s *storageProvisionerSuite) TestCreateVolumeBackedFilesystem(c *gc.C) {
 	).([]params.Filesystem)
 	c.Assert(filesystemInfo, jc.DeepEquals, []params.Filesystem{{
 		FilesystemTag: "filesystem-0-1",
-		FilesystemId:  "xvdf2",
-		Size:          246,
+		Info: params.FilesystemInfo{
+			FilesystemId: "xvdf2",
+			Size:         246,
+		},
 	}})
 }
 
@@ -484,8 +508,10 @@ func (s *storageProvisionerSuite) TestAttachVolumeBackedFilesystem(c *gc.C) {
 	filesystemAccessor.provisionedFilesystems["filesystem-0-0"] = params.Filesystem{
 		FilesystemTag: "filesystem-0-0",
 		VolumeTag:     "volume-0-0",
-		FilesystemId:  "whatever",
-		Size:          123,
+		Info: params.FilesystemInfo{
+			FilesystemId: "whatever",
+			Size:         123,
+		},
 	}
 	filesystemAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
 
@@ -510,8 +536,10 @@ func (s *storageProvisionerSuite) TestAttachVolumeBackedFilesystem(c *gc.C) {
 	c.Assert(info, jc.DeepEquals, []params.FilesystemAttachment{{
 		FilesystemTag: "filesystem-0-0",
 		MachineTag:    "machine-0",
-		MountPoint:    "/mnt/xvdf1",
-		ReadOnly:      true,
+		Info: params.FilesystemAttachmentInfo{
+			MountPoint: "/mnt/xvdf1",
+			ReadOnly:   true,
+		},
 	}})
 }
 

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -565,10 +565,12 @@ func volumeFromParams(in params.Volume) (storage.Volume, error) {
 	}
 	return storage.Volume{
 		volumeTag,
-		in.Info.VolumeId,
-		in.Info.HardwareId,
-		in.Info.Size,
-		in.Info.Persistent,
+		storage.VolumeInfo{
+			in.Info.VolumeId,
+			in.Info.HardwareId,
+			in.Info.Size,
+			in.Info.Persistent,
+		},
 	}, nil
 }
 
@@ -584,8 +586,10 @@ func volumeAttachmentFromParams(in params.VolumeAttachment) (storage.VolumeAttac
 	return storage.VolumeAttachment{
 		volumeTag,
 		machineTag,
-		in.Info.DeviceName,
-		in.Info.ReadOnly,
+		storage.VolumeAttachmentInfo{
+			in.Info.DeviceName,
+			in.Info.ReadOnly,
+		},
 	}, nil
 }
 

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -532,10 +532,12 @@ func volumesFromStorage(in []storage.Volume) []params.Volume {
 	for i, v := range in {
 		out[i] = params.Volume{
 			v.Tag.String(),
-			v.VolumeId,
-			v.HardwareId,
-			v.Size,
-			v.Persistent,
+			params.VolumeInfo{
+				v.VolumeId,
+				v.HardwareId,
+				v.Size,
+				v.Persistent,
+			},
 		}
 	}
 	return out
@@ -547,8 +549,10 @@ func volumeAttachmentsFromStorage(in []storage.VolumeAttachment) []params.Volume
 		out[i] = params.VolumeAttachment{
 			v.Volume.String(),
 			v.Machine.String(),
-			v.DeviceName,
-			v.ReadOnly,
+			params.VolumeAttachmentInfo{
+				v.DeviceName,
+				v.ReadOnly,
+			},
 		}
 	}
 	return out
@@ -561,10 +565,10 @@ func volumeFromParams(in params.Volume) (storage.Volume, error) {
 	}
 	return storage.Volume{
 		volumeTag,
-		in.VolumeId,
-		in.HardwareId,
-		in.Size,
-		in.Persistent,
+		in.Info.VolumeId,
+		in.Info.HardwareId,
+		in.Info.Size,
+		in.Info.Persistent,
 	}, nil
 }
 
@@ -580,8 +584,8 @@ func volumeAttachmentFromParams(in params.VolumeAttachment) (storage.VolumeAttac
 	return storage.VolumeAttachment{
 		volumeTag,
 		machineTag,
-		in.DeviceName,
-		in.ReadOnly,
+		in.Info.DeviceName,
+		in.Info.ReadOnly,
 	}, nil
 }
 


### PR DESCRIPTION
In the API and in the storage package, we separate
volume/filesystem descriptions from their identities.
This enables us to fix the DescribeVolumes signature,
and reduces the amount of redundant information we
pass around in some cases.

The first two commits are mostly mechanical. The third
commit changes DescribeVolumes and implementations.

(Review request: http://reviews.vapour.ws/r/1750/)