### PR TITLE
storage: add FilesystemSource.DestroyFilesystems

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -115,6 +115,10 @@ type FilesystemSource interface {
 	// CreateFilesystems creates filesystems with the specified size, in MiB.
 	CreateFilesystems(params []FilesystemParams) ([]Filesystem, error)
 
+	// DestroyFilesystems destroys the filesystems with the specified
+	// providerd filesystem IDs.
+	DestroyFilesystems(fsIds []string) []error
+
 	// AttachFilesystems attaches filesystems to machines.
 	//
 	// AttachFilesystems must be idempotent; it may be called even if

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -97,6 +97,12 @@ func (s *managedFilesystemSource) createFilesystem(arg storage.FilesystemParams)
 	}, nil
 }
 
+// DestroyFilesystems is defined on storage.FilesystemSource.
+func (s *managedFilesystemSource) DestroyFilesystems(filesystemIds []string) []error {
+	// DestroyFilesystems is a no-op; there is nothing to destroy.
+	return make([]error, len(filesystemIds))
+}
+
 func (s *managedFilesystemSource) devicePath(dev storage.BlockDevice) string {
 	if dev.DeviceName != "" {
 		return path.Join("/dev", dev.DeviceName)

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -99,7 +99,9 @@ func (s *managedFilesystemSource) createFilesystem(arg storage.FilesystemParams)
 
 // DestroyFilesystems is defined on storage.FilesystemSource.
 func (s *managedFilesystemSource) DestroyFilesystems(filesystemIds []string) []error {
-	// DestroyFilesystems is a no-op; there is nothing to destroy.
+	// DestroyFilesystems is a no-op; there is nothing to destroy,
+	// since the filesystem is just data on a volume. The volume
+	// is destroyed separately.
 	return make([]error, len(filesystemIds))
 }
 

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -180,7 +180,8 @@ func (s *rootfsFilesystemSource) createFilesystem(params storage.FilesystemParam
 
 // DestroyFilesystems is defined on the FilesystemSource interface.
 func (s *rootfsFilesystemSource) DestroyFilesystems(filesystemIds []string) []error {
-	// DestroyFilesystems is a no-op; there is nothing to destroy.
+	// DestroyFilesystems is a no-op; we leave the storage directory
+	// in tact for post-mortems and such.
 	return make([]error, len(filesystemIds))
 }
 

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -178,6 +178,12 @@ func (s *rootfsFilesystemSource) createFilesystem(params storage.FilesystemParam
 	return filesystem, nil
 }
 
+// DestroyFilesystems is defined on the FilesystemSource interface.
+func (s *rootfsFilesystemSource) DestroyFilesystems(filesystemIds []string) []error {
+	// DestroyFilesystems is a no-op; there is nothing to destroy.
+	return make([]error, len(filesystemIds))
+}
+
 // AttachFilesystems is defined on the FilesystemSource interface.
 func (s *rootfsFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.FilesystemAttachment, error) {
 	attachments := make([]storage.FilesystemAttachment, len(args))

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -144,7 +144,9 @@ func (s *tmpfsFilesystemSource) createFilesystem(params storage.FilesystemParams
 
 // DestroyFilesystems is defined on the FilesystemSource interface.
 func (s *tmpfsFilesystemSource) DestroyFilesystems(filesystemIds []string) []error {
-	// DestroyFilesystems is a no-op; there is nothing to destroy.
+	// DestroyFilesystems is a no-op; there is nothing to destroy,
+	// since the filesystem is ephemeral and disappears once
+	// detached.
 	return make([]error, len(filesystemIds))
 }
 

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -142,6 +142,12 @@ func (s *tmpfsFilesystemSource) createFilesystem(params storage.FilesystemParams
 	return storage.Filesystem{params.Tag, params.Volume, info}, nil
 }
 
+// DestroyFilesystems is defined on the FilesystemSource interface.
+func (s *tmpfsFilesystemSource) DestroyFilesystems(filesystemIds []string) []error {
+	// DestroyFilesystems is a no-op; there is nothing to destroy.
+	return make([]error, len(filesystemIds))
+}
+
 // AttachFilesystems is defined on the FilesystemSource interface.
 func (s *tmpfsFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.FilesystemAttachment, error) {
 	attachments := make([]storage.FilesystemAttachment, len(args))

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -597,6 +597,10 @@ func (s *mockManagedFilesystemSource) CreateFilesystems(args []storage.Filesyste
 	return filesystems, nil
 }
 
+func (s *mockManagedFilesystemSource) DestroyFilesystems(filesystemIds []string) []error {
+	return make([]error, len(filesystemIds))
+}
+
 func (s *mockManagedFilesystemSource) AttachFilesystems(args []storage.FilesystemAttachmentParams) ([]storage.FilesystemAttachment, error) {
 	var filesystemAttachments []storage.FilesystemAttachment
 	for _, arg := range args {


### PR DESCRIPTION
All existing filesystem implementations have no-op
implementations, since they don't actually create
anything (their Attach/DetachFilesystems create
filesystems).

(Review request: http://reviews.vapour.ws/r/1953/)