### PR TITLE
juju system use-environment

### DIFF
--- a/api/environmentmanager/environmentmanager.go
+++ b/api/environmentmanager/environmentmanager.go
@@ -76,7 +76,6 @@ type UserEnvironment struct {
 	Name           string
 	UUID           string
 	Owner          string
-	ServerUUID     string
 	LastConnection *time.Time
 }
 
@@ -98,13 +97,12 @@ func (c *Client) ListEnvironments(user string) ([]UserEnvironment, error) {
 	for i, env := range environments.UserEnvironments {
 		owner, err := names.ParseUserTag(env.OwnerTag)
 		if err != nil {
-			return nil, errors.Errorf("OwnerTag %q at position %d is not a valid user tag", env.OwnerTag, i)
+			return nil, errors.Annotatef(err, "OwnerTag %q at position %d", env.OwnerTag, i)
 		}
 		result[i] = UserEnvironment{
 			Name:           env.Name,
 			UUID:           env.UUID,
 			Owner:          owner.Username(),
-			ServerUUID:     env.ServerUUID,
 			LastConnection: env.LastConnection,
 		}
 	}

--- a/api/environmentmanager/environmentmanager.go
+++ b/api/environmentmanager/environmentmanager.go
@@ -5,6 +5,7 @@ package environmentmanager
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -68,19 +69,44 @@ func (c *Client) CreateEnvironment(owner string, account, config map[string]inte
 	return result, nil
 }
 
+// UserEnvironment holds information about an environment and the last
+// time the environment was accessed for a particular user. This is a client
+// side structure that translates the owner tag into a user facing string.
+type UserEnvironment struct {
+	Name           string
+	UUID           string
+	Owner          string
+	ServerUUID     string
+	LastConnection *time.Time
+}
+
 // ListEnvironments returns the environments that the specified user
 // has access to in the current server.  Only that state server owner
 // can list environments for any user (at this stage).  Other users
 // can only ask about their own environments.
-func (c *Client) ListEnvironments(user string) ([]params.UserEnvironment, error) {
-	var result params.UserEnvironmentList
+func (c *Client) ListEnvironments(user string) ([]UserEnvironment, error) {
+	var environments params.UserEnvironmentList
 	if !names.IsValidUser(user) {
 		return nil, fmt.Errorf("invalid user name %q", user)
 	}
 	entity := params.Entity{names.NewUserTag(user).String()}
-	err := c.facade.FacadeCall("ListEnvironments", entity, &result)
+	err := c.facade.FacadeCall("ListEnvironments", entity, &environments)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return result.UserEnvironments, nil
+	result := make([]UserEnvironment, len(environments.UserEnvironments))
+	for i, env := range environments.UserEnvironments {
+		owner, err := names.ParseUserTag(env.OwnerTag)
+		if err != nil {
+			return nil, errors.Errorf("OwnerTag %q at position %d is not a valid user tag", env.OwnerTag, i)
+		}
+		result[i] = UserEnvironment{
+			Name:           env.Name,
+			UUID:           env.UUID,
+			Owner:          owner.Username(),
+			ServerUUID:     env.ServerUUID,
+			LastConnection: env.LastConnection,
+		}
+	}
+	return result, nil
 }

--- a/api/environmentmanager/environmentmanager_test.go
+++ b/api/environmentmanager/environmentmanager_test.go
@@ -113,5 +113,7 @@ func (s *environmentmanagerSuite) TestListEnvironments(c *gc.C) {
 	c.Assert(envs, gc.HasLen, 2)
 
 	envNames := []string{envs[0].Name, envs[1].Name}
-	c.Assert(envNames, jc.SameContents, []string{"first", "second"})
+	c.Assert(envNames, jc.DeepEquals, []string{"first", "second"})
+	ownerNames := []string{envs[0].Owner, envs[1].Owner}
+	c.Assert(ownerNames, jc.DeepEquals, []string{"user@remote", "user@remote"})
 }

--- a/cmd/juju/system/environments.go
+++ b/cmd/juju/system/environments.go
@@ -99,7 +99,7 @@ func (c *EnvironmentsCommand) Run(ctx *cmd.Context) error {
 
 // formatTabular takes an interface{} to adhere to the cmd.Formatter interface
 func (c *EnvironmentsCommand) formatTabular(value interface{}) ([]byte, error) {
-	envs, ok := value.([]params.UserEnvironment)
+	envs, ok := value.([]environmentmanager.UserEnvironment)
 	if !ok {
 		return nil, errors.Errorf("expected value of type %T, got %T", envs, value)
 	}

--- a/cmd/juju/system/environments.go
+++ b/cmd/juju/system/environments.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/api/environmentmanager"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/environs/configstore"
@@ -36,7 +36,7 @@ var envsDoc = `List all the environments the user can access on the current syst
 // environments command calls.
 type EnvironmentManagerAPI interface {
 	Close() error
-	ListEnvironments(user string) ([]params.UserEnvironment, error)
+	ListEnvironments(user string) ([]environmentmanager.UserEnvironment, error)
 }
 
 // Info implements Command.Info
@@ -127,7 +127,7 @@ func (c *EnvironmentsCommand) formatTabular(value interface{}) ([]byte, error) {
 		if env.LastConnection != nil {
 			lastConn = user.UserFriendlyDuration(*env.LastConnection, time.Now())
 		}
-		fmt.Fprintf(tw, "\t%s\t%s\n", env.OwnerTag, lastConn)
+		fmt.Fprintf(tw, "\t%s\t%s\n", env.Owner, lastConn)
 	}
 	tw.Flush()
 	return out.Bytes(), nil

--- a/cmd/juju/system/environments_test.go
+++ b/cmd/juju/system/environments_test.go
@@ -10,8 +10,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api/environmentmanager"
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/system"
 	"github.com/juju/juju/environs/configstore"
@@ -54,27 +54,21 @@ func (s *EnvironmentsSuite) SetUpTest(c *gc.C) {
 	last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
 	last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
 
-	envs := []params.UserEnvironment{
+	envs := []environmentmanager.UserEnvironment{
 		{
-			Environment: params.Environment{
-				Name:     "test-env1",
-				OwnerTag: "user-admin@local",
-				UUID:     "test-env1-UUID",
-			},
+			Name:           "test-env1",
+			Owner:          "user-admin@local",
+			UUID:           "test-env1-UUID",
 			LastConnection: &last1,
 		}, {
-			Environment: params.Environment{
-				Name:     "test-env2",
-				OwnerTag: "user-admin@local",
-				UUID:     "test-env2-UUID",
-			},
+			Name:           "test-env2",
+			Owner:          "user-admin@local",
+			UUID:           "test-env2-UUID",
 			LastConnection: &last2,
 		}, {
-			Environment: params.Environment{
-				Name:     "test-env3",
-				OwnerTag: "user-admin@local",
-				UUID:     "test-env3-UUID",
-			},
+			Name:  "test-env3",
+			Owner: "user-admin@local",
+			UUID:  "test-env3-UUID",
 		},
 	}
 	s.api = &fakeEnvMgrAPIClient{envs: envs}

--- a/cmd/juju/system/environments_test.go
+++ b/cmd/juju/system/environments_test.go
@@ -29,14 +29,14 @@ var _ = gc.Suite(&EnvironmentsSuite{})
 type fakeEnvMgrAPIClient struct {
 	err  error
 	user string
-	envs []params.UserEnvironment
+	envs []environmentmanager.UserEnvironment
 }
 
 func (f *fakeEnvMgrAPIClient) Close() error {
 	return nil
 }
 
-func (f *fakeEnvMgrAPIClient) ListEnvironments(user string) ([]params.UserEnvironment, error) {
+func (f *fakeEnvMgrAPIClient) ListEnvironments(user string) ([]environmentmanager.UserEnvironment, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -31,3 +31,12 @@ func NewLoginCommand(apiOpen APIOpenFunc, getUserManager GetUserManagerFunc) *Lo
 		getUserManager: getUserManager,
 	}
 }
+
+// NewUseEnvironmentCommand returns a UseEnvironmentCommand with the API and
+// userCreds provided as specified.
+func NewUseEnvironmentCommand(api EnvironmentManagerAPI, userCreds *configstore.APICredentials) *UseEnvironmentCommand {
+	return &UseEnvironmentCommand{
+		api:       api,
+		userCreds: userCreds,
+	}
+}

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -34,9 +34,10 @@ func NewLoginCommand(apiOpen APIOpenFunc, getUserManager GetUserManagerFunc) *Lo
 
 // NewUseEnvironmentCommand returns a UseEnvironmentCommand with the API and
 // userCreds provided as specified.
-func NewUseEnvironmentCommand(api EnvironmentManagerAPI, userCreds *configstore.APICredentials) *UseEnvironmentCommand {
+func NewUseEnvironmentCommand(api EnvironmentManagerAPI, userCreds *configstore.APICredentials, endpoint *configstore.APIEndpoint) *UseEnvironmentCommand {
 	return &UseEnvironmentCommand{
 		api:       api,
 		userCreds: userCreds,
+		endpoint:  endpoint,
 	}
 }

--- a/cmd/juju/system/system.go
+++ b/cmd/juju/system/system.go
@@ -29,6 +29,7 @@ func NewSuperCommand() cmd.Command {
 	systemCmd.Register(&ListCommand{})
 	systemCmd.Register(&LoginCommand{})
 	systemCmd.Register(envcmd.WrapSystem(&EnvironmentsCommand{}))
+	systemCmd.Register(envcmd.WrapSystem(&UseEnvironmentCommand{}))
 
 	return systemCmd
 }

--- a/cmd/juju/system/system_test.go
+++ b/cmd/juju/system/system_test.go
@@ -22,6 +22,8 @@ var expectedCommmandNames = []string{
 	"help",
 	"list",
 	"login",
+	"use-env", // aliase for use-environment
+	"use-environment",
 }
 
 func (s *SystemCommandSuite) TestHelp(c *gc.C) {

--- a/cmd/juju/system/system_test.go
+++ b/cmd/juju/system/system_test.go
@@ -22,7 +22,7 @@ var expectedCommmandNames = []string{
 	"help",
 	"list",
 	"login",
-	"use-env", // aliase for use-environment
+	"use-env", // alias for use-environment
 	"use-environment",
 }
 

--- a/cmd/juju/system/useenvironment.go
+++ b/cmd/juju/system/useenvironment.go
@@ -1,0 +1,268 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"launchpad.net/gnuflag"
+
+	envmgr "github.com/juju/juju/api/environmentmanager"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/environs/configstore"
+)
+
+// UseEnvironmentCommand returns the list of all the environments the
+// current user can access on the current system.
+type UseEnvironmentCommand struct {
+	envcmd.SysCommandBase
+
+	apiOpen   APIOpenFunc
+	api       EnvironmentManagerAPI
+	userCreds *configstore.APICredentials
+	endpoint  *configstore.APIEndpoint
+
+	LocalName string
+	Owner     string
+	EnvName   string
+	EnvUUID   string
+}
+
+var useEnvDoc = `
+use-environment caches the necessary information about the specified environment
+on the current machine. This allows you to switch between environments.
+
+By default, the local names for the environment are based on the name that the
+owner of the environment gave it when they created it.  If you are the owner of
+the environment, then the local name is just the name of the environment. If you
+are not the owner, the name is prefixed by the name of the owner and a dash.
+
+See Also:
+    juju environment create
+    juju environment share
+    juju environment unshare
+    juju switch
+    juju user add
+`
+
+// Info implements Command.Info
+func (c *UseEnvironmentCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "use-environment",
+		Purpose: "use an environmeht that you have access to on this machine",
+		Doc:     useEnvDoc,
+		Aliases: []string{"use-env"},
+	}
+}
+
+func (c *UseEnvironmentCommand) getAPI() (EnvironmentManagerAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	return c.NewEnvironmentManagerAPIClient()
+}
+
+func (c *UseEnvironmentCommand) getConnectionCredentials() (configstore.APICredentials, error) {
+	if c.userCreds != nil {
+		return *c.userCreds, nil
+	}
+	return c.ConnectionCredentials()
+}
+
+func (c *UseEnvironmentCommand) getConnectionEndpoint() (configstore.APIEndpoint, error) {
+	if c.endpoint != nil {
+		return *c.endpoint, nil
+	}
+	return c.ConnectionEndpoint()
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *UseEnvironmentCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.LocalName, "name", "", "the local name for this environment")
+}
+
+// SetFlags implements Command.Init.
+func (c *UseEnvironmentCommand) Init(args []string) error {
+	if c.apiOpen == nil {
+		c.apiOpen = apiOpen
+	}
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return errors.New("no environment supplied")
+	}
+
+	name, args := args[0], args[1:]
+
+	// First check to see if an owner has been specified.
+	bits := strings.SplitN(name, "/", 2)
+	switch len(bits) {
+	case 1:
+		// No user specified
+		c.EnvName = bits[0]
+	case 2:
+		owner := bits[0]
+		if names.IsValidUser(owner) {
+			c.Owner = owner
+		} else {
+			return errors.Errorf("%q is not a valid user", owner)
+		}
+		c.EnvName = bits[1]
+	}
+
+	// Environment names can generally be anything, but we take a good
+	// stab at trying to determine if the user has speicifed a UUID
+	// instead of a name. For now, we only accept a properly formatted UUID,
+	// which means one with dashes in the right place.
+	if names.IsValidEnvironment(c.EnvName) {
+		c.EnvUUID, c.EnvName = c.EnvName, ""
+	}
+
+	return cmd.CheckEmpty(args)
+}
+
+// Run implements Command.Run
+func (c *UseEnvironmentCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer client.Close()
+
+	creds, err := c.getConnectionCredentials()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	endpoint, err := c.getConnectionEndpoint()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	username := names.NewUserTag(creds.User).Username()
+
+	env, err := c.findMatchingEnvironment(ctx, client, creds)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if c.LocalName == "" {
+		if env.Owner == username {
+			c.LocalName = env.Name
+		} else {
+			envOwner := names.NewUserTag(env.Owner)
+			c.LocalName = envOwner.Name() + "-" + env.Name
+		}
+	}
+
+	// Check with the store to see if we have an environment with that name.
+	store, err := configstore.Default()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	existing, err := store.ReadInfo(c.LocalName)
+	if err == nil {
+		// We have an existing environment with the same name. If it is the
+		// same environment with the same user, then this is fine, and we just
+		// change the current envrionment.
+		endpoint := existing.APIEndpoint()
+		existingCreds := existing.APICredentials()
+		// Need to make sure we check the username of the credentials,
+		// not just matching tags.
+		existingUsername := names.NewUserTag(existingCreds.User).Username()
+		if endpoint.EnvironUUID == env.UUID && existingUsername == username {
+			ctx.Infof("You already have environment details for %q cached locally.", c.LocalName)
+			return c.setCurrentEnvironment(ctx)
+		}
+		ctx.Infof("You have an existing environment called %q, use --name to specify a different local name.", c.LocalName)
+		return errors.New("existing environment")
+	}
+
+	info := store.CreateInfo(c.LocalName)
+	if err := c.updateCachedInfo(info, env.UUID, creds, endpoint); err != nil {
+		return errors.Annotatef(err, "failed to cache environment details")
+	}
+
+	return c.setCurrentEnvironment(ctx)
+}
+
+func (c *UseEnvironmentCommand) setCurrentEnvironment(ctx *cmd.Context) error {
+	if err := envcmd.WriteCurrentEnvironment(c.LocalName); err != nil {
+		return errors.Annotatef(err, "could not set %q to be the current environment", c.LocalName)
+	}
+	ctx.Infof("Current environment now %q.", c.LocalName)
+	return nil
+}
+
+func (c *UseEnvironmentCommand) updateCachedInfo(info configstore.EnvironInfo, envUUID string, creds configstore.APICredentials, endpoint configstore.APIEndpoint) error {
+	info.SetAPICredentials(creds)
+	// Specify the environment UUID. The server UUID will be the same as the
+	// endpoint that we have just connected to, as will be the CACert, addresses
+	// and hostnames.
+	endpoint.EnvironUUID = envUUID
+	info.SetAPIEndpoint(endpoint)
+	return errors.Trace(info.Write())
+}
+
+func (c *UseEnvironmentCommand) findMatchingEnvironment(ctx *cmd.Context, client EnvironmentManagerAPI, creds configstore.APICredentials) (envmgr.UserEnvironment, error) {
+
+	var empty envmgr.UserEnvironment
+
+	envs, err := client.ListEnvironments(creds.User)
+	if err != nil {
+		return empty, errors.Annotate(err, "cannot list environments")
+	}
+
+	var owner string
+	if c.Owner != "" {
+		// The username always contains the provider aspect of the user.
+		owner = names.NewUserTag(c.Owner).Username()
+	}
+
+	// If we have a UUID, we warn if the owner is different, but accept it.
+	// We also trust that the environment UUIDs are unique
+	if c.EnvUUID != "" {
+		for _, env := range envs {
+			if env.UUID == c.EnvUUID {
+				if owner != "" && env.Owner != owner {
+					ctx.Infof("Specified environment owned by %s, not %s", env.Owner, owner)
+				}
+				return env, nil
+			}
+		}
+		return empty, errors.NotFoundf("matching environment")
+	}
+
+	var matches []envmgr.UserEnvironment
+	for _, env := range envs {
+		match := env.Name == c.EnvName
+		if match && owner != "" {
+			match = env.Owner == owner
+		}
+		if match {
+			matches = append(matches, env)
+		}
+	}
+
+	// If there is only one match, that's the one.
+	switch len(matches) {
+	case 0:
+		return empty, errors.NotFoundf("matching environment")
+	case 1:
+		return matches[0], nil
+	}
+
+	// We are going to return an error, but tell the user what the matches
+	// were so they can make an informed decision. We are also going to assume
+	// here that the resulting environment list has only one matching name for
+	// each user. There are tests creating environments that enforce this.
+	ctx.Infof("Multiple environments matched name %q:", c.EnvName)
+	for _, env := range matches {
+		ctx.Infof("  %s, owned by %s", env.UUID, env.Owner)
+	}
+	ctx.Infof("Please specify either the environment UUID or the owner to disambiguate.")
+
+	return empty, errors.New("multiple environments matched")
+}

--- a/cmd/juju/system/useenvironment_test.go
+++ b/cmd/juju/system/useenvironment_test.go
@@ -1,0 +1,287 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system_test
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/environmentmanager"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/system"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/testing"
+)
+
+const (
+	serverUUID = "0dbfe161-de6c-47ad-9283-5e3ea64e1dd3"
+	env1UUID   = "ebf03329-cdad-44a5-9f10-fe318efda3ce"
+	env2UUID   = "b366cdd5-82da-49a1-ac18-001f26bb59a3"
+	env3UUID   = "fd0f57a3-eb94-4095-9ab0-d1f6042f942a"
+	env4UUID   = "1e45141b-85cb-4a0a-96ef-0aa6bbeac45a"
+)
+
+type UseEnvironmentSuite struct {
+	testing.FakeJujuHomeSuite
+	api      *fakeEnvMgrAPIClient
+	creds    configstore.APICredentials
+	endpoint configstore.APIEndpoint
+}
+
+var _ = gc.Suite(&UseEnvironmentSuite{})
+
+func (s *UseEnvironmentSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+
+	err := envcmd.WriteCurrentSystem("fake")
+	c.Assert(err, jc.ErrorIsNil)
+
+	envs := []environmentmanager.UserEnvironment{
+		{
+			Name:  "unique",
+			Owner: "tester@local",
+			UUID:  "some-uuid",
+		}, {
+			Name:  "test",
+			Owner: "tester@local",
+			UUID:  env1UUID,
+		}, {
+			Name:  "test",
+			Owner: "bob@local",
+			UUID:  env2UUID,
+		}, {
+			Name:  "other",
+			Owner: "bob@local",
+			UUID:  env3UUID,
+		}, {
+			Name:  "other",
+			Owner: "bob@remote",
+			UUID:  env4UUID,
+		},
+	}
+	s.api = &fakeEnvMgrAPIClient{envs: envs}
+	s.creds = configstore.APICredentials{User: "tester", Password: "password"}
+	s.endpoint = configstore.APIEndpoint{
+		Addresses:  []string{"127.0.0.1:12345"},
+		Hostnames:  []string{"localhost:12345"},
+		CACert:     testing.CACert,
+		ServerUUID: serverUUID,
+	}
+}
+
+func (s *UseEnvironmentSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	command := system.NewUseEnvironmentCommand(s.api, &s.creds, &s.endpoint)
+	return testing.RunCommand(c, envcmd.WrapSystem(command), args...)
+}
+
+func (s *UseEnvironmentSuite) TestInit(c *gc.C) {
+	for i, test := range []struct {
+		args        []string
+		errorString string
+		localName   string
+		owner       string
+		envName     string
+		envUUID     string
+	}{
+		{
+			errorString: "no environment supplied",
+		}, {
+			args:        []string{""},
+			errorString: "no environment supplied",
+		}, {
+			args:    []string{"env-name"},
+			envName: "env-name",
+		}, {
+			args:      []string{"env-name", "--name", "foo"},
+			localName: "foo",
+			envName:   "env-name",
+		}, {
+			args:    []string{"user/foobar"},
+			envName: "foobar",
+			owner:   "user",
+		}, {
+			args:    []string{"user@local/foobar"},
+			envName: "foobar",
+			owner:   "user@local",
+		}, {
+			args:    []string{"user@remote/foobar"},
+			envName: "foobar",
+			owner:   "user@remote",
+		}, {
+			args:        []string{"user+name/foobar"},
+			errorString: `"user\+name" is not a valid user`,
+		}, {
+			args:    []string{env1UUID},
+			envUUID: env1UUID,
+		}, {
+			args:    []string{"user/" + env1UUID},
+			owner:   "user",
+			envUUID: env1UUID,
+		},
+	} {
+		c.Logf("test %d", i)
+		command := &system.UseEnvironmentCommand{}
+		err := testing.InitCommand(command, test.args)
+		if test.errorString == "" {
+			c.Check(command.LocalName, gc.Equals, test.localName)
+			c.Check(command.EnvName, gc.Equals, test.envName)
+			c.Check(command.EnvUUID, gc.Equals, test.envUUID)
+			c.Check(command.Owner, gc.Equals, test.owner)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.errorString)
+		}
+	}
+}
+
+func (s *UseEnvironmentSuite) TestEnvironmentsError(c *gc.C) {
+	s.api.err = common.ErrPerm
+	_, err := s.run(c, "ignored-but-needed")
+	c.Assert(err, gc.ErrorMatches, "cannot list environments: permission denied")
+}
+
+func (s *UseEnvironmentSuite) TestNameNotFound(c *gc.C) {
+	_, err := s.run(c, "missing")
+	c.Assert(err, gc.ErrorMatches, "matching environment not found")
+}
+
+func (s *UseEnvironmentSuite) TestUUID(c *gc.C) {
+	_, err := s.run(c, env3UUID)
+	c.Assert(err, gc.IsNil)
+
+	s.assertCurrentEnvironment(c, "bob-other", env3UUID)
+}
+
+func (s *UseEnvironmentSuite) TestUUIDCorrectOwner(c *gc.C) {
+	_, err := s.run(c, "bob/"+env3UUID)
+	c.Assert(err, gc.IsNil)
+
+	s.assertCurrentEnvironment(c, "bob-other", env3UUID)
+}
+
+func (s *UseEnvironmentSuite) TestUUIDWrongOwner(c *gc.C) {
+	ctx, err := s.run(c, "charles/"+env3UUID)
+	c.Assert(err, gc.IsNil)
+	expected := "Specified environment owned by bob@local, not charles@local"
+	c.Assert(testing.Stderr(ctx), jc.Contains, expected)
+
+	s.assertCurrentEnvironment(c, "bob-other", env3UUID)
+}
+
+func (s *UseEnvironmentSuite) TestUniqueName(c *gc.C) {
+	_, err := s.run(c, "unique")
+	c.Assert(err, gc.IsNil)
+
+	s.assertCurrentEnvironment(c, "unique", "some-uuid")
+}
+
+func (s *UseEnvironmentSuite) TestMultipleNameMatches(c *gc.C) {
+	ctx, err := s.run(c, "test")
+	c.Assert(err, gc.ErrorMatches, "multiple environments matched")
+
+	message := strings.TrimSpace(testing.Stderr(ctx))
+	lines := strings.Split(message, "\n")
+	c.Assert(lines, gc.HasLen, 4)
+	c.Assert(lines[0], gc.Equals, `Multiple environments matched name "test":`)
+	c.Assert(lines[1], gc.Equals, "  "+env1UUID+", owned by tester@local")
+	c.Assert(lines[2], gc.Equals, "  "+env2UUID+", owned by bob@local")
+	c.Assert(lines[3], gc.Equals, `Please specify either the environment UUID or the owner to disambiguate.`)
+}
+
+func (s *UseEnvironmentSuite) TestUserOwnerOfEnvironment(c *gc.C) {
+	_, err := s.run(c, "tester/test")
+	c.Assert(err, gc.IsNil)
+
+	s.assertCurrentEnvironment(c, "test", env1UUID)
+}
+
+func (s *UseEnvironmentSuite) TestOtherUsersEnvironment(c *gc.C) {
+	_, err := s.run(c, "bob/test")
+	c.Assert(err, gc.IsNil)
+
+	s.assertCurrentEnvironment(c, "bob-test", env2UUID)
+}
+
+func (s *UseEnvironmentSuite) TestRemoteUsersEnvironmentName(c *gc.C) {
+	_, err := s.run(c, "bob@remote/other")
+	c.Assert(err, gc.IsNil)
+
+	s.assertCurrentEnvironment(c, "bob-other", env4UUID)
+}
+
+func (s *UseEnvironmentSuite) TestDisambiguateWrongOwner(c *gc.C) {
+	_, err := s.run(c, "wrong/test")
+	c.Assert(err, gc.ErrorMatches, "matching environment not found")
+}
+
+func (s *UseEnvironmentSuite) TestUseEnvAlreadyExisting(c *gc.C) {
+	s.makeLocalEnvironment(c, "unique", "", "")
+	ctx, err := s.run(c, "unique")
+	c.Assert(err, gc.ErrorMatches, "existing environment")
+	expected := `You have an existing environment called "unique", use --name to specify a different local name.`
+	c.Assert(testing.Stderr(ctx), jc.Contains, expected)
+}
+
+func (s *UseEnvironmentSuite) TestUseEnvAlreadyExistingSameEnv(c *gc.C) {
+	s.makeLocalEnvironment(c, "unique", "some-uuid", "tester")
+	ctx, err := s.run(c, "unique")
+	c.Assert(err, gc.IsNil)
+
+	message := strings.TrimSpace(testing.Stderr(ctx))
+	lines := strings.Split(message, "\n")
+	c.Assert(lines, gc.HasLen, 2)
+
+	expected := `You already have environment details for "unique" cached locally.`
+	c.Assert(lines[0], gc.Equals, expected)
+	c.Assert(lines[1], gc.Equals, `Current environment now "unique".`)
+
+	current, err := envcmd.ReadCurrentEnvironment()
+	c.Assert(err, gc.IsNil)
+	c.Assert(current, gc.Equals, "unique")
+}
+
+func (s *UseEnvironmentSuite) assertCurrentEnvironment(c *gc.C, name, uuid string) {
+	current, err := envcmd.ReadCurrentEnvironment()
+	c.Assert(err, gc.IsNil)
+	c.Assert(current, gc.Equals, name)
+
+	store, err := configstore.Default()
+	c.Assert(err, gc.IsNil)
+
+	info, err := store.ReadInfo(name)
+	c.Assert(err, gc.IsNil)
+	c.Assert(info.APIEndpoint(), jc.DeepEquals, configstore.APIEndpoint{
+		Addresses:   []string{"127.0.0.1:12345"},
+		Hostnames:   []string{"localhost:12345"},
+		CACert:      testing.CACert,
+		EnvironUUID: uuid,
+		ServerUUID:  serverUUID,
+	})
+	c.Assert(info.APICredentials(), jc.DeepEquals, s.creds)
+}
+
+func (s *UseEnvironmentSuite) makeLocalEnvironment(c *gc.C, name, uuid, owner string) {
+	store, err := configstore.Default()
+	c.Assert(err, gc.IsNil)
+
+	if uuid == "" {
+		uuid = utils.MustNewUUID().String()
+	}
+	if owner == "" {
+		owner = "random@person"
+	}
+	info := store.CreateInfo(name)
+	info.SetAPIEndpoint(configstore.APIEndpoint{
+		EnvironUUID: uuid,
+	})
+	info.SetAPICredentials(configstore.APICredentials{
+		User: owner,
+	})
+	err = info.Write()
+	c.Assert(err, gc.IsNil)
+}

--- a/cmd/juju/system/useenvironment_test.go
+++ b/cmd/juju/system/useenvironment_test.go
@@ -42,29 +42,27 @@ func (s *UseEnvironmentSuite) SetUpTest(c *gc.C) {
 	err := envcmd.WriteCurrentSystem("fake")
 	c.Assert(err, jc.ErrorIsNil)
 
-	envs := []environmentmanager.UserEnvironment{
-		{
-			Name:  "unique",
-			Owner: "tester@local",
-			UUID:  "some-uuid",
-		}, {
-			Name:  "test",
-			Owner: "tester@local",
-			UUID:  env1UUID,
-		}, {
-			Name:  "test",
-			Owner: "bob@local",
-			UUID:  env2UUID,
-		}, {
-			Name:  "other",
-			Owner: "bob@local",
-			UUID:  env3UUID,
-		}, {
-			Name:  "other",
-			Owner: "bob@remote",
-			UUID:  env4UUID,
-		},
-	}
+	envs := []environmentmanager.UserEnvironment{{
+		Name:  "unique",
+		Owner: "tester@local",
+		UUID:  "some-uuid",
+	}, {
+		Name:  "test",
+		Owner: "tester@local",
+		UUID:  env1UUID,
+	}, {
+		Name:  "test",
+		Owner: "bob@local",
+		UUID:  env2UUID,
+	}, {
+		Name:  "other",
+		Owner: "bob@local",
+		UUID:  env3UUID,
+	}, {
+		Name:  "other",
+		Owner: "bob@remote",
+		UUID:  env4UUID,
+	}}
 	s.api = &fakeEnvMgrAPIClient{envs: envs}
 	s.creds = configstore.APICredentials{User: "tester", Password: "password"}
 	s.endpoint = configstore.APIEndpoint{
@@ -88,43 +86,41 @@ func (s *UseEnvironmentSuite) TestInit(c *gc.C) {
 		owner       string
 		envName     string
 		envUUID     string
-	}{
-		{
-			errorString: "no environment supplied",
-		}, {
-			args:        []string{""},
-			errorString: "no environment supplied",
-		}, {
-			args:    []string{"env-name"},
-			envName: "env-name",
-		}, {
-			args:      []string{"env-name", "--name", "foo"},
-			localName: "foo",
-			envName:   "env-name",
-		}, {
-			args:    []string{"user/foobar"},
-			envName: "foobar",
-			owner:   "user",
-		}, {
-			args:    []string{"user@local/foobar"},
-			envName: "foobar",
-			owner:   "user@local",
-		}, {
-			args:    []string{"user@remote/foobar"},
-			envName: "foobar",
-			owner:   "user@remote",
-		}, {
-			args:        []string{"user+name/foobar"},
-			errorString: `"user\+name" is not a valid user`,
-		}, {
-			args:    []string{env1UUID},
-			envUUID: env1UUID,
-		}, {
-			args:    []string{"user/" + env1UUID},
-			owner:   "user",
-			envUUID: env1UUID,
-		},
-	} {
+	}{{
+		errorString: "no environment supplied",
+	}, {
+		args:        []string{""},
+		errorString: "no environment supplied",
+	}, {
+		args:    []string{"env-name"},
+		envName: "env-name",
+	}, {
+		args:      []string{"env-name", "--name", "foo"},
+		localName: "foo",
+		envName:   "env-name",
+	}, {
+		args:    []string{"user/foobar"},
+		envName: "foobar",
+		owner:   "user",
+	}, {
+		args:    []string{"user@local/foobar"},
+		envName: "foobar",
+		owner:   "user@local",
+	}, {
+		args:    []string{"user@remote/foobar"},
+		envName: "foobar",
+		owner:   "user@remote",
+	}, {
+		args:        []string{"user+name/foobar"},
+		errorString: `"user\+name" is not a valid user`,
+	}, {
+		args:    []string{env1UUID},
+		envUUID: env1UUID,
+	}, {
+		args:    []string{"user/" + env1UUID},
+		owner:   "user",
+		envUUID: env1UUID,
+	}} {
 		c.Logf("test %d", i)
 		command := &system.UseEnvironmentCommand{}
 		err := testing.InitCommand(command, test.args)

--- a/cmd/juju/user/info.go
+++ b/cmd/juju/user/info.go
@@ -144,29 +144,34 @@ func (c *InfoCommandBase) apiUsersToUserInfoSlice(users []params.UserInfo) []Use
 	var now = time.Now()
 	for _, info := range users {
 		outInfo := UserInfo{
-			Username:    info.Username,
-			DisplayName: info.DisplayName,
-			Disabled:    info.Disabled,
+			Username:       info.Username,
+			DisplayName:    info.DisplayName,
+			Disabled:       info.Disabled,
+			LastConnection: LastConnection(info.LastConnection, now, c.exactTime),
 		}
 		if c.exactTime {
 			outInfo.DateCreated = info.DateCreated.String()
 		} else {
 			outInfo.DateCreated = UserFriendlyDuration(info.DateCreated, now)
 		}
-		if info.LastConnection != nil {
-			if c.exactTime {
-				outInfo.LastConnection = info.LastConnection.String()
-			} else {
-				outInfo.LastConnection = UserFriendlyDuration(*info.LastConnection, now)
-			}
-		} else {
-			outInfo.LastConnection = "never connected"
-		}
 
 		output = append(output, outInfo)
 	}
 
 	return output
+}
+
+// LastConnection turns the *time.Time returned from the API server
+// into a user facing string with either exact time or a user friendly
+// string based on the args.
+func LastConnection(connectionTime *time.Time, now time.Time, exact bool) string {
+	if connectionTime == nil {
+		return "never connected"
+	}
+	if exact {
+		return connectionTime.String()
+	}
+	return UserFriendlyDuration(*connectionTime, now)
 }
 
 // UserFriendlyDuration translates a time in the past into a user

--- a/featuretests/cmd_juju_system_test.go
+++ b/featuretests/cmd_juju_system_test.go
@@ -57,9 +57,9 @@ func (s *cmdSystemSuite) TestSystemEnvironmentsCommand(c *gc.C) {
 	context, err := testing.RunCommand(c, envcmd.WrapSystem(&system.EnvironmentsCommand{}))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"NAME      OWNER                   LAST CONNECTION\n"+
-		"dummyenv  user-dummy-admin@local  just now\n"+
-		"new-env   user-dummy-admin@local  never connected\n"+
+		"NAME      OWNER              LAST CONNECTION\n"+
+		"dummyenv  dummy-admin@local  just now\n"+
+		"new-env   dummy-admin@local  never connected\n"+
 		"\n")
 }
 


### PR DESCRIPTION
This branch also fixes a problem with the client api environment manager, as it was passing back stringified user tags. I changed this so the api client converts the tag into a username.

Almost all the rest is around use-environment.

(Review request: http://reviews.vapour.ws/r/1809/)