### PR TITLE
Replace spool directory lock with batch-specific lock.

### DIFF
--- a/worker/uniter/metrics/export_test.go
+++ b/worker/uniter/metrics/export_test.go
@@ -1,8 +1,0 @@
-// Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package metrics
-
-var (
-	LockTimeout = lockTimeout
-)

--- a/worker/uniter/metrics/metrics.go
+++ b/worker/uniter/metrics/metrics.go
@@ -143,7 +143,7 @@ func (m *JSONMetricRecorder) Close() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	err := errors.Trace(m.file.Close())
+	err := m.file.Close()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -153,7 +153,8 @@ func (m *JSONMetricRecorder) Close() error {
 	//
 	// Now write the meta file so that JSONMetricReader discovers a finished
 	// pair of files.
-	if err := m.recordMetaData(); err != nil {
+	err = m.recordMetaData()
+	if err != nil {
 		return errors.Trace(err)
 	}
 

--- a/worker/uniter/metrics/metrics_file_test.go
+++ b/worker/uniter/metrics/metrics_file_test.go
@@ -1,0 +1,79 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metrics
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type metricFileSuite struct {
+	spoolDir string
+}
+
+var _ = gc.Suite(&metricFileSuite{})
+
+func (s *metricFileSuite) SetUpTest(c *gc.C) {
+	s.spoolDir = c.MkDir()
+}
+
+func cleanupFile(f *metricFile) {
+	if f != nil {
+		f.File.Close()
+	}
+}
+
+func (s *metricFileSuite) TestRenameOnClose(c *gc.C) {
+	fileName := filepath.Join(s.spoolDir, "foo")
+	mf, err := createMetricFile(fileName)
+	c.Assert(err, gc.IsNil)
+
+	_, err = io.CopyN(mf, rand.Reader, 78666)
+	c.Assert(err, gc.IsNil)
+
+	_, err = os.Stat(fileName)
+	c.Assert(os.IsNotExist(err), jc.IsTrue)
+
+	err = mf.Close()
+	c.Assert(err, gc.IsNil)
+
+	st, err := os.Stat(fileName)
+	c.Assert(err, gc.IsNil)
+	c.Assert(st.Size(), gc.Equals, int64(78666))
+}
+
+func (s *metricFileSuite) TestContention(c *gc.C) {
+	fileName := filepath.Join(s.spoolDir, "foo")
+	mf1, err := createMetricFile(fileName)
+	c.Assert(err, gc.IsNil)
+	mf2, err := createMetricFile(fileName)
+	c.Assert(err, gc.IsNil)
+
+	_, err = fmt.Fprint(mf1, "emacs")
+	c.Assert(err, gc.IsNil)
+	_, err = fmt.Fprint(mf2, "vi")
+	c.Assert(err, gc.IsNil)
+
+	_, err = os.Stat(fileName)
+	c.Assert(os.IsNotExist(err), jc.IsTrue)
+
+	err = mf2.Close()
+	c.Assert(err, gc.IsNil)
+	err = mf1.Close()
+	c.Assert(err, gc.NotNil)
+
+	st, err := os.Stat(fileName)
+	c.Assert(err, gc.IsNil)
+	c.Assert(st.Size(), gc.Equals, int64(2))
+	contents, err := ioutil.ReadFile(fileName)
+	c.Assert(err, gc.IsNil)
+	c.Assert(contents, gc.DeepEquals, []byte("vi"))
+}

--- a/worker/uniter/metrics/metrics_test.go
+++ b/worker/uniter/metrics/metrics_test.go
@@ -13,7 +13,6 @@ import (
 	gc "gopkg.in/check.v1"
 	corecharm "gopkg.in/juju/charm.v5"
 
-	jujutesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/metrics"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -112,7 +111,6 @@ var _ = gc.Suite(&MetricsRecorderSuite{})
 func (s *MetricsRecorderSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.paths = newTestPaths(c)
-	s.PatchValue(&metrics.LockTimeout, jujutesting.ShortWait)
 }
 
 func (s *MetricsRecorderSuite) TestInit(c *gc.C) {
@@ -189,21 +187,6 @@ func (s *MetricsReaderSuite) TestTwoSimultaneousReaders(c *gc.C) {
 	c.Assert(r2, gc.NotNil)
 	err = r2.Close()
 	c.Assert(err, jc.ErrorIsNil)
-	err = r.Close()
-	c.Assert(err, jc.ErrorIsNil)
-
-}
-
-func (s *MetricsReaderSuite) TestBlockedReaders(c *gc.C) {
-	r, err := metrics.NewJSONMetricReader(s.paths.GetMetricsSpoolDir())
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = r.Read()
-	c.Assert(err, jc.ErrorIsNil)
-
-	r2, err := metrics.NewJSONMetricReader(s.paths.GetMetricsSpoolDir())
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = r2.Read()
-	c.Assert(err, gc.ErrorMatches, `lock timeout exceeded`)
 	err = r.Close()
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
The use of `utils/fslock` here is too fragile IMO. If the unit agent is killed and restarted, the "lock" is left on the filesystem. The only way to resolve it is to manually remove it (or reboot the system if the workload is Linux).

Instead of locking the spool directory, we can lock each metric batch by exploiting the atomicity of filesystem renames.

The order of operations needs to change slightly in JSONMetricsWriter in order to pull this off correctly:

1. Open the metrics (JSON) file in the spool directory, but with a unique temporary name.
2. Append objects with `json.Encoder`. FWIW, this is why we chose JSON to begin with -- it lends itself to streaming.
3. Close the metrics file and rename it to its final intended name.
4. Write a meta file in the same directory -- this is the file used by the JSONMetricsReader to "discover" new metrics and consume them -- using the same "write to a temp file, then rename on close" method.

When the meta file appears we should be able to guarantee with the above steps that:
1. Metrics file is completely written, and no other JSONMetricsWriter will try to append to it.
2. Metrics meta file is completely written.

Marking WIP because I'd like to discuss with @tasdomas to see if this sounds good, and if there are some test cases we could add.

(Review request: http://reviews.vapour.ws/r/2150/)