### PR TITLE
Fix runner behaviour when stopping worker quickly.

### DIFF
--- a/worker/runner.go
+++ b/worker/runner.go
@@ -196,7 +196,7 @@ func (runner *runner) run() error {
 			logger.Debugf("%q started", info.id)
 			workerInfo := workers[info.id]
 			workerInfo.worker = info.worker
-			if isDying {
+			if isDying || workerInfo.stopping {
 				killWorker(info.id, workerInfo)
 			}
 		case info := <-runner.donec:

--- a/worker/runner_test.go
+++ b/worker/runner_test.go
@@ -37,7 +37,8 @@ func noImportance(err0, err1 error) bool {
 
 func (s *runnerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.PatchValue(&worker.RestartDelay, time.Duration(0))
+	// Avoid patching RestartDealy to zero, as it changes worker behaviour.
+	s.PatchValue(&worker.RestartDelay, time.Duration(time.Millisecond))
 }
 
 func (*runnerSuite) TestOneWorkerStart(c *gc.C) {


### PR DESCRIPTION
If a worker is asked to stop before that worker has told the runner that started it that it has started, it won't get told to stop.

This problem occurs when the runner test is run with the -race flag, as that changes the timing of the go routines starting.

(Review request: http://reviews.vapour.ws/r/2073/)