### PR TITLE
Fix: 1441478 availability zone upgrade fails if containers are present

### DIFF
--- a/environs/errors.go
+++ b/environs/errors.go
@@ -4,13 +4,13 @@
 package environs
 
 import (
-	"errors"
+	"github.com/juju/errors"
 )
 
 var (
 	ErrNotBootstrapped     = errors.New("environment is not bootstrapped")
 	ErrAlreadyBootstrapped = errors.New("environment is already bootstrapped")
-	ErrNoInstances         = errors.New("no instances found")
+	ErrNoInstances         = errors.NotFoundf("instances")
 	ErrPartialInstances    = errors.New("only some instances were found")
 
 	// Errors indicating that the provider can't allocate an IP address to an

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -830,12 +830,16 @@ func AddAvailabilityZoneToInstanceData(st *State, azFunc func(*State, instance.I
 	defer iter.Close()
 	for iter.Next(&doc) {
 		zone, ok := doc["availzone"]
-		if ok {
+		if ok || ParentId(doc["machineid"].(string)) != "" {
 			continue
 		}
 
 		zone, err := azFunc(st, instance.Id(doc["instanceid"].(string)))
 		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+
 			if !errors.IsNotSupported(err) {
 				return errors.Trace(err)
 			}


### PR DESCRIPTION
Don't add availability zones to containers, don't error on missing
instances.

(Review request: http://reviews.vapour.ws/r/1873/)