### PR TITLE
Do not enable API on machine agent startup if tools upgrades are pending

### DIFF
--- a/apiserver/upgrading_root_test.go
+++ b/apiserver/upgrading_root_test.go
@@ -17,13 +17,17 @@ type upgradingRootSuite struct {
 
 var _ = gc.Suite(&upgradingRootSuite{})
 
-func (r *upgradingRootSuite) TestFindAllowedMethod(c *gc.C) {
+func (r *upgradingRootSuite) TestClientMethods(c *gc.C) {
 	root := apiserver.TestingUpgradingRoot(nil)
 
-	caller, err := root.FindMethod("Client", 0, "FullStatus")
-
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(caller, gc.NotNil)
+	for _, method := range []string{
+		"FullStatus", "EnvironmentGet", "PrivateAddress",
+		"PublicAddress",
+	} {
+		caller, err := root.FindMethod("Client", 0, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
 }
 
 func (r *upgradingRootSuite) TestFindDisallowedMethod(c *gc.C) {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -35,6 +35,7 @@ import (
 	apiagent "github.com/juju/juju/api/agent"
 	apideployer "github.com/juju/juju/api/deployer"
 	"github.com/juju/juju/api/metricsmanager"
+	apiupgrader "github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cert"
@@ -282,6 +283,7 @@ func NewMachineAgent(
 		workersStarted:       make(chan struct{}),
 		upgradeWorkerContext: upgradeWorkerContext,
 		runner:               runner,
+		initialAgentUpgradeCheckComplete: make(chan struct{}),
 	}
 }
 
@@ -307,6 +309,11 @@ type MachineAgent struct {
 	restoring            bool
 	workersStarted       chan struct{}
 
+	// Used to signal that the upgrade worker will not
+	// reboot the agent on startup because there are no
+	// longer any immediately pending agent upgrades.
+	initialAgentUpgradeCheckComplete chan struct{}
+
 	mongoInitMutex   sync.Mutex
 	mongoInitialized bool
 
@@ -330,6 +337,15 @@ func (a *MachineAgent) IsRestorePreparing() bool {
 // and running the actual restore process.
 func (a *MachineAgent) IsRestoreRunning() bool {
 	return a.restoring
+}
+
+func (a *MachineAgent) isAgentUpgradePending() bool {
+	select {
+	case <-a.initialAgentUpgradeCheckComplete:
+		return false
+	default:
+		return true
+	}
 }
 
 // Wait waits for the machine agent to finish.
@@ -657,17 +673,9 @@ func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 
 	runner := newConnRunner(st)
 
-	// Run the upgrader and the upgrade-steps worker without waiting for
+	// Run the agent upgrader and the upgrade-steps worker without waiting for
 	// the upgrade steps to complete.
-	runner.StartWorker("upgrader", func() (worker.Worker, error) {
-		return upgrader.NewUpgrader(
-			st.Upgrader(),
-			agentConfig,
-			a.previousAgentVersion,
-			a.upgradeWorkerContext.IsUpgradeRunning,
-		), nil
-	})
-
+	runner.StartWorker("upgrader", a.agentUpgraderWorkerStarter(st.Upgrader(), agentConfig))
 	runner.StartWorker("upgrade-steps", a.upgradeStepsWorkerStarter(st, entity.Jobs()))
 
 	// All other workers must wait for the upgrade steps to complete before starting.
@@ -830,6 +838,21 @@ func (a *MachineAgent) upgradeStepsWorkerStarter(
 ) func() (worker.Worker, error) {
 	return func() (worker.Worker, error) {
 		return a.upgradeWorkerContext.Worker(a, st, jobs), nil
+	}
+}
+
+func (a *MachineAgent) agentUpgraderWorkerStarter(
+	st *apiupgrader.State,
+	agentConfig agent.Config,
+) func() (worker.Worker, error) {
+	return func() (worker.Worker, error) {
+		return upgrader.NewAgentUpgrader(
+			st,
+			agentConfig,
+			a.previousAgentVersion,
+			a.upgradeWorkerContext.IsUpgradeRunning,
+			a.initialAgentUpgradeCheckComplete,
+		), nil
 	}
 }
 
@@ -1192,7 +1215,7 @@ func (a *MachineAgent) newApiserverWorker(st *state.State, certChanged chan para
 }
 
 // limitLogins is called by the API server for each login attempt.
-// it returns an error if upgrads or restore are running.
+// it returns an error if upgrades or restore are running.
 func (a *MachineAgent) limitLogins(req params.LoginRequest) error {
 	if err := a.limitLoginsDuringRestore(req); err != nil {
 		return err
@@ -1234,7 +1257,7 @@ func (a *MachineAgent) limitLoginsDuringRestore(req params.LoginRequest) error {
 // attempt. It returns an error if upgrades are in progress unless the
 // login is for a user (i.e. a client) or the local machine.
 func (a *MachineAgent) limitLoginsDuringUpgrade(req params.LoginRequest) error {
-	if a.upgradeWorkerContext.IsUpgradeRunning() {
+	if a.upgradeWorkerContext.IsUpgradeRunning() || a.isAgentUpgradePending() {
 		authTag, err := names.ParseTag(req.AuthTag)
 		if err != nil {
 			return errors.Annotate(err, "could not parse auth tag")
@@ -1529,11 +1552,16 @@ func (a *MachineAgent) startWorkerAfterUpgrade(runner worker.Runner, name string
 // upgradeWaiterWorker runs the specified worker after upgrades have completed.
 func (a *MachineAgent) upgradeWaiterWorker(start func() (worker.Worker, error)) worker.Worker {
 	return worker.NewSimpleWorker(func(stop <-chan struct{}) error {
-		// Wait for the upgrade to complete (or for us to be stopped).
-		select {
-		case <-stop:
-			return nil
-		case <-a.upgradeWorkerContext.UpgradeComplete:
+		// Wait for the agent upgrade and upgrade steps to complete (or for us to be stopped).
+		for _, ch := range []chan struct{}{
+			a.upgradeWorkerContext.UpgradeComplete,
+			a.initialAgentUpgradeCheckComplete,
+		} {
+			select {
+			case <-stop:
+				return nil
+			case <-ch:
+			}
 		}
 		// Upgrades are done, start the worker.
 		worker, err := start()
@@ -1571,6 +1599,13 @@ func (a *MachineAgent) setMachineStatus(apiState *api.State, status params.Statu
 // have been started. This is provided for testing purposes.
 func (a *MachineAgent) WorkersStarted() <-chan struct{} {
 	return a.workersStarted
+}
+
+// InitialAgentUpgradeCheckComplete returns a channel that's closed once
+// the initial checks to see if an agent upgrade is required are complete.
+// This is provided for testing purposes.
+func (a *MachineAgent) InitialAgentUpgradeCheckComplete() <-chan struct{} {
+	return a.initialAgentUpgradeCheckComplete
 }
 
 func (a *MachineAgent) Tag() names.Tag {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -312,6 +312,7 @@ type MachineAgent struct {
 	// Used to signal that the upgrade worker will not
 	// reboot the agent on startup because there are no
 	// longer any immediately pending agent upgrades.
+	// Channel used as a selectable bool (closed means true).
 	initialAgentUpgradeCheckComplete chan struct{}
 
 	mongoInitMutex   sync.Mutex
@@ -1599,13 +1600,6 @@ func (a *MachineAgent) setMachineStatus(apiState *api.State, status params.Statu
 // have been started. This is provided for testing purposes.
 func (a *MachineAgent) WorkersStarted() <-chan struct{} {
 	return a.workersStarted
-}
-
-// InitialAgentUpgradeCheckComplete returns a channel that's closed once
-// the initial checks to see if an agent upgrade is required are complete.
-// This is provided for testing purposes.
-func (a *MachineAgent) InitialAgentUpgradeCheckComplete() <-chan struct{} {
-	return a.initialAgentUpgradeCheckComplete
 }
 
 func (a *MachineAgent) Tag() names.Tag {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -807,7 +807,7 @@ func (s *MachineSuite) TestNoUpgradeRequired(c *gc.C) {
 	done := make(chan error)
 	go func() { done <- a.Run(nil) }()
 	select {
-	case <-a.InitialAgentUpgradeCheckComplete():
+	case <-a.initialAgentUpgradeCheckComplete:
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timeout waiting for upgrade check")
 	}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -798,6 +798,22 @@ func (s *MachineSuite) TestUpgradeRequest(c *gc.C) {
 	m, _, currentTools := s.primeAgent(c, version.Current, state.JobManageEnviron, state.JobHostUnits)
 	a := s.newAgent(c, m)
 	s.testUpgradeRequest(c, a, m.Tag().String(), currentTools)
+	c.Assert(a.isAgentUpgradePending(), jc.IsTrue)
+}
+
+func (s *MachineSuite) TestNoUpgradeRequired(c *gc.C) {
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron, state.JobHostUnits)
+	a := s.newAgent(c, m)
+	done := make(chan error)
+	go func() { done <- a.Run(nil) }()
+	select {
+	case <-a.InitialAgentUpgradeCheckComplete():
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout waiting for upgrade check")
+	}
+	defer a.Stop() // in case of failure
+	s.waitStopped(c, state.JobManageEnviron, a, done)
+	c.Assert(a.isAgentUpgradePending(), jc.IsFalse)
 }
 
 var fastDialOpts = api.DialOpts{
@@ -1671,6 +1687,7 @@ func (s *MachineSuite) TestMachineAgentAPIWorkerErrorClosesAPI(c *gc.C) {
 
 	c.Assert(worker, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "cannot set machine agent version: test failure")
+	c.Assert(a.isAgentUpgradePending(), jc.IsTrue)
 }
 
 type machineAgentUpgrader struct{}

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -533,7 +533,7 @@ func (s *UpgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 	// Wait for agent upgrade worker to determine that no
 	// agent upgrades are required.
 	select {
-	case <-a.InitialAgentUpgradeCheckComplete():
+	case <-a.initialAgentUpgradeCheckComplete:
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timeout waiting for upgrade check")
 	}

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -522,6 +522,22 @@ func (s *UpgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 
 	waitForUpgradeToFinish(c, machine0Conf)
 
+	// Only user and local logins are allowed even after upgrade steps because
+	// agent upgrade not finished yet.
+	s.checkLoginToAPIAsUser(c, machine0Conf, RestrictedAPIExposed)
+	c.Assert(canLoginToAPIAsMachine(c, machine0Conf, machine0Conf), jc.IsTrue)
+	c.Assert(canLoginToAPIAsMachine(c, machine1Conf, machine0Conf), jc.IsFalse)
+
+	machineAPI := s.OpenAPIAsMachine(c, machine.Tag(), initialMachinePassword, agent.BootstrapNonce)
+	runner.StartWorker("upgrader", a.agentUpgraderWorkerStarter(machineAPI.Upgrader(), machine0Conf))
+	// Wait for agent upgrade worker to determine that no
+	// agent upgrades are required.
+	select {
+	case <-a.InitialAgentUpgradeCheckComplete():
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timeout waiting for upgrade check")
+	}
+
 	// All logins are allowed after upgrade
 	s.checkLoginToAPIAsUser(c, machine0Conf, FullAPIExposed)
 	c.Assert(canLoginToAPIAsMachine(c, machine0Conf, machine0Conf), jc.IsTrue)

--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -54,6 +54,7 @@ type UnitAgent struct {
 	// Used to signal that the upgrade worker will not
 	// reboot the agent on startup because there are no
 	// longer any immediately pending agent upgrades.
+	// Channel used as a selectable bool (closed means true).
 	initialAgentUpgradeCheckComplete chan struct{}
 }
 


### PR DESCRIPTION
Partially fixes: https://bugs.launchpad.net/bugs/1455260

This PR doesn't prevent the implicit upgrade when the machine agent first starts. What it does do is delay the full API being available until any pending agent upgrades are done. There are now 2 conditions for the full API being made available: 
1. upgrade steps completed
2. agent upgrade worker sees on startup that no new tools are required

This change will prevent the scenario where scripts or the deployer bootstrap and connect immediately to start a deploy, but then get disconnected a short time later because the agents restart to complete an upgrade.

As a driveby, enhance the TestClientMethods test to check more APIs.

(Review request: http://reviews.vapour.ws/r/1805/)