### PR TITLE
Fix force unit destroy checks

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -335,7 +335,7 @@ func (st *State) obliterateUnit(unitName string) error {
 	// prevent further dependencies being added. If we're really lucky, the
 	// unit will be removed immediately.
 	if err := unit.Destroy(); err != nil {
-		return err
+		return errors.Annotatef(err, "cannot destroy unit %q", unitName)
 	}
 	if err := unit.Refresh(); errors.IsNotFound(err) {
 		return nil

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1001,37 +1001,6 @@ func (s *UnitSuite) TestShortCircuitDestroyUnit(c *gc.C) {
 	assertRemoved(c, s.unit)
 }
 
-func (s *UnitSuite) TestShortCircuitDestroyUnitStillInstalling(c *gc.C) {
-	// A unit that has not yet started is removed directly.
-	for i, test := range []struct {
-		agentStatus state.Status
-		agentInfo   string
-		unitStatus  state.Status
-		unitInfo    string
-	}{{
-		state.StatusAllocating, "blah",
-		state.StatusUnknown, "Waiting for agent initialization to finish",
-	}, {
-		state.StatusExecuting, "blah",
-		state.StatusMaintenance, "installing charm software",
-	}} {
-		c.Logf("test %d", i)
-		unit, err := s.service.AddUnit()
-		c.Assert(err, jc.ErrorIsNil)
-		// Allocating is default and we aren't allowed to set it ourselves.
-		if test.agentStatus != state.StatusAllocating {
-			err := unit.SetAgentStatus(test.agentStatus, test.agentInfo, nil)
-			c.Assert(err, jc.ErrorIsNil)
-		}
-		err = unit.SetStatus(test.unitStatus, test.unitInfo, nil)
-		c.Assert(err, jc.ErrorIsNil)
-		err = unit.Destroy()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(unit.Life(), gc.Equals, state.Dying)
-		assertRemoved(c, unit)
-	}
-}
-
 func (s *UnitSuite) TestCannotShortCircuitDestroyWithSubordinates(c *gc.C) {
 	// A unit with subordinates is just set to Dying.
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
@@ -1054,7 +1023,11 @@ func (s *UnitSuite) TestCannotShortCircuitDestroyWithStatus(c *gc.C) {
 		status state.Status
 		info   string
 	}{{
-		state.StatusExecuting, "",
+		state.StatusExecuting, "blah",
+	}, {
+		state.StatusIdle, "blah",
+	}, {
+		state.StatusFailed, "blah",
 	}, {
 		state.StatusRebooting, "blah",
 	}} {


### PR DESCRIPTION
The previous implementations short circuited if unit hadn't been allocated OR it hadn't been installed.

However, the behaviour in 1.21 before the new status work was to only short circuit if the unit hadn't finished allocating. This branch restores the 1.21 behaviour.

(Review request: http://reviews.vapour.ws/r/1968/)