### PR TITLE
state/multiwatcher: removed invalid and misleading bson tags

### DIFF
--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -121,7 +121,7 @@ type UnitSettings struct {
 // MachineInfo holds the information about a Machine
 // that is watched by StateMultiwatcher.
 type MachineInfo struct {
-	Id                       string `bson:"_id"`
+	Id                       string
 	InstanceId               string
 	Status                   Status
 	StatusInfo               string
@@ -154,7 +154,7 @@ type StatusInfo struct {
 }
 
 type ServiceInfo struct {
-	Name        string `bson:"_id"`
+	Name        string
 	Exposed     bool
 	CharmURL    string
 	OwnerTag    string
@@ -174,7 +174,7 @@ func (i *ServiceInfo) EntityId() EntityId {
 }
 
 type UnitInfo struct {
-	Name           string `bson:"_id"`
+	Name           string
 	Service        string
 	Series         string
 	CharmURL       string
@@ -201,16 +201,16 @@ func (i *UnitInfo) EntityId() EntityId {
 }
 
 type ActionInfo struct {
-	Id         string                 `bson:"_id"`
-	Receiver   string                 `bson:"receiver"`
-	Name       string                 `bson:"name"`
-	Parameters map[string]interface{} `bson:"parameters"`
-	Status     string                 `bson:"status"`
-	Message    string                 `bson:"message"`
-	Results    map[string]interface{} `bson:"results"`
-	Enqueued   time.Time              `bson:"enqueued"`
-	Started    time.Time              `bson:"started"`
-	Completed  time.Time              `bson:"completed"`
+	Id         string
+	Receiver   string
+	Name       string
+	Parameters map[string]interface{}
+	Status     string
+	Message    string
+	Results    map[string]interface{}
+	Enqueued   time.Time
+	Started    time.Time
+	Completed  time.Time
 }
 
 func (i *ActionInfo) EntityId() EntityId {
@@ -221,7 +221,7 @@ func (i *ActionInfo) EntityId() EntityId {
 }
 
 type RelationInfo struct {
-	Key       string `bson:"_id"`
+	Key       string
 	Id        int
 	Endpoints []Endpoint
 }
@@ -282,10 +282,10 @@ func AnyJobNeedsState(jobs ...MachineJob) bool {
 // BlockInfo holds the information about blocks
 // in this environment that are watched.
 type BlockInfo struct {
-	Id      string    `bson:"_id"`
-	Type    BlockType `bson:"type"`
-	Message string    `bson:"message,omitempty"`
-	Tag     string    `bson:"tag"`
+	Id      string
+	Type    BlockType
+	Message string
+	Tag     string
 }
 
 // EntityId returns block id.


### PR DESCRIPTION
A number of the entity info structs had bson struct tags. This doesn't make sense because these structs are never marshalled to BSON (JSON only). To make things worse, the field names in the tags didn't match the actual field name used over the API, creating unnecessary confusion.

I have manually checked that this change results in no actual change in the field names used over the API.

(Review request: http://reviews.vapour.ws/r/2276/)