### PR TITLE
Merge pull request #2453 from wallyworld/status-time-utc-format

### DIFF
--- a/cmd/juju/common.go
+++ b/cmd/juju/common.go
@@ -263,8 +263,13 @@ func (c *csClient) authorize(curl *charm.URL) (*macaroon.Macaroon, error) {
 // if u is specified.
 func formatStatusTime(t *time.Time, formatISO bool) string {
 	if formatISO {
-		// If requested, use ISO time format
-		return t.Format(time.RFC3339)
+		// If requested, use ISO time format.
+		// The format we use is RFC3339 without the "T". From the spec:
+		// NOTE: ISO 8601 defines date and time separated by "T".
+		// Applications using this syntax may choose, for the sake of
+		// readability, to specify a full-date and full-time separated by
+		// (say) a space character.
+		return t.UTC().Format("2006-01-02 15:04:05Z")
 	} else {
 		// Otherwise use local time.
 		return t.Local().Format("02 Jan 2006 15:04:05 MST")

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -2618,7 +2618,7 @@ func substituteFakeSinceTime(c *gc.C, in []byte, expectIsoTime bool) []byte {
 			}
 			timeFormat := "02 Jan 2006 15:04:05 MST"
 			if expectIsoTime {
-				timeFormat = "2006-01-02T15:04:05Z07:00"
+				timeFormat = "2006-01-02 15:04:05Z"
 			}
 			_, err := time.Parse(timeFormat, matches[i])
 			c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Tweak iso time format

Fixes: https://bugs.launchpad.net/juju-core/+bug/1459611

For some reason, for some people UTC times weren't being displayed, and more over the RFC3339 time format was screwed up (see bug).

So we attempt to fix that here, and also remove the "T" from the format.

(Review request: http://reviews.vapour.ws/r/1817/)

(Review request: http://reviews.vapour.ws/r/1819/)