### PR TITLE
Don't use '7' for centos version as it is ambiguous

### DIFF
--- a/version/osversion_test.go
+++ b/version/osversion_test.go
@@ -57,7 +57,7 @@ VERSION_ID='12.04'
 }, {
 	`NAME="CentOS Linux"
 ID="centos"
-VERSION_ID="7"
+VERSION_ID="centos7"
 `,
 	"centos7",
 	"",

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -56,11 +56,11 @@ var seriesVersions = map[string]string{
 	"win7":        "win7",
 	"win8":        "win8",
 	"win81":       "win81",
-	"centos7":     "7",
+	"centos7":     "centos7",
 }
 
 var centosSeries = map[string]string{
-	"centos7": "7",
+	"centos7": "centos7",
 }
 
 var ubuntuSeries = map[string]string{


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1459250

Changed to be consistent with how windows series are done.

(Review request: http://reviews.vapour.ws/r/1800/)