### PR TITLE
FP: fix 1370896 on master

### DIFF
--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -237,7 +237,7 @@ var NewRsyslogConfigWorker = func(st *apirsyslog.State, agentConfig agent.Config
 	if err != nil {
 		return nil, err
 	}
-	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs)
+	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, agentConfig.DataDir())
 }
 
 // ParamsStateServingInfoToStateStateServingInfo converts a

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -42,4 +42,8 @@ var (
 	AddEnvironmentUUIDToAgentConfig = addEnvironmentUUIDToAgentConfig
 	AddDefaultStoragePools          = addDefaultStoragePools
 	MoveBlocksFromEnvironToState    = moveBlocksFromEnvironToState
+
+	// 124 upgrade functions
+	MoveSyslogConfig = moveSyslogConfig
+	CopyFile         = copyFile
 )

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -18,6 +18,7 @@ var (
 
 	ChownPath      = &chownPath
 	IsLocalEnviron = &isLocalEnviron
+	OsRemove       = &osRemove
 
 	// 118 upgrade functions
 	StepsFor118                            = stepsFor118

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -56,6 +56,10 @@ var upgradeOperations = func() []Operation {
 			version.MustParse("1.23.0"),
 			stepsFor123(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.24.0"),
+			stepsFor124(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -73,8 +73,10 @@ func moveSyslogConfig(context Context) error {
 			errs = append(errs, err.Error())
 			continue
 		}
-		if err := os.Remove(oldpath); err != nil && !os.IsNotExist(err) {
-			errs = append(errs, err.Error())
+		if err := osRemove(oldpath); err != nil {
+			// Don't fail the step if we can't get rid of the old files.
+			// We don't actually care if they still exist or not.
+			logger.Warningf("Can't delete old config file %q: %s", oldpath, err)
 		}
 	}
 	if len(errs) > 0 {
@@ -82,6 +84,9 @@ func moveSyslogConfig(context Context) error {
 	}
 	return nil
 }
+
+// for testing... of course.
+var osRemove = os.Remove
 
 // copyFile copies a file from one location to another.  It won't overwrite
 // existing files and will return nil in this case.  This is used instead of

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -4,6 +4,12 @@
 package upgrades
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/juju/juju/state"
 )
 
@@ -30,4 +36,79 @@ func stateStepsFor124() []Step {
 			},
 		},
 	}
+}
+
+// stepsFor124 returns upgrade steps for Juju 1.24 that only need the API.
+func stepsFor124() []Step {
+	return steps
+		&upgradeStep{
+			description: "move syslog config from LogDir to DataDir",
+			targets:     []Target{AllMachines},
+			run:         moveSyslogConfig,
+		},
+	}
+}
+
+func moveSyslogConfig(context Context) error {
+	config := context.AgentConfig()
+	logdir := config.LogDir()
+	datadir := config.DataDir()
+
+	// these values were copied from
+	// github.com/juju/juju/utils/syslog/config.go
+	// Yes this is bad, but it is only needed once every for an
+	// upgrade, so it didn't seem worth exporting those values.
+	files := []string{
+		"ca-cert.pem",
+		"rsyslog-cert.pem",
+		"rsyslog-key.pem",
+		"logrotate.conf",
+		"logrotate.run",
+	}
+	var errs []string
+	for _, f := range files {
+		oldpath := filepath.Join(logdir, f)
+		newpath := filepath.Join(datadir, f)
+		if err := copyFile(newpath, oldpath); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		if err := os.Remove(oldpath); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("error(s) while moving old syslog config files: %s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+// copyFile copies a file from one location to another.  It won't overwrite
+// existing files and will return nil in this case.  This is used instead of
+// os.Rename because os.Rename won't work across partitions.
+func copyFile(to, from string) error {
+	logger.Debugf("Copying %q to %q", from, to)
+	orig, err := os.Open(from)
+	if os.IsNotExist(err) {
+		logger.Debugf("Old file %q does not exist, skipping.", from)
+		// original doesn't exist, that's fine.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer orig.Close()
+	info, err := orig.Stat()
+	if err != nil {
+		return err
+	}
+	target, err := os.OpenFile(to, os.O_CREATE|os.O_WRONLY|os.O_EXCL, info.Mode())
+	if os.IsExist(err) {
+		return nil
+	}
+	defer target.Close()
+	if _, err := io.Copy(target, orig); err != nil {
+		return err
+	}
+	return nil
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -40,7 +40,7 @@ func stateStepsFor124() []Step {
 
 // stepsFor124 returns upgrade steps for Juju 1.24 that only need the API.
 func stepsFor124() []Step {
-	return steps
+	return []Step{
 		&upgradeStep{
 			description: "move syslog config from LogDir to DataDir",
 			targets:     []Target{AllMachines},

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -4,9 +4,16 @@
 package upgrades_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
 )
 
@@ -23,4 +30,152 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 		"add instance id field to IP addresses",
 	}
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
+}
+
+func (s *steps124Suite) TestStepsFor124(c *gc.C) {
+	expected := []string{
+		"move syslog config from LogDir to DataDir",
+	}
+	assertSteps(c, version.MustParse("1.24.0"), expected)
+}
+
+func (s *steps124Suite) TestCopyFileNew(c *gc.C) {
+	src := c.MkDir()
+	dest := c.MkDir()
+	srcdata := []byte("new data!")
+
+	// test that a file in src dir and not in dest dir gets copied.
+
+	newSrc := filepath.Join(src, "new")
+	err := ioutil.WriteFile(newSrc, srcdata, 0644)
+	c.Assert(err, gc.IsNil)
+
+	newDest := filepath.Join(dest, "new")
+
+	err = upgrades.CopyFile(newDest, newSrc)
+	c.Assert(err, gc.IsNil)
+
+	srcb, err := ioutil.ReadFile(newSrc)
+	c.Assert(err, gc.IsNil)
+	destb, err := ioutil.ReadFile(newDest)
+	c.Assert(err, gc.IsNil)
+	// convert to string and use Equals because we'll get a better failure message
+	c.Assert(string(destb), gc.Equals, string(srcb))
+}
+
+func (s *steps124Suite) TestCopyFileExisting(c *gc.C) {
+	src := c.MkDir()
+	dest := c.MkDir()
+	srcdata := []byte("new data!")
+	destdata := []byte("old data!")
+
+	exSrc := filepath.Join(src, "existing")
+	exDest := filepath.Join(dest, "existing")
+
+	err := ioutil.WriteFile(exSrc, srcdata, 0644)
+	c.Assert(err, gc.IsNil)
+	err = ioutil.WriteFile(exDest, destdata, 0644)
+	c.Assert(err, gc.IsNil)
+
+	err = upgrades.CopyFile(exDest, exSrc)
+	c.Assert(err, gc.IsNil)
+
+	// assert we haven't changed the destination
+	b, err := ioutil.ReadFile(exDest)
+
+	c.Assert(err, gc.IsNil)
+	// convert to string because we'll get a better failure message
+	c.Assert(string(b), gc.Equals, string(destdata))
+}
+
+func (s *steps124Suite) TestMoveSyslogConfigDefault(c *gc.C) {
+	logdir := c.MkDir()
+	datadir := c.MkDir()
+	data := []byte("data!")
+	files := []string{
+		"ca-cert.pem",
+		"rsyslog-cert.pem",
+		"rsyslog-key.pem",
+		"logrotate.conf",
+		"logrotate.run",
+	}
+	for _, f := range files {
+		err := ioutil.WriteFile(filepath.Join(logdir, f), data, 0644)
+		c.Assert(err, gc.IsNil)
+	}
+
+	ctx := fakeContext{cfg: fakeConfig{logdir: logdir, datadir: datadir}}
+	err := upgrades.MoveSyslogConfig(ctx)
+	c.Assert(err, gc.IsNil)
+
+	for _, f := range files {
+		_, err := os.Stat(filepath.Join(datadir, f))
+		c.Assert(err, gc.IsNil)
+		_, err = os.Stat(filepath.Join(logdir, f))
+		c.Assert(err, jc.Satisfies, os.IsNotExist)
+	}
+}
+
+func (s *steps124Suite) TestMoveSyslogConfig(c *gc.C) {
+	logdir := c.MkDir()
+	datadir := c.MkDir()
+	data := []byte("data!")
+	files := []string{
+		"logrotate.conf",
+		"logrotate.run",
+	}
+
+	// ensure that we don't overwrite an existing file in datadir, and don't
+	// error out if one of the files exists in datadir but not logdir.
+
+	err := ioutil.WriteFile(filepath.Join(logdir, "logrotate.conf"), data, 0644)
+	c.Assert(err, gc.IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(datadir, "logrotate.run"), data, 0644)
+	c.Assert(err, gc.IsNil)
+
+	differentData := []byte("different")
+	existing := filepath.Join(datadir, "logrotate.conf")
+	err = ioutil.WriteFile(existing, differentData, 0644)
+	c.Assert(err, gc.IsNil)
+
+	ctx := fakeContext{cfg: fakeConfig{logdir: logdir, datadir: datadir}}
+	err = upgrades.MoveSyslogConfig(ctx)
+	c.Assert(err, gc.IsNil)
+
+	for _, f := range files {
+		_, err := os.Stat(filepath.Join(datadir, f))
+		c.Assert(err, gc.IsNil)
+		_, err = os.Stat(filepath.Join(logdir, f))
+		c.Assert(err, jc.Satisfies, os.IsNotExist)
+	}
+
+	b, err := ioutil.ReadFile(existing)
+	c.Assert(err, gc.IsNil)
+	// convert to string because we'll get a better failure message
+	c.Assert(string(b), gc.Not(gc.Equals), string(existing))
+
+}
+
+type fakeContext struct {
+	upgrades.Context
+	cfg fakeConfig
+}
+
+func (f fakeContext) AgentConfig() agent.ConfigSetter {
+	return f.cfg
+}
+
+type fakeConfig struct {
+	agent.ConfigSetter
+	logdir  string
+	datadir string
+}
+
+func (f fakeConfig) LogDir() string {
+	return f.logdir
+}
+
+func (f fakeConfig) DataDir() string {
+	return f.datadir
 }

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -48,17 +48,17 @@ func (s *steps124Suite) TestCopyFileNew(c *gc.C) {
 
 	newSrc := filepath.Join(src, "new")
 	err := ioutil.WriteFile(newSrc, srcdata, 0644)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	newDest := filepath.Join(dest, "new")
 
 	err = upgrades.CopyFile(newDest, newSrc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	srcb, err := ioutil.ReadFile(newSrc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	destb, err := ioutil.ReadFile(newDest)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	// convert to string and use Equals because we'll get a better failure message
 	c.Assert(string(destb), gc.Equals, string(srcb))
 }
@@ -73,17 +73,17 @@ func (s *steps124Suite) TestCopyFileExisting(c *gc.C) {
 	exDest := filepath.Join(dest, "existing")
 
 	err := ioutil.WriteFile(exSrc, srcdata, 0644)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(exDest, destdata, 0644)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = upgrades.CopyFile(exDest, exSrc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// assert we haven't changed the destination
 	b, err := ioutil.ReadFile(exDest)
 
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	// convert to string because we'll get a better failure message
 	c.Assert(string(b), gc.Equals, string(destdata))
 }
@@ -101,16 +101,16 @@ func (s *steps124Suite) TestMoveSyslogConfigDefault(c *gc.C) {
 	}
 	for _, f := range files {
 		err := ioutil.WriteFile(filepath.Join(logdir, f), data, 0644)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, jc.ErrorIsNil)
 	}
 
 	ctx := fakeContext{cfg: fakeConfig{logdir: logdir, datadir: datadir}}
 	err := upgrades.MoveSyslogConfig(ctx)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	for _, f := range files {
 		_, err := os.Stat(filepath.Join(datadir, f))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, jc.ErrorIsNil)
 		_, err = os.Stat(filepath.Join(logdir, f))
 		c.Assert(err, jc.Satisfies, os.IsNotExist)
 	}
@@ -129,32 +129,55 @@ func (s *steps124Suite) TestMoveSyslogConfig(c *gc.C) {
 	// error out if one of the files exists in datadir but not logdir.
 
 	err := ioutil.WriteFile(filepath.Join(logdir, "logrotate.conf"), data, 0644)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = ioutil.WriteFile(filepath.Join(datadir, "logrotate.run"), data, 0644)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	differentData := []byte("different")
 	existing := filepath.Join(datadir, "logrotate.conf")
 	err = ioutil.WriteFile(existing, differentData, 0644)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := fakeContext{cfg: fakeConfig{logdir: logdir, datadir: datadir}}
 	err = upgrades.MoveSyslogConfig(ctx)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	for _, f := range files {
 		_, err := os.Stat(filepath.Join(datadir, f))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, jc.ErrorIsNil)
 		_, err = os.Stat(filepath.Join(logdir, f))
 		c.Assert(err, jc.Satisfies, os.IsNotExist)
 	}
 
 	b, err := ioutil.ReadFile(existing)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	// convert to string because we'll get a better failure message
 	c.Assert(string(b), gc.Not(gc.Equals), string(existing))
 
+}
+
+func (s *steps124Suite) TestMoveSyslogConfigCantDeleteOld(c *gc.C) {
+	logdir := c.MkDir()
+	datadir := c.MkDir()
+	file := filepath.Join(logdir, "logrotate.conf")
+
+	// ensure that we don't error out if we can't remove the old file.
+	// error out if one of the files exists in datadir but not logdir.
+	s.PatchValue(upgrades.OsRemove, func(string) error { return os.ErrPermission })
+
+	err := ioutil.WriteFile(file, []byte("data!"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := fakeContext{cfg: fakeConfig{logdir: logdir, datadir: datadir}}
+	err = upgrades.MoveSyslogConfig(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// should still exist in both places (i.e. check we didn't screw up the test)
+	_, err = os.Stat(file)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = os.Stat(filepath.Join(datadir, "logrotate.conf"))
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 type fakeContext struct {

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -671,7 +671,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0", "1.24.0"})
 }
 
 func extractUpgradeVersions(c *gc.C, ops []upgrades.Operation) []string {

--- a/worker/rsyslog/manifold.go
+++ b/worker/rsyslog/manifold.go
@@ -42,5 +42,6 @@ var newWorker = func(agent agent.Agent, apiCaller base.APICaller) (worker.Worker
 		tag,
 		namespace,
 		addrs,
+		agentConfig.DataDir(),
 	)
 }

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -93,14 +93,14 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
 	addrs := []string{"0.1.2.3", "0.2.4.6"}
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "foo", addrs)
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "foo", addrs, s.DataDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
 
 	// We should get a ca-cert.pem with the contents introduced into state config.
-	waitForFile(c, filepath.Join(*rsyslog.LogDir, "ca-cert.pem"))
-	caCertPEM, err := ioutil.ReadFile(filepath.Join(*rsyslog.LogDir, "ca-cert.pem"))
+	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(caCertPEM), gc.DeepEquals, coretesting.CACert)
 
@@ -108,6 +108,6 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 	s.mu.Lock()
 	s.mu.Unlock() // assert read barrier before accessing s.dialTags
 	for _, dialTag := range s.dialTags {
-		c.Assert(dialTag, gc.Equals, "juju-foo-"+m.Tag().String())
+		c.Check(dialTag, gc.Equals, "juju-foo-"+m.Tag().String())
 	}
 }

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -111,3 +111,28 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 		c.Check(dialTag, gc.Equals, "juju-foo-"+m.Tag().String())
 	}
 }
+
+func (s *RsyslogSuite) TestNoNamespace(c *gc.C) {
+	err := s.APIState.Client().EnvironmentSet(map[string]interface{}{
+		"rsyslog-ca-cert": coretesting.CACert,
+		"rsyslog-ca-key":  coretesting.CAKey,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
+	addrs := []string{"0.1.2.3", "0.2.4.6"}
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", addrs, s.DataDir())
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+
+	// We should get a ca-cert.pem with the contents introduced into state config.
+	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(caCertPEM), gc.DeepEquals, coretesting.CACert)
+
+	c.Assert(*rsyslog.SyslogTargets, gc.HasLen, 2)
+	for _, dialTag := range s.dialTags {
+		c.Check(dialTag, gc.Equals, "juju-"+m.Tag().String())
+	}
+}

--- a/worker/rsyslog/rsyslog_test.go
+++ b/worker/rsyslog/rsyslog_test.go
@@ -43,7 +43,7 @@ func assertPathExists(c *gc.C, path string) {
 
 func (s *RsyslogSuite) TestStartStop(c *gc.C) {
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", []string{"0.1.2.3"})
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
 	c.Assert(err, jc.ErrorIsNil)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
@@ -51,7 +51,7 @@ func (s *RsyslogSuite) TestStartStop(c *gc.C) {
 
 func (s *RsyslogSuite) TestTearDown(c *gc.C) {
 	st, m := s.st, s.machine
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"})
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
 	c.Assert(err, jc.ErrorIsNil)
 	confFile := filepath.Join(*rsyslog.RsyslogConfDir, "25-juju.conf")
 	// On worker teardown, the rsyslog config file should be removed.
@@ -69,13 +69,13 @@ func (s *RsyslogSuite) TestRsyslogCert(c *gc.C) {
 	err := s.machine.SetProviderAddresses(network.NewAddress("example.com"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"})
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
-	waitForFile(c, filepath.Join(*rsyslog.LogDir, "rsyslog-cert.pem"))
+	waitForFile(c, filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
 
-	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(*rsyslog.LogDir, "rsyslog-cert.pem"))
+	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	cert, err := cert.ParseCert(string(rsyslogCertPEM))
@@ -94,18 +94,18 @@ func (s *RsyslogSuite) TestRsyslogCert(c *gc.C) {
 
 func (s *RsyslogSuite) TestModeAccumulate(c *gc.C) {
 	st, m := s.st, s.machine
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", nil)
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", nil, s.DataDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
-	waitForFile(c, filepath.Join(*rsyslog.LogDir, "ca-cert.pem"))
+	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
 
 	// We should have ca-cert.pem, rsyslog-cert.pem, and rsyslog-key.pem.
-	caCertPEM, err := ioutil.ReadFile(filepath.Join(*rsyslog.LogDir, "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
-	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(*rsyslog.LogDir, "rsyslog-cert.pem"))
+	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
-	rsyslogKeyPEM, err := ioutil.ReadFile(filepath.Join(*rsyslog.LogDir, "rsyslog-key.pem"))
+	rsyslogKeyPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-key.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, _, err = cert.ParseCertAndKey(string(rsyslogCertPEM), string(rsyslogKeyPEM))
@@ -119,22 +119,42 @@ func (s *RsyslogSuite) TestModeAccumulate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	syslogPort := s.Environ.Config().SyslogPort()
-	syslogConfig := syslog.NewAccumulateConfig(m.Tag().String(), *rsyslog.LogDir, syslogPort, "", []string{})
+
+	syslogConfig := &syslog.SyslogConfig{
+		LogFileName:          m.Tag().String(),
+		LogDir:               *rsyslog.LogDir,
+		Port:                 syslogPort,
+		Namespace:            "",
+		StateServerAddresses: []string{},
+	}
+
+	syslog.NewAccumulateConfig(syslogConfig)
 	syslogConfig.ConfigDir = *rsyslog.RsyslogConfDir
+	syslogConfig.JujuConfigDir = s.DataDir()
 	rendered, err := syslogConfig.Render()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(string(rsyslogConf), gc.DeepEquals, string(rendered))
 
 	// Verify logrotate files
-	assertPathExists(c, filepath.Join(*rsyslog.LogDir, "logrotate.conf"))
-	assertPathExists(c, filepath.Join(*rsyslog.LogDir, "logrotate.run"))
+	assertPathExists(c, filepath.Join(s.DataDir(), "logrotate.conf"))
+	assertPathExists(c, filepath.Join(s.DataDir(), "logrotate.run"))
 
 }
 
 func (s *RsyslogSuite) TestAccumulateHA(c *gc.C) {
 	m := s.machine
-	syslogConfig := syslog.NewAccumulateConfig(m.Tag().String(), *rsyslog.LogDir, 6541, "", []string{"192.168.1", "127.0.0.1"})
+
+	syslogConfig := &syslog.SyslogConfig{
+		LogFileName:          m.Tag().String(),
+		LogDir:               *rsyslog.LogDir,
+		Port:                 6541,
+		Namespace:            "",
+		StateServerAddresses: []string{"192.168.1", "127.0.0.1"},
+	}
+
+	syslog.NewAccumulateConfig(syslogConfig)
+	syslogConfig.JujuConfigDir = s.DataDir()
 	rendered, err := syslogConfig.Render()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -171,9 +191,11 @@ func (s *RsyslogSuite) testNamespace(c *gc.C, st *api.State, tag names.Tag, name
 		return nil
 	})
 
+	jujuConfigDir := s.AgentConfigForTag(c, tag).DataDir()
+
 	err := os.MkdirAll(expectedLogDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, tag, namespace, []string{"0.1.2.3"})
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, tag, namespace, []string{"0.1.2.3"}, jujuConfigDir)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -188,7 +210,7 @@ func (s *RsyslogSuite) testNamespace(c *gc.C, st *api.State, tag names.Tag, name
 	waitForRestart(c, restarted)
 
 	// Ensure that ca-cert.pem gets written to the expected log dir.
-	waitForFile(c, filepath.Join(expectedLogDir, "ca-cert.pem"))
+	waitForFile(c, filepath.Join(jujuConfigDir, "ca-cert.pem"))
 
 	dir, err := os.Open(*rsyslog.RsyslogConfDir)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -205,7 +205,11 @@ func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {
 			host = j
 		}
 		target := fmt.Sprintf("%s:%d", host, h.syslogConfig.Port)
-		logTag := "juju" + "-" + h.syslogConfig.Namespace + "-" + h.tag.String()
+		namespace := h.syslogConfig.Namespace
+		if namespace != "" {
+			namespace = "-" + namespace
+		}
+		logTag := "juju" + namespace + "-" + h.tag.String()
 		logger.Debugf("making syslog connection for %q to %s", logTag, target)
 		writer, err := dialSyslog("tcp", target, rsyslog.LOG_DEBUG, logTag, tlsConf)
 		if err != nil {


### PR DESCRIPTION
FP of #2458, #2476, and #2489 since the latter two are just fixes to the original PR. 

Fix 1370896 - juju has conf files in /var/log/juju on instances

Fixes https://bugs.launchpad.net/juju-core/+bug/1370896

All the rsyslog configuration files are now created in juju's data directory (by default, /var/lib/juju), instead of the log directory (/var/log/juju).  Also added an upgrade step to move the files from old location to new location.

I made a couple changes to how you create a SyslogConfig, mostly because it was using a function with a huge number of string arguments, which made it very difficult to read, and to understand what value was being assigned to what field.  This made updating the code almost impossible, because of minor positional differences in the function signatures.

I changed  syslog.NewAccumulateConfig and NewForwardConfig to just take a pointer to a SyslogConfig, since pretty much all they did was set exported fields on the type.  Now they just set the non-exported field, and the caller sets everything else in a struct literal.

I also changed it so that the Namespace field in SyslogConfig always stays just "Namespace", not "-Namespace", since it's an exported value, and having it be something different than what was set is really confusing.  Instead, we just add the dash when rendering to the template.

Changed the tests much the same way - just set up the struct and pass it in is so much easier to read than a huge function call with a ton of different string parameters in a random order.  Also changed the test template, so that there aren't hard-coded values in it, and instead actually use the values passed in.

(Review request: http://reviews.vapour.ws/r/1871/)