### PR TITLE
Add system list-blocks command

### DIFF
--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -86,7 +86,7 @@ func (c *CreateEnvironmentCommand) ConfValues() map[string]string {
 	return c.confValues
 }
 
-// NewDestroyCommand returns a DestroyCommand with the the systemmanager and client
+// NewDestroyCommand returns a DestroyCommand with the systemmanager and client
 // endpoints mocked out.
 func NewDestroyCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error) *DestroyCommand {
 	return &DestroyCommand{
@@ -98,7 +98,7 @@ func NewDestroyCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr 
 	}
 }
 
-// NewKillCommand returns a KillCommand with the the systemmanager and client
+// NewKillCommand returns a KillCommand with the systemmanager and client
 // endpoints mocked out.
 func NewKillCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error, dialFunc func(string) (*api.State, error)) *KillCommand {
 	return &KillCommand{
@@ -108,5 +108,14 @@ func NewKillCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr err
 			apierr:    apierr,
 		},
 		dialFunc,
+	}
+}
+
+// NewListBlocksCommand returns a ListBlocksCommand with the systemmanager
+// endpoint mocked out.
+func NewListBlocksCommand(api listBlocksAPI, apierr error) *ListBlocksCommand {
+	return &ListBlocksCommand{
+		api:    api,
+		apierr: apierr,
 	}
 }

--- a/cmd/juju/system/listblocks.go
+++ b/cmd/juju/system/listblocks.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+)
+
+// ListBlocksCommand lists all blocks for environments within the system.
+type ListBlocksCommand struct {
+	envcmd.SysCommandBase
+	out    cmd.Output
+	api    listBlocksAPI
+	apierr error
+}
+
+var listBlocksDoc = `List all blocks for environments within the specified system`
+
+// listBlocksAPI defines the methods on the system manager API endpoint
+// that the list-blocks command calls.
+type listBlocksAPI interface {
+	Close() error
+	ListBlockedEnvironments() ([]params.EnvironmentBlockInfo, error)
+}
+
+// Info implements Command.Info.
+func (c *ListBlocksCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "list-blocks",
+		Purpose: "list all blocks within the system",
+		Doc:     listBlocksDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *ListBlocksCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatTabularBlockedEnvironments,
+	})
+}
+
+func (c *ListBlocksCommand) getAPI() (listBlocksAPI, error) {
+	if c.api != nil {
+		return c.api, c.apierr
+	}
+	return c.NewSystemManagerAPIClient()
+}
+
+// Run implements Command.Run
+func (c *ListBlocksCommand) Run(ctx *cmd.Context) error {
+	api, err := c.getAPI()
+	if err != nil {
+		return errors.Annotate(err, "cannot connect to the API")
+	}
+	defer api.Close()
+
+	envs, err := api.ListBlockedEnvironments()
+	if err != nil {
+		logger.Errorf("Unable to list blocked environments: %s", err)
+		return err
+	}
+	return c.out.Write(ctx, envs)
+}

--- a/cmd/juju/system/listblocks_test.go
+++ b/cmd/juju/system/listblocks_test.go
@@ -1,0 +1,118 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package system_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/system"
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
+)
+
+type ListBlocksSuite struct {
+	testing.FakeJujuHomeSuite
+	api      *fakeListBlocksAPI
+	apierror error
+}
+
+var _ = gc.Suite(&ListBlocksSuite{})
+
+// fakeListBlocksAPI mocks out the systemmanager API
+type fakeListBlocksAPI struct {
+	err    error
+	blocks []params.EnvironmentBlockInfo
+}
+
+func (f *fakeListBlocksAPI) Close() error { return nil }
+
+func (f *fakeListBlocksAPI) ListBlockedEnvironments() ([]params.EnvironmentBlockInfo, error) {
+	return f.blocks, f.err
+}
+
+func (s *ListBlocksSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuHomeSuite.SetUpTest(c)
+	s.apierror = nil
+	s.api = &fakeListBlocksAPI{
+		blocks: []params.EnvironmentBlockInfo{
+			params.EnvironmentBlockInfo{
+				Name:     "test1",
+				UUID:     "test1-uuid",
+				OwnerTag: "cheryl@local",
+				Blocks: []string{
+					"BlockDestroy",
+				},
+			},
+			params.EnvironmentBlockInfo{
+				Name:     "test2",
+				UUID:     "test2-uuid",
+				OwnerTag: "bob@local",
+				Blocks: []string{
+					"BlockDestroy",
+					"BlockChange",
+				},
+			},
+		},
+	}
+}
+
+func (s *ListBlocksSuite) runListBlocksCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	cmd := system.NewListBlocksCommand(s.api, s.apierror)
+	return testing.RunCommand(c, cmd, args...)
+}
+
+func (s *ListBlocksSuite) TestListBlocksCannotConnectToAPI(c *gc.C) {
+	s.apierror = errors.New("connection refused")
+	_, err := s.runListBlocksCommand(c)
+	c.Assert(err, gc.ErrorMatches, "cannot connect to the API: connection refused")
+}
+
+func (s *ListBlocksSuite) TestListBlocksError(c *gc.C) {
+	s.api.err = errors.New("unexpected api error")
+	s.runListBlocksCommand(c)
+	testLog := c.GetTestLog()
+	c.Check(testLog, jc.Contains, "Unable to list blocked environments: unexpected api error")
+}
+
+func (s *ListBlocksSuite) TestListBlocksTabular(c *gc.C) {
+	ctx, err := s.runListBlocksCommand(c)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(testing.Stdout(ctx), gc.Equals, ""+
+		"NAME   ENVIRONMENT UUID  OWNER         BLOCKS\n"+
+		"test1  test1-uuid        cheryl@local  destroy-environment\n"+
+		"test2  test2-uuid        bob@local     destroy-environment,all-changes\n"+
+		"\n")
+}
+
+func (s *ListBlocksSuite) TestListBlocksJSON(c *gc.C) {
+	ctx, err := s.runListBlocksCommand(c, "--format", "json")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(testing.Stdout(ctx), gc.Equals, "["+
+		`{"name":"test1","env-uuid":"test1-uuid","owner-tag":"cheryl@local",`+
+		`"blocks":["BlockDestroy"]},`+
+		`{"name":"test2","env-uuid":"test2-uuid","owner-tag":"bob@local",`+
+		`"blocks":["BlockDestroy","BlockChange"]}`+
+		"]\n")
+}
+
+func (s *ListBlocksSuite) TestListBlocksYAML(c *gc.C) {
+	ctx, err := s.runListBlocksCommand(c, "--format", "yaml")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(testing.Stdout(ctx), gc.Equals, ""+
+		"- name: test1\n"+
+		"  uuid: test1-uuid\n"+
+		"  ownertag: cheryl@local\n"+
+		"  blocks:\n"+
+		"  - BlockDestroy\n"+
+		"- name: test2\n"+
+		"  uuid: test2-uuid\n"+
+		"  ownertag: bob@local\n"+
+		"  blocks:\n"+
+		"  - BlockDestroy\n"+
+		"  - BlockChange\n")
+}

--- a/cmd/juju/system/system.go
+++ b/cmd/juju/system/system.go
@@ -44,6 +44,7 @@ func NewSuperCommand() cmd.Command {
 	systemCmd.Register(&LoginCommand{})
 	systemCmd.Register(&DestroyCommand{})
 	systemCmd.Register(&KillCommand{apiDialerFunc: juju.NewAPIFromName})
+	systemCmd.Register(envcmd.WrapSystem(&ListBlocksCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&EnvironmentsCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&CreateEnvironmentCommand{}))
 	systemCmd.Register(envcmd.WrapSystem(&RemoveBlocksCommand{}))

--- a/cmd/juju/system/system_test.go
+++ b/cmd/juju/system/system_test.go
@@ -28,6 +28,7 @@ var expectedCommmandNames = []string{
 	"help",
 	"kill",
 	"list",
+	"list-blocks",
 	"login",
 	"remove-blocks",
 	"use-env", // alias for use-environment


### PR DESCRIPTION
This command will list all of the blocks set
on environments within the specified or current
system.

(Review request: http://reviews.vapour.ws/r/2233/)