### PR TITLE
apiserver: fix machine storage attachment watcher

### DIFF
--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -260,11 +260,7 @@ func newMachineStorageIdsWatcher(
 	if !ok {
 		return nil, common.ErrUnknownWatcher
 	}
-	return &srvMachineStorageIdsWatcher{
-		watcher:   watcher,
-		id:        id,
-		resources: resources,
-	}, nil
+	return &srvMachineStorageIdsWatcher{watcher, id, resources, parser}, nil
 }
 
 // Next returns when a change has occured to an entity of the
@@ -272,7 +268,7 @@ func newMachineStorageIdsWatcher(
 // or the Watch call that created the srvMachineStorageIdsWatcher.
 func (w *srvMachineStorageIdsWatcher) Next() (params.MachineStorageIdsWatchResult, error) {
 	if stringChanges, ok := <-w.watcher.Changes(); ok {
-		changes, err := common.ParseVolumeAttachmentIds(stringChanges)
+		changes, err := w.parser(stringChanges)
 		if err != nil {
 			return params.MachineStorageIdsWatchResult{}, err
 		}

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -1,0 +1,89 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+type watcherSuite struct {
+	testing.BaseSuite
+	st         *state.State
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+}
+
+var _ = gc.Suite(&watcherSuite{})
+
+func (s *watcherSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.st = nil // none of the watcher facades use the State object
+	s.resources = common.NewResources()
+	s.authorizer = apiservertesting.FakeAuthorizer{}
+}
+
+func (s *watcherSuite) getFacade(c *gc.C, name string, version int, id string) interface{} {
+	factory, err := common.Facades.GetFactory(name, version)
+	c.Assert(err, jc.ErrorIsNil)
+	facade, err := factory(s.st, s.resources, s.authorizer, id)
+	c.Assert(err, jc.ErrorIsNil)
+	return facade
+}
+
+func (s *watcherSuite) TestVolumeAttachmentsWatcher(c *gc.C) {
+	ch := make(chan []string, 1)
+	id := s.resources.Register(&fakeStringsWatcher{ch: ch})
+	s.authorizer.Tag = names.NewMachineTag("123")
+
+	ch <- []string{"0:1", "1:2"}
+	facade := s.getFacade(c, "VolumeAttachmentsWatcher", 1, id).(machineStorageIdsWatcher)
+	result, err := facade.Next()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result, jc.DeepEquals, params.MachineStorageIdsWatchResult{
+		Changes: []params.MachineStorageId{
+			{MachineTag: "machine-0", AttachmentTag: "volume-1"},
+			{MachineTag: "machine-1", AttachmentTag: "volume-2"},
+		},
+	})
+}
+
+func (s *watcherSuite) TestFilesystemAttachmentsWatcher(c *gc.C) {
+	ch := make(chan []string, 1)
+	id := s.resources.Register(&fakeStringsWatcher{ch: ch})
+	s.authorizer.Tag = names.NewMachineTag("123")
+
+	ch <- []string{"0:1", "1:2"}
+	facade := s.getFacade(c, "FilesystemAttachmentsWatcher", 1, id).(machineStorageIdsWatcher)
+	result, err := facade.Next()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result, jc.DeepEquals, params.MachineStorageIdsWatchResult{
+		Changes: []params.MachineStorageId{
+			{MachineTag: "machine-0", AttachmentTag: "filesystem-1"},
+			{MachineTag: "machine-1", AttachmentTag: "filesystem-2"},
+		},
+	})
+}
+
+type machineStorageIdsWatcher interface {
+	Next() (params.MachineStorageIdsWatchResult, error)
+}
+
+type fakeStringsWatcher struct {
+	state.StringsWatcher
+	ch chan []string
+}
+
+func (w *fakeStringsWatcher) Changes() <-chan []string {
+	return w.ch
+}


### PR DESCRIPTION
(Forward port from 1.24 to master)

The common code for watching volume and filesystem
attachments was just catering for the volume case,
ignoring the parameter. This fixes that, and adds
minimal tests for the watchers.

(Review request: http://reviews.vapour.ws/r/2025/)