### PR TITLE
Add an "info" hook context command to expose workload processes.

### DIFF
--- a/component/all/process.go
+++ b/component/all/process.go
@@ -118,7 +118,15 @@ func (workloadProcesses) registerHookContextCommands() {
 		compCtx := workloadProcessesHookContext{ctx}
 		cmd, err := context.NewProcLaunchCommand(plugin.Find, plugin.Plugin.Launch, compCtx)
 		if err != nil {
-			// TODO(ericsnow) Return an error instead.
+			panic(err)
+		}
+		return cmd
+	})
+
+	jujuc.RegisterCommand("info", func(ctx jujuc.Context) cmd.Command {
+		compCtx := workloadProcessesHookContext{ctx}
+		cmd, err := context.NewProcInfoCommand(compCtx)
+		if err != nil {
 			panic(err)
 		}
 		return cmd

--- a/component/all/process.go
+++ b/component/all/process.go
@@ -123,7 +123,7 @@ func (workloadProcesses) registerHookContextCommands() {
 		return cmd
 	})
 
-	jujuc.RegisterCommand("info", func(ctx jujuc.Context) cmd.Command {
+	jujuc.RegisterCommand("proc-info", func(ctx jujuc.Context) cmd.Command {
 		compCtx := workloadProcessesHookContext{ctx}
 		cmd, err := context.NewProcInfoCommand(compCtx)
 		if err != nil {

--- a/component/all/process.go
+++ b/component/all/process.go
@@ -123,7 +123,8 @@ func (workloadProcesses) registerHookContextCommands() {
 		return cmd
 	})
 
-	jujuc.RegisterCommand("proc-info", func(ctx jujuc.Context) cmd.Command {
+	name = context.InfoCommandInfo.Name
+	jujuc.RegisterCommand(name, func(ctx jujuc.Context) cmd.Command {
 		compCtx := workloadProcessesHookContext{ctx}
 		cmd, err := context.NewProcInfoCommand(compCtx)
 		if err != nil {

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -109,6 +109,19 @@ func (c *stubContextComponent) Get(procName string) (*process.Info, error) {
 	return info, nil
 }
 
+func (c *stubContextComponent) List() ([]string, error) {
+	c.stub.AddCall("List")
+	if err := c.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var ids []string
+	for k := range c.procs {
+		ids = append(ids, k)
+	}
+	return ids, nil
+}
+
 func (c *stubContextComponent) Set(procName string, info *process.Info) error {
 	c.stub.AddCall("Set", procName, info)
 	if err := c.stub.NextErr(); err != nil {

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -121,7 +121,7 @@ func (c *baseCommand) defsFromCharm() (map[string]charm.Process, error) {
 	return defMap, nil
 }
 
-func (c *baseCommand) registeredProcs(ids ...string) ([]process.Info, error) {
+func (c *baseCommand) registeredProcs(ids ...string) (map[string]*process.Info, error) {
 	if len(ids) == 0 {
 		registered, err := c.compCtx.List()
 		if err != nil {
@@ -133,17 +133,15 @@ func (c *baseCommand) registeredProcs(ids ...string) ([]process.Info, error) {
 		ids = registered
 	}
 
-	var procs []process.Info
+	procs := make(map[string]*process.Info)
 	for _, id := range ids {
 		proc, err := c.compCtx.Get(id)
 		if errors.IsNotFound(err) {
-			// This is an inconsequential race so we ignore it.
-			continue
-		}
-		if err != nil {
+			proc = nil
+		} else if err != nil {
 			return nil, errors.Trace(err)
 		}
-		procs = append(procs, *proc)
+		procs[id] = proc
 	}
 	return procs, nil
 }

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -132,15 +132,16 @@ func (c *baseCommand) init(args map[string]string) error {
 		return errors.Errorf("got empty name")
 	}
 	c.Name = name
+	return nil
+}
 
-	// TODO(ericsnow) Pull the definitions from the metadata here...
-
+// Run implements cmd.Command.
+func (c *baseCommand) Run(ctx *cmd.Context) error {
 	pInfo, err := c.compCtx.Get(c.Name)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
 	c.info = pInfo
-
 	return nil
 }
 
@@ -222,8 +223,9 @@ func (c *registeringCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(cmd.NewAppendStringsValue(&c.Additions), "extend", "extend process definition")
 }
 
-func (c *registeringCommand) init(args map[string]string) error {
-	if err := c.baseCommand.init(args); err != nil {
+// Run implements cmd.Command.
+func (c *registeringCommand) Run(ctx *cmd.Context) error {
+	if err := c.baseCommand.Run(ctx); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -64,8 +64,8 @@ func newCommand(ctx HookContext) (*baseCommand, error) {
 
 // Info implements cmd.Command.
 func (c baseCommand) Info() *cmd.Info {
-	args := []string{"<name>"} // name isn't optional
-	for _, name := range c.cmdInfo.ExtraArgs {
+	var args []string
+	for _, name := range append([]string{"name"}, c.cmdInfo.ExtraArgs...) {
 		arg := "<" + name + ">"
 		for _, optional := range c.cmdInfo.OptionalArgs {
 			if name == optional {

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -121,6 +121,33 @@ func (c *baseCommand) defsFromCharm() (map[string]charm.Process, error) {
 	return defMap, nil
 }
 
+func (c *baseCommand) registeredProcs(ids ...string) ([]process.Info, error) {
+	if len(ids) == 0 {
+		registered, err := c.compCtx.List()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(registered) == 0 {
+			return nil, nil
+		}
+		ids = registered
+	}
+
+	var procs []process.Info
+	for _, id := range ids {
+		proc, err := c.compCtx.Get(id)
+		if errors.IsNotFound(err) {
+			// This is an inconsequential race so we ignore it.
+			continue
+		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		procs = append(procs, *proc)
+	}
+	return procs, nil
+}
+
 // registeringCommand is the base for commands that register a process
 // that has been launched.
 type registeringCommand struct {

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -4,7 +4,10 @@
 package context
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/process"
@@ -35,6 +38,8 @@ type Component interface {
 	Get(procName string) (*process.Info, error)
 	// Set records the process info in the hook context.
 	Set(procName string, info *process.Info) error
+	// List returns the list of registered process IDs.
+	List() ([]string, error)
 	// ListDefinitions returns the charm-defined processes.
 	ListDefinitions() ([]charm.Process, error)
 	// Flush pushes the hook context data out to state.
@@ -46,6 +51,7 @@ type Context struct {
 	api       APIClient
 	processes map[string]*process.Info
 	updates   map[string]*process.Info
+	ids       set.Strings
 }
 
 // NewContext returns a new jujuc.ContextComponent for workload processes.
@@ -57,6 +63,7 @@ func NewContext(api APIClient, procs ...*process.Info) *Context {
 	return &Context{
 		processes: processes,
 		api:       api,
+		ids:       set.NewStrings(),
 	}
 }
 
@@ -70,6 +77,7 @@ func NewContextAPI(api APIClient) (*Context, error) {
 	ctx := NewContext(api)
 	for _, id := range ids {
 		ctx.processes[id] = nil
+		ctx.ids.Add(id)
 	}
 	return ctx, nil
 }
@@ -144,6 +152,8 @@ func mergeProcMaps(procs, updates map[string]*process.Info) map[string]*process.
 	return result
 }
 
+// TODO(ericsnow) Should be build in refreshes?
+
 // Get returns the process info corresponding to the given ID.
 func (c *Context) Get(procName string) (*process.Info, error) {
 	actual, ok := c.updates[procName]
@@ -164,6 +174,14 @@ func (c *Context) Get(procName string) (*process.Info, error) {
 	return actual, nil
 }
 
+// List returns the names of all registered processes.
+func (c *Context) List() ([]string, error) {
+	ids := make([]string, len(c.ids))
+	copy(ids, c.ids.Values())
+	sort.Strings(ids)
+	return ids, nil
+}
+
 // Set records the process info in the hook context.
 func (c *Context) Set(procName string, info *process.Info) error {
 	if procName != info.Name {
@@ -182,6 +200,7 @@ func (c *Context) set(id string, pInfo *process.Info) {
 	var info process.Info
 	info = *pInfo
 	c.updates[id] = &info
+	c.ids.Add(id)
 }
 
 // ListDefinitions returns the unit's charm-defined processes.

--- a/process/context/export_test.go
+++ b/process/context/export_test.go
@@ -13,7 +13,10 @@ func SetComponent(cmd cmd.Command, compCtx Component) {
 	switch cmd := cmd.(type) {
 	case *ProcRegistrationCommand:
 		cmd.compCtx = compCtx
+	case *ProcInfoCommand:
+		cmd.compCtx = compCtx
 	}
+	// TODO(ericsnow) Add ProcLaunchCommand here.
 }
 
 func AddProc(ctx *Context, id string, original *process.Info) {

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -1,0 +1,148 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+)
+
+const infoDoc = `
+"info" is used while a hook is running to access a currently registered
+workload process (or the list of all the unit's processes). The process
+info is printed to stdout as YAML-formatted text.
+`
+
+// ProcInfoCommand implements the register command.
+type ProcInfoCommand struct {
+	baseCommand
+
+	// Available indicates that only unregistered process definitions
+	// from the charm metadata should be shown.
+	Available bool
+}
+
+// NewProcInfoCommand returns a new ProcInfoCommand.
+func NewProcInfoCommand(ctx HookContext) (*ProcInfoCommand, error) {
+	base, err := newCommand(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ProcInfoCommand{
+		baseCommand: *base,
+	}, nil
+}
+
+// Info implements cmd.Command.
+func (c *ProcInfoCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "info",
+		Args:    "[<name>]",
+		Purpose: "get info about a workload process (or all of them)",
+		Doc:     infoDoc,
+	}
+}
+
+// SetFlags implements cmd.Command.
+func (c *ProcInfoCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.Available, "available", false, "show unregistered processes instead")
+}
+
+// Init implements cmd.Command.
+func (c *ProcInfoCommand) Init(args []string) error {
+	if len(args) > 1 {
+		return errors.Errorf("expected <name> (or nothing), got: %v", args)
+	}
+	if len(args) > 0 {
+		if c.Available {
+			c.Name = args[0]
+			// Do not call c.init().
+		} else if err := c.init(args[0]); err != nil {
+			return errors.Trace(err)
+		}
+	} // Otherwise we do *not* call c.init().
+	return nil
+}
+
+// Run implements cmd.Command.
+func (c *ProcInfoCommand) Run(ctx *cmd.Context) error {
+	var ids []string
+	if c.Name != "" {
+		ids = append(ids, c.Name)
+	}
+
+	if c.Available {
+		if err := c.printDefinitions(ctx, ids...); err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		if err := c.printInfos(ctx, ids...); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (c *ProcInfoCommand) printInfos(ctx *cmd.Context, ids ...string) error {
+	procs, err := c.registeredProcs(ids...)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(procs) == 0 {
+		if len(ids) != 0 {
+			return errors.NotFoundf("%v", ids)
+		}
+		fmt.Fprintln(ctx.Stderr, " [no processes registered]")
+		return nil
+	}
+	// TODO(ericsnow) Sort if len(ids) == 0.
+	var values []interface{}
+	for _, v := range procs {
+		values = append(values, v)
+	}
+	if err := dumpAll(ctx, values...); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *ProcInfoCommand) printDefinitions(ctx *cmd.Context, names ...string) error {
+	definitions, err := c.defsFromCharm(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(names) == 0 {
+		if len(definitions) == 0 {
+			fmt.Fprintln(ctx.Stderr, " [no processes defined in charm]")
+			return nil
+		}
+		for _, def := range definitions {
+			names = append(names, def.Name)
+		}
+		sort.Strings(names)
+	}
+
+	// Now print them out.
+	definition, ok := definitions[names[0]]
+	if !ok {
+		return errors.NotFoundf(names[0])
+	}
+	if err := dump(ctx, definition); err != nil {
+		return errors.Trace(err)
+	}
+	for _, name := range names[1:] {
+		definition, ok := definitions[name]
+		if !ok {
+			return errors.NotFoundf(name)
+		}
+		if err := dump(ctx, definition); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -12,11 +12,17 @@ import (
 	"launchpad.net/gnuflag"
 )
 
-const infoDoc = `
+// InfoCommandInfo is the info for the proc-info command.
+var InfoCommandInfo = cmdInfo{
+	Name:         "process-info",
+	OptionalArgs: []string{"name"},
+	Summary:      "get info about a workload process (or all of them)",
+	Doc: `
 "info" is used while a hook is running to access a currently registered
 workload process (or the list of all the unit's processes). The process
 info is printed to stdout as YAML-formatted text.
-`
+`,
+}
 
 // ProcInfoCommand implements the register command.
 type ProcInfoCommand struct {
@@ -33,19 +39,11 @@ func NewProcInfoCommand(ctx HookContext) (*ProcInfoCommand, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &ProcInfoCommand{
+	c := &ProcInfoCommand{
 		baseCommand: *base,
-	}, nil
-}
-
-// Info implements cmd.Command.
-func (c *ProcInfoCommand) Info() *cmd.Info {
-	return &cmd.Info{
-		Name:    "info",
-		Args:    "[<name>]",
-		Purpose: "get info about a workload process (or all of them)",
-		Doc:     infoDoc,
 	}
+	c.cmdInfo = InfoCommandInfo
+	return c, nil
 }
 
 // SetFlags implements cmd.Command.

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
 )
 
 // InfoCommandInfo is the info for the proc-info command.
@@ -26,6 +27,8 @@ The process info is printed to stdout as YAML-formatted text.
 // ProcInfoCommand implements the register command.
 type ProcInfoCommand struct {
 	baseCommand
+
+	output cmd.Output
 }
 
 // NewProcInfoCommand returns a new ProcInfoCommand.
@@ -40,6 +43,14 @@ func NewProcInfoCommand(ctx HookContext) (*ProcInfoCommand, error) {
 	c.cmdInfo = InfoCommandInfo
 	c.handleArgs = c.init
 	return c, nil
+}
+
+func (c *ProcInfoCommand) SetFlags(f *gnuflag.FlagSet) {
+	defaultFormat := "yaml"
+	c.output.AddFlags(f, defaultFormat, map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
 }
 
 func (c *ProcInfoCommand) init(args map[string]string) error {
@@ -59,41 +70,45 @@ func (c *ProcInfoCommand) Run(ctx *cmd.Context) error {
 		ids = append(ids, c.Name)
 	}
 
-	if err := c.printInfos(ctx, ids...); err != nil {
+	formatted, err := c.formatInfos(ids...)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(formatted) == 0 {
+		fmt.Fprintln(ctx.Stderr, "<no processes registered>")
+		return nil
+	}
+
+	if err := c.output.Write(ctx, formatted); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
 }
 
-func (c *ProcInfoCommand) printInfos(ctx *cmd.Context, ids ...string) error {
+func (c *ProcInfoCommand) formatInfos(ids ...string) (map[string]interface{}, error) {
 	procs, err := c.registeredProcs(ids...)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	if len(procs) == 0 {
-		if len(ids) != 0 {
-			return errors.NotFoundf("%v", ids)
+	if len(ids) != 0 {
+		if len(procs) == 0 {
+			return nil, errors.NotFoundf("%v", ids)
 		}
-		fmt.Fprintln(ctx.Stderr, " [no processes registered]")
-		return nil
-	}
-	if len(ids) == 0 {
+	} else {
 		for _, proc := range procs {
 			ids = append(ids, proc.Name)
 		}
 		sort.Strings(ids)
 	}
 
-	values := make(map[string]interface{})
-	for k, v := range procs {
-		if v == nil {
-			values[k] = nil
-			continue
+	results := make(map[string]interface{}, len(ids))
+	for _, id := range ids {
+		proc := procs[id]
+		if proc == nil {
+			results[id] = "<not found>"
+		} else {
+			results[id] = *proc
 		}
-		values[k] = v
 	}
-	if err := dumpAll(ctx, ids, values); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	return results, nil
 }

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -100,12 +100,22 @@ func (c *ProcInfoCommand) printInfos(ctx *cmd.Context, ids ...string) error {
 		fmt.Fprintln(ctx.Stderr, " [no processes registered]")
 		return nil
 	}
-	// TODO(ericsnow) Sort if len(ids) == 0.
-	var values []interface{}
-	for _, v := range procs {
-		values = append(values, v)
+	if len(ids) == 0 {
+		for _, proc := range procs {
+			ids = append(ids, proc.Name)
+		}
+		sort.Strings(ids)
 	}
-	if err := dumpAll(ctx, values...); err != nil {
+
+	values := make(map[string]interface{})
+	for k, v := range procs {
+		if v == nil {
+			values[k] = nil
+			continue
+		}
+		values[k] = v
+	}
+	if err := dumpAll(ctx, ids, values); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -128,21 +138,28 @@ func (c *ProcInfoCommand) printDefinitions(ctx *cmd.Context, names ...string) er
 	}
 
 	// Now print them out.
-	definition, ok := definitions[names[0]]
-	if !ok {
-		return errors.NotFoundf(names[0])
+	values := make(map[string]interface{})
+	for k, v := range definitions {
+		values[k] = v
 	}
-	if err := dump(ctx, definition); err != nil {
+	if err := dumpAll(ctx, names, values); err != nil {
 		return errors.Trace(err)
 	}
-	for _, name := range names[1:] {
-		definition, ok := definitions[name]
-		if !ok {
-			return errors.NotFoundf(name)
-		}
-		if err := dump(ctx, definition); err != nil {
-			return errors.Trace(err)
-		}
-	}
+	//definition, ok := definitions[names[0]]
+	//if !ok {
+	//	return errors.NotFoundf(names[0])
+	//}
+	//if err := dump(ctx, ndefinition); err != nil {
+	//	return errors.Trace(err)
+	//}
+	//for _, name := range names[1:] {
+	//	definition, ok := definitions[name]
+	//	if !ok {
+	//		return errors.NotFoundf(name)
+	//	}
+	//	if err := dump(ctx, definition); err != nil {
+	//		return errors.Trace(err)
+	//	}
+	//}
 	return nil
 }

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -43,6 +43,7 @@ func NewProcInfoCommand(ctx HookContext) (*ProcInfoCommand, error) {
 		baseCommand: *base,
 	}
 	c.cmdInfo = InfoCommandInfo
+	c.handleArgs = c.init
 	return c, nil
 }
 
@@ -51,19 +52,15 @@ func (c *ProcInfoCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.Available, "available", false, "show unregistered processes instead")
 }
 
-// Init implements cmd.Command.
-func (c *ProcInfoCommand) Init(args []string) error {
-	if len(args) > 1 {
-		return errors.Errorf("expected <name> (or nothing), got: %v", args)
-	}
+func (c *ProcInfoCommand) init(args map[string]string) error {
 	if len(args) > 0 {
 		if c.Available {
-			c.Name = args[0]
+			c.Name = args["name"]
 			// Do not call c.init().
-		} else if err := c.init(args[0]); err != nil {
+		} else if err := c.baseCommand.init(args); err != nil {
 			return errors.Trace(err)
 		}
-	} // Otherwise we do *not* call c.init().
+	} // Otherwise we do nothing.
 	return nil
 }
 

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -17,9 +17,9 @@ var InfoCommandInfo = cmdInfo{
 	OptionalArgs: []string{"name"},
 	Summary:      "get info about a workload process (or all of them)",
 	Doc: `
-"info" is used while a hook is running to access a currently registered
-workload process (or the list of all the unit's processes). The process
-info is printed to stdout as YAML-formatted text.
+"process-info" is used while a hook is running to access a currently
+registered workload process (or the list of all the unit's processes).
+The process info is printed to stdout as YAML-formatted text.
 `,
 }
 

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -53,14 +53,12 @@ func (c *ProcInfoCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *ProcInfoCommand) init(args map[string]string) error {
-	if len(args) > 0 {
-		if c.Available {
-			c.Name = args["name"]
-			// Do not call c.init().
-		} else if err := c.baseCommand.init(args); err != nil {
-			return errors.Trace(err)
-		}
-	} // Otherwise we do nothing.
+	if len(args) == 0 {
+		return nil
+	}
+	if err := c.baseCommand.init(args); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 
@@ -140,21 +138,5 @@ func (c *ProcInfoCommand) printDefinitions(ctx *cmd.Context, names ...string) er
 	if err := dumpAll(ctx, names, values); err != nil {
 		return errors.Trace(err)
 	}
-	//definition, ok := definitions[names[0]]
-	//if !ok {
-	//	return errors.NotFoundf(names[0])
-	//}
-	//if err := dump(ctx, ndefinition); err != nil {
-	//	return errors.Trace(err)
-	//}
-	//for _, name := range names[1:] {
-	//	definition, ok := definitions[name]
-	//	if !ok {
-	//		return errors.NotFoundf(name)
-	//	}
-	//	if err := dump(ctx, definition); err != nil {
-	//		return errors.Trace(err)
-	//	}
-	//}
 	return nil
 }

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -112,7 +112,7 @@ func (c *ProcInfoCommand) printInfos(ctx *cmd.Context, ids ...string) error {
 }
 
 func (c *ProcInfoCommand) printDefinitions(ctx *cmd.Context, names ...string) error {
-	definitions, err := c.defsFromCharm(ctx)
+	definitions, err := c.defsFromCharm()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -1,0 +1,322 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context_test
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/process"
+	"github.com/juju/juju/process/context"
+)
+
+var (
+	rawProcs = []string{
+		`
+process:
+  name: myprocess0
+  description: ""
+  type: myplugin
+  typeoptions:
+    extra: "5"
+  command: do-something
+  image: myimage
+  ports: []
+  volumes: []
+  envvars:
+    ENV_VAR: some value
+details:
+  id: xyz123
+  status:
+    label: running
+`[1:],
+		`
+process:
+  name: myprocess1
+  description: ""
+  type: myplugin
+  typeoptions: {}
+  command: do-something
+  image: myimage
+  ports: []
+  volumes: []
+  envvars: {}
+details:
+  id: xyz456
+  status:
+    label: running
+`[1:],
+		`
+process:
+  name: myprocess2
+  description: ""
+  type: myplugin
+  typeoptions: {}
+  command: ""
+  image: ""
+  ports: []
+  volumes: []
+  envvars: {}
+details:
+  id: xyz789
+  status:
+    label: invalid
+`[1:],
+	}
+	procs = []*process.Info{{
+		Process: charm.Process{
+			Name: "myprocess0",
+			Type: "myplugin",
+			TypeOptions: map[string]string{
+				"extra": "5",
+			},
+			Command: "do-something",
+			Image:   "myimage",
+			EnvVars: map[string]string{
+				"ENV_VAR": "some value",
+			},
+		},
+		Details: process.Details{
+			ID: "xyz123",
+			Status: process.PluginStatus{
+				Label: "running",
+			},
+		},
+	}, {
+		Process: charm.Process{
+			Name:    "myprocess1",
+			Type:    "myplugin",
+			Command: "do-something",
+			Image:   "myimage",
+		},
+		Details: process.Details{
+			ID: "xyz456",
+			Status: process.PluginStatus{
+				Label: "running",
+			},
+		},
+	}, {
+		Process: charm.Process{
+			Name: "myprocess2",
+			Type: "myplugin",
+		},
+		Details: process.Details{
+			ID: "xyz789",
+			Status: process.PluginStatus{
+				Label: "invalid",
+			},
+		},
+	}}
+
+	rawDefinition = `
+name: wistful
+description: ""
+type: other-type
+typeoptions: {}
+command: run
+image: ""
+ports: []
+volumes: []
+envvars: {}
+`[1:]
+	definition = charm.Process{
+		Name:    "wistful",
+		Type:    "other-type",
+		Command: "run",
+	}
+	meta = charm.Meta{
+		Name:        "mycharm",
+		Summary:     "a charm",
+		Description: "a charm",
+		Processes: map[string]charm.Process{
+			"wistful": definition,
+		},
+	}
+)
+
+type infoSuite struct {
+	commandSuite
+
+	infoCmd *context.ProcInfoCommand
+}
+
+var _ = gc.Suite(&infoSuite{})
+
+func (s *infoSuite) SetUpTest(c *gc.C) {
+	s.commandSuite.SetUpTest(c)
+
+	cmd, err := context.NewProcInfoCommand(s.Ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.infoCmd = cmd
+	s.setCommand(c, "info", s.infoCmd)
+
+	cmd.ReadMetadata = s.readMetadata
+}
+
+func (s *infoSuite) init(c *gc.C, name string) {
+	if name == "" {
+		err := s.infoCmd.Init(nil)
+		c.Assert(err, jc.ErrorIsNil)
+	} else {
+		err := s.infoCmd.Init([]string{name})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *infoSuite) TestCommandRegistered(c *gc.C) {
+	s.checkCommandRegistered(c)
+}
+
+func (s *infoSuite) TestHelp(c *gc.C) {
+	s.checkHelp(c, `
+usage: info [options] [<name>]
+purpose: get info about a workload process (or all of them)
+
+options:
+--available  (= false)
+    show unregistered processes instead
+
+"info" is used while a hook is running to access a currently registered
+workload process (or the list of all the unit's processes). The process
+info is printed to stdout as YAML-formatted text.
+`[1:])
+}
+
+func (s *infoSuite) TestInitWithNameRegistered(c *gc.C) {
+	context.AddProcs(s.compCtx, s.proc)
+
+	err := s.infoCmd.Init([]string{s.proc.Name})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(s.infoCmd.Name, gc.Equals, s.proc.Name)
+}
+
+func (s *infoSuite) TestInitWithNameAvailable(c *gc.C) {
+	s.infoCmd.Available = true
+	context.AddProcs(s.compCtx, s.proc)
+
+	err := s.infoCmd.Init([]string{s.proc.Name})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(s.infoCmd.Name, gc.Equals, s.proc.Name)
+}
+
+func (s *infoSuite) TestInitWithoutNameRegistered(c *gc.C) {
+	err := s.infoCmd.Init(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(s.infoCmd.Name, gc.Equals, "")
+}
+
+func (s *infoSuite) TestInitWithoutNameAvailable(c *gc.C) {
+	s.infoCmd.Available = true
+	err := s.infoCmd.Init(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(s.infoCmd.Name, gc.Equals, "")
+}
+
+func (s *infoSuite) TestInitNotFound(c *gc.C) {
+	err := s.infoCmd.Init([]string{s.proc.Name})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(s.infoCmd.Name, gc.Equals, s.proc.Name)
+}
+
+func (s *infoSuite) TestInitTooManyArgs(c *gc.C) {
+	err := s.infoCmd.Init([]string{s.proc.Name, "other"})
+
+	c.Check(err, gc.ErrorMatches, `expected <name> \(or nothing\), got: .*`)
+}
+
+func (s *infoSuite) TestRunWithNameOkay(c *gc.C) {
+	compCtx := newStubContextComponent(s.Stub)
+	compCtx.procs["myprocess0"] = procs[0]
+	compCtx.procs["myprocess1"] = procs[1]
+	compCtx.procs["myprocess2"] = procs[2]
+	s.init(c, "myprocess0")
+	context.SetComponent(s.cmd, compCtx)
+
+	s.checkRun(c, rawProcs[0]+"\n", "")
+	s.Stub.CheckCallNames(c, "Get")
+}
+
+func (s *infoSuite) TestRunWithoutNameOkay(c *gc.C) {
+	compCtx := newStubContextComponent(s.Stub)
+	compCtx.procs["myprocess0"] = procs[0]
+	compCtx.procs["myprocess1"] = procs[1]
+	compCtx.procs["myprocess2"] = procs[2]
+	context.AddProcs(s.compCtx, procs...)
+	s.init(c, "")
+	context.SetComponent(s.cmd, compCtx)
+
+	expected := strings.Join(rawProcs, "\n")
+	s.checkRun(c, expected+"\n", "")
+	s.Stub.CheckCallNames(c, "List", "Get", "Get", "Get")
+}
+
+func (s *infoSuite) TestRunWithNameMissing(c *gc.C) {
+	compCtx := newStubContextComponent(s.Stub)
+	s.init(c, "myprocess0")
+	context.SetComponent(s.cmd, compCtx)
+
+	err := s.infoCmd.Run(s.cmdCtx)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	s.Stub.CheckCallNames(c, "Get")
+}
+
+func (s *infoSuite) TestRunWithoutNameEmpty(c *gc.C) {
+	compCtx := newStubContextComponent(s.Stub)
+	s.init(c, "")
+	context.SetComponent(s.cmd, compCtx)
+
+	s.checkRun(c, "", " [no processes registered]\n")
+	s.Stub.CheckCallNames(c, "List")
+}
+
+func (s *infoSuite) TestRunWithNameAvailable(c *gc.C) {
+	s.infoCmd.Available = true
+	//context.AddProcs(s.compCtx, procs...)
+	s.metadata = &meta
+	s.init(c, "wistful")
+
+	s.checkRun(c, rawDefinition+"\n", "")
+	s.Stub.CheckCalls(c, nil)
+}
+
+func (s *infoSuite) TestRunWithoutNameAvailable(c *gc.C) {
+	s.infoCmd.Available = true
+	//context.AddProcs(s.compCtx, procs...)
+	s.metadata = &meta
+	s.init(c, "")
+
+	s.checkRun(c, rawDefinition+"\n", "")
+	s.Stub.CheckCalls(c, nil)
+}
+
+func (s *infoSuite) TestRunWithNameNotAvailable(c *gc.C) {
+	s.infoCmd.Available = true
+	//context.AddProcs(s.compCtx, procs...)
+	s.init(c, "wistful")
+
+	err := s.infoCmd.Run(s.cmdCtx)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	s.Stub.CheckCalls(c, nil)
+}
+
+func (s *infoSuite) TestRunWithoutNameNotAvailable(c *gc.C) {
+	s.infoCmd.Available = true
+	//context.AddProcs(s.compCtx, procs...)
+	s.init(c, "")
+
+	s.checkRun(c, "", " [no processes defined in charm]\n")
+	s.Stub.CheckCalls(c, nil)
+}

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -156,7 +156,6 @@ func (s *infoSuite) init(c *gc.C, name string) {
 		err := s.infoCmd.Init([]string{name})
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	s.Stub.ResetCalls()
 }
 
 func (s *infoSuite) TestCommandRegistered(c *gc.C) {

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -154,7 +154,7 @@ func (s *infoSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.infoCmd = cmd
-	s.setCommand(c, "info", s.infoCmd)
+	s.setCommand(c, "proc-info", s.infoCmd)
 
 	cmd.ReadMetadata = s.readMetadata
 }

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -150,9 +150,9 @@ func (s *infoSuite) TestHelp(c *gc.C) {
 usage: process-info [<name>]
 purpose: get info about a workload process (or all of them)
 
-"info" is used while a hook is running to access a currently registered
-workload process (or the list of all the unit's processes). The process
-info is printed to stdout as YAML-formatted text.
+"process-info" is used while a hook is running to access a currently
+registered workload process (or the list of all the unit's processes).
+The process info is printed to stdout as YAML-formatted text.
 `[1:])
 }
 

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -6,7 +6,6 @@ package context_test
 import (
 	"strings"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
@@ -250,9 +249,7 @@ func (s *infoSuite) TestRunWithoutNameOkay(c *gc.C) {
 func (s *infoSuite) TestRunWithNameMissing(c *gc.C) {
 	s.init(c, "myprocess0")
 
-	err := s.infoCmd.Run(s.cmdCtx)
-
-	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	s.checkRun(c, `["myprocess0" not found]`+"\n", "")
 	s.Stub.CheckCallNames(c, "Get")
 }
 
@@ -285,9 +282,7 @@ func (s *infoSuite) TestRunWithNameNotAvailable(c *gc.C) {
 	s.infoCmd.Available = true
 	s.init(c, "wistful")
 
-	err := s.infoCmd.Run(s.cmdCtx)
-
-	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	s.checkRun(c, `["wistful" not found]`+"\n", "")
 	s.Stub.CheckCallNames(c, "ListDefinitions")
 }
 

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	procs = []*process.Info{{
+	proc0 = process.Info{
 		Process: charm.Process{
 			Name: "myprocess0",
 			Type: "myplugin",
@@ -33,7 +33,8 @@ var (
 				Label: "running",
 			},
 		},
-	}, {
+	}
+	proc1 = process.Info{
 		Process: charm.Process{
 			Name:    "myprocess1",
 			Type:    "myplugin",
@@ -46,7 +47,8 @@ var (
 				Label: "running",
 			},
 		},
-	}, {
+	}
+	proc2 = process.Info{
 		Process: charm.Process{
 			Name: "myprocess2",
 			Type: "myplugin",
@@ -57,7 +59,7 @@ var (
 				Label: "invalid",
 			},
 		},
-	}}
+	}
 )
 
 type infoSuite struct {
@@ -141,9 +143,9 @@ func (s *infoSuite) TestInitTooManyArgs(c *gc.C) {
 }
 
 func (s *infoSuite) TestRunWithNameOkay(c *gc.C) {
-	s.compCtx.procs["myprocess0"] = procs[0]
-	s.compCtx.procs["myprocess1"] = procs[1]
-	s.compCtx.procs["myprocess2"] = procs[2]
+	s.compCtx.procs["myprocess0"] = &proc0
+	s.compCtx.procs["myprocess1"] = &proc1
+	s.compCtx.procs["myprocess2"] = &proc2
 	s.init(c, "myprocess0")
 
 	expected := `
@@ -170,9 +172,9 @@ myprocess0:
 }
 
 func (s *infoSuite) TestRunWithoutNameOkay(c *gc.C) {
-	s.compCtx.procs["myprocess0"] = procs[0]
-	s.compCtx.procs["myprocess1"] = procs[1]
-	s.compCtx.procs["myprocess2"] = procs[2]
+	s.compCtx.procs["myprocess0"] = &proc0
+	s.compCtx.procs["myprocess1"] = &proc1
+	s.compCtx.procs["myprocess2"] = &proc2
 	s.init(c, "")
 
 	expected := `

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -111,23 +111,6 @@ details:
 			},
 		},
 	}}
-
-	rawDefinition = `
-name: wistful
-description: ""
-type: other-type
-typeoptions: {}
-command: run
-image: ""
-ports: []
-volumes: []
-envvars: {}
-`[1:]
-	definition = charm.Process{
-		Name:    "wistful",
-		Type:    "other-type",
-		Command: "run",
-	}
 )
 
 type infoSuite struct {
@@ -164,12 +147,8 @@ func (s *infoSuite) TestCommandRegistered(c *gc.C) {
 
 func (s *infoSuite) TestHelp(c *gc.C) {
 	s.checkHelp(c, `
-usage: process-info [options] [<name>]
+usage: process-info [<name>]
 purpose: get info about a workload process (or all of them)
-
-options:
---available  (= false)
-    show unregistered processes instead
 
 "info" is used while a hook is running to access a currently registered
 workload process (or the list of all the unit's processes). The process
@@ -177,7 +156,7 @@ info is printed to stdout as YAML-formatted text.
 `[1:])
 }
 
-func (s *infoSuite) TestInitWithNameRegistered(c *gc.C) {
+func (s *infoSuite) TestInitWithName(c *gc.C) {
 	s.compCtx.procs[s.proc.Name] = s.proc
 
 	err := s.infoCmd.Init([]string{s.proc.Name})
@@ -186,25 +165,7 @@ func (s *infoSuite) TestInitWithNameRegistered(c *gc.C) {
 	c.Check(s.infoCmd.Name, gc.Equals, s.proc.Name)
 }
 
-func (s *infoSuite) TestInitWithNameAvailable(c *gc.C) {
-	s.infoCmd.Available = true
-	s.compCtx.procs[s.proc.Name] = s.proc
-
-	err := s.infoCmd.Init([]string{s.proc.Name})
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(s.infoCmd.Name, gc.Equals, s.proc.Name)
-}
-
-func (s *infoSuite) TestInitWithoutNameRegistered(c *gc.C) {
-	err := s.infoCmd.Init(nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(s.infoCmd.Name, gc.Equals, "")
-}
-
-func (s *infoSuite) TestInitWithoutNameAvailable(c *gc.C) {
-	s.infoCmd.Available = true
+func (s *infoSuite) TestInitWithoutName(c *gc.C) {
 	err := s.infoCmd.Init(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -257,38 +218,4 @@ func (s *infoSuite) TestRunWithoutNameEmpty(c *gc.C) {
 
 	s.checkRun(c, "", " [no processes registered]\n")
 	s.Stub.CheckCallNames(c, "List")
-}
-
-func (s *infoSuite) TestRunWithNameAvailable(c *gc.C) {
-	s.infoCmd.Available = true
-	s.compCtx.definitions[definition.Name] = definition
-	s.init(c, "wistful")
-
-	s.checkRun(c, rawDefinition+"\n", "")
-	s.Stub.CheckCallNames(c, "ListDefinitions")
-}
-
-func (s *infoSuite) TestRunWithoutNameAvailable(c *gc.C) {
-	s.infoCmd.Available = true
-	s.compCtx.definitions[definition.Name] = definition
-	s.init(c, "")
-
-	s.checkRun(c, rawDefinition+"\n", "")
-	s.Stub.CheckCallNames(c, "ListDefinitions")
-}
-
-func (s *infoSuite) TestRunWithNameNotAvailable(c *gc.C) {
-	s.infoCmd.Available = true
-	s.init(c, "wistful")
-
-	s.checkRun(c, `["wistful" not found]`+"\n", "")
-	s.Stub.CheckCallNames(c, "ListDefinitions")
-}
-
-func (s *infoSuite) TestRunWithoutNameNotAvailable(c *gc.C) {
-	s.infoCmd.Available = true
-	s.init(c, "")
-
-	s.checkRun(c, "", " [no processes defined in charm]\n")
-	s.Stub.CheckCallNames(c, "ListDefinitions")
 }

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -145,7 +145,7 @@ func (s *infoSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.infoCmd = cmd
-	s.setCommand(c, "proc-info", s.infoCmd)
+	s.setCommand(c, "process-info", s.infoCmd)
 }
 
 func (s *infoSuite) init(c *gc.C, name string) {
@@ -165,7 +165,7 @@ func (s *infoSuite) TestCommandRegistered(c *gc.C) {
 
 func (s *infoSuite) TestHelp(c *gc.C) {
 	s.checkHelp(c, `
-usage: info [options] [<name>]
+usage: process-info [options] [<name>]
 purpose: get info about a workload process (or all of them)
 
 options:

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -222,7 +222,7 @@ func (s *infoSuite) TestInitNotFound(c *gc.C) {
 func (s *infoSuite) TestInitTooManyArgs(c *gc.C) {
 	err := s.infoCmd.Init([]string{s.proc.Name, "other"})
 
-	c.Check(err, gc.ErrorMatches, `expected <name> \(or nothing\), got: .*`)
+	c.Check(err, gc.ErrorMatches, `unrecognized args: .*`)
 }
 
 func (s *infoSuite) TestRunWithNameOkay(c *gc.C) {

--- a/process/context/launch.go
+++ b/process/context/launch.go
@@ -44,6 +44,7 @@ func NewProcLaunchCommand(findPlugin FindPluginFn, launchPlugin LaunchPluginFn, 
 		launchPlugin:       launchPlugin,
 	}
 	c.cmdInfo = LaunchCommandInfo
+	c.handleArgs = c.init
 	return c, nil
 }
 
@@ -54,22 +55,6 @@ type ProcLaunchCommand struct {
 
 	findPlugin   FindPluginFn
 	launchPlugin LaunchPluginFn
-}
-
-// Init implements cmd.Command.
-func (c *ProcLaunchCommand) Init(args []string) error {
-	if len(args) != 1 {
-		return errors.Errorf("expected %s, got %v", c.Info().Args, args)
-	}
-
-	return c.init(args[0])
-}
-
-func (c *ProcLaunchCommand) init(name string) error {
-	if err := c.registeringCommand.init(name); err != nil {
-		return err
-	}
-	return nil
 }
 
 // Run implements cmd.Command.

--- a/process/context/launch.go
+++ b/process/context/launch.go
@@ -59,6 +59,9 @@ type ProcLaunchCommand struct {
 
 // Run implements cmd.Command.
 func (c *ProcLaunchCommand) Run(ctx *cmd.Context) error {
+	if err := c.registeringCommand.Run(ctx); err != nil {
+		return errors.Trace(err)
+	}
 
 	info, err := c.findValidInfo(ctx)
 	if err != nil {

--- a/process/context/launch.go
+++ b/process/context/launch.go
@@ -18,7 +18,7 @@ var LaunchCommandInfo = cmdInfo{
 	Name:    "process-launch",
 	Summary: "launch a workload process",
 	Doc: `
-"launch" is used to launch a workload process.
+"process-launch" is used to launch a workload process.
 
 The process name must correspond to one of the processes defined in
 the charm's metadata.yaml.`,

--- a/process/context/launch_test.go
+++ b/process/context/launch_test.go
@@ -39,7 +39,7 @@ func (s *launchCmdSuite) TestInitInvalidArgsReturnsErr(c *gc.C) {
 	c.Check(
 		err.Error(),
 		gc.Equals,
-		fmt.Sprintf("expected %s, got [mock-name invalid-arg]", cmd.Info().Args),
+		`unrecognized args: ["invalid-arg"]`,
 	)
 }
 

--- a/process/context/launch_test.go
+++ b/process/context/launch_test.go
@@ -73,8 +73,6 @@ func (s *launchCmdSuite) TestRun(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
-	cmd.ReadMetadata = s.readMetadata
-	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	err = cmd.Init([]string{s.proc.Name})
 	c.Assert(err, jc.ErrorIsNil)

--- a/process/context/launch_test.go
+++ b/process/context/launch_test.go
@@ -73,6 +73,8 @@ func (s *launchCmdSuite) TestRun(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
+	cmd.ReadMetadata = s.readMetadata
+	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	err = cmd.Init([]string{s.proc.Name})
 	c.Assert(err, jc.ErrorIsNil)

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -61,6 +61,10 @@ func (c *ProcRegistrationCommand) init(args map[string]string) error {
 
 // Run implements cmd.Command.
 func (c *ProcRegistrationCommand) Run(ctx *cmd.Context) error {
+	if err := c.registeringCommand.Run(ctx); err != nil {
+		return errors.Trace(err)
+	}
+
 	// TODO(wwitzel3) should charmer have direct access to pInfo.Status?
 	if err := c.register(ctx); err != nil {
 		return errors.Trace(err)

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/juju/process"
 )
 
-// RegisterCommandInfo is the info for the proc-launch command.
+// RegisterCommandInfo is the info for the proc-register command.
 var RegisterCommandInfo = cmdInfo{
 	Name:      "process-register",
 	ExtraArgs: []string{"proc-details"},

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -40,22 +40,16 @@ func NewProcRegistrationCommand(ctx HookContext) (*ProcRegistrationCommand, erro
 		registeringCommand: *base,
 	}
 	c.cmdInfo = RegisterCommandInfo
+	c.handleArgs = c.init
 	return c, nil
 }
 
-// Init implements cmd.Command.
-func (c *ProcRegistrationCommand) Init(args []string) error {
-	if len(args) != 2 {
-		return errors.Errorf("expected <name> <proc-details>, got: %v", args)
-	}
-	return c.init(args[0], args[1])
-}
-
-func (c *ProcRegistrationCommand) init(name, detailsStr string) error {
-	if err := c.registeringCommand.init(name); err != nil {
+func (c *ProcRegistrationCommand) init(args map[string]string) error {
+	if err := c.registeringCommand.init(args); err != nil {
 		return errors.Trace(err)
 	}
 
+	detailsStr := args["proc-details"]
 	details, err := process.UnmarshalDetails([]byte(detailsStr))
 	if err != nil {
 		return errors.Trace(err)

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -16,9 +16,9 @@ var RegisterCommandInfo = cmdInfo{
 	ExtraArgs: []string{"proc-details"},
 	Summary:   "register a workload process",
 	Doc: `
-"register" is used while a hook is running to let Juju know that
-a workload process has been manually started. The information used
-to start the process must be provided when "register" is run.
+"process-register" is used while a hook is running to let Juju know
+that a workload process has been manually started. The information
+used to start the process must be provided when "register" is run.
 
 The process name must correspond to one of the processes defined in
 the charm's metadata.yaml.

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -67,9 +67,9 @@ options:
 --override  (= )
     override process definition
 
-"register" is used while a hook is running to let Juju know that
-a workload process has been manually started. The information used
-to start the process must be provided when "register" is run.
+"process-register" is used while a hook is running to let Juju know
+that a workload process has been manually started. The information
+used to start the process must be provided when "register" is run.
 
 The process name must correspond to one of the processes defined in
 the charm's metadata.yaml.

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -104,10 +104,10 @@ func (s *registerSuite) TestInitAlreadyRegistered(c *gc.C) {
 
 func (s *registerSuite) TestInitTooFewArgs(c *gc.C) {
 	err := s.registerCmd.Init([]string{})
-	c.Check(err, gc.ErrorMatches, "expected <name> <proc-details>, got: .*")
+	c.Check(err, gc.ErrorMatches, `missing args .*`)
 
 	err = s.registerCmd.Init([]string{s.proc.Name})
-	c.Check(err, gc.ErrorMatches, "expected <name> <proc-details>, got: .*")
+	c.Check(err, gc.ErrorMatches, `missing args .*`)
 }
 
 func (s *registerSuite) TestInitTooManyArgs(c *gc.C) {
@@ -117,7 +117,7 @@ func (s *registerSuite) TestInitTooManyArgs(c *gc.C) {
 		"other",
 	})
 
-	c.Check(err, gc.ErrorMatches, "expected <name> <proc-details>, got: .*")
+	c.Check(err, gc.ErrorMatches, "unrecognized args: .*")
 }
 
 func (s *registerSuite) TestInitEmptyName(c *gc.C) {

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -303,7 +303,6 @@ func (s *registerSuite) TestAdditionMissingColon(c *gc.C) {
 func (s *registerSuite) TestRunOkay(c *gc.C) {
 	s.setMetadata(*s.proc)
 	s.init(c, s.proc.Name, "abc123", "running")
-	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	s.checkRun(c, "", "")
 	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
@@ -314,7 +313,6 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 	s.setMetadata(*s.proc)
 	s.registerCmd.Overrides = []string{"description:foo"}
 	s.init(c, s.proc.Name, "abc123", "running")
-	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	s.checkRun(c, "", "")
 

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -90,18 +90,6 @@ func (s *registerSuite) TestInitAllArgs(c *gc.C) {
 	})
 }
 
-func (s *registerSuite) TestInitAlreadyRegistered(c *gc.C) {
-	s.proc.Details.ID = "xyz123"
-	s.compCtx.procs[s.proc.Name] = s.proc
-
-	err := s.registerCmd.Init([]string{
-		s.proc.Name,
-		`{"id":"abc123", "status":{"label":"okay"}}`,
-	})
-
-	c.Check(err, gc.ErrorMatches, ".*already registered")
-}
-
 func (s *registerSuite) TestInitTooFewArgs(c *gc.C) {
 	err := s.registerCmd.Init([]string{})
 	c.Check(err, gc.ErrorMatches, `missing args .*`)
@@ -306,6 +294,16 @@ func (s *registerSuite) TestRunOkay(c *gc.C) {
 
 	s.checkRun(c, "", "")
 	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
+}
+
+func (s *registerSuite) TestRunAlreadyRegistered(c *gc.C) {
+	s.proc.Details.ID = "xyz123"
+	s.compCtx.procs[s.proc.Name] = s.proc
+	s.init(c, s.proc.Name, "abc123", "okay")
+
+	err := s.registerCmd.Run(s.cmdCtx)
+
+	c.Check(err, gc.ErrorMatches, ".*already registered")
 }
 
 func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -303,6 +303,7 @@ func (s *registerSuite) TestAdditionMissingColon(c *gc.C) {
 func (s *registerSuite) TestRunOkay(c *gc.C) {
 	s.setMetadata(*s.proc)
 	s.init(c, s.proc.Name, "abc123", "running")
+	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	s.checkRun(c, "", "")
 	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
@@ -313,6 +314,7 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 	s.setMetadata(*s.proc)
 	s.registerCmd.Overrides = []string{"description:foo"}
 	s.init(c, s.proc.Name, "abc123", "running")
+	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	s.checkRun(c, "", "")
 

--- a/process/context/utils.go
+++ b/process/context/utils.go
@@ -13,30 +13,36 @@ import (
 	goyaml "gopkg.in/yaml.v1"
 )
 
-func dumpAll(ctx *cmd.Context, values ...interface{}) error {
-	if len(values) == 0 {
+func dumpAll(ctx *cmd.Context, ids []string, values map[string]interface{}) error {
+	if len(ids) == 0 {
 		return nil
 	}
-	if err := dump(ctx, values[0]); err != nil {
+	if err := dump(ctx, ids[0], values); err != nil {
 		return errors.Trace(err)
 	}
-	for _, value := range values[1:] {
+	for _, id := range ids[1:] {
 		// TODO(ericsnow) Separate each entry or dump as a YAML list?
-		if err := dump(ctx, value); err != nil {
+		if err := dump(ctx, id, values); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	return nil
 }
 
-func dump(ctx *cmd.Context, value interface{}) error {
+func dump(ctx *cmd.Context, id string, values map[string]interface{}) error {
 	// TODO(ericsnow) support passing in an indent size?
 
-	data, err := goyaml.Marshal(value)
-	if err != nil {
-		return errors.Trace(err)
+	value := values[id]
+	output := fmt.Sprintf("[%q not found]", id)
+	if value != nil {
+		data, err := goyaml.Marshal(value)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		output = string(data)
 	}
-	if _, err := fmt.Fprintln(ctx.Stdout, string(data)); err != nil {
+
+	if _, err := fmt.Fprintln(ctx.Stdout, output); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/process/context/utils.go
+++ b/process/context/utils.go
@@ -21,8 +21,7 @@ func dumpAll(ctx *cmd.Context, values ...interface{}) error {
 		return errors.Trace(err)
 	}
 	for _, value := range values[1:] {
-		// TODO(ericsnow) Use a different separator or dump as a YAML list?
-		fmt.Fprintln(ctx.Stdout, "")
+		// TODO(ericsnow) Separate each entry or dump as a YAML list?
 		if err := dump(ctx, value); err != nil {
 			return errors.Trace(err)
 		}

--- a/process/context/utils.go
+++ b/process/context/utils.go
@@ -4,12 +4,44 @@
 package context
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v5"
 	goyaml "gopkg.in/yaml.v1"
 )
+
+func dumpAll(ctx *cmd.Context, values ...interface{}) error {
+	if len(values) == 0 {
+		return nil
+	}
+	if err := dump(ctx, values[0]); err != nil {
+		return errors.Trace(err)
+	}
+	for _, value := range values[1:] {
+		// TODO(ericsnow) Use a different separator or dump as a YAML list?
+		fmt.Fprintln(ctx.Stdout, "")
+		if err := dump(ctx, value); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func dump(ctx *cmd.Context, value interface{}) error {
+	// TODO(ericsnow) support passing in an indent size?
+
+	data, err := goyaml.Marshal(value)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if _, err := fmt.Fprintln(ctx.Stdout, string(data)); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
 
 func parseDefinition(name string, data []byte) (*charm.Process, error) {
 	raw := make(map[interface{}]interface{})

--- a/process/context/utils.go
+++ b/process/context/utils.go
@@ -4,49 +4,12 @@
 package context
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v5"
 	goyaml "gopkg.in/yaml.v1"
 )
-
-func dumpAll(ctx *cmd.Context, ids []string, values map[string]interface{}) error {
-	if len(ids) == 0 {
-		return nil
-	}
-	if err := dump(ctx, ids[0], values); err != nil {
-		return errors.Trace(err)
-	}
-	for _, id := range ids[1:] {
-		// TODO(ericsnow) Separate each entry or dump as a YAML list?
-		if err := dump(ctx, id, values); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
-func dump(ctx *cmd.Context, id string, values map[string]interface{}) error {
-	// TODO(ericsnow) support passing in an indent size?
-
-	value := values[id]
-	output := fmt.Sprintf("[%q not found]", id)
-	if value != nil {
-		data, err := goyaml.Marshal(value)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		output = string(data)
-	}
-
-	if _, err := fmt.Fprintln(ctx.Stdout, output); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
 
 func parseDefinition(name string, data []byte) (*charm.Process, error) {
 	raw := make(map[interface{}]interface{})


### PR DESCRIPTION
The command is used to get the info for the unit's workload processes.  It merely exposes the functionality that we already added to the API.  We need the command to properly perform feature tests for WPM.

(Review request: http://reviews.vapour.ws/r/2202/)