### PR TITLE
Bump mgo dependency to latest v2

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,7 +42,7 @@ gopkg.in/juju/charm.v5	git	192aa737f07ab3411f59ff8f6c41d55bc8097521	2015-05-05T0
 gopkg.in/juju/charmstore.v4	git	ab64d50370f9c167a7cd55be8ea22c3842aae46d	2015-04-10T09:44:12Z
 gopkg.in/macaroon-bakery.v0	git	9593b80b01ba04b519769d045dffd6abd827d2fd	2015-04-10T07:46:55Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
-gopkg.in/mgo.v2	git	01ee097136da162d1dd3c9b44fbdf3abf4fd6552	2015-05-29T15:47:11Z
+gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27Z
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08-11T16:19:00Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z


### PR DESCRIPTION
This is primarily to get the fixes made to PurgeMissing on to every Juju developer's machines.

(Review request: http://reviews.vapour.ws/r/1988/)