### PR TITLE
state: Fix 1465873 Environment.Users mismatched UUID

### DIFF
--- a/state/environ.go
+++ b/state/environ.go
@@ -234,6 +234,9 @@ func (e *Environment) refresh(query *mgo.Query) error {
 
 // Users returns a slice of all users for this environment.
 func (e *Environment) Users() ([]*EnvironmentUser, error) {
+	if e.st.EnvironUUID() != e.UUID() {
+		return nil, errors.New("cannot lookup environment users outside the current environment")
+	}
 	coll, closer := e.st.getCollection(envUsersC)
 	defer closer()
 

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -215,6 +215,23 @@ func (s *EnvironSuite) TestListEnvironmentUsers(c *gc.C) {
 	assertObtainedUsersMatchExpectedUsers(c, obtained, expected)
 }
 
+func (s *EnvironSuite) TestMisMatchedEnvs(c *gc.C) {
+	// create another environment
+	otherEnvState := s.Factory.MakeEnvironment(c, nil)
+	defer otherEnvState.Close()
+	otherEnv, err := otherEnvState.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// get that environment from State
+	env, err := s.State.GetEnvironment(otherEnv.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// check that the Users method errors
+	users, err := env.Users()
+	c.Assert(users, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "cannot lookup environment users outside the current environment")
+}
+
 func (s *EnvironSuite) TestListUsersTwoEnvironments(c *gc.C) {
 	env, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Make Environment.Users return an error if the environment's UUID does
not match that of the backing state's environment.

(Review request: http://reviews.vapour.ws/r/1946/)