### PR TITLE
bootstrap command waits till api server is ready before existing

### DIFF
--- a/cmd/juju/bootstrap.go
+++ b/cmd/juju/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	apiblock "github.com/juju/juju/api/block"
+	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/constraints"
@@ -320,8 +321,8 @@ func (c *BootstrapCommand) waitForAgentInitialisation(ctx *cmd.Context) (err err
 		if err == nil {
 			return nil
 		}
-		ctx.Infof("Waiting for API to become available.")
-		if strings.Contains(err.Error(), "upgrade is in progress") {
+		if strings.Contains(err.Error(), apiserver.UpgradeInProgressError.Error()) {
+			ctx.Infof("Waiting for API to become available: %v", err.Error())
 			continue
 		}
 		return err

--- a/cmd/juju/bootstrap.go
+++ b/cmd/juju/bootstrap.go
@@ -6,14 +6,19 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v5"
 	"launchpad.net/gnuflag"
 
+	apiblock "github.com/juju/juju/api/block"
 	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -273,7 +278,55 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	if err != nil {
 		return errors.Annotate(err, "failed to bootstrap environment")
 	}
-	return c.SetBootstrapEndpointAddress(environ)
+	err = c.SetBootstrapEndpointAddress(environ)
+	if err != nil {
+		return errors.Annotate(err, "saving bootstrap endpoint address")
+	}
+	// To avoid race conditions when running scripted bootstraps, wait
+	// for the state server's machine agent to be ready to accept commands
+	// before exiting this bootstrap command.
+	return c.waitForAgentInitialisation(ctx)
+}
+
+var (
+	bootstrapReadyPollDelay = 1 * time.Second
+	bootstrapReadyPollCount = 60
+	blockAPI                = getBlockAPI
+)
+
+// getBlockAPI returns a block api for listing blocks.
+func getBlockAPI(c *envcmd.EnvCommandBase) (block.BlockListAPI, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, err
+	}
+	return apiblock.NewClient(root), nil
+}
+
+// waitForAgentInitialisation polls the bootstrapped state server with a read-only
+// command which will fail until the state server is fully initialised.
+// TODO(wallyworld) - add a bespoke command to maybe the admin facade for this purpose.
+func (c *BootstrapCommand) waitForAgentInitialisation(ctx *cmd.Context) (err error) {
+	client, err := blockAPI(&c.EnvCommandBase)
+	if err != nil {
+		return err
+	}
+	attempts := utils.AttemptStrategy{
+		Min:   bootstrapReadyPollCount,
+		Delay: bootstrapReadyPollDelay,
+	}
+	for attempt := attempts.Start(); attempt.Next(); {
+		_, err = client.List()
+		if err == nil {
+			return nil
+		}
+		ctx.Infof("Waiting for API to become available.")
+		if strings.Contains(err.Error(), "upgrade is in progress") {
+			continue
+		}
+		return err
+	}
+	return err
 }
 
 var environType = func(envName string) (string, error) {

--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -16,7 +17,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/block"
 	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -45,6 +48,7 @@ type BootstrapSuite struct {
 	coretesting.FakeJujuHomeSuite
 	gitjujutesting.MgoSuite
 	envtesting.ToolsFixture
+	mockBlockClient *mockBlockClient
 }
 
 var _ = gc.Suite(&BootstrapSuite{})
@@ -69,6 +73,11 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&envtools.DefaultBaseURL, sourceDir)
 
 	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c))
+
+	s.mockBlockClient = &mockBlockClient{}
+	s.PatchValue(&blockAPI, func(c *envcmd.EnvCommandBase) (block.BlockListAPI, error) {
+		return s.mockBlockClient, nil
+	})
 }
 
 func (s *BootstrapSuite) TearDownSuite(c *gc.C) {
@@ -81,6 +90,66 @@ func (s *BootstrapSuite) TearDownTest(c *gc.C) {
 	s.MgoSuite.TearDownTest(c)
 	s.FakeJujuHomeSuite.TearDownTest(c)
 	dummy.Reset()
+}
+
+type mockBlockClient struct {
+	retry_count int
+	num_retries int
+}
+
+func (c *mockBlockClient) List() ([]params.Block, error) {
+	if c.num_retries < 0 {
+		return nil, fmt.Errorf("other error")
+	}
+	if c.retry_count < c.num_retries {
+		c.retry_count += 1
+		return nil, fmt.Errorf("upgrade is in progress")
+	}
+	return []params.Block{}, nil
+}
+
+func (c *mockBlockClient) Close() error {
+	return nil
+}
+
+func (s *BootstrapSuite) TestBootstrapAPIReadyRetries(c *gc.C) {
+	s.PatchValue(&bootstrapReadyPollDelay, 1*time.Millisecond)
+	s.PatchValue(&bootstrapReadyPollCount, 5)
+	defaultSeriesVersion := version.Current
+	// Force a dev version by having a non zero build number.
+	// This is because we have not uploaded any tools and auto
+	// upload is only enabled for dev versions.
+	defaultSeriesVersion.Build = 1234
+	s.PatchValue(&version.Current, defaultSeriesVersion)
+	for _, t := range []struct {
+		num_retries int
+		err         string
+	}{
+		{0, ""}, // agent ready immediately
+		{2, ""}, // agent ready after 2 polls
+		{6, "upgrade is in progress"}, // agent ready after 6 polls but that's too long
+		{-1, "other error"},           // another error is returned
+	} {
+		resetJujuHome(c, "devenv")
+
+		s.mockBlockClient.num_retries = t.num_retries
+		s.mockBlockClient.retry_count = 0
+		_, err := coretesting.RunCommand(c, envcmd.Wrap(&BootstrapCommand{}), "-e", "devenv")
+		if t.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, t.err)
+		}
+		expectedRetries := 0
+		if t.num_retries > 0 {
+			expectedRetries = t.num_retries
+		}
+		// Only retry maximum of bootstrapReadyPollCount times.
+		if expectedRetries > 5 {
+			expectedRetries = 5
+		}
+		c.Check(s.mockBlockClient.retry_count, gc.Equals, expectedRetries)
+	}
 }
 
 func (s *BootstrapSuite) TestRunTests(c *gc.C) {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1272,7 +1272,7 @@ func (a *MachineAgent) limitLoginsDuringUpgrade(req params.LoginRequest) error {
 				return nil
 			}
 		}
-		return errors.Errorf("login for %q blocked because upgrade is in progress", authTag)
+		return errors.Errorf("login for %q blocked because %s", authTag, apiserver.UpgradeInProgressError.Error())
 	} else {
 		return nil // allow all logins
 	}


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1460171

Before the bootstrap command exits, it will "poll" the state server API until the API is ready. This "poll" is done by running a read-only command juju block list. 

The end effect is that when bootstrap exists, the state server is ready to accept commands, and this will prevent scripted deployments from exiting because juju-deployer gets an "upgrade in progress" error.

(Review request: http://reviews.vapour.ws/r/1836/)