### PR TITLE
Pass stdin to jujuc if prompted

### DIFF
--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/exec"
 	"github.com/juju/utils/featureflag"
@@ -73,7 +75,7 @@ func getwd() (string, error) {
 // jujuCMain uses JUJU_CONTEXT_ID and JUJU_AGENT_SOCKET to ask a running unit agent
 // to execute a Command on our behalf. Individual commands should be exposed
 // by symlinking the command name to this executable.
-func jujuCMain(commandName string, args []string) (code int, err error) {
+func jujuCMain(commandName string, ctx *cmd.Context, args []string) (code int, err error) {
 	code = 1
 	contextId, err := getenv("JUJU_CONTEXT_ID")
 	if err != nil {
@@ -100,6 +102,15 @@ func jujuCMain(commandName string, args []string) (code int, err error) {
 	defer client.Close()
 	var resp exec.ExecResponse
 	err = client.Call("Jujuc.Main", req, &resp)
+	if err != nil && err.Error() == jujuc.ErrNoStdin.Error() {
+		req.Stdin, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			err = errors.Annotate(err, "cannot read stdin")
+			return
+		}
+		req.StdinSet = true
+		err = client.Call("Jujuc.Main", req, &resp)
+	}
 	if err != nil {
 		return
 	}
@@ -158,7 +169,7 @@ func Main(args []string) {
 	} else if commandName == names.JujuRun {
 		code = cmd.Main(&RunCommand{}, ctx, args[1:])
 	} else {
-		code, err = jujuCMain(commandName, args)
+		code, err = jujuCMain(commandName, ctx, args)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -4,9 +4,11 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -165,14 +167,21 @@ func (c *RemoteCommand) Run(ctx *cmd.Context) error {
 	if c.msg != "" {
 		return errors.New(c.msg)
 	}
-	fmt.Fprintf(ctx.Stdout, "success!\n")
+	n, err := io.Copy(ctx.Stdout, ctx.Stdin)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		fmt.Fprintf(ctx.Stdout, "success!\n")
+	}
 	return nil
 }
 
-func run(c *gc.C, sockPath string, contextId string, exit int, cmd ...string) string {
+func run(c *gc.C, sockPath string, contextId string, exit int, stdin []byte, cmd ...string) string {
 	args := append([]string{"-test.run", "TestRunMain", "-run-main", "--"}, cmd...)
 	c.Logf("check %v %#v", os.Args[0], args)
 	ps := exec.Command(os.Args[0], args...)
+	ps.Stdin = bytes.NewBuffer(stdin)
 	ps.Dir = c.MkDir()
 	ps.Env = []string{
 		fmt.Sprintf("JUJU_AGENT_SOCKET=%s", sockPath),
@@ -252,7 +261,7 @@ func (s *JujuCMainSuite) TestArgs(c *gc.C) {
 	}
 	for _, t := range argsTests {
 		c.Log(t.args)
-		output := run(c, s.sockPath, "bill", t.code, t.args...)
+		output := run(c, s.sockPath, "bill", t.code, nil, t.args...)
 		c.Assert(output, gc.Equals, t.output)
 	}
 }
@@ -261,7 +270,7 @@ func (s *JujuCMainSuite) TestNoClientId(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, s.sockPath, "", 1, "remote")
+	output := run(c, s.sockPath, "", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: JUJU_CONTEXT_ID not set\n")
 }
 
@@ -269,7 +278,7 @@ func (s *JujuCMainSuite) TestBadClientId(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, s.sockPath, "ben", 1, "remote")
+	output := run(c, s.sockPath, "ben", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: bad request: bad context: ben\n")
 }
 
@@ -277,7 +286,7 @@ func (s *JujuCMainSuite) TestNoSockPath(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
-	output := run(c, "", "bill", 1, "remote")
+	output := run(c, "", "bill", 1, nil, "remote")
 	c.Assert(output, gc.Equals, "error: JUJU_AGENT_SOCKET not set\n")
 }
 
@@ -286,7 +295,15 @@ func (s *JujuCMainSuite) TestBadSockPath(c *gc.C) {
 		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
 	}
 	badSock := filepath.Join(c.MkDir(), "bad.sock")
-	output := run(c, badSock, "bill", 1, "remote")
+	output := run(c, badSock, "bill", 1, nil, "remote")
 	err := fmt.Sprintf("error: dial unix %s: .*\n", badSock)
 	c.Assert(output, gc.Matches, err)
+}
+
+func (s *JujuCMainSuite) TestStdin(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("issue 1403084: test panics on CryptAcquireContext on windows")
+	}
+	output := run(c, s.sockPath, "bill", 0, []byte("some standard input"), "remote")
+	c.Assert(output, gc.Equals, "some standard input")
 }

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -9,6 +9,7 @@ package jujuc
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net"
 	"net/rpc"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/exec"
 
@@ -23,6 +25,10 @@ import (
 )
 
 var logger = loggo.GetLogger("worker.uniter.jujuc")
+
+// ErrNoStdin is returned by Jujuc.Main if the hook tool requests
+// stdin, and none is supplied.
+var ErrNoStdin = errors.New("hook tool requires stdin, none supplied")
 
 type creator func(Context) cmd.Command
 
@@ -97,6 +103,12 @@ type Request struct {
 	Dir         string
 	CommandName string
 	Args        []string
+
+	// StdinSet indicates whether or not the client supplied stdin. This is
+	// necessary as Stdin will be nil if the client supplied stdin but it
+	// is empty.
+	StdinSet bool
+	Stdin    []byte
 }
 
 // CmdGetter looks up a Command implementation connected to a particular Context.
@@ -126,10 +138,18 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 	if err != nil {
 		return badReqErrorf("%s", err)
 	}
-	var stdin, stdout, stderr bytes.Buffer
+	var stdin io.Reader
+	if req.StdinSet {
+		stdin = bytes.NewReader(req.Stdin)
+	} else {
+		// noStdinReader will error with ErrNoStdin
+		// if its Read method is called.
+		stdin = noStdinReader{}
+	}
+	var stdout, stderr bytes.Buffer
 	ctx := &cmd.Context{
 		Dir:    req.Dir,
-		Stdin:  &stdin,
+		Stdin:  stdin,
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
@@ -137,7 +157,11 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 	defer j.mu.Unlock()
 	logger.Infof("running hook tool %q %q", req.CommandName, req.Args)
 	logger.Debugf("hook context id %q; dir %q", req.ContextId, req.Dir)
-	resp.Code = cmd.Main(c, ctx, req.Args)
+	wrapper := &cmdWrapper{c, nil}
+	resp.Code = cmd.Main(wrapper, ctx, req.Args)
+	if errors.Cause(wrapper.err) == ErrNoStdin {
+		return ErrNoStdin
+	}
 	resp.Stdout = stdout.Bytes()
 	resp.Stderr = stderr.Bytes()
 	return nil
@@ -210,4 +234,23 @@ func (s *Server) Close() {
 	close(s.closing)
 	s.listener.Close()
 	<-s.closed
+}
+
+type noStdinReader struct{}
+
+// Read implements io.Reader, simply returning ErrNoStdin any time it's called.
+func (noStdinReader) Read([]byte) (int, error) {
+	return 0, ErrNoStdin
+}
+
+// cmdWrapper wraps a cmd.Command's Run method so the error returned can be
+// intercepted when the command is run via cmd.Main.
+type cmdWrapper struct {
+	cmd.Command
+	err error
+}
+
+func (c *cmdWrapper) Run(ctx *cmd.Context) error {
+	c.err = c.Command.Run(ctx)
+	return c.err
 }


### PR DESCRIPTION
The jujuc CLI will now pass through stdin to
the server if prompted with a special error.
If the client has not provided stdin, the
server passes a special io.Reader to the command
that will yield the special error; this is
sent to the client, which then re-executes
the command after consuming os.Stdin.

Fixes https://bugs.launchpad.net/juju-core/+bug/1454678

(Review request: http://reviews.vapour.ws/r/1977/)