### PR TITLE
cmd/jujud: move the unit agent out of the main package

### DIFF
--- a/cmd/jujud/agent/common_test.go
+++ b/cmd/jujud/agent/common_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/agent"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+)
+
+// This file contains bits of test infrastructure that are shared by
+// the unit and machine agent tests.
+
+type runner interface {
+	Run(*cmd.Context) error
+	Stop() error
+}
+
+// runWithTimeout runs an agent and waits
+// for it to complete within a reasonable time.
+func runWithTimeout(r runner) error {
+	done := make(chan error)
+	go func() {
+		done <- r.Run(nil)
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(coretesting.LongWait):
+	}
+	err := r.Stop()
+	return fmt.Errorf("timed out waiting for agent to finish; stop error: %v", err)
+}
+
+func newDummyWorker() worker.Worker {
+	return worker.NewSimpleWorker(func(stop <-chan struct{}) error {
+		<-stop
+		return nil
+	})
+}
+
+type FakeConfig struct {
+	agent.Config
+}
+
+func (FakeConfig) LogDir() string {
+	return filepath.FromSlash("/var/log/juju/")
+}
+
+func (FakeConfig) Tag() names.Tag {
+	return names.NewMachineTag("42")
+}
+
+type FakeAgentConfig struct {
+	AgentConf
+}
+
+func (FakeAgentConfig) ReadConfig(string) error { return nil }
+
+func (FakeAgentConfig) CurrentConfig() agent.Config {
+	return FakeConfig{}
+}
+
+func (FakeAgentConfig) CheckArgs([]string) error { return nil }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -115,7 +115,7 @@ var (
 	newCertificateUpdater    = certupdater.NewCertificateUpdater
 	reportOpenedState        = func(io.Closer) {}
 	reportOpenedAPI          = func(io.Closer) {}
-	reportClosedAPI          = func(io.Closer) {}
+	reportClosedMachineAPI   = func(io.Closer) {}
 	getMetricAPI             = metricAPI
 )
 
@@ -623,7 +623,7 @@ func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 	defer func() {
 		if err != nil {
 			st.Close()
-			reportClosedAPI(st)
+			reportClosedMachineAPI(st)
 		}
 	}()
 

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package main
+package agent
 
 import (
 	"fmt"
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/leadership"
-	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/tools"
@@ -35,31 +34,32 @@ import (
 )
 
 var (
-	agentLogger     = loggo.GetLogger("juju.jujud")
-	reportClosedAPI = func(io.Closer) {}
+	agentLogger         = loggo.GetLogger("juju.jujud")
+	reportClosedUnitAPI = func(io.Closer) {}
 )
 
 // UnitAgent is a cmd.Command responsible for running a unit agent.
 type UnitAgent struct {
 	cmd.CommandBase
 	tomb tomb.Tomb
-	agentcmd.AgentConf
+	AgentConf
 	UnitName         string
 	runner           worker.Runner
 	setupLogging     func(agent.Config) error
 	logToStdErr      bool
 	ctx              *cmd.Context
-	apiStateUpgrader agentcmd.APIStateUpgrader
+	apiStateUpgrader APIStateUpgrader
 }
 
 // NewUnitAgent creates a new UnitAgent value properly initialized.
-func NewUnitAgent() *UnitAgent {
+func NewUnitAgent(ctx *cmd.Context) *UnitAgent {
 	return &UnitAgent{
-		AgentConf: agentcmd.NewAgentConf(""),
+		AgentConf: NewAgentConf(""),
+		ctx:       ctx,
 	}
 }
 
-func (a *UnitAgent) getUpgrader(st *api.State) agentcmd.APIStateUpgrader {
+func (a *UnitAgent) getUpgrader(st *api.State) APIStateUpgrader {
 	if a.apiStateUpgrader != nil {
 		return a.apiStateUpgrader
 	}
@@ -144,7 +144,7 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 	if err != nil {
 		return nil, err
 	}
-	st, entity, err := agentcmd.OpenAPIState(agentConfig, a)
+	st, entity, err := OpenAPIState(agentConfig, a)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 	defer func() {
 		if err != nil {
 			st.Close()
-			reportClosedAPI(st)
+			reportClosedUnitAPI(st)
 		}
 	}()
 

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -125,9 +125,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf)
 	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
 
-	a := NewUnitAgent()
-	a.ctx = ctx
-	jujud.Register(a)
+	jujud.Register(agentcmd.NewUnitAgent(ctx))
 
 	code = cmd.Main(jujud, ctx, args[1:])
 	return code, nil


### PR DESCRIPTION
The unit agent code now lives in the cmd/jujud/agent package so that it can be imported for testing elsewhere (e.g. the feature tests). This also allows a lot of duplicated test code to be removed.

(Review request: http://reviews.vapour.ws/r/1784/)