### PR TITLE
Fix 1370896 - juju has conf files in /var/log/juju on instances

### DIFF
--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -237,7 +237,7 @@ var NewRsyslogConfigWorker = func(st *apirsyslog.State, agentConfig agent.Config
 	if err != nil {
 		return nil, err
 	}
-	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs)
+	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, agentConfig.DataDir())
 }
 
 // ParamsStateServingInfoToStateStateServingInfo converts a

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -42,4 +42,8 @@ var (
 	AddEnvironmentUUIDToAgentConfig = addEnvironmentUUIDToAgentConfig
 	AddDefaultStoragePools          = addDefaultStoragePools
 	MoveBlocksFromEnvironToState    = moveBlocksFromEnvironToState
+
+	// 124 upgrade functions
+	MoveSyslogConfig = moveSyslogConfig
+	CopyFile         = copyFile
 )

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -56,6 +56,10 @@ var upgradeOperations = func() []Operation {
 			version.MustParse("1.23.0"),
 			stepsFor123(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.24.0"),
+			stepsFor124(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -3,12 +3,19 @@
 
 package upgrades
 
-import "github.com/juju/juju/state"
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/juju/state"
+)
 
 // stateStepsFor124 returns upgrade steps for Juju 1.24 that manipulate state directly.
 func stateStepsFor124() []Step {
-	var steps []Step
-	steps = append(steps,
+	return []Step{
 		&upgradeStep{
 			description: "add block device documents for existing machines",
 			targets:     []Target{DatabaseMaster},
@@ -22,6 +29,74 @@ func stateStepsFor124() []Step {
 				return state.AddInstanceIdFieldOfIPAddresses(context.State())
 			},
 		},
-	)
-	return steps
+	}
+}
+
+// stepsFor124 returns upgrade steps for Juju 1.24 that only need the API.
+func stepsFor124() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "move syslog config from LogDir to DataDir",
+			targets:     []Target{AllMachines},
+			run: func(context Context) error {
+				config := context.AgentConfig()
+				logdir := config.LogDir()
+				datadir := config.DataDir()
+
+				// these values were copied from
+				// github.com/juju/juju/utils/syslog/config.go
+				// Yes this is bad, but it is only needed once every for an
+				// upgrade, so it didn't seem worth exporting those values.
+				files := []string{
+					"ca-cert.pem",
+					"rsyslog-cert.pem",
+					"rsyslog-key.pem",
+					"logrotate.conf",
+					"logrotate.run",
+				}
+				var errs []string
+				for _, f := range files {
+					oldpath := filepath.Join(logdir, f)
+					newpath := filepath.Join(datadir, f)
+					if err := copy(newpath, oldpath); err != nil {
+						errs = append(errs, err.Error())
+					}
+				}
+				if len(errs) > 0 {
+					return fmt.Errorf("error(s) while moving old syslog config files: ", strings.Join(errs, "\n"))
+				}
+				return nil
+			},
+		},
+	}
+}
+
+func copy(to, from string) error {
+	orig, err := os.Open(from)
+	if os.IsNotExist(err) {
+		// original doesn't exist, that's fine.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer orig.Close()
+	info, err := orig.Stat()
+	if err != nil {
+		return err
+	}
+	target, err := os.OpenFile(to, os.O_CREATE|os.O_WRONLY, info.Mode())
+	if os.IsExist(err) {
+		// don't overwrite an existing target
+		orig.Close()
+
+		// this may fail, but there's not much we can do about it.
+		_ = os.Remove(from)
+		return nil
+	}
+	defer target.Close()
+	if _, err := io.Copy(target, orig); err != nil {
+		return err
+	}
+	return nil
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -60,6 +60,10 @@ func stepsFor124() []Step {
 					newpath := filepath.Join(datadir, f)
 					if err := copy(newpath, oldpath); err != nil {
 						errs = append(errs, err.Error())
+						continue
+					}
+					if err := os.Remove(oldpath); err != nil {
+						errs = append(errs, err.Error())
 					}
 				}
 				if len(errs) > 0 {
@@ -72,8 +76,10 @@ func stepsFor124() []Step {
 }
 
 func copy(to, from string) error {
+	logger.Debugf("Moving %q to %q", from, to)
 	orig, err := os.Open(from)
 	if os.IsNotExist(err) {
+		logger.Debugf("Old file %q does not exist, skipping.", from)
 		// original doesn't exist, that's fine.
 		return nil
 	}
@@ -87,6 +93,7 @@ func copy(to, from string) error {
 	}
 	target, err := os.OpenFile(to, os.O_CREATE|os.O_WRONLY, info.Mode())
 	if os.IsExist(err) {
+		logger.Debugf("New file %q already exists, deleting old file %q", to, from)
 		// don't overwrite an existing target
 		orig.Close()
 

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -23,3 +23,10 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 	}
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
 }
+
+func (s *steps124Suite) TestStepsFor124(c *gc.C) {
+	expected := []string{
+		"move syslog config from LogDir to DataDir",
+	}
+	assertSteps(c, version.MustParse("1.24.0"), expected)
+}

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -4,9 +4,16 @@
 package upgrades_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
 )
 
@@ -29,4 +36,145 @@ func (s *steps124Suite) TestStepsFor124(c *gc.C) {
 		"move syslog config from LogDir to DataDir",
 	}
 	assertSteps(c, version.MustParse("1.24.0"), expected)
+}
+
+func (s *steps124Suite) TestCopyFileNew(c *gc.C) {
+	src := c.MkDir()
+	dest := c.MkDir()
+	srcdata := []byte("new data!")
+
+	// test that a file in src dir and not in dest dir gets copied.
+
+	newSrc := filepath.Join(src, "new")
+	err := ioutil.WriteFile(newSrc, srcdata, 0644)
+	c.Assert(err, gc.IsNil)
+
+	newDest := filepath.Join(dest, "new")
+
+	err = upgrades.CopyFile(newDest, newSrc)
+	c.Assert(err, gc.IsNil)
+
+	srcb, err := ioutil.ReadFile(newSrc)
+	c.Assert(err, gc.IsNil)
+	destb, err := ioutil.ReadFile(newDest)
+	c.Assert(err, gc.IsNil)
+	// convert to string and use Equals because we'll get a better failure message
+	c.Assert(string(destb), gc.Equals, string(srcb))
+}
+
+func (s *steps124Suite) TestCopyFileExisting(c *gc.C) {
+	src := c.MkDir()
+	dest := c.MkDir()
+	srcdata := []byte("new data!")
+	destdata := []byte("old data!")
+
+	exSrc := filepath.Join(src, "existing")
+	exDest := filepath.Join(dest, "existing")
+
+	err := ioutil.WriteFile(exSrc, srcdata, 0644)
+	c.Assert(err, gc.IsNil)
+	err = ioutil.WriteFile(exDest, destdata, 0644)
+	c.Assert(err, gc.IsNil)
+
+	err = upgrades.CopyFile(exDest, exSrc)
+	c.Assert(err, gc.IsNil)
+
+	// assert we haven't changed the destination
+	b, err := ioutil.ReadFile(exDest)
+
+	c.Assert(err, gc.IsNil)
+	// convert to string because we'll get a better failure message
+	c.Assert(string(b), gc.Equals, string(destdata))
+}
+
+func (s *steps124Suite) TestMoveSyslogConfigDefault(c *gc.C) {
+	logdir := c.MkDir()
+	datadir := c.MkDir()
+	data := []byte("data!")
+	files := []string{
+		"ca-cert.pem",
+		"rsyslog-cert.pem",
+		"rsyslog-key.pem",
+		"logrotate.conf",
+		"logrotate.run",
+	}
+	for _, f := range files {
+		err := ioutil.WriteFile(filepath.Join(logdir, f), data, 0644)
+		c.Assert(err, gc.IsNil)
+	}
+
+	ctx := fakeContext{cfg: fakeConfig{logdir: logdir, datadir: datadir}}
+	err := upgrades.MoveSyslogConfig(ctx)
+	c.Assert(err, gc.IsNil)
+
+	for _, f := range files {
+		_, err := os.Stat(filepath.Join(datadir, f))
+		c.Assert(err, gc.IsNil)
+		_, err = os.Stat(filepath.Join(logdir, f))
+		c.Assert(err, jc.Satisfies, os.IsNotExist)
+	}
+}
+
+func (s *steps124Suite) TestMoveSyslogConfig(c *gc.C) {
+	logdir := c.MkDir()
+	datadir := c.MkDir()
+	data := []byte("data!")
+	files := []string{
+		"logrotate.conf",
+		"logrotate.run",
+	}
+
+	// ensure that we don't overwrite an existing file in datadir, and don't
+	// error out if one of the files exists in datadir but not logdir.
+
+	err := ioutil.WriteFile(filepath.Join(logdir, "logrotate.conf"), data, 0644)
+	c.Assert(err, gc.IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(datadir, "logrotate.run"), data, 0644)
+	c.Assert(err, gc.IsNil)
+
+	differentData := []byte("different")
+	existing := filepath.Join(datadir, "logrotate.conf")
+	err = ioutil.WriteFile(existing, differentData, 0644)
+	c.Assert(err, gc.IsNil)
+
+	ctx := fakeContext{cfg: fakeConfig{logdir: logdir, datadir: datadir}}
+	err = upgrades.MoveSyslogConfig(ctx)
+	c.Assert(err, gc.IsNil)
+
+	for _, f := range files {
+		_, err := os.Stat(filepath.Join(datadir, f))
+		c.Assert(err, gc.IsNil)
+		_, err = os.Stat(filepath.Join(logdir, f))
+		c.Assert(err, jc.Satisfies, os.IsNotExist)
+	}
+
+	b, err := ioutil.ReadFile(existing)
+	c.Assert(err, gc.IsNil)
+	// convert to string because we'll get a better failure message
+	c.Assert(string(b), gc.Not(gc.Equals), string(existing))
+
+}
+
+type fakeContext struct {
+	upgrades.Context
+	cfg fakeConfig
+}
+
+func (f fakeContext) AgentConfig() agent.ConfigSetter {
+	return f.cfg
+}
+
+type fakeConfig struct {
+	agent.ConfigSetter
+	logdir  string
+	datadir string
+}
+
+func (f fakeConfig) LogDir() string {
+	return f.logdir
+}
+
+func (f fakeConfig) DataDir() string {
+	return f.datadir
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -671,7 +671,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0", "1.24.0"})
 }
 
 func extractUpgradeVersions(c *gc.C, ops []upgrades.Operation) []string {

--- a/utils/syslog/config.go
+++ b/utils/syslog/config.go
@@ -224,6 +224,8 @@ type SyslogConfig struct {
 	LogDir string
 	// namespace is used when there are multiple environments on one machine
 	Namespace string
+	// directory where juju stores its config files
+	JujuConfigDir string
 }
 
 // NewForwardConfig creates a SyslogConfig instance used on unit nodes to forward log entries
@@ -272,29 +274,29 @@ func (slConfig *SyslogConfig) ConfigFilePath() string {
 
 func (slConfig *SyslogConfig) CACertPath() string {
 	filename := either(slConfig.CACertFileName, defaultCACertFileName)
-	return filepath.Join(slConfig.LogDir, filename)
+	return filepath.Join(slConfig.JujuConfigDir, filename)
 }
 
 func (slConfig *SyslogConfig) ServerCertPath() string {
 	filename := either(slConfig.ServerCertFileName, defaultServerCertFileName)
-	return filepath.Join(slConfig.LogDir, filename)
+	return filepath.Join(slConfig.JujuConfigDir, filename)
 }
 
 func (slConfig *SyslogConfig) ServerKeyPath() string {
 	filename := either(slConfig.ServerCertFileName, defaultServerKeyFileName)
-	return filepath.Join(slConfig.LogDir, filename)
+	return filepath.Join(slConfig.JujuConfigDir, filename)
 }
 
 // LogrotateConfPath returns the the the entire logrotate.conf path including filename.
 func (slConfig *SyslogConfig) LogrotateConfPath() string {
 	filename := either(slConfig.LogrotateConfFileName, defaultLogrotateConfFileName)
-	return filepath.Join(slConfig.LogDir, filename)
+	return filepath.Join(slConfig.JujuConfigDir, filename)
 }
 
 // LogrotateHelperPath returns the entire logrotate.helper path including filename.
 func (slConfig *SyslogConfig) LogrotateHelperPath() string {
 	filename := either(slConfig.LogrotateHelperFileName, defaultLogrotateHelperFileName)
-	return filepath.Join(slConfig.LogDir, filename)
+	return filepath.Join(slConfig.JujuConfigDir, filename)
 }
 
 // LogrotateConfFile returns a ready to write to disk byte array of the logrotate.conf file.

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -87,14 +87,14 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
 	addrs := []string{"0.1.2.3", "0.2.4.6"}
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "foo", addrs)
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "foo", addrs, s.DataDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
 
 	// We should get a ca-cert.pem with the contents introduced into state config.
-	waitForFile(c, filepath.Join(*rsyslog.LogDir, "ca-cert.pem"))
-	caCertPEM, err := ioutil.ReadFile(filepath.Join(*rsyslog.LogDir, "ca-cert.pem"))
+	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(caCertPEM), gc.DeepEquals, coretesting.CACert)
 

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -100,6 +100,6 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 
 	c.Assert(*rsyslog.SyslogTargets, gc.HasLen, 2)
 	for _, dialTag := range s.dialTags {
-		c.Assert(dialTag, gc.Equals, "juju-foo-"+m.Tag().String())
+		c.Check(dialTag, gc.Equals, "juju-foo-"+m.Tag().String())
 	}
 }

--- a/worker/rsyslog/rsyslog_test.go
+++ b/worker/rsyslog/rsyslog_test.go
@@ -119,7 +119,16 @@ func (s *RsyslogSuite) TestModeAccumulate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	syslogPort := s.Environ.Config().SyslogPort()
-	syslogConfig := syslog.NewAccumulateConfig(m.Tag().String(), *rsyslog.LogDir, syslogPort, "", []string{})
+
+	syslogConfig := &syslog.SyslogConfig{
+		LogFileName:          m.Tag().String(),
+		LogDir:               *rsyslog.LogDir,
+		Port:                 syslogPort,
+		Namespace:            "",
+		StateServerAddresses: []string{},
+	}
+
+	syslog.NewAccumulateConfig(syslogConfig)
 	syslogConfig.ConfigDir = *rsyslog.RsyslogConfDir
 	syslogConfig.JujuConfigDir = s.DataDir()
 	rendered, err := syslogConfig.Render()
@@ -135,7 +144,16 @@ func (s *RsyslogSuite) TestModeAccumulate(c *gc.C) {
 
 func (s *RsyslogSuite) TestAccumulateHA(c *gc.C) {
 	m := s.machine
-	syslogConfig := syslog.NewAccumulateConfig(m.Tag().String(), *rsyslog.LogDir, 6541, "", []string{"192.168.1", "127.0.0.1"})
+
+	syslogConfig := &syslog.SyslogConfig{
+		LogFileName:          m.Tag().String(),
+		LogDir:               *rsyslog.LogDir,
+		Port:                 6541,
+		Namespace:            "",
+		StateServerAddresses: []string{"192.168.1", "127.0.0.1"},
+	}
+
+	syslog.NewAccumulateConfig(syslogConfig)
 	syslogConfig.JujuConfigDir = s.DataDir()
 	rendered, err := syslogConfig.Render()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-core/+bug/1370896

All the rsyslog configuration files are now created in juju's data directory (by default, /var/lib/juju), instead of the log directory (/var/log/juju).  Also added an upgrade step to move the files from old location to new location.

I made a couple changes to how you create a SyslogConfig, mostly because it was using a function with a huge number of string arguments, which made it very difficult to read, and to understand what value was being assigned to what field.  This made updating the code almost impossible, because of minor positional differences in the function signatures.

I changed  syslog.NewAccumulateConfig and NewForwardConfig to just take a pointer to a SyslogConfig, since pretty much all they did was set exported fields on the type.  Now they just set the non-exported field, and the caller sets everything else in a struct literal.

I also changed it so that the Namespace field in SyslogConfig always stays just "Namespace", not "-Namespace", since it's an exported value, and having it be something different than what was set is really confusing.  Instead, we just add the dash when rendering to the template.

Changed the tests much the same way - just set up the struct and pass it in is so much easier to read than a huge function call with a ton of different string parameters in a random order.  Also changed the test template, so that there aren't hard-coded values in it, and instead actually use the values passed in.




(Review request: http://reviews.vapour.ws/r/1822/)