### PR TITLE
State: Introduce an Environment Count

### DIFF
--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -311,3 +311,25 @@ func (s *EnvironSuite) TestDestroyEnvironmentWithPersistentVolumesFails(c *gc.C)
 	// TODO(wallyworld) when we can destroy/remove volume, ensure env can then be destroyed
 	c.Assert(errors.Cause(env.Destroy()), gc.Equals, state.ErrPersistentVolumesExist)
 }
+
+func (s *EnvironSuite) TestEnvironCount(c *gc.C) {
+	c.Assert(state.EnvironCount(c, s.State), gc.Equals, 0)
+
+	st1 := s.factory.MakeEnvironment(c, nil)
+	defer st1.Close()
+	c.Assert(state.EnvironCount(c, s.State), gc.Equals, 1)
+
+	st2 := s.factory.MakeEnvironment(c, nil)
+	defer st2.Close()
+	c.Assert(state.EnvironCount(c, s.State), gc.Equals, 2)
+
+	env1, err := st1.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env1.Destroy(), jc.ErrorIsNil)
+	c.Assert(state.EnvironCount(c, s.State), gc.Equals, 1)
+
+	env2, err := st2.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env2.Destroy(), jc.ErrorIsNil)
+	c.Assert(state.EnvironCount(c, s.State), gc.Equals, 0)
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -329,6 +329,16 @@ func RemoveEnvironment(st *State, uuid string) error {
 	return st.runTransaction(ops)
 }
 
+func EnvironCount(c *gc.C, st *State) int {
+	var doc envCountDoc
+	stateServers, closer := st.getCollection(stateServersC)
+	defer closer()
+
+	err := stateServers.Find(bson.D{{"_id", hostedEnvCountKey}}).One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	return doc.Count
+}
+
 type MockGlobalEntity struct {
 }
 

--- a/state/open.go
+++ b/state/open.go
@@ -120,6 +120,12 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 			Assert: txn.DocMissing,
 			Insert: &StateServingInfo{},
 		},
+		txn.Op{
+			C:      stateServersC,
+			Id:     hostedEnvCountKey,
+			Assert: txn.DocMissing,
+			Insert: &envCountDoc{},
+		},
 	)
 
 	if err := st.runTransactionNoEnvAliveAssert(ops); err != nil {
@@ -145,6 +151,7 @@ func (st *State) envSetupOps(cfg *config.Config, envUUID, serverUUID string, own
 		createEnvironmentOp(st, owner, cfg.Name(), envUUID, serverUUID),
 		createUniqueOwnerEnvNameOp(owner, cfg.Name()),
 		envUserOp,
+		incEnvironCountOp(),
 	}
 	return ops, nil
 }


### PR DESCRIPTION
Introduce an environment count that is incremented / decremented
each time an environment is respectively created / destroyed. The
system environment is not counted.

This is a prerequisite to refactoring environment Destroy. A future
branch will use the count to ensure the system environment cannot be
deleted if the environment count is > 0.

(Review request: http://reviews.vapour.ws/r/2093/)