### PR TITLE
Make sure the Juju conf dir exists for an upgrade step.

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -211,6 +211,9 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 
 // newAgent returns a new MachineAgent instance
 func (s *commonMachineSuite) newAgent(c *gc.C, m *state.Machine) *MachineAgent {
+	confDir := filepath.Join(s.RootDir, "/etc/juju")
+	s.PatchValue(&agent.DefaultConfDir, confDir)
+
 	agentConf := agentConf{dataDir: s.DataDir()}
 	agentConf.ReadConfig(names.NewMachineTag(m.Id()).String())
 	machineAgentFactory := MachineAgentFactoryFn(&agentConf, &agentConf)

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -237,7 +237,8 @@ var NewRsyslogConfigWorker = func(st *apirsyslog.State, agentConfig agent.Config
 	if err != nil {
 		return nil, err
 	}
-	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, agent.DefaultConfDir)
+	confDir := agent.DefaultConfDir
+	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, confDir)
 }
 
 // ParamsStateServingInfoToStateStateServingInfo converts a

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -39,7 +39,7 @@ func stateStepsFor124() []Step {
 func stepsFor124() []Step {
 	return []Step{
 		&upgradeStep{
-			description: "move syslog config from LogDir to DataDir",
+			description: "move syslog config from LogDir to ConfDir",
 			targets:     []Target{AllMachines},
 			run:         moveSyslogConfig,
 		},

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -50,9 +50,13 @@ func moveSyslogConfig(context Context) error {
 	config := context.AgentConfig()
 	namespace := config.Value(agent.Namespace)
 	logdir := config.LogDir()
+
 	confdir := agent.DefaultConfDir
 	if namespace != "" {
 		confdir += "-" + namespace
+	}
+	if err := os.MkdirAll(confdir, 0755); err != nil {
+		return errors.Trace(err)
 	}
 
 	// these values were copied from

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -103,20 +103,23 @@ func copyFile(to, from string) error {
 		return errors.NotFoundf(from)
 	}
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer orig.Close()
 	info, err := orig.Stat()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	target, err := os.OpenFile(to, os.O_CREATE|os.O_WRONLY|os.O_EXCL, info.Mode())
 	if os.IsExist(err) {
 		return nil
 	}
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer target.Close()
 	if _, err := io.Copy(target, orig); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -55,6 +55,7 @@ func moveSyslogConfig(context Context) error {
 	if namespace != "" {
 		confdir += "-" + namespace
 	}
+	confdir = filepath.Join(confdir, "rsyslog")
 	if err := os.MkdirAll(confdir, 0755); err != nil {
 		return errors.Trace(err)
 	}

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -34,7 +34,7 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 
 func (s *steps124Suite) TestStepsFor124(c *gc.C) {
 	expected := []string{
-		"move syslog config from LogDir to DataDir",
+		"move syslog config from LogDir to ConfDir",
 	}
 	assertSteps(c, version.MustParse("1.24.0"), expected)
 }

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -195,6 +195,24 @@ func (s *steps124SyslogSuite) TestMoveSyslogConfigCantDeleteOld(c *gc.C) {
 	s.newFile("logrotate.conf").checkExists(c)
 }
 
+func (s *steps124SyslogSuite) TestMoveSyslogConfigTargetDirMissing(c *gc.C) {
+	err := os.Remove(s.confDir)
+	c.Assert(err, jc.ErrorIsNil)
+	files := []string{
+		"ca-cert.pem",
+		"rsyslog-cert.pem",
+		"rsyslog-key.pem",
+		"logrotate.conf",
+		"logrotate.run",
+	}
+	s.writeOldFiles(c, files)
+
+	err = upgrades.MoveSyslogConfig(s.ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkFiles(c, files)
+}
+
 type testFile struct {
 	path     string
 	dirname  string

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -123,7 +123,11 @@ func (s *steps124SyslogSuite) oldFile(filename string) testFile {
 }
 
 func (s *steps124SyslogSuite) newFile(filename string) testFile {
-	return newTestFile(s.confDir, filename, s.data)
+	dirname := filepath.Join(s.confDir, "rsyslog")
+	if err := os.MkdirAll(dirname, 0755); err != nil {
+		panic(err)
+	}
+	return newTestFile(dirname, filename, s.data)
 }
 
 func (s *steps124SyslogSuite) writeOldFiles(c *gc.C, files []string) {


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1468815)

Revision 70d9e74126b9 changed the 1.24 rsyslog upgrade step so that files moved to /etc/juju rather than to the Juju data dir.  However, that change did not ensure that the directory already exists.  Since we weren't using /etc/juju prior to 1.24, the upgrade step would always fail.

This change ensures that /etc/juju gets created when missing and adds a test to catch the case where the target dir does not exist.

(Review request: http://reviews.vapour.ws/r/2035/)