### PR TITLE
Apiserver race condition fix

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -135,6 +135,8 @@ func (cl *changeCertListener) Close() error {
 // processCertChanges receives new certificate information and
 // calls a method to update the listener's certificate.
 func (cl *changeCertListener) processCertChanges() error {
+	cl.m.Lock()
+	defer cl.m.Unlock()
 	for {
 		select {
 		case info := <-cl.certChanged:


### PR DESCRIPTION
Fixes a race condition i noticed in cmd/jujud/agent running go test --race 

See here: https://pastebin.canonical.com/134276/

(Review request: http://reviews.vapour.ws/r/2059/)