### PR TITLE
Remove bashisms from the init discovery script.

### DIFF
--- a/service/discovery.go
+++ b/service/discovery.go
@@ -124,10 +124,10 @@ func discoverLocalInitSystem() (string, error) {
 
 const discoverInitSystemScript = `
 # Use guaranteed discovery mechanisms for known init systems.
-if [[ -d /run/systemd/system ]]; then
+if [ -d /run/systemd/system ]; then
     echo -n systemd
     exit 0
-elif [[ -f /sbin/initctl ]] && /sbin/initctl --system list 2>&1 > /dev/null; then
+elif [ -f /sbin/initctl ] && /sbin/initctl --system list 2>&1 > /dev/null; then
     echo -n upstart
     exit 0
 fi


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1459775)
(Also see https://github.com/juju/juju/pull/2378.)

The "[[" syntax is bash-specific and does not work under /bin/sh (dash or the bourne shell).  This patch switches the script to the "[" syntax.

(Review request: http://reviews.vapour.ws/r/1808/)