### PR TITLE
Split up jujuc.Context into sub-interfaces.

### DIFF
--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -330,11 +330,11 @@ func (ctx *HookContext) AvailabilityZone() (string, bool) {
 	return ctx.availabilityzone, ctx.availabilityzone != ""
 }
 
-func (ctx *HookContext) HookStorage() (jujuc.ContextStorage, bool) {
+func (ctx *HookContext) HookStorage() (jujuc.ContextStorageAttachment, bool) {
 	return ctx.Storage(ctx.storageTag)
 }
 
-func (ctx *HookContext) Storage(tag names.StorageTag) (jujuc.ContextStorage, bool) {
+func (ctx *HookContext) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachment, bool) {
 	return ctx.storage.Storage(tag)
 }
 

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -52,9 +52,9 @@ type Factory interface {
 // for a jujuc.Context.
 type StorageContextAccessor interface {
 
-	// Storage returns the jujuc.ContextStorage with the supplied tag if
-	// it was found, and whether it was found.
-	Storage(names.StorageTag) (jujuc.ContextStorage, bool)
+	// Storage returns the jujuc.ContextStorageAttachment with the
+	// supplied tag if it was found, and whether it was found.
+	Storage(names.StorageTag) (jujuc.ContextStorageAttachment, bool)
 }
 
 // RelationsFunc is used to get snapshots of relation membership at context

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -127,13 +127,13 @@ type Context interface {
 	// RequestReboot will set the reboot flag to true on the machine agent
 	RequestReboot(prio RebootPriority) error
 
-	// Storage returns the ContextStorage with the supplied tag if it was
-	// found, and whether it was found.
-	Storage(names.StorageTag) (ContextStorage, bool)
+	// Storage returns the ContextStorageAttachment with the supplied
+	// tag if it was found, and whether it was found.
+	Storage(names.StorageTag) (ContextStorageAttachment, bool)
 
 	// HookStorageAttachment returns the storage attachment associated
 	// the executing hook if it was found, and whether it was found.
-	HookStorage() (ContextStorage, bool)
+	HookStorage() (ContextStorageAttachment, bool)
 
 	// AddUnitStorage saves storage constraints in the context.
 	AddUnitStorage(map[string]params.StorageConstraints)
@@ -165,9 +165,9 @@ type ContextRelation interface {
 	ReadSettings(unit string) (params.Settings, error)
 }
 
-// ContextStorage expresses the capabilities of a hook with respect to a
-// storage attachment.
-type ContextStorage interface {
+// ContextStorageAttachment expresses the capabilities of a hook with
+// respect to a storage attachment.
+type ContextStorageAttachment interface {
 
 	// Tag returns a tag which uniquely identifies the storage attachment
 	// in the context of the unit.

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -32,30 +32,113 @@ const (
 // Context is the interface that all hook helper commands
 // depend on to interact with the rest of the system.
 type Context interface {
+	HookContext
+	relationHookContext
+	actionHookContext
+}
 
+// HookContext represents the information and functionality that is
+// common to all charm hooks.
+type HookContext interface {
+	ContextUnit
+	ContextStatus
+	ContextInstance
+	ContextNetworking
+	ContextLeadership
+	ContextMetrics
+	ContextStorage
+	ContextRelations
+}
+
+// UnitHookContext is the context for a unit hook.
+type UnitHookContext interface {
+	HookContext
+}
+
+// RelationHookContext is the context for a relation hook.
+type RelationHookContext interface {
+	HookContext
+	relationHookContext
+}
+
+type relationHookContext interface {
+	// HookRelation returns the ContextRelation associated with the executing
+	// hook if it was found, and whether it was found.
+	HookRelation() (ContextRelation, bool)
+
+	// RemoteUnitName returns the name of the remote unit the hook execution
+	// is associated with if it was found, and whether it was found.
+	RemoteUnitName() (string, bool)
+}
+
+// ActionHookContext is the context for an action hook.
+type ActionHookContext interface {
+	HookContext
+	actionHookContext
+}
+
+type actionHookContext interface {
+	// ActionParams returns the map of params passed with an Action.
+	ActionParams() (map[string]interface{}, error)
+
+	// UpdateActionResults inserts new values for use with action-set.
+	// The results struct will be delivered to the state server upon
+	// completion of the Action.
+	UpdateActionResults(keys []string, value string) error
+
+	// SetActionMessage sets a message for the Action.
+	SetActionMessage(string) error
+
+	// SetActionFailed sets a failure state for the Action.
+	SetActionFailed() error
+}
+
+// ContextUnit is the part of a hook context related to the unit.
+type ContextUnit interface {
 	// UnitName returns the executing unit's name.
 	UnitName() string
 
+	// OwnerTag returns the user tag of the service the executing
+	// units belongs to.
+	OwnerTag() string
+
+	// Config returns the current service configuration of the executing unit.
+	ConfigSettings() (charm.Settings, error)
+}
+
+// ContextStatus is the part of a hook context related to the unit's status.
+type ContextStatus interface {
 	// UnitStatus returns the executing unit's current status.
 	UnitStatus() (*StatusInfo, error)
 
 	// SetUnitStatus updates the unit's status.
 	SetUnitStatus(StatusInfo) error
 
-	// SetServiceStatus updates the status for the unit's service.
-	SetServiceStatus(StatusInfo) error
-
-	// ServiceStatus returns the executing unit's service status (including all units).
+	// ServiceStatus returns the executing unit's service status
+	// (including all units).
 	ServiceStatus() (ServiceStatusInfo, error)
 
+	// SetServiceStatus updates the status for the unit's service.
+	SetServiceStatus(StatusInfo) error
+}
+
+// ContextInstace is the part of a hook context related to the unit's intance.
+type ContextInstance interface {
+	// AvailabilityZone returns the executing unit's availablilty zone.
+	AvailabilityZone() (string, bool)
+
+	// RequestReboot will set the reboot flag to true on the machine agent
+	RequestReboot(prio RebootPriority) error
+}
+
+// ContextNetworking is the part of a hook context related to network
+// interface of the unit's instance.
+type ContextNetworking interface {
 	// PublicAddress returns the executing unit's public address.
 	PublicAddress() (string, bool)
 
 	// PrivateAddress returns the executing unit's private address.
 	PrivateAddress() (string, bool)
-
-	// AvailabilityZone returns the executing unit's availablilty zone.
-	AvailabilityZone() (string, bool)
 
 	// OpenPorts marks the supplied port range for opening when the
 	// executing unit's service is exposed.
@@ -70,10 +153,11 @@ type Context interface {
 	// unit on its assigned machine. The result is sorted first by
 	// protocol, then by number.
 	OpenedPorts() []network.PortRange
+}
 
-	// Config returns the current service configuration of the executing unit.
-	ConfigSettings() (charm.Settings, error)
-
+// ContextLeadership is the part of a hook context related to the
+// unit leadership.
+type ContextLeadership interface {
 	// IsLeader returns true if the local unit is known to be leader for at
 	// least the next 30s.
 	IsLeader() (bool, error)
@@ -86,29 +170,31 @@ type Context interface {
 	// WriteLeaderSettings writes the supplied settings directly to state, or
 	// fails if the local unit is not the service's leader.
 	WriteLeaderSettings(map[string]string) error
+}
 
-	// ActionParams returns the map of params passed with an Action.
-	ActionParams() (map[string]interface{}, error)
+// ContextLeadership is the part of a hook context related to metrics.
+type ContextMetrics interface {
+	// AddMetric records a metric to return after hook execution.
+	AddMetric(string, string, time.Time) error
+}
 
-	// UpdateActionResults inserts new values for use with action-set.
-	// The results struct will be delivered to the state server upon
-	// completion of the Action.
-	UpdateActionResults(keys []string, value string) error
+// ContextStorage is the part of a hook context related to storage
+// resources associated with the unit.
+type ContextStorage interface {
+	// Storage returns the ContextStorageAttachment with the supplied
+	// tag if it was found, and whether it was found.
+	Storage(names.StorageTag) (ContextStorageAttachment, bool)
 
-	// SetActionMessage sets a message for the Action.
-	SetActionMessage(string) error
+	// HookStorage returns the storage attachment associated
+	// the executing hook if it was found, and whether it was found.
+	HookStorage() (ContextStorageAttachment, bool)
 
-	// SetActionFailed sets a failure state for the Action.
-	SetActionFailed() error
+	// AddUnitStorage saves storage constraints in the context.
+	AddUnitStorage(map[string]params.StorageConstraints)
+}
 
-	// HookRelation returns the ContextRelation associated with the executing
-	// hook if it was found, and whether it was found.
-	HookRelation() (ContextRelation, bool)
-
-	// RemoteUnitName returns the name of the remote unit the hook execution
-	// is associated with if it was found, and whether it was found.
-	RemoteUnitName() (string, bool)
-
+// ContextRelations exposes the relations associated with the unit.
+type ContextRelations interface {
 	// Relation returns the relation with the supplied id if it was found, and
 	// whether it was found.
 	Relation(id int) (ContextRelation, bool)
@@ -116,27 +202,6 @@ type Context interface {
 	// RelationIds returns the ids of all relations the executing unit is
 	// currently participating in.
 	RelationIds() []int
-
-	// OwnerTag returns the user tag of the service the executing
-	// units belongs to.
-	OwnerTag() string
-
-	// AddMetric records a metric to return after hook execution.
-	AddMetric(string, string, time.Time) error
-
-	// RequestReboot will set the reboot flag to true on the machine agent
-	RequestReboot(prio RebootPriority) error
-
-	// Storage returns the ContextStorageAttachment with the supplied
-	// tag if it was found, and whether it was found.
-	Storage(names.StorageTag) (ContextStorageAttachment, bool)
-
-	// HookStorageAttachment returns the storage attachment associated
-	// the executing hook if it was found, and whether it was found.
-	HookStorage() (ContextStorageAttachment, bool)
-
-	// AddUnitStorage saves storage constraints in the context.
-	AddUnitStorage(map[string]params.StorageConstraints)
 }
 
 // ContextRelation expresses the capabilities of a hook with respect to a relation.

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -174,14 +174,14 @@ func (c *Context) AvailabilityZone() (string, bool) {
 	return "us-east-1a", true
 }
 
-func (c *Context) Storage(tag names.StorageTag) (jujuc.ContextStorage, bool) {
+func (c *Context) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachment, bool) {
 	storage, ok := c.storage[tag]
 	return storage, ok
 }
 
 func (c *Context) AddUnitStorage(all map[string]params.StorageConstraints) {}
 
-func (c *Context) HookStorage() (jujuc.ContextStorage, bool) {
+func (c *Context) HookStorage() (jujuc.ContextStorageAttachment, bool) {
 	return c.Storage(c.storageTag)
 }
 

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -354,7 +354,7 @@ type storageContextAccessor struct {
 	storage map[names.StorageTag]*contextStorage
 }
 
-func (s *storageContextAccessor) Storage(tag names.StorageTag) (jujuc.ContextStorage, bool) {
+func (s *storageContextAccessor) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachment, bool) {
 	storage, ok := s.storage[tag]
 	return storage, ok
 }

--- a/worker/uniter/storage/attachments.go
+++ b/worker/uniter/storage/attachments.go
@@ -297,7 +297,7 @@ func (a *Attachments) Empty() bool {
 
 // Storage returns the ContextStorage with the supplied tag if it was
 // found, and whether it was found.
-func (a *Attachments) Storage(tag names.StorageTag) (jujuc.ContextStorage, bool) {
+func (a *Attachments) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachment, bool) {
 	if s, ok := a.storagers[tag]; ok {
 		return s.Context()
 	}

--- a/worker/uniter/storage/context.go
+++ b/worker/uniter/storage/context.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/juju/storage"
 )
 
-// contextStorage is an implementation of jujuc.ContextStorage.
+// contextStorage is an implementation of jujuc.ContextStorageAttachment.
 type contextStorage struct {
 	tag      names.StorageTag
 	kind     storage.StorageKind

--- a/worker/uniter/storage/export_test.go
+++ b/worker/uniter/storage/export_test.go
@@ -21,7 +21,7 @@ type StorageHookQueue interface {
 	Next() hook.Info
 	Pop()
 	Update(attachment params.StorageAttachment) error
-	Context() (jujuc.ContextStorage, bool)
+	Context() (jujuc.ContextStorageAttachment, bool)
 }
 
 func StateAttached(s State) bool {

--- a/worker/uniter/storage/source.go
+++ b/worker/uniter/storage/source.go
@@ -219,7 +219,7 @@ func (s *storageHookQueue) Update(attachment params.StorageAttachment) error {
 // Context returns the ContextStorage for the storage that this hook queue
 // corresponds to, and whether there is any context available yet. There
 // will be context beginning from when the first hook is queued.
-func (s *storageHookQueue) Context() (jujuc.ContextStorage, bool) {
+func (s *storageHookQueue) Context() (jujuc.ContextStorageAttachment, bool) {
 	if s.context != nil {
 		return s.context, true
 	}

--- a/worker/uniter/storage/storager.go
+++ b/worker/uniter/storage/storager.go
@@ -56,7 +56,7 @@ func (s *storager) Stop() error {
 // Context returns the ContextStorage for the storage that this storager
 // corresponds to, and whether there is any context available yet. There
 // will be context beginning from when the first hook is queued.
-func (s *storager) Context() (jujuc.ContextStorage, bool) {
+func (s *storager) Context() (jujuc.ContextStorageAttachment, bool) {
 	return s.source.Context()
 }
 


### PR DESCRIPTION
Splitting up the interface provides maintenance and on-boarding benefits.  It also helps explicitly delineate how new features fit into hook contexts.

Since the patch uses composition of the sub-interfaces, jujuc.Context keeps all the same methods, which means that no other code in Juju needs to change.  The only adjustment in the patch is renaming "ContextStorage" to "ContextStorageAttachment", which was necessary to make room for the "ContextStorage" sub-interface.

(Review request: http://reviews.vapour.ws/r/1887/)