### PR TITLE
Adjust error messages to be compatible with Go 1.5

### DIFF
--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -287,6 +287,6 @@ func (s *JujuCMainSuite) TestBadSockPath(c *gc.C) {
 	}
 	badSock := filepath.Join(c.MkDir(), "bad.sock")
 	output := run(c, badSock, "bill", 1, "remote")
-	err := fmt.Sprintf("error: dial unix %s: .*\n", badSock)
+	err := fmt.Sprintf(".*%s: .* no such file or directory\n", badSock)
 	c.Assert(output, gc.Matches, err)
 }

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -287,6 +287,6 @@ func (s *JujuCMainSuite) TestBadSockPath(c *gc.C) {
 	}
 	badSock := filepath.Join(c.MkDir(), "bad.sock")
 	output := run(c, badSock, "bill", 1, "remote")
-	err := fmt.Sprintf(".*%s: .* no such file or directory\n", badSock)
+	err := fmt.Sprintf(".*%s:.*no such file or directory\n", badSock)
 	c.Assert(output, gc.Matches, err)
 }

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -206,7 +206,7 @@ func (s *RunTestSuite) TestMissingSocket(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = testing.RunCommand(c, &RunCommand{}, "foo/1", "bar")
-	c.Assert(err, gc.ErrorMatches, `dial unix .*/run.socket: .* `+utils.NoSuchFileErrRegexp)
+	c.Assert(err, gc.ErrorMatches, `dial unix .*/run.socket:.*`+utils.NoSuchFileErrRegexp)
 }
 
 func (s *RunTestSuite) TestRunning(c *gc.C) {

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -206,7 +206,7 @@ func (s *RunTestSuite) TestMissingSocket(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = testing.RunCommand(c, &RunCommand{}, "foo/1", "bar")
-	c.Assert(err, gc.ErrorMatches, `dial unix .*/run.socket: `+utils.NoSuchFileErrRegexp)
+	c.Assert(err, gc.ErrorMatches, `dial unix .*/run.socket: .* `+utils.NoSuchFileErrRegexp)
 }
 
 func (s *RunTestSuite) TestRunning(c *gc.C) {


### PR DESCRIPTION
Make test compatible with Go 1.2 and Go 1.4+

(Review request: http://reviews.vapour.ws/r/1773/)