### PR TITLE
Ensure --update and --extend args are respected for proc-launch.

### DIFF
--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -24,25 +24,13 @@ func init() {
 
 type baseSuite struct {
 	jujuctesting.ContextSuite
-	proc      *process.Info
-	compCtx   *context.Context
-	apiClient *stubAPIClient
-	Ctx       *stubHookContext
+	proc *process.Info
 }
 
 func (s *baseSuite) SetUpTest(c *gc.C) {
 	s.ContextSuite.SetUpTest(c)
 
-	s.apiClient = newStubAPIClient(s.Stub)
-	proc := s.newProc("proc A", "docker")
-	compCtx := context.NewContext(s.apiClient)
-
-	hctx, info := s.NewHookContext()
-	info.SetComponent(process.ComponentName, compCtx)
-
-	s.proc = proc
-	s.compCtx = compCtx
-	s.Ctx = hctx
+	s.proc = s.newProc("proc A", "docker")
 }
 
 func (s *baseSuite) newProc(name, ptype string) *process.Info {

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -10,12 +10,15 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/yaml.v1"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/process"
 )
+
+var logger = loggo.GetLogger("juju.process.persistence")
 
 // TODO(ericsnow) How to convert endpoints (charm.Process.Ports[].Name)
 // into actual ports? For now we should error out with such definitions
@@ -160,13 +163,6 @@ func (c *registeringCommand) register(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	newProcess, err := c.parseUpdates(info.Process)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	c.UpdatedProcess = newProcess
-	info.Process = *newProcess
-
 	info.Details = c.Details
 
 	if err := c.compCtx.Set(c.Name, info); err != nil {
@@ -184,7 +180,18 @@ func (c *registeringCommand) register(ctx *cmd.Context) error {
 
 func (c *registeringCommand) findValidInfo(ctx *cmd.Context) (*process.Info, error) {
 	if c.info != nil {
+		logger.Debugf("using existing process.Info")
 		copied := *c.info
+
+		if c.UpdatedProcess == nil {
+			logger.Debugf("parsing updates")
+			newProcess, err := c.parseUpdates(c.info.Process)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			c.UpdatedProcess = newProcess
+			copied.Process = *newProcess
+		}
 		return &copied, nil
 	}
 
@@ -208,13 +215,24 @@ func (c *registeringCommand) findValidInfo(ctx *cmd.Context) (*process.Info, err
 		}
 		definition = *cliDef
 	}
+	logger.Debugf("creating new process.Info")
 	info := &process.Info{Process: definition}
-	c.info = info
+
+	logger.Debugf("parsing updates")
+	newProcess, err := c.parseUpdates(info.Process)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c.UpdatedProcess = newProcess
+	info.Process = *newProcess
 
 	// validate
 	if err := info.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	c.info = info
+
 	if info.IsRegistered() {
 		return nil, errors.Errorf("already registered")
 	}

--- a/process/context/command_test.go
+++ b/process/context/command_test.go
@@ -24,11 +24,17 @@ type commandSuite struct {
 	cmd      cmd.Command
 	cmdCtx   *cmd.Context
 	metadata *charm.Meta
+	compCtx  *stubContextComponent
+	Ctx      *stubHookContext
 }
 
 func (s *commandSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
 
+	s.compCtx = newStubContextComponent(s.Stub)
+	hctx, info := s.NewHookContext()
+	info.SetComponent(process.ComponentName, s.compCtx)
+	s.Ctx = hctx
 	s.cmdCtx = coretesting.Context(c)
 
 	s.setMetadata()

--- a/process/context/command_test.go
+++ b/process/context/command_test.go
@@ -74,11 +74,6 @@ func (s *commandSuite) checkStderr(c *gc.C, expected string) {
 	c.Check(s.cmdCtx.Stderr.(*bytes.Buffer).String(), gc.Equals, expected)
 }
 
-func (s *commandSuite) checkDetails(c *gc.C, expected process.Details) {
-	info := context.GetCmdInfo(s.cmd)
-	c.Check(info.Details, jc.DeepEquals, expected)
-}
-
 func (s *commandSuite) checkCommandRegistered(c *gc.C) {
 	component := &context.Context{}
 	hctx, info := s.NewHookContext()
@@ -105,4 +100,21 @@ func (s *commandSuite) checkRun(c *gc.C, expectedOut, expectedErr string) {
 
 	s.checkStdout(c, expectedOut)
 	s.checkStderr(c, expectedErr)
+}
+
+type registeringCommandSuite struct {
+	commandSuite
+}
+
+func (s *registeringCommandSuite) checkRunInfo(c *gc.C, orig, sent process.Info) {
+	s.checkRun(c, "", "")
+
+	info := context.GetCmdInfo(s.cmd)
+	c.Check(info, jc.DeepEquals, &orig)
+
+	s.Stub.CheckCallNames(c, "Get", "Set", "Flush")
+	c.Check(s.Stub.Calls()[1].Args, jc.DeepEquals, []interface{}{
+		sent.Name,
+		&sent,
+	})
 }

--- a/process/context/context_test.go
+++ b/process/context/context_test.go
@@ -15,12 +15,17 @@ import (
 
 type contextSuite struct {
 	baseSuite
+	compCtx   *context.Context
+	apiClient *stubAPIClient
 }
 
 var _ = gc.Suite(&contextSuite{})
 
 func (s *contextSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
+
+	s.apiClient = newStubAPIClient(s.Stub)
+	s.compCtx = context.NewContext(s.apiClient)
 
 	context.AddProcs(s.compCtx, s.proc)
 }

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type registerSuite struct {
-	commandSuite
+	registeringCommandSuite
 
 	registerCmd *context.ProcRegistrationCommand
 	details     process.Details
@@ -45,10 +45,10 @@ func (s *registerSuite) init(c *gc.C, name, id, status string) {
 	}
 }
 
-func (s *registerSuite) checkRun(c *gc.C, expectedOut, expectedErr string) {
-	s.commandSuite.checkRun(c, expectedOut, expectedErr)
+func (s *registerSuite) checkRunInfo(c *gc.C, orig, sent process.Info) {
+	s.registeringCommandSuite.checkRunInfo(c, orig, sent)
 
-	s.checkDetails(c, s.details)
+	c.Check(s.registerCmd.UpdatedProcess, jc.DeepEquals, &sent.Process)
 }
 
 func (s *registerSuite) TestCommandRegistered(c *gc.C) {
@@ -174,11 +174,12 @@ func (s *registerSuite) TestOverridesWithoutSubfield(c *gc.C) {
 	}
 	s.init(c, s.proc.Name, "abc123-override", "okay")
 
-	s.checkRun(c, "", "")
-
-	expected := s.proc.Process.Copy()
-	expected.Description = "foo"
-	c.Check(s.registerCmd.UpdatedProcess, jc.DeepEquals, &expected)
+	def := s.proc.Process.Copy()
+	def.Description = "foo"
+	s.checkRunInfo(c, *s.proc, process.Info{
+		Process: def,
+		Details: s.details,
+	})
 }
 
 func (s *registerSuite) TestOverridesWithSubfield(c *gc.C) {
@@ -189,11 +190,12 @@ func (s *registerSuite) TestOverridesWithSubfield(c *gc.C) {
 	}
 	s.init(c, s.proc.Name, "abc123-override", "okay")
 
-	s.checkRun(c, "", "")
-
-	expected := s.proc.Process.Copy()
-	expected.EnvVars = map[string]string{"foo": "baz"}
-	c.Check(s.registerCmd.UpdatedProcess, jc.DeepEquals, &expected)
+	def := s.proc.Process.Copy()
+	def.EnvVars = map[string]string{"foo": "baz"}
+	s.checkRunInfo(c, *s.proc, process.Info{
+		Process: def,
+		Details: s.details,
+	})
 }
 
 func (s *registerSuite) TestOverridesMissingField(c *gc.C) {
@@ -240,11 +242,12 @@ func (s *registerSuite) TestAdditionsWithoutSubfield(c *gc.C) {
 	}
 	s.init(c, s.proc.Name, "abc123-override", "okay")
 
-	s.checkRun(c, "", "")
-
-	expected := s.proc.Process.Copy()
-	expected.Description = "foo"
-	c.Check(s.registerCmd.UpdatedProcess, jc.DeepEquals, &expected)
+	def := s.proc.Process.Copy()
+	def.Description = "foo"
+	s.checkRunInfo(c, *s.proc, process.Info{
+		Process: def,
+		Details: s.details,
+	})
 }
 
 func (s *registerSuite) TestAdditionsWithSubfield(c *gc.C) {
@@ -254,11 +257,12 @@ func (s *registerSuite) TestAdditionsWithSubfield(c *gc.C) {
 	}
 	s.init(c, s.proc.Name, "abc123-override", "okay")
 
-	s.checkRun(c, "", "")
-
-	expected := s.proc.Process.Copy()
-	expected.EnvVars = map[string]string{"foo": "baz"}
-	c.Check(s.registerCmd.UpdatedProcess, jc.DeepEquals, &expected)
+	def := s.proc.Process.Copy()
+	def.EnvVars = map[string]string{"foo": "baz"}
+	s.checkRunInfo(c, *s.proc, process.Info{
+		Process: def,
+		Details: s.details,
+	})
 }
 
 func (s *registerSuite) TestAdditionsMissingField(c *gc.C) {

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -93,7 +93,7 @@ func (s *registerSuite) TestInitAllArgs(c *gc.C) {
 
 func (s *registerSuite) TestInitAlreadyRegistered(c *gc.C) {
 	s.proc.Details.ID = "xyz123"
-	context.AddProcs(s.compCtx, s.proc)
+	s.compCtx.procs[s.proc.Name] = s.proc
 
 	err := s.registerCmd.Init([]string{
 		s.proc.Name,
@@ -302,7 +302,7 @@ func (s *registerSuite) TestRunOkay(c *gc.C) {
 	s.init(c, s.proc.Name, "abc123", "running")
 
 	s.checkRun(c, "", "")
-	s.Stub.CheckCallNames(c, "Set", "Flush")
+	s.Stub.CheckCallNames(c, "Get", "Set", "Flush")
 }
 
 func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
@@ -316,6 +316,9 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 	s.proc.Process = *s.registerCmd.UpdatedProcess
 	s.proc.Details = s.details
 	s.Stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "Get",
+		Args:     []interface{}{s.proc.Name},
+	}, {
 		FuncName: "Set",
 		Args:     []interface{}{s.proc.Name, s.proc},
 	}, {


### PR DESCRIPTION
We missed a call to parseUpdates in LaunchCommand.Run.  This patch adds in and does so in a way that the updates are made safely.

(Review request: http://reviews.vapour.ws/r/2245/)