### PR TITLE
state: use default block source for filesystems

### DIFF
--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -361,6 +361,21 @@ func (s *ConfigSuite) TestPrepareDoesNotTouchExistingControlBucket(c *gc.C) {
 	c.Assert(bucket, gc.Equals, "burblefoo")
 }
 
+func (s *ConfigSuite) TestPrepareSetsDefaultBlockSource(c *gc.C) {
+	s.PatchValue(&verifyCredentials, func(*environ) error { return nil })
+	attrs := testing.FakeConfig().Merge(testing.Attrs{
+		"type": "ec2",
+	})
+	cfg, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	source, ok := env.(*environ).ecfg().StorageDefaultBlockSource()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(source, gc.Equals, "ebs")
+}
+
 func (*ConfigSuite) TestSchema(c *gc.C) {
 	fields := providerInstance.Schema()
 	// Check that all the fields defined in environs/config

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -78,7 +78,7 @@ func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, 
 	if err != nil {
 		return nil, fmt.Errorf("invalid EC2 provider config: %v", err)
 	}
-	return cfg.Apply(newEcfg.attrs)
+	return newEcfg.Apply(newEcfg.attrs)
 }
 
 // MetadataLookupParams returns parameters which are used to query image metadata to

--- a/state/storage.go
+++ b/state/storage.go
@@ -1027,9 +1027,10 @@ func defaultStoragePool(cfg *config.Config, kind storage.StorageKind, cons Stora
 	switch kind {
 	case storage.StorageKindBlock:
 		loopPool := string(provider.LoopProviderType)
-		// No constraints at all
+
 		emptyConstraints := StorageConstraints{}
 		if cons == emptyConstraints {
+			// No constraints at all: use loop.
 			return loopPool, nil
 		}
 		// Either size or count specified, use env default.
@@ -1038,8 +1039,21 @@ func defaultStoragePool(cfg *config.Config, kind storage.StorageKind, cons Stora
 			defaultPool = loopPool
 		}
 		return defaultPool, nil
+
 	case storage.StorageKindFilesystem:
-		return string(provider.RootfsProviderType), nil
+		rootfsPool := string(provider.RootfsProviderType)
+		emptyConstraints := StorageConstraints{}
+		if cons == emptyConstraints {
+			return rootfsPool, nil
+		}
+
+		// TODO(axw) add env configuration for default
+		// filesystem source, prefer that.
+		defaultPool, ok := cfg.StorageDefaultBlockSource()
+		if !ok {
+			defaultPool = rootfsPool
+		}
+		return defaultPool, nil
 	}
 	return "", ErrNoDefaultStoragePool
 }


### PR DESCRIPTION
If a filesystem is requested, with size but no storage
pool specified, then we use the environment's default
block storage pool if there is one. Otherwise, we use
rootfs.

Also, fix ec2 provider's code that sets the default
block storage source.

Fixes https://bugs.launchpad.net/juju-core/+bug/1468153

(Review request: http://reviews.vapour.ws/r/2048/)