### PR TITLE
Merge pull request #2441 from wallyworld/tools-upgrade-before-api

### DIFF
--- a/apiserver/upgrading_root_test.go
+++ b/apiserver/upgrading_root_test.go
@@ -17,13 +17,17 @@ type upgradingRootSuite struct {
 
 var _ = gc.Suite(&upgradingRootSuite{})
 
-func (r *upgradingRootSuite) TestFindAllowedMethod(c *gc.C) {
+func (r *upgradingRootSuite) TestClientMethods(c *gc.C) {
 	root := apiserver.TestingUpgradingRoot(nil)
 
-	caller, err := root.FindMethod("Client", 0, "FullStatus")
-
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(caller, gc.NotNil)
+	for _, method := range []string{
+		"FullStatus", "EnvironmentGet", "PrivateAddress",
+		"PublicAddress",
+	} {
+		caller, err := root.FindMethod("Client", 0, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
 }
 
 func (r *upgradingRootSuite) TestFindDisallowedMethod(c *gc.C) {

--- a/worker/upgrader/manifold.go
+++ b/worker/upgrader/manifold.go
@@ -27,14 +27,15 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 var newWorker = func(agent agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	currentConfig := agent.CurrentConfig()
 	upgraderFacade := upgrader.NewState(apiCaller)
-	return NewUpgrader(
+	return NewAgentUpgrader(
 		upgraderFacade,
 		currentConfig,
 		// TODO(fwereade): surely we shouldn't need both currentConfig
 		// *and* currentConfig.UpgradedToVersion?
 		currentConfig.UpgradedToVersion(),
-		// TODO(fwereade): this is unit-agent-specific, and very much
+		// TODO(fwereade): these are unit-agent-specific, and very much
 		// unsuitable for use in a machine agent.
 		func() bool { return false },
+		make(chan struct{}),
 	), nil
 }


### PR DESCRIPTION
Do not enable API on machine agent startup if tools upgrades are pending

Partially fixes: https://bugs.launchpad.net/bugs/1455260

This PR doesn't prevent the implicit upgrade when the machine agent first starts. What it does do is delay the full API being available until any pending agent upgrades are done. There are now 2 conditions for the full API being made available:
1. upgrade steps completed
2. agent upgrade worker sees on startup that no new tools are required

This change will prevent the scenario where scripts or the deployer bootstrap and connect immediately to start a deploy, but then get disconnected a short time later because the agents restart to complete an upgrade.

As a driveby, enhance the TestClientMethods test to check more APIs.

(Review request: http://reviews.vapour.ws/r/1805/)


(Review request: http://reviews.vapour.ws/r/1814/)