### PR TITLE
Storage constraints can be omitted.

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -742,11 +742,7 @@ func (u *Unit) AddStorage(constraints map[string]params.StorageConstraints) erro
 	}
 
 	all := make([]params.StorageAddParams, 0, len(constraints))
-	min := uint64(1)
 	for storage, cons := range constraints {
-		if cons.Count == nil {
-			cons.Count = &min
-		}
 		all = append(all, params.StorageAddParams{u.Tag().String(), storage, cons})
 	}
 

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -32,10 +32,9 @@ func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 		"data": params.StorageConstraints{Pool: "loop"},
 	}
 
-	count := uint64(1)
 	expected := params.StoragesAddParams{
 		Storages: []params.StorageAddParams{
-			{"unit-mysql-0", "data", params.StorageConstraints{Pool: "loop", Count: &count}},
+			{"unit-mysql-0", "data", params.StorageConstraints{Pool: "loop"}},
 		},
 	}
 
@@ -63,10 +62,9 @@ func (s *unitStorageSuite) TestAddUnitStorageError(c *gc.C) {
 		"data": params.StorageConstraints{Pool: "loop"},
 	}
 
-	count := uint64(1)
 	expected := params.StoragesAddParams{
 		Storages: []params.StorageAddParams{
-			{"unit-mysql-0", "data", params.StorageConstraints{Pool: "loop", Count: &count}},
+			{"unit-mysql-0", "data", params.StorageConstraints{Pool: "loop"}},
 		},
 	}
 

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -92,7 +92,7 @@ func (c *AddCommand) Init(args []string) (err error) {
 	}
 	c.unitTag = names.NewUnitTag(u).String()
 
-	c.storageCons, err = storage.ParseStorageConstraints(args[1:])
+	c.storageCons, err = storage.ParseConstraintsMap(args[1:], false)
 	return
 }
 

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -22,7 +22,7 @@ Specify a unit and a storage specification in the same format
 as passed to juju deploy --storage=”...”.
 
 A storage directive consists of a storage name as per charm specification
-and storage constraints, for e.g. pool, count, size.
+and storage constraints, e.g. pool, count, size.
 
 The acceptable format for storage constraints is a comma separated
 sequence of: POOL, COUNT, and SIZE, where
@@ -45,18 +45,27 @@ Environment default values will be used for all ommitted constraint values.
 There is no need to comma-separate ommitted constraints. 
 
 Example:
-    juju storage add u/0 data=ebs,1024,3 
-    juju storage add u/0 data=ebs,1024,3, 
-    Add 3 ebs storage instances for "data" storage to unit u/0. 
+    Add 3 ebs storage instances for "data" storage to unit u/0:     
+
+      juju storage add u/0 data=ebs,1024,3 
+    or
+      juju storage add u/0 data=ebs,3
+    or
+      juju storage add u/0 data=ebs,,3 
     
-    juju storage add u/0 data=1 
-    juju storage add u/0 data 
+    
     Add 1 storage instances for "data" storage to unit u/0 
-        using default environment provider pool. 
+    using default environment provider pool: 
+
+      juju storage add u/0 data=1 
+    or
+      juju storage add u/0 data 
 `
 	addCommandAgs = `
 <unit name> <storage directive> ...
-    where storage directive is <charm storage name>=<storage constraints> or
+    where storage directive is 
+        <charm storage name>=<storage constraints> 
+    or
         <charm storage name>
 `
 )

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -46,6 +46,7 @@ type tstData struct {
 var errorTsts = []tstData{
 	{nil, ".*storage add requires a unit and a storage directive.*"},
 	{[]string{"tst/123"}, ".*storage add requires a unit and a storage directive.*"},
+	{[]string{"tst/123", "data="}, `.*storage constraints require at least one.*`},
 	{[]string{"tst/123", "data=-676"}, `.*count must be greater than zero, got "-676".*`},
 	{[]string{"tst/123", "data=676", "data=676"}, `.*storage "data" specified more than once.*`},
 }
@@ -75,7 +76,6 @@ func (s *addSuite) TestAddInvalidUnit(c *gc.C) {
 var successTsts = []tstData{
 	{[]string{"tst/123", "data=676"}, ""},
 	{[]string{"tst/123", "data"}, ``},
-	{[]string{"tst/123", "data="}, ``},
 }
 
 func (s *addSuite) TestAddSuccess(c *gc.C) {

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -46,9 +46,8 @@ type tstData struct {
 var errorTsts = []tstData{
 	{nil, ".*storage add requires a unit and a storage directive.*"},
 	{[]string{"tst/123"}, ".*storage add requires a unit and a storage directive.*"},
-	{[]string{"tst/123", "data"}, `.*expected "key=value", got "data".*`},
-	{[]string{"tst/123", "data="}, `.*storage constraints require at least one field to be specified`},
 	{[]string{"tst/123", "data=-676"}, `.*count must be greater than zero, got "-676".*`},
+	{[]string{"tst/123", "data=676", "data=676"}, `.*storage "data" specified more than once.*`},
 }
 
 func (s *addSuite) TestAddArgs(c *gc.C) {
@@ -73,9 +72,18 @@ func (s *addSuite) TestAddInvalidUnit(c *gc.C) {
 	s.assertAddErrorOutput(c, `.*unit name "tst-123" not valid.*`)
 }
 
+var successTsts = []tstData{
+	{[]string{"tst/123", "data=676"}, ""},
+	{[]string{"tst/123", "data"}, ``},
+	{[]string{"tst/123", "data="}, ``},
+}
+
 func (s *addSuite) TestAddSuccess(c *gc.C) {
-	s.args = []string{"tst/123", "data=676"}
-	s.assertAddOutput(c, "", "")
+	for i, t := range successTsts {
+		c.Logf("test %d for %q", i, t.args)
+		s.args = t.args
+		s.assertAddOutput(c, "", "")
+	}
 }
 
 func (s *addSuite) TestAddOperationAborted(c *gc.C) {

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -98,7 +98,7 @@ func IsValidPoolName(s string) bool {
 	return poolRE.MatchString(s)
 }
 
-// ParseStorageConstraints parses string representation of
+// ParseConstraintsMap parses string representation of
 // storage constraints into a map keyed on storage names
 // with constraints as values.
 //
@@ -109,13 +109,18 @@ func IsValidPoolName(s string) bool {
 // where latter is equivalent to <name>=1.
 //
 // Duplicate storage names cause an error to be returned.
-func ParseStorageConstraints(args []string) (map[string]Constraints, error) {
+// Constraints presence can be enforced.
+func ParseConstraintsMap(args []string, mustHaveConstraints bool) (map[string]Constraints, error) {
 	results := make(map[string]Constraints, len(args))
 	for _, kv := range args {
 		parts := strings.SplitN(kv, "=", -1)
 		name := parts[0]
 		if len(parts) > 2 || len(name) == 0 {
 			return nil, errors.Errorf(`expected "name=constraints" or "name", got %q`, kv)
+		}
+
+		if mustHaveConstraints && len(parts) == 1 {
+			return nil, errors.Errorf(`expected "name=constraints" where "constraints" must be specified, got %q`, kv)
 		}
 
 		if _, exists := results[name]; exists {

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -121,12 +121,9 @@ func ParseStorageConstraints(args []string) (map[string]Constraints, error) {
 			return nil, errors.Errorf("storage %q specified more than once", parts[0])
 		}
 		if len(parts) == 1 {
-			// This will happen if only <name> is supplied.
-			parts = append(parts, "")
-		}
-		if len(parts[1]) == 0 {
-			//<name> is equivalent to <name>=1
-			parts[1] = "1"
+			// This will happen if only <name> is supplied which is
+			//  equivalent to <name>=1
+			parts = append(parts, "1")
 		}
 		cons, err := ParseConstraints(parts[1])
 		if err != nil {

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -113,24 +113,24 @@ func ParseStorageConstraints(args []string) (map[string]Constraints, error) {
 	results := make(map[string]Constraints, len(args))
 	for _, kv := range args {
 		parts := strings.SplitN(kv, "=", -1)
-		if len(parts) > 2 || len(parts[0]) == 0 {
+		name := parts[0]
+		if len(parts) > 2 || len(name) == 0 {
 			return nil, errors.Errorf(`expected "name=constraints" or "name", got %q`, kv)
 		}
 
-		if _, exists := results[parts[0]]; exists {
-			return nil, errors.Errorf("storage %q specified more than once", parts[0])
+		if _, exists := results[name]; exists {
+			return nil, errors.Errorf("storage %q specified more than once", name)
 		}
-		if len(parts) == 1 {
-			// This will happen if only <name> is supplied which is
-			//  equivalent to <name>=1
-			parts = append(parts, "1")
+		consString := "1"
+		if len(parts) > 1 {
+			consString = parts[1]
 		}
-		cons, err := ParseConstraints(parts[1])
+		cons, err := ParseConstraints(consString)
 		if err != nil {
-			return nil, errors.Annotatef(err, "cannot parse constraints for storage %q", parts[0])
+			return nil, errors.Annotatef(err, "cannot parse constraints for storage %q", name)
 		}
 
-		results[parts[0]] = cons
+		results[name] = cons
 	}
 	return results, nil
 }

--- a/storage/constraints_test.go
+++ b/storage/constraints_test.go
@@ -118,10 +118,10 @@ func (s *ConstraintsSuite) TestParseStorageConstraints(c *gc.C) {
 			Count: 1,
 		}})
 	s.testParseStorageConstraints(c,
-		[]string{"data", "cache"},
+		[]string{"data=3", "cache"},
 		map[string]storage.Constraints{
 			"data": storage.Constraints{
-				Count: 1,
+				Count: 3,
 			},
 			"cache": storage.Constraints{
 				Count: 1,

--- a/storage/constraints_test.go
+++ b/storage/constraints_test.go
@@ -118,12 +118,7 @@ func (s *ConstraintsSuite) TestParseStorageConstraints(c *gc.C) {
 			Count: 1,
 		}})
 	s.testParseStorageConstraints(c,
-		[]string{"data="},
-		map[string]storage.Constraints{"data": storage.Constraints{
-			Count: 1,
-		}})
-	s.testParseStorageConstraints(c,
-		[]string{"data=", "cache"},
+		[]string{"data", "cache"},
 		map[string]storage.Constraints{
 			"data": storage.Constraints{
 				Count: 1,
@@ -143,6 +138,9 @@ func (s *ConstraintsSuite) TestParseStorageConstraintsErrors(c *gc.C) {
 		`storage "data" specified more than once`)
 	s.testStorageConstraintsError(c,
 		[]string{"data=-1"},
+		`.*cannot parse constraints for storage "data".*`)
+	s.testStorageConstraintsError(c,
+		[]string{"data="},
 		`.*cannot parse constraints for storage "data".*`)
 }
 

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -65,7 +65,7 @@ func (s *StorageAddCommand) Init(args []string) error {
 		return errors.New("storage add requires a storage directive")
 	}
 
-	cons, err := storage.ParseStorageConstraints(args)
+	cons, err := storage.ParseConstraintsMap(args, false)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -26,7 +26,7 @@ func NewStorageAddCommand(ctx Context) cmd.Command {
 var StorageAddDoc = `
 Storage add adds storage instances to unit using provided storage directives.
 A storage directive consists of a storage name as per charm specification
-and storage constraints, for e.g. pool, count, size.
+and storage constraints, e.g. pool, count, size.
 
 The acceptable format for storage constraints is a comma separated
 sequence of: POOL, COUNT, and SIZE, where

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -6,7 +6,6 @@ package jujuc
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/utils/keyvalues"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/storage"
@@ -45,11 +44,11 @@ sequence of: POOL, COUNT, and SIZE, where
     the set (M, G, T, P, E, Z, Y), which are all treated as
     powers of 1024.
 
-Storage constraints can be optionally ommitted as long as at least one 
-value is provided. 
+Storage constraints can be optionally ommitted.
 Environment default values will be used for all ommitted constraint values.
-There is no need to comma-separate ommitted constraints, 
-e.g. data=ebs,2, can be written as  data=ebs,2
+There is no need to comma-separate ommitted constraints, e.g. 
+    data=ebs,2,    <equivalent to>   data=ebs,2
+    data=1         <equivalent to>   data
 `
 
 func (s *StorageAddCommand) Info() *cmd.Info {
@@ -66,22 +65,14 @@ func (s *StorageAddCommand) Init(args []string) error {
 		return errors.New("storage add requires a storage directive")
 	}
 
-	// TODO (anastasiamac 2015-5-27) Bug 1459060:
-	//     For store names that already have constraints,
-	//     add support for "storage-add <name>".
-	//     This is equivalent to "storage-add <name>=1".
-	cons, err := keyvalues.Parse(args, true)
+	cons, err := storage.ParseStorageConstraints(args)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	s.all = make(map[string]params.StorageConstraints, len(cons))
 	for k, v := range cons {
-		c, err := storage.ParseConstraints(v)
-		if err != nil {
-			return errors.Annotatef(err, "cannot parse constraints for %q", k)
-		}
-		s.all[k] = params.StorageConstraints{c.Pool, &c.Size, &c.Count}
+		s.all[k] = params.StorageConstraints{v.Pool, &v.Size, &v.Count}
 	}
 	return nil
 }

--- a/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/worker/uniter/runner/jujuc/storage-add_test.go
@@ -56,8 +56,6 @@ type tstData struct {
 func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
 	tests := []tstData{
 		{[]string{}, 1, "storage add requires a storage directive"},
-		{[]string{"data"}, 1, `expected "key=value", got "data"`},
-		{[]string{"data="}, 1, ".*storage constraints require at least one.*"},
 		{[]string{"data=-676"}, 1, `.*cannot parse count: count must be gre.*`},
 	}
 	for i, t := range tests {
@@ -70,6 +68,8 @@ func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
 func (s *storageAddSuite) TestAddUnitStorage(c *gc.C) {
 	tests := []tstData{
 		{[]string{"data=676"}, 0, ""},
+		{[]string{"data"}, 0, ``},
+		{[]string{"data="}, 0, ""},
 	}
 
 	for i, t := range tests {

--- a/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/worker/uniter/runner/jujuc/storage-add_test.go
@@ -57,6 +57,7 @@ func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
 	tests := []tstData{
 		{[]string{}, 1, "storage add requires a storage directive"},
 		{[]string{"data=-676"}, 1, `.*cannot parse count: count must be gre.*`},
+		{[]string{"data="}, 1, ".*storage constraints require at least one.*"},
 	}
 	for i, t := range tests {
 		c.Logf("test %d: %#v", i, t.args)
@@ -69,7 +70,6 @@ func (s *storageAddSuite) TestAddUnitStorage(c *gc.C) {
 	tests := []tstData{
 		{[]string{"data=676"}, 0, ""},
 		{[]string{"data"}, 0, ``},
-		{[]string{"data="}, 0, ""},
 	}
 
 	for i, t := range tests {


### PR DESCRIPTION
Added support for "storage-add <name>" (bug https://bugs.launchpad.net/juju-core/+bug/1459060)

When specifying storage constraints to add unit, the actual constraints can be omitted.
When only storage name is specified, environment default values for constraints will be used. This  translates into "add 1 instance of <storage name> with default constraints configuration".

(Review request: http://reviews.vapour.ws/r/1827/)