### PR TITLE
Allow placement directives to be used for add unit

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -457,6 +457,19 @@ func (c *Client) AddServiceUnits(service string, numUnits int, machineSpec strin
 	return results.Units, err
 }
 
+// AddServiceUnitsWithPlacement adds a given number of units to a service using the specified
+// placement directives to assign units to machines.
+func (c *Client) AddServiceUnitsWithPlacement(service string, numUnits int, placement []*instance.Placement) ([]string, error) {
+	args := params.AddServiceUnits{
+		ServiceName: service,
+		NumUnits:    numUnits,
+		Placement:   placement,
+	}
+	results := new(params.AddServiceUnitsResults)
+	err := c.facade.FacadeCall("AddServiceUnitsWithPlacement", args, results)
+	return results.Units, err
+}
+
 // DestroyServiceUnits decreases the number of units dedicated to a service.
 func (c *Client) DestroyServiceUnits(unitNames ...string) error {
 	params := params.DestroyServiceUnits{unitNames}

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -410,6 +410,13 @@ func addServiceUnits(state *state.State, args params.AddServiceUnits) ([]*state.
 	if args.NumUnits < 1 {
 		return nil, fmt.Errorf("must add at least one unit")
 	}
+
+	// New API uses placement directives.
+	if len(args.Placement) > 0 {
+		return jjj.AddUnitsWithPlacement(state, service, args.NumUnits, args.Placement)
+	}
+
+	// Otherwise we use the older machine spec.
 	if args.NumUnits > 1 && args.ToMachineSpec != "" {
 		return nil, fmt.Errorf("cannot use NumUnits with ToMachineSpec")
 	}
@@ -425,6 +432,11 @@ func addServiceUnits(state *state.State, args params.AddServiceUnits) ([]*state.
 
 // AddServiceUnits adds a given number of units to a service.
 func (c *Client) AddServiceUnits(args params.AddServiceUnits) (params.AddServiceUnitsResults, error) {
+	return c.AddServiceUnitsWithPlacement(args)
+}
+
+// AddServiceUnits adds a given number of units to a service.
+func (c *Client) AddServiceUnitsWithPlacement(args params.AddServiceUnits) (params.AddServiceUnitsResults, error) {
 	if err := c.check.ChangeAllowed(); err != nil {
 		return params.AddServiceUnitsResults{}, errors.Trace(err)
 	}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -334,6 +334,7 @@ type AddServiceUnits struct {
 	ServiceName   string
 	NumUnits      int
 	ToMachineSpec string
+	Placement     []*instance.Placement
 }
 
 // DestroyServiceUnits holds parameters for the DestroyUnits call.

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -229,7 +229,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		if !constraints.IsEmpty(&c.Constraints) {
 			return errors.New("cannot use --constraints with subordinate service")
 		}
-		if numUnits == 1 && c.ToMachineSpec == "" {
+		if numUnits == 1 && c.PlacementSpec == "" {
 			numUnits = 0
 		} else {
 			return errors.New("cannot use --num-units or --to with subordinate service")
@@ -262,7 +262,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 			numUnits,
 			string(configYAML),
 			c.Constraints,
-			c.ToMachineSpec,
+			c.PlacementSpec,
 			requestedNetworks,
 			c.Storage,
 		)
@@ -278,7 +278,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		numUnits,
 		string(configYAML),
 		c.Constraints,
-		c.ToMachineSpec,
+		c.PlacementSpec,
 		requestedNetworks,
 	)
 	if params.IsCodeNotImplemented(err) {
@@ -291,7 +291,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 			numUnits,
 			string(configYAML),
 			c.Constraints,
-			c.ToMachineSpec)
+			c.PlacementSpec)
 	}
 
 	if err != nil {

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -78,11 +78,8 @@ var initErrorTests = []struct {
 		args: []string{"craziness", "burble1", "-n", "0"},
 		err:  `--num-units must be a positive integer`,
 	}, {
-		args: []string{"craziness", "burble1", "--to", "bigglesplop"},
-		err:  `invalid --to parameter "bigglesplop"`,
-	}, {
-		args: []string{"craziness", "burble1", "-n", "2", "--to", "123"},
-		err:  `cannot use --num-units > 1 with --to`,
+		args: []string{"craziness", "burble1", "--to", "#:foo"},
+		err:  `invalid --to parameter "#:foo"`,
 	}, {
 		args: []string{"craziness", "burble1", "--constraints", "gibber=plop"},
 		err:  `invalid value "gibber=plop" for flag --constraints: unknown constraint "gibber"`,

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -57,10 +57,10 @@ machine be running Ubuntu, that it be accessible via SSH, and be running on
 the same network as the API server.
 
 It is possible to override or augment constraints by passing provider-specific
-"placement directives" with "--to"; these give the provider additional
+"placement directives" as an argument; these give the provider additional
 information about how to allocate the machine. For example, one can direct the
-MAAS provider to acquire a particular node by specifying its hostname with
-"--to". For more information on placement directives, see "juju help placement".
+MAAS provider to acquire a particular node by specifying its hostname.
+For more information on placement directives, see "juju help placement".
 
 Examples:
    juju machine add                      (starts a new machine)
@@ -70,7 +70,8 @@ Examples:
    juju machine add lxc:4                (starts a new lxc container on machine 4)
    juju machine add --constraints mem=8G (starts a machine with at least 8GB RAM)
    juju machine add ssh:user@10.10.0.3   (manually provisions a machine with ssh)
-   juju machine add zone=us-east-1a
+   juju machine add zone=us-east-1a      (start a machine in zone us-east-1a on AWS)
+   juju machine add maas2.name           (acquire machine maas2.name on MAAS)
 
 See Also:
    juju help constraints

--- a/cmd/juju/service/addunit.go
+++ b/cmd/juju/service/addunit.go
@@ -4,12 +4,11 @@
 package service
 
 import (
-	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"launchpad.net/gnuflag"
 
@@ -24,9 +23,11 @@ import (
 // UnitCommandBase provides support for commands which deploy units. It handles the parsing
 // and validation of --to and --num-units arguments.
 type UnitCommandBase struct {
-	Placement     []*instance.Placement
+	// PlacementSpec is the raw string command arg value used to specify placement directives.
 	PlacementSpec string
-	NumUnits      int
+	// Placement is the result of parsing the PlacementSpec arg value.
+	Placement []*instance.Placement
+	NumUnits  int
 }
 
 func (c *UnitCommandBase) SetFlags(f *gnuflag.FlagSet) {
@@ -49,7 +50,7 @@ func (c *UnitCommandBase) Init(args []string) error {
 		for i, spec := range placementSpecs {
 			placement, err := parsePlacement(spec)
 			if err != nil {
-				return fmt.Errorf("invalid --to parameter %q", spec)
+				return errors.Errorf("invalid --to parameter %q", spec)
 			}
 			c.Placement[i] = placement
 		}
@@ -67,7 +68,7 @@ func parsePlacement(spec string) (*instance.Placement, error) {
 		placement, err = instance.ParsePlacement(spec)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("invalid --to parameter %q", spec)
+		return nil, errors.Errorf("invalid --to parameter %q", spec)
 	}
 	return placement, nil
 }
@@ -202,7 +203,7 @@ func (c *AddUnitCommand) Run(_ *cmd.Context) error {
 		}
 	}
 	if c.PlacementSpec != "" && !IsMachineOrNewContainer(c.PlacementSpec) {
-		return fmt.Errorf("invalid --to parameter %q", c.PlacementSpec)
+		return errors.Errorf("unsupported --to parameter %q", c.PlacementSpec)
 	}
 	if c.PlacementSpec != "" && c.NumUnits > 1 {
 		return errors.New("this version of Juju does not support --num-units > 1 with --to")

--- a/cmd/juju/service/addunit_test.go
+++ b/cmd/juju/service/addunit_test.go
@@ -125,7 +125,7 @@ func (s *AddUnitSuite) TestInvalidToParamWithOlderServer(c *gc.C) {
 	c.Assert(s.fake.numUnits, gc.Equals, 2)
 
 	err = s.runAddUnit(c, "--to", "bigglesplop", "some-service-name")
-	c.Assert(err, gc.ErrorMatches, `invalid --to parameter "bigglesplop"`)
+	c.Assert(err, gc.ErrorMatches, `unsupported --to parameter "bigglesplop"`)
 }
 
 func (s *AddUnitSuite) TestUnsupportedNumUnitsWithOlderServer(c *gc.C) {

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -214,6 +214,73 @@ func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 	c.Assert(machineCons, gc.DeepEquals, *unitCons)
 }
 
+func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.Id(), gc.Equals, "0")
+	err = s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
+	c.Assert(err, jc.ErrorIsNil)
+	serviceCons := constraints.MustParse("cpu-cores=2")
+	service, err := juju.DeployService(s.State,
+		juju.DeployServiceParams{
+			ServiceName: "bob",
+			Charm:       s.charm,
+			Constraints: serviceCons,
+			NumUnits:    3,
+			Placement: []*instance.Placement{
+				{Scope: s.State.EnvironUUID(), Directive: "valid"},
+				{Scope: "#", Directive: "0"},
+				{Scope: "lxc", Directive: "1"},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertConstraints(c, service, serviceCons)
+	units, err := service.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 3)
+
+	// Check each of the newly added units.
+	s.assertAssignedUnit(c, units[0], "1", constraints.MustParse("mem=2G cpu-cores=2"))
+	s.assertAssignedUnit(c, units[1], "0", constraints.Value{})
+	s.assertAssignedUnit(c, units[2], "1/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
+}
+
+func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
+	err := s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
+	c.Assert(err, jc.ErrorIsNil)
+	serviceCons := constraints.MustParse("cpu-cores=2")
+	service, err := juju.DeployService(s.State,
+		juju.DeployServiceParams{
+			ServiceName: "bob",
+			Charm:       s.charm,
+			Constraints: serviceCons,
+			NumUnits:    3,
+			Placement: []*instance.Placement{
+				{Scope: s.State.EnvironUUID(), Directive: "valid"},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertConstraints(c, service, serviceCons)
+	units, err := service.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 3)
+
+	// Check each of the newly added units.
+	s.assertAssignedUnit(c, units[0], "0", constraints.MustParse("mem=2G cpu-cores=2"))
+	s.assertAssignedUnit(c, units[1], "1", constraints.MustParse("mem=2G cpu-cores=2"))
+	s.assertAssignedUnit(c, units[2], "2", constraints.MustParse("mem=2G cpu-cores=2"))
+}
+
+func (s *DeployLocalSuite) assertAssignedUnit(c *gc.C, u *state.Unit, mId string, cons constraints.Value) {
+	id, err := u.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+	machineCons, err := machine.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machineCons, gc.DeepEquals, cons)
+}
+
 func (s *DeployLocalSuite) assertCharm(c *gc.C, service *state.Service, expect *charm.URL) {
 	curl, force := service.CharmURL()
 	c.Assert(curl, gc.DeepEquals, expect)


### PR DESCRIPTION
Partially Fixes: https://bugs.launchpad.net/juju-core/+bug/1358941

Deploying or adding units need to support proper placement directives, not just a machine or container.

This branch adds support for using placement directives when adding units to existing services. For backwards compatibility, the existing machine spec form is also still supported.

The next branch will add support for using placement directives when actually deploying a charm for the first time. This PR contains necessary tweaks in that area but it's not done yet.

(Review request: http://reviews.vapour.ws/r/2111/)