### PR TITLE
fix CentOS version detection

### DIFF
--- a/version/osversion.go
+++ b/version/osversion.go
@@ -4,6 +4,7 @@
 package version
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -82,7 +83,8 @@ func readSeries() (string, error) {
 	case strings.ToLower(Ubuntu.String()):
 		return getValue(ubuntuSeries, values["VERSION_ID"])
 	case strings.ToLower(CentOS.String()):
-		return getValue(centosSeries, values["VERSION_ID"])
+		codename := fmt.Sprintf("%s%s", values["ID"], values["VERSION_ID"])
+		return getValue(centosSeries, codename)
 	default:
 		return "unknown", nil
 	}

--- a/version/osversion_test.go
+++ b/version/osversion_test.go
@@ -57,7 +57,7 @@ VERSION_ID='12.04'
 }, {
 	`NAME="CentOS Linux"
 ID="centos"
-VERSION_ID="centos7"
+VERSION_ID="7"
 `,
 	"centos7",
 	"",


### PR DESCRIPTION
This PR fixes bug #1470150 and brings back CentOS support.

(Review request: http://reviews.vapour.ws/r/2062/)