### PR TITLE
cert: fix data race in checkTLSConnection

### DIFF
--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -226,55 +225,48 @@ func checkTLSConnection(c *gc.C, caCert, srvCert *x509.Certificate, srvKey *rsa.
 	clientCertPool := x509.NewCertPool()
 	clientCertPool.AddCert(caCert)
 
-	var inBytes, outBytes bytes.Buffer
+	var outBytes bytes.Buffer
 
 	const msg = "hello to the server"
 	p0, p1 := net.Pipe()
-	p0 = bufferedConn(p0, 3)
-	p0 = recordingConn(p0, &inBytes, &outBytes)
+	p0 = &recordingConn{
+		Conn:   p0,
+		Writer: io.MultiWriter(p0, &outBytes),
+	}
 
 	var clientState tls.ConnectionState
 	done := make(chan error)
 	go func() {
-		clientConn := tls.Client(p0, &tls.Config{
-			ServerName: "anyServer",
-			RootCAs:    clientCertPool,
-		})
-		defer clientConn.Close()
-
-		_, err := clientConn.Write([]byte(msg))
-		if err != nil {
-			done <- fmt.Errorf("client: %v", err)
-		}
-		clientState = clientConn.ConnectionState()
-		done <- nil
-	}()
-	go func() {
-		serverConn := tls.Server(p1, &tls.Config{
-			Certificates: []tls.Certificate{
-				newTLSCert(c, srvCert, srvKey),
-			},
-		})
-		defer serverConn.Close()
-		data, err := ioutil.ReadAll(serverConn)
-		if err != nil {
-			done <- fmt.Errorf("server: %v", err)
-			return
-		}
-		if string(data) != msg {
-			done <- fmt.Errorf("server: got %q; expected %q", data, msg)
-			return
+		config := tls.Config{
+			Certificates: []tls.Certificate{{
+				Certificate: [][]byte{srvCert.Raw},
+				PrivateKey:  srvKey,
+			}},
 		}
 
-		done <- nil
+		conn := tls.Server(p1, &config)
+		defer conn.Close()
+		data, err := ioutil.ReadAll(conn)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(string(data), gc.Equals, msg)
+		close(done)
 	}()
 
-	for i := 0; i < 2; i++ {
-		err := <-done
-		c.Check(err, jc.ErrorIsNil)
-	}
+	clientConn := tls.Client(p0, &tls.Config{
+		ServerName: "anyServer",
+		RootCAs:    clientCertPool,
+	})
+	defer clientConn.Close()
 
-	outData := string(outBytes.Bytes())
+	_, err := clientConn.Write([]byte(msg))
+	c.Check(err, jc.ErrorIsNil)
+	clientState = clientConn.ConnectionState()
+	clientConn.Close()
+
+	// wait for server to exit
+	<-done
+
+	outData := outBytes.String()
 	c.Assert(outData, gc.Not(gc.HasLen), 0)
 	if strings.Index(outData, msg) != -1 {
 		c.Fatalf("TLS connection not encrypted")
@@ -284,43 +276,13 @@ func checkTLSConnection(c *gc.C, caCert, srvCert *x509.Certificate, srvKey *rsa.
 	return clientState.VerifiedChains[0][1].Subject.CommonName
 }
 
-func newTLSCert(c *gc.C, cert *x509.Certificate, key *rsa.PrivateKey) tls.Certificate {
-	return tls.Certificate{
-		Certificate: [][]byte{cert.Raw},
-		PrivateKey:  key,
-	}
+type recordingConn struct {
+	net.Conn
+	io.Writer
 }
 
-// bufferedConn adds buffering for at least
-// n writes to the given connection.
-func bufferedConn(c net.Conn, n int) net.Conn {
-	for i := 0; i < n; i++ {
-		p0, p1 := net.Pipe()
-		go copyClose(p1, c)
-		go copyClose(c, p1)
-		c = p0
-	}
-	return c
-}
-
-// recordingConn returns a connection which
-// records traffic in or out of the given connection.
-func recordingConn(c net.Conn, in, out io.Writer) net.Conn {
-	p0, p1 := net.Pipe()
-	go func() {
-		io.Copy(io.MultiWriter(c, out), p1)
-		c.Close()
-	}()
-	go func() {
-		io.Copy(io.MultiWriter(p1, in), c)
-		p1.Close()
-	}()
-	return p0
-}
-
-func copyClose(w io.WriteCloser, r io.Reader) {
-	io.Copy(w, r)
-	w.Close()
+func (c recordingConn) Write(buf []byte) (int, error) {
+	return c.Writer.Write(buf)
 }
 
 // roundTime returns t rounded to the previous whole second.

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -259,7 +259,7 @@ func checkTLSConnection(c *gc.C, caCert, srvCert *x509.Certificate, srvKey *rsa.
 	defer clientConn.Close()
 
 	_, err := clientConn.Write([]byte(msg))
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	clientState = clientConn.ConnectionState()
 	clientConn.Close()
 


### PR DESCRIPTION
Fix data race on outBytes and make the test a whole lot simpler.

(Review request: http://reviews.vapour.ws/r/1764/)