### PR TITLE
Various LXC and KVM fixes

### DIFF
--- a/container/storage.go
+++ b/container/storage.go
@@ -3,16 +3,6 @@
 
 package container
 
-import "errors"
-
-// ErrLoopMountNotAllowed is used when loop devices are requested to be
-// mounted inside an LXC container, but this has not been allowed using
-// an environment config setting.
-var ErrLoopMountNotAllowed = errors.New(`
-Mounting of loop devices inside LXC containers must be explicitly enabled using this environment config setting:
-  allow-lxc-loop-mounts=true
-`[1:])
-
 // StorageConfig defines how the container will be configured to support
 // storage requirements.
 type StorageConfig struct {

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -397,12 +397,24 @@ func (s *ContainerSetupSuite) TestMaybeOverrideDefaultLXCNet(c *gc.C) {
 	}
 }
 
-func AssertFileContains(c *gc.C, filename, expectedContent string) {
+func AssertFileContains(c *gc.C, filename string, expectedContent ...string) {
 	// TODO(dimitern): We should put this in juju/testing repo and
 	// replace all similar checks with it.
 	data, err := ioutil.ReadFile(filename)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(data), jc.Contains, expectedContent)
+	for _, s := range expectedContent {
+		c.Assert(string(data), jc.Contains, s)
+	}
+}
+
+func AssertFileContents(c *gc.C, checker gc.Checker, filename string, expectedContent ...string) {
+	// TODO(dimitern): We should put this in juju/testing repo and
+	// replace all similar checks with it.
+	data, err := ioutil.ReadFile(filename)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, s := range expectedContent {
+		c.Assert(string(data), checker, s)
+	}
 }
 
 type SetIPAndARPForwardingSuite struct {

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/kvm"
-	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 )
@@ -148,22 +147,22 @@ func (broker *kvmBroker) AllInstances() (result []instance.Instance, err error) 
 	return broker.manager.ListContainers()
 }
 
-// MaintainInstance is only called for LXC hosts.
-// Stub to fulfill the environs.InstanceBroker interface.
+// MaintainInstance checks that the container's host has the required iptables and routing
+// rules to make the container visible to both the host and other machines on the same subnet.
 func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineId := args.InstanceConfig.MachineId
 	if !environs.AddressAllocationEnabled() {
-		lxcLogger.Infof("Address allocation disabled: Not running maintenance for lxc container with machineId: %s",
+		kvmLogger.Debugf("address allocation disabled: Not running maintenance for kvm with machineId: %s",
 			machineId)
 		return nil
 	}
 
-	lxcLogger.Infof("Running maintenance for lxc container with machineId: %s", machineId)
+	kvmLogger.Debugf("running maintenance for kvm with machineId: %s", machineId)
 
 	// Default to using the host network until we can configure.
 	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
 	if bridgeDevice == "" {
-		bridgeDevice = lxc.DefaultLxcBridge
+		bridgeDevice = kvm.DefaultKvmBridge
 	}
 	_, err := configureContainerNetwork(
 		machineId,

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/juju/juju/container/kvm/mock"
 	kvmtesting "github.com/juju/juju/container/kvm/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -41,6 +43,7 @@ type kvmBrokerSuite struct {
 	kvmSuite
 	broker      environs.InstanceBroker
 	agentConfig agent.Config
+	api         *fakeAPI
 }
 
 var _ = gc.Suite(&kvmBrokerSuite{})
@@ -85,8 +88,9 @@ func (s *kvmBrokerSuite) SetUpTest(c *gc.C) {
 			Environment:       coretesting.EnvironmentTag,
 		})
 	c.Assert(err, jc.ErrorIsNil)
+	s.api = NewFakeAPI()
 	managerConfig := container.ManagerConfig{container.ConfigName: "juju"}
-	s.broker, err = provisioner.NewKvmBroker(&fakeAPI{}, s.agentConfig, managerConfig, false)
+	s.broker, err = provisioner.NewKvmBroker(s.api, s.agentConfig, managerConfig, false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -108,6 +112,75 @@ func (s *kvmBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return result.Instance
+}
+
+func (s *kvmBrokerSuite) maintainInstance(c *gc.C, machineId string) {
+	machineNonce := "fake-nonce"
+	stateInfo := jujutesting.FakeStateInfo(machineId)
+	apiInfo := jujutesting.FakeAPIInfo(machineId)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	cons := constraints.Value{}
+	possibleTools := coretools.List{&coretools.Tools{
+		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+	}}
+	err = s.broker.MaintainInstance(environs.StartInstanceParams{
+		Constraints:    cons,
+		Tools:          possibleTools,
+		InstanceConfig: instanceConfig,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *kvmBrokerSuite) TestStartInstance(c *gc.C) {
+	machineId := "1/kvm/0"
+	s.SetFeatureFlags(feature.AddressAllocation)
+	kvm := s.startInstance(c, machineId)
+	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "PrepareContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-kvm-0")},
+	}, {
+		FuncName: "ContainerConfig",
+	}})
+	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))
+	s.assertInstances(c, kvm)
+}
+
+func (s *kvmBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
+	machineId := "1/kvm/0"
+	kvm := s.startInstance(c, machineId)
+	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}})
+	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))
+	s.assertInstances(c, kvm)
+}
+
+func (s *kvmBrokerSuite) TestMaintainInstance(c *gc.C) {
+	machineId := "1/kvm/0"
+	s.SetFeatureFlags(feature.AddressAllocation)
+	kvm := s.startInstance(c, machineId)
+	s.api.ResetCalls()
+
+	s.maintainInstance(c, machineId)
+	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "GetContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-kvm-0")},
+	}})
+	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))
+	s.assertInstances(c, kvm)
+}
+
+func (s *kvmBrokerSuite) TestMaintainInstanceAddressAllocationDisabled(c *gc.C) {
+	machineId := "1/kvm/0"
+	kvm := s.startInstance(c, machineId)
+	s.api.ResetCalls()
+
+	s.maintainInstance(c, machineId)
+	s.api.CheckCalls(c, []gitjujutesting.StubCall{})
+	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))
+	s.assertInstances(c, kvm)
 }
 
 func (s *kvmBrokerSuite) TestStopInstance(c *gc.C) {

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -443,6 +443,11 @@ var setupRoutesAndIPTables = func(
 		if code != 2 && err != nil {
 			return errors.Trace(err)
 		}
+		if code == 2 {
+			logger.Tracef("route already exists - not added")
+		} else {
+			logger.Tracef("route added: container uses host network interface")
+		}
 	}
 	logger.Infof("successfully configured iptables and routes for container interfaces")
 

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -589,12 +589,12 @@ func configureContainerNetwork(
 func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineId := args.InstanceConfig.MachineId
 	if !environs.AddressAllocationEnabled() {
-		lxcLogger.Infof("Address allocation disabled: Not running maintenance for lxc container with machineId: %s",
+		lxcLogger.Debugf("address allocation disabled: Not running maintenance for lxc container with machineId: %s",
 			machineId)
 		return nil
 	}
 
-	lxcLogger.Infof("Running maintenance for lxc container with machineId: %s", machineId)
+	lxcLogger.Debugf("running maintenance for lxc container with machineId: %s", machineId)
 
 	// Default to using the host network until we can configure.
 	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -156,6 +156,13 @@ func (s *lxcBrokerSuite) maintainInstance(c *gc.C, machineId string, volumes []s
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *lxcBrokerSuite) assertDefaultNetworkConfig(c *gc.C, lxc instance.Instance) {
+	AssertFileContents(c, jc.Contains, filepath.Join(s.ContainerDir, string(lxc.Id()), "lxc.conf"),
+		"lxc.network.type = veth", "lxc.network.link = lxcbr0")
+	AssertFileContents(c, gc.Not(jc.Contains), filepath.Join(s.LxcDir, string(lxc.Id()), "config"),
+		"lxc.aa_profile = lxc-container-default-with-mounting")
+}
+
 func (s *lxcBrokerSuite) TestStartInstance(c *gc.C) {
 	machineId := "1/lxc/0"
 	s.SetFeatureFlags(feature.AddressAllocation)
@@ -169,14 +176,7 @@ func (s *lxcBrokerSuite) TestStartInstance(c *gc.C) {
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
 	s.assertInstances(c, lxc)
-	// Uses default network config
-	lxcConfContents, err := ioutil.ReadFile(filepath.Join(s.ContainerDir, string(lxc.Id()), "lxc.conf"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.type = veth")
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.link = lxcbr0")
-	containerConfigContents, err := ioutil.ReadFile(filepath.Join(s.LxcDir, string(lxc.Id()), "config"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(containerConfigContents), gc.Not(jc.Contains), "lxc.aa_profile = lxc-container-default-with-mounting")
+	s.assertDefaultNetworkConfig(c, lxc)
 }
 
 func (s *lxcBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
@@ -188,14 +188,7 @@ func (s *lxcBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
 	s.assertInstances(c, lxc)
-	// Uses default network config
-	lxcConfContents, err := ioutil.ReadFile(filepath.Join(s.ContainerDir, string(lxc.Id()), "lxc.conf"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.type = veth")
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.link = lxcbr0")
-	containerConfigContents, err := ioutil.ReadFile(filepath.Join(s.LxcDir, string(lxc.Id()), "config"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(containerConfigContents), gc.Not(jc.Contains), "lxc.aa_profile = lxc-container-default-with-mounting")
+	s.assertDefaultNetworkConfig(c, lxc)
 }
 
 func (s *lxcBrokerSuite) TestMaintainInstance(c *gc.C) {
@@ -212,14 +205,7 @@ func (s *lxcBrokerSuite) TestMaintainInstance(c *gc.C) {
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
 	s.assertInstances(c, lxc)
-	// Uses default network config
-	lxcConfContents, err := ioutil.ReadFile(filepath.Join(s.ContainerDir, string(lxc.Id()), "lxc.conf"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.type = veth")
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.link = lxcbr0")
-	containerConfigContents, err := ioutil.ReadFile(filepath.Join(s.LxcDir, string(lxc.Id()), "config"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(containerConfigContents), gc.Not(jc.Contains), "lxc.aa_profile = lxc-container-default-with-mounting")
+	s.assertDefaultNetworkConfig(c, lxc)
 }
 
 func (s *lxcBrokerSuite) TestMaintainInstanceAddressAllocationDisabled(c *gc.C) {
@@ -232,14 +218,7 @@ func (s *lxcBrokerSuite) TestMaintainInstanceAddressAllocationDisabled(c *gc.C) 
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
 	s.assertInstances(c, lxc)
-	// Uses default network config
-	lxcConfContents, err := ioutil.ReadFile(filepath.Join(s.ContainerDir, string(lxc.Id()), "lxc.conf"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.type = veth")
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.link = lxcbr0")
-	containerConfigContents, err := ioutil.ReadFile(filepath.Join(s.LxcDir, string(lxc.Id()), "config"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(containerConfigContents), gc.Not(jc.Contains), "lxc.aa_profile = lxc-container-default-with-mounting")
+	s.assertDefaultNetworkConfig(c, lxc)
 }
 
 func (s *lxcBrokerSuite) TestStartInstanceWithStorage(c *gc.C) {
@@ -257,9 +236,8 @@ func (s *lxcBrokerSuite) TestStartInstanceWithStorage(c *gc.C) {
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
 	s.assertInstances(c, lxc)
 	// Check storage config.
-	containerConfigContents, err := ioutil.ReadFile(filepath.Join(s.LxcDir, string(lxc.Id()), "config"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(containerConfigContents), jc.Contains, "lxc.aa_profile = lxc-container-default-with-mounting")
+	AssertFileContents(c, jc.Contains, filepath.Join(s.LxcDir, string(lxc.Id()), "config"),
+		"lxc.aa_profile = lxc-container-default-with-mounting")
 }
 
 func (s *lxcBrokerSuite) TestStartInstanceLoopMountsDisallowed(c *gc.C) {
@@ -331,10 +309,8 @@ func (s *lxcBrokerSuite) TestStartInstanceWithBridgeEnviron(c *gc.C) {
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
 	s.assertInstances(c, lxc)
 	// Uses default network config
-	lxcConfContents, err := ioutil.ReadFile(filepath.Join(s.ContainerDir, string(lxc.Id()), "lxc.conf"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.type = veth")
-	c.Assert(string(lxcConfContents), jc.Contains, "lxc.network.link = br0")
+	AssertFileContents(c, jc.Contains, filepath.Join(s.ContainerDir, string(lxc.Id()), "lxc.conf"),
+		"lxc.network.type = veth", "lxc.network.link = br0")
 }
 
 func (s *lxcBrokerSuite) TestStopInstance(c *gc.C) {


### PR DESCRIPTION
Fixes for race conditions in LXC and KVM tests.
GetContainerInterfaceInfo not called when address allocation is disabled.
MaintainInstance implemented for KVM broker
Adding a route that already exists no longer results in an error.

(Review request: http://reviews.vapour.ws/r/1936/)