### PR TITLE
Add system wide block operations

### DIFF
--- a/apiserver/common/block_test.go
+++ b/apiserver/common/block_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 type mockBlock struct {
+	state.Block
 	t state.BlockType
 	m string
 }

--- a/apiserver/machinemanager/machinemanager_test.go
+++ b/apiserver/machinemanager/machinemanager_test.go
@@ -151,7 +151,9 @@ func (st *mockState) AddMachineInsideMachine(template state.MachineTemplate, par
 	panic("not implemented")
 }
 
-type mockBlock struct{}
+type mockBlock struct {
+	state.Block
+}
 
 func (st *mockBlock) Id() string {
 	return "id"

--- a/apiserver/storage/package_test.go
+++ b/apiserver/storage/package_test.go
@@ -178,7 +178,10 @@ func (s *baseStorageSuite) constructState(c *gc.C) *mockState {
 }
 
 func (s *baseStorageSuite) addBlock(c *gc.C, t state.BlockType, msg string) {
-	s.blocks[t] = mockBlock{t, msg}
+	s.blocks[t] = mockBlock{
+		t:   t,
+		msg: msg,
+	}
 }
 
 func (s *baseStorageSuite) blockAllChanges(c *gc.C, msg string) {
@@ -469,16 +472,9 @@ func (va *mockVolumeAttachment) Params() (state.VolumeAttachmentParams, bool) {
 }
 
 type mockBlock struct {
+	state.Block
 	t   state.BlockType
 	msg string
-}
-
-func (b mockBlock) Id() string {
-	panic("not implemented for test")
-}
-
-func (b mockBlock) Tag() (names.Tag, error) {
-	panic("not implemented for test")
 }
 
 func (b mockBlock) Type() state.BlockType {

--- a/state/block.go
+++ b/state/block.go
@@ -209,10 +209,6 @@ func (st *State) RemoveAllBlocksForSystem() error {
 		return errors.Trace(err)
 	}
 
-	if len(blocks) == 0 {
-		return nil
-	}
-
 	ops := []txn.Op{}
 	for _, blk := range blocks {
 		ops = append(ops, txn.Op{

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -162,6 +162,18 @@ func (s *blockSuite) TestRemoveAllBlocksForSystem(c *gc.C) {
 	c.Assert(len(blocks), gc.Equals, 0)
 }
 
+func (s *blockSuite) TestRemoveAllBlocksForSystemNoBlocks(c *gc.C) {
+	_, st2 := s.createTestEnv(c)
+	defer st2.Close()
+
+	err := st2.RemoveAllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+
+	blocks, err := st2.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(blocks), gc.Equals, 0)
+}
+
 func (s *blockSuite) TestEnvUUID(c *gc.C) {
 	st := s.Factory.MakeEnvironment(c, nil)
 	defer st.Close()

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -131,6 +131,49 @@ func (s *blockSuite) TestMultiEnvBlocked(c *gc.C) {
 	s.assertNoTypedBlock(c, t)
 }
 
+func (s *blockSuite) TestAllBlocksForSystem(c *gc.C) {
+	_, st2 := s.createTestEnv(c)
+	defer st2.Close()
+
+	err := st2.SwitchBlockOn(state.ChangeBlock, "block test")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.SwitchBlockOn(state.ChangeBlock, "block test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	blocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(blocks), gc.Equals, 2)
+}
+
+func (s *blockSuite) TestRemoveAllBlocksForSystem(c *gc.C) {
+	_, st2 := s.createTestEnv(c)
+	defer st2.Close()
+
+	err := st2.SwitchBlockOn(state.ChangeBlock, "block test")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.SwitchBlockOn(state.ChangeBlock, "block test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.RemoveAllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+
+	blocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(blocks), gc.Equals, 0)
+}
+
+func (s *blockSuite) TestEnvUUID(c *gc.C) {
+	st := s.Factory.MakeEnvironment(c, nil)
+	defer st.Close()
+	err := st.SwitchBlockOn(state.ChangeBlock, "blocktest")
+	c.Assert(err, jc.ErrorIsNil)
+
+	blocks, err := st.AllBlocks()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(blocks), gc.Equals, 1)
+	c.Assert(blocks[0].EnvUUID(), gc.Equals, st.EnvironUUID())
+}
+
 func (s *blockSuite) createTestEnv(c *gc.C) (*state.Environment, *state.State) {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This patch introduces two new block methods
which operate on blocks within a system.

AllBlocksForSystem lists all blocks for the
state server and any hosted environments.

RemoveAllBlocksForSystem removes all blocks
for the state server and any hosted
environments.

(Review request: http://reviews.vapour.ws/r/2071/)