### PR TITLE
Don't automatically add env life assertions to txns

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -279,6 +279,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+	prereqOps = append(prereqOps, assertEnvAliveOp(st.EnvironUUID()))
 	prereqOps = append(prereqOps, st.insertNewContainerRefOp(mdoc.Id))
 	if template.InstanceId != "" {
 		prereqOps = append(prereqOps, txn.Op{
@@ -300,6 +301,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 			},
 		})
 	}
+
 	return mdoc, append(prereqOps, machineOp), nil
 }
 

--- a/state/environ.go
+++ b/state/environ.go
@@ -120,7 +120,7 @@ func (st *State) NewEnvironment(cfg *config.Config, owner names.UserTag) (_ *Env
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "failed to create new environment")
 	}
-	err = newState.runTransactionNoEnvAliveAssert(ops)
+	err = newState.runTransaction(ops)
 	if err == txn.ErrAborted {
 
 		// We have a  unique key restriction on the "owner" and "name" fields,

--- a/state/environ.go
+++ b/state/environ.go
@@ -441,9 +441,15 @@ func createUniqueOwnerEnvNameOp(owner names.UserTag, envName string) txn.Op {
 
 // assertAliveOp returns a txn.Op that asserts the environment is alive.
 func (e *Environment) assertAliveOp() txn.Op {
+	return assertEnvAliveOp(e.UUID())
+}
+
+// assertAliveOp returns a txn.Op that asserts the given environment
+// UUID refers to an alive environment.
+func assertEnvAliveOp(envUUID string) txn.Op {
 	return txn.Op{
 		C:      environmentsC,
-		Id:     e.UUID(),
+		Id:     envUUID,
 		Assert: isEnvAliveDoc,
 	}
 }

--- a/state/environ.go
+++ b/state/environ.go
@@ -462,3 +462,13 @@ func assertEnvAliveOp(envUUID string) txn.Op {
 var isEnvAliveDoc = bson.D{
 	{"life", bson.D{{"$in", []interface{}{Alive, nil}}}},
 }
+
+func checkEnvLife(st *State) error {
+	env, err := st.Environment()
+	if (err == nil && env.Life() != Alive) || errors.IsNotFound(err) {
+		return errors.New("environment is no longer alive")
+	} else if err != nil {
+		return errors.Annotate(err, "unable to read environment")
+	}
+	return nil
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -78,7 +78,7 @@ func SetRetryHooks(c *gc.C, st *State, block, check func()) txntesting.Transacti
 }
 
 func newMultiEnvRunnerForHooks(st *State) jujutxn.Runner {
-	runner := newMultiEnvRunner(st.EnvironUUID(), st.db, txnAssertEnvIsAlive)
+	runner := newMultiEnvRunner(st.EnvironUUID(), st.db)
 	st.transactionRunner = runner
 	return getRawRunner(runner)
 }
@@ -305,9 +305,8 @@ func GetRawCollection(st *State, name string) (*mgo.Collection, func()) {
 
 func NewMultiEnvRunnerForTesting(envUUID string, baseRunner jujutxn.Runner) jujutxn.Runner {
 	return &multiEnvRunner{
-		rawRunner:      baseRunner,
-		envUUID:        envUUID,
-		assertEnvAlive: true,
+		rawRunner: baseRunner,
+		envUUID:   envUUID,
 	}
 }
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -1207,20 +1207,23 @@ func (m *Machine) AddNetworkInterface(args NetworkInterfaceInfo) (iface *Network
 		return nil, fmt.Errorf("interface name must be not empty")
 	}
 	doc := newNetworkInterfaceDoc(m.doc.Id, m.st.EnvironUUID(), args)
-	ops := []txn.Op{{
-		C:      networksC,
-		Id:     m.st.docID(args.NetworkName),
-		Assert: txn.DocExists,
-	}, {
-		C:      machinesC,
-		Id:     m.doc.DocID,
-		Assert: isAliveDoc,
-	}, {
-		C:      networkInterfacesC,
-		Id:     doc.Id,
-		Assert: txn.DocMissing,
-		Insert: doc,
-	}}
+	ops := []txn.Op{
+		assertEnvAliveOp(m.st.EnvironUUID()),
+		{
+			C:      networksC,
+			Id:     m.st.docID(args.NetworkName),
+			Assert: txn.DocExists,
+		}, {
+			C:      machinesC,
+			Id:     m.doc.DocID,
+			Assert: isAliveDoc,
+		}, {
+			C:      networkInterfacesC,
+			Id:     doc.Id,
+			Assert: txn.DocMissing,
+			Insert: doc,
+		},
+	}
 
 	err = m.st.runTransaction(ops)
 	switch err {

--- a/state/networkinterfaces.go
+++ b/state/networkinterfaces.go
@@ -206,8 +206,12 @@ func (ni *NetworkInterface) setDisabled(shouldDisable bool) error {
 	if err != nil {
 		return err
 	}
+	ops = append(ops, assertEnvAliveOp(ni.st.EnvironUUID()))
 	err = ni.st.runTransaction(ops)
 	if err != nil {
+		if err := checkEnvLife(ni.st); err != nil {
+			return errors.Trace(err)
+		}
 		return onAbort(err, errors.NotFoundf("network interface"))
 	}
 	ni.doc.IsDisabled = shouldDisable

--- a/state/open.go
+++ b/state/open.go
@@ -122,7 +122,7 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 		},
 	)
 
-	if err := st.runTransactionNoEnvAliveAssert(ops); err != nil {
+	if err := st.runTransaction(ops); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return st, nil

--- a/state/ports.go
+++ b/state/ports.go
@@ -200,6 +200,9 @@ func (p *Ports) OpenPorts(portRange PortRange) (err error) {
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
+			if err := checkEnvLife(p.st); err != nil {
+				return nil, errors.Trace(err)
+			}
 			if err = ports.Refresh(); errors.IsNotFound(err) {
 				// No longer exists, we'll create it.
 				if !ports.areNew {
@@ -226,15 +229,19 @@ func (p *Ports) OpenPorts(portRange PortRange) (err error) {
 			}
 		}
 
+		ops := []txn.Op{
+			assertEnvAliveOp(p.st.EnvironUUID()),
+		}
 		if ports.areNew {
 			// Create a new document.
 			assert := txn.DocMissing
-			return addPortsDocOps(p.st, &ports.doc, assert, portRange)
+			ops = append(ops, addPortsDocOps(p.st, &ports.doc, assert, portRange)...)
 		} else {
 			// Update an existing document.
 			assert := bson.D{{"txn-revno", ports.doc.TxnRevno}}
-			return updatePortsDocOps(p.st, ports.doc, assert, portRange), nil
+			ops = append(ops, updatePortsDocOps(p.st, ports.doc, assert, portRange)...)
 		}
+		return ops, nil
 	}
 	// Run the transaction using the state transaction runner.
 	if err = p.st.run(buildTxn); err != nil {
@@ -389,7 +396,7 @@ func (m *Machine) AllPorts() ([]*Ports, error) {
 // statement for on the openedPorts collection op.
 var addPortsDocOps = addPortsDocOpsFunc
 
-func addPortsDocOpsFunc(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) ([]txn.Op, error) {
+func addPortsDocOpsFunc(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) []txn.Op {
 	pDoc.Ports = ports
 	return []txn.Op{{
 		C:      machinesC,
@@ -400,7 +407,7 @@ func addPortsDocOpsFunc(st *State, pDoc *portsDoc, portsAssert interface{}, port
 		Id:     pDoc.DocID,
 		Assert: portsAssert,
 		Insert: pDoc,
-	}}, nil
+	}}
 }
 
 // updatePortsDocOps returns the ops for adding a port range to an

--- a/state/state.go
+++ b/state/state.go
@@ -1320,10 +1320,7 @@ func (st *State) AddService(
 	ops = append(ops, peerOps...)
 
 	if err := st.runTransaction(ops); err == txn.ErrAborted {
-		err := env.Refresh()
-		if (err == nil && env.Life() != Alive) || errors.IsNotFound(err) {
-			return nil, errors.Errorf("environment is no longer alive")
-		} else if err != nil {
+		if err := checkEnvLife(st); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return nil, errors.Errorf("service already exists")

--- a/state/state.go
+++ b/state/state.go
@@ -1362,16 +1362,22 @@ func (st *State) AddIPAddress(addr network.Address, subnetid string) (ipaddress 
 	}
 
 	ipaddress = &IPAddress{doc: ipDoc, st: st}
-	ops := []txn.Op{{
-		C:      ipaddressesC,
-		Id:     addressID,
-		Assert: txn.DocMissing,
-		Insert: ipDoc,
-	}}
+	ops := []txn.Op{
+		assertEnvAliveOp(st.EnvironUUID()),
+		{
+			C:      ipaddressesC,
+			Id:     addressID,
+			Assert: txn.DocMissing,
+			Insert: ipDoc,
+		},
+	}
 
 	err = st.runTransaction(ops)
 	switch err {
 	case txn.ErrAborted:
+		if err := checkEnvLife(st); err != nil {
+			return nil, errors.Trace(err)
+		}
 		if _, err = st.IPAddress(addr.Value); err == nil {
 			return nil, errors.AlreadyExistsf("address")
 		}
@@ -1452,16 +1458,22 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 	if err != nil {
 		return nil, err
 	}
-	ops := []txn.Op{{
-		C:      subnetsC,
-		Id:     subnetID,
-		Assert: txn.DocMissing,
-		Insert: subDoc,
-	}}
+	ops := []txn.Op{
+		assertEnvAliveOp(st.EnvironUUID()),
+		{
+			C:      subnetsC,
+			Id:     subnetID,
+			Assert: txn.DocMissing,
+			Insert: subDoc,
+		},
+	}
 
 	err = st.runTransaction(ops)
 	switch err {
 	case txn.ErrAborted:
+		if err := checkEnvLife(st); err != nil {
+			return nil, errors.Trace(err)
+		}
 		if _, err = st.Subnet(args.CIDR); err == nil {
 			return nil, errors.AlreadyExistsf("subnet %q", args.CIDR)
 		} else if err != nil {
@@ -1518,15 +1530,21 @@ func (st *State) AddNetwork(args NetworkInfo) (n *Network, err error) {
 		return nil, errors.Errorf("invalid VLAN tag %d: must be between 0 and 4094", args.VLANTag)
 	}
 	doc := st.newNetworkDoc(args)
-	ops := []txn.Op{{
-		C:      networksC,
-		Id:     doc.DocID,
-		Assert: txn.DocMissing,
-		Insert: doc,
-	}}
+	ops := []txn.Op{
+		assertEnvAliveOp(st.EnvironUUID()),
+		{
+			C:      networksC,
+			Id:     doc.DocID,
+			Assert: txn.DocMissing,
+			Insert: doc,
+		},
+	}
 	err = st.runTransaction(ops)
 	switch err {
 	case txn.ErrAborted:
+		if err := checkEnvLife(st); err != nil {
+			return nil, errors.Trace(err)
+		}
 		if _, err = st.Network(args.Name); err == nil {
 			return nil, errors.AlreadyExistsf("network %q", args.Name)
 		} else if err != nil {

--- a/state/txns.go
+++ b/state/txns.go
@@ -171,14 +171,6 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) []txn.Op {
 	return ops
 }
 
-func assertEnvAliveOp(envUUID string) txn.Op {
-	return txn.Op{
-		C:      environmentsC,
-		Id:     envUUID,
-		Assert: isEnvAliveDoc,
-	}
-}
-
 var envAliveColls = newEnvAliveColls()
 
 // newEnvAliveColls returns a copy of multiEnvCollections minus cleanupsC.

--- a/state/txns.go
+++ b/state/txns.go
@@ -14,11 +14,6 @@ import (
 	"gopkg.in/mgo.v2/txn"
 )
 
-const (
-	txnAssertEnvIsAlive    = true
-	txnAssertEnvIsNotAlive = false
-)
-
 // txnRunner returns a jujutxn.Runner instance.
 //
 // If st.transactionRunner is non-nil, then that will be
@@ -33,25 +28,7 @@ func (st *State) txnRunner(session *mgo.Session) jujutxn.Runner {
 	if st.transactionRunner != nil {
 		return st.transactionRunner
 	}
-	return newMultiEnvRunner(st.EnvironUUID(), st.db.With(session), txnAssertEnvIsAlive)
-}
-
-// txnRunnerNoEnvAliveAssert returns a jujutxn.Runner instance that does not
-// add an assertion for a live environment to the transaction. It was
-// introduced only to allow the initial environment to be created and should
-// be used rarely.
-func (st *State) txnRunnerNoEnvAliveAssert(session *mgo.Session) jujutxn.Runner {
-	if st.transactionRunner != nil {
-		return st.transactionRunner
-	}
-	return newMultiEnvRunner(st.EnvironUUID(), st.db.With(session), txnAssertEnvIsNotAlive)
-}
-
-// runTransactionNoEnvAliveAssert is a convenience method delegating to txnRunnerNoEnvAliveAssert.
-func (st *State) runTransactionNoEnvAliveAssert(ops []txn.Op) error {
-	session := st.db.Session.Copy()
-	defer session.Close()
-	return st.txnRunnerNoEnvAliveAssert(session).RunTransaction(ops)
+	return newMultiEnvRunner(st.EnvironUUID(), st.db.With(session))
 }
 
 // runTransaction is a convenience method delegating to transactionRunner.
@@ -83,18 +60,16 @@ func (st *State) MaybePruneTransactions() error {
 	return st.txnRunner(session).MaybePruneTransactions(2.0)
 }
 
-func newMultiEnvRunner(envUUID string, db *mgo.Database, assertEnvAlive bool) jujutxn.Runner {
+func newMultiEnvRunner(envUUID string, db *mgo.Database) jujutxn.Runner {
 	return &multiEnvRunner{
-		rawRunner:      jujutxn.NewRunner(jujutxn.RunnerParams{Database: db}),
-		envUUID:        envUUID,
-		assertEnvAlive: assertEnvAlive,
+		rawRunner: jujutxn.NewRunner(jujutxn.RunnerParams{Database: db}),
+		envUUID:   envUUID,
 	}
 }
 
 type multiEnvRunner struct {
-	rawRunner      jujutxn.Runner
-	envUUID        string
-	assertEnvAlive bool
+	rawRunner jujutxn.Runner
+	envUUID   string
 }
 
 // RunTransaction is part of the jujutxn.Runner interface. Operations
@@ -133,7 +108,6 @@ func (r *multiEnvRunner) MaybePruneTransactions(pruneFactor float32) error {
 }
 
 func (r *multiEnvRunner) updateOps(ops []txn.Op) []txn.Op {
-	var opsNeedEnvAlive bool
 	for i, op := range ops {
 		if multiEnvCollections.Contains(op.C) {
 			var docID interface{}
@@ -159,14 +133,8 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) []txn.Op {
 					}
 
 				}
-				if r.assertEnvAlive && !opsNeedEnvAlive && envAliveColls.Contains(op.C) {
-					opsNeedEnvAlive = true
-				}
 			}
 		}
-	}
-	if opsNeedEnvAlive {
-		ops = append(ops, assertEnvAliveOp(r.envUUID))
 	}
 	return ops
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1797,7 +1797,7 @@ func (s *upgradesSuite) patchPortOptFuncs() {
 
 	s.PatchValue(
 		&addPortsDocOps,
-		func(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) ([]txn.Op, error) {
+		func(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) []txn.Op {
 			pDoc.Ports = ports
 			return []txn.Op{{
 				C:      machinesC,
@@ -1808,7 +1808,7 @@ func (s *upgradesSuite) patchPortOptFuncs() {
 				Id:     portsGlobalKey(pDoc.MachineID, pDoc.NetworkName),
 				Assert: portsAssert,
 				Insert: pDoc,
-			}}, nil
+			}}
 		})
 
 	s.PatchValue(


### PR DESCRIPTION
The multiEnvRunner will no longer automatically add assertions on environment life to transactions as this create a serious performance bottleneck. Instead, the env is asserted to be alive in specific key areas (mainly where a txn may result in provisioning of resources).

Fixes LP #1474195

(Review request: http://reviews.vapour.ws/r/2180/)