### PR TITLE
state: add EnvUUID to allwatcher entity info structs

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2455,6 +2455,7 @@ func (s *clientSuite) TestClientWatchAll(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	if !c.Check(deltas, gc.DeepEquals, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
+			EnvUUID:                 s.State.EnvironUUID(),
 			Id:                      m.Id(),
 			InstanceId:              "i-0",
 			Status:                  multiwatcher.Status("pending"),

--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -39,6 +39,7 @@ var marshalTestCases = []struct {
 	about: "MachineInfo Delta",
 	value: multiwatcher.Delta{
 		Entity: &multiwatcher.MachineInfo{
+			EnvUUID:                 "uuid",
 			Id:                      "Benji",
 			InstanceId:              "Shazam",
 			Status:                  "error",
@@ -51,11 +52,12 @@ var marshalTestCases = []struct {
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
 		},
 	},
-	json: `["machine","change",{"Id":"Benji","InstanceId":"Shazam","HasVote":false,"WantsVote":false,"Status":"error","StatusInfo":"foo","StatusData":null,"Life":"alive","Series":"trusty","SupportedContainers":["lxc"],"SupportedContainersKnown":false,"Jobs":["JobManageEnviron"],"Addresses":[],"HardwareCharacteristics":{}}]`,
+	json: `["machine","change",{"EnvUUID": "uuid", "Id":"Benji","InstanceId":"Shazam","HasVote":false,"WantsVote":false,"Status":"error","StatusInfo":"foo","StatusData":null,"Life":"alive","Series":"trusty","SupportedContainers":["lxc"],"SupportedContainersKnown":false,"Jobs":["JobManageEnviron"],"Addresses":[],"HardwareCharacteristics":{}}]`,
 }, {
 	about: "ServiceInfo Delta",
 	value: multiwatcher.Delta{
 		Entity: &multiwatcher.ServiceInfo{
+			EnvUUID:     "uuid",
 			Name:        "Benji",
 			Exposed:     true,
 			CharmURL:    "cs:quantal/name",
@@ -73,11 +75,12 @@ var marshalTestCases = []struct {
 			},
 		},
 	},
-	json: `["service","change",{"CharmURL": "cs:quantal/name","Name":"Benji","Exposed":true,"Life":"dying","OwnerTag":"test-owner","MinUnits":42,"Constraints":{"arch":"armhf", "mem": 1024},"Config": {"hello":"goodbye","foo":false},"Subordinate":false,"Status":{"Current":"active", "Message":"all good", "Version": "", "Err": null, "Data": null, "Since": null}}]`,
+	json: `["service","change",{"EnvUUID": "uuid", "CharmURL": "cs:quantal/name","Name":"Benji","Exposed":true,"Life":"dying","OwnerTag":"test-owner","MinUnits":42,"Constraints":{"arch":"armhf", "mem": 1024},"Config": {"hello":"goodbye","foo":false},"Subordinate":false,"Status":{"Current":"active", "Message":"all good", "Version": "", "Err": null, "Data": null, "Since": null}}]`,
 }, {
 	about: "UnitInfo Delta",
 	value: multiwatcher.Delta{
 		Entity: &multiwatcher.UnitInfo{
+			EnvUUID:  "uuid",
 			Name:     "Benji",
 			Service:  "Shazam",
 			Series:   "precise",
@@ -105,40 +108,43 @@ var marshalTestCases = []struct {
 			},
 		},
 	},
-	json: `["unit", "change", {"CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "PortRanges": [{"FromPort": 80, "ToPort": 80, "Protocol": "http"}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "WorkloadStatus":{"Current":"active", "Message":"all good", "Version": "", "Err": null, "Data": null, "Since": null}, "AgentStatus":{"Current":"idle", "Message":"", "Version": "", "Err": null, "Data": null, "Since": null}, "Subordinate": false}]`,
+	json: `["unit", "change", {"EnvUUID": "uuid", "CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "PortRanges": [{"FromPort": 80, "ToPort": 80, "Protocol": "http"}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "WorkloadStatus":{"Current":"active", "Message":"all good", "Version": "", "Err": null, "Data": null, "Since": null}, "AgentStatus":{"Current":"idle", "Message":"", "Version": "", "Err": null, "Data": null, "Since": null}, "Subordinate": false}]`,
 }, {
 	about: "RelationInfo Delta",
 	value: multiwatcher.Delta{
 		Entity: &multiwatcher.RelationInfo{
-			Key: "Benji",
-			Id:  4711,
+			EnvUUID: "uuid",
+			Key:     "Benji",
+			Id:      4711,
 			Endpoints: []multiwatcher.Endpoint{
 				{ServiceName: "logging", Relation: charm.Relation{Name: "logging-directory", Role: "requirer", Interface: "logging", Optional: false, Limit: 1, Scope: "container"}},
 				{ServiceName: "wordpress", Relation: charm.Relation{Name: "logging-dir", Role: "provider", Interface: "logging", Optional: false, Limit: 0, Scope: "container"}}},
 		},
 	},
-	json: `["relation","change",{"Key":"Benji", "Id": 4711, "Endpoints": [{"ServiceName":"logging", "Relation":{"Name":"logging-directory", "Role":"requirer", "Interface":"logging", "Optional":false, "Limit":1, "Scope":"container"}}, {"ServiceName":"wordpress", "Relation":{"Name":"logging-dir", "Role":"provider", "Interface":"logging", "Optional":false, "Limit":0, "Scope":"container"}}]}]`,
+	json: `["relation","change",{"EnvUUID": "uuid", "Key":"Benji", "Id": 4711, "Endpoints": [{"ServiceName":"logging", "Relation":{"Name":"logging-directory", "Role":"requirer", "Interface":"logging", "Optional":false, "Limit":1, "Scope":"container"}}, {"ServiceName":"wordpress", "Relation":{"Name":"logging-dir", "Role":"provider", "Interface":"logging", "Optional":false, "Limit":0, "Scope":"container"}}]}]`,
 }, {
 	about: "AnnotationInfo Delta",
 	value: multiwatcher.Delta{
 		Entity: &multiwatcher.AnnotationInfo{
-			Tag: "machine-0",
+			EnvUUID: "uuid",
+			Tag:     "machine-0",
 			Annotations: map[string]string{
 				"foo":   "bar",
 				"arble": "2 4",
 			},
 		},
 	},
-	json: `["annotation","change",{"Tag":"machine-0","Annotations":{"foo":"bar","arble":"2 4"}}]`,
+	json: `["annotation","change",{"EnvUUID": "uuid", "Tag":"machine-0","Annotations":{"foo":"bar","arble":"2 4"}}]`,
 }, {
 	about: "Delta Removed True",
 	value: multiwatcher.Delta{
 		Removed: true,
 		Entity: &multiwatcher.RelationInfo{
-			Key: "Benji",
+			EnvUUID: "uuid",
+			Key:     "Benji",
 		},
 	},
-	json: `["relation","remove",{"Key":"Benji", "Id": 0, "Endpoints": null}]`,
+	json: `["relation","remove",{"EnvUUID": "uuid", "Key":"Benji", "Id": 0, "Endpoints": null}]`,
 }}
 
 func (s *MarshalSuite) TestDeltaMarshalJSON(c *gc.C) {

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -29,6 +29,7 @@ type backingMachine machineDoc
 
 func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string) error {
 	info := &multiwatcher.MachineInfo{
+		EnvUUID:                  st.EnvironUUID(),
 		Id:                       m.Id,
 		Life:                     multiwatcher.Life(m.Life.String()),
 		Series:                   m.Series,
@@ -144,6 +145,7 @@ func unitAndAgentStatus(st *State, name string) (unitStatus, agentStatus *Status
 
 func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) error {
 	info := &multiwatcher.UnitInfo{
+		EnvUUID:     st.EnvironUUID(),
 		Name:        u.Name,
 		Service:     u.Service,
 		Series:      u.Series,
@@ -265,6 +267,7 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id strin
 		return errors.Trace(err)
 	}
 	info := &multiwatcher.ServiceInfo{
+		EnvUUID:     st.EnvironUUID(),
 		Name:        svc.Name,
 		Exposed:     svc.Exposed,
 		CharmURL:    svc.CharmURL.String(),
@@ -377,6 +380,7 @@ func (a *backingAction) removed(st *State, store *multiwatcherStore, id string) 
 
 func (a *backingAction) updated(st *State, store *multiwatcherStore, id string) error {
 	info := &multiwatcher.ActionInfo{
+		EnvUUID:    st.EnvironUUID(),
 		Id:         id,
 		Receiver:   a.Receiver,
 		Name:       a.Name,
@@ -403,6 +407,7 @@ func (r *backingRelation) updated(st *State, store *multiwatcherStore, id string
 		}
 	}
 	info := &multiwatcher.RelationInfo{
+		EnvUUID:   st.EnvironUUID(),
 		Key:       r.Key,
 		Id:        r.Id,
 		Endpoints: eps,
@@ -426,6 +431,7 @@ type backingAnnotation annotatorDoc
 
 func (a *backingAnnotation) updated(st *State, store *multiwatcherStore, id string) error {
 	info := &multiwatcher.AnnotationInfo{
+		EnvUUID:     st.EnvironUUID(),
 		Tag:         a.Tag,
 		Annotations: a.Annotations,
 	}
@@ -452,6 +458,7 @@ type backingBlock blockDoc
 
 func (a *backingBlock) updated(st *State, store *multiwatcherStore, id string) error {
 	info := &multiwatcher.BlockInfo{
+		EnvUUID: st.EnvironUUID(),
 		Id:      id,
 		Tag:     a.Tag,
 		Type:    a.Type.ToParams(),

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -121,6 +121,7 @@ type UnitSettings struct {
 // MachineInfo holds the information about a Machine
 // that is watched by StateMultiwatcher.
 type MachineInfo struct {
+	EnvUUID                  string
 	Id                       string
 	InstanceId               string
 	Status                   Status
@@ -154,6 +155,7 @@ type StatusInfo struct {
 }
 
 type ServiceInfo struct {
+	EnvUUID     string
 	Name        string
 	Exposed     bool
 	CharmURL    string
@@ -174,6 +176,7 @@ func (i *ServiceInfo) EntityId() EntityId {
 }
 
 type UnitInfo struct {
+	EnvUUID        string
 	Name           string
 	Service        string
 	Series         string
@@ -201,6 +204,7 @@ func (i *UnitInfo) EntityId() EntityId {
 }
 
 type ActionInfo struct {
+	EnvUUID    string
 	Id         string
 	Receiver   string
 	Name       string
@@ -221,6 +225,7 @@ func (i *ActionInfo) EntityId() EntityId {
 }
 
 type RelationInfo struct {
+	EnvUUID   string
 	Key       string
 	Id        int
 	Endpoints []Endpoint
@@ -234,6 +239,7 @@ func (i *RelationInfo) EntityId() EntityId {
 }
 
 type AnnotationInfo struct {
+	EnvUUID     string
 	Tag         string
 	Annotations map[string]string
 }
@@ -282,6 +288,7 @@ func AnyJobNeedsState(jobs ...MachineJob) bool {
 // BlockInfo holds the information about blocks
 // in this environment that are watched.
 type BlockInfo struct {
+	EnvUUID string
 	Id      string
 	Type    BlockType
 	Message string


### PR DESCRIPTION
The environment UUID is now included on all entity structs returned by the WatchAll API. This is in preparation for a cross-environment watcher which will use much of the same infrastructure.

(Review request: http://reviews.vapour.ws/r/2277/)