### PR TITLE
state: add LifeBinding() to Volume and Filesystem

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -342,9 +342,6 @@ func (st *State) cleanupContainers(machine *Machine) error {
 }
 
 func cleanupDyingMachineResources(m *Machine) error {
-	// TODO(axw) add a delete-on-termination flag field to volume/filesystem
-	// attachments, and when cleaning up here we would check it and trigger
-	// deletion of volumes/filesystems.
 	volumeAttachments, err := m.st.MachineVolumeAttachments(m.MachineTag())
 	if err != nil {
 		return errors.Annotate(err, "getting machine volume attachments")

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -33,6 +33,27 @@ type Filesystem interface {
 	// Life returns the life of the filesystem.
 	Life() Life
 
+	// Binding is the tag of an entity that the filesystem's life span is
+	// bound to. This may be nil (i.e. the filesystem may persist beyond
+	// the span of environment), or one of EnvironmentTag, StorageTag, or
+	// MachineTag. The filesystem will be destroyed when the identified
+	// entity is destroyed.
+	//
+	// The following is a description of the effects of binding to
+	// different entities:
+	//   Machine:     If the filesystem is bound to a machine, then the
+	//                filesystem will be destroyed when it is detached from
+	//                the machine. It is not permitted for a filesystem to
+	//                be attached to multiple machines while it is bound to
+	//                a machine.
+	//   Storage:     If the filesystem is bound to a storage instance,
+	//                then the filesystem will be destroyed when the
+	//                storage insance is removed from state.
+	//   Environment: If the filesystem is bound to the environment, then
+	//                the filesystem must be destroyed prior to the
+	//                environment being destroyed.
+	Binding() names.Tag
+
 	// Storage returns the tag of the storage instance that this
 	// filesystem is assigned to, if any. If the filesystem is not
 	// assigned to a storage instance, an error satisfying
@@ -100,8 +121,10 @@ type filesystemDoc struct {
 	StorageId    string `bson:"storageid,omitempty"`
 	VolumeId     string `bson:"volumeid,omitempty"`
 	// TODO(axw) 2015-06-22 #1467379
-	// upgrade step to set this for 1.24 environments
+	// upgrade step to set "attachmentcount" and "binding"
+	// for 1.24 environments.
 	AttachmentCount int               `bson:"attachmentcount"`
+	Binding         string            `bson:"binding,omitempty"`
 	Info            *FilesystemInfo   `bson:"info,omitempty"`
 	Params          *FilesystemParams `bson:"params,omitempty"`
 }
@@ -123,6 +146,10 @@ type FilesystemParams struct {
 	// storage, if non-zero, is the tag of the storage instance
 	// that the filesystem is to be assigned to.
 	storage names.StorageTag
+
+	// binding, if non-nil, is the tag of the entity to which
+	// the filesystem's lifecycle will be bound.
+	binding names.Tag
 
 	Pool string `bson:"pool"`
 	Size uint64 `bson:"size"`
@@ -155,6 +182,26 @@ type FilesystemAttachmentParams struct {
 	ReadOnly bool   `bson:"read-only"`
 }
 
+// validate validates the contents of the filesystem document.
+func (f *filesystem) validate() error {
+	if f.doc.Binding != "" {
+		tag, err := names.ParseTag(f.doc.Binding)
+		if err != nil {
+			return errors.Annotate(err, "parsing binding")
+		}
+		switch tag.(type) {
+		case names.EnvironTag:
+			// TODO(axw) support binding to environment
+			return errors.NotSupportedf("binding to environment")
+		case names.MachineTag:
+		case names.StorageTag:
+		default:
+			return errors.Errorf("invalid binding: %v", f.doc.Binding)
+		}
+	}
+	return nil
+}
+
 // Tag is required to implement Entity.
 func (f *filesystem) Tag() names.Tag {
 	return f.FilesystemTag()
@@ -168,6 +215,16 @@ func (f *filesystem) FilesystemTag() names.FilesystemTag {
 // Life is required to implement Filesystem.
 func (f *filesystem) Life() Life {
 	return f.doc.Life
+}
+
+// Binding is required to implement Filesystem.
+func (f *filesystem) Binding() names.Tag {
+	if f.doc.Binding == "" {
+		return nil
+	}
+	// Tag is validated in filesystem.validate.
+	tag, _ := names.ParseTag(f.doc.Binding)
+	return tag
 }
 
 // Storage is required to implement Filesystem.
@@ -236,30 +293,38 @@ func (f *filesystemAttachment) Params() (FilesystemAttachmentParams, bool) {
 
 // Filesystem returns the Filesystem with the specified name.
 func (st *State) Filesystem(tag names.FilesystemTag) (Filesystem, error) {
-	f, err := st.filesystemInternal(tag)
+	f, err := st.filesystemByTag(tag)
 	return f, err
 }
 
-func (st *State) filesystemInternal(tag names.FilesystemTag) (*filesystem, error) {
+func (st *State) filesystemByTag(tag names.FilesystemTag) (*filesystem, error) {
 	query := bson.D{{"_id", tag.Id()}}
-	description := names.ReadableString(tag)
+	description := fmt.Sprintf("filesystem %q", tag.Id())
+	return st.filesystem(query, description)
+}
+
+func (st *State) storageInstanceFilesystem(tag names.StorageTag) (*filesystem, error) {
+	query := bson.D{{"storageid", tag.Id()}}
+	description := fmt.Sprintf("filesystem for storage instance %q", tag.Id())
 	return st.filesystem(query, description)
 }
 
 // StorageInstanceFilesystem returns the Filesystem assigned to the specified
 // storage instance.
 func (st *State) StorageInstanceFilesystem(tag names.StorageTag) (Filesystem, error) {
-	query := bson.D{{"storageid", tag.Id()}}
-	description := fmt.Sprintf("filesystem for storage instance %q", tag.Id())
-	f, err := st.filesystem(query, description)
+	f, err := st.storageInstanceFilesystem(tag)
 	return f, err
+}
+
+func (st *State) volumeFilesystem(tag names.VolumeTag) (*filesystem, error) {
+	query := bson.D{{"volumeid", tag.Id()}}
+	description := fmt.Sprintf("filesystem for volume %q", tag.Id())
+	return st.filesystem(query, description)
 }
 
 // VolumeFilesystem returns the Filesystem backed by the specified volume.
 func (st *State) VolumeFilesystem(tag names.VolumeTag) (Filesystem, error) {
-	query := bson.D{{"volumeid", tag.Id()}}
-	description := fmt.Sprintf("filesystem for volume %q", tag.Id())
-	f, err := st.filesystem(query, description)
+	f, err := st.volumeFilesystem(tag)
 	return f, err
 }
 
@@ -273,6 +338,9 @@ func (st *State) filesystem(query bson.D, description string) (*filesystem, erro
 		return nil, errors.NotFoundf(description)
 	} else if err != nil {
 		return nil, errors.Annotate(err, "cannot get filesystem")
+	}
+	if err := f.validate(); err != nil {
+		return nil, errors.Annotate(err, "validating filesystem")
 	}
 	return &f, nil
 }
@@ -434,7 +502,7 @@ func (st *State) RemoveFilesystemAttachment(machine names.MachineTag, filesystem
 		if attachment.Life() != Dying {
 			return nil, errors.New("filesystem attachment is not dying")
 		}
-		f, err := st.filesystemInternal(filesystem)
+		f, err := st.filesystemByTag(filesystem)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -459,6 +527,7 @@ func removeFilesystemAttachmentOps(m names.MachineTag, f *filesystem) []txn.Op {
 	decrefFilesystemOp := machineStorageDecrefOp(
 		filesystemsC, f.doc.FilesystemId,
 		f.doc.AttachmentCount, f.doc.Life,
+		m, f.doc.Binding,
 	)
 	return []txn.Op{{
 		C:      filesystemAttachmentsC,
@@ -472,7 +541,7 @@ func removeFilesystemAttachmentOps(m names.MachineTag, f *filesystem) []txn.Op {
 // be destroyed and removed from state at some point in the future.
 func (st *State) DestroyFilesystem(tag names.FilesystemTag) (err error) {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		filesystem, err := st.filesystemInternal(tag)
+		filesystem, err := st.filesystemByTag(tag)
 		if errors.IsNotFound(err) {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
@@ -534,19 +603,18 @@ func removeFilesystemOps(st *State, filesystem Filesystem) ([]txn.Op, error) {
 		Assert: txn.DocExists,
 		Remove: true,
 	}}
-	// TODO(axw) The below should only be done if the volume's
-	// lifecycle is bound to the filesystem, or to the machine
-	// that the filesystem is scoped to and the machine is Dying.
-	//
-	// If the filesystem is backed by a volume, the volume can and
-	// should be destroyed once the filesystem is removed.
+	// If the filesystem is backed by a volume, the volume should
+	// be destroyed once the filesystem is removed if it is bound
+	// to the filesystem.
 	volumeTag, err := filesystem.Volume()
 	if err == nil {
-		volume, err := st.volume(volumeTag)
+		volume, err := st.volumeByTag(volumeTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ops = append(ops, destroyVolumeOps(st, volume)...)
+		if volume.Binding() == filesystem.Tag() {
+			ops = append(ops, destroyVolumeOps(st, volume)...)
+		}
 	} else if err != ErrNoBackingVolume {
 		return nil, errors.Trace(err)
 	}
@@ -592,6 +660,9 @@ func newFilesystemId(st *State, machineId string) (string, error) {
 // directly, a volume will be created and Juju will manage a filesystem
 // on it.
 func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]txn.Op, names.FilesystemTag, names.VolumeTag, error) {
+	if params.binding == nil {
+		params.binding = names.NewMachineTag(machineId)
+	}
 	params, err := st.filesystemParamsWithDefaults(params)
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Trace(err)
@@ -600,6 +671,12 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 	if err != nil {
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Annotate(err, "validating filesystem params")
 	}
+
+	filesystemId, err := newFilesystemId(st, machineId)
+	if err != nil {
+		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Annotate(err, "cannot generate filesystem name")
+	}
+	filesystemTag := names.NewFilesystemTag(filesystemId)
 
 	// Check if the filesystem needs a volume.
 	var volumeId string
@@ -613,6 +690,7 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 		var volumeOp txn.Op
 		volumeParams := VolumeParams{
 			params.storage,
+			filesystemTag, // volume is bound to filesystem
 			params.Pool,
 			params.Size,
 		}
@@ -624,25 +702,22 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 		ops = append(ops, volumeOp)
 	}
 
-	id, err := newFilesystemId(st, machineId)
-	if err != nil {
-		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Annotate(err, "cannot generate filesystem name")
-	}
 	filesystemOp := txn.Op{
 		C:      filesystemsC,
-		Id:     id,
+		Id:     filesystemId,
 		Assert: txn.DocMissing,
 		Insert: &filesystemDoc{
-			FilesystemId: id,
+			FilesystemId: filesystemId,
 			VolumeId:     volumeId,
 			StorageId:    params.storage.Id(),
+			Binding:      params.binding.String(),
 			Params:       &params,
 			// Every filesystem is created with one attachment.
 			AttachmentCount: 1,
 		},
 	}
 	ops = append(ops, filesystemOp)
-	return ops, names.NewFilesystemTag(id), volumeTag, nil
+	return ops, filesystemTag, volumeTag, nil
 }
 
 func (st *State) filesystemParamsWithDefaults(params FilesystemParams) (FilesystemParams, error) {

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -649,6 +649,10 @@ func (s *FilesystemStateSuite) TestFilesystemBindingMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	filesystem = s.filesystem(c, filesystem.FilesystemTag())
 	c.Assert(filesystem.Life(), gc.Equals, state.Dead)
+
+	// TODO(axw) when we can assign storage to an existing filesystem, we
+	// should test that a machine-bound filesystem is not destroyed when
+	// its assigned storage instance is removed.
 }
 
 func (s *FilesystemStateSuite) TestFilesystemBindingStorage(c *gc.C) {

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -641,7 +641,7 @@ func (s *FilesystemStateSuite) TestFilesystemBindingMachine(c *gc.C) {
 	// Filesystems created unassigned to a storage instance are
 	// bound to the initially attached machine.
 	filesystem, machine := s.setupFilesystemAttachment(c, "rootfs")
-	c.Assert(filesystem.Binding(), gc.Equals, machine.Tag())
+	c.Assert(filesystem.LifeBinding(), gc.Equals, machine.Tag())
 
 	err := s.State.DetachFilesystem(machine.MachineTag(), filesystem.FilesystemTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -658,7 +658,7 @@ func (s *FilesystemStateSuite) TestFilesystemBindingStorage(c *gc.C) {
 	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
 	c.Assert(err, jc.ErrorIsNil)
 	filesystem := s.storageInstanceFilesystem(c, storageTag)
-	c.Assert(filesystem.Binding(), gc.Equals, storageTag)
+	c.Assert(filesystem.LifeBinding(), gc.Equals, storageTag)
 
 	err = s.State.DestroyStorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)
@@ -683,7 +683,7 @@ func (s *FilesystemStateSuite) TestFilesystemVolumeBinding(c *gc.C) {
 	// A volume backing a filesystem is bound to the filesystem.
 	filesystem, _ := s.setupFilesystemAttachment(c, "loop")
 	volume := s.filesystemVolume(c, filesystem.FilesystemTag())
-	c.Assert(volume.Binding(), gc.Equals, filesystem.Tag())
+	c.Assert(volume.LifeBinding(), gc.Equals, filesystem.Tag())
 
 	// TestRemoveFilesystemVolumeBacked tests that removal of
 	// filesystem destroys volume.

--- a/state/interface.go
+++ b/state/interface.go
@@ -56,6 +56,21 @@ var (
 	_ Lifer = (*Relation)(nil)
 )
 
+// LifeBinder represents an entity whose lifespan is bindable
+// to that of another entity.
+type LifeBinder interface {
+	Lifer
+
+	// LifeBinding either returns the tag of an entity to which this
+	// entity's lifespan is bound; the result may be nil, indicating
+	// that the entity's lifespan is not bound to anything.
+	//
+	// The types of tags that may be returned are depdendent on the
+	// entity type. For example, a Volume may be bound to a Filesystem,
+	// but a Filesystem may not be bound to a Filesystem.
+	LifeBinding() names.Tag
+}
+
 // AgentTooler is implemented by entities
 // that have associated agent tools.
 type AgentTooler interface {

--- a/state/storage.go
+++ b/state/storage.go
@@ -300,7 +300,7 @@ func removeStorageInstanceOps(
 		ops = append(ops, machineStorageOp(
 			volumesC, volume.Tag().Id(),
 		))
-		if volume.Binding() == tag {
+		if volume.LifeBinding() == tag {
 			ops = append(ops, destroyVolumeOps(st, volume)...)
 		}
 	} else if !errors.IsNotFound(err) {
@@ -311,7 +311,7 @@ func removeStorageInstanceOps(
 		ops = append(ops, machineStorageOp(
 			filesystemsC, filesystem.Tag().Id(),
 		))
-		if filesystem.Binding() == tag {
+		if filesystem.LifeBinding() == tag {
 			ops = append(ops, destroyFilesystemOps(st, filesystem)...)
 		}
 	} else if !errors.IsNotFound(err) {

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -308,6 +308,8 @@ func (s *storageAddSuite) TestAddStorageFilesystem(c *gc.C) {
 }
 
 func (s *storageAddSuite) TestAddStorageStatic(c *gc.C) {
+	// Create a unit with static storage; ensure that storage-add
+	// fails to add more of this kind of storage.
 	_, u, _ := s.setupSingleStorage(c, "filesystem", "static")
 	s.assertStorageCount(c, 1)
 

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -10,8 +10,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/storage/provider/dummy"
-	"github.com/juju/juju/storage/provider/registry"
 )
 
 type storageAddSuite struct {
@@ -310,13 +308,6 @@ func (s *storageAddSuite) TestAddStorageFilesystem(c *gc.C) {
 }
 
 func (s *storageAddSuite) TestAddStorageStatic(c *gc.C) {
-	// Create a unit with static storage; ensure that storage-add
-	// fails to add more of this kind of storage.
-	registry.RegisterProvider("static", &dummy.StorageProvider{
-		IsDynamic: false,
-	})
-	registry.RegisterEnvironStorageProviders("someprovider", "static")
-	defer registry.RegisterProvider("static", nil)
 	_, u, _ := s.setupSingleStorage(c, "filesystem", "static")
 	s.assertStorageCount(c, 1)
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -1635,10 +1635,10 @@ func machineStorageParamsForStorageInstance(
 			// to create a volume.
 			cons := allCons[storage.StorageName()]
 			volumeParams := VolumeParams{
-				storage.StorageTag(),
-				storage.StorageTag(),
-				cons.Pool,
-				cons.Size,
+				storage: storage.StorageTag(),
+				binding: storage.StorageTag(),
+				Pool:    cons.Pool,
+				Size:    cons.Size,
 			}
 			volumes = append(volumes, MachineVolumeParams{
 				volumeParams, volumeAttachmentParams,
@@ -1663,10 +1663,10 @@ func machineStorageParamsForStorageInstance(
 			// to create a filesystem.
 			cons := allCons[storage.StorageName()]
 			filesystemParams := FilesystemParams{
-				storage.StorageTag(),
-				storage.StorageTag(),
-				cons.Pool,
-				cons.Size,
+				storage: storage.StorageTag(),
+				binding: storage.StorageTag(),
+				Pool:    cons.Pool,
+				Size:    cons.Size,
 			}
 			filesystems = append(filesystems, MachineFilesystemParams{
 				filesystemParams, filesystemAttachmentParams,

--- a/state/unit.go
+++ b/state/unit.go
@@ -1635,9 +1635,10 @@ func machineStorageParamsForStorageInstance(
 			// to create a volume.
 			cons := allCons[storage.StorageName()]
 			volumeParams := VolumeParams{
-				storage: storage.StorageTag(),
-				Pool:    cons.Pool,
-				Size:    cons.Size,
+				storage.StorageTag(),
+				storage.StorageTag(),
+				cons.Pool,
+				cons.Size,
 			}
 			volumes = append(volumes, MachineVolumeParams{
 				volumeParams, volumeAttachmentParams,
@@ -1662,9 +1663,10 @@ func machineStorageParamsForStorageInstance(
 			// to create a filesystem.
 			cons := allCons[storage.StorageName()]
 			filesystemParams := FilesystemParams{
-				storage: storage.StorageTag(),
-				Pool:    cons.Pool,
-				Size:    cons.Size,
+				storage.StorageTag(),
+				storage.StorageTag(),
+				cons.Pool,
+				cons.Size,
 			}
 			filesystems = append(filesystems, MachineFilesystemParams{
 				filesystemParams, filesystemAttachmentParams,

--- a/state/volume.go
+++ b/state/volume.go
@@ -27,6 +27,29 @@ type Volume interface {
 	// Life returns the life of the volume.
 	Life() Life
 
+	// Binding is the tag of an entity that the volume's life span is bound
+	// to. This may be nil (i.e. the volume may persist beyond the span of
+	// environment), or one of EnvironmentTag, StorageTag, FilesystemTag,
+	// or MachineTag.
+	//
+	// The following is a description of the effects of binding to
+	// different entities:
+	//   Machine:     If the volume is bound to a machine, then the volume
+	//                will be destroyed when it is detached from the
+	//                machine. It is not permitted for a volume to be
+	//                attached to multiple machines while it is bound to a
+	//                machine.
+	//   Storage:     If the volume is bound to a storage instance, then
+	//                the volume will be destroyed when the storage insance
+	//                is removed from state.
+	//   Filesystem:  If the volume is bound to a filesystem, i.e. the
+	//                volume backs that filesystem, then it will be
+	//                destroyed when the filesystem is removed from state.
+	//   Environment: If the volume is bound to the environment, then the
+	//                volume must be destroyed prior to the environment
+	//                being destroyed.
+	Binding() names.Tag
+
 	// StorageInstance returns the tag of the storage instance that this
 	// volume is assigned to, if any. If the volume is not assigned to
 	// a storage instance, an error satisfying errors.IsNotAssigned will
@@ -86,8 +109,10 @@ type volumeDoc struct {
 	Life      Life   `bson:"life"`
 	StorageId string `bson:"storageid,omitempty"`
 	// TODO(axw) 2015-06-22 #1467379
-	// upgrade step to set this for 1.24 environments
+	// upgrade step to set "attachmentcount" and "binding"
+	// for 1.24 environments.
 	AttachmentCount int           `bson:"attachmentcount"`
+	Binding         string        `bson:"binding,omitempty"`
 	Info            *VolumeInfo   `bson:"info,omitempty"`
 	Params          *VolumeParams `bson:"params,omitempty"`
 }
@@ -109,6 +134,10 @@ type VolumeParams struct {
 	// storage, if non-zero, is the tag of the storage instance
 	// that the volume is to be assigned to.
 	storage names.StorageTag
+
+	// binding, if non-nil, is the tag of the entity to which
+	// the volume's lifecycle will be bound.
+	binding names.Tag
 
 	Pool string `bson:"pool"`
 	Size uint64 `bson:"size"`
@@ -135,6 +164,27 @@ type VolumeAttachmentParams struct {
 	ReadOnly bool `bson:"read-only"`
 }
 
+// validate validates the contents of the volume document.
+func (v *volume) validate() error {
+	if v.doc.Binding != "" {
+		tag, err := names.ParseTag(v.doc.Binding)
+		if err != nil {
+			return errors.Annotate(err, "parsing binding")
+		}
+		switch tag.(type) {
+		case names.EnvironTag:
+			// TODO(axw) support binding to environment
+			return errors.NotSupportedf("binding to environment")
+		case names.MachineTag:
+		case names.FilesystemTag:
+		case names.StorageTag:
+		default:
+			return errors.Errorf("invalid binding: %v", v.doc.Binding)
+		}
+	}
+	return nil
+}
+
 // Tag is required to implement Entity.
 func (v *volume) Tag() names.Tag {
 	return v.VolumeTag()
@@ -148,6 +198,16 @@ func (v *volume) VolumeTag() names.VolumeTag {
 // Life returns the volume's current lifecycle state.
 func (v *volume) Life() Life {
 	return v.doc.Life
+}
+
+// Binding is required to implement Volume.
+func (v *volume) Binding() names.Tag {
+	if v.doc.Binding == "" {
+		return nil
+	}
+	// Tag is validated in volume.validate.
+	tag, _ := names.ParseTag(v.doc.Binding)
+	return tag
 }
 
 // StorageInstance is required to implement Volume.
@@ -208,57 +268,76 @@ func (v *volumeAttachment) Params() (VolumeAttachmentParams, bool) {
 
 // Volume returns the Volume with the specified name.
 func (st *State) Volume(tag names.VolumeTag) (Volume, error) {
-	v, err := st.volume(tag)
+	v, err := st.volumeByTag(tag)
 	return v, err
 }
 
-func (st *State) volume(tag names.VolumeTag) (*volume, error) {
+func (st *State) volumes(query interface{}) ([]*volume, error) {
 	coll, cleanup := st.getCollection(volumesC)
 	defer cleanup()
 
-	var v volume
-	err := coll.FindId(tag.Id()).One(&v.doc)
-	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("volume %q", tag.Id())
-	} else if err != nil {
-		return nil, errors.Annotate(err, "cannot get volume")
+	var docs []volumeDoc
+	err := coll.Find(query).All(&docs)
+	if err != nil {
+		return nil, errors.Annotate(err, "querying volumes")
 	}
-	return &v, nil
+	volumes := make([]*volume, len(docs))
+	for i := range docs {
+		volume := &volume{docs[i]}
+		if err := volume.validate(); err != nil {
+			return nil, errors.Annotate(err, "validating volume")
+		}
+		volumes[i] = volume
+	}
+	return volumes, nil
+}
+
+func (st *State) volume(query bson.D, description string) (*volume, error) {
+	volumes, err := st.volumes(query)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(volumes) == 0 {
+		return nil, errors.NotFoundf("%s", description)
+	} else if len(volumes) != 1 {
+		return nil, errors.Errorf("expected 1 volume, got %d", len(volumes))
+	}
+	return volumes[0], nil
+}
+
+func (st *State) volumeByTag(tag names.VolumeTag) (*volume, error) {
+	return st.volume(bson.D{{"_id", tag.Id()}}, fmt.Sprintf("volume %q", tag.Id()))
+}
+
+func volumesToInterfaces(volumes []*volume) []Volume {
+	result := make([]Volume, len(volumes))
+	for i, v := range volumes {
+		result[i] = v
+	}
+	return result
 }
 
 // PersistentVolumes returns any alive persistent Volumes scoped to the environment or any machine.
 func (st *State) PersistentVolumes() ([]Volume, error) {
-	coll, cleanup := st.getCollection(volumesC)
-	defer cleanup()
-
-	var vDocs []volumeDoc
-	err := coll.Find(
-		bson.D{{"info.persistent", true}},
-	).All(&vDocs)
+	volumes, err := st.volumes(bson.D{{"info.persistent", true}})
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get persistent volumes")
 	}
-	v := make([]Volume, len(vDocs))
-	for i, vDoc := range vDocs {
-		v[i] = &volume{vDoc}
-	}
-	return v, nil
+	return volumesToInterfaces(volumes), nil
+}
+
+func (st *State) storageInstanceVolume(tag names.StorageTag) (*volume, error) {
+	return st.volume(
+		bson.D{{"storageid", tag.Id()}},
+		fmt.Sprintf("volume for storage instance %q", tag.Id()),
+	)
 }
 
 // StorageInstanceVolume returns the Volume assigned to the specified
 // storage instance.
 func (st *State) StorageInstanceVolume(tag names.StorageTag) (Volume, error) {
-	coll, cleanup := st.getCollection(volumesC)
-	defer cleanup()
-
-	var v volume
-	err := coll.Find(bson.D{{"storageid", tag.Id()}}).One(&v.doc)
-	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("volume for storage instance %q", tag.Id())
-	} else if err != nil {
-		return nil, errors.Annotate(err, "cannot get volume")
-	}
-	return &v, nil
+	v, err := st.storageInstanceVolume(tag)
+	return v, err
 }
 
 // VolumeAttachment returns the VolumeAttachment corresponding to
@@ -335,7 +414,7 @@ func (st *State) removeMachineVolumesOps(machine names.MachineTag) ([]txn.Op, er
 	ops := make([]txn.Op, 0, len(attachments))
 	for _, a := range attachments {
 		volumeTag := a.Volume()
-		volume, err := st.volume(volumeTag)
+		volume, err := st.Volume(volumeTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -440,7 +519,7 @@ func (st *State) RemoveVolumeAttachment(machine names.MachineTag, volume names.V
 		if attachment.Life() != Dying {
 			return nil, errors.New("volume attachment is not dying")
 		}
-		v, err := st.volume(volume)
+		v, err := st.volumeByTag(volume)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -453,6 +532,7 @@ func removeVolumeAttachmentOps(m names.MachineTag, v *volume) []txn.Op {
 	decrefVolumeOp := machineStorageDecrefOp(
 		volumesC, v.doc.Name,
 		v.doc.AttachmentCount, v.doc.Life,
+		m, v.doc.Binding,
 	)
 	return []txn.Op{{
 		C:      volumeAttachmentsC,
@@ -469,6 +549,8 @@ func removeVolumeAttachmentOps(m names.MachineTag, v *volume) []txn.Op {
 func machineStorageDecrefOp(
 	collection, id string,
 	attachmentCount int, life Life,
+	machine names.MachineTag,
+	binding string,
 ) txn.Op {
 	op := txn.Op{
 		C:  collection,
@@ -502,16 +584,27 @@ func machineStorageDecrefOp(
 		}
 	} else {
 		// The volume is still Alive: decref, retrying if the
-		// volume is destroyed concurrently. Otherwise, when
-		// DestroyVolume is called, the volume will be marked
-		// Dead if it has no attachments.
-		op.Assert = bson.D{
-			{"life", Alive},
-			{"attachmentcount", bson.D{{"$gt", 0}}},
-		}
-		op.Update = bson.D{
+		// volume is destroyed concurrently or the binding changes.
+		// If the volume is bound to the machine, advance it to
+		// Dead; binding storage to a machine and attaching the
+		// storage to multiple machines will be mutually exclusive.
+		//
+		// Otherwise, when DestroyVolume is called, the volume will
+		// be marked Dead if it has no attachments.
+		update := bson.D{
 			{"$inc", bson.D{{"attachmentcount", -1}}},
 		}
+		if binding == machine.String() {
+			update = append(update, bson.DocElem{
+				"$set", bson.D{{"life", Dead}},
+			})
+		}
+		op.Assert = bson.D{
+			{"life", Alive},
+			{"binding", binding},
+			{"attachmentcount", bson.D{{"$gt", 0}}},
+		}
+		op.Update = update
 	}
 	return op
 }
@@ -528,7 +621,7 @@ func (st *State) DestroyVolume(tag names.VolumeTag) (err error) {
 		return errors.Trace(err)
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		volume, err := st.volume(tag)
+		volume, err := st.volumeByTag(tag)
 		if errors.IsNotFound(err) {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
@@ -543,7 +636,6 @@ func (st *State) DestroyVolume(tag names.VolumeTag) (err error) {
 }
 
 func destroyVolumeOps(st *State, v *volume) []txn.Op {
-	logger.Debugf("destroyVolumeOps(%v)", v.Tag())
 	if v.doc.AttachmentCount == 0 {
 		hasNoAttachments := bson.D{{"attachmentcount", 0}}
 		return []txn.Op{{
@@ -608,6 +700,9 @@ func newVolumeName(st *State, machineId string) (string, error) {
 // provider is machine-scoped, then the volume will be scoped to that
 // machine.
 func (st *State) addVolumeOp(params VolumeParams, machineId string) (txn.Op, names.VolumeTag, error) {
+	if params.binding == nil {
+		params.binding = names.NewMachineTag(machineId)
+	}
 	params, err := st.volumeParamsWithDefaults(params)
 	if err != nil {
 		return txn.Op{}, names.VolumeTag{}, errors.Trace(err)
@@ -628,6 +723,7 @@ func (st *State) addVolumeOp(params VolumeParams, machineId string) (txn.Op, nam
 		Insert: &volumeDoc{
 			Name:      name,
 			StorageId: params.storage.Id(),
+			Binding:   params.binding.String(),
 			Params:    &params,
 			// Every volume is created with one attachment.
 			AttachmentCount: 1,
@@ -876,18 +972,9 @@ func setVolumeInfoOps(tag names.VolumeTag, info VolumeInfo, unsetParams bool) []
 
 // AllVolumes returns all Volumes scoped to the environment.
 func (st *State) AllVolumes() ([]Volume, error) {
-	coll, cleanup := st.getCollection(volumesC)
-	defer cleanup()
-
-	var vDocs []volumeDoc
-	err := coll.Find(nil).All(&vDocs)
+	volumes, err := st.volumes(nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get volumes")
 	}
-
-	v := make([]Volume, len(vDocs))
-	for i, vDoc := range vDocs {
-		v[i] = &volume{vDoc}
-	}
-	return v, nil
+	return volumesToInterfaces(volumes), nil
 }

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -458,9 +458,9 @@ func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (_ *state.Machine, all, 
 	volume2 := s.volume(c, names.NewVolumeTag("0/1"))
 	volume3 := s.volume(c, names.NewVolumeTag("2"))
 
-	c.Assert(volume1.Binding(), gc.Equals, machine.MachineTag())
-	c.Assert(volume2.Binding(), gc.Equals, machine.MachineTag())
-	c.Assert(volume3.Binding(), gc.Equals, machine.MachineTag())
+	c.Assert(volume1.LifeBinding(), gc.Equals, machine.MachineTag())
+	c.Assert(volume2.LifeBinding(), gc.Equals, machine.MachineTag())
+	c.Assert(volume3.LifeBinding(), gc.Equals, machine.MachineTag())
 
 	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
 	err = s.State.SetVolumeInfo(volume1.VolumeTag(), volumeInfoSet)
@@ -726,7 +726,7 @@ func (s *VolumeStateSuite) TestVolumeBindingMachine(c *gc.C) {
 	// Volumes created unassigned to a storage instance are
 	// bound to the initially attached machine.
 	volume := s.volume(c, names.NewVolumeTag("0"))
-	c.Assert(volume.Binding(), gc.Equals, machine.Tag())
+	c.Assert(volume.LifeBinding(), gc.Equals, machine.Tag())
 	c.Assert(volume.Life(), gc.Equals, state.Alive)
 
 	err = s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
@@ -743,7 +743,7 @@ func (s *VolumeStateSuite) TestVolumeBindingStorage(c *gc.C) {
 	volume, _ := s.setupVolumeAttachment(c)
 	storageTag, err := volume.StorageInstance()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volume.Binding(), gc.Equals, storageTag)
+	c.Assert(volume.LifeBinding(), gc.Equals, storageTag)
 
 	err = s.State.DestroyStorageInstance(storageTag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -735,6 +735,10 @@ func (s *VolumeStateSuite) TestVolumeBindingMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	volume = s.volume(c, volume.VolumeTag())
 	c.Assert(volume.Life(), gc.Equals, state.Dead)
+
+	// TODO(axw) when we can assign storage to an existing volume, we
+	// should test that a machine-bound volume is not destroyed when
+	// its assigned storage instance is removed.
 }
 
 func (s *VolumeStateSuite) TestVolumeBindingStorage(c *gc.C) {

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -12,13 +12,10 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
-	"github.com/juju/juju/storage/provider/dummy"
-	"github.com/juju/juju/storage/provider/registry"
 )
 
 type VolumeStateSuite struct {
@@ -444,18 +441,6 @@ func (s *VolumeStateSuite) TestPersistentVolumes(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (_ *state.Machine, all, persistent []names.VolumeTag) {
-	registry.RegisterProvider("static", &dummy.StorageProvider{
-		IsDynamic: false,
-	})
-	s.AddCleanup(func(*gc.C) {
-		registry.RegisterProvider("static", nil)
-	})
-
-	registry.RegisterEnvironStorageProviders("someprovider", ec2.EBS_ProviderType, "static")
-	pm := poolmanager.New(state.NewStateSettings(s.State))
-	_, err := pm.Create("persistent-block", ec2.EBS_ProviderType, map[string]interface{}{"persistent": "true"})
-	c.Assert(err, jc.ErrorIsNil)
-
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
@@ -472,6 +457,10 @@ func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (_ *state.Machine, all, 
 	volume1 := s.volume(c, names.NewVolumeTag("0"))
 	volume2 := s.volume(c, names.NewVolumeTag("0/1"))
 	volume3 := s.volume(c, names.NewVolumeTag("2"))
+
+	c.Assert(volume1.Binding(), gc.Equals, machine.MachineTag())
+	c.Assert(volume2.Binding(), gc.Equals, machine.MachineTag())
+	c.Assert(volume3.Binding(), gc.Equals, machine.MachineTag())
 
 	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
 	err = s.State.SetVolumeInfo(volume1.VolumeTag(), volumeInfoSet)
@@ -671,14 +660,6 @@ func (s *VolumeStateSuite) TestRemoveVolumeAttachmentAlive(c *gc.C) {
 }
 
 func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
-	registry.RegisterProvider("static", &dummy.StorageProvider{IsDynamic: false})
-	s.AddCleanup(func(*gc.C) { registry.RegisterProvider("static", nil) })
-	registry.RegisterEnvironStorageProviders("someprovider", ec2.EBS_ProviderType, "static")
-
-	pm := poolmanager.New(state.NewStateSettings(s.State))
-	_, err := pm.Create("persistent-block", ec2.EBS_ProviderType, map[string]interface{}{"persistent": "true"})
-	c.Assert(err, jc.ErrorIsNil)
-
 	machine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
@@ -730,6 +711,57 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	attachments, err := s.State.MachineVolumeAttachments(machine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attachments, gc.HasLen, 0)
+}
+
+func (s *VolumeStateSuite) TestVolumeBindingMachine(c *gc.C) {
+	machine, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Volumes: []state.MachineVolumeParams{{
+			Volume: state.VolumeParams{Pool: "environscoped", Size: 1024},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Volumes created unassigned to a storage instance are
+	// bound to the initially attached machine.
+	volume := s.volume(c, names.NewVolumeTag("0"))
+	c.Assert(volume.Binding(), gc.Equals, machine.Tag())
+	c.Assert(volume.Life(), gc.Equals, state.Alive)
+
+	err = s.State.DetachVolume(machine.MachineTag(), volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	volume = s.volume(c, volume.VolumeTag())
+	c.Assert(volume.Life(), gc.Equals, state.Dead)
+}
+
+func (s *VolumeStateSuite) TestVolumeBindingStorage(c *gc.C) {
+	// Volumes created assigned to a storage instance are bound
+	// to the storage instance.
+	volume, _ := s.setupVolumeAttachment(c)
+	storageTag, err := volume.StorageInstance()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volume.Binding(), gc.Equals, storageTag)
+
+	err = s.State.DestroyStorageInstance(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	attachments, err := s.State.StorageAttachments(storageTag)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, a := range attachments {
+		err = s.State.DestroyStorageAttachment(storageTag, a.Unit())
+		c.Assert(err, jc.ErrorIsNil)
+		err = s.State.RemoveStorageAttachment(storageTag, a.Unit())
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	// The storage instance should be removed,
+	// and the volume should be Dying.
+	_, err = s.State.StorageInstance(storageTag)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	volume = s.volume(c, volume.VolumeTag())
+	c.Assert(volume.Life(), gc.Equals, state.Dying)
 }
 
 func (s *VolumeStateSuite) setupVolumeAttachment(c *gc.C) (state.Volume, *state.Machine) {


### PR DESCRIPTION
We add the LifeBinding() method to Volume and Filesystem,
backed by a new "binding" document field. This field
identifies an entity whose destruction triggers the
destruction of the volume or filesystem.

This is the mechanism we will use to ensure that, by
default, volumes and filesystems will be destroyed
when their associated storage is destroyed. Volumes
that back filesystems are bound to the filesystem;
volumes and filesystems directly related to storage
instances will be bound to said storage; otherwise
volumes and filesystems may be bound to the environment
(destroy when the environment is (cleanly) destroyed),
to the machine they're attached to (destroy on detach),
or to nothing (don't destroy ever, unless explicitly
requested).

(Review request: http://reviews.vapour.ws/r/2016/)