### PR TITLE
Fix windows version detection

### DIFF
--- a/version/export_windows_test.go
+++ b/version/export_windows_test.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Copyright 2015 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package version
+
+var (
+	CurrentVersionKey = &currentVersionKey
+	OSVersion         = osVersion
+)

--- a/version/osversion_windows.go
+++ b/version/osversion_windows.go
@@ -11,6 +11,8 @@ import (
 	"github.com/juju/errors"
 )
 
+// currentVersionKey is defined as a variable instead of a constant
+// to allow overwriting during testing
 var currentVersionKey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"
 
 func getVersionFromRegistry() (string, error) {

--- a/version/osversion_windows_test.go
+++ b/version/osversion_windows_test.go
@@ -1,25 +1,112 @@
-// Copyright 2014 Canonical Ltd.
-// Copyright 2014 Cloudbase Solutions SRL
+// Copyright 2015 Canonical Ltd.
+// Copyright 2015 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package version_test
 
 import (
+	"fmt"
+
+	"github.com/juju/juju/version"
+	"github.com/juju/utils"
+
+	"github.com/gabriel-samfira/sys/windows/registry"
+	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 )
 
-type windowsVersionSuite struct{}
+type windowsVersionSuite struct {
+	testing.BaseSuite
+}
 
 var _ = gc.Suite(&windowsVersionSuite{})
 
-func (s *windowsVersionSuite) TestOSVersion(c *gc.C) {
-	knownSeries := set.NewStrings()
-	for _, series := range windowsVersions {
-		knownSeries.Add(series)
-	}
-	version, err := osVersion()
+var versionTests = []struct {
+	version string
+	want    string
+}{
+	{
+		"Hyper-V Server 2012 R2",
+		"win2012hvr2",
+	},
+	{
+		"Hyper-V Server 2012",
+		"win2012hv",
+	},
+	{
+		"Windows Server 2012 R2",
+		"win2012r2",
+	},
+	{
+		"Windows Server 2012",
+		"win2012",
+	},
+	{
+		"Windows Server 2012 R2 Datacenter",
+		"win2012r2",
+	},
+	{
+		"Windows Server 2012 Standard",
+		"win2012",
+	},
+	{
+		"Windows Storage Server 2012 R2",
+		"win2012r2",
+	},
+	{
+		"Windows Storage Server 2012 Standard",
+		"win2012",
+	},
+	{
+		"Windows Storage Server 2012 R2 Standard",
+		"win2012r2",
+	},
+	{
+		"Windows 7 Home",
+		"win7",
+	},
+	{
+		"Windows 8 Pro",
+		"win8",
+	},
+	{
+		"Windows 8.1 Pro",
+		"win81",
+	},
+}
+
+func (s *windowsVersionSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	salt, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(version, jc.Satisfies, knownSeries.Contains)
+	regKey := fmt.Sprintf(`SOFTWARE\JUJU\%s`, salt)
+	s.PatchValue(version.CurrentVersionKey, regKey)
+
+	k, _, err := registry.CreateKey(registry.LOCAL_MACHINE, *version.CurrentVersionKey, registry.ALL_ACCESS)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = k.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.AddCleanup(func(*gc.C) {
+		registry.DeleteKey(registry.LOCAL_MACHINE, *version.CurrentVersionKey)
+	})
+}
+
+func (s *windowsVersionSuite) TestOSVersion(c *gc.C) {
+	for _, value := range versionTests {
+		k, err := registry.OpenKey(registry.LOCAL_MACHINE, *version.CurrentVersionKey, registry.ALL_ACCESS)
+		c.Assert(err, jc.ErrorIsNil)
+
+		err = k.SetStringValue("ProductName", value.version)
+		c.Assert(err, jc.ErrorIsNil)
+
+		err = k.Close()
+		c.Assert(err, jc.ErrorIsNil)
+
+		ver, err := version.OSVersion()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(ver, gc.Equals, value.want)
+	}
 }

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -100,9 +100,10 @@ var ubuntuSeries = map[string]string{
 }
 
 // Windows versions come in various flavors:
-// Standard, Datacenter, etc. We use regex to match them to one
+// Standard, Datacenter, etc. We use string prefix match them to one
 // of the following. Specify the longest name in a particular series first
-// For example, if we have "Win 2012" and "Win 2012 R2", we specify "Win 2012 R2" first
+// For example, if we have "Win 2012" and "Win 2012 R2", we specify "Win 2012 R2" first.
+// We need to make sure we manually update this list with each new windows release.
 var windowsVersionMatchOrder = []string{
 	"Hyper-V Server 2012 R2",
 	"Hyper-V Server 2012",

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -99,14 +99,24 @@ var ubuntuSeries = map[string]string{
 	"vivid":   "15.04",
 }
 
-// windowsVersions is a mapping consisting of the output from
-// the following WMI query: (gwmi Win32_OperatingSystem).Name
 // Windows versions come in various flavors:
 // Standard, Datacenter, etc. We use regex to match them to one
 // of the following. Specify the longest name in a particular series first
 // For example, if we have "Win 2012" and "Win 2012 R2", we specify "Win 2012 R2" first
-// TODO: Replace this with actual full names once we compile a complete
-// list with all flavors
+var windowsVersionMatchOrder = []string{
+	"Hyper-V Server 2012 R2",
+	"Hyper-V Server 2012",
+	"Windows Server 2012 R2",
+	"Windows Server 2012",
+	"Windows Storage Server 2012 R2",
+	"Windows Storage Server 2012",
+	"Windows 7",
+	"Windows 8.1",
+	"Windows 8",
+}
+
+// windowsVersions is a mapping consisting of the output from
+// the following WMI query: (gwmi Win32_OperatingSystem).Name
 var windowsVersions = map[string]string{
 	"Hyper-V Server 2012 R2":         "win2012hvr2",
 	"Hyper-V Server 2012":            "win2012hv",
@@ -115,8 +125,8 @@ var windowsVersions = map[string]string{
 	"Windows Storage Server 2012 R2": "win2012r2",
 	"Windows Storage Server 2012":    "win2012",
 	"Windows 7":                      "win7",
-	"Windows 8":                      "win8",
 	"Windows 8.1":                    "win81",
+	"Windows 8":                      "win8",
 }
 
 var distroInfo = "/usr/share/distro-info/ubuntu.csv"


### PR DESCRIPTION
The current code was written a while back, under the assumption that maps are ordered. That is not the case. This PR fixes bug #1430245

(Review request: http://reviews.vapour.ws/r/2133/)