### PR TITLE
Add a helper method to dump the logs after a specified timeout.

### DIFF
--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -118,6 +118,10 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 		return s.machineIsMaster, nil
 	}
 	s.PatchValue(&isMachineMaster, fakeIsMachineMaster)
+	// Most of these tests normally finish sub-second on a fast machine.
+	// If any given test hits a minute, we have almost certainly become
+	// wedged, so dump the logs.
+	coretesting.DumpTestLogsAfter(time.Minute, c, s)
 }
 
 func (s *UpgradeSuite) captureLogs(c *gc.C) {


### PR DESCRIPTION
This should help debug the cases where a test panics due to getting wedged and taking too long.

(Review request: http://reviews.vapour.ws/r/2053/)