### PR TITLE
apiserver: fixed missed call up to BaseSuite.SetUpTest

### DIFF
--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -23,6 +23,7 @@ type debugLogDBIntSuite struct {
 var _ = gc.Suite(&debugLogDBIntSuite{})
 
 func (s *debugLogDBIntSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
 	s.sock = newFakeDebugLogSocket()
 }
 


### PR DESCRIPTION
This was causing the debugLogDBIntSuite to fail under Windows.

(Review request: http://reviews.vapour.ws/r/2124/)