### PR TITLE
Fix cloudinit failures on windows and ppc

### DIFF
--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/service"
 	systemdtesting "github.com/juju/juju/service/systemd/testing"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 func Test(t *stdtesting.T) {
@@ -157,7 +156,7 @@ func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 
 func (s *UserDataSuite) TestShutdownInitCommandsUpstart(c *gc.C) {
 	s.SetFeatureFlags(feature.AddressAllocation)
-	cmds, err := containerinit.ShutdownInitCommands(service.InitSystemUpstart)
+	cmds, err := containerinit.ShutdownInitCommands(service.InitSystemUpstart, "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
 	filename := "/etc/init/juju-template-restart.conf"
@@ -190,8 +189,7 @@ end script
 
 func (s *UserDataSuite) TestShutdownInitCommandsSystemd(c *gc.C) {
 	s.SetFeatureFlags(feature.AddressAllocation)
-	s.PatchValue(&version.Current.Series, "vivid")
-	commands, err := containerinit.ShutdownInitCommands(service.InitSystemSystemd)
+	commands, err := containerinit.ShutdownInitCommands(service.InitSystemSystemd, "vivid")
 	c.Assert(err, jc.ErrorIsNil)
 
 	test := systemdtesting.WriteConfTest{

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -193,21 +193,12 @@ func (cfg *InstanceConfig) InitService(renderer shell.Renderer) (service.Service
 	conf := service.AgentConf(cfg.agentInfo(), renderer)
 
 	name := cfg.MachineAgentServiceName
-	initSystem, ok := cfg.initSystem()
-	if !ok {
-		return nil, errors.New("could not identify init system")
-	}
-	logger.Debugf("using init system %q for machine agent script", initSystem)
-	svc, err := newService(name, conf, initSystem)
+	svc, err := newService(name, conf, cfg.Series)
 	return svc, errors.Trace(err)
 }
 
-func (cfg *InstanceConfig) initSystem() (string, bool) {
-	return service.VersionInitSystem(cfg.Tools.Version)
-}
-
-var newService = func(name string, conf common.Conf, initSystem string) (service.Service, error) {
-	return service.NewService(name, conf, initSystem)
+var newService = func(name string, conf common.Conf, series string) (service.Service, error) {
+	return service.NewService(name, conf, series)
 }
 
 func (cfg *InstanceConfig) AgentConfig(

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -359,7 +359,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 			CloudInitOutputLog: cloudInitOutputLog,
 			Bootstrap:          false,
 			Tools:              newSimpleTools("1.2.3-vivid-amd64"),
-			Series:             "quantal",
+			Series:             "vivid",
 			MachineNonce:       "FAKE_NONCE",
 			MongoInfo: &mongo.MongoInfo{
 				Tag:      names.NewMachineTag("99"),
@@ -1098,7 +1098,6 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		err = udata.Configure()
 		c.Check(err, gc.ErrorMatches, "invalid machine configuration: "+test.err)
-
 	}
 }
 

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -93,10 +93,11 @@ func (w *unixConfigure) ConfigureBasic() error {
 	case version.Ubuntu:
 		w.conf.AddSSHAuthorizedKeys(w.icfg.AuthorizedKeys)
 		if w.icfg.Tools != nil {
-			initSystem, ok := service.VersionInitSystem(w.icfg.Tools.Version)
-			if ok {
-				w.addCleanShutdownJob(initSystem)
+			initSystem, err := service.VersionInitSystem(w.icfg.Series)
+			if err != nil {
+				return errors.Trace(err)
 			}
+			w.addCleanShutdownJob(initSystem)
 		}
 	// On unix systems that are not ubuntu we create an ubuntu user so that we
 	// are able to ssh in the machine and have all the functionality dependant

--- a/service/service.go
+++ b/service/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 
+	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/service/upstart"
@@ -97,11 +98,19 @@ type RestartableService interface {
 // and several helper functions.
 
 // NewService returns a new Service based on the provided info.
-func NewService(name string, conf common.Conf, initSystem string) (Service, error) {
+func NewService(name string, conf common.Conf, series string) (Service, error) {
 	if name == "" {
 		return nil, errors.New("missing name")
 	}
 
+	initSystem, err := versionInitSystem(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return newService(name, conf, initSystem, series)
+}
+
+func newService(name string, conf common.Conf, initSystem, series string) (Service, error) {
 	switch initSystem {
 	case InitSystemWindows:
 		svc, err := windows.NewService(name, conf)
@@ -112,7 +121,13 @@ func NewService(name string, conf common.Conf, initSystem string) (Service, erro
 	case InitSystemUpstart:
 		return upstart.NewService(name, conf), nil
 	case InitSystemSystemd:
-		svc, err := systemd.NewService(name, conf)
+
+		dataDir, err := paths.DataDir(series)
+		if err != nil {
+			return nil, errors.Annotatef(err, "failed to find juju data dir for service %q", name)
+		}
+
+		svc, err := systemd.NewService(name, conf, dataDir)
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to wrap service %q", name)
 		}
@@ -124,9 +139,9 @@ func NewService(name string, conf common.Conf, initSystem string) (Service, erro
 
 // ListServices lists all installed services on the running system
 func ListServices() ([]string, error) {
-	initName, ok := VersionInitSystem(version.Current)
-	if !ok {
-		return nil, errors.NotFoundf("init system on local host")
+	initName, err := VersionInitSystem(version.Current.Series)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	switch initName {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -24,18 +24,27 @@ type serviceSuite struct {
 var _ = gc.Suite(&serviceSuite{})
 
 func (s *serviceSuite) TestNewServiceKnown(c *gc.C) {
-	initSystems := []string{
-		service.InitSystemSystemd,
-		service.InitSystemUpstart,
-		service.InitSystemWindows,
-	}
-	for _, initSystem := range initSystems {
-		svc, err := service.NewService(s.Name, s.Conf, initSystem)
+	for _, test := range []struct {
+		series     string
+		initSystem string
+	}{
+		{
+			series:     "vivid",
+			initSystem: service.InitSystemSystemd,
+		}, {
+			series:     "trusty",
+			initSystem: service.InitSystemUpstart,
+		}, {
+			series:     "win2012",
+			initSystem: service.InitSystemWindows,
+		},
+	} {
+		svc, err := service.NewService(s.Name, s.Conf, test.series)
 		if !c.Check(err, jc.ErrorIsNil) {
 			continue
 		}
 
-		switch initSystem {
+		switch test.initSystem {
 		case service.InitSystemSystemd:
 			c.Check(svc, gc.FitsTypeOf, &systemd.Service{})
 		case service.InitSystemUpstart:

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -148,8 +148,9 @@ func serialize(name string, conf common.Conf, renderer shell.Renderer) ([]byte, 
 	unitOptions = append(unitOptions, serializeUnit(conf)...)
 	unitOptions = append(unitOptions, serializeService(conf)...)
 	unitOptions = append(unitOptions, serializeInstall(conf)...)
-
-	data, err := ioutil.ReadAll(unit.Serialize(unitOptions))
+	// Don't use unit.Serialize because it has map ordering issues.
+	// Serialize copied locally, and outputs sections in alphabetical order.
+	data, err := ioutil.ReadAll(UnitSerialize(unitOptions))
 	return data, errors.Trace(err)
 }
 

--- a/service/systemd/export_test.go
+++ b/service/systemd/export_test.go
@@ -15,12 +15,6 @@ type patcher interface {
 	PatchValue(interface{}, interface{})
 }
 
-func PatchFindDataDir(patcher patcher, dataDir string) {
-	patcher.PatchValue(&findDataDir, func() (string, error) {
-		return dataDir, nil
-	})
-}
-
 func PatchNewChan(patcher patcher) chan string {
 	ch := make(chan string, 1)
 	patcher.PatchValue(&newChan, func() chan string { return ch })

--- a/service/systemd/serialize.go
+++ b/service/systemd/serialize.go
@@ -1,0 +1,76 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systemd
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/coreos/go-systemd/unit"
+)
+
+// UnitSerialize encodes all of the given UnitOption objects into a unit file.
+// Renamed from Serialize from github.com/coreos/go-systemd/unit so as to not
+// confict with the exported internal function in export_test.go.
+func UnitSerialize(opts []*unit.UnitOption) io.Reader {
+	var buf bytes.Buffer
+
+	if len(opts) == 0 {
+		return &buf
+	}
+
+	idx := map[string][]*unit.UnitOption{}
+	for _, opt := range opts {
+		idx[opt.Section] = append(idx[opt.Section], opt)
+	}
+
+	// CHANGED HERE: Output in the following order:
+	// - Unit
+	// - Service
+	// - Install
+	// rather than just iterating over the map in random order.
+	for _, curSection := range []string{"Unit", "Service", "Install"} {
+		curOpts, found := idx[curSection]
+		if !found {
+			continue
+		}
+		writeSectionHeader(&buf, curSection)
+		writeNewline(&buf)
+
+		for _, opt := range curOpts {
+			writeOption(&buf, opt)
+			writeNewline(&buf)
+		}
+		writeNewline(&buf)
+	}
+
+	return &buf
+}
+
+func writeNewline(buf *bytes.Buffer) {
+	buf.WriteRune('\n')
+}
+
+func writeSectionHeader(buf *bytes.Buffer, section string) {
+	buf.WriteRune('[')
+	buf.WriteString(section)
+	buf.WriteRune(']')
+}
+
+func writeOption(buf *bytes.Buffer, opt *unit.UnitOption) {
+	buf.WriteString(opt.Name)
+	buf.WriteRune('=')
+	buf.WriteString(opt.Value)
+}

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -15,9 +15,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/shell"
 
-	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/service/common"
-	"github.com/juju/juju/version"
 )
 
 var (
@@ -92,12 +90,8 @@ type Service struct {
 }
 
 // NewService returns a new value that implements Service for systemd.
-func NewService(name string, conf common.Conf) (*Service, error) {
+func NewService(name string, conf common.Conf, dataDir string) (*Service, error) {
 	confName := name + ".service"
-	dataDir, err := findDataDir()
-	if err != nil {
-		return nil, errors.Annotatef(err, "failed to find juju data dir for service %q", name)
-	}
 	dirname := path.Join(dataDir, "init", name)
 
 	service := &Service{
@@ -115,10 +109,6 @@ func NewService(name string, conf common.Conf) (*Service, error) {
 	}
 
 	return service, nil
-}
-
-var findDataDir = func() (string, error) {
-	return paths.DataDir(version.Current.Series)
 }
 
 // dbusAPI exposes all the systemd API methods needed by juju.

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -6,6 +6,7 @@ package systemd_test
 import (
 	"bytes"
 	"fmt"
+	"github.com/juju/juju/juju/paths"
 	"os"
 	"strings"
 
@@ -71,9 +72,10 @@ var _ = gc.Suite(&initSystemSuite{})
 func (s *initSystemSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
+	dataDir, err := paths.DataDir("vivid")
+	c.Assert(err, jc.ErrorIsNil)
+	s.dataDir = dataDir
 	// Patch things out.
-	s.dataDir = "/juju/data/dir" // This is never used concretely in tests.
-	systemd.PatchFindDataDir(s, s.dataDir)
 	s.ch = systemd.PatchNewChan(s)
 
 	s.stub = &testing.Stub{}
@@ -91,11 +93,16 @@ func (s *initSystemSuite) SetUpTest(c *gc.C) {
 		Desc:      "juju agent for " + tagStr,
 		ExecStart: jujud + " " + tagStr,
 	}
-	s.service, err = systemd.NewService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
+	s.service = s.newService(c)
 
 	// Reset any incidental calls.
 	s.stub.ResetCalls()
+}
+
+func (s *initSystemSuite) newService(c *gc.C) *systemd.Service {
+	service, err := systemd.NewService(s.name, s.conf, s.dataDir)
+	c.Assert(err, jc.ErrorIsNil)
+	return service
 }
 
 func (s *initSystemSuite) newConfStr(name string) string {
@@ -213,9 +220,7 @@ func (s *initSystemSuite) TestListServicesEmpty(c *gc.C) {
 }
 
 func (s *initSystemSuite) TestNewService(c *gc.C) {
-	service, err := systemd.NewService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
-
+	service := s.newService(c)
 	c.Check(service, jc.DeepEquals, &systemd.Service{
 		Service: common.Service{
 			Name: s.name,
@@ -230,9 +235,7 @@ func (s *initSystemSuite) TestNewService(c *gc.C) {
 
 func (s *initSystemSuite) TestNewServiceLogfile(c *gc.C) {
 	s.conf.Logfile = "/var/log/juju/machine-0.log"
-
-	service, err := systemd.NewService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
+	service := s.newService(c)
 
 	dirname := fmt.Sprintf("%s/init/%s", s.dataDir, s.name)
 	script := `
@@ -267,7 +270,7 @@ exec 2>&1
 }
 
 func (s *initSystemSuite) TestNewServiceEmptyConf(c *gc.C) {
-	service, err := systemd.NewService(s.name, common.Conf{})
+	service, err := systemd.NewService(s.name, common.Conf{}, s.dataDir)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(service, jc.DeepEquals, &systemd.Service{
@@ -283,9 +286,7 @@ func (s *initSystemSuite) TestNewServiceEmptyConf(c *gc.C) {
 
 func (s *initSystemSuite) TestNewServiceBasic(c *gc.C) {
 	s.conf.ExecStart = "/path/to/some/other/command"
-
-	svc, err := systemd.NewService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
+	svc := s.newService(c)
 
 	c.Check(svc, jc.DeepEquals, &systemd.Service{
 		Service: common.Service{
@@ -301,9 +302,7 @@ func (s *initSystemSuite) TestNewServiceBasic(c *gc.C) {
 
 func (s *initSystemSuite) TestNewServiceExtraScript(c *gc.C) {
 	s.conf.ExtraScript = "'/path/to/another/command'"
-
-	svc, err := systemd.NewService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
+	svc := s.newService(c)
 
 	dirname := fmt.Sprintf("%s/init/%s", s.dataDir, s.name)
 	script := `
@@ -331,9 +330,7 @@ func (s *initSystemSuite) TestNewServiceExtraScript(c *gc.C) {
 
 func (s *initSystemSuite) TestNewServiceMultiline(c *gc.C) {
 	s.conf.ExecStart = "a\nb\nc"
-
-	svc, err := systemd.NewService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
+	svc := s.newService(c)
 
 	dirname := fmt.Sprintf("%s/init/%s", s.dataDir, s.name)
 	script := `
@@ -706,7 +703,7 @@ func (s *initSystemSuite) TestInstallZombie(c *gc.C) {
 	s.ch <- "done"
 
 	conf.Env["a"] = "c"
-	service, err := systemd.NewService(s.name, conf)
+	service, err := systemd.NewService(s.name, conf, s.dataDir)
 	c.Assert(err, jc.ErrorIsNil)
 	err = service.Install()
 	c.Assert(err, jc.ErrorIsNil)
@@ -771,9 +768,6 @@ func (s *initSystemSuite) TestInstallEmptyConf(c *gc.C) {
 
 func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
 	name := "jujud-machine-0"
-	s.dataDir = "/tmp"
-	s.service.Dirname = "/tmp/init/jujud-machine-0"
-
 	commands, err := s.service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -787,12 +781,8 @@ func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
 
 func (s *initSystemSuite) TestInstallCommandsLogfile(c *gc.C) {
 	name := "jujud-machine-0"
-	s.dataDir = "/tmp"
-	systemd.PatchFindDataDir(s, s.dataDir)
 	s.conf.Logfile = "/var/log/juju/machine-0.log"
-
-	service, err := systemd.NewService(s.name, s.conf)
-	c.Assert(err, jc.ErrorIsNil)
+	service := s.newService(c)
 	commands, err := service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -802,7 +792,7 @@ func (s *initSystemSuite) TestInstallCommandsLogfile(c *gc.C) {
 		Expected: strings.Replace(
 			s.newConfStr(name),
 			"ExecStart=/var/lib/juju/bin/jujud machine-0",
-			"ExecStart=/tmp/init/jujud-machine-0/exec-start.sh",
+			"ExecStart=/var/lib/juju/init/jujud-machine-0/exec-start.sh",
 			-1),
 		Script: `
 # Set up logging.
@@ -819,13 +809,10 @@ exec 2>&1
 }
 
 func (s *initSystemSuite) TestInstallCommandsShutdown(c *gc.C) {
-	s.dataDir = "/tmp"
-	systemd.PatchFindDataDir(s, s.dataDir)
-
 	name := "juju-shutdown-job"
 	conf, err := service.ShutdownAfterConf("cloud-final")
 	c.Assert(err, jc.ErrorIsNil)
-	svc, err := systemd.NewService(name, conf)
+	svc, err := systemd.NewService(name, conf, s.dataDir)
 	c.Assert(err, jc.ErrorIsNil)
 	commands, err := svc.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
There were two fundamental problems:
 * using the host series to determine the datadir location for serializing systemd files
 * map ordering issues when serializing systemd conf files

The serialization problem is in the upstream code. I have copied it into juju (just the serialization file) and made it work in a deterministic manner.

The datadir required a bit more messing around to pass the series around.

(Review request: http://reviews.vapour.ws/r/2002/)