### PR TITLE
Fix uniter metrics collecting and sending tests.

### DIFF
--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -6,6 +6,8 @@ package uniter
 import (
 	"fmt"
 	"time"
+
+	"github.com/juju/juju/testing"
 )
 
 func SetUniterObserver(u *Uniter, observer UniterExecutionObserver) {
@@ -29,7 +31,7 @@ type ManualTicker struct {
 func (t *ManualTicker) Tick() error {
 	select {
 	case t.c <- time.Now():
-	default:
+	case <-time.After(testing.LongWait):
 		return fmt.Errorf("ticker channel blocked")
 	}
 	return nil
@@ -42,7 +44,7 @@ func (t *ManualTicker) ReturnTimer(now, lastRun time.Time, interval time.Duratio
 
 func NewManualTicker() *ManualTicker {
 	return &ManualTicker{
-		c: make(chan time.Time, 1),
+		c: make(chan time.Time),
 	}
 }
 

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1384,8 +1384,7 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 			verifyCharm{},
 			collectMetricsTick{},
 			waitHooks{"collect-metrics"},
-		),
-		ut(
+		), ut(
 			"collect-metrics resumed after hook error",
 			startupErrorWithCustomCharm{
 				badHook: "config-changed",
@@ -1393,7 +1392,7 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 					ctx.writeMetricsYaml(c, path)
 				},
 			},
-			collectMetricsTick{},
+			collectMetricsTick{expectFail: true},
 			fixHook{"config-changed"},
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
@@ -1403,7 +1402,9 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"config-changed", "start", "collect-metrics"},
+			waitHooks{"config-changed", "start"},
+			collectMetricsTick{},
+			waitHooks{"collect-metrics"},
 			verifyRunning{},
 		),
 		ut(
@@ -1414,7 +1415,7 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 					ctx.writeMetricsYaml(c, path)
 				},
 			},
-			collectMetricsTick{},
+			collectMetricsTick{expectFail: true},
 			fixHook{"config-changed"},
 			stopUniter{},
 			startUniter{},
@@ -1426,13 +1427,14 @@ func (s *UniterSuite) TestUniterCollectMetrics(c *gc.C) {
 				statusGetter: unitStatusGetter,
 				status:       params.StatusUnknown,
 			},
-			waitHooks{"config-changed", "start", "collect-metrics"},
+			waitHooks{"config-changed", "start"},
+			collectMetricsTick{},
+			waitHooks{"collect-metrics"},
 			verifyRunning{},
-		),
-		ut(
+		), ut(
 			"collect-metrics event not triggered for non-metered charm",
 			quickStart{},
-			collectMetricsTick{},
+			collectMetricsTick{expectFail: true},
 			waitHooks{},
 		),
 	})
@@ -1453,8 +1455,7 @@ func (s *UniterSuite) TestUniterSendMetrics(c *gc.C) {
 			addMetrics{[]string{"15", "17"}},
 			sendMetricsTick{},
 			checkStateMetrics{number: 1, values: []string{"17", "15"}},
-		),
-		ut(
+		), ut(
 			"send-metrics resumed after hook error",
 			startupErrorWithCustomCharm{
 				badHook: "config-changed",
@@ -1463,7 +1464,7 @@ func (s *UniterSuite) TestUniterSendMetrics(c *gc.C) {
 				},
 			},
 			addMetrics{[]string{"15"}},
-			sendMetricsTick{},
+			sendMetricsTick{expectFail: true},
 			fixHook{"config-changed"},
 			resolveError{state.ResolvedRetryHooks},
 			waitHooks{"config-changed", "start"},
@@ -1471,8 +1472,7 @@ func (s *UniterSuite) TestUniterSendMetrics(c *gc.C) {
 			sendMetricsTick{},
 			checkStateMetrics{number: 2, values: []string{"15", "17"}},
 			verifyRunning{},
-		),
-		ut(
+		), ut(
 			"send-metrics state maintained during uniter restart",
 			startupErrorWithCustomCharm{
 				badHook: "config-changed",
@@ -1480,25 +1480,26 @@ func (s *UniterSuite) TestUniterSendMetrics(c *gc.C) {
 					ctx.writeMetricsYaml(c, path)
 				},
 			},
-			collectMetricsTick{},
+			collectMetricsTick{expectFail: true},
 			addMetrics{[]string{"13"}},
-			sendMetricsTick{},
+			sendMetricsTick{expectFail: true},
 			fixHook{"config-changed"},
 			stopUniter{},
 			startUniter{},
 			resolveError{state.ResolvedRetryHooks},
-			waitHooks{"config-changed", "start", "collect-metrics"},
+			waitHooks{"config-changed", "start"},
+			collectMetricsTick{},
+			waitHooks{"collect-metrics"},
 			addMetrics{[]string{"21"}},
 			sendMetricsTick{},
 			checkStateMetrics{number: 2, values: []string{"13", "21"}},
 			verifyRunning{},
-		),
-		ut(
+		), ut(
 			"collect-metrics event not triggered for non-metered charm",
 			quickStart{},
-			collectMetricsTick{},
+			collectMetricsTick{expectFail: true},
 			addMetrics{[]string{"21"}},
-			sendMetricsTick{},
+			sendMetricsTick{expectFail: true},
 			waitHooks{},
 			checkStateMetrics{number: 0},
 		),

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -881,11 +881,17 @@ func (s changeMeterStatus) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-type collectMetricsTick struct{}
+type collectMetricsTick struct {
+	expectFail bool
+}
 
 func (s collectMetricsTick) step(c *gc.C, ctx *context) {
 	err := ctx.collectMetricsTicker.Tick()
-	c.Assert(err, jc.ErrorIsNil)
+	if s.expectFail {
+		c.Assert(err, gc.ErrorMatches, "ticker channel blocked")
+	} else {
+		c.Assert(err, jc.ErrorIsNil)
+	}
 }
 
 type updateStatusHookTick struct{}
@@ -895,11 +901,18 @@ func (s updateStatusHookTick) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-type sendMetricsTick struct{}
+type sendMetricsTick struct {
+	expectFail bool
+}
 
 func (s sendMetricsTick) step(c *gc.C, ctx *context) {
 	err := ctx.sendMetricsTicker.Tick()
-	c.Assert(err, jc.ErrorIsNil)
+	if s.expectFail {
+		c.Assert(err, gc.ErrorMatches, "ticker channel blocked")
+
+	} else {
+		c.Assert(err, jc.ErrorIsNil)
+	}
 }
 
 type addMetrics struct {


### PR DESCRIPTION
Due to the changes in the way metrics are collected and sent from the uniter, manual tickers with buffered channels make little sense (plus they fail). So, instead a manual ticker with an unbuffered channel is used, along with the ability to expect a failed tick in uniter_test.go.

(Review request: http://reviews.vapour.ws/r/2143/)