### PR TITLE
Use the system manager endpoint to destroy the system.

### DIFF
--- a/cmd/juju/system/destroy_test.go
+++ b/cmd/juju/system/destroy_test.go
@@ -31,24 +31,26 @@ type DestroySuite struct {
 
 var _ = gc.Suite(&DestroySuite{})
 
-// fakeDestroyAPI mocks out the environmentmanager API
+// fakeDestroyAPI mocks out the systemmanager API
 type fakeDestroyAPI struct {
-	err     error
-	env     map[string]interface{}
-	envUUID string
+	err          error
+	env          map[string]interface{}
+	destroyAll   bool
+	ignoreBlocks bool
 }
 
 func (f *fakeDestroyAPI) Close() error { return nil }
 
-func (f *fakeDestroyAPI) EnvironmentGet() (map[string]interface{}, error) {
+func (f *fakeDestroyAPI) EnvironmentConfig() (map[string]interface{}, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
 	return f.env, nil
 }
 
-func (f *fakeDestroyAPI) DestroyEnvironment(envUUID string) error {
-	f.envUUID = envUUID
+func (f *fakeDestroyAPI) DestroySystem(destroyAll bool, ignoreBlocks bool) error {
+	f.destroyAll = destroyAll
+	f.ignoreBlocks = ignoreBlocks
 	return f.err
 }
 
@@ -177,12 +179,12 @@ func (s *DestroySuite) TestDestroyNonSystemEnvFails(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "\"test2\" is not a system; use juju environment destroy to destroy it")
 }
 
-func (s *DestroySuite) TestDestroySystemNotFoundRemovedFromStore(c *gc.C) {
+func (s *DestroySuite) TestDestroySystemNotFoundNotRemovedFromStore(c *gc.C) {
 	s.apierror = errors.NotFoundf("test1")
-	ctx, err := s.runDestroyCommand(c, "test1", "-y")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "system not found, removing config file\n")
-	checkSystemRemovedFromStore(c, "test1", s.store)
+	_, err := s.runDestroyCommand(c, "test1", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot connect to API: test1 not found")
+	c.Check(c.GetTestLog(), jc.Contains, "If the system is unusable")
+	checkSystemExistsInStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
@@ -196,7 +198,17 @@ func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 func (s *DestroySuite) TestDestroy(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.envUUID, gc.Equals, "test1-uuid")
+	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
+	c.Assert(s.api.destroyAll, jc.IsFalse)
+	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) TestDestroyWithDestroyAllEnvsFlag(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-environments")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
+	c.Assert(s.api.destroyAll, jc.IsTrue)
 	checkSystemRemovedFromStore(c, "test1", s.store)
 }
 
@@ -229,7 +241,8 @@ func (s *DestroySuite) TestFailedDestroyEnvironment(c *gc.C) {
 	s.api.err = errors.New("permission denied")
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy system: permission denied")
-	c.Assert(s.api.envUUID, gc.Equals, "test1-uuid")
+	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
+	c.Assert(s.api.destroyAll, jc.IsFalse)
 	checkSystemExistsInStore(c, "test1", s.store)
 }
 
@@ -258,7 +271,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	_, errc := cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
-		c.Check(err, gc.ErrorMatches, "environment destruction aborted")
+		c.Check(err, gc.ErrorMatches, "system destruction aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
@@ -271,7 +284,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	_, errc = cmdtesting.RunCommand(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
-		c.Check(err, gc.ErrorMatches, "environment destruction aborted")
+		c.Check(err, gc.ErrorMatches, "system destruction aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -74,7 +74,7 @@ func (c *CreateEnvironmentCommand) ConfValues() map[string]string {
 
 // NewDestroyCommand returns a DestroyCommand with the the environmentmanager and client
 // endpoints mocked out.
-func NewDestroyCommand(api destroyEnvironmentAPI, clientapi destroyEnvironmentClientAPI, apierr error) *DestroyCommand {
+func NewDestroyCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error) *DestroyCommand {
 	return &DestroyCommand{
 		api:       api,
 		clientapi: clientapi,


### PR DESCRIPTION
This branch does a few things:
 * uses the system manager api endpoint to destroy the system, which allows removal of other environments
 * falls back to the normal client destroy environment call for older systems
 * removes the removal of the cached config details if there are errors connecting

Some follow up work will be needed I think around managing the cached environment values.

(Review request: http://reviews.vapour.ws/r/2125/)