### PR TITLE
Add the apiserver endpoint for the system manager.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -49,6 +49,7 @@ var facadeVersions = map[string]int{
 	"Storage":                      1,
 	"StorageProvisioner":           1,
 	"StringsWatcher":               0,
+	"SystemManager":                1,
 	"Upgrader":                     0,
 	"Uniter":                       2,
 	"UserManager":                  0,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/juju/juju/apiserver/service"
 	_ "github.com/juju/juju/apiserver/storage"
 	_ "github.com/juju/juju/apiserver/storageprovisioner"
+	_ "github.com/juju/juju/apiserver/systemmanager"
 	_ "github.com/juju/juju/apiserver/uniter"
 	_ "github.com/juju/juju/apiserver/upgrader"
 	_ "github.com/juju/juju/apiserver/usermanager"

--- a/apiserver/common/block_test.go
+++ b/apiserver/common/block_test.go
@@ -29,6 +29,8 @@ func (m mockBlock) Type() state.BlockType { return m.t }
 
 func (m mockBlock) Message() string { return m.m }
 
+func (m mockBlock) EnvUUID() string { return "" }
+
 type blockCheckerSuite struct {
 	testing.FakeJujuHomeSuite
 	aBlock                  state.Block

--- a/apiserver/common/environdestroy.go
+++ b/apiserver/common/environdestroy.go
@@ -1,0 +1,103 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+)
+
+// DestroyEnvironment destroys all services and non-manager machine
+// instances in the specified environment. This function assumes that all
+// necessary authenticiation checks have been done.
+func DestroyEnvironment(st *state.State, environTag names.EnvironTag) error {
+	var err error
+	if environTag != st.EnvironTag() {
+		if st, err = st.ForEnviron(environTag); err != nil {
+			return errors.Trace(err)
+		}
+		defer st.Close()
+	}
+
+	check := NewBlockChecker(st)
+	if err = check.DestroyAllowed(); err != nil {
+		return errors.Trace(err)
+	}
+
+	env, err := st.Environment()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err = env.Destroy(); err != nil {
+		return errors.Trace(err)
+	}
+
+	machines, err := st.AllMachines()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// We must destroy instances server-side to support JES (Juju Environment
+	// Server), as there's no CLI to fall back on. In that case, we only ever
+	// destroy non-state machines; we leave destroying state servers in non-
+	// hosted environments to the CLI, as otherwise the API server may get cut
+	// off.
+	if err := destroyInstances(st, machines); err != nil {
+		return errors.Trace(err)
+	}
+
+	// If this is not the state server environment, remove all documents from
+	// state associated with the environment.
+	if env.EnvironTag() != env.ServerTag() {
+		return errors.Trace(st.RemoveAllEnvironDocs())
+	}
+
+	// Return to the caller. If it's the CLI, it will finish up
+	// by calling the provider's Destroy method, which will
+	// destroy the state servers, any straggler instances, and
+	// other provider-specific resources.
+	return nil
+}
+
+// destroyInstances directly destroys all non-manager, non-manual machine
+// instances.
+func destroyInstances(st *state.State, machines []*state.Machine) error {
+	var ids []instance.Id
+	for _, m := range machines {
+		if m.IsManager() {
+			continue
+		}
+		if _, isContainer := m.ParentId(); isContainer {
+			continue
+		}
+		manual, err := m.IsManual()
+		if manual {
+			continue
+		} else if err != nil {
+			return err
+		}
+		id, err := m.InstanceId()
+		if err != nil {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	envcfg, err := st.EnvironConfig()
+	if err != nil {
+		return err
+	}
+	env, err := environs.New(envcfg)
+	if err != nil {
+		return err
+	}
+	return env.StopInstances(ids...)
+}

--- a/apiserver/common/environdestroy_test.go
+++ b/apiserver/common/environdestroy_test.go
@@ -1,0 +1,278 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/client"
+	"github.com/juju/juju/apiserver/common"
+	commontesting "github.com/juju/juju/apiserver/common/testing"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/state"
+	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type destroyEnvironmentSuite struct {
+	testing.JujuConnSuite
+	commontesting.BlockHelper
+}
+
+var _ = gc.Suite(&destroyEnvironmentSuite{})
+
+func (s *destroyEnvironmentSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
+	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
+}
+
+// setUpManual adds "manually provisioned" machines to state:
+// one manager machine, and one non-manager.
+func (s *destroyEnvironmentSuite) setUpManual(c *gc.C) (m0, m1 *state.Machine) {
+	m0, err := s.State.AddMachine("precise", state.JobManageEnviron)
+	c.Assert(err, jc.ErrorIsNil)
+	err = m0.SetProvisioned(instance.Id("manual:0"), "manual:0:fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	m1, err = s.State.AddMachine("precise", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = m1.SetProvisioned(instance.Id("manual:1"), "manual:1:fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	return m0, m1
+}
+
+// setUpInstances adds machines to state backed by instances:
+// one manager machine, one non-manager, and a container in the
+// non-manager.
+func (s *destroyEnvironmentSuite) setUpInstances(c *gc.C) (m0, m1, m2 *state.Machine) {
+	m0, err := s.State.AddMachine("precise", state.JobManageEnviron)
+	c.Assert(err, jc.ErrorIsNil)
+	inst, _ := testing.AssertStartInstance(c, s.Environ, m0.Id())
+	err = m0.SetProvisioned(inst.Id(), "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m1, err = s.State.AddMachine("precise", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	inst, _ = testing.AssertStartInstance(c, s.Environ, m1.Id())
+	err = m1.SetProvisioned(inst.Id(), "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m2, err = s.State.AddMachineInsideMachine(state.MachineTemplate{
+		Series: "precise",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	}, m1.Id(), instance.LXC)
+	c.Assert(err, jc.ErrorIsNil)
+	err = m2.SetProvisioned("container0", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	return m0, m1, m2
+}
+
+func (s *destroyEnvironmentSuite) TestDestroyEnvironmentManual(c *gc.C) {
+	_, nonManager := s.setUpManual(c)
+
+	// If there are any non-manager manual machines in state, DestroyEnvironment will
+	// error. It will not set the Dying flag on the environment.
+	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("failed to destroy environment: manually provisioned machines must first be destroyed with `juju destroy-machine %s`", nonManager.Id()))
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Alive)
+
+	// If we remove the non-manager machine, it should pass.
+	// Manager machines will remain.
+	err = nonManager.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = nonManager.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+	err = common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroyEnvironmentSuite) TestDestroyEnvironment(c *gc.C) {
+	manager, nonManager, _ := s.setUpInstances(c)
+	managerId, _ := manager.InstanceId()
+	nonManagerId, _ := nonManager.InstanceId()
+
+	instances, err := s.Environ.Instances([]instance.Id{managerId, nonManagerId})
+	c.Assert(err, jc.ErrorIsNil)
+	for _, inst := range instances {
+		c.Assert(inst, gc.NotNil)
+	}
+
+	services, err := s.State.AllServices()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// After DestroyEnvironment returns, we should have:
+	//   - all non-manager instances stopped
+	instances, err = s.Environ.Instances([]instance.Id{managerId, nonManagerId})
+	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
+	c.Assert(instances[0], gc.NotNil)
+	c.Assert(instances[1], jc.ErrorIsNil)
+	//   - all services in state are Dying or Dead (or removed altogether),
+	//     after running the state Cleanups.
+	needsCleanup, err := s.State.NeedsCleanup()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(needsCleanup, jc.IsTrue)
+	err = s.State.Cleanup()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, s := range services {
+		err = s.Refresh()
+		if err != nil {
+			c.Assert(err, jc.Satisfies, errors.IsNotFound)
+		} else {
+			c.Assert(s.Life(), gc.Not(gc.Equals), state.Alive)
+		}
+	}
+	//   - environment is Dying
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroyEnvironmentSuite) TestDestroyEnvironmentWithContainers(c *gc.C) {
+	ops := make(chan dummy.Operation, 500)
+	dummy.Listen(ops)
+
+	_, nonManager, _ := s.setUpInstances(c)
+	nonManagerId, _ := nonManager.InstanceId()
+
+	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+	for op := range ops {
+		if op, ok := op.(dummy.OpStopInstances); ok {
+			c.Assert(op.Ids, jc.SameContents, []instance.Id{nonManagerId})
+			break
+		}
+	}
+}
+
+func (s *destroyEnvironmentSuite) TestBlockDestroyDestroyEnvironment(c *gc.C) {
+	// Setup environment
+	s.setUpInstances(c)
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyDestroyEnvironment")
+	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	s.AssertBlocked(c, err, "TestBlockDestroyDestroyEnvironment")
+}
+
+func (s *destroyEnvironmentSuite) TestBlockRemoveDestroyEnvironment(c *gc.C) {
+	// Setup environment
+	s.setUpInstances(c)
+	s.BlockRemoveObject(c, "TestBlockRemoveDestroyEnvironment")
+	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	s.AssertBlocked(c, err, "TestBlockRemoveDestroyEnvironment")
+}
+
+func (s *destroyEnvironmentSuite) TestBlockChangesDestroyEnvironment(c *gc.C) {
+	// Setup environment
+	s.setUpInstances(c)
+	// lock environment: can't destroy locked environment
+	s.BlockAllChanges(c, "TestBlockChangesDestroyEnvironment")
+	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	s.AssertBlocked(c, err, "TestBlockChangesDestroyEnvironment")
+}
+
+type destroyTwoEnvironmentsSuite struct {
+	testing.JujuConnSuite
+	otherState     *state.State
+	otherEnvOwner  names.UserTag
+	otherEnvClient *client.Client
+}
+
+var _ = gc.Suite(&destroyTwoEnvironmentsSuite{})
+
+func (s *destroyTwoEnvironmentsSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.otherEnvOwner = names.NewUserTag("jess@dummy")
+	s.otherState = factory.NewFactory(s.State).MakeEnvironment(c, &factory.EnvParams{
+		Owner:   s.otherEnvOwner,
+		Prepare: true,
+		ConfigAttrs: jujutesting.Attrs{
+			"state-server": false,
+		},
+	})
+	s.AddCleanup(func(*gc.C) { s.otherState.Close() })
+
+	// get the client for the other environment
+	auth := apiservertesting.FakeAuthorizer{
+		Tag:            s.otherEnvOwner,
+		EnvironManager: false,
+	}
+	var err error
+	s.otherEnvClient, err = client.NewClient(s.otherState, common.NewResources(), auth)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestCleanupEnvironDocs(c *gc.C) {
+	otherFactory := factory.NewFactory(s.otherState)
+	otherFactory.MakeMachine(c, nil)
+	m := otherFactory.MakeMachine(c, nil)
+	otherFactory.MakeMachineNested(c, m.Id(), nil)
+
+	err := common.DestroyEnvironment(s.otherState, s.otherState.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.otherState.Environment()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+
+	_, err = s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.otherState.EnsureEnvironmentRemoved(), jc.ErrorIsNil)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDifferentStateEnv(c *gc.C) {
+	otherFactory := factory.NewFactory(s.otherState)
+	otherFactory.MakeMachine(c, nil)
+	m := otherFactory.MakeMachine(c, nil)
+	otherFactory.MakeMachineNested(c, m.Id(), nil)
+
+	// NOTE: pass in the main test State instance, which is 'bound'
+	// to the state server environment.
+	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.otherState.Environment()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+
+	_, err = s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.otherState.EnsureEnvironmentRemoved(), jc.ErrorIsNil)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroyStateServerAfterNonStateServerIsDestroyed(c *gc.C) {
+	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	c.Assert(err, gc.ErrorMatches, "failed to destroy environment: state server environment cannot be destroyed before all other environments are destroyed")
+	err = common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestCanDestroyNonBlockedEnv(c *gc.C) {
+	bh := commontesting.NewBlockHelper(s.APIState)
+	defer bh.Close()
+
+	bh.BlockDestroyEnvironment(c, "TestBlockDestroyDestroyEnvironment")
+
+	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	bh.AssertBlocked(c, err, "TestBlockDestroyDestroyEnvironment")
+}

--- a/apiserver/machinemanager/machinemanager_test.go
+++ b/apiserver/machinemanager/machinemanager_test.go
@@ -170,3 +170,7 @@ func (st *mockBlock) Type() state.BlockType {
 func (st *mockBlock) Message() string {
 	return "not allowed"
 }
+
+func (st *mockBlock) EnvUUID() string {
+	return "uuid"
+}

--- a/apiserver/params/systemmanager.go
+++ b/apiserver/params/systemmanager.go
@@ -1,0 +1,31 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+// DestroySystemArgs holds the arguments for destroying a system.
+type DestroySystemArgs struct {
+	// DestroyEnvironments specifies whether or not the hosted environments
+	// should be destroyed as well. If this is not specified, and there are
+	// other hosted environments, the destruction of the system will fail.
+	DestroyEnvironments bool `json:"destroy-environments"`
+
+	// IgnoreBlocks specifies whether or not to ignore blocks
+	// on hosted environments.
+	IgnoreBlocks bool `json:"ignore-blocks"`
+}
+
+// EnvironmentBlockInfo holds information about an environment and its
+// current blocks.
+type EnvironmentBlockInfo struct {
+	Name     string   `json:"name"`
+	UUID     string   `json:"env-uuid"`
+	OwnerTag string   `json:"owner-tag"`
+	Blocks   []string `json:"blocks"`
+}
+
+// EnvironmentBlockInfoList holds information about the blocked environments
+// for a system.
+type EnvironmentBlockInfoList struct {
+	Environments []EnvironmentBlockInfo `json:"environments,omitempty"`
+}

--- a/apiserver/restricted_root.go
+++ b/apiserver/restricted_root.go
@@ -27,6 +27,7 @@ func newRestrictedRoot(finder rpc.MethodFinder) *restrictedRoot {
 // boundaries.
 var restrictedRootNames = set.NewStrings(
 	"EnvironmentManager",
+	"SystemManager",
 	"UserManager",
 )
 

--- a/apiserver/restricted_root_test.go
+++ b/apiserver/restricted_root_test.go
@@ -41,6 +41,11 @@ func (r *restrictedRootSuite) TestFindAllowedMethod(c *gc.C) {
 	r.assertMethodAllowed(c, "UserManager", 0, "AddUser")
 	r.assertMethodAllowed(c, "UserManager", 0, "SetPassword")
 	r.assertMethodAllowed(c, "UserManager", 0, "UserInfo")
+
+	r.assertMethodAllowed(c, "SystemManager", 1, "AllEnvironments")
+	r.assertMethodAllowed(c, "SystemManager", 1, "DestroySystem")
+	r.assertMethodAllowed(c, "SystemManager", 1, "EnvironmentConfig")
+	r.assertMethodAllowed(c, "SystemManager", 1, "ListBlockedEnvironments")
 }
 
 func (r *restrictedRootSuite) TestFindDisallowedMethod(c *gc.C) {

--- a/apiserver/systemmanager/destroy_test.go
+++ b/apiserver/systemmanager/destroy_test.go
@@ -1,0 +1,182 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	commontesting "github.com/juju/juju/apiserver/common/testing"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/systemmanager"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+// NOTE: the testing of the general environment destruction code
+// is found in apiserver/common/environdestroy_test.go.
+//
+// The tests here are around the validation and behaviour of
+// the flags passed in to the system manager destroy system call.
+
+type destroySystemSuite struct {
+	jujutesting.JujuConnSuite
+	commontesting.BlockHelper
+
+	systemManager *systemmanager.SystemManagerAPI
+
+	otherState    *state.State
+	otherEnvOwner names.UserTag
+	otherEnvUUID  string
+}
+
+var _ = gc.Suite(&destroySystemSuite{})
+
+func (s *destroySystemSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
+	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
+
+	resources := common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
+
+	authoriser := apiservertesting.FakeAuthorizer{
+		Tag: s.AdminUserTag(c),
+	}
+	systemManager, err := systemmanager.NewSystemManagerAPI(s.State, resources, authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	s.systemManager = systemManager
+
+	s.otherEnvOwner = names.NewUserTag("jess@dummy")
+	s.otherState = factory.NewFactory(s.State).MakeEnvironment(c, &factory.EnvParams{
+		Name:    "dummytoo",
+		Owner:   s.otherEnvOwner,
+		Prepare: true,
+		ConfigAttrs: testing.Attrs{
+			"state-server": false,
+		},
+	})
+	s.AddCleanup(func(c *gc.C) { s.otherState.Close() })
+	s.otherEnvUUID = s.otherState.EnvironUUID()
+}
+
+func (s *destroySystemSuite) TestDestroySystemKillsHostedEnvsWithBlocks(c *gc.C) {
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+	s.otherState.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.otherState.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	err := s.systemManager.DestroySystem(params.DestroySystemArgs{
+		DestroyEnvironments: true,
+		IgnoreBlocks:        true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.otherState.Environment()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroySystemSuite) TestDestroySystemReturnsBlockedEnvironmentsErr(c *gc.C) {
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+	s.otherState.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.otherState.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	err := s.systemManager.DestroySystem(params.DestroySystemArgs{
+		DestroyEnvironments: true,
+	})
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+
+	numBlocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(numBlocks), gc.Equals, 4)
+
+	_, err = s.otherState.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *destroySystemSuite) TestDestroySystemKillsHostedEnvs(c *gc.C) {
+	err := s.systemManager.DestroySystem(params.DestroySystemArgs{
+		DestroyEnvironments: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.otherState.Environment()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroySystemSuite) TestDestroySystemLeavesBlocksIfNotKillAll(c *gc.C) {
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+	s.otherState.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.otherState.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	err := s.systemManager.DestroySystem(params.DestroySystemArgs{
+		IgnoreBlocks: true,
+	})
+	c.Assert(err, gc.ErrorMatches, "state server environment cannot be destroyed before all other environments are destroyed")
+
+	numBlocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(numBlocks), gc.Equals, 4)
+}
+
+func (s *destroySystemSuite) TestDestroySystemNoHostedEnvs(c *gc.C) {
+	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.systemManager.DestroySystem(params.DestroySystemArgs{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroySystemSuite) TestDestroySystemNoHostedEnvsWithBlock(c *gc.C) {
+	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+
+	err = s.systemManager.DestroySystem(params.DestroySystemArgs{
+		IgnoreBlocks: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+}
+
+func (s *destroySystemSuite) TestDestroySystemNoHostedEnvsWithBlockFail(c *gc.C) {
+	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
+	s.BlockRemoveObject(c, "TestBlockRemoveObject")
+
+	err = s.systemManager.DestroySystem(params.DestroySystemArgs{})
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+
+	numBlocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(numBlocks), gc.Equals, 2)
+}

--- a/apiserver/systemmanager/package_test.go
+++ b/apiserver/systemmanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -215,7 +215,7 @@ func (s *SystemManagerAPI) DestroySystem(args params.DestroySystemArgs) error {
 			environTag := env.EnvironTag()
 			if environTag != systemTag {
 				if err := common.DestroyEnvironment(s.state, environTag); err != nil {
-					logger.Warningf("unable to destroy environment %q: %s", env.UUID(), err)
+					logger.Errorf("unable to destroy environment %q: %s", env.UUID(), err)
 				}
 			}
 		}

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -1,0 +1,307 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The systemmanager package defines an API end point for functions dealing
+// with systems as a whole. Primarily the destruction of systems.
+package systemmanager
+
+import (
+	"github.com/juju/utils/set"
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/state"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.systemmanager")
+
+func init() {
+	common.RegisterStandardFacadeForFeature("SystemManager", 1, NewSystemManagerAPI, feature.JES)
+}
+
+// SystemManager defines the methods on the systemmanager API end point.
+type SystemManager interface {
+	AllEnvironments() (params.UserEnvironmentList, error)
+	DestroySystem(args params.DestroySystemArgs) error
+	EnvironmentConfig() (params.EnvironmentConfigResults, error)
+	ListBlockedEnvironments() (params.EnvironmentBlockInfoList, error)
+}
+
+// SystemManagerAPI implements the environment manager interface and is
+// the concrete implementation of the api end point.
+type SystemManagerAPI struct {
+	state      *state.State
+	authorizer common.Authorizer
+	apiUser    names.UserTag
+}
+
+var _ SystemManager = (*SystemManagerAPI)(nil)
+
+// NewSystemManagerAPI creates a new api server endpoint for managing
+// environments.
+func NewSystemManagerAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*SystemManagerAPI, error) {
+	if !authorizer.AuthClient() {
+		return nil, errors.Trace(common.ErrPerm)
+	}
+
+	// Since we know this is a user tag (because AuthClient is true),
+	// we just do the type assertion to the UserTag.
+	apiUser, _ := authorizer.GetAuthTag().(names.UserTag)
+	isAdmin, err := st.IsSystemAdministrator(apiUser)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// The entire end point is only accessible to system administrators.
+	if !isAdmin {
+		return nil, errors.Trace(common.ErrPerm)
+	}
+
+	return &SystemManagerAPI{
+		state:      st,
+		authorizer: authorizer,
+		apiUser:    apiUser,
+	}, nil
+}
+
+// AllEnvironments allows system administrators to get the list of all the
+// environments in the system.
+func (s *SystemManagerAPI) AllEnvironments() (params.UserEnvironmentList, error) {
+	result := params.UserEnvironmentList{}
+
+	// Get all the environments that the authenticated user can see, and
+	// supplement that with the other environments that exist that the user
+	// cannot see. The reason we do this is to get the LastConnection time for
+	// the environments that the user is able to see, so we have consistent
+	// output when listing with or without --all when an admin user.
+	environments, err := s.state.EnvironmentsForUser(s.apiUser)
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	visibleEnvironments := set.NewStrings()
+	for _, env := range environments {
+		visibleEnvironments.Add(env.UUID())
+		result.UserEnvironments = append(result.UserEnvironments, params.UserEnvironment{
+			Environment: params.Environment{
+				Name:     env.Name(),
+				UUID:     env.UUID(),
+				OwnerTag: env.Owner().String(),
+			},
+			LastConnection: env.LastConnection,
+		})
+	}
+
+	allEnvs, err := s.state.AllEnvironments()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	for _, env := range allEnvs {
+		if !visibleEnvironments.Contains(env.UUID()) {
+			result.UserEnvironments = append(result.UserEnvironments, params.UserEnvironment{
+				Environment: params.Environment{
+					Name:     env.Name(),
+					UUID:     env.UUID(),
+					OwnerTag: env.Owner().String(),
+				},
+				// No LastConnection as this user hasn't.
+			})
+		}
+	}
+
+	// Sort the resulting sequence by environment name, then owner.
+	sort.Sort(orderedUserEnvironments(result.UserEnvironments))
+
+	return result, nil
+}
+
+// ListBlockedEnvironments returns a list of all environments on the system
+// which have a block in place.  The resulting slice is sorted by environment
+// name, then owner. Callers must be system administrators to retrieve the
+// list.
+func (s *SystemManagerAPI) ListBlockedEnvironments() (params.EnvironmentBlockInfoList, error) {
+	results := params.EnvironmentBlockInfoList{}
+
+	blocks, err := s.state.AllBlocksForSystem()
+	if err != nil {
+		return results, errors.Trace(err)
+	}
+
+	envBlocks := make(map[string][]string)
+	for _, block := range blocks {
+		uuid := block.EnvUUID()
+		types, ok := envBlocks[uuid]
+		if !ok {
+			types = []string{block.Type().String()}
+		} else {
+			types = append(types, block.Type().String())
+		}
+		envBlocks[uuid] = types
+	}
+
+	for uuid, blocks := range envBlocks {
+		envInfo, err := s.state.GetEnvironment(names.NewEnvironTag(uuid))
+		if err != nil {
+			logger.Debugf("Unable to get name for environment: %s", uuid)
+			continue
+		}
+		results.Environments = append(results.Environments, params.EnvironmentBlockInfo{
+			UUID:     envInfo.UUID(),
+			Name:     envInfo.Name(),
+			OwnerTag: envInfo.Owner().String(),
+			Blocks:   blocks,
+		})
+	}
+
+	// Sort the resulting sequence by environment name, then owner.
+	sort.Sort(orderedBlockInfo(results.Environments))
+
+	return results, nil
+}
+
+// DestroySystem will attempt to destroy the system. If the args specify the
+// removal of blocks or the destruction of the environments, this method will
+// attempt to do so.
+func (s *SystemManagerAPI) DestroySystem(args params.DestroySystemArgs) error {
+	// Get list of all environments in the system.
+	allEnvs, err := s.state.AllEnvironments()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// If there are hosted environments and DestroyEnvironments was not
+	// specified, don't bother trying to destroy the system, as it will fail.
+	if len(allEnvs) > 1 && !args.DestroyEnvironments {
+		return errors.Errorf("state server environment cannot be destroyed before all other environments are destroyed")
+	}
+
+	// If there are blocks, and we aren't being told to ignore them, let the
+	// user know.
+	blocks, err := s.state.AllBlocksForSystem()
+	if err != nil {
+		logger.Debugf("Unable to get blocks for system: %s", err)
+		if !args.IgnoreBlocks {
+			return errors.Trace(err)
+		}
+	}
+	if len(blocks) > 0 {
+		if !args.IgnoreBlocks {
+			return common.ErrOperationBlocked("found blocks in system environments")
+		}
+
+		err := s.state.RemoveAllBlocksForSystem()
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	systemEnv, err := s.state.StateServerEnvironment()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	systemTag := systemEnv.EnvironTag()
+
+	if args.DestroyEnvironments {
+		for _, env := range allEnvs {
+			environTag := env.EnvironTag()
+			if environTag != systemTag {
+				if err := common.DestroyEnvironment(s.state, environTag); err != nil {
+					logger.Warningf("unable to destroy environment %q: %s", env.UUID(), err)
+				}
+			}
+		}
+	}
+
+	return errors.Trace(common.DestroyEnvironment(s.state, systemTag))
+}
+
+// EnvironmentConfig returns the environment config for the system
+// environment.  For information on the current environment, use
+// client.EnvironmentGet
+func (s *SystemManagerAPI) EnvironmentConfig() (params.EnvironmentConfigResults, error) {
+	result := params.EnvironmentConfigResults{}
+
+	stateServerEnv, err := s.state.StateServerEnvironment()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	config, err := stateServerEnv.Config()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	result.Config = config.AllAttrs()
+	return result, nil
+}
+
+type orderedBlockInfo []params.EnvironmentBlockInfo
+
+func (o orderedBlockInfo) Len() int {
+	return len(o)
+}
+
+func (o orderedBlockInfo) Less(i, j int) bool {
+	if o[i].Name < o[j].Name {
+		return true
+	}
+	if o[i].Name > o[j].Name {
+		return false
+	}
+
+	if o[i].OwnerTag < o[j].OwnerTag {
+		return true
+	}
+	if o[i].OwnerTag > o[j].OwnerTag {
+		return false
+	}
+
+	// Unreachable based on the rules of there not being duplicate
+	// environments of the same name for the same owner, but return false
+	// instead of panicing.
+	return false
+}
+
+func (o orderedBlockInfo) Swap(i, j int) {
+	o[i], o[j] = o[j], o[i]
+}
+
+type orderedUserEnvironments []params.UserEnvironment
+
+func (o orderedUserEnvironments) Len() int {
+	return len(o)
+}
+
+func (o orderedUserEnvironments) Less(i, j int) bool {
+	if o[i].Name < o[j].Name {
+		return true
+	}
+	if o[i].Name > o[j].Name {
+		return false
+	}
+
+	if o[i].OwnerTag < o[j].OwnerTag {
+		return true
+	}
+	if o[i].OwnerTag > o[j].OwnerTag {
+		return false
+	}
+
+	// Unreachable based on the rules of there not being duplicate
+	// environments of the same name for the same owner, but return false
+	// instead of panicing.
+	return false
+}
+
+func (o orderedUserEnvironments) Swap(i, j int) {
+	o[i], o[j] = o[j], o[i]
+}

--- a/apiserver/systemmanager/systemmanager_test.go
+++ b/apiserver/systemmanager/systemmanager_test.go
@@ -1,0 +1,158 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager_test
+
+import (
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/systemmanager"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+type systemManagerSuite struct {
+	jujutesting.JujuConnSuite
+
+	systemManager *systemmanager.SystemManagerAPI
+	resources     *common.Resources
+}
+
+var _ = gc.Suite(&systemManagerSuite{})
+
+func (s *systemManagerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	authoriser := apiservertesting.FakeAuthorizer{
+		Tag: s.AdminUserTag(c),
+	}
+
+	systemManager, err := systemmanager.NewSystemManagerAPI(s.State, s.resources, authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	s.systemManager = systemManager
+
+	loggo.GetLogger("juju.apiserver.systemmanager").SetLogLevel(loggo.TRACE)
+}
+
+func (s *systemManagerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
+	anAuthoriser := apiservertesting.FakeAuthorizer{
+		Tag: names.NewUnitTag("mysql/0"),
+	}
+	endPoint, err := systemmanager.NewSystemManagerAPI(s.State, s.resources, anAuthoriser)
+	c.Assert(endPoint, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *systemManagerSuite) TestNewAPIRefusesNonAdmins(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{NoEnvUser: true})
+	anAuthoriser := apiservertesting.FakeAuthorizer{
+		Tag: user.Tag(),
+	}
+	endPoint, err := systemmanager.NewSystemManagerAPI(s.State, s.resources, anAuthoriser)
+	c.Assert(endPoint, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *systemManagerSuite) checkEnvironmentMatches(c *gc.C, env params.Environment, expected *state.Environment) {
+	c.Check(env.Name, gc.Equals, expected.Name())
+	c.Check(env.UUID, gc.Equals, expected.UUID())
+	c.Check(env.OwnerTag, gc.Equals, expected.Owner().String())
+}
+
+func (s *systemManagerSuite) TestAllEnvironments(c *gc.C) {
+	admin := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
+
+	s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "owned", Owner: admin.UserTag()}).Close()
+	remoteUserTag := names.NewUserTag("user@remote")
+	st := s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "user", Owner: remoteUserTag})
+	defer st.Close()
+	st.AddEnvironmentUser(admin.UserTag(), remoteUserTag, "Foo Bar")
+
+	s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "no-access", Owner: remoteUserTag}).Close()
+
+	response, err := s.systemManager.AllEnvironments()
+	c.Assert(err, jc.ErrorIsNil)
+	// The results are sorted.
+	expected := []string{"dummyenv", "no-access", "owned", "user"}
+	var obtained []string
+	for _, env := range response.UserEnvironments {
+		obtained = append(obtained, env.Name)
+		stateEnv, err := s.State.GetEnvironment(names.NewEnvironTag(env.UUID))
+		c.Assert(err, jc.ErrorIsNil)
+		s.checkEnvironmentMatches(c, env.Environment, stateEnv)
+	}
+	c.Assert(obtained, jc.DeepEquals, expected)
+}
+
+func (s *systemManagerSuite) TestListBlockedEnvironments(c *gc.C) {
+	st := s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "test"})
+	defer st.Close()
+
+	s.State.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.State.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	st.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	list, err := s.systemManager.ListBlockedEnvironments()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(list.Environments, jc.DeepEquals, []params.EnvironmentBlockInfo{
+		params.EnvironmentBlockInfo{
+			Name:     "dummyenv",
+			UUID:     s.State.EnvironUUID(),
+			OwnerTag: s.AdminUserTag(c).String(),
+			Blocks: []string{
+				"BlockDestroy",
+				"BlockChange",
+			},
+		},
+		params.EnvironmentBlockInfo{
+			Name:     "test",
+			UUID:     st.EnvironUUID(),
+			OwnerTag: s.AdminUserTag(c).String(),
+			Blocks: []string{
+				"BlockDestroy",
+				"BlockChange",
+			},
+		},
+	})
+
+}
+
+func (s *systemManagerSuite) TestListBlockedEnvironmentsNoBlocks(c *gc.C) {
+	list, err := s.systemManager.ListBlockedEnvironments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(list.Environments), gc.Equals, 0)
+}
+
+func (s *systemManagerSuite) TestEnvironmentConfig(c *gc.C) {
+	env, err := s.systemManager.EnvironmentConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Config["name"], gc.Equals, "dummyenv")
+}
+
+func (s *systemManagerSuite) TestEnvironmentConfigFromNonStateServer(c *gc.C) {
+	st := s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "test"})
+	defer st.Close()
+
+	authorizer := &apiservertesting.FakeAuthorizer{Tag: s.AdminUserTag(c)}
+	systemManager, err := systemmanager.NewSystemManagerAPI(st, common.NewResources(), authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	env, err := systemManager.EnvironmentConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Config["name"], gc.Equals, "dummyenv")
+}


### PR DESCRIPTION
Add a lot of duplication until we remove the methods from the EnvironmentManager.

(Review request: http://reviews.vapour.ws/r/2113/)