### PR TITLE
fix bug in namespace usage (lp:1461354)

### DIFF
--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -103,3 +103,28 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 		c.Check(dialTag, gc.Equals, "juju-foo-"+m.Tag().String())
 	}
 }
+
+func (s *RsyslogSuite) TestNoNamespace(c *gc.C) {
+	err := s.APIState.Client().EnvironmentSet(map[string]interface{}{
+		"rsyslog-ca-cert": coretesting.CACert,
+		"rsyslog-ca-key":  coretesting.CAKey,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
+	addrs := []string{"0.1.2.3", "0.2.4.6"}
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", addrs, s.DataDir())
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+
+	// We should get a ca-cert.pem with the contents introduced into state config.
+	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(caCertPEM), gc.DeepEquals, coretesting.CACert)
+
+	c.Assert(*rsyslog.SyslogTargets, gc.HasLen, 2)
+	for _, dialTag := range s.dialTags {
+		c.Check(dialTag, gc.Equals, "juju-"+m.Tag().String())
+	}
+}

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -205,7 +205,11 @@ func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {
 			host = j
 		}
 		target := fmt.Sprintf("%s:%d", host, h.syslogConfig.Port)
-		logTag := "juju" + "-" + h.syslogConfig.Namespace + "-" + h.tag.String()
+		namespace := h.syslogConfig.Namespace
+		if namespace != "" {
+			namespace = "-" + namespace
+		}
+		logTag := "juju" + namespace + "-" + h.tag.String()
 		logger.Debugf("making syslog connection for %q to %s", logTag, target)
 		writer, err := dialSyslog("tcp", target, rsyslog.LOG_DEBUG, logTag, tlsConf)
 		if err != nil {


### PR DESCRIPTION
fixes-1461354

https://bugs.launchpad.net/juju-core/+bug/1461354
debug-log EOF: invalid tag and panic seen in state server logs

This was a result of me changing the namespace stored in the config to no longer store the leading "-". Instead, it just stores the namespace itself, and where we use it, we have to format it correctly. This seems like a much more sane way to do it, so the value you set is the value that exists, and we don't dictate formatting to everyone using the namespace.... however, it meant I forgot to check for an empty namespace in this one case.

(Review request: http://reviews.vapour.ws/r/1855/)