### PR TITLE
worker/storageprovisioner: react to Dead vo/fs

### DIFF
--- a/apiserver/common/filesystems.go
+++ b/apiserver/common/filesystems.go
@@ -13,7 +13,8 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 )
 
-// FilesystemParams returns the parameters for creating the given filesystem.
+// FilesystemParams returns the parameters for creating or destroying the
+// given filesystem.
 func FilesystemParams(
 	f state.Filesystem,
 	storageInstance state.StorageInstance,

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -572,10 +572,7 @@ func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]params.VolumeP
 			return nil, errors.Annotatef(err, "getting volume %q storage instance", volumeTag.Id())
 		}
 		volumeParams, err := common.VolumeParams(volume, storageInstance, envConfig, poolManager)
-		if common.IsVolumeAlreadyProvisioned(err) {
-			// Already provisioned, so must be dynamic.
-			continue
-		} else if err != nil {
+		if err != nil {
 			return nil, errors.Annotatef(err, "getting volume %q parameters", volumeTag.Id())
 		}
 		provider, err := registry.StorageProvider(storage.ProviderType(volumeParams.Provider))

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -534,8 +534,8 @@ func (s *StorageProvisionerAPI) FilesystemAttachments(args params.MachineStorage
 	return results, nil
 }
 
-// VolumeParams returns the parameters for creating the volumes
-// with the specified tags.
+// VolumeParams returns the parameters for creating or destroying
+// the volumes with the specified tags.
 func (s *StorageProvisionerAPI) VolumeParams(args params.Entities) (params.VolumeParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -363,7 +363,20 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.VolumeParamsResults{
 		Results: []params.VolumeParamsResult{
-			{Error: &params.Error{`volume "0/0" is already provisioned`, ""}},
+			{Result: params.VolumeParams{
+				VolumeTag: "volume-0-0",
+				Size:      1024,
+				Provider:  "machinescoped",
+				Tags: map[string]string{
+					tags.JujuEnv: testing.EnvironmentTag.Id(),
+				},
+				Attachment: &params.VolumeAttachmentParams{
+					MachineTag: "machine-0",
+					VolumeTag:  "volume-0-0",
+					Provider:   "machinescoped",
+					InstanceId: "inst-id",
+				},
+			}},
 			{Result: params.VolumeParams{
 				VolumeTag: "volume-1",
 				Size:      2048,
@@ -412,7 +425,14 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.FilesystemParamsResults{
 		Results: []params.FilesystemParamsResult{
-			{Error: &params.Error{`filesystem "0/0" is already provisioned`, ""}},
+			{Result: params.FilesystemParams{
+				FilesystemTag: "filesystem-0-0",
+				Size:          1024,
+				Provider:      "machinescoped",
+				Tags: map[string]string{
+					tags.JujuEnv: testing.EnvironmentTag.Id(),
+				},
+			}},
 			{Result: params.FilesystemParams{
 				FilesystemTag: "filesystem-1",
 				Size:          2048,

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -70,21 +70,6 @@ func attachmentLife(ctx *context, ids []params.MachineStorageId) (
 	return alive, dying, dead, nil
 }
 
-// ensureDead ensures that each specified entity immediately becomes Dead
-// if it is not already Dead or removed.
-func ensureDead(ctx *context, tags []names.Tag) error {
-	errorResults, err := ctx.life.EnsureDead(tags)
-	if err != nil {
-		return errors.Annotate(err, "ensuring storage entities dead")
-	}
-	for i, result := range errorResults {
-		if result.Error != nil {
-			return errors.Annotatef(result.Error, "ensuring %s dead", names.ReadableString(tags[i]))
-		}
-	}
-	return nil
-}
-
 // removeEntities removes each specified Dead entity from state.
 func removeEntities(ctx *context, tags []names.Tag) error {
 	errorResults, err := ctx.life.Remove(tags)

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -116,10 +116,6 @@ type LifecycleManager interface {
 	// Life returns the lifecycle state of the specified entities.
 	Life([]names.Tag) ([]params.LifeResult, error)
 
-	// EnsureDead ensures that the specified entities become Dead if
-	// they are Alive or Dying.
-	EnsureDead([]names.Tag) ([]params.ErrorResult, error)
-
 	// Remove removes the specified entities from state.
 	Remove([]names.Tag) ([]params.ErrorResult, error)
 

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -168,7 +168,11 @@ func NewStorageProvisioner(
 	}
 	go func() {
 		defer w.tomb.Done()
-		w.tomb.Kill(w.loop())
+		err := w.loop()
+		if err != tomb.ErrDying {
+			logger.Errorf("%s", err)
+		}
+		w.tomb.Kill(err)
 	}()
 	return w
 }

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -24,19 +24,11 @@ func volumesChanged(ctx *context, changes []string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// TODO(axw) wait for volumes to have no attachments first.
-	// We can then have the removal of the last attachment trigger
-	// the volume's Life being transitioned to Dead, or watch the
-	// attachments until they're all gone. We need to watch
-	// attachments *anyway*, so we can probably integrate the two
-	// things.
 	logger.Debugf("volumes alive: %v, dying: %v, dead: %v", alive, dying, dead)
-	if err := ensureDead(ctx, dying); err != nil {
-		return errors.Annotate(err, "ensuring volumes dead")
-	}
-	// Once the entities are Dead, they can be removed from state
-	// after the corresponding cloud storage resources are removed.
-	dead = append(dead, dying...)
+	// Note: we don't take any action for Dying volumes. This is an
+	// intermediate state in which a volume exists until all of its
+	// dependents are removed from state, at which point it becomes
+	// Dead.
 	if len(alive)+len(dead) == 0 {
 		return nil
 	}
@@ -54,17 +46,12 @@ func volumesChanged(ctx *context, changes []string) error {
 	if err != nil {
 		return errors.Annotatef(err, "getting volume information")
 	}
-
-	// Deprovision "dead" volumes, and then remove from state.
 	if err := processDeadVolumes(ctx, volumeTags[len(alive):], volumeResults[len(alive):]); err != nil {
 		return errors.Annotate(err, "deprovisioning volumes")
 	}
-
-	// Provision "alive" volumes.
 	if err := processAliveVolumes(ctx, alive, volumeResults[:len(alive)]); err != nil {
 		return errors.Annotate(err, "provisioning volumes")
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
When a volume or filesystem becomes Dying, we now simply clear out any
pending provisioning. When a volume or filesystem becomes Dead, then we
destroy (if provisioned) and remove from state. The entity being Dead is
predicated on it having no dependents; this will be taken care of in state.

The VolumeParams and FilesystemParams methods will now return results
for already-provisioned entities. This is so that we can construct the
storage source from pool config, to destroy the IaaS resources.

EnsureDead has been removed from the API, since we will not be using it.

Note: currently we don't have a DestroyFilesystems method in
storage.FilesystemSource. Also, the Remove method on the apiserver side
has not been implemented. Neither of these poses a problem, since we don't
yet set volumes or filesystems to Dead in state.

(Review request: http://reviews.vapour.ws/r/1951/)