### PR TITLE
storage-add is provided only count.

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -744,9 +744,6 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 	all := make([]params.StorageAddParams, 0, len(constraints))
 	for storage, cons := range constraints {
 		for _, one := range cons {
-			if one != (params.StorageConstraints{Count: one.Count}) {
-				return errors.Errorf("only count can be specified for %q", storage)
-			}
 			all = append(all, params.StorageAddParams{u.Tag().String(), storage, one})
 		}
 	}

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -744,7 +744,7 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 	all := make([]params.StorageAddParams, 0, len(constraints))
 	for storage, cons := range constraints {
 		for _, one := range cons {
-			if one.Pool != "" || one.Size != nil {
+			if one != (params.StorageConstraints{Count: one.Count}) {
 				return errors.Errorf("only count can be specified for %q", storage)
 			}
 			all = append(all, params.StorageAddParams{u.Tag().String(), storage, one})

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -744,6 +744,9 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 	all := make([]params.StorageAddParams, 0, len(constraints))
 	for storage, cons := range constraints {
 		for _, one := range cons {
+			if one.Pool != "" || one.Size != nil {
+				return errors.Errorf("only count can be specified for %q", storage)
+			}
 			all = append(all, params.StorageAddParams{u.Tag().String(), storage, one})
 		}
 	}

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -28,14 +28,15 @@ func (s *unitStorageSuite) createTestUnit(c *gc.C, t string, apiCaller basetesti
 }
 
 func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
+	count := uint64(1)
 	args := map[string][]params.StorageConstraints{
 		"data": []params.StorageConstraints{
-			params.StorageConstraints{Pool: "loop"}},
+			params.StorageConstraints{Count: &count}},
 	}
 
 	expected := params.StoragesAddParams{
 		Storages: []params.StorageAddParams{
-			{"unit-mysql-0", "data", params.StorageConstraints{Pool: "loop"}},
+			{"unit-mysql-0", "data", params.StorageConstraints{Count: &count}},
 		},
 	}
 
@@ -59,13 +60,14 @@ func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 }
 
 func (s *unitStorageSuite) TestAddUnitStorageError(c *gc.C) {
+	count := uint64(1)
 	args := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{params.StorageConstraints{Pool: "loop"}},
+		"data": []params.StorageConstraints{params.StorageConstraints{Count: &count}},
 	}
 
 	expected := params.StoragesAddParams{
 		Storages: []params.StorageAddParams{
-			{"unit-mysql-0", "data", params.StorageConstraints{Pool: "loop"}},
+			{"unit-mysql-0", "data", params.StorageConstraints{Count: &count}},
 		},
 	}
 

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -26,6 +26,7 @@ type storageStateInterface interface {
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
+	UnitConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
 }
 
 type storageStateShim struct {
@@ -49,4 +50,19 @@ func (s storageStateShim) UnitAssignedMachine(tag names.UnitTag) (names.MachineT
 		return names.MachineTag{}, errors.Trace(err)
 	}
 	return names.NewMachineTag(mid), nil
+}
+
+// UnitConstraints returns storage constraints for this unit,
+// or an error if the unit or its constraints cannot be obtained.
+func (s storageStateShim) UnitConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error) {
+	unit, err := s.Unit(u.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cons, err := unit.StorageConstraints()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return cons, nil
 }

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -26,7 +26,7 @@ type storageStateInterface interface {
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
-	UnitConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
+	UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
 }
 
 type storageStateShim struct {
@@ -52,9 +52,9 @@ func (s storageStateShim) UnitAssignedMachine(tag names.UnitTag) (names.MachineT
 	return names.NewMachineTag(mid), nil
 }
 
-// UnitConstraints returns storage constraints for this unit,
+// UnitStorageConstraints returns storage constraints for this unit,
 // or an error if the unit or its constraints cannot be obtained.
-func (s storageStateShim) UnitConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error) {
+func (s storageStateShim) UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error) {
 	unit, err := s.Unit(u.Id())
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -375,11 +375,11 @@ func validConstraints(
 
 	onlyCount := params.StorageConstraints{Count: p.Constraints.Count}
 	if p.Constraints != onlyCount {
-		return emptyCons, errors.Errorf("only count can be specified for %q", p.StorageName)
+		return emptyCons, errors.New("only count can be specified")
 	}
 
 	if p.Constraints.Count == nil || *p.Constraints.Count == 0 {
-		return emptyCons, errors.Errorf("count must be specified for %q", p.StorageName)
+		return emptyCons, errors.New("count must be specified")
 	}
 
 	result.Count = *p.Constraints.Count

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -342,7 +342,7 @@ func (a *StorageAPI) AddUnitStorage(
 			continue
 		}
 
-		cons, err := a.st.UnitConstraints(u)
+		cons, err := a.st.UnitStorageConstraints(u)
 		if err != nil {
 			result[i] = serverErr(err)
 			continue
@@ -367,21 +367,22 @@ func validConstraints(
 	cons map[string]state.StorageConstraints,
 ) (state.StorageConstraints, error) {
 	emptyCons := state.StorageConstraints{}
-	onlyCount := params.StorageConstraints{Count: p.Constraints.Count}
-
-	if p.Constraints != onlyCount {
-		return emptyCons, errors.Errorf("only count can be specified for %q", p.StorageName)
-	}
 
 	result, ok := cons[p.StorageName]
 	if !ok {
 		return emptyCons, errors.NotFoundf("storage %q", p.StorageName)
 	}
 
-	result.Count = 0
-	if p.Constraints.Count != nil {
-		result.Count = *p.Constraints.Count
+	onlyCount := params.StorageConstraints{Count: p.Constraints.Count}
+	if p.Constraints != onlyCount {
+		return emptyCons, errors.Errorf("only count can be specified for %q", p.StorageName)
 	}
+
+	if p.Constraints.Count == nil || *p.Constraints.Count == 0 {
+		return emptyCons, errors.Errorf("count must be specified for %q", p.StorageName)
+	}
+
+	result.Count = *p.Constraints.Count
 	return result, nil
 }
 

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -369,10 +369,10 @@ func (s *storageSuite) TestAddUnitStorageConstraintsErrors(c *gc.C) {
 	})
 	c.Assert(errors, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
-			{&params.Error{Message: `adding storage data for unit-mysql-0: only count can be specified for "data"`}},
-			{&params.Error{Message: `adding storage data for unit-mysql-0: only count can be specified for "data"`}},
-			{&params.Error{Message: `adding storage data for unit-mysql-0: count must be specified for "data"`}},
-			{&params.Error{Message: `adding storage data for unit-mysql-0: count must be specified for "data"`}},
+			{&params.Error{Message: `adding storage data for unit-mysql-0: only count can be specified`}},
+			{&params.Error{Message: `adding storage data for unit-mysql-0: only count can be specified`}},
+			{&params.Error{Message: `adding storage data for unit-mysql-0: count must be specified`}},
+			{&params.Error{Message: `adding storage data for unit-mysql-0: count must be specified`}},
 			{&params.Error{
 				Code:    "not found",
 				Message: "adding storage store for unit-mysql-0: storage \"store\" not found"}},

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -5,11 +5,9 @@ package uniter_test
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
 
@@ -22,6 +20,7 @@ import (
 
 type storageSuite struct {
 	testing.BaseSuite
+	called []string
 }
 
 var _ = gc.Suite(&storageSuite{})
@@ -299,9 +298,14 @@ func (s *storageSuite) TestRemoveStorageAttachments(c *gc.C) {
 	})
 }
 
-func (s *storageSuite) TestAddUnitStorage(c *gc.C) {
-	setMock := func(st *mockStorageState, f func(tag names.UnitTag, name string, cons state.StorageConstraints) error) {
-		st.addUnitStorage = f
+const (
+	unitConstraintsCall = "mockConstraints"
+	addStorageCall      = "mockAdd"
+)
+
+func (s *storageSuite) TestAddUnitStorageConstraintsErrors(c *gc.C) {
+	setMockConstraints := func(st *mockStorageState, f func(u names.UnitTag) (map[string]state.StorageConstraints, error)) {
+		st.unitConstraints = f
 	}
 
 	unitTag0 := names.NewUnitTag("mysql/0")
@@ -315,45 +319,134 @@ func (s *storageSuite) TestAddUnitStorage(c *gc.C) {
 		}, nil
 	}
 
-	p := "blah"
-	size := uint64(1)
-	pools := set.NewStrings("", p)
-	sizes := set.NewStrings("0", "1")
-
-	isCalled := false
+	s.called = []string{}
 	mockState := &mockStorageState{}
-	setMock(mockState, func(u names.UnitTag, name string, cons state.StorageConstraints) error {
-		isCalled = true
+	setMockConstraints(mockState, func(u names.UnitTag) (map[string]state.StorageConstraints, error) {
+		s.called = append(s.called, unitConstraintsCall)
+		c.Assert(u, gc.DeepEquals, unitTag0)
+
+		return map[string]state.StorageConstraints{
+			storageName0: state.StorageConstraints{},
+		}, nil
+	})
+
+	storage, err := uniter.NewStorageAPI(mockState, resources, getCanAccess)
+	c.Assert(err, jc.ErrorIsNil)
+	size := uint64(10)
+	errors, err := storage.AddUnitStorage(params.StoragesAddParams{
+		Storages: []params.StorageAddParams{
+			{
+				UnitTag:     unitTag0.String(),
+				StorageName: storageName0,
+				Constraints: params.StorageConstraints{Pool: "matter"},
+			}, {
+				UnitTag:     unitTag0.String(),
+				StorageName: storageName0,
+				Constraints: params.StorageConstraints{Size: &size},
+			}, {
+				UnitTag:     unitTag0.String(),
+				StorageName: storageName1,
+				Constraints: params.StorageConstraints{},
+			},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.called, jc.SameContents, []string{
+		unitConstraintsCall,
+		unitConstraintsCall,
+		unitConstraintsCall,
+	})
+	c.Assert(errors, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{&params.Error{Message: `adding storage data for unit-mysql-0: only count can be specified for "data"`}},
+			{&params.Error{Message: `adding storage data for unit-mysql-0: only count can be specified for "data"`}},
+			{&params.Error{
+				Code:    "not found",
+				Message: "adding storage store for unit-mysql-0: storage \"store\" not found"}},
+		},
+	})
+}
+
+func (s *storageSuite) TestAddUnitStorage(c *gc.C) {
+	setMockConstraints := func(st *mockStorageState, f func(u names.UnitTag) (map[string]state.StorageConstraints, error)) {
+		st.unitConstraints = f
+	}
+	setMockAdd := func(st *mockStorageState, f func(tag names.UnitTag, name string, cons state.StorageConstraints) error) {
+		st.addUnitStorage = f
+	}
+
+	unitTag0 := names.NewUnitTag("mysql/0")
+	storageName0 := "data"
+	storageName1 := "store"
+
+	unitPool := "real"
+	size := uint64(3)
+	unitSize := size * 2
+	unitCount := uint64(100)
+	testCount := uint64(10)
+
+	resources := common.NewResources()
+	getCanAccess := func() (common.AuthFunc, error) {
+		return func(tag names.Tag) bool {
+			return tag == unitTag0
+		}, nil
+	}
+
+	s.called = []string{}
+	mockState := &mockStorageState{}
+
+	setMockConstraints(mockState, func(u names.UnitTag) (map[string]state.StorageConstraints, error) {
+		s.called = append(s.called, unitConstraintsCall)
+		c.Assert(u, gc.DeepEquals, unitTag0)
+
+		return map[string]state.StorageConstraints{
+			storageName0: state.StorageConstraints{
+				Pool:  unitPool,
+				Size:  unitSize,
+				Count: unitCount,
+			},
+			storageName1: state.StorageConstraints{},
+		}, nil
+	})
+
+	setMockAdd(mockState, func(u names.UnitTag, name string, cons state.StorageConstraints) error {
+		s.called = append(s.called, addStorageCall)
 		c.Assert(u, gc.DeepEquals, unitTag0)
 		if name == storageName1 {
 			return errors.New("badness")
 		}
-		c.Assert(cons.Count, gc.Equals, uint64(0))
-		c.Assert(pools.Contains(cons.Pool), jc.IsTrue)
-		c.Assert(sizes.Contains(fmt.Sprintf("%d", cons.Size)), jc.IsTrue)
+		c.Assert(cons.Count, gc.Not(gc.Equals), unitCount)
+		c.Assert(cons.Count == testCount || cons.Count == uint64(0), jc.IsTrue)
+		c.Assert(cons.Pool, jc.DeepEquals, unitPool)
+		c.Assert(cons.Size, jc.DeepEquals, unitSize)
 		return nil
 	})
 
 	storage, err := uniter.NewStorageAPI(mockState, resources, getCanAccess)
 	c.Assert(err, jc.ErrorIsNil)
 	errors, err := storage.AddUnitStorage(params.StoragesAddParams{
-		Storages: []params.StorageAddParams{{
-			UnitTag:     unitTag0.String(),
-			StorageName: storageName0,
-			Constraints: params.StorageConstraints{Pool: p},
-		}, {
-			UnitTag:     unitTag0.String(),
-			StorageName: storageName0,
-			Constraints: params.StorageConstraints{Size: &size},
-		}, {
-			UnitTag:     unitTag0.String(),
-			StorageName: storageName1,
-			Constraints: params.StorageConstraints{},
-		},
+		Storages: []params.StorageAddParams{
+			{
+				UnitTag:     unitTag0.String(),
+				StorageName: storageName0,
+				Constraints: params.StorageConstraints{},
+			}, {
+				UnitTag:     unitTag0.String(),
+				StorageName: storageName0,
+				Constraints: params.StorageConstraints{Count: &testCount},
+			}, {
+				UnitTag:     unitTag0.String(),
+				StorageName: storageName1,
+				Constraints: params.StorageConstraints{},
+			},
 		}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(isCalled, jc.IsTrue)
+	c.Assert(s.called, jc.SameContents, []string{
+		unitConstraintsCall, addStorageCall,
+		unitConstraintsCall, addStorageCall,
+		unitConstraintsCall, addStorageCall,
+	})
 	c.Assert(errors, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
 			{nil},
@@ -376,6 +469,7 @@ type mockStorageState struct {
 	watchFilesystemAttachment     func(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	watchVolumeAttachment         func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	addUnitStorage                func(u names.UnitTag, name string, cons state.StorageConstraints) error
+	unitConstraints               func(u names.UnitTag) (map[string]state.StorageConstraints, error)
 }
 
 func (m *mockStorageState) DestroyUnitStorageAttachments(u names.UnitTag) error {
@@ -420,6 +514,10 @@ func (m *mockStorageState) WatchVolumeAttachment(mtag names.MachineTag, v names.
 
 func (m *mockStorageState) AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error {
 	return m.addUnitStorage(tag, name, cons)
+}
+
+func (m *mockStorageState) UnitConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error) {
+	return m.unitConstraints(u)
 }
 
 type mockStringsWatcher struct {

--- a/worker/uniter/runner/flush_test.go
+++ b/worker/uniter/runner/flush_test.go
@@ -376,7 +376,7 @@ func (s *FlushContextSuite) TestRunHookAddUnitStorageOnSuccess(c *gc.C) {
 
 	// Flush the context with a success.
 	err = ctx.FlushContext("success", nil)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, `.*charm storage "allecto" not found.*`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, `.*storage "allecto" not found.*`)
 
 	all, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -26,35 +26,16 @@ func NewStorageAddCommand(ctx Context) cmd.Command {
 var StorageAddDoc = `
 Storage add adds storage instances to unit using provided storage directives.
 A storage directive consists of a storage name as per charm specification
-and storage constraints, e.g. pool, count, size.
+and optional storage COUNT.
 
-The acceptable format for storage constraints is a comma separated
-sequence of: POOL, COUNT, and SIZE, where
-
-    POOL identifies the storage pool. POOL can be a string
-    starting with a letter, followed by zero or more digits
-    or letters optionally separated by hyphens.
-
-    COUNT is a positive integer indicating how many instances
-    of the storage to create. If unspecified, and SIZE is
-    specified, COUNT defaults to 1.
-
-    SIZE describes the minimum size of the storage instances to
-    create. SIZE is a floating point number and multiplier from
-    the set (M, G, T, P, E, Z, Y), which are all treated as
-    powers of 1024.
-
-Storage constraints can be optionally ommitted.
-Environment default values will be used for all ommitted constraint values.
-There is no need to comma-separate ommitted constraints, e.g. 
-    data=ebs,2,    <equivalent to>   data=ebs,2
-    data=1         <equivalent to>   data
+COUNT is a positive integer indicating how many instances
+of the storage to create. If unspecified, COUNT defaults to 1.
 `
 
 func (s *StorageAddCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "storage-add",
-		Args:    "<charm storage name>=<constraints> ...",
+		Args:    "<charm storage name>[=count] ...",
 		Purpose: "add storage instances",
 		Doc:     StorageAddDoc,
 	}
@@ -72,12 +53,10 @@ func (s *StorageAddCommand) Init(args []string) error {
 
 	s.all = make(map[string]params.StorageConstraints, len(cons))
 	for k, v := range cons {
-		// Unit should not be able to specify from which pool to add storage
-		// nor what size storage should be.
 		if v.Pool != "" || v.Size > 0 {
 			return errors.Errorf("only count can be specified for %q", k)
 		}
-		s.all[k] = params.StorageConstraints{v.Pool, &v.Size, &v.Count}
+		s.all[k] = params.StorageConstraints{Count: &v.Count}
 	}
 	return nil
 }

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -75,7 +75,7 @@ func (s *StorageAddCommand) Init(args []string) error {
 		// Unit should not be able to specify from which pool to add storage
 		// nor what size storage should be.
 		if v.Pool != "" || v.Size > 0 {
-			return errors.Errorf("pool or size specified for %q", k)
+			return errors.Errorf("only count can be specified for %q", k)
 		}
 		s.all[k] = params.StorageConstraints{v.Pool, &v.Size, &v.Count}
 	}

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -53,7 +53,7 @@ func (s *StorageAddCommand) Init(args []string) error {
 
 	s.all = make(map[string]params.StorageConstraints, len(cons))
 	for k, v := range cons {
-		if v.Pool != "" || v.Size > 0 {
+		if v != (storage.Constraints{Count: v.Count}) {
 			return errors.Errorf("only count can be specified for %q", k)
 		}
 		s.all[k] = params.StorageConstraints{Count: &v.Count}

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -72,6 +72,11 @@ func (s *StorageAddCommand) Init(args []string) error {
 
 	s.all = make(map[string]params.StorageConstraints, len(cons))
 	for k, v := range cons {
+		// Unit should not be able to specify from which pool to add storage
+		// nor what size storage should be.
+		if v.Pool != "" || v.Size > 0 {
+			return errors.Errorf("pool or size specified for %q", k)
+		}
 		s.all[k] = params.StorageConstraints{v.Pool, &v.Size, &v.Count}
 	}
 	return nil

--- a/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/worker/uniter/runner/jujuc/storage-add_test.go
@@ -58,11 +58,11 @@ func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
 		{[]string{}, 1, "storage add requires a storage directive"},
 		{[]string{"data=-676"}, 1, `.*cannot parse count: count must be gre.*`},
 		{[]string{"data="}, 1, ".*storage constraints require at least one.*"},
-		{[]string{"data=pool"}, 1, `.*pool or size specified for "data".*`},
-		{[]string{"data=pool,1M"}, 1, `.*pool or size specified for "data".*`},
-		{[]string{"data=1M"}, 1, `.*pool or size specified for "data".*`},
-		{[]string{"data=2,1M"}, 1, `.*pool or size specified for "data".*`},
-		{[]string{"cache", "data=2,1M"}, 1, `.*pool or size specified for "data".*`},
+		{[]string{"data=pool"}, 1, `.*only count can be specified for "data".*`},
+		{[]string{"data=pool,1M"}, 1, `.*only count can be specified for "data".*`},
+		{[]string{"data=1M"}, 1, `.*only count can be specified for "data".*`},
+		{[]string{"data=2,1M"}, 1, `.*only count can be specified for "data".*`},
+		{[]string{"cache", "data=2,1M"}, 1, `.*only count can be specified for "data".*`},
 	}
 	for i, t := range tests {
 		c.Logf("test %d: %#v", i, t.args)

--- a/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/worker/uniter/runner/jujuc/storage-add_test.go
@@ -58,6 +58,11 @@ func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
 		{[]string{}, 1, "storage add requires a storage directive"},
 		{[]string{"data=-676"}, 1, `.*cannot parse count: count must be gre.*`},
 		{[]string{"data="}, 1, ".*storage constraints require at least one.*"},
+		{[]string{"data=pool"}, 1, `.*pool or size specified for "data".*`},
+		{[]string{"data=pool,1M"}, 1, `.*pool or size specified for "data".*`},
+		{[]string{"data=1M"}, 1, `.*pool or size specified for "data".*`},
+		{[]string{"data=2,1M"}, 1, `.*pool or size specified for "data".*`},
+		{[]string{"cache", "data=2,1M"}, 1, `.*pool or size specified for "data".*`},
 	}
 	for i, t := range tests {
 		c.Logf("test %d: %#v", i, t.args)

--- a/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/worker/uniter/runner/jujuc/storage-add_test.go
@@ -35,7 +35,7 @@ func (s *storageAddSuite) TestHelp(c *gc.C) {
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	help := `
-usage: storage-add <charm storage name>=<constraints> ...
+usage: storage-add <charm storage name>[=count] ...
 purpose: add storage instances
 `[1:] +
 		jujuc.StorageAddDoc

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -75,7 +75,43 @@ func (s *unitStorageSuite) TestAddUnitStorageZeroCount(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(after)-s.initialStorageInstancesCount, gc.Equals, 0)
 	s.assertExistingStorage(c, after)
+}
 
+func (s *unitStorageSuite) TestAddUnitStorageWithSize(c *gc.C) {
+	s.createStorageBlockUnit(c)
+	size := uint64(1)
+	cons := map[string]params.StorageConstraints{
+		"allecto": params.StorageConstraints{Size: &size}}
+
+	ctx := s.addUnitStorage(c, cons)
+
+	// Flush the context with a success.
+	err := ctx.FlushContext("success", nil)
+	c.Assert(err, gc.ErrorMatches, `.*only count can be specified for "allecto".*`)
+
+	// Make sure no storage instances was added
+	after, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(after)-s.initialStorageInstancesCount, gc.Equals, 0)
+	s.assertExistingStorage(c, after)
+}
+
+func (s *unitStorageSuite) TestAddUnitStorageWithPool(c *gc.C) {
+	s.createStorageBlockUnit(c)
+	cons := map[string]params.StorageConstraints{
+		"allecto": params.StorageConstraints{Pool: "loop"}}
+
+	ctx := s.addUnitStorage(c, cons)
+
+	// Flush the context with a success.
+	err := ctx.FlushContext("success", nil)
+	c.Assert(err, gc.ErrorMatches, `.*only count can be specified for "allecto".*`)
+
+	// Make sure no storage instances was added
+	after, err := s.State.AllStorageInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(after)-s.initialStorageInstancesCount, gc.Equals, 0)
+	s.assertExistingStorage(c, after)
 }
 
 func (s *unitStorageSuite) TestAddUnitStorageAccumulated(c *gc.C) {

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -68,7 +68,7 @@ func (s *unitStorageSuite) TestAddUnitStorageZeroCount(c *gc.C) {
 
 	// Flush the context with a success.
 	err := ctx.FlushContext("success", nil)
-	c.Assert(err, gc.ErrorMatches, `.*adding storage where instance count is 0 not valid.*`)
+	c.Assert(err, gc.ErrorMatches, `.*count must be specified.*`)
 
 	// Make sure no storage instances was added
 	after, err := s.State.AllStorageInstances()
@@ -87,7 +87,7 @@ func (s *unitStorageSuite) TestAddUnitStorageWithSize(c *gc.C) {
 
 	// Flush the context with a success.
 	err := ctx.FlushContext("success", nil)
-	c.Assert(err, gc.ErrorMatches, `.*only count can be specified for "allecto".*`)
+	c.Assert(err, gc.ErrorMatches, `.*only count can be specified.*`)
 
 	// Make sure no storage instances was added
 	after, err := s.State.AllStorageInstances()
@@ -105,7 +105,7 @@ func (s *unitStorageSuite) TestAddUnitStorageWithPool(c *gc.C) {
 
 	// Flush the context with a success.
 	err := ctx.FlushContext("success", nil)
-	c.Assert(err, gc.ErrorMatches, `.*only count can be specified for "allecto".*`)
+	c.Assert(err, gc.ErrorMatches, `.*only count can be specified.*`)
 
 	// Make sure no storage instances was added
 	after, err := s.State.AllStorageInstances()

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -61,9 +61,8 @@ func (s *unitStorageSuite) TestAddUnitStorageIgnoresBlocks(c *gc.C) {
 
 func (s *unitStorageSuite) TestAddUnitStorageZeroCount(c *gc.C) {
 	s.createStorageBlockUnit(c)
-	size := uint64(1)
 	cons := map[string]params.StorageConstraints{
-		"allecto": params.StorageConstraints{Size: &size}}
+		"allecto": params.StorageConstraints{}}
 
 	ctx := s.addUnitStorage(c, cons)
 
@@ -82,10 +81,9 @@ func (s *unitStorageSuite) TestAddUnitStorageZeroCount(c *gc.C) {
 func (s *unitStorageSuite) TestAddUnitStorageAccumulated(c *gc.C) {
 	s.createStorageBlock2Unit(c)
 	count := uint64(1)
-	size := uint64(2048)
 	s.assertUnitStorageAdded(c,
 		map[string]params.StorageConstraints{
-			"multi2up": params.StorageConstraints{Size: &size, Count: &count}},
+			"multi2up": params.StorageConstraints{Count: &count}},
 		map[string]params.StorageConstraints{
 			"multi1to10": params.StorageConstraints{Count: &count}})
 }
@@ -93,10 +91,9 @@ func (s *unitStorageSuite) TestAddUnitStorageAccumulated(c *gc.C) {
 func (s *unitStorageSuite) TestAddUnitStorageAccumulatedSame(c *gc.C) {
 	s.createStorageBlock2Unit(c)
 	count := uint64(1)
-	size := uint64(2048)
 	s.assertUnitStorageAdded(c,
 		map[string]params.StorageConstraints{
-			"multi2up": params.StorageConstraints{Size: &size, Count: &count}},
+			"multi2up": params.StorageConstraints{Count: &count}},
 		map[string]params.StorageConstraints{
 			"multi2up": params.StorageConstraints{Count: &count}})
 }


### PR DESCRIPTION
 Units should only be able to request more of storage that has already been assigned, i.e. they should be able to specify count.


(Review request: http://reviews.vapour.ws/r/1844/)