### PR TITLE
testing: add SignalSuite for capturing signals during tests

### DIFF
--- a/testing/signal.go
+++ b/testing/signal.go
@@ -19,13 +19,11 @@ type SignalSuite struct {
 
 	// quit holds the channel used to tell handleSignal to exit.
 	quit chan bool
-
-	// sigfunc is called when a signal is received.
-	// As the signal is caught at this point, sigfunc is responsible for
-	// deciding to exit the process.
-	sigfunc func(c *gc.C, sig os.Signal)
 }
 
+// SetUpSuite registers sigfunc to be called when a signal is received.
+// As a terminating signal is caught at this point, sigfunc should cause the
+// process to exit. sigfunc should not return.
 func (s *SignalSuite) SetUpSuite(c *gc.C, sigfunc func(*gc.C, os.Signal)) {
 	if sigfunc == nil {
 		c.Fatal("sigfunc cannot be nil")

--- a/testing/signal.go
+++ b/testing/signal.go
@@ -1,0 +1,70 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"os"
+	"os/signal"
+
+	gc "gopkg.in/check.v1"
+)
+
+// SignalSuite inserts a signal handler to catch shutdown signals
+// and run the supplied function in its place.
+type SignalSuite struct {
+
+	// ch holds the channel registered with the signal handler.
+	ch chan os.Signal
+
+	// quit holds the channel used to tell handleSignal to exit.
+	quit chan bool
+
+	// sigfunc is called when a signal is received.
+	// As the signal is caught at this point, sigfunc is responsible for
+	// deciding to exit the process.
+	sigfunc func(c *gc.C, sig os.Signal)
+}
+
+func (s *SignalSuite) SetUpSuite(c *gc.C, sigfunc func(*gc.C, os.Signal)) {
+	if sigfunc == nil {
+		c.Fatal("sigfunc cannot be nil")
+	}
+
+	s.ch = make(chan os.Signal, 1)
+	s.quit = make(chan bool)
+	go s.handleSignal(c, sigfunc)
+	c.Logf("registering handler for: %s", Signals)
+	signal.Notify(s.ch, Signals...)
+}
+
+func (s *SignalSuite) TearDownSuite(c *gc.C) {
+	// deregister s.ch and close channel to exit handleSignal worker.
+	signal.Stop(s.ch)
+
+	// even though we asked os/signal to stop sending signals to this channel
+	// it appear that it still holds a reference to the channel and if closed
+	// the program will dump core. Instead of closing s.ch to signal handleSignal
+	// to quit, we close s.quit instead.
+	close(s.quit)
+	c.Logf("stopped listening for: %s", Signals)
+}
+
+func (s *SignalSuite) handleSignal(c *gc.C, sigfunc func(*gc.C, os.Signal)) {
+	c.Logf("signal handler waiting for: %s", Signals)
+	for {
+		select {
+		case sig := <-s.ch:
+			sigfunc(c, sig)
+
+			// Sigfunc is expected to call os.Exit, it should not return.
+			c.Errorf("Sigfunc should not have returned")
+		case <-s.quit:
+
+			// during TearDownSuite we unregister the channel for signal notifications
+			// and close s.quit, this will cause the range loop to exit, shutting down this
+			// goroutine.
+			c.Logf("signal handler exited")
+		}
+	}
+}

--- a/testing/signal.go
+++ b/testing/signal.go
@@ -40,7 +40,7 @@ func (s *SignalSuite) TearDownSuite(c *gc.C) {
 	// deregister s.ch and close channel to exit handleSignal worker.
 	signal.Stop(s.ch)
 
-	// even though we asked os/signal to stop sending signals to this channel
+	// even though we asked os/signal to stop sending signals to this channel/:
 	// it appear that it still holds a reference to the channel and if closed
 	// the program will dump core. Instead of closing s.ch to signal handleSignal
 	// to quit, we close s.quit instead.
@@ -55,8 +55,8 @@ func (s *SignalSuite) handleSignal(c *gc.C, sigfunc func(*gc.C, os.Signal)) {
 		case sig := <-s.ch:
 			sigfunc(c, sig)
 
-			// Sigfunc is expected to call os.Exit, it should not return.
-			c.Errorf("Sigfunc should not have returned")
+			// sigfunc is expected to call os.Exit, it should not return.
+			c.Errorf("sigfunc should not have returned")
 		case <-s.quit:
 
 			// during TearDownSuite we unregister the channel for signal notifications

--- a/testing/signal.go
+++ b/testing/signal.go
@@ -40,7 +40,7 @@ func (s *SignalSuite) TearDownSuite(c *gc.C) {
 	// deregister s.ch and close channel to exit handleSignal worker.
 	signal.Stop(s.ch)
 
-	// even though we asked os/signal to stop sending signals to this channel/:
+	// even though we asked os/signal to stop sending signals to this channel
 	// it appear that it still holds a reference to the channel and if closed
 	// the program will dump core. Instead of closing s.ch to signal handleSignal
 	// to quit, we close s.quit instead.

--- a/testing/signal_unix.go
+++ b/testing/signal_unix.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package testing
+
+import (
+	"os"
+	"syscall"
+)
+
+// Signals is the list of operating system signals this suite will capture
+var Signals = []os.Signal{
+	os.Interrupt,
+	syscall.SIGTERM,
+	syscall.SIGQUIT,
+}

--- a/testing/signal_windows.go
+++ b/testing/signal_windows.go
@@ -1,0 +1,12 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import "os"
+
+// Signals is the list of operating system signals this suite will capture
+var Signals = []os.Signal{
+	os.Interrupt,
+	os.Kill,
+}


### PR DESCRIPTION
This PR adds a SignalSuite which can be used to hook signals, like SIGQUIT,
which is generated by the timeout from the test runner.

The list of signals handled is defined in the `testing.Signals` variable. This is for documentation purposes, it should not be modified.

The function supplied to `SignalSuite.SetUpSuite` should not return. If it does, the test suite will be marked as failed unconditionally.

Usage:

       s.SignalSuite.SetUpSuite(c, func(c *gc.C, sig os.Signal) {
               fmt.Fprintf(os.Stderr, "exiting with signal: %v\n", sig)
               os.Exit(1)
       })