### PR TITLE
Allow agent version to be pinned when bootstrapping

### DIFF
--- a/cmd/juju/bootstrap_test.go
+++ b/cmd/juju/bootstrap_test.go
@@ -338,6 +338,22 @@ var bootstrapTests = []bootstrapTest{{
 	info: "additional args",
 	args: []string{"anything", "else"},
 	err:  `unrecognized args: \["anything" "else"\]`,
+}, {
+	info: "--agent-version with --upload-tools",
+	args: []string{"--agent-version", "1.1.0", "--upload-tools"},
+	err:  `--agent-version and --upload-tools can't be used together`,
+}, {
+	info: "--agent-version with --no-auto-upgrade",
+	args: []string{"--agent-version", "1.1.0", "--no-auto-upgrade"},
+	err:  `--agent-version and --no-auto-upgrade can't be used together`,
+}, {
+	info: "invalid --agent-version value",
+	args: []string{"--agent-version", "foo"},
+	err:  `invalid version "foo"`,
+}, {
+	info: "agent-version doesn't match client version major.minor",
+	args: []string{"--agent-version", "666.666.0"},
+	err:  `requested agent version major.minor mismatch`,
 }}
 
 func (s *BootstrapSuite) TestRunEnvNameMissing(c *gc.C) {
@@ -633,6 +649,68 @@ func (s *BootstrapSuite) TestBootstrapCalledWithMetadataDir(c *gc.C) {
 		"--metadata-source", sourceDir, "--constraints", "mem=4G",
 	)
 	c.Assert(_bootstrap.args.MetadataDir, gc.Equals, sourceDir)
+}
+
+func (s *BootstrapSuite) TestBootstrapWithVersionNumber(c *gc.C) {
+	resetJujuHome(c, "devenv")
+
+	_bootstrap := &fakeBootstrapFuncs{}
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return _bootstrap
+	})
+
+	currentVersion := version.Current
+	currentVersion.Major = 2
+	currentVersion.Minor = 3
+	s.PatchValue(&version.Current, currentVersion)
+	coretesting.RunCommand(
+		c, envcmd.Wrap(&BootstrapCommand{}),
+		"--agent-version", "2.3.4",
+	)
+	c.Assert(_bootstrap.args.AgentVersion, gc.NotNil)
+	c.Assert(*_bootstrap.args.AgentVersion, gc.Equals, version.MustParse("2.3.4"))
+}
+
+func (s *BootstrapSuite) TestBootstrapWithBinaryVersionNumber(c *gc.C) {
+	resetJujuHome(c, "devenv")
+
+	_bootstrap := &fakeBootstrapFuncs{}
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return _bootstrap
+	})
+
+	currentVersion := version.Current
+	currentVersion.Major = 2
+	currentVersion.Minor = 3
+	s.PatchValue(&version.Current, currentVersion)
+	coretesting.RunCommand(
+		c, envcmd.Wrap(&BootstrapCommand{}),
+		"--agent-version", "2.3.4-trusty-amd64",
+	)
+	c.Assert(_bootstrap.args.AgentVersion, gc.NotNil)
+	c.Assert(*_bootstrap.args.AgentVersion, gc.Equals, version.MustParse("2.3.4"))
+}
+
+func (s *BootstrapSuite) TestBootstrapWithNoAutoUpgrade(c *gc.C) {
+	resetJujuHome(c, "devenv")
+
+	_bootstrap := &fakeBootstrapFuncs{}
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return _bootstrap
+	})
+
+	currentVersion := version.Current
+	currentVersion.Major = 2
+	currentVersion.Minor = 22
+	currentVersion.Patch = 46
+	currentVersion.Series = "trusty"
+	currentVersion.Arch = "amd64"
+	s.PatchValue(&version.Current, currentVersion)
+	coretesting.RunCommand(
+		c, envcmd.Wrap(&BootstrapCommand{}),
+		"--no-auto-upgrade",
+	)
+	c.Assert(*_bootstrap.args.AgentVersion, gc.Equals, version.MustParse("2.22.46"))
 }
 
 func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -6,6 +6,7 @@ package bootstrap_test
 import (
 	"fmt"
 	"runtime"
+	"strings"
 	stdtesting "testing"
 
 	"github.com/juju/errors"
@@ -28,7 +29,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
-	"strings"
 )
 
 func TestPackage(t *stdtesting.T) {
@@ -340,7 +340,7 @@ func (s *bootstrapSuite) TestBootstrapNoSpecificVersion(c *gc.C) {
 	})
 }
 
-func (s *bootstrapSuite) TestBootstrapSpecificVersionClientMajorMismatch(c *gc.C) {
+func (s *bootstrapSuite) TestBootstrapSpecificVersionClientMinorMismatch(c *gc.C) {
 	// bootstrap using a specified version only works if the patch number is different.
 	// The bootstrap client major and minor versions need to match the tools asked for.
 	toolsVersion := version.MustParse("10.11.12")
@@ -349,7 +349,7 @@ func (s *bootstrapSuite) TestBootstrapSpecificVersionClientMajorMismatch(c *gc.C
 	c.Assert(bootstrapCount, gc.Equals, 0)
 }
 
-func (s *bootstrapSuite) TestBootstrapSpecificVersionClientMinorMismatch(c *gc.C) {
+func (s *bootstrapSuite) TestBootstrapSpecificVersionClientMajorMismatch(c *gc.C) {
 	// bootstrap using a specified version only works if the patch number is different.
 	// The bootstrap client major and minor versions need to match the tools asked for.
 	toolsVersion := version.MustParse("10.11.12")

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -28,6 +28,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
+	"strings"
 )
 
 func TestPackage(t *stdtesting.T) {
@@ -282,6 +283,79 @@ func (s *bootstrapSuite) TestBootstrapMetadataImagesMissing(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(datasources, gc.HasLen, 1)
 	c.Assert(datasources[0].Description(), gc.Equals, "default cloud images")
+}
+
+func (s *bootstrapSuite) setupBootstrapSpecificVersion(
+	c *gc.C, clientMajor, clientMinor int, toolsVersion *version.Number,
+) (error, int, version.Number) {
+	currentVersion := version.Current
+	currentVersion.Major = clientMajor
+	currentVersion.Minor = clientMinor
+	currentVersion.Series = "trusty"
+	currentVersion.Arch = "amd64"
+	s.PatchValue(&version.Current, currentVersion)
+
+	env := newEnviron("foo", useDefaultKeys, nil)
+	s.setDummyStorage(c, env)
+	envtools.RegisterToolsDataSourceFunc("local storage", func(environs.Environ) (simplestreams.DataSource, error) {
+		return storage.NewStorageSimpleStreamsDataSource("test datasource", env.storage, "tools"), nil
+	})
+	defer envtools.UnregisterToolsDataSourceFunc("local storage")
+
+	toolsBinaries := []version.Binary{
+		version.MustParseBinary("10.11.12-trusty-amd64"),
+		version.MustParseBinary("10.11.13-trusty-amd64"),
+	}
+	_, err := envtesting.UploadFakeToolsVersions(env.storage, "released", "released", toolsBinaries...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
+		AgentVersion: toolsVersion,
+	})
+	vers, _ := env.cfg.AgentVersion()
+	return err, env.bootstrapCount, vers
+}
+
+func (s *bootstrapSuite) TestBootstrapSpecificVersion(c *gc.C) {
+	toolsVersion := version.MustParse("10.11.12")
+	err, bootstrapCount, vers := s.setupBootstrapSpecificVersion(c, 10, 11, &toolsVersion)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bootstrapCount, gc.Equals, 1)
+	c.Assert(vers, gc.DeepEquals, version.Number{
+		Major: 10,
+		Minor: 11,
+		Patch: 12,
+	})
+}
+
+func (s *bootstrapSuite) TestBootstrapNoSpecificVersion(c *gc.C) {
+	// bootstrap with no specific version will use latest major.minor tools version.
+	err, bootstrapCount, vers := s.setupBootstrapSpecificVersion(c, 10, 11, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bootstrapCount, gc.Equals, 1)
+	c.Assert(vers, gc.DeepEquals, version.Number{
+		Major: 10,
+		Minor: 11,
+		Patch: 13,
+	})
+}
+
+func (s *bootstrapSuite) TestBootstrapSpecificVersionClientMajorMismatch(c *gc.C) {
+	// bootstrap using a specified version only works if the patch number is different.
+	// The bootstrap client major and minor versions need to match the tools asked for.
+	toolsVersion := version.MustParse("10.11.12")
+	err, bootstrapCount, _ := s.setupBootstrapSpecificVersion(c, 10, 1, &toolsVersion)
+	c.Assert(strings.Replace(err.Error(), "\n", "", -1), gc.Matches, ".* no tools are available .*")
+	c.Assert(bootstrapCount, gc.Equals, 0)
+}
+
+func (s *bootstrapSuite) TestBootstrapSpecificVersionClientMinorMismatch(c *gc.C) {
+	// bootstrap using a specified version only works if the patch number is different.
+	// The bootstrap client major and minor versions need to match the tools asked for.
+	toolsVersion := version.MustParse("10.11.12")
+	err, bootstrapCount, _ := s.setupBootstrapSpecificVersion(c, 1, 11, &toolsVersion)
+	c.Assert(strings.Replace(err.Error(), "\n", "", -1), gc.Matches, ".* no tools are available .*")
+	c.Assert(bootstrapCount, gc.Equals, 0)
 }
 
 type bootstrapEnviron struct {

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -54,7 +54,7 @@ func validateUploadAllowed(env environs.Environ, toolsArch *string) error {
 // including tools that may be locally built and then
 // uploaded. Tools that need to be built will have an
 // empty URL.
-func findAvailableTools(env environs.Environ, arch *string, upload bool) (coretools.List, error) {
+func findAvailableTools(env environs.Environ, vers *version.Number, arch *string, upload bool) (coretools.List, error) {
 	if upload {
 		// We're forcing an upload: ensure we can do so.
 		if err := validateUploadAllowed(env, arch); err != nil {
@@ -66,9 +66,13 @@ func findAvailableTools(env environs.Environ, arch *string, upload bool) (coreto
 	// We're not forcing an upload, so look for tools
 	// in the environment's simplestreams search paths
 	// for existing tools.
-	var vers *version.Number
-	if agentVersion, ok := env.Config().AgentVersion(); ok {
-		vers = &agentVersion
+
+	// If the user hasn't asked for a specified tools version, see if
+	// one is configured in the environment.
+	if vers == nil {
+		if agentVersion, ok := env.Config().AgentVersion(); ok {
+			vers = &agentVersion
+		}
 	}
 	logger.Debugf("looking for bootstrap tools: version=%v", vers)
 	toolsList, findToolsErr := findBootstrapTools(env, vers, arch)

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -116,7 +116,7 @@ func (s *toolsSuite) TestFindAvailableToolsError(c *gc.C) {
 		return nil, errors.New("splat")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	_, err := bootstrap.FindAvailableTools(env, nil, false)
+	_, err := bootstrap.FindAvailableTools(env, nil, nil, false)
 	c.Assert(err, gc.ErrorMatches, "splat")
 }
 
@@ -127,7 +127,7 @@ func (s *toolsSuite) TestFindAvailableToolsNoUpload(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"agent-version": "1.17.1",
 	})
-	_, err := bootstrap.FindAvailableTools(env, nil, false)
+	_, err := bootstrap.FindAvailableTools(env, nil, nil, false)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -141,7 +141,7 @@ func (s *toolsSuite) TestFindAvailableToolsForceUpload(c *gc.C) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	uploadedTools, err := bootstrap.FindAvailableTools(env, nil, true)
+	uploadedTools, err := bootstrap.FindAvailableTools(env, nil, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uploadedTools, gc.Not(gc.HasLen), 0)
 	c.Assert(findToolsCalled, gc.Equals, 0)
@@ -163,9 +163,37 @@ func (s *toolsSuite) TestFindAvailableToolsForceUploadInvalidArch(c *gc.C) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	_, err := bootstrap.FindAvailableTools(env, nil, true)
+	_, err := bootstrap.FindAvailableTools(env, nil, nil, true)
 	c.Assert(err, gc.ErrorMatches, `environment "foo" of type dummy does not support instances running on "i386"`)
 	c.Assert(findToolsCalled, gc.Equals, 0)
+}
+
+func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
+	currentVersion := version.Current
+	currentVersion.Major = 2
+	currentVersion.Minor = 3
+	s.PatchValue(&version.Current, currentVersion)
+	s.PatchValue(bootstrap.FindTools, func(_ environs.Environ, major, minor int, f tools.Filter) (tools.List, error) {
+		c.Assert(f.Number.Major, gc.Equals, 10)
+		c.Assert(f.Number.Minor, gc.Equals, 11)
+		c.Assert(f.Number.Patch, gc.Equals, 12)
+		return []*tools.Tools{
+			&tools.Tools{
+				Version: currentVersion,
+				URL:     "http://testing.invalid/tools.tar.gz",
+			},
+		}, nil
+	})
+	env := newEnviron("foo", useDefaultKeys, nil)
+	toolsVersion := version.MustParse("10.11.12")
+	result, err := bootstrap.FindAvailableTools(env, &toolsVersion, nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, tools.List{
+		&tools.Tools{
+			Version: currentVersion,
+			URL:     "http://testing.invalid/tools.tar.gz",
+		},
+	})
 }
 
 func (s *toolsSuite) TestFindAvailableToolsAutoUpload(c *gc.C) {
@@ -182,7 +210,7 @@ func (s *toolsSuite) TestFindAvailableToolsAutoUpload(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"agent-stream": "proposed"})
-	availableTools, err := bootstrap.FindAvailableTools(env, nil, false)
+	availableTools, err := bootstrap.FindAvailableTools(env, nil, nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(availableTools), jc.GreaterThan, 1)
 	c.Assert(env.supportedArchitecturesCount, gc.Equals, 1)
@@ -221,7 +249,7 @@ func (s *toolsSuite) TestFindAvailableToolsCompleteNoValidate(c *gc.C) {
 		return allTools, nil
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	availableTools, err := bootstrap.FindAvailableTools(env, nil, false)
+	availableTools, err := bootstrap.FindAvailableTools(env, nil, nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(availableTools, gc.HasLen, len(allTools))
 	c.Assert(env.supportedArchitecturesCount, gc.Equals, 0)

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -173,10 +173,12 @@ func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
 	currentVersion.Major = 2
 	currentVersion.Minor = 3
 	s.PatchValue(&version.Current, currentVersion)
+	var findToolsCalled int
 	s.PatchValue(bootstrap.FindTools, func(_ environs.Environ, major, minor int, f tools.Filter) (tools.List, error) {
 		c.Assert(f.Number.Major, gc.Equals, 10)
 		c.Assert(f.Number.Minor, gc.Equals, 11)
 		c.Assert(f.Number.Patch, gc.Equals, 12)
+		findToolsCalled++
 		return []*tools.Tools{
 			&tools.Tools{
 				Version: currentVersion,
@@ -188,6 +190,7 @@ func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
 	toolsVersion := version.MustParse("10.11.12")
 	result, err := bootstrap.FindAvailableTools(env, &toolsVersion, nil, false)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(findToolsCalled, gc.Equals, 1)
 	c.Assert(result, jc.DeepEquals, tools.List{
 		&tools.Tools{
 			Version: currentVersion,


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1455260

juju bootstrap gains a new "agent-version" argument, used to ensure that only the explicitly specified version of agent tools is used to run the agents.

The agent-verson arg can be a numeric version (eg 1.2.3) or the full binary version (eg 1.2.3-trusty-amd64). In the later case just the number is extracted and used. This is to allow `juju version` to be used to pin the tools version.

An alias for "match the client version" is --no-auto-upgrade.

The agent-version number specified must match the client major and minor version numbers to help better ensure compatibility. 

(Review request: http://reviews.vapour.ws/r/1937/)