### PR TITLE
Added a test for sending metrics when the server reports an error.

### DIFF
--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -38,6 +38,12 @@ type MetricsRecorder interface {
 	Close() error
 }
 
+// metricsSender is used to send metrics to state. Its default implementation is
+// *uniter.Unit.
+type metricsSender interface {
+	AddMetricBatches(batches []params.MetricBatch) (map[string]error, error)
+}
+
 // MetricsReader is used to read metrics batches stored by the metrics recorder
 // and remove metrics batches that have been marked as succesfully sent.
 type MetricsReader interface {
@@ -121,6 +127,9 @@ type HookContext struct {
 
 	// metricsReader is used to read metric batches from storage.
 	metricsReader MetricsReader
+
+	// metricsSender is used to send metrics to state.
+	metricsSender metricsSender
 
 	// definedMetrics specifies the metrics the charm has defined in its metrics.yaml file.
 	definedMetrics *charm.Metrics
@@ -680,7 +689,7 @@ func (ctx *HookContext) FlushContext(process string, ctxErr error) (err error) {
 		}
 		sendBatches = append(sendBatches, batchParam)
 	}
-	results, err := ctx.unit.AddMetricBatches(sendBatches)
+	results, err := ctx.metricsSender.AddMetricBatches(sendBatches)
 	if err != nil {
 		// Do not return metric sending error.
 		logger.Errorf("%v", err)

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -284,6 +284,7 @@ func (f *factory) coreContext() (*HookContext, error) {
 		relationId:         -1,
 		metricsRecorder:    nil,
 		definedMetrics:     nil,
+		metricsSender:      f.unit,
 		pendingPorts:       make(map[PortRange]PortRangeInfo),
 		storage:            f.storage,
 	}


### PR DESCRIPTION
This is a backport of http://reviews.vapour.ws/r/1923/ to 1.24

(Review request: http://reviews.vapour.ws/r/1931/)