### PR TITLE
integrated logsender worker into the machine and unit agents

### DIFF
--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -21,12 +21,14 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/leadership"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/apiaddressupdater"
 	workerlogger "github.com/juju/juju/worker/logger"
+	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/proxyupdater"
 	"github.com/juju/juju/worker/rsyslog"
 	"github.com/juju/juju/worker/uniter"
@@ -45,6 +47,7 @@ type UnitAgent struct {
 	AgentConf
 	UnitName         string
 	runner           worker.Runner
+	bufferedLogs     logsender.LogRecordCh
 	setupLogging     func(agent.Config) error
 	logToStdErr      bool
 	ctx              *cmd.Context
@@ -52,10 +55,11 @@ type UnitAgent struct {
 }
 
 // NewUnitAgent creates a new UnitAgent value properly initialized.
-func NewUnitAgent(ctx *cmd.Context) *UnitAgent {
+func NewUnitAgent(ctx *cmd.Context, bufferedLogs logsender.LogRecordCh) *UnitAgent {
 	return &UnitAgent{
-		AgentConf: NewAgentConf(""),
-		ctx:       ctx,
+		AgentConf:    NewAgentConf(""),
+		ctx:          ctx,
+		bufferedLogs: bufferedLogs,
 	}
 }
 
@@ -187,10 +191,16 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 	}
 
 	runner := worker.NewRunner(cmdutil.ConnectionIsFatal(logger, st), cmdutil.MoreImportant)
+
 	// start proxyupdater first to ensure proxy settings are correct
 	runner.StartWorker("proxyupdater", func() (worker.Worker, error) {
 		return proxyupdater.New(st.Environment(), false), nil
 	})
+	if featureflag.Enabled(feature.DbLog) {
+		runner.StartWorker("logsender", func() (worker.Worker, error) {
+			return logsender.New(a.bufferedLogs, agentConfig.APIInfo()), nil
+		})
+	}
 	runner.StartWorker("upgrader", func() (worker.Worker, error) {
 		return upgrader.NewUpgrader(
 			st.Upgrader(),

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -98,7 +98,7 @@ func (s *UnitSuite) primeAgent(c *gc.C) (*state.Machine, *state.Unit, agent.Conf
 }
 
 func (s *UnitSuite) newAgent(c *gc.C, unit *state.Unit) *UnitAgent {
-	a := NewUnitAgent(nil)
+	a := NewUnitAgent(nil, nil)
 	s.InitAgent(c, a, "--unit-name", unit.Name(), "--log-to-stderr=true")
 	err := a.ReadConfig(unit.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
@@ -106,7 +106,7 @@ func (s *UnitSuite) newAgent(c *gc.C, unit *state.Unit) *UnitAgent {
 }
 
 func (s *UnitSuite) TestParseSuccess(c *gc.C) {
-	a := NewUnitAgent(nil)
+	a := NewUnitAgent(nil, nil)
 	err := coretesting.InitCommand(a, []string{
 		"--data-dir", "jd",
 		"--unit-name", "w0rd-pre55/1",
@@ -119,7 +119,7 @@ func (s *UnitSuite) TestParseSuccess(c *gc.C) {
 }
 
 func (s *UnitSuite) TestParseMissing(c *gc.C) {
-	uc := NewUnitAgent(nil)
+	uc := NewUnitAgent(nil, nil)
 	err := coretesting.InitCommand(uc, []string{
 		"--data-dir", "jc",
 	})
@@ -135,13 +135,13 @@ func (s *UnitSuite) TestParseNonsense(c *gc.C) {
 		{"--unit-name", "wordpress/wild/9"},
 		{"--unit-name", "20/20"},
 	} {
-		err := coretesting.InitCommand(NewUnitAgent(nil), append(args, "--data-dir", "jc"))
+		err := coretesting.InitCommand(NewUnitAgent(nil, nil), append(args, "--data-dir", "jc"))
 		c.Check(err, gc.ErrorMatches, `--unit-name option expects "<service>/<n>" argument`)
 	}
 }
 
 func (s *UnitSuite) TestParseUnknown(c *gc.C) {
-	err := coretesting.InitCommand(NewUnitAgent(nil), []string{
+	err := coretesting.InitCommand(NewUnitAgent(nil, nil), []string{
 		"--unit-name", "wordpress/1",
 		"thundering typhoons",
 	})

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/exec"
 	"github.com/juju/utils/featureflag"
@@ -24,6 +25,7 @@ import (
 	"github.com/juju/juju/juju/sockets"
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
+	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -111,6 +113,11 @@ func jujuCMain(commandName string, args []string) (code int, err error) {
 // Main registers subcommands for the jujud executable, and hands over control
 // to the cmd package.
 func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
+	logCh, err := logsender.InstallBufferedLogWriter(20000)
+	if err != nil {
+		return 1, errors.Trace(err)
+	}
+
 	jujud := jujucmd.NewSuperCommand(cmd.SuperCommandParams{
 		Name: "jujud",
 		Doc:  jujudDoc,
@@ -122,10 +129,10 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	// MachineAgent type has called out the seperate concerns; the
 	// AgentConf should be split up to follow suite.
 	agentConf := agentcmd.NewAgentConf("")
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, logCh)
 	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
 
-	jujud.Register(agentcmd.NewUnitAgent(ctx))
+	jujud.Register(agentcmd.NewUnitAgent(ctx, logCh))
 
 	code = cmd.Main(jujud, ctx, args[1:])
 	return code, nil

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"io/ioutil"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/agent"
+	agentcmd "github.com/juju/juju/cmd/jujud/agent"
+	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/lease"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/version"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/logsender"
+)
+
+// dblogSuite tests that logs flow correctly from the machine and unit
+// agents over the API into MongoDB. These are very much integration
+// tests with more detailed testing of the individual components
+// being done in unit tests.
+type dblogSuite struct {
+	agenttesting.AgentSuite
+}
+
+func (s *dblogSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.DbLog)
+	s.AgentSuite.SetUpTest(c)
+
+	// Change the path to "juju-run", so that the
+	// tests don't try to write to /usr/local/bin.
+	file, _ := ioutil.TempFile("", "juju-run")
+	defer file.Close()
+	s.PatchValue(&agentcmd.JujuRun, file.Name())
+
+	// If we don't have a lease manager running somewhere, the
+	// leadership API calls made by the unit agent hang.
+	leaseWorker := worker.NewSimpleWorker(lease.WorkerLoop(s.State))
+	s.AddCleanup(func(*gc.C) { worker.Stop(leaseWorker) })
+}
+
+func (s *dblogSuite) TestMachineAgentLogsGoToDB(c *gc.C) {
+	foundLogs := s.runMachineAgentTest(c)
+	c.Assert(foundLogs, jc.IsTrue)
+}
+
+func (s *dblogSuite) TestMachineAgentWithoutFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags()
+	foundLogs := s.runMachineAgentTest(c)
+	c.Assert(foundLogs, jc.IsFalse)
+}
+
+func (s *dblogSuite) TestUnitAgentLogsGoToDB(c *gc.C) {
+	foundLogs := s.runUnitAgentTest(c)
+	c.Assert(foundLogs, jc.IsTrue)
+}
+
+func (s *dblogSuite) TestUnitAgentWithoutFeatureFlag(c *gc.C) {
+	s.SetFeatureFlags()
+	foundLogs := s.runUnitAgentTest(c)
+	c.Assert(foundLogs, jc.IsFalse)
+}
+
+func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
+	// Create a machine and an agent for it.
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: agent.BootstrapNonce,
+	})
+
+	s.PrimeAgent(c, m.Tag(), password, version.Current)
+	agentConf := agentcmd.NewAgentConf(s.DataDir())
+	agentConf.ReadConfig(m.Tag().String())
+	logsCh, err := logsender.InstallBufferedLogWriter(1000)
+	c.Assert(err, jc.ErrorIsNil)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, logsCh)
+	a := machineAgentFactory(m.Id())
+
+	// Ensure there's no logs to begin with.
+	c.Assert(s.getLogCount(c, m.Tag()), gc.Equals, 0)
+
+	// Start the agent.
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	defer a.Stop()
+
+	return s.waitForLogs(c, m.Tag())
+}
+
+func (s *dblogSuite) runUnitAgentTest(c *gc.C) bool {
+	// Create a unit and an agent for it.
+	u, password := s.Factory.MakeUnitReturningPassword(c, nil)
+	s.PrimeAgent(c, u.Tag(), password, version.Current)
+	logsCh, err := logsender.InstallBufferedLogWriter(1000)
+	c.Assert(err, jc.ErrorIsNil)
+	a := agentcmd.NewUnitAgent(nil, logsCh)
+	s.InitAgent(c, a, "--unit-name", u.Name(), "--log-to-stderr=true")
+
+	// Ensure there's no logs to begin with.
+	c.Assert(s.getLogCount(c, u.Tag()), gc.Equals, 0)
+
+	// Start the agent.
+	go func() { c.Assert(a.Run(nil), jc.ErrorIsNil) }()
+	defer a.Stop()
+
+	return s.waitForLogs(c, u.Tag())
+}
+
+func (s *dblogSuite) getLogCount(c *gc.C, entity names.Tag) int {
+	// TODO(mjs) - replace this with State's functionality for reading
+	// logs from the DB, once it gets this. This will happen before
+	// the DB logging feature branch is merged.
+	logs := s.Session.DB("logs").C("logs")
+	count, err := logs.Find(bson.M{"n": entity.String()}).Count()
+	c.Assert(err, jc.ErrorIsNil)
+	return count
+}
+
+func (s *dblogSuite) waitForLogs(c *gc.C, entityTag names.Tag) bool {
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		if s.getLogCount(c, entityTag) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -41,7 +41,6 @@ type leadershipSuite struct {
 }
 
 func (s *leadershipSuite) SetUpTest(c *gc.C) {
-
 	s.AgentSuite.SetUpTest(c)
 
 	file, _ := ioutil.TempFile("", "juju-run")
@@ -90,7 +89,7 @@ func (s *leadershipSuite) SetUpTest(c *gc.C) {
 
 	// Create & start a machine agent so the tests have something to call into.
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, nil)
 	s.machineAgent = machineAgentFactory(stateServer.Id())
 
 	// See comment in createMockJujudExecutable
@@ -334,7 +333,7 @@ func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 
 	// Create & start a machine agent so the tests have something to call into.
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, nil)
 	s.machineAgent = machineAgentFactory(stateServer.Id())
 
 	// See comment in createMockJujudExecutable

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -31,6 +31,7 @@ func init() {
 	gc.Suite(&apiCharmsSuite{})
 	gc.Suite(&cmdEnvironmentSuite{})
 	gc.Suite(&cmdStorageSuite{})
+	gc.Suite(&dblogSuite{})
 }
 
 func Test(t *testing.T) {

--- a/worker/logsender/worker.go
+++ b/worker/logsender/worker.go
@@ -61,7 +61,7 @@ func dialLogsinkAPI(apiInfo *api.Info) (*websocket.Conn, error) {
 	// connections to both /log (debuglog) and /logsink.
 	header := utils.BasicAuthHeader(apiInfo.Tag.String(), apiInfo.Password)
 	header.Set("X-Juju-Nonce", apiInfo.Nonce)
-	conn, err := api.Connect(apiInfo, "/logsink", header, api.DefaultDialOpts())
+	conn, err := api.Connect(apiInfo, "/logsink", header, api.DialOpts{})
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to connect to logsink API")
 	}


### PR DESCRIPTION
worker/logsender: added helpers for managing a global BufferedLogWriter instance

---

worker/logsender: don't use DefaultDialOpts

In order to remain responsive, the logsender should just error out quickly if it can't make an API connection but DefaultDialOpts entails a 10 minute timeout. Using DialOpts allows the connection attempt to timeout quickly. This is in line with what the machine agent API worker does.

---

cmd/jujud: integrated logsender into the machine and unit agents

Logs generated by machine and unit agents are now buffered and pushed up to the API server if the feature flag is enabled.

Added feature tests to check that all the pieces integrate together and also that the feature flag is checked.


(Review request: http://reviews.vapour.ws/r/1795/)