### PR TITLE
state: added LogTailer

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -27,7 +27,7 @@ github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-30T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T10:32:42Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	16d187c1d8218c9b97bdbb8a17ff31705f72c1cf	2015-05-26T23:59:59Z
+github.com/juju/utils	git	ae45df0635c6b27c1e8a17a10ed7602fe6012575	2015-06-16T21:27:54Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -6,8 +6,11 @@ package state
 import (
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"path/filepath"
+	"time"
 
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	jujutxn "github.com/juju/txn"
@@ -400,4 +403,42 @@ func UnitGlobalKey(u *Unit) string {
 
 func UnitAgentGlobalKey(u *UnitAgent) string {
 	return u.globalKey()
+}
+
+// WriteLogWithOplog writes out a log record to the a (probably fake)
+// oplog collection and the logs collection.
+func WriteLogWithOplog(
+	oplog *mgo.Collection,
+	envUUID string,
+	entity names.Tag,
+	t time.Time,
+	module string,
+	location string,
+	level loggo.Level,
+	msg string,
+) error {
+	doc := &logDoc{
+		Id:       bson.NewObjectId(),
+		Time:     t,
+		EnvUUID:  envUUID,
+		Entity:   entity.String(),
+		Module:   module,
+		Location: location,
+		Level:    level,
+		Message:  msg,
+	}
+	err := oplog.Insert(bson.D{
+		{"ts", bson.MongoTimestamp(time.Now().Unix() << 32)}, // an approximation which will do
+		{"h", rand.Int63()},                                  // again, a suitable fake
+		{"op", "i"},                                          // this will always be an insert
+		{"ns", "logs.logs"},
+		{"o", doc},
+	})
+	if err != nil {
+		return err
+	}
+
+	session := oplog.Database.Session
+	logs := session.DB("logs").C("logs")
+	return logs.Insert(doc)
 }

--- a/state/logs.go
+++ b/state/logs.go
@@ -6,14 +6,21 @@
 package state
 
 import (
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"github.com/juju/utils/deque"
+	"github.com/juju/utils/set"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/mongo"
 )
 
 const logsDB = "logs"
@@ -83,6 +90,300 @@ func (logger *DbLogger) Log(t time.Time, module string, location string, level l
 func (logger *DbLogger) Close() {
 	if logger.logsColl != nil {
 		logger.logsColl.Database.Session.Close()
+	}
+}
+
+// LogTailer allows for retrieval of Juju's logs from MongoDB. It
+// first returns any matching already recorded logs and then waits for
+// additional matching logs as they appear.
+type LogTailer interface {
+	// Logs returns the channel through which the LogTailer returns
+	// Juju logs. It will be closed when the tailer stops.
+	Logs() <-chan *LogRecord
+
+	// Dying returns a channel which will be closed as the LogTailer
+	// stops.
+	Dying() <-chan struct{}
+
+	// Stop is used to request that the LogTailer stops. It blocks
+	// unil the LogTailer has stopped.
+	Stop() error
+
+	// Err returns the error that caused the LogTailer to stopped. If
+	// it hasn't stopped or stopped without error nil will be
+	// returned.
+	Err() error
+}
+
+// LogRecord defines a single Juju log message as returned by
+// LogTailer.
+type LogRecord struct {
+	Time     time.Time
+	Entity   string
+	Module   string
+	Location string
+	Level    loggo.Level
+	Message  string
+}
+
+// LogTailerParams specifies the filtering a LogTailer should apply to
+// logs in order to decide which to return.
+type LogTailerParams struct {
+	StartTime     time.Time
+	MinLevel      loggo.Level
+	InitialLines  int
+	IncludeEntity []string
+	ExcludeEntity []string
+	IncludeModule []string
+	ExcludeModule []string
+	Oplog         *mgo.Collection // For testing only
+}
+
+// This is the maximum number of log document ids that will be tracked
+// to avoid re-reporting messages when moving querying the logs
+// collection and tailing the oplog.
+const maxRecentLogIds = 5192
+
+// NewLogTailer returns a LogTailer which filters according to the
+// parameters given.
+func NewLogTailer(st *State, params *LogTailerParams) LogTailer {
+	session := st.MongoSession().Copy()
+	t := &logTailer{
+		envUUID:   st.EnvironUUID(),
+		session:   session,
+		logsColl:  session.DB(logsDB).C(logsC).With(session),
+		params:    params,
+		logCh:     make(chan *LogRecord),
+		recentIds: newRecentIdTracker(maxRecentLogIds),
+	}
+	go func() {
+		err := t.loop()
+		t.tomb.Kill(errors.Cause(err))
+		close(t.logCh)
+		session.Close()
+		t.tomb.Done()
+	}()
+	return t
+}
+
+type logTailer struct {
+	tomb      tomb.Tomb
+	envUUID   string
+	session   *mgo.Session
+	logsColl  *mgo.Collection
+	params    *LogTailerParams
+	logCh     chan *LogRecord
+	lastTime  time.Time
+	recentIds *recentIdTracker
+}
+
+// Logs implements the LogTailer interface.
+func (t *logTailer) Logs() <-chan *LogRecord {
+	return t.logCh
+}
+
+// Dying implements the LogTailer interface.
+func (t *logTailer) Dying() <-chan struct{} {
+	return t.tomb.Dying()
+}
+
+// Stop implements the LogTailer interface.
+func (t *logTailer) Stop() error {
+	t.tomb.Kill(nil)
+	return t.tomb.Wait()
+}
+
+// Err implements the LogTailer interface.
+func (t *logTailer) Err() error {
+	return t.tomb.Err()
+}
+
+func (t *logTailer) loop() error {
+	err := t.processCollection()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = t.tailOplog()
+	return errors.Trace(err)
+}
+
+func (t *logTailer) processCollection() error {
+	// Create a selector from the params.
+	sel := t.paramsToSelector(t.params, "")
+	query := t.logsColl.Find(sel)
+
+	if t.params.InitialLines > 0 {
+		// This is a little racy but it's good enough.
+		count, err := query.Count()
+		if err != nil {
+			return errors.Annotate(err, "query count failed")
+		}
+		query = query.Skip(count - t.params.InitialLines)
+	}
+
+	iter := query.Sort("t", "_id").Iter()
+	doc := new(logDoc)
+	for iter.Next(doc) {
+		select {
+		case <-t.tomb.Dying():
+			return errors.Trace(tomb.ErrDying)
+		case t.logCh <- logDocToRecord(doc):
+			t.lastTime = doc.Time
+			t.recentIds.Add(doc.Id)
+		}
+	}
+	return errors.Trace(iter.Close())
+}
+
+func (t *logTailer) tailOplog() error {
+	recentIds := t.recentIds.AsSet()
+
+	newParams := t.params
+	newParams.StartTime = t.lastTime
+	oplogSel := append(t.paramsToSelector(newParams, "o."),
+		bson.DocElem{"ns", logsDB + "." + logsC},
+	)
+
+	oplog := t.params.Oplog
+	if oplog == nil {
+		oplog = mongo.GetOplog(t.session)
+	}
+	oplogTailer := mongo.NewOplogTailer(oplog, oplogSel)
+	defer oplogTailer.Stop()
+
+	for {
+		select {
+		case <-t.tomb.Dying():
+			return errors.Trace(tomb.ErrDying)
+		case oplogDoc, ok := <-oplogTailer.Out():
+			if !ok {
+				return errors.Annotate(oplogTailer.Err(), "oplog tailer died")
+			}
+
+			doc := new(logDoc)
+			err := oplogDoc.UnmarshalObject(doc)
+			if err != nil {
+				return errors.Annotate(err, "oplog unmarshalling failed")
+			}
+
+			if recentIds.Contains(doc.Id) {
+				// This document has already been reported.
+				continue
+			}
+
+			select {
+			case <-t.tomb.Dying():
+				return errors.Trace(tomb.ErrDying)
+			case t.logCh <- logDocToRecord(doc):
+			}
+		}
+	}
+}
+
+func (t *logTailer) paramsToSelector(params *LogTailerParams, prefix string) bson.D {
+	sel := bson.D{
+		{"e", t.envUUID},
+		{"t", bson.M{"$gte": params.StartTime}},
+	}
+	if params.MinLevel > loggo.UNSPECIFIED {
+		sel = append(sel, bson.DocElem{"v", bson.M{"$gte": params.MinLevel}})
+	}
+	if len(params.IncludeEntity) > 0 {
+		sel = append(sel,
+			bson.DocElem{"n", bson.RegEx{Pattern: makeEntityPattern(params.IncludeEntity)}})
+	}
+	if len(params.ExcludeEntity) > 0 {
+		sel = append(sel,
+			bson.DocElem{"n", bson.M{"$not": bson.RegEx{Pattern: makeEntityPattern(params.ExcludeEntity)}}})
+	}
+	if len(params.IncludeModule) > 0 {
+		sel = append(sel,
+			bson.DocElem{"m", bson.RegEx{Pattern: makeModulePattern(params.IncludeModule)}})
+	}
+	if len(params.ExcludeModule) > 0 {
+		sel = append(sel,
+			bson.DocElem{"m", bson.M{"$not": bson.RegEx{Pattern: makeModulePattern(params.ExcludeModule)}}})
+	}
+
+	if prefix != "" {
+		for i, elem := range sel {
+			sel[i].Name = prefix + elem.Name
+		}
+	}
+	return sel
+}
+
+func makeEntityPattern(entities []string) string {
+	var patterns []string
+	for _, entity := range entities {
+		// Convert * wildcard to the regex equivalent. This is safe
+		// because * never appears in entity names.
+		patterns = append(patterns, strings.Replace(entity, "*", ".*", -1))
+	}
+	return `^(` + strings.Join(patterns, "|") + `)$`
+}
+
+func makeModulePattern(modules []string) string {
+	var patterns []string
+	for _, module := range modules {
+		patterns = append(patterns, regexp.QuoteMeta(module))
+	}
+	return `^(` + strings.Join(patterns, "|") + `)(\..+)?$`
+}
+
+func newRecentIdTracker(maxLen int) *recentIdTracker {
+	return &recentIdTracker{
+		ids: deque.NewWithMaxLen(maxLen),
+	}
+}
+
+type recentIdTracker struct {
+	ids *deque.Deque
+}
+
+func (t *recentIdTracker) Add(id bson.ObjectId) {
+	t.ids.PushBack(id)
+}
+
+func (t *recentIdTracker) AsSet() *objectIdSet {
+	out := newObjectIdSet()
+	for {
+		id, ok := t.ids.PopFront()
+		if !ok {
+			break
+		}
+		out.Add(id.(bson.ObjectId))
+	}
+	return out
+}
+
+func newObjectIdSet() *objectIdSet {
+	return &objectIdSet{
+		ids: set.NewStrings(),
+	}
+}
+
+type objectIdSet struct {
+	ids set.Strings
+}
+
+func (s *objectIdSet) Add(id bson.ObjectId) {
+	s.ids.Add(string(id))
+}
+
+func (s *objectIdSet) Contains(id bson.ObjectId) bool {
+	return s.ids.Contains(string(id))
+}
+
+func logDocToRecord(doc *logDoc) *LogRecord {
+	return &LogRecord{
+		Time:     doc.Time,
+		Entity:   doc.Entity,
+		Module:   doc.Module,
+		Location: doc.Location,
+		Level:    doc.Level,
+		Message:  doc.Message,
 	}
 }
 

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type LogsSuite struct {
@@ -152,11 +154,11 @@ func (s *LogsSuite) TestPruneLogsBySize(c *gc.C) {
 	assertLatestTs(s2)
 }
 
-func (s *LogsSuite) generateLogs(c *gc.C, st *state.State, now time.Time, count int) {
+func (s *LogsSuite) generateLogs(c *gc.C, st *state.State, endTime time.Time, count int) {
 	dbLogger := state.NewDbLogger(st, names.NewMachineTag("0"))
 	defer dbLogger.Close()
 	for i := 0; i < count; i++ {
-		ts := now.Add(-time.Duration(i) * time.Second)
+		ts := endTime.Add(-time.Duration(i) * time.Second)
 		err := dbLogger.Log(ts, "module", "loc", loggo.INFO, "message")
 		c.Assert(err, jc.ErrorIsNil)
 	}
@@ -166,4 +168,400 @@ func (s *LogsSuite) countLogs(c *gc.C, st *state.State) int {
 	count, err := s.logsColl.Find(bson.M{"e": st.EnvironUUID()}).Count()
 	c.Assert(err, jc.ErrorIsNil)
 	return count
+}
+
+type LogTailerSuite struct {
+	ConnSuite
+	logsColl  *mgo.Collection
+	oplogColl *mgo.Collection
+}
+
+var _ = gc.Suite(&LogTailerSuite{})
+
+func (s *LogTailerSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+
+	session := s.State.MongoSession()
+	s.logsColl = session.DB("logs").C("logs")
+
+	// Create a fake oplog collection.
+	s.oplogColl = session.DB("logs").C("oplog.fake")
+	err := s.oplogColl.Create(&mgo.CollectionInfo{
+		Capped:   true,
+		MaxBytes: 1024 * 1024,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { s.oplogColl.DropCollection() })
+}
+
+func (s *LogTailerSuite) TestTimeFiltering(c *gc.C) {
+	// Add 10 logs that shouldn't be returned.
+	threshT := time.Now()
+	s.writeLogsT(c,
+		threshT.Add(-5*time.Second), threshT.Add(-time.Millisecond), 5,
+		logTemplate{Message: "dont want"},
+	)
+
+	// Add 5 logs that should be returned.
+	want := logTemplate{Message: "want"}
+	s.writeLogsT(c, threshT, threshT.Add(5*time.Second), 5, want)
+	tailer := state.NewLogTailer(s.State, &state.LogTailerParams{
+		StartTime: threshT,
+		Oplog:     s.oplogColl,
+	})
+	defer tailer.Stop()
+	s.assertTailer(c, tailer, 5, want)
+
+	// Write more logs. These will be read from the the oplog.
+	want2 := logTemplate{Message: "want 2"}
+	s.writeLogsT(c, threshT.Add(6*time.Second), threshT.Add(10*time.Second), 5, want2)
+	s.assertTailer(c, tailer, 5, want2)
+
+}
+
+func (s *LogTailerSuite) TestOplogTransition(c *gc.C) {
+	// Ensure that logs aren't repeated as the log tailer moves from
+	// reading from the logs collection to tailing the oplog.
+	//
+	// All logs are written out with the same timestamp to create a
+	// challenging scenario for the tailer.
+
+	for i := 0; i < 5; i++ {
+		s.writeLogs(c, 1, logTemplate{Message: strconv.Itoa(i)})
+	}
+
+	tailer := state.NewLogTailer(s.State, &state.LogTailerParams{
+		Oplog: s.oplogColl,
+	})
+	defer tailer.Stop()
+	for i := 0; i < 5; i++ {
+		s.assertTailer(c, tailer, 1, logTemplate{Message: strconv.Itoa(i)})
+	}
+
+	// Write more logs. These will be read from the the oplog.
+	for i := 5; i < 10; i++ {
+		lt := logTemplate{Message: strconv.Itoa(i)}
+		s.writeLogs(c, 2, lt)
+		s.assertTailer(c, tailer, 2, lt)
+	}
+}
+
+func (s *LogTailerSuite) TestEnvironmentFiltering(c *gc.C) {
+	good := logTemplate{Message: "good"}
+	writeLogs := func() {
+		s.writeLogs(c, 1, logTemplate{
+			EnvUUID: "someuuid0",
+			Message: "bad",
+		})
+		s.writeLogs(c, 1, logTemplate{
+			EnvUUID: "someuuid1",
+			Message: "bad",
+		})
+		s.writeLogs(c, 1, good)
+	}
+
+	assert := func(tailer state.LogTailer) {
+		// Only the entries the s.State's UUID should be reported.
+		s.assertTailer(c, tailer, 1, good)
+	}
+
+	s.checkLogTailerFiltering(&state.LogTailerParams{}, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestLevelFiltering(c *gc.C) {
+	info := logTemplate{Level: loggo.INFO}
+	error := logTemplate{Level: loggo.ERROR}
+	writeLogs := func() {
+		s.writeLogs(c, 1, logTemplate{Level: loggo.DEBUG})
+		s.writeLogs(c, 1, info)
+		s.writeLogs(c, 1, error)
+	}
+	params := &state.LogTailerParams{
+		MinLevel: loggo.INFO,
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 1, info)
+		s.assertTailer(c, tailer, 1, error)
+	}
+	s.checkLogTailerFiltering(params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestInitialLines(c *gc.C) {
+	expected := logTemplate{Message: "want"}
+	s.writeLogs(c, 3, logTemplate{Message: "dont want"})
+	s.writeLogs(c, 5, expected)
+
+	tailer := state.NewLogTailer(s.State, &state.LogTailerParams{
+		InitialLines: 5,
+	})
+	defer tailer.Stop()
+
+	// Should see just the last 5 lines as requested.
+	s.assertTailer(c, tailer, 5, expected)
+}
+
+func (s *LogTailerSuite) TestIncludeEntity(c *gc.C) {
+	machine0 := logTemplate{Entity: names.NewMachineTag("0")}
+	foo0 := logTemplate{Entity: names.NewUnitTag("foo/0")}
+	foo1 := logTemplate{Entity: names.NewUnitTag("foo/1")}
+	writeLogs := func() {
+		s.writeLogs(c, 3, machine0)
+		s.writeLogs(c, 2, foo0)
+		s.writeLogs(c, 1, foo1)
+		s.writeLogs(c, 3, machine0)
+	}
+	params := &state.LogTailerParams{
+		IncludeEntity: []string{
+			"unit-foo-0",
+			"unit-foo-1",
+		},
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 2, foo0)
+		s.assertTailer(c, tailer, 1, foo1)
+	}
+	s.checkLogTailerFiltering(params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestIncludeEntityWildcard(c *gc.C) {
+	machine0 := logTemplate{Entity: names.NewMachineTag("0")}
+	foo0 := logTemplate{Entity: names.NewUnitTag("foo/0")}
+	foo1 := logTemplate{Entity: names.NewUnitTag("foo/1")}
+	writeLogs := func() {
+		s.writeLogs(c, 3, machine0)
+		s.writeLogs(c, 2, foo0)
+		s.writeLogs(c, 1, foo1)
+		s.writeLogs(c, 3, machine0)
+	}
+	params := &state.LogTailerParams{
+		IncludeEntity: []string{
+			"unit-foo*",
+		},
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 2, foo0)
+		s.assertTailer(c, tailer, 1, foo1)
+	}
+	s.checkLogTailerFiltering(params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestExcludeEntity(c *gc.C) {
+	machine0 := logTemplate{Entity: names.NewMachineTag("0")}
+	foo0 := logTemplate{Entity: names.NewUnitTag("foo/0")}
+	foo1 := logTemplate{Entity: names.NewUnitTag("foo/1")}
+	writeLogs := func() {
+		s.writeLogs(c, 3, machine0)
+		s.writeLogs(c, 2, foo0)
+		s.writeLogs(c, 1, foo1)
+		s.writeLogs(c, 3, machine0)
+	}
+	params := &state.LogTailerParams{
+		ExcludeEntity: []string{
+			"machine-0",
+			"unit-foo-0",
+		},
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 1, foo1)
+	}
+	s.checkLogTailerFiltering(params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestExcludeEntityWildcard(c *gc.C) {
+	machine0 := logTemplate{Entity: names.NewMachineTag("0")}
+	foo0 := logTemplate{Entity: names.NewUnitTag("foo/0")}
+	foo1 := logTemplate{Entity: names.NewUnitTag("foo/1")}
+	writeLogs := func() {
+		s.writeLogs(c, 3, machine0)
+		s.writeLogs(c, 2, foo0)
+		s.writeLogs(c, 1, foo1)
+		s.writeLogs(c, 3, machine0)
+	}
+	params := &state.LogTailerParams{
+		ExcludeEntity: []string{
+			"machine*",
+			"unit-*-0",
+		},
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 1, foo1)
+	}
+	s.checkLogTailerFiltering(params, writeLogs, assert)
+}
+func (s *LogTailerSuite) TestIncludeModule(c *gc.C) {
+	mod0 := logTemplate{Module: "foo.bar"}
+	mod1 := logTemplate{Module: "juju.thing"}
+	subMod1 := logTemplate{Module: "juju.thing.hai"}
+	mod2 := logTemplate{Module: "elsewhere"}
+	writeLogs := func() {
+		s.writeLogs(c, 1, mod0)
+		s.writeLogs(c, 1, mod1)
+		s.writeLogs(c, 1, mod0)
+		s.writeLogs(c, 1, subMod1)
+		s.writeLogs(c, 1, mod0)
+		s.writeLogs(c, 1, mod2)
+	}
+	params := &state.LogTailerParams{
+		IncludeModule: []string{"juju.thing", "elsewhere"},
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 1, mod1)
+		s.assertTailer(c, tailer, 1, subMod1)
+		s.assertTailer(c, tailer, 1, mod2)
+	}
+	s.checkLogTailerFiltering(params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestExcludeModule(c *gc.C) {
+	mod0 := logTemplate{Module: "foo.bar"}
+	mod1 := logTemplate{Module: "juju.thing"}
+	subMod1 := logTemplate{Module: "juju.thing.hai"}
+	mod2 := logTemplate{Module: "elsewhere"}
+	writeLogs := func() {
+		s.writeLogs(c, 1, mod0)
+		s.writeLogs(c, 1, mod1)
+		s.writeLogs(c, 1, mod0)
+		s.writeLogs(c, 1, subMod1)
+		s.writeLogs(c, 1, mod0)
+		s.writeLogs(c, 1, mod2)
+	}
+	params := &state.LogTailerParams{
+		ExcludeModule: []string{"juju.thing", "elsewhere"},
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 2, mod0)
+	}
+	s.checkLogTailerFiltering(params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestIncludeExcludeModule(c *gc.C) {
+	foo := logTemplate{Module: "foo"}
+	bar := logTemplate{Module: "bar"}
+	barSub := logTemplate{Module: "bar.thing"}
+	baz := logTemplate{Module: "baz"}
+	qux := logTemplate{Module: "qux"}
+	writeLogs := func() {
+		s.writeLogs(c, 1, foo)
+		s.writeLogs(c, 1, bar)
+		s.writeLogs(c, 1, barSub)
+		s.writeLogs(c, 1, baz)
+		s.writeLogs(c, 1, qux)
+	}
+	params := &state.LogTailerParams{
+		IncludeModule: []string{"foo", "bar", "qux"},
+		ExcludeModule: []string{"foo", "bar"},
+	}
+	assert := func(tailer state.LogTailer) {
+		// Except just "qux" because "foo" and "bar" were included and
+		// then excluded.
+		s.assertTailer(c, tailer, 1, qux)
+	}
+	s.checkLogTailerFiltering(params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) checkLogTailerFiltering(
+	params *state.LogTailerParams,
+	writeLogs func(),
+	assertTailer func(state.LogTailer),
+) {
+	// Check the tailer does the right thing when reading from the
+	// logs collection.
+	writeLogs()
+	params.Oplog = s.oplogColl
+	tailer := state.NewLogTailer(s.State, params)
+	defer tailer.Stop()
+	assertTailer(tailer)
+
+	// Now write out logs and check the tailer again. These will be
+	// read from the oplog.
+	writeLogs()
+	assertTailer(tailer)
+}
+
+type logTemplate struct {
+	EnvUUID  string
+	Entity   names.Tag
+	Module   string
+	Location string
+	Level    loggo.Level
+	Message  string
+}
+
+// writeLogs creates count log messages at the current time using
+// the supplied template. As well as writing to the logs collection,
+// entries are also made into the fake oplog collection.
+func (s *LogTailerSuite) writeLogs(c *gc.C, count int, lt logTemplate) {
+	t := time.Now()
+	s.writeLogsT(c, t, t, count, lt)
+}
+
+// writeLogsT creates count log messages between startTime and
+// endTime using the supplied template. As well as writing to the logs
+// collection, entries are also made into the fake oplog collection.
+func (s *LogTailerSuite) writeLogsT(c *gc.C, startTime, endTime time.Time, count int, lt logTemplate) {
+	s.normaliseLogTemplate(&lt)
+
+	interval := endTime.Sub(startTime) / time.Duration(count)
+	t := startTime
+	for i := 0; i < count; i++ {
+		err := state.WriteLogWithOplog(
+			s.oplogColl,
+			lt.EnvUUID,
+			lt.Entity,
+			t,
+			lt.Module,
+			lt.Location,
+			lt.Level,
+			lt.Message,
+		)
+		c.Assert(err, jc.ErrorIsNil)
+		t = t.Add(interval)
+	}
+}
+
+func (s *LogTailerSuite) normaliseLogTemplate(lt *logTemplate) {
+	if lt.EnvUUID == "" {
+		lt.EnvUUID = s.State.EnvironUUID()
+	}
+	if lt.Entity == nil {
+		lt.Entity = names.NewMachineTag("0")
+	}
+	if lt.Module == "" {
+		lt.Module = "module"
+	}
+	if lt.Location == "" {
+		lt.Location = "loc"
+	}
+	if lt.Level == loggo.UNSPECIFIED {
+		lt.Level = loggo.INFO
+	}
+	if lt.Message == "" {
+		lt.Message = "message"
+	}
+}
+
+func (s *LogTailerSuite) assertTailer(c *gc.C, tailer state.LogTailer, expectedCount int, lt logTemplate) {
+	s.normaliseLogTemplate(&lt)
+
+	timeout := time.After(coretesting.LongWait)
+	count := 0
+	for {
+		select {
+		case log, ok := <-tailer.Logs():
+			if !ok {
+				c.Fatalf("tailer died unexpectedly: %v", tailer.Err())
+			}
+			c.Assert(log.Entity, gc.Equals, lt.Entity.String())
+			c.Assert(log.Module, gc.Equals, lt.Module)
+			c.Assert(log.Location, gc.Equals, lt.Location)
+			c.Assert(log.Level, gc.Equals, lt.Level)
+			c.Assert(log.Message, gc.Equals, lt.Message)
+			count++
+			if count == expectedCount {
+				return
+			}
+		case <-timeout:
+			c.Fatalf("timed out waiting for logs (received %d)", count)
+		}
+	}
 }


### PR DESCRIPTION
The LogTailer allows filtered retrieval of logs from the logs collection and then tails the MongoDB oplog for more matching logs.

(Review request: http://reviews.vapour.ws/r/1975/)