### PR TITLE
container/lxc: RunningInsideLXC for !linux

### DIFF
--- a/container/lxc/lxcutils/utils.go
+++ b/container/lxc/lxcutils/utils.go
@@ -3,40 +3,8 @@
 
 package lxcutils
 
-import (
-	"bufio"
-	"os"
-	"strings"
-
-	"github.com/juju/errors"
-)
-
-var initProcessCgroupFile = "/proc/1/cgroup"
-
 // RunningInsideLXC reports whether or not we are running inside an
 // LXC container.
 func RunningInsideLXC() (bool, error) {
-	file, err := os.Open(initProcessCgroupFile)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		fields := strings.Split(line, ":")
-		if len(fields) != 3 {
-			return false, errors.Errorf("malformed cgroup file")
-		}
-		if fields[2] != "/" {
-			// When running in a container the anchor point will be
-			// something other than "/".
-			return true, nil
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return false, errors.Annotate(err, "failed to read cgroup file")
-	}
-	return false, nil
+	return runningInsideLXC()
 }

--- a/container/lxc/lxcutils/utils_linux.go
+++ b/container/lxc/lxcutils/utils_linux.go
@@ -1,0 +1,40 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxcutils
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+var initProcessCgroupFile = "/proc/1/cgroup"
+
+func runningInsideLXC() (bool, error) {
+	file, err := os.Open(initProcessCgroupFile)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Split(line, ":")
+		if len(fields) != 3 {
+			return false, errors.Errorf("malformed cgroup file")
+		}
+		if fields[2] != "/" {
+			// When running in a container the anchor point will be
+			// something other than "/".
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, errors.Annotate(err, "failed to read cgroup file")
+	}
+	return false, nil
+}

--- a/container/lxc/lxcutils/utils_notlinux.go
+++ b/container/lxc/lxcutils/utils_notlinux.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//+build !linux
+
+package lxcutils
+
+func runningInsideLXC() (bool, error) {
+	return false, nil
+}

--- a/storage/looputil/loop.go
+++ b/storage/looputil/loop.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -64,7 +64,7 @@ func (m *loopDeviceManager) DetachLoopDevices(rootfs, prefix string) error {
 		if !strings.HasPrefix(info.backingFile, prefix) {
 			continue
 		}
-		rootedBackingFile := filepath.Join(rootfs, info.backingFile)
+		rootedBackingFile := path.Join(rootfs, info.backingFile)
 		st, err := m.stat(rootedBackingFile)
 		if os.IsNotExist(err) {
 			continue


### PR DESCRIPTION
Add an implementation of RunningInsideLXC for
OSes other than Linux that just returns false.

Fixes https://bugs.launchpad.net/juju-core/+bug/1477355

(Review request: http://reviews.vapour.ws/r/2246/)