### PR TITLE
state: improve env UUID migration robustness

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -1617,7 +1617,11 @@ func (st *State) AllServices() (services []*Service, err error) {
 // where the environment uuid is prefixed to the
 // localID.
 func (st *State) docID(localID string) string {
-	return st.EnvironUUID() + ":" + localID
+	prefix := st.EnvironUUID() + ":"
+	if strings.HasPrefix(localID, prefix) {
+		return localID
+	}
+	return prefix + localID
 }
 
 // localID returns the local id value by stripping

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -87,6 +87,10 @@ func (s *StateSuite) TestDocID(c *gc.C) {
 	id := "wordpress"
 	docID := state.DocID(s.State, id)
 	c.Assert(docID, gc.Equals, s.State.EnvironUUID()+":"+id)
+
+	// Ensure that the prefix isn't added if it's already there.
+	docID2 := state.DocID(s.State, docID)
+	c.Assert(docID2, gc.Equals, docID)
 }
 
 func (s *StateSuite) TestLocalID(c *gc.C) {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -475,6 +475,14 @@ func (s *upgradesSuite) TestAddCharmStoragePaths(c *gc.C) {
 	c.Assert(dummyCharm.StoragePath(), gc.Equals, "/some/where")
 }
 
+func (s *upgradesSuite) TestEnvUUIDMigrationWithIdAlreadyPrefixed(c *gc.C) {
+	s.checkEnvUUID(c, AddEnvUUIDToServices, servicesC,
+		[]bson.M{
+			{"_id": s.state.docID("mysql")},
+			{"_id": s.state.docID("mediawiki")},
+		}, false)
+}
+
 func (s *upgradesSuite) TestAddEnvUUIDToServices(c *gc.C) {
 	coll, newIDs := s.checkAddEnvUUIDToCollection(c, AddEnvUUIDToServices, servicesC,
 		bson.M{


### PR DESCRIPTION
Handle docs that already have_ids with the env UUID prefix but don't have the env-uuid field. This was happening b/c the leadership code was active during upgrades and for complicated reasons was writing out documents with correct _id fields but the without the env-uuid field.

See LP #1468994 for more details.

(Review request: http://reviews.vapour.ws/r/2046/)