### PR TITLE
apiserver: fix the data race for tls.Config

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -83,28 +83,12 @@ type changeCertListener struct {
 	certChanged <-chan params.StateServingInfo
 
 	// The config to update with any new certificate.
-	config *tls.Config
+	config tls.Config
 }
 
-// changeCertConn wraps a TLS net.Conn.
-// It allows connection handshakes to be
-// blocked while the TLS certificate is updated.
-type changeCertConn struct {
-	net.Conn
-	m *sync.Mutex
-}
-
-// Handshake runs the client or server handshake
-// protocol if it has not yet been run.
-func (c *changeCertConn) Handshake() error {
-	c.m.Lock()
-	defer c.m.Unlock()
-	return c.Conn.(*tls.Conn).Handshake()
-}
-
-func newChangeCertListener(tlsListener net.Listener, certChanged <-chan params.StateServingInfo, config *tls.Config) *changeCertListener {
+func newChangeCertListener(lis net.Listener, certChanged <-chan params.StateServingInfo, config tls.Config) *changeCertListener {
 	cl := &changeCertListener{
-		Listener:    tlsListener,
+		Listener:    lis,
 		certChanged: certChanged,
 		config:      config,
 	}
@@ -116,14 +100,15 @@ func newChangeCertListener(tlsListener net.Listener, certChanged <-chan params.S
 }
 
 // Accept waits for and returns the next connection to the listener.
-func (cl *changeCertListener) Accept() (c net.Conn, err error) {
-	if c, err = cl.Listener.Accept(); err != nil {
-		return c, err
+func (cl *changeCertListener) Accept() (net.Conn, error) {
+	conn, err := cl.Listener.Accept()
+	if err != nil {
+		return nil, err
 	}
-	// Create a wrapped connection so we can
-	// control the handshakes.
-	conn := changeCertConn{c, &cl.m}
-	return conn, err
+	cl.m.Lock()
+	defer cl.m.Unlock()
+	config := cl.config
+	return tls.Server(conn, &config), nil
 }
 
 // Close closes the listener.
@@ -135,8 +120,6 @@ func (cl *changeCertListener) Close() error {
 // processCertChanges receives new certificate information and
 // calls a method to update the listener's certificate.
 func (cl *changeCertListener) processCertChanges() error {
-	cl.m.Lock()
-	defer cl.m.Unlock()
 	for {
 		select {
 		case info := <-cl.certChanged:
@@ -206,8 +189,7 @@ func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (*Server,
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 	}
-	tlsListener := tls.NewListener(lis, &tlsConfig)
-	changeCertListener := newChangeCertListener(tlsListener, cfg.CertChanged, &tlsConfig)
+	changeCertListener := newChangeCertListener(lis, cfg.CertChanged, tlsConfig)
 	go srv.run(changeCertListener)
 	return srv, nil
 }


### PR DESCRIPTION
Each connection gets a private copy of the tls.Config so that only future connections are affected by certificate updates. This avoids the race and is just generally safer.
    
Also simplify the changeCertListener somewhat.
    
This also fixes a serious bug recently introduced in c147767d. The addition of the Lock call at the top of processCertChanges caused the cert update to hang when updateCertificate tries to grab the lock again.

(Review request: http://reviews.vapour.ws/r/2095/)