### PR TITLE
CMD: Fix 1464679 status missing info

### DIFF
--- a/cmd/juju/commands/status.go
+++ b/cmd/juju/commands/status.go
@@ -73,16 +73,19 @@ func (c *StatusCommand) Info() *cmd.Info {
 func (c *StatusCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.isoTime, "utc", false, "display time as UTC in RFC3339 format")
 
+	oneLineFormatter := FormatOneline
 	defaultFormat := "yaml"
 	if c.CompatVersion() > 1 {
 		defaultFormat = "tabular"
+		oneLineFormatter = FormatOnelineV2
 	}
+
 	c.out.AddFlags(f, defaultFormat, map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
-		"short":   FormatOneline,
-		"oneline": FormatOneline,
-		"line":    FormatOneline,
+		"short":   oneLineFormatter,
+		"oneline": oneLineFormatter,
+		"line":    oneLineFormatter,
 		"tabular": FormatTabular,
 		"summary": FormatSummary,
 	})

--- a/cmd/juju/commands/status_test.go
+++ b/cmd/juju/commands/status_test.go
@@ -3111,13 +3111,25 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 
 	ctx.run(c, steps)
 
-	const expected = `
+	const expectedV1 = `
 - mysql/0: dummyenv-2.dns (started)
   - logging/1: dummyenv-2.dns (error)
 - wordpress/0: dummyenv-1.dns (started)
   - logging/0: dummyenv-1.dns (started)
 `
+	assertOneLineStatus(c, expectedV1)
 
+	const expectedV2 = `
+- mysql/0: dummyenv-2.dns (agent:idle, workload:active)
+  - logging/1: dummyenv-2.dns (agent:idle, workload:error)
+- wordpress/0: dummyenv-1.dns (agent:idle, workload:active)
+  - logging/0: dummyenv-1.dns (agent:idle, workload:active)
+`
+	s.PatchEnvironment(osenv.JujuCLIVersion, "2")
+	assertOneLineStatus(c, expectedV2)
+}
+
+func assertOneLineStatus(c *gc.C, expected string) {
 	code, stdout, stderr := runStatus(c, "--format", "oneline")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
@@ -3135,6 +3147,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, expected)
 }
+
 func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 	ctx := s.newContext(c)
 	steps := []stepper{


### PR DESCRIPTION
Allow different formats to be set for different CLI versions. Set the
format for CLI Version 2 to use unitStatus.WorloadStutusInfo instead of
unitStatus.AgentState, used in Version 1.

(Review request: http://reviews.vapour.ws/r/2278/)