### PR TITLE
worker/storageprovisioner: order detach correctly

### DIFF
--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -72,6 +72,7 @@ func attachmentLife(ctx *context, ids []params.MachineStorageId) (
 
 // removeEntities removes each specified Dead entity from state.
 func removeEntities(ctx *context, tags []names.Tag) error {
+	logger.Debugf("removing entities: %v", tags)
 	errorResults, err := ctx.life.Remove(tags)
 	if err != nil {
 		return errors.Annotate(err, "removing storage entities")

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -26,17 +26,17 @@ func filesystemsChanged(ctx *context, changes []string) error {
 		return errors.Trace(err)
 	}
 	logger.Debugf("filesystems alive: %v, dying: %v, dead: %v", alive, dying, dead)
-	if err := processDyingFilesystems(ctx, dying); err != nil {
-		return errors.Annotate(err, "processing dying filesystems")
-	}
-	if len(alive)+len(dead) == 0 {
+	if len(alive)+len(dying)+len(dead) == 0 {
 		return nil
 	}
 
 	// Get filesystem information for alive and dead filesystems, so
 	// we can provision/deprovision.
-	filesystemTags := make([]names.FilesystemTag, 0, len(alive)+len(dead))
+	filesystemTags := make([]names.FilesystemTag, 0, len(alive)+len(dying)+len(dead))
 	for _, tag := range alive {
+		filesystemTags = append(filesystemTags, tag.(names.FilesystemTag))
+	}
+	for _, tag := range dying {
 		filesystemTags = append(filesystemTags, tag.(names.FilesystemTag))
 	}
 	for _, tag := range dead {
@@ -46,10 +46,21 @@ func filesystemsChanged(ctx *context, changes []string) error {
 	if err != nil {
 		return errors.Annotatef(err, "getting filesystem information")
 	}
-	if err := processDeadFilesystems(ctx, filesystemTags[len(alive):], filesystemResults[len(alive):]); err != nil {
+
+	aliveFilesystemTags := filesystemTags[:len(alive)]
+	dyingFilesystemTags := filesystemTags[len(alive) : len(alive)+len(dying)]
+	deadFilesystemTags := filesystemTags[len(alive)+len(dying):]
+	aliveFilesystemResults := filesystemResults[:len(alive)]
+	dyingFilesystemResults := filesystemResults[len(alive) : len(alive)+len(dying)]
+	deadFilesystemResults := filesystemResults[len(alive)+len(dying):]
+
+	if err := processDeadFilesystems(ctx, deadFilesystemTags, deadFilesystemResults); err != nil {
 		return errors.Annotate(err, "deprovisioning filesystems")
 	}
-	if err := processAliveFilesystems(ctx, alive, filesystemResults[:len(alive)]); err != nil {
+	if err := processDyingFilesystems(ctx, dyingFilesystemTags, dyingFilesystemResults); err != nil {
+		return errors.Annotate(err, "processing dying filesystems")
+	}
+	if err := processAliveFilesystems(ctx, aliveFilesystemTags, aliveFilesystemResults); err != nil {
 		return errors.Annotate(err, "provisioning filesystems")
 	}
 	return nil
@@ -96,10 +107,23 @@ func filesystemAttachmentsChanged(ctx *context, ids []params.MachineStorageId) e
 }
 
 // processDyingFilesystems processes the FilesystemResults for Dying filesystems,
-// removing them from provisioning-pending as necessary.
-func processDyingFilesystems(ctx *context, tags []names.Tag) error {
+// removing them from provisioning-pending as necessary, and storing the current
+// filesystem info for provisioned filesystems so that attachments may be destroyed.
+func processDyingFilesystems(ctx *context, tags []names.FilesystemTag, filesystemResults []params.FilesystemResult) error {
 	for _, tag := range tags {
-		delete(ctx.pendingFilesystems, tag.(names.FilesystemTag))
+		delete(ctx.pendingFilesystems, tag)
+	}
+	for i, result := range filesystemResults {
+		tag := tags[i]
+		if result.Error == nil {
+			filesystem, err := filesystemFromParams(result.Result)
+			if err != nil {
+				return errors.Annotate(err, "getting filesystem info")
+			}
+			ctx.filesystems[tag] = filesystem
+		} else if !params.IsCodeNotProvisioned(result.Error) {
+			return errors.Annotatef(result.Error, "getting information for filesystem %s", tag.Id())
+		}
 	}
 	return nil
 }
@@ -184,32 +208,33 @@ func processDyingFilesystemAttachments(
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if err := detachFilesystems(ctx, attachmentParams); err != nil {
-			return errors.Annotate(err, "detaching filesystems")
+		for i, params := range attachmentParams {
+			ctx.pendingDyingFilesystemAttachments[detach[i]] = params
 		}
-		remove = append(remove, detach...)
 	}
-	if err := removeAttachments(ctx, remove); err != nil {
-		return errors.Annotate(err, "removing attachments from state")
+	if len(remove) > 0 {
+		if err := removeAttachments(ctx, remove); err != nil {
+			return errors.Annotate(err, "removing attachments from state")
+		}
 	}
 	return nil
 }
 
 // processAliveFilesystems processes the FilesystemResults for Alive filesystems,
 // provisioning filesystems and setting the info in state as necessary.
-func processAliveFilesystems(ctx *context, tags []names.Tag, filesystemResults []params.FilesystemResult) error {
+func processAliveFilesystems(ctx *context, tags []names.FilesystemTag, filesystemResults []params.FilesystemResult) error {
 	// Filter out the already-provisioned filesystems.
 	pending := make([]names.FilesystemTag, 0, len(tags))
 	for i, result := range filesystemResults {
-		filesystemTag := tags[i].(names.FilesystemTag)
+		tag := tags[i]
 		if result.Error == nil {
 			// Filesystem is already provisioned: skip.
-			logger.Debugf("filesystem %q is already provisioned, nothing to do", filesystemTag.Id())
+			logger.Debugf("filesystem %q is already provisioned, nothing to do", tag.Id())
 			filesystem, err := filesystemFromParams(result.Result)
 			if err != nil {
 				return errors.Annotate(err, "getting filesystem info")
 			}
-			ctx.filesystems[filesystemTag] = filesystem
+			ctx.filesystems[tag] = filesystem
 			if filesystem.Volume != (names.VolumeTag{}) {
 				// Ensure that volume-backed filesystems' block
 				// devices are present even after creating the
@@ -220,12 +245,12 @@ func processAliveFilesystems(ctx *context, tags []names.Tag, filesystemResults [
 		}
 		if !params.IsCodeNotProvisioned(result.Error) {
 			return errors.Annotatef(
-				result.Error, "getting filesystem information for filesystem %q", filesystemTag.Id(),
+				result.Error, "getting filesystem information for filesystem %q", tag.Id(),
 			)
 		}
 		// The filesystem has not yet been provisioned, so record its tag
 		// to enquire about parameters below.
-		pending = append(pending, filesystemTag)
+		pending = append(pending, tag)
 	}
 	if len(pending) == 0 {
 		return nil
@@ -448,6 +473,34 @@ func processPendingFilesystemAttachments(ctx *context) error {
 	}
 	if err := setFilesystemAttachmentInfo(ctx, filesystemAttachments); err != nil {
 		return errors.Trace(err)
+	}
+	return nil
+}
+
+func processPendingDyingFilesystemAttachments(ctx *context) error {
+	if len(ctx.pendingDyingFilesystemAttachments) == 0 {
+		logger.Tracef("no pending, dying filesystem attachments")
+		return nil
+	}
+	var detach []storage.FilesystemAttachmentParams
+	var remove []params.MachineStorageId
+	for id, params := range ctx.pendingDyingFilesystemAttachments {
+		if _, ok := ctx.filesystems[params.Filesystem]; !ok {
+			// Wait until the filesystem info is known.
+			continue
+		}
+		delete(ctx.pendingDyingFilesystemAttachments, id)
+		detach = append(detach, params)
+		remove = append(remove, id)
+	}
+	if len(detach) == 0 {
+		return nil
+	}
+	if err := detachFilesystems(ctx, detach); err != nil {
+		return errors.Annotate(err, "detaching filesystems")
+	}
+	if err := removeAttachments(ctx, remove); err != nil {
+		return errors.Annotate(err, "removing attachments from state")
 	}
 	return nil
 }

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -30,8 +30,8 @@ func filesystemsChanged(ctx *context, changes []string) error {
 		return nil
 	}
 
-	// Get filesystem information for alive and dead filesystems, so
-	// we can provision/deprovision.
+	// Get filesystem information for filesystems, so we can provision,
+	// deprovision, attach and detach.
 	filesystemTags := make([]names.FilesystemTag, 0, len(alive)+len(dying)+len(dead))
 	for _, tag := range alive {
 		filesystemTags = append(filesystemTags, tag.(names.FilesystemTag))

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -262,24 +262,25 @@ func (w *storageprovisioner) loop() error {
 	}
 
 	ctx := context{
-		scope:                        w.scope,
-		storageDir:                   w.storageDir,
-		volumeAccessor:               w.volumes,
-		filesystemAccessor:           w.filesystems,
-		life:                         w.life,
-		machineAccessor:              w.machines,
-		volumes:                      make(map[names.VolumeTag]storage.Volume),
-		volumeAttachments:            make(map[params.MachineStorageId]storage.VolumeAttachment),
-		volumeBlockDevices:           make(map[names.VolumeTag]storage.BlockDevice),
-		filesystems:                  make(map[names.FilesystemTag]storage.Filesystem),
-		filesystemAttachments:        make(map[params.MachineStorageId]storage.FilesystemAttachment),
-		machines:                     make(map[names.MachineTag]*machineWatcher),
-		machineChanges:               machineChanges,
-		pendingVolumes:               make(map[names.VolumeTag]storage.VolumeParams),
-		pendingVolumeAttachments:     make(map[params.MachineStorageId]storage.VolumeAttachmentParams),
-		pendingVolumeBlockDevices:    make(set.Tags),
-		pendingFilesystems:           make(map[names.FilesystemTag]storage.FilesystemParams),
-		pendingFilesystemAttachments: make(map[params.MachineStorageId]storage.FilesystemAttachmentParams),
+		scope:                             w.scope,
+		storageDir:                        w.storageDir,
+		volumeAccessor:                    w.volumes,
+		filesystemAccessor:                w.filesystems,
+		life:                              w.life,
+		machineAccessor:                   w.machines,
+		volumes:                           make(map[names.VolumeTag]storage.Volume),
+		volumeAttachments:                 make(map[params.MachineStorageId]storage.VolumeAttachment),
+		volumeBlockDevices:                make(map[names.VolumeTag]storage.BlockDevice),
+		filesystems:                       make(map[names.FilesystemTag]storage.Filesystem),
+		filesystemAttachments:             make(map[params.MachineStorageId]storage.FilesystemAttachment),
+		machines:                          make(map[names.MachineTag]*machineWatcher),
+		machineChanges:                    machineChanges,
+		pendingVolumes:                    make(map[names.VolumeTag]storage.VolumeParams),
+		pendingVolumeAttachments:          make(map[params.MachineStorageId]storage.VolumeAttachmentParams),
+		pendingVolumeBlockDevices:         make(set.Tags),
+		pendingFilesystems:                make(map[names.FilesystemTag]storage.FilesystemParams),
+		pendingFilesystemAttachments:      make(map[params.MachineStorageId]storage.FilesystemAttachmentParams),
+		pendingDyingFilesystemAttachments: make(map[params.MachineStorageId]storage.FilesystemAttachmentParams),
 	}
 	ctx.managedFilesystemSource = newManagedFilesystemSource(
 		ctx.volumeBlockDevices, ctx.filesystems,
@@ -373,6 +374,9 @@ func processPending(ctx *context) error {
 	if err := processPendingFilesystems(ctx); err != nil {
 		return errors.Annotate(err, "processing pending filesystems")
 	}
+	if err := processPendingDyingFilesystemAttachments(ctx); err != nil {
+		return errors.Annotate(err, "processing pending, dying filesystem attachments")
+	}
 	if err := processPendingFilesystemAttachments(ctx); err != nil {
 		return errors.Annotate(err, "processing pending filesystem attachments")
 	}
@@ -437,6 +441,10 @@ type context struct {
 	// pendingFilesystemAttachments contains parameters for filesystem attachments
 	// that are yet to be created.
 	pendingFilesystemAttachments map[params.MachineStorageId]storage.FilesystemAttachmentParams
+
+	// pendingDyingFilesystemAttachments contains parameters for filesystem attachments
+	// that are to be destroyed.
+	pendingDyingFilesystemAttachments map[params.MachineStorageId]storage.FilesystemAttachmentParams
 
 	// managedFilesystemSource is a storage.FilesystemSource that
 	// manages filesystems backed by volumes attached to the host


### PR DESCRIPTION
Detaching filesystems requires that the we store
information about the filesystem first, since we
need to know whether or not the filesystem is
volume-backed, for example. So we change filesystem
detachment to not be immediate, and use the state-
machine/pending style used like in other cases,
with detachment depending on filesystem info being
seen first.

(Review request: http://reviews.vapour.ws/r/2027/)