### PR TITLE
Fix 1471657: stop relying on map ordering

### DIFF
--- a/process/persistence/processes_test.go
+++ b/process/persistence/processes_test.go
@@ -4,6 +4,8 @@
 package persistence_test
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -700,6 +702,9 @@ func (s *procsPersistenceSuite) TestListAllOkay(c *gc.C) {
 
 	s.stub.CheckCallNames(c, "All", "All", "All")
 	c.Check(s.state.ops, gc.HasLen, 0)
+	sort.Sort(byName(procs))
+	sort.Sort(byName(existing))
+
 	c.Check(procs, jc.DeepEquals, existing)
 }
 
@@ -735,8 +740,16 @@ func (s *procsPersistenceSuite) TestListAllIncludeCharmDefined(c *gc.C) {
 			Type: "docker",
 		},
 	})
+	sort.Sort(byName(procs))
+	sort.Sort(byName(existing))
 	c.Check(procs, jc.DeepEquals, existing)
 }
+
+type byName []process.Info
+
+func (b byName) Len() int           { return len(b) }
+func (b byName) Less(i, j int) bool { return b[i].Name < b[j].Name }
+func (b byName) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 
 func (s *procsPersistenceSuite) TestListAllInconsistent(c *gc.C) {
 	existing := s.newProcesses("docker", "procA/xyz", "procB/abc")

--- a/process/persistence/processes_test.go
+++ b/process/persistence/processes_test.go
@@ -4,8 +4,6 @@
 package persistence_test
 
 import (
-	"sort"
-
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -702,10 +700,7 @@ func (s *procsPersistenceSuite) TestListAllOkay(c *gc.C) {
 
 	s.stub.CheckCallNames(c, "All", "All", "All")
 	c.Check(s.state.ops, gc.HasLen, 0)
-	sort.Sort(byName(procs))
-	sort.Sort(byName(existing))
-
-	c.Check(procs, jc.DeepEquals, existing)
+	c.Check(procs, jc.SameContents, existing)
 }
 
 func (s *procsPersistenceSuite) TestListAllEmpty(c *gc.C) {
@@ -740,16 +735,8 @@ func (s *procsPersistenceSuite) TestListAllIncludeCharmDefined(c *gc.C) {
 			Type: "docker",
 		},
 	})
-	sort.Sort(byName(procs))
-	sort.Sort(byName(existing))
-	c.Check(procs, jc.DeepEquals, existing)
+	c.Check(procs, jc.SameContents, existing)
 }
-
-type byName []process.Info
-
-func (b byName) Len() int           { return len(b) }
-func (b byName) Less(i, j int) bool { return b[i].Name < b[j].Name }
-func (b byName) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 
 func (s *procsPersistenceSuite) TestListAllInconsistent(c *gc.C) {
 	existing := s.newProcesses("docker", "procA/xyz", "procB/abc")

--- a/process/persistence/processes_test.go
+++ b/process/persistence/processes_test.go
@@ -4,6 +4,8 @@
 package persistence_test
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -700,7 +702,10 @@ func (s *procsPersistenceSuite) TestListAllOkay(c *gc.C) {
 
 	s.stub.CheckCallNames(c, "All", "All", "All")
 	c.Check(s.state.ops, gc.HasLen, 0)
-	c.Check(procs, jc.SameContents, existing)
+	sort.Sort(byName(procs))
+	sort.Sort(byName(existing))
+
+	c.Check(procs, jc.DeepEquals, existing)
 }
 
 func (s *procsPersistenceSuite) TestListAllEmpty(c *gc.C) {
@@ -735,8 +740,16 @@ func (s *procsPersistenceSuite) TestListAllIncludeCharmDefined(c *gc.C) {
 			Type: "docker",
 		},
 	})
-	c.Check(procs, jc.SameContents, existing)
+	sort.Sort(byName(procs))
+	sort.Sort(byName(existing))
+	c.Check(procs, jc.DeepEquals, existing)
 }
+
+type byName []process.Info
+
+func (b byName) Len() int           { return len(b) }
+func (b byName) Less(i, j int) bool { return b[i].Name < b[j].Name }
+func (b byName) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 
 func (s *procsPersistenceSuite) TestListAllInconsistent(c *gc.C) {
 	existing := s.newProcesses("docker", "procA/xyz", "procB/abc")


### PR DESCRIPTION
This addresses https://bugs.launchpad.net/juju-core/+bug/1471657
linker error in procsPersistenceSuite unit test on ppc64

I can't reproduce the linker error even on ppc64 (tested on stilson-07). However, there's a map ordering issue that shows up when testing with gccgo on any platform, so I've fixed that here.  Hopefully the linker error is just a spurious problem that won't come back.

 Actually, there's more to it than this, the title of the bug was just incorrect.  The linker error is in the process/context package.  This is, as of yet, unresolved.

(Review request: http://reviews.vapour.ws/r/2194/)