### PR TITLE
Update deps to use txn with fixed licence.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -25,7 +25,7 @@ github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-
 github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-30T01:12:23Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T10:32:42Z
-github.com/juju/txn	git	5c38fee875d088643ebe2074f308d79680578ba7	2015-05-21T12:30:32Z
+github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/utils	git	16d187c1d8218c9b97bdbb8a17ff31705f72c1cf	2015-05-26T23:59:59Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z


### PR DESCRIPTION
Update github.com/juju/txn in dependencies.tsv to use the revision with the
fixed licence. This change pulls in just 1 commit; this branch was using the
previous tip.

Fixes https://bugs.launchpad.net/juju-core/+bug/1463455

(Review request: http://reviews.vapour.ws/r/1902/)