### PR TITLE
apiserver/environmentmanager: call PrepareForCreateEnvironment server side

### DIFF
--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -196,6 +196,10 @@ func (em *EnvironmentManagerAPI) validConfig(attrs map[string]interface{}) (*con
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	cfg, err = provider.PrepareForCreateEnvironment(cfg)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	cfg, err = provider.Validate(cfg, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "provider validation failed")

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -140,7 +140,7 @@ func (s *envManagerSuite) TestRestrictedProviderFields(c *gc.C) {
 			provider: "local",
 			expected: []string{
 				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert", "rsyslog-ca-key",
-				"container", "network-bridge", "root-dir"},
+				"container", "network-bridge", "root-dir", "proxy-ssh"},
 		}, {
 			provider: "maas",
 			expected: []string{
@@ -342,6 +342,10 @@ type fakeProvider struct {
 }
 
 func (*fakeProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
+	return cfg, nil
+}
+
+func (*fakeProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 

--- a/cmd/juju/environment/create_test.go
+++ b/cmd/juju/environment/create_test.go
@@ -5,6 +5,8 @@ package environment_test
 
 import (
 	"io/ioutil"
+	"os"
+	"os/user"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -185,6 +187,103 @@ func (s *createSuite) TestConfigValuePrecedence(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.fake.config["account"], gc.Equals, "magic")
 	c.Assert(s.fake.config["cloud"], gc.Equals, "special")
+}
+
+var setConfigSpecialCaseDefaultsTests = []struct {
+	about        string
+	userEnvVar   string
+	userCurrent  func() (*user.User, error)
+	config       map[string]interface{}
+	expectConfig map[string]interface{}
+	expectError  string
+}{{
+	about:      "use env var if available",
+	userEnvVar: "bob",
+	config: map[string]interface{}{
+		"name": "envname",
+		"type": "local",
+	},
+	expectConfig: map[string]interface{}{
+		"name":      "envname",
+		"type":      "local",
+		"namespace": "bob-envname",
+	},
+}, {
+	about: "fall back to user.Current",
+	userCurrent: func() (*user.User, error) {
+		return &user.User{Username: "bob"}, nil
+	},
+	config: map[string]interface{}{
+		"name": "envname",
+		"type": "local",
+	},
+	expectConfig: map[string]interface{}{
+		"name":      "envname",
+		"type":      "local",
+		"namespace": "bob-envname",
+	},
+}, {
+	about:      "other provider types unaffected",
+	userEnvVar: "bob",
+	config: map[string]interface{}{
+		"name": "envname",
+		"type": "dummy",
+	},
+	expectConfig: map[string]interface{}{
+		"name": "envname",
+		"type": "dummy",
+	},
+}, {
+	about: "explicit namespace takes precedence",
+	userCurrent: func() (*user.User, error) {
+		return &user.User{Username: "bob"}, nil
+	},
+	config: map[string]interface{}{
+		"name":      "envname",
+		"namespace": "something",
+		"type":      "local",
+	},
+	expectConfig: map[string]interface{}{
+		"name":      "envname",
+		"namespace": "something",
+		"type":      "local",
+	},
+}, {
+	about: "user.Current returns error",
+	userCurrent: func() (*user.User, error) {
+		return nil, errors.New("an error")
+	},
+	config: map[string]interface{}{
+		"name": "envname",
+		"type": "local",
+	},
+	expectError: "failed to determine username for namespace: an error",
+}}
+
+func (s *createSuite) TestSetConfigSpecialCaseDefaults(c *gc.C) {
+	noUserCurrent := func() (*user.User, error) {
+		panic("should not be called")
+	}
+	s.PatchValue(environment.UserCurrent, noUserCurrent)
+	// We test setConfigSpecialCaseDefaults independently
+	// because we can't use the local provider in the tests.
+	for i, test := range setConfigSpecialCaseDefaultsTests {
+		c.Logf("test %d: %s", i, test.about)
+		os.Setenv("USER", test.userEnvVar)
+		if test.userCurrent != nil {
+			*environment.UserCurrent = test.userCurrent
+		} else {
+			*environment.UserCurrent = noUserCurrent
+		}
+		err := environment.SetConfigSpecialCaseDefaults(test.config["name"].(string), test.config)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(test.config, jc.DeepEquals, test.expectConfig)
+		}
+	}
+
 }
 
 func (s *createSuite) TestCreateErrorRemoveConfigstoreInfo(c *gc.C) {

--- a/cmd/juju/environment/export_test.go
+++ b/cmd/juju/environment/export_test.go
@@ -3,6 +3,11 @@
 
 package environment
 
+var (
+	SetConfigSpecialCaseDefaults = setConfigSpecialCaseDefaults
+	UserCurrent                  = &userCurrent
+)
+
 // NewGetCommand returns a GetCommand with the api provided as specified.
 func NewGetCommand(api GetEnvironmentAPI) *GetCommand {
 	return &GetCommand{

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -28,6 +28,8 @@ type EnvironProvider interface {
 	// additional configuration attributes are added to the config passed in
 	// and returned.  This allows providers to add additional required config
 	// for new environments that may be created in an existing juju server.
+	// Note that this is not called in a client context, so environment variables,
+	// local files, etc are not available.
 	PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error)
 
 	// PrepareForBootstrap prepares an environment for use. Any additional

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -582,7 +582,7 @@ func (p *environProvider) RestrictedConfigAttributes() []string {
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (p *environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
-	return p.prepare(cfg)
+	return cfg, nil
 }
 
 func (p *environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {

--- a/provider/gce/config.go
+++ b/provider/gce/config.go
@@ -126,11 +126,6 @@ var osEnvFields = map[string]string{
 	google.OSEnvImageEndpoint: cfgImageEndpoint,
 }
 
-func parseOSEnv() (map[string]interface{}, error) {
-	// TODO(ericsnow) Support pulling ID/PK from shell environment variables.
-	return nil, nil
-}
-
 // handleInvalidField converts a google.InvalidConfigValue into a new
 // error, translating a {provider/gce/google}.OSEnvVar* value into a
 // GCE config key in the new error.

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -41,16 +41,6 @@ func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg 
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
-	// Make any necessary updates to the config. This needs to happen
-	// before any defaults are applied.
-	updates, err := parseOSEnv()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	cfg, err = cfg.Apply(updates)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	return cfg, nil
 }
 

--- a/provider/local/config_test.go
+++ b/provider/local/config_test.go
@@ -35,14 +35,7 @@ func minimalConfigValues() map[string]interface{} {
 }
 
 func minimalConfig(c *gc.C) *config.Config {
-	minimal := minimalConfigValues()
-	testConfig, err := config.New(config.NoDefaults, minimal)
-	c.Assert(err, jc.ErrorIsNil)
-	testConfig, err = local.Provider.PrepareForCreateEnvironment(testConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	valid, err := local.Provider.Validate(testConfig, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	return valid
+	return localConfig(c, nil)
 }
 
 func localConfig(c *gc.C, extra map[string]interface{}) *config.Config {
@@ -52,11 +45,9 @@ func localConfig(c *gc.C, extra map[string]interface{}) *config.Config {
 	}
 	testConfig, err := config.New(config.NoDefaults, values)
 	c.Assert(err, jc.ErrorIsNil)
-	testConfig, err = local.Provider.PrepareForCreateEnvironment(testConfig)
+	testEnv, err := local.Provider.PrepareForBootstrap(envtesting.BootstrapContext(c), testConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	valid, err := local.Provider.Validate(testConfig, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	return valid
+	return testEnv.Config()
 }
 
 func (s *configSuite) TestDefaultNetworkBridge(c *gc.C) {

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -94,11 +94,16 @@ func (p environProvider) correctLocalhostURLs(cfg *config.Config, providerCfg *e
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (p environProvider) RestrictedConfigAttributes() []string {
-	return []string{ContainerKey, NetworkBridgeKey, RootDirKey}
+	return []string{ContainerKey, NetworkBridgeKey, RootDirKey, "proxy-ssh"}
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return cfg, nil
+}
+
+// PrepareForBootstrap implements environs.EnvironProvider.PrepareForBootstrap.
+func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
 	attrs := map[string]interface{}{
 		// We must not proxy SSH through the API server in a
 		// local provider environment. Besides not being useful,
@@ -160,16 +165,6 @@ func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*confi
 	}
 	// Make sure everything is valid.
 	cfg, err = p.Validate(cfg, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return cfg, nil
-}
-
-// PrepareForBootstrap implements environs.EnvironProvider.PrepareForBootstrap.
-func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	cfg, err := p.PrepareForCreateEnvironment(cfg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/local/environprovider_test.go
+++ b/provider/local/environprovider_test.go
@@ -396,8 +396,10 @@ var urlReplacementTests = []testURL{{
 	port:         ":8877",
 	expectChange: true,
 }, {
-	message:      "replace ::1 with bridge ip in proxy url",
-	url:          "::1",
+	// Note that http//::1 (without the square brackets)
+	// is not a legal URL. See https://www.ietf.org/rfc/rfc2732.txt.
+	message:      "replace [::1] with bridge ip in proxy url",
+	url:          "[::1]",
 	port:         "",
 	expectChange: true,
 }, {

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -478,10 +479,10 @@ func (factory *Factory) MakeEnvironment(c *gc.C, params *EnvParams) *state.State
 		// Prepare the environment.
 		provider, err := environs.Provider(cfg.Type())
 		c.Assert(err, jc.ErrorIsNil)
-		cfg, err = provider.PrepareForCreateEnvironment(cfg)
+		env, err := provider.PrepareForBootstrap(envtesting.BootstrapContext(c), cfg)
 		c.Assert(err, jc.ErrorIsNil)
 		// Now save the config back.
-		err = st.UpdateEnvironConfig(cfg.AllAttrs(), nil, nil)
+		err = st.UpdateEnvironConfig(env.Config().AllAttrs(), nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	return st


### PR DESCRIPTION
This means that the client doesn't need to call it, which will enable
non-CLI clients to create environments.

We also change one test in the local provider because it cannot pass
under later Go versions because http://::1 is not a valid URL [1]
and later Go versions enforce this.


(Review request: http://reviews.vapour.ws/r/2089/)