### PR TITLE
Don't automatically add env life assertions to txns

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -279,6 +279,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+	prereqOps = append(prereqOps, assertEnvAliveOp(st.EnvironUUID()))
 	prereqOps = append(prereqOps, st.insertNewContainerRefOp(mdoc.Id))
 	if template.InstanceId != "" {
 		prereqOps = append(prereqOps, txn.Op{
@@ -300,6 +301,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 			},
 		})
 	}
+
 	return mdoc, append(prereqOps, machineOp), nil
 }
 

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -141,9 +141,7 @@ func allCollections() collectionSchema {
 		// This collection is used for internal bookkeeping; certain complex
 		// or tedious state changes are deferred by recording a cleanup doc
 		// for later handling.
-		cleanupsC: {
-			insertWithoutEnvironment: true,
-		},
+		cleanupsC: {},
 
 		// This collection contains incrementing integers, subdivided by name,
 		// to ensure various IDs aren't reused.
@@ -153,7 +151,6 @@ func allCollections() collectionSchema {
 		// implement service leadership, but is namespaced and available
 		// for use by other clients in future.
 		leasesC: {
-			insertWithoutEnvironment: true,
 			indexes: []mgo.Index{{
 				Key: []string{"env-uuid", "type"},
 			}, {

--- a/state/database.go
+++ b/state/database.go
@@ -70,11 +70,6 @@ type collectionInfo struct {
 	// relevant environment uuid.
 	global bool
 
-	// insertWithoutEnvironment allows us to run transactions that insert to
-	// this collection even while the environment is dying or missing. It
-	// applies only to non-global collections.
-	insertWithoutEnvironment bool
-
 	// rawAccess collections can be safely accessed as a mongo.WriteCollection.
 	// Direct database access to txn-aware collections is strongly discouraged:
 	// merely writing directly to a field makes it impossible to use that field

--- a/state/environ.go
+++ b/state/environ.go
@@ -490,9 +490,15 @@ func createUniqueOwnerEnvNameOp(owner names.UserTag, envName string) txn.Op {
 
 // assertAliveOp returns a txn.Op that asserts the environment is alive.
 func (e *Environment) assertAliveOp() txn.Op {
+	return assertEnvAliveOp(e.UUID())
+}
+
+// assertEnvAliveOp returns a txn.Op that asserts the given
+// environment UUID refers to an Alive environment.
+func assertEnvAliveOp(envUUID string) txn.Op {
 	return txn.Op{
 		C:      environmentsC,
-		Id:     e.UUID(),
+		Id:     envUUID,
 		Assert: isEnvAliveDoc,
 	}
 }
@@ -502,6 +508,9 @@ func (e *Environment) assertAliveOp() txn.Op {
 // Environment documents from versions of Juju prior to 1.17
 // do not have the life field; if it does not exist, it should
 // be considered to have the value Alive.
+//
+// TODO(mjs) - this should be removed with existing uses replaced with
+// isAliveDoc. A DB migration should convert nil to Alive.
 var isEnvAliveDoc = bson.D{
 	{"life", bson.D{{"$in", []interface{}{Alive, nil}}}},
 }

--- a/state/environ.go
+++ b/state/environ.go
@@ -514,3 +514,13 @@ func assertEnvAliveOp(envUUID string) txn.Op {
 var isEnvAliveDoc = bson.D{
 	{"life", bson.D{{"$in", []interface{}{Alive, nil}}}},
 }
+
+func checkEnvLife(st *State) error {
+	env, err := st.Environment()
+	if (err == nil && env.Life() != Alive) || errors.IsNotFound(err) {
+		return errors.New("environment is no longer alive")
+	} else if err != nil {
+		return errors.Annotate(err, "unable to read environment")
+	}
+	return nil
+}

--- a/state/machine.go
+++ b/state/machine.go
@@ -1326,20 +1326,23 @@ func (m *Machine) AddNetworkInterface(args NetworkInterfaceInfo) (iface *Network
 		return nil, fmt.Errorf("interface name must be not empty")
 	}
 	doc := newNetworkInterfaceDoc(m.doc.Id, m.st.EnvironUUID(), args)
-	ops := []txn.Op{{
-		C:      networksC,
-		Id:     m.st.docID(args.NetworkName),
-		Assert: txn.DocExists,
-	}, {
-		C:      machinesC,
-		Id:     m.doc.DocID,
-		Assert: isAliveDoc,
-	}, {
-		C:      networkInterfacesC,
-		Id:     doc.Id,
-		Assert: txn.DocMissing,
-		Insert: doc,
-	}}
+	ops := []txn.Op{
+		assertEnvAliveOp(m.st.EnvironUUID()),
+		{
+			C:      networksC,
+			Id:     m.st.docID(args.NetworkName),
+			Assert: txn.DocExists,
+		}, {
+			C:      machinesC,
+			Id:     m.doc.DocID,
+			Assert: isAliveDoc,
+		}, {
+			C:      networkInterfacesC,
+			Id:     doc.Id,
+			Assert: txn.DocMissing,
+			Insert: doc,
+		},
+	}
 
 	err = m.st.runTransaction(ops)
 	switch err {

--- a/state/networkinterfaces.go
+++ b/state/networkinterfaces.go
@@ -206,8 +206,12 @@ func (ni *NetworkInterface) setDisabled(shouldDisable bool) error {
 	if err != nil {
 		return err
 	}
+	ops = append(ops, assertEnvAliveOp(ni.st.EnvironUUID()))
 	err = ni.st.runTransaction(ops)
 	if err != nil {
+		if err := checkEnvLife(ni.st); err != nil {
+			return errors.Trace(err)
+		}
 		return onAbort(err, errors.NotFoundf("network interface"))
 	}
 	ni.doc.IsDisabled = shouldDisable

--- a/state/ports.go
+++ b/state/ports.go
@@ -200,6 +200,9 @@ func (p *Ports) OpenPorts(portRange PortRange) (err error) {
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
+			if err := checkEnvLife(p.st); err != nil {
+				return nil, errors.Trace(err)
+			}
 			if err = ports.Refresh(); errors.IsNotFound(err) {
 				// No longer exists, we'll create it.
 				if !ports.areNew {
@@ -226,15 +229,19 @@ func (p *Ports) OpenPorts(portRange PortRange) (err error) {
 			}
 		}
 
+		ops := []txn.Op{
+			assertEnvAliveOp(p.st.EnvironUUID()),
+		}
 		if ports.areNew {
 			// Create a new document.
 			assert := txn.DocMissing
-			return addPortsDocOps(p.st, &ports.doc, assert, portRange)
+			ops = append(ops, addPortsDocOps(p.st, &ports.doc, assert, portRange)...)
 		} else {
 			// Update an existing document.
 			assert := bson.D{{"txn-revno", ports.doc.TxnRevno}}
-			return updatePortsDocOps(p.st, ports.doc, assert, portRange), nil
+			ops = append(ops, updatePortsDocOps(p.st, ports.doc, assert, portRange)...)
 		}
+		return ops, nil
 	}
 	// Run the transaction using the state transaction runner.
 	if err = p.st.run(buildTxn); err != nil {
@@ -389,7 +396,7 @@ func (m *Machine) AllPorts() ([]*Ports, error) {
 // statement for on the openedPorts collection op.
 var addPortsDocOps = addPortsDocOpsFunc
 
-func addPortsDocOpsFunc(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) ([]txn.Op, error) {
+func addPortsDocOpsFunc(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) []txn.Op {
 	pDoc.Ports = ports
 	return []txn.Op{{
 		C:      machinesC,
@@ -400,7 +407,7 @@ func addPortsDocOpsFunc(st *State, pDoc *portsDoc, portsAssert interface{}, port
 		Id:     pDoc.DocID,
 		Assert: portsAssert,
 		Insert: pDoc,
-	}}, nil
+	}}
 }
 
 // updatePortsDocOps returns the ops for adding a port range to an

--- a/state/state.go
+++ b/state/state.go
@@ -1157,10 +1157,7 @@ func (st *State) AddService(
 	ops = append(ops, peerOps...)
 
 	if err := st.runTransaction(ops); err == txn.ErrAborted {
-		err := env.Refresh()
-		if (err == nil && env.Life() != Alive) || errors.IsNotFound(err) {
-			return nil, errors.Errorf("environment is no longer alive")
-		} else if err != nil {
+		if err := checkEnvLife(st); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return nil, errors.Errorf("service already exists")

--- a/state/txns.go
+++ b/state/txns.go
@@ -177,14 +177,6 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 	return ops, nil
 }
 
-func assertEnvAliveOp(envUUID string) txn.Op {
-	return txn.Op{
-		C:      environmentsC,
-		Id:     envUUID,
-		Assert: isEnvAliveDoc,
-	}
-}
-
 func (r *multiEnvRunner) updateBsonD(doc bson.D, docID interface{}) (bson.D, error) {
 	idSeen := false
 	envUUIDSeen := false

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -42,7 +42,6 @@ func (s *MultiEnvRunnerSuite) SetUpTest(c *gc.C) {
 			environmentsC:      {global: true},
 			"other":            {global: true},
 			"raw":              {rawAccess: true},
-			"insert":           {insertWithoutEnvironment: true},
 		},
 	}
 }
@@ -55,10 +54,9 @@ type altMachineDoc struct {
 }
 
 type multiEnvRunnerTestCase struct {
-	label         string
-	input         txn.Op
-	expected      txn.Op
-	needsAliveEnv bool
+	label    string
+	input    txn.Op
+	expected txn.Op
 }
 
 // Test cases are returned by a function because transaction
@@ -78,7 +76,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 				Id:     "whatever",
 				Insert: bson.M{"_id": "whatever"},
 			},
-			false,
 		}, {
 			"env UUID added to doc",
 			txn.Op{
@@ -96,7 +93,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 					EnvUUID: "uuid",
 				},
 			},
-			true,
 		}, {
 			"_id added to doc if missing",
 			txn.Op{
@@ -112,7 +108,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 					EnvUUID: "uuid",
 				},
 			},
-			true,
 		}, {
 			"fields matched by struct tag, not field name",
 			txn.Op{
@@ -131,7 +126,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 					Environment: "uuid",
 				},
 			},
-			true,
 		}, {
 			"doc passed as struct value", // ok as long as no change to struct required
 			txn.Op{
@@ -151,7 +145,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 					EnvUUID: "uuid",
 				},
 			},
-			true,
 		}, {
 			"document passed as bson.D",
 			txn.Op{
@@ -167,7 +160,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 					{"env-uuid", "uuid"},
 				},
 			},
-			true,
 		}, {
 			"document passed as bson.M",
 			txn.Op{
@@ -183,7 +175,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 					"env-uuid": "uuid",
 				},
 			},
-			true,
 		}, {
 			"document passed as map[string]interface{}",
 			txn.Op{
@@ -199,7 +190,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 					"env-uuid": "uuid",
 				},
 			},
-			true,
 		},
 	}
 }
@@ -217,10 +207,6 @@ func (s *MultiEnvRunnerSuite) TestRunTransaction(c *gc.C) {
 		// Input should have been modified in-place.
 		c.Check(inOps, gc.DeepEquals, expected)
 
-		if t.needsAliveEnv {
-			expected = append(expected, assertEnvAliveOp(envUUID))
-		}
-
 		// Check ops seen by underlying runner.
 		c.Check(s.testRunner.seenOps, gc.DeepEquals, expected)
 	}
@@ -229,23 +215,15 @@ func (s *MultiEnvRunnerSuite) TestRunTransaction(c *gc.C) {
 func (s *MultiEnvRunnerSuite) TestMultipleOps(c *gc.C) {
 	var inOps []txn.Op
 	var expectedOps []txn.Op
-	var needsAliveEnv bool
 	for _, t := range getTestCases() {
 		inOps = append(inOps, t.input)
 		expectedOps = append(expectedOps, t.expected)
-		if !needsAliveEnv && t.needsAliveEnv {
-			needsAliveEnv = true
-		}
 	}
 
 	err := s.multiEnvRunner.RunTransaction(inOps)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(inOps, gc.DeepEquals, expectedOps)
-
-	if needsAliveEnv {
-		expectedOps = append(expectedOps, assertEnvAliveOp(envUUID))
-	}
 	c.Assert(s.testRunner.seenOps, gc.DeepEquals, expectedOps)
 }
 
@@ -277,9 +255,7 @@ func (s *MultiEnvRunnerSuite) TestWithObjectIds(c *gc.C) {
 			Id:      id,
 			EnvUUID: envUUID,
 		},
-	},
-		assertEnvAliveOp(envUUID),
-	}
+	}}
 
 	c.Assert(s.testRunner.seenOps, gc.DeepEquals, updatedOps)
 }
@@ -296,57 +272,6 @@ func (s *MultiEnvRunnerSuite) TestDoesNotAssertReferencedEnv(c *gc.C) {
 		Id:     envUUID,
 		Insert: bson.M{},
 	}})
-}
-
-func (s *MultiEnvRunnerSuite) TestIgnoreInsertRestrictionsWorks(c *gc.C) {
-	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
-		C:      "insert",
-		Id:     "whatever",
-		Insert: bson.M{},
-	}})
-	c.Check(err, jc.ErrorIsNil)
-
-	docID := envUUID + ":whatever"
-	c.Check(s.testRunner.seenOps, jc.DeepEquals, []txn.Op{{
-		C:  "insert",
-		Id: docID,
-		Insert: bson.M{
-			"_id":      docID,
-			"env-uuid": envUUID,
-		},
-	}})
-}
-
-func (s *MultiEnvRunnerSuite) TestIgnoreInsertRestrictionsDoesNotOverride(c *gc.C) {
-	err := s.multiEnvRunner.RunTransaction([]txn.Op{{
-		C:      "insert",
-		Id:     "whatever",
-		Insert: bson.M{},
-	}, {
-		C:      machinesC,
-		Id:     "123",
-		Insert: bson.M{},
-	}})
-	c.Check(err, jc.ErrorIsNil)
-
-	insertID := envUUID + ":whatever"
-	machineID := envUUID + ":123"
-	c.Check(s.testRunner.seenOps, jc.DeepEquals, []txn.Op{{
-		C:  "insert",
-		Id: insertID,
-		Insert: bson.M{
-			"_id":      insertID,
-			"env-uuid": envUUID,
-		},
-	}, {
-		C:  machinesC,
-		Id: machineID,
-		Insert: bson.M{
-			"_id":      machineID,
-			"env-uuid": envUUID,
-		},
-	}, assertEnvAliveOp(envUUID),
-	})
 }
 
 func (s *MultiEnvRunnerSuite) TestRejectRawAccessCollection(c *gc.C) {
@@ -456,13 +381,8 @@ func (s *MultiEnvRunnerSuite) TestRun(c *gc.C) {
 		})
 		c.Assert(err, jc.ErrorIsNil)
 
-		expected := []txn.Op{t.expected}
-		if t.needsAliveEnv {
-			expected = append(expected, assertEnvAliveOp(envUUID))
-		}
-
 		c.Check(seenAttempt, gc.Equals, testTxnAttempt)
-		c.Check(s.testRunner.seenOps, gc.DeepEquals, expected)
+		c.Check(s.testRunner.seenOps, gc.DeepEquals, []txn.Op{t.expected})
 	}
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1798,7 +1798,7 @@ func (s *upgradesSuite) patchPortOptFuncs() {
 
 	s.PatchValue(
 		&addPortsDocOps,
-		func(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) ([]txn.Op, error) {
+		func(st *State, pDoc *portsDoc, portsAssert interface{}, ports ...PortRange) []txn.Op {
 			pDoc.Ports = ports
 			return []txn.Op{{
 				C:      machinesC,
@@ -1809,7 +1809,7 @@ func (s *upgradesSuite) patchPortOptFuncs() {
 				Id:     portsGlobalKey(pDoc.MachineID, pDoc.NetworkName),
 				Assert: portsAssert,
 				Insert: pDoc,
-			}}, nil
+			}}
 		})
 
 	s.PatchValue(


### PR DESCRIPTION
This is a forward port of https://github.com/juju/juju/pull/2801, fixing LP #1474195.

The multiEnvRunner will no longer automatically add assertions on environment life to transactions as this create a serious performance bottleneck. Instead, the env is asserted to be alive in specific key areas (mainly where a txn may result in provisioning of resources).

(Review request: http://reviews.vapour.ws/r/2231/)