### PR TITLE
cmd/juju/agent: stop watcher in waitForOtherStateServers

### DIFF
--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -277,6 +277,7 @@ func (c *upgradeWorkerContext) prepareForUpgrade() (*state.UpgradeInfo, error) {
 
 func (c *upgradeWorkerContext) waitForOtherStateServers(info *state.UpgradeInfo) error {
 	watcher := info.Watch()
+	defer watcher.Stop()
 
 	maxWait := getUpgradeStartTimeout(c.isMaster)
 	timeout := time.After(maxWait)


### PR DESCRIPTION
Without this change, UpgradeSuite fails more often than not (it panics). With it,
it passes consistently for me.


(Review request: http://reviews.vapour.ws/r/1859/)