### PR TITLE
LP-1464392 :: Close mgo.Iter used in FindActionTagsByPrefix

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -317,6 +317,12 @@ func (st *State) FindActionTagsByPrefix(prefix string) []names.ActionTag {
 	defer closer()
 
 	iter := actions.Find(bson.D{{"_id", bson.D{{"$regex", "^" + st.docID(prefix)}}}}).Iter()
+	defer func() {
+		err := iter.Close()
+		if err != nil {
+			actionLogger.Errorf("error closing mongo iterator: %v", err)
+		}
+	}()
 	for iter.Next(&doc) {
 		actionLogger.Tracef("FindActionTagsByPrefix() iter doc %+v", doc)
 		localID := st.localID(doc.Id)

--- a/state/action.go
+++ b/state/action.go
@@ -317,12 +317,7 @@ func (st *State) FindActionTagsByPrefix(prefix string) []names.ActionTag {
 	defer closer()
 
 	iter := actions.Find(bson.D{{"_id", bson.D{{"$regex", "^" + st.docID(prefix)}}}}).Iter()
-	defer func() {
-		err := iter.Close()
-		if err != nil {
-			actionLogger.Errorf("error closing mongo iterator: %v", err)
-		}
-	}()
+	defer iter.Close()
 	for iter.Next(&doc) {
 		actionLogger.Tracef("FindActionTagsByPrefix() iter doc %+v", doc)
 		localID := st.localID(doc.Id)


### PR DESCRIPTION
 We should probably modify the signature of FindActionTagsByPrefix to
 return an error, but I don't want to change the API for this.

 Hopefully logging an error is good enough.

(Review request: http://reviews.vapour.ws/r/1924/)