### PR TITLE
Removed transactions from status history

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -406,9 +406,9 @@ func NewStatusDoc(s StatusDoc) statusDoc {
 	return statusDoc(s)
 }
 
-func NewHistoricalStatusDoc(s StatusDoc, key string) *historicalStatusDoc {
+func NewHistoricalStatusDoc(id int, s StatusDoc, key string) *historicalStatusDoc {
 	sdoc := statusDoc(s)
-	return newHistoricalStatusDoc(sdoc, key)
+	return newHistoricalStatusDoc(id, sdoc, key)
 }
 
 var StatusHistory = statusHistory

--- a/state/status.go
+++ b/state/status.go
@@ -272,8 +272,9 @@ type historicalStatusDoc struct {
 	EntityId   string
 }
 
-func newHistoricalStatusDoc(s statusDoc, entityId string) *historicalStatusDoc {
+func newHistoricalStatusDoc(id int, s statusDoc, entityId string) *historicalStatusDoc {
 	return &historicalStatusDoc{
+		Id:         id,
 		EnvUUID:    s.EnvUUID,
 		Status:     s.Status,
 		StatusInfo: s.StatusInfo,
@@ -288,15 +289,11 @@ func updateStatusHistory(oldDoc statusDoc, globalKey string, st *State) error {
 	if err != nil {
 		errors.Annotatef(err, "cannot make id updating status history of unit agent %q", globalKey)
 	}
-	hDoc := newHistoricalStatusDoc(oldDoc, globalKey)
-
-	h := txn.Op{
-		C:      statusesHistoryC,
-		Id:     id,
-		Insert: hDoc,
-	}
-
-	err = st.runTransaction([]txn.Op{h})
+	hDoc := newHistoricalStatusDoc(id, oldDoc, globalKey)
+	history, closer := st.getCollection(statusesHistoryC)
+	defer closer()
+	historyW := history.Writeable()
+	err = historyW.Insert(hDoc)
 	return errors.Annotatef(err, "cannot update status history of unit agent %q", globalKey)
 }
 
@@ -587,9 +584,7 @@ func removeStatusOp(st *State, globalKey string) txn.Op {
 func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
 	history, closer := st.getCollection(statusesHistoryC)
 	defer closer()
-	// XXX(fwereade): 2015-06-19 this is anything but safe: we must not mix
-	// txn and non-txn operations in the same collection without clear and
-	// detailed reasoning for so doing.
+
 	historyW := history.Writeable()
 
 	globalKeys, err := getEntitiesWithStatuses(historyW)

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -38,6 +38,9 @@ func testGetUnitStatusHistory(c *gc.C, statusHistory statusHistoryFunc, st *stat
 			StatusInfo: message,
 			Updated:    &updated}
 		sdoc := state.NewStatusDoc(statusDoc)
+		// EnvUUID is added here because the oldDoc we just created will
+		// not have one. EnvUUID is populated by the transaction runner.
+		sdoc.EnvUUID = st.EnvironUUID()
 		err := state.UpdateStatusHistory(sdoc, globalKey, st)
 		c.Assert(err, jc.ErrorIsNil)
 	}
@@ -663,6 +666,11 @@ func (s *UnitSuite) TestSetUnitStatusHistory(c *gc.C) {
 	statusInfo, err = s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, state.StatusActive)
+
+	h, err = state.StatusHistory(10, globalKey, s.State)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(h, gc.HasLen, 2)
 
 	err = s.unit.SetStatus(state.StatusUnknown, "really unknown status", nil)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Status history works like a simple pile so we removed all traces of transactions to avoid mixing transactional and non transactional operations and produce breakage.

(Review request: http://reviews.vapour.ws/r/2148/)