### PR TITLE
Second go at fixing charm migration

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -4,19 +4,13 @@
 package state
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -24,7 +18,6 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider"
-	"github.com/juju/juju/state/storage"
 )
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
@@ -949,108 +942,4 @@ func FixSequenceFields(st *State) error {
 		return err
 	}
 	return st.runRawTransaction(ops)
-}
-
-// Patched for testing.
-var (
-	charmBundleURL            = (*Charm).BundleURL
-	charmStoragePath          = (*Charm).StoragePath
-	stateAddCharmStoragePaths = AddCharmStoragePaths
-)
-
-// MigrateCharmStorage is an upgrade step only which copies uploaded
-// charms from provider storage to environment storage, and then adds
-// the storage path into the charm's document in state.
-func MigrateCharmStorage(st *State, providerType, storageDir string) error {
-	logger.Debugf("migrating charms to environment storage")
-	// Load the charms from a raw collection as this step is done
-	// before the env UUID migration.
-	charmsCollection, closer := st.getRawCollection(charmsC)
-	defer closer()
-
-	var charms []*Charm
-	var cdoc charmDoc
-	iter := charmsCollection.Find(nil).Iter()
-	for iter.Next(&cdoc) {
-		charms = append(charms, newCharm(st, &cdoc))
-	}
-
-	if err := iter.Close(); err != nil {
-		return errors.Trace(err)
-	}
-	storage := storage.NewStorage(st.EnvironUUID(), st.MongoSession())
-
-	// Local and manual provider host storage on the state server's
-	// filesystem, and serve via HTTP storage. The storage worker
-	// doesn't run yet, so we just open the files directly.
-	fetchCharmArchive := fetchCharmArchive
-	if providerType == provider.Local || provider.IsManual(providerType) {
-		fetchCharmArchive = localstorage{storageDir}.fetchCharmArchive
-	}
-
-	storagePaths := make(map[*charm.URL]string)
-	for _, ch := range charms {
-		if ch.IsPlaceholder() {
-			logger.Debugf("skipping %s, placeholder charm", ch.URL())
-			continue
-		}
-		if !ch.IsUploaded() {
-			logger.Debugf("skipping %s, not uploaded to provider storage", ch.URL())
-			continue
-		}
-		if charmStoragePath(ch) != "" {
-			logger.Debugf("skipping %s, already in environment storage", ch.URL())
-			continue
-		}
-		url := charmBundleURL(ch)
-		if url == nil {
-			logger.Debugf("skipping %s, has no bundle URL", ch.URL())
-			continue
-		}
-		uuid, err := utils.NewUUID()
-		if err != nil {
-			return err
-		}
-		data, err := fetchCharmArchive(url)
-		if err != nil {
-			return err
-		}
-
-		curl := ch.URL()
-		storagePath := fmt.Sprintf("charms/%s-%s", curl, uuid)
-		logger.Debugf("uploading %s to %q in environment storage", curl, storagePath)
-		err = storage.Put(storagePath, bytes.NewReader(data), int64(len(data)))
-		if err != nil {
-			return errors.Annotatef(err, "failed to upload %s to storage", curl)
-		}
-		storagePaths[curl] = storagePath
-	}
-
-	return stateAddCharmStoragePaths(st, storagePaths)
-}
-
-func fetchCharmArchive(url *url.URL) ([]byte, error) {
-	client := utils.GetNonValidatingHTTPClient()
-	resp, err := client.Get(url.String())
-	if err != nil {
-		return nil, errors.Annotatef(err, "cannot get %q", url)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, errors.Annotatef(err, "cannot read charm archive")
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("cannot get %q: %s %s", url, resp.Status, body)
-	}
-	return body, nil
-}
-
-type localstorage struct {
-	storageDir string
-}
-
-func (s localstorage) fetchCharmArchive(url *url.URL) ([]byte, error) {
-	path := filepath.Join(s.storageDir, url.Path)
-	return ioutil.ReadFile(path)
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5,9 +5,6 @@ package state
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/url"
-	"path/filepath"
 	"time"
 
 	"github.com/juju/errors"
@@ -20,15 +17,13 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
 
-type baseUpgradesSuite struct {
+type upgradesSuite struct {
 	gitjujutesting.CleanupSuite
 	testing.BaseSuite
 	gitjujutesting.MgoSuite
@@ -36,19 +31,19 @@ type baseUpgradesSuite struct {
 	owner names.UserTag
 }
 
-func (s *baseUpgradesSuite) SetUpSuite(c *gc.C) {
+func (s *upgradesSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
 	s.CleanupSuite.SetUpSuite(c)
 }
 
-func (s *baseUpgradesSuite) TearDownSuite(c *gc.C) {
+func (s *upgradesSuite) TearDownSuite(c *gc.C) {
 	s.CleanupSuite.TearDownSuite(c)
 	s.MgoSuite.TearDownSuite(c)
 	s.BaseSuite.TearDownSuite(c)
 }
 
-func (s *baseUpgradesSuite) SetUpTest(c *gc.C) {
+func (s *upgradesSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
 	s.CleanupSuite.SetUpTest(c)
@@ -58,17 +53,13 @@ func (s *baseUpgradesSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *baseUpgradesSuite) TearDownTest(c *gc.C) {
+func (s *upgradesSuite) TearDownTest(c *gc.C) {
 	if s.state != nil {
 		s.state.Close()
 	}
 	s.CleanupSuite.TearDownTest(c)
 	s.MgoSuite.TearDownTest(c)
 	s.BaseSuite.TearDownTest(c)
-}
-
-type upgradesSuite struct {
-	baseUpgradesSuite
 }
 
 var _ = gc.Suite(&upgradesSuite{})
@@ -2026,111 +2017,4 @@ func (s *upgradesSuite) TestFixSequenceFields(c *gc.C) {
 		EnvUUID: uuid,
 		Counter: 4,
 	}})
-}
-
-type migrateCharmStorageSuite struct {
-	baseUpgradesSuite
-	bundleURLs map[string]*url.URL
-}
-
-var _ = gc.Suite(&migrateCharmStorageSuite{})
-
-func (s *migrateCharmStorageSuite) SetUpTest(c *gc.C) {
-	s.baseUpgradesSuite.SetUpTest(c)
-	s.bundleURLs = make(map[string]*url.URL)
-
-	s.PatchValue(&charmBundleURL, func(ch *Charm) *url.URL {
-		return s.bundleURLs[ch.URL().String()]
-	})
-	s.PatchValue(&charmStoragePath, func(ch *Charm) string {
-		// pretend none of the charms have storage paths
-		return ""
-	})
-}
-
-func (s *migrateCharmStorageSuite) TestMigrateCharmStorage(c *gc.C) {
-	// Make a fake storage for the charms and add a charm.
-	dir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(dir, "somewhere"), []byte("abc"), 0644)
-	c.Assert(err, jc.ErrorIsNil)
-	stor, err := filestorage.NewFileStorageReader(dir)
-	c.Assert(err, jc.ErrorIsNil)
-
-	dummyCharm := AddTestingCharm(c, s.state, "dummy")
-	dummyCharmURL, err := stor.URL("somewhere")
-	c.Assert(err, jc.ErrorIsNil)
-	url, err := url.Parse(dummyCharmURL)
-	c.Assert(err, jc.ErrorIsNil)
-	s.bundleURLs[dummyCharm.URL().String()] = url
-
-	s.testMigrateCharmStorage(c, dummyCharm.URL(), "", "")
-}
-
-func (s *migrateCharmStorageSuite) TestMigrateCharmStorageLocalstorage(c *gc.C) {
-	storageDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(storageDir, "somewhere"), []byte("abc"), 0644)
-	c.Assert(err, jc.ErrorIsNil)
-
-	dummyCharm := AddTestingCharm(c, s.state, "dummy")
-	url := &url.URL{Scheme: "https", Host: "localhost:8040", Path: "/somewhere"}
-	c.Assert(err, jc.ErrorIsNil)
-	s.bundleURLs[dummyCharm.URL().String()] = url
-
-	s.testMigrateCharmStorage(c, dummyCharm.URL(), "local", storageDir)
-}
-
-func (s *migrateCharmStorageSuite) testMigrateCharmStorage(c *gc.C, curl *charm.URL, providerType, storageDir string) {
-	curlPlaceholder := charm.MustParseURL("cs:quantal/dummy-1")
-	err := s.state.AddStoreCharmPlaceholder(curlPlaceholder)
-	c.Assert(err, jc.ErrorIsNil)
-
-	curlPending := charm.MustParseURL("cs:quantal/missing-123")
-	_, err = s.state.PrepareStoreCharmUpload(curlPending)
-	c.Assert(err, jc.ErrorIsNil)
-
-	var storagePath string
-	var called bool
-	s.PatchValue(&stateAddCharmStoragePaths, func(st *State, storagePaths map[*charm.URL]string) error {
-		c.Assert(storagePaths, gc.HasLen, 1)
-		for k, v := range storagePaths {
-			c.Assert(k.String(), gc.Equals, curl.String())
-			storagePath = v
-		}
-		called = true
-		return nil
-	})
-	err = MigrateCharmStorage(s.state, providerType, storageDir)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
-
-	storage := storage.NewStorage(s.state.EnvironUUID(), s.state.MongoSession())
-	r, length, err := storage.Get(storagePath)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(r, gc.NotNil)
-	defer r.Close()
-	c.Assert(length, gc.Equals, int64(3))
-	data, err := ioutil.ReadAll(r)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(data), gc.Equals, "abc")
-}
-
-func (s *migrateCharmStorageSuite) TestMigrateCharmStorageIdempotency(c *gc.C) {
-	// If MigrateCharmStorage is called a second time, it will
-	// leave alone the charms that have already been migrated.
-	// The final step of migration is a transactional update
-	// of the charm document in state, which is what we base
-	// the decision on.
-	s.PatchValue(&charmStoragePath, func(ch *Charm) string {
-		return "alreadyset"
-	})
-	AddTestingCharm(c, s.state, "dummy")
-	var called bool
-	s.PatchValue(&stateAddCharmStoragePaths, func(st *State, storagePaths map[*charm.URL]string) error {
-		c.Assert(storagePaths, gc.HasLen, 0)
-		called = true
-		return nil
-	})
-	err := MigrateCharmStorage(s.state, "", "")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }

--- a/upgrades/charmstorage.go
+++ b/upgrades/charmstorage.go
@@ -1,0 +1,116 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"gopkg.in/juju/charm.v4"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/provider"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/storage"
+)
+
+var (
+	charmBundleURL            = (*state.Charm).BundleURL
+	charmStoragePath          = (*state.Charm).StoragePath
+	stateAddCharmStoragePaths = state.AddCharmStoragePaths
+)
+
+// migrateCharmStorage copies uploaded charms from provider storage
+// to environment storage, and then adds the storage path into the
+// charm's document in state.
+func migrateCharmStorage(st *state.State, agentConfig agent.Config) error {
+	logger.Debugf("migrating charms to environment storage")
+	charms, err := st.AllCharms()
+	if err != nil {
+		return err
+	}
+	storage := storage.NewStorage(st.EnvironUUID(), st.MongoSession())
+
+	// Local and manual provider host storage on the state server's
+	// filesystem, and serve via HTTP storage. The storage worker
+	// doesn't run yet, so we just open the files directly.
+	fetchCharmArchive := fetchCharmArchive
+	providerType := agentConfig.Value(agent.ProviderType)
+	if providerType == provider.Local || provider.IsManual(providerType) {
+		storageDir := agentConfig.Value(agent.StorageDir)
+		fetchCharmArchive = localstorage{storageDir}.fetchCharmArchive
+	}
+
+	storagePaths := make(map[*charm.URL]string)
+	for _, ch := range charms {
+		if ch.IsPlaceholder() {
+			logger.Debugf("skipping %s, placeholder charm", ch.URL())
+			continue
+		}
+		if !ch.IsUploaded() {
+			logger.Debugf("skipping %s, not uploaded to provider storage", ch.URL())
+			continue
+		}
+		if charmStoragePath(ch) != "" {
+			logger.Debugf("skipping %s, already in environment storage", ch.URL())
+			continue
+		}
+		url := charmBundleURL(ch)
+		if url == nil {
+			logger.Debugf("skipping %s, has no bundle URL", ch.URL())
+			continue
+		}
+		uuid, err := utils.NewUUID()
+		if err != nil {
+			return err
+		}
+		data, err := fetchCharmArchive(url)
+		if err != nil {
+			return err
+		}
+
+		curl := ch.URL()
+		storagePath := fmt.Sprintf("charms/%s-%s", curl, uuid)
+		logger.Debugf("uploading %s to %q in environment storage", curl, storagePath)
+		err = storage.Put(storagePath, bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			return errors.Annotatef(err, "failed to upload %s to storage", curl)
+		}
+		storagePaths[curl] = storagePath
+	}
+
+	return stateAddCharmStoragePaths(st, storagePaths)
+}
+
+func fetchCharmArchive(url *url.URL) ([]byte, error) {
+	client := utils.GetNonValidatingHTTPClient()
+	resp, err := client.Get(url.String())
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get %q", url)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot read charm archive")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("cannot get %q: %s %s", url, resp.Status, body)
+	}
+	return body, nil
+}
+
+type localstorage struct {
+	storageDir string
+}
+
+func (s localstorage) fetchCharmArchive(url *url.URL) ([]byte, error) {
+	path := filepath.Join(s.storageDir, url.Path)
+	return ioutil.ReadFile(path)
+}

--- a/upgrades/charmstorage_test.go
+++ b/upgrades/charmstorage_test.go
@@ -1,0 +1,132 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	"io/ioutil"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/environs"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/storage"
+	"github.com/juju/juju/upgrades"
+)
+
+type migrateCharmStorageSuite struct {
+	jujutesting.JujuConnSuite
+
+	bundleURLs map[string]*url.URL
+}
+
+var _ = gc.Suite(&migrateCharmStorageSuite{})
+
+func (s *migrateCharmStorageSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.bundleURLs = make(map[string]*url.URL)
+
+	s.PatchValue(upgrades.CharmBundleURL, func(ch *state.Charm) *url.URL {
+		return s.bundleURLs[ch.URL().String()]
+	})
+	s.PatchValue(upgrades.CharmStoragePath, func(ch *state.Charm) string {
+		// pretend none of the charms have storage paths
+		return ""
+	})
+}
+
+func (s *migrateCharmStorageSuite) TestMigrateCharmStorage(c *gc.C) {
+	stor := s.Environ.(environs.EnvironStorage).Storage()
+	err := stor.Put("somewhere", strings.NewReader("abc"), 3)
+	c.Assert(err, jc.ErrorIsNil)
+
+	dummyCharm := s.AddTestingCharm(c, "dummy")
+	dummyCharmURL, err := stor.URL("somewhere")
+	c.Assert(err, jc.ErrorIsNil)
+	url, err := url.Parse(dummyCharmURL)
+	c.Assert(err, jc.ErrorIsNil)
+	s.bundleURLs[dummyCharm.URL().String()] = url
+
+	s.testMigrateCharmStorage(c, dummyCharm.URL(), &mockAgentConfig{})
+}
+
+func (s *migrateCharmStorageSuite) TestMigrateCharmStorageLocalstorage(c *gc.C) {
+	storageDir := c.MkDir()
+	err := ioutil.WriteFile(filepath.Join(storageDir, "somewhere"), []byte("abc"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	dummyCharm := s.AddTestingCharm(c, "dummy")
+	url := &url.URL{Scheme: "https", Host: "localhost:8040", Path: "/somewhere"}
+	c.Assert(err, jc.ErrorIsNil)
+	s.bundleURLs[dummyCharm.URL().String()] = url
+
+	s.testMigrateCharmStorage(c, dummyCharm.URL(), &mockAgentConfig{
+		values: map[string]string{
+			agent.ProviderType: "local",
+			agent.StorageDir:   storageDir,
+		},
+	})
+}
+
+func (s *migrateCharmStorageSuite) testMigrateCharmStorage(c *gc.C, curl *charm.URL, agentConfig agent.Config) {
+	curlPlaceholder := charm.MustParseURL("cs:quantal/dummy-1")
+	err := s.State.AddStoreCharmPlaceholder(curlPlaceholder)
+	c.Assert(err, jc.ErrorIsNil)
+
+	curlPending := charm.MustParseURL("cs:quantal/missing-123")
+	_, err = s.State.PrepareStoreCharmUpload(curlPending)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var storagePath string
+	var called bool
+	s.PatchValue(upgrades.StateAddCharmStoragePaths, func(st *state.State, storagePaths map[*charm.URL]string) error {
+		c.Assert(storagePaths, gc.HasLen, 1)
+		for k, v := range storagePaths {
+			c.Assert(k.String(), gc.Equals, curl.String())
+			storagePath = v
+		}
+		called = true
+		return nil
+	})
+	err = upgrades.MigrateCharmStorage(s.State, agentConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+
+	storage := storage.NewStorage(s.State.EnvironUUID(), s.State.MongoSession())
+	r, length, err := storage.Get(storagePath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, gc.NotNil)
+	defer r.Close()
+	c.Assert(length, gc.Equals, int64(3))
+	data, err := ioutil.ReadAll(r)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "abc")
+}
+
+func (s *migrateCharmStorageSuite) TestMigrateCharmStorageIdempotency(c *gc.C) {
+	// If MigrateCharmStorage is called a second time, it will
+	// leave alone the charms that have already been migrated.
+	// The final step of migration is a transactional update
+	// of the charm document in state, which is what we base
+	// the decision on.
+	s.PatchValue(upgrades.CharmStoragePath, func(ch *state.Charm) string {
+		return "alreadyset"
+	})
+	s.AddTestingCharm(c, "dummy")
+	var called bool
+	s.PatchValue(upgrades.StateAddCharmStoragePaths, func(st *state.State, storagePaths map[*charm.URL]string) error {
+		c.Assert(storagePaths, gc.HasLen, 0)
+		called = true
+		return nil
+	})
+	err := upgrades.MigrateCharmStorage(s.State, &mockAgentConfig{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -4,14 +4,17 @@
 package upgrades
 
 var (
-	UpgradeOperations      = &upgradeOperations
-	StateUpgradeOperations = &stateUpgradeOperations
-	UbuntuHome             = &ubuntuHome
-	RootLogDir             = &rootLogDir
-	RootSpoolDir           = &rootSpoolDir
-	NewStateStorage        = &newStateStorage
-	StateToolsStorage      = &stateToolsStorage
-	AddAZToInstData        = &addAZToInstData
+	UpgradeOperations         = &upgradeOperations
+	StateUpgradeOperations    = &stateUpgradeOperations
+	UbuntuHome                = &ubuntuHome
+	RootLogDir                = &rootLogDir
+	RootSpoolDir              = &rootSpoolDir
+	CharmBundleURL            = &charmBundleURL
+	CharmStoragePath          = &charmStoragePath
+	StateAddCharmStoragePaths = &stateAddCharmStoragePaths
+	NewStateStorage           = &newStateStorage
+	StateToolsStorage         = &stateToolsStorage
+	AddAZToInstData           = &addAZToInstData
 
 	ChownPath      = &chownPath
 	IsLocalEnviron = &isLocalEnviron
@@ -33,4 +36,5 @@ var (
 	EnsureSystemSSHKeyRedux               = ensureSystemSSHKeyRedux
 	UpdateAuthorizedKeysForSystemIdentity = updateAuthorizedKeysForSystemIdentity
 	AddAvaililityZoneToInstanceData       = addAvaililityZoneToInstanceData
+	MigrateCharmStorage                   = migrateCharmStorage
 )

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -27,6 +27,10 @@ var stateUpgradeOperations = func() []Operation {
 			version.MustParse("1.22.0"),
 			stateStepsFor122(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.22.7"),
+			stateStepsFor1227(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps121.go
+++ b/upgrades/steps121.go
@@ -4,7 +4,6 @@
 package upgrades
 
 import (
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/state"
 )
 
@@ -123,18 +122,6 @@ func stateStepsFor121() []Step {
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return state.AddStateUsersAsEnvironUsers(context.State())
-			},
-		},
-		&upgradeStep{
-			description: "migrate charm archives into environment storage",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				agentConf := context.AgentConfig()
-				return state.MigrateCharmStorage(
-					context.State(),
-					agentConf.Value(agent.ProviderType),
-					agentConf.Value(agent.StorageDir),
-				)
 			},
 		},
 		&upgradeStep{

--- a/upgrades/steps121_test.go
+++ b/upgrades/steps121_test.go
@@ -42,7 +42,6 @@ func (s *steps121Suite) TestStateStepsFor121(c *gc.C) {
 		// Non-environment UUID upgrade steps follow.
 		"rename the user LastConnection field to LastLogin",
 		"add all users in state as environment users",
-		"migrate charm archives into environment storage",
 		"migrate custom image metadata into environment storage",
 		"migrate tools into environment storage",
 		"migrate individual unit ports to openedPorts collection",

--- a/upgrades/steps122.go
+++ b/upgrades/steps122.go
@@ -116,3 +116,17 @@ func stepsFor122() []Step {
 		},
 	}
 }
+
+// stateStepsFor1227 returns upgrade steps form Juju 1.22.7 that manipulate state directly.
+func stateStepsFor1227() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "migrate charm archives into environment storage",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				agentConf := context.AgentConfig()
+				return migrateCharmStorage(context.State(), agentConf)
+			},
+		},
+	}
+}

--- a/upgrades/steps122_test.go
+++ b/upgrades/steps122_test.go
@@ -45,3 +45,10 @@ func (s *steps122Suite) TestStepsFor122(c *gc.C) {
 	}
 	assertSteps(c, version.MustParse("1.22.0"), expected)
 }
+
+func (s *steps122Suite) TestStateStepsFor1227(c *gc.C) {
+	expected := []string{
+		"migrate charm archives into environment storage",
+	}
+	assertStateSteps(c, version.MustParse("1.22.7"), expected)
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -666,7 +666,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.22.7"})
 }
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1474931

The first attempt to add charm migration to storage failed because charm doc serialisation had changed between 1.21 and 1.22. An attempt to work around fixed that issue and another surfaced.

Instead, this issue is resolved using the same technique as for 1.24 - introduce a new 1.22.7 migration step which occurs after the charm collection has been upgraded. Doing it as 1.22.7 also ensures 1.22.6 and earlier environments that missed out on the step have it run.

The PR moves code back to its original location as it was in 1.22.6

(Review request: http://reviews.vapour.ws/r/2181/)