### PR TITLE
state: fix block-device/address update assertions

### DIFF
--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -85,7 +85,7 @@ func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceIn
 		}, {
 			C:      blockDevicesC,
 			Id:     machineId,
-			Assert: bson.D{{"blockdevices", oldInfo}},
+			Assert: txn.DocExists,
 			Update: bson.D{{"$set", bson.D{{"blockdevices", newInfo}}}},
 		}}
 		return ops, nil

--- a/state/machine.go
+++ b/state/machine.go
@@ -1033,9 +1033,14 @@ func (m *Machine) Addresses() (addresses []network.Address) {
 // SetProviderAddresses records any addresses related to the machine, sourced
 // by asking the provider.
 func (m *Machine) SetProviderAddresses(addresses ...network.Address) (err error) {
-	if err = m.setAddresses(addresses, &m.doc.Addresses, "addresses"); err != nil {
+	mdoc, err := m.st.getMachineDoc(m.Id())
+	if err != nil {
+		return errors.Annotatef(err, "cannot refresh provider addresses for machine %s", m)
+	}
+	if err = m.setAddresses(addresses, &mdoc.Addresses, "addresses"); err != nil {
 		return fmt.Errorf("cannot set addresses of machine %v: %v", m, err)
 	}
+	m.doc.Addresses = mdoc.Addresses
 	return nil
 }
 
@@ -1060,9 +1065,14 @@ func (m *Machine) MachineAddresses() (addresses []network.Address) {
 // SetMachineAddresses records any addresses related to the machine, sourced
 // by asking the machine.
 func (m *Machine) SetMachineAddresses(addresses ...network.Address) (err error) {
-	if err = m.setAddresses(addresses, &m.doc.MachineAddresses, "machineaddresses"); err != nil {
+	mdoc, err := m.st.getMachineDoc(m.Id())
+	if err != nil {
+		return errors.Annotatef(err, "cannot refresh machine addresses for machine %s", m)
+	}
+	if err = m.setAddresses(addresses, &mdoc.MachineAddresses, "machineaddresses"); err != nil {
 		return fmt.Errorf("cannot set machine addresses of machine %v: %v", m, err)
 	}
+	m.doc.MachineAddresses = mdoc.MachineAddresses
 	return nil
 }
 
@@ -1102,46 +1112,30 @@ func (m *Machine) setAddresses(addresses []network.Address, field *[]address, fi
 		addressesToSet = make([]network.Address, len(addresses))
 		copy(addressesToSet, addresses)
 	}
+
 	// Update addresses now.
-	var changed bool
 	envConfig, err := m.st.EnvironConfig()
 	if err != nil {
 		return err
 	}
-
 	network.SortAddresses(addressesToSet, envConfig.PreferIPv6())
 	stateAddresses := fromNetworkAddresses(addressesToSet)
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		changed = false
-		if attempt > 0 {
-			if err := m.Refresh(); err != nil {
-				return nil, err
-			}
-		}
-		if m.doc.Life == Dead {
-			return nil, ErrDead
-		}
-		if addressesEqual(addressesToSet, networkAddresses(*field)) {
-			return nil, jujutxn.ErrNoOperations
-		}
-		changed = true
-		return []txn.Op{{
-			C:      machinesC,
-			Id:     m.doc.DocID,
-			Assert: notDeadDoc,
-			Update: bson.D{{"$set", bson.D{{fieldName, stateAddresses}}}},
-		}}, nil
+
+	if addressesEqual(addressesToSet, networkAddresses(*field)) {
+		return nil
 	}
-	switch err := m.st.run(buildTxn); err {
-	case nil:
-	case jujutxn.ErrExcessiveContention:
-		return errors.Annotatef(err, "cannot set %s for machine %s", fieldName, m)
-	default:
-		return err
+	if err := m.st.runTransaction([]txn.Op{{
+		C:      machinesC,
+		Id:     m.doc.DocID,
+		Assert: notDeadDoc,
+		Update: bson.D{{"$set", bson.D{{fieldName, stateAddresses}}}},
+	}}); err != nil {
+		if err == txn.ErrAborted {
+			return ErrDead
+		}
+		return errors.Trace(err)
 	}
-	if changed {
-		*field = stateAddresses
-	}
+	*field = stateAddresses
 	return nil
 }
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2078,10 +2078,10 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeEqual(c *gc.C) {
 	err = machine.SetProviderAddresses(addr0, addr1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Doc should not have been updated, but Machine object's view should be.
+	// Doc will be updated; concurrent changes are explicitly ignored.
 	revno2, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(revno2, gc.Equals, revno1)
+	c.Assert(revno2, gc.Not(gc.Equals), revno1)
 	c.Assert(machine.Addresses(), jc.SameContents, []network.Address{addr0, addr1})
 }
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2072,7 +2072,7 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeEqual(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		revno1, err = state.TxnRevno(s.State, "machines", machineDocID)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(revno1, gc.Equals, revno0+1)
+		c.Assert(revno1, jc.GreaterThan, revno0)
 	}).Check()
 
 	err = machine.SetProviderAddresses(addr0, addr1)
@@ -2081,7 +2081,7 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeEqual(c *gc.C) {
 	// Doc will be updated; concurrent changes are explicitly ignored.
 	revno2, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(revno2, gc.Not(gc.Equals), revno1)
+	c.Assert(revno2, jc.GreaterThan, revno1)
 	c.Assert(machine.Addresses(), jc.SameContents, []network.Address{addr0, addr1})
 }
 
@@ -2109,7 +2109,7 @@ func (s *MachineSuite) TestSetProviderAddressesInvalidateMemory(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	revno1, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(revno1, gc.Not(gc.Equals), revno0)
+	c.Assert(revno1, jc.GreaterThan, revno0)
 	c.Assert(machine.Addresses(), jc.SameContents, []network.Address{addr0})
 	c.Assert(machine2.Addresses(), jc.SameContents, []network.Address{addr1})
 
@@ -2117,7 +2117,7 @@ func (s *MachineSuite) TestSetProviderAddressesInvalidateMemory(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	revno2, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(revno2, gc.Not(gc.Equals), revno1)
+	c.Assert(revno2, jc.GreaterThan, revno1)
 	c.Assert(machine.Addresses(), jc.SameContents, []network.Address{addr0})
 }
 


### PR DESCRIPTION
Change block-device and machine address updates to not
care about concurrent updates.

Block-device and address updates are currently asserting
that there are no concurrent changes. There are several
problems with this:
 - to do this, they assert that the current field value
   is equal to the in-memory struct representation. This
   means that removing or reordering fields in the struct
   will cause assertion failures
 - even without changing the above, there is an issue in
   mgo that can cause reordering of map elements in
   assertions
 - the assertions are pointless

The assertions are pointless for two main reasons:
 - for each of block-devices and addresses, there is a single
   worker responsible for updating. Any concurrent update
   issues are thus purely academic
 - even if we prevent a change between observing the current
   value and updating, we still loop and then update. The net
   effect is that we always update, except in the case of
   "state changing too fast".

Fixes https://bugs.launchpad.net/bugs/1461871

(Review request: http://reviews.vapour.ws/r/1879/)