### PR TITLE
Fix 1464335 rsyslog certs location.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -32,20 +32,27 @@ import (
 
 var logger = loggo.GetLogger("juju.agent")
 
-// logDir returns a filesystem path to the location where juju
-// may create a folder containing its logs
-var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
+// These are base values used for the corresponding defaults.
+var (
+	logDir  = paths.MustSucceed(paths.LogDir(version.Current.Series))
+	dataDir = paths.MustSucceed(paths.DataDir(version.Current.Series))
+	confDir = paths.MustSucceed(paths.ConfDir(version.Current.Series))
+)
 
-// dataDir returns the default data directory for this running system
-var dataDir = paths.MustSucceed(paths.DataDir(version.Current.Series))
+var (
+	// DefaultLogDir defines the default log directory for juju agents.
+	// It's defined as a variable so it could be overridden in tests.
+	DefaultLogDir = path.Join(logDir, "juju")
 
-// DefaultLogDir defines the default log directory for juju agents.
-// It's defined as a variable so it could be overridden in tests.
-var DefaultLogDir = path.Join(logDir, "juju")
+	// DefaultDataDir defines the default data directory for juju agents.
+	// It's defined as a variable so it could be overridden in tests.
+	DefaultDataDir = dataDir
 
-// DefaultDataDir defines the default data directory for juju agents.
-// It's defined as a variable so it could be overridden in tests.
-var DefaultDataDir = dataDir
+	// DefaultConfDir defines the default config file directory for
+	// Juju agents.
+	// It's defined as a variable so it could be overridden in tests.
+	DefaultConfDir = confDir
+)
 
 // SystemIdentity is the name of the file where the environment SSH key is kept.
 const SystemIdentity = "system-identity"

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -6,6 +6,7 @@ package util
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -237,7 +238,14 @@ var NewRsyslogConfigWorker = func(st *apirsyslog.State, agentConfig agent.Config
 	if err != nil {
 		return nil, err
 	}
-	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, agentConfig.DataDir())
+	jujuConfDir := agent.DefaultConfDir
+	if namespace != "" {
+		jujuConfDir += "-" + namespace
+	}
+	if err := os.MkdirAll(jujuConfDir, 0755); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, jujuConfDir)
 }
 
 // ParamsStateServingInfoToStateStateServingInfo converts a

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -6,7 +6,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strconv"
 
@@ -238,14 +237,7 @@ var NewRsyslogConfigWorker = func(st *apirsyslog.State, agentConfig agent.Config
 	if err != nil {
 		return nil, err
 	}
-	jujuConfDir := agent.DefaultConfDir
-	if namespace != "" {
-		jujuConfDir += "-" + namespace
-	}
-	if err := os.MkdirAll(jujuConfDir, 0755); err != nil {
-		return nil, errors.Trace(err)
-	}
-	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, jujuConfDir)
+	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, agent.DefaultConfDir)
 }
 
 // ParamsStateServingInfoToStateStateServingInfo converts a

--- a/environs/export_test.go
+++ b/environs/export_test.go
@@ -6,6 +6,8 @@ package environs
 var (
 	Providers       = &providers
 	ProviderAliases = &providerAliases
+	UserCurrent     = &userCurrent
+	GetUsername     = &localUsername
 )
 
 func UpdateEnvironAttrs(envs *Environs, name string, newAttrs map[string]interface{}) {

--- a/environs/export_test.go
+++ b/environs/export_test.go
@@ -4,10 +4,9 @@
 package environs
 
 var (
-	Providers       = &providers
-	ProviderAliases = &providerAliases
-	UserCurrent     = &userCurrent
-	GetUsername     = &localUsername
+	Providers         = &providers
+	ProviderAliases   = &providerAliases
+	ResolveSudoByFunc = resolveSudo
 )
 
 func UpdateEnvironAttrs(envs *Environs, name string, newAttrs map[string]interface{}) {

--- a/environs/utils.go
+++ b/environs/utils.go
@@ -17,41 +17,88 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var userCurrent = user.Current
+// TODO(ericsnow) Move the username helpers to the utils repo.
 
-// LocalUsername determines the current username on the local host.
-func LocalUsername() (string, error) {
-	username := os.Getenv("USER")
-	if username == "" {
-		u, err := userCurrent()
+// ResolveSudo returns the original username if sudo was used. The
+// original username is extracted from the OS environment.
+func ResolveSudo(username string) string {
+	return resolveSudo(username, os.Getenv)
+}
+
+func resolveSudo(username string, getenvFunc func(string) string) string {
+	if username != "root" {
+		return username
+	}
+	// sudo was probably called, get the original user.
+	if username := getenvFunc("SUDO_USER"); username != "" {
+		return username
+	}
+	return username
+}
+
+// EnvUsername returns the username from the OS environment.
+func EnvUsername() (string, error) {
+	return os.Getenv("USER"), nil
+}
+
+// OSUsername returns the username of the current OS user (based on UID).
+func OSUsername() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return u.Username, nil
+}
+
+// ResolveUsername returns the username determined by the provided
+// functions. The functions are tried in the same order in which they
+// were passed in. An error returned from any of them is immediately
+// returned. If an empty string is returned then that signals that the
+// function did not find the username and the next function is tried.
+// Once a username is found, the provided resolveSudo func (if any) is
+// called with that username and the result is returned. If no username
+// is found then errors.NotFound is returned.
+func ResolveUsername(resolveSudo func(string) string, usernameFuncs ...func() (string, error)) (string, error) {
+	for _, usernameFunc := range usernameFuncs {
+		username, err := usernameFunc()
 		if err != nil {
 			return "", errors.Trace(err)
 		}
-		username = u.Username
-	}
-	if username == "" {
-		return "", errors.Errorf("cannot get current user from the environment: %v", os.Environ())
-	}
-
-	if username == "root" {
-		// sudo was probably called, get the original user.
-		if original := os.Getenv("SUDO_USER"); original != "" {
-			username = original
+		if username != "" {
+			if resolveSudo != nil {
+				if original := resolveSudo(username); original != "" {
+					username = original
+				}
+			}
+			return username, nil
 		}
+	}
+	return "", errors.NotFoundf("username")
+}
+
+// Namespace generates a namespace name for the given username and
+// environment name.
+func Namespace(username, envName string) string {
+	return fmt.Sprintf("%s-%s", username, envName)
+}
+
+// LocalUsername determines the current username on the local host.
+func LocalUsername() (string, error) {
+	username, err := ResolveUsername(ResolveSudo, EnvUsername, OSUsername)
+	if err != nil {
+		return "", errors.Annotatef(err, "cannot get current user from the environment: %v", os.Environ())
 	}
 	return username, nil
 }
 
-var localUsername = LocalUsername
-
 // LocalNamespace generates a namespace name for the given environment
 // name. The namespace is based on the current local user.
 func LocalNamespace(envName string) (string, error) {
-	username, err := localUsername()
+	username, err := LocalUsername()
 	if err != nil {
 		return "", errors.Annotate(err, "failed to determine username for namespace")
 	}
-	return fmt.Sprintf("%s-%s", username, envName), nil
+	return Namespace(username, envName), nil
 }
 
 // LegacyStorage creates an Environ from the config in state and returns

--- a/environs/utils_test.go
+++ b/environs/utils_test.go
@@ -1,0 +1,88 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environs_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+)
+
+type utilsSuite struct {
+	testing.IsolationSuite
+}
+
+func (s *utilsSuite) TestLocalUsername(c *gc.C) {
+	type test struct {
+		userEnv   string
+		sudoEnv   string
+		userOS    string
+		userOSErr error
+		namespace string
+		err       string
+	}
+	tests := []test{{
+		userEnv:   "someone",
+		sudoEnv:   "notroot",
+		userOS:    "other",
+		namespace: "someone-test",
+	}, {
+		userOS:    "other",
+		namespace: "other-test",
+	}, {
+		userEnv:   "root",
+		namespace: "root-test",
+	}, {
+		userEnv:   "root",
+		sudoEnv:   "other",
+		namespace: "other-test",
+	}, {
+		userOSErr: errors.New("oh noes"),
+		err:       "failed to determine username for namespace: oh noes",
+	}}
+
+	for i, test := range tests {
+		c.Logf("test %d: %v", i, test)
+		s.PatchEnvironment("USER", test.userEnv)
+		s.PatchEnvironment("SUDO_USER", test.sudoEnv)
+		s.PatchValue(environs.UserCurrent, func() (string, error) {
+			return test.userOS, test.userOSErr
+		})
+
+		namespace, err := environs.LocalUsername()
+
+		if test.err == "" {
+			if c.Check(err, jc.ErrorIsNil) {
+				c.Check(namespace, gc.Equals, test.namespace)
+			}
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}
+
+func (s *utilsSuite) TestLocalNamespaceOkay(c *gc.C) {
+	s.PatchValue(&environs.GetUsername, func() (string, error) {
+		return "a", nil
+	})
+
+	namespace, err := environs.LocalNamespace("test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(namespace, gc.Equals, "a-test")
+}
+
+func (s *utilsSuite) TestLocalNamespaceError(c *gc.C) {
+	expected := errors.New("<failure>")
+	s.PatchValue(&environs.GetUsername, func() (string, error) {
+		return "", expected
+	})
+
+	_, err := environs.LocalNamespace("test")
+
+	c.Check(errors.Cause(err), gc.Equals, expected)
+}

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -16,6 +16,7 @@ const (
 	tmpDir osVarType = iota
 	logDir
 	dataDir
+	confDir
 	jujuRun
 )
 
@@ -23,6 +24,7 @@ var nixVals = map[osVarType]string{
 	tmpDir:  "/tmp",
 	logDir:  "/var/log",
 	dataDir: "/var/lib/juju",
+	confDir: "/etc/juju",
 	jujuRun: "/usr/bin/juju-run",
 }
 
@@ -30,6 +32,7 @@ var winVals = map[osVarType]string{
 	tmpDir:  "C:/Juju/tmp",
 	logDir:  "C:/Juju/log",
 	dataDir: "C:/Juju/lib/juju",
+	confDir: "C:/Juju/etc",
 	jujuRun: "C:/Juju/bin/juju-run.exe",
 }
 
@@ -67,6 +70,12 @@ func LogDir(series string) (string, error) {
 // store tools, charms, locks, etc
 func DataDir(series string) (string, error) {
 	return osVal(series, dataDir)
+}
+
+// ConfDir returns the path to the directory where Juju may store
+// configuration files.
+func ConfDir(series string) (string, error) {
+	return osVal(series, confDir)
 }
 
 // JujuRun returns the absolute path to the juju-run binary for

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -531,6 +531,13 @@ func (s *JujuConnSuite) DataDir() string {
 	return filepath.Join(s.RootDir, "/var/lib/juju")
 }
 
+func (s *JujuConnSuite) ConfDir() string {
+	if s.RootDir == "" {
+		panic("DataDir called out of test context")
+	}
+	return filepath.Join(s.RootDir, "/etc/juju")
+}
+
 // WriteConfig writes a juju config file to the "home" directory.
 func (s *JujuConnSuite) WriteConfig(configData string) {
 	if s.RootDir == "" {

--- a/provider/local/export_test.go
+++ b/provider/local/export_test.go
@@ -20,7 +20,7 @@ var (
 	DetectPackageProxies = &detectPackageProxies
 	ExecuteCloudConfig   = &executeCloudConfig
 	Provider             = providerInstance
-	UserCurrent          = &userCurrent
+	GetNamespace         = &getNamespace
 )
 
 // CheckConfigNamespace checks the result of the namespace call on the

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -15,7 +15,6 @@ var (
 	NewStateStorage           = &newStateStorage
 	StateToolsStorage         = &stateToolsStorage
 	AddAZToInstData           = &addAZToInstData
-	GetSyslogNamespace        = &getSyslogNamespace
 
 	ChownPath      = &chownPath
 	IsLocalEnviron = &isLocalEnviron

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -15,6 +15,7 @@ var (
 	NewStateStorage           = &newStateStorage
 	StateToolsStorage         = &stateToolsStorage
 	AddAZToInstData           = &addAZToInstData
+	GetSyslogNamespace        = &getSyslogNamespace
 
 	ChownPath      = &chownPath
 	IsLocalEnviron = &isLocalEnviron

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -46,32 +46,9 @@ func stepsFor124() []Step {
 	}
 }
 
-var getSyslogNamespace = func(context Context) (string, error) {
-	st := context.State()
-	if st == nil {
-		// We're running on a different node than the state server.
-		return "", nil
-	}
-
-	envConfig, err := st.EnvironConfig()
-	if err != nil {
-		return "", errors.Annotate(err, "failed to read current config")
-	}
-
-	namespace, err := getNamespace(envConfig)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return namespace, nil
-}
-
 func moveSyslogConfig(context Context) error {
-	namespace, err := getSyslogNamespace(context)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	config := context.AgentConfig()
+	namespace := config.Value(agent.Namespace)
 	logdir := config.LogDir()
 	confdir := agent.DefaultConfDir
 	if namespace != "" {

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -10,6 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/state"
 )
 
@@ -43,10 +46,37 @@ func stepsFor124() []Step {
 	}
 }
 
+var getSyslogNamespace = func(context Context) (string, error) {
+	st := context.State()
+	if st == nil {
+		// We're running on a different node than the state server.
+		return "", nil
+	}
+
+	envConfig, err := st.EnvironConfig()
+	if err != nil {
+		return "", errors.Annotate(err, "failed to read current config")
+	}
+
+	namespace, err := getNamespace(envConfig)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return namespace, nil
+}
+
 func moveSyslogConfig(context Context) error {
+	namespace, err := getSyslogNamespace(context)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	config := context.AgentConfig()
 	logdir := config.LogDir()
-	datadir := config.DataDir()
+	confdir := agent.DefaultConfDir
+	if namespace != "" {
+		confdir += "-" + namespace
+	}
 
 	// these values were copied from
 	// github.com/juju/juju/utils/syslog/config.go
@@ -62,8 +92,10 @@ func moveSyslogConfig(context Context) error {
 	var errs []string
 	for _, f := range files {
 		oldpath := filepath.Join(logdir, f)
-		newpath := filepath.Join(datadir, f)
-		if err := copyFile(newpath, oldpath); err != nil {
+		newpath := filepath.Join(confdir, f)
+		if err := copyFile(newpath, oldpath); errors.IsNotFound(err) {
+			continue
+		} else if err != nil {
 			errs = append(errs, err.Error())
 			continue
 		}
@@ -91,7 +123,7 @@ func copyFile(to, from string) error {
 	if os.IsNotExist(err) {
 		logger.Debugf("Old file %q does not exist, skipping.", from)
 		// original doesn't exist, that's fine.
-		return nil
+		return errors.NotFoundf(from)
 	}
 	if err != nil {
 		return err

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -104,10 +104,6 @@ func (s *steps124SyslogSuite) SetUpTest(c *gc.C) {
 	logDir := c.MkDir()
 	confDir := c.MkDir()
 	s.setPaths(logDir, confDir)
-
-	s.PatchValue(upgrades.GetSyslogNamespace, func(ctx upgrades.Context) (string, error) {
-		return "", nil
-	})
 }
 
 func (s *steps124SyslogSuite) setPaths(logDir, confDir string) {
@@ -252,6 +248,10 @@ type fakeConfig struct {
 	agent.ConfigSetter
 	logdir  string
 	datadir string
+}
+
+func (f fakeConfig) Value(key string) string {
+	return ""
 }
 
 func (f fakeConfig) LogDir() string {

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -45,11 +45,6 @@ func waitForFile(c *gc.C, file string) {
 		case <-timeout:
 			c.Fatalf("timed out waiting for %s to be written", file)
 		case <-time.After(coretesting.ShortWait):
-			c.Logf("-----------")
-			filepath.Walk(filepath.Dir(filepath.Dir(filepath.Dir(file))), func(path string, _ os.FileInfo, _ error) error {
-				c.Logf(path)
-				return nil
-			})
 			if _, err := os.Stat(file); err == nil {
 				return
 			}

--- a/worker/rsyslog/rsyslog_test.go
+++ b/worker/rsyslog/rsyslog_test.go
@@ -43,7 +43,7 @@ func assertPathExists(c *gc.C, path string) {
 
 func (s *RsyslogSuite) TestStartStop(c *gc.C) {
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", []string{"0.1.2.3"}, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
@@ -51,7 +51,7 @@ func (s *RsyslogSuite) TestStartStop(c *gc.C) {
 
 func (s *RsyslogSuite) TestTearDown(c *gc.C) {
 	st, m := s.st, s.machine
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	confFile := filepath.Join(*rsyslog.RsyslogConfDir, "25-juju.conf")
 	// On worker teardown, the rsyslog config file should be removed.
@@ -69,13 +69,14 @@ func (s *RsyslogSuite) TestRsyslogCert(c *gc.C) {
 	err := s.machine.SetProviderAddresses(network.NewAddress("example.com"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
-	waitForFile(c, filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
+	filename := filepath.Join(s.ConfDir(), "rsyslog", "rsyslog-cert.pem")
+	waitForFile(c, filename)
 
-	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
+	rsyslogCertPEM, err := ioutil.ReadFile(filename)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cert, err := cert.ParseCert(string(rsyslogCertPEM))
@@ -94,18 +95,19 @@ func (s *RsyslogSuite) TestRsyslogCert(c *gc.C) {
 
 func (s *RsyslogSuite) TestModeAccumulate(c *gc.C) {
 	st, m := s.st, s.machine
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", nil, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", nil, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
-	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
+	dirname := filepath.Join(s.ConfDir(), "rsyslog")
+	waitForFile(c, filepath.Join(dirname, "ca-cert.pem"))
 
 	// We should have ca-cert.pem, rsyslog-cert.pem, and rsyslog-key.pem.
-	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(dirname, "ca-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
-	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
+	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(dirname, "rsyslog-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
-	rsyslogKeyPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-key.pem"))
+	rsyslogKeyPEM, err := ioutil.ReadFile(filepath.Join(dirname, "rsyslog-key.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, _, err = cert.ParseCertAndKey(string(rsyslogCertPEM), string(rsyslogKeyPEM))
@@ -130,15 +132,15 @@ func (s *RsyslogSuite) TestModeAccumulate(c *gc.C) {
 
 	syslog.NewAccumulateConfig(syslogConfig)
 	syslogConfig.ConfigDir = *rsyslog.RsyslogConfDir
-	syslogConfig.JujuConfigDir = s.DataDir()
+	syslogConfig.JujuConfigDir = filepath.Join(s.ConfDir(), "rsyslog")
 	rendered, err := syslogConfig.Render()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(string(rsyslogConf), gc.DeepEquals, string(rendered))
 
 	// Verify logrotate files
-	assertPathExists(c, filepath.Join(s.DataDir(), "logrotate.conf"))
-	assertPathExists(c, filepath.Join(s.DataDir(), "logrotate.run"))
+	assertPathExists(c, filepath.Join(dirname, "logrotate.conf"))
+	assertPathExists(c, filepath.Join(dirname, "logrotate.run"))
 
 }
 
@@ -154,7 +156,7 @@ func (s *RsyslogSuite) TestAccumulateHA(c *gc.C) {
 	}
 
 	syslog.NewAccumulateConfig(syslogConfig)
-	syslogConfig.JujuConfigDir = s.DataDir()
+	syslogConfig.JujuConfigDir = filepath.Join(s.ConfDir(), "rsyslog")
 	rendered, err := syslogConfig.Render()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -191,11 +193,10 @@ func (s *RsyslogSuite) testNamespace(c *gc.C, st *api.State, tag names.Tag, name
 		return nil
 	})
 
-	jujuConfigDir := s.AgentConfigForTag(c, tag).DataDir()
-
 	err := os.MkdirAll(expectedLogDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, tag, namespace, []string{"0.1.2.3"}, jujuConfigDir)
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(),
+		rsyslog.RsyslogModeAccumulate, tag, namespace, []string{"0.1.2.3"}, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -210,7 +211,8 @@ func (s *RsyslogSuite) testNamespace(c *gc.C, st *api.State, tag names.Tag, name
 	waitForRestart(c, restarted)
 
 	// Ensure that ca-cert.pem gets written to the expected log dir.
-	waitForFile(c, filepath.Join(jujuConfigDir, "ca-cert.pem"))
+	dirname := filepath.Join(s.ConfDir(), "rsyslog")
+	waitForFile(c, filepath.Join(dirname, "ca-cert.pem"))
 
 	dir, err := os.Open(*rsyslog.RsyslogConfDir)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
@@ -107,6 +108,14 @@ func NewRsyslogConfigWorker(st *apirsyslog.State, mode RsyslogMode, tag names.Ta
 }
 
 func newRsyslogConfigHandler(st *apirsyslog.State, mode RsyslogMode, tag names.Tag, namespace string, stateServerAddrs []string, jujuConfigDir string) (*RsyslogConfigHandler, error) {
+	if namespace != "" {
+		jujuConfigDir += "-" + namespace
+	}
+	jujuConfigDir = filepath.Join(jujuConfigDir, "rsyslog")
+	if err := os.MkdirAll(jujuConfigDir, 0755); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	syslogConfig := &syslog.SyslogConfig{
 		LogFileName:          tag.String(),
 		LogDir:               logDir,


### PR DESCRIPTION
Instead of putting the certs (etc.) in the Juju data dir, we put them in /etc/juju.  Normally the data dir is fine since it is normally /var/lib/juju.  However, on local provider the default data dir is ~/.juju/local, where ~/.juju has 0700 permissions (meaning rsyslog can't read the files).

This patch moves the rsyslog cert/rotation files over to /etc/juju and updates the 1.24 upgrade steps.  In the case that the environment has a namespace (i.e. local provider), the namespace is added onto the path where the files are stored (e.g. /etc/juju-esnow-local).

In order to facilitate the namespace handling, this patch also factors out a helper that generates the namespace.  The changes to all the environs/* files, provider/local/* files and upgrades/agentconfig.go are all strictly related to factoring out that helper.

The changes in the agent, cmd, juju/paths, and worker packages are strictly related to the actual change to the certs location.  The remaining changes in the upgrades package fix the upgrade steps.

(Review request: http://reviews.vapour.ws/r/1963/)