### PR TITLE
Merge pull request #2404 from wallyworld/service-amchine-destroy

### DIFF
--- a/cmd/juju/removeservice.go
+++ b/cmd/juju/removeservice.go
@@ -19,12 +19,22 @@ type RemoveServiceCommand struct {
 	ServiceName string
 }
 
+const removeServiceDoc = `
+Removing a service will remove all its units and relations.
+
+If this is the only service running, the machine on which
+the service is hosted will also be destroyed, if possible.
+The machine will be destroyed if:
+- it is not a state server
+- it is not hosting any Juju managed containers
+`
+
 func (c *RemoveServiceCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-service",
 		Args:    "<service>",
 		Purpose: "remove a service from the environment",
-		Doc:     "Removing a service will remove all its units and relations.",
+		Doc:     removeServiceDoc,
 		Aliases: []string{"destroy-service"},
 	}
 }

--- a/cmd/juju/removeunit.go
+++ b/cmd/juju/removeunit.go
@@ -19,11 +19,22 @@ type RemoveUnitCommand struct {
 	UnitNames []string
 }
 
+const removeUnitDoc = `
+Remove service units from the environment.
+
+If this is the only unit running, the machine on which
+the unit is hosted will also be destroyed, if possible.
+The machine will be destroyed if:
+- it is not a state server
+- it is not hosting any Juju managed containers
+`
+
 func (c *RemoveUnitCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-unit",
 		Args:    "<unit> [...]",
 		Purpose: "remove service units from the environment",
+		Doc:     removeUnitDoc,
 		Aliases: []string{"destroy-unit"},
 	}
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -531,29 +531,30 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 		Id:     m.doc.DocID,
 		Update: bson.D{{"$set", bson.D{{"life", life}}}},
 	}
-	advanceAsserts := bson.D{
-		{"jobs", bson.D{{"$nin", []MachineJob{JobManageEnviron}}}},
-		{"$or", []bson.D{
+	// noUnits asserts that the machine has no principal units.
+	noUnits := bson.DocElem{
+		"$or", []bson.D{
 			{{"principals", bson.D{{"$size", 0}}}},
 			{{"principals", bson.D{{"$exists", false}}}},
-		}},
-		{"hasvote", bson.D{{"$ne", true}}},
+		},
 	}
 	// multiple attempts: one with original data, one with refreshed data, and a final
 	// one intended to determine the cause of failure of the preceding attempt.
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		// If the transaction was aborted, grab a fresh copy of the machine data.
+		advanceAsserts := bson.D{
+			{"jobs", bson.D{{"$nin", []MachineJob{JobManageEnviron}}}},
+			{"hasvote", bson.D{{"$ne", true}}},
+		}
+		// Grab a fresh copy of the machine data.
 		// We don't write to original, because the expectation is that state-
 		// changing methods only set the requested change on the receiver; a case
 		// could perhaps be made that this is not a helpful convention in the
 		// context of the new state API, but we maintain consistency in the
 		// face of uncertainty.
-		if attempt != 0 {
-			if m, err = m.st.Machine(m.doc.Id); errors.IsNotFound(err) {
-				return nil, jujutxn.ErrNoOperations
-			} else if err != nil {
-				return nil, err
-			}
+		if m, err = m.st.Machine(m.doc.Id); errors.IsNotFound(err) {
+			return nil, jujutxn.ErrNoOperations
+		} else if err != nil {
+			return nil, err
 		}
 		// Check that the life change is sane, and collect the assertions
 		// necessary to determine that it remains so.
@@ -562,12 +563,12 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 			if m.doc.Life != Alive {
 				return nil, jujutxn.ErrNoOperations
 			}
-			op.Assert = append(advanceAsserts, isAliveDoc...)
+			advanceAsserts = append(advanceAsserts, isAliveDoc...)
 		case Dead:
 			if m.doc.Life == Dead {
 				return nil, jujutxn.ErrNoOperations
 			}
-			op.Assert = append(advanceAsserts, notDeadDoc...)
+			advanceAsserts = append(advanceAsserts, notDeadDoc...)
 		default:
 			panic(fmt.Errorf("cannot advance lifecycle to %v", life))
 		}
@@ -582,12 +583,63 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 		if m.doc.HasVote {
 			return nil, fmt.Errorf("machine %s is a voting replica set member", m.doc.Id)
 		}
-		if len(m.doc.Principals) != 0 {
+		// If there are no alive units left on the machine, or all the services are dying,
+		// then the machine may be soon destroyed by a cleanup worker.
+		// In that case, we don't want to return any error about not being able to
+		// destroy a machine with units as it will be a lie.
+		if life == Dying {
+			canDie := true
+			var principalUnitnames []string
+			for _, principalUnit := range m.doc.Principals {
+				principalUnitnames = append(principalUnitnames, principalUnit)
+				u, err := m.st.Unit(principalUnit)
+				if err != nil {
+					return nil, errors.Annotatef(err, "reading machine %s principal unit %v", m, m.doc.Principals[0])
+				}
+				svc, err := u.Service()
+				if err != nil {
+					return nil, errors.Annotatef(err, "reading machine %s principal unit service %v", m, u.doc.Service)
+				}
+				if u.Life() == Alive && svc.Life() == Alive {
+					canDie = false
+					break
+				}
+			}
+			if canDie {
+				containers, err := m.Containers()
+				if err != nil {
+					return nil, errors.Annotatef(err, "reading machine %s containers", m)
+				}
+				canDie = len(containers) == 0
+			}
+			if canDie {
+				checkUnits := bson.DocElem{
+					"$or", []bson.D{
+						{{"principals", principalUnitnames}},
+						{{"principals", bson.D{{"$size", 0}}}},
+						{{"principals", bson.D{{"$exists", false}}}},
+					},
+				}
+				op.Assert = append(advanceAsserts, checkUnits)
+				containerCheck := txn.Op{
+					C:  containerRefsC,
+					Id: m.doc.DocID,
+					Assert: bson.D{{"$or", []bson.D{
+						{{"children", bson.D{{"$size", 0}}}},
+						{{"children", bson.D{{"$exists", false}}}},
+					}}},
+				}
+				return []txn.Op{op, containerCheck}, nil
+			}
+		}
+		if len(m.doc.Principals) > 0 {
 			return nil, &HasAssignedUnitsError{
 				MachineId: m.doc.Id,
 				UnitNames: m.doc.Principals,
 			}
 		}
+		// Add the additional asserts needed for this transaction.
+		op.Assert = append(advanceAsserts, noUnits)
 		return []txn.Op{op}, nil
 	}
 	if err = m.st.run(buildTxn); err == jujutxn.ErrExcessiveContention {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -276,7 +276,7 @@ func (s *MachineSuite) TestLifeJobHostUnits(c *gc.C) {
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.Destroy()
-	c.Assert(err, gc.FitsTypeOf, &state.HasAssignedUnitsError{})
+	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
 	c.Assert(err, gc.ErrorMatches, `machine 1 has unit "wordpress/0" assigned`)
 	err1 := s.machine.EnsureDead()
 	c.Assert(err1, gc.DeepEquals, err)
@@ -345,7 +345,7 @@ func (s *MachineSuite) TestDestroyCancel(c *gc.C) {
 		c.Assert(unit.AssignToMachine(s.machine), gc.IsNil)
 	}).Check()
 	err = s.machine.Destroy()
-	c.Assert(err, gc.FitsTypeOf, &state.HasAssignedUnitsError{})
+	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
 }
 
 func (s *MachineSuite) TestDestroyContention(c *gc.C) {
@@ -361,6 +361,86 @@ func (s *MachineSuite) TestDestroyContention(c *gc.C) {
 
 	err = s.machine.Destroy()
 	c.Assert(err, gc.ErrorMatches, "machine 1 cannot advance lifecycle: state changing too quickly; try again soon")
+}
+
+func (s *MachineSuite) TestDestroyWithServiceDestroyPending(c *gc.C) {
+	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = svc.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	// Machine is still advanced to Dying.
+	life := s.machine.Life()
+	c.Assert(life, gc.Equals, state.Dying)
+}
+
+func (s *MachineSuite) TestDestroyFailsWhenNewUnitAdded(c *gc.C) {
+	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = svc.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		anotherSvc := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
+		anotherUnit, err := anotherSvc.AddUnit()
+		c.Assert(err, jc.ErrorIsNil)
+		err = anotherUnit.AssignToMachine(s.machine)
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+
+	err = s.machine.Destroy()
+	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
+	life := s.machine.Life()
+	c.Assert(life, gc.Equals, state.Alive)
+}
+
+func (s *MachineSuite) TestDestroyWithUnitDestroyPending(c *gc.C) {
+	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = unit.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	// Machine is still advanced to Dying.
+	life := s.machine.Life()
+	c.Assert(life, gc.Equals, state.Dying)
+}
+
+func (s *MachineSuite) TestDestroyFailsWhenNewContainerAdded(c *gc.C) {
+	svc := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	unit, err := svc.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(s.machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = svc.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, s.State, func() {
+		_, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
+			Series: "quantal",
+			Jobs:   []state.MachineJob{state.JobHostUnits},
+		}, s.machine.Id(), instance.LXC)
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+
+	err = s.machine.Destroy()
+	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
+	life := s.machine.Life()
+	c.Assert(life, gc.Equals, state.Alive)
 }
 
 func (s *MachineSuite) TestRemove(c *gc.C) {

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -109,9 +109,15 @@ func (mr *Machiner) Handle() error {
 		return fmt.Errorf("%s failed to set status stopped: %v", mr.tag, err)
 	}
 
-	// If the machine is Dying, it has no units,
-	// and can be safely set to Dead.
+	// Attempt to mark the machine Dead. If the
+	// machine still has units assigned, this
+	// will fail with CodeHasAssignedUnits. Once
+	// the units are removed, the watcher will
+	// trigger again and we'll reattempt.
 	if err := mr.machine.EnsureDead(); err != nil {
+		if params.IsCodeHasAssignedUnits(err) {
+			return nil
+		}
 		return fmt.Errorf("%s failed to set machine to dead: %v", mr.tag, err)
 	}
 	return worker.ErrTerminateAgent


### PR DESCRIPTION
Don't complain when destroying a machine that is about to be cleaned up

Fixes: https://bugs.launchpad.net/juju-core/+bug/1455158

Adds extra doc to service and unit destroy commands to explain that when the last unit is destroyed, the machine can also be cleaned up.

Add code to machine destroy to check that if there is a unit still on that machine, the service itself may be dying and thus the cleanup worker will eventually harvest the machine. So the machine destroy becomes a no-op and there's no error returned. Previously an error was returned which complained that the machine had assigned units, which it sort of did, but not alive for much longer and the user would get an error and see the machine destroyed anyway.

(Review request: http://reviews.vapour.ws/r/1766/)

(Review request: http://reviews.vapour.ws/r/1778/)