### PR TITLE
{lease,leadership}: use tomb, interrupt callers

### DIFF
--- a/apiserver/leadership/settings_test.go
+++ b/apiserver/leadership/settings_test.go
@@ -47,11 +47,11 @@ func (s *settingsSuite) TestWriteSettings(c *gc.C) {
 	}
 
 	numIsLeaderCalls := 0
-	isLeader := func(serviceId, unitId string) bool {
+	isLeader := func(serviceId, unitId string) (bool, error) {
 		numIsLeaderCalls++
 		c.Check(serviceId, gc.Equals, StubServiceNm)
 		c.Check(unitId, gc.Equals, StubUnitNm)
-		return true
+		return true, nil
 	}
 
 	accessor := NewLeadershipSettingsAccessor(&stubAuthorizer{}, nil, nil, writeSettings, isLeader)
@@ -73,11 +73,11 @@ func (s *settingsSuite) TestWriteSettings(c *gc.C) {
 
 func (s *settingsSuite) TestWriteSettingFailsForNonLeader(c *gc.C) {
 	numIsLeaderCalls := 0
-	isLeader := func(serviceId, unitId string) bool {
+	isLeader := func(serviceId, unitId string) (bool, error) {
 		numIsLeaderCalls++
 		c.Check(serviceId, gc.Equals, StubServiceNm)
 		c.Check(unitId, gc.Equals, StubUnitNm)
-		return false
+		return false, nil
 	}
 
 	accessor := NewLeadershipSettingsAccessor(&stubAuthorizer{}, nil, nil, nil, isLeader)

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -983,8 +983,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				return a.newRestoreStateWatcherWorker(st)
 			})
 			a.startWorkerAfterUpgrade(runner, "lease manager", func() (worker.Worker, error) {
-				workerLoop := lease.WorkerLoop(st)
-				return worker.NewSimpleWorker(workerLoop), nil
+				return lease.NewLeaseManager(st)
 			})
 			certChangedChan := make(chan params.StateServingInfo, 1)
 			runner.StartWorker("apiserver", a.apiserverWorkerStarter(st, certChangedChan))

--- a/cmd/jujud/unit_test.go
+++ b/cmd/jujud/unit_test.go
@@ -28,7 +28,6 @@ import (
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	envtesting "github.com/juju/juju/environs/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/lease"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -42,7 +41,6 @@ import (
 type UnitSuite struct {
 	coretesting.GitSuite
 	agenttesting.AgentSuite
-	leaseWorker worker.Worker
 }
 
 var _ = gc.Suite(&UnitSuite{})
@@ -60,16 +58,9 @@ func (s *UnitSuite) TearDownSuite(c *gc.C) {
 func (s *UnitSuite) SetUpTest(c *gc.C) {
 	s.GitSuite.SetUpTest(c)
 	s.AgentSuite.SetUpTest(c)
-	// If we don't have a lease manager running somewhere, the API calls hang.
-	workerLoop := lease.WorkerLoop(s.State)
-	s.leaseWorker = worker.NewSimpleWorker(workerLoop)
 }
 
 func (s *UnitSuite) TearDownTest(c *gc.C) {
-	if s.leaseWorker != nil {
-		c.Check(worker.Stop(s.leaseWorker), jc.ErrorIsNil)
-		s.leaseWorker = nil
-	}
 	s.AgentSuite.TearDownTest(c)
 	s.GitSuite.TearDownTest(c)
 }

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
+	"github.com/juju/juju/lease"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -44,6 +45,13 @@ type leadershipSuite struct {
 func (s *leadershipSuite) SetUpTest(c *gc.C) {
 
 	s.AgentSuite.SetUpTest(c)
+
+	leaseManager, err := lease.NewLeaseManager(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		leaseManager.Kill()
+		c.Assert(leaseManager.Wait(), jc.ErrorIsNil)
+	})
 
 	file, _ := ioutil.TempFile("", "juju-run")
 	defer file.Close()
@@ -296,6 +304,13 @@ func (s *uniterLeadershipSuite) TestSettingsChangeNotifier(c *gc.C) {
 func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 
 	s.AgentSuite.SetUpTest(c)
+
+	leaseManager, err := lease.NewLeaseManager(s.State)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		leaseManager.Kill()
+		c.Assert(leaseManager.Wait(), jc.ErrorIsNil)
+	})
 
 	file, _ := ioutil.TempFile("", "juju-run")
 	defer file.Close()

--- a/leadership/interface.go
+++ b/leadership/interface.go
@@ -43,11 +43,13 @@ type LeadershipLeaseManager interface {
 	// RetrieveLease retrieves the current lease token for a given
 	// namespace. This is not intended to be exposed to clients, and is
 	// only available within a server-process.
-	RetrieveLease(namespace string) lease.Token
+	RetrieveLease(namespace string) (lease.Token, error)
 
 	// LeaseReleasedNotifier returns a channel a caller can block on to be
-	// notified of when a lease is released for namespace. This channel is
-	// reusable, but will be closed if it does not respond within
-	// "notificationTimeout".
-	LeaseReleasedNotifier(namespace string) (notifier <-chan struct{})
+	// notified of when a lease is released for namespace. The caller must
+	// use a comma-ok to decide whether or not the channel was notified or
+	// was closed: if notified, then the lease has been released; if closed,
+	// then the lease manager has been disrupted before it could notify
+	// the caller.
+	LeaseReleasedNotifier(namespace string) (notifier <-chan struct{}, err error)
 }

--- a/leadership/leadership.go
+++ b/leadership/leadership.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"launchpad.net/tomb"
 
 	"github.com/juju/juju/lease"
 )
@@ -15,6 +14,8 @@ import (
 const (
 	leadershipNamespaceSuffix = "-leadership"
 )
+
+var errWorkerStopped = errors.New("worker stopped")
 
 // NewLeadershipManager returns a new Manager.
 func NewLeadershipManager(leaseMgr LeadershipLeaseManager) *Manager {
@@ -68,7 +69,7 @@ func (m *Manager) BlockUntilLeadershipReleased(serviceId string) error {
 	}
 	_, ok := <-notifier
 	if !ok {
-		return tomb.ErrDying
+		return errWorkerStopped
 	}
 	return nil
 }

--- a/leadership/leadership_test.go
+++ b/leadership/leadership_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"launchpad.net/tomb"
 
 	"github.com/juju/juju/lease"
 )
@@ -180,5 +179,5 @@ func (s *leadershipSuite) TestBlockUntilLeadershipChannelClosed(c *gc.C) {
 
 	leaderMgr := NewLeadershipManager(stub)
 	err := leaderMgr.BlockUntilLeadershipReleased(StubServiceNm)
-	c.Check(err, gc.Equals, tomb.ErrDying)
+	c.Check(err, gc.ErrorMatches, "worker stopped")
 }

--- a/lease/lease.go
+++ b/lease/lease.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"launchpad.net/tomb"
 )
 
 const (
@@ -21,36 +22,16 @@ const (
 )
 
 var (
-	singleton           *leaseManager
 	LeaseClaimDeniedErr = errors.New("lease claim denied")
 	NotLeaseOwnerErr    = errors.Unauthorizedf("caller did not own lease for namespace")
 
-	// TODO(Wallyworld) - a stop-gap error until we refactor using a tomb.
-	LeaseManagerErr = errors.New("lease manager restarted due to error")
-
 	logger = loggo.GetLogger("juju.lease")
 )
-
-func init() {
-	singleton = &leaseManager{
-		claimLease:       make(chan claimLeaseMsg),
-		releaseLease:     make(chan releaseLeaseMsg),
-		leaseReleasedSub: make(chan leaseReleasedMsg),
-		copyOfTokens:     make(chan copyTokensMsg),
-	}
-}
 
 type leasePersistor interface {
 	WriteToken(string, Token) error
 	RemoveToken(id string) error
 	PersistedTokens() ([]Token, error)
-}
-
-// WorkerLoop returns a function which can be utilized within a
-// worker.
-func WorkerLoop(persistor leasePersistor) func(<-chan struct{}) error {
-	singleton.leasePersistor = persistor
-	return singleton.workerLoop
 }
 
 // Token represents a lease claim.
@@ -59,65 +40,95 @@ type Token struct {
 	Expiration    time.Time
 }
 
-// Manager returns a manager.
-func Manager() *leaseManager {
-	// Guaranteed to be initialized because the init function runs
-	// first.
-	return singleton
-}
-
 //
 // Messages for channels.
 //
 
-type claimLeaseResponse struct {
-	token Token
-	err   error
-}
-
 type claimLeaseMsg struct {
 	Token    Token
-	Response chan<- claimLeaseResponse
+	Response chan<- Token
 }
+
 type releaseLeaseMsg struct {
 	Token    Token
 	Response chan<- error
 }
+
 type leaseReleasedMsg struct {
 	Watcher      chan<- struct{}
 	ForNamespace string
 }
+
 type copyTokensMsg struct {
 	Response chan<- []Token
 }
 
 type leaseManager struct {
+	tomb             tomb.Tomb
 	leasePersistor   leasePersistor
-	retrieveLease    chan Token
 	claimLease       chan claimLeaseMsg
 	releaseLease     chan releaseLeaseMsg
 	leaseReleasedSub chan leaseReleasedMsg
 	copyOfTokens     chan copyTokensMsg
 }
 
+func NewLeaseManager(leasePersistor leasePersistor) (*leaseManager, error) {
+	m := &leaseManager{
+		leasePersistor:   leasePersistor,
+		claimLease:       make(chan claimLeaseMsg),
+		releaseLease:     make(chan releaseLeaseMsg),
+		leaseReleasedSub: make(chan leaseReleasedMsg),
+		copyOfTokens:     make(chan copyTokensMsg),
+	}
+	if err := singleton.setLeaseManager(m); err != nil {
+		return nil, err
+	}
+	go func() {
+		defer m.tomb.Done()
+		defer singleton.setLeaseManager(nil)
+		m.tomb.Kill(m.loop())
+	}()
+	return m, nil
+}
+
+func (m *leaseManager) Kill() {
+	m.tomb.Kill(nil)
+}
+
+func (m *leaseManager) Wait() error {
+	return m.tomb.Wait()
+}
+
 // CopyOfLeaseTokens returns a copy of the lease tokens currently held
 // by the manager.
-func (m *leaseManager) CopyOfLeaseTokens() []Token {
-	ch := make(chan []Token)
-	m.copyOfTokens <- copyTokensMsg{ch}
-	return <-ch
+func (m *leaseManager) CopyOfLeaseTokens() ([]Token, error) {
+	reqch := m.copyOfTokens
+	respch := make(chan []Token, 1)
+	for {
+		select {
+		case <-m.tomb.Dead():
+			return nil, m.tomb.Err()
+		case reqch <- copyTokensMsg{respch}:
+			reqch = nil
+		case resp := <-respch:
+			return resp, nil
+		}
+	}
 }
 
 // RetrieveLease returns the lease token currently stored for the
 // given namespace.
-func (m *leaseManager) RetrieveLease(namespace string) Token {
-	for _, tok := range m.CopyOfLeaseTokens() {
-		if tok.Namespace != namespace {
-			continue
-		}
-		return tok
+func (m *leaseManager) RetrieveLease(namespace string) (Token, error) {
+	tokens, err := m.CopyOfLeaseTokens()
+	if err != nil {
+		return Token{}, err
 	}
-	return Token{}
+	for _, tok := range tokens {
+		if tok.Namespace == namespace {
+			return tok, nil
+		}
+	}
+	return Token{}, errors.NotFoundf("lease for %s", namespace)
 }
 
 // Claimlease claims a lease for the given duration for the given
@@ -125,32 +136,42 @@ func (m *leaseManager) RetrieveLease(namespace string) Token {
 // LeaseClaimDeniedErr will be returned. Either way the current lease
 // owner's ID will be returned.
 func (m *leaseManager) ClaimLease(namespace, id string, forDur time.Duration) (leaseOwnerId string, err error) {
-
-	ch := make(chan claimLeaseResponse)
+	reqch := m.claimLease
+	respch := make(chan Token, 1)
 	token := Token{namespace, id, time.Now().Add(forDur)}
-	message := claimLeaseMsg{token, ch}
-	m.claimLease <- message
-	claimResponse := <-ch
-	if claimResponse.err != nil {
-		return "", claimResponse.err
+	for {
+		select {
+		case <-m.tomb.Dead():
+			return "", m.tomb.Err()
+		case reqch <- claimLeaseMsg{token, respch}:
+			reqch = nil
+		case lease := <-respch:
+			leaseOwnerId = lease.Id
+			if id != leaseOwnerId {
+				err = LeaseClaimDeniedErr
+			}
+			return leaseOwnerId, err
+		}
 	}
-
-	leaseOwnerId = claimResponse.token.Id
-	if id != leaseOwnerId {
-		err = LeaseClaimDeniedErr
-	}
-
-	return leaseOwnerId, err
 }
 
 // ReleaseLease releases the lease held for namespace by id.
 func (m *leaseManager) ReleaseLease(namespace, id string) (err error) {
 
-	ch := make(chan error)
+	reqch := m.releaseLease
+	respch := make(chan error, 1)
 	token := Token{Namespace: namespace, Id: id}
-	message := releaseLeaseMsg{token, ch}
-	m.releaseLease <- message
-	err = <-ch
+loop:
+	for {
+		select {
+		case <-m.tomb.Dead():
+			return m.tomb.Err()
+		case reqch <- releaseLeaseMsg{token, respch}:
+			reqch = nil
+		case err = <-respch:
+			break loop
+		}
+	}
 
 	if err != nil {
 		err = errors.Annotatef(err, `could not release lease for namespace %q, id %q`, namespace, id)
@@ -171,16 +192,19 @@ func (m *leaseManager) ReleaseLease(namespace, id string) (err error) {
 // LeaseReleasedNotifier returns a channel a caller can block on to be
 // notified of when a lease is released for namespace. This channel is
 // reusable, but will be closed if it does not respond within
-// "notificationTimeout".
-func (m *leaseManager) LeaseReleasedNotifier(namespace string) (notifier <-chan struct{}) {
-	watcher := make(chan struct{})
-	m.leaseReleasedSub <- leaseReleasedMsg{watcher, namespace}
-
-	return watcher
+// "notificationTimeout", or if the lease manager exits.
+func (m *leaseManager) LeaseReleasedNotifier(namespace string) (notifier <-chan struct{}, err error) {
+	watcher := make(chan struct{}, 1)
+	select {
+	case <-m.tomb.Dead():
+		return nil, m.tomb.Err()
+	case m.leaseReleasedSub <- leaseReleasedMsg{watcher, namespace}:
+		return watcher, nil
+	}
 }
 
 // workerLoop serializes all requests into a single thread.
-func (m *leaseManager) workerLoop(stop <-chan struct{}) error {
+func (m *leaseManager) loop() error {
 	// These data-structures are local to ensure they're only utilized
 	// within this thread-safe context.
 
@@ -189,46 +213,66 @@ func (m *leaseManager) workerLoop(stop <-chan struct{}) error {
 	// Pull everything off our data-store & check for expirations.
 	leaseCache, err := populateTokenCache(m.leasePersistor)
 	if err != nil {
-		return err
+		return errors.Annotate(err, "populating cache")
 	}
-	nextExpiration := m.expireLeases(leaseCache, releaseSubs)
+	nextExpiration, err := m.expireLeases(leaseCache, releaseSubs)
+	if err != nil {
+		return errors.Annotate(err, "expiring leases")
+	}
 
 	for {
 		select {
-		case <-stop:
-			return nil
+		case <-m.tomb.Dying():
+			// Close any outstanding subscribers, to inform them
+			// that the worker is dying.
+			for _, subs := range releaseSubs {
+				for _, sub := range subs {
+					close(sub)
+				}
+			}
+			return tomb.ErrDying
 		case claim := <-m.claimLease:
 			lease := claimLease(leaseCache, claim.Token)
 			if lease.Id == claim.Token.Id {
 				if err := m.leasePersistor.WriteToken(lease.Namespace, lease); err != nil {
-					claim.Response <- claimLeaseResponse{err: LeaseManagerErr}
-					return err
+					return errors.Annotate(err, "writing lease token")
 				}
 				if lease.Expiration.Before(nextExpiration) {
 					nextExpiration = lease.Expiration
 				}
 			}
-			claim.Response <- claimLeaseResponse{lease, err}
+			select {
+			case <-m.tomb.Dying():
+			case claim.Response <- lease:
+			}
 		case release := <-m.releaseLease:
 			// Unwind our layers from most volatile to least.
 			err := releaseLease(leaseCache, release.Token)
 			if err == nil {
 				namespace := release.Token.Namespace
 				if err := m.leasePersistor.RemoveToken(namespace); err != nil {
-					release.Response <- LeaseManagerErr
-					return err
+					return errors.Annotate(err, "removing lease token")
 				}
 				notifyOfRelease(releaseSubs[namespace], namespace)
 			}
-			release.Response <- err
+			select {
+			case <-m.tomb.Dying():
+			case release.Response <- err:
+			}
 		case subscription := <-m.leaseReleasedSub:
 			subscribe(releaseSubs, subscription)
 		case msg := <-m.copyOfTokens:
 			// create a copy of the lease cache for use by code
 			// external to our thread-safe context.
-			msg.Response <- copyTokens(leaseCache)
+			select {
+			case <-m.tomb.Dying():
+			case msg.Response <- copyTokens(leaseCache):
+			}
 		case <-time.After(nextExpiration.Sub(time.Now())):
-			nextExpiration = m.expireLeases(leaseCache, releaseSubs)
+			nextExpiration, err = m.expireLeases(leaseCache, releaseSubs)
+			if err != nil {
+				return errors.Annotate(err, "expiring leases")
+			}
 		}
 	}
 }
@@ -236,7 +280,7 @@ func (m *leaseManager) workerLoop(stop <-chan struct{}) error {
 func (m *leaseManager) expireLeases(
 	cache map[string]Token,
 	subscribers map[string][]chan<- struct{},
-) time.Time {
+) (time.Time, error) {
 
 	// Having just looped through all the leases we're holding, we can
 	// inform the caller of when the next expiration will occur.
@@ -256,15 +300,13 @@ func (m *leaseManager) expireLeases(
 
 		logger.Infof(`Lease for namespace %q has expired.`, token.Namespace)
 		if err := releaseLease(cache, token); err != nil {
-			// TODO(fwereade): we should certainly be returning the error and
-			// killing the main loop.
-			logger.Errorf("Failed to release expired lease for namespace %q: %v", token.Namespace, err)
+			return time.Time{}, errors.Annotatef(err, "releasing expired lease for namespace %q", token.Namespace)
 		} else {
 			notifyOfRelease(subscribers[token.Namespace], token.Namespace)
 		}
 	}
 
-	return nextExpiration
+	return nextExpiration, nil
 }
 
 func copyTokens(cache map[string]Token) (copy []Token) {

--- a/lease/lease_test.go
+++ b/lease/lease_test.go
@@ -161,7 +161,7 @@ func (s *leaseSuite) TestClaimLeaseError(c *gc.C) {
 	manager, err := NewLeaseManager(s.persistor)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = manager.ClaimLease(testNamespace, "error", testDuration)
-	c.Assert(err, gc.ErrorMatches, "writing lease token: error")
+	c.Assert(err, gc.ErrorMatches, "worker stopped")
 	err = manager.Wait()
 	c.Assert(err, gc.ErrorMatches, "writing lease token: error")
 }
@@ -227,12 +227,12 @@ func (s *leaseSuite) TestReleaseLeaseError(c *gc.C) {
 	manager, err := NewLeaseManager(&stubLeasePersistorRemoveError{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = manager.ClaimLease(testNamespace, testId, testDuration)
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.manager.ReleaseLease(testNamespace, testId)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
+	err = manager.ReleaseLease(testNamespace, testId)
+	c.Check(err, gc.ErrorMatches, "worker stopped")
 	manager.Kill()
 	err = manager.Wait()
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, "removing lease token: error")
 }
 
 func (s *leaseSuite) TestReleaseLeaseNotOwned(c *gc.C) {

--- a/lease/lease_test.go
+++ b/lease/lease_test.go
@@ -61,32 +61,37 @@ func (p *stubLeasePersistor) PersistedTokens() ([]Token, error) {
 
 type leaseSuite struct {
 	coretesting.BaseSuite
+
+	persistor *stubLeasePersistor
+	manager   *leaseManager
 }
 
-func (s *leaseSuite) TestSingleton(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
+func (s *leaseSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.persistor = &stubLeasePersistor{}
+	manager, err := NewLeaseManager(s.persistor)
+	c.Assert(err, jc.ErrorIsNil)
+	s.manager = manager
+}
 
-	copyA := Manager()
-	copyB := Manager()
-
-	c.Assert(copyA, gc.NotNil)
-	c.Assert(copyA, gc.Equals, copyB)
+func (s *leaseSuite) TearDownTest(c *gc.C) {
+	s.manager.Kill()
+	c.Check(s.manager.Wait(), jc.ErrorIsNil)
+	s.manager = nil
+	s.persistor = nil
+	s.BaseSuite.TearDownTest(c)
 }
 
 // TestTokenListIsolation ensures that the copy of the lease tokens we
 // get is truly a copy and thus isolated from all other code.
 func (s *leaseSuite) TestCopyOfLeaseTokensIsolated(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	_, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Assert(err, jc.ErrorIsNil)
 
-	toksA := mgr.CopyOfLeaseTokens()
-	toksB := mgr.CopyOfLeaseTokens()
+	toksA, err := s.manager.CopyOfLeaseTokens()
+	c.Assert(err, jc.ErrorIsNil)
+	toksB, err := s.manager.CopyOfLeaseTokens()
+	c.Assert(err, jc.ErrorIsNil)
 
 	// The tokens are equivalent...
 	c.Assert(toksA, gc.HasLen, 1)
@@ -97,16 +102,12 @@ func (s *leaseSuite) TestCopyOfLeaseTokensIsolated(c *gc.C) {
 	c.Check(toksA[0], gc.Not(gc.Equals), toksB[0])
 
 	//...and the cache remains intact.
-	err = mgr.ReleaseLease(testNamespace, testId)
+	err = s.manager.ReleaseLease(testNamespace, testId)
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *leaseSuite) TestCopyOfLeaseTokensRaces(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	_, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Fill a channel with several concurrently-acquired copies...
@@ -116,8 +117,10 @@ func (s *leaseSuite) TestCopyOfLeaseTokensRaces(c *gc.C) {
 	for i := 0; i < count; i++ {
 		wg.Add(1)
 		go func() {
-			results <- mgr.CopyOfLeaseTokens()
-			wg.Done()
+			defer wg.Done()
+			tokens, err := s.manager.CopyOfLeaseTokens()
+			c.Check(err, jc.ErrorIsNil)
+			results <- tokens
 		}()
 	}
 	wg.Wait()
@@ -140,39 +143,30 @@ func (s *leaseSuite) TestCopyOfLeaseTokensRaces(c *gc.C) {
 }
 
 func (s *leaseSuite) TestClaimLeaseSuccess(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-
-	ownerId, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	ownerId, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ownerId, gc.Equals, testId)
 
-	toks := mgr.CopyOfLeaseTokens()
+	toks, err := s.manager.CopyOfLeaseTokens()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(toks, gc.HasLen, 1)
 	c.Assert(toks[0].Namespace, gc.Equals, testNamespace)
 	c.Assert(toks[0].Id, gc.Equals, testId)
 }
 
 func (s *leaseSuite) TestClaimLeaseError(c *gc.C) {
-	stop := make(chan struct{})
-	go func() {
-		err := WorkerLoop(&stubLeasePersistor{})(stop)
-		c.Assert(err, gc.NotNil)
-	}()
-	mgr := Manager()
+	s.manager.Kill()
+	c.Assert(s.manager.Wait(), jc.ErrorIsNil)
 
-	_, err := mgr.ClaimLease(testNamespace, "error", testDuration)
-	c.Assert(errors.Cause(err), gc.Equals, LeaseManagerErr)
+	manager, err := NewLeaseManager(s.persistor)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = manager.ClaimLease(testNamespace, "error", testDuration)
+	c.Assert(err, gc.ErrorMatches, "writing lease token: error")
+	err = manager.Wait()
+	c.Assert(err, gc.ErrorMatches, "writing lease token: error")
 }
 
 func (s *leaseSuite) TestClaimLeaseRaces(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-
 	// Run several concurrent requests for different ids in the same namespace.
 	var wg sync.WaitGroup
 	const count = 10
@@ -181,7 +175,7 @@ func (s *leaseSuite) TestClaimLeaseRaces(c *gc.C) {
 		wg.Add(1)
 		go func(i int) {
 			id := fmt.Sprintf("unit/%d", i)
-			ownerId, err := mgr.ClaimLease(testNamespace, id, testDuration)
+			ownerId, err := s.manager.ClaimLease(testNamespace, id, testDuration)
 			c.Logf(ownerId)
 			if err != nil {
 				c.Check(err, gc.Equals, LeaseClaimDeniedErr)
@@ -207,17 +201,14 @@ func (s *leaseSuite) TestClaimLeaseRaces(c *gc.C) {
 }
 
 func (s *leaseSuite) TestReleaseLease(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	_, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = mgr.ReleaseLease(testNamespace, testId)
+	err = s.manager.ReleaseLease(testNamespace, testId)
 	c.Assert(err, jc.ErrorIsNil)
 
-	toks := mgr.CopyOfLeaseTokens()
+	toks, err := s.manager.CopyOfLeaseTokens()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(toks, gc.HasLen, 0)
 }
 
@@ -230,50 +221,43 @@ func (p *stubLeasePersistorRemoveError) RemoveToken(id string) error {
 }
 
 func (s *leaseSuite) TestReleaseLeaseError(c *gc.C) {
-	stop := make(chan struct{})
-	go func() {
-		err := WorkerLoop(&stubLeasePersistorRemoveError{})(stop)
-		c.Assert(err, gc.NotNil)
-	}()
-	mgr := Manager()
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
-	c.Assert(err, jc.ErrorIsNil)
+	s.manager.Kill()
+	c.Assert(s.manager.Wait(), jc.ErrorIsNil)
 
-	err = mgr.ReleaseLease(testNamespace, testId)
-	c.Assert(errors.Cause(err), gc.Equals, LeaseManagerErr)
+	manager, err := NewLeaseManager(&stubLeasePersistorRemoveError{})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = manager.ClaimLease(testNamespace, testId, testDuration)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.manager.ReleaseLease(testNamespace, testId)
+	c.Assert(err, jc.ErrorIsNil)
+	manager.Kill()
+	err = manager.Wait()
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *leaseSuite) TestReleaseLeaseNotOwned(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	_, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = mgr.ReleaseLease(testNamespace, "1234")
+	err = s.manager.ReleaseLease(testNamespace, "1234")
 	// No error returned (we log it).
 	c.Assert(err, jc.ErrorIsNil)
 	// But cache unaffected.
-	toks := mgr.CopyOfLeaseTokens()
+	toks, err := s.manager.CopyOfLeaseTokens()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(toks, gc.HasLen, 1)
 	c.Assert(toks[0].Namespace, gc.Equals, testNamespace)
 	c.Assert(toks[0].Id, gc.Equals, testId)
 }
 
 func (s *leaseSuite) TestReleaseLeaseRaces(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-
 	// Add several leases in different namespaces.
 	const count = 10
 	var namespaces []string
 	for i := 0; i < count; i++ {
 		namespace := fmt.Sprintf("namespace-%d", i)
 		namespaces = append(namespaces, namespace)
-		_, err := mgr.ClaimLease(namespace, testId, testDuration)
+		_, err := s.manager.ClaimLease(namespace, testId, testDuration)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -282,7 +266,7 @@ func (s *leaseSuite) TestReleaseLeaseRaces(c *gc.C) {
 	for _, namespace := range namespaces {
 		wg.Add(1)
 		go func(namespace string) {
-			err := mgr.ReleaseLease(namespace, testId)
+			err := s.manager.ReleaseLease(namespace, testId)
 			c.Check(err, jc.ErrorIsNil)
 			wg.Done()
 		}(namespace)
@@ -290,44 +274,33 @@ func (s *leaseSuite) TestReleaseLeaseRaces(c *gc.C) {
 	wg.Wait()
 
 	// Check the cache agrees they're all released.
-	toks := mgr.CopyOfLeaseTokens()
+	toks, err := s.manager.CopyOfLeaseTokens()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(toks, gc.HasLen, 0)
 }
 
 func (s *leaseSuite) TestRetrieveLease(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	_, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Assert(err, jc.ErrorIsNil)
 
-	tok := mgr.RetrieveLease(testNamespace)
+	tok, err := s.manager.RetrieveLease(testNamespace)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(tok.Id, gc.Equals, testId)
 	c.Check(tok.Namespace, gc.Equals, testNamespace)
 }
 
 func (s *leaseSuite) TestRetrieveLeaseWithBadNamespaceFails(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-
-	mgr := Manager()
-
-	tok := mgr.RetrieveLease(testNamespace)
-	c.Assert(tok, gc.DeepEquals, Token{})
+	_, err := s.manager.RetrieveLease(testNamespace)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *leaseSuite) TestReleaseLeaseNotification(c *gc.C) {
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-	mgr := Manager()
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	_, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Listen for the lease to be released.
-	subscription := mgr.LeaseReleasedNotifier(testNamespace)
+	subscription, err := s.manager.LeaseReleasedNotifier(testNamespace)
+	c.Assert(err, jc.ErrorIsNil)
 	receivedSignal := make(chan struct{})
 	go func() {
 		<-subscription
@@ -335,7 +308,7 @@ func (s *leaseSuite) TestReleaseLeaseNotification(c *gc.C) {
 	}()
 
 	// Release it
-	err = mgr.ReleaseLease(testNamespace, testId)
+	err = s.manager.ReleaseLease(testNamespace, testId)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
@@ -352,10 +325,6 @@ func (s *leaseSuite) TestLeaseExpiration(c *gc.C) {
 	// it is testing. For that reason, we try a few times to see if we
 	// can get a successful run.
 
-	stop := make(chan struct{})
-	go WorkerLoop(&stubLeasePersistor{})(stop)
-	defer func() { stop <- struct{}{} }()
-
 	const (
 		leaseDuration      = 500 * time.Millisecond
 		acceptableOverhead = 50 * time.Millisecond
@@ -367,8 +336,8 @@ func (s *leaseSuite) TestLeaseExpiration(c *gc.C) {
 
 	// Listen for releases before sending the claim to avoid the
 	// overhead which may affect our timing measurements.
-	mgr := Manager()
-	subscription := mgr.LeaseReleasedNotifier(testNamespace)
+	subscription, err := s.manager.LeaseReleasedNotifier(testNamespace)
+	c.Assert(err, jc.ErrorIsNil)
 	receivedSignal := make(chan struct{})
 
 	var leaseClaimedTime time.Time
@@ -393,7 +362,7 @@ func (s *leaseSuite) TestLeaseExpiration(c *gc.C) {
 	}()
 
 	// Grab a lease.
-	_, err := mgr.ClaimLease(testNamespace, testId, leaseDuration)
+	_, err = s.manager.ClaimLease(testNamespace, testId, leaseDuration)
 	leaseClaimedTime = time.Now()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -407,16 +376,8 @@ func (s *leaseSuite) TestLeaseExpiration(c *gc.C) {
 
 func (s *leaseSuite) TestManagerPeresistsOnClaims(c *gc.C) {
 
-	persistor := &stubLeasePersistor{}
-
-	stop := make(chan struct{})
-	go WorkerLoop(persistor)(stop)
-	defer func() { stop <- struct{}{} }()
-
-	mgr := Manager()
-
 	numWriteCalls := 0
-	persistor.WriteTokenFn = func(id string, tok Token) error {
+	s.persistor.WriteTokenFn = func(id string, tok Token) error {
 		numWriteCalls++
 
 		c.Assert(tok, gc.NotNil)
@@ -427,62 +388,56 @@ func (s *leaseSuite) TestManagerPeresistsOnClaims(c *gc.C) {
 		return nil
 	}
 
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	_, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(numWriteCalls, gc.Equals, 1)
 }
 
 func (s *leaseSuite) TestManagerRemovesOnRelease(c *gc.C) {
 
-	persistor := &stubLeasePersistor{}
-
-	stop := make(chan struct{})
-	go WorkerLoop(persistor)(stop)
-	defer func() { stop <- struct{}{} }()
-
-	mgr := Manager()
-
 	// Grab a lease.
-	_, err := mgr.ClaimLease(testNamespace, testId, testDuration)
+	_, err := s.manager.ClaimLease(testNamespace, testId, testDuration)
 	c.Assert(err, jc.ErrorIsNil)
 
 	numRemoveCalls := 0
-	persistor.RemoveTokenFn = func(id string) error {
+	s.persistor.RemoveTokenFn = func(id string) error {
 		numRemoveCalls++
 		c.Check(id, gc.Equals, testNamespace)
 		return nil
 	}
 
 	// Release the lease, and the persistor should be called.
-	mgr.ReleaseLease(testNamespace, testId)
+	s.manager.ReleaseLease(testNamespace, testId)
 
 	c.Check(numRemoveCalls, gc.Equals, 1)
 }
 
 func (s *leaseSuite) TestManagerDepersistsAllTokensOnStart(c *gc.C) {
-
-	persistor := &stubLeasePersistor{}
+	s.manager.Kill()
+	c.Assert(s.manager.Wait(), jc.ErrorIsNil)
 
 	numCalls := 0
 	testToks := []Token{
 		{testNamespace, testId, time.Now().Add(testDuration)},
 		{testNamespace + "2", "a" + testId, time.Now().Add(testDuration)},
 	}
-	persistor.PersistedTokensFn = func() ([]Token, error) {
-
+	s.persistor.PersistedTokensFn = func() ([]Token, error) {
 		numCalls++
 		return testToks, nil
 	}
 
-	stop := make(chan struct{})
-	go WorkerLoop(persistor)(stop)
-	defer func() { stop <- struct{}{} }()
-
-	mgr := Manager()
+	manager, err := NewLeaseManager(s.persistor)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		err := manager.Wait()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+	defer manager.Kill()
 
 	// NOTE: This call will naturally block until the worker loop is
 	// sucessfully pumping. Place all checks below here.
-	heldToks := mgr.CopyOfLeaseTokens()
+	heldToks, err := manager.CopyOfLeaseTokens()
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(numCalls, gc.Equals, 1)
 

--- a/lease/singleton.go
+++ b/lease/singleton.go
@@ -1,0 +1,81 @@
+package lease
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrNoLeaseManager is the error returned by
+// singletonLeaseManager methods if no lease
+// manager is running.
+var ErrNoLeaseManager = errors.New("no active lease manager")
+
+// ErrLeaseManagerRunning is the error returned
+// by NewLeaseManager if there is already one
+// running.
+var ErrLeaseManagerRunning = errors.New("lease manager already running")
+
+var singleton singletonLeaseManager
+
+type singletonLeaseManager struct {
+	mu sync.Mutex
+	m  *leaseManager
+}
+
+// Manager returns a singleton lease manager, which is active so long
+// as there is a running leaseManager worker.
+func Manager() *singletonLeaseManager {
+	return &singleton
+}
+
+func (s *singletonLeaseManager) setLeaseManager(m *leaseManager) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if m != nil && s.m != nil {
+		return ErrLeaseManagerRunning
+	}
+	s.m = m
+	return nil
+}
+
+func (s *singletonLeaseManager) getLeaseManager() (*leaseManager, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		return nil, ErrNoLeaseManager
+	}
+	return s.m, nil
+}
+
+func (s *singletonLeaseManager) ClaimLease(namespace, id string, forDur time.Duration) (leaseOwnerId string, err error) {
+	m, err := s.getLeaseManager()
+	if err != nil {
+		return "", err
+	}
+	return m.ClaimLease(namespace, id, forDur)
+}
+
+func (s *singletonLeaseManager) ReleaseLease(namespace, id string) (err error) {
+	m, err := s.getLeaseManager()
+	if err != nil {
+		return err
+	}
+	return m.ReleaseLease(namespace, id)
+}
+
+func (s *singletonLeaseManager) RetrieveLease(namespace string) (Token, error) {
+	m, err := s.getLeaseManager()
+	if err != nil {
+		return Token{}, err
+	}
+	return m.RetrieveLease(namespace)
+}
+
+func (s *singletonLeaseManager) LeaseReleasedNotifier(namespace string) (notifier <-chan struct{}, err error) {
+	m, err := s.getLeaseManager()
+	if err != nil {
+		return nil, err
+	}
+	return m.LeaseReleasedNotifier(namespace)
+}

--- a/lease/singleton_test.go
+++ b/lease/singleton_test.go
@@ -1,0 +1,64 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&singletonLeaseSuite{})
+
+type singletonLeaseSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *singletonLeaseSuite) TestSingletonNewLeaseManager(c *gc.C) {
+	assertSingletonInactive(c)
+
+	var called bool
+	manager, err := NewLeaseManager(&stubLeasePersistor{
+		WriteTokenFn: func(string, Token) error {
+			called = true
+			return nil
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = Manager().ClaimLease("foo", "bar", 0)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(called, jc.IsTrue)
+
+	manager.Kill()
+	c.Assert(manager.Wait(), jc.ErrorIsNil)
+	assertSingletonInactive(c)
+}
+
+func (s *singletonLeaseSuite) TestSingletonSingular(c *gc.C) {
+	var called bool
+	manager, err := NewLeaseManager(&stubLeasePersistor{
+		WriteTokenFn: func(string, Token) error {
+			called = true
+			return nil
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		manager.Kill()
+		c.Assert(manager.Wait(), jc.ErrorIsNil)
+	}()
+	_, err = NewLeaseManager(&stubLeasePersistor{})
+	c.Check(err, gc.Equals, ErrLeaseManagerRunning)
+
+	// Ensure the first lease manager is still in tact.
+	_, err = Manager().ClaimLease("foo", "bar", 0)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(called, jc.IsTrue)
+}
+
+func assertSingletonInactive(c *gc.C) {
+	_, err := Manager().ClaimLease("foo", "bar", 0)
+	c.Assert(err, gc.Equals, ErrNoLeaseManager)
+}

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -115,10 +115,11 @@ func (ctx *context) HookFailed(hookName string) {
 
 func (ctx *context) run(c *gc.C, steps []stepper) {
 	// We need this lest leadership calls block forever.
-	workerLoop := lease.WorkerLoop(ctx.st)
-	leaseWorker := worker.NewSimpleWorker(workerLoop)
+	lease, err := lease.NewLeaseManager(ctx.st)
+	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
-		c.Assert(worker.Stop(leaseWorker), jc.ErrorIsNil)
+		lease.Kill()
+		c.Assert(lease.Wait(), jc.ErrorIsNil)
 	}()
 
 	defer func() {


### PR DESCRIPTION
The lease manager is updated to use a tomb, as in
other workers. In order to do this, the core lease
manager code is no longer singleton-based; but the
worker sets/unsets a singleton in the lease package
when it starts/stops. Thus, attempting to run two
lease manager workers concurrently will result in
an error. If no lease manager worker is active, then
the singleton's methods will error immediately;
otherwise they defer to the active worker.

When a lease manager dies, it will now notify all
outstanding subscribers by closing their channels.
All lease manager and leadership methods now return
errors.

Fixes https://bugs.launchpad.net/juju-core/+bug/1457728

(Review request: http://reviews.vapour.ws/r/1806/)