### PR TITLE
apiserver: fix data race in certChangeListener

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -117,6 +117,8 @@ func newChangeCertListener(tlsListener net.Listener, certChanged <-chan params.S
 
 // Accept waits for and returns the next connection to the listener.
 func (cl *changeCertListener) Accept() (c net.Conn, err error) {
+	cl.m.Lock()
+	defer cl.m.Unlock()
 	if c, err = cl.Listener.Accept(); err != nil {
 		return c, err
 	}


### PR DESCRIPTION
Fixes LP 1467753

This PR takes the cl.m lock during certChangeListener.Accept().
This ensures that the cert change listener cannot change the TLS config
concurrently with accepting a new connection.

This does have the downside that because Accept is a blocking call, the lock
will be held until an incoming connection is recieved. This means the cert change
requires at least one incoming connection to be _accepted_ (not completed) before
taking effect.

In practice this does not appear to be an issue.

(Review request: http://reviews.vapour.ws/r/2094/)