### PR TITLE
Improve update-status hook.

### DIFF
--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -13,7 +13,6 @@ func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
 }
 
 var (
-	ActiveMetricsTimer  = &activeMetricsTimer
 	IdleWaitTime        = &idleWaitTime
 	LeadershipGuarantee = &leadershipGuarantee
 )
@@ -43,6 +42,26 @@ func NewManualTicker() *ManualTicker {
 	return &ManualTicker{
 		c: make(chan time.Time, 1),
 	}
+}
+
+func (u *Uniter) ReplaceEnterAbide(f simpleUniterFunc) {
+	u.enterAbide = f
+}
+
+func (u *Uniter) ReplaceEnterIdle(f simpleUniterFunc) {
+	u.enterIdle = f
+}
+
+func RunUpdateStatusOnce(u *Uniter) error {
+	return runUpdateStatusOnce(u)
+}
+
+func (u *Uniter) SetUpdateStatusAt(t TimedSignal) {
+	u.updateStatusAt = t
+}
+
+func (u *Uniter) SetActiveMetrics(t TimedSignal) {
+	u.metricsTimer.active = t
 }
 
 func UpdateStatusSignal(now, lastSignal time.Time, interval time.Duration) <-chan time.Time {

--- a/worker/uniter/metrics.go
+++ b/worker/uniter/metrics.go
@@ -18,7 +18,7 @@ const (
 // as close to interval after the last run as possible.
 var activeMetricsTimer = func(now, lastRun time.Time, interval time.Duration) <-chan time.Time {
 	waitDuration := interval - now.Sub(lastRun)
-	logger.Debugf("waiting for %v", waitDuration)
+	logger.Debugf("metrics waiting for %v", waitDuration)
 	return time.After(waitDuration)
 }
 

--- a/worker/uniter/metrics.go
+++ b/worker/uniter/metrics.go
@@ -28,12 +28,24 @@ func inactiveMetricsTimer(_, _ time.Time, _ time.Duration) <-chan time.Time {
 	return nil
 }
 
+type timerChooser struct {
+	active   TimedSignal
+	inactive TimedSignal
+}
+
 // getMetricsTimer returns the metrics timer we should be using, given the supplied
 // charm.
-func getMetricsTimer(ch corecharm.Charm) TimedSignal {
+func (t *timerChooser) getMetricsTimer(ch corecharm.Charm) TimedSignal {
 	metrics := ch.Metrics()
 	if metrics != nil && len(metrics.Metrics) > 0 {
-		return activeMetricsTimer
+		return t.active
 	}
-	return inactiveMetricsTimer
+	return t.inactive
+}
+
+func NewTimerChooser() *timerChooser {
+	return &timerChooser{
+		active:   activeMetricsTimer,
+		inactive: inactiveMetricsTimer,
+	}
 }

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -157,5 +157,6 @@ func (opc *operationCallbacks) InitializeMetricsCollector() error {
 
 // SetExecutingStatus is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) SetExecutingStatus(message string) error {
-	return setAgentStatus(opc.u, params.StatusExecuting, message, nil)
+	_, err := setAgentStatus(opc.u, params.StatusExecuting, message, nil)
+	return err
 }

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -157,6 +157,6 @@ func (opc *operationCallbacks) InitializeMetricsCollector() error {
 
 // SetExecutingStatus is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) SetExecutingStatus(message string) error {
-	_, err := setAgentStatus(opc.u, params.StatusExecuting, message, nil)
+	err := setAgentStatus(opc.u, params.StatusExecuting, message, nil)
 	return err
 }

--- a/worker/uniter/status.go
+++ b/worker/uniter/status.go
@@ -15,5 +15,6 @@ const (
 // updateStatusSignal returns a time channel that fires after a given interval.
 func updateStatusSignal(now, lastSignal time.Time, interval time.Duration) <-chan time.Time {
 	waitDuration := interval - now.Sub(lastSignal)
+	logger.Debugf("status hook waiting for %v", waitDuration)
 	return time.After(waitDuration)
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -204,6 +204,20 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 	})
 }
 
+func (s *UniterSuite) TestUniterUpdateStatusHook(c *gc.C) {
+	s.runUniterTests(c, []uniterTest{
+		ut(
+			"update status hook runs at least once",
+			createCharm{},
+			serveCharm{},
+			createUniter{},
+			waitHooks{"install", "leader-elected", "config-changed", "start", "update-status"},
+			waitUnitAgent{status: params.StatusIdle},
+			waitHooks{"update-status"},
+		),
+	})
+}
+
 func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 	s.runUniterTests(c, []uniterTest{
 		ut(
@@ -1342,7 +1356,7 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
-			metricsTick{},
+			timerTick{},
 			waitHooks{"collect-metrics"},
 		),
 		ut(
@@ -1353,7 +1367,7 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 					ctx.writeMetricsYaml(c, path)
 				},
 			},
-			metricsTick{},
+			timerTick{},
 			fixHook{"config-changed"},
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
@@ -1374,7 +1388,7 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 					ctx.writeMetricsYaml(c, path)
 				},
 			},
-			metricsTick{},
+			timerTick{},
 			fixHook{"config-changed"},
 			stopUniter{},
 			startUniter{},
@@ -1392,7 +1406,7 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 		ut(
 			"collect-metrics event not triggered for non-metered charm",
 			quickStart{},
-			metricsTick{},
+			timerTick{},
 			waitHooks{},
 		),
 	})

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -75,24 +75,27 @@ func assertAssignUnit(c *gc.C, st *state.State, u *state.Unit) {
 }
 
 type context struct {
-	uuid          string
-	path          string
-	dataDir       string
-	s             *UniterSuite
-	st            *state.State
-	api           *apiuniter.State
-	leader        leadership.LeadershipManager
-	charms        map[string][]byte
-	hooks         []string
-	sch           *state.Charm
-	svc           *state.Service
-	unit          *state.Unit
-	uniter        *uniter.Uniter
-	relatedSvc    *state.Service
-	relation      *state.Relation
-	relationUnits map[string]*state.RelationUnit
-	subordinate   *state.Unit
-	ticker        *uniter.ManualTicker
+	uuid                   string
+	path                   string
+	dataDir                string
+	s                      *UniterSuite
+	st                     *state.State
+	api                    *apiuniter.State
+	leader                 leadership.LeadershipManager
+	charms                 map[string][]byte
+	hooks                  []string
+	sch                    *state.Charm
+	svc                    *state.Service
+	unit                   *state.Unit
+	uniter                 *uniter.Uniter
+	relatedSvc             *state.Service
+	relation               *state.Relation
+	relationUnits          map[string]*state.RelationUnit
+	subordinate            *state.Unit
+	metricsTicker          *uniter.ManualTicker
+	updateStatusHookTicker *uniter.ManualTicker
+	enterAbide             func(u *uniter.Uniter) error
+	enterIdle              func(u *uniter.Uniter) error
 
 	wg             sync.WaitGroup
 	mu             sync.Mutex
@@ -292,8 +295,7 @@ var (
 	baseCharmHooks = []string{
 		"install", "start", "config-changed", "upgrade-charm", "stop",
 		"db-relation-joined", "db-relation-changed", "db-relation-departed",
-		"db-relation-broken", "meter-status-changed", "collect-metrics",
-		"update-status",
+		"db-relation-broken", "meter-status-changed", "collect-metrics", "update-status",
 	}
 	leaderCharmHooks = []string{
 		"leader-elected", "leader-deposed", "leader-settings-changed",
@@ -454,6 +456,20 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 	lock, err := fslock.NewLock(locksDir, "uniter-hook-execution")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx.uniter = uniter.NewUniter(ctx.api, tag, ctx.leader, ctx.dataDir, lock)
+	ctx.uniter.ReplaceEnterAbide(func(*uniter.Uniter) error { return nil })
+	if ctx.enterAbide != nil {
+		ctx.uniter.ReplaceEnterAbide(uniter.RunUpdateStatusOnce)
+	}
+	ctx.uniter.ReplaceEnterIdle(func(*uniter.Uniter) error { return nil })
+	if ctx.enterIdle != nil {
+		ctx.uniter.ReplaceEnterIdle(uniter.RunUpdateStatusOnce)
+	}
+	if ctx.updateStatusHookTicker != nil {
+		ctx.uniter.SetUpdateStatusAt(ctx.updateStatusHookTicker.ReturnTimer)
+	}
+	if ctx.metricsTicker != nil {
+		ctx.uniter.SetActiveMetrics(ctx.metricsTicker.ReturnTimer)
+	}
 	uniter.SetUniterObserver(ctx.uniter, ctx)
 }
 
@@ -860,10 +876,17 @@ func (s changeMeterStatus) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-type timerTick struct{}
+type metricsTick struct{}
 
-func (s timerTick) step(c *gc.C, ctx *context) {
-	err := ctx.ticker.Tick()
+func (s metricsTick) step(c *gc.C, ctx *context) {
+	err := ctx.metricsTicker.Tick()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type updateStatusHookTick struct{}
+
+func (s updateStatusHookTick) step(c *gc.C, ctx *context) {
+	err := ctx.updateStatusHookTicker.Tick()
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1677,4 +1700,11 @@ func (s verifyStorageDetached) step(c *gc.C, ctx *context) {
 	storageAttachments, err := ctx.st.UnitStorageAttachments(ctx.unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageAttachments, gc.HasLen, 0)
+}
+
+type useActualUpdateStatusRunners struct{}
+
+func (s useActualUpdateStatusRunners) step(c *gc.C, ctx *context) {
+	ctx.enterAbide = uniter.RunUpdateStatusOnce
+	ctx.enterIdle = uniter.RunUpdateStatusOnce
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -293,6 +293,7 @@ var (
 		"install", "start", "config-changed", "upgrade-charm", "stop",
 		"db-relation-joined", "db-relation-changed", "db-relation-departed",
 		"db-relation-broken", "meter-status-changed", "collect-metrics",
+		"update-status",
 	}
 	leaderCharmHooks = []string{
 		"leader-elected", "leader-deposed", "leader-settings-changed",
@@ -859,9 +860,9 @@ func (s changeMeterStatus) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-type metricsTick struct{}
+type timerTick struct{}
 
-func (s metricsTick) step(c *gc.C, ctx *context) {
+func (s timerTick) step(c *gc.C, ctx *context) {
 	err := ctx.ticker.Tick()
 	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
Update status hook needed to be called after returning
from certain statuses and now its called every time
uniter enters abide mode.
Update status needed to be called after a batch of
hooks has been run and it is now run after uniter
enters idle status.

(Review request: http://reviews.vapour.ws/r/1832/)