### PR TITLE
state: use supported type when writing leadership settings docs

### DIFF
--- a/state/leadership.go
+++ b/state/leadership.go
@@ -3,6 +3,7 @@ package state
 import (
 	"fmt"
 
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 )
 
@@ -12,7 +13,7 @@ func addLeadershipSettingsOp(serviceId string) txn.Op {
 	return txn.Op{
 		C:      settingsC,
 		Id:     LeadershipSettingsDocId(serviceId),
-		Insert: make(map[string]interface{}),
+		Insert: bson.D{},
 		Assert: txn.DocMissing,
 	}
 }


### PR DESCRIPTION
A bare empty map is written to the settings collection by
addLeadershipSettingsOp which is unsupported by the multi-env txn
layer. This means that the document is written out without the
env-uuid field.

This is the bare minimum fix. There be further PRs which improve the
multi-env txn layer to avoid this kind of problem in the future.

This is part of the fix for LP #1468994.

(Review request: http://reviews.vapour.ws/r/2036/)