### PR TITLE
Merge pull request #2515 from axw/storage-add-bug1462146

### DIFF
--- a/state/service.go
+++ b/state/service.go
@@ -756,7 +756,10 @@ func (s *Service) unitStorageOps(unitName string) (ops []txn.Op, numStorageAttac
 	url := charm.URL()
 	tag := names.NewUnitTag(unitName)
 	// TODO(wallyworld) - record constraints info in data model - size and pool name
-	ops, numStorageAttachments, err = createStorageOps(s.st, tag, meta, url, cons)
+	ops, numStorageAttachments, err = createStorageOps(
+		s.st, tag, meta, url, cons,
+		false, // unit is not assigned yet; don't create machine storage
+	)
 	if err != nil {
 		return nil, -1, errors.Trace(err)
 	}

--- a/state/storage.go
+++ b/state/storage.go
@@ -331,6 +331,7 @@ func createStorageOps(
 	charmMeta *charm.Meta,
 	curl *charm.URL,
 	cons map[string]StorageConstraints,
+	machineOpsNeeded bool,
 ) (ops []txn.Op, numStorageAttachments int, err error) {
 
 	type template struct {
@@ -410,6 +411,19 @@ func createStorageOps(
 				Assert: txn.DocMissing,
 				Insert: doc,
 			})
+			if machineOpsNeeded {
+				machineOps, err := unitAssignedMachineStorageOps(
+					st, entity, charmMeta, cons,
+					&storageInstance{st, *doc},
+				)
+				if err == nil {
+					ops = append(ops, machineOps...)
+				} else if !errors.IsNotAssigned(err) {
+					return nil, -1, errors.Annotatef(
+						err, "creating machine storage for storage %s", id,
+					)
+				}
+			}
 		}
 	}
 
@@ -421,6 +435,46 @@ func createStorageOps(
 	// is when units are added to said service.
 
 	return ops, numStorageAttachments, nil
+}
+
+// unitAssignedMachineStorageOps returns ops for creating volumes, filesystems
+// and their attachments to the machine that the specified unit is assigned to,
+// corresponding to the specified storage instance.
+func unitAssignedMachineStorageOps(
+	st *State,
+	entity names.Tag,
+	charmMeta *charm.Meta,
+	cons map[string]StorageConstraints,
+	storage StorageInstance,
+) (ops []txn.Op, err error) {
+	tag, ok := entity.(names.UnitTag)
+	if !ok {
+		return nil, errors.NotSupportedf("dynamic creation of shared storage")
+	}
+	storageParams, err := machineStorageParamsForStorageInstance(
+		st, charmMeta, tag, cons, storage,
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	u, err := st.Unit(tag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	m, err := u.machine()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err := validateDynamicMachineStorageParams(m, storageParams); err != nil {
+		return nil, errors.Trace(err)
+	}
+	storageOps, err := st.machineStorageOps(&m.doc, storageParams)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return storageOps, nil
 }
 
 // createStorageAttachmentOps returns a txn.Op for creating a storage attachment.
@@ -1059,7 +1113,7 @@ func (st *State) addStorageForUnit(
 		return ops, nil
 	}
 	if err := st.run(buildTxn); err != nil {
-		return errors.Annotatef(err, "adding %q storage to unit %s", name, u)
+		return errors.Annotatef(err, "adding storage to unit %s", u)
 	}
 	return nil
 }
@@ -1096,7 +1150,9 @@ func (st *State) constructAddUnitStorageOps(
 		u.Tag(),
 		ch.Meta(),
 		ch.URL(),
-		map[string]StorageConstraints{name: cons})
+		map[string]StorageConstraints{name: cons},
+		true, // create machine storage
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -145,7 +145,7 @@ func (s *storageAddSuite) TestAddStorageToDyingUnitFails(c *gc.C) {
 	}).Check()
 
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
-	c.Assert(err, gc.ErrorMatches, `adding "multi1to10" storage to unit storage-block2/0: unit is not alive`)
+	c.Assert(err, gc.ErrorMatches, `adding storage to unit storage-block2/0: unit is not alive`)
 
 	s.assertStorageCount(c, s.originalStorageCount)
 }

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -10,18 +10,24 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage/provider/dummy"
+	"github.com/juju/juju/storage/provider/registry"
 )
 
-type StorageAddSuite struct {
+type storageAddSuite struct {
 	StorageStateSuiteBase
 
-	unitTag              names.UnitTag
-	originalStorageCount int
+	unitTag    names.UnitTag
+	machineTag names.MachineTag
+
+	originalStorageCount    int
+	originalVolumeCount     int
+	originalFilesystemCount int
 }
 
-var _ = gc.Suite(&StorageAddSuite{})
+var _ = gc.Suite(&storageAddSuite{})
 
-func (s *StorageAddSuite) setupMultipleStoragesForAdd(c *gc.C) {
+func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 	storageCons := map[string]state.StorageConstraints{
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
@@ -30,36 +36,90 @@ func (s *StorageAddSuite) setupMultipleStoragesForAdd(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	s.unitTag = u.Tag().(names.UnitTag)
-
+	s.unitTag = u.UnitTag()
 	all, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	s.originalStorageCount = len(all)
+	return u
 }
 
-func (s *StorageAddSuite) assertStorageCount(c *gc.C, expected int) {
+func (s *storageAddSuite) assignUnit(c *gc.C, u *state.Unit) {
+	// Assign unit to machine to get volumes and filesystems
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+	machineId, err := u.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+
+	m, err := s.State.Machine(machineId)
+	c.Assert(err, jc.ErrorIsNil)
+	s.machineTag = m.MachineTag()
+
+	volumes, err := s.State.AllVolumes()
+	c.Assert(err, jc.ErrorIsNil)
+	s.originalVolumeCount = len(volumes)
+
+	filesystems, err := s.State.MachineFilesystemAttachments(s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.originalFilesystemCount = len(filesystems)
+}
+
+func (s *storageAddSuite) assertStorageCount(c *gc.C, count int) {
 	all, err := s.State.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(all), gc.Equals, expected)
+	c.Assert(all, gc.HasLen, count)
 }
 
-func (s *StorageAddSuite) TestAddStorageToUnit(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) assertVolumeCount(c *gc.C, count int) {
+	all, err := s.State.AllVolumes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all, gc.HasLen, count)
+}
+
+func (s *storageAddSuite) assertFileSystemCount(c *gc.C, count int) {
+	all, err := s.State.MachineFilesystemAttachments(s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all, gc.HasLen, count)
+}
+
+func (s *storageAddSuite) TestAddStorageToUnit(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
+	s.assertVolumeCount(c, s.originalVolumeCount+1)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageWithCount(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageToUnitNotAssigned(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	// don't assign unit
+
+	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, s.originalStorageCount+1)
+	s.assertVolumeCount(c, 0)
+	s.assertFileSystemCount(c, 0)
+
+	s.assignUnit(c, u)
+	s.assertVolumeCount(c, 6)
+	s.assertFileSystemCount(c, 0)
+}
+
+func (s *storageAddSuite) TestAddStorageWithCount(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+2)
+	s.assertVolumeCount(c, s.originalVolumeCount+2)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 2))
 	c.Assert(err, jc.ErrorIsNil)
@@ -70,9 +130,11 @@ func (s *StorageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
 	err = s.State.AddStorageForUnit(s.unitTag, "multi1to10", makeStorageCons("loop-pool", 1024, 6))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified.*`)
 	s.assertStorageCount(c, s.originalStorageCount+2)
+	s.assertVolumeCount(c, s.originalVolumeCount+2)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageToDyingUnitFails(c *gc.C) {
+func (s *storageAddSuite) TestAddStorageToDyingUnitFails(c *gc.C) {
 	s.setupMultipleStoragesForAdd(c)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -88,75 +150,113 @@ func (s *StorageAddSuite) TestAddStorageToDyingUnitFails(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageExceedCount(c *gc.C) {
+func (s *storageAddSuite) TestAddStorageExceedCount(c *gc.C) {
 	_, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
 	s.assertStorageCount(c, 1)
 
-	err := s.State.AddStorageForUnit(u.Tag().(names.UnitTag), "data", makeStorageCons("loop-pool", 1024, 1))
+	err := s.State.AddStorageForUnit(u.UnitTag(), "data", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block" store "data": at most 1 instances supported, 2 specified.*`)
 	s.assertStorageCount(c, 1)
+	s.assertVolumeCount(c, 0)
+	s.assertFileSystemCount(c, 0)
 }
 
-func (s *StorageAddSuite) TestAddStorageMinCount(c *gc.C) {
+func (s *storageAddSuite) createAndAssignUnitWithSingleStorage(c *gc.C) names.UnitTag {
 	_, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
 	s.assertStorageCount(c, 1)
 
-	err := s.State.AddStorageForUnit(u.Tag().(names.UnitTag), "allecto", makeStorageCons("loop-pool", 1024, 1))
+	// Assign unit to machine to get volumes and filesystems
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumes, err := s.State.AllVolumes()
+	c.Assert(err, jc.ErrorIsNil)
+	s.originalVolumeCount = len(volumes)
+
+	filesystems, err := s.State.MachineFilesystemAttachments(s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.originalFilesystemCount = len(filesystems)
+
+	return u.UnitTag()
+}
+
+func (s *storageAddSuite) TestAddStorageMinCount(c *gc.C) {
+	unit := s.createAndAssignUnitWithSingleStorage(c)
+	err := s.State.AddStorageForUnit(unit, "allecto", makeStorageCons("loop-pool", 1024, 1))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, 2)
+	s.assertVolumeCount(c, 2)
+	s.assertFileSystemCount(c, 0)
 }
 
-func (s *StorageAddSuite) TestAddStorageZeroCount(c *gc.C) {
-	_, u, _ := s.setupSingleStorage(c, "block", "loop-pool")
-	s.assertStorageCount(c, 1)
-
-	err := s.State.AddStorageForUnit(u.Tag().(names.UnitTag), "allecto", state.StorageConstraints{Pool: "loop-pool", Size: 1024})
+func (s *storageAddSuite) TestAddStorageZeroCount(c *gc.C) {
+	unit := s.createAndAssignUnitWithSingleStorage(c)
+	err := s.State.AddStorageForUnit(unit, "allecto", state.StorageConstraints{Pool: "loop-pool", Size: 1024})
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "adding storage where instance count is 0 not valid")
 	s.assertStorageCount(c, 1)
+	s.assertVolumeCount(c, 1)
+	s.assertFileSystemCount(c, 0)
 }
 
-func (s *StorageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Count: 1})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
+	s.assertVolumeCount(c, s.originalVolumeCount+1)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageDiffPool(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageDiffPool(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Pool: "loop-pool", Count: 1})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
+	s.assertVolumeCount(c, s.originalVolumeCount+1)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageDiffSize(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageDiffSize(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 
 	err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Size: 2048, Count: 1})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStorageCount(c, s.originalStorageCount+1)
+	s.assertVolumeCount(c, s.originalVolumeCount+1)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 
 	err := s.State.AddStorageForUnit(s.unitTag, "multi2up", state.StorageConstraints{Size: 2, Count: 1})
 	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 2.0MB specified.*`)
 	s.assertStorageCount(c, s.originalStorageCount)
+	s.assertVolumeCount(c, s.originalVolumeCount)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageWrongName(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageWrongName(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 
 	err := s.State.AddStorageForUnit(s.unitTag, "furball", state.StorageConstraints{Size: 2})
 	c.Assert(err, gc.ErrorMatches, `.*charm storage "furball" not found.*`)
 	s.assertStorageCount(c, s.originalStorageCount)
+	s.assertVolumeCount(c, s.originalVolumeCount)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageConcurrently(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageConcurrently(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
+
 	addStorage := func() {
 		err := s.State.AddStorageForUnit(s.unitTag, "multi1to10", state.StorageConstraints{Count: 1})
 		c.Assert(err, jc.ErrorIsNil)
@@ -164,10 +264,13 @@ func (s *StorageAddSuite) TestAddStorageConcurrently(c *gc.C) {
 	defer state.SetBeforeHooks(c, s.State, addStorage).Check()
 	addStorage()
 	s.assertStorageCount(c, s.originalStorageCount+2)
+	s.assertVolumeCount(c, s.originalVolumeCount+2)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
 }
 
-func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
-	s.setupMultipleStoragesForAdd(c)
+func (s *storageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
+	u := s.setupMultipleStoragesForAdd(c)
+	s.assignUnit(c, u)
 
 	count := 6
 	addStorage := func() {
@@ -180,4 +283,58 @@ func (s *StorageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
 
 	// Only "count" number of instances should have been added.
 	s.assertStorageCount(c, s.originalStorageCount+count)
+	s.assertVolumeCount(c, s.originalVolumeCount+count)
+	s.assertFileSystemCount(c, s.originalFilesystemCount)
+}
+
+func (s *storageAddSuite) TestAddStorageFilesystem(c *gc.C) {
+	_, u, _ := s.setupSingleStorage(c, "filesystem", "loop-pool")
+
+	// Assign unit to machine to get volumes and filesystems
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+	machineId, err := u.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	s.machineTag = names.NewMachineTag(machineId)
+	s.assertFileSystemCount(c, 1)
+
+	s.assertStorageCount(c, 1)
+	s.assertVolumeCount(c, 1)
+	s.assertFileSystemCount(c, 1)
+
+	err = s.State.AddStorageForUnit(u.UnitTag(), "data", makeStorageCons("loop-pool", 1024, 1))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertStorageCount(c, 2)
+	s.assertVolumeCount(c, 2)
+	s.assertFileSystemCount(c, 2)
+}
+
+func (s *storageAddSuite) TestAddStorageStatic(c *gc.C) {
+	// Create a unit with static storage; ensure that storage-add
+	// fails to add more of this kind of storage.
+	registry.RegisterProvider("static", &dummy.StorageProvider{
+		IsDynamic: false,
+	})
+	registry.RegisterEnvironStorageProviders("someprovider", "static")
+	defer registry.RegisterProvider("static", nil)
+	_, u, _ := s.setupSingleStorage(c, "filesystem", "static")
+	s.assertStorageCount(c, 1)
+
+	// Assign unit to machine to get volumes and filesystems
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+	machineId, err := u.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	s.machineTag = names.NewMachineTag(machineId)
+	s.assertFileSystemCount(c, 1)
+
+	err = s.State.AddStorageForUnit(
+		u.UnitTag(), "data",
+		makeStorageCons("static", 1024, 1),
+	)
+	c.Assert(err, gc.ErrorMatches, "adding storage to unit storage-filesystem/0: "+
+		"creating machine storage for storage data/1: "+
+		"static storage provider does not support dynamic storage")
+	s.assertStorageCount(c, 1)    // no change
+	s.assertFileSystemCount(c, 1) // no change
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -1575,6 +1575,8 @@ func (u *Unit) machineStorageParams() (*machineStorageParams, error) {
 		return nil, errors.Annotatef(err, "getting storage constraints")
 	}
 
+	chMeta := ch.Meta()
+
 	var volumes []MachineVolumeParams
 	var filesystems []MachineFilesystemParams
 	volumeAttachments := make(map[names.VolumeTag]VolumeAttachmentParams)
@@ -1584,66 +1586,107 @@ func (u *Unit) machineStorageParams() (*machineStorageParams, error) {
 		if err != nil {
 			return nil, errors.Annotatef(err, "getting storage instance")
 		}
-
-		charmStorage := ch.Meta().Storage[storage.StorageName()]
-
-		switch storage.Kind() {
-		case StorageKindBlock:
-			volumeAttachmentParams := VolumeAttachmentParams{
-				charmStorage.ReadOnly,
-			}
-			if storage.Owner() == u.Tag() {
-				// The storage instance is owned by the unit, so we'll need
-				// to create a volume.
-				cons := allCons[storage.StorageName()]
-				volumeParams := VolumeParams{
-					storage: storage.StorageTag(),
-					Pool:    cons.Pool,
-					Size:    cons.Size,
-				}
-				volumes = append(volumes, MachineVolumeParams{
-					volumeParams, volumeAttachmentParams,
-				})
-			} else {
-				// The storage instance is owned by the service, so there
-				// should be a (shared) volume already, for which we will
-				// just add an attachment.
-				volume, err := u.st.StorageInstanceVolume(storage.StorageTag())
-				if err != nil {
-					return nil, errors.Annotatef(err, "getting volume for storage %q", storage.Tag().Id())
-				}
-				volumeAttachments[volume.VolumeTag()] = volumeAttachmentParams
-			}
-		case StorageKindFilesystem:
-			filesystemAttachmentParams := FilesystemAttachmentParams{
-				charmStorage.Location,
-				charmStorage.ReadOnly,
-			}
-			if storage.Owner() == u.Tag() {
-				// The storage instance is owned by the unit, so we'll need
-				// to create a filesystem.
-				cons := allCons[storage.StorageName()]
-				filesystemParams := FilesystemParams{
-					storage: storage.StorageTag(),
-					Pool:    cons.Pool,
-					Size:    cons.Size,
-				}
-				filesystems = append(filesystems, MachineFilesystemParams{
-					filesystemParams, filesystemAttachmentParams,
-				})
-			} else {
-				// The storage instance is owned by the service, so there
-				// should be a (shared) filesystem already, for which we will
-				// just add an attachment.
-				filesystem, err := u.st.StorageInstanceFilesystem(storage.StorageTag())
-				if err != nil {
-					return nil, errors.Annotatef(err, "getting filesystem for storage %q", storage.Tag().Id())
-				}
-				filesystemAttachments[filesystem.FilesystemTag()] = filesystemAttachmentParams
-			}
-		default:
-			return nil, errors.Errorf("invalid storage kind %v", storage.Kind())
+		machineParams, err := machineStorageParamsForStorageInstance(
+			u.st, chMeta, u.UnitTag(), allCons, storage,
+		)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
+
+		volumes = append(volumes, machineParams.volumes...)
+		for k, v := range machineParams.volumeAttachments {
+			volumeAttachments[k] = v
+		}
+
+		filesystems = append(filesystems, machineParams.filesystems...)
+		for k, v := range machineParams.filesystemAttachments {
+			filesystemAttachments[k] = v
+		}
+	}
+	result := &machineStorageParams{
+		volumes,
+		volumeAttachments,
+		filesystems,
+		filesystemAttachments,
+	}
+	return result, nil
+}
+
+// machineStorageParamsForStorageInstance returns parameters for creating
+// volumes/filesystems and volume/filesystem attachments for a machine that
+// the unit will be assigned to. These parameters are based on a given storage
+// instance.
+func machineStorageParamsForStorageInstance(
+	st *State,
+	charmMeta *charm.Meta,
+	unit names.UnitTag,
+	allCons map[string]StorageConstraints,
+	storage StorageInstance,
+) (*machineStorageParams, error) {
+
+	charmStorage := charmMeta.Storage[storage.StorageName()]
+
+	var volumes []MachineVolumeParams
+	var filesystems []MachineFilesystemParams
+	volumeAttachments := make(map[names.VolumeTag]VolumeAttachmentParams)
+	filesystemAttachments := make(map[names.FilesystemTag]FilesystemAttachmentParams)
+
+	switch storage.Kind() {
+	case StorageKindBlock:
+		volumeAttachmentParams := VolumeAttachmentParams{
+			charmStorage.ReadOnly,
+		}
+		if unit == storage.Owner() {
+			// The storage instance is owned by the unit, so we'll need
+			// to create a volume.
+			cons := allCons[storage.StorageName()]
+			volumeParams := VolumeParams{
+				storage: storage.StorageTag(),
+				Pool:    cons.Pool,
+				Size:    cons.Size,
+			}
+			volumes = append(volumes, MachineVolumeParams{
+				volumeParams, volumeAttachmentParams,
+			})
+		} else {
+			// The storage instance is owned by the service, so there
+			// should be a (shared) volume already, for which we will
+			// just add an attachment.
+			volume, err := st.StorageInstanceVolume(storage.StorageTag())
+			if err != nil {
+				return nil, errors.Annotatef(err, "getting volume for storage %q", storage.Tag().Id())
+			}
+			volumeAttachments[volume.VolumeTag()] = volumeAttachmentParams
+		}
+	case StorageKindFilesystem:
+		filesystemAttachmentParams := FilesystemAttachmentParams{
+			charmStorage.Location,
+			charmStorage.ReadOnly,
+		}
+		if unit == storage.Owner() {
+			// The storage instance is owned by the unit, so we'll need
+			// to create a filesystem.
+			cons := allCons[storage.StorageName()]
+			filesystemParams := FilesystemParams{
+				storage: storage.StorageTag(),
+				Pool:    cons.Pool,
+				Size:    cons.Size,
+			}
+			filesystems = append(filesystems, MachineFilesystemParams{
+				filesystemParams, filesystemAttachmentParams,
+			})
+		} else {
+			// The storage instance is owned by the service, so there
+			// should be a (shared) filesystem already, for which we will
+			// just add an attachment.
+			filesystem, err := st.StorageInstanceFilesystem(storage.StorageTag())
+			if err != nil {
+				return nil, errors.Annotatef(err, "getting filesystem for storage %q", storage.Tag().Id())
+			}
+			filesystemAttachments[filesystem.FilesystemTag()] = filesystemAttachmentParams
+		}
+	default:
+		return nil, errors.Errorf("invalid storage kind %v", storage.Kind())
 	}
 	result := &machineStorageParams{
 		volumes,

--- a/testcharms/charm-repo/quantal/storage-filesystem/metadata.yaml
+++ b/testcharms/charm-repo/quantal/storage-filesystem/metadata.yaml
@@ -4,3 +4,6 @@ description: See above
 storage:
     data:
         type: filesystem
+        read-only: true
+        multiple:
+          range: 1+


### PR DESCRIPTION
This is a forward port from 1.24 (https://github.com/juju/juju/commit/340a95ecacd73be4c25fb22d71f008c477048fc2)
Please review as there were conflicts.


Create machine storage on storage-add

When storage is added to a unit, we must create corresponding
machine storage if the unit is already assigned to a machine.

Supersedes http://reviews.vapour.ws/r/1870/

Bug https://bugs.launchpad.net/juju-core/+bug/1462146

(Review request: http://reviews.vapour.ws/r/1881/)
Conflicts:
	state/storage.go
	state/storage_dynamicadd_test.go

(Review request: http://reviews.vapour.ws/r/1927/)