### PR TITLE
apiserver/provisioner: fix compatibility with 1.20

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -35,6 +35,13 @@ import (
 var logger = loggo.GetLogger("juju.apiserver.provisioner")
 
 func init() {
+	common.RegisterStandardFacade("Provisioner", 0, NewProvisionerAPI)
+
+	// Version 1 has the same set of methods as 0, with the same
+	// signatures, but its ProvisioningInfo returns additional
+	// information. Clients may require version 1 so that they
+	// receive this additional information; otherwise they are
+	// compatible.
 	common.RegisterStandardFacade("Provisioner", 1, NewProvisionerAPI)
 }
 
@@ -52,6 +59,7 @@ type ProvisionerAPI struct {
 	*common.EnvironMachinesWatcher
 	*common.InstanceIdGetter
 	*common.ToolsFinder
+	*common.ToolsGetter
 
 	st          *state.State
 	resources   *common.Resources
@@ -93,6 +101,9 @@ func NewProvisionerAPI(st *state.State, resources *common.Resources, authorizer 
 			}
 		}, nil
 	}
+	getAuthOwner := func() (common.AuthFunc, error) {
+		return authorizer.AuthOwner, nil
+	}
 	env, err := st.Environment()
 	if err != nil {
 		return nil, err
@@ -111,6 +122,7 @@ func NewProvisionerAPI(st *state.State, resources *common.Resources, authorizer 
 		EnvironMachinesWatcher: common.NewEnvironMachinesWatcher(st, resources, authorizer),
 		InstanceIdGetter:       common.NewInstanceIdGetter(st, getAuthFunc),
 		ToolsFinder:            common.NewToolsFinder(st, st, urlGetter),
+		ToolsGetter:            common.NewToolsGetter(st, st, st, urlGetter, getAuthOwner),
 		st:                     st,
 		resources:              resources,
 		authorizer:             authorizer,


### PR DESCRIPTION
(Forward port)

Several backwards-incompatible changes were made to
the provisioner facade: v0 was first broken, and then
removed. We restore v0, and restore the ToolsGetter
functionality to it. This allows upgrading from 1.20.

Fixes https://bugs.launchpad.net/juju-core/+bug/1466969

(Review request: http://reviews.vapour.ws/r/2222/)