### PR TITLE
Move cloud-init logic out of service/systemd

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -300,14 +300,11 @@ func shutdownInitCommands(initSystem string) ([]string, error) {
 		return nil, errors.Trace(err)
 	}
 
-	// The service should be explicitly started with systemd
-	if initSystem == service.InitSystemSystemd {
-		startCommands, err := svc.StartCommands()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		cmds = append(cmds, startCommands...)
+	startCommands, err := svc.StartCommands()
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+	cmds = append(cmds, startCommands...)
 
 	return cmds, nil
 }

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -225,5 +225,5 @@ EOC
   /bin/rm -fr /var/lib/dhcp/dhclient* /var/log/cloud-init*.log
   /sbin/shutdown -h now`[1:],
 	}
-	test.CheckInstallTemplateContainerCommands(c, commands)
+	test.CheckInstallAndStartCommands(c, commands)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -86,17 +86,6 @@ type Service interface {
 	StartCommands() ([]string, error)
 }
 
-// TemplateShutdownService represents a service which can be used to halt a
-// template lxc container after cloud-init completes.
-type TemplateShutdownService interface {
-	Service
-
-	// InstallTemplateContainerCommands returns the commands to install
-	// and start the service which will halt the template container after
-	// cloud-init completes.
-	InstallTemplateContainerCommands() ([]string, error)
-}
-
 // RestartableService is a service that directly supports restarting.
 type RestartableService interface {
 	// Restart restarts the service.
@@ -126,23 +115,6 @@ func NewService(name string, conf common.Conf, initSystem string) (Service, erro
 		return svc, nil
 	default:
 		return nil, errors.NotFoundf("init system %q", initSystem)
-	}
-}
-
-// NewTemplateShutdownService returns a new TemplateService that can be used to create
-// the shutdown service used in container templates
-func NewTemplateShutdownService(name string, conf common.Conf, initSystem string) (TemplateShutdownService, error) {
-	switch initSystem {
-	case InitSystemUpstart:
-		return upstart.NewTemplateShutdownService(name, conf), nil
-	case InitSystemSystemd:
-		svc, err := systemd.NewTemplateShutdownService(name, conf)
-		if err != nil {
-			return nil, errors.Annotatef(err, "failed to wrap service %q", name)
-		}
-		return svc, nil
-	default:
-		return nil, errors.Errorf("unsupported init system for container template: %q", initSystem)
 	}
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -48,31 +48,6 @@ func (s *serviceSuite) TestNewServiceKnown(c *gc.C) {
 	}
 }
 
-func (s *serviceSuite) TestNewTemplateShutdownService(c *gc.C) {
-	initSystems := []string{
-		service.InitSystemSystemd,
-		service.InitSystemUpstart,
-		service.InitSystemWindows,
-	}
-	for _, initSystem := range initSystems {
-		svc, err := service.NewTemplateShutdownService(s.Name, s.Conf, initSystem)
-
-		switch initSystem {
-		case service.InitSystemSystemd:
-			c.Check(svc, gc.FitsTypeOf, &systemd.Service{})
-			c.Check(err, jc.ErrorIsNil)
-		case service.InitSystemUpstart:
-			c.Check(svc, gc.FitsTypeOf, &upstart.Service{})
-			c.Check(err, jc.ErrorIsNil)
-		case service.InitSystemWindows:
-			c.Check(err, gc.ErrorMatches, "unsupported init system for container template: \"windows\"")
-			continue
-		}
-		c.Check(svc.Name(), gc.Equals, s.Name)
-		c.Check(svc.Conf(), jc.DeepEquals, s.Conf)
-	}
-}
-
 func (s *serviceSuite) TestNewServiceMissingName(c *gc.C) {
 	_, err := service.NewService("", s.Conf, service.InitSystemUpstart)
 

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -117,15 +117,6 @@ func NewService(name string, conf common.Conf) (*Service, error) {
 	return service, nil
 }
 
-// NewTemplateShutdownService returns a new value that implements
-// TemplateShutdownService for systemd.
-func NewTemplateShutdownService(name string, conf common.Conf) (*Service, error) {
-	if conf.AfterStopped == "cloud-final" {
-		conf.AfterStopped = "cloud-config.target"
-	}
-	return NewService(name, conf)
-}
-
 var findDataDir = func() (string, error) {
 	return paths.DataDir(version.Current.Series)
 }
@@ -591,22 +582,6 @@ func (s *Service) InstallCommands() ([]string, error) {
 		cmds.enableLinked(name, dirname),
 	}...)
 	return cmdList, nil
-}
-
-// InstallTempalteContainerCommands returns shell commands to install
-// and start the shutdown service required for template containers.
-func (s *Service) InstallTemplateContainerCommands() ([]string, error) {
-	installCmds, err := s.InstallCommands()
-	if err != nil {
-		return nil, err
-	}
-
-	startCmds, err := s.StartCommands()
-	if err != nil {
-		return nil, err
-	}
-
-	return append(installCmds, startCmds...), nil
 }
 
 // StartCommands implements Service.

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -228,42 +228,6 @@ func (s *initSystemSuite) TestNewService(c *gc.C) {
 	s.stub.CheckCalls(c, nil)
 }
 
-func (s *initSystemSuite) TestNewTemplateShutdownService(c *gc.C) {
-	s.conf.AfterStopped = "cloud-final"
-	service, err := systemd.NewTemplateShutdownService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.conf.AfterStopped = "cloud-config.target"
-
-	c.Check(service, jc.DeepEquals, &systemd.Service{
-		Service: common.Service{
-			Name: s.name,
-			Conf: s.conf,
-		},
-		ConfName: s.name + ".service",
-		UnitName: s.name + ".service",
-		Dirname:  fmt.Sprintf("%s/init/%s", s.dataDir, s.name),
-	})
-	s.stub.CheckCalls(c, nil)
-}
-
-func (s *initSystemSuite) TestNewTemplateWithUnexpectedAfterStopped(c *gc.C) {
-	s.conf.AfterStopped = "foobar"
-	service, err := systemd.NewTemplateShutdownService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(service, jc.DeepEquals, &systemd.Service{
-		Service: common.Service{
-			Name: s.name,
-			Conf: s.conf,
-		},
-		ConfName: s.name + ".service",
-		UnitName: s.name + ".service",
-		Dirname:  fmt.Sprintf("%s/init/%s", s.dataDir, s.name),
-	})
-	s.stub.CheckCalls(c, nil)
-}
-
 func (s *initSystemSuite) TestNewServiceLogfile(c *gc.C) {
 	s.conf.Logfile = "/var/log/juju/machine-0.log"
 
@@ -895,21 +859,6 @@ func (s *initSystemSuite) TestInstallCommandsEmptyConf(c *gc.C) {
 
 	c.Check(err, gc.ErrorMatches, `.*missing conf.*`)
 	s.stub.CheckCalls(c, nil)
-}
-
-func (s *initSystemSuite) TestInstallTemplateContainerCommands(c *gc.C) {
-	s.dataDir = "/tmp"
-	s.service.Dirname = "/tmp/init/" + s.name
-
-	commands, err := s.service.InstallTemplateContainerCommands()
-	c.Assert(err, jc.ErrorIsNil)
-
-	test := systemdtesting.WriteConfTest{
-		Service:  s.name,
-		DataDir:  s.dataDir,
-		Expected: s.newConfStr(s.name),
-	}
-	test.CheckInstallTemplateContainerCommands(c, commands)
 }
 
 func (s *initSystemSuite) TestStartCommands(c *gc.C) {

--- a/service/systemd/testing/writeconf.go
+++ b/service/systemd/testing/writeconf.go
@@ -50,7 +50,7 @@ func (wct WriteConfTest) CheckCommands(c *gc.C, commands []string) {
 	wct.checkWriteConf(c, commands)
 }
 
-func (wct WriteConfTest) CheckInstallTemplateContainerCommands(c *gc.C, commands []string) {
+func (wct WriteConfTest) CheckInstallAndStartCommands(c *gc.C, commands []string) {
 	wct.CheckCommands(c, commands[:len(commands)-1])
 	c.Check(commands[len(commands)-1], gc.Equals, "/bin/systemctl start "+wct.servicename())
 }

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -315,6 +315,7 @@ func (s *Service) InstallCommands() ([]string, error) {
 
 // StartCommands returns shell commands to start the service.
 func (s *Service) StartCommands() ([]string, error) {
+	// TODO(ericsnow) Add clarification about why transient services are not started.
 	if s.Service.Conf.Transient {
 		return nil, nil
 	}

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -104,12 +104,6 @@ func NewService(name string, conf common.Conf) *Service {
 	}
 }
 
-// NewTemplateShutdownService returns a new value that implements
-// TemplateShutdownService for upstart.
-func NewTemplateShutdownService(name string, conf common.Conf) *Service {
-	return NewService(name, conf)
-}
-
 // Name implements service.Service.
 func (s Service) Name() string {
 	return s.Service.Name
@@ -317,12 +311,6 @@ func (s *Service) InstallCommands() ([]string, error) {
 	}
 	cmd := fmt.Sprintf("cat > %s << 'EOF'\n%sEOF\n", s.confPath(), conf)
 	return []string{cmd}, nil
-}
-
-// InstallTempalteContainerCommands returns shell commands to install
-// and start the shutdown service required for template containers.
-func (s *Service) InstallTemplateContainerCommands() ([]string, error) {
-	return s.InstallCommands()
 }
 
 // StartCommands returns shell commands to start the service.


### PR DESCRIPTION
This PR addresses additional review comments for the original fix for:
https://bugs.launchpad.net/juju-core/+bug/1442308

The behavior is the same, but moves around some of the logic to match the changes made in master.  The commits for master were cherry picked to 1.24 and manually tested.

Review on master:  http://reviews.vapour.ws/r/1797/

(Review request: http://reviews.vapour.ws/r/1831/)