### PR TITLE
state: multiEnvRunner now rejects unknown document types

### DIFF
--- a/state/txns.go
+++ b/state/txns.go
@@ -150,10 +150,15 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) []txn.Op {
 					ops[i].Insert = r.updateBsonD(doc, docID, op.C)
 				case bson.M:
 					r.updateBsonM(doc, docID, op.C)
+				case map[string]interface{}:
+					r.updateBsonM(bson.M(doc), docID, op.C)
 				default:
-					r.updateStruct(doc, docID, op.C)
-				}
+					if !r.updateStruct(doc, docID, op.C) {
+						panic(fmt.Sprintf("unsupported document type for multi-environment collection "+
+							"(must be bson.D, bson.M or struct). Got %T for insert into %s.", doc, op.C))
+					}
 
+				}
 				if r.assertEnvAlive && !opsNeedEnvAlive && envAliveColls.Contains(op.C) {
 					opsNeedEnvAlive = true
 				}
@@ -234,7 +239,7 @@ func (r *multiEnvRunner) updateBsonM(doc bson.M, docID interface{}, collName str
 	}
 }
 
-func (r *multiEnvRunner) updateStruct(doc, docID interface{}, collName string) {
+func (r *multiEnvRunner) updateStruct(doc, docID interface{}, collName string) bool {
 	v := reflect.ValueOf(doc)
 	t := v.Type()
 
@@ -243,23 +248,26 @@ func (r *multiEnvRunner) updateStruct(doc, docID interface{}, collName string) {
 		t = v.Type()
 	}
 
-	if t.Kind() == reflect.Struct {
-		envUUIDSeen := false
-		for i := 0; i < t.NumField(); i++ {
-			f := t.Field(i)
-			switch f.Tag.Get("bson") {
-			case "_id":
-				r.updateStructField(v, f.Name, docID, collName, overrideField)
-			case "env-uuid":
-				r.updateStructField(v, f.Name, r.envUUID, collName, fieldMustMatch)
-				envUUIDSeen = true
-			}
-		}
-		if !envUUIDSeen {
-			panic(fmt.Sprintf("struct for insert into %s is missing an env-uuid field", collName))
-		}
+	if t.Kind() != reflect.Struct {
+		return false
 	}
 
+	envUUIDSeen := false
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		switch f.Tag.Get("bson") {
+		case "_id":
+			r.updateStructField(v, f.Name, docID, collName, overrideField)
+		case "env-uuid":
+			r.updateStructField(v, f.Name, r.envUUID, collName, fieldMustMatch)
+			envUUIDSeen = true
+		}
+	}
+	if !envUUIDSeen {
+		panic(fmt.Sprintf("struct for insert into %s is missing an env-uuid field", collName))
+	}
+
+	return true
 }
 
 const overrideField = "override"

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -172,6 +172,22 @@ func getTestCases() []multiEnvRunnerTestCase {
 				},
 			},
 			true,
+		}, {
+			"document passed as map[string]interface{}",
+			txn.Op{
+				C:      machinesC,
+				Id:     "5",
+				Insert: map[string]interface{}{},
+			},
+			txn.Op{
+				C:  machinesC,
+				Id: "uuid:5",
+				Insert: map[string]interface{}{
+					"_id":      "uuid:5",
+					"env-uuid": "uuid",
+				},
+			},
+			true,
 		},
 	}
 }
@@ -325,6 +341,19 @@ func (s *MultiEnvRunnerSuite) TestPanicWhenBsonMEnvUUIDMismatch(c *gc.C) {
 	}
 	c.Assert(attempt, gc.PanicMatches,
 		"environment UUID for document to insert into machines does not match state")
+}
+
+func (s *MultiEnvRunnerSuite) TestPanicForUnsupportedDocType(c *gc.C) {
+	attempt := func() {
+		s.multiEnvRunner.RunTransaction([]txn.Op{{
+			C:      machinesC,
+			Id:     "uuid:0",
+			Insert: make(map[int]int),
+		}})
+	}
+	c.Assert(attempt, gc.PanicMatches, `unsupported document type for multi-environment `+
+		`collection \(must be bson.D, bson.M or struct\). Got map\[int\]int for insert `+
+		`into machines.`)
 }
 
 func (s *MultiEnvRunnerSuite) TestRun(c *gc.C) {


### PR DESCRIPTION
... instead of silently leaving them untouched. 

Also added support for map[string]interface{} documents which are widely used within state.

(Review request: http://reviews.vapour.ws/r/2043/)