### PR TITLE
Fix 1459093: Upgrade fails if there's an unknown series in streams 

### DIFF
--- a/cmd/juju/upgradejuju_test.go
+++ b/cmd/juju/upgradejuju_test.go
@@ -505,6 +505,22 @@ upgrade to this version by running
     juju upgrade-juju --version="2.1.3"
 `,
 		},
+		{
+			about:          "dry run ignores unknown series",
+			cmdArgs:        []string{"--dry-run"},
+			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "1.2.3-myawesomeseries-amd64"},
+			currentVersion: "2.0.0-quantal-amd64",
+			agentVersion:   "2.0.0",
+			expectedCmdOutput: `available tools:
+    2.1.0-quantal-amd64
+    2.1.2-quantal-i386
+    2.1.3-quantal-amd64
+best version:
+    2.1.3
+upgrade to this version by running
+    juju upgrade-juju --version="2.1.3"
+`,
+		},
 	}
 
 	for i, test := range tests {
@@ -526,7 +542,10 @@ upgrade to this version by running
 		c.Assert(err, jc.ErrorIsNil)
 		versions := make([]version.Binary, len(test.tools))
 		for i, v := range test.tools {
-			versions[i] = version.MustParseBinary(v)
+			versions[i], err = version.ParseBinary(v)
+			if err != nil {
+				c.Assert(err, jc.Satisfies, version.IsUnknownOSForSeriesError)
+			}
 		}
 		if len(versions) > 0 {
 			stor, err := filestorage.NewFileStorageWriter(toolsDir)
@@ -547,6 +566,23 @@ upgrade to this version by running
 		output := coretesting.Stderr(ctx)
 		c.Assert(output, gc.Equals, test.expectedCmdOutput)
 	}
+}
+
+func (s *UpgradeJujuSuite) TestUpgradeUnknownSeriesInStreams(c *gc.C) {
+	fakeAPI := NewFakeUpgradeJujuAPI(c, s.State)
+	fakeAPI.addTools("2.1.0-weird-amd64")
+	fakeAPI.patch(s)
+
+	cmd := &UpgradeJujuCommand{}
+	err := coretesting.InitCommand(envcmd.Wrap(cmd), []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cmd.Run(coretesting.Context(c))
+	c.Assert(err, gc.IsNil)
+
+	// ensure find tools was called
+	c.Assert(fakeAPI.findToolsCalled, jc.IsTrue)
+	c.Assert(fakeAPI.tools, gc.DeepEquals, []string{"2.1.0-weird-amd64", fakeAPI.nextVersion.String()})
 }
 
 func (s *UpgradeJujuSuite) TestUpgradeInProgress(c *gc.C) {
@@ -658,18 +694,28 @@ type fakeUpgradeJujuAPI struct {
 	setVersionErr             error
 	abortCurrentUpgradeCalled bool
 	setVersionCalledWith      version.Number
+	tools                     []string
+	findToolsCalled           bool
 }
 
 func (a *fakeUpgradeJujuAPI) reset() {
 	a.setVersionErr = nil
 	a.abortCurrentUpgradeCalled = false
 	a.setVersionCalledWith = version.Number{}
+	a.tools = []string{}
+	a.findToolsCalled = false
 }
 
 func (a *fakeUpgradeJujuAPI) patch(s *UpgradeJujuSuite) {
 	s.PatchValue(&getUpgradeJujuAPI, func(*UpgradeJujuCommand) (upgradeJujuAPI, error) {
 		return a, nil
 	})
+}
+
+func (a *fakeUpgradeJujuAPI) addTools(tools ...string) {
+	for _, tool := range tools {
+		a.tools = append(a.tools, tool)
+	}
 }
 
 func (a *fakeUpgradeJujuAPI) EnvironmentGet() (map[string]interface{}, error) {
@@ -683,7 +729,9 @@ func (a *fakeUpgradeJujuAPI) EnvironmentGet() (map[string]interface{}, error) {
 func (a *fakeUpgradeJujuAPI) FindTools(majorVersion, minorVersion int, series, arch string) (
 	result params.FindToolsResult, err error,
 ) {
-	tools := toolstesting.MakeTools(a.c, a.c.MkDir(), "released", []string{a.nextVersion.String()})
+	a.findToolsCalled = true
+	a.tools = append(a.tools, a.nextVersion.String())
+	tools := toolstesting.MakeTools(a.c, a.c.MkDir(), "released", a.tools)
 	return params.FindToolsResult{
 		List:  tools,
 		Error: nil,

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -239,7 +239,7 @@ type imageKey struct {
 // appendMatchingImages updates matchingImages with image metadata records from images which belong to the
 // specified region. If an image already exists in matchingImages, it is not overwritten.
 func appendMatchingImages(source simplestreams.DataSource, matchingImages []interface{},
-	images map[string]interface{}, cons simplestreams.LookupConstraint) []interface{} {
+	images map[string]interface{}, cons simplestreams.LookupConstraint) ([]interface{}, error) {
 
 	imagesMap := make(map[imageKey]*ImageMetadata, len(matchingImages))
 	for _, val := range matchingImages {
@@ -255,7 +255,7 @@ func appendMatchingImages(source simplestreams.DataSource, matchingImages []inte
 			matchingImages = append(matchingImages, im)
 		}
 	}
-	return matchingImages
+	return matchingImages, nil
 }
 
 // GetLatestImageIdMetadata is provided so it can be call by tests outside the imagemetadata package.

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -322,7 +322,7 @@ const (
 	MirrorFormat  = "mirrors:1.0"
 )
 
-type appendMatchingFunc func(DataSource, []interface{}, map[string]interface{}, LookupConstraint) []interface{}
+type appendMatchingFunc func(DataSource, []interface{}, map[string]interface{}, LookupConstraint) ([]interface{}, error)
 
 // ValueParams contains the information required to pull out from the metadata structs of a particular type.
 type ValueParams struct {
@@ -1003,7 +1003,10 @@ func GetLatestMetadata(metadata *CloudMetadata, cons LookupConstraint, source Da
 		}
 		sort.Sort(bv)
 		for _, itemCollVersion := range bv {
-			matchingItems = filterFunc(source, matchingItems, itemCollVersion.ItemCollection.Items, cons)
+			matchingItems, err = filterFunc(source, matchingItems, itemCollVersion.ItemCollection.Items, cons)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 	}
 	return matchingItems, nil

--- a/environs/tools/marshal_test.go
+++ b/environs/tools/marshal_test.go
@@ -52,7 +52,8 @@ var expectedIndex = `{
             "path": "streams/v1/com.ubuntu.juju-proposed-tools.json",
             "products": [
                 "com.ubuntu.juju:14.04:arm64",
-                "com.ubuntu.juju:14.10:ppc64el"
+                "com.ubuntu.juju:14.10:ppc64el",
+                "com.ubuntu.juju:unknown:amd64"
             ]
         },
         "com.ubuntu.juju:released:tools": {
@@ -63,7 +64,8 @@ var expectedIndex = `{
             "products": [
                 "com.ubuntu.juju:12.04:amd64",
                 "com.ubuntu.juju:12.04:arm",
-                "com.ubuntu.juju:13.10:arm"
+                "com.ubuntu.juju:13.10:arm",
+                "com.ubuntu.juju:unknown:amd64"
             ]
         }
     },
@@ -81,7 +83,8 @@ var expectedLegacyIndex = `{
             "products": [
                 "com.ubuntu.juju:12.04:amd64",
                 "com.ubuntu.juju:12.04:arm",
-                "com.ubuntu.juju:13.10:arm"
+                "com.ubuntu.juju:13.10:arm",
+                "com.ubuntu.juju:unknown:amd64"
             ]
         }
     },
@@ -147,6 +150,34 @@ var expectedReleasedProducts = `{
                     }
                 }
             }
+        },
+        "com.ubuntu.juju:unknown:amd64": {
+            "version": "4.3.2.1",
+            "arch": "amd64",
+            "versions": {
+                "19700101": {
+                    "items": {
+                        "4.3.2.1-xuanhuaceratops-amd64": {
+                            "release": "xuanhuaceratops",
+                            "version": "4.3.2.1",
+                            "arch": "amd64",
+                            "size": 42,
+                            "path": "dinodance.tar.gz",
+                            "ftype": "tar.gz",
+                            "sha256": ""
+                        },
+                        "5.4.3.2-xuanhanosaurus-amd64": {
+                            "release": "xuanhanosaurus",
+                            "version": "5.4.3.2",
+                            "arch": "amd64",
+                            "size": 42,
+                            "path": "dinodisco.tar.gz",
+                            "ftype": "tar.gz",
+                            "sha256": ""
+                        }
+                    }
+                }
+            }
         }
     },
     "updated": "Thu, 01 Jan 1970 00:00:00 +0000",
@@ -193,6 +224,34 @@ var expectedProposedProducts = `{
                     }
                 }
             }
+        },
+        "com.ubuntu.juju:unknown:amd64": {
+            "version": "4.3.2.1",
+            "arch": "amd64",
+            "versions": {
+                "19700101": {
+                    "items": {
+                        "4.3.2.1-xuanhuaceratops-amd64": {
+                            "release": "xuanhuaceratops",
+                            "version": "4.3.2.1",
+                            "arch": "amd64",
+                            "size": 42,
+                            "path": "dinodance.tar.gz",
+                            "ftype": "tar.gz",
+                            "sha256": ""
+                        },
+                        "5.4.3.2-xuanhanosaurus-amd64": {
+                            "release": "xuanhanosaurus",
+                            "version": "5.4.3.2",
+                            "arch": "amd64",
+                            "size": 42,
+                            "path": "dinodisco.tar.gz",
+                            "ftype": "tar.gz",
+                            "sha256": ""
+                        }
+                    }
+                }
+            }
         }
     },
     "updated": "Thu, 01 Jan 1970 00:00:00 +0000",
@@ -225,6 +284,22 @@ var releasedToolMetadataForTesting = []*tools.ToolsMetadata{
 		FileType: "tar.gz",
 		SHA256:   "afb14e65c794464e378def12cbad6a96f9186d69",
 	},
+	{
+		Release:  "xuanhuaceratops",
+		Version:  "4.3.2.1",
+		Arch:     "amd64",
+		Size:     42,
+		Path:     "dinodance.tar.gz",
+		FileType: "tar.gz",
+	},
+	{
+		Release:  "xuanhanosaurus",
+		Version:  "5.4.3.2",
+		Arch:     "amd64",
+		Size:     42,
+		Path:     "dinodisco.tar.gz",
+		FileType: "tar.gz",
+	},
 }
 
 var proposedToolMetadataForTesting = []*tools.ToolsMetadata{
@@ -242,6 +317,22 @@ var proposedToolMetadataForTesting = []*tools.ToolsMetadata{
 		Arch:     "arm64",
 		Size:     42,
 		Path:     "gotham.tar.gz",
+		FileType: "tar.gz",
+	},
+	{
+		Release:  "xuanhuaceratops",
+		Version:  "4.3.2.1",
+		Arch:     "amd64",
+		Size:     42,
+		Path:     "dinodance.tar.gz",
+		FileType: "tar.gz",
+	},
+	{
+		Release:  "xuanhanosaurus",
+		Version:  "5.4.3.2",
+		Arch:     "amd64",
+		Size:     42,
+		Path:     "dinodisco.tar.gz",
 		FileType: "tar.gz",
 	},
 }

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -353,6 +353,16 @@ func (s *simplestreamsSuite) TestWriteMetadataNoFetch(c *gc.C) {
 			SHA256:  "xyz",
 		},
 	}
+
+	// Add tools with an unknown series
+	vers, err := version.ParseBinary("3.2.1-xuanhuaceratops-amd64")
+	c.Assert(err, jc.Satisfies, version.IsUnknownOSForSeriesError)
+	toolsList = append(toolsList, &coretools.Tools{
+		Version: vers,
+		Size:    456,
+		SHA256:  "wqe",
+	})
+
 	dir := c.MkDir()
 	writer, err := filestorage.NewFileStorageWriter(dir)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -135,8 +135,12 @@ func FindToolsForCloud(sources []simplestreams.DataSource, cloudSpec simplestrea
 	}
 	list = make(coretools.List, len(toolsMetadata))
 	for i, metadata := range toolsMetadata {
+		binary, err := metadata.binary()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		list[i] = &coretools.Tools{
-			Version: metadata.binary(),
+			Version: binary,
 			URL:     metadata.FullPath,
 			Size:    metadata.Size,
 			SHA256:  metadata.SHA256,

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -185,5 +185,5 @@ func (s *environInstanceSuite) TestStartInstanceError(c *gc.C) {
 		InstanceConfig: &instancecfg.InstanceConfig{Tools: toolsVal},
 	})
 	c.Check(res, gc.IsNil)
-	c.Check(err, gc.ErrorMatches, "cannot make user data: invalid series \"\"")
+	c.Check(err, gc.ErrorMatches, "cannot make user data: series \"\" not valid")
 }

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -182,7 +182,7 @@ var findInstanceSpecErrorTests = []struct {
 	{
 		series: "bad",
 		arches: both,
-		err:    `invalid series "bad"`,
+		err:    `unknown version for series: "bad"`,
 	}, {
 		series: testing.FakeDefaultSeries,
 		arches: []string{"arm"},

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -81,7 +81,7 @@ func imageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.
 }
 
 func appendMatchingFunc(source simplestreams.DataSource, matchingImages []interface{},
-	images map[string]interface{}, cons simplestreams.LookupConstraint) []interface{} {
+	images map[string]interface{}, cons simplestreams.LookupConstraint) ([]interface{}, error) {
 
 	for _, val := range images {
 		file := val.(*OvaFileMetadata)
@@ -92,5 +92,5 @@ func appendMatchingFunc(source simplestreams.DataSource, matchingImages []interf
 			matchingImages = append(matchingImages, file)
 		}
 	}
-	return matchingImages
+	return matchingImages, nil
 }

--- a/version/supportedseries_test.go
+++ b/version/supportedseries_test.go
@@ -42,7 +42,11 @@ var getOSFromSeriesTests = []struct {
 }, {
 	series: "centos7",
 	want:   version.CentOS,
-}}
+}, {
+	series: "",
+	err:    "series \"\" not valid",
+},
+}
 
 func (s *supportedSeriesSuite) TestGetOSFromSeries(c *gc.C) {
 	for _, t := range getOSFromSeriesTests {
@@ -54,6 +58,12 @@ func (s *supportedSeriesSuite) TestGetOSFromSeries(c *gc.C) {
 			c.Assert(got, gc.Equals, t.want)
 		}
 	}
+}
+
+func (s *supportedSeriesSuite) TestUnknownOSFromSeries(c *gc.C) {
+	_, err := version.GetOSFromSeries("Xuanhuaceratops")
+	c.Assert(err, jc.Satisfies, version.IsUnknownOSForSeriesError)
+	c.Assert(err, gc.ErrorMatches, `unknown OS for series: "Xuanhuaceratops"`)
 }
 
 func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {

--- a/version/version.go
+++ b/version/version.go
@@ -191,12 +191,9 @@ func ParseBinary(s string) (Binary, error) {
 	}
 	v.Series = m[7]
 	v.Arch = m[8]
-	operatingSystem, err := GetOSFromSeries(v.Series)
-	if err != nil {
-		return Binary{}, err
-	}
-	v.OS = operatingSystem
-	return v, nil
+	var err error
+	v.OS, err = GetOSFromSeries(v.Series)
+	return v, err
 }
 
 // Parse parses the version, which is of the form 1.2.3


### PR DESCRIPTION
Allow tools metadata with an unknown OS to be merged into
simplestreams. Such tools will not have a known series version.
Introduce an "unknown" series version. Use this to construct the
metadata's productId under which these tools are catalogued in 
the simplestreams JSON output.

In addition to testing the above, test that upgrade-juju succeeds with
an unknown series in simplestreams.

(Review request: http://reviews.vapour.ws/r/1939/)