### PR TITLE
Fix logic to short circuit a unit destruction

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -794,7 +794,7 @@ func canBeLost(status *api.UnitStatus) bool {
 		return status.UnitAgent.Info != operation.RunningHookMessage(string(hooks.Install))
 	}
 	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := status.Workload.Status != params.StatusMaintenance || status.Workload.Info != "installing charm software"
+	isInstalled := status.Workload.Status != params.StatusMaintenance || status.Workload.Info != state.MessageInstalling
 	return isInstalled
 }
 

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -385,7 +385,7 @@ func (st *State) obliterateUnit(unitName string) error {
 	// prevent further dependencies being added. If we're really lucky, the
 	// unit will be removed immediately.
 	if err := unit.Destroy(); err != nil {
-		return err
+		return errors.Annotatef(err, "cannot destroy unit %q", unitName)
 	}
 	if err := unit.Refresh(); errors.IsNotFound(err) {
 		return nil

--- a/state/service.go
+++ b/state/service.go
@@ -649,6 +649,8 @@ func (s *Service) newUnitName() (string, error) {
 	return name, nil
 }
 
+const MessageWaitForAgentInit = "Waiting for agent initialization to finish"
+
 // addUnitOps returns a unique name for a new unit, and a list of txn operations
 // necessary to create that unit. The principalName param must be non-empty if
 // and only if s is a subordinate service. Only one subordinate of a given
@@ -693,7 +695,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	}
 	unitStatusDoc := statusDoc{
 		Status:     StatusUnknown,
-		StatusInfo: "Waiting for agent initialization to finish",
+		StatusInfo: MessageWaitForAgentInit,
 		Updated:    &now,
 		EnvUUID:    s.st.EnvironUUID(),
 	}

--- a/state/status.go
+++ b/state/status.go
@@ -625,6 +625,8 @@ func getEntitiesWithStatuses(coll stateCollection) ([]string, error) {
 	return entityKeys, nil
 }
 
+const MessageInstalling = "installing charm software"
+
 // TranslateLegacyAgentStatus returns the status value clients expect to see for
 // agent-state in versions prior to 1.24
 func TranslateToLegacyAgentState(agentStatus, workloadStatus Status, workloadMessage string) (Status, bool) {
@@ -641,7 +643,7 @@ func TranslateToLegacyAgentState(agentStatus, workloadStatus Status, workloadMes
 	// For the purposes of deriving the legacy status, there's currently no better
 	// way to determine if a unit is installed.
 	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := workloadStatus != StatusMaintenance || workloadMessage != "installing charm software"
+	isInstalled := workloadStatus != StatusMaintenance || workloadMessage != MessageInstalling
 
 	switch agentStatus {
 	case StatusAllocating:

--- a/state/unit.go
+++ b/state/unit.go
@@ -336,10 +336,24 @@ func (u *Unit) eraseHistory() error {
 	return nil
 }
 
-// unitAgentAllocating actually refers to the unit's agent.
-var unitAgentAllocating = bson.D{
+// unitAgentAllocatingOrInstalling is used to assert that a unit agent may be installing a unit.
+var unitAgentAllocatingOrInstalling = bson.D{
 	{"$or", []bson.D{
 		{{"status", StatusAllocating}},
+		{{"status", StatusExecuting}},
+	}}}
+
+// unitInitialisingOrInstalling is used to assert that a unit is not yet finished installing.
+var unitInitialisingOrInstalling = bson.D{
+	{"$or", []bson.D{
+		{{"$and", []bson.D{
+			{{"status", StatusMaintenance}},
+			{{"statusinfo", MessageInstalling}},
+		}}},
+		{{"$and", []bson.D{
+			{{"status", StatusUnknown}},
+			{{"statusinfo", MessageWaitForAgentInit}},
+		}}},
 	}}}
 
 // destroyOps returns the operations required to destroy the unit. If it
@@ -398,24 +412,30 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 	isAllocated := agentStatusDoc.Status != StatusAllocating
 	isError := agentStatusDoc.Status == StatusError
 
-	unitStatusDoc, err := getStatus(u.st, u.globalKey())
+	unitStatusDocId := u.globalKey()
+	unitStatusDoc, err := getStatus(u.st, unitStatusDocId)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	// There's currently no better way to determine if a unit is installed.
 	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := unitStatusDoc.Status != StatusMaintenance || unitStatusDoc.StatusInfo != "installing charm software"
+	isInstalled := unitStatusDoc.Status != StatusMaintenance || unitStatusDoc.StatusInfo != MessageInstalling
 
 	// If already allocated and installed, or there's an error, then we can't set directly to dead.
 	if isError || isAllocated && isInstalled {
 		return setDyingOps, nil
 	}
 
-	ops := []txn.Op{{
-		C:      statusesC,
-		Id:     u.st.docID(agentStatusDocId),
-		Assert: unitAgentAllocating,
-	}, minUnitsOp}
+	ops := []txn.Op{
+		{
+			C:      statusesC,
+			Id:     u.st.docID(agentStatusDocId),
+			Assert: unitAgentAllocatingOrInstalling,
+		}, {
+			C:      statusesC,
+			Id:     u.st.docID(unitStatusDocId),
+			Assert: unitInitialisingOrInstalling,
+		}, minUnitsOp}
 	removeAsserts := append(isAliveDoc, bson.DocElem{
 		"$and", []bson.D{
 			unitHasNoSubordinates,

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1001,37 +1001,6 @@ func (s *UnitSuite) TestShortCircuitDestroyUnit(c *gc.C) {
 	assertRemoved(c, s.unit)
 }
 
-func (s *UnitSuite) TestShortCircuitDestroyUnitStillInstalling(c *gc.C) {
-	// A unit that has not yet started is removed directly.
-	for i, test := range []struct {
-		agentStatus state.Status
-		agentInfo   string
-		unitStatus  state.Status
-		unitInfo    string
-	}{{
-		state.StatusAllocating, "blah",
-		state.StatusUnknown, "Waiting for agent initialization to finish",
-	}, {
-		state.StatusExecuting, "blah",
-		state.StatusMaintenance, "installing charm software",
-	}} {
-		c.Logf("test %d", i)
-		unit, err := s.service.AddUnit()
-		c.Assert(err, jc.ErrorIsNil)
-		// Allocating is default and we aren't allowed to set it ourselves.
-		if test.agentStatus != state.StatusAllocating {
-			err := unit.SetAgentStatus(test.agentStatus, test.agentInfo, nil)
-			c.Assert(err, jc.ErrorIsNil)
-		}
-		err = unit.SetStatus(test.unitStatus, test.unitInfo, nil)
-		c.Assert(err, jc.ErrorIsNil)
-		err = unit.Destroy()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(unit.Life(), gc.Equals, state.Dying)
-		assertRemoved(c, unit)
-	}
-}
-
 func (s *UnitSuite) TestCannotShortCircuitDestroyWithSubordinates(c *gc.C) {
 	// A unit with subordinates is just set to Dying.
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))
@@ -1054,7 +1023,11 @@ func (s *UnitSuite) TestCannotShortCircuitDestroyWithStatus(c *gc.C) {
 		status state.Status
 		info   string
 	}{{
-		state.StatusExecuting, "",
+		state.StatusExecuting, "blah",
+	}, {
+		state.StatusIdle, "blah",
+	}, {
+		state.StatusFailed, "blah",
 	}, {
 		state.StatusRebooting, "blah",
 	}} {

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1001,6 +1001,37 @@ func (s *UnitSuite) TestShortCircuitDestroyUnit(c *gc.C) {
 	assertRemoved(c, s.unit)
 }
 
+func (s *UnitSuite) TestShortCircuitDestroyUnitStillInstalling(c *gc.C) {
+	// A unit that has not yet started is removed directly.
+	for i, test := range []struct {
+		agentStatus state.Status
+		agentInfo   string
+		unitStatus  state.Status
+		unitInfo    string
+	}{{
+		state.StatusAllocating, "blah",
+		state.StatusUnknown, "Waiting for agent initialization to finish",
+	}, {
+		state.StatusExecuting, "blah",
+		state.StatusMaintenance, "installing charm software",
+	}} {
+		c.Logf("test %d", i)
+		unit, err := s.service.AddUnit()
+		c.Assert(err, jc.ErrorIsNil)
+		// Allocating is default and we aren't allowed to set it ourselves.
+		if test.agentStatus != state.StatusAllocating {
+			err := unit.SetAgentStatus(test.agentStatus, test.agentInfo, nil)
+			c.Assert(err, jc.ErrorIsNil)
+		}
+		err = unit.SetStatus(test.unitStatus, test.unitInfo, nil)
+		c.Assert(err, jc.ErrorIsNil)
+		err = unit.Destroy()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(unit.Life(), gc.Equals, state.Dying)
+		assertRemoved(c, unit)
+	}
+}
+
 func (s *UnitSuite) TestCannotShortCircuitDestroyWithSubordinates(c *gc.C) {
 	// A unit with subordinates is just set to Dying.
 	s.AddTestingService(c, "logging", s.AddTestingCharm(c, "logging"))


### PR DESCRIPTION
Fix logic to short circuit a unit destruction

Fixes: https://bugs.launchpad.net/juju-core/+bug/1464616

destroy machine --force was broken for units with bad install
hooks because the logic to short circuit the unit destruction
 was broken.


(Review request: http://reviews.vapour.ws/r/1973/)