### PR TITLE
Fix two lp bug links from github transition

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -389,7 +389,7 @@ func (s *MachineSuite) TestDyingMachine(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	case <-time.After(watcher.Period * 5 / 4):
 		// TODO(rog) Fix this so it doesn't wait for so long.
-		// https://bugs.github.com/juju/juju/+bug/1163983
+		// https://bugs.launchpad.net/juju-core/+bug/1163983
 		c.Fatalf("timed out waiting for agent to terminate")
 	}
 	err = m.Refresh()

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -646,7 +646,7 @@ func isEmpty(val interface{}) bool {
 	case int:
 		// TODO(rog) fix this to return false when
 		// we can lose backward compatibility.
-		// https://bugs.github.com/juju/juju/+bug/1224492
+		// https://bugs.launchpad.net/juju-core/+bug/1224492
 		return val == 0
 	case string:
 		return val == ""


### PR DESCRIPTION
Rog pointed out the move to github and auto-rename of all
the imports also accidentally broke a couple of bug links
in his comments. Switch them back to pointing at launchpad.

(Review request: http://reviews.vapour.ws/r/1861/)