### PR TITLE
Add juju system remove-blocks

### DIFF
--- a/api/systemmanager/systemmanager.go
+++ b/api/systemmanager/systemmanager.go
@@ -80,3 +80,8 @@ func (c *Client) ListBlockedEnvironments() ([]params.EnvironmentBlockInfo, error
 	err := c.facade.FacadeCall("ListBlockedEnvironments", nil, &result)
 	return result.Environments, err
 }
+
+// RemoveBlocks removes all the blocks in the system.
+func (c *Client) RemoveBlocks() error {
+	return c.facade.FacadeCall("RemoveBlocks", nil, nil)
+}

--- a/api/systemmanager/systemmanager.go
+++ b/api/systemmanager/systemmanager.go
@@ -83,5 +83,6 @@ func (c *Client) ListBlockedEnvironments() ([]params.EnvironmentBlockInfo, error
 
 // RemoveBlocks removes all the blocks in the system.
 func (c *Client) RemoveBlocks() error {
-	return c.facade.FacadeCall("RemoveBlocks", nil, nil)
+	args := params.RemoveBlocksArgs{All: true}
+	return c.facade.FacadeCall("RemoveBlocks", args, nil)
 }

--- a/api/systemmanager/systemmanager_test.go
+++ b/api/systemmanager/systemmanager_test.go
@@ -99,3 +99,16 @@ func (s *systemManagerSuite) TestListBlockedEnvironments(c *gc.C) {
 		},
 	})
 }
+
+func (s *systemManagerSuite) TestRemoveBlocks(c *gc.C) {
+	s.State.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.State.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	sysManager := s.OpenAPI(c)
+	err := sysManager.RemoveBlocks()
+	c.Assert(err, jc.ErrorIsNil)
+
+	blocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocks, gc.HasLen, 0)
+}

--- a/apiserver/params/systemmanager.go
+++ b/apiserver/params/systemmanager.go
@@ -29,3 +29,10 @@ type EnvironmentBlockInfo struct {
 type EnvironmentBlockInfoList struct {
 	Environments []EnvironmentBlockInfo `json:"environments,omitempty"`
 }
+
+// RemoveBlocksArgs holds the arguments for the RemoveBlocks command. It is a
+// struct to facilitate the easy addition of being able to remove blocks for
+// individual environments at a later date.
+type RemoveBlocksArgs struct {
+	All bool `json:"all"`
+}

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -31,7 +31,7 @@ type SystemManager interface {
 	DestroySystem(args params.DestroySystemArgs) error
 	EnvironmentConfig() (params.EnvironmentConfigResults, error)
 	ListBlockedEnvironments() (params.EnvironmentBlockInfoList, error)
-	RemoveBlocks() error
+	RemoveBlocks(args params.RemoveBlocksArgs) error
 }
 
 // SystemManagerAPI implements the environment manager interface and is
@@ -246,7 +246,10 @@ func (s *SystemManagerAPI) EnvironmentConfig() (params.EnvironmentConfigResults,
 }
 
 // RemoveBlocks removes all the blocks in the system.
-func (s *SystemManagerAPI) RemoveBlocks() error {
+func (s *SystemManagerAPI) RemoveBlocks(args params.RemoveBlocksArgs) error {
+	if !args.All {
+		return errors.New("not supported")
+	}
 	return errors.Trace(s.state.RemoveAllBlocksForSystem())
 }
 

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -31,6 +31,7 @@ type SystemManager interface {
 	DestroySystem(args params.DestroySystemArgs) error
 	EnvironmentConfig() (params.EnvironmentConfigResults, error)
 	ListBlockedEnvironments() (params.EnvironmentBlockInfoList, error)
+	RemoveBlocks() error
 }
 
 // SystemManagerAPI implements the environment manager interface and is
@@ -242,6 +243,11 @@ func (s *SystemManagerAPI) EnvironmentConfig() (params.EnvironmentConfigResults,
 
 	result.Config = config.AllAttrs()
 	return result, nil
+}
+
+// RemoveBlocks removes all the blocks in the system.
+func (s *SystemManagerAPI) RemoveBlocks() error {
+	return errors.Trace(s.state.RemoveAllBlocksForSystem())
 }
 
 type orderedBlockInfo []params.EnvironmentBlockInfo

--- a/apiserver/systemmanager/systemmanager_test.go
+++ b/apiserver/systemmanager/systemmanager_test.go
@@ -167,10 +167,15 @@ func (s *systemManagerSuite) TestRemoveBlocks(c *gc.C) {
 	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
 	st.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
 
-	err := s.systemManager.RemoveBlocks()
+	err := s.systemManager.RemoveBlocks(params.RemoveBlocksArgs{All: true})
 	c.Assert(err, jc.ErrorIsNil)
 
 	blocks, err := s.State.AllBlocksForSystem()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocks, gc.HasLen, 0)
+}
+
+func (s *systemManagerSuite) TestRemoveBlocksNotAll(c *gc.C) {
+	err := s.systemManager.RemoveBlocks(params.RemoveBlocksArgs{})
+	c.Assert(err, gc.ErrorMatches, "not supported")
 }

--- a/apiserver/systemmanager/systemmanager_test.go
+++ b/apiserver/systemmanager/systemmanager_test.go
@@ -135,7 +135,7 @@ func (s *systemManagerSuite) TestListBlockedEnvironments(c *gc.C) {
 func (s *systemManagerSuite) TestListBlockedEnvironmentsNoBlocks(c *gc.C) {
 	list, err := s.systemManager.ListBlockedEnvironments()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(list.Environments), gc.Equals, 0)
+	c.Assert(list.Environments, gc.HasLen, 0)
 }
 
 func (s *systemManagerSuite) TestEnvironmentConfig(c *gc.C) {
@@ -155,4 +155,22 @@ func (s *systemManagerSuite) TestEnvironmentConfigFromNonStateServer(c *gc.C) {
 	env, err := systemManager.EnvironmentConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Config["name"], gc.Equals, "dummyenv")
+}
+
+func (s *systemManagerSuite) TestRemoveBlocks(c *gc.C) {
+	st := s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "test"})
+	defer st.Close()
+
+	s.State.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.State.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	st.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	err := s.systemManager.RemoveBlocks()
+	c.Assert(err, jc.ErrorIsNil)
+
+	blocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocks, gc.HasLen, 0)
 }

--- a/cmd/juju/system/destroy.go
+++ b/cmd/juju/system/destroy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/api/systemmanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
-	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
@@ -220,7 +219,11 @@ func (c *DestroyCommand) ensureUserFriendlyErrorLog(err error) error {
 		return nil
 	}
 	if params.IsCodeOperationBlocked(err) {
-		return block.ProcessBlockedError(err, block.BlockDestroy)
+		logger.Errorf(`there are blocks preventing system destruction
+To remove all blocks in the system, please run:
+    juju system remove-blocks
+`)
+		return cmd.ErrSilent
 	}
 	logger.Errorf(stdFailureMsg, c.systemName)
 	return err

--- a/cmd/juju/system/destroy_test.go
+++ b/cmd/juju/system/destroy_test.go
@@ -312,5 +312,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 func (s *DestroySuite) TestBlockedDestroy(c *gc.C) {
 	s.api.err = &params.Error{Code: params.CodeOperationBlocked}
 	s.runDestroyCommand(c, "test1", "-y")
-	c.Check(c.GetTestLog(), jc.Contains, "To remove the block")
+	testLog := c.GetTestLog()
+	c.Check(testLog, jc.Contains, "To remove all blocks in the system, please run:")
+	c.Check(testLog, jc.Contains, "juju system remove-blocks")
 }

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -57,6 +57,14 @@ func NewUseEnvironmentCommand(api UseEnvironmentAPI, userCreds *configstore.APIC
 	}
 }
 
+// NewRemoveBlocksCommand returns a RemoveBlocksCommand with the function used
+// to open the API connection mocked out.
+func NewRemoveBlocksCommand(api removeBlocksAPI) *RemoveBlocksCommand {
+	return &RemoveBlocksCommand{
+		api: api,
+	}
+}
+
 // Name makes the private name attribute accessible for tests.
 func (c *CreateEnvironmentCommand) Name() string {
 	return c.name

--- a/cmd/juju/system/removeblocks.go
+++ b/cmd/juju/system/removeblocks.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
+// RemoveBlocksCommand returns the list of all systems the user is
+// currently logged in to on the current machine.
+type RemoveBlocksCommand struct {
+	envcmd.SysCommandBase
+	api removeBlocksAPI
+}
+
+type removeBlocksAPI interface {
+	Close() error
+	RemoveBlocks() error
+}
+
+var removeBlocksDoc = `
+Remove all blocks in the Juju system.
+
+A system administrator is able to remove all the blocks that have been added
+in a Juju system.
+
+See Also:
+    juju help block
+    juju help unblock
+`
+
+// Info implements Command.Info
+func (c *RemoveBlocksCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "remove-blocks",
+		Purpose: "remove all blocks in the Juju system",
+		Doc:     removeBlocksDoc,
+	}
+}
+
+func (c *RemoveBlocksCommand) getAPI() (removeBlocksAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	return c.NewSystemManagerAPIClient()
+}
+
+// Run implements Command.Run
+func (c *RemoveBlocksCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer client.Close()
+	return errors.Annotatef(client.RemoveBlocks(), "cannot remove blocks")
+}

--- a/cmd/juju/system/removeblocks_test.go
+++ b/cmd/juju/system/removeblocks_test.go
@@ -1,0 +1,68 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system_test
+
+import (
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/system"
+	"github.com/juju/juju/testing"
+)
+
+type removeBlocksSuite struct {
+	testing.FakeJujuHomeSuite
+	api *fakeRemoveBlocksAPI
+}
+
+var _ = gc.Suite(&removeBlocksSuite{})
+
+func (s *removeBlocksSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+
+	err := envcmd.WriteCurrentSystem("fake")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.api = &fakeRemoveBlocksAPI{}
+}
+
+func (s *removeBlocksSuite) newCommand() cmd.Command {
+	command := system.NewRemoveBlocksCommand(s.api)
+	return envcmd.WrapSystem(command)
+}
+
+func (s *removeBlocksSuite) TestRemove(c *gc.C) {
+	_, err := testing.RunCommand(c, s.newCommand())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.api.called, jc.IsTrue)
+}
+
+func (s *removeBlocksSuite) TestUnrecognizedArg(c *gc.C) {
+	_, err := testing.RunCommand(c, s.newCommand(), "whoops")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+	c.Assert(s.api.called, jc.IsFalse)
+}
+
+func (s *removeBlocksSuite) TestEnvironmentsError(c *gc.C) {
+	s.api.err = common.ErrPerm
+	_, err := testing.RunCommand(c, s.newCommand())
+	c.Assert(err, gc.ErrorMatches, "cannot remove blocks: permission denied")
+}
+
+type fakeRemoveBlocksAPI struct {
+	err    error
+	called bool
+}
+
+func (f *fakeRemoveBlocksAPI) Close() error {
+	return nil
+}
+
+func (f *fakeRemoveBlocksAPI) RemoveBlocks() error {
+	f.called = true
+	return f.err
+}

--- a/cmd/juju/system/system.go
+++ b/cmd/juju/system/system.go
@@ -44,6 +44,7 @@ func NewSuperCommand() cmd.Command {
 	systemCmd.Register(&DestroyCommand{})
 	systemCmd.Register(envcmd.WrapSystem(&EnvironmentsCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&CreateEnvironmentCommand{}))
+	systemCmd.Register(envcmd.WrapSystem(&RemoveBlocksCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&UseEnvironmentCommand{}))
 
 	return systemCmd

--- a/cmd/juju/system/system_test.go
+++ b/cmd/juju/system/system_test.go
@@ -28,6 +28,7 @@ var expectedCommmandNames = []string{
 	"help",
 	"list",
 	"login",
+	"remove-blocks",
 	"use-env", // alias for use-environment
 	"use-environment",
 }

--- a/featuretests/cmd_juju_system_test.go
+++ b/featuretests/cmd_juju_system_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -128,4 +129,16 @@ func (s *cmdSystemSuite) TestSystemDestroy(c *gc.C) {
 	store, err := configstore.Default()
 	_, err = store.ReadInfo("dummyenv")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *cmdSystemSuite) TestRemoveBlocks(c *gc.C) {
+	c.Assert(envcmd.WriteCurrentSystem("dummyenv"), jc.ErrorIsNil)
+	s.State.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	s.State.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
+
+	s.run(c, "remove-blocks")
+
+	blocks, err := s.State.AllBlocksForSystem()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocks, gc.HasLen, 0)
 }


### PR DESCRIPTION
I thought long and hard about whether to have the command under "juju unblock system" or "juju system remove-blocks". I went for the latter in the end due to the potential confusion around the "juju block" and "juju unblock" commands.  Both of those commands only work on a single environment, and to mix that with a system based command just felt more wrong than having a different command that was responsible for removing the blocks on a system.

The output text on the 'juju system destroy' command now mentions the remove-blocks command.

(Review request: http://reviews.vapour.ws/r/2160/)