### PR TITLE
Add storage dynamically

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -101,3 +101,14 @@ func (c *Client) ListVolumes(machines []string) ([]params.VolumeItem, error) {
 	}
 	return found.Results, nil
 }
+
+// AddToUnit adds specified storage to desired units.
+func (c *Client) AddToUnit(storages []params.StorageAddParams) ([]params.ErrorResult, error) {
+	out := params.ErrorResults{}
+	in := params.StoragesAddParams{Storages: storages}
+	err := c.facade.FacadeCall("AddToUnit", in, &out)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return out.Results, nil
+}

--- a/api/uniter/export_test.go
+++ b/api/uniter/export_test.go
@@ -5,7 +5,10 @@ package uniter
 import (
 	"fmt"
 
+	"github.com/juju/names"
+
 	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/apiserver/params"
 )
 
 var (
@@ -34,4 +37,9 @@ func PatchUnitResponse(p testing.Patcher, u *Unit, expectedRequest string, respo
 // PatchUnitFacadeCall changes the internal FacadeCaller to one that calls the provided request handler function.
 func PatchUnitFacadeCall(p testing.Patcher, u *Unit, respFunc func(request string, params, response interface{}) error) {
 	testing.PatchFacadeCall(p, &u.st.facade, respFunc)
+}
+
+// CreateUnit creates uniter.Unit for tests.
+func CreateUnit(st *State, tag names.UnitTag) *Unit {
+	return &Unit{st, tag, params.Alive}
 }

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -1,0 +1,91 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type unitStorageSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&unitStorageSuite{})
+
+func (s *unitStorageSuite) createTestUnit(c *gc.C, t string, apiCaller basetesting.APICallerFunc) *uniter.Unit {
+	tag := names.NewUnitTag(t)
+	st := uniter.NewState(apiCaller, tag)
+	return uniter.CreateUnit(st, tag)
+}
+
+func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
+	args := map[string]params.StorageConstraints{
+		"data": params.StorageConstraints{Pool: "loop"},
+	}
+
+	count := uint64(1)
+	expected := params.StoragesAddParams{
+		Storages: []params.StorageAddParams{
+			{"unit-mysql-0", "data", params.StorageConstraints{Pool: "loop", Count: &count}},
+		},
+	}
+
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "Uniter")
+		c.Assert(version, gc.Equals, 2)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "AddUnitStorage")
+		c.Assert(arg, gc.DeepEquals, expected)
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "yoink"},
+			}},
+		}
+		return nil
+	})
+	u := s.createTestUnit(c, "mysql/0", apiCaller)
+	err := u.AddStorage(args)
+	c.Assert(err, gc.ErrorMatches, "yoink")
+}
+
+func (s *unitStorageSuite) TestAddUnitStorageError(c *gc.C) {
+	args := map[string]params.StorageConstraints{
+		"data": params.StorageConstraints{Pool: "loop"},
+	}
+
+	count := uint64(1)
+	expected := params.StoragesAddParams{
+		Storages: []params.StorageAddParams{
+			{"unit-mysql-0", "data", params.StorageConstraints{Pool: "loop", Count: &count}},
+		},
+	}
+
+	var called bool
+	msg := "yoink"
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "Uniter")
+		c.Assert(version, gc.Equals, 2)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "AddUnitStorage")
+		c.Assert(arg, gc.DeepEquals, expected)
+		called = true
+
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		return errors.New(msg)
+	})
+
+	u := s.createTestUnit(c, "mysql/0", apiCaller)
+	err := u.AddStorage(args)
+	c.Assert(err, gc.ErrorMatches, msg)
+	c.Assert(called, jc.IsTrue)
+}

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -520,3 +520,33 @@ type VolumeItem struct {
 type VolumeItemsResult struct {
 	Results []VolumeItem `json:"results,omitempty"`
 }
+
+// StorageConstraints contains constraints for storage instance.
+type StorageConstraints struct {
+	// Pool is the name of the storage pool from which to provision the
+	// storage instance.
+	Pool string `bson:"pool,omitempty"`
+
+	// Size is the required size of the storage instance, in MiB.
+	Size *uint64 `bson:"size,omitempty"`
+
+	// Count is the required number of storage instances.
+	Count *uint64 `bson:"count,omitempty"`
+}
+
+// StorageAddParams holds storage details to add to a unit dynamically.
+type StorageAddParams struct {
+	// UnitTag  is unit name.
+	UnitTag string `json:"unit"`
+
+	// StorageName is the name of the storage as specified in the charm.
+	StorageName string `bson:"name"`
+
+	// Constraints are specified storage constraints.
+	Constraints StorageConstraints `json:"storage"`
+}
+
+// StoragesAddParams holds storage details to add to units dynamically.
+type StoragesAddParams struct {
+	Storages []StorageAddParams `json:"storages"`
+}

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -228,7 +228,7 @@ func (s *serviceSuite) TestClientServiceDeployWithStorage(c *gc.C) {
 		"allecto": {
 			Count: 0,
 			Size:  1024,
-			Pool:  "loop-pool",
+			Pool:  "loop",
 		},
 	})
 }

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -225,6 +225,11 @@ func (s *serviceSuite) TestClientServiceDeployWithStorage(c *gc.C) {
 			Size:  1024,
 			Pool:  "loop-pool",
 		},
+		"allecto": {
+			Count: 0,
+			Size:  1024,
+			Pool:  "loop-pool",
+		},
 	})
 }
 

--- a/apiserver/storage/package_test.go
+++ b/apiserver/storage/package_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/storage"
 	"github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
@@ -45,6 +46,8 @@ type baseStorageSuite struct {
 
 	poolManager *mockPoolManager
 	pools       map[string]*jujustorage.Config
+
+	blocks map[state.BlockType]state.Block
 }
 
 func (s *baseStorageSuite) SetUpTest(c *gc.C) {
@@ -60,6 +63,26 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.api, err = storage.CreateAPI(s.state, s.poolManager, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+func (s *baseStorageSuite) assertCalls(c *gc.C, expectedCalls []string) {
+	c.Assert(s.calls, jc.SameContents, expectedCalls)
+}
+
+const (
+	allStorageInstancesCall                 = "allStorageInstances"
+	storageInstanceAttachmentsCall          = "storageInstanceAttachments"
+	unitAssignedMachineCall                 = "UnitAssignedMachine"
+	storageInstanceCall                     = "StorageInstance"
+	storageInstanceFilesystemCall           = "StorageInstanceFilesystem"
+	storageInstanceFilesystemAttachmentCall = "storageInstanceFilesystemAttachment"
+	storageInstanceVolumeCall               = "storageInstanceVolume"
+	volumeCall                              = "volumeCall"
+	machineVolumeAttachmentsCall            = "machineVolumeAttachments"
+	volumeAttachmentsCall                   = "volumeAttachments"
+	allVolumesCall                          = "allVolumes"
+	addStorageForUnitCall                   = "addStorageForUnit"
+	getBlockForTypeCall                     = "getBlockForType"
+)
 
 func (s *baseStorageSuite) constructState(c *gc.C) *mockState {
 	s.unitTag = names.NewUnitTag("mysql/0")
@@ -84,6 +107,7 @@ func (s *baseStorageSuite) constructState(c *gc.C) *mockState {
 		MachineTag: s.machineTag,
 	}
 
+	s.blocks = make(map[state.BlockType]state.Block)
 	return &mockState{
 		allStorageInstances: func() ([]state.StorageInstance, error) {
 			s.calls = append(s.calls, allStorageInstancesCall)
@@ -140,7 +164,37 @@ func (s *baseStorageSuite) constructState(c *gc.C) *mockState {
 			return []state.Volume{s.volume}, nil
 		},
 		envName: "storagetest",
+		addStorageForUnit: func(u names.UnitTag, name string, cons state.StorageConstraints) error {
+			s.calls = append(s.calls, addStorageForUnitCall)
+			return nil
+		},
+		getBlockForType: func(t state.BlockType) (state.Block, bool, error) {
+			s.calls = append(s.calls, getBlockForTypeCall)
+			val, found := s.blocks[t]
+			return val, found, nil
+		},
 	}
+}
+
+func (s *baseStorageSuite) addBlock(c *gc.C, t state.BlockType, msg string) {
+	s.blocks[t] = mockBlock{t, msg}
+}
+
+func (s *baseStorageSuite) blockAllChanges(c *gc.C, msg string) {
+	s.addBlock(c, state.ChangeBlock, msg)
+}
+
+func (s *baseStorageSuite) blockDestroyEnvironment(c *gc.C, msg string) {
+	s.addBlock(c, state.DestroyBlock, msg)
+}
+
+func (s *baseStorageSuite) blockRemoveObject(c *gc.C, msg string) {
+	s.addBlock(c, state.RemoveBlock, msg)
+}
+
+func (s *baseStorageSuite) assertBlocked(c *gc.C, err error, msg string) {
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, msg)
 }
 
 func (s *baseStorageSuite) constructPoolManager(c *gc.C) *mockPoolManager {
@@ -212,6 +266,8 @@ type mockState struct {
 	machineVolumeAttachments            func(machine names.MachineTag) ([]state.VolumeAttachment, error)
 	volumeAttachments                   func(volume names.VolumeTag) ([]state.VolumeAttachment, error)
 	allVolumes                          func() ([]state.Volume, error)
+	addStorageForUnit                   func(u names.UnitTag, name string, cons state.StorageConstraints) error
+	getBlockForType                     func(t state.BlockType) (state.Block, bool, error)
 }
 
 func (st *mockState) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {
@@ -276,6 +332,14 @@ func (st *mockState) MachineVolumeAttachments(machine names.MachineTag) ([]state
 
 func (st *mockState) Volume(tag names.VolumeTag) (state.Volume, error) {
 	return st.volume(tag)
+}
+
+func (st *mockState) AddStorageForUnit(u names.UnitTag, name string, cons state.StorageConstraints) error {
+	return st.addStorageForUnit(u, name, cons)
+}
+
+func (st *mockState) GetBlockForType(t state.BlockType) (state.Block, bool, error) {
+	return st.getBlockForType(t)
 }
 
 type mockNotifyWatcher struct {
@@ -401,4 +465,25 @@ func (va *mockVolumeAttachment) Info() (state.VolumeAttachmentInfo, error) {
 
 func (va *mockVolumeAttachment) Params() (state.VolumeAttachmentParams, bool) {
 	panic("not implemented for test")
+}
+
+type mockBlock struct {
+	t   state.BlockType
+	msg string
+}
+
+func (b mockBlock) Id() string {
+	panic("not implemented for test")
+}
+
+func (b mockBlock) Tag() (names.Tag, error) {
+	panic("not implemented for test")
+}
+
+func (b mockBlock) Type() state.BlockType {
+	return b.t
+}
+
+func (b mockBlock) Message() string {
+	return b.msg
 }

--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -58,6 +58,12 @@ type storageAccess interface {
 
 	// Volume is required for volume functionality.
 	Volume(tag names.VolumeTag) (state.Volume, error)
+
+	// AddStorageForUnit is required for storage add functionality.
+	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
+
+	// GetBlockForType is required to block operations.
+	GetBlockForType(t state.BlockType) (state.Block, bool, error)
 }
 
 var getState = func(st *state.State) storageAccess {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -571,12 +571,9 @@ func groupAttachmentsByVolume(all []state.VolumeAttachment) map[string][]params.
 }
 
 // AddToUnit validates and creates additional storage instances for units.
-// Storage instances are defined in collection of storages.
-// If no directives were specified, we do not try to add any instances.
-// Any failed operations are reported as errors.
-// Failures on an individual storage instance do not block remaining
-// instances being processed.
-// This method handles bulk add operations.
+// This method handles bulk add operations and
+// a failure on one individual storage instance does not block remaining
+// instances from being processed.
 // A "CHANGE" block can block this operation.
 func (a *API) AddToUnit(args params.StoragesAddParams) (params.ErrorResults, error) {
 	// Check if changes are allowed and the operation may proceed.

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -21,20 +21,6 @@ type storageSuite struct {
 
 var _ = gc.Suite(&storageSuite{})
 
-const (
-	allStorageInstancesCall                 = "allStorageInstances"
-	storageInstanceAttachmentsCall          = "storageInstanceAttachments"
-	unitAssignedMachineCall                 = "UnitAssignedMachine"
-	storageInstanceCall                     = "StorageInstance"
-	storageInstanceFilesystemCall           = "StorageInstanceFilesystem"
-	storageInstanceFilesystemAttachmentCall = "storageInstanceFilesystemAttachment"
-	storageInstanceVolumeCall               = "storageInstanceVolume"
-	volumeCall                              = "volumeCall"
-	machineVolumeAttachmentsCall            = "machineVolumeAttachments"
-	volumeAttachmentsCall                   = "volumeAttachments"
-	allVolumesCall                          = "allVolumes"
-)
-
 func (s *storageSuite) TestStorageListEmpty(c *gc.C) {
 	s.state.allStorageInstances = func() ([]state.StorageInstance, error) {
 		s.calls = append(s.calls, allStorageInstancesCall)
@@ -239,10 +225,6 @@ func (s *storageSuite) createTestStorageInfo() params.StorageInfo {
 		},
 		nil,
 	}
-}
-
-func (s *storageSuite) assertCalls(c *gc.C, expectedCalls []string) {
-	c.Assert(s.calls, jc.SameContents, expectedCalls)
 }
 
 func (s *storageSuite) assertInstanceInfoError(c *gc.C, obtained params.StorageInfo, wanted params.StorageInfo, expected string) {

--- a/apiserver/storage/storageadd_test.go
+++ b/apiserver/storage/storageadd_test.go
@@ -1,0 +1,158 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+type storageAddSuite struct {
+	baseStorageSuite
+}
+
+var _ = gc.Suite(&storageAddSuite{})
+
+func (s *storageAddSuite) assertStorageAddedNoErrors(c *gc.C, args params.StorageAddParams) {
+	s.assertStoragesAddedNoErrors(c,
+		params.StoragesAddParams{[]params.StorageAddParams{args}},
+	)
+}
+
+func (s *storageAddSuite) assertStoragesAddedNoErrors(c *gc.C, args params.StoragesAddParams) {
+	failures, err := s.api.AddToUnit(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(failures.Results, gc.HasLen, len(args.Storages))
+	for _, one := range failures.Results {
+		c.Assert(one.Error, gc.IsNil)
+	}
+}
+
+func (s *storageAddSuite) TestStorageAddEmpty(c *gc.C) {
+	s.assertStoragesAddedNoErrors(c, params.StoragesAddParams{Storages: nil})
+	s.assertStoragesAddedNoErrors(c, params.StoragesAddParams{Storages: []params.StorageAddParams{}})
+}
+
+func (s *storageAddSuite) TestStorageAddUnit(c *gc.C) {
+	args := params.StorageAddParams{
+		UnitTag:     s.unitTag.String(),
+		StorageName: "data",
+	}
+	s.assertStorageAddedNoErrors(c, args)
+	s.assertCalls(c, []string{getBlockForTypeCall, addStorageForUnitCall})
+}
+
+func (s *storageAddSuite) TestStorageAddUnitBlocked(c *gc.C) {
+	s.blockAllChanges(c, "TestStorageAddUnitBlocked")
+
+	args := params.StorageAddParams{
+		UnitTag:     s.unitTag.String(),
+		StorageName: "data",
+	}
+	_, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	s.assertBlocked(c, err, "TestStorageAddUnitBlocked")
+}
+
+func (s *storageAddSuite) TestStorageAddUnitDestroyIgnored(c *gc.C) {
+	s.blockDestroyEnvironment(c, "TestStorageAddUnitDestroyIgnored")
+	s.blockRemoveObject(c, "TestStorageAddUnitDestroyIgnored")
+
+	args := params.StorageAddParams{
+		UnitTag:     s.unitTag.String(),
+		StorageName: "data",
+	}
+	s.assertStorageAddedNoErrors(c, args)
+	s.assertCalls(c, []string{getBlockForTypeCall, addStorageForUnitCall})
+}
+
+func (s *storageAddSuite) TestStorageAddUnitError(c *gc.C) {
+	args := params.StorageAddParams{
+		StorageName: "data",
+	}
+	failures, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(failures.Results, gc.HasLen, 1)
+	c.Assert(failures.Results[0].Error.Error(), gc.Matches, ".*is not a valid tag.*")
+
+	expectedCalls := []string{getBlockForTypeCall}
+	s.assertCalls(c, expectedCalls)
+}
+
+func (s *storageAddSuite) TestStorageAddUnitStateError(c *gc.C) {
+	msg := "add test directive error"
+	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) error {
+		s.calls = append(s.calls, addStorageForUnitCall)
+		return errors.Errorf(msg)
+	}
+
+	args := params.StorageAddParams{
+		UnitTag:     s.unitTag.String(),
+		StorageName: "data",
+	}
+	failures, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(failures.Results, gc.HasLen, 1)
+	c.Assert(failures.Results[0].Error.Error(), gc.Matches, fmt.Sprintf(".*%v.*", msg))
+
+	s.assertCalls(c, []string{getBlockForTypeCall, addStorageForUnitCall})
+}
+
+func (s *storageAddSuite) TestStorageAddUnitPermError(c *gc.C) {
+	msg := "add test directive error"
+	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) error {
+		s.calls = append(s.calls, addStorageForUnitCall)
+		return errors.NotFoundf(msg)
+	}
+
+	args := params.StorageAddParams{
+		UnitTag:     s.unitTag.String(),
+		StorageName: "data",
+	}
+	failures, err := s.api.AddToUnit(params.StoragesAddParams{[]params.StorageAddParams{args}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(failures.Results, gc.HasLen, 1)
+	c.Assert(failures.Results[0].Error.Error(), gc.Matches, ".*permission denied.*")
+
+	s.assertCalls(c, []string{getBlockForTypeCall, addStorageForUnitCall})
+}
+
+func (s *storageAddSuite) TestStorageAddUnitResultOrder(c *gc.C) {
+	wrong0 := params.StorageAddParams{
+		StorageName: "data",
+	}
+	right := params.StorageAddParams{
+		UnitTag:     s.unitTag.String(),
+		StorageName: "data",
+	}
+	wrong1 := params.StorageAddParams{
+		UnitTag: s.unitTag.String(),
+	}
+	msg := "storage name missing error"
+	s.state.addStorageForUnit = func(u names.UnitTag, name string, cons state.StorageConstraints) error {
+		s.calls = append(s.calls, addStorageForUnitCall)
+		if name == "" {
+			return errors.Errorf(msg)
+		}
+		return nil
+	}
+	failures, err := s.api.AddToUnit(params.StoragesAddParams{
+		[]params.StorageAddParams{
+			wrong0,
+			right,
+			wrong1}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(failures.Results, gc.HasLen, 3)
+	c.Assert(failures.Results[0].Error.Error(), gc.Matches, ".*is not a valid tag.*")
+	c.Assert(failures.Results[1].Error, gc.IsNil)
+	c.Assert(failures.Results[2].Error.Error(), gc.Matches, fmt.Sprintf(".*%v.*", msg))
+
+	s.assertCalls(c, []string{getBlockForTypeCall, addStorageForUnitCall, addStorageForUnitCall})
+}

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -25,6 +25,7 @@ type storageStateInterface interface {
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
 }
 
 type storageStateShim struct {

--- a/cmd/juju/block/protection.go
+++ b/cmd/juju/block/protection.go
@@ -5,7 +5,6 @@ package block
 
 import (
 	"fmt"
-	//	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"

--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -236,6 +236,11 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 			Count: 1,
 			Size:  1024,
 		},
+		"allecto": {
+			Pool:  "loop",
+			Count: 0,
+			Size:  1024,
+		},
 	})
 }
 

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -1,0 +1,147 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils/keyvalues"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	addCommandDoc = `
+Add storage instances to a unit dynamically.
+Specify a unit and a storage specification in the same format 
+as passed to juju deploy --storage=”...”.
+
+Example:
+    juju storage add u/0 data=ebs,1024,3 
+    Add 3 ebs storage instances for "data" storage to unit u/0. 
+`
+	addCommandAgs = `
+<unit name> <storage directive> ...
+    where storage directive is <charm storage name=<storage constraints>
+`
+)
+
+// AddCommand adds unit storage instances dynamically.
+type AddCommand struct {
+	StorageCommandBase
+	unitTag string
+
+	// storageCons is a map of storage constraints, keyed on the storage name
+	// defined in charm storage metadata.
+	storageCons map[string]storage.Constraints
+}
+
+// Init implements Command.Init.
+func (c *AddCommand) Init(args []string) (err error) {
+	if len(args) < 2 {
+		return errors.New("storage add requires a unit and a storage directive")
+	}
+
+	u := args[0]
+	if !names.IsValidUnit(u) {
+		return errors.NotValidf("unit name %q", u)
+	}
+	c.unitTag = names.NewUnitTag(u).String()
+
+	options, err := keyvalues.Parse(args[1:], true)
+	if err != nil {
+		return err
+	}
+	c.storageCons = make(map[string]storage.Constraints, len(options))
+	for key, value := range options {
+		cons, err := storage.ParseConstraints(value)
+		if err != nil {
+			return errors.Annotatef(err, "cannot parse constraints for storage %q", key)
+		}
+		c.storageCons[key] = cons
+	}
+
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *AddCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "add",
+		Purpose: "adds unit storage dynamically",
+		Doc:     addCommandDoc,
+		Args:    addCommandAgs,
+	}
+}
+
+// Run implements Command.Run.
+func (c *AddCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := getStorageAddAPI(c)
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	storages := c.createStorageAddParams()
+	results, err := api.AddToUnit(storages)
+	if err != nil {
+		return err
+	}
+	// If there are any failures, display them first.
+	// Then display all added storage.
+	// If there are no failures, then there is no need to display all successes.
+	var added []string
+
+	for i, one := range results {
+		us := storages[i]
+		if one.Error != nil {
+			fmt.Fprintf(ctx.Stderr, fail+": %v\n", us.StorageName, one.Error)
+			continue
+		}
+		added = append(added, fmt.Sprintf(success, us.StorageName))
+	}
+	if len(added) < len(storages) {
+		fmt.Fprintf(ctx.Stderr, strings.Join(added, "\n"))
+	}
+	return nil
+}
+
+var (
+	getStorageAddAPI = (*AddCommand).getStorageAddAPI
+	storageName      = "storage %q"
+	success          = "success: " + storageName
+	fail             = "fail: " + storageName
+)
+
+// StorageAddAPI defines the API methods that the storage commands use.
+type StorageAddAPI interface {
+	Close() error
+	AddToUnit(storages []params.StorageAddParams) ([]params.ErrorResult, error)
+}
+
+func (c *AddCommand) getStorageAddAPI() (StorageAddAPI, error) {
+	return c.NewStorageAPI()
+}
+
+func (c *AddCommand) createStorageAddParams() []params.StorageAddParams {
+	all := make([]params.StorageAddParams, 0, len(c.storageCons))
+	for one, cons := range c.storageCons {
+		all = append(all,
+			params.StorageAddParams{
+				UnitTag:     c.unitTag,
+				StorageName: one,
+				Constraints: params.StorageConstraints{
+					cons.Pool,
+					&cons.Size,
+					&cons.Count,
+				},
+			})
+	}
+	return all
+}

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -1,0 +1,134 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/storage"
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
+)
+
+type addSuite struct {
+	SubStorageSuite
+	mockAPI *mockAddAPI
+	args    []string
+}
+
+var _ = gc.Suite(&addSuite{})
+
+func (s *addSuite) SetUpTest(c *gc.C) {
+	s.SubStorageSuite.SetUpTest(c)
+
+	s.mockAPI = &mockAddAPI{}
+	s.PatchValue(storage.GetStorageAddAPI, func(c *storage.AddCommand) (storage.StorageAddAPI, error) {
+		return s.mockAPI, nil
+	})
+	s.args = nil
+}
+
+type tstData struct {
+	args        []string
+	expectedErr string
+}
+
+var errorTsts = []tstData{
+	{nil, ".*storage add requires a unit and a storage directive.*"},
+	{[]string{"tst/123"}, ".*storage add requires a unit and a storage directive.*"},
+	{[]string{"tst/123", "data"}, `.*expected "key=value", got "data".*`},
+	{[]string{"tst/123", "data="}, `.*storage constraints require at least one field to be specified`},
+	{[]string{"tst/123", "data=-676"}, `.*count must be greater than zero, got "-676".*`},
+}
+
+func (s *addSuite) TestAddArgs(c *gc.C) {
+	for i, t := range errorTsts {
+		c.Logf("test %d for %q", i, t.args)
+		s.args = t.args
+		s.assertAddErrorOutput(c, t.expectedErr)
+	}
+}
+
+func (s *addSuite) assertAddErrorOutput(c *gc.C, expected string) {
+	_, err := runAdd(c, s.args...)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, expected)
+}
+
+func runAdd(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, envcmd.Wrap(&storage.AddCommand{}), args...)
+}
+
+func (s *addSuite) TestAddInvalidUnit(c *gc.C) {
+	s.args = []string{"tst-123", "data=676"}
+	s.assertAddErrorOutput(c, `.*unit name "tst-123" not valid.*`)
+}
+
+func (s *addSuite) TestAddSuccess(c *gc.C) {
+	s.args = []string{"tst/123", "data=676"}
+	s.assertAddOutput(c, "", "")
+}
+
+func (s *addSuite) TestAddOperationAborted(c *gc.C) {
+	s.args = []string{"tst/123", "data=676"}
+	s.mockAPI.abort = true
+	s.assertAddErrorOutput(c, ".*aborted.*")
+}
+
+func (s *addSuite) TestAddFailure(c *gc.C) {
+	s.args = []string{"tst/123", "err=676"}
+	s.assertAddOutput(c, "", "fail: storage \"err\": test failure\n")
+}
+
+func (s *addSuite) TestAddMixOrderPreserved(c *gc.C) {
+	expectedErr := `
+fail: storage "err": test failure
+success: storage "a"`[1:]
+
+	s.args = []string{"tst/123", "a=676", "err=676"}
+	s.assertAddOutput(c, "", expectedErr)
+
+	s.args = []string{"tst/123", "err=676", "a=676"}
+	s.assertAddOutput(c, "", expectedErr)
+}
+
+func (s *addSuite) assertAddOutput(c *gc.C, expectedValid, expectedErr string) {
+	context, err := runAdd(c, s.args...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtainedErr := testing.Stderr(context)
+	c.Assert(obtainedErr, gc.Equals, expectedErr)
+
+	obtainedValid := testing.Stdout(context)
+	c.Assert(obtainedValid, gc.Equals, expectedValid)
+}
+
+type mockAddAPI struct {
+	abort bool
+}
+
+func (s mockAddAPI) Close() error {
+	return nil
+}
+
+func (s mockAddAPI) AddToUnit(storages []params.StorageAddParams) ([]params.ErrorResult, error) {
+	if s.abort {
+		return nil, errors.New("aborted")
+	}
+	result := make([]params.ErrorResult, len(storages))
+	for i, one := range storages {
+		if strings.HasPrefix(one.StorageName, "err") {
+			result[i].Error = common.ServerError(fmt.Errorf("test failure"))
+		}
+	}
+	return result, nil
+}

--- a/cmd/juju/storage/export_test.go
+++ b/cmd/juju/storage/export_test.go
@@ -11,4 +11,5 @@ var (
 	GetVolumeListAPI  = &getVolumeListAPI
 
 	ConvertToVolumeInfo = convertToVolumeInfo
+	GetStorageAddAPI    = &getStorageAddAPI
 )

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -24,7 +24,7 @@ options:
    specify output format (json|tabular|yaml)
 `
 
-// ListCommand attempts to release storage instance.
+// ListCommand returns storage instances.
 type ListCommand struct {
 	StorageCommandBase
 	out cmd.Output

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -41,6 +41,7 @@ func NewSuperCommand() cmd.Command {
 			})}
 	storagecmd.Register(envcmd.Wrap(&ShowCommand{}))
 	storagecmd.Register(envcmd.Wrap(&ListCommand{}))
+	storagecmd.Register(envcmd.Wrap(&AddCommand{}))
 	storagecmd.Register(NewPoolSuperCommand())
 	storagecmd.Register(NewVolumeSuperCommand())
 	return &storagecmd

--- a/cmd/juju/storage/storage_test.go
+++ b/cmd/juju/storage/storage_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 var expectedSubCommmandNames = []string{
+	"add",
 	"help",
 	"list",
 	"pool",

--- a/doc/charms-in-action.txt
+++ b/doc/charms-in-action.txt
@@ -122,6 +122,7 @@ All hooks can directly use the following tools:
   * relation-set (write the local unit's relation settings)
   * relation-ids (list all relations using a given charm relation)
   * relation-list (list all units of a related service)
+  * storage-add (add storage instances)
   * storage-get (get storage instance values)
   * status-get (get unit workload status information)
   * status-set (set unit workload status information)

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -55,10 +55,7 @@ func createUnitWithStorage(c *gc.C, s *jujutesting.JujuConnSuite, poolName strin
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 
-	machineId, err := unit.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-
-	return machineId
+	return unit.Tag().Id()
 }
 
 type cmdStorageSuite struct {
@@ -411,4 +408,43 @@ MACHINE  UNIT             STORAGE  DEVICE  VOLUME  ID  SIZE
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 	c.Assert(testing.Stderr(context), gc.Equals, "")
+}
+
+func runAddToUnit(c *gc.C, args ...string) *cmd.Context {
+	context, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.AddCommand{}), args...)
+	c.Assert(err, jc.ErrorIsNil)
+	return context
+}
+
+func (s *cmdStorageSuite) TestStorageAddToUnitSuccess(c *gc.C) {
+	u := createUnitWithStorage(c, &s.JujuConnSuite, testPool)
+	before, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageExist(c, before, "data")
+
+	context := runAddToUnit(c, u, "allecto=1")
+	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(testing.Stderr(context), gc.Equals, "")
+
+	after, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(after)-len(before), gc.Equals, 1)
+	s.assertStorageExist(c, after, "data", "allecto")
+}
+
+func (s *cmdStorageSuite) assertStorageExist(c *gc.C,
+	all []state.StorageInstance,
+	expected ...string) {
+
+	names := make([]string, len(all))
+	for i, one := range all {
+		names[i] = one.StorageName()
+	}
+	c.Assert(names, jc.SameContents, expected)
+}
+
+func (s *cmdStorageSuite) TestStorageAddToUnitFailure(c *gc.C) {
+	context := runAddToUnit(c, "fluffyunit/0", "allecto=1")
+	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(testing.Stderr(context), gc.Equals, "fail: storage \"allecto\": permission denied\n")
 }

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1010,7 +1010,7 @@ func (s *assignCleanSuite) TestAssignUnitToMachineWorksWithMachine0(c *gc.C) {
 func (s *AssignSuite) TestAssignUnitWithStorageCleanAvailable(c *gc.C) {
 	cons, err := s.storageSvc.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.HasLen, 1)
+	c.Assert(cons, gc.HasLen, 2)
 
 	unit, err := s.storageSvc.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -36,9 +36,17 @@ func (s *FilesystemStateSuite) TestAddServiceNoPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
-	// TODO(axw) implement support for default filesystem pool.
-	c.Assert(err, gc.ErrorMatches, `cannot add service "storage-filesystem": finding default pool for "data" storage: no storage pool specifed and no default available`)
+	svc, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
+	c.Assert(err, jc.ErrorIsNil)
+	cons, err := svc.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, jc.DeepEquals, map[string]state.StorageConstraints{
+		"data": state.StorageConstraints{
+			Pool:  "rootfs",
+			Size:  1024,
+			Count: 1,
+		},
+	})
 }
 
 func (s *FilesystemStateSuite) TestAddFilesystemWithoutBackingVolume(c *gc.C) {

--- a/state/storage.go
+++ b/state/storage.go
@@ -687,6 +687,25 @@ func storageKind(storageType charm.StorageType) storage.StorageKind {
 }
 
 func validateStorageConstraints(st *State, allCons map[string]StorageConstraints, charmMeta *charm.Meta) error {
+	err := validateStorageConstraintsAgainstCharm(st, allCons, charmMeta)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Ensure all stores have constraints specified. Defaults should have
+	// been set by this point, if the user didn't specify constraints.
+	for name, charmStorage := range charmMeta.Storage {
+		if _, ok := allCons[name]; !ok && charmStorage.CountMin > 0 {
+			return errors.Errorf("no constraints specified for store %q", name)
+		}
+	}
+	return nil
+}
+
+func validateStorageConstraintsAgainstCharm(
+	st *State,
+	allCons map[string]StorageConstraints,
+	charmMeta *charm.Meta,
+) error {
 	for name, cons := range allCons {
 		charmStorage, ok := charmMeta.Storage[name]
 		if !ok {
@@ -714,19 +733,14 @@ func validateStorageConstraints(st *State, allCons map[string]StorageConstraints
 		if charmStorage.MinimumSize > 0 && cons.Size < charmStorage.MinimumSize {
 			return errors.Errorf(
 				"charm %q store %q: minimum storage size is %s, %s specified",
-				charmMeta.Name, name, humanize.Bytes(charmStorage.MinimumSize*humanize.MByte), humanize.Bytes(cons.Size*humanize.MByte),
+				charmMeta.Name, name,
+				humanize.Bytes(charmStorage.MinimumSize*humanize.MByte),
+				humanize.Bytes(cons.Size*humanize.MByte),
 			)
 		}
 		kind := storageKind(charmStorage.Type)
 		if err := validateStoragePool(st, cons.Pool, kind, nil); err != nil {
 			return err
-		}
-	}
-	// Ensure all stores have constraints specified. Defaults should have
-	// been set by this point, if the user didn't specify constraints.
-	for name, charmStorage := range charmMeta.Storage {
-		if _, ok := allCons[name]; !ok && charmStorage.CountMin > 0 {
-			return errors.Errorf("no constraints specified for store %q", name)
 		}
 	}
 	return nil
@@ -863,30 +877,31 @@ func addDefaultStorageConstraints(st *State, allCons map[string]StorageConstrain
 				Count: uint64(charmStorage.CountMin),
 			}
 		}
-		cons, err := storageConstraintsWithDefaults(conf, kind, charmStorage, cons, name)
+		cons, err := storageConstraintsWithDefaults(conf, charmStorage, name, allCons[name])
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		allCons[name] = cons
 	}
 	return nil
 }
 
-// storageConstraintsWithDefaults returns a constraints derived from cons, with any defaults filled in.
+// storageConstraintsWithDefaults returns a constraints
+// derived from cons, with any defaults filled in.
 func storageConstraintsWithDefaults(
 	cfg *config.Config,
-	kind storage.StorageKind,
 	charmStorage charm.Storage,
+	name string,
 	cons StorageConstraints,
-	storageName string,
 ) (StorageConstraints, error) {
 	withDefaults := cons
 
 	// If no pool is specified, determine the pool from the env config and other constraints.
 	if cons.Pool == "" {
+		kind := storageKind(charmStorage.Type)
 		poolName, err := defaultStoragePool(cfg, kind, cons)
 		if err != nil {
-			return withDefaults, errors.Annotatef(err, "finding default pool for %q storage", storageName)
+			return withDefaults, errors.Annotatef(err, "finding default pool for %q storage", name)
 		}
 		withDefaults.Pool = poolName
 	}
@@ -925,4 +940,127 @@ func defaultStoragePool(cfg *config.Config, kind storage.StorageKind, cons Stora
 		return defaultPool, nil
 	}
 	return "", ErrNoDefaultStoragePool
+}
+
+// AddStorage adds StorageConstraints to
+// given entity dynamically, one storage directive at a time.
+func (st *State) AddStorageForUnit(
+	charmMeta *charm.Meta, u *Unit,
+	name string, cons StorageConstraints,
+) error {
+	all, err := u.StorageConstraints()
+	if err != nil {
+		return errors.Annotatef(err, "getting existing storage directives for %s", u.Tag().Id())
+	}
+
+	// Check storage name was declared.
+	_, exists := all[name]
+	if !exists {
+		return errors.NotFoundf("charm storage %q", name)
+	}
+
+	// Populate missing configuration parameters with default values.
+	conf, err := st.EnvironConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	completeCons, err := storageConstraintsWithDefaults(
+		conf,
+		charmMeta.Storage[name],
+		name, cons,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		err := u.Refresh()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		err = st.validateUnitStorage(charmMeta, u, name, completeCons)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops, err := st.constructAddUnitStorageOps(charmMeta, u, name, completeCons)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
+	}
+	if err := st.run(buildTxn); err != nil {
+		return errors.Annotate(err, "while creating storage")
+	}
+	return nil
+}
+
+func (st *State) validateUnitStorage(
+	charmMeta *charm.Meta, u *Unit, name string, cons StorageConstraints,
+) error {
+	// Storage directive may provide storage instance count
+	// which combined with existing storage instance may exceed
+	// number of storage instances specified by charm.
+	// We must take it into account when validating.
+	currentCount, err := st.countEntityStorageInstancesForName(u.Tag(), name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cons.Count = cons.Count + currentCount
+
+	err = validateStorageConstraintsAgainstCharm(
+		st,
+		map[string]StorageConstraints{name: cons},
+		charmMeta)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (st *State) constructAddUnitStorageOps(
+	charmMeta *charm.Meta, u *Unit, name string, cons StorageConstraints,
+) ([]txn.Op, error) {
+	// Create storage db operations
+	storageOps, _, err := createStorageOps(
+		st,
+		u.Tag(),
+		charmMeta,
+		map[string]StorageConstraints{name: cons})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Update storage attachment count.
+	priorCount := u.doc.StorageAttachmentCount
+	newCount := priorCount + int(cons.Count)
+	ops := []txn.Op{
+		{
+			C:  unitsC,
+			Id: u.doc.DocID,
+			// Count validation ensures transactionality.
+			Assert: bson.D{{"storageattachmentcount", priorCount}},
+			Update: bson.D{{"$set",
+				bson.D{{"storageattachmentcount", newCount}}}},
+		},
+	}
+	return append(ops, storageOps...), nil
+}
+
+func (st *State) countEntityStorageInstancesForName(
+	tag names.Tag,
+	name string,
+) (uint64, error) {
+	storageCollection, closer := st.getCollection(storageInstancesC)
+	defer closer()
+	criteria := bson.D{{
+		"$and", []bson.D{
+			bson.D{{"owner", tag.String()}},
+			bson.D{{"storagename", name}},
+		},
+	}}
+	result, err := storageCollection.Find(criteria).Count()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(result), err
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -1003,6 +1003,13 @@ func (st *State) addStorageForUnit(
 		return errors.Trace(err)
 	}
 
+	// This can happen for charm stores that specify instances range from 0,
+	// and no count was specified at deploy as storage constraints for this store,
+	// and no count was specified to storage add as a contraint either.
+	if cons.Count == 0 {
+		return errors.NotValidf("adding storage where instance count is 0")
+	}
+
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		err := u.Refresh()
 		if err != nil {

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -13,8 +14,7 @@ import (
 type StorageAddSuite struct {
 	StorageStateSuiteBase
 
-	charm                *state.Charm
-	unit                 *state.Unit
+	unitTag              names.UnitTag
 	originalStorageCount int
 }
 
@@ -24,11 +24,12 @@ func (s *StorageAddSuite) setupMultipleStoragesForAdd(c *gc.C) {
 	storageCons := map[string]state.StorageConstraints{
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
-	s.charm = s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", s.charm, nil, storageCons)
+	charm := s.AddTestingCharm(c, "storage-block2")
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", charm, nil, storageCons)
 	c.Assert(err, jc.ErrorIsNil)
-	s.unit, err = service.AddUnit()
+	u, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
+	s.unitTag = u.Tag().(names.UnitTag)
 
 	all, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
@@ -44,14 +45,14 @@ func (s *StorageAddSuite) assertStorageCount(c *gc.C, expected int) {
 func (s *StorageAddSuite) TestAddStorageToUnit(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
+	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
 }
 
 func (s *StorageAddSuite) TestAddStorageWithCount(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+2)
 }
@@ -59,37 +60,31 @@ func (s *StorageAddSuite) TestAddStorageWithCount(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+2)
 
 	// Should not succeed as the number of storages after
 	// this call would be 11 whereas our upper limit is 10 here.
-	err = s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
+	err = s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified.*`)
 	s.assertStorageCount(c, s.originalStorageCount+2)
 }
 
 func (s *StorageAddSuite) TestAddStorageExceedCount(c *gc.C) {
-	service, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
+	_, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
 	s.assertStorageCount(c, 1)
 
-	ch, _, err := service.Charm()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.State.AddStorageForUnit(ch.Meta(), u, "data", makeStorageCons("loop-pool", 1024, 1))
+	err := s.State.AddStorageForUnit(u.Tag().(names.UnitTag), "data", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block" store "data": at most 1 instances supported, 2 specified.*`)
 	s.assertStorageCount(c, 1)
 }
 
 func (s *StorageAddSuite) TestAddStorageMinCount(c *gc.C) {
-	service, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
+	_, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
 	s.assertStorageCount(c, 1)
 
-	ch, _, err := service.Charm()
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.State.AddStorageForUnit(ch.Meta(), u, "allecto", makeStorageCons("loop-pool", 1024, 1))
+	err := s.State.AddStorageForUnit(u.Tag().(names.UnitTag), "allecto", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, 2)
 }
@@ -97,7 +92,7 @@ func (s *StorageAddSuite) TestAddStorageMinCount(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
+	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
 }
@@ -105,7 +100,7 @@ func (s *StorageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageDiffPool(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
+	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
 }
@@ -113,7 +108,7 @@ func (s *StorageAddSuite) TestAddStorageDiffPool(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageDiffSize(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Size: 2048})
+	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Size: 2048})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
 }
@@ -121,7 +116,7 @@ func (s *StorageAddSuite) TestAddStorageDiffSize(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi2up", state.StorageConstraints{Size: 2})
+	err := s.State.AddStorageForUnit(s.unitTag, "multi2up", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 2.0MB specified.*`)
 	s.assertStorageCount(c, s.originalStorageCount)
 }
@@ -129,7 +124,7 @@ func (s *StorageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageWrongName(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "furball", state.StorageConstraints{Size: 2})
+	err := s.State.AddStorageForUnit(s.unitTag, "furball", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm storage "furball" not found.*`)
 	s.assertStorageCount(c, s.originalStorageCount)
 }
@@ -137,7 +132,7 @@ func (s *StorageAddSuite) TestAddStorageWrongName(c *gc.C) {
 func (s *StorageAddSuite) TestAddStorageConcurrently(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 	addStorage := func() {
-		err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
+		err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
@@ -150,11 +145,11 @@ func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
 
 	count := 6
 	addStorage := func() {
-		err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+		err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Count: uint64(count)})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
-	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Count: uint64(count)})
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 15 specified.*`)
 
 	// Only "count" number of instances should have been added.

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -1,0 +1,162 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+)
+
+type StorageAddSuite struct {
+	StorageStateSuiteBase
+
+	charm                *state.Charm
+	unit                 *state.Unit
+	originalStorageCount int
+}
+
+var _ = gc.Suite(&StorageAddSuite{})
+
+func (s *StorageAddSuite) setupMultipleStoragesForAdd(c *gc.C) {
+	storageCons := map[string]state.StorageConstraints{
+		"multi1to10": makeStorageCons("loop", 0, 3),
+	}
+	s.charm = s.AddTestingCharm(c, "storage-block2")
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", s.charm, nil, storageCons)
+	c.Assert(err, jc.ErrorIsNil)
+	s.unit, err = service.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+
+	all, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	s.originalStorageCount = len(all)
+}
+
+func (s *StorageAddSuite) assertStorageCount(c *gc.C, expected int) {
+	all, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(all), gc.Equals, expected)
+}
+
+func (s *StorageAddSuite) TestAddStorageToUnit(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, s.originalStorageCount+1)
+}
+
+func (s *StorageAddSuite) TestAddStorageWithCount(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, s.originalStorageCount+2)
+}
+
+func (s *StorageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, s.originalStorageCount+2)
+
+	// Should not succeed as the number of storages after
+	// this call would be 11 whereas our upper limit is 10 here.
+	err = s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
+	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified.*`)
+	s.assertStorageCount(c, s.originalStorageCount+2)
+}
+
+func (s *StorageAddSuite) TestAddStorageExceedCount(c *gc.C) {
+	service, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
+	s.assertStorageCount(c, 1)
+
+	ch, _, err := service.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.AddStorageForUnit(ch.Meta(), u, "data", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block" store "data": at most 1 instances supported, 2 specified.*`)
+	s.assertStorageCount(c, 1)
+}
+
+func (s *StorageAddSuite) TestAddStorageMinCount(c *gc.C) {
+	service, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
+	s.assertStorageCount(c, 1)
+
+	ch, _, err := service.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.AddStorageForUnit(ch.Meta(), u, "allecto", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, 2)
+}
+
+func (s *StorageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, s.originalStorageCount+1)
+}
+
+func (s *StorageAddSuite) TestAddStorageDiffPool(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Pool: "loop-pool"})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, s.originalStorageCount+1)
+}
+
+func (s *StorageAddSuite) TestAddStorageDiffSize(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Size: 2048})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, s.originalStorageCount+1)
+}
+
+func (s *StorageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi2up", state.StorageConstraints{Size: 2})
+	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 2.0MB specified.*`)
+	s.assertStorageCount(c, s.originalStorageCount)
+}
+
+func (s *StorageAddSuite) TestAddStorageWrongName(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "furball", state.StorageConstraints{Size: 2})
+	c.Assert(err, gc.ErrorMatches, `.*charm storage "furball" not found.*`)
+	s.assertStorageCount(c, s.originalStorageCount)
+}
+
+func (s *StorageAddSuite) TestAddStorageConcurrently(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+	addStorage := func() {
+		err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
+	addStorage()
+	s.assertStorageCount(c, s.originalStorageCount+2)
+}
+
+func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
+	s.setupMultipleStoragesForAdd(c)
+
+	count := 6
+	addStorage := func() {
+		err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
+	err := s.State.AddStorageForUnit(s.charm.Meta(), s.unit, "multi1to10", state.StorageConstraints{Count: uint64(count)})
+	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 15 specified.*`)
+
+	// Only "count" number of instances should have been added.
+	s.assertStorageCount(c, s.originalStorageCount+count)
+}

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -201,7 +201,8 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultPool(c *gc.C)
 		"data": makeStorageCons("", 2048, 1),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop-pool", 2048, 1),
+		"data":    makeStorageCons("loop-pool", 2048, 1),
+		"allecto": makeStorageCons("loop-pool", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
@@ -211,7 +212,8 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoUserDefaultPool(c 
 		"data": makeStorageCons("", 2048, 1),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop", 2048, 1),
+		"data":    makeStorageCons("loop", 2048, 1),
+		"allecto": makeStorageCons("loop", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "", storageCons, expectedCons)
 }
@@ -221,7 +223,8 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFallback(
 		"data": makeStorageCons("loop-pool", 0, 1),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop-pool", 1024, 1),
+		"data":    makeStorageCons("loop-pool", 1024, 1),
+		"allecto": makeStorageCons("loop-pool", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -117,6 +117,11 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 			Count: 1,
 			Size:  1024,
 		},
+		"allecto": {
+			Pool:  "loop",
+			Count: 0,
+			Size:  1024,
+		},
 	})
 
 	ch = s.AddTestingCharm(c, "storage-filesystem")
@@ -181,7 +186,8 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsNoConstraintsUsed(c 
 		"data": makeStorageCons("", 0, 0),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop", 1024, 1),
+		"data":    makeStorageCons("loop", 1024, 1),
+		"allecto": makeStorageCons("loop", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
@@ -191,7 +197,8 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsJustCount(c *gc.C) {
 		"data": makeStorageCons("", 0, 1),
 	}
 	expectedCons := map[string]state.StorageConstraints{
-		"data": makeStorageCons("loop-pool", 1024, 1),
+		"data":    makeStorageCons("loop-pool", 1024, 1),
+		"allecto": makeStorageCons("loop", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
@@ -202,7 +209,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultPool(c *gc.C)
 	}
 	expectedCons := map[string]state.StorageConstraints{
 		"data":    makeStorageCons("loop-pool", 2048, 1),
-		"allecto": makeStorageCons("loop-pool", 1024, 0),
+		"allecto": makeStorageCons("loop", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }
@@ -224,7 +231,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFallback(
 	}
 	expectedCons := map[string]state.StorageConstraints{
 		"data":    makeStorageCons("loop-pool", 1024, 1),
-		"allecto": makeStorageCons("loop-pool", 1024, 0),
+		"allecto": makeStorageCons("loop", 1024, 0),
 	}
 	s.assertAddServiceStorageConstraintsDefaults(c, "loop-pool", storageCons, expectedCons)
 }

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -103,6 +103,11 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 			Size:  1024,
 			Count: 1,
 		},
+		"allecto": state.StorageConstraints{
+			Pool:  "loop",
+			Size:  1024,
+			Count: 0,
+		},
 	})
 }
 
@@ -128,6 +133,11 @@ func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 			Pool:  "default-block",
 			Size:  1024,
 			Count: 1,
+		},
+		"allecto": state.StorageConstraints{
+			Pool:  "default-block",
+			Size:  1024,
+			Count: 0,
 		},
 	})
 }

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -135,7 +135,7 @@ func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 			Count: 1,
 		},
 		"allecto": state.StorageConstraints{
-			Pool:  "default-block",
+			Pool:  "loop",
 			Size:  1024,
 			Count: 0,
 		},

--- a/testcharms/charm-repo/quantal/storage-block/metadata.yaml
+++ b/testcharms/charm-repo/quantal/storage-block/metadata.yaml
@@ -4,3 +4,7 @@ description: See above
 storage:
     data:
         type: block
+    allecto:
+        type: block
+        multiple:
+                range: 0+

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	"github.com/juju/utils/exec"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
@@ -25,16 +24,6 @@ type InterfaceSuite struct {
 }
 
 var _ = gc.Suite(&InterfaceSuite{})
-
-func (s *InterfaceSuite) GetContext(
-	c *gc.C, relId int, remoteName string,
-) jujuc.Context {
-	uuid, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	return s.HookContextSuite.getHookContext(
-		c, uuid.String(), relId, remoteName, noProxies,
-	)
-}
 
 func (s *InterfaceSuite) TestUtils(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")

--- a/worker/uniter/runner/export_test.go
+++ b/worker/uniter/runner/export_test.go
@@ -187,7 +187,6 @@ func NewHookContext(
 		code: statusCode,
 		info: statusInfo,
 	}
-
 	return ctx, nil
 }
 

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -128,6 +128,9 @@ type Context interface {
 	// HookStorageAttachment returns the storage attachment associated
 	// the executing hook if it was found, and whether it was found.
 	HookStorage() (ContextStorage, bool)
+
+	// AddUnitStorage saves storage constraints in the context.
+	AddUnitStorage(map[string]params.StorageConstraints)
 }
 
 // ContextRelation expresses the capabilities of a hook with respect to a relation.

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -49,6 +49,7 @@ var baseCommands = map[string]creator{
 }
 
 var storageCommands = map[string]creator{
+	"storage-add" + cmdSuffix: NewStorageAddCommand,
 	"storage-get" + cmdSuffix: NewStorageGetCommand,
 }
 

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -219,6 +219,7 @@ var newCommandTests = []struct {
 	{"relation-list", ""},
 	{"relation-set", ""},
 	{"unit-get", ""},
+	{"storage-add", ""},
 	{"storage-get", ""},
 	{"status-get", ""},
 	{"status-set", ""},

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -1,0 +1,92 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/utils/keyvalues"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/storage"
+)
+
+// StorageAddCommand implements the status-set command.
+type StorageAddCommand struct {
+	cmd.CommandBase
+	ctx Context
+	all map[string]params.StorageConstraints
+}
+
+// NewStorageAddCommand makes a jujuc storage-add command.
+func NewStorageAddCommand(ctx Context) cmd.Command {
+	return &StorageAddCommand{ctx: ctx}
+}
+
+var StorageAddDoc = `
+Storage add adds storage instances to unit using provided storage directives.
+A storage directive consists of a storage name as per charm specification
+and storage constraints, for e.g. pool, count, size.
+
+The acceptable format for storage constraints is a comma separated
+sequence of: POOL, COUNT, and SIZE, where
+
+    POOL identifies the storage pool. POOL can be a string
+    starting with a letter, followed by zero or more digits
+    or letters optionally separated by hyphens.
+
+    COUNT is a positive integer indicating how many instances
+    of the storage to create. If unspecified, and SIZE is
+    specified, COUNT defaults to 1.
+
+    SIZE describes the minimum size of the storage instances to
+    create. SIZE is a floating point number and multiplier from
+    the set (M, G, T, P, E, Z, Y), which are all treated as
+    powers of 1024.
+
+Storage constraints can be optionally ommitted as long as at least one 
+value is provided. 
+Environment default values will be used for all ommitted constraint values.
+There is no need to comma-separate ommitted constraints, 
+e.g. data=ebs,2, can be written as  data=ebs,2
+`
+
+func (s *StorageAddCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "storage-add",
+		Args:    "<charm storage name>=<constraints> ...",
+		Purpose: "add storage instances",
+		Doc:     StorageAddDoc,
+	}
+}
+
+func (s *StorageAddCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("storage add requires a storage directive")
+	}
+
+	// TODO (anastasiamac 2015-5-27) Bug 1459060:
+	//     For store names that already have constraints,
+	//     add support for "storage-add <name>".
+	//     This is equivalent to "storage-add <name>=1".
+	cons, err := keyvalues.Parse(args, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	s.all = make(map[string]params.StorageConstraints, len(cons))
+	for k, v := range cons {
+		c, err := storage.ParseConstraints(v)
+		if err != nil {
+			return errors.Annotatef(err, "cannot parse constraints for %q", k)
+		}
+		s.all[k] = params.StorageConstraints{c.Pool, &c.Size, &c.Count}
+	}
+	return nil
+}
+
+func (s *StorageAddCommand) Run(ctx *cmd.Context) error {
+	s.ctx.AddUnitStorage(s.all)
+	return nil
+}

--- a/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/worker/uniter/runner/jujuc/storage-add_test.go
@@ -1,0 +1,83 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type storageAddSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&storageAddSuite{})
+
+func (s *storageAddSuite) SetUpTest(c *gc.C) {
+	s.ContextSuite.SetUpTest(c)
+}
+
+func (s *storageAddSuite) getStorageUnitAddCommand(c *gc.C) cmd.Command {
+	hctx := s.GetStorageAddHookContext(c)
+	com, err := jujuc.NewCommand(hctx, cmdString("storage-add"))
+	c.Assert(err, jc.ErrorIsNil)
+	return com
+}
+
+func (s *storageAddSuite) TestHelp(c *gc.C) {
+	com := s.getStorageUnitAddCommand(c)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, []string{"--help"})
+	c.Assert(code, gc.Equals, 0)
+	help := `
+usage: storage-add <charm storage name>=<constraints> ...
+purpose: add storage instances
+`[1:] +
+		jujuc.StorageAddDoc
+	s.assertOutput(c, ctx, help, "")
+}
+
+func (s *storageAddSuite) assertOutput(c *gc.C, ctx *cmd.Context, o, e string) {
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, o)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, e)
+}
+
+type tstData struct {
+	args []string
+	code int
+	err  string
+}
+
+func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
+	tests := []tstData{
+		{[]string{}, 1, "storage add requires a storage directive"},
+		{[]string{"data"}, 1, `expected "key=value", got "data"`},
+		{[]string{"data="}, 1, ".*storage constraints require at least one.*"},
+		{[]string{"data=-676"}, 1, `.*cannot parse count: count must be gre.*`},
+	}
+	for i, t := range tests {
+		c.Logf("test %d: %#v", i, t.args)
+		com := s.getStorageUnitAddCommand(c)
+		testing.TestInit(c, com, t.args, t.err)
+	}
+}
+
+func (s *storageAddSuite) TestAddUnitStorage(c *gc.C) {
+	tests := []tstData{
+		{[]string{"data=676"}, 0, ""},
+	}
+
+	for i, t := range tests {
+		c.Logf("test %d: %#v", i, t.args)
+		com := s.getStorageUnitAddCommand(c)
+		ctx := testing.Context(c)
+		code := cmd.Main(com, ctx, t.args)
+		c.Assert(code, gc.Equals, t.code)
+		s.assertOutput(c, ctx, "", t.err)
+	}
+}

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -97,6 +97,10 @@ func (s *ContextSuite) GetStatusHookContext(c *gc.C) *Context {
 	return &Context{}
 }
 
+func (s *ContextSuite) GetStorageAddHookContext(c *gc.C) *Context {
+	return &Context{}
+}
+
 func setSettings(c *gc.C, ru *state.RelationUnit, settings map[string]interface{}) {
 	node, err := ru.Settings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -160,6 +164,8 @@ func (c *Context) Storage(tag names.StorageTag) (jujuc.ContextStorage, bool) {
 	storage, ok := c.storage[tag]
 	return storage, ok
 }
+
+func (c *Context) AddUnitStorage(all map[string]params.StorageConstraints) {}
 
 func (c *Context) HookStorage() (jujuc.ContextStorage, bool) {
 	return c.Storage(c.storageTag)

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -1,0 +1,176 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner_test
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/provider/ec2"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage/poolmanager"
+	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/storage/provider/registry"
+)
+
+type unitStorageSuite struct {
+	HookContextSuite
+	expectedStorageNames         set.Strings
+	charmName                    string
+	initCons                     map[string]state.StorageConstraints
+	ch                           *state.Charm
+	initialStorageInstancesCount int
+}
+
+var _ = gc.Suite(&unitStorageSuite{})
+
+const (
+	testPool           = "block"
+	testPersistentPool = "block-persistent"
+)
+
+func (s *unitStorageSuite) SetUpTest(c *gc.C) {
+	s.HookContextSuite.SetUpTest(c)
+	setupTestStorageSupport(c, s.State)
+}
+
+func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
+	s.createStorageBlockUnit(c)
+	count := uint64(1)
+	s.assertUnitStorageAdded(c,
+		map[string]params.StorageConstraints{
+			"allecto": params.StorageConstraints{Count: &count}})
+}
+
+func (s *unitStorageSuite) TestAddUnitStorageIgnoresBlocks(c *gc.C) {
+	s.createStorageBlockUnit(c)
+	count := uint64(1)
+	s.BlockDestroyEnvironment(c, "TestAddUnitStorageIgnoresBlocks")
+	s.BlockRemoveObject(c, "TestAddUnitStorageIgnoresBlocks")
+	s.BlockAllChanges(c, "TestAddUnitStorageIgnoresBlocks")
+	s.assertUnitStorageAdded(c,
+		map[string]params.StorageConstraints{
+			"allecto": params.StorageConstraints{Count: &count}})
+}
+
+func (s *unitStorageSuite) TestAddUnitStorageZeroCount(c *gc.C) {
+	s.createStorageBlockUnit(c)
+	size := uint64(1)
+	s.assertUnitStorageAdded(c,
+		map[string]params.StorageConstraints{
+			"allecto": params.StorageConstraints{Size: &size}})
+}
+
+func (s *unitStorageSuite) TestAddUnitStorageAccumulated(c *gc.C) {
+	s.createStorageBlock2Unit(c)
+	count := uint64(1)
+	size := uint64(2048)
+	s.assertUnitStorageAdded(c,
+		map[string]params.StorageConstraints{
+			"multi2up": params.StorageConstraints{Size: &size}},
+		map[string]params.StorageConstraints{
+			"multi1to10": params.StorageConstraints{Count: &count}})
+}
+
+func setupTestStorageSupport(c *gc.C, s *state.State) {
+	stsetts := state.NewStateSettings(s)
+	poolManager := poolmanager.New(stsetts)
+	_, err := poolManager.Create(testPool, provider.LoopProviderType, map[string]interface{}{"it": "works"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = poolManager.Create(testPersistentPool, ec2.EBS_ProviderType, map[string]interface{}{"persistent": true})
+	c.Assert(err, jc.ErrorIsNil)
+
+	registry.RegisterEnvironStorageProviders("dummy", ec2.EBS_ProviderType)
+	registry.RegisterEnvironStorageProviders("dummyenv", ec2.EBS_ProviderType)
+}
+
+func (s *unitStorageSuite) createStorageEnabledUnit(c *gc.C) {
+	s.ch = s.AddTestingCharm(c, s.charmName)
+	s.service = s.AddTestingServiceWithStorage(c, s.charmName, s.ch, s.initCons)
+	s.unit = s.AddUnit(c, s.service)
+
+	s.assertStorageCreated(c)
+	s.createHookSupport(c)
+}
+
+func (s *unitStorageSuite) createStorageBlockUnit(c *gc.C) {
+	s.charmName = "storage-block"
+	s.initCons = map[string]state.StorageConstraints{
+		"data": makeStorageCons("block", 1024, 1),
+	}
+	s.createStorageEnabledUnit(c)
+	s.assertStorageCreated(c)
+	s.createHookSupport(c)
+}
+
+func (s *unitStorageSuite) createStorageBlock2Unit(c *gc.C) {
+	s.charmName = "storage-block2"
+	s.initCons = map[string]state.StorageConstraints{
+		"multi1to10": makeStorageCons("loop", 0, 3),
+	}
+	s.createStorageEnabledUnit(c)
+	s.assertStorageCreated(c)
+	s.createHookSupport(c)
+}
+
+func (s *unitStorageSuite) assertStorageCreated(c *gc.C) {
+	all, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	s.initialStorageInstancesCount = len(all)
+	s.expectedStorageNames = set.NewStrings()
+	for _, one := range all {
+		s.expectedStorageNames.Add(one.StorageName())
+	}
+}
+
+func (s *unitStorageSuite) createHookSupport(c *gc.C) {
+	password, err := utils.RandomPassword()
+	err = s.unit.SetPassword(password)
+	c.Assert(err, jc.ErrorIsNil)
+	s.st = s.OpenAPIAs(c, s.unit.Tag(), password)
+	s.uniter, err = s.st.Uniter()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.uniter, gc.NotNil)
+	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.unit.SetCharmURL(s.ch.URL())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
+	return state.StorageConstraints{Pool: pool, Size: size, Count: count}
+}
+
+func (s *unitStorageSuite) assertUnitStorageAdded(c *gc.C, cons ...map[string]params.StorageConstraints) {
+	// Get the context.
+	ctx := s.getHookContext(c, s.State.EnvironUUID(), -1, "", noProxies)
+	c.Assert(ctx.UnitName(), gc.Equals, s.unit.Name())
+
+	for _, one := range cons {
+		for storage, _ := range one {
+			s.expectedStorageNames.Add(storage)
+		}
+		ctx.AddUnitStorage(one)
+	}
+
+	// Flush the context with a success.
+	err := ctx.FlushContext("success", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	after, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(after)-s.initialStorageInstancesCount, gc.Equals, len(cons))
+	s.assertExistingStorage(c, after)
+}
+
+func (s *unitStorageSuite) assertExistingStorage(c *gc.C, all []state.StorageInstance) {
+	for _, one := range all {
+		c.Assert(s.expectedStorageNames.Contains(one.StorageName()), jc.IsTrue)
+	}
+}


### PR DESCRIPTION
This is a backport of dynamic storage add from the master.

There were 5 cherry-picked merges:
+ state c4baca38168181615ca60b1f368001c3525b9ef1
+ apiserver 3ded121bcf2a02308f7b2a23350e7b34f041b787
+ api 20b4b5a4b7081fb89a40f63389cb9518a4414861
+ cli 4d7e6f523e36807ef03654d270ea8611e77bc988
+ hook 64d6c3f5c1a0020a295055e1d040961b7aa8fe82

There were some conflicts in state/storage.go. For sanity check, please put under special scrutiny:
    * destroy storage attachment(s)
    * default storage pool
    * default storage constraints
  

(Review request: http://reviews.vapour.ws/r/1803/)