### PR TITLE
Fix the singular worker timer looping.

### DIFF
--- a/worker/singular/singular.go
+++ b/worker/singular/singular.go
@@ -73,8 +73,7 @@ func (r *runner) pinger() {
 		r.Runner.Wait()
 		close(underlyingDead)
 	}()
-	timer := time.NewTimer(0)
-	for {
+	for timer := time.NewTimer(PingInterval); ; timer.Reset(PingInterval) {
 		if err := r.conn.Ping(); err != nil {
 			// The ping has failed: cause all other workers
 			// to exit with the ping error.
@@ -83,7 +82,7 @@ func (r *runner) pinger() {
 			close(r.pingerDied)
 			return
 		}
-		timer.Reset(PingInterval)
+
 		select {
 		case <-timer.C:
 		case <-underlyingDead:


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-core/+bug/1455623

When the timer.Reset is called, it returns a bool to say if the timer had been active.  If the timer was inactive before, there was something on the channel timer.C, so the select below would immediately fire.

This is fixed by initializing the timer with the duration, and using a modified for loop.

(Review request: http://reviews.vapour.ws/r/2066/)