### PR TITLE
Add an --all option to system environments.

### DIFF
--- a/api/environmentmanager/environmentmanager.go
+++ b/api/environmentmanager/environmentmanager.go
@@ -109,6 +109,30 @@ func (c *Client) ListEnvironments(user string) ([]UserEnvironment, error) {
 	return result, nil
 }
 
+// AllEnvironments allows system administrators to get the list of all the
+// environments in the system.
+func (c *Client) AllEnvironments() ([]UserEnvironment, error) {
+	var environments params.UserEnvironmentList
+	err := c.facade.FacadeCall("AllEnvironments", nil, &environments)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]UserEnvironment, len(environments.UserEnvironments))
+	for i, env := range environments.UserEnvironments {
+		owner, err := names.ParseUserTag(env.OwnerTag)
+		if err != nil {
+			return nil, errors.Annotatef(err, "OwnerTag %q at position %d", env.OwnerTag, i)
+		}
+		result[i] = UserEnvironment{
+			Name:           env.Name,
+			UUID:           env.UUID,
+			Owner:          owner.Username(),
+			LastConnection: env.LastConnection,
+		}
+	}
+	return result, nil
+}
+
 // EnvironmentGet returns all environment settings for the
 // system environment.
 func (c *Client) EnvironmentGet() (map[string]interface{}, error) {

--- a/apiserver/environmentmanager/destroy_test.go
+++ b/apiserver/environmentmanager/destroy_test.go
@@ -24,12 +24,12 @@ import (
 )
 
 type destroyEnvironmentSuite struct {
-	envManagerSuite
+	envManagerBaseSuite
 	commontesting.BlockHelper
 }
 
 func (s *destroyEnvironmentSuite) SetUpTest(c *gc.C) {
-	s.envManagerSuite.SetUpTest(c)
+	s.envManagerBaseSuite.SetUpTest(c)
 	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
 	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
 }
@@ -201,7 +201,7 @@ func (s *destroyEnvironmentSuite) TestCannotDestroyUnsharedEnvironment(c *gc.C) 
 }
 
 type destroyTwoEnvironmentsSuite struct {
-	envManagerSuite
+	envManagerBaseSuite
 	commontesting.BlockHelper
 	otherState    *state.State
 	otherEnvOwner names.UserTag
@@ -211,7 +211,7 @@ type destroyTwoEnvironmentsSuite struct {
 var _ = gc.Suite(&destroyTwoEnvironmentsSuite{})
 
 func (s *destroyTwoEnvironmentsSuite) SetUpTest(c *gc.C) {
-	s.envManagerSuite.SetUpTest(c)
+	s.envManagerBaseSuite.SetUpTest(c)
 
 	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
 	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })

--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -388,8 +388,10 @@ func (em *EnvironmentManagerAPI) AllEnvironments() (params.UserEnvironmentList, 
 	}
 
 	// Get all the environments that the authenticated user can see, and
-	// supplement that with the other environments that exist that the user cannot
-	// see.
+	// supplement that with the other environments that exist that the user
+	// cannot see. The reason we do this is to get the LastConnection time for
+	// the environments that the user is able to see, so we have consistent
+	// output when listing with or without --all when an admin user.
 	visibleEnvironments, err := em.ListEnvironments(params.Entity{Tag: apiUser.String()})
 	if err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -33,6 +33,7 @@ type EnvironmentManager interface {
 	ConfigSkeleton(args params.EnvironmentSkeletonConfigArgs) (params.EnvironConfigResult, error)
 	CreateEnvironment(args params.EnvironmentCreateArgs) (params.Environment, error)
 	ListEnvironments(user params.Entity) (params.UserEnvironmentList, error)
+	AllEnvironments() (params.UserEnvironmentList, error)
 }
 
 // EnvironmentManagerAPI implements the environment manager interface and is
@@ -362,6 +363,63 @@ func (em *EnvironmentManagerAPI) ListEnvironments(user params.Entity) (params.Us
 			LastConnection: env.LastConnection,
 		})
 		logger.Debugf("list env: %s, %s, %s", env.Name(), env.UUID(), env.Owner())
+	}
+
+	return result, nil
+}
+
+// AllEnvironments allows system administrators to get the list of all the
+// environments in the system.
+func (em *EnvironmentManagerAPI) AllEnvironments() (params.UserEnvironmentList, error) {
+	result := params.UserEnvironmentList{}
+
+	authTag := em.authorizer.GetAuthTag()
+	apiUser, ok := authTag.(names.UserTag)
+	if !ok {
+		return result, errors.Errorf("auth tag should be a user, but isn't: %q", authTag.String())
+	}
+
+	isAdmin, err := em.state.IsSystemAdministrator(apiUser)
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	if !isAdmin {
+		return result, common.ErrPerm
+	}
+
+	// Get all the environments that the authenticated user can see, and
+	// supplement that with the other environments that exist that the user cannot
+	// see.
+	visibleEnvironments, err := em.ListEnvironments(params.Entity{Tag: apiUser.String()})
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	envs := make(map[string]params.UserEnvironment)
+	for _, env := range visibleEnvironments.UserEnvironments {
+		envs[env.UUID] = env
+	}
+
+	allEnvs, err := em.state.AllEnvironments()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	for _, env := range allEnvs {
+		if _, ok := envs[env.UUID()]; !ok {
+			envs[env.UUID()] = params.UserEnvironment{
+				Environment: params.Environment{
+					Name:     env.Name(),
+					UUID:     env.UUID(),
+					OwnerTag: env.Owner().String(),
+				},
+				// No LastConnection as this user hasn't.
+			}
+		}
+	}
+
+	for _, userEnv := range envs {
+		result.UserEnvironments = append(result.UserEnvironments, userEnv)
 	}
 
 	return result, nil

--- a/apiserver/environmentmanager/state.go
+++ b/apiserver/environmentmanager/state.go
@@ -15,6 +15,7 @@ var getState = func(st *state.State) stateInterface {
 }
 
 type stateInterface interface {
+	AllEnvironments() ([]*state.Environment, error)
 	AllMachines() ([]*state.Machine, error)
 	Close() error
 	Environment() (*state.Environment, error)
@@ -24,6 +25,7 @@ type stateInterface interface {
 	EnvironUUID() string
 	ForEnviron(names.EnvironTag) (*state.State, error)
 	GetBlockForType(state.BlockType) (state.Block, bool, error)
+	IsSystemAdministrator(user names.UserTag) (bool, error)
 	NewEnvironment(*config.Config, names.UserTag) (*state.Environment, *state.State, error)
 	RemoveAllEnvironDocs() error
 	StateServerEnvironment() (*state.Environment, error)


### PR DESCRIPTION
Resulted in extra api call being needed.

(Review request: http://reviews.vapour.ws/r/1948/)