### PR TITLE
Add 'juju user credentials'

### DIFF
--- a/cmd/juju/user/credentials.go
+++ b/cmd/juju/user/credentials.go
@@ -27,7 +27,7 @@ For Example:
 
 
 See Also:
-    juju server login
+    juju system login
 `
 
 // CredentialsCommand changes the password for a user.

--- a/cmd/juju/user/credentials.go
+++ b/cmd/juju/user/credentials.go
@@ -23,7 +23,7 @@ For Example:
 
     copy the staging.creds file to another machine
 
-    $ juju system login staging --server staging.creds
+    $ juju system login staging --server staging.creds --keep-password
 
 
 See Also:

--- a/cmd/juju/user/credentials.go
+++ b/cmd/juju/user/credentials.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"launchpad.net/gnuflag"
+)
+
+const userCredentialsDoc = `
+Writes out the current user and credentails to a file that can be used
+with 'juju system login' to allow the user to access the same environments
+as the same user from another machine.
+
+For Example:
+
+    $ juju user credentials --output staging.creds
+
+    copy the staging.creds file to another machine
+
+    $ juju system login staging --server staging.creds
+
+
+See Also:
+    juju server login
+`
+
+// CredentialsCommand changes the password for a user.
+type CredentialsCommand struct {
+	UserCommandBase
+	OutPath string
+}
+
+// Info implements Command.Info.
+func (c *CredentialsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "credentials",
+		Purpose: "save the credentials and server details to a file",
+		Doc:     userCredentialsDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *CredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.OutPath, "o", "", "specifies the path of the generated file")
+	f.StringVar(&c.OutPath, "output", "", "")
+}
+
+// Run implements Command.Run.
+func (c *CredentialsCommand) Run(ctx *cmd.Context) error {
+	creds, err := c.ConnectionCredentials()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	filename := c.OutPath
+	if filename == "" {
+		name := names.NewUserTag(creds.User).Name()
+		filename = fmt.Sprintf("%s.server", name)
+	}
+	return writeServerFile(c, ctx, creds.User, creds.Password, filename)
+}

--- a/cmd/juju/user/credentials.go
+++ b/cmd/juju/user/credentials.go
@@ -13,15 +13,15 @@ import (
 )
 
 const userCredentialsDoc = `
-Writes out the current user and credentails to a file that can be used
+Writes out the current user and credentials to a file that can be used
 with 'juju system login' to allow the user to access the same environments
 as the same user from another machine.
 
-For Example:
+Examples:
 
     $ juju user credentials --output staging.creds
 
-    copy the staging.creds file to another machine
+    # copy the staging.creds file to another machine
 
     $ juju system login staging --server staging.creds --keep-password
 
@@ -60,6 +60,11 @@ func (c *CredentialsCommand) Run(ctx *cmd.Context) error {
 
 	filename := c.OutPath
 	if filename == "" {
+		// The reason for the dance though the newUserTag
+		// is to strip off the optional provider.
+		//   user -> user
+		//   user@local -> user
+		//   user@remote -> user
 		name := names.NewUserTag(creds.User).Name()
 		filename = fmt.Sprintf("%s.server", name)
 	}

--- a/cmd/juju/user/credentials_test.go
+++ b/cmd/juju/user/credentials_test.go
@@ -1,0 +1,86 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user_test
+
+import (
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/testing"
+)
+
+type CredentialsCommandSuite struct {
+	BaseSuite
+	serverFilename string
+}
+
+var _ = gc.Suite(&CredentialsCommandSuite{})
+
+func (s *CredentialsCommandSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.serverFilename = ""
+	s.PatchValue(user.ServerFileNotify, func(filename string) {
+		s.serverFilename = filename
+	})
+}
+
+func (s *CredentialsCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	command := envcmd.WrapSystem(&user.CredentialsCommand{})
+	return testing.RunCommand(c, command, args...)
+}
+
+func (s *CredentialsCommandSuite) TestInit(c *gc.C) {
+	for i, test := range []struct {
+		args        []string
+		outPath     string
+		errorString string
+	}{
+		{
+		// no args is fine
+		}, {
+			args:    []string{"--output=foo.bar"},
+			outPath: "foo.bar",
+		}, {
+			args:    []string{"-o", "foo.bar"},
+			outPath: "foo.bar",
+		}, {
+			args:        []string{"foobar"},
+			errorString: `unrecognized args: \["foobar"\]`,
+		},
+	} {
+		c.Logf("test %d", i)
+		command := &user.CredentialsCommand{}
+		err := testing.InitCommand(command, test.args)
+		if test.errorString == "" {
+			c.Check(command.OutPath, gc.Equals, test.outPath)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.errorString)
+		}
+	}
+}
+
+func (s *CredentialsCommandSuite) TestNoArgs(c *gc.C) {
+	context, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+	// User and password are set in BaseSuite.SetUpTest.
+	s.assertServerFileMatches(c, s.serverFilename, "user-test", "password")
+	expected := `
+server file written to .*user-test.server
+`[1:]
+	c.Assert(testing.Stderr(context), gc.Matches, expected)
+}
+
+func (s *CredentialsCommandSuite) TestFilename(c *gc.C) {
+	context, err := s.run(c, "--output=testing.creds")
+	c.Assert(err, jc.ErrorIsNil)
+	// User and password are set in BaseSuite.SetUpTest.
+	s.assertServerFileMatches(c, s.serverFilename, "user-test", "password")
+	expected := `
+server file written to .*testing.creds
+`[1:]
+	c.Assert(testing.Stderr(context), gc.Matches, expected)
+}

--- a/cmd/juju/user/user.go
+++ b/cmd/juju/user/user.go
@@ -30,6 +30,7 @@ func NewSuperCommand() cmd.Command {
 	})
 	usercmd.Register(envcmd.WrapSystem(&AddCommand{}))
 	usercmd.Register(envcmd.WrapSystem(&ChangePasswordCommand{}))
+	usercmd.Register(envcmd.WrapSystem(&CredentialsCommand{}))
 	usercmd.Register(envcmd.WrapSystem(&InfoCommand{}))
 	usercmd.Register(envcmd.WrapSystem(&DisableCommand{}))
 	usercmd.Register(envcmd.WrapSystem(&EnableCommand{}))

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -27,6 +27,7 @@ var _ = gc.Suite(&UserCommandSuite{})
 var expectedUserCommmandNames = []string{
 	"add",
 	"change-password",
+	"credentials",
 	"disable",
 	"enable",
 	"help",


### PR DESCRIPTION
Add a simple user command that can generate a server file usable by 'juju system login'

(Review request: http://reviews.vapour.ws/r/1894/)