### PR TITLE
Fixed lp:1442257 - port of #2366 to 1.25

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -704,6 +704,30 @@ func (s *provisionerSuite) TestContainerManagerConfigPermissive(c *gc.C) {
 	})
 }
 
+func (s *provisionerSuite) TestContainerManagerConfigLXCDefaultMTU(c *gc.C) {
+	var resultConfig = map[string]string{
+		"lxc-default-mtu": "9000",
+	}
+	var called bool
+	provisioner.PatchFacadeCall(s, s.provisioner, func(request string, args, response interface{}) error {
+		called = true
+		c.Assert(request, gc.Equals, "ContainerManagerConfig")
+		expected := params.ContainerManagerConfigParams{
+			Type: instance.LXC,
+		}
+		c.Assert(args, gc.Equals, expected)
+		result := response.(*params.ContainerManagerConfig)
+		result.ManagerConfig = resultConfig
+		return nil
+	})
+
+	args := params.ContainerManagerConfigParams{Type: instance.LXC}
+	result, err := s.provisioner.ContainerManagerConfig(args)
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.ManagerConfig, jc.DeepEquals, resultConfig)
+}
+
 func (s *provisionerSuite) TestContainerConfig(c *gc.C) {
 	result, err := s.provisioner.ContainerConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -84,20 +84,20 @@ func (s *UserDataSuite) TestGenerateNetworkConfig(c *gc.C) {
 	data, err := containerinit.GenerateNetworkConfig(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.HasLen, 0)
-	netConfig := container.BridgeNetworkConfig("foo", nil)
+	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	data, err = containerinit.GenerateNetworkConfig(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.HasLen, 0)
 
 	// Test with all interface types.
-	netConfig = container.BridgeNetworkConfig("foo", s.fakeInterfaces)
+	netConfig = container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
 	data, err = containerinit.GenerateNetworkConfig(netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.Equals, s.expectedNetConfig)
 }
 
 func (s *UserDataSuite) TestNewCloudInitConfigWithNetworks(c *gc.C) {
-	netConfig := container.BridgeNetworkConfig("foo", s.fakeInterfaces)
+	netConfig := container.BridgeNetworkConfig("foo", 0, s.fakeInterfaces)
 	cloudConf, err := containerinit.NewCloudInitConfigWithNetworks("quantal", netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	// We need to indent expectNetConfig to make it valid YAML,
@@ -117,7 +117,7 @@ bootcmd:
 }
 
 func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksNoConfig(c *gc.C) {
-	netConfig := container.BridgeNetworkConfig("foo", nil)
+	netConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	cloudConf, err := containerinit.NewCloudInitConfigWithNetworks("quantal", netConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := "#cloud-config\n{}\n"
@@ -127,7 +127,7 @@ func (s *UserDataSuite) TestNewCloudInitConfigWithNetworksNoConfig(c *gc.C) {
 func (s *UserDataSuite) TestCloudInitUserData(c *gc.C) {
 	instanceConfig, err := containertesting.MockMachineConfig("1/lxc/0")
 	c.Assert(err, jc.ErrorIsNil)
-	networkConfig := container.BridgeNetworkConfig("foo", nil)
+	networkConfig := container.BridgeNetworkConfig("foo", 0, nil)
 	data, err := containerinit.CloudInitUserData(instanceConfig, networkConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	// No need to test the exact contents here, as they are already

--- a/container/interface.go
+++ b/container/interface.go
@@ -18,6 +18,17 @@ const (
 	// supports networking.
 	ConfigIPForwarding = "ip-forwarding"
 
+	// ConfigEnableNAT, if set to a non-empty value, instructs the
+	// container manager to enable NAT for hosted containers. NAT is
+	// required for AWS, but should be disabled for MAAS.
+	ConfigEnableNAT = "enable-nat"
+
+	// ConfigLXCDefaultMTU, if set to a positive integer (serialized
+	// as a string), will cause all network interfaces on all created
+	// LXC containers (not KVM instances) to use the given MTU
+	// setting.
+	ConfigLXCDefaultMTU = "lxc-default-mtu"
+
 	DefaultNamespace = "juju"
 )
 

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -63,7 +63,7 @@ func (s *KVMSuite) TestListInitiallyEmpty(c *gc.C) {
 
 func (s *KVMSuite) createRunningContainer(c *gc.C, name string) kvm.Container {
 	kvmContainer := s.ContainerFactory.New(name)
-	network := container.BridgeNetworkConfig("testbr0", nil)
+	network := container.BridgeNetworkConfig("testbr0", 0, nil)
 	c.Assert(kvmContainer.Start(kvm.StartParams{
 		Series:       "quantal",
 		Arch:         version.Current.Arch,

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -87,7 +87,7 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, imagemetadata.ReleasedStream, "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	network := container.BridgeNetworkConfig("virbr0", nil)
+	network := container.BridgeNetworkConfig("virbr0", 0, nil)
 
 	instanceConfig.Tools = &tools.Tools{
 		Version: version.MustParseBinary("2.3.4-foo-bar"),

--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -14,7 +14,6 @@ var (
 	ParseConfigLine         = parseConfigLine
 	UpdateContainerConfig   = updateContainerConfig
 	ReorderNetworkConfig    = reorderNetworkConfig
-	DiscoverHostNIC         = &discoverHostNIC
 	NetworkConfigTemplate   = networkConfigTemplate
 	RestartSymlink          = restartSymlink
 	ReleaseVersion          = &releaseVersion

--- a/container/network.go
+++ b/container/network.go
@@ -18,6 +18,7 @@ const (
 type NetworkConfig struct {
 	NetworkType string
 	Device      string
+	MTU         int
 
 	Interfaces []network.InterfaceInfo
 }
@@ -25,17 +26,17 @@ type NetworkConfig struct {
 // BridgeNetworkConfig returns a valid NetworkConfig to use the
 // specified device as a network bridge for the container. It also
 // allows passing in specific configuration for the container's
-// network interfaces. If interfaces is nil the default configuration
-// is used for the respective container type.
-func BridgeNetworkConfig(device string, interfaces []network.InterfaceInfo) *NetworkConfig {
-	return &NetworkConfig{BridgeNetwork, device, interfaces}
+// network interfaces and default MTU to use. If interfaces is nil the
+// default configuration is used for the respective container type.
+func BridgeNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
+	return &NetworkConfig{BridgeNetwork, device, mtu, interfaces}
 }
 
 // PhysicalNetworkConfig returns a valid NetworkConfig to use the
 // specified device as the network device for the container. It also
 // allows passing in specific configuration for the container's
-// network interfaces. If interfaces is nil the default configuration
-// is used for the respective container type.
-func PhysicalNetworkConfig(device string, interfaces []network.InterfaceInfo) *NetworkConfig {
-	return &NetworkConfig{PhysicalNetwork, device, interfaces}
+// network interfaces and default MTU to use. If interfaces is nil the
+// default configuration is used for the respective container type.
+func PhysicalNetworkConfig(device string, mtu int, interfaces []network.InterfaceInfo) *NetworkConfig {
+	return &NetworkConfig{PhysicalNetwork, device, mtu, interfaces}
 }

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -57,7 +57,7 @@ func CreateContainerWithMachineConfig(
 	instanceConfig *instancecfg.InstanceConfig,
 ) instance.Instance {
 
-	networkConfig := container.BridgeNetworkConfig("nic42", nil)
+	networkConfig := container.BridgeNetworkConfig("nic42", 0, nil)
 	storageConfig := &container.StorageConfig{}
 	return CreateContainerWithMachineAndNetworkAndStorageConfig(c, manager, instanceConfig, networkConfig, storageConfig)
 }
@@ -114,7 +114,7 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 	}
 	instanceConfig.Config = envConfig
 
-	network := container.BridgeNetworkConfig("nic42", nil)
+	network := container.BridgeNetworkConfig("nic42", 0, nil)
 	storage := &container.StorageConfig{}
 
 	inst, hardware, err := manager.CreateContainer(instanceConfig, "quantal", network, storage)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -104,6 +104,9 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	} else if err != nil {
 		return err
 	}
+	if lxcMTU, ok := cfg.LXCDefaultMTU(); ok {
+		logger.Debugf("using MTU %v for all created LXC containers' network interfaces", lxcMTU)
+	}
 
 	// If we're uploading, we must override agent-version;
 	// if we're not uploading, we want to ensure we have an

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -88,6 +88,11 @@ const (
 	// Only prevent all-changes from running
 	// if user specifically requests it. Otherwise, let them run.
 	DefaultPreventAllChanges = false
+
+	// DefaultLXCDefaultMTU is the default value for "lxc-default-mtu"
+	// config setting. Only non-zero, positive integer values will
+	// have effect.
+	DefaultLXCDefaultMTU = 0
 )
 
 // TODO(katco-): Please grow this over time.
@@ -154,6 +159,11 @@ const (
 	// devices. A theoretical security issue, so must be explicitly
 	// allowed by the user.
 	AllowLXCLoopMounts = "allow-lxc-loop-mounts"
+
+	// LXCDefaultMTU, when set to a positive integer, overrides the
+	// Machine Transmission Unit (MTU) setting of all network
+	// interfaces created for LXC containers. See also bug #1442257.
+	LXCDefaultMTU = "lxc-default-mtu"
 
 	//
 	// Deprecated Settings Attributes
@@ -616,6 +626,11 @@ func Validate(cfg, old *Config) error {
 				return fmt.Errorf("cannot clear agent-version")
 			}
 		}
+	}
+
+	// Check LXCDefaultMTU is a positive integer, when set.
+	if lxcDefaultMTU, ok := cfg.LXCDefaultMTU(); ok && lxcDefaultMTU < 0 {
+		return errors.Errorf("%s: expected positive integer, got %v", LXCDefaultMTU, lxcDefaultMTU)
 	}
 
 	cfg.defined = ProcessDeprecatedAttributes(cfg.defined)
@@ -1100,6 +1115,16 @@ func (c *Config) LXCUseCloneAUFS() (bool, bool) {
 	return v, ok
 }
 
+// LXCDefaultMTU reports whether the LXC provisioner should create a
+// containers with a specific MTU value for all network intefaces.
+func (c *Config) LXCDefaultMTU() (int, bool) {
+	v, ok := c.defined[LXCDefaultMTU].(int)
+	if !ok {
+		return DefaultLXCDefaultMTU, false
+	}
+	return v, ok
+}
+
 // DisableNetworkManagement reports whether Juju is allowed to
 // configure and manage networking inside the environment.
 func (c *Config) DisableNetworkManagement() (bool, bool) {
@@ -1202,6 +1227,7 @@ var fields = schema.Fields{
 	"proxy-ssh":                  schema.Bool(),
 	LxcClone:                     schema.Bool(),
 	"lxc-clone-aufs":             schema.Bool(),
+	LXCDefaultMTU:                schema.ForceInt(),
 	"prefer-ipv6":                schema.Bool(),
 	"enable-os-refresh-update":   schema.Bool(),
 	"enable-os-upgrade":          schema.Bool(),
@@ -1251,6 +1277,7 @@ var alwaysOptional = schema.Defaults{
 	AptFtpProxyKey:               schema.Omit,
 	"apt-mirror":                 schema.Omit,
 	LxcClone:                     schema.Omit,
+	LXCDefaultMTU:                schema.Omit,
 	"disable-network-management": schema.Omit,
 	AgentStreamKey:               schema.Omit,
 	SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
@@ -1362,6 +1389,7 @@ var immutableAttributes = []string{
 	"bootstrap-retry-delay",
 	"bootstrap-addresses-delay",
 	LxcClone,
+	LXCDefaultMTU,
 	"lxc-clone-aufs",
 	"syslog-port",
 	"prefer-ipv6",

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -219,6 +219,39 @@ var configTests = []configTest{
 			"allow-lxc-loop-mounts": false,
 		},
 	}, {
+		about:       "LXC default MTU not set",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+		},
+	}, {
+		about:       "LXC default MTU set explicitly",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":            "my-type",
+			"name":            "my-name",
+			"lxc-default-mtu": 9000,
+		},
+	}, {
+		about:       "LXC default MTU invalid (not a number)",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":            "my-type",
+			"name":            "my-name",
+			"lxc-default-mtu": "foo",
+		},
+		err: `lxc-default-mtu: expected number, got string\("foo"\)`,
+	}, {
+		about:       "LXC default MTU invalid (negative)",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type":            "my-type",
+			"name":            "my-name",
+			"lxc-default-mtu": -42,
+		},
+		err: `lxc-default-mtu: expected positive integer, got -42`,
+	}, {
 		about:       "CA cert & key from path",
 		useDefaults: config.UseDefaults,
 		attrs: testing.Attrs{
@@ -1437,6 +1470,11 @@ var validationTests = []validationTest{{
 	old:   testing.Attrs{"lxc-clone-aufs": false},
 	new:   testing.Attrs{"lxc-clone-aufs": true},
 	err:   `cannot change lxc-clone-aufs from false to true`,
+}, {
+	about: "Cannot change lxc-default-mtu",
+	old:   testing.Attrs{"lxc-default-mtu": 9000},
+	new:   testing.Attrs{"lxc-default-mtu": 42},
+	err:   `cannot change lxc-default-mtu from 9000 to 42`,
 }, {
 	about: "Cannot change prefer-ipv6",
 	old:   testing.Attrs{"prefer-ipv6": false},

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -395,7 +395,7 @@ func (env *localEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 // Override for testing.
 var createContainer = func(env *localEnviron, args environs.StartInstanceParams) (instance.Instance, *instance.HardwareCharacteristics, error) {
 	series := args.Tools.OneSeries()
-	network := container.BridgeNetworkConfig(env.config.networkBridge(), args.NetworkInfo)
+	network := container.BridgeNetworkConfig(env.config.networkBridge(), 0, args.NetworkInfo)
 	allowLoopMounts, _ := env.config.AllowLXCLoopMounts()
 	isLXC := env.config.container() == instance.LXC
 	storage := &container.StorageConfig{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,6 +11,7 @@ const (
 	Joyent = "joyent"
 	Local  = "local"
 	MAAS   = "maas"
+	EC2    = "ec2"
 )
 
 // IsManual returns true iff the specified provider

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -5,6 +5,7 @@ package provisioner
 
 import (
 	"fmt"
+	"strconv"
 	"sync/atomic"
 
 	"github.com/juju/errors"
@@ -37,6 +38,8 @@ type ContainerSetup struct {
 	config                agent.Config
 	initLock              *fslock.Lock
 	addressableContainers bool
+	enableNAT             bool
+	lxcDefaultMTU         int
 
 	// Save the workerName so the worker thread can be stopped.
 	workerName string
@@ -242,6 +245,16 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		return nil, nil, nil, err
 	}
 
+	// Override default MTU for LXC NICs, if needed.
+	if mtu := managerConfig.PopValue(container.ConfigLXCDefaultMTU); mtu != "" {
+		value, err := strconv.Atoi(mtu)
+		if err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+		logger.Infof("setting MTU to %v for all LXC containers' interfaces", value)
+		cs.lxcDefaultMTU = value
+	}
+
 	// Enable IP forwarding and ARP proxying if needed.
 	if ipfwd := managerConfig.PopValue(container.ConfigIPForwarding); ipfwd != "" {
 		if err := setIPAndARPForwarding(true); err != nil {
@@ -249,6 +262,12 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		}
 		cs.addressableContainers = true
 		logger.Infof("enabled IP forwarding and ARP proxying for containers")
+	}
+
+	// Enable NAT if needed.
+	if nat := managerConfig.PopValue(container.ConfigEnableNAT); nat != "" {
+		cs.enableNAT = true
+		logger.Infof("enabling NAT for containers")
 	}
 
 	switch containerType {
@@ -259,7 +278,14 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		}
 
 		initialiser = lxc.NewContainerInitialiser(series)
-		broker, err = NewLxcBroker(cs.provisioner, cs.config, managerConfig, cs.imageURLGetter)
+		broker, err = NewLxcBroker(
+			cs.provisioner,
+			cs.config,
+			managerConfig,
+			cs.imageURLGetter,
+			cs.enableNAT,
+			cs.lxcDefaultMTU,
+		)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -272,7 +298,12 @@ func (cs *ContainerSetup) getContainerArtifacts(
 
 	case instance.KVM:
 		initialiser = kvm.NewContainerInitialiser()
-		broker, err = NewKvmBroker(cs.provisioner, cs.config, managerConfig)
+		broker, err = NewKvmBroker(
+			cs.provisioner,
+			cs.config,
+			managerConfig,
+			cs.enableNAT,
+		)
 		if err != nil {
 			logger.Errorf("failed to create new kvm broker")
 			return nil, nil, nil, err

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -51,7 +51,7 @@ var SetIPAndARPForwarding func(bool) error
 
 // SetupRoutesAndIPTables calls the internal setupRoutesAndIPTables
 // and the restores the mocked one.
-var SetupRoutesAndIPTables func(string, network.Address, string, []network.InterfaceInfo) error
+var SetupRoutesAndIPTables func(string, network.Address, string, []network.InterfaceInfo, bool) error
 
 func init() {
 	// In order to isolate the host machine from the running tests,
@@ -69,7 +69,7 @@ func init() {
 		func(bool) error { return nil },
 	)
 	mockSetupRoutesAndIPTablesValue := reflect.ValueOf(
-		func(string, network.Address, string, []network.InterfaceInfo) error { return nil },
+		func(string, network.Address, string, []network.InterfaceInfo, bool) error { return nil },
 	)
 	switchValues := func(newValue, oldValue reflect.Value) {
 		newValue.Set(oldValue)
@@ -82,9 +82,9 @@ func init() {
 		defer switchValues(newSetIPAndARPForwardingValue, mockSetIPAndARPForwardingValue)
 		return setIPAndARPForwarding(v)
 	}
-	SetupRoutesAndIPTables = func(nic string, addr network.Address, bridge string, ifinfo []network.InterfaceInfo) error {
+	SetupRoutesAndIPTables = func(nic string, addr network.Address, bridge string, ifinfo []network.InterfaceInfo, enableNAT bool) error {
 		switchValues(newSetupRoutesAndIPTablesValue, oldSetupRoutesAndIPTablesValue)
 		defer switchValues(newSetupRoutesAndIPTablesValue, mockSetupRoutesAndIPTablesValue)
-		return setupRoutesAndIPTables(nic, addr, bridge, ifinfo)
+		return setupRoutesAndIPTables(nic, addr, bridge, ifinfo, enableNAT)
 	}
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -86,7 +86,7 @@ func (s *kvmBrokerSuite) SetUpTest(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, s.agentConfig, managerConfig)
+	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, s.agentConfig, managerConfig, false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -234,7 +234,7 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 	machineTag := names.NewMachineTag("0")
 	agentConfig := s.AgentConfigForTag(c, machineTag)
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig)
+	broker, err := provisioner.NewKvmBroker(s.provisioner, agentConfig, managerConfig, false)
 	c.Assert(err, jc.ErrorIsNil)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
 	return provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker, toolsFinder)

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -46,8 +46,12 @@ var _ APICalls = (*apiprovisioner.State)(nil)
 var NewLxcBroker = newLxcBroker
 
 func newLxcBroker(
-	api APICalls, agentConfig agent.Config, managerConfig container.ManagerConfig,
+	api APICalls,
+	agentConfig agent.Config,
+	managerConfig container.ManagerConfig,
 	imageURLGetter container.ImageURLGetter,
+	enableNAT bool,
+	defaultMTU int,
 ) (environs.InstanceBroker, error) {
 	manager, err := lxc.NewContainerManager(managerConfig, imageURLGetter)
 	if err != nil {
@@ -57,6 +61,8 @@ func newLxcBroker(
 		manager:     manager,
 		api:         api,
 		agentConfig: agentConfig,
+		enableNAT:   enableNAT,
+		defaultMTU:  defaultMTU,
 	}, nil
 }
 
@@ -64,6 +70,8 @@ type lxcBroker struct {
 	manager     container.Manager
 	api         APICalls
 	agentConfig agent.Config
+	enableNAT   bool
+	defaultMTU  int
 }
 
 // StartInstance is specified in the Broker interface.
@@ -89,7 +97,13 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	} else {
 		logger.Debugf("trying to allocate static IP for container %q", machineId)
 		allocatedInfo, err := configureContainerNetwork(
-			machineId, bridgeDevice, broker.api, args.NetworkInfo, true)
+			machineId,
+			bridgeDevice,
+			broker.api,
+			args.NetworkInfo,
+			true, // allocate a new address.
+			broker.enableNAT,
+		)
 		if err != nil {
 			// It's fine, just ignore it. The effect will be that the
 			// container won't have a static address configured.
@@ -98,7 +112,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 			args.NetworkInfo = allocatedInfo
 		}
 	}
-	network := container.BridgeNetworkConfig(bridgeDevice, args.NetworkInfo)
+	network := container.BridgeNetworkConfig(bridgeDevice, broker.defaultMTU, args.NetworkInfo)
 
 	// The provisioner worker will provide all tools it knows about
 	// (after applying explicitly specified constraints), which may
@@ -350,6 +364,7 @@ var setupRoutesAndIPTables = func(
 	primaryAddr network.Address,
 	bridgeName string,
 	ifaceInfo []network.InterfaceInfo,
+	enableNAT bool,
 ) error {
 
 	if primaryNIC == "" || primaryAddr.Value == "" || bridgeName == "" || len(ifaceInfo) == 0 {
@@ -398,6 +413,11 @@ var setupRoutesAndIPTables = func(
 		}
 
 		for name, rule := range iptablesRules {
+			if !enableNAT && name == "iptablesSNAT" {
+				// Do not add the SNAT rule if we shouldn't enable
+				// NAT.
+				continue
+			}
 			if err := addRuleIfDoesNotExist(name, rule); err != nil {
 				return err
 			}
@@ -405,11 +425,15 @@ var setupRoutesAndIPTables = func(
 
 		// TODO(dooferlad): subnets should be a list of subnets in the EC2 VPC and
 		// should be empty for MAAS. See bug http://pad.lv/1443942
-		subnets := []string{data.HostIP + "/16"}
-		for _, subnet := range subnets {
-			data.SubnetCIDR = subnet
-			if err := addRuleIfDoesNotExist("skipSNAT", skipSNATRule); err != nil {
-				return err
+		if enableNAT {
+			// Only add the following hack to allow AWS egress traffic
+			// for hosted containers to work.
+			subnets := []string{data.HostIP + "/16"}
+			for _, subnet := range subnets {
+				data.SubnetCIDR = subnet
+				if err := addRuleIfDoesNotExist("skipSNAT", skipSNATRule); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -478,20 +502,23 @@ func discoverPrimaryNIC() (string, network.Address, error) {
 // while the rest is kept as-is.
 const MACAddressTemplate = "00:16:3e:xx:xx:xx"
 
-// configureContainerNetworking tries to allocate a static IP address for the
-// given containerId using the provisioner API. If it fails, it's not
-// critical - just a warning, and it won't cause StartInstance to
-// fail.
+// configureContainerNetworking tries to allocate a static IP address
+// for the given containerId using the provisioner API, when
+// allocateAddress is true. Otherwise it configures the container with
+// an already allocated address, when allocateAddress is false (e.g.
+// after a host reboot). If the API call fails, it's not critical -
+// just a warning, and it won't cause StartInstance to fail.
 func configureContainerNetwork(
 	containerId, bridgeDevice string,
 	apiFacade APICalls,
 	ifaceInfo []network.InterfaceInfo,
 	allocateAddress bool,
+	enableNAT bool,
 ) (finalIfaceInfo []network.InterfaceInfo, err error) {
 	defer func() {
 		if err != nil {
 			logger.Warningf(
-				"failed allocating a static IP for container %q: %v",
+				"failed configuring a static IP for container %q: %v",
 				containerId, err,
 			)
 		}
@@ -501,7 +528,6 @@ func configureContainerNetwork(
 		// When we already have interface info, don't overwrite it.
 		return nil, nil
 	}
-	logger.Debugf("trying to allocate a static IP for container %q", containerId)
 
 	var primaryNIC string
 	var primaryAddr network.Address
@@ -511,14 +537,16 @@ func configureContainerNetwork(
 	}
 
 	if allocateAddress {
+		logger.Debugf("trying to allocate a static IP for container %q", containerId)
 		finalIfaceInfo, err = apiFacade.PrepareContainerInterfaceInfo(names.NewMachineTag(containerId))
 	} else {
+		logger.Debugf("getting allocated static IP for container %q", containerId)
 		finalIfaceInfo, err = apiFacade.GetContainerInterfaceInfo(names.NewMachineTag(containerId))
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Debugf("PrepareContainerInterfaceInfo returned %#v", finalIfaceInfo)
+	logger.Debugf("container interface info result %#v", finalIfaceInfo)
 
 	// Populate ConfigType and DNSServers as needed.
 	var dnsServers []network.Address
@@ -541,7 +569,13 @@ func configureContainerNetwork(
 		finalIfaceInfo[i].DNSSearch = searchDomain
 		finalIfaceInfo[i].GatewayAddress = primaryAddr
 	}
-	err = setupRoutesAndIPTables(primaryNIC, primaryAddr, bridgeDevice, finalIfaceInfo)
+	err = setupRoutesAndIPTables(
+		primaryNIC,
+		primaryAddr,
+		bridgeDevice,
+		finalIfaceInfo,
+		enableNAT,
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -559,6 +593,13 @@ func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) err
 	if bridgeDevice == "" {
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
-	_, err := configureContainerNetwork(machineId, bridgeDevice, broker.api, args.NetworkInfo, false)
+	_, err := configureContainerNetwork(
+		machineId,
+		bridgeDevice,
+		broker.api,
+		args.NetworkInfo,
+		false, // don't allocate a new address.
+		broker.enableNAT,
+	)
 	return err
 }

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -106,7 +106,7 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 		"use-clone":          "false",
 	}
 	api := NewFakeAPI(c)
-	s.broker, err = provisioner.NewLxcBroker(&api, s.agentConfig, managerConfig, nil)
+	s.broker, err = provisioner.NewLxcBroker(&api, s.agentConfig, managerConfig, nil, false, 0)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -548,6 +548,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesInvalidArgs(c *gc.C) {
 			test.primaryAddr,
 			test.bridgeName,
 			test.ifaceInfo,
+			false, // TODO(dimitern): Untested.
 		)
 		c.Check(err, gc.ErrorMatches, test.expectErr)
 	}
@@ -563,7 +564,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesCheckError(c *gc.C) {
 	}}
 
 	addr := network.NewAddress("0.1.2.1")
-	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo, false)
 	c.Assert(err, gc.ErrorMatches, "iptables failed with unexpected exit code 42")
 }
 
@@ -589,7 +590,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPTablesAddError(c *gc.C) {
 	}}
 
 	addr := network.NewAddress("0.1.2.1")
-	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo, false)
 	c.Assert(err, gc.ErrorMatches, `command "iptables -t nat -I .*" failed with exit code 42`)
 }
 
@@ -604,7 +605,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesIPRouteError(c *gc.C) {
 	}}
 
 	addr := network.NewAddress("0.1.2.1")
-	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo, false)
 	c.Assert(err, gc.ErrorMatches,
 		`command "ip route add 0.1.2.3 dev bridge" failed with exit code 123`,
 	)
@@ -633,7 +634,7 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesAddsRuleIfMissing(c *gc.C) {
 	}}
 
 	addr := network.NewAddress("0.1.2.1")
-	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo)
+	err := provisioner.SetupRoutesAndIPTables("nic", addr, "bridge", ifaceInfo, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now verify the expected commands - since check returns 1, add
@@ -752,7 +753,7 @@ func (s *lxcBrokerSuite) TestDiscoverPrimaryNICSuccess(c *gc.C) {
 	c.Assert(addr, jc.DeepEquals, network.NewAddress("0.1.2.3"))
 }
 
-func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
+func (s *lxcBrokerSuite) TestConfigureContainerNetwork(c *gc.C) {
 	// All the pieces used by this func are separately tested, we just
 	// test the integration between them.
 	s.PatchValue(provisioner.NetInterfaces, func() ([]net.Interface, error) {
@@ -775,14 +776,14 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 	ifaceInfo := []network.InterfaceInfo{{DeviceIndex: 0}}
 	// First call as if we are configuring the container for the first time
 	api := NewFakeAPI(c)
-	result, err := provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, true)
+	result, err := provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, true, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.IsNil)
 	c.Assert(api.calls, gc.DeepEquals, []string{})
 
 	// Next call as if the container has already been configured.
 	api.calls = []string{}
-	result, err = provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, false)
+	result, err = provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.IsNil)
 	c.Assert(api.calls, gc.DeepEquals, []string{})
@@ -790,14 +791,14 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 	// Call as if the container already has a network configuration, but doesn't.
 	api = NewFakeAPI(c)
 	ifaceInfo = []network.InterfaceInfo{}
-	result, err = provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, false)
+	result, err = provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, false, false)
 	c.Assert(err, gc.ErrorMatches, "machine-42 has no network provisioning info not provisioned")
 	c.Assert(result, jc.DeepEquals, []network.InterfaceInfo{})
 	c.Assert(api.calls, gc.DeepEquals, []string{"GetContainerInterfaceInfo"})
 
 	// When it's not empty, result should be populated as expected.
 	api.calls = []string{}
-	result, err = provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, true)
+	result, err = provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, true, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:    0,
@@ -812,7 +813,7 @@ func (s *lxcBrokerSuite) TestMaybeAllocateStaticIP(c *gc.C) {
 	c.Assert(api.calls, gc.DeepEquals, []string{"PrepareContainerInterfaceInfo"})
 
 	api.calls = []string{}
-	result, err = provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, false)
+	result, err = provisioner.ConfigureContainerNetwork("42", "bridge", &api, ifaceInfo, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:    0,
@@ -930,7 +931,7 @@ func (s *lxcProvisionerSuite) newLxcProvisioner(c *gc.C) provisioner.Provisioner
 		"log-dir":            c.MkDir(),
 		"use-clone":          "false",
 	}
-	broker, err := provisioner.NewLxcBroker(s.provisioner, agentConfig, managerConfig, &containertesting.MockURLGetter{})
+	broker, err := provisioner.NewLxcBroker(s.provisioner, agentConfig, managerConfig, &containertesting.MockURLGetter{}, false, 0)
 	c.Assert(err, jc.ErrorIsNil)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
 	return provisioner.NewContainerProvisioner(instance.LXC, s.provisioner, agentConfig, broker, toolsFinder)


### PR DESCRIPTION
This includes 2 fixes for 1.25:

* http://pad.lv/1442257 - instead of inheriting LXC containers' host's
  primary NIC's MTU value for container NICs, now we have an optional
  integer environment setting "lxc-default-mtu", which when set to a
  positive number will cause all LXC (but not KVM) NICs to use that
  MTU. This is a straightforward port of #2365 to 1.25.
* Related, but not a fix for http://pad.lv/1443942 (originally proposed
  as #2190 but it didn't land in time) - only add iptables SNAT rules
  on the container hosts for EC2 environments, as this breaks MAAS and
  it's not needed (fallout from the original fix #2071 for bug
  http://pad.lv/1442801).

Live tested on MAAS and EC2 with the following configurations:
* bootstrap on trusty, add a precise node
* bootstrap on precise, add a trusty node
* in both cases above, do a test with and without the address-allocation
  feature flag
* deploy workloads and relate them in LXC and KVM

More unit tests around the enableNAT logic will be added later,
as described bug lp:1443942.