### PR TITLE
state: fix address update assertions

### DIFF
--- a/state/machine.go
+++ b/state/machine.go
@@ -961,9 +961,15 @@ func (m *Machine) Addresses() (addresses []network.Address) {
 // SetProviderAddresses records any addresses related to the machine, sourced
 // by asking the provider.
 func (m *Machine) SetProviderAddresses(addresses ...network.Address) (err error) {
-	if err = m.setAddresses(addresses, &m.doc.Addresses, "addresses"); err != nil {
+	// Refresh addresses without modifying any other fields of m.
+	m2, err := m.st.Machine(m.Id())
+	if err != nil {
+		return errors.Annotatef(err, "cannot refresh provider addresses for machine %s", m)
+	}
+	if err = m2.setAddresses(addresses, &m2.doc.Addresses, "addresses"); err != nil {
 		return fmt.Errorf("cannot set addresses of machine %v: %v", m, err)
 	}
+	m.doc.Addresses = m2.doc.Addresses
 	return nil
 }
 
@@ -988,52 +994,42 @@ func (m *Machine) MachineAddresses() (addresses []network.Address) {
 // SetMachineAddresses records any addresses related to the machine, sourced
 // by asking the machine.
 func (m *Machine) SetMachineAddresses(addresses ...network.Address) (err error) {
-	if err = m.setAddresses(addresses, &m.doc.MachineAddresses, "machineaddresses"); err != nil {
+	// Refresh addresses without modifying any other fields of m.
+	m2, err := m.st.Machine(m.Id())
+	if err != nil {
+		return errors.Annotatef(err, "cannot refresh machine addresses for machine %s", m)
+	}
+	if err = m2.setAddresses(addresses, &m2.doc.MachineAddresses, "machineaddresses"); err != nil {
 		return fmt.Errorf("cannot set machine addresses of machine %v: %v", m, err)
 	}
+	m.doc.MachineAddresses = m2.doc.MachineAddresses
 	return nil
 }
 
 // setAddresses updates the machine's addresses (either Addresses or
-// MachineAddresses, depending on the field argument).
+// MachineAddresses, depending on the field argument). Changes are
+// only predicated on the machine not being Dead; concurrent address
+// changes are ignored.
 func (m *Machine) setAddresses(addresses []network.Address, field *[]address, fieldName string) error {
-	var changed bool
 	envConfig, err := m.st.EnvironConfig()
 	if err != nil {
 		return err
 	}
 	network.SortAddresses(addresses, envConfig.PreferIPv6())
 	stateAddresses := instanceAddressesToAddresses(addresses)
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		changed = false
-		if attempt > 0 {
-			if err := m.Refresh(); err != nil {
-				return nil, err
-			}
-		}
-		if m.doc.Life == Dead {
-			return nil, ErrDead
-		}
-		op := txn.Op{
-			C:      machinesC,
-			Id:     m.doc.DocID,
-			Assert: append(bson.D{{fieldName, *field}}, notDeadDoc...),
-		}
-		if !addressesEqual(addresses, addressesToInstanceAddresses(*field)) {
-			op.Update = bson.D{{"$set", bson.D{{fieldName, stateAddresses}}}}
-			changed = true
-		}
-		return []txn.Op{op}, nil
-	}
-	switch err := m.st.run(buildTxn); err {
-	case nil:
-	case jujutxn.ErrExcessiveContention:
-		return errors.Annotatef(err, "cannot set %s for machine %s", fieldName, m)
-	default:
-		return err
-	}
-	if !changed {
+	if addressesEqual(addresses, addressesToInstanceAddresses(*field)) {
 		return nil
+	}
+	if err := m.st.runTransaction([]txn.Op{{
+		C:      machinesC,
+		Id:     m.doc.DocID,
+		Assert: notDeadDoc,
+		Update: bson.D{{"$set", bson.D{{fieldName, stateAddresses}}}},
+	}}); err != nil {
+		if err == txn.ErrAborted {
+			return ErrDead
+		}
+		return errors.Trace(err)
 	}
 	*field = stateAddresses
 	return nil


### PR DESCRIPTION
Back-port of https://github.com/juju/juju/pull/2513

Change machine address updates to not care about concurrent updates.

Block-device and address updates are currently asserting
that there are no concurrent changes. There are several
problems with this:
 - to do this, they assert that the current field value
   is equal to the in-memory struct representation. This
   means that removing or reordering fields in the struct
   will cause assertion failures
 - even without changing the above, there is an issue in
   mgo that can cause reordering of map elements in
   assertions
 - the assertions are pointless. Even if we prevent a change
   between observing the current value and updating, we still
   loop and then update. The net effect is that we always update,
   except in the case of "state changing too fast".

Fixes https://bugs.launchpad.net/bugs/1461871

(Review request: http://reviews.vapour.ws/r/1890/)