### PR TITLE
worker/uniter/...: add storage-list hook tool

### DIFF
--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -329,6 +329,10 @@ func (ctx *HookContext) AvailabilityZone() (string, bool) {
 	return ctx.availabilityzone, ctx.availabilityzone != ""
 }
 
+func (ctx *HookContext) StorageTags() []names.StorageTag {
+	return ctx.storage.StorageTags()
+}
+
 func (ctx *HookContext) HookStorage() (jujuc.ContextStorageAttachment, bool) {
 	return ctx.Storage(ctx.storageTag)
 }

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -53,6 +53,10 @@ type Factory interface {
 // for a jujuc.Context.
 type StorageContextAccessor interface {
 
+	// StorageTags returns the tags of storage instances attached to
+	// the unit.
+	StorageTags() []names.StorageTag
+
 	// Storage returns the jujuc.ContextStorageAttachment with the
 	// supplied tag if it was found, and whether it was found.
 	Storage(names.StorageTag) (jujuc.ContextStorageAttachment, bool)

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -184,6 +184,10 @@ type ContextMetrics interface {
 // ContextStorage is the part of a hook context related to storage
 // resources associated with the unit.
 type ContextStorage interface {
+	// StorageTags returns a list of tags for storage instances
+	// attached to the unit.
+	StorageTags() []names.StorageTag
+
 	// Storage returns the ContextStorageAttachment with the supplied
 	// tag if it was found, and whether it was found.
 	Storage(names.StorageTag) (ContextStorageAttachment, bool)

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -55,8 +55,9 @@ var baseCommands = map[string]creator{
 }
 
 var storageCommands = map[string]creator{
-	"storage-add" + cmdSuffix: NewStorageAddCommand,
-	"storage-get" + cmdSuffix: NewStorageGetCommand,
+	"storage-add" + cmdSuffix:  NewStorageAddCommand,
+	"storage-get" + cmdSuffix:  NewStorageGetCommand,
+	"storage-list" + cmdSuffix: NewStorageListCommand,
 }
 
 var leaderCommands = map[string]creator{

--- a/worker/uniter/runner/jujuc/storage-list.go
+++ b/worker/uniter/runner/jujuc/storage-list.go
@@ -1,0 +1,52 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+)
+
+// StorageListCommand implements the storage-list command.
+//
+// StorageListCommand implements cmd.Command.
+type StorageListCommand struct {
+	cmd.CommandBase
+	ctx Context
+	out cmd.Output
+}
+
+func NewStorageListCommand(ctx Context) cmd.Command {
+	return &StorageListCommand{ctx: ctx}
+}
+
+func (c *StorageListCommand) Info() *cmd.Info {
+	doc := `
+storage-list will list the names of all storage instances
+attached to the unit. These names can be passed to storage-get
+via the "-s" flag to query the storage attributes.
+`
+	return &cmd.Info{
+		Name:    "storage-list",
+		Purpose: "list storage attached to the unit",
+		Doc:     doc,
+	}
+}
+
+func (c *StorageListCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+}
+
+func (c *StorageListCommand) Init(args []string) (err error) {
+	return cmd.CheckEmpty(args)
+}
+
+func (c *StorageListCommand) Run(ctx *cmd.Context) error {
+	tags := c.ctx.StorageTags()
+	names := make([]string, len(tags))
+	for i, tag := range tags {
+		names[i] = tag.Id()
+	}
+	return c.out.Write(ctx, names)
+}

--- a/worker/uniter/runner/jujuc/storage-list_test.go
+++ b/worker/uniter/runner/jujuc/storage-list_test.go
@@ -1,0 +1,104 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"encoding/json"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
+)
+
+type storageListSuite struct {
+	storageSuite
+}
+
+var _ = gc.Suite(&storageListSuite{})
+
+func (s *storageListSuite) newHookContext() *jujuctesting.Context {
+	ctx, info := s.NewHookContext()
+	info.SetBlockStorage("data/0", "/dev/sda", s.Stub)
+	info.SetBlockStorage("data/1", "/dev/sdb", s.Stub)
+	info.SetBlockStorage("data/2", "/dev/sdc", s.Stub)
+	return ctx
+}
+
+func (s *storageListSuite) TestOutputFormatYAML(c *gc.C) {
+	s.testOutputFormat(c,
+		[]string{"--format", "yaml"},
+		formatYaml,
+		[]string{"data/0", "data/1", "data/2"},
+	)
+}
+
+func (s *storageListSuite) TestOutputFormatJSON(c *gc.C) {
+	s.testOutputFormat(c,
+		[]string{"--format", "json"},
+		formatJson,
+		[]string{"data/0", "data/1", "data/2"},
+	)
+}
+
+func (s *storageListSuite) TestOutputFormatDefault(c *gc.C) {
+	// The default output format is "smart", which is
+	// a newline-separated list of strings.
+	s.testOutputFormat(c,
+		[]string{},
+		-1, // don't specify format
+		"data/0\ndata/1\ndata/2\n",
+	)
+}
+
+func (s *storageListSuite) testOutputFormat(c *gc.C, args []string, format int, expect interface{}) {
+	hctx := s.newHookContext()
+	com, err := jujuc.NewCommand(hctx, cmdString("storage-list"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, args)
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+
+	var out interface{}
+	var outSlice []string
+	switch format {
+	case formatYaml:
+		c.Assert(goyaml.Unmarshal(bufferBytes(ctx.Stdout), &outSlice), gc.IsNil)
+		out = outSlice
+	case formatJson:
+		c.Assert(json.Unmarshal(bufferBytes(ctx.Stdout), &outSlice), gc.IsNil)
+		out = outSlice
+	default:
+		out = string(bufferBytes(ctx.Stdout))
+	}
+	c.Assert(out, jc.DeepEquals, expect)
+}
+
+func (s *storageListSuite) TestHelp(c *gc.C) {
+	hctx := s.newHookContext()
+	com, err := jujuc.NewCommand(hctx, cmdString("storage-list"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, []string{"--help"})
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: storage-list [options]
+purpose: list storage attached to the unit
+
+options:
+--format  (= smart)
+    specify output format (json|smart|yaml)
+-o, --output (= "")
+    specify an output file
+
+storage-list will list the names of all storage instances
+attached to the unit. These names can be passed to storage-get
+via the "-s" flag to query the storage attributes.
+`)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+}

--- a/worker/uniter/runner/jujuc/storage_test.go
+++ b/worker/uniter/runner/jujuc/storage_test.go
@@ -14,6 +14,8 @@ var (
 		"location": "/dev/sda",
 		"kind":     "block",
 	}
+
+	storageName = "data/0"
 )
 
 type storageSuite struct {

--- a/worker/uniter/runner/jujuc/testing/storage.go
+++ b/worker/uniter/runner/jujuc/testing/storage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/names"
 	"github.com/juju/testing"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/storage"
@@ -78,6 +79,22 @@ func (s *Storage) AddUnitStorage(all map[string]params.StorageConstraints) {
 type ContextStorage struct {
 	contextBase
 	info *Storage
+}
+
+// StorageTags implements jujuc.ContextStorage.
+func (c *ContextStorage) StorageTags() []names.StorageTag {
+	c.stub.AddCall("StorageTags")
+	c.stub.NextErr()
+
+	tags := set.NewTags()
+	for tag := range c.info.Storage {
+		tags.Add(tag)
+	}
+	storageTags := make([]names.StorageTag, tags.Size())
+	for i, tag := range tags.SortedValues() {
+		storageTags[i] = tag.(names.StorageTag)
+	}
+	return storageTags
 }
 
 // Storage implements jujuc.ContextStorage.

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -16,6 +16,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/proxy"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
@@ -354,6 +355,18 @@ func makeCharm(c *gc.C, spec hookSpec, charmDir string) {
 
 type storageContextAccessor struct {
 	storage map[names.StorageTag]*contextStorage
+}
+
+func (s *storageContextAccessor) StorageTags() []names.StorageTag {
+	tags := set.NewTags()
+	for tag := range s.storage {
+		tags.Add(tag)
+	}
+	storageTags := make([]names.StorageTag, len(tags))
+	for i, tag := range tags.SortedValues() {
+		storageTags[i] = tag.(names.StorageTag)
+	}
+	return storageTags
 }
 
 func (s *storageContextAccessor) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachment, bool) {

--- a/worker/uniter/storage/attachments.go
+++ b/worker/uniter/storage/attachments.go
@@ -304,6 +304,19 @@ func (a *Attachments) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachm
 	return nil, false
 }
 
+// StorageTags returns the names.StorageTags for the active storage attachments.
+func (a *Attachments) StorageTags() []names.StorageTag {
+	tags := set.NewTags()
+	for tag := range a.storagers {
+		tags.Add(tag)
+	}
+	storageTags := make([]names.StorageTag, tags.Size())
+	for i, tag := range tags.SortedValues() {
+		storageTags[i] = tag.(names.StorageTag)
+	}
+	return storageTags
+}
+
 // ValidateHook validates the hook against the current state.
 func (a *Attachments) ValidateHook(hi hook.Info) error {
 	storager, err := a.storagerForHook(hi)

--- a/worker/uniter/storage/attachments_test.go
+++ b/worker/uniter/storage/attachments_test.go
@@ -26,6 +26,10 @@ type attachmentsSuite struct {
 
 var _ = gc.Suite(&attachmentsSuite{})
 
+func assertStorageTags(c *gc.C, a *storage.Attachments, tags ...names.StorageTag) {
+	c.Assert(a.StorageTags(), jc.SameContents, tags)
+}
+
 func (s *attachmentsSuite) TestNewAttachments(c *gc.C) {
 	stateDir := filepath.Join(c.MkDir(), "nonexistent")
 	unitTag := names.NewUnitTag("mysql/0")
@@ -88,6 +92,7 @@ func (s *attachmentsSuite) TestNewAttachmentsInit(c *gc.C) {
 			StorageId: storageTag.Id(),
 		})
 		c.Assert(err, gc.ErrorMatches, `unknown storage "data/0"`)
+		assertStorageTags(c, att) // no active attachment
 	})
 	c.Assert(called, gc.Equals, 1)
 
@@ -115,6 +120,7 @@ func (s *attachmentsSuite) TestNewAttachmentsInit(c *gc.C) {
 			StorageId: "data/1",
 		})
 		c.Assert(err, gc.ErrorMatches, `unknown storage "data/1"`)
+		assertStorageTags(c, att, storageTag)
 	})
 	c.Assert(called, gc.Equals, 2)
 	c.Assert(filepath.Join(stateDir, "data-0"), jc.IsNonEmptyFile)
@@ -199,6 +205,7 @@ func (s *attachmentsSuite) TestAttachmentsStorage(c *gc.C) {
 	// There should be no context for data/0 until a hook is queued.
 	_, ok := att.Storage(storageTag)
 	c.Assert(ok, jc.IsFalse)
+	assertStorageTags(c, att)
 
 	err = att.UpdateStorage([]names.StorageTag{storageTag})
 	c.Assert(err, jc.ErrorIsNil)
@@ -207,6 +214,7 @@ func (s *attachmentsSuite) TestAttachmentsStorage(c *gc.C) {
 		Kind:      hooks.StorageAttached,
 		StorageId: storageTag.Id(),
 	})
+	assertStorageTags(c, att, storageTag)
 
 	ctx, ok := att.Storage(storageTag)
 	c.Assert(ok, jc.IsTrue)
@@ -437,11 +445,13 @@ func (s *attachmentsUpdateSuite) TestAttachmentsUpdateUntrackedAlive(c *gc.C) {
 	// data/0 is initially unattached and untracked, so
 	// updating with Alive will cause a storager to be
 	// started and a storage-attached event to be emitted.
+	assertStorageTags(c, s.att)
 	for i := 0; i < 2; i++ {
 		// Updating twice, to ensure idempotency.
 		err := s.att.UpdateStorage([]names.StorageTag{s.storageTag0})
 		c.Assert(err, jc.ErrorIsNil)
 	}
+	assertStorageTags(c, s.att, s.storageTag0)
 	hi := waitOneHook(c, s.att.Hooks())
 	c.Assert(hi, gc.Equals, hook.Info{
 		Kind:      hooks.StorageAttached,
@@ -458,6 +468,7 @@ func (s *attachmentsUpdateSuite) TestAttachmentsUpdateUntrackedDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	assertNoHooks(c, s.att.Hooks())
 	c.Assert(s.att.Pending(), gc.Equals, 0)
+	assertStorageTags(c, s.att)
 }
 
 func (s *attachmentsUpdateSuite) TestAttachmentsRefresh(c *gc.C) {
@@ -509,4 +520,5 @@ func (s *attachmentsUpdateSuite) TestAttachmentsUpdateShortCircuitNoHooks(c *gc.
 	})
 	c.Assert(err, gc.ErrorMatches, `unknown storage "data/1"`)
 	c.Assert(s.att.Pending(), gc.Equals, 0)
+	assertStorageTags(c, s.att)
 }


### PR DESCRIPTION
We add a "storage-list" hook tool that charms may
call to get a list of all storage attached, or due
to be attached, to the unit.

(Review request: http://reviews.vapour.ws/r/2266/)