### PR TITLE
mongo: added OplogTailer

### DIFF
--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -11,9 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
-	stdtesting "testing"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -30,14 +28,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
-
-func Test(t *stdtesting.T) {
-	//TODO(bogdanteleaga): Fix these on windows
-	if runtime.GOOS == "windows" {
-		t.Skip("bug 1403084: Skipping for now on windows")
-	}
-	gc.TestingT(t)
-}
 
 type MongoSuite struct {
 	coretesting.BaseSuite

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -1,0 +1,157 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongo
+
+import (
+	"time"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"launchpad.net/tomb"
+)
+
+// GetOplog returns the the oplog collection in the local database.
+func GetOplog(session *mgo.Session) *mgo.Collection {
+	return session.DB("local").C("oplog.rs")
+}
+
+// NewOplogTailer returns a new OplogTailer.
+//
+// Arguments:
+// - "oplog" is the collection to use for the oplog. Typically this
+//   would be the result of GetOpLog.
+// - "query" can be used to limit the returned oplog entries. A
+//    typical filter would limit based on ns ("<database>.<collection>")
+//    and o (object).
+//
+// Remember to call Stop on the returned OplogTailer when it is no
+// longer needed.
+func NewOplogTailer(oplog *mgo.Collection, query bson.D) *OplogTailer {
+	// Use a fresh session for the tailer.
+	session := oplog.Database.Session.Copy()
+	t := &OplogTailer{
+		oplog: oplog.With(session),
+		query: query,
+		outCh: make(chan *OplogDoc, 1),
+	}
+	go func() {
+		defer func() {
+			t.tomb.Done()
+			session.Close()
+		}()
+		t.tomb.Kill(t.loop())
+	}()
+	return t
+}
+
+// OplogTailer tails MongoDB's replication oplog.
+type OplogTailer struct {
+	tomb  tomb.Tomb
+	oplog *mgo.Collection
+	query bson.D
+	outCh chan *OplogDoc
+}
+
+// OplogDoc represents a document in the oplog.rs collection.
+// See: http://www.kchodorow.com/blog/2010/10/12/replication-internals/
+type OplogDoc struct {
+	Timestamp    bson.MongoTimestamp `bson:"ts"`
+	OperationId  int64               `bson:"h"`
+	MongoVersion int                 `bson:"v"`
+	Operation    string              `bson:"op"` // "i" - insert, "u" - update, "d" - delete
+	Namespace    string              `bson:"ns"`
+	Object       bson.D              `bson:"o"`
+	UpdateObject bson.D              `bson:"o2"`
+}
+
+// Out returns a channel that reports the oplog entries matching the
+// query passed to NewOplogTailer as they appear.
+func (t *OplogTailer) Out() <-chan *OplogDoc {
+	return t.outCh
+}
+
+// Dying returns a channel that will be closed with the OplogTailer is
+// shutting down.
+func (t *OplogTailer) Dying() <-chan struct{} {
+	return t.tomb.Dying()
+}
+
+// Stop shuts down the OplogTailer. It will block until shutdown is
+// complete.
+func (t *OplogTailer) Stop() error {
+	t.tomb.Kill(nil)
+	return t.tomb.Wait()
+}
+
+const oplogTailTimeout = time.Second
+
+func (t *OplogTailer) loop() error {
+	var iter *mgo.Iter
+
+	// lastTimestamp tracks the most recent oplog timestamp reported.
+	var lastTimestamp bson.MongoTimestamp
+
+	// idsForLastTimestamp records the unique operation ids that have
+	// been reported for the most recently reported oplog
+	// timestamp. This is used to avoid re-reporting oplog entries
+	// when the iterator is restarted. It's possible for there to be
+	// many oplog entries for a given timestamp.
+	var idsForLastTimestamp []int64
+
+	for {
+		if t.dying() {
+			return tomb.ErrDying
+		}
+
+		if iter == nil {
+			// When recreating the iterator (required when the cursor
+			// is invalidated) avoid reporting oplog entries that have
+			// already been reported.
+			query := append(t.query,
+				bson.DocElem{"ts", bson.D{{"$gte", lastTimestamp}}},
+				bson.DocElem{"h", bson.D{{"$nin", idsForLastTimestamp}}},
+			)
+			// Time the tail call out every second so that requests to
+			// stop can be honoured.
+			//
+			// TODO(mjs): Ideally -1 (no timeout) could be used here,
+			// with session.Close() being used to unblock Next() if
+			// the tailer should stop (these semantics are hinted at
+			// by the mgo docs). Unfortunately this can trigger
+			// panics. See: https://github.com/go-mgo/mgo/issues/121
+			iter = t.oplog.Find(query).LogReplay().Tail(oplogTailTimeout)
+		}
+
+		var doc OplogDoc
+		if iter.Next(&doc) {
+			t.outCh <- &doc
+
+			if doc.Timestamp > lastTimestamp {
+				lastTimestamp = doc.Timestamp
+				idsForLastTimestamp = nil
+			}
+			idsForLastTimestamp = append(idsForLastTimestamp, doc.OperationId)
+		} else {
+			if err := iter.Err(); err != nil {
+				return err
+			}
+			if iter.Timeout() {
+				continue
+			}
+			// No timeout and no error so cursor must have
+			// expired. Force it to be recreated next loop by marking
+			// it as nil.
+			iter = nil
+		}
+	}
+}
+
+func (t *OplogTailer) dying() bool {
+	select {
+	case <-t.tomb.Dying():
+		return true
+	default:
+		return false
+	}
+}

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -1,0 +1,254 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongo_test
+
+import (
+	"time"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/mongo"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/peergrouper"
+)
+
+type oplogSuite struct {
+	jujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&oplogSuite{})
+
+func (s *oplogSuite) TestWithRealOplog(c *gc.C) {
+	_, session := s.startMongoWithReplicaset(c)
+
+	// Watch for oplog entries for the "bar" collection in the "foo"
+	// DB.
+	oplog := mongo.GetOplog(session)
+	tailer := mongo.NewOplogTailer(oplog, bson.D{{"ns", "foo.bar"}})
+	defer tailer.Stop()
+
+	assertOplog := func(expectedOp string, expectedObj bson.D) {
+		doc := s.getNextOplog(c, tailer)
+		c.Assert(doc.Operation, gc.Equals, expectedOp)
+		c.Assert(doc.Object, jc.DeepEquals, expectedObj)
+	}
+
+	// Insert into foo.bar and see that the oplog entry is reported.
+	db := session.DB("foo")
+	coll := db.C("bar")
+	s.insertDoc(c, session, coll, bson.M{"_id": "thing"})
+	assertOplog("i", bson.D{{"_id", "thing"}})
+
+	// Update foo.bar and see the update reported.
+	err := coll.UpdateId("thing", bson.M{"$set": bson.M{"blah": 42}})
+	c.Assert(err, jc.ErrorIsNil)
+	assertOplog("u", bson.D{{"$set", bson.D{{"blah", 42}}}})
+
+	// Insert into another collection (shouldn't be reported due to filter).
+	s.insertDoc(c, session, db.C("elsewhere"), bson.M{"_id": "boo"})
+	s.assertNoOplog(c, tailer)
+}
+
+func (s *oplogSuite) TestStops(c *gc.C) {
+	_, session := s.startMongo(c)
+
+	oplog := s.makeFakeOplog(c, session)
+	tailer := mongo.NewOplogTailer(oplog, nil)
+	defer tailer.Stop()
+
+	s.insertDoc(c, session, oplog, &mongo.OplogDoc{Timestamp: 1})
+	doc := s.getNextOplog(c, tailer)
+	c.Assert(doc.Timestamp, gc.Equals, bson.MongoTimestamp(1))
+
+	err := tailer.Stop()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.insertDoc(c, session, oplog, &mongo.OplogDoc{Timestamp: 2})
+	s.assertNoOplog(c, tailer)
+}
+
+func (s *oplogSuite) TestRestartsOnError(c *gc.C) {
+	_, session := s.startMongo(c)
+
+	oplog := s.makeFakeOplog(c, session)
+	tailer := mongo.NewOplogTailer(oplog, nil)
+	defer tailer.Stop()
+
+	// First, ensure that the tailer is seeing oplog inserts.
+	s.insertDoc(c, session, oplog, &mongo.OplogDoc{
+		Timestamp:   1,
+		OperationId: 99,
+	})
+	doc := s.getNextOplog(c, tailer)
+	c.Assert(doc.Timestamp, gc.Equals, bson.MongoTimestamp(1))
+
+	s.emptyCapped(c, oplog)
+
+	// Ensure that the tailer still works.
+	s.insertDoc(c, session, oplog, &mongo.OplogDoc{
+		Timestamp:   2,
+		OperationId: 42,
+	})
+	doc = s.getNextOplog(c, tailer)
+	c.Assert(doc.Timestamp, gc.Equals, bson.MongoTimestamp(2))
+}
+
+func (s *oplogSuite) TestNoRepeatsAfterIterRestart(c *gc.C) {
+	_, session := s.startMongo(c)
+
+	oplog := s.makeFakeOplog(c, session)
+	tailer := mongo.NewOplogTailer(oplog, nil)
+	defer tailer.Stop()
+
+	// Insert a bunch of oplog entries with the same timestamp (but
+	// with different ids) and see them reported.
+	for id := int64(10); id < 15; id++ {
+		s.insertDoc(c, session, oplog, &mongo.OplogDoc{
+			Timestamp:   1,
+			OperationId: id,
+		})
+
+		doc := s.getNextOplog(c, tailer)
+		c.Assert(doc.Timestamp, gc.Equals, bson.MongoTimestamp(1))
+		c.Assert(doc.OperationId, gc.Equals, id)
+	}
+
+	// Force the OplogTailer's iterator to be recreated.
+	s.emptyCapped(c, oplog)
+
+	// Reinsert the oplog entries that were already there before and a
+	// few more.
+	for id := int64(10); id < 20; id++ {
+		s.insertDoc(c, session, oplog, &mongo.OplogDoc{
+			Timestamp:   1,
+			OperationId: id,
+		})
+	}
+
+	// Insert an entry for a later timestamp.
+	s.insertDoc(c, session, oplog, &mongo.OplogDoc{
+		Timestamp:   2,
+		OperationId: 42,
+	})
+
+	// Ensure that only previously unreported entries are now reported.
+	for id := int64(15); id < 20; id++ {
+		doc := s.getNextOplog(c, tailer)
+		c.Assert(doc.Timestamp, gc.Equals, bson.MongoTimestamp(1))
+		c.Assert(doc.OperationId, gc.Equals, id)
+	}
+
+	doc := s.getNextOplog(c, tailer)
+	c.Assert(doc.Timestamp, gc.Equals, bson.MongoTimestamp(2))
+	c.Assert(doc.OperationId, gc.Equals, int64(42))
+}
+
+func (s *oplogSuite) TestDiesOnFatalError(c *gc.C) {
+	_, session := s.startMongo(c)
+
+	oplog := s.makeFakeOplog(c, session)
+	tailer := mongo.NewOplogTailer(oplog, nil)
+	defer tailer.Stop()
+
+	// Induce a fatal error by removing the oplog collection.
+	err := oplog.DropCollection()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// OplogTailer should die.
+	select {
+	case <-tailer.Dying():
+		// Success.
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("tailer should have died")
+	}
+}
+
+func (s *oplogSuite) startMongoWithReplicaset(c *gc.C) (*jujutesting.MgoInstance, *mgo.Session) {
+	inst := &jujutesting.MgoInstance{
+		Params: []string{
+			"--replSet", "juju",
+		},
+	}
+	err := inst.Start(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { inst.Destroy() })
+
+	// Initiate replicaset.
+	info := inst.DialInfo()
+	args := peergrouper.InitiateMongoParams{
+		DialInfo:       info,
+		MemberHostPort: inst.Addr(),
+	}
+	err = peergrouper.MaybeInitiateMongoServer(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	return inst, s.dialMongo(c, inst)
+}
+
+func (s *oplogSuite) startMongo(c *gc.C) (*jujutesting.MgoInstance, *mgo.Session) {
+	inst := &jujutesting.MgoInstance{
+		Params: []string{
+			"--setParameter", "enableTestCommands=1", // allows "emptycapped" command
+		},
+	}
+	err := inst.Start(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { inst.Destroy() })
+	return inst, s.dialMongo(c, inst)
+}
+
+func (s *oplogSuite) emptyCapped(c *gc.C, coll *mgo.Collection) {
+	// Call the emptycapped (test) command on a capped
+	// collection. This invalidates any cursors on the collection.
+	err := coll.Database.Run(bson.D{{"emptycapped", coll.Name}}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *oplogSuite) dialMongo(c *gc.C, inst *jujutesting.MgoInstance) *mgo.Session {
+	session, err := inst.Dial()
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { session.Close() })
+	return session
+}
+
+func (s *oplogSuite) makeFakeOplog(c *gc.C, session *mgo.Session) *mgo.Collection {
+	db := session.DB("local")
+	oplog := db.C("oplog.fake")
+	err := oplog.Create(&mgo.CollectionInfo{
+		Capped:   true,
+		MaxBytes: 1024 * 1024,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return oplog
+}
+
+func (s *oplogSuite) insertDoc(c *gc.C, srcSession *mgo.Session, coll *mgo.Collection, doc interface{}) {
+	session := srcSession.Copy()
+	defer session.Close()
+	err := coll.With(session).Insert(doc)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *oplogSuite) getNextOplog(c *gc.C, tailer *mongo.OplogTailer) *mongo.OplogDoc {
+	select {
+	case doc := <-tailer.Out():
+		return doc
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for oplog doc")
+	}
+	return nil
+}
+
+func (s *oplogSuite) assertNoOplog(c *gc.C, tailer *mongo.OplogTailer) {
+	select {
+	case <-tailer.Out():
+		c.Fatal("unexpected oplog activity reported")
+	case <-time.After(coretesting.ShortWait):
+		// Success
+	}
+}

--- a/mongo/package_test.go
+++ b/mongo/package_test.go
@@ -1,0 +1,19 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongo_test
+
+import (
+	"runtime"
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *stdtesting.T) {
+	//TODO(bogdanteleaga): Fix these on windows
+	if runtime.GOOS == "windows" {
+		t.Skip("bug 1403084: Skipping for now on windows")
+	}
+	gc.TestingT(t)
+}


### PR DESCRIPTION
OplogTailer supports real-time tailing of MongoDB's replication oplog. New entries are reported as they appear in oplog collection.

This is needed to allow tailing of logs in the DB.

(Review request: http://reviews.vapour.ws/r/1921/)