### PR TITLE
Fix logic to short circuit a unit destruction

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -794,7 +794,7 @@ func canBeLost(status *api.UnitStatus) bool {
 		return status.UnitAgent.Info != operation.RunningHookMessage(string(hooks.Install))
 	}
 	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := status.Workload.Status != params.StatusMaintenance || status.Workload.Info != state.InstallingMessage
+	isInstalled := status.Workload.Status != params.StatusMaintenance || status.Workload.Info != state.MessageInstalling
 	return isInstalled
 }
 

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -794,7 +794,7 @@ func canBeLost(status *api.UnitStatus) bool {
 		return status.UnitAgent.Info != operation.RunningHookMessage(string(hooks.Install))
 	}
 	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := status.Workload.Status != params.StatusMaintenance || status.Workload.Info != "installing charm software"
+	isInstalled := status.Workload.Status != params.StatusMaintenance || status.Workload.Info != state.InstallingMessage
 	return isInstalled
 }
 

--- a/state/service.go
+++ b/state/service.go
@@ -648,6 +648,8 @@ func (s *Service) newUnitName() (string, error) {
 	return name, nil
 }
 
+const WaitForAgentInitMessage = "Waiting for agent initialization to finish"
+
 // addUnitOps returns a unique name for a new unit, and a list of txn operations
 // necessary to create that unit. The principalName param must be non-empty if
 // and only if s is a subordinate service. Only one subordinate of a given
@@ -692,7 +694,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	}
 	unitStatusDoc := statusDoc{
 		Status:     StatusUnknown,
-		StatusInfo: "Waiting for agent initialization to finish",
+		StatusInfo: WaitForAgentInitMessage,
 		Updated:    &now,
 		EnvUUID:    s.st.EnvironUUID(),
 	}

--- a/state/service.go
+++ b/state/service.go
@@ -648,7 +648,7 @@ func (s *Service) newUnitName() (string, error) {
 	return name, nil
 }
 
-const WaitForAgentInitMessage = "Waiting for agent initialization to finish"
+const MessageWaitForAgentInit = "Waiting for agent initialization to finish"
 
 // addUnitOps returns a unique name for a new unit, and a list of txn operations
 // necessary to create that unit. The principalName param must be non-empty if
@@ -694,7 +694,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	}
 	unitStatusDoc := statusDoc{
 		Status:     StatusUnknown,
-		StatusInfo: WaitForAgentInitMessage,
+		StatusInfo: MessageWaitForAgentInit,
 		Updated:    &now,
 		EnvUUID:    s.st.EnvironUUID(),
 	}

--- a/state/status.go
+++ b/state/status.go
@@ -639,6 +639,8 @@ func getEntitiesWithStatuses(coll stateCollection) ([]string, error) {
 	return entityKeys, nil
 }
 
+const InstallingMessage = "installing charm software"
+
 // TranslateLegacyAgentStatus returns the status value clients expect to see for
 // agent-state in versions prior to 1.24
 func TranslateToLegacyAgentState(agentStatus, workloadStatus Status, workloadMessage string) (Status, bool) {
@@ -655,7 +657,7 @@ func TranslateToLegacyAgentState(agentStatus, workloadStatus Status, workloadMes
 	// For the purposes of deriving the legacy status, there's currently no better
 	// way to determine if a unit is installed.
 	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := workloadStatus != StatusMaintenance || workloadMessage != "installing charm software"
+	isInstalled := workloadStatus != StatusMaintenance || workloadMessage != InstallingMessage
 
 	switch agentStatus {
 	case StatusAllocating:

--- a/state/status.go
+++ b/state/status.go
@@ -639,7 +639,7 @@ func getEntitiesWithStatuses(coll stateCollection) ([]string, error) {
 	return entityKeys, nil
 }
 
-const InstallingMessage = "installing charm software"
+const MessageInstalling = "installing charm software"
 
 // TranslateLegacyAgentStatus returns the status value clients expect to see for
 // agent-state in versions prior to 1.24
@@ -657,7 +657,7 @@ func TranslateToLegacyAgentState(agentStatus, workloadStatus Status, workloadMes
 	// For the purposes of deriving the legacy status, there's currently no better
 	// way to determine if a unit is installed.
 	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := workloadStatus != StatusMaintenance || workloadMessage != InstallingMessage
+	isInstalled := workloadStatus != StatusMaintenance || workloadMessage != MessageInstalling
 
 	switch agentStatus {
 	case StatusAllocating:

--- a/state/unit.go
+++ b/state/unit.go
@@ -410,6 +410,7 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 
 	// See if the unit's machine has been allocated and the unit has been installed.
 	isAllocated := agentStatusDoc.Status != StatusAllocating
+	isError := agentStatusDoc.Status == StatusError
 
 	unitStatusDocId := u.globalKey()
 	unitStatusDoc, err := getStatus(u.st, unitStatusDocId)
@@ -421,7 +422,7 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 	isInstalled := unitStatusDoc.Status != StatusMaintenance || unitStatusDoc.StatusInfo != MessageInstalling
 
 	// If already allocated and installed, or there's an error, then we can't set directly to dead.
-	if isAllocated && isInstalled || agentStatusDoc.Status == StatusError {
+	if isError || isAllocated && isInstalled {
 		return setDyingOps, nil
 	}
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -336,8 +336,8 @@ func (u *Unit) eraseHistory() error {
 	return nil
 }
 
-// unitAgentAllocatingOrInstalling is used to assert that a unit agent may be installing a unit.
-var unitAgentAllocatingOrInstalling = bson.D{
+// unitAgentAllocatingOrInstallingOrError is used to assert that a unit agent may be installing a unit.
+var unitAgentAllocatingOrInstallingOrError = bson.D{
 	{"$or", []bson.D{
 		{{"status", StatusAllocating}},
 		{{"status", StatusExecuting}},
@@ -349,11 +349,11 @@ var unitInstalling = bson.D{
 	{"$or", []bson.D{
 		{{"$and", []bson.D{
 			{{"status", StatusMaintenance}},
-			{{"statusinfo", InstallingMessage}},
+			{{"statusinfo", MessageInstalling}},
 		}}},
 		{{"$and", []bson.D{
 			{{"status", StatusUnknown}},
-			{{"statusinfo", WaitForAgentInitMessage}},
+			{{"statusinfo", MessageWaitForAgentInit}},
 		}}},
 	}}}
 
@@ -419,7 +419,7 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 	}
 	// There's currently no better way to determine if a unit is installed.
 	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := unitStatusDoc.Status != StatusMaintenance || unitStatusDoc.StatusInfo != InstallingMessage
+	isInstalled := unitStatusDoc.Status != StatusMaintenance || unitStatusDoc.StatusInfo != MessageInstalling
 
 	// If already allocated and installed, or there's an error, then we can't set directly to dead.
 	if isAllocated && isInstalled {
@@ -430,7 +430,7 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 		{
 			C:      statusesC,
 			Id:     u.st.docID(agentStatusDocId),
-			Assert: unitAgentAllocatingOrInstalling,
+			Assert: unitAgentAllocatingOrInstallingOrError,
 		}, {
 			C:      statusesC,
 			Id:     u.st.docID(unitStatusDocId),

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1014,9 +1014,6 @@ func (s *UnitSuite) TestShortCircuitDestroyUnitStillInstalling(c *gc.C) {
 	}, {
 		state.StatusExecuting, "blah",
 		state.StatusMaintenance, "installing charm software",
-	}, {
-		state.StatusError, "blah",
-		state.StatusMaintenance, "installing charm software",
 	}} {
 		c.Logf("test %d", i)
 		unit, err := s.service.AddUnit()


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1464616

destroy machine --force was broken for units with bad install hooks because the logic to short circuit the unit destruction was broken.

(Review request: http://reviews.vapour.ws/r/1947/)