### PR TITLE
jujuc: send stdin to server

### DIFF
--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -4,9 +4,11 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -165,14 +167,21 @@ func (c *RemoteCommand) Run(ctx *cmd.Context) error {
 	if c.msg != "" {
 		return errors.New(c.msg)
 	}
-	fmt.Fprintf(ctx.Stdout, "success!\n")
+	n, err := io.Copy(ctx.Stdout, ctx.Stdin)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		fmt.Fprintf(ctx.Stdout, "success!\n")
+	}
 	return nil
 }
 
-func run(c *gc.C, sockPath string, contextId string, exit int, cmd ...string) string {
+func run(c *gc.C, sockPath string, contextId string, exit int, stdin []byte, cmd ...string) string {
 	args := append([]string{"-test.run", "TestRunMain", "-run-main", "--"}, cmd...)
 	c.Logf("check %v %#v", os.Args[0], args)
 	ps := exec.Command(os.Args[0], args...)
+	ps.Stdin = bytes.NewBuffer(stdin)
 	ps.Dir = c.MkDir()
 	ps.Env = []string{
 		fmt.Sprintf("JUJU_AGENT_SOCKET=%s", sockPath),
@@ -252,7 +261,7 @@ func (s *JujuCMainSuite) TestArgs(c *gc.C) {
 	}
 	for _, t := range argsTests {
 		c.Log(t.args)
-		output := run(c, s.sockPath, "bill", t.code, t.args...)
+		output := run(c, s.sockPath, "bill", t.code, nil, t.args...)
 		c.Assert(output, gc.Equals, t.output)
 	}
 }
@@ -261,7 +270,7 @@ func (s *JujuCMainSuite) TestNoClientId(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, s.sockPath, "", 1, "remote")
+	output := run(c, s.sockPath, "", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: JUJU_CONTEXT_ID not set\n")
 }
 
@@ -269,7 +278,7 @@ func (s *JujuCMainSuite) TestBadClientId(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, s.sockPath, "ben", 1, "remote")
+	output := run(c, s.sockPath, "ben", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: bad request: bad context: ben\n")
 }
 
@@ -277,7 +286,7 @@ func (s *JujuCMainSuite) TestNoSockPath(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, "", "bill", 1, "remote")
+	output := run(c, "", "bill", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: JUJU_AGENT_SOCKET not set\n")
 }
 
@@ -286,7 +295,15 @@ func (s *JujuCMainSuite) TestBadSockPath(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	badSock := filepath.Join(c.MkDir(), "bad.sock")
-	output := run(c, badSock, "bill", 1, "remote")
+	output := run(c, badSock, "bill", 1, nil, "remote")
 	err := fmt.Sprintf("error: dial unix %s: .*\n", badSock)
 	c.Assert(output, gc.Matches, err)
+}
+
+func (s *JujuCMainSuite) TestStdin(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
+	}
+	output := run(c, s.sockPath, "bill", 0, []byte("some standard input"), "remote")
+	c.Assert(output, gc.Equals, "some standard input")
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -29,7 +29,7 @@ github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-30T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	a3720f880a5787622a21fbf718a3ac9d551dbe9c	2015-04-10T20:58:11Z
 github.com/juju/txn	git	5c38fee875d088643ebe2074f308d79680578ba7	2015-05-21T12:30:32Z
-github.com/juju/utils	git	4a0d9395ff427578c988ffc7709a17dd4608231e	2015-05-08T17:09:17Z
+github.com/juju/utils	git	054b2566beb7c16c4fb790fbaae32543ef528cdb	2015-05-27T01:53:34Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T00:00:00Z

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -96,6 +96,7 @@ type Request struct {
 	Dir         string
 	CommandName string
 	Args        []string
+	Stdin       []byte
 }
 
 // CmdGetter looks up a Command implementation connected to a particular Context.
@@ -125,10 +126,10 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 	if err != nil {
 		return badReqErrorf("%s", err)
 	}
-	var stdin, stdout, stderr bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	ctx := &cmd.Context{
 		Dir:    req.Dir,
-		Stdin:  &stdin,
+		Stdin:  bytes.NewBuffer(req.Stdin),
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -7,6 +7,7 @@ package jujuc_test
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -55,6 +56,9 @@ func (c *RpcCommand) Run(ctx *cmd.Context) error {
 	if c.Slow {
 		time.Sleep(testing.ShortWait)
 		return nil
+	}
+	if _, err := io.Copy(ctx.Stdout, ctx.Stdin); err != nil {
+		return err
 	}
 	ctx.Stdout.Write([]byte("eye of newt\n"))
 	ctx.Stderr.Write([]byte("toe of frog\n"))
@@ -122,10 +126,11 @@ func (s *ServerSuite) TestHappyPath(c *gc.C) {
 	dir := c.MkDir()
 	resp, err := s.Call(c, jujuc.Request{
 		"validCtx", dir, "remote", []string{"--value", "something"},
+		[]byte("wool of bat\n"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.Code, gc.Equals, 0)
-	c.Assert(string(resp.Stdout), gc.Equals, "eye of newt\n")
+	c.Assert(string(resp.Stdout), gc.Equals, "wool of bat\neye of newt\n")
 	c.Assert(string(resp.Stderr), gc.Equals, "toe of frog\n")
 	content, err := ioutil.ReadFile(filepath.Join(dir, "local"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -140,7 +145,7 @@ func (s *ServerSuite) TestLocks(c *gc.C) {
 		go func() {
 			dir := c.MkDir()
 			resp, err := s.Call(c, jujuc.Request{
-				"validCtx", dir, "remote", []string{"--slow"},
+				"validCtx", dir, "remote", []string{"--slow"}, nil,
 			})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(resp.Code, gc.Equals, 0)
@@ -154,16 +159,16 @@ func (s *ServerSuite) TestLocks(c *gc.C) {
 
 func (s *ServerSuite) TestBadCommandName(c *gc.C) {
 	dir := c.MkDir()
-	_, err := s.Call(c, jujuc.Request{"validCtx", dir, "", nil})
+	_, err := s.Call(c, jujuc.Request{"validCtx", dir, "", nil, nil})
 	c.Assert(err, gc.ErrorMatches, "bad request: command not specified")
-	_, err = s.Call(c, jujuc.Request{"validCtx", dir, "witchcraft", nil})
+	_, err = s.Call(c, jujuc.Request{"validCtx", dir, "witchcraft", nil, nil})
 	c.Assert(err, gc.ErrorMatches, `bad request: unknown command "witchcraft"`)
 }
 
 func (s *ServerSuite) TestBadDir(c *gc.C) {
 	for _, req := range []jujuc.Request{
-		{"validCtx", "", "anything", nil},
-		{"validCtx", "foo/bar", "anything", nil},
+		{"validCtx", "", "anything", nil, nil},
+		{"validCtx", "foo/bar", "anything", nil, nil},
 	} {
 		_, err := s.Call(c, req)
 		c.Assert(err, gc.ErrorMatches, "bad request: Dir is not absolute")
@@ -171,12 +176,12 @@ func (s *ServerSuite) TestBadDir(c *gc.C) {
 }
 
 func (s *ServerSuite) TestBadContextId(c *gc.C) {
-	_, err := s.Call(c, jujuc.Request{"whatever", c.MkDir(), "remote", nil})
+	_, err := s.Call(c, jujuc.Request{"whatever", c.MkDir(), "remote", nil, nil})
 	c.Assert(err, gc.ErrorMatches, `bad request: unknown context "whatever"`)
 }
 
 func (s *ServerSuite) AssertBadCommand(c *gc.C, args []string, code int) exec.ExecResponse {
-	resp, err := s.Call(c, jujuc.Request{"validCtx", c.MkDir(), args[0], args[1:]})
+	resp, err := s.Call(c, jujuc.Request{"validCtx", c.MkDir(), args[0], args[1:], nil})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.Code, gc.Equals, code)
 	return resp


### PR DESCRIPTION
Send stdin to the uniter's RPC server when invoking
jujuc commands. This enables the user to pipe data
to jujuc commands.

Fixes https://bugs.launchpad.net/juju-core/+bug/1454678

(Review request: http://reviews.vapour.ws/r/1776/)