### PR TITLE
apiserver: /logs API can now read from the DB

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -333,14 +333,16 @@ func (srv *Server) run(lis net.Listener) {
 	// registered first.
 	mux := pat.New()
 
+	srvDying := srv.tomb.Dying()
+
 	if feature.IsDbLogEnabled() {
 		handleAll(mux, "/environment/:envuuid/logsink",
 			newLogSinkHandler(httpHandler{ssState: srv.state}, srv.logDir))
 		handleAll(mux, "/environment/:envuuid/log",
-			newDebugLogDBHandler(srv.state, srv.tomb.Dying()))
+			newDebugLogDBHandler(srv.state, srvDying))
 	} else {
 		handleAll(mux, "/environment/:envuuid/log",
-			newDebugLogFileHandler(srv.state, srv.logDir))
+			newDebugLogFileHandler(srv.state, srvDying, srv.logDir))
 	}
 	handleAll(mux, "/environment/:envuuid/charms",
 		&charmsHandler{
@@ -377,9 +379,9 @@ func (srv *Server) run(lis net.Listener) {
 	// For backwards compatibility we register all the old paths
 
 	if feature.IsDbLogEnabled() {
-		handleAll(mux, "/log", newDebugLogDBHandler(srv.state, srv.tomb.Dying()))
+		handleAll(mux, "/log", newDebugLogDBHandler(srv.state, srvDying))
 	} else {
-		handleAll(mux, "/log", newDebugLogFileHandler(srv.state, srv.logDir))
+		handleAll(mux, "/log", newDebugLogFileHandler(srv.state, srvDying, srv.logDir))
 	}
 
 	handleAll(mux, "/charms",

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -333,11 +333,14 @@ func (srv *Server) run(lis net.Listener) {
 	// registered first.
 	mux := pat.New()
 
-	handleAll(mux, "/environment/:envuuid/log",
-		newDebugLogFileHandler(srv.state, srv.logDir))
 	if feature.IsDbLogEnabled() {
 		handleAll(mux, "/environment/:envuuid/logsink",
 			newLogSinkHandler(httpHandler{ssState: srv.state}, srv.logDir))
+		handleAll(mux, "/environment/:envuuid/log",
+			newDebugLogDBHandler(srv.state, srv.tomb.Dying()))
+	} else {
+		handleAll(mux, "/environment/:envuuid/log",
+			newDebugLogFileHandler(srv.state, srv.logDir))
 	}
 	handleAll(mux, "/environment/:envuuid/charms",
 		&charmsHandler{
@@ -372,7 +375,13 @@ func (srv *Server) run(lis net.Listener) {
 			dataDir:     srv.dataDir},
 	)
 	// For backwards compatibility we register all the old paths
-	handleAll(mux, "/log", newDebugLogFileHandler(srv.state, srv.logDir))
+
+	if feature.IsDbLogEnabled() {
+		handleAll(mux, "/log", newDebugLogDBHandler(srv.state, srv.tomb.Dying()))
+	} else {
+		handleAll(mux, "/log", newDebugLogFileHandler(srv.state, srv.logDir))
+	}
+
 	handleAll(mux, "/charms",
 		&charmsHandler{
 			httpHandler: httpHandler{ssState: srv.state},

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -1,0 +1,95 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/state"
+)
+
+func newDebugLogDBHandler(ssState *state.State, stop <-chan struct{}) http.Handler {
+	return newDebugLogHandler(ssState, stop, handleDebugLogDBRequest)
+}
+
+func handleDebugLogDBRequest(
+	st state.LoggingState,
+	reqParams *debugLogParams,
+	socket debugLogSocket,
+	stop <-chan struct{},
+) error {
+	params := makeLogTailerParams(reqParams)
+	tailer := newLogTailer(st, params)
+	defer tailer.Stop()
+
+	// Indicate that all is well.
+	if err := socket.sendOk(); err != nil {
+		return errors.Trace(err)
+	}
+
+	var lineCount uint
+	for {
+		select {
+		case <-stop:
+			return nil
+		case rec, ok := <-tailer.Logs():
+			if !ok {
+				return errors.Annotate(tailer.Err(), "tailer stopped")
+			}
+
+			line := formatLogRecord(rec)
+			_, err := socket.Write([]byte(line))
+			if err != nil {
+				return errors.Annotate(err, "sending failed")
+			}
+
+			lineCount++
+			if reqParams.maxLines > 0 && lineCount == reqParams.maxLines {
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func makeLogTailerParams(reqParams *debugLogParams) *state.LogTailerParams {
+	params := &state.LogTailerParams{
+		MinLevel:      reqParams.filterLevel,
+		InitialLines:  int(reqParams.backlog),
+		IncludeEntity: reqParams.includeEntity,
+		ExcludeEntity: reqParams.excludeEntity,
+		IncludeModule: reqParams.includeModule,
+		ExcludeModule: reqParams.excludeModule,
+	}
+	if reqParams.fromTheStart {
+		params.InitialLines = 0
+	}
+	return params
+}
+
+func formatLogRecord(r *state.LogRecord) string {
+	return fmt.Sprintf("%s: %s %s %s %s %s\n",
+		r.Entity,
+		formatTime(r.Time),
+		r.Level.String(),
+		r.Module,
+		r.Location,
+		r.Message,
+	)
+}
+
+func formatTime(t time.Time) string {
+	return t.In(time.UTC).Format("2006-01-02 15:04:05")
+}
+
+var newLogTailer = _newLogTailer // For replacing in tests
+
+func _newLogTailer(st state.LoggingState, params *state.LogTailerParams) state.LogTailer {
+	return state.NewLogTailer(st, params)
+}

--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -1,0 +1,249 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type debugLogDBIntSuite struct {
+	coretesting.BaseSuite
+	sock *fakeDebugLogSocket
+}
+
+var _ = gc.Suite(&debugLogDBIntSuite{})
+
+func (s *debugLogDBIntSuite) SetUpTest(c *gc.C) {
+	s.sock = newFakeDebugLogSocket()
+}
+
+func (s *debugLogDBIntSuite) TestParamConversion(c *gc.C) {
+	reqParams := &debugLogParams{
+		fromTheStart:  false,
+		backlog:       11,
+		filterLevel:   loggo.INFO,
+		includeEntity: []string{"foo"},
+		includeModule: []string{"bar"},
+		excludeEntity: []string{"baz"},
+		excludeModule: []string{"qux"},
+	}
+
+	called := false
+	s.PatchValue(&newLogTailer, func(_ state.LoggingState, params *state.LogTailerParams) state.LogTailer {
+		called = true
+
+		// Start time will be used once the client is extended to send
+		// time range arguments.
+		c.Assert(params.StartTime.IsZero(), jc.IsTrue)
+
+		c.Assert(params.MinLevel, gc.Equals, loggo.INFO)
+		c.Assert(params.InitialLines, gc.Equals, 11)
+		c.Assert(params.IncludeEntity, jc.DeepEquals, []string{"foo"})
+		c.Assert(params.IncludeModule, jc.DeepEquals, []string{"bar"})
+		c.Assert(params.ExcludeEntity, jc.DeepEquals, []string{"baz"})
+		c.Assert(params.ExcludeModule, jc.DeepEquals, []string{"qux"})
+
+		return newFakeLogTailer()
+	})
+
+	stop := make(chan struct{})
+	close(stop) // Stop the request immediately.
+	err := handleDebugLogDBRequest(nil, reqParams, s.sock, stop)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *debugLogDBIntSuite) TestParamConversionReplay(c *gc.C) {
+	reqParams := &debugLogParams{
+		fromTheStart: true,
+		backlog:      123,
+	}
+
+	called := false
+	s.PatchValue(&newLogTailer, func(_ state.LoggingState, params *state.LogTailerParams) state.LogTailer {
+		called = true
+
+		c.Assert(params.StartTime.IsZero(), jc.IsTrue)
+		c.Assert(params.InitialLines, gc.Equals, 0)
+
+		return newFakeLogTailer()
+	})
+
+	stop := make(chan struct{})
+	close(stop) // Stop the request immediately.
+	err := handleDebugLogDBRequest(nil, reqParams, s.sock, stop)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *debugLogDBIntSuite) TestFullRequest(c *gc.C) {
+	// Set up a fake log tailer with a 2 log records ready to send.
+	tailer := newFakeLogTailer()
+	tailer.logsCh <- &state.LogRecord{
+		Time:     time.Date(2015, 6, 19, 15, 34, 37, 0, time.UTC),
+		Entity:   "machine-99",
+		Module:   "some.where",
+		Location: "code.go:42",
+		Level:    loggo.INFO,
+		Message:  "stuff happened",
+	}
+	tailer.logsCh <- &state.LogRecord{
+		Time:     time.Date(2015, 6, 19, 15, 36, 40, 0, time.UTC),
+		Entity:   "unit-foo-2",
+		Module:   "else.where",
+		Location: "go.go:22",
+		Level:    loggo.ERROR,
+		Message:  "whoops",
+	}
+	s.PatchValue(&newLogTailer, func(_ state.LoggingState, params *state.LogTailerParams) state.LogTailer {
+		return tailer
+	})
+
+	stop := make(chan struct{})
+	done := s.runRequest(&debugLogParams{}, stop)
+
+	s.assertOutput(c, []string{
+		"ok", // sendOk() call needs to happen first.
+		"machine-99: 2015-06-19 15:34:37 INFO some.where code.go:42 stuff happened\n",
+		"unit-foo-2: 2015-06-19 15:36:40 ERROR else.where go.go:22 whoops\n",
+	})
+
+	// Check the request stops when requested.
+	close(stop)
+	s.assertStops(c, done, tailer)
+}
+
+func (s *debugLogDBIntSuite) TestRequestStopsWhenTailerStops(c *gc.C) {
+	tailer := newFakeLogTailer()
+	s.PatchValue(&newLogTailer, func(_ state.LoggingState, params *state.LogTailerParams) state.LogTailer {
+		close(tailer.logsCh) // make the request stop immediately
+		return tailer
+	})
+
+	err := handleDebugLogDBRequest(nil, &debugLogParams{}, s.sock, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tailer.stopped, jc.IsTrue)
+}
+
+func (s *debugLogDBIntSuite) TestMaxLines(c *gc.C) {
+	// Set up a fake log tailer with a 5 log records ready to send.
+	tailer := newFakeLogTailer()
+	for i := 0; i < 5; i++ {
+		tailer.logsCh <- &state.LogRecord{
+			Time:     time.Date(2015, 6, 19, 15, 34, 37, 0, time.UTC),
+			Entity:   "machine-99",
+			Module:   "some.where",
+			Location: "code.go:42",
+			Level:    loggo.INFO,
+			Message:  "stuff happened",
+		}
+	}
+	s.PatchValue(&newLogTailer, func(_ state.LoggingState, params *state.LogTailerParams) state.LogTailer {
+		return tailer
+	})
+
+	done := s.runRequest(&debugLogParams{maxLines: 3}, nil)
+
+	s.assertOutput(c, []string{
+		"ok", // sendOk() call needs to happen first.
+		"machine-99: 2015-06-19 15:34:37 INFO some.where code.go:42 stuff happened\n",
+		"machine-99: 2015-06-19 15:34:37 INFO some.where code.go:42 stuff happened\n",
+		"machine-99: 2015-06-19 15:34:37 INFO some.where code.go:42 stuff happened\n",
+	})
+
+	// The tailer should now stop by itself after the line limit was reached.
+	s.assertStops(c, done, tailer)
+}
+
+func (s *debugLogDBIntSuite) runRequest(params *debugLogParams, stop chan struct{}) chan error {
+	done := make(chan error)
+	go func() {
+		done <- handleDebugLogDBRequest(&fakeState{}, params, s.sock, stop)
+	}()
+	return done
+}
+
+func (s *debugLogDBIntSuite) assertOutput(c *gc.C, expectedWrites []string) {
+	timeout := time.After(coretesting.LongWait)
+	for i, expectedWrite := range expectedWrites {
+		select {
+		case actualWrite := <-s.sock.writes:
+			c.Assert(actualWrite, gc.Equals, expectedWrite)
+		case <-timeout:
+			c.Fatalf("timed out waiting for socket write (received %d)", i)
+		}
+	}
+}
+
+func (s *debugLogDBIntSuite) assertStops(c *gc.C, done chan error, tailer *fakeLogTailer) {
+	select {
+	case err := <-done:
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(tailer.stopped, jc.IsTrue)
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for request handler to stop")
+	}
+}
+
+type fakeState struct {
+	state.LoggingState
+}
+
+func newFakeLogTailer() *fakeLogTailer {
+	return &fakeLogTailer{
+		logsCh: make(chan *state.LogRecord, 10),
+	}
+}
+
+type fakeLogTailer struct {
+	state.LogTailer
+	logsCh  chan *state.LogRecord
+	stopped bool
+}
+
+func (t *fakeLogTailer) Logs() <-chan *state.LogRecord {
+	return t.logsCh
+}
+
+func (t *fakeLogTailer) Stop() error {
+	t.stopped = true
+	return nil
+}
+
+func (t *fakeLogTailer) Err() error {
+	return nil
+}
+
+func newFakeDebugLogSocket() *fakeDebugLogSocket {
+	return &fakeDebugLogSocket{
+		writes: make(chan string, 10),
+	}
+}
+
+type fakeDebugLogSocket struct {
+	writes chan string
+}
+
+func (s *fakeDebugLogSocket) sendOk() error {
+	s.writes <- "ok"
+	return nil
+}
+
+func (s *fakeDebugLogSocket) sendError(err error) error {
+	s.writes <- fmt.Sprintf("err: %v", err)
+	return nil
+}
+
+func (s *fakeDebugLogSocket) Write(buf []byte) (int, error) {
+	s.writes <- string(buf)
+	return len(buf), nil
+}

--- a/apiserver/debuglog_db_test.go
+++ b/apiserver/debuglog_db_test.go
@@ -1,0 +1,23 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import gc "gopkg.in/check.v1"
+
+// debugLogDBSuite runs the common debuglog API tests when the db-log
+// feature flag is enabled. These tests are inherited from
+// debugLogBaseSuite.
+type debugLogDBSuite struct {
+	debugLogBaseSuite
+}
+
+var _ = gc.Suite(&debugLogDBSuite{})
+
+func (s *debugLogDBSuite) SetUpSuite(c *gc.C) {
+	s.SetInitialFeatureFlags("db-log")
+	s.debugLogBaseSuite.SetUpSuite(c)
+}
+
+// See debuglog_db_internal_test.go for DB specific unit tests and the
+// featuretests package for an end-to-end integration test.

--- a/apiserver/debuglog_file.go
+++ b/apiserver/debuglog_file.go
@@ -18,15 +18,9 @@ import (
 	"github.com/juju/utils/tailer"
 )
 
-func newDebugLogFileHandler(st *state.State, logDir string) http.Handler {
-	fileHandler := &debugLogFileHandler{
-		logDir: logDir,
-	}
-
-	h := new(debugLogHandler)
-	h.httpHandler = httpHandler{ssState: st}
-	h.handle = fileHandler.handle
-	return h
+func newDebugLogFileHandler(ssState *state.State, stop <-chan struct{}, logDir string) http.Handler {
+	fileHandler := &debugLogFileHandler{logDir: logDir}
+	return newDebugLogHandler(ssState, stop, fileHandler.handle)
 }
 
 // debugLogFileHandler handles requests to watch all-machines.log.
@@ -62,7 +56,7 @@ func (h *debugLogFileHandler) handle(
 	}
 
 	stream.start(logFile, socket)
-	return stream.wait()
+	return stream.wait(stop)
 }
 
 func newLogFileStream(params *debugLogParams) *logFileStream {
@@ -155,12 +149,14 @@ func (stream *logFileStream) start(logFile io.ReadSeeker, writer io.Writer) {
 }
 
 // wait blocks until the logTailer is done or the maximum line count
-// has been reached.
-func (stream *logFileStream) wait() error {
+// has been reached or the stop channel is closed.
+func (stream *logFileStream) wait(stop <-chan struct{}) error {
 	select {
 	case <-stream.logTailer.Dead():
 		return stream.logTailer.Err()
 	case <-stream.maxLinesReached:
+		stream.logTailer.Stop()
+	case <-stop:
 		stream.logTailer.Stop()
 	}
 	return nil

--- a/apiserver/debuglog_file.go
+++ b/apiserver/debuglog_file.go
@@ -34,7 +34,12 @@ type debugLogFileHandler struct {
 	logDir string
 }
 
-func (h *debugLogFileHandler) handle(params *debugLogParams, socket *debugLogSocket) error {
+func (h *debugLogFileHandler) handle(
+	_ state.LoggingState,
+	params *debugLogParams,
+	socket debugLogSocket,
+	stop <-chan struct{},
+) error {
 	stream := newLogFileStream(params)
 
 	// Open log file.

--- a/apiserver/debuglog_file_internal_test.go
+++ b/apiserver/debuglog_file_internal_test.go
@@ -253,7 +253,7 @@ line 3
 
 	stream.logTailer.Stop()
 
-	err = stream.wait()
+	err = stream.wait(nil)
 	if errMatch == "" {
 		c.Assert(err, jc.ErrorIsNil)
 	} else {

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -1,0 +1,94 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"bufio"
+	"net/http"
+	"net/url"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"golang.org/x/net/websocket"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing/factory"
+)
+
+// debugLogBaseSuite has tests that should be run for both the file
+// and DB based variants of debuglog, as well as some test helpers.
+type debugLogBaseSuite struct {
+	userAuthHttpSuite
+}
+
+func (s *debugLogBaseSuite) TestBadParams(c *gc.C) {
+	reader := s.openWebsocket(c, url.Values{"maxLines": {"foo"}})
+	assertJSONError(c, reader, `maxLines value "foo" is not a valid unsigned number`)
+	s.assertWebsocketClosed(c, reader)
+}
+
+func (s *debugLogBaseSuite) TestWithHTTP(c *gc.C) {
+	uri := s.logURL(c, "http", nil).String()
+	_, err := s.sendRequest(c, "", "", "GET", uri, "", nil)
+	c.Assert(err, gc.ErrorMatches, `.*malformed HTTP response.*`)
+}
+
+func (s *debugLogBaseSuite) TestWithHTTPS(c *gc.C) {
+	uri := s.logURL(c, "https", nil).String()
+	response, err := s.sendRequest(c, "", "", "GET", uri, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(response.StatusCode, gc.Equals, http.StatusBadRequest)
+}
+
+func (s *debugLogBaseSuite) TestNoAuth(c *gc.C) {
+	conn := s.dialWebsocketInternal(c, nil, nil)
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	assertJSONError(c, reader, "auth failed: invalid request format")
+	s.assertWebsocketClosed(c, reader)
+}
+
+func (s *debugLogBaseSuite) TestAgentLoginsRejected(c *gc.C) {
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Nonce: "foo-nonce",
+	})
+	header := utils.BasicAuthHeader(m.Tag().String(), password)
+	header.Add("X-Juju-Nonce", "foo-nonce")
+	conn := s.dialWebsocketInternal(c, nil, header)
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	assertJSONError(c, reader, "auth failed: invalid entity name or password")
+	s.assertWebsocketClosed(c, reader)
+}
+
+func (s *debugLogBaseSuite) openWebsocket(c *gc.C, values url.Values) *bufio.Reader {
+	conn := s.dialWebsocket(c, values)
+	s.AddCleanup(func(_ *gc.C) { conn.Close() })
+	return bufio.NewReader(conn)
+}
+
+func (s *debugLogBaseSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Reader {
+	server := s.logURL(c, "wss", nil)
+	server.Path = path
+	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
+	conn := s.dialWebsocketFromURL(c, server.String(), header)
+	s.AddCleanup(func(_ *gc.C) { conn.Close() })
+	return bufio.NewReader(conn)
+}
+
+func (s *debugLogBaseSuite) logURL(c *gc.C, scheme string, queryParams url.Values) *url.URL {
+	return s.makeURL(c, scheme, "/log", queryParams)
+}
+
+func (s *debugLogBaseSuite) dialWebsocket(c *gc.C, queryParams url.Values) *websocket.Conn {
+	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
+	return s.dialWebsocketInternal(c, queryParams, header)
+}
+
+func (s *debugLogBaseSuite) dialWebsocketInternal(c *gc.C, queryParams url.Values, header http.Header) *websocket.Conn {
+	server := s.logURL(c, "wss", queryParams).String()
+	return s.dialWebsocketFromURL(c, server, header)
+}

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -26,6 +26,7 @@ var (
 	NewBackups            = &newBackups
 	ParseLogLine          = parseLogLine
 	AgentMatchesFilter    = agentMatchesFilter
+	NewLogTailer          = &newLogTailer
 )
 
 func ApiHandlerWithEntity(entity state.Entity) *apiHandler {

--- a/state/logs.go
+++ b/state/logs.go
@@ -147,8 +147,8 @@ type LogTailerParams struct {
 }
 
 // This is the maximum number of log document ids that will be tracked
-// to avoid re-reporting messages when moving querying the logs
-// collection and tailing the oplog.
+// to avoid re-reporting logs when transitioning between querying the
+// logs collection and tailing the oplog.
 const maxRecentLogIds = 5192
 
 // NewLogTailer returns a LogTailer which filters according to the

--- a/state/logs.go
+++ b/state/logs.go
@@ -26,6 +26,13 @@ import (
 const logsDB = "logs"
 const logsC = "logs"
 
+// LoggingState describes the methods on State required for logging to
+// the database.
+type LoggingState interface {
+	EnvironUUID() string
+	MongoSession() *mgo.Session
+}
+
 // InitDbLogs sets up the indexes for the logs collection. It should
 // be called as state is opened. It is idempotent.
 func InitDbLogs(session *mgo.Session) error {
@@ -63,7 +70,7 @@ type DbLogger struct {
 
 // NewDbLogger returns a DbLogger instance which is used to write logs
 // to the database.
-func NewDbLogger(st *State, entity names.Tag) *DbLogger {
+func NewDbLogger(st LoggingState, entity names.Tag) *DbLogger {
 	_, logsColl := initLogsSession(st)
 	return &DbLogger{
 		logsColl: logsColl,
@@ -146,7 +153,7 @@ const maxRecentLogIds = 5192
 
 // NewLogTailer returns a LogTailer which filters according to the
 // parameters given.
-func NewLogTailer(st *State, params *LogTailerParams) LogTailer {
+func NewLogTailer(st LoggingState, params *LogTailerParams) LogTailer {
 	session := st.MongoSession().Copy()
 	t := &logTailer{
 		envUUID:   st.EnvironUUID(),
@@ -391,7 +398,7 @@ func logDocToRecord(doc *logDoc) *LogRecord {
 // logs collection. All logs older than minLogTime are
 // removed. Further removal is also performed if the logs collection
 // size is greater than maxLogsMB.
-func PruneLogs(st *State, minLogTime time.Time, maxLogsMB int) error {
+func PruneLogs(st LoggingState, minLogTime time.Time, maxLogsMB int) error {
 	session, logsColl := initLogsSession(st)
 	defer session.Close()
 
@@ -472,7 +479,7 @@ func PruneLogs(st *State, minLogTime time.Time, maxLogsMB int) error {
 // initLogsSession creates a new session suitable for logging updates,
 // returning the session and a logs mgo.Collection connected to that
 // session.
-func initLogsSession(st *State) (*mgo.Session, *mgo.Collection) {
+func initLogsSession(st LoggingState) (*mgo.Session, *mgo.Collection) {
 	// To improve throughput, only wait for the logs to be written to
 	// the primary. For some reason, this makes a huge difference even
 	// when the replicaset only has one member (i.e. a single primary).


### PR DESCRIPTION
state: use a minimal interface for State functionality required for DB logging

---

apiserver: debuglog /logs API now supports DB based logs

---

apiserver: file-based debuglog handler should stop when the API server does


(Review request: http://reviews.vapour.ws/r/2000/)