### PR TITLE
storage: loop creates Persistent volumes in LXC

### DIFF
--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -18,8 +18,8 @@ var (
 	RestartSymlink          = restartSymlink
 	ReleaseVersion          = &releaseVersion
 	PreferFastLXC           = preferFastLXC
-	InitProcessCgroupFile   = &initProcessCgroupFile
 	RuntimeGOOS             = &runtimeGOOS
+	RunningInsideLXC        = &runningInsideLXC
 )
 
 func GetCreateWithCloneValue(mgr container.Manager) bool {

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -43,6 +43,7 @@ var (
 	LxcRestartDir    = "/etc/lxc/auto"
 	LxcObjectFactory = golxc.Factory()
 	runtimeGOOS      = runtime.GOOS
+	runningInsideLXC = lxcutils.RunningInsideLXC
 )
 
 const (
@@ -88,7 +89,7 @@ func IsLXCSupported() (bool, error) {
 		return false, nil
 	}
 	// We do not support running nested LXC containers.
-	insideLXC, err := lxcutils.RunningInsideLXC()
+	insideLXC, err := runningInsideLXC()
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -1256,7 +1256,7 @@ func (s *LxcSuite) TestIsLXCSupportedMalformedCgroupFile(c *gc.C) {
 
 	s.PatchValue(lxc.InitProcessCgroupFile, cgroup)
 	supports, err := lxc.IsLXCSupported()
-	c.Assert(err.Error(), gc.Equals, "Malformed cgroup file")
+	c.Assert(err.Error(), gc.Equals, "malformed cgroup file")
 	c.Assert(supports, jc.IsFalse)
 }
 

--- a/container/lxc/lxcutils/export_test.go
+++ b/container/lxc/lxcutils/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxcutils
+
+var (
+	InitProcessCgroupFile = &initProcessCgroupFile
+)

--- a/container/lxc/lxcutils/lxcutils_test.go
+++ b/container/lxc/lxcutils/lxcutils_test.go
@@ -1,0 +1,98 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxcutils_test
+
+import (
+	"path/filepath"
+	"runtime"
+	stdtesting "testing"
+
+	jc "github.com/juju/testing/checkers"
+	ft "github.com/juju/testing/filetesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/container/lxc/lxcutils"
+	"github.com/juju/juju/testing"
+)
+
+func Test(t *stdtesting.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("LXC is a Linux thing")
+	}
+	gc.TestingT(t)
+}
+
+type LxcUtilsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&LxcUtilsSuite{})
+
+var lxcCgroupContents = `11:hugetlb:/lxc/juju-machine-1-lxc-0
+10:perf_event:/lxc/juju-machine-1-lxc-0
+9:blkio:/lxc/juju-machine-1-lxc-0
+8:freezer:/lxc/juju-machine-1-lxc-0
+7:devices:/lxc/juju-machine-1-lxc-0
+6:memory:/lxc/juju-machine-1-lxc-0
+5:cpuacct:/lxc/juju-machine-1-lxc-0
+4:cpu:/lxc/juju-machine-1-lxc-0
+3:cpuset:/lxc/juju-machine-1-lxc-0
+2:name=systemd:/lxc/juju-machine-1-lxc-0
+`
+
+var hostCgroupContents = `11:hugetlb:/
+10:perf_event:/
+9:blkio:/
+8:freezer:/
+7:devices:/
+6:memory:/
+5:cpuacct:/
+4:cpu:/
+3:cpuset:/
+2:name=systemd:/
+`
+
+var malformedCgroupFile = `some bogus content
+more bogus content`
+
+func (s *LxcUtilsSuite) TestRunningInsideLXCOnHost(c *gc.C) {
+	baseDir := c.MkDir()
+	cgroup := filepath.Join(baseDir, "cgroup")
+
+	ft.File{"cgroup", hostCgroupContents, 0400}.Create(c, baseDir)
+
+	s.PatchValue(lxcutils.InitProcessCgroupFile, cgroup)
+	runningInLXC, err := lxcutils.RunningInsideLXC()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(runningInLXC, jc.IsFalse)
+}
+
+func (s *LxcUtilsSuite) TestRunningInsideLXCOnLXCContainer(c *gc.C) {
+	baseDir := c.MkDir()
+	cgroup := filepath.Join(baseDir, "cgroup")
+
+	ft.File{"cgroup", lxcCgroupContents, 0400}.Create(c, baseDir)
+
+	s.PatchValue(lxcutils.InitProcessCgroupFile, cgroup)
+	runningInLXC, err := lxcutils.RunningInsideLXC()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(runningInLXC, jc.IsTrue)
+}
+
+func (s *LxcUtilsSuite) TestRunningInsideLXCMissingCgroupFile(c *gc.C) {
+	s.PatchValue(lxcutils.InitProcessCgroupFile, "")
+	_, err := lxcutils.RunningInsideLXC()
+	c.Assert(err.Error(), gc.Matches, "open : no such file or directory")
+}
+
+func (s *LxcUtilsSuite) TestRunningInsideLXCMalformedCgroupFile(c *gc.C) {
+	baseDir := c.MkDir()
+	cgroup := filepath.Join(baseDir, "cgroup")
+
+	ft.File{"cgroup", malformedCgroupFile, 0400}.Create(c, baseDir)
+
+	s.PatchValue(lxcutils.InitProcessCgroupFile, cgroup)
+	_, err := lxcutils.RunningInsideLXC()
+	c.Assert(err.Error(), gc.Equals, "malformed cgroup file")
+}

--- a/container/lxc/lxcutils/utils.go
+++ b/container/lxc/lxcutils/utils.go
@@ -1,0 +1,41 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxcutils
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// RunningInsideLXC reports whether or not we are running inside an
+// LXC container.
+func RunningInsideLXC() (bool, error) {
+	const initProcessCgroupFile = "/proc/1/cgroup"
+	file, err := os.Open(initProcessCgroupFile)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Split(line, ":")
+		if len(fields) != 3 {
+			return false, errors.Errorf("malformed cgroup file")
+		}
+		if fields[2] != "/" {
+			// When running in a container the anchor point will be
+			// something other than "/".
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, errors.Annotate(err, "failed to read cgroup file")
+	}
+	return false, nil
+}

--- a/container/lxc/lxcutils/utils.go
+++ b/container/lxc/lxcutils/utils.go
@@ -11,10 +11,11 @@ import (
 	"github.com/juju/errors"
 )
 
+var initProcessCgroupFile = "/proc/1/cgroup"
+
 // RunningInsideLXC reports whether or not we are running inside an
 // LXC container.
 func RunningInsideLXC() (bool, error) {
-	const initProcessCgroupFile = "/proc/1/cgroup"
 	file, err := os.Open(initProcessCgroupFile)
 	if err != nil {
 		return false, errors.Trace(err)

--- a/storage/provider/common.go
+++ b/storage/provider/common.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/container/lxc/lxcutils"
 	"github.com/juju/juju/storage"
 )
 
@@ -14,7 +15,7 @@ var errNoMountPoint = errors.New("filesystem mount point not specified")
 // CommonProviders returns the storage providers used by all environments.
 func CommonProviders() map[storage.ProviderType]storage.Provider {
 	return map[storage.ProviderType]storage.Provider{
-		LoopProviderType:   &loopProvider{logAndExec},
+		LoopProviderType:   &loopProvider{logAndExec, lxcutils.RunningInsideLXC},
 		RootfsProviderType: &rootfsProvider{logAndExec},
 		TmpfsProviderType:  &tmpfsProvider{logAndExec},
 	}

--- a/storage/provider/export_test.go
+++ b/storage/provider/export_test.go
@@ -16,16 +16,23 @@ import (
 
 var Getpagesize = &getpagesize
 
-func LoopVolumeSource(storageDir string, run func(string, ...string) (string, error)) (storage.VolumeSource, *MockDirFuncs) {
+func LoopVolumeSource(
+	storageDir string,
+	run func(string, ...string) (string, error),
+	insideLXC bool,
+) (storage.VolumeSource, *MockDirFuncs) {
 	dirFuncs := &MockDirFuncs{
 		osDirFuncs{run},
 		set.NewStrings(),
 	}
-	return &loopVolumeSource{dirFuncs, run, storageDir}, dirFuncs
+	return &loopVolumeSource{dirFuncs, run, storageDir, insideLXC}, dirFuncs
 }
 
-func LoopProvider(run func(string, ...string) (string, error)) storage.Provider {
-	return &loopProvider{run}
+func LoopProvider(
+	run func(string, ...string) (string, error),
+	insideLXC func() (bool, error),
+) storage.Provider {
+	return &loopProvider{run, insideLXC}
 }
 
 func NewMockManagedFilesystemSource(

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -25,8 +25,11 @@ const (
 
 // loopProviders create volume sources which use loop devices.
 type loopProvider struct {
-	// run is a function type used for running commands on the local machine.
+	// run is a function used for running commands on the local machine.
 	run runCommandFunc
+	// runningInsideLXC is a function that determines whether or not
+	// the code is running within an LXC container.
+	runningInsideLXC func() (bool, error)
 }
 
 var _ storage.Provider = (*loopProvider)(nil)
@@ -59,12 +62,17 @@ func (lp *loopProvider) VolumeSource(
 	if err := lp.validateFullConfig(sourceConfig); err != nil {
 		return nil, err
 	}
+	insideLXC, err := lp.runningInsideLXC()
+	if err != nil {
+		return nil, err
+	}
 	// storageDir is validated by validateFullConfig.
 	storageDir, _ := sourceConfig.ValueString(storage.ConfigStorageDir)
 	return &loopVolumeSource{
 		&osDirFuncs{lp.run},
 		lp.run,
 		storageDir,
+		insideLXC,
 	}, nil
 }
 
@@ -94,9 +102,10 @@ func (*loopProvider) Dynamic() bool {
 // loopVolumeSource provides common functionality to handle
 // loop devices for rootfs and host loop volume sources.
 type loopVolumeSource struct {
-	dirFuncs   dirFuncs
-	run        runCommandFunc
-	storageDir string
+	dirFuncs         dirFuncs
+	run              runCommandFunc
+	storageDir       string
+	runningInsideLXC bool
 }
 
 var _ storage.VolumeSource = (*loopVolumeSource)(nil)
@@ -128,6 +137,10 @@ func (lvs *loopVolumeSource) createVolume(params storage.VolumeParams) (storage.
 		storage.VolumeInfo{
 			VolumeId: volumeId,
 			Size:     params.Size,
+			// Loop devices may outlive LXC containers. If we're
+			// running inside an LXC container, mark the volume as
+			// persistent.
+			Persistent: lvs.runningInsideLXC,
 		},
 	}, nil
 }


### PR DESCRIPTION
The loop storage provider will now mark volumes
as Persistent when used within an LXC container,
including the local provider. This is necessary
to ensure that containers are not destroyed until
the loop devices are detached, since they will
outlive the container.

A new lxcutil package has been introduced, with
a single function extracted from container/lxc.
This is necessary to prevent an import cycle.

(Review request: http://reviews.vapour.ws/r/2018/)