### PR TITLE
state/resourcestorage: resource storage

### DIFF
--- a/charmresources/interface.go
+++ b/charmresources/interface.go
@@ -72,6 +72,14 @@ type ResourceManager interface {
 
 	// ResourcePut stores the resource with the specified metadata,
 	// and returns the metadata with additional attributes filled in.
+	//
+	// If SHA384Hash is specified in metadata, then ResourcePut
+	// should return an error if it does not match the SHA-384
+	// hash of the content. If SHA384Hash is unspecified in metadata,
+	// it will be calculated and returned in the resulting Resource.
+	//
+	// If Size is <= 0, then data will be consumed from rdr until
+	// EOF, and Size will be returned in the resulting Resource.
 	ResourcePut(metadata Resource, rdr io.Reader) (Resource, error)
 
 	// ResourceList returns resource metadata matching the specified filter.

--- a/charmresources/resourcepath.go
+++ b/charmresources/resourcepath.go
@@ -5,6 +5,8 @@ package charmresources
 
 import (
 	"path"
+	"regexp"
+	"strings"
 
 	"github.com/juju/errors"
 )
@@ -38,9 +40,46 @@ func ResourcePath(params ResourceAttributes) (string, error) {
 	return resPath, nil
 }
 
+var segmentSnippet = "[^/]+"
+var resourcePathRe = regexp.MustCompile(
+	"^/" +
+		"(" + segmentSnippet + ")/" + // type
+		"(?:org/(" + segmentSnippet + ")/)?" + // org
+		"(?:u/(" + segmentSnippet + ")/)?" + // user
+		"(?:c/(" + segmentSnippet + ")/)?" + // stream
+		"(?:s/(" + segmentSnippet + ")/)?" + // series
+		"(" + segmentSnippet + ")" + // path-name
+		"(?:/(" + segmentSnippet + "))?" + // revision
+		"$",
+)
+
+// ParseResourcePath parses a resource path into its constituent
+// ResourceAttributes.
+func ParseResourcePath(resourcePath string) (ResourceAttributes, error) {
+	var attrs ResourceAttributes
+	submatch := resourcePathRe.FindStringSubmatch(resourcePath)
+	if submatch == nil {
+		return attrs, errors.Errorf("invalid resource path %q", resourcePath)
+	}
+	attrs.Type = submatch[1]
+	attrs.Org = submatch[2]
+	attrs.User = submatch[3]
+	attrs.Stream = submatch[4]
+	attrs.Series = submatch[5]
+	attrs.PathName = submatch[6]
+	attrs.Revision = submatch[7]
+	if err := validatePathParameters(attrs); err != nil {
+		return attrs, errors.Trace(err)
+	}
+	return attrs, nil
+}
+
 func validatePathParameters(params ResourceAttributes) error {
 	if params.PathName == "" {
 		return errors.New("resource path name cannot be empty")
+	}
+	if strings.Contains(params.PathName, "/") {
+		return errors.New(`resource path name cannot contain "/"`)
 	}
 	if params.User != "" && params.Org != "" {
 		return errors.New("both user and org cannot be specified together")

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -9,7 +9,7 @@ github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
-github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
+github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/cmd	git	a7964f7cbac96484d1a9ba25e37bd32b7fa3cd90	2015-04-10T20:58:56Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z

--- a/state/imagestorage/image.go
+++ b/state/imagestorage/image.go
@@ -232,6 +232,7 @@ func (s *imageStorage) Image(kind, series, arch string) (*Metadata, io.ReadClose
 	managedStorage := s.getManagedStorage(session)
 	image, err := s.imageBlob(managedStorage, metadataDoc.Path)
 	if err != nil {
+		session.Close()
 		return nil, nil, err
 	}
 	metadata := &Metadata{

--- a/state/resources.go
+++ b/state/resources.go
@@ -5,11 +5,11 @@ package state
 
 import (
 	"github.com/juju/juju/charmresources"
+	"github.com/juju/juju/state/resourcestorage"
 )
 
 // ResourceManager returns a new charmresources.ResourceManager
 // that stores charm resources metadata.
 func (st *State) ResourceManager() charmresources.ResourceManager {
-	// TODO - wallyworld
-	panic("not implemented")
+	return resourcestorage.NewResourceManager(st.session, st.EnvironUUID())
 }

--- a/state/resourcestorage/export_test.go
+++ b/state/resourcestorage/export_test.go
@@ -1,0 +1,40 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resourcestorage
+
+import (
+	"github.com/juju/blobstore"
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/charmresources"
+)
+
+var NewResourceManagerInternal = newResourceManagerInternal
+
+type ResourceMetadataDoc resourceMetadataDoc
+
+// ManagedStorage returns the managedStorage attribute for the storage.
+func ManagedStorage(r charmresources.ResourceManager, session *mgo.Session) blobstore.ManagedStorage {
+	return r.(*resourceStorage).getManagedStorage(session)
+}
+
+// MetadataCollection returns the metadataCollection attribute for the storage.
+func MetadataCollection(r charmresources.ResourceManager) *mgo.Collection {
+	return r.(*resourceStorage).metadataCollection
+}
+
+// RemoveFailsManagedStorage returns a patched managedStorage,
+// which fails when Remove is called.
+func RemoveFailsManagedStorage(db *mgo.Database, rs blobstore.ResourceStorage) blobstore.ManagedStorage {
+	return removeFailsManagedStorage{blobstore.NewManagedStorage(db, rs)}
+}
+
+type removeFailsManagedStorage struct {
+	blobstore.ManagedStorage
+}
+
+func (removeFailsManagedStorage) RemoveForEnvironment(uuid, path string) error {
+	return errors.Errorf("cannot remove %s:%s", uuid, path)
+}

--- a/state/resourcestorage/resources.go
+++ b/state/resourcestorage/resources.go
@@ -1,0 +1,405 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resourcestorage
+
+import (
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"io"
+	"time"
+
+	"github.com/juju/blobstore"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jujutxn "github.com/juju/txn"
+	"github.com/juju/utils"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/charmresources"
+	"github.com/juju/juju/mongo"
+)
+
+var logger = loggo.GetLogger("juju.state.resourcestorage")
+
+const (
+	// resourcemetadataC is the collection used to store resource metadata.
+	resourcemetadataC = "resourcemetadata"
+
+	// ResourcesDB is the database used to store resource blobs.
+	ResourcesDB = "resources"
+)
+
+type resourceStorage struct {
+	envUUID               string
+	metadataCollection    *mgo.Collection
+	blobDb                *mgo.Database
+	getManagedStorageFunc func(*mgo.Database, blobstore.ResourceStorage) blobstore.ManagedStorage
+	getTxnRunnerFunc      func(*mgo.Database) jujutxn.Runner
+	getTimeFunc           func() time.Time
+}
+
+var _ charmresources.ResourceManager = (*resourceStorage)(nil)
+
+// NewResourceManager constructs a new ResourceManager that stores resource
+// blobs in a "resources" database. Metadata is also stored in this database
+// in the "resourcemetadata" collection.
+func NewResourceManager(session *mgo.Session, envUUID string) charmresources.ResourceManager {
+	return newResourceManagerInternal(session, envUUID, nil, nil, nil)
+}
+
+func newResourceManagerInternal(
+	session *mgo.Session,
+	envUUID string,
+	getManagedStorage func(*mgo.Database, blobstore.ResourceStorage) blobstore.ManagedStorage,
+	getTxnRunner func(*mgo.Database) jujutxn.Runner,
+	getTime func() time.Time,
+) charmresources.ResourceManager {
+	blobDb := session.DB(ResourcesDB)
+	metadataCollection := blobDb.C(resourcemetadataC)
+	if getManagedStorage == nil {
+		getManagedStorage = func(db *mgo.Database, rs blobstore.ResourceStorage) blobstore.ManagedStorage {
+			return blobstore.NewManagedStorage(db, rs)
+		}
+	}
+	if getTxnRunner == nil {
+		getTxnRunner = func(db *mgo.Database) jujutxn.Runner {
+			return jujutxn.NewRunner(jujutxn.RunnerParams{Database: db})
+		}
+	}
+	if getTime == nil {
+		getTime = time.Now
+	}
+	return &resourceStorage{
+		envUUID, metadataCollection, blobDb,
+		getManagedStorage, getTxnRunner, getTime,
+	}
+}
+
+func (s *resourceStorage) getManagedStorage(session *mgo.Session) blobstore.ManagedStorage {
+	rs := blobstore.NewGridFS(ResourcesDB, ResourcesDB, session)
+	db := session.DB(ResourcesDB)
+	metadataDb := db.With(session)
+	return s.getManagedStorageFunc(metadataDb, rs)
+}
+
+func (s *resourceStorage) txnRunner(session *mgo.Session) jujutxn.Runner {
+	db := s.metadataCollection.Database
+	runnerDb := db.With(session)
+	return s.getTxnRunnerFunc(runnerDb)
+}
+
+// ResourcePut is defined on the ResourceManager interface.
+func (s *resourceStorage) ResourcePut(meta charmresources.Resource, r io.Reader) (
+	result charmresources.Resource, resultErr error,
+) {
+	attrs, err := charmresources.ParseResourcePath(meta.Path)
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	blobPath, err := newResourceBlobPath(meta.Path)
+	if err != nil {
+		return result, errors.Annotate(err, "cannot create resource blob path")
+	}
+
+	result = meta
+	result.Size = 0 // init Size to 0, as we'll count
+	result.Created = s.getTimeFunc()
+	r = countingReader{r, &result.Size}
+
+	// If size is unspecified, instruct PutForEnvironmentAndCheckHash
+	// to read until EOF and count the bytes read.
+	if meta.Size <= 0 {
+		meta.Size = -1
+	}
+
+	// If the hash is specified, then we'll check it in
+	// PutForEnvironmentAndCheckHash. Otherwise, compute the hash for
+	// the result.
+	var hash hash.Hash
+	if meta.SHA384Hash == "" {
+		hash = sha512.New384()
+		r = io.TeeReader(r, hash)
+	}
+
+	session := s.blobDb.Session.Copy()
+	defer session.Close()
+	managedStorage := s.getManagedStorage(session)
+	if err := managedStorage.PutForEnvironmentAndCheckHash(s.envUUID, blobPath, r, meta.Size, meta.SHA384Hash); err != nil {
+		return result, errors.Annotate(err, "cannot store resource")
+	}
+	defer func() {
+		if resultErr == nil {
+			return
+		}
+		err := managedStorage.RemoveForEnvironment(s.envUUID, blobPath)
+		if err != nil {
+			logger.Errorf("failed to remove resource blob: %v", err)
+		}
+	}()
+	if hash != nil {
+		result.SHA384Hash = fmt.Sprintf("%x", hash.Sum(nil))
+	}
+
+	newDoc := resourceMetadataDoc{
+		Id:       docId(s.envUUID, meta.Path),
+		EnvUUID:  s.envUUID,
+		SHA384:   result.SHA384Hash,
+		Size:     result.Size,
+		Created:  result.Created,
+		BlobPath: blobPath,
+		Type:     attrs.Type,
+		User:     attrs.User,
+		Org:      attrs.Org,
+		Stream:   attrs.Stream,
+		Series:   attrs.Series,
+		PathName: attrs.PathName,
+		Revision: attrs.Revision,
+	}
+
+	// Add or replace metadata. If replacing, record the
+	// existing path so we can remove the blob later.
+	var oldBlobPath string
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		op := txn.Op{
+			C:  resourcemetadataC,
+			Id: newDoc.Id,
+		}
+
+		// On the first attempt we assume we're adding a new resource blob.
+		// Subsequent attempts to add resource will fetch the existing
+		// doc, record the old path, and attempt to update fields.
+		if attempt == 0 {
+			op.Assert = txn.DocMissing
+			op.Insert = &newDoc
+		} else {
+			oldDoc, err := s.resourceMetadataDoc(meta.Path)
+			if err != nil {
+				return nil, err
+			}
+			oldBlobPath = oldDoc.BlobPath
+			op.Assert = bson.D{{"blobpath", oldBlobPath}}
+			if oldBlobPath != blobPath {
+				op.Update = bson.D{{
+					"$set", bson.D{
+						{"sha384", newDoc.SHA384},
+						{"size", newDoc.Size},
+						{"created", newDoc.Created},
+						{"blobpath", newDoc.BlobPath},
+						// The ResourceAttributes fields
+						// cannot have changed, as they
+						// are used to determine the path.
+					},
+				}}
+			}
+		}
+		return []txn.Op{op}, nil
+	}
+	txnRunner := s.txnRunner(session)
+	if err := txnRunner.Run(buildTxn); err != nil {
+		return result, errors.Annotate(err, "cannot store resource metadata")
+	}
+
+	if oldBlobPath != "" && oldBlobPath != blobPath {
+		// Attempt to remove the old path. Failure is non-fatal.
+		err := managedStorage.RemoveForEnvironment(s.envUUID, oldBlobPath)
+		if err != nil {
+			logger.Errorf("failed to remove old resource blob: %v", err)
+		} else {
+			logger.Debugf("removed old resource blob")
+		}
+	}
+	return result, nil
+}
+
+// ResourceList is defined on the ResourceManager interface.
+func (s *resourceStorage) ResourceList(filter charmresources.ResourceAttributes) ([]charmresources.Resource, error) {
+	metadataDocs, err := s.listResourceMetadataDocs(filter)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]charmresources.Resource, len(metadataDocs))
+	for i, doc := range metadataDocs {
+		resourcePath, err := charmresources.ResourcePath(charmresources.ResourceAttributes{
+			doc.Type,
+			doc.User,
+			doc.Org,
+			doc.Stream,
+			doc.Series,
+			doc.PathName,
+			doc.Revision,
+		})
+		if err != nil {
+			return nil, errors.Annotate(err, "getting resource path")
+		}
+		result[i] = charmresources.Resource{
+			resourcePath,
+			doc.SHA384,
+			doc.Size,
+			doc.Created,
+		}
+	}
+	return result, nil
+}
+
+// ResourceDelete is defined on the ResourceManager interface.
+func (s *resourceStorage) ResourceDelete(resourcePath string) (resultErr error) {
+	metadataDoc, err := s.resourceMetadataDoc(resourcePath)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	blobPath := metadataDoc.BlobPath
+
+	session := s.blobDb.Session.Copy()
+	defer session.Close()
+	managedStorage := s.getManagedStorage(session)
+	if err := managedStorage.RemoveForEnvironment(s.envUUID, blobPath); err != nil {
+		return errors.Annotate(err, "cannot remove resource blob")
+	}
+	// Remove the metadata.
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		op := txn.Op{
+			C:      resourcemetadataC,
+			Id:     metadataDoc.Id,
+			Remove: true,
+		}
+		return []txn.Op{op}, nil
+	}
+	txnRunner := s.txnRunner(session)
+	if err := txnRunner.Run(buildTxn); err == mgo.ErrNotFound {
+		// Metadata already removed, we don't care.
+		return nil
+	}
+	return errors.Annotate(err, "cannot remove resource metadata")
+}
+
+// resourceCloser encapsulates a resource reader and session
+// so that both are closed together.
+type resourceCloser struct {
+	io.ReadCloser
+	session *mgo.Session
+}
+
+func (c *resourceCloser) Close() error {
+	c.session.Close()
+	return c.ReadCloser.Close()
+}
+
+// ResourceGet is defined on the ResourceManager interface.
+func (s *resourceStorage) ResourceGet(resourcePath string) ([]charmresources.ResourceReader, error) {
+	metadataDoc, err := s.resourceMetadataDoc(resourcePath)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	blobPath := metadataDoc.BlobPath
+	session := s.blobDb.Session.Copy()
+	managedStorage := s.getManagedStorage(session)
+	rc, err := s.resourceBlobReader(managedStorage, blobPath)
+	if err != nil {
+		session.Close()
+		return nil, errors.Trace(err)
+	}
+	return []charmresources.ResourceReader{{
+		&resourceCloser{rc, session},
+		charmresources.Resource{
+			resourcePath,
+			metadataDoc.SHA384,
+			metadataDoc.Size,
+			metadataDoc.Created,
+		},
+	}}, nil
+}
+
+type resourceMetadataDoc struct {
+	Id       string    `bson:"_id"`
+	EnvUUID  string    `bson:"envuuid"`
+	SHA384   string    `bson:"sha384"`
+	Size     int64     `bson:"size"`
+	Created  time.Time `bson:"created"`
+	BlobPath string    `bson:"blobpath"`
+
+	// Fields below map 1:1 to charmresources.ResourceAttributes.
+
+	Type     string `bson:"type"`
+	User     string `bson:"user"`
+	Org      string `bson:"org"`
+	Stream   string `bson:"stream"`
+	Series   string `bson:"series"`
+	PathName string `bson:"pathname"`
+	Revision string `bson:"revision"`
+}
+
+func (s *resourceStorage) resourceMetadataDoc(resourcePath string) (*resourceMetadataDoc, error) {
+	var doc resourceMetadataDoc
+	id := docId(s.envUUID, resourcePath)
+	coll, closer := mongo.CollectionFromName(s.metadataCollection.Database, resourcemetadataC)
+	defer closer()
+	err := coll.FindId(id).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("%v resource metadata", id)
+	} else if err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+func (s *resourceStorage) listResourceMetadataDocs(filter charmresources.ResourceAttributes) ([]resourceMetadataDoc, error) {
+	coll, closer := mongo.CollectionFromName(s.metadataCollection.Database, resourcemetadataC)
+	defer closer()
+	resourceDocs := []resourceMetadataDoc{}
+
+	query := bson.D{{"envuuid", s.envUUID}}
+	filterOn := func(k string, v string) {
+		if v != "" {
+			query = append(query, bson.DocElem{k, v})
+		}
+	}
+	filterOn("type", filter.Type)
+	filterOn("user", filter.User)
+	filterOn("org", filter.Org)
+	filterOn("stream", filter.Stream)
+	filterOn("series", filter.Series)
+	filterOn("pathname", filter.PathName)
+	filterOn("revision", filter.Revision)
+
+	err := coll.Find(query).All(&resourceDocs)
+	if err != nil {
+		return nil, errors.Annotate(err, "listing resource metadata")
+	}
+	return resourceDocs, nil
+}
+
+func (s *resourceStorage) resourceBlobReader(managedStorage blobstore.ManagedStorage, path string) (io.ReadCloser, error) {
+	r, _, err := managedStorage.GetForEnvironment(s.envUUID, path)
+	return r, err
+}
+
+// newResourceBlobPath returns a new unique blob storage path, given a
+// resource path. The returned path will incorporate the resource path
+// as an eye-catcher, and a UUID for its uniqueness.
+func newResourceBlobPath(resourcePath string) (string, error) {
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return fmt.Sprintf("resources%s:%s", resourcePath, uuid.String()), nil
+}
+
+// docId returns an id for the mongo resource metadata document.
+func docId(envUUID, resourcePath string) string {
+	return fmt.Sprintf("%s-%s", envUUID, resourcePath)
+}
+
+type countingReader struct {
+	r     io.Reader
+	count *int64
+}
+
+func (r countingReader) Read(buf []byte) (n int, err error) {
+	n, err = r.r.Read(buf)
+	*r.count += int64(n)
+	return n, err
+}

--- a/state/resourcestorage/resources_test.go
+++ b/state/resourcestorage/resources_test.go
@@ -1,0 +1,636 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resourcestorage_test
+
+import (
+	"crypto/sha512"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	stdtesting "testing"
+	"time"
+
+	"github.com/juju/blobstore"
+	"github.com/juju/errors"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/txn"
+	txntesting "github.com/juju/txn/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/charmresources"
+	"github.com/juju/juju/state/resourcestorage"
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&ResourceSuite{})
+
+// Note: using bson.Now instead of time.Now because the timed stored
+// only has millisecond precision, which is what bson.Now returns.
+// We don't care apart from when we're checking the values in tests.
+var hammerTime = bson.Now()
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+type ResourceSuite struct {
+	testing.BaseSuite
+	mongo              *gitjujutesting.MgoInstance
+	session            *mgo.Session
+	storage            charmresources.ResourceManager
+	metadataCollection *mgo.Collection
+
+	getTimeFunc func() time.Time
+}
+
+func (s *ResourceSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.mongo = &gitjujutesting.MgoInstance{}
+	s.mongo.Start(nil)
+
+	s.getTimeFunc = func() time.Time {
+		return hammerTime
+	}
+
+	var err error
+	s.session, err = s.mongo.Dial()
+	c.Assert(err, jc.ErrorIsNil)
+	s.storage = resourcestorage.NewResourceManagerInternal(
+		s.session, "my-uuid",
+		nil,
+		nil,
+		s.getTimeFunc,
+	)
+	s.metadataCollection = resourcestorage.MetadataCollection(s.storage)
+}
+
+func (s *ResourceSuite) TearDownTest(c *gc.C) {
+	s.session.Close()
+	s.mongo.DestroyWithLog()
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *ResourceSuite) TestResourcePut(c *gc.C) {
+	s.testResourcePut(c, "some-resource")
+}
+
+func (s *ResourceSuite) TestResourcePutReplaces(c *gc.C) {
+	s.testResourcePut(c, "abc")
+	s.testResourcePut(c, "defghi")
+}
+
+func (s *ResourceSuite) testResourcePut(c *gc.C, content string) {
+	metaIn := charmresources.Resource{
+		Path: "/blob/s/trusty/tahr.gz",
+	}
+	metaOut, err := s.storage.ResourcePut(metaIn, strings.NewReader(content))
+	c.Assert(err, jc.ErrorIsNil)
+
+	hash := sha512.New384()
+	_, err = io.WriteString(hash, content)
+	c.Assert(err, jc.ErrorIsNil)
+
+	metaIn.Size = int64(len(content))
+	metaIn.SHA384Hash = fmt.Sprintf("%x", hash.Sum(nil))
+	metaIn.Created = hammerTime
+	c.Assert(metaOut, jc.DeepEquals, metaIn)
+	s.assertResource(c, metaOut, content)
+}
+
+func (s *ResourceSuite) TestResourceGet(c *gc.C) {
+	_, err := s.storage.ResourceGet("/blob/not-there")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, `.* resource metadata not found`)
+
+	insertedMetadata := charmresources.Resource{
+		Path:       "/blob/s/trusty/tahr.gz",
+		Size:       4,
+		SHA384Hash: "whatever",
+		Created:    bson.Now(),
+	}
+	s.addMetadataDoc(c, "blob-path", insertedMetadata)
+	_, err = s.storage.ResourceGet(insertedMetadata.Path)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(err, gc.ErrorMatches, `resource at path "environs/my-uuid/blob-path" not found`)
+
+	managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+	err = managedStorage.PutForEnvironment("my-uuid", "blob-path", strings.NewReader("blah"), -1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	r, err := s.storage.ResourceGet(insertedMetadata.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	defer r[0].Close()
+	c.Assert(r[0].Resource, jc.DeepEquals, insertedMetadata)
+
+	data, err := ioutil.ReadAll(r[0])
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "blah")
+}
+
+func (s *ResourceSuite) TestResourcePutRemovesExisting(c *gc.C) {
+	// Add a metadata doc and a blob at a known path, then
+	// call ResourcePut and ensure the original blob is removed.
+	originalMetadata := charmresources.Resource{
+		Path:       "/blob/s/trusty/tahr.gz",
+		Size:       4,
+		SHA384Hash: "original-hash",
+		Created:    bson.Now(),
+	}
+	s.addMetadataDoc(c, "blob-path", originalMetadata)
+
+	managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+	err := managedStorage.PutForEnvironment("my-uuid", "blob-path", strings.NewReader("blah"), -1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	updatedMetadata := charmresources.Resource{
+		Path: "/blob/s/trusty/tahr.gz",
+		Size: 5,
+	}
+	result, err := s.storage.ResourcePut(updatedMetadata, strings.NewReader("xyzzy"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// old blob should be gone
+	_, _, err = managedStorage.GetForEnvironment("my-uuid", "blob-path")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	// new data should be in its place
+	s.assertResource(c, result, "xyzzy")
+}
+
+func (s *ResourceSuite) TestResourcePutRemovesExistingRemoveFails(c *gc.C) {
+	s.storage = resourcestorage.NewResourceManagerInternal(
+		s.session, "my-uuid",
+		resourcestorage.RemoveFailsManagedStorage,
+		nil,
+		s.getTimeFunc,
+	)
+
+	// Add a metadata doc and a blob at a known path, then
+	// call ResourcePut and ensure that ResourcePut attempts
+	// to remove the original blob, but does not return an
+	// error if it fails.
+	s.addMetadataDoc(c, "blob-path", charmresources.Resource{
+		Path: "/blob/s/trusty/tahr.gz",
+	})
+	managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+	err := managedStorage.PutForEnvironment("my-uuid", "blob-path", strings.NewReader("blah"), -1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	metaIn := charmresources.Resource{
+		Path: "/blob/s/trusty/tahr.gz",
+	}
+	metaOut, err := s.storage.ResourcePut(metaIn, strings.NewReader("xyzzy"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// old blob should still be there
+	r, _, err := managedStorage.GetForEnvironment("my-uuid", "blob-path")
+	c.Assert(err, jc.ErrorIsNil)
+	r.Close()
+
+	s.assertResource(c, metaOut, "xyzzy")
+}
+
+type errorTransactionRunner struct {
+	txn.Runner
+}
+
+func (errorTransactionRunner) Run(transactions txn.TransactionSource) error {
+	return errors.New("Run fails")
+}
+
+func getErrorTransactionRunner(db *mgo.Database) txn.Runner {
+	runner := txn.NewRunner(txn.RunnerParams{Database: db})
+	return errorTransactionRunner{runner}
+}
+
+type recordingManagedStorage struct {
+	gitjujutesting.Stub
+	blobstore.ManagedStorage
+}
+
+func (r *recordingManagedStorage) GetForEnvironment(envUUID, path string) (io.ReadCloser, int64, error) {
+	r.Stub.MethodCall(r, "GetForEnvironment", envUUID, path)
+	return r.ManagedStorage.GetForEnvironment(envUUID, path)
+}
+
+func (r *recordingManagedStorage) PutForEnvironment(envUUID, path string, rdr io.Reader, length int64) error {
+	r.Stub.MethodCall(r, "PutForEnvironment", envUUID, path, rdr, length)
+	return r.ManagedStorage.PutForEnvironment(envUUID, path, rdr, length)
+}
+
+func (r *recordingManagedStorage) PutForEnvironmentAndCheckHash(envUUID, path string, rdr io.Reader, length int64, hash string) error {
+	r.Stub.MethodCall(r, "PutForEnvironmentAndCheckHash", envUUID, path, rdr, length, hash)
+	return r.ManagedStorage.PutForEnvironmentAndCheckHash(envUUID, path, rdr, length, hash)
+}
+
+func (r *recordingManagedStorage) RemoveForEnvironment(envUUID, path string) error {
+	r.Stub.MethodCall(r, "RemoveForEnvironment", envUUID, path)
+	return r.ManagedStorage.RemoveForEnvironment(envUUID, path)
+}
+
+func (r *recordingManagedStorage) getBlobPath(c *gc.C, resourcePath string) string {
+	c.Assert(r, gc.NotNil)
+	putCall := r.Calls()[0]
+	blobPath := putCall.Args[1].(string)
+	c.Assert(strings.HasPrefix(blobPath, "resources"+resourcePath+":"), jc.IsTrue)
+	return blobPath
+}
+
+func (s *ResourceSuite) TestResourcePutRemovesBlobOnFailure(c *gc.C) {
+	var rms *recordingManagedStorage
+	getManagedStorage := func(db *mgo.Database, rs blobstore.ResourceStorage) blobstore.ManagedStorage {
+		rms = &recordingManagedStorage{
+			ManagedStorage: blobstore.NewManagedStorage(db, rs),
+		}
+		return rms
+	}
+
+	s.storage = resourcestorage.NewResourceManagerInternal(
+		s.session, "my-uuid",
+		getManagedStorage,
+		getErrorTransactionRunner,
+		s.getTimeFunc,
+	)
+
+	metaIn := charmresources.Resource{
+		Path: "/blob/badness",
+	}
+	_, err := s.storage.ResourcePut(metaIn, strings.NewReader("xyzzy"))
+	c.Assert(err, gc.ErrorMatches, "cannot store resource metadata: Run fails")
+
+	blobPath := rms.getBlobPath(c, metaIn.Path)
+	managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+	_, _, err = managedStorage.GetForEnvironment("my-uuid", blobPath)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *ResourceSuite) TestResourcePutRemovesBlobOnFailureRemoveFails(c *gc.C) {
+	var rms *recordingManagedStorage
+	getManagedStorage := func(db *mgo.Database, rs blobstore.ResourceStorage) blobstore.ManagedStorage {
+		rms = &recordingManagedStorage{
+			ManagedStorage: resourcestorage.RemoveFailsManagedStorage(db, rs),
+		}
+		return rms
+	}
+	s.storage = resourcestorage.NewResourceManagerInternal(
+		s.session, "my-uuid",
+		getManagedStorage,
+		getErrorTransactionRunner,
+		s.getTimeFunc,
+	)
+
+	meta := charmresources.Resource{Path: "/blob/badness"}
+	_, err := s.storage.ResourcePut(meta, strings.NewReader("xyzzy"))
+	c.Assert(err, gc.ErrorMatches, "cannot store resource metadata: Run fails")
+
+	// blob should still be there, because the removal failed.
+	blobPath := rms.getBlobPath(c, meta.Path)
+	managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+	r, _, err := managedStorage.GetForEnvironment("my-uuid", blobPath)
+	c.Assert(err, jc.ErrorIsNil)
+	r.Close()
+}
+
+func (s *ResourceSuite) TestResourcePutSame(c *gc.C) {
+	metaIn := charmresources.Resource{Path: "/blob/s/trusty/tahr.gz"}
+	metaOut, err := s.storage.ResourcePut(metaIn, strings.NewReader("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertResource(c, metaOut, "0")
+	_, err = s.storage.ResourcePut(metaIn, strings.NewReader("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertResource(c, metaOut, "0") // nothing should have changed
+}
+
+func (s *ResourceSuite) TestResourcePutAndJustMetadataExists(c *gc.C) {
+	s.addMetadataDoc(c, "blob-path", charmresources.Resource{
+		Path:       "/blob/s/trusty/tahr.gz",
+		Size:       4,
+		SHA384Hash: "whatever",
+	})
+	n, err := s.metadataCollection.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(n, gc.Equals, 1)
+	s.testResourcePut(c, "abc")
+	n, err = s.metadataCollection.Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(n, gc.Equals, 1)
+}
+
+func (s *ResourceSuite) TestJustMetadataFails(c *gc.C) {
+	s.addMetadataDoc(c, "blob-path", charmresources.Resource{
+		Path: "/blob/s/trusty/tahr.gz",
+	})
+	_, err := s.storage.ResourceGet("/blob/s/trusty/tahr.gz")
+	c.Assert(err, gc.ErrorMatches, `resource at path "environs/my-uuid/blob-path" not found`)
+}
+
+func (s *ResourceSuite) TestResourcePutConcurrent(c *gc.C) {
+	var rms *recordingManagedStorage
+	getManagedStorage := func(db *mgo.Database, rs blobstore.ResourceStorage) blobstore.ManagedStorage {
+		rms = &recordingManagedStorage{
+			ManagedStorage: blobstore.NewManagedStorage(db, rs),
+		}
+		return rms
+	}
+	txnRunner := txn.NewRunner(txn.RunnerParams{Database: s.metadataCollection.Database})
+	getTxnRunner := func(db *mgo.Database) txn.Runner {
+		return txnRunner
+	}
+	s.storage = resourcestorage.NewResourceManagerInternal(
+		s.session, "my-uuid",
+		getManagedStorage,
+		getTxnRunner,
+		s.getTimeFunc,
+	)
+
+	metadata0 := charmresources.Resource{
+		Path: "/blob/s/trusty/tahr.gz",
+		// sha384sum(abc)
+		SHA384Hash: "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7",
+	}
+	metadata1 := charmresources.Resource{
+		Path: "/blob/s/trusty/tahr.gz",
+		// sha384sum(def)
+		SHA384Hash: "180c325cccb299e76ec6c03a5b5a7755af8ef499906dbf531f18d0ca509e4871b0805cac0f122b962d54badc6119f3cf",
+	}
+
+	var oldBlobPath string
+	resourcePut := func() {
+		_, err := s.storage.ResourcePut(metadata0, strings.NewReader("abc"))
+		c.Assert(err, jc.ErrorIsNil)
+		oldBlobPath = rms.getBlobPath(c, metadata0.Path)
+		managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+		r, _, err := managedStorage.GetForEnvironment("my-uuid", oldBlobPath)
+		c.Assert(err, jc.ErrorIsNil)
+		r.Close()
+	}
+	defer txntesting.SetBeforeHooks(c, txnRunner, resourcePut).Check()
+
+	metaOut, err := s.storage.ResourcePut(metadata1, strings.NewReader("def"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Blob added in before-hook should be removed.
+	managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+	_, _, err = managedStorage.GetForEnvironment("my-uuid", oldBlobPath)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	s.assertResource(c, metaOut, "def")
+}
+
+func (s *ResourceSuite) TestResourcePutExcessiveContention(c *gc.C) {
+	var rms *recordingManagedStorage
+	getManagedStorage := func(db *mgo.Database, rs blobstore.ResourceStorage) blobstore.ManagedStorage {
+		rms = &recordingManagedStorage{
+			ManagedStorage: blobstore.NewManagedStorage(db, rs),
+		}
+		return rms
+	}
+	txnRunner := txn.NewRunner(txn.RunnerParams{Database: s.metadataCollection.Database})
+	getTxnRunner := func(db *mgo.Database) txn.Runner {
+		return txnRunner
+	}
+	s.storage = resourcestorage.NewResourceManagerInternal(
+		s.session, "my-uuid",
+		getManagedStorage,
+		getTxnRunner,
+		s.getTimeFunc,
+	)
+
+	content := []string{"abc", "def", "ghi", "jkl"}
+	metadata := []charmresources.Resource{{
+		Path: "/blob/s/trusty/tahr.gz",
+		// sha384sum(abc)
+		SHA384Hash: "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7",
+	}, {
+		Path: "/blob/s/trusty/tahr.gz",
+		// sha384sum(def)
+		SHA384Hash: "180c325cccb299e76ec6c03a5b5a7755af8ef499906dbf531f18d0ca509e4871b0805cac0f122b962d54badc6119f3cf",
+	}, {
+		Path: "/blob/s/trusty/tahr.gz",
+		// sha384sum(ghi)
+		SHA384Hash: "1ad66ef0418b7e24de0bf2db0c46e700bd8a705efd781a477f5663561970f418f85a159ead0a6de87f17eba03cb7f542",
+	}, {
+		Path: "/blob/s/trusty/tahr.gz",
+		// sha384sum(jkl)
+		SHA384Hash: "264270d5871aa7f6f2a765aa512889fe095bca5335a2bdc60dc60478e85153b348ecd8dc167cf5277356e462f4ba1e97",
+	}}
+
+	i := 1
+	var blobPaths []string
+	metaOut := make([]charmresources.Resource, 1) // placeholder for the outer ResourcePut
+	resourcePut := func() {
+		if i == 1 {
+			// This is for the outer ResourcePut
+			blobPaths = []string{rms.getBlobPath(c, metadata[0].Path)}
+		}
+		meta, err := s.storage.ResourcePut(metadata[i], strings.NewReader(content[i]))
+		c.Assert(err, jc.ErrorIsNil)
+		blobPaths = append(blobPaths, rms.getBlobPath(c, metadata[i].Path))
+		metaOut = append(metaOut, meta)
+		i++
+	}
+	defer txntesting.SetBeforeHooks(c, txnRunner, resourcePut, resourcePut, resourcePut).Check()
+
+	_, err := s.storage.ResourcePut(metadata[0], strings.NewReader(content[0]))
+	c.Assert(err, gc.ErrorMatches, "cannot store resource metadata: state changing too quickly; try again soon")
+
+	// There should be no blobs apart from the one added by the last before-hook.
+	for i := 0; i < 3; i++ {
+		managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+		_, _, err = managedStorage.GetForEnvironment("my-uuid", blobPaths[i])
+		c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	}
+
+	s.assertResource(c, metaOut[3], content[3])
+}
+
+func (s *ResourceSuite) TestResourceDelete(c *gc.C) {
+	s.addMetadataDoc(c, "blob-path", charmresources.Resource{
+		Path:       "/blob/s/trusty/tahr.gz",
+		SHA384Hash: "whatever",
+		Size:       4,
+	})
+	managedStorage := resourcestorage.ManagedStorage(s.storage, s.session)
+	err := managedStorage.PutForEnvironment("my-uuid", "blob-path", strings.NewReader("blah"), -1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	r, err := s.storage.ResourceGet("/blob/s/trusty/tahr.gz")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, gc.NotNil)
+	r[0].Close()
+
+	err = s.storage.ResourceDelete("/blob/s/trusty/tahr.gz")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = managedStorage.GetForEnvironment("my-uuid", "blob-path")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	_, err = s.storage.ResourceGet("/blob/s/trusty/tahr.gz")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *ResourceSuite) TestResourceDeleteNotFound(c *gc.C) {
+	err := s.storage.ResourceDelete("/blob/not-found")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *ResourceSuite) addMetadataDoc(c *gc.C, blobPath string, r charmresources.Resource) {
+	attrs, err := charmresources.ParseResourcePath(r.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	doc := resourcestorage.ResourceMetadataDoc{
+		Id:       fmt.Sprintf("my-uuid-%s", r.Path),
+		EnvUUID:  "my-uuid",
+		SHA384:   r.SHA384Hash,
+		Size:     r.Size,
+		Created:  r.Created,
+		BlobPath: blobPath,
+		Type:     attrs.Type,
+		User:     attrs.User,
+		Org:      attrs.Org,
+		Stream:   attrs.Stream,
+		Series:   attrs.Series,
+		PathName: attrs.PathName,
+		Revision: attrs.Revision,
+	}
+	err = s.metadataCollection.Insert(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ResourceSuite) assertResource(c *gc.C, meta charmresources.Resource, content string) {
+	r, err := s.storage.ResourceGet(meta.Path)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, gc.HasLen, 1)
+	c.Assert(r[0], gc.NotNil)
+	defer r[0].Close()
+	c.Assert(r[0].Resource, jc.DeepEquals, meta)
+
+	data, err := ioutil.ReadAll(r[0])
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, content)
+}
+
+func (s *ResourceSuite) createListResourceMetadata(c *gc.C, paths ...string) []charmresources.Resource {
+	var resources []charmresources.Resource
+	for _, path := range paths {
+		resource := charmresources.Resource{Path: path}
+		s.addMetadataDoc(c, "blob-path", resource)
+		resources = append(resources, resource)
+	}
+	return resources
+}
+
+func (s *ResourceSuite) TestListAllResources(c *gc.C) {
+	expected := s.createListResourceMetadata(c,
+		"/blob/s/trusty/tahr.gz",
+		"/zip/u/doo/dah",
+		"/blob/org/anic/ally",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, expected)
+}
+
+func (s *ResourceSuite) TestResourceListByType(c *gc.C) {
+	all := s.createListResourceMetadata(c,
+		"/blob/s/trusty/tahr.gz",
+		"/zip/u/doo/dah",
+		"/blob/org/anic/ally",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{Type: "blob"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, []charmresources.Resource{all[0], all[2]})
+}
+
+func (s *ResourceSuite) TestResourceListBySeries(c *gc.C) {
+	all := s.createListResourceMetadata(c,
+		"/blob/s/trusty/tahr.gz",
+		"/zip/u/doo/dah",
+		"/blob/org/anic/ally",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{Series: "trusty"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, []charmresources.Resource{all[0]})
+}
+
+func (s *ResourceSuite) TestResourceListByStream(c *gc.C) {
+	all := s.createListResourceMetadata(c,
+		"/blob/c/released/hounds",
+		"/blob/c/debug/isbuggy",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{Stream: "released"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, []charmresources.Resource{all[0]})
+}
+
+func (s *ResourceSuite) TestResourceListByUser(c *gc.C) {
+	all := s.createListResourceMetadata(c,
+		"/blob/u/sir/areanidiot",
+		"/blob/u/surper/throne",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{User: "sir"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, []charmresources.Resource{all[0]})
+}
+
+func (s *ResourceSuite) TestResourceListByOrg(c *gc.C) {
+	all := s.createListResourceMetadata(c,
+		"/blob/org/anic/ally",
+		"/blob/org/anis/m",
+		"/blob/org/anis/t",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{Org: "anis"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, all[1:])
+}
+
+func (s *ResourceSuite) TestResourceListByPathName(c *gc.C) {
+	all := s.createListResourceMetadata(c,
+		"/blob/c/release/thingy",
+		"/blob/c/debug/thingy",
+		"/blob/c/debug/thingy2",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{PathName: "thingy"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, all[:2])
+}
+
+func (s *ResourceSuite) TestResourceListByRevision(c *gc.C) {
+	all := s.createListResourceMetadata(c,
+		"/blob/c/release/thingy/0.0.1-r2",
+		"/blob/c/debug/thingy/0.0.1-r2",
+		"/blob/c/debug/thingy2/0.0.1-r3",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{Revision: "0.0.1-r2"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, all[:2])
+}
+
+func (s *ResourceSuite) TestResourceListNoMatch(c *gc.C) {
+	s.createListResourceMetadata(c,
+		"/blob/c/released/hounds",
+		"/blob/c/debug/isbuggy",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{Stream: "fnord"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, []charmresources.Resource{})
+}
+
+func (s *ResourceSuite) TestResourceListMultiFilter(c *gc.C) {
+	all := s.createListResourceMetadata(c,
+		"/blob/c/released/s/trusty/hounds",
+		"/blob/c/released/s/trusty/c/kraken",
+		"/blob/c/debug/s/trusty/hounds",
+		"/blob/c/released/s/vivid/hounds",
+		"/blob/c/debug/s/vivid/isbuggy",
+	)
+	metadata, err := s.storage.ResourceList(charmresources.ResourceAttributes{
+		Series: "trusty", Stream: "released",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, jc.SameContents, all[:2])
+}


### PR DESCRIPTION
Add the state/resourcestorage package, which implements
charmresources.ResourceManager on top of juju/blobstore.

Also added the charmresources.ParseResourcePath function,
which takes a resource path string and breaks it down into
a ResourceAttributes.

This PR requires https://github.com/juju/blobstore/pull/24

(Review request: http://reviews.vapour.ws/r/2273/)