### PR TITLE
Remove error message that is filling up my logs

### DIFF
--- a/worker/diskmanager/lsblk.go
+++ b/worker/diskmanager/lsblk.go
@@ -110,9 +110,6 @@ func listBlockDevices() ([]storage.BlockDevice, error) {
 			// host, but the devices will typically not be present.
 			continue
 		} else if err != nil {
-			logger.Errorf(
-				"error checking if %q is in use: %v", dev.DeviceName, err,
-			)
 			// We cannot detect, so err on the side of caution and default to
 			// "in use" so the device cannot be used.
 			dev.InUse = true


### PR DESCRIPTION
I have a loopback device /dev/loop1 that is in use by another program.  Every roughly 10 seconds it looks like I'm getting a log message about this being in use.  I removed the error line so it stops filling up my logs.  :)