### PR TITLE
state: require ID in Set{Volume,Filesystem}Info

### DIFF
--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -160,10 +160,12 @@ func (s *cmdStorageSuite) TestStoragePersistentProvisioned(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 	vol, err := s.State.StorageInstanceVolume(names.NewStorageTag("data/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	s.State.SetVolumeInfo(vol.VolumeTag(), state.VolumeInfo{
+	err = s.State.SetVolumeInfo(vol.VolumeTag(), state.VolumeInfo{
 		Size:       1024,
 		Persistent: true,
+		VolumeId:   "vol-ume",
 	})
+	c.Assert(err, jc.ErrorIsNil)
 
 	context := runShow(c, "data/0")
 	expected := `

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -302,7 +302,7 @@ func (s *EnvironSuite) TestDestroyEnvironmentWithPersistentVolumesFails(c *gc.C)
 
 	volume1, err := s.State.StorageInstanceVolume(names.NewStorageTag("multi1to10/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
+	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true, VolumeId: "vol-ume"}
 	err = s.State.SetVolumeInfo(volume1.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -783,6 +783,9 @@ func createMachineFilesystemAttachmentsOps(machineId string, attachments []files
 // SetFilesystemInfo sets the FilesystemInfo for the specified filesystem.
 func (st *State) SetFilesystemInfo(tag names.FilesystemTag, info FilesystemInfo) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set info for filesystem %q", tag.Id())
+	if info.FilesystemId == "" {
+		return errors.New("filesystem ID not set")
+	}
 	fs, err := st.Filesystem(tag)
 	if err != nil {
 		return errors.Trace(err)
@@ -804,8 +807,6 @@ func (st *State) SetFilesystemInfo(tag names.FilesystemTag, info FilesystemInfo)
 	} else if errors.Cause(err) != ErrNoBackingVolume {
 		return errors.Trace(err)
 	}
-	// TODO(axw) we should reject info without FilesystemId set; can't do this
-	// until the providers all set it correctly.
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			fs, err = st.Filesystem(tag)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -83,7 +83,7 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoImmutable(c *gc.C) {
 	err = machine.SetProvisioned("inst-id", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	filesystemInfoSet := state.FilesystemInfo{Size: 123}
+	filesystemInfoSet := state.FilesystemInfo{Size: 123, FilesystemId: "fs-id"}
 	err = s.State.SetFilesystemInfo(filesystem.FilesystemTag(), filesystemInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -96,6 +96,20 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoImmutable(c *gc.C) {
 
 	filesystemInfoSet.Pool = "rootfs"
 	s.assertFilesystemInfo(c, filesystemTag, filesystemInfoSet)
+}
+
+func (s *FilesystemStateSuite) TestSetFilesystemInfoNoFilesystemId(c *gc.C) {
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "loop-pool")
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
+	filesystemTag := filesystem.FilesystemTag()
+	s.assertFilesystemUnprovisioned(c, filesystemTag)
+
+	filesystemInfoSet := state.FilesystemInfo{Size: 123}
+	err = s.State.SetFilesystemInfo(filesystem.FilesystemTag(), filesystemInfoSet)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for filesystem "0/0": filesystem ID not set`)
 }
 
 func (s *FilesystemStateSuite) TestVolumeFilesystem(c *gc.C) {
@@ -426,7 +440,7 @@ func (s *FilesystemStateSuite) TestSetFilesystemAttachmentInfoMachineNotProvisio
 	filesystemAttachment, _ := s.addUnitWithFilesystem(c, "rootfs", false)
 	err := s.State.SetFilesystemInfo(
 		filesystemAttachment.Filesystem(),
-		state.FilesystemInfo{Size: 123},
+		state.FilesystemInfo{Size: 123, FilesystemId: "fs-id"},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.SetFilesystemAttachmentInfo(
@@ -441,7 +455,7 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoVolumeAttachmentNotProvision
 	filesystemAttachment, _ := s.addUnitWithFilesystem(c, "loop", true)
 	err := s.State.SetFilesystemInfo(
 		filesystemAttachment.Filesystem(),
-		state.FilesystemInfo{Size: 123},
+		state.FilesystemInfo{Size: 123, FilesystemId: "fs-id"},
 	)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for filesystem "0/0": volume attachment "0/0" on "0" not provisioned`)
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1065,9 +1065,18 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 	c.Assert(err, gc.ErrorMatches, `cannot add network interface "" to machine "1": MAC address must be not empty`)
 	assertNotProvisioned()
 
-	invalidVolumes := map[names.VolumeTag]state.VolumeInfo{names.NewVolumeTag("1065"): state.VolumeInfo{}}
+	invalidVolumes := map[names.VolumeTag]state.VolumeInfo{
+		names.NewVolumeTag("1065"): state.VolumeInfo{VolumeId: "vol-ume"},
+	}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set info for volume \"1065\": volume \"1065\" not found`)
+	assertNotProvisioned()
+
+	invalidVolumes = map[names.VolumeTag]state.VolumeInfo{
+		names.NewVolumeTag("1065"): state.VolumeInfo{},
+	}
+	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidVolumes, nil)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for volume \"1065\": volume ID not set`)
 	assertNotProvisioned()
 
 	// TODO(axw) test invalid volume attachment

--- a/state/volume.go
+++ b/state/volume.go
@@ -925,6 +925,9 @@ func setProvisionedVolumeInfo(st *State, volumes map[names.VolumeTag]VolumeInfo)
 // SetVolumeInfo sets the VolumeInfo for the specified volume.
 func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set info for volume %q", tag.Id())
+	if info.VolumeId == "" {
+		return errors.New("volume ID not set")
+	}
 	// TODO(axw) we should reject info without VolumeId set; can't do this
 	// until the providers all set it correctly.
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -150,11 +150,25 @@ func (s *VolumeStateSuite) TestSetVolumeInfo(c *gc.C) {
 	volumeTag := volume.VolumeTag()
 	s.assertVolumeUnprovisioned(c, volumeTag)
 
-	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
+	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true, VolumeId: "vol-ume"}
 	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfoSet.Pool = "loop-pool" // taken from params
 	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
+}
+
+func (s *VolumeStateSuite) TestSetVolumeInfoNoVolumeId(c *gc.C) {
+	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume := s.storageInstanceVolume(c, storageTag)
+	volumeTag := volume.VolumeTag()
+	s.assertVolumeUnprovisioned(c, volumeTag)
+
+	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
+	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for volume "0/0": volume ID not set`)
 }
 
 func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
@@ -193,7 +207,7 @@ func (s *VolumeStateSuite) TestSetVolumeInfoNoStorageAssigned(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotAssigned)
 
 	s.assertVolumeUnprovisioned(c, volumeTag)
-	volumeInfoSet := state.VolumeInfo{Size: 123}
+	volumeInfoSet := state.VolumeInfo{Size: 123, VolumeId: "vol-ume"}
 	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfoSet.Pool = "loop-pool" // taken from params
@@ -207,7 +221,7 @@ func (s *VolumeStateSuite) TestSetVolumeInfoImmutable(c *gc.C) {
 	volume := s.storageInstanceVolume(c, storageTag)
 	volumeTag := volume.VolumeTag()
 
-	volumeInfoSet := state.VolumeInfo{Size: 123}
+	volumeInfoSet := state.VolumeInfo{Size: 123, VolumeId: "vol-ume"}
 	err = s.State.SetVolumeInfo(volume.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -465,11 +479,11 @@ func (s *VolumeStateSuite) assertCreateVolumes(c *gc.C) (_ *state.Machine, all, 
 	c.Assert(volume2.LifeBinding(), gc.Equals, machine.MachineTag())
 	c.Assert(volume3.LifeBinding(), gc.Equals, machine.MachineTag())
 
-	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
+	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true, VolumeId: "vol-1"}
 	err = s.State.SetVolumeInfo(volume1.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 
-	volumeInfoSet = state.VolumeInfo{Size: 456, Persistent: false}
+	volumeInfoSet = state.VolumeInfo{Size: 456, Persistent: false, VolumeId: "vol-2"}
 	err = s.State.SetVolumeInfo(volume2.VolumeTag(), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -696,13 +710,13 @@ func (s *VolumeStateSuite) TestRemoveMachineRemovesVolumes(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true}
+	volumeInfoSet := state.VolumeInfo{Size: 123, Persistent: true, VolumeId: "vol-1"}
 	err = s.State.SetVolumeInfo(names.NewVolumeTag("0/1"), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeInfoSet = state.VolumeInfo{Size: 456, Persistent: false}
+	volumeInfoSet = state.VolumeInfo{Size: 456, Persistent: false, VolumeId: "vol-2"}
 	err = s.State.SetVolumeInfo(names.NewVolumeTag("0/3"), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeInfoSet = state.VolumeInfo{Size: 789, Persistent: false}
+	volumeInfoSet = state.VolumeInfo{Size: 789, Persistent: false, VolumeId: "vol-3"}
 	err = s.State.SetVolumeInfo(names.NewVolumeTag("4"), volumeInfoSet)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -128,7 +128,8 @@ func (s *tmpfsFilesystemSource) createFilesystem(params storage.FilesystemParams
 	}
 
 	info := storage.FilesystemInfo{
-		Size: sizeInMiB,
+		FilesystemId: params.Tag.String(),
+		Size:         sizeInMiB,
 	}
 
 	// Creating the mount is the responsibility of AttachFilesystems.
@@ -240,7 +241,10 @@ func (s *tmpfsFilesystemSource) readFilesystemInfo(tag names.FilesystemTag) (sto
 	if info.Size == nil {
 		return storage.FilesystemInfo{}, errors.New("invalid filesystem info: missing size")
 	}
-	return storage.FilesystemInfo{Size: *info.Size}, nil
+	return storage.FilesystemInfo{
+		FilesystemId: tag.String(),
+		Size:         *info.Size,
+	}, nil
 }
 
 func (s *tmpfsFilesystemSource) filesystemInfoFile(tag names.FilesystemTag) string {

--- a/storage/provider/tmpfs_test.go
+++ b/storage/provider/tmpfs_test.go
@@ -98,7 +98,8 @@ func (s *tmpfsSuite) TestCreateFilesystems(c *gc.C) {
 	c.Assert(filesystems, jc.DeepEquals, []storage.Filesystem{{
 		Tag: names.NewFilesystemTag("6"),
 		FilesystemInfo: storage.FilesystemInfo{
-			Size: 2,
+			FilesystemId: "filesystem-6",
+			Size:         2,
 		},
 	}})
 }
@@ -120,12 +121,14 @@ func (s *tmpfsSuite) TestCreateFilesystemsHugePages(c *gc.C) {
 	c.Assert(filesystems, jc.DeepEquals, []storage.Filesystem{{
 		Tag: names.NewFilesystemTag("1"),
 		FilesystemInfo: storage.FilesystemInfo{
-			Size: 32,
+			FilesystemId: "filesystem-1",
+			Size:         32,
 		},
 	}, {
 		Tag: names.NewFilesystemTag("2"),
 		FilesystemInfo: storage.FilesystemInfo{
-			Size: 16,
+			FilesystemId: "filesystem-2",
+			Size:         16,
 		},
 	}})
 }


### PR DESCRIPTION
SetVolumeInfo and SetFilesystemInfo now require
that VolumeId and FilesystemId be specified
respectively. One existing filesystem provider,
tmpfs, was not setting filesystem ID; this has
been rectified.

(Review request: http://reviews.vapour.ws/r/2055/)