### PR TITLE
Force the DB logging to be on if JES is enabled

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils"
-	"github.com/juju/utils/featureflag"
 	"golang.org/x/net/websocket"
 	"launchpad.net/tomb"
 
@@ -336,7 +335,7 @@ func (srv *Server) run(lis net.Listener) {
 			httpHandler: httpHandler{ssState: srv.state},
 			logDir:      srv.logDir},
 	)
-	if featureflag.Enabled(feature.DbLog) {
+	if feature.IsDbLogEnabled() {
 		handleAll(mux, "/environment/:envuuid/logsink",
 			&logSinkHandler{
 				httpHandler: httpHandler{ssState: srv.state},

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -18,7 +18,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/apiserver"
-	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -43,7 +42,7 @@ type logsinkSuite struct {
 var _ = gc.Suite(&logsinkSuite{})
 
 func (s *logsinkSuite) SetUpTest(c *gc.C) {
-	s.SetInitialFeatureFlags(feature.DbLog)
+	s.SetInitialFeatureFlags("db-log")
 	s.logsinkBaseSuite.SetUpTest(c)
 	s.nonce = "nonce"
 	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -707,7 +707,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		return proxyupdater.New(st.Environment(), writeSystemFiles), nil
 	})
 
-	if featureflag.Enabled(feature.DbLog) {
+	if feature.IsDbLogEnabled() {
 		runner.StartWorker("logsender", func() (worker.Worker, error) {
 			return logsender.New(a.bufferedLogs, agentConfig.APIInfo()), nil
 		})
@@ -1012,7 +1012,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				return newCertificateUpdater(m, agentConfig, st, stateServingSetter, certChangedChan), nil
 			})
 
-			if featureflag.Enabled(feature.DbLog) {
+			if feature.IsDbLogEnabled() {
 				a.startWorkerAfterUpgrade(singularRunner, "dblogpruner", func() (worker.Worker, error) {
 					return dblogpruner.New(st, dblogpruner.NewLogPruneParams()), nil
 				})

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -44,7 +44,6 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -652,7 +651,7 @@ func (s *MachineSuite) TestManageEnvironRunsPeergrouper(c *gc.C) {
 }
 
 func (s *MachineSuite) TestManageEnvironRunsDbLogPrunerIfFeatureFlagEnabled(c *gc.C) {
-	s.SetFeatureFlags(feature.DbLog)
+	s.SetFeatureFlags("db-log")
 
 	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
 	a := s.newAgent(c, m)

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -196,7 +196,7 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 	runner.StartWorker("proxyupdater", func() (worker.Worker, error) {
 		return proxyupdater.New(st.Environment(), false), nil
 	})
-	if featureflag.Enabled(feature.DbLog) {
+	if feature.IsDbLogEnabled() {
 		runner.StartWorker("logsender", func() (worker.Worker, error) {
 			return logsender.New(a.bufferedLogs, agentConfig.APIInfo()), nil
 		})

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -4,6 +4,10 @@
 // The feature package defines the names of the current feature flags.
 package feature
 
+import (
+	"github.com/juju/utils/featureflag"
+)
+
 // TODO (anastasiamac 2015-03-02)
 // Features that have commands that can be blocked,
 // command list for "juju block" and "juju unblock"
@@ -39,9 +43,15 @@ const LegacyUpstart = "legacy-upstart"
 // use statically allocated IP addresses.
 const AddressAllocation = "address-allocation"
 
-// DbLog is the the feature which has Juju's logs go to
-// MongoDB instead of to all-machines.log using rsyslog.
-const DbLog = "db-log"
+// dbLog indicates that Juju's logs go to MongoDB. It is not exported
+// because it should be checked for using IsDbLogEnabled.
+const dbLog = "db-log"
+
+// IsDbLogEnabled returns true if logging to MongoDB should be enabled
+// based on the dbLog or JES feature flags.
+func IsDbLogEnabled() bool {
+	return featureflag.Enabled(dbLog) || featureflag.Enabled(JES)
+}
 
 // CloudSigma enables the CloudSigma provider.
 const CloudSigma = "cloudsigma"

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -32,7 +32,7 @@ type dblogSuite struct {
 }
 
 func (s *dblogSuite) SetUpTest(c *gc.C) {
-	s.SetInitialFeatureFlags(feature.DbLog)
+	s.SetInitialFeatureFlags("db-log")
 	s.AgentSuite.SetUpTest(c)
 
 	// Change the path to "juju-run", so that the
@@ -48,6 +48,13 @@ func (s *dblogSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *dblogSuite) TestMachineAgentLogsGoToDB(c *gc.C) {
+	s.SetFeatureFlags("db-log")
+	foundLogs := s.runMachineAgentTest(c)
+	c.Assert(foundLogs, jc.IsTrue)
+}
+
+func (s *dblogSuite) TestMachineAgentLogsGoToDBWithJES(c *gc.C) {
+	s.SetFeatureFlags(feature.JES)
 	foundLogs := s.runMachineAgentTest(c)
 	c.Assert(foundLogs, jc.IsTrue)
 }
@@ -59,6 +66,13 @@ func (s *dblogSuite) TestMachineAgentWithoutFeatureFlag(c *gc.C) {
 }
 
 func (s *dblogSuite) TestUnitAgentLogsGoToDB(c *gc.C) {
+	s.SetFeatureFlags("db-log")
+	foundLogs := s.runUnitAgentTest(c)
+	c.Assert(foundLogs, jc.IsTrue)
+}
+
+func (s *dblogSuite) TestUnitAgentLogsGoToDBWithJES(c *gc.C) {
+	s.SetFeatureFlags(feature.JES)
 	foundLogs := s.runUnitAgentTest(c)
 	c.Assert(foundLogs, jc.IsTrue)
 }

--- a/worker/logsender/bufferedlogwriter.go
+++ b/worker/logsender/bufferedlogwriter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/deque"
-	"github.com/juju/utils/featureflag"
 )
 
 // LogRecord represents a log message in an agent which is to be
@@ -37,7 +36,7 @@ const writerName = "buffered-logs"
 // InstallBufferedLogWriter creates a new BufferedLogWriter, registers
 // it with Loggo and returns its output channel.
 func InstallBufferedLogWriter(maxLen int) (LogRecordCh, error) {
-	if !featureflag.Enabled(feature.DbLog) {
+	if !feature.IsDbLogEnabled() {
 		return nil, nil
 	}
 
@@ -52,7 +51,7 @@ func InstallBufferedLogWriter(maxLen int) (LogRecordCh, error) {
 // UninstallBufferedLogWriter removes the BufferedLogWriter previously
 // installed by InstallBufferedLogWriter and closes it.
 func UninstallBufferedLogWriter() error {
-	if !featureflag.Enabled(feature.DbLog) {
+	if !feature.IsDbLogEnabled() {
 		return nil
 	}
 

--- a/worker/logsender/bufferedlogwriter_test.go
+++ b/worker/logsender/bufferedlogwriter_test.go
@@ -12,7 +12,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/logsender"
 )
@@ -131,7 +130,7 @@ func (s *bufferedLogWriterSuite) TestClose(c *gc.C) {
 }
 
 func (s *bufferedLogWriterSuite) TestInstallBufferedLogWriter(c *gc.C) {
-	s.SetFeatureFlags(feature.DbLog)
+	s.SetFeatureFlags("db-log")
 
 	logsCh, err := logsender.InstallBufferedLogWriter(10)
 	c.Assert(err, jc.ErrorIsNil)
@@ -154,7 +153,7 @@ func (s *bufferedLogWriterSuite) TestInstallBufferedLogWriter(c *gc.C) {
 }
 
 func (s *bufferedLogWriterSuite) TestUninstallBufferedLogWriter(c *gc.C) {
-	s.SetFeatureFlags(feature.DbLog)
+	s.SetFeatureFlags("db-log")
 
 	_, err := logsender.InstallBufferedLogWriter(10)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/logsender/worker_test.go
+++ b/worker/logsender/worker_test.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -28,7 +27,7 @@ type workerSuite struct {
 var _ = gc.Suite(&workerSuite{})
 
 func (s *workerSuite) SetUpTest(c *gc.C) {
-	s.SetInitialFeatureFlags(feature.DbLog)
+	s.SetInitialFeatureFlags("db-log")
 	s.JujuConnSuite.SetUpTest(c)
 
 	// Create a machine for the client to log in as.


### PR DESCRIPTION
If the JES feature flag is enabled then the we want it to be as if the DbLog feature flag was enabled too. A helper function is introduced to help with his and the DbLog constant is no longer exported to enforce
usage of the helper (tests now use the feature flag name directly instead of the constant).

(Review request: http://reviews.vapour.ws/r/1802/)