### PR TITLE
Detach loop devices when destroying LXC containers

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -45,6 +45,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/kvm"
 	"github.com/juju/juju/container/lxc"
+	"github.com/juju/juju/container/lxc/lxcutils"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
@@ -60,6 +61,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statestorage "github.com/juju/juju/state/storage"
+	"github.com/juju/juju/storage/looputil"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
@@ -262,6 +264,7 @@ func MachineAgentFactoryFn(
 	agentConfWriter AgentConfigWriter,
 	apiAddressSetter apiaddressupdater.APIAddressSetter,
 	bufferedLogs logsender.LogRecordCh,
+	loopDeviceManager looputil.LoopDeviceManager,
 ) func(string) *MachineAgent {
 	return func(machineId string) *MachineAgent {
 		return NewMachineAgent(
@@ -271,6 +274,7 @@ func MachineAgentFactoryFn(
 			bufferedLogs,
 			NewUpgradeWorkerContext(),
 			worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant),
+			loopDeviceManager,
 		)
 	}
 }
@@ -283,6 +287,7 @@ func NewMachineAgent(
 	bufferedLogs logsender.LogRecordCh,
 	upgradeWorkerContext *upgradeWorkerContext,
 	runner worker.Runner,
+	loopDeviceManager looputil.LoopDeviceManager,
 ) *MachineAgent {
 	return &MachineAgent{
 		machineId:            machineId,
@@ -293,6 +298,7 @@ func NewMachineAgent(
 		workersStarted:       make(chan struct{}),
 		runner:               runner,
 		initialAgentUpgradeCheckComplete: make(chan struct{}),
+		loopDeviceManager:                loopDeviceManager,
 	}
 }
 
@@ -329,6 +335,8 @@ type MachineAgent struct {
 	mongoInitialized bool
 
 	apiStateUpgrader APIStateUpgrader
+
+	loopDeviceManager looputil.LoopDeviceManager
 }
 
 func (a *MachineAgent) getUpgrader(st *api.State) APIStateUpgrader {
@@ -1678,9 +1686,26 @@ func (a *MachineAgent) uninstallAgent(agentConfig agent.Config) error {
 			errors = append(errors, fmt.Errorf("cannot remove service %q: %v", agentServiceName, err))
 		}
 	}
+
 	// Remove the juju-run symlink.
 	if err := os.Remove(JujuRun); err != nil && !os.IsNotExist(err) {
 		errors = append(errors, err)
+	}
+
+	insideLXC, err := lxcutils.RunningInsideLXC()
+	if err != nil {
+		errors = append(errors, err)
+	} else if insideLXC {
+		// We're running inside LXC, so loop devices may leak. Detach
+		// any loop devices that are backed by files on this machine.
+		//
+		// It is necessary to do this here as well as in container/lxc,
+		// as container/lxc needs to check in the container's rootfs
+		// to see if the loop device is attached to the container; that
+		// will fail if the data-dir is removed first.
+		if err := a.loopDeviceManager.DetachLoopDevices("/", agentConfig.DataDir()); err != nil {
+			errors = append(errors, err)
+		}
 	}
 
 	namespace := agentConfig.Value(agent.Namespace)

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -22,6 +22,7 @@ import (
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/sockets"
+	"github.com/juju/juju/storage/looputil"
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/worker/logsender"
@@ -135,7 +136,10 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	// MachineAgent type has called out the seperate concerns; the
 	// AgentConf should be split up to follow suite.
 	agentConf := agentcmd.NewAgentConf("")
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, logCh)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
+		agentConf, agentConf, logCh,
+		looputil.NewLoopDeviceManager(),
+	)
 	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
 
 	jujud.Register(agentcmd.NewUnitAgent(ctx, logCh))

--- a/container/factory/factory.go
+++ b/container/factory/factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/container/kvm"
 	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage/looputil"
 )
 
 // NewContainerManager creates the appropriate container.Manager for the
@@ -20,7 +21,7 @@ func NewContainerManager(forType instance.ContainerType, conf container.ManagerC
 ) (container.Manager, error) {
 	switch forType {
 	case instance.LXC:
-		return lxc.NewContainerManager(conf, imageURLGetter)
+		return lxc.NewContainerManager(conf, imageURLGetter, looputil.NewLoopDeviceManager())
 	case instance.KVM:
 		return kvm.NewContainerManager(conf)
 	}

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -48,10 +48,11 @@ func Test(t *stdtesting.T) {
 type LxcSuite struct {
 	lxctesting.TestSuite
 
-	events   chan mock.Event
-	useClone bool
-	useAUFS  bool
-	logDir   string
+	events            chan mock.Event
+	useClone          bool
+	useAUFS           bool
+	logDir            string
+	loopDeviceManager mockLoopDeviceManager
 }
 
 var _ = gc.Suite(&LxcSuite{})
@@ -92,6 +93,7 @@ func (s *LxcSuite) SetUpTest(c *gc.C) {
 	s.TestSuite.ContainerFactory.AddListener(s.events)
 	s.PatchValue(&lxc.TemplateLockDir, c.MkDir())
 	s.PatchValue(&lxc.TemplateStopTimeout, 500*time.Millisecond)
+	s.loopDeviceManager = mockLoopDeviceManager{}
 }
 
 func (s *LxcSuite) TearDownTest(c *gc.C) {
@@ -156,7 +158,7 @@ func (s *LxcSuite) TestContainerManagerLXCClone(c *gc.C) {
 		mgr, err := lxc.NewContainerManager(container.ManagerConfig{
 			container.ConfigName: "juju",
 			"use-clone":          test.useClone,
-		}, &containertesting.MockURLGetter{})
+		}, &containertesting.MockURLGetter{}, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(lxc.GetCreateWithCloneValue(mgr), gc.Equals, test.expectClone)
 	}
@@ -597,7 +599,10 @@ func (s *LxcSuite) makeManager(c *gc.C, name string) container.Manager {
 	if s.useAUFS {
 		params["use-aufs"] = "true"
 	}
-	manager, err := lxc.NewContainerManager(params, &containertesting.MockURLGetter{})
+	manager, err := lxc.NewContainerManager(
+		params, &containertesting.MockURLGetter{},
+		&s.loopDeviceManager,
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	return manager
 }
@@ -606,7 +611,7 @@ func (*LxcSuite) TestManagerWarnsAboutUnknownOption(c *gc.C) {
 	_, err := lxc.NewContainerManager(container.ManagerConfig{
 		container.ConfigName: "BillyBatson",
 		"shazam":             "Captain Marvel",
-	}, &containertesting.MockURLGetter{})
+	}, &containertesting.MockURLGetter{}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(c.GetTestLog(), jc.Contains, `WARNING juju.container unused config option: "shazam" -> "Captain Marvel"`)
 }
@@ -862,6 +867,10 @@ func (s *LxcSuite) TestDestroyContainer(c *gc.C) {
 	c.Assert(filepath.Join(s.ContainerDir, name), jc.DoesNotExist)
 	// but instead, in the removed container dir
 	c.Assert(filepath.Join(s.RemovedDir, name), jc.IsDirectory)
+
+	c.Assert(s.loopDeviceManager.detachLoopDevicesArgs, jc.DeepEquals, [][]string{
+		{filepath.Join(s.LxcDir, name, "rootfs"), "/"},
+	})
 }
 
 func (s *LxcSuite) TestDestroyContainerNameClash(c *gc.C) {
@@ -1242,4 +1251,13 @@ func (s *LxcSuite) TestIsLXCSupportedNonLinuxSystem(c *gc.C) {
 	supports, err := lxc.IsLXCSupported()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(supports, jc.IsFalse)
+}
+
+type mockLoopDeviceManager struct {
+	detachLoopDevicesArgs [][]string
+}
+
+func (m *mockLoopDeviceManager) DetachLoopDevices(rootfs, prefix string) error {
+	m.detachLoopDevicesArgs = append(m.detachLoopDevicesArgs, []string{rootfs, prefix})
+	return nil
 }

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -97,7 +97,7 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 	agentConf.ReadConfig(m.Tag().String())
 	logsCh, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, logsCh)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, logsCh, nil)
 	a := machineAgentFactory(m.Id())
 
 	// Ensure there's no logs to begin with.

--- a/featuretests/leadership_test.go
+++ b/featuretests/leadership_test.go
@@ -98,7 +98,7 @@ func (s *leadershipSuite) SetUpTest(c *gc.C) {
 
 	// Create & start a machine agent so the tests have something to call into.
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, nil)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, nil, nil)
 	s.machineAgent = machineAgentFactory(stateServer.Id())
 
 	// See comment in createMockJujudExecutable
@@ -359,7 +359,7 @@ func (s *uniterLeadershipSuite) SetUpTest(c *gc.C) {
 
 	// Create & start a machine agent so the tests have something to call into.
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, nil)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, nil, nil)
 	s.machineAgent = machineAgentFactory(stateServer.Id())
 
 	// See comment in createMockJujudExecutable

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -329,7 +329,7 @@ func (s *localJujuTestSuite) TestDestroyRemovesContainers(c *gc.C) {
 		container.ConfigName:   namespace,
 		container.ConfigLogDir: "logdir",
 		"use-clone":            "false",
-	}, nil)
+	}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	machine1 := containertesting.CreateContainer(c, manager, "1")

--- a/storage/looputil/export_test.go
+++ b/storage/looputil/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package looputil
+
+import "os"
+
+func NewTestLoopDeviceManager(
+	run func(cmd string, args ...string) (string, error),
+	stat func(path string) (os.FileInfo, error),
+	inode func(info os.FileInfo) uint64,
+) LoopDeviceManager {
+	return &loopDeviceManager{run, stat, inode}
+}

--- a/storage/looputil/inode_linux.go
+++ b/storage/looputil/inode_linux.go
@@ -1,0 +1,13 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package looputil
+
+import (
+	"os"
+	"syscall"
+)
+
+func fileInode(info os.FileInfo) uint64 {
+	return info.Sys().(*syscall.Stat_t).Ino
+}

--- a/storage/looputil/inode_notlinux.go
+++ b/storage/looputil/inode_notlinux.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//+build !linux
+
+package looputil
+
+import (
+	"os"
+	"runtime"
+)
+
+func fileInode(os.FileInfo) uint64 {
+	panic("loop devices not supported on " + runtime.GOOS)
+}

--- a/storage/looputil/loop.go
+++ b/storage/looputil/loop.go
@@ -1,0 +1,134 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package looputil
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.storage.looputil")
+
+// LoopDeviceManager is an API for dealing with storage loop devices.
+type LoopDeviceManager interface {
+	// DetachLoopDevices detaches loop devices that are backed by files
+	// inside the given root filesystem with the given prefix.
+	DetachLoopDevices(rootfs, prefix string) error
+}
+
+type runFunc func(cmd string, args ...string) (string, error)
+
+type loopDeviceManager struct {
+	run   runFunc
+	stat  func(string) (os.FileInfo, error)
+	inode func(os.FileInfo) uint64
+}
+
+// NewLoopDeviceManager returns a new LoopDeviceManager for dealing
+// with storage loop devices on the local machine.
+func NewLoopDeviceManager() LoopDeviceManager {
+	run := func(cmd string, args ...string) (string, error) {
+		out, err := exec.Command(cmd, args...).CombinedOutput()
+		out = bytes.TrimSpace(out)
+		if err != nil {
+			if len(out) > 0 {
+				err = errors.Annotatef(err, "failed with %q", out)
+			}
+			return "", err
+		}
+		return string(out), nil
+	}
+	return &loopDeviceManager{run, os.Stat, fileInode}
+}
+
+// DetachLoopDevices detaches loop devices that are backed by files
+// inside the given root filesystem with the given prefix.
+func (m *loopDeviceManager) DetachLoopDevices(rootfs, prefix string) error {
+	logger.Debugf("detaching loop devices inside %q", rootfs)
+	loopDevices, err := loopDevices(m.run)
+	if err != nil {
+		return errors.Annotate(err, "listing loop devices")
+	}
+
+	for _, info := range loopDevices {
+		logger.Debugf("checking loop device: %v", info)
+		if !strings.HasPrefix(info.backingFile, prefix) {
+			continue
+		}
+		rootedBackingFile := filepath.Join(rootfs, info.backingFile)
+		st, err := m.stat(rootedBackingFile)
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return errors.Annotate(err, "querying backing file")
+		}
+		if m.inode(st) != info.backingInode {
+			continue
+		}
+		logger.Debugf("detaching loop device %q", info.name)
+		if err := detachLoopDevice(m.run, info.name); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+type loopDeviceInfo struct {
+	name         string
+	backingFile  string
+	backingInode uint64
+}
+
+func loopDevices(run runFunc) ([]loopDeviceInfo, error) {
+	out, err := run("losetup", "-a")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if out == "" {
+		return nil, nil
+	}
+	lines := strings.Split(out, "\n")
+	devices := make([]loopDeviceInfo, len(lines))
+	for i, line := range lines {
+		info, err := parseLoopDeviceInfo(strings.TrimSpace(line))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		devices[i] = info
+	}
+	return devices, nil
+}
+
+// e.g. "/dev/loop0: [0021]:7504142 (/tmp/test.dat)"
+//      "/dev/loop0: [002f]:7504142 (/tmp/test.dat (deleted))"
+var loopDeviceInfoRegexp = regexp.MustCompile(`^([^ ]+): \[[[:xdigit:]]+\]:(\d+) \((.*?)(?: \(.*\))?\)$`)
+
+func parseLoopDeviceInfo(line string) (loopDeviceInfo, error) {
+	submatch := loopDeviceInfoRegexp.FindStringSubmatch(line)
+	if submatch == nil {
+		return loopDeviceInfo{}, errors.Errorf("cannot parse loop device info from %q", line)
+	}
+	name := submatch[1]
+	backingFile := submatch[3]
+	backingInode, err := strconv.ParseUint(submatch[2], 10, 64)
+	if err != nil {
+		return loopDeviceInfo{}, errors.Annotate(err, "parsing inode")
+	}
+	return loopDeviceInfo{name, backingFile, backingInode}, nil
+}
+
+func detachLoopDevice(run runFunc, deviceName string) error {
+	if _, err := run("losetup", "-d", deviceName); err != nil {
+		return errors.Annotatef(err, "detaching loop device %q", deviceName)
+	}
+	return nil
+}

--- a/storage/looputil/loop_test.go
+++ b/storage/looputil/loop_test.go
@@ -1,0 +1,197 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package looputil_test
+
+import (
+	"os"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/storage/looputil"
+	"github.com/juju/juju/testing"
+)
+
+type LoopUtilSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&LoopUtilSuite{})
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesNone(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a")
+
+	m := looputil.NewTestLoopDeviceManager(commands.run, nil, nil)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesListError(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("", errors.New("badness"))
+
+	m := looputil.NewTestLoopDeviceManager(commands.run, nil, nil)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, gc.ErrorMatches, "listing loop devices: badness")
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesListBadOutput(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("bad output", nil)
+
+	m := looputil.NewTestLoopDeviceManager(commands.run, nil, nil)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, gc.ErrorMatches, `listing loop devices: cannot parse loop device info from "bad output"`)
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesListBadInode(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("/dev/loop0: [0]:99999999999999999999999 (woop)", nil)
+
+	m := looputil.NewTestLoopDeviceManager(commands.run, nil, nil)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, gc.ErrorMatches, `listing loop devices: parsing inode: strconv.ParseUint: parsing "99999999999999999999999": value out of range`)
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesNotFound(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("/dev/loop0: [0021]:7504142 (/tmp/test.dat)", nil)
+	stat := func(string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	m := looputil.NewTestLoopDeviceManager(commands.run, stat, nil)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesStatError(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("/dev/loop0: [0021]:7504142 (/tmp/test.dat)", nil)
+	stat := func(path string) (os.FileInfo, error) {
+		return nil, errors.Errorf("stat fails for %q", path)
+	}
+	m := looputil.NewTestLoopDeviceManager(commands.run, stat, nil)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, gc.ErrorMatches, `querying backing file: stat fails for "/tmp/test.dat"`)
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesInodeMismatch(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("/dev/loop0: [0021]:7504142 (/tmp/test.dat)", nil)
+	stat := func(path string) (os.FileInfo, error) {
+		return mockFileInfo{inode: 123}, nil
+	}
+	m := looputil.NewTestLoopDeviceManager(commands.run, stat, mockFileInfoInode)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesInodeMatch(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("/dev/loop0: [0021]:7504142 (/tmp/test.dat)", nil)
+	commands.expect("losetup", "-d", "/dev/loop0")
+	stat := func(path string) (os.FileInfo, error) {
+		return mockFileInfo{inode: 7504142}, nil
+	}
+	m := looputil.NewTestLoopDeviceManager(commands.run, stat, mockFileInfoInode)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesDetachError(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("/dev/loop0: [0021]:7504142 (/tmp/test.dat)", nil)
+	commands.expect("losetup", "-d", "/dev/loop0").respond("", errors.New("oh noes"))
+	stat := func(path string) (os.FileInfo, error) {
+		return mockFileInfo{inode: 7504142}, nil
+	}
+	m := looputil.NewTestLoopDeviceManager(commands.run, stat, mockFileInfoInode)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, gc.ErrorMatches, `detaching loop device "/dev/loop0": oh noes`)
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesMultiple(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond(
+		"/dev/loop0: [0021]:7504142 (/tmp/test1.dat)\n"+
+			"/dev/loop1: [002f]:7504143 (/tmp/test2.dat (deleted))\n"+
+			"/dev/loop2: [002a]:7504144 (/tmp/test3.dat)",
+		nil,
+	)
+	commands.expect("losetup", "-d", "/dev/loop0")
+	commands.expect("losetup", "-d", "/dev/loop2")
+	var statted []string
+	stat := func(path string) (os.FileInfo, error) {
+		statted = append(statted, path)
+		switch path {
+		case "/tmp/test1.dat":
+			return mockFileInfo{inode: 7504142}, nil
+		case "/tmp/test3.dat":
+			return mockFileInfo{inode: 7504144}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	m := looputil.NewTestLoopDeviceManager(commands.run, stat, mockFileInfoInode)
+	err := m.DetachLoopDevices("", "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statted, jc.DeepEquals, []string{"/tmp/test1.dat", "/tmp/test2.dat", "/tmp/test3.dat"})
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesAlternativeRoot(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond("/dev/loop0: [0021]:7504142 (/tmp/test.dat)", nil)
+	var statted string
+	stat := func(path string) (os.FileInfo, error) {
+		statted = path
+		return nil, os.ErrNotExist
+	}
+	m := looputil.NewTestLoopDeviceManager(commands.run, stat, mockFileInfoInode)
+	err := m.DetachLoopDevices("/var/lib/lxc/mycontainer/rootfs", "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statted, gc.Equals, "/var/lib/lxc/mycontainer/rootfs/tmp/test.dat")
+}
+
+func (s *LoopUtilSuite) TestDetachLoopDevicesAlternativeRootWithPrefix(c *gc.C) {
+	commands := &mockRunCommand{c: c}
+	defer commands.assertDrained()
+	commands.expect("losetup", "-a").respond(
+		"/dev/loop0: [0021]:7504142 (/var/lib/juju/storage/loop/volume-0-0)\n"+
+			"/dev/loop1: [002f]:7504143 (/some/random/loop/device)",
+		nil,
+	)
+	commands.expect("losetup", "-d", "/dev/loop0")
+	var statted []string
+	stat := func(path string) (os.FileInfo, error) {
+		statted = append(statted, path)
+		return mockFileInfo{inode: 7504142}, nil
+	}
+	m := looputil.NewTestLoopDeviceManager(commands.run, stat, mockFileInfoInode)
+	err := m.DetachLoopDevices("/var/lib/lxc/mycontainer/rootfs", "/var/lib/juju")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statted, jc.DeepEquals, []string{
+		"/var/lib/lxc/mycontainer/rootfs/var/lib/juju/storage/loop/volume-0-0",
+	})
+}
+
+type mockFileInfo struct {
+	os.FileInfo
+	inode uint64
+}
+
+func mockFileInfoInode(info os.FileInfo) uint64 {
+	return info.(mockFileInfo).inode
+}

--- a/storage/looputil/package_test.go
+++ b/storage/looputil/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package looputil_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/storage/looputil/util_test.go
+++ b/storage/looputil/util_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package looputil_test
+
+import gc "gopkg.in/check.v1"
+
+type mockRunCommand struct {
+	c        *gc.C
+	commands []*mockCommand
+}
+
+type mockCommand struct {
+	cmd    string
+	args   []string
+	result string
+	err    error
+}
+
+func (m *mockCommand) respond(result string, err error) {
+	m.result = result
+	m.err = err
+}
+
+func (m *mockRunCommand) expect(cmd string, args ...string) *mockCommand {
+	command := &mockCommand{cmd: cmd, args: args}
+	m.commands = append(m.commands, command)
+	return command
+}
+
+func (m *mockRunCommand) assertDrained() {
+	m.c.Assert(m.commands, gc.HasLen, 0)
+}
+
+func (m *mockRunCommand) run(cmd string, args ...string) (stdout string, err error) {
+	m.c.Assert(m.commands, gc.Not(gc.HasLen), 0)
+	expect := m.commands[0]
+	m.commands = m.commands[1:]
+	m.c.Assert(cmd, gc.Equals, expect.cmd)
+	m.c.Assert(args, gc.DeepEquals, expect.args)
+	return expect.result, expect.err
+}

--- a/storage/provider/common.go
+++ b/storage/provider/common.go
@@ -6,7 +6,6 @@ package provider
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/container/lxc/lxcutils"
 	"github.com/juju/juju/storage"
 )
 
@@ -15,7 +14,7 @@ var errNoMountPoint = errors.New("filesystem mount point not specified")
 // CommonProviders returns the storage providers used by all environments.
 func CommonProviders() map[storage.ProviderType]storage.Provider {
 	return map[storage.ProviderType]storage.Provider{
-		LoopProviderType:   &loopProvider{logAndExec, lxcutils.RunningInsideLXC},
+		LoopProviderType:   &loopProvider{logAndExec},
 		RootfsProviderType: &rootfsProvider{logAndExec},
 		TmpfsProviderType:  &tmpfsProvider{logAndExec},
 	}

--- a/storage/provider/export_test.go
+++ b/storage/provider/export_test.go
@@ -19,20 +19,18 @@ var Getpagesize = &getpagesize
 func LoopVolumeSource(
 	storageDir string,
 	run func(string, ...string) (string, error),
-	insideLXC bool,
 ) (storage.VolumeSource, *MockDirFuncs) {
 	dirFuncs := &MockDirFuncs{
 		osDirFuncs{run},
 		set.NewStrings(),
 	}
-	return &loopVolumeSource{dirFuncs, run, storageDir, insideLXC}, dirFuncs
+	return &loopVolumeSource{dirFuncs, run, storageDir}, dirFuncs
 }
 
 func LoopProvider(
 	run func(string, ...string) (string, error),
-	insideLXC func() (bool, error),
 ) storage.Provider {
-	return &loopProvider{run, insideLXC}
+	return &loopProvider{run}
 }
 
 func NewMockManagedFilesystemSource(

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -27,9 +27,6 @@ const (
 type loopProvider struct {
 	// run is a function used for running commands on the local machine.
 	run runCommandFunc
-	// runningInsideLXC is a function that determines whether or not
-	// the code is running within an LXC container.
-	runningInsideLXC func() (bool, error)
 }
 
 var _ storage.Provider = (*loopProvider)(nil)
@@ -62,17 +59,12 @@ func (lp *loopProvider) VolumeSource(
 	if err := lp.validateFullConfig(sourceConfig); err != nil {
 		return nil, err
 	}
-	insideLXC, err := lp.runningInsideLXC()
-	if err != nil {
-		return nil, err
-	}
 	// storageDir is validated by validateFullConfig.
 	storageDir, _ := sourceConfig.ValueString(storage.ConfigStorageDir)
 	return &loopVolumeSource{
 		&osDirFuncs{lp.run},
 		lp.run,
 		storageDir,
-		insideLXC,
 	}, nil
 }
 
@@ -102,10 +94,9 @@ func (*loopProvider) Dynamic() bool {
 // loopVolumeSource provides common functionality to handle
 // loop devices for rootfs and host loop volume sources.
 type loopVolumeSource struct {
-	dirFuncs         dirFuncs
-	run              runCommandFunc
-	storageDir       string
-	runningInsideLXC bool
+	dirFuncs   dirFuncs
+	run        runCommandFunc
+	storageDir string
 }
 
 var _ storage.VolumeSource = (*loopVolumeSource)(nil)
@@ -137,10 +128,6 @@ func (lvs *loopVolumeSource) createVolume(params storage.VolumeParams) (storage.
 		storage.VolumeInfo{
 			VolumeId: volumeId,
 			Size:     params.Size,
-			// Loop devices may outlive LXC containers. If we're
-			// running inside an LXC container, mark the volume as
-			// persistent.
-			Persistent: lvs.runningInsideLXC,
 		},
 	}, nil
 }

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -24,15 +24,13 @@ var _ = gc.Suite(&loopSuite{})
 
 type loopSuite struct {
 	testing.BaseSuite
-	storageDir       string
-	commands         *mockRunCommand
-	runningInsideLXC bool
+	storageDir string
+	commands   *mockRunCommand
 }
 
 func (s *loopSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.storageDir = c.MkDir()
-	s.runningInsideLXC = false
 }
 
 func (s *loopSuite) TearDownTest(c *gc.C) {
@@ -42,10 +40,7 @@ func (s *loopSuite) TearDownTest(c *gc.C) {
 
 func (s *loopSuite) loopProvider(c *gc.C) storage.Provider {
 	s.commands = &mockRunCommand{c: c}
-	runningInsideLXC := func() (bool, error) {
-		return s.runningInsideLXC, nil
-	}
-	return provider.LoopProvider(s.commands.run, runningInsideLXC)
+	return provider.LoopProvider(s.commands.run)
 }
 
 func (s *loopSuite) TestVolumeSource(c *gc.C) {
@@ -88,7 +83,6 @@ func (s *loopSuite) loopVolumeSource(c *gc.C) (storage.VolumeSource, *provider.M
 	return provider.LoopVolumeSource(
 		s.storageDir,
 		s.commands.run,
-		s.runningInsideLXC,
 	)
 }
 
@@ -128,32 +122,6 @@ func (s *loopSuite) TestCreateVolumesNoAttachment(c *gc.C) {
 	}})
 	// loop volumes may be created without attachments
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *loopSuite) TestCreateVolumesInsideLXC(c *gc.C) {
-	s.runningInsideLXC = true
-
-	source, _ := s.loopVolumeSource(c)
-	s.testCreateVolumesInsideLXC(c, source)
-
-	p := s.loopProvider(c)
-	cfg, err := storage.NewConfig("name", provider.LoopProviderType, map[string]interface{}{
-		"storage-dir": s.storageDir,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	source, err = p.VolumeSource(nil, cfg)
-	c.Assert(err, jc.ErrorIsNil)
-	s.testCreateVolumesInsideLXC(c, source)
-}
-
-func (s *loopSuite) testCreateVolumesInsideLXC(c *gc.C, source storage.VolumeSource) {
-	s.commands.expect("fallocate", "-l", "2MiB", filepath.Join(s.storageDir, "volume-0"))
-	volumes, _, err := source.CreateVolumes([]storage.VolumeParams{{
-		Tag: names.NewVolumeTag("0"), Size: 2,
-	}})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volumes, gc.HasLen, 1)
-	c.Assert(volumes[0].VolumeInfo.Persistent, jc.IsTrue)
 }
 
 func (s *loopSuite) TestDestroyVolumes(c *gc.C) {

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/storage/looputil"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -53,7 +54,9 @@ func newLxcBroker(
 	enableNAT bool,
 	defaultMTU int,
 ) (environs.InstanceBroker, error) {
-	manager, err := lxc.NewContainerManager(managerConfig, imageURLGetter)
+	manager, err := lxc.NewContainerManager(
+		managerConfig, imageURLGetter, looputil.NewLoopDeviceManager(),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Loop devices can outlive LXC containers, so we currently mark them as Persistent if allocated by an LXC container, and require that they be destroyed before the machine can be destroyed. The Juju agent remains running until the storage provisioner detaches all of the loop devices. This leaves a hole: "juju destroy-environment --force" will forcibly destroy the containers in the environment, so the loop devices remain.

To address this, we now detach loop devices when destroying LXC containers. There are two parts to this:
 - when the Juju agent uninstalls itself (due to it becoming Dead) from an LXC container, it will first detach any loop devices that are backed by files inside the data directory.
 - when Juju destroys an LXC container, it will detach any loop devices backed by files inside the container's root filesystem.

Both parts are necessary due to how we identify the relationship between a loop device and a container (i.e. by inspecting container filesystems).

As a result of these changes, no loop devices will leak any more, and so we no longer mark loop devices Persistent in any scenario. Once this lands, we can loosen the rules for machine destruction in state to assume that machine-scoped storage is always non-persistent.

Tested live with the local provider, with the following:
  - juju destroy-machine
  - juju destroy-environment
  - juju destroy-environment --force
Also tested with multiple machines, and ensured that only the destroyed machine's loop devices were detached.

(Review request: http://reviews.vapour.ws/r/2209/)