### PR TITLE
worker/rsyslog: ensure CA cert/key in state

### DIFF
--- a/worker/rsyslog/rsyslog_test.go
+++ b/worker/rsyslog/rsyslog_test.go
@@ -5,6 +5,8 @@
 package rsyslog_test
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -165,6 +167,42 @@ func (s *RsyslogSuite) TestAccumulateHA(c *gc.C) {
 
 	c.Assert(strings.Contains(string(rendered), stateServer1Config), jc.IsTrue)
 	c.Assert(strings.Contains(string(rendered), stateServer2Config), jc.IsTrue)
+}
+
+// TestModeAccumulateCertsExist is a regression test for
+// https://bugs.launchpad.net/juju-core/+bug/1464335,
+// where the CA certs existing (in local provider) at
+// bootstrap caused the worker to not publish to state.
+func (s *RsyslogSuite) TestModeAccumulateCertsExistOnDisk(c *gc.C) {
+	dirname := filepath.Join(s.ConfDir(), "rsyslog")
+	err := os.MkdirAll(dirname, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(filepath.Join(dirname, "ca-cert.pem"), nil, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	st, m := s.st, s.machine
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", nil, s.ConfDir())
+	c.Assert(err, jc.ErrorIsNil)
+	// The worker should create certs and publish to state during setup,
+	// so we can kill and wait and be confident that the task is done.
+	worker.Kill()
+	c.Assert(worker.Wait(), jc.ErrorIsNil)
+
+	// The CA cert and key should have been published to state.
+	cfg, err := s.State.EnvironConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.AllAttrs()["rsyslog-ca-cert"], gc.NotNil)
+	c.Assert(cfg.AllAttrs()["rsyslog-ca-key"], gc.NotNil)
+
+	// ca-cert.pem isn't updated on disk until the worker reacts to the
+	// state change. Let's just ensure that rsyslog-ca-cert is a valid
+	// certificate, and no the zero-length string we wrote to ca-cert.pem.
+	caCertPEM := cfg.AllAttrs()["rsyslog-ca-cert"].(string)
+	c.Assert(err, jc.ErrorIsNil)
+	block, _ := pem.Decode([]byte(caCertPEM))
+	c.Assert(block, gc.NotNil)
+	_, err = x509.ParseCertificate(block.Bytes)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *RsyslogSuite) TestNamespace(c *gc.C) {

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -151,6 +151,7 @@ func newRsyslogConfigHandler(st *apirsyslog.State, mode RsyslogMode, tag names.T
 	if namespace != "" {
 		syslogConfig.LogDir += "-" + namespace
 	}
+
 	return &RsyslogConfigHandler{
 		st:           st,
 		mode:         mode,
@@ -161,7 +162,7 @@ func newRsyslogConfigHandler(st *apirsyslog.State, mode RsyslogMode, tag names.T
 
 func (h *RsyslogConfigHandler) SetUp() (watcher.NotifyWatcher, error) {
 	if h.mode == RsyslogModeAccumulate {
-		if err := h.ensureCertificates(); err != nil {
+		if err := h.ensureCA(); err != nil {
 			return nil, errors.Annotate(err, "failed to write rsyslog certificates")
 		}
 
@@ -363,49 +364,30 @@ func (h *RsyslogConfigHandler) rsyslogHosts() ([]string, error) {
 	return hosts, nil
 }
 
-// ensureCertificates ensures that a CA certificate,
-// server certificate, and private key exist in the log
-// directory, and writes them if not. The CA certificate
-// is entered into the environment configuration to be
-// picked up by other agents.
-func (h *RsyslogConfigHandler) ensureCertificates() error {
-	// We write ca-cert.pem last, after propagating into state.
-	// If it's there, then there's nothing to do. Otherwise,
-	// start over.
-	caCertPEM := h.syslogConfig.CACertPath()
-	if _, err := os.Stat(caCertPEM); err == nil {
+// ensureCA ensures that a CA certificate and key exist in state,
+// to be picked up by all rsyslog workers in the environment.
+func (h *RsyslogConfigHandler) ensureCA() error {
+	// We never write the CA key to local disk, so
+	// we must check state to know whether or not
+	// we need to generate new certs and keys.
+	cfg, err := h.st.GetRsyslogConfig(h.tag.String())
+	if err != nil {
+		return errors.Annotate(err, "cannot get environ config")
+	}
+	if cfg.CACert != "" && cfg.CAKey != "" {
 		return nil
 	}
 
-	// Generate a new CA and server cert/key pairs.
-	// The CA key will be discarded after the server
-	// cert has been generated.
+	// Generate a new CA and server cert/key pairs, and
+	// publish to state. Rsyslog workers will observe
+	// this and generate certificates and keys for
+	// rsyslog in response.
 	expiry := time.Now().UTC().AddDate(10, 0, 0)
 	caCertPEM, caKeyPEM, err := cert.NewCA("rsyslog", expiry)
 	if err != nil {
 		return err
 	}
-
-	// Update the environment config with the CA cert,
-	// so clients can configure rsyslog.
-	if err := h.st.SetRsyslogCert(caCertPEM, caKeyPEM); err != nil {
-		return err
-	}
-
-	rsyslogCertPEM, rsyslogKeyPEM, err := h.rsyslogServerCerts(caCertPEM, caKeyPEM)
-	if err != nil {
-		return err
-	}
-
-	if err := writeCertificates([]certPair{
-		{h.syslogConfig.ServerCertPath(), rsyslogCertPEM},
-		{h.syslogConfig.ServerKeyPath(), rsyslogKeyPEM},
-		{h.syslogConfig.CACertPath(), caCertPEM},
-	}); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
+	return h.st.SetRsyslogCert(caCertPEM, caKeyPEM)
 }
 
 // writeCertificates persists any certPair to disk. If any


### PR DESCRIPTION
Use the CA cert/key presence in state as the
condition for regenerating at setup time. This
fixes a bug where we would not publish the
cert/key to state if the files existed on disk
at bootstrap time.

Also, don't bother writing out files during
setup, as the worker will react to the state
change and write out.

Fixes https://bugs.launchpad.net/juju-core/+bug/1464335

(Review request: http://reviews.vapour.ws/r/2183/)