### PR TITLE
Merge pull request #2805 from wallyworld/report-uniter-errors

### DIFF
--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -233,6 +233,7 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 			hookLock,
 			uniter.NewMetricsTimerChooser(),
 			uniter.NewUpdateStatusTimer(),
+			nil,
 		}
 		return uniter.NewUniter(&uniterParams), nil
 	})

--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -19,6 +19,7 @@ var (
 	EnterLoopIsIdleTime    = &enterLoopIsIdleWaitTime
 	ActiveSendMetricsTimer = &activeSendMetricsTimer
 	LeadershipGuarantee    = &leadershipGuarantee
+	NewExecutor            = newOperationExecutor
 )
 
 // manualTicker will be used to generate collect-metrics events

--- a/worker/uniter/modes.go
+++ b/worker/uniter/modes.go
@@ -32,21 +32,14 @@ func setAgentStatus(u *Uniter, status params.Status, info string, data map[strin
 	return u.unit.SetAgentStatus(status, info, data)
 }
 
-// updateAgentStatus updates the agent status to reflect what the uniter is doing,
-// or to report on an error.
-func updateAgentStatus(u *Uniter, userMessage string, err error) {
-	// If there was an error performing the operation, set the state
-	// of the agent to Failed.
-	if err != nil {
-		msg := fmt.Sprintf("%s: %v", userMessage, err)
-		err2 := setAgentStatus(u, params.StatusFailed, msg, nil)
-		if err2 != nil {
-			logger.Errorf("updating agent status: %v", err2)
-		}
+// reportAgentError reports if there was an error performing an agent operation.
+func reportAgentError(u *Uniter, userMessage string, err error) {
+	// If a non-nil error is reported (e.g. due to an operation failing),
+	// set the agent status to Failed.
+	if err == nil {
 		return
 	}
-	// Anything else, the uniter is doing something, running a hook or action etc.
-	err2 := setAgentStatus(u, params.StatusExecuting, userMessage, nil)
+	err2 := setAgentStatus(u, params.StatusFailed, userMessage, nil)
 	if err2 != nil {
 		logger.Errorf("updating agent status: %v", err2)
 	}

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/charm"
 	"github.com/juju/juju/worker/uniter/metrics"
+	"github.com/juju/juju/worker/uniter/operation"
 )
 
 // worstCase is used for timeouts when timing out
@@ -96,6 +97,7 @@ type context struct {
 	collectMetricsTicker   *uniter.ManualTicker
 	sendMetricsTicker      *uniter.ManualTicker
 	updateStatusHookTicker *uniter.ManualTicker
+	err                    string
 
 	wg             sync.WaitGroup
 	mu             sync.Mutex
@@ -118,6 +120,12 @@ func (ctx *context) HookFailed(hookName string) {
 	ctx.mu.Unlock()
 }
 
+func (ctx *context) setExpectedError(err string) {
+	ctx.mu.Lock()
+	ctx.err = err
+	ctx.mu.Unlock()
+}
+
 func (ctx *context) run(c *gc.C, steps []stepper) {
 	// We need this lest leadership calls block forever.
 	lease, err := lease.NewLeaseManager(ctx.st)
@@ -130,7 +138,11 @@ func (ctx *context) run(c *gc.C, steps []stepper) {
 	defer func() {
 		if ctx.uniter != nil {
 			err := ctx.uniter.Stop()
-			c.Assert(err, jc.ErrorIsNil)
+			if ctx.err == "" {
+				c.Assert(err, jc.ErrorIsNil)
+			} else {
+				c.Assert(err, gc.ErrorMatches, ctx.err)
+			}
 		}
 	}()
 	for i, s := range steps {
@@ -403,7 +415,8 @@ func (csau createServiceAndUnit) step(c *gc.C, ctx *context) {
 }
 
 type createUniter struct {
-	minion bool
+	minion       bool
+	executorFunc func(*uniter.Uniter) (operation.Executor, error)
 }
 
 func (s createUniter) step(c *gc.C, ctx *context) {
@@ -412,7 +425,7 @@ func (s createUniter) step(c *gc.C, ctx *context) {
 	if s.minion {
 		step(c, ctx, forceMinion{})
 	}
-	step(c, ctx, startUniter{})
+	step(c, ctx, startUniter{newExecutorFunc: s.executorFunc})
 	step(c, ctx, waitAddresses{})
 }
 
@@ -445,7 +458,8 @@ func (waitAddresses) step(c *gc.C, ctx *context) {
 }
 
 type startUniter struct {
-	unitTag string
+	unitTag         string
+	newExecutorFunc func(*uniter.Uniter) (operation.Executor, error)
 }
 
 func (s startUniter) step(c *gc.C, ctx *context) {
@@ -475,7 +489,8 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 			ctx.collectMetricsTicker.ReturnTimer,
 			ctx.sendMetricsTicker.ReturnTimer,
 		),
-		UpdateStatusSignal: ctx.updateStatusHookTicker.ReturnTimer,
+		UpdateStatusSignal:   ctx.updateStatusHookTicker.ReturnTimer,
+		NewOperationExecutor: s.newExecutorFunc,
 	}
 	ctx.uniter = uniter.NewUniter(&uniterParams)
 	uniter.SetUniterObserver(ctx.uniter, ctx)
@@ -1847,4 +1862,12 @@ func (s shortWaitEnterLoopIsIdleTime) step(c *gc.C, ctx *context) {
 
 func ust(summary string, steps ...stepper) uniterTest {
 	return ut(summary, shortWaitEnterLoopIsIdleTime{steps})
+}
+
+type expectError struct {
+	err string
+}
+
+func (s expectError) step(c *gc.C, ctx *context) {
+	ctx.setExpectedError(s.err)
 }


### PR DESCRIPTION
Ensure uniter operation errors are reported in status

Fixes: https://bugs.launchpad.net/bugs/1475163

When the uniter runs a hook or action etc, and that api call fails, it needs to be reported as agent status "failed". It is currently just logged.

(Review request: http://reviews.vapour.ws/r/2184/)

(Review request: http://reviews.vapour.ws/r/2191/)