### PR TITLE
Skip changing password during test

### DIFF
--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/api"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
+	"github.com/juju/juju/cmd/jujud/util/password"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/lease"
 	"github.com/juju/juju/state"
@@ -40,6 +41,7 @@ type dblogSuite struct {
 func (s *dblogSuite) SetUpTest(c *gc.C) {
 	s.SetInitialFeatureFlags("db-log")
 	s.AgentSuite.SetUpTest(c)
+	s.PatchValue(&password.EnsureJujudPassword, func() error { return nil })
 
 	// Change the path to "juju-run", so that the
 	// tests don't try to write to /usr/local/bin.


### PR DESCRIPTION
This function should really never be called unless we're in production since it tries to modify the user's password. 

(Review request: http://reviews.vapour.ws/r/2146/)