### PR TITLE
Rework all the user commands to be system commands

### DIFF
--- a/cmd/envcmd/files.go
+++ b/cmd/envcmd/files.go
@@ -29,6 +29,15 @@ var (
 	lockTimeout = 5 * time.Second
 )
 
+// ServerFile describes the information that is needed for a user
+// to connect to an api server.
+type ServerFile struct {
+	Addresses []string `yaml:"addresses"`
+	CACert    string   `yaml:"ca-cert,omitempty"`
+	Username  string   `yaml:"username"`
+	Password  string   `yaml:"password"`
+}
+
 // NOTE: synchronisation across functions in this file.
 //
 // Each of the read and write functions use a fslock to synchronise calls

--- a/cmd/envcmd/systemcommand.go
+++ b/cmd/envcmd/systemcommand.go
@@ -84,19 +84,43 @@ func (c *SysCommandBase) newAPIRoot() (*api.State, error) {
 }
 
 // ConnectionCredentials returns the credentials used to connect to the API for
-// the specified environment.
+// the specified system.
 func (c *SysCommandBase) ConnectionCredentials() (configstore.APICredentials, error) {
 	// TODO: the user may soon be specified through the command line
 	// or through an environment setting, so return these when they are ready.
 	var emptyCreds configstore.APICredentials
-	if c.systemName == "" {
-		return emptyCreds, errors.Trace(ErrNoSystemSpecified)
-	}
-	info, err := ConnectionInfoForName(c.systemName)
+	info, err := c.ConnectionInfo()
 	if err != nil {
 		return emptyCreds, errors.Trace(err)
 	}
 	return info.APICredentials(), nil
+}
+
+// ConnectionEndpoint returns the endpoint details used to connect to the API for
+// the specified system.
+func (c *SysCommandBase) ConnectionEndpoint() (configstore.APIEndpoint, error) {
+	// TODO: the user may soon be specified through the command line
+	// or through an environment setting, so return these when they are ready.
+	var empty configstore.APIEndpoint
+	info, err := c.ConnectionInfo()
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	return info.APIEndpoint(), nil
+}
+
+// ConnectionInfo returns the environ info from the cached config store.
+func (c *SysCommandBase) ConnectionInfo() (configstore.EnvironInfo, error) {
+	// TODO: the user may soon be specified through the command line
+	// or through an environment setting, so return these when they are ready.
+	if c.systemName == "" {
+		return nil, errors.Trace(ErrNoSystemSpecified)
+	}
+	info, err := ConnectionInfoForName(c.systemName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return info, nil
 }
 
 // Wrap wraps the specified SystemCommand, returning a Command

--- a/cmd/juju/system/login.go
+++ b/cmd/juju/system/login.go
@@ -19,18 +19,6 @@ import (
 	"github.com/juju/juju/network"
 )
 
-// ServerFile describes the information that is needed for a user
-// to connect to an api server.
-//
-// TODO(thumper): This will need to move when the user manager commands
-// generate this file format.  The file format is expected to be YAML.
-type ServerFile struct {
-	Addresses []string `yaml:"addresses"`
-	CACert    string   `yaml:"ca-cert,omitempty"`
-	Username  string   `yaml:"username"`
-	Password  string   `yaml:"password"`
-}
-
 // APIOpenFunc defines a function that opens the api connection
 // and returns the defined interface.
 type APIOpenFunc func(*api.Info, api.DialOpts) (APIConnection, error)
@@ -103,7 +91,7 @@ func (c *LoginCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	var serverDetails ServerFile
+	var serverDetails envcmd.ServerFile
 	if err := goyaml.Unmarshal(serverYAML, &serverDetails); err != nil {
 		return errors.Trace(err)
 	}
@@ -157,7 +145,7 @@ func (c *LoginCommand) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-func (c *LoginCommand) cacheConnectionInfo(serverDetails ServerFile, apiState APIConnection) (configstore.EnvironInfo, error) {
+func (c *LoginCommand) cacheConnectionInfo(serverDetails envcmd.ServerFile, apiState APIConnection) (configstore.EnvironInfo, error) {
 	store, err := configstore.Default()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -103,7 +103,7 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 		user = fmt.Sprintf("%s (%s)", c.DisplayName, user)
 	}
 
-	fmt.Fprintf(ctx.Stdout, "user %q added\n", user)
+	ctx.Infof("user %q added", user)
 
 	outPath := ctx.AbsPath(c.OutPath)
 	return writeServerFile(c, ctx, user, password, outPath)

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -5,46 +5,46 @@ package user
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/juju/block"
-	"github.com/juju/juju/environs/configstore"
 )
 
 const userAddCommandDoc = `
 Add users to an existing environment.
 
 The user information is stored within an existing environment, and will be
-lost when the environent is destroyed.  An environment file (.jenv) will be
-written out in the current directory.  You can control the name and location
-of this file using the --output option.
+lost when the environent is destroyed.  A server file will be written out in
+the current directory.  You can control the name and location of this file
+using the --output option.
 
 Examples:
-  # Add user "foobar". You will be prompted to enter a password.
-  juju user add foobar
-
-  # Add user "foobar" with a strong random password is generated.
-  juju user add foobar --generate
+    # Add user "foobar" with a strong random password is generated.
+    juju user add foobar
 
 
 See Also:
-  juju user change-password
+    juju user change-password
 `
+
+// AddUserAPI defines the usermanager API methods that the add command uses.
+type AddUserAPI interface {
+	AddUser(username, displayName, password string) (names.UserTag, error)
+	Close() error
+}
 
 // AddCommand adds new users into a Juju Server.
 type AddCommand struct {
 	UserCommandBase
+	api         AddUserAPI
 	User        string
 	DisplayName string
-	Password    string
 	OutPath     string
-	Generate    bool
 }
 
 // Info implements Command.Info.
@@ -59,7 +59,6 @@ func (c *AddCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *AddCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.Generate, "generate", false, "generate a new strong password")
 	f.StringVar(&c.OutPath, "o", "", "specify the environment file for new user")
 	f.StringVar(&c.OutPath, "output", "", "")
 }
@@ -73,68 +72,30 @@ func (c *AddCommand) Init(args []string) error {
 	if len(args) > 0 {
 		c.DisplayName, args = args[0], args[1:]
 	}
+	if c.OutPath == "" {
+		c.OutPath = c.User + ".server"
+	}
 	return cmd.CheckEmpty(args)
 }
 
-// AddUserAPI defines the usermanager API methods that the add command uses.
-type AddUserAPI interface {
-	AddUser(username, displayName, password string) (names.UserTag, error)
-	Close() error
-}
-
-// ShareEnvironmentAPI defines the client API methods that the add command uses.
-type ShareEnvironmentAPI interface {
-	ShareEnvironment(users ...names.UserTag) error
-	Close() error
-}
-
-func (c *AddCommand) getAddUserAPI() (AddUserAPI, error) {
-	return c.NewUserManagerClient()
-}
-
-func (c *AddCommand) getShareEnvAPI() (ShareEnvironmentAPI, error) {
-	return c.NewAPIClient()
-}
-
-var (
-	getAddUserAPI  = (*AddCommand).getAddUserAPI
-	getShareEnvAPI = (*AddCommand).getShareEnvAPI
-)
-
 // Run implements Command.Run.
 func (c *AddCommand) Run(ctx *cmd.Context) error {
-	client, err := getAddUserAPI(c)
-	if err != nil {
-		return err
+	if c.api == nil {
+		api, err := c.NewUserManagerAPIClient()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		c.api = api
 	}
-	defer client.Close()
+	defer c.api.Close()
 
-	if !c.Generate {
-		ctx.Infof("To generate a random strong password, use the --generate flag.")
-	}
-
-	shareClient, err := getShareEnvAPI(c)
+	password, err := utils.RandomPassword()
 	if err != nil {
-		return err
-	}
-	defer shareClient.Close()
-
-	c.Password, err = c.generateOrReadPassword(ctx, c.Generate)
-	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "failed to generate random password")
 	}
 
-	tag, err := client.AddUser(c.User, c.DisplayName, c.Password)
-	if err != nil {
+	if _, err := c.api.AddUser(c.User, c.DisplayName, password); err != nil {
 		return block.ProcessBlockedError(err, block.BlockChange)
-	}
-	// Until we have multiple environments stored in a state server
-	// it makes no sense at all to create a user and not have that user
-	// able to log in and use the one and only environment.
-	// So we share the existing environment with the user here and now.
-	err = shareClient.ShareEnvironment(tag)
-	if err != nil {
-		return err
 	}
 
 	user := c.User
@@ -143,56 +104,8 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 	}
 
 	fmt.Fprintf(ctx.Stdout, "user %q added\n", user)
-	if c.OutPath == "" {
-		c.OutPath = c.User + ".jenv"
-	}
 
-	outPath := normaliseJenvPath(ctx, c.OutPath)
-	err = generateUserJenv(c.ConnectionName(), c.User, c.Password, outPath)
-	if err == nil {
-		fmt.Fprintf(ctx.Stdout, "environment file written to %s\n", outPath)
-	}
+	outPath := ctx.AbsPath(c.OutPath)
+	return writeServerFile(c, ctx, user, password, outPath)
 
-	return err
-}
-
-func normaliseJenvPath(ctx *cmd.Context, outPath string) string {
-	if !strings.HasSuffix(outPath, ".jenv") {
-		outPath = outPath + ".jenv"
-	}
-	return ctx.AbsPath(outPath)
-}
-
-func generateUserJenv(envName, user, password, outPath string) error {
-	store, err := configstore.Default()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	storeInfo, err := store.ReadInfo(envName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	endpoint := storeInfo.APIEndpoint()
-	outputInfo := configstore.EnvironInfoData{
-		User:         user,
-		Password:     password,
-		EnvironUUID:  endpoint.EnvironUUID,
-		StateServers: endpoint.Addresses,
-		CACert:       endpoint.CACert,
-	}
-	yaml, err := cmd.FormatYaml(outputInfo)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	outFile, err := os.Create(outPath)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer outFile.Close()
-	outFile.Write(yaml)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return nil
 }

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -93,6 +93,9 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to generate random password")
 	}
+	if randomPasswordNotify != nil {
+		randomPasswordNotify(password)
+	}
 
 	if _, err := c.api.AddUser(c.User, c.DisplayName, password); err != nil {
 		return block.ProcessBlockedError(err, block.BlockChange)
@@ -105,7 +108,5 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 
 	ctx.Infof("user %q added", user)
 
-	outPath := ctx.AbsPath(c.OutPath)
-	return writeServerFile(c, ctx, user, password, outPath)
-
+	return writeServerFile(c, ctx, user, password, c.OutPath)
 }

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -86,16 +86,14 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 		c.api = api
+		defer c.api.Close()
 	}
-	defer c.api.Close()
 
 	password, err := utils.RandomPassword()
 	if err != nil {
 		return errors.Annotate(err, "failed to generate random password")
 	}
-	if randomPasswordNotify != nil {
-		randomPasswordNotify(password)
-	}
+	randomPasswordNotify(password)
 
 	if _, err := c.api.AddUser(c.User, c.DisplayName, password); err != nil {
 		return block.ProcessBlockedError(err, block.BlockChange)

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -117,7 +117,7 @@ func (s *UserAddCommandSuite) TestBlockAddUser(c *gc.C) {
 
 func (s *UserAddCommandSuite) TestAddUserErrorResponse(c *gc.C) {
 	s.mockAPI.failMessage = "failed to create user, chaos ensues"
-	context, err := s.run(c, "foobar")
+	_, err := s.run(c, "foobar")
 	c.Assert(err, gc.ErrorMatches, "failed to create user, chaos ensues")
 }
 

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -133,7 +133,7 @@ func (s *UserAddCommandSuite) TestBlockAddUser(c *gc.C) {
 func (s *UserAddCommandSuite) TestAddUserErrorResponse(c *gc.C) {
 	s.mockAPI.failMessage = "failed to create user, chaos ensues"
 	_, err := s.run(c, "foobar")
-	c.Assert(err, gc.ErrorMatches, "failed to create user, chaos ensues")
+	c.Assert(err, gc.ErrorMatches, s.mockAPI.failMessage)
 }
 
 type mockAddUserAPI struct {

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -45,22 +45,20 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 		outPath     string
 		errorString string
 	}{
-		//TODO(thumper) check init tested fully
 		{
 			errorString: "no username supplied",
 		}, {
-			args: []string{"foobar"},
-			user: "foobar",
+			args:    []string{"foobar"},
+			user:    "foobar",
+			outPath: "foobar.server",
 		}, {
 			args:        []string{"foobar", "Foo Bar"},
 			user:        "foobar",
 			displayname: "Foo Bar",
+			outPath:     "foobar.server",
 		}, {
 			args:        []string{"foobar", "Foo Bar", "extra"},
 			errorString: `unrecognized args: \["extra"\]`,
-		}, {
-			args: []string{"foobar", "--generate"},
-			user: "foobar",
 		}, {
 			args:    []string{"foobar", "--output", "somefile"},
 			user:    "foobar",
@@ -91,7 +89,7 @@ func (s *UserAddCommandSuite) TestUsername(c *gc.C) {
 	c.Assert(s.mockAPI.displayname, gc.Equals, "")
 	expected := `
 user "foobar" added
-environment file written to .*foobar.server
+server file written to .*foobar.server
 `[1:]
 	c.Assert(testing.Stderr(context), gc.Matches, expected)
 }

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -4,8 +4,6 @@
 package user_test
 
 import (
-	"io/ioutil"
-	"path/filepath"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -32,16 +30,11 @@ var _ = gc.Suite(&UserAddCommandSuite{})
 func (s *UserAddCommandSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.mockAPI = &mockAddUserAPI{}
-	s.PatchValue(user.GetAddUserAPI, func(c *user.AddCommand) (user.AddUserAPI, error) {
-		return s.mockAPI, nil
-	})
-	s.PatchValue(user.GetShareEnvAPI, func(c *user.AddCommand) (user.ShareEnvironmentAPI, error) {
-		return s.mockAPI, nil
-	})
 }
 
-func newUserAddCommand() cmd.Command {
-	return envcmd.Wrap(&user.AddCommand{})
+func (s *UserAddCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	addCommand := envcmd.WrapSystem(user.NewAddCommand(s.mockAPI))
+	return testing.RunCommand(c, addCommand, args...)
 }
 
 func (s *UserAddCommandSuite) TestInit(c *gc.C) {
@@ -50,9 +43,9 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 		user        string
 		displayname string
 		outPath     string
-		generate    bool
 		errorString string
 	}{
+		//TODO(thumper) check init tested fully
 		{
 			errorString: "no username supplied",
 		}, {
@@ -66,9 +59,8 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 			args:        []string{"foobar", "Foo Bar", "extra"},
 			errorString: `unrecognized args: \["extra"\]`,
 		}, {
-			args:     []string{"foobar", "--generate"},
-			user:     "foobar",
-			generate: true,
+			args: []string{"foobar", "--generate"},
+			user: "foobar",
 		}, {
 			args:    []string{"foobar", "--output", "somefile"},
 			user:    "foobar",
@@ -86,114 +78,47 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 			c.Check(addUserCmd.User, gc.Equals, test.user)
 			c.Check(addUserCmd.DisplayName, gc.Equals, test.displayname)
 			c.Check(addUserCmd.OutPath, gc.Equals, test.outPath)
-			c.Check(addUserCmd.Generate, gc.Equals, test.generate)
 		} else {
 			c.Check(err, gc.ErrorMatches, test.errorString)
 		}
 	}
 }
 
-// serializedCACert adjusts the testing.CACert for the test below.
-func serializedCACert() string {
-	parts := strings.Split(testing.CACert, "\n")
-	for i, part := range parts {
-		parts[i] = strings.TrimSpace(part)
-	}
-	return strings.Join(parts[:len(parts)-1], "\n")
-}
-
-func assertJENVContents(c *gc.C, filename, username, password string) {
-	raw, err := ioutil.ReadFile(filename)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := map[string]interface{}{
-		"user":          username,
-		"password":      password,
-		"state-servers": []interface{}{"127.0.0.1:12345"},
-		"ca-cert":       serializedCACert(),
-		"environ-uuid":  "env-uuid",
-	}
-	c.Assert(string(raw), jc.YAMLEquals, expected)
-}
-
-func (s *UserAddCommandSuite) AssertJENVContents(c *gc.C, filename string) {
-	assertJENVContents(c, filename, s.mockAPI.username, s.mockAPI.password)
-}
-
-func (s *UserAddCommandSuite) TestAddUserJustUsername(c *gc.C) {
-	context, err := testing.RunCommand(c, newUserAddCommand(), "foobar")
+func (s *UserAddCommandSuite) TestUsername(c *gc.C) {
+	context, err := s.run(c, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
 	c.Assert(s.mockAPI.displayname, gc.Equals, "")
-	c.Assert(s.mockAPI.password, gc.Equals, "sekrit")
 	expected := `
-password:
-type password again:
 user "foobar" added
-environment file written to .*foobar.jenv
+environment file written to .*foobar.server
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Matches, expected)
-	c.Assert(testing.Stderr(context), gc.Equals, "To generate a random strong password, use the --generate flag.\n")
-	s.AssertJENVContents(c, context.AbsPath("foobar.jenv"))
+	c.Assert(testing.Stderr(context), gc.Matches, expected)
 }
 
-func (s *UserAddCommandSuite) TestAddUserUsernameAndDisplayname(c *gc.C) {
-	context, err := testing.RunCommand(c, newUserAddCommand(), "foobar", "Foo Bar")
+func (s *UserAddCommandSuite) TestUsernameAndDisplayname(c *gc.C) {
+	context, err := s.run(c, "foobar", "Foo Bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
 	c.Assert(s.mockAPI.displayname, gc.Equals, "Foo Bar")
 	expected := `user "Foo Bar (foobar)" added`
-	c.Assert(testing.Stdout(context), jc.Contains, expected)
-	s.AssertJENVContents(c, context.AbsPath("foobar.jenv"))
+	c.Assert(testing.Stderr(context), jc.Contains, expected)
 }
 
 func (s *UserAddCommandSuite) TestBlockAddUser(c *gc.C) {
 	// Block operation
 	s.mockAPI.blocked = true
-	_, err := testing.RunCommand(c, newUserAddCommand(), "foobar", "Foo Bar")
+	_, err := s.run(c, "foobar", "Foo Bar")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 	// msg is logged
 	stripped := strings.Replace(c.GetTestLog(), "\n", "", -1)
 	c.Check(stripped, gc.Matches, ".*To unblock changes.*")
 }
 
-func (s *UserAddCommandSuite) TestGeneratePassword(c *gc.C) {
-	context, err := testing.RunCommand(c, newUserAddCommand(), "foobar", "--generate")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
-	c.Assert(s.mockAPI.password, gc.Not(gc.Equals), "sekrit")
-	c.Assert(s.mockAPI.password, gc.HasLen, 24)
-	expected := `
-user "foobar" added
-environment file written to .*foobar.jenv
-`[1:]
-	c.Assert(testing.Stdout(context), gc.Matches, expected)
-	c.Assert(testing.Stderr(context), gc.Equals, "")
-	s.AssertJENVContents(c, context.AbsPath("foobar.jenv"))
-}
-
 func (s *UserAddCommandSuite) TestAddUserErrorResponse(c *gc.C) {
 	s.mockAPI.failMessage = "failed to create user, chaos ensues"
-	context, err := testing.RunCommand(c, newUserAddCommand(), "foobar", "--generate")
+	context, err := s.run(c, "foobar")
 	c.Assert(err, gc.ErrorMatches, "failed to create user, chaos ensues")
-	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
-	c.Assert(s.mockAPI.displayname, gc.Equals, "")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
-}
-
-func (s *UserAddCommandSuite) TestJenvOutput(c *gc.C) {
-	outputName := filepath.Join(c.MkDir(), "output")
-	context, err := testing.RunCommand(c, newUserAddCommand(),
-		"foobar", "--output", outputName)
-	c.Assert(err, jc.ErrorIsNil)
-	s.AssertJENVContents(c, context.AbsPath(outputName+".jenv"))
-}
-
-func (s *UserAddCommandSuite) TestJenvOutputWithSuffix(c *gc.C) {
-	outputName := filepath.Join(c.MkDir(), "output.jenv")
-	context, err := testing.RunCommand(c, newUserAddCommand(),
-		"foobar", "--output", outputName)
-	c.Assert(err, jc.ErrorIsNil)
-	s.AssertJENVContents(c, context.AbsPath(outputName))
 }
 
 type mockAddUserAPI struct {
@@ -219,14 +144,6 @@ func (m *mockAddUserAPI) AddUser(username, displayname, password string) (names.
 		return names.NewLocalUserTag(username), nil
 	}
 	return names.UserTag{}, errors.New(m.failMessage)
-}
-
-func (m *mockAddUserAPI) ShareEnvironment(users ...names.UserTag) error {
-	if m.shareFailMsg != "" {
-		return errors.New(m.shareFailMsg)
-	}
-	m.sharedUsers = users
-	return nil
 }
 
 func (*mockAddUserAPI) Close() error {

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -16,9 +16,8 @@ import (
 	"github.com/juju/juju/environs/configstore"
 )
 
-// randomPasswordNotify is called if non-nil when a random password
-// is generated.
-var randomPasswordNotify func(string)
+// randomPasswordNotify is called when a random password is generated.
+var randomPasswordNotify = func(string) {}
 
 const userChangePasswordDoc = `
 Change the password for the user you are currently logged in as,
@@ -102,8 +101,8 @@ func (c *ChangePasswordCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 		c.api = api
+		defer c.api.Close()
 	}
-	defer c.api.Close()
 
 	password, err := c.generateOrReadPassword(ctx, c.Generate)
 	if err != nil {
@@ -164,9 +163,7 @@ func (*ChangePasswordCommand) generateOrReadPassword(ctx *cmd.Context, generate 
 		if err != nil {
 			return "", errors.Annotate(err, "failed to generate random password")
 		}
-		if randomPasswordNotify != nil {
-			randomPasswordNotify(password)
-		}
+		randomPasswordNotify(password)
 		return password, nil
 	}
 

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -146,7 +146,7 @@ func (s *ChangePasswordCommandSuite) TestChangePasswordRevertApiFails(c *gc.C) {
 func (s *ChangePasswordCommandSuite) TestChangeOthersPassword(c *gc.C) {
 	// The checks for user existence and admin rights are tested
 	// at the apiserver level.
-	context, err := s.run(c, "other")
+	_, err := s.run(c, "other")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "other")
 	c.Assert(s.mockAPI.password, gc.Not(gc.Equals), "sekrit")
@@ -158,7 +158,7 @@ func (s *ChangePasswordCommandSuite) TestChangeOthersPasswordWithFile(c *gc.C) {
 	// The checks for user existence and admin rights are tested
 	// at the apiserver level.
 	filename := filepath.Join(c.MkDir(), "test.result")
-	context, err := s.run(c, "other", "-o", filename)
+	_, err := s.run(c, "other", "-o", filename)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "other")
 	c.Assert(s.mockAPI.password, gc.Equals, "sekrit")

--- a/cmd/juju/user/common.go
+++ b/cmd/juju/user/common.go
@@ -1,0 +1,43 @@
+// Copyright 2012-2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+import (
+	"io/ioutil"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/environs/configstore"
+)
+
+// EndpointProvider defines the method used by the WriteServerFile
+// in order
+type EndpointProvider interface {
+	ConnectionEndpoint() (configstore.APIEndpoint, error)
+}
+
+func writeServerFile(endpointProvider EndpointProvider, ctx *cmd.Context, username, password, outPath string) error {
+	endpoint, err := endpointProvider.ConnectionEndpoint()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	outputInfo := envcmd.ServerFile{
+		Username:  username,
+		Password:  password,
+		Addresses: endpoint.Addresses,
+		CACert:    endpoint.CACert,
+	}
+	yaml, err := cmd.FormatYaml(outputInfo)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := ioutil.WriteFile(outPath, yaml, 0644); err != nil {
+		return errors.Trace(err)
+	}
+	ctx.Infof("server file written to %s\n", outPath)
+	return nil
+}

--- a/cmd/juju/user/common.go
+++ b/cmd/juju/user/common.go
@@ -13,12 +13,12 @@ import (
 	"github.com/juju/juju/environs/configstore"
 )
 
-// serverFileNotify is called if non-nil with the absolute path of the
-// written server file.
-var serverFileNotify func(string)
+// serverFileNotify is called with the absolute path of the written server
+// file.
+var serverFileNotify = func(string) {}
 
-// EndpointProvider defines the method used by the WriteServerFile
-// in order
+// EndpointProvider defines the method used by the writeServerFile
+// in order to get the addresses and ca-cert of the juju server.
 type EndpointProvider interface {
 	ConnectionEndpoint() (configstore.APIEndpoint, error)
 }
@@ -43,9 +43,7 @@ func writeServerFile(endpointProvider EndpointProvider, ctx *cmd.Context, userna
 	if err := ioutil.WriteFile(outPath, yaml, 0644); err != nil {
 		return errors.Trace(err)
 	}
-	if serverFileNotify != nil {
-		serverFileNotify(outPath)
-	}
+	serverFileNotify(outPath)
 	ctx.Infof("server file written to %s", outPath)
 	return nil
 }

--- a/cmd/juju/user/common.go
+++ b/cmd/juju/user/common.go
@@ -13,6 +13,10 @@ import (
 	"github.com/juju/juju/environs/configstore"
 )
 
+// serverFileNotify is called if non-nil with the absolute path of the
+// written server file.
+var serverFileNotify func(string)
+
 // EndpointProvider defines the method used by the WriteServerFile
 // in order
 type EndpointProvider interface {
@@ -20,6 +24,7 @@ type EndpointProvider interface {
 }
 
 func writeServerFile(endpointProvider EndpointProvider, ctx *cmd.Context, username, password, outPath string) error {
+	outPath = ctx.AbsPath(outPath)
 	endpoint, err := endpointProvider.ConnectionEndpoint()
 	if err != nil {
 		return errors.Trace(err)
@@ -37,6 +42,9 @@ func writeServerFile(endpointProvider EndpointProvider, ctx *cmd.Context, userna
 	}
 	if err := ioutil.WriteFile(outPath, yaml, 0644); err != nil {
 		return errors.Trace(err)
+	}
+	if serverFileNotify != nil {
+		serverFileNotify(outPath)
 	}
 	ctx.Infof("server file written to %s", outPath)
 	return nil

--- a/cmd/juju/user/common.go
+++ b/cmd/juju/user/common.go
@@ -38,6 +38,6 @@ func writeServerFile(endpointProvider EndpointProvider, ctx *cmd.Context, userna
 	if err := ioutil.WriteFile(outPath, yaml, 0644); err != nil {
 		return errors.Trace(err)
 	}
-	ctx.Infof("server file written to %s\n", outPath)
+	ctx.Infof("server file written to %s", outPath)
 	return nil
 }

--- a/cmd/juju/user/common_test.go
+++ b/cmd/juju/user/common_test.go
@@ -1,0 +1,54 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user_test
+
+import (
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/testing"
+)
+
+type CommonSuite struct {
+	BaseSuite
+	serverFilename string
+}
+
+var _ = gc.Suite(&CommonSuite{})
+
+func (s *CommonSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.serverFilename = ""
+	s.PatchValue(user.ServerFileNotify, func(filename string) {
+		s.serverFilename = filename
+	})
+}
+
+// ConnectionEndpoint so this suite implements the EndpointProvider interface.
+func (s *CommonSuite) ConnectionEndpoint() (configstore.APIEndpoint, error) {
+	return configstore.APIEndpoint{
+		// NOTE: the content here is the same as t
+		Addresses: []string{"127.0.0.1:12345"},
+		CACert:    testing.CACert,
+	}, nil
+}
+
+func (s *CommonSuite) TestAbsolutePath(c *gc.C) {
+	ctx := testing.Context(c)
+	err := user.WriteServerFile(s, ctx, "username", "password", "outfile.blah")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filepath.IsAbs(s.serverFilename), jc.IsTrue)
+	c.Assert(s.serverFilename, gc.Equals, filepath.Join(ctx.Dir, "outfile.blah"))
+}
+
+func (s *CommonSuite) TestFileContent(c *gc.C) {
+	ctx := testing.Context(c)
+	err := user.WriteServerFile(s, ctx, "username", "password", "outfile.blah")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertServerFileMatches(c, s.serverFilename, "username", "password")
+}

--- a/cmd/juju/user/disenable.go
+++ b/cmd/juju/user/disenable.go
@@ -88,7 +88,7 @@ type DisenableUserAPI interface {
 }
 
 func (c *DisenableUserBase) getDisableUserAPI() (DisenableUserAPI, error) {
-	return c.NewUserManagerClient()
+	return c.NewUserManagerAPIClient()
 }
 
 var getDisableUserAPI = (*DisenableUserBase).getDisableUserAPI

--- a/cmd/juju/user/disenable.go
+++ b/cmd/juju/user/disenable.go
@@ -111,8 +111,8 @@ func (c *DisableCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 		c.api = api
+		defer c.api.Close()
 	}
-	defer c.api.Close()
 
 	if err := c.api.DisableUser(c.User); err != nil {
 		return block.ProcessBlockedError(err, block.BlockChange)
@@ -129,8 +129,8 @@ func (c *EnableCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 		c.api = api
+		defer c.api.Close()
 	}
-	defer c.api.Close()
 
 	if err := c.api.EnableUser(c.User); err != nil {
 		return block.ProcessBlockedError(err, block.BlockChange)

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -6,6 +6,8 @@ package user
 var (
 	RandomPasswordNotify = &randomPasswordNotify
 	ReadPassword         = &readPassword
+	ServerFileNotify     = &serverFileNotify
+	WriteServerFile      = writeServerFile
 )
 
 // NewAddCommand returns an AddCommand with the api provided as specified.

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -4,7 +4,8 @@
 package user
 
 var (
-	ReadPassword = &readPassword
+	RandomPasswordNotify = &randomPasswordNotify
+	ReadPassword         = &readPassword
 )
 
 // NewAddCommand returns an AddCommand with the api provided as specified.

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -3,33 +3,8 @@
 
 package user
 
-import (
-	"github.com/juju/cmd"
-)
-
 var (
 	ReadPassword = &readPassword
-	// disable and enable
-	GetDisableUserAPI = &getDisableUserAPI
-)
-
-// DisenableCommand is used for testing both Disable and Enable user commands.
-type DisenableCommand interface {
-	cmd.Command
-	Username() string
-}
-
-func (c *DisableCommand) Username() string {
-	return c.user
-}
-
-func (c *EnableCommand) Username() string {
-	return c.user
-}
-
-var (
-	_ DisenableCommand = (*DisableCommand)(nil)
-	_ DisenableCommand = (*EnableCommand)(nil)
 )
 
 // NewAddCommand returns an AddCommand with the api provided as specified.
@@ -45,6 +20,26 @@ func NewChangePasswordCommand(api ChangePasswordAPI, writer EnvironInfoCredsWrit
 	return &ChangePasswordCommand{
 		api:    api,
 		writer: writer,
+	}
+}
+
+// NewDisableCommand returns a DisableCommand with the api provided as
+// specified.
+func NewDisableCommand(api DisenableUserAPI) *DisableCommand {
+	return &DisableCommand{
+		DisenableUserBase{
+			api: api,
+		},
+	}
+}
+
+// NewEnableCommand returns a EnableCommand with the api provided as
+// specified.
+func NewEnableCommand(api DisenableUserAPI) *EnableCommand {
+	return &EnableCommand{
+		DisenableUserBase{
+			api: api,
+		},
 	}
 }
 

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -9,13 +9,6 @@ import (
 
 var (
 	ReadPassword = &readPassword
-	// add
-	GetAddUserAPI  = &getAddUserAPI
-	GetShareEnvAPI = &getShareEnvAPI
-	// change password
-	GetChangePasswordAPI     = &getChangePasswordAPI
-	GetEnvironInfoWriter     = &getEnvironInfoWriter
-	GetConnectionCredentials = &getConnectionCredentials
 	// disable and enable
 	GetDisableUserAPI = &getDisableUserAPI
 )
@@ -38,6 +31,22 @@ var (
 	_ DisenableCommand = (*DisableCommand)(nil)
 	_ DisenableCommand = (*EnableCommand)(nil)
 )
+
+// NewAddCommand returns an AddCommand with the api provided as specified.
+func NewAddCommand(api AddUserAPI) *AddCommand {
+	return &AddCommand{
+		api: api,
+	}
+}
+
+// NewChangePasswordCommand returns a ChangePasswordCommand with the api
+// and writer provided as specified.
+func NewChangePasswordCommand(api ChangePasswordAPI, writer EnvironInfoCredsWriter) *ChangePasswordCommand {
+	return &ChangePasswordCommand{
+		api:    api,
+		writer: writer,
+	}
+}
 
 // NewInfoCommand returns an InfoCommand with the api provided as specified.
 func NewInfoCommand(api UserInfoAPI) *InfoCommand {

--- a/cmd/juju/user/info.go
+++ b/cmd/juju/user/info.go
@@ -107,7 +107,7 @@ func (c *InfoCommandBase) getUserInfoAPI() (UserInfoAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
-	return c.NewUserManagerClient()
+	return c.NewUserManagerAPIClient()
 }
 
 // Run implements Command.Run.

--- a/cmd/juju/user/info_test.go
+++ b/cmd/juju/user/info_test.go
@@ -36,7 +36,7 @@ var (
 )
 
 func newUserInfoCommand() cmd.Command {
-	return envcmd.Wrap(user.NewInfoCommand(&fakeUserInfoAPI{}))
+	return envcmd.WrapSystem(user.NewInfoCommand(&fakeUserInfoAPI{}))
 }
 
 type fakeUserInfoAPI struct{}

--- a/cmd/juju/user/list_test.go
+++ b/cmd/juju/user/list_test.go
@@ -27,7 +27,7 @@ type UserListCommandSuite struct {
 var _ = gc.Suite(&UserListCommandSuite{})
 
 func newUserListCommand() cmd.Command {
-	return envcmd.Wrap(user.NewListCommand(&fakeUserListAPI{}))
+	return envcmd.WrapSystem(user.NewListCommand(&fakeUserListAPI{}))
 }
 
 type fakeUserListAPI struct{}

--- a/cmd/juju/user/user.go
+++ b/cmd/juju/user/user.go
@@ -4,13 +4,8 @@
 package user
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/utils"
-	"github.com/juju/utils/readpass"
 
 	"github.com/juju/juju/cmd/envcmd"
 )
@@ -46,31 +41,4 @@ func NewSuperCommand() cmd.Command {
 // user manager client.
 type UserCommandBase struct {
 	envcmd.SysCommandBase
-}
-
-var readPassword = readpass.ReadPassword
-
-func (*UserCommandBase) generateOrReadPassword(ctx *cmd.Context, generate bool) (string, error) {
-	if generate {
-		password, err := utils.RandomPassword()
-		if err != nil {
-			return "", errors.Annotate(err, "failed to generate random password")
-		}
-		return password, nil
-	}
-
-	fmt.Fprintln(ctx.Stdout, "password:")
-	password, err := readPassword()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	fmt.Fprintln(ctx.Stdout, "type password again:")
-	verify, err := readPassword()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if password != verify {
-		return "", errors.New("Passwords do not match")
-	}
-	return password, nil
 }

--- a/cmd/juju/user/user.go
+++ b/cmd/juju/user/user.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/readpass"
 
-	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/cmd/envcmd"
 )
 
@@ -34,29 +33,19 @@ func NewSuperCommand() cmd.Command {
 		UsagePrefix: "juju",
 		Purpose:     userCommandPurpose,
 	})
-	usercmd.Register(envcmd.Wrap(&AddCommand{}))
-	usercmd.Register(envcmd.Wrap(&ChangePasswordCommand{}))
-	usercmd.Register(envcmd.Wrap(&InfoCommand{}))
-	usercmd.Register(envcmd.Wrap(&DisableCommand{}))
-	usercmd.Register(envcmd.Wrap(&EnableCommand{}))
-	usercmd.Register(envcmd.Wrap(&ListCommand{}))
+	usercmd.Register(envcmd.WrapSystem(&AddCommand{}))
+	usercmd.Register(envcmd.WrapSystem(&ChangePasswordCommand{}))
+	usercmd.Register(envcmd.WrapSystem(&InfoCommand{}))
+	usercmd.Register(envcmd.WrapSystem(&DisableCommand{}))
+	usercmd.Register(envcmd.WrapSystem(&EnableCommand{}))
+	usercmd.Register(envcmd.WrapSystem(&ListCommand{}))
 	return usercmd
 }
 
 // UserCommandBase is a helper base structure that has a method to get the
 // user manager client.
 type UserCommandBase struct {
-	envcmd.EnvCommandBase
-}
-
-// NewUserManagerClient returns a usermanager client for the root api endpoint
-// that the environment command returns.
-func (c *UserCommandBase) NewUserManagerClient() (*usermanager.Client, error) {
-	root, err := c.NewAPIRoot()
-	if err != nil {
-		return nil, err
-	}
-	return usermanager.NewClient(root), nil
+	envcmd.SysCommandBase
 }
 
 var readPassword = readpass.ReadPassword

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -4,6 +4,7 @@
 package user_test
 
 import (
+	"github.com/juju/juju/cmd/envcmd"
 	"os"
 
 	jc "github.com/juju/testing/checkers"
@@ -40,11 +41,11 @@ func (s *UserCommandSuite) TestHelp(c *gc.C) {
 }
 
 type BaseSuite struct {
-	testing.BaseSuite
+	testing.FakeJujuHomeSuite
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.FakeJujuHomeSuite.SetUpTest(c)
 	memstore := configstore.NewMem()
 	s.PatchValue(&configstore.Default, func() (configstore.Storage, error) {
 		return memstore, nil
@@ -67,4 +68,6 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(user.ReadPassword, func() (string, error) {
 		return "sekrit", nil
 	})
+	err = envcmd.WriteCurrentSystem("testing")
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -4,12 +4,14 @@
 package user_test
 
 import (
-	"github.com/juju/juju/cmd/envcmd"
+	"io/ioutil"
 	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v1"
 
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/juju/osenv"
@@ -70,4 +72,17 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	})
 	err = envcmd.WriteCurrentSystem("testing")
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BaseSuite) assertServerFileMatches(c *gc.C, serverfile, username, password string) {
+	yaml, err := ioutil.ReadFile(serverfile)
+	c.Assert(err, jc.ErrorIsNil)
+	var content envcmd.ServerFile
+	err = goyaml.Unmarshal(yaml, &content)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(content.Username, gc.Equals, username)
+	c.Assert(content.Password, gc.Equals, password)
+	c.Assert(content.CACert, gc.Equals, testing.CACert)
+	c.Assert(content.Addresses, jc.DeepEquals, []string{"127.0.0.1:12345"})
 }

--- a/featuretests/cmd_juju_system_test.go
+++ b/featuretests/cmd_juju_system_test.go
@@ -69,7 +69,7 @@ func (s *cmdSystemSuite) TestSystemLoginCommand(c *gc.C) {
 		Password:  "super-secret",
 	})
 	apiInfo := s.APIInfo(c)
-	serverFile := system.ServerFile{
+	serverFile := envcmd.ServerFile{
 		Addresses: apiInfo.Addrs,
 		CACert:    apiInfo.CACert,
 		Username:  user.Name(),


### PR DESCRIPTION
This branch also changes the behaviour of the 'juju user add' command.

It now always generates passwords randomly, and writes server files.

Minor tweak for change password so when asking for the password, it doesn't add the carriage return until after the user has pressed enter on the readpass.

(Review request: http://reviews.vapour.ws/r/1791/)