### PR TITLE
All: fix various issues detected by go vet

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -145,7 +145,6 @@ func (cl *changeCertListener) processCertChanges() error {
 			return tomb.ErrDying
 		}
 	}
-	return nil
 }
 
 // updateCertificate generates a new TLS certificate and assigns it

--- a/cmd/juju/package_test.go
+++ b/cmd/juju/package_test.go
@@ -1,12 +1,12 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package main
-
 // TODO(dimitern): bug http://pad.lv/1425569
 // Disabled until we have time to fix these tests on i386 properly.
 //
 // +build !386
+
+package main
 
 import (
 	"flag"

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -1,7 +1,6 @@
 package paths
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -47,7 +47,6 @@ func osVal(series string, valname osVarType) (string, error) {
 	default:
 		return nixVals[valname], nil
 	}
-	return "", fmt.Errorf("Unknown OS: %q", os)
 }
 
 // TempDir returns the path on disk to the corect tmp directory

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -35,10 +35,6 @@ type environ struct {
 	supportedArchitectures []string
 }
 
-var _ environs.Environ = (*environ)(nil)
-var _ simplestreams.HasRegion = (*environ)(nil)
-var _ simplestreams.MetadataValidator = (*environ)(nil)
-
 // Name returns the Environ's name.
 func (env environ) Name() string {
 	return env.name

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+var _ environs.Environ = (*environ)(nil)
+var _ simplestreams.HasRegion = (*environ)(nil)
+var _ simplestreams.MetadataValidator = (*environ)(nil)
+
 type environSuite struct {
 	testing.BaseSuite
 }

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -85,7 +85,7 @@ func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, 
 // find matching image information.
 func (p environProvider) MetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
 	if region == "" {
-		fmt.Errorf("region must be specified")
+		return nil, fmt.Errorf("region must be specified")
 	}
 	ec2Region, ok := allRegions[region]
 	if !ok {

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -45,7 +45,7 @@ func getSystemIdValues(key string, instanceIds []instance.Id) url.Values {
 // filesystem during its first startup.  That file is then read by the juju
 // agent running on the node and converted back into a machineInfo object.
 type machineInfo struct {
-	Hostname string `yaml:,omitempty`
+	Hostname string `yaml:",omitempty"`
 }
 
 var maasDataDir = paths.MustSucceed(paths.DataDir(config.LatestLtsSeries()))

--- a/state/backups/storage_test.go
+++ b/state/backups/storage_test.go
@@ -74,7 +74,7 @@ func (s *storageSuite) checkMeta(c *gc.C, meta, expected *backups.Metadata, id s
 	c.Check(meta.Origin.Machine, gc.Equals, expected.Origin.Machine)
 	c.Check(meta.Origin.Hostname, gc.Equals, expected.Origin.Hostname)
 	c.Check(meta.Origin.Version, gc.Equals, expected.Origin.Version)
-	if meta.Stored() != nil && expected.Stored != nil {
+	if meta.Stored() != nil && expected.Stored() != nil {
 		c.Check(meta.Stored().Unix(), gc.Equals, expected.Stored().Unix())
 	} else {
 		c.Check(meta.Stored(), gc.Equals, expected.Stored())

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -710,10 +710,10 @@ func (p *Pinger) ping() (err error) {
 // the local clock and the database clock.
 func clockDelta(c *mgo.Collection) (time.Duration, error) {
 	var server struct {
-		time.Time "retval"
+		time.Time `bson:"retval"`
 	}
 	var isMaster struct {
-		LocalTime time.Time "localTime"
+		LocalTime time.Time `bson:"localTime"`
 	}
 	var after time.Time
 	var before time.Time

--- a/state/service.go
+++ b/state/service.go
@@ -37,7 +37,7 @@ type serviceDoc struct {
 	Series            string     `bson:"series"`
 	Subordinate       bool       `bson:"subordinate"`
 	CharmURL          *charm.URL `bson:"charmurl"`
-	ForceCharm        bool       `bson:forcecharm"`
+	ForceCharm        bool       `bson:"forcecharm"`
 	Life              Life       `bson:"life"`
 	UnitCount         int        `bson:"unitcount"`
 	RelationCount     int        `bson:"relationcount"`

--- a/state/storage.go
+++ b/state/storage.go
@@ -234,7 +234,6 @@ func (st *State) DestroyStorageInstance(tag names.StorageTag) (err error) {
 		default:
 			return nil, errors.Trace(err)
 		}
-		return nil, jujutxn.ErrTransientFailure
 	}
 	return st.run(buildTxn)
 }

--- a/state/watcher/watcher_test.go
+++ b/state/watcher/watcher_test.go
@@ -140,7 +140,7 @@ func assertOrder(c *gc.C, revnos ...int64) {
 
 func (s *watcherSuite) revno(c string, id interface{}) (revno int64) {
 	var doc struct {
-		Revno int64 "txn-revno"
+		Revno int64 `bson:"txn-revno"`
 	}
 	err := s.log.Database.C(c).FindId(id).One(&doc)
 	if err != nil {

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -119,8 +119,7 @@ func (*Factory) RandomSuffix(prefix string) string {
 }
 
 func uniqueInteger() int {
-	index = atomic.AddUint32(&index, 1)
-	return int(index)
+	return int(atomic.AddUint32(&index, 1))
 }
 
 func uniqueString(prefix string) string {

--- a/worker/txnpruner/txnpruner.go
+++ b/worker/txnpruner/txnpruner.go
@@ -37,6 +37,5 @@ func New(tp TransactionPruner, interval time.Duration) worker.Worker {
 				return nil
 			}
 		}
-		return nil
 	})
 }


### PR DESCRIPTION
apiserver/apiserver.go:148: unreachable code
cmd/juju/package_test.go:9: +build comment must appear before package clause and be followed by a blank line
juju/paths/paths.go:50: unreachable code
provider/ec2/provider.go:88: result of fmt.Errorf call not used
provider/maas/util.go:48: struct field tag `yaml:,omitempty` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
state/service.go:40: struct field tag `bson:forcecharm"` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
state/storage.go:237: unreachable code
state/backups/storage_test.go:77: comparison of function Stored != nil is always true
state/presence/presence.go:713: struct field tag "retval" not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
state/presence/presence.go:716: struct field tag "localTime" not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
state/watcher/watcher_test.go:143: struct field tag "txn-revno" not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
testing/factory/factory.go:122: direct assignment to atomic value
worker/txnpruner/txnpruner.go:40: unreachable code

(Review request: http://reviews.vapour.ws/r/1929/)