### PR TITLE
Delete device on address release

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1263,7 +1263,7 @@ func (p *ProvisionerAPI) setAllocatedOrRelease(
 				addr.String(), state.AddressStateUnavailable, err,
 			)
 		}
-		err = environ.ReleaseAddress(instId, subnetId, addr.Address())
+		err = environ.ReleaseAddress(instId, subnetId, addr.Address(), addr.MACAddress())
 		if err == nil {
 			logger.Infof("address %q released; trying to allocate new", addr.String())
 			return

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -20,7 +20,7 @@ type Networking interface {
 
 	// ReleaseAddress releases a specific address previously allocated with
 	// AllocateAddress.
-	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address) error
+	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error
 
 	// Subnets returns basic information about subnets known
 	// by the provider for the environment.

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -201,7 +201,7 @@ func (env *environ) StopInstances(instances ...instance.Id) error {
 func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address, macAddress, hostname string) error {
 	return errors.NotSupportedf("AllocateAddress")
 }
-func (env *environ) ReleaseAddress(instId instance.Id, netId network.Id, addr network.Address) error {
+func (env *environ) ReleaseAddress(instId instance.Id, netId network.Id, addr network.Address, macAddress string) error {
 	return errors.NotSupportedf("ReleaseAddress")
 }
 func (env *environ) Subnets(inst instance.Id) ([]network.SubnetInfo, error) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -174,6 +174,7 @@ type OpReleaseAddress struct {
 	InstanceId instance.Id
 	SubnetId   network.Id
 	Address    network.Address
+	MACAddress string
 }
 
 type OpNetworkInterfaces struct {
@@ -1123,7 +1124,7 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
-func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}
@@ -1143,6 +1144,7 @@ func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr
 		InstanceId: instId,
 		SubnetId:   subnetId,
 		Address:    addr,
+		MACAddress: macAddress,
 	}
 	return nil
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -818,7 +818,7 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
-func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, _ string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -808,12 +808,12 @@ func (t *localServerSuite) TestReleaseAddress(c *gc.C) {
 	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = env.ReleaseAddress(instId, "", addr)
+	err = env.ReleaseAddress(instId, "", addr, "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Releasing a second time tests that the first call actually released
 	// it plus tests the error handling of ReleaseAddress
-	err = env.ReleaseAddress(instId, "", addr)
+	err = env.ReleaseAddress(instId, "", addr, "")
 	msg := fmt.Sprintf(`failed to release address "8\.0\.0\.4" from instance %q.*`, instId)
 	c.Assert(err, gc.ErrorMatches, msg)
 }
@@ -824,7 +824,7 @@ func (t *localServerSuite) TestReleaseAddressUnknownInstance(c *gc.C) {
 	// We should be able to release an address with an unknown instance id
 	// without it being allocated.
 	addr := network.Address{Value: "8.0.0.4"}
-	err := env.ReleaseAddress(instance.UnknownId, "", addr)
+	err := env.ReleaseAddress(instance.UnknownId, "", addr, "")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -909,7 +909,7 @@ func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
 func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
 	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
-	err := env.ReleaseAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	err := env.ReleaseAddress("i-foo", "net1", network.NewAddress("1.2.3.4"), "")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -17,7 +17,7 @@ func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr n
 }
 
 // ReleaseAddress implements environs.Environ, but is not implmemented.
-func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address) error {
+func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, macAddres string) error {
 	return errors.Trace(errNotImplemented)
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1391,21 +1391,21 @@ func (environ *maasEnviron) fetchFullDevice(macAddress string) (map[string]gomaa
 	params.Add("mac_address", macAddress)
 	result, err := devices.CallGet("list", params)
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	resultArray, err := result.GetArray()
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	if len(resultArray) == 0 {
-		return "", errors.NotFoundf("no device for MAC %q", macAddress)
+		return nil, errors.NotFoundf("no device for MAC %q", macAddress)
 	}
 	if len(resultArray) != 1 {
-		return "", errors.Errorf("unexpected response, expected 1 device got %d", len(resultArray))
+		return nil, errors.Errorf("unexpected response, expected 1 device got %d", len(resultArray))
 	}
 	resultMap, err := resultArray[0].GetMap()
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	return resultMap, nil
 }
@@ -1420,7 +1420,7 @@ func (environ *maasEnviron) fetchDevice(macAddress string) (string, error) {
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return device, nil
+	return deviceId, nil
 }
 
 // createOrFetchDevice returns a device Id associated with a MAC address. If
@@ -1533,7 +1533,7 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 		return errors.Trace(err)
 	}
 	if supportsDevices {
-		device, err := environ.fetchFullDevice(macAddres)
+		device, err := environ.fetchFullDevice(macAddress)
 		if errors.IsNotFound(err) {
 			fmt.Printf("%v", device)
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1533,7 +1533,7 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 		return err
 	}
 
-	logger.Tracef("releasing address: %q, MAC address: %q, supports devices: %v", addr, macAddress, supportsDevices)
+	logger.Infof("releasing address: %q, MAC address: %q, supports devices: %v", addr, macAddress, supportsDevices)
 	// Addresses originally allocated without a device will have macAddress
 	// set to "". We shouldn't look for a device for these addresses.
 	if supportsDevices && macAddress != "" {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1533,6 +1533,7 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 		return err
 	}
 
+	logger.Trace("releasing address: %q, MAC address: %q, supports devices: %v", addr, macAddress, supportsDevices)
 	// Addresses originally allocated without a device will have macAddress
 	// set to "". We shouldn't look for a device for these addresses.
 	if supportsDevices && macAddress != "" {
@@ -1553,11 +1554,10 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 				// could change and this code will continue to work.
 				// The device is only destroyed when we come to release
 				// the last address. Race conditions aside.
-				deviceAPI := environ.getMAASClient().GetSubObject("device").GetSubObject(systemId)
+				deviceAPI := environ.getMAASClient().GetSubObject("devices").GetSubObject(systemId)
 				err = deviceAPI.Delete()
 				return err
 			}
-
 		} else if !errors.IsNotFound(err) {
 			return err
 		}

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1532,7 +1532,10 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 	if err != nil {
 		return err
 	}
-	if supportsDevices {
+
+	// Addresses originally allocated without a device will have macAddress
+	// set to "". We shouldn't look for a device for these addresses.
+	if supportsDevices && macAddress != "" {
 		device, err := environ.fetchFullDevice(macAddress)
 		if errors.IsNotFound(err) {
 			addresses, err := device["ip_addresses"].GetArray()

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1537,7 +1537,7 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 	// set to "". We shouldn't look for a device for these addresses.
 	if supportsDevices && macAddress != "" {
 		device, err := environ.fetchFullDevice(macAddress)
-		if errors.IsNotFound(err) {
+		if err == nil {
 			addresses, err := device["ip_addresses"].GetArray()
 			if err != nil {
 				return err
@@ -1558,7 +1558,7 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 				return err
 			}
 
-		} else if err != nil {
+		} else if !errors.IsNotFound(err) {
 			return err
 		}
 		// No device for this IP address, release the address normally.

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1533,7 +1533,7 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 		return err
 	}
 
-	logger.Trace("releasing address: %q, MAC address: %q, supports devices: %v", addr, macAddress, supportsDevices)
+	logger.Tracef("releasing address: %q, MAC address: %q, supports devices: %v", addr, macAddress, supportsDevices)
 	// Addresses originally allocated without a device will have macAddress
 	// set to "". We shouldn't look for a device for these addresses.
 	if supportsDevices && macAddress != "" {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1364,7 +1364,7 @@ func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hos
 	params.Add("mac_addresses", macAddress)
 	params.Add("hostname", hostname)
 	params.Add("parent", extractSystemId(instId))
-	logger.Warningf("creating a new MAAS device for MAC %q, hostname %q, parent %q", macAddress, hostname, string(instId))
+	logger.Tracef("creating a new MAAS device for MAC %q, hostname %q, parent %q", macAddress, hostname, string(instId))
 	result, err := devices.CallPost("new", params)
 	if err != nil {
 		return "", errors.Trace(err)

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1396,12 +1396,13 @@ func (suite *environSuite) TestReleaseAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress)
+	macAddress := "foobar"
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// by releasing again we can test that the first release worked, *and*
 	// the error handling of ReleaseError
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress)
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
 	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q.*", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
 }

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1364,9 +1364,10 @@ func (suite *environSuite) TestReleaseAddressDeletesDevice(c *gc.C) {
 	devicesArray := suite.getDeviceArray(c)
 	c.Assert(devicesArray, gc.HasLen, 1)
 
-	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "bar")
+	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo")
 	c.Assert(err, jc.ErrorIsNil)
 
+	devicesArray = suite.getDeviceArray(c)
 	c.Assert(devicesArray, gc.HasLen, 0)
 }
 

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -17,8 +17,8 @@ func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, add
 	return env.changeAddress(instID, subnetID, addr, true)
 }
 
-// ReleaseAddress implements environs.Environ:w.
-func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address) error {
+// ReleaseAddress implements environs.Environ.
+func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, _ string) error {
 	return env.changeAddress(instID, netID, addr, false)
 }
 

--- a/worker/addresser/worker.go
+++ b/worker/addresser/worker.go
@@ -22,7 +22,7 @@ var logger = loggo.GetLogger("juju.worker.addresser")
 type releaser interface {
 	// ReleaseAddress has the same signature as the same method in the
 	// environs.Networking interface.
-	ReleaseAddress(instance.Id, network.Id, network.Address) error
+	ReleaseAddress(instance.Id, network.Id, network.Address, string) error
 }
 
 // stateAddresser defines the State methods used by the addresserHandler
@@ -105,7 +105,7 @@ func (a *addresserHandler) releaseIPAddress(addr *state.IPAddress) (err error) {
 
 	subnetId := network.Id(addr.SubnetId())
 	for attempt := common.ShortAttempt.Start(); attempt.Next(); {
-		err = a.releaser.ReleaseAddress(addr.InstanceId(), subnetId, addr.Address())
+		err = a.releaser.ReleaseAddress(addr.InstanceId(), subnetId, addr.Address(), addr.MACAddress())
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
If an address was allocated with a device, and it is the last address allocated to that device (with our current code it always will be as we only allocate one address per container) then the device is deleted on address release.

Manually tested against MAAS 1.9.

(Review request: http://reviews.vapour.ws/r/2116/)