### PR TITLE
Test UpdateStatus Hook and add UniterParams

### DIFF
--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -215,7 +215,16 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return uniter.NewUniter(uniterFacade, unitTag, leadership.NewClient(st), dataDir, hookLock), nil
+		uniterParams := uniter.UniterParams{
+			uniterFacade,
+			unitTag,
+			leadership.NewClient(st),
+			dataDir,
+			hookLock,
+			uniter.NewMetricsTimerChooser(),
+			uniter.NewUpdateStatusTimer(),
+		}
+		return uniter.NewUniter(&uniterParams), nil
 	})
 
 	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {

--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -13,7 +13,6 @@ func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
 }
 
 var (
-	ActiveMetricsTimer  = &activeMetricsTimer
 	IdleWaitTime        = &idleWaitTime
 	LeadershipGuarantee = &leadershipGuarantee
 )
@@ -42,6 +41,13 @@ func (t *ManualTicker) ReturnTimer(now, lastRun time.Time, interval time.Duratio
 func NewManualTicker() *ManualTicker {
 	return &ManualTicker{
 		c: make(chan time.Time, 1),
+	}
+}
+
+func NewTestingMetricsTimerChooser(active TimedSignal) *timerChooser {
+	return &timerChooser{
+		active:   active,
+		inactive: inactiveMetricsTimer,
 	}
 }
 

--- a/worker/uniter/metrics.go
+++ b/worker/uniter/metrics.go
@@ -28,6 +28,8 @@ func inactiveMetricsTimer(_, _ time.Time, _ time.Duration) <-chan time.Time {
 	return nil
 }
 
+// timerChooser allows modeAbide to choose a proper timer for metrics
+// depending on the charm.
 type timerChooser struct {
 	active   TimedSignal
 	inactive TimedSignal
@@ -43,12 +45,8 @@ func (t *timerChooser) getMetricsTimer(ch corecharm.Charm) TimedSignal {
 	return t.inactive
 }
 
-// defaultTimer returns the timer that is to be used when there is no charm
-// to supply.
-func (t *timerChooser) defaultTimer() TimedSignal {
-	return t.inactive
-}
-
+// NewMetricsTimerChooser returns a timerChooser for
+// collect-metrics.
 func NewMetricsTimerChooser() *timerChooser {
 	return &timerChooser{
 		active:   activeMetricsTimer,

--- a/worker/uniter/metrics.go
+++ b/worker/uniter/metrics.go
@@ -18,7 +18,7 @@ const (
 // as close to interval after the last run as possible.
 var activeMetricsTimer = func(now, lastRun time.Time, interval time.Duration) <-chan time.Time {
 	waitDuration := interval - now.Sub(lastRun)
-	logger.Debugf("waiting for %v", waitDuration)
+	logger.Debugf("metrics waiting for %v", waitDuration)
 	return time.After(waitDuration)
 }
 
@@ -28,12 +28,30 @@ func inactiveMetricsTimer(_, _ time.Time, _ time.Duration) <-chan time.Time {
 	return nil
 }
 
+type timerChooser struct {
+	active   TimedSignal
+	inactive TimedSignal
+}
+
 // getMetricsTimer returns the metrics timer we should be using, given the supplied
 // charm.
-func getMetricsTimer(ch corecharm.Charm) TimedSignal {
+func (t *timerChooser) getMetricsTimer(ch corecharm.Charm) TimedSignal {
 	metrics := ch.Metrics()
 	if metrics != nil && len(metrics.Metrics) > 0 {
-		return activeMetricsTimer
+		return t.active
 	}
-	return inactiveMetricsTimer
+	return t.inactive
+}
+
+// defaultTimer returns the timer that is to be used when there is no charm
+// to supply.
+func (t *timerChooser) defaultTimer() TimedSignal {
+	return t.inactive
+}
+
+func NewMetricsTimerChooser() *timerChooser {
+	return &timerChooser{
+		active:   activeMetricsTimer,
+		inactive: inactiveMetricsTimer,
+	}
 }

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -276,7 +276,7 @@ func ModeAbide(u *Uniter) (next Mode, err error) {
 
 // idleWaitTime is the time after which, if there are no uniter events,
 // the agent state becomes idle.
-var idleWaitTime = 10 * time.Second
+var idleWaitTime = 2 * time.Second
 
 // modeAbideAliveLoop handles all state changes for ModeAbide when the unit
 // is in an Alive state.

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -276,7 +276,7 @@ func ModeAbide(u *Uniter) (next Mode, err error) {
 
 // idleWaitTime is the time after which, if there are no uniter events,
 // the agent state becomes idle.
-var idleWaitTime = 2 * time.Second
+var idleWaitTime = 10 * time.Second
 
 // modeAbideAliveLoop handles all state changes for ModeAbide when the unit
 // is in an Alive state.

--- a/worker/uniter/status.go
+++ b/worker/uniter/status.go
@@ -17,3 +17,8 @@ func updateStatusSignal(now, lastSignal time.Time, interval time.Duration) <-cha
 	waitDuration := interval - now.Sub(lastSignal)
 	return time.After(waitDuration)
 }
+
+// NewUpdateStatusTimer returns a timed signal suitable for update-status hook.
+func NewUpdateStatusTimer() TimedSignal {
+	return updateStatusSignal
+}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -46,6 +46,8 @@ type UniterExecutionObserver interface {
 	HookFailed(hookName string)
 }
 
+type simpleUniterFunc func(*Uniter) error
+
 // Uniter implements the capabilities of the unit agent. It is not intended to
 // implement the actual *behaviour* of the unit agent; that responsibility is
 // delegated to Mode values, which are expected to react to events and direct
@@ -83,6 +85,10 @@ type Uniter struct {
 	// need to be extended, perhaps a list of observers would be needed.
 	observer UniterExecutionObserver
 
+	// metricsTimer is a struct that allows metrics to switch between
+	// active and inactive timers.
+	metricsTimer *timerChooser
+
 	// collectMetricsAt defines a function that will be used to generate signals
 	// for the collect-metrics hook.
 	collectMetricsAt TimedSignal
@@ -92,28 +98,36 @@ type Uniter struct {
 	updateStatusAt TimedSignal
 }
 
+// UniterParams hold all the necessary parameters for a new Uniter.
+type UniterParams struct {
+	St                 *uniter.State
+	UnitTag            names.UnitTag
+	LeadershipManager  coreleadership.LeadershipManager
+	DataDir            string
+	HookLock           *fslock.Lock
+	MetricsTimer       *timerChooser
+	UpdateStatusSignal TimedSignal
+}
+
 // NewUniter creates a new Uniter which will install, run, and upgrade
 // a charm on behalf of the unit with the given unitTag, by executing
 // hooks and operations provoked by changes in st.
-func NewUniter(
-	st *uniter.State,
-	unitTag names.UnitTag,
-	leadershipManager coreleadership.LeadershipManager,
-	dataDir string,
-	hookLock *fslock.Lock,
-) *Uniter {
+func NewUniter(uniterParams *UniterParams) *Uniter {
 	u := &Uniter{
-		st:                st,
-		paths:             NewPaths(dataDir, unitTag),
-		hookLock:          hookLock,
-		leadershipManager: leadershipManager,
-		collectMetricsAt:  inactiveMetricsTimer,
-		updateStatusAt:    updateStatusSignal,
+		st:                uniterParams.St,
+		paths:             NewPaths(uniterParams.DataDir, uniterParams.UnitTag),
+		hookLock:          uniterParams.HookLock,
+		leadershipManager: uniterParams.LeadershipManager,
+		metricsTimer:      uniterParams.MetricsTimer,
+		// TODO(perrito666) make these signals directly fetched from
+		// the timer.
+		collectMetricsAt: uniterParams.MetricsTimer.defaultTimer(),
+		updateStatusAt:   uniterParams.UpdateStatusSignal,
 	}
 	go func() {
 		defer u.tomb.Done()
 		defer u.runCleanups()
-		u.tomb.Kill(u.loop(unitTag))
+		u.tomb.Kill(u.loop(uniterParams.UnitTag))
 	}()
 	return u
 }
@@ -329,7 +343,7 @@ func (u *Uniter) initializeMetricsCollector() error {
 	if err != nil {
 		return err
 	}
-	u.collectMetricsAt = getMetricsTimer(charm)
+	u.collectMetricsAt = u.metricsTimer.getMetricsTimer(charm)
 	return nil
 }
 


### PR DESCRIPTION
Added proper testing for update-status hook and also
converted uniter to use UniterParams instead of a lot
of arguments, making it cleaner to use.
A proper way to change metrics timer was also added.