### PR TITLE
Changed worker/instancepoller to use the API

### DIFF
--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -35,8 +35,8 @@ func (APICallerFunc) Close() error {
 // fields non empty fields will be checked to match the arguments
 // recieved by the APICall() method of the returned APICallerFunc. If
 // Id is empty, but IdIsEmpty is true, the id argument is checked to
-// be empty. The same applies to Version being empty, but
-// VersionIsZero set to true - the version is checked to be 0.
+// be empty. The same applies to Version being empty, but if
+// VersionIsZero set to true the version is checked to be 0.
 type CheckArgs struct {
 	Facade  string
 	Version int

--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -3,7 +3,14 @@
 
 package testing
 
-import "github.com/juju/names"
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+)
 
 // APICallerFunc is a function type that implements APICaller.
 type APICallerFunc func(objType string, version int, id, request string, params, response interface{}) error
@@ -22,4 +29,64 @@ func (APICallerFunc) EnvironTag() (names.EnvironTag, error) {
 
 func (APICallerFunc) Close() error {
 	return nil
+}
+
+// CheckArgs holds the possible arguments to CheckingAPICaller(). Any
+// fields non empty fields will be checked to match the arguments
+// recieved by the APICall() method of the returned APICallerFunc. If
+// Id is empty, but IdIsEmpty is true, the id argument is checked to
+// be empty. The same applies to Version being empty, but
+// VersionIsZero set to true - the version is checked to be 0.
+type CheckArgs struct {
+	Facade  string
+	Version int
+	Id      string
+	Method  string
+	Args    interface{}
+	Results interface{}
+
+	IdIsEmpty     bool
+	VersionIsZero bool
+}
+
+// CheckingAPICaller returns an APICallerFunc which can report the
+// number of times its APICall() method was called (if numCalls is not
+// nil), as well as check if any of the arguments passed to the
+// APICall() method match the values given in args (if args itself is
+// not nil, otherwise no arguments are checked). The final error
+// result of the APICall() will be set to err.
+func CheckingAPICaller(c *gc.C, args *CheckArgs, numCalls *int, err error) base.APICaller {
+	return APICallerFunc(
+		func(facade string, version int, id, method string, inArgs, outResults interface{}) error {
+			if numCalls != nil {
+				*numCalls++
+			}
+			if args != nil {
+				if args.Facade != "" {
+					c.Check(facade, gc.Equals, args.Facade)
+				}
+				if args.Version != 0 {
+					c.Check(version, gc.Equals, args.Version)
+				} else if args.VersionIsZero {
+					c.Check(version, gc.Equals, 0)
+				}
+				if args.Id != "" {
+					c.Check(id, gc.Equals, args.Id)
+				} else if args.IdIsEmpty {
+					c.Check(id, gc.Equals, "")
+				}
+				if args.Method != "" {
+					c.Check(method, gc.Equals, args.Method)
+				}
+				if args.Args != nil {
+					c.Check(inArgs, jc.DeepEquals, args.Args)
+				}
+				if args.Results != nil {
+					c.Check(outResults, gc.NotNil)
+					testing.PatchValue(outResults, args.Results)
+				}
+			}
+			return err
+		},
+	)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -28,6 +28,7 @@ var facadeVersions = map[string]int{
 	"Firewaller":                   1,
 	"HighAvailability":             1,
 	"ImageManager":                 1,
+	"InstancePoller":               1,
 	"KeyManager":                   0,
 	"KeyUpdater":                   0,
 	"LeadershipService":            1,

--- a/api/instancepoller/export_test.go
+++ b/api/instancepoller/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+func NewMachine(caller base.APICaller, tag names.MachineTag, life params.Life) *Machine {
+	facade := base.NewFacadeCaller(caller, instancePollerFacade)
+	return &Machine{facade, tag, life}
+}

--- a/api/instancepoller/export_test.go
+++ b/api/instancepoller/export_test.go
@@ -14,3 +14,5 @@ func NewMachine(caller base.APICaller, tag names.MachineTag, life params.Life) *
 	facade := base.NewFacadeCaller(caller, instancePollerFacade)
 	return &Machine{facade, tag, life}
 }
+
+var NewStringsWatcher = &newStringsWatcher

--- a/api/instancepoller/instancepoller.go
+++ b/api/instancepoller/instancepoller.go
@@ -1,0 +1,53 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+)
+
+const instancePollerFacade = "InstancePoller"
+
+// API provides access to the InstancePoller API facade.
+type API struct {
+	*common.EnvironWatcher
+
+	facade base.FacadeCaller
+}
+
+// NewAPI creates a new client-side InstancePoller facade.
+func NewAPI(caller base.APICaller) *API {
+	facadeCaller := base.NewFacadeCaller(caller, instancePollerFacade)
+	return &API{
+		EnvironWatcher: common.NewEnvironWatcher(facadeCaller),
+		facade:         facadeCaller,
+	}
+}
+
+// Machine provides access to methods of a state.Machine through the
+// facade.
+func (api *API) Machine(tag names.MachineTag) (*Machine, error) {
+	life, err := common.Life(api.facade, tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &Machine{api.facade, tag, life}, nil
+}
+
+// WatchEnvironMachines return a StringsWatcher reporting waiting for the
+// environment configuration to change.
+func (api *API) WatchEnvironMachines() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	err := api.facade.FacadeCall("WatchEnvironMachines", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return watcher.NewStringsWatcher(api.facade.RawAPICaller(), result), nil
+}

--- a/api/instancepoller/instancepoller.go
+++ b/api/instancepoller/instancepoller.go
@@ -24,6 +24,9 @@ type API struct {
 
 // NewAPI creates a new client-side InstancePoller facade.
 func NewAPI(caller base.APICaller) *API {
+	if caller == nil {
+		panic("caller is nil")
+	}
 	facadeCaller := base.NewFacadeCaller(caller, instancePollerFacade)
 	return &API{
 		EnvironWatcher: common.NewEnvironWatcher(facadeCaller),
@@ -41,6 +44,8 @@ func (api *API) Machine(tag names.MachineTag) (*Machine, error) {
 	return &Machine{api.facade, tag, life}, nil
 }
 
+var newStringsWatcher = watcher.NewStringsWatcher
+
 // WatchEnvironMachines return a StringsWatcher reporting waiting for the
 // environment configuration to change.
 func (api *API) WatchEnvironMachines() (watcher.StringsWatcher, error) {
@@ -49,5 +54,8 @@ func (api *API) WatchEnvironMachines() (watcher.StringsWatcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	return watcher.NewStringsWatcher(api.facade.RawAPICaller(), result), nil
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return newStringsWatcher(api.facade.RawAPICaller(), result), nil
 }

--- a/api/instancepoller/instancepoller_test.go
+++ b/api/instancepoller/instancepoller_test.go
@@ -1,0 +1,186 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller_test
+
+import (
+	"errors"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/instancepoller"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type InstancePollerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&InstancePollerSuite{})
+
+func (s *InstancePollerSuite) TestNewAPI(c *gc.C) {
+	var called int
+	apiCaller := clientErrorAPICaller(c, "Life", nil, &called)
+	api := instancepoller.NewAPI(apiCaller)
+	c.Check(api, gc.NotNil)
+	c.Check(called, gc.Equals, 0)
+
+	// Nothing happens until we actually call something else.
+	m, err := api.Machine(names.MachineTag{})
+	c.Assert(err, gc.ErrorMatches, "client error!")
+	c.Assert(m, gc.IsNil)
+	c.Assert(called, gc.Equals, 1)
+}
+
+func (s *InstancePollerSuite) TestNewAPIWithNilCaller(c *gc.C) {
+	panicFunc := func() { instancepoller.NewAPI(nil) }
+	c.Assert(panicFunc, gc.PanicMatches, "caller is nil")
+}
+
+func (s *InstancePollerSuite) TestMachineCallsLife(c *gc.C) {
+	// We have tested separately the Life method, here we just check
+	// it's called internally.
+	var called int
+	expectedResults := params.LifeResults{
+		Results: []params.LifeResult{{Life: "working"}},
+	}
+	apiCaller := successAPICaller(c, "Life", entitiesArgs, expectedResults, &called)
+	api := instancepoller.NewAPI(apiCaller)
+	m, err := api.Machine(names.NewMachineTag("42"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, gc.Equals, 1)
+	c.Assert(m.Life(), gc.Equals, params.Life("working"))
+	c.Assert(m.Id(), gc.Equals, "42")
+}
+
+func (s *InstancePollerSuite) TestWatchEnvironMachinesSuccess(c *gc.C) {
+	// We're not testing the watcher logic here as it's already tested elsewhere.
+	var numFacadeCalls int
+	var numWatcherCalls int
+	expectResult := params.StringsWatchResult{
+		StringsWatcherId: "42",
+		Changes:          []string{"foo", "bar"},
+	}
+	watcherFunc := func(caller base.APICaller, result params.StringsWatchResult) watcher.StringsWatcher {
+		numWatcherCalls++
+		c.Check(caller, gc.NotNil)
+		c.Check(result, jc.DeepEquals, expectResult)
+		return nil
+	}
+	s.PatchValue(instancepoller.NewStringsWatcher, watcherFunc)
+
+	apiCaller := successAPICaller(c, "WatchEnvironMachines", nil, expectResult, &numFacadeCalls)
+
+	api := instancepoller.NewAPI(apiCaller)
+	w, err := api.WatchEnvironMachines()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(numFacadeCalls, gc.Equals, 1)
+	c.Assert(numWatcherCalls, gc.Equals, 1)
+	c.Assert(w, gc.IsNil)
+}
+
+func (s *InstancePollerSuite) TestWatchEnvironMachinesClientError(c *gc.C) {
+	var called int
+	apiCaller := clientErrorAPICaller(c, "WatchEnvironMachines", nil, &called)
+	api := instancepoller.NewAPI(apiCaller)
+	w, err := api.WatchEnvironMachines()
+	c.Assert(err, gc.ErrorMatches, "client error!")
+	c.Assert(w, gc.IsNil)
+	c.Assert(called, gc.Equals, 1)
+}
+
+func (s *InstancePollerSuite) TestWatchEnvironMachinesServerError(c *gc.C) {
+	var called int
+	expectedResults := params.StringsWatchResult{
+		Error: apiservertesting.ServerError("server boom!"),
+	}
+	apiCaller := successAPICaller(c, "WatchEnvironMachines", nil, expectedResults, &called)
+
+	api := instancepoller.NewAPI(apiCaller)
+	w, err := api.WatchEnvironMachines()
+	c.Assert(err, gc.ErrorMatches, "server boom!")
+	c.Assert(called, gc.Equals, 1)
+	c.Assert(w, gc.IsNil)
+}
+
+func (s *InstancePollerSuite) TestWatchForEnvironConfigChangesClientError(c *gc.C) {
+	// We're not testing the success case as we're not patching the
+	// NewNotifyWatcher call the embedded EnvironWatcher is calling.
+	var called int
+	apiCaller := clientErrorAPICaller(c, "WatchForEnvironConfigChanges", nil, &called)
+
+	api := instancepoller.NewAPI(apiCaller)
+	w, err := api.WatchForEnvironConfigChanges()
+	c.Assert(err, gc.ErrorMatches, "client error!")
+	c.Assert(called, gc.Equals, 1)
+	c.Assert(w, gc.IsNil)
+}
+
+func (s *InstancePollerSuite) TestEnvironConfigSuccess(c *gc.C) {
+	var called int
+	expectedConfig := coretesting.EnvironConfig(c)
+	expectedResults := params.EnvironConfigResult{
+		Config: params.EnvironConfig(expectedConfig.AllAttrs()),
+	}
+	apiCaller := successAPICaller(c, "EnvironConfig", nil, expectedResults, &called)
+
+	api := instancepoller.NewAPI(apiCaller)
+	cfg, err := api.EnvironConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, gc.Equals, 1)
+	c.Assert(cfg, jc.DeepEquals, expectedConfig)
+}
+
+func (s *InstancePollerSuite) TestEnvironConfigClientError(c *gc.C) {
+	var called int
+	apiCaller := clientErrorAPICaller(c, "EnvironConfig", nil, &called)
+	api := instancepoller.NewAPI(apiCaller)
+	cfg, err := api.EnvironConfig()
+	c.Assert(err, gc.ErrorMatches, "client error!")
+	c.Assert(cfg, gc.IsNil)
+	c.Assert(called, gc.Equals, 1)
+}
+
+func (s *InstancePollerSuite) TestEnvironConfigServerError(c *gc.C) {
+	var called int
+	expectResults := params.EnvironConfigResult{
+		Config: params.EnvironConfig{"type": "foo"},
+	}
+	apiCaller := successAPICaller(c, "EnvironConfig", nil, expectResults, &called)
+
+	api := instancepoller.NewAPI(apiCaller)
+	cfg, err := api.EnvironConfig()
+	c.Assert(err, gc.NotNil) // the actual error doesn't matter
+	c.Assert(called, gc.Equals, 1)
+	c.Assert(cfg, gc.IsNil)
+}
+
+func clientErrorAPICaller(c *gc.C, method string, expectArgs interface{}, numCalls *int) base.APICaller {
+	args := &apitesting.CheckArgs{
+		Facade:        "InstancePoller",
+		VersionIsZero: true,
+		IdIsEmpty:     true,
+		Method:        method,
+		Args:          expectArgs,
+	}
+	return apitesting.CheckingAPICaller(c, args, numCalls, errors.New("client error!"))
+}
+
+func successAPICaller(c *gc.C, method string, expectArgs, useResults interface{}, numCalls *int) base.APICaller {
+	args := &apitesting.CheckArgs{
+		Facade:        "InstancePoller",
+		VersionIsZero: true,
+		IdIsEmpty:     true,
+		Method:        method,
+		Args:          expectArgs,
+		Results:       useResults,
+	}
+	return apitesting.CheckingAPICaller(c, args, numCalls, nil)
+}

--- a/api/instancepoller/machine.go
+++ b/api/instancepoller/machine.go
@@ -1,0 +1,189 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+)
+
+// Machine represents a juju machine as seen by an instancepoller
+// worker.
+type Machine struct {
+	facade base.FacadeCaller
+
+	tag  names.MachineTag
+	life params.Life
+}
+
+// Id returns the machine's id.
+func (m *Machine) Id() string {
+	return m.tag.Id()
+}
+
+// Tag returns the machine's tag.
+func (m *Machine) Tag() names.MachineTag {
+	return m.tag
+}
+
+// String returns the machine as a string.
+func (m *Machine) String() string {
+	return m.Id()
+}
+
+// Life returns the machine's lifecycle value.
+func (m *Machine) Life() params.Life {
+	return m.life
+}
+
+// Refresh updates the cached local copy of the machine's data.
+func (m *Machine) Refresh() error {
+	life, err := common.Life(m.facade, m.tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	m.life = life
+	return nil
+}
+
+// Status returns the machine status.
+func (m *Machine) Status() (params.StatusResult, error) {
+	var results params.StatusResults
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: m.tag.String()},
+	}}
+	err := m.facade.FacadeCall("Status", args, &results)
+	if err != nil {
+		return params.StatusResult{}, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		err := errors.Errorf("expected 1 result, got %d", len(results.Results))
+		return params.StatusResult{}, err
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return params.StatusResult{}, result.Error
+	}
+	return result, nil
+}
+
+// IsManual returns whether the machine is manually provisioned.
+func (m *Machine) IsManual() (bool, error) {
+	var results params.BoolResults
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: m.tag.String()},
+	}}
+	err := m.facade.FacadeCall("AreManuallyProvisioned", args, &results)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		err := errors.Errorf("expected 1 result, got %d", len(results.Results))
+		return false, err
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.Result, nil
+}
+
+// InstanceId returns the machine's instance id.
+func (m *Machine) InstanceId() (instance.Id, error) {
+	var results params.StringResults
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: m.tag.String()},
+	}}
+	err := m.facade.FacadeCall("InstanceId", args, &results)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		err := errors.Errorf("expected 1 result, got %d", len(results.Results))
+		return "", err
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return instance.Id(result.Result), nil
+}
+
+// InstanceStatus returns the machine's instance status.
+func (m *Machine) InstanceStatus() (string, error) {
+	var results params.StringResults
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: m.tag.String()},
+	}}
+	err := m.facade.FacadeCall("InstanceStatus", args, &results)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		err := errors.Errorf("expected 1 result, got %d", len(results.Results))
+		return "", err
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return result.Result, nil
+}
+
+// SetInstanceStatus sets the instance status of the machine.
+func (m *Machine) SetInstanceStatus(status string) error {
+	var result params.ErrorResults
+	args := params.SetInstancesStatus{Entities: []params.InstanceStatus{
+		{Tag: m.tag.String(), Status: status},
+	}}
+	err := m.facade.FacadeCall("SetInstancesStatus", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}
+
+// ProviderAddresses returns all addresses of the machine known to the
+// cloud provider.
+func (m *Machine) ProviderAddresses() ([]network.Address, error) {
+	var results params.MachineAddressesResults
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: m.tag.String()},
+	}}
+	err := m.facade.FacadeCall("ProviderAddresses", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		err := errors.Errorf("expected 1 result, got %d", len(results.Results))
+		return nil, err
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return params.NetworkAddresses(result.Addresses), nil
+}
+
+// SetProviderAddresses sets the cached provider addresses for the
+// machine.
+func (m *Machine) SetProviderAddresses(addrs ...network.Address) error {
+	var result params.ErrorResults
+	args := params.SetMachinesAddresses{
+		MachineAddresses: []params.MachineAddresses{{
+			Tag:       m.tag.String(),
+			Addresses: params.FromNetworkAddresses(addrs),
+		}}}
+	err := m.facade.FacadeCall("SetProviderAddresses", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}

--- a/api/instancepoller/machine.go
+++ b/api/instancepoller/machine.go
@@ -143,7 +143,7 @@ func (m *Machine) SetInstanceStatus(status string) error {
 	args := params.SetInstancesStatus{Entities: []params.InstanceStatus{
 		{Tag: m.tag.String(), Status: status},
 	}}
-	err := m.facade.FacadeCall("SetInstancesStatus", args, &result)
+	err := m.facade.FacadeCall("SetInstanceStatus", args, &result)
 	if err != nil {
 		return err
 	}

--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -1,0 +1,38 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/instancepoller"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type MachineSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&MachineSuite{})
+
+func (s *MachineSuite) TestNonFacadeMethods(c *gc.C) {
+	nopCaller := apitesting.APICallerFunc(
+		func(_ string, _ int, _, _ string, _, _ interface{}) error {
+			c.Fatalf("facade call was not expected")
+			return errors.New("boom")
+		},
+	)
+	tag := names.NewMachineTag("42")
+	machine := instancepoller.NewMachine(nopCaller, tag, params.Dying)
+
+	c.Assert(machine.Id(), gc.Equals, "42")
+	c.Assert(machine.Tag(), jc.DeepEquals, tag)
+	c.Assert(machine.String(), gc.Equals, "42")
+	c.Assert(machine.Life(), gc.Equals, params.Dying)
+}

--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -4,7 +4,9 @@
 package instancepoller_test
 
 import (
-	"github.com/juju/errors"
+	"reflect"
+	"time"
+
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -12,27 +14,321 @@ import (
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/instancepoller"
 	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type MachineSuite struct {
 	coretesting.BaseSuite
+
+	tag names.MachineTag
 }
 
 var _ = gc.Suite(&MachineSuite{})
+
+func (s *MachineSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.tag = names.NewMachineTag("42")
+}
 
 func (s *MachineSuite) TestNonFacadeMethods(c *gc.C) {
 	nopCaller := apitesting.APICallerFunc(
 		func(_ string, _ int, _, _ string, _, _ interface{}) error {
 			c.Fatalf("facade call was not expected")
-			return errors.New("boom")
+			return nil
 		},
 	)
-	tag := names.NewMachineTag("42")
-	machine := instancepoller.NewMachine(nopCaller, tag, params.Dying)
+	machine := instancepoller.NewMachine(nopCaller, s.tag, params.Dying)
 
 	c.Assert(machine.Id(), gc.Equals, "42")
-	c.Assert(machine.Tag(), jc.DeepEquals, tag)
+	c.Assert(machine.Tag(), jc.DeepEquals, s.tag)
 	c.Assert(machine.String(), gc.Equals, "42")
 	c.Assert(machine.Life(), gc.Equals, params.Dying)
+}
+
+// methodWrapper wraps a Machine method call and returns the error,
+// ignoring the result (if any).
+type methodWrapper func(*instancepoller.Machine) error
+
+// machineErrorTests contains all the necessary information to test
+// how each Machine method handles client- and server-side API errors,
+// as well as the case when the server-side API returns more results
+// than expected.
+var machineErrorTests = []struct {
+	method     string // only for logging
+	wrapper    methodWrapper
+	resultsRef interface{} // an instance of the server-side method's result type
+}{{
+	method:     "Refresh",
+	wrapper:    (*instancepoller.Machine).Refresh,
+	resultsRef: params.LifeResults{},
+}, {
+	method: "IsManual",
+	wrapper: func(m *instancepoller.Machine) error {
+		_, err := m.IsManual()
+		return err
+	},
+	resultsRef: params.BoolResults{},
+}, {
+	method: "InstanceId",
+	wrapper: func(m *instancepoller.Machine) error {
+		_, err := m.InstanceId()
+		return err
+	},
+	resultsRef: params.StringResults{},
+}, {
+	method: "Status",
+	wrapper: func(m *instancepoller.Machine) error {
+		_, err := m.Status()
+		return err
+	},
+	resultsRef: params.StatusResults{},
+}, {
+	method: "InstanceStatus",
+	wrapper: func(m *instancepoller.Machine) error {
+		_, err := m.InstanceStatus()
+		return err
+	},
+	resultsRef: params.StringResults{},
+}, {
+	method: "SetInstanceStatus",
+	wrapper: func(m *instancepoller.Machine) error {
+		return m.SetInstanceStatus("")
+	},
+	resultsRef: params.ErrorResults{},
+}, {
+	method: "ProviderAddresses",
+	wrapper: func(m *instancepoller.Machine) error {
+		_, err := m.ProviderAddresses()
+		return err
+	},
+	resultsRef: params.MachineAddressesResults{},
+}, {
+	method: "SetProviderAddresses",
+	wrapper: func(m *instancepoller.Machine) error {
+		return m.SetProviderAddresses()
+	},
+	resultsRef: params.ErrorResults{},
+}}
+
+func (s *MachineSuite) TestClientError(c *gc.C) {
+	for i, test := range machineErrorTests {
+		c.Logf("test #%d: %s", i, test.method)
+		s.CheckClientError(c, test.wrapper)
+	}
+}
+
+func (s *MachineSuite) TestServerError(c *gc.C) {
+	err := apiservertesting.ServerError("server error!")
+	expected := err.Error()
+	for i, test := range machineErrorTests {
+		c.Logf("test #%d: %s", i, test.method)
+		results := MakeResultsWithErrors(test.resultsRef, err, 1)
+		s.CheckServerError(c, test.wrapper, expected, results)
+	}
+}
+
+func (s *MachineSuite) TestTooManyResultsServerError(c *gc.C) {
+	err := apiservertesting.ServerError("some error")
+	expected := "expected 1 result, got 2"
+	for i, test := range machineErrorTests {
+		c.Logf("test #%d: %s", i, test.method)
+		results := MakeResultsWithErrors(test.resultsRef, err, 2)
+		s.CheckServerError(c, test.wrapper, expected, results)
+	}
+}
+
+func (s *MachineSuite) TestRefreshSuccess(c *gc.C) {
+	var called int
+	results := params.LifeResults{
+		Results: []params.LifeResult{{Life: params.Dying}},
+	}
+	apiCaller := successAPICaller(c, "Life", entitiesArgs, results, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	c.Check(machine.Refresh(), jc.ErrorIsNil)
+	c.Check(machine.Life(), gc.Equals, params.Dying)
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) TestStatusSuccess(c *gc.C) {
+	var called int
+	now := time.Now()
+	expectStatus := params.StatusResult{
+		Status: "foo",
+		Info:   "bar",
+		Data: map[string]interface{}{
+			"int":    42,
+			"bool":   true,
+			"float":  3.14,
+			"slice":  []string{"a", "b"},
+			"map":    map[int]string{5: "five"},
+			"string": "argh",
+		},
+		Since: &now,
+	}
+	results := params.StatusResults{Results: []params.StatusResult{expectStatus}}
+	apiCaller := successAPICaller(c, "Status", entitiesArgs, results, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	status, err := machine.Status()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(status, jc.DeepEquals, expectStatus)
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) TestIsManualSuccess(c *gc.C) {
+	var called int
+	results := params.BoolResults{
+		Results: []params.BoolResult{{Result: true}},
+	}
+	apiCaller := successAPICaller(c, "AreManuallyProvisioned", entitiesArgs, results, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	isManual, err := machine.IsManual()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(isManual, jc.IsTrue)
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) TestInstanceIdSuccess(c *gc.C) {
+	var called int
+	results := params.StringResults{
+		Results: []params.StringResult{{Result: "i-foo"}},
+	}
+	apiCaller := successAPICaller(c, "InstanceId", entitiesArgs, results, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	instId, err := machine.InstanceId()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(instId, gc.Equals, instance.Id("i-foo"))
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) TestInstanceStatusSuccess(c *gc.C) {
+	var called int
+	results := params.StringResults{
+		Results: []params.StringResult{{Result: "A-OK"}},
+	}
+	apiCaller := successAPICaller(c, "InstanceStatus", entitiesArgs, results, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	status, err := machine.InstanceStatus()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(status, gc.Equals, "A-OK")
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) TestSetInstanceStatusSuccess(c *gc.C) {
+	var called int
+	expectArgs := params.SetInstancesStatus{
+		Entities: []params.InstanceStatus{{
+			Tag:    "machine-42",
+			Status: "RUNNING",
+		}}}
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{Error: nil}},
+	}
+	apiCaller := successAPICaller(c, "SetInstancesStatus", expectArgs, results, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	err := machine.SetInstanceStatus("RUNNING")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) TestProviderAddressesSuccess(c *gc.C) {
+	var called int
+	addresses := network.NewAddresses("2001:db8::1", "0.1.2.3")
+	results := params.MachineAddressesResults{
+		Results: []params.MachineAddressesResult{{
+			Addresses: params.FromNetworkAddresses(addresses),
+		}}}
+	apiCaller := successAPICaller(c, "ProviderAddresses", entitiesArgs, results, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	addrs, err := machine.ProviderAddresses()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(addrs, jc.DeepEquals, addresses)
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) TestSetProviderAddressesSuccess(c *gc.C) {
+	var called int
+	addresses := network.NewAddresses("2001:db8::1", "0.1.2.3")
+	expectArgs := params.SetMachinesAddresses{
+		MachineAddresses: []params.MachineAddresses{{
+			Tag:       "machine-42",
+			Addresses: params.FromNetworkAddresses(addresses),
+		}}}
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{Error: nil}},
+	}
+	apiCaller := successAPICaller(c, "SetProviderAddresses", expectArgs, results, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	err := machine.SetProviderAddresses(addresses...)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) CheckClientError(c *gc.C, wf methodWrapper) {
+	var called int
+	apiCaller := clientErrorAPICaller(c, "", nil, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	c.Check(wf(machine), gc.ErrorMatches, "client error!")
+	c.Check(called, gc.Equals, 1)
+}
+
+func (s *MachineSuite) CheckServerError(c *gc.C, wf methodWrapper, expectErr string, serverResults interface{}) {
+	var called int
+	apiCaller := successAPICaller(c, "", nil, serverResults, &called)
+	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
+	c.Check(wf(machine), gc.ErrorMatches, expectErr)
+	c.Check(called, gc.Equals, 1)
+}
+
+var entitiesArgs = params.Entities{
+	Entities: []params.Entity{{Tag: "machine-42"}},
+}
+
+// MakeResultsWithErrors constructs a new instance of the results type
+// (from apiserver/params), matching the given resultsRef, finds its
+// first field (expected to be a slice, usually "Results") and adds
+// howMany elements to it, setting the Error field of each element to
+// err.
+//
+// This helper makes a few assumptions:
+// - resultsRef's type is a struct and has a single field (commonly - "Results")
+// - that field is a slice of structs, which have an Error field
+// - the Error field is of type *params.Error
+//
+// Example:
+//   err := apiservertesting.ServerError("foo")
+//   r := MakeResultsWithErrors(params.LifeResults{}, err, 2)
+// is equvalent to:
+//   r := params.LifeResults{Results: []params.LifeResult{{Error: err}, {Error: err}}}
+//
+func MakeResultsWithErrors(resultsRef interface{}, err *params.Error, howMany int) interface{} {
+	// Make a new instance of the same type as resultsRef.
+	resultsType := reflect.TypeOf(resultsRef)
+	newResults := reflect.New(resultsType).Elem()
+
+	// Make a new empty slice for the results.
+	sliceField := newResults.Field(0)
+	newSlice := reflect.New(sliceField.Type()).Elem()
+
+	// Make a new result of the slice's element type and set it to err.
+	newResult := reflect.New(newSlice.Type().Elem()).Elem()
+	newResult.FieldByName("Error").Set(reflect.ValueOf(err))
+
+	// Append howMany copies of newResult to the slice.
+	for howMany > 0 {
+		sliceField.Set(reflect.Append(sliceField, newResult))
+		howMany--
+	}
+
+	return newResults.Interface()
+}
+
+// TODO(dimitern): Move this and MakeResultsWithErrors in params/testing ?
+func (MachineSuite) TestMakeResultsWithErrors(c *gc.C) {
+	err := apiservertesting.ServerError("foo")
+	r1 := MakeResultsWithErrors(params.LifeResults{}, err, 2)
+	r2 := params.LifeResults{Results: []params.LifeResult{{Error: err}, {Error: err}}}
+	c.Assert(r1, jc.DeepEquals, r2)
 }

--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -226,7 +226,7 @@ func (s *MachineSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 	results := params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	}
-	apiCaller := successAPICaller(c, "SetInstancesStatus", expectArgs, results, &called)
+	apiCaller := successAPICaller(c, "SetInstanceStatus", expectArgs, results, &called)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	err := machine.SetInstanceStatus("RUNNING")
 	c.Check(err, jc.ErrorIsNil)

--- a/api/instancepoller/package_test.go
+++ b/api/instancepoller/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/state.go
+++ b/api/state.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/api/diskmanager"
 	"github.com/juju/juju/api/environment"
 	"github.com/juju/juju/api/firewaller"
+	"github.com/juju/juju/api/instancepoller"
 	"github.com/juju/juju/api/keyupdater"
 	apilogger "github.com/juju/juju/api/logger"
 	"github.com/juju/juju/api/machiner"
@@ -331,6 +332,11 @@ func (st *State) Logger() *apilogger.State {
 // KeyUpdater returns access to the KeyUpdater API
 func (st *State) KeyUpdater() *keyupdater.State {
 	return keyupdater.NewState(st)
+}
+
+// InstancePoller returns access to the InstancePoller API
+func (st *State) InstancePoller() *instancepoller.API {
+	return instancepoller.NewAPI(st)
 }
 
 // CharmRevisionUpdater returns access to the CharmRevisionUpdater API

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/juju/juju/apiserver/environmentmanager"
 	_ "github.com/juju/juju/apiserver/firewaller"
 	_ "github.com/juju/juju/apiserver/imagemanager"
+	_ "github.com/juju/juju/apiserver/instancepoller"
 	_ "github.com/juju/juju/apiserver/keymanager"
 	_ "github.com/juju/juju/apiserver/keyupdater"
 	_ "github.com/juju/juju/apiserver/logger"

--- a/apiserver/common/interfaces.go
+++ b/apiserver/common/interfaces.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 )
 
@@ -74,6 +75,24 @@ func AuthNever() GetAuthFunc {
 	return func() (AuthFunc, error) {
 		return func(tag names.Tag) bool {
 			return false
+		}, nil
+	}
+}
+
+// AuthFuncForTagKind returns a GetAuthFunc which creates an AuthFunc
+// allowing only the given tag kind and denies all others. Passing an
+// empty kind is an error.
+func AuthFuncForTagKind(kind string) GetAuthFunc {
+	return func() (AuthFunc, error) {
+		if kind == "" {
+			return nil, errors.Errorf("tag kind cannot be empty")
+		}
+		return func(tag names.Tag) bool {
+			// Allow only the given tag kind.
+			if tag == nil {
+				return false
+			}
+			return tag.Kind() == kind
 		}, nil
 	}
 }

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -48,10 +48,10 @@ func NewFirewallerAPI(
 		return nil, common.ErrPerm
 	}
 	// Set up the various authorization checkers.
-	accessEnviron := getAuthFuncForTagKind(names.EnvironTagKind)
-	accessUnit := getAuthFuncForTagKind(names.UnitTagKind)
-	accessService := getAuthFuncForTagKind(names.ServiceTagKind)
-	accessMachine := getAuthFuncForTagKind(names.MachineTagKind)
+	accessEnviron := common.AuthFuncForTagKind(names.EnvironTagKind)
+	accessUnit := common.AuthFuncForTagKind(names.UnitTagKind)
+	accessService := common.AuthFuncForTagKind(names.ServiceTagKind)
+	accessMachine := common.AuthFuncForTagKind(names.MachineTagKind)
 	accessUnitOrService := common.AuthEither(accessUnit, accessService)
 	accessUnitServiceOrMachine := common.AuthEither(accessUnitOrService, accessMachine)
 
@@ -327,18 +327,4 @@ func (f *FirewallerAPI) getMachine(canAccess common.AuthFunc, tag names.MachineT
 	// The authorization function guarantees that the tag represents a
 	// machine.
 	return entity.(*state.Machine), nil
-}
-
-// getAuthFuncForTagKind returns a GetAuthFunc which creates an
-// AuthFunc allowing only the given tag kind and denies all
-// others. In the special case where a single empty string is given,
-// it's assumed only environment tags are allowed, but not specified
-// (for now).
-func getAuthFuncForTagKind(kind string) common.GetAuthFunc {
-	return func() (common.AuthFunc, error) {
-		return func(tag names.Tag) bool {
-			// Allow only the given tag kind.
-			return tag.Kind() == kind
-		}, nil
-	}
 }

--- a/apiserver/instancepoller/export_test.go
+++ b/apiserver/instancepoller/export_test.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller
+
+import (
+	"github.com/juju/juju/state"
+)
+
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}
+
+func PatchState(p Patcher, st StateInterface) {
+	p.PatchValue(&getState, func(*state.State) StateInterface {
+		return st
+	})
+}

--- a/apiserver/instancepoller/instancepoller.go
+++ b/apiserver/instancepoller/instancepoller.go
@@ -1,0 +1,215 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller
+
+import (
+	"fmt"
+
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("InstancePoller", 1, NewInstancePollerAPI)
+}
+
+var logger = loggo.GetLogger("juju.apiserver.instancepoller")
+
+// InstancePollerAPI provides access to the InstancePoller API facade.
+type InstancePollerAPI struct {
+	*common.LifeGetter
+	*common.EnvironWatcher
+	*common.EnvironMachinesWatcher
+	*common.InstanceIdGetter
+	*common.StatusGetter
+
+	st            StateInterface
+	resources     *common.Resources
+	authorizer    common.Authorizer
+	accessMachine common.GetAuthFunc
+}
+
+// NewInstancePollerAPI creates a new server-side InstancePoller API
+// facade.
+func NewInstancePollerAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*InstancePollerAPI, error) {
+
+	if !authorizer.AuthEnvironManager() {
+		// InstancePoller must run as environment manager.
+		return nil, common.ErrPerm
+	}
+	accessMachine := common.AuthFuncForTagKind(names.MachineTagKind)
+	sti := getState(st)
+
+	// Life() is supported for machines.
+	lifeGetter := common.NewLifeGetter(
+		sti,
+		accessMachine,
+	)
+	// EnvironConfig() and WatchForEnvironConfigChanges() are allowed
+	// with unrestriced access.
+	environWatcher := common.NewEnvironWatcher(
+		sti,
+		resources,
+		authorizer,
+	)
+	// WatchEnvironMachines() is allowed with unrestricted access.
+	machinesWatcher := common.NewEnvironMachinesWatcher(
+		sti,
+		resources,
+		authorizer,
+	)
+	// InstanceId() is supported for machines.
+	instanceIdGetter := common.NewInstanceIdGetter(
+		sti,
+		accessMachine,
+	)
+	// Status() is supported for machines.
+	statusGetter := common.NewStatusGetter(
+		sti,
+		accessMachine,
+	)
+
+	return &InstancePollerAPI{
+		LifeGetter:             lifeGetter,
+		EnvironWatcher:         environWatcher,
+		EnvironMachinesWatcher: machinesWatcher,
+		InstanceIdGetter:       instanceIdGetter,
+		StatusGetter:           statusGetter,
+		st:                     sti,
+		resources:              resources,
+		authorizer:             authorizer,
+		accessMachine:          accessMachine,
+	}, nil
+}
+
+func (a *InstancePollerAPI) getOneMachine(tag string, canAccess common.AuthFunc) (StateMachine, error) {
+	machineTag, err := names.ParseMachineTag(tag)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccess(machineTag) {
+		return nil, common.ErrPerm
+	}
+	entity, err := a.st.FindEntity(machineTag)
+	if err != nil {
+		return nil, err
+	}
+	machine, ok := entity.(StateMachine)
+	if !ok {
+		return nil, common.NotSupportedError(
+			machineTag, fmt.Sprintf("expected machine, got %T", entity),
+		)
+	}
+	return machine, nil
+}
+
+// ProviderAddresses returns the list of all known provider addresses
+// for each given entity. Only machine tags are accepted.
+func (a *InstancePollerAPI) ProviderAddresses(args params.Entities) (params.MachineAddressesResults, error) {
+	result := params.MachineAddressesResults{
+		Results: make([]params.MachineAddressesResult, len(args.Entities)),
+	}
+	canAccess, err := a.accessMachine()
+	if err != nil {
+		return result, err
+	}
+	for i, arg := range args.Entities {
+		machine, err := a.getOneMachine(arg.Tag, canAccess)
+		if err == nil {
+			addrs := machine.ProviderAddresses()
+			result.Results[i].Addresses = params.FromNetworkAddresses(addrs)
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+// SetProviderAddresses updates the list of known provider addresses
+// for each given entity. Only machine tags are accepted.
+func (a *InstancePollerAPI) SetProviderAddresses(args params.SetMachinesAddresses) (params.ErrorResults, error) {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.MachineAddresses)),
+	}
+	canAccess, err := a.accessMachine()
+	if err != nil {
+		return result, err
+	}
+	for i, arg := range args.MachineAddresses {
+		machine, err := a.getOneMachine(arg.Tag, canAccess)
+		if err == nil {
+			addrsToSet := params.NetworkAddresses(arg.Addresses)
+			err = machine.SetProviderAddresses(addrsToSet...)
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+// InstanceStatus returns the instance status for each given entity.
+// Only machine tags are accepted.
+func (a *InstancePollerAPI) InstanceStatus(args params.Entities) (params.StringResults, error) {
+	result := params.StringResults{
+		Results: make([]params.StringResult, len(args.Entities)),
+	}
+	canAccess, err := a.accessMachine()
+	if err != nil {
+		return result, err
+	}
+	for i, arg := range args.Entities {
+		machine, err := a.getOneMachine(arg.Tag, canAccess)
+		if err == nil {
+			result.Results[i].Result, err = machine.InstanceStatus()
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+// SetInstanceStatus updates the instance status for each given
+// entity. Only machine tags are accepted.
+func (a *InstancePollerAPI) SetInstanceStatus(args params.SetInstancesStatus) (params.ErrorResults, error) {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Entities)),
+	}
+	canAccess, err := a.accessMachine()
+	if err != nil {
+		return result, err
+	}
+	for i, arg := range args.Entities {
+		machine, err := a.getOneMachine(arg.Tag, canAccess)
+		if err == nil {
+			err = machine.SetInstanceStatus(arg.Status)
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+// AreManuallyProvisioned returns whether each given entity is
+// manually provisioned or not. Only machine tags are accepted.
+func (a *InstancePollerAPI) AreManuallyProvisioned(args params.Entities) (params.BoolResults, error) {
+	result := params.BoolResults{
+		Results: make([]params.BoolResult, len(args.Entities)),
+	}
+	canAccess, err := a.accessMachine()
+	if err != nil {
+		return result, err
+	}
+	for i, arg := range args.Entities {
+		machine, err := a.getOneMachine(arg.Tag, canAccess)
+		if err == nil {
+			result.Results[i].Result, err = machine.IsManual()
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}

--- a/apiserver/instancepoller/instancepoller_test.go
+++ b/apiserver/instancepoller/instancepoller_test.go
@@ -1,0 +1,959 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/instancepoller"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type InstancePollerSuite struct {
+	coretesting.BaseSuite
+
+	st         *mockState
+	api        *instancepoller.InstancePollerAPI
+	authoriser apiservertesting.FakeAuthorizer
+	resources  *common.Resources
+}
+
+var _ = gc.Suite(&InstancePollerSuite{})
+
+func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.authoriser = apiservertesting.FakeAuthorizer{
+		EnvironManager: true,
+	}
+	s.resources = common.NewResources()
+	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
+
+	s.st = NewMockState()
+	instancepoller.PatchState(s, s.st)
+
+	var err error
+	s.api, err = instancepoller.NewInstancePollerAPI(nil, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *InstancePollerSuite) TestNewInstancePollerAPIRequiresEnvironManager(c *gc.C) {
+	anAuthoriser := s.authoriser
+	anAuthoriser.EnvironManager = false
+	api, err := instancepoller.NewInstancePollerAPI(nil, s.resources, anAuthoriser)
+	c.Assert(api, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *InstancePollerSuite) TestEnvironConfigFailure(c *gc.C) {
+	s.st.SetErrors(errors.New("boom"))
+
+	result, err := s.api.EnvironConfig()
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(result, jc.DeepEquals, params.EnvironConfigResult{})
+
+	s.st.CheckCallNames(c, "EnvironConfig")
+}
+
+func (s *InstancePollerSuite) TestEnvironConfigSuccess(c *gc.C) {
+	envConfig := coretesting.EnvironConfig(c)
+	s.st.SetConfig(c, envConfig)
+
+	result, err := s.api.EnvironConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.EnvironConfigResult{
+		Config: envConfig.AllAttrs(),
+	})
+
+	s.st.CheckCallNames(c, "EnvironConfig")
+}
+
+func (s *InstancePollerSuite) TestWatchForEnvironConfigChangesFailure(c *gc.C) {
+	// Force the Changes() method of the mock watcher to return a
+	// closed channel by setting an error.
+	s.st.SetErrors(errors.New("boom"))
+
+	result, err := s.api.WatchForEnvironConfigChanges()
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(result, jc.DeepEquals, params.NotifyWatchResult{})
+
+	c.Assert(s.resources.Count(), gc.Equals, 0) // no watcher registered
+	s.st.CheckCallNames(c, "WatchForEnvironConfigChanges")
+}
+
+func (s *InstancePollerSuite) TestWatchForEnvironConfigChangesSuccess(c *gc.C) {
+	result, err := s.api.WatchForEnvironConfigChanges()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.NotifyWatchResult{
+		Error: nil, NotifyWatcherId: "1",
+	})
+
+	// Verify the watcher resource was registered.
+	c.Assert(s.resources.Count(), gc.Equals, 1)
+	resource := s.resources.Get("1")
+	defer statetesting.AssertStop(c, resource)
+
+	// Check that the watcher has consumed the initial event
+	wc := statetesting.NewNotifyWatcherC(c, s.st, resource.(state.NotifyWatcher))
+	wc.AssertNoChange()
+
+	s.st.CheckCallNames(c, "WatchForEnvironConfigChanges")
+
+	// Try changing the config to verify an event is reported.
+	envConfig := coretesting.EnvironConfig(c)
+	s.st.SetConfig(c, envConfig)
+	wc.AssertOneChange()
+}
+
+func (s *InstancePollerSuite) TestWatchEnvironMachinesFailure(c *gc.C) {
+	// Force the Changes() method of the mock watcher to return a
+	// closed channel by setting an error.
+	s.st.SetErrors(errors.Errorf("boom"))
+
+	result, err := s.api.WatchEnvironMachines()
+	c.Assert(err, gc.ErrorMatches, "cannot obtain initial environment machines: boom")
+	c.Assert(result, jc.DeepEquals, params.StringsWatchResult{})
+
+	c.Assert(s.resources.Count(), gc.Equals, 0) // no watcher registered
+	s.st.CheckCallNames(c, "WatchEnvironMachines")
+}
+
+func (s *InstancePollerSuite) TestWatchEnvironMachinesSuccess(c *gc.C) {
+	// Add a couple of machines.
+	s.st.SetMachineInfo(c, machineInfo{id: "2"})
+	s.st.SetMachineInfo(c, machineInfo{id: "1"})
+
+	expectedResult := params.StringsWatchResult{
+		Error:            nil,
+		StringsWatcherId: "1",
+		Changes:          []string{"1", "2"}, // initial event (sorted ids)
+	}
+	result, err := s.api.WatchEnvironMachines()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, expectedResult)
+
+	// Verify the watcher resource was registered.
+	c.Assert(s.resources.Count(), gc.Equals, 1)
+	resource1 := s.resources.Get("1")
+	defer func() {
+		if resource1 != nil {
+			statetesting.AssertStop(c, resource1)
+		}
+	}()
+
+	// Check that the watcher has consumed the initial event
+	wc1 := statetesting.NewStringsWatcherC(c, s.st, resource1.(state.StringsWatcher))
+	wc1.AssertNoChange()
+
+	s.st.CheckCallNames(c, "WatchEnvironMachines")
+
+	// Add another watcher to verify events coalescence.
+	result, err = s.api.WatchEnvironMachines()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedResult.StringsWatcherId = "2"
+	c.Assert(result, jc.DeepEquals, expectedResult)
+	s.st.CheckCallNames(c, "WatchEnvironMachines", "WatchEnvironMachines")
+	c.Assert(s.resources.Count(), gc.Equals, 2)
+	resource2 := s.resources.Get("2")
+	defer statetesting.AssertStop(c, resource2)
+	wc2 := statetesting.NewStringsWatcherC(c, s.st, resource2.(state.StringsWatcher))
+	wc2.AssertNoChange()
+
+	// Remove machine 1, check it's reported.
+	s.st.RemoveMachine(c, "1")
+	wc1.AssertChangeInSingleEvent("1")
+
+	// Make separate changes, check they're combined.
+	s.st.SetMachineInfo(c, machineInfo{id: "2", life: state.Dying})
+	s.st.SetMachineInfo(c, machineInfo{id: "3"})
+	s.st.RemoveMachine(c, "42") // ignored
+	wc1.AssertChangeInSingleEvent("2", "3")
+	wc2.AssertChangeInSingleEvent("1", "2", "3")
+
+	// Stop the first watcher and assert its changes chan is closed.
+	c.Assert(resource1.Stop(), jc.ErrorIsNil)
+	wc1.AssertClosed()
+	resource1 = nil
+}
+
+func (s *InstancePollerSuite) TestLifeSuccess(c *gc.C) {
+	s.st.SetMachineInfo(c, machineInfo{id: "1", life: state.Alive})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", life: state.Dying})
+	s.st.SetMachineInfo(c, machineInfo{id: "3", life: state.Dead})
+
+	result, err := s.api.Life(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-3"},
+			{Tag: "machine-42"},
+			{Tag: "service-unknown"},
+			{Tag: "invalid-tag"},
+			{Tag: "unit-missing-1"},
+			{Tag: ""},
+			{Tag: "42"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.LifeResults{
+		Results: []params.LifeResult{
+			{Life: params.Alive},
+			{Life: params.Dying},
+			{Life: params.Dead},
+			{Error: apiservertesting.NotFoundError("machine 42")},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "Life",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "Life",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}, {
+		FuncName: "Life",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("42")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestLifeFailure(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("pow!"),                   // m1 := FindEntity("1"); Life not called
+		nil,                                  // m2 := FindEntity("2")
+		errors.New("FAIL"),                   // m2.Life() - unused
+		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
+	)
+	s.st.SetMachineInfo(c, machineInfo{id: "1", life: state.Alive})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", life: state.Dead})
+	s.st.SetMachineInfo(c, machineInfo{id: "3", life: state.Dying})
+
+	result, err := s.api.Life(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-3"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.LifeResults{
+		Results: []params.LifeResult{
+			{Error: apiservertesting.ServerError("pow!")},
+			{Life: params.Dead},
+			{Error: apiservertesting.NotProvisionedError("42")},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "Life",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestInstanceIdSuccess(c *gc.C) {
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceId: "i-foo"})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceId: ""})
+
+	result, err := s.api.InstanceId(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-42"},
+			{Tag: "service-unknown"},
+			{Tag: "invalid-tag"},
+			{Tag: "unit-missing-1"},
+			{Tag: ""},
+			{Tag: "42"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Result: "i-foo"},
+			{Result: ""},
+			{Error: apiservertesting.NotFoundError("machine 42")},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "InstanceId",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "InstanceId",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("42")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestInstanceIdFailure(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("pow!"),                   // m1 := FindEntity("1"); InstanceId not called
+		nil,                                  // m2 := FindEntity("2")
+		errors.New("FAIL"),                   // m2.InstanceId()
+		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
+	)
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceId: ""})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceId: "i-bar"})
+
+	result, err := s.api.InstanceId(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-3"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Error: apiservertesting.ServerError("pow!")},
+			{Error: apiservertesting.ServerError("FAIL")},
+			{Error: apiservertesting.NotProvisionedError("42")},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "InstanceId",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestStatusSuccess(c *gc.C) {
+	now := time.Now()
+	s1 := state.StatusInfo{
+		Status:  state.StatusError,
+		Message: "not really",
+		Data: map[string]interface{}{
+			"price": 4.2,
+			"bool":  false,
+			"bar":   []string{"a", "b"},
+		},
+		Since: &now,
+	}
+	s2 := state.StatusInfo{}
+	s.st.SetMachineInfo(c, machineInfo{id: "1", status: s1})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", status: s2})
+
+	result, err := s.api.Status(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-42"},
+			{Tag: "service-unknown"},
+			{Tag: "invalid-tag"},
+			{Tag: "unit-missing-1"},
+			{Tag: ""},
+			{Tag: "42"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.StatusResults{
+		Results: []params.StatusResult{
+			{
+				Status: params.StatusError,
+				Info:   s1.Message,
+				Data:   s1.Data,
+				Since:  s1.Since,
+			},
+			{Status: "", Info: "", Data: nil, Since: nil},
+			{Error: apiservertesting.NotFoundError("machine 42")},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ServerError(`"invalid-tag" is not a valid tag`)},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ServerError(`"" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"42" is not a valid tag`)},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "Status",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "Status",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("42")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestStatusFailure(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("pow!"),                   // m1 := FindEntity("1"); Status not called
+		nil,                                  // m2 := FindEntity("2")
+		errors.New("FAIL"),                   // m2.Status()
+		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
+	)
+	s.st.SetMachineInfo(c, machineInfo{id: "1"})
+	s.st.SetMachineInfo(c, machineInfo{id: "2"})
+
+	result, err := s.api.Status(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-3"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.StatusResults{
+		Results: []params.StatusResult{
+			{Error: apiservertesting.ServerError("pow!")},
+			{Error: apiservertesting.ServerError("FAIL")},
+			{Error: apiservertesting.NotProvisionedError("42")},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "Status",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestProviderAddressesSuccess(c *gc.C) {
+	addrs := network.NewAddresses("0.1.2.3", "127.0.0.1", "8.8.8.8")
+	expectedAddresses := params.FromNetworkAddresses(addrs)
+	s.st.SetMachineInfo(c, machineInfo{id: "1", providerAddresses: addrs})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", providerAddresses: nil})
+
+	result, err := s.api.ProviderAddresses(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-42"},
+			{Tag: "service-unknown"},
+			{Tag: "invalid-tag"},
+			{Tag: "unit-missing-1"},
+			{Tag: ""},
+			{Tag: "42"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.MachineAddressesResults{
+		Results: []params.MachineAddressesResult{
+			{Addresses: expectedAddresses},
+			{Addresses: nil},
+			{Error: apiservertesting.NotFoundError("machine 42")},
+			{Error: apiservertesting.ServerError(`"service-unknown" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"invalid-tag" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"unit-missing-1" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"42" is not a valid tag`)},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "ProviderAddresses",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "ProviderAddresses",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("42")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestProviderAddressesFailure(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("pow!"),                   // m1 := FindEntity("1")
+		nil,                                  // m2 := FindEntity("2")
+		errors.New("FAIL"),                   // m2.ProviderAddresses()- unused
+		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
+	)
+	s.st.SetMachineInfo(c, machineInfo{id: "1"})
+	s.st.SetMachineInfo(c, machineInfo{id: "2"})
+
+	result, err := s.api.ProviderAddresses(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-3"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.MachineAddressesResults{
+		Results: []params.MachineAddressesResult{
+			{Error: apiservertesting.ServerError("pow!")},
+			{Addresses: nil},
+			{Error: apiservertesting.NotProvisionedError("42")},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "ProviderAddresses",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestSetProviderAddressesSuccess(c *gc.C) {
+	oldAddrs := network.NewAddresses("0.1.2.3", "127.0.0.1", "8.8.8.8")
+	newAddrs := network.NewAddresses("1.2.3.4", "8.4.4.8", "2001:db8::")
+	s.st.SetMachineInfo(c, machineInfo{id: "1", providerAddresses: oldAddrs})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", providerAddresses: nil})
+
+	result, err := s.api.SetProviderAddresses(params.SetMachinesAddresses{
+		MachineAddresses: []params.MachineAddresses{
+			{Tag: "machine-1", Addresses: nil},
+			{Tag: "machine-2", Addresses: params.FromNetworkAddresses(newAddrs)},
+			{Tag: "machine-42"},
+			{Tag: "service-unknown"},
+			{Tag: "invalid-tag"},
+			{Tag: "unit-missing-1"},
+			{Tag: ""},
+			{Tag: "42"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: nil},
+			{Error: nil},
+			{Error: apiservertesting.NotFoundError("machine 42")},
+			{Error: apiservertesting.ServerError(`"service-unknown" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"invalid-tag" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"unit-missing-1" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"42" is not a valid tag`)},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "SetProviderAddresses",
+		Args:     []interface{}{},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "SetProviderAddresses",
+		Args:     []interface{}{newAddrs[0], newAddrs[1], newAddrs[2]},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("42")},
+	}})
+	// Ensure machines were updated.
+	machine, err := s.st.Machine("1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.ProviderAddresses(), gc.HasLen, 0)
+
+	machine, err = s.st.Machine("2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.ProviderAddresses(), jc.DeepEquals, newAddrs)
+}
+
+func (s *InstancePollerSuite) TestSetProviderAddressesFailure(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("pow!"),                   // m1 := FindEntity("1")
+		nil,                                  // m2 := FindEntity("2")
+		errors.New("FAIL"),                   // m2.SetProviderAddresses()
+		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
+	)
+	oldAddrs := network.NewAddresses("0.1.2.3", "127.0.0.1", "8.8.8.8")
+	newAddrs := network.NewAddresses("1.2.3.4", "8.4.4.8", "2001:db8::")
+	s.st.SetMachineInfo(c, machineInfo{id: "1", providerAddresses: oldAddrs})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", providerAddresses: nil})
+
+	result, err := s.api.SetProviderAddresses(params.SetMachinesAddresses{
+		MachineAddresses: []params.MachineAddresses{
+			{Tag: "machine-1", Addresses: nil},
+			{Tag: "machine-2", Addresses: params.FromNetworkAddresses(newAddrs)},
+			{Tag: "machine-3"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: apiservertesting.ServerError("pow!")},
+			{Error: apiservertesting.ServerError("FAIL")},
+			{Error: apiservertesting.NotProvisionedError("42")},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "SetProviderAddresses",
+		Args:     []interface{}{newAddrs[0], newAddrs[1], newAddrs[2]},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}})
+	// Ensure machine 2 wasn't updated.
+	machine, err := s.st.Machine("2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.ProviderAddresses(), gc.HasLen, 0)
+}
+
+func (s *InstancePollerSuite) TestInstanceStatusSuccess(c *gc.C) {
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: "foo"})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: ""})
+
+	result, err := s.api.InstanceStatus(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-42"},
+			{Tag: "service-unknown"},
+			{Tag: "invalid-tag"},
+			{Tag: "unit-missing-1"},
+			{Tag: ""},
+			{Tag: "42"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Result: "foo"},
+			{Result: ""},
+			{Error: apiservertesting.NotFoundError("machine 42")},
+			{Error: apiservertesting.ServerError(`"service-unknown" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"invalid-tag" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"unit-missing-1" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"42" is not a valid tag`)},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "InstanceStatus",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "InstanceStatus",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("42")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestInstanceStatusFailure(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("pow!"),                   // m1 := FindEntity("1")
+		nil,                                  // m2 := FindEntity("2")
+		errors.New("FAIL"),                   // m2.InstanceStatus()
+		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
+	)
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: "foo"})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: ""})
+
+	result, err := s.api.InstanceStatus(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-3"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Error: apiservertesting.ServerError("pow!")},
+			{Error: apiservertesting.ServerError("FAIL")},
+			{Error: apiservertesting.NotProvisionedError("42")},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "InstanceStatus",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestSetInstanceStatusSuccess(c *gc.C) {
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: "foo"})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: ""})
+
+	result, err := s.api.SetInstanceStatus(params.SetInstancesStatus{
+		Entities: []params.InstanceStatus{
+			{Tag: "machine-1", Status: ""},
+			{Tag: "machine-2", Status: "new status"},
+			{Tag: "machine-42"},
+			{Tag: "service-unknown"},
+			{Tag: "invalid-tag"},
+			{Tag: "unit-missing-1"},
+			{Tag: ""},
+			{Tag: "42"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: nil},
+			{Error: nil},
+			{Error: apiservertesting.NotFoundError("machine 42")},
+			{Error: apiservertesting.ServerError(`"service-unknown" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"invalid-tag" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"unit-missing-1" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"42" is not a valid tag`)},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "SetInstanceStatus",
+		Args:     []interface{}{""},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "SetInstanceStatus",
+		Args:     []interface{}{"new status"},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("42")},
+	}})
+	// Ensure machines were updated.
+	machine, err := s.st.Machine("1")
+	c.Assert(err, jc.ErrorIsNil)
+	setStatus, err := machine.InstanceStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(setStatus, gc.Equals, "")
+
+	machine, err = s.st.Machine("2")
+	c.Assert(err, jc.ErrorIsNil)
+	setStatus, err = machine.InstanceStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(setStatus, gc.Equals, "new status")
+}
+
+func (s *InstancePollerSuite) TestSetInstanceStatusFailure(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("pow!"),                   // m1 := FindEntity("1")
+		nil,                                  // m2 := FindEntity("2")
+		errors.New("FAIL"),                   // m2.SetInstanceStatus()
+		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
+	)
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: "foo"})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: ""})
+
+	result, err := s.api.SetInstanceStatus(params.SetInstancesStatus{
+		Entities: []params.InstanceStatus{
+			{Tag: "machine-1", Status: "new"},
+			{Tag: "machine-2", Status: "invalid"},
+			{Tag: "machine-3", Status: ""},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: apiservertesting.ServerError("pow!")},
+			{Error: apiservertesting.ServerError("FAIL")},
+			{Error: apiservertesting.NotProvisionedError("42")},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "SetInstanceStatus",
+		Args:     []interface{}{"invalid"},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestAreManuallyProvisionedSuccess(c *gc.C) {
+	s.st.SetMachineInfo(c, machineInfo{id: "1", isManual: true})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", isManual: false})
+
+	result, err := s.api.AreManuallyProvisioned(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-42"},
+			{Tag: "service-unknown"},
+			{Tag: "invalid-tag"},
+			{Tag: "unit-missing-1"},
+			{Tag: ""},
+			{Tag: "42"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.BoolResults{
+		Results: []params.BoolResult{
+			{Result: true},
+			{Result: false},
+			{Error: apiservertesting.NotFoundError("machine 42")},
+			{Error: apiservertesting.ServerError(`"service-unknown" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"invalid-tag" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"unit-missing-1" is not a valid machine tag`)},
+			{Error: apiservertesting.ServerError(`"" is not a valid tag`)},
+			{Error: apiservertesting.ServerError(`"42" is not a valid tag`)},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "IsManual",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "IsManual",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("42")},
+	}})
+}
+
+func (s *InstancePollerSuite) TestAreManuallyProvisionedFailure(c *gc.C) {
+	s.st.SetErrors(
+		errors.New("pow!"),                   // m1 := FindEntity("1")
+		nil,                                  // m2 := FindEntity("2")
+		errors.New("FAIL"),                   // m2.IsManual()
+		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
+	)
+	s.st.SetMachineInfo(c, machineInfo{id: "1", isManual: true})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", isManual: false})
+
+	result, err := s.api.AreManuallyProvisioned(params.Entities{
+		Entities: []params.Entity{
+			{Tag: "machine-1"},
+			{Tag: "machine-2"},
+			{Tag: "machine-3"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.BoolResults{
+		Results: []params.BoolResult{
+			{Error: apiservertesting.ServerError("pow!")},
+			{Error: apiservertesting.ServerError("FAIL")},
+			{Error: apiservertesting.NotProvisionedError("42")},
+		}},
+	)
+
+	s.st.CheckCalls(c, []testing.StubCall{{
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("1")},
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("2")},
+	}, {
+		FuncName: "IsManual",
+		Args:     nil,
+	}, {
+		FuncName: "FindEntity",
+		Args:     []interface{}{names.NewMachineTag("3")},
+	}})
+}

--- a/apiserver/instancepoller/mock_test.go
+++ b/apiserver/instancepoller/mock_test.go
@@ -1,0 +1,488 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller_test
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/instancepoller"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+// mockState implements StateInterface and allows inspection of called
+// methods.
+type mockState struct {
+	*testing.Stub
+
+	mu sync.Mutex
+
+	configWatchers   []*mockConfigWatcher
+	machinesWatchers []*mockMachinesWatcher
+
+	config   *config.Config
+	machines map[string]*mockMachine
+}
+
+func NewMockState() *mockState {
+	return &mockState{
+		Stub:     &testing.Stub{},
+		machines: make(map[string]*mockMachine),
+	}
+}
+
+var _ instancepoller.StateInterface = (*mockState)(nil)
+
+// WatchForEnvironConfigChanges implements StateInterface.
+func (m *mockState) WatchForEnvironConfigChanges() state.NotifyWatcher {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "WatchForEnvironConfigChanges")
+
+	w := NewMockConfigWatcher(m.NextErr())
+	m.configWatchers = append(m.configWatchers, w)
+	return w
+}
+
+// EnvironConfig implements StateInterface.
+func (m *mockState) EnvironConfig() (*config.Config, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "EnvironConfig")
+
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.config, nil
+}
+
+// SetConfig updates the environ config stored internally. Triggers a
+// change event for all created config watchers.
+func (m *mockState) SetConfig(c *gc.C, newConfig *config.Config) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.config = newConfig
+
+	// Notify any watchers for the changes.
+	for _, w := range m.configWatchers {
+		w.incoming <- struct{}{}
+	}
+}
+
+// WatchEnvironMachines implements StateInterface.
+func (m *mockState) WatchEnvironMachines() state.StringsWatcher {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "WatchEnvironMachines")
+
+	ids := make([]string, 0, len(m.machines))
+	// Initial event - all machine ids, sorted.
+	for id := range m.machines {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	w := NewMockMachinesWatcher(ids, m.NextErr())
+	m.machinesWatchers = append(m.machinesWatchers, w)
+	return w
+}
+
+// FindEntity implements StateInterface.
+func (m *mockState) FindEntity(tag names.Tag) (state.Entity, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "FindEntity", tag)
+
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	if tag == nil {
+		return nil, errors.NotValidf("nil tag is") // +" not valid"
+	}
+	machine, found := m.machines[tag.Id()]
+	if !found {
+		return nil, errors.NotFoundf("machine %s", tag.Id())
+	}
+	return machine, nil
+}
+
+// SetMachineInfo adds a new or updates existing mockMachine info.
+// Triggers any created mock machines watchers to return a change.
+func (m *mockState) SetMachineInfo(c *gc.C, args machineInfo) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c.Assert(args.id, gc.Not(gc.Equals), "")
+
+	machine, found := m.machines[args.id]
+	if !found {
+		machine = &mockMachine{
+			Stub:        m.Stub, // reuse parent stub.
+			machineInfo: args,
+		}
+	} else {
+		machine.machineInfo = args
+	}
+	m.machines[args.id] = machine
+
+	// Notify any watchers for the changes.
+	ids := []string{args.id}
+	for _, w := range m.machinesWatchers {
+		w.incoming <- ids
+	}
+}
+
+// RemoveMachine removes an existing mockMachine with the given id.
+// Triggers the machines watchers on success. If the id is not found
+// no error occurs and no change is reported by the watchers.
+func (m *mockState) RemoveMachine(c *gc.C, id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, found := m.machines[id]; !found {
+		return
+	}
+
+	delete(m.machines, id)
+
+	// Notify any watchers for the changes.
+	ids := []string{id}
+	for _, w := range m.machinesWatchers {
+		w.incoming <- ids
+	}
+}
+
+// Machine implements StateInterface.
+func (m *mockState) Machine(id string) (instancepoller.StateMachine, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "Machine", id)
+
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	machine, found := m.machines[id]
+	if !found {
+		return nil, errors.NotFoundf("machine %s", id)
+	}
+	return machine, nil
+}
+
+// StartSync implements statetesting.SyncStarter, so mockState can be
+// used with watcher helpers/checkers.
+func (m *mockState) StartSync() {}
+
+type machineInfo struct {
+	id                string
+	instanceId        instance.Id
+	status            state.StatusInfo
+	instanceStatus    string
+	providerAddresses []network.Address
+	life              state.Life
+	isManual          bool
+}
+
+type mockMachine struct {
+	*testing.Stub
+
+	mu sync.Mutex
+
+	machineInfo
+}
+
+var _ instancepoller.StateMachine = (*mockMachine)(nil)
+
+// Tag implements StateMachine.
+func (m *mockMachine) Tag() names.Tag {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "Tag")
+	m.NextErr() // consume the unused error
+	return names.NewMachineTag(m.id)
+}
+
+// Id implements StateMachine.
+func (m *mockMachine) Id() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "Id")
+	m.NextErr() // consume the unused error
+	return m.id
+}
+
+// String implements StateMachine.
+func (m *mockMachine) String() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "String")
+	m.NextErr() // consume the unused error
+	return m.id
+}
+
+// InstanceId implements StateMachine.
+func (m *mockMachine) InstanceId() (instance.Id, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "InstanceId")
+	if err := m.NextErr(); err != nil {
+		return "", err
+	}
+	return m.instanceId, nil
+}
+
+// ProviderAddresses implements StateMachine.
+func (m *mockMachine) ProviderAddresses() []network.Address {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "ProviderAddresses")
+	m.NextErr() // consume the unused error
+	return m.providerAddresses
+}
+
+// SetProviderAddresses implements StateMachine.
+func (m *mockMachine) SetProviderAddresses(addrs ...network.Address) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	args := make([]interface{}, len(addrs))
+	for i, addr := range addrs {
+		args[i] = addr
+	}
+	m.MethodCall(m, "SetProviderAddresses", args...)
+	if err := m.NextErr(); err != nil {
+		return err
+	}
+	m.providerAddresses = addrs
+	return nil
+}
+
+// InstanceStatus implements StateMachine.
+func (m *mockMachine) InstanceStatus() (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "InstanceStatus")
+	if err := m.NextErr(); err != nil {
+		return "", err
+	}
+	return m.instanceStatus, nil
+}
+
+// SetInstanceStatus implements StateMachine.
+func (m *mockMachine) SetInstanceStatus(status string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "SetInstanceStatus", status)
+	if err := m.NextErr(); err != nil {
+		return err
+	}
+	m.instanceStatus = status
+	return nil
+}
+
+// Refresh implements StateMachine.
+func (m *mockMachine) Refresh() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "Refresh")
+	return m.NextErr()
+}
+
+// Life implements StateMachine.
+func (m *mockMachine) Life() state.Life {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "Life")
+	m.NextErr() // consume the unused error
+	return m.life
+}
+
+// IsManual implements StateMachine.
+func (m *mockMachine) IsManual() (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "IsManual")
+	return m.isManual, m.NextErr()
+}
+
+// Status implements StateMachine.
+func (m *mockMachine) Status() (state.StatusInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "Status")
+	return m.status, m.NextErr()
+}
+
+type mockConfigWatcher struct {
+	err      error
+	incoming chan struct{}
+	changes  chan struct{}
+	done     chan struct{}
+}
+
+var _ state.NotifyWatcher = (*mockConfigWatcher)(nil)
+
+func NewMockConfigWatcher(err error) *mockConfigWatcher {
+	w := &mockConfigWatcher{
+		err:      err,
+		incoming: make(chan struct{}),
+		changes:  make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	go w.loop()
+	return w
+}
+
+func (m *mockConfigWatcher) loop() {
+	// If there's an error, don't even start.
+	if m.err != nil {
+		m.Stop()
+		return
+	}
+	// Prepare initial event.
+	outChanges := m.changes
+	// Forward any incoming changes until stopped.
+	for {
+		select {
+		case <-m.done:
+			// We're about to quit.
+			return
+		case outChanges <- struct{}{}:
+			outChanges = nil
+		case <-m.incoming:
+			outChanges = m.changes
+		}
+	}
+}
+
+// Kill implements state.NotifyWatcher.
+func (m *mockConfigWatcher) Kill() {}
+
+// Stop implements state.NotifyWatcher.
+func (m *mockConfigWatcher) Stop() error {
+	if m.done != nil {
+		// Signal the loop we want to stop.
+		close(m.done)
+		// Signal the clients we've closed.
+		close(m.changes)
+		m.done = nil
+	}
+	return m.err
+}
+
+// Wait implements state.NotifyWatcher.
+func (m *mockConfigWatcher) Wait() error {
+	return m.Stop()
+}
+
+// Err implements state.NotifyWatcher.
+func (m *mockConfigWatcher) Err() error {
+	return m.err
+}
+
+// Changes implements state.NotifyWatcher.
+func (m *mockConfigWatcher) Changes() <-chan struct{} {
+	return m.changes
+}
+
+type mockMachinesWatcher struct {
+	err      error
+	initial  []string
+	incoming chan []string
+	changes  chan []string
+	done     chan struct{}
+}
+
+func NewMockMachinesWatcher(initial []string, err error) *mockMachinesWatcher {
+	w := &mockMachinesWatcher{
+		err:      err,
+		initial:  initial,
+		incoming: make(chan []string),
+		changes:  make(chan []string),
+		done:     make(chan struct{}),
+	}
+	go w.loop()
+	return w
+}
+
+func (m *mockMachinesWatcher) loop() {
+	// If there's an error, don't even start.
+	if m.err != nil {
+		m.Stop()
+		return
+	}
+	// Prepare initial event.
+	unsent := m.initial
+	outChanges := m.changes
+	// Forward any incoming changes until stopped.
+	for {
+		select {
+		case <-m.done:
+			// We're about to quit.
+			return
+		case outChanges <- unsent:
+			outChanges = nil
+			unsent = nil
+		case ids := <-m.incoming:
+			unsent = append(unsent, ids...)
+			outChanges = m.changes
+		}
+	}
+}
+
+// Kill implements state.StringsWatcher.
+func (m *mockMachinesWatcher) Kill() {}
+
+// Stop implements state.StringsWatcher.
+func (m *mockMachinesWatcher) Stop() error {
+	if m.done != nil {
+		// Signal the loop we want to stop.
+		close(m.done)
+		// Signal the clients we've closed.
+		close(m.changes)
+		m.done = nil
+	}
+	return m.err
+}
+
+// Wait implements state.StringsWatcher.
+func (m *mockMachinesWatcher) Wait() error {
+	return m.Stop()
+}
+
+// Err implements state.StringsWatcher.
+func (m *mockMachinesWatcher) Err() error {
+	return m.err
+}
+
+// Changes implements state.StringsWatcher.
+func (m *mockMachinesWatcher) Changes() <-chan []string {
+	return m.changes
+}
+
+var _ state.StringsWatcher = (*mockMachinesWatcher)(nil)

--- a/apiserver/instancepoller/mock_test.go
+++ b/apiserver/instancepoller/mock_test.go
@@ -42,6 +42,22 @@ func NewMockState() *mockState {
 
 var _ instancepoller.StateInterface = (*mockState)(nil)
 
+// CheckFindEntityCall is a helper wrapper aroud
+// testing.Stub.CheckCall for FindEntity.
+func (m *mockState) CheckFindEntityCall(c *gc.C, index int, machineId string) {
+	m.CheckCall(c, index, "FindEntity", interface{}(names.NewMachineTag(machineId)))
+}
+
+// CheckSetProviderAddressesCall is a helper wrapper aroud
+// testing.Stub.CheckCall for SetProviderAddresses.
+func (m *mockState) CheckSetProviderAddressesCall(c *gc.C, index int, addrs []network.Address) {
+	args := make([]interface{}, len(addrs))
+	for i, addr := range addrs {
+		args[i] = addr
+	}
+	m.CheckCall(c, index, "SetProviderAddresses", args...)
+}
+
 // WatchForEnvironConfigChanges implements StateInterface.
 func (m *mockState) WatchForEnvironConfigChanges() state.NotifyWatcher {
 	m.mu.Lock()

--- a/apiserver/instancepoller/package_test.go
+++ b/apiserver/instancepoller/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/instancepoller/state.go
+++ b/apiserver/instancepoller/state.go
@@ -1,0 +1,46 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instancepoller
+
+import (
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+type StateMachine interface {
+	state.Entity
+
+	Id() string
+	InstanceId() (instance.Id, error)
+	ProviderAddresses() []network.Address
+	SetProviderAddresses(...network.Address) error
+	InstanceStatus() (string, error)
+	SetInstanceStatus(status string) error
+	String() string
+	Refresh() error
+	Life() state.Life
+	Status() (state.StatusInfo, error)
+	IsManual() (bool, error)
+}
+
+type StateInterface interface {
+	state.EnvironAccessor
+	state.EnvironMachinesWatcher
+	state.EntityFinder
+
+	Machine(id string) (StateMachine, error)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) Machine(id string) (StateMachine, error) {
+	return s.State.Machine(id)
+}
+
+var getState = func(st *state.State) StateInterface {
+	return stateShim{st}
+}

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -345,6 +345,18 @@ type SetStatus struct {
 	Entities []EntityStatus
 }
 
+// InstanceStatus holds an entity tag and instance status.
+type InstanceStatus struct {
+	Tag    string
+	Status string
+}
+
+// SetInstancesStatus holds parameters for making a
+// SetInstancesStatus() call.
+type SetInstancesStatus struct {
+	Entities []InstanceStatus
+}
+
 type HistoryKind string
 
 const (
@@ -375,11 +387,6 @@ type StatusResult struct {
 // StatusResults holds multiple status results.
 type StatusResults struct {
 	Results []StatusResult
-}
-
-// SetMachinesAddresses holds the parameters for making a SetMachineAddresses call.
-type SetMachinesAddresses struct {
-	MachineAddresses []MachineAddresses
 }
 
 // ConstraintsResult holds machine constraints or an error.

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -352,7 +352,7 @@ type InstanceStatus struct {
 }
 
 // SetInstancesStatus holds parameters for making a
-// SetInstancesStatus() call.
+// SetInstanceStatus() call.
 type SetInstancesStatus struct {
 	Entities []InstanceStatus
 }

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -323,6 +323,25 @@ type MachineAddresses struct {
 	Addresses []Address `json:"Addresses"`
 }
 
+// SetMachinesAddresses holds the parameters for making an
+// API call to update machine addresses.
+type SetMachinesAddresses struct {
+	MachineAddresses []MachineAddresses `json:"MachineAddresses"`
+}
+
+// MachineAddressesResult holds a list of machine addresses or an
+// error.
+type MachineAddressesResult struct {
+	Error     *Error    `json:"Error"`
+	Addresses []Address `json:"Addresses"`
+}
+
+// MachineAddressesResults holds the results of calling an API method
+// returning a list of addresses per machine.
+type MachineAddressesResults struct {
+	Results []MachineAddressesResult `json:"Results"`
+}
+
 // MachinePortRange holds a single port range open on a machine for
 // the given unit and relation tags.
 type MachinePortRange struct {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -724,9 +724,6 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 			// brutalising the transaction log.
 			return newResumer(st.Resumer()), nil
 		})
-		runner.StartWorker("instancepoller", func() (worker.Worker, error) {
-			return newInstancePoller(st.InstancePoller()), nil
-		})
 	}
 
 	runner.StartWorker("machiner", func() (worker.Worker, error) {
@@ -1141,6 +1138,9 @@ func (a *MachineAgent) startEnvWorkers(
 	})
 	runner.StartWorker("metricmanagerworker", func() (worker.Worker, error) {
 		return metricworker.NewMetricsManager(getMetricAPI(apiSt))
+	})
+	singularRunner.StartWorker("instancepoller", func() (worker.Worker, error) {
+		return newInstancePoller(apiSt.InstancePoller()), nil
 	})
 
 	// TODO(axw) 2013-09-24 bug #1229506

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -246,6 +246,7 @@ var perEnvSingularWorkers = []string{
 	"addresserworker",
 	"environ-provisioner",
 	"charm-revision-updater",
+	"instancepoller",
 	"firewaller",
 }
 

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/testing"
 )
@@ -120,13 +119,13 @@ func (c NotifyWatcherC) AssertClosed() {
 // the behaviour of any watcher that uses a <-chan []string.
 type StringsWatcherC struct {
 	*gc.C
-	State   *state.State
+	State   SyncStarter
 	Watcher StringsWatcher
 }
 
 // NewStringsWatcherC returns a StringsWatcherC that checks for aggressive
 // event coalescence.
-func NewStringsWatcherC(c *gc.C, st *state.State, w StringsWatcher) StringsWatcherC {
+func NewStringsWatcherC(c *gc.C, st SyncStarter, w StringsWatcher) StringsWatcherC {
 	return StringsWatcherC{
 		C:       c,
 		State:   st,
@@ -232,7 +231,7 @@ func (c StringsWatcherC) AssertClosed() {
 // params.RelationUnitsChange.
 type RelationUnitsWatcherC struct {
 	*gc.C
-	State   *state.State
+	State   SyncStarter
 	Watcher RelationUnitsWatcher
 	// settingsVersions keeps track of the settings version of each
 	// changed unit since the last received changes to ensure version
@@ -242,7 +241,7 @@ type RelationUnitsWatcherC struct {
 
 // NewRelationUnitsWatcherC returns a RelationUnitsWatcherC that
 // checks for aggressive event coalescence.
-func NewRelationUnitsWatcherC(c *gc.C, st *state.State, w RelationUnitsWatcher) RelationUnitsWatcherC {
+func NewRelationUnitsWatcherC(c *gc.C, st SyncStarter, w RelationUnitsWatcher) RelationUnitsWatcherC {
 	return RelationUnitsWatcherC{
 		C:                c,
 		State:            st,

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -7,14 +7,14 @@ package instancepoller
 import (
 	stderrors "errors"
 	"fmt"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-	"github.com/juju/names"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -7,14 +7,15 @@ package instancepoller
 import (
 	stderrors "errors"
 	"fmt"
-	"github.com/juju/names"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -5,9 +5,9 @@ package instancepoller
 
 import (
 	"fmt"
-	"time"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"time"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -5,9 +5,10 @@ package instancepoller
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	"time"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"reflect"
 	"time"
-
-	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
+	apiinstancepoller "github.com/juju/juju/api/instancepoller"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -26,6 +28,15 @@ var _ = gc.Suite(&workerSuite{})
 
 type workerSuite struct {
 	testing.JujuConnSuite
+
+	apiSt *api.State
+	api   *apiinstancepoller.API
+}
+
+func (s *workerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.apiSt, _ = s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
+	s.api = s.apiSt.InstancePoller()
 }
 
 func (*workerSuite) instId(i int) instance.Id {
@@ -45,7 +56,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 	s.PatchValue(&gatherTime, 10*time.Millisecond)
 	machines, insts := s.setupScenario(c)
 	s.State.StartSync()
-	w := NewWorker(s.State)
+	w := NewWorker(s.api)
 	defer func() {
 		c.Assert(worker.Stop(w), gc.IsNil)
 	}()
@@ -53,12 +64,14 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 	checkInstanceInfo := func(index int, m machine, expectedStatus string) bool {
 		isProvisioned := true
 		status, err := m.InstanceStatus()
-		if errors.IsNotProvisioned(err) {
+		if params.IsCodeNotProvisioned(err) {
 			isProvisioned = false
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
 		}
-		return reflect.DeepEqual(m.ProviderAddresses(), s.addressesForIndex(index)) && (!isProvisioned || status == expectedStatus)
+		providerAddresses, err := m.ProviderAddresses()
+		c.Assert(err, jc.ErrorIsNil)
+		return reflect.DeepEqual(providerAddresses, s.addressesForIndex(index)) && (!isProvisioned || status == expectedStatus)
 	}
 
 	// Wait for the odd numbered machines in the
@@ -69,26 +82,29 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 			c.Fatalf("timed out waiting for instance info")
 		}
 
-		if machinesSatisfy(c, machines, func(i int, m *state.Machine) bool {
+		if machinesSatisfy(c, machines, func(i int, m *apiinstancepoller.Machine) bool {
 			if i < len(machines)/2 && i%2 == 1 {
 				return checkInstanceInfo(i, m, "running")
 			}
 			status, err := m.InstanceStatus()
 			if i%2 == 0 {
 				// Even machines not provisioned yet.
-				c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+				c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
 			} else {
 				c.Assert(status, gc.Equals, "")
 			}
-			return len(m.Addresses()) == 0
+			stm, err := s.State.Machine(m.Id())
+			c.Assert(err, jc.ErrorIsNil)
+			return len(stm.Addresses()) == 0
 		}) {
 			break
 		}
 	}
 	// Now provision the even machines in the first half and watch them get addresses.
 	for i := 0; i < len(insts)/2; i += 2 {
-		m := machines[i]
-		err := m.SetProvisioned(insts[i].Id(), "nonce", nil)
+		m, err := s.State.Machine(machines[i].Id())
+		c.Assert(err, jc.ErrorIsNil)
+		err = m.SetProvisioned(insts[i].Id(), "nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		dummy.SetInstanceAddresses(insts[i], s.addressesForIndex(i))
 		dummy.SetInstanceStatus(insts[i], "running")
@@ -97,7 +113,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 		if !a.HasNext() {
 			c.Fatalf("timed out waiting for machine instance info")
 		}
-		if machinesSatisfy(c, machines, func(i int, m *state.Machine) bool {
+		if machinesSatisfy(c, machines, func(i int, m *apiinstancepoller.Machine) bool {
 			if i < len(machines)/2 {
 				return checkInstanceInfo(i, m, "running")
 			}
@@ -105,11 +121,13 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 			status, err := m.InstanceStatus()
 			if i%2 == 0 {
 				// Even machines not provisioned yet.
-				c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+				c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
 			} else {
 				c.Assert(status, gc.Equals, "")
 			}
-			return len(m.Addresses()) == 0
+			stm, err := s.State.Machine(m.Id())
+			c.Assert(err, jc.ErrorIsNil)
+			return len(stm.Addresses()) == 0
 		}) {
 			break
 		}
@@ -118,8 +136,9 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 	// Provision the remaining machines and check the address and status.
 	for i := len(insts) / 2; i < len(insts); i++ {
 		if i%2 == 0 {
-			m := machines[i]
-			err := m.SetProvisioned(insts[i].Id(), "nonce", nil)
+			m, err := s.State.Machine(machines[i].Id())
+			c.Assert(err, jc.ErrorIsNil)
+			err = m.SetProvisioned(insts[i].Id(), "nonce", nil)
 			c.Assert(err, jc.ErrorIsNil)
 		}
 		dummy.SetInstanceAddresses(insts[i], s.addressesForIndex(i))
@@ -129,7 +148,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 		if !a.HasNext() {
 			c.Fatalf("timed out waiting for machine instance info")
 		}
-		if machinesSatisfy(c, machines, func(i int, m *state.Machine) bool {
+		if machinesSatisfy(c, machines, func(i int, m *apiinstancepoller.Machine) bool {
 			return checkInstanceInfo(i, m, "running")
 		}) {
 			break
@@ -142,7 +161,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 // - check that the environment observer is stopped.
 // - check that the errors propagate correctly.
 
-func machinesSatisfy(c *gc.C, machines []*state.Machine, f func(i int, m *state.Machine) bool) bool {
+func machinesSatisfy(c *gc.C, machines []*apiinstancepoller.Machine, f func(i int, m *apiinstancepoller.Machine) bool) bool {
 	for i, m := range machines {
 		err := m.Refresh()
 		c.Assert(err, jc.ErrorIsNil)
@@ -153,20 +172,24 @@ func machinesSatisfy(c *gc.C, machines []*state.Machine, f func(i int, m *state.
 	return true
 }
 
-func (s *workerSuite) setupScenario(c *gc.C) ([]*state.Machine, []instance.Instance) {
-	var machines []*state.Machine
+func (s *workerSuite) setupScenario(c *gc.C) ([]*apiinstancepoller.Machine, []instance.Instance) {
+	var machines []*apiinstancepoller.Machine
 	var insts []instance.Instance
 	for i := 0; i < 10; i++ {
 		m, err := s.State.AddMachine("series", state.JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
-		machines = append(machines, m)
+		apiMachine, err := s.api.Machine(names.NewMachineTag(m.Id()))
+		c.Assert(err, jc.ErrorIsNil)
+		machines = append(machines, apiMachine)
 		inst, _ := testing.AssertStartInstance(c, s.Environ, m.Id())
 		insts = append(insts, inst)
 	}
 	// Associate the odd-numbered machines with an instance.
 	for i := 1; i < len(machines); i += 2 {
-		m := machines[i]
-		err := m.SetProvisioned(insts[i].Id(), "nonce", nil)
+		apiMachine := machines[i]
+		m, err := s.State.Machine(apiMachine.Id())
+		c.Assert(err, jc.ErrorIsNil)
+		err = m.SetProvisioned(insts[i].Id(), "nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	// Associate the first half of the instances with an address and status.

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -6,11 +6,11 @@ package instancepoller
 
 import (
 	"fmt"
-	"reflect"
-	"time"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"reflect"
+	"time"
 
 	"github.com/juju/juju/api"
 	apiinstancepoller "github.com/juju/juju/api/instancepoller"

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -6,11 +6,12 @@ package instancepoller
 
 import (
 	"fmt"
+	"reflect"
+	"time"
+
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"reflect"
-	"time"
 
 	"github.com/juju/juju/api"
 	apiinstancepoller "github.com/juju/juju/api/instancepoller"


### PR DESCRIPTION
Introduced new InstancePoller server- and client-side facades. Changed
the worker/instancepoller to use the API instead of *state.State
directly. Modified the machine agent to start the instancepoller worker
with an API connection. A few improvements to api/base/testing factored
out: CheckingAPICaller - allows inspecting the arguments passed to
APICall() as well as overriding the returned results and error.

Testing: make check; live on EC2.

(Review request: http://reviews.vapour.ws/r/1830/)