### PR TITLE
Added a test for sending metrics when the server reports an error.

### DIFF
--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -38,6 +38,12 @@ type MetricsRecorder interface {
 	Close() error
 }
 
+// metricsSender is used to send metrics to state. Its default implementation is
+// *uniter.Unit.
+type metricsSender interface {
+	AddMetricBatches(batches []params.MetricBatch) (map[string]error, error)
+}
+
 // MetricsReader is used to read metrics batches stored by the metrics recorder
 // and remove metrics batches that have been marked as succesfully sent.
 type MetricsReader interface {
@@ -121,6 +127,9 @@ type HookContext struct {
 
 	// metricsReader is used to read metric batches from storage.
 	metricsReader MetricsReader
+
+	// metricsSender is used to send metrics to state.
+	metricsSender metricsSender
 
 	// definedMetrics specifies the metrics the charm has defined in its metrics.yaml file.
 	definedMetrics *charm.Metrics
@@ -680,7 +689,7 @@ func (ctx *HookContext) FlushContext(process string, ctxErr error) (err error) {
 		}
 		sendBatches = append(sendBatches, batchParam)
 	}
-	results, err := ctx.unit.AddMetricBatches(sendBatches)
+	results, err := ctx.metricsSender.AddMetricBatches(sendBatches)
 	if err != nil {
 		// Do not return metric sending error.
 		logger.Errorf("%v", err)

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -284,6 +284,7 @@ func (f *factory) coreContext() (*HookContext, error) {
 		relationId:         -1,
 		metricsRecorder:    nil,
 		definedMetrics:     nil,
+		metricsSender:      f.unit,
 		pendingPorts:       make(map[PortRange]PortRangeInfo),
 		storage:            f.storage,
 	}

--- a/worker/uniter/runner/flush_test.go
+++ b/worker/uniter/runner/flush_test.go
@@ -205,6 +205,52 @@ func (s *FlushContextSuite) TestRunHookMetricSendingGetDuplicate(c *gc.C) {
 
 }
 
+func (s *FlushContextSuite) TestRunHookMetricSendingFailedByServer(c *gc.C) {
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("pings"))
+
+	// Send batches once.
+	batches := []runner.MetricsBatch{
+		{
+			CharmURL: s.meteredCharm.URL().String(),
+			UUID:     utils.MustNewUUID().String(),
+			Created:  time.Now(),
+			Metrics:  []jujuc.Metric{{Key: "pings", Value: "1", Time: time.Now()}},
+		}, {
+			CharmURL: s.meteredCharm.URL().String(),
+			UUID:     utils.MustNewUUID().String(),
+			Created:  time.Now(),
+			Metrics:  []jujuc.Metric{{Key: "pings", Value: "1", Time: time.Now()}},
+		},
+	}
+
+	reader := &StubMetricsReader{
+		Stub:    &s.Stub,
+		Batches: batches,
+	}
+
+	restoreRunner := runner.PatchMetricsReader(ctx, reader)
+	defer restoreRunner()
+
+	restoreSender := runner.PatchMetricsSender(ctx, func(batches []params.MetricBatch) (map[string]error, error) {
+		responses := make(map[string]error, len(batches))
+		for i := range responses {
+			responses[i] = errors.New("failed to store")
+		}
+		return responses, nil
+	})
+	defer restoreSender()
+
+	// Flush the context.
+	err = ctx.FlushContext("some badge", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check stub calls, metrics should not be removed.
+	s.Stub.CheckCallNames(c, "Open", "Close")
+	s.Stub.ResetCalls()
+}
+
 func (s *FlushContextSuite) TestRunHookNoMetricSendingOnFailure(c *gc.C) {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Added a test to make sure metric batches are not removed from the unit's spool when the server reports an error saving the metrics.

(Review request: http://reviews.vapour.ws/r/1923/)