### PR TITLE
Implemented AddSubnets API with 100% test coverage

### DIFF
--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -492,3 +492,14 @@ type SpaceResult struct {
 type SpaceResults struct {
 	Results []SpaceResult `json:"Results"`
 }
+
+// AddSubnetsParams holds the arguments of AddSubnets API call.
+type AddSubnetsParams struct {
+	Subnets []AddSubnetParam `json:"Subnets"`
+}
+
+// AddSubnetParam holds a single pair of subnet and space tags.
+type AddSubnetParam struct {
+	SubnetTag string `json:"SubnetTag"`
+	SpaceTag  string `json:"SpaceTag"`
+}

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -495,11 +495,16 @@ type SpaceResults struct {
 
 // AddSubnetsParams holds the arguments of AddSubnets API call.
 type AddSubnetsParams struct {
-	Subnets []AddSubnetParam `json:"Subnets"`
+	Subnets []AddSubnetParams `json:"Subnets"`
 }
 
-// AddSubnetParam holds a single pair of subnet and space tags.
-type AddSubnetParam struct {
-	SubnetTag string `json:"SubnetTag"`
-	SpaceTag  string `json:"SpaceTag"`
+// AddSubnetParams holds a subnet and space tags, subnet provider ID,
+// and a list of zones to associate the subnet to. Either SubnetTag or
+// SubnetProviderId must be set, but not both. Zones can be empty if
+// they can be discovered
+type AddSubnetParams struct {
+	SubnetTag        string   `json:"SubnetTag,omitempty"`
+	SubnetProviderId string   `json:"SubnetProviderId,omitempty"`
+	SpaceTag         string   `json:"SpaceTag"`
+	Zones            []string `json:"Zones,omitempty"`
 }

--- a/apiserver/subnets/package_test.go
+++ b/apiserver/subnets/package_test.go
@@ -5,6 +5,7 @@ package subnets_test
 
 import (
 	"fmt"
+	"net"
 	stdtesting "testing"
 
 	"github.com/juju/testing"
@@ -14,6 +15,8 @@ import (
 	"github.com/juju/juju/apiserver/subnets"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -23,26 +26,84 @@ func TestPackage(t *stdtesting.T) {
 }
 
 const (
-	StubProviderType     = "stub-provider"
-	StubEnvironName      = "stub-environ"
-	StubZonedEnvironName = "stub-zoned-environ"
+	StubProviderType               = "stub-provider"
+	StubEnvironName                = "stub-environ"
+	StubZonedEnvironName           = "stub-zoned-environ"
+	StubNetworkingEnvironName      = "stub-networking-environ"
+	StubZonedNetworkingEnvironName = "stub-zoned-networking-environ"
 )
 
 var (
 	// SharedStub records all method calls to any of the stubs.
 	SharedStub = &testing.Stub{}
 
-	BackingInstance      = &StubBacking{Stub: SharedStub}
-	ProviderInstance     = &StubProvider{Stub: SharedStub}
-	EnvironInstance      = &StubEnviron{Stub: SharedStub}
-	ZonedEnvironInstance = &StubZonedEnviron{Stub: SharedStub}
+	BackingInstance                = &StubBacking{Stub: SharedStub}
+	ProviderInstance               = &StubProvider{Stub: SharedStub}
+	EnvironInstance                = &StubEnviron{Stub: SharedStub}
+	ZonedEnvironInstance           = &StubZonedEnviron{Stub: SharedStub}
+	NetworkingEnvironInstance      = &StubNetworkingEnviron{Stub: SharedStub}
+	ZonedNetworkingEnvironInstance = &StubZonedNetworkingEnviron{Stub: SharedStub}
 )
 
 func init() {
 	ProviderInstance.Zones = []providercommon.AvailabilityZone{
-		&FakeZone{"env-zone1", true},
-		&FakeZone{"env-zone2", false},
+		&FakeZone{"zone1", true},
+		&FakeZone{"zone2", false},
+		&FakeZone{"zone3", true},
+		&FakeZone{"zone4", false},
+		&FakeZone{"zone4", false}, // duplicates are ignored
 	}
+	ProviderInstance.Subnets = []network.SubnetInfo{{
+		CIDR:              "10.10.0.0/24",
+		ProviderId:        "sn-zadf00d",
+		AvailabilityZones: []string{"zone1"},
+		AllocatableIPLow:  net.ParseIP("10.10.0.10"),
+		AllocatableIPHigh: net.ParseIP("10.10.0.100"),
+	}, {
+		CIDR:              "2001:db8::/32",
+		ProviderId:        "sn-ipv6",
+		AvailabilityZones: []string{"zone1", "zone3"},
+	}, {
+		CIDR:       "",
+		ProviderId: "",
+		// no CIDR or provider id -> cached, but cannot be added
+	}, {
+		CIDR:       "",
+		ProviderId: "sn-empty",
+		// no CIDR, just provider id -> cached, but can only be added by id
+	}, {
+		CIDR:       "invalid",
+		ProviderId: "sn-invalid",
+		// invalid CIDR and provider id -> cannot be added, but is cached
+	}, {
+		CIDR:       "0.1.2.3/4",
+		ProviderId: "sn-awesome",
+		// incorrectly specified CIDR, with provider id -> cached, cannot be added
+	}, {
+		CIDR: "10.20.0.0/16",
+		// no zones, no provider-id -> cached, but can only be added by CIDR
+	}, {
+		CIDR:              "10.99.88.0/24",
+		ProviderId:        "sn-deadbeef",
+		AvailabilityZones: []string{"zone1", "zone2"},
+		// with zones, duplicate provider-id -> overwritten by the last
+		// subnet with the same provider id when caching.
+	}, {
+		CIDR:       "10.42.0.0/16",
+		ProviderId: "sn-42",
+		// no zones
+	}, {
+		CIDR:              "10.10.0.0/24",
+		ProviderId:        "sn-deadbeef",
+		AvailabilityZones: []string{"zone2"},
+		// in an unavailable zone, duplicate CIDR -> cannot be added, but is cached
+	}, {
+		CIDR:              "10.30.1.0/24",
+		ProviderId:        "vlan-42",
+		VLANTag:           42,
+		AvailabilityZones: []string{"zone3"},
+	}}
+
 	environs.RegisterProvider(StubProviderType, ProviderInstance)
 }
 
@@ -91,6 +152,26 @@ func ZonedEnvironCall(name string, args ...interface{}) StubMethodCall {
 	}
 }
 
+// NetworkingEnvironCall makes it easy to check method calls on
+// NetworkingEnvironInstance.
+func NetworkingEnvironCall(name string, args ...interface{}) StubMethodCall {
+	return StubMethodCall{
+		Receiver: NetworkingEnvironInstance,
+		FuncName: name,
+		Args:     args,
+	}
+}
+
+// ZonedNetworkingEnvironCall makes it easy to check method calls on
+// ZonedNetworkingEnvironInstance.
+func ZonedNetworkingEnvironCall(name string, args ...interface{}) StubMethodCall {
+	return StubMethodCall{
+		Receiver: ZonedNetworkingEnvironInstance,
+		FuncName: name,
+		Args:     args,
+	}
+}
+
 // CheckMethodCalls works like testing.Stub.CheckCalls, but also
 // checks the receivers.
 func CheckMethodCalls(c *gc.C, stub *testing.Stub, calls ...StubMethodCall) {
@@ -98,12 +179,8 @@ func CheckMethodCalls(c *gc.C, stub *testing.Stub, calls ...StubMethodCall) {
 	for i, call := range calls {
 		receivers[i] = call.Receiver
 	}
-	if !stub.CheckReceivers(c, receivers...) {
-		return
-	}
-	if !c.Check(stub.Calls(), gc.HasLen, len(calls)) {
-		return
-	}
+	stub.CheckReceivers(c, receivers...)
+	c.Check(stub.Calls(), gc.HasLen, len(calls))
 	for i, call := range calls {
 		stub.CheckCall(c, i, call.FuncName, call.Args...)
 	}
@@ -146,6 +223,18 @@ func (f *FakeSpace) GoString() string {
 	return fmt.Sprintf("&FakeSpace{%q}", f.name)
 }
 
+// FakeSubnet implements subnets.BackingSubnet for testing.
+type FakeSubnet struct {
+	info subnets.BackingSubnetInfo
+}
+
+var _ subnets.BackingSubnet = (*FakeSubnet)(nil)
+
+// GoString implements fmt.GoStringer.
+func (f *FakeSubnet) GoString() string {
+	return fmt.Sprintf("&FakeSubnet{%#v}", f.info)
+}
+
 // ResetStub resets all recorded calls and errors of the given stub.
 func ResetStub(stub *testing.Stub) {
 	*stub = testing.Stub{}
@@ -158,8 +247,9 @@ type StubBacking struct {
 
 	EnvConfig *config.Config
 
-	Zones  []providercommon.AvailabilityZone
-	Spaces []subnets.BackingSpace
+	Zones   []providercommon.AvailabilityZone
+	Spaces  []subnets.BackingSpace
+	Subnets []subnets.BackingSubnet
 }
 
 var _ subnets.Backing = (*StubBacking)(nil)
@@ -167,13 +257,15 @@ var _ subnets.Backing = (*StubBacking)(nil)
 type SetUpFlag bool
 
 const (
-	WithZones     SetUpFlag = true
-	WithoutZones  SetUpFlag = false
-	WithSpaces    SetUpFlag = true
-	WithoutSpaces SetUpFlag = true
+	WithZones      SetUpFlag = true
+	WithoutZones   SetUpFlag = false
+	WithSpaces     SetUpFlag = true
+	WithoutSpaces  SetUpFlag = false
+	WithSubnets    SetUpFlag = true
+	WithoutSubnets SetUpFlag = false
 )
 
-func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces SetUpFlag) {
+func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, withSubnets SetUpFlag) {
 	// This method should be called at the beginning of each test, so
 	// reset the recorded calls and errors.
 	ResetStub(sb.Stub)
@@ -187,11 +279,8 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces SetU
 	sb.EnvConfig = coretesting.CustomEnvironConfig(c, extraAttrs)
 	sb.Zones = []providercommon.AvailabilityZone{}
 	if withZones {
-		sb.Zones = []providercommon.AvailabilityZone{
-			&FakeZone{"zone1", true},
-			&FakeZone{"zone2", false},
-			&FakeZone{"zone3", true},
-		}
+		sb.Zones = make([]providercommon.AvailabilityZone, len(ProviderInstance.Zones))
+		copy(sb.Zones, ProviderInstance.Zones)
 	}
 	sb.Spaces = []subnets.BackingSpace{}
 	if withSpaces {
@@ -199,6 +288,29 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces SetU
 			&FakeSpace{"default"},
 			&FakeSpace{"dmz"},
 			&FakeSpace{"private"},
+			&FakeSpace{"private"}, // duplicates are ignored when caching spaces.
+		}
+	}
+	sb.Subnets = []subnets.BackingSubnet{}
+	if withSubnets {
+		info0 := subnets.BackingSubnetInfo{
+			CIDR:              ProviderInstance.Subnets[0].CIDR,
+			ProviderId:        string(ProviderInstance.Subnets[0].ProviderId),
+			AllocatableIPLow:  ProviderInstance.Subnets[0].AllocatableIPLow.String(),
+			AllocatableIPHigh: ProviderInstance.Subnets[0].AllocatableIPHigh.String(),
+			AvailabilityZones: ProviderInstance.Subnets[0].AvailabilityZones,
+			SpaceName:         "private",
+		}
+		info1 := subnets.BackingSubnetInfo{
+			CIDR:              ProviderInstance.Subnets[1].CIDR,
+			ProviderId:        string(ProviderInstance.Subnets[1].ProviderId),
+			AvailabilityZones: ProviderInstance.Subnets[1].AvailabilityZones,
+			SpaceName:         "dmz",
+		}
+
+		sb.Subnets = []subnets.BackingSubnet{
+			&FakeSubnet{info0},
+			&FakeSubnet{info1},
 		}
 	}
 }
@@ -232,12 +344,28 @@ func (sb *StubBacking) AllSpaces() ([]subnets.BackingSpace, error) {
 	return sb.Spaces, nil
 }
 
+func (sb *StubBacking) AddSubnet(subnetInfo subnets.BackingSubnetInfo) (subnets.BackingSubnet, error) {
+	sb.MethodCall(sb, "AddSubnet", subnetInfo)
+	if err := sb.NextErr(); err != nil {
+		return nil, err
+	}
+	fs := &FakeSubnet{info: subnetInfo}
+	sb.Subnets = append(sb.Subnets, fs)
+	return fs, nil
+}
+
+// GoString implements fmt.GoStringer.
+func (se *StubBacking) GoString() string {
+	return "&StubBacking{}"
+}
+
 // StubProvider implements a subset of environs.EnvironProvider
 // methods used in tests.
 type StubProvider struct {
 	*testing.Stub
 
-	Zones []providercommon.AvailabilityZone
+	Zones   []providercommon.AvailabilityZone
+	Subnets []network.SubnetInfo
 
 	environs.EnvironProvider // panic on any not implemented method call.
 }
@@ -254,8 +382,17 @@ func (sp *StubProvider) Open(cfg *config.Config) (environs.Environ, error) {
 		return EnvironInstance, nil
 	case StubZonedEnvironName:
 		return ZonedEnvironInstance, nil
+	case StubNetworkingEnvironName:
+		return NetworkingEnvironInstance, nil
+	case StubZonedNetworkingEnvironName:
+		return ZonedNetworkingEnvironInstance, nil
 	}
 	panic("unexpected environment name: " + cfg.Name())
+}
+
+// GoString implements fmt.GoStringer.
+func (se *StubProvider) GoString() string {
+	return "&StubProvider{}"
 }
 
 // StubEnviron is used in tests where environs.Environ is needed.
@@ -266,6 +403,11 @@ type StubEnviron struct {
 }
 
 var _ environs.Environ = (*StubEnviron)(nil)
+
+// GoString implements fmt.GoStringer.
+func (se *StubEnviron) GoString() string {
+	return "&StubEnviron{}"
+}
 
 // StubZonedEnviron is used in tests where providercommon.ZonedEnviron
 // is needed.
@@ -278,6 +420,66 @@ type StubZonedEnviron struct {
 var _ providercommon.ZonedEnviron = (*StubZonedEnviron)(nil)
 
 func (se *StubZonedEnviron) AvailabilityZones() ([]providercommon.AvailabilityZone, error) {
+	se.MethodCall(se, "AvailabilityZones")
+	if err := se.NextErr(); err != nil {
+		return nil, err
+	}
+	return ProviderInstance.Zones, nil
+}
+
+// GoString implements fmt.GoStringer.
+func (se *StubZonedEnviron) GoString() string {
+	return "&StubZonedEnviron{}"
+}
+
+// StubNetworkingEnviron is used in tests where
+// environs.NetworkingEnviron is needed.
+type StubNetworkingEnviron struct {
+	*testing.Stub
+
+	environs.NetworkingEnviron // panic on any not implemented method call
+}
+
+var _ environs.NetworkingEnviron = (*StubNetworkingEnviron)(nil)
+
+func (se *StubNetworkingEnviron) Subnets(instId instance.Id, subIds []network.Id) ([]network.SubnetInfo, error) {
+	se.MethodCall(se, "Subnets", instId, subIds)
+	if err := se.NextErr(); err != nil {
+		return nil, err
+	}
+	return ProviderInstance.Subnets, nil
+}
+
+// GoString implements fmt.GoStringer.
+func (se *StubNetworkingEnviron) GoString() string {
+	return "&StubNetworkingEnviron{}"
+}
+
+// StubZonedNetworkingEnviron is used in tests where features from
+// both environs.Networking and providercommon.ZonedEnviron are
+// needed.
+type StubZonedNetworkingEnviron struct {
+	*testing.Stub
+
+	// panic on any not implemented method call
+	providercommon.ZonedEnviron
+	environs.Networking
+}
+
+// GoString implements fmt.GoStringer.
+func (se *StubZonedNetworkingEnviron) GoString() string {
+	return "&StubZonedNetworkingEnviron{}"
+}
+
+func (se *StubZonedNetworkingEnviron) Subnets(instId instance.Id, subIds []network.Id) ([]network.SubnetInfo, error) {
+	se.MethodCall(se, "Subnets", instId, subIds)
+	if err := se.NextErr(); err != nil {
+		return nil, err
+	}
+	return ProviderInstance.Subnets, nil
+}
+
+func (se *StubZonedNetworkingEnviron) AvailabilityZones() ([]providercommon.AvailabilityZone, error) {
 	se.MethodCall(se, "AvailabilityZones")
 	if err := se.NextErr(); err != nil {
 		return nil, err

--- a/apiserver/subnets/package_test.go
+++ b/apiserver/subnets/package_test.go
@@ -64,39 +64,39 @@ func init() {
 		ProviderId:        "sn-ipv6",
 		AvailabilityZones: []string{"zone1", "zone3"},
 	}, {
+		// no CIDR or provider id -> cached, but cannot be added
 		CIDR:       "",
 		ProviderId: "",
-		// no CIDR or provider id -> cached, but cannot be added
 	}, {
+		// no CIDR, just provider id -> cached, but can only be added by id
 		CIDR:       "",
 		ProviderId: "sn-empty",
-		// no CIDR, just provider id -> cached, but can only be added by id
 	}, {
+		// invalid CIDR and provider id -> cannot be added, but is cached
 		CIDR:       "invalid",
 		ProviderId: "sn-invalid",
-		// invalid CIDR and provider id -> cannot be added, but is cached
 	}, {
+		// incorrectly specified CIDR, with provider id -> cached, cannot be added
 		CIDR:       "0.1.2.3/4",
 		ProviderId: "sn-awesome",
-		// incorrectly specified CIDR, with provider id -> cached, cannot be added
 	}, {
-		CIDR: "10.20.0.0/16",
 		// no zones, no provider-id -> cached, but can only be added by CIDR
+		CIDR: "10.20.0.0/16",
 	}, {
+		// with zones, duplicate provider-id -> overwritten by the last
+		// subnet with the same provider id when caching.
 		CIDR:              "10.99.88.0/24",
 		ProviderId:        "sn-deadbeef",
 		AvailabilityZones: []string{"zone1", "zone2"},
-		// with zones, duplicate provider-id -> overwritten by the last
-		// subnet with the same provider id when caching.
 	}, {
+		// no zones
 		CIDR:       "10.42.0.0/16",
 		ProviderId: "sn-42",
-		// no zones
 	}, {
+		// in an unavailable zone, duplicate CIDR -> cannot be added, but is cached
 		CIDR:              "10.10.0.0/24",
 		ProviderId:        "sn-deadbeef",
 		AvailabilityZones: []string{"zone2"},
-		// in an unavailable zone, duplicate CIDR -> cannot be added, but is cached
 	}, {
 		CIDR:              "10.30.1.0/24",
 		ProviderId:        "vlan-42",
@@ -266,8 +266,9 @@ const (
 )
 
 func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, withSubnets SetUpFlag) {
-	// This method should be called at the beginning of each test, so
-	// reset the recorded calls and errors.
+	// This method must be called at the beginning of each test, which
+	// needs access to any of the mocks, to reset the recorded calls
+	// and errors, as well as to initialize the mocks as needed.
 	ResetStub(sb.Stub)
 
 	// Make sure we use the stub provider.

--- a/apiserver/subnets/subnets.go
+++ b/apiserver/subnets/subnets.go
@@ -12,6 +12,8 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 )
 
@@ -33,6 +35,58 @@ type BackingSpace interface {
 	Name() string
 }
 
+// BackingSubnet defines the methods supported by a Subnet entity
+// stored persistently.
+//
+// TODO(dimitern): Once the state backing is implemented, remove this
+// and just use *state.Subnet.
+type BackingSubnet interface {
+	// no methods needed yet.
+}
+
+// BackingSubnetInfo describes a single subnet to be added in the
+// backing store.
+//
+// TODO(dimitern): Replace state.SubnetInfo with this and remove
+// BackingSubnetInfo, once the rest of state backing methods and the
+// following pre-reqs are done:
+// * subnetDoc.AvailabilityZone becomes subnetDoc.AvailabilityZones,
+//   adding an upgrade step to migrate existing non empty zones on
+//   subnet docs. Also change state.Subnet.AvailabilityZone to
+// * add subnetDoc.SpaceName - no upgrade step needed, as it will only
+//   be used for new space-aware subnets.
+// * ensure EC2 and MAAS providers accept empty IDs as Subnets() args
+//   and return all subnets, including the AvailabilityZones (for EC2;
+//   empty for MAAS as zones are orthogonal to networks).
+type BackingSubnetInfo struct {
+	// ProviderId is a provider-specific network id. This may be empty.
+	ProviderId string
+
+	// CIDR of the network, in 123.45.67.89/24 format.
+	CIDR string
+
+	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for normal
+	// networks. It's defined by IEEE 802.1Q standard.
+	VLANTag int
+
+	// AllocatableIPHigh and Low describe the allocatable portion of the
+	// subnet. The remainder, if any, is reserved by the provider.
+	// Either both of these must be set or neither, if they're empty it
+	// means that none of the subnet is allocatable. If present they must
+	// be valid IP addresses within the subnet CIDR.
+	AllocatableIPHigh string
+	AllocatableIPLow  string
+
+	// AvailabilityZones describes which availability zone(s) this
+	// subnet is in. It can be empty if the provider does not support
+	// availability zones.
+	AvailabilityZones []string
+
+	// SpaceName holds the juju network space this subnet is
+	// associated with. Can be empty if not supported.
+	SpaceName string
+}
+
 // Backing defines the methods needed by the API facade to store and
 // retrieve information from the underlying persistency layer (state
 // DB).
@@ -52,7 +106,7 @@ type Backing interface {
 	AllSpaces() ([]BackingSpace, error)
 
 	// AddSubnet creates a backing subnet for an existing subnet.
-	AddSubnet()
+	AddSubnet(subnetInfo BackingSubnetInfo) (BackingSubnet, error)
 }
 
 // API defines the methods the Subnets API facade implements.
@@ -159,6 +213,26 @@ func (a *internalAPI) zonedEnviron() (providercommon.ZonedEnviron, error) {
 	return nil, errors.NotSupportedf("availability zones")
 }
 
+// networkingEnviron returns a environs.NetworkingEnviron instance
+// from the current environment config, if supported. If the
+// environment does not support environs.Networking, an error
+// satisfying errors.IsNotSupported() will be returned.
+func (a *internalAPI) networkingEnviron() (environs.NetworkingEnviron, error) {
+	envConfig, err := a.backing.EnvironConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting environment config")
+	}
+
+	env, err := environs.New(envConfig)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting environment")
+	}
+	if netEnv, ok := environs.SupportsNetworking(env); ok {
+		return netEnv, nil
+	}
+	return nil, errors.NotSupportedf("environment networking features") // " not supported"
+}
+
 // updateZones attempts to retrieve all availability zones from the
 // environment provider (if supported) and then updates the persisted
 // list of zones in state, returning them as well on success.
@@ -178,31 +252,113 @@ func (a *internalAPI) updateZones() ([]providercommon.AvailabilityZone, error) {
 	return zones, nil
 }
 
+func (a *internalAPI) addOneSubnet(args params.AddSubnetParams, cachedInfo *[]network.SubnetInfo) error {
+	// Validate required arguments.
+	if args.SubnetTag == "" && args.SubnetProviderId == "" {
+		return errors.Errorf("either SubnetTag or SubnetProviderId is required")
+	} else if args.SubnetTag != "" && args.SubnetProviderId != "" {
+		return errors.Errorf("SubnetTag or SubnetProviderId cannot be both set")
+	}
+	if args.SpaceTag == "" {
+		return errors.Errorf("SpaceTag is required")
+	}
+	spaceTag, err := names.ParseSpaceTag(args.SpaceTag)
+	if err != nil {
+		return errors.Annotate(err, "invalid space tag given")
+	}
+
+	// Get all subnets (from cache or the provider).
+	var subnetInfo []network.SubnetInfo
+	if cachedInfo == nil || len(*cachedInfo) == 0 {
+		netEnv, err := a.networkingEnviron()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		subnetInfo, err = netEnv.Subnets(instance.UnknownId, nil)
+		if err != nil {
+			return errors.Annotate(err, "cannot get provider subnets")
+		}
+		// Only cache them if requested (cachedInfo != nil).
+		if cachedInfo != nil {
+			*cachedInfo = make([]network.SubnetInfo, len(subnetInfo))
+			copy(*cachedInfo, subnetInfo)
+		}
+	} else if cachedInfo != nil && len(*cachedInfo) > 0 {
+		// Use the cache instead.
+		subnetInfo = make([]network.SubnetInfo, len(*cachedInfo))
+		copy(subnetInfo, *cachedInfo)
+	}
+	if len(subnetInfo) == 0 {
+		return errors.Errorf("cannot find any subnets")
+	}
+
+	// Use the tag if specified, otherwise use the provider ID.
+	var subnetTag names.SubnetTag
+	var providerId network.Id
+	if args.SubnetTag != "" {
+		subnetTag, err = names.ParseSubnetTag(args.SubnetTag)
+		if err != nil {
+			return errors.Annotate(err, "invalid subnet tag given")
+		}
+	} else {
+		providerId = network.Id(args.SubnetProviderId)
+	}
+
+	// Find a matching subnet info - by tag or provider ID.
+	var sub network.SubnetInfo
+	for _, info := range subnetInfo {
+		if (info.CIDR == subnetTag.Id() && info.CIDR != "") ||
+			(info.ProviderId == providerId && info.ProviderId != "") {
+			sub = info
+			break
+		}
+	}
+	// Return nicer error when we can't find it.
+	if sub.CIDR == "" {
+		if args.SubnetProviderId != "" {
+			return errors.NotFoundf("subnet with ProviderId %q", args.SubnetProviderId)
+		}
+		return errors.NotFoundf("subnet %q", subnetTag.Id())
+	}
+
+	// At this point zones must be specified if cannot be discovered.
+	if len(sub.AvailabilityZones) == 0 {
+		return errors.Errorf("Zones cannot be discovered from the provider and must be set")
+	}
+
+	// Try adding the subnet.
+	backingInfo := BackingSubnetInfo{
+		ProviderId:        string(sub.ProviderId),
+		CIDR:              sub.CIDR,
+		AvailabilityZones: sub.AvailabilityZones,
+		SpaceName:         spaceTag.Id(),
+	}
+	if sub.AllocatableIPLow != nil {
+		backingInfo.AllocatableIPLow = sub.AllocatableIPLow.String()
+	}
+	if sub.AllocatableIPHigh != nil {
+		backingInfo.AllocatableIPHigh = sub.AllocatableIPHigh.String()
+	}
+	if _, err := a.backing.AddSubnet(backingInfo); err != nil {
+		return errors.Annotate(err, "cannot add subnet")
+	}
+	return nil
+}
+
 // AddSubnets is defined on the API interface.
 func (a *internalAPI) AddSubnets(args params.AddSubnetsParams) (params.ErrorResults, error) {
-	var results params.ErrorResults
+	results := params.ErrorResults{Results: make([]params.ErrorResult, len(args.Subnets))}
 
-	// Try fetching cached zones first.
-	zones, err := a.backing.AvailabilityZones()
-	if err != nil {
-		return results, errors.Trace(err)
+	if len(args.Subnets) == 0 {
+		return results, nil
 	}
-	if len(zones) == 0 {
-		// This is likely the first time we're called.
-		// Fetch all zones from the provider and update.
-		zones, err = a.updateZones()
+
+	var cache []network.SubnetInfo
+	for i, arg := range args.Subnets {
+		err := a.addOneSubnet(arg, &cache)
 		if err != nil {
-			return results, errors.Annotate(err, "cannot update known zones")
+			results.Results[i].Error = common.ServerError(err)
 		}
-		logger.Debugf("updated the list of known zones from the environment: %v", zones)
-	} else {
-		logger.Debugf("using cached list of known zones: %v", zones)
-	}
-
-	results.Results = make([]params.ZoneResult, len(zones))
-	for i, zone := range zones {
-		results.Results[i].Name = zone.Name()
-		results.Results[i].Available = zone.Available()
 	}
 	return results, nil
 }

--- a/apiserver/subnets/subnets_test.go
+++ b/apiserver/subnets/subnets_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/subnets"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	providercommon "github.com/juju/juju/provider/common"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -29,7 +31,7 @@ var _ = gc.Suite(&SubnetsSuite{})
 
 func (s *SubnetsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	BackingInstance.SetUp(c, StubZonedEnvironName, WithZones, WithSpaces)
+	BackingInstance.SetUp(c, StubZonedEnvironName, WithZones, WithSpaces, WithSubnets)
 
 	s.resources = common.NewResources()
 	s.authorizer = apiservertesting.FakeAuthorizer{
@@ -112,7 +114,7 @@ func (s *SubnetsSuite) TestAllZonesUsesBackingZonesWhenAvailable(c *gc.C) {
 }
 
 func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesUpdates(c *gc.C) {
-	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces)
+	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces, WithSubnets)
 
 	results, err := s.facade.AllZones()
 	c.Assert(err, jc.ErrorIsNil)
@@ -128,7 +130,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesUpdates(c *gc.C) {
 }
 
 func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
-	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces)
+	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces, WithSubnets)
 	SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.EnvironConfig
@@ -155,7 +157,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndSetFails(c *gc.C) {
 }
 
 func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc.C) {
-	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces)
+	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces, WithSubnets)
 	SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.EnvironConfig
@@ -180,7 +182,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndFetchingZonesFails(c *gc
 }
 
 func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndEnvironConfigFails(c *gc.C) {
-	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces)
+	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces, WithSubnets)
 	SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		errors.NotFoundf("config"), // Backing.EnvironConfig
@@ -201,7 +203,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndEnvironConfigFails(c *gc
 }
 
 func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
-	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces)
+	BackingInstance.SetUp(c, StubZonedEnvironName, WithoutZones, WithSpaces, WithSubnets)
 	SharedStub.SetErrors(
 		nil, // Backing.AvailabilityZones
 		nil, // Backing.EnvironConfig
@@ -210,7 +212,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 
 	results, err := s.facade.AllZones()
 	c.Assert(err, gc.ErrorMatches,
-		`cannot update known zones: getting environment: config not valid`,
+		`cannot update known zones: opening environment: config not valid`,
 	)
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
@@ -224,7 +226,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 }
 
 func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndZonesNotSupported(c *gc.C) {
-	BackingInstance.SetUp(c, StubEnvironName, WithoutZones, WithSpaces)
+	BackingInstance.SetUp(c, StubEnvironName, WithoutZones, WithSpaces, WithSubnets)
 	// ZonedEnviron not supported
 
 	results, err := s.facade.AllZones()
@@ -251,7 +253,7 @@ func (s *SubnetsSuite) TestAllSpacesNoExistingSuccess(c *gc.C) {
 }
 
 func (s *SubnetsSuite) testAllSpacesSuccess(c *gc.C, withBackingSpaces SetUpFlag) {
-	BackingInstance.SetUp(c, StubZonedEnvironName, WithZones, withBackingSpaces)
+	BackingInstance.SetUp(c, StubZonedEnvironName, WithZones, withBackingSpaces, WithSubnets)
 
 	results, err := s.facade.AllSpaces()
 	c.Assert(err, jc.ErrorIsNil)
@@ -273,5 +275,472 @@ func (s *SubnetsSuite) TestAllSpacesFailure(c *gc.C) {
 
 	CheckMethodCalls(c, SharedStub,
 		BackingCall("AllSpaces"),
+	)
+}
+
+func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
+	BackingInstance.SetUp(c, StubNetworkingEnvironName, WithZones, WithSpaces, WithSubnets)
+
+	args := params.AddSubnetsParams{Subnets: []params.AddSubnetParams{{
+	// nothing set; early exit: no calls
+	}, {
+		// neither tag nor id set: the rest is ignored; same as above
+		SpaceTag: "any",
+		Zones:    []string{"any", "ignored"},
+	}, {
+		// both tag and id set; same as above
+		SubnetTag:        "any",
+		SubnetProviderId: "any",
+	}, {
+		// lookup by id needed, no cached subnets; EnvironConfig(): error
+		SubnetProviderId: "any",
+	}, {
+		// same as above, need to cache subnets; EnvironConfig(): ok; Open(): error
+		SubnetProviderId: "ignored",
+	}, {
+		// as above, caching again; EnvironConfig(), Open(): ok; Subnets(): error
+		SubnetProviderId: "unimportant",
+	}, {
+		// exactly as above, except all 3 calls ok; cached lookup: id not found
+		SubnetProviderId: "missing",
+	}, {
+		// cached lookup by id (no calls): not found error
+		SubnetProviderId: "void",
+	}, {
+		// cached lookup by id: ok; parsing space tag: invalid tag error
+		SubnetProviderId: "sn-deadbeef",
+		SpaceTag:         "invalid",
+	}, {
+		// as above, but slightly different error: invalid space tag error
+		SubnetProviderId: "sn-zadf00d",
+		SpaceTag:         "unit-foo",
+	}, {
+		// as above; yet another similar error (valid tag with another kind)
+		SubnetProviderId: "vlan-42",
+		SpaceTag:         "unit-foo-0",
+	}, {
+		// invalid tag (no kind): error (no calls)
+		SubnetTag: "invalid",
+	}, {
+		// invalid subnet tag (another kind): same as above
+		SubnetTag: "service-bar",
+	}, {
+		// cached lookup by missing CIDR: not found error
+		SubnetTag: "subnet-1.2.3.0/24",
+	}, {
+		// cached lookup by duplicate CIDR: multiple choices error
+		SubnetTag: "subnet-10.10.0.0/24",
+	}, {
+		// cached lookup by CIDR with empty provider id: ok; space tag is required error
+		SubnetTag: "subnet-10.20.0.0/16",
+	}, {
+		// cached lookup by id with invalid CIDR: cannot be added error
+		SubnetProviderId: "sn-invalid",
+	}, {
+		// cached lookup by id with empty CIDR: cannot be added error
+		SubnetProviderId: "sn-empty",
+	}, {
+		// cached lookup by id with incorrectly specified CIDR: cannot be added error
+		SubnetProviderId: "sn-awesome",
+	}, {
+		// cached lookup by CIDR: ok; valid tag; caching spaces: AllSpaces(): error
+		SubnetTag: "subnet-10.30.1.0/24",
+		SpaceTag:  "space-unverified",
+	}, {
+		// exactly as above, except AllSpaces(): ok; cached lookup: space not found
+		SubnetTag: "subnet-2001:db8::/32",
+		SpaceTag:  "space-missing",
+	}, {
+		// both cached lookups (CIDR, space): ok; no provider or given zones: error
+		SubnetTag: "subnet-10.42.0.0/16",
+		SpaceTag:  "space-dmz",
+	}, {
+		// like above; with provider zones, extra given: error
+		SubnetProviderId: "vlan-42",
+		SpaceTag:         "space-private",
+		Zones: []string{
+			"zone2",   // not allowed, existing, unavailable
+			"zone3",   // allowed, existing, available
+			"missing", // not allowed, non-existing
+			"zone3",   // duplicates are ignored (should they ?)
+			"zone1",   // not allowed, existing, available
+		},
+	}, {
+		// like above; no provider, only given zones; caching: AllZones(): error
+		SubnetTag: "subnet-10.42.0.0/16",
+		SpaceTag:  "space-dmz",
+		Zones:     []string{"any", "ignored"},
+	}, {
+		// as above, but unknown zones given: cached: AllZones(): ok; unknown zones error
+		SubnetTag: "subnet-10.42.0.0/16",
+		SpaceTag:  "space-dmz",
+		Zones:     []string{"missing", "gone"},
+	}, {
+		// as above, but unknown and unavailable zones given: same error (no calls)
+		SubnetTag: "subnet-10.42.0.0/16",
+		SpaceTag:  "space-dmz",
+		Zones:     []string{"zone4", "missing", "zone2"},
+	}, {
+		// as above, but unavailable zones given: Zones contains unavailable error
+		SubnetTag: "subnet-10.42.0.0/16",
+		SpaceTag:  "space-dmz",
+		Zones:     []string{"zone2", "zone4"},
+	}, {
+		// as above, but available and unavailable zones given: same error as above
+		SubnetTag: "subnet-10.42.0.0/16",
+		SpaceTag:  "space-dmz",
+		Zones:     []string{"zone4", "zone3"},
+	}, {
+		// everything succeeds, using caches as needed, until: AddSubnet(): error
+		SubnetProviderId: "sn-ipv6",
+		SpaceTag:         "space-dmz",
+		Zones:            []string{"zone1"},
+		// restriction of provider zones [zone1, zone3]
+	}, {
+		// cached lookups by CIDR, space: ok; duplicated provider id: unavailable zone2
+		SubnetTag: "subnet-10.99.88.0/24",
+		SpaceTag:  "space-dmz",
+		Zones:     []string{"zone2"},
+		// due to the duplicate ProviderId provider zones from subnet
+		// with the last ProviderId=sn-deadbeef are used
+		// (10.10.0.0/24); [zone2], not the 10.99.88.0/24 provider
+		// zones: [zone1, zone2].
+	}, {
+		// same as above, but AddSubnet(): ok; success (backing verified later)
+		SubnetProviderId: "sn-ipv6",
+		SpaceTag:         "space-dmz",
+		Zones:            []string{"zone1"},
+		// restriction of provider zones [zone1, zone3]
+	}, {
+		// success (CIDR lookup; with provider (no given) zones): AddSubnet(): ok
+		SubnetTag: "subnet-10.30.1.0/24",
+		SpaceTag:  "space-private",
+		// Zones not given, so provider zones are used instead: [zone3]
+	}, {
+		// success (id lookup; given zones match provider zones) AddSubnet(): ok
+		SubnetProviderId: "sn-zadf00d",
+		SpaceTag:         "space-private",
+		Zones:            []string{"zone1"},
+	}}}
+	SharedStub.SetErrors(
+		// caching subnets (1st attempt): fails
+		errors.NotFoundf("config"), // BackingInstance.EnvironConfig (1st call)
+
+		// caching subnets (2nd attepmt): fails
+		nil, // BackingInstance.EnvironConfig (2nd call)
+		errors.NotFoundf("provider"), // ProviderInstance.Open (1st call)
+
+		// caching subnets (3rd attempt): fails
+		nil, // BackingInstance.EnvironConfig (3rd call)
+		nil, // ProviderInstance.Open (2nd call)
+		errors.NotFoundf("subnets"), // NetworkingEnvironInstance.Subnets (1st call)
+
+		// caching subnets (4th attempt): succeeds
+		nil, // BackingInstance.EnvironConfig (4th call)
+		nil, // ProviderInstance.Open (3rd call)
+		nil, // NetworkingEnvironInstance.Subnets (2nd call)
+
+		// caching spaces (1st and 2nd attempts)
+		errors.NotFoundf("spaces"), // BackingInstance.AllSpaces (1st call)
+		nil, // BackingInstance.AllSpaces (2nd call)
+
+		// cacing zones (1st and 2nd attempts)
+		errors.NotFoundf("zones"), // BackingInstance.AvailabilityZones (1st call)
+		nil, // BackingInstance.AvailabilityZones (2nd call)
+
+		// validation done; adding subnets to backing store
+		errors.NotFoundf("state"), // BackingInstance.AddSubnet (1st call)
+		// the next 3 BackingInstance.AddSubnet calls succeed(2nd call)
+	)
+
+	expectedErrors := []struct {
+		message   string
+		satisfier func(error) bool
+	}{
+		{"either SubnetTag or SubnetProviderId is required", nil},
+		{"either SubnetTag or SubnetProviderId is required", nil},
+		{"SubnetTag and SubnetProviderId cannot be both set", nil},
+		{"getting environment config: config not found", params.IsCodeNotFound},
+		{"opening environment: provider not found", params.IsCodeNotFound},
+		{"cannot get provider subnets: subnets not found", params.IsCodeNotFound},
+		{`subnet with CIDR "" and ProviderId "missing" not found`, params.IsCodeNotFound},
+		{`subnet with CIDR "" and ProviderId "void" not found`, params.IsCodeNotFound},
+		{`given SpaceTag is invalid: "invalid" is not a valid tag`, nil},
+		{`given SpaceTag is invalid: "unit-foo" is not a valid unit tag`, nil},
+		{`given SpaceTag is invalid: "unit-foo-0" is not a valid space tag`, nil},
+		{`given SubnetTag is invalid: "invalid" is not a valid tag`, nil},
+		{`given SubnetTag is invalid: "service-bar" is not a valid subnet tag`, nil},
+		{`subnet with CIDR "1.2.3.0/24" not found`, params.IsCodeNotFound},
+		{
+			`multiple subnets with CIDR "10.10.0.0/24": ` +
+				`retry using ProviderId from: "sn-deadbeef", "sn-zadf00d"`, nil,
+		},
+		{"SpaceTag is required", nil},
+		{`subnet with CIDR "invalid" and ProviderId "sn-invalid": invalid CIDR`, nil},
+		{`subnet with ProviderId "sn-empty": empty CIDR`, nil},
+		{
+			`subnet with ProviderId "sn-awesome": ` +
+				`incorrect CIDR format "0.1.2.3/4", expected "0.0.0.0/4"`, nil,
+		},
+		{"cannot validate given SpaceTag: spaces not found", params.IsCodeNotFound},
+		{`given SpaceTag "space-missing" not found`, params.IsCodeNotFound},
+		{"Zones cannot be discovered from the provider and must be set", nil},
+		{`Zones contain zones not allowed by the provider: "missing", "zone1", "zone2"`, nil},
+		{"given Zones cannot be validated: zones not found", params.IsCodeNotFound},
+		{`Zones contain unknown zones: "gone", "missing"`, nil},
+		{`Zones contain unknown zones: "missing"`, nil},
+		{`Zones contain unavailable zones: "zone2", "zone4"`, nil},
+		{`Zones contain unavailable zones: "zone4"`, nil},
+		{"cannot add subnet: state not found", params.IsCodeNotFound},
+		{`Zones contain unavailable zones: "zone2"`, nil},
+		{"", nil},
+		{"", nil},
+		{"", nil},
+	}
+	expectedBackingInfos := []subnets.BackingSubnetInfo{{
+		ProviderId:        "sn-ipv6",
+		CIDR:              "2001:db8::/32",
+		VLANTag:           0,
+		AllocatableIPHigh: "",
+		AllocatableIPLow:  "",
+		AvailabilityZones: []string{"zone1"},
+		SpaceName:         "dmz",
+	}, {
+		ProviderId:        "vlan-42",
+		CIDR:              "10.30.1.0/24",
+		VLANTag:           42,
+		AllocatableIPHigh: "",
+		AllocatableIPLow:  "",
+		AvailabilityZones: []string{"zone3"},
+		SpaceName:         "private",
+	}, {
+		ProviderId:        "sn-zadf00d",
+		CIDR:              "10.10.0.0/24",
+		VLANTag:           0,
+		AllocatableIPHigh: "10.10.0.100",
+		AllocatableIPLow:  "10.10.0.10",
+		AvailabilityZones: []string{"zone1"},
+		SpaceName:         "private",
+	}}
+	c.Check(expectedErrors, gc.HasLen, len(args.Subnets))
+	results, err := s.facade.AddSubnets(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(results.Results), gc.Equals, len(args.Subnets))
+	for i, result := range results.Results {
+		c.Logf("result #%d: expected: %q", i, expectedErrors[i].message)
+		if expectedErrors[i].message == "" {
+			if !c.Check(result.Error, gc.IsNil) {
+				c.Logf("unexpected error: %v; args: %#v", result.Error, args.Subnets[i])
+			}
+			continue
+		}
+		if !c.Check(result.Error, gc.NotNil) {
+			c.Logf("unexpected success; args: %#v", args.Subnets[i])
+			continue
+		}
+		c.Check(result.Error.Message, gc.Equals, expectedErrors[i].message)
+		if expectedErrors[i].satisfier != nil {
+			c.Check(result.Error, jc.Satisfies, expectedErrors[i].satisfier)
+		} else {
+			c.Check(result.Error.Code, gc.Equals, "")
+		}
+	}
+
+	CheckMethodCalls(c, SharedStub,
+		// caching subnets (1st attempt): fails
+		BackingCall("EnvironConfig"),
+
+		// caching subnets (2nd attepmt): fails
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+
+		// caching subnets (3rd attempt): fails
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+		NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
+
+		// caching subnets (4th attempt): succeeds
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+		NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
+
+		// caching spaces (1st and 2nd attempts)
+		BackingCall("AllSpaces"),
+		BackingCall("AllSpaces"),
+
+		// cacing zones (1st and 2nd attempts)
+		BackingCall("AvailabilityZones"),
+		BackingCall("AvailabilityZones"),
+
+		// validation done; adding subnets to backing store
+		BackingCall("AddSubnet", expectedBackingInfos[0]),
+		BackingCall("AddSubnet", expectedBackingInfos[0]),
+		BackingCall("AddSubnet", expectedBackingInfos[1]),
+		BackingCall("AddSubnet", expectedBackingInfos[2]),
+	)
+	ResetStub(SharedStub)
+
+	// Finally, check that no params yields no results.
+	results, err = s.facade.AddSubnets(params.AddSubnetsParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.NotNil)
+	c.Assert(results.Results, gc.HasLen, 0)
+
+	CheckMethodCalls(c, SharedStub)
+}
+
+func (s *SubnetsSuite) CheckAddSubnetsFails(
+	c *gc.C, envName string,
+	withZones, withSpaces, withSubnets SetUpFlag,
+	expectedError string,
+) {
+
+	BackingInstance.SetUp(c, envName, withZones, withSpaces, withSubnets)
+
+	// These calls always happen.
+	expectedCalls := []StubMethodCall{
+		BackingCall("EnvironConfig"),
+		ProviderCall("Open", BackingInstance.EnvConfig),
+	}
+
+	// Subnets is also always called. but the receiver is different.
+	switch envName {
+	case StubNetworkingEnvironName:
+		expectedCalls = append(
+			expectedCalls,
+			NetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
+		)
+	case StubZonedNetworkingEnvironName:
+		expectedCalls = append(
+			expectedCalls,
+			ZonedNetworkingEnvironCall("Subnets", instance.UnknownId, []network.Id(nil)),
+		)
+	}
+
+	if !withSubnets {
+		// Set provider subnets to empty for this test.
+		originalSubnets := make([]network.SubnetInfo, len(ProviderInstance.Subnets))
+		copy(originalSubnets, ProviderInstance.Subnets)
+		ProviderInstance.Subnets = []network.SubnetInfo{}
+
+		defer func() {
+			ProviderInstance.Subnets = make([]network.SubnetInfo, len(originalSubnets))
+			copy(ProviderInstance.Subnets, originalSubnets)
+		}()
+
+		if envName == StubEnvironName || envName == StubNetworkingEnvironName {
+			// networking is either not supported or no subnets are
+			// defined, so expected the same calls for each of the two
+			// arguments to AddSubnets() below.
+			expectedCalls = append(expectedCalls, expectedCalls...)
+		}
+	} else {
+		// Having subnets implies spaces will be cached as well.
+		expectedCalls = append(expectedCalls, BackingCall("AllSpaces"))
+	}
+
+	if withSpaces && withSubnets {
+		// Having both subnets and spaces means we'll also cache zones.
+		expectedCalls = append(expectedCalls, BackingCall("AvailabilityZones"))
+	}
+
+	if !withZones && withSpaces {
+		// Set provider zones to empty for this test.
+		originalZones := make([]providercommon.AvailabilityZone, len(ProviderInstance.Zones))
+		copy(originalZones, ProviderInstance.Zones)
+		ProviderInstance.Zones = []providercommon.AvailabilityZone{}
+
+		defer func() {
+			ProviderInstance.Zones = make([]providercommon.AvailabilityZone, len(originalZones))
+			copy(ProviderInstance.Zones, originalZones)
+		}()
+
+		// updateZones tries to constructs a ZonedEnviron with these calls.
+		zoneCalls := append([]StubMethodCall{},
+			BackingCall("EnvironConfig"),
+			ProviderCall("Open", BackingInstance.EnvConfig),
+		)
+		// Receiver can differ according to envName, but
+		// AvailabilityZones() will be called on either receiver.
+		switch envName {
+		case StubZonedEnvironName:
+			zoneCalls = append(
+				zoneCalls,
+				ZonedEnvironCall("AvailabilityZones"),
+			)
+		case StubZonedNetworkingEnvironName:
+			zoneCalls = append(
+				zoneCalls,
+				ZonedNetworkingEnvironCall("AvailabilityZones"),
+			)
+		}
+		// Finally after caching provider zones backing zones are
+		// updated.
+		zoneCalls = append(
+			zoneCalls,
+			BackingCall("SetAvailabilityZones", ProviderInstance.Zones),
+		)
+
+		// Now, because we have 2 arguments to AddSubnets() below, we
+		// need to expect the same zoneCalls twice, with a
+		// AvailabilityZones backing lookup between them.
+		expectedCalls = append(expectedCalls, zoneCalls...)
+		expectedCalls = append(expectedCalls, BackingCall("AvailabilityZones"))
+		expectedCalls = append(expectedCalls, zoneCalls...)
+	}
+
+	// Pass 2 arguments covering all cases we need.
+	args := params.AddSubnetsParams{Subnets: []params.AddSubnetParams{{
+		SubnetTag: "subnet-10.42.0.0/16",
+		SpaceTag:  "space-dmz",
+		Zones:     []string{"zone1"},
+	}, {
+		SubnetProviderId: "vlan-42",
+		SpaceTag:         "space-private",
+		Zones:            []string{"zone3"},
+	}}}
+	results, err := s.facade.AddSubnets(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, len(args.Subnets))
+	for _, result := range results.Results {
+		if !c.Check(result.Error, gc.NotNil) {
+			continue
+		}
+		c.Check(result.Error, gc.ErrorMatches, expectedError)
+		c.Check(result.Error.Code, gc.Equals, "")
+	}
+
+	CheckMethodCalls(c, SharedStub, expectedCalls...)
+}
+
+func (s *SubnetsSuite) TestAddSubnetsWithNoProviderSubnetsFails(c *gc.C) {
+	s.CheckAddSubnetsFails(
+		c, StubNetworkingEnvironName,
+		WithoutZones, WithoutSpaces, WithoutSubnets,
+		"no subnets defined",
+	)
+}
+
+func (s *SubnetsSuite) TestAddSubnetsWithNoBackingSpacesFails(c *gc.C) {
+	s.CheckAddSubnetsFails(
+		c, StubNetworkingEnvironName,
+		WithoutZones, WithoutSpaces, WithSubnets,
+		"no spaces defined",
+	)
+}
+
+func (s *SubnetsSuite) TestAddSubnetsWithNoProviderZonesFails(c *gc.C) {
+	s.CheckAddSubnetsFails(
+		c, StubZonedNetworkingEnvironName,
+		WithoutZones, WithSpaces, WithSubnets,
+		"no zones defined",
+	)
+}
+
+func (s *SubnetsSuite) TestAddSubnetsWhenNetworkingEnvironNotSupported(c *gc.C) {
+	s.CheckAddSubnetsFails(
+		c, StubEnvironName,
+		WithoutZones, WithoutSpaces, WithoutSubnets,
+		"environment networking features not supported",
 	)
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/jujusvg	git	28683402583926ce903491c14a07cdc5cb371adb	2015-04-10T08:55:05Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
-github.com/juju/names	git	4c70644adb1d8beef5d94bda6a60acd845bcbb8f	2015-06-19T11:06:44Z
+github.com/juju/names	git	b6ee6a4d3b21c6498857cafd159f86886272fa36	2015-06-29T10:34:18Z
 github.com/juju/persistent-cookiejar	git	beee02cb39231c7ad4a01a677fc54c48d2b46b08	2015-04-09T09:48:35Z
 github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-30T01:41:32Z
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z

--- a/network/network.go
+++ b/network/network.go
@@ -56,6 +56,15 @@ type SubnetInfo struct {
 	// allocatable.
 	AllocatableIPLow  net.IP
 	AllocatableIPHigh net.IP
+
+	// AvailabilityZones describes with availability zone(s) this
+	// subnet is in. It can be empty if the provider does not support
+	// availability zones.
+	AvailabilityZones []string
+
+	// SpaceName holds the juju network space associated with this
+	// subnet. Can be empty if not supported.
+	SpaceName string
 }
 
 type SpaceInfo struct {


### PR DESCRIPTION
Only the API server side of the method is implemented and tested, but
all relevant cases are covered, including when the provider returns
incorrect data (e.g. empty subnet ProviderId and/or CIDR, as well as
incorrect or invalid CIDRs).

Next step is to implement client-side Subnets API for AllSubnets and
AddSubnets.

(Review request: http://reviews.vapour.ws/r/2088/)