### PR TITLE
Cloudimagesurlfix

### DIFF
--- a/api/service/client_test.go
+++ b/api/service/client_test.go
@@ -88,14 +88,14 @@ func (s *serviceSuite) TestSetServiceDeploy(c *gc.C) {
 		c.Assert(args.Services[0].Constraints, gc.DeepEquals, constraints.MustParse("mem=4G"))
 		c.Assert(args.Services[0].ToMachineSpec, gc.Equals, "machineSpec")
 		c.Assert(args.Services[0].Networks, gc.DeepEquals, []string{"neta"})
-		c.Assert(args.Services[0].Storage, gc.DeepEquals, map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}})
+		c.Assert(args.Services[0].Storage, gc.DeepEquals, map[string]storage.Constraints{"data": {Pool: "pool"}})
 
 		result := response.(*params.ErrorResults)
 		result.Results = make([]params.ErrorResult, 1)
 		return nil
 	})
 	err := s.client.ServiceDeploy("charmURL", "serviceA", 2, "configYAML", constraints.MustParse("mem=4G"),
-		"machineSpec", []string{"neta"}, map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}})
+		"machineSpec", []string{"neta"}, map[string]storage.Constraints{"data": {Pool: "pool"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -49,17 +49,17 @@ func (s *storageMockSuite) TestShow(c *gc.C) {
 
 			if results, k := result.(*params.StorageDetailsResults); k {
 				instances := []params.StorageDetailsResult{
-					params.StorageDetailsResult{
+					{
 						Result: params.StorageDetails{StorageTag: oneTag.String()},
 					},
-					params.StorageDetailsResult{
+					{
 						Result: params.StorageDetails{
 							StorageTag: twoTag.String(),
 							Status:     "attached",
 							Persistent: true,
 						},
 					},
-					params.StorageDetailsResult{Error: common.ServerError(errors.New(msg))},
+					{Error: common.ServerError(errors.New(msg))},
 				}
 				results.Results = instances
 			}
@@ -118,11 +118,11 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 
 			if results, k := result.(*params.StorageInfosResult); k {
 				instances := []params.StorageInfo{
-					params.StorageInfo{
+					{
 						params.StorageDetails{StorageTag: oneTag.String()},
 						common.ServerError(errors.New(msg)),
 					},
-					params.StorageInfo{
+					{
 						params.StorageDetails{
 							StorageTag: twoTag.String(),
 							Status:     "attached",
@@ -141,12 +141,12 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 2)
 	expected := []params.StorageInfo{
-		params.StorageInfo{
+		{
 			StorageDetails: params.StorageDetails{
 				StorageTag: "storage-shared-fs-0"},
 			Error: &params.Error{Message: msg},
 		},
-		params.StorageInfo{
+		{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				Status:     "attached",
@@ -179,9 +179,9 @@ func (s *storageMockSuite) TestListFacadeCallError(c *gc.C) {
 
 func (s *storageMockSuite) TestListPools(c *gc.C) {
 	expected := []params.StoragePool{
-		params.StoragePool{Name: "name0", Provider: "type0"},
-		params.StoragePool{Name: "name1", Provider: "type1"},
-		params.StoragePool{Name: "name2", Provider: "type2"},
+		{Name: "name0", Provider: "type0"},
+		{Name: "name1", Provider: "type1"},
+		{Name: "name2", Provider: "type2"},
 	}
 	want := len(expected)
 
@@ -325,7 +325,7 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 					MachineTag: m}
 			}
 			results.Results = []params.VolumeItem{
-				params.VolumeItem{Attachments: attachments},
+				{Attachments: attachments},
 			}
 			return nil
 		})
@@ -400,9 +400,9 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 
 	errOut := "error"
 	unitStorages := []params.StorageAddParams{
-		params.StorageAddParams{UnitTag: "u-a", StorageName: "one", Constraints: cons},
-		params.StorageAddParams{UnitTag: "u-b", StorageName: errOut, Constraints: cons},
-		params.StorageAddParams{UnitTag: "u-b", StorageName: "nil-constraints"},
+		{UnitTag: "u-a", StorageName: "one", Constraints: cons},
+		{UnitTag: "u-b", StorageName: errOut, Constraints: cons},
+		{UnitTag: "u-b", StorageName: "nil-constraints"},
 	}
 
 	storageN := 3
@@ -454,7 +454,7 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 
 func (s *storageMockSuite) TestAddToUnitFacadeCallError(c *gc.C) {
 	unitStorages := []params.StorageAddParams{
-		params.StorageAddParams{UnitTag: "u-a", StorageName: "one"},
+		{UnitTag: "u-a", StorageName: "one"},
 	}
 
 	msg := "facade failure"

--- a/api/uniter/unitstorage_test.go
+++ b/api/uniter/unitstorage_test.go
@@ -30,8 +30,8 @@ func (s *unitStorageSuite) createTestUnit(c *gc.C, t string, apiCaller basetesti
 func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 	count := uint64(1)
 	args := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{
-			params.StorageConstraints{Count: &count}},
+		"data": {
+			{Count: &count}},
 	}
 
 	expected := params.StoragesAddParams{
@@ -62,7 +62,7 @@ func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 func (s *unitStorageSuite) TestAddUnitStorageError(c *gc.C) {
 	count := uint64(1)
 	args := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{params.StorageConstraints{Count: &count}},
+		"data": {{Count: &count}},
 	}
 
 	expected := params.StoragesAddParams{

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -86,12 +86,12 @@ func (*statusGetterSuite) TestServiceStatus(c *gc.C) {
 				},
 				statusError: nil,
 				unitsStatus: map[string]state.StatusInfo{
-					"unit-x-1": state.StatusInfo{
+					"unit-x-1": {
 						Status:  state.StatusActive,
 						Message: "foo",
 						Since:   &now,
 					},
-					"unit-x-2": state.StatusInfo{
+					"unit-x-2": {
 						Status:  state.StatusActive,
 						Message: "foo 2",
 						Since:   &now,
@@ -104,7 +104,7 @@ func (*statusGetterSuite) TestServiceStatus(c *gc.C) {
 
 	expected := params.ServiceStatusResults{
 		Results: []params.ServiceStatusResult{
-			params.ServiceStatusResult{
+			{
 				Service: params.StatusResult{
 					Error:  nil,
 					Id:     "",
@@ -115,7 +115,7 @@ func (*statusGetterSuite) TestServiceStatus(c *gc.C) {
 					Since:  &now,
 				},
 				Units: map[string]params.StatusResult{
-					"unit-x-1": params.StatusResult{
+					"unit-x-1": {
 						Error:  nil,
 						Id:     "",
 						Life:   "",
@@ -124,7 +124,7 @@ func (*statusGetterSuite) TestServiceStatus(c *gc.C) {
 						Data:   nil,
 						Since:  &now,
 					},
-					"unit-x-2": params.StatusResult{
+					"unit-x-2": {
 						Error:  nil,
 						Id:     "",
 						Life:   "",
@@ -143,7 +143,7 @@ func (*statusGetterSuite) TestServiceStatus(c *gc.C) {
 
 	args := params.Entities{
 		Entities: []params.Entity{
-			params.Entity{
+			{
 				Tag: "unit-x-1",
 			},
 		},
@@ -176,12 +176,12 @@ func (*statusGetterSuite) TestServiceStatusNotLeader(c *gc.C) {
 				},
 				statusError: nil,
 				unitsStatus: map[string]state.StatusInfo{
-					"unit-x-1": state.StatusInfo{
+					"unit-x-1": {
 						Status:  state.StatusActive,
 						Message: "foo",
 						Since:   &now,
 					},
-					"unit-x-2": state.StatusInfo{
+					"unit-x-2": {
 						Status:  state.StatusActive,
 						Message: "foo 2",
 						Since:   &now,
@@ -210,7 +210,7 @@ func (*statusGetterSuite) TestServiceStatusNotLeader(c *gc.C) {
 	}
 	args := params.Entities{
 		Entities: []params.Entity{
-			params.Entity{
+			{
 				Tag: "unit-x-1",
 			},
 		},

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -237,7 +237,7 @@ func (s *serviceSuite) TestClientServiceDeployWithInvalidStoragePool(c *gc.C) {
 	setupStoragePool(c, s.State)
 	curl, _ := s.UploadCharm(c, "utopic/storage-block-0", "storage-block")
 	storageConstraints := map[string]storage.Constraints{
-		"data": storage.Constraints{
+		"data": {
 			Pool:  "foo",
 			Count: 1,
 			Size:  1024,
@@ -268,7 +268,7 @@ func (s *serviceSuite) TestClientServiceDeployWithUnsupportedStoragePool(c *gc.C
 
 	curl, _ := s.UploadCharm(c, "utopic/storage-block-0", "storage-block")
 	storageConstraints := map[string]storage.Constraints{
-		"data": storage.Constraints{
+		"data": {
 			Pool:  "host-loop-pool",
 			Count: 1,
 			Size:  1024,

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -122,7 +122,7 @@ func (api *API) createStorageDetailsResult(
 ) []params.StorageDetailsResult {
 	attachments, err := api.getStorageAttachments(storageTag, instance)
 	if err != nil {
-		return []params.StorageDetailsResult{params.StorageDetailsResult{Result: instance, Error: err}}
+		return []params.StorageDetailsResult{{Result: instance, Error: err}}
 	}
 	if len(attachments) > 0 {
 		// If any attachments were found for this storage instance,
@@ -134,7 +134,7 @@ func (api *API) createStorageDetailsResult(
 		return result
 	}
 	// If we are here then this storage instance is unattached.
-	return []params.StorageDetailsResult{params.StorageDetailsResult{Result: instance}}
+	return []params.StorageDetailsResult{{Result: instance}}
 }
 
 func (api *API) getStorageAttachments(

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -104,7 +104,7 @@ func (s *volumeSuite) TestGetVolumeItems(c *gc.C) {
 	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []params.VolumeItem{
-		params.VolumeItem{
+		{
 			Volume:      expectedVolume,
 			Attachments: storage.ConvertStateVolumeAttachmentsToParams(attachments)},
 	}

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -326,7 +326,7 @@ func (s *storageSuite) TestAddUnitStorageConstraintsErrors(c *gc.C) {
 		c.Assert(u, gc.DeepEquals, unitTag0)
 
 		return map[string]state.StorageConstraints{
-			storageName0: state.StorageConstraints{},
+			storageName0: {},
 		}, nil
 	})
 
@@ -413,12 +413,12 @@ func (s *storageSuite) TestAddUnitStorage(c *gc.C) {
 		c.Assert(u, gc.DeepEquals, unitTag0)
 
 		return map[string]state.StorageConstraints{
-			storageName0: state.StorageConstraints{
+			storageName0: {
 				Pool:  unitPool,
 				Size:  unitSize,
 				Count: unitCount,
 			},
-			storageName1: state.StorageConstraints{},
+			storageName1: {},
 		}, nil
 	})
 

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -198,7 +198,7 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 
 	var pkgsWithTargetRelease []string
 	pkgs := cfg.Packages()
-	for i, _ := range pkgs {
+	for i := range pkgs {
 		pack := pkgs[i]
 		if pack == "--target-release" || len(pkgsWithTargetRelease) > 0 {
 			// We have --target-release foo/bar package. Accumulate

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -146,7 +146,7 @@ func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 		outcmds := out["bootcmd"].([]interface{})
 		confcmds := cloudConf.BootCmds()
 		c.Assert(len(outcmds), gc.Equals, len(confcmds))
-		for i, _ := range outcmds {
+		for i := range outcmds {
 			c.Assert(outcmds[i].(string), gc.Equals, confcmds[i])
 		}
 	} else {

--- a/cmd/juju/block/export_test.go
+++ b/cmd/juju/block/export_test.go
@@ -38,7 +38,7 @@ func (c *MockBlockClient) List() ([]params.Block, error) {
 	}
 
 	return []params.Block{
-		params.Block{
+		{
 			Type:    c.BlockType,
 			Message: c.Msg,
 		},

--- a/cmd/juju/bootstrap.go
+++ b/cmd/juju/bootstrap.go
@@ -284,7 +284,7 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	ctx.InterruptNotify(interrupted)
 	defer ctx.StopInterruptNotify(interrupted)
 	go func() {
-		for _ = range interrupted {
+		for range interrupted {
 			ctx.Infof("Interrupt signalled: waiting for bootstrap to exit")
 		}
 	}()
@@ -403,7 +403,7 @@ func handleBootstrapError(ctx *cmd.Context, err error, cleanup func()) {
 	defer ctx.StopInterruptNotify(ch)
 	defer close(ch)
 	go func() {
-		for _ = range ch {
+		for range ch {
 			fmt.Fprintln(ctx.GetStderr(), "Cleaning up failed bootstrap")
 		}
 	}()

--- a/cmd/juju/plugin.go
+++ b/cmd/juju/plugin.go
@@ -180,7 +180,7 @@ func GetPluginDescriptions() []PluginDescription {
 	}
 	resultMap := map[string]PluginDescription{}
 	// gather the results at the end
-	for _ = range plugins {
+	for range plugins {
 		result := <-description
 		resultMap[result.name] = result
 	}

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -3072,9 +3072,9 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 	status := formattedStatus{
 		Services: map[string]serviceStatus{
-			"foo": serviceStatus{
+			"foo": {
 				Units: map[string]unitStatus{
-					"foo/0": unitStatus{
+					"foo/0": {
 						AgentStatusInfo: statusInfoContents{
 							Current: params.StatusExecuting,
 							Message: "running config-changed hook",
@@ -3084,7 +3084,7 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 							Message: "doing some work",
 						},
 					},
-					"foo/1": unitStatus{
+					"foo/1": {
 						AgentStatusInfo: statusInfoContents{
 							Current: params.StatusExecuting,
 							Message: "running action backup database",

--- a/container/image.go
+++ b/container/image.go
@@ -73,7 +73,7 @@ func ImageDownloadURL(kind instance.ContainerType, series, arch string) (string,
 	// This will be somewhere on http://cloud-images.ubuntu.com.
 	cmd := exec.Command("ubuntu-cloudimg-query", series, "released", arch, "--format", "%{url}")
 	// TODO should pass the image-metadata-url parameter
-	cmd.Env = []string{"UBUNTU_CLOUDIMG_QUERY_BASEURL=http://cloud-images.ubuntu.com/query"} 
+	cmd.Env = []string{"UBUNTU_CLOUDIMG_QUERY_BASEURL=http://cloud-images.ubuntu.com/query"}
 	urlBytes, err := cmd.CombinedOutput()
 	if err != nil {
 		stderr := string(urlBytes)

--- a/container/image.go
+++ b/container/image.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	
-//	"github.com/juju/juju/environs"
+
+	//	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 )
 

--- a/container/image.go
+++ b/container/image.go
@@ -10,7 +10,8 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-
+	
+//	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 )
 
@@ -68,12 +69,16 @@ func ImageDownloadURL(kind instance.ContainerType, series, arch string) (string,
 	if kind != instance.LXC {
 		return "", errors.Errorf("unsupported container type: %v", kind)
 	}
+	// sources is supposed to be imamge-metadata-url param
+	//Add configured and environment-specific datasources.
+
+	//sources, err := environs.ImageMetadataSources(env)
 
 	// Use the ubuntu-cloudimg-query command to get the url from which to fetch the image.
 	// This will be somewhere on http://cloud-images.ubuntu.com.
 	cmd := exec.Command("ubuntu-cloudimg-query", series, "released", arch, "--format", "%{url}")
-	// TODO should pass the image-metadata-url parameter
 	cmd.Env = []string{"UBUNTU_CLOUDIMG_QUERY_BASEURL=http://cloud-images.ubuntu.com/query"}
+
 	urlBytes, err := cmd.CombinedOutput()
 	if err != nil {
 		stderr := string(urlBytes)

--- a/container/image.go
+++ b/container/image.go
@@ -72,6 +72,8 @@ func ImageDownloadURL(kind instance.ContainerType, series, arch string) (string,
 	// Use the ubuntu-cloudimg-query command to get the url from which to fetch the image.
 	// This will be somewhere on http://cloud-images.ubuntu.com.
 	cmd := exec.Command("ubuntu-cloudimg-query", series, "released", arch, "--format", "%{url}")
+	// TODO should pass the image-metadata-url parameter
+	cmd.Env = []string{"UBUNTU_CLOUDIMG_QUERY_BASEURL=http://cloud-images.ubuntu.com/query"} 
 	urlBytes, err := cmd.CombinedOutput()
 	if err != nil {
 		stderr := string(urlBytes)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -3,7 +3,6 @@ github.com/altoros/gosigma	git	31228935eec685587914528585da4eb9b073c76d	2015-04-
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
 github.com/coreos/go-systemd	git	2d21675230a81a503f4363f4aa3490af06d52bb8	2015-01-26T19:09:17Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
-github.com/gabriel-samfira/sys	git	9ddc60d56b511544223adecea68da1e4f2153beb	2015-06-08T13:21:19Z
 github.com/godbus/dbus	git	88765d85c0fdadcd98a54e30694fa4e4f5b51133	2015-01-22T18:02:51Z
 github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
@@ -25,9 +24,9 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-3
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-30T01:12:23Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
-github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T10:32:42Z
+github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T04:40:43Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	16d187c1d8218c9b97bdbb8a17ff31705f72c1cf	2015-05-26T23:59:59Z
+github.com/juju/utils	git	16d187c1d8218c9b97bdbb8a17ff31705f72c1cf	2015-06-04T15:55:21Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -180,7 +180,7 @@ func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
 		c.Assert(f.Number.Patch, gc.Equals, 12)
 		findToolsCalled++
 		return []*tools.Tools{
-			&tools.Tools{
+			{
 				Version: currentVersion,
 				URL:     "http://testing.invalid/tools.tar.gz",
 			},

--- a/environs/config_test.go
+++ b/environs/config_test.go
@@ -245,7 +245,7 @@ func (s *suite) TestConfigPerm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	oldPerm := info.Mode().Perm()
 	env := `
-environments:
+environments:.
     only:
         type: dummy
         state-server: false

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -567,7 +567,7 @@ func newMachineToolWaiter(m *state.Machine) *toolsWaiter {
 		tooler:  m,
 	}
 	go func() {
-		for _ = range w.Changes() {
+		for range w.Changes() {
 			waiter.changes <- struct{}{}
 		}
 		close(waiter.changes)
@@ -583,7 +583,7 @@ func newUnitToolWaiter(u *state.Unit) *toolsWaiter {
 		tooler:  u,
 	}
 	go func() {
-		for _ = range w.Changes() {
+		for range w.Changes() {
 			waiter.changes <- struct{}{}
 		}
 		close(waiter.changes)
@@ -598,7 +598,7 @@ func (w *toolsWaiter) Stop() error {
 // NextTools returns the next changed tools, waiting
 // until the tools are actually set.
 func (w *toolsWaiter) NextTools(c *gc.C) (*coretools.Tools, error) {
-	for _ = range w.changes {
+	for range w.changes {
 		err := w.tooler.Refresh()
 		if err != nil {
 			return nil, fmt.Errorf("cannot refresh: %v", err)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -348,7 +348,7 @@ func installMongod(numaCtl bool) error {
 		logger.Infof("installing %s", mongoPkg)
 	}
 
-	for i, _ := range pkgs {
+	for i := range pkgs {
 		// apply release targeting if needed.
 		if pacconfer.IsCloudArchivePackage(pkgs[i]) {
 			pkgs[i] = strings.Join(pacconfer.ApplyCloudArchiveTarget(pkgs[i]), " ")

--- a/provider/cloudsigma/constraints_test.go
+++ b/provider/cloudsigma/constraints_test.go
@@ -26,21 +26,21 @@ type strv struct{ v string }
 type uint64v struct{ v uint64 }
 
 var defConstraints = map[string]sigmaConstraints{
-	"bootstrap-trusty": sigmaConstraints{
+	"bootstrap-trusty": {
 		driveTemplate: validImageId,
 		driveSize:     5 * gosigma.Gigabyte,
 		cores:         1,
 		power:         2000,
 		mem:           2 * gosigma.Gigabyte,
 	},
-	"trusty": sigmaConstraints{
+	"trusty": {
 		driveTemplate: validImageId,
 		driveSize:     0,
 		cores:         1,
 		power:         2000,
 		mem:           2 * gosigma.Gigabyte,
 	},
-	"trusty-c2-p4000": sigmaConstraints{
+	"trusty-c2-p4000": {
 		driveTemplate: validImageId,
 		driveSize:     0,
 		cores:         2,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -288,7 +288,7 @@ func init() {
 	// the testing environment by simply importing it.
 	c := make(chan Operation)
 	go func() {
-		for _ = range c {
+		for range c {
 		}
 	}()
 	discardOperations = c

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -540,7 +540,7 @@ func (v *ebsVolumeSource) instances(instIds []string) (map[string]ec2.Instance, 
 	// TODO(wallyworld) - retry to allow instances to get to running state.
 	if len(instances) < len(instIds) {
 		notRunning := set.NewStrings(instIds...)
-		for id, _ := range instances {
+		for id := range instances {
 			notRunning.Remove(id)
 		}
 		return nil, errors.Errorf(

--- a/provider/gce/google/conn_instance_test.go
+++ b/provider/gce/google/conn_instance_test.go
@@ -264,7 +264,7 @@ func (s *connSuite) TestConnectionRemoveInstancesAPI(c *gc.C) {
 func (s *connSuite) TestConnectionRemoveInstancesMultiple(c *gc.C) {
 	s.FakeConn.Instances = []*compute.Instance{
 		&s.RawInstanceFull,
-		&compute.Instance{
+		{
 			Name: "special",
 			Zone: "a-zone",
 		},
@@ -288,7 +288,7 @@ func (s *connSuite) TestConnectionRemoveInstancesMultiple(c *gc.C) {
 func (s *connSuite) TestConnectionRemoveInstancesPartialMatch(c *gc.C) {
 	s.FakeConn.Instances = []*compute.Instance{
 		&s.RawInstanceFull,
-		&compute.Instance{
+		{
 			Name: "special",
 			Zone: "a-zone",
 		},

--- a/provider/vsphere/fake_methods_test.go
+++ b/provider/vsphere/fake_methods_test.go
@@ -262,12 +262,12 @@ func (s *BaseSuite) FakeCreateInstance(c *fakeClient, serverUrl string, checker 
 		resBody.Res = &types.WaitForUpdatesExResponse{
 			Returnval: &types.UpdateSet{
 				FilterSet: []types.PropertyFilterUpdate{
-					types.PropertyFilterUpdate{
+					{
 						ObjectSet: []types.ObjectUpdate{
-							types.ObjectUpdate{
+							{
 								Obj: powerOnTask,
 								ChangeSet: []types.PropertyChange{
-									types.PropertyChange{
+									{
 										Name: "info",
 										Op:   types.PropertyChangeOpAssign,
 										Val: types.TaskInfo{
@@ -299,7 +299,7 @@ func (s *BaseSuite) FakeImportOvf(c *fakeClient, serverUrl string, checker *gc.C
 		resBody.Res = &types.CreateImportSpecResponse{
 			Returnval: types.OvfCreateImportSpecResult{
 				FileItem: []types.OvfFileItem{
-					types.OvfFileItem{
+					{
 						DeviceId: "key1",
 						Path:     "ubuntu-14.04-server-cloudimg-amd64.vmdk",
 					},
@@ -341,23 +341,23 @@ func (s *BaseSuite) FakeImportOvf(c *fakeClient, serverUrl string, checker *gc.C
 		resBody.Res = &types.WaitForUpdatesExResponse{
 			Returnval: &types.UpdateSet{
 				FilterSet: []types.PropertyFilterUpdate{
-					types.PropertyFilterUpdate{
+					{
 						ObjectSet: []types.ObjectUpdate{
-							types.ObjectUpdate{
+							{
 								Obj: lease,
 								ChangeSet: []types.PropertyChange{
-									types.PropertyChange{
+									{
 										Name: "info",
 										Val: types.HttpNfcLeaseInfo{
 											DeviceUrl: []types.HttpNfcLeaseDeviceUrl{
-												types.HttpNfcLeaseDeviceUrl{
+												{
 													ImportKey: "key1",
 													Url:       serverUrl + "/disk-device/",
 												},
 											},
 										},
 									},
-									types.PropertyChange{
+									{
 										Name: "state",
 										Val:  types.HttpNfcLeaseStateReady,
 									},

--- a/provider/vsphere/ova_import_manager.go
+++ b/provider/vsphere/ova_import_manager.go
@@ -74,8 +74,8 @@ func (m *ovaImportManager) importOva(ecfg *environConfig, instSpec *instanceSpec
 	cisp := types.OvfCreateImportSpecParams{
 		EntityName: instSpec.machineID,
 		PropertyMapping: []types.KeyValue{
-			types.KeyValue{Key: "public-keys", Value: instSpec.sshKey},
-			types.KeyValue{Key: "user-data", Value: base64.StdEncoding.EncodeToString(instSpec.userData)},
+			{Key: "public-keys", Value: instSpec.sshKey},
+			{Key: "user-data", Value: base64.StdEncoding.EncodeToString(instSpec.userData)},
 		},
 	}
 

--- a/provider/vsphere/testing_test.go
+++ b/provider/vsphere/testing_test.go
@@ -178,13 +178,13 @@ var newFakeConnection = func(url *url.URL) (*govmomi.Client, error) {
 var CommonRetrieveProperties = func(resBody *methods.RetrievePropertiesBody, objType, objValue, propName string, propValue interface{}) {
 	resBody.Res = &types.RetrievePropertiesResponse{
 		Returnval: []types.ObjectContent{
-			types.ObjectContent{
+			{
 				Obj: types.ManagedObjectReference{
 					Type:  objType,
 					Value: objValue,
 				},
 				PropSet: []types.DynamicProperty{
-					types.DynamicProperty{Name: propName, Val: propValue},
+					{Name: propName, Val: propValue},
 				},
 			},
 		},
@@ -198,17 +198,17 @@ var RetrieveDatacenter = func(reqBody, resBody *methods.RetrievePropertiesBody) 
 var RetrieveDatacenterProperties = func(reqBody, resBody *methods.RetrievePropertiesBody) {
 	resBody.Res = &types.RetrievePropertiesResponse{
 		Returnval: []types.ObjectContent{
-			types.ObjectContent{
+			{
 				Obj: types.ManagedObjectReference{
 					Type:  "Datacenter",
 					Value: "FakeDatacenter",
 				},
 				PropSet: []types.DynamicProperty{
-					types.DynamicProperty{Name: "hostFolder", Val: types.ManagedObjectReference{
+					{Name: "hostFolder", Val: types.ManagedObjectReference{
 						Type:  "Folder",
 						Value: "FakeHostFolder",
 					}},
-					types.DynamicProperty{Name: "vmFolder", Val: types.ManagedObjectReference{
+					{Name: "vmFolder", Val: types.ManagedObjectReference{
 						Type:  "Folder",
 						Value: "FakeVmFolder",
 					}},

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1175,7 +1175,7 @@ func (s *assignCleanSuite) TestAssignUnitPolicy(c *gc.C) {
 
 	// Assign units to all the expectedMachines machines.
 	var got []string
-	for _ = range expectedMachines {
+	for range expectedMachines {
 		unit, err := s.wordpress.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
 		err = s.State.AssignUnit(unit, s.policy)
@@ -1280,7 +1280,7 @@ func (s *assignCleanSuite) TestAssignUnitPolicyConcurrently(c *gc.C) {
 		}()
 	}
 	assignments := make(map[string][]*state.Unit)
-	for _ = range us {
+	for range us {
 		r := <-done
 		if !c.Check(r.err, gc.IsNil) {
 			continue

--- a/state/block.go
+++ b/state/block.go
@@ -235,7 +235,7 @@ func removeEnvironmentBlockOps(st *State, t BlockType) ([]txn.Op, error) {
 		return nil, errors.Annotatef(err, "removing block %v", t.String())
 	}
 	if exists {
-		return []txn.Op{txn.Op{
+		return []txn.Op{{
 			C:      blocksC,
 			Id:     tBlock.Id(),
 			Remove: true,

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -38,7 +38,7 @@ func (s *FilesystemStateSuite) TestAddServiceNoPool(c *gc.C) {
 	cons, err := svc.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, map[string]state.StorageConstraints{
-		"data": state.StorageConstraints{
+		"data": {
 			Pool:  "rootfs",
 			Size:  1024,
 			Count: 1,

--- a/state/leadership/manager_block_test.go
+++ b/state/leadership/manager_block_test.go
@@ -32,7 +32,7 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipNotHeld(c *gc.C) {
 func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpires(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -59,7 +59,7 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpires(c *gc.C) {
 func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipChanged(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -89,7 +89,7 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipChanged(c *gc.C) {
 func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpiredEarly(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -116,11 +116,11 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpiredEarly(c *gc.C) 
 func (s *BlockUntilLeadershipReleasedSuite) TestMultiple(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
-			"store": lease.Info{
+			"store": {
 				Holder: "store/0",
 				Expiry: offset(time.Second),
 			},
@@ -167,7 +167,7 @@ func (s *BlockUntilLeadershipReleasedSuite) TestMultiple(c *gc.C) {
 func (s *BlockUntilLeadershipReleasedSuite) TestKillManager(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},

--- a/state/leadership/manager_check_test.go
+++ b/state/leadership/manager_check_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&CheckLeadershipSuite{})
 func (s *CheckLeadershipSuite) TestSuccess(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder:   "redis/0",
 				Expiry:   offset(time.Second),
 				AssertOp: txn.Op{C: "fake", Id: "fake"},

--- a/state/leadership/manager_claim_test.go
+++ b/state/leadership/manager_claim_test.go
@@ -98,7 +98,7 @@ func (s *ClaimLeadershipSuite) TestClaimLease_Failure_Error(c *gc.C) {
 func (s *ClaimLeadershipSuite) TestExtendLease_Success(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -117,7 +117,7 @@ func (s *ClaimLeadershipSuite) TestExtendLease_Success(c *gc.C) {
 func (s *ClaimLeadershipSuite) TestExtendLease_Success_Expired(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -143,7 +143,7 @@ func (s *ClaimLeadershipSuite) TestExtendLease_Success_Expired(c *gc.C) {
 func (s *ClaimLeadershipSuite) TestExtendLease_Failure_OtherHolder(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -169,7 +169,7 @@ func (s *ClaimLeadershipSuite) TestExtendLease_Failure_OtherHolder(c *gc.C) {
 func (s *ClaimLeadershipSuite) TestExtendLease_Failure_Error(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -192,7 +192,7 @@ func (s *ClaimLeadershipSuite) TestExtendLease_Failure_Error(c *gc.C) {
 func (s *ClaimLeadershipSuite) TestOtherHolder_Failure(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/1",
 				Expiry: offset(time.Second),
 			},

--- a/state/leadership/manager_expire_test.go
+++ b/state/leadership/manager_expire_test.go
@@ -24,7 +24,7 @@ var _ = gc.Suite(&ExpireLeadershipSuite{})
 func (s *ExpireLeadershipSuite) TestStartup_ExpiryInPast(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{Expiry: offset(-time.Second)},
+			"redis": {Expiry: offset(-time.Second)},
 		},
 		expectCalls: []call{{
 			method: "ExpireLease",
@@ -40,7 +40,7 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInPast(c *gc.C) {
 func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 	}
 	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *Clock) {
@@ -51,7 +51,7 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture(c *gc.C) {
 func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture_TimePasses(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
 			method: "ExpireLease",
@@ -69,7 +69,7 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture_TimePasses(c *gc.C) {
 func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Expired(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
 			method: "ExpireLease",
@@ -88,7 +88,7 @@ func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Expired(c *gc.C) {
 func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Updated(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
 			method: "ExpireLease",
@@ -107,7 +107,7 @@ func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Updated(c *gc.C) {
 func (s *ExpireLeadershipSuite) TestExpire_OtherError(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{Expiry: offset(time.Second)},
+			"redis": {Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
 			method: "ExpireLease",
@@ -174,7 +174,7 @@ func (s *ExpireLeadershipSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 func (s *ExpireLeadershipSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -201,7 +201,7 @@ func (s *ExpireLeadershipSuite) TestExtend_ExpiryInFuture(c *gc.C) {
 func (s *ExpireLeadershipSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
@@ -234,23 +234,23 @@ func (s *ExpireLeadershipSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 func (s *ExpireLeadershipSuite) TestExpire_Multiple(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
-			"redis": lease.Info{
+			"redis": {
 				Holder: "redis/0",
 				Expiry: offset(time.Second),
 			},
-			"store": lease.Info{
+			"store": {
 				Holder: "store/3",
 				Expiry: offset(5 * time.Second),
 			},
-			"tokumx": lease.Info{
+			"tokumx": {
 				Holder: "tokumx/5",
 				Expiry: offset(10 * time.Second), // will not expire.
 			},
-			"ultron": lease.Info{
+			"ultron": {
 				Holder: "ultron/7",
 				Expiry: offset(5 * time.Second),
 			},
-			"vvvvvv": lease.Info{
+			"vvvvvv": {
 				Holder: "vvvvvv/2",
 				Expiry: offset(time.Second), // would expire, but errors first.
 			},

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1065,7 +1065,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	c.Assert(err, gc.ErrorMatches, `cannot add network interface "" to machine "1": MAC address must be not empty`)
 	assertNotProvisioned()
 
-	invalidVolumes := map[names.VolumeTag]state.VolumeInfo{names.NewVolumeTag("1065"): state.VolumeInfo{}}
+	invalidVolumes := map[names.VolumeTag]state.VolumeInfo{names.NewVolumeTag("1065"): {}}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for volume \"1065\": volume \"1065\" not found`)
 	assertNotProvisioned()

--- a/state/storage.go
+++ b/state/storage.go
@@ -1179,8 +1179,8 @@ func (st *State) countEntityStorageInstancesForName(
 	defer closer()
 	criteria := bson.D{{
 		"$and", []bson.D{
-			bson.D{{"owner", tag.String()}},
-			bson.D{{"storagename", name}},
+			{{"owner", tag.String()}},
+			{{"storagename", name}},
 		},
 	}}
 	result, err := storageCollection.Find(criteria).Count()

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2738,9 +2738,9 @@ func (s *upgradesSuite) readDocIDs(c *gc.C, coll, regex string) []string {
 
 func (s *upgradesSuite) TestAddLeadershipSettingsDocs(c *gc.C) {
 	expectedDocIDs := s.prepareEnvsForLeadership(c, map[string][]string{
-		"": []string{"mediawiki", "postgresql"},
-		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"foobar"},
-		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"mysql"},
+		"": {"mediawiki", "postgresql"},
+		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": {"foobar"},
+		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": {"mysql"},
 	})
 
 	err := AddLeadershipSettingsDocs(s.state)
@@ -2773,9 +2773,9 @@ func (s *upgradesSuite) TestAddLeadershipSettingsMultipleEmpty(c *gc.C) {
 
 func (s *upgradesSuite) TestAddLeadershipSettingsIdempotent(c *gc.C) {
 	s.prepareEnvsForLeadership(c, map[string][]string{
-		"": []string{"mediawiki", "postgresql"},
-		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"foobar"},
-		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"mysql"},
+		"": {"mediawiki", "postgresql"},
+		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": {"foobar"},
+		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": {"mysql"},
 	})
 
 	originalIDs := s.readDocIDs(c, settingsC, ".+#leader$")
@@ -2832,9 +2832,9 @@ func (s *upgradesSuite) prepareEnvsForMachineBlockDevices(c *gc.C, envs map[stri
 
 func (s *upgradesSuite) TestAddBlockDevicesDocs(c *gc.C) {
 	expectedDocIDs := s.prepareEnvsForMachineBlockDevices(c, map[string][]string{
-		"": []string{"1", "2"},
-		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"1"},
-		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"1"},
+		"": {"1", "2"},
+		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": {"1"},
+		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": {"1"},
 	})
 
 	err := AddDefaultBlockDevicesDocs(s.state)
@@ -2867,9 +2867,9 @@ func (s *upgradesSuite) TestAddBlockDevicesDocsMultipleEmpty(c *gc.C) {
 
 func (s *upgradesSuite) TestAddBlockDevicesDocsIdempotent(c *gc.C) {
 	s.prepareEnvsForMachineBlockDevices(c, map[string][]string{
-		"": []string{"1", "2"},
-		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"1"},
-		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": []string{"1"},
+		"": {"1", "2"},
+		"6983ac70-b0aa-45c5-80fe-9f207bbb18d9": {"1"},
+		"7983ac70-b0aa-45c5-80fe-9f207bbb18d9": {"1"},
 	})
 
 	originalIDs := s.readDocIDs(c, blockDevicesC, "")

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -98,12 +98,12 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	cons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, map[string]state.StorageConstraints{
-		"data": state.StorageConstraints{
+		"data": {
 			Pool:  "loop",
 			Size:  1024,
 			Count: 1,
 		},
-		"allecto": state.StorageConstraints{
+		"allecto": {
 			Pool:  "loop",
 			Size:  1024,
 			Count: 0,
@@ -129,12 +129,12 @@ func (s *VolumeStateSuite) TestAddServiceDefaultPool(c *gc.C) {
 	cons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, jc.DeepEquals, map[string]state.StorageConstraints{
-		"data": state.StorageConstraints{
+		"data": {
 			Pool:  "default-block",
 			Size:  1024,
 			Count: 1,
 		},
-		"allecto": state.StorageConstraints{
+		"allecto": {
 			Pool:  "loop",
 			Size:  1024,
 			Count: 0,

--- a/storage/constraints_test.go
+++ b/storage/constraints_test.go
@@ -107,23 +107,23 @@ func (s *ConstraintsSuite) TestInvalidPoolName(c *gc.C) {
 func (s *ConstraintsSuite) TestParseStorageConstraints(c *gc.C) {
 	s.testParseStorageConstraints(c,
 		[]string{"data=p,1M,"}, true,
-		map[string]storage.Constraints{"data": storage.Constraints{
+		map[string]storage.Constraints{"data": {
 			Pool:  "p",
 			Count: 1,
 			Size:  1,
 		}})
 	s.testParseStorageConstraints(c,
 		[]string{"data"}, false,
-		map[string]storage.Constraints{"data": storage.Constraints{
+		map[string]storage.Constraints{"data": {
 			Count: 1,
 		}})
 	s.testParseStorageConstraints(c,
 		[]string{"data=3", "cache"}, false,
 		map[string]storage.Constraints{
-			"data": storage.Constraints{
+			"data": {
 				Count: 3,
 			},
-			"cache": storage.Constraints{
+			"cache": {
 				Count: 1,
 			},
 		})

--- a/upgrades/toolstorage_test.go
+++ b/upgrades/toolstorage_test.go
@@ -101,12 +101,12 @@ func (s *migrateToolsStorageSuite) testMigrateToolsStorage(c *gc.C, agentConfig 
 	err := upgrades.MigrateToolsStorage(s.State, agentConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeToolsStorage.stored, gc.DeepEquals, map[version.Binary]toolstorage.Metadata{
-		tools[0].Version: toolstorage.Metadata{
+		tools[0].Version: {
 			Version: tools[0].Version,
 			Size:    tools[0].Size,
 			SHA256:  tools[0].SHA256,
 		},
-		tools[1].Version: toolstorage.Metadata{
+		tools[1].Version: {
 			Version: tools[1].Version,
 			Size:    tools[1].Size,
 			SHA256:  tools[1].SHA256,

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -336,11 +336,11 @@ func (s *ContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 		packages [][]string
 	}{
 		{instance.LXC, [][]string{
-			[]string{"--target-release", "precise-updates/cloud-tools", "lxc"},
-			[]string{"--target-release", "precise-updates/cloud-tools", "cloud-image-utils"}}},
+			{"--target-release", "precise-updates/cloud-tools", "lxc"},
+			{"--target-release", "precise-updates/cloud-tools", "cloud-image-utils"}}},
 		{instance.KVM, [][]string{
-			[]string{"uvtool-libvirt"},
-			[]string{"uvtool"}}},
+			{"uvtool-libvirt"},
+			{"uvtool"}}},
 	} {
 		s.assertContainerInitialised(c, test.ctype, test.packages, false)
 	}

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -563,7 +563,7 @@ func configureContainerNetwork(
 		return nil, errors.Trace(err)
 	}
 	// Generate the final configuration for each container interface.
-	for i, _ := range finalIfaceInfo {
+	for i := range finalIfaceInfo {
 		// Always start at the first device index and generate the
 		// interface name based on that. We need to do this otherwise
 		// the container will inherit the host's device index and

--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -604,8 +604,8 @@ func (s *FilterSuite) TestMeterStatusEvents(c *gc.C) {
 func (s *FilterSuite) TestStorageEvents(c *gc.C) {
 	storageCharm := s.AddTestingCharm(c, "storage-block2")
 	svc := s.AddTestingServiceWithStorage(c, "storage-block2", storageCharm, map[string]state.StorageConstraints{
-		"multi1to10": state.StorageConstraints{Pool: "loop", Size: 1024, Count: 1},
-		"multi2up":   state.StorageConstraints{Pool: "loop", Size: 2048, Count: 2},
+		"multi1to10": {Pool: "loop", Size: 1024, Count: 1},
+		"multi2up":   {Pool: "loop", Size: 2048, Count: 2},
 	})
 	unit, err := svc.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -321,8 +321,8 @@ func (s *InterfaceSuite) TestRequestRebootNowNoProcess(c *gc.C) {
 
 func (s *InterfaceSuite) TestStorageAddConstraints(c *gc.C) {
 	expected := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{
-			params.StorageConstraints{},
+		"data": {
+			{},
 		},
 	}
 
@@ -335,9 +335,9 @@ var two = uint64(2)
 
 func (s *InterfaceSuite) TestStorageAddConstraintsSameStorage(c *gc.C) {
 	expected := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{
-			params.StorageConstraints{},
-			params.StorageConstraints{Count: &two},
+		"data": {
+			{},
+			{Count: &two},
 		},
 	}
 
@@ -349,9 +349,9 @@ func (s *InterfaceSuite) TestStorageAddConstraintsSameStorage(c *gc.C) {
 
 func (s *InterfaceSuite) TestStorageAddConstraintsDifferentStorage(c *gc.C) {
 	expected := map[string][]params.StorageConstraints{
-		"data": []params.StorageConstraints{params.StorageConstraints{}},
-		"diff": []params.StorageConstraints{
-			params.StorageConstraints{Count: &two}},
+		"data": {{}},
+		"diff": {
+			{Count: &two}},
 	}
 
 	ctx := runner.HookContext{}

--- a/worker/uniter/runner/env.go
+++ b/worker/uniter/runner/env.go
@@ -93,7 +93,7 @@ func mergeWindowsEnvironment(newEnv, env []string) []string {
 		}
 	}
 
-	for k, _ := range orig {
+	for k := range orig {
 		tmpEnv = append(tmpEnv, k+"="+uppers[strings.ToUpper(k)])
 	}
 

--- a/worker/uniter/runner/flush_test.go
+++ b/worker/uniter/runner/flush_test.go
@@ -394,7 +394,7 @@ func (s *FlushContextSuite) TestRunHookAddStorageOnFailure(c *gc.C) {
 	size := uint64(1)
 	ctx.AddUnitStorage(
 		map[string]params.StorageConstraints{
-			"allecto": params.StorageConstraints{Size: &size},
+			"allecto": {Size: &size},
 		})
 
 	// Flush the context with an error.
@@ -417,7 +417,7 @@ func (s *FlushContextSuite) TestRunHookAddUnitStorageOnSuccess(c *gc.C) {
 	size := uint64(1)
 	ctx.AddUnitStorage(
 		map[string]params.StorageConstraints{
-			"allecto": params.StorageConstraints{Size: &size},
+			"allecto": {Size: &size},
 		})
 
 	// Flush the context with a success.

--- a/worker/uniter/runner/jujuc/status-set_test.go
+++ b/worker/uniter/runner/jujuc/status-set_test.go
@@ -69,8 +69,8 @@ func (s *statusSetSuite) TestHelp(c *gc.C) {
 
 func (s *statusSetSuite) TestStatus(c *gc.C) {
 	for i, args := range [][]string{
-		[]string{"maintenance", "doing some work"},
-		[]string{"active", ""},
+		{"maintenance", "doing some work"},
+		{"active", ""},
 	} {
 		c.Logf("test %d: %#v", i, args)
 		hctx := s.GetStatusHookContext(c)
@@ -90,8 +90,8 @@ func (s *statusSetSuite) TestStatus(c *gc.C) {
 
 func (s *statusSetSuite) TestServiceStatus(c *gc.C) {
 	for i, args := range [][]string{
-		[]string{"--service", "maintenance", "doing some work"},
-		[]string{"--service", "active", ""},
+		{"--service", "maintenance", "doing some work"},
+		{"--service", "active", ""},
 	} {
 		c.Logf("test %d: %#v", i, args)
 		hctx := s.GetStatusHookContext(c)

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -45,7 +45,7 @@ func (s *unitStorageSuite) TestAddUnitStorage(c *gc.C) {
 	count := uint64(1)
 	s.assertUnitStorageAdded(c,
 		map[string]params.StorageConstraints{
-			"allecto": params.StorageConstraints{Count: &count}})
+			"allecto": {Count: &count}})
 }
 
 func (s *unitStorageSuite) TestAddUnitStorageIgnoresBlocks(c *gc.C) {
@@ -56,13 +56,13 @@ func (s *unitStorageSuite) TestAddUnitStorageIgnoresBlocks(c *gc.C) {
 	s.BlockAllChanges(c, "TestAddUnitStorageIgnoresBlocks")
 	s.assertUnitStorageAdded(c,
 		map[string]params.StorageConstraints{
-			"allecto": params.StorageConstraints{Count: &count}})
+			"allecto": {Count: &count}})
 }
 
 func (s *unitStorageSuite) TestAddUnitStorageZeroCount(c *gc.C) {
 	s.createStorageBlockUnit(c)
 	cons := map[string]params.StorageConstraints{
-		"allecto": params.StorageConstraints{}}
+		"allecto": {}}
 
 	ctx := s.addUnitStorage(c, cons)
 
@@ -81,7 +81,7 @@ func (s *unitStorageSuite) TestAddUnitStorageWithSize(c *gc.C) {
 	s.createStorageBlockUnit(c)
 	size := uint64(1)
 	cons := map[string]params.StorageConstraints{
-		"allecto": params.StorageConstraints{Size: &size}}
+		"allecto": {Size: &size}}
 
 	ctx := s.addUnitStorage(c, cons)
 
@@ -99,7 +99,7 @@ func (s *unitStorageSuite) TestAddUnitStorageWithSize(c *gc.C) {
 func (s *unitStorageSuite) TestAddUnitStorageWithPool(c *gc.C) {
 	s.createStorageBlockUnit(c)
 	cons := map[string]params.StorageConstraints{
-		"allecto": params.StorageConstraints{Pool: "loop"}}
+		"allecto": {Pool: "loop"}}
 
 	ctx := s.addUnitStorage(c, cons)
 
@@ -119,9 +119,9 @@ func (s *unitStorageSuite) TestAddUnitStorageAccumulated(c *gc.C) {
 	count := uint64(1)
 	s.assertUnitStorageAdded(c,
 		map[string]params.StorageConstraints{
-			"multi2up": params.StorageConstraints{Count: &count}},
+			"multi2up": {Count: &count}},
 		map[string]params.StorageConstraints{
-			"multi1to10": params.StorageConstraints{Count: &count}})
+			"multi1to10": {Count: &count}})
 }
 
 func (s *unitStorageSuite) TestAddUnitStorageAccumulatedSame(c *gc.C) {
@@ -129,9 +129,9 @@ func (s *unitStorageSuite) TestAddUnitStorageAccumulatedSame(c *gc.C) {
 	count := uint64(1)
 	s.assertUnitStorageAdded(c,
 		map[string]params.StorageConstraints{
-			"multi2up": params.StorageConstraints{Count: &count}},
+			"multi2up": {Count: &count}},
 		map[string]params.StorageConstraints{
-			"multi2up": params.StorageConstraints{Count: &count}})
+			"multi2up": {Count: &count}})
 }
 
 func setupTestStorageSupport(c *gc.C, s *state.State) {
@@ -210,7 +210,7 @@ func (s *unitStorageSuite) addUnitStorage(c *gc.C, cons ...map[string]params.Sto
 	c.Assert(ctx.UnitName(), gc.Equals, s.unit.Name())
 
 	for _, one := range cons {
-		for storage, _ := range one {
+		for storage := range one {
 			s.expectedStorageNames.Add(storage)
 		}
 		ctx.AddUnitStorage(one)

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -166,7 +166,7 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	storageData0 := names.NewStorageTag("data/0")
 	s.storage = &storageContextAccessor{
 		map[names.StorageTag]*contextStorage{
-			storageData0: &contextStorage{
+			storageData0: {
 				storageData0,
 				storage.StorageKindBlock,
 				"/dev/sdb",

--- a/worker/uniter/storage/attachments_test.go
+++ b/worker/uniter/storage/attachments_test.go
@@ -462,7 +462,7 @@ func (s *attachmentsUpdateSuite) TestAttachmentsUpdateUntrackedDying(c *gc.C) {
 func (s *attachmentsUpdateSuite) TestAttachmentsRefresh(c *gc.C) {
 	// This test combines the above two.
 	s.unitAttachmentIds = map[names.UnitTag][]params.StorageAttachmentId{
-		s.unitTag: []params.StorageAttachmentId{{
+		s.unitTag: {{
 			StorageTag: s.storageTag0.String(),
 			UnitTag:    s.unitTag.String(),
 		}, {


### PR DESCRIPTION
This simple (hardcoded) fix allow to cache the initial lxc image when behind proxy and for orangebox. 

Ideally it should be set to image-metadata-url parameter.

Did test successfully on OB.
