### PR TITLE
worker/txnpruner: allow for the worker to run exactly on the interval

### DIFF
--- a/worker/txnpruner/txnpruner_test.go
+++ b/worker/txnpruner/txnpruner_test.go
@@ -34,7 +34,8 @@ func (s *TxnPrunerSuite) TestPrunes(c *gc.C) {
 				// Check that pruning runs at the expected interval
 				// (but not the first time around as we don't know
 				// when the worker actually started).
-				c.Assert(t1.Sub(t0), jc.GreaterThan, interval)
+				td := t1.Sub(t0)
+				c.Assert(td >= interval, jc.IsTrue, gc.Commentf("td=%s", td))
 			}
 			t0 = t1
 		case <-time.After(testing.LongWait):


### PR DESCRIPTION
This happens on Windows occasionally.

Fixes LP #1459291

(Review request: http://reviews.vapour.ws/r/1877/)