### PR TITLE
Fix lp-1461150

### DIFF
--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -277,11 +277,11 @@ func (p *containerProvisioner) loop() error {
 	environConfigChanges = environWatcher.Changes()
 	defer watcher.Stop(environWatcher, &p.tomb)
 
-	environ, err := worker.WaitForEnviron(environWatcher, p.st, p.tomb.Dying())
+	config, err := p.st.EnvironConfig()
 	if err != nil {
 		return err
 	}
-	harvestMode := environ.Config().ProvisionerHarvestMode()
+	harvestMode := config.ProvisionerHarvestMode()
 
 	task, err := p.getStartTask(harvestMode)
 	if err != nil {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1461150

The container provisioner was loading an environment when it didn't need to.

(Review request: http://reviews.vapour.ws/r/1889/)