### PR TITLE
Add system kill command.

### DIFF
--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -89,9 +89,11 @@ func (c *CreateEnvironmentCommand) ConfValues() map[string]string {
 // endpoints mocked out.
 func NewDestroyCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error) *DestroyCommand {
 	return &DestroyCommand{
-		api:       api,
-		clientapi: clientapi,
-		apierr:    apierr,
+		DestroyCommandBase: DestroyCommandBase{
+			api:       api,
+			clientapi: clientapi,
+			apierr:    apierr,
+		},
 	}
 }
 
@@ -99,7 +101,7 @@ func NewDestroyCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr 
 // endpoints mocked out.
 func NewKillCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error) *KillCommand {
 	return &KillCommand{
-		DestroyCommand{
+		DestroyCommandBase{
 			api:       api,
 			clientapi: clientapi,
 			apierr:    apierr,

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -85,12 +85,24 @@ func (c *CreateEnvironmentCommand) ConfValues() map[string]string {
 	return c.confValues
 }
 
-// NewDestroyCommand returns a DestroyCommand with the the environmentmanager and client
+// NewDestroyCommand returns a DestroyCommand with the the systemmanager and client
 // endpoints mocked out.
 func NewDestroyCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error) *DestroyCommand {
 	return &DestroyCommand{
 		api:       api,
 		clientapi: clientapi,
 		apierr:    apierr,
+	}
+}
+
+// NewKillCommand returns a KillCommand with the the systemmanager and client
+// endpoints mocked out.
+func NewKillCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error) *KillCommand {
+	return &KillCommand{
+		DestroyCommand{
+			api:       api,
+			clientapi: clientapi,
+			apierr:    apierr,
+		},
 	}
 }

--- a/cmd/juju/system/kill.go
+++ b/cmd/juju/system/kill.go
@@ -1,0 +1,162 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system
+
+import (
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/systemmanager"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/juju"
+)
+
+var (
+	killDoc         = `Forcefully destroys the specified system`
+	DialAPI         = juju.NewAPIFromName
+	apiTimeout      = 10 * time.Second
+	ErrConnTimedOut = errors.New("connection to state server timed out")
+)
+
+// KillCommand kills the specified system.
+type KillCommand struct {
+	DestroyCommand
+}
+
+// Info implements Command.Info.
+func (c *KillCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "kill",
+		Args:    "<system name>",
+		Purpose: "forcefully terminate all machines and other associated resources for a system environment",
+		Doc:     killDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *KillCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation")
+	f.BoolVar(&c.assumeYes, "yes", false, "")
+}
+
+func (c *KillCommand) getSystemAPI(info configstore.EnvironInfo) (destroySystemAPI, error) {
+	if c.api != nil {
+		return c.api, c.apierr
+	}
+
+	// Attempt to connect to the API with a short timeout
+	apic := make(chan *api.State)
+	errc := make(chan error)
+	go func() {
+		api, dialErr := DialAPI(c.systemName)
+		if dialErr != nil {
+			errc <- dialErr
+			return
+		}
+		apic <- api
+	}()
+
+	var apiRoot *api.State
+	select {
+	case err := <-errc:
+		return nil, err
+	case apiRoot = <-apic:
+	case <-time.After(apiTimeout):
+		return nil, ErrConnTimedOut
+	}
+
+	return systemmanager.NewClient(apiRoot), nil
+}
+
+// Run implements Command.Run
+func (c *KillCommand) Run(ctx *cmd.Context) error {
+	store, err := configstore.Default()
+	if err != nil {
+		return errors.Annotate(err, "cannot open system info storage")
+	}
+
+	cfgInfo, err := store.ReadInfo(c.systemName)
+	if err != nil {
+		return errors.Annotate(err, "cannot read system info")
+	}
+
+	// Verify that we're destroying a system
+	apiEndpoint := cfgInfo.APIEndpoint()
+	if apiEndpoint.ServerUUID != "" && apiEndpoint.EnvironUUID != apiEndpoint.ServerUUID {
+		return errors.Errorf("%q is not a system; use juju environment destroy to destroy it", c.systemName)
+	}
+
+	if !c.assumeYes {
+		if err = confirmDestruction(ctx, c.systemName); err != nil {
+			return err
+		}
+	}
+
+	// Attempt to connect to the API.
+	api, err := c.getSystemAPI(cfgInfo)
+	switch {
+	case err == nil:
+		defer api.Close()
+	case errors.Cause(err) == common.ErrPerm:
+		return errors.Annotate(err, "cannot destroy system")
+	case errors.IsNotFound(err):
+		// TODO (cherylj) display message about how to clean up jenv / cache file
+		// once a command is created to do so?
+		return errors.Annotate(err, "cannot destroy system")
+	default:
+		logger.Infof("Unable to open API: %s\n", err)
+		api = nil
+	}
+
+	// Obtain bootstrap / system environ information
+	systemEnviron, err := c.getSystemEnviron(cfgInfo, api)
+	if err != nil {
+		return errors.Annotate(err, "cannot obtain bootstrap information")
+	}
+
+	// If we were unable to connect to the API, just destroy the system through
+	// the environs interface.
+	if api == nil {
+		return environs.Destroy(systemEnviron, store)
+	}
+
+	// Attempt to destroy the system with destroyEnvs and ignoreBlocks = true
+	err = api.DestroySystem(true, true)
+	if params.IsCodeNotImplemented(err) {
+		// Fall back to using the client endpoint to destroy the system,
+		// sending the info we were already able to collect.
+		return c.killSystemViaClient(ctx, cfgInfo, systemEnviron, store)
+	}
+
+	if err != nil {
+		logger.Infof("Unable to destroy system through the API: %s.  Destroying through provider.", err)
+	}
+
+	return environs.Destroy(systemEnviron, store)
+}
+
+// killSystemViaClient attempts to kill the system using the client
+// endpoint for older juju systems which do not implement systemmanager.DestroySystem
+func (c *KillCommand) killSystemViaClient(ctx *cmd.Context, info configstore.EnvironInfo, systemEnviron environs.Environ, store configstore.Storage) error {
+	api, err := c.getClientAPI()
+	if err != nil {
+		defer api.Close()
+	}
+
+	if api != nil {
+		err = api.DestroyEnvironment()
+		if err != nil {
+			logger.Infof("Unable to destroy system through the API: %s.  Destroying through provider.", err)
+		}
+	}
+
+	return environs.Destroy(systemEnviron, store)
+}

--- a/cmd/juju/system/kill_test.go
+++ b/cmd/juju/system/kill_test.go
@@ -1,0 +1,185 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system_test
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/system"
+	cmdtesting "github.com/juju/juju/cmd/testing"
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
+)
+
+type KillSuite struct {
+	DestroySuite
+}
+
+var _ = gc.Suite(&KillSuite{})
+
+func (s *KillSuite) SetUpTest(c *gc.C) {
+	s.DestroySuite.SetUpTest(c)
+}
+
+func (s *KillSuite) runKillCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	cmd := system.NewKillCommand(s.api, s.clientapi, s.apierror)
+	return testing.RunCommand(c, cmd, args...)
+}
+
+func (s *KillSuite) newKillCommand() *system.KillCommand {
+	return system.NewKillCommand(s.api, s.clientapi, s.apierror)
+}
+
+func (s *KillSuite) TestKillNoSystemNameError(c *gc.C) {
+	_, err := s.runKillCommand(c)
+	c.Assert(err, gc.ErrorMatches, "no system specified")
+}
+
+func (s *KillSuite) TestKillBadFlags(c *gc.C) {
+	_, err := s.runKillCommand(c, "-n")
+	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: -n")
+}
+
+func (s *KillSuite) TestKillUnknownArgument(c *gc.C) {
+	_, err := s.runKillCommand(c, "environment", "whoops")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+}
+
+func (s *KillSuite) TestKillUnknownSystem(c *gc.C) {
+	_, err := s.runKillCommand(c, "foo")
+	c.Assert(err, gc.ErrorMatches, `cannot read system info: environment "foo" not found`)
+}
+
+func (s *KillSuite) TestKillNonSystemEnvFails(c *gc.C) {
+	_, err := s.runKillCommand(c, "test2")
+	c.Assert(err, gc.ErrorMatches, "\"test2\" is not a system; use juju environment destroy to destroy it")
+}
+
+func (s *KillSuite) TestDestroySystemNotFoundNotRemovedFromStore(c *gc.C) {
+	s.apierror = errors.NotFoundf("test1")
+	_, err := s.runKillCommand(c, "test1", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot destroy system: test1 not found")
+	checkSystemExistsInStore(c, "test1", s.store)
+}
+
+func (s *KillSuite) TestKillCannotConnectToAPISucceeds(c *gc.C) {
+	s.apierror = errors.New("connection refused")
+	_, err := s.runKillCommand(c, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(c.GetTestLog(), jc.Contains, "Unable to open API: connection refused")
+	checkSystemRemovedFromStore(c, "test1", s.store)
+
+	// Check that we didn't call the API
+	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
+}
+
+func (s *KillSuite) TestKillWithAPIConnection(c *gc.C) {
+	_, err := s.runKillCommand(c, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.api.ignoreBlocks, jc.IsTrue)
+	c.Assert(s.api.destroyAll, jc.IsTrue)
+	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *KillSuite) TestKillEnvironmentGetFailsWithoutAPIConnection(c *gc.C) {
+	s.apierror = errors.New("connection refused")
+	s.api.err = errors.NotFoundf(`system "test3"`)
+	_, err := s.runKillCommand(c, "test3", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot obtain bootstrap information: unable to get bootstrap information from API")
+	checkSystemExistsInStore(c, "test3", s.store)
+}
+
+func (s *KillSuite) TestKillEnvironmentGetFailsWithAPIConnection(c *gc.C) {
+	s.api.err = errors.NotFoundf(`system "test3"`)
+	_, err := s.runKillCommand(c, "test3", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot obtain bootstrap information: system \"test3\" not found")
+	checkSystemExistsInStore(c, "test3", s.store)
+}
+
+func (s *KillSuite) TestKillFallsBackToClient(c *gc.C) {
+	s.api.err = &params.Error{"DestroySystem", params.CodeNotImplemented}
+	_, err := s.runKillCommand(c, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.clientapi.destroycalled, jc.IsTrue)
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *KillSuite) TestClientKillDestroysSystemWithAPIError(c *gc.C) {
+	s.api.err = &params.Error{"DestroySystem", params.CodeNotImplemented}
+	s.clientapi.err = errors.New("some destroy error")
+	_, err := s.runKillCommand(c, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(c.GetTestLog(), jc.Contains, "Unable to destroy system through the API: some destroy error.  Destroying through provider.")
+	c.Assert(s.clientapi.destroycalled, jc.IsTrue)
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *KillSuite) TestKillDestroysSystemWithAPIError(c *gc.C) {
+	s.api.err = errors.New("some destroy error")
+	_, err := s.runKillCommand(c, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(c.GetTestLog(), jc.Contains, "Unable to destroy system through the API: some destroy error.  Destroying through provider.")
+	c.Assert(s.api.ignoreBlocks, jc.IsTrue)
+	c.Assert(s.api.destroyAll, jc.IsTrue)
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *KillSuite) TestKillCommandConfirmation(c *gc.C) {
+	var stdin, stdout bytes.Buffer
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
+	ctx.Stdout = &stdout
+	ctx.Stdin = &stdin
+
+	// Ensure confirmation is requested if "-y" is not specified.
+	stdin.WriteString("n")
+	_, errc := cmdtesting.RunCommand(ctx, s.newKillCommand(), "test1")
+	select {
+	case err := <-errc:
+		c.Check(err, gc.ErrorMatches, "system destruction aborted")
+	case <-time.After(testing.LongWait):
+		c.Fatalf("command took too long")
+	}
+	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
+	checkSystemExistsInStore(c, "test1", s.store)
+}
+
+func (s *KillSuite) TestKillAPIPermErrFails(c *gc.C) {
+	testDialer := func(sysName string) (*api.State, error) {
+		return nil, common.ErrPerm
+	}
+	s.PatchValue(&system.DialAPI, testDialer)
+
+	cmd := system.NewKillCommand(nil, nil, nil)
+	_, err := testing.RunCommand(c, cmd, "test1", "-y")
+	c.Assert(err, gc.ErrorMatches, "cannot destroy system: permission denied")
+	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
+	checkSystemExistsInStore(c, "test1", s.store)
+}
+
+func (s *KillSuite) TestKillEarlyAPIConnectionTimeout(c *gc.C) {
+	testDialer := func(sysName string) (*api.State, error) {
+		time.Sleep(5 * time.Minute)
+		return nil, errors.New("kill command waited too long")
+	}
+	s.PatchValue(&system.DialAPI, testDialer)
+
+	cmd := system.NewKillCommand(nil, nil, nil)
+	_, err := testing.RunCommand(c, cmd, "test1", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(c.GetTestLog(), jc.Contains, "Unable to open API: connection to state server timed out")
+	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
+	c.Assert(s.api.destroyAll, jc.IsFalse)
+	checkSystemRemovedFromStore(c, "test1", s.store)
+}

--- a/cmd/juju/system/system.go
+++ b/cmd/juju/system/system.go
@@ -42,6 +42,7 @@ func NewSuperCommand() cmd.Command {
 	systemCmd.Register(&ListCommand{})
 	systemCmd.Register(&LoginCommand{})
 	systemCmd.Register(&DestroyCommand{})
+	systemCmd.Register(&KillCommand{})
 	systemCmd.Register(envcmd.WrapSystem(&EnvironmentsCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&CreateEnvironmentCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&RemoveBlocksCommand{}))

--- a/cmd/juju/system/system_test.go
+++ b/cmd/juju/system/system_test.go
@@ -26,6 +26,7 @@ var expectedCommmandNames = []string{
 	"destroy",
 	"environments",
 	"help",
+	"kill",
 	"list",
 	"login",
 	"remove-blocks",

--- a/featuretests/cmd_juju_system_test.go
+++ b/featuretests/cmd_juju_system_test.go
@@ -142,3 +142,17 @@ func (s *cmdSystemSuite) TestRemoveBlocks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocks, gc.HasLen, 0)
 }
+
+func (s *cmdSystemSuite) TestSystemKill(c *gc.C) {
+	st := s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name: "foo",
+	})
+	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
+	st.Close()
+
+	s.run(c, "kill", "dummyenv", "-y")
+
+	store, err := configstore.Default()
+	_, err = store.ReadInfo("dummyenv")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}


### PR DESCRIPTION
This new command will forcefully kill the system,
even if the state server is unreachable.  The
command will attempt to contact the state server
and will perform access checks and to attempt to
clean up the system and any hosted environments,
if the state server is reachable.

(Review request: http://reviews.vapour.ws/r/2177/)