### PR TITLE
Arch version detection for client

### DIFF
--- a/version/osversion.go
+++ b/version/osversion.go
@@ -53,13 +53,15 @@ func readOSRelease() (map[string]string, error) {
 		}
 		values[c[0]] = strings.Trim(c[1], "\t '\"")
 	}
-	_, ok := values["ID"]
+	id, ok := values["ID"]
 	if !ok {
 		return values, errors.New("OS release file is missing ID")
 	}
-	_, ok = values["VERSION_ID"]
-	if !ok {
-		return values, errors.New("OS release file is missing VERSION_ID")
+	if _, ok := values["VERSION_ID"]; !ok {
+		values["VERSION_ID"], ok = defaultVersionIDs[id]
+		if !ok {
+			return values, errors.New("OS release file is missing VERSION_ID")
+		}
 	}
 	return values, nil
 }
@@ -82,6 +84,8 @@ func readSeries() (string, error) {
 	switch values["ID"] {
 	case strings.ToLower(Ubuntu.String()):
 		return getValue(ubuntuSeries, values["VERSION_ID"])
+	case strings.ToLower(Arch.String()):
+		return getValue(archSeries, values["VERSION_ID"])
 	case strings.ToLower(CentOS.String()):
 		codename := fmt.Sprintf("%s%s", values["ID"], values["VERSION_ID"])
 		return getValue(centosSeries, codename)

--- a/version/osversion_test.go
+++ b/version/osversion_test.go
@@ -62,6 +62,17 @@ VERSION_ID="7"
 	"centos7",
 	"",
 }, {
+	`NAME="Arch Linux"
+ID=arch
+PRETTY_NAME="Arch Linux"
+ANSI_COLOR="0;36"
+HOME_URL="https://www.archlinux.org/"
+SUPPORT_URL="https://bbs.archlinux.org/"
+BUG_REPORT_URL="https://bugs.archlinux.org/"
+`,
+	"arch",
+	"",
+}, {
 	`NAME="Ubuntu"
 VERSION="14.04.1 LTS, Trusty Tahr"
 ID=ubuntu

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -22,6 +22,7 @@ const (
 	Windows
 	OSX
 	CentOS
+	Arch
 )
 
 func (t OSType) String() string {
@@ -34,6 +35,8 @@ func (t OSType) String() string {
 		return "OSX"
 	case CentOS:
 		return "CentOS"
+	case Arch:
+		return "Arch"
 	}
 	return "Unknown"
 }
@@ -62,6 +65,10 @@ func IsUnknownSeriesVersionError(err error) bool {
 	return ok
 }
 
+var defaultVersionIDs = map[string]string{
+	"arch": "rolling",
+}
+
 // seriesVersions provides a mapping between series names and versions.
 // The values here are current as of the time of writing. On Ubuntu systems, we update
 // these values from /usr/share/distro-info/ubuntu.csv to ensure we have the latest values.
@@ -83,10 +90,15 @@ var seriesVersions = map[string]string{
 	"win8":        "win8",
 	"win81":       "win81",
 	"centos7":     "centos7",
+	"arch":        "rolling",
 }
 
 var centosSeries = map[string]string{
 	"centos7": "centos7",
+}
+
+var archSeries = map[string]string{
+	"arch": "rolling",
 }
 
 var ubuntuSeries = map[string]string{
@@ -143,6 +155,9 @@ func GetOSFromSeries(series string) (OSType, error) {
 	}
 	if _, ok := centosSeries[series]; ok {
 		return CentOS, nil
+	}
+	if _, ok := archSeries[series]; ok {
+		return Arch, nil
 	}
 	for _, val := range windowsVersions {
 		if val == series {

--- a/version/supportedseries_test.go
+++ b/version/supportedseries_test.go
@@ -43,6 +43,9 @@ var getOSFromSeriesTests = []struct {
 	series: "centos7",
 	want:   version.CentOS,
 }, {
+	series: "arch",
+	want:   version.Arch,
+}, {
 	series: "",
 	err:    "series \"\" not valid",
 },
@@ -73,6 +76,7 @@ func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
 		"win7":    "win7",
 		"win81":   "win81",
 		"centos7": "centos7",
+		"arch":    "rolling",
 	})
 	series := version.OSSupportedSeries(version.Ubuntu)
 	c.Assert(series, jc.SameContents, []string{"trusty", "utopic"})
@@ -80,4 +84,6 @@ func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
 	c.Assert(series, jc.SameContents, []string{"win7", "win81"})
 	series = version.OSSupportedSeries(version.CentOS)
 	c.Assert(series, jc.SameContents, []string{"centos7"})
+	series = version.OSSupportedSeries(version.Arch)
+	c.Assert(series, jc.SameContents, []string{"arch"})
 }


### PR DESCRIPTION
This patch enables arch version detection and enables the client on arch.

This could also mean a AUR pkgbuild could be created and we could very easily package the juju client on arch for testing and/or development.

(Review request: http://reviews.vapour.ws/r/2253/)