### PR TITLE
Change worker/resumer to use the API instead

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -41,6 +41,7 @@ var facadeVersions = map[string]int{
 	"Provisioner":                  0,
 	"Reboot":                       1,
 	"RelationUnitsWatcher":         0,
+	"Resumer":                      1,
 	"Rsyslog":                      0,
 	"Service":                      1,
 	"Storage":                      1,

--- a/api/resumer/package_test.go
+++ b/api/resumer/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/api/resumer/package_test.go
+++ b/api/resumer/package_test.go
@@ -4,11 +4,11 @@
 package resumer_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
-func TestAll(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
 }

--- a/api/resumer/resumer.go
+++ b/api/resumer/resumer.go
@@ -1,0 +1,27 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer
+
+import (
+	"github.com/juju/juju/api/base"
+)
+
+const resumerFacade = "Resumer"
+
+// API provides access to the Resumer API facade.
+type API struct {
+	facade base.FacadeCaller
+}
+
+// NewAPI creates a new client-side Resumer facade.
+func NewAPI(caller base.APICaller) *API {
+	facadeCaller := base.NewFacadeCaller(caller, resumerFacade)
+	return &API{facade: facadeCaller}
+
+}
+
+// ResumeTransactions calls the server-side ResumeTransactions method.
+func (api *API) ResumeTransactions() error {
+	return api.facade.FacadeCall("ResumeTransactions", nil, nil)
+}

--- a/api/resumer/resumer_test.go
+++ b/api/resumer/resumer_test.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/resumer"
+	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+)
+
+type ResumerSuite struct {
+	testing.JujuConnSuite
+
+	st      *api.State
+	resumer *resumer.API
+}
+
+var _ = gc.Suite(&ResumerSuite{})
+
+func (s *ResumerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	apiState, _ := s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
+	// Create the machiner API facade.
+	s.resumer = apiState.Resumer()
+	c.Assert(s.resumer, gc.NotNil)
+}
+
+func (s *ResumerSuite) TestResumeTransactions(c *gc.C) {
+	err := s.resumer.ResumeTransactions()
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/api/state.go
+++ b/api/state.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/api/networker"
 	"github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/api/reboot"
+	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/rsyslog"
 	"github.com/juju/juju/api/storageprovisioner"
 	"github.com/juju/juju/api/uniter"
@@ -235,6 +236,12 @@ func (st *State) Client() *Client {
 // required by the machiner worker.
 func (st *State) Machiner() *machiner.State {
 	return machiner.NewState(st)
+}
+
+// Resumer returns a version of the state that provides functionality
+// required by the resumer worker.
+func (st *State) Resumer() *resumer.API {
+	return resumer.NewAPI(st)
 }
 
 // Networker returns a version of the state that provides functionality

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/juju/juju/apiserver/networker"
 	_ "github.com/juju/juju/apiserver/provisioner"
 	_ "github.com/juju/juju/apiserver/reboot"
+	_ "github.com/juju/juju/apiserver/resumer"
 	_ "github.com/juju/juju/apiserver/rsyslog"
 	_ "github.com/juju/juju/apiserver/service"
 	_ "github.com/juju/juju/apiserver/storage"

--- a/apiserver/resumer/export_test.go
+++ b/apiserver/resumer/export_test.go
@@ -1,0 +1,20 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer
+
+import (
+	"github.com/juju/juju/state"
+)
+
+type StateInterface stateInterface
+
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}
+
+func PatchState(p Patcher, st StateInterface) {
+	p.PatchValue(&getState, func(*state.State) stateInterface {
+		return st
+	})
+}

--- a/apiserver/resumer/package_test.go
+++ b/apiserver/resumer/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/resumer/package_test.go
+++ b/apiserver/resumer/package_test.go
@@ -4,11 +4,11 @@
 package resumer_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
-func TestAll(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
 }

--- a/apiserver/resumer/resumer.go
+++ b/apiserver/resumer/resumer.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The resumer package implements the API interface
+// used by the resumer worker.
+package resumer
+
+import (
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("Resumer", 1, NewResumerAPI)
+}
+
+var logger = loggo.GetLogger("juju.apiserver.resumer")
+
+// ResumerAPI implements the API used by the resumer worker.
+type ResumerAPI struct {
+	st   *state.State
+	auth common.Authorizer
+}
+
+// NewResumerAPI creates a new instance of the Resumer API.
+func NewResumerAPI(st *state.State, _ *common.Resources, authorizer common.Authorizer) (*ResumerAPI, error) {
+	if !authorizer.AuthEnvironManager() {
+		return nil, common.ErrPerm
+	}
+	return &ResumerAPI{
+		st:   st,
+		auth: authorizer,
+	}, nil
+}
+
+func (api *ResumerAPI) ResumeTransactions() error {
+	return api.st.ResumeTransactions()
+}

--- a/apiserver/resumer/resumer.go
+++ b/apiserver/resumer/resumer.go
@@ -20,7 +20,7 @@ var logger = loggo.GetLogger("juju.apiserver.resumer")
 
 // ResumerAPI implements the API used by the resumer worker.
 type ResumerAPI struct {
-	st   *state.State
+	st   stateInterface
 	auth common.Authorizer
 }
 
@@ -30,7 +30,7 @@ func NewResumerAPI(st *state.State, _ *common.Resources, authorizer common.Autho
 		return nil, common.ErrPerm
 	}
 	return &ResumerAPI{
-		st:   st,
+		st:   getState(st),
 		auth: authorizer,
 	}, nil
 }

--- a/apiserver/resumer/resumer_test.go
+++ b/apiserver/resumer/resumer_test.go
@@ -1,0 +1,50 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/resumer"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
+)
+
+type ResumerSuite struct {
+	jujutesting.JujuConnSuite
+
+	resumer    *resumer.ResumerAPI
+	resources  *common.Resources
+	authoriser apiservertesting.FakeAuthorizer
+}
+
+var _ = gc.Suite(&ResumerSuite{})
+
+func (s *ResumerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+	s.authoriser = apiservertesting.FakeAuthorizer{
+		EnvironManager: true,
+	}
+	var err error
+	s.resumer, err = resumer.NewResumerAPI(s.State, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ResumerSuite) TestNewResumerAPIRequiresEnvironManager(c *gc.C) {
+	anAuthoriser := s.authoriser
+	anAuthoriser.EnvironManager = false
+	resumer, err := resumer.NewResumerAPI(s.State, s.resources, anAuthoriser)
+	c.Assert(resumer, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *ResumerSuite) TestResumeTransactions(c *gc.C) {
+	err := s.resumer.ResumeTransactions()
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/apiserver/resumer/state.go
+++ b/apiserver/resumer/state.go
@@ -1,0 +1,20 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer
+
+import (
+	"github.com/juju/juju/state"
+)
+
+type stateInterface interface {
+	ResumeTransactions() error
+}
+
+type stateShim struct {
+	*state.State
+}
+
+var getState = func(st *state.State) stateInterface {
+	return stateShim{st}
+}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -113,6 +113,7 @@ var (
 	newDiskManager           = diskmanager.NewWorker
 	newStorageWorker         = storageprovisioner.NewStorageProvisioner
 	newCertificateUpdater    = certupdater.NewCertificateUpdater
+	newResumer               = resumer.NewResumer
 	reportOpenedState        = func(io.Closer) {}
 	reportOpenedAPI          = func(io.Closer) {}
 	reportClosedAPI          = func(io.Closer) {}
@@ -1097,7 +1098,7 @@ func (a *MachineAgent) startEnvWorkers(
 		// The action of resumer is so subtle that it is not tested,
 		// because we can't figure out how to do so without
 		// brutalising the transaction log.
-		return resumer.NewResumer(apiSt.Resumer()), nil
+		return newResumer(apiSt.Resumer()), nil
 	})
 	singularRunner.StartWorker("environ-provisioner", func() (worker.Worker, error) {
 		return provisioner.NewEnvironProvisioner(apiSt.Provisioner(), agentConfig), nil

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -707,6 +707,15 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		return proxyupdater.New(st.Environment(), writeSystemFiles), nil
 	})
 
+	if isEnvironManager {
+		runner.StartWorker("resumer", func() (worker.Worker, error) {
+			// The action of resumer is so subtle that it is not tested,
+			// because we can't figure out how to do so without
+			// brutalising the transaction log.
+			return newResumer(st.Resumer()), nil
+		})
+	}
+
 	runner.StartWorker("machiner", func() (worker.Worker, error) {
 		return machiner.NewMachiner(st.Machiner(), agentConfig), nil
 	})
@@ -1094,12 +1103,6 @@ func (a *MachineAgent) startEnvWorkers(
 	})
 
 	// Start workers that use an API connection.
-	singularRunner.StartWorker("resumer", func() (worker.Worker, error) {
-		// The action of resumer is so subtle that it is not tested,
-		// because we can't figure out how to do so without
-		// brutalising the transaction log.
-		return newResumer(apiSt.Resumer()), nil
-	})
 	singularRunner.StartWorker("environ-provisioner", func() (worker.Worker, error) {
 		return provisioner.NewEnvironProvisioner(apiSt.Provisioner(), agentConfig), nil
 	})

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1009,13 +1009,6 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				return statushistorypruner.New(st, statushistorypruner.NewHistoryPrunerParams()), nil
 			})
 
-			a.startWorkerAfterUpgrade(singularRunner, "resumer", func() (worker.Worker, error) {
-				// The action of resumer is so subtle that it is not tested,
-				// because we can't figure out how to do so without brutalising
-				// the transaction log.
-				return resumer.NewResumer(st), nil
-			})
-
 			a.startWorkerAfterUpgrade(singularRunner, "txnpruner", func() (worker.Worker, error) {
 				return txnpruner.New(st, time.Hour*2), nil
 			})
@@ -1100,6 +1093,12 @@ func (a *MachineAgent) startEnvWorkers(
 	})
 
 	// Start workers that use an API connection.
+	singularRunner.StartWorker("resumer", func() (worker.Worker, error) {
+		// The action of resumer is so subtle that it is not tested,
+		// because we can't figure out how to do so without
+		// brutalising the transaction log.
+		return resumer.NewResumer(apiSt.Resumer()), nil
+	})
 	singularRunner.StartWorker("environ-provisioner", func() (worker.Worker, error) {
 		return provisioner.NewEnvironProvisioner(apiSt.Provisioner(), agentConfig), nil
 	})

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -245,7 +245,6 @@ var perEnvSingularWorkers = []string{
 	"cleaner",
 	"minunitsworker",
 	"addresserworker",
-	"resumer",
 	"environ-provisioner",
 	"charm-revision-updater",
 	"firewaller",
@@ -600,7 +599,7 @@ func (s *MachineSuite) TestManageEnvironRunsResumer(c *gc.C) {
 	r := s.singularRecord.nextRunner(c)
 	r.waitForWorker(c, "charm-revision-updater")
 
-	// Now make sure the firewaller doesn't start.
+	// Now make sure the resumer starts.
 	select {
 	case <-started:
 	case <-time.After(coretesting.LongWait):

--- a/worker/resumer/package_test.go
+++ b/worker/resumer/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
Introduced a new Resumer API (server- and client-side) facade v1, which
is now used by the resumer worker. Resumer is now starting along with
the other API-enabled workers (in cmd/jujud/agent/machine.go -
startEnvWorkers(), instead of inside the StateWorker() method).

After the initial reviews a few more improvements were done around tests.
JujuConnSuite is not used anymore in the api/, apiserver/, or worker/ tests.
Instead testing.Stub and mocking is used (cf. diskmanager API).

(Review request: http://reviews.vapour.ws/r/1777/)