### PR TITLE
Fix for bug 1471936: suite.TestRunCmd shows script failure

### DIFF
--- a/process/plugin/plugin.go
+++ b/process/plugin/plugin.go
@@ -133,14 +133,14 @@ func (p Plugin) Status(id string) (process.Status, error) {
 
 // run runs the given subcommand of the plugin with the given args.
 func (p Plugin) run(subcommand string, args ...string) ([]byte, error) {
-	return runCmd(p.Name, p.Executable, subcommand, args...)
+	cmd := exec.Command(p.Executable, append([]string{subcommand}, args...)...)
+	return runCmd(p.Name, cmd)
 }
 
 // runCmd runs the executable at path with the subcommand as the first argument
 // and any args in args as further arguments.  It logs to loggo using the name
 // as a namespace.
-var runCmd = func(name, path, subcommand string, args ...string) ([]byte, error) {
-	cmd := exec.Command(path, append([]string{subcommand}, args...)...)
+var runCmd = func(name string, cmd *exec.Cmd) ([]byte, error) {
 	log := getLogger("juju.process.plugin." + name)
 	stdout := &bytes.Buffer{}
 	cmd.Stdout = stdout


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/juju-core/+bug/1471936

I was doing a lot of ugly script generation, but since then have figured out a better way to mock out running commands, so we only ever rely on Go code, not OS-specific scripting languages.  This means that if the code works on one platform, it'll work on all of them.

This code utilizes the testing executable itself to have a runnable command that can be controlled via environment variables.  More details on how this works can be seen here: https://npf.io/2015/06/testing-exec-command/

(Review request: http://reviews.vapour.ws/r/2174/)