### PR TITLE
upgrades: migrate 1.24.{0,1} rsyslog config

### DIFF
--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -57,8 +57,8 @@ var upgradeOperations = func() []Operation {
 			stepsFor123(),
 		},
 		upgradeToVersion{
-			version.MustParse("1.24.0"),
-			stepsFor124(),
+			version.MustParse("1.24.3"),
+			stepsFor1243(),
 		},
 	}
 	return steps

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -671,7 +671,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0", "1.24.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0", "1.24.3"})
 }
 
 func extractUpgradeVersions(c *gc.C, ops []upgrades.Operation) []string {


### PR DESCRIPTION
In 1.24.0, there was an upgrade step introduced
that migrated rsyslog certs and other config files
from LogDir to DataDir. In 1.24.2 this was changed
to go from LogDir to ConfDir, but there was no
consideration for environments that were already
upgraded to 1.24.0.

This means the rsyslog config gets left behind in
DataDir, and new config gets generated by the rsyslog
worker. Each state server does this, which then
causes an initial problems with inconsistencies
between CA certs and certs generate for rsyslog.

We fix this by checking in both DataDir and LogDir
for config to migrate; we stop at DataDir if we
find it there, otherwise check in LogDir.

Fixes https://bugs.launchpad.net/juju-core/+bug/1474614

(Review request: http://reviews.vapour.ws/r/2164/)