### PR TITLE
apiserver: fix LP 1466011

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -224,24 +224,12 @@ func Connect(info *Info, pathTail string, header http.Header, opts DialOpts) (*w
 	}
 	pool.AddCert(xcert)
 
-	// If they exist, only use localhost addresses.
-	var addrs []string
-	for _, addr := range info.Addrs {
-		if strings.HasPrefix(addr, "localhost:") {
-			addrs = append(addrs, addr)
-			break
-		}
-	}
-	if len(addrs) == 0 {
-		addrs = info.Addrs
-	}
-
 	path := makeAPIPath(info.EnvironTag.Id(), pathTail)
 
 	// Dial all addresses at reasonable intervals.
 	try := parallel.NewTry(0, nil)
 	defer try.Kill()
-	for _, addr := range addrs {
+	for _, addr := range info.Addrs {
 		err := dialWebsocket(addr, path, header, opts, pool, try)
 		if err == parallel.ErrStopped {
 			break

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -651,7 +651,7 @@ func (s *baseLoginSuite) setupServerWithValidator(c *gc.C, validator apiserver.L
 }
 
 func (s *baseLoginSuite) setupServerForEnvironmentWithValidator(c *gc.C, envTag names.EnvironTag, validator apiserver.LoginValidator) (*api.Info, func()) {
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, jc.ErrorIsNil)
 	srv, err := apiserver.NewServer(
 		s.State,

--- a/cmd/juju/endpoint_test.go
+++ b/cmd/juju/endpoint_test.go
@@ -132,10 +132,9 @@ func (s *EndpointSuite) TestSortingAndFilteringBeforeCachingRespectsPreferIPv6(c
 		"2001:db8::1",
 		"169.254.1.2", // link-local - will be removed.
 		"fd00::1",
-		"localhost", // will be put at the top as last successful.
-		"ff01::1",   // link-local - will be removed.
+		"ff01::1", // link-local - will be removed.
 		"fc00::1",
-		"localhost", // will be removed as a duplicate.
+		"localhost",
 		"0.1.2.3",
 		"127.0.1.1", // removed as a duplicate.
 		"::1",       // removed as a duplicate.
@@ -152,11 +151,12 @@ func (s *EndpointSuite) TestSortingAndFilteringBeforeCachingRespectsPreferIPv6(c
 
 	// Build the expected addresses list, after processing.
 	expectAddresses := s.addressesWithAPIPort(c,
-		"localhost", // This is always on top.
+		"127.0.0.1", // This is always on top.
 		"2001:db8::1",
 		"0.1.2.3",
 		"192.0.0.0",
 		"8.8.8.8",
+		"localhost",
 		"fc00::1",
 		"fd00::1",
 		"10.0.0.1",
@@ -173,11 +173,12 @@ func (s *EndpointSuite) TestSortingAndFilteringBeforeCachingRespectsPreferIPv6(c
 	// Rebuild the expected addresses and rebuild them so IPv4 comes
 	// before IPv6.
 	expectAddresses = s.addressesWithAPIPort(c,
-		"localhost", // This is always on top.
+		"127.0.0.1", // This is always on top.
 		"0.1.2.3",
 		"192.0.0.0",
 		"8.8.8.8",
 		"2001:db8::1",
+		"localhost",
 		"10.0.0.1",
 		"fc00::1",
 		"fd00::1",


### PR DESCRIPTION
Fixes LP 1466011

http://reviews.vapour.ws/r/1928/ removed a bunch of string munging logic related to the reported address of the api server.

This change exposed an expectation by the apiserver test cases that the apiserver would _always_ report it was listening on "localhost", even though the test suite never bound the socket to localhost in the first place. Fix this by explicitly binding to 127.0.0.1 as the test expects, and in the process remove a bunch of code in the api client which had grown to expect a set of 'special' addresses in the api.Info.Addrs slice.

As _real_ clients always use the address specified in their jenv file, that is they never are asked to connect to "0.0.0.0" or "::" or "localhost", the behaviour of the test now better mirrors how the code is used.