### PR TITLE
Merge pull request #2424 from wallyworld/leadership-err-fix

### DIFF
--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -58,7 +59,7 @@ func (s *leadershipSuite) SetUpTest(c *gc.C) {
 		Jobs:       []state.MachineJob{state.JobManageEnviron},
 	})
 	c.Assert(stateServer.PasswordValid(password), gc.Equals, true)
-	c.Assert(stateServer.SetMongoPassword(password), gc.IsNil)
+	c.Assert(stateServer.SetMongoPassword(password), jc.ErrorIsNil)
 
 	// Create a machine to host some units.
 	unitHostMachine := s.Factory.MakeMachine(c, &factory.MachineParams{
@@ -74,7 +75,7 @@ func (s *leadershipSuite) SetUpTest(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Machine: unitHostMachine, Service: service})
 	s.unitId = unit.UnitTag().Id()
 
-	c.Assert(unit.SetPassword(password), gc.IsNil)
+	c.Assert(unit.SetPassword(password), jc.ErrorIsNil)
 	s.apiState = s.OpenAPIAs(c, unit.Tag(), password)
 
 	// Tweak and write out the config file for the state server.
@@ -102,18 +103,18 @@ func (s *leadershipSuite) SetUpTest(c *gc.C) {
 	c.Log("Starting machine agent...")
 	go func() {
 		err := s.machineAgent.Run(coretesting.Context(c))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, jc.ErrorIsNil)
 	}()
 }
 
 func (s *leadershipSuite) TearDownTest(c *gc.C) {
 	c.Log("Stopping machine agent...")
 	err := s.machineAgent.Stop()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	os.RemoveAll(filepath.Join(s.DataDir(), "tools"))
 	if s.apiState != nil {
 		err := s.apiState.Close()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, jc.ErrorIsNil)
 	}
 
 	s.AgentSuite.TearDownTest(c)
@@ -124,12 +125,18 @@ func (s *leadershipSuite) TestClaimLeadership(c *gc.C) {
 	client := leadership.NewClient(s.apiState)
 
 	err := client.ClaimLeadership(s.serviceId, s.unitId, 10*time.Second)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	tokens, err := s.State.LeasePersistor.PersistedTokens()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tokens, gc.HasLen, 1)
+	c.Assert(tokens[0].Namespace, gc.Equals, "mysql-leadership")
+	c.Assert(tokens[0].Id, gc.Equals, "mysql/0")
 
 	unblocked := make(chan struct{})
 	go func() {
 		err := client.BlockUntilLeadershipReleased(s.serviceId)
-		c.Check(err, gc.IsNil)
+		c.Check(err, jc.ErrorIsNil)
 		unblocked <- struct{}{}
 	}()
 
@@ -147,10 +154,14 @@ func (s *leadershipSuite) TestReleaseLeadership(c *gc.C) {
 	client := leadership.NewClient(s.apiState)
 
 	err := client.ClaimLeadership(s.serviceId, s.unitId, 10*time.Second)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = client.ReleaseLeadership(s.serviceId, s.unitId)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	tokens, err := s.State.LeasePersistor.PersistedTokens()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tokens, gc.HasLen, 0)
 }
 
 func (s *leadershipSuite) TestUnblock(c *gc.C) {
@@ -158,19 +169,19 @@ func (s *leadershipSuite) TestUnblock(c *gc.C) {
 	client := leadership.NewClient(s.apiState)
 
 	err := client.ClaimLeadership(s.serviceId, s.unitId, 10*time.Second)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	unblocked := make(chan struct{})
 	go func() {
 		err := client.BlockUntilLeadershipReleased(s.serviceId)
-		c.Check(err, gc.IsNil)
+		c.Check(err, jc.ErrorIsNil)
 		unblocked <- struct{}{}
 	}()
 
 	time.Sleep(coretesting.ShortWait)
 
 	err = client.ReleaseLeadership(s.serviceId, s.unitId)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	select {
 	case <-time.After(coretesting.LongWait):
@@ -196,7 +207,7 @@ func (s *uniterLeadershipSuite) TestReadLeadershipSettings(c *gc.C) {
 	// First, the unit must be elected leader; otherwise merges will be denied.
 	leaderClient := leadership.NewClient(s.apiState)
 	err := leaderClient.ClaimLeadership(s.serviceId, s.unitId, 10*time.Second)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	client := uniter.NewState(s.apiState, names.NewUnitTag(s.unitId))
 
@@ -207,10 +218,10 @@ func (s *uniterLeadershipSuite) TestReadLeadershipSettings(c *gc.C) {
 	}
 
 	err = client.LeadershipSettings.Merge(s.serviceId, desiredSettings)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	settings, err := client.LeadershipSettings.Read(s.serviceId)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(settings, gc.DeepEquals, desiredSettings)
 }
 
@@ -219,13 +230,13 @@ func (s *uniterLeadershipSuite) TestMergeLeadershipSettings(c *gc.C) {
 	// First, the unit must be elected leader; otherwise merges will be denied.
 	leaderClient := leadership.NewClient(s.apiState)
 	err := leaderClient.ClaimLeadership(s.serviceId, s.unitId, 10*time.Second)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	client := uniter.NewState(s.apiState, names.NewUnitTag(s.unitId))
 
 	// Grab what settings exist.
 	settings, err := client.LeadershipSettings.Read(s.serviceId)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	// Double check that it's empty so that we don't pass the test by
 	// happenstance.
 	c.Assert(settings, gc.HasLen, 0)
@@ -235,10 +246,10 @@ func (s *uniterLeadershipSuite) TestMergeLeadershipSettings(c *gc.C) {
 	settings["baz"] = "biz"
 
 	err = client.LeadershipSettings.Merge(s.serviceId, settings)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	settings, err = client.LeadershipSettings.Read(s.serviceId)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(settings["foo"], gc.Equals, "bar")
 	c.Check(settings["baz"], gc.Equals, "biz")
 }
@@ -248,13 +259,13 @@ func (s *uniterLeadershipSuite) TestSettingsChangeNotifier(c *gc.C) {
 	// First, the unit must be elected leader; otherwise merges will be denied.
 	leaderClient := leadership.NewClient(s.apiState)
 	err := leaderClient.ClaimLeadership(s.serviceId, s.unitId, 10*time.Second)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	client := uniter.NewState(s.apiState, names.NewUnitTag(s.unitId))
 
 	// Listen for changes
 	watcher, err := client.LeadershipSettings.WatchLeadershipSettings(s.serviceId)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	defer statetesting.AssertStop(c, watcher)
 
@@ -264,21 +275,21 @@ func (s *uniterLeadershipSuite) TestSettingsChangeNotifier(c *gc.C) {
 
 	// Make some changes
 	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"foo": "bar"})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	leadershipC.AssertOneChange()
 
 	// And check that the changes were actually applied
 	settings, err := client.LeadershipSettings.Read(s.serviceId)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(settings["foo"], gc.Equals, "bar")
 
 	// Make a couple of changes, and then check that they have been
 	// coalesced into a single event
 	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"foo": "baz"})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	err = client.LeadershipSettings.Merge(s.serviceId, map[string]string{"bing": "bong"})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	leadershipC.AssertOneChange()
 }
 
@@ -302,7 +313,7 @@ func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 		Jobs:       []state.MachineJob{state.JobManageEnviron},
 	})
 	c.Assert(stateServer.PasswordValid(password), gc.Equals, true)
-	c.Assert(stateServer.SetMongoPassword(password), gc.IsNil)
+	c.Assert(stateServer.SetMongoPassword(password), jc.ErrorIsNil)
 
 	// Create a machine to host some units.
 	unitHostMachine := s.factory.MakeMachine(c, &factory.MachineParams{
@@ -318,7 +329,7 @@ func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 	unit := s.factory.MakeUnit(c, &factory.UnitParams{Machine: unitHostMachine, Service: service})
 	s.unitId = unit.UnitTag().Id()
 
-	c.Assert(unit.SetPassword(password), gc.IsNil)
+	c.Assert(unit.SetPassword(password), jc.ErrorIsNil)
 	s.apiState = s.OpenAPIAs(c, unit.Tag(), password)
 
 	// Tweak and write out the config file for the state server.
@@ -346,7 +357,7 @@ func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 	c.Log("Starting machine agent...")
 	go func() {
 		err := s.machineAgent.Run(coretesting.Context(c))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, jc.ErrorIsNil)
 	}()
 }
 
@@ -356,20 +367,20 @@ func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 func createMockJujudExecutable(c *gc.C, dir, tag string) string {
 	toolsDir := filepath.Join(dir, "tools")
 	err := os.MkdirAll(filepath.Join(toolsDir, tag), 0755)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(filepath.Join(toolsDir, tag, "jujud.exe"),
 		[]byte("echo 1"), 0777)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	return toolsDir
 }
 
 func (s *uniterLeadershipSuite) TearDownTest(c *gc.C) {
 	c.Log("Stopping machine agent...")
 	err := s.machineAgent.Stop()
-	c.Check(err, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
 	if s.apiState != nil {
 		err := s.apiState.Close()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, jc.ErrorIsNil)
 	}
 	s.AgentSuite.TearDownTest(c)
 }
@@ -405,8 +416,8 @@ func writeStateAgentConfig(
 			StatePort:    gitjujutesting.MgoServer.Port(),
 			APIPort:      port,
 		})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	conf.SetPassword(password)
-	c.Assert(conf.Write(), gc.IsNil)
+	c.Assert(conf.Write(), jc.ErrorIsNil)
 	return conf
 }

--- a/lease/lease_test.go
+++ b/lease/lease_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/errors"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -35,6 +36,9 @@ type stubLeasePersistor struct {
 }
 
 func (p *stubLeasePersistor) WriteToken(id string, tok Token) error {
+	if tok.Id == "error" {
+		return errors.New("error")
+	}
 	if p.WriteTokenFn != nil {
 		return p.WriteTokenFn(id, tok)
 	}
@@ -55,7 +59,9 @@ func (p *stubLeasePersistor) PersistedTokens() ([]Token, error) {
 	return nil, nil
 }
 
-type leaseSuite struct{}
+type leaseSuite struct {
+	coretesting.BaseSuite
+}
 
 func (s *leaseSuite) TestSingleton(c *gc.C) {
 	stop := make(chan struct{})
@@ -149,6 +155,18 @@ func (s *leaseSuite) TestClaimLeaseSuccess(c *gc.C) {
 	c.Assert(toks[0].Id, gc.Equals, testId)
 }
 
+func (s *leaseSuite) TestClaimLeaseError(c *gc.C) {
+	stop := make(chan struct{})
+	go func() {
+		err := WorkerLoop(&stubLeasePersistor{})(stop)
+		c.Assert(err, gc.NotNil)
+	}()
+	mgr := Manager()
+
+	_, err := mgr.ClaimLease(testNamespace, "error", testDuration)
+	c.Assert(errors.Cause(err), gc.Equals, LeaseManagerErr)
+}
+
 func (s *leaseSuite) TestClaimLeaseRaces(c *gc.C) {
 	stop := make(chan struct{})
 	go WorkerLoop(&stubLeasePersistor{})(stop)
@@ -201,6 +219,46 @@ func (s *leaseSuite) TestReleaseLease(c *gc.C) {
 
 	toks := mgr.CopyOfLeaseTokens()
 	c.Assert(toks, gc.HasLen, 0)
+}
+
+type stubLeasePersistorRemoveError struct {
+	stubLeasePersistor
+}
+
+func (p *stubLeasePersistorRemoveError) RemoveToken(id string) error {
+	return errors.New("error")
+}
+
+func (s *leaseSuite) TestReleaseLeaseError(c *gc.C) {
+	stop := make(chan struct{})
+	go func() {
+		err := WorkerLoop(&stubLeasePersistorRemoveError{})(stop)
+		c.Assert(err, gc.NotNil)
+	}()
+	mgr := Manager()
+	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = mgr.ReleaseLease(testNamespace, testId)
+	c.Assert(errors.Cause(err), gc.Equals, LeaseManagerErr)
+}
+
+func (s *leaseSuite) TestReleaseLeaseNotOwned(c *gc.C) {
+	stop := make(chan struct{})
+	go WorkerLoop(&stubLeasePersistor{})(stop)
+	defer func() { stop <- struct{}{} }()
+	mgr := Manager()
+	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = mgr.ReleaseLease(testNamespace, "1234")
+	// No error returned (we log it).
+	c.Assert(err, jc.ErrorIsNil)
+	// But cache unaffected.
+	toks := mgr.CopyOfLeaseTokens()
+	c.Assert(toks, gc.HasLen, 1)
+	c.Assert(toks[0].Namespace, gc.Equals, testNamespace)
+	c.Assert(toks[0].Id, gc.Equals, testId)
 }
 
 func (s *leaseSuite) TestReleaseLeaseRaces(c *gc.C) {

--- a/state/lease.go
+++ b/state/lease.go
@@ -7,28 +7,39 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/lease"
 )
 
+// leaseEntity represents a lease in mongo.
 type leaseEntity struct {
-	LastUpdate time.Time
-	lease.Token
+	LastUpdate  time.Time `bson:"lastupdate"`
+	lease.Token `bson:"token"`
+
+	// TxnRevNo is used to ensure no other client has
+	// updated the same lease while a write is being done.
+	TxnRevno int64 `bson:"txn-revno"`
 }
 
 // NewLeasePersistor returns a new LeasePersistor. It should be passed
 // functions it can use to run transactions and get collections.
 func NewLeasePersistor(
 	collectionName string,
-	runTransaction func([]txn.Op) error,
+	runTransaction func(jujutxn.TransactionSource) error,
 	getCollection func(string) (_ stateCollection, closer func()),
 ) *LeasePersistor {
+	getLeaseCollection := func(name string) (_ leaseCollection, closer func()) {
+		sc, closer := getCollection(name)
+		return &genericLeaseCollection{sc}, closer
+	}
 	return &LeasePersistor{
 		collectionName: collectionName,
 		runTransaction: runTransaction,
-		getCollection:  getCollection,
+		getCollection:  getLeaseCollection,
 	}
 }
 
@@ -36,35 +47,70 @@ func NewLeasePersistor(
 // data store.
 type LeasePersistor struct {
 	collectionName string
-	runTransaction func([]txn.Op) error
-	getCollection  func(string) (_ stateCollection, closer func())
+	runTransaction func(jujutxn.TransactionSource) error
+	getCollection  func(string) (_ leaseCollection, closer func())
+}
+
+// leaseCollection provides bespoke lease methods on top of a standard
+// state collection.
+type leaseCollection interface {
+	stateCollection
+
+	// FindById finds the lease with the specified id.
+	FindById(id string) (*leaseEntity, error)
+}
+
+type genericLeaseCollection struct {
+	stateCollection
+}
+
+// FindById finds the lease with the specified id.
+func (lf *genericLeaseCollection) FindById(id string) (*leaseEntity, error) {
+	var lease leaseEntity
+	if err := lf.FindId(id).One(&lease); err != nil {
+		return nil, err
+	}
+	return &lease, nil
 }
 
 // WriteToken writes the given token to the data store with the given
 // ID.
 func (p *LeasePersistor) WriteToken(id string, tok lease.Token) error {
 
-	entity := leaseEntity{time.Now(), tok}
+	collection, closer := p.getCollection(p.collectionName)
+	defer closer()
 
-	// Write's should always overwrite anything that's there. The
-	// business-logic of managing leases is handled elsewhere.
-	ops := []txn.Op{
-		// First remove anything that's there.
-		{
-			C:      p.collectionName,
-			Id:     id,
-			Remove: true,
-		},
-		// Then insert the token.
-		{
-			Assert: txn.DocMissing,
-			C:      p.collectionName,
-			Id:     id,
-			Insert: entity,
-		},
+	// TODO(wallyworld) - this logic is a stop-gap until a proper refactoring is done
+	// We'll be especially paranoid here - to avoid potentially overwriting lease info
+	// from another client, if the txn fails to apply, we'll abort instead of retrying.
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			return nil, errors.New("simultaneous lease updates occurred")
+		}
+		existing, err := collection.FindById(id)
+		if err == mgo.ErrNotFound {
+			entity := leaseEntity{LastUpdate: time.Now(), Token: tok}
+			return []txn.Op{
+				{
+					C:      p.collectionName,
+					Id:     id,
+					Assert: txn.DocMissing,
+					Insert: entity,
+				},
+			}, nil
+		} else if err != nil {
+			return nil, errors.Annotatef(err, "reading existing lease for token %v", tok)
+		}
+		return []txn.Op{
+			{
+				C:      p.collectionName,
+				Id:     id,
+				Assert: bson.D{{"txn-revno", existing.TxnRevno}},
+				Update: bson.M{"$set": bson.M{"lastupdate": time.Now(), "token": tok}},
+			},
+		}, nil
 	}
-
-	if err := p.runTransaction(ops); err != nil {
+	if err := p.runTransaction(buildTxn); err != nil {
 		return errors.Annotatef(err, `could not add token "%s" to data-store`, tok.Id)
 	}
 
@@ -75,8 +121,20 @@ func (p *LeasePersistor) WriteToken(id string, tok lease.Token) error {
 // store.
 func (p *LeasePersistor) RemoveToken(id string) error {
 
-	ops := []txn.Op{{C: p.collectionName, Id: id, Remove: true}}
-	if err := p.runTransaction(ops); err != nil {
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt == 0 {
+			return []txn.Op{
+				{
+					C:      p.collectionName,
+					Id:     id,
+					Assert: txn.DocExists,
+					Remove: true,
+				},
+			}, nil
+		}
+		return nil, jujutxn.ErrNoOperations
+	}
+	if err := p.runTransaction(buildTxn); err != nil {
 		return errors.Annotatef(err, `could not remove token "%s"`, id)
 	}
 

--- a/state/lease_test.go
+++ b/state/lease_test.go
@@ -6,7 +6,11 @@ package state
 import (
 	"time"
 
+	jc "github.com/juju/testing/checkers"
+	jujutxn "github.com/juju/txn"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/lease"
@@ -27,7 +31,7 @@ var (
 // Stub functions for when we don't care.
 //
 
-func stubRunTransaction(ops []txn.Op) error {
+func stubRunTransaction(txns jujutxn.TransactionSource) error {
 	return nil
 }
 
@@ -35,44 +39,112 @@ func stubGetCollection(collectionName string) (stateCollection, func()) {
 	return &genericStateCollection{}, func() {}
 }
 
+type stubLeaseCollection struct {
+	stateCollection
+	tokenToReturn *leaseEntity
+}
+
+func (s *stubLeaseCollection) FindById(id string) (*leaseEntity, error) {
+	if s.tokenToReturn == nil {
+		return nil, mgo.ErrNotFound
+	}
+	return s.tokenToReturn, nil
+}
+
 type leaseSuite struct{}
 
-func (s *leaseSuite) TestWriteToken(c *gc.C) {
+func (s *leaseSuite) TestWriteNewToken(c *gc.C) {
 
 	tok := lease.Token{testNamespace, testId, time.Now().Add(testDuration)}
 
-	stubRunTransaction := func(ops []txn.Op) error {
-		c.Assert(ops, gc.HasLen, 2)
-
-		// First delete.
+	stubRunTransaction := func(txns jujutxn.TransactionSource) error {
+		ops, err := txns(0)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(ops[0].Assert, gc.Equals, txn.DocMissing)
 		c.Check(ops[0].C, gc.Equals, testCollectionName)
-		c.Check(ops[0].Remove, gc.Equals, true)
+		c.Check(ops[0].Insert.(leaseEntity).Token, gc.DeepEquals, tok)
 		c.Check(ops[0].Id, gc.Equals, testId)
-
-		// Then insert.
-		c.Check(ops[1].Assert, gc.Equals, txn.DocMissing)
-		c.Check(ops[1].C, gc.Equals, testCollectionName)
-		c.Check(ops[1].Insert.(leaseEntity).Token, gc.DeepEquals, tok)
-		c.Check(ops[1].Id, gc.Equals, testId)
-
 		return nil
 	}
 
-	persistor := NewLeasePersistor(testCollectionName, stubRunTransaction, stubGetCollection)
-
+	closerCallCount := 0
+	stubGetCollection := func(collectionName string) (leaseCollection, func()) {
+		c.Check(collectionName, gc.Equals, testCollectionName)
+		return &stubLeaseCollection{&genericStateCollection{}, nil}, func() { closerCallCount++ }
+	}
+	persistor := LeasePersistor{testCollectionName, stubRunTransaction, stubGetCollection}
 	err := persistor.WriteToken(testId, tok)
-
 	c.Assert(err, gc.IsNil)
+	c.Assert(closerCallCount, gc.Equals, 1)
+}
+
+func (s *leaseSuite) TestWriteTokenReplaceExisting(c *gc.C) {
+
+	tok := lease.Token{testNamespace, testId, time.Now().Add(testDuration)}
+	now := time.Now()
+	stubRunTransaction := func(txns jujutxn.TransactionSource) error {
+		ops, err := txns(0)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(ops[0].Assert, gc.DeepEquals, bson.D{bson.DocElem{Name: "txn-revno", Value: int64(10)}})
+		c.Check(ops[0].C, gc.Equals, testCollectionName)
+		c.Check(ops[0].Id, gc.Equals, testId)
+
+		values := ops[0].Update.(bson.M)["$set"].(bson.M)
+		token := values["token"].(lease.Token)
+		c.Assert(token, gc.DeepEquals, tok)
+		lastUpdate := values["lastupdate"].(time.Time)
+		c.Assert(lastUpdate.After(now), jc.IsTrue)
+		return nil
+	}
+
+	existingTok := lease.Token{testNamespace, "1234", time.Now().Add(testDuration)}
+	existing := leaseEntity{now, existingTok, 10}
+	closerCallCount := 0
+	stubGetCollection := func(collectionName string) (leaseCollection, func()) {
+		c.Check(collectionName, gc.Equals, testCollectionName)
+		return &stubLeaseCollection{&genericStateCollection{}, &existing}, func() { closerCallCount++ }
+	}
+	persistor := LeasePersistor{testCollectionName, stubRunTransaction, stubGetCollection}
+	err := persistor.WriteToken(testId, tok)
+	c.Assert(err, gc.IsNil)
+	c.Assert(closerCallCount, gc.Equals, 1)
+}
+
+func (s *leaseSuite) TestWriteTokenConflict(c *gc.C) {
+
+	tok := lease.Token{testNamespace, testId, time.Now().Add(testDuration)}
+
+	stubRunTransaction := func(txns jujutxn.TransactionSource) error {
+		// Any attempt to build txns with attempt>1 is rejected.
+		_, err := txns(1)
+		c.Assert(err, gc.NotNil)
+		return err
+	}
+
+	closerCallCount := 0
+	stubGetCollection := func(collectionName string) (leaseCollection, func()) {
+		c.Check(collectionName, gc.Equals, testCollectionName)
+		return &stubLeaseCollection{&genericStateCollection{}, nil}, func() { closerCallCount++ }
+	}
+	persistor := LeasePersistor{testCollectionName, stubRunTransaction, stubGetCollection}
+	err := persistor.WriteToken(testId, tok)
+	c.Assert(err, gc.NotNil)
+	c.Assert(closerCallCount, gc.Equals, 1)
 }
 
 func (s *leaseSuite) TestRemoveToken(c *gc.C) {
 
-	stubRunTransaction := func(ops []txn.Op) error {
+	stubRunTransaction := func(txns jujutxn.TransactionSource) error {
+		ops, err := txns(0)
+		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(ops, gc.HasLen, 1)
 
 		c.Check(ops[0].C, gc.Equals, testCollectionName)
 		c.Check(ops[0].Remove, gc.Equals, true)
 		c.Check(ops[0].Id, gc.Equals, testId)
+
+		_, err = txns(1)
+		c.Assert(err, gc.Equals, jujutxn.ErrNoOperations)
 
 		return nil
 	}

--- a/state/open.go
+++ b/state/open.go
@@ -261,7 +261,7 @@ func newState(session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (
 			}
 		}
 	}()
-	st.LeasePersistor = NewLeasePersistor(leaseC, st.runTransaction, st.getCollection)
+	st.LeasePersistor = NewLeasePersistor(leaseC, st.run, st.getCollection)
 
 	// Create DB indexes.
 	for _, item := range indexes {


### PR DESCRIPTION
Fix lease txn structure; do not ignore errors; worker exists on error

Various leadership issues are fixes, as highlighted by WIlliam.

1. The lease persister has been refactored to use the (Juju) standard txnrunner.run() mechanism. This takes a buildTxn function which can be used to ensure that all txn ops are conditional.

2. Based on 1, transaction ops are no longer unconditional.

3. Errors persisting leases are not ignored. The callers receive the error and the worker now exists. This allows it to restart and reload its lease cache to ensure the cache is not corrupted.

4. Unit tests enhanced to check worker exit on error etc.

5. Feature tests enhanced to actually confirm that the lease records are persisted/updated when a lease is claimed / released.

(Review request: http://reviews.vapour.ws/r/1787/)

(Review request: http://reviews.vapour.ws/r/1792/)