### PR TITLE
util/ssh: fix data races in test

### DIFF
--- a/utils/ssh/run.go
+++ b/utils/ssh/run.go
@@ -73,7 +73,9 @@ func ExecuteCommandOnMachine(params ExecParams) (result utilexec.ExecResponse, e
 		err = fmt.Errorf("command timed out")
 		command.Kill()
 	}
+
 	// In either case, gather as much as we have from stdout and stderr
+	<-commandDone // command.Wait is not current, must wait for the other waiter to exit.
 	command.Wait()
 	result.Stderr = stderr.Bytes()
 	result.Stdout = stdout.Bytes()

--- a/utils/ssh/ssh_gocrypto_test.go
+++ b/utils/ssh/ssh_gocrypto_test.go
@@ -50,7 +50,7 @@ func (s *sshServer) run(c *gc.C) {
 	netconn, err := s.listener.Accept()
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
-		err = netconn.Close()
+		err := netconn.Close()
 		c.Assert(err, jc.ErrorIsNil)
 	}()
 	conn, chans, reqs, err := cryptossh.NewServerConn(netconn, s.cfg)


### PR DESCRIPTION
Updates LP 1467362

There is one race remaining, that is blocked on https://github.com/go-check/check/issues/43

(Review request: http://reviews.vapour.ws/r/1991/)