### PR TITLE
Enforce use of timeouts for MongoDB connections

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -142,7 +142,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(err, jc.ErrorIsNil)
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	st, m, err := agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, m, err := agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -211,7 +211,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(agent.Password(newCfg), gc.Not(gc.Equals), testing.DefaultMongoPassword)
 	info, ok := cfg.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st1, err := state.Open(info, mongo.DialOpts{}, environs.NewStatePolicy())
+	st1, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 }
@@ -233,7 +233,7 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	c.Assert(available, jc.IsFalse)
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	_, _, err = agent.InitializeState(adminUser, cfg, nil, agent.BootstrapMachineConfig{}, mongo.DialOpts{}, environs.NewStatePolicy())
+	_, _, err = agent.InitializeState(adminUser, cfg, nil, agent.BootstrapMachineConfig{}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
 }
@@ -277,11 +277,11 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	st, _, err := agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, _, err := agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 
-	st, _, err = agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, _, err = agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	if err == nil {
 		st.Close()
 	}
@@ -328,7 +328,7 @@ func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, password string) {
 		Tag:      nil, // admin user
 		Password: password,
 	}
-	st, err := state.Open(info, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	_, err = st.Machine("0")

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -172,7 +172,7 @@ func (s *machineSuite) TestClearReboot(c *gc.C) {
 }
 
 func tryOpenState(info *mongo.MongoInfo) error {
-	st, err := state.Open(info, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	if err == nil {
 		st.Close()
 	}

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -644,7 +644,7 @@ func (s *provisionerSuite) TestContainerManagerConfigKVM(c *gc.C) {
 
 func (s *provisionerSuite) TestContainerManagerConfigLXC(c *gc.C) {
 	args := params.ContainerManagerConfigParams{Type: instance.LXC}
-	st, err := state.Open(s.MongoInfo(c), mongo.DialOpts{}, state.Policy(nil))
+	st, err := state.Open(s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1430,7 +1430,9 @@ func (a *MachineAgent) ensureMongoSharedSecret(agentConfig agent.Config) error {
 	// Note: we set Direct=true in the mongo options because it's
 	// possible that we've previously upgraded the mongo server's
 	// configuration to form a replicaset, but failed to initiate it.
-	st, _, err := openState(agentConfig, mongo.DialOpts{Direct: true})
+	dialOpts := mongo.DefaultDialOpts()
+	dialOpts.Direct = true
+	st, _, err := openState(agentConfig, dialOpts)
 	if err != nil {
 		return err
 	}
@@ -1475,7 +1477,9 @@ func isReplicasetInitNeeded(mongoInfo *mongo.MongoInfo) (bool, error) {
 // network addresses.
 func getMachineAddresses(agentConfig agent.Config) ([]network.Address, error) {
 	logger.Debugf("opening state to get machine addresses")
-	st, m, err := openState(agentConfig, mongo.DialOpts{Direct: true})
+	dialOpts := mongo.DefaultDialOpts()
+	dialOpts.Direct = true
+	st, m, err := openState(agentConfig, dialOpts)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to open state to retrieve machine addresses")
 	}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -116,7 +116,7 @@ func (s *commonMachineSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 	s.TestSuite.SetUpTest(c)
 	s.AgentSuite.PatchValue(&charmrepo.CacheDir, c.MkDir())
-	s.AgentSuite.PatchValue(&stateWorkerDialOpts, mongo.DialOpts{})
+	s.AgentSuite.PatchValue(&stateWorkerDialOpts, mongo.DefaultDialOpts())
 
 	os.Remove(JujuRun) // ignore error; may not exist
 	// Patch ssh user to avoid touching ~ubuntu/.ssh/authorized_keys.

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -165,7 +165,7 @@ func (s *AgentSuite) AssertCanOpenState(c *gc.C, tag names.Tag, dataDir string) 
 	c.Assert(err, jc.ErrorIsNil)
 	info, ok := config.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st, err := state.Open(info, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 }

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -397,7 +397,7 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 
 	stateinfo, ok := machineConf1.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st, err = state.Open(stateinfo, mongo.DialOpts{}, environs.NewStatePolicy())
+	st, err = state.Open(stateinfo, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -39,9 +39,9 @@ type DialOpts struct {
 	Timeout time.Duration
 
 	// SocketTimeout is the amount of time to wait for a
-	// non-responding socket to the database before it is
-	// forcefully closed. If this is zero, Timeout will be
-	// used.
+	// non-responding socket to the database before it is forcefully
+	// closed. If this is zero, the value of the SocketTimeout const
+	// will be used.
 	SocketTimeout time.Duration
 
 	// Direct informs whether to establish connections only with the
@@ -145,9 +145,11 @@ func DialWithInfo(info Info, opts DialOpts) (*mgo.Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	if opts.SocketTimeout != 0 {
-		session.SetSocketTimeout(opts.SocketTimeout)
+	if opts.SocketTimeout == 0 {
+		opts.SocketTimeout = SocketTimeout
 	}
+	session.SetSocketTimeout(opts.SocketTimeout)
+
 	if opts.PostDial != nil {
 		if err := opts.PostDial(session); err != nil {
 			session.Close()

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -137,14 +137,20 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 // DialWithInfo establishes a new session to the cluster identified by info,
 // with the specified options.
 func DialWithInfo(info Info, opts DialOpts) (*mgo.Session, error) {
+	if opts.Timeout == 0 {
+		return nil, errors.New("a non-zero Timeout must be specified")
+	}
+
 	dialInfo, err := DialInfo(info, opts)
 	if err != nil {
 		return nil, err
 	}
+
 	session, err := mgo.DialWithInfo(dialInfo)
 	if err != nil {
 		return nil, err
 	}
+
 	if opts.SocketTimeout == 0 {
 		opts.SocketTimeout = SocketTimeout
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -205,10 +205,11 @@ func (st *State) RemoveAllEnvironDocs() error {
 	return st.runTransaction(ops)
 }
 
-// ForEnviron returns a connection to mongo for the specified environment. The
-// connection uses the same credentails and policy as the existing connection.
+// ForEnviron returns a connection to mongo for the specified
+// environment. The connection uses the same credentials and policy as
+// the existing connection.
 func (st *State) ForEnviron(env names.EnvironTag) (*State, error) {
-	newState, err := open(st.mongoInfo, mongo.DialOpts{}, st.policy)
+	newState, err := open(st.mongoInfo, mongo.DefaultDialOpts(), st.policy)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
mongo: use SocketTimeout if not specified in dial options

It doesn't make sense to not set a socket timeout.

Also fixed the incorrect comment for DialOpts.SocketTimeout.

---

Require that all Juju's connections to MongoDB use a timeout

A possible (but unlikely) fix to LP #1469199 but good to fix anyway. Without this mongo dial attempts could block forever if mongod wasn't there.

(Review request: http://reviews.vapour.ws/r/2102/)