### PR TITLE
Allow units with just dynamic storage to be assigned to a clean machine

### DIFF
--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1035,7 +1035,7 @@ func (s *assignCleanSuite) TestAssignToMachineErrors(c *gc.C) {
 	err = unit.AssignToMachine(machine)
 	c.Assert(
 		err, gc.ErrorMatches,
-		`cannot assign unit "storage-filesystem/0" to machine 0: dynamic storage with static storage provider not supported`,
+		`cannot assign unit "storage-filesystem/0" to machine 0: "static" storage provider does not support dynamic storage`,
 	)
 
 	container, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
@@ -1071,7 +1071,7 @@ func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageCleanAvailable(c *
 	// Check the machine on the unit is set.
 	machineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
-	// Check that the machine is our clean one.
+	// Check that the machine isn't our clean one.
 	c.Assert(machineId, gc.Not(gc.Equals), clean.Id())
 }
 

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/txn"
 	gc "gopkg.in/check.v1"
@@ -18,13 +19,13 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
 type AssignSuite struct {
 	ConnSuite
-	wordpress  *state.Service
-	storageSvc *state.Service
+	wordpress *state.Service
 }
 
 var _ = gc.Suite(&AssignSuite{})
@@ -33,11 +34,6 @@ var _ = gc.Suite(&assignCleanSuite{ConnSuite{}, state.AssignClean, nil})
 
 func (s *AssignSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	pm := poolmanager.New(state.NewStateSettings(s.State))
-	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
-	c.Assert(err, jc.ErrorIsNil)
-	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
-
 	wordpress := s.AddTestingServiceWithNetworks(
 		c,
 		"wordpress",
@@ -46,16 +42,6 @@ func (s *AssignSuite) SetUpTest(c *gc.C) {
 	)
 	wordpress.SetConstraints(constraints.MustParse("networks=net3,^net4,^net5"))
 	s.wordpress = wordpress
-	s.storageSvc = s.AddTestingServiceWithStorage(
-		c, "storage-block", s.AddTestingCharm(c, "storage-block"),
-		map[string]state.StorageConstraints{
-			"data": {
-				Pool:  "loop-pool",
-				Count: 1,
-				Size:  1024,
-			},
-		},
-	)
 }
 
 func (s *AssignSuite) addSubordinate(c *gc.C, principal *state.Unit) *state.Unit {
@@ -693,6 +679,10 @@ func (s *assignCleanSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 	wordpress := s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.wordpress = wordpress
+	pm := poolmanager.New(state.NewStateSettings(s.State))
+	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	registry.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
 }
 
 func (s *assignCleanSuite) errorMessage(msg string) string {
@@ -976,7 +966,7 @@ func (s *assignCleanSuite) TestAssignUnitWithRemovedService(c *gc.C) {
 	_, err = s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.assignUnit(unit)
-	c.Assert(err, gc.ErrorMatches, s.errorMessage(`cannot assign unit "wordpress/0" to %s machine.*: unit not found`))
+	c.Assert(err, gc.ErrorMatches, s.errorMessage(`cannot assign unit "wordpress/0" to %s machine.* not found`))
 }
 
 func (s *assignCleanSuite) TestAssignUnitToMachineWithRemovedUnit(c *gc.C) {
@@ -1007,13 +997,63 @@ func (s *assignCleanSuite) TestAssignUnitToMachineWorksWithMachine0(c *gc.C) {
 	c.Assert(assignedTo.Id(), gc.Equals, "0")
 }
 
-func (s *AssignSuite) TestAssignUnitWithStorageCleanAvailable(c *gc.C) {
-	cons, err := s.storageSvc.StorageConstraints()
+func (s *assignCleanSuite) setupSingleStorage(c *gc.C, kind, pool string) (*state.Service, *state.Unit, names.StorageTag) {
+	// There are test charms called "storage-block" and
+	// "storage-filesystem" which are what you'd expect.
+	ch := s.AddTestingCharm(c, "storage-"+kind)
+	storage := map[string]state.StorageConstraints{
+		"data": makeStorageCons(pool, 1024, 1),
+	}
+	service := s.AddTestingServiceWithStorage(c, "storage-"+kind, ch, storage)
+	unit, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.HasLen, 2)
+	storageTag := names.NewStorageTag("data/0")
+	return service, unit, storageTag
+}
 
-	unit, err := s.storageSvc.AddUnit()
+func (s *assignCleanSuite) TestAssignToMachine(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "loop-pool")
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+	filesystemAttachments, err := s.State.MachineFilesystemAttachments(machine.MachineTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystemAttachments, gc.HasLen, 1)
+}
+
+func (s *assignCleanSuite) TestAssignToMachineErrors(c *gc.C) {
+	registry.RegisterProvider("static", &dummy.StorageProvider{
+		IsDynamic: false,
+	})
+	registry.RegisterEnvironStorageProviders("someprovider", "static")
+	defer registry.RegisterProvider("static", nil)
+
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "static")
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(machine)
+	c.Assert(
+		err, gc.ErrorMatches,
+		`cannot assign unit "storage-filesystem/0" to machine 0: dynamic storage with static storage provider not supported`,
+	)
+
+	container, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	}, machine.Id(), instance.LXC)
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(container)
+	c.Assert(err, gc.ErrorMatches, `cannot assign unit "storage-filesystem/0" to machine 0/lxc/0: adding storage to lxc container not supported`)
+}
+
+func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageCleanAvailable(c *gc.C) {
+	registry.RegisterProvider("static", &dummy.StorageProvider{
+		IsDynamic: false,
+	})
+	registry.RegisterEnvironStorageProviders("someprovider", "static")
+	defer registry.RegisterProvider("static", nil)
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "static")
 	storageAttachments, err := s.State.UnitStorageAttachments(unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageAttachments, gc.HasLen, 1)
@@ -1023,8 +1063,29 @@ func (s *AssignSuite) TestAssignUnitWithStorageCleanAvailable(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// assign the unit to a machine, requesting clean/empty. Since
-	// the unit has storage instances associated, it will be forced
-	// onto a new machine.
+	// the unit has non dynamic storage instances associated,
+	// it will be forced onto a new machine.
+	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check the machine on the unit is set.
+	machineId, err := unit.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	// Check that the machine is our clean one.
+	c.Assert(machineId, gc.Not(gc.Equals), clean.Id())
+}
+
+func (s *assignCleanSuite) TestAssignUnitWithDynamicStorageCleanAvailable(c *gc.C) {
+	_, unit, _ := s.setupSingleStorage(c, "filesystem", "loop-pool")
+	storageAttachments, err := s.State.UnitStorageAttachments(unit.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageAttachments, gc.HasLen, 1)
+
+	// Add a clean machine.
+	clean, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// assign the unit to a machine, requesting clean/empty
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1032,7 +1093,7 @@ func (s *AssignSuite) TestAssignUnitWithStorageCleanAvailable(c *gc.C) {
 	machineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 	// Check that the machine isn't our clean one.
-	c.Assert(machineId, gc.Not(gc.Equals), clean.Id())
+	c.Assert(machineId, gc.Equals, clean.Id())
 
 	// Check that a volume attachments were added to the machine.
 	machine, err := s.State.Machine(machineId)

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -334,7 +334,7 @@ func (s *storageAddSuite) TestAddStorageStatic(c *gc.C) {
 	)
 	c.Assert(err, gc.ErrorMatches, "adding storage to unit storage-filesystem/0: "+
 		"creating machine storage for storage data/1: "+
-		"static storage provider does not support dynamic storage")
+		`"static" storage provider does not support dynamic storage`)
 	s.assertStorageCount(c, 1)    // no change
 	s.assertFileSystemCount(c, 1) // no change
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -1269,6 +1269,8 @@ func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParam
 
 // validateDynamicStorageParams validates that all storage providers required for
 // provisioning the storage in params support dynamic storage.
+// If any provider doesn't support dynamic storage, then an IsNotSupported error
+// is returned.
 func validateDynamicStorageParams(st *State, params *machineStorageParams) error {
 	pools := make(set.Strings)
 	for _, v := range params.volumes {
@@ -1321,10 +1323,9 @@ func validateDynamicStorageParams(st *State, params *machineStorageParams) error
 			return errors.Trace(err)
 		}
 		if !provider.Dynamic() {
-			return errors.NotSupportedf(
-				"dynamic storage with %s storage provider",
-				providerType,
-			)
+			return errors.NewNotSupported(
+				err,
+				fmt.Sprintf("%q storage provider does not support dynamic storage", providerType))
 		}
 	}
 	return nil

--- a/state/unit.go
+++ b/state/unit.go
@@ -1264,23 +1264,29 @@ func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParam
 		// to be restarted to pick up new configuration.
 		return errors.NotSupportedf("adding storage to %s container", m.ContainerType())
 	}
+	return validateDynamicStorageParams(m.st, params)
+}
+
+// validateDynamicStorageParams validates that all storage providers required for
+// provisioning the storage in params support dynamic storage.
+func validateDynamicStorageParams(st *State, params *machineStorageParams) error {
 	pools := make(set.Strings)
 	for _, v := range params.volumes {
-		v, err := m.st.volumeParamsWithDefaults(v.Volume)
+		v, err := st.volumeParamsWithDefaults(v.Volume)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		pools.Add(v.Pool)
 	}
 	for _, f := range params.filesystems {
-		f, err := m.st.filesystemParamsWithDefaults(f.Filesystem)
+		f, err := st.filesystemParamsWithDefaults(f.Filesystem)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		pools.Add(f.Pool)
 	}
 	for volumeTag := range params.volumeAttachments {
-		volume, err := m.st.Volume(volumeTag)
+		volume, err := st.Volume(volumeTag)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1295,7 +1301,7 @@ func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParam
 		}
 	}
 	for filesystemTag := range params.filesystemAttachments {
-		filesystem, err := m.st.Filesystem(filesystemTag)
+		filesystem, err := st.Filesystem(filesystemTag)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1310,13 +1316,13 @@ func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParam
 		}
 	}
 	for pool := range pools {
-		providerType, provider, err := poolStorageProvider(m.st, pool)
+		providerType, provider, err := poolStorageProvider(st, pool)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		if !provider.Dynamic() {
-			return errors.Errorf(
-				"%s storage provider does not support dynamic storage",
+			return errors.NotSupportedf(
+				"dynamic storage with %s storage provider",
 				providerType,
 			)
 		}
@@ -1832,16 +1838,19 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 		return nil, err
 	}
 
-	// TODO(axw) once we support dynamic storage provisioning, we
-	// should check whether all of the storage constraints can be
-	// fulfilled dynamically (by querying a policy).
-	storageCons, err := u.StorageConstraints()
+	// If any required storage s not all dynamic, then assigning
+	// to a new machine is required.
+	storageParams, err := u.machineStorageParams()
 	if err != nil {
 		assignContextf(&err, u, context)
 		return nil, err
 	}
-	if len(storageCons) > 0 {
-		return nil, noCleanMachines
+	if err := validateDynamicStorageParams(u.st, storageParams); err != nil {
+		if errors.IsNotSupported(err) {
+			return nil, noCleanMachines
+		}
+		assignContextf(&err, u, context)
+		return nil, err
 	}
 
 	// Get the unit constraints to see what deployment requirements we have to adhere to.
@@ -1914,6 +1923,15 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 	// provisioned without the fact having yet been recorded
 	// in state.
 	for _, m := range machines {
+		// Check that the unit storage is compatible with
+		// the machine in question.
+		if err := validateDynamicMachineStorageParams(m, storageParams); err != nil {
+			if errors.IsNotSupported(err) {
+				continue
+			}
+			assignContextf(&err, u, context)
+			return nil, err
+		}
 		err := u.assignToMachine(m, true)
 		if err == nil {
 			return m, nil


### PR DESCRIPTION
Units with just dynamic storage can now be assigned to a clean machine. Previously, a unit with any storage was forced onto a new machine.

(Review request: http://reviews.vapour.ws/r/1965/)