### PR TITLE
Add system destroy command

### DIFF
--- a/api/environmentmanager/environmentmanager.go
+++ b/api/environmentmanager/environmentmanager.go
@@ -108,3 +108,20 @@ func (c *Client) ListEnvironments(user string) ([]UserEnvironment, error) {
 	}
 	return result, nil
 }
+
+// EnvironmentGet returns all environment settings for the
+// system environment.
+func (c *Client) EnvironmentGet() (map[string]interface{}, error) {
+	result := params.EnvironmentConfigResults{}
+	err := c.facade.FacadeCall("EnvironmentGet", nil, &result)
+	return result.Config, err
+}
+
+// DestroyEnvironment puts the environment into a "dying" state,
+// and removes all non-manager machine instances. DestroyEnvironment
+// will fail if there are any manually-provisioned non-manager machines
+// in state.
+func (c *Client) DestroyEnvironment(envUUID string) error {
+	env := params.EnvironmentDestroyArgs{envUUID}
+	return c.facade.FacadeCall("DestroyEnvironment", env, nil)
+}

--- a/api/environmentmanager/environmentmanager_test.go
+++ b/api/environmentmanager/environmentmanager_test.go
@@ -117,3 +117,11 @@ func (s *environmentmanagerSuite) TestListEnvironments(c *gc.C) {
 	ownerNames := []string{envs[0].Owner, envs[1].Owner}
 	c.Assert(ownerNames, jc.DeepEquals, []string{"user@remote", "user@remote"})
 }
+
+func (s *environmentmanagerSuite) TestEnvironmentGet(c *gc.C) {
+	s.SetFeatureFlags(feature.JES)
+	envManager := s.OpenAPI(c)
+	env, err := envManager.EnvironmentGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env["name"], gc.Equals, "dummyenv")
+}

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -1045,5 +1045,5 @@ func (c *Client) DestroyEnvironment() (err error) {
 		return errors.Trace(err)
 	}
 
-	return envManager.DestroyEnvironment(c.api.state.EnvironUUID())
+	return envManager.DestroyEnvironment(params.EnvironmentDestroyArgs{c.api.state.EnvironUUID()})
 }

--- a/apiserver/environmentmanager/destroy_test.go
+++ b/apiserver/environmentmanager/destroy_test.go
@@ -13,6 +13,7 @@ import (
 
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/environmentmanager"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
@@ -79,7 +80,7 @@ func (s *destroyEnvironmentSuite) setUpInstances(c *gc.C) (m0, m1, m2 *state.Mac
 func (s *destroyEnvironmentSuite) destroyEnvironment(c *gc.C, envUUID string) error {
 	envManager, err := environmentmanager.NewEnvironmentManagerAPI(s.State, s.resources, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
-	return envManager.DestroyEnvironment(envUUID)
+	return envManager.DestroyEnvironment(params.EnvironmentDestroyArgs{envUUID})
 }
 
 func (s *destroyEnvironmentSuite) TestDestroyEnvironmentManual(c *gc.C) {
@@ -230,7 +231,7 @@ func (s *destroyTwoEnvironmentsSuite) SetUpTest(c *gc.C) {
 func (s *destroyTwoEnvironmentsSuite) destroyEnvironment(c *gc.C, envUUID string) error {
 	envManager, err := environmentmanager.NewEnvironmentManagerAPI(s.State, s.resources, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
-	return envManager.DestroyEnvironment(envUUID)
+	return envManager.DestroyEnvironment(params.EnvironmentDestroyArgs{envUUID})
 }
 
 func (s *destroyTwoEnvironmentsSuite) TestCleanupEnvironDocs(c *gc.C) {

--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -392,8 +392,9 @@ func (em *EnvironmentManagerAPI) destroyEnvironmentAuthCheck(st stateInterface) 
 
 // DestroyEnvironment destroys all services and non-manager machine
 // instances in the specified environment.
-func (em *EnvironmentManagerAPI) DestroyEnvironment(envUUID string) (err error) {
+func (em *EnvironmentManagerAPI) DestroyEnvironment(args params.EnvironmentDestroyArgs) (err error) {
 	st := em.state
+	envUUID := args.EnvUUID
 	if envUUID != em.state.EnvironUUID() {
 		envTag := names.NewEnvironTag(envUUID)
 		if st, err = em.state.ForEnviron(envTag); err != nil {
@@ -483,4 +484,23 @@ func destroyInstances(st stateInterface, machines []*state.Machine) error {
 		return err
 	}
 	return env.StopInstances(ids...)
+}
+
+// EnvironmentGet returns the environment config for the system
+// environment.  For information on the current environment, use
+// client.EnvironmentGet
+func (em *EnvironmentManagerAPI) EnvironmentGet() (params.EnvironmentConfigResults, error) {
+	result := params.EnvironmentConfigResults{}
+	stateServerEnv, err := em.state.StateServerEnvironment()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	config, err := stateServerEnv.Config()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	result.Config = config.AllAttrs()
+	return result, nil
 }

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -360,8 +360,16 @@ func (s *envManagerSuite) TestListEnvironmentsDenied(c *gc.C) {
 }
 
 func (s *envManagerSuite) TestEnvironmentGet(c *gc.C) {
-	user := names.NewUserTag("dummy-admin")
-	s.setAPIUser(c, user)
+	s.setAPIUser(c, s.AdminUserTag(c))
+	env, err := s.envmanager.EnvironmentGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Config["name"], gc.Equals, "dummyenv")
+}
+
+func (s *envManagerSuite) TestEnvironmentGetNonAdminUser(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoEnvUser: false})
+
+	s.setAPIUser(c, user.UserTag())
 	env, err := s.envmanager.EnvironmentGet()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Config["name"], gc.Equals, "dummyenv")
@@ -372,7 +380,7 @@ func (s *envManagerSuite) TestEnvironmentGetFromNonStateServer(c *gc.C) {
 		Name: "test"})
 	defer st.Close()
 
-	authorizer := &apiservertesting.FakeAuthorizer{Tag: names.NewUserTag("dummy-admin")}
+	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.AdminUserTag(c)}
 	envManager, err := environmentmanager.NewEnvironmentManagerAPI(st, common.NewResources(), authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := envManager.EnvironmentGet()

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -89,6 +89,11 @@ type EnvironmentSkeletonConfigArgs struct {
 	Region   string
 }
 
+// EnvironmentDestroyArgs wraps the environment UUID to destroy.
+type EnvironmentDestroyArgs struct {
+	EnvUUID string
+}
+
 // EnvironmentCreateArgs holds the arguments that are necessary to create
 // and environment.
 type EnvironmentCreateArgs struct {

--- a/cmd/juju/system/destroy.go
+++ b/cmd/juju/system/destroy.go
@@ -1,0 +1,259 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/api/environmentmanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/juju"
+)
+
+// DestroyCommand destroys the specified system.
+type DestroyCommand struct {
+	envcmd.SysCommandBase
+	systemName string
+	assumeYes  bool
+
+	// The following fields are for mocking out
+	// api behavior for testing.
+	api       destroyEnvironmentAPI
+	clientapi destroyEnvironmentClientAPI
+	apierr    error
+}
+
+var destroyDoc = `Destroys the specified system`
+var destroyEnvMsg = `
+WARNING! this command will destroy the %q system.
+This includes all machines, services, data and other resources.
+
+Continue [y/N]? `[1:]
+
+// environmentGetterAPI defines the method on the API endpoint that
+// the destroy command calls to obtain bootstrap information for
+// the system being destroyed.
+type environmentGetterAPI interface {
+	EnvironmentGet() (map[string]interface{}, error)
+}
+
+// destroyEnvironmentAPI defines the methods on the environmentmanager
+// API that the destroy command calls.
+type destroyEnvironmentAPI interface {
+	environmentGetterAPI
+	Close() error
+	DestroyEnvironment(string) error
+}
+
+// destroyEnvironmentClientAPI defines the methods on the client
+// API that the destroy command calls.
+type destroyEnvironmentClientAPI interface {
+	environmentGetterAPI
+	Close() error
+	DestroyEnvironment() error
+}
+
+// Info implements Command.Info.
+func (c *DestroyCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "destroy",
+		Args:    "<system name>",
+		Purpose: "terminate all machines and other associated resources for a system environment",
+		Doc:     destroyDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *DestroyCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation")
+	f.BoolVar(&c.assumeYes, "yes", false, "")
+}
+
+// Init implements Command.Init.
+func (c *DestroyCommand) Init(args []string) error {
+	switch len(args) {
+	case 0:
+		return errors.New("no system specified")
+	case 1:
+		c.systemName = args[0]
+		return nil
+	default:
+		return cmd.CheckEmpty(args[1:])
+	}
+}
+
+func (c *DestroyCommand) getAPI() (destroyEnvironmentAPI, error) {
+	if c.api != nil {
+		return c.api, c.apierr
+	}
+	root, err := juju.NewAPIFromName(c.systemName)
+	if err != nil {
+		return nil, err
+	}
+
+	return environmentmanager.NewClient(root), nil
+}
+
+func (c *DestroyCommand) getClientAPI() (destroyEnvironmentClientAPI, error) {
+	if c.clientapi != nil {
+		return c.clientapi, nil
+	}
+	return juju.NewAPIClientFromName(c.systemName)
+}
+
+// Run implements Command.Run
+func (c *DestroyCommand) Run(ctx *cmd.Context) error {
+	store, err := configstore.Default()
+	if err != nil {
+		return errors.Annotate(err, "cannot open system info storage")
+	}
+
+	cfgInfo, err := store.ReadInfo(c.systemName)
+	if err != nil {
+		return errors.Annotate(err, "cannot read system info")
+	}
+
+	// Verify that we're destroying a system
+	apiEndpoint := cfgInfo.APIEndpoint()
+	if apiEndpoint.ServerUUID != "" && apiEndpoint.EnvironUUID != apiEndpoint.ServerUUID {
+		return fmt.Errorf("%q is not a system; use juju environment destroy to destroy it", c.systemName)
+	}
+
+	if !c.assumeYes {
+		fmt.Fprintf(ctx.Stdout, destroyEnvMsg, c.systemName)
+
+		scanner := bufio.NewScanner(ctx.Stdin)
+		scanner.Scan()
+		err := scanner.Err()
+		if err != nil && err != io.EOF {
+			return errors.Annotate(err, "environment destruction aborted")
+		}
+		answer := strings.ToLower(scanner.Text())
+		if answer != "y" && answer != "yes" {
+			return errors.New("environment destruction aborted")
+		}
+	}
+
+	// Attempt to connect to the API.  If we can't, fail the destroy.  Users will
+	// need to use the system force-destroy command if we can't connect.
+	api, err := c.getAPI()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Warningf("system not found, removing config file")
+			ctx.Infof("system not found, removing config file")
+			return environs.DestroyInfo(c.systemName, store)
+		}
+		return c.ensureUserFriendlyErrorLog(errors.Annotate(err, "cannot connect to API"))
+	}
+	defer api.Close()
+
+	// Obtain bootstrap / system environ information
+	systemEnviron, err := c.getSystemEnviron(cfgInfo, api)
+	if params.IsCodeNotImplemented(err) {
+		// Fall back to using the client endpoint to obtain bootstrap
+		// information and to destroy the system, sending the info
+		// we were already able to collect.
+		return c.destroyEnvironmentViaClient(ctx, cfgInfo, nil, store)
+	}
+	if err != nil {
+		return errors.Annotate(err, "cannot obtain bootstrap information")
+	}
+
+	// Attempt to destroy the system.
+	err = api.DestroyEnvironment(apiEndpoint.ServerUUID)
+	if params.IsCodeNotImplemented(err) {
+		// Fall back to using the client endpoint to destroy the system,
+		// sending the info we were already able to collect.
+		return c.destroyEnvironmentViaClient(ctx, cfgInfo, systemEnviron, store)
+	}
+	if err != nil {
+		return c.ensureUserFriendlyErrorLog(errors.Annotate(err, "cannot destroy system"))
+	}
+
+	return environs.Destroy(systemEnviron, store)
+}
+
+// getSystemEnviron gets the bootstrap information required to destroy the environment
+// by first checking the config store, then querying the API if the information is not
+// in the store.
+func (c *DestroyCommand) getSystemEnviron(info configstore.EnvironInfo, api environmentGetterAPI) (_ environs.Environ, err error) {
+	bootstrapCfg := info.BootstrapConfig()
+	if bootstrapCfg == nil {
+		bootstrapCfg, err = api.EnvironmentGet()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cfg, err := config.New(config.NoDefaults, bootstrapCfg)
+	if err != nil {
+		return nil, err
+	}
+	return environs.New(cfg)
+}
+
+// destroyEnvironmentViaClient attempts to destroy the environment using the client
+// endpoint for older juju systems which do not implement environmentmanager.DestroyEnvironment
+func (c *DestroyCommand) destroyEnvironmentViaClient(ctx *cmd.Context, info configstore.EnvironInfo, systemEnviron environs.Environ, store configstore.Storage) error {
+	api, err := c.getClientAPI()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Warningf("environment not found, removing config file")
+			ctx.Infof("environment not found, removing config file")
+			return environs.DestroyInfo(c.systemName, store)
+		}
+		return c.ensureUserFriendlyErrorLog(errors.Annotate(err, "cannot connect to API"))
+	}
+	defer api.Close()
+
+	if systemEnviron == nil {
+		systemEnviron, err = c.getSystemEnviron(info, api)
+		if err != nil {
+			return errors.Annotate(err, "cannot obtain bootstrap information")
+		}
+	}
+
+	err = api.DestroyEnvironment()
+	if err != nil {
+		return c.ensureUserFriendlyErrorLog(errors.Annotate(err, "cannot destroy system"))
+	}
+
+	return environs.Destroy(systemEnviron, store)
+}
+
+// ensureUserFriendlyErrorLog ensures that error will be logged and displayed
+// in a user-friendly manner with readable and digestable error message.
+func (c *DestroyCommand) ensureUserFriendlyErrorLog(err error) error {
+	if err == nil {
+		return nil
+	}
+	if params.IsCodeOperationBlocked(err) {
+		return block.ProcessBlockedError(err, block.BlockDestroy)
+	}
+	logger.Errorf(stdFailureMsg, c.systemName)
+	return err
+}
+
+var stdFailureMsg = `failed to destroy system %q
+
+If the system is unusable, then you may run
+
+    juju system force-destroy
+
+to forcefully destroy the environment. Upon doing so, review
+your environment provider console for any resources that need
+to be cleaned up.
+`

--- a/cmd/juju/system/destroy.go
+++ b/cmd/juju/system/destroy.go
@@ -38,7 +38,7 @@ type DestroyCommand struct {
 
 var destroyDoc = `Destroys the specified system`
 var destroyEnvMsg = `
-WARNING! this command will destroy the %q system.
+WARNING! This command will destroy the %q system.
 This includes all machines, services, data and other resources.
 
 Continue [y/N]? `[1:]
@@ -129,7 +129,7 @@ func (c *DestroyCommand) Run(ctx *cmd.Context) error {
 	// Verify that we're destroying a system
 	apiEndpoint := cfgInfo.APIEndpoint()
 	if apiEndpoint.ServerUUID != "" && apiEndpoint.EnvironUUID != apiEndpoint.ServerUUID {
-		return fmt.Errorf("%q is not a system; use juju environment destroy to destroy it", c.systemName)
+		return errors.Errorf("%q is not a system; use juju environment destroy to destroy it", c.systemName)
 	}
 
 	if !c.assumeYes {
@@ -173,7 +173,7 @@ func (c *DestroyCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Attempt to destroy the system.
-	err = api.DestroyEnvironment(apiEndpoint.ServerUUID)
+	err = api.DestroyEnvironment(apiEndpoint.EnvironUUID)
 	if params.IsCodeNotImplemented(err) {
 		// Fall back to using the client endpoint to destroy the system,
 		// sending the info we were already able to collect.
@@ -253,7 +253,7 @@ If the system is unusable, then you may run
 
     juju system force-destroy
 
-to forcefully destroy the environment. Upon doing so, review
+to forcefully destroy the system. Upon doing so, review
 your environment provider console for any resources that need
 to be cleaned up.
 `

--- a/cmd/juju/system/destroy_test.go
+++ b/cmd/juju/system/destroy_test.go
@@ -201,7 +201,7 @@ func (s *DestroySuite) TestDestroy(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyEnvironmentGetFails(c *gc.C) {
-	s.api.err = errors.New("system \"test3\" not found")
+	s.api.err = errors.NotFoundf(`system "test3"`)
 	_, err := s.runDestroyCommand(c, "test3", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot obtain bootstrap information: system \"test3\" not found")
 	checkSystemExistsInStore(c, "test3", s.store)
@@ -211,7 +211,7 @@ func (s *DestroySuite) TestDestroyFallsBackToClient(c *gc.C) {
 	s.api.err = &params.Error{"DestroyEnvironment", params.CodeNotImplemented}
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.clientapi.destroycalled, gc.Equals, true)
+	c.Assert(s.clientapi.destroycalled, jc.IsTrue)
 	checkSystemRemovedFromStore(c, "test1", s.store)
 }
 
@@ -220,8 +220,8 @@ func (s *DestroySuite) TestEnvironmentGetFallsBackToClient(c *gc.C) {
 	s.clientapi.env = createBootstrapInfo(c, "test3")
 	_, err := s.runDestroyCommand(c, "test3", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.clientapi.envgetcalled, gc.Equals, true)
-	c.Assert(s.clientapi.destroycalled, gc.Equals, true)
+	c.Assert(s.clientapi.envgetcalled, jc.IsTrue)
+	c.Assert(s.clientapi.destroycalled, jc.IsTrue)
 	checkSystemRemovedFromStore(c, "test3", s.store)
 }
 

--- a/cmd/juju/system/destroy_test.go
+++ b/cmd/juju/system/destroy_test.go
@@ -1,0 +1,303 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system_test
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/system"
+	cmdtesting "github.com/juju/juju/cmd/testing"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/configstore"
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
+)
+
+type DestroySuite struct {
+	testing.FakeJujuHomeSuite
+	api       *fakeDestroyAPI
+	clientapi *fakeDestroyAPIClient
+	store     configstore.Storage
+	apierror  error
+}
+
+var _ = gc.Suite(&DestroySuite{})
+
+// fakeDestroyAPI mocks out the environmentmanager API
+type fakeDestroyAPI struct {
+	err     error
+	env     map[string]interface{}
+	envUUID string
+}
+
+func (f *fakeDestroyAPI) Close() error { return nil }
+
+func (f *fakeDestroyAPI) EnvironmentGet() (map[string]interface{}, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.env, nil
+}
+
+func (f *fakeDestroyAPI) DestroyEnvironment(envUUID string) error {
+	f.envUUID = envUUID
+	return f.err
+}
+
+// fakeDestroyAPIClient mocks out the client API
+type fakeDestroyAPIClient struct {
+	err           error
+	env           map[string]interface{}
+	envgetcalled  bool
+	destroycalled bool
+}
+
+func (f *fakeDestroyAPIClient) Close() error { return nil }
+
+func (f *fakeDestroyAPIClient) EnvironmentGet() (map[string]interface{}, error) {
+	f.envgetcalled = true
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.env, nil
+}
+
+func (f *fakeDestroyAPIClient) DestroyEnvironment() error {
+	f.destroycalled = true
+	return f.err
+}
+
+func createBootstrapInfo(c *gc.C, name string) map[string]interface{} {
+	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
+		"type":         "dummy",
+		"name":         name,
+		"state-server": "true",
+		"state-id":     "1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return cfg.AllAttrs()
+}
+
+func (s *DestroySuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+	s.clientapi = &fakeDestroyAPIClient{}
+	s.api = &fakeDestroyAPI{}
+	s.apierror = nil
+
+	var err error
+	s.store, err = configstore.Default()
+	c.Assert(err, jc.ErrorIsNil)
+
+	var envList = []struct {
+		name         string
+		serverUUID   string
+		envUUID      string
+		bootstrapCfg map[string]interface{}
+	}{
+		{
+			name:         "test1",
+			serverUUID:   "test1-uuid",
+			envUUID:      "test1-uuid",
+			bootstrapCfg: createBootstrapInfo(c, "test1"),
+		}, {
+			name:       "test2",
+			serverUUID: "test1-uuid",
+			envUUID:    "test2-uuid",
+		}, {
+			name:    "test3",
+			envUUID: "test3-uuid",
+		},
+	}
+	for _, env := range envList {
+		info := s.store.CreateInfo(env.name)
+		info.SetAPIEndpoint(configstore.APIEndpoint{
+			Addresses:   []string{"localhost"},
+			CACert:      testing.CACert,
+			EnvironUUID: env.envUUID,
+			ServerUUID:  env.serverUUID,
+		})
+
+		if env.bootstrapCfg != nil {
+			info.SetBootstrapConfig(env.bootstrapCfg)
+		}
+		err := info.Write()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *DestroySuite) runDestroyCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	cmd := system.NewDestroyCommand(s.api, s.clientapi, s.apierror)
+	return testing.RunCommand(c, cmd, args...)
+}
+
+func (s *DestroySuite) newDestroyCommand() *system.DestroyCommand {
+	return system.NewDestroyCommand(s.api, s.clientapi, s.apierror)
+}
+
+func checkSystemExistsInStore(c *gc.C, name string, store configstore.Storage) {
+	_, err := store.ReadInfo(name)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func checkSystemRemovedFromStore(c *gc.C, name string, store configstore.Storage) {
+	_, err := store.ReadInfo(name)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *DestroySuite) TestDestroyNoSystemNameError(c *gc.C) {
+	_, err := s.runDestroyCommand(c)
+	c.Assert(err, gc.ErrorMatches, "no system specified")
+}
+
+func (s *DestroySuite) TestDestroyBadFlags(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "-n")
+	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: -n")
+}
+
+func (s *DestroySuite) TestDestroyUnknownArgument(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "environment", "whoops")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+}
+
+func (s *DestroySuite) TestDestroyUnknownSystem(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "foo")
+	c.Assert(err, gc.ErrorMatches, "cannot read system info: environment \"foo\" not found")
+}
+
+func (s *DestroySuite) TestDestroyNonSystemEnvFails(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "test2")
+	c.Assert(err, gc.ErrorMatches, "\"test2\" is not a system; use juju environment destroy to destroy it")
+}
+
+func (s *DestroySuite) TestDestroySystemNotFoundRemovedFromStore(c *gc.C) {
+	s.apierror = errors.NotFoundf("test1")
+	ctx, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stderr(ctx), gc.Equals, "system not found, removing config file\n")
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
+	s.apierror = errors.New("connection refused")
+	_, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot connect to API: connection refused")
+	c.Check(c.GetTestLog(), jc.Contains, "If the system is unusable")
+	checkSystemExistsInStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) TestDestroy(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.api.envUUID, gc.Equals, "test1-uuid")
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) TestDestroyEnvironmentGetFails(c *gc.C) {
+	s.api.err = errors.New("system \"test3\" not found")
+	_, err := s.runDestroyCommand(c, "test3", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot obtain bootstrap information: system \"test3\" not found")
+	checkSystemExistsInStore(c, "test3", s.store)
+}
+
+func (s *DestroySuite) TestDestroyFallsBackToClient(c *gc.C) {
+	s.api.err = &params.Error{"DestroyEnvironment", params.CodeNotImplemented}
+	_, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.clientapi.destroycalled, gc.Equals, true)
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) TestEnvironmentGetFallsBackToClient(c *gc.C) {
+	s.api.err = &params.Error{"EnvironmentGet", params.CodeNotImplemented}
+	s.clientapi.env = createBootstrapInfo(c, "test3")
+	_, err := s.runDestroyCommand(c, "test3", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.clientapi.envgetcalled, gc.Equals, true)
+	c.Assert(s.clientapi.destroycalled, gc.Equals, true)
+	checkSystemRemovedFromStore(c, "test3", s.store)
+}
+
+func (s *DestroySuite) TestFailedDestroyEnvironment(c *gc.C) {
+	s.api.err = errors.New("permission denied")
+	_, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot destroy system: permission denied")
+	c.Assert(s.api.envUUID, gc.Equals, "test1-uuid")
+	checkSystemExistsInStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) resetSystem(c *gc.C) {
+	info := s.store.CreateInfo("test1")
+	info.SetAPIEndpoint(configstore.APIEndpoint{
+		Addresses:   []string{"localhost"},
+		CACert:      testing.CACert,
+		EnvironUUID: "test1-uuid",
+		ServerUUID:  "test1-uuid",
+	})
+	info.SetBootstrapConfig(createBootstrapInfo(c, "test1"))
+	err := info.Write()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
+	var stdin, stdout bytes.Buffer
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
+	ctx.Stdout = &stdout
+	ctx.Stdin = &stdin
+
+	// Ensure confirmation is requested if "-y" is not specified.
+	stdin.WriteString("n")
+	_, errc := cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
+	select {
+	case err := <-errc:
+		c.Check(err, gc.ErrorMatches, "environment destruction aborted")
+	case <-time.After(testing.LongWait):
+		c.Fatalf("command took too long")
+	}
+	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	checkSystemExistsInStore(c, "test1", s.store)
+
+	// EOF on stdin: equivalent to answering no.
+	stdin.Reset()
+	stdout.Reset()
+	_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
+	select {
+	case err := <-errc:
+		c.Check(err, gc.ErrorMatches, "environment destruction aborted")
+	case <-time.After(testing.LongWait):
+		c.Fatalf("command took too long")
+	}
+	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	checkSystemExistsInStore(c, "test1", s.store)
+
+	for _, answer := range []string{"y", "Y", "yes", "YES"} {
+		stdin.Reset()
+		stdout.Reset()
+		stdin.WriteString(answer)
+		_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
+		select {
+		case err := <-errc:
+			c.Check(err, jc.ErrorIsNil)
+		case <-time.After(testing.LongWait):
+			c.Fatalf("command took too long")
+		}
+		checkSystemRemovedFromStore(c, "test1", s.store)
+
+		// Add the test1 system back into the store for the next test
+		s.resetSystem(c)
+	}
+}
+
+func (s *DestroySuite) TestBlockedDestroy(c *gc.C) {
+	s.api.err = &params.Error{Code: params.CodeOperationBlocked}
+	s.runDestroyCommand(c, "test1", "-y")
+	c.Check(c.GetTestLog(), jc.Contains, "To remove the block")
+}

--- a/cmd/juju/system/destroy_test.go
+++ b/cmd/juju/system/destroy_test.go
@@ -169,7 +169,7 @@ func (s *DestroySuite) TestDestroyUnknownArgument(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyUnknownSystem(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "foo")
-	c.Assert(err, gc.ErrorMatches, "cannot read system info: environment \"foo\" not found")
+	c.Assert(err, gc.ErrorMatches, `cannot read system info: environment "foo" not found`)
 }
 
 func (s *DestroySuite) TestDestroyNonSystemEnvFails(c *gc.C) {

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -70,3 +70,13 @@ func (c *CreateEnvironmentCommand) ConfigFile() cmd.FileVar {
 func (c *CreateEnvironmentCommand) ConfValues() map[string]string {
 	return c.confValues
 }
+
+// NewDestroyCommand returns a DestroyCommand with the the environmentmanager and client
+// endpoints mocked out.
+func NewDestroyCommand(api destroyEnvironmentAPI, clientapi destroyEnvironmentClientAPI, apierr error) *DestroyCommand {
+	return &DestroyCommand{
+		api:       api,
+		clientapi: clientapi,
+		apierr:    apierr,
+	}
+}

--- a/cmd/juju/system/system.go
+++ b/cmd/juju/system/system.go
@@ -28,6 +28,7 @@ func NewSuperCommand() cmd.Command {
 
 	systemCmd.Register(&ListCommand{})
 	systemCmd.Register(&LoginCommand{})
+	systemCmd.Register(&DestroyCommand{})
 	systemCmd.Register(envcmd.WrapSystem(&EnvironmentsCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&CreateEnvironmentCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&UseEnvironmentCommand{}))

--- a/cmd/juju/system/system_test.go
+++ b/cmd/juju/system/system_test.go
@@ -23,6 +23,7 @@ var _ = gc.Suite(&SystemCommandSuite{})
 var expectedCommmandNames = []string{
 	"create-env", // alias for create-environment
 	"create-environment",
+	"destroy",
 	"environments",
 	"help",
 	"list",


### PR DESCRIPTION
This patch adds the new system destroy command which is
used to destroy state server environments.

Still to do - add in end to end testing and tests for the new environmentmanager.EnvironmentGet method.

(Review request: http://reviews.vapour.ws/r/1893/)