### PR TITLE
Fix the add user problem

### DIFF
--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -106,5 +106,5 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 
 	ctx.Infof("user %q added", user)
 
-	return writeServerFile(c, ctx, user, password, c.OutPath)
+	return writeServerFile(c, ctx, c.User, password, c.OutPath)
 }

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -99,12 +99,12 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}
 
-	user := c.User
+	displayName := c.User
 	if c.DisplayName != "" {
-		user = fmt.Sprintf("%s (%s)", c.DisplayName, user)
+		displayName = fmt.Sprintf("%s (%s)", c.DisplayName, c.User)
 	}
 
-	ctx.Infof("user %q added", user)
+	ctx.Infof("user %q added", displayName)
 
 	return writeServerFile(c, ctx, c.User, password, c.OutPath)
 }

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -118,6 +118,7 @@ func (s *UserAddCommandSuite) TestUsernameAndDisplayname(c *gc.C) {
 	c.Assert(s.mockAPI.displayname, gc.Equals, "Foo Bar")
 	expected := `user "Foo Bar (foobar)" added`
 	c.Assert(testing.Stderr(context), jc.Contains, expected)
+	s.assertServerFileMatches(c, s.serverFilename, "foobar", s.randomPassword)
 }
 
 func (s *UserAddCommandSuite) TestBlockAddUser(c *gc.C) {

--- a/cmd/juju/user/common.go
+++ b/cmd/juju/user/common.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/names"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs/configstore"
@@ -29,7 +30,9 @@ func writeServerFile(endpointProvider EndpointProvider, ctx *cmd.Context, userna
 	if err != nil {
 		return errors.Trace(err)
 	}
-
+	if !names.IsValidUser(username) {
+		return errors.Errorf("%q is not a valid username", username)
+	}
 	outputInfo := envcmd.ServerFile{
 		Username:  username,
 		Password:  password,

--- a/cmd/juju/user/common_test.go
+++ b/cmd/juju/user/common_test.go
@@ -52,3 +52,9 @@ func (s *CommonSuite) TestFileContent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertServerFileMatches(c, s.serverFilename, "username", "password")
 }
+
+func (s *CommonSuite) TestWriteServerFileBadUser(c *gc.C) {
+	ctx := testing.Context(c)
+	err := user.WriteServerFile(s, ctx, "bad user", "password", "outfile.blah")
+	c.Assert(err, gc.ErrorMatches, `"bad user" is not a valid username`)
+}


### PR DESCRIPTION
If the user specified a display name for the user, the command wrote an invalid username into the server file.

(Review request: http://reviews.vapour.ws/r/1866/)