### PR TITLE
apiserver: avoid log file mode test on Windows

### DIFF
--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/juju/loggo"
@@ -186,9 +187,14 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	line1 := envUUID + " machine-0: 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes\n"
 	c.Assert(string(logContents), gc.Equals, line0+line1)
 
-	info, err := os.Stat(logPath)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.Mode(), gc.Equals, os.FileMode(0600))
+	// Check the file mode is as expected. This doesn't work on
+	// Windows (but this code is very unlikely to run on Windows so
+	// it's ok).
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(logPath)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(info.Mode(), gc.Equals, os.FileMode(0600))
+	}
 }
 
 func (s *logsinkSuite) dialWebsocket(c *gc.C) *websocket.Conn {


### PR DESCRIPTION
This doesn't work on Windows (and doesn't have to).

Fixes LP #1462418.

(Review request: http://reviews.vapour.ws/r/1876/)