### PR TITLE
apiserver/storageprovisioner: +RemoveAttachment

### DIFF
--- a/apiserver/storageprovisioner/state.go
+++ b/apiserver/storageprovisioner/state.go
@@ -40,7 +40,9 @@ type provisionerState interface {
 	VolumeAttachments(names.VolumeTag) ([]state.VolumeAttachment, error)
 
 	RemoveFilesystem(names.FilesystemTag) error
+	RemoveFilesystemAttachment(names.MachineTag, names.FilesystemTag) error
 	RemoveVolume(names.VolumeTag) error
+	RemoveVolumeAttachment(names.MachineTag, names.VolumeTag) error
 
 	SetFilesystemInfo(names.FilesystemTag, state.FilesystemInfo) error
 	SetFilesystemAttachmentInfo(names.MachineTag, names.FilesystemTag, state.FilesystemAttachmentInfo) error

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -1139,7 +1139,7 @@ func (s *StorageProvisionerAPI) RemoveAttachment(args params.MachineStorageIds) 
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Ids)),
 	}
-	one := func(arg params.MachineStorageId) error {
+	removeAttachment := func(arg params.MachineStorageId) error {
 		machineTag, err := names.ParseMachineTag(arg.MachineTag)
 		if err != nil {
 			return err
@@ -1161,7 +1161,7 @@ func (s *StorageProvisionerAPI) RemoveAttachment(args params.MachineStorageIds) 
 		}
 	}
 	for i, arg := range args.Ids {
-		if err := one(arg); err != nil {
+		if err := removeAttachment(arg); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 		}
 	}

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -1128,3 +1128,42 @@ func (s *StorageProvisionerAPI) Remove(args params.Entities) (params.ErrorResult
 	}
 	return results, nil
 }
+
+// RemoveAttachments removes the specified machine storage attachments
+// from state.
+func (s *StorageProvisionerAPI) RemoveAttachment(args params.MachineStorageIds) (params.ErrorResults, error) {
+	canAccess, err := s.getAttachmentAuthFunc()
+	if err != nil {
+		return params.ErrorResults{}, err
+	}
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Ids)),
+	}
+	one := func(arg params.MachineStorageId) error {
+		machineTag, err := names.ParseMachineTag(arg.MachineTag)
+		if err != nil {
+			return err
+		}
+		attachmentTag, err := names.ParseTag(arg.AttachmentTag)
+		if err != nil {
+			return err
+		}
+		if !canAccess(machineTag, attachmentTag) {
+			return common.ErrPerm
+		}
+		switch attachmentTag := attachmentTag.(type) {
+		case names.VolumeTag:
+			return s.st.RemoveVolumeAttachment(machineTag, attachmentTag)
+		case names.FilesystemTag:
+			return s.st.RemoveFilesystemAttachment(machineTag, attachmentTag)
+		default:
+			return common.ErrPerm
+		}
+	}
+	for i, arg := range args.Ids {
+		if err := one(arg); err != nil {
+			results.Results[i].Error = common.ServerError(err)
+		}
+	}
+	return results, nil
+}

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -1186,6 +1186,72 @@ func (s *provisionerSuite) TestRemoveFilesystemsMachineAgent(c *gc.C) {
 	})
 }
 
+func (s *provisionerSuite) TestRemoveVolumeAttachments(c *gc.C) {
+	s.setupVolumes(c)
+	s.authorizer.EnvironManager = false
+
+	err := s.State.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("1"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := s.api.RemoveAttachment(params.MachineStorageIds{
+		Ids: []params.MachineStorageId{{
+			MachineTag:    "machine-0",
+			AttachmentTag: "volume-0-0",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "volume-1",
+		}, {
+			MachineTag:    "machine-2",
+			AttachmentTag: "volume-4",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "volume-42",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: &params.Error{Message: "removing attachment of volume 0/0 from machine 0: volume attachment is not dying"}},
+			{Error: nil},
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{`removing attachment of volume 42 from machine 0: volume "42" on machine "0" not found`, "not found"}},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestRemoveFilesystemAttachments(c *gc.C) {
+	s.setupFilesystems(c)
+	s.authorizer.EnvironManager = false
+
+	err := s.State.DetachFilesystem(names.NewMachineTag("0"), names.NewFilesystemTag("1"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := s.api.RemoveAttachment(params.MachineStorageIds{
+		Ids: []params.MachineStorageId{{
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-0-0",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-1",
+		}, {
+			MachineTag:    "machine-2",
+			AttachmentTag: "filesystem-4",
+		}, {
+			MachineTag:    "machine-0",
+			AttachmentTag: "filesystem-42",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: &params.Error{Message: "removing attachment of filesystem 0/0 from machine 0: filesystem attachment is not dying"}},
+			{Error: nil},
+			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{`removing attachment of filesystem 42 from machine 0: filesystem "42" on machine "0" not found`, "not found"}},
+		},
+	})
+}
+
 type byMachineAndEntity []params.MachineStorageId
 
 func (b byMachineAndEntity) Len() int {


### PR DESCRIPTION
Implement the RemoveAttachment method in the
apiserver/storageprovisioner API server facade.
The client side is in place, and is hooked up
in the worker; it just hasn't been triggered
due to missing lifecycle support, which will
be landing soon.

Also, some related changes to
Remove{Volume,Filesystem}Attachment in state,
to return a NotFound error if the attachment
isn't found initially.

(Review request: http://reviews.vapour.ws/r/2017/)