### PR TITLE
Fixed lp:1456989 - port to 1.25 of the cloud-init 0.6.3 (precise) workaround

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -196,16 +196,35 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 		cmds = append(cmds, looper+cfg.paccmder.UpgradeCmd())
 	}
 
+	var pkgsWithTargetRelease []string
 	pkgs := cfg.Packages()
 	for i, _ := range pkgs {
 		pack := pkgs[i]
-		// apply --target-release, if required.
-		if config.SeriesRequiresCloudArchiveTools(cfg.series) && cfg.pacconfer.IsCloudArchivePackage(pack) {
-			pack = strings.Join(cfg.pacconfer.ApplyCloudArchiveTarget(pack), " ")
+		if pack == "--target-release" || len(pkgsWithTargetRelease) > 0 {
+			// We have --target-release foo/bar package. Accumulate
+			// the args until we've reached the package, before
+			// passing the 3 element slice to InstallCmd below.
+			pkgsWithTargetRelease = append(pkgsWithTargetRelease, pack)
+			if len(pkgsWithTargetRelease) < 3 {
+				// We expect exactly 3 elements, the last one being
+				// the package.
+				continue
+			}
+		}
+		packageName := pack
+		installArgs := []string{pack}
+
+		if len(pkgsWithTargetRelease) == 3 {
+			// If we have a --target-release package, build the
+			// install command args from the accumulated
+			// pkgsWithTargetRelease slice and reset it.
+			installArgs = append([]string{}, pkgsWithTargetRelease...)
+			packageName = strings.Join(installArgs, " ")
+			pkgsWithTargetRelease = []string{}
 		}
 
-		cmds = append(cmds, LogProgressCmd("Installing package: %s", pkgs[i]))
-		cmd := looper + cfg.paccmder.InstallCmd(pack)
+		cmds = append(cmds, LogProgressCmd("Installing package: %s", packageName))
+		cmd := looper + cfg.paccmder.InstallCmd(installArgs...)
 		cmds = append(cmds, cmd)
 	}
 
@@ -263,9 +282,15 @@ func (cfg *ubuntuCloudConfig) addRequiredPackages() {
 	for _, pack := range packages {
 		if config.SeriesRequiresCloudArchiveTools(cfg.series) && cfg.pacconfer.IsCloudArchivePackage(pack) {
 			// On precise, we need to pass a --target-release entry in
-			// pieces for it to work:
-			// TODO (aznashwan): figure out what the hell precise wants.
-			cfg.AddPackage(strings.Join(cfg.pacconfer.ApplyCloudArchiveTarget(pack), " "))
+			// pieces (as "packages") for it to work:
+			// --target-release, precise-updates/cloud-tools,
+			// package-name. All these 3 entries are needed so
+			// cloud-init 0.6.3 can generate the correct apt-get
+			// install command line for "package-name".
+			args := cfg.pacconfer.ApplyCloudArchiveTarget(pack)
+			for _, arg := range args {
+				cfg.AddPackage(arg)
+			}
 		} else {
 			cfg.AddPackage(pack)
 		}

--- a/container/lxc/initialisation_test.go
+++ b/container/lxc/initialisation_test.go
@@ -50,8 +50,8 @@ func (s *InitialiserSuite) TestLTSSeriesPackages(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.calledCmds, gc.DeepEquals, []string{
-		paccmder.InstallCmd("--target-release precise-updates/cloud-tools lxc"),
-		paccmder.InstallCmd("--target-release precise-updates/cloud-tools cloud-image-utils"),
+		paccmder.InstallCmd("--target-release", "precise-updates/cloud-tools", "lxc"),
+		paccmder.InstallCmd("--target-release", "precise-updates/cloud-tools", "cloud-image-utils"),
 	})
 }
 


### PR DESCRIPTION
Reintroducing a change which was dropped with the introduction of CentOS
support (#2066): cloud-init 0.6.3 needs special handling for packages
needing the cloud-tools repo (precise-updates/cloud-tools). Without this
fix, deploying to precise fails at cloud-init time with errors running
apt-get install. For more details see http://pad.lv/1456989.

This ports #2395 to 1.25, no other changes.

Live tested on MAAS and EC2.

(Review request: http://reviews.vapour.ws/r/1769/)