### PR TITLE
Fix for 1442308: fix cloud-config for systemd

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -285,12 +285,12 @@ func shutdownInitCommands(initSystem string) ([]string, error) {
 		AfterStopped: "cloud-final",
 		ExecStart:    execStart,
 	}
-	svc, err := service.NewService(name, conf, initSystem)
+	svc, err := service.NewTemplateShutdownService(name, conf, initSystem)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	cmds, err := svc.InstallCommands()
+	cmds, err := svc.InstallTemplateContainerCommands()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -203,12 +203,14 @@ Description=juju shutdown job
 After=syslog.target
 After=network.target
 After=systemd-user-sessions.service
-After=cloud-final
-Conflicts=cloud-final
+After=cloud-config.target
 
 [Service]
 ExecStart=/var/lib/juju/init/juju-template-restart/exec-start.sh
 ExecStopPost=/bin/systemctl disable juju-template-restart.service
+
+[Install]
+WantedBy=multi-user.target
 `[1:],
 		Script: `
 /bin/cat > /etc/network/interfaces << EOC
@@ -223,5 +225,5 @@ EOC
   /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now`[1:],
 	}
-	test.CheckCommands(c, commands)
+	test.CheckInstallTemplateContainerCommands(c, commands)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -86,6 +86,17 @@ type Service interface {
 	StartCommands() ([]string, error)
 }
 
+// TemplateShutdownService represents a service which can be used to halt a
+// template lxc container after cloud-init completes.
+type TemplateShutdownService interface {
+	Service
+
+	// InstallTemplateContainerCommands returns the commands to install
+	// and start the service which will halt the template container after
+	// cloud-init completes.
+	InstallTemplateContainerCommands() ([]string, error)
+}
+
 // RestartableService is a service that directly supports restarting.
 type RestartableService interface {
 	// Restart restarts the service.
@@ -115,6 +126,23 @@ func NewService(name string, conf common.Conf, initSystem string) (Service, erro
 		return svc, nil
 	default:
 		return nil, errors.NotFoundf("init system %q", initSystem)
+	}
+}
+
+// NewTemplateShutdownService returns a new TemplateService that can be used to create
+// the shutdown service used in container templates
+func NewTemplateShutdownService(name string, conf common.Conf, initSystem string) (TemplateShutdownService, error) {
+	switch initSystem {
+	case InitSystemUpstart:
+		return upstart.NewTemplateShutdownService(name, conf), nil
+	case InitSystemSystemd:
+		svc, err := systemd.NewTemplateShutdownService(name, conf)
+		if err != nil {
+			return nil, errors.Annotatef(err, "failed to wrap service %q", name)
+		}
+		return svc, nil
+	default:
+		return nil, errors.Errorf("unsupported init system for container template: %q", initSystem)
 	}
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -48,6 +48,31 @@ func (s *serviceSuite) TestNewServiceKnown(c *gc.C) {
 	}
 }
 
+func (s *serviceSuite) TestNewTemplateShutdownService(c *gc.C) {
+	initSystems := []string{
+		service.InitSystemSystemd,
+		service.InitSystemUpstart,
+		service.InitSystemWindows,
+	}
+	for _, initSystem := range initSystems {
+		svc, err := service.NewTemplateShutdownService(s.Name, s.Conf, initSystem)
+
+		switch initSystem {
+		case service.InitSystemSystemd:
+			c.Check(svc, gc.FitsTypeOf, &systemd.Service{})
+			c.Check(err, jc.ErrorIsNil)
+		case service.InitSystemUpstart:
+			c.Check(svc, gc.FitsTypeOf, &upstart.Service{})
+			c.Check(err, jc.ErrorIsNil)
+		case service.InitSystemWindows:
+			c.Check(err, gc.ErrorMatches, "unsupported init system for container template: \"windows\"")
+			continue
+		}
+		c.Check(svc.Name(), gc.Equals, s.Name)
+		c.Check(svc.Conf(), jc.DeepEquals, s.Conf)
+	}
+}
+
 func (s *serviceSuite) TestNewServiceMissingName(c *gc.C) {
 	_, err := service.NewService("", s.Conf, service.InitSystemUpstart)
 

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -183,11 +183,6 @@ func serializeUnit(conf common.Conf) []*unit.UnitOption {
 			Name:    "After",
 			Value:   conf.AfterStopped,
 		})
-		unitOptions = append(unitOptions, &unit.UnitOption{
-			Section: "Unit",
-			Name:    "Conflicts",
-			Value:   conf.AfterStopped,
-		})
 	}
 
 	return unitOptions
@@ -254,13 +249,11 @@ func serializeService(conf common.Conf) []*unit.UnitOption {
 func serializeInstall(conf common.Conf) []*unit.UnitOption {
 	var unitOptions []*unit.UnitOption
 
-	if !conf.Transient {
-		unitOptions = append(unitOptions, &unit.UnitOption{
-			Section: "Install",
-			Name:    "WantedBy",
-			Value:   "multi-user.target",
-		})
-	}
+	unitOptions = append(unitOptions, &unit.UnitOption{
+		Section: "Install",
+		Name:    "WantedBy",
+		Value:   "multi-user.target",
+	})
 
 	return unitOptions
 }

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -117,6 +117,15 @@ func NewService(name string, conf common.Conf) (*Service, error) {
 	return service, nil
 }
 
+// NewTemplateShutdownService returns a new value that implements
+// TemplateShutdownService for systemd.
+func NewTemplateShutdownService(name string, conf common.Conf) (*Service, error) {
+	if conf.AfterStopped == "cloud-final" {
+		conf.AfterStopped = "cloud-config.target"
+	}
+	return NewService(name, conf)
+}
+
 var findDataDir = func() (string, error) {
 	return paths.DataDir(version.Current.Series)
 }
@@ -582,6 +591,22 @@ func (s *Service) InstallCommands() ([]string, error) {
 		cmds.enableLinked(name, dirname),
 	}...)
 	return cmdList, nil
+}
+
+// InstallTempalteContainerCommands returns shell commands to install
+// and start the shutdown service required for template containers.
+func (s *Service) InstallTemplateContainerCommands() ([]string, error) {
+	installCmds, err := s.InstallCommands()
+	if err != nil {
+		return nil, err
+	}
+
+	startCmds, err := s.StartCommands()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(installCmds, startCmds...), nil
 }
 
 // StartCommands implements Service.

--- a/service/systemd/testing/writeconf.go
+++ b/service/systemd/testing/writeconf.go
@@ -35,6 +35,10 @@ func (wct WriteConfTest) scriptname() string {
 	return fmt.Sprintf("'%s/init/%s/exec-start.sh'", wct.DataDir, wct.Service)
 }
 
+func (wct WriteConfTest) servicename() string {
+	return fmt.Sprintf("%s.service", wct.Service)
+}
+
 // CheckCommands checks the given commands against the test's expectations.
 func (wct WriteConfTest) CheckCommands(c *gc.C, commands []string) {
 	c.Check(commands[0], gc.Equals, "mkdir -p "+wct.dirname())
@@ -44,6 +48,11 @@ func (wct WriteConfTest) CheckCommands(c *gc.C, commands []string) {
 		commands = commands[2:]
 	}
 	wct.checkWriteConf(c, commands)
+}
+
+func (wct WriteConfTest) CheckInstallTemplateContainerCommands(c *gc.C, commands []string) {
+	wct.CheckCommands(c, commands[:len(commands)-1])
+	c.Check(commands[len(commands)-1], gc.Equals, "/bin/systemctl start "+wct.servicename())
 }
 
 func (wct WriteConfTest) checkWriteExecScript(c *gc.C, commands []string) {

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -104,6 +104,12 @@ func NewService(name string, conf common.Conf) *Service {
 	}
 }
 
+// NewTemplateShutdownService returns a new value that implements
+// TemplateShutdownService for upstart.
+func NewTemplateShutdownService(name string, conf common.Conf) *Service {
+	return NewService(name, conf)
+}
+
 // Name implements service.Service.
 func (s Service) Name() string {
 	return s.Service.Name
@@ -311,6 +317,12 @@ func (s *Service) InstallCommands() ([]string, error) {
 	}
 	cmd := fmt.Sprintf("cat > %s << 'EOF'\n%sEOF\n", s.confPath(), conf)
 	return []string{cmd}, nil
+}
+
+// InstallTempalteContainerCommands returns shell commands to install
+// and start the shutdown service required for template containers.
+func (s *Service) InstallTemplateContainerCommands() ([]string, error) {
+	return s.InstallCommands()
 }
 
 // StartCommands returns shell commands to start the service.


### PR DESCRIPTION
Juju was previously unable to create vivid containers
due to problems with the service started with systemd
to shutdown the template container.  The problems
addressed were:

- Specifying an "After" for systemd should not generate
a "Conflicts" entry.  Starting the service would cause
the conflicting service to be killed.  The proper way
to specify that a service should wait for another service
to complete before starting is to use a target.  For our
case, the target to specify that cloud-init has finished
is cloud-config.target.

- Even transient services must include an Install section.
This is required for services registered with systemctl.

- The service must be explicitly started for systemd.

(Review request: http://reviews.vapour.ws/r/1789/)