### PR TITLE
Fix upgrade on windows

### DIFF
--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -61,6 +61,11 @@ func (w *windowsConfigure) ConfigureJuju() error {
 	if err := w.icfg.VerifyConfig(); err != nil {
 		return errors.Trace(err)
 	}
+	if w.icfg.Bootstrap == true {
+		// Bootstrap machine not supported on windows
+		return errors.Errorf("bootstrapping is not supported on windows")
+	}
+
 	toolsJson, err := json.Marshal(w.icfg.Tools)
 	if err != nil {
 		return errors.Annotate(err, "while serializing the tools")
@@ -87,11 +92,6 @@ func (w *windowsConfigure) ConfigureJuju() error {
 
 	for _, cmd := range CreateJujuRegistryKeyCmds() {
 		w.conf.AddRunCmd(cmd)
-	}
-
-	if w.icfg.Bootstrap == true {
-		// Bootstrap machine not supported on windows
-		return errors.Errorf("bootstrapping is not supported on windows")
 	}
 
 	machineTag := names.NewMachineTag(w.icfg.MachineId)

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -89,17 +89,6 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		w.conf.AddRunCmd(cmd)
 	}
 
-	w.conf.AddScripts(
-		// Create a JUJU_DEV_FEATURE_FLAGS entry which may or may not be empty.
-		fmt.Sprintf(`New-ItemProperty -Path '%s' -Name '%s'`,
-			osenv.JujuRegistryKey,
-			osenv.JujuFeatureFlagEnvKey),
-		fmt.Sprintf(`Set-ItemProperty -Path '%s' -Name '%s' -Value '%s'`,
-			osenv.JujuRegistryKey,
-			osenv.JujuFeatureFlagEnvKey,
-			featureflag.AsEnvironmentValue()),
-	)
-
 	if w.icfg.Bootstrap == true {
 		// Bootstrap machine not supported on windows
 		return errors.Errorf("bootstrapping is not supported on windows")
@@ -128,5 +117,13 @@ func CreateJujuRegistryKeyCmds() []string {
 		`$rule = New-Object System.Security.AccessControl.RegistryAccessRule $perm`,
 		`$acl.SetAccessRule($rule)`,
 		fmt.Sprintf(`Set-Acl -Path '%s' -AclObject $acl`, osenv.JujuRegistryKey),
+		// Create a JUJU_DEV_FEATURE_FLAGS entry which may or may not be empty.
+		fmt.Sprintf(`New-ItemProperty -Path '%s' -Name '%s'`,
+			osenv.JujuRegistryKey,
+			osenv.JujuFeatureFlagEnvKey),
+		fmt.Sprintf(`Set-ItemProperty -Path '%s' -Name '%s' -Value '%s'`,
+			osenv.JujuRegistryKey,
+			osenv.JujuFeatureFlagEnvKey,
+			featureflag.AsEnvironmentValue()),
 	}
 }

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -83,18 +83,13 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		fmt.Sprintf(`& "%s" -c "import tarfile;archive = tarfile.open('$tmpBinDir\\tools.tar.gz');archive.extractall(path='$tmpBinDir')"`, python),
 		`rm "$binDir\tools.tar*"`,
 		fmt.Sprintf(`Set-Content $binDir\downloaded-tools.txt '%s'`, string(toolsJson)),
+	)
 
-		// Create a registry key for storing juju related information
-		fmt.Sprintf(`New-Item -Path '%s'`, osenv.JujuRegistryKey),
-		fmt.Sprintf(`$acl = Get-Acl -Path '%s'`, osenv.JujuRegistryKey),
+	for _, cmd := range CreateJujuRegistryKeyCmds() {
+		w.conf.AddRunCmd(cmd)
+	}
 
-		// Reset the ACL's on it and add administrator access only.
-		`$acl.SetAccessRuleProtection($true, $false)`,
-		`$perm = "BUILTIN\Administrators", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"`,
-		`$rule = New-Object System.Security.AccessControl.RegistryAccessRule $perm`,
-		`$acl.SetAccessRule($rule)`,
-		fmt.Sprintf(`Set-Acl -Path '%s' -AclObject $acl`, osenv.JujuRegistryKey),
-
+	w.conf.AddScripts(
 		// Create a JUJU_DEV_FEATURE_FLAGS entry which may or may not be empty.
 		fmt.Sprintf(`New-ItemProperty -Path '%s' -Name '%s'`,
 			osenv.JujuRegistryKey,
@@ -116,4 +111,22 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		return errors.Trace(err)
 	}
 	return w.addMachineAgentToBoot()
+}
+
+// CreateJujuRegistryKey is going to create a juju registry key and set
+// permissions on it such that it's only accessible to administrators
+// It is exported because it is used in an upgrade step
+func CreateJujuRegistryKeyCmds() []string {
+	return []string{
+		// Create a registry key for storing juju related information
+		fmt.Sprintf(`New-Item -Path '%s'`, osenv.JujuRegistryKey),
+		fmt.Sprintf(`$acl = Get-Acl -Path '%s'`, osenv.JujuRegistryKey),
+
+		// Reset the ACL's on it and add administrator access only.
+		`$acl.SetAccessRuleProtection($true, $false)`,
+		`$perm = "BUILTIN\Administrators", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"`,
+		`$rule = New-Object System.Security.AccessControl.RegistryAccessRule $perm`,
+		`$acl.SetAccessRule($rule)`,
+		fmt.Sprintf(`Set-Acl -Path '%s' -AclObject $acl`, osenv.JujuRegistryKey),
+	}
 }

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -50,4 +50,5 @@ var (
 
 	// 125 upgrade functions
 	AddInstanceTags = addInstanceTags
+	RemoveJujudpass = removeJujudpass
 )

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -16,9 +16,10 @@ var (
 	StateToolsStorage         = &stateToolsStorage
 	AddAZToInstData           = &addAZToInstData
 
-	ChownPath      = &chownPath
-	IsLocalEnviron = &isLocalEnviron
-	OsRemove       = &osRemove
+	ChownPath       = &chownPath
+	IsLocalEnviron  = &isLocalEnviron
+	OsRemove        = &osRemove
+	ExecRunCommands = &execRunCommands
 
 	// 118 upgrade functions
 	StepsFor118                            = stepsFor118
@@ -51,4 +52,5 @@ var (
 	// 125 upgrade functions
 	AddInstanceTags = addInstanceTags
 	RemoveJujudpass = removeJujudpass
+	AddJujuRegKey   = addJujuRegKey
 )

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -64,6 +64,10 @@ var upgradeOperations = func() []Operation {
 			version.MustParse("1.24.0"),
 			stepsFor124(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.25.0"),
+			stepsFor125(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -4,10 +4,15 @@
 package upgrades
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
+	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
+	"github.com/juju/utils/exec"
 )
 
 // stateStepsFor125 returns upgrade steps for Juju 1.25 that manipulate state directly.
@@ -51,9 +56,15 @@ func stepsFor125() []Step {
 			targets:     []Target{HostMachine},
 			run:         removeJujudpass,
 		},
+		&upgradeStep{
+			description: "add juju registry key",
+			targets:     []Target{HostMachine},
+			run:         addJujuRegKey,
+		},
 	}
 }
 
+// removeJujudpass removes a file that is no longer used on versions >1.25
 // The Jujud.pass file was created during cloud init before
 // so we know it's location for sure in case it exists
 func removeJujudpass(context Context) error {
@@ -62,8 +73,29 @@ func removeJujudpass(context Context) error {
 		if err := osRemove(fileLocation); err != nil {
 			// Don't fail the step if we can't get rid of the old files.
 			// We don't actually care if they still exist or not.
-			logger.Warningf("Can't delete old password file %q: %s", fileLocation, err)
+			logger.Warningf("can't delete old password file %q: %s", fileLocation, err)
 		}
+	}
+	return nil
+}
+
+var execRunCommands = exec.RunCommands
+
+// addJujuRegKey tries to create the same key that is now created during cloudinit
+// on machines having version 1.25 or up
+// Since support for ACL's in golang is quite disastrous at the moment, and they're
+// not especially easy to use, this is done using the exact same steps used in cloudinit
+func addJujuRegKey(context Context) error {
+	if version.Current.OS == version.Windows {
+		cmds := cloudconfig.CreateJujuRegistryKeyCmds()
+		_, err := execRunCommands(exec.RunParams{
+			Commands: strings.Join(cmds, "\n"),
+		})
+		if err != nil {
+			return errors.Annotate(err, "could not create juju registry key")
+		}
+		logger.Infof("created juju registry key at %s", osenv.JujuRegistryKey)
+		return nil
 	}
 	return nil
 }

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -4,9 +4,14 @@
 package upgrades_test
 
 import (
+	"errors"
+
 	gc "gopkg.in/check.v1"
 
+	jc "github.com/juju/testing/checkers"
+
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
 )
 
@@ -22,4 +27,59 @@ func (s *steps125Suite) TestStateStepsFor125(c *gc.C) {
 		"tag machine instances",
 	}
 	assertStateSteps(c, version.MustParse("1.25.0"), expected)
+}
+
+func (s *steps125Suite) TestStepsFor125(c *gc.C) {
+	expected := []string{
+		"remove Jujud.pass file on windows",
+	}
+	assertSteps(c, version.MustParse("1.25.0"), expected)
+}
+
+type mockOSRemove struct {
+	called     bool
+	path       string
+	shouldFail bool
+}
+
+func (m *mockOSRemove) osRemove(path string) error {
+	m.called = true
+	m.path = path
+	if m.shouldFail {
+		return errors.New("i done error'd")
+	}
+	return nil
+}
+
+var removeFileTests = []struct {
+	os           version.OSType
+	callExpected bool
+	shouldFail   bool
+}{
+	{
+		os:           version.Ubuntu,
+		callExpected: false,
+		shouldFail:   false,
+	},
+	{
+		os:           version.Windows,
+		callExpected: true,
+		shouldFail:   false,
+	},
+	{
+		os:           version.Windows,
+		callExpected: true,
+		shouldFail:   true,
+	},
+}
+
+func (s *steps125Suite) TestRemoveJujudPass(c *gc.C) {
+	for _, t := range removeFileTests {
+		mock := &mockOSRemove{shouldFail: t.shouldFail}
+		s.PatchValue(upgrades.OsRemove, mock.osRemove)
+		s.PatchValue(&version.Current.OS, t.os)
+		err := upgrades.RemoveJujudpass(nil)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(mock.called, gc.Equals, t.callExpected)
+	}
 }

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -5,11 +5,14 @@ package upgrades_test
 
 import (
 	"errors"
+	"strings"
 
 	gc "gopkg.in/check.v1"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/exec"
 
+	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
@@ -32,6 +35,7 @@ func (s *steps125Suite) TestStateStepsFor125(c *gc.C) {
 func (s *steps125Suite) TestStepsFor125(c *gc.C) {
 	expected := []string{
 		"remove Jujud.pass file on windows",
+		"add juju registry key",
 	}
 	assertSteps(c, version.MustParse("1.25.0"), expected)
 }
@@ -80,6 +84,61 @@ func (s *steps125Suite) TestRemoveJujudPass(c *gc.C) {
 		s.PatchValue(&version.Current.OS, t.os)
 		err := upgrades.RemoveJujudpass(nil)
 		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(mock.called, gc.Equals, t.callExpected)
+	}
+}
+
+type mockRunCmds struct {
+	c          *gc.C
+	commands   string
+	called     bool
+	shouldFail bool
+}
+
+func (m *mockRunCmds) runCommands(params exec.RunParams) (*exec.ExecResponse, error) {
+	m.called = true
+	m.c.Assert(params.Commands, gc.Equals, strings.Join(cloudconfig.CreateJujuRegistryKeyCmds(), "\n"))
+	if m.shouldFail {
+		return nil, errors.New("derp")
+	}
+	return nil, nil
+}
+
+var addRegKeyTests = []struct {
+	os           version.OSType
+	callExpected bool
+	shouldFail   bool
+	errMessage   string
+}{
+	{
+		os:           version.Ubuntu,
+		callExpected: false,
+		shouldFail:   false,
+	},
+	{
+		os:           version.Windows,
+		callExpected: true,
+		shouldFail:   false,
+	},
+	{
+		os:           version.Windows,
+		callExpected: true,
+		shouldFail:   true,
+		errMessage:   "could not create juju registry key: derp",
+	},
+}
+
+func (s *steps125Suite) TestAddJujuRegKey(c *gc.C) {
+	for _, t := range addRegKeyTests {
+		mock := &mockRunCmds{shouldFail: t.shouldFail, c: c}
+		s.PatchValue(upgrades.ExecRunCommands, mock.runCommands)
+		s.PatchValue(&version.Current.OS, t.os)
+		err := upgrades.AddJujuRegKey(nil)
+		if t.shouldFail {
+			c.Assert(err, gc.ErrorMatches, t.errMessage)
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+		}
 		c.Assert(mock.called, gc.Equals, t.callExpected)
 	}
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -676,7 +676,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0", "1.24.0"})
+	c.Assert(versions, gc.DeepEquals, []string{"1.18.0", "1.22.0", "1.23.0", "1.24.0", "1.25.0"})
 }
 
 func extractUpgradeVersions(c *gc.C, ops []upgrades.Operation) []string {


### PR DESCRIPTION
While adding a upgrade step for cleanup on windows, I noticed the machine wouldn't upgrade because ensureJujudPassword assumed a registry key was available from cloudinit. In hindsight, this obviously will not work with upgrades.

The reason it uses powershell code when upgrading is that ACL's are pretty hard to implement in go having no direct library anywhere and it would require a lot of syscalls which would amount to converging with the powershell code anyway. 

(Review request: http://reviews.vapour.ws/r/2218/)