### PR TITLE
Disable part of the test for windows.

### DIFF
--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -267,6 +267,16 @@ func (s *UniterSuite) TestUniterUpdateStatusHook(c *gc.C) {
 			waitUnitAgent{status: params.StatusIdle},
 			waitHooks{"start"},
 		),
+	})
+}
+
+func (s *UniterSuite) TestUniterUpdateStatusHookContinued(c *gc.C) {
+	// Additional tests here only to disable for windows:
+	// FIXME: bug 1476060, 2015-07-20, thumper
+	if runtime.GOOS == "windows" {
+		c.Skip("bug 1476060: startUpgradeError{} fails for windows")
+	}
+	s.runUniterTests(c, []uniterTest{
 		ust(
 			"timer ignored when in upgrade conflict state",
 			startUpgradeError{},


### PR DESCRIPTION
UniterSuite.TestUniterUpdateStatusHook fails on windows due to use of chmod.

Skipping that test on windows for now, and filed a bug.



(Review request: http://reviews.vapour.ws/r/2206/)