### PR TITLE
Use a "namespace" prefix for hook context commands.

### DIFF
--- a/component/all/process.go
+++ b/component/all/process.go
@@ -101,7 +101,7 @@ func (workloadProcesses) registerHookContextCommands() {
 		return
 	}
 
-	jujuc.RegisterCommand("register", func(ctx jujuc.Context) cmd.Command {
+	jujuc.RegisterCommand("proc-register", func(ctx jujuc.Context) cmd.Command {
 		compCtx := workloadProcessesHookContext{ctx}
 		cmd, err := context.NewProcRegistrationCommand(compCtx)
 		if err != nil {
@@ -111,7 +111,7 @@ func (workloadProcesses) registerHookContextCommands() {
 		return cmd
 	})
 
-	jujuc.RegisterCommand("launch", func(ctx jujuc.Context) cmd.Command {
+	jujuc.RegisterCommand("proc-launch", func(ctx jujuc.Context) cmd.Command {
 		compCtx := workloadProcessesHookContext{ctx}
 		cmd, err := context.NewProcLaunchCommand(plugin.Find, plugin.Plugin.Launch, compCtx)
 		if err != nil {

--- a/component/all/process.go
+++ b/component/all/process.go
@@ -101,7 +101,8 @@ func (workloadProcesses) registerHookContextCommands() {
 		return
 	}
 
-	jujuc.RegisterCommand("proc-register", func(ctx jujuc.Context) cmd.Command {
+	name := context.RegisterCommandInfo.Name
+	jujuc.RegisterCommand(name, func(ctx jujuc.Context) cmd.Command {
 		compCtx := workloadProcessesHookContext{ctx}
 		cmd, err := context.NewProcRegistrationCommand(compCtx)
 		if err != nil {
@@ -111,7 +112,8 @@ func (workloadProcesses) registerHookContextCommands() {
 		return cmd
 	})
 
-	jujuc.RegisterCommand("proc-launch", func(ctx jujuc.Context) cmd.Command {
+	name = context.LaunchCommandInfo.Name
+	jujuc.RegisterCommand(name, func(ctx jujuc.Context) cmd.Command {
 		compCtx := workloadProcessesHookContext{ctx}
 		cmd, err := context.NewProcLaunchCommand(plugin.Find, plugin.Plugin.Launch, compCtx)
 		if err != nil {

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -20,6 +20,17 @@ import (
 
 var logger = loggo.GetLogger("juju.process.persistence")
 
+type cmdInfo struct {
+	// Name is the command's name.
+	Name string
+	// ExtraArgs is the list of arg names that follow "name", if any.
+	ExtraArgs []string
+	// Summary is the one-line description of the command.
+	Summary string
+	// Doc is the multi-line description of the command.
+	Doc string
+}
+
 // TODO(ericsnow) How to convert endpoints (charm.Process.Ports[].Name)
 // into actual ports? For now we should error out with such definitions
 // (and recommend overriding).

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -25,6 +25,8 @@ type cmdInfo struct {
 	Name string
 	// ExtraArgs is the list of arg names that follow "name", if any.
 	ExtraArgs []string
+	// OptionalArgs is the list of optional args, if any.
+	OptionalArgs []string
 	// Summary is the one-line description of the command.
 	Summary string
 	// Doc is the multi-line description of the command.
@@ -39,6 +41,8 @@ type cmdInfo struct {
 // hook env commands.
 type baseCommand struct {
 	cmd.CommandBase
+
+	cmdInfo
 
 	ctx     HookContext
 	compCtx Component
@@ -59,6 +63,27 @@ func newCommand(ctx HookContext) (*baseCommand, error) {
 		ctx:     ctx,
 		compCtx: compCtx,
 	}, nil
+}
+
+// Info implements cmd.Command.
+func (c baseCommand) Info() *cmd.Info {
+	args := []string{"<name>"} // name isn't optional
+	for _, name := range c.cmdInfo.ExtraArgs {
+		arg := "<" + name + ">"
+		for _, optional := range c.cmdInfo.OptionalArgs {
+			if name == optional {
+				arg = "[" + arg + "]"
+				break
+			}
+		}
+		args = append(args, arg)
+	}
+	return &cmd.Info{
+		Name:    c.cmdInfo.Name,
+		Args:    strings.Join(args, " "),
+		Purpose: c.cmdInfo.Summary,
+		Doc:     c.cmdInfo.Doc,
+	}
 }
 
 // Init implements cmd.Command.

--- a/process/context/launch.go
+++ b/process/context/launch.go
@@ -52,7 +52,7 @@ type ProcLaunchCommand struct {
 // Info implements cmd.Command.
 func (c *ProcLaunchCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "launch",
+		Name:    "proc-launch",
 		Args:    "<name>",
 		Purpose: "launch a workload process",
 		Doc:     launchDoc,

--- a/process/context/launch.go
+++ b/process/context/launch.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/charm.v5"
 )
 
+// LaunchCommandInfo is the info for the proc-launch command.
 var LaunchCommandInfo = cmdInfo{
 	Name:    "proc-launch",
 	Summary: "launch a workload process",
@@ -37,11 +38,13 @@ func NewProcLaunchCommand(findPlugin FindPluginFn, launchPlugin LaunchPluginFn, 
 		return nil, err
 	}
 
-	return &ProcLaunchCommand{
+	c := &ProcLaunchCommand{
 		registeringCommand: *base,
 		findPlugin:         findPlugin,
 		launchPlugin:       launchPlugin,
-	}, nil
+	}
+	c.cmdInfo = LaunchCommandInfo
+	return c, nil
 }
 
 // ProcLaunchCommand implements the launch command for launching
@@ -51,16 +54,6 @@ type ProcLaunchCommand struct {
 
 	findPlugin   FindPluginFn
 	launchPlugin LaunchPluginFn
-}
-
-// Info implements cmd.Command.
-func (c *ProcLaunchCommand) Info() *cmd.Info {
-	return &cmd.Info{
-		Name:    LaunchCommandInfo.Name,
-		Args:    "<name>",
-		Purpose: LaunchCommandInfo.Summary,
-		Doc:     LaunchCommandInfo.Doc,
-	}
 }
 
 // Init implements cmd.Command.

--- a/process/context/launch.go
+++ b/process/context/launch.go
@@ -13,11 +13,15 @@ import (
 	"gopkg.in/juju/charm.v5"
 )
 
-const launchDoc = `
+var LaunchCommandInfo = cmdInfo{
+	Name:    "proc-launch",
+	Summary: "launch a workload process",
+	Doc: `
 "launch" is used to launch a workload process.
 
 The process name must correspond to one of the processes defined in
-the charm's metadata.yaml.`
+the charm's metadata.yaml.`,
+}
 
 // FindPluginFn will find a plugin given its name.
 type FindPluginFn func(string) (*plugin.Plugin, error)
@@ -52,10 +56,10 @@ type ProcLaunchCommand struct {
 // Info implements cmd.Command.
 func (c *ProcLaunchCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "proc-launch",
+		Name:    LaunchCommandInfo.Name,
 		Args:    "<name>",
-		Purpose: "launch a workload process",
-		Doc:     launchDoc,
+		Purpose: LaunchCommandInfo.Summary,
+		Doc:     LaunchCommandInfo.Doc,
 	}
 }
 

--- a/process/context/launch.go
+++ b/process/context/launch.go
@@ -15,7 +15,7 @@ import (
 
 // LaunchCommandInfo is the info for the proc-launch command.
 var LaunchCommandInfo = cmdInfo{
-	Name:    "proc-launch",
+	Name:    "process-launch",
 	Summary: "launch a workload process",
 	Doc: `
 "launch" is used to launch a workload process.

--- a/process/context/launch_test.go
+++ b/process/context/launch_test.go
@@ -71,7 +71,7 @@ func (s *launchCmdSuite) TestRun(c *gc.C) {
 
 	cmd, err := context.NewProcLaunchCommand(findPlugin, launchPlugin, s.Ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	s.setCommand(c, "proc-launch", cmd)
+	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
 	cmd.ReadMetadata = s.readMetadata
 
@@ -91,7 +91,7 @@ func (s *launchCmdSuite) TestRunCantFindPlugin(c *gc.C) {
 
 	cmd, err := context.NewProcLaunchCommand(findPlugin, nil, s.Ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	s.setCommand(c, "proc-launch", cmd)
+	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
 	cmd.ReadMetadata = s.readMetadata
 
@@ -114,7 +114,7 @@ func (s *launchCmdSuite) TestLaunchCommandErrorRunning(c *gc.C) {
 
 	cmd, err := context.NewProcLaunchCommand(findPlugin, launchPlugin, s.Ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	s.setCommand(c, "proc-launch", cmd)
+	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
 	cmd.ReadMetadata = s.readMetadata
 

--- a/process/context/launch_test.go
+++ b/process/context/launch_test.go
@@ -71,7 +71,7 @@ func (s *launchCmdSuite) TestRun(c *gc.C) {
 
 	cmd, err := context.NewProcLaunchCommand(findPlugin, launchPlugin, s.Ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	s.setCommand(c, "launch", cmd)
+	s.setCommand(c, "proc-launch", cmd)
 	s.setMetadata(*s.proc)
 	cmd.ReadMetadata = s.readMetadata
 
@@ -91,7 +91,7 @@ func (s *launchCmdSuite) TestRunCantFindPlugin(c *gc.C) {
 
 	cmd, err := context.NewProcLaunchCommand(findPlugin, nil, s.Ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	s.setCommand(c, "launch", cmd)
+	s.setCommand(c, "proc-launch", cmd)
 	s.setMetadata(*s.proc)
 	cmd.ReadMetadata = s.readMetadata
 
@@ -114,7 +114,7 @@ func (s *launchCmdSuite) TestLaunchCommandErrorRunning(c *gc.C) {
 
 	cmd, err := context.NewProcLaunchCommand(findPlugin, launchPlugin, s.Ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	s.setCommand(c, "launch", cmd)
+	s.setCommand(c, "proc-launch", cmd)
 	s.setMetadata(*s.proc)
 	cmd.ReadMetadata = s.readMetadata
 

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -10,14 +10,19 @@ import (
 	"github.com/juju/juju/process"
 )
 
-const registerDoc = `
+var RegisterCommandInfo = cmdInfo{
+	Name:      "proc-register",
+	ExtraArgs: []string{"proc-details"},
+	Summary:   "register a workload process",
+	Doc: `
 "register" is used while a hook is running to let Juju know that
 a workload process has been manually started. The information used
 to start the process must be provided when "register" is run.
 
 The process name must correspond to one of the processes defined in
 the charm's metadata.yaml.
-`
+`,
+}
 
 // ProcRegistrationCommand implements the register command.
 type ProcRegistrationCommand struct {
@@ -38,10 +43,10 @@ func NewProcRegistrationCommand(ctx HookContext) (*ProcRegistrationCommand, erro
 // Info implements cmd.Command.
 func (c *ProcRegistrationCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "proc-register",
+		Name:    RegisterCommandInfo.Name,
 		Args:    "<name> <proc-details>",
-		Purpose: "register a workload process",
-		Doc:     registerDoc,
+		Purpose: RegisterCommandInfo.Summary,
+		Doc:     RegisterCommandInfo.Doc,
 	}
 }
 

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -12,7 +12,7 @@ import (
 
 // RegisterCommandInfo is the info for the proc-launch command.
 var RegisterCommandInfo = cmdInfo{
-	Name:      "proc-register",
+	Name:      "process-register",
 	ExtraArgs: []string{"proc-details"},
 	Summary:   "register a workload process",
 	Doc: `

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -38,7 +38,7 @@ func NewProcRegistrationCommand(ctx HookContext) (*ProcRegistrationCommand, erro
 // Info implements cmd.Command.
 func (c *ProcRegistrationCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "register",
+		Name:    "proc-register",
 		Args:    "<name> <proc-details>",
 		Purpose: "register a workload process",
 		Doc:     registerDoc,

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/process"
 )
 
+// RegisterCommandInfo is the info for the proc-launch command.
 var RegisterCommandInfo = cmdInfo{
 	Name:      "proc-register",
 	ExtraArgs: []string{"proc-details"},
@@ -35,19 +36,11 @@ func NewProcRegistrationCommand(ctx HookContext) (*ProcRegistrationCommand, erro
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &ProcRegistrationCommand{
+	c := &ProcRegistrationCommand{
 		registeringCommand: *base,
-	}, nil
-}
-
-// Info implements cmd.Command.
-func (c *ProcRegistrationCommand) Info() *cmd.Info {
-	return &cmd.Info{
-		Name:    RegisterCommandInfo.Name,
-		Args:    "<name> <proc-details>",
-		Purpose: RegisterCommandInfo.Summary,
-		Doc:     RegisterCommandInfo.Doc,
 	}
+	c.cmdInfo = RegisterCommandInfo
+	return c, nil
 }
 
 // Init implements cmd.Command.

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -30,7 +30,7 @@ func (s *registerSuite) SetUpTest(c *gc.C) {
 	cmd.ReadMetadata = s.readMetadata
 
 	s.registerCmd = cmd
-	s.setCommand(c, "proc-register", s.registerCmd)
+	s.setCommand(c, "process-register", s.registerCmd)
 }
 
 func (s *registerSuite) init(c *gc.C, name, id, status string) {
@@ -57,7 +57,7 @@ func (s *registerSuite) TestCommandRegistered(c *gc.C) {
 
 func (s *registerSuite) TestHelp(c *gc.C) {
 	s.checkHelp(c, `
-usage: proc-register [options] <name> <proc-details>
+usage: process-register [options] <name> <proc-details>
 purpose: register a workload process
 
 options:

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -30,7 +30,7 @@ func (s *registerSuite) SetUpTest(c *gc.C) {
 	cmd.ReadMetadata = s.readMetadata
 
 	s.registerCmd = cmd
-	s.setCommand(c, "register", s.registerCmd)
+	s.setCommand(c, "proc-register", s.registerCmd)
 }
 
 func (s *registerSuite) init(c *gc.C, name, id, status string) {

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -57,7 +57,7 @@ func (s *registerSuite) TestCommandRegistered(c *gc.C) {
 
 func (s *registerSuite) TestHelp(c *gc.C) {
 	s.checkHelp(c, `
-usage: register [options] <name> <proc-details>
+usage: proc-register [options] <name> <proc-details>
 purpose: register a workload process
 
 options:


### PR DESCRIPTION
The current lack of a prefix makes the commands a bit ambiguous and raises the risk of a name collision.

(Review request: http://reviews.vapour.ws/r/2235/)