### PR TITLE
apiserver: fix data race in tests

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -336,11 +336,7 @@ func startPingerIfAgent(root *apiHandler, entity state.Entity) error {
 		}
 	}
 	pingTimeout := newPingTimeout(action, maxClientPingInterval)
-	err = root.getResources().RegisterNamed("pingTimeout", pingTimeout)
-	if err != nil {
-		return err
-	}
-	return nil
+	return root.getResources().RegisterNamed("pingTimeout", pingTimeout)
 }
 
 // errRoot implements the API that a client first sees

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -23,8 +23,6 @@ var (
 	NewPingTimeout        = newPingTimeout
 	MaxClientPingInterval = &maxClientPingInterval
 	MongoPingInterval     = &mongoPingInterval
-	NewTimer              = &newTimer
-	ResetTimer            = &resetTimer
 	NewBackups            = &newBackups
 	ParseLogLine          = parseLogLine
 	AgentMatchesFilter    = agentMatchesFilter

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -95,35 +95,21 @@ func (s *pingerSuite) TestAgentConnectionShutsDownWithNoPing(c *gc.C) {
 }
 
 func (s *pingerSuite) TestAgentConnectionDelaysShutdownWithPing(c *gc.C) {
-	var resetCount int
-	s.PatchValue(apiserver.ResetTimer, func(timer *time.Timer, d time.Duration) bool {
-		resetCount += 1
-		return timer.Reset(d)
-	})
-	// We patch out NewTimer so that we can call Reset on the timer
-	// right before we check the failure case below.
-	var timer *time.Timer
-	s.PatchValue(apiserver.NewTimer, func(d time.Duration) *time.Timer {
-		timer = time.NewTimer(d)
-		return timer
-	})
+	const shortTimeout = 20 * time.Millisecond
+	s.PatchValue(apiserver.MaxClientPingInterval, time.Duration(shortTimeout))
 
 	st, _ := s.OpenAPIAsNewMachine(c)
 	err := st.Ping()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// As long as we don't wait too long, the connection stays open
-	resetCount = 0
 	for i := 0; i < 10; i++ {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(shortTimeout / 2)
 		err = st.Ping()
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	c.Check(resetCount, gc.Equals, 10)
 
 	// However, once we stop pinging for too long, the connection dies
-	const shortTimeout = 10 * time.Millisecond
-	timer.Reset(shortTimeout)
 	time.Sleep(2 * shortTimeout) // Exceed the timeout.
 	err = st.Ping()
 	c.Assert(err, gc.ErrorMatches, "connection is shut down")


### PR DESCRIPTION
This PR removes the data race on the timer reference captured using PatchValue.
timer's cannot be reset across multiple goroutines, the only part that is safe
to use concurrently is the timer.C channel.

Resetting the timer was only used during the latter part of the test to avoid waiting
for the entire 3 minutes, so replace that with a call to set the timer to an initally
small value, then adjust the test to work around multiples of this value.

(Review request: http://reviews.vapour.ws/r/1762/)