### PR TITLE
worker/peergrouper: fix data race in test

### DIFF
--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -413,9 +413,13 @@ func parseDescr(s string) []descr {
 
 func assertMembers(c *gc.C, obtained interface{}, expected []replicaset.Member) {
 	c.Assert(obtained, gc.FitsTypeOf, []replicaset.Member{})
-	sort.Sort(membersById(obtained.([]replicaset.Member)))
+	// Avoid mutating the obtained slice: because it's usually retrieved
+	// directly from the memberWatcher voyeur.Value,
+	// mutation can cause races.
+	obtainedMembers := deepCopy(obtained).([]replicaset.Member)
+	sort.Sort(membersById(obtainedMembers))
 	sort.Sort(membersById(expected))
-	c.Assert(obtained, jc.DeepEquals, expected)
+	c.Assert(obtainedMembers, jc.DeepEquals, expected)
 }
 
 type membersById []replicaset.Member


### PR DESCRIPTION
This reverts PR #2629, which breaks watcher invariants and will not
actually fix the test, and fixes the issue slightly differently.

There are still multiple intermittent failures in this package which this
PR does not fix.

If PR #2629 had not been applied, the only changes would have been
to the assertMembers function.

(Review request: http://reviews.vapour.ws/r/2005/)