### PR TITLE
certupdater: fix the intermittent failure due to bare channel write

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1016,12 +1016,16 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			})
 			certChangedChan := make(chan params.StateServingInfo, 1)
 			runner.StartWorker("apiserver", a.apiserverWorkerStarter(st, certChangedChan))
-			var stateServingSetter certupdater.StateServingInfoSetter = func(info params.StateServingInfo) error {
+			var stateServingSetter certupdater.StateServingInfoSetter = func(info params.StateServingInfo, done <-chan struct{}) error {
 				return a.ChangeConfig(func(config agent.ConfigSetter) error {
 					config.SetStateServingInfo(info)
 					logger.Infof("update apiserver worker with new certificate")
-					certChangedChan <- info
-					return nil
+					select {
+					case certChangedChan <- info:
+						return nil
+					case <-done:
+						return nil
+					}
 				})
 			}
 			a.startWorkerAfterUpgrade(runner, "certupdater", func() (worker.Worker, error) {

--- a/worker/apiaddressupdater/apiaddressupdater.go
+++ b/worker/apiaddressupdater/apiaddressupdater.go
@@ -50,7 +50,7 @@ func (c *APIAddressUpdater) SetUp() (watcher.NotifyWatcher, error) {
 	return c.addresser.WatchAPIHostPorts()
 }
 
-func (c *APIAddressUpdater) Handle() error {
+func (c *APIAddressUpdater) Handle(_ <-chan struct{}) error {
 	addresses, err := c.addresser.APIHostPorts()
 	if err != nil {
 		return fmt.Errorf("error getting addresses: %v", err)

--- a/worker/authenticationworker/worker.go
+++ b/worker/authenticationworker/worker.go
@@ -106,7 +106,7 @@ func (kw *keyupdaterWorker) writeSSHKeys(jujuKeys []string) error {
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (kw *keyupdaterWorker) Handle() error {
+func (kw *keyupdaterWorker) Handle(_ <-chan struct{}) error {
 	// Read the keys that Juju has.
 	newKeys, err := kw.st.AuthorisedKeys(kw.tag)
 	if err != nil {

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -106,7 +106,7 @@ func (g *mockAPIHostGetter) APIHostPorts() ([][]network.HostPort, error) {
 
 func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
 	var initialAddresses []string
-	setter := func(info params.StateServingInfo) error {
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {
 		// Only care about first time called.
 		if len(initialAddresses) > 0 {
 			return nil
@@ -133,7 +133,7 @@ func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
 func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	var srvCert *x509.Certificate
 	updated := make(chan struct{})
-	setter := func(info params.StateServingInfo) error {
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {
 		s.stateServingInfo = info
 		var err error
 		srvCert, err = cert.ParseCert(info.Cert)
@@ -186,7 +186,7 @@ func (g *mockStateServingGetterNoCAKey) StateServingInfo() (params.StateServingI
 
 func (s *CertUpdaterSuite) TestAddressChangeNoCAKey(c *gc.C) {
 	updated := make(chan struct{})
-	setter := func(info params.StateServingInfo) error {
+	setter := func(info params.StateServingInfo, dying <-chan struct{}) error {
 		close(updated)
 		return nil
 	}

--- a/worker/cleaner/cleaner.go
+++ b/worker/cleaner/cleaner.go
@@ -28,7 +28,7 @@ func (c *Cleaner) SetUp() (watcher.NotifyWatcher, error) {
 	return c.st.WatchCleanups(), nil
 }
 
-func (c *Cleaner) Handle() error {
+func (c *Cleaner) Handle(_ <-chan struct{}) error {
 	if err := c.st.Cleanup(); err != nil {
 		logger.Errorf("cannot cleanup state: %v", err)
 	}

--- a/worker/conv2state/converter.go
+++ b/worker/conv2state/converter.go
@@ -78,7 +78,7 @@ func (c *converter) SetUp() (watcher.NotifyWatcher, error) {
 // Handle implements NotifyWatchHandler's Handle method.  If the change means
 // that the machine is now expected to manage the environment, we change its
 // password (to set its password in mongo) and restart the agent.
-func (c *converter) Handle() error {
+func (c *converter) Handle(_ <-chan struct{}) error {
 	results, err := c.machine.Jobs()
 	if err != nil {
 		return errors.Annotate(err, "can't get jobs for machine")

--- a/worker/conv2state/converter_test.go
+++ b/worker/conv2state/converter_test.go
@@ -70,7 +70,7 @@ func (s Suite) TestHandle(c *gc.C) {
 	conv := &converter{machiner: mr, agent: a}
 	_, err := conv.SetUp()
 	c.Assert(err, gc.IsNil)
-	err = conv.Handle()
+	err = conv.Handle(nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(a.didRestart, jc.IsTrue)
 }
@@ -85,7 +85,7 @@ func (s Suite) TestHandleNoManageEnviron(c *gc.C) {
 	conv := &converter{machiner: mr, agent: a}
 	_, err := conv.SetUp()
 	c.Assert(err, gc.IsNil)
-	err = conv.Handle()
+	err = conv.Handle(nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(a.didRestart, jc.IsFalse)
 }
@@ -101,7 +101,7 @@ func (Suite) TestHandleJobsError(c *gc.C) {
 	conv := &converter{machiner: mr, agent: a}
 	_, err := conv.SetUp()
 	c.Assert(err, gc.IsNil)
-	err = conv.Handle()
+	err = conv.Handle(nil)
 	c.Assert(errors.Cause(err), gc.Equals, m.jobsErr)
 	c.Assert(a.didRestart, jc.IsFalse)
 }
@@ -119,7 +119,7 @@ func (s Suite) TestHandleRestartError(c *gc.C) {
 	conv := &converter{machiner: mr, agent: a}
 	_, err := conv.SetUp()
 	c.Assert(err, gc.IsNil)
-	err = conv.Handle()
+	err = conv.Handle(nil)
 	c.Assert(errors.Cause(err), gc.Equals, a.restartErr)
 
 	// We set this to true whenver the function is called, even though we're

--- a/worker/logger/logger.go
+++ b/worker/logger/logger.go
@@ -64,7 +64,7 @@ func (logger *Logger) SetUp() (watcher.NotifyWatcher, error) {
 	return logger.api.WatchLoggingConfig(logger.agentConfig.Tag())
 }
 
-func (logger *Logger) Handle() error {
+func (logger *Logger) Handle(_ <-chan struct{}) error {
 	logger.setLogging()
 	return nil
 }

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -103,7 +103,7 @@ func setMachineAddresses(m *machiner.Machine) error {
 	return m.SetMachineAddresses(hostAddresses)
 }
 
-func (mr *Machiner) Handle() error {
+func (mr *Machiner) Handle(_ <-chan struct{}) error {
 	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return worker.ErrTerminateAgent
 	} else if err != nil {

--- a/worker/notifyworker.go
+++ b/worker/notifyworker.go
@@ -35,9 +35,12 @@ type NotifyWatchHandler interface {
 	// TearDown should cleanup any resources that are left around
 	TearDown() error
 
-	// Handle is called when the Watcher has indicated there are
-	// changes, do whatever work is necessary to process it
-	Handle() error
+	// Handle is called when the Watcher has indicated there are changes, do
+	// whatever work is necessary to process it. The done channel is closed if
+	// the worker is being interrupted to finish. Any worker should avoid any
+	// bare channel reads or writes, but instead use a select with the done
+	// channel.
+	Handle(done <-chan struct{}) error
 }
 
 // NewNotifyWorker starts a new worker running the business logic from
@@ -96,7 +99,7 @@ func (nw *notifyWorker) loop() error {
 			if !ok {
 				return ensureErr(w)
 			}
-			if err := nw.handler.Handle(); err != nil {
+			if err := nw.handler.Handle(nw.tomb.Dying()); err != nil {
 				return err
 			}
 		}

--- a/worker/notifyworker_test.go
+++ b/worker/notifyworker_test.go
@@ -93,7 +93,7 @@ func (nh *notifyHandler) TearDown() error {
 	return nh.teardownError
 }
 
-func (nh *notifyHandler) Handle() error {
+func (nh *notifyHandler) Handle(_ <-chan struct{}) error {
 	nh.mu.Lock()
 	defer nh.mu.Unlock()
 	nh.actions = append(nh.actions, "handler")

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -212,7 +212,7 @@ func (w *proxyWorker) SetUp() (watcher.NotifyWatcher, error) {
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (w *proxyWorker) Handle() error {
+func (w *proxyWorker) Handle(_ <-chan struct{}) error {
 	return w.onChange()
 }
 

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -74,7 +74,7 @@ func (r *Reboot) SetUp() (watcher.NotifyWatcher, error) {
 	return watcher, nil
 }
 
-func (r *Reboot) Handle() error {
+func (r *Reboot) Handle(_ <-chan struct{}) error {
 	rAction, err := r.st.GetRebootAction()
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -248,7 +248,7 @@ func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {
 	return nil
 }
 
-func (h *RsyslogConfigHandler) Handle() error {
+func (h *RsyslogConfigHandler) Handle(_ <-chan struct{}) error {
 	cfg, err := h.st.GetRsyslogConfig(h.tag.String())
 	if err != nil {
 		return errors.Annotate(err, "cannot get environ config")

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -272,5 +272,6 @@ func (runner *runner) runWorker(delay time.Duration, id string, start func() (Wo
 		runner.startedc <- startInfo{id, worker}
 		err = worker.Wait()
 	}
+	logger.Infof("stopped %q, err: %v", id, err)
 	runner.donec <- doneInfo{id, err}
 }


### PR DESCRIPTION
This is a backport from master.

Have the notify worker pass through the tomb dying channel to the handle function and use it in the certupdater.

(Review request: http://reviews.vapour.ws/r/2192/)