### PR TITLE
state: storage entity relationship fixes

### DIFF
--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -59,6 +59,9 @@ func (s *uniterV2Suite) TestStorageAttachments(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
 
+	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.State.SetVolumeInfo(
 		volumeAttachments[0].Volume(),
 		state.VolumeInfo{VolumeId: "vol-123", Size: 456},

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -61,8 +61,7 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoImmutable(c *gc.C) {
 	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "rootfs")
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
-	filesystem, err := s.State.StorageInstanceFilesystem(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
 	filesystemTag := filesystem.FilesystemTag()
 
 	assignedMachineId, err := u.AssignedMachineId()
@@ -88,20 +87,18 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoImmutable(c *gc.C) {
 }
 
 func (s *FilesystemStateSuite) TestVolumeFilesystem(c *gc.C) {
-	filesystemAttachment := s.addUnitWithFilesystem(c, "loop", true)
-	filesystem, err := s.State.Filesystem(filesystemAttachment.Filesystem())
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = filesystem.Info()
+	filesystemAttachment, _ := s.addUnitWithFilesystem(c, "loop", true)
+	filesystem := s.filesystem(c, filesystemAttachment.Filesystem())
+	_, err := filesystem.Info()
 	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 
 	volumeTag, err := filesystem.Volume()
 	c.Assert(err, jc.ErrorIsNil)
-	filesystem, err = s.State.VolumeFilesystem(volumeTag)
-	c.Assert(err, jc.ErrorIsNil)
+	filesystem = s.volumeFilesystem(c, volumeTag)
 	c.Assert(filesystem.FilesystemTag(), gc.Equals, filesystemAttachment.Filesystem())
 }
 
-func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withVolume bool) state.FilesystemAttachment {
+func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withVolume bool) (state.FilesystemAttachment, state.StorageAttachment) {
 	ch := s.AddTestingCharm(c, "storage-filesystem")
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons(pool, 1024, 1),
@@ -122,8 +119,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageInstance.Kind(), gc.Equals, state.StorageKindFilesystem)
 
-	filesystem, err := s.State.StorageInstanceFilesystem(storageInstance.StorageTag())
-	c.Assert(err, jc.ErrorIsNil)
+	filesystem := s.storageInstanceFilesystem(c, storageInstance.StorageTag())
 	c.Assert(filesystem.FilesystemTag(), gc.Equals, names.NewFilesystemTag("0/0"))
 	filesystemStorageTag, err := filesystem.Storage()
 	c.Assert(err, jc.ErrorIsNil)
@@ -165,7 +161,7 @@ func (s *FilesystemStateSuite) addUnitWithFilesystem(c *gc.C, pool string, withV
 
 	att, err := s.State.FilesystemAttachment(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
-	return att
+	return att, storageAttachments[0]
 }
 
 func (s *FilesystemStateSuite) TestWatchFilesystemAttachment(c *gc.C) {
@@ -176,8 +172,7 @@ func (s *FilesystemStateSuite) TestWatchFilesystemAttachment(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	machineTag := names.NewMachineTag(assignedMachineId)
 
-	filesystem, err := s.State.StorageInstanceFilesystem(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
 	filesystemTag := filesystem.FilesystemTag()
 
 	w := s.State.WatchFilesystemAttachment(machineTag, filesystemTag)
@@ -214,8 +209,7 @@ func (s *FilesystemStateSuite) TestFilesystemInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	machineTag := names.NewMachineTag(assignedMachineId)
 
-	filesystem, err := s.State.StorageInstanceFilesystem(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
 	filesystemTag := filesystem.FilesystemTag()
 
 	s.assertFilesystemUnprovisioned(c, filesystemTag)
@@ -244,8 +238,7 @@ func (s *FilesystemStateSuite) TestVolumeBackedFilesystemScope(c *gc.C) {
 	err := s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 
-	filesystem, err := s.State.StorageInstanceFilesystem(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
 	c.Assert(filesystem.Tag(), gc.Equals, names.NewFilesystemTag("0/0"))
 	volumeTag, err := filesystem.Volume()
 	c.Assert(err, jc.ErrorIsNil)
@@ -407,36 +400,21 @@ func (s *FilesystemStateSuite) TestAssignToMachineErrors(c *gc.C) {
 }
 
 func (s *FilesystemStateSuite) TestRemoveStorageInstanceUnassignsFilesystem(c *gc.C) {
-	filesystemAttachment := s.addUnitWithFilesystem(c, "loop", true)
-	filesystem, err := s.State.Filesystem(filesystemAttachment.Filesystem())
-	c.Assert(err, jc.ErrorIsNil)
-	filesystemTag := filesystem.FilesystemTag()
-	volumeTag, err := filesystem.Volume()
-	c.Assert(err, jc.ErrorIsNil)
-	volume, err := s.State.Volume(volumeTag)
-	c.Assert(err, jc.ErrorIsNil)
-	storageTag, err := filesystem.Storage()
-	c.Assert(err, jc.ErrorIsNil)
-	volumeStorageTag, err := volume.StorageInstance()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volumeStorageTag, gc.Equals, storageTag)
+	filesystemAttachment, storageAttachment := s.addUnitWithFilesystem(c, "loop", true)
+	filesystem := s.filesystem(c, filesystemAttachment.Filesystem())
+	volume := s.filesystemVolume(c, filesystemAttachment.Filesystem())
+	storageTag := storageAttachment.StorageInstance()
+	unitTag := storageAttachment.Unit()
 
-	storageAttachments, err := s.State.StorageAttachments(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(storageAttachments, gc.HasLen, 1)
-	unitTag := storageAttachments[0].Unit()
-
-	err = s.State.DestroyStorageInstance(storageTag)
+	err := s.State.DestroyStorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.DestroyStorageAttachment(storageTag, unitTag)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The storage instance and attachment are dying, but not yet
 	// removed from state. The filesystem should still be assigned.
-	_, err = s.State.StorageInstanceFilesystem(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.StorageInstanceVolume(storageTag)
-	c.Assert(err, jc.ErrorIsNil)
+	s.storageInstanceFilesystem(c, storageTag)
+	s.storageInstanceVolume(c, storageTag)
 
 	err = s.State.RemoveStorageAttachment(storageTag, unitTag)
 	c.Assert(err, jc.ErrorIsNil)
@@ -449,14 +427,12 @@ func (s *FilesystemStateSuite) TestRemoveStorageInstanceUnassignsFilesystem(c *g
 	c.Assert(err, gc.ErrorMatches, `volume for storage instance "data/0" not found`)
 
 	// The filesystem and volume should not have been destroyed, though.
-	_, err = s.State.Filesystem(filesystemTag)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.Volume(volumeTag)
-	c.Assert(err, jc.ErrorIsNil)
+	s.filesystem(c, filesystem.FilesystemTag())
+	s.volume(c, volume.VolumeTag())
 }
 
 func (s *FilesystemStateSuite) TestSetFilesystemAttachmentInfoFilesystemNotProvisioned(c *gc.C) {
-	filesystemAttachment := s.addUnitWithFilesystem(c, "rootfs", false)
+	filesystemAttachment, _ := s.addUnitWithFilesystem(c, "rootfs", false)
 	err := s.State.SetFilesystemAttachmentInfo(
 		filesystemAttachment.Machine(),
 		filesystemAttachment.Filesystem(),
@@ -466,7 +442,7 @@ func (s *FilesystemStateSuite) TestSetFilesystemAttachmentInfoFilesystemNotProvi
 }
 
 func (s *FilesystemStateSuite) TestSetFilesystemAttachmentInfoMachineNotProvisioned(c *gc.C) {
-	filesystemAttachment := s.addUnitWithFilesystem(c, "rootfs", false)
+	filesystemAttachment, _ := s.addUnitWithFilesystem(c, "rootfs", false)
 	err := s.State.SetFilesystemInfo(
 		filesystemAttachment.Filesystem(),
 		state.FilesystemInfo{Size: 123},
@@ -481,48 +457,10 @@ func (s *FilesystemStateSuite) TestSetFilesystemAttachmentInfoMachineNotProvisio
 }
 
 func (s *FilesystemStateSuite) TestSetFilesystemInfoVolumeAttachmentNotProvisioned(c *gc.C) {
-	filesystemAttachment := s.addUnitWithFilesystem(c, "loop", true)
+	filesystemAttachment, _ := s.addUnitWithFilesystem(c, "loop", true)
 	err := s.State.SetFilesystemInfo(
 		filesystemAttachment.Filesystem(),
 		state.FilesystemInfo{Size: 123},
 	)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for filesystem "0/0": volume attachment "0/0" on "0" not provisioned`)
-}
-
-func (s *FilesystemStateSuite) assertFilesystemUnprovisioned(c *gc.C, tag names.FilesystemTag) {
-	filesystem, err := s.State.Filesystem(tag)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = filesystem.Info()
-	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
-	_, ok := filesystem.Params()
-	c.Assert(ok, jc.IsTrue)
-}
-
-func (s *FilesystemStateSuite) assertFilesystemInfo(c *gc.C, tag names.FilesystemTag, expect state.FilesystemInfo) {
-	filesystem, err := s.State.Filesystem(tag)
-	c.Assert(err, jc.ErrorIsNil)
-	info, err := filesystem.Info()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info, jc.DeepEquals, expect)
-	_, ok := filesystem.Params()
-	c.Assert(ok, jc.IsFalse)
-}
-
-func (s *FilesystemStateSuite) assertFilesystemAttachmentUnprovisioned(c *gc.C, m names.MachineTag, f names.FilesystemTag) {
-	filesystemAttachment, err := s.State.FilesystemAttachment(m, f)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = filesystemAttachment.Info()
-	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
-	_, ok := filesystemAttachment.Params()
-	c.Assert(ok, jc.IsTrue)
-}
-
-func (s *FilesystemStateSuite) assertFilesystemAttachmentInfo(c *gc.C, m names.MachineTag, f names.FilesystemTag, expect state.FilesystemAttachmentInfo) {
-	filesystemAttachment, err := s.State.FilesystemAttachment(m, f)
-	c.Assert(err, jc.ErrorIsNil)
-	info, err := filesystemAttachment.Info()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info, jc.DeepEquals, expect)
-	_, ok := filesystemAttachment.Params()
-	c.Assert(ok, jc.IsFalse)
 }

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
@@ -99,6 +100,100 @@ func (s *StorageStateSuite) storageInstanceExists(c *gc.C, tag names.StorageTag)
 		return false
 	}
 	return true
+}
+
+func (s *StorageStateSuiteBase) assertFilesystemUnprovisioned(c *gc.C, tag names.FilesystemTag) {
+	filesystem := s.filesystem(c, tag)
+	_, err := filesystem.Info()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	_, ok := filesystem.Params()
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *StorageStateSuiteBase) assertFilesystemInfo(c *gc.C, tag names.FilesystemTag, expect state.FilesystemInfo) {
+	filesystem := s.filesystem(c, tag)
+	info, err := filesystem.Info()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, expect)
+	_, ok := filesystem.Params()
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *StorageStateSuiteBase) assertFilesystemAttachmentUnprovisioned(c *gc.C, m names.MachineTag, f names.FilesystemTag) {
+	filesystemAttachment := s.filesystemAttachment(c, m, f)
+	_, err := filesystemAttachment.Info()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	_, ok := filesystemAttachment.Params()
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *StorageStateSuiteBase) assertFilesystemAttachmentInfo(c *gc.C, m names.MachineTag, f names.FilesystemTag, expect state.FilesystemAttachmentInfo) {
+	filesystemAttachment := s.filesystemAttachment(c, m, f)
+	info, err := filesystemAttachment.Info()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, expect)
+	_, ok := filesystemAttachment.Params()
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *StorageStateSuiteBase) assertVolumeUnprovisioned(c *gc.C, tag names.VolumeTag) {
+	volume := s.volume(c, tag)
+	_, err := volume.Info()
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	_, ok := volume.Params()
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *StorageStateSuiteBase) assertVolumeInfo(c *gc.C, tag names.VolumeTag, expect state.VolumeInfo) {
+	volume := s.volume(c, tag)
+	info, err := volume.Info()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, expect)
+	_, ok := volume.Params()
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *StorageStateSuiteBase) filesystem(c *gc.C, tag names.FilesystemTag) state.Filesystem {
+	filesystem, err := s.State.Filesystem(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	return filesystem
+}
+
+func (s *StorageStateSuiteBase) filesystemVolume(c *gc.C, tag names.FilesystemTag) state.Volume {
+	filesystem := s.filesystem(c, tag)
+	volumeTag, err := filesystem.Volume()
+	c.Assert(err, jc.ErrorIsNil)
+	return s.volume(c, volumeTag)
+}
+
+func (s *StorageStateSuiteBase) filesystemAttachment(c *gc.C, m names.MachineTag, f names.FilesystemTag) state.FilesystemAttachment {
+	attachment, err := s.State.FilesystemAttachment(m, f)
+	c.Assert(err, jc.ErrorIsNil)
+	return attachment
+}
+
+func (s *StorageStateSuiteBase) volume(c *gc.C, tag names.VolumeTag) state.Volume {
+	volume, err := s.State.Volume(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	return volume
+}
+
+func (s *StorageStateSuiteBase) volumeFilesystem(c *gc.C, tag names.VolumeTag) state.Filesystem {
+	filesystem, err := s.State.VolumeFilesystem(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	return filesystem
+}
+
+func (s *StorageStateSuiteBase) storageInstanceVolume(c *gc.C, tag names.StorageTag) state.Volume {
+	volume, err := s.State.StorageInstanceVolume(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	return volume
+}
+
+func (s *StorageStateSuiteBase) storageInstanceFilesystem(c *gc.C, tag names.StorageTag) state.Filesystem {
+	filesystem, err := s.State.StorageInstanceFilesystem(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	return filesystem
 }
 
 func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {


### PR DESCRIPTION
Ensure that storage cannot be added to units
unless they're alive. Also, storage instances
owned by units will now be removed once the
attachment is removed.

When a storage instance is removed from state,
we will now unassign any previously assigned
volumes and filesystems from it. The volumes
and filesystems are not destroyed.

Finally, we ensure prerequisites are provisioned
in SetFilesystemInfo, and
Set{Volume,Filesystem}AttachmentInfo, and update
several tests to go through the proper sequence
of operations.

(Review request: http://reviews.vapour.ws/r/1908/)