### PR TITLE
Add new system manager API end point

### DIFF
--- a/api/environmentmanager/environmentmanager.go
+++ b/api/environmentmanager/environmentmanager.go
@@ -145,7 +145,7 @@ func (c *Client) EnvironmentGet() (map[string]interface{}, error) {
 // and removes all non-manager machine instances. DestroyEnvironment
 // will fail if there are any manually-provisioned non-manager machines
 // in state.
-func (c *Client) DestroyEnvironment(envUUID string) error {
-	env := params.EnvironmentDestroyArgs{envUUID}
+func (c *Client) DestroyEnvironment(envUUID names.EnvironTag) error {
+	env := params.DestroyEnvironmentArgs{envUUID.String()}
 	return c.facade.FacadeCall("DestroyEnvironment", env, nil)
 }

--- a/api/environmentmanager/environmentmanager_test.go
+++ b/api/environmentmanager/environmentmanager_test.go
@@ -5,6 +5,7 @@ package environmentmanager_test
 
 import (
 	"fmt"
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -150,4 +151,17 @@ func (s *environmentmanagerSuite) TestEnvironmentGet(c *gc.C) {
 	env, err := envManager.EnvironmentGet()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env["name"], gc.Equals, "dummyenv")
+}
+
+func (s *environmentmanagerSuite) TestDestroyEnvironment(c *gc.C) {
+	s.SetFeatureFlags(feature.JES)
+	envManager := s.OpenAPI(c)
+	otherState := s.Factory.MakeEnvironment(c, &factory.EnvParams{Name: "test"})
+	defer otherState.Close()
+
+	err := envManager.DestroyEnvironment(names.NewEnvironTag(otherState.EnvironUUID()))
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = otherState.Environment()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -49,6 +49,7 @@ var facadeVersions = map[string]int{
 	"Storage":                      1,
 	"StorageProvisioner":           1,
 	"StringsWatcher":               0,
+	"SystemManager":                0,
 	"Upgrader":                     0,
 	"Uniter":                       2,
 	"UserManager":                  0,

--- a/api/systemmanager/package_test.go
+++ b/api/systemmanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/api/systemmanager/systemmanager.go
+++ b/api/systemmanager/systemmanager.go
@@ -1,0 +1,58 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager
+
+import (
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var logger = loggo.GetLogger("juju.api.systemmanager")
+
+// Client provides methods that the Juju client command uses to interact
+// with systems stored in the Juju Server.
+type Client struct {
+	base.ClientFacade
+	facade base.FacadeCaller
+}
+
+// NewClient creates a new `Client` based on an existing authenticated API
+// connection.
+func NewClient(st base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(st, "SystemManager")
+	logger.Debugf("%#v", frontend)
+	return &Client{ClientFacade: frontend, facade: backend}
+}
+
+// EnvironmentGet returns all environment settings for the
+// system environment.
+func (c *Client) EnvironmentGet() (map[string]interface{}, error) {
+	result := params.EnvironmentConfigResults{}
+	err := c.facade.FacadeCall("EnvironmentGet", nil, &result)
+	return result.Config, err
+}
+
+// DestroySystem puts the system environment into a "dying" state,
+// and removes all non-manager machine instances. Underlying DestroyEnvironment
+// calls will fail if there are any manually-provisioned non-manager machines
+// in state.
+func (c *Client) DestroySystem(envUUID names.EnvironTag, destroyEnvs bool, ignoreBlocks bool) error {
+	args := params.DestroySystemArgs{
+		EnvTag:       envUUID.String(),
+		DestroyEnvs:  destroyEnvs,
+		IgnoreBlocks: ignoreBlocks,
+	}
+	return c.facade.FacadeCall("DestroySystem", args, nil)
+}
+
+// ListBlockedEnvironments returns a list of all environments within the system
+// which have at least one block in place.
+func (c *Client) ListBlockedEnvironments() ([]params.EnvironmentBlockInfo, error) {
+	result := params.EnvironmentBlockInfoList{}
+	err := c.facade.FacadeCall("ListBlockedEnvironments", nil, &result)
+	return result.Environments, err
+}

--- a/api/systemmanager/systemmanager_test.go
+++ b/api/systemmanager/systemmanager_test.go
@@ -1,0 +1,79 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager_test
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/systemmanager"
+	commontesting "github.com/juju/juju/apiserver/common/testing"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+type systemmanagerSuite struct {
+	jujutesting.JujuConnSuite
+	commontesting.BlockHelper
+}
+
+var _ = gc.Suite(&systemmanagerSuite{})
+
+func (s *systemmanagerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+}
+
+func (s *systemmanagerSuite) OpenAPI(c *gc.C) *systemmanager.Client {
+	conn, err := juju.NewAPIState(s.AdminUserTag(c), s.Environ, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { conn.Close() })
+	return systemmanager.NewClient(conn)
+}
+
+func (s *systemmanagerSuite) TestEnvironmentGet(c *gc.C) {
+	s.SetFeatureFlags(feature.JES)
+	sysManager := s.OpenAPI(c)
+	env, err := sysManager.EnvironmentGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env["name"], gc.Equals, "dummyenv")
+}
+
+func (s *systemmanagerSuite) TestDestroySystem(c *gc.C) {
+	s.SetFeatureFlags(feature.JES)
+	s.Factory.MakeEnvironment(c, &factory.EnvParams{Name: "foo"}).Close()
+
+	sysManager := s.OpenAPI(c)
+	err := sysManager.DestroySystem(names.NewEnvironTag(s.State.EnvironUUID()), false, false)
+	c.Assert(err, gc.ErrorMatches, "state server environment cannot be destroyed before all other environments are destroyed")
+}
+
+func (s *systemmanagerSuite) TestListBlockedEnvironments(c *gc.C) {
+	s.SetFeatureFlags(feature.JES)
+	err := s.State.SwitchBlockOn(state.ChangeBlock, "change block for state server")
+	err = s.State.SwitchBlockOn(state.DestroyBlock, "destroy block for state server")
+	c.Assert(err, jc.ErrorIsNil)
+
+	sysManager := s.OpenAPI(c)
+	results, err := sysManager.ListBlockedEnvironments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, []params.EnvironmentBlockInfo{
+		params.EnvironmentBlockInfo{
+			params.Environment{
+				Name:     "dummyenv",
+				UUID:     s.State.EnvironUUID(),
+				OwnerTag: s.AdminUserTag(c).String(),
+			},
+			[]string{
+				"BlockChange",
+				"BlockDestroy",
+			},
+		},
+	})
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/juju/juju/apiserver/service"
 	_ "github.com/juju/juju/apiserver/storage"
 	_ "github.com/juju/juju/apiserver/storageprovisioner"
+	_ "github.com/juju/juju/apiserver/systemmanager"
 	_ "github.com/juju/juju/apiserver/uniter"
 	_ "github.com/juju/juju/apiserver/upgrader"
 	_ "github.com/juju/juju/apiserver/usermanager"

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -1045,5 +1045,6 @@ func (c *Client) DestroyEnvironment() (err error) {
 		return errors.Trace(err)
 	}
 
-	return envManager.DestroyEnvironment(params.EnvironmentDestroyArgs{c.api.state.EnvironUUID()})
+	envTag := names.NewEnvironTag(c.api.state.EnvironUUID())
+	return envManager.DestroyEnvironment(params.DestroyEnvironmentArgs{envTag.String()})
 }

--- a/apiserver/environmentmanager/destroy_test.go
+++ b/apiserver/environmentmanager/destroy_test.go
@@ -80,7 +80,7 @@ func (s *destroyEnvironmentSuite) setUpInstances(c *gc.C) (m0, m1, m2 *state.Mac
 func (s *destroyEnvironmentSuite) destroyEnvironment(c *gc.C, envUUID string) error {
 	envManager, err := environmentmanager.NewEnvironmentManagerAPI(s.State, s.resources, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
-	return envManager.DestroyEnvironment(params.EnvironmentDestroyArgs{envUUID})
+	return envManager.DestroyEnvironment(params.DestroyEnvironmentArgs{names.NewEnvironTag(envUUID).String()})
 }
 
 func (s *destroyEnvironmentSuite) TestDestroyEnvironmentManual(c *gc.C) {
@@ -231,7 +231,7 @@ func (s *destroyTwoEnvironmentsSuite) SetUpTest(c *gc.C) {
 func (s *destroyTwoEnvironmentsSuite) destroyEnvironment(c *gc.C, envUUID string) error {
 	envManager, err := environmentmanager.NewEnvironmentManagerAPI(s.State, s.resources, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
-	return envManager.DestroyEnvironment(params.EnvironmentDestroyArgs{envUUID})
+	return envManager.DestroyEnvironment(params.DestroyEnvironmentArgs{names.NewEnvironTag(envUUID).String()})
 }
 
 func (s *destroyTwoEnvironmentsSuite) TestCleanupEnvironDocs(c *gc.C) {

--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -452,11 +452,14 @@ func (em *EnvironmentManagerAPI) environmentAuthCheck(st stateInterface) error {
 
 // DestroyEnvironment destroys all services and non-manager machine
 // instances in the specified environment.
-func (em *EnvironmentManagerAPI) DestroyEnvironment(args params.EnvironmentDestroyArgs) (err error) {
+func (em *EnvironmentManagerAPI) DestroyEnvironment(args params.DestroyEnvironmentArgs) (err error) {
 	st := em.state
-	envUUID := args.EnvUUID
-	if envUUID != em.state.EnvironUUID() {
-		envTag := names.NewEnvironTag(envUUID)
+	envTag, err := names.ParseEnvironTag(args.EnvTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if envTag.Id() != em.state.EnvironUUID() {
 		if st, err = em.state.ForEnviron(envTag); err != nil {
 			return errors.Trace(err)
 		}

--- a/apiserver/params/environment.go
+++ b/apiserver/params/environment.go
@@ -72,3 +72,8 @@ type EnvUserInfoResult struct {
 type EnvUserInfoResults struct {
 	Results []EnvUserInfoResult `json:"results"`
 }
+
+// DestroyEnvironmentArgs wraps the environment environment tag to destroy.
+type DestroyEnvironmentArgs struct {
+	EnvTag string
+}

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -89,11 +89,6 @@ type EnvironmentSkeletonConfigArgs struct {
 	Region   string
 }
 
-// EnvironmentDestroyArgs wraps the environment UUID to destroy.
-type EnvironmentDestroyArgs struct {
-	EnvUUID string
-}
-
 // EnvironmentCreateArgs holds the arguments that are necessary to create
 // and environment.
 type EnvironmentCreateArgs struct {

--- a/apiserver/params/systemmanager.go
+++ b/apiserver/params/systemmanager.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+// DestroySystemArgs holds the arguments for destroying a system.
+type DestroySystemArgs struct {
+	// EnvTag is the tag of the system to destroy.
+	EnvTag string
+
+	// DestroyEnvs specifies whether or not the hosted systems
+	// should be destroyed in the DestroySystem call.
+	DestroyEnvs bool
+
+	// IgnoreBlocks specifies whether or not to ignore blocks
+	// on hosted environments.
+	IgnoreBlocks bool
+}
+
+// EnvironmentBlockInfo holds information about an environment and its
+// current blocks.
+type EnvironmentBlockInfo struct {
+	Environment
+
+	// Blocks contains a list of the current block types enabled
+	// for this environment.
+	Blocks []string `json:"blocks"`
+}
+
+// EnvironmentBlockInfoList holds information about the blocked environments
+// for a system.
+type EnvironmentBlockInfoList struct {
+	Environments []EnvironmentBlockInfo `json:"environments,omitempty"`
+}

--- a/apiserver/restricted_root.go
+++ b/apiserver/restricted_root.go
@@ -28,6 +28,7 @@ func newRestrictedRoot(finder rpc.MethodFinder) *restrictedRoot {
 var restrictedRootNames = set.NewStrings(
 	"EnvironmentManager",
 	"UserManager",
+	"SystemManager",
 )
 
 // FindMethod returns a not supported error if the rootName is not one

--- a/apiserver/restricted_root_test.go
+++ b/apiserver/restricted_root_test.go
@@ -41,6 +41,10 @@ func (r *restrictedRootSuite) TestFindAllowedMethod(c *gc.C) {
 	r.assertMethodAllowed(c, "UserManager", 0, "AddUser")
 	r.assertMethodAllowed(c, "UserManager", 0, "SetPassword")
 	r.assertMethodAllowed(c, "UserManager", 0, "UserInfo")
+
+	r.assertMethodAllowed(c, "SystemManager", 0, "DestroySystem")
+	r.assertMethodAllowed(c, "SystemManager", 0, "EnvironmentGet")
+	r.assertMethodAllowed(c, "SystemManager", 0, "ListBlockedEnvironments")
 }
 
 func (r *restrictedRootSuite) TestFindDisallowedMethod(c *gc.C) {

--- a/apiserver/systemmanager/package_test.go
+++ b/apiserver/systemmanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -1,0 +1,236 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The systemmanager package defines an API end point for functions
+// dealing with systems.
+
+package systemmanager
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/environmentmanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/state"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.systemmanager")
+
+func init() {
+	common.RegisterStandardFacadeForFeature("SystemManager", 0, NewSystemManagerAPI, feature.JES)
+}
+
+// SystemManager defines the methods on the systemmanager API endpoint.
+type SystemManager interface {
+	DestroySystem(args params.DestroySystemArgs) error
+	EnvironmentGet() (params.EnvironmentConfigResults, error)
+	ListBlockedEnvironments() (params.EnvironmentBlockInfoList, error)
+}
+
+// SystemManagerAPI implements the system manager interface and is
+// the concrete implementation of the api endpoint.
+type SystemManagerAPI struct {
+	state      *state.State
+	authorizer common.Authorizer
+	resources  *common.Resources
+}
+
+var _ SystemManager = (*SystemManagerAPI)(nil)
+
+// NewSystemManagerAPI creates a new api server endpoint for managing
+// systems.
+func NewSystemManagerAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*SystemManagerAPI, error) {
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
+
+	return &SystemManagerAPI{
+		state:      st,
+		authorizer: authorizer,
+	}, nil
+}
+
+// isSystemAdministrator determines if the api user is a system administrator
+func (sm *SystemManagerAPI) isSystemAdministrator() (bool, error) {
+	authTag := sm.authorizer.GetAuthTag()
+	apiUser, ok := authTag.(names.UserTag)
+	if !ok {
+		return false, errors.Errorf("auth tag should be a user, but isn't: %q", authTag.String())
+	}
+
+	isAdmin, err := sm.state.IsSystemAdministrator(apiUser)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	return isAdmin, nil
+}
+
+// ListBlockedEnvironments returns a list of all environments on the system which
+// have a block in place.  Callers must be a system administrator to retrieve the list.
+func (sm *SystemManagerAPI) ListBlockedEnvironments() (params.EnvironmentBlockInfoList, error) {
+	results := params.EnvironmentBlockInfoList{}
+
+	// Check that we are authorized
+	isAdmin, err := sm.isSystemAdministrator()
+	if err != nil {
+		return results, errors.Trace(err)
+	}
+
+	if !isAdmin {
+		return results, common.ErrPerm
+	}
+
+	blocks, err := sm.state.AllBlocksForSystem()
+	if err != nil {
+		return results, errors.Trace(err)
+	}
+
+	envBlocks := make(map[string][]string)
+	for _, block := range blocks {
+		uuid := block.EnvUUID()
+		envBlocks[uuid] = append(envBlocks[uuid], block.Type().String())
+	}
+
+	for uuid, blocks := range envBlocks {
+		envInfo, err := sm.state.GetEnvironment(names.NewEnvironTag(uuid))
+		if err != nil {
+			// Environment no longer exists, don't list it.
+			logger.Debugf("Unable to get name for environment: %s", uuid)
+			continue
+		}
+		results.Environments = append(results.Environments, params.EnvironmentBlockInfo{
+			Environment: params.Environment{
+				UUID:     envInfo.UUID(),
+				Name:     envInfo.Name(),
+				OwnerTag: envInfo.Owner().String(),
+			},
+			Blocks: blocks,
+		})
+	}
+
+	return results, nil
+}
+
+func (sm *SystemManagerAPI) DestroySystem(args params.DestroySystemArgs) error {
+	// Check we're destroying the system env
+	st := sm.state
+
+	envTag, err := names.ParseEnvironTag(args.EnvTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	stateServerEnv, err := st.StateServerEnvironment()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if envTag.Id() != stateServerEnv.ServerUUID() {
+		return errors.Errorf("%q is not a system", envTag.Id())
+	}
+
+	// Check that we are authorized
+	isAdmin, err := sm.isSystemAdministrator()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if !isAdmin {
+		return common.ErrPerm
+	}
+
+	// Make sure we can get an EnvironmentManagerAPI connection to destroy
+	// the environments
+	envManager, err := environmentmanager.NewEnvironmentManagerAPI(sm.state, sm.resources, sm.authorizer)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Get list of all environments in the system.
+	allEnvs, err := st.AllEnvironments()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// If there are hosted environments and DestroyEnvs was not specified, don't
+	// bother trying to destroy the system, as it will fail.
+	if len(allEnvs) > 1 && !args.DestroyEnvs {
+		return errors.Errorf("state server environment cannot be destroyed before all other environments are destroyed")
+	}
+
+	// Check for blocks
+	blocks, err := st.AllBlocksForSystem()
+	if err != nil {
+		// If we're ignoring blocks, we're trying to kill the system.  Don't fail
+		// here and attempt to destroy environments to clean up as much as possible.
+		logger.Warningf("Unable to get blocks for system: %s", err)
+		if !args.IgnoreBlocks {
+			return errors.Trace(err)
+		}
+	}
+	if len(blocks) > 0 {
+		if !args.IgnoreBlocks {
+			return common.ErrOperationBlocked("found blocks in system environments")
+		}
+
+		err := st.RemoveAllBlocksForSystem()
+		if err != nil {
+			// If we're ignoring blocks, we're trying to kill the system.  Don't fail
+			// here and attempt to destroy environments to clean up as much as possible.
+			logger.Warningf("Unable to remove all blocks for system: %s", err)
+		}
+	}
+
+	if args.DestroyEnvs {
+		for _, env := range allEnvs {
+			if env.UUID() != envTag.Id() {
+				tag := names.NewEnvironTag(env.UUID())
+				err = envManager.DestroyEnvironment(params.DestroyEnvironmentArgs{tag.String()})
+				if err != nil {
+					logger.Warningf("unable to destroy environment %q: %s", env.UUID(), err)
+				}
+			}
+		}
+	}
+
+	return envManager.DestroyEnvironment(params.DestroyEnvironmentArgs{envTag.String()})
+}
+
+// EnvironmentGet returns the environment config for the system
+// environment.  For information on the current environment, use
+// client.EnvironmentGet
+func (sm *SystemManagerAPI) EnvironmentGet() (_ params.EnvironmentConfigResults, err error) {
+	result := params.EnvironmentConfigResults{}
+
+	stateServerEnv, err := sm.state.StateServerEnvironment()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	// Check that we are authorized
+	isAdmin, err := sm.isSystemAdministrator()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	if !isAdmin {
+		return result, common.ErrPerm
+	}
+
+	config, err := stateServerEnv.Config()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	result.Config = config.AllAttrs()
+	return result, nil
+}

--- a/apiserver/systemmanager/systemmanager_test.go
+++ b/apiserver/systemmanager/systemmanager_test.go
@@ -1,0 +1,359 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	commontesting "github.com/juju/juju/apiserver/common/testing"
+	"github.com/juju/juju/apiserver/environmentmanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/systemmanager"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type sysManagerBaseSuite struct {
+	testing.JujuConnSuite
+
+	sysmanager *systemmanager.SystemManagerAPI
+	resources  *common.Resources
+	authoriser apiservertesting.FakeAuthorizer
+}
+
+func (s *sysManagerBaseSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authoriser = apiservertesting.FakeAuthorizer{
+		Tag: s.AdminUserTag(c),
+	}
+
+	loggo.GetLogger("juju.apiserver.systemmanager").SetLogLevel(loggo.TRACE)
+}
+
+func (s *sysManagerBaseSuite) setAPIUser(c *gc.C, user names.UserTag) {
+	s.authoriser.Tag = user
+	sysmanager, err := systemmanager.NewSystemManagerAPI(s.State, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	s.sysmanager = sysmanager
+}
+
+type sysManagerSuite struct {
+	sysManagerBaseSuite
+}
+
+var _ = gc.Suite(&sysManagerSuite{})
+
+func (s *sysManagerSuite) TestNewAPIAcceptsClient(c *gc.C) {
+	anAuthoriser := s.authoriser
+	anAuthoriser.Tag = names.NewUserTag("external@remote")
+	endPoint, err := systemmanager.NewSystemManagerAPI(s.State, s.resources, anAuthoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(endPoint, gc.NotNil)
+}
+
+func (s *sysManagerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
+	anAuthoriser := s.authoriser
+	anAuthoriser.Tag = names.NewUnitTag("mysql/0")
+	endPoint, err := systemmanager.NewSystemManagerAPI(s.State, s.resources, anAuthoriser)
+	c.Assert(endPoint, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *sysManagerSuite) TestEnvironmentGet(c *gc.C) {
+	s.setAPIUser(c, s.AdminUserTag(c))
+	env, err := s.sysmanager.EnvironmentGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Config["name"], gc.Equals, "dummyenv")
+}
+
+func (s *sysManagerSuite) TestEnvironmentGetNonAdminUser(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoEnvUser: false})
+
+	s.setAPIUser(c, user.UserTag())
+	env, err := s.sysmanager.EnvironmentGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Config["name"], gc.Equals, "dummyenv")
+}
+
+func (s *sysManagerSuite) TestEnvironmentGetFromNonStateServer(c *gc.C) {
+	st := s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "test"})
+	defer st.Close()
+
+	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.AdminUserTag(c)}
+	sysManager, err := systemmanager.NewSystemManagerAPI(st, common.NewResources(), authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	env, err := sysManager.EnvironmentGet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Config["name"], gc.Equals, "dummyenv")
+}
+
+func (s *sysManagerSuite) TestUnauthorizedEnvironmentGet(c *gc.C) {
+	owner := names.NewUserTag("external@remote")
+	s.setAPIUser(c, owner)
+	_, err := s.sysmanager.EnvironmentGet()
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *sysManagerSuite) TestListBlockedEnvironments(c *gc.C) {
+	st := s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "test"})
+	defer st.Close()
+
+	s.State.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.State.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	st.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	s.setAPIUser(c, s.AdminUserTag(c))
+	list, err := s.sysmanager.ListBlockedEnvironments()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(list.Environments, jc.DeepEquals, []params.EnvironmentBlockInfo{
+		params.EnvironmentBlockInfo{
+			params.Environment{
+				Name:     "dummyenv",
+				UUID:     s.State.EnvironUUID(),
+				OwnerTag: s.AdminUserTag(c).String(),
+			},
+			[]string{
+				"BlockDestroy",
+				"BlockChange",
+			},
+		},
+		params.EnvironmentBlockInfo{
+			params.Environment{
+				Name:     "test",
+				UUID:     st.EnvironUUID(),
+				OwnerTag: s.AdminUserTag(c).String(),
+			},
+			[]string{
+				"BlockDestroy",
+				"BlockChange",
+			},
+		},
+	})
+
+}
+
+func (s *sysManagerSuite) TestUnauthorizedListBlockedEnvironments(c *gc.C) {
+	owner := names.NewUserTag("external@remote")
+	s.setAPIUser(c, owner)
+	_, err := s.sysmanager.ListBlockedEnvironments()
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *sysManagerSuite) TestListBlockedEnvironmentsNoBlocks(c *gc.C) {
+	s.setAPIUser(c, s.AdminUserTag(c))
+	list, err := s.sysmanager.ListBlockedEnvironments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(list.Environments), gc.Equals, 0)
+}
+
+type destroyTwoEnvironmentsSuite struct {
+	sysManagerBaseSuite
+	commontesting.BlockHelper
+	otherState    *state.State
+	otherEnvOwner names.UserTag
+	otherEnvUUID  string
+}
+
+var _ = gc.Suite(&destroyTwoEnvironmentsSuite{})
+
+func (s *destroyTwoEnvironmentsSuite) SetUpTest(c *gc.C) {
+	s.sysManagerBaseSuite.SetUpTest(c)
+
+	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
+	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
+
+	s.otherEnvOwner = names.NewUserTag("jess@dummy")
+	s.otherState = factory.NewFactory(s.State).MakeEnvironment(c, &factory.EnvParams{
+		Name:    "dummytoo",
+		Owner:   s.otherEnvOwner,
+		Prepare: true,
+		ConfigAttrs: jujutesting.Attrs{
+			"state-server": false,
+		},
+	})
+	s.AddCleanup(func(c *gc.C) { s.otherState.Close() })
+	s.otherEnvUUID = s.otherState.EnvironUUID()
+}
+
+func (s *destroyTwoEnvironmentsSuite) destroyEnvironment(c *gc.C, envUUID string) error {
+	envManager, err := environmentmanager.NewEnvironmentManagerAPI(s.State, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	return envManager.DestroyEnvironment(params.DestroyEnvironmentArgs{names.NewEnvironTag(envUUID).String()})
+}
+
+func (s *destroyTwoEnvironmentsSuite) destroySystem(c *gc.C, envUUID string, destroyEnvs bool, ignoreBlocks bool) error {
+	sysManager, err := systemmanager.NewSystemManagerAPI(s.State, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	return sysManager.DestroySystem(params.DestroySystemArgs{
+		EnvTag:       names.NewEnvironTag(envUUID).String(),
+		DestroyEnvs:  destroyEnvs,
+		IgnoreBlocks: ignoreBlocks,
+	})
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemNotASystem(c *gc.C) {
+	err := s.destroySystem(c, s.otherState.EnvironUUID(), false, false)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("%q is not a system", s.otherState.EnvironUUID()))
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemNotASystemFromHostedEnv(c *gc.C) {
+	authoriser := apiservertesting.FakeAuthorizer{
+		Tag: s.AdminUserTag(c),
+	}
+
+	sysmanager, err := systemmanager.NewSystemManagerAPI(s.otherState, s.resources, authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = sysmanager.DestroySystem(params.DestroySystemArgs{
+		EnvTag:       names.NewEnvironTag(s.otherState.EnvironUUID()).String(),
+		DestroyEnvs:  true,
+		IgnoreBlocks: true,
+	})
+
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("%q is not a system", s.otherState.EnvironUUID()))
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemUnauthorized(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{
+		Name:      "unautheduser",
+		NoEnvUser: true,
+	})
+
+	authoriser := apiservertesting.FakeAuthorizer{
+		Tag: user.UserTag(),
+	}
+
+	sysmanager, err := systemmanager.NewSystemManagerAPI(s.State, s.resources, authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = sysmanager.DestroySystem(params.DestroySystemArgs{
+		EnvTag:       names.NewEnvironTag(s.State.EnvironUUID()).String(),
+		DestroyEnvs:  true,
+		IgnoreBlocks: true,
+	})
+
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemKillsHostedEnvsWithBlocks(c *gc.C) {
+	// Tests destroyEnvs=true, ignoreBlocks=true, hosted environments=Y, blocks=Y
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+	s.otherState.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.otherState.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+	err := s.destroySystem(c, s.State.EnvironUUID(), true, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.otherState.Environment()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemReturnsBlockedEnvironmentsErr(c *gc.C) {
+	// Tests destroyEnvs=true, ignoreBlocks=false, hosted environments=Y, blocks=Y
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+	s.otherState.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.otherState.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+	err := s.destroySystem(c, s.State.EnvironUUID(), true, false)
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+
+	numBlocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(numBlocks), gc.Equals, 4)
+
+	_, err = s.otherState.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemKillsHostedEnvs(c *gc.C) {
+	// Tests destroyEnvs=true, ignoreBlocks=false, hosted environments=Y, blocks=N
+	err := s.destroySystem(c, s.State.EnvironUUID(), true, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.otherState.Environment()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemLeavesBlocksIfNotKillAll(c *gc.C) {
+	// Tests destroyEnvs=false, ignoreBlocks=true, hosted environments=Y, blocks=Y
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+	s.otherState.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.otherState.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	err := s.destroySystem(c, s.State.EnvironUUID(), false, true)
+	c.Assert(err, gc.ErrorMatches, "state server environment cannot be destroyed before all other environments are destroyed")
+
+	numBlocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(numBlocks), gc.Equals, 4)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemNoHostedEnvs(c *gc.C) {
+	// Tests destroyEnvs=false, ignoreBlocks=false, hosted environments=N, blocks=N
+	err := s.destroyEnvironment(c, s.otherEnvUUID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.destroySystem(c, s.State.EnvironUUID(), false, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemNoHostedEnvsWithBlock(c *gc.C) {
+	// Tests destroyEnvs=false, ignoreBlocks=true, hosted environments=N, blocks=Y
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+	err := s.destroyEnvironment(c, s.otherEnvUUID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.destroySystem(c, s.State.EnvironUUID(), false, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroySystemNoHostedEnvsWithBlockFail(c *gc.C) {
+	// Tests destroyEnvs=false, ignoreBlocks=false, hosted environments=N, blocks=Y
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+	err := s.destroyEnvironment(c, s.otherEnvUUID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.destroySystem(c, s.State.EnvironUUID(), false, false)
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+
+	numBlocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(numBlocks), gc.Equals, 2)
+}

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -73,7 +73,7 @@ func (c *CreateEnvironmentCommand) ConfValues() map[string]string {
 
 // NewDestroyCommand returns a DestroyCommand with the the environmentmanager and client
 // endpoints mocked out.
-func NewDestroyCommand(api destroyEnvironmentAPI, clientapi destroyEnvironmentClientAPI, apierr error) *DestroyCommand {
+func NewDestroyCommand(api destroySystemAPI, clientapi destroyEnvironmentClientAPI, apierr error) *DestroyCommand {
 	return &DestroyCommand{
 		api:       api,
 		clientapi: clientapi,


### PR DESCRIPTION
This patch adds a new system manager end point which
provides functions for dealing with Juju systems:

EnvironmentGet returns information about the system
environment so that the juju system destroy command
can retrieve bootstrap information from state server.

ListBlockedEnvironments returns a list of all the
environments within the system which have at least one
block in place.  This will be used for a future
juju system command to allow administrators to see all
the blocks currently in place within a system.

DestroySystem will destroy the system environment. It
accepts two flags:
 - DestroyEnvs: this corresponds to the --destroy-all-envs
   flag used in the juju system destroy command.  If
   specified, it will iterate through all the environments
   in the system and attempt to destroy them.  If there
   are any blocks in the system, the destroy command will
   not attempt to destroy any environments unless the
   IgnoreBlocks flag is also specified.
 - IgnoreBlocks: will be used in the forthcoming juju
   system kill command.  It will attempt to remove all
   blocks in the system before destroying the environments.

This patch also updates the juju system destroy command to:
 - Use the new DestroySystem method on the SystemManager
   endpoint.
 - Accept a new flag, --destroy-all-envs which will
   attempt to destroy all hosted environments within the
   system.
The juju system destroy command will honor blocks on
environments.  A follow on command, juju system kill
can be used to destroy a system with blocks in place
(or a broken state server).

(Review request: http://reviews.vapour.ws/r/2108/)