### PR TITLE
apiserver/storageprovisioner: implement Remove

### DIFF
--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -39,6 +39,9 @@ type provisionerState interface {
 	VolumeAttachment(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
 
+	RemoveFilesystem(names.FilesystemTag) error
+	RemoveVolume(names.VolumeTag) error
+
 	SetFilesystemInfo(names.FilesystemTag, state.FilesystemInfo) error
 	SetFilesystemAttachmentInfo(names.MachineTag, names.FilesystemTag, state.FilesystemAttachmentInfo) error
 	SetVolumeInfo(names.VolumeTag, state.VolumeInfo) error


### PR DESCRIPTION
Add the Remove method, to remove destroyed volumes
and filesystems from state.

(Review request: http://reviews.vapour.ws/r/1952/)