### PR TITLE
Check for white space in dependencies.tsv

### DIFF
--- a/dependencies_test.go
+++ b/dependencies_test.go
@@ -39,5 +39,9 @@ func (*dependenciesTest) TestDependenciesTsvFormat(c *gc.C) {
 		}
 		segments := strings.Split(line, "\t")
 		c.Assert(segments, gc.HasLen, 4)
+		for _, seg := range segments {
+			c.Assert(strings.HasPrefix(seg, " "), jc.IsFalse)
+			c.Assert(strings.HasSuffix(seg, " "), jc.IsFalse)
+		}
 	}
 }


### PR DESCRIPTION
If a revision id begins or ends with a space,
TestDependenciesTsvFormat will pass, but godeps will fail. Update the
test to check that the prefix and suffix are not spaces.

(Review request: http://reviews.vapour.ws/r/1840/)