### PR TITLE
Extract state.stateCollection to mongo.Collection and .WriteCollection

### DIFF
--- a/mongo/collections.go
+++ b/mongo/collections.go
@@ -8,8 +8,51 @@ import "gopkg.in/mgo.v2"
 // CollectionFromName returns a named collection on the specified database,
 // initialised with a new session. Also returned is a close function which
 // must be called when the collection is no longer required.
-func CollectionFromName(db *mgo.Database, coll string) (*mgo.Collection, func()) {
+func CollectionFromName(db *mgo.Database, coll string) (Collection, func()) {
 	session := db.Session.Copy()
 	newColl := db.C(coll).With(session)
-	return newColl, session.Close
+	return WrapCollection(newColl), session.Close
+}
+
+// Collection allows us to construct wrappers for *mgo.Collection objects.
+// It's not generally useful for mocking, because (1) you need a real mongo
+// in the background to implement Find[Id], not to mention Underlying; and
+// (2) if you're working at the level where you're directly concerned with
+// collections, it's important to write tests that verify their practical
+// behaviour.
+type Collection interface {
+
+	// Name returns the name of the collection.
+	Name() string
+
+	// Underlying returns the underlying *mgo.Collection. If you're using
+	// the collection with mgo/txn, you should be very wary of this method:
+	// careless use will disrupt the operation of mgo/txn and cause arbitrary
+	// badness.
+	Underlying() *mgo.Collection
+
+	// All other methods act as documented for *mgo.Collection.
+	Count() (int, error)
+	Find(query interface{}) *mgo.Query
+	FindId(id interface{}) *mgo.Query
+}
+
+// WrapCollection returns a Collection that wraps the supplied *mgo.Collection.
+func WrapCollection(coll *mgo.Collection) Collection {
+	return collectionWrapper{coll}
+}
+
+// collectionWrapper wraps a *mgo.Collection and implements Collection.
+type collectionWrapper struct {
+	*mgo.Collection
+}
+
+// Name is part of the Collection interface.
+func (cw collectionWrapper) Name() string {
+	return cw.Collection.Name
+}
+
+// Underlying is part of the Collection interface.
+func (cw collectionWrapper) Underlying() *mgo.Collection {
+	return cw.Collection
 }

--- a/state/charm.go
+++ b/state/charm.go
@@ -13,22 +13,31 @@ import (
 // charmDoc represents the internal state of a charm in MongoDB.
 type charmDoc struct {
 	DocID   string     `bson:"_id"`
-	URL     *charm.URL `bson:"url"`
+	URL     *charm.URL `bson:"url"` // DANGEROUS see below
 	EnvUUID string     `bson:"env-uuid"`
-	Meta    *charm.Meta
-	Config  *charm.Config
-	Actions *charm.Actions
-	Metrics *charm.Metrics
+
+	// XXX(fwereade) 2015-06-18
+	// DANGEROUS: our schema can change any time the charm package changes,
+	// and we have no automated way to detect when that happens. We *must*
+	// not depend upon serializations we cannot control from inside this
+	// package. What's in a *charm.Meta? What will be tomorrow? What logic
+	// will we be writing on the assumption that all stored Metas have set
+	// some field? What fields might lose precision when they go into the
+	// database?
+	Meta    *charm.Meta    `bson:"meta"`
+	Config  *charm.Config  `bson:"config"`
+	Actions *charm.Actions `bson:"actions"`
+	Metrics *charm.Metrics `bson:"metrics"`
 
 	// DEPRECATED: BundleURL is deprecated, and exists here
 	// only for migration purposes. We should remove this
 	// when migrations are no longer necessary.
 	BundleURL *url.URL `bson:"bundleurl,omitempty"`
 
-	BundleSha256  string
-	StoragePath   string
-	PendingUpload bool
-	Placeholder   bool
+	BundleSha256  string `bson:"bundlesha256"`
+	StoragePath   string `bson:"storagepath"`
+	PendingUpload bool   `bson:"pendingupload"`
+	Placeholder   bool   `bson:"placeholder"`
 }
 
 // Charm represents the state of a charm in the environment.

--- a/state/charm.go
+++ b/state/charm.go
@@ -5,9 +5,15 @@ package state
 
 import (
 	"net/url"
+	"regexp"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v5"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo"
 )
 
 // charmDoc represents the internal state of a charm in MongoDB.
@@ -38,6 +44,145 @@ type charmDoc struct {
 	StoragePath   string `bson:"storagepath"`
 	PendingUpload bool   `bson:"pendingupload"`
 	Placeholder   bool   `bson:"placeholder"`
+}
+
+// insertCharmOps returns the txn operations necessary to insert the supplied
+// charm data.
+func insertCharmOps(
+	st *State, ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string,
+) ([]txn.Op, error) {
+	return insertAnyCharmOps(&charmDoc{
+		DocID:        st.docID(curl.String()),
+		URL:          curl,
+		EnvUUID:      st.EnvironTag().Id(),
+		Meta:         ch.Meta(),
+		Config:       safeConfig(ch),
+		Metrics:      ch.Metrics(),
+		Actions:      ch.Actions(),
+		BundleSha256: bundleSha256,
+		StoragePath:  storagePath,
+	})
+}
+
+// insertPlaceholderCharmOps returns the txn operations necessary to insert a
+// charm document referencing a store charm that is not yet directly accessible
+// within the environment.
+func insertPlaceholderCharmOps(st *State, curl *charm.URL) ([]txn.Op, error) {
+	return insertAnyCharmOps(&charmDoc{
+		DocID:       st.docID(curl.String()),
+		URL:         curl,
+		EnvUUID:     st.EnvironTag().Id(),
+		Placeholder: true,
+	})
+}
+
+// insertPendingCharmOps returns the txn operations necessary to insert a charm
+// document referencing a charm that has yet to be uploaded to the environment.
+func insertPendingCharmOps(st *State, curl *charm.URL) ([]txn.Op, error) {
+	return insertAnyCharmOps(&charmDoc{
+		DocID:         st.docID(curl.String()),
+		URL:           curl,
+		EnvUUID:       st.EnvironTag().Id(),
+		PendingUpload: true,
+	})
+}
+
+// insertAnyCharmOps returns the txn operations necessary to insert the supplied
+// charm document.
+func insertAnyCharmOps(cdoc *charmDoc) ([]txn.Op, error) {
+	return []txn.Op{{
+		C:      charmsC,
+		Id:     cdoc.DocID,
+		Assert: txn.DocMissing,
+		Insert: cdoc,
+	}}, nil
+}
+
+// updateCharmOps returns the txn operations necessary to update the charm
+// document with the supplied data, so long as the supplied assert still holds
+// true.
+func updateCharmOps(
+	st *State, ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string, assert bson.D,
+) ([]txn.Op, error) {
+
+	updateFields := bson.D{{"$set", bson.D{
+		{"meta", ch.Meta()},
+		{"config", safeConfig(ch)},
+		{"actions", ch.Actions()},
+		{"metrics", ch.Metrics()},
+		{"storagepath", storagePath},
+		{"bundlesha256", bundleSha256},
+		{"pendingupload", false},
+		{"placeholder", false},
+	}}}
+	return []txn.Op{{
+		C:      charmsC,
+		Id:     st.docID(curl.String()),
+		Assert: assert,
+		Update: updateFields,
+	}}, nil
+}
+
+// convertPlaceholderCharmOps returns the txn operations necessary to convert
+// the charm with the supplied docId from a placeholder to one marked for
+// pending upload.
+func convertPlaceholderCharmOps(docID string) ([]txn.Op, error) {
+	return []txn.Op{{
+		C:  charmsC,
+		Id: docID,
+		Assert: bson.D{
+			{"bundlesha256", ""},
+			{"pendingupload", false},
+			{"placeholder", true},
+		},
+		Update: bson.D{{"$set", bson.D{
+			{"pendingupload", true},
+			{"placeholder", false},
+		}}},
+	}}, nil
+
+}
+
+// deleteOldPlaceholderCharmsOps returns the txn ops required to delete all placeholder charm
+// records older than the specified charm URL.
+func deleteOldPlaceholderCharmsOps(st *State, charms mongo.Collection, curl *charm.URL) ([]txn.Op, error) {
+	// Get a regex with the charm URL and no revision.
+	noRevURL := curl.WithRevision(-1)
+	curlRegex := "^" + regexp.QuoteMeta(st.docID(noRevURL.String()))
+
+	var docs []charmDoc
+	query := bson.D{{"_id", bson.D{{"$regex", curlRegex}}}, {"placeholder", true}}
+	err := charms.Find(query).Select(bson.D{{"_id", 1}, {"url", 1}}).All(&docs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var ops []txn.Op
+	for _, doc := range docs {
+		if doc.URL.Revision >= curl.Revision {
+			continue
+		}
+		ops = append(ops, txn.Op{
+			C:      charmsC,
+			Id:     doc.DocID,
+			Assert: stillPlaceholder,
+			Remove: true,
+		})
+	}
+	return ops, nil
+}
+
+// safeConfig is a travesty which attempts to work around our continued failure
+// to properly insulate our database from code changes.
+func safeConfig(ch charm.Charm) *charm.Config {
+	// Make sure we escape any "$" and "." in config option names
+	// first. See http://pad.lv/1308146.
+	cfg := ch.Config()
+	escapedConfig := charm.NewConfig()
+	for optionName, option := range cfg.Options {
+		escapedName := escapeReplacer.Replace(optionName)
+		escapedConfig.Options[escapedName] = option
+	}
+	return escapedConfig
 }
 
 // Charm represents the state of a charm in the environment.

--- a/state/collections.go
+++ b/state/collections.go
@@ -20,9 +20,9 @@ import (
 // If the collection stores documents for multiple environments, the
 // returned collection will automatically perform environment
 // filtering where possible. See envStateCollection below.
-func (st *State) getCollection(name string) (stateCollection, func()) {
-	coll, closer := mongo.CollectionFromName(st.db, name)
-	return newStateCollection(coll, st.EnvironUUID()), closer
+func (st *State) getCollection(name string) (mongo.Collection, func()) {
+	collection, closer := mongo.CollectionFromName(st.db, name)
+	return newStateCollection(collection, st.EnvironUUID()), closer
 }
 
 // getRawCollection returns the named mgo Collection. As no automatic
@@ -30,7 +30,9 @@ func (st *State) getCollection(name string) (stateCollection, func()) {
 // should be rarely used. getCollection() should be used in almost all
 // cases.
 func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
-	return mongo.CollectionFromName(st.db, name)
+	// TODO(fwereade): drop all [gG]etRawCollection usage?
+	collection, closer := mongo.CollectionFromName(st.db, name)
+	return collection.Underlying(), closer
 }
 
 // getCollectionFromDB returns the specified collection from the given
@@ -39,22 +41,9 @@ func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
 // An environment UUID must be provided so that environment filtering
 // can be automatically applied if the collection stores data for
 // multiple environments.
-func getCollectionFromDB(db *mgo.Database, name, envUUID string) stateCollection {
-	return newStateCollection(db.C(name), envUUID)
-}
-
-type stateCollection interface {
-	Name() string
-	Underlying() *mgo.Collection
-	Count() (int, error)
-	Find(query interface{}) *mgo.Query
-	FindId(id interface{}) *mgo.Query
-	Insert(docs ...interface{}) error
-	Update(selector interface{}, update interface{}) error
-	UpdateId(id interface{}, update interface{}) error
-	Remove(sel interface{}) error
-	RemoveId(id interface{}) error
-	RemoveAll(sel interface{}) (*mgo.ChangeInfo, error)
+func getCollectionFromDB(db *mgo.Database, name, envUUID string) mongo.Collection {
+	collection := mongo.WrapCollection(db.C(name))
+	return newStateCollection(collection, envUUID)
 }
 
 // This is all collections that contain data for multiple
@@ -100,57 +89,45 @@ var multiEnvCollections = set.NewStrings(
 	volumeAttachmentsC,
 )
 
-func newStateCollection(coll *mgo.Collection, envUUID string) stateCollection {
-	if multiEnvCollections.Contains(coll.Name) {
+func newStateCollection(collection mongo.Collection, envUUID string) mongo.Collection {
+	if multiEnvCollections.Contains(collection.Name()) {
 		return &envStateCollection{
-			Collection: coll,
+			collection: collection,
 			envUUID:    envUUID,
 		}
 	}
-	return &genericStateCollection{Collection: coll}
+	return collection
 }
 
-// genericStateCollection wraps a mgo Collection. It acts as a
-// pass-through which implements the stateCollection interface.
-type genericStateCollection struct {
-	*mgo.Collection
-}
-
-// Name returns the MongoDB collection name.
-func (c *genericStateCollection) Name() string {
-	return c.Collection.Name
-}
-
-// Underlying returns the mgo Collection that the
-// genericStateCollection is wrapping.
-func (c *genericStateCollection) Underlying() *mgo.Collection {
-	return c.Collection
-}
-
-// envStateCollection wraps a mgo Collection, implementing the
-// stateCollection interface. It will automatically modify query
+// envStateCollection wraps a mongo.Collection, preserving the
+// mongo.Collection interface. It will automatically modify query
 // selectors so that so that the query only interacts with data for a
 // single environment (where possible).
 type envStateCollection struct {
-	*mgo.Collection
-	envUUID string
+	// we pointedly do not embed a mongo.Collection here, because the environ-
+	// filtering is of critical importance. If someone adds to the Collection
+	// interface this type will (correctly!) fail to implement the interface,
+	// causing a compilation error, and forcing us to implement a version of
+	// the method that correctly filters by environ.
+	collection mongo.Collection
+	envUUID    string
 }
 
 // Name returns the MongoDB collection name.
 func (c *envStateCollection) Name() string {
-	return c.Collection.Name
+	return c.collection.Name()
 }
 
 // Underlying returns the mgo Collection that the
-// envStateCollection is wrapping.
+// envStateCollection is ultimately wrapping.
 func (c *envStateCollection) Underlying() *mgo.Collection {
-	return c.Collection
+	return c.collection.Underlying()
 }
 
 // Count returns the number of documents in the collection that belong
 // to the environment that the envStateCollection is filtering on.
 func (c *envStateCollection) Count() (int, error) {
-	return c.Collection.Find(bson.D{{"env-uuid", c.envUUID}}).Count()
+	return c.collection.Find(bson.D{{"env-uuid", c.envUUID}}).Count()
 }
 
 // Find performs a query on the collection. The query must be given as
@@ -166,7 +143,7 @@ func (c *envStateCollection) Count() (int, error) {
 // these cases it is up to the caller to add environment UUID
 // prefixes when necessary.
 func (c *envStateCollection) Find(query interface{}) *mgo.Query {
-	return c.Collection.Find(c.mungeQuery(query))
+	return c.collection.Find(c.mungeQuery(query))
 }
 
 // FindId looks up a single document by _id. If the id is a string the
@@ -174,9 +151,17 @@ func (c *envStateCollection) Find(query interface{}) *mgo.Query {
 // query will be handled as per Find().
 func (c *envStateCollection) FindId(id interface{}) *mgo.Query {
 	if sid, ok := id.(string); ok {
-		return c.Collection.FindId(addEnvUUID(c.envUUID, sid))
+		return c.collection.FindId(addEnvUUID(c.envUUID, sid))
 	}
 	return c.Find(bson.D{{"_id", id}})
+}
+
+// Insert just panics. Nobody implemented it yet; nobody's used it; I'd
+// rather have envStateCollection fail to insert loudly, rather than fail
+// to filter quietly. You can grab Underlying() if you need it, but you
+// most likely shouldn't.
+func (c *envStateCollection) Insert(...interface{}) error {
+	panic("env-aware insert not implemented; use .Underlying() explicitly")
 }
 
 // Update finds a single document matching the provided query document and
@@ -192,7 +177,7 @@ func (c *envStateCollection) FindId(id interface{}) *mgo.Query {
 // these cases it is up to the caller to add environment UUID
 // prefixes when necessary.
 func (c *envStateCollection) Update(query interface{}, update interface{}) error {
-	return c.Collection.Update(c.mungeQuery(query), update)
+	return c.collection.Update(c.mungeQuery(query), update)
 }
 
 // UpdateId finds a single document by _id and modifies it according to the
@@ -201,15 +186,15 @@ func (c *envStateCollection) Update(query interface{}, update interface{}) error
 // prefix isn't there already.
 func (c *envStateCollection) UpdateId(id interface{}, update interface{}) error {
 	if sid, ok := id.(string); ok {
-		return c.Collection.UpdateId(addEnvUUID(c.envUUID, sid), update)
+		return c.collection.UpdateId(addEnvUUID(c.envUUID, sid), update)
 	}
-	return c.Collection.UpdateId(bson.D{{"_id", id}}, update)
+	return c.collection.UpdateId(bson.D{{"_id", id}}, update)
 }
 
 // Remove deletes a single document using the query provided. The
 // query will be handled as per Find().
 func (c *envStateCollection) Remove(query interface{}) error {
-	return c.Collection.Remove(c.mungeQuery(query))
+	return c.collection.Remove(c.mungeQuery(query))
 }
 
 // RemoveId deletes a single document by id. If the id is a string the
@@ -217,7 +202,7 @@ func (c *envStateCollection) Remove(query interface{}) error {
 // query will be handled as per Find().
 func (c *envStateCollection) RemoveId(id interface{}) error {
 	if sid, ok := id.(string); ok {
-		return c.Collection.RemoveId(addEnvUUID(c.envUUID, sid))
+		return c.collection.RemoveId(addEnvUUID(c.envUUID, sid))
 	}
 	return c.Remove(bson.D{{"_id", id}})
 }
@@ -225,7 +210,7 @@ func (c *envStateCollection) RemoveId(id interface{}) error {
 // RemoveAll deletes all docuemnts that match a query. The query will
 // be handled as per Find().
 func (c *envStateCollection) RemoveAll(query interface{}) (*mgo.ChangeInfo, error) {
-	return c.Collection.RemoveAll(c.mungeQuery(query))
+	return c.collection.RemoveAll(c.mungeQuery(query))
 }
 
 func (c *envStateCollection) mungeQuery(inq interface{}) bson.D {

--- a/state/collections.go
+++ b/state/collections.go
@@ -30,7 +30,6 @@ func (st *State) getCollection(name string) (mongo.Collection, func()) {
 // should be rarely used. getCollection() should be used in almost all
 // cases.
 func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
-	// TODO(fwereade): drop all [gG]etRawCollection usage?
 	collection, closer := mongo.CollectionFromName(st.db, name)
 	return collection.Writeable().Underlying(), closer
 }

--- a/state/collections_test.go
+++ b/state/collections_test.go
@@ -37,7 +37,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 	s.factory.MakeUser(c, &factory.UserParams{Name: "foo", DisplayName: "Ms Foo"})
 	s.factory.MakeUser(c, &factory.UserParams{Name: "bar"})
 
-	collSnapshot := newCollectionSnapshot(c, coll.Underlying())
+	collSnapshot := newCollectionSnapshot(c, coll.Writeable().Underlying())
 
 	for i, t := range []collectionsTestCase{
 		{
@@ -71,7 +71,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "Insert",
 			test: func() (int, error) {
-				err := coll.Insert(bson.D{{"_id", "more"}})
+				err := coll.Writeable().Insert(bson.D{{"_id", "more"}})
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},
@@ -80,7 +80,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "RemoveId",
 			test: func() (int, error) {
-				err := coll.RemoveId("bar")
+				err := coll.Writeable().RemoveId("bar")
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},
@@ -89,7 +89,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "Remove",
 			test: func() (int, error) {
-				err := coll.Remove(bson.D{{"displayname", "Ms Foo"}})
+				err := coll.Writeable().Remove(bson.D{{"displayname", "Ms Foo"}})
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},
@@ -98,7 +98,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll",
 			test: func() (int, error) {
-				_, err := coll.RemoveAll(bson.D{{"createdby", s.Owner.Name()}})
+				_, err := coll.Writeable().RemoveAll(bson.D{{"createdby", s.Owner.Name()}})
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},
@@ -107,7 +107,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "Update",
 			test: func() (int, error) {
-				err := coll.Update(bson.D{{"_id", "bar"}},
+				err := coll.Writeable().Update(bson.D{{"_id", "bar"}},
 					bson.D{{"$set", bson.D{{"displayname", "Updated Bar"}}}})
 				c.Assert(err, jc.ErrorIsNil)
 
@@ -118,7 +118,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "UpdateId",
 			test: func() (int, error) {
-				err := coll.UpdateId("bar",
+				err := coll.Writeable().UpdateId("bar",
 					bson.D{{"$set", bson.D{{"displayname", "Updated Bar"}}}})
 				c.Assert(err, jc.ErrorIsNil)
 
@@ -192,8 +192,8 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 	networkInterfaces, closer := state.GetCollection(s.State, state.NetworkInterfacesC)
 	defer closer()
 
-	machinesSnapshot := newCollectionSnapshot(c, machines0.Underlying())
-	networkInterfacesSnapshot := newCollectionSnapshot(c, networkInterfaces.Underlying())
+	machinesSnapshot := newCollectionSnapshot(c, machines0.Writeable().Underlying())
+	networkInterfacesSnapshot := newCollectionSnapshot(c, networkInterfaces.Writeable().Underlying())
 
 	c.Assert(machines0.Name(), gc.Equals, state.MachinesC)
 	c.Assert(networkInterfaces.Name(), gc.Equals, state.NetworkInterfacesC)
@@ -308,7 +308,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Insert works",
 			test: func() (int, error) {
-				err := machines0.Insert(bson.D{
+				err := machines0.Writeable().Insert(bson.D{
 					{"_id", state.DocID(s.State, "99")},
 					{"machineid", 99},
 					{"env-uuid", s.State.EnvironUUID()},
@@ -321,7 +321,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Remove adds env UUID prefix to _id",
 			test: func() (int, error) {
-				err := machines0.Remove(bson.D{{"_id", "0"}})
+				err := machines0.Writeable().Remove(bson.D{{"_id", "0"}})
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -333,7 +333,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 				// Attempt to remove the trusty machine in the second
 				// env with the collection that's filtering for the
 				// first env - nothing should get removed.
-				err := machines0.Remove(bson.D{{"series", "trusty"}})
+				err := machines0.Writeable().Remove(bson.D{{"series", "trusty"}})
 				c.Assert(err, gc.ErrorMatches, "not found")
 				return s.machines.Count()
 			},
@@ -342,7 +342,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Remove filters by env 2",
 			test: func() (int, error) {
-				err := machines0.Remove(bson.D{{"machineid", "0"}})
+				err := machines0.Writeable().Remove(bson.D{{"machineid", "0"}})
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -351,7 +351,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveId adds env UUID prefix",
 			test: func() (int, error) {
-				err := machines0.RemoveId(m0.Id())
+				err := machines0.Writeable().RemoveId(m0.Id())
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -360,7 +360,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveId tolerates env UUID prefix already being there",
 			test: func() (int, error) {
-				err := machines0.RemoveId(state.DocID(s.State, m0.Id()))
+				err := machines0.Writeable().RemoveId(state.DocID(s.State, m0.Id()))
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -369,7 +369,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveId filters by env-uuid field",
 			test: func() (int, error) {
-				err := networkInterfaces.RemoveId(otherIfaceId)
+				err := networkInterfaces.Writeable().RemoveId(otherIfaceId)
 				c.Assert(err, gc.ErrorMatches, "not found")
 				return networkInterfaces.Count()
 			},
@@ -378,7 +378,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll filters by env",
 			test: func() (int, error) {
-				_, err := machines0.RemoveAll(bson.D{{"series", m0.Series()}})
+				_, err := machines0.Writeable().RemoveAll(bson.D{{"series", m0.Series()}})
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -387,7 +387,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll adds env UUID when _id is provided",
 			test: func() (int, error) {
-				_, err := machines0.RemoveAll(bson.D{{"_id", m0.Id()}})
+				_, err := machines0.Writeable().RemoveAll(bson.D{{"_id", m0.Id()}})
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -396,7 +396,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll tolerates env UUID prefix already being present",
 			test: func() (int, error) {
-				_, err := machines0.RemoveAll(bson.D{
+				_, err := machines0.Writeable().RemoveAll(bson.D{
 					{"_id", state.DocID(s.State, m0.Id())},
 				})
 				c.Assert(err, jc.ErrorIsNil)
@@ -407,7 +407,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll with no selector still filters by env",
 			test: func() (int, error) {
-				_, err := machines0.RemoveAll(nil)
+				_, err := machines0.Writeable().RemoveAll(nil)
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -416,7 +416,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll panics if env-uuid is included",
 			test: func() (int, error) {
-				machines0.RemoveAll(bson.D{{"env-uuid", "whatever"}})
+				machines0.Writeable().RemoveAll(bson.D{{"env-uuid", "whatever"}})
 				return 0, nil
 			},
 			expectedPanic: "env-uuid is added automatically and should not be provided",
@@ -424,7 +424,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll panics if query type is unsupported",
 			test: func() (int, error) {
-				machines0.RemoveAll(bson.M{"foo": "bar"})
+				machines0.Writeable().RemoveAll(bson.M{"foo": "bar"})
 				return 0, nil
 			},
 			expectedPanic: "query must either be bson.D or nil",
@@ -432,7 +432,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Update",
 			test: func() (int, error) {
-				err := machines0.Update(bson.D{{"_id", m0.Id()}},
+				err := machines0.Writeable().Update(bson.D{{"_id", m0.Id()}},
 					bson.D{{"$set", bson.D{{"update-field", "field value"}}}})
 				c.Assert(err, jc.ErrorIsNil)
 				return machines0.Find(bson.D{{"update-field", "field value"}}).Count()
@@ -442,7 +442,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "UpdateId",
 			test: func() (int, error) {
-				err := machines0.UpdateId(m0.Id(),
+				err := machines0.Writeable().UpdateId(m0.Id(),
 					bson.D{{"$set", bson.D{{"update-field", "field value"}}}})
 				c.Assert(err, jc.ErrorIsNil)
 				return machines0.Find(bson.D{{"update-field", "field value"}}).Count()

--- a/state/errors.go
+++ b/state/errors.go
@@ -1,0 +1,55 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v5"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// ErrCharmAlreadyUploaded is returned by UpdateUploadedCharm() when
+// the given charm is already uploaded and marked as not pending in
+// state.
+type ErrCharmAlreadyUploaded struct {
+	curl *charm.URL
+}
+
+func (e *ErrCharmAlreadyUploaded) Error() string {
+	return fmt.Sprintf("charm %q already uploaded", e.curl)
+}
+
+// IsCharmAlreadyUploadedError returns if the given error is
+// ErrCharmAlreadyUploaded.
+func IsCharmAlreadyUploadedError(err interface{}) bool {
+	if err == nil {
+		return false
+	}
+	// In case of a wrapped error, check the cause first.
+	value := err
+	cause := errors.Cause(err.(error))
+	if cause != nil {
+		value = cause
+	}
+	_, ok := value.(*ErrCharmAlreadyUploaded)
+	return ok
+}
+
+// ErrCharmRevisionAlreadyModified is returned when a pending or
+// placeholder charm is no longer pending or a placeholder, signaling
+// the charm is available in state with its full information.
+var ErrCharmRevisionAlreadyModified = fmt.Errorf("charm revision already modified")
+
+var ErrDead = fmt.Errorf("not found or dead")
+var errNotAlive = fmt.Errorf("not found or not alive")
+
+func onAbort(txnErr, err error) error {
+	if txnErr == txn.ErrAborted ||
+		errors.Cause(txnErr) == txn.ErrAborted {
+		return errors.Trace(err)
+	}
+	return errors.Trace(txnErr)
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testcharms"
 )
@@ -295,7 +296,7 @@ func GetUnitEnvUUID(unit *Unit) string {
 	return unit.doc.EnvUUID
 }
 
-func GetCollection(st *State, name string) (stateCollection, func()) {
+func GetCollection(st *State, name string) (mongo.Collection, func()) {
 	return st.getCollection(name)
 }
 

--- a/state/lease.go
+++ b/state/lease.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/lease"
+	"github.com/juju/juju/mongo"
 )
 
 // leaseEntity represents a lease in mongo.
@@ -30,7 +31,7 @@ type leaseEntity struct {
 func NewLeasePersistor(
 	collectionName string,
 	runTransaction func(jujutxn.TransactionSource) error,
-	getCollection func(string) (_ stateCollection, closer func()),
+	getCollection func(string) (_ mongo.Collection, closer func()),
 ) *LeasePersistor {
 	getLeaseCollection := func(name string) (_ leaseCollection, closer func()) {
 		sc, closer := getCollection(name)
@@ -54,14 +55,14 @@ type LeasePersistor struct {
 // leaseCollection provides bespoke lease methods on top of a standard
 // state collection.
 type leaseCollection interface {
-	stateCollection
+	mongo.Collection
 
 	// FindById finds the lease with the specified id.
 	FindById(id string) (*leaseEntity, error)
 }
 
 type genericLeaseCollection struct {
-	stateCollection
+	mongo.Collection
 }
 
 // FindById finds the lease with the specified id.

--- a/state/lease_test.go
+++ b/state/lease_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/lease"
+	"github.com/juju/juju/mongo"
 )
 
 const (
@@ -35,12 +36,16 @@ func stubRunTransaction(txns jujutxn.TransactionSource) error {
 	return nil
 }
 
-func stubGetCollection(collectionName string) (stateCollection, func()) {
+func stubGetCollection(collectionName string) (mongo.Collection, func()) {
 	return &genericStateCollection{}, func() {}
 }
 
+type genericStateCollection struct {
+	mongo.Collection
+}
+
 type stubLeaseCollection struct {
-	stateCollection
+	mongo.Collection
 	tokenToReturn *leaseEntity
 }
 
@@ -155,7 +160,7 @@ func (s *leaseSuite) TestRemoveToken(c *gc.C) {
 func (s *leaseSuite) TestPersistedTokens(c *gc.C) {
 
 	closerCallCount := 0
-	stubGetCollection := func(collectionName string) (stateCollection, func()) {
+	stubGetCollection := func(collectionName string) (mongo.Collection, func()) {
 		c.Check(collectionName, gc.Equals, testCollectionName)
 		return &genericStateCollection{}, func() { closerCallCount++ }
 	}

--- a/state/life.go
+++ b/state/life.go
@@ -3,7 +3,11 @@
 
 package state
 
-import "gopkg.in/mgo.v2/bson"
+import (
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/mongo"
+)
 
 // Life represents the lifecycle state of the entities
 // Relation, Unit, Service and Machine.
@@ -54,7 +58,7 @@ func isAlive(st *State, collName string, id interface{}) (bool, error) {
 	return isAliveWithSession(coll, id)
 }
 
-func isAliveWithSession(coll stateCollection, id interface{}) (bool, error) {
+func isAliveWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 	n, err := coll.Find(bson.D{{"_id", id}, {"life", Alive}}).Count()
 	return n == 1, err
 }
@@ -65,7 +69,7 @@ func isNotDead(st *State, collName string, id interface{}) (bool, error) {
 	return isNotDeadWithSession(coll, id)
 }
 
-func isNotDeadWithSession(coll stateCollection, id interface{}) (bool, error) {
+func isNotDeadWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 	n, err := coll.Find(bson.D{{"_id", id}, {"life", bson.D{{"$ne", Dead}}}}).Count()
 	return n == 1, err
 }

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -930,7 +930,7 @@ func (b *allWatcherStateBacking) GetAll(all *multiwatcherStore) error {
 		if c.subsidiary {
 			continue
 		}
-		col := newStateCollection(db.C(c.Name), envUUID)
+		col := getCollectionFromDB(db, c.Name, envUUID)
 		infoSlicePtr := reflect.New(reflect.SliceOf(c.infoType))
 		if err := col.Find(nil).All(infoSlicePtr.Interface()); err != nil {
 			return fmt.Errorf("cannot get all %s: %v", c.Name, err)

--- a/state/state.go
+++ b/state/state.go
@@ -562,17 +562,6 @@ func (st *State) SetEnvironConstraints(cons constraints.Value) error {
 	return writeConstraints(st, environGlobalKey, cons)
 }
 
-var ErrDead = fmt.Errorf("not found or dead")
-var errNotAlive = fmt.Errorf("not found or not alive")
-
-func onAbort(txnErr, err error) error {
-	if txnErr == txn.ErrAborted ||
-		errors.Cause(txnErr) == txn.ErrAborted {
-		return errors.Trace(err)
-	}
-	return errors.Trace(txnErr)
-}
-
 // AllMachines returns all machines in the environment
 // ordered by id.
 func (st *State) AllMachines() (machines []*Machine, err error) {
@@ -798,11 +787,11 @@ func (st *State) AddCharm(ch charm.Charm, curl *charm.URL, storagePath, bundleSh
 			Placeholder bool `bson:"placeholder"`
 		}
 		if err := query.One(&placeholderDoc); err == mgo.ErrNotFound {
-			return st.insertCharmOps(ch, curl, storagePath, bundleSha256)
+			return insertCharmOps(st, ch, curl, storagePath, bundleSha256)
 		} else if err != nil {
 			return nil, errors.Trace(err)
 		} else if placeholderDoc.Placeholder {
-			return st.updateCharmOps(ch, curl, storagePath, bundleSha256, stillPlaceholder)
+			return updateCharmOps(st, ch, curl, storagePath, bundleSha256, stillPlaceholder)
 		}
 		return nil, errors.AlreadyExistsf("charm %q", curl)
 	}
@@ -810,38 +799,6 @@ func (st *State) AddCharm(ch charm.Charm, curl *charm.URL, storagePath, bundleSh
 		return st.Charm(curl)
 	}
 	return nil, errors.Trace(err)
-}
-
-func (st *State) insertCharmOps(ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string) []txn.Op {
-	// The charm may already exist in state as a placeholder, so we
-	// check for that situation and update the existing charm record
-	// if necessary, otherwise add a new record.
-	var existing charmDoc
-	charms, closer := st.getCollection(charmsC)
-	defer closer()
-
-	err = charms.Find(bson.D{{"_id", curl.String()}, {"placeholder", true}}).One(&existing)
-	if err == mgo.ErrNotFound {
-		cdoc := &charmDoc{
-			DocID:        st.docID(curl.String()),
-			URL:          curl,
-			EnvUUID:      st.EnvironTag().Id(),
-			Meta:         ch.Meta(),
-			Config:       ch.Config(),
-			Metrics:      ch.Metrics(),
-			Actions:      ch.Actions(),
-			BundleSha256: bundleSha256,
-			StoragePath:  storagePath,
-		}
-		err = charms.Underlying().Insert(cdoc)
-		if err != nil {
-			return nil, errors.Annotatef(err, "cannot add charm %q", curl)
-		}
-		return newCharm(st, cdoc), nil
-	} else if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return st.updateCharmDoc(ch, curl, storagePath, bundleSha256, stillPlaceholder)
 }
 
 // AllCharms returns all charms in state.
@@ -952,20 +909,7 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenUrl *charm.URL,
 			chosenRevision = maxRevision + 1
 		}
 		chosenUrl = curl.WithRevision(chosenRevision)
-
-		uploadedCharm := &charmDoc{
-			DocID:         st.docID(chosenUrl.String()),
-			EnvUUID:       st.EnvironTag().Id(),
-			URL:           chosenUrl,
-			PendingUpload: true,
-		}
-		ops := []txn.Op{{
-			C:      charmsC,
-			Id:     uploadedCharm.DocID,
-			Assert: txn.DocMissing,
-			Insert: uploadedCharm,
-		}}
-		return ops, nil
+		return insertPendingCharmOps(st, chosenUrl)
 	}
 	if err = st.run(buildTxn); err == nil {
 		return chosenUrl, nil
@@ -976,7 +920,7 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenUrl *charm.URL,
 // PrepareStoreCharmUpload must be called before a charm store charm
 // is uploaded to the provider storage in order to create a charm
 // document in state. If a charm with the same URL is already in
-// state, it will be returned as a *state.Charm (is can be still
+// state, it will be returned as a *state.Charm (it can be still
 // pending or already uploaded). Otherwise, a new charm document is
 // added in state with just the given charm URL and
 // PendingUpload=true, which is then returned as a *state.Charm.
@@ -1001,55 +945,28 @@ func (st *State) PrepareStoreCharmUpload(curl *charm.URL) (*Charm, error) {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// Find an uploaded or pending charm with the given exact curl.
 		err := charms.FindId(curl.String()).One(&uploadedCharm)
-		if err != nil && err != mgo.ErrNotFound {
-			return nil, errors.Trace(err)
-		} else if err == nil && !uploadedCharm.Placeholder {
-			// The charm exists and it's either uploaded or still
-			// pending, but it's not a placeholder. In any case,
-			// there's nothing to do.
-			return nil, jujutxn.ErrNoOperations
-		} else if err == mgo.ErrNotFound {
-			// Prepare the pending charm document for insertion.
+		switch {
+		case err == mgo.ErrNotFound:
 			uploadedCharm = charmDoc{
 				DocID:         st.docID(curl.String()),
 				EnvUUID:       st.EnvironTag().Id(),
 				URL:           curl,
 				PendingUpload: true,
-				Placeholder:   false,
 			}
-		}
-
-		var ops []txn.Op
-		if uploadedCharm.Placeholder {
-			// Convert the placeholder to a pending charm, while
-			// asserting the fields updated after an upload have not
-			// changed yet.
-			ops = []txn.Op{{
-				C:  charmsC,
-				Id: uploadedCharm.DocID,
-				Assert: bson.D{
-					{"bundlesha256", ""},
-					{"pendingupload", false},
-					{"placeholder", true},
-				},
-				Update: bson.D{{"$set", bson.D{
-					{"pendingupload", true},
-					{"placeholder", false},
-				}}},
-			}}
+			return insertAnyCharmOps(&uploadedCharm)
+		case err != nil:
+			return nil, errors.Trace(err)
+		case uploadedCharm.Placeholder:
 			// Update the fields of the document we're returning.
 			uploadedCharm.PendingUpload = true
 			uploadedCharm.Placeholder = false
-		} else {
-			// No charm document with this curl yet, insert it.
-			ops = []txn.Op{{
-				C:      charmsC,
-				Id:     uploadedCharm.DocID,
-				Assert: txn.DocMissing,
-				Insert: uploadedCharm,
-			}}
+			return convertPlaceholderCharmOps(uploadedCharm.DocID)
+		default:
+			// The charm exists and it's either uploaded or still
+			// pending, but it's not a placeholder. In any case,
+			// there's nothing to do.
+			return nil, jujutxn.ErrNoOperations
 		}
-		return ops, nil
 	}
 	if err = st.run(buildTxn); err == nil {
 		return newCharm(st, &uploadedCharm), nil
@@ -1088,89 +1005,19 @@ func (st *State) AddStoreCharmPlaceholder(curl *charm.URL) (err error) {
 		}
 
 		// Delete all previous placeholders so we don't fill up the database with unused data.
-		ops, err := st.deleteOldPlaceholderCharmsOps(curl)
+		deleteOps, err := deleteOldPlaceholderCharmsOps(st, charms, curl)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		// Add the new charm doc.
-		placeholderCharm := &charmDoc{
-			DocID:       st.docID(curl.String()),
-			EnvUUID:     st.EnvironTag().Id(),
-			URL:         curl,
-			Placeholder: true,
+		insertOps, err := insertPlaceholderCharmOps(st, curl)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
-		ops = append(ops, txn.Op{
-			C:      charmsC,
-			Id:     placeholderCharm.DocID,
-			Assert: txn.DocMissing,
-			Insert: placeholderCharm,
-		})
+		ops := append(deleteOps, insertOps...)
 		return ops, nil
 	}
 	return errors.Trace(st.run(buildTxn))
 }
-
-// deleteOldPlaceholderCharmsOps returns the txn ops required to delete all placeholder charm
-// records older than the specified charm URL.
-func (st *State) deleteOldPlaceholderCharmsOps(curl *charm.URL) ([]txn.Op, error) {
-	// Get a regex with the charm URL and no revision.
-	noRevURL := curl.WithRevision(-1)
-	curlRegex := "^" + regexp.QuoteMeta(st.docID(noRevURL.String()))
-	charms, closer := st.getCollection(charmsC)
-	defer closer()
-
-	var docs []charmDoc
-	query := bson.D{{"_id", bson.D{{"$regex", curlRegex}}}, {"placeholder", true}}
-	err := charms.Find(query).Select(bson.D{{"_id", 1}, {"url", 1}}).All(&docs)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	var ops []txn.Op
-	for _, doc := range docs {
-		if doc.URL.Revision >= curl.Revision {
-			continue
-		}
-		ops = append(ops, txn.Op{
-			C:      charmsC,
-			Id:     doc.DocID,
-			Assert: stillPlaceholder,
-			Remove: true,
-		})
-	}
-	return ops, nil
-}
-
-// ErrCharmAlreadyUploaded is returned by UpdateUploadedCharm() when
-// the given charm is already uploaded and marked as not pending in
-// state.
-type ErrCharmAlreadyUploaded struct {
-	curl *charm.URL
-}
-
-func (e *ErrCharmAlreadyUploaded) Error() string {
-	return fmt.Sprintf("charm %q already uploaded", e.curl)
-}
-
-// IsCharmAlreadyUploadedError returns if the given error is
-// ErrCharmAlreadyUploaded.
-func IsCharmAlreadyUploadedError(err interface{}) bool {
-	if err == nil {
-		return false
-	}
-	// In case of a wrapped error, check the cause first.
-	value := err
-	cause := errors.Cause(err.(error))
-	if cause != nil {
-		value = cause
-	}
-	_, ok := value.(*ErrCharmAlreadyUploaded)
-	return ok
-}
-
-// ErrCharmRevisionAlreadyModified is returned when a pending or
-// placeholder charm is no longer pending or a placeholder, signaling
-// the charm is available in state with its full information.
-var ErrCharmRevisionAlreadyModified = fmt.Errorf("charm revision already modified")
 
 // UpdateUploadedCharm marks the given charm URL as uploaded and
 // updates the rest of its data, returning it as *state.Charm.
@@ -1190,76 +1037,14 @@ func (st *State) UpdateUploadedCharm(ch charm.Charm, curl *charm.URL, storagePat
 		return nil, errors.Trace(&ErrCharmAlreadyUploaded{curl})
 	}
 
-	return st.updateCharmDoc(ch, curl, storagePath, bundleSha256, stillPending)
-}
-
-// updateCharmDoc updates the charm with specified URL with the given
-// data, and resets the placeholder and pendingupdate flags.  If the
-// charm is no longer a placeholder or pending (depending on preReq),
-// it returns ErrCharmRevisionAlreadyModified.
-func (st *State) updateCharmDoc(
-	ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string, preReq interface{},
-) (*Charm, error) {
-
-	// Make sure we escape any "$" and "." in config option names
-	// first. See http://pad.lv/1308146.
-	cfg := ch.Config()
-	escapedConfig := charm.NewConfig()
-	for optionName, option := range cfg.Options {
-		escapedName := escapeReplacer.Replace(optionName)
-		escapedConfig.Options[escapedName] = option
+	ops, err := updateCharmOps(st, ch, curl, storagePath, bundleSha256, stillPending)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	updateFields := bson.D{{"$set", bson.D{
-		{"meta", ch.Meta()},
-		{"config", escapedConfig},
-		{"actions", ch.Actions()},
-		{"metrics", ch.Metrics()},
-		{"storagepath", storagePath},
-		{"bundlesha256", bundleSha256},
-		{"pendingupload", false},
-		{"placeholder", false},
-	}}}
-	ops := []txn.Op{{
-		C:      charmsC,
-		Id:     st.docID(curl.String()),
-		Assert: preReq,
-		Update: updateFields,
-	}}
 	if err := st.runTransaction(ops); err != nil {
 		return nil, onAbort(err, ErrCharmRevisionAlreadyModified)
 	}
 	return st.Charm(curl)
-}
-
-func (st *State) updateCharmOps(
-	ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string, preReq interface{},
-) (*Charm, error) {
-
-	// Make sure we escape any "$" and "." in config option names
-	// first. See http://pad.lv/1308146.
-	cfg := ch.Config()
-	escapedConfig := charm.NewConfig()
-	for optionName, option := range cfg.Options {
-		escapedName := escapeReplacer.Replace(optionName)
-		escapedConfig.Options[escapedName] = option
-	}
-
-	updateFields := bson.D{{"$set", bson.D{
-		{"meta", ch.Meta()},
-		{"config", escapedConfig},
-		{"actions", ch.Actions()},
-		{"metrics", ch.Metrics()},
-		{"storagepath", storagePath},
-		{"bundlesha256", bundleSha256},
-		{"pendingupload", false},
-		{"placeholder", false},
-	}}}
-	ops := []txn.Op{{
-		C:      charmsC,
-		Id:     st.docID(curl.String()),
-		Assert: preReq,
-		Update: updateFields,
-	}}
 }
 
 // addPeerRelationsOps returns the operations necessary to add the

--- a/state/status.go
+++ b/state/status.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo"
 )
 
 var (
@@ -601,7 +603,7 @@ func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
 
 // getOldestTimeToKeep returns the create time for the oldest
 // status log to be kept.
-func getOldestTimeToKeep(coll stateCollection, globalKey string, size int) (int, bool, error) {
+func getOldestTimeToKeep(coll mongo.Collection, globalKey string, size int) (int, bool, error) {
 	result := historicalStatusDoc{}
 	err := coll.Find(bson.D{{"entityid", globalKey}}).Sort("-_id").Skip(size - 1).One(&result)
 	if err == mgo.ErrNotFound {
@@ -616,7 +618,7 @@ func getOldestTimeToKeep(coll stateCollection, globalKey string, size int) (int,
 
 // getEntitiesWithStatuses returns the ids for all entities that
 // have history entries
-func getEntitiesWithStatuses(coll stateCollection) ([]string, error) {
+func getEntitiesWithStatuses(coll mongo.Collection) ([]string, error) {
 	var entityKeys []string
 	err := coll.Find(nil).Distinct("entityid", &entityKeys)
 	if err != nil {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
 )
@@ -141,9 +142,9 @@ type lifecycleWatcher struct {
 	commonWatcher
 	out chan []string
 
-	// coll is a function returning the stateCollection holding all
+	// coll is a function returning the mongo.Collection holding all
 	// interesting entities
-	coll     func() (stateCollection, func())
+	coll     func() (mongo.Collection, func())
 	collName string
 
 	// members is used to select the initial set of interesting entities.
@@ -157,8 +158,8 @@ type lifecycleWatcher struct {
 	life map[string]Life
 }
 
-func collFactory(st *State, collName string) func() (stateCollection, func()) {
-	return func() (stateCollection, func()) {
+func collFactory(st *State, collName string) func() (mongo.Collection, func()) {
+	return func() (mongo.Collection, func()) {
 		return st.getCollection(collName)
 	}
 }
@@ -1500,7 +1501,7 @@ func (w *docWatcher) Changes() <-chan struct{} {
 // given key in the given collection. It is useful to enable
 // a watcher.Watcher to be primed with the correct revision
 // id.
-func getTxnRevno(coll stateCollection, key interface{}) (int64, error) {
+func getTxnRevno(coll mongo.Collection, key interface{}) (int64, error) {
 	doc := struct {
 		TxnRevno int64 `bson:"txn-revno"`
 	}{}


### PR DESCRIPTION
The new Collection interface is wanted for use by the state/lease package, so it can be fed an envStateCollection for automatic env-awareness.

When extracting the interface, did a quick audit of "surprising" mongo usage and split Collection into two, with most of the dangerous capabilities attached to the WriteCollection accessed via Writeable(). Some illegitimate layer-breaking has been removed (charm insert and settings remove); much of the charm code was moved from state.go into charm.go, and some was moved to the new errors.go; and all questionable mongo was at least flagged.

Currently there are a couple of probably-legitimate RemoveAlls (preserved); but there are still a number of risky and hard-to-justfify hacks that have also been preserved for want of bandwidth to fix them.

(Review request: http://reviews.vapour.ws/r/1984/)