### PR TITLE
Ensure megawatcher backing doc for unit is updated correctly

### DIFF
--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -487,7 +487,13 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id interfac
 		return nil
 	case *multiwatcher.UnitInfo:
 		newInfo := *info
-		if err := s.updatedUnitStatus(st, store, id.(string), &newInfo); err != nil {
+		// Get the unit's current recorded status from state.
+		// It's needed to reset the unit status when a unit comes off error.
+		sdoc, err := getStatus(st, unitGlobalKey(newInfo.Name))
+		if err != nil {
+			return err
+		}
+		if err := s.updatedUnitStatus(st, store, id.(string), sdoc, &newInfo); err != nil {
 			return err
 		}
 		info0 = &newInfo
@@ -511,7 +517,7 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id interfac
 	return nil
 }
 
-func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, id string, newInfo *multiwatcher.UnitInfo) error {
+func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, id string, unitStatus statusDoc, newInfo *multiwatcher.UnitInfo) error {
 	// Unit or workload status - display the agent status or any error.
 	if strings.HasSuffix(id, "#charm") || s.Status == StatusError {
 		newInfo.WorkloadStatus.Current = multiwatcher.Status(s.Status)
@@ -523,6 +529,14 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 		newInfo.AgentStatus.Message = s.StatusInfo
 		newInfo.AgentStatus.Data = s.StatusData
 		newInfo.AgentStatus.Since = s.Updated
+		// If the unit was in error and now it's now, we need to reset its
+		// status back to what was previously recorded.
+		if newInfo.WorkloadStatus.Current == multiwatcher.Status(StatusError) {
+			newInfo.WorkloadStatus.Current = multiwatcher.Status(unitStatus.Status)
+			newInfo.WorkloadStatus.Message = unitStatus.StatusInfo
+			newInfo.WorkloadStatus.Data = unitStatus.StatusData
+			newInfo.WorkloadStatus.Since = s.Updated
+		}
 	}
 
 	// Legacy status info - it is an aggregated value between workload and agent statuses.

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -529,7 +529,7 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 		newInfo.AgentStatus.Message = s.StatusInfo
 		newInfo.AgentStatus.Data = s.StatusData
 		newInfo.AgentStatus.Since = s.Updated
-		// If the unit was in error and now it's now, we need to reset its
+		// If the unit was in error and now it's not, we need to reset its
 		// status back to what was previously recorded.
 		if newInfo.WorkloadStatus.Current == multiwatcher.Status(StatusError) {
 			newInfo.WorkloadStatus.Current = multiwatcher.Status(unitStatus.Status)

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -1398,6 +1398,58 @@ func (s *storeManagerStateSuite) TestChangeUnits(c *gc.C) {
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.UnitInfo{
 					Name:       "wordpress/0",
 					Service:    "wordpress",
+					Status:     multiwatcher.Status("started"),
+					StatusInfo: "",
+					AgentStatus: multiwatcher.StatusInfo{
+						Current: "idle",
+						Message: "",
+						Data:    map[string]interface{}{},
+						Since:   &now,
+					},
+					WorkloadStatus: multiwatcher.StatusInfo{
+						Current: "maintenance",
+						Message: "working",
+						Data:    map[string]interface{}{},
+						Since:   &now,
+					},
+				}},
+				change: watcher.Change{
+					C:  "statuses",
+					Id: st.docID("u#wordpress/0"),
+				},
+				expectContents: []multiwatcher.EntityInfo{
+					&multiwatcher.UnitInfo{
+						Name:       "wordpress/0",
+						Service:    "wordpress",
+						Status:     multiwatcher.Status("started"),
+						StatusInfo: "",
+						StatusData: make(map[string]interface{}),
+						WorkloadStatus: multiwatcher.StatusInfo{
+							Current: "maintenance",
+							Message: "working",
+							Data:    map[string]interface{}{},
+						},
+						AgentStatus: multiwatcher.StatusInfo{
+							Current: "idle",
+							Message: "",
+							Data:    map[string]interface{}{},
+						},
+					}}}
+		},
+		func(c *gc.C, st *State) changeTestCase {
+			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
+			u, err := wordpress.AddUnit()
+			c.Assert(err, jc.ErrorIsNil)
+			err = u.SetAgentStatus(StatusIdle, "", nil)
+			c.Assert(err, jc.ErrorIsNil)
+			err = u.SetStatus(StatusMaintenance, "doing work", nil)
+			c.Assert(err, jc.ErrorIsNil)
+
+			return changeTestCase{
+				about: "unit status is changed if the agent comes off error state",
+				initialContents: []multiwatcher.EntityInfo{&multiwatcher.UnitInfo{
+					Name:       "wordpress/0",
+					Service:    "wordpress",
 					Status:     multiwatcher.Status("error"),
 					StatusInfo: "failure",
 					AgentStatus: multiwatcher.StatusInfo{
@@ -1421,12 +1473,12 @@ func (s *storeManagerStateSuite) TestChangeUnits(c *gc.C) {
 					&multiwatcher.UnitInfo{
 						Name:       "wordpress/0",
 						Service:    "wordpress",
-						Status:     multiwatcher.Status("error"),
-						StatusInfo: "failure",
+						Status:     multiwatcher.Status("started"),
+						StatusInfo: "",
 						StatusData: make(map[string]interface{}),
 						WorkloadStatus: multiwatcher.StatusInfo{
-							Current: "error",
-							Message: "failure",
+							Current: "maintenance",
+							Message: "doing work",
 							Data:    map[string]interface{}{},
 						},
 						AgentStatus: multiwatcher.StatusInfo{


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1467690

When a hook errors and is retried automatically (not via resolve --retry), the metawatcher was incorrectly reporting the unit workload as still being in error state. So we tweak the backing doc logic to handle this properly.

(Review request: http://reviews.vapour.ws/r/2007/)