### PR TITLE
Merge pull request #2758 from wallyworld/mixed-ha-address

### DIFF
--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -155,6 +155,28 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(s.machine.MachineAddresses(), jc.DeepEquals, expectAddresses)
 }
 
+func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
+	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	setAddresses := network.NewAddresses(
+		"8.8.8.8",
+		"127.0.0.1",
+		"10.0.0.1",
+	)
+	err = machine.SetMachineAddresses(setAddresses)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine.MachineAddresses(), gc.HasLen, 3)
+
+	err = machine.SetMachineAddresses(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine.MachineAddresses(), gc.HasLen, 0)
+}
+
 func (s *machinerSuite) TestWatch(c *gc.C) {
 	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -657,6 +657,16 @@ func (s *unitSuite) TestWatchAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
+	// Change is reported for machine addresses.
+	err = s.wordpressMachine.SetMachineAddresses(network.NewAddress("0.1.2.5"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Set machine addresses to empty is reported.
+	err = s.wordpressMachine.SetMachineAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
 	// NOTE: This test is not as exhaustive as the one in state,
 	// because the watcher is already tested there. Here we just
 	// ensure we get the events when we expect them and don't get

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -184,6 +184,37 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(s.machine0.MachineAddresses(), gc.HasLen, 0)
 }
 
+func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
+	// Set some addresses so we can ensure they are removed.
+	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
+	args := params.SetMachinesAddresses{MachineAddresses: []params.MachineAddresses{
+		{Tag: "machine-1", Addresses: params.FromNetworkAddresses(addresses)},
+	}}
+	result, err := s.machiner.SetMachineAddresses(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{nil},
+		},
+	})
+	err = s.machine1.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine1.MachineAddresses(), gc.HasLen, 2)
+
+	args.MachineAddresses[0].Addresses = nil
+	result, err = s.machiner.SetMachineAddresses(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{nil},
+		},
+	})
+
+	err = s.machine1.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine1.MachineAddresses(), gc.HasLen, 0)
+}
+
 func (s *machinerSuite) TestJobs(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "machine-1"},

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -111,6 +111,7 @@ var (
 	ensureMongoAdminUser     = mongo.EnsureAdminUser
 	newSingularRunner        = singular.New
 	peergrouperNew           = peergrouper.New
+	newMachiner              = machiner.NewMachiner
 	newNetworker             = networker.NewNetworker
 	newFirewaller            = firewaller.NewFirewaller
 	newDiskManager           = diskmanager.NewWorker
@@ -746,9 +747,17 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		})
 	}
 
+	envConfig, err := st.Environment().EnvironConfig()
+	if err != nil {
+		return nil, fmt.Errorf("cannot read environment config: %v", err)
+	}
+	ignoreMachineAddresses, _ := envConfig.IgnoreMachineAddresses()
+	if ignoreMachineAddresses {
+		logger.Infof("machine addresses not used, only addresses from provider")
+	}
 	runner.StartWorker("machiner", func() (worker.Worker, error) {
 		accessor := machiner.APIMachineAccessor{st.Machiner()}
-		return machiner.NewMachiner(accessor, agentConfig), nil
+		return newMachiner(accessor, agentConfig, ignoreMachineAddresses), nil
 	})
 	runner.StartWorker("reboot", func() (worker.Worker, error) {
 		reboot, err := st.Reboot()
@@ -800,10 +809,6 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	})
 
 	// Check if the network management is disabled.
-	envConfig, err := st.Environment().EnvironConfig()
-	if err != nil {
-		return nil, fmt.Errorf("cannot read environment config: %v", err)
-	}
 	disableNetworkManagement, _ := envConfig.DisableNetworkManagement()
 	if disableNetworkManagement {
 		logger.Infof("network management is disabled")

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -190,6 +190,11 @@ const (
 	// Deprecated by use-clone
 	// LxcUseClone stores the key for this setting.
 	LxcUseClone = "lxc-use-clone"
+
+	// IgnoreMachineAddresses, when true, will cause the
+	// machine worker not to discover any machine addresses
+	// on start up.
+	IgnoreMachineAddresses = "ignore-machine-addresses"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -1137,6 +1142,13 @@ func (c *Config) DisableNetworkManagement() (bool, bool) {
 	return v, ok
 }
 
+// IgnoreMachineAddresses reports whether Juju will discover
+// and store machine addresses on startup.
+func (c *Config) IgnoreMachineAddresses() (bool, bool) {
+	v, ok := c.defined[IgnoreMachineAddresses].(bool)
+	return v, ok
+}
+
 // StorageDefaultBlockSource returns the default block storage
 // source for the environment.
 func (c *Config) StorageDefaultBlockSource() (string, bool) {
@@ -1257,6 +1269,7 @@ var alwaysOptional = schema.Defaults{
 	LxcClone:                     schema.Omit,
 	LXCDefaultMTU:                schema.Omit,
 	"disable-network-management": schema.Omit,
+	IgnoreMachineAddresses:       schema.Omit,
 	AgentStreamKey:               schema.Omit,
 	SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
 	AllowLXCLoopMounts:           false,
@@ -1328,6 +1341,7 @@ func allDefaults() schema.Defaults {
 		"proxy-ssh":                  true,
 		"prefer-ipv6":                false,
 		"disable-network-management": false,
+		IgnoreMachineAddresses:       false,
 		SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
 	}
 	for attr, val := range alwaysOptional {
@@ -1635,6 +1649,11 @@ var configSchema = environschema.Fields{
 	},
 	"disable-network-management": {
 		Description: "Whether the provider should control networks (on MAAS environments, set to true for MAAS to control networks",
+		Type:        environschema.Tbool,
+		Group:       environschema.EnvironGroup,
+	},
+	IgnoreMachineAddresses: {
+		Description: "Whether the machine worker should discover machine addresses on startup",
 		Type:        environschema.Tbool,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -406,6 +406,31 @@ var configTests = []configTest{
 			"disable-network-management": true,
 		},
 	}, {
+		about:       "Invalid ignore-machine-addresses flag",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+			"ignore-machine-addresses": "invalid",
+		},
+		err: `ignore-machine-addresses: expected bool, got string\("invalid"\)`,
+	}, {
+		about:       "ignore-machine-addresses off",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+			"ignore-machine-addresses": false,
+		},
+	}, {
+		about:       "ignore-machine-addresses on",
+		useDefaults: config.UseDefaults,
+		attrs: testing.Attrs{
+			"type": "my-type",
+			"name": "my-name",
+			"ignore-machine-addresses": true,
+		},
+	}, {
 		about:       "set-numa-control-policy on",
 		useDefaults: config.UseDefaults,
 		attrs: testing.Attrs{

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1960,6 +1960,28 @@ func (s *MachineSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(machine.MachineAddresses(), jc.DeepEquals, expectedAddresses)
 }
 
+func (s *MachineSuite) TestSetEmptyMachineAddresses(c *gc.C) {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.Addresses(), gc.HasLen, 0)
+
+	// Add some machine addresses initially to make sure they're removed.
+	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
+	err = machine.SetMachineAddresses(addresses...)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.MachineAddresses(), gc.HasLen, 2)
+
+	// Make call with empty address list.
+	err = machine.SetMachineAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(machine.MachineAddresses(), gc.HasLen, 0)
+}
+
 func (s *MachineSuite) TestMergedAddresses(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Fix for bug 1463480 - allow disable of machiner setting addresses

Fixes: https://bugs.launchpad.net/juju-core/+bug/1463480

As per Dimiter's instructions, a new config attribute as been added: ignore-machine-addresses
This prevents the machiner from setting the discovered machines addreses on startup.
Setting the addresses to empty overwrites any that are there and triggers a machine address watcher event which causes a unit config changed hook.

(Review request: http://reviews.vapour.ws/r/2138/)

(Review request: http://reviews.vapour.ws/r/2162/)