### PR TITLE
state: detach/destroy machine storage

### DIFF
--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -516,9 +516,8 @@ func (st *State) RemoveFilesystem(tag names.FilesystemTag) (err error) {
 			Assert: txn.DocExists,
 			Remove: true,
 		}}
-		// If the filesystem is backed by a volume, the volume
-		// attachment can and should be destroyed once the
-		// filesystem attachment is removed.
+		// If the filesystem is backed by a volume, the volume can and
+		// should be destroyed once the filesystem is removed.
 		volumeTag, err := filesystem.Volume()
 		if err == nil {
 			ops = append(ops, destroyVolumeOps(st, volumeTag)...)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -485,8 +485,14 @@ func (s *FilesystemStateSuite) TestRemoveFilesystem(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveFilesystemAttachment(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveFilesystem(names.NewFilesystemTag("42"))
-	c.Assert(err, jc.ErrorIsNil)
+	assertRemove := func() {
+		err = s.State.RemoveFilesystem(filesystem.FilesystemTag())
+		c.Assert(err, jc.ErrorIsNil)
+		_, err = s.State.Filesystem(filesystem.FilesystemTag())
+		c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	}
+	defer state.SetBeforeHooks(c, s.State, assertRemove).Check()
+	assertRemove()
 }
 
 func (s *FilesystemStateSuite) TestRemoveFilesystemVolumeBacked(c *gc.C) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -728,9 +728,19 @@ func (m *Machine) Remove() (err error) {
 	if err != nil {
 		return err
 	}
+	filesystemOps, err := m.st.removeMachineFilesystemsOps(m.MachineTag())
+	if err != nil {
+		return err
+	}
+	volumeOps, err := m.st.removeMachineVolumesOps(m.MachineTag())
+	if err != nil {
+		return err
+	}
 	ops = append(ops, ifacesOps...)
 	ops = append(ops, portsOps...)
 	ops = append(ops, removeContainerRefOps(m.st, m.Id())...)
+	ops = append(ops, filesystemOps...)
+	ops = append(ops, volumeOps...)
 	ipAddresses, err := m.st.AllocatedIPAddresses(m.Id())
 	if err != nil {
 		return errors.Trace(err)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -153,6 +153,12 @@ func (s *StorageStateSuiteBase) assertVolumeInfo(c *gc.C, tag names.VolumeTag, e
 	c.Assert(ok, jc.IsFalse)
 }
 
+func (s *StorageStateSuiteBase) machine(c *gc.C, id string) *state.Machine {
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+	return machine
+}
+
 func (s *StorageStateSuiteBase) filesystem(c *gc.C, tag names.FilesystemTag) state.Filesystem {
 	filesystem, err := s.State.Filesystem(tag)
 	c.Assert(err, jc.ErrorIsNil)
@@ -182,6 +188,12 @@ func (s *StorageStateSuiteBase) volumeFilesystem(c *gc.C, tag names.VolumeTag) s
 	filesystem, err := s.State.VolumeFilesystem(tag)
 	c.Assert(err, jc.ErrorIsNil)
 	return filesystem
+}
+
+func (s *StorageStateSuiteBase) volumeAttachment(c *gc.C, m names.MachineTag, v names.VolumeTag) state.VolumeAttachment {
+	attachment, err := s.State.VolumeAttachment(m, v)
+	c.Assert(err, jc.ErrorIsNil)
+	return attachment
 }
 
 func (s *StorageStateSuiteBase) storageInstanceVolume(c *gc.C, tag names.StorageTag) state.Volume {

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -277,8 +277,20 @@ func (s *VolumeStateSuite) TestWatchEnvironVolumes(c *gc.C) {
 	wc.AssertChangeInSingleEvent("3")
 	wc.AssertNoChange()
 
-	// TODO(axw) respond to Dying/Dead when we have
-	// the means to progress Volume lifecycle.
+	err := s.State.DestroyVolume(names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0") // dying
+	wc.AssertNoChange()
+
+	err = s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.RemoveVolume(names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0") // removed
+	wc.AssertNoChange()
 }
 
 func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
@@ -301,8 +313,15 @@ func (s *VolumeStateSuite) TestWatchEnvironVolumeAttachments(c *gc.C) {
 	wc.AssertChangeInSingleEvent("1:3")
 	wc.AssertNoChange()
 
-	// TODO(axw) respond to Dying/Dead when we have
-	// the means to progress Volume lifecycle.
+	err := s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0:0") // dying
+	wc.AssertNoChange()
+
+	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0:0") // removed
+	wc.AssertNoChange()
 }
 
 func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
@@ -325,8 +344,20 @@ func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 	// no change, since we're only interested in the one machine.
 	wc.AssertNoChange()
 
-	// TODO(axw) respond to Dying/Dead when we have
-	// the means to progress Volume lifecycle.
+	err := s.State.DestroyVolume(names.NewVolumeTag("0/1"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0/1") // dying
+	wc.AssertNoChange()
+
+	err = s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0/1"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/1"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.RemoveVolume(names.NewVolumeTag("0/1"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0/1") // removed
+	wc.AssertNoChange()
 }
 
 func (s *VolumeStateSuite) TestWatchMachineVolumeAttachments(c *gc.C) {
@@ -349,10 +380,18 @@ func (s *VolumeStateSuite) TestWatchMachineVolumeAttachments(c *gc.C) {
 	// no change, since we're only interested in the one machine.
 	wc.AssertNoChange()
 
+	err := s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0:0") // dying
+	wc.AssertNoChange()
+
+	err = s.State.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0:0") // removed
+	wc.AssertNoChange()
+
 	// TODO(axw) respond to changes to the same machine when we support
 	// dynamic storage and/or placement.
-	// TODO(axw) respond to Dying/Dead when we have
-	// the means to progress Volume lifecycle.
 }
 
 func (s *VolumeStateSuite) TestParseVolumeAttachmentId(c *gc.C) {
@@ -376,6 +415,17 @@ func (s *VolumeStateSuite) TestParseVolumeAttachmentIdError(c *gc.C) {
 	assertError("0", `invalid volume attachment ID "0"`)
 	assertError("0:foo", `invalid volume attachment ID "0:foo"`)
 	assertError("bar:0", `invalid volume attachment ID "bar:0"`)
+}
+
+func (s *VolumeStateSuite) TestAllVolumes(c *gc.C) {
+	expected, _ := s.assertCreateVolumes(c)
+
+	found, err := s.State.AllVolumes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found, gc.HasLen, 3)
+	for _, one := range found {
+		c.Assert(expected.Contains(one.VolumeTag()), jc.IsTrue)
+	}
 }
 
 func (s *VolumeStateSuite) TestPersistentVolumes(c *gc.C) {
@@ -421,17 +471,6 @@ func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (all, persistent set.Tag
 	volume3 := s.storageInstanceVolume(c, names.NewStorageTag("multi2up/2"))
 
 	return set.NewTags(volume1.VolumeTag(), volume2.VolumeTag(), volume3.VolumeTag()), set.NewTags(volume1.VolumeTag())
-}
-
-func (s *VolumeStateSuite) TestAllVolumes(c *gc.C) {
-	expected, _ := s.assertCreateVolumes(c)
-
-	found, err := s.State.AllVolumes()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found, gc.HasLen, 3)
-	for _, one := range found {
-		c.Assert(expected.Contains(one.VolumeTag()), jc.IsTrue)
-	}
 }
 
 func (s *VolumeStateSuite) TestRemoveStorageInstanceUnassignsVolume(c *gc.C) {
@@ -480,4 +519,79 @@ func (s *VolumeStateSuite) TestSetVolumeAttachmentInfoVolumeNotProvisioned(c *gc
 		},
 	)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for volume attachment 0/0:0: volume "0/0" not provisioned`)
+}
+
+func (s *VolumeStateSuite) TestDestroyVolume(c *gc.C) {
+	volume, _ := s.setupVolumeAttachment(c)
+	assertDestroy := func() {
+		err := s.State.DestroyVolume(volume.VolumeTag())
+		c.Assert(err, jc.ErrorIsNil)
+		volume = s.volume(c, volume.VolumeTag())
+		c.Assert(volume.Life(), gc.Equals, state.Dying)
+	}
+	defer state.SetBeforeHooks(c, s.State, assertDestroy).Check()
+	assertDestroy()
+}
+
+func (s *VolumeStateSuite) TestRemoveVolume(c *gc.C) {
+	volume, machine := s.setupVolumeAttachment(c)
+	err := s.State.DestroyVolume(volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolume(names.NewVolumeTag("42"))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *VolumeStateSuite) TestRemoveVolumeNotFound(c *gc.C) {
+	err := s.State.RemoveVolume(names.NewVolumeTag("42"))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *VolumeStateSuite) TestRemoveVolumeAlive(c *gc.C) {
+	volume, _ := s.setupVolumeAttachment(c)
+	err := s.State.RemoveVolume(volume.VolumeTag())
+	c.Assert(err, gc.ErrorMatches, "removing volume 0/0: volume is not dying")
+}
+
+func (s *VolumeStateSuite) TestRemoveWithVolumeAttachments(c *gc.C) {
+	volume, _ := s.setupVolumeAttachment(c)
+	err := s.State.DestroyVolume(volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolume(volume.VolumeTag())
+	c.Assert(err, gc.ErrorMatches, "removing volume 0/0: volume is attached to machines \\[0\\]")
+}
+
+func (s *VolumeStateSuite) TestDetachVolume(c *gc.C) {
+	volume, machine := s.setupVolumeAttachment(c)
+	assertDetach := func() {
+		err := s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+		c.Assert(err, jc.ErrorIsNil)
+		attachment := s.volumeAttachment(c, machine.MachineTag(), volume.VolumeTag())
+		c.Assert(attachment.Life(), gc.Equals, state.Dying)
+	}
+	defer state.SetBeforeHooks(c, s.State, assertDetach).Check()
+	assertDetach()
+}
+
+func (s *VolumeStateSuite) TestRemoveVolumeAttachmentNotFound(c *gc.C) {
+	err := s.State.RemoveVolumeAttachment(names.NewMachineTag("42"), names.NewVolumeTag("42"))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *VolumeStateSuite) TestRemoveVolumeAttachmentAlive(c *gc.C) {
+	volume, machine := s.setupVolumeAttachment(c)
+	err := s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	c.Assert(err, gc.ErrorMatches, "removing attachment of volume 0/0 from machine 0: volume attachment is not dying")
+}
+
+func (s *VolumeStateSuite) setupVolumeAttachment(c *gc.C) (state.Volume, *state.Machine) {
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+	assignedMachineId, err := u.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	return s.storageInstanceVolume(c, storageTag), s.machine(c, assignedMachineId)
 }

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -550,6 +550,7 @@ func createFilesystemAttachments(
 }
 
 func destroyFilesystems(filesystems []params.Filesystem) ([]error, error) {
+	// TODO(axw) implement destroy
 	err := errors.New("destroy filesystems is not implemented")
 	errs := make([]error, len(filesystems))
 	for i := range errs {
@@ -559,6 +560,7 @@ func destroyFilesystems(filesystems []params.Filesystem) ([]error, error) {
 }
 
 func detachFilesystems(attachments []params.FilesystemAttachment) ([]error, error) {
+	// TODO(axw) implement detach
 	err := errors.New("detach filesystems is not implemented")
 	errs := make([]error, len(attachments))
 	for i := range errs {

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -550,11 +550,21 @@ func createFilesystemAttachments(
 }
 
 func destroyFilesystems(filesystems []params.Filesystem) ([]error, error) {
-	panic("not implemented")
+	err := errors.New("destroy filesystems is not implemented")
+	errs := make([]error, len(filesystems))
+	for i := range errs {
+		errs[i] = err
+	}
+	return errs, nil
 }
 
 func detachFilesystems(attachments []params.FilesystemAttachment) ([]error, error) {
-	panic("not implemented")
+	err := errors.New("detach filesystems is not implemented")
+	errs := make([]error, len(attachments))
+	for i := range errs {
+		errs[i] = err
+	}
+	return errs, nil
 }
 
 func filesystemsFromStorage(in []storage.Filesystem) []params.Filesystem {

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -519,6 +519,7 @@ func setVolumeAttachmentInfo(ctx *context, volumeAttachments []storage.VolumeAtt
 }
 
 func destroyVolumes(volumes []params.Volume) ([]error, error) {
+	// TODO(axw) implement destroy
 	err := errors.New("destroy volumes is not implemented")
 	errs := make([]error, len(volumes))
 	for i := range errs {
@@ -528,6 +529,7 @@ func destroyVolumes(volumes []params.Volume) ([]error, error) {
 }
 
 func detachVolumes(attachments []params.VolumeAttachment) ([]error, error) {
+	// TODO(axw) implement detach
 	err := errors.New("detach volumes is not implemented")
 	errs := make([]error, len(attachments))
 	for i := range errs {

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -519,11 +519,21 @@ func setVolumeAttachmentInfo(ctx *context, volumeAttachments []storage.VolumeAtt
 }
 
 func destroyVolumes(volumes []params.Volume) ([]error, error) {
-	panic("not implemented")
+	err := errors.New("destroy volumes is not implemented")
+	errs := make([]error, len(volumes))
+	for i := range errs {
+		errs[i] = err
+	}
+	return errs, nil
 }
 
 func detachVolumes(attachments []params.VolumeAttachment) ([]error, error) {
-	panic("not implemented")
+	err := errors.New("detach volumes is not implemented")
+	errs := make([]error, len(attachments))
+	for i := range errs {
+		errs[i] = err
+	}
+	return errs, nil
 }
 
 func volumesFromStorage(in []storage.Volume) []params.Volume {


### PR DESCRIPTION
This diff introduces functionality into state to detach
and destroy volumes and filesystems. There is more work
to do be done to react to the state changes in the
storage provisioner, which will be done in a follow-up.

When a machine is destroyed, we will now queue a cleanup
to destroy the associated volume and filesystem attachments.
Later, we will prevent a machine from fully terminating
(i.e. EnsureDead will fail) until those attachments have
been removed from state.

When a machine is removed from state, we will remove all
volume and filesystem attachments related to that machine,
and we will remove the corresponding volumes and filesystems
*iff* they are non-persistent, or if they have not been
provisioned and are provisioned with the machine ("static").

When a volume or filesystem is destroyed, we now queue
cleanups to destroy their attachments. The entity cannot
be removed from state until all attachments are removed.

If a volume backs a filesystem, the volume cannot be
destroyed until the filesystem is removed. Upon removing
the filesystem, Juju will initiate the destruction of
the volume. Similarly, the volume cannot be detached
until the filesystem is detached.

(Review request: http://reviews.vapour.ws/r/1922/)