### PR TITLE
Fix 1467037 - Remove camel case username envusers

### DIFF
--- a/state/envuser_test.go
+++ b/state/envuser_test.go
@@ -112,7 +112,7 @@ func (s *EnvUserSuite) TestAddEnvironmentNoCreatedByUserFails(c *gc.C) {
 }
 
 func (s *EnvUserSuite) TestRemoveEnvironmentUser(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
+	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validUsername"})
 	_, err := s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
RemoveEnvironmentUser should convert the username
to lower case when creating the ID for the op.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1467037

(Review request: http://reviews.vapour.ws/r/1985/)