### PR TITLE
state: prevent Machine.EnsureDead with storage

### DIFF
--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -144,6 +144,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeNotProvisioned
 	case state.IsUpgradeInProgressError(err):
 		code = params.CodeUpgradeInProgress
+	case state.IsHasAttachmentsError(err):
+		code = params.CodeMachineHasAttachedStorage
 	case IsUnknownEnviromentError(err):
 		code = params.CodeNotFound
 	default:

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -35,25 +35,26 @@ func (e Error) GoString() string {
 
 // The Code constants hold error codes for some kinds of error.
 const (
-	CodeNotFound              = "not found"
-	CodeUnauthorized          = "unauthorized access"
-	CodeCannotEnterScope      = "cannot enter scope"
-	CodeCannotEnterScopeYet   = "cannot enter scope yet"
-	CodeExcessiveContention   = "excessive contention"
-	CodeUnitHasSubordinates   = "unit has subordinates"
-	CodeNotAssigned           = "not assigned"
-	CodeStopped               = "stopped"
-	CodeDead                  = "dead"
-	CodeHasAssignedUnits      = "machine has assigned units"
-	CodeNotProvisioned        = "not provisioned"
-	CodeNoAddressSet          = "no address set"
-	CodeTryAgain              = "try again"
-	CodeNotImplemented        = rpc.CodeNotImplemented
-	CodeAlreadyExists         = "already exists"
-	CodeUpgradeInProgress     = "upgrade in progress"
-	CodeActionNotAvailable    = "action no longer available"
-	CodeOperationBlocked      = "operation is blocked"
-	CodeLeadershipClaimDenied = "leadership claim denied"
+	CodeNotFound                  = "not found"
+	CodeUnauthorized              = "unauthorized access"
+	CodeCannotEnterScope          = "cannot enter scope"
+	CodeCannotEnterScopeYet       = "cannot enter scope yet"
+	CodeExcessiveContention       = "excessive contention"
+	CodeUnitHasSubordinates       = "unit has subordinates"
+	CodeNotAssigned               = "not assigned"
+	CodeStopped                   = "stopped"
+	CodeDead                      = "dead"
+	CodeHasAssignedUnits          = "machine has assigned units"
+	CodeMachineHasAttachedStorage = "machine has attached storage"
+	CodeNotProvisioned            = "not provisioned"
+	CodeNoAddressSet              = "no address set"
+	CodeTryAgain                  = "try again"
+	CodeNotImplemented            = rpc.CodeNotImplemented
+	CodeAlreadyExists             = "already exists"
+	CodeUpgradeInProgress         = "upgrade in progress"
+	CodeActionNotAvailable        = "action no longer available"
+	CodeOperationBlocked          = "operation is blocked"
+	CodeLeadershipClaimDenied     = "leadership claim denied"
 )
 
 // ErrCode returns the error code associated with
@@ -135,6 +136,10 @@ func IsCodeDead(err error) bool {
 
 func IsCodeHasAssignedUnits(err error) bool {
 	return ErrCode(err) == CodeHasAssignedUnits
+}
+
+func IsCodeMachineHasAttachedStorage(err error) bool {
+	return ErrCode(err) == CodeMachineHasAttachedStorage
 }
 
 func IsCodeNotProvisioned(err error) bool {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -728,7 +728,8 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	}
 
 	runner.StartWorker("machiner", func() (worker.Worker, error) {
-		return machiner.NewMachiner(st.Machiner(), agentConfig), nil
+		accessor := machiner.APIMachineAccessor{st.Machiner()}
+		return machiner.NewMachiner(accessor, agentConfig), nil
 	})
 	runner.StartWorker("reboot", func() (worker.Worker, error) {
 		reboot, err := st.Reboot()

--- a/state/machine.go
+++ b/state/machine.go
@@ -109,6 +109,14 @@ type machineDoc struct {
 	HasVote       bool
 	PasswordHash  string
 	Clean         bool
+	// TODO(axw) 2015-06-22 #1467379
+	// We need an upgrade step to populate "volumes" and "filesystems"
+	// for entities created in 1.24.
+	//
+	// Volumes contains the names of volumes attached to the machine.
+	Volumes []string `bson:"volumes,omitempty"`
+	// Filesystems contains the names of filesystems attached to the machine.
+	Filesystems []string `bson:"filesystems,omitempty"`
 	// We store 2 different sets of addresses for the machine, obtained
 	// from different sources.
 	// Addresses is the set of addresses obtained by asking the provider.
@@ -490,8 +498,33 @@ func (e *HasContainersError) Error() string {
 	return fmt.Sprintf("machine %s is hosting containers %q", e.MachineId, strings.Join(e.ContainerIds, ","))
 }
 
+// IsHasContainersError reports whether or not the error is a
+// HasContainersError, indicating that an attempt to destroy
+// a machine failed due to it having containers.
 func IsHasContainersError(err error) bool {
-	_, ok := err.(*HasContainersError)
+	_, ok := errors.Cause(err).(*HasContainersError)
+	return ok
+}
+
+// HasAttachmentsError is the error returned by EnsureDead if the machine
+// has attachments to resources that must be cleaned up first.
+type HasAttachmentsError struct {
+	MachineId   string
+	Attachments []names.Tag
+}
+
+func (e *HasAttachmentsError) Error() string {
+	return fmt.Sprintf(
+		"machine %s has attachments %s",
+		e.MachineId, e.Attachments,
+	)
+}
+
+// IsHasAttachmentsError reports whether or not the error is a
+// HasAttachmentsError, indicating that an attempt to destroy
+// a machine failed due to it having storage attachments.
+func IsHasAttachmentsError(err error) bool {
+	_, ok := errors.Cause(err).(*HasAttachmentsError)
 	return ok
 }
 
@@ -633,20 +666,95 @@ func (original *Machine) advanceLifecycle(life Life) (err error) {
 				return []txn.Op{op, containerCheck, cleanupOp}, nil
 			}
 		}
+
 		if len(m.doc.Principals) > 0 {
 			return nil, &HasAssignedUnitsError{
 				MachineId: m.doc.Id,
 				UnitNames: m.doc.Principals,
 			}
 		}
+		advanceAsserts = append(advanceAsserts, noUnits)
+
+		if life == Dead {
+			// A machine may not become Dead until it has no more
+			// attachments to inherently machine-bound storage.
+			storageAsserts, err := m.assertNoPersistentStorage()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			advanceAsserts = append(advanceAsserts, storageAsserts...)
+		}
+
 		// Add the additional asserts needed for this transaction.
-		op.Assert = append(advanceAsserts, noUnits)
+		op.Assert = advanceAsserts
 		return []txn.Op{op, cleanupOp}, nil
 	}
 	if err = m.st.run(buildTxn); err == jujutxn.ErrExcessiveContention {
 		err = errors.Annotatef(err, "machine %s cannot advance lifecycle", m)
 	}
 	return err
+}
+
+// assertNoPersistentStorage ensures that there are no persistent volumes or
+// filesystems attached to the machine, and returns any mgo/txn assertions
+// required to ensure that remains true.
+func (m *Machine) assertNoPersistentStorage() (bson.D, error) {
+	attachments := make(set.Tags)
+	for _, v := range m.doc.Volumes {
+		tag := names.NewVolumeTag(v)
+		machineBound, err := isVolumeInherentlyMachineBound(m.st, tag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !machineBound {
+			attachments.Add(tag)
+		}
+	}
+	for _, f := range m.doc.Filesystems {
+		tag := names.NewFilesystemTag(f)
+		machineBound, err := isFilesystemInherentlyMachineBound(m.st, tag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !machineBound {
+			attachments.Add(tag)
+		}
+	}
+	if len(attachments) > 0 {
+		return nil, &HasAttachmentsError{
+			MachineId:   m.doc.Id,
+			Attachments: attachments.SortedValues(),
+		}
+	}
+	if m.doc.Life == Dying {
+		return nil, nil
+	}
+	// A Dying machine cannot have attachments added to it,
+	// but if we're advancing from Alive to Dead then we
+	// must ensure no concurrent attachments are made.
+	noNewVolumes := bson.DocElem{
+		"volumes", bson.D{{
+			"$not", bson.D{{
+				"$elemMatch", bson.D{{
+					"$nin", m.doc.Volumes,
+				}},
+			}},
+		}},
+		// There are no volumes that are not in
+		// the set of volumes we previously knew
+		// about => the current set of volumes
+		// is a subset of the previously known set.
+	}
+	noNewFilesystems := bson.DocElem{
+		"filesystems", bson.D{{
+			"$not", bson.D{{
+				"$elemMatch", bson.D{{
+					"$nin", m.doc.Filesystems,
+				}},
+			}},
+		}},
+	}
+	return bson.D{noNewVolumes, noNewFilesystems}, nil
 }
 
 func (m *Machine) removePortsOps() ([]txn.Op, error) {

--- a/state/storage.go
+++ b/state/storage.go
@@ -480,10 +480,15 @@ func unitAssignedMachineStorageOps(
 	if err := validateDynamicMachineStorageParams(m, storageParams); err != nil {
 		return nil, errors.Trace(err)
 	}
-	storageOps, err := st.machineStorageOps(&m.doc, storageParams)
+	storageOps, volumesAttached, filesystemsAttached, err := st.machineStorageOps(
+		&m.doc, storageParams,
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	storageOps = append(storageOps, addMachineStorageAttachmentsOp(
+		m.doc.Id, volumesAttached, filesystemsAttached,
+	))
 	return storageOps, nil
 }
 

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -88,6 +88,7 @@ func (s *storageAddSuite) TestAddStorageToUnit(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount+1)
 	s.assertVolumeCount(c, s.originalVolumeCount+1)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageToUnitNotAssigned(c *gc.C) {
@@ -113,6 +114,7 @@ func (s *storageAddSuite) TestAddStorageWithCount(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount+2)
 	s.assertVolumeCount(c, s.originalVolumeCount+2)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
@@ -130,6 +132,7 @@ func (s *storageAddSuite) TestAddStorageMultipleCalls(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount+2)
 	s.assertVolumeCount(c, s.originalVolumeCount+2)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageToDyingUnitFails(c *gc.C) {
@@ -185,6 +188,7 @@ func (s *storageAddSuite) TestAddStorageMinCount(c *gc.C) {
 	s.assertStorageCount(c, 2)
 	s.assertVolumeCount(c, 2)
 	s.assertFileSystemCount(c, 0)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageZeroCount(c *gc.C) {
@@ -194,6 +198,7 @@ func (s *storageAddSuite) TestAddStorageZeroCount(c *gc.C) {
 	s.assertStorageCount(c, 1)
 	s.assertVolumeCount(c, 1)
 	s.assertFileSystemCount(c, 0)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
@@ -205,6 +210,7 @@ func (s *storageAddSuite) TestAddStorageTriggerDefaultPopulated(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount+1)
 	s.assertVolumeCount(c, s.originalVolumeCount+1)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageDiffPool(c *gc.C) {
@@ -216,6 +222,7 @@ func (s *storageAddSuite) TestAddStorageDiffPool(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount+1)
 	s.assertVolumeCount(c, s.originalVolumeCount+1)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageDiffSize(c *gc.C) {
@@ -227,6 +234,7 @@ func (s *storageAddSuite) TestAddStorageDiffSize(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount+1)
 	s.assertVolumeCount(c, s.originalVolumeCount+1)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
@@ -238,6 +246,7 @@ func (s *storageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount)
 	s.assertVolumeCount(c, s.originalVolumeCount)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageWrongName(c *gc.C) {
@@ -264,6 +273,7 @@ func (s *storageAddSuite) TestAddStorageConcurrently(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount+2)
 	s.assertVolumeCount(c, s.originalVolumeCount+2)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
@@ -283,6 +293,7 @@ func (s *storageAddSuite) TestAddStorageConcurrentlyExceedCount(c *gc.C) {
 	s.assertStorageCount(c, s.originalStorageCount+count)
 	s.assertVolumeCount(c, s.originalVolumeCount+count)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageFilesystem(c *gc.C) {
@@ -305,6 +316,7 @@ func (s *storageAddSuite) TestAddStorageFilesystem(c *gc.C) {
 	s.assertStorageCount(c, 2)
 	s.assertVolumeCount(c, 2)
 	s.assertFileSystemCount(c, 2)
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }
 
 func (s *storageAddSuite) TestAddStorageStatic(c *gc.C) {
@@ -330,4 +342,5 @@ func (s *storageAddSuite) TestAddStorageStatic(c *gc.C) {
 		`"static" storage provider does not support dynamic storage`)
 	s.assertStorageCount(c, 1)    // no change
 	s.assertFileSystemCount(c, 1) // no change
+	assertMachineStorageRefs(c, s.State, s.machineTag)
 }

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -221,6 +221,71 @@ func (s *StorageStateSuiteBase) storageInstanceFilesystem(c *gc.C, tag names.Sto
 	return filesystem
 }
 
+func (s *StorageStateSuiteBase) obliterateVolume(c *gc.C, tag names.VolumeTag) {
+	err := s.State.DestroyVolume(tag)
+	if errors.IsNotFound(err) {
+		return
+	}
+	attachments, err := s.State.VolumeAttachments(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, a := range attachments {
+		s.obliterateVolumeAttachment(c, a.Machine(), a.Volume())
+	}
+	err = s.State.RemoveVolume(tag)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *StorageStateSuiteBase) obliterateVolumeAttachment(c *gc.C, m names.MachineTag, v names.VolumeTag) {
+	err := s.State.DetachVolume(m, v)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolumeAttachment(m, v)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *StorageStateSuiteBase) obliterateFilesystemAttachment(c *gc.C, m names.MachineTag, f names.FilesystemTag) {
+	err := s.State.DetachFilesystem(m, f)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveFilesystemAttachment(m, f)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// assertMachineStorageRefs ensures that the specified machine's set of volume
+// and filesystem references corresponds exactly to the volume and filesystem
+// attachments that relate to the machine.
+func assertMachineStorageRefs(c *gc.C, st *state.State, m names.MachineTag) {
+	machines, closer := state.GetRawCollection(st, state.MachinesC)
+	defer closer()
+
+	var doc struct {
+		Volumes     []string `bson:"volumes,omitempty"`
+		Filesystems []string `bson:"filesystems,omitempty"`
+	}
+	err := machines.FindId(state.DocID(st, m.Id())).One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+
+	have := make(set.Tags)
+	for _, v := range doc.Volumes {
+		have.Add(names.NewVolumeTag(v))
+	}
+	for _, f := range doc.Filesystems {
+		have.Add(names.NewFilesystemTag(f))
+	}
+
+	expect := make(set.Tags)
+	volumeAttachments, err := st.MachineVolumeAttachments(m)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, a := range volumeAttachments {
+		expect.Add(a.Volume())
+	}
+	filesystemAttachments, err := st.MachineFilesystemAttachments(m)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, a := range filesystemAttachments {
+		expect.Add(a.Filesystem())
+	}
+
+	c.Assert(have, jc.DeepEquals, expect)
+}
+
 func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
 	return state.StorageConstraints{Pool: pool, Size: size, Count: count}
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -1179,10 +1179,15 @@ func (u *Unit) assignToMachine(m *Machine, unused bool) (err error) {
 	if err := validateDynamicMachineStorageParams(m, storageParams); err != nil {
 		return errors.Trace(err)
 	}
-	storageOps, err := u.st.machineStorageOps(&m.doc, storageParams)
+	storageOps, volumesAttached, filesystemsAttached, err := u.st.machineStorageOps(
+		&m.doc, storageParams,
+	)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	storageOps = append(storageOps, addMachineStorageAttachmentsOp(
+		m.doc.Id, volumesAttached, filesystemsAttached,
+	))
 
 	assert := append(isAliveDoc, bson.D{
 		{"$or", []bson.D{

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -74,6 +74,8 @@ func (s *VolumeStateSuite) assertMachineVolume(c *gc.C, unit *state.Unit) {
 
 	_, err = s.State.VolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 	c.Assert(err, jc.ErrorIsNil)
+
+	assertMachineStorageRefs(c, s.State, machine.MachineTag())
 }
 
 func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
@@ -453,6 +455,7 @@ func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (_ *state.Machine, all, 
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	assertMachineStorageRefs(c, s.State, machine.MachineTag())
 
 	volume1 := s.volume(c, names.NewVolumeTag("0"))
 	volume2 := s.volume(c, names.NewVolumeTag("0/1"))
@@ -506,7 +509,7 @@ func (s *VolumeStateSuite) TestRemoveStorageInstanceUnassignsVolume(c *gc.C) {
 	_, err = s.State.StorageInstanceVolume(storageTag)
 	c.Assert(err, gc.ErrorMatches, `volume for storage instance "data/0" not found`)
 
-	// The volume should not have been destroyed, though.
+	// The volume should not have been removed, though.
 	s.volume(c, volumeTag)
 }
 
@@ -661,6 +664,7 @@ func (s *VolumeStateSuite) TestRemoveVolumeAttachmentConcurrently(c *gc.C) {
 	remove := func() {
 		err := s.State.RemoveVolumeAttachment(machine.MachineTag(), volume.VolumeTag())
 		c.Assert(err, jc.ErrorIsNil)
+		assertMachineStorageRefs(c, s.State, machine.MachineTag())
 	}
 	defer state.SetBeforeHooks(c, s.State, remove).Check()
 	remove()
@@ -683,6 +687,8 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 		}, {
 			Volume: state.VolumeParams{Pool: "loop-pool", Size: 2048}, // unprovisioned
 		}, {
+			Volume: state.VolumeParams{Pool: "loop-pool", Size: 2048}, // provisioned, non-persistent
+		}, {
 			Volume: state.VolumeParams{Pool: "static", Size: 2048}, // provisioned
 		}, {
 			Volume: state.VolumeParams{Pool: "static", Size: 2048}, // unprovisioned
@@ -694,7 +700,10 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	err = s.State.SetVolumeInfo(names.NewVolumeTag("0/1"), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfoSet = state.VolumeInfo{Size: 456, Persistent: false}
-	err = s.State.SetVolumeInfo(names.NewVolumeTag("3"), volumeInfoSet)
+	err = s.State.SetVolumeInfo(names.NewVolumeTag("0/3"), volumeInfoSet)
+	c.Assert(err, jc.ErrorIsNil)
+	volumeInfoSet = state.VolumeInfo{Size: 789, Persistent: false}
+	err = s.State.SetVolumeInfo(names.NewVolumeTag("4"), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 
 	allVolumes, err := s.State.AllVolumes()
@@ -704,6 +713,15 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	c.Assert(len(allVolumes), jc.GreaterThan, len(persistentVolumes))
 
 	c.Assert(machine.Destroy(), jc.ErrorIsNil)
+
+	// Cannot advance to Dead while there are persistent, or
+	// unprovisioned dynamic volumes (regardless of scope).
+	err = machine.EnsureDead()
+	c.Assert(err, jc.Satisfies, state.IsHasAttachmentsError)
+	c.Assert(err, gc.ErrorMatches, "machine 0 has attachments \\[volume-0 volume-0-1 volume-0-2\\]")
+	s.obliterateVolumeAttachment(c, machine.MachineTag(), names.NewVolumeTag("0"))
+	s.obliterateVolumeAttachment(c, machine.MachineTag(), names.NewVolumeTag("0/1"))
+	s.obliterateVolumeAttachment(c, machine.MachineTag(), names.NewVolumeTag("0/2"))
 	c.Assert(machine.EnsureDead(), jc.ErrorIsNil)
 	c.Assert(machine.Remove(), jc.ErrorIsNil)
 
@@ -711,14 +729,13 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	// scoped storage should be gone too.
 	allVolumes, err = s.State.AllVolumes()
 	c.Assert(err, jc.ErrorIsNil)
-	// We should only have the persistent volume and the provisioned loop
-	// device remaining.
+	// We should only have the persistent volume and the loop devices remaining.
 	remaining := make(set.Strings)
 	for _, v := range allVolumes {
 		remaining.Add(v.Tag().String())
 	}
 	c.Assert(remaining.SortedValues(), jc.DeepEquals, []string{
-		"volume-0", "volume-0-1",
+		"volume-0", "volume-0-1", "volume-0-2",
 	})
 
 	attachments, err := s.State.MachineVolumeAttachments(machine.MachineTag())

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/names"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
@@ -21,16 +20,15 @@ var logger = loggo.GetLogger("juju.worker.machiner")
 
 // Machiner is responsible for a machine agent's lifecycle.
 type Machiner struct {
-	st      *machiner.State
+	st      MachineAccessor
 	tag     names.MachineTag
-	machine *machiner.Machine
+	machine Machine
 }
 
 // NewMachiner returns a Worker that will wait for the identified machine
 // to become Dying and make it Dead; or until the machine becomes Dead by
 // other means.
-func NewMachiner(st *machiner.State, agentConfig agent.Config) worker.Worker {
-	// TODO(dfc) clearly agentConfig.Tag() can _only_ return a machine tag
+func NewMachiner(st MachineAccessor, agentConfig agent.Config) worker.Worker {
 	mr := &Machiner{st: st, tag: agentConfig.Tag().(names.MachineTag)}
 	return worker.NewNotifyWorker(mr)
 }
@@ -46,7 +44,7 @@ func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	mr.machine = m
 
 	// Set the addresses in state to the host's addresses.
-	if err := setMachineAddresses(m); err != nil {
+	if err := setMachineAddresses(mr.tag, m); err != nil {
 		return nil, err
 	}
 
@@ -63,7 +61,7 @@ var interfaceAddrs = net.InterfaceAddrs
 
 // setMachineAddresses sets the addresses for this machine to all of the
 // host's non-loopback interface IP addresses.
-func setMachineAddresses(m *machiner.Machine) error {
+func setMachineAddresses(tag names.MachineTag, m Machine) error {
 	addrs, err := interfaceAddrs()
 	if err != nil {
 		return err
@@ -91,7 +89,7 @@ func setMachineAddresses(m *machiner.Machine) error {
 	}
 	// Filter out any LXC bridge addresses.
 	hostAddresses = network.FilterLXCAddresses(hostAddresses)
-	logger.Infof("setting addresses for %v to %q", m.Tag(), hostAddresses)
+	logger.Infof("setting addresses for %v to %q", tag, hostAddresses)
 	return m.SetMachineAddresses(hostAddresses)
 }
 
@@ -101,10 +99,11 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 	} else if err != nil {
 		return err
 	}
-	if mr.machine.Life() == params.Alive {
+	life := mr.machine.Life()
+	if life == params.Alive {
 		return nil
 	}
-	logger.Debugf("%q is now %s", mr.tag, mr.machine.Life())
+	logger.Debugf("%q is now %s", mr.tag, life)
 	if err := mr.machine.SetStatus(params.StatusStopped, "", nil); err != nil {
 		return fmt.Errorf("%s failed to set status stopped: %v", mr.tag, err)
 	}

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/juju/names"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -26,6 +27,91 @@ import (
 	"github.com/juju/juju/worker/machiner"
 )
 
+type MachinerSuite struct {
+	coretesting.BaseSuite
+	accessor    *mockMachineAccessor
+	agentConfig agent.Config
+	addresses   []net.Addr
+}
+
+var _ = gc.Suite(&MachinerSuite{})
+
+func (s *MachinerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.accessor = &mockMachineAccessor{}
+	s.accessor.machine.watcher.changes = make(chan struct{})
+	s.accessor.machine.life = params.Alive
+	s.agentConfig = agentConfig(names.NewMachineTag("123"))
+	s.addresses = []net.Addr{ // anything will do
+		&net.IPAddr{IP: net.IPv4bcast},
+		&net.IPAddr{IP: net.IPv4zero},
+	}
+	s.PatchValue(machiner.InterfaceAddrs, func() ([]net.Addr, error) {
+		return s.addresses, nil
+	})
+}
+
+func (s *MachinerSuite) TestMachinerStorageAttached(c *gc.C) {
+	// Machine is dying. We'll respond to "EnsureDead" by
+	// saying that there are still storage attachments;
+	// this should not cause an error.
+	s.accessor.machine.life = params.Dying
+	s.accessor.machine.SetErrors(
+		nil, // SetMachineAddresses
+		nil, // SetStatus
+		nil, // Watch
+		nil, // Refresh
+		nil, // SetStatus
+		&params.Error{Code: params.CodeMachineHasAttachedStorage},
+	)
+
+	worker := machiner.NewMachiner(s.accessor, s.agentConfig)
+	s.accessor.machine.watcher.changes <- struct{}{}
+	worker.Kill()
+	c.Check(worker.Wait(), jc.ErrorIsNil)
+
+	s.accessor.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "Machine",
+		Args:     []interface{}{s.agentConfig.Tag()},
+	}})
+
+	s.accessor.machine.watcher.CheckCalls(c, []gitjujutesting.StubCall{
+		{FuncName: "Changes"}, {FuncName: "Changes"}, {FuncName: "Stop"},
+	})
+
+	s.accessor.machine.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "SetMachineAddresses",
+		Args: []interface{}{
+			network.NewAddresses(
+				"255.255.255.255",
+				"0.0.0.0",
+			),
+		},
+	}, {
+		FuncName: "SetStatus",
+		Args: []interface{}{
+			params.StatusStarted,
+			"",
+			map[string]interface{}(nil),
+		},
+	}, {
+		FuncName: "Watch",
+	}, {
+		FuncName: "Refresh",
+	}, {
+		FuncName: "Life",
+	}, {
+		FuncName: "SetStatus",
+		Args: []interface{}{
+			params.StatusStopped,
+			"",
+			map[string]interface{}(nil),
+		},
+	}, {
+		FuncName: "EnsureDead",
+	}})
+}
+
 // worstCase is used for timeouts when timing out
 // will fail the test. Raising this value should
 // not affect the overall running time of the tests
@@ -36,7 +122,7 @@ func TestPackage(t *stdtesting.T) {
 	coretesting.MgoTestPackage(t)
 }
 
-type MachinerSuite struct {
+type MachinerStateSuite struct {
 	testing.JujuConnSuite
 
 	st            *api.State
@@ -45,9 +131,9 @@ type MachinerSuite struct {
 	apiMachine    *apimachiner.Machine
 }
 
-var _ = gc.Suite(&MachinerSuite{})
+var _ = gc.Suite(&MachinerStateSuite{})
 
-func (s *MachinerSuite) SetUpTest(c *gc.C) {
+func (s *MachinerStateSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.st, s.machine = s.OpenAPIAsNewMachine(c)
 
@@ -71,7 +157,7 @@ func (s *MachinerSuite) SetUpTest(c *gc.C) {
 
 }
 
-func (s *MachinerSuite) waitMachineStatus(c *gc.C, m *state.Machine, expectStatus state.Status) {
+func (s *MachinerStateSuite) waitMachineStatus(c *gc.C, m *state.Machine, expectStatus state.Status) {
 	timeout := time.After(worstCase)
 	for {
 		select {
@@ -104,23 +190,29 @@ func agentConfig(tag names.Tag) agent.Config {
 	return &mockConfig{tag: tag}
 }
 
-func (s *MachinerSuite) TestNotFoundOrUnauthorized(c *gc.C) {
-	mr := machiner.NewMachiner(s.machinerState, agentConfig(names.NewMachineTag("99")))
+func (s *MachinerStateSuite) TestNotFoundOrUnauthorized(c *gc.C) {
+	mr := machiner.NewMachiner(
+		machiner.APIMachineAccessor{s.machinerState},
+		agentConfig(names.NewMachineTag("99")),
+	)
 	c.Assert(mr.Wait(), gc.Equals, worker.ErrTerminateAgent)
 }
 
-func (s *MachinerSuite) makeMachiner() worker.Worker {
-	return machiner.NewMachiner(s.machinerState, agentConfig(s.apiMachine.Tag()))
+func (s *MachinerStateSuite) makeMachiner() worker.Worker {
+	return machiner.NewMachiner(
+		machiner.APIMachineAccessor{s.machinerState},
+		agentConfig(s.apiMachine.Tag()),
+	)
 }
 
-func (s *MachinerSuite) TestRunStop(c *gc.C) {
+func (s *MachinerStateSuite) TestRunStop(c *gc.C) {
 	mr := s.makeMachiner()
 	c.Assert(worker.Stop(mr), gc.IsNil)
 	c.Assert(s.apiMachine.Refresh(), gc.IsNil)
 	c.Assert(s.apiMachine.Life(), gc.Equals, params.Alive)
 }
 
-func (s *MachinerSuite) TestStartSetsStatus(c *gc.C) {
+func (s *MachinerStateSuite) TestStartSetsStatus(c *gc.C) {
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
@@ -132,14 +224,14 @@ func (s *MachinerSuite) TestStartSetsStatus(c *gc.C) {
 	s.waitMachineStatus(c, s.machine, state.StatusStarted)
 }
 
-func (s *MachinerSuite) TestSetsStatusWhenDying(c *gc.C) {
+func (s *MachinerStateSuite) TestSetsStatusWhenDying(c *gc.C) {
 	mr := s.makeMachiner()
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), gc.IsNil)
 	s.waitMachineStatus(c, s.machine, state.StatusStopped)
 }
 
-func (s *MachinerSuite) TestSetDead(c *gc.C) {
+func (s *MachinerStateSuite) TestSetDead(c *gc.C) {
 	mr := s.makeMachiner()
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), gc.IsNil)
@@ -149,7 +241,7 @@ func (s *MachinerSuite) TestSetDead(c *gc.C) {
 	c.Assert(s.machine.Life(), gc.Equals, state.Dead)
 }
 
-func (s *MachinerSuite) TestSetDeadWithDyingUnit(c *gc.C) {
+func (s *MachinerStateSuite) TestSetDeadWithDyingUnit(c *gc.C) {
 	mr := s.makeMachiner()
 	defer worker.Stop(mr)
 
@@ -181,7 +273,7 @@ func (s *MachinerSuite) TestSetDeadWithDyingUnit(c *gc.C) {
 
 }
 
-func (s *MachinerSuite) TestMachineAddresses(c *gc.C) {
+func (s *MachinerStateSuite) TestMachineAddresses(c *gc.C) {
 	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
 	netConf := []byte(`
   # comments ignored
@@ -228,10 +320,3 @@ LXC_BRIDGE="ignored"`[1:])
 		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
 	})
 }
-
-// TODO(axw) add test for IsCodeMachineHasAttachedStorage when one of the
-//           following is true:
-//            - we can unbind volumes/filesystems from storage instances, or
-//            - we can dynamically add volumes/filesystems to machines
-//              independent of storage, or
-//            - these tests are made into unit tests, with mocked out state

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -228,3 +228,10 @@ LXC_BRIDGE="ignored"`[1:])
 		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
 	})
 }
+
+// TODO(axw) add test for IsCodeMachineHasAttachedStorage when one of the
+//           following is true:
+//            - we can unbind volumes/filesystems from storage instances, or
+//            - we can dynamically add volumes/filesystems to machines
+//              independent of storage, or
+//            - these tests are made into unit tests, with mocked out state

--- a/worker/machiner/mock_test.go
+++ b/worker/machiner/mock_test.go
@@ -1,0 +1,87 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machiner_test
+
+import (
+	"github.com/juju/names"
+	gitjujutesting "github.com/juju/testing"
+
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/worker/machiner"
+)
+
+type mockWatcher struct {
+	gitjujutesting.Stub
+	changes chan struct{}
+}
+
+func (w *mockWatcher) Changes() <-chan struct{} {
+	w.MethodCall(w, "Changes")
+	return w.changes
+}
+
+func (w *mockWatcher) Stop() error {
+	w.MethodCall(w, "Stop")
+	return w.NextErr()
+}
+
+func (w *mockWatcher) Err() error {
+	w.MethodCall(w, "Err")
+	return w.NextErr()
+}
+
+type mockMachine struct {
+	machiner.Machine
+	gitjujutesting.Stub
+	watcher mockWatcher
+	life    params.Life
+}
+
+func (m *mockMachine) Refresh() error {
+	m.MethodCall(m, "Refresh")
+	return m.NextErr()
+}
+
+func (m *mockMachine) Life() params.Life {
+	m.MethodCall(m, "Life")
+	return m.life
+}
+
+func (m *mockMachine) EnsureDead() error {
+	m.MethodCall(m, "EnsureDead")
+	return m.NextErr()
+}
+
+func (m *mockMachine) SetMachineAddresses(addresses []network.Address) error {
+	m.MethodCall(m, "SetMachineAddresses", addresses)
+	return m.NextErr()
+}
+
+func (m *mockMachine) SetStatus(status params.Status, info string, data map[string]interface{}) error {
+	m.MethodCall(m, "SetStatus", status, info, data)
+	return m.NextErr()
+}
+
+func (m *mockMachine) Watch() (watcher.NotifyWatcher, error) {
+	m.MethodCall(m, "Watch")
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	return &m.watcher, nil
+}
+
+type mockMachineAccessor struct {
+	gitjujutesting.Stub
+	machine mockMachine
+}
+
+func (a *mockMachineAccessor) Machine(tag names.MachineTag) (machiner.Machine, error) {
+	a.MethodCall(a, "Machine", tag)
+	if err := a.NextErr(); err != nil {
+		return nil, err
+	}
+	return &a.machine, nil
+}

--- a/worker/machiner/state.go
+++ b/worker/machiner/state.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package machiner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/machiner"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+	"github.com/juju/names"
+)
+
+type MachineAccessor interface {
+	Machine(names.MachineTag) (Machine, error)
+}
+
+type Machine interface {
+	Refresh() error
+	Life() params.Life
+	EnsureDead() error
+	SetMachineAddresses(addresses []network.Address) error
+	SetStatus(status params.Status, info string, data map[string]interface{}) error
+	Watch() (watcher.NotifyWatcher, error)
+}
+
+type APIMachineAccessor struct {
+	State *machiner.State
+}
+
+func (a APIMachineAccessor) Machine(tag names.MachineTag) (Machine, error) {
+	m, err := a.State.Machine(tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return m, nil
+}


### PR DESCRIPTION
Machine.EnsureDead will now fail if the machine has
non-inherently-machine-bound storage associated with it. This includes
persistent storage, and any unprovisioned dynamic storage, since we don't
know whether or not it will be persistent once provisioned, and that could
happen concurrently.

If such storage is present, then EnsureDead will fail with an error that
satisfies state.IsHasAttachmentsError. worker/machiner will check for this
error (which has a new API error code), and ignore it; detaching storage
will cause the machiner worker to be notified again, so it can reattempt.

(Review request: http://reviews.vapour.ws/r/2029/)