### PR TITLE
Fix incompatibility between state.UnitProcesses and process/api/server.UnitProcesses.

### DIFF
--- a/component/all/process.go
+++ b/component/all/process.go
@@ -61,13 +61,16 @@ func (c workloadProcesses) registerHookContext() {
 
 func (c workloadProcesses) registerHookContextFacade() {
 
-	newHookContextApi := func(st *state.State, _ *state.Unit) (interface{}, error) {
+	newHookContextApi := func(st *state.State, unit *state.Unit) (interface{}, error) {
 		if st == nil {
 			return nil, errors.NewNotValid(nil, "st is nil")
 		}
-		// TODO(natefinch): uncomment when the appropriate state functions exist.
-		//return &server.HookContextAPI{ st }, nil
-		return &server.HookContextAPI{}, nil
+
+		up, err := st.UnitProcesses(unit)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return server.NewHookContextAPI(up), nil
 	}
 
 	common.RegisterHookContextFacade(

--- a/process/api/server-args.go
+++ b/process/api/server-args.go
@@ -14,8 +14,6 @@ var BulkFailure = errors.Errorf("at least one bulk arg has an error")
 
 // RegisterProcessArgs are the arguments for the RegisterProcesses endpoint.
 type RegisterProcessesArgs struct {
-	// UnitTag is the tag of the unit on which the processes reside.
-	UnitTag string
 	// Processes is the list of Processes to register
 	Processes []Process
 }
@@ -39,8 +37,6 @@ type ProcessResult struct {
 
 // ListProcessesesArgs are the arguments for the ListProcesses endpoint.
 type ListProcessesArgs struct {
-	// UnitTag is the tag of the unit on which the process resides.
-	UnitTag string
 	// IDs is the list of IDs of the processes you want information on.
 	IDs []string
 }
@@ -65,8 +61,6 @@ type ListProcessResult struct {
 
 // SetProcessesStatusArgs are the arguments for the SetProcessesStatus endpoint.
 type SetProcessesStatusArgs struct {
-	// UnitTag is the tag of the unit on which the process resides.
-	UnitTag string
 	// Args is the list of arguments to pass to this function.
 	Args []SetProcessStatusArg
 }
@@ -82,8 +76,6 @@ type SetProcessStatusArg struct {
 
 // UnregisterProcessesArgs are the arguments for the UnregisterProcesses endpoint.
 type UnregisterProcessesArgs struct {
-	// UnitTag is the tag of the unit on which the process resides.
-	UnitTag string
 	// IDs is a list of IDs of processes.
 	IDs []string
 }

--- a/process/api/server/hookcontext_test.go
+++ b/process/api/server/hookcontext_test.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
@@ -22,7 +21,6 @@ func (suite) TestRegisterProcess(c *gc.C) {
 	a := HookContextAPI{st}
 
 	args := api.RegisterProcessesArgs{
-		UnitTag: "foo/0",
 		Processes: []api.Process{{
 			Definition: api.ProcessDefinition{
 				Name:        "foobar",
@@ -55,7 +53,6 @@ func (suite) TestRegisterProcess(c *gc.C) {
 
 	res, err := a.RegisterProcesses(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(st.unit, gc.Equals, names.NewUnitTag("foo/0"))
 
 	expectedResults := api.ProcessResults{
 		Results: []api.ProcessResult{{
@@ -138,8 +135,7 @@ func (suite) TestListProcessesOne(c *gc.C) {
 	st := &FakeState{procs: []process.Info{proc}}
 	a := HookContextAPI{st}
 	args := api.ListProcessesArgs{
-		UnitTag: "foo/0",
-		IDs:     []string{"foobar/idfoo"},
+		IDs: []string{"foobar/idfoo"},
 	}
 	results, err := a.ListProcesses(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -223,9 +219,7 @@ func (suite) TestListProcessesAll(c *gc.C) {
 	}
 	st := &FakeState{procs: []process.Info{proc}}
 	a := HookContextAPI{st}
-	args := api.ListProcessesArgs{
-		UnitTag: "foo/0",
-	}
+	args := api.ListProcessesArgs{}
 	results, err := a.ListProcesses(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -277,7 +271,6 @@ func (suite) TestSetProcessStatus(c *gc.C) {
 	st := &FakeState{}
 	a := HookContextAPI{st}
 	args := api.SetProcessesStatusArgs{
-		UnitTag: "foo/0",
 		Args: []api.SetProcessStatusArg{{
 			ID: "fooID",
 			Status: api.ProcessStatus{
@@ -289,7 +282,6 @@ func (suite) TestSetProcessStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(st.id, gc.Equals, "fooID")
-	c.Assert(st.unit, gc.Equals, names.NewUnitTag("foo/0"))
 	c.Assert(st.status, jc.DeepEquals, &process.Status{
 		Label: "statusfoo",
 	})
@@ -307,14 +299,12 @@ func (suite) TestUnregisterProcesses(c *gc.C) {
 	st := &FakeState{}
 	a := HookContextAPI{st}
 	args := api.UnregisterProcessesArgs{
-		UnitTag: "foo/0",
-		IDs:     []string{"fooID"},
+		IDs: []string{"fooID"},
 	}
 	res, err := a.UnregisterProcesses(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(st.id, gc.Equals, "fooID")
-	c.Assert(st.unit, gc.Equals, names.NewUnitTag("foo/0"))
 
 	expected := api.ProcessResults{
 		Results: []api.ProcessResult{{
@@ -327,7 +317,6 @@ func (suite) TestUnregisterProcesses(c *gc.C) {
 
 type FakeState struct {
 	// inputs
-	unit   names.UnitTag
 	id     string
 	ids    []string
 	status *process.Status
@@ -338,11 +327,6 @@ type FakeState struct {
 	//outputs
 	procs []process.Info
 	err   error
-}
-
-func (f *FakeState) UnitProcesses(unit names.UnitTag) (UnitProcesses, error) {
-	f.unit = unit
-	return f, nil
 }
 
 func (f *FakeState) Register(info process.Info) error {

--- a/state/processes.go
+++ b/state/processes.go
@@ -63,21 +63,21 @@ type unitProcesses struct {
 
 // UnitProcesses exposes interaction with workload processes in state
 // for a the given unit.
-func (st *State) UnitProcesses(unit names.UnitTag) (UnitProcesses, error) {
+func (st *State) UnitProcesses(unit *Unit) (UnitProcesses, error) {
 	if newUnitProcesses == nil {
 		return nil, errors.Errorf("unit processes not supported")
 	}
 
-	// TODO(ericsnow) State.unitCharm is sometimes wrong...
-	// TODO(ericsnow) Do we really need the charm tag?
-	charm, err := st.unitCharm(unit)
+	// TODO(ericsnow) unit.charm is sometimes wrong...
+	charm, err := unit.charm()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// TODO(ericsnow) Do we really need the charm tag?
 	charmTag := charm.Tag().(names.CharmTag)
 
 	persist := st.newPersistence()
-	unitProcs, err := newUnitProcesses(persist, unit, charmTag)
+	unitProcs, err := newUnitProcesses(persist, unit.UnitTag(), charmTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/processes.go
+++ b/state/processes.go
@@ -83,7 +83,6 @@ func (st *State) UnitProcesses(unit *Unit) (UnitProcesses, error) {
 	}
 
 	return &unitProcesses{
-		// TODO(ericsnow) Eliminate the dependency on process/state?
 		UnitProcesses: unitProcs,
 		charm:         charm,
 		st:            st,

--- a/state/processes_test.go
+++ b/state/processes_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/component/all"
 	"github.com/juju/juju/process"
+	"github.com/juju/juju/state"
 )
 
 func init() {
@@ -38,7 +39,7 @@ processes:
       IMPORTANT: YES
 `
 
-func (s *unitProcessesSuite) addUnit(c *gc.C, charmName, serviceName, meta string) (names.CharmTag, names.UnitTag) {
+func (s *unitProcessesSuite) addUnit(c *gc.C, charmName, serviceName, meta string) (names.CharmTag, *state.Unit) {
 	ch := s.AddTestingCharm(c, charmName)
 	ch = s.AddMetaCharm(c, charmName, meta, 2)
 
@@ -47,14 +48,13 @@ func (s *unitProcessesSuite) addUnit(c *gc.C, charmName, serviceName, meta strin
 	c.Assert(err, jc.ErrorIsNil)
 
 	charmTag := ch.Tag().(names.CharmTag)
-	unitTag := unit.UnitTag()
-	return charmTag, unitTag
+	return charmTag, unit
 }
 
 func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
-	_, unitTag := s.addUnit(c, "dummy", "a-service", metaYAML)
+	_, unit := s.addUnit(c, "dummy", "a-service", metaYAML)
 
-	st, err := s.State.UnitProcesses(unitTag)
+	st, err := s.State.UnitProcesses(unit)
 	c.Assert(err, jc.ErrorIsNil)
 
 	procs, err := st.List()

--- a/state/unit.go
+++ b/state/unit.go
@@ -1060,18 +1060,6 @@ func (u *Unit) charm() (*Charm, error) {
 	return ch, nil
 }
 
-func (st *State) unitCharm(unitTag names.UnitTag) (*Charm, error) {
-	u, err := st.Unit(unitTag.Id())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ch, err := u.charm()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return ch, nil
-}
-
 // AgentPresence returns whether the respective remote agent is alive.
 func (u *Unit) AgentPresence() (bool, error) {
 	return u.st.pwatcher.Alive(u.globalAgentKey())


### PR DESCRIPTION
process/api/server.HookContextAPI expected a "State" type with a UnitProcesses method that returns a process/api/server.UnitProcesses.  However, the state.State.UnitProcesses method returns a state.UnitProcesses.  Even though the two interfaces are identical, Go does not treat them a equivalent.

To address this we cut out the middle man (the process/api/server.State interface).  We change the field on HookContextAPI from the State interface to UnitProcesses.  We can do this because RegisterHookContextAPI now gives us the context's unit, which means we don't need to have the unit's tag on the API args (and then build a new UnitProcesses for each API call).  Switching the HookContextAPI field eliminates the incompatibility issue.  As a pleasant side effect, it also allows us to clean up the code a bit.

(Review request: http://reviews.vapour.ws/r/2092/)