### PR TITLE
worker/envworkermanager: always stop worker on exit

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1062,7 +1062,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 func (a *MachineAgent) startEnvWorkers(
 	ssSt envworkermanager.InitialState,
 	st *state.State,
-) (runner worker.Runner, err error) {
+) (_ worker.Worker, err error) {
 	envUUID := st.EnvironUUID()
 	defer errors.DeferredAnnotatef(&err, "failed to start workers for env %s", envUUID)
 	logger.Infof("starting workers for env %s", envUUID)
@@ -1079,7 +1079,7 @@ func (a *MachineAgent) startEnvWorkers(
 	// Create a runner for workers specific to this
 	// environment. Either the State or API connection failing will be
 	// considered fatal, killing the runner and all its workers.
-	runner = newConnRunner(st, apiSt)
+	runner := newConnRunner(st, apiSt)
 	defer func() {
 		if err != nil && runner != nil {
 			runner.Kill()


### PR DESCRIPTION
This fixes an intermittent test failure in TestLoopExitKillsRunner
which happened because the underlying worker was not killed
when the loop terminated with an error.

We also change the API into a slightly more general form - there's
no need for the EnvWorkerManager to know that the worker
it's dealing with is actually a worker.Runner, and this makes
the tests slightly simpler to write (and arguably the API easier
to understand)


(Review request: http://reviews.vapour.ws/r/1858/)