### PR TITLE
Pull proc definitions from metadata in state rather than from metadata.yaml.

### DIFF
--- a/component/all/process.go
+++ b/component/all/process.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/common"
@@ -128,8 +129,8 @@ func (c workloadProcesses) registerState() {
 	// TODO(ericsnow) Use a more general registration mechanism.
 	//state.RegisterMultiEnvCollections(persistence.Collections...)
 
-	newUnitProcesses := func(persist state.Persistence, unit names.UnitTag) (state.UnitProcesses, error) {
-		return procstate.NewUnitProcesses(persist, unit), nil
+	newUnitProcesses := func(persist state.Persistence, unit names.UnitTag, getMetadata func() (*charm.Meta, error)) (state.UnitProcesses, error) {
+		return procstate.NewUnitProcesses(persist, unit, getMetadata), nil
 	}
 	state.SetProcessesComponent(newUnitProcesses)
 }

--- a/process/api/client/hookcontext.go
+++ b/process/api/client/hookcontext.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/process"
 	"github.com/juju/juju/process/api"
@@ -25,6 +26,24 @@ type HookContextClient struct {
 // NewHookContextClient builds a new workload process API client.
 func NewHookContextClient(caller facadeCaller) HookContextClient {
 	return HookContextClient{caller}
+}
+
+// AllDefinitions calls the ListDefinitions API server method.
+func (c HookContextClient) AllDefinitions() ([]charm.Process, error) {
+	var results api.ListDefinitionsResults
+	if err := c.FacadeCall("ListDefinitions", nil, &results); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if results.Error != nil {
+		return nil, errors.Errorf(results.Error.GoString())
+	}
+
+	var definitions []charm.Process
+	for _, result := range results.Results {
+		definition := api.API2Definition(result)
+		definitions = append(definitions, definition)
+	}
+	return definitions, nil
 }
 
 // RegisterProcesses calls the RegisterProcesses API server method.

--- a/process/api/client/package_test.go
+++ b/process/api/client/package_test.go
@@ -1,0 +1,11 @@
+package client_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/process/api/helpers.go
+++ b/process/api/helpers.go
@@ -8,20 +8,42 @@ import (
 	"gopkg.in/juju/charm.v5"
 )
 
+// API2Definition converts an API process definition struct into
+// a charm.Process struct.
+func API2Definition(d ProcessDefinition) charm.Process {
+	return charm.Process{
+		Name:        d.Name,
+		Description: d.Description,
+		Type:        d.Type,
+		TypeOptions: d.TypeOptions,
+		Command:     d.Command,
+		Image:       d.Image,
+		Ports:       API2charmPorts(d.Ports),
+		Volumes:     API2charmVolumes(d.Volumes),
+		EnvVars:     d.EnvVars,
+	}
+}
+
+// Definition2api converts a charm.Process struct into an
+// api.ProcessDefinition struct.
+func Definition2api(d charm.Process) ProcessDefinition {
+	return ProcessDefinition{
+		Name:        d.Name,
+		Description: d.Description,
+		Type:        d.Type,
+		TypeOptions: d.TypeOptions,
+		Command:     d.Command,
+		Image:       d.Image,
+		Ports:       Charm2apiPorts(d.Ports),
+		Volumes:     Charm2apiVolumes(d.Volumes),
+		EnvVars:     d.EnvVars,
+	}
+}
+
 // API2Proc converts an API Process info struct into a process.Info struct.
 func API2Proc(p Process) process.Info {
 	return process.Info{
-		Process: charm.Process{
-			Name:        p.Definition.Name,
-			Description: p.Definition.Description,
-			Type:        p.Definition.Type,
-			TypeOptions: p.Definition.TypeOptions,
-			Command:     p.Definition.Command,
-			Image:       p.Definition.Image,
-			Ports:       API2charmPorts(p.Definition.Ports),
-			Volumes:     API2charmVolumes(p.Definition.Volumes),
-			EnvVars:     p.Definition.EnvVars,
-		},
+		Process: API2Definition(p.Definition),
 		Details: process.Details{
 			ID:     p.Details.ID,
 			Status: APIStatus2Status(p.Details.Status),
@@ -32,17 +54,7 @@ func API2Proc(p Process) process.Info {
 // Proc2api converts a process.Info struct into an api.Process struct.
 func Proc2api(p process.Info) Process {
 	return Process{
-		Definition: ProcessDefinition{
-			Name:        p.Process.Name,
-			Description: p.Process.Description,
-			Type:        p.Process.Type,
-			TypeOptions: p.Process.TypeOptions,
-			Command:     p.Process.Command,
-			Image:       p.Process.Image,
-			Ports:       Charm2apiPorts(p.Process.Ports),
-			Volumes:     Charm2apiVolumes(p.Process.Volumes),
-			EnvVars:     p.Process.EnvVars,
-		},
+		Definition: Definition2api(p.Process),
 		Details: ProcessDetails{
 			ID:     p.Details.ID,
 			Status: Status2apiStatus(p.Details.Status),

--- a/process/api/server-args.go
+++ b/process/api/server-args.go
@@ -63,6 +63,14 @@ type ListProcessResult struct {
 	Error *params.Error
 }
 
+// ListDefinitionsResults contains the results for a call to ListDefinitions.
+type ListDefinitionsResults struct {
+	// Results is the list of definition results.
+	Results []ProcessDefinition
+	// Error is the error (if any) for the call as a whole.
+	Error *params.Error
+}
+
 // SetProcessesStatusArgs are the arguments for the SetProcessesStatus endpoint.
 type SetProcessesStatusArgs struct {
 	// Args is the list of arguments to pass to this function.

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -83,8 +83,9 @@ func (c stubHookContext) Component(name string) (context.Component, error) {
 }
 
 type stubContextComponent struct {
-	stub  *testing.Stub
-	procs map[string]*process.Info
+	stub        *testing.Stub
+	procs       map[string]*process.Info
+	definitions map[string]charm.Process
 }
 
 func newStubContextComponent(stub *testing.Stub) *stubContextComponent {
@@ -118,6 +119,19 @@ func (c *stubContextComponent) Set(procName string, info *process.Info) error {
 	}
 	c.procs[procName] = info
 	return nil
+}
+
+func (c *stubContextComponent) ListDefinitions() ([]charm.Process, error) {
+	c.stub.AddCall("ListDefinitions")
+	if err := c.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var definitions []charm.Process
+	for _, definition := range c.definitions {
+		definitions = append(definitions, definition)
+	}
+	return definitions, nil
 }
 
 func (c *stubContextComponent) Flush() error {
@@ -160,7 +174,7 @@ func (c *stubAPIClient) AllDefinitions() ([]charm.Process, error) {
 		return nil, errors.Trace(err)
 	}
 
-	definitions := make([]charm.Process, len(c.definitions))
+	var definitions []charm.Process
 	for _, definition := range c.definitions {
 		definitions = append(definitions, definition)
 	}

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -90,8 +90,9 @@ type stubContextComponent struct {
 
 func newStubContextComponent(stub *testing.Stub) *stubContextComponent {
 	return &stubContextComponent{
-		stub:  stub,
-		procs: make(map[string]*process.Info),
+		stub:        stub,
+		procs:       make(map[string]*process.Info),
+		definitions: make(map[string]charm.Process),
 	}
 }
 

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -130,14 +130,16 @@ func (c *stubContextComponent) Flush() error {
 }
 
 type stubAPIClient struct {
-	stub  *testing.Stub
-	procs map[string]*process.Info
+	stub        *testing.Stub
+	procs       map[string]*process.Info
+	definitions map[string]charm.Process
 }
 
 func newStubAPIClient(stub *testing.Stub) *stubAPIClient {
 	return &stubAPIClient{
-		stub:  stub,
-		procs: make(map[string]*process.Info),
+		stub:        stub,
+		procs:       make(map[string]*process.Info),
+		definitions: make(map[string]charm.Process),
 	}
 }
 
@@ -150,6 +152,19 @@ func (c *stubAPIClient) setNew(ids ...string) []*process.Info {
 		procs = append(procs, &proc)
 	}
 	return procs
+}
+
+func (c *stubAPIClient) AllDefinitions() ([]charm.Process, error) {
+	c.stub.AddCall("AllDefinitions")
+	if err := c.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	definitions := make([]charm.Process, len(c.definitions))
+	for _, definition := range c.definitions {
+		definitions = append(definitions, definition)
+	}
+	return definitions, nil
 }
 
 func (c *stubAPIClient) List() ([]string, error) {

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -4,7 +4,6 @@
 package context
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v5"
-	goyaml "gopkg.in/yaml.v1"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/process"
@@ -87,21 +85,6 @@ func (c baseCommand) Info() *cmd.Info {
 		Purpose: c.cmdInfo.Summary,
 		Doc:     c.cmdInfo.Doc,
 	}
-}
-
-func readMetadata(filename string) (*charm.Meta, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer file.Close()
-
-	meta, err := charm.ReadMeta(file)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return meta, nil
 }
 
 // Init implements cmd.Command.
@@ -283,23 +266,6 @@ func (c *registeringCommand) defFromMetadata(name, filename string) (*charm.Proc
 	return nil, errors.NotFoundf(name)
 }
 
-func parseDefinition(name string, data []byte) (*charm.Process, error) {
-	raw := make(map[interface{}]interface{})
-	if err := goyaml.Unmarshal(data, raw); err != nil {
-		return nil, errors.Trace(err)
-	}
-	definition, err := charm.ParseProcess(name, raw)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if definition.Name == "" {
-		definition.Name = name
-	} else if definition.Name != name {
-		return nil, errors.Errorf("process name mismatch; %q != %q", definition.Name, name)
-	}
-	return definition, nil
-}
-
 // checkSpace ensures that the requested network space is available
 // to the hook.
 func (c *registeringCommand) checkSpace() error {
@@ -324,43 +290,4 @@ func (c *registeringCommand) parseUpdates(definition charm.Process) (*charm.Proc
 	}
 
 	return newDefinition, nil
-}
-
-// parseUpdate builds a charm.ProcessFieldValue from an update string.
-func parseUpdate(update string) (charm.ProcessFieldValue, error) {
-	var pfv charm.ProcessFieldValue
-
-	parts := strings.SplitN(update, ":", 2)
-	if len(parts) == 1 {
-		return pfv, errors.Errorf("missing value")
-	}
-	pfv.Field, pfv.Value = parts[0], parts[1]
-
-	if pfv.Field == "" {
-		return pfv, errors.Errorf("missing field")
-	}
-	if pfv.Value == "" {
-		return pfv, errors.Errorf("missing value")
-	}
-
-	fieldParts := strings.SplitN(pfv.Field, "/", 2)
-	if len(fieldParts) == 2 {
-		pfv.Field = fieldParts[0]
-		pfv.Subfield = fieldParts[1]
-	}
-
-	return pfv, nil
-}
-
-// parseUpdates parses the updates list in to a charm.ProcessFieldValue list.
-func parseUpdates(updates []string) ([]charm.ProcessFieldValue, error) {
-	var results []charm.ProcessFieldValue
-	for _, update := range updates {
-		pfv, err := parseUpdate(update)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		results = append(results, pfv)
-	}
-	return results, nil
 }

--- a/process/context/command_test.go
+++ b/process/context/command_test.go
@@ -93,8 +93,6 @@ func (s *commandSuite) checkHelp(c *gc.C, expected string) {
 }
 
 func (s *commandSuite) checkRun(c *gc.C, expectedOut, expectedErr string) {
-	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
-
 	err := s.cmd.Run(s.cmdCtx)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/process/context/command_test.go
+++ b/process/context/command_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/process"
 	"github.com/juju/juju/process/context"
@@ -20,12 +19,11 @@ import (
 type commandSuite struct {
 	baseSuite
 
-	cmdName  string
-	cmd      cmd.Command
-	cmdCtx   *cmd.Context
-	metadata *charm.Meta
-	compCtx  *stubContextComponent
-	Ctx      *stubHookContext
+	cmdName string
+	cmd     cmd.Command
+	cmdCtx  *cmd.Context
+	compCtx *stubContextComponent
+	Ctx     *stubHookContext
 }
 
 func (s *commandSuite) SetUpTest(c *gc.C) {
@@ -48,21 +46,10 @@ func (s *commandSuite) setCommand(c *gc.C, name string, cmd cmd.Command) {
 	s.cmd = cmd
 }
 
-func (s *commandSuite) readMetadata(string) (*charm.Meta, error) {
-	return s.metadata, nil
-}
-
 func (s *commandSuite) setMetadata(procs ...process.Info) {
-	definitions := make(map[string]charm.Process)
 	for _, proc := range procs {
 		definition := proc.Process
-		definitions[definition.Name] = definition
-	}
-	s.metadata = &charm.Meta{
-		Name:        "a-charm",
-		Summary:     "a charm",
-		Description: "a charm",
-		Processes:   definitions,
+		s.compCtx.definitions[definition.Name] = definition
 	}
 }
 
@@ -110,8 +97,8 @@ func (s *registeringCommandSuite) checkRunInfo(c *gc.C, orig, sent process.Info)
 	info := context.GetCmdInfo(s.cmd)
 	c.Check(info, jc.DeepEquals, &orig)
 
-	s.Stub.CheckCallNames(c, "Get", "Set", "Flush")
-	c.Check(s.Stub.Calls()[1].Args, jc.DeepEquals, []interface{}{
+	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
+	c.Check(s.Stub.Calls()[2].Args, jc.DeepEquals, []interface{}{
 		sent.Name,
 		&sent,
 	})

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -5,9 +5,13 @@ package context
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/process"
 )
+
+// TODO(ericsnow) Normalize method names across all the arch. layers
+// (e.g. List->AllProcesses, Get->Processes, Set->AddProcess).
 
 // APIClient represents the API needs of a Context.
 type APIClient interface {
@@ -17,7 +21,13 @@ type APIClient interface {
 	Get(ids ...string) ([]*process.Info, error)
 	// Set sends a request to update state with the provided processes.
 	Set(procs ...*process.Info) error
+	// AllDefinitions returns the process definitions found in the
+	// unit's metadata.
+	AllDefinitions() ([]charm.Process, error)
 }
+
+// TODO(ericsnow) Rename Get and Set to more specifically describe what
+// they are for.
 
 // omponent provides the hook context data specific to workload processes.
 type Component interface {

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -35,6 +35,8 @@ type Component interface {
 	Get(procName string) (*process.Info, error)
 	// Set records the process info in the hook context.
 	Set(procName string, info *process.Info) error
+	// ListDefinitions returns the charm-defined processes.
+	ListDefinitions() ([]charm.Process, error)
 	// Flush pushes the hook context data out to state.
 	Flush() error
 }
@@ -180,6 +182,15 @@ func (c *Context) set(id string, pInfo *process.Info) {
 	var info process.Info
 	info = *pInfo
 	c.updates[id] = &info
+}
+
+// ListDefinitions returns the unit's charm-defined processes.
+func (c *Context) ListDefinitions() ([]charm.Process, error) {
+	definitions, err := c.api.AllDefinitions()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return definitions, nil
 }
 
 // TODO(ericsnow) The context machinery is not actually using this yet.

--- a/process/context/context_test.go
+++ b/process/context/context_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/process"
 	"github.com/juju/juju/process/context"
@@ -325,6 +326,23 @@ func (s *contextSuite) TestSetNameMismatch(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "mismatch on name: A != B")
 	c.Check(before, jc.DeepEquals, []*process.Info{&other})
 	c.Check(after, jc.DeepEquals, []*process.Info{&other})
+}
+
+func (s *contextSuite) TestListDefinitions(c *gc.C) {
+	definition := charm.Process{
+		Name: "procA",
+		Type: "myplugin",
+	}
+	s.apiClient.definitions["procA"] = definition
+	ctx := context.NewContext(s.apiClient)
+
+	definitions, err := ctx.ListDefinitions()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(definitions, gc.DeepEquals, []charm.Process{
+		definition,
+	})
+	s.Stub.CheckCallNames(c, "AllDefinitions")
 }
 
 func (s *contextSuite) TestFlushDirty(c *gc.C) {

--- a/process/context/launch_test.go
+++ b/process/context/launch_test.go
@@ -73,8 +73,6 @@ func (s *launchCmdSuite) TestRun(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
-	cmd.ReadMetadata = s.readMetadata
-	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	err = cmd.Init([]string{s.proc.Name})
 	c.Assert(err, jc.ErrorIsNil)
@@ -94,7 +92,6 @@ func (s *launchCmdSuite) TestRunCantFindPlugin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
-	cmd.ReadMetadata = s.readMetadata
 
 	err = cmd.Init([]string{s.proc.Name})
 	c.Assert(err, jc.ErrorIsNil)
@@ -117,7 +114,6 @@ func (s *launchCmdSuite) TestLaunchCommandErrorRunning(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
-	cmd.ReadMetadata = s.readMetadata
 
 	err = cmd.Init([]string{s.proc.Name})
 	c.Assert(err, jc.ErrorIsNil)

--- a/process/context/launch_test.go
+++ b/process/context/launch_test.go
@@ -74,6 +74,7 @@ func (s *launchCmdSuite) TestRun(c *gc.C) {
 	s.setCommand(c, "process-launch", cmd)
 	s.setMetadata(*s.proc)
 	cmd.ReadMetadata = s.readMetadata
+	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	err = cmd.Init([]string{s.proc.Name})
 	c.Assert(err, jc.ErrorIsNil)

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -27,7 +27,6 @@ func (s *registerSuite) SetUpTest(c *gc.C) {
 
 	cmd, err := context.NewProcRegistrationCommand(s.Ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	cmd.ReadMetadata = s.readMetadata
 
 	s.registerCmd = cmd
 	s.setCommand(c, "process-register", s.registerCmd)
@@ -304,10 +303,9 @@ func (s *registerSuite) TestAdditionMissingColon(c *gc.C) {
 func (s *registerSuite) TestRunOkay(c *gc.C) {
 	s.setMetadata(*s.proc)
 	s.init(c, s.proc.Name, "abc123", "running")
-	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	s.checkRun(c, "", "")
-	s.Stub.CheckCallNames(c, "Get", "Set", "Flush")
+	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
 }
 
 func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
@@ -315,7 +313,6 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 	s.setMetadata(*s.proc)
 	s.registerCmd.Overrides = []string{"description:foo"}
 	s.init(c, s.proc.Name, "abc123", "running")
-	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	s.checkRun(c, "", "")
 
@@ -324,6 +321,8 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 	s.Stub.CheckCalls(c, []testing.StubCall{{
 		FuncName: "Get",
 		Args:     []interface{}{s.proc.Name},
+	}, {
+		FuncName: "ListDefinitions",
 	}, {
 		FuncName: "Set",
 		Args:     []interface{}{s.proc.Name, s.proc},

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -304,6 +304,7 @@ func (s *registerSuite) TestAdditionMissingColon(c *gc.C) {
 func (s *registerSuite) TestRunOkay(c *gc.C) {
 	s.setMetadata(*s.proc)
 	s.init(c, s.proc.Name, "abc123", "running")
+	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	s.checkRun(c, "", "")
 	s.Stub.CheckCallNames(c, "Get", "Set", "Flush")
@@ -314,6 +315,7 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 	s.setMetadata(*s.proc)
 	s.registerCmd.Overrides = []string{"description:foo"}
 	s.init(c, s.proc.Name, "abc123", "running")
+	context.SetComponent(s.cmd, newStubContextComponent(s.Stub))
 
 	s.checkRun(c, "", "")
 

--- a/process/context/utils.go
+++ b/process/context/utils.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package context
+
+import (
+	"os"
+	"strings"
+
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v5"
+	goyaml "gopkg.in/yaml.v1"
+)
+
+func readMetadata(filename string) (*charm.Meta, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer file.Close()
+
+	meta, err := charm.ReadMeta(file)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return meta, nil
+}
+
+func parseDefinition(name string, data []byte) (*charm.Process, error) {
+	raw := make(map[interface{}]interface{})
+	if err := goyaml.Unmarshal(data, raw); err != nil {
+		return nil, errors.Trace(err)
+	}
+	definition, err := charm.ParseProcess(name, raw)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if definition.Name == "" {
+		definition.Name = name
+	} else if definition.Name != name {
+		return nil, errors.Errorf("process name mismatch; %q != %q", definition.Name, name)
+	}
+	return definition, nil
+}
+
+// parseUpdate builds a charm.ProcessFieldValue from an update string.
+func parseUpdate(update string) (charm.ProcessFieldValue, error) {
+	var pfv charm.ProcessFieldValue
+
+	parts := strings.SplitN(update, ":", 2)
+	if len(parts) == 1 {
+		return pfv, errors.Errorf("missing value")
+	}
+	pfv.Field, pfv.Value = parts[0], parts[1]
+
+	if pfv.Field == "" {
+		return pfv, errors.Errorf("missing field")
+	}
+	if pfv.Value == "" {
+		return pfv, errors.Errorf("missing value")
+	}
+
+	fieldParts := strings.SplitN(pfv.Field, "/", 2)
+	if len(fieldParts) == 2 {
+		pfv.Field = fieldParts[0]
+		pfv.Subfield = fieldParts[1]
+	}
+
+	return pfv, nil
+}
+
+// parseUpdates parses the updates list in to a charm.ProcessFieldValue list.
+func parseUpdates(updates []string) ([]charm.ProcessFieldValue, error) {
+	var results []charm.ProcessFieldValue
+	for _, update := range updates {
+		pfv, err := parseUpdate(update)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		results = append(results, pfv)
+	}
+	return results, nil
+}

--- a/process/context/utils.go
+++ b/process/context/utils.go
@@ -4,28 +4,12 @@
 package context
 
 import (
-	"os"
 	"strings"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v5"
 	goyaml "gopkg.in/yaml.v1"
 )
-
-func readMetadata(filename string) (*charm.Meta, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer file.Close()
-
-	meta, err := charm.ReadMeta(file)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return meta, nil
-}
 
 func parseDefinition(name string, data []byte) (*charm.Process, error) {
 	raw := make(map[interface{}]interface{})

--- a/state/processes_test.go
+++ b/state/processes_test.go
@@ -61,6 +61,31 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 	st, err := s.State.UnitProcesses(unit)
 	c.Assert(err, jc.ErrorIsNil)
 
+	definitions, err := st.ListDefinitions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(definitions, jc.DeepEquals, []charm.Process{{
+		Name:        "procA",
+		Type:        "docker",
+		TypeOptions: map[string]string{},
+		Command:     "do-something cool",
+		Image:       "spam/eggs",
+		Volumes: []charm.ProcessVolume{{
+			ExternalMount: "/var/nginx/html",
+			InternalMount: "/usr/share/nginx/html",
+			Mode:          "ro",
+			Name:          "",
+		}},
+		Ports: []charm.ProcessPort{{
+			External: 8080,
+			Internal: 80,
+			Endpoint: "",
+		}},
+		EnvVars: map[string]string{
+			// TODO(erisnow) YAML coerces YES into true...
+			"IMPORTANT": "true",
+		},
+	}})
+
 	procs, err := st.List()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(procs, gc.HasLen, 0)
@@ -83,7 +108,6 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 				Endpoint: "website",
 			}},
 			EnvVars: map[string]string{
-				// TODO(erisnow) YAML coerces YES into true...
 				"IMPORTANT": "true",
 			},
 		},


### PR DESCRIPTION
Doing so simplifies the code a bit.

(Review request: http://reviews.vapour.ws/r/2202/)