### PR TITLE
Fix container provisioner

### DIFF
--- a/cmd/juju/bootstrap.go
+++ b/cmd/juju/bootstrap.go
@@ -321,6 +321,7 @@ func (c *BootstrapCommand) waitForAgentInitialisation(ctx *cmd.Context) (err err
 		_, err = client.List()
 		client.Close()
 		if err == nil {
+			ctx.Infof("Bootstrap complete")
 			return nil
 		}
 		if strings.Contains(err.Error(), apiserver.UpgradeInProgressError.Error()) {

--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -407,13 +407,13 @@ func (*mockBootstrapInstance) Addresses() ([]network.Address, error) {
 func (s *BootstrapSuite) TestSeriesDeprecation(c *gc.C) {
 	ctx := s.checkSeriesArg(c, "--series")
 	c.Check(coretesting.Stderr(ctx), gc.Equals,
-		"Use of --series is obsolete. --upload-tools now expands to all supported series of the same operating system.\n")
+		"Use of --series is obsolete. --upload-tools now expands to all supported series of the same operating system.\nBootstrap complete\n")
 }
 
 func (s *BootstrapSuite) TestUploadSeriesDeprecation(c *gc.C) {
 	ctx := s.checkSeriesArg(c, "--upload-series")
 	c.Check(coretesting.Stderr(ctx), gc.Equals,
-		"Use of --upload-series is obsolete. --upload-tools now expands to all supported series of the same operating system.\n")
+		"Use of --upload-series is obsolete. --upload-tools now expands to all supported series of the same operating system.\nBootstrap complete\n")
 }
 
 func (s *BootstrapSuite) checkSeriesArg(c *gc.C, argVariant string) *cmd.Context {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -169,7 +169,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	if err := finalizer(ctx, instanceConfig); err != nil {
 		return err
 	}
-	ctx.Infof("Bootstrap complete")
+	ctx.Infof("Bootstrap agent installed")
 	return nil
 }
 

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -278,11 +278,11 @@ func (p *containerProvisioner) loop() error {
 	environConfigChanges = environWatcher.Changes()
 	defer watcher.Stop(environWatcher, &p.tomb)
 
-	environ, err := worker.WaitForEnviron(environWatcher, p.st, p.tomb.Dying())
+	config, err := p.st.EnvironConfig()
 	if err != nil {
 		return err
 	}
-	harvestMode := environ.Config().ProvisionerHarvestMode()
+	harvestMode := config.ProvisionerHarvestMode()
 
 	task, err := p.getStartTask(harvestMode)
 	if err != nil {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1461150

The container provisioner was loading an environment when it didn't need to.

Also, drive by improvement to bootstrap messages.

(Review request: http://reviews.vapour.ws/r/1843/)