### PR TITLE
Add extra logging and dump logs on test timeout.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1555,12 +1555,12 @@ func openState(agentConfig agent.Config, dialOpts mongo.DialOpts) (_ *state.Stat
 // but only after waiting for upgrades to complete.
 func (a *MachineAgent) startWorkerAfterUpgrade(runner worker.Runner, name string, start func() (worker.Worker, error)) {
 	runner.StartWorker(name, func() (worker.Worker, error) {
-		return a.upgradeWaiterWorker(start), nil
+		return a.upgradeWaiterWorker(name, start), nil
 	})
 }
 
 // upgradeWaiterWorker runs the specified worker after upgrades have completed.
-func (a *MachineAgent) upgradeWaiterWorker(start func() (worker.Worker, error)) worker.Worker {
+func (a *MachineAgent) upgradeWaiterWorker(name string, start func() (worker.Worker, error)) worker.Worker {
 	return worker.NewSimpleWorker(func(stop <-chan struct{}) error {
 		// Wait for the agent upgrade and upgrade steps to complete (or for us to be stopped).
 		for _, ch := range []chan struct{}{
@@ -1573,6 +1573,7 @@ func (a *MachineAgent) upgradeWaiterWorker(start func() (worker.Worker, error)) 
 			case <-ch:
 			}
 		}
+		logger.Debugf("upgrades done, starting worker %q", name)
 		// Upgrades are done, start the worker.
 		worker, err := start()
 		if err != nil {
@@ -1585,8 +1586,10 @@ func (a *MachineAgent) upgradeWaiterWorker(start func() (worker.Worker, error)) 
 		}()
 		select {
 		case err := <-waitCh:
+			logger.Debugf("worker %q exited with %v", name, err)
 			return err
 		case <-stop:
+			logger.Debugf("stopping so killing worker %q", name)
 			worker.Kill()
 		}
 		return <-waitCh // Ensure worker has stopped before returning.

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -119,6 +119,10 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 		return s.machineIsMaster, nil
 	}
 	s.PatchValue(&isMachineMaster, fakeIsMachineMaster)
+	// Most of these tests normally finish sub-second on a fast machine.
+	// If any given test hits a minute, we have almost certainly become
+	// wedged, so dump the logs.
+	coretesting.DumpTestLogsAfter(time.Minute, c, s)
 }
 
 func (s *UpgradeSuite) captureLogs(c *gc.C) {

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -188,18 +188,22 @@ func (runner *runner) run() error {
 			info.start = req.start
 			info.restartDelay = 0
 		case id := <-runner.stopc:
+			logger.Debugf("stop %q", id)
 			if info := workers[id]; info != nil {
 				killWorker(id, info)
 			}
 		case info := <-runner.startedc:
+			logger.Debugf("%q started", info.id)
 			workerInfo := workers[info.id]
 			workerInfo.worker = info.worker
 			if isDying {
 				killWorker(info.id, workerInfo)
 			}
 		case info := <-runner.donec:
+			logger.Debugf("%q done: %v", info.id, info.err)
 			workerInfo := workers[info.id]
 			if !workerInfo.stopping && info.err == nil {
+				logger.Debugf("removing %q from known workers", info.id)
 				delete(workers, info.id)
 				break
 			}
@@ -220,6 +224,8 @@ func (runner *runner) run() error {
 				}
 			}
 			if workerInfo.start == nil {
+				logger.Debugf("no restart, removing %q from known workers", info.id)
+
 				// The worker has been deliberately stopped;
 				// we can now remove it from the list of workers.
 				delete(workers, info.id)
@@ -242,6 +248,8 @@ func killWorker(id string, info *workerInfo) {
 		logger.Debugf("killing %q", id)
 		info.worker.Kill()
 		info.worker = nil
+	} else {
+		logger.Debugf("couldn't kill %q, not yet started", id)
 	}
 	info.stopping = true
 	info.start = nil


### PR DESCRIPTION
Forward port of 1.24 changes to help debug power test timeouts.

(Review request: http://reviews.vapour.ws/r/2054/)