### PR TITLE
storage/provider: implement loop DetachVolumes

### DIFF
--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -116,7 +116,7 @@ func (lvs *loopVolumeSource) CreateVolumes(args []storage.VolumeParams) ([]stora
 
 func (lvs *loopVolumeSource) createVolume(params storage.VolumeParams) (storage.Volume, error) {
 	volumeId := params.Tag.String()
-	loopFilePath := lvs.volumeFilePath(volumeId)
+	loopFilePath := lvs.volumeFilePath(params.Tag)
 	if err := ensureDir(lvs.dirFuncs, filepath.Dir(loopFilePath)); err != nil {
 		return storage.Volume{}, errors.Trace(err)
 	}
@@ -132,8 +132,8 @@ func (lvs *loopVolumeSource) createVolume(params storage.VolumeParams) (storage.
 	}, nil
 }
 
-func (lvs *loopVolumeSource) volumeFilePath(volumeId string) string {
-	return filepath.Join(lvs.storageDir, volumeId)
+func (lvs *loopVolumeSource) volumeFilePath(tag names.VolumeTag) string {
+	return filepath.Join(lvs.storageDir, tag.String())
 }
 
 // DescribeVolumes is defined on the VolumeSource interface.
@@ -154,23 +154,13 @@ func (lvs *loopVolumeSource) DestroyVolumes(volumeIds []string) []error {
 }
 
 func (lvs *loopVolumeSource) destroyVolume(volumeId string) error {
-	if _, err := names.ParseVolumeTag(volumeId); err != nil {
+	tag, err := names.ParseVolumeTag(volumeId)
+	if err != nil {
 		return errors.Errorf("invalid loop volume ID %q", volumeId)
 	}
-	loopFilePath := lvs.volumeFilePath(volumeId)
-	deviceNames, err := associatedLoopDevices(lvs.run, loopFilePath)
-	if err != nil {
-		return errors.Annotate(err, "locating loop device")
-	}
-	if len(deviceNames) > 1 {
-		logger.Warningf("expected 1 loop device, got %d", len(deviceNames))
-	}
-	for _, deviceName := range deviceNames {
-		if err := detachLoopDevice(lvs.run, deviceName); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	if err := os.Remove(loopFilePath); err != nil {
+	loopFilePath := lvs.volumeFilePath(tag)
+	err = os.Remove(loopFilePath)
+	if err != nil && !os.IsNotExist(err) {
 		return errors.Annotate(err, "removing loop backing file")
 	}
 	return nil
@@ -198,7 +188,7 @@ func (lvs *loopVolumeSource) AttachVolumes(args []storage.VolumeAttachmentParams
 }
 
 func (lvs *loopVolumeSource) attachVolume(arg storage.VolumeAttachmentParams) (storage.VolumeAttachment, error) {
-	loopFilePath := lvs.volumeFilePath(arg.VolumeId)
+	loopFilePath := lvs.volumeFilePath(arg.Volume)
 	deviceName, err := attachLoopDevice(lvs.run, loopFilePath, arg.ReadOnly)
 	if err != nil {
 		os.Remove(loopFilePath)
@@ -215,9 +205,30 @@ func (lvs *loopVolumeSource) attachVolume(arg storage.VolumeAttachmentParams) (s
 }
 
 // DetachVolumes is defined on the VolumeSource interface.
-func (lvs *loopVolumeSource) DetachVolumes([]storage.VolumeAttachmentParams) error {
-	// TODO(axw)
-	return errors.NotSupportedf("detaching loop devices")
+func (lvs *loopVolumeSource) DetachVolumes(args []storage.VolumeAttachmentParams) error {
+	for _, arg := range args {
+		if err := lvs.detachVolume(arg.Volume); err != nil {
+			return errors.Annotatef(err, "detaching volume %s", arg.Volume.Id())
+		}
+	}
+	return nil
+}
+
+func (lvs *loopVolumeSource) detachVolume(tag names.VolumeTag) error {
+	loopFilePath := lvs.volumeFilePath(tag)
+	deviceNames, err := associatedLoopDevices(lvs.run, loopFilePath)
+	if err != nil {
+		return errors.Annotate(err, "locating loop device")
+	}
+	if len(deviceNames) > 1 {
+		logger.Warningf("expected 1 loop device, got %d", len(deviceNames))
+	}
+	for _, deviceName := range deviceNames {
+		if err := detachLoopDevice(lvs.run, deviceName); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
 }
 
 // createBlockFile creates a file at the specified path, with the


### PR DESCRIPTION
This diff implements the DetachVolumes method of
the loop storage provider, which is mostly just
extracted from the existing DestroyVolumes method.
The latter is changed to just remove the backing
file.

(Review request: http://reviews.vapour.ws/r/1956/)