### PR TITLE
Fixed subnet add CLI behavior (according the model) and tests

### DIFF
--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -29,10 +29,10 @@ is supported on a wider variety of clouds (where SDN features are not
 available, e.g. MAAS). The subnet will be associated with the given
 existing Juju network space.
 
-Subnets can be referenced by either their CIDR or provider-specific ID.
-If CIDR is used an multiple subnets have the same CIDR, an error will
-be returned, including the list of possible provider IDs uniquely
-identifying each subnet.
+Subnets can be referenced by either their CIDR or ProviderId (if the
+provider supports it). If CIDR is used an multiple subnets have the
+same CIDR, an error will be returned, including the list of possible
+provider IDs uniquely identifying each subnet.
 
 Any availablility zones associated with the added subnet are automatically
 discovered using the cloud API (if supported). If this is not possible,

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -15,8 +15,11 @@ import (
 type AddCommand struct {
 	SubnetCommandBase
 
-	CIDR  string
-	Space names.SpaceTag
+	CIDR       string
+	RawCIDR    string // before normalizing (e.g. 10.10.0.0/8 to 10.0.0.0/8)
+	ProviderId string
+	Space      names.SpaceTag
+	Zones      []string
 }
 
 const addCommandDoc = `
@@ -26,15 +29,22 @@ is supported on a wider variety of clouds (where SDN features are not
 available, e.g. MAAS). The subnet will be associated with the given
 existing Juju network space.
 
+Subnets can be referenced by either their CIDR or provider-specific ID.
+If CIDR is used an multiple subnets have the same CIDR, an error will
+be returned, including the list of possible provider IDs uniquely
+identifying each subnet.
+
 Any availablility zones associated with the added subnet are automatically
-discovered using the cloud API (if supported).
+discovered using the cloud API (if supported). If this is not possible,
+since any subnet needs to be part of at least one zone, specifying
+zone(s) is required.
 `
 
 // Info is defined on the cmd.Command interface.
 func (c *AddCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add",
-		Args:    "<CIDR> <space>",
+		Args:    "<CIDR>|<provider-id> <space> [<zone1> <zone2> ...]",
 		Purpose: "add an existing subnet to Juju",
 		Doc:     strings.TrimSpace(addCommandDoc),
 	}
@@ -43,16 +53,23 @@ func (c *AddCommand) Info() *cmd.Info {
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
 func (c *AddCommand) Init(args []string) error {
-	// Ensure we have exactly 2 arguments.
-	err := c.CheckNumArgs(args, []error{errNoCIDR, errNoSpace})
-	if err != nil {
-		return err
+	// Ensure we have 2 or more arguments.
+	switch len(args) {
+	case 0:
+		return errNoCIDROrID
+	case 1:
+		return errNoSpace
 	}
 
-	// Validate given CIDR.
-	c.CIDR, err = c.ValidateCIDR(args[0])
+	// Try to validate first argument as a CIDR first.
+	var err error
+	c.RawCIDR = args[0]
+	c.CIDR, err = c.ValidateCIDR(args[0], false)
 	if err != nil {
-		return err
+		// If it's not a CIDR it could be a ProviderId, so ignore the
+		// error.
+		c.ProviderId = args[0]
+		c.RawCIDR = ""
 	}
 
 	// Validate the space name.
@@ -61,7 +78,11 @@ func (c *AddCommand) Init(args []string) error {
 		return err
 	}
 
-	return cmd.CheckEmpty(args[2:])
+	// Add any given zones.
+	for _, zone := range args[2:] {
+		c.Zones = append(c.Zones, zone)
+	}
+	return nil
 }
 
 // Run implements Command.Run.
@@ -72,12 +93,28 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 	}
 	defer api.Close()
 
+	if c.CIDR != "" && c.RawCIDR != c.CIDR {
+		ctx.Infof(
+			"WARNING: using CIDR %q instead of the incorrectly specified %q.",
+			c.CIDR, c.RawCIDR,
+		)
+	}
+
 	// Add the existing subnet.
-	err = api.AddSubnet(c.CIDR, c.Space)
-	if err != nil {
+	err = api.AddSubnet(c.CIDR, c.ProviderId, c.Space, c.Zones)
+	// TODO(dimitern): Change this once the API returns a concrete error.
+	if err != nil && strings.Contains(err.Error(), "multiple subnets with") {
+		// Special case: multiple subnets with the same CIDR exist
+		ctx.Infof("ERROR: %v.", err)
+		return nil
+	} else if err != nil {
 		return errors.Annotatef(err, "cannot add subnet %q", c.CIDR)
 	}
 
-	ctx.Infof("added subnet %q in space %q", c.CIDR, c.Space.Id())
+	if c.CIDR == "" {
+		ctx.Infof("added subnet with ProviderId %q in space %q", c.ProviderId, c.Space.Id())
+	} else {
+		ctx.Infof("added subnet with CIDR %q in space %q", c.CIDR, c.Space.Id())
+	}
 	return nil
 }

--- a/cmd/juju/subnet/create.go
+++ b/cmd/juju/subnet/create.go
@@ -87,7 +87,7 @@ func (c *CreateCommand) Init(args []string) error {
 	}
 
 	// Validate given CIDR.
-	c.CIDR, err = c.ValidateCIDR(args[0])
+	c.CIDR, err = c.ValidateCIDR(args[0], true)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -215,8 +215,8 @@ func (sa *StubAPI) CreateSubnet(subnetCIDR string, spaceTag names.SpaceTag, zone
 	return sa.NextErr()
 }
 
-func (sa *StubAPI) AddSubnet(subnetCIDR string, spaceTag names.SpaceTag) error {
-	sa.MethodCall(sa, "AddSubnet", subnetCIDR, spaceTag)
+func (sa *StubAPI) AddSubnet(cidr, id string, spaceTag names.SpaceTag, zones []string) error {
+	sa.MethodCall(sa, "AddSubnet", cidr, id, spaceTag, zones)
 	return sa.NextErr()
 }
 

--- a/cmd/juju/subnet/remove.go
+++ b/cmd/juju/subnet/remove.go
@@ -52,7 +52,7 @@ func (c *RemoveCommand) Init(args []string) error {
 	}
 
 	// Validate given CIDR.
-	c.CIDR, err = c.ValidateCIDR(args[0])
+	c.CIDR, err = c.ValidateCIDR(args[0], true)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -48,14 +48,16 @@ type SubnetAPI interface {
 var logger = loggo.GetLogger("juju.cmd.juju.subnet")
 
 const commandDoc = `
-"juju subnet" provides commands to manage Juju subnets. In Juju, a subnet
-is a logical address range, a subdivision of a network, defined by the
-subnet's Classless Inter-Domain Routing (CIDR) range, like 10.10.0.0/24 or
-2001:db8::/32. Subnets have two kinds of supported access: "public" (using
-shadow addresses) or "private" (using cloud-local addresses, this is the
-default). For more information about subnets and shadow addresses, please
-refer to Juju's glossary help topics ("juju help glossary").
-`
+"juju subnet" provides commands to manage Juju subnets. In Juju, a
+subnet is a logical address range, a subdivision of a network, defined
+by the subnet's Classless Inter-Domain Routing (CIDR) range, like
+10.10.0.0/24 or 2001:db8::/32. Alternatively, subnets can be
+identified uniquely by their provider-specific identifier
+(ProviderId), if the provider supports that. Subnets have two kinds of
+supported access: "public" (using shadow addresses) or "private"
+(using cloud-local addresses, this is the default). For more
+information about subnets and shadow addresses, please refer to Juju's
+glossary help topics ("juju help glossary"). `
 
 // NewSuperCommand creates the "subnet" supercommand and registers the
 // subcommands that it supports.

--- a/cmd/juju/subnet/subnet_test.go
+++ b/cmd/juju/subnet/subnet_test.go
@@ -86,36 +86,68 @@ func (s *SubnetCommandBaseSuite) TestValidateCIDR(c *gc.C) {
 	for i, test := range []struct {
 		about     string
 		input     string
+		strict    bool
+		output    string
 		expectErr string
 	}{{
-		about: "valid IPv4 CIDR",
-		input: "10.0.5.0/24",
+		about:  "valid IPv4 CIDR, struct=false",
+		input:  "10.0.5.0/24",
+		strict: false,
+		output: "10.0.5.0/24",
 	}, {
-		about: "valid IPv6 CIDR",
-		input: "2001:db8::/32",
+		about:  "valid IPv4 CIDR, struct=true",
+		input:  "10.0.5.0/24",
+		strict: true,
+		output: "10.0.5.0/24",
 	}, {
-		about:     "incorrectly specified IPv4 CIDR",
+		about:  "valid IPv6 CIDR, strict=false",
+		input:  "2001:db8::/32",
+		strict: false,
+		output: "2001:db8::/32",
+	}, {
+		about:  "valid IPv6 CIDR, strict=true",
+		input:  "2001:db8::/32",
+		strict: true,
+		output: "2001:db8::/32",
+	}, {
+		about:  "incorrectly specified IPv4 CIDR, strict=false",
+		input:  "192.168.10.20/16",
+		strict: false,
+		output: "192.168.0.0/16",
+	}, {
+		about:     "incorrectly specified IPv4 CIDR, strict=true",
 		input:     "192.168.10.20/16",
+		strict:    true,
 		expectErr: `"192.168.10.20/16" is not correctly specified, expected "192.168.0.0/16"`,
 	}, {
-		about:     "incorrectly specified IPv6 CIDR",
+		about:  "incorrectly specified IPv6 CIDR, strict=false",
+		input:  "2001:db8::2/48",
+		strict: false,
+		output: "2001:db8::/48",
+	}, {
+		about:     "incorrectly specified IPv6 CIDR, strict=true",
 		input:     "2001:db8::2/48",
+		strict:    true,
 		expectErr: `"2001:db8::2/48" is not correctly specified, expected "2001:db8::/48"`,
 	}, {
-		about:     "empty CIDR",
+		about:     "empty CIDR, strict=false",
 		input:     "",
+		strict:    false,
+		expectErr: `"" is not a valid CIDR`,
+	}, {
+		about:     "empty CIDR, strict=true",
+		input:     "",
+		strict:    true,
 		expectErr: `"" is not a valid CIDR`,
 	}} {
 		c.Logf("test #%d: %s -> %s", i, test.about, test.expectErr)
-		validated, err := s.baseCmd.ValidateCIDR(test.input)
+		validated, err := s.baseCmd.ValidateCIDR(test.input, test.strict)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
-			c.Check(validated, gc.Equals, "")
 		} else {
 			c.Check(err, jc.ErrorIsNil)
-			// When the input is valid it should stay the same.
-			c.Check(validated, gc.Equals, test.input)
 		}
+		c.Check(validated, gc.Equals, test.output)
 	}
 }
 


### PR DESCRIPTION
The `juju subnet add` command now accepts both CIDR or ProviderId as a
first argument. After the first two arguments any number of zones can be
given (including 0). Improved UX around error reporting and
usability (e.g. zones are optional unless the API server method reports
otherwise, the possibility of duplicated CIDRs for subnets is handled
nicely).

Tests coverage is still 100%.

(Review request: http://reviews.vapour.ws/r/2090/)