### PR TITLE
Lock operations before starting prepare

### DIFF
--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/names"
 	corecharm "gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charm.v5/hooks"
-	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/uniter/charm"
@@ -22,26 +21,6 @@ import (
 // keep those methods off the Uniter itself.
 type operationCallbacks struct {
 	u *Uniter
-}
-
-// AcquireExecutionLock is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) AcquireExecutionLock(message string) (func(), error) {
-	// We want to make sure we don't block forever when locking, but take the
-	// Uniter's tomb into account.
-	checkTomb := func() error {
-		select {
-		case <-opc.u.tomb.Dying():
-			return tomb.ErrDying
-		default:
-			// no-op to fall through to return.
-		}
-		return nil
-	}
-	message = fmt.Sprintf("%s: %s", opc.u.unit.Name(), message)
-	if err := opc.u.hookLock.LockWithFunc(message, checkTomb); err != nil {
-		return nil, err
-	}
-	return func() { opc.u.hookLock.Unlock() }, nil
 }
 
 // PrepareHook is part of the operation.Callbacks interface.

--- a/worker/uniter/operation/deploy.go
+++ b/worker/uniter/operation/deploy.go
@@ -16,6 +16,8 @@ import (
 
 // deploy implements charm install and charm upgrade operations.
 type deploy struct {
+	DoesNotRequireMachineLock
+
 	kind     Kind
 	charmURL *corecharm.URL
 	revert   bool

--- a/worker/uniter/operation/deploy_test.go
+++ b/worker/uniter/operation/deploy_test.go
@@ -651,3 +651,26 @@ func (s *DeploySuite) TestCommitInterruptedHook_RevertUpgrade(c *gc.C) {
 func (s *DeploySuite) TestCommitInterruptedHook_ResolvedUpgrade(c *gc.C) {
 	s.testCommitInterruptedHook(c, (operation.Factory).NewResolvedUpgrade)
 }
+
+func (s *DeploySuite) testDoesNotNeedGlobalMachineLock(c *gc.C, newDeploy newDeploy) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := newDeploy(factory, curl("cs:quantal/x-0"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.NeedsGlobalMachineLock(), jc.IsFalse)
+}
+
+func (s *DeploySuite) TestDoesNotNeedGlobalMachineLock_Install(c *gc.C) {
+	s.testDoesNotNeedGlobalMachineLock(c, (operation.Factory).NewInstall)
+}
+
+func (s *DeploySuite) TestDoesNotNeedGlobalMachineLock_Upgrade(c *gc.C) {
+	s.testDoesNotNeedGlobalMachineLock(c, (operation.Factory).NewUpgrade)
+}
+
+func (s *DeploySuite) TestDoesNotNeedGlobalMachineLock_RevertUpgrade(c *gc.C) {
+	s.testDoesNotNeedGlobalMachineLock(c, (operation.Factory).NewRevertUpgrade)
+}
+
+func (s *DeploySuite) TestDoesNotNeedGlobalMachineLock_ResolvedUpgrade(c *gc.C) {
+	s.testDoesNotNeedGlobalMachineLock(c, (operation.Factory).NewResolvedUpgrade)
+}

--- a/worker/uniter/operation/executor_test.go
+++ b/worker/uniter/operation/executor_test.go
@@ -29,6 +29,10 @@ func failGetInstallCharm() (*corecharm.URL, error) {
 	return nil, errors.New("lol!")
 }
 
+func failAcquireLock(string) (func() error, error) {
+	return nil, errors.New("wat")
+}
+
 func (s *NewExecutorSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.basePath = c.MkDir()
@@ -39,14 +43,14 @@ func (s *NewExecutorSuite) path(path string) string {
 }
 
 func (s *NewExecutorSuite) TestNewExecutorNoFileNoCharm(c *gc.C) {
-	executor, err := operation.NewExecutor(s.path("missing"), failGetInstallCharm)
+	executor, err := operation.NewExecutor(s.path("missing"), failGetInstallCharm, failAcquireLock)
 	c.Assert(executor, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "lol!")
 }
 
 func (s *NewExecutorSuite) TestNewExecutorInvalidFile(c *gc.C) {
 	ft.File{"existing", "", 0666}.Create(c, s.basePath)
-	executor, err := operation.NewExecutor(s.path("existing"), failGetInstallCharm)
+	executor, err := operation.NewExecutor(s.path("existing"), failGetInstallCharm, failAcquireLock)
 	c.Assert(executor, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `cannot read ".*": invalid operation state: .*`)
 }
@@ -56,7 +60,7 @@ func (s *NewExecutorSuite) TestNewExecutorNoFile(c *gc.C) {
 	getInstallCharm := func() (*corecharm.URL, error) {
 		return charmURL, nil
 	}
-	executor, err := operation.NewExecutor(s.path("missing"), getInstallCharm)
+	executor, err := operation.NewExecutor(s.path("missing"), getInstallCharm, failAcquireLock)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(executor.State(), gc.DeepEquals, operation.State{
 		Kind:     operation.Install,
@@ -76,7 +80,7 @@ started: true
 op: continue
 opstep: pending
 `[1:], 0666}.Create(c, s.basePath)
-	executor, err := operation.NewExecutor(s.path("existing"), failGetInstallCharm)
+	executor, err := operation.NewExecutor(s.path("existing"), failGetInstallCharm, failAcquireLock)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(executor.State(), gc.DeepEquals, operation.State{
 		Kind:    operation.Continue,
@@ -101,7 +105,7 @@ func newExecutor(c *gc.C, st *operation.State) (operation.Executor, string) {
 	path := filepath.Join(c.MkDir(), "state")
 	err := operation.NewStateFile(path).Write(st)
 	c.Assert(err, jc.ErrorIsNil)
-	executor, err := operation.NewExecutor(path, failGetInstallCharm)
+	executor, err := operation.NewExecutor(path, failGetInstallCharm, failAcquireLock)
 	c.Assert(err, jc.ErrorIsNil)
 	return executor, path
 }
@@ -116,6 +120,7 @@ func justInstalledState() operation.State {
 func (s *ExecutorSuite) TestSucceedNoStateChanges(c *gc.C) {
 	initialState := justInstalledState()
 	executor, statePath := newExecutor(c, &initialState)
+
 	op := &mockOperation{
 		prepare: newStep(nil, nil),
 		execute: newStep(nil, nil),
@@ -320,10 +325,225 @@ func (s *ExecutorSuite) TestFailCommitWithStateChange(c *gc.C) {
 	c.Assert(executor.State(), gc.DeepEquals, *op.commit.newState)
 }
 
+func (s *ExecutorSuite) initLockTest(c *gc.C, lockFunc func(string) (func() error, error)) operation.Executor {
+
+	initialState := justInstalledState()
+	statePath := filepath.Join(c.MkDir(), "state")
+	err := operation.NewStateFile(statePath).Write(&initialState)
+	c.Assert(err, jc.ErrorIsNil)
+	executor, err := operation.NewExecutor(statePath, failGetInstallCharm, lockFunc)
+	c.Assert(err, jc.ErrorIsNil)
+
+	return executor
+}
+
+func (s *ExecutorSuite) TestLockSucceedsStepsCalled(c *gc.C) {
+	op := &mockOperation{
+		needsLock: true,
+		prepare:   newStep(nil, nil),
+		execute:   newStep(nil, nil),
+		commit:    newStep(nil, nil),
+	}
+
+	mockLock := &mockLockFunc{op: op}
+	lockFunc := mockLock.newSucceedingLockUnlockSucceeds()
+	executor := s.initLockTest(c, lockFunc)
+
+	err := executor.Run(op)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(mockLock.calledLock, jc.IsTrue)
+	c.Assert(mockLock.calledUnlock, jc.IsTrue)
+	c.Assert(mockLock.noStepsCalledOnLock, jc.IsTrue)
+
+	expectedStepsOnUnlock := []bool{true, true, true}
+	c.Assert(mockLock.stepsCalledOnUnlock, gc.DeepEquals, expectedStepsOnUnlock)
+}
+
+func (s *ExecutorSuite) TestLockSucceedsStepsCalledUnlockFails(c *gc.C) {
+	op := &mockOperation{
+		needsLock: true,
+		prepare:   newStep(nil, nil),
+		execute:   newStep(nil, nil),
+		commit:    newStep(nil, nil),
+	}
+
+	mockLock := &mockLockFunc{op: op}
+	lockFunc := mockLock.newSucceedingLockUnlockFails()
+	executor := s.initLockTest(c, lockFunc)
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, "but why")
+
+	c.Assert(mockLock.calledLock, jc.IsTrue)
+	c.Assert(mockLock.calledUnlock, jc.IsTrue)
+	c.Assert(mockLock.noStepsCalledOnLock, jc.IsTrue)
+
+	expectedStepsOnUnlock := []bool{true, true, true}
+	c.Assert(mockLock.stepsCalledOnUnlock, gc.DeepEquals, expectedStepsOnUnlock)
+}
+
+func (s *ExecutorSuite) TestOpFailsUnlockFailsUnlockErrPropagated(c *gc.C) {
+	op := &mockOperation{
+		needsLock: true,
+		prepare:   newStep(nil, errors.New("kerblooie")),
+		execute:   newStep(nil, nil),
+		commit:    newStep(nil, nil),
+	}
+
+	mockLock := &mockLockFunc{op: op}
+	lockFunc := mockLock.newSucceedingLockUnlockFails()
+	executor := s.initLockTest(c, lockFunc)
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, "but why")
+
+	c.Assert(mockLock.calledLock, jc.IsTrue)
+	c.Assert(mockLock.calledUnlock, jc.IsTrue)
+	c.Assert(mockLock.noStepsCalledOnLock, jc.IsTrue)
+
+	expectedStepsOnUnlock := []bool{true, false, false}
+	c.Assert(mockLock.stepsCalledOnUnlock, gc.DeepEquals, expectedStepsOnUnlock)
+}
+
+func (s *ExecutorSuite) TestLockFailsOpsStepsNotCalled(c *gc.C) {
+	op := &mockOperation{
+		needsLock: true,
+		prepare:   newStep(nil, nil),
+		execute:   newStep(nil, nil),
+		commit:    newStep(nil, nil),
+	}
+
+	mockLock := &mockLockFunc{op: op}
+	lockFunc := mockLock.newFailingLock()
+	executor := s.initLockTest(c, lockFunc)
+
+	err := executor.Run(op)
+	c.Assert(err, gc.ErrorMatches, "could not acquire lock: wat")
+
+	c.Assert(mockLock.calledLock, jc.IsFalse)
+	c.Assert(mockLock.calledUnlock, jc.IsFalse)
+	c.Assert(mockLock.noStepsCalledOnLock, jc.IsTrue)
+
+	c.Assert(op.prepare.called, jc.IsFalse)
+	c.Assert(op.execute.called, jc.IsFalse)
+	c.Assert(op.commit.called, jc.IsFalse)
+}
+
+func (s *ExecutorSuite) testLockUnlocksOnError(c *gc.C, op *mockOperation) (error, *mockLockFunc) {
+	mockLock := &mockLockFunc{op: op}
+	lockFunc := mockLock.newSucceedingLockUnlockSucceeds()
+	executor := s.initLockTest(c, lockFunc)
+
+	err := executor.Run(op)
+
+	c.Assert(mockLock.calledLock, jc.IsTrue)
+	c.Assert(mockLock.calledUnlock, jc.IsTrue)
+	c.Assert(mockLock.noStepsCalledOnLock, jc.IsTrue)
+
+	return err, mockLock
+}
+
+func (s *ExecutorSuite) TestLockUnlocksOnError_Prepare(c *gc.C) {
+	op := &mockOperation{
+		needsLock: true,
+		prepare:   newStep(nil, errors.New("kerblooie")),
+		execute:   newStep(nil, nil),
+		commit:    newStep(nil, nil),
+	}
+
+	err, mockLock := s.testLockUnlocksOnError(c, op)
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": kerblooie`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "kerblooie")
+
+	expectedStepsOnUnlock := []bool{true, false, false}
+	c.Assert(mockLock.stepsCalledOnUnlock, gc.DeepEquals, expectedStepsOnUnlock)
+}
+
+func (s *ExecutorSuite) TestLockUnlocksOnError_Execute(c *gc.C) {
+	op := &mockOperation{
+		needsLock: true,
+		prepare:   newStep(nil, nil),
+		execute:   newStep(nil, errors.New("you asked for it")),
+		commit:    newStep(nil, nil),
+	}
+
+	err, mockLock := s.testLockUnlocksOnError(c, op)
+	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation": you asked for it`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "you asked for it")
+
+	expectedStepsOnUnlock := []bool{true, true, false}
+	c.Assert(mockLock.stepsCalledOnUnlock, gc.DeepEquals, expectedStepsOnUnlock)
+}
+
+func (s *ExecutorSuite) TestLockUnlocksOnError_Commit(c *gc.C) {
+	op := &mockOperation{
+		needsLock: true,
+		prepare:   newStep(nil, nil),
+		execute:   newStep(nil, nil),
+		commit:    newStep(nil, errors.New("well, shit")),
+	}
+
+	err, mockLock := s.testLockUnlocksOnError(c, op)
+	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation": well, shit`)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "well, shit")
+
+	expectedStepsOnUnlock := []bool{true, true, true}
+	c.Assert(mockLock.stepsCalledOnUnlock, gc.DeepEquals, expectedStepsOnUnlock)
+}
+
+type mockLockFunc struct {
+	noStepsCalledOnLock bool
+	stepsCalledOnUnlock []bool
+	calledLock          bool
+	calledUnlock        bool
+	op                  *mockOperation
+}
+
+func (mock *mockLockFunc) newFailingLock() func(string) (func() error, error) {
+	return func(string) (func() error, error) {
+		mock.noStepsCalledOnLock = mock.op.prepare.called == false &&
+			mock.op.commit.called == false &&
+			mock.op.prepare.called == false
+		return nil, errors.New("wat")
+	}
+
+}
+
+func (mock *mockLockFunc) newSucceedingLock(unlockFails bool) func(string) (func() error, error) {
+	return func(string) (func() error, error) {
+		mock.calledLock = true
+		// Ensure that when we lock no operation has been called
+		mock.noStepsCalledOnLock = mock.op.prepare.called == false &&
+			mock.op.commit.called == false &&
+			mock.op.prepare.called == false
+		return func() error {
+			// Record steps called when unlocking
+			mock.stepsCalledOnUnlock = []bool{mock.op.prepare.called,
+				mock.op.execute.called,
+				mock.op.commit.called}
+			mock.calledUnlock = true
+			if unlockFails {
+				return errors.New("but why")
+			}
+			return nil
+		}, nil
+	}
+}
+
+func (mock *mockLockFunc) newSucceedingLockUnlockFails() func(string) (func() error, error) {
+	return mock.newSucceedingLock(true)
+}
+
+func (mock *mockLockFunc) newSucceedingLockUnlockSucceeds() func(string) (func() error, error) {
+	return mock.newSucceedingLock(false)
+}
+
 type mockStep struct {
 	gotState operation.State
 	newState *operation.State
 	err      error
+	called   bool
 }
 
 func newStep(newState *operation.State, err error) *mockStep {
@@ -331,18 +551,24 @@ func newStep(newState *operation.State, err error) *mockStep {
 }
 
 func (step *mockStep) run(state operation.State) (*operation.State, error) {
+	step.called = true
 	step.gotState = state
 	return step.newState, step.err
 }
 
 type mockOperation struct {
-	prepare *mockStep
-	execute *mockStep
-	commit  *mockStep
+	needsLock bool
+	prepare   *mockStep
+	execute   *mockStep
+	commit    *mockStep
 }
 
 func (op *mockOperation) String() string {
 	return "mock operation"
+}
+
+func (op *mockOperation) NeedsGlobalMachineLock() bool {
+	return op.needsLock
 }
 
 func (op *mockOperation) Prepare(state operation.State) (*operation.State, error) {

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -25,6 +25,9 @@ type Operation interface {
 	// String returns a short representation of the operation.
 	String() string
 
+	// NeedsGlobalMachineLock returns a bool expressing whether we need to lock the machine.
+	NeedsGlobalMachineLock() bool
+
 	// Prepare ensures that the operation is valid and ready to be executed.
 	// If it returns a non-nil state, that state will be validated and recorded.
 	// If it returns ErrSkipExecute, it indicates that the operation can be
@@ -133,8 +136,6 @@ type CommandResponseFunc func(*utilexec.ExecResponse, error)
 // It's far from cohesive, and fundamentally represents inappropriate coupling, so
 // it's a prime candidate for future refactoring.
 type Callbacks interface {
-	ExecutionLocker
-
 	// PrepareHook and CommitHook exist so that we can defer worrying about how
 	// to untangle Uniter.relationers from everything else. They're only used by
 	// RunHook operations.
@@ -186,14 +187,4 @@ type StorageUpdater interface {
 	// UpdateStorage updates local knowledge of the storage attachments
 	// with the specified tags.
 	UpdateStorage([]names.StorageTag) error
-}
-
-// ExecutionLocker is an interface that provides a means of acquiring and
-// releasing a machine-level lock. When acquiring the lock, the caller provides
-// a message which will be recorded to aid in debugging.
-type ExecutionLocker interface {
-	// AcquireExecutionLock acquires the machine-level execution lock, and
-	// returns a func that must be called to unlock it. It's used by all the
-	// operations that execute external code.
-	AcquireExecutionLock(message string) (unlock func(), err error)
 }

--- a/worker/uniter/operation/leader.go
+++ b/worker/uniter/operation/leader.go
@@ -9,7 +9,9 @@ import (
 	"github.com/juju/juju/worker/uniter/hook"
 )
 
-type acceptLeadership struct{}
+type acceptLeadership struct {
+	DoesNotRequireMachineLock
+}
 
 // String is part of the Operation interface.
 func (al *acceptLeadership) String() string {
@@ -58,7 +60,9 @@ func (al *acceptLeadership) checkState(state State) error {
 	return nil
 }
 
-type resignLeadership struct{}
+type resignLeadership struct {
+	DoesNotRequireMachineLock
+}
 
 // String is part of the Operation interface.
 func (rl *resignLeadership) String() string {

--- a/worker/uniter/operation/leader_test.go
+++ b/worker/uniter/operation/leader_test.go
@@ -114,6 +114,13 @@ func (s *LeaderSuite) TestAcceptLeadership_Commit_AlreadyLeader(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
+func (s *LeaderSuite) TestAcceptLeadership_DoesNotNeedGlobalMachineLock(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewAcceptLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.NeedsGlobalMachineLock(), jc.IsFalse)
+}
+
 func (s *LeaderSuite) TestResignLeadership_Prepare_Leader(c *gc.C) {
 	factory := operation.NewFactory(nil, nil, nil, nil, nil)
 	op, err := factory.NewResignLeadership()
@@ -178,4 +185,11 @@ func (s *LeaderSuite) TestResignLeadership_Commit_All(c *gc.C) {
 	newState, err := op.Commit(leaderState)
 	c.Check(newState, gc.DeepEquals, &overwriteState)
 	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *LeaderSuite) TestResignLeadership_DoesNotNeedGlobalMachineLock(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewResignLeadership()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.NeedsGlobalMachineLock(), jc.IsFalse)
 }

--- a/worker/uniter/operation/lock.go
+++ b/worker/uniter/operation/lock.go
@@ -1,0 +1,21 @@
+// Copyright 2014-2015 Canonical Ltd.
+// Copyright 2015 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package operation
+
+// DoesNotRequireMachineLock is embedded in the various operations to express whether
+// they need a global machine lock or not.
+type RequiresMachineLock struct{}
+
+// NeedsGlobalMachineLock is part of the Operation interface.
+// It is embedded in the various operations.
+func (RequiresMachineLock) NeedsGlobalMachineLock() bool { return true }
+
+// DoesNotRequireMachineLock is embedded in the various operations to express whether
+// they need a global machine lock or not.
+type DoesNotRequireMachineLock struct{}
+
+// NeedsGlobalMachineLock is part of the Operation interface.
+// It is embedded in the various operations.
+func (DoesNotRequireMachineLock) NeedsGlobalMachineLock() bool { return false }

--- a/worker/uniter/operation/relations.go
+++ b/worker/uniter/operation/relations.go
@@ -11,6 +11,8 @@ type updateRelations struct {
 	ids []int
 
 	callbacks Callbacks
+
+	DoesNotRequireMachineLock
 }
 
 // String is part of the Operation interface.

--- a/worker/uniter/operation/relations_test.go
+++ b/worker/uniter/operation/relations_test.go
@@ -69,3 +69,10 @@ func (s *UpdateRelationsSuite) TestCommit(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(state, gc.IsNil)
 }
+
+func (s *UpdateRelationsSuite) TestDoesNotNeedGlobalMachineLock(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewUpdateRelations(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.NeedsGlobalMachineLock(), jc.IsFalse)
+}

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -19,6 +19,8 @@ type runAction struct {
 
 	name   string
 	runner runner.Runner
+
+	RequiresMachineLock
 }
 
 // String is part of the Operation interface.
@@ -61,17 +63,12 @@ func (ra *runAction) Prepare(state State) (*State, error) {
 // Execute is part of the Operation interface.
 func (ra *runAction) Execute(state State) (*State, error) {
 	message := fmt.Sprintf("running action %s", ra.name)
-	unlock, err := ra.callbacks.AcquireExecutionLock(message)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
 
 	if err := ra.callbacks.SetExecutingStatus(message); err != nil {
 		return nil, err
 	}
 
-	err = ra.runner.RunAction(ra.name)
+	err := ra.runner.RunAction(ra.name)
 	if err != nil {
 		// This indicates an actual error -- an action merely failing should
 		// be handled inside the Runner, and returned as nil.

--- a/worker/uniter/operation/runcommands.go
+++ b/worker/uniter/operation/runcommands.go
@@ -19,6 +19,8 @@ type runCommands struct {
 	runnerFactory runner.Factory
 
 	runner runner.Runner
+
+	RequiresMachineLock
 }
 
 // String is part of the Operation interface.
@@ -53,12 +55,6 @@ func (rc *runCommands) Prepare(state State) (*State, error) {
 // state change.
 // Execute is part of the Operation interface.
 func (rc *runCommands) Execute(state State) (*State, error) {
-	unlock, err := rc.callbacks.AcquireExecutionLock("run commands")
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
-
 	if err := rc.callbacks.SetExecutingStatus("running commands"); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/operation/runcommands_test.go
+++ b/worker/uniter/operation/runcommands_test.go
@@ -58,34 +58,12 @@ func (s *RunCommandsSuite) TestPrepareSuccess(c *gc.C) {
 	})
 }
 
-func (s *RunCommandsSuite) TestExecuteLockError(c *gc.C) {
-	runnerFactory := &MockRunnerFactory{
-		MockNewCommandRunner: &MockNewCommandRunner{},
-	}
-	callbacks := &RunCommandsCallbacks{
-		MockAcquireExecutionLock: &MockAcquireExecutionLock{err: errors.New("sneh")},
-	}
-	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil, nil)
-	sendResponse := func(*utilexec.ExecResponse, error) { panic("not expected") }
-	op, err := factory.NewCommands(someCommandArgs, sendResponse)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	newState, err := op.Execute(operation.State{})
-	c.Assert(newState, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "sneh")
-	c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "run commands")
-}
-
 func (s *RunCommandsSuite) TestExecuteRebootErrors(c *gc.C) {
 	for _, sendErr := range []error{runner.ErrRequeueAndReboot, runner.ErrReboot} {
 		runnerFactory := NewRunCommandsRunnerFactory(
 			&utilexec.ExecResponse{Code: 101}, sendErr,
 		)
-		callbacks := &RunCommandsCallbacks{
-			MockAcquireExecutionLock: &MockAcquireExecutionLock{},
-		}
+		callbacks := &RunCommandsCallbacks{}
 		factory := operation.NewFactory(nil, runnerFactory, callbacks, nil, nil)
 		sendResponse := &MockSendResponse{}
 		op, err := factory.NewCommands(someCommandArgs, sendResponse.Call)
@@ -96,8 +74,6 @@ func (s *RunCommandsSuite) TestExecuteRebootErrors(c *gc.C) {
 		newState, err := op.Execute(operation.State{})
 		c.Assert(newState, gc.IsNil)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "run commands")
-		c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 		c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
 		c.Assert(*sendResponse.gotResponse, gc.DeepEquals, &utilexec.ExecResponse{Code: 101})
 		c.Assert(*sendResponse.gotErr, gc.Equals, operation.ErrNeedsReboot)
@@ -108,9 +84,7 @@ func (s *RunCommandsSuite) TestExecuteOtherError(c *gc.C) {
 	runnerFactory := NewRunCommandsRunnerFactory(
 		nil, errors.New("sneh"),
 	)
-	callbacks := &RunCommandsCallbacks{
-		MockAcquireExecutionLock: &MockAcquireExecutionLock{},
-	}
+	callbacks := &RunCommandsCallbacks{}
 	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil, nil)
 	sendResponse := &MockSendResponse{}
 	op, err := factory.NewCommands(someCommandArgs, sendResponse.Call)
@@ -121,8 +95,6 @@ func (s *RunCommandsSuite) TestExecuteOtherError(c *gc.C) {
 	newState, err := op.Execute(operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "run commands")
-	c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
 	c.Assert(*sendResponse.gotResponse, gc.IsNil)
 	c.Assert(*sendResponse.gotErr, gc.ErrorMatches, "sneh")
@@ -132,9 +104,7 @@ func (s *RunCommandsSuite) TestExecuteSuccess(c *gc.C) {
 	runnerFactory := NewRunCommandsRunnerFactory(
 		&utilexec.ExecResponse{Code: 222}, nil,
 	)
-	callbacks := &RunCommandsCallbacks{
-		MockAcquireExecutionLock: &MockAcquireExecutionLock{},
-	}
+	callbacks := &RunCommandsCallbacks{}
 	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil, nil)
 	sendResponse := &MockSendResponse{}
 	op, err := factory.NewCommands(someCommandArgs, sendResponse.Call)
@@ -145,9 +115,6 @@ func (s *RunCommandsSuite) TestExecuteSuccess(c *gc.C) {
 	newState, err := op.Execute(operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "run commands")
-	c.Assert(callbacks.executingMessage, gc.Equals, "running commands")
-	c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
 	c.Assert(*sendResponse.gotResponse, gc.DeepEquals, &utilexec.ExecResponse{Code: 222})
 	c.Assert(*sendResponse.gotErr, jc.ErrorIsNil)
@@ -161,4 +128,12 @@ func (s *RunCommandsSuite) TestCommit(c *gc.C) {
 	newState, err := op.Commit(operation.State{})
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *RunCommandsSuite) TestNeedsGlobalMachineLock(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	sendResponse := &MockSendResponse{}
+	op, err := factory.NewCommands(someCommandArgs, sendResponse.Call)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.NeedsGlobalMachineLock(), jc.IsTrue)
 }

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -24,6 +24,8 @@ type runHook struct {
 
 	name   string
 	runner runner.Runner
+
+	RequiresMachineLock
 }
 
 // String is part of the Operation interface.
@@ -72,12 +74,6 @@ func RunningHookMessage(hookName string) string {
 // Execute is part of the Operation interface.
 func (rh *runHook) Execute(state State) (*State, error) {
 	message := RunningHookMessage(rh.name)
-	unlock, err := rh.callbacks.AcquireExecutionLock(message)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
-
 	if err := rh.beforeHook(); err != nil {
 		return nil, err
 	}
@@ -91,7 +87,7 @@ func (rh *runHook) Execute(state State) (*State, error) {
 	ranHook := true
 	step := Done
 
-	err = rh.runner.RunHook(rh.name)
+	err := rh.runner.RunHook(rh.name)
 	cause := errors.Cause(err)
 	switch {
 	case runner.IsMissingHookError(cause):

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -163,39 +163,12 @@ func (s *RunHookSuite) TestPrepareSuccess_Preserve(c *gc.C) {
 	}
 }
 
-func (s *RunHookSuite) testExecuteLockError(c *gc.C, newHook newHook) {
-	runnerFactory := NewRunHookRunnerFactory(errors.New("should not call"))
-	callbacks := &ExecuteHookCallbacks{
-		PrepareHookCallbacks:     NewPrepareHookCallbacks(),
-		MockAcquireExecutionLock: &MockAcquireExecutionLock{err: errors.New("blart")},
-	}
-	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil, nil)
-	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = op.Prepare(operation.State{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	newState, err := op.Execute(operation.State{})
-	c.Assert(newState, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "blart")
-	c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "running some-hook-name hook")
-}
-
-func (s *RunHookSuite) TestExecuteLockError_Run(c *gc.C) {
-	s.testExecuteLockError(c, (operation.Factory).NewRunHook)
-}
-
-func (s *RunHookSuite) TestExecuteLockError_Retry(c *gc.C) {
-	s.testExecuteLockError(c, (operation.Factory).NewRetryHook)
-}
-
 func (s *RunHookSuite) getExecuteRunnerTest(c *gc.C, newHook newHook, kind hooks.Kind, runErr error) (operation.Operation, *ExecuteHookCallbacks, *MockRunnerFactory) {
 	runnerFactory := NewRunHookRunnerFactory(runErr)
 	callbacks := &ExecuteHookCallbacks{
-		PrepareHookCallbacks:     NewPrepareHookCallbacks(),
-		MockAcquireExecutionLock: &MockAcquireExecutionLock{},
-		MockNotifyHookCompleted:  &MockNotify{},
-		MockNotifyHookFailed:     &MockNotify{},
+		PrepareHookCallbacks:    NewPrepareHookCallbacks(),
+		MockNotifyHookCompleted: &MockNotify{},
+		MockNotifyHookFailed:    &MockNotify{},
 	}
 	factory := operation.NewFactory(nil, runnerFactory, callbacks, nil, nil)
 	op, err := newHook(factory, hook.Info{Kind: kind})
@@ -218,8 +191,6 @@ func (s *RunHookSuite) testExecuteMissingHookError(c *gc.C, newHook newHook) {
 			Step: operation.Done,
 			Hook: &hook.Info{Kind: kind},
 		})
-		c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "running some-hook-name hook")
-		c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 		c.Assert(*runnerFactory.MockNewHookRunner.runner.MockRunHook.gotName, gc.Equals, "some-hook-name")
 		c.Assert(callbacks.MockNotifyHookCompleted.gotName, gc.IsNil)
 		c.Assert(callbacks.MockNotifyHookFailed.gotName, gc.IsNil)
@@ -251,8 +222,6 @@ func (s *RunHookSuite) testExecuteRequeueRebootError(c *gc.C, newHook newHook) {
 		Step: operation.Queued,
 		Hook: &hook.Info{Kind: hooks.ConfigChanged},
 	})
-	c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "running some-hook-name hook")
-	c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 	c.Assert(*runnerFactory.MockNewHookRunner.runner.MockRunHook.gotName, gc.Equals, "some-hook-name")
 	c.Assert(*callbacks.MockNotifyHookCompleted.gotName, gc.Equals, "some-hook-name")
 	c.Assert(*callbacks.MockNotifyHookCompleted.gotContext, gc.Equals, runnerFactory.MockNewHookRunner.runner.context)
@@ -280,8 +249,6 @@ func (s *RunHookSuite) testExecuteRebootError(c *gc.C, newHook newHook) {
 		Step: operation.Done,
 		Hook: &hook.Info{Kind: hooks.ConfigChanged},
 	})
-	c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "running some-hook-name hook")
-	c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 	c.Assert(*runnerFactory.MockNewHookRunner.runner.MockRunHook.gotName, gc.Equals, "some-hook-name")
 	c.Assert(*callbacks.MockNotifyHookCompleted.gotName, gc.Equals, "some-hook-name")
 	c.Assert(*callbacks.MockNotifyHookCompleted.gotContext, gc.Equals, runnerFactory.MockNewHookRunner.runner.context)
@@ -305,8 +272,6 @@ func (s *RunHookSuite) testExecuteOtherError(c *gc.C, newHook newHook) {
 	newState, err := op.Execute(operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrHookFailed)
 	c.Assert(newState, gc.IsNil)
-	c.Assert(*callbacks.MockAcquireExecutionLock.gotMessage, gc.Equals, "running some-hook-name hook")
-	c.Assert(callbacks.MockAcquireExecutionLock.didUnlock, jc.IsTrue)
 	c.Assert(*runnerFactory.MockNewHookRunner.runner.MockRunHook.gotName, gc.Equals, "some-hook-name")
 	c.Assert(*callbacks.MockNotifyHookFailed.gotName, gc.Equals, "some-hook-name")
 	c.Assert(*callbacks.MockNotifyHookFailed.gotContext, gc.Equals, runnerFactory.MockNewHookRunner.runner.context)
@@ -882,4 +847,23 @@ func (s *RunHookSuite) TestCommitSuccess_CollectMetricsTime_Retry(c *gc.C) {
 
 func (s *RunHookSuite) TestCommitSuccess_CollectMetricsTime_Skip(c *gc.C) {
 	s.testCommitSuccess_CollectMetricsTime(c, (operation.Factory).NewSkipHook)
+}
+
+func (s *RunHookSuite) testNeedsGlobalMachineLock(c *gc.C, newHook newHook, expected bool) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := newHook(factory, hook.Info{Kind: hooks.ConfigChanged})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.NeedsGlobalMachineLock(), gc.Equals, expected)
+}
+
+func (s *RunHookSuite) TestNeedsGlobalMachineLock_Run(c *gc.C) {
+	s.testNeedsGlobalMachineLock(c, (operation.Factory).NewRunHook, true)
+}
+
+func (s *RunHookSuite) TestNeedsGlobalMachineLock_Retry(c *gc.C) {
+	s.testNeedsGlobalMachineLock(c, (operation.Factory).NewRetryHook, true)
+}
+
+func (s *RunHookSuite) TestNeedsGlobalMachineLock_Skip(c *gc.C) {
+	s.testNeedsGlobalMachineLock(c, (operation.Factory).NewSkipHook, false)
 }

--- a/worker/uniter/operation/skip.go
+++ b/worker/uniter/operation/skip.go
@@ -16,6 +16,11 @@ func (op *skipOperation) String() string {
 	return fmt.Sprintf("skip %s", op.Operation)
 }
 
+// NeedsGlobalMachineLock is part of the Operation interface.
+func (op *skipOperation) NeedsGlobalMachineLock() bool {
+	return false
+}
+
 // Prepare is part of the Operation interface.
 func (op *skipOperation) Prepare(state State) (*State, error) {
 	return nil, ErrSkipExecute

--- a/worker/uniter/operation/storage.go
+++ b/worker/uniter/operation/storage.go
@@ -13,6 +13,8 @@ type updateStorage struct {
 	tags []names.StorageTag
 
 	storageUpdater StorageUpdater
+
+	DoesNotRequireMachineLock
 }
 
 // String is part of the Operation interface.

--- a/worker/uniter/operation/storage_test.go
+++ b/worker/uniter/operation/storage_test.go
@@ -75,6 +75,13 @@ func (s *UpdateStorageSuite) TestCommit(c *gc.C) {
 	c.Check(state, gc.IsNil)
 }
 
+func (s *UpdateStorageSuite) TestDoesNotNeedGlobalMachineLock(c *gc.C) {
+	factory := operation.NewFactory(nil, nil, nil, nil, nil)
+	op, err := factory.NewUpdateStorage(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.NeedsGlobalMachineLock(), jc.IsFalse)
+}
+
 type mockStorageUpdater struct {
 	tags [][]names.StorageTag
 	err  error

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -123,33 +123,14 @@ func (mock *MockFailAction) Call(actionId, message string) error {
 	return mock.err
 }
 
-type MockAcquireExecutionLock struct {
-	gotMessage *string
-	didUnlock  bool
-	err        error
-}
-
-func (mock *MockAcquireExecutionLock) Call(message string) (func(), error) {
-	mock.gotMessage = &message
-	if mock.err != nil {
-		return nil, mock.err
-	}
-	return func() { mock.didUnlock = true }, nil
-}
-
 type RunActionCallbacks struct {
 	operation.Callbacks
 	*MockFailAction
-	*MockAcquireExecutionLock
 	executingMessage string
 }
 
 func (cb *RunActionCallbacks) FailAction(actionId, message string) error {
 	return cb.MockFailAction.Call(actionId, message)
-}
-
-func (cb *RunActionCallbacks) AcquireExecutionLock(message string) (func(), error) {
-	return cb.MockAcquireExecutionLock.Call(message)
 }
 
 func (cb *RunActionCallbacks) SetExecutingStatus(message string) error {
@@ -159,12 +140,7 @@ func (cb *RunActionCallbacks) SetExecutingStatus(message string) error {
 
 type RunCommandsCallbacks struct {
 	operation.Callbacks
-	*MockAcquireExecutionLock
 	executingMessage string
-}
-
-func (cb *RunCommandsCallbacks) AcquireExecutionLock(message string) (func(), error) {
-	return cb.MockAcquireExecutionLock.Call(message)
 }
 
 func (cb *RunCommandsCallbacks) SetExecutingStatus(message string) error {
@@ -215,13 +191,8 @@ func (mock *MockNotify) Call(hookName string, ctx runner.Context) {
 
 type ExecuteHookCallbacks struct {
 	*PrepareHookCallbacks
-	*MockAcquireExecutionLock
 	MockNotifyHookCompleted *MockNotify
 	MockNotifyHookFailed    *MockNotify
-}
-
-func (cb *ExecuteHookCallbacks) AcquireExecutionLock(message string) (func(), error) {
-	return cb.MockAcquireExecutionLock.Call(message)
 }
 
 func (cb *ExecuteHookCallbacks) NotifyHookCompleted(hookName string, ctx runner.Context) {


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-core/+bug/1464470

The main idea is to acquire the machine lock before starting the executor steps.

(Review request: http://reviews.vapour.ws/r/2034/)