### PR TITLE
Fix the intermittent failure due to bare channel write.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1024,14 +1024,14 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			certChangedChan := make(chan params.StateServingInfo, 1)
 			runner.StartWorker("apiserver", a.apiserverWorkerStarter(st, certChangedChan))
 			var stateServingSetter certupdater.StateServingInfoSetter = func(info params.StateServingInfo, tombDying <-chan struct{}) error {
-				return a.ChangeConfig(func(config agent.ConfigSetter) {
+				return a.ChangeConfig(func(config agent.ConfigSetter) error {
 					config.SetStateServingInfo(info)
 					logger.Infof("update apiserver worker with new certificate")
 					select {
 					case certChangedChan <- info:
-						return
+						return nil
 					case <-tombDying:
-						return
+						return nil
 					}
 				})
 			}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1023,14 +1023,14 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			})
 			certChangedChan := make(chan params.StateServingInfo, 1)
 			runner.StartWorker("apiserver", a.apiserverWorkerStarter(st, certChangedChan))
-			var stateServingSetter certupdater.StateServingInfoSetter = func(info params.StateServingInfo, tombDying <-chan struct{}) error {
+			var stateServingSetter certupdater.StateServingInfoSetter = func(info params.StateServingInfo, done <-chan struct{}) error {
 				return a.ChangeConfig(func(config agent.ConfigSetter) error {
 					config.SetStateServingInfo(info)
 					logger.Infof("update apiserver worker with new certificate")
 					select {
 					case certChangedChan <- info:
 						return nil
-					case <-tombDying:
+					case <-done:
 						return nil
 					}
 				})

--- a/worker/apiaddressupdater/apiaddressupdater.go
+++ b/worker/apiaddressupdater/apiaddressupdater.go
@@ -50,7 +50,7 @@ func (c *APIAddressUpdater) SetUp() (watcher.NotifyWatcher, error) {
 	return c.addresser.WatchAPIHostPorts()
 }
 
-func (c *APIAddressUpdater) Handle() error {
+func (c *APIAddressUpdater) Handle(tombDying <-chan struct{}) error {
 	addresses, err := c.addresser.APIHostPorts()
 	if err != nil {
 		return fmt.Errorf("error getting addresses: %v", err)

--- a/worker/apiaddressupdater/apiaddressupdater.go
+++ b/worker/apiaddressupdater/apiaddressupdater.go
@@ -50,7 +50,7 @@ func (c *APIAddressUpdater) SetUp() (watcher.NotifyWatcher, error) {
 	return c.addresser.WatchAPIHostPorts()
 }
 
-func (c *APIAddressUpdater) Handle(tombDying <-chan struct{}) error {
+func (c *APIAddressUpdater) Handle(_ <-chan struct{}) error {
 	addresses, err := c.addresser.APIHostPorts()
 	if err != nil {
 		return fmt.Errorf("error getting addresses: %v", err)

--- a/worker/authenticationworker/worker.go
+++ b/worker/authenticationworker/worker.go
@@ -106,7 +106,7 @@ func (kw *keyupdaterWorker) writeSSHKeys(jujuKeys []string) error {
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (kw *keyupdaterWorker) Handle(tombDying <-chan struct{}) error {
+func (kw *keyupdaterWorker) Handle(_ <-chan struct{}) error {
 	// Read the keys that Juju has.
 	newKeys, err := kw.st.AuthorisedKeys(kw.tag)
 	if err != nil {

--- a/worker/authenticationworker/worker.go
+++ b/worker/authenticationworker/worker.go
@@ -106,7 +106,7 @@ func (kw *keyupdaterWorker) writeSSHKeys(jujuKeys []string) error {
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (kw *keyupdaterWorker) Handle() error {
+func (kw *keyupdaterWorker) Handle(tombDying <-chan struct{}) error {
 	// Read the keys that Juju has.
 	newKeys, err := kw.st.AuthorisedKeys(kw.tag)
 	if err != nil {

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -4,6 +4,8 @@
 package certupdater
 
 import (
+	"reflect"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -28,6 +30,7 @@ type CertificateUpdater struct {
 	setter         StateServingInfoSetter
 	configGetter   EnvironConfigGetter
 	certChanged    chan params.StateServingInfo
+	addresses      []network.Address
 }
 
 // AddressWatcher is an interface that is provided to NewCertificateUpdater
@@ -76,7 +79,14 @@ func (c *CertificateUpdater) SetUp() (watcher.NotifyWatcher, error) {
 // Handle is defined on the NotifyWatchHandler interface.
 func (c *CertificateUpdater) Handle() error {
 	addresses := c.addressWatcher.Addresses()
-	logger.Debugf("new machine addresses: %v", addresses)
+	logger.Debugf("new machine addresses: %#v", addresses)
+	if reflect.DeepEqual(addresses, c.addresses) {
+		// Sometimes the watcher will tell us things have changed, when they
+		// haven't as far as we can tell.
+		logger.Debugf("addresses haven't really changed since last updated cert")
+		return nil
+	}
+	c.addresses = addresses
 
 	// Older Juju deployments will not have the CA cert private key
 	// available.

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -54,7 +54,7 @@ type StateServingInfoGetter interface {
 
 // StateServingInfoSetter defines a function that is called to set a
 // StateServingInfo value with a newly generated certificate.
-type StateServingInfoSetter func(info params.StateServingInfo, tombDying <-chan struct{}) error
+type StateServingInfoSetter func(info params.StateServingInfo, done <-chan struct{}) error
 
 // NewCertificateUpdater returns a worker.Worker that watches for changes to
 // machine addresses and then generates a new state server certificate with those
@@ -77,7 +77,7 @@ func (c *CertificateUpdater) SetUp() (watcher.NotifyWatcher, error) {
 }
 
 // Handle is defined on the NotifyWatchHandler interface.
-func (c *CertificateUpdater) Handle(tombDying <-chan struct{}) error {
+func (c *CertificateUpdater) Handle(done <-chan struct{}) error {
 	addresses := c.addressWatcher.Addresses()
 	logger.Debugf("new machine addresses: %#v", addresses)
 	if reflect.DeepEqual(addresses, c.addresses) {
@@ -130,7 +130,7 @@ func (c *CertificateUpdater) Handle(tombDying <-chan struct{}) error {
 	}
 	stateInfo.Cert = string(newCert)
 	stateInfo.PrivateKey = string(newKey)
-	c.setter(stateInfo, tombDying)
+	c.setter(stateInfo, done)
 	logger.Infof("State Server cerificate addresses updated to %q", addresses)
 	return nil
 }

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -54,7 +54,7 @@ type StateServingInfoGetter interface {
 
 // StateServingInfoSetter defines a function that is called to set a
 // StateServingInfo value with a newly generated certificate.
-type StateServingInfoSetter func(info params.StateServingInfo, tombDying <-chan struct{})
+type StateServingInfoSetter func(info params.StateServingInfo, tombDying <-chan struct{}) error
 
 // NewCertificateUpdater returns a worker.Worker that watches for changes to
 // machine addresses and then generates a new state server certificate with those

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -90,7 +90,9 @@ func (g *mockConfigGetter) EnvironConfig() (*config.Config, error) {
 }
 
 func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
-	setter := func(info params.StateServingInfo, dying <-chan struct{}) {}
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {
+		return nil
+	}
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
@@ -103,7 +105,7 @@ func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
 func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	var srvCert *x509.Certificate
 	updated := make(chan struct{})
-	setter := func(info params.StateServingInfo, dying <-chan struct{}) {
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {
 		var err error
 		srvCert, err = cert.ParseCert(info.Cert)
 		c.Assert(err, jc.ErrorIsNil)
@@ -114,6 +116,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 		if len(sanIPs) == 1 && sanIPs[0] == "0.1.2.3" {
 			close(updated)
 		}
+		return nil
 	}
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
@@ -153,8 +156,9 @@ func (g *mockStateServingGetterNoCAKey) StateServingInfo() (params.StateServingI
 
 func (s *CertUpdaterSuite) TestAddressChangeNoCAKey(c *gc.C) {
 	updated := make(chan struct{})
-	setter := func(info params.StateServingInfo, dying <-chan struct{}) {
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {
 		close(updated)
+		return nil
 	}
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -90,9 +90,7 @@ func (g *mockConfigGetter) EnvironConfig() (*config.Config, error) {
 }
 
 func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
-	setter := func(info params.StateServingInfo) error {
-		return nil
-	}
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) {}
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
@@ -105,7 +103,7 @@ func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
 func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	var srvCert *x509.Certificate
 	updated := make(chan struct{})
-	setter := func(info params.StateServingInfo) error {
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) {
 		var err error
 		srvCert, err = cert.ParseCert(info.Cert)
 		c.Assert(err, jc.ErrorIsNil)
@@ -116,7 +114,6 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 		if len(sanIPs) == 1 && sanIPs[0] == "0.1.2.3" {
 			close(updated)
 		}
-		return nil
 	}
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
@@ -156,9 +153,8 @@ func (g *mockStateServingGetterNoCAKey) StateServingInfo() (params.StateServingI
 
 func (s *CertUpdaterSuite) TestAddressChangeNoCAKey(c *gc.C) {
 	updated := make(chan struct{})
-	setter := func(info params.StateServingInfo) error {
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) {
 		close(updated)
-		return nil
 	}
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)

--- a/worker/cleaner/cleaner.go
+++ b/worker/cleaner/cleaner.go
@@ -32,7 +32,7 @@ func (c *Cleaner) SetUp() (watcher.NotifyWatcher, error) {
 	return c.st.WatchCleanups()
 }
 
-func (c *Cleaner) Handle() error {
+func (c *Cleaner) Handle(tombDying <-chan struct{}) error {
 	if err := c.st.Cleanup(); err != nil {
 		logger.Errorf("cannot cleanup state: %v", err)
 	}

--- a/worker/cleaner/cleaner.go
+++ b/worker/cleaner/cleaner.go
@@ -32,7 +32,7 @@ func (c *Cleaner) SetUp() (watcher.NotifyWatcher, error) {
 	return c.st.WatchCleanups()
 }
 
-func (c *Cleaner) Handle(tombDying <-chan struct{}) error {
+func (c *Cleaner) Handle(_ <-chan struct{}) error {
 	if err := c.st.Cleanup(); err != nil {
 		logger.Errorf("cannot cleanup state: %v", err)
 	}

--- a/worker/conv2state/converter.go
+++ b/worker/conv2state/converter.go
@@ -78,7 +78,7 @@ func (c *converter) SetUp() (watcher.NotifyWatcher, error) {
 // Handle implements NotifyWatchHandler's Handle method.  If the change means
 // that the machine is now expected to manage the environment, we change its
 // password (to set its password in mongo) and restart the agent.
-func (c *converter) Handle() error {
+func (c *converter) Handle(tombDying <-chan struct{}) error {
 	results, err := c.machine.Jobs()
 	if err != nil {
 		return errors.Annotate(err, "can't get jobs for machine")

--- a/worker/conv2state/converter.go
+++ b/worker/conv2state/converter.go
@@ -78,7 +78,7 @@ func (c *converter) SetUp() (watcher.NotifyWatcher, error) {
 // Handle implements NotifyWatchHandler's Handle method.  If the change means
 // that the machine is now expected to manage the environment, we change its
 // password (to set its password in mongo) and restart the agent.
-func (c *converter) Handle(tombDying <-chan struct{}) error {
+func (c *converter) Handle(_ <-chan struct{}) error {
 	results, err := c.machine.Jobs()
 	if err != nil {
 		return errors.Annotate(err, "can't get jobs for machine")

--- a/worker/conv2state/converter_test.go
+++ b/worker/conv2state/converter_test.go
@@ -70,7 +70,7 @@ func (s Suite) TestHandle(c *gc.C) {
 	conv := &converter{machiner: mr, agent: a}
 	_, err := conv.SetUp()
 	c.Assert(err, gc.IsNil)
-	err = conv.Handle()
+	err = conv.Handle(nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(a.didRestart, jc.IsTrue)
 }
@@ -85,7 +85,7 @@ func (s Suite) TestHandleNoManageEnviron(c *gc.C) {
 	conv := &converter{machiner: mr, agent: a}
 	_, err := conv.SetUp()
 	c.Assert(err, gc.IsNil)
-	err = conv.Handle()
+	err = conv.Handle(nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(a.didRestart, jc.IsFalse)
 }
@@ -101,7 +101,7 @@ func (Suite) TestHandleJobsError(c *gc.C) {
 	conv := &converter{machiner: mr, agent: a}
 	_, err := conv.SetUp()
 	c.Assert(err, gc.IsNil)
-	err = conv.Handle()
+	err = conv.Handle(nil)
 	c.Assert(errors.Cause(err), gc.Equals, m.jobsErr)
 	c.Assert(a.didRestart, jc.IsFalse)
 }
@@ -119,7 +119,7 @@ func (s Suite) TestHandleRestartError(c *gc.C) {
 	conv := &converter{machiner: mr, agent: a}
 	_, err := conv.SetUp()
 	c.Assert(err, gc.IsNil)
-	err = conv.Handle()
+	err = conv.Handle(nil)
 	c.Assert(errors.Cause(err), gc.Equals, a.restartErr)
 
 	// We set this to true whenver the function is called, even though we're

--- a/worker/logger/logger.go
+++ b/worker/logger/logger.go
@@ -64,7 +64,7 @@ func (logger *Logger) SetUp() (watcher.NotifyWatcher, error) {
 	return logger.api.WatchLoggingConfig(logger.agentConfig.Tag())
 }
 
-func (logger *Logger) Handle() error {
+func (logger *Logger) Handle(tombDying <-chan struct{}) error {
 	logger.setLogging()
 	return nil
 }

--- a/worker/logger/logger.go
+++ b/worker/logger/logger.go
@@ -64,7 +64,7 @@ func (logger *Logger) SetUp() (watcher.NotifyWatcher, error) {
 	return logger.api.WatchLoggingConfig(logger.agentConfig.Tag())
 }
 
-func (logger *Logger) Handle(tombDying <-chan struct{}) error {
+func (logger *Logger) Handle(_ <-chan struct{}) error {
 	logger.setLogging()
 	return nil
 }

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -95,7 +95,7 @@ func setMachineAddresses(m *machiner.Machine) error {
 	return m.SetMachineAddresses(hostAddresses)
 }
 
-func (mr *Machiner) Handle(tombDying <-chan struct{}) error {
+func (mr *Machiner) Handle(_ <-chan struct{}) error {
 	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return worker.ErrTerminateAgent
 	} else if err != nil {

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -95,7 +95,7 @@ func setMachineAddresses(m *machiner.Machine) error {
 	return m.SetMachineAddresses(hostAddresses)
 }
 
-func (mr *Machiner) Handle() error {
+func (mr *Machiner) Handle(tombDying <-chan struct{}) error {
 	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return worker.ErrTerminateAgent
 	} else if err != nil {

--- a/worker/notifyworker.go
+++ b/worker/notifyworker.go
@@ -35,9 +35,12 @@ type NotifyWatchHandler interface {
 	// TearDown should cleanup any resources that are left around
 	TearDown() error
 
-	// Handle is called when the Watcher has indicated there are
-	// changes, do whatever work is necessary to process it
-	Handle(<-chan struct{}) error
+	// Handle is called when the Watcher has indicated there are changes, do
+	// whatever work is necessary to process it. The done channel is closed if
+	// the worker is being interrupted to finish. Any worker should avoid any
+	// bare channel reads or writes, but instead use a select with the done
+	// channel.
+	Handle(done <-chan struct{}) error
 }
 
 // NewNotifyWorker starts a new worker running the business logic from

--- a/worker/notifyworker.go
+++ b/worker/notifyworker.go
@@ -37,7 +37,7 @@ type NotifyWatchHandler interface {
 
 	// Handle is called when the Watcher has indicated there are
 	// changes, do whatever work is necessary to process it
-	Handle() error
+	Handle(<-chan struct{}) error
 }
 
 // NewNotifyWorker starts a new worker running the business logic from
@@ -97,7 +97,7 @@ func (nw *notifyWorker) loop() error {
 			if !ok {
 				return ensureErr(w)
 			}
-			if err := nw.handler.Handle(); err != nil {
+			if err := nw.handler.Handle(nw.tomb.Dying()); err != nil {
 				return err
 			}
 		}

--- a/worker/notifyworker_test.go
+++ b/worker/notifyworker_test.go
@@ -93,7 +93,7 @@ func (nh *notifyHandler) TearDown() error {
 	return nh.teardownError
 }
 
-func (nh *notifyHandler) Handle(tombDying <-chan struct{}) error {
+func (nh *notifyHandler) Handle(_ <-chan struct{}) error {
 	nh.mu.Lock()
 	defer nh.mu.Unlock()
 	nh.actions = append(nh.actions, "handler")

--- a/worker/notifyworker_test.go
+++ b/worker/notifyworker_test.go
@@ -93,7 +93,7 @@ func (nh *notifyHandler) TearDown() error {
 	return nh.teardownError
 }
 
-func (nh *notifyHandler) Handle() error {
+func (nh *notifyHandler) Handle(tombDying <-chan struct{}) error {
 	nh.mu.Lock()
 	defer nh.mu.Unlock()
 	nh.actions = append(nh.actions, "handler")

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -212,7 +212,7 @@ func (w *proxyWorker) SetUp() (watcher.NotifyWatcher, error) {
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (w *proxyWorker) Handle(tombDying <-chan struct{}) error {
+func (w *proxyWorker) Handle(_ <-chan struct{}) error {
 	return w.onChange()
 }
 

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -212,7 +212,7 @@ func (w *proxyWorker) SetUp() (watcher.NotifyWatcher, error) {
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (w *proxyWorker) Handle() error {
+func (w *proxyWorker) Handle(tombDying <-chan struct{}) error {
 	return w.onChange()
 }
 

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -74,7 +74,7 @@ func (r *Reboot) SetUp() (watcher.NotifyWatcher, error) {
 	return watcher, nil
 }
 
-func (r *Reboot) Handle(tombDying <-chan struct{}) error {
+func (r *Reboot) Handle(_ <-chan struct{}) error {
 	rAction, err := r.st.GetRebootAction()
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -74,7 +74,7 @@ func (r *Reboot) SetUp() (watcher.NotifyWatcher, error) {
 	return watcher, nil
 }
 
-func (r *Reboot) Handle() error {
+func (r *Reboot) Handle(tombDying <-chan struct{}) error {
 	rAction, err := r.st.GetRebootAction()
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -227,7 +227,7 @@ func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {
 	return nil
 }
 
-func (h *RsyslogConfigHandler) Handle(tombDying <-chan struct{}) error {
+func (h *RsyslogConfigHandler) Handle(_ <-chan struct{}) error {
 	cfg, err := h.st.GetRsyslogConfig(h.tag.String())
 	if err != nil {
 		return errors.Annotate(err, "cannot get environ config")

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -227,7 +227,7 @@ func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {
 	return nil
 }
 
-func (h *RsyslogConfigHandler) Handle() error {
+func (h *RsyslogConfigHandler) Handle(tombDying <-chan struct{}) error {
 	cfg, err := h.st.GetRsyslogConfig(h.tag.String())
 	if err != nil {
 		return errors.Annotate(err, "cannot get environ config")

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -264,5 +264,6 @@ func (runner *runner) runWorker(delay time.Duration, id string, start func() (Wo
 		runner.startedc <- startInfo{id, worker}
 		err = worker.Wait()
 	}
+	logger.Infof("stopped %q, err: %v", id, err)
 	runner.donec <- doneInfo{id, err}
 }


### PR DESCRIPTION
The certupdater worker was making the mistake of trusting a watcher. It
was blindly getting the addresses and updating the certificate. The
cases where the agent failed to stop was when for some reason, the
address watcher fired twice after the apiserver worker had shut down,
but before the certupdater worker was signalled to die (or before it
noticed). The certupdater worker communicates with the apiserver worker
through a buffered channel (with a one item buffer).  It was the second
notification that triggered the blocking channel send.

I added a memory to the cert updater, so it doesn't blindly update the
cert, but only when the addresses do in fact change.


(Review request: http://reviews.vapour.ws/r/1964/)