### PR TITLE
Fix for bug 1463480 - allow disable of machiner setting addresses

### DIFF
--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -166,6 +166,9 @@ func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	)
 	err = machine.SetMachineAddresses(setAddresses)
 	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine.MachineAddresses(), gc.HasLen, 3)
 
 	err = machine.SetMachineAddresses(nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -155,6 +155,25 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(s.machine.MachineAddresses(), jc.DeepEquals, expectAddresses)
 }
 
+func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
+	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	setAddresses := network.NewAddresses(
+		"8.8.8.8",
+		"127.0.0.1",
+		"10.0.0.1",
+	)
+	err = machine.SetMachineAddresses(setAddresses)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetMachineAddresses(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine.MachineAddresses(), gc.HasLen, 0)
+}
+
 func (s *machinerSuite) TestWatch(c *gc.C) {
 	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -657,6 +657,16 @@ func (s *unitSuite) TestWatchAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
+	// Change is reported for machine addresses.
+	err = s.wordpressMachine.SetMachineAddresses(network.NewAddress("0.1.2.5"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Set machine addresses to empty is reported.
+	err = s.wordpressMachine.SetMachineAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
 	// NOTE: This test is not as exhaustive as the one in state,
 	// because the watcher is already tested there. Here we just
 	// ensure we get the events when we expect them and don't get

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -184,6 +184,34 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(s.machine0.MachineAddresses(), gc.HasLen, 0)
 }
 
+func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
+	// Set some addresses so we can ensure they are removed.
+	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
+	args := params.SetMachinesAddresses{MachineAddresses: []params.MachineAddresses{
+		{Tag: "machine-1", Addresses: params.FromNetworkAddresses(addresses)},
+	}}
+	result, err := s.machiner.SetMachineAddresses(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{nil},
+		},
+	})
+
+	args.MachineAddresses[0].Addresses = nil
+	result, err = s.machiner.SetMachineAddresses(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{nil},
+		},
+	})
+
+	err = s.machine1.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine1.MachineAddresses(), gc.HasLen, 0)
+}
+
 func (s *machinerSuite) TestJobs(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "machine-1"},

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -197,6 +197,9 @@ func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 			{nil},
 		},
 	})
+	err = s.machine1.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine1.MachineAddresses(), gc.HasLen, 2)
 
 	args.MachineAddresses[0].Addresses = nil
 	result, err = s.machiner.SetMachineAddresses(args)

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -109,6 +109,7 @@ var (
 	ensureMongoAdminUser     = mongo.EnsureAdminUser
 	newSingularRunner        = singular.New
 	peergrouperNew           = peergrouper.New
+	newMachiner              = machiner.NewMachiner
 	newNetworker             = networker.NewNetworker
 	newFirewaller            = firewaller.NewFirewaller
 	newDiskManager           = diskmanager.NewWorker
@@ -715,8 +716,16 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		return proxyupdater.New(st.Environment(), writeSystemFiles), nil
 	})
 
+	envConfig, err := st.Environment().EnvironConfig()
+	if err != nil {
+		return nil, fmt.Errorf("cannot read environment config: %v", err)
+	}
+	ignoreMachineAddresses, _ := envConfig.IgnoreMachineAddresses()
+	if ignoreMachineAddresses {
+		logger.Infof("machine addresses not used, only addresses from provider")
+	}
 	runner.StartWorker("machiner", func() (worker.Worker, error) {
-		return machiner.NewMachiner(st.Machiner(), agentConfig), nil
+		return newMachiner(st.Machiner(), agentConfig, ignoreMachineAddresses), nil
 	})
 	runner.StartWorker("reboot", func() (worker.Worker, error) {
 		reboot, err := st.Reboot()
@@ -761,10 +770,6 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	})
 
 	// Check if the network management is disabled.
-	envConfig, err := st.Environment().EnvironConfig()
-	if err != nil {
-		return nil, fmt.Errorf("cannot read environment config: %v", err)
-	}
 	disableNetworkManagement, _ := envConfig.DisableNetworkManagement()
 	if disableNetworkManagement {
 		logger.Infof("network management is disabled")

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -190,6 +190,11 @@ const (
 	// Deprecated by use-clone
 	// LxcUseClone stores the key for this setting.
 	LxcUseClone = "lxc-use-clone"
+
+	// IgnoreMachineAddresses, when true, will cause the
+	// machine worker not to discover any machine addresses
+	// on start up.
+	IgnoreMachineAddresses = "ignore-machine-addresses"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -1145,6 +1150,13 @@ func (c *Config) DisableNetworkManagement() (bool, bool) {
 	return v, ok
 }
 
+// IgnoreMachineAddresses reports whether Juju will discover
+// and store machine addresses on startup.
+func (c *Config) IgnoreMachineAddresses() (bool, bool) {
+	v, ok := c.defined[IgnoreMachineAddresses].(bool)
+	return v, ok
+}
+
 // StorageDefaultBlockSource returns the default block storage
 // source for the environment.
 func (c *Config) StorageDefaultBlockSource() (string, bool) {
@@ -1282,6 +1294,7 @@ var fields = schema.Fields{
 	"enable-os-refresh-update":   schema.Bool(),
 	"enable-os-upgrade":          schema.Bool(),
 	"disable-network-management": schema.Bool(),
+	IgnoreMachineAddresses:       schema.Bool(),
 	SetNumaControlPolicyKey:      schema.Bool(),
 	PreventDestroyEnvironmentKey: schema.Bool(),
 	PreventRemoveObjectKey:       schema.Bool(),
@@ -1330,6 +1343,7 @@ var alwaysOptional = schema.Defaults{
 	LxcClone:                     schema.Omit,
 	LXCDefaultMTU:                schema.Omit,
 	"disable-network-management": schema.Omit,
+	IgnoreMachineAddresses:       schema.Omit,
 	AgentStreamKey:               schema.Omit,
 	SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
 	AllowLXCLoopMounts:           false,
@@ -1401,6 +1415,7 @@ func allDefaults() schema.Defaults {
 		"proxy-ssh":                  true,
 		"prefer-ipv6":                false,
 		"disable-network-management": false,
+		IgnoreMachineAddresses:       false,
 		SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
 	}
 	for attr, val := range alwaysOptional {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -405,6 +405,31 @@ var configTests = []configTest{
 			"disable-network-management": true,
 		},
 	}, {
+		about:       "Invalid ignore-machine-addresses flag",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+			"ignore-machine-addresses": "invalid",
+		},
+		err: `ignore-machine-addresses: expected bool, got string\("invalid"\)`,
+	}, {
+		about:       "ignore-machine-addresses off",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+			"ignore-machine-addresses": false,
+		},
+	}, {
+		about:       "ignore-machine-addresses on",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+			"ignore-machine-addresses": true,
+		},
+	}, {
 		about:       "set-numa-control-policy on",
 		useDefaults: config.UseDefaults,
 		attrs: testing.Attrs{

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1951,6 +1951,27 @@ func (s *MachineSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(machine.MachineAddresses(), jc.DeepEquals, expectedAddresses)
 }
 
+func (s *MachineSuite) TestSetEmptyMachineAddresses(c *gc.C) {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.Addresses(), gc.HasLen, 0)
+
+	// Add some machine addresses initially to make sure they're removed.
+	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
+	err = machine.SetMachineAddresses(addresses...)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make call with empty address list.
+	err = machine.SetMachineAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(machine.MachineAddresses(), gc.HasLen, 0)
+}
+
 func (s *MachineSuite) TestMergedAddresses(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1962,6 +1962,7 @@ func (s *MachineSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.MachineAddresses(), gc.HasLen, 2)
 
 	// Make call with empty address list.
 	err = machine.SetMachineAddresses()

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -47,6 +47,7 @@ func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	mr.machine = m
 
 	if mr.ignoreAddressesOnStart {
+		logger.Debugf("machine addresses ignored on start - resetting machine addresses")
 		if err := m.SetMachineAddresses(nil); err != nil {
 			return nil, errors.Annotate(err, "reseting machine addresses")
 		}

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -3,9 +3,9 @@
 package machiner
 
 import (
-	"fmt"
 	"net"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 
@@ -21,17 +21,18 @@ var logger = loggo.GetLogger("juju.worker.machiner")
 
 // Machiner is responsible for a machine agent's lifecycle.
 type Machiner struct {
-	st      *machiner.State
-	tag     names.MachineTag
-	machine *machiner.Machine
+	st                     *machiner.State
+	tag                    names.MachineTag
+	machine                *machiner.Machine
+	ignoreAddressesOnStart bool
 }
 
 // NewMachiner returns a Worker that will wait for the identified machine
 // to become Dying and make it Dead; or until the machine becomes Dead by
 // other means.
-func NewMachiner(st *machiner.State, agentConfig agent.Config) worker.Worker {
+func NewMachiner(st *machiner.State, agentConfig agent.Config, ignoreAddressesOnStart bool) worker.Worker {
 	// TODO(dfc) clearly agentConfig.Tag() can _only_ return a machine tag
-	mr := &Machiner{st: st, tag: agentConfig.Tag().(names.MachineTag)}
+	mr := &Machiner{st: st, tag: agentConfig.Tag().(names.MachineTag), ignoreAddressesOnStart: ignoreAddressesOnStart}
 	return worker.NewNotifyWorker(mr)
 }
 
@@ -41,18 +42,24 @@ func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return nil, worker.ErrTerminateAgent
 	} else if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	mr.machine = m
 
-	// Set the addresses in state to the host's addresses.
-	if err := setMachineAddresses(m); err != nil {
-		return nil, err
+	if mr.ignoreAddressesOnStart {
+		if err := m.SetMachineAddresses(nil); err != nil {
+			return nil, errors.Annotate(err, "reseting machine addresses")
+		}
+	} else {
+		// Set the addresses in state to the host's addresses.
+		if err := setMachineAddresses(m); err != nil {
+			return nil, errors.Annotate(err, "setting machine addresses")
+		}
 	}
 
 	// Mark the machine as started and log it.
 	if err := m.SetStatus(params.StatusStarted, "", nil); err != nil {
-		return nil, fmt.Errorf("%s failed to set status started: %v", mr.tag, err)
+		return nil, errors.Annotatef(err, "%s failed to set status started", mr.tag)
 	}
 	logger.Infof("%q started", mr.tag)
 
@@ -106,7 +113,7 @@ func (mr *Machiner) Handle() error {
 	}
 	logger.Debugf("%q is now %s", mr.tag, mr.machine.Life())
 	if err := mr.machine.SetStatus(params.StatusStopped, "", nil); err != nil {
-		return fmt.Errorf("%s failed to set status stopped: %v", mr.tag, err)
+		return errors.Annotatef(err, "%s failed to set status stopped", mr.tag)
 	}
 
 	// Attempt to mark the machine Dead. If the
@@ -118,7 +125,7 @@ func (mr *Machiner) Handle() error {
 		if params.IsCodeHasAssignedUnits(err) {
 			return nil
 		}
-		return fmt.Errorf("%s failed to set machine to dead: %v", mr.tag, err)
+		return errors.Annotatef(err, "%s failed to set machine to dead", mr.tag)
 	}
 	return worker.ErrTerminateAgent
 }

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -105,16 +105,16 @@ func agentConfig(tag names.Tag) agent.Config {
 }
 
 func (s *MachinerSuite) TestNotFoundOrUnauthorized(c *gc.C) {
-	mr := machiner.NewMachiner(s.machinerState, agentConfig(names.NewMachineTag("99")))
+	mr := machiner.NewMachiner(s.machinerState, agentConfig(names.NewMachineTag("99")), false)
 	c.Assert(mr.Wait(), gc.Equals, worker.ErrTerminateAgent)
 }
 
-func (s *MachinerSuite) makeMachiner() worker.Worker {
-	return machiner.NewMachiner(s.machinerState, agentConfig(s.apiMachine.Tag()))
+func (s *MachinerSuite) makeMachiner(ignoreAddresses bool) worker.Worker {
+	return machiner.NewMachiner(s.machinerState, agentConfig(s.apiMachine.Tag()), ignoreAddresses)
 }
 
 func (s *MachinerSuite) TestRunStop(c *gc.C) {
-	mr := s.makeMachiner()
+	mr := s.makeMachiner(false)
 	c.Assert(worker.Stop(mr), gc.IsNil)
 	c.Assert(s.apiMachine.Refresh(), gc.IsNil)
 	c.Assert(s.apiMachine.Life(), gc.Equals, params.Alive)
@@ -126,21 +126,21 @@ func (s *MachinerSuite) TestStartSetsStatus(c *gc.C) {
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
 	c.Assert(statusInfo.Message, gc.Equals, "")
 
-	mr := s.makeMachiner()
+	mr := s.makeMachiner(false)
 	defer worker.Stop(mr)
 
 	s.waitMachineStatus(c, s.machine, state.StatusStarted)
 }
 
 func (s *MachinerSuite) TestSetsStatusWhenDying(c *gc.C) {
-	mr := s.makeMachiner()
+	mr := s.makeMachiner(false)
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), gc.IsNil)
 	s.waitMachineStatus(c, s.machine, state.StatusStopped)
 }
 
 func (s *MachinerSuite) TestSetDead(c *gc.C) {
-	mr := s.makeMachiner()
+	mr := s.makeMachiner(false)
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), gc.IsNil)
 	s.State.StartSync()
@@ -150,7 +150,7 @@ func (s *MachinerSuite) TestSetDead(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestSetDeadWithDyingUnit(c *gc.C) {
-	mr := s.makeMachiner()
+	mr := s.makeMachiner(false)
 	defer worker.Stop(mr)
 
 	// Add a service, assign to machine.
@@ -181,7 +181,7 @@ func (s *MachinerSuite) TestSetDeadWithDyingUnit(c *gc.C) {
 
 }
 
-func (s *MachinerSuite) TestMachineAddresses(c *gc.C) {
+func (s *MachinerSuite) setupSetMachineAddresses(c *gc.C, ignore bool) {
 	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
 	netConf := []byte(`
   # comments ignored
@@ -215,16 +215,25 @@ LXC_BRIDGE="ignored"`[1:])
 	})
 	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
 
-	mr := s.makeMachiner()
+	mr := s.makeMachiner(ignore)
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), gc.IsNil)
 	s.State.StartSync()
 	c.Assert(mr.Wait(), gc.Equals, worker.ErrTerminateAgent)
 	c.Assert(s.machine.Refresh(), gc.IsNil)
+}
+
+func (s *MachinerSuite) TestMachineAddresses(c *gc.C) {
+	s.setupSetMachineAddresses(c, false)
 	c.Assert(s.machine.MachineAddresses(), jc.DeepEquals, []network.Address{
 		network.NewAddress("2001:db8::1"),
 		network.NewScopedAddress("10.0.0.1", network.ScopeCloudLocal),
 		network.NewScopedAddress("::1", network.ScopeMachineLocal),
 		network.NewScopedAddress("127.0.0.1", network.ScopeMachineLocal),
 	})
+}
+
+func (s *MachinerSuite) TestMachineAddressesWithIgnoreFlag(c *gc.C) {
+	s.setupSetMachineAddresses(c, true)
+	c.Assert(s.machine.MachineAddresses(), gc.HasLen, 0)
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1463480

As per Dimiter's instructions, a new config attribute as been added: ignore-machine-addresses
This prevents the machiner from setting the discovered machines addreses on startup.
Setting the addresses to empty overwrites any that are there and triggers a machine address watcher event which causes a unit config changed hook.


(Review request: http://reviews.vapour.ws/r/2138/)