### PR TITLE
Use template generation for starting KVM instances with a MAC address

### DIFF
--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/network"
 )
 
 type kvmContainer struct {
@@ -33,9 +34,11 @@ func (c *kvmContainer) Start(params StartParams) error {
 		return err
 	}
 	var bridge string
+	var interfaces []network.InterfaceInfo
 	if params.Network != nil {
 		if params.Network.NetworkType == container.BridgeNetwork {
 			bridge = params.Network.Device
+			interfaces = params.Network.Interfaces
 		} else {
 			err := errors.New("Non-bridge network devices not yet supported")
 			logger.Infof(err.Error())
@@ -52,7 +55,7 @@ func (c *kvmContainer) Start(params StartParams) error {
 		Memory:        params.Memory,
 		CpuCores:      params.CpuCores,
 		RootDisk:      params.RootDisk,
-		Interfaces:    params.Network.Interfaces,
+		Interfaces:    interfaces,
 	}); err != nil {
 		return err
 	}

--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -52,6 +52,7 @@ func (c *kvmContainer) Start(params StartParams) error {
 		Memory:        params.Memory,
 		CpuCores:      params.CpuCores,
 		RootDisk:      params.RootDisk,
+		Interfaces:    params.Network.Interfaces,
 	}); err != nil {
 		return err
 	}

--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -5,6 +5,8 @@ package kvm
 
 var KVMPath = &kvmPath
 
+var KVMRun = &run
+
 // Used to export the parameters used to call Start on the KVM Container
 var TestStartParams = &startParams
 

--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -5,7 +5,6 @@ package kvm
 
 var (
 	KVMPath = &kvmPath
-	KVMRun  = &run
 
 	// Used to export the parameters used to call Start on the KVM Container
 	TestStartParams = &startParams

--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -3,12 +3,13 @@ package kvm
 // This file exports internal package implementations so that tests
 // can utilize them to mock behavior.
 
-var KVMPath = &kvmPath
+var (
+	KVMPath = &kvmPath
+	KVMRun  = &run
 
-var KVMRun = &run
-
-// Used to export the parameters used to call Start on the KVM Container
-var TestStartParams = &startParams
+	// Used to export the parameters used to call Start on the KVM Container
+	TestStartParams = &startParams
+)
 
 func NewEmptyKvmContainer() *kvmContainer {
 	return &kvmContainer{}

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -111,9 +111,7 @@ func (s *KVMSuite) TestWriteTemplate(c *gc.C) {
 			{MACAddress: "00:16:3e:20:b0:11"},
 		},
 	}
-	tempDir, err := ioutil.TempDir("", "kvm")
-	c.Assert(err, jc.ErrorIsNil)
-	defer os.RemoveAll(tempDir)
+	tempDir := c.MkDir()
 
 	templatePath := filepath.Join(tempDir, "kvm.xml")
 	err = kvm.WriteTemplate(templatePath, params)

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -114,7 +114,7 @@ func (s *KVMSuite) TestWriteTemplate(c *gc.C) {
 	tempDir := c.MkDir()
 
 	templatePath := filepath.Join(tempDir, "kvm.xml")
-	err = kvm.WriteTemplate(templatePath, params)
+	err := kvm.WriteTemplate(templatePath, params)
 	c.Assert(err, jc.ErrorIsNil)
 	templateBytes, err := ioutil.ReadFile(templatePath)
 	c.Assert(err, jc.ErrorIsNil)

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -131,7 +131,7 @@ func (s *KVMSuite) TestCreateMachineUsesTemplate(c *gc.C) {
 	var runArgs []string
 	mockRun := func(command string, args ...string) (string, error) {
 		c.Assert(args, gc.HasLen, 5)
-		c.Assert(args[3], jc.Contains, "kvm.xml")
+		c.Assert(args[3], jc.Contains, "kvm-template.xml")
 
 		// this asserts the template file exists
 		_, err := os.Stat(args[3])
@@ -157,9 +157,6 @@ func (s *KVMSuite) TestCreateMachineUsesTemplate(c *gc.C) {
 	c.Assert(runArgs, gc.HasLen, 5)
 	c.Assert(runArgs[0:3], jc.DeepEquals, []string{"create", "--log-console-output", "--template"})
 	c.Assert(runArgs[4], gc.Equals, "foo-bar")
-
-	_, err = os.Stat(filepath.Dir(runArgs[3]))
-	c.Assert(err, jc.Satisfies, os.IsNotExist)
 }
 
 func (s *KVMSuite) TestDestroyContainer(c *gc.C) {

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -21,6 +22,7 @@ import (
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -99,6 +101,21 @@ func (s *KVMSuite) TestCreateContainer(c *gc.C) {
 	name := string(instance.Id())
 	cloudInitFilename := filepath.Join(s.ContainerDir, name, "cloud-init")
 	containertesting.AssertCloudInit(c, cloudInitFilename)
+}
+
+func (s *KVMSuite) DONTTestCreateUsesTemplate(c *gc.C) {
+	params := kvm.CreateMachineParams{
+		Hostname:      "foo-bar",
+		NetworkBridge: "br0",
+		Interfaces: []network.InterfaceInfo{
+			{MACAddress: "00:16:3e:20:b0:11"},
+		},
+	}
+	err := kvm.CreateMachine(params)
+	if err != nil {
+		panic(err)
+	}
+	time.Sleep(100 * time.Second)
 }
 
 func (s *KVMSuite) TestDestroyContainer(c *gc.C) {

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -85,9 +85,6 @@ func CreateMachine(params CreateMachineParams) error {
 	if params.UserDataFile != "" {
 		args = append(args, "--user-data", params.UserDataFile)
 	}
-	if params.NetworkBridge != "" {
-		args = append(args, "--bridge", params.NetworkBridge)
-	}
 	if params.Memory != 0 {
 		args = append(args, "--memory", fmt.Sprint(params.Memory))
 	}
@@ -110,6 +107,8 @@ func CreateMachine(params CreateMachineParams) error {
 			return errors.Trace(err)
 		}
 		args = append(args, "--template", templatePath)
+	} else if params.NetworkBridge != "" {
+		args = append(args, "--bridge", params.NetworkBridge)
 	}
 
 	args = append(args, params.Hostname)
@@ -121,6 +120,7 @@ func CreateMachine(params CreateMachineParams) error {
 	}
 	output, err := run("uvt-kvm", args...)
 	logger.Debugf("is this the logged output?:\n%s", output)
+	panic("finished")
 	return err
 }
 

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -70,7 +70,7 @@ type CreateMachineParams struct {
 	Memory        uint64
 	CpuCores      uint64
 	RootDisk      uint64
-	Interfaces    []*network.InterfaceInfo
+	Interfaces    []network.InterfaceInfo
 }
 
 // CreateMachine creates a virtual machine and starts it.

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -34,7 +34,7 @@ var (
 )
 
 // run the command and return the combined output.
-var run = func(command string, args ...string) (output string, err error) {
+func run(command string, args ...string) (output string, err error) {
 	logger.Tracef("%s %v", command, args)
 	output, err = utils.RunCommand(command, args...)
 	logger.Tracef("output: %v", output)

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -120,7 +120,6 @@ func CreateMachine(params CreateMachineParams) error {
 	}
 	output, err := run("uvt-kvm", args...)
 	logger.Debugf("is this the logged output?:\n%s", output)
-	panic("finished")
 	return err
 }
 

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -94,21 +94,24 @@ func CreateMachine(params CreateMachineParams) error {
 	if params.RootDisk != 0 {
 		args = append(args, "--disk", fmt.Sprint(params.RootDisk))
 	}
-	if len(params.Interfaces) != 0 {
-		tempDir, err := ioutil.TempDir("", "kvm")
-		if err != nil {
-			return errors.Trace(err)
-		}
-		defer os.RemoveAll(tempDir)
+	if params.NetworkBridge != "" {
+		if len(params.Interfaces) != 0 {
+			tempDir, err := ioutil.TempDir("", "kvm")
+			if err != nil {
+				return errors.Trace(err)
+			}
+			defer os.RemoveAll(tempDir)
 
-		templatePath := filepath.Join(tempDir, "kvm.xml")
-		err = WriteTemplate(templatePath, params)
-		if err != nil {
-			return errors.Trace(err)
+			templatePath := filepath.Join(tempDir, "kvm.xml")
+			err = WriteTemplate(templatePath, params)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			args = append(args, "--template", templatePath)
+		} else {
+			args = append(args, "--bridge", params.NetworkBridge)
 		}
-		args = append(args, "--template", templatePath)
-	} else if params.NetworkBridge != "" {
-		args = append(args, "--bridge", params.NetworkBridge)
 	}
 
 	args = append(args, params.Hostname)

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -36,7 +36,7 @@ var (
 )
 
 // run the command and return the combined output.
-func run(command string, args ...string) (output string, err error) {
+var run = func(command string, args ...string) (output string, err error) {
 	logger.Tracef("%s %v", command, args)
 	output, err = utils.RunCommand(command, args...)
 	logger.Tracef("output: %v", output)

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -16,8 +16,6 @@ package kvm
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -96,14 +94,10 @@ func CreateMachine(params CreateMachineParams) error {
 	}
 	if params.NetworkBridge != "" {
 		if len(params.Interfaces) != 0 {
-			tempDir, err := ioutil.TempDir("", "kvm")
-			if err != nil {
-				return errors.Trace(err)
-			}
-			defer os.RemoveAll(tempDir)
+			templateDir := filepath.Dir(params.UserDataFile)
 
-			templatePath := filepath.Join(tempDir, "kvm.xml")
-			err = WriteTemplate(templatePath, params)
+			templatePath := filepath.Join(templateDir, "kvm-template.xml")
+			err := WriteTemplate(templatePath, params)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -19,6 +19,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/juju/errors"
+	"github.com/juju/juju/network"
 	"github.com/juju/utils"
 )
 
@@ -65,6 +67,7 @@ type CreateMachineParams struct {
 	Memory        uint64
 	CpuCores      uint64
 	RootDisk      uint64
+	Interfaces    []*network.InterfaceInfo
 }
 
 // CreateMachine creates a virtual machine and starts it.
@@ -91,7 +94,15 @@ func CreateMachine(params CreateMachineParams) error {
 	if params.RootDisk != 0 {
 		args = append(args, "--disk", fmt.Sprint(params.RootDisk))
 	}
-	// TODO add memory, cpu and disk prior to hostname
+	if len(params.Interfaces) != 0 {
+		somePath := ""
+		err := WriteTemplate(somePath, params)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		args = append(args, "--template", somePath)
+	}
+
 	args = append(args, params.Hostname)
 	if params.Series != "" {
 		args = append(args, fmt.Sprintf("release=%s", params.Series))

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package kvm
+
+import (
+	"text/template"
+
+	"github.com/juju/errors"
+)
+
+var kvmTemplate = `
+<domain type='kvm'>
+  <name>{{Name}}</name>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type>hvm</type>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <devices>
+    <controller type='usb' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <serial type='stdio'>
+      <target port='0'/>
+    </serial>
+    <console type='stdio'>
+      <target type='serial' port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1'>
+      <listen type='address' address='127.0.0.1'/>
+    </graphics>
+    <video>
+      <model type='cirrus' vram='9216' heads='1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+
+    <interface type='network'>
+      <mac address='52:54:00:7a:ef:cf'/>
+      <model type='virtio'/>
+      <source network='maas'/>
+    </interface>
+  </devices>
+</domain>
+`
+
+func WriteTemplate(path string, params StartParams) error {
+	templ, err := template.New("kvm").Parse(kvmTemplate)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -13,7 +13,7 @@ import (
 
 var kvmTemplate = `
 <domain type='kvm'>
-  <name>{{Name}}</name>
+  <name>{{.Hostname}}</name>
   <vcpu placement='static'>1</vcpu>
   <os>
     <type>hvm</type>
@@ -48,14 +48,14 @@ var kvmTemplate = `
     <interface type='network'>
       <mac address='[{$nic.MACAddress}}'/>
       <model type='virtio'/>
-      <source network='{{.Device}}'/>
+      <source network='{{.NetworkBridge}}'/>
     </interface>
     {{end}}
   </devices>
 </domain>
 `
 
-func WriteTemplate(path string, params StartParams) (err error) {
+func WriteTemplate(path string, params CreateMachineParams) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot write kvm container config")
 
 	tmpl, err := template.New("kvm").Parse(kvmTemplate)
@@ -64,7 +64,7 @@ func WriteTemplate(path string, params StartParams) (err error) {
 	}
 
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, params.Network); err != nil {
+	if err := tmpl.Execute(&buf, params); err != nil {
 		return err
 	}
 

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -44,11 +44,11 @@ var kvmTemplate = `
       <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
     </video>
 
-    {{range $nic := .Interfaces}}
-    <interface type='network'>
-      <mac address='[{$nic.MACAddress}}'/>
+    {{$bridge := .NetworkBridge}}{{range $nic := .Interfaces}}
+    <interface type='bridge'>
+      <mac address='{{$nic.MACAddress}}'/>
       <model type='virtio'/>
-      <source network='{{.NetworkBridge}}'/>
+      <source bridge='{{$bridge}}'/>
     </interface>
     {{end}}
   </devices>
@@ -58,6 +58,7 @@ var kvmTemplate = `
 func WriteTemplate(path string, params CreateMachineParams) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot write kvm container config")
 
+	logger.Warningf("Using params: %#v", params)
 	tmpl, err := template.New("kvm").Parse(kvmTemplate)
 	if err != nil {
 		return err
@@ -73,6 +74,8 @@ func WriteTemplate(path string, params CreateMachineParams) (err error) {
 		return err
 	}
 	defer f.Close()
-	_, err = f.WriteString(buf.String())
+	data := buf.String()
+	logger.Warningf("generated template %#v", data)
+	_, err = f.WriteString(data)
 	return err
 }

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -58,7 +58,6 @@ var kvmTemplate = `
 func WriteTemplate(path string, params CreateMachineParams) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot write kvm container config")
 
-	logger.Warningf("Using params: %#v", params)
 	tmpl, err := template.New("kvm").Parse(kvmTemplate)
 	if err != nil {
 		return err
@@ -74,8 +73,6 @@ func WriteTemplate(path string, params CreateMachineParams) (err error) {
 		return err
 	}
 	defer f.Close()
-	data := buf.String()
-	logger.Warningf("generated template %#v", data)
-	_, err = f.WriteString(data)
+	_, err = f.WriteString(buf.String())
 	return err
 }


### PR DESCRIPTION
Generate and use an XML template for starting KVM instances when we specify a NIC with a MAC address.

I've manually tested that CreateMachine can successfully start KVM instances with a NIC using the specified MAC address.

(Review request: http://reviews.vapour.ws/r/1860/)