### PR TITLE
Upgrade step to add missing env-uuid field to statuses docs

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1403,3 +1403,45 @@ func AddDefaultBlockDevicesDocs(st *State) error {
 	}
 	return nil
 }
+
+// AddMissingEnvUUIDOnStatuses populates the env-uuid field where it
+// is missing due to LP #1474606.
+func AddMissingEnvUUIDOnStatuses(st *State) error {
+	statuses, closer := st.getRawCollection(statusesC)
+	defer closer()
+
+	sel := bson.M{"$or": []bson.M{
+		{"env-uuid": bson.M{"$exists": false}},
+		{"env-uuid": ""},
+	}}
+	var docs []bson.M
+	err := statuses.Find(sel).Select(bson.M{"_id": 1}).All(&docs)
+	if err != nil {
+		return errors.Annotate(err, "failed to read statuses")
+	}
+
+	var ops []txn.Op
+	for _, doc := range docs {
+		id, ok := doc["_id"].(string)
+		if !ok {
+			return errors.Errorf("unexpected id: %v", doc["_id"])
+		}
+
+		idParts := strings.SplitN(id, ":", 2)
+		if len(idParts) != 2 {
+			return errors.Errorf("unexpected id format: %v", id)
+		}
+
+		ops = append(ops, txn.Op{
+			C:      statusesC,
+			Id:     id,
+			Assert: txn.DocExists,
+			Update: bson.M{"$set": bson.M{"env-uuid": idParts[0]}},
+		})
+	}
+
+	if err := st.runRawTransaction(ops); err != nil {
+		return errors.Annotate(err, "statuses update failed")
+	}
+	return nil
+}

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -35,6 +35,10 @@ var stateUpgradeOperations = func() []Operation {
 			version.MustParse("1.24.0"),
 			stateStepsFor124(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.24.3"),
+			stateStepsFor1243(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -42,6 +42,19 @@ func stateStepsFor124() []Step {
 	}
 }
 
+// stateStepsFor1243 returns upgrade steps for Juju 1.24.3 that manipulate state directly.
+func stateStepsFor1243() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add missing env-uuid to statuses",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddMissingEnvUUIDOnStatuses(context.State())
+			},
+		},
+	}
+}
+
 // stepsFor1243 returns upgrade steps for Juju 1.24.3 that only need the API.
 func stepsFor1243() []Step {
 	return []Step{

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -33,6 +33,13 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
 }
 
+func (s *steps124Suite) TestStateStepsFor1243(c *gc.C) {
+	expected := []string{
+		"add missing env-uuid to statuses",
+	}
+	assertStateSteps(c, version.MustParse("1.24.3"), expected)
+}
+
 func (s *steps124Suite) TestStepsFor1243(c *gc.C) {
 	expected := []string{
 		"move syslog config from LogDir/DataDir to ConfDir",

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -671,7 +671,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0", "1.24.3"})
 }
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {


### PR DESCRIPTION
Part of the fix for LP #1474606.

(Review request: http://reviews.vapour.ws/r/2210/)