### PR TITLE
Deal with process IDs rather than just process names.

### DIFF
--- a/process/api/client/hookcontext.go
+++ b/process/api/client/hookcontext.go
@@ -11,8 +11,6 @@ import (
 	"github.com/juju/juju/process/api"
 )
 
-const processAPI = "Process"
-
 type facadeCaller interface {
 	FacadeCall(request string, params, response interface{}) error
 }

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -96,15 +96,15 @@ func newStubContextComponent(stub *testing.Stub) *stubContextComponent {
 	}
 }
 
-func (c *stubContextComponent) Get(procName string) (*process.Info, error) {
-	c.stub.AddCall("Get", procName)
+func (c *stubContextComponent) Get(id string) (*process.Info, error) {
+	c.stub.AddCall("Get", id)
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	info, ok := c.procs[procName]
+	info, ok := c.procs[id]
 	if !ok {
-		return nil, errors.NotFoundf(procName)
+		return nil, errors.NotFoundf(id)
 	}
 	return info, nil
 }
@@ -122,16 +122,16 @@ func (c *stubContextComponent) List() ([]string, error) {
 	return ids, nil
 }
 
-func (c *stubContextComponent) Set(procName string, info *process.Info) error {
-	c.stub.AddCall("Set", procName, info)
+func (c *stubContextComponent) Set(id string, info *process.Info) error {
+	c.stub.AddCall("Set", id, info)
 	if err := c.stub.NextErr(); err != nil {
 		return errors.Trace(err)
 	}
 
-	if info.ID() != procName {
-		return errors.Errorf("name mismatch (expected %q, got %q)", info.Name, procName)
+	if info.ID() != id {
+		return errors.Errorf("name mismatch (expected %q, got %q)", info.Name, id)
 	}
-	c.procs[procName] = info
+	c.procs[id] = info
 	return nil
 }
 

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -128,16 +128,13 @@ func (c *stubContextComponent) List() ([]string, error) {
 	return ids, nil
 }
 
-func (c *stubContextComponent) Set(id string, info *process.Info) error {
-	c.stub.AddCall("Set", id, info)
+func (c *stubContextComponent) Set(info process.Info) error {
+	c.stub.AddCall("Set", info)
 	if err := c.stub.NextErr(); err != nil {
 		return errors.Trace(err)
 	}
 
-	if info.ID() != id {
-		return errors.Errorf("name mismatch (expected %q, got %q)", info.Name, id)
-	}
-	c.procs[id] = info
+	c.procs[info.ID()] = &info
 	return nil
 }
 

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -128,8 +128,8 @@ func (c *stubContextComponent) Set(procName string, info *process.Info) error {
 		return errors.Trace(err)
 	}
 
-	if info.Name != procName {
-		return errors.Errorf("name mismatch")
+	if info.ID() != procName {
+		return errors.Errorf("name mismatch (expected %q, got %q)", info.Name, procName)
 	}
 	c.procs[procName] = info
 	return nil

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -30,14 +30,20 @@ type baseSuite struct {
 func (s *baseSuite) SetUpTest(c *gc.C) {
 	s.ContextSuite.SetUpTest(c)
 
-	s.proc = s.newProc("proc A", "docker")
+	s.proc = s.newProc("proc A", "docker", "", "")
 }
 
-func (s *baseSuite) newProc(name, ptype string) *process.Info {
+func (s *baseSuite) newProc(name, ptype, id, status string) *process.Info {
 	return &process.Info{
 		Process: charm.Process{
 			Name: name,
 			Type: ptype,
+		},
+		Details: process.Details{
+			ID: id,
+			Status: process.PluginStatus{
+				Label: status,
+			},
 		},
 	}
 }
@@ -174,10 +180,27 @@ func newStubAPIClient(stub *testing.Stub) *stubAPIClient {
 func (c *stubAPIClient) setNew(ids ...string) []*process.Info {
 	var procs []*process.Info
 	for _, id := range ids {
-		var proc process.Info
-		proc.Name = id
-		c.procs[id] = &proc
-		procs = append(procs, &proc)
+		name, pluginID := process.ParseID(id)
+		if name == "" {
+			panic("missing name")
+		}
+		if pluginID == "" {
+			panic("missing id")
+		}
+		proc := &process.Info{
+			Process: charm.Process{
+				Name: name,
+				Type: "myplugin",
+			},
+			Details: process.Details{
+				ID: pluginID,
+				Status: process.PluginStatus{
+					Label: "okay",
+				},
+			},
+		}
+		c.procs[id] = proc
+		procs = append(procs, proc)
 	}
 	return procs
 }

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -291,7 +291,7 @@ func (c *registeringCommand) findValidInfo(ctx *cmd.Context) (*process.Info, err
 	info.Process = *c.UpdatedProcess
 
 	// validate
-	if err := info.Validate(); err != nil {
+	if err := info.Process.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if info.IsRegistered() {

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -14,6 +14,8 @@ import (
 	"github.com/juju/juju/process"
 )
 
+const idArg = "name"
+
 type cmdInfo struct {
 	// Name is the command's name.
 	Name string
@@ -76,7 +78,7 @@ func newCommand(ctx HookContext) (*baseCommand, error) {
 // Info implements cmd.Command.
 func (c baseCommand) Info() *cmd.Info {
 	var args []string
-	for _, name := range append([]string{"name"}, c.cmdInfo.ExtraArgs...) {
+	for _, name := range append([]string{idArg}, c.cmdInfo.ExtraArgs...) {
 		arg := "<" + name + ">"
 		if c.cmdInfo.isOptional(name) {
 			arg = "[" + arg + "]"
@@ -101,7 +103,7 @@ func (c *baseCommand) Init(args []string) error {
 }
 
 func (c *baseCommand) processArgs(args []string) (map[string]string, error) {
-	argNames := append([]string{"name"}, c.cmdInfo.ExtraArgs...)
+	argNames := append([]string{idArg}, c.cmdInfo.ExtraArgs...)
 	results := make(map[string]string)
 	for i, name := range argNames {
 		if len(args) == 0 {
@@ -126,7 +128,7 @@ func (c *baseCommand) processArgs(args []string) (map[string]string, error) {
 }
 
 func (c *baseCommand) init(args map[string]string) error {
-	id := args["name"]
+	id := args[idArg]
 	if id == "" {
 		return errors.Errorf("got empty name")
 	}

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -257,7 +257,7 @@ func (c *registeringCommand) register(ctx *cmd.Context) error {
 
 	info.Details = c.Details
 
-	if err := c.compCtx.Set(info.ID(), info); err != nil {
+	if err := c.compCtx.Set(*info); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -14,12 +14,12 @@ import (
 	"github.com/juju/juju/process"
 )
 
-const idArg = "name"
+const idArg = "name-or-id"
 
 type cmdInfo struct {
 	// Name is the command's name.
 	Name string
-	// ExtraArgs is the list of arg names that follow "name", if any.
+	// ExtraArgs is the list of arg names that follow "name-or-id", if any.
 	ExtraArgs []string
 	// OptionalArgs is the list of optional args, if any.
 	OptionalArgs []string
@@ -130,7 +130,7 @@ func (c *baseCommand) processArgs(args []string) (map[string]string, error) {
 func (c *baseCommand) init(args map[string]string) error {
 	id := args[idArg]
 	if id == "" {
-		return errors.Errorf("got empty name")
+		return errors.Errorf("got empty " + idArg)
 	}
 	name, _ := process.ParseID(id)
 	c.Name = name

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -222,6 +222,7 @@ func (c *registeringCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements cmd.Command.
 func (c *registeringCommand) Run(ctx *cmd.Context) error {
+	// TODO(ericsnow) The Get call here should be match on just c.Name...
 	if err := c.baseCommand.Run(ctx); err != nil {
 		return errors.Trace(err)
 	}
@@ -256,7 +257,7 @@ func (c *registeringCommand) register(ctx *cmd.Context) error {
 
 	info.Details = c.Details
 
-	if err := c.compCtx.Set(c.Name, info); err != nil {
+	if err := c.compCtx.Set(info.ID(), info); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -8,14 +8,11 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v5"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/process"
 )
-
-var logger = loggo.GetLogger("juju.process.persistence")
 
 type cmdInfo struct {
 	// Name is the command's name.

--- a/process/context/command_test.go
+++ b/process/context/command_test.go
@@ -99,7 +99,7 @@ func (s *registeringCommandSuite) checkRunInfo(c *gc.C, orig, sent process.Info)
 
 	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
 	c.Check(s.Stub.Calls()[2].Args, jc.DeepEquals, []interface{}{
-		sent.Name,
+		sent.ID(),
 		&sent,
 	})
 }

--- a/process/context/command_test.go
+++ b/process/context/command_test.go
@@ -98,8 +98,5 @@ func (s *registeringCommandSuite) checkRunInfo(c *gc.C, orig, sent process.Info)
 	c.Check(info, jc.DeepEquals, &orig)
 
 	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
-	c.Check(s.Stub.Calls()[2].Args, jc.DeepEquals, []interface{}{
-		sent.ID(),
-		&sent,
-	})
+	c.Check(s.Stub.Calls()[2].Args, jc.DeepEquals, []interface{}{sent})
 }

--- a/process/context/command_test.go
+++ b/process/context/command_test.go
@@ -97,6 +97,6 @@ func (s *registeringCommandSuite) checkRunInfo(c *gc.C, orig, sent process.Info)
 	info := context.GetCmdInfo(s.cmd)
 	c.Check(info, jc.DeepEquals, &orig)
 
-	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
+	s.Stub.CheckCallNames(c, "List", "ListDefinitions", "Set", "Flush")
 	c.Check(s.Stub.Calls()[2].Args, jc.DeepEquals, []interface{}{sent})
 }

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -105,8 +105,10 @@ func ContextComponent(ctx HookContext) (Component, error) {
 func (c *Context) addProc(id string, original *process.Info) error {
 	var proc *process.Info
 	if original != nil {
+		if id != original.ID() {
+			return errors.Errorf("ID mismatch")
+		}
 		info := *original
-		info.Name = id
 		proc = &info
 	}
 	if _, ok := c.processes[id]; !ok {
@@ -197,8 +199,8 @@ func (c *Context) List() ([]string, error) {
 
 // Set records the process info in the hook context.
 func (c *Context) Set(id string, info *process.Info) error {
-	if id != info.Name {
-		return errors.Errorf("mismatch on name: %s != %s", id, info.Name)
+	if id != info.ID() {
+		return errors.Errorf("mismatch on ID: %s != %s", id, info.ID())
 	}
 	// TODO(ericsnow) We are likely missing mechanisim for local persistence.
 

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -102,27 +102,6 @@ func ContextComponent(ctx HookContext) (Component, error) {
 
 // TODO(ericsnow) Should we build in refreshes in all the methods?
 
-func (c *Context) addProc(id string, original *process.Info) error {
-	var proc *process.Info
-	if original != nil {
-		if id != original.ID() {
-			return errors.Errorf("ID mismatch")
-		}
-		info := *original
-		proc = &info
-	}
-	if _, ok := c.processes[id]; !ok {
-		c.processes[id] = proc
-	} else {
-		if proc == nil {
-			return errors.Errorf("update can't be nil")
-		}
-		info := *proc
-		c.updates[info.ID()] = &info
-	}
-	return nil
-}
-
 // Processes returns the processes known to the context.
 func (c *Context) Processes() ([]*process.Info, error) {
 	var procs []*process.Info

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -59,14 +59,16 @@ type Context struct {
 
 // NewContext returns a new jujuc.ContextComponent for workload processes.
 func NewContext(api APIClient, procs ...*process.Info) *Context {
+	ids := set.NewStrings()
 	processes := make(map[string]*process.Info)
 	for _, proc := range procs {
 		processes[proc.Name] = proc
+		ids.Add(proc.ID())
 	}
 	return &Context{
 		processes: processes,
 		api:       api,
-		ids:       set.NewStrings(),
+		ids:       ids,
 	}
 }
 

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -7,11 +7,14 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/process"
 )
+
+var logger = loggo.GetLogger("juju.process.context")
 
 // TODO(ericsnow) Normalize method names across all the arch. layers
 // (e.g. List->AllProcesses, Get->Processes, Set->AddProcess).

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -56,14 +56,11 @@ type Context struct {
 }
 
 // NewContext returns a new jujuc.ContextComponent for workload processes.
-func NewContext(api APIClient, procs ...*process.Info) *Context {
-	processes := make(map[string]*process.Info)
-	for _, proc := range procs {
-		processes[proc.Name] = proc
-	}
+func NewContext(api APIClient) *Context {
 	return &Context{
-		processes: processes,
 		api:       api,
+		processes: make(map[string]*process.Info),
+		updates:   make(map[string]*process.Info),
 	}
 }
 

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -160,7 +160,7 @@ func (c *Context) Get(id string) (*process.Info, error) {
 	return actual, nil
 }
 
-// List returns the names of all registered processes.
+// List returns the sorted names of all registered processes.
 func (c *Context) List() ([]string, error) {
 	procs, err := c.Processes()
 	if err != nil {

--- a/process/context/context.go
+++ b/process/context/context.go
@@ -37,9 +37,9 @@ type APIClient interface {
 // omponent provides the hook context data specific to workload processes.
 type Component interface {
 	// Get returns the process info corresponding to the given ID.
-	Get(procName string) (*process.Info, error)
+	Get(id string) (*process.Info, error)
 	// Set records the process info in the hook context.
-	Set(procName string, info *process.Info) error
+	Set(id string, info *process.Info) error
 	// List returns the list of registered process IDs.
 	List() ([]string, error)
 	// ListDefinitions returns the charm-defined processes.
@@ -163,16 +163,16 @@ func (c *Context) fetch(id string) (*process.Info, error) {
 }
 
 // Get returns the process info corresponding to the given ID.
-func (c *Context) Get(procName string) (*process.Info, error) {
-	actual, ok := c.updates[procName]
+func (c *Context) Get(id string) (*process.Info, error) {
+	actual, ok := c.updates[id]
 	if !ok {
-		actual, ok = c.processes[procName]
+		actual, ok = c.processes[id]
 		if !ok {
-			return nil, errors.NotFoundf("%s", procName)
+			return nil, errors.NotFoundf("%s", id)
 		}
 	}
 	if actual == nil {
-		fetched, err := c.fetch(procName)
+		fetched, err := c.fetch(id)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -199,13 +199,13 @@ func (c *Context) List() ([]string, error) {
 }
 
 // Set records the process info in the hook context.
-func (c *Context) Set(procName string, info *process.Info) error {
-	if procName != info.Name {
-		return errors.Errorf("mismatch on name: %s != %s", procName, info.Name)
+func (c *Context) Set(id string, info *process.Info) error {
+	if id != info.Name {
+		return errors.Errorf("mismatch on name: %s != %s", id, info.Name)
 	}
 	// TODO(ericsnow) We are likely missing mechanisim for local persistence.
 
-	c.set(procName, info)
+	c.set(id, info)
 	return nil
 }
 

--- a/process/context/context_test.go
+++ b/process/context/context_test.go
@@ -197,8 +197,8 @@ func (s *contextSuite) TestProcessesAdditions(c *gc.C) {
 
 	ctx := s.newContext(c, expected[0])
 	context.AddProc(ctx, "B/eggs", nil)
-	ctx.Set(infoC.ID(), infoC)
-	ctx.Set(infoD.ID(), infoD)
+	ctx.Set(*infoC)
+	ctx.Set(*infoD)
 
 	procs, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
@@ -216,8 +216,8 @@ func (s *contextSuite) TestProcessesOverrides(c *gc.C) {
 	ctx := context.NewContext(s.apiClient)
 	context.AddProc(ctx, "A/xyz123", nil)
 	context.AddProc(ctx, "B/xyz456", nil)
-	ctx.Set(infoB.ID(), infoB)
-	ctx.Set(infoC.ID(), infoC)
+	ctx.Set(*infoB)
+	ctx.Set(*infoC)
 
 	procs, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
@@ -292,7 +292,7 @@ func (s *contextSuite) TestSetOkay(c *gc.C) {
 	ctx := context.NewContext(s.apiClient)
 	before, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.Set(info.ID(), info)
+	err = ctx.Set(*info)
 	c.Assert(err, jc.ErrorIsNil)
 	after, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
@@ -307,28 +307,13 @@ func (s *contextSuite) TestSetOverwrite(c *gc.C) {
 	ctx := s.newContext(c, other)
 	before, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.Set(info.ID(), info)
+	err = ctx.Set(*info)
 	c.Assert(err, jc.ErrorIsNil)
 	after, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(before, jc.DeepEquals, []*process.Info{other})
 	c.Check(after, jc.DeepEquals, []*process.Info{info})
-}
-
-func (s *contextSuite) TestSetNameMismatch(c *gc.C) {
-	info := s.newProc("B", "myplugin", "eggs", "running")
-	other := s.newProc("A", "myplugin", "spam", "stopped")
-	ctx := s.newContext(c, other)
-	before, err2 := ctx.Processes()
-	c.Assert(err2, jc.ErrorIsNil)
-	err := ctx.Set("A/spam", info)
-	after, err2 := ctx.Processes()
-	c.Assert(err2, jc.ErrorIsNil)
-
-	c.Check(err, gc.ErrorMatches, "mismatch on ID: A/spam != B/eggs")
-	c.Check(before, jc.DeepEquals, []*process.Info{other})
-	c.Check(after, jc.DeepEquals, []*process.Info{other})
 }
 
 func (s *contextSuite) TestListDefinitions(c *gc.C) {
@@ -352,7 +337,7 @@ func (s *contextSuite) TestFlushDirty(c *gc.C) {
 	info := s.newProc("A", "myplugin", "xyz123", "okay")
 
 	ctx := context.NewContext(s.apiClient)
-	err := ctx.Set(info.ID(), info)
+	err := ctx.Set(*info)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = ctx.Flush()

--- a/process/context/context_test.go
+++ b/process/context/context_test.go
@@ -31,6 +31,14 @@ func (s *contextSuite) SetUpTest(c *gc.C) {
 	context.AddProcs(s.compCtx, s.proc)
 }
 
+func (s *contextSuite) newContext(c *gc.C, procs ...*process.Info) *context.Context {
+	ctx := context.NewContext(s.apiClient)
+	for _, proc := range procs {
+		context.AddProc(ctx, proc.ID(), proc)
+	}
+	return ctx
+}
+
 func (s *contextSuite) TestNewContextEmpty(c *gc.C) {
 	ctx := context.NewContext(s.apiClient)
 	procs, err := ctx.Processes()
@@ -44,7 +52,7 @@ func (s *contextSuite) TestNewContextPrePopulated(c *gc.C) {
 	expected[0].Name = "A"
 	expected[1].Name = "B"
 
-	ctx := context.NewContext(s.apiClient, expected...)
+	ctx := s.newContext(c, expected...)
 	procs, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -147,7 +155,7 @@ func (s *contextSuite) TestProcessesOkay(c *gc.C) {
 	expected[1].Name = "B"
 	expected[2].Name = "C"
 
-	ctx := context.NewContext(s.apiClient, expected...)
+	ctx := s.newContext(c, expected...)
 	procs, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -186,7 +194,7 @@ func (s *contextSuite) TestProcessesAdditions(c *gc.C) {
 	infoD.Name = "D"
 	expected = append(expected, &infoC, &infoD)
 
-	ctx := context.NewContext(s.apiClient, expected[0])
+	ctx := s.newContext(c, expected[0])
 	context.AddProc(ctx, "B", nil)
 	ctx.Set("C", &infoC)
 	ctx.Set("D", &infoD)
@@ -222,7 +230,7 @@ func (s *contextSuite) TestGetOkay(c *gc.C) {
 	var expected, extra process.Info
 	expected.Name = "A"
 
-	ctx := context.NewContext(s.apiClient, &expected, &extra)
+	ctx := s.newContext(c, &expected, &extra)
 	info, err := ctx.Get("A")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -234,7 +242,7 @@ func (s *contextSuite) TestGetAPIPull(c *gc.C) {
 	procs := s.apiClient.setNew("A", "B")
 	expected := procs[0]
 
-	ctx := context.NewContext(s.apiClient, procs[1])
+	ctx := s.newContext(c, procs[1])
 	context.AddProc(ctx, "A", nil)
 
 	info, err := ctx.Get("A")
@@ -248,7 +256,7 @@ func (s *contextSuite) TestGetAPINoPull(c *gc.C) {
 	procs := s.apiClient.setNew("A", "B")
 	expected := procs[0]
 
-	ctx := context.NewContext(s.apiClient, procs...)
+	ctx := s.newContext(c, procs...)
 
 	info, err := ctx.Get("A")
 	c.Assert(err, jc.ErrorIsNil)
@@ -261,7 +269,7 @@ func (s *contextSuite) TestGetOverride(c *gc.C) {
 	procs := s.apiClient.setNew("A", "B")
 	expected := procs[0]
 
-	ctx := context.NewContext(s.apiClient, procs[1])
+	ctx := s.newContext(c, procs[1])
 	context.AddProc(ctx, "A", nil)
 	context.AddProc(ctx, "A", expected)
 
@@ -300,7 +308,7 @@ func (s *contextSuite) TestSetOverwrite(c *gc.C) {
 	info.Details.Status.Label = "running"
 	other.Name = "A"
 	other.Details.Status.Label = "stopped"
-	ctx := context.NewContext(s.apiClient, &other)
+	ctx := s.newContext(c, &other)
 	before, err := ctx.Processes()
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.Set("A", &info)
@@ -316,7 +324,7 @@ func (s *contextSuite) TestSetNameMismatch(c *gc.C) {
 	var info, other process.Info
 	info.Name = "B"
 	other.Name = "A"
-	ctx := context.NewContext(s.apiClient, &other)
+	ctx := s.newContext(c, &other)
 	before, err2 := ctx.Processes()
 	c.Assert(err2, jc.ErrorIsNil)
 	err := ctx.Set("A", &info)
@@ -362,7 +370,7 @@ func (s *contextSuite) TestFlushDirty(c *gc.C) {
 func (s *contextSuite) TestFlushNotDirty(c *gc.C) {
 	var info process.Info
 	info.Name = "flush-not-dirty"
-	ctx := context.NewContext(s.apiClient, &info)
+	ctx := s.newContext(c, &info)
 
 	err := ctx.Flush()
 	c.Assert(err, jc.ErrorIsNil)

--- a/process/context/export_test.go
+++ b/process/context/export_test.go
@@ -20,8 +20,22 @@ func SetComponent(cmd cmd.Command, compCtx Component) {
 }
 
 func AddProc(ctx *Context, id string, original *process.Info) {
-	if err := ctx.addProc(id, original); err != nil {
-		panic(err)
+	var proc *process.Info
+	if original != nil {
+		if id != original.ID() {
+			panic("ID mismatch")
+		}
+		info := *original
+		proc = &info
+	}
+	if _, ok := ctx.processes[id]; !ok {
+		ctx.processes[id] = proc
+	} else {
+		if proc == nil {
+			panic("update can't be nil")
+		}
+		info := *proc
+		ctx.updates[info.ID()] = &info
 	}
 }
 

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -15,7 +15,7 @@ import (
 // InfoCommandInfo is the info for the proc-info command.
 var InfoCommandInfo = cmdInfo{
 	Name:         "process-info",
-	OptionalArgs: []string{"name"},
+	OptionalArgs: []string{idArg},
 	Summary:      "get info about a workload process (or all of them)",
 	Doc: `
 "process-info" is used while a hook is running to access a currently

--- a/process/context/info.go
+++ b/process/context/info.go
@@ -66,8 +66,14 @@ func (c *ProcInfoCommand) init(args map[string]string) error {
 // Run implements cmd.Command.
 func (c *ProcInfoCommand) Run(ctx *cmd.Context) error {
 	var ids []string
-	if c.Name != "" {
-		ids = append(ids, c.Name)
+	if c.ID != "" {
+		id, err := c.findID()
+		if errors.IsNotFound(err) {
+			id = c.ID
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+		ids = append(ids, id)
 	}
 
 	formatted, err := c.formatInfos(ids...)
@@ -96,7 +102,7 @@ func (c *ProcInfoCommand) formatInfos(ids ...string) (map[string]interface{}, er
 		}
 	} else {
 		for _, proc := range procs {
-			ids = append(ids, proc.Name)
+			ids = append(ids, proc.ID())
 		}
 		sort.Strings(ids)
 	}

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -142,14 +142,14 @@ func (s *infoSuite) TestInitTooManyArgs(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `unrecognized args: .*`)
 }
 
-func (s *infoSuite) TestRunWithNameOkay(c *gc.C) {
-	s.compCtx.procs["myprocess0"] = &proc0
-	s.compCtx.procs["myprocess1"] = &proc1
-	s.compCtx.procs["myprocess2"] = &proc2
-	s.init(c, "myprocess0")
+func (s *infoSuite) TestRunWithIDkay(c *gc.C) {
+	s.compCtx.procs["myprocess0/xyz123"] = &proc0
+	s.compCtx.procs["myprocess1/xyz456"] = &proc1
+	s.compCtx.procs["myprocess2/xyz789"] = &proc2
+	s.init(c, "myprocess0/xyz123")
 
 	expected := `
-myprocess0:
+myprocess0/xyz123:
   process:
     name: myprocess0
     description: ""
@@ -171,14 +171,14 @@ myprocess0:
 	s.Stub.CheckCallNames(c, "Get")
 }
 
-func (s *infoSuite) TestRunWithoutNameOkay(c *gc.C) {
-	s.compCtx.procs["myprocess0"] = &proc0
-	s.compCtx.procs["myprocess1"] = &proc1
-	s.compCtx.procs["myprocess2"] = &proc2
+func (s *infoSuite) TestRunWithoutIDOkay(c *gc.C) {
+	s.compCtx.procs["myprocess0/xyz123"] = &proc0
+	s.compCtx.procs["myprocess1/xyz456"] = &proc1
+	s.compCtx.procs["myprocess2/xyz789"] = &proc2
 	s.init(c, "")
 
 	expected := `
-myprocess0:
+myprocess0/xyz123:
   process:
     name: myprocess0
     description: ""
@@ -195,7 +195,7 @@ myprocess0:
     id: xyz123
     status:
       label: running
-myprocess1:
+myprocess1/xyz456:
   process:
     name: myprocess1
     description: ""
@@ -210,7 +210,7 @@ myprocess1:
     id: xyz456
     status:
       label: running
-myprocess2:
+myprocess2/xyz789:
   process:
     name: myprocess2
     description: ""
@@ -230,14 +230,50 @@ myprocess2:
 	s.Stub.CheckCallNames(c, "List", "Get", "Get", "Get")
 }
 
+func (s *infoSuite) TestRunWithNameOkay(c *gc.C) {
+	s.compCtx.procs["myprocess0/xyz123"] = &proc0
+	s.compCtx.procs["myprocess1/xyz456"] = &proc1
+	s.compCtx.procs["myprocess2/xyz789"] = &proc2
+	s.init(c, "myprocess0")
+
+	expected := `
+myprocess0/xyz123:
+  process:
+    name: myprocess0
+    description: ""
+    type: myplugin
+    typeoptions:
+      extra: "5"
+    command: do-something
+    image: myimage
+    ports: []
+    volumes: []
+    envvars:
+      ENV_VAR: some value
+  details:
+    id: xyz123
+    status:
+      label: running
+`[1:]
+	s.checkRun(c, expected, "")
+	s.Stub.CheckCallNames(c, "List", "Get")
+}
+
+func (s *infoSuite) TestRunWithIDMissing(c *gc.C) {
+	s.init(c, "myprocess0/xyz123")
+
+	s.checkRun(c, `myprocess0/xyz123: <not found>`+"\n", "")
+	s.Stub.CheckCallNames(c, "Get")
+}
+
 func (s *infoSuite) TestRunWithNameMissing(c *gc.C) {
 	s.init(c, "myprocess0")
 
 	s.checkRun(c, `myprocess0: <not found>`+"\n", "")
-	s.Stub.CheckCallNames(c, "Get")
+	s.Stub.CheckCallNames(c, "List", "Get")
 }
 
-func (s *infoSuite) TestRunWithoutNameEmpty(c *gc.C) {
+func (s *infoSuite) TestRunWithoutIDEmpty(c *gc.C) {
 	s.init(c, "")
 
 	s.checkRun(c, "", "<no processes registered>\n")

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -98,7 +98,7 @@ func (s *infoSuite) TestCommandRegistered(c *gc.C) {
 
 func (s *infoSuite) TestHelp(c *gc.C) {
 	s.checkHelp(c, `
-usage: process-info [options] [<name>]
+usage: process-info [options] [<name-or-id>]
 purpose: get info about a workload process (or all of them)
 
 options:

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -56,7 +56,7 @@ func (s *registerSuite) TestCommandRegistered(c *gc.C) {
 
 func (s *registerSuite) TestHelp(c *gc.C) {
 	s.checkHelp(c, `
-usage: process-register [options] <name> <proc-details>
+usage: process-register [options] <name-or-id> <proc-details>
 purpose: register a workload process
 
 options:
@@ -114,7 +114,7 @@ func (s *registerSuite) TestInitEmptyName(c *gc.C) {
 		"abc123",
 	})
 
-	c.Check(err, gc.ErrorMatches, "got empty name")
+	c.Check(err, gc.ErrorMatches, "got empty name-or-id")
 }
 
 func (s *registerSuite) TestInitEmptyID(c *gc.C) {

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -323,7 +323,7 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 		FuncName: "ListDefinitions",
 	}, {
 		FuncName: "Set",
-		Args:     []interface{}{s.proc.ID(), s.proc},
+		Args:     []interface{}{*s.proc},
 	}, {
 		FuncName: "Flush",
 		Args:     nil,

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -323,7 +323,7 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 		FuncName: "ListDefinitions",
 	}, {
 		FuncName: "Set",
-		Args:     []interface{}{s.proc.Name, s.proc},
+		Args:     []interface{}{s.proc.ID(), s.proc},
 	}, {
 		FuncName: "Flush",
 		Args:     nil,

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -293,7 +293,7 @@ func (s *registerSuite) TestRunOkay(c *gc.C) {
 	s.init(c, s.proc.Name, "abc123", "running")
 
 	s.checkRun(c, "", "")
-	s.Stub.CheckCallNames(c, "Get", "ListDefinitions", "Set", "Flush")
+	s.Stub.CheckCallNames(c, "List", "ListDefinitions", "Set", "Flush")
 }
 
 func (s *registerSuite) TestRunAlreadyRegistered(c *gc.C) {
@@ -317,8 +317,7 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 	s.proc.Process = *s.registerCmd.UpdatedProcess
 	s.proc.Details = s.details
 	s.Stub.CheckCalls(c, []testing.StubCall{{
-		FuncName: "Get",
-		Args:     []interface{}{s.proc.Name},
+		FuncName: "List",
 	}, {
 		FuncName: "ListDefinitions",
 	}, {

--- a/process/info.go
+++ b/process/info.go
@@ -50,10 +50,8 @@ func (info Info) Validate() error {
 		return errors.Trace(err)
 	}
 
-	if !reflect.DeepEqual(info.Details, Details{}) {
-		if err := info.Details.Validate(); err != nil {
-			return errors.Trace(err)
-		}
+	if err := info.Details.Validate(); err != nil {
+		return errors.Trace(err)
 	}
 
 	return nil

--- a/process/info_test.go
+++ b/process/info_test.go
@@ -72,6 +72,8 @@ func (s *infoSuite) TestParseIDExtras(c *gc.C) {
 
 func (s *infoSuite) TestValidateOkay(c *gc.C) {
 	info := s.newInfo("a proc", "docker")
+	info.Details.ID = "my-proc"
+	info.Details.Status.Label = "running"
 	err := info.Validate()
 
 	c.Check(err, jc.ErrorIsNil)


### PR DESCRIPTION
Currently the hook context commands deal only with proc names.  However, registered processes must be identified by the name + the ID provided by the plugin.  This patch fixes that.

(Review request: http://reviews.vapour.ws/r/2265/)