### PR TITLE
Merge pull request #2747 from wallyworld/complete-san-addresses

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1037,7 +1037,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				})
 			}
 			a.startWorkerAfterUpgrade(runner, "certupdater", func() (worker.Worker, error) {
-				return newCertificateUpdater(m, agentConfig, st, stateServingSetter, certChangedChan), nil
+				return newCertificateUpdater(m, agentConfig, st, st, stateServingSetter, certChangedChan), nil
 			})
 
 			if featureflag.Enabled(feature.DbLog) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1414,7 +1414,7 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 func (s *MachineSuite) TestMachineAgentRunsCertificateUpdateWorkerForStateServer(c *gc.C) {
 	started := make(chan struct{})
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
 	) worker.Worker {
 		close(started)
 		return worker.NewNoOpWorker()
@@ -1438,7 +1438,7 @@ func (s *MachineSuite) TestMachineAgentRunsCertificateUpdateWorkerForStateServer
 func (s *MachineSuite) TestMachineAgentDoesNotRunsCertificateUpdateWorkerForNonStateServer(c *gc.C) {
 	started := make(chan struct{})
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
 	) worker.Worker {
 		close(started)
 		return worker.NewNoOpWorker()
@@ -1497,7 +1497,7 @@ func (s *MachineSuite) TestCertificateUpdateWorkerUpdatesCertificate(c *gc.C) {
 func (s *MachineSuite) TestCertificateDNSUpdated(c *gc.C) {
 	// Disable the certificate work so it doesn't update the certificate.
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
 	) worker.Worker {
 		return worker.NewNoOpWorker()
 	}

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -25,12 +27,13 @@ var logger = loggo.GetLogger("juju.worker.certupdater")
 // that server's machines addresses in state, and write a new certificate to the
 // agent's config file.
 type CertificateUpdater struct {
-	addressWatcher AddressWatcher
-	getter         StateServingInfoGetter
-	setter         StateServingInfoSetter
-	configGetter   EnvironConfigGetter
-	certChanged    chan params.StateServingInfo
-	addresses      []network.Address
+	addressWatcher  AddressWatcher
+	getter          StateServingInfoGetter
+	setter          StateServingInfoSetter
+	configGetter    EnvironConfigGetter
+	hostPortsGetter APIHostPortsGetter
+	certChanged     chan params.StateServingInfo
+	addresses       []network.Address
 }
 
 // AddressWatcher is an interface that is provided to NewCertificateUpdater
@@ -56,36 +59,66 @@ type StateServingInfoGetter interface {
 // StateServingInfo value with a newly generated certificate.
 type StateServingInfoSetter func(info params.StateServingInfo, done <-chan struct{}) error
 
+// APIHostPortsGetter is an interface that is provided to NewCertificateUpdater
+// whose APIHostPorts method will be invoked to get state server addresses.
+type APIHostPortsGetter interface {
+	APIHostPorts() ([][]network.HostPort, error)
+}
+
 // NewCertificateUpdater returns a worker.Worker that watches for changes to
 // machine addresses and then generates a new state server certificate with those
 // addresses in the certificate's SAN value.
 func NewCertificateUpdater(addressWatcher AddressWatcher, getter StateServingInfoGetter,
-	configGetter EnvironConfigGetter, setter StateServingInfoSetter, certChanged chan params.StateServingInfo,
+	configGetter EnvironConfigGetter, hostPortsGetter APIHostPortsGetter, setter StateServingInfoSetter,
+	certChanged chan params.StateServingInfo,
 ) worker.Worker {
 	return worker.NewNotifyWorker(&CertificateUpdater{
-		addressWatcher: addressWatcher,
-		configGetter:   configGetter,
-		getter:         getter,
-		setter:         setter,
-		certChanged:    certChanged,
+		addressWatcher:  addressWatcher,
+		configGetter:    configGetter,
+		hostPortsGetter: hostPortsGetter,
+		getter:          getter,
+		setter:          setter,
+		certChanged:     certChanged,
 	})
 }
 
 // SetUp is defined on the NotifyWatchHandler interface.
 func (c *CertificateUpdater) SetUp() (watcher.NotifyWatcher, error) {
+	// Populate certificate SAN with any addresses we know about now.
+	apiHostPorts, err := c.hostPortsGetter.APIHostPorts()
+	if err != nil {
+		return nil, errors.Annotate(err, "retrieving initial server addesses")
+	}
+	var initialSANAddresses []network.Address
+	for _, server := range apiHostPorts {
+		for _, nhp := range server {
+			if nhp.Scope != network.ScopeCloudLocal {
+				continue
+			}
+			initialSANAddresses = append(initialSANAddresses, nhp.Address)
+		}
+	}
+	if err := c.updateCertificate(initialSANAddresses, make(chan struct{})); err != nil {
+		return nil, errors.Annotate(err, "setting initial cerificate SAN list")
+	}
+	// Return
 	return c.addressWatcher.WatchAddresses(), nil
 }
 
 // Handle is defined on the NotifyWatchHandler interface.
 func (c *CertificateUpdater) Handle(done <-chan struct{}) error {
 	addresses := c.addressWatcher.Addresses()
-	logger.Debugf("new machine addresses: %#v", addresses)
 	if reflect.DeepEqual(addresses, c.addresses) {
 		// Sometimes the watcher will tell us things have changed, when they
 		// haven't as far as we can tell.
 		logger.Debugf("addresses haven't really changed since last updated cert")
 		return nil
 	}
+	return c.updateCertificate(addresses, done)
+}
+
+func (c *CertificateUpdater) updateCertificate(addresses []network.Address, done <-chan struct{}) error {
+	logger.Debugf("new machine addresses: %#v", addresses)
 	c.addresses = addresses
 
 	// Older Juju deployments will not have the CA cert private key
@@ -122,17 +155,48 @@ func (c *CertificateUpdater) Handle(done <-chan struct{}) error {
 		}
 		serverAddrs = append(serverAddrs, addr.Value)
 	}
+	newServerAddrs, update, err := updateRequired(stateInfo.Cert, serverAddrs)
+	if err != nil {
+		return errors.Annotate(err, "cannot determine if cert update needed")
+	}
+	if !update {
+		logger.Debugf("no certificate update required")
+		return nil
+	}
 
 	// Generate a new state server certificate with the machine addresses in the SAN value.
-	newCert, newKey, err := envConfig.GenerateStateServerCertAndKey(serverAddrs)
+	newCert, newKey, err := envConfig.GenerateStateServerCertAndKey(newServerAddrs)
 	if err != nil {
 		return errors.Annotate(err, "cannot generate state server certificate")
 	}
 	stateInfo.Cert = string(newCert)
 	stateInfo.PrivateKey = string(newKey)
-	c.setter(stateInfo, done)
-	logger.Infof("State Server cerificate addresses updated to %q", addresses)
+	err = c.setter(stateInfo, done)
+	if err != nil {
+		return errors.Annotate(err, "cannot write agent config")
+	}
+	logger.Infof("State Server cerificate addresses updated to %q", newServerAddrs)
 	return nil
+}
+
+// updateRequired returns true and a list of merged addresses if any of the
+// new addresses are not yet contained in the server cert SAN list.
+func updateRequired(serverCert string, newAddrs []string) ([]string, bool, error) {
+	x509Cert, err := cert.ParseCert(serverCert)
+	if err != nil {
+		return nil, false, errors.Annotate(err, "cannot parse existing TLS certificate")
+	}
+	existingAddr := set.NewStrings()
+	for _, ip := range x509Cert.IPAddresses {
+		existingAddr.Add(ip.String())
+	}
+	logger.Debugf("existing cert addresses %v", existingAddr)
+	logger.Debugf("new addresses %v", newAddrs)
+	// Does newAddr contain any that are not already in existingAddr?
+	newAddrSet := set.NewStrings(newAddrs...)
+	update := newAddrSet.Difference(existingAddr).Size() > 0
+	newAddrSet = newAddrSet.Union(existingAddr)
+	return newAddrSet.SortedValues(), update, nil
 }
 
 // TearDown is defined on the NotifyWatchHandler interface.

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -26,9 +27,20 @@ func TestPackage(t *stdtesting.T) {
 
 type CertUpdaterSuite struct {
 	coretesting.BaseSuite
+	stateServingInfo params.StateServingInfo
 }
 
 var _ = gc.Suite(&CertUpdaterSuite{})
+
+func (s *CertUpdaterSuite) SetUpTest(c *gc.C) {
+	s.stateServingInfo = params.StateServingInfo{
+		Cert:         coretesting.ServerCert,
+		PrivateKey:   coretesting.ServerKey,
+		CAPrivateKey: coretesting.CAKey,
+		StatePort:    123,
+		APIPort:      456,
+	}
+}
 
 type mockNotifyWatcher struct {
 	changes <-chan struct{}
@@ -70,16 +82,8 @@ func (m *mockMachine) Addresses() (addresses []network.Address) {
 	}}
 }
 
-type mockStateServingGetter struct{}
-
-func (g *mockStateServingGetter) StateServingInfo() (params.StateServingInfo, bool) {
-	return params.StateServingInfo{
-		Cert:         coretesting.ServerCert,
-		PrivateKey:   coretesting.ServerKey,
-		CAPrivateKey: coretesting.CAKey,
-		StatePort:    123,
-		APIPort:      456,
-	}, true
+func (s *CertUpdaterSuite) StateServingInfo() (params.StateServingInfo, bool) {
+	return s.stateServingInfo, true
 }
 
 type mockConfigGetter struct{}
@@ -89,23 +93,48 @@ func (g *mockConfigGetter) EnvironConfig() (*config.Config, error) {
 
 }
 
+type mockAPIHostGetter struct{}
+
+func (g *mockAPIHostGetter) APIHostPorts() ([][]network.HostPort, error) {
+	return [][]network.HostPort{
+		{
+			{Address: network.Address{Value: "192.168.1.1", Scope: network.ScopeCloudLocal}, Port: 17070},
+			{Address: network.Address{Value: "10.1.1.1", Scope: network.ScopeMachineLocal}, Port: 17070},
+		},
+	}, nil
+}
+
 func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
+	var initialAddresses []string
 	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {
+		// Only care about first time called.
+		if len(initialAddresses) > 0 {
+			return nil
+		}
+		srvCert, err := cert.ParseCert(info.Cert)
+		c.Assert(err, jc.ErrorIsNil)
+		initialAddresses = make([]string, len(srvCert.IPAddresses))
+		for i, ip := range srvCert.IPAddresses {
+			initialAddresses[i] = ip.String()
+		}
 		return nil
 	}
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, &mockStateServingGetter{}, &mockConfigGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, s, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
 	)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
+	// Initial cert addresses initialised to cloud local ones.
+	c.Assert(initialAddresses, jc.DeepEquals, []string{"192.168.1.1"})
 }
 
 func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	var srvCert *x509.Certificate
 	updated := make(chan struct{})
 	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {
+		s.stateServingInfo = info
 		var err error
 		srvCert, err = cert.ParseCert(info.Cert)
 		c.Assert(err, jc.ErrorIsNil)
@@ -113,7 +142,8 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 		for i, ip := range srvCert.IPAddresses {
 			sanIPs[i] = ip.String()
 		}
-		if len(sanIPs) == 1 && sanIPs[0] == "0.1.2.3" {
+		sanIPsSet := set.NewStrings(sanIPs...)
+		if sanIPsSet.Size() == 2 && sanIPsSet.Contains("0.1.2.3") && sanIPsSet.Contains("192.168.1.1") {
 			close(updated)
 		}
 		return nil
@@ -121,7 +151,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, &mockStateServingGetter{}, &mockConfigGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, s, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -138,7 +168,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	// name for backwards-compatibility with API clients. They must
 	// also report "juju-mongodb" because these certicates are also
 	// used for serving MongoDB connections.
-	c.Assert(srvCert.DNSNames, gc.DeepEquals,
+	c.Assert(srvCert.DNSNames, jc.SameContents,
 		[]string{"localhost", "juju-apiserver", "juju-mongodb", "anything"})
 }
 
@@ -163,7 +193,7 @@ func (s *CertUpdaterSuite) TestAddressChangeNoCAKey(c *gc.C) {
 	changes := make(chan struct{})
 	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, &mockStateServingGetterNoCAKey{}, &mockConfigGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, &mockStateServingGetterNoCAKey{}, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()


### PR DESCRIPTION
Initialise state server cert with any known existing api server addresses

Fixes: https://bugs.launchpad.net/juju-core/+bug/1472014

The machine address watcher is used to notify the state server certificate worker of newly discovered IP addresses so that these can be added to the certificate SAN list. However, the address processing ignores all but one of the machine's local cloud addresses.

To get around the above issue, we update the certificate SAN when the work first starts, using any currently known machine addresses - the known machine addresses come from the recorded state server api hosts.

As an optimisation, do not update certificate unless addresses have changed.

(Review request: http://reviews.vapour.ws/r/2126/)

(Review request: http://reviews.vapour.ws/r/2131/)