### PR TITLE
Add juju system command top level aliases

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -214,6 +214,9 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 		r.Register(system.NewSuperCommand())
 		r.RegisterSuperAlias("systems", "system", "list", nil)
 		r.RegisterSuperAlias("environments", "system", "environments", nil)
+		r.RegisterSuperAlias("login", "system", "login", nil)
+		r.RegisterSuperAlias("create-environment", "system", "create-environment", nil)
+		r.RegisterSuperAlias("create-env", "system", "create-env", nil)
 	}
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -213,6 +213,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	if featureflag.Enabled(feature.JES) {
 		r.Register(system.NewSuperCommand())
 		r.RegisterSuperAlias("systems", "system", "list", nil)
+
+		// Add top level aliases of the same name as the subcommands.
 		r.RegisterSuperAlias("environments", "system", "environments", nil)
 		r.RegisterSuperAlias("login", "system", "login", nil)
 		r.RegisterSuperAlias("create-environment", "system", "create-environment", nil)


### PR DESCRIPTION
To match the spec for the JES CLI work, a
couple top level aliases need to be
added for some systems commands.

(Review request: http://reviews.vapour.ws/r/2260/)