### PR TITLE
Fix 1376246: MAAS Failed deployment

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -50,6 +50,6 @@ gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20141121040613-ztm1q0iy9rune3zt	13
-launchpad.net/gomaasapi	bzr	ian.booth@canonical.com-20150113032002-n7hj4l5a9j9dzaa0	61
+launchpad.net/gomaasapi	bzr	jesse.meek@canonical.com-20150602215105-oh5pin1u2qe8ct89	62
 launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20141203072923-27pcp2hckqyezbfe	242
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1021,6 +1021,9 @@ func (environ *maasEnviron) waitForNodeDeployment(id instance.Id) error {
 		if statusValues[systemId] == "Deployed" {
 			return nil
 		}
+		if statusValues[systemId] == "Failed deployment" {
+			return errors.Errorf("instance %q failed to deploy", id)
+		}
 	}
 	return errors.Errorf("instance %q is started but not deployed", id)
 }


### PR DESCRIPTION
Ensure maas.waitForNodeDeployment returns an error if the node
status is "Failed deployment". This PR relies on an updated gomaasapi
to report the correct node status.

Forward port of bug fix targeting 1.24.

(Review request: http://reviews.vapour.ws/r/1841/)