### PR TITLE
merge in correct version of leadership interface

### DIFF
--- a/apiserver/leadership/interface.go
+++ b/apiserver/leadership/interface.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
+// LeadershipService implements a variant of leadership.Claimer for consumption
+// over the API.
 type LeadershipService interface {
 
 	// ClaimLeadership makes a leadership claim with the given parameters.

--- a/leadership/interface.go
+++ b/leadership/interface.go
@@ -30,25 +30,35 @@ type Claimer interface {
 }
 
 // Token represents a unit's leadership of its service.
+//
+// It seems to be generic enough (it could easily represent any fact) that it
+// should find a more general home.
 type Token interface {
 
-	// Read exposes the token's content. The client is expected to magically
-	// know the token's meaning, and how it will be expressed, and pass a
-	// pointer to a suitable type. In practice, most implementations will
-	// likely expect *[]txn.Op, so that they can be used to gate mgo/txn-
-	// based state changes.
-	Read(interface{}) error
+	// Check returns an error if the condition it embodies no longer holds.
+	// If you pass a non-nil value into Check, it must be a pointer to data
+	// of the correct type, into which the token's content will be copied.
+	//
+	// The "correct type" is implementation-specific, and no implementation
+	// is obliged to accept any non-nil parameter; but methods that return
+	// Tokens should explain whether, and how, they will expose their content.
+	//
+	// In practice, most Token implementations will likely expect *[]txn.Op,
+	// so that they can be used to gate mgo/txn-based state changes.
+	Check(interface{}) error
 }
 
 // Checker exposes leadership testing capabilities.
 type Checker interface {
 
-	// CheckLeadership verifies that the named unit is leader of the named
+	// LeadershipCheck verifies that the named unit is leader of the named
 	// service, and returns a Token attesting to that fact for use building
 	// mgo/txn transactions that depend upon it.
-	CheckLeadership(serviceName, unitName string) (Token, error)
+	LeadershipCheck(serviceName, unitName string) Token
 }
 
+// LeadershipLeaseManager exposes lease management capabilities for the
+// convenience of the Manager type in this package.
 type LeadershipLeaseManager interface {
 
 	// Claimlease claims a lease for the given duration for the given

--- a/leadership/leadership.go
+++ b/leadership/leadership.go
@@ -41,7 +41,7 @@ func (m *Manager) Leader(sid, uid string) (bool, error) {
 	return tok.Id == uid, nil
 }
 
-// ClaimLeadership implements the LeadershipManager interface.
+// ClaimLeadership is part of the Claimer interface.
 func (m *Manager) ClaimLeadership(sid, uid string, duration time.Duration) error {
 
 	_, err := m.leaseMgr.ClaimLease(leadershipNamespace(sid), uid, duration)
@@ -56,12 +56,13 @@ func (m *Manager) ClaimLeadership(sid, uid string, duration time.Duration) error
 	return err
 }
 
-// ReleaseLeadership implements the LeadershipManager interface.
+// ReleaseLeadership releases leadership. It's deprecated and only still exists
+// for the comvennience of certainn tests.
 func (m *Manager) ReleaseLeadership(sid, uid string) error {
 	return m.leaseMgr.ReleaseLease(leadershipNamespace(sid), uid)
 }
 
-// BlockUntilLeadershipReleased implements the LeadershipManager interface.
+// BlockUntilLeadershipReleased is part of the Claimer interface.
 func (m *Manager) BlockUntilLeadershipReleased(serviceId string) error {
 	notifier, err := m.leaseMgr.LeaseReleasedNotifier(leadershipNamespace(serviceId))
 	if err != nil {

--- a/leadership/leadership.go
+++ b/leadership/leadership.go
@@ -57,7 +57,7 @@ func (m *Manager) ClaimLeadership(sid, uid string, duration time.Duration) error
 }
 
 // ReleaseLeadership releases leadership. It's deprecated and only still exists
-// for the comvennience of certainn tests.
+// for the convenience of certain tests.
 func (m *Manager) ReleaseLeadership(sid, uid string) error {
 	return m.leaseMgr.ReleaseLease(leadershipNamespace(sid), uid)
 }

--- a/state/leadership/check.go
+++ b/state/leadership/check.go
@@ -6,16 +6,15 @@ package leadership
 import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
-
-	"github.com/juju/juju/leadership"
+	"gopkg.in/mgo.v2/txn"
 )
 
 // check is used to deliver leadership-check requests to a manager's loop
-// goroutine on behalf of CheckLeadership.
+// goroutine on behalf of LeadershipCheck.
 type check struct {
 	serviceName string
 	unitName    string
-	response    chan leadership.Token
+	response    chan txn.Op
 	abort       <-chan struct{}
 }
 
@@ -37,31 +36,36 @@ func (c check) validate() error {
 }
 
 // invoke sends the check on the supplied channel, waits for a response, and
-// returns either a Token that can be used to assert continued leadership in
+// returns either a txn.Op that can be used to assert continued leadership in
 // the future, or an error.
-func (c check) invoke(ch chan<- check) (leadership.Token, error) {
+func (c check) invoke(ch chan<- check) (txn.Op, error) {
 	if err := c.validate(); err != nil {
-		return nil, errors.Annotatef(err, "cannot check leadership")
+		return txn.Op{}, errors.Annotatef(err, "cannot check leadership")
 	}
 	for {
 		select {
 		case <-c.abort:
-			return nil, errStopped
+			return txn.Op{}, errStopped
 		case ch <- c:
 			ch = nil
-		case token := <-c.response:
-			if token == nil {
-				return nil, errors.Errorf("%q is not leader of %q", c.unitName, c.serviceName)
+		case op, ok := <-c.response:
+			if !ok {
+				return txn.Op{}, errors.Errorf("%q is not leader of %q", c.unitName, c.serviceName)
 			}
-			return token, nil
+			return op, nil
 		}
 	}
 }
 
-// respond causes the supplied token to be sent back to invoke.
-func (c check) respond(token leadership.Token) {
+// succeed sends the supplied operation back to the originating invoke.
+func (c check) succeed(op txn.Op) {
 	select {
 	case <-c.abort:
-	case c.response <- token:
+	case c.response <- op:
 	}
+}
+
+// fail causes the originating invoke to return an error indicating non-leadership.
+func (c check) fail() {
+	close(c.response)
 }

--- a/state/leadership/fixture_test.go
+++ b/state/leadership/fixture_test.go
@@ -46,7 +46,7 @@ func almostSeconds(seconds int) time.Duration {
 	return (time.Second * time.Duration(seconds)) - time.Nanosecond
 }
 
-// Fixture allows us to test a leadership.Manager with a usefully-mocked
+// Fixture allows us to test a leadership.ManagerWorker with a usefully-mocked
 // lease.Clock and lease.Client.
 type Fixture struct {
 

--- a/state/leadership/manager_block_test.go
+++ b/state/leadership/manager_block_test.go
@@ -107,7 +107,7 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpiredEarly(c *gc.C) 
 
 		// Induce a refresh by making an unexpected check; it turns out the
 		// lease had already been expired by someone else.
-		manager.CheckLeadership("redis", "redis/99")
+		manager.LeadershipCheck("redis", "redis/99").Check(nil)
 		err := blockTest.assertUnblocked(c)
 		c.Check(err, jc.ErrorIsNil)
 	})

--- a/state/leadership/manager_check_test.go
+++ b/state/leadership/manager_check_test.go
@@ -17,13 +17,13 @@ import (
 	"github.com/juju/juju/state/lease"
 )
 
-type CheckLeadershipSuite struct {
+type LeadershipCheckSuite struct {
 	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&CheckLeadershipSuite{})
+var _ = gc.Suite(&LeadershipCheckSuite{})
 
-func (s *CheckLeadershipSuite) TestSuccess(c *gc.C) {
+func (s *LeadershipCheckSuite) TestSuccess(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
 			"redis": lease.Info{
@@ -34,15 +34,14 @@ func (s *CheckLeadershipSuite) TestSuccess(c *gc.C) {
 		},
 	}
 	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
-		token, err := manager.CheckLeadership("redis", "redis/0")
-		c.Assert(err, jc.ErrorIsNil)
+		token := manager.LeadershipCheck("redis", "redis/0")
 		c.Check(assertOps(c, token), jc.DeepEquals, []txn.Op{{
 			C: "fake", Id: "fake",
 		}})
 	})
 }
 
-func (s *CheckLeadershipSuite) TestMissingRefresh_Success(c *gc.C) {
+func (s *LeadershipCheckSuite) TestMissingRefresh_Success(c *gc.C) {
 	fix := &Fixture{
 		expectCalls: []call{{
 			method: "Refresh",
@@ -56,15 +55,14 @@ func (s *CheckLeadershipSuite) TestMissingRefresh_Success(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
-		token, err := manager.CheckLeadership("redis", "redis/0")
-		c.Assert(err, jc.ErrorIsNil)
+		token := manager.LeadershipCheck("redis", "redis/0")
 		c.Check(assertOps(c, token), jc.DeepEquals, []txn.Op{{
 			C: "fake", Id: "fake",
 		}})
 	})
 }
 
-func (s *CheckLeadershipSuite) TestOtherHolderRefresh_Success(c *gc.C) {
+func (s *LeadershipCheckSuite) TestOtherHolderRefresh_Success(c *gc.C) {
 	fix := &Fixture{
 		expectCalls: []call{{
 			method: "Refresh",
@@ -78,28 +76,26 @@ func (s *CheckLeadershipSuite) TestOtherHolderRefresh_Success(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
-		token, err := manager.CheckLeadership("redis", "redis/0")
-		c.Assert(err, jc.ErrorIsNil)
+		token := manager.LeadershipCheck("redis", "redis/0")
 		c.Check(assertOps(c, token), jc.DeepEquals, []txn.Op{{
 			C: "fake", Id: "fake",
 		}})
 	})
 }
 
-func (s *CheckLeadershipSuite) TestRefresh_Failure_Missing(c *gc.C) {
+func (s *LeadershipCheckSuite) TestRefresh_Failure_Missing(c *gc.C) {
 	fix := &Fixture{
 		expectCalls: []call{{
 			method: "Refresh",
 		}},
 	}
 	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
-		token, err := manager.CheckLeadership("redis", "redis/0")
-		c.Check(err, gc.ErrorMatches, `"redis/0" is not leader of "redis"`)
-		c.Check(token, gc.IsNil)
+		token := manager.LeadershipCheck("redis", "redis/0")
+		c.Check(token.Check(nil), gc.ErrorMatches, `"redis/0" is not leader of "redis"`)
 	})
 }
 
-func (s *CheckLeadershipSuite) TestRefresh_Failure_OtherHolder(c *gc.C) {
+func (s *LeadershipCheckSuite) TestRefresh_Failure_OtherHolder(c *gc.C) {
 	fix := &Fixture{
 		expectCalls: []call{{
 			method: "Refresh",
@@ -113,13 +109,12 @@ func (s *CheckLeadershipSuite) TestRefresh_Failure_OtherHolder(c *gc.C) {
 		}},
 	}
 	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
-		token, err := manager.CheckLeadership("redis", "redis/0")
-		c.Check(err, gc.ErrorMatches, `"redis/0" is not leader of "redis"`)
-		c.Check(token, gc.IsNil)
+		token := manager.LeadershipCheck("redis", "redis/0")
+		c.Check(token.Check(nil), gc.ErrorMatches, `"redis/0" is not leader of "redis"`)
 	})
 }
 
-func (s *CheckLeadershipSuite) TestRefresh_Error(c *gc.C) {
+func (s *LeadershipCheckSuite) TestRefresh_Error(c *gc.C) {
 	fix := &Fixture{
 		expectCalls: []call{{
 			method: "Refresh",
@@ -128,16 +123,15 @@ func (s *CheckLeadershipSuite) TestRefresh_Error(c *gc.C) {
 		expectDirty: true,
 	}
 	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
-		token, err := manager.CheckLeadership("redis", "redis/0")
-		c.Check(err, gc.ErrorMatches, "leadership manager stopped")
-		c.Check(token, gc.IsNil)
-		err = manager.Wait()
+		token := manager.LeadershipCheck("redis", "redis/0")
+		c.Check(token.Check(nil), gc.ErrorMatches, "leadership manager stopped")
+		err := manager.Wait()
 		c.Check(err, gc.ErrorMatches, "crunch squish")
 	})
 }
 
 func assertOps(c *gc.C, token coreleadership.Token) (out []txn.Op) {
-	err := token.Read(&out)
+	err := token.Check(&out)
 	c.Check(err, jc.ErrorIsNil)
 	return out
 }

--- a/state/leadership/manager_validation_test.go
+++ b/state/leadership/manager_validation_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/state/leadership"
+	"github.com/juju/juju/state/lease"
 )
 
 type ValidationSuite struct {
@@ -58,21 +60,39 @@ func (s *ValidationSuite) TestClaimLeadership_Duration(c *gc.C) {
 	})
 }
 
-func (s *ValidationSuite) TestCheckLeadership_ServiceName(c *gc.C) {
+func (s *ValidationSuite) TestLeadershipCheck_ServiceName(c *gc.C) {
 	fix := &Fixture{}
 	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
-		token, err := manager.CheckLeadership("foo/0", "bar/0")
-		c.Check(err, gc.ErrorMatches, `cannot check leadership: invalid service name "foo/0"`)
-		c.Check(token, gc.IsNil)
+		token := manager.LeadershipCheck("foo/0", "bar/0")
+		c.Check(token.Check(nil), gc.ErrorMatches, `cannot check leadership: invalid service name "foo/0"`)
 	})
 }
 
-func (s *ValidationSuite) TestCheckLeadership_UnitName(c *gc.C) {
+func (s *ValidationSuite) TestLeadershipCheck_UnitName(c *gc.C) {
 	fix := &Fixture{}
 	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
-		token, err := manager.CheckLeadership("foo", "bar")
-		c.Check(err, gc.ErrorMatches, `cannot check leadership: invalid unit name "bar"`)
-		c.Check(token, gc.IsNil)
+		token := manager.LeadershipCheck("foo", "bar")
+		c.Check(token.Check(nil), gc.ErrorMatches, `cannot check leadership: invalid unit name "bar"`)
+	})
+}
+
+func (s *ValidationSuite) TestLeadershipCheck_OutPtr(c *gc.C) {
+	fix := &Fixture{
+		expectCalls: []call{{
+			method: "Refresh",
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Holder:   "redis/0",
+					Expiry:   offset(time.Second),
+					AssertOp: txn.Op{C: "fake", Id: "fake"},
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager leadership.ManagerWorker, _ *Clock) {
+		bad := "bad"
+		token := manager.LeadershipCheck("redis", "redis/0")
+		c.Check(token.Check(&bad), gc.ErrorMatches, `expected pointer to \[\]txn.Op`)
 	})
 }
 

--- a/state/leadership/token.go
+++ b/state/leadership/token.go
@@ -10,15 +10,33 @@ import (
 
 // token implements leadership.Token.
 type token struct {
-	op txn.Op
+	serviceName string
+	unitName    string
+	checks      chan<- check
+	abort       <-chan struct{}
 }
 
-// Read is part of the leadership.Token interface.
-func (t token) Read(out interface{}) error {
-	outPtr, ok := out.(*[]txn.Op)
-	if !ok {
-		return errors.New("expected pointer to []txn.Op")
+// Check is part of the leadership.Token interface.
+func (t token) Check(out interface{}) error {
+
+	// Check validity and get the assert op in case it's needed.
+	op, err := check{
+		serviceName: t.serviceName,
+		unitName:    t.unitName,
+		response:    make(chan txn.Op),
+		abort:       t.abort,
+	}.invoke(t.checks)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	*outPtr = []txn.Op{t.op}
+
+	// Report transaction ops if the client wants them.
+	if out != nil {
+		outPtr, ok := out.(*[]txn.Op)
+		if !ok {
+			return errors.New("expected pointer to []txn.Op")
+		}
+		*outPtr = []txn.Op{op}
+	}
 	return nil
 }


### PR DESCRIPTION
...I had two branches with similar names and similar code and didn't look closely enough.

This introduces a leadership.Token interface that's retryable and suitable for use in a buildTxn loop.

(Review request: http://reviews.vapour.ws/r/2229/)