### PR TITLE
Switch to forked version of sys package

### DIFF
--- a/cmd/jujud/main_windows.go
+++ b/cmd/jujud/main_windows.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/sys/windows/svc"
+	"github.com/gabriel-samfira/sys/windows/svc"
 
 	"github.com/juju/juju/cmd/service"
 	"github.com/juju/juju/juju/names"

--- a/cmd/service/service_handler.go
+++ b/cmd/service/service_handler.go
@@ -7,7 +7,7 @@
 package service
 
 import (
-	"golang.org/x/sys/windows/svc"
+	"github.com/gabriel-samfira/sys/windows/svc"
 )
 
 // SystemService type that is responsible for managing the life-cycle of the service

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -3,6 +3,7 @@ github.com/altoros/gosigma	git	31228935eec685587914528585da4eb9b073c76d	2015-04-
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
 github.com/coreos/go-systemd	git	2d21675230a81a503f4363f4aa3490af06d52bb8	2015-01-26T19:09:17Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
+github.com/gabriel-samfira/sys	git	9ddc60d56b511544223adecea68da1e4f2153beb	2015-06-08T13:21:19Z
 github.com/godbus/dbus	git	88765d85c0fdadcd98a54e30694fa4e4f5b51133	2015-01-22T18:02:51Z
 github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
@@ -31,7 +32,6 @@ github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:1
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
-golang.org/x/sys	git	3dec8fc77cf0b9e8ecfbc701285a63360b05b71c	2015-05-12T03:31:30Z
 google.golang.org/api	git	0d3983fb069cb6651353fc44c5cb604e263f2a93	2014-12-10T23:51:26Z
 google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T22:36:35Z
 gopkg.in/amz.v3	git	fa965cc75d3936912a8e608318d3427120c1ef21	2015-06-04T08:58:42Z

--- a/service/windows/service_windows_test.go
+++ b/service/windows/service_windows_test.go
@@ -7,10 +7,10 @@
 package windows_test
 
 import (
+	"github.com/gabriel-samfira/sys/windows/svc"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"golang.org/x/sys/windows/svc"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/service/common"

--- a/service/windows/stubwinsvc_test.go
+++ b/service/windows/stubwinsvc_test.go
@@ -7,8 +7,8 @@
 package windows
 
 import (
-	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/mgr"
+	"github.com/gabriel-samfira/sys/windows/svc"
+	"github.com/gabriel-samfira/sys/windows/svc/mgr"
 
 	"github.com/juju/testing"
 )

--- a/service/windows/zservice_windows.go
+++ b/service/windows/zservice_windows.go
@@ -5,7 +5,7 @@ package windows
 
 import "unsafe"
 import "syscall"
-import "golang.org/x/sys/windows"
+import "github.com/gabriel-samfira/sys/windows"
 
 var (
 	modadvapi32 = syscall.NewLazyDLL("advapi32.dll")


### PR DESCRIPTION
The version from golang.org/x/sys requires version 1.4.x of Go to build. This branch switches to a forked version of that that builds on 1.2.1. This change will be reverted when we upgrade to Go 1.4.X.

(Review request: http://reviews.vapour.ws/r/1897/)