### PR TITLE
Backport of fix for custom cloud image metadata to 1.24

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1302,3 +1302,11 @@ func (env *azureEnviron) SupportsUnitPlacement() error {
 	}
 	return nil
 }
+
+func getCustomImageSource(env environs.Environ) (simplestreams.DataSource, error) {
+	_, ok := env.(*azureEnviron)
+	if !ok {
+		return nil, errors.NotSupportedf("non-azure environment")
+	}
+	return common.GetCustomImageSource(env)
+}

--- a/provider/azure/export_test.go
+++ b/provider/azure/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+)
+
+func MakeEnvironForTest(c *gc.C) environs.Environ {
+	return makeEnviron(c)
+}

--- a/provider/azure/init.go
+++ b/provider/azure/init.go
@@ -5,6 +5,7 @@ package azure
 
 import (
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
@@ -16,4 +17,7 @@ func init() {
 	environs.RegisterProvider(providerType, azureEnvironProvider{})
 
 	registry.RegisterEnvironStorageProviders(providerType)
+
+	// Register cloud local storage as simplestreams image data source.
+	environs.RegisterImageDataSourceFunc(common.CloudLocalStorageDesc, getCustomImageSource)
 }

--- a/provider/azure/init_test.go
+++ b/provider/azure/init_test.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/azure"
+	"github.com/juju/juju/testing"
+)
+
+type initSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&initSuite{})
+
+func (s *initSuite) TestImageMetadataDatasourceAdded(c *gc.C) {
+	env := azure.MakeEnvironForTest(c)
+	dss, err := environs.ImageMetadataSources(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	found := false
+	for i, ds := range dss {
+		c.Logf("datasource %d: %+v", i, ds)
+		if ds.Description() == "cloud local storage" {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, jc.IsTrue)
+}

--- a/provider/common/storage.go
+++ b/provider/common/storage.go
@@ -1,0 +1,23 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/environs/storage"
+)
+
+const CloudLocalStorageDesc = "cloud local storage"
+
+// GetCustomImageSource returns a simplestreams datasource for image metadata.
+func GetCustomImageSource(env environs.Environ) (simplestreams.DataSource, error) {
+	s, ok := env.(environs.EnvironStorage)
+	if !ok {
+		return nil, errors.NotSupportedf("provider storage")
+	}
+	return storage.NewStorageSimpleStreamsDataSource(CloudLocalStorageDesc, s.Storage(), storage.BaseImagesPath), nil
+}

--- a/provider/common/util.go
+++ b/provider/common/util.go
@@ -10,7 +10,7 @@ import (
 )
 
 // EnvFullName returns a string based on the provided environment
-// that is suitable for identifying the env on a provider. The resuling
+// that is suitable for identifying the env on a provider. The resulting
 // string clearly associates the value with juju, whereas the
 // environment's UUID alone isn't very distinctive for humans. This
 // benefits users by helping them quickly identify in their hosting

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1298,6 +1298,14 @@ func (e *environ) ensureGroup(name string, perms []ec2.IPPerm) (g ec2.SecurityGr
 	return g, nil
 }
 
+func getCustomImageSource(env environs.Environ) (simplestreams.DataSource, error) {
+	_, ok := env.(*environ)
+	if !ok {
+		return nil, errors.NotSupportedf("non-ec2 environment")
+	}
+	return common.GetCustomImageSource(env)
+}
+
 // permKey represents a permission for a group or an ip address range
 // to access the given range of ports. Only one of groupName or ipAddr
 // should be non-empty.

--- a/provider/ec2/init.go
+++ b/provider/ec2/init.go
@@ -5,6 +5,7 @@ package ec2
 
 import (
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
@@ -20,4 +21,7 @@ func init() {
 
 	// Inform the storage provider registry about the AWS providers.
 	registry.RegisterEnvironStorageProviders(providerType, EBS_ProviderType)
+
+	// Register cloud local storage as simplestreams image data source.
+	environs.RegisterImageDataSourceFunc(common.CloudLocalStorageDesc, getCustomImageSource)
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -694,10 +694,23 @@ func (t *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	params.Endpoint = "https://ec2.endpoint.com"
 	params.Sources, err = environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
+	assertSourcesContains(c, params.Sources, "cloud local storage")
 	image_ids, _, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(image_ids)
 	c.Assert(image_ids, gc.DeepEquals, []string{"ami-00000033", "ami-00000034", "ami-00000035", "ami-00000039"})
+}
+
+func assertSourcesContains(c *gc.C, sources []simplestreams.DataSource, expected string) {
+	found := false
+	for i, s := range sources {
+		c.Logf("datasource %d: %+v", i, s)
+		if s.Description() == expected {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, jc.IsTrue)
 }
 
 func (t *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -182,3 +182,11 @@ func (env *joyentEnviron) Region() (simplestreams.CloudSpec, error) {
 		Endpoint: env.Ecfg().sdcUrl(),
 	}, nil
 }
+
+func getCustomImageSource(env environs.Environ) (simplestreams.DataSource, error) {
+	_, ok := env.(*joyentEnviron)
+	if !ok {
+		return nil, errors.NotSupportedf("non-joyent environment")
+	}
+	return common.GetCustomImageSource(env)
+}

--- a/provider/joyent/init.go
+++ b/provider/joyent/init.go
@@ -5,6 +5,7 @@ package joyent
 
 import (
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
@@ -16,4 +17,7 @@ func init() {
 	environs.RegisterProvider(providerType, providerInstance)
 
 	registry.RegisterEnvironStorageProviders(providerType)
+
+	// Register cloud local storage as simplestreams image data source.
+	environs.RegisterImageDataSourceFunc(common.CloudLocalStorageDesc, getCustomImageSource)
 }

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -360,10 +360,23 @@ func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	params.Sources, err = environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
+	assertSourcesContains(c, params.Sources, "cloud local storage")
 	params.Series = "raring"
 	image_ids, _, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image_ids, gc.DeepEquals, []string{"11223344-0a0a-dd77-33cd-abcd1234e5f6"})
+}
+
+func assertSourcesContains(c *gc.C, sources []simplestreams.DataSource, expected string) {
+	found := false
+	for i, s := range sources {
+		c.Logf("datasource %d: %+v", i, s)
+		if s.Description() == expected {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, jc.IsTrue)
 }
 
 func (s *localServerSuite) TestRemoveAll(c *gc.C) {

--- a/provider/openstack/init.go
+++ b/provider/openstack/init.go
@@ -6,6 +6,7 @@ package openstack
 import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage/provider/registry"
 )
 
@@ -15,6 +16,10 @@ const (
 
 func init() {
 	environs.RegisterProvider(providerType, environProvider{})
+
+	// Register cloud local storage as simplestreams image data source.
+	environs.RegisterImageDataSourceFunc(common.CloudLocalStorageDesc, getCustomImageSource)
+
 	environs.RegisterImageDataSourceFunc("keystone catalog", getKeystoneImageSource)
 	tools.RegisterToolsDataSourceFunc("keystone catalog", getKeystoneToolsSource)
 
@@ -26,5 +31,4 @@ func init() {
 
 	// Register the Cinder provider with the Openstack provider.
 	registry.RegisterEnvironStorageProviders(providerType, CinderProviderType)
-
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -788,7 +788,7 @@ func (s *localServerSuite) assertGetImageMetadataSources(c *gc.C, stream, offici
 	c.Assert(err, jc.ErrorIsNil)
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, gc.HasLen, 3)
+	c.Assert(sources, gc.HasLen, 4)
 	var urls = make([]string, len(sources))
 	for i, source := range sources {
 		url, err := source.URL("")
@@ -798,8 +798,8 @@ func (s *localServerSuite) assertGetImageMetadataSources(c *gc.C, stream, offici
 	// The image-metadata-url ends with "/juju-dist-test/".
 	c.Check(strings.HasSuffix(urls[0], "/juju-dist-test/"), jc.IsTrue)
 	// The product-streams URL ends with "/imagemetadata".
-	c.Check(strings.HasSuffix(urls[1], "/imagemetadata/"), jc.IsTrue)
-	c.Assert(urls[2], gc.Equals, fmt.Sprintf("http://cloud-images.ubuntu.com/%s/", officialSourcePath))
+	c.Check(strings.HasSuffix(urls[2], "/imagemetadata/"), jc.IsTrue)
+	c.Assert(urls[3], gc.Equals, fmt.Sprintf("http://cloud-images.ubuntu.com/%s/", officialSourcePath))
 }
 
 func (s *localServerSuite) TestGetImageMetadataSources(c *gc.C) {
@@ -815,9 +815,12 @@ func (s *localServerSuite) TestGetImageMetadataSourcesNoProductStreams(c *gc.C) 
 	env := s.Open(c)
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, gc.HasLen, 2)
+	c.Assert(sources, gc.HasLen, 3)
+
+	// Check that data sources are in the right order
 	c.Check(sources[0].Description(), gc.Equals, "image-metadata-url")
-	c.Check(sources[1].Description(), gc.Equals, "default cloud images")
+	c.Check(sources[1].Description(), gc.Equals, "cloud local storage")
+	c.Check(sources[2].Description(), gc.Equals, "default cloud images")
 }
 
 func (s *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {
@@ -967,10 +970,23 @@ func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	params.Sources, err = environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
+	assertSourcesContains(c, params.Sources, "cloud local storage")
 	params.Series = "raring"
 	image_ids, _, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image_ids, jc.SameContents, []string{"id-y"})
+}
+
+func assertSourcesContains(c *gc.C, sources []simplestreams.DataSource, expected string) {
+	found := false
+	for i, s := range sources {
+		c.Logf("datasource %d: %+v", i, s)
+		if s.Description() == expected {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, jc.IsTrue)
 }
 
 func (s *localServerSuite) TestRemoveAll(c *gc.C) {
@@ -1182,7 +1198,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	sources, err := environs.ImageMetadataSources(s.env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, gc.HasLen, 3)
+	c.Assert(sources, gc.HasLen, 4)
 
 	// Make sure there is something to download from each location
 	metadata := "metadata-content"
@@ -1194,8 +1210,15 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	err = customStorage.Put(custom, bytes.NewBufferString(custom), int64(len(custom)))
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Produce map of data sources keyed on description
+	mappedSources := make(map[string]simplestreams.DataSource, len(sources))
+	for i, s := range sources {
+		c.Logf("datasource %d: %+v", i, s)
+		mappedSources[s.Description()] = s
+	}
+
 	// Read from the Config entry's image-metadata-url
-	contentReader, url, err := sources[0].Fetch(custom)
+	contentReader, url, err := mappedSources["image-metadata-url"].Fetch(custom)
 	c.Assert(err, jc.ErrorIsNil)
 	defer contentReader.Close()
 	content, err := ioutil.ReadAll(contentReader)
@@ -1204,7 +1227,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	c.Check(url[:8], gc.Equals, "https://")
 
 	// Check the entry we got from keystone
-	contentReader, url, err = sources[1].Fetch(metadata)
+	contentReader, url, err = mappedSources["keystone catalog"].Fetch(metadata)
 	c.Assert(err, jc.ErrorIsNil)
 	defer contentReader.Close()
 	content, err = ioutil.ReadAll(contentReader)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1657,3 +1657,11 @@ func (e *environ) cloudSpec(region string) (simplestreams.CloudSpec, error) {
 		Endpoint: e.ecfg().authURL(),
 	}, nil
 }
+
+func getCustomImageSource(env environs.Environ) (simplestreams.DataSource, error) {
+	_, ok := env.(*environ)
+	if !ok {
+		return nil, errors.NotSupportedf("non-openstack environment")
+	}
+	return common.GetCustomImageSource(env)
+}


### PR DESCRIPTION
Merge pull request #2748 from anastasiamac/lp1452422-master
Register cloud local storage as a data source.

 Bug# https://bugs.launchpad.net/juju-core/+bug/1452422

Custom images are not being picked up. This fix is added to support clouds that provide local storage.

A better solution will be soon proposed that will work for any cloud.

(Review request: http://reviews.vapour.ws/r/2127/)

(Review request: http://reviews.vapour.ws/r/2149/)