### PR TITLE
Add support for deployment directives to deploy command

### DIFF
--- a/api/service/client.go
+++ b/api/service/client.go
@@ -92,10 +92,10 @@ func (c *Client) ServiceDeploy(
 	var err error
 	if len(placement) > 0 {
 		err = c.facade.FacadeCall("ServicesDeployWithPlacement", args, &results)
-		if params.IsCodeNotImplemented(err) {
-			return errors.Errorf("unsupported --to parameter %q", toMachineSpec)
-		}
 		if err != nil {
+			if params.IsCodeNotImplemented(err) {
+				return errors.Errorf("unsupported --to parameter %q", toMachineSpec)
+			}
 			return err
 		}
 	} else {

--- a/api/service/client.go
+++ b/api/service/client.go
@@ -9,13 +9,17 @@ package service
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 )
+
+var logger = loggo.GetLogger("juju.api.service")
 
 // Client allows access to the service API end point.
 type Client struct {
@@ -44,11 +48,22 @@ func (c *Client) SetMetricCredentials(service string, credentials []byte) error 
 	return errors.Trace(results.OneError())
 }
 
+// EnvironmentUUID returns the environment UUID from the client connection.
+func (c *Client) EnvironmentUUID() string {
+	tag, err := c.st.EnvironTag()
+	if err != nil {
+		logger.Warningf("environ tag not an environ: %v", err)
+		return ""
+	}
+	return tag.Id()
+}
+
 // ServiceDeploy obtains the charm, either locally or from
 // the charm store, and deploys it. It allows the specification of
 // requested networks that must be present on the machines where the
 // service is deployed. Another way to specify networks to include/exclude
-// is using constraints.
+// is using constraints. Placement directives, if provided, specify the
+// machine on which the charm is deployed.
 func (c *Client) ServiceDeploy(
 	charmURL string,
 	serviceName string,
@@ -56,6 +71,7 @@ func (c *Client) ServiceDeploy(
 	configYAML string,
 	cons constraints.Value,
 	toMachineSpec string,
+	placement []*instance.Placement,
 	networks []string,
 	storage map[string]storage.Constraints,
 ) error {
@@ -67,12 +83,24 @@ func (c *Client) ServiceDeploy(
 			ConfigYAML:    configYAML,
 			Constraints:   cons,
 			ToMachineSpec: toMachineSpec,
+			Placement:     placement,
 			Networks:      networks,
 			Storage:       storage,
 		}},
 	}
 	var results params.ErrorResults
-	err := c.facade.FacadeCall("ServicesDeploy", args, &results)
+	var err error
+	if len(placement) > 0 {
+		err = c.facade.FacadeCall("ServicesDeployWithPlacement", args, &results)
+		if params.IsCodeNotImplemented(err) {
+			return errors.Errorf("unsupported --to parameter %q", toMachineSpec)
+		}
+		if err != nil {
+			return err
+		}
+	} else {
+		err = c.facade.FacadeCall("ServicesDeploy", args, &results)
+	}
 	if err != nil {
 		return err
 	}

--- a/api/service/client_test.go
+++ b/api/service/client_test.go
@@ -95,7 +95,7 @@ func (s *serviceSuite) TestSetServiceDeploy(c *gc.C) {
 		return nil
 	})
 	err := s.client.ServiceDeploy("charmURL", "serviceA", 2, "configYAML", constraints.MustParse("mem=4G"),
-		"machineSpec", []string{"neta"}, map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}})
+		"machineSpec", nil, []string{"neta"}, map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -200,6 +200,7 @@ type ServiceDeploy struct {
 	ConfigYAML    string // Takes precedence over config if both are present.
 	Constraints   constraints.Value
 	ToMachineSpec string
+	Placement     []*instance.Placement
 	Networks      []string
 	Storage       map[string]storage.Constraints
 }

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -232,6 +232,7 @@ func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
 				{Scope: "#", Directive: "0"},
 				{Scope: "lxc", Directive: "1"},
 			},
+			ToMachineSpec: "will be ignored",
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertConstraints(c, service, serviceCons)


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1358941

Following on from the previous branch, this one adds support for placement directives to the initial deploy command.

(Review request: http://reviews.vapour.ws/r/2114/)