### PR TITLE
cmd/jujud/agent: fix data race in test

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1319,7 +1319,7 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 
-	var numWorkers uint32
+	var numWorkers, machineWorkers, environWorkers uint32
 	started := make(chan struct{})
 	newWorker := func(
 		scope names.Tag,
@@ -1329,19 +1329,18 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 		_ storageprovisioner.LifecycleManager,
 		_ storageprovisioner.EnvironAccessor,
 	) worker.Worker {
-		var machineWorkerStarted, environWorkerStarted bool
 		// storageDir is empty for environ storage provisioners
 		if storageDir == "" {
 			c.Check(scope, gc.Equals, s.State.EnvironTag())
-			environWorkerStarted = true
+			c.Assert(atomic.CompareAndSwapUint32(&environWorkers, 0, 1), gc.Equals, uint32(1))
 			atomic.AddUint32(&numWorkers, 1)
 		}
 		if storageDir != "" {
 			c.Check(scope, gc.Equals, m.Tag())
-			machineWorkerStarted = true
+			c.Assert(atomic.CompareAndSwapUint32(&machineWorkers, 0, 1), gc.Equals, uint32(1))
 			atomic.AddUint32(&numWorkers, 1)
 		}
-		if environWorkerStarted && machineWorkerStarted {
+		if atomic.LoadUint32(&environWorkers) == 1 && atomic.LoadUint32(&machineWorkers) == 1 {
 			close(started)
 		}
 		return worker.NewNoOpWorker()

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1332,12 +1332,12 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 		// storageDir is empty for environ storage provisioners
 		if storageDir == "" {
 			c.Check(scope, gc.Equals, s.State.EnvironTag())
-			c.Assert(atomic.CompareAndSwapUint32(&environWorkers, 0, 1), gc.Equals, uint32(1))
+			c.Check(atomic.AddUint32(&environWorkers, 1), gc.Equals, uint32(1))
 			atomic.AddUint32(&numWorkers, 1)
 		}
 		if storageDir != "" {
 			c.Check(scope, gc.Equals, m.Tag())
-			c.Assert(atomic.CompareAndSwapUint32(&machineWorkers, 0, 1), gc.Equals, uint32(1))
+			c.Check(atomic.AddUint32(&machineWorkers, 1), gc.Equals, uint32(1))
 			atomic.AddUint32(&numWorkers, 1)
 		}
 		if atomic.LoadUint32(&environWorkers) == 1 && atomic.LoadUint32(&machineWorkers) == 1 {

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -6,8 +6,9 @@
 package vsphere
 
 import (
-	"github.com/juju/errors"
 	"strings"
+
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -6,9 +6,10 @@
 package vsphere_test
 
 import (
+	"os"
+
 	"github.com/juju/errors"
 	gc "gopkg.in/check.v1"
-	"os"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"

--- a/provider/vsphere/ssh_client.go
+++ b/provider/vsphere/ssh_client.go
@@ -7,9 +7,10 @@ package vsphere
 
 import (
 	"fmt"
-	"github.com/juju/errors"
 	"strconv"
 	"strings"
+
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/utils/ssh"


### PR DESCRIPTION
Fix data race in test by using atomics for the counter and moving variables captured via an anon closure into the closure.

(Review request: http://reviews.vapour.ws/r/1774/)