### PR TITLE
Fixes a test failure

### DIFF
--- a/worker/logsender/bufferedlogwriter_test.go
+++ b/worker/logsender/bufferedlogwriter_test.go
@@ -126,7 +126,7 @@ func (s *bufferedLogWriterSuite) TestClose(c *gc.C) {
 	}
 
 	// Further Write attempts should fail.
-	c.Assert(func() { s.writeAndReceive(c) }, gc.PanicMatches, ".+ send on closed channel")
+	c.Assert(func() { s.writeAndReceive(c) }, gc.PanicMatches, ".*send on closed channel")
 }
 
 func (s *bufferedLogWriterSuite) TestInstallBufferedLogWriter(c *gc.C) {


### PR DESCRIPTION
bufferedlogwriter_test.go:129:
    // Further Write attempts should fail.
    c.Assert(func() { s.writeAndReceive(c) }, gc.PanicMatches, ".+ send on closed channel")
... panic string = "send on closed channel"
... expected string = ".+ send on closed channel"

using golang 1.4

(Review request: http://reviews.vapour.ws/r/2168/)