### PR TITLE
Initialise state server cert with any known existing api server addresses

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1020,7 +1020,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				})
 			}
 			a.startWorkerAfterUpgrade(runner, "certupdater", func() (worker.Worker, error) {
-				return newCertificateUpdater(m, agentConfig, st, stateServingSetter, certChangedChan), nil
+				return newCertificateUpdater(m, agentConfig, st, st, stateServingSetter, certChangedChan), nil
 			})
 
 			if featureflag.Enabled(feature.DbLog) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1387,7 +1387,7 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 func (s *MachineSuite) TestMachineAgentRunsCertificateUpdateWorkerForStateServer(c *gc.C) {
 	started := make(chan struct{})
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
 	) worker.Worker {
 		close(started)
 		return worker.NewNoOpWorker()
@@ -1411,7 +1411,7 @@ func (s *MachineSuite) TestMachineAgentRunsCertificateUpdateWorkerForStateServer
 func (s *MachineSuite) TestMachineAgentDoesNotRunsCertificateUpdateWorkerForNonStateServer(c *gc.C) {
 	started := make(chan struct{})
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
 	) worker.Worker {
 		close(started)
 		return worker.NewNoOpWorker()
@@ -1470,7 +1470,7 @@ func (s *MachineSuite) TestCertificateUpdateWorkerUpdatesCertificate(c *gc.C) {
 func (s *MachineSuite) TestCertificateDNSUpdated(c *gc.C) {
 	// Disable the certificate work so it doesn't update the certificate.
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
 	) worker.Worker {
 		return worker.NewNoOpWorker()
 	}

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -26,9 +27,20 @@ func TestPackage(t *stdtesting.T) {
 
 type CertUpdaterSuite struct {
 	coretesting.BaseSuite
+	stateServingInfo params.StateServingInfo
 }
 
 var _ = gc.Suite(&CertUpdaterSuite{})
+
+func (s *CertUpdaterSuite) SetUpTest(c *gc.C) {
+	s.stateServingInfo = params.StateServingInfo{
+		Cert:         coretesting.ServerCert,
+		PrivateKey:   coretesting.ServerKey,
+		CAPrivateKey: coretesting.CAKey,
+		StatePort:    123,
+		APIPort:      456,
+	}
+}
 
 type mockNotifyWatcher struct {
 	changes <-chan struct{}
@@ -70,16 +82,8 @@ func (m *mockMachine) Addresses() (addresses []network.Address) {
 	}}
 }
 
-type mockStateServingGetter struct{}
-
-func (g *mockStateServingGetter) StateServingInfo() (params.StateServingInfo, bool) {
-	return params.StateServingInfo{
-		Cert:         coretesting.ServerCert,
-		PrivateKey:   coretesting.ServerKey,
-		CAPrivateKey: coretesting.CAKey,
-		StatePort:    123,
-		APIPort:      456,
-	}, true
+func (s *CertUpdaterSuite) StateServingInfo() (params.StateServingInfo, bool) {
+	return s.stateServingInfo, true
 }
 
 type mockConfigGetter struct{}
@@ -89,23 +93,48 @@ func (g *mockConfigGetter) EnvironConfig() (*config.Config, error) {
 
 }
 
+type mockAPIHostGetter struct{}
+
+func (g *mockAPIHostGetter) APIHostPorts() ([][]network.HostPort, error) {
+	return [][]network.HostPort{
+		{
+			{Address: network.Address{Value: "192.168.1.1", Scope: network.ScopeCloudLocal}, Port: 17070},
+			{Address: network.Address{Value: "10.1.1.1", Scope: network.ScopeMachineLocal}, Port: 17070},
+		},
+	}, nil
+}
+
 func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
+	var initialAddresses []string
 	setter := func(info params.StateServingInfo) error {
+		// Only care about first time called.
+		if len(initialAddresses) > 0 {
+			return nil
+		}
+		srvCert, err := cert.ParseCert(info.Cert)
+		c.Assert(err, jc.ErrorIsNil)
+		initialAddresses = make([]string, len(srvCert.IPAddresses))
+		for i, ip := range srvCert.IPAddresses {
+			initialAddresses[i] = ip.String()
+		}
 		return nil
 	}
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, &mockStateServingGetter{}, &mockConfigGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, s, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
 	)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
+	// Initial cert addresses initialised to cloud local ones.
+	c.Assert(initialAddresses, jc.DeepEquals, []string{"192.168.1.1"})
 }
 
 func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	var srvCert *x509.Certificate
 	updated := make(chan struct{})
 	setter := func(info params.StateServingInfo) error {
+		s.stateServingInfo = info
 		var err error
 		srvCert, err = cert.ParseCert(info.Cert)
 		c.Assert(err, jc.ErrorIsNil)
@@ -113,7 +142,8 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 		for i, ip := range srvCert.IPAddresses {
 			sanIPs[i] = ip.String()
 		}
-		if len(sanIPs) == 1 && sanIPs[0] == "0.1.2.3" {
+		sanIPsSet := set.NewStrings(sanIPs...)
+		if sanIPsSet.Size() == 2 && sanIPsSet.Contains("0.1.2.3") && sanIPsSet.Contains("192.168.1.1") {
 			close(updated)
 		}
 		return nil
@@ -121,7 +151,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, &mockStateServingGetter{}, &mockConfigGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, s, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -138,7 +168,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	// name for backwards-compatibility with API clients. They must
 	// also report "juju-mongodb" because these certicates are also
 	// used for serving MongoDB connections.
-	c.Assert(srvCert.DNSNames, gc.DeepEquals,
+	c.Assert(srvCert.DNSNames, jc.SameContents,
 		[]string{"localhost", "juju-apiserver", "juju-mongodb", "anything"})
 }
 
@@ -163,7 +193,7 @@ func (s *CertUpdaterSuite) TestAddressChangeNoCAKey(c *gc.C) {
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, &mockStateServingGetterNoCAKey{}, &mockConfigGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, &mockStateServingGetterNoCAKey{}, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1472014

The machine address watcher is used to notify the state server certificate worker of newly discovered IP addresses so that these can be added to the certificate SAN list. However, the address processing ignores all but one of the machine's local cloud addresses.

To get around the above issue, we update the certificate SAN when the work first starts, using any currently known machine addresses - the known machine addresses come from the recorded state server api hosts.

As an optimisation, do not update certificate unless addresses have changed.

(Review request: http://reviews.vapour.ws/r/2126/)