### PR TITLE
provider/{ec2,openstack}: update resource tags

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
+	"github.com/juju/utils/keyvalues"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charm.v5/charmrepo"
@@ -154,6 +155,10 @@ const (
 
 	// The default block storage source.
 	StorageDefaultBlockSourceKey = "storage-default-block-source"
+
+	// ResourceTagsKey is an optional list or space-separated string
+	// of k=v pairs, defining the tags for ResourceTags.
+	ResourceTagsKey = "resource-tags"
 
 	// For LXC containers, is the container allowed to mount block
 	// devices. A theoretical security issue, so must be explicitly
@@ -599,6 +604,11 @@ func Validate(cfg, old *Config) error {
 		}
 	}
 
+	// Ensure the resource tags have the expected k=v format.
+	if _, err := cfg.resourceTags(); err != nil {
+		return errors.Annotate(err, "validating resource tags")
+	}
+
 	// Check the immutable config values.  These can't change
 	if old != nil {
 		for _, attr := range immutableAttributes {
@@ -650,6 +660,8 @@ func isEmpty(val interface{}) bool {
 		return val == 0
 	case string:
 		return val == ""
+	case []interface{}:
+		return len(val) == 0
 	}
 	panic(fmt.Errorf("unexpected type %T in configuration", val))
 }
@@ -1146,6 +1158,34 @@ func (c *Config) AllowLXCLoopMounts() (bool, bool) {
 	return v, ok
 }
 
+// ResourceTags returns a set of tags to set on environment resources
+// that Juju creates and manages, if the provider supports them. These
+// tags have no special meaning to Juju, but may be used for existing
+// chargeback accounting schemes or other identification purposes.
+func (c *Config) ResourceTags() (map[string]string, bool) {
+	tags, err := c.resourceTags()
+	if err != nil {
+		panic(err) // should be prevented by Validate
+	}
+	return tags, tags != nil
+}
+
+func (c *Config) resourceTags() (map[string]string, error) {
+	var fields []string
+	switch v := c.defined[ResourceTagsKey].(type) {
+	case string:
+		fields = strings.Fields(v)
+	case []interface{}:
+		fields = make([]string, len(v))
+		for i, f := range v {
+			fields[i] = f.(string)
+		}
+	default:
+		return nil, nil
+	}
+	return keyvalues.Parse(fields, true)
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1238,6 +1278,7 @@ var fields = schema.Fields{
 	PreventAllChangesKey:         schema.Bool(),
 	StorageDefaultBlockSourceKey: schema.String(),
 	AllowLXCLoopMounts:           schema.Bool(),
+	ResourceTagsKey:              schema.OneOf(schema.String(), schema.List(schema.String())),
 
 	// Deprecated fields, retain for backwards compatibility.
 	ToolsMetadataURLKey:    schema.String(),
@@ -1282,6 +1323,7 @@ var alwaysOptional = schema.Defaults{
 	AgentStreamKey:               schema.Omit,
 	SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
 	AllowLXCLoopMounts:           false,
+	ResourceTagsKey:              schema.Omit,
 
 	// Storage related config.
 	// Environ providers will specify their own defaults.

--- a/provider/common/tags.go
+++ b/provider/common/tags.go
@@ -6,9 +6,9 @@ package common
 const (
 	// TagJujuEnv is the tag name used for identifying the
 	// Juju environment a resource is part of.
-	TagJujuEnv = "JujuEnv"
+	TagJujuEnv = "juju-env-uuid"
 
 	// TagJujuStateServer is the tag name used for determining
 	// whether a machine instance is a state server or not.
-	TagJujuStateServer = "JujuStateServer"
+	TagJujuStateServer = "juju-is-state"
 )

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -184,7 +184,7 @@ func (e *ebsProvider) VolumeSource(environConfig *config.Config, cfg *storage.Co
 	if err != nil {
 		return nil, errors.Annotate(err, "creating AWS clients")
 	}
-	source := &ebsVolumeSource{ec2: ec2}
+	source := &ebsVolumeSource{ec2: ec2, envName: environConfig.Name()}
 	if uuid, ok := environConfig.UUID(); ok {
 		source.uuid = &uuid
 	}
@@ -201,6 +201,7 @@ func (e *ebsProvider) FilesystemSource(environConfig *config.Config, providerCon
 
 type ebsVolumeSource struct {
 	ec2          *ec2.EC2
+	envName      string // non-unique, informational only
 	uuid         *string
 	resourceTags map[string]string
 }
@@ -288,7 +289,7 @@ func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []stor
 		for k, v := range v.resourceTags {
 			tags[k] = v
 		}
-		tags[tagName] = p.Tag.String()
+		tags[tagName] = resourceName(p.Tag, v.envName)
 		if v.uuid != nil {
 			tags[common.TagJujuEnv] = *v.uuid
 		}

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -211,6 +211,9 @@ func (s *ebsVolumeSuite) TestCreateVolumes(c *gc.C) {
 }
 
 func (s *ebsVolumeSuite) TestVolumeTags(c *gc.C) {
+	s.TestConfig["resource-tags"] = "User=Specified"
+	defer func() { delete(s.TestConfig, "resource-tags") }()
+
 	vs := s.volumeSource(c, nil)
 	vols, err := s.createVolumes(vs, "")
 	c.Assert(err, jc.ErrorIsNil)
@@ -245,14 +248,17 @@ func (s *ebsVolumeSuite) TestVolumeTags(c *gc.C) {
 	c.Assert(ec2Vols.Volumes[0].Tags, jc.SameContents, []awsec2.Tag{
 		{"Name", "volume-0"},
 		{"JujuEnv", testing.EnvironmentTag.Id()},
+		{"User", "Specified"},
 	})
 	c.Assert(ec2Vols.Volumes[1].Tags, jc.SameContents, []awsec2.Tag{
 		{"Name", "volume-1"},
 		{"JujuEnv", testing.EnvironmentTag.Id()},
+		{"User", "Specified"},
 	})
 	c.Assert(ec2Vols.Volumes[2].Tags, jc.SameContents, []awsec2.Tag{
 		{"Name", "volume-2"},
 		{"JujuEnv", testing.EnvironmentTag.Id()},
+		{"User", "Specified"},
 	})
 }
 

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -246,18 +246,18 @@ func (s *ebsVolumeSuite) TestVolumeTags(c *gc.C) {
 	c.Assert(ec2Vols.Volumes, gc.HasLen, 3)
 	sortBySize(ec2Vols.Volumes)
 	c.Assert(ec2Vols.Volumes[0].Tags, jc.SameContents, []awsec2.Tag{
-		{"Name", "volume-0"},
-		{"JujuEnv", testing.EnvironmentTag.Id()},
+		{"Name", "juju-sample-volume-0"},
+		{"juju-env-uuid", testing.EnvironmentTag.Id()},
 		{"User", "Specified"},
 	})
 	c.Assert(ec2Vols.Volumes[1].Tags, jc.SameContents, []awsec2.Tag{
-		{"Name", "volume-1"},
-		{"JujuEnv", testing.EnvironmentTag.Id()},
+		{"Name", "juju-sample-volume-1"},
+		{"juju-env-uuid", testing.EnvironmentTag.Id()},
 		{"User", "Specified"},
 	})
 	c.Assert(ec2Vols.Volumes[2].Tags, jc.SameContents, []awsec2.Tag{
-		{"Name", "volume-2"},
-		{"JujuEnv", testing.EnvironmentTag.Id()},
+		{"Name", "juju-sample-volume-2"},
+		{"juju-env-uuid", testing.EnvironmentTag.Id()},
 		{"User", "Specified"},
 	})
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -427,10 +427,10 @@ func (*environ) MaintainInstance(args environs.StartInstanceParams) error {
 	return nil
 }
 
-// machineName returns the string to use for a machine's Name tag,
-// to help users identify Juju-managed instances in the AWS console.
-func (e *environ) machineName(id string) string {
-	return fmt.Sprintf("juju-%s-%s", e.Config().Name(), names.NewMachineTag(id))
+// resourceName returns the string to use for a resource's Name tag,
+// to help users identify Juju-managed resources in the AWS console.
+func resourceName(tag names.Tag, envName string) string {
+	return fmt.Sprintf("juju-%s-%s", envName, tag)
 }
 
 // StartInstance is specified in the InstanceBroker interface.
@@ -565,7 +565,9 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 	if !ok {
 		tags = make(map[string]string)
 	}
-	tags[tagName] = e.machineName(args.InstanceConfig.MachineId)
+	tags[tagName] = resourceName(
+		names.NewMachineTag(args.InstanceConfig.MachineId), e.Config().Name(),
+	)
 	if stateServer {
 		// It's a state server; tag it as such. We don't currently use
 		// this tag for anything, but we can use this to migrate away

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -973,13 +973,13 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	ec2Inst := ec2.InstanceEC2(bootstrapInst)
 	c.Assert(ec2Inst.Tags, jc.SameContents, []amzec2.Tag{
 		{"Name", "juju-sample-machine-0"},
-		{"JujuEnv", coretesting.EnvironmentTag.Id()},
-		{"JujuStateServer", "true"},
+		{"juju-env-uuid", coretesting.EnvironmentTag.Id()},
+		{"juju-is-state", "true"},
 	})
 	ec2Inst = ec2.InstanceEC2(inst)
 	c.Assert(ec2Inst.Tags, jc.SameContents, []amzec2.Tag{
 		{"Name", "juju-sample-machine-1"},
-		{"JujuEnv", coretesting.EnvironmentTag.Id()},
+		{"juju-env-uuid", coretesting.EnvironmentTag.Id()},
 		{"User", "Specified"},
 	})
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -945,6 +945,15 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Set resource tags after bootstrapping.
+	cfg, err := env.Config().Apply(map[string]interface{}{
+		"resource-tags": "User=Specified",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.SetConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
 	inst, _ := testing.AssertStartInstance(c, env, "1")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -963,14 +972,15 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 
 	ec2Inst := ec2.InstanceEC2(bootstrapInst)
 	c.Assert(ec2Inst.Tags, jc.SameContents, []amzec2.Tag{
-		{"Name", "machine-0"},
+		{"Name", "juju-sample-machine-0"},
 		{"JujuEnv", coretesting.EnvironmentTag.Id()},
 		{"JujuStateServer", "true"},
 	})
 	ec2Inst = ec2.InstanceEC2(inst)
 	c.Assert(ec2Inst.Tags, jc.SameContents, []amzec2.Tag{
-		{"Name", "machine-1"},
+		{"Name", "juju-sample-machine-1"},
 		{"JujuEnv", coretesting.EnvironmentTag.Id()},
+		{"User", "Specified"},
 	})
 }
 

--- a/provider/gce/gce.go
+++ b/provider/gce/gce.go
@@ -6,11 +6,13 @@ package gce
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+
+	"github.com/juju/juju/provider/common"
 )
 
 // The metadata keys used when creating new instances.
 const (
-	metadataKeyIsState = "juju-is-state"
+	metadataKeyIsState = common.TagJujuEnv
 	// This is defined by the cloud-init code:
 	// http://bazaar.launchpad.net/~cloud-init-dev/cloud-init/trunk/view/head:/cloudinit/sources/DataSourceGCE.py
 	// http://cloudinit.readthedocs.org/en/latest/

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -45,7 +45,10 @@ func (p *cinderProvider) VolumeSource(environConfig *config.Config, providerConf
 	if err != nil {
 		return nil, err
 	}
-	source := &cinderVolumeSource{storageAdapter: storageAdapter}
+	source := &cinderVolumeSource{
+		storageAdapter: storageAdapter,
+		envName:        environConfig.Name(),
+	}
 	if uuid, ok := environConfig.UUID(); ok {
 		source.uuid = &uuid
 	}
@@ -88,6 +91,7 @@ func (p *cinderProvider) Dynamic() bool {
 
 type cinderVolumeSource struct {
 	storageAdapter openstackStorage
+	envName        string // non unique, informational only
 	uuid           *string
 	resourceTags   map[string]string
 }
@@ -159,7 +163,7 @@ func (s *cinderVolumeSource) createVolume(arg storage.VolumeParams) (storage.Vol
 		// The Cinder documentation incorrectly states the
 		// size parameter is in GB. It is actually GiB.
 		Size: int(math.Ceil(float64(arg.Size / 1024))),
-		Name: arg.Tag.String(),
+		Name: resourceName(arg.Tag, s.envName),
 		// TODO(axw) use the AZ of the initially attached machine.
 		AvailabilityZone: "",
 		Metadata:         metadata,

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -84,9 +84,9 @@ func (s *cinderVolumeSourceSuite) TestCreateVolume(c *gc.C) {
 		createVolume: func(args cinder.CreateVolumeVolumeParams) (*cinder.Volume, error) {
 			c.Assert(args, jc.DeepEquals, cinder.CreateVolumeVolumeParams{
 				Size: requestedSize / 1024,
-				Name: "volume-123",
+				Name: "juju-testenv-volume-123",
 				Metadata: map[string]string{
-					"JujuEnv": testing.EnvironmentTag.Id(),
+					"juju-env-uuid": testing.EnvironmentTag.Id(),
 				},
 			})
 			return &cinder.Volume{
@@ -160,11 +160,11 @@ func (s *cinderVolumeSourceSuite) TestResourceTags(c *gc.C) {
 			created = true
 			c.Assert(args, jc.DeepEquals, cinder.CreateVolumeVolumeParams{
 				Size: 1,
-				Name: "volume-123",
+				Name: "juju-testenv-volume-123",
 				Metadata: map[string]string{
-					"JujuEnv":      testing.EnvironmentTag.Id(),
-					"ResourceTag1": "Value1",
-					"ResourceTag2": "Value2",
+					"juju-env-uuid": testing.EnvironmentTag.Id(),
+					"ResourceTag1":  "Value1",
+					"ResourceTag2":  "Value2",
 				},
 			})
 			return &cinder.Volume{ID: mockVolId}, nil

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -51,7 +51,7 @@ func (s *cinderVolumeSourceSuite) TestAttachVolumes(c *gc.C) {
 		},
 	}
 
-	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, nil)
 	attachments, err := volSource.AttachVolumes([]storage.VolumeAttachmentParams{{
 		Volume:   mockVolumeTag,
 		VolumeId: mockVolId,
@@ -117,7 +117,7 @@ func (s *cinderVolumeSourceSuite) TestCreateVolume(c *gc.C) {
 		},
 	}
 
-	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, nil)
 	volumes, attachments, err := volSource.CreateVolumes([]storage.VolumeParams{{
 		Provider: openstack.CinderProviderType,
 		Tag:      mockVolumeTag,
@@ -153,6 +153,59 @@ func (s *cinderVolumeSourceSuite) TestCreateVolume(c *gc.C) {
 	c.Check(getVolumeCalls, gc.Equals, 3)
 }
 
+func (s *cinderVolumeSourceSuite) TestResourceTags(c *gc.C) {
+	var created bool
+	mockAdapter := &mockAdapter{
+		createVolume: func(args cinder.CreateVolumeVolumeParams) (*cinder.Volume, error) {
+			created = true
+			c.Assert(args, jc.DeepEquals, cinder.CreateVolumeVolumeParams{
+				Size: 1,
+				Name: "volume-123",
+				Metadata: map[string]string{
+					"JujuEnv":      testing.EnvironmentTag.Id(),
+					"ResourceTag1": "Value1",
+					"ResourceTag2": "Value2",
+				},
+			})
+			return &cinder.Volume{ID: mockVolId}, nil
+		},
+		getVolume: func(volumeId string) (*cinder.Volume, error) {
+			return &cinder.Volume{
+				ID:     volumeId,
+				Size:   1,
+				Status: "available",
+			}, nil
+		},
+		attachVolume: func(serverId, volId, mountPoint string) (*nova.VolumeAttachment, error) {
+			return &nova.VolumeAttachment{
+				Id:       volId,
+				VolumeId: volId,
+				ServerId: serverId,
+				Device:   "/dev/sda",
+			}, nil
+		},
+	}
+
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, map[string]string{
+		"ResourceTag1": "Value1",
+		"ResourceTag2": "Value2",
+	})
+	_, _, err := volSource.CreateVolumes([]storage.VolumeParams{{
+		Provider: openstack.CinderProviderType,
+		Tag:      mockVolumeTag,
+		Size:     1024,
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				Provider:   openstack.CinderProviderType,
+				Machine:    mockMachineTag,
+				InstanceId: instance.Id(mockServerId),
+			},
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(created, jc.IsTrue)
+}
+
 func (s *cinderVolumeSourceSuite) TestDescribeVolumes(c *gc.C) {
 	mockAdapter := &mockAdapter{
 		getVolumesSimple: func() ([]cinder.Volume, error) {
@@ -162,7 +215,7 @@ func (s *cinderVolumeSourceSuite) TestDescribeVolumes(c *gc.C) {
 			}}, nil
 		},
 	}
-	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, nil)
 	volumes, err := volSource.DescribeVolumes([]string{mockVolId})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(volumes, jc.DeepEquals, []storage.VolumeInfo{{
@@ -182,7 +235,7 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumes(c *gc.C) {
 		},
 	}
 
-	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, nil)
 	errs := volSource.DestroyVolumes([]string{mockVolId})
 	c.Assert(numCalls, gc.Equals, 1)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
@@ -215,7 +268,7 @@ func (s *cinderVolumeSourceSuite) TestDetachVolumes(c *gc.C) {
 		},
 	}
 
-	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, nil)
 	err := volSource.DetachVolumes([]storage.VolumeAttachmentParams{{
 		Volume:   names.NewVolumeTag("123"),
 		VolumeId: mockVolId,
@@ -280,7 +333,7 @@ func (s *cinderVolumeSourceSuite) TestCreateVolumeCleanupDestroys(c *gc.C) {
 		},
 	}
 
-	volSource := openstack.NewCinderVolumeSource(mockAdapter)
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, nil)
 	volumeParams := []storage.VolumeParams{{
 		Provider: openstack.CinderProviderType,
 		Tag:      names.NewVolumeTag("0"),

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -78,8 +78,9 @@ var (
 type OpenstackStorage openstackStorage
 
 func NewCinderVolumeSource(s OpenstackStorage, tags map[string]string) storage.VolumeSource {
+	const envName = "testenv"
 	uuid := testing.EnvironmentTag.Id()
-	return &cinderVolumeSource{openstackStorage(s), &uuid, tags}
+	return &cinderVolumeSource{openstackStorage(s), envName, &uuid, tags}
 }
 
 var indexData = `

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -77,9 +77,9 @@ var (
 
 type OpenstackStorage openstackStorage
 
-func NewCinderVolumeSource(s OpenstackStorage) storage.VolumeSource {
+func NewCinderVolumeSource(s OpenstackStorage, tags map[string]string) storage.VolumeSource {
 	uuid := testing.EnvironmentTag.Id()
-	return &cinderVolumeSource{openstackStorage(s), &uuid}
+	return &cinderVolumeSource{openstackStorage(s), &uuid, tags}
 }
 
 var indexData = `

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1604,6 +1604,15 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Set resource tags after bootstrapping.
+	cfg, err := env.Config().Apply(map[string]interface{}{
+		"resource-tags": "User=Specified",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.SetConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
 	inst, _ := testing.AssertStartInstance(c, env, "1")
 
 	instances, err := env.AllInstances()
@@ -1632,6 +1641,7 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 		jc.DeepEquals,
 		map[string]string{
 			"JujuEnv": coretesting.EnvironmentTag.Id(),
+			"User":    "Specified",
 		},
 	)
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1632,16 +1632,16 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 		openstack.InstanceServerDetail(bootstrapInst).Metadata,
 		jc.DeepEquals,
 		map[string]string{
-			"JujuEnv":         coretesting.EnvironmentTag.Id(),
-			"JujuStateServer": "true",
+			"juju-env-uuid": coretesting.EnvironmentTag.Id(),
+			"juju-is-state": "true",
 		},
 	)
 	c.Assert(
 		openstack.InstanceServerDetail(inst).Metadata,
 		jc.DeepEquals,
 		map[string]string{
-			"JujuEnv": coretesting.EnvironmentTag.Id(),
-			"User":    "Specified",
+			"juju-env-uuid": coretesting.EnvironmentTag.Id(),
+			"User":          "Specified",
 		},
 	)
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1058,10 +1058,15 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		metadata[common.TagJujuStateServer] = "true"
 	}
 
+	machineName := resourceName(
+		names.NewMachineTag(args.InstanceConfig.MachineId),
+		e.Config().Name(),
+	)
+
 	var server *nova.Entity
 	for _, availZone := range availabilityZones {
 		var opts = nova.RunServerOpts{
-			Name:               e.machineFullName(args.InstanceConfig.MachineId),
+			Name:               machineName,
 			FlavorId:           spec.InstanceType.Id,
 			ImageId:            spec.Image.Id,
 			UserData:           userData,
@@ -1340,8 +1345,8 @@ func (e *environ) jujuGroupName() string {
 	return fmt.Sprintf("juju-%s", e.name)
 }
 
-func (e *environ) machineFullName(machineId string) string {
-	return fmt.Sprintf("juju-%s-%s", e.Config().Name(), names.NewMachineTag(machineId))
+func resourceName(tag names.Tag, envName string) string {
+	return fmt.Sprintf("juju-%s-%s", envName, tag)
 }
 
 // machinesFilter returns a nova.Filter matching all machines in the environment.

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1047,7 +1047,10 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	}
 
 	stateServer := multiwatcher.AnyJobNeedsState(args.InstanceConfig.Jobs...)
-	metadata := make(map[string]string)
+	metadata, ok := e.Config().ResourceTags()
+	if !ok {
+		metadata = make(map[string]string)
+	}
 	if uuid, ok := e.Config().UUID(); ok {
 		metadata[common.TagJujuEnv] = uuid
 	}


### PR DESCRIPTION
We introduce a new "resource-tags" config attribute,
which defines a set of tags to apply to resources
created in the environment, depending on provider
support. This may be used to apply tags, for example,
for existing chargeback accounting schemes.

The resource-tags config is now used by the ec2 and
openstack providers. In addition, the ec2 instance
names are now updated to be like openstack's; and
in both providers we name volumes similarly to
machines. That is: juju-<envname>-<tag>.

(Review request: http://reviews.vapour.ws/r/1815/)