### PR TITLE
Separate runner factory from the context factory.

### DIFF
--- a/worker/uniter/runner/contextfactory.go
+++ b/worker/uniter/runner/contextfactory.go
@@ -1,0 +1,369 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"gopkg.in/juju/charm.v5"
+	"gopkg.in/juju/charm.v5/hooks"
+
+	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker/leadership"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/metrics"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+// ContextFactory represents a long-lived object that can create execution contexts
+// relevant to a specific unit.
+type ContextFactory interface {
+	// CommandContext creates a new context for running a juju command.
+	CommandContext(commandInfo CommandInfo) (*HookContext, error)
+
+	// HookContext creates a new context for running a juju hook.
+	HookContext(hookInfo hook.Info) (*HookContext, error)
+
+	// ActionContext creates a new context for running a juju action.
+	ActionContext(actionData *ActionData) (*HookContext, error)
+}
+
+// StorageContextAccessor is an interface providing access to StorageContexts
+// for a jujuc.Context.
+type StorageContextAccessor interface {
+
+	// StorageTags returns the tags of storage instances attached to
+	// the unit.
+	StorageTags() []names.StorageTag
+
+	// Storage returns the jujuc.ContextStorageAttachment with the
+	// supplied tag if it was found, and whether it was found.
+	Storage(names.StorageTag) (jujuc.ContextStorageAttachment, bool)
+}
+
+// RelationsFunc is used to get snapshots of relation membership at context
+// creation time.
+type RelationsFunc func() map[int]*RelationInfo
+
+type contextFactory struct {
+	// API connection fields; unit should be deprecated, but isn't yet.
+	unit    *uniter.Unit
+	state   *uniter.State
+	tracker leadership.Tracker
+
+	// Fields that shouldn't change in a factory's lifetime.
+	paths      Paths
+	envUUID    string
+	envName    string
+	machineTag names.MachineTag
+	ownerTag   names.UserTag
+	storage    StorageContextAccessor
+
+	// Callback to get relation state snapshot.
+	getRelationInfos RelationsFunc
+	relationCaches   map[int]*RelationCache
+
+	// For generating "unique" context ids.
+	rand *rand.Rand
+}
+
+// NewContextFactory returns a ContextFactory capable of creating execution contexts backed
+// by the supplied unit's supplied API connection.
+func NewContextFactory(
+	state *uniter.State,
+	unitTag names.UnitTag,
+	tracker leadership.Tracker,
+	getRelationInfos RelationsFunc,
+	storage StorageContextAccessor,
+	paths Paths,
+) (
+	ContextFactory, error,
+) {
+	unit, err := state.Unit(unitTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	service, err := state.Service(unit.ServiceTag())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ownerTag, err := service.OwnerTag()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	machineTag, err := unit.AssignedMachine()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	environment, err := state.Environment()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	f := &contextFactory{
+		unit:             unit,
+		state:            state,
+		tracker:          tracker,
+		paths:            paths,
+		envUUID:          environment.UUID(),
+		envName:          environment.Name(),
+		machineTag:       machineTag,
+		ownerTag:         ownerTag,
+		getRelationInfos: getRelationInfos,
+		relationCaches:   map[int]*RelationCache{},
+		storage:          storage,
+		rand:             rand.New(rand.NewSource(time.Now().Unix())),
+	}
+	return f, nil
+}
+
+// newId returns a probably-unique identifier for a new context, containing the
+// supplied string.
+func (f *contextFactory) newId(name string) string {
+	return fmt.Sprintf("%s-%s-%d", f.unit.Name(), name, f.rand.Int63())
+}
+
+// coreContext creates a new context with all unspecialised fields filled in.
+func (f *contextFactory) coreContext() (*HookContext, error) {
+	leadershipContext := newLeadershipContext(
+		f.state.LeadershipSettings,
+		f.tracker,
+	)
+	ctx := &HookContext{
+		unit:               f.unit,
+		state:              f.state,
+		LeadershipContext:  leadershipContext,
+		uuid:               f.envUUID,
+		envName:            f.envName,
+		unitName:           f.unit.Name(),
+		assignedMachineTag: f.machineTag,
+		serviceOwner:       f.ownerTag,
+		relations:          f.getContextRelations(),
+		relationId:         -1,
+		metricsRecorder:    nil,
+		definedMetrics:     nil,
+		pendingPorts:       make(map[PortRange]PortRangeInfo),
+		storage:            f.storage,
+	}
+	if err := f.updateContext(ctx); err != nil {
+		return nil, err
+	}
+	return ctx, nil
+}
+
+// ActionContext is part of the ContextFactory interface.
+func (f *contextFactory) ActionContext(actionData *ActionData) (*HookContext, error) {
+	if actionData == nil {
+		return nil, errors.New("nil actionData specified")
+	}
+	ctx, err := f.coreContext()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ctx.actionData = actionData
+	ctx.id = f.newId(actionData.Name)
+	return ctx, nil
+}
+
+// HookContext is part of the ContextFactory interface.
+func (f *contextFactory) HookContext(hookInfo hook.Info) (*HookContext, error) {
+	ctx, err := f.coreContext()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	hookName := string(hookInfo.Kind)
+	if hookInfo.Kind.IsRelation() {
+		ctx.relationId = hookInfo.RelationId
+		ctx.remoteUnitName = hookInfo.RemoteUnit
+		relation, found := ctx.relations[hookInfo.RelationId]
+		if !found {
+			return nil, errors.Errorf("unknown relation id: %v", hookInfo.RelationId)
+		}
+		if hookInfo.Kind == hooks.RelationDeparted {
+			relation.cache.RemoveMember(hookInfo.RemoteUnit)
+		} else if hookInfo.RemoteUnit != "" {
+			// Clear remote settings cache for changing remote unit.
+			relation.cache.InvalidateMember(hookInfo.RemoteUnit)
+		}
+		hookName = fmt.Sprintf("%s-%s", relation.Name(), hookInfo.Kind)
+	}
+	if hookInfo.Kind.IsStorage() {
+		ctx.storageTag = names.NewStorageTag(hookInfo.StorageId)
+		if _, found := ctx.storage.Storage(ctx.storageTag); !found {
+			return nil, errors.Errorf("unknown storage id: %v", hookInfo.StorageId)
+		}
+		storageName, err := names.StorageName(hookInfo.StorageId)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		hookName = fmt.Sprintf("%s-%s", storageName, hookName)
+	}
+	// Metrics are only sent from the collect-metrics hook.
+	if hookInfo.Kind == hooks.CollectMetrics {
+		ch, err := getCharm(f.paths.GetCharmDir())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ctx.definedMetrics = ch.Metrics()
+
+		chURL, err := f.unit.CharmURL()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		charmMetrics := map[string]charm.Metric{}
+		if ch.Metrics() != nil {
+			charmMetrics = ch.Metrics().Metrics
+		}
+		ctx.metricsRecorder, err = metrics.NewJSONMetricRecorder(
+			f.paths.GetMetricsSpoolDir(),
+			charmMetrics,
+			chURL.String())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	ctx.id = f.newId(hookName)
+	return ctx, nil
+}
+
+// CommandContext is part of the ContextFactory interface.
+func (f *contextFactory) CommandContext(commandInfo CommandInfo) (*HookContext, error) {
+	ctx, err := f.coreContext()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	relationId, remoteUnitName, err := inferRemoteUnit(ctx.relations, commandInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ctx.relationId = relationId
+	ctx.remoteUnitName = remoteUnitName
+	ctx.id = f.newId("run-commands")
+	return ctx, nil
+}
+
+// getContextRelations updates the factory's relation caches, and uses them
+// to construct ContextRelations for a fresh context.
+func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
+	contextRelations := map[int]*ContextRelation{}
+	relationInfos := f.getRelationInfos()
+	relationCaches := map[int]*RelationCache{}
+	for id, info := range relationInfos {
+		relationUnit := info.RelationUnit
+		memberNames := info.MemberNames
+		cache, found := f.relationCaches[id]
+		if found {
+			cache.Prune(memberNames)
+		} else {
+			cache = NewRelationCache(relationUnit.ReadSettings, memberNames)
+		}
+		relationCaches[id] = cache
+		contextRelations[id] = NewContextRelation(relationUnit, cache)
+	}
+	f.relationCaches = relationCaches
+	return contextRelations
+}
+
+// updateContext fills in all unspecialized fields that require an API call to
+// discover.
+//
+// Approximately *every* line of code in this function represents a bug: ie, some
+// piece of information we expose to the charm but which we fail to report changes
+// to via hooks. Furthermore, the fact that we make multiple API calls at this
+// time, rather than grabbing everything we need in one go, is unforgivably yucky.
+func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
+	defer errors.Trace(err)
+
+	ctx.apiAddrs, err = f.state.APIAddresses()
+	if err != nil {
+		return err
+	}
+	ctx.machinePorts, err = f.state.AllMachinePorts(f.machineTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	statusCode, statusInfo, err := f.unit.MeterStatus()
+	if err != nil {
+		return errors.Annotate(err, "could not retrieve meter status for unit")
+	}
+	ctx.meterStatus = &meterStatus{
+		code: statusCode,
+		info: statusInfo,
+	}
+
+	// TODO(fwereade) 23-10-2014 bug 1384572
+	// Nothing here should ever be getting the environ config directly.
+	environConfig, err := f.state.EnvironConfig()
+	if err != nil {
+		return err
+	}
+	ctx.proxySettings = environConfig.ProxySettings()
+
+	// Calling these last, because there's a potential race: they're not guaranteed
+	// to be set in time to be needed for a hook. If they're not, we just leave them
+	// unset as we always have; this isn't great but it's about behaviour preservation.
+	ctx.publicAddress, err = f.unit.PublicAddress()
+	if err != nil && !params.IsCodeNoAddressSet(err) {
+		return err
+	}
+	ctx.privateAddress, err = f.unit.PrivateAddress()
+	if err != nil && !params.IsCodeNoAddressSet(err) {
+		return err
+	}
+	return nil
+}
+
+func inferRemoteUnit(rctxs map[int]*ContextRelation, info CommandInfo) (int, string, error) {
+	relationId := info.RelationId
+	hasRelation := relationId != -1
+	remoteUnit := info.RemoteUnitName
+	hasRemoteUnit := remoteUnit != ""
+
+	// Check baseline sanity of remote unit, if supplied.
+	if hasRemoteUnit {
+		if !names.IsValidUnit(remoteUnit) {
+			return -1, "", errors.Errorf(`invalid remote unit: %s`, remoteUnit)
+		} else if !hasRelation {
+			return -1, "", errors.Errorf("remote unit provided without a relation: %s", remoteUnit)
+		}
+	}
+
+	// Check sanity of relation, if supplied, otherwise easy early return.
+	if !hasRelation {
+		return relationId, remoteUnit, nil
+	}
+	rctx, found := rctxs[relationId]
+	if !found {
+		return -1, "", errors.Errorf("unknown relation id: %d", relationId)
+	}
+
+	// Past basic sanity checks; if forced, accept what we're given.
+	if info.ForceRemoteUnit {
+		return relationId, remoteUnit, nil
+	}
+
+	// Infer an appropriate remote unit if we can.
+	possibles := rctx.UnitNames()
+	if remoteUnit == "" {
+		switch len(possibles) {
+		case 0:
+			return -1, "", errors.Errorf("cannot infer remote unit in empty relation %d", relationId)
+		case 1:
+			return relationId, possibles[0], nil
+		}
+		return -1, "", errors.Errorf("ambiguous remote unit; possibilities are %+v", possibles)
+	}
+	for _, possible := range possibles {
+		if remoteUnit == possible {
+			return relationId, remoteUnit, nil
+		}
+	}
+	return -1, "", errors.Errorf("unknown remote unit %s; possibilities are %+v", remoteUnit, possibles)
+}

--- a/worker/uniter/runner/contextfactory_test.go
+++ b/worker/uniter/runner/contextfactory_test.go
@@ -1,0 +1,203 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package runner_test
+
+import (
+	"os"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/fs"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5/hooks"
+
+	"github.com/juju/juju/testcharms"
+	"github.com/juju/juju/worker/leadership"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/runner"
+)
+
+type ContextFactorySuite struct {
+	HookContextSuite
+	paths      RealPaths
+	factory    runner.ContextFactory
+	membership map[int][]string
+}
+
+var _ = gc.Suite(&ContextFactorySuite{})
+
+type fakeTracker struct {
+	leadership.Tracker
+}
+
+func (fakeTracker) ServiceName() string {
+	return "service-name"
+}
+
+func (s *ContextFactorySuite) SetUpTest(c *gc.C) {
+	s.HookContextSuite.SetUpTest(c)
+	s.paths = NewRealPaths(c)
+	s.membership = map[int][]string{}
+
+	contextFactory, err := runner.NewContextFactory(
+		s.uniter,
+		s.unit.Tag().(names.UnitTag),
+		fakeTracker{},
+		s.getRelationInfos,
+		s.storage,
+		s.paths,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.factory = contextFactory
+}
+
+func (s *ContextFactorySuite) SetCharm(c *gc.C, name string) {
+	err := os.RemoveAll(s.paths.charm)
+	c.Assert(err, jc.ErrorIsNil)
+	err = fs.Copy(testcharms.Repo.CharmDirPath(name), s.paths.charm)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ContextFactorySuite) getRelationInfos() map[int]*runner.RelationInfo {
+	info := map[int]*runner.RelationInfo{}
+	for relId, relUnit := range s.apiRelunits {
+		info[relId] = &runner.RelationInfo{
+			RelationUnit: relUnit,
+			MemberNames:  s.membership[relId],
+		}
+	}
+	return info
+}
+
+func (s *ContextFactorySuite) testLeadershipContextWiring(c *gc.C, createContext func() runner.Context) {
+	var stub testing.Stub
+	stub.SetErrors(errors.New("bam"))
+	restore := runner.PatchNewLeadershipContext(
+		func(accessor runner.LeadershipSettingsAccessor, tracker leadership.Tracker) runner.LeadershipContext {
+			stub.AddCall("NewLeadershipContext", accessor, tracker)
+			return &StubLeadershipContext{Stub: &stub}
+		},
+	)
+	defer restore()
+
+	ctx := createContext()
+	isLeader, err := ctx.IsLeader()
+	c.Check(err, gc.ErrorMatches, "bam")
+	c.Check(isLeader, jc.IsFalse)
+
+	stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "NewLeadershipContext",
+		Args:     []interface{}{s.uniter.LeadershipSettings, fakeTracker{}},
+	}, {
+		FuncName: "IsLeader",
+	}})
+
+}
+
+func (s *ContextFactorySuite) TestNewHookRunnerLeadershipContext(c *gc.C) {
+	s.testLeadershipContextWiring(c, func() runner.Context {
+		ctx, err := s.factory.HookContext(hook.Info{Kind: hooks.ConfigChanged})
+		c.Assert(err, jc.ErrorIsNil)
+		return ctx
+	})
+}
+
+func (s *ContextFactorySuite) TestNewCommandRunnerLeadershipContext(c *gc.C) {
+	s.testLeadershipContextWiring(c, func() runner.Context {
+		ctx, err := s.factory.CommandContext(runner.CommandInfo{RelationId: -1})
+		c.Assert(err, jc.ErrorIsNil)
+		return ctx
+	})
+}
+
+func (s *ContextFactorySuite) TestNewActionRunnerLeadershipContext(c *gc.C) {
+	s.testLeadershipContextWiring(c, func() runner.Context {
+		s.SetCharm(c, "dummy")
+		action, err := s.State.EnqueueAction(s.unit.Tag(), "snapshot", nil)
+		c.Assert(err, jc.ErrorIsNil)
+
+		actionData := &runner.ActionData{
+			Name:       action.Name(),
+			Tag:        names.NewActionTag(action.Id()),
+			Params:     action.Parameters(),
+			ResultsMap: map[string]interface{}{},
+		}
+
+		ctx, err := s.factory.ActionContext(actionData)
+		c.Assert(err, jc.ErrorIsNil)
+		return ctx
+	})
+}
+
+func (s *ContextFactorySuite) TestRelationHookContext(c *gc.C) {
+	hi := hook.Info{
+		Kind:       hooks.RelationBroken,
+		RelationId: 1,
+	}
+	ctx, err := s.factory.HookContext(hi)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertCoreContext(c, ctx)
+	s.AssertNotActionContext(c, ctx)
+	s.AssertRelationContext(c, ctx, 1, "")
+	s.AssertNotStorageContext(c, ctx)
+}
+
+func (s *ContextFactorySuite) TestMetricsHookContext(c *gc.C) {
+	s.SetCharm(c, "metered")
+	hi := hook.Info{Kind: hooks.CollectMetrics}
+	ctx, err := s.factory.HookContext(hi)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = ctx.AddMetric("pings", "1", time.Now())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.AssertCoreContext(c, ctx)
+	s.AssertNotActionContext(c, ctx)
+	s.AssertNotRelationContext(c, ctx)
+	s.AssertNotStorageContext(c, ctx)
+}
+
+func (s *ContextFactorySuite) TestActionContext(c *gc.C) {
+	s.SetCharm(c, "dummy")
+	action, err := s.State.EnqueueAction(s.unit.Tag(), "snapshot", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	actionData := &runner.ActionData{
+		Name:       action.Name(),
+		Tag:        names.NewActionTag(action.Id()),
+		Params:     action.Parameters(),
+		ResultsMap: map[string]interface{}{},
+	}
+
+	ctx, err := s.factory.ActionContext(actionData)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.AssertCoreContext(c, ctx)
+	s.AssertActionContext(c, ctx)
+	s.AssertNotRelationContext(c, ctx)
+	s.AssertNotStorageContext(c, ctx)
+}
+
+func (s *ContextFactorySuite) TestCommandContext(c *gc.C) {
+	ctx, err := s.factory.CommandContext(runner.CommandInfo{RelationId: -1})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.AssertCoreContext(c, ctx)
+	s.AssertNotActionContext(c, ctx)
+	s.AssertNotRelationContext(c, ctx)
+	s.AssertNotStorageContext(c, ctx)
+}
+
+type StubLeadershipContext struct {
+	runner.LeadershipContext
+	*testing.Stub
+}
+
+func (stub *StubLeadershipContext) IsLeader() (bool, error) {
+	stub.MethodCall(stub, "IsLeader")
+	return false, stub.NextErr()
+}

--- a/worker/uniter/runner/export_test.go
+++ b/worker/uniter/runner/export_test.go
@@ -40,7 +40,8 @@ func PatchNewLeadershipContext(f LeadershipContextFunc) func() {
 
 func UpdateCachedSettings(f0 Factory, relId int, unitName string, settings params.Settings) {
 	f := f0.(*factory)
-	members := f.relationCaches[relId].members
+	cf := f.contextFactory.(*contextFactory)
+	members := cf.relationCaches[relId].members
 	if members[unitName] == nil {
 		members[unitName] = params.Settings{}
 	}
@@ -51,7 +52,8 @@ func UpdateCachedSettings(f0 Factory, relId int, unitName string, settings param
 
 func CachedSettings(f0 Factory, relId int, unitName string) (params.Settings, bool) {
 	f := f0.(*factory)
-	settings, found := f.relationCaches[relId].members[unitName]
+	cf := f.contextFactory.(*contextFactory)
+	settings, found := cf.relationCaches[relId].members[unitName]
 	return settings, found
 }
 

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -4,21 +4,13 @@
 package runner
 
 import (
-	"fmt"
-	"math/rand"
-	"time"
-
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v5"
-	"gopkg.in/juju/charm.v5/hooks"
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/worker/leadership"
 	"github.com/juju/juju/worker/uniter/hook"
-	"github.com/juju/juju/worker/uniter/metrics"
-	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
 type CommandInfo struct {
@@ -30,10 +22,8 @@ type CommandInfo struct {
 	ForceRemoteUnit bool
 }
 
-// Factory represents a long-lived object that can create execution contexts
-// relevant to a specific unit. In its current state, it is somewhat bizarre
-// and inconsistent; its main value is as an evolutionary step towards a better
-// division of responsibilities across worker/uniter and its subpackages.
+// Factory represents a long-lived object that can create runners
+// relevant to a specific unit.
 type Factory interface {
 
 	// NewCommandRunner returns an execution context suitable for running
@@ -49,106 +39,40 @@ type Factory interface {
 	NewActionRunner(actionId string) (Runner, error)
 }
 
-// StorageContextAccessor is an interface providing access to StorageContexts
-// for a jujuc.Context.
-type StorageContextAccessor interface {
-
-	// StorageTags returns the tags of storage instances attached to
-	// the unit.
-	StorageTags() []names.StorageTag
-
-	// Storage returns the jujuc.ContextStorageAttachment with the
-	// supplied tag if it was found, and whether it was found.
-	Storage(names.StorageTag) (jujuc.ContextStorageAttachment, bool)
-}
-
-// RelationsFunc is used to get snapshots of relation membership at context
-// creation time.
-type RelationsFunc func() map[int]*RelationInfo
-
-// NewFactory returns a Factory capable of creating execution contexts backed
-// by the supplied unit's supplied API connection.
+// NewFactory returns a Factory capable of creating runners for executing
+// charm hooks, actions and commands.
 func NewFactory(
 	state *uniter.State,
-	unitTag names.UnitTag,
-	tracker leadership.Tracker,
-	getRelationInfos RelationsFunc,
-	storage StorageContextAccessor,
 	paths Paths,
+	contextFactory ContextFactory,
 ) (
 	Factory, error,
 ) {
-	unit, err := state.Unit(unitTag)
-	if err != nil {
-		return nil, errors.Trace(err)
+	f := &factory{
+		state:          state,
+		paths:          paths,
+		contextFactory: contextFactory,
 	}
-	service, err := state.Service(unit.ServiceTag())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ownerTag, err := service.OwnerTag()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	machineTag, err := unit.AssignedMachine()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	environment, err := state.Environment()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &factory{
-		unit:             unit,
-		state:            state,
-		tracker:          tracker,
-		paths:            paths,
-		envUUID:          environment.UUID(),
-		envName:          environment.Name(),
-		machineTag:       machineTag,
-		ownerTag:         ownerTag,
-		getRelationInfos: getRelationInfos,
-		relationCaches:   map[int]*RelationCache{},
-		storage:          storage,
-		rand:             rand.New(rand.NewSource(time.Now().Unix())),
-	}, nil
+
+	return f, nil
 }
 
 type factory struct {
-	// API connection fields; unit should be deprecated, but isn't yet.
-	unit    *uniter.Unit
-	state   *uniter.State
-	tracker leadership.Tracker
+	contextFactory ContextFactory
+
+	// API connection fields.
+	state *uniter.State
 
 	// Fields that shouldn't change in a factory's lifetime.
-	paths      Paths
-	envUUID    string
-	envName    string
-	machineTag names.MachineTag
-	ownerTag   names.UserTag
-	storage    StorageContextAccessor
-
-	// Callback to get relation state snapshot.
-	getRelationInfos RelationsFunc
-	relationCaches   map[int]*RelationCache
-
-	// For generating "unique" context ids.
-	rand *rand.Rand
+	paths Paths
 }
 
 // NewCommandRunner exists to satisfy the Factory interface.
 func (f *factory) NewCommandRunner(commandInfo CommandInfo) (Runner, error) {
-	ctx, err := f.coreContext()
+	ctx, err := f.contextFactory.CommandContext(commandInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	relationId, remoteUnitName, err := inferRemoteUnit(ctx.relations, commandInfo)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ctx.relationId = relationId
-	ctx.remoteUnitName = remoteUnitName
-	ctx.id = f.newId("run-commands")
 	runner := NewRunner(ctx, f.paths)
 	return runner, nil
 }
@@ -159,71 +83,17 @@ func (f *factory) NewHookRunner(hookInfo hook.Info) (Runner, error) {
 		return nil, errors.Trace(err)
 	}
 
-	ctx, err := f.coreContext()
+	ctx, err := f.contextFactory.HookContext(hookInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	hookName := string(hookInfo.Kind)
-	if hookInfo.Kind.IsRelation() {
-		ctx.relationId = hookInfo.RelationId
-		ctx.remoteUnitName = hookInfo.RemoteUnit
-		relation, found := ctx.relations[hookInfo.RelationId]
-		if !found {
-			return nil, errors.Errorf("unknown relation id: %v", hookInfo.RelationId)
-		}
-		if hookInfo.Kind == hooks.RelationDeparted {
-			relation.cache.RemoveMember(hookInfo.RemoteUnit)
-		} else if hookInfo.RemoteUnit != "" {
-			// Clear remote settings cache for changing remote unit.
-			relation.cache.InvalidateMember(hookInfo.RemoteUnit)
-		}
-		hookName = fmt.Sprintf("%s-%s", relation.Name(), hookInfo.Kind)
-	}
-	if hookInfo.Kind.IsStorage() {
-		ctx.storageTag = names.NewStorageTag(hookInfo.StorageId)
-		if _, found := ctx.storage.Storage(ctx.storageTag); !found {
-			return nil, errors.Errorf("unknown storage id: %v", hookInfo.StorageId)
-		}
-		storageName, err := names.StorageName(hookInfo.StorageId)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		hookName = fmt.Sprintf("%s-%s", storageName, hookName)
-	}
-	// Metrics are only sent from the collect-metrics hook.
-	if hookInfo.Kind == hooks.CollectMetrics {
-		ch, err := f.getCharm()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		ctx.definedMetrics = ch.Metrics()
-
-		chURL, err := f.unit.CharmURL()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		charmMetrics := map[string]charm.Metric{}
-		if ch.Metrics() != nil {
-			charmMetrics = ch.Metrics().Metrics
-		}
-		ctx.metricsRecorder, err = metrics.NewJSONMetricRecorder(
-			f.paths.GetMetricsSpoolDir(),
-			charmMetrics,
-			chURL.String())
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	ctx.id = f.newId(hookName)
 	runner := NewRunner(ctx, f.paths)
 	return runner, nil
 }
 
 // NewActionRunner exists to satisfy the Factory interface.
 func (f *factory) NewActionRunner(actionId string) (Runner, error) {
-	ch, err := f.getCharm()
+	ch, err := getCharm(f.paths.GetCharmDir())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -257,174 +127,16 @@ func (f *factory) NewActionRunner(actionId string) (Runner, error) {
 		return nil, &badActionError{name, err.Error()}
 	}
 
-	ctx, err := f.coreContext()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ctx.actionData = newActionData(name, &tag, params)
-	ctx.id = f.newId(name)
+	actionData := newActionData(name, &tag, params)
+	ctx, err := f.contextFactory.ActionContext(actionData)
 	runner := NewRunner(ctx, f.paths)
 	return runner, nil
 }
 
-// newId returns a probably-unique identifier for a new context, containing the
-// supplied string.
-func (f *factory) newId(name string) string {
-	return fmt.Sprintf("%s-%s-%d", f.unit.Name(), name, f.rand.Int63())
-}
-
-// coreContext creates a new context with all unspecialised fields filled in.
-func (f *factory) coreContext() (*HookContext, error) {
-	leadershipContext := newLeadershipContext(
-		f.state.LeadershipSettings,
-		f.tracker,
-	)
-	ctx := &HookContext{
-		unit:               f.unit,
-		state:              f.state,
-		LeadershipContext:  leadershipContext,
-		uuid:               f.envUUID,
-		envName:            f.envName,
-		unitName:           f.unit.Name(),
-		assignedMachineTag: f.machineTag,
-		serviceOwner:       f.ownerTag,
-		relations:          f.getContextRelations(),
-		relationId:         -1,
-		metricsRecorder:    nil,
-		definedMetrics:     nil,
-		pendingPorts:       make(map[PortRange]PortRangeInfo),
-		storage:            f.storage,
-	}
-	if err := f.updateContext(ctx); err != nil {
-		return nil, err
-	}
-	return ctx, nil
-}
-
-func (f *factory) getCharm() (charm.Charm, error) {
-	ch, err := charm.ReadCharm(f.paths.GetCharmDir())
+func getCharm(charmPath string) (charm.Charm, error) {
+	ch, err := charm.ReadCharm(charmPath)
 	if err != nil {
 		return nil, err
 	}
 	return ch, nil
-}
-
-// getContextRelations updates the factory's relation caches, and uses them
-// to construct ContextRelations for a fresh context.
-func (f *factory) getContextRelations() map[int]*ContextRelation {
-	contextRelations := map[int]*ContextRelation{}
-	relationInfos := f.getRelationInfos()
-	relationCaches := map[int]*RelationCache{}
-	for id, info := range relationInfos {
-		relationUnit := info.RelationUnit
-		memberNames := info.MemberNames
-		cache, found := f.relationCaches[id]
-		if found {
-			cache.Prune(memberNames)
-		} else {
-			cache = NewRelationCache(relationUnit.ReadSettings, memberNames)
-		}
-		relationCaches[id] = cache
-		contextRelations[id] = NewContextRelation(relationUnit, cache)
-	}
-	f.relationCaches = relationCaches
-	return contextRelations
-}
-
-// updateContext fills in all unspecialized fields that require an API call to
-// discover.
-//
-// Approximately *every* line of code in this function represents a bug: ie, some
-// piece of information we expose to the charm but which we fail to report changes
-// to via hooks. Furthermore, the fact that we make multiple API calls at this
-// time, rather than grabbing everything we need in one go, is unforgivably yucky.
-func (f *factory) updateContext(ctx *HookContext) (err error) {
-	defer errors.Trace(err)
-
-	ctx.apiAddrs, err = f.state.APIAddresses()
-	if err != nil {
-		return err
-	}
-	ctx.machinePorts, err = f.state.AllMachinePorts(f.machineTag)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	statusCode, statusInfo, err := f.unit.MeterStatus()
-	if err != nil {
-		return errors.Annotate(err, "could not retrieve meter status for unit")
-	}
-	ctx.meterStatus = &meterStatus{
-		code: statusCode,
-		info: statusInfo,
-	}
-
-	// TODO(fwereade) 23-10-2014 bug 1384572
-	// Nothing here should ever be getting the environ config directly.
-	environConfig, err := f.state.EnvironConfig()
-	if err != nil {
-		return err
-	}
-	ctx.proxySettings = environConfig.ProxySettings()
-
-	// Calling these last, because there's a potential race: they're not guaranteed
-	// to be set in time to be needed for a hook. If they're not, we just leave them
-	// unset as we always have; this isn't great but it's about behaviour preservation.
-	ctx.publicAddress, err = f.unit.PublicAddress()
-	if err != nil && !params.IsCodeNoAddressSet(err) {
-		return err
-	}
-	ctx.privateAddress, err = f.unit.PrivateAddress()
-	if err != nil && !params.IsCodeNoAddressSet(err) {
-		return err
-	}
-	return nil
-}
-
-func inferRemoteUnit(rctxs map[int]*ContextRelation, info CommandInfo) (int, string, error) {
-	relationId := info.RelationId
-	hasRelation := relationId != -1
-	remoteUnit := info.RemoteUnitName
-	hasRemoteUnit := remoteUnit != ""
-
-	// Check baseline sanity of remote unit, if supplied.
-	if hasRemoteUnit {
-		if !names.IsValidUnit(remoteUnit) {
-			return -1, "", errors.Errorf(`invalid remote unit: %s`, remoteUnit)
-		} else if !hasRelation {
-			return -1, "", errors.Errorf("remote unit provided without a relation: %s", remoteUnit)
-		}
-	}
-
-	// Check sanity of relation, if supplied, otherwise easy early return.
-	if !hasRelation {
-		return relationId, remoteUnit, nil
-	}
-	rctx, found := rctxs[relationId]
-	if !found {
-		return -1, "", errors.Errorf("unknown relation id: %d", relationId)
-	}
-
-	// Past basic sanity checks; if forced, accept what we're given.
-	if info.ForceRemoteUnit {
-		return relationId, remoteUnit, nil
-	}
-
-	// Infer an appropriate remote unit if we can.
-	possibles := rctx.UnitNames()
-	if remoteUnit == "" {
-		switch len(possibles) {
-		case 0:
-			return -1, "", errors.Errorf("cannot infer remote unit in empty relation %d", relationId)
-		case 1:
-			return relationId, possibles[0], nil
-		}
-		return -1, "", errors.Errorf("ambiguous remote unit; possibilities are %+v", possibles)
-	}
-	for _, possible := range possibles {
-		if remoteUnit == possible {
-			return relationId, remoteUnit, nil
-		}
-	}
-	return -1, "", errors.Errorf("unknown remote unit %s; possibilities are %+v", remoteUnit, possibles)
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -273,8 +273,14 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		return errors.Annotatef(err, "cannot create deployer")
 	}
 	u.deployer = &deployerProxy{deployer}
-	runnerFactory, err := runner.NewFactory(
+	contextFactory, err := runner.NewContextFactory(
 		u.st, unitTag, u.leadershipTracker, u.relations.GetInfo, u.storage, u.paths,
+	)
+	if err != nil {
+		return err
+	}
+	runnerFactory, err := runner.NewFactory(
+		u.st, u.paths, contextFactory,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR separates the runner factory from the context factory in the uniter. Follow-up pull requests will split them into separate packages. This is necessary to be able to supply other context factories (e.g. API connection independent ones) to the runner factory.

(Review request: http://reviews.vapour.ws/r/2239/)