### PR TITLE
environs: Ignore unknown tools metadata

### DIFF
--- a/environs/tools/marshal_test.go
+++ b/environs/tools/marshal_test.go
@@ -52,8 +52,7 @@ var expectedIndex = `{
             "path": "streams/v1/com.ubuntu.juju-proposed-tools.json",
             "products": [
                 "com.ubuntu.juju:14.04:arm64",
-                "com.ubuntu.juju:14.10:ppc64el",
-                "com.ubuntu.juju:unknown:amd64"
+                "com.ubuntu.juju:14.10:ppc64el"            
             ]
         },
         "com.ubuntu.juju:released:tools": {
@@ -64,8 +63,7 @@ var expectedIndex = `{
             "products": [
                 "com.ubuntu.juju:12.04:amd64",
                 "com.ubuntu.juju:12.04:arm",
-                "com.ubuntu.juju:13.10:arm",
-                "com.ubuntu.juju:unknown:amd64"
+                "com.ubuntu.juju:13.10:arm"            
             ]
         }
     },
@@ -83,8 +81,7 @@ var expectedLegacyIndex = `{
             "products": [
                 "com.ubuntu.juju:12.04:amd64",
                 "com.ubuntu.juju:12.04:arm",
-                "com.ubuntu.juju:13.10:arm",
-                "com.ubuntu.juju:unknown:amd64"
+                "com.ubuntu.juju:13.10:arm"            
             ]
         }
     },
@@ -150,34 +147,6 @@ var expectedReleasedProducts = `{
                     }
                 }
             }
-        },
-        "com.ubuntu.juju:unknown:amd64": {
-            "version": "4.3.2.1",
-            "arch": "amd64",
-            "versions": {
-                "19700101": {
-                    "items": {
-                        "4.3.2.1-xuanhuaceratops-amd64": {
-                            "release": "xuanhuaceratops",
-                            "version": "4.3.2.1",
-                            "arch": "amd64",
-                            "size": 42,
-                            "path": "dinodance.tar.gz",
-                            "ftype": "tar.gz",
-                            "sha256": ""
-                        },
-                        "5.4.3.2-xuanhanosaurus-amd64": {
-                            "release": "xuanhanosaurus",
-                            "version": "5.4.3.2",
-                            "arch": "amd64",
-                            "size": 42,
-                            "path": "dinodisco.tar.gz",
-                            "ftype": "tar.gz",
-                            "sha256": ""
-                        }
-                    }
-                }
-            }
         }
     },
     "updated": "Thu, 01 Jan 1970 00:00:00 +0000",
@@ -218,34 +187,6 @@ var expectedProposedProducts = `{
                             "arch": "ppc64el",
                             "size": 9223372036854775807,
                             "path": "/funkytown.tar.gz",
-                            "ftype": "tar.gz",
-                            "sha256": ""
-                        }
-                    }
-                }
-            }
-        },
-        "com.ubuntu.juju:unknown:amd64": {
-            "version": "4.3.2.1",
-            "arch": "amd64",
-            "versions": {
-                "19700101": {
-                    "items": {
-                        "4.3.2.1-xuanhuaceratops-amd64": {
-                            "release": "xuanhuaceratops",
-                            "version": "4.3.2.1",
-                            "arch": "amd64",
-                            "size": 42,
-                            "path": "dinodance.tar.gz",
-                            "ftype": "tar.gz",
-                            "sha256": ""
-                        },
-                        "5.4.3.2-xuanhanosaurus-amd64": {
-                            "release": "xuanhanosaurus",
-                            "version": "5.4.3.2",
-                            "arch": "amd64",
-                            "size": 42,
-                            "path": "dinodisco.tar.gz",
                             "ftype": "tar.gz",
                             "sha256": ""
                         }

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -209,7 +209,7 @@ func (t *ToolsMetadata) binary() (version.Binary, error) {
 
 func (t *ToolsMetadata) productId() (string, error) {
 	seriesVersion, err := version.SeriesVersion(t.Release)
-	if err != nil && !version.IsUnknownSeriesVersionError(err) {
+	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("com.ubuntu.juju:%s:%s", seriesVersion, t.Arch), nil

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -353,8 +353,10 @@ func (s *simplestreamsSuite) TestWriteMetadataNoFetch(c *gc.C) {
 			SHA256:  "xyz",
 		},
 	}
+	expected := toolsList
 
-	// Add tools with an unknown series
+	// Add tools with an unknown series. Do not add an entry in the
+	// expected list as these tools should be ignored.
 	vers, err := version.ParseBinary("3.2.1-xuanhuaceratops-amd64")
 	c.Assert(err, jc.Satisfies, version.IsUnknownOSForSeriesError)
 	toolsList = append(toolsList, &coretools.Tools{
@@ -369,7 +371,7 @@ func (s *simplestreamsSuite) TestWriteMetadataNoFetch(c *gc.C) {
 	err = tools.MergeAndWriteMetadata(writer, "proposed", "proposed", toolsList, tools.DoNotWriteMirrors)
 	c.Assert(err, jc.ErrorIsNil)
 	metadata := toolstesting.ParseMetadataFromDir(c, dir, "proposed", false)
-	assertMetadataMatches(c, dir, "proposed", toolsList, metadata)
+	assertMetadataMatches(c, dir, "proposed", expected, metadata)
 }
 
 func (s *simplestreamsSuite) assertWriteMetadata(c *gc.C, withMirrors bool) {

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -62,10 +62,6 @@ func IsUnknownSeriesVersionError(err error) bool {
 	return ok
 }
 
-const (
-	unknownSeriesVersion = "unknown"
-)
-
 // seriesVersions provides a mapping between series names and versions.
 // The values here are current as of the time of writing. On Ubuntu systems, we update
 // these values from /usr/share/distro-info/ubuntu.csv to ensure we have the latest values.
@@ -170,7 +166,7 @@ func SeriesVersion(series string) (string, error) {
 		return vers, nil
 	}
 
-	return unknownSeriesVersion, errors.Trace(unknownSeriesVersionError(series))
+	return "", errors.Trace(unknownSeriesVersionError(series))
 }
 
 // SupportedSeries returns the series on which we can run Juju workloads.


### PR DESCRIPTION
When no OS or series version can be found for tools metadata,
ignore the record.

(Review request: http://reviews.vapour.ws/r/1955/)