### PR TITLE
Stop the kvm tests creating /etc/network in lxc dir.

### DIFF
--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/kvm/mock"
 	kvmtesting "github.com/juju/juju/container/kvm/testing"
-	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
@@ -107,8 +106,6 @@ func (s *kvmBrokerSuite) instanceConfig(c *gc.C, machineId string) *instancecfg.
 	apiInfo := jujutesting.FakeAPIInfo(machineId)
 	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	// Ensure the <rootfs>/etc/network path exists.
-	containertesting.EnsureRootFSEtcNetwork(c, "juju-"+names.NewMachineTag(machineId).String())
 	return instanceConfig
 }
 

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -118,7 +118,7 @@ func (s *lxcBrokerSuite) instanceConfig(c *gc.C, machineId string) *instancecfg.
 	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", true, nil, stateInfo, apiInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure the <rootfs>/etc/network path exists.
-	containertesting.EnsureRootFSEtcNetwork(c, "juju-"+names.NewMachineTag(machineId).String())
+	containertesting.EnsureLXCRootFSEtcNetwork(c, "juju-"+names.NewMachineTag(machineId).String())
 	return instanceConfig
 }
 
@@ -1092,7 +1092,7 @@ func (s *lxcProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 
 	container := s.addContainer(c)
 	name := "juju-" + container.Tag().String()
-	containertesting.EnsureRootFSEtcNetwork(c, name)
+	containertesting.EnsureLXCRootFSEtcNetwork(c, name)
 	instId := s.expectStarted(c, container)
 
 	// ...and removed, along with the machine, when the machine is Dead.


### PR DESCRIPTION
Renamed the test function so it is obvious it is doing LXC things.

The kvm tests should use this method.

(Review request: http://reviews.vapour.ws/r/2190/)