### PR TITLE
Merge pull request #2460 from wallyworld/container-harvest-mode

### DIFF
--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -12,10 +12,16 @@ import (
 )
 
 func SetObserver(p Provisioner, observer chan<- *config.Config) {
-	ep := p.(*environProvisioner)
-	ep.Lock()
-	ep.observer = observer
-	ep.Unlock()
+	var configObserver *configObserver
+	if ep, ok := p.(*environProvisioner); ok {
+		configObserver = &ep.configObserver
+	} else {
+		cp := p.(*containerProvisioner)
+		configObserver = &cp.configObserver
+	}
+	configObserver.Lock()
+	configObserver.observer = observer
+	configObserver.Unlock()
 }
 
 func GetRetryWatcher(p Provisioner) (watcher.NotifyWatcher, error) {

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -289,3 +289,9 @@ func (s *kvmProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 	s.expectStopped(c, instId)
 	s.waitRemoved(c, container)
 }
+
+func (s *kvmProvisionerSuite) TestKVMProvisionerObservesConfigChanges(c *gc.C) {
+	p := s.newKvmProvisioner(c)
+	defer stop(c, p)
+	s.assertProvisionerObservesConfigChanges(c, p)
+}

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -950,6 +950,12 @@ func (s *lxcProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 	s.waitRemoved(c, container)
 }
 
+func (s *lxcProvisionerSuite) TestLXCProvisionerObservesConfigChanges(c *gc.C) {
+	p := s.newLxcProvisioner(c)
+	defer stop(c, p)
+	s.assertProvisionerObservesConfigChanges(c, p)
+}
+
 type fakeAPI struct {
 	c            *gc.C
 	suite        *lxcBrokerSuite

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -51,6 +51,7 @@ type containerProvisioner struct {
 	provisioner
 	containerType instance.ContainerType
 	machine       *apiprovisioner.Machine
+	configObserver
 }
 
 // provisioner providers common behaviour for a running provisioning worker.
@@ -269,7 +270,21 @@ func NewContainerProvisioner(
 }
 
 func (p *containerProvisioner) loop() error {
-	task, err := p.getStartTask(config.HarvestDestroyed)
+	var environConfigChanges <-chan struct{}
+	environWatcher, err := p.st.WatchForEnvironConfigChanges()
+	if err != nil {
+		return err
+	}
+	environConfigChanges = environWatcher.Changes()
+	defer watcher.Stop(environWatcher, &p.tomb)
+
+	environ, err := worker.WaitForEnviron(environWatcher, p.st, p.tomb.Dying())
+	if err != nil {
+		return err
+	}
+	harvestMode := environ.Config().ProvisionerHarvestMode()
+
+	task, err := p.getStartTask(harvestMode)
 	if err != nil {
 		return err
 	}
@@ -283,6 +298,17 @@ func (p *containerProvisioner) loop() error {
 			err := task.Err()
 			logger.Errorf("%s provisioner died: %v", p.containerType, err)
 			return err
+		case _, ok := <-environConfigChanges:
+			if !ok {
+				return watcher.EnsureErr(environWatcher)
+			}
+			environConfig, err := p.st.EnvironConfig()
+			if err != nil {
+				logger.Errorf("cannot load environment configuration: %v", err)
+				return err
+			}
+			p.configObserver.notify(environConfig)
+			task.SetHarvestMode(environConfig.ProvisionerHarvestMode())
 		}
 	}
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -53,6 +53,33 @@ type CommonProvisionerSuite struct {
 	provisioner *apiprovisioner.State
 }
 
+func (s *CommonProvisionerSuite) assertProvisionerObservesConfigChanges(c *gc.C, p provisioner.Provisioner) {
+	// Inject our observer into the provisioner
+	cfgObserver := make(chan *config.Config, 1)
+	provisioner.SetObserver(p, cfgObserver)
+
+	// Switch to reaping on All machines.
+	attrs := map[string]interface{}{
+		config.ProvisionerHarvestModeKey: config.HarvestAll.String(),
+	}
+	err := s.State.UpdateEnvironConfig(attrs, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.BackingState.StartSync()
+
+	// Wait for the PA to load the new configuration.
+	select {
+	case newCfg := <-cfgObserver:
+		c.Assert(
+			newCfg.ProvisionerHarvestMode().String(),
+			gc.Equals,
+			config.HarvestAll.String(),
+		)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("PA did not action config change")
+	}
+}
+
 type ProvisionerSuite struct {
 	CommonProvisionerSuite
 }
@@ -1067,34 +1094,10 @@ func (s *ProvisionerSuite) TestMachineErrorsRetainInstances(c *gc.C) {
 	s.checkNoOperations(c)
 }
 
-func (s *ProvisionerSuite) TestProvisionerObservesConfigChanges(c *gc.C) {
+func (s *ProvisionerSuite) TestEnvironProvisionerObservesConfigChanges(c *gc.C) {
 	p := s.newEnvironProvisioner(c)
 	defer stop(c, p)
-
-	// Inject our observer into the provisioner
-	cfgObserver := make(chan *config.Config, 1)
-	provisioner.SetObserver(p, cfgObserver)
-
-	// Switch to reaping on All machines.
-	attrs := map[string]interface{}{
-		config.ProvisionerHarvestModeKey: config.HarvestAll.String(),
-	}
-	err := s.State.UpdateEnvironConfig(attrs, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.BackingState.StartSync()
-
-	// Wait for the PA to load the new configuration.
-	select {
-	case newCfg := <-cfgObserver:
-		c.Assert(
-			newCfg.ProvisionerHarvestMode().String(),
-			gc.Equals,
-			config.HarvestAll.String(),
-		)
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("PA did not action config change")
-	}
+	s.assertProvisionerObservesConfigChanges(c, p)
 }
 
 func (s *ProvisionerSuite) newProvisionerTask(


### PR DESCRIPTION
Container provisioner now supports configured harvest mode

Fixes: https://bugs.launchpad.net/juju-core/+bug/1459885

The container provisioner was hard coded to use harvest mode HarvestDestroyed.
This branch copies a bunch of code from the environment provisioner to allow the container provisioner to instead use the mode configured in environment config.

(Review request: http://reviews.vapour.ws/r/1825/)