### PR TITLE
Fix the two cloud init failures.

### DIFF
--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/service"
 	systemdtesting "github.com/juju/juju/service/systemd/testing"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 func Test(t *stdtesting.T) {
@@ -157,7 +156,7 @@ func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 
 func (s *UserDataSuite) TestShutdownInitCommandsUpstart(c *gc.C) {
 	s.SetFeatureFlags(feature.AddressAllocation)
-	cmds, err := containerinit.ShutdownInitCommands(service.InitSystemUpstart)
+	cmds, err := containerinit.ShutdownInitCommands(service.InitSystemUpstart, "trusty")
 	c.Assert(err, jc.ErrorIsNil)
 
 	filename := "/etc/init/juju-template-restart.conf"
@@ -190,8 +189,7 @@ end script
 
 func (s *UserDataSuite) TestShutdownInitCommandsSystemd(c *gc.C) {
 	s.SetFeatureFlags(feature.AddressAllocation)
-	s.PatchValue(&version.Current.Series, "vivid")
-	commands, err := containerinit.ShutdownInitCommands(service.InitSystemSystemd)
+	commands, err := containerinit.ShutdownInitCommands(service.InitSystemSystemd, "vivid")
 	c.Assert(err, jc.ErrorIsNil)
 
 	test := systemdtesting.WriteConfTest{

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -193,21 +193,12 @@ func (cfg *InstanceConfig) InitService(renderer shell.Renderer) (service.Service
 	conf := service.AgentConf(cfg.agentInfo(), renderer)
 
 	name := cfg.MachineAgentServiceName
-	initSystem, ok := cfg.initSystem()
-	if !ok {
-		return nil, errors.New("could not identify init system")
-	}
-	logger.Debugf("using init system %q for machine agent script", initSystem)
-	svc, err := newService(name, conf, initSystem)
+	svc, err := newService(name, conf, cfg.Series)
 	return svc, errors.Trace(err)
 }
 
-func (cfg *InstanceConfig) initSystem() (string, bool) {
-	return service.VersionInitSystem(cfg.Tools.Version)
-}
-
-var newService = func(name string, conf common.Conf, initSystem string) (service.Service, error) {
-	return service.NewService(name, conf, initSystem)
+var newService = func(name string, conf common.Conf, series string) (service.Service, error) {
+	return service.NewService(name, conf, series)
 }
 
 func (cfg *InstanceConfig) AgentConfig(

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -359,7 +359,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 			CloudInitOutputLog: cloudInitOutputLog,
 			Bootstrap:          false,
 			Tools:              newSimpleTools("1.2.3-vivid-amd64"),
-			Series:             "quantal",
+			Series:             "vivid",
 			MachineNonce:       "FAKE_NONCE",
 			MongoInfo: &mongo.MongoInfo{
 				Tag:      names.NewMachineTag("99"),
@@ -1072,7 +1072,6 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		err = udata.Configure()
 		c.Check(err, gc.ErrorMatches, "invalid machine configuration: "+test.err)
-
 	}
 }
 

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -93,10 +93,11 @@ func (w *unixConfigure) ConfigureBasic() error {
 	case version.Ubuntu:
 		w.conf.AddSSHAuthorizedKeys(w.icfg.AuthorizedKeys)
 		if w.icfg.Tools != nil {
-			initSystem, ok := service.VersionInitSystem(w.icfg.Tools.Version)
-			if ok {
-				w.addCleanShutdownJob(initSystem)
+			initSystem, err := service.VersionInitSystem(w.icfg.Series)
+			if err != nil {
+				return errors.Trace(err)
 			}
+			w.addCleanShutdownJob(initSystem)
 		}
 	// On unix systems that are not ubuntu we create an ubuntu user so that we
 	// are able to ssh in the machine and have all the functionality dependant

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -24,18 +24,27 @@ type serviceSuite struct {
 var _ = gc.Suite(&serviceSuite{})
 
 func (s *serviceSuite) TestNewServiceKnown(c *gc.C) {
-	initSystems := []string{
-		service.InitSystemSystemd,
-		service.InitSystemUpstart,
-		service.InitSystemWindows,
-	}
-	for _, initSystem := range initSystems {
-		svc, err := service.NewService(s.Name, s.Conf, initSystem)
+	for _, test := range []struct {
+		series     string
+		initSystem string
+	}{
+		{
+			series:     "vivid",
+			initSystem: service.InitSystemSystemd,
+		}, {
+			series:     "trusty",
+			initSystem: service.InitSystemUpstart,
+		}, {
+			series:     "win2012",
+			initSystem: service.InitSystemWindows,
+		},
+	} {
+		svc, err := service.NewService(s.Name, s.Conf, test.series)
 		if !c.Check(err, jc.ErrorIsNil) {
 			continue
 		}
 
-		switch initSystem {
+		switch test.initSystem {
 		case service.InitSystemSystemd:
 			c.Check(svc, gc.FitsTypeOf, &systemd.Service{})
 		case service.InitSystemUpstart:

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -148,8 +148,9 @@ func serialize(name string, conf common.Conf, renderer shell.Renderer) ([]byte, 
 	unitOptions = append(unitOptions, serializeUnit(conf)...)
 	unitOptions = append(unitOptions, serializeService(conf)...)
 	unitOptions = append(unitOptions, serializeInstall(conf)...)
-
-	data, err := ioutil.ReadAll(unit.Serialize(unitOptions))
+	// Don't use unit.Serialize because it has map ordering issues.
+	// Serialize copied locally, and outputs sections in alphabetical order.
+	data, err := ioutil.ReadAll(UnitSerialize(unitOptions))
 	return data, errors.Trace(err)
 }
 

--- a/service/systemd/serialize.go
+++ b/service/systemd/serialize.go
@@ -1,0 +1,76 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systemd
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/coreos/go-systemd/unit"
+)
+
+// UnitSerialize encodes all of the given UnitOption objects into a unit file.
+// Renamed from Serialize from github.com/coreos/go-systemd/unit so as to not
+// confict with the exported internal function in export_test.go.
+func UnitSerialize(opts []*unit.UnitOption) io.Reader {
+	var buf bytes.Buffer
+
+	if len(opts) == 0 {
+		return &buf
+	}
+
+	idx := map[string][]*unit.UnitOption{}
+	for _, opt := range opts {
+		idx[opt.Section] = append(idx[opt.Section], opt)
+	}
+
+	// CHANGED HERE: Output in the following order:
+	// - Unit
+	// - Service
+	// - Install
+	// rather than just iterating over the map in random order.
+	for _, curSection := range []string{"Unit", "Service", "Install"} {
+		curOpts, found := idx[curSection]
+		if !found {
+			continue
+		}
+		writeSectionHeader(&buf, curSection)
+		writeNewline(&buf)
+
+		for _, opt := range curOpts {
+			writeOption(&buf, opt)
+			writeNewline(&buf)
+		}
+		writeNewline(&buf)
+	}
+
+	return &buf
+}
+
+func writeNewline(buf *bytes.Buffer) {
+	buf.WriteRune('\n')
+}
+
+func writeSectionHeader(buf *bytes.Buffer, section string) {
+	buf.WriteRune('[')
+	buf.WriteString(section)
+	buf.WriteRune(']')
+}
+
+func writeOption(buf *bytes.Buffer, opt *unit.UnitOption) {
+	buf.WriteString(opt.Name)
+	buf.WriteRune('=')
+	buf.WriteString(opt.Value)
+}

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -92,7 +92,6 @@ type Service struct {
 // NewService returns a new value that implements Service for systemd.
 func NewService(name string, conf common.Conf, dataDir string) (*Service, error) {
 	confName := name + ".service"
-	// TODO(ericsnow) Factor out the datadir-related code.
 	var volName string
 	if conf.ExecStart != "" {
 		volName = renderer.VolumeName(common.Unquote(strings.Fields(conf.ExecStart)[0]))


### PR DESCRIPTION
One was due to the method to create a new systemd service using the host machines
series to determine the datadir. This worked by mistake on most developers machines,
but failed on windows.
The second was a map ordering issue in the output of the systemd configuration files.

(Review request: http://reviews.vapour.ws/r/2010/)