### PR TITLE
state: <location>/<subdir> for multiple storage

### DIFF
--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -15,21 +15,24 @@ const (
 	tmpDir osVarType = iota
 	logDir
 	dataDir
+	storageDir
 	jujuRun
 )
 
 var nixVals = map[osVarType]string{
-	tmpDir:  "/tmp",
-	logDir:  "/var/log",
-	dataDir: "/var/lib/juju",
-	jujuRun: "/usr/bin/juju-run",
+	tmpDir:     "/tmp",
+	logDir:     "/var/log",
+	dataDir:    "/var/lib/juju",
+	storageDir: "/var/lib/juju/storage",
+	jujuRun:    "/usr/bin/juju-run",
 }
 
 var winVals = map[osVarType]string{
-	tmpDir:  "C:/Juju/tmp",
-	logDir:  "C:/Juju/log",
-	dataDir: "C:/Juju/lib/juju",
-	jujuRun: "C:/Juju/bin/juju-run.exe",
+	tmpDir:     "C:/Juju/tmp",
+	logDir:     "C:/Juju/log",
+	dataDir:    "C:/Juju/lib/juju",
+	storageDir: "C:/Juju/lib/juju/storage",
+	jujuRun:    "C:/Juju/bin/juju-run.exe",
 }
 
 // osVal will lookup the value of the key valname
@@ -67,8 +70,14 @@ func DataDir(series string) (string, error) {
 	return osVal(series, dataDir)
 }
 
+// StorageDir returns a filesystem path to the folder used by juju to
+// mount machine-level storage.
+func StorageDir(series string) (string, error) {
+	return osVal(series, storageDir)
+}
+
 // JujuRun returns the absolute path to the juju-run binary for
-// a particula series
+// a particular series
 func JujuRun(series string) (string, error) {
 	return osVal(series, jujuRun)
 }

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -5,15 +5,18 @@ package state
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
+	"gopkg.in/juju/charm.v5"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/storage"
 )
 
@@ -932,4 +935,36 @@ func setFilesystemAttachmentInfoOps(
 		Assert: asserts,
 		Update: update,
 	}}
+}
+
+// filesystemMountPoint returns a mount point to use for the given charm
+// storage. For stores with potentially multiple instances, the instance
+// name is appended to the location.
+func filesystemMountPoint(
+	meta charm.Storage,
+	tag names.StorageTag,
+	series string,
+) (string, error) {
+	storageDir, err := paths.StorageDir(series)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if strings.HasPrefix(meta.Location, storageDir) {
+		return "", errors.Errorf(
+			"invalid location %q: must not fall within %q",
+			meta.Location, storageDir,
+		)
+	}
+	if meta.Location != "" && meta.CountMax == 1 {
+		// The location is specified and it's a singleton
+		// store, so just use the location as-is.
+		return meta.Location, nil
+	}
+	// If the location is unspecified then we use
+	// <storage-dir>/<storage-id> as the location.
+	// Otherwise, we use <location>/<storage-id>.
+	if meta.Location != "" {
+		storageDir = meta.Location
+	}
+	return path.Join(storageDir, tag.Id()), nil
 }

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
@@ -757,6 +758,82 @@ func (s *FilesystemStateSuite) TestEnsureMachineDeadRemoveFilesystemConcurrently
 	// Removing a filesystem concurrently does not cause a transaction failure.
 	err := machine.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsSingletonNoLocation(c *gc.C) {
+	s.testFilesystemAttachmentParams(c, 0, 1, "", state.FilesystemAttachmentParams{
+		Location: "/var/lib/juju/storage/data/0",
+	})
+}
+
+func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsMultipleNoLocation(c *gc.C) {
+	s.testFilesystemAttachmentParams(c, 0, -1, "", state.FilesystemAttachmentParams{
+		Location: "/var/lib/juju/storage/data/0",
+	})
+}
+
+func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsSingletonLocation(c *gc.C) {
+	s.testFilesystemAttachmentParams(c, 0, 1, "/srv", state.FilesystemAttachmentParams{
+		Location: "/srv",
+	})
+}
+
+func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsMultipleLocation(c *gc.C) {
+	s.testFilesystemAttachmentParams(c, 0, -1, "/srv", state.FilesystemAttachmentParams{
+		Location: "/srv/data/0",
+	})
+}
+
+func (s *FilesystemStateSuite) testFilesystemAttachmentParams(
+	c *gc.C, countMin, countMax int, location string,
+	expect state.FilesystemAttachmentParams,
+) {
+	ch := s.createStorageCharm(c, "storage-filesystem", charm.Storage{
+		Name:     "data",
+		Type:     charm.StorageFilesystem,
+		CountMin: countMin,
+		CountMax: countMax,
+		Location: location,
+	})
+	storage := map[string]state.StorageConstraints{
+		"data": makeStorageCons("rootfs", 1024, 1),
+	}
+
+	service := s.AddTestingServiceWithStorage(c, "storage-filesystem", ch, storage)
+	unit, err := service.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+	machineId, err := unit.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+
+	storageTag := names.NewStorageTag("data/0")
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
+	filesystemAttachment := s.filesystemAttachment(
+		c, names.NewMachineTag(machineId), filesystem.FilesystemTag(),
+	)
+	params, ok := filesystemAttachment.Params()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(params, jc.DeepEquals, expect)
+}
+
+func (s *FilesystemStateSuite) TestFilesystemAttachmentParamsLocationStorageDir(c *gc.C) {
+	ch := s.createStorageCharm(c, "storage-filesystem", charm.Storage{
+		Name:     "data",
+		Type:     charm.StorageFilesystem,
+		CountMin: 1,
+		CountMax: 1,
+		Location: "/var/lib/juju/storage",
+	})
+	service := s.AddTestingService(c, "storage-filesystem", ch)
+	unit, err := service.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)
+	c.Assert(err, gc.ErrorMatches, `cannot assign unit \"storage-filesystem/0\" to machine: `+
+		`cannot assign unit "storage-filesystem/0" to clean, empty machine: `+
+		`getting filesystem mount point for storage data: `+
+		`invalid location "/var/lib/juju/storage": `+
+		`must not fall within "/var/lib/juju/storage"`)
 }
 
 func (s *FilesystemStateSuite) setupFilesystemAttachment(c *gc.C, pool string) (state.Filesystem, *state.Machine) {

--- a/state/service.go
+++ b/state/service.go
@@ -441,6 +441,15 @@ func (s *Service) checkStorageUpgrade(newMeta *charm.Meta) (err error) {
 				name, oldCountMax, newStorageMeta.CountMax,
 			)
 		}
+		if oldStorageMeta.Location != "" && oldStorageMeta.CountMax == 1 && newStorageMeta.CountMax != 1 {
+			// If a location is specified, the store may not go
+			// from being a singleton to multiple, since then the
+			// location has a different meaning.
+			return errors.Errorf(
+				"existing storage %q with location changed from singleton to multiple",
+				name,
+			)
+		}
 	}
 	return nil
 }
@@ -760,6 +769,7 @@ func (s *Service) unitStorageOps(unitName string) (ops []txn.Op, numStorageAttac
 	// TODO(wallyworld) - record constraints info in data model - size and pool name
 	ops, numStorageAttachments, err = createStorageOps(
 		s.st, tag, meta, url, cons,
+		s.doc.Series,
 		false, // unit is not assigned yet; don't create machine storage
 	)
 	if err != nil {

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -1881,6 +1881,15 @@ storage:
     location: /srv
 `
 
+const oneMultipleLocationStorageMeta = `
+storage:
+  data0:
+    type: filesystem
+    location: /srv
+    multiple:
+      range: 1-
+`
+
 func storageRange(min, max int) string {
 	var minStr, maxStr string
 	if min > 0 {
@@ -1989,4 +1998,12 @@ func (s *ServiceSuite) TestSetCharmStorageLocationChanged(c *gc.C) {
 		mysqlBaseMeta+oneRequiredLocationStorageMeta,
 	)
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade service "test" to charm "mysql": existing storage "data0" location changed from "" to "/srv"`)
+}
+
+func (s *ServiceSuite) TestSetCharmStorageWithLocationSingletonToMultipleAdded(c *gc.C) {
+	err := s.setCharmFromMeta(c,
+		mysqlBaseMeta+oneRequiredLocationStorageMeta,
+		mysqlBaseMeta+oneMultipleLocationStorageMeta,
+	)
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade service "test" to charm "mysql": existing storage "data0" with location changed from singleton to multiple`)
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -341,6 +341,7 @@ func createStorageOps(
 	charmMeta *charm.Meta,
 	curl *charm.URL,
 	cons map[string]StorageConstraints,
+	series string,
 	machineOpsNeeded bool,
 ) (ops []txn.Op, numStorageAttachments int, err error) {
 
@@ -423,7 +424,7 @@ func createStorageOps(
 			})
 			if machineOpsNeeded {
 				machineOps, err := unitAssignedMachineStorageOps(
-					st, entity, charmMeta, cons,
+					st, entity, charmMeta, cons, series,
 					&storageInstance{st, *doc},
 				)
 				if err == nil {
@@ -455,6 +456,7 @@ func unitAssignedMachineStorageOps(
 	entity names.Tag,
 	charmMeta *charm.Meta,
 	cons map[string]StorageConstraints,
+	series string,
 	storage StorageInstance,
 ) (ops []txn.Op, err error) {
 	tag, ok := entity.(names.UnitTag)
@@ -462,7 +464,7 @@ func unitAssignedMachineStorageOps(
 		return nil, errors.NotSupportedf("dynamic creation of shared storage")
 	}
 	storageParams, err := machineStorageParamsForStorageInstance(
-		st, charmMeta, tag, cons, storage,
+		st, charmMeta, tag, series, cons, storage,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1180,6 +1182,7 @@ func (st *State) constructAddUnitStorageOps(
 		ch.Meta(),
 		ch.URL(),
 		map[string]StorageConstraints{name: cons},
+		u.Series(),
 		true, // create machine storage
 	)
 	if err != nil {

--- a/state/unit.go
+++ b/state/unit.go
@@ -1586,7 +1586,7 @@ func (u *Unit) machineStorageParams() (*machineStorageParams, error) {
 			return nil, errors.Annotatef(err, "getting storage instance")
 		}
 		machineParams, err := machineStorageParamsForStorageInstance(
-			u.st, chMeta, u.UnitTag(), allCons, storage,
+			u.st, chMeta, u.UnitTag(), u.Series(), allCons, storage,
 		)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -1619,6 +1619,7 @@ func machineStorageParamsForStorageInstance(
 	st *State,
 	charmMeta *charm.Meta,
 	unit names.UnitTag,
+	series string,
 	allCons map[string]StorageConstraints,
 	storage StorageInstance,
 ) (*machineStorageParams, error) {
@@ -1659,8 +1660,15 @@ func machineStorageParamsForStorageInstance(
 			volumeAttachments[volume.VolumeTag()] = volumeAttachmentParams
 		}
 	case StorageKindFilesystem:
+		location, err := filesystemMountPoint(charmStorage, storage.StorageTag(), series)
+		if err != nil {
+			return nil, errors.Annotatef(
+				err, "getting filesystem mount point for storage %s",
+				storage.StorageName(),
+			)
+		}
 		filesystemAttachmentParams := FilesystemAttachmentParams{
-			charmStorage.Location,
+			location,
 			charmStorage.ReadOnly,
 		}
 		if unit == storage.Owner() {


### PR DESCRIPTION
If a charm storage can have multiple instances,
and it specifies a location, then we should be
creating a sub-directory for each storage
instance. If the storage is a singleton, then
we should use the location as-is.

At the same time, we reject storage that
specifies a location inside the Juju storage
directory, which is reserved for Juju.

(Review request: http://reviews.vapour.ws/r/2068/)