### PR TITLE
provider/{ec2,local}: use environschema

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1481,6 +1481,24 @@ func AptProxyConfigMap(proxySettings proxy.Settings) map[string]interface{} {
 	return settings
 }
 
+// Schema returns a configuration schema that includes both
+// the given extra fields and all the fields defined in this package.
+// It returns an error if extra defines any fields defined in this
+// package.
+func Schema(extra environschema.Fields) (environschema.Fields, error) {
+	fields := make(environschema.Fields)
+	for name, field := range configSchema {
+		fields[name] = field
+	}
+	for name, field := range extra {
+		if _, ok := fields[name]; ok {
+			return nil, errors.Errorf("config field %q clashes with global config", name)
+		}
+		fields[name] = field
+	}
+	return fields, nil
+}
+
 // configSchema holds information on all the fields defined by
 // the config package.
 // TODO(rog) make this available to external packages.

--- a/environs/config/export_test.go
+++ b/environs/config/export_test.go
@@ -5,6 +5,7 @@ package config
 
 var (
 	DistroLtsSeries = &distroLtsSeries
+	ConfigSchema    = configSchema
 )
 
 func ResetCachedLtsSeries() {

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -360,3 +360,14 @@ func (s *ConfigSuite) TestPrepareDoesNotTouchExistingControlBucket(c *gc.C) {
 	bucket := env.(*environ).ecfg().controlBucket()
 	c.Assert(bucket, gc.Equals, "burblefoo")
 }
+
+func (*ConfigSuite) TestSchema(c *gc.C) {
+	fields := providerInstance.Schema()
+	// Check that all the fields defined in environs/config
+	// are in the returned schema.
+	globalFields, err := config.Schema(nil)
+	c.Assert(err, gc.IsNil)
+	for name, field := range globalFields {
+		c.Check(fields[name], jc.DeepEquals, field)
+	}
+}

--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -190,3 +190,14 @@ func (s *configSuite) TestLocalRespectsUpgradeSettings(c *gc.C) {
 	c.Check(testConfig.EnableOSRefreshUpdate(), jc.IsTrue)
 	c.Check(testConfig.EnableOSUpgrade(), jc.IsTrue)
 }
+
+func (*configSuite) TestSchema(c *gc.C) {
+	fields := local.Provider.Schema()
+	// Check that all the fields defined in environs/config
+	// are in the returned schema.
+	globalFields, err := config.Schema(nil)
+	c.Assert(err, gc.IsNil)
+	for name, field := range globalFields {
+		c.Check(fields[name], jc.DeepEquals, field)
+	}
+}

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"github.com/juju/utils/proxy"
+	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -55,6 +56,15 @@ func (environProvider) Open(cfg *config.Config) (environs.Environ, error) {
 		return nil, errors.Annotate(err, "failure setting config")
 	}
 	return environ, nil
+}
+
+// Schema returns the configuration schema for an environment.
+func (environProvider) Schema() environschema.Fields {
+	fields, err := config.Schema(configSchema)
+	if err != nil {
+		panic(err)
+	}
+	return fields
 }
 
 // correctLocalhostURLs exams proxy attributes and changes URL values pointing to localhost to use bridge IP.


### PR DESCRIPTION
We add Schema methods to the providers to make the schema available
directly. In a future PR we will add the Schema method to the Provider
interface, but for the moment it's optional to avoid the need to change
all the providers at once.


(Review request: http://reviews.vapour.ws/r/1969/)