### PR TITLE
apiserver: avoid data race in shutdown

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -300,12 +300,6 @@ func (srv *Server) run(lis net.Listener) {
 	defer srv.wg.Wait() // wait for any outstanding requests to complete.
 	srv.wg.Add(1)
 	go func() {
-		<-srv.tomb.Dying()
-		lis.Close()
-		srv.wg.Done()
-	}()
-	srv.wg.Add(1)
-	go func() {
 		err := srv.mongoPinger()
 		srv.tomb.Kill(err)
 		srv.wg.Done()
@@ -381,8 +375,14 @@ func (srv *Server) run(lis net.Listener) {
 		}},
 	)
 	handleAll(mux, "/", http.HandlerFunc(srv.apiHandler))
-	// The error from http.Serve is not interesting.
-	http.Serve(lis, mux)
+
+	go func() {
+		// The error from http.Serve is not interesting.
+		http.Serve(lis, mux)
+	}()
+
+	<-srv.tomb.Dying()
+	lis.Close()
 }
 
 func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Fixes LP 1465115

Ensure that the listening socket is always the first thing that is closed
when Server.Kill or Stop is issued. This avoids a race where requests in
fly may increase the waitgroup count while the final wg.Wait() defer is in
effect.

(Review request: http://reviews.vapour.ws/r/2119/)