### PR TITLE
storage/provider: implement DetachFilesystems

### DIFF
--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -4,6 +4,9 @@
 package provider_test
 
 import (
+	"path/filepath"
+
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -27,4 +30,31 @@ func (s *providerCommonSuite) TestCommonProvidersExported(c *gc.C) {
 		provider.RootfsProviderType,
 		provider.TmpfsProviderType,
 	})
+}
+
+// testDetachFilesystems is a test-case for detaching filesystems that use
+// the common "maybeUnmount" method.
+func testDetachFilesystems(c *gc.C, commands *mockRunCommand, source storage.FilesystemSource, mounted bool) {
+	const testMountPoint = "/in/the/place"
+
+	cmd := commands.expect("df", "--output=source", filepath.Dir(testMountPoint))
+	cmd.respond("headers\n/same/as/rootfs", nil)
+	cmd = commands.expect("df", "--output=source", testMountPoint)
+	if mounted {
+		cmd.respond("headers\n/different/to/rootfs", nil)
+		commands.expect("unmount", testMountPoint)
+	} else {
+		cmd.respond("headers\n/same/as/rootfs", nil)
+	}
+
+	err := source.DetachFilesystems([]storage.FilesystemAttachmentParams{{
+		Filesystem:   names.NewFilesystemTag("0/0"),
+		FilesystemId: "filesystem-0-0",
+		AttachmentParams: storage.AttachmentParams{
+			Machine:    names.NewMachineTag("0"),
+			InstanceId: "inst-id",
+		},
+		Path: testMountPoint,
+	}})
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -42,7 +42,7 @@ func testDetachFilesystems(c *gc.C, commands *mockRunCommand, source storage.Fil
 	cmd = commands.expect("df", "--output=source", testMountPoint)
 	if mounted {
 		cmd.respond("headers\n/different/to/rootfs", nil)
-		commands.expect("unmount", testMountPoint)
+		commands.expect("umount", testMountPoint)
 	} else {
 		cmd.respond("headers\n/same/as/rootfs", nil)
 	}

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -195,8 +195,8 @@ func maybeUnmount(run runCommandFunc, dirFuncs dirFuncs, mountPoint string) erro
 		return nil
 	}
 	logger.Debugf("attempting to unmount filesystem at %q", mountPoint)
-	if _, err := run("unmount", mountPoint); err != nil {
-		return errors.Annotate(err, "unmount failed")
+	if _, err := run("umount", mountPoint); err != nil {
+		return errors.Annotate(err, "umount failed")
 	}
 	logger.Infof("unmounted filesystem at %q", mountPoint)
 	return nil

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -6,7 +6,6 @@ package provider_test
 import (
 	"path/filepath"
 
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -165,6 +164,10 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool)
 
 func (s *managedfsSuite) TestDetachFilesystems(c *gc.C) {
 	source := s.initSource(c)
-	err := source.DetachFilesystems(nil)
-	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+	testDetachFilesystems(c, s.commands, source, true)
+}
+
+func (s *managedfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
+	source := s.initSource(c)
+	testDetachFilesystems(c, s.commands, source, false)
 }

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -320,3 +320,17 @@ func (s *rootfsSuite) TestAttachFilesystemsBindSameFSNonEmptyDirClaimed(c *gc.C)
 		},
 	}})
 }
+
+func (s *rootfsSuite) TestDetachFilesystems(c *gc.C) {
+	source := s.rootfsFilesystemSource(c)
+	testDetachFilesystems(c, s.commands, source, true)
+}
+
+func (s *rootfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
+	// The "unattached" case covers both idempotency, and
+	// also the scenario where bind-mounting failed. In
+	// either case, there is no attachment-specific filesystem
+	// mount.
+	source := s.rootfsFilesystemSource(c)
+	testDetachFilesystems(c, s.commands, source, false)
+}

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -201,8 +201,12 @@ func (s *tmpfsFilesystemSource) attachFilesystem(arg storage.FilesystemAttachmen
 
 // DetachFilesystems is defined on the FilesystemSource interface.
 func (s *tmpfsFilesystemSource) DetachFilesystems(args []storage.FilesystemAttachmentParams) error {
-	// TODO(axw)
-	return errors.NotImplementedf("DetachFilesystems")
+	for _, arg := range args {
+		if err := maybeUnmount(s.run, s.dirFuncs, arg.Path); err != nil {
+			return errors.Annotatef(err, "detaching filesystem %s", arg.Filesystem.Id())
+		}
+	}
+	return nil
 }
 
 func (s *tmpfsFilesystemSource) writeFilesystemInfo(tag names.FilesystemTag, info storage.FilesystemInfo) error {

--- a/storage/provider/tmpfs_test.go
+++ b/storage/provider/tmpfs_test.go
@@ -249,3 +249,13 @@ func (s *tmpfsSuite) TestAttachFilesystemsNoFilesystem(c *gc.C) {
 	}})
 	c.Assert(err, gc.ErrorMatches, "attaching filesystem 6: reading filesystem info from disk: open .*/6.info: no such file or directory")
 }
+
+func (s *tmpfsSuite) TestDetachFilesystems(c *gc.C) {
+	source := s.tmpfsFilesystemSource(c)
+	testDetachFilesystems(c, s.commands, source, true)
+}
+
+func (s *tmpfsSuite) TestDetachFilesystemsUnattached(c *gc.C) {
+	source := s.tmpfsFilesystemSource(c)
+	testDetachFilesystems(c, s.commands, source, false)
+}


### PR DESCRIPTION
All of the existing filesystem storage providers
use "unmount" to detach. We introduce some common
code to unmount if mounted, and common test code
for each provider.

(Review request: http://reviews.vapour.ws/r/1954/)