### PR TITLE
Ensure uniter operation errors are reported in status

### DIFF
--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -215,7 +215,7 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return uniter.NewUniter(uniterFacade, unitTag, leadership.NewClient(st), dataDir, machineLock), nil
+		return uniter.NewUniter(uniterFacade, unitTag, leadership.NewClient(st), dataDir, machineLock, nil), nil
 	})
 
 	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {

--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -16,6 +16,7 @@ var (
 	ActiveMetricsTimer  = &activeMetricsTimer
 	IdleWaitTime        = &idleWaitTime
 	LeadershipGuarantee = &leadershipGuarantee
+	NewExecutor         = &newExecutor
 )
 
 // manualTicker will be used to generate collect-metrics events

--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -16,7 +16,7 @@ var (
 	ActiveMetricsTimer  = &activeMetricsTimer
 	IdleWaitTime        = &idleWaitTime
 	LeadershipGuarantee = &leadershipGuarantee
-	NewExecutor         = &newExecutor
+	NewExecutor         = newOperationExecutor
 )
 
 // manualTicker will be used to generate collect-metrics events

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -34,13 +34,12 @@ func setAgentStatus(u *Uniter, status params.Status, info string, data map[strin
 
 // reportAgentError reports if there was an error performing an agent operation.
 func reportAgentError(u *Uniter, userMessage string, err error) {
-	// If there was an error performing the operation, set the state
-	// of the agent to Failed.
+	// If a non-nil error is reported (e.g. due to an operation failing),
+	// set the agent status to Failed.
 	if err == nil {
 		return
 	}
-	msg := fmt.Sprintf("%s: %v", userMessage, err)
-	err2 := setAgentStatus(u, params.StatusFailed, msg, nil)
+	err2 := setAgentStatus(u, params.StatusFailed, userMessage, nil)
 	if err2 != nil {
 		logger.Errorf("updating agent status: %v", err2)
 	}

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -32,21 +32,15 @@ func setAgentStatus(u *Uniter, status params.Status, info string, data map[strin
 	return u.unit.SetAgentStatus(status, info, data)
 }
 
-// updateAgentStatus updates the agent status to reflect what the uniter is doing,
-// or to report on an error.
-func updateAgentStatus(u *Uniter, userMessage string, err error) {
+// reportAgentError reports if there was an error performing an agent operation.
+func reportAgentError(u *Uniter, userMessage string, err error) {
 	// If there was an error performing the operation, set the state
 	// of the agent to Failed.
-	if err != nil {
-		msg := fmt.Sprintf("%s: %v", userMessage, err)
-		err2 := setAgentStatus(u, params.StatusFailed, msg, nil)
-		if err2 != nil {
-			logger.Errorf("updating agent status: %v", err2)
-		}
+	if err == nil {
 		return
 	}
-	// Anything else, the uniter is doing something, running a hook or action etc.
-	err2 := setAgentStatus(u, params.StatusExecuting, userMessage, nil)
+	msg := fmt.Sprintf("%s: %v", userMessage, err)
+	err2 := setAgentStatus(u, params.StatusFailed, msg, nil)
 	if err2 != nil {
 		logger.Errorf("updating agent status: %v", err2)
 	}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -203,6 +203,13 @@ func (u *Uniter) setupLocks() (err error) {
 	return nil
 }
 
+// Override for testing.
+var newExecutor = func(u *Uniter) (operation.Executor, error) {
+	return operation.NewExecutor(
+		u.paths.State.OperationsFile, u.getServiceCharmURL, u.acquireExecutionLock,
+	)
+}
+
 func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	u.unit, err = u.st.Unit(unitTag)
 	if err != nil {
@@ -261,9 +268,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		u.tomb.Dying(),
 	)
 
-	operationExecutor, err := operation.NewExecutor(
-		u.paths.State.OperationsFile, u.getServiceCharmURL, u.acquireExecutionLock,
-	)
+	operationExecutor, err := newExecutor(u)
 	if err != nil {
 		return err
 	}
@@ -390,11 +395,16 @@ func (u *Uniter) RunCommands(args RunCommandsArgs) (results *exec.ExecResponse, 
 //       * this can't be done quite yet, though, because relation changes are
 //         not yet encapsulated in operations, and that needs to happen before
 //         RunCommands will *actually* be goroutine-safe.
-func (u *Uniter) runOperation(creator creator) error {
+func (u *Uniter) runOperation(creator creator) (err error) {
+	errorMessage := "creating operation to run"
+	defer func() {
+		reportAgentError(u, errorMessage, err)
+	}()
 	op, err := creator(u.operationFactory)
 	if err != nil {
 		return errors.Annotatef(err, "cannot create operation")
 	}
+	errorMessage = op.String()
 	before := u.operationState()
 	defer func() {
 		// Check that if we lose leadership as a result of this

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -2116,11 +2116,11 @@ func (s *UniterSuite) TestOperationErrorReported(c *gc.C) {
 			createCharm{},
 			serveCharm{},
 			createUniter{},
-			operationError{".*some error occurred.*"},
 			waitUnitAgent{
 				status: params.StatusFailed,
-				info:   "run install hook: some error occurred",
+				info:   "run install hook",
 			},
+			expectError{".*some error occurred.*"},
 		),
 	})
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -11,9 +11,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
 	gc "gopkg.in/check.v1"
@@ -26,6 +28,7 @@ import (
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter"
+	"github.com/juju/juju/worker/uniter/operation"
 )
 
 type UniterSuite struct {
@@ -2084,5 +2087,40 @@ func (s *UniterSuite) TestStorage(c *gc.C) {
 		// storage attachments before upgrade-charm is run. This
 		// requires additions to state to add storage when a charm
 		// is upgraded.
+	})
+}
+
+type mockExecutor struct {
+	operation.Executor
+}
+
+func (m *mockExecutor) Run(op operation.Operation) error {
+	// want to allow charm unpacking to occur
+	if strings.HasPrefix(op.String(), "install") {
+		return m.Executor.Run(op)
+	}
+	// but hooks should error
+	return errors.New("some error occurred")
+}
+
+func (s *UniterSuite) TestOperationErrorReported(c *gc.C) {
+	originalExecutorFunc := *uniter.NewExecutor
+	s.PatchValue(uniter.NewExecutor, func(u *uniter.Uniter) (operation.Executor, error) {
+		e, err := originalExecutorFunc(u)
+		c.Assert(err, jc.ErrorIsNil)
+		return &mockExecutor{e}, nil
+	})
+	s.runUniterTests(c, []uniterTest{
+		ut(
+			"error running operations are reported",
+			createCharm{},
+			serveCharm{},
+			createUniter{},
+			operationError{".*some error occurred.*"},
+			waitUnitAgent{
+				status: params.StatusFailed,
+				info:   "run install hook: some error occurred",
+			},
+		),
 	})
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -114,7 +114,7 @@ func (ctx *context) HookFailed(hookName string) {
 	ctx.mu.Unlock()
 }
 
-func (ctx *context) OperationFailed(err string) {
+func (ctx *context) setExpectedError(err string) {
 	ctx.mu.Lock()
 	ctx.err = err
 	ctx.mu.Unlock()
@@ -1689,10 +1689,10 @@ func (s verifyStorageDetached) step(c *gc.C, ctx *context) {
 	c.Assert(storageAttachments, gc.HasLen, 0)
 }
 
-type operationError struct {
+type expectError struct {
 	err string
 }
 
-func (s operationError) step(c *gc.C, ctx *context) {
-	ctx.OperationFailed(s.err)
+func (s expectError) step(c *gc.C, ctx *context) {
+	ctx.setExpectedError(s.err)
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1475163

When the uniter runs a hook or action etc, and that api call fails, it needs to be reported as agent status "failed". It is currently just logged.

(Review request: http://reviews.vapour.ws/r/2184/)