### PR TITLE
State: Upgrade step, add and set hosted env count

### DIFF
--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/errors"
@@ -3159,4 +3160,60 @@ func (s *upgradesSuite) TestMoveServiceUnitSeqToSequenceWithPreExistingSequence(
 	count, err := s.state.sequence("service-my-service")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(count, gc.Equals, 7)
+}
+
+func (s *upgradesSuite) TestSetHostedEnvironCount(c *gc.C) {
+	s.removeEnvCountDoc(c)
+
+	s.makeEnvironment(c)
+	s.makeEnvironment(c)
+	s.makeEnvironment(c)
+	SetHostedEnvironCount(s.state)
+
+	//While there are 4 environments, the system environment should not be
+	//counted.
+	c.Assert(EnvironCount(c, s.state), gc.Equals, 3)
+}
+
+func (s *upgradesSuite) TestSetHostedEnvironCountIdempotent(c *gc.C) {
+	s.removeEnvCountDoc(c)
+
+	s.makeEnvironment(c)
+	s.makeEnvironment(c)
+	s.makeEnvironment(c)
+	SetHostedEnvironCount(s.state)
+	SetHostedEnvironCount(s.state)
+
+	c.Assert(EnvironCount(c, s.state), gc.Equals, 3)
+}
+
+var index uint32
+
+// We can't use factory.MakeEnvironment due to an import cycle.
+func (s *upgradesSuite) makeEnvironment(c *gc.C) {
+	st := s.state
+
+	env, err := st.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	ops := []txn.Op{createEnvironmentOp(
+		s.state, env.Owner(),
+		fmt.Sprintf("envname-%d", int(atomic.AddUint32(&index, 1))),
+		uuid.String(),
+		env.UUID())}
+
+	err = st.runTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradesSuite) removeEnvCountDoc(c *gc.C) {
+	err := s.state.runTransaction([]txn.Op{{
+		C:      stateServersC,
+		Id:     hostedEnvCountKey,
+		Assert: txn.DocExists,
+		Remove: true,
+	}})
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -35,6 +35,10 @@ var stateUpgradeOperations = func() []Operation {
 			version.MustParse("1.24.0"),
 			stateStepsFor124(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.25.0"),
+			stateStepsFor125(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -1,0 +1,20 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"github.com/juju/juju/state"
+)
+
+// stateStepsFor125 returns upgrade steps for Juju 1.25 that manipulate state directly.
+func stateStepsFor125() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "set hosted environment count to number of hosted environments",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.SetHostedEnvironCount(context.State())
+			}},
+	}
+}

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
+)
+
+type steps125Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps125Suite{})
+
+func (s *steps125Suite) TestStateStepsFor125(c *gc.C) {
+	expected := []string{
+		"set hosted environment count to number of hosted environments",
+	}
+	assertStateSteps(c, version.MustParse("1.25.0"), expected)
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -666,7 +666,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0", "1.25.0"})
 }
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {


### PR DESCRIPTION
Add an upgrade step to add the environ count doc to State and set
Count to the number of existing hosted environments. Add a new 1.25
state operation and register upgrades.

(Review request: http://reviews.vapour.ws/r/2101/)