### PR TITLE
provider/openstack: don't require object-store

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -770,7 +770,11 @@ func authClient(ecfg *environConfig) client.AuthenticatingClient {
 	if !ecfg.SSLHostnameVerification() {
 		newClient = client.NewNonValidatingClient
 	}
-	return newClient(cred, authMode, nil)
+	client := newClient(cred, authMode, nil)
+	// By default, the client requires "compute" and
+	// "object-store". Juju only requires "compute".
+	client.SetRequiredServiceTypes([]string{"compute"})
+	return client
 }
 
 var authenticateClient = func(e *environ) error {


### PR DESCRIPTION
Tweak the goose client to not require the object-store
service in keystone. We do not use it anymore, so not
requiring it enables Juju to work with more OpenStack
installations.

Fixes https://bugs.launchpad.net/juju-core/+bug/1456265

(Review request: http://reviews.vapour.ws/r/2195/)