### PR TITLE
Move charm upgrade strp from 1.21 to 1.24 so it runs properly

### DIFF
--- a/upgrades/steps121.go
+++ b/upgrades/steps121.go
@@ -125,13 +125,6 @@ func stateStepsFor121() []Step {
 			},
 		},
 		&upgradeStep{
-			description: "migrate charm archives into environment storage",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return migrateCharmStorage(context.State(), context.AgentConfig())
-			},
-		},
-		&upgradeStep{
 			description: "migrate custom image metadata into environment storage",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps121_test.go
+++ b/upgrades/steps121_test.go
@@ -42,7 +42,6 @@ func (s *steps121Suite) TestStateStepsFor121(c *gc.C) {
 		// Non-environment UUID upgrade steps follow.
 		"rename the user LastConnection field to LastLogin",
 		"add all users in state as environment users",
-		"migrate charm archives into environment storage",
 		"migrate custom image metadata into environment storage",
 		"migrate tools into environment storage",
 		"migrate individual unit ports to openedPorts collection",

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -32,6 +32,13 @@ func stateStepsFor124() []Step {
 				return state.AddInstanceIdFieldOfIPAddresses(context.State())
 			},
 		},
+		&upgradeStep{
+			description: "migrate charm archives into environment storage",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return migrateCharmStorage(context.State(), context.AgentConfig())
+			},
+		},
 	}
 }
 

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -28,6 +28,7 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 	expected := []string{
 		"add block device documents for existing machines",
 		"add instance id field to IP addresses",
+		"migrate charm archives into environment storage",
 	}
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
 }


### PR DESCRIPTION
The upgrade step to import charms from cloud storage to environment blob store was a 1.21 upgrade step. However, this broke from 1.22 onwards due to JES collection changes filtering on env-uuid.

The easiest approach from a code perspective is simply to move the upgrade step from 1.21 to 1.24 to ensure it runs after the charm collection is upgraded in a 1.22 upgrade step.

This solution is premised on us deciding against doing another 1.22 release to fix the issue. There's a work around, so we may well stick with this solution. If not, a more comprehensive fix is required.

(Review request: http://reviews.vapour.ws/r/2153/)