### PR TITLE
[Resources] Add http service for resource upload / download

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -399,6 +399,16 @@ func (srv *Server) run(lis net.Listener) {
 			httpHandler{ssState: srv.state},
 		}},
 	)
+	handleAll(mux, "/environment/:envuuid/resources",
+		&resourcesUploadHandler{resourcesHandler{
+			httpHandler{ssState: srv.state},
+		}},
+	)
+	handleAll(mux, "/environment/:envuuid/resources/:basepath",
+		&resourcesDownloadHandler{resourcesHandler{
+			httpHandler{ssState: srv.state},
+		}},
+	)
 	handleAll(mux, "/", http.HandlerFunc(srv.apiHandler))
 	// The error from http.Serve is not interesting.
 	http.Serve(lis, mux)

--- a/apiserver/charmresources/package_test.go
+++ b/apiserver/charmresources/package_test.go
@@ -125,6 +125,8 @@ func (s *baseResourcesSuite) constructResourceManager(c *gc.C) *mockResourceMana
 				if filter.Series != "" && !strings.Contains(v.Path, "s/"+filter.Series) {
 					continue
 				}
+				// Resources always have the type in their path.
+				v.Path = "/blob/" + v.Path
 				result = append(result, v)
 			}
 			return result, nil
@@ -133,7 +135,7 @@ func (s *baseResourcesSuite) constructResourceManager(c *gc.C) *mockResourceMana
 }
 
 func (s *baseResourcesSuite) addResource(res resources.Resource) {
-	s.resources[res.Path] = res
+	s.resources["/blob/"+res.Path] = res
 }
 
 type mockResourceManager struct {

--- a/apiserver/charmresources/resourcemanager_test.go
+++ b/apiserver/charmresources/resourcemanager_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"fmt"
 	"github.com/juju/juju/apiserver/charmresources"
 	"github.com/juju/juju/apiserver/params"
 	resources "github.com/juju/juju/charmresources"
@@ -52,7 +53,7 @@ func (s *resourcesSuite) TestResourcesListAll(c *gc.C) {
 
 	c.Assert(found.Resources, gc.HasLen, 1)
 	c.Assert(found.Resources[0], jc.DeepEquals, params.ResourceMetadata{
-		ResourcePath: "respath",
+		ResourcePath: "/blob/respath",
 		Size:         100,
 		Created:      now,
 	})
@@ -81,11 +82,11 @@ func (s *resourcesSuite) TestResourcesList(c *gc.C) {
 	c.Assert(found.Resources, gc.HasLen, 2)
 	c.Assert(found.Resources, jc.SameContents, []params.ResourceMetadata{
 		{
-			ResourcePath: "respath",
+			ResourcePath: "/blob/respath",
 			Size:         100,
 			Created:      now,
 		}, {
-			ResourcePath: "s/trusty/another",
+			ResourcePath: "/blob/s/trusty/another",
 			Size:         200,
 			Created:      now,
 		},
@@ -235,15 +236,18 @@ func (s *resourcesSuite) TestResourcesDelete(c *gc.C) {
 		expectedErrors[i] = result.Results[i].Error.Message
 	}
 	c.Assert(expectedErrors, gc.DeepEquals, []string{
-		"path cannot be empty", "", "resource notfound not found",
+		"resource path name cannot be empty", "", "resource /blob/notfound not found",
 	})
+
+	fmt.Println(s.resources)
+
 	c.Assert(s.resources, gc.HasLen, 2)
 	var expectedPaths []string
 	for p, _ := range s.resources {
 		expectedPaths = append(expectedPaths, p)
 	}
 	c.Assert(expectedPaths, jc.SameContents, []string{
-		"s/trusty/another",
-		"s/precise/another",
+		"/blob/s/trusty/another",
+		"/blob/s/precise/another",
 	})
 }

--- a/apiserver/charmresources/state.go
+++ b/apiserver/charmresources/state.go
@@ -30,10 +30,6 @@ var getState = func(st *state.State) managerState {
 	return stateShim{st}
 }
 
-func (s stateShim) ResourceManager() resources.ResourceManager {
-	return s.State.ResourceManager()
-}
-
 func (s stateShim) EnvOwner() (names.UserTag, error) {
 	env, err := s.State.Environment()
 	if err != nil {

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -26,6 +26,7 @@ var (
 	NewBackups            = &newBackups
 	ParseLogLine          = parseLogLine
 	AgentMatchesFilter    = agentMatchesFilter
+	GetResourceState      = &getResourceState
 )
 
 func ApiHandlerWithEntity(entity state.Entity) *apiHandler {

--- a/apiserver/params/resources.go
+++ b/apiserver/params/resources.go
@@ -30,7 +30,15 @@ type ListResourcesResult struct {
 
 // ResourceMetadata represents an resource in storage.
 type ResourceMetadata struct {
-	ResourcePath string    `json:"resourcepaths"`
+	ResourcePath string    `json:"resourcepath"`
+	URL          string    `json:"url"`
+	SHA384       string    `json:"sha384"`
 	Size         int64     `json:"size"`
 	Created      time.Time `json:"created"`
+}
+
+// ResourceResult is returned when uploading a resource.
+type ResourceResult struct {
+	Resource ResourceMetadata
+	Error    *Error
 }

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -1,0 +1,294 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	apihttp "github.com/juju/juju/apiserver/http"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/charmresources"
+	"github.com/juju/juju/state"
+)
+
+// resourcesHandler is the base type for uploading and downloading
+// resources over HTTPS via the API server.
+type resourcesHandler struct {
+	httpHandler
+}
+
+// resourcesUploadHandler handles resources upload through HTTPS in the API server.
+type resourcesUploadHandler struct {
+	resourcesHandler
+}
+
+// resourcesHandler handles resources download through HTTPS in the API server.
+type resourcesDownloadHandler struct {
+	resourcesHandler
+}
+
+func (h *resourcesDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	stateWrapper, err := h.validateEnvironUUID(r)
+	if err != nil {
+		h.sendExistingError(w, http.StatusNotFound, err)
+		return
+	}
+	defer stateWrapper.cleanup()
+
+	switch r.Method {
+	case "GET":
+		readers, err := h.processGet(r, getResourceState(stateWrapper.state))
+		if err != nil {
+			logger.Errorf("GET(%s) failed: %v", r.URL, err)
+			h.sendExistingError(w, http.StatusBadRequest, err)
+			return
+		}
+		err = h.sendResources(w, http.StatusOK, readers)
+		if err != nil {
+			logger.Errorf("GET(%s) failed: %v", r.URL, err)
+			h.sendExistingError(w, http.StatusInternalServerError, err)
+			return
+		}
+	default:
+		h.sendError(w, http.StatusMethodNotAllowed, fmt.Sprintf("unsupported method: %q", r.Method))
+	}
+}
+
+func (h *resourcesUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Validate before authenticate because the authentication is dependent
+	// on the state connection that is determined during the validation.
+	stateWrapper, err := h.validateEnvironUUID(r)
+	if err != nil {
+		h.sendExistingError(w, http.StatusNotFound, err)
+		return
+	}
+	defer stateWrapper.cleanup()
+
+	if err := stateWrapper.authenticateUser(r); err != nil {
+		h.authError(w, h)
+		return
+	}
+
+	switch r.Method {
+	case "POST":
+		// Add resources to storage.
+		resource, err := h.processPost(r, getResourceState(stateWrapper.state))
+		if err != nil {
+			h.sendExistingError(w, http.StatusBadRequest, err)
+			return
+		}
+		h.sendJSON(w, http.StatusOK, &params.ResourceResult{Resource: *resource})
+	default:
+		h.sendError(w, http.StatusMethodNotAllowed, fmt.Sprintf("unsupported method: %q", r.Method))
+	}
+}
+
+// sendJSON sends a JSON-encoded response to the client.
+func (h *resourcesHandler) sendJSON(w http.ResponseWriter, statusCode int, response *params.ResourceResult) error {
+	w.Header().Set("Content-Type", apihttp.CTypeJSON)
+	w.WriteHeader(statusCode)
+	body, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+	w.Write(body)
+	return nil
+}
+
+// sendError sends a JSON-encoded error response using desired
+// error message.
+func (h *resourcesHandler) sendError(w http.ResponseWriter, statusCode int, message string) {
+	h.sendExistingError(w, statusCode, errors.New(message))
+}
+
+// sendExistingError sends a JSON-encoded error response
+// for errors encountered during processing.
+func (h *resourcesHandler) sendExistingError(w http.ResponseWriter, statusCode int, existing error) {
+	logger.Debugf("sending error: %v %v", statusCode, existing)
+	err := common.ServerError(existing)
+	if err := h.sendJSON(w, statusCode, &params.ResourceResult{Error: err}); err != nil {
+		logger.Errorf("failed to send error: %v", err)
+	}
+}
+
+func resourceAttributes(url *url.URL) charmresources.ResourceAttributes {
+	query := url.Query()
+	attrs := charmresources.ResourceAttributes{
+		PathName: query.Get("path"),
+		Revision: query.Get("revision"),
+		Type:     query.Get("type"),
+		User:     query.Get("user"),
+		Org:      query.Get("org"),
+		Stream:   query.Get("stream"),
+		Series:   query.Get("series"),
+	}
+	// If this is for a download then path is part of URL.
+	if attrs.PathName == "" {
+		attrs.PathName = query.Get(":basepath")
+	}
+	return attrs
+}
+
+func resourceURL(serverRoot string, attrs charmresources.ResourceAttributes) string {
+	url := fmt.Sprintf("%s/resources/%s", serverRoot, attrs.PathName)
+	url += fmt.Sprintf("?revision=%s", attrs.Revision)
+	if attrs.Org != "" {
+		url += fmt.Sprintf("&org=%s", attrs.Org)
+	}
+	if attrs.User != "" {
+		url += fmt.Sprintf("&user=%s", attrs.User)
+	}
+	if attrs.Stream != "" {
+		url += fmt.Sprintf("&stream=%s", attrs.Stream)
+	}
+	if attrs.Series != "" {
+		url += fmt.Sprintf("&series=%s", attrs.Series)
+	}
+	if attrs.Type != "" {
+		url += fmt.Sprintf("&type=%s", attrs.Type)
+	}
+	return url
+}
+
+// processGet handles a resource GET request.
+func (h *resourcesDownloadHandler) processGet(r *http.Request, st ResourceState) ([]charmresources.ResourceReader, error) {
+	attrs := resourceAttributes(r.URL)
+	resourcePath, err := charmresources.ResourcePath(attrs)
+	if err != nil {
+		return nil, errors.Annotate(err, "invalid resource attributes")
+	}
+	manager := st.ResourceManager()
+	readers, err := manager.ResourceGet(resourcePath)
+	if errors.IsNotFound(err) {
+		// TODO(wallyworld) - fetch from public store and cache
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(readers) > 1 {
+		// TODO(wallyworld) - support multiple resource streams
+		return nil, errors.NotSupportedf("dependent resources")
+	}
+	return readers, nil
+}
+
+// sendResources streams the resources to the client.
+func (h *resourcesDownloadHandler) sendResources(w http.ResponseWriter, statusCode int, readers []charmresources.ResourceReader) error {
+	if len(readers) != 1 {
+		// TODO(wallyworld) - support dependent resources (multipart)
+		// This has already been checked.
+		panic("dependent resources not supported")
+	}
+	reader := readers[0]
+	defer reader.Close()
+	// Stream the resource to the caller.
+	logger.Debugf("streaming resource %v from state resource store", reader.Path)
+	w.Header().Set("Content-Type", apihttp.CTypeRaw)
+	w.Header().Set("Digest", fmt.Sprintf("%s=%s", apihttp.DigestSHA, reader.SHA384Hash))
+	w.Header().Set("Content-Length", fmt.Sprint(reader.Size))
+	w.WriteHeader(http.StatusOK)
+	if _, err := io.Copy(w, reader); err != nil {
+		return errors.Annotate(err, "while streaming resource")
+	}
+	return nil
+}
+
+// processPost handles a resource upload POST request after authentication.
+func (h *resourcesUploadHandler) processPost(r *http.Request, st ResourceState) (*params.ResourceMetadata, error) {
+	attrs := resourceAttributes(r.URL)
+	if attrs.Revision == "" {
+		return nil, errors.New("revision is required to upload resources")
+	}
+	// Make sure the content type is correct.
+	contentType := r.Header.Get("Content-Type")
+	if contentType != apihttp.CTypeRaw {
+		return nil, errors.Errorf("expected Content-Type: %v, got: %v", apihttp.CTypeRaw, contentType)
+	}
+
+	// Get the server root, so we know how to form the URL in the resources returned.
+	serverRoot, err := h.getServerRoot(r, r.URL.Query(), st)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot to determine server root")
+	}
+
+	resourcePath, err := charmresources.ResourcePath(attrs)
+	if err != nil {
+		return nil, errors.Annotate(err, "invalid resource attributes")
+	}
+	query := r.URL.Query()
+	resourceMetadata := charmresources.Resource{
+		Path:       resourcePath,
+		SHA384Hash: query.Get("sha384"),
+	}
+
+	defer r.Body.Close()
+	return h.handleUpload(r.Body, attrs, resourceMetadata, serverRoot, st)
+}
+
+func (h *resourcesUploadHandler) getServerRoot(r *http.Request, query url.Values, st ResourceState) (string, error) {
+	uuid := query.Get(":envuuid")
+	if uuid == "" {
+		uuid = st.EnvironUUID()
+	}
+	return fmt.Sprintf("https://%s/environment/%s", r.Host, uuid), nil
+}
+
+// handleUpload uploads the RESOURCES data from the reader to resource storage at the specified path.
+func (h *resourcesUploadHandler) handleUpload(
+	rdr io.Reader, attrs charmresources.ResourceAttributes, resourceMetadata charmresources.Resource,
+	serverRoot string, st ResourceState,
+) (*params.ResourceMetadata, error) {
+	// Check if changes are allowed and the command may proceed.
+	blockChecker := common.NewBlockChecker(st)
+	if err := blockChecker.ChangeAllowed(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	manager := st.ResourceManager()
+	metadata, err := manager.ResourcePut(resourceMetadata, rdr)
+	if err != nil {
+		return nil, errors.Annotatef(err, "saving resource %v", metadata.Path)
+	}
+	if metadata.Size == 0 {
+		return nil, errors.New("no resources uploaded")
+	}
+	path := metadata.Path
+	if path[0] == '/' {
+		path = path[1:]
+	}
+	result := &params.ResourceMetadata{
+		ResourcePath: metadata.Path,
+		Size:         metadata.Size,
+		SHA384:       metadata.SHA384Hash,
+		Created:      metadata.Created,
+		URL:          resourceURL(serverRoot, attrs),
+	}
+	return result, nil
+}
+
+// ResourceState is used to allow a mock to be substituted when testing.
+type ResourceState interface {
+	// ResourceManager provides the capability to persist resources.
+	ResourceManager() charmresources.ResourceManager
+
+	// EnvironUUID is needed for resource uploads.
+	EnvironUUID() string
+
+	// GetBlockForType is required to block operations.
+	GetBlockForType(t state.BlockType) (state.Block, bool, error)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+var getResourceState = func(st *state.State) ResourceState {
+	return stateShim{st}
+}

--- a/apiserver/resources_test.go
+++ b/apiserver/resources_test.go
@@ -166,6 +166,10 @@ func sha384sum(c *gc.C, path string) (int64, string) {
 }
 
 func (s *resourcesSuite) TestUpload(c *gc.C) {
+	// These block wil not stop uploads.
+	s.BlockDestroyEnvironment(c, "TestUpload")
+	s.BlockRemoveObject(c, "TestUpload")
+
 	// Make a fake resource.
 	expectedMetadata, resPath := s.setupResourceForUpload(c)
 	expectedMetadata.ResourcePath = "/zip/u/fred/c/test/s/trusty/test-resource/1.2.3"

--- a/apiserver/resources_test.go
+++ b/apiserver/resources_test.go
@@ -1,0 +1,500 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"crypto/sha512"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	commontesting "github.com/juju/juju/apiserver/common/testing"
+	apihttp "github.com/juju/juju/apiserver/http"
+	"github.com/juju/juju/apiserver/params"
+
+	"bytes"
+	"encoding/hex"
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/charmresources"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"path/filepath"
+	"time"
+)
+
+type resourcesSuite struct {
+	userAuthHttpSuite
+	commontesting.BlockHelper
+	baseResourcesSuite
+}
+
+var _ = gc.Suite(&resourcesSuite{})
+
+func (s *resourcesSuite) SetUpSuite(c *gc.C) {
+	s.userAuthHttpSuite.SetUpSuite(c)
+	s.baseResourcesSuite.SetUpSuite(c)
+	s.archiveContentType = "application/x-tar-gz"
+}
+
+func (s *resourcesSuite) SetUpTest(c *gc.C) {
+	s.userAuthHttpSuite.SetUpTest(c)
+	s.baseResourcesSuite.SetUpTest(c)
+	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
+	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
+}
+
+func (s *resourcesSuite) TearDownSuite(c *gc.C) {
+	s.baseResourcesSuite.TearDownSuite(c)
+	s.userAuthHttpSuite.TearDownSuite(c)
+}
+
+func (s *resourcesSuite) TearDownTest(c *gc.C) {
+	s.baseResourcesSuite.TearDownTest(c)
+	s.userAuthHttpSuite.TearDownTest(c)
+}
+
+func (s *resourcesSuite) TestResourcesUploadedSecurely(c *gc.C) {
+	info := s.APIInfo(c)
+	uri := "http://" + info.Addrs[0] + "/resources"
+	_, err := s.sendRequest(c, "", "", "PUT", uri, "", nil)
+	c.Assert(err, gc.ErrorMatches, `.*malformed HTTP response.*`)
+}
+
+func (s *resourcesSuite) TestRequiresAuth(c *gc.C) {
+	resp, err := s.sendRequest(c, "", "", "GET", s.resourcesURI(c, "", "path=foo"), "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "unauthorized")
+}
+
+func (s *resourcesSuite) TestRequiresPOST(c *gc.C) {
+	resp, err := s.authRequest(c, "PUT", s.resourcesURI(c, "", "path=foo"), "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "PUT"`)
+}
+
+func (s *resourcesSuite) TestAuthRequiresUser(c *gc.C) {
+	// Add a machine and try to login.
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetProvisioned("foo", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	password, err := utils.RandomPassword()
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetPassword(password)
+	c.Assert(err, jc.ErrorIsNil)
+
+	resp, err := s.sendRequest(c, machine.Tag().String(), password, "POST", s.resourcesURI(c, "", "path=foo"), "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "unauthorized")
+
+	// Now try a user login.
+	resp, err = s.authRequest(c, "POST", s.resourcesURI(c, "", "path=foo"), "application/octet-stream", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, "revision is required to upload resources")
+}
+
+func (s *resourcesSuite) TestUploadRequiresRevision(c *gc.C) {
+	resp, err := s.authRequest(c, "POST", s.resourcesURI(c, "", "path=foo"), "application/octet-stream", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, "revision is required to upload resources")
+}
+
+func (s *resourcesSuite) TestUploadFailsWithNoResources(c *gc.C) {
+	// Create an empty file.
+	tempFile, err := ioutil.TempFile(c.MkDir(), "resource")
+	c.Assert(err, jc.ErrorIsNil)
+
+	resp, err := s.uploadRequest(c, s.resourcesURI(c, "", "path=foo&revision=v1.2"), false, tempFile.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, "no resources uploaded")
+}
+
+func (s *resourcesSuite) TestUploadFailsWithInvalidContentType(c *gc.C) {
+	// Create an empty file.
+	tempFile, err := ioutil.TempFile(c.MkDir(), "resource")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now try with the default Content-Type.
+	resp, err := s.uploadRequest(c, s.resourcesURI(c, "", "path=foo&revision=v1.2"), true, tempFile.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(
+		c, resp, http.StatusBadRequest, "expected Content-Type: application/octet-stream, got: application/x-tar-gz")
+}
+
+func (s *resourcesSuite) setupResourceForUpload(c *gc.C) (*params.ResourceMetadata, string) {
+	localStorage := c.MkDir()
+	path := filepath.Join(localStorage, "test-resource.dat")
+	data := "this is a resource"
+	err := ioutil.WriteFile(path, []byte(data), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	metadata := &params.ResourceMetadata{
+		ResourcePath: "/blob/test-resource/1.2.3",
+	}
+	metadata.Size, metadata.SHA384 = sha384sum(c, path)
+	return metadata, path
+}
+
+func sha384sum(c *gc.C, path string) (int64, string) {
+	if strings.HasPrefix(path, "file://") {
+		path = path[len("file://"):]
+	}
+	f, err := os.Open(path)
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer f.Close()
+	hash := sha512.New384()
+	size, err := io.Copy(hash, f)
+	c.Assert(err, jc.ErrorIsNil)
+	digest := hex.EncodeToString(hash.Sum(nil))
+	return size, digest
+}
+
+func (s *resourcesSuite) TestUpload(c *gc.C) {
+	// Make a fake resource.
+	expectedMetadata, resPath := s.setupResourceForUpload(c)
+	expectedMetadata.ResourcePath = "/zip/u/fred/c/test/s/trusty/test-resource/1.2.3"
+	// Now try uploading them.
+	resourceParams := "revision=1.2.3&user=fred&stream=test&series=trusty&type=zip"
+	resp, err := s.uploadRequest(
+		c, s.resourcesURI(c, "", "path=test-resource&"+resourceParams), false, resPath)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedCalls := []string{
+		getBlockForTypeCall,
+		resourceManagerCall,
+		resourcePutCall,
+	}
+	s.assertCalls(c, expectedCalls)
+
+	// Check the response.
+	expectedMetadata.URL = fmt.Sprintf("%s/environment/%s/resources/test-resource?"+resourceParams, s.baseURL(c), s.State.EnvironUUID())
+	c.Assert(expectedMetadata.Created.Unix(), gc.Not(gc.Equals), 0)
+	s.assertUploadResponse(c, resp, expectedMetadata)
+
+	// Check the contents.
+	uploadedData := s.resourcesData["/zip/u/fred/c/test/s/trusty/test-resource/1.2.3"]
+	expectedData, err := ioutil.ReadFile(resPath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uploadedData, gc.DeepEquals, expectedData)
+
+	// Can it be downloaded again ie is the URL correct.
+	metadata := charmresources.Resource{
+		Path:       "/zip/u/fred/c/test/s/trusty/test-resource/1.2.3",
+		Size:       expectedMetadata.Size,
+		SHA384Hash: expectedMetadata.SHA384,
+	}
+	s.testDownload(c, expectedMetadata.URL, metadata)
+}
+
+//
+func (s *resourcesSuite) TestBlockUpload(c *gc.C) {
+	// Make a fake resource.
+	_, resPath := s.setupResourceForUpload(c)
+	// Block all changes.
+	s.blockAllChanges(c, "TestUpload")
+	// Now try uploading them.
+	resp, err := s.uploadRequest(
+		c, s.resourcesURI(c, "", "path=test-resource&revision=1.2.3"), false, resPath)
+	c.Check(err, jc.ErrorIsNil)
+	problem := s.assertErrorResponse(c, resp, http.StatusBadRequest, "TestUpload")
+	s.AssertBlocked(c, problem, "TestUpload")
+
+	expectedCalls := []string{
+		getBlockForTypeCall,
+	}
+	s.assertCalls(c, expectedCalls)
+
+	// Check the contents.
+	_, ok := s.resourcesData["/blob/test-resource/1.2.3"]
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *resourcesSuite) TestUploadAllowsOtherEnvUUIDPath(c *gc.C) {
+	envState := s.setupOtherEnvironment(c)
+	// Make a fake resource.
+	expectedMetadata, resPath := s.setupResourceForUpload(c)
+	url := s.resourcesURL(c, "", "path=test-resource&revision=1.2.3")
+	url.Path = fmt.Sprintf("/environment/%s/resources", envState.EnvironUUID())
+	resp, err := s.uploadRequest(c, url.String(), false, resPath)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check the response.
+	expectedMetadata.URL = fmt.Sprintf(
+		"%s/environment/%s/resources/test-resource?revision=1.2.3", s.baseURL(c), envState.EnvironUUID())
+	s.assertUploadResponse(c, resp, expectedMetadata)
+}
+
+func (s *resourcesSuite) TestUploadRejectsWrongEnvUUIDPath(c *gc.C) {
+	// Check that we cannot access the resources at https://host:port/BADENVUUID/resources
+	url := s.resourcesURL(c, "", "path=test-resource&revision=1.2.3")
+	url.Path = "/environment/dead-beef-123456/resources"
+	resp, err := s.authRequest(c, "POST", url.String(), "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown environment: "dead-beef-123456"`)
+}
+
+func (s *resourcesSuite) TestDownload(c *gc.C) {
+	metadata := charmresources.Resource{
+		Path: "/blob/test-resource/1.2.3",
+		Size: 3,
+	}
+	hash := sha512.New384()
+	hash.Write([]byte("abc"))
+	metadata.SHA384Hash = hex.EncodeToString(hash.Sum(nil))
+
+	s.storeFakeResource(c, "abc", metadata)
+	url := s.resourcesURL(c, "test-resource", "revision=1.2.3")
+	s.testDownload(c, url.String(), metadata)
+
+	expectedCalls := []string{
+		resourceManagerCall,
+		resourceGetCall,
+	}
+	s.assertCalls(c, expectedCalls)
+
+}
+
+func (s *resourcesSuite) TestDownloadOtherEnvUUIDPath(c *gc.C) {
+	envState := s.setupOtherEnvironment(c)
+	metadata := charmresources.Resource{
+		Path: "/blob/test-resource/1.2.3",
+		Size: 3,
+	}
+	hash := sha512.New384()
+	hash.Write([]byte("abc"))
+	metadata.SHA384Hash = hex.EncodeToString(hash.Sum(nil))
+
+	s.storeFakeResource(c, "abc", metadata)
+	url := s.resourcesURL(c, "test-resource", "revision=1.2.3")
+	url.Path = fmt.Sprintf("/environment/%s/resources/test-resource", envState.EnvironUUID())
+	s.testDownload(c, url.String(), metadata)
+}
+
+func (s *resourcesSuite) testDownload(c *gc.C, url string, metadata charmresources.Resource) []byte {
+	resp, err := s.downloadRequest(c, url)
+	c.Assert(err, jc.ErrorIsNil)
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.HasLen, int(metadata.Size))
+
+	hash := sha512.New384()
+	hash.Write(data)
+	c.Assert(fmt.Sprintf("%x", hash.Sum(nil)), gc.Equals, metadata.SHA384Hash)
+	return data
+}
+
+func (s *resourcesSuite) TestDownloadRejectsWrongEnvUUIDPath(c *gc.C) {
+	url := s.resourcesURL(c, "test-resource", "revision=1.2.3")
+	url.Path = "/environment/dead-beef-123456/resources/test-resource"
+	resp, err := s.downloadRequest(c, url.String())
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown environment: "dead-beef-123456"`)
+}
+
+func (s *resourcesSuite) resourcesURL(c *gc.C, basePath, query string) *url.URL {
+	uri := s.baseURL(c)
+	if basePath != "" && basePath[0] != '/' {
+		basePath = "/" + basePath
+	}
+	uri.Path = fmt.Sprintf("/environment/%s/resources%s", s.envUUID, basePath)
+	uri.RawQuery = query
+	return uri
+}
+
+func (s *resourcesSuite) resourcesURI(c *gc.C, basePath, query string) string {
+	if query != "" && query[0] == '?' {
+		query = query[1:]
+	}
+	return s.resourcesURL(c, basePath, query).String()
+}
+
+func (s *resourcesSuite) downloadRequest(c *gc.C, url string) (*http.Response, error) {
+	return s.sendRequest(c, "", "", "GET", url, "", nil)
+}
+
+func (s *resourcesSuite) assertUploadResponse(c *gc.C, resp *http.Response, resource *params.ResourceMetadata) {
+	body := assertResponse(c, resp, http.StatusOK, apihttp.CTypeJSON)
+	resourceResult := jsonResourcesResponse(c, body)
+	c.Check(resourceResult.Error, gc.IsNil)
+	// Make the crested times match so we can compare.
+	resource.Created = time.Now()
+	resourceResult.Resource.Created = resource.Created
+	c.Check(&resourceResult.Resource, gc.DeepEquals, resource)
+}
+
+func (s *resourcesSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBody, expContentType string) {
+	body := assertResponse(c, resp, http.StatusOK, expContentType)
+	c.Check(string(body), gc.Equals, expBody)
+}
+
+func (s *resourcesSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) error {
+	body := assertResponse(c, resp, expCode, apihttp.CTypeJSON)
+	err := jsonResourcesResponse(c, body).Error
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, expError)
+	return err
+}
+
+func jsonResourcesResponse(c *gc.C, body []byte) (jsonResponse params.ResourceResult) {
+	err := json.Unmarshal(body, &jsonResponse)
+	c.Assert(err, jc.ErrorIsNil)
+	return
+}
+
+// baseResourceSuite provides mocked state and resource storage.
+type baseResourcesSuite struct {
+	coretesting.BaseSuite
+
+	state *mockState
+
+	calls []string
+
+	resourceManager *mockResourceManager
+	resources       map[string]charmresources.Resource
+	resourcesData   map[string][]byte
+	blocks          map[state.BlockType]state.Block
+}
+
+func (s *baseResourcesSuite) SetUpTest(c *gc.C) {
+	s.calls = []string{}
+	s.state = s.constructState(c)
+
+	s.resources = make(map[string]charmresources.Resource)
+	s.resourcesData = make(map[string][]byte)
+	s.resourceManager = s.constructResourceManager(c)
+	st := s.constructState(c)
+	s.PatchValue(apiserver.GetResourceState, func(*state.State) apiserver.ResourceState {
+		return st
+	})
+}
+
+func (s *baseResourcesSuite) assertCalls(c *gc.C, expectedCalls []string) {
+	c.Assert(s.calls, jc.SameContents, expectedCalls)
+}
+
+const (
+	resourceGetCall     = "resourceGet"
+	resourcePutCall     = "resourcePut"
+	resourceManagerCall = "resourceManager"
+	getBlockForTypeCall = "getBlockForType"
+)
+
+func (s *baseResourcesSuite) constructState(c *gc.C) *mockState {
+	s.blocks = make(map[state.BlockType]state.Block)
+	return &mockState{
+		resourceManager: func() charmresources.ResourceManager {
+			s.calls = append(s.calls, resourceManagerCall)
+			return s.resourceManager
+		},
+		getBlockForType: func(t state.BlockType) (state.Block, bool, error) {
+			s.calls = append(s.calls, getBlockForTypeCall)
+			val, found := s.blocks[t]
+			return val, found, nil
+		},
+	}
+}
+
+func (s *baseResourcesSuite) storeFakeResource(c *gc.C, content string, metadata charmresources.Resource) {
+	s.resources[metadata.Path] = metadata
+	s.resourcesData[metadata.Path] = []byte(content)
+}
+
+func (s *baseResourcesSuite) constructResourceManager(c *gc.C) *mockResourceManager {
+	return &mockResourceManager{
+		resourcePut: func(metadata charmresources.Resource, rdr io.Reader) (charmresources.Resource, error) {
+			s.calls = append(s.calls, resourcePutCall)
+			sha384hash := sha512.New384()
+			r := io.TeeReader(rdr, sha384hash)
+			data, err := ioutil.ReadAll(r)
+			c.Assert(err, jc.ErrorIsNil)
+			s.resourcesData[metadata.Path] = data
+			res := metadata
+			res.Size = int64(len(data))
+			res.SHA384Hash = hex.EncodeToString(sha384hash.Sum(nil))
+			return res, nil
+		},
+		resourceGet: func(resourcePath string) ([]charmresources.ResourceReader, error) {
+			s.calls = append(s.calls, resourceGetCall)
+			data, ok := s.resourcesData[resourcePath]
+			if !ok {
+				return nil, errors.NotFoundf("resource at path %v", resourcePath)
+			}
+			hash := sha512.New384()
+			hash.Write(data)
+			metadata := charmresources.Resource{
+				Path:       resourcePath,
+				Size:       int64(len(data)),
+				SHA384Hash: hex.EncodeToString(hash.Sum(nil)),
+			}
+			rdr := ioutil.NopCloser(bytes.NewReader(data))
+			return []charmresources.ResourceReader{
+				{rdr, metadata},
+			}, nil
+		},
+	}
+}
+
+type mockResourceManager struct {
+	charmresources.ResourceManager
+	resourcePut func(metadata charmresources.Resource, rdr io.Reader) (charmresources.Resource, error)
+	resourceGet func(resourcePath string) ([]charmresources.ResourceReader, error)
+}
+
+func (m *mockResourceManager) ResourceGet(resourcePath string) ([]charmresources.ResourceReader, error) {
+	return m.resourceGet(resourcePath)
+}
+
+func (m *mockResourceManager) ResourcePut(metadata charmresources.Resource, rdr io.Reader) (charmresources.Resource, error) {
+	return m.resourcePut(metadata, rdr)
+}
+
+type mockState struct {
+	resourceManager func() charmresources.ResourceManager
+	getBlockForType func(t state.BlockType) (state.Block, bool, error)
+}
+
+func (st *mockState) ResourceManager() charmresources.ResourceManager {
+	return st.resourceManager()
+}
+
+func (st *mockState) GetBlockForType(t state.BlockType) (state.Block, bool, error) {
+	return st.getBlockForType(t)
+}
+
+func (st *mockState) EnvironUUID() string {
+	return "uuid"
+}
+
+func (s *baseResourcesSuite) addBlock(c *gc.C, t state.BlockType, msg string) {
+	s.blocks[t] = mockBlock{t: t, msg: msg}
+}
+
+func (s *baseResourcesSuite) blockAllChanges(c *gc.C, msg string) {
+	s.addBlock(c, state.ChangeBlock, msg)
+}
+
+type mockBlock struct {
+	state.Block
+	t   state.BlockType
+	msg string
+}
+
+func (b mockBlock) Type() state.BlockType {
+	return b.t
+}
+
+func (b mockBlock) Message() string {
+	return b.msg
+}

--- a/charmresources/interface.go
+++ b/charmresources/interface.go
@@ -8,10 +8,20 @@ import (
 	"time"
 )
 
+type ResourceType string
+
+const (
+	// These constants represent the supported resource types.
+	ResourceTypeBlob = ResourceType("blob")
+	ResourceTypeZip  = ResourceType("zip")
+
+	DefaultResourceType = ResourceTypeBlob
+)
+
 // ResourceReader is used to gain access to a resource's data bytes.
 type ResourceReader struct {
-	io.Reader
-	PathName string
+	io.ReadCloser
+	Resource
 }
 
 // ResourceAttributes describe a resource and are used to form
@@ -61,7 +71,8 @@ type ResourceManager interface {
 	ResourceGet(resourcePath string) ([]ResourceReader, error)
 
 	// ResourcePut stores the resource with the specified metadata.
-	ResourcePut(metadata Resource, rdr io.ReadCloser) error
+	// Returned is the metadata with additional attributes filled in.
+	ResourcePut(metadata Resource, rdr io.Reader) (Resource, error)
 
 	// ResourceList returns resource metadata matching the specified filter.
 	ResourceList(filter ResourceAttributes) ([]Resource, error)

--- a/charmresources/interface.go
+++ b/charmresources/interface.go
@@ -70,8 +70,8 @@ type ResourceManager interface {
 	// dependent resources from the specified path.
 	ResourceGet(resourcePath string) ([]ResourceReader, error)
 
-	// ResourcePut stores the resource with the specified metadata.
-	// Returned is the metadata with additional attributes filled in.
+	// ResourcePut stores the resource with the specified metadata,
+	// and returns the metadata with additional attributes filled in.
 	ResourcePut(metadata Resource, rdr io.Reader) (Resource, error)
 
 	// ResourceList returns resource metadata matching the specified filter.

--- a/charmresources/resourcepath.go
+++ b/charmresources/resourcepath.go
@@ -12,13 +12,38 @@ import (
 // ResourcePath constructs a path to use in a resource store from
 // the specified resource attributes.
 func ResourcePath(params ResourceAttributes) (string, error) {
-	// TODO(wallyworld) - this is not complete, just enough to allow ResourceManager tests to work.
+	if err := validatePathParameters(params); err != nil {
+		return "", err
+	}
+	if params.Type == "" {
+		params.Type = string(ResourceTypeBlob)
+	}
 	path := params.PathName
-	if path == "" {
-		return "", errors.New("path cannot be empty")
-	}
 	if params.Series != "" {
-		path = fmt.Sprintf("/s/%s/%s", params.Series, path)
+		path = fmt.Sprintf("s/%s/%s", params.Series, path)
 	}
+	if params.Stream != "" {
+		path = fmt.Sprintf("c/%s/%s", params.Stream, path)
+	}
+	if params.User != "" {
+		path = fmt.Sprintf("u/%s/%s", params.User, path)
+	}
+	if params.Org != "" {
+		path = fmt.Sprintf("org/%s/%s", params.Org, path)
+	}
+	if params.Revision != "" {
+		path = fmt.Sprintf("%s/%s", path, params.Revision)
+	}
+	path = fmt.Sprintf("/%s/%s", params.Type, path)
 	return path, nil
+}
+
+func validatePathParameters(params ResourceAttributes) error {
+	if params.PathName == "" {
+		return errors.New("resource path name cannot be empty")
+	}
+	if params.User != "" && params.Org != "" {
+		return errors.New("both user and org cannot be specified together")
+	}
+	return nil
 }

--- a/charmresources/resourcepath.go
+++ b/charmresources/resourcepath.go
@@ -4,7 +4,7 @@
 package charmresources
 
 import (
-	"fmt"
+	"path"
 
 	"github.com/juju/errors"
 )
@@ -18,24 +18,24 @@ func ResourcePath(params ResourceAttributes) (string, error) {
 	if params.Type == "" {
 		params.Type = string(ResourceTypeBlob)
 	}
-	path := params.PathName
+	resPath := params.PathName
 	if params.Series != "" {
-		path = fmt.Sprintf("s/%s/%s", params.Series, path)
+		resPath = path.Join("s", params.Series, resPath)
 	}
 	if params.Stream != "" {
-		path = fmt.Sprintf("c/%s/%s", params.Stream, path)
+		resPath = path.Join("c", params.Stream, resPath)
 	}
 	if params.User != "" {
-		path = fmt.Sprintf("u/%s/%s", params.User, path)
+		resPath = path.Join("u", params.User, resPath)
 	}
 	if params.Org != "" {
-		path = fmt.Sprintf("org/%s/%s", params.Org, path)
+		resPath = path.Join("org", params.Org, resPath)
 	}
 	if params.Revision != "" {
-		path = fmt.Sprintf("%s/%s", path, params.Revision)
+		resPath = path.Join(resPath, params.Revision)
 	}
-	path = fmt.Sprintf("/%s/%s", params.Type, path)
-	return path, nil
+	resPath = path.Join("/"+params.Type, resPath)
+	return resPath, nil
 }
 
 func validatePathParameters(params ResourceAttributes) error {

--- a/charmresources/resourcepath_test.go
+++ b/charmresources/resourcepath_test.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmresources_test
+
+import (
+	stdtesting "testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/charmresources"
+	"github.com/juju/juju/testing"
+)
+
+func Test(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+type resourcepathSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&resourcepathSuite{})
+
+func (*resourcepathSuite) TestPathFromAttributes(c *gc.C) {
+	for i, test := range []struct {
+		attrs    charmresources.ResourceAttributes
+		expected string
+		err      string
+	}{{
+		attrs: charmresources.ResourceAttributes{},
+		err:   "resource path name cannot be empty",
+	}, {
+		attrs: charmresources.ResourceAttributes{PathName: "path", User: "foo", Org: "bar"},
+		err:   "both user and org cannot be specified together",
+	}, {
+		attrs:    charmresources.ResourceAttributes{PathName: "base-path"},
+		expected: "/blob/base-path",
+	}, {
+		attrs:    charmresources.ResourceAttributes{PathName: "base-path", Stream: "test"},
+		expected: "/blob/c/test/base-path",
+	}, {
+		attrs:    charmresources.ResourceAttributes{PathName: "base-path", Series: "trusty"},
+		expected: "/blob/s/trusty/base-path",
+	}, {
+		attrs:    charmresources.ResourceAttributes{PathName: "base-path", Revision: "1.2.3"},
+		expected: "/blob/base-path/1.2.3",
+	}, {
+		attrs:    charmresources.ResourceAttributes{PathName: "base-path", Type: "zip"},
+		expected: "/zip/base-path",
+	}, {
+		attrs:    charmresources.ResourceAttributes{PathName: "base-path", User: "fred"},
+		expected: "/blob/u/fred/base-path",
+	}, {
+		attrs:    charmresources.ResourceAttributes{PathName: "base-path", Org: "acme"},
+		expected: "/blob/org/acme/base-path",
+	}, {
+		attrs:    charmresources.ResourceAttributes{PathName: "base-path", User: "fred", Stream: "test", Series: "trusty", Revision: "1.2.3"},
+		expected: "/blob/u/fred/c/test/s/trusty/base-path/1.2.3",
+	}} {
+		c.Logf("test %d", i)
+		path, err := charmresources.ResourcePath(test.attrs)
+		if test.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(path, gc.Equals, test.expected)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}


### PR DESCRIPTION
http servers are provided to support upload and download of resources
There's no backend yet - the state resource manager is mocked out in tests.

(Review request: http://reviews.vapour.ws/r/2031/)