### PR TITLE
Implement two useful state methods.

### DIFF
--- a/state/collections_test.go
+++ b/state/collections_test.go
@@ -34,8 +34,8 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 
 	c.Check(coll.Name(), gc.Equals, state.UsersC)
 
-	s.factory.MakeUser(c, &factory.UserParams{Name: "foo", DisplayName: "Ms Foo"})
-	s.factory.MakeUser(c, &factory.UserParams{Name: "bar"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "foo", DisplayName: "Ms Foo"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "bar"})
 
 	collSnapshot := newCollectionSnapshot(c, coll.Underlying())
 
@@ -139,9 +139,9 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 	// The machines collection requires filtering by env UUID. Set up
 	// 2 environments with machines in each.
-	m0 := s.factory.MakeMachine(c, nil)
-	s.factory.MakeMachine(c, nil)
-	st1 := s.factory.MakeEnvironment(c, nil)
+	m0 := s.Factory.MakeMachine(c, nil)
+	s.Factory.MakeMachine(c, nil)
+	st1 := s.Factory.MakeEnvironment(c, nil)
 	defer st1.Close()
 	f1 := factory.NewFactory(st1)
 	otherM0 := f1.MakeMachine(c, &factory.MachineParams{Series: "trusty"})

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
 )
 
 // TestPackage integrates the tests into gotest.
@@ -34,7 +33,6 @@ type ConnSuite struct {
 	units        *mgo.Collection
 	stateServers *mgo.Collection
 	policy       statetesting.MockPolicy
-	factory      *factory.Factory
 	envTag       names.EnvironTag
 }
 
@@ -47,7 +45,6 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	cs.StateSuite.SetUpTest(c)
 
 	cs.envTag = cs.State.EnvironTag()
-	cs.factory = factory.NewFactory(cs.State)
 
 	jujuDB := cs.MgoSuite.Session.DB("juju")
 	cs.annotations = jujuDB.C("annotations")

--- a/state/environ.go
+++ b/state/environ.go
@@ -81,6 +81,25 @@ func (st *State) GetEnvironment(tag names.EnvironTag) (*Environment, error) {
 	return env, nil
 }
 
+// AllEnvironments returns all the environments in the system.
+func (st *State) AllEnvironments() ([]*Environment, error) {
+	environments, closer := st.getCollection(environmentsC)
+	defer closer()
+
+	var envDocs []environmentDoc
+	err := environments.Find(nil).All(&envDocs)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*Environment, len(envDocs))
+	for i, doc := range envDocs {
+		result[i] = &Environment{st: st, doc: doc}
+	}
+
+	return result, nil
+}
+
 // NewEnvironment creates a new environment with its own UUID and
 // prepares it for use. Environment and State instances for the new
 // environment are returned.

--- a/state/envuser_test.go
+++ b/state/envuser_test.go
@@ -254,6 +254,21 @@ func (s *EnvUserSuite) TestIsSystemAdministrator(c *gc.C) {
 	c.Assert(isAdmin, jc.IsTrue)
 }
 
+func (s *EnvUserSuite) TestIsSystemAdministratorFromOtherState(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoEnvUser: true})
+
+	otherState := s.Factory.MakeEnvironment(c, &factory.EnvParams{Owner: user.UserTag()})
+	defer otherState.Close()
+
+	isAdmin, err := otherState.IsSystemAdministrator(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isAdmin, jc.IsFalse)
+
+	isAdmin, err = otherState.IsSystemAdministrator(s.Owner)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isAdmin, jc.IsTrue)
+}
+
 // UUIDOrder is used to sort the environments into a stable order
 type UUIDOrder []*state.Environment
 

--- a/state/envuser_test.go
+++ b/state/envuser_test.go
@@ -26,8 +26,8 @@ var _ = gc.Suite(&EnvUserSuite{})
 
 func (s *EnvUserSuite) TestAddEnvironmentUser(c *gc.C) {
 	now := state.NowToTheSecond()
-	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validusername", NoEnvUser: true})
-	createdBy := s.factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", NoEnvUser: true})
+	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	envUser, err := s.State.AddEnvironmentUser(user.UserTag(), createdBy.UserTag(), "")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -53,7 +53,7 @@ func (s *EnvUserSuite) TestAddEnvironmentUser(c *gc.C) {
 func (s *EnvUserSuite) TestCaseSensitiveEnvUserErrors(c *gc.C) {
 	env, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	s.factory.MakeEnvUser(c, &factory.EnvUserParams{User: "Bob@ubuntuone"})
+	s.Factory.MakeEnvUser(c, &factory.EnvUserParams{User: "Bob@ubuntuone"})
 
 	_, err = s.State.AddEnvironmentUser(names.NewUserTag("boB@ubuntuone"), env.Owner(), "")
 	c.Assert(err, gc.ErrorMatches, `environment user "boB@ubuntuone" already exists`)
@@ -77,7 +77,7 @@ func (s *EnvUserSuite) TestCaseInsensitiveLookupInMultiEnvirons(c *gc.C) {
 		}
 	}
 
-	otherSt := s.factory.MakeEnvironment(c, nil)
+	otherSt := s.Factory.MakeEnvironment(c, nil)
 	defer otherSt.Close()
 	assertIsolated(s.State, otherSt,
 		"Bob@UbuntuOne",
@@ -92,27 +92,27 @@ func (s *EnvUserSuite) TestCaseInsensitiveLookupInMultiEnvirons(c *gc.C) {
 }
 
 func (s *EnvUserSuite) TestAddEnvironmentDisplayName(c *gc.C) {
-	envUserDefault := s.factory.MakeEnvUser(c, nil)
+	envUserDefault := s.Factory.MakeEnvUser(c, nil)
 	c.Assert(envUserDefault.DisplayName(), gc.Matches, "display name-[0-9]*")
 
-	envUser := s.factory.MakeEnvUser(c, &factory.EnvUserParams{DisplayName: "Override user display name"})
+	envUser := s.Factory.MakeEnvUser(c, &factory.EnvUserParams{DisplayName: "Override user display name"})
 	c.Assert(envUser.DisplayName(), gc.Equals, "Override user display name")
 }
 
 func (s *EnvUserSuite) TestAddEnvironmentNoUserFails(c *gc.C) {
-	createdBy := s.factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
+	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
 	_, err := s.State.AddEnvironmentUser(names.NewLocalUserTag("validusername"), createdBy.UserTag(), "")
 	c.Assert(err, gc.ErrorMatches, `user "validusername" does not exist locally: user "validusername" not found`)
 }
 
 func (s *EnvUserSuite) TestAddEnvironmentNoCreatedByUserFails(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
 	_, err := s.State.AddEnvironmentUser(user.UserTag(), names.NewLocalUserTag("createdby"), "")
 	c.Assert(err, gc.ErrorMatches, `createdBy user "createdby" does not exist locally: user "createdby" not found`)
 }
 
 func (s *EnvUserSuite) TestRemoveEnvironmentUser(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
 	_, err := s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -124,15 +124,15 @@ func (s *EnvUserSuite) TestRemoveEnvironmentUser(c *gc.C) {
 }
 
 func (s *EnvUserSuite) TestRemoveEnvironmentUserFails(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{NoEnvUser: true})
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoEnvUser: true})
 	err := s.State.RemoveEnvironmentUser(user.UserTag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *EnvUserSuite) TestUpdateLastConnection(c *gc.C) {
 	now := state.NowToTheSecond()
-	createdBy := s.factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
-	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
+	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
 	envUser, err := s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = envUser.UpdateLastConnection()
@@ -151,14 +151,14 @@ func (s *EnvUserSuite) TestEnvironmentsForUserNone(c *gc.C) {
 }
 
 func (s *EnvUserSuite) TestEnvironmentsForUserNewLocalUser(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{NoEnvUser: true})
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoEnvUser: true})
 	environments, err := s.State.EnvironmentsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(environments, gc.HasLen, 0)
 }
 
 func (s *EnvUserSuite) TestEnvironmentsForUser(c *gc.C) {
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 	environments, err := s.State.EnvironmentsForUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(environments, gc.HasLen, 1)
@@ -198,7 +198,7 @@ func (s *EnvUserSuite) checkSameEnvironment(c *gc.C, env1, env2 *state.Environme
 }
 
 func (s *EnvUserSuite) newEnvWithUser(c *gc.C, name string, user names.UserTag) *state.Environment {
-	envState := s.factory.MakeEnvironment(c, &factory.EnvParams{Name: name})
+	envState := s.Factory.MakeEnvironment(c, &factory.EnvParams{Name: name})
 	defer envState.Close()
 	newEnv, err := envState.Environment()
 	c.Assert(err, jc.ErrorIsNil)
@@ -236,6 +236,22 @@ func (s *EnvUserSuite) TestEnvironmentsForUserMultiple(c *gc.C) {
 	for i := range expected {
 		s.checkSameEnvironment(c, environments[i].Environment, expected[i])
 	}
+}
+
+func (s *EnvUserSuite) TestIsSystemAdministrator(c *gc.C) {
+	isAdmin, err := s.State.IsSystemAdministrator(s.Owner)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isAdmin, jc.IsTrue)
+
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoEnvUser: true})
+	isAdmin, err = s.State.IsSystemAdministrator(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isAdmin, jc.IsFalse)
+
+	s.Factory.MakeEnvUser(c, &factory.EnvUserParams{User: user.UserTag().Username()})
+	isAdmin, err = s.State.IsSystemAdministrator(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isAdmin, jc.IsTrue)
 }
 
 // UUIDOrder is used to sort the environments into a stable order

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -115,12 +115,12 @@ func (s *LogsSuite) TestPruneLogsBySize(c *gc.C) {
 	startingLogsS0 := 10
 	s.generateLogs(c, s0, now, startingLogsS0)
 
-	s1 := s.factory.MakeEnvironment(c, nil)
+	s1 := s.Factory.MakeEnvironment(c, nil)
 	defer s1.Close()
 	startingLogsS1 := 10000
 	s.generateLogs(c, s1, now, startingLogsS1)
 
-	s2 := s.factory.MakeEnvironment(c, nil)
+	s2 := s.Factory.MakeEnvironment(c, nil)
 	defer s2.Close()
 	startingLogsS2 := 12000
 	s.generateLogs(c, s2, now, startingLogsS2)

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -77,9 +77,9 @@ func assertUnitDead(c *gc.C, unit *state.Unit) {
 }
 
 func (s *MetricSuite) assertAddUnit(c *gc.C) {
-	s.meteredCharm = s.factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
-	s.service = s.factory.MakeService(c, &factory.ServiceParams{Charm: s.meteredCharm})
-	s.unit = s.factory.MakeUnit(c, &factory.UnitParams{Service: s.service, SetCharmURL: true})
+	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
+	s.service = s.Factory.MakeService(c, &factory.ServiceParams{Charm: s.meteredCharm})
+	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Service: s.service, SetCharmURL: true})
 }
 
 func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
@@ -217,9 +217,9 @@ func (s *MetricSuite) TestMetricCredentials(c *gc.C) {
 func (s *MetricSuite) TestCountMetrics(c *gc.C) {
 	now := time.Now()
 	m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
-	s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
-	s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
-	s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, Time: &now, Metrics: m})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, Time: &now, Metrics: m})
 	sent, err := s.State.CountOfSentMetrics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sent, gc.Equals, 1)
@@ -234,7 +234,7 @@ func (s *MetricSuite) TestSetMetricBatchesSent(c *gc.C) {
 	metrics := make([]*state.MetricBatch, 3)
 	for i := range metrics {
 		m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
-		metrics[i] = s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
+		metrics[i] = s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
 	}
 	uuids := make([]string, len(metrics))
 	for i, m := range metrics {
@@ -251,9 +251,9 @@ func (s *MetricSuite) TestSetMetricBatchesSent(c *gc.C) {
 func (s *MetricSuite) TestMetricsToSend(c *gc.C) {
 	now := state.NowToTheSecond()
 	m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
-	s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
-	s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
-	s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, Time: &now, Metrics: m})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
+	s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, Time: &now, Metrics: m})
 	result, err := s.State.MetricsToSend(5)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 2)
@@ -264,11 +264,11 @@ func (s *MetricSuite) TestMetricsToSendBatches(c *gc.C) {
 	now := state.NowToTheSecond()
 	for i := 0; i < 6; i++ {
 		m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
-		s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
+		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: false, Time: &now, Metrics: m})
 	}
 	for i := 0; i < 4; i++ {
 		m := []state.Metric{{Key: "pings", Value: "123", Time: now}}
-		s.factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, Time: &now, Metrics: m})
+		s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.unit, Sent: true, Time: &now, Metrics: m})
 	}
 	for i := 0; i < 3; i++ {
 		result, err := s.State.MetricsToSend(2)
@@ -286,9 +286,9 @@ func (s *MetricSuite) TestMetricsToSendBatches(c *gc.C) {
 }
 
 func (s *MetricSuite) TestMetricValidation(c *gc.C) {
-	nonMeteredUnit := s.factory.MakeUnit(c, &factory.UnitParams{SetCharmURL: true})
-	meteredService := s.factory.MakeService(c, &factory.ServiceParams{Name: "metered-service", Charm: s.meteredCharm})
-	meteredUnit := s.factory.MakeUnit(c, &factory.UnitParams{Service: meteredService, SetCharmURL: true})
+	nonMeteredUnit := s.Factory.MakeUnit(c, &factory.UnitParams{SetCharmURL: true})
+	meteredService := s.Factory.MakeService(c, &factory.ServiceParams{Name: "metered-service", Charm: s.meteredCharm})
+	meteredUnit := s.Factory.MakeUnit(c, &factory.UnitParams{Service: meteredService, SetCharmURL: true})
 	dyingUnit, err := meteredService.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = dyingUnit.SetCharmURL(s.meteredCharm.URL())
@@ -349,7 +349,7 @@ func (s *MetricSuite) TestMetricsAcrossEnvironments(c *gc.C) {
 	m1, err := s.unit.AddMetrics(utils.MustNewUUID().String(), now, "", []state.Metric{m})
 	c.Assert(err, jc.ErrorIsNil)
 
-	st := s.factory.MakeEnvironment(c, nil)
+	st := s.Factory.MakeEnvironment(c, nil)
 	defer st.Close()
 	f := factory.NewFactory(st)
 	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})

--- a/state/sequence_test.go
+++ b/state/sequence_test.go
@@ -41,7 +41,7 @@ func (s *sequenceSuite) TestMultipleSequences(c *gc.C) {
 
 func (s *sequenceSuite) TestSequenceWithMultipleEnvs(c *gc.C) {
 	state1 := s.State
-	state2 := s.factory.MakeEnvironment(c, nil)
+	state2 := s.Factory.MakeEnvironment(c, nil)
 	defer state2.Close()
 
 	s.incAndCheck(c, state1, "foo", 0)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -165,7 +165,7 @@ func (s *MultiEnvStateSuite) SetUpTest(c *gc.C) {
 		validator.RegisterUnsupported([]string{constraints.CpuPower})
 		return validator, nil
 	}
-	s.OtherState = s.factory.MakeEnvironment(c, nil)
+	s.OtherState = s.Factory.MakeEnvironment(c, nil)
 }
 
 func (s *MultiEnvStateSuite) TearDownTest(c *gc.C) {
@@ -2159,13 +2159,13 @@ func (s *StateSuite) TestWatchEnvironmentsBulkEvents(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Dying environment...
-	st1 := s.factory.MakeEnvironment(c, nil)
+	st1 := s.Factory.MakeEnvironment(c, nil)
 	defer st1.Close()
 	dying, err := st1.Environment()
 	c.Assert(err, jc.ErrorIsNil)
 	dying.Destroy()
 
-	st2 := s.factory.MakeEnvironment(c, nil)
+	st2 := s.Factory.MakeEnvironment(c, nil)
 	defer st2.Close()
 	err = state.RemoveEnvironment(s.State, st2.EnvironUUID())
 	c.Assert(err, jc.ErrorIsNil)
@@ -2193,7 +2193,7 @@ func (s *StateSuite) TestWatchEnvironmentsLifecycle(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Add an environment: reported.
-	st1 := s.factory.MakeEnvironment(c, nil)
+	st1 := s.Factory.MakeEnvironment(c, nil)
 	defer st1.Close()
 	env, err := st1.Environment()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2647,7 +2647,7 @@ func (s *StateSuite) TestAdditionalValidation(c *gc.C) {
 }
 
 func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
-	st := s.factory.MakeEnvironment(c, nil)
+	st := s.Factory.MakeEnvironment(c, nil)
 	defer st.Close()
 
 	// insert one doc for each multiEnvCollection
@@ -3060,7 +3060,7 @@ var entityTypes = map[string]interface{}{
 }
 
 func (s *StateSuite) TestFindEntity(c *gc.C) {
-	s.factory.MakeUser(c, &factory.UserParams{Name: "eric"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "eric"})
 	_, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	svc := s.AddTestingService(c, "ser-vice2", s.AddTestingCharm(c, "mysql"))
@@ -3068,7 +3068,7 @@ func (s *StateSuite) TestFindEntity(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = unit.AddAction("fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.factory.MakeUser(c, &factory.UserParams{Name: "arble"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "arble"})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	eps, err := s.State.InferEndpoints("wordpress", "ser-vice2")
@@ -3168,7 +3168,7 @@ func (s *StateSuite) TestParseActionTag(c *gc.C) {
 }
 
 func (s *StateSuite) TestParseUserTag(c *gc.C) {
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 	coll, id, err := state.ConvertTagToCollectionNameAndId(s.State, user.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coll, gc.Equals, "users")

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -72,7 +72,7 @@ func (s *UserSuite) TestAddUser(c *gc.C) {
 }
 
 func (s *UserSuite) TestCheckUserExists(c *gc.C) {
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 	exists, err := state.CheckUserExists(s.State, user.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(exists, jc.IsTrue)
@@ -82,13 +82,13 @@ func (s *UserSuite) TestCheckUserExists(c *gc.C) {
 }
 
 func (s *UserSuite) TestString(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{Name: "foo"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foo"})
 	c.Assert(user.String(), gc.Equals, "foo@local")
 }
 
 func (s *UserSuite) TestUpdateLastLogin(c *gc.C) {
 	now := time.Now().Round(time.Second).UTC()
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 	err := user.UpdateLastLogin()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.LastLogin().After(now) ||
@@ -96,14 +96,14 @@ func (s *UserSuite) TestUpdateLastLogin(c *gc.C) {
 }
 
 func (s *UserSuite) TestSetPassword(c *gc.C) {
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 	testSetPassword(c, func() (state.Authenticator, error) {
 		return s.State.User(user.UserTag())
 	})
 }
 
 func (s *UserSuite) TestAddUserSetsSalt(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{Password: "a-password"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "a-password"})
 	salt, hash := state.GetUserPasswordSaltAndHash(user)
 	c.Assert(hash, gc.Not(gc.Equals), "")
 	c.Assert(salt, gc.Not(gc.Equals), "")
@@ -112,7 +112,7 @@ func (s *UserSuite) TestAddUserSetsSalt(c *gc.C) {
 }
 
 func (s *UserSuite) TestSetPasswordChangesSalt(c *gc.C) {
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 	origSalt, origHash := state.GetUserPasswordSaltAndHash(user)
 	c.Assert(origSalt, gc.Not(gc.Equals), "")
 	user.SetPassword("a-password")
@@ -124,7 +124,7 @@ func (s *UserSuite) TestSetPasswordChangesSalt(c *gc.C) {
 }
 
 func (s *UserSuite) TestDisable(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{Password: "a-password"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "a-password"})
 	c.Assert(user.IsDisabled(), jc.IsFalse)
 
 	err := user.Disable()
@@ -139,7 +139,7 @@ func (s *UserSuite) TestDisable(c *gc.C) {
 }
 
 func (s *UserSuite) TestSetPasswordHash(c *gc.C) {
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 
 	err := user.SetPasswordHash(utils.UserPasswordHash("foo", utils.CompatSalt), utils.CompatSalt)
 	c.Assert(err, jc.ErrorIsNil)
@@ -157,7 +157,7 @@ func (s *UserSuite) TestSetPasswordHash(c *gc.C) {
 }
 
 func (s *UserSuite) TestSetPasswordHashWithSalt(c *gc.C) {
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 
 	err := user.SetPasswordHash(utils.UserPasswordHash("foo", "salted"), "salted")
 	c.Assert(err, jc.ErrorIsNil)
@@ -169,7 +169,7 @@ func (s *UserSuite) TestSetPasswordHashWithSalt(c *gc.C) {
 }
 
 func (s *UserSuite) TestPasswordValidUpdatesSalt(c *gc.C) {
-	user := s.factory.MakeUser(c, nil)
+	user := s.Factory.MakeUser(c, nil)
 
 	compatHash := utils.UserPasswordHash("foo", utils.CompatSalt)
 	err := user.SetPasswordHash(compatHash, "")
@@ -203,7 +203,7 @@ func (s *UserSuite) TestCantDisableAdmin(c *gc.C) {
 }
 
 func (s *UserSuite) TestCaseSensitiveUsersErrors(c *gc.C) {
-	s.factory.MakeUser(c, &factory.UserParams{Name: "Bob"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "Bob"})
 
 	_, err := s.State.AddUser(
 		"boB", "ignored", "ignored", "ignored")
@@ -212,7 +212,7 @@ func (s *UserSuite) TestCaseSensitiveUsersErrors(c *gc.C) {
 }
 
 func (s *UserSuite) TestCaseInsensitiveLookup(c *gc.C) {
-	expectedUser := s.factory.MakeUser(c, &factory.UserParams{Name: "Bob"})
+	expectedUser := s.Factory.MakeUser(c, &factory.UserParams{Name: "Bob"})
 
 	assertCaseInsensitiveLookup := func(name string) {
 		userTag := names.NewUserTag(name)
@@ -229,12 +229,12 @@ func (s *UserSuite) TestCaseInsensitiveLookup(c *gc.C) {
 
 func (s *UserSuite) TestAllUsers(c *gc.C) {
 	// Create in non-alphabetical order.
-	s.factory.MakeUser(c, &factory.UserParams{Name: "conrad"})
-	s.factory.MakeUser(c, &factory.UserParams{Name: "adam"})
-	s.factory.MakeUser(c, &factory.UserParams{Name: "debbie", Disabled: true})
-	s.factory.MakeUser(c, &factory.UserParams{Name: "barbara"})
-	s.factory.MakeUser(c, &factory.UserParams{Name: "fred", Disabled: true})
-	s.factory.MakeUser(c, &factory.UserParams{Name: "erica"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "conrad"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "adam"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "debbie", Disabled: true})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "barbara"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred", Disabled: true})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "erica"})
 	// There is the existing state server owner called "test-admin"
 
 	includeDeactivated := false


### PR DESCRIPTION
Adds IsSystemAdministrator to see if the user has access to the server environment, and AllEnvironments that returns, as you would expect, all the environments.

As a drive by I noticed that there were two factories on the state.ConnSuite, so I removed one.

(Review request: http://reviews.vapour.ws/r/1943/)