### PR TITLE
apiserver/storageprovisioner: read-only coverage

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -514,6 +514,7 @@ func (st *State) machineStorageOps(mdoc *machineDoc, args *machineStorageParams)
 			filesystemTag, f.Attachment,
 		})
 		if volumeTag != (names.VolumeTag{}) {
+			// The filesystem requires a volume, so create a volume attachment too.
 			volumeAttachments = append(volumeAttachments, volumeAttachmentTemplate{
 				volumeTag, VolumeAttachmentParams{},
 			})


### PR DESCRIPTION
Improve test coverage related to read-only storage,
and fix a bug found in the process.

(Review request: http://reviews.vapour.ws/r/1751/)