### PR TITLE
Revert "jujuc: send stdin to server"

### DIFF
--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -74,7 +73,7 @@ func getwd() (string, error) {
 // jujuCMain uses JUJU_CONTEXT_ID and JUJU_AGENT_SOCKET to ask a running unit agent
 // to execute a Command on our behalf. Individual commands should be exposed
 // by symlinking the command name to this executable.
-func jujuCMain(commandName string, ctx *cmd.Context, args []string) (code int, err error) {
+func jujuCMain(commandName string, args []string) (code int, err error) {
 	code = 1
 	contextId, err := getenv("JUJU_CONTEXT_ID")
 	if err != nil {
@@ -84,16 +83,11 @@ func jujuCMain(commandName string, ctx *cmd.Context, args []string) (code int, e
 	if err != nil {
 		return
 	}
-	stdin, err := ioutil.ReadAll(ctx.Stdin)
-	if err != nil {
-		return
-	}
 	req := jujuc.Request{
 		ContextId:   contextId,
 		Dir:         dir,
 		CommandName: commandName,
 		Args:        args[1:],
-		Stdin:       stdin,
 	}
 	socketPath, err := getenv("JUJU_AGENT_SOCKET")
 	if err != nil {
@@ -166,7 +160,7 @@ func Main(args []string) {
 	} else if commandName == names.JujuRun {
 		code = cmd.Main(&RunCommand{}, ctx, args[1:])
 	} else {
-		code, err = jujuCMain(commandName, ctx, args)
+		code, err = jujuCMain(commandName, args)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -97,7 +97,6 @@ type Request struct {
 	Dir         string
 	CommandName string
 	Args        []string
-	Stdin       []byte
 }
 
 // CmdGetter looks up a Command implementation connected to a particular Context.
@@ -127,10 +126,10 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 	if err != nil {
 		return badReqErrorf("%s", err)
 	}
-	var stdout, stderr bytes.Buffer
+	var stdin, stdout, stderr bytes.Buffer
 	ctx := &cmd.Context{
 		Dir:    req.Dir,
-		Stdin:  bytes.NewBuffer(req.Stdin),
+		Stdin:  &stdin,
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}


### PR DESCRIPTION
This reverts commit f35a8c6c2d2ca2fe75ea64ad0804e7228d580811.

f35a8c6 fixed bug #1454678 but introduced bug #1463117, which is more
serious. The juju/utils dependency is not reverted as this did not
cause the bug.

(Review request: http://reviews.vapour.ws/r/1895/)