### PR TITLE
provider/...: destroy storage along with env

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -37,7 +37,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	6b2122eca400138028f15e5d412cfb9fb7440ead	2015-07-22T05:05:21Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	15098963088579c1cd9eb1a7da285831e548390b	2015-07-07T18:34:45Z
-gopkg.in/goose.v1	git	c405c311b9fd9518e2bde5229b4ad2a90b198add	2015-07-22T04:01:58Z
+gopkg.in/goose.v1	git	39e4e7a5d0eba2923cec7c841870e39decddf05e	2015-07-23T01:53:30Z
 gopkg.in/juju/charm.v5	git	1d5ef3d01f135c3324e309ca06393882ba5e6d0e	2015-07-20T12:55:48Z
 gopkg.in/juju/charmstore.v4	git	b90d24652753eeb1f7d209483d499f6b24dcf25e	2015-07-10T10:24:09Z
 gopkg.in/juju/environschema.v1	git	ec1fe091f545c41e29e336ff79800df14a924aca	2015-06-15T15:30:06Z

--- a/provider/common/destroy.go
+++ b/provider/common/destroy.go
@@ -4,8 +4,15 @@
 package common
 
 import (
+	"strings"
+
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider/registry"
 )
 
 // Destroy is a common implementation of the Destroy method defined on
@@ -13,6 +20,17 @@ import (
 // used when writing a new provider.
 func Destroy(env environs.Environ) error {
 	logger.Infof("destroying environment %q", env.Config().Name())
+	if err := destroyInstances(env); err != nil {
+		return errors.Annotate(err, "destroying instances")
+	}
+	if err := destroyStorage(env); err != nil {
+		return errors.Annotate(err, "destroying storage")
+	}
+	return nil
+}
+
+func destroyInstances(env environs.Environ) error {
+	logger.Infof("destroying instances")
 	instances, err := env.AllInstances()
 	switch err {
 	case nil:
@@ -29,4 +47,71 @@ func Destroy(env environs.Environ) error {
 	default:
 		return err
 	}
+}
+
+func destroyStorage(env environs.Environ) error {
+	logger.Infof("destroying storage")
+	environConfig := env.Config()
+	storageProviderTypes, ok := registry.EnvironStorageProviders(environConfig.Type())
+	if !ok {
+		return nil
+	}
+	for _, storageProviderType := range storageProviderTypes {
+		storageProvider, err := registry.StorageProvider(storageProviderType)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !storageProvider.Dynamic() {
+			continue
+		}
+		if storageProvider.Scope() != storage.ScopeEnviron {
+			continue
+		}
+		if err := destroyVolumes(environConfig, storageProviderType, storageProvider); err != nil {
+			return errors.Trace(err)
+		}
+		// TODO(axw) destroy env-level filesystems when we have them.
+	}
+	return nil
+}
+
+func destroyVolumes(
+	environConfig *config.Config,
+	storageProviderType storage.ProviderType,
+	storageProvider storage.Provider,
+) error {
+	if !storageProvider.Supports(storage.StorageKindBlock) {
+		return nil
+	}
+
+	storageConfig, err := storage.NewConfig(
+		string(storageProviderType),
+		storageProviderType,
+		map[string]interface{}{},
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	volumeSource, err := storageProvider.VolumeSource(environConfig, storageConfig)
+	if err != nil {
+		return errors.Annotate(err, "getting volume source")
+	}
+
+	volumeIds, err := volumeSource.ListVolumes()
+	if err != nil {
+		return errors.Annotate(err, "listing volumes")
+	}
+
+	var errStrings []string
+	errs := volumeSource.DestroyVolumes(volumeIds)
+	for _, err := range errs {
+		if err != nil {
+			errStrings = append(errStrings, err.Error())
+		}
+	}
+	if len(errStrings) > 0 {
+		return errors.Errorf("destroying volumes: %s", strings.Join(errStrings, ", "))
+	}
+	return nil
 }

--- a/provider/common/destroy_test.go
+++ b/provider/common/destroy_test.go
@@ -4,15 +4,21 @@
 package common_test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider/dummy"
+	"github.com/juju/juju/storage/provider/registry"
 	"github.com/juju/juju/testing"
 )
 
@@ -30,7 +36,7 @@ func (s *DestroySuite) TestCannotGetInstances(c *gc.C) {
 		config: configGetter(c),
 	}
 	err := common.Destroy(env)
-	c.Assert(err, gc.ErrorMatches, "nope")
+	c.Assert(err, gc.ErrorMatches, "destroying instances: nope")
 }
 
 func (s *DestroySuite) TestCannotStopInstances(c *gc.C) {
@@ -50,12 +56,12 @@ func (s *DestroySuite) TestCannotStopInstances(c *gc.C) {
 		config: configGetter(c),
 	}
 	err := common.Destroy(env)
-	c.Assert(err, gc.ErrorMatches, "nah")
+	c.Assert(err, gc.ErrorMatches, "destroying instances: nah")
 }
 
 func (s *DestroySuite) TestSuccessWhenStorageErrors(c *gc.C) {
-	// common.Destroy doesn't touch storage anymore, so
-	// failing storage should not affect success.
+	// common.Destroy doesn't touch provider/object storage anymore,
+	// so failing storage should not affect success.
 	env := &mockEnviron{
 		storage: &mockStorage{removeAllErr: fmt.Errorf("noes!")},
 		allInstances: func() ([]instance.Instance, error) {
@@ -98,7 +104,7 @@ func (s *DestroySuite) TestSuccess(c *gc.C) {
 	err = common.Destroy(env)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// common.Destroy doesn't touch storage anymore.
+	// common.Destroy doesn't touch provider/object storage anymore.
 	r, err := stor.Get("somewhere")
 	c.Assert(err, jc.ErrorIsNil)
 	r.Close()
@@ -118,4 +124,151 @@ func (s *DestroySuite) TestSuccessWhenNoInstances(c *gc.C) {
 	}
 	err = common.Destroy(env)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *DestroySuite) TestDestroyEnvScopedVolumes(c *gc.C) {
+	volumeSource := &dummy.VolumeSource{
+		ListVolumesFunc: func() ([]string, error) {
+			return []string{"vol-0", "vol-1", "vol-2"}, nil
+		},
+		DestroyVolumesFunc: func(ids []string) []error {
+			return make([]error, len(ids))
+		},
+	}
+	staticProvider := &dummy.StorageProvider{
+		IsDynamic:    true,
+		StorageScope: storage.ScopeEnviron,
+		VolumeSourceFunc: func(*config.Config, *storage.Config) (storage.VolumeSource, error) {
+			return volumeSource, nil
+		},
+	}
+	registry.RegisterProvider("environ", staticProvider)
+	defer registry.RegisterProvider("environ", nil)
+	registry.RegisterEnvironStorageProviders("anything, really", "environ")
+	defer registry.ResetEnvironStorageProviders("anything, really")
+
+	env := &mockEnviron{
+		config: configGetter(c),
+		allInstances: func() ([]instance.Instance, error) {
+			return nil, environs.ErrNoInstances
+		},
+	}
+	err := common.Destroy(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// common.Destroy will ignore machine-scoped storage providers.
+	staticProvider.CheckCallNames(c, "Dynamic", "Scope", "Supports", "VolumeSource")
+	volumeSource.CheckCalls(c, []gitjujutesting.StubCall{
+		{"ListVolumes", nil},
+		{"DestroyVolumes", []interface{}{[]string{"vol-0", "vol-1", "vol-2"}}},
+	})
+}
+
+func (s *DestroySuite) TestDestroyVolumeErrors(c *gc.C) {
+	volumeSource := &dummy.VolumeSource{
+		ListVolumesFunc: func() ([]string, error) {
+			return []string{"vol-0", "vol-1", "vol-2"}, nil
+		},
+		DestroyVolumesFunc: func(ids []string) []error {
+			return []error{
+				nil,
+				errors.New("cannot destroy vol-1"),
+				errors.New("cannot destroy vol-2"),
+			}
+		},
+	}
+
+	staticProvider := &dummy.StorageProvider{
+		IsDynamic:    true,
+		StorageScope: storage.ScopeEnviron,
+		VolumeSourceFunc: func(*config.Config, *storage.Config) (storage.VolumeSource, error) {
+			return volumeSource, nil
+		},
+	}
+	registry.RegisterProvider("environ", staticProvider)
+	defer registry.RegisterProvider("environ", nil)
+	registry.RegisterEnvironStorageProviders("anything, really", "environ")
+	defer registry.ResetEnvironStorageProviders("anything, really")
+
+	env := &mockEnviron{
+		config: configGetter(c),
+		allInstances: func() ([]instance.Instance, error) {
+			return nil, environs.ErrNoInstances
+		},
+	}
+	err := common.Destroy(env)
+	c.Assert(err, gc.ErrorMatches, "destroying storage: destroying volumes: cannot destroy vol-1, cannot destroy vol-2")
+}
+
+func (s *DestroySuite) TestIgnoreStaticVolumes(c *gc.C) {
+	staticProvider := &dummy.StorageProvider{
+		IsDynamic:    false,
+		StorageScope: storage.ScopeEnviron,
+	}
+	registry.RegisterProvider("static", staticProvider)
+	defer registry.RegisterProvider("static", nil)
+	registry.RegisterEnvironStorageProviders("anything, really", "static")
+	defer registry.ResetEnvironStorageProviders("anything, really")
+
+	env := &mockEnviron{
+		config: configGetter(c),
+		allInstances: func() ([]instance.Instance, error) {
+			return nil, environs.ErrNoInstances
+		},
+	}
+	err := common.Destroy(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// common.Destroy will ignore static storage providers.
+	staticProvider.CheckCallNames(c, "Dynamic")
+}
+
+func (s *DestroySuite) TestIgnoreMachineScopedVolumes(c *gc.C) {
+	staticProvider := &dummy.StorageProvider{
+		IsDynamic:    true,
+		StorageScope: storage.ScopeMachine,
+	}
+	registry.RegisterProvider("machine", staticProvider)
+	defer registry.RegisterProvider("machine", nil)
+	registry.RegisterEnvironStorageProviders("anything, really", "machine")
+	defer registry.ResetEnvironStorageProviders("anything, really")
+
+	env := &mockEnviron{
+		config: configGetter(c),
+		allInstances: func() ([]instance.Instance, error) {
+			return nil, environs.ErrNoInstances
+		},
+	}
+	err := common.Destroy(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// common.Destroy will ignore machine-scoped storage providers.
+	staticProvider.CheckCallNames(c, "Dynamic", "Scope")
+}
+
+func (s *DestroySuite) TestIgnoreNoVolumeSupport(c *gc.C) {
+	staticProvider := &dummy.StorageProvider{
+		IsDynamic:    true,
+		StorageScope: storage.ScopeEnviron,
+		SupportsFunc: func(storage.StorageKind) bool {
+			return false
+		},
+	}
+	registry.RegisterProvider("filesystem", staticProvider)
+	defer registry.RegisterProvider("filesystem", nil)
+	registry.RegisterEnvironStorageProviders("anything, really", "filesystem")
+	defer registry.ResetEnvironStorageProviders("anything, really")
+
+	env := &mockEnviron{
+		config: configGetter(c),
+		allInstances: func() ([]instance.Instance, error) {
+			return nil, environs.ErrNoInstances
+		},
+	}
+	err := common.Destroy(env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// common.Destroy will ignore storage providers that don't support
+	// volumes (until we have persistent filesystems, that is).
+	staticProvider.CheckCallNames(c, "Dynamic", "Scope", "Supports")
 }

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -116,8 +116,9 @@ func UseTestInstanceTypeData(content instanceTypeCost) {
 }
 
 var (
-	ShortAttempt   = &shortAttempt
-	StorageAttempt = &storageAttempt
+	ShortAttempt         = &shortAttempt
+	StorageAttempt       = &storageAttempt
+	DestroyVolumeAttempt = &destroyVolumeAttempt
 )
 
 func EC2ErrCode(err error) string {

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -267,9 +267,10 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumes(c *gc.C) {
 	volSource := openstack.NewCinderVolumeSource(mockAdapter)
 	errs := volSource.DestroyVolumes([]string{mockVolId})
 	c.Assert(errs, jc.DeepEquals, []error{nil})
-	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{{
-		"DeleteVolume", []interface{}{mockVolId},
-	}})
+	mockAdapter.CheckCalls(c, []gitjujutesting.StubCall{
+		{"GetVolume", []interface{}{mockVolId}},
+		{"DeleteVolume", []interface{}{mockVolId}},
+	})
 }
 
 func (s *cinderVolumeSourceSuite) TestDestroyVolumesAttached(c *gc.C) {

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/jujutest"
 	"github.com/juju/juju/environs/simplestreams"
@@ -76,6 +77,14 @@ var (
 )
 
 type OpenstackStorage openstackStorage
+
+func NewCinderProvider(s OpenstackStorage) storage.Provider {
+	return &cinderProvider{
+		func(*config.Config) (openstackStorage, error) {
+			return openstackStorage(s), nil
+		},
+	}
+}
 
 func NewCinderVolumeSource(s OpenstackStorage) storage.VolumeSource {
 	const envName = "testenv"

--- a/storage/provider/dummy/provider.go
+++ b/storage/provider/dummy/provider.go
@@ -5,6 +5,8 @@ package dummy
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/testing"
+
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/storage"
 )
@@ -15,6 +17,8 @@ var _ storage.Provider = (*StorageProvider)(nil)
 // Each method's default behaviour may be overridden by setting the corresponding
 // Func field.
 type StorageProvider struct {
+	testing.Stub
+
 	// StorageScope defines the scope of storage managed by this provider.
 	StorageScope storage.Scope
 
@@ -41,6 +45,7 @@ type StorageProvider struct {
 
 // VolumeSource is defined on storage.Provider.
 func (p *StorageProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
+	p.MethodCall(p, "VolumeSource", environConfig, providerConfig)
 	if p.VolumeSourceFunc != nil {
 		return p.VolumeSourceFunc(environConfig, providerConfig)
 	}
@@ -49,6 +54,7 @@ func (p *StorageProvider) VolumeSource(environConfig *config.Config, providerCon
 
 // FilesystemSource is defined on storage.Provider.
 func (p *StorageProvider) FilesystemSource(environConfig *config.Config, providerConfig *storage.Config) (storage.FilesystemSource, error) {
+	p.MethodCall(p, "FilesystemSource", environConfig, providerConfig)
 	if p.FilesystemSourceFunc != nil {
 		return p.FilesystemSourceFunc(environConfig, providerConfig)
 	}
@@ -57,6 +63,7 @@ func (p *StorageProvider) FilesystemSource(environConfig *config.Config, provide
 
 // ValidateConfig is defined on storage.Provider.
 func (p *StorageProvider) ValidateConfig(providerConfig *storage.Config) error {
+	p.MethodCall(p, "ValidateConfig", providerConfig)
 	if p.ValidateConfigFunc != nil {
 		return p.ValidateConfigFunc(providerConfig)
 	}
@@ -65,6 +72,7 @@ func (p *StorageProvider) ValidateConfig(providerConfig *storage.Config) error {
 
 // Supports is defined on storage.Provider.
 func (p *StorageProvider) Supports(kind storage.StorageKind) bool {
+	p.MethodCall(p, "Supports", kind)
 	if p.SupportsFunc != nil {
 		return p.SupportsFunc(kind)
 	}
@@ -73,10 +81,12 @@ func (p *StorageProvider) Supports(kind storage.StorageKind) bool {
 
 // Scope is defined on storage.Provider.
 func (p *StorageProvider) Scope() storage.Scope {
+	p.MethodCall(p, "Scope")
 	return p.StorageScope
 }
 
 // Dynamic is defined on storage.Provider.
 func (p *StorageProvider) Dynamic() bool {
+	p.MethodCall(p, "Dynamic")
 	return p.IsDynamic
 }

--- a/storage/provider/dummy/volumesource.go
+++ b/storage/provider/dummy/volumesource.go
@@ -1,0 +1,90 @@
+package dummy
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/storage"
+	"github.com/juju/testing"
+)
+
+// VolumeSource is an implementation of storage.VolumeSource, suitable for
+// testing. Each method's default behaviour may be overridden by setting
+// the corresponding Func field.
+type VolumeSource struct {
+	testing.Stub
+
+	CreateVolumesFunc        func([]storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error)
+	ListVolumesFunc          func() ([]string, error)
+	DescribeVolumesFunc      func([]string) ([]storage.VolumeInfo, error)
+	DestroyVolumesFunc       func([]string) []error
+	ValidateVolumeParamsFunc func(storage.VolumeParams) error
+	AttachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]storage.VolumeAttachment, error)
+	DetachVolumesFunc        func([]storage.VolumeAttachmentParams) error
+}
+
+// CreateVolumes is defined on storage.VolumeSource.
+func (s *VolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
+	s.MethodCall(s, "CreateVolumes", params)
+	if s.CreateVolumesFunc != nil {
+		return s.CreateVolumesFunc(params)
+	}
+	return nil, nil, errors.NotImplementedf("CreateVolumes")
+}
+
+// ListVolumes is defined on storage.VolumeSource.
+func (s *VolumeSource) ListVolumes() ([]string, error) {
+	s.MethodCall(s, "ListVolumes")
+	if s.ListVolumesFunc != nil {
+		return s.ListVolumesFunc()
+	}
+	return nil, nil
+}
+
+// DescribeVolumes is defined on storage.VolumeSource.
+func (s *VolumeSource) DescribeVolumes(volIds []string) ([]storage.VolumeInfo, error) {
+	s.MethodCall(s, "DescribeVolumes", volIds)
+	if s.DescribeVolumesFunc != nil {
+		return s.DescribeVolumesFunc(volIds)
+	}
+	return nil, errors.NotImplementedf("DescribeVolumes")
+}
+
+// DestroyVolumes is defined on storage.VolumeSource.
+func (s *VolumeSource) DestroyVolumes(volIds []string) []error {
+	s.MethodCall(s, "DestroyVolumes", volIds)
+	if s.DestroyVolumesFunc != nil {
+		return s.DestroyVolumesFunc(volIds)
+	}
+	errs := make([]error, len(volIds))
+	for i := range errs {
+		errs[i] = errors.NotImplementedf("DestroyVolumes")
+	}
+	return errs
+}
+
+// ValidateVolumeParams is defined on storage.VolumeSource.
+func (s *VolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
+	s.MethodCall(s, "ValidateVolumeParams", params)
+	if s.ValidateVolumeParamsFunc != nil {
+		return s.ValidateVolumeParamsFunc(params)
+	}
+	return nil
+}
+
+// AttachVolumes is defined on storage.VolumeSource.
+func (s *VolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([]storage.VolumeAttachment, error) {
+	s.MethodCall(s, "AttachVolumes", params)
+	if s.AttachVolumesFunc != nil {
+		return s.AttachVolumesFunc(params)
+	}
+	return nil, errors.NotImplementedf("AttachVolumes")
+}
+
+// DetachVolumes is defined on storage.VolumeSource.
+func (s *VolumeSource) DetachVolumes(params []storage.VolumeAttachmentParams) error {
+	s.MethodCall(s, "DetachVolumes", params)
+	if s.DetachVolumesFunc != nil {
+		return s.DetachVolumesFunc(params)
+	}
+	return errors.NotImplementedf("DetachVolumes")
+
+}

--- a/storage/provider/registry/providerregistry.go
+++ b/storage/provider/registry/providerregistry.go
@@ -52,6 +52,12 @@ func StorageProvider(providerType storage.ProviderType) (storage.Provider, error
 // supported ProviderType(s).
 var supportedEnvironProviders = make(map[string][]storage.ProviderType)
 
+// ResetEnvironStorageProviders clears out the supported storage providers for
+// the specified environment type. This is provided for testing purposes.
+func ResetEnvironStorageProviders(envType string) {
+	delete(supportedEnvironProviders, envType)
+}
+
 // RegisterEnvironStorageProviders records which storage provider types
 // are valid for an environment.
 // This is to be called from the environ provider's init().


### PR DESCRIPTION
provider/common.Destroy will now enumerate storage
providers, and destroy environment-scoped volumes
when an environment is (forcibly) destroyed.

There are some modifications to the ebs and cinder
volume sources' DestroyVolumes implementations to
deal better with scenarios where attachments are
still remaining when the DestroyVolumes call is
made.

(Review request: http://reviews.vapour.ws/r/2257/)