### PR TITLE
worker/rsyslog: ensure CA cert/key in state (1.25)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -32,20 +32,27 @@ import (
 
 var logger = loggo.GetLogger("juju.agent")
 
-// logDir returns a filesystem path to the location where juju
-// may create a folder containing its logs
-var logDir = paths.MustSucceed(paths.LogDir(version.Current.Series))
+// These are base values used for the corresponding defaults.
+var (
+	logDir  = paths.MustSucceed(paths.LogDir(version.Current.Series))
+	dataDir = paths.MustSucceed(paths.DataDir(version.Current.Series))
+	confDir = paths.MustSucceed(paths.ConfDir(version.Current.Series))
+)
 
-// dataDir returns the default data directory for this running system
-var dataDir = paths.MustSucceed(paths.DataDir(version.Current.Series))
+var (
+	// DefaultLogDir defines the default log directory for juju agents.
+	// It's defined as a variable so it could be overridden in tests.
+	DefaultLogDir = path.Join(logDir, "juju")
 
-// DefaultLogDir defines the default log directory for juju agents.
-// It's defined as a variable so it could be overridden in tests.
-var DefaultLogDir = path.Join(logDir, "juju")
+	// DefaultDataDir defines the default data directory for juju agents.
+	// It's defined as a variable so it could be overridden in tests.
+	DefaultDataDir = dataDir
 
-// DefaultDataDir defines the default data directory for juju agents.
-// It's defined as a variable so it could be overridden in tests.
-var DefaultDataDir = dataDir
+	// DefaultConfDir defines the default config file directory for
+	// Juju agents.
+	// It's defined as a variable so it could be overridden in tests.
+	DefaultConfDir = confDir
+)
 
 // SystemIdentity is the name of the file where the environment SSH key is kept.
 const SystemIdentity = "system-identity"

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -238,7 +238,7 @@ var NewRsyslogConfigWorker = func(st *apirsyslog.State, agentConfig agent.Config
 	if err != nil {
 		return nil, err
 	}
-	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, agentConfig.DataDir())
+	return rsyslog.NewRsyslogConfigWorker(st, mode, tag, namespace, addrs, agent.DefaultConfDir)
 }
 
 // ParamsStateServingInfoToStateStateServingInfo converts a

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -16,6 +16,7 @@ const (
 	logDir
 	dataDir
 	storageDir
+	confDir
 	jujuRun
 	certDir
 )
@@ -25,6 +26,7 @@ var nixVals = map[osVarType]string{
 	logDir:     "/var/log",
 	dataDir:    "/var/lib/juju",
 	storageDir: "/var/lib/juju/storage",
+	confDir:    "/etc/juju",
 	jujuRun:    "/usr/bin/juju-run",
 	certDir:    "/etc/juju/certs.d",
 }
@@ -34,6 +36,7 @@ var winVals = map[osVarType]string{
 	logDir:     "C:/Juju/log",
 	dataDir:    "C:/Juju/lib/juju",
 	storageDir: "C:/Juju/lib/juju/storage",
+	confDir:    "C:/Juju/etc",
 	jujuRun:    "C:/Juju/bin/juju-run.exe",
 	certDir:    "C:/Juju/certs",
 }
@@ -84,6 +87,12 @@ func CertDir(series string) (string, error) {
 // mount machine-level storage.
 func StorageDir(series string) (string, error) {
 	return osVal(series, storageDir)
+}
+
+// ConfDir returns the path to the directory where Juju may store
+// configuration files.
+func ConfDir(series string) (string, error) {
+	return osVal(series, confDir)
 }
 
 // JujuRun returns the absolute path to the juju-run binary for

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -537,6 +537,13 @@ func (s *JujuConnSuite) DataDir() string {
 	return filepath.Join(s.RootDir, "/var/lib/juju")
 }
 
+func (s *JujuConnSuite) ConfDir() string {
+	if s.RootDir == "" {
+		panic("DataDir called out of test context")
+	}
+	return filepath.Join(s.RootDir, "/etc/juju")
+}
+
 // WriteConfig writes a juju config file to the "home" directory.
 func (s *JujuConnSuite) WriteConfig(configData string) {
 	if s.RootDir == "" {

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -47,6 +47,11 @@ func waitForFile(c *gc.C, file string) {
 		case <-timeout:
 			c.Fatalf("timed out waiting for %s to be written", file)
 		case <-time.After(coretesting.ShortWait):
+			c.Logf("-----------")
+			filepath.Walk(filepath.Dir(filepath.Dir(filepath.Dir(file))), func(path string, _ os.FileInfo, _ error) error {
+				c.Logf(path)
+				return nil
+			})
 			if _, err := os.Stat(file); err == nil {
 				return
 			}
@@ -93,14 +98,15 @@ func (s *RsyslogSuite) TestModeForwarding(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
 	addrs := []string{"0.1.2.3", "0.2.4.6"}
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "foo", addrs, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "foo", addrs, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
 
 	// We should get a ca-cert.pem with the contents introduced into state config.
-	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
-	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
+	dirname := filepath.Join(s.ConfDir()+"-foo", "rsyslog")
+	waitForFile(c, filepath.Join(dirname, "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(dirname, "ca-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(caCertPEM), gc.DeepEquals, coretesting.CACert)
 
@@ -121,14 +127,15 @@ func (s *RsyslogSuite) TestNoNamespace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
 	addrs := []string{"0.1.2.3", "0.2.4.6"}
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", addrs, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", addrs, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
 
 	// We should get a ca-cert.pem with the contents introduced into state config.
-	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
-	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
+	dirname := filepath.Join(s.ConfDir(), "rsyslog")
+	waitForFile(c, filepath.Join(dirname, "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(dirname, "ca-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(caCertPEM), gc.DeepEquals, coretesting.CACert)
 

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -47,11 +47,6 @@ func waitForFile(c *gc.C, file string) {
 		case <-timeout:
 			c.Fatalf("timed out waiting for %s to be written", file)
 		case <-time.After(coretesting.ShortWait):
-			c.Logf("-----------")
-			filepath.Walk(filepath.Dir(filepath.Dir(filepath.Dir(file))), func(path string, _ os.FileInfo, _ error) error {
-				c.Logf(path)
-				return nil
-			})
 			if _, err := os.Stat(file); err == nil {
 				return
 			}

--- a/worker/rsyslog/rsyslog_test.go
+++ b/worker/rsyslog/rsyslog_test.go
@@ -43,7 +43,7 @@ func assertPathExists(c *gc.C, path string) {
 
 func (s *RsyslogSuite) TestStartStop(c *gc.C) {
 	st, m := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeForwarding, m.Tag(), "", []string{"0.1.2.3"}, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
@@ -51,7 +51,7 @@ func (s *RsyslogSuite) TestStartStop(c *gc.C) {
 
 func (s *RsyslogSuite) TestTearDown(c *gc.C) {
 	st, m := s.st, s.machine
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	confFile := filepath.Join(*rsyslog.RsyslogConfDir, "25-juju.conf")
 	// On worker teardown, the rsyslog config file should be removed.
@@ -69,13 +69,14 @@ func (s *RsyslogSuite) TestRsyslogCert(c *gc.C) {
 	err := s.machine.SetProviderAddresses(network.NewAddress("example.com"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", []string{"0.1.2.3"}, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
-	waitForFile(c, filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
+	filename := filepath.Join(s.ConfDir(), "rsyslog", "rsyslog-cert.pem")
+	waitForFile(c, filename)
 
-	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
+	rsyslogCertPEM, err := ioutil.ReadFile(filename)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cert, err := cert.ParseCert(string(rsyslogCertPEM))
@@ -94,18 +95,19 @@ func (s *RsyslogSuite) TestRsyslogCert(c *gc.C) {
 
 func (s *RsyslogSuite) TestModeAccumulate(c *gc.C) {
 	st, m := s.st, s.machine
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", nil, s.DataDir())
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", nil, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
-	waitForFile(c, filepath.Join(s.DataDir(), "ca-cert.pem"))
+	dirname := filepath.Join(s.ConfDir(), "rsyslog")
+	waitForFile(c, filepath.Join(dirname, "ca-cert.pem"))
 
 	// We should have ca-cert.pem, rsyslog-cert.pem, and rsyslog-key.pem.
-	caCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "ca-cert.pem"))
+	caCertPEM, err := ioutil.ReadFile(filepath.Join(dirname, "ca-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
-	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-cert.pem"))
+	rsyslogCertPEM, err := ioutil.ReadFile(filepath.Join(dirname, "rsyslog-cert.pem"))
 	c.Assert(err, jc.ErrorIsNil)
-	rsyslogKeyPEM, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "rsyslog-key.pem"))
+	rsyslogKeyPEM, err := ioutil.ReadFile(filepath.Join(dirname, "rsyslog-key.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, _, err = cert.ParseCertAndKey(string(rsyslogCertPEM), string(rsyslogKeyPEM))
@@ -130,15 +132,15 @@ func (s *RsyslogSuite) TestModeAccumulate(c *gc.C) {
 
 	syslog.NewAccumulateConfig(syslogConfig)
 	syslogConfig.ConfigDir = *rsyslog.RsyslogConfDir
-	syslogConfig.JujuConfigDir = s.DataDir()
+	syslogConfig.JujuConfigDir = filepath.Join(s.ConfDir(), "rsyslog")
 	rendered, err := syslogConfig.Render()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(string(rsyslogConf), gc.DeepEquals, string(rendered))
 
 	// Verify logrotate files
-	assertPathExists(c, filepath.Join(s.DataDir(), "logrotate.conf"))
-	assertPathExists(c, filepath.Join(s.DataDir(), "logrotate.run"))
+	assertPathExists(c, filepath.Join(dirname, "logrotate.conf"))
+	assertPathExists(c, filepath.Join(dirname, "logrotate.run"))
 
 }
 
@@ -154,7 +156,7 @@ func (s *RsyslogSuite) TestAccumulateHA(c *gc.C) {
 	}
 
 	syslog.NewAccumulateConfig(syslogConfig)
-	syslogConfig.JujuConfigDir = s.DataDir()
+	syslogConfig.JujuConfigDir = filepath.Join(s.ConfDir(), "rsyslog")
 	rendered, err := syslogConfig.Render()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -191,11 +193,10 @@ func (s *RsyslogSuite) testNamespace(c *gc.C, st *api.State, tag names.Tag, name
 		return nil
 	})
 
-	jujuConfigDir := s.AgentConfigForTag(c, tag).DataDir()
-
 	err := os.MkdirAll(expectedLogDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, tag, namespace, []string{"0.1.2.3"}, jujuConfigDir)
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(),
+		rsyslog.RsyslogModeAccumulate, tag, namespace, []string{"0.1.2.3"}, s.ConfDir())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -210,7 +211,8 @@ func (s *RsyslogSuite) testNamespace(c *gc.C, st *api.State, tag names.Tag, name
 	waitForRestart(c, restarted)
 
 	// Ensure that ca-cert.pem gets written to the expected log dir.
-	waitForFile(c, filepath.Join(jujuConfigDir, "ca-cert.pem"))
+	dirname := filepath.Join(s.ConfDir(), "rsyslog")
+	waitForFile(c, filepath.Join(dirname, "ca-cert.pem"))
 
 	dir, err := os.Open(*rsyslog.RsyslogConfDir)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/rsyslog/rsyslog_test.go
+++ b/worker/rsyslog/rsyslog_test.go
@@ -5,6 +5,8 @@
 package rsyslog_test
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -165,6 +167,42 @@ func (s *RsyslogSuite) TestAccumulateHA(c *gc.C) {
 
 	c.Assert(strings.Contains(string(rendered), stateServer1Config), jc.IsTrue)
 	c.Assert(strings.Contains(string(rendered), stateServer2Config), jc.IsTrue)
+}
+
+// TestModeAccumulateCertsExist is a regression test for
+// https://bugs.launchpad.net/juju-core/+bug/1464335,
+// where the CA certs existing (in local provider) at
+// bootstrap caused the worker to not publish to state.
+func (s *RsyslogSuite) TestModeAccumulateCertsExistOnDisk(c *gc.C) {
+	dirname := filepath.Join(s.ConfDir(), "rsyslog")
+	err := os.MkdirAll(dirname, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(filepath.Join(dirname, "ca-cert.pem"), nil, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	st, m := s.st, s.machine
+	worker, err := rsyslog.NewRsyslogConfigWorker(st.Rsyslog(), rsyslog.RsyslogModeAccumulate, m.Tag(), "", nil, s.ConfDir())
+	c.Assert(err, jc.ErrorIsNil)
+	// The worker should create certs and publish to state during setup,
+	// so we can kill and wait and be confident that the task is done.
+	worker.Kill()
+	c.Assert(worker.Wait(), jc.ErrorIsNil)
+
+	// The CA cert and key should have been published to state.
+	cfg, err := s.State.EnvironConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.AllAttrs()["rsyslog-ca-cert"], gc.NotNil)
+	c.Assert(cfg.AllAttrs()["rsyslog-ca-key"], gc.NotNil)
+
+	// ca-cert.pem isn't updated on disk until the worker reacts to the
+	// state change. Let's just ensure that rsyslog-ca-cert is a valid
+	// certificate, and no the zero-length string we wrote to ca-cert.pem.
+	caCertPEM := cfg.AllAttrs()["rsyslog-ca-cert"].(string)
+	c.Assert(err, jc.ErrorIsNil)
+	block, _ := pem.Decode([]byte(caCertPEM))
+	c.Assert(block, gc.NotNil)
+	_, err = x509.ParseCertificate(block.Bytes)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *RsyslogSuite) TestNamespace(c *gc.C) {

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
@@ -107,6 +108,14 @@ func NewRsyslogConfigWorker(st *apirsyslog.State, mode RsyslogMode, tag names.Ta
 }
 
 func newRsyslogConfigHandler(st *apirsyslog.State, mode RsyslogMode, tag names.Tag, namespace string, stateServerAddrs []string, jujuConfigDir string) (*RsyslogConfigHandler, error) {
+	if namespace != "" {
+		jujuConfigDir += "-" + namespace
+	}
+	jujuConfigDir = filepath.Join(jujuConfigDir, "rsyslog")
+	if err := os.MkdirAll(jujuConfigDir, 0755); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	syslogConfig := &syslog.SyslogConfig{
 		LogFileName:          tag.String(),
 		LogDir:               logDir,

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -151,6 +151,7 @@ func newRsyslogConfigHandler(st *apirsyslog.State, mode RsyslogMode, tag names.T
 	if namespace != "" {
 		syslogConfig.LogDir += "-" + namespace
 	}
+
 	return &RsyslogConfigHandler{
 		st:           st,
 		mode:         mode,
@@ -161,7 +162,7 @@ func newRsyslogConfigHandler(st *apirsyslog.State, mode RsyslogMode, tag names.T
 
 func (h *RsyslogConfigHandler) SetUp() (watcher.NotifyWatcher, error) {
 	if h.mode == RsyslogModeAccumulate {
-		if err := h.ensureCertificates(); err != nil {
+		if err := h.ensureCA(); err != nil {
 			return nil, errors.Annotate(err, "failed to write rsyslog certificates")
 		}
 
@@ -363,49 +364,30 @@ func (h *RsyslogConfigHandler) rsyslogHosts() ([]string, error) {
 	return hosts, nil
 }
 
-// ensureCertificates ensures that a CA certificate,
-// server certificate, and private key exist in the log
-// directory, and writes them if not. The CA certificate
-// is entered into the environment configuration to be
-// picked up by other agents.
-func (h *RsyslogConfigHandler) ensureCertificates() error {
-	// We write ca-cert.pem last, after propagating into state.
-	// If it's there, then there's nothing to do. Otherwise,
-	// start over.
-	caCertPEM := h.syslogConfig.CACertPath()
-	if _, err := os.Stat(caCertPEM); err == nil {
+// ensureCA ensures that a CA certificate and key exist in state,
+// to be picked up by all rsyslog workers in the environment.
+func (h *RsyslogConfigHandler) ensureCA() error {
+	// We never write the CA key to local disk, so
+	// we must check state to know whether or not
+	// we need to generate new certs and keys.
+	cfg, err := h.st.GetRsyslogConfig(h.tag.String())
+	if err != nil {
+		return errors.Annotate(err, "cannot get environ config")
+	}
+	if cfg.CACert != "" && cfg.CAKey != "" {
 		return nil
 	}
 
-	// Generate a new CA and server cert/key pairs.
-	// The CA key will be discarded after the server
-	// cert has been generated.
+	// Generate a new CA and server cert/key pairs, and
+	// publish to state. Rsyslog workers will observe
+	// this and generate certificates and keys for
+	// rsyslog in response.
 	expiry := time.Now().UTC().AddDate(10, 0, 0)
 	caCertPEM, caKeyPEM, err := cert.NewCA("rsyslog", expiry)
 	if err != nil {
 		return err
 	}
-
-	// Update the environment config with the CA cert,
-	// so clients can configure rsyslog.
-	if err := h.st.SetRsyslogCert(caCertPEM, caKeyPEM); err != nil {
-		return err
-	}
-
-	rsyslogCertPEM, rsyslogKeyPEM, err := h.rsyslogServerCerts(caCertPEM, caKeyPEM)
-	if err != nil {
-		return err
-	}
-
-	if err := writeCertificates([]certPair{
-		{h.syslogConfig.ServerCertPath(), rsyslogCertPEM},
-		{h.syslogConfig.ServerKeyPath(), rsyslogKeyPEM},
-		{h.syslogConfig.CACertPath(), caCertPEM},
-	}); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
+	return h.st.SetRsyslogCert(caCertPEM, caKeyPEM)
 }
 
 // writeCertificates persists any certPair to disk. If any


### PR DESCRIPTION
(This is a forward port of fixes to worker/rsyslog
made in 1.24. There were  a bunch of changes to
move config files from /var/log/juju to /var/lib/juju
which were forward ported, but then there were more
changes to move them again to /etc/juju which were
not forward ported. I have included the latter in
this PR.)

Use the CA cert/key presence in state as the condition for regenerating at
setup time. This fixes a bug where we would not publish the cert/key to
state if the files existed on disk at bootstrap time.

Also, don't bother writing out files during setup, as the worker will react
to the state change and write out.

Fixes https://bugs.launchpad.net/juju-core/+bug/1464335

(Review request: http://reviews.vapour.ws/r/2263/)