### PR TITLE
Use windows-compatible utils.MoveFile.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -27,7 +27,7 @@ github.com/juju/schema	git	1c4e902df91bd058b84029533bf4ce92e6ef87ab	2015-03-30T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T10:32:42Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	f24fcb37d33e6d8fa7f51442aad41b7b83b06f5d	2015-07-01T15:20:54Z
+github.com/juju/utils	git	64a93c89a0247572070fcaeb1610ef03c2ec2f2f	2015-07-16T20:17:45Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z

--- a/worker/uniter/metrics/metrics.go
+++ b/worker/uniter/metrics/metrics.go
@@ -54,15 +54,12 @@ func (f *metricFile) Close() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer func() {
-		err := os.Remove(f.Name())
-		if err != nil {
-			logger.Errorf("failed to remove temporary file %q: %v", f.Name(), err)
-		}
-	}()
-	err = os.Link(f.Name(), f.finalName)
+	ok, err := utils.MoveFile(f.Name(), f.finalName)
 	if err != nil {
-		return errors.Trace(err)
+		if !ok {
+			return errors.Trace(err)
+		}
+		logger.Errorf("failed to remove temporary file %q: %v", f.Name(), err)
 	}
 	return nil
 }

--- a/worker/uniter/metrics/metrics.go
+++ b/worker/uniter/metrics/metrics.go
@@ -56,6 +56,11 @@ func (f *metricFile) Close() error {
 	}
 	ok, err := utils.MoveFile(f.Name(), f.finalName)
 	if err != nil {
+		// ok can be true even when there is an error completing the move, on
+		// platforms that implement it in multiple steps that can fail
+		// separately. POSIX for example, uses link(2) to claim the new
+		// location atomically, followed by an unlink(2) to release the old
+		// location.
 		if !ok {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
Fixes [LP1475271](https://bugs.launchpad.net/juju-core/+bug/1475271).

(Review request: http://reviews.vapour.ws/r/2189/)