### PR TITLE
Don't complain when destroying a machine that is about to be cleaned up

### DIFF
--- a/cmd/juju/removeservice.go
+++ b/cmd/juju/removeservice.go
@@ -19,12 +19,22 @@ type RemoveServiceCommand struct {
 	ServiceName string
 }
 
+const removeServiceDoc = `
+Removing a service will remove all its units and relations.
+
+If this is the only service running, the machine on which
+the service is hosted will also be destroyed, if possible.
+The machine will be destroyed if:
+- it is not a state server
+- it is not hosting any Juju managed containers
+`
+
 func (c *RemoveServiceCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-service",
 		Args:    "<service>",
 		Purpose: "remove a service from the environment",
-		Doc:     "Removing a service will remove all its units and relations.",
+		Doc:     removeServiceDoc,
 		Aliases: []string{"destroy-service"},
 	}
 }

--- a/cmd/juju/removeunit.go
+++ b/cmd/juju/removeunit.go
@@ -33,7 +33,8 @@ func (c *RemoveUnitCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-unit",
 		Args:    "<unit> [...]",
-		Purpose: removeUnitDoc,
+		Purpose: "remove service units from the environment",
+		Doc:     removeUnitDoc,
 		Aliases: []string{"destroy-unit"},
 	}
 }

--- a/cmd/juju/removeunit.go
+++ b/cmd/juju/removeunit.go
@@ -19,11 +19,21 @@ type RemoveUnitCommand struct {
 	UnitNames []string
 }
 
+const removeUnitDoc = `
+Remove service units from the environment.
+
+If this is the only unit running, the machine on which
+the unit is hosted will also be destroyed, if possible.
+The machine will be destroyed if:
+- it is not a state server
+- it is not hosting any Juju managed containers
+`
+
 func (c *RemoveUnitCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-unit",
 		Args:    "<unit> [...]",
-		Purpose: "remove service units from the environment",
+		Purpose: removeUnitDoc,
 		Aliases: []string{"destroy-unit"},
 	}
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -586,7 +586,6 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 		// then the machine may be soon destroyed by a cleanup worker.
 		// In that case, we don't want to return any error about not being able to
 		// destroy a machine with units as it will be a lie.
-		fmt.Println(m.doc.Principals)
 		if len(m.doc.Principals) == 1 {
 			// Get the sole unit and service on the machine.
 			u, err := m.st.Unit(m.doc.Principals[0])

--- a/state/machine.go
+++ b/state/machine.go
@@ -589,7 +589,9 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 		// destroy a machine with units as it will be a lie.
 		if life == Dying {
 			canDie := true
+			var principalUnitnames []string
 			for _, principalUnit := range m.doc.Principals {
+				principalUnitnames = append(principalUnitnames, principalUnit)
 				u, err := m.st.Unit(principalUnit)
 				if err != nil {
 					return nil, errors.Annotatef(err, "reading machine %s principal unit %v", m, m.doc.Principals[0])
@@ -613,7 +615,9 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 			if canDie {
 				checkUnits := bson.DocElem{
 					"$or", []bson.D{
-						{{"principals", bson.D{{"$size", len(m.doc.Principals)}}}},
+						// Sadly mgo doesn't support $eq so we need to hack around that.
+						{{"principals", bson.D{{"$not", bson.D{{"$ne", principalUnitnames}}}}}},
+						{{"principals", bson.D{{"$size", 0}}}},
 						{{"principals", bson.D{{"$exists", false}}}},
 					},
 				}

--- a/state/machine.go
+++ b/state/machine.go
@@ -615,8 +615,7 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 			if canDie {
 				checkUnits := bson.DocElem{
 					"$or", []bson.D{
-						// Sadly mgo doesn't support $eq so we need to hack around that.
-						{{"principals", bson.D{{"$not", bson.D{{"$ne", principalUnitnames}}}}}},
+						{{"principals", principalUnitnames}},
 						{{"principals", bson.D{{"$size", 0}}}},
 						{{"principals", bson.D{{"$exists", false}}}},
 					},

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -276,7 +276,7 @@ func (s *MachineSuite) TestLifeJobHostUnits(c *gc.C) {
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.Destroy()
-	c.Assert(err, gc.FitsTypeOf, &state.HasAssignedUnitsError{})
+	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
 	c.Assert(err, gc.ErrorMatches, `machine 1 has unit "wordpress/0" assigned`)
 	err1 := s.machine.EnsureDead()
 	c.Assert(err1, gc.DeepEquals, err)
@@ -345,7 +345,7 @@ func (s *MachineSuite) TestDestroyCancel(c *gc.C) {
 		c.Assert(unit.AssignToMachine(s.machine), gc.IsNil)
 	}).Check()
 	err = s.machine.Destroy()
-	c.Assert(err, gc.FitsTypeOf, &state.HasAssignedUnitsError{})
+	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
 }
 
 func (s *MachineSuite) TestDestroyContention(c *gc.C) {
@@ -363,7 +363,7 @@ func (s *MachineSuite) TestDestroyContention(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "machine 1 cannot advance lifecycle: state changing too quickly; try again soon")
 }
 
-func (s *MachineSuite) TestDestroyWithCleanupPending(c *gc.C) {
+func (s *MachineSuite) TestDestroyWithServiceDestroyPending(c *gc.C) {
 	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	unit, err := svc.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -375,10 +375,72 @@ func (s *MachineSuite) TestDestroyWithCleanupPending(c *gc.C) {
 	err = s.machine.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	// Machine is still advanced to Dying.
-	err = s.machine.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
 	life := s.machine.Life()
 	c.Assert(life, gc.Equals, state.Dying)
+}
+
+func (s *MachineSuite) TestDestroyFailsWhenNewUnitAdded(c *gc.C) {
+	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = svc.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		anotherSvc := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
+		anotherUnit, err := anotherSvc.AddUnit()
+		c.Assert(err, jc.ErrorIsNil)
+		err = anotherUnit.AssignToMachine(s.machine)
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+
+	err = s.machine.Destroy()
+	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
+	life := s.machine.Life()
+	c.Assert(life, gc.Equals, state.Alive)
+}
+
+func (s *MachineSuite) TestDestroyWithUnitDestroyPending(c *gc.C) {
+	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = unit.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	// Machine is still advanced to Dying.
+	life := s.machine.Life()
+	c.Assert(life, gc.Equals, state.Dying)
+}
+
+func (s *MachineSuite) TestDestroyFailsWhenNewContainerAdded(c *gc.C) {
+	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = svc.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		_, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
+			Series: "quantal",
+			Jobs:   []state.MachineJob{state.JobHostUnits},
+		}, s.machine.Id(), instance.LXC)
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+
+	err = s.machine.Destroy()
+	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
+	life := s.machine.Life()
+	c.Assert(life, gc.Equals, state.Alive)
 }
 
 func (s *MachineSuite) TestRemove(c *gc.C) {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -374,11 +374,11 @@ func (s *MachineSuite) TestDestroyWithCleanupPending(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	// Machine is not destroyed because cleanup worker will do it.
+	// Machine is still advanced to Dying.
 	err = s.machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	life := s.machine.Life()
-	c.Assert(life, gc.Equals, state.Alive)
+	c.Assert(life, gc.Equals, state.Dying)
 }
 
 func (s *MachineSuite) TestRemove(c *gc.C) {

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -109,12 +109,12 @@ func (mr *Machiner) Handle() error {
 		return fmt.Errorf("%s failed to set status stopped: %v", mr.tag, err)
 	}
 
-	// If the machine is Dying, it has no units,
-	// and can be safely set to Dead.
+	// Attempt to mark the machine Dead. If the
+	// machine still has units assigned, this
+	// will fail with CodeHasAssignedUnits. Once
+	// the units are removed, the watcher will
+	// trigger again and we'll reattempt.
 	if err := mr.machine.EnsureDead(); err != nil {
-		// The machine may have a unit assigned that is
-		// in the process of dying. So we'll wait till it's
-		// dead before removing this machine.
 		if params.IsCodeHasAssignedUnits(err) {
 			return nil
 		}

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -112,6 +112,12 @@ func (mr *Machiner) Handle() error {
 	// If the machine is Dying, it has no units,
 	// and can be safely set to Dead.
 	if err := mr.machine.EnsureDead(); err != nil {
+		// The machine may have a unit assigned that is
+		// in the process of dying. So we'll wait till it's
+		// dead before removing this machine.
+		if params.IsCodeHasAssignedUnits(err) {
+			return nil
+		}
 		return fmt.Errorf("%s failed to set machine to dead: %v", mr.tag, err)
 	}
 	return worker.ErrTerminateAgent


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1455158

Adds extra doc to service and unit destroy commands to explain that when the last unit is destroyed, the machine can also be cleaned up.

Add code to machine destroy to check that if there is a unit still on that machine, the service itself may be dying and thus the cleanup worker will eventually harvest the machine. So the machine destroy becomes a no-op and there's no error returned. Previously an error was returned which complained that the machine had assigned units, which it sort of did, but not alive for much longer and the user would get an error and see the machine destroyed anyway.

(Review request: http://reviews.vapour.ws/r/1766/)