### PR TITLE
Use juju/txn package with fixed licence.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-2
 github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-29T20:12:23Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-06T07:00:34Z
 github.com/juju/testing	git	e35bf4acb97c4e7acda329bd7430f14ee968346b	2015-03-31T10:29:16Z
-github.com/juju/txn	git	5c38fee875d088643ebe2074f308d79680578ba7	2015-05-21T12:30:32Z
+github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-05-21T12:30:32Z
 github.com/juju/utils	git	732e0c300dc0f35c597e788a4366372065c27b7c	2015-03-30T21:32:30Z
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T00:00:00Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-2
 github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-29T20:12:23Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-06T07:00:34Z
 github.com/juju/testing	git	e35bf4acb97c4e7acda329bd7430f14ee968346b	2015-03-31T10:29:16Z
-github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-05-21T12:30:32Z
+github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/utils	git	732e0c300dc0f35c597e788a4366372065c27b7c	2015-03-30T21:32:30Z
 golang.org/x/crypto	git	1fbbd62cfec66bd39d91e97749579579d4d3037e	2014-12-09T23:26:36Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T00:00:00Z


### PR DESCRIPTION
Update github.com/juju/txn in dependencies.tsv to use the revision with the fixed licence. This change pulls in just 1 commit; this branch was using the previous tip.

Fixes https://bugs.launchpad.net/juju-core/+bug/1463455

(Review request: http://reviews.vapour.ws/r/1899/)