### PR TITLE
Pass stdin to jujuc if prompted

### DIFF
--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -4,9 +4,11 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -165,14 +167,21 @@ func (c *RemoteCommand) Run(ctx *cmd.Context) error {
 	if c.msg != "" {
 		return errors.New(c.msg)
 	}
-	fmt.Fprintf(ctx.Stdout, "success!\n")
+	n, err := io.Copy(ctx.Stdout, ctx.Stdin)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		fmt.Fprintf(ctx.Stdout, "success!\n")
+	}
 	return nil
 }
 
-func run(c *gc.C, sockPath string, contextId string, exit int, cmd ...string) string {
+func run(c *gc.C, sockPath string, contextId string, exit int, stdin []byte, cmd ...string) string {
 	args := append([]string{"-test.run", "TestRunMain", "-run-main", "--"}, cmd...)
 	c.Logf("check %v %#v", os.Args[0], args)
 	ps := exec.Command(os.Args[0], args...)
+	ps.Stdin = bytes.NewBuffer(stdin)
 	ps.Dir = c.MkDir()
 	ps.Env = []string{
 		fmt.Sprintf("JUJU_AGENT_SOCKET=%s", sockPath),
@@ -252,7 +261,7 @@ func (s *JujuCMainSuite) TestArgs(c *gc.C) {
 	}
 	for _, t := range argsTests {
 		c.Log(t.args)
-		output := run(c, s.sockPath, "bill", t.code, t.args...)
+		output := run(c, s.sockPath, "bill", t.code, nil, t.args...)
 		c.Assert(output, gc.Equals, t.output)
 	}
 }
@@ -261,7 +270,7 @@ func (s *JujuCMainSuite) TestNoClientId(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, s.sockPath, "", 1, "remote")
+	output := run(c, s.sockPath, "", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: JUJU_CONTEXT_ID not set\n")
 }
 
@@ -269,7 +278,7 @@ func (s *JujuCMainSuite) TestBadClientId(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, s.sockPath, "ben", 1, "remote")
+	output := run(c, s.sockPath, "ben", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: bad request: bad context: ben\n")
 }
 
@@ -277,7 +286,7 @@ func (s *JujuCMainSuite) TestNoSockPath(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, "", "bill", 1, "remote")
+	output := run(c, "", "bill", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: JUJU_AGENT_SOCKET not set\n")
 }
 
@@ -286,7 +295,15 @@ func (s *JujuCMainSuite) TestBadSockPath(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	badSock := filepath.Join(c.MkDir(), "bad.sock")
-	output := run(c, badSock, "bill", 1, "remote")
+	output := run(c, badSock, "bill", 1, nil, "remote")
 	err := fmt.Sprintf("error: dial unix %s: .*\n", badSock)
 	c.Assert(output, gc.Matches, err)
+}
+
+func (s *JujuCMainSuite) TestStdin(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
+	}
+	output := run(c, s.sockPath, "bill", 0, []byte("some standard input"), "remote")
+	c.Assert(output, gc.Equals, "some standard input")
 }

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -9,6 +9,7 @@ package jujuc
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net"
 	"net/rpc"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/exec"
 
@@ -23,6 +25,10 @@ import (
 )
 
 var logger = loggo.GetLogger("worker.uniter.jujuc")
+
+// ErrNoStdin is returned by Jujuc.Main if the hook tool requests
+// stdin, and none is supplied.
+var ErrNoStdin = errors.New("hook tool requires stdin, none supplied")
 
 type creator func(Context) cmd.Command
 
@@ -97,6 +103,12 @@ type Request struct {
 	Dir         string
 	CommandName string
 	Args        []string
+
+	// StdinSet indicates whether or not the client supplied stdin. This is
+	// necessary as Stdin will be nil if the client supplied stdin but it
+	// is empty.
+	StdinSet bool
+	Stdin    []byte
 }
 
 // CmdGetter looks up a Command implementation connected to a particular Context.
@@ -126,10 +138,18 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 	if err != nil {
 		return badReqErrorf("%s", err)
 	}
-	var stdin, stdout, stderr bytes.Buffer
+	var stdin io.Reader
+	if req.StdinSet {
+		stdin = bytes.NewReader(req.Stdin)
+	} else {
+		// noStdinReader will error with ErrNoStdin
+		// if its Read method is called.
+		stdin = noStdinReader{}
+	}
+	var stdout, stderr bytes.Buffer
 	ctx := &cmd.Context{
 		Dir:    req.Dir,
-		Stdin:  &stdin,
+		Stdin:  stdin,
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
@@ -137,7 +157,11 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 	defer j.mu.Unlock()
 	logger.Infof("running hook tool %q %q", req.CommandName, req.Args)
 	logger.Debugf("hook context id %q; dir %q", req.ContextId, req.Dir)
-	resp.Code = cmd.Main(c, ctx, req.Args)
+	wrapper := &cmdWrapper{c, nil}
+	resp.Code = cmd.Main(wrapper, ctx, req.Args)
+	if errors.Cause(wrapper.err) == ErrNoStdin {
+		return ErrNoStdin
+	}
 	resp.Stdout = stdout.Bytes()
 	resp.Stderr = stderr.Bytes()
 	return nil
@@ -210,4 +234,23 @@ func (s *Server) Close() {
 	close(s.closing)
 	s.listener.Close()
 	<-s.closed
+}
+
+type noStdinReader struct{}
+
+// Read implements io.Reader, simply returning ErrNoStdin any time it's called.
+func (noStdinReader) Read([]byte) (int, error) {
+	return 0, ErrNoStdin
+}
+
+// cmdWrapper wraps a cmd.Command's Run method so the error returned can be
+// intercepted when the command is run via cmd.Main.
+type cmdWrapper struct {
+	cmd.Command
+	err error
+}
+
+func (c *cmdWrapper) Run(ctx *cmd.Context) error {
+	c.err = c.Command.Run(ctx)
+	return c.err
 }

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -7,6 +7,7 @@ package jujuc_test
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -29,6 +30,7 @@ type RpcCommand struct {
 	cmd.CommandBase
 	Value string
 	Slow  bool
+	Echo  bool
 }
 
 func (c *RpcCommand) Info() *cmd.Info {
@@ -42,6 +44,7 @@ func (c *RpcCommand) Info() *cmd.Info {
 func (c *RpcCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Value, "value", "", "doc")
 	f.BoolVar(&c.Slow, "slow", false, "doc")
+	f.BoolVar(&c.Echo, "echo", false, "doc")
 }
 
 func (c *RpcCommand) Init(args []string) error {
@@ -55,6 +58,11 @@ func (c *RpcCommand) Run(ctx *cmd.Context) error {
 	if c.Slow {
 		time.Sleep(testing.ShortWait)
 		return nil
+	}
+	if c.Echo {
+		if _, err := io.Copy(ctx.Stdout, ctx.Stdin); err != nil {
+			return err
+		}
 	}
 	ctx.Stdout.Write([]byte("eye of newt\n"))
 	ctx.Stderr.Write([]byte("toe of frog\n"))
@@ -121,15 +129,24 @@ func (s *ServerSuite) Call(c *gc.C, req jujuc.Request) (resp exec.ExecResponse, 
 func (s *ServerSuite) TestHappyPath(c *gc.C) {
 	dir := c.MkDir()
 	resp, err := s.Call(c, jujuc.Request{
-		"validCtx", dir, "remote", []string{"--value", "something"},
+		"validCtx", dir, "remote", []string{"--value", "something", "--echo"},
+		true, []byte("wool of bat\n"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.Code, gc.Equals, 0)
-	c.Assert(string(resp.Stdout), gc.Equals, "eye of newt\n")
+	c.Assert(string(resp.Stdout), gc.Equals, "wool of bat\neye of newt\n")
 	c.Assert(string(resp.Stderr), gc.Equals, "toe of frog\n")
 	content, err := ioutil.ReadFile(filepath.Join(dir, "local"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, "something")
+}
+
+func (s *ServerSuite) TestNoStdin(c *gc.C) {
+	dir := c.MkDir()
+	_, err := s.Call(c, jujuc.Request{
+		"validCtx", dir, "remote", []string{"--echo"}, false, nil,
+	})
+	c.Assert(err, gc.ErrorMatches, jujuc.ErrNoStdin.Error())
 }
 
 func (s *ServerSuite) TestLocks(c *gc.C) {
@@ -141,6 +158,7 @@ func (s *ServerSuite) TestLocks(c *gc.C) {
 			dir := c.MkDir()
 			resp, err := s.Call(c, jujuc.Request{
 				"validCtx", dir, "remote", []string{"--slow"},
+				false, nil,
 			})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(resp.Code, gc.Equals, 0)
@@ -154,16 +172,16 @@ func (s *ServerSuite) TestLocks(c *gc.C) {
 
 func (s *ServerSuite) TestBadCommandName(c *gc.C) {
 	dir := c.MkDir()
-	_, err := s.Call(c, jujuc.Request{"validCtx", dir, "", nil})
+	_, err := s.Call(c, jujuc.Request{"validCtx", dir, "", nil, false, nil})
 	c.Assert(err, gc.ErrorMatches, "bad request: command not specified")
-	_, err = s.Call(c, jujuc.Request{"validCtx", dir, "witchcraft", nil})
+	_, err = s.Call(c, jujuc.Request{"validCtx", dir, "witchcraft", nil, false, nil})
 	c.Assert(err, gc.ErrorMatches, `bad request: unknown command "witchcraft"`)
 }
 
 func (s *ServerSuite) TestBadDir(c *gc.C) {
 	for _, req := range []jujuc.Request{
-		{"validCtx", "", "anything", nil},
-		{"validCtx", "foo/bar", "anything", nil},
+		{"validCtx", "", "anything", nil, false, nil},
+		{"validCtx", "foo/bar", "anything", nil, false, nil},
 	} {
 		_, err := s.Call(c, req)
 		c.Assert(err, gc.ErrorMatches, "bad request: Dir is not absolute")
@@ -171,12 +189,12 @@ func (s *ServerSuite) TestBadDir(c *gc.C) {
 }
 
 func (s *ServerSuite) TestBadContextId(c *gc.C) {
-	_, err := s.Call(c, jujuc.Request{"whatever", c.MkDir(), "remote", nil})
+	_, err := s.Call(c, jujuc.Request{"whatever", c.MkDir(), "remote", nil, false, nil})
 	c.Assert(err, gc.ErrorMatches, `bad request: unknown context "whatever"`)
 }
 
 func (s *ServerSuite) AssertBadCommand(c *gc.C, args []string, code int) exec.ExecResponse {
-	resp, err := s.Call(c, jujuc.Request{"validCtx", c.MkDir(), args[0], args[1:]})
+	resp, err := s.Call(c, jujuc.Request{"validCtx", c.MkDir(), args[0], args[1:], false, nil})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.Code, gc.Equals, code)
 	return resp


### PR DESCRIPTION
The jujuc CLI will now pass through stdin to
the server if prompted with a special error.
If the client has not provided stdin, the
server passes a special io.Reader to the command
that will yield the special error; this is
sent to the client, which then re-executes
the command after consuming os.Stdin.

Fixes https://bugs.launchpad.net/juju-core/+bug/1454678

(Review request: http://reviews.vapour.ws/r/1976/)