### PR TITLE
jujuc: use juju/rpc, proxy client's stdio

### DIFF
--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -240,7 +240,7 @@ var argsTests = []struct {
 	{[]string{"remote"}, 0, "success!\n"},
 	{[]string{"/path/to/remote"}, 0, "success!\n"},
 	{[]string{"remote", "--help"}, 0, expectUsage},
-	{[]string{"unknown"}, 1, "error: bad request: bad command: unknown\n"},
+	{[]string{"unknown"}, 1, "error: request error: bad request: bad command: unknown\n"},
 	{[]string{"remote", "--error", "borken"}, 1, "error: borken\n"},
 	{[]string{"remote", "--unknown"}, 2, "error: flag provided but not defined: --unknown\n"},
 	{[]string{"remote", "unwanted"}, 2, `error: unrecognized args: ["unwanted"]` + "\n"},
@@ -270,7 +270,7 @@ func (s *JujuCMainSuite) TestBadClientId(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	output := run(c, s.sockPath, "ben", 1, "remote")
-	c.Assert(output, gc.Equals, "error: bad request: bad context: ben\n")
+	c.Assert(output, gc.Equals, "error: request error: bad request: bad context: ben\n")
 }
 
 func (s *JujuCMainSuite) TestNoSockPath(c *gc.C) {

--- a/juju/sockets/sockets_nix.go
+++ b/juju/sockets/sockets_nix.go
@@ -4,12 +4,19 @@ package sockets
 
 import (
 	"net"
-	"net/rpc"
 	"os"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/jsoncodec"
 )
 
-func Dial(socketPath string) (*rpc.Client, error) {
-	return rpc.Dial("unix", socketPath)
+func Dial(socketPath string) (*rpc.Conn, error) {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+	codec := jsoncodec.NewNet(conn)
+	return rpc.NewConn(codec, nil), nil
 }
 
 func Listen(socketPath string) (net.Listener, error) {

--- a/juju/sockets/sockets_windows.go
+++ b/juju/sockets/sockets_windows.go
@@ -2,17 +2,20 @@ package sockets
 
 import (
 	"net"
-	"net/rpc"
 
 	"gopkg.in/natefinch/npipe.v2"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/jsoncodec"
 )
 
-func Dial(socketPath string) (*rpc.Client, error) {
+func Dial(socketPath string) (*rpc.Conn, error) {
 	conn, err := npipe.Dial(socketPath)
 	if err != nil {
 		return nil, err
 	}
-	return rpc.NewClient(conn), nil
+	codec := jsoncodec.NewNet(conn)
+	return rpc.NewConn(codec, nil), nil
 }
 
 func Listen(socketPath string) (net.Listener, error) {

--- a/worker/uniter/runlistener_test.go
+++ b/worker/uniter/runlistener_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/sockets"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter"
 )
@@ -65,6 +66,7 @@ func (s *ListenerSuite) TestClientCall(c *gc.C) {
 	client, err := sockets.Dial(s.socketPath)
 	c.Assert(err, jc.ErrorIsNil)
 	defer client.Close()
+	client.Start()
 
 	var result exec.ExecResponse
 	args := uniter.RunCommandsArgs{
@@ -73,7 +75,9 @@ func (s *ListenerSuite) TestClientCall(c *gc.C) {
 		RemoteUnitName:  "",
 		ForceRemoteUnit: false,
 	}
-	err = client.Call(uniter.JujuRunEndpoint, args, &result)
+	err = client.Call(rpc.Request{
+		uniter.JujuRunServerType, 0, "", uniter.JujuRunRunCommandsAction,
+	}, &args, &result)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(string(result.Stdout), gc.Equals, "some-command stdout")

--- a/worker/uniter/runner/jujuc/stdio.go
+++ b/worker/uniter/runner/jujuc/stdio.go
@@ -1,0 +1,92 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"io"
+
+	"github.com/juju/juju/rpc"
+)
+
+// StdioServerRoot is a juju/rpc server root object that provides
+// a "Stdio" RPC object with methods for interacting with the
+// server's stdio.
+type StdioServerRoot struct {
+	stdin io.Reader
+}
+
+// NewStdioServerRoot returns a new StdioServerRoot with the
+// specified reader used for stdin.
+func NewStdioServerRoot(stdin io.Reader) *StdioServerRoot {
+	return &StdioServerRoot{stdin}
+}
+
+// ReadRequest contains arguments for performing a Read operation.
+type ReadRequest struct {
+	// Len is the maximum number of bytes to read.
+	Len int
+}
+
+// ReadResponse contains the result of a Read operation.
+type ReadResponse struct {
+	Data []byte
+	EOF  bool
+}
+
+// Stdio returns the exported "Stdio" juju/rpc type.
+func (s *StdioServerRoot) Stdio(id string) (*StdioServer, error) {
+	return &StdioServer{s.stdin}, nil
+}
+
+// StdioServer provides methods for interacting with stdio.
+type StdioServer struct {
+	stdin io.Reader
+}
+
+// ReadStdin reads data from the server's stdin, and returns it to the client.
+func (s *StdioServer) ReadStdin(arg ReadRequest) (ReadResponse, error) {
+	buf := make([]byte, arg.Len)
+	n, err := s.stdin.Read(buf)
+	if err != nil && err != io.EOF {
+		return ReadResponse{}, err
+	}
+	return ReadResponse{Data: buf[:n], EOF: err == io.EOF}, nil
+}
+
+// RpcCaller is an interface passed to StdioClient for interacting with
+// a remote StdioServer. RpcCaller is implemented by *juju/rpc.Conn.
+type RpcCaller interface {
+	Call(req rpc.Request, params, response interface{}) error
+}
+
+// StdioClient wraps a juju/rpc connection to interact with a
+// remote server of StdioServerRoot.
+type StdioClient struct {
+	Conn RpcCaller
+}
+
+// Stdin returns an io.Reader that reads from the server's stdin.
+func (c *StdioClient) Stdin() io.Reader {
+	return &stdioReader{c.Conn, "ReadStdin"}
+}
+
+type stdioReader struct {
+	caller RpcCaller
+	method string
+}
+
+// Read implements io.Reader.
+func (r *stdioReader) Read(p []byte) (n int, err error) {
+	var res ReadResponse
+	args := ReadRequest{len(p)}
+	err = r.caller.Call(rpc.Request{"Stdio", 0, "", r.method}, &args, &res)
+	if err != nil {
+		return 0, err
+	}
+	if res.EOF {
+		err = io.EOF
+	}
+	n = copy(p, res.Data)
+	return n, err
+}

--- a/worker/uniter/runner/jujuc/stdio_test.go
+++ b/worker/uniter/runner/jujuc/stdio_test.go
@@ -1,0 +1,117 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing/iotest"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type StdioSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&StdioSuite{})
+
+func (s *StdioSuite) TestStdioServer(c *gc.C) {
+	stdin := strings.NewReader("abcdef")
+	server := newStdioServer(c, iotest.TimeoutReader(stdin))
+	assertRead(c, server, 0, []byte{}, false, "")
+	assertRead(c, server, 4, []byte{}, false, "timeout")
+	assertRead(c, server, 4, []byte("abcd"), false, "")
+	assertRead(c, server, 3, []byte("ef"), false, "")
+	assertRead(c, server, 99, []byte{}, true, "")
+
+	stdin.Seek(0, 0)
+	server = newStdioServer(c, iotest.DataErrReader(stdin))
+	assertRead(c, server, 6, []byte("abcdef"), true, "")
+}
+
+func (s *StdioSuite) TestStdioClient(c *gc.C) {
+	expectedParams := []*jujuc.ReadRequest{{1}, {1}, {1}}
+	responses := []jujuc.ReadResponse{
+		{[]byte("a"), false},
+		{[]byte("b"), false},
+		{[]byte("c"), true},
+	}
+	var calls int
+	call := func(req rpc.Request, params, response interface{}) error {
+		c.Assert(req, jc.DeepEquals, rpc.Request{
+			"Stdio", 0, "", "ReadStdin",
+		})
+		c.Assert(params, jc.DeepEquals, expectedParams[calls])
+		c.Assert(response, gc.FitsTypeOf, &jujuc.ReadResponse{})
+		*response.(*jujuc.ReadResponse) = responses[calls]
+		calls++
+		return nil
+	}
+
+	client := &jujuc.StdioClient{mockRpcCaller{call}}
+	stdin := client.Stdin()
+	c.Assert(stdin, gc.NotNil)
+
+	data, err := ioutil.ReadAll(iotest.OneByteReader(stdin))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, []byte("abc"))
+	c.Assert(calls, gc.Equals, len(responses))
+}
+
+func (s *StdioSuite) TestStdioClientErrors(c *gc.C) {
+	var response jujuc.ReadResponse
+	var serverErr error
+	call := func(req rpc.Request, params, out interface{}) error {
+		*out.(*jujuc.ReadResponse) = response
+		return serverErr
+	}
+	client := &jujuc.StdioClient{mockRpcCaller{call}}
+	stdin := client.Stdin()
+
+	buf := make([]byte, 1)
+	response.EOF = true
+	_, err := stdin.Read(buf)
+	c.Assert(err, gc.Equals, io.EOF)
+
+	serverErr = errors.New("badness")
+	_, err = stdin.Read(buf)
+	c.Assert(err, gc.Equals, serverErr)
+}
+
+func newStdioServer(c *gc.C, stdin io.Reader) *jujuc.StdioServer {
+	root := jujuc.NewStdioServerRoot(stdin)
+	c.Assert(root, gc.NotNil)
+	server, err := root.Stdio("anything")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(server, gc.NotNil)
+	return server
+}
+
+func assertRead(c *gc.C, server *jujuc.StdioServer, n int, expect []byte, expectEOF bool, expectErr string) {
+	response, err := server.ReadStdin(jujuc.ReadRequest{n})
+	if expectErr != "" {
+		c.Assert(err, gc.ErrorMatches, expectErr)
+	} else {
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(response.Data, jc.DeepEquals, expect)
+		c.Assert(response.EOF, gc.Equals, expectEOF)
+	}
+
+}
+
+type mockRpcCaller struct {
+	call func(req rpc.Request, params, response interface{}) error
+}
+
+func (c mockRpcCaller) Call(req rpc.Request, params, response interface{}) error {
+	return c.call(req, params, response)
+}

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/leadership"
 	"github.com/juju/juju/lease"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/testcharms"
@@ -1388,9 +1389,12 @@ func (cmds asyncRunCommands) step(c *gc.C, ctx *context) {
 		client, err := sockets.Dial(socketPath)
 		c.Assert(err, jc.ErrorIsNil)
 		defer client.Close()
+		client.Start()
 
 		var result utilexec.ExecResponse
-		err = client.Call(uniter.JujuRunEndpoint, args, &result)
+		err = client.Call(rpc.Request{
+			uniter.JujuRunServerType, 0, "", uniter.JujuRunRunCommandsAction,
+		}, &args, &result)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(result.Code, gc.Equals, 0)
 		c.Check(string(result.Stdout), gc.Equals, "")


### PR DESCRIPTION
The jujuc and "juju run" commands now use
juju/rpc to communicate between the client
and server. This enables bidirectional
requests.

Using the above, we expose the jujud/client
process's stdio (currently just stdin) to
the server via RPC. The server implements
a client for this that implements io.Reader,
which we pass into the jujuc commands via
the cmd.Context structure.

Fixes https://bugs.launchpad.net/juju-core/+bug/1454678

(Review request: http://reviews.vapour.ws/r/1966/)