### PR TITLE
Leadership backport to 1.24

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -157,7 +157,8 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(env.UUID(), gc.Equals, uuid)
 
 	// Check that initial admin user has been set up correctly.
-	s.assertCanLogInAsAdmin(c, pwHash)
+	envTag := env.Tag().(names.EnvironTag)
+	s.assertCanLogInAsAdmin(c, envTag, pwHash)
 	user, err := st.User(env.Owner())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.PasswordValid(testing.DefaultMongoPassword), jc.IsTrue)
@@ -211,7 +212,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(agent.Password(newCfg), gc.Not(gc.Equals), testing.DefaultMongoPassword)
 	info, ok := cfg.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st1, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st1, err := state.Open(newCfg.Environment(), info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 }
@@ -319,7 +320,7 @@ func (s *bootstrapSuite) TestMachineJobFromParams(c *gc.C) {
 	}
 }
 
-func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, password string) {
+func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, environTag names.EnvironTag, password string) {
 	info := &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{s.mgoInst.Addr()},
@@ -328,7 +329,7 @@ func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, password string) {
 		Tag:      nil, // admin user
 		Password: password,
 	}
-	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(environTag, info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	_, err = st.Machine("0")

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -149,8 +149,8 @@ func (s *machineSuite) TestEntitySetPassword(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	info.Tag = tag
 	info.Password = "foo-12345678901234567890"
-	err = tryOpenState(info)
-	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
+	err = tryOpenState(s.State.EnvironTag(), info)
+	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsUnauthorized)
 }
 
 func (s *machineSuite) TestClearReboot(c *gc.C) {
@@ -171,8 +171,8 @@ func (s *machineSuite) TestClearReboot(c *gc.C) {
 	c.Assert(rFlag, jc.IsFalse)
 }
 
-func tryOpenState(info *mongo.MongoInfo) error {
-	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+func tryOpenState(envTag names.EnvironTag, info *mongo.MongoInfo) error {
+	st, err := state.Open(envTag, info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	if err == nil {
 		st.Close()
 	}

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -644,7 +644,7 @@ func (s *provisionerSuite) TestContainerManagerConfigKVM(c *gc.C) {
 
 func (s *provisionerSuite) TestContainerManagerConfigLXC(c *gc.C) {
 	args := params.ContainerManagerConfigParams{Type: instance.LXC}
-	st, err := state.Open(s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.State.EnvironTag(), s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -123,7 +123,7 @@ func (s *baseSuite) tryOpenState(c *gc.C, e apiAuthenticator, password string) e
 	stateInfo := s.MongoInfo(c)
 	stateInfo.Tag = e.Tag()
 	stateInfo.Password = password
-	st, err := state.Open(stateInfo, mongo.DialOpts{
+	st, err := state.Open(s.State.EnvironTag(), stateInfo, mongo.DialOpts{
 		Timeout: 25 * time.Millisecond,
 	}, environs.NewStatePolicy())
 	if err == nil {

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -114,15 +114,15 @@ func (s *pingerSuite) TestAgentConnectionDelaysShutdownWithPing(c *gc.C) {
 
 	// As long as we don't wait too long, the connection stays open
 	resetCount = 0
+	const shortTimeout = 10 * time.Millisecond
 	for i := 0; i < 10; i++ {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(shortTimeout / 4)
 		err = st.Ping()
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	c.Check(resetCount, gc.Equals, 10)
 
 	// However, once we stop pinging for too long, the connection dies
-	const shortTimeout = 10 * time.Millisecond
 	timer.Reset(shortTimeout)
 	time.Sleep(2 * shortTimeout) // Exceed the timeout.
 	err = st.Ping()

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -352,11 +352,7 @@ func (s *serverSuite) TestApiHandlerTeardownInitialEnviron(c *gc.C) {
 }
 
 func (s *serverSuite) TestApiHandlerTeardownOtherEnviron(c *gc.C) {
-	// ForEnviron doens't validate the UUID so there's no need to
-	// actually create another env for this test.
-	otherState, err := s.State.ForEnviron(names.NewEnvironTag("uuid"))
-	c.Assert(err, jc.ErrorIsNil)
-
+	otherState := s.Factory.MakeEnvironment(c, nil)
 	s.checkApiHandlerTeardown(c, s.State, otherState)
 }
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1524,7 +1524,7 @@ func openState(agentConfig agent.Config, dialOpts mongo.DialOpts) (_ *state.Stat
 	if !ok {
 		return nil, nil, fmt.Errorf("no state info available")
 	}
-	st, err := state.Open(info, dialOpts, environs.NewStatePolicy())
+	st, err := state.Open(agentConfig.Environment(), info, dialOpts, environs.NewStatePolicy())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -165,7 +165,7 @@ func (s *AgentSuite) AssertCanOpenState(c *gc.C, tag names.Tag, dataDir string) 
 	c.Assert(err, jc.ErrorIsNil)
 	info, ok := config.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(config.Environment(), info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 }

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -408,7 +408,7 @@ var openStateForUpgrade = func(
 	if !ok {
 		return nil, fmt.Errorf("no state info available")
 	}
-	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(agentConfig.Environment(), info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -107,7 +107,7 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 
 	var fakeOpenStateForUpgrade = func(upgradingMachineAgent, agent.Config) (*state.State, error) {
 		mongoInfo := s.State.MongoConnectionInfo()
-		st, err := state.Open(mongoInfo, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+		st, err := state.Open(s.State.EnvironTag(), mongoInfo, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 		c.Assert(err, jc.ErrorIsNil)
 		return st, nil
 	}

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -219,7 +219,7 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	c.Assert(s.fakeEnsureMongo.InitiateParams.User, gc.Equals, "")
 	c.Assert(s.fakeEnsureMongo.InitiateParams.Password, gc.Equals, "")
 
-	st, err := state.Open(&mongo.MongoInfo{
+	st, err := state.Open(testing.EnvironmentTag, &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -270,7 +270,7 @@ func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := state.Open(&mongo.MongoInfo{
+	st, err := state.Open(testing.EnvironmentTag, &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -306,7 +306,7 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := state.Open(&mongo.MongoInfo{
+	st, err := state.Open(testing.EnvironmentTag, &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -327,7 +327,7 @@ func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := state.Open(&mongo.MongoInfo{
+	st, err := state.Open(testing.EnvironmentTag, &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -342,7 +342,7 @@ func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 }
 
 func testOpenState(c *gc.C, info *mongo.MongoInfo, expectErrType error) {
-	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(testing.EnvironmentTag, info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	if st != nil {
 		st.Close()
 	}
@@ -370,7 +370,7 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 	// Check we can log in to mongo as admin.
 	// TODO(dfc) does passing nil for the admin user name make your skin crawl ? mine too.
 	info.Tag, info.Password = nil, testPasswordHash()
-	st, err := state.Open(info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(testing.EnvironmentTag, info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -397,7 +397,7 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 
 	stateinfo, ok := machineConf1.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st, err = state.Open(stateinfo, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err = state.Open(testing.EnvironmentTag, stateinfo, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -565,7 +565,7 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 	// The tools should have been added to tools storage, and
 	// exploded into each of the supported series of
 	// the same operating system if the tools were uploaded.
-	st, err := state.Open(&mongo.MongoInfo{
+	st, err := state.Open(testing.EnvironmentTag, &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
@@ -696,7 +696,7 @@ func (s *BootstrapSuite) TestDefaultStoragePools(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	st, err := state.Open(&mongo.MongoInfo{
+	st, err := state.Open(testing.EnvironmentTag, &mongo.MongoInfo{
 		Info: mongo.Info{
 			Addrs:  []string{gitjujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,

--- a/mongo/collections.go
+++ b/mongo/collections.go
@@ -8,8 +8,71 @@ import "gopkg.in/mgo.v2"
 // CollectionFromName returns a named collection on the specified database,
 // initialised with a new session. Also returned is a close function which
 // must be called when the collection is no longer required.
-func CollectionFromName(db *mgo.Database, coll string) (*mgo.Collection, func()) {
+func CollectionFromName(db *mgo.Database, coll string) (Collection, func()) {
 	session := db.Session.Copy()
 	newColl := db.C(coll).With(session)
-	return newColl, session.Close
+	return WrapCollection(newColl), session.Close
+}
+
+// Collection imperfectly insulates clients from the capacity to write to
+// MongoDB. Query results can still be used to write; and the Writeable
+// method exposes the underlying *mgo.Collection when absolutely required;
+// but the general expectation in juju is that writes will occur only via
+// mgo/txn, and any layer-skipping is done only in exceptional and well-
+// supported circumstances.
+type Collection interface {
+
+	// Name returns the name of the collection.
+	Name() string
+
+	// Count, Find, and FindId methods act as documented for *mgo.Collection.
+	Count() (int, error)
+	Find(query interface{}) *mgo.Query
+	FindId(id interface{}) *mgo.Query
+
+	// Writeable gives access to methods that enable direct DB access. It
+	// should be used with judicious care, and for only the best of reasons.
+	Writeable() WriteCollection
+}
+
+// WriteCollection allows read/write access to a MongoDB collection.
+type WriteCollection interface {
+	Collection
+
+	// Underlying returns the underlying *mgo.Collection.
+	Underlying() *mgo.Collection
+
+	// All other methods act as documented for *mgo.Collection.
+	Insert(docs ...interface{}) error
+	Update(selector interface{}, update interface{}) error
+	UpdateId(id interface{}, update interface{}) error
+	Remove(sel interface{}) error
+	RemoveId(id interface{}) error
+	RemoveAll(sel interface{}) (*mgo.ChangeInfo, error)
+}
+
+// WrapCollection returns a Collection that wraps the supplied *mgo.Collection.
+func WrapCollection(coll *mgo.Collection) Collection {
+	return collectionWrapper{coll}
+}
+
+// collectionWrapper wraps a *mgo.Collection and implements Collection and
+// WriteCollection.
+type collectionWrapper struct {
+	*mgo.Collection
+}
+
+// Name is part of the Collection interface.
+func (cw collectionWrapper) Name() string {
+	return cw.Collection.Name
+}
+
+// Writeable is part of the Collection interface.
+func (cw collectionWrapper) Writeable() WriteCollection {
+	return cw
+}
+
+// Underlying is part of the WriteCollection interface.
+func (cw collectionWrapper) Underlying() *mgo.Collection {
+	return cw.Collection
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -1,0 +1,358 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"gopkg.in/mgo.v2"
+)
+
+// The capped collection used for transaction logs defaults to 10MB.
+// It's tweaked in export_test.go to 1MB to avoid the overhead of
+// creating and deleting the large file repeatedly in tests.
+var (
+	txnLogSize      = 10000000
+	txnLogSizeTests = 1000000
+)
+
+// allCollections should be the single source of truth for information about
+// any collection we use. It's broken up into 4 main sections:
+//
+//  * infrastructure: we really don't have any business touching these once
+//    we've created them. They should have the rawAccess attribute set, so that
+//    multiEnvRunner will consider them forbidden.
+//
+//  * global: these hold information external to environments. They may include
+//    environment metadata, or references; but they're generally not relevant
+//    from the perspective of a given environment.
+//
+//  * local (in opposition to global; and for want of a better term): these
+//    hold information relevant *within* specific environments (machines,
+//    services, relations, settings, bookkeeping, etc) and should generally be
+//    read via an envStateCollection, and written via a multiEnvRunner. This is
+//    the most common form of collection, and the above access should usually
+//    be automatic via Database.Collection and Database.Runner.
+//
+//  * raw-access: there's certainly data that's a poor fit for mgo/txn. Most
+//    forms of logs, for example, will benefit both from the speedy insert and
+//    worry-free bulk deletion; so raw-access collections are fine. Just don't
+//    try to run transactions that reference them.
+//
+// Please do not use collections not referenced here; and when adding new
+// collections, please document them, and make an effort to put them in an
+// appropriate section.
+func allCollections() collectionSchema {
+	return collectionSchema{
+
+		// Infrastructure collections
+		// ==========================
+
+		txnsC: {
+			// This collection is used exclusively by mgo/txn to record transactions.
+			global:         true,
+			rawAccess:      true,
+			explicitCreate: &mgo.CollectionInfo{},
+		},
+		txnLogC: {
+			// This collection is used by mgo/txn to record the set of documents
+			// affected by each successful transaction; and by state/watcher to
+			// generate a stream of document-resolution events that are delivered
+			// to, and interpreted by, both state and state/multiwatcher.
+			global:    true,
+			rawAccess: true,
+			explicitCreate: &mgo.CollectionInfo{
+				Capped:   true,
+				MaxBytes: txnLogSize,
+			},
+		},
+
+		// ------------------
+
+		// Global collections
+		// ==================
+
+		// This collection holds the details of the state servers hosting, well,
+		// everything in state.
+		stateServersC: {global: true},
+
+		// This collection is used to track progress when restoring a
+		// state server from backup.
+		restoreInfoC: {global: true},
+
+		// This collection is used by the state servers to coordinate binary
+		// upgrades and schema migrations.
+		upgradeInfoC: {global: true},
+
+		// This collection holds a convenient representation of the content of
+		// the simplestreams data source pointing to binaries required by juju.
+		toolsmetadataC: {global: true},
+
+		// This collection holds environment information; in particular its
+		// Life and its UUID.
+		environmentsC: {global: true},
+
+		// This collection holds user information that's not specific to any
+		// one environment.
+		usersC: {
+			global: true,
+			indexes: []mgo.Index{{
+				// TODO(thumper): schema change to remove this index.
+				Key: []string{"name"},
+			}},
+		},
+
+		// This collection is used as a unique key restraint. The _id field is
+		// a concatenation of multiple fields that form a compound index,
+		// allowing us to ensure users cannot have the same name for two
+		// different environments at a time.
+		userenvnameC: {global: true},
+
+		// This collection holds workload metrics reported by certain charms
+		// for passing onward to other tools.
+		metricsC: {global: true},
+
+		// This collection holds persistent state for the metrics manager.
+		metricsManagerC: {global: true},
+
+		// This collection holds lease data, which is per-environment, but is
+		// not itself multi-environment-aware; happily it will imminently be
+		// deprecated in favour of the non-global leasesC below.
+		// TODO(fwereade): drop leaseC entirely so can't use wrong const.
+		leaseC: {global: true},
+
+		// This collection was deprecated before multi-environment support
+		// was implemented.
+		actionresultsC: {global: true},
+
+		// -----------------
+
+		// Local collections
+		// =================
+
+		// This collection is basically a standard SQL intersection table; it
+		// references the global records of the users allowed access to a
+		// given collection.
+		envUsersC: {},
+
+		// This collection contains governors that prevent certain kinds of
+		// changes from being accepted.
+		blocksC: {},
+
+		// This collection is used for internal bookkeeping; certain complex
+		// or tedious state changes are deferred by recording a cleanup doc
+		// for later handling.
+		cleanupsC: {},
+
+		// This collection contains incrementing integers, subdivided by name,
+		// to ensure various IDs aren't reused.
+		sequenceC: {},
+
+		// -----
+
+		// These collections hold information associated with services.
+		charmsC:   {},
+		servicesC: {},
+		unitsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "service"},
+			}, {
+				Key: []string{"env-uuid", "principal"},
+			}, {
+				Key: []string{"env-uuid", "machineid"},
+			}},
+		},
+		minUnitsC: {},
+
+		// meterStatusC is the collection used to store meter status information.
+		meterStatusC:  {},
+		settingsrefsC: {},
+		relationsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "endpoints.relationname"},
+			}, {
+				Key: []string{"env-uuid", "endpoints.servicename"},
+			}},
+		},
+		relationScopesC: {},
+
+		// -----
+
+		// These collections hold information associated with machines.
+		containerRefsC: {},
+		instanceDataC:  {},
+		machinesC:      {},
+		rebootC:        {},
+
+		// -----
+
+		// These collections hold information associated with storage.
+		blockDevicesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "machineid"},
+			}},
+		},
+		filesystemsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "storageid"},
+			}},
+		},
+		filesystemAttachmentsC: {},
+		storageInstancesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "owner"},
+			}},
+		},
+		storageAttachmentsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "storageid"},
+			}, {
+				Key: []string{"env-uuid", "unitid"},
+			}},
+		},
+		volumesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "storageid"},
+			}},
+		},
+		volumeAttachmentsC: {},
+
+		// -----
+
+		// These collections hold information associated with networking.
+		ipaddressesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "state"},
+			}, {
+				Key: []string{"env-uuid", "subnetid"},
+			}},
+		},
+		networkInterfacesC: {
+			indexes: []mgo.Index{{
+				Key:    []string{"env-uuid", "interfacename", "machineid"},
+				Unique: true,
+			}, {
+				Key:    []string{"env-uuid", "macaddress", "networkname"},
+				Unique: true,
+			}, {
+				Key: []string{"env-uuid", "machineid"},
+			}, {
+				Key: []string{"env-uuid", "networkname"},
+			}},
+		},
+		networksC: {
+			indexes: []mgo.Index{{
+				Key:    []string{"env-uuid", "providerid"},
+				Unique: true,
+			}},
+		},
+		openedPortsC:       {},
+		requestedNetworksC: {},
+		subnetsC: {
+			indexes: []mgo.Index{{
+				// TODO(dimitern): make unique per-environment, not globally.
+				Key: []string{"providerid"},
+				// Not always present; but, if present, must be unique; hence
+				// both unique and sparse.
+				Unique: true,
+				Sparse: true,
+			}},
+		},
+
+		// -----
+
+		// These collections hold information associated with actions.
+		actionsC:             {},
+		actionNotificationsC: {},
+
+		// -----
+
+		// The remaining non-global collections share the property of being
+		// relevant to multiple other kinds of entities, and are thus generally
+		// indexed by globalKey(). This is unhelpfully named in this context --
+		// it's meant to imply "global within an environment", because it was
+		// named before multi-env support.
+
+		// This collection holds user annotations for various entities. They
+		// shouldn't be written or interpreted by juju.
+		annotationsC: {},
+
+		// This collection in particular holds an astounding number of
+		// different sorts of data: service config settings by charm version,
+		// unit relation settings, environment config, etc etc etc.
+		settingsC: {},
+
+		constraintsC:        {},
+		storageConstraintsC: {},
+		statusesC:           {},
+		statusesHistoryC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "entityid"},
+			}},
+		},
+
+		// ----------------------
+
+		// Raw-access collections
+		// ======================
+
+		// metrics; status-history; logs; ..?
+	}
+}
+
+// These constants are used to avoid sprinkling the package with any more
+// magic strings. If a collection deserves documentation, please document
+// it in allCollections, above; and please keep this list sorted for easy
+// inspection.
+const (
+	actionNotificationsC   = "actionnotifications"
+	actionresultsC         = "actionresults"
+	actionsC               = "actions"
+	annotationsC           = "annotations"
+	blockDevicesC          = "blockdevices"
+	blocksC                = "blocks"
+	charmsC                = "charms"
+	cleanupsC              = "cleanups"
+	constraintsC           = "constraints"
+	containerRefsC         = "containerRefs"
+	envUsersC              = "envusers"
+	environmentsC          = "environments"
+	filesystemAttachmentsC = "filesystemAttachments"
+	filesystemsC           = "filesystems"
+	instanceDataC          = "instanceData"
+	ipaddressesC           = "ipaddresses"
+	leaseC                 = "lease"
+	machinesC              = "machines"
+	meterStatusC           = "meterStatus"
+	metricsC               = "metrics"
+	metricsManagerC        = "metricsmanager"
+	minUnitsC              = "minunits"
+	networkInterfacesC     = "networkinterfaces"
+	networksC              = "networks"
+	openedPortsC           = "openedPorts"
+	presenceC              = "presence"
+	rebootC                = "reboot"
+	relationScopesC        = "relationscopes"
+	relationsC             = "relations"
+	requestedNetworksC     = "requestednetworks"
+	restoreInfoC           = "restoreInfo"
+	sequenceC              = "sequence"
+	servicesC              = "services"
+	settingsC              = "settings"
+	settingsrefsC          = "settingsrefs"
+	stateServersC          = "stateServers"
+	statusesC              = "statuses"
+	statusesHistoryC       = "statuseshistory"
+	storageAttachmentsC    = "storageattachments"
+	storageConstraintsC    = "storageconstraints"
+	storageInstancesC      = "storageinstances"
+	subnetsC               = "subnets"
+	toolsmetadataC         = "toolsmetadata"
+	txnLogC                = "txns.log"
+	txnsC                  = "txns"
+	unitsC                 = "units"
+	upgradeInfoC           = "upgradeInfo"
+	userenvnameC           = "userenvname"
+	usersC                 = "users"
+	volumeAttachmentsC     = "volumeattachments"
+	volumesC               = "volumes"
+)

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -147,6 +147,17 @@ func allCollections() collectionSchema {
 		// to ensure various IDs aren't reused.
 		sequenceC: {},
 
+		// This collection holds lease data. It's currently only used to
+		// implement service leadership, but is namespaced and available
+		// for use by other clients in future.
+		leasesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"env-uuid", "type"},
+			}, {
+				Key: []string{"env-uuid", "namespace"},
+			}},
+		},
+
 		// -----
 
 		// These collections hold information associated with services.
@@ -321,6 +332,7 @@ const (
 	instanceDataC          = "instanceData"
 	ipaddressesC           = "ipaddresses"
 	leaseC                 = "lease"
+	leasesC                = "leases"
 	machinesC              = "machines"
 	meterStatusC           = "meterStatus"
 	metricsC               = "metrics"
@@ -329,7 +341,6 @@ const (
 	networkInterfacesC     = "networkinterfaces"
 	networksC              = "networks"
 	openedPortsC           = "openedPorts"
-	presenceC              = "presence"
 	rebootC                = "reboot"
 	relationScopesC        = "relationscopes"
 	relationsC             = "relations"

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -28,8 +28,6 @@ type AssignSuite struct {
 }
 
 var _ = gc.Suite(&AssignSuite{})
-var _ = gc.Suite(&assignCleanSuite{ConnSuite{}, state.AssignCleanEmpty, nil})
-var _ = gc.Suite(&assignCleanSuite{ConnSuite{}, state.AssignClean, nil})
 
 func (s *AssignSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
@@ -687,6 +685,9 @@ type assignCleanSuite struct {
 	policy    state.AssignmentPolicy
 	wordpress *state.Service
 }
+
+var _ = gc.Suite(&assignCleanSuite{ConnSuite{}, state.AssignCleanEmpty, nil})
+var _ = gc.Suite(&assignCleanSuite{ConnSuite{}, state.AssignClean, nil})
 
 func (s *assignCleanSuite) SetUpTest(c *gc.C) {
 	c.Logf("assignment policy for this test: %q", s.policy)

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -108,7 +108,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) error {
 		return errors.Errorf("cannot retrieve info to connect to mongo")
 	}
 
-	st, err := newStateConnection(mgoInfo)
+	st, err := newStateConnection(agentConfig.Environment(), mgoInfo)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -119,7 +119,7 @@ var mongoDefaultDialOpts = mongo.DefaultDialOpts
 var environsNewStatePolicy = environs.NewStatePolicy
 
 // newStateConnection tries to connect to the newly restored state server.
-func newStateConnection(info *mongo.MongoInfo) (*state.State, error) {
+func newStateConnection(environTag names.EnvironTag, info *mongo.MongoInfo) (*state.State, error) {
 	// We need to retry here to allow mongo to come up on the restored state server.
 	// The connection might succeed due to the mongo dial retries but there may still
 	// be a problem issuing database commands.
@@ -133,7 +133,7 @@ func newStateConnection(info *mongo.MongoInfo) (*state.State, error) {
 	)
 	attempt := utils.AttemptStrategy{Delay: newStateConnDelay, Min: newStateConnMinAttempts}
 	for a := attempt.Start(); a.Next(); {
-		st, err = state.Open(info, mongoDefaultDialOpts(), environsNewStatePolicy())
+		st, err = state.Open(environTag, info, mongoDefaultDialOpts(), environsNewStatePolicy())
 		if err == nil {
 			return st, nil
 		}

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -255,7 +255,7 @@ func (r *RestoreSuite) TestNewConnection(c *gc.C) {
 
 	r.PatchValue(&mongoDefaultDialOpts, statetesting.NewDialOpts)
 	r.PatchValue(&environsNewStatePolicy, func() state.Policy { return nil })
-	st, err = newStateConnection(statetesting.NewMongoInfo())
+	st, err = newStateConnection(st.EnvironTag(), statetesting.NewMongoInfo())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st.Close(), jc.ErrorIsNil)
 }

--- a/state/charm.go
+++ b/state/charm.go
@@ -5,30 +5,185 @@ package state
 
 import (
 	"net/url"
+	"regexp"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v5"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo"
 )
 
 // charmDoc represents the internal state of a charm in MongoDB.
 type charmDoc struct {
 	DocID   string     `bson:"_id"`
-	URL     *charm.URL `bson:"url"`
+	URL     *charm.URL `bson:"url"` // DANGEROUS see below
 	EnvUUID string     `bson:"env-uuid"`
-	Meta    *charm.Meta
-	Config  *charm.Config
-	Actions *charm.Actions
-	Metrics *charm.Metrics
+
+	// TODO(fwereade) 2015-06-18 lp:1467964
+	// DANGEROUS: our schema can change any time the charm package changes,
+	// and we have no automated way to detect when that happens. We *must*
+	// not depend upon serializations we cannot control from inside this
+	// package. What's in a *charm.Meta? What will be tomorrow? What logic
+	// will we be writing on the assumption that all stored Metas have set
+	// some field? What fields might lose precision when they go into the
+	// database?
+	Meta    *charm.Meta    `bson:"meta"`
+	Config  *charm.Config  `bson:"config"`
+	Actions *charm.Actions `bson:"actions"`
+	Metrics *charm.Metrics `bson:"metrics"`
 
 	// DEPRECATED: BundleURL is deprecated, and exists here
 	// only for migration purposes. We should remove this
 	// when migrations are no longer necessary.
 	BundleURL *url.URL `bson:"bundleurl,omitempty"`
 
-	BundleSha256  string
-	StoragePath   string
-	PendingUpload bool
-	Placeholder   bool
+	BundleSha256  string `bson:"bundlesha256"`
+	StoragePath   string `bson:"storagepath"`
+	PendingUpload bool   `bson:"pendingupload"`
+	Placeholder   bool   `bson:"placeholder"`
+}
+
+// insertCharmOps returns the txn operations necessary to insert the supplied
+// charm data.
+func insertCharmOps(
+	st *State, ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string,
+) ([]txn.Op, error) {
+	return insertAnyCharmOps(&charmDoc{
+		DocID:        curl.String(),
+		URL:          curl,
+		EnvUUID:      st.EnvironTag().Id(),
+		Meta:         ch.Meta(),
+		Config:       safeConfig(ch),
+		Metrics:      ch.Metrics(),
+		Actions:      ch.Actions(),
+		BundleSha256: bundleSha256,
+		StoragePath:  storagePath,
+	})
+}
+
+// insertPlaceholderCharmOps returns the txn operations necessary to insert a
+// charm document referencing a store charm that is not yet directly accessible
+// within the environment.
+func insertPlaceholderCharmOps(st *State, curl *charm.URL) ([]txn.Op, error) {
+	return insertAnyCharmOps(&charmDoc{
+		DocID:       curl.String(),
+		URL:         curl,
+		EnvUUID:     st.EnvironTag().Id(),
+		Placeholder: true,
+	})
+}
+
+// insertPendingCharmOps returns the txn operations necessary to insert a charm
+// document referencing a charm that has yet to be uploaded to the environment.
+func insertPendingCharmOps(st *State, curl *charm.URL) ([]txn.Op, error) {
+	return insertAnyCharmOps(&charmDoc{
+		DocID:         curl.String(),
+		URL:           curl,
+		EnvUUID:       st.EnvironTag().Id(),
+		PendingUpload: true,
+	})
+}
+
+// insertAnyCharmOps returns the txn operations necessary to insert the supplied
+// charm document.
+func insertAnyCharmOps(cdoc *charmDoc) ([]txn.Op, error) {
+	return []txn.Op{{
+		C:      charmsC,
+		Id:     cdoc.DocID,
+		Assert: txn.DocMissing,
+		Insert: cdoc,
+	}}, nil
+}
+
+// updateCharmOps returns the txn operations necessary to update the charm
+// document with the supplied data, so long as the supplied assert still holds
+// true.
+func updateCharmOps(
+	st *State, ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string, assert bson.D,
+) ([]txn.Op, error) {
+
+	updateFields := bson.D{{"$set", bson.D{
+		{"meta", ch.Meta()},
+		{"config", safeConfig(ch)},
+		{"actions", ch.Actions()},
+		{"metrics", ch.Metrics()},
+		{"storagepath", storagePath},
+		{"bundlesha256", bundleSha256},
+		{"pendingupload", false},
+		{"placeholder", false},
+	}}}
+	return []txn.Op{{
+		C:      charmsC,
+		Id:     curl.String(),
+		Assert: assert,
+		Update: updateFields,
+	}}, nil
+}
+
+// convertPlaceholderCharmOps returns the txn operations necessary to convert
+// the charm with the supplied docId from a placeholder to one marked for
+// pending upload.
+func convertPlaceholderCharmOps(docID string) ([]txn.Op, error) {
+	return []txn.Op{{
+		C:  charmsC,
+		Id: docID,
+		Assert: bson.D{
+			{"bundlesha256", ""},
+			{"pendingupload", false},
+			{"placeholder", true},
+		},
+		Update: bson.D{{"$set", bson.D{
+			{"pendingupload", true},
+			{"placeholder", false},
+		}}},
+	}}, nil
+
+}
+
+// deleteOldPlaceholderCharmsOps returns the txn ops required to delete all placeholder charm
+// records older than the specified charm URL.
+func deleteOldPlaceholderCharmsOps(st *State, charms mongo.Collection, curl *charm.URL) ([]txn.Op, error) {
+	// Get a regex with the charm URL and no revision.
+	noRevURL := curl.WithRevision(-1)
+	curlRegex := "^" + regexp.QuoteMeta(st.docID(noRevURL.String()))
+
+	var docs []charmDoc
+	query := bson.D{{"_id", bson.D{{"$regex", curlRegex}}}, {"placeholder", true}}
+	err := charms.Find(query).Select(bson.D{{"_id", 1}, {"url", 1}}).All(&docs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var ops []txn.Op
+	for _, doc := range docs {
+		if doc.URL.Revision >= curl.Revision {
+			continue
+		}
+		ops = append(ops, txn.Op{
+			C:      charmsC,
+			Id:     doc.DocID,
+			Assert: stillPlaceholder,
+			Remove: true,
+		})
+	}
+	return ops, nil
+}
+
+// safeConfig is a travesty which attempts to work around our continued failure
+// to properly insulate our database from code changes; it escapes mongo-
+// significant characters in config options. See lp:1467964.
+func safeConfig(ch charm.Charm) *charm.Config {
+	// Make sure we escape any "$" and "." in config option names
+	// first. See http://pad.lv/1308146.
+	cfg := ch.Config()
+	escapedConfig := charm.NewConfig()
+	for optionName, option := range cfg.Options {
+		escapedName := escapeReplacer.Replace(optionName)
+		escapedConfig.Options[escapedName] = option
+	}
+	return escapedConfig
 }
 
 // Charm represents the state of a charm in the environment.

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -111,16 +111,18 @@ func (st *State) Cleanup() error {
 }
 
 func (st *State) cleanupRelationSettings(prefix string) error {
+	settings, closer := st.getCollection(settingsC)
+	defer closer()
 	// Documents marked for cleanup are not otherwise referenced in the
 	// system, and will not be under watch, and are therefore safe to
 	// delete directly.
-	settings, closer := st.getCollection(settingsC)
-	defer closer()
+	settingsW := settings.Writeable()
+
 	sel := bson.D{{"_id", bson.D{{"$regex", "^" + st.docID(prefix)}}}}
-	if count, err := settings.Find(sel).Count(); err != nil {
+	if count, err := settingsW.Find(sel).Count(); err != nil {
 		return fmt.Errorf("cannot detect cleanup targets: %v", err)
 	} else if count != 0 {
-		if _, err := settings.RemoveAll(sel); err != nil {
+		if _, err := settingsW.RemoveAll(sel); err != nil {
 			return fmt.Errorf("cannot remove documents marked for cleanup: %v", err)
 		}
 	}

--- a/state/collection.go
+++ b/state/collection.go
@@ -6,7 +6,6 @@ package state
 import (
 	"strings"
 
-	"github.com/juju/utils/set"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
@@ -21,8 +20,7 @@ import (
 // returned collection will automatically perform environment
 // filtering where possible. See envStateCollection below.
 func (st *State) getCollection(name string) (mongo.Collection, func()) {
-	collection, closer := mongo.CollectionFromName(st.db, name)
-	return newStateCollection(collection, st.EnvironUUID()), closer
+	return st.database.GetCollection(name)
 }
 
 // getRawCollection returns the named mgo Collection. As no automatic
@@ -30,98 +28,26 @@ func (st *State) getCollection(name string) (mongo.Collection, func()) {
 // should be rarely used. getCollection() should be used in almost all
 // cases.
 func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
-	collection, closer := mongo.CollectionFromName(st.db, name)
+	collection, closer := st.database.GetCollection(name)
 	return collection.Writeable().Underlying(), closer
 }
 
-// getCollectionFromDB returns the specified collection from the given
-// database.
-//
-// An environment UUID must be provided so that environment filtering
-// can be automatically applied if the collection stores data for
-// multiple environments.
-func getCollectionFromDB(db *mgo.Database, name, envUUID string) mongo.Collection {
-	collection := mongo.WrapCollection(db.C(name))
-	return newStateCollection(collection, envUUID)
-}
-
-// This is all collections that contain data for multiple
-// environments. Automatic environment filtering will be applied to
-// these collections.
-var multiEnvCollections = set.NewStrings(
-	actionNotificationsC,
-	actionsC,
-	annotationsC,
-	blockDevicesC,
-	blocksC,
-	charmsC,
-	cleanupsC,
-	constraintsC,
-	containerRefsC,
-	envUsersC,
-	filesystemsC,
-	filesystemAttachmentsC,
-	instanceDataC,
-	ipaddressesC,
-	machinesC,
-	meterStatusC,
-	minUnitsC,
-	networkInterfacesC,
-	networksC,
-	openedPortsC,
-	rebootC,
-	relationScopesC,
-	relationsC,
-	requestedNetworksC,
-	sequenceC,
-	servicesC,
-	settingsC,
-	settingsrefsC,
-	statusesC,
-	statusesHistoryC,
-	storageAttachmentsC,
-	storageConstraintsC,
-	storageInstancesC,
-	subnetsC,
-	unitsC,
-	volumesC,
-	volumeAttachmentsC,
-)
-
-func newStateCollection(collection mongo.Collection, envUUID string) mongo.Collection {
-	if multiEnvCollections.Contains(collection.Name()) {
-		return &envStateCollection{
-			WriteCollection: collection.Writeable(),
-			envUUID:         envUUID,
-		}
-	}
-	return collection
-}
-
 // envStateCollection wraps a mongo.Collection, preserving the
-// mongo.Collection interface and its Writeable behaviour.. It will
+// mongo.Collection interface and its Writeable behaviour. It will
 // automatically modify query selectors so that so that the query only
 // interacts with data for a single environment (where possible).
+//
 // In particular, Inserts are not trapped at all. Be careful.
 type envStateCollection struct {
 	mongo.WriteCollection
 	envUUID string
 }
 
-// Name returns the MongoDB collection name.
-func (c *envStateCollection) Name() string {
-	return c.WriteCollection.Name()
-}
-
 // Writeable is part of the Collection interface.
 func (c *envStateCollection) Writeable() mongo.WriteCollection {
+	// Note that we can't delegate this to the embedded WriteCollection:
+	// that would return a writeable collection without any env-handling.
 	return c
-}
-
-// Underlying returns the mgo Collection that the
-// envStateCollection is ultimately wrapping.
-func (c *envStateCollection) Underlying() *mgo.Collection {
-	return c.WriteCollection.Underlying()
 }
 
 // Count returns the number of documents in the collection that belong
@@ -151,7 +77,7 @@ func (c *envStateCollection) Find(query interface{}) *mgo.Query {
 // query will be handled as per Find().
 func (c *envStateCollection) FindId(id interface{}) *mgo.Query {
 	if sid, ok := id.(string); ok {
-		return c.WriteCollection.FindId(addEnvUUID(c.envUUID, sid))
+		return c.WriteCollection.FindId(ensureEnvUUID(c.envUUID, sid))
 	}
 	return c.Find(bson.D{{"_id", id}})
 }
@@ -178,7 +104,7 @@ func (c *envStateCollection) Update(query interface{}, update interface{}) error
 // prefix isn't there already.
 func (c *envStateCollection) UpdateId(id interface{}, update interface{}) error {
 	if sid, ok := id.(string); ok {
-		return c.WriteCollection.UpdateId(addEnvUUID(c.envUUID, sid), update)
+		return c.WriteCollection.UpdateId(ensureEnvUUID(c.envUUID, sid), update)
 	}
 	return c.WriteCollection.UpdateId(bson.D{{"_id", id}}, update)
 }
@@ -194,7 +120,7 @@ func (c *envStateCollection) Remove(query interface{}) error {
 // query will be handled as per Find().
 func (c *envStateCollection) RemoveId(id interface{}) error {
 	if sid, ok := id.(string); ok {
-		return c.WriteCollection.RemoveId(addEnvUUID(c.envUUID, sid))
+		return c.WriteCollection.RemoveId(ensureEnvUUID(c.envUUID, sid))
 	}
 	return c.Remove(bson.D{{"_id", id}})
 }
@@ -213,7 +139,7 @@ func (c *envStateCollection) mungeQuery(inq interface{}) bson.D {
 			switch elem.Name {
 			case "_id":
 				if id, ok := elem.Value.(string); ok {
-					elem.Value = addEnvUUID(c.envUUID, id)
+					elem.Value = ensureEnvUUID(c.envUUID, id)
 				}
 			case "env-uuid":
 				panic("env-uuid is added automatically and should not be provided")
@@ -229,7 +155,7 @@ func (c *envStateCollection) mungeQuery(inq interface{}) bson.D {
 	return outq
 }
 
-func addEnvUUID(envUUID, id string) string {
+func ensureEnvUUID(envUUID, id string) string {
 	prefix := envUUID + ":"
 	if strings.HasPrefix(id, prefix) {
 		return id

--- a/state/collections.go
+++ b/state/collections.go
@@ -20,9 +20,9 @@ import (
 // If the collection stores documents for multiple environments, the
 // returned collection will automatically perform environment
 // filtering where possible. See envStateCollection below.
-func (st *State) getCollection(name string) (stateCollection, func()) {
-	coll, closer := mongo.CollectionFromName(st.db, name)
-	return newStateCollection(coll, st.EnvironUUID()), closer
+func (st *State) getCollection(name string) (mongo.Collection, func()) {
+	collection, closer := mongo.CollectionFromName(st.db, name)
+	return newStateCollection(collection, st.EnvironUUID()), closer
 }
 
 // getRawCollection returns the named mgo Collection. As no automatic
@@ -30,7 +30,8 @@ func (st *State) getCollection(name string) (stateCollection, func()) {
 // should be rarely used. getCollection() should be used in almost all
 // cases.
 func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
-	return mongo.CollectionFromName(st.db, name)
+	collection, closer := mongo.CollectionFromName(st.db, name)
+	return collection.Writeable().Underlying(), closer
 }
 
 // getCollectionFromDB returns the specified collection from the given
@@ -39,22 +40,9 @@ func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
 // An environment UUID must be provided so that environment filtering
 // can be automatically applied if the collection stores data for
 // multiple environments.
-func getCollectionFromDB(db *mgo.Database, name, envUUID string) stateCollection {
-	return newStateCollection(db.C(name), envUUID)
-}
-
-type stateCollection interface {
-	Name() string
-	Underlying() *mgo.Collection
-	Count() (int, error)
-	Find(query interface{}) *mgo.Query
-	FindId(id interface{}) *mgo.Query
-	Insert(docs ...interface{}) error
-	Update(selector interface{}, update interface{}) error
-	UpdateId(id interface{}, update interface{}) error
-	Remove(sel interface{}) error
-	RemoveId(id interface{}) error
-	RemoveAll(sel interface{}) (*mgo.ChangeInfo, error)
+func getCollectionFromDB(db *mgo.Database, name, envUUID string) mongo.Collection {
+	collection := mongo.WrapCollection(db.C(name))
+	return newStateCollection(collection, envUUID)
 }
 
 // This is all collections that contain data for multiple
@@ -100,57 +88,46 @@ var multiEnvCollections = set.NewStrings(
 	volumeAttachmentsC,
 )
 
-func newStateCollection(coll *mgo.Collection, envUUID string) stateCollection {
-	if multiEnvCollections.Contains(coll.Name) {
+func newStateCollection(collection mongo.Collection, envUUID string) mongo.Collection {
+	if multiEnvCollections.Contains(collection.Name()) {
 		return &envStateCollection{
-			Collection: coll,
-			envUUID:    envUUID,
+			WriteCollection: collection.Writeable(),
+			envUUID:         envUUID,
 		}
 	}
-	return &genericStateCollection{Collection: coll}
+	return collection
 }
 
-// genericStateCollection wraps a mgo Collection. It acts as a
-// pass-through which implements the stateCollection interface.
-type genericStateCollection struct {
-	*mgo.Collection
-}
-
-// Name returns the MongoDB collection name.
-func (c *genericStateCollection) Name() string {
-	return c.Collection.Name
-}
-
-// Underlying returns the mgo Collection that the
-// genericStateCollection is wrapping.
-func (c *genericStateCollection) Underlying() *mgo.Collection {
-	return c.Collection
-}
-
-// envStateCollection wraps a mgo Collection, implementing the
-// stateCollection interface. It will automatically modify query
-// selectors so that so that the query only interacts with data for a
-// single environment (where possible).
+// envStateCollection wraps a mongo.Collection, preserving the
+// mongo.Collection interface and its Writeable behaviour.. It will
+// automatically modify query selectors so that so that the query only
+// interacts with data for a single environment (where possible).
+// In particular, Inserts are not trapped at all. Be careful.
 type envStateCollection struct {
-	*mgo.Collection
+	mongo.WriteCollection
 	envUUID string
 }
 
 // Name returns the MongoDB collection name.
 func (c *envStateCollection) Name() string {
-	return c.Collection.Name
+	return c.WriteCollection.Name()
+}
+
+// Writeable is part of the Collection interface.
+func (c *envStateCollection) Writeable() mongo.WriteCollection {
+	return c
 }
 
 // Underlying returns the mgo Collection that the
-// envStateCollection is wrapping.
+// envStateCollection is ultimately wrapping.
 func (c *envStateCollection) Underlying() *mgo.Collection {
-	return c.Collection
+	return c.WriteCollection.Underlying()
 }
 
 // Count returns the number of documents in the collection that belong
 // to the environment that the envStateCollection is filtering on.
 func (c *envStateCollection) Count() (int, error) {
-	return c.Collection.Find(bson.D{{"env-uuid", c.envUUID}}).Count()
+	return c.WriteCollection.Find(bson.D{{"env-uuid", c.envUUID}}).Count()
 }
 
 // Find performs a query on the collection. The query must be given as
@@ -166,7 +143,7 @@ func (c *envStateCollection) Count() (int, error) {
 // these cases it is up to the caller to add environment UUID
 // prefixes when necessary.
 func (c *envStateCollection) Find(query interface{}) *mgo.Query {
-	return c.Collection.Find(c.mungeQuery(query))
+	return c.WriteCollection.Find(c.mungeQuery(query))
 }
 
 // FindId looks up a single document by _id. If the id is a string the
@@ -174,7 +151,7 @@ func (c *envStateCollection) Find(query interface{}) *mgo.Query {
 // query will be handled as per Find().
 func (c *envStateCollection) FindId(id interface{}) *mgo.Query {
 	if sid, ok := id.(string); ok {
-		return c.Collection.FindId(addEnvUUID(c.envUUID, sid))
+		return c.WriteCollection.FindId(addEnvUUID(c.envUUID, sid))
 	}
 	return c.Find(bson.D{{"_id", id}})
 }
@@ -192,7 +169,7 @@ func (c *envStateCollection) FindId(id interface{}) *mgo.Query {
 // these cases it is up to the caller to add environment UUID
 // prefixes when necessary.
 func (c *envStateCollection) Update(query interface{}, update interface{}) error {
-	return c.Collection.Update(c.mungeQuery(query), update)
+	return c.WriteCollection.Update(c.mungeQuery(query), update)
 }
 
 // UpdateId finds a single document by _id and modifies it according to the
@@ -201,15 +178,15 @@ func (c *envStateCollection) Update(query interface{}, update interface{}) error
 // prefix isn't there already.
 func (c *envStateCollection) UpdateId(id interface{}, update interface{}) error {
 	if sid, ok := id.(string); ok {
-		return c.Collection.UpdateId(addEnvUUID(c.envUUID, sid), update)
+		return c.WriteCollection.UpdateId(addEnvUUID(c.envUUID, sid), update)
 	}
-	return c.Collection.UpdateId(bson.D{{"_id", id}}, update)
+	return c.WriteCollection.UpdateId(bson.D{{"_id", id}}, update)
 }
 
 // Remove deletes a single document using the query provided. The
 // query will be handled as per Find().
 func (c *envStateCollection) Remove(query interface{}) error {
-	return c.Collection.Remove(c.mungeQuery(query))
+	return c.WriteCollection.Remove(c.mungeQuery(query))
 }
 
 // RemoveId deletes a single document by id. If the id is a string the
@@ -217,7 +194,7 @@ func (c *envStateCollection) Remove(query interface{}) error {
 // query will be handled as per Find().
 func (c *envStateCollection) RemoveId(id interface{}) error {
 	if sid, ok := id.(string); ok {
-		return c.Collection.RemoveId(addEnvUUID(c.envUUID, sid))
+		return c.WriteCollection.RemoveId(addEnvUUID(c.envUUID, sid))
 	}
 	return c.Remove(bson.D{{"_id", id}})
 }
@@ -225,7 +202,7 @@ func (c *envStateCollection) RemoveId(id interface{}) error {
 // RemoveAll deletes all docuemnts that match a query. The query will
 // be handled as per Find().
 func (c *envStateCollection) RemoveAll(query interface{}) (*mgo.ChangeInfo, error) {
-	return c.Collection.RemoveAll(c.mungeQuery(query))
+	return c.WriteCollection.RemoveAll(c.mungeQuery(query))
 }
 
 func (c *envStateCollection) mungeQuery(inq interface{}) bson.D {

--- a/state/collections_test.go
+++ b/state/collections_test.go
@@ -270,10 +270,10 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Find panics if query type is unsupported",
 			test: func() (int, error) {
-				machines0.Find(bson.M{"foo": "bar"})
+				machines0.Find(map[string]string{"foo": "bar"})
 				return 0, nil
 			},
-			expectedPanic: "query must either be bson.D or nil",
+			expectedPanic: "query must be bson.D, bson.M, or nil",
 		},
 		{
 			label: "FindId adds env UUID prefix",
@@ -424,10 +424,10 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll panics if query type is unsupported",
 			test: func() (int, error) {
-				machines0.Writeable().RemoveAll(bson.M{"foo": "bar"})
+				machines0.Writeable().RemoveAll(map[string]string{"foo": "bar"})
 				return 0, nil
 			},
-			expectedPanic: "query must either be bson.D or nil",
+			expectedPanic: "query must be bson.D, bson.M, or nil",
 		},
 		{
 			label: "Update",

--- a/state/collections_test.go
+++ b/state/collections_test.go
@@ -37,7 +37,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 	s.factory.MakeUser(c, &factory.UserParams{Name: "foo", DisplayName: "Ms Foo"})
 	s.factory.MakeUser(c, &factory.UserParams{Name: "bar"})
 
-	collSnapshot := newCollectionSnapshot(c, coll.Underlying())
+	collSnapshot := newCollectionSnapshot(c, coll.Writeable().Underlying())
 
 	for i, t := range []collectionsTestCase{
 		{
@@ -71,7 +71,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "Insert",
 			test: func() (int, error) {
-				err := coll.Insert(bson.D{{"_id", "more"}})
+				err := coll.Writeable().Insert(bson.D{{"_id", "more"}})
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},
@@ -80,7 +80,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "RemoveId",
 			test: func() (int, error) {
-				err := coll.RemoveId("bar")
+				err := coll.Writeable().RemoveId("bar")
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},
@@ -89,7 +89,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "Remove",
 			test: func() (int, error) {
-				err := coll.Remove(bson.D{{"displayname", "Ms Foo"}})
+				err := coll.Writeable().Remove(bson.D{{"displayname", "Ms Foo"}})
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},
@@ -98,7 +98,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll",
 			test: func() (int, error) {
-				_, err := coll.RemoveAll(bson.D{{"createdby", s.Owner.Name()}})
+				_, err := coll.Writeable().RemoveAll(bson.D{{"createdby", s.Owner.Name()}})
 				c.Assert(err, jc.ErrorIsNil)
 				return coll.Count()
 			},
@@ -107,7 +107,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "Update",
 			test: func() (int, error) {
-				err := coll.Update(bson.D{{"_id", "bar"}},
+				err := coll.Writeable().Update(bson.D{{"_id", "bar"}},
 					bson.D{{"$set", bson.D{{"displayname", "Updated Bar"}}}})
 				c.Assert(err, jc.ErrorIsNil)
 
@@ -118,7 +118,7 @@ func (s *CollectionsSuite) TestGenericStateCollection(c *gc.C) {
 		{
 			label: "UpdateId",
 			test: func() (int, error) {
-				err := coll.UpdateId("bar",
+				err := coll.Writeable().UpdateId("bar",
 					bson.D{{"$set", bson.D{{"displayname", "Updated Bar"}}}})
 				c.Assert(err, jc.ErrorIsNil)
 
@@ -192,8 +192,8 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 	networkInterfaces, closer := state.GetCollection(s.State, state.NetworkInterfacesC)
 	defer closer()
 
-	machinesSnapshot := newCollectionSnapshot(c, machines0.Underlying())
-	networkInterfacesSnapshot := newCollectionSnapshot(c, networkInterfaces.Underlying())
+	machinesSnapshot := newCollectionSnapshot(c, machines0.Writeable().Underlying())
+	networkInterfacesSnapshot := newCollectionSnapshot(c, networkInterfaces.Writeable().Underlying())
 
 	c.Assert(machines0.Name(), gc.Equals, state.MachinesC)
 	c.Assert(networkInterfaces.Name(), gc.Equals, state.NetworkInterfacesC)
@@ -308,7 +308,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Insert works",
 			test: func() (int, error) {
-				err := machines0.Insert(bson.D{
+				err := machines0.Writeable().Insert(bson.D{
 					{"_id", state.DocID(s.State, "99")},
 					{"machineid", 99},
 					{"env-uuid", s.State.EnvironUUID()},
@@ -321,7 +321,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Remove adds env UUID prefix to _id",
 			test: func() (int, error) {
-				err := machines0.Remove(bson.D{{"_id", "0"}})
+				err := machines0.Writeable().Remove(bson.D{{"_id", "0"}})
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -333,7 +333,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 				// Attempt to remove the trusty machine in the second
 				// env with the collection that's filtering for the
 				// first env - nothing should get removed.
-				err := machines0.Remove(bson.D{{"series", "trusty"}})
+				err := machines0.Writeable().Remove(bson.D{{"series", "trusty"}})
 				c.Assert(err, gc.ErrorMatches, "not found")
 				return s.machines.Count()
 			},
@@ -342,7 +342,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Remove filters by env 2",
 			test: func() (int, error) {
-				err := machines0.Remove(bson.D{{"machineid", "0"}})
+				err := machines0.Writeable().Remove(bson.D{{"machineid", "0"}})
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -351,7 +351,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveId adds env UUID prefix",
 			test: func() (int, error) {
-				err := machines0.RemoveId(m0.Id())
+				err := machines0.Writeable().RemoveId(m0.Id())
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -360,7 +360,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveId tolerates env UUID prefix already being there",
 			test: func() (int, error) {
-				err := machines0.RemoveId(state.DocID(s.State, m0.Id()))
+				err := machines0.Writeable().RemoveId(state.DocID(s.State, m0.Id()))
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -369,7 +369,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveId filters by env-uuid field",
 			test: func() (int, error) {
-				err := networkInterfaces.RemoveId(otherIfaceId)
+				err := networkInterfaces.Writeable().RemoveId(otherIfaceId)
 				c.Assert(err, gc.ErrorMatches, "not found")
 				return networkInterfaces.Count()
 			},
@@ -378,7 +378,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll filters by env",
 			test: func() (int, error) {
-				_, err := machines0.RemoveAll(bson.D{{"series", m0.Series()}})
+				_, err := machines0.Writeable().RemoveAll(bson.D{{"series", m0.Series()}})
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -387,7 +387,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll adds env UUID when _id is provided",
 			test: func() (int, error) {
-				_, err := machines0.RemoveAll(bson.D{{"_id", m0.Id()}})
+				_, err := machines0.Writeable().RemoveAll(bson.D{{"_id", m0.Id()}})
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -396,7 +396,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll tolerates env UUID prefix already being present",
 			test: func() (int, error) {
-				_, err := machines0.RemoveAll(bson.D{
+				_, err := machines0.Writeable().RemoveAll(bson.D{
 					{"_id", state.DocID(s.State, m0.Id())},
 				})
 				c.Assert(err, jc.ErrorIsNil)
@@ -407,7 +407,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll with no selector still filters by env",
 			test: func() (int, error) {
-				_, err := machines0.RemoveAll(nil)
+				_, err := machines0.Writeable().RemoveAll(nil)
 				c.Assert(err, jc.ErrorIsNil)
 				return s.machines.Count()
 			},
@@ -416,7 +416,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll panics if env-uuid is included",
 			test: func() (int, error) {
-				machines0.RemoveAll(bson.D{{"env-uuid", "whatever"}})
+				machines0.Writeable().RemoveAll(bson.D{{"env-uuid", "whatever"}})
 				return 0, nil
 			},
 			expectedPanic: "env-uuid is added automatically and should not be provided",
@@ -424,7 +424,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "RemoveAll panics if query type is unsupported",
 			test: func() (int, error) {
-				machines0.RemoveAll(bson.M{"foo": "bar"})
+				machines0.Writeable().RemoveAll(bson.M{"foo": "bar"})
 				return 0, nil
 			},
 			expectedPanic: "query must either be bson.D or nil",
@@ -432,7 +432,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "Update",
 			test: func() (int, error) {
-				err := machines0.Update(bson.D{{"_id", m0.Id()}},
+				err := machines0.Writeable().Update(bson.D{{"_id", m0.Id()}},
 					bson.D{{"$set", bson.D{{"update-field", "field value"}}}})
 				c.Assert(err, jc.ErrorIsNil)
 				return machines0.Find(bson.D{{"update-field", "field value"}}).Count()
@@ -442,7 +442,7 @@ func (s *CollectionsSuite) TestEnvStateCollection(c *gc.C) {
 		{
 			label: "UpdateId",
 			test: func() (int, error) {
-				err := machines0.UpdateId(m0.Id(),
+				err := machines0.Writeable().UpdateId(m0.Id(),
 					bson.D{{"$set", bson.D{{"update-field", "field value"}}}})
 				c.Assert(err, jc.ErrorIsNil)
 				return machines0.Find(bson.D{{"update-field", "field value"}}).Count()

--- a/state/database.go
+++ b/state/database.go
@@ -1,0 +1,226 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/mongo"
+)
+
+type SessionCloser func()
+
+func dontCloseAnything() {}
+
+// Database exposes the mongodb capabilities that most of state should see.
+type Database interface {
+
+	// CopySession returns a matching Database with its own session, and a
+	// func that must be called when the Database is no longer needed.
+	//
+	// GetCollection and TransactionRunner results from the resulting Database
+	// will all share a session; this does not absolve you of responsibility
+	// for calling those collections' closers.
+	CopySession() (Database, SessionCloser)
+
+	// GetCollection returns the named Collection, and a func that must be
+	// called when the Collection is no longer needed. The returned Collection
+	// might or might not have its own session, depending on the Database; the
+	// closer must always be called regardless.
+	//
+	// If the schema specifies environment-filtering for the named collection,
+	// the returned collection will automatically filter queries; for details,
+	// see envStateCollection.
+	GetCollection(name string) (mongo.Collection, SessionCloser)
+
+	// TransactionRunner() returns a runner responsible for making changes to
+	// the database, and a func that must be called when the runner is no longer
+	// needed. The returned Runner might or might not have its own session,
+	// depending on the Database; the closer must always be called regardless.
+	//
+	// It will reject transactions that reference raw-access (or unknown)
+	// collections; it will automatically rewrite operations that reference
+	// non-global collections; and it will ensure that non-global documents can
+	// only be inserted while the corresponding environment is still Alive.
+	TransactionRunner() (jujutxn.Runner, SessionCloser)
+
+	// Schema returns the schema used to load the database. The returned schema
+	// is not a copy and must not be modified.
+	Schema() collectionSchema
+}
+
+// collectionInfo describes important features of a collection.
+type collectionInfo struct {
+
+	// explicitCreate, if non-nil, will cause the collection to be explicitly
+	// Create~d (with the given value) before ensuring indexes.
+	explicitCreate *mgo.CollectionInfo
+
+	// indexes listed here will be EnsureIndex~ed before state is opened.
+	indexes []mgo.Index
+
+	// global collections will not have environment filtering applied. Non-
+	// global collections will have both transactions and reads filtered by
+	// relevant environment uuid.
+	global bool
+
+	// rawAccess collections can be safely accessed as a mongo.WriteCollection.
+	// Direct database access to txn-aware collections is strongly discouraged:
+	// merely writing directly to a field makes it impossible to use that field
+	// with mgo/txn; in the worst case, document deletion can destroy critical
+	// parts of the state distributed by mgo/txn, causing different runners to
+	// choose different global transaction orderings; this can in turn cause
+	// operations to be skipped.
+	//
+	// Short explanation follows: two different runners pick different -- but
+	// overlapping -- "next" transactions; they each pick the same txn-id; the
+	// first runner writes to an overlapping document and records the txn-id;
+	// and then the second runner inspects that document, sees that the chosen
+	// txn-id has already been applied, and <splat> skips that operation.
+	//
+	// Goodbye consistency. So please don't mix txn and non-txn writes without
+	// very careful analysis; and then, please, just don't do it anyway. If you
+	// need raw mgo, use a rawAccess collection.
+	rawAccess bool
+}
+
+// collectionSchema defines the set of collections used in juju.
+type collectionSchema map[string]collectionInfo
+
+// Load causes all recorded collections to be created and indexed as specified;
+// the returned Database will filter queries and transactions according to the
+// suppplied environment UUID.
+func (schema collectionSchema) Load(db *mgo.Database, environUUID string) (Database, error) {
+	if !names.IsValidEnvironment(environUUID) {
+		return nil, errors.New("invalid environment UUID")
+	}
+	for name, info := range schema {
+		rawCollection := db.C(name)
+		if spec := info.explicitCreate; spec != nil {
+			if err := createCollection(rawCollection, spec); err != nil {
+				message := fmt.Sprintf("cannot create collection %q", name)
+				return nil, maybeUnauthorized(err, message)
+			}
+		}
+		for _, index := range info.indexes {
+			if err := rawCollection.EnsureIndex(index); err != nil {
+				return nil, maybeUnauthorized(err, "cannot create index")
+			}
+		}
+	}
+	return &database{
+		raw:         db,
+		schema:      schema,
+		environUUID: environUUID,
+	}, nil
+}
+
+// createCollection swallows collection-already-exists errors.
+func createCollection(raw *mgo.Collection, spec *mgo.CollectionInfo) error {
+	err := raw.Create(spec)
+	// The lack of error code for this error was reported upstream:
+	//     https://jira.mongodb.org/browse/SERVER-6992
+	if err == nil || err.Error() == "collection already exists" {
+		return nil
+	}
+	return err
+}
+
+// database implements Database.
+type database struct {
+
+	// raw is the underlying mgo Database.
+	raw *mgo.Database
+
+	// schema specifies how the various collections must be handled.
+	schema collectionSchema
+
+	// environUUID is used to automatically filter queries and operations on
+	// certain collections (as defined in .schema).
+	environUUID string
+
+	// runner exists for testing purposes; if non-nil, the result of
+	// TransactionRunner will always ultimately use this value to run
+	// all transactions. Setting it renders the database goroutine-unsafe.
+	runner jujutxn.Runner
+
+	// ownSession is used to avoid copying additional sessions in a database
+	// resulting from CopySession.
+	ownSession bool
+}
+
+// CopySession is part of the Database interface.
+func (db *database) CopySession() (Database, SessionCloser) {
+	session := db.raw.Session.Copy()
+	return &database{
+		raw:         db.raw.With(session),
+		schema:      db.schema,
+		environUUID: db.environUUID,
+		runner:      db.runner,
+		ownSession:  true,
+	}, session.Close
+}
+
+// GetCollection is part of the Database interface.
+func (db *database) GetCollection(name string) (collection mongo.Collection, closer SessionCloser) {
+	info, found := db.schema[name]
+	if !found {
+		logger.Warningf("using unknown collection %q", name)
+	}
+
+	// Copy session if necessary.
+	if db.ownSession {
+		collection = mongo.WrapCollection(db.raw.C(name))
+		closer = dontCloseAnything
+	} else {
+		collection, closer = mongo.CollectionFromName(db.raw, name)
+	}
+
+	// Apply environment filtering.
+	if !info.global {
+		collection = &envStateCollection{
+			WriteCollection: collection.Writeable(),
+			envUUID:         db.environUUID,
+		}
+	}
+
+	// Prevent layer-breaking.
+	if !info.rawAccess {
+		// TODO(fwereade): it would be nice to tweak the mongo.Collection
+		// interface a bit to drop Writeable in this situation, but it's
+		// not convenient yet.
+	}
+	return collection, closer
+}
+
+// TransactionRunner is part of the Database interface.
+func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCloser) {
+	runner = db.runner
+	closer = dontCloseAnything
+	if runner == nil {
+		raw := db.raw
+		if !db.ownSession {
+			session := raw.Session.Copy()
+			raw = raw.With(session)
+			closer = session.Close
+		}
+		params := jujutxn.RunnerParams{Database: raw}
+		runner = jujutxn.NewRunner(params)
+	}
+	return &multiEnvRunner{
+		rawRunner: runner,
+		envUUID:   db.environUUID,
+		schema:    db.schema,
+	}, closer
+}
+
+// Schema is part of the Database interface.
+func (db *database) Schema() collectionSchema {
+	return db.schema
+}

--- a/state/errors.go
+++ b/state/errors.go
@@ -1,0 +1,55 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v5"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// ErrCharmAlreadyUploaded is returned by UpdateUploadedCharm() when
+// the given charm is already uploaded and marked as not pending in
+// state.
+type ErrCharmAlreadyUploaded struct {
+	curl *charm.URL
+}
+
+func (e *ErrCharmAlreadyUploaded) Error() string {
+	return fmt.Sprintf("charm %q already uploaded", e.curl)
+}
+
+// IsCharmAlreadyUploadedError returns if the given error is
+// ErrCharmAlreadyUploaded.
+func IsCharmAlreadyUploadedError(err interface{}) bool {
+	if err == nil {
+		return false
+	}
+	// In case of a wrapped error, check the cause first.
+	value := err
+	cause := errors.Cause(err.(error))
+	if cause != nil {
+		value = cause
+	}
+	_, ok := value.(*ErrCharmAlreadyUploaded)
+	return ok
+}
+
+// ErrCharmRevisionAlreadyModified is returned when a pending or
+// placeholder charm is no longer pending or a placeholder, signaling
+// the charm is available in state with its full information.
+var ErrCharmRevisionAlreadyModified = fmt.Errorf("charm revision already modified")
+
+var ErrDead = fmt.Errorf("not found or dead")
+var errNotAlive = fmt.Errorf("not found or not alive")
+
+func onAbort(txnErr, err error) error {
+	if txnErr == txn.ErrAborted ||
+		errors.Cause(txnErr) == txn.ErrAborted {
+		return errors.Trace(err)
+	}
+	return errors.Trace(txnErr)
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testcharms"
 )
@@ -295,7 +296,7 @@ func GetUnitEnvUUID(unit *Unit) string {
 	return unit.doc.EnvUUID
 }
 
-func GetCollection(st *State, name string) (stateCollection, func()) {
+func GetCollection(st *State, name string) (mongo.Collection, func()) {
 	return st.getCollection(name)
 }
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -46,7 +46,6 @@ var (
 	PortsGlobalKey         = portsGlobalKey
 	CurrentUpgradeId       = currentUpgradeId
 	NowToTheSecond         = nowToTheSecond
-	MultiEnvCollections    = multiEnvCollections
 	PickAddress            = &pickAddress
 	AddVolumeOp            = (*State).addVolumeOp
 	CombineMeterStatus     = combineMeterStatus
@@ -63,25 +62,26 @@ type (
 )
 
 func SetTestHooks(c *gc.C, st *State, hooks ...jujutxn.TestHook) txntesting.TransactionChecker {
-	return txntesting.SetTestHooks(c, newMultiEnvRunnerForHooks(st), hooks...)
+	return txntesting.SetTestHooks(c, newRunnerForHooks(st), hooks...)
 }
 
 func SetBeforeHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChecker {
-	return txntesting.SetBeforeHooks(c, newMultiEnvRunnerForHooks(st), fs...)
+	return txntesting.SetBeforeHooks(c, newRunnerForHooks(st), fs...)
 }
 
 func SetAfterHooks(c *gc.C, st *State, fs ...func()) txntesting.TransactionChecker {
-	return txntesting.SetAfterHooks(c, newMultiEnvRunnerForHooks(st), fs...)
+	return txntesting.SetAfterHooks(c, newRunnerForHooks(st), fs...)
 }
 
 func SetRetryHooks(c *gc.C, st *State, block, check func()) txntesting.TransactionChecker {
-	return txntesting.SetRetryHooks(c, newMultiEnvRunnerForHooks(st), block, check)
+	return txntesting.SetRetryHooks(c, newRunnerForHooks(st), block, check)
 }
 
-func newMultiEnvRunnerForHooks(st *State) jujutxn.Runner {
-	runner := newMultiEnvRunner(st.EnvironUUID(), st.db)
-	st.transactionRunner = runner
-	return getRawRunner(runner)
+func newRunnerForHooks(st *State) jujutxn.Runner {
+	db := st.database.(*database)
+	runner := jujutxn.NewRunner(jujutxn.RunnerParams{Database: db.raw})
+	db.runner = runner
+	return runner
 }
 
 // SetPolicy updates the State's policy field to the
@@ -203,11 +203,13 @@ func init() {
 
 // TxnRevno returns the txn-revno field of the document
 // associated with the given Id in the given collection.
-func TxnRevno(st *State, coll string, id interface{}) (int64, error) {
+func TxnRevno(st *State, collName string, id interface{}) (int64, error) {
 	var doc struct {
 		TxnRevno int64 `bson:"txn-revno"`
 	}
-	err := st.db.C(coll).FindId(id).One(&doc)
+	coll, closer := st.getCollection(collName)
+	defer closer()
+	err := coll.FindId(id).One(&doc)
 	if err != nil {
 		return 0, err
 	}
@@ -304,11 +306,14 @@ func GetRawCollection(st *State, name string) (*mgo.Collection, func()) {
 	return st.getRawCollection(name)
 }
 
-func NewMultiEnvRunnerForTesting(envUUID string, baseRunner jujutxn.Runner) jujutxn.Runner {
-	return &multiEnvRunner{
-		rawRunner: baseRunner,
-		envUUID:   envUUID,
+func MultiEnvCollections() []string {
+	var result []string
+	for name, info := range allCollections() {
+		if !info.global {
+			result = append(result, name)
+		}
 	}
+	return result
 }
 
 func Sequence(st *State, name string) (int, error) {

--- a/state/images.go
+++ b/state/images.go
@@ -14,5 +14,5 @@ var (
 // ImageStorage returns a new imagestorage.Storage
 // that stores image metadata.
 func (st *State) ImageStorage() imagestorage.Storage {
-	return imageStorageNewStorage(st.db.Session, st.EnvironUUID())
+	return imageStorageNewStorage(st.session, st.EnvironUUID())
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -39,8 +39,13 @@ func (s *InitializeSuite) SetUpTest(c *gc.C) {
 	s.MgoSuite.SetUpTest(c)
 }
 
-func (s *InitializeSuite) openState(c *gc.C) {
-	st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+func (s *InitializeSuite) openState(c *gc.C, environTag names.EnvironTag) {
+	st, err := state.Open(
+		environTag,
+		statetesting.NewMongoInfo(),
+		statetesting.NewDialOpts(),
+		state.Policy(nil),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 }
@@ -68,7 +73,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	err = st.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.openState(c)
+	s.openState(c, envTag)
 
 	cfg, err = s.State.EnvironConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -134,7 +139,7 @@ func (s *InitializeSuite) TestEnvironConfigWithAdminSecret(c *gc.C) {
 	st := statetesting.Initialize(c, owner, good, nil)
 	st.Close()
 
-	s.openState(c)
+	s.openState(c, st.EnvironTag())
 	err = s.State.UpdateEnvironConfig(badUpdateAttrs, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "admin-secret should never be written to the state")
 
@@ -160,7 +165,7 @@ func (s *InitializeSuite) TestEnvironConfigWithoutAgentVersion(c *gc.C) {
 	// yay side effects
 	st.Close()
 
-	s.openState(c)
+	s.openState(c, st.EnvironTag())
 	err = s.State.UpdateEnvironConfig(map[string]interface{}{}, []string{"agent-version"}, nil)
 	c.Assert(err, gc.ErrorMatches, "agent-version must always be set in state")
 

--- a/state/leadership/block.go
+++ b/state/leadership/block.go
@@ -1,0 +1,68 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+)
+
+// block is used to deliver leaderlessness-notification requests to a manager's
+// loop goroutine on behalf of BlockUntilLeadershipReleased.
+type block struct {
+	serviceName string
+	unblock     chan struct{}
+	abort       <-chan struct{}
+}
+
+// validate returns an error if any fields are invalid or missing.
+func (b block) validate() error {
+	if !names.IsValidService(b.serviceName) {
+		return errors.Errorf("invalid service name %q", b.serviceName)
+	}
+	if b.unblock == nil {
+		return errors.New("missing unblock channel")
+	}
+	if b.abort == nil {
+		return errors.New("missing abort channel")
+	}
+	return nil
+}
+
+// invoke sends the block request on the supplied channel, and waits for the
+// unblock channel to be closed.
+func (b block) invoke(ch chan<- block) error {
+	if err := b.validate(); err != nil {
+		return errors.Annotatef(err, "cannot wait for leaderlessness")
+	}
+	for {
+		select {
+		case <-b.abort:
+			return errStopped
+		case ch <- b:
+			ch = nil
+		case <-b.unblock:
+			return nil
+		}
+	}
+}
+
+// blocks is used to keep track of leaderlessness-notification channels for
+// each service name.
+type blocks map[string][]chan struct{}
+
+// add records the block's unblock channel under the block's service name.
+func (b blocks) add(block block) {
+	b[block.serviceName] = append(b[block.serviceName], block.unblock)
+}
+
+// unblock closes all channels added under the supplied name and removes
+// them from blocks.
+func (b blocks) unblock(serviceName string) {
+	unblocks := b[serviceName]
+	delete(b, serviceName)
+	for _, unblock := range unblocks {
+		close(unblock)
+	}
+}

--- a/state/leadership/check.go
+++ b/state/leadership/check.go
@@ -1,0 +1,65 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+)
+
+// check is used to deliver leadership-check requests to a manager's loop
+// goroutine on behalf of CheckLeadership.
+type check struct {
+	serviceName string
+	unitName    string
+	response    chan Token
+	abort       <-chan struct{}
+}
+
+// validate returns an error if any fields are invalid or missing.
+func (c check) validate() error {
+	if !names.IsValidService(c.serviceName) {
+		return errors.Errorf("invalid service name %q", c.serviceName)
+	}
+	if !names.IsValidUnit(c.unitName) {
+		return errors.Errorf("invalid unit name %q", c.unitName)
+	}
+	if c.response == nil {
+		return errors.New("missing response channel")
+	}
+	if c.abort == nil {
+		return errors.New("missing abort channel")
+	}
+	return nil
+}
+
+// invoke sends the check on the supplied channel, waits for a response, and
+// returns either a Token that can be used to assert continued leadership in
+// the future, or an error.
+func (c check) invoke(ch chan<- check) (Token, error) {
+	if err := c.validate(); err != nil {
+		return nil, errors.Annotatef(err, "cannot check leadership")
+	}
+	for {
+		select {
+		case <-c.abort:
+			return nil, errStopped
+		case ch <- c:
+			ch = nil
+		case token := <-c.response:
+			if token == nil {
+				return nil, errors.Errorf("%q is not leader of %q", c.unitName, c.serviceName)
+			}
+			return token, nil
+		}
+	}
+}
+
+// respond causes the supplied token to be sent back to invoke.
+func (c check) respond(token Token) {
+	select {
+	case <-c.abort:
+	case c.response <- token:
+	}
+}

--- a/state/leadership/claim.go
+++ b/state/leadership/claim.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/leadership"
+)
+
+// claim is used to deliver leadership-claim requests to a manager's loop
+// goroutine on behalf of ClaimLeadership.
+type claim struct {
+	serviceName string
+	unitName    string
+	duration    time.Duration
+	response    chan bool
+	abort       <-chan struct{}
+}
+
+// validate returns an error if any fields are invalid or missing.
+func (c claim) validate() error {
+	if !names.IsValidService(c.serviceName) {
+		return errors.Errorf("invalid service name %q", c.serviceName)
+	}
+	if !names.IsValidUnit(c.unitName) {
+		return errors.Errorf("invalid unit name %q", c.unitName)
+	}
+	if c.duration <= 0 {
+		return errors.Errorf("invalid duration %v", c.duration)
+	}
+	if c.response == nil {
+		return errors.New("missing response channel")
+	}
+	if c.abort == nil {
+		return errors.New("missing abort channel")
+	}
+	return nil
+}
+
+// invoke sends the claim on the supplied channel and waits for a response.
+func (c claim) invoke(ch chan<- claim) error {
+	if err := c.validate(); err != nil {
+		return errors.Annotatef(err, "cannot claim leadership")
+	}
+	for {
+		select {
+		case <-c.abort:
+			return errStopped
+		case ch <- c:
+			ch = nil
+		case success := <-c.response:
+			if !success {
+				return leadership.ErrClaimDenied
+			}
+			return nil
+		}
+	}
+}
+
+// respond causes the supplied success value to be sent back to invoke.
+func (c claim) respond(success bool) {
+	select {
+	case <-c.abort:
+	case c.response <- success:
+	}
+}

--- a/state/leadership/config.go
+++ b/state/leadership/config.go
@@ -1,0 +1,29 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/state/lease"
+)
+
+// ManagerConfig contains the resources and information required to create a
+// Manager.
+type ManagerConfig struct {
+	Client lease.Client
+	Clock  lease.Clock
+}
+
+// Validate returns an error if the configuration contains invalid information
+// or missing resources.
+func (config ManagerConfig) Validate() error {
+	if config.Client == nil {
+		return errors.New("missing client")
+	}
+	if config.Clock == nil {
+		return errors.New("missing clock")
+	}
+	return nil
+}

--- a/state/leadership/fixture_test.go
+++ b/state/leadership/fixture_test.go
@@ -1,0 +1,89 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/leadership"
+	"github.com/juju/juju/state/lease"
+)
+
+var (
+	defaultClockStart time.Time
+	almostOneSecond   = time.Second - time.Nanosecond
+)
+
+func init() {
+	// We pick a time with a comfortable h:m:s component but:
+	//  (1) past the int32 unix epoch limit;
+	//  (2) at a 5ns offset to make sure we're not discarding precision;
+	//  (3) in a weird time zone.
+	value := "2073-03-03T01:00:00.000000005-08:40"
+	var err error
+	defaultClockStart, err = time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// offset returns the result of defaultClockStart.Add(d); it exists to make
+// exppiry tests easier to write.
+func offset(d time.Duration) time.Time {
+	return defaultClockStart.Add(d)
+}
+
+// almostSeconds returns a duration smaller than the supplied number of
+// seconds by one nanosecond.
+func almostSeconds(seconds int) time.Duration {
+	if seconds < 1 {
+		panic("unexpected")
+	}
+	return (time.Second * time.Duration(seconds)) - time.Nanosecond
+}
+
+// Fixture allows us to test a leadership.Manager with a usefully-mocked
+// lease.Clock and lease.Client.
+type Fixture struct {
+
+	// leases contains the leases the lease.Client should report when the
+	// test starts up.
+	leases map[string]lease.Info
+
+	// expectCalls contains the calls that should be made to the lease.Client
+	// in the course of a test. By specifying a callback you can cause the
+	// reported leases to change.
+	expectCalls []call
+
+	// expectDirty should be set for tests that purposefully abuse the manager
+	// to the extent that it returns an error on Wait(); tests that don't set
+	// this flag will check that the manager's shutdown error is nil.
+	expectDirty bool
+}
+
+// RunTest sets up a Manager and a Clock and passes them into the supplied
+// test function. The manager will be cleaned up afterwards.
+func (fix *Fixture) RunTest(c *gc.C, test func(leadership.ManagerWorker, *Clock)) {
+	clock := NewClock(defaultClockStart)
+	client := NewClient(fix.leases, fix.expectCalls)
+	manager, err := leadership.NewManager(leadership.ManagerConfig{
+		Clock:  clock,
+		Client: client,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		// Dirty tests will probably have stopped the manager anyway, but no
+		// sense leaving them around if things aren't exactly as we expect.
+		manager.Kill()
+		err := manager.Wait()
+		if !fix.expectDirty {
+			c.Check(err, jc.ErrorIsNil)
+		}
+	}()
+	defer client.Wait(c)
+	test(manager, clock)
+}

--- a/state/leadership/interface.go
+++ b/state/leadership/interface.go
@@ -1,0 +1,52 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/worker"
+)
+
+// Token exposes mgo/txn operations that can be added to a transaction in order
+// to abort it if the check that generated the Token would no longer pass.
+type Token interface {
+
+	// AssertOps returns mgo/txn operations that will abort if some fact no
+	// longer holds true.
+	AssertOps() []txn.Op
+}
+
+// Manager allows units to claim service leadership; to verify a unit's continued
+// leadership of a service; and to wait until a service has no leader.
+type Manager interface {
+
+	// ClaimLeadership claims leadership of the named service on behalf of the
+	// named unit. If no error is returned, leadership will be guaranteed for
+	// at least the supplied duration from the point when the call was made.
+	ClaimLeadership(serviceName, unitName string, duration time.Duration) error
+
+	// CheckLeadership verifies that the named unit is leader of the named
+	// service, and returns a Token attesting to that fact for use building
+	// mgo/txn transactions that depend upon it.
+	CheckLeadership(serviceName, unitName string) (Token, error)
+
+	// BlockUntilLeadershipReleased blocks until the named service is known
+	// to have no leader, in which case it returns no error; or until the
+	// manager is stopped, in which case it will fail.
+	BlockUntilLeadershipReleased(serviceName string) error
+}
+
+// ManagerWorker implements Manager and worker.Worker.
+type ManagerWorker interface {
+	worker.Worker
+	Manager
+}
+
+// errStopped is returned to clients when an operation cannot complete because
+// the manager has started (and possibly finished) shutdown.
+var errStopped = errors.New("leadership manager stopped")

--- a/state/leadership/interface.go
+++ b/state/leadership/interface.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"gopkg.in/mgo.v2/txn"
-
-	"github.com/juju/juju/worker"
 )
 
 // Token exposes mgo/txn operations that can be added to a transaction in order
@@ -41,10 +39,13 @@ type Manager interface {
 	BlockUntilLeadershipReleased(serviceName string) error
 }
 
-// ManagerWorker implements Manager and worker.Worker.
+// ManagerWorker implements Manager and worker.Worker. We don't import worker
+// because it pulls in a lot of dependencies and causes import cycles when you
+// try to use leadership in state.
 type ManagerWorker interface {
-	worker.Worker
 	Manager
+	Kill()
+	Wait() error
 }
 
 // errStopped is returned to clients when an operation cannot complete because

--- a/state/leadership/manager.go
+++ b/state/leadership/manager.go
@@ -1,0 +1,243 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership
+
+import (
+	"sort"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state/lease"
+)
+
+var logger = loggo.GetLogger("juju.state.leadership")
+
+// NewManager returns a Manager implementation, backed by a lease.Client,
+// which (in addition to its exposed Manager capabilities) will expire all
+// known leases as they run out. The caller takes responsibility for killing,
+// and handling errors from, the returned Worker.
+func NewManager(config ManagerConfig) (ManagerWorker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	manager := &manager{
+		config: config,
+		claims: make(chan claim),
+		checks: make(chan check),
+		blocks: make(chan block),
+	}
+	go func() {
+		defer manager.tomb.Done()
+		// note: we don't directly tomb.Kill, because we may need to
+		// unwrap tomb.ErrDying in order to function correctly.
+		manager.kill(manager.loop())
+	}()
+	return manager, nil
+}
+
+// manager implements ManagerWorker.
+type manager struct {
+	tomb tomb.Tomb
+
+	// config collects all external configuration and dependencies.
+	config ManagerConfig
+
+	// claims is used to deliver leadership claim requests to the loop.
+	claims chan claim
+
+	// checks is used to deliver leadership check requests to the loop.
+	checks chan check
+
+	// blocks is used to deliver leaderlessness block requests to the loop.
+	blocks chan block
+}
+
+// Kill is part of the worker.Worker interface.
+func (manager *manager) Kill() {
+	manager.kill(nil)
+}
+
+// kill unwraps tomb.ErrDying before killing the tomb, thus allowing the worker
+// to use errors.Trace liberally and still stop cleanly.
+func (manager *manager) kill(err error) {
+	if errors.Cause(err) == tomb.ErrDying {
+		err = tomb.ErrDying
+	} else if err != nil {
+		logger.Errorf("stopping leadership manager with error: %v", err)
+	}
+	manager.tomb.Kill(err)
+}
+
+// Wait is part of the worker.Worker interface.
+func (manager *manager) Wait() error {
+	return manager.tomb.Wait()
+}
+
+// loop runs until the manager is stopped.
+func (manager *manager) loop() error {
+	blocks := make(blocks)
+	for {
+		if err := manager.choose(blocks); err != nil {
+			return errors.Trace(err)
+		}
+
+		leases := manager.config.Client.Leases()
+		for serviceName := range blocks {
+			if _, found := leases[serviceName]; !found {
+				blocks.unblock(serviceName)
+			}
+		}
+	}
+}
+
+// choose breaks the select out of loop to make the blocking logic clearer.
+func (manager *manager) choose(blocks blocks) error {
+	select {
+	case <-manager.tomb.Dying():
+		return tomb.ErrDying
+	case <-manager.nextExpiry():
+		return manager.expire()
+	case claim := <-manager.claims:
+		return manager.handleClaim(claim)
+	case check := <-manager.checks:
+		return manager.handleCheck(check)
+	case block := <-manager.blocks:
+		blocks.add(block)
+		return nil
+	}
+}
+
+// ClaimLeadership is part of the leadership.Manager interface.
+func (manager *manager) ClaimLeadership(serviceName, unitName string, duration time.Duration) error {
+	return claim{
+		serviceName: serviceName,
+		unitName:    unitName,
+		duration:    duration,
+		response:    make(chan bool),
+		abort:       manager.tomb.Dying(),
+	}.invoke(manager.claims)
+}
+
+// handleClaim processes and responds to the supplied claim. It will only return
+// unrecoverable errors; mere failure to claim just indicates a bad request, and
+// is communicated back to the claim's originator.
+func (manager *manager) handleClaim(claim claim) error {
+	client := manager.config.Client
+	request := lease.Request{claim.unitName, claim.duration}
+	err := lease.ErrInvalid
+	for err == lease.ErrInvalid {
+		select {
+		case <-manager.tomb.Dying():
+			return tomb.ErrDying
+		default:
+			info, found := client.Leases()[claim.serviceName]
+			switch {
+			case !found:
+				err = client.ClaimLease(claim.serviceName, request)
+			case info.Holder == claim.unitName:
+				err = client.ExtendLease(claim.serviceName, request)
+			default:
+				claim.respond(false)
+				return nil
+			}
+		}
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	claim.respond(true)
+	return nil
+}
+
+// CheckLeadership is part of the leadership.Manager interface.
+func (manager *manager) CheckLeadership(serviceName, unitName string) (Token, error) {
+	return check{
+		serviceName: serviceName,
+		unitName:    unitName,
+		response:    make(chan Token),
+		abort:       manager.tomb.Dying(),
+	}.invoke(manager.checks)
+}
+
+// handleCheck processes and responds to the supplied check. It will only return
+// unrecoverable errors; mere untruth of the assertion just indicates a bad
+// request, and is communicated back to the check's originator.
+func (manager *manager) handleCheck(check check) error {
+	client := manager.config.Client
+	info, found := client.Leases()[check.serviceName]
+	if !found || info.Holder != check.unitName {
+		if err := client.Refresh(); err != nil {
+			return errors.Trace(err)
+		}
+		info, found = client.Leases()[check.serviceName]
+	}
+	var result Token
+	if found && info.Holder == check.unitName {
+		result = token{info.AssertOp}
+	}
+	check.respond(result)
+	return nil
+}
+
+// BlockUntilLeadershipReleased is part of the leadership.Manager interface.
+func (manager *manager) BlockUntilLeadershipReleased(serviceName string) error {
+	return block{
+		serviceName: serviceName,
+		unblock:     make(chan struct{}),
+		abort:       manager.tomb.Dying(),
+	}.invoke(manager.blocks)
+}
+
+// nextExpiry returns a channel that will send a value at some point when we
+// expect at least one lease to be ready to expire. If no leases are known,
+// it will return nil.
+func (manager *manager) nextExpiry() <-chan time.Time {
+	var nextExpiry *time.Time
+	for _, info := range manager.config.Client.Leases() {
+		if nextExpiry != nil {
+			if info.Expiry.After(*nextExpiry) {
+				continue
+			}
+		}
+		nextExpiry = &info.Expiry
+	}
+	if nextExpiry == nil {
+		logger.Debugf("no leases recorded; never waking for expiry")
+		return nil
+	}
+	logger.Debugf("waking to expire leases at %s", *nextExpiry)
+	return manager.config.Clock.Alarm(*nextExpiry)
+}
+
+// expire will attempt to expire all leases that may have expired. There might
+// be none; they might have been extended or expired already by someone else; so
+// ErrInvalid is expected, and ignored, in the comfortable knowledge that the
+// client will have been updated and we'll see fresh info when we scan for new
+// expiries next time through the loop. It will return only unrecoverable errors.
+func (manager *manager) expire() error {
+	client := manager.config.Client
+	leases := client.Leases()
+
+	// Sort lease names so we expire in a predictable order for the tests.
+	names := make([]string, 0, len(leases))
+	for name := range leases {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		now := manager.config.Clock.Now()
+		if leases[name].Expiry.After(now) {
+			continue
+		}
+		switch err := client.ExpireLease(name); err {
+		case nil, lease.ErrInvalid:
+		default:
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}

--- a/state/leadership/manager_block_test.go
+++ b/state/leadership/manager_block_test.go
@@ -1,0 +1,230 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/leadership"
+	"github.com/juju/juju/state/lease"
+)
+
+type BlockUntilLeadershipReleasedSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&BlockUntilLeadershipReleasedSuite{})
+
+func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipNotHeld(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		blockTest := newBlockTest(manager, "redis")
+		err := blockTest.assertUnblocked(c)
+		c.Check(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpires(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		blockTest := newBlockTest(manager, "redis")
+		blockTest.assertBlocked(c)
+
+		// Trigger expiry.
+		clock.Advance(time.Second)
+		err := blockTest.assertUnblocked(c)
+		c.Check(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipChanged(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder: "redis/99",
+					Expiry: offset(time.Minute),
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		blockTest := newBlockTest(manager, "redis")
+		blockTest.assertBlocked(c)
+
+		// Trigger abortive expiry.
+		clock.Advance(time.Second)
+		blockTest.assertBlocked(c)
+	})
+}
+
+func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpiredEarly(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "Refresh",
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		blockTest := newBlockTest(manager, "redis")
+		blockTest.assertBlocked(c)
+
+		// Induce a refresh by making an unexpected check; it turns out the
+		// lease had already been expired by someone else.
+		manager.CheckLeadership("redis", "redis/99")
+		err := blockTest.assertUnblocked(c)
+		c.Check(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *BlockUntilLeadershipReleasedSuite) TestMultiple(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+			"store": lease.Info{
+				Holder: "store/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+				leases["store"] = lease.Info{
+					Holder: "store/9",
+					Expiry: offset(time.Minute),
+				}
+			},
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{"store"},
+			err:    lease.ErrInvalid,
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		redisTest1 := newBlockTest(manager, "redis")
+		redisTest1.assertBlocked(c)
+		redisTest2 := newBlockTest(manager, "redis")
+		redisTest2.assertBlocked(c)
+		storeTest1 := newBlockTest(manager, "store")
+		storeTest1.assertBlocked(c)
+		storeTest2 := newBlockTest(manager, "store")
+		storeTest2.assertBlocked(c)
+
+		// Induce attempted expiry; redis was expired already, store was
+		// refreshed and not expired.
+		clock.Advance(time.Second)
+		err := redisTest2.assertUnblocked(c)
+		c.Check(err, jc.ErrorIsNil)
+		err = redisTest1.assertUnblocked(c)
+		c.Check(err, jc.ErrorIsNil)
+		storeTest2.assertBlocked(c)
+		storeTest1.assertBlocked(c)
+	})
+}
+
+func (s *BlockUntilLeadershipReleasedSuite) TestKillManager(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		blockTest := newBlockTest(manager, "redis")
+		blockTest.assertBlocked(c)
+
+		manager.Kill()
+		err := blockTest.assertUnblocked(c)
+		c.Check(err, gc.ErrorMatches, "leadership manager stopped")
+	})
+}
+
+// blockTest wraps a goroutine running BlockUntilLeadershipReleased, and
+// fails if it's used more than a second after creation (which should be
+// *plenty* of time).
+type blockTest struct {
+	manager     leadership.Manager
+	serviceName string
+	done        chan error
+	abort       <-chan time.Time
+}
+
+// newBlockTest starts a test goroutine blocking until the manager confirms
+// leaderlessness of the named service.
+func newBlockTest(manager leadership.Manager, serviceName string) *blockTest {
+	bt := &blockTest{
+		manager:     manager,
+		serviceName: serviceName,
+		done:        make(chan error),
+		abort:       time.After(time.Second),
+	}
+	go func() {
+		select {
+		case <-bt.abort:
+		case bt.done <- bt.manager.BlockUntilLeadershipReleased(bt.serviceName):
+		}
+	}()
+	return bt
+}
+
+func (bt *blockTest) assertBlocked(c *gc.C) {
+	select {
+	case err := <-bt.done:
+		c.Fatalf("unblocked unexpectedly with %v", err)
+	default:
+	}
+}
+
+func (bt *blockTest) assertUnblocked(c *gc.C) error {
+	select {
+	case err := <-bt.done:
+		return err
+	case <-bt.abort:
+		c.Fatalf("timed out before unblocking")
+	}
+	panic("unreachable")
+}

--- a/state/leadership/manager_check_test.go
+++ b/state/leadership/manager_check_test.go
@@ -1,0 +1,136 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/state/leadership"
+	"github.com/juju/juju/state/lease"
+)
+
+type CheckLeadershipSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&CheckLeadershipSuite{})
+
+func (s *CheckLeadershipSuite) TestSuccess(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder:   "redis/0",
+				Expiry:   offset(time.Second),
+				AssertOp: txn.Op{C: "fake", Id: "fake"},
+			},
+		},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		token, err := manager.CheckLeadership("redis", "redis/0")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(token.AssertOps(), jc.DeepEquals, []txn.Op{{
+			C: "fake", Id: "fake",
+		}})
+	})
+}
+
+func (s *CheckLeadershipSuite) TestMissingRefresh_Success(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "Refresh",
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder:   "redis/0",
+					Expiry:   offset(time.Second),
+					AssertOp: txn.Op{C: "fake", Id: "fake"},
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		token, err := manager.CheckLeadership("redis", "redis/0")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(token.AssertOps(), jc.DeepEquals, []txn.Op{{
+			C: "fake", Id: "fake",
+		}})
+	})
+}
+
+func (s *CheckLeadershipSuite) TestOtherHolderRefresh_Success(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "Refresh",
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder:   "redis/0",
+					Expiry:   offset(time.Second),
+					AssertOp: txn.Op{C: "fake", Id: "fake"},
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		token, err := manager.CheckLeadership("redis", "redis/0")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(token.AssertOps(), jc.DeepEquals, []txn.Op{{
+			C: "fake", Id: "fake",
+		}})
+	})
+}
+
+func (s *CheckLeadershipSuite) TestRefresh_Failure_Missing(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "Refresh",
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		token, err := manager.CheckLeadership("redis", "redis/0")
+		c.Check(err, gc.ErrorMatches, `"redis/0" is not leader of "redis"`)
+		c.Check(token, gc.IsNil)
+	})
+}
+
+func (s *CheckLeadershipSuite) TestRefresh_Failure_OtherHolder(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "Refresh",
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder:   "redis/1",
+					Expiry:   offset(time.Second),
+					AssertOp: txn.Op{C: "fake", Id: "fake"},
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		token, err := manager.CheckLeadership("redis", "redis/0")
+		c.Check(err, gc.ErrorMatches, `"redis/0" is not leader of "redis"`)
+		c.Check(token, gc.IsNil)
+	})
+}
+
+func (s *CheckLeadershipSuite) TestRefresh_Error(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "Refresh",
+			err:    errors.New("crunch squish"),
+		}},
+		expectDirty: true,
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		token, err := manager.CheckLeadership("redis", "redis/0")
+		c.Check(err, gc.ErrorMatches, "leadership manager stopped")
+		c.Check(token, gc.IsNil)
+		err = manager.Wait()
+		c.Check(err, gc.ErrorMatches, "crunch squish")
+	})
+}

--- a/state/leadership/manager_claim_test.go
+++ b/state/leadership/manager_claim_test.go
@@ -1,0 +1,205 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coreleadership "github.com/juju/juju/leadership"
+	"github.com/juju/juju/state/leadership"
+	"github.com/juju/juju/state/lease"
+)
+
+type ClaimLeadershipSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ClaimLeadershipSuite{})
+
+func (s *ClaimLeadershipSuite) TestClaimLease_Success(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "ClaimLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *ClaimLeadershipSuite) TestClaimLease_Success_SameHolder(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "ClaimLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder: "redis/0",
+					Expiry: offset(time.Second),
+				}
+			},
+		}, {
+			method: "ExtendLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *ClaimLeadershipSuite) TestClaimLease_Failure_OtherHolder(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "ClaimLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder: "redis/1",
+					Expiry: offset(time.Second),
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, gc.Equals, coreleadership.ErrClaimDenied)
+	})
+}
+
+func (s *ClaimLeadershipSuite) TestClaimLease_Failure_Error(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "ClaimLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			err:    errors.New("lol borken"),
+		}},
+		expectDirty: true,
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, gc.ErrorMatches, "leadership manager stopped")
+		err = manager.Wait()
+		c.Check(err, gc.ErrorMatches, "lol borken")
+	})
+}
+
+func (s *ClaimLeadershipSuite) TestExtendLease_Success(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExtendLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *ClaimLeadershipSuite) TestExtendLease_Success_Expired(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExtendLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}, {
+			method: "ClaimLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, jc.ErrorIsNil)
+	})
+}
+
+func (s *ClaimLeadershipSuite) TestExtendLease_Failure_OtherHolder(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExtendLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder: "redis/1",
+					Expiry: offset(time.Second),
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, gc.Equals, coreleadership.ErrClaimDenied)
+	})
+}
+
+func (s *ClaimLeadershipSuite) TestExtendLease_Failure_Error(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExtendLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			err:    errors.New("boom splat"),
+		}},
+		expectDirty: true,
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, gc.ErrorMatches, "leadership manager stopped")
+		err = manager.Wait()
+		c.Check(err, gc.ErrorMatches, "boom splat")
+	})
+}
+
+func (s *ClaimLeadershipSuite) TestOtherHolder_Failure(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/1",
+				Expiry: offset(time.Second),
+			},
+		},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Check(err, gc.Equals, coreleadership.ErrClaimDenied)
+	})
+}

--- a/state/leadership/manager_expire_test.go
+++ b/state/leadership/manager_expire_test.go
@@ -1,0 +1,283 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/leadership"
+	"github.com/juju/juju/state/lease"
+)
+
+type ExpireLeadershipSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ExpireLeadershipSuite{})
+
+func (s *ExpireLeadershipSuite) TestStartup_ExpiryInPast(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{Expiry: offset(-time.Second)},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, _ *Clock) {})
+}
+
+func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{Expiry: offset(time.Second)},
+		},
+	}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *Clock) {
+		clock.Advance(almostSeconds(1))
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture_TimePasses(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{Expiry: offset(time.Second)},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *Clock) {
+		clock.Advance(time.Second)
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Expired(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{Expiry: offset(time.Second)},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *Clock) {
+		clock.Advance(time.Second)
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Updated(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{Expiry: offset(time.Second)},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{Expiry: offset(time.Minute)}
+			},
+		}},
+	}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *Clock) {
+		clock.Advance(time.Second)
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestExpire_OtherError(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{Expiry: offset(time.Second)},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			err:    errors.New("snarfblat hobalob"),
+		}},
+		expectDirty: true,
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		clock.Advance(time.Second)
+		err := manager.Wait()
+		c.Check(err, gc.ErrorMatches, "snarfblat hobalob")
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestClaim_ExpiryInFuture(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "ClaimLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder: "redis/0",
+					Expiry: offset(63 * time.Second),
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		// Ask for a minute, actually get 63s. Don't expire early.
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Assert(err, jc.ErrorIsNil)
+		clock.Advance(almostSeconds(63))
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "ClaimLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder: "redis/0",
+					Expiry: offset(63 * time.Second),
+				}
+			},
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		// Ask for a minute, actually get 63s. Expire on time.
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Assert(err, jc.ErrorIsNil)
+		clock.Advance(63 * time.Second)
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestExtend_ExpiryInFuture(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExtendLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder: "redis/0",
+					Expiry: offset(63 * time.Second),
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		// Ask for a minute, actually get 63s. Don't expire early.
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Assert(err, jc.ErrorIsNil)
+		clock.Advance(almostSeconds(63))
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExtendLease",
+			args:   []interface{}{"redis", lease.Request{"redis/0", time.Minute}},
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder: "redis/0",
+					Expiry: offset(63 * time.Second),
+				}
+			},
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		// Ask for a minute, actually get 63s. Expire on time.
+		err := manager.ClaimLeadership("redis", "redis/0", time.Minute)
+		c.Assert(err, jc.ErrorIsNil)
+		clock.Advance(63 * time.Second)
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestExpire_Multiple(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"redis": lease.Info{
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+			"store": lease.Info{
+				Holder: "store/3",
+				Expiry: offset(5 * time.Second),
+			},
+			"tokumx": lease.Info{
+				Holder: "tokumx/5",
+				Expiry: offset(10 * time.Second), // will not expire.
+			},
+			"ultron": lease.Info{
+				Holder: "ultron/7",
+				Expiry: offset(5 * time.Second),
+			},
+			"vvvvvv": lease.Info{
+				Holder: "vvvvvv/2",
+				Expiry: offset(time.Second), // would expire, but errors first.
+			},
+		},
+		expectCalls: []call{{
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{"store"},
+			err:    lease.ErrInvalid,
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "store")
+			},
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{"ultron"},
+			err:    errors.New("what is this?"),
+		}},
+		expectDirty: true,
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, clock *Clock) {
+		clock.Advance(5 * time.Second)
+		err := manager.Wait()
+		c.Check(err, gc.ErrorMatches, "what is this\\?")
+	})
+}

--- a/state/leadership/manager_validation_test.go
+++ b/state/leadership/manager_validation_test.go
@@ -1,0 +1,85 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/leadership"
+)
+
+type ValidationSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ValidationSuite{})
+
+func (s *ValidationSuite) TestMissingClient(c *gc.C) {
+	manager, err := leadership.NewManager(leadership.ManagerConfig{
+		Clock: NewClock(time.Now()),
+	})
+	c.Check(err, gc.ErrorMatches, "missing client")
+	c.Check(manager, gc.IsNil)
+}
+
+func (s *ValidationSuite) TestMissingClock(c *gc.C) {
+	manager, err := leadership.NewManager(leadership.ManagerConfig{
+		Client: NewClient(nil, nil),
+	})
+	c.Check(err, gc.ErrorMatches, "missing clock")
+	c.Check(manager, gc.IsNil)
+}
+
+func (s *ValidationSuite) TestClaimLeadership_ServiceName(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("foo/0", "bar/0", time.Minute)
+		c.Check(err, gc.ErrorMatches, `cannot claim leadership: invalid service name "foo/0"`)
+	})
+}
+
+func (s *ValidationSuite) TestClaimLeadership_UnitName(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("foo", "bar", time.Minute)
+		c.Check(err, gc.ErrorMatches, `cannot claim leadership: invalid unit name "bar"`)
+	})
+}
+
+func (s *ValidationSuite) TestClaimLeadership_Duration(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.ClaimLeadership("foo", "bar/0", 0)
+		c.Check(err, gc.ErrorMatches, `cannot claim leadership: invalid duration 0`)
+	})
+}
+
+func (s *ValidationSuite) TestCheckLeadership_ServiceName(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		token, err := manager.CheckLeadership("foo/0", "bar/0")
+		c.Check(err, gc.ErrorMatches, `cannot check leadership: invalid service name "foo/0"`)
+		c.Check(token, gc.IsNil)
+	})
+}
+
+func (s *ValidationSuite) TestCheckLeadership_UnitName(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		token, err := manager.CheckLeadership("foo", "bar")
+		c.Check(err, gc.ErrorMatches, `cannot check leadership: invalid unit name "bar"`)
+		c.Check(token, gc.IsNil)
+	})
+}
+
+func (s *ValidationSuite) TestBlockUntilLeadershipReleased_ServiceName(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		err := manager.BlockUntilLeadershipReleased("foo/0")
+		c.Check(err, gc.ErrorMatches, `cannot wait for leaderlessness: invalid service name "foo/0"`)
+	})
+}

--- a/state/leadership/package_test.go
+++ b/state/leadership/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/state/leadership/token.go
+++ b/state/leadership/token.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership
+
+import (
+	"gopkg.in/mgo.v2/txn"
+)
+
+// token implements Token.
+type token struct {
+	op txn.Op
+}
+
+// AssertOps is part of the Token interface.
+func (t token) AssertOps() []txn.Op {
+	return []txn.Op{t.op}
+}

--- a/state/leadership/util_test.go
+++ b/state/leadership/util_test.go
@@ -1,0 +1,196 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/lease"
+)
+
+// Client implements lease.Client for testing purposes.
+type Client struct {
+	leases map[string]lease.Info
+	expect []call
+	failed string
+	done   chan struct{}
+}
+
+// NewClient initializes and returns a new client configured to report
+// the supplied leases and expect the supplied calls.
+func NewClient(leases map[string]lease.Info, expect []call) *Client {
+	if leases == nil {
+		leases = make(map[string]lease.Info)
+	}
+	done := make(chan struct{})
+	if len(expect) == 0 {
+		close(done)
+	}
+	return &Client{
+		leases: leases,
+		expect: expect,
+		done:   done,
+	}
+}
+
+// Wait will return when all expected calls have been made, or fail the test
+// if they don't happen within a second. (You control the clock; your tests
+// should pass in *way* less than a second of wall-clock time.)
+func (client *Client) Wait(c *gc.C) {
+	select {
+	case <-client.done:
+		if client.failed != "" {
+			c.Fatalf(client.failed)
+		}
+	case <-time.After(time.Second):
+		c.Fatalf("Client test took way too long")
+	}
+}
+
+// Leases is part of the lease.Client interface.
+func (client *Client) Leases() map[string]lease.Info {
+	result := make(map[string]lease.Info)
+	for k, v := range client.leases {
+		result[k] = v
+	}
+	return result
+}
+
+// call implements the bulk of the lease.Client interface.
+func (client *Client) call(method string, args []interface{}) error {
+	select {
+	case <-client.done:
+		return errors.Errorf("Client method called after test complete: %s %v", method, args)
+	default:
+		defer func() {
+			if len(client.expect) == 0 || client.failed != "" {
+				close(client.done)
+			}
+		}()
+	}
+
+	expect := client.expect[0]
+	client.expect = client.expect[1:]
+	if expect.callback != nil {
+		expect.callback(client.leases)
+	}
+
+	if method == expect.method {
+		if ok, _ := jc.DeepEqual(args, expect.args); ok {
+			return expect.err
+		}
+	}
+	client.failed = fmt.Sprintf("unexpected Client call:\n  actual: %s %v\n  expect: %s %v",
+		method, args, expect.method, expect.args,
+	)
+	return errors.New(client.failed)
+}
+
+// ClaimLease is part of the lease.Client interface.
+func (client *Client) ClaimLease(name string, request lease.Request) error {
+	return client.call("ClaimLease", []interface{}{name, request})
+}
+
+// ExtendLease is part of the lease.Client interface.
+func (client *Client) ExtendLease(name string, request lease.Request) error {
+	return client.call("ExtendLease", []interface{}{name, request})
+}
+
+// ExpireLease is part of the lease.Client interface.
+func (client *Client) ExpireLease(name string) error {
+	return client.call("ExpireLease", []interface{}{name})
+}
+
+// Refresh is part of the lease.Client interface.
+func (client *Client) Refresh() error {
+	return client.call("Refresh", nil)
+}
+
+// call defines a expected method call on a Client; it encodes:
+type call struct {
+
+	// method is the name of the method.
+	method string
+
+	// args is the expected arguments.
+	args []interface{}
+
+	// err is the error to return.
+	err error
+
+	// callback, if non-nil, will be passed the internal leases dict; for
+	// modification, if desired. Otherwise you can use it to, e.g., assert
+	// clock time.
+	callback func(leases map[string]lease.Info)
+}
+
+// Clock implements lease.Clock for testing purposes.
+type Clock struct {
+	mu     sync.Mutex
+	now    time.Time
+	alarms []alarm
+}
+
+// NewClock returns a new clock set to the supplied time.
+func NewClock(now time.Time) *Clock {
+	return &Clock{now: now}
+}
+
+// Now is part of the lease.Clock interface.
+func (clock *Clock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+// Alarm is part of the lease.Clock interface.
+func (clock *Clock) Alarm(t time.Time) <-chan time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	notify := make(chan time.Time, 1)
+	if !clock.now.Before(t) {
+		notify <- clock.now
+	} else {
+		clock.alarms = append(clock.alarms, alarm{t, notify})
+		sort.Sort(byTime(clock.alarms))
+	}
+	return notify
+}
+
+// Advance advances the result of Now by the supplied duration, and sends
+// the "current" time on all alarms which are no longer "in the future".
+func (clock *Clock) Advance(d time.Duration) {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	clock.now = clock.now.Add(d)
+	rung := 0
+	for _, alarm := range clock.alarms {
+		if clock.now.Before(alarm.time) {
+			break
+		}
+		alarm.notify <- clock.now
+		rung++
+	}
+	clock.alarms = clock.alarms[rung:]
+}
+
+// alarm records the time at which we're expected to send on notify.
+type alarm struct {
+	time   time.Time
+	notify chan time.Time
+}
+
+// byTime is used to sort alarms by time.
+type byTime []alarm
+
+func (a byTime) Len() int           { return len(a) }
+func (a byTime) Less(i, j int) bool { return a[i].time.Before(a[j].time) }
+func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/state/lease.go
+++ b/state/lease.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/lease"
+	"github.com/juju/juju/mongo"
 )
 
 // leaseEntity represents a lease in mongo.
@@ -30,7 +31,7 @@ type leaseEntity struct {
 func NewLeasePersistor(
 	collectionName string,
 	runTransaction func(jujutxn.TransactionSource) error,
-	getCollection func(string) (_ stateCollection, closer func()),
+	getCollection func(string) (_ mongo.Collection, closer func()),
 ) *LeasePersistor {
 	getLeaseCollection := func(name string) (_ leaseCollection, closer func()) {
 		sc, closer := getCollection(name)
@@ -54,14 +55,14 @@ type LeasePersistor struct {
 // leaseCollection provides bespoke lease methods on top of a standard
 // state collection.
 type leaseCollection interface {
-	stateCollection
+	mongo.Collection
 
 	// FindById finds the lease with the specified id.
 	FindById(id string) (*leaseEntity, error)
 }
 
 type genericLeaseCollection struct {
-	stateCollection
+	mongo.Collection
 }
 
 // FindById finds the lease with the specified id.

--- a/state/lease/client.go
+++ b/state/lease/client.go
@@ -1,0 +1,512 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo"
+)
+
+// NewClient returns a new Client using the supplied config, or an error. Any
+// of the following situations will prevent client creation:
+//  * invalid config
+//  * invalid clock data stored in the namespace
+//  * invalid lease data stored in the namespace
+// ...but a returned Client will hold a recent cache of lease data and be ready
+// to use.
+// Clients do not need to be cleaned up themselves, but they will not function
+// past the lifetime of their configured Mongo.
+func NewClient(config ClientConfig) (Client, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	loggerName := fmt.Sprintf("state.lease.%s.%s", config.Namespace, config.Id)
+	logger := loggo.GetLogger(loggerName)
+	client := &client{
+		config: config,
+		logger: logger,
+	}
+	if err := client.ensureClockDoc(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := client.Refresh(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return client, nil
+}
+
+// client implements the Client interface.
+type client struct {
+
+	// config holds resources and configuration necessary to store leases.
+	config ClientConfig
+
+	// logger holds a logger unique to this lease Client.
+	logger loggo.Logger
+
+	// entries records recent information about leases.
+	entries map[string]entry
+
+	// skews records recent information about remote writers' clocks.
+	skews map[string]Skew
+}
+
+// Leases is part of the Client interface.
+func (client *client) Leases() map[string]Info {
+	leases := make(map[string]Info)
+	for name, entry := range client.entries {
+		skew := client.skews[entry.writer]
+		leases[name] = Info{
+			Holder:   entry.holder,
+			Expiry:   skew.Latest(entry.expiry),
+			AssertOp: client.assertOp(name, entry.holder),
+		}
+	}
+	return leases
+}
+
+// ClaimLease is part of the Client interface.
+func (client *client) ClaimLease(name string, request Request) error {
+	return client.request(name, request, client.claimLeaseOps, "claiming")
+}
+
+// ExtendLease is part of the Client interface.
+func (client *client) ExtendLease(name string, request Request) error {
+	return client.request(name, request, client.extendLeaseOps, "extending")
+}
+
+// opsFunc is used to make the signature of the request method somewhat readable.
+type opsFunc func(name string, request Request) ([]txn.Op, entry, error)
+
+// request implements ClaimLease and ExtendLease.
+func (client *client) request(name string, request Request, getOps opsFunc, verb string) error {
+	if err := validateString(name); err != nil {
+		return errors.Annotatef(err, "invalid name")
+	}
+	if err := request.Validate(); err != nil {
+		return errors.Annotatef(err, "invalid request")
+	}
+
+	// Close over cacheEntry to record in case of success.
+	var cacheEntry entry
+	err := client.config.Mongo.RunTransaction(func(attempt int) ([]txn.Op, error) {
+		client.logger.Debugf("%s lease %q for %s (attempt %d)", verb, name, request, attempt)
+
+		// On the first attempt, assume cache is good.
+		if attempt > 0 {
+			if err := client.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+
+		// It's possible that the request is for an "extension" isn't an
+		// extension at all; this isn't a problem, but does require separate
+		// handling.
+		ops, nextEntry, err := getOps(name, request)
+		cacheEntry = nextEntry
+		if errors.Cause(err) == errNoExtension {
+			return nil, jujutxn.ErrNoOperations
+		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
+	})
+
+	// Unwrap ErrInvalid if necessary.
+	if errors.Cause(err) == ErrInvalid {
+		return ErrInvalid
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Update the cache for this lease only.
+	client.entries[name] = cacheEntry
+	return nil
+}
+
+// ExpireLease is part of the Client interface.
+func (client *client) ExpireLease(name string) error {
+	if err := validateString(name); err != nil {
+		return errors.Annotatef(err, "invalid name")
+	}
+
+	// No cache updates needed, only deletes; no closure here.
+	err := client.config.Mongo.RunTransaction(func(attempt int) ([]txn.Op, error) {
+		client.logger.Debugf("expiring lease %q (attempt %d)", name, attempt)
+
+		// On the first attempt, assume cache is good.
+		if attempt > 0 {
+			if err := client.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+
+		// No special error handling here.
+		ops, err := client.expireLeaseOps(name)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
+	})
+
+	// Unwrap ErrInvalid if necessary.
+	if errors.Cause(err) == ErrInvalid {
+		return ErrInvalid
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Uncache this lease entry.
+	delete(client.entries, name)
+	return nil
+}
+
+// Refresh is part of the Client interface.
+func (client *client) Refresh() error {
+	client.logger.Debugf("refreshing")
+
+	// Always read entries before skews, because skews are written before
+	// entries; we increase the risk of reading older skew data, but (should)
+	// eliminate the risk of reading an entry whose writer is not present
+	// in the skews data.
+	collection, closer := client.config.Mongo.GetCollection(client.config.Collection)
+	defer closer()
+	entries, err := client.readEntries(collection)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	skews, err := client.readSkews(collection)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Check we're not missing any required clock information before
+	// updating our local state.
+	for name, entry := range entries {
+		if _, found := skews[entry.writer]; !found {
+			return errors.Errorf("lease %q invalid: no clock data for %s", name, entry.writer)
+		}
+	}
+	client.skews = skews
+	client.entries = entries
+	return nil
+}
+
+// ensureClockDoc returns an error if it can neither find nor create a
+// valid clock document for the client's namespace.
+func (client *client) ensureClockDoc() error {
+	collection, closer := client.config.Mongo.GetCollection(client.config.Collection)
+	defer closer()
+
+	clockDocId := client.clockDocId()
+	err := client.config.Mongo.RunTransaction(func(attempt int) ([]txn.Op, error) {
+		client.logger.Debugf("checking clock %q (attempt %d)", clockDocId, attempt)
+		var clockDoc clockDoc
+		err := collection.FindId(clockDocId).One(&clockDoc)
+		if err == nil {
+			client.logger.Debugf("clock already exists")
+			if err := clockDoc.validate(); err != nil {
+				return nil, errors.Annotatef(err, "corrupt clock document")
+			}
+			return nil, jujutxn.ErrNoOperations
+		}
+		if err != mgo.ErrNotFound {
+			return nil, errors.Trace(err)
+		}
+		client.logger.Debugf("creating clock")
+		newClockDoc, err := newClockDoc(client.config.Namespace)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return []txn.Op{{
+			C:      client.config.Collection,
+			Id:     clockDocId,
+			Assert: txn.DocMissing,
+			Insert: newClockDoc,
+		}}, nil
+	})
+	return errors.Trace(err)
+}
+
+// readEntries reads all lease data for the client's namespace.
+func (client *client) readEntries(collection mongo.Collection) (map[string]entry, error) {
+
+	// Read all lease documents in the client's namespace.
+	query := bson.M{
+		fieldType:      typeLease,
+		fieldNamespace: client.config.Namespace,
+	}
+	iter := collection.Find(query).Iter()
+
+	// Extract valid entries for each one.
+	entries := make(map[string]entry)
+	var leaseDoc leaseDoc
+	for iter.Next(&leaseDoc) {
+		name, entry, err := leaseDoc.entry()
+		if err != nil {
+			return nil, errors.Annotatef(err, "corrupt lease document %q", leaseDoc.Id)
+		}
+		entries[name] = entry
+	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return entries, nil
+}
+
+// readSkews reads all clock data for the client's namespace.
+func (client *client) readSkews(collection mongo.Collection) (map[string]Skew, error) {
+
+	// Read the clock document, recording the time before and after completion.
+	readBefore := client.config.Clock.Now()
+	var clockDoc clockDoc
+	if err := collection.FindId(client.clockDocId()).One(&clockDoc); err != nil {
+		return nil, errors.Trace(err)
+	}
+	readAfter := client.config.Clock.Now()
+	if err := clockDoc.validate(); err != nil {
+		return nil, errors.Annotatef(err, "corrupt clock document")
+	}
+
+	// Create skew entries for each known writer...
+	skews, err := clockDoc.skews(readBefore, readAfter)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// If a writer was previously known to us, and has not written since last
+	// time we read, we should keep the original skew, which is more accurate.
+	for writer, skew := range client.skews {
+		if skews[writer].LastWrite == skew.LastWrite {
+			skews[writer] = skew
+		}
+	}
+
+	// ...and overwrite our own with a zero skew, which will DTRT (assuming
+	// nobody's reusing client ids across machines with different clocks,
+	// which *should* never happen).
+	skews[client.config.Id] = Skew{}
+	return skews, nil
+}
+
+// claimLeaseOps returns the []txn.Op necessary to claim the supplied lease
+// until duration in the future, and a cache entry corresponding to the values
+// that will be written if the transaction succeeds. If the claim would conflict
+// with cached state, it returns ErrInvalid.
+func (client *client) claimLeaseOps(name string, request Request) ([]txn.Op, entry, error) {
+
+	// We can't claim a lease that's already held.
+	if _, found := client.entries[name]; found {
+		return nil, entry{}, ErrInvalid
+	}
+
+	// According to the local clock, we want the lease to extend until
+	// <duration> in the future.
+	now := client.config.Clock.Now()
+	expiry := now.Add(request.Duration)
+	nextEntry := entry{
+		holder: request.Holder,
+		expiry: expiry,
+		writer: client.config.Id,
+	}
+
+	// We need to write the entry to the database in a specific format.
+	leaseDoc, err := newLeaseDoc(client.config.Namespace, name, nextEntry)
+	if err != nil {
+		return nil, entry{}, errors.Trace(err)
+	}
+	extendLeaseOp := txn.Op{
+		C:      client.config.Collection,
+		Id:     leaseDoc.Id,
+		Assert: txn.DocMissing,
+		Insert: leaseDoc,
+	}
+
+	// We always write a clock-update operation *before* writing lease info.
+	writeClockOp := client.writeClockOp(now)
+	ops := []txn.Op{writeClockOp, extendLeaseOp}
+	return ops, nextEntry, nil
+}
+
+// extendLeaseOps returns the []txn.Op necessary to extend the supplied lease
+// until duration in the future, and a cache entry corresponding to the values
+// that will be written if the transaction succeeds. If the supplied lease
+// already extends far enough that no operations are required, it will return
+// errNoExtension. If the extension would conflict with cached state, it will
+// return ErrInvalid.
+func (client *client) extendLeaseOps(name string, request Request) ([]txn.Op, entry, error) {
+
+	// Reject extensions when there's no lease, or the holder doesn't match.
+	lastEntry, found := client.entries[name]
+	if !found {
+		return nil, entry{}, ErrInvalid
+	}
+	if lastEntry.holder != request.Holder {
+		return nil, entry{}, ErrInvalid
+	}
+
+	// According to the local clock, we want the lease to extend until
+	// <duration> in the future.
+	now := client.config.Clock.Now()
+	expiry := now.Add(request.Duration)
+
+	// We don't know what time the original writer thinks it is, but we
+	// can figure out the earliest and latest local times at which it
+	// could be expecting its original lease to expire.
+	skew := client.skews[lastEntry.writer]
+	if expiry.Before(skew.Earliest(lastEntry.expiry)) {
+		// The "extended" lease will certainly expire before the
+		// existing lease could. Done.
+		return nil, lastEntry, errNoExtension
+	}
+	latestExpiry := skew.Latest(lastEntry.expiry)
+	if expiry.Before(latestExpiry) {
+		// The lease might be long enough, but we're not sure, so we'll
+		// write a new one that definitely is long enough; but we must
+		// be sure that the new lease has an expiry time such that no
+		// other writer can consider it to have expired before the
+		// original writer considers its own lease to have expired.
+		expiry = latestExpiry
+	}
+
+	// We know we need to write a lease; we know when it needs to expire; we
+	// know what needs to go into the local cache:
+	nextEntry := entry{
+		holder: lastEntry.holder,
+		expiry: expiry,
+		writer: client.config.Id,
+	}
+
+	// ...and what needs to change in the database, and how to ensure the
+	// change is still valid when it's executed.
+	extendLeaseOp := txn.Op{
+		C:  client.config.Collection,
+		Id: client.leaseDocId(name),
+		Assert: bson.M{
+			fieldLeaseHolder: lastEntry.holder,
+			fieldLeaseExpiry: toInt64(lastEntry.expiry),
+			fieldLeaseWriter: lastEntry.writer,
+		},
+		Update: bson.M{"$set": bson.M{
+			fieldLeaseExpiry: toInt64(expiry),
+			fieldLeaseWriter: client.config.Id,
+		}},
+	}
+
+	// We always write a clock-update operation *before* writing lease info.
+	writeClockOp := client.writeClockOp(now)
+	ops := []txn.Op{writeClockOp, extendLeaseOp}
+	return ops, nextEntry, nil
+}
+
+// expireLeaseOps returns the []txn.Op necessary to vacate the lease. If the
+// expiration would conflict with cached state, it will return ErrInvalid.
+func (client *client) expireLeaseOps(name string) ([]txn.Op, error) {
+
+	// We can't expire a lease that doesn't exist.
+	lastEntry, found := client.entries[name]
+	if !found {
+		return nil, ErrInvalid
+	}
+
+	// We also can't expire a lease whose expiry time may be in the future.
+	skew := client.skews[lastEntry.writer]
+	latestExpiry := skew.Latest(lastEntry.expiry)
+	now := client.config.Clock.Now()
+	if !now.After(latestExpiry) {
+		client.logger.Debugf("lease %q expires in the future", name)
+		return nil, ErrInvalid
+	}
+
+	// The database change is simple, and depends on the lease doc being
+	// untouched since we looked:
+	expireLeaseOp := txn.Op{
+		C:  client.config.Collection,
+		Id: client.leaseDocId(name),
+		Assert: bson.M{
+			fieldLeaseHolder: lastEntry.holder,
+			fieldLeaseExpiry: toInt64(lastEntry.expiry),
+			fieldLeaseWriter: lastEntry.writer,
+		},
+		Remove: true,
+	}
+
+	// We always write a clock-update operation *before* writing lease info.
+	// Removing a lease document counts as writing lease info.
+	writeClockOp := client.writeClockOp(now)
+	ops := []txn.Op{writeClockOp, expireLeaseOp}
+	return ops, nil
+}
+
+// writeClockOp returns a txn.Op which writes the supplied time to the writer's
+// field in the skew doc, and aborts if a more recent time has been recorded for
+// that writer.
+func (client *client) writeClockOp(now time.Time) txn.Op {
+	dbNow := toInt64(now)
+	dbKey := fmt.Sprintf("%s.%s", fieldClockWriters, client.config.Id)
+	return txn.Op{
+		C:  client.config.Collection,
+		Id: client.clockDocId(),
+		Assert: bson.M{
+			"$or": []bson.M{{
+				dbKey: bson.M{"$lte": dbNow},
+			}, {
+				dbKey: bson.M{"$exists": false},
+			}},
+		},
+		Update: bson.M{
+			"$set": bson.M{dbKey: dbNow},
+		},
+	}
+}
+
+// assertOp returns a txn.Op which will succeed only if holder holds the
+// named lease.
+func (client *client) assertOp(name, holder string) txn.Op {
+	return txn.Op{
+		C:  client.config.Collection,
+		Id: client.leaseDocId(name),
+		Assert: bson.M{
+			fieldLeaseHolder: holder,
+		},
+	}
+}
+
+// clockDocId returns the id of the clock document in the client's namespace.
+func (client *client) clockDocId() string {
+	return clockDocId(client.config.Namespace)
+}
+
+// leaseDocId returns the id of the named lease document in the client's
+// namespace.
+func (client *client) leaseDocId(name string) string {
+	return leaseDocId(client.config.Namespace, name)
+}
+
+// entry holds the details of a lease and how it was written.
+type entry struct {
+	// holder identifies the current holder of the lease.
+	holder string
+
+	// expiry is the (writer-local) time at which the lease is safe to remove.
+	expiry time.Time
+
+	// writer identifies the client that wrote the lease.
+	writer string
+}
+
+// errNoExtension is used internally to avoid running unnecessary transactions.
+var errNoExtension = errors.New("lease needs no extension")

--- a/state/lease/client_assert_test.go
+++ b/state/lease/client_assert_test.go
@@ -1,0 +1,75 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/state/lease"
+)
+
+// ClientAssertSuite tests that AssertOp does what it should.
+type ClientAssertSuite struct {
+	FixtureSuite
+	fix  *Fixture
+	info lease.Info
+}
+
+var _ = gc.Suite(&ClientAssertSuite{})
+
+func (s *ClientAssertSuite) SetUpTest(c *gc.C) {
+	s.FixtureSuite.SetUpTest(c)
+	s.fix = s.EasyFixture(c)
+	err := s.fix.Client.ClaimLease("name", lease.Request{"holder", time.Minute})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert("name", s.fix.Holder(), "holder")
+}
+
+func (s *ClientAssertSuite) TestPassesWhenLeaseHeld(c *gc.C) {
+	info := s.fix.Client.Leases()["name"]
+
+	ops := []txn.Op{info.AssertOp}
+	err := s.fix.Runner.RunTransaction(ops)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *ClientAssertSuite) TestPassesWhenLeaseStillHeldDespiteWriterChange(c *gc.C) {
+	info := s.fix.Client.Leases()["name"]
+
+	fix2 := s.NewFixture(c, FixtureParams{Id: "other-client"})
+	err := fix2.Client.ExtendLease("name", lease.Request{"holder", time.Hour})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ops := []txn.Op{info.AssertOp}
+	err = s.fix.Runner.RunTransaction(ops)
+	c.Check(err, gc.IsNil)
+}
+
+func (s *ClientAssertSuite) TestPassesWhenLeaseStillHeldDespitePassingExpiry(c *gc.C) {
+	info := s.fix.Client.Leases()["name"]
+
+	s.fix.Clock.Advance(time.Hour)
+	err := s.fix.Client.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	ops := []txn.Op{info.AssertOp}
+	err = s.fix.Runner.RunTransaction(ops)
+	c.Check(err, gc.IsNil)
+}
+
+func (s *ClientAssertSuite) TestAbortsWhenLeaseVacant(c *gc.C) {
+	info := s.fix.Client.Leases()["name"]
+
+	s.fix.Clock.Advance(time.Hour)
+	err := s.fix.Client.ExpireLease("name")
+	c.Assert(err, jc.ErrorIsNil)
+
+	ops := []txn.Op{info.AssertOp}
+	err = s.fix.Runner.RunTransaction(ops)
+	c.Check(err, gc.Equals, txn.ErrAborted)
+}

--- a/state/lease/client_operation_test.go
+++ b/state/lease/client_operation_test.go
@@ -1,0 +1,166 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/lease"
+)
+
+// ClientOperationSuite verifies behaviour when claiming, extending, and expiring leases.
+type ClientOperationSuite struct {
+	FixtureSuite
+}
+
+var _ = gc.Suite(&ClientOperationSuite{})
+
+func (s *ClientOperationSuite) TestClaimLease(c *gc.C) {
+	fix := s.EasyFixture(c)
+
+	leaseDuration := time.Minute
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The lease is claimed, for an exact duration.
+	c.Check("name", fix.Holder(), "holder")
+	exactExpiry := fix.Zero.Add(leaseDuration)
+	c.Check("name", fix.Expiry(), exactExpiry)
+}
+
+func (s *ClientOperationSuite) TestClaimMultipleLeases(c *gc.C) {
+	fix := s.EasyFixture(c)
+
+	err := fix.Client.ClaimLease("short", lease.Request{"holder", time.Second})
+	c.Assert(err, jc.ErrorIsNil)
+	err = fix.Client.ClaimLease("medium", lease.Request{"grasper", time.Minute})
+	c.Assert(err, jc.ErrorIsNil)
+	err = fix.Client.ClaimLease("long", lease.Request{"clutcher", time.Hour})
+	c.Assert(err, jc.ErrorIsNil)
+
+	check := func(name, holder string, duration time.Duration) {
+		c.Check(name, fix.Holder(), holder)
+		expiry := fix.Zero.Add(duration)
+		c.Check(name, fix.Expiry(), expiry)
+	}
+	check("short", "holder", time.Second)
+	check("medium", "grasper", time.Minute)
+	check("long", "clutcher", time.Hour)
+}
+
+func (s *ClientOperationSuite) TestCannotClaimLeaseTwice(c *gc.C) {
+	fix := s.EasyFixture(c)
+
+	leaseDuration := time.Minute
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The lease is claimed and cannot be claimed again...
+	err = fix.Client.ClaimLease("name", lease.Request{"other-holder", leaseDuration})
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+
+	// ...not even for the same holder...
+	err = fix.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+
+	// ...not even when the lease has expired.
+	fix.Clock.Advance(time.Hour)
+	err = fix.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+}
+
+func (s *ClientOperationSuite) TestExtendLease(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", time.Second})
+	c.Assert(err, jc.ErrorIsNil)
+
+	leaseDuration := time.Minute
+	err = fix.Client.ExtendLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The lease is extended, *to* (not by) the exact duration requested.
+	c.Check("name", fix.Holder(), "holder")
+	exactExpiry := fix.Zero.Add(leaseDuration)
+	c.Check("name", fix.Expiry(), exactExpiry)
+}
+
+func (s *ClientOperationSuite) TestCanExtendStaleLease(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", time.Second})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Advance the clock past lease expiry time, then extend.
+	fix.Clock.Advance(time.Minute)
+	extendTime := fix.Clock.Now()
+	leaseDuration := time.Minute
+	err = fix.Client.ExtendLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The lease is extended fine, *to* (not by) the exact duration requested.
+	c.Check("name", fix.Holder(), "holder")
+	exactExpiry := extendTime.Add(leaseDuration)
+	c.Check("name", fix.Expiry(), exactExpiry)
+}
+
+func (s *ClientOperationSuite) TestExtendLeaseCannotChangeHolder(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", time.Second})
+	c.Assert(err, jc.ErrorIsNil)
+
+	leaseDuration := time.Minute
+	err = fix.Client.ExtendLease("name", lease.Request{"other-holder", leaseDuration})
+	c.Assert(err, gc.Equals, lease.ErrInvalid)
+}
+
+func (s *ClientOperationSuite) TestExtendLeaseCannotShortenLease(c *gc.C) {
+	fix := s.EasyFixture(c)
+	leaseDuration := time.Minute
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// A non-extension will succeed -- we can still honour all guarantees
+	// implied by a nil error...
+	err = fix.Client.ExtendLease("name", lease.Request{"holder", time.Second})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// ...but we can't make it any shorter, lest we fail to honour the
+	// guarantees implied by the original lease.
+	c.Check("name", fix.Holder(), "holder")
+	exactExpiry := fix.Zero.Add(leaseDuration)
+	c.Check("name", fix.Expiry(), exactExpiry)
+}
+
+func (s *ClientOperationSuite) TestCannotExpireLeaseBeforeExpiry(c *gc.C) {
+	fix := s.EasyFixture(c)
+	leaseDuration := time.Minute
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// It can't be expired until after the duration has elapsed.
+	fix.Clock.Advance(leaseDuration)
+	err = fix.Client.ExpireLease("name")
+	c.Assert(err, gc.Equals, lease.ErrInvalid)
+}
+
+func (s *ClientOperationSuite) TestExpireLeaseAfterExpiry(c *gc.C) {
+	fix := s.EasyFixture(c)
+	leaseDuration := time.Minute
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// It can be expired as soon as the duration has elapsed.
+	fix.Clock.Advance(leaseDuration + time.Nanosecond)
+	err = fix.Client.ExpireLease("name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check("name", fix.Holder(), "")
+}
+
+func (s *ClientOperationSuite) TestCannotExpireUnheldLease(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ExpireLease("name")
+	c.Assert(err, gc.Equals, lease.ErrInvalid)
+}

--- a/state/lease/client_persistence_test.go
+++ b/state/lease/client_persistence_test.go
@@ -1,0 +1,160 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/state/lease"
+)
+
+// ClientPersistenceSuite checks that the operations really affect the DB in
+// the expected way.
+type ClientPersistenceSuite struct {
+	FixtureSuite
+}
+
+var _ = gc.Suite(&ClientPersistenceSuite{})
+
+func (s *ClientPersistenceSuite) TestNewClientInvalidClockDoc(c *gc.C) {
+	config := lease.ClientConfig{
+		Id:         "client",
+		Namespace:  "namespace",
+		Collection: "collection",
+		Mongo:      NewMongo(s.db),
+		Clock:      lease.SystemClock{},
+	}
+	dbKey := "clock#namespace#"
+	err := s.db.C("collection").Insert(bson.M{"_id": dbKey})
+	c.Assert(err, jc.ErrorIsNil)
+
+	client, err := lease.NewClient(config)
+	c.Check(client, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, `corrupt clock document: invalid type ""`)
+}
+
+func (s *ClientPersistenceSuite) TestNewClientInvalidLeaseDoc(c *gc.C) {
+	config := lease.ClientConfig{
+		Id:         "client",
+		Namespace:  "namespace",
+		Collection: "collection",
+		Mongo:      NewMongo(s.db),
+		Clock:      lease.SystemClock{},
+	}
+	err := s.db.C("collection").Insert(bson.M{
+		"_id":       "snagglepuss",
+		"type":      "lease",
+		"namespace": "namespace",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	client, err := lease.NewClient(config)
+	c.Check(client, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, `corrupt lease document "snagglepuss": inconsistent _id`)
+}
+
+func (s *ClientPersistenceSuite) TestNewClientMissingClockDoc(c *gc.C) {
+	// The database starts out empty, so just creating the fixture is enough
+	// to test this code path.
+	s.EasyFixture(c)
+}
+
+func (s *ClientPersistenceSuite) TestNewClientExtantClockDoc(c *gc.C) {
+	// Empty database: new Client creates clock doc.
+	s.EasyFixture(c)
+
+	// Clock doc exists; new Client created successfully.
+	s.EasyFixture(c)
+}
+
+func (s *ClientPersistenceSuite) TestClaimLease(c *gc.C) {
+	fix1 := s.EasyFixture(c)
+	leaseDuration := time.Minute
+	err := fix1.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Same client id, same clock, new instance: sees exact same lease.
+	fix2 := s.EasyFixture(c)
+	c.Check("name", fix2.Holder(), "holder")
+	exactExpiry := fix1.Zero.Add(leaseDuration)
+	c.Check("name", fix2.Expiry(), exactExpiry)
+}
+
+func (s *ClientPersistenceSuite) TestExtendLease(c *gc.C) {
+	fix1 := s.EasyFixture(c)
+	err := fix1.Client.ClaimLease("name", lease.Request{"holder", time.Second})
+	c.Assert(err, jc.ErrorIsNil)
+	leaseDuration := time.Minute
+	err = fix1.Client.ExtendLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Same client id, same clock, new instance: sees exact same lease.
+	fix2 := s.EasyFixture(c)
+	c.Check("name", fix2.Holder(), "holder")
+	exactExpiry := fix1.Zero.Add(leaseDuration)
+	c.Check("name", fix2.Expiry(), exactExpiry)
+}
+
+func (s *ClientPersistenceSuite) TestExpireLease(c *gc.C) {
+	fix1 := s.EasyFixture(c)
+	leaseDuration := time.Minute
+	err := fix1.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+	fix1.Clock.Advance(leaseDuration + time.Nanosecond)
+	err = fix1.Client.ExpireLease("name")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Same client id, same clock, new instance: sees no lease.
+	fix2 := s.EasyFixture(c)
+	c.Check("name", fix2.Holder(), "")
+}
+
+func (s *ClientPersistenceSuite) TestNamespaceIsolation(c *gc.C) {
+	fix1 := s.EasyFixture(c)
+	leaseDuration := time.Minute
+	err := fix1.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Same client id, same clock, different namespace: sees no lease.
+	fix2 := s.NewFixture(c, FixtureParams{
+		Namespace: "different-namespace",
+	})
+	c.Check("name", fix2.Holder(), "")
+}
+
+func (s *ClientPersistenceSuite) TestTimezoneChanges(c *gc.C) {
+	fix1 := s.EasyFixture(c)
+	leaseDuration := time.Minute
+	err := fix1.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Same client can come up in a different timezone and still work correctly.
+	fix2 := s.NewFixture(c, FixtureParams{
+		ClockStart: fix1.Zero.In(time.FixedZone("somewhere", -1234)),
+	})
+	c.Check("name", fix2.Holder(), "holder")
+	exactExpiry := fix2.Zero.Add(leaseDuration)
+	c.Check("name", fix2.Expiry(), exactExpiry)
+}
+
+func (s *ClientPersistenceSuite) TestTimezoneIsolation(c *gc.C) {
+	fix1 := s.EasyFixture(c)
+	leaseDuration := time.Minute
+	err := fix1.Client.ClaimLease("name", lease.Request{"holder", leaseDuration})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Different client *and* different timezone; but clock agrees perfectly,
+	// so we still see no skew.
+	fix2 := s.NewFixture(c, FixtureParams{
+		Id:         "remote-client",
+		ClockStart: fix1.Zero.UTC(),
+	})
+	c.Check("name", fix2.Holder(), "holder")
+	exactExpiry := fix1.Zero.Add(leaseDuration).UTC()
+	c.Check("name", fix2.Expiry(), exactExpiry)
+}

--- a/state/lease/client_race_test.go
+++ b/state/lease/client_race_test.go
@@ -1,0 +1,301 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	jujutxn "github.com/juju/txn"
+	txntesting "github.com/juju/txn/testing"
+	gc "gopkg.in/check.v1"
+	_ "gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/state/lease"
+)
+
+// ClientSimpleRaceSuite tests what happens when two clients interfere with
+// each other when creating clients and/or leases.
+type ClientSimpleRaceSuite struct {
+	FixtureSuite
+}
+
+var _ = gc.Suite(&ClientSimpleRaceSuite{})
+
+func (s *ClientSimpleRaceSuite) TestNewClient_WorksDespite_CreateClockRace(c *gc.C) {
+	config := func(id string) lease.ClientConfig {
+		return lease.ClientConfig{
+			Id:         id,
+			Namespace:  "ns",
+			Collection: "leases",
+			Mongo:      NewMongo(s.db),
+			Clock:      lease.SystemClock{},
+		}
+	}
+	sutConfig := config("sut")
+	sutRunner := sutConfig.Mongo.(*Mongo).runner
+
+	// Set up a hook to create the clock doc (and write some important data to
+	// it)  by creating another client before the SUT gets a chance.
+	defer txntesting.SetBeforeHooks(c, sutRunner, func() {
+		client, err := lease.NewClient(config("blocker"))
+		c.Check(err, jc.ErrorIsNil)
+		err = client.ClaimLease("somewhere", lease.Request{"someone", time.Minute})
+		c.Check(err, jc.ErrorIsNil)
+	})()
+
+	// Create a client against an apparently-empty namespace.
+	client, err := lease.NewClient(sutConfig)
+	c.Check(err, jc.ErrorIsNil)
+
+	// Despite the scramble, it's generated with recent lease data and no error.
+	leases := client.Leases()
+	info, found := leases["somewhere"]
+	c.Check(found, jc.IsTrue)
+	c.Check(info.Holder, gc.Equals, "someone")
+}
+
+func (s *ClientSimpleRaceSuite) TestClaimLease_BlockedBy_ClaimLease(c *gc.C) {
+	sut := s.EasyFixture(c)
+	blocker := s.NewFixture(c, FixtureParams{Id: "blocker"})
+
+	// Set up a hook to grab the lease "name" just before the next txn runs.
+	defer txntesting.SetBeforeHooks(c, sut.Runner, func() {
+		err := blocker.Client.ClaimLease("name", lease.Request{"ha-haa", time.Minute})
+		c.Check(err, jc.ErrorIsNil)
+	})()
+
+	// Try to grab the lease "name", and fail.
+	err := sut.Client.ClaimLease("name", lease.Request{"trying", time.Second})
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+
+	// The client that failed has refreshed state (as it had to, in order
+	// to discover the reason for the invalidity).
+	c.Check("name", sut.Holder(), "ha-haa")
+	c.Check("name", sut.Expiry(), sut.Zero.Add(time.Minute))
+}
+
+func (s *ClientSimpleRaceSuite) TestClaimLease_Pathological(c *gc.C) {
+	sut := s.EasyFixture(c)
+	blocker := s.NewFixture(c, FixtureParams{Id: "blocker"})
+
+	// Set up hooks to claim a lease just before every transaction, but remove
+	// it again before the SUT goes and looks to figure out what it should do.
+	interfere := jujutxn.TestHook{
+		Before: func() {
+			err := blocker.Client.ClaimLease("name", lease.Request{"ha-haa", time.Second})
+			c.Check(err, jc.ErrorIsNil)
+		},
+		After: func() {
+			blocker.Clock.Advance(time.Minute)
+			err := blocker.Client.ExpireLease("name")
+			c.Check(err, jc.ErrorIsNil)
+		},
+	}
+	defer txntesting.SetTestHooks(
+		c, sut.Runner,
+		interfere, interfere, interfere,
+	)()
+
+	// Try to claim, and watch the poor thing collapse in exhaustion.
+	err := sut.Client.ClaimLease("name", lease.Request{"trying", time.Minute})
+	c.Check(err, gc.ErrorMatches, "state changing too quickly; try again soon")
+}
+
+// ClientTrickyRaceSuite tests what happens when two clients interfere with
+// each other when extending and/or expiring leases.
+type ClientTrickyRaceSuite struct {
+	FixtureSuite
+	sut     *Fixture
+	blocker *Fixture
+}
+
+var _ = gc.Suite(&ClientTrickyRaceSuite{})
+
+func (s *ClientTrickyRaceSuite) SetUpTest(c *gc.C) {
+	s.FixtureSuite.SetUpTest(c)
+	s.sut = s.EasyFixture(c)
+	err := s.sut.Client.ClaimLease("name", lease.Request{"holder", time.Minute})
+	c.Assert(err, jc.ErrorIsNil)
+	s.blocker = s.NewFixture(c, FixtureParams{Id: "blocker"})
+}
+
+func (s *ClientTrickyRaceSuite) TestExtendLease_WorksDespite_ShorterExtendLease(c *gc.C) {
+
+	shorterRequest := 90 * time.Second
+	longerRequest := 120 * time.Second
+
+	// Set up hooks to extend the lease by a little, before the SUT's extend
+	// gets a chance; and then to verify state after it's applied its retry.
+	defer txntesting.SetRetryHooks(c, s.sut.Runner, func() {
+		err := s.blocker.Client.ExtendLease("name", lease.Request{"holder", shorterRequest})
+		c.Check(err, jc.ErrorIsNil)
+	}, func() {
+		err := s.blocker.Client.Refresh()
+		c.Check(err, jc.ErrorIsNil)
+		c.Check("name", s.blocker.Expiry(), s.blocker.Zero.Add(longerRequest))
+	})()
+
+	// Extend the lease.
+	err := s.sut.Client.ExtendLease("name", lease.Request{"holder", longerRequest})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *ClientTrickyRaceSuite) TestExtendLease_WorksDespite_LongerExtendLease(c *gc.C) {
+
+	shorterRequest := 90 * time.Second
+	longerRequest := 120 * time.Second
+
+	// Set up hooks to extend the lease by a lot, before the SUT's extend can.
+	defer txntesting.SetBeforeHooks(c, s.sut.Runner, func() {
+		err := s.blocker.Client.ExtendLease("name", lease.Request{"holder", longerRequest})
+		c.Check(err, jc.ErrorIsNil)
+	})()
+
+	// Extend the lease by a little.
+	err := s.sut.Client.ExtendLease("name", lease.Request{"holder", shorterRequest})
+	c.Check(err, jc.ErrorIsNil)
+
+	// The SUT was refreshed, and knows that the lease is really valid for longer.
+	c.Check("name", s.sut.Expiry(), s.sut.Zero.Add(longerRequest))
+}
+
+func (s *ClientTrickyRaceSuite) TestExtendLease_BlockedBy_ExpireLease(c *gc.C) {
+
+	// Set up a hook to expire the lease before the extend gets a chance.
+	defer txntesting.SetBeforeHooks(c, s.sut.Runner, func() {
+		s.blocker.Clock.Advance(90 * time.Second)
+		err := s.blocker.Client.ExpireLease("name")
+		c.Check(err, jc.ErrorIsNil)
+	})()
+
+	// Try to extend; check it aborts.
+	err := s.sut.Client.ExtendLease("name", lease.Request{"holder", 2 * time.Minute})
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+
+	// The SUT has been refreshed, and you can see why the operation was invalid.
+	c.Check("name", s.sut.Holder(), "")
+}
+
+func (s *ClientTrickyRaceSuite) TestExtendLease_BlockedBy_ExpireThenReclaimDifferentHolder(c *gc.C) {
+
+	// Set up a hook to expire and reclaim the lease before the extend gets a
+	// chance.
+	defer txntesting.SetBeforeHooks(c, s.sut.Runner, func() {
+		s.blocker.Clock.Advance(90 * time.Second)
+		err := s.blocker.Client.ExpireLease("name")
+		c.Check(err, jc.ErrorIsNil)
+		err = s.blocker.Client.ClaimLease("name", lease.Request{"different-holder", time.Minute})
+		c.Check(err, jc.ErrorIsNil)
+	})()
+
+	// Try to extend; check it aborts.
+	err := s.sut.Client.ExtendLease("name", lease.Request{"holder", 2 * time.Minute})
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+
+	// The SUT has been refreshed, and you can see why the operation was invalid.
+	c.Check("name", s.sut.Holder(), "different-holder")
+}
+
+func (s *ClientTrickyRaceSuite) TestExtendLease_WorksDespite_ExpireThenReclaimSameHolder(c *gc.C) {
+
+	// Set up hooks to expire and reclaim the lease before the extend gets a
+	// chance; and to verify that the second attempt successfully extends.
+	defer txntesting.SetRetryHooks(c, s.sut.Runner, func() {
+		s.blocker.Clock.Advance(90 * time.Second)
+		err := s.blocker.Client.ExpireLease("name")
+		c.Check(err, jc.ErrorIsNil)
+		err = s.blocker.Client.ClaimLease("name", lease.Request{"holder", time.Minute})
+		c.Check(err, jc.ErrorIsNil)
+	}, func() {
+		err := s.blocker.Client.Refresh()
+		c.Check(err, jc.ErrorIsNil)
+		c.Check("name", s.blocker.Expiry(), s.blocker.Zero.Add(5*time.Minute))
+	})()
+
+	// Try to extend; check it worked.
+	err := s.sut.Client.ExtendLease("name", lease.Request{"holder", 5 * time.Minute})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *ClientTrickyRaceSuite) TestExtendLease_Pathological(c *gc.C) {
+
+	// Set up hooks to remove the lease just before every transaction, but
+	// replace it before the SUT goes and looks to figure out what it should do.
+	interfere := jujutxn.TestHook{
+		Before: func() {
+			s.blocker.Clock.Advance(time.Minute + time.Second)
+			err := s.blocker.Client.ExpireLease("name")
+			c.Check(err, jc.ErrorIsNil)
+		},
+		After: func() {
+			err := s.blocker.Client.ClaimLease("name", lease.Request{"holder", time.Second})
+			c.Check(err, jc.ErrorIsNil)
+		},
+	}
+	defer txntesting.SetTestHooks(
+		c, s.sut.Runner,
+		interfere, interfere, interfere,
+	)()
+
+	// Try to extend, and watch the poor thing collapse in exhaustion.
+	err := s.sut.Client.ExtendLease("name", lease.Request{"holder", time.Minute})
+	c.Check(err, gc.ErrorMatches, "state changing too quickly; try again soon")
+}
+
+func (s *ClientTrickyRaceSuite) TestExpireLease_BlockedBy_ExtendLease(c *gc.C) {
+
+	// Set up a hook to extend the lease before the expire gets a chance.
+	defer txntesting.SetBeforeHooks(c, s.sut.Runner, func() {
+		s.blocker.Clock.Advance(90 * time.Second)
+		err := s.blocker.Client.ExtendLease("name", lease.Request{"holder", 30 * time.Second})
+		c.Check(err, jc.ErrorIsNil)
+	})()
+
+	// Try to expire; check it aborts.
+	s.sut.Clock.Advance(90 * time.Second)
+	err := s.sut.Client.ExpireLease("name")
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+
+	// The SUT has been refreshed, and you can see why the operation was invalid.
+	c.Check("name", s.sut.Expiry(), s.sut.Zero.Add(2*time.Minute))
+}
+
+func (s *ClientTrickyRaceSuite) TestExpireLease_BlockedBy_ExpireLease(c *gc.C) {
+
+	// Set up a hook to expire the lease before the SUT gets a chance.
+	defer txntesting.SetBeforeHooks(c, s.sut.Runner, func() {
+		s.blocker.Clock.Advance(90 * time.Second)
+		err := s.blocker.Client.ExpireLease("name")
+		c.Check(err, jc.ErrorIsNil)
+	})()
+
+	// Try to expire; check it aborts.
+	s.sut.Clock.Advance(90 * time.Second)
+	err := s.sut.Client.ExpireLease("name")
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+
+	// The SUT has been refreshed, and you can see why the operation was invalid.
+	c.Check("name", s.sut.Holder(), "")
+}
+
+func (s *ClientTrickyRaceSuite) TestExpireLease_BlockedBy_ExpireThenReclaim(c *gc.C) {
+
+	// Set up a hook to expire the lease and then reclaim it.
+	defer txntesting.SetBeforeHooks(c, s.sut.Runner, func() {
+		s.blocker.Clock.Advance(90 * time.Second)
+		err := s.blocker.Client.ExpireLease("name")
+		c.Check(err, jc.ErrorIsNil)
+		err = s.blocker.Client.ClaimLease("name", lease.Request{"holder", time.Minute})
+		c.Check(err, jc.ErrorIsNil)
+	})()
+
+	// Try to expire; check it aborts.
+	s.sut.Clock.Advance(90 * time.Second)
+	err := s.sut.Client.ExpireLease("name")
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+
+	// The SUT has been refreshed, and you can see why the operation was invalid.
+	c.Check("name", s.sut.Expiry(), s.sut.Zero.Add(150*time.Second))
+}

--- a/state/lease/client_remote_test.go
+++ b/state/lease/client_remote_test.go
@@ -1,0 +1,102 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/lease"
+)
+
+// ClientRemoteSuite checks that clients do not break one another's promises.
+type ClientRemoteSuite struct {
+	FixtureSuite
+	lease    time.Duration
+	offset   time.Duration
+	readTime time.Duration
+	baseline *Fixture
+	skewed   *Fixture
+}
+
+var _ = gc.Suite(&ClientRemoteSuite{})
+
+func (s *ClientRemoteSuite) SetUpTest(c *gc.C) {
+	s.FixtureSuite.SetUpTest(c)
+
+	s.lease = time.Minute
+	s.offset = time.Second
+	s.readTime = 100 * time.Millisecond
+
+	s.baseline = s.EasyFixture(c)
+	err := s.baseline.Client.ClaimLease("name", lease.Request{"holder", s.lease})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Remote client, possibly reading in the future and possibly just ahead
+	// by a second, taking 100ms to read the clock doc; sees same lease with
+	// suitable uncertainty.
+	s.skewed = s.NewFixture(c, FixtureParams{
+		Id:         "remote-client",
+		ClockStart: s.baseline.Zero.Add(s.offset),
+		ClockStep:  s.readTime,
+	})
+	// We don't really want the clock to keep going outside our control here.
+	s.skewed.Clock.step = 0
+}
+
+func (s *ClientRemoteSuite) guaranteedUntil() time.Time {
+	return s.baseline.Zero.Add(s.lease + s.offset)
+}
+
+func (s *ClientRemoteSuite) latestValid() time.Time {
+	return s.guaranteedUntil().Add(s.readTime)
+}
+
+func (s *ClientRemoteSuite) TestReadSkew(c *gc.C) {
+	c.Check("name", s.skewed.Holder(), "holder")
+	c.Check("name", s.skewed.Expiry(), s.latestValid())
+}
+
+func (s *ClientRemoteSuite) TestExtendRemoteLeaseNoop(c *gc.C) {
+	err := s.skewed.Client.ExtendLease("name", lease.Request{"holder", 10 * time.Second})
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check("name", s.skewed.Holder(), "holder")
+	c.Check("name", s.skewed.Expiry(), s.latestValid())
+}
+
+func (s *ClientRemoteSuite) TestExtendRemoteLeaseSimpleExtend(c *gc.C) {
+	leaseDuration := 10 * time.Minute
+	err := s.skewed.Client.ExtendLease("name", lease.Request{"holder", leaseDuration})
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check("name", s.skewed.Holder(), "holder")
+	expectExpiry := s.skewed.Clock.Now().Add(leaseDuration)
+	c.Check("name", s.skewed.Expiry(), expectExpiry)
+}
+
+func (s *ClientRemoteSuite) TestExtendRemoteLeasePaddedExtend(c *gc.C) {
+	needsPadding := s.lease - s.readTime
+	err := s.skewed.Client.ExtendLease("name", lease.Request{"holder", needsPadding})
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check("name", s.skewed.Holder(), "holder")
+	c.Check("name", s.skewed.Expiry(), s.latestValid())
+}
+
+func (s *ClientRemoteSuite) TestCannotExpireRemoteLeaseEarly(c *gc.C) {
+	s.skewed.Clock.Reset(s.latestValid(), 0)
+	err := s.skewed.Client.ExpireLease("name")
+	c.Check(err, gc.Equals, lease.ErrInvalid)
+}
+
+func (s *ClientRemoteSuite) TestCanExpireRemoteLease(c *gc.C) {
+	s.skewed.Clock.Reset(s.latestValid().Add(time.Nanosecond), 0)
+	err := s.skewed.Client.ExpireLease("name")
+	c.Check(err, jc.ErrorIsNil)
+}
+
+// ------------------------------------

--- a/state/lease/client_validation_test.go
+++ b/state/lease/client_validation_test.go
@@ -1,0 +1,96 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/lease"
+)
+
+// ClientValidationSuite sends bad data into all of Client's methods.
+type ClientValidationSuite struct {
+	FixtureSuite
+}
+
+var _ = gc.Suite(&ClientValidationSuite{})
+
+func (s *ClientValidationSuite) TestNewClientId(c *gc.C) {
+	fix := s.EasyFixture(c)
+	fix.Config.Id = "$bad"
+	_, err := lease.NewClient(fix.Config)
+	c.Check(err, gc.ErrorMatches, "invalid id: string contains forbidden characters")
+}
+
+func (s *ClientValidationSuite) TestNewClientNamespace(c *gc.C) {
+	fix := s.EasyFixture(c)
+	fix.Config.Namespace = "$bad"
+	_, err := lease.NewClient(fix.Config)
+	c.Check(err, gc.ErrorMatches, "invalid namespace: string contains forbidden characters")
+}
+
+func (s *ClientValidationSuite) TestNewClientCollection(c *gc.C) {
+	fix := s.EasyFixture(c)
+	fix.Config.Collection = "$bad"
+	_, err := lease.NewClient(fix.Config)
+	c.Check(err, gc.ErrorMatches, "invalid collection: string contains forbidden characters")
+}
+
+func (s *ClientValidationSuite) TestNewClientMongo(c *gc.C) {
+	fix := s.EasyFixture(c)
+	fix.Config.Mongo = nil
+	_, err := lease.NewClient(fix.Config)
+	c.Check(err, gc.ErrorMatches, "missing mongo")
+}
+
+func (s *ClientValidationSuite) TestNewClientClock(c *gc.C) {
+	fix := s.EasyFixture(c)
+	fix.Config.Clock = nil
+	_, err := lease.NewClient(fix.Config)
+	c.Check(err, gc.ErrorMatches, "missing clock")
+}
+
+func (s *ClientValidationSuite) TestClaimLeaseName(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ClaimLease("$name", lease.Request{"holder", time.Minute})
+	c.Check(err, gc.ErrorMatches, "invalid name: string contains forbidden characters")
+}
+
+func (s *ClientValidationSuite) TestClaimLeaseHolder(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ClaimLease("name", lease.Request{"$holder", time.Minute})
+	c.Check(err, gc.ErrorMatches, "invalid request: invalid holder: string contains forbidden characters")
+}
+
+func (s *ClientValidationSuite) TestClaimLeaseDuration(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ClaimLease("name", lease.Request{"holder", 0})
+	c.Check(err, gc.ErrorMatches, "invalid request: invalid duration")
+}
+
+func (s *ClientValidationSuite) TestExtendLeaseName(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ExtendLease("$name", lease.Request{"holder", time.Minute})
+	c.Check(err, gc.ErrorMatches, "invalid name: string contains forbidden characters")
+}
+
+func (s *ClientValidationSuite) TestExtendLeaseHolder(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ExtendLease("name", lease.Request{"$holder", time.Minute})
+	c.Check(err, gc.ErrorMatches, "invalid request: invalid holder: string contains forbidden characters")
+}
+
+func (s *ClientValidationSuite) TestExtendLeaseDuration(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ExtendLease("name", lease.Request{"holder", 0})
+	c.Check(err, gc.ErrorMatches, "invalid request: invalid duration")
+}
+
+func (s *ClientValidationSuite) TestExpireLeaseName(c *gc.C) {
+	fix := s.EasyFixture(c)
+	err := fix.Client.ExpireLease("$name")
+	c.Check(err, gc.ErrorMatches, "invalid name: string contains forbidden characters")
+}

--- a/state/lease/clock.go
+++ b/state/lease/clock.go
@@ -1,0 +1,22 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+import (
+	"time"
+)
+
+// SystemClock exposes wall-clock time as returned by time.Now.
+type SystemClock struct{}
+
+// Now is part of the Clock interface.
+func (SystemClock) Now() time.Time {
+	return time.Now()
+}
+
+// Alarm returns a channel that will send a value at some point after
+// the supplied time.
+func (clock SystemClock) Alarm(t time.Time) <-chan time.Time {
+	return time.After(t.Sub(clock.Now()))
+}

--- a/state/lease/config.go
+++ b/state/lease/config.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jujutxn "github.com/juju/txn"
+
+	"github.com/juju/juju/mongo"
+)
+
+// Mongo exposes MongoDB operations for use by the lease package.
+type Mongo interface {
+
+	// RunTransaction should probably delegate to a jujutxn.Runner's Run method.
+	RunTransaction(jujutxn.TransactionSource) error
+
+	// GetCollection should probably call the mongo.CollectionFromName func.
+	GetCollection(name string) (collection mongo.Collection, closer func())
+}
+
+// Clock exposes wall-clock time for use by the lease package.
+type Clock interface {
+
+	// Now returns the current wall-clock time.
+	Now() time.Time
+}
+
+// ClientConfig contains the resources and information required to create
+// a Client. Multiple clients can collaborate if they share a collection and
+// namespace, so long as they do not share ids; but within a collection,
+// clients for different namespaces will not interfere with one another,
+// regardlless of id.
+type ClientConfig struct {
+
+	// Id uniquely identifies the client. Multiple clients with the same id
+	// running concurrently will cause undefined behaviour.
+	Id string
+
+	// Namespace identifies a group of clients which operate on the same data.
+	Namespace string
+
+	// Collection names the MongoDB collection in which lease data is stored.
+	Collection string
+
+	// Mongo exposes the mgo[/txn] capabilities required by a Client.
+	Mongo Mongo
+
+	// Clock exposes the wall-clock time to a Client.
+	Clock Clock
+}
+
+// Validate returns an error if the supplied config is not valid.
+func (config ClientConfig) Validate() error {
+	if err := validateString(config.Id); err != nil {
+		return errors.Annotatef(err, "invalid id")
+	}
+	if err := validateString(config.Namespace); err != nil {
+		return errors.Annotatef(err, "invalid namespace")
+	}
+	if err := validateString(config.Collection); err != nil {
+		return errors.Annotatef(err, "invalid collection")
+	}
+	if config.Mongo == nil {
+		return errors.New("missing mongo")
+	}
+	if config.Clock == nil {
+		return errors.New("missing clock")
+	}
+	return nil
+}
+
+// SystemClock exposes wall-clock time as returned by time.Now.
+type SystemClock struct{}
+
+// Now is part of the Clock interface.
+func (SystemClock) Now() time.Time {
+	return time.Now()
+}

--- a/state/lease/config.go
+++ b/state/lease/config.go
@@ -22,18 +22,22 @@ type Mongo interface {
 	GetCollection(name string) (collection mongo.Collection, closer func())
 }
 
-// Clock exposes wall-clock time for use by the lease package.
+// Clock exposes wall-clock time for use by and with the lease package.
 type Clock interface {
 
 	// Now returns the current wall-clock time.
 	Now() time.Time
+
+	// Alarm returns a channel that will have the time sent on it at some point
+	// after the supplied time occurs.
+	Alarm(time.Time) <-chan time.Time
 }
 
 // ClientConfig contains the resources and information required to create
 // a Client. Multiple clients can collaborate if they share a collection and
 // namespace, so long as they do not share ids; but within a collection,
 // clients for different namespaces will not interfere with one another,
-// regardlless of id.
+// regardless of id.
 type ClientConfig struct {
 
 	// Id uniquely identifies the client. Multiple clients with the same id
@@ -71,12 +75,4 @@ func (config ClientConfig) Validate() error {
 		return errors.New("missing clock")
 	}
 	return nil
-}
-
-// SystemClock exposes wall-clock time as returned by time.Now.
-type SystemClock struct{}
-
-// Now is part of the Clock interface.
-func (SystemClock) Now() time.Time {
-	return time.Now()
 }

--- a/state/lease/doc.go
+++ b/state/lease/doc.go
@@ -1,0 +1,117 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+/*
+
+The lease package exists to implement distributed lease management on top of
+mgo/txn, and to expose assert operations that allow us to gate other mgo/txn
+transactions on lease state. This necessity has affected the package; but,
+apart from leaking assertion operations, it functions as a distributed lease-
+management system with various useful properties.
+
+These properties of course rest upon assumptions; ensuring the validity of the
+following statements is the job of the client.
+
+  * The lease package has exclusive access to any collection it's configured
+    to use. (Please don't store anything else in there.)
+
+  * Given any (collection,namespace) pair, any client Id will be unique at any
+    given point in time. (Run no more than one per namespace per server, and
+    identify them according to where they're running).
+
+  * Time passes at approximately the same rate for all clients. (Note that
+    the clients do *not* have to agree what time it is, or what time zone
+    anyone is in: just that 1s == 1s. This is likely to be true already if
+    you use lease.SystemClock{}.)
+
+So long as the above holds true, the following statements will too:
+
+  * A successful ClaimLease guarantees lease ownership until *at least* the
+    requested duration after the start of the call. (It does *not* guaranntee
+    any sort of timely expiry.)
+
+  * A successful ExtendLease makes the same guarantees. (In particular, note
+    that this cannot cause a lease to be shortened; but that success may
+    indicate ownership is guaranteed for longer than requested.)
+
+  * ExpireLease will only succeed when the most recent writer of the lease is
+    known to believe the time is after the expiry time it wrote.
+
+
+Remarks on clock skew
+---------------------
+
+When expiring a lease (or determining whether it needs to be extended) we only
+need to care about the writer, because everybody else is determining their own
+skew relative only to the writer. That is, assuming 3 clients:
+
+ A) knows "the real time"; wrote a lease at 01:00:00, expiring at 01:00:30A
+ B) is 20 seconds ahead; read the lease between 01:00:23B and 01:00:24B
+ C) is 5 seconds behind; read the lease between 00:59:57C and 00:59:58C
+
+...then B cannot infer an expiry time earlier than 01:00:54L (=01:00:34A) and
+C cannot infer an expiry time earlier than 01:00:28C (=01:00:33A). If A fails
+to expire its lease, then C will trigger first and try to expire it, and most
+likely succeed; and when C succeeds, B's subsequent attempt to expire the
+lease will certainly fail, because C has updated both the clock document and
+the lease document and invalidated B's assertions.
+
+So B can and does then Refresh; and sees the lease document written by C, and
+now needs only to consider its offset relative to C in order to Do The Right
+Thing.
+
+
+Schema design
+-------------
+
+For each namespace, we store a single clock document; and one additional
+document per lease. The lease document holds the name, holder, expiry, and
+writer of the lease; the clock document contains the most recent time
+acknowledged by each client that has written to the namespace.
+
+Every transaction that the lease package makes is gated on a write to the
+clock document (which *must* precede any lease operations) which acks a
+recent time and fails if it appears to be going backward in time (this could
+happen if we crashed at the wrong moment and left a transaction queued but
+unprepared for some time: we definitely don't want to accept those operations).
+
+The fact that the clock document is involved in every transaction renders it a
+per-namespace bottleneck, but the ability to discard outdated transactions is
+valuable; and the centralised record of acknowledged times mitigates the impact
+of client failure.
+
+That is to say: assuming client C wrote lease L at time T, and wrote lease M
+at time U (later than T); and then failed; then a fresh client D will be able
+to expire lease L earlier (by U-T) than it could infer with the information in
+lease L alone.
+
+(We could ofc still calculate that by storing a written time in each lease
+document, but it'd be more hassle to collate the data, harder to inspect the
+database, and would only be able to make much weaker anti-time-travel promises
+than we can manage with the clock doc.)
+
+
+Client usage considerations
+---------------------------
+
+  * Client operates at a relatively low level of abstraction. Claiming a held
+    lease will fail, even on behalf of the holder; expiring an expired lease
+    will fail; but at least we can allow lease extensions to race benignly,
+    because they don't involve ownership change and thus can't break promises
+    (so long as our skew logic is correct).
+
+  * ErrInvalid is normal and expected; you should never pass that on to your
+    own clients, because it indicates that you tried to manipulate the client
+    in an impossible way. You can and should inspect Leases() and figure out
+    what to do instead; that may well be "return an error", but please be sure
+    to return your own error, suitable for your own level of abstraction.
+
+  * You *probably* shouldn't ever need to actually call Refresh. It's perfectly
+    safe to let state drift arbitrarily far out of sync; when you try to run
+    operations, you will either succeed by luck despite your aged cache... or,
+    if you fail, you'll get ErrInvalid and a fresh cache to inspect to find out
+    recent state.
+
+
+*/
+package lease

--- a/state/lease/fixture_test.go
+++ b/state/lease/fixture_test.go
@@ -1,0 +1,191 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"fmt"
+	"time"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	jujutxn "github.com/juju/txn"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/state/lease"
+)
+
+var (
+	defaultClient     = "default-client"
+	defaultNamespace  = "default-namespace"
+	defaultCollection = "default-collection"
+	defaultClockStart time.Time
+)
+
+func init() {
+	// We pick a time with a comfortable h:m:s component but:
+	//  (1) past the int32 unix epoch limit;
+	//  (2) at a 5ns offset to make sure we're not discarding precision;
+	//  (3) in a weird time zone.
+	value := "2073-03-03T01:00:00.000000005-08:40"
+	var err error
+	defaultClockStart, err = time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type FixtureParams struct {
+	Id         string
+	Namespace  string
+	Collection string
+	ClockStart time.Time
+	ClockStep  time.Duration
+}
+
+// Fixture collects together a running client and a bunch of useful data.
+type Fixture struct {
+	Client lease.Client
+	Config lease.ClientConfig
+	Runner jujutxn.Runner
+	Clock  *Clock
+	Zero   time.Time
+}
+
+func NewFixture(c *gc.C, database *mgo.Database, params FixtureParams) *Fixture {
+	mongo := NewMongo(database)
+	clockStart := params.ClockStart
+	if clockStart.IsZero() {
+		clockStart = defaultClockStart
+	}
+	clock := NewClock(clockStart, params.ClockStep)
+	config := lease.ClientConfig{
+		Id:         or(params.Id, "default-client"),
+		Namespace:  or(params.Namespace, "default-namespace"),
+		Collection: or(params.Collection, "default-collection"),
+		Mongo:      mongo,
+		Clock:      clock,
+	}
+	client, err := lease.NewClient(config)
+	c.Assert(err, jc.ErrorIsNil)
+	return &Fixture{
+		Client: client,
+		Config: config,
+		Runner: mongo.runner,
+		Clock:  clock,
+		Zero:   clockStart,
+	}
+}
+
+func or(u, v string) string {
+	if u != "" {
+		return u
+	}
+	return v
+}
+
+func (fix *Fixture) badge() string {
+	return fmt.Sprintf("%s %s", fix.Config.Id, fix.Config.Namespace)
+}
+
+func (fix *Fixture) Holder() gc.Checker {
+	return &callbackChecker{
+		CheckerInfo: &gc.CheckerInfo{
+			Name:   fmt.Sprintf("Holder[%s]", fix.badge()),
+			Params: []string{"name", "holder"},
+		},
+		callback: fix.infoChecker(checkHolder),
+	}
+}
+
+func (fix *Fixture) Expiry() gc.Checker {
+	return &callbackChecker{
+		CheckerInfo: &gc.CheckerInfo{
+			Name:   fmt.Sprintf("Expiry[%s]", fix.badge()),
+			Params: []string{"name", "expiry"},
+		},
+		callback: fix.infoChecker(checkExpiry),
+	}
+}
+
+func (fix *Fixture) infoChecker(checkInfo checkInfoFunc) checkFunc {
+
+	return func(params []interface{}, names []string) (result bool, error string) {
+		defer func() {
+			if v := recover(); v != nil {
+				result = false
+				error = fmt.Sprint(v)
+			}
+		}()
+		name := params[0].(string)
+		info := fix.Client.Leases()[name]
+		return checkInfo(info, params[1])
+	}
+}
+
+type callbackChecker struct {
+	*gc.CheckerInfo
+	callback checkFunc
+}
+
+func (c *callbackChecker) Check(params []interface{}, names []string) (bool, string) {
+	return c.callback(params, names)
+}
+
+type checkFunc func(params []interface{}, names []string) (bool, string)
+
+type checkInfoFunc func(info lease.Info, param interface{}) (bool, string)
+
+func checkHolder(info lease.Info, holder interface{}) (bool, string) {
+	actual := info.Holder
+	expect := holder.(string)
+	if actual == expect {
+		return true, ""
+	}
+	return false, fmt.Sprintf("lease held by %q; expected %q", actual, expect)
+}
+
+func checkExpiry(info lease.Info, expiry interface{}) (bool, string) {
+	actual := info.Expiry
+	expect := expiry.(time.Time)
+	if actual.Equal(expect) {
+		return true, ""
+	}
+	return false, fmt.Sprintf("expiry is %s; expected %s", actual, expect)
+}
+
+type FixtureSuite struct {
+	jujutesting.IsolationSuite
+	jujutesting.MgoSuite
+	db *mgo.Database
+}
+
+func (s *FixtureSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+	s.MgoSuite.SetUpSuite(c)
+}
+
+func (s *FixtureSuite) TearDownSuite(c *gc.C) {
+	s.MgoSuite.TearDownSuite(c)
+	s.IsolationSuite.TearDownSuite(c)
+}
+
+func (s *FixtureSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.MgoSuite.SetUpTest(c)
+	s.db = s.Session.DB("juju")
+}
+
+func (s *FixtureSuite) TearDownTest(c *gc.C) {
+	s.MgoSuite.TearDownTest(c)
+	s.IsolationSuite.TearDownTest(c)
+}
+
+func (s *FixtureSuite) NewFixture(c *gc.C, fp FixtureParams) *Fixture {
+	return NewFixture(c, s.db, fp)
+}
+
+func (s *FixtureSuite) EasyFixture(c *gc.C) *Fixture {
+	return s.NewFixture(c, FixtureParams{})
+}

--- a/state/lease/interface.go
+++ b/state/lease/interface.go
@@ -1,0 +1,86 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// Client manipulates leases backed by MongoDB. Client implementations are not
+// expected to be goroutine-safe.
+type Client interface {
+
+	// ClaimLease records the supplied holder's claim to the supplied lease. If
+	// it succeeds, the claim is guaranteed until at least the supplied duration
+	// after the call to ClaimLease was initiated. If it returns ErrInvalid,
+	// check Leases() for updated state.
+	ClaimLease(lease string, request Request) error
+
+	// ExtendLease records the supplied holder's continued claim to the supplied
+	// lease, if necessary. If it succeeds, the claim is guaranteed until at
+	// least the supplied duration after the call to ExtendLease was initiated.
+	// If it returns ErrInvalid, check Leases() for updated state.
+	ExtendLease(lease string, request Request) error
+
+	// ExpireLease records the vacation of the supplied lease. It will fail if
+	// we cannot verify that the lease's writer considers the expiry time to
+	// have passed. If it returns ErrInvalid, check Leases() for updated state.
+	ExpireLease(lease string) error
+
+	// Leases returns a recent snapshot of lease state. Expiry times are
+	// expressed according to the Clock the client was configured with.
+	Leases() map[string]Info
+
+	// Refresh reads all lease state from the database.
+	Refresh() error
+}
+
+// Info holds information about a lease. It's MongoDB-specific, because it
+// includes information that can be used with the mgo/txn package to gate
+// transaction operations on lease state.
+type Info struct {
+
+	// Holder is the name of the current leaseholder.
+	Holder string
+
+	// Expiry is the latest time at which it's possible the lease might still
+	// be valid. Attempting to expire the lease before this time will fail.
+	Expiry time.Time
+
+	// AssertOp, if included in a mgo/txn transaction, will gate the transaction
+	// on the lease remaining held by Holder. If we didn't need this, we could
+	// easily implement Clients backed by other substrates.
+	AssertOp txn.Op
+}
+
+// Request describes a lease request.
+type Request struct {
+
+	// Holder identifies the lease holder.
+	Holder string
+
+	// Duration specifies the time for which the lease is required.
+	Duration time.Duration
+}
+
+// Validate returns an error if any fields are invalid or inconsistent.
+func (request Request) Validate() error {
+	if err := validateString(request.Holder); err != nil {
+		return errors.Annotatef(err, "invalid holder")
+	}
+	if request.Duration <= 0 {
+		return errors.Errorf("invalid duration")
+	}
+	return nil
+}
+
+// ErrInvalid indicates that a client operation failed because latest state
+// indicates that it's a logical impossibility. It's a short-range signal to
+// calling code only; that code should never pass it on, but should inspect
+// the Client's updated Leases() and either attempt a new operation or return
+// a new error at a suitable level of abstraction.
+var ErrInvalid = errors.New("invalid lease operation")

--- a/state/lease/package_test.go
+++ b/state/lease/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	stdtesting "testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	coretesting.MgoTestPackage(t)
+}

--- a/state/lease/schema.go
+++ b/state/lease/schema.go
@@ -1,0 +1,213 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/juju/errors"
+)
+
+// These constants define the field names and type values used by documents in
+// a lease collection. They *must* remain in sync with the bson marshalling
+// annotations in leaseDoc and clockDoc.
+const (
+	// fieldType and fieldNamespace identify the Type and Namespace fields in
+	// both leaseDoc and clockDoc.
+	fieldType      = "type"
+	fieldNamespace = "namespace"
+
+	// typeLease and typeClock are the acceptable values for fieldType.
+	typeLease = "lease"
+	typeClock = "clock"
+
+	// fieldLease* identify the fields in a leaseDoc.
+	fieldLeaseName   = "name"
+	fieldLeaseHolder = "holder"
+	fieldLeaseExpiry = "expiry"
+	fieldLeaseWriter = "writer"
+
+	// fieldClock* identify the fields in a clockDoc.
+	fieldClockWriters = "writers"
+)
+
+// toInt64 converts a local time.Time into a database value that doesn't
+// silently lose precision.
+func toInt64(t time.Time) int64 {
+	return t.UnixNano()
+}
+
+// toTime converts a toInt64 result, as loaded from the db, back to a time.Time.
+func toTime(v int64) time.Time {
+	return time.Unix(0, v)
+}
+
+// For simplicity's sake, we impose the same restrictions on all strings used
+// with the lease package: they may not be empty, and none of the following
+// characters are allowed.
+//   * '.' and '$' mean things to mongodb; we don't want to risk seeing them
+//     in key names.
+//   * '#' means something to the lease package and we don't want to risk
+//     confusing ourselves.
+//   * whitespace just seems like a bad idea.
+const badCharacters = ".$# \t\r\n"
+
+// validateString returns an error if the string is not valid.
+func validateString(s string) error {
+	if s == "" {
+		return errors.New("string is empty")
+	}
+	if strings.ContainsAny(s, badCharacters) {
+		return errors.New("string contains forbidden characters")
+	}
+	return nil
+}
+
+// leaseDocId returns the _id for the document holding details of the supplied
+// namespace and lease.
+func leaseDocId(namespace, lease string) string {
+	return fmt.Sprintf("%s#%s#%s#", typeLease, namespace, lease)
+}
+
+// leaseDoc is used to serialise lease entries.
+type leaseDoc struct {
+	// Id is always "<Type>#<Namespace>#<Name>#", and <Type> is always "lease",
+	// so that we can extract useful information from a stream of watcher events
+	// without incurring extra DB hits.
+	// Apart from checking validity on load, though, there's little reason
+	// to use Id elsewhere; Namespace and Name are the sources of truth.
+	Id        string `bson:"_id"`
+	Type      string `bson:"type"`      // TODO(fwereade) add index
+	Namespace string `bson:"namespace"` // TODO(fwereade) add index
+	Name      string `bson:"name"`
+
+	// Holder, Expiry, and Writer map directly to entry.
+	Holder string `bson:"holder"`
+	Expiry int64  `bson:"expiry"`
+	Writer string `bson:"writer"`
+}
+
+// validate returns an error if any fields are invalid or inconsistent.
+func (doc leaseDoc) validate() error {
+	if doc.Type != typeLease {
+		return errors.Errorf("invalid type %q", doc.Type)
+	}
+	if doc.Id != leaseDocId(doc.Namespace, doc.Name) {
+		return errors.Errorf("inconsistent _id")
+	}
+	if err := validateString(doc.Holder); err != nil {
+		return errors.Annotatef(err, "invalid holder")
+	}
+	if doc.Expiry == 0 {
+		return errors.Errorf("invalid expiry")
+	}
+	if err := validateString(doc.Writer); err != nil {
+		return errors.Annotatef(err, "invalid writer")
+	}
+	return nil
+}
+
+// entry returns the lease name and an entry corresponding to the document. If
+// the document cannot be validated, it returns an error.
+func (doc leaseDoc) entry() (string, entry, error) {
+	if err := doc.validate(); err != nil {
+		return "", entry{}, errors.Trace(err)
+	}
+	entry := entry{
+		holder: doc.Holder,
+		expiry: toTime(doc.Expiry),
+		writer: doc.Writer,
+	}
+	return doc.Name, entry, nil
+}
+
+// newLeaseDoc returns a valid lease document encoding the supplied lease and
+// entry in the supplied namespace, or an error.
+func newLeaseDoc(namespace, name string, entry entry) (*leaseDoc, error) {
+	doc := &leaseDoc{
+		Id:        leaseDocId(namespace, name),
+		Type:      typeLease,
+		Namespace: namespace,
+		Name:      name,
+		Holder:    entry.holder,
+		Expiry:    toInt64(entry.expiry),
+		Writer:    entry.writer,
+	}
+	if err := doc.validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return doc, nil
+}
+
+// clockDocId returns the _id for the document holding clock skew information
+// for clients that have written in the supplied namespace.
+func clockDocId(namespace string) string {
+	return fmt.Sprintf("%s#%s#", typeClock, namespace)
+}
+
+// clockDoc is used to synchronise clients.
+type clockDoc struct {
+	// Id is always "<Type>#<Namespace>#", and <Type> is always "clock", for
+	// consistency with leaseDoc and ease of querying within the collection.
+	Id        string `bson:"_id"`
+	Type      string `bson:"type"`
+	Namespace string `bson:"namespace"`
+
+	// Writers holds a the latest acknowledged time for every known client.
+	Writers map[string]int64 `bson:"writers"`
+}
+
+// validate returns an error if any fields are invalid or inconsistent.
+func (doc clockDoc) validate() error {
+	if doc.Type != typeClock {
+		return errors.Errorf("invalid type %q", doc.Type)
+	}
+	if doc.Id != clockDocId(doc.Namespace) {
+		return errors.Errorf("inconsistent _id")
+	}
+	for writer, written := range doc.Writers {
+		if written == 0 {
+			return errors.Errorf("invalid time for writer %q", writer)
+		}
+	}
+	return nil
+}
+
+// skews returns clock skew information for all writers recorded in the
+// document, given that the document was read between the supplied local
+// times. It will return an error if the clock document is not valid, or
+// if the times don't make sense.
+func (doc clockDoc) skews(readAfter, readBefore time.Time) (map[string]Skew, error) {
+	if err := doc.validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if readBefore.Before(readAfter) {
+		return nil, errors.New("end of read window preceded beginning")
+	}
+	skews := make(map[string]Skew)
+	for writer, written := range doc.Writers {
+		skews[writer] = Skew{
+			LastWrite:  toTime(written),
+			ReadAfter:  readAfter,
+			ReadBefore: readBefore,
+		}
+	}
+	return skews, nil
+}
+
+// newClockDoc returns an empty clockDoc for the supplied namespace.
+func newClockDoc(namespace string) (clockDoc, error) {
+	doc := clockDoc{
+		Id:        clockDocId(namespace),
+		Type:      typeClock,
+		Namespace: namespace,
+		Writers:   make(map[string]int64),
+	}
+	if err := doc.validate(); err != nil {
+		return clockDoc{}, errors.Trace(err)
+	}
+	return doc, nil
+}

--- a/state/lease/skew.go
+++ b/state/lease/skew.go
@@ -1,0 +1,50 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+import (
+	"time"
+)
+
+// Skew holds information about a remote writer's idea of the current time.
+type Skew struct {
+
+	// LastWrite is the most recent remote time known to have been written
+	// by the skewed writer.
+	LastWrite time.Time
+
+	// ReadAfter should be the latest known local time before LastWrite
+	// was read.
+	ReadAfter time.Time
+
+	// ReadBefore should be the earliest known local time after LastWrite
+	// was read.
+	ReadBefore time.Time
+}
+
+// Earliest returns the earliest local time after which we can be confident
+// that the remote writer will agree the supplied time is in the past.
+func (skew Skew) Earliest(remote time.Time) (local time.Time) {
+	if skew.isZero() {
+		return remote
+	}
+	delta := remote.Sub(skew.LastWrite)
+	return skew.ReadAfter.Add(delta)
+}
+
+// Latest returns the latest local time after which we can be confident that
+// the remote writer will agree the supplied time is in the past.
+func (skew Skew) Latest(remote time.Time) (local time.Time) {
+	if skew.isZero() {
+		return remote
+	}
+	delta := remote.Sub(skew.LastWrite)
+	return skew.ReadBefore.Add(delta)
+}
+
+// isZero lets us shortcut Earliest and Latest when the skew represents a
+// perfect unskewed clock (such as for a local writer).
+func (skew Skew) isZero() bool {
+	return skew.LastWrite.IsZero() && skew.ReadAfter.IsZero() && skew.ReadBefore.IsZero()
+}

--- a/state/lease/skew_test.go
+++ b/state/lease/skew_test.go
@@ -1,0 +1,162 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/lease"
+)
+
+type SkewSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&SkewSuite{})
+
+func (s *SkewSuite) TestZero(c *gc.C) {
+	now := time.Now()
+
+	// The zero Skew should act as unskewed.
+	skew := lease.Skew{}
+
+	c.Check(skew.Earliest(now), gc.Equals, now)
+	c.Check(skew.Latest(now), gc.Equals, now)
+}
+
+func (s *SkewSuite) TestApparentPastWrite(c *gc.C) {
+	now := time.Now()
+	c.Logf("now: %s", now)
+	oneSecondAgo := now.Add(-time.Second)
+	threeSecondsAgo := now.Add(-3 * time.Second)
+	nineSecondsAgo := now.Add(-9 * time.Second)
+	sixSecondsLater := now.Add(6 * time.Second)
+	eightSecondsLater := now.Add(8 * time.Second)
+
+	// Where T is the current local time:
+	// between T-3 and T-1, we read T-9 from the remote clock.
+	skew := lease.Skew{
+		LastWrite:  nineSecondsAgo,
+		ReadAfter:  threeSecondsAgo,
+		ReadBefore: oneSecondAgo,
+	}
+
+	// If the remote wrote a long time ago -- say, 20 minutes ago it thought it
+	// was 9 seconds ago -- its clock could be arbitrarily far ahead of ours.
+	// But we know that when we started reading, 3 seconds ago, it might not
+	// have seen a time later than 9 seconds ago; so right now, three seconds
+	// after that, it might not have seen a time later than 6 seconds ago.
+	c.Check(skew.Earliest(now), gc.DeepEquals, sixSecondsLater)
+
+	// If the remote wrote at the very last moment -- exactly one second ago,
+	// it thought it was nine seconds ago -- it could have a clock a full 8
+	// seconds behind ours. If so, the *latest* time at which it *might* still
+	// think it's before now is 8 seconds in the future.
+	c.Check(skew.Latest(now), gc.DeepEquals, eightSecondsLater)
+}
+
+func (s *SkewSuite) TestApparentFutureWrite(c *gc.C) {
+	now := time.Now()
+	c.Logf("now: %s", now)
+	oneSecondAgo := now.Add(-time.Second)
+	threeSecondsAgo := now.Add(-3 * time.Second)
+	tenSecondsAgo := now.Add(-10 * time.Second)
+	twelveSecondsAgo := now.Add(-12 * time.Second)
+	nineSecondsLater := now.Add(9 * time.Second)
+
+	// Where T is the current local time:
+	// between T-3 and T-1, we read T+9 from the remote clock.
+	skew := lease.Skew{
+		LastWrite:  nineSecondsLater,
+		ReadAfter:  threeSecondsAgo,
+		ReadBefore: oneSecondAgo,
+	}
+
+	// If the remote wrote a long time ago -- say, 20 minutes ago it thought
+	// it was nine seconds after now -- its clock could be arbitrarily far
+	// ahead of ours. But we know that when we started reading, 3 seconds ago,
+	// it might not have seen a time later than 9 seconds in the future; so
+	// right now, three seconds after that, it might not have seen a time later
+	// than twelve seconds in the future.
+	c.Check(skew.Earliest(now), gc.DeepEquals, twelveSecondsAgo)
+
+	// If the remote wrote at the very last moment -- exactly one second ago,
+	// it thought it was 9 seconds in the future -- it could have a clock a
+	// full 10 seconds ahead of ours. If so, the *latest* time at which it
+	// might still have thought it was before now is ten seconds in the past.
+	c.Check(skew.Latest(now), gc.DeepEquals, tenSecondsAgo)
+}
+
+func (s *SkewSuite) TestBracketedWrite(c *gc.C) {
+	now := time.Now()
+	c.Logf("now: %s", now)
+	oneSecondAgo := now.Add(-time.Second)
+	twoSecondsAgo := now.Add(-2 * time.Second)
+	threeSecondsAgo := now.Add(-3 * time.Second)
+	fiveSecondsAgo := now.Add(-5 * time.Second)
+	oneSecondLater := now.Add(time.Second)
+
+	// Where T is the current local time:
+	// between T-5 and T-1, we read T-2 from the remote clock.
+	skew := lease.Skew{
+		LastWrite:  twoSecondsAgo,
+		ReadAfter:  fiveSecondsAgo,
+		ReadBefore: oneSecondAgo,
+	}
+
+	// If the remote wrote a long time ago -- say, 20 minutes ago it thought
+	// it was two seconds before now -- its clock could be arbitrarily far
+	// ahead of ours. But we know that when we started reading, 5 seconds ago,
+	// it might not have seen a time later than 2 seconds in the past; so
+	// right now, five seconds after that, it might not have seen a time later
+	// than three seconds in the future.
+	c.Check(skew.Earliest(now), gc.DeepEquals, threeSecondsAgo)
+
+	// If the remote wrote at the very last moment -- exactly one second ago,
+	// it thought it was 2 seconds in the past -- it could have a clock one
+	// second behind ours. If so, the *latest* time at which it might still
+	// have thought it was before now is one second in the future.
+	c.Check(skew.Latest(now), gc.DeepEquals, oneSecondLater)
+}
+
+func (s *SkewSuite) TestMixedTimezones(c *gc.C) {
+	here := time.FixedZone("here", -3600)
+	there := time.FixedZone("there", -7200)
+	elsewhere := time.FixedZone("elsewhere", -10800)
+
+	// This is a straight copy of TestBracketedWrite, with strange timezones
+	// inserted to check that they don't affect the results at all.
+	now := time.Now()
+	c.Logf("now: %s", now)
+	oneSecondAgo := now.Add(-time.Second)
+	twoSecondsAgo := now.Add(-2 * time.Second)
+	threeSecondsAgo := now.Add(-3 * time.Second)
+	fiveSecondsAgo := now.Add(-5 * time.Second)
+	oneSecondLater := now.Add(time.Second)
+
+	// Where T is the current local time:
+	// between T-5 and T-1, we read T-2 from the remote clock.
+	skew := lease.Skew{
+		LastWrite:  twoSecondsAgo.In(here),
+		ReadAfter:  fiveSecondsAgo.In(there),
+		ReadBefore: oneSecondAgo.In(elsewhere),
+	}
+
+	// If the remote wrote a long time ago -- say, 20 minutes ago it thought
+	// it was two seconds before now -- its clock could be arbitrarily far
+	// ahead of ours. But we know that when we started reading, 5 seconds ago,
+	// it might not have seen a time later than 2 seconds in the past; so
+	// right now, five seconds after that, it might not have seen a time later
+	// than three seconds in the future.
+	c.Check(skew.Earliest(now), gc.DeepEquals, threeSecondsAgo.In(there))
+
+	// If the remote wrote at the very last moment -- exactly one second ago,
+	// it thought it was 2 seconds in the past -- it could have a clock one
+	// second behind ours. If so, the *latest* time at which it might still
+	// have thought it was before now is one second in the future.
+	c.Check(skew.Latest(now), gc.DeepEquals, oneSecondLater.In(elsewhere))
+}

--- a/state/lease/util_test.go
+++ b/state/lease/util_test.go
@@ -10,11 +10,15 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state/lease"
 )
 
 // Clock exposes time via Now, and can be controlled via Reset and Advance. It
-// can be configured to Advance automatically whenever Now is called.
+// can be configured to Advance automatically whenever Now is called. Attempts
+// to call Alarm will panic: they're not useful to a lease.Client itself, but
+// are extremely helpful when driving one.
 type Clock struct {
+	lease.Clock
 	now  time.Time
 	step time.Duration
 }
@@ -22,7 +26,7 @@ type Clock struct {
 // NewClock returns a *Clock, set to now, that advances by step whenever Now()
 // is called.
 func NewClock(now time.Time, step time.Duration) *Clock {
-	return &Clock{now, step}
+	return &Clock{now: now, step: step}
 }
 
 // Now is part of the lease.Clock interface.

--- a/state/lease/util_test.go
+++ b/state/lease/util_test.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease_test
+
+import (
+	"time"
+
+	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/mongo"
+)
+
+// Clock exposes time via Now, and can be controlled via Reset and Advance. It
+// can be configured to Advance automatically whenever Now is called.
+type Clock struct {
+	now  time.Time
+	step time.Duration
+}
+
+// NewClock returns a *Clock, set to now, that advances by step whenever Now()
+// is called.
+func NewClock(now time.Time, step time.Duration) *Clock {
+	return &Clock{now, step}
+}
+
+// Now is part of the lease.Clock interface.
+func (clock *Clock) Now() time.Time {
+	defer clock.Advance(clock.step)
+	return clock.now
+}
+
+// Reset causes the clock to act as though it had just been created with
+// NewClock(now, step).
+func (clock *Clock) Reset(now time.Time, step time.Duration) {
+	clock.now = now
+}
+
+// Advance advances the clock by the supplied time.
+func (clock *Clock) Advance(duration time.Duration) {
+	clock.now = clock.now.Add(duration)
+}
+
+// Mongo exposes database operations. It uses a real database -- we can't mock
+// mongo out, we need to check it really actually works -- but it's good to
+// have the runner accessible for adversarial transaction tests.
+type Mongo struct {
+	database *mgo.Database
+	runner   jujutxn.Runner
+}
+
+// NewMongo returns a *Mongo backed by the supplied database.
+func NewMongo(database *mgo.Database) *Mongo {
+	return &Mongo{
+		database: database,
+		runner: jujutxn.NewRunner(jujutxn.RunnerParams{
+			Database: database,
+		}),
+	}
+}
+
+// GetCollection is part of the lease.Mongo interface.
+func (m *Mongo) GetCollection(name string) (mongo.Collection, func()) {
+	return mongo.CollectionFromName(m.database, name)
+}
+
+// RunTransaction is part of the lease.Mongo interface.
+func (m *Mongo) RunTransaction(getTxn jujutxn.TransactionSource) error {
+	return m.runner.Run(getTxn)
+}

--- a/state/lease_test.go
+++ b/state/lease_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/lease"
+	"github.com/juju/juju/mongo"
 )
 
 const (
@@ -35,12 +36,16 @@ func stubRunTransaction(txns jujutxn.TransactionSource) error {
 	return nil
 }
 
-func stubGetCollection(collectionName string) (stateCollection, func()) {
+func stubGetCollection(collectionName string) (mongo.Collection, func()) {
 	return &genericStateCollection{}, func() {}
 }
 
+type genericStateCollection struct {
+	mongo.Collection
+}
+
 type stubLeaseCollection struct {
-	stateCollection
+	mongo.Collection
 	tokenToReturn *leaseEntity
 }
 
@@ -155,7 +160,7 @@ func (s *leaseSuite) TestRemoveToken(c *gc.C) {
 func (s *leaseSuite) TestPersistedTokens(c *gc.C) {
 
 	closerCallCount := 0
-	stubGetCollection := func(collectionName string) (stateCollection, func()) {
+	stubGetCollection := func(collectionName string) (mongo.Collection, func()) {
 		c.Check(collectionName, gc.Equals, testCollectionName)
 		return &genericStateCollection{}, func() { closerCallCount++ }
 	}

--- a/state/life.go
+++ b/state/life.go
@@ -3,7 +3,11 @@
 
 package state
 
-import "gopkg.in/mgo.v2/bson"
+import (
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/mongo"
+)
 
 // Life represents the lifecycle state of the entities
 // Relation, Unit, Service and Machine.
@@ -54,7 +58,7 @@ func isAlive(st *State, collName string, id interface{}) (bool, error) {
 	return isAliveWithSession(coll, id)
 }
 
-func isAliveWithSession(coll stateCollection, id interface{}) (bool, error) {
+func isAliveWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 	n, err := coll.Find(bson.D{{"_id", id}, {"life", Alive}}).Count()
 	return n == 1, err
 }
@@ -65,7 +69,7 @@ func isNotDead(st *State, collName string, id interface{}) (bool, error) {
 	return isNotDeadWithSession(coll, id)
 }
 
-func isNotDeadWithSession(coll stateCollection, id interface{}) (bool, error) {
+func isNotDeadWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 	n, err := coll.Find(bson.D{{"_id", id}, {"life", bson.D{{"$ne", Dead}}}}).Count()
 	return n == 1, err
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -344,7 +344,7 @@ func (m *Machine) SetMongoPassword(password string) error {
 	if !m.IsManager() {
 		return errors.NotSupportedf("setting mongo password for non-state server machine %v", m)
 	}
-	return mongo.SetAdminMongoPassword(m.st.db.Session, m.Tag().String(), password)
+	return mongo.SetAdminMongoPassword(m.st.session, m.Tag().String(), password)
 }
 
 // SetPassword sets the password for the machine's agent.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -593,9 +593,16 @@ func (s *MachineSuite) TestTag(c *gc.C) {
 
 func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 	info := testing.NewMongoInfo()
-	st, err := state.Open(info, testing.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.envTag, info, testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
-	defer st.Close()
+	defer func() {
+		// Remove the admin password so that the test harness can reset the state.
+		err := st.SetAdminMongoPassword("")
+		c.Check(err, jc.ErrorIsNil)
+		err = st.Close()
+		c.Check(err, jc.ErrorIsNil)
+	}()
+
 	// Turn on fully-authenticated mode.
 	err = st.SetAdminMongoPassword("admin-secret")
 	c.Assert(err, jc.ErrorIsNil)
@@ -611,12 +618,13 @@ func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 	// Check that we cannot log in with the wrong password.
 	info.Tag = ent.Tag()
 	info.Password = "bar"
-	err = tryOpenState(info)
-	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
+	err = tryOpenState(s.envTag, info)
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsUnauthorized)
+	c.Check(err, gc.ErrorMatches, `cannot log in to admin database as "machine-0": unauthorized mongo access: .*`)
 
 	// Check that we can log in with the correct password.
 	info.Password = "foo"
-	st1, err := state.Open(info, testing.NewDialOpts(), state.Policy(nil))
+	st1, err := state.Open(s.envTag, info, testing.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 
@@ -629,21 +637,18 @@ func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 
 	// Check that we cannot log in with the old password.
 	info.Password = "foo"
-	err = tryOpenState(info)
-	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
+	err = tryOpenState(s.envTag, info)
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsUnauthorized)
+	c.Check(err, gc.ErrorMatches, `cannot log in to admin database as "machine-0": unauthorized mongo access: .*`)
 
 	// Check that we can log in with the correct password.
 	info.Password = "bar"
-	err = tryOpenState(info)
+	err = tryOpenState(s.envTag, info)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that the administrator can still log in.
 	info.Tag, info.Password = nil, "admin-secret"
-	err = tryOpenState(info)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Remove the admin password so that the test harness can reset the state.
-	err = st.SetAdminMongoPassword("")
+	err = tryOpenState(s.envTag, info)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1358,7 +1363,7 @@ func (s *MachineSuite) TestWatchDiesOnStateClose(c *gc.C) {
 	//  Unit.Watch
 	//  State.WatchForEnvironConfigChanges
 	//  Unit.WatchConfigSettings
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		m, err := st.Machine(s.machine.Id())
 		c.Assert(err, jc.ErrorIsNil)
 		w := m.Watch()
@@ -1466,7 +1471,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 func (s *MachineSuite) TestWatchPrincipalUnitsDiesOnStateClose(c *gc.C) {
 	// This test is testing logic in watcher.unitsWatcher, which
 	// is also used by Unit.WatchSubordinateUnits.
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		m, err := st.Machine(s.machine.Id())
 		c.Assert(err, jc.ErrorIsNil)
 		w := m.WatchPrincipalUnits()
@@ -1570,7 +1575,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 }
 
 func (s *MachineSuite) TestWatchUnitsDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		m, err := st.Machine(s.machine.Id())
 		c.Assert(err, jc.ErrorIsNil)
 		w := m.WatchUnits()
@@ -2445,7 +2450,7 @@ func (s *MachineSuite) TestWatchInterfaces(c *gc.C) {
 }
 
 func (s *MachineSuite) TestWatchInterfacesDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		m, err := st.Machine(s.machine.Id())
 		c.Assert(err, jc.ErrorIsNil)
 		w := m.WatchInterfaces()

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -944,7 +944,7 @@ func (b *allWatcherStateBacking) GetAll(all *multiwatcherStore) error {
 		if c.subsidiary {
 			continue
 		}
-		col := newStateCollection(db.C(c.Name), envUUID)
+		col := getCollectionFromDB(db, c.Name, envUUID)
 		infoSlicePtr := reflect.New(reflect.SliceOf(c.infoType))
 		if err := col.Find(nil).All(infoSlicePtr.Interface()); err != nil {
 			return fmt.Errorf("cannot get all %s: %v", c.Name, err)

--- a/state/megawatcher_internal_test.go
+++ b/state/megawatcher_internal_test.go
@@ -51,17 +51,17 @@ type storeManagerStateSuite struct {
 
 func (s *storeManagerStateSuite) SetUpTest(c *gc.C) {
 	s.internalStateSuite.SetUpTest(c)
-
 	s.OtherState = s.newState(c)
-	s.AddCleanup(func(*gc.C) { s.OtherState.Close() })
+	s.AddCleanup(func(c *gc.C) {
+		err := s.OtherState.Close()
+		c.Check(err, jc.ErrorIsNil)
+	})
 }
 
 func (s *storeManagerStateSuite) newState(c *gc.C) *State {
-	uuid, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
 	cfg := testing.CustomEnvironConfig(c, testing.Attrs{
 		"name": "newtestenv",
-		"uuid": uuid.String(),
+		"uuid": utils.MustNewUUID().String(),
 	})
 	_, st, err := s.state.NewEnvironment(cfg, s.owner)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/mongo.go
+++ b/state/mongo.go
@@ -1,0 +1,26 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	jujutxn "github.com/juju/txn"
+
+	"github.com/juju/juju/mongo"
+)
+
+// environMongo implements state/lease.Mongo to expose environ-filtered mongo
+// capabilities to the lease package.
+type environMongo struct {
+	state *State
+}
+
+// GetCollection is part of the lease.Mongo interface.
+func (m *environMongo) GetCollection(name string) (mongo.Collection, func()) {
+	return m.state.getCollection(name)
+}
+
+// RunTransaction is part of the lease.Mongo interface.
+func (m *environMongo) RunTransaction(buildTxn jujutxn.TransactionSource) error {
+	return m.state.run(buildTxn)
+}

--- a/state/open.go
+++ b/state/open.go
@@ -38,7 +38,12 @@ func Open(tag names.EnvironTag, info *mongo.MongoInfo, opts mongo.DialOpts, poli
 		}
 		return nil, errors.Annotatef(err, "cannot read environment %s", tag.Id())
 	}
-	st.startPresenceWatcher()
+
+	// State should only be Opened on behalf of a state server environ; all
+	// other *States should be created via ForEnviron.
+	if err := st.start(tag); err != nil {
+		return nil, errors.Trace(err)
+	}
 	return st, nil
 }
 
@@ -75,20 +80,21 @@ func open(tag names.EnvironTag, info *mongo.MongoInfo, opts mongo.DialOpts, poli
 // Initialize sets up an initial empty state and returns it.
 // This needs to be performed only once for the initial state server environment.
 // It returns unauthorizedError if access is unauthorized.
-func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (rst *State, err error) {
+func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (_ *State, err error) {
 	uuid, ok := cfg.UUID()
 	if !ok {
 		return nil, errors.Errorf("environment uuid was not supplied")
 	}
 	envTag := names.NewEnvironTag(uuid)
-
 	st, err := open(envTag, info, opts, policy)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	defer func() {
 		if err != nil {
-			st.Close()
+			if closeErr := st.Close(); closeErr != nil {
+				logger.Errorf("error closing state while aborting Initialize: %v", closeErr)
+			}
 		}
 	}()
 
@@ -100,11 +106,10 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 	} else if !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
-	logger.Infof("starting presence watcher")
-	st.startPresenceWatcher()
 
 	// When creating the state server environment, the new environment
 	// UUID is also used as the state server UUID.
+	logger.Infof("initializing state server environment %s", uuid)
 	ops, err := st.envSetupOps(cfg, uuid, uuid, owner)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -134,6 +139,9 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 	)
 
 	if err := st.runTransaction(ops); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := st.start(envTag); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return st, nil
@@ -190,6 +198,9 @@ func isUnauthorized(err error) bool {
 	return false
 }
 
+// newState creates an incomplete *State, with a configured watcher but no
+// pwatcher, leadershipManager, or serverTag. You must start() the returned
+// *State before it will function correctly.
 func newState(environTag names.EnvironTag, session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (_ *State, resultErr error) {
 	admin := session.DB("admin")
 	if mongoInfo.Tag != nil {
@@ -215,7 +226,6 @@ func newState(environTag names.EnvironTag, session *mgo.Session, mongoInfo *mong
 	// Create State.
 	st := &State{
 		environTag: environTag,
-		serverTag:  environTag,
 		mongoInfo:  mongoInfo,
 		session:    session,
 		database:   database,
@@ -238,31 +248,38 @@ func (st *State) CACert() string {
 
 func (st *State) Close() (err error) {
 	defer errors.DeferredAnnotatef(&err, "closing state failed")
-	err1 := st.watcher.Stop()
-	var err2 error
+
+	// TODO(fwereade): we have no defence against these components failing
+	// and leaving other parts of state going. They should be managed by a
+	// dependency.Engine (or perhaps worker.Runner).
+	var errs []error
+	handle := func(name string, err error) {
+		if err != nil {
+			errs = append(errs, errors.Annotatef(err, "error stopping %s", name))
+		}
+	}
+
+	handle("transaction watcher", st.watcher.Stop())
 	if st.pwatcher != nil {
-		err2 = st.pwatcher.Stop()
+		handle("presence watcher", st.pwatcher.Stop())
+	}
+	if st.leadershipManager != nil {
+		st.leadershipManager.Kill()
+		handle("leadership manager", st.leadershipManager.Wait())
 	}
 	st.mu.Lock()
-	var err3 error
 	if st.allManager != nil {
-		err3 = st.allManager.Stop()
+		handle("multiwatcher backing", st.allManager.Stop())
 	}
 	st.session.Close()
 	st.mu.Unlock()
-	var i int
-	for i, err = range []error{err1, err2, err3} {
-		if err != nil {
-			switch i {
-			case 0:
-				err = errors.Annotatef(err, "failed to stop state watcher")
-			case 1:
-				err = errors.Annotatef(err, "failed to stop presence watcher")
-			case 2:
-				err = errors.Annotatef(err, "failed to stop all manager")
-			}
-			return err
+
+	if len(errs) > 0 {
+		for _, err := range errs[1:] {
+			logger.Errorf("while closing state: %v", err)
 		}
+		return errs[0]
 	}
+	logger.Debugf("closed state without error")
 	return nil
 }

--- a/state/open.go
+++ b/state/open.go
@@ -27,32 +27,44 @@ import (
 // may be provided.
 //
 // Open returns unauthorizedError if access is unauthorized.
-func Open(info *mongo.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, error) {
-	st, err := open(info, opts, policy)
+func Open(tag names.EnvironTag, info *mongo.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, error) {
+	st, err := open(tag, info, opts, policy)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ssInfo, err := st.StateServerInfo()
-	if err != nil {
-		st.Close()
-		return nil, errors.Annotate(err, "could not access state server info")
+	if _, err := st.Environment(); err != nil {
+		if err := st.Close(); err != nil {
+			logger.Errorf("error closing state for unreadable environment %s: %v", tag.Id(), err)
+		}
+		return nil, errors.Annotatef(err, "cannot read environment %s", tag.Id())
 	}
-	st.environTag = ssInfo.EnvironmentTag
-	st.serverTag = ssInfo.EnvironmentTag
 	st.startPresenceWatcher()
 	return st, nil
 }
 
-func open(info *mongo.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, error) {
+func open(tag names.EnvironTag, info *mongo.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, error) {
 	logger.Infof("opening state, mongo addresses: %q; entity %v", info.Addrs, info.Tag)
 	logger.Debugf("dialing mongo")
 	session, err := mongo.DialWithInfo(info.Info, opts)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, maybeUnauthorized(err, "cannot connect to mongodb")
 	}
 	logger.Debugf("connection established")
 
-	st, err := newState(session, info, policy)
+	// In rare circumstances, we may be upgrading from pre-1.23, and not have the
+	// environment UUID available. In that case we need to infer what it might be;
+	// we depend on the assumption that this is the only circumstance in which
+	// the the UUID might not be known.
+	if tag.Id() == "" {
+		logger.Warningf("creating state without environment tag; inferring bootstrap environment")
+		ssInfo, err := readRawStateServerInfo(session)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		tag = ssInfo.EnvironmentTag
+	}
+
+	st, err := newState(tag, session, info, policy)
 	if err != nil {
 		session.Close()
 		return nil, errors.Trace(err)
@@ -64,7 +76,13 @@ func open(info *mongo.MongoInfo, opts mongo.DialOpts, policy Policy) (*State, er
 // This needs to be performed only once for the initial state server environment.
 // It returns unauthorizedError if access is unauthorized.
 func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (rst *State, err error) {
-	st, err := open(info, opts, policy)
+	uuid, ok := cfg.UUID()
+	if !ok {
+		return nil, errors.Errorf("environment uuid was not supplied")
+	}
+	envTag := names.NewEnvironTag(uuid)
+
+	st, err := open(envTag, info, opts, policy)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -73,13 +91,6 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 			st.Close()
 		}
 	}()
-	uuid, ok := cfg.UUID()
-	if !ok {
-		return nil, errors.Errorf("environment uuid was not supplied")
-	}
-	envTag := names.NewEnvironTag(uuid)
-	st.environTag = envTag
-	st.serverTag = envTag
 
 	// A valid environment is used as a signal that the
 	// state has already been initalized. If this is the case
@@ -149,47 +160,6 @@ func (st *State) envSetupOps(cfg *config.Config, envUUID, serverUUID string, own
 	return ops, nil
 }
 
-var indexes = []struct {
-	collection string
-	key        []string
-	unique     bool
-	sparse     bool
-}{
-
-	// Create an upgrade step to remove old indexes when editing or removing
-	// items from this slice.
-	{relationsC, []string{"env-uuid", "endpoints.relationname"}, false, false},
-	{relationsC, []string{"env-uuid", "endpoints.servicename"}, false, false},
-	{unitsC, []string{"env-uuid", "service"}, false, false},
-	{unitsC, []string{"env-uuid", "principal"}, false, false},
-	{unitsC, []string{"env-uuid", "machineid"}, false, false},
-	// TODO(thumper): schema change to remove this index.
-	{usersC, []string{"name"}, false, false},
-	{networksC, []string{"env-uuid", "providerid"}, true, false},
-	{networkInterfacesC, []string{"env-uuid", "interfacename", "machineid"}, true, false},
-	{networkInterfacesC, []string{"env-uuid", "macaddress", "networkname"}, true, false},
-	{networkInterfacesC, []string{"env-uuid", "networkname"}, false, false},
-	{networkInterfacesC, []string{"env-uuid", "machineid"}, false, false},
-	{blockDevicesC, []string{"env-uuid", "machineid"}, false, false},
-	{subnetsC, []string{"providerid"}, true, true},
-	{ipaddressesC, []string{"env-uuid", "state"}, false, false},
-	{ipaddressesC, []string{"env-uuid", "subnetid"}, false, false},
-	{storageInstancesC, []string{"env-uuid", "owner"}, false, false},
-	{storageAttachmentsC, []string{"env-uuid", "storageid"}, false, false},
-	{storageAttachmentsC, []string{"env-uuid", "unitid"}, false, false},
-	{volumesC, []string{"env-uuid", "storageid"}, false, false},
-	{filesystemsC, []string{"env-uuid", "storageid"}, false, false},
-	{statusesHistoryC, []string{"env-uuid", "entityid"}, false, false},
-}
-
-// The capped collection used for transaction logs defaults to 10MB.
-// It's tweaked in export_test.go to 1MB to avoid the overhead of
-// creating and deleting the large file repeatedly in tests.
-var (
-	txnLogSize      = 10000000
-	txnLogSizeTests = 1000000
-)
-
 func maybeUnauthorized(err error, msg string) error {
 	if err == nil {
 		return nil
@@ -197,7 +167,7 @@ func maybeUnauthorized(err error, msg string) error {
 	if isUnauthorized(err) {
 		return errors.Unauthorizedf("%s: unauthorized mongo access: %v", msg, err)
 	}
-	return errors.Annotatef(err, "%s: %v", msg, err)
+	return errors.Annotatef(err, msg)
 }
 
 func isUnauthorized(err error) bool {
@@ -205,20 +175,22 @@ func isUnauthorized(err error) bool {
 		return false
 	}
 	// Some unauthorized access errors have no error code,
-	// just a simple error string.
-	if strings.HasPrefix(err.Error(), "auth fail") {
-		return true
+	// just a simple error string; and some do have error codes
+	// but are not of consistent types (LastError/QueryError).
+	for _, prefix := range []string{"auth fail", "not authorized"} {
+		if strings.HasPrefix(err.Error(), prefix) {
+			return true
+		}
 	}
 	if err, ok := err.(*mgo.QueryError); ok {
 		return err.Code == 10057 ||
 			err.Message == "need to login" ||
-			err.Message == "unauthorized" ||
-			strings.HasPrefix(err.Message, "not authorized")
+			err.Message == "unauthorized"
 	}
 	return false
 }
 
-func newState(session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (_ *State, resultErr error) {
+func newState(environTag names.EnvironTag, session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (_ *State, resultErr error) {
 	admin := session.DB("admin")
 	if mongoInfo.Tag != nil {
 		if err := admin.Login(mongoInfo.Tag.String(), mongoInfo.Password); err != nil {
@@ -230,56 +202,28 @@ func newState(session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (
 		}
 	}
 
-	db := session.DB("juju")
-
-	// Create collections used to track client-side transactions (mgo/txn).
-	txnLog := db.C(txnLogC)
-	txnLogInfo := mgo.CollectionInfo{Capped: true, MaxBytes: txnLogSize}
-	err := txnLog.Create(&txnLogInfo)
-	if isCollectionExistsError(err) {
-		return nil, maybeUnauthorized(err, "cannot create transaction log collection")
+	// Set up database.
+	rawDB := session.DB(jujuDB)
+	database, err := allCollections().Load(rawDB, environTag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	txns := db.C(txnsC)
-	err = txns.Create(new(mgo.CollectionInfo))
-	if isCollectionExistsError(err) {
-		return nil, maybeUnauthorized(err, "cannot create transaction collection")
-	}
-
-	// Create and set up State.
-	st := &State{
-		mongoInfo: mongoInfo,
-		policy:    policy,
-		db:        db,
-		watcher:   watcher.New(txnLog),
-	}
-	defer func() {
-		if resultErr != nil {
-			if err := st.watcher.Stop(); err != nil {
-				logger.Errorf("failed to stop watcher: %v", err)
-			}
-		}
-	}()
-	st.LeasePersistor = NewLeasePersistor(leaseC, st.run, st.getCollection)
-
-	// Create DB indexes.
-	for _, item := range indexes {
-		index := mgo.Index{Key: item.key, Unique: item.unique, Sparse: item.sparse}
-		if err := db.C(item.collection).EnsureIndex(index); err != nil {
-			return nil, errors.Annotate(err, "cannot create database index")
-		}
-	}
-
 	if err := InitDbLogs(session); err != nil {
 		return nil, errors.Trace(err)
 	}
 
+	// Create State.
+	st := &State{
+		environTag: environTag,
+		serverTag:  environTag,
+		mongoInfo:  mongoInfo,
+		session:    session,
+		database:   database,
+		policy:     policy,
+		watcher:    watcher.New(rawDB.C(txnLogC)),
+	}
+	st.LeasePersistor = NewLeasePersistor(leaseC, st.run, st.getCollection)
 	return st, nil
-}
-
-func isCollectionExistsError(err error) bool {
-	// The lack of error code for this error was reported upstream:
-	//     https://jira.mongodb.org/browse/SERVER-6992
-	return err != nil && err.Error() != "collection already exists"
 }
 
 // MongoConnectionInfo returns information for connecting to mongo
@@ -304,8 +248,8 @@ func (st *State) Close() (err error) {
 	if st.allManager != nil {
 		err3 = st.allManager.Stop()
 	}
+	st.session.Close()
 	st.mu.Unlock()
-	st.db.Session.Close()
 	var i int
 	for i, err = range []error{err1, err2, err3} {
 		if err != nil {

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -71,8 +71,8 @@ var ErrCannotEnterScopeYet = stderrors.New("cannot enter scope yet: non-alive su
 func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	db, closer := ru.st.newDB()
 	defer closer()
-	envUUID := ru.st.EnvironUUID()
-	relationScopes := getCollectionFromDB(db, relationScopesC, envUUID)
+	relationScopes, closer := db.GetCollection(relationScopesC)
+	defer closer()
 
 	// Verify that the unit is not already in scope, and abort without error
 	// if it is.
@@ -108,7 +108,8 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	//   before we create the scope doc, because the existence of a scope doc
 	//   is considered to be a guarantee of the existence of a settings doc.
 	settingsChanged := func() (bool, error) { return false, nil }
-	settingsColl := getCollectionFromDB(db, settingsC, envUUID)
+	settingsColl, closer := db.GetCollection(settingsC)
+	defer closer()
 	if count, err := settingsColl.FindId(ruKey).Count(); err != nil {
 		return err
 	} else if count == 0 {
@@ -155,8 +156,10 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 		return nil
 	}
 
-	units := getCollectionFromDB(db, unitsC, envUUID)
-	relations := getCollectionFromDB(db, relationsC, envUUID)
+	units, closer := db.GetCollection(unitsC)
+	defer closer()
+	relations, closer := db.GetCollection(relationsC)
+	defer closer()
 
 	// The relation or unit might no longer be Alive. (Note that there is no
 	// need for additional checks if we're trying to create a subordinate

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -411,7 +411,7 @@ func (s *RelationUnitSuite) TestAliveRelationScope(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchWatchScopeDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		pr := NewPeerRelation(c, st, s.Owner)
 		w := pr.ru0.WatchScope()
 		<-w.Changes()

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -18,7 +18,9 @@ type sequenceDoc struct {
 }
 
 func (s *State) sequence(name string) (int, error) {
-	query := s.db.C(sequenceC).FindId(s.docID(name))
+	sequences, closer := s.getCollection(sequenceC)
+	defer closer()
+	query := sequences.FindId(name)
 	inc := mgo.Change{
 		Update: bson.M{
 			"$set": bson.M{

--- a/state/state.go
+++ b/state/state.go
@@ -555,17 +555,6 @@ func (st *State) SetEnvironConstraints(cons constraints.Value) error {
 	return writeConstraints(st, environGlobalKey, cons)
 }
 
-var ErrDead = fmt.Errorf("not found or dead")
-var errNotAlive = fmt.Errorf("not found or not alive")
-
-func onAbort(txnErr, err error) error {
-	if txnErr == txn.ErrAborted ||
-		errors.Cause(txnErr) == txn.ErrAborted {
-		return errors.Trace(err)
-	}
-	return errors.Trace(txnErr)
-}
-
 // AllMachines returns all machines in the environment
 // ordered by id.
 func (st *State) AllMachines() (machines []*Machine, err error) {
@@ -781,35 +770,28 @@ func (st *State) tagToCollectionAndId(tag names.Tag) (string, interface{}, error
 // AddCharm adds the ch charm with curl to the state.
 // On success the newly added charm state is returned.
 func (st *State) AddCharm(ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string) (stch *Charm, err error) {
-	// The charm may already exist in state as a placeholder, so we
-	// check for that situation and update the existing charm record
-	// if necessary, otherwise add a new record.
-	var existing charmDoc
 	charms, closer := st.getCollection(charmsC)
 	defer closer()
 
-	err = charms.Find(bson.D{{"_id", curl.String()}, {"placeholder", true}}).One(&existing)
-	if err == mgo.ErrNotFound {
-		cdoc := &charmDoc{
-			DocID:        st.docID(curl.String()),
-			URL:          curl,
-			EnvUUID:      st.EnvironTag().Id(),
-			Meta:         ch.Meta(),
-			Config:       ch.Config(),
-			Metrics:      ch.Metrics(),
-			Actions:      ch.Actions(),
-			BundleSha256: bundleSha256,
-			StoragePath:  storagePath,
+	query := charms.FindId(curl.String()).Select(bson.D{{"placeholder", 1}})
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		var placeholderDoc struct {
+			Placeholder bool `bson:"placeholder"`
 		}
-		err = charms.Insert(cdoc)
-		if err != nil {
-			return nil, errors.Annotatef(err, "cannot add charm %q", curl)
+		if err := query.One(&placeholderDoc); err == mgo.ErrNotFound {
+			return insertCharmOps(st, ch, curl, storagePath, bundleSha256)
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		} else if placeholderDoc.Placeholder {
+			return updateCharmOps(st, ch, curl, storagePath, bundleSha256, stillPlaceholder)
 		}
-		return newCharm(st, cdoc), nil
-	} else if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.AlreadyExistsf("charm %q", curl)
 	}
-	return st.updateCharmDoc(ch, curl, storagePath, bundleSha256, stillPlaceholder)
+	if err = st.run(buildTxn); err == nil {
+		return st.Charm(curl)
+	}
+	return nil, errors.Trace(err)
 }
 
 // AllCharms returns all charms in state.
@@ -920,20 +902,7 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenUrl *charm.URL,
 			chosenRevision = maxRevision + 1
 		}
 		chosenUrl = curl.WithRevision(chosenRevision)
-
-		uploadedCharm := &charmDoc{
-			DocID:         st.docID(chosenUrl.String()),
-			EnvUUID:       st.EnvironTag().Id(),
-			URL:           chosenUrl,
-			PendingUpload: true,
-		}
-		ops := []txn.Op{{
-			C:      charmsC,
-			Id:     uploadedCharm.DocID,
-			Assert: txn.DocMissing,
-			Insert: uploadedCharm,
-		}}
-		return ops, nil
+		return insertPendingCharmOps(st, chosenUrl)
 	}
 	if err = st.run(buildTxn); err == nil {
 		return chosenUrl, nil
@@ -944,7 +913,7 @@ func (st *State) PrepareLocalCharmUpload(curl *charm.URL) (chosenUrl *charm.URL,
 // PrepareStoreCharmUpload must be called before a charm store charm
 // is uploaded to the provider storage in order to create a charm
 // document in state. If a charm with the same URL is already in
-// state, it will be returned as a *state.Charm (is can be still
+// state, it will be returned as a *state.Charm (it can be still
 // pending or already uploaded). Otherwise, a new charm document is
 // added in state with just the given charm URL and
 // PendingUpload=true, which is then returned as a *state.Charm.
@@ -969,55 +938,28 @@ func (st *State) PrepareStoreCharmUpload(curl *charm.URL) (*Charm, error) {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// Find an uploaded or pending charm with the given exact curl.
 		err := charms.FindId(curl.String()).One(&uploadedCharm)
-		if err != nil && err != mgo.ErrNotFound {
-			return nil, errors.Trace(err)
-		} else if err == nil && !uploadedCharm.Placeholder {
-			// The charm exists and it's either uploaded or still
-			// pending, but it's not a placeholder. In any case,
-			// there's nothing to do.
-			return nil, jujutxn.ErrNoOperations
-		} else if err == mgo.ErrNotFound {
-			// Prepare the pending charm document for insertion.
+		switch {
+		case err == mgo.ErrNotFound:
 			uploadedCharm = charmDoc{
 				DocID:         st.docID(curl.String()),
 				EnvUUID:       st.EnvironTag().Id(),
 				URL:           curl,
 				PendingUpload: true,
-				Placeholder:   false,
 			}
-		}
-
-		var ops []txn.Op
-		if uploadedCharm.Placeholder {
-			// Convert the placeholder to a pending charm, while
-			// asserting the fields updated after an upload have not
-			// changed yet.
-			ops = []txn.Op{{
-				C:  charmsC,
-				Id: uploadedCharm.DocID,
-				Assert: bson.D{
-					{"bundlesha256", ""},
-					{"pendingupload", false},
-					{"placeholder", true},
-				},
-				Update: bson.D{{"$set", bson.D{
-					{"pendingupload", true},
-					{"placeholder", false},
-				}}},
-			}}
+			return insertAnyCharmOps(&uploadedCharm)
+		case err != nil:
+			return nil, errors.Trace(err)
+		case uploadedCharm.Placeholder:
 			// Update the fields of the document we're returning.
 			uploadedCharm.PendingUpload = true
 			uploadedCharm.Placeholder = false
-		} else {
-			// No charm document with this curl yet, insert it.
-			ops = []txn.Op{{
-				C:      charmsC,
-				Id:     uploadedCharm.DocID,
-				Assert: txn.DocMissing,
-				Insert: uploadedCharm,
-			}}
+			return convertPlaceholderCharmOps(uploadedCharm.DocID)
+		default:
+			// The charm exists and it's either uploaded or still
+			// pending, but it's not a placeholder. In any case,
+			// there's nothing to do.
+			return nil, jujutxn.ErrNoOperations
 		}
-		return ops, nil
 	}
 	if err = st.run(buildTxn); err == nil {
 		return newCharm(st, &uploadedCharm), nil
@@ -1056,89 +998,19 @@ func (st *State) AddStoreCharmPlaceholder(curl *charm.URL) (err error) {
 		}
 
 		// Delete all previous placeholders so we don't fill up the database with unused data.
-		ops, err := st.deleteOldPlaceholderCharmsOps(curl)
+		deleteOps, err := deleteOldPlaceholderCharmsOps(st, charms, curl)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		// Add the new charm doc.
-		placeholderCharm := &charmDoc{
-			DocID:       st.docID(curl.String()),
-			EnvUUID:     st.EnvironTag().Id(),
-			URL:         curl,
-			Placeholder: true,
+		insertOps, err := insertPlaceholderCharmOps(st, curl)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
-		ops = append(ops, txn.Op{
-			C:      charmsC,
-			Id:     placeholderCharm.DocID,
-			Assert: txn.DocMissing,
-			Insert: placeholderCharm,
-		})
+		ops := append(deleteOps, insertOps...)
 		return ops, nil
 	}
 	return errors.Trace(st.run(buildTxn))
 }
-
-// deleteOldPlaceholderCharmsOps returns the txn ops required to delete all placeholder charm
-// records older than the specified charm URL.
-func (st *State) deleteOldPlaceholderCharmsOps(curl *charm.URL) ([]txn.Op, error) {
-	// Get a regex with the charm URL and no revision.
-	noRevURL := curl.WithRevision(-1)
-	curlRegex := "^" + regexp.QuoteMeta(st.docID(noRevURL.String()))
-	charms, closer := st.getCollection(charmsC)
-	defer closer()
-
-	var docs []charmDoc
-	query := bson.D{{"_id", bson.D{{"$regex", curlRegex}}}, {"placeholder", true}}
-	err := charms.Find(query).Select(bson.D{{"_id", 1}, {"url", 1}}).All(&docs)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	var ops []txn.Op
-	for _, doc := range docs {
-		if doc.URL.Revision >= curl.Revision {
-			continue
-		}
-		ops = append(ops, txn.Op{
-			C:      charmsC,
-			Id:     doc.DocID,
-			Assert: stillPlaceholder,
-			Remove: true,
-		})
-	}
-	return ops, nil
-}
-
-// ErrCharmAlreadyUploaded is returned by UpdateUploadedCharm() when
-// the given charm is already uploaded and marked as not pending in
-// state.
-type ErrCharmAlreadyUploaded struct {
-	curl *charm.URL
-}
-
-func (e *ErrCharmAlreadyUploaded) Error() string {
-	return fmt.Sprintf("charm %q already uploaded", e.curl)
-}
-
-// IsCharmAlreadyUploadedError returns if the given error is
-// ErrCharmAlreadyUploaded.
-func IsCharmAlreadyUploadedError(err interface{}) bool {
-	if err == nil {
-		return false
-	}
-	// In case of a wrapped error, check the cause first.
-	value := err
-	cause := errors.Cause(err.(error))
-	if cause != nil {
-		value = cause
-	}
-	_, ok := value.(*ErrCharmAlreadyUploaded)
-	return ok
-}
-
-// ErrCharmRevisionAlreadyModified is returned when a pending or
-// placeholder charm is no longer pending or a placeholder, signaling
-// the charm is available in state with its full information.
-var ErrCharmRevisionAlreadyModified = fmt.Errorf("charm revision already modified")
 
 // UpdateUploadedCharm marks the given charm URL as uploaded and
 // updates the rest of its data, returning it as *state.Charm.
@@ -1158,40 +1030,10 @@ func (st *State) UpdateUploadedCharm(ch charm.Charm, curl *charm.URL, storagePat
 		return nil, errors.Trace(&ErrCharmAlreadyUploaded{curl})
 	}
 
-	return st.updateCharmDoc(ch, curl, storagePath, bundleSha256, stillPending)
-}
-
-// updateCharmDoc updates the charm with specified URL with the given
-// data, and resets the placeholder and pendingupdate flags.  If the
-// charm is no longer a placeholder or pending (depending on preReq),
-// it returns ErrCharmRevisionAlreadyModified.
-func (st *State) updateCharmDoc(
-	ch charm.Charm, curl *charm.URL, storagePath, bundleSha256 string, preReq interface{}) (*Charm, error) {
-
-	// Make sure we escape any "$" and "." in config option names
-	// first. See http://pad.lv/1308146.
-	cfg := ch.Config()
-	escapedConfig := charm.NewConfig()
-	for optionName, option := range cfg.Options {
-		escapedName := escapeReplacer.Replace(optionName)
-		escapedConfig.Options[escapedName] = option
+	ops, err := updateCharmOps(st, ch, curl, storagePath, bundleSha256, stillPending)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	updateFields := bson.D{{"$set", bson.D{
-		{"meta", ch.Meta()},
-		{"config", escapedConfig},
-		{"actions", ch.Actions()},
-		{"metrics", ch.Metrics()},
-		{"storagepath", storagePath},
-		{"bundlesha256", bundleSha256},
-		{"pendingupload", false},
-		{"placeholder", false},
-	}}}
-	ops := []txn.Op{{
-		C:      charmsC,
-		Id:     st.docID(curl.String()),
-		Assert: preReq,
-		Update: updateFields,
-	}}
 	if err := st.runTransaction(ops); err != nil {
 		return nil, onAbort(err, ErrCharmRevisionAlreadyModified)
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -37,87 +37,11 @@ import (
 var logger = loggo.GetLogger("juju.state")
 
 const (
-	// The following define the mongo collections used to record the Juju environment state.
-	environmentsC      = "environments"
-	charmsC            = "charms"
-	machinesC          = "machines"
-	containerRefsC     = "containerRefs"
-	instanceDataC      = "instanceData"
-	relationsC         = "relations"
-	relationScopesC    = "relationscopes"
-	servicesC          = "services"
-	requestedNetworksC = "requestednetworks"
-	networksC          = "networks"
-	networkInterfacesC = "networkinterfaces"
-	minUnitsC          = "minunits"
-	settingsC          = "settings"
-	settingsrefsC      = "settingsrefs"
-	constraintsC       = "constraints"
-	unitsC             = "units"
-	subnetsC           = "subnets"
-	ipaddressesC       = "ipaddresses"
-
-	// actionsC and related collections store state of Actions that
-	// have been enqueued.
-	actionsC = "actions"
-	// actionNotificationsC are only used for notification of newly
-	// enqueued Actions.
-	actionNotificationsC = "actionnotifications"
-	// actionResultsC is deprecated and will soon be folded into
-	// actionsC.
-	actionresultsC = "actionresults"
-
-	usersC                 = "users"
-	envUsersC              = "envusers"
-	presenceC              = "presence"
-	cleanupsC              = "cleanups"
-	annotationsC           = "annotations"
-	statusesC              = "statuses"
-	statusesHistoryC       = "statuseshistory"
-	stateServersC          = "stateServers"
-	openedPortsC           = "openedPorts"
-	metricsC               = "metrics"
-	metricsManagerC        = "metricsmanager"
-	upgradeInfoC           = "upgradeInfo"
-	rebootC                = "reboot"
-	blockDevicesC          = "blockdevices"
-	storageAttachmentsC    = "storageattachments"
-	storageConstraintsC    = "storageconstraints"
-	storageInstancesC      = "storageinstances"
-	volumesC               = "volumes"
-	volumeAttachmentsC     = "volumeattachments"
-	filesystemsC           = "filesystems"
-	filesystemAttachmentsC = "filesystemAttachments"
-
-	// leaseC is used to store lease tokens
-	leaseC = "lease"
-
-	// sequenceC is used to generate unique identifiers.
-	sequenceC = "sequence"
-
-	// meterStatusC is the collection used to store meter status information.
-	meterStatusC = "meterStatus"
-
-	// toolsmetadataC is the collection used to store tools metadata.
-	toolsmetadataC = "toolsmetadata"
-
-	// These collections are used by the mgo transaction runner.
-	txnLogC = "txns.log"
-	txnsC   = "txns"
+	// jujuDB is the name of the main juju database.
+	jujuDB = "juju"
 
 	// blobstoreDB is the name of the blobstore GridFS database.
 	blobstoreDB = "blobstore"
-
-	// restoreInfoC is used to track restore progress
-	restoreInfoC = "restoreInfo"
-
-	// blocksC is used to identify collection of environment blocks.
-	blocksC = "blocks"
-
-	// The following mongo collections are used as unique key restraints. The
-	// _id field of each collection is a concatenation of multiple fields
-	// that form a compound index.
-	userenvnameC = "userenvname"
 )
 
 // State represents the state of an environment
@@ -125,21 +49,23 @@ const (
 type State struct {
 	// TODO(katco-): As state gets broken up, remove this.
 	*LeasePersistor
-	// transactionRunner is normally nil, which means that a new one
-	// will be created for each operation, ensuring a fresh mgo.Session
-	// is used. However, for tests, a value may be assigned and this will
-	// be used instead of creating a new runnner each time.
-	transactionRunner jujutxn.Runner
-	mongoInfo         *mongo.MongoInfo
-	policy            Policy
-	db                *mgo.Database
-	watcher           *watcher.Watcher
-	pwatcher          *presence.Watcher
+
+	environTag names.EnvironTag
+	serverTag  names.EnvironTag
+	mongoInfo  *mongo.MongoInfo
+	session    *mgo.Session
+	database   Database
+	policy     Policy
+
+	// TODO(fwereade): move these out of state and make them independent
+	// workers on which state depends.
+	watcher  *watcher.Watcher
+	pwatcher *presence.Watcher
+	// leadershipManager leadership.Manager
+
 	// mu guards allManager.
 	mu         sync.Mutex
 	allManager *storeManager
-	environTag names.EnvironTag
-	serverTag  names.EnvironTag
 }
 
 // StateServingInfo holds information needed by a state server.
@@ -183,37 +109,38 @@ func (st *State) RemoveAllEnvironDocs() error {
 		Remove: true,
 	}}
 
-	// add all multiEnv docs to the txn
-	var ids []bson.M
-	for collName := range multiEnvCollections {
-		coll, closer := st.getCollection(collName)
+	// Add all per-environment docs to the txn.
+	for name, info := range st.database.Schema() {
+		if info.global {
+			continue
+		}
+		coll, closer := st.getCollection(name)
 		defer closer()
+
+		var ids []bson.M
 		err := coll.Find(nil).Select(bson.D{{"_id", 1}}).All(&ids)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		for _, id := range ids {
 			ops = append(ops, txn.Op{
-				C:      collName,
+				C:      name,
 				Id:     id["_id"],
 				Remove: true,
 			})
 		}
-		ids = nil
 	}
 
 	return st.runTransaction(ops)
 }
 
-// ForEnviron returns a connection to mongo for the specified
-// environment. The connection uses the same credentials and policy as
-// the existing connection.
+// ForEnviron returns a connection to mongo for the specified environment. The
+// connection uses the same credentials and policy as the existing connection.
 func (st *State) ForEnviron(env names.EnvironTag) (*State, error) {
-	newState, err := open(st.mongoInfo, mongo.DefaultDialOpts(), st.policy)
+	newState, err := open(env, st.mongoInfo, mongo.DefaultDialOpts(), st.policy)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	newState.environTag = env
 	newState.serverTag = st.serverTag
 	newState.startPresenceWatcher()
 	return newState, nil
@@ -236,24 +163,28 @@ func userEnvNameIndex(username, envName string) string {
 	return strings.ToLower(username) + ":" + envName
 }
 
-// EnsureEnvironmentRemoved returns an error if any multi-enviornment
+// EnsureEnvironmentRemoved returns an error if any multi-environment
 // documents for this environment are found. It is intended only to be used in
 // tests and exported so it can be used in the tests of other packages.
 func (st *State) EnsureEnvironmentRemoved() error {
-	colls := multiEnvCollections
-	colls.Remove(cleanupsC)
 	found := map[string]int{}
 	var foundOrdered []string
-	for collName := range colls {
-		coll, closer := st.getCollection(collName)
+	for name, info := range st.database.Schema() {
+		if info.global {
+			continue
+		}
+		if name == cleanupsC {
+			continue
+		}
+		coll, closer := st.getCollection(name)
 		defer closer()
 		n, err := coll.Find(nil).Count()
 		if err != nil {
 			return errors.Trace(err)
 		}
 		if n != 0 {
-			found[collName] = n
-			foundOrdered = append(foundOrdered, collName)
+			found[name] = n
+			foundOrdered = append(foundOrdered, name)
 		}
 	}
 
@@ -273,11 +204,11 @@ func (st *State) EnsureEnvironmentRemoved() error {
 
 // getPresence returns the presence m.
 func (st *State) getPresence() *mgo.Collection {
-	return st.db.Session.DB("presence").C(presenceC)
+	return st.session.DB("presence").C(presenceC)
 }
 
 func (st *State) startPresenceWatcher() {
-	pdb := st.db.Session.DB("presence")
+	pdb := st.session.DB("presence")
 	st.pwatcher = presence.NewWatcher(pdb.C(presenceC), st.environTag)
 }
 
@@ -285,15 +216,14 @@ func (st *State) startPresenceWatcher() {
 // a closer function for the session. This is useful where you need to work
 // with various collections in a single session, so don't want to call
 // getCollection multiple times.
-func (st *State) newDB() (*mgo.Database, func()) {
-	session := st.db.Session.Copy()
-	return st.db.With(session), session.Close
+func (st *State) newDB() (Database, func()) {
+	return st.database.CopySession()
 }
 
 // Ping probes the state's database connection to ensure
 // that it is still alive.
 func (st *State) Ping() error {
-	return st.db.Session.Ping()
+	return st.session.Ping()
 }
 
 // MongoSession returns the underlying mongodb session
@@ -301,7 +231,7 @@ func (st *State) Ping() error {
 // can maintain the mongo replica set and should not
 // otherwise be used.
 func (st *State) MongoSession() *mgo.Session {
-	return st.db.Session
+	return st.session
 }
 
 type closeFunc func()
@@ -383,7 +313,8 @@ func (st *State) checkCanUpgrade(currentVersion, newVersion string) error {
 	}}}
 	var agentTags []string
 	for _, name := range []string{machinesC, unitsC} {
-		collection := db.C(name)
+		collection, closer := db.GetCollection(name)
+		defer closer()
 		var doc struct {
 			DocID string `bson:"_id"`
 		}
@@ -1880,7 +1811,7 @@ func (st *State) StartSync() {
 // all subsequent attempts to access the state must
 // be authorized; otherwise no authorization is required.
 func (st *State) SetAdminMongoPassword(password string) error {
-	err := mongo.SetAdminMongoPassword(st.db.Session, mongo.AdminUser, password)
+	err := mongo.SetAdminMongoPassword(st.session, mongo.AdminUser, password)
 	return errors.Trace(err)
 }
 
@@ -1913,8 +1844,17 @@ type StateServerInfo struct {
 // StateServerInfo returns information about
 // the currently configured state server machines.
 func (st *State) StateServerInfo() (*StateServerInfo, error) {
-	stateServers, closer := st.getCollection(stateServersC)
-	defer closer()
+	session := st.session.Copy()
+	defer session.Close()
+	return readRawStateServerInfo(st.session)
+}
+
+// readRawStateServerInfo reads StateServerInfo direct from the supplied session,
+// falling back to the bootstrap environment document to extract the UUID when
+// required.
+func readRawStateServerInfo(session *mgo.Session) (*StateServerInfo, error) {
+	db := session.DB(jujuDB)
+	stateServers := db.C(stateServersC)
 
 	var doc stateServersDoc
 	err := stateServers.Find(bson.D{{"_id", environGlobalKey}}).One(&doc)
@@ -1929,8 +1869,7 @@ func (st *State) StateServerInfo() (*StateServerInfo, error) {
 		// upgrade steps have been run. Without this hack environTag
 		// on State ends up empty, breaking basic functionality needed
 		// to run upgrade steps (a chicken-and-egg scenario).
-		environments, closer := st.getCollection(environmentsC)
-		defer closer()
+		environments := db.C(environmentsC)
 
 		var envDoc environmentDoc
 		query := environments.Find(nil)

--- a/state/state.go
+++ b/state/state.go
@@ -29,6 +29,8 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state/leadership"
+	"github.com/juju/juju/state/lease"
 	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/version"
@@ -40,8 +42,16 @@ const (
 	// jujuDB is the name of the main juju database.
 	jujuDB = "juju"
 
+	// presenceDB is the name of the database used to hold presence pinger data.
+	presenceDB = "presence"
+	presenceC  = "presence"
+
 	// blobstoreDB is the name of the blobstore GridFS database.
 	blobstoreDB = "blobstore"
+
+	// serviceLeadershipNamespace is the name of the lease.Client namespace
+	// used by the leadership manager.
+	serviceLeadershipNamespace = "service-leadership"
 )
 
 // State represents the state of an environment
@@ -59,9 +69,9 @@ type State struct {
 
 	// TODO(fwereade): move these out of state and make them independent
 	// workers on which state depends.
-	watcher  *watcher.Watcher
-	pwatcher *presence.Watcher
-	// leadershipManager leadership.Manager
+	watcher           *watcher.Watcher
+	pwatcher          *presence.Watcher
+	leadershipManager leadership.ManagerWorker
 
 	// mu guards allManager.
 	mu         sync.Mutex
@@ -141,9 +151,61 @@ func (st *State) ForEnviron(env names.EnvironTag) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	newState.serverTag = st.serverTag
-	newState.startPresenceWatcher()
+	if err := newState.start(st.serverTag); err != nil {
+		return nil, errors.Trace(err)
+	}
 	return newState, nil
+}
+
+// start starts the presence watcher and leadership manager, and fills in the
+// serverTag field with the supplied value.
+func (st *State) start(serverTag names.EnvironTag) error {
+	st.serverTag = serverTag
+
+	var clientId string
+	if identity := st.mongoInfo.Tag; identity != nil {
+		// TODO(fwereade): it feels a bit wrong to take this from MongoInfo -- I
+		// think it's just coincidental that the mongodb user happens to map to
+		// the machine that's executing the code -- but there doesn't seem to be
+		// an accessible alternative.
+		clientId = identity.String()
+	} else {
+		// If we're running state anonymously, we can still use the lease
+		// manager; but we need to make sure we use a unique client ID, and
+		// will thus not be very performant.
+		logger.Infof("running state anonymously; using unique client id")
+		uuid, err := utils.NewUUID()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		clientId = fmt.Sprintf("anon-%s", uuid.String())
+	}
+
+	logger.Infof("creating lease client as %s", clientId)
+	clock := lease.SystemClock{}
+	leaseClient, err := lease.NewClient(lease.ClientConfig{
+		Id:         clientId,
+		Namespace:  serviceLeadershipNamespace,
+		Collection: leasesC,
+		Mongo:      &environMongo{st},
+		Clock:      clock,
+	})
+	if err != nil {
+		return errors.Annotatef(err, "cannot create lease client")
+	}
+	logger.Infof("starting leadership manager")
+	leadershipManager, err := leadership.NewManager(leadership.ManagerConfig{
+		Client: leaseClient,
+		Clock:  clock,
+	})
+	if err != nil {
+		return errors.Annotatef(err, "cannot create leadership manager")
+	}
+	st.leadershipManager = leadershipManager
+
+	logger.Infof("starting presence watcher")
+	st.pwatcher = presence.NewWatcher(st.getPresence(), st.environTag)
+	return nil
 }
 
 // EnvironTag() returns the environment tag for the environment controlled by
@@ -171,9 +233,6 @@ func (st *State) EnsureEnvironmentRemoved() error {
 	var foundOrdered []string
 	for name, info := range st.database.Schema() {
 		if info.global {
-			continue
-		}
-		if name == cleanupsC {
 			continue
 		}
 		coll, closer := st.getCollection(name)
@@ -204,12 +263,7 @@ func (st *State) EnsureEnvironmentRemoved() error {
 
 // getPresence returns the presence m.
 func (st *State) getPresence() *mgo.Collection {
-	return st.session.DB("presence").C(presenceC)
-}
-
-func (st *State) startPresenceWatcher() {
-	pdb := st.session.DB("presence")
-	st.pwatcher = presence.NewWatcher(pdb.C(presenceC), st.environTag)
+	return st.session.DB(presenceDB).C(presenceC)
 }
 
 // newDB returns a database connection using a new session, along with

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -167,7 +167,7 @@ func (s *StateSuite) TestEnvironUUID(c *gc.C) {
 
 func (s *StateSuite) TestNoEnvDocs(c *gc.C) {
 	c.Assert(s.State.EnsureEnvironmentRemoved(), gc.ErrorMatches,
-		fmt.Sprintf("found documents for environment with uuid %s: 1 constraints doc, 1 envusers doc, 1 settings doc", s.State.EnvironUUID()))
+		fmt.Sprintf("found documents for environment with uuid %s: 1 constraints doc, 1 envusers doc, 1 leases doc, 1 settings doc", s.State.EnvironUUID()))
 }
 
 func (s *StateSuite) TestMongoSession(c *gc.C) {
@@ -2695,7 +2695,7 @@ func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
 		defer closer()
 		n, err := coll.Find(bson.D{{"env-uuid", st.EnvironUUID()}}).Count()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(n, gc.Equals, 1)
+		c.Assert(n, gc.Not(gc.Equals), 0)
 	}
 
 	// test that we can find the user:envName unique index

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -128,14 +128,33 @@ func (s *StateSuite) TestStrictLocalIDWithNoPrefix(c *gc.C) {
 func (s *StateSuite) TestDialAgain(c *gc.C) {
 	// Ensure idempotent operations on Dial are working fine.
 	for i := 0; i < 2; i++ {
-		st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+		st, err := state.Open(s.envTag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st.Close(), gc.IsNil)
 	}
 }
 
+func (s *StateSuite) TestOpenAcceptsMissingEnvironmentTag(c *gc.C) {
+	st, err := state.Open(names.EnvironTag{}, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(st.EnvironTag(), gc.Equals, s.envTag)
+	c.Check(st.Close(), jc.ErrorIsNil)
+}
+
+func (s *StateSuite) TestOpenRequiresExtantEnvironmentTag(c *gc.C) {
+	uuid := utils.MustNewUUID()
+	tag := names.NewEnvironTag(uuid.String())
+	st, err := state.Open(tag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	if !c.Check(st, gc.IsNil) {
+		c.Check(st.Close(), jc.ErrorIsNil)
+	}
+	expect := fmt.Sprintf("cannot read environment %s: environment not found", uuid)
+	c.Check(err, gc.ErrorMatches, expect)
+}
+
 func (s *StateSuite) TestOpenSetsEnvironmentTag(c *gc.C) {
-	st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.envTag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -2289,7 +2308,7 @@ func (s *StateSuite) TestWatchServicesDiesOnStateClose(c *gc.C) {
 	//     Service.WatchRelations
 	//     State.WatchEnviron
 	//     Machine.WatchContainers
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		w := st.WatchServices()
 		<-w.Changes()
 		return w
@@ -2656,7 +2675,7 @@ func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
 
 	// insert one doc for each multiEnvCollection
 	var ops []mgotxn.Op
-	for collName := range state.MultiEnvCollections {
+	for _, collName := range state.MultiEnvCollections() {
 		// skip adding constraints, envuser and settings as they were added when the
 		// environment was created
 		if collName == "constraints" || collName == "envusers" || collName == "settings" {
@@ -2671,7 +2690,7 @@ func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// test that we can find each doc in state
-	for collName := range state.MultiEnvCollections {
+	for _, collName := range state.MultiEnvCollections() {
 		coll, closer := state.GetRawCollection(st, collName)
 		defer closer()
 		n, err := coll.Find(bson.D{{"env-uuid", st.EnvironUUID()}}).Count()
@@ -2698,7 +2717,7 @@ func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
 	c.Assert(n, gc.Equals, 0)
 
 	// ensure all docs for all multiEnvCollections are removed
-	for collName := range state.MultiEnvCollections {
+	for _, collName := range state.MultiEnvCollections() {
 		coll, closer := state.GetRawCollection(st, collName)
 		defer closer()
 		n, err := coll.Find(bson.D{{"env-uuid", st.EnvironUUID()}}).Count()
@@ -2747,7 +2766,7 @@ func (s *StateSuite) TestWatchEnvironConfig(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchEnvironConfigDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		w := st.WatchEnvironConfig()
 		<-w.Changes()
 		return w
@@ -2879,10 +2898,10 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 	c.Assert(relation1, jc.DeepEquals, relation3)
 }
 
-func tryOpenState(info *mongo.MongoInfo) error {
-	st, err := state.Open(info, statetesting.NewDialOpts(), state.Policy(nil))
+func tryOpenState(envTag names.EnvironTag, info *mongo.MongoInfo) error {
+	st, err := state.Open(envTag, info, statetesting.NewDialOpts(), state.Policy(nil))
 	if err == nil {
-		st.Close()
+		err = st.Close()
 	}
 	return err
 }
@@ -2890,28 +2909,30 @@ func tryOpenState(info *mongo.MongoInfo) error {
 func (s *StateSuite) TestOpenWithoutSetMongoPassword(c *gc.C) {
 	info := statetesting.NewMongoInfo()
 	info.Tag, info.Password = names.NewUserTag("arble"), "bar"
-	err := tryOpenState(info)
-	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
+	err := tryOpenState(s.envTag, info)
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsUnauthorized)
+	c.Check(err, gc.ErrorMatches, `cannot log in to admin database as "user-arble": unauthorized mongo access: .*`)
 
 	info.Tag, info.Password = names.NewUserTag("arble"), ""
-	err = tryOpenState(info)
-	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
+	err = tryOpenState(s.envTag, info)
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsUnauthorized)
+	c.Check(err, gc.ErrorMatches, `cannot log in to admin database as "user-arble": unauthorized mongo access: .*`)
 
 	info.Tag, info.Password = nil, ""
-	err = tryOpenState(info)
-	c.Assert(err, jc.ErrorIsNil)
+	err = tryOpenState(s.envTag, info)
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *StateSuite) TestOpenBadAddress(c *gc.C) {
 	info := statetesting.NewMongoInfo()
 	info.Addrs = []string{"0.1.2.3:1234"}
-	st, err := state.Open(info, mongo.DialOpts{
+	st, err := state.Open(testing.EnvironmentTag, info, mongo.DialOpts{
 		Timeout: 1 * time.Millisecond,
 	}, state.Policy(nil))
 	if err == nil {
 		st.Close()
 	}
-	c.Assert(err, gc.ErrorMatches, "no reachable servers")
+	c.Assert(err, gc.ErrorMatches, "cannot connect to mongodb: no reachable servers")
 }
 
 func (s *StateSuite) TestOpenDelaysRetryBadAddress(c *gc.C) {
@@ -2921,13 +2942,13 @@ func (s *StateSuite) TestOpenDelaysRetryBadAddress(c *gc.C) {
 	info.Addrs = []string{"0.1.2.3:1234"}
 
 	t0 := time.Now()
-	st, err := state.Open(info, mongo.DialOpts{
+	st, err := state.Open(testing.EnvironmentTag, info, mongo.DialOpts{
 		Timeout: 1 * time.Millisecond,
 	}, state.Policy(nil))
 	if err == nil {
 		st.Close()
 	}
-	c.Assert(err, gc.ErrorMatches, "no reachable servers")
+	c.Assert(err, gc.ErrorMatches, "cannot connect to mongodb: no reachable servers")
 	// tryOpenState should have delayed for at least retryDelay
 	if t1 := time.Since(t0); t1 < retryDelay {
 		c.Errorf("mgo.Dial only paused for %v, expected at least %v", t1, retryDelay)
@@ -3247,7 +3268,7 @@ func (s *StateSuite) TestWatchCleanups(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchCleanupsDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		w := st.WatchCleanups()
 		<-w.Changes()
 		return w
@@ -3370,7 +3391,7 @@ func (s *StateSuite) TestWatchMinUnits(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchMinUnitsDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, func(c *gc.C, st *state.State) waiter {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		w := st.WatchMinUnits()
 		<-w.Changes()
 		return w
@@ -3634,8 +3655,8 @@ type waiter interface {
 // event, otherwise the watcher's initialisation logic may
 // interact with the closed state, causing it to return an
 // unexpected error (often "Closed explictly").
-func testWatcherDiesWhenStateCloses(c *gc.C, startWatcher func(c *gc.C, st *state.State) waiter) {
-	st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+func testWatcherDiesWhenStateCloses(c *gc.C, envTag names.EnvironTag, startWatcher func(c *gc.C, st *state.State) waiter) {
+	st, err := state.Open(envTag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	watcher := startWatcher(c, st)
 	err = st.Close()
@@ -3683,7 +3704,7 @@ func (s *StateSuite) TestReopenWithNoMachines(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, expected)
 
-	st, err := state.Open(statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.envTag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -4388,17 +4409,20 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 	err = st.MongoSession().DB("admin").Login("admin", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = tryOpenState(mongoInfo)
-	c.Assert(err, jc.Satisfies, errors.IsUnauthorized)
+	err = tryOpenState(st.EnvironTag(), mongoInfo)
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsUnauthorized)
+	// note: collections are set up in arbitrary order, proximate cause of
+	// failure may differ.
+	c.Check(err, gc.ErrorMatches, `[^:]+: unauthorized mongo access: .*`)
 
 	mongoInfo.Password = "foo"
-	err = tryOpenState(mongoInfo)
+	err = tryOpenState(st.EnvironTag(), mongoInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.SetAdminMongoPassword("")
 	c.Assert(err, jc.ErrorIsNil)
 
 	mongoInfo.Password = ""
-	err = tryOpenState(mongoInfo)
+	err = tryOpenState(st.EnvironTag(), mongoInfo)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/status.go
+++ b/state/status.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo"
 )
 
 var (
@@ -596,21 +598,26 @@ func removeStatusOp(st *State, globalKey string) txn.Op {
 // PruneStatusHistory removes status history entries until
 // only the maxLogsPerEntity newest records per unit remain.
 func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
-	historyColl, closer := st.getCollection(statusesHistoryC)
+	history, closer := st.getCollection(statusesHistoryC)
 	defer closer()
-	globalKeys, err := getEntitiesWithStatuses(historyColl)
+	// XXX(fwereade): 2015-06-19 this is anything but safe: we must not mix
+	// txn and non-txn operations in the same collection without clear and
+	// detailed reasoning for so doing.
+	historyW := history.Writeable()
+
+	globalKeys, err := getEntitiesWithStatuses(historyW)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	for _, globalKey := range globalKeys {
-		keepUpTo, ok, err := getOldestTimeToKeep(historyColl, globalKey, maxLogsPerEntity)
+		keepUpTo, ok, err := getOldestTimeToKeep(historyW, globalKey, maxLogsPerEntity)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		if !ok {
 			continue
 		}
-		_, err = historyColl.RemoveAll(bson.D{
+		_, err = historyW.RemoveAll(bson.D{
 			{"entityid", globalKey},
 			{"_id", bson.M{"$lt": keepUpTo}},
 		})
@@ -623,7 +630,7 @@ func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
 
 // getOldestTimeToKeep returns the create time for the oldest
 // status log to be kept.
-func getOldestTimeToKeep(coll stateCollection, globalKey string, size int) (int, bool, error) {
+func getOldestTimeToKeep(coll mongo.Collection, globalKey string, size int) (int, bool, error) {
 	result := historicalStatusDoc{}
 	err := coll.Find(bson.D{{"entityid", globalKey}}).Sort("-_id").Skip(size - 1).One(&result)
 	if err == mgo.ErrNotFound {
@@ -638,7 +645,7 @@ func getOldestTimeToKeep(coll stateCollection, globalKey string, size int) (int,
 
 // getEntitiesWithStatuses returns the ids for all entities that
 // have history entries
-func getEntitiesWithStatuses(coll stateCollection) ([]string, error) {
+func getEntitiesWithStatuses(coll mongo.Collection) ([]string, error) {
 	var entityKeys []string
 	err := coll.Find(nil).Distinct("entityid", &entityKeys)
 	if err != nil {

--- a/state/txns.go
+++ b/state/txns.go
@@ -146,6 +146,7 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 			}
 		}
 	}
+	logger.Tracef("rewrote transaction: %#v", ops)
 	return ops, nil
 }
 

--- a/state/txns.go
+++ b/state/txns.go
@@ -4,71 +4,58 @@
 package state
 
 import (
-	"fmt"
 	"reflect"
 
+	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
-	"github.com/juju/utils/set"
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 )
 
-// txnRunner returns a jujutxn.Runner instance.
-//
-// If st.transactionRunner is non-nil, then that will be
-// returned and the session argument will be ignored. This
-// is the case in tests only, when we want to test concurrent
-// operations.
-//
-// If st.transactionRunner is nil, then we create a new
-// transaction runner with the provided session and return
-// that.
-func (st *State) txnRunner(session *mgo.Session) jujutxn.Runner {
-	if st.transactionRunner != nil {
-		return st.transactionRunner
-	}
-	return newMultiEnvRunner(st.EnvironUUID(), st.db.With(session))
-}
-
-// runTransaction is a convenience method delegating to transactionRunner.
+// runTransaction is a convenience method delegating to the state's Database.
 func (st *State) runTransaction(ops []txn.Op) error {
-	session := st.db.Session.Copy()
-	defer session.Close()
-	return st.txnRunner(session).RunTransaction(ops)
+	runner, closer := st.database.TransactionRunner()
+	defer closer()
+	return runner.RunTransaction(ops)
 }
 
-// run is a convenience method delegating to transactionRunner.
+// runRawTransaction is a convenience method that will run a single
+// transaction using a "raw" transaction runner that won't perform
+// environment filtering.
+func (st *State) runRawTransaction(ops []txn.Op) error {
+	runner, closer := st.database.TransactionRunner()
+	defer closer()
+	if multiRunner, ok := runner.(*multiEnvRunner); ok {
+		runner = multiRunner.rawRunner
+	}
+	return runner.RunTransaction(ops)
+}
+
+// run is a convenience method delegating to the state's Database.
 func (st *State) run(transactions jujutxn.TransactionSource) error {
-	session := st.db.Session.Copy()
-	defer session.Close()
-	return st.txnRunner(session).Run(transactions)
+	runner, closer := st.database.TransactionRunner()
+	defer closer()
+	return runner.Run(transactions)
 }
 
 // ResumeTransactions resumes all pending transactions.
 func (st *State) ResumeTransactions() error {
-	session := st.db.Session.Copy()
-	defer session.Close()
-	return st.txnRunner(session).ResumeTransactions()
+	runner, closer := st.database.TransactionRunner()
+	defer closer()
+	return runner.ResumeTransactions()
 }
 
 // MaybePruneTransactions removes data for completed transactions.
 func (st *State) MaybePruneTransactions() error {
-	session := st.db.Session.Copy()
-	defer session.Close()
+	runner, closer := st.database.TransactionRunner()
+	defer closer()
 	// Prune txns only when txn count has doubled since last prune.
-	return st.txnRunner(session).MaybePruneTransactions(2.0)
-}
-
-func newMultiEnvRunner(envUUID string, db *mgo.Database) jujutxn.Runner {
-	return &multiEnvRunner{
-		rawRunner: jujutxn.NewRunner(jujutxn.RunnerParams{Database: db}),
-		envUUID:   envUUID,
-	}
+	return runner.MaybePruneTransactions(2.0)
 }
 
 type multiEnvRunner struct {
 	rawRunner jujutxn.Runner
+	schema    collectionSchema
 	envUUID   string
 }
 
@@ -76,7 +63,10 @@ type multiEnvRunner struct {
 // that affect multi-environment collections will be modified in-place
 // to ensure correct interaction with these collections.
 func (r *multiEnvRunner) RunTransaction(ops []txn.Op) error {
-	ops = r.updateOps(ops)
+	ops, err := r.updateOps(ops)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	return r.rawRunner.RunTransaction(ops)
 }
 
@@ -92,7 +82,10 @@ func (r *multiEnvRunner) Run(transactions jujutxn.TransactionSource) error {
 			// and won't deal correctly with some returned errors.
 			return nil, err
 		}
-		ops = r.updateOps(ops)
+		ops, err = r.updateOps(ops)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		return ops, nil
 	})
 }
@@ -107,50 +100,56 @@ func (r *multiEnvRunner) MaybePruneTransactions(pruneFactor float32) error {
 	return r.rawRunner.MaybePruneTransactions(pruneFactor)
 }
 
-func (r *multiEnvRunner) updateOps(ops []txn.Op) []txn.Op {
+func (r *multiEnvRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 	for i, op := range ops {
-		if multiEnvCollections.Contains(op.C) {
+		info, found := r.schema[op.C]
+		if !found {
+			return nil, errors.Errorf("forbidden transaction: references unknown collection %q", op.C)
+		}
+		if info.rawAccess {
+			return nil, errors.Errorf("forbidden transaction: references raw-access collection %q", op.C)
+		}
+		if !info.global {
+			// TODO(fwereade): this interface implies we're returning a copy
+			// of the transactions -- as I think we should be -- rather than
+			// rewriting them in place (which IMO breaks client expectations
+			// pretty hard, not to mention rendering us unable to accept any
+			// structs passed by value, or which lack an env-uuid field).
+			//
+			// The counterargument is that it's convenient to use rewritten
+			// docs directly to construct entities; I think that's suboptimal,
+			// because the cost of a DB read to just grab the actual data pales
+			// in the face of the transaction operation itself, and it's a
+			// small price to pay for a safer implementation.
 			var docID interface{}
 			if id, ok := op.Id.(string); ok {
-				docID = addEnvUUID(r.envUUID, id)
+				docID = ensureEnvUUID(r.envUUID, id)
 				ops[i].Id = docID
 			} else {
 				docID = op.Id
 			}
-
 			if op.Insert != nil {
+				var err error
 				switch doc := op.Insert.(type) {
 				case bson.D:
-					ops[i].Insert = r.updateBsonD(doc, docID, op.C)
+					ops[i].Insert, err = r.updateBsonD(doc, docID)
 				case bson.M:
-					r.updateBsonM(doc, docID, op.C)
+					err = r.updateBsonM(doc, docID)
 				case map[string]interface{}:
-					r.updateBsonM(bson.M(doc), docID, op.C)
+					err = r.updateBsonM(bson.M(doc), docID)
 				default:
-					if !r.updateStruct(doc, docID, op.C) {
-						panic(fmt.Sprintf("unsupported document type for multi-environment collection "+
-							"(must be bson.D, bson.M or struct). Got %T for insert into %s.", doc, op.C))
-					}
-
+					err = r.updateStruct(doc, docID)
+				}
+				if err != nil {
+					return nil, errors.Annotatef(err, "cannot insert into %q", op.C)
 				}
 			}
 		}
 	}
-	return ops
+	return ops, nil
 }
 
-var envAliveColls = newEnvAliveColls()
-
-// newEnvAliveColls returns a copy of multiEnvCollections minus cleanupsC.
-// This set is used to check if a txn needs to assert that there is a live
-// environment be inserting docs.
-func newEnvAliveColls() set.Strings {
-	e := set.NewStrings(multiEnvCollections.Values()...)
-	e.Remove(cleanupsC)
-	return e
-}
-
-func (r *multiEnvRunner) updateBsonD(doc bson.D, docID interface{}, collName string) bson.D {
+func (r *multiEnvRunner) updateBsonD(doc bson.D, docID interface{}) (bson.D, error) {
 	idSeen := false
 	envUUIDSeen := false
 	for i, elem := range doc {
@@ -161,8 +160,7 @@ func (r *multiEnvRunner) updateBsonD(doc bson.D, docID interface{}, collName str
 		case "env-uuid":
 			envUUIDSeen = true
 			if elem.Value != r.envUUID {
-				panic(fmt.Sprintf("environment UUID for document to insert into "+
-					"%s does not match state", collName))
+				return nil, errors.Errorf(`bad "env-uuid" value: expected %s, got %s`, r.envUUID, elem.Value)
 			}
 		}
 	}
@@ -172,10 +170,10 @@ func (r *multiEnvRunner) updateBsonD(doc bson.D, docID interface{}, collName str
 	if !envUUIDSeen {
 		doc = append(doc, bson.DocElem{"env-uuid", r.envUUID})
 	}
-	return doc
+	return doc, nil
 }
 
-func (r *multiEnvRunner) updateBsonM(doc bson.M, docID interface{}, collName string) {
+func (r *multiEnvRunner) updateBsonM(doc bson.M, docID interface{}) error {
 	idSeen := false
 	envUUIDSeen := false
 	for key, value := range doc {
@@ -186,8 +184,7 @@ func (r *multiEnvRunner) updateBsonM(doc bson.M, docID interface{}, collName str
 		case "env-uuid":
 			envUUIDSeen = true
 			if value != r.envUUID {
-				panic(fmt.Sprintf("environment UUID for document to insert into "+
-					"%s does not match state", collName))
+				return errors.Errorf(`bad "env-uuid" value: expected %s, got %s`, r.envUUID, value)
 			}
 		}
 	}
@@ -197,9 +194,10 @@ func (r *multiEnvRunner) updateBsonM(doc bson.M, docID interface{}, collName str
 	if !envUUIDSeen {
 		doc["env-uuid"] = r.envUUID
 	}
+	return nil
 }
 
-func (r *multiEnvRunner) updateStruct(doc, docID interface{}, collName string) bool {
+func (r *multiEnvRunner) updateStruct(doc, docID interface{}) error {
 	v := reflect.ValueOf(doc)
 	t := v.Type()
 
@@ -209,74 +207,44 @@ func (r *multiEnvRunner) updateStruct(doc, docID interface{}, collName string) b
 	}
 
 	if t.Kind() != reflect.Struct {
-		return false
+		return errors.Errorf("unknown type %s", t)
 	}
 
 	envUUIDSeen := false
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
+		var err error
 		switch f.Tag.Get("bson") {
 		case "_id":
-			r.updateStructField(v, f.Name, docID, collName, overrideField)
+			err = r.updateStructField(v, f.Name, docID, overrideField)
 		case "env-uuid":
-			r.updateStructField(v, f.Name, r.envUUID, collName, fieldMustMatch)
+			err = r.updateStructField(v, f.Name, r.envUUID, fieldMustMatch)
 			envUUIDSeen = true
+		}
+		if err != nil {
+			return errors.Trace(err)
 		}
 	}
 	if !envUUIDSeen {
-		panic(fmt.Sprintf("struct for insert into %s is missing an env-uuid field", collName))
+		return errors.Errorf(`struct lacks field with bson:"env-uuid" tag`)
 	}
-
-	return true
+	return nil
 }
 
 const overrideField = "override"
 const fieldMustMatch = "mustmatch"
 
-func (r *multiEnvRunner) updateStructField(v reflect.Value, name string, newValue interface{}, collName, updateType string) {
+func (r *multiEnvRunner) updateStructField(v reflect.Value, name string, newValue interface{}, updateType string) error {
 	fv := v.FieldByName(name)
 	if fv.Interface() != newValue {
 		if updateType == fieldMustMatch && fv.String() != "" {
-			panic(fmt.Sprintf("%s for insert into %s does not match expected value",
-				name, collName))
+			return errors.Errorf("bad %q field value: expected %s, got %s", name, newValue, fv.String())
 		}
 		if fv.CanSet() {
 			fv.Set(reflect.ValueOf(newValue))
 		} else {
-			panic(fmt.Sprintf("struct for insert into %s requires "+
-				"%s change but was passed by value", collName, name))
+			return errors.Errorf("cannot set %q field: struct passed by value", name)
 		}
 	}
-}
-
-// rawTxnRunner returns a transaction runner that won't perform
-// automatic addition of environment UUIDs into transaction
-// operations, even for collections that contain documents for
-// multiple environments. It should be used rarely.
-func (st *State) rawTxnRunner(session *mgo.Session) jujutxn.Runner {
-	if st.transactionRunner != nil {
-		return getRawRunner(st.transactionRunner)
-	}
-	return jujutxn.NewRunner(jujutxn.RunnerParams{
-		Database: st.db.With(session),
-	})
-}
-
-// runRawTransaction is a convenience method that will run a single
-// transaction using a "raw" transaction runner, as returned by
-// rawTxnRunner.
-func (st *State) runRawTransaction(ops []txn.Op) error {
-	session := st.db.Session.Copy()
-	defer session.Close()
-	runner := st.rawTxnRunner(session)
-	return runner.RunTransaction(ops)
-}
-
-// getRawRunner returns the underlying "raw" transaction runner from
-// the passed transaction runner.
-func getRawRunner(runner jujutxn.Runner) jujutxn.Runner {
-	if runner, ok := runner.(*multiEnvRunner); ok {
-		return runner.rawRunner
-	}
-	return runner
+	return nil
 }

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -32,7 +32,17 @@ const (
 
 func (s *MultiEnvRunnerSuite) SetUpTest(c *gc.C) {
 	s.testRunner = &recordingRunner{}
-	s.multiEnvRunner = NewMultiEnvRunnerForTesting(envUUID, s.testRunner)
+	s.multiEnvRunner = &multiEnvRunner{
+		rawRunner: s.testRunner,
+		envUUID:   envUUID,
+		schema: collectionSchema{
+			machinesC:          {},
+			networkInterfacesC: {},
+			environmentsC:      {global: true},
+			"other":            {global: true},
+			"raw":              {rawAccess: true},
+		},
+	}
 }
 
 // An alternative machine document to test that fields are matched by
@@ -249,88 +259,114 @@ func (s *MultiEnvRunnerSuite) TestWithObjectIds(c *gc.C) {
 	c.Assert(s.testRunner.seenOps, gc.DeepEquals, updatedOps)
 }
 
-func (s *MultiEnvRunnerSuite) TestPanicWhenStructIsPassedByValueAndNeedsChange(c *gc.C) {
-	// When a document struct is passed by reference it can't be
-	// changed in place. It's important that the caller sees any
-	// modifications made by multiEnvRunner in case the document
-	// struct is used to create an object after insertion into
-	// MongoDB.
-	attempt := func() {
-		s.multiEnvRunner.RunTransaction([]txn.Op{{
-			C:      machinesC,
-			Id:     "uuid:0",
-			Insert: machineDoc{},
-		}})
-	}
-	c.Assert(attempt, gc.PanicMatches,
-		"struct for insert into machines requires DocID change but was passed by value")
+func (s *MultiEnvRunnerSuite) TestDoesNotAssertReferencedEnv(c *gc.C) {
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:      environmentsC,
+		Id:     envUUID,
+		Insert: bson.M{},
+	}})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(s.testRunner.seenOps, jc.DeepEquals, []txn.Op{{
+		C:      environmentsC,
+		Id:     envUUID,
+		Insert: bson.M{},
+	}})
 }
 
-func (s *MultiEnvRunnerSuite) TestPanicWhenStructIsMissingEnvUUIDField(c *gc.C) {
+func (s *MultiEnvRunnerSuite) TestRejectRawAccessCollection(c *gc.C) {
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:      "raw",
+		Id:     "whatever",
+		Assert: bson.D{{"any", "thing"}},
+	}})
+	c.Check(err, gc.ErrorMatches, `forbidden transaction: references raw-access collection "raw"`)
+	c.Check(s.testRunner.seenOps, gc.IsNil)
+}
+
+func (s *MultiEnvRunnerSuite) TestRejectUnknownCollection(c *gc.C) {
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:      "unknown",
+		Id:     "whatever",
+		Assert: bson.D{{"any", "thing"}},
+	}})
+	c.Check(err, gc.ErrorMatches, `forbidden transaction: references unknown collection "unknown"`)
+	c.Check(s.testRunner.seenOps, gc.IsNil)
+}
+
+func (s *MultiEnvRunnerSuite) TestRejectStructPassedByValueAndNeedsChange(c *gc.C) {
+	// When a document struct is passed by reference it can't be
+	// changed in place, it's important that the caller sees any
+	// modifications made by multiEnvRunner in case the document
+	// struct is used to create an object after insertion into
+	// MongoDB (but see comments in multiEnvRunner.updateOps).
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:      machinesC,
+		Id:     "uuid:0",
+		Insert: machineDoc{},
+	}})
+	c.Check(err, gc.ErrorMatches,
+		`cannot insert into "machines": cannot set "DocID" field: struct passed by value`)
+	c.Check(s.testRunner.seenOps, gc.IsNil)
+}
+
+func (s *MultiEnvRunnerSuite) TestRejectStructMissingEnvUUIDField(c *gc.C) {
 	type someDoc struct {
 		DocID string `bson:"_id"`
 	}
-	attempt := func() {
-		s.multiEnvRunner.RunTransaction([]txn.Op{{
-			C:      machinesC,
-			Id:     "uuid:0",
-			Insert: &someDoc{DocID: "uuid:0"},
-		}})
-	}
-	c.Assert(attempt, gc.PanicMatches,
-		"struct for insert into machines is missing an env-uuid field")
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:      machinesC,
+		Id:     "uuid:0",
+		Insert: &someDoc{DocID: "uuid:0"},
+	}})
+	c.Check(err, gc.ErrorMatches,
+		`cannot insert into "machines": struct lacks field with bson:"env-uuid" tag`)
+	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
-func (s *MultiEnvRunnerSuite) TestPanicWhenStructEnvUUIDMismatch(c *gc.C) {
-	attempt := func() {
-		s.multiEnvRunner.RunTransaction([]txn.Op{{
-			C:  machinesC,
-			Id: "uuid:0",
-			Insert: &machineDoc{
-				DocID:   "uuid:0",
-				EnvUUID: "somethingelse",
-			},
-		}})
-	}
-	c.Assert(attempt, gc.PanicMatches,
-		"EnvUUID for insert into machines does not match expected value")
+func (s *MultiEnvRunnerSuite) TestRejectStructEnvUUIDMismatch(c *gc.C) {
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:  machinesC,
+		Id: "uuid:0",
+		Insert: &machineDoc{
+			DocID:   "uuid:0",
+			EnvUUID: "somethingelse",
+		},
+	}})
+	c.Check(err, gc.ErrorMatches,
+		`cannot insert into "machines": bad "EnvUUID" field value: expected uuid, got somethingelse`)
+	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
-func (s *MultiEnvRunnerSuite) TestPanicWhenBsonDEnvUUIDMismatch(c *gc.C) {
-	attempt := func() {
-		s.multiEnvRunner.RunTransaction([]txn.Op{{
-			C:      machinesC,
-			Id:     "uuid:0",
-			Insert: bson.D{{"env-uuid", "wtf"}},
-		}})
-	}
-	c.Assert(attempt, gc.PanicMatches,
-		"environment UUID for document to insert into machines does not match state")
+func (s *MultiEnvRunnerSuite) TestRejectBsonDEnvUUIDMismatch(c *gc.C) {
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:      machinesC,
+		Id:     "uuid:0",
+		Insert: bson.D{{"env-uuid", "wtf"}},
+	}})
+	c.Check(err, gc.ErrorMatches,
+		`cannot insert into "machines": bad "env-uuid" value: expected uuid, got wtf`)
+	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
-func (s *MultiEnvRunnerSuite) TestPanicWhenBsonMEnvUUIDMismatch(c *gc.C) {
-	attempt := func() {
-		s.multiEnvRunner.RunTransaction([]txn.Op{{
-			C:      machinesC,
-			Id:     "uuid:0",
-			Insert: bson.M{"env-uuid": "wtf"},
-		}})
-	}
-	c.Assert(attempt, gc.PanicMatches,
-		"environment UUID for document to insert into machines does not match state")
+func (s *MultiEnvRunnerSuite) TestRejectBsonMEnvUUIDMismatch(c *gc.C) {
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:      machinesC,
+		Id:     "uuid:0",
+		Insert: bson.M{"env-uuid": "wtf"},
+	}})
+	c.Check(err, gc.ErrorMatches,
+		`cannot insert into "machines": bad "env-uuid" value: expected uuid, got wtf`)
+	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
-func (s *MultiEnvRunnerSuite) TestPanicForUnsupportedDocType(c *gc.C) {
-	attempt := func() {
-		s.multiEnvRunner.RunTransaction([]txn.Op{{
-			C:      machinesC,
-			Id:     "uuid:0",
-			Insert: make(map[int]int),
-		}})
-	}
-	c.Assert(attempt, gc.PanicMatches, `unsupported document type for multi-environment `+
-		`collection \(must be bson.D, bson.M or struct\). Got map\[int\]int for insert `+
-		`into machines.`)
+func (s *MultiEnvRunnerSuite) TestRejectUnsupportedDocType(c *gc.C) {
+	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
+		C:      machinesC,
+		Id:     "uuid:0",
+		Insert: make(map[int]int),
+	}})
+	c.Check(err, gc.ErrorMatches, `cannot insert into "machines": unknown type map\[int\]int`)
+	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
 func (s *MultiEnvRunnerSuite) TestRun(c *gc.C) {
@@ -353,32 +389,32 @@ func (s *MultiEnvRunnerSuite) TestRunWithError(c *gc.C) {
 	err := s.multiEnvRunner.Run(func(attempt int) ([]txn.Op, error) {
 		return nil, errors.New("boom")
 	})
-	c.Assert(err, gc.ErrorMatches, "boom")
-	c.Assert(s.testRunner.seenOps, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "boom")
+	c.Check(s.testRunner.seenOps, gc.IsNil)
 }
 
 func (s *MultiEnvRunnerSuite) TestResumeTransactions(c *gc.C) {
 	err := s.multiEnvRunner.ResumeTransactions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.testRunner.resumeTransactionsCalled, jc.IsTrue)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(s.testRunner.resumeTransactionsCalled, jc.IsTrue)
 }
 
 func (s *MultiEnvRunnerSuite) TestResumeTransactionsWithError(c *gc.C) {
 	s.testRunner.resumeTransactionsErr = errors.New("boom")
 	err := s.multiEnvRunner.ResumeTransactions()
-	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Check(err, gc.ErrorMatches, "boom")
 }
 
 func (s *MultiEnvRunnerSuite) TestMaybePruneTransactions(c *gc.C) {
 	err := s.multiEnvRunner.MaybePruneTransactions(2.0)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.testRunner.pruneTransactionsCalled, jc.IsTrue)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(s.testRunner.pruneTransactionsCalled, jc.IsTrue)
 }
 
 func (s *MultiEnvRunnerSuite) TestMaybePruneTransactionsWithError(c *gc.C) {
 	s.testRunner.pruneTransactionsErr = errors.New("boom")
 	err := s.multiEnvRunner.MaybePruneTransactions(2.0)
-	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Check(err, gc.ErrorMatches, "boom")
 }
 
 // recordingRunner is fake transaction running that implements the

--- a/state/unit.go
+++ b/state/unit.go
@@ -985,9 +985,10 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 
 	db, closer := u.st.newDB()
 	defer closer()
-	envUUID := u.st.EnvironUUID()
-	units := getCollectionFromDB(db, unitsC, envUUID)
-	charms := getCollectionFromDB(db, charmsC, envUUID)
+	units, closer := db.GetCollection(unitsC)
+	defer closer()
+	charms, closer := db.GetCollection(charmsC)
+	defer closer()
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
@@ -1453,23 +1454,24 @@ func (u *Unit) AssignToNewMachineOrContainer() (err error) {
 	}
 
 	// Find a clean, empty machine on which to create a container.
-	var host machineDoc
 	hostCons := *cons
 	noContainer := instance.NONE
 	hostCons.Container = &noContainer
-	query, closer, err := u.findCleanMachineQuery(true, &hostCons)
+	query, err := u.findCleanMachineQuery(true, &hostCons)
 	if err != nil {
 		return err
 	}
+	machinesCollection, closer := u.st.getCollection(machinesC)
 	defer closer()
-	err = query.One(&host)
-	if err == mgo.ErrNotFound {
+	var host machineDoc
+	if err := machinesCollection.Find(query).One(&host); err == mgo.ErrNotFound {
 		// No existing clean, empty machine so create a new one.
 		// The container constraint will be used by AssignToNewMachine to create the required container.
 		return u.AssignToNewMachine()
 	} else if err != nil {
 		return err
 	}
+
 	svc, err := u.Service()
 	if err != nil {
 		return err
@@ -1720,23 +1722,20 @@ var hasNoContainersTerm = bson.DocElem{
 
 // findCleanMachineQuery returns a Mongo query to find clean (and possibly empty) machines with
 // characteristics matching the specified constraints.
-func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value) (_ *mgo.Query, _ func(), err error) {
+func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value) (bson.D, error) {
 	db, closer := u.st.newDB()
-	defer func() {
-		if err != nil {
-			closer()
-		}
-	}()
-	containerRefsCollection := db.C(containerRefsC)
+	defer closer()
+	containerRefsCollection, closer := db.GetCollection(containerRefsC)
+	defer closer()
 
 	// Select all machines that can accept principal units and are clean.
 	var containerRefs []machineContainers
 	// If we need empty machines, first build up a list of machine ids which have containers
 	// so we can exclude those.
 	if requireEmpty {
-		err = containerRefsCollection.Find(bson.D{hasContainerTerm}).All(&containerRefs)
+		err := containerRefsCollection.Find(bson.D{hasContainerTerm}).All(&containerRefs)
 		if err != nil {
-			return nil, closer, err
+			return nil, err
 		}
 	}
 	var machinesWithContainers = make([]string, len(containerRefs))
@@ -1789,10 +1788,11 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 		suitableTerms = append(suitableTerms, bson.DocElem{"tags", bson.D{{"$all", *cons.Tags}}})
 	}
 	if len(suitableTerms) > 0 {
-		instanceData := db.C(instanceDataC)
-		err := instanceData.Find(suitableTerms).Select(bson.M{"_id": 1}).All(&suitableInstanceData)
+		instanceDataCollection, closer := db.GetCollection(instanceDataC)
+		defer closer()
+		err := instanceDataCollection.Find(suitableTerms).Select(bson.M{"_id": 1}).All(&suitableInstanceData)
 		if err != nil {
-			return nil, closer, err
+			return nil, err
 		}
 		var suitableIds = make([]string, len(suitableInstanceData))
 		for i, m := range suitableInstanceData {
@@ -1800,8 +1800,7 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 		}
 		terms = append(terms, bson.DocElem{"_id", bson.D{{"$in", suitableIds}}})
 	}
-	machines := db.C(machinesC)
-	return machines.Find(terms), closer, nil
+	return terms, nil
 }
 
 // assignToCleanMaybeEmptyMachine implements AssignToCleanMachine and AssignToCleanEmptyMachine.
@@ -1837,19 +1836,20 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 		assignContextf(&err, u, context)
 		return nil, err
 	}
-	query, closer, err := u.findCleanMachineQuery(requireEmpty, cons)
+	query, err := u.findCleanMachineQuery(requireEmpty, cons)
 	if err != nil {
 		assignContextf(&err, u, context)
 		return nil, err
 	}
-	defer closer()
 
 	// Find all of the candidate machines, and associated
 	// instances for those that are provisioned. Instances
 	// will be distributed across in preference to
 	// unprovisioned machines.
+	machinesCollection, closer := u.st.getCollection(machinesC)
+	defer closer()
 	var mdocs []*machineDoc
-	if err := query.All(&mdocs); err != nil {
+	if err := machinesCollection.Find(query).All(&mdocs); err != nil {
 		assignContextf(&err, u, context)
 		return nil, err
 	}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2153,7 +2153,9 @@ func (s *upgradesSuite) tearDownJobManageNetworking(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	// Reset machine sequence.
-	query := s.state.db.C(sequenceC).FindId(s.state.docID("machine"))
+	sequences, closer := s.state.getCollection(sequenceC)
+	defer closer()
+	query := sequences.FindId(s.state.docID("machine"))
 	set := mgo.Change{
 		Update: bson.M{"$set": bson.M{"counter": 0}},
 		Upsert: true,

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
 )
@@ -141,9 +142,9 @@ type lifecycleWatcher struct {
 	commonWatcher
 	out chan []string
 
-	// coll is a function returning the stateCollection holding all
+	// coll is a function returning the mongo.Collection holding all
 	// interesting entities
-	coll     func() (stateCollection, func())
+	coll     func() (mongo.Collection, func())
 	collName string
 
 	// members is used to select the initial set of interesting entities.
@@ -157,8 +158,8 @@ type lifecycleWatcher struct {
 	life map[string]Life
 }
 
-func collFactory(st *State, collName string) func() (stateCollection, func()) {
-	return func() (stateCollection, func()) {
+func collFactory(st *State, collName string) func() (mongo.Collection, func()) {
+	return func() (mongo.Collection, func()) {
 		return st.getCollection(collName)
 	}
 }
@@ -1500,7 +1501,7 @@ func (w *docWatcher) Changes() <-chan struct{} {
 // given key in the given collection. It is useful to enable
 // a watcher.Watcher to be primed with the correct revision
 // id.
-func getTxnRevno(coll stateCollection, key interface{}) (int64, error) {
+func getTxnRevno(coll mongo.Collection, key interface{}) (int64, error) {
 	doc := struct {
 		TxnRevno int64 `bson:"txn-revno"`
 	}{}

--- a/upgrades/rsyslogport.go
+++ b/upgrades/rsyslogport.go
@@ -17,9 +17,9 @@ func updateRsyslogPort(context Context) error {
 	if !ok {
 		return fmt.Errorf("Failed to get MongoInfo")
 	}
-	// we need to re-open state with a nil policay so we can bypass
+	// we need to re-open state with a nil policy so we can bypass
 	// validation, as the syslog-port is normally immutable
-	st, err := state.Open(info, mongo.DefaultDialOpts(), nil)
+	st, err := state.Open(agentConfig.Environment(), info, mongo.DefaultDialOpts(), nil)
 	if err != nil {
 		return err
 	}

--- a/upgrades/rsyslogport_test.go
+++ b/upgrades/rsyslogport_test.go
@@ -25,8 +25,9 @@ func (s *rsyslogPortSuite) SetUpTest(c *gc.C) {
 	apiState, _ := s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
 	s.ctx = &mockContext{
 		agentConfig: &mockAgentConfig{
-			dataDir:   s.DataDir(),
-			mongoInfo: s.MongoInfo(c),
+			dataDir:    s.DataDir(),
+			mongoInfo:  s.MongoInfo(c),
+			environTag: s.State.EnvironTag(),
 		},
 		apiState: apiState,
 		state:    s.State,

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -160,6 +160,7 @@ type mockAgentConfig struct {
 	values       map[string]string
 	mongoInfo    *mongo.MongoInfo
 	servingInfo  params.StateServingInfo
+	environTag   names.EnvironTag
 }
 
 func (mock *mockAgentConfig) Tag() names.Tag {
@@ -200,6 +201,10 @@ func (mock *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) 
 
 func (mock *mockAgentConfig) SetStateServingInfo(info params.StateServingInfo) {
 	mock.servingInfo = info
+}
+
+func (mock *mockAgentConfig) Environment() names.EnvironTag {
+	return mock.environTag
 }
 
 func stateUpgradeOperations() []upgrades.Operation {

--- a/worker/environ_test.go
+++ b/worker/environ_test.go
@@ -58,7 +58,7 @@ func (s *environSuite) TestInvalidConfig(c *gc.C) {
 	// tweaking the provider type.
 	info := s.MongoInfo(c)
 	opts := mongo.DefaultDialOpts()
-	st2, err := state.Open(info, opts, state.Policy(nil))
+	st2, err := state.Open(s.State.EnvironTag(), info, opts, state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st2.Close()
 	err = st2.UpdateEnvironConfig(map[string]interface{}{"type": "unknown"}, nil, nil)
@@ -87,7 +87,7 @@ func (s *environSuite) TestInvalidConfig(c *gc.C) {
 
 func (s *environSuite) TestErrorWhenEnvironIsInvalid(c *gc.C) {
 	// reopen the state so that we can wangle a dodgy environ config in there.
-	st, err := state.Open(s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.State.EnvironTag(), s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	err = st.UpdateEnvironConfig(map[string]interface{}{"secret": 999}, nil, nil)
@@ -115,7 +115,7 @@ func (s *environSuite) TestEnvironmentChanges(c *gc.C) {
 
 	info := s.MongoInfo(c)
 	opts := mongo.DefaultDialOpts()
-	st2, err := state.Open(info, opts, state.Policy(nil))
+	st2, err := state.Open(s.State.EnvironTag(), info, opts, state.Policy(nil))
 	defer st2.Close()
 
 	// Change to an invalid configuration and check

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -173,7 +173,7 @@ func breakDummyProvider(c *gc.C, st *state.State, environMethod string) string {
 // so the Settings returned from the watcher will not pass
 // validation.
 func (s *CommonProvisionerSuite) invalidateEnvironment(c *gc.C) {
-	st, err := state.Open(s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.State.EnvironTag(), s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	attrs := map[string]interface{}{"type": "unknown"}
@@ -183,7 +183,7 @@ func (s *CommonProvisionerSuite) invalidateEnvironment(c *gc.C) {
 
 // fixEnvironment undoes the work of invalidateEnvironment.
 func (s *CommonProvisionerSuite) fixEnvironment(c *gc.C) error {
-	st, err := state.Open(s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.State.EnvironTag(), s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	attrs := map[string]interface{}{"type": s.cfg.AllAttrs()["type"]}


### PR DESCRIPTION
This is a combination of my 5 most recent pushes to master, bringing 1.24 up to date with the leadership changes that it's become apparent need to be in 1.24. For reference, the 5 commits correspond to, in order:

  * http://reviews.vapour.ws/r/1984/
  * http://reviews.vapour.ws/r/1987/
  * http://reviews.vapour.ws/r/2008/
  * http://reviews.vapour.ws/r/2078/
  * http://reviews.vapour.ws/r/2104/

...and have been discussed in detail there; the only complexities encountered in the merge were:

  * 1.24 multiEnvRunner no longer inserts env-life checks: dropped ignoreInsertRestrictions logic
  * didn't add indexes not previously known in 1.24

I'm sorry to push so much at once, but (1) I'm confident in this change and (2) it's important that I base further leadership work on 1.24, and I'd like to sync as quickly as possible.

(Review request: http://reviews.vapour.ws/r/2205/)