### PR TITLE
uniter/runner: Added juju-units built in metric.

### DIFF
--- a/worker/uniter/metrics/metrics.go
+++ b/worker/uniter/metrics/metrics.go
@@ -163,12 +163,19 @@ func (m *JSONMetricRecorder) Close() error {
 
 // AddMetric implements the MetricsRecorder interface.
 func (m *JSONMetricRecorder) AddMetric(key, value string, created time.Time) error {
-	if _, ok := m.validMetrics[key]; !ok {
+	if !m.IsValidMetric(key) {
 		return errors.Errorf("invalid metric key: %v", key)
 	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	return errors.Trace(m.enc.Encode(jujuc.Metric{Key: key, Value: value, Time: created}))
+}
+
+// IsValidMetric returns true if the metric the recorder is permitted to store this metric.
+// Returns false if the uniter using this recorder doesn't define this metric.
+func (m *JSONMetricRecorder) IsValidMetric(key string) bool {
+	_, ok := m.validMetrics[key]
+	return ok
 }
 
 func (m *JSONMetricRecorder) open() error {

--- a/worker/uniter/metrics/metrics.go
+++ b/worker/uniter/metrics/metrics.go
@@ -163,17 +163,17 @@ func (m *JSONMetricRecorder) Close() error {
 
 // AddMetric implements the MetricsRecorder interface.
 func (m *JSONMetricRecorder) AddMetric(key, value string, created time.Time) error {
-	if !m.IsValidMetric(key) {
-		return errors.Errorf("invalid metric key: %v", key)
+	if !m.IsDeclaredMetric(key) {
+		return errors.Errorf("metric key %q not declared by the charm", key)
 	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	return errors.Trace(m.enc.Encode(jujuc.Metric{Key: key, Value: value, Time: created}))
 }
 
-// IsValidMetric returns true if the metric the recorder is permitted to store this metric.
+// IsDeclaredMetric returns true if the metric recorder is permitted to store this metric.
 // Returns false if the uniter using this recorder doesn't define this metric.
-func (m *JSONMetricRecorder) IsValidMetric(key string) bool {
+func (m *JSONMetricRecorder) IsDeclaredMetric(key string) bool {
 	_, ok := m.validMetrics[key]
 	return ok
 }

--- a/worker/uniter/metrics/metrics_test.go
+++ b/worker/uniter/metrics/metrics_test.go
@@ -143,7 +143,7 @@ func (s *MetricsRecorderSuite) TestUnknownMetricKey(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 	err = w.AddMetric("pings", "5", time.Now())
-	c.Assert(err, gc.ErrorMatches, "invalid metric key: pings")
+	c.Assert(err, gc.ErrorMatches, `metric key "pings" not declared by the charm`)
 	err = w.Close()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -36,7 +36,7 @@ type meterStatus struct {
 // MetricsRecorder is used to store metrics supplied by the add-metric command.
 type MetricsRecorder interface {
 	AddMetric(key, value string, created time.Time) error
-	IsValidMetric(key string) bool
+	IsDeclaredMetric(key string) bool
 	Close() error
 }
 
@@ -557,8 +557,8 @@ func (ctx *HookContext) handleReboot(err *error) {
 // addJujuUnitsMetric adds the juju-units built in metric if it
 // is defined for this context.
 func (ctx *HookContext) addJujuUnitsMetric() error {
-	if ctx.metricsRecorder.IsValidMetric("juju-units") {
-		err := ctx.metricsRecorder.AddMetric("juju-units", "1", time.Now())
+	if ctx.metricsRecorder.IsDeclaredMetric("juju-units") {
+		err := ctx.metricsRecorder.AddMetric("juju-units", "1", time.Now().UTC())
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -85,8 +85,8 @@ func (s *InterfaceSuite) TestAddingMetricsWhenNotEnabledFails(c *gc.C) {
 
 func (s *InterfaceSuite) TestAddingMetrics(c *gc.C) {
 	uuid := utils.MustNewUUID()
-	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"))
-	cleanup := runner.PatchMetricsRecorder(ctx, StubMetricsRecorder{&s.stub})
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"), NewRealPaths(c))
+	cleanup := runner.PatchMetricsRecorder(ctx, &StubMetricsRecorder{&s.stub})
 	defer cleanup()
 
 	now := time.Now()

--- a/worker/uniter/runner/flush_test.go
+++ b/worker/uniter/runner/flush_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/worker/uniter/metrics"
 	"github.com/juju/juju/worker/uniter/runner"
 )
 
@@ -23,6 +24,11 @@ type FlushContextSuite struct {
 }
 
 var _ = gc.Suite(&FlushContextSuite{})
+
+func (s *FlushContextSuite) SetUpTest(c *gc.C) {
+	s.HookContextSuite.SetUpTest(c)
+	s.stub.ResetCalls()
+}
 
 func (s *FlushContextSuite) TestRunHookRelationFlushingError(c *gc.C) {
 	ctx := s.context(c)
@@ -204,9 +210,9 @@ func (s *FlushContextSuite) TestRunHookAddUnitStorageOnSuccess(c *gc.C) {
 
 func (s *FlushContextSuite) TestFlushClosesMetricsRecorder(c *gc.C) {
 	uuid := utils.MustNewUUID()
-	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"))
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"), NewRealPaths(c))
 
-	runner.PatchMetricsRecorder(ctx, StubMetricsRecorder{&s.stub})
+	runner.PatchMetricsRecorder(ctx, &StubMetricsRecorder{&s.stub})
 
 	err := ctx.AddMetric("key", "value", time.Now())
 
@@ -214,15 +220,55 @@ func (s *FlushContextSuite) TestFlushClosesMetricsRecorder(c *gc.C) {
 	err = ctx.FlushContext("success", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.stub.CheckCalls(c,
-		[]testing.StubCall{{
-			FuncName: "Close",
-		}})
-
+	s.stub.CheckCallNames(c, "IsValidMetric", "AddMetric", "Close")
 }
 
 func (s *HookContextSuite) context(c *gc.C) *runner.HookContext {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	return s.getHookContext(c, uuid.String(), -1, "", noProxies)
+}
+
+func (s *FlushContextSuite) TestBuiltinMetric(c *gc.C) {
+	uuid := utils.MustNewUUID()
+	paths := NewRealPaths(c)
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("juju-units"), paths)
+	reader, err := metrics.NewJSONMetricReader(
+		paths.GetMetricsSpoolDir(),
+	)
+
+	err = ctx.FlushContext("some badge", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	metrics, err := reader.Read()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metrics, gc.HasLen, 1)
+	c.Assert(metrics[0].Metrics, gc.HasLen, 1)
+	c.Assert(metrics[0].Metrics[0].Key, gc.Equals, "juju-units")
+	c.Assert(metrics[0].Metrics[0].Value, gc.Equals, "1")
+}
+
+func (s *FlushContextSuite) TestBuiltinMetricNotGeneratedIfNotDefined(c *gc.C) {
+	uuid := utils.MustNewUUID()
+	paths := NewRealPaths(c)
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("pings"), paths)
+	reader, err := metrics.NewJSONMetricReader(
+		paths.GetMetricsSpoolDir(),
+	)
+
+	err = ctx.FlushContext("some badge", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	metrics, err := reader.Read()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metrics, gc.HasLen, 0)
+}
+
+func (s *FlushContextSuite) TestRecorderIsClosedAfterBuiltIn(c *gc.C) {
+	uuid := utils.MustNewUUID()
+	paths := NewRealPaths(c)
+	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("juju-units"), paths)
+	runner.PatchMetricsRecorder(ctx, &StubMetricsRecorder{&s.stub})
+
+	err := ctx.FlushContext("some badge", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.CheckCallNames(c, "IsValidMetric", "AddMetric", "Close")
 }

--- a/worker/uniter/runner/flush_test.go
+++ b/worker/uniter/runner/flush_test.go
@@ -220,7 +220,7 @@ func (s *FlushContextSuite) TestFlushClosesMetricsRecorder(c *gc.C) {
 	err = ctx.FlushContext("success", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.stub.CheckCallNames(c, "IsValidMetric", "AddMetric", "Close")
+	s.stub.CheckCallNames(c, "IsDeclaredMetric", "AddMetric", "Close")
 }
 
 func (s *HookContextSuite) context(c *gc.C) *runner.HookContext {
@@ -239,12 +239,12 @@ func (s *FlushContextSuite) TestBuiltinMetric(c *gc.C) {
 
 	err = ctx.FlushContext("some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	metrics, err := reader.Read()
+	batches, err := reader.Read()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(metrics, gc.HasLen, 1)
-	c.Assert(metrics[0].Metrics, gc.HasLen, 1)
-	c.Assert(metrics[0].Metrics[0].Key, gc.Equals, "juju-units")
-	c.Assert(metrics[0].Metrics[0].Value, gc.Equals, "1")
+	c.Assert(batches, gc.HasLen, 1)
+	c.Assert(batches[0].Metrics, gc.HasLen, 1)
+	c.Assert(batches[0].Metrics[0].Key, gc.Equals, "juju-units")
+	c.Assert(batches[0].Metrics[0].Value, gc.Equals, "1")
 }
 
 func (s *FlushContextSuite) TestBuiltinMetricNotGeneratedIfNotDefined(c *gc.C) {
@@ -257,9 +257,9 @@ func (s *FlushContextSuite) TestBuiltinMetricNotGeneratedIfNotDefined(c *gc.C) {
 
 	err = ctx.FlushContext("some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	metrics, err := reader.Read()
+	batches, err := reader.Read()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(metrics, gc.HasLen, 0)
+	c.Assert(batches, gc.HasLen, 0)
 }
 
 func (s *FlushContextSuite) TestRecorderIsClosedAfterBuiltIn(c *gc.C) {
@@ -270,5 +270,5 @@ func (s *FlushContextSuite) TestRecorderIsClosedAfterBuiltIn(c *gc.C) {
 
 	err := ctx.FlushContext("some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.stub.CheckCallNames(c, "IsValidMetric", "AddMetric", "Close")
+	s.stub.CheckCallNames(c, "IsDeclaredMetric", "AddMetric", "Close")
 }

--- a/worker/uniter/runner/jujuc/add-metric.go
+++ b/worker/uniter/runner/jujuc/add-metric.go
@@ -5,12 +5,15 @@ package jujuc
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils/keyvalues"
 )
+
+const builtinMetricPrexix string = "juju"
 
 // Metric represents a single metric set by the charm.
 type Metric struct {
@@ -24,6 +27,11 @@ type AddMetricCommand struct {
 	cmd.CommandBase
 	ctx     Context
 	Metrics []Metric
+}
+
+// IsBuiltinMetric returns true if the metric key provided is in the builtin metric namespace.
+func IsBuiltinMetric(key string) bool {
+	return strings.HasPrefix(key, builtinMetricPrexix)
 }
 
 // NewAddMetricCommand generates a new AddMetricCommand.
@@ -59,6 +67,9 @@ func (c *AddMetricCommand) Init(args []string) error {
 // Run adds metrics to the hook context.
 func (c *AddMetricCommand) Run(ctx *cmd.Context) (err error) {
 	for _, metric := range c.Metrics {
+		if IsBuiltinMetric(metric.Key) {
+			return errors.Errorf("%v is in the builtin metric namespace", metric.Key)
+		}
 		err := c.ctx.AddMetric(metric.Key, metric.Value, metric.Time)
 		if err != nil {
 			return errors.Annotate(err, "cannot record metric")

--- a/worker/uniter/runner/jujuc/add-metric.go
+++ b/worker/uniter/runner/jujuc/add-metric.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/utils/keyvalues"
 )
 
-const builtinMetricPrexix string = "juju"
+const builtinMetricPrefix string = "juju"
 
 // Metric represents a single metric set by the charm.
 type Metric struct {
@@ -31,7 +31,7 @@ type AddMetricCommand struct {
 
 // IsBuiltinMetric returns true if the metric key provided is in the builtin metric namespace.
 func IsBuiltinMetric(key string) bool {
-	return strings.HasPrefix(key, builtinMetricPrexix)
+	return strings.HasPrefix(key, builtinMetricPrefix)
 }
 
 // NewAddMetricCommand generates a new AddMetricCommand.
@@ -68,7 +68,7 @@ func (c *AddMetricCommand) Init(args []string) error {
 func (c *AddMetricCommand) Run(ctx *cmd.Context) (err error) {
 	for _, metric := range c.Metrics {
 		if IsBuiltinMetric(metric.Key) {
-			return errors.Errorf("%v is in the builtin metric namespace", metric.Key)
+			return errors.Errorf("%v uses a reserved prefix", metric.Key)
 		}
 		err := c.ctx.AddMetric(metric.Key, metric.Value, metric.Time)
 		if err != nil {

--- a/worker/uniter/runner/jujuc/add-metric_test.go
+++ b/worker/uniter/runner/jujuc/add-metric_test.go
@@ -139,7 +139,7 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			true,
 			1,
 			"",
-			"error: juju-key is in the builtin metric namespace\n",
+			"error: juju-key uses a reserved prefix\n",
 			nil,
 		}}
 	for i, t := range testCases {

--- a/worker/uniter/runner/jujuc/add-metric_test.go
+++ b/worker/uniter/runner/jujuc/add-metric_test.go
@@ -133,6 +133,14 @@ func (s *AddMetricSuite) TestAddMetric(c *gc.C) {
 			"",
 			"error: cannot record metric: metrics disabled\n",
 			nil,
+		}, {
+			"cannot add builtin metric",
+			[]string{"add-metric", "juju-key=50"},
+			true,
+			1,
+			"",
+			"error: juju-key is in the builtin metric namespace\n",
+			nil,
 		}}
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -264,7 +264,7 @@ func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int,
 }
 
 func (s *HookContextSuite) getMeteredHookContext(c *gc.C, uuid string, relid int,
-	remote string, proxies proxy.Settings, canAddMetrics bool, metrics *charm.Metrics) *runner.HookContext {
+	remote string, proxies proxy.Settings, canAddMetrics bool, metrics *charm.Metrics, paths RealPaths) *runner.HookContext {
 	if relid != -1 {
 		_, found := s.apiRelunits[relid]
 		c.Assert(found, jc.IsTrue)
@@ -280,7 +280,7 @@ func (s *HookContextSuite) getMeteredHookContext(c *gc.C, uuid string, relid int
 
 	context, err := runner.NewHookContext(s.meteredApiUnit, facade, "TestCtx", uuid,
 		"test-env-name", relid, remote, relctxs, apiAddrs, names.NewUserTag("owner"),
-		proxies, canAddMetrics, metrics, nil, s.machine.Tag().(names.MachineTag), NewRealPaths(c))
+		proxies, canAddMetrics, metrics, nil, s.machine.Tag().(names.MachineTag), paths)
 	c.Assert(err, jc.ErrorIsNil)
 	return context
 }
@@ -428,6 +428,11 @@ type StubMetricsRecorder struct {
 func (s StubMetricsRecorder) AddMetric(key, value string, created time.Time) error {
 	s.AddCall("AddMetric", key, value, created)
 	return nil
+}
+
+func (mr *StubMetricsRecorder) IsValidMetric(key string) bool {
+	mr.MethodCall(mr, "IsValidMetric", key)
+	return true
 }
 
 // Close implements the MetricsRecorder interface.

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -430,8 +430,8 @@ func (s StubMetricsRecorder) AddMetric(key, value string, created time.Time) err
 	return nil
 }
 
-func (mr *StubMetricsRecorder) IsValidMetric(key string) bool {
-	mr.MethodCall(mr, "IsValidMetric", key)
+func (mr *StubMetricsRecorder) IsDeclaredMetric(key string) bool {
+	mr.MethodCall(mr, "IsDeclaredMetric", key)
 	return true
 }
 


### PR DESCRIPTION
Also prevent the add-metric tool from adding metrics that exist in the reserved namespace.

(Review request: http://reviews.vapour.ws/r/2173/)