### PR TITLE
worker: always clear workerInfo.worker before restarting a worker

### DIFF
--- a/worker/runner.go
+++ b/worker/runner.go
@@ -225,6 +225,11 @@ func (runner *runner) run() error {
 				delete(workers, info.id)
 				break
 			}
+			
+			// clear workerInfo.worker so that we don't accidentally send the 
+			// Kill signal to a previous invocation of this worker.
+			workerInfo.worker = nil
+
 			go runner.runWorker(workerInfo.restartDelay, info.id, workerInfo.start)
 			workerInfo.restartDelay = RestartDelay
 		}

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -225,8 +225,8 @@ func (runner *runner) run() error {
 				delete(workers, info.id)
 				break
 			}
-			
-			// clear workerInfo.worker so that we don't accidentally send the 
+
+			// clear workerInfo.worker so that we don't accidentally send the
 			// Kill signal to a previous invocation of this worker.
 			workerInfo.worker = nil
 


### PR DESCRIPTION
If a worker is being restarted, make sure that the previous Worker
reference is removed before starting a new one.

Rather than the previous situation where the Kill signal could be delivered
to a previous copy of the worker, this change will cause the runner to
continue to try to issue killAll, which will do nothing as there are no non nil
workerInfo.worker's registered in the worker map, until the new worker reference
is recieved via runner.startedc. At this point the killAll loop will then be able
to issue the Kill command to the correct copy of the worker.

(Review request: http://reviews.vapour.ws/r/2044/)