### PR TITLE
Multiple cons bug1459057

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -743,7 +743,9 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 
 	all := make([]params.StorageAddParams, 0, len(constraints))
 	for storage, cons := range constraints {
-		all = append(all, params.StorageAddParams{u.Tag().String(), storage, cons})
+		for _, one := range cons {
+			all = append(all, params.StorageAddParams{u.Tag().String(), storage, one})
+		}
 	}
 
 	args := params.StoragesAddParams{Storages: all}

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -736,7 +736,7 @@ func (u *Unit) WatchStorage() (watcher.StringsWatcher, error) {
 }
 
 // AddStorage adds desired storage instances to a unit.
-func (u *Unit) AddStorage(constraints map[string]params.StorageConstraints) error {
+func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) error {
 	if u.st.facade.BestAPIVersion() < 2 {
 		return errors.NotImplementedf("AddStorage() (need V2+)")
 	}

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -28,8 +28,9 @@ func (s *unitStorageSuite) createTestUnit(c *gc.C, t string, apiCaller basetesti
 }
 
 func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
-	args := map[string]params.StorageConstraints{
-		"data": params.StorageConstraints{Pool: "loop"},
+	args := map[string][]params.StorageConstraints{
+		"data": []params.StorageConstraints{
+			params.StorageConstraints{Pool: "loop"}},
 	}
 
 	expected := params.StoragesAddParams{
@@ -58,8 +59,8 @@ func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 }
 
 func (s *unitStorageSuite) TestAddUnitStorageError(c *gc.C) {
-	args := map[string]params.StorageConstraints{
-		"data": params.StorageConstraints{Pool: "loop"},
+	args := map[string][]params.StorageConstraints{
+		"data": []params.StorageConstraints{params.StorageConstraints{Pool: "loop"}},
 	}
 
 	expected := params.StoragesAddParams{

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/uniter/runner"
@@ -299,4 +300,64 @@ func (s *InterfaceSuite) TestRequestRebootNowNoProcess(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "no process to kill")
 	priority := ctx.GetRebootPriority()
 	c.Assert(priority, gc.Equals, jujuc.RebootNow)
+}
+
+func (s *InterfaceSuite) TestStorageAddConstraints(c *gc.C) {
+	expected := map[string][]params.StorageConstraints{
+		"data": []params.StorageConstraints{
+			params.StorageConstraints{},
+		},
+	}
+
+	ctx := runner.HookContext{}
+	addStorageToContext(&ctx, "data", params.StorageConstraints{})
+	assertStorageAddInContext(c, ctx, expected)
+}
+
+var two = uint64(2)
+
+func (s *InterfaceSuite) TestStorageAddConstraintsSameStorage(c *gc.C) {
+	expected := map[string][]params.StorageConstraints{
+		"data": []params.StorageConstraints{
+			params.StorageConstraints{},
+			params.StorageConstraints{Count: &two},
+		},
+	}
+
+	ctx := runner.HookContext{}
+	addStorageToContext(&ctx, "data", params.StorageConstraints{})
+	addStorageToContext(&ctx, "data", params.StorageConstraints{Count: &two})
+	assertStorageAddInContext(c, ctx, expected)
+}
+
+func (s *InterfaceSuite) TestStorageAddConstraintsDifferentStorage(c *gc.C) {
+	expected := map[string][]params.StorageConstraints{
+		"data": []params.StorageConstraints{params.StorageConstraints{}},
+		"diff": []params.StorageConstraints{
+			params.StorageConstraints{Count: &two}},
+	}
+
+	ctx := runner.HookContext{}
+	addStorageToContext(&ctx, "data", params.StorageConstraints{})
+	addStorageToContext(&ctx, "diff", params.StorageConstraints{Count: &two})
+	assertStorageAddInContext(c, ctx, expected)
+}
+
+func addStorageToContext(ctx *runner.HookContext,
+	name string,
+	cons params.StorageConstraints,
+) {
+	addOne := map[string]params.StorageConstraints{name: cons}
+	ctx.AddUnitStorage(addOne)
+}
+
+func assertStorageAddInContext(c *gc.C,
+	ctx runner.HookContext, expected map[string][]params.StorageConstraints,
+) {
+	obtained := ctx.StorageAddConstraints()
+	c.Assert(len(obtained), gc.Equals, len(expected))
+	for k, v := range obtained {
+		c.Assert(v, jc.SameContents, expected[k])
+	}
+
 }

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -359,5 +359,4 @@ func assertStorageAddInContext(c *gc.C,
 	for k, v := range obtained {
 		c.Assert(v, jc.SameContents, expected[k])
 	}
-
 }

--- a/worker/uniter/runner/export_test.go
+++ b/worker/uniter/runner/export_test.go
@@ -229,3 +229,7 @@ func SetEnvironmentHookContextRelation(
 		},
 	}
 }
+
+func (ctx *HookContext) StorageAddConstraints() map[string][]params.StorageConstraints {
+	return ctx.storageAddConstraints
+}

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -90,6 +90,17 @@ func (s *unitStorageSuite) TestAddUnitStorageAccumulated(c *gc.C) {
 			"multi1to10": params.StorageConstraints{Count: &count}})
 }
 
+func (s *unitStorageSuite) TestAddUnitStorageAccumulatedSame(c *gc.C) {
+	s.createStorageBlock2Unit(c)
+	count := uint64(1)
+	size := uint64(2048)
+	s.assertUnitStorageAdded(c,
+		map[string]params.StorageConstraints{
+			"multi2up": params.StorageConstraints{Size: &size}},
+		map[string]params.StorageConstraints{
+			"multi2up": params.StorageConstraints{Count: &count}})
+}
+
 func setupTestStorageSupport(c *gc.C, s *state.State) {
 	stsetts := state.NewStateSettings(s)
 	poolManager := poolmanager.New(stsetts)

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -96,7 +96,7 @@ func (s *unitStorageSuite) TestAddUnitStorageAccumulatedSame(c *gc.C) {
 	size := uint64(2048)
 	s.assertUnitStorageAdded(c,
 		map[string]params.StorageConstraints{
-			"multi2up": params.StorageConstraints{Size: &size}},
+			"multi2up": params.StorageConstraints{Size: &size, Count: &count}},
 		map[string]params.StorageConstraints{
 			"multi2up": params.StorageConstraints{Count: &count}})
 }


### PR DESCRIPTION
Added support for multiple storage-add constraints for the same storage (bug https://bugs.launchpad.net/juju-core/+bug/1459057).

Storage constraints are accumulated in hook tool until hook successfully completes - the actual add to state happens in the hook context flush. Until this PR, constraints for the same storage were not accumulated. This is the fix :)

This PR depends on landing of https://github.com/juju/juju/pull/2463. 

(Review request: http://reviews.vapour.ws/r/1828/)