### PR TITLE
state: multiEnvRunner now handles $set struct updates

### DIFF
--- a/state/txns.go
+++ b/state/txns.go
@@ -100,6 +100,11 @@ func (r *multiEnvRunner) MaybePruneTransactions(pruneFactor float32) error {
 	return r.rawRunner.MaybePruneTransactions(pruneFactor)
 }
 
+// updateOps modifies the Insert and Update fields in a slice of
+// txn.Ops to ensure they are multi-environment safe where possible.
+//
+// Note that the input slice is actually modified in-place (but see
+// TODO below).
 func (r *multiEnvRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 	for i, op := range ops {
 		info, found := r.schema[op.C]
@@ -129,20 +134,18 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 				docID = op.Id
 			}
 			if op.Insert != nil {
-				var err error
-				switch doc := op.Insert.(type) {
-				case bson.D:
-					ops[i].Insert, err = r.updateBsonD(doc, docID)
-				case bson.M:
-					err = r.updateBsonM(doc, docID)
-				case map[string]interface{}:
-					err = r.updateBsonM(bson.M(doc), docID)
-				default:
-					err = r.updateStruct(doc, docID)
-				}
+				newInsert, err := r.mungeInsert(op.Insert, docID)
 				if err != nil {
 					return nil, errors.Annotatef(err, "cannot insert into %q", op.C)
 				}
+				ops[i].Insert = newInsert
+			}
+			if op.Update != nil {
+				newUpdate, err := r.mungeUpdate(op.Update, docID)
+				if err != nil {
+					return nil, errors.Annotatef(err, "cannot update %q", op.C)
+				}
+				ops[i].Update = newUpdate
 			}
 		}
 	}
@@ -150,7 +153,24 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 	return ops, nil
 }
 
-func (r *multiEnvRunner) updateBsonD(doc bson.D, docID interface{}) (bson.D, error) {
+// mungeInsert takes the value of an txn.Op Insert field and modifies
+// it to be multi-environment safe, returning the modified document.
+func (r *multiEnvRunner) mungeInsert(doc interface{}, docID interface{}) (interface{}, error) {
+	switch doc := doc.(type) {
+	case bson.D:
+		return r.mungeBsonD(doc, docID)
+	case bson.M:
+		return doc, r.mungeBsonM(doc, docID)
+	case map[string]interface{}:
+		return doc, r.mungeBsonM(bson.M(doc), docID)
+	default:
+		return doc, r.mungeStruct(doc, docID)
+	}
+}
+
+// mungeBsonD takes the value of a txn.Op field expressed as a bson.D
+// and modifies it to be multi-environment safe.
+func (r *multiEnvRunner) mungeBsonD(doc bson.D, docID interface{}) (bson.D, error) {
 	idSeen := false
 	envUUIDSeen := false
 	for i, elem := range doc {
@@ -174,7 +194,10 @@ func (r *multiEnvRunner) updateBsonD(doc bson.D, docID interface{}) (bson.D, err
 	return doc, nil
 }
 
-func (r *multiEnvRunner) updateBsonM(doc bson.M, docID interface{}) error {
+// mungeBsonM takes the value of a txn.Op field expressed as a bson.M
+// and modifies it to be multi-environment safe. The map is modified
+// in-place.
+func (r *multiEnvRunner) mungeBsonM(doc bson.M, docID interface{}) error {
 	idSeen := false
 	envUUIDSeen := false
 	for key, value := range doc {
@@ -198,7 +221,10 @@ func (r *multiEnvRunner) updateBsonM(doc bson.M, docID interface{}) error {
 	return nil
 }
 
-func (r *multiEnvRunner) updateStruct(doc, docID interface{}) error {
+// mungeStruct takes the value of a txn.Op field expressed as some
+// struct and modifies it to be multi-environment safe. The struct is
+// modified in-place.
+func (r *multiEnvRunner) mungeStruct(doc, docID interface{}) error {
 	v := reflect.ValueOf(doc)
 	t := v.Type()
 
@@ -217,9 +243,9 @@ func (r *multiEnvRunner) updateStruct(doc, docID interface{}) error {
 		var err error
 		switch f.Tag.Get("bson") {
 		case "_id":
-			err = r.updateStructField(v, f.Name, docID, overrideField)
+			err = r.mungeStructField(v, f.Name, docID, overrideField)
 		case "env-uuid":
-			err = r.updateStructField(v, f.Name, r.envUUID, fieldMustMatch)
+			err = r.mungeStructField(v, f.Name, r.envUUID, fieldMustMatch)
 			envUUIDSeen = true
 		}
 		if err != nil {
@@ -235,7 +261,10 @@ func (r *multiEnvRunner) updateStruct(doc, docID interface{}) error {
 const overrideField = "override"
 const fieldMustMatch = "mustmatch"
 
-func (r *multiEnvRunner) updateStructField(v reflect.Value, name string, newValue interface{}, updateType string) error {
+// mungeStructFIeld updates the field of a struct to a new value. If
+// updateType is overrideField == fieldMustMatch then the field must
+// match the value given, if present.
+func (r *multiEnvRunner) mungeStructField(v reflect.Value, name string, newValue interface{}, updateType string) error {
 	fv := v.FieldByName(name)
 	if fv.Interface() != newValue {
 		if updateType == fieldMustMatch && fv.String() != "" {
@@ -248,4 +277,69 @@ func (r *multiEnvRunner) updateStructField(v reflect.Value, name string, newValu
 		}
 	}
 	return nil
+}
+
+// mungeInsert takes the value of an txn.Op Update field and modifies
+// it to be multi-environment safe, returning the modified document.
+func (r *multiEnvRunner) mungeUpdate(updateDoc, docID interface{}) (interface{}, error) {
+	switch doc := updateDoc.(type) {
+	case bson.D:
+		return r.mungeBsonDUpdate(doc, docID)
+	case bson.M:
+		return r.mungeBsonMUpdate(doc, docID)
+	default:
+		return nil, errors.Errorf("don't know how to handle %T", updateDoc)
+	}
+}
+
+// mungeBsonDUpdate modifies Update field values expressed as a bson.D
+// and attempts to make them multi-environment safe.
+func (r *multiEnvRunner) mungeBsonDUpdate(updateDoc bson.D, docID interface{}) (bson.D, error) {
+	outDoc := make(bson.D, 0, len(updateDoc))
+	for _, elem := range updateDoc {
+		if elem.Name == "$set" {
+			// TODO(mjs) - only worry about structs for now. This is
+			// enough to fix LP #1474606 and a more extensive change
+			// to simplify the multi-env txn layer and correctly
+			// handle all cases is coming soon.
+			newSetDoc, err := r.mungeStructOnly(elem.Value, docID)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			outDoc = append(outDoc, bson.DocElem{elem.Name, newSetDoc})
+		} else {
+			outDoc = append(outDoc, elem)
+		}
+	}
+	return outDoc, nil
+}
+
+// mungeBsonMUpdate modifies Update field values expressed as a bson.M
+// and attempts to make them multi-environment safe.
+func (r *multiEnvRunner) mungeBsonMUpdate(updateDoc bson.M, docID interface{}) (bson.M, error) {
+	outDoc := make(bson.M)
+	for name, elem := range updateDoc {
+		if name == "$set" {
+			// TODO(mjs) - as above.
+			newSetDoc, err := r.mungeStructOnly(elem, docID)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			outDoc[name] = newSetDoc
+		} else {
+			outDoc[name] = elem
+		}
+	}
+	return outDoc, nil
+}
+
+// mungeStructOnly modifies the input document to address
+// multi-environment concerns, but only if it's a struct.
+func (r *multiEnvRunner) mungeStructOnly(doc interface{}, docID interface{}) (interface{}, error) {
+	switch doc := doc.(type) {
+	case bson.D, bson.M, map[string]interface{}:
+		return doc, nil
+	default:
+		return doc, r.mungeStruct(doc, docID)
+	}
 }


### PR DESCRIPTION
Multi-env processing is now applied when a struct is for a $set update. This avoids env-uuid fields being blanked out.

Fixes LP #1474606.

As indicated by the TODO a more extensive change in this area is coming soon.

(Review request: http://reviews.vapour.ws/r/2207/)