### PR TITLE
Merge pull request #2762 from wallyworld/certchanged-channel-close

### DIFF
--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -201,6 +201,11 @@ func updateRequired(serverCert string, newAddrs []string) ([]string, bool, error
 
 // TearDown is defined on the NotifyWatchHandler interface.
 func (c *CertificateUpdater) TearDown() error {
-	close(c.certChanged)
+	select {
+	case <-c.certChanged:
+		// already closed
+	default:
+		close(c.certChanged)
+	}
 	return nil
 }


### PR DESCRIPTION
Ensure cert changed channel only closed once

Fixes: https://bugs.launchpad.net/juju-core/+bug/1472729

Looking at the logs in the above bug, agent shutdown can result in attempting to close the cert changed channel twice.

(Review request: http://reviews.vapour.ws/r/2142/)

(Review request: http://reviews.vapour.ws/r/2166/)