### PR TITLE
Limit the initial oplog documents considered by LogTailer

### DIFF
--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -62,6 +62,20 @@ func (d *OplogDoc) unmarshal(raw *bson.Raw, out interface{}) error {
 	return raw.Unmarshal(out)
 }
 
+// NewMongoTimestamp returns a bson.MongoTimestamp repesentation for
+// the time.Time given. Note that these timestamps are not the same
+// the usual MongoDB time fields. These are an internal format used
+// only in a few places such as the replication oplog.
+//
+// See: http://docs.mongodb.org/manual/reference/bson-types/#timestamps
+func NewMongoTimestamp(t time.Time) bson.MongoTimestamp {
+	unixTime := t.Unix()
+	if unixTime < 0 {
+		unixTime = 0
+	}
+	return bson.MongoTimestamp(unixTime << 32)
+}
+
 // GetOplog returns the the oplog collection in the local database.
 func GetOplog(session *mgo.Session) *mgo.Collection {
 	return session.DB("local").C("oplog.rs")

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -177,6 +177,18 @@ func (s *oplogSuite) TestDiesOnFatalError(c *gc.C) {
 	c.Assert(tailer.Err(), gc.Not(jc.ErrorIsNil))
 }
 
+func (s *oplogSuite) TestNewMongoTimestamp(c *gc.C) {
+	t := time.Date(2015, 6, 24, 12, 47, 0, 0, time.FixedZone("somewhere", 5*3600))
+
+	expected := bson.MongoTimestamp(6163845091342417920)
+	c.Assert(mongo.NewMongoTimestamp(t), gc.Equals, expected)
+	c.Assert(mongo.NewMongoTimestamp(t.In(time.UTC)), gc.Equals, expected)
+}
+
+func (s *oplogSuite) TestNewMongoTimestampBeforeUnixEpoch(c *gc.C) {
+	c.Assert(mongo.NewMongoTimestamp(time.Time{}), gc.Equals, bson.MongoTimestamp(0))
+}
+
 func (s *oplogSuite) startMongoWithReplicaset(c *gc.C) (*jujutesting.MgoInstance, *mgo.Session) {
 	inst := &jujutesting.MgoInstance{
 		Params: []string{

--- a/state/logs.go
+++ b/state/logs.go
@@ -147,11 +147,6 @@ type LogTailerParams struct {
 	Oplog         *mgo.Collection // For testing only
 }
 
-// This is the maximum number of log document ids that will be tracked
-// to avoid re-reporting logs when transitioning between querying the
-// logs collection and tailing the oplog.
-const maxRecentLogIds = 5192
-
 // oplogOverlap is used to decide on the initial oplog timestamp to
 // use when the LogTailer transitions from querying the logs
 // collection to tailing the oplog. Oplog records with a timestamp >=
@@ -160,6 +155,14 @@ const maxRecentLogIds = 5192
 // cluster hosts and log writes that occur during the transition
 // period.
 const oplogOverlap = time.Minute
+
+// This is the maximum number of log document ids that will be tracked
+// to avoid re-reporting logs when transitioning between querying the
+// logs collection and tailing the oplog.
+//
+// The value was calculated by looking at the per-minute peak log
+// output of large broken environments with logging at DEBUG.
+var maxRecentLogIds = int(oplogOverlap.Minutes() * 150000)
 
 // NewLogTailer returns a LogTailer which filters according to the
 // parameters given.


### PR DESCRIPTION
mongo: added NewMongoTimestamp

This generates MongoDB's internal timestamps which are used in the oplog.

---

mongo: OplogTailer now supports an starting op timestamp

A correctly chosen initial timestmap can make starting the tail much more efficient.

---

state: limit the oplog docs considered by LogTailer

Only entries logged within 1 minute of the last log read from the logs collection will be considered. This avoids reading the entire oplog when oplog tailing starts.

---

state: bump the maximum log ids that the log tailer will track

This is based on checking the logs emitted by real, large (and broken) environments.

---


(Review request: http://reviews.vapour.ws/r/2028/)