### PR TITLE
OplogTailer tweaks

### DIFF
--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -37,6 +37,7 @@ func NewOplogTailer(oplog *mgo.Collection, query bson.D) *OplogTailer {
 	}
 	go func() {
 		defer func() {
+			close(t.outCh)
 			t.tomb.Done()
 			session.Close()
 		}()

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -102,8 +102,12 @@ func (t *OplogTailer) loop() error {
 	// idsForLastTimestamp records the unique operation ids that have
 	// been reported for the most recently reported oplog
 	// timestamp. This is used to avoid re-reporting oplog entries
-	// when the iterator is restarted. It's possible for there to be
-	// many oplog entries for a given timestamp.
+	// when the iterator is restarted. These timestamps are unique for
+	// a given mongod but when there's multiple replicaset members
+	// it's possible for there to be multiple oplog entries for a
+	// given timestamp.
+	//
+	// See: http://docs.mongodb.org/v2.4/reference/bson-types/#timestamps
 	var idsForLastTimestamp []int64
 
 	for {

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -85,6 +85,12 @@ func (t *OplogTailer) Stop() error {
 	return t.tomb.Wait()
 }
 
+// Err returns the error that caused the OplogTailer to stop. If it
+// finished normally or hasn't stopped then nil will be returned.
+func (t *OplogTailer) Err() error {
+	return t.tomb.Err()
+}
+
 const oplogTailTimeout = time.Second
 
 func (t *OplogTailer) loop() error {

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -68,6 +68,7 @@ func (s *oplogSuite) TestStops(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertStopped(c, tailer)
+	c.Assert(tailer.Err(), jc.ErrorIsNil)
 }
 
 func (s *oplogSuite) TestRestartsOnError(c *gc.C) {
@@ -162,6 +163,9 @@ func (s *oplogSuite) TestDiesOnFatalError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertStopped(c, tailer)
+	// The actual error varies by MongoDB version so just check that
+	// there is one.
+	c.Assert(tailer.Err(), gc.Not(jc.ErrorIsNil))
 }
 
 func (s *oplogSuite) startMongoWithReplicaset(c *gc.C) (*jujutesting.MgoInstance, *mgo.Session) {

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -221,7 +221,7 @@ func (s *oplogSuite) dialMongo(c *gc.C, inst *jujutesting.MgoInstance) *mgo.Sess
 }
 
 func (s *oplogSuite) makeFakeOplog(c *gc.C, session *mgo.Session) *mgo.Collection {
-	db := session.DB("local")
+	db := session.DB("foo")
 	oplog := db.C("oplog.fake")
 	err := oplog.Create(&mgo.CollectionInfo{
 		Capped:   true,


### PR DESCRIPTION
A bunch of commits which improve OplogTailer and its tests.

---

mongo: don't put fake oplog in "local" DB

For some reason, if the fake oplog collection used during testing is
in the local DB there are often 1s pauses when reading from the tail
cursor. Putting it in another DB works around the issue.

---

mongo: removed naked channel write in OplogTailer

While writing to the output channel the tomb needs to be checked too.

---

mongo: close the OplogTailer output when it finishes

The output channel will be closed if the tailer stops due to a fatal
error or because it was asked to.

---

mongo: added OplogTailer.Err()

Returns the error that caused the tailer to finish.

---

mongo: clarified description of idsForLastTimestamp

---


(Review request: http://reviews.vapour.ws/r/1949/)