### PR TITLE
Added metrics-related tests to uniter context.

### DIFF
--- a/worker/uniter/runner/export_test.go
+++ b/worker/uniter/runner/export_test.go
@@ -221,3 +221,14 @@ func SetEnvironmentHookContextRelation(
 func (ctx *HookContext) StorageAddConstraints() map[string][]params.StorageConstraints {
 	return ctx.storageAddConstraints
 }
+
+// PatchMetricsRecorder patches the metrics writer used by the context with a new
+// object.
+func PatchMetricsRecorder(ctx jujuc.Context, writer MetricsRecorder) func() {
+	hctx := ctx.(*HookContext)
+	oldRecorder := hctx.metricsRecorder
+	hctx.metricsRecorder = writer
+	return func() {
+		hctx.metricsRecorder = oldRecorder
+	}
+}

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/juju/names"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/proxy"
@@ -416,3 +418,22 @@ func (s *BlockHelper) BlockDestroyEnvironment(c *gc.C, msg string) {
 func (s *BlockHelper) Close() {
 	s.blockClient.Close()
 }
+
+// StubMetricsRecorder implements the MetricsRecorder interface.
+type StubMetricsRecorder struct {
+	*jujutesting.Stub
+}
+
+// AddMetric implements the MetricsRecorder interface.
+func (s StubMetricsRecorder) AddMetric(key, value string, created time.Time) error {
+	s.AddCall("AddMetric", key, value, created)
+	return nil
+}
+
+// Close implements the MetricsRecorder interface.
+func (s StubMetricsRecorder) Close() error {
+	s.AddCall("Close")
+	return nil
+}
+
+var _ runner.MetricsRecorder = (*StubMetricsRecorder)(nil)


### PR DESCRIPTION
When the metricsReader was moved out of context.Flush, tests executing some of the metrics capabilities went away - this patch reintroduces them.

(Review request: http://reviews.vapour.ws/r/2155/)