### PR TITLE
Rename FlushContext method and ActionData fields

### DIFF
--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -49,7 +49,7 @@ func (ra *runAction) Prepare(state State) (*State, error) {
 		// this should *really* never happen, but let's not panic
 		return nil, errors.Trace(err)
 	}
-	ra.name = actionData.ActionName
+	ra.name = actionData.Name
 	ra.runner = rnr
 	return stateChange{
 		Kind:     RunAction,

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -415,7 +415,7 @@ func NewRunActionRunnerFactory(runErr error) *MockRunnerFactory {
 			runner: &MockRunner{
 				MockRunAction: &MockRunAction{err: runErr},
 				context: &MockContext{
-					actionData: &runner.ActionData{ActionName: "some-action-name"},
+					actionData: &runner.ActionData{Name: "some-action-name"},
 				},
 			},
 		},

--- a/worker/uniter/runner/action.go
+++ b/worker/uniter/runner/action.go
@@ -9,10 +9,10 @@ import (
 
 // ActionData contains the tag, parameters, and results of an Action.
 type ActionData struct {
-	ActionName     string
-	ActionTag      names.ActionTag
-	ActionParams   map[string]interface{}
-	ActionFailed   bool
+	Name           string
+	Tag            names.ActionTag
+	Params         map[string]interface{}
+	Failed         bool
 	ResultsMessage string
 	ResultsMap     map[string]interface{}
 }

--- a/worker/uniter/runner/action.go
+++ b/worker/uniter/runner/action.go
@@ -21,10 +21,10 @@ type ActionData struct {
 // this should only be called in the event that an Action hook is being requested.
 func newActionData(name string, tag *names.ActionTag, params map[string]interface{}) *ActionData {
 	return &ActionData{
-		ActionName:   name,
-		ActionTag:    *tag,
-		ActionParams: params,
-		ResultsMap:   map[string]interface{}{},
+		Name:       name,
+		Tag:        *tag,
+		Params:     params,
+		ResultsMap: map[string]interface{}{},
 	}
 }
 

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -566,8 +566,8 @@ func (ctx *HookContext) addJujuUnitsMetric() error {
 	return nil
 }
 
-// FlushContext implements the Context interface.
-func (ctx *HookContext) FlushContext(process string, ctxErr error) (err error) {
+// Flush implements the Context interface.
+func (ctx *HookContext) Flush(process string, ctxErr error) (err error) {
 	// A non-existant metricsRecorder simply means that metrics were disabled
 	// for this hook run.
 	if ctx.metricsRecorder != nil {

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -403,7 +403,7 @@ func (ctx *HookContext) ActionName() (string, error) {
 	if ctx.actionData == nil {
 		return "", errors.New("not running an action")
 	}
-	return ctx.actionData.ActionName, nil
+	return ctx.actionData.Name, nil
 }
 
 // ActionParams simply returns the arguments to the Action.
@@ -411,7 +411,7 @@ func (ctx *HookContext) ActionParams() (map[string]interface{}, error) {
 	if ctx.actionData == nil {
 		return nil, errors.New("not running an action")
 	}
-	return ctx.actionData.ActionParams, nil
+	return ctx.actionData.Params, nil
 }
 
 // SetActionMessage sets a message for the Action, usually an error message.
@@ -428,7 +428,7 @@ func (ctx *HookContext) SetActionFailed() error {
 	if ctx.actionData == nil {
 		return errors.New("not running an action")
 	}
-	ctx.actionData.ActionFailed = true
+	ctx.actionData.Failed = true
 	return nil
 }
 
@@ -521,9 +521,9 @@ func (context *HookContext) HookVars(paths Paths) []string {
 	}
 	if context.actionData != nil {
 		vars = append(vars,
-			"JUJU_ACTION_NAME="+context.actionData.ActionName,
-			"JUJU_ACTION_UUID="+context.actionData.ActionTag.Id(),
-			"JUJU_ACTION_TAG="+context.actionData.ActionTag.String(),
+			"JUJU_ACTION_NAME="+context.actionData.Name,
+			"JUJU_ACTION_UUID="+context.actionData.Tag.Id(),
+			"JUJU_ACTION_TAG="+context.actionData.Tag.String(),
 		)
 	}
 	return append(vars, osDependentEnvVars(paths)...)
@@ -673,9 +673,9 @@ func (ctx *HookContext) finalizeAction(err, unhandledErr error) error {
 	// TODO (binary132): synchronize with gsamfira's reboot logic
 	message := ctx.actionData.ResultsMessage
 	results := ctx.actionData.ResultsMap
-	tag := ctx.actionData.ActionTag
+	tag := ctx.actionData.Tag
 	status := params.ActionCompleted
-	if ctx.actionData.ActionFailed {
+	if ctx.actionData.Failed {
 		status = params.ActionFailed
 	}
 

--- a/worker/uniter/runner/context_test.go
+++ b/worker/uniter/runner/context_test.go
@@ -278,7 +278,7 @@ func (s *InterfaceSuite) TestSetActionFailed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	actionData, err := hctx.ActionData()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(actionData.ActionFailed, jc.IsTrue)
+	c.Check(actionData.Failed, jc.IsTrue)
 }
 
 // TestSetActionMessage ensures SetActionMessage works properly.

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -568,9 +568,9 @@ func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 	data, err := ctx.ActionData()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, jc.DeepEquals, &runner.ActionData{
-		ActionName: "snapshot",
-		ActionTag:  action.ActionTag(),
-		ActionParams: map[string]interface{}{
+		Name: "snapshot",
+		Tag:  action.ActionTag(),
+		Params: map[string]interface{}{
 			"outfile": "/some/file.bz2",
 		},
 		ResultsMap: map[string]interface{}{},

--- a/worker/uniter/runner/flush_test.go
+++ b/worker/uniter/runner/flush_test.go
@@ -46,7 +46,7 @@ func (s *FlushContextSuite) TestRunHookRelationFlushingError(c *gc.C) {
 	node1.Set("bar", "2")
 
 	// Flush the context with a failure.
-	err = ctx.FlushContext("some badge", errors.New("blam pow"))
+	err = ctx.Flush("some badge", errors.New("blam pow"))
 	c.Assert(err, gc.ErrorMatches, "blam pow")
 
 	// Check that the changes have not been written to state.
@@ -74,7 +74,7 @@ func (s *FlushContextSuite) TestRunHookRelationFlushingSuccess(c *gc.C) {
 	node1.Set("qux", "4")
 
 	// Flush the context with a success.
-	err = ctx.FlushContext("some badge", nil)
+	err = ctx.Flush("some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that the changes have been written to state.
@@ -157,7 +157,7 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	})
 
 	// Flush the context with a success.
-	err = ctx.FlushContext("some badge", nil)
+	err = ctx.Flush("some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify the unit ranges are now open.
@@ -181,7 +181,7 @@ func (s *FlushContextSuite) TestRunHookAddStorageOnFailure(c *gc.C) {
 
 	// Flush the context with an error.
 	msg := "test fail run hook"
-	err := ctx.FlushContext("test fail run hook", errors.New(msg))
+	err := ctx.Flush("test fail run hook", errors.New(msg))
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 
 	all, err := s.State.AllStorageInstances()
@@ -200,7 +200,7 @@ func (s *FlushContextSuite) TestRunHookAddUnitStorageOnSuccess(c *gc.C) {
 		})
 
 	// Flush the context with a success.
-	err := ctx.FlushContext("success", nil)
+	err := ctx.Flush("success", nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, `.*storage "allecto" not found.*`)
 
 	all, err := s.State.AllStorageInstances()
@@ -217,7 +217,7 @@ func (s *FlushContextSuite) TestFlushClosesMetricsRecorder(c *gc.C) {
 	err := ctx.AddMetric("key", "value", time.Now())
 
 	// Flush the context with a success.
-	err = ctx.FlushContext("success", nil)
+	err = ctx.Flush("success", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "IsDeclaredMetric", "AddMetric", "Close")
@@ -237,7 +237,7 @@ func (s *FlushContextSuite) TestBuiltinMetric(c *gc.C) {
 		paths.GetMetricsSpoolDir(),
 	)
 
-	err = ctx.FlushContext("some badge", nil)
+	err = ctx.Flush("some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	batches, err := reader.Read()
 	c.Assert(err, jc.ErrorIsNil)
@@ -255,7 +255,7 @@ func (s *FlushContextSuite) TestBuiltinMetricNotGeneratedIfNotDefined(c *gc.C) {
 		paths.GetMetricsSpoolDir(),
 	)
 
-	err = ctx.FlushContext("some badge", nil)
+	err = ctx.Flush("some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	batches, err := reader.Read()
 	c.Assert(err, jc.ErrorIsNil)
@@ -268,7 +268,7 @@ func (s *FlushContextSuite) TestRecorderIsClosedAfterBuiltIn(c *gc.C) {
 	ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("juju-units"), paths)
 	runner.PatchMetricsRecorder(ctx, &StubMetricsRecorder{&s.stub})
 
-	err := ctx.FlushContext("some badge", nil)
+	err := ctx.Flush("some badge", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.stub.CheckCallNames(c, "IsDeclaredMetric", "AddMetric", "Close")
 }

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -42,7 +42,7 @@ type Context interface {
 	HookVars(paths Paths) []string
 	ActionData() (*ActionData, error)
 	SetProcess(process *os.Process)
-	FlushContext(badge string, failure error) error
+	Flush(badge string, failure error) error
 	HasExecutionSetUnitStatus() bool
 	ResetExecutionSetUnitStatus()
 }
@@ -105,7 +105,7 @@ func (runner *runner) RunCommands(commands string) (*utilexec.ExecResponse, erro
 
 	// Block and wait for process to finish
 	result, err := command.Wait()
-	return result, runner.context.FlushContext("run commands", err)
+	return result, runner.context.Flush("run commands", err)
 }
 
 // RunAction exists to satisfy the Runner interface.
@@ -143,7 +143,7 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string) e
 	} else {
 		err = runner.runCharmHook(hookName, env, charmLocation)
 	}
-	return runner.context.FlushContext(hookName, err)
+	return runner.context.Flush(hookName, err)
 }
 
 func (runner *runner) runCharmHook(hookName string, env []string, charmLocation string) error {

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -172,7 +172,7 @@ func (ctx *MockContext) SetProcess(process *os.Process) {
 	ctx.expectPid = process.Pid
 }
 
-func (ctx *MockContext) FlushContext(badge string, failure error) error {
+func (ctx *MockContext) Flush(badge string, failure error) error {
 	ctx.flushBadge = badge
 	ctx.flushFailure = failure
 	return ctx.flushResult

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -67,7 +67,7 @@ func (s *unitStorageSuite) TestAddUnitStorageZeroCount(c *gc.C) {
 	ctx := s.addUnitStorage(c, cons)
 
 	// Flush the context with a success.
-	err := ctx.FlushContext("success", nil)
+	err := ctx.Flush("success", nil)
 	c.Assert(err, gc.ErrorMatches, `.*count must be specified.*`)
 
 	// Make sure no storage instances was added
@@ -86,7 +86,7 @@ func (s *unitStorageSuite) TestAddUnitStorageWithSize(c *gc.C) {
 	ctx := s.addUnitStorage(c, cons)
 
 	// Flush the context with a success.
-	err := ctx.FlushContext("success", nil)
+	err := ctx.Flush("success", nil)
 	c.Assert(err, gc.ErrorMatches, `.*only count can be specified.*`)
 
 	// Make sure no storage instances was added
@@ -104,7 +104,7 @@ func (s *unitStorageSuite) TestAddUnitStorageWithPool(c *gc.C) {
 	ctx := s.addUnitStorage(c, cons)
 
 	// Flush the context with a success.
-	err := ctx.FlushContext("success", nil)
+	err := ctx.Flush("success", nil)
 	c.Assert(err, gc.ErrorMatches, `.*only count can be specified.*`)
 
 	// Make sure no storage instances was added
@@ -222,7 +222,7 @@ func (s *unitStorageSuite) assertUnitStorageAdded(c *gc.C, cons ...map[string]pa
 	ctx := s.addUnitStorage(c, cons...)
 
 	// Flush the context with a success.
-	err := ctx.FlushContext("success", nil)
+	err := ctx.Flush("success", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	after, err := s.State.AllStorageInstances()


### PR DESCRIPTION
Context.FlushContext is redundant, so it's going to be renamed to Flush.
ActionData fields ActionName, ActionParams, ActionTag and ActionFailed lose the Action prefix.



(Review request: http://reviews.vapour.ws/r/2254/)