### PR TITLE
[Resources] Implement ResourceManager facade

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -43,6 +43,7 @@ var facadeVersions = map[string]int{
 	"Provisioner":                  1,
 	"Reboot":                       1,
 	"RelationUnitsWatcher":         0,
+	"ResourceManager":              1,
 	"Resumer":                      1,
 	"Rsyslog":                      0,
 	"Service":                      1,

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -43,7 +43,6 @@ var facadeVersions = map[string]int{
 	"Provisioner":                  1,
 	"Reboot":                       1,
 	"RelationUnitsWatcher":         0,
-	"ResourceManager":              1,
 	"Resumer":                      1,
 	"Rsyslog":                      0,
 	"Service":                      1,

--- a/apiserver/charmresources/export_test.go
+++ b/apiserver/charmresources/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmresources
+
+var (
+	CreateAPI = createAPI
+)

--- a/apiserver/charmresources/package_test.go
+++ b/apiserver/charmresources/package_test.go
@@ -4,7 +4,6 @@
 package charmresources_test
 
 import (
-	"io"
 	"strings"
 	stdtesting "testing"
 
@@ -92,7 +91,7 @@ func (s *baseResourcesSuite) constructState(c *gc.C) *mockState {
 }
 
 func (s *baseResourcesSuite) addBlock(c *gc.C, t state.BlockType, msg string) {
-	s.blocks[t] = mockBlock{t, msg}
+	s.blocks[t] = mockBlock{t: t, msg: msg}
 }
 
 func (s *baseResourcesSuite) blockAllChanges(c *gc.C, msg string) {
@@ -138,6 +137,7 @@ func (s *baseResourcesSuite) addResource(res resources.Resource) {
 }
 
 type mockResourceManager struct {
+	resources.ResourceManager
 	resourceList   func(filter resources.ResourceAttributes) ([]resources.Resource, error)
 	resourceDelete func(resourcePath string) error
 }
@@ -148,14 +148,6 @@ func (m *mockResourceManager) ResourceList(filter resources.ResourceAttributes) 
 
 func (m *mockResourceManager) ResourceDelete(resourcePath string) error {
 	return m.resourceDelete(resourcePath)
-}
-
-func (m *mockResourceManager) ResourceGet(resourcePath string) ([]resources.ResourceReader, error) {
-	panic("not implemented")
-}
-
-func (m *mockResourceManager) ResourcePut(metadata resources.Resource, rdr io.ReadCloser) error {
-	panic("not implemented")
 }
 
 type mockState struct {
@@ -177,16 +169,9 @@ func (st *mockState) GetBlockForType(t state.BlockType) (state.Block, bool, erro
 }
 
 type mockBlock struct {
+	state.Block
 	t   state.BlockType
 	msg string
-}
-
-func (b mockBlock) Id() string {
-	panic("not implemented for test")
-}
-
-func (b mockBlock) Tag() (names.Tag, error) {
-	panic("not implemented for test")
 }
 
 func (b mockBlock) Type() state.BlockType {

--- a/apiserver/charmresources/package_test.go
+++ b/apiserver/charmresources/package_test.go
@@ -1,0 +1,198 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmresources_test
+
+import (
+	"io"
+	"strings"
+	stdtesting "testing"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/charmresources"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/testing"
+	resources "github.com/juju/juju/charmresources"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+type baseResourcesSuite struct {
+	coretesting.BaseSuite
+
+	apiResources *common.Resources
+	authorizer   testing.FakeAuthorizer
+
+	api          *charmresources.ResourceManagerAPI
+	state        *mockState
+	environOwner string
+
+	calls []string
+
+	resourceManager *mockResourceManager
+	resources       map[string]resources.Resource
+
+	blocks map[state.BlockType]state.Block
+}
+
+func (s *baseResourcesSuite) SetUpTest(c *gc.C) {
+	s.apiResources = common.NewResources()
+	s.authorizer = testing.FakeAuthorizer{names.NewUserTag("testuser"), true}
+	s.calls = []string{}
+	s.state = s.constructState(c)
+	s.environOwner = "testuser"
+
+	s.resources = make(map[string]resources.Resource)
+	s.resourceManager = s.constructResourceManager(c)
+
+	var err error
+	s.api, err = charmresources.CreateAPI(s.state, s.apiResources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *baseResourcesSuite) assertCalls(c *gc.C, expectedCalls []string) {
+	c.Assert(s.calls, jc.SameContents, expectedCalls)
+}
+
+const (
+	resourceListCall    = "resourceList"
+	resourceDeleteCall  = "resourceDelete"
+	resourceManagerCall = "resourceManager"
+	getBlockForTypeCall = "getBlockForType"
+)
+
+func (s *baseResourcesSuite) envOwner() string {
+	return s.environOwner
+}
+
+func (s *baseResourcesSuite) constructState(c *gc.C) *mockState {
+	s.blocks = make(map[state.BlockType]state.Block)
+	return &mockState{
+		resourceManager: func() resources.ResourceManager {
+			s.calls = append(s.calls, resourceManagerCall)
+			return s.resourceManager
+		},
+		getBlockForType: func(t state.BlockType) (state.Block, bool, error) {
+			s.calls = append(s.calls, getBlockForTypeCall)
+			val, found := s.blocks[t]
+			return val, found, nil
+		},
+		envOwner: func() (names.UserTag, error) {
+			return names.NewUserTag(s.envOwner()), nil
+		},
+	}
+}
+
+func (s *baseResourcesSuite) addBlock(c *gc.C, t state.BlockType, msg string) {
+	s.blocks[t] = mockBlock{t, msg}
+}
+
+func (s *baseResourcesSuite) blockAllChanges(c *gc.C, msg string) {
+	s.addBlock(c, state.ChangeBlock, msg)
+}
+
+func (s *baseResourcesSuite) blockRemoveObject(c *gc.C, msg string) {
+	s.addBlock(c, state.RemoveBlock, msg)
+}
+
+func (s *baseResourcesSuite) assertBlocked(c *gc.C, err error, msg string) {
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, msg)
+}
+
+func (s *baseResourcesSuite) constructResourceManager(c *gc.C) *mockResourceManager {
+	return &mockResourceManager{
+		resourceDelete: func(path string) error {
+			s.calls = append(s.calls, resourceDeleteCall)
+			delete(s.resources, path)
+			return nil
+		},
+		resourceList: func(filter resources.ResourceAttributes) ([]resources.Resource, error) {
+			s.calls = append(s.calls, resourceListCall)
+			var result []resources.Resource
+			for _, v := range s.resources {
+				// For testing, we'll just do a very simple match (not production code).
+				if filter.PathName != "" && !strings.HasSuffix(v.Path, filter.PathName) {
+					continue
+				}
+				if filter.Series != "" && !strings.Contains(v.Path, "s/"+filter.Series) {
+					continue
+				}
+				result = append(result, v)
+			}
+			return result, nil
+		},
+	}
+}
+
+func (s *baseResourcesSuite) addResource(res resources.Resource) {
+	s.resources[res.Path] = res
+}
+
+type mockResourceManager struct {
+	resourceList   func(filter resources.ResourceAttributes) ([]resources.Resource, error)
+	resourceDelete func(resourcePath string) error
+}
+
+func (m *mockResourceManager) ResourceList(filter resources.ResourceAttributes) ([]resources.Resource, error) {
+	return m.resourceList(filter)
+}
+
+func (m *mockResourceManager) ResourceDelete(resourcePath string) error {
+	return m.resourceDelete(resourcePath)
+}
+
+func (m *mockResourceManager) ResourceGet(resourcePath string) ([]resources.ResourceReader, error) {
+	panic("not implemented")
+}
+
+func (m *mockResourceManager) ResourcePut(metadata resources.Resource, rdr io.ReadCloser) error {
+	panic("not implemented")
+}
+
+type mockState struct {
+	resourceManager func() resources.ResourceManager
+	getBlockForType func(t state.BlockType) (state.Block, bool, error)
+	envOwner        func() (names.UserTag, error)
+}
+
+func (st *mockState) EnvOwner() (names.UserTag, error) {
+	return st.envOwner()
+}
+
+func (st *mockState) ResourceManager() resources.ResourceManager {
+	return st.resourceManager()
+}
+
+func (st *mockState) GetBlockForType(t state.BlockType) (state.Block, bool, error) {
+	return st.getBlockForType(t)
+}
+
+type mockBlock struct {
+	t   state.BlockType
+	msg string
+}
+
+func (b mockBlock) Id() string {
+	panic("not implemented for test")
+}
+
+func (b mockBlock) Tag() (names.Tag, error) {
+	panic("not implemented for test")
+}
+
+func (b mockBlock) Type() state.BlockType {
+	return b.t
+}
+
+func (b mockBlock) Message() string {
+	return b.msg
+}

--- a/apiserver/charmresources/resourcemanager.go
+++ b/apiserver/charmresources/resourcemanager.go
@@ -66,7 +66,7 @@ func NewResourceManagerAPI(st *state.State, resources *common.Resources, authori
 	return createAPI(getState(st), resources, authorizer)
 }
 
-// ResourceList is implemented on charmresources.ResourceManager
+// ResourceList implements charmresources.ResourceManager
 func (api *ResourceManagerAPI) ResourceList(arg params.ResourceFilterParams) (params.ListResourcesResult, error) {
 	var result params.ListResourcesResult
 	manager := api.st.ResourceManager()
@@ -100,7 +100,7 @@ func (api *ResourceManagerAPI) ResourceList(arg params.ResourceFilterParams) (pa
 	return result, nil
 }
 
-// ResourceDelete is implemented on charmresources.ResourceManager
+// ResourceDelete implements charmresources.ResourceManager
 func (api *ResourceManagerAPI) ResourceDelete(arg params.ResourceFilterParams) (params.ErrorResults, error) {
 	// Permission checks
 	if !api.canWrite() {

--- a/apiserver/charmresources/resourcemanager.go
+++ b/apiserver/charmresources/resourcemanager.go
@@ -1,0 +1,157 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmresources
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/charmresources"
+	"github.com/juju/juju/state"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.charmresources")
+
+func init() {
+	common.RegisterStandardFacade("ResourceManager", 1, NewResourceManagerAPI)
+}
+
+// ResourceManager defines the methods on the ResourceManager API end point.
+type ResourceManager interface {
+	ResourceList(arg params.ResourceFilterParams) (params.ListResourcesResult, error)
+	ResourceDelete(arg params.ResourceFilterParams) (params.ErrorResults, error)
+}
+
+// ResourceManagerAPI provides access to the ResourceManager API facade.
+type ResourceManagerAPI struct {
+	st         managerState
+	check      *common.BlockChecker
+	resources  *common.Resources
+	authorizer common.Authorizer
+	canWrite   func() bool
+}
+
+var _ ResourceManager = (*ResourceManagerAPI)(nil)
+
+func createAPI(st managerState, resources *common.Resources, authorizer common.Authorizer) (*ResourceManagerAPI, error) {
+	// Only clients can access the resource manager service.
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
+	owner, err := st.EnvOwner()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// For gccgo interface comparisons, we need a Tag.
+	ownerName := names.Tag(owner)
+	// For now, only environment owners can delete resources.
+	canWrite := func() bool {
+		return authorizer.GetAuthTag() == ownerName
+	}
+	return &ResourceManagerAPI{
+		st:         st,
+		check:      common.NewBlockChecker(st),
+		resources:  resources,
+		authorizer: authorizer,
+		canWrite:   canWrite,
+	}, nil
+}
+
+// NewResourceManagerAPI creates a new server-side resource manager API end point.
+func NewResourceManagerAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*ResourceManagerAPI, error) {
+	return createAPI(getState(st), resources, authorizer)
+}
+
+// ResourceList is implemented on charmresources.ResourceManager
+func (api *ResourceManagerAPI) ResourceList(arg params.ResourceFilterParams) (params.ListResourcesResult, error) {
+	var result params.ListResourcesResult
+	manager := api.st.ResourceManager()
+
+	// If no filter terms, we effectively ask for everything.
+	filterTerms := arg.Resources
+	if len(filterTerms) == 0 {
+		filterTerms = append(filterTerms, params.ResourceParams{})
+	}
+	for _, filterTerm := range filterTerms {
+		filter := charmresources.ResourceAttributes{
+			User:     filterTerm.User,
+			Org:      filterTerm.Org,
+			Stream:   filterTerm.User,
+			Series:   filterTerm.Series,
+			PathName: filterTerm.PathName,
+			Revision: filterTerm.Revision,
+		}
+		metadata, err := manager.ResourceList(filter)
+		if err != nil {
+			return result, common.ServerError(err)
+		}
+		for _, m := range metadata {
+			result.Resources = append(result.Resources, params.ResourceMetadata{
+				ResourcePath: m.Path,
+				Size:         m.Size,
+				Created:      m.Created,
+			})
+		}
+	}
+	return result, nil
+}
+
+// ResourceDelete is implemented on charmresources.ResourceManager
+func (api *ResourceManagerAPI) ResourceDelete(arg params.ResourceFilterParams) (params.ErrorResults, error) {
+	// Permission checks
+	if !api.canWrite() {
+		return params.ErrorResults{}, common.ErrPerm
+	}
+	if err := api.check.RemoveAllowed(); err != nil {
+		return params.ErrorResults{}, errors.Trace(err)
+	}
+
+	if len(arg.Resources) == 0 {
+		return params.ErrorResults{}, errors.New("no resources specified to delete")
+	}
+
+	// Delete each set of matching resources in turn.
+	var result params.ErrorResults
+	result.Results = make([]params.ErrorResult, len(arg.Resources))
+	manager := api.st.ResourceManager()
+	for i, resourceSpec := range arg.Resources {
+		attrs := charmresources.ResourceAttributes{
+			User:     resourceSpec.User,
+			Org:      resourceSpec.Org,
+			Stream:   resourceSpec.User,
+			Series:   resourceSpec.Series,
+			PathName: resourceSpec.PathName,
+			Revision: resourceSpec.Revision,
+		}
+		// Grab the path of the resource to delete.
+		resourcePath, err := charmresources.ResourcePath(attrs)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		// Check resource exists.
+		res, err := manager.ResourceList(attrs)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+
+		if len(res) != 1 {
+			result.Results[i].Error = common.ServerError(
+				errors.NotFoundf("resource %s", resourcePath))
+			continue
+		}
+		// No ready to delete.
+		logger.Infof("deleting resource with metadata %+v", res[0])
+		err = manager.ResourceDelete(resourcePath)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+	}
+	return result, nil
+}

--- a/apiserver/charmresources/resourcemanager_test.go
+++ b/apiserver/charmresources/resourcemanager_test.go
@@ -1,0 +1,249 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmresources_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/charmresources"
+	"github.com/juju/juju/apiserver/params"
+	resources "github.com/juju/juju/charmresources"
+)
+
+type resourcesSuite struct {
+	baseResourcesSuite
+}
+
+var _ = gc.Suite(&resourcesSuite{})
+
+func (s *resourcesSuite) TestResourcesListEmpty(c *gc.C) {
+	s.resourceManager.resourceList = func(filter resources.ResourceAttributes) ([]resources.Resource, error) {
+		s.calls = append(s.calls, resourceListCall)
+		return []resources.Resource{}, nil
+	}
+
+	found, err := s.api.ResourceList(params.ResourceFilterParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Resources, gc.HasLen, 0)
+	expectedCalls := []string{
+		resourceManagerCall,
+		resourceListCall,
+	}
+	s.assertCalls(c, expectedCalls)
+}
+
+func (s *resourcesSuite) TestResourcesListAll(c *gc.C) {
+	now := time.Now()
+	s.addResource(resources.Resource{Path: "respath", Size: 100, Created: now})
+	found, err := s.api.ResourceList(params.ResourceFilterParams{})
+
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedCalls := []string{
+		resourceManagerCall,
+		resourceListCall,
+	}
+	s.assertCalls(c, expectedCalls)
+
+	c.Assert(found.Resources, gc.HasLen, 1)
+	c.Assert(found.Resources[0], jc.DeepEquals, params.ResourceMetadata{
+		ResourcePath: "respath",
+		Size:         100,
+		Created:      now,
+	})
+}
+
+func (s *resourcesSuite) TestResourcesList(c *gc.C) {
+	now := time.Now()
+	s.addResource(resources.Resource{Path: "respath", Size: 100, Created: now})
+	s.addResource(resources.Resource{Path: "s/trusty/another", Size: 200, Created: now})
+	s.addResource(resources.Resource{Path: "s/precise/another", Size: 300, Created: now})
+	found, err := s.api.ResourceList(params.ResourceFilterParams{
+		Resources: []params.ResourceParams{
+			{Series: "trusty"},
+			{PathName: "respath"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedCalls := []string{
+		resourceManagerCall,
+		resourceListCall,
+		resourceListCall,
+	}
+	s.assertCalls(c, expectedCalls)
+
+	c.Assert(found.Resources, gc.HasLen, 2)
+	c.Assert(found.Resources, jc.SameContents, []params.ResourceMetadata{
+		{
+			ResourcePath: "respath",
+			Size:         100,
+			Created:      now,
+		}, {
+			ResourcePath: "s/trusty/another",
+			Size:         200,
+			Created:      now,
+		},
+	})
+}
+
+func (s *resourcesSuite) TestResourcesListError(c *gc.C) {
+	msg := "list test error"
+	s.resourceManager.resourceList = func(filter resources.ResourceAttributes) ([]resources.Resource, error) {
+		s.calls = append(s.calls, resourceListCall)
+		return nil, errors.New(msg)
+	}
+
+	found, err := s.api.ResourceList(params.ResourceFilterParams{})
+	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
+
+	expectedCalls := []string{
+		resourceManagerCall,
+		resourceListCall,
+	}
+	s.assertCalls(c, expectedCalls)
+	c.Assert(found.Resources, gc.HasLen, 0)
+}
+
+func (s *resourcesSuite) TestResourcesDeleteError(c *gc.C) {
+	s.addResource(resources.Resource{Path: "respath", Size: 100})
+	msg := "delete test error"
+	s.resourceManager.resourceDelete = func(path string) error {
+		s.calls = append(s.calls, resourceDeleteCall)
+		return errors.New(msg)
+	}
+
+	result, err := s.api.ResourceDelete(params.ResourceFilterParams{
+		Resources: []params.ResourceParams{{PathName: "respath"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedCalls := []string{
+		getBlockForTypeCall,
+		getBlockForTypeCall,
+		resourceManagerCall,
+		resourceListCall,
+		resourceDeleteCall,
+	}
+	s.assertCalls(c, expectedCalls)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error.Error(), gc.Equals, msg)
+}
+
+func (s *resourcesSuite) TestResourcesNotFoundDeleteError(c *gc.C) {
+	result, err := s.api.ResourceDelete(params.ResourceFilterParams{
+		Resources: []params.ResourceParams{{PathName: "foo"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedCalls := []string{
+		getBlockForTypeCall,
+		getBlockForTypeCall,
+		resourceManagerCall,
+		resourceListCall,
+	}
+	s.assertCalls(c, expectedCalls)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error.ErrorCode(), gc.Equals, params.CodeNotFound)
+}
+
+func (s *resourcesSuite) TestNoResourcesDeleteError(c *gc.C) {
+	result, err := s.api.ResourceDelete(params.ResourceFilterParams{})
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "no resources specified to delete")
+
+	expectedCalls := []string{
+		getBlockForTypeCall,
+		getBlockForTypeCall,
+	}
+	s.assertCalls(c, expectedCalls)
+	c.Assert(result.Results, gc.HasLen, 0)
+}
+
+func (s *resourcesSuite) TestResourceDeleteBlockedAllChanges(c *gc.C) {
+	s.blockAllChanges(c, "TestResourceDeleteBlocked")
+
+	_, err := s.api.ResourceDelete(params.ResourceFilterParams{
+		Resources: []params.ResourceParams{{PathName: "foo"}},
+	})
+	s.assertBlocked(c, err, "TestResourceDeleteBlocked")
+	expectedCalls := []string{
+		getBlockForTypeCall,
+		getBlockForTypeCall,
+	}
+	s.assertCalls(c, expectedCalls)
+}
+
+func (s *resourcesSuite) TestResourceDeleteBlockedDeletes(c *gc.C) {
+	s.blockRemoveObject(c, "TestResourceDeleteBlockedDeletes")
+
+	_, err := s.api.ResourceDelete(params.ResourceFilterParams{
+		Resources: []params.ResourceParams{{PathName: "foo"}},
+	})
+	s.assertBlocked(c, err, "TestResourceDeleteBlockedDeletes")
+	expectedCalls := []string{
+		getBlockForTypeCall,
+	}
+	s.assertCalls(c, expectedCalls)
+}
+
+func (s *resourcesSuite) TestResourcesDeleteNotEnvOwner(c *gc.C) {
+	s.environOwner = "foo"
+	var err error
+	s.api, err = charmresources.CreateAPI(s.state, s.apiResources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.api.ResourceDelete(params.ResourceFilterParams{
+		Resources: []params.ResourceParams{{PathName: "foo"}},
+	})
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "permission denied")
+}
+
+func (s *resourcesSuite) TestResourcesDelete(c *gc.C) {
+	now := time.Now()
+	s.addResource(resources.Resource{Path: "respath", Size: 100, Created: now})
+	s.addResource(resources.Resource{Path: "s/trusty/another", Size: 200, Created: now})
+	s.addResource(resources.Resource{Path: "s/precise/another", Size: 300, Created: now})
+	result, err := s.api.ResourceDelete(params.ResourceFilterParams{
+		Resources: []params.ResourceParams{
+			{Series: "trusty"},
+			{PathName: "respath"},
+			{PathName: "notfound"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedCalls := []string{
+		getBlockForTypeCall,
+		getBlockForTypeCall,
+		resourceManagerCall,
+		resourceListCall,
+		resourceDeleteCall,
+		resourceListCall,
+	}
+	s.assertCalls(c, expectedCalls)
+
+	c.Assert(result.Results, gc.HasLen, 3)
+	var expectedErrors = make([]string, len(result.Results))
+	for i, err := range result.Results {
+		if err.Error == nil {
+			continue
+		}
+		expectedErrors[i] = result.Results[i].Error.Message
+	}
+	c.Assert(expectedErrors, gc.DeepEquals, []string{
+		"path cannot be empty", "", "resource notfound not found",
+	})
+	c.Assert(s.resources, gc.HasLen, 2)
+	var expectedPaths []string
+	for p, _ := range s.resources {
+		expectedPaths = append(expectedPaths, p)
+	}
+	c.Assert(expectedPaths, jc.SameContents, []string{
+		"s/trusty/another",
+		"s/precise/another",
+	})
+}

--- a/apiserver/charmresources/state.go
+++ b/apiserver/charmresources/state.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmresources
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	resources "github.com/juju/juju/charmresources"
+	"github.com/juju/juju/state"
+)
+
+type managerState interface {
+	// ResourceManager provides the capability to persist resources.
+	ResourceManager() resources.ResourceManager
+
+	// EnvOwner is needed for validation purposes.
+	EnvOwner() (names.UserTag, error)
+
+	// GetBlockForType is required to block operations.
+	GetBlockForType(t state.BlockType) (state.Block, bool, error)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+var getState = func(st *state.State) managerState {
+	return stateShim{st}
+}
+
+func (s stateShim) ResourceManager() resources.ResourceManager {
+	return s.State.ResourceManager()
+}
+
+func (s stateShim) EnvOwner() (names.UserTag, error) {
+	env, err := s.State.Environment()
+	if err != nil {
+		return names.UserTag{}, errors.Trace(err)
+	}
+	return env.Owner(), nil
+}

--- a/apiserver/params/resources.go
+++ b/apiserver/params/resources.go
@@ -1,0 +1,36 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+import (
+	"time"
+)
+
+// ResourceParams describe a resource.
+type ResourceParams struct {
+	Type     string `json:"type"`
+	User     string `json:"user"`
+	Org      string `json:"org"`
+	Stream   string `json:"stream"`
+	Series   string `json:"series"`
+	PathName string `json:"pathname"`
+	Revision string `json:"revision"`
+}
+
+// ResourceFilterParams holds the parameters used to specify resources to list or delete.
+type ResourceFilterParams struct {
+	Resources []ResourceParams `json:"resources"`
+}
+
+// ListResourcesResult holds the results of querying resources.
+type ListResourcesResult struct {
+	Resources []ResourceMetadata `json:"result"`
+}
+
+// ResourceMetadata represents an resource in storage.
+type ResourceMetadata struct {
+	ResourcePath string    `json:"resourcepaths"`
+	Size         int64     `json:"size"`
+	Created      time.Time `json:"created"`
+}

--- a/charmresources/interface.go
+++ b/charmresources/interface.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmresources
+
+import (
+	"io"
+	"time"
+)
+
+// ResourceReader is used to gain access to a resource's data bytes.
+type ResourceReader struct {
+	io.Reader
+	PathName string
+}
+
+// ResourceAttributes describe a resource and are used to form
+// the resource's path.
+type ResourceAttributes struct {
+	// Type is the resource type eg blob, deb.
+	Type string
+
+	// User is the optional user the resource is associated with.
+	User string
+
+	// Org is the optional organisation or team the resource is associated with.
+	Org string
+
+	// Stream is a category of resource eg proposed, test, released.
+	Stream string
+
+	// Series is the OS series for which the resource is applicable.
+	Series string
+
+	// PathName is the resource's main identified and is mandatory.
+	PathName string
+
+	// Revision is the version associated with the resource.
+	Revision string
+}
+
+// Resource describes a stored charm resource.
+type Resource struct {
+	// Path is the location of the resource in a resource store.
+	Path string
+
+	// SHA384Hash is the hash of the resource data.
+	SHA384Hash string
+
+	// Size is the number of bytes in the resource data.
+	Size int64
+
+	// Created is when the resource was first stored.
+	Created time.Time
+}
+
+// ResourceManager instances provide the capability to manage charm resources.
+type ResourceManager interface {
+	// ResourceGet returns a primary and zero or more
+	// dependent resources from the specified path.
+	ResourceGet(resourcePath string) ([]ResourceReader, error)
+
+	// ResourcePut stores the resource with the specified metadata.
+	ResourcePut(metadata Resource, rdr io.ReadCloser) error
+
+	// ResourceList returns resource metadata matching the specified filter.
+	ResourceList(filter ResourceAttributes) ([]Resource, error)
+
+	// ResourceDelete removes the resource at the specified path.
+	ResourceDelete(resourcePath string) error
+}

--- a/charmresources/resourcepath.go
+++ b/charmresources/resourcepath.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmresources
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+)
+
+// ResourcePath constructs a path to use in a resource store from
+// the specified resource attributes.
+func ResourcePath(params ResourceAttributes) (string, error) {
+	// TODO(wallyworld) - this is not complete, just enough to allow ResourceManager tests to work.
+	path := params.PathName
+	if path == "" {
+		return "", errors.New("path cannot be empty")
+	}
+	if params.Series != "" {
+		path = fmt.Sprintf("/s/%s/%s", params.Series, path)
+	}
+	return path, nil
+}

--- a/state/resources.go
+++ b/state/resources.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/juju/charmresources"
+)
+
+// ResourceManager returns a new charmresources.ResourceManager
+// that stores charm resources metadata.
+func (st *State) ResourceManager() charmresources.ResourceManager {
+	// TODO - wallyworld
+	panic("not implemented")
+}


### PR DESCRIPTION
A new ResourceManager interface is defined providing capability to Put(), Get(), List(), Delete() resources.

A new ResourceManager facade is provided in the apiserver/charmresources package.
Implementations for List() and Delete() are done.

The facade does not contain the Put() and Get() methods - these will be will be done using http server implementations as for tools and images.

There's no state backend for any of this yet. That will come later when a resource store is implemented using a blob store.

(Review request: http://reviews.vapour.ws/r/2004/)