### PR TITLE
state: add env UUID to multiwatcher.EntityId

### DIFF
--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -467,8 +467,11 @@ func (s *storeManagerStateSuite) TestChangeAnnotations(c *gc.C) {
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			return changeTestCase{
-				about:           "annotation is removed if it's not in backing",
-				initialContents: []multiwatcher.EntityInfo{&multiwatcher.AnnotationInfo{Tag: "machine-0"}},
+				about: "annotation is removed if it's not in backing",
+				initialContents: []multiwatcher.EntityInfo{&multiwatcher.AnnotationInfo{
+					EnvUUID: st.EnvironUUID(),
+					Tag:     "machine-0",
+				}},
 				change: watcher.Change{
 					C:  "annotations",
 					Id: st.docID("m#0"),
@@ -506,7 +509,8 @@ func (s *storeManagerStateSuite) TestChangeAnnotations(c *gc.C) {
 			return changeTestCase{
 				about: "annotation is updated if it's in backing and in multiwatcher.Store",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.AnnotationInfo{
-					Tag: "machine-0",
+					EnvUUID: st.EnvironUUID(),
+					Tag:     "machine-0",
 					Annotations: map[string]string{
 						"arble":  "baz",
 						"foo":    "bar",
@@ -632,8 +636,11 @@ func (s *storeManagerStateSuite) TestChangeMachines(c *gc.C) {
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			return changeTestCase{
-				about:           "machine is removed if it's not in backing",
-				initialContents: []multiwatcher.EntityInfo{&multiwatcher.MachineInfo{Id: "1"}},
+				about: "machine is removed if it's not in backing",
+				initialContents: []multiwatcher.EntityInfo{&multiwatcher.MachineInfo{
+					EnvUUID: st.EnvironUUID(),
+					Id:      "1",
+				}},
 				change: watcher.Change{
 					C:  "machines",
 					Id: st.docID("1"),
@@ -1279,10 +1286,12 @@ func (s *storeManagerStateSuite) TestChangeUnits(c *gc.C) {
 				about: "unit info is updated if a port is opened on the machine it is placed in",
 				initialContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						Name: "wordpress/0",
+						EnvUUID: st.EnvironUUID(),
+						Name:    "wordpress/0",
 					},
 					&multiwatcher.MachineInfo{
-						Id: "0",
+						EnvUUID: st.EnvironUUID(),
+						Id:      "0",
 					},
 				},
 				change: watcher.Change{
@@ -1291,12 +1300,14 @@ func (s *storeManagerStateSuite) TestChangeUnits(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
+						EnvUUID:    st.EnvironUUID(),
 						Name:       "wordpress/0",
 						Ports:      []network.Port{{"tcp", 4242}},
 						PortRanges: []network.PortRange{{4242, 4242, "tcp"}},
 					},
 					&multiwatcher.MachineInfo{
-						Id: "0",
+						EnvUUID: st.EnvironUUID(),
+						Id:      "0",
 					},
 				}}
 		},
@@ -2390,12 +2401,10 @@ func (s entityInfoSlice) Less(i, j int) bool {
 	if id0.Kind != id1.Kind {
 		return id0.Kind < id1.Kind
 	}
-	switch id := id0.Id.(type) {
-	case string:
-		return id < id1.Id.(string)
-	default:
+	if id0.EnvUUID != id1.EnvUUID {
+		return id0.EnvUUID < id1.EnvUUID
 	}
-	panic("unexpected entity id type")
+	return id0.Id < id1.Id
 }
 
 func checkDeltasEqual(c *gc.C, d0, d1 []multiwatcher.Delta) {

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -32,8 +32,9 @@ type EntityInfo interface {
 }
 
 type EntityId struct {
-	Kind string
-	Id   interface{}
+	Kind    string
+	EnvUUID string
+	Id      string
 }
 
 // Delta holds details of a change to the environment.
@@ -140,8 +141,9 @@ type MachineInfo struct {
 
 func (i *MachineInfo) EntityId() EntityId {
 	return EntityId{
-		Kind: "machine",
-		Id:   i.Id,
+		Kind:    "machine",
+		EnvUUID: i.EnvUUID,
+		Id:      i.Id,
 	}
 }
 
@@ -170,8 +172,9 @@ type ServiceInfo struct {
 
 func (i *ServiceInfo) EntityId() EntityId {
 	return EntityId{
-		Kind: "service",
-		Id:   i.Name,
+		Kind:    "service",
+		EnvUUID: i.EnvUUID,
+		Id:      i.Name,
 	}
 }
 
@@ -198,8 +201,9 @@ type UnitInfo struct {
 
 func (i *UnitInfo) EntityId() EntityId {
 	return EntityId{
-		Kind: "unit",
-		Id:   i.Name,
+		Kind:    "unit",
+		EnvUUID: i.EnvUUID,
+		Id:      i.Name,
 	}
 }
 
@@ -219,8 +223,9 @@ type ActionInfo struct {
 
 func (i *ActionInfo) EntityId() EntityId {
 	return EntityId{
-		Kind: "action",
-		Id:   i.Id,
+		Kind:    "action",
+		EnvUUID: i.EnvUUID,
+		Id:      i.Id,
 	}
 }
 
@@ -233,8 +238,9 @@ type RelationInfo struct {
 
 func (i *RelationInfo) EntityId() EntityId {
 	return EntityId{
-		Kind: "relation",
-		Id:   i.Key,
+		Kind:    "relation",
+		EnvUUID: i.EnvUUID,
+		Id:      i.Key,
 	}
 }
 
@@ -246,8 +252,9 @@ type AnnotationInfo struct {
 
 func (i *AnnotationInfo) EntityId() EntityId {
 	return EntityId{
-		Kind: "annotation",
-		Id:   i.Tag,
+		Kind:    "annotation",
+		EnvUUID: i.EnvUUID,
+		Id:      i.Tag,
 	}
 }
 
@@ -298,8 +305,9 @@ type BlockInfo struct {
 // EntityId returns block id.
 func (i *BlockInfo) EntityId() EntityId {
 	return EntityId{
-		Kind: "block",
-		Id:   i.Id,
+		Kind:    "block",
+		EnvUUID: i.EnvUUID,
+		Id:      i.Id,
 	}
 }
 

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -5,11 +5,11 @@ package state
 
 import (
 	"container/list"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
@@ -93,40 +93,41 @@ var StoreChangeMethodTests = []struct {
 }, {
 	about: "mark removed on existing entry",
 	change: func(all *multiwatcherStore) {
-		all.Update(&multiwatcher.MachineInfo{Id: "0"})
-		all.Update(&multiwatcher.MachineInfo{Id: "1"})
-		StoreIncRef(all, multiwatcher.EntityId{"machine", "0"})
-		all.Remove(multiwatcher.EntityId{"machine", "0"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "1"})
+		StoreIncRef(all, multiwatcher.EntityId{"machine", "uuid", "0"})
+		all.Remove(multiwatcher.EntityId{"machine", "uuid", "0"})
 	},
 	expectRevno: 3,
 	expectContents: []entityEntry{{
 		creationRevno: 2,
 		revno:         2,
-		info:          &multiwatcher.MachineInfo{Id: "1"},
+		info:          &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "1"},
 	}, {
 		creationRevno: 1,
 		revno:         3,
 		refCount:      1,
 		removed:       true,
-		info:          &multiwatcher.MachineInfo{Id: "0"},
+		info:          &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"},
 	}},
 }, {
 	about: "mark removed on nonexistent entry",
 	change: func(all *multiwatcherStore) {
-		all.Remove(multiwatcher.EntityId{"machine", "0"})
+		all.Remove(multiwatcher.EntityId{"machine", "uuid", "0"})
 	},
 }, {
 	about: "mark removed on already marked entry",
 	change: func(all *multiwatcherStore) {
-		all.Update(&multiwatcher.MachineInfo{Id: "0"})
-		all.Update(&multiwatcher.MachineInfo{Id: "1"})
-		StoreIncRef(all, multiwatcher.EntityId{"machine", "0"})
-		all.Remove(multiwatcher.EntityId{"machine", "0"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "1"})
+		StoreIncRef(all, multiwatcher.EntityId{"machine", "uuid", "0"})
+		all.Remove(multiwatcher.EntityId{"machine", "uuid", "0"})
 		all.Update(&multiwatcher.MachineInfo{
+			EnvUUID:    "uuid",
 			Id:         "1",
 			InstanceId: "i-1",
 		})
-		all.Remove(multiwatcher.EntityId{"machine", "0"})
+		all.Remove(multiwatcher.EntityId{"machine", "uuid", "0"})
 	},
 	expectRevno: 4,
 	expectContents: []entityEntry{{
@@ -134,11 +135,12 @@ var StoreChangeMethodTests = []struct {
 		revno:         3,
 		refCount:      1,
 		removed:       true,
-		info:          &multiwatcher.MachineInfo{Id: "0"},
+		info:          &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"},
 	}, {
 		creationRevno: 2,
 		revno:         4,
 		info: &multiwatcher.MachineInfo{
+			EnvUUID:    "uuid",
 			Id:         "1",
 			InstanceId: "i-1",
 		},
@@ -146,15 +148,15 @@ var StoreChangeMethodTests = []struct {
 }, {
 	about: "mark removed on entry with zero ref count",
 	change: func(all *multiwatcherStore) {
-		all.Update(&multiwatcher.MachineInfo{Id: "0"})
-		all.Remove(multiwatcher.EntityId{"machine", "0"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"})
+		all.Remove(multiwatcher.EntityId{"machine", "uuid", "0"})
 	},
 	expectRevno: 2,
 }, {
 	about: "delete entry",
 	change: func(all *multiwatcherStore) {
-		all.Update(&multiwatcher.MachineInfo{Id: "0"})
-		all.delete(multiwatcher.EntityId{"machine", "0"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"})
+		all.delete(multiwatcher.EntityId{"machine", "uuid", "0"})
 	},
 	expectRevno: 1,
 }, {
@@ -203,7 +205,10 @@ func (s *storeSuite) TestChangesSince(c *gc.C) {
 	// Add three entries.
 	var deltas []multiwatcher.Delta
 	for i := 0; i < 3; i++ {
-		m := &multiwatcher.MachineInfo{Id: fmt.Sprint(i)}
+		m := &multiwatcher.MachineInfo{
+			EnvUUID: "uuid",
+			Id:      fmt.Sprint(i),
+		}
 		a.Update(m)
 		deltas = append(deltas, multiwatcher.Delta{Entity: m})
 	}
@@ -220,6 +225,7 @@ func (s *storeSuite) TestChangesSince(c *gc.C) {
 	// Update one machine and check we see the changes.
 	rev := a.latestRevno
 	m1 := &multiwatcher.MachineInfo{
+		EnvUUID:    "uuid",
 		Id:         "1",
 		InstanceId: "foo",
 	}
@@ -228,17 +234,17 @@ func (s *storeSuite) TestChangesSince(c *gc.C) {
 
 	// Make sure the machine isn't simply removed from
 	// the list when it's marked as removed.
-	StoreIncRef(a, multiwatcher.EntityId{"machine", "0"})
+	StoreIncRef(a, multiwatcher.EntityId{"machine", "uuid", "0"})
 
 	// Remove another machine and check we see it's removed.
-	m0 := &multiwatcher.MachineInfo{Id: "0"}
+	m0 := &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"}
 	a.Remove(m0.EntityId())
 
 	// Check that something that never saw m0 does not get
 	// informed of its removal (even those the removed entity
 	// is still in the list.
 	c.Assert(a.ChangesSince(0), gc.DeepEquals, []multiwatcher.Delta{{
-		Entity: &multiwatcher.MachineInfo{Id: "2"},
+		Entity: &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "2"},
 	}, {
 		Entity: m1,
 	}})
@@ -258,11 +264,11 @@ func (s *storeSuite) TestChangesSince(c *gc.C) {
 
 func (s *storeSuite) TestGet(c *gc.C) {
 	a := newStore()
-	m := &multiwatcher.MachineInfo{Id: "0"}
+	m := &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"}
 	a.Update(m)
 
 	c.Assert(a.Get(m.EntityId()), gc.Equals, m)
-	c.Assert(a.Get(multiwatcher.EntityId{"machine", "1"}), gc.IsNil)
+	c.Assert(a.Get(multiwatcher.EntityId{"machine", "uuid", "1"}), gc.IsNil)
 }
 
 type storeManagerSuite struct {
@@ -329,8 +335,9 @@ func (s *storeManagerSuite) TestHandleStopNoDecRefIfMoreRecentlyCreated(c *gc.C)
 	// If the Multiwatcher hasn't seen the item, then we shouldn't
 	// decrement its ref count when it is stopped.
 	sm := newStoreManager(newTestBacking(nil))
-	sm.all.Update(&multiwatcher.MachineInfo{Id: "0"})
-	StoreIncRef(sm.all, multiwatcher.EntityId{"machine", "0"})
+	mi := &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"}
+	sm.all.Update(mi)
+	StoreIncRef(sm.all, multiwatcher.EntityId{"machine", "uuid", "0"})
 	w := &Multiwatcher{all: sm}
 
 	// Stop the watcher.
@@ -339,19 +346,22 @@ func (s *storeManagerSuite) TestHandleStopNoDecRefIfMoreRecentlyCreated(c *gc.C)
 		creationRevno: 1,
 		revno:         1,
 		refCount:      1,
-		info: &multiwatcher.MachineInfo{
-			Id: "0",
-		},
+		info:          mi,
 	}})
 }
 
 func (s *storeManagerSuite) TestHandleStopNoDecRefIfAlreadySeenRemoved(c *gc.C) {
 	// If the Multiwatcher has already seen the item removed, then
 	// we shouldn't decrement its ref count when it is stopped.
+
 	sm := newStoreManager(newTestBacking(nil))
-	sm.all.Update(&multiwatcher.MachineInfo{Id: "0"})
-	StoreIncRef(sm.all, multiwatcher.EntityId{"machine", "0"})
-	sm.all.Remove(multiwatcher.EntityId{"machine", "0"})
+	mi := &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"}
+	sm.all.Update(mi)
+
+	id := multiwatcher.EntityId{"machine", "uuid", "0"}
+	StoreIncRef(sm.all, id)
+	sm.all.Remove(id)
+
 	w := &Multiwatcher{all: sm}
 	// Stop the watcher.
 	sm.handle(&request{w: w})
@@ -360,9 +370,7 @@ func (s *storeManagerSuite) TestHandleStopNoDecRefIfAlreadySeenRemoved(c *gc.C) 
 		revno:         2,
 		refCount:      1,
 		removed:       true,
-		info: &multiwatcher.MachineInfo{
-			Id: "0",
-		},
+		info:          mi,
 	}})
 }
 
@@ -370,8 +378,9 @@ func (s *storeManagerSuite) TestHandleStopDecRefIfAlreadySeenAndNotRemoved(c *gc
 	// If the Multiwatcher has already seen the item removed, then
 	// we should decrement its ref count when it is stopped.
 	sm := newStoreManager(newTestBacking(nil))
-	sm.all.Update(&multiwatcher.MachineInfo{Id: "0"})
-	StoreIncRef(sm.all, multiwatcher.EntityId{"machine", "0"})
+	mi := &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"}
+	sm.all.Update(mi)
+	StoreIncRef(sm.all, multiwatcher.EntityId{"machine", "uuid", "0"})
 	w := &Multiwatcher{all: sm}
 	w.revno = sm.all.latestRevno
 	// Stop the watcher.
@@ -379,9 +388,7 @@ func (s *storeManagerSuite) TestHandleStopDecRefIfAlreadySeenAndNotRemoved(c *gc
 	assertStoreContents(c, sm.all, 1, []entityEntry{{
 		creationRevno: 1,
 		revno:         1,
-		info: &multiwatcher.MachineInfo{
-			Id: "0",
-		},
+		info:          mi,
 	}})
 }
 
@@ -389,8 +396,9 @@ func (s *storeManagerSuite) TestHandleStopNoDecRefIfNotSeen(c *gc.C) {
 	// If the Multiwatcher hasn't seen the item at all, it should
 	// leave the ref count untouched.
 	sm := newStoreManager(newTestBacking(nil))
-	sm.all.Update(&multiwatcher.MachineInfo{Id: "0"})
-	StoreIncRef(sm.all, multiwatcher.EntityId{"machine", "0"})
+	mi := &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"}
+	sm.all.Update(mi)
+	StoreIncRef(sm.all, multiwatcher.EntityId{"machine", "uuid", "0"})
 	w := &Multiwatcher{all: sm}
 	// Stop the watcher.
 	sm.handle(&request{w: w})
@@ -398,33 +406,32 @@ func (s *storeManagerSuite) TestHandleStopNoDecRefIfNotSeen(c *gc.C) {
 		creationRevno: 1,
 		revno:         1,
 		refCount:      1,
-		info: &multiwatcher.MachineInfo{
-			Id: "0",
-		},
+		info:          mi,
 	}})
 }
 
 var respondTestChanges = [...]func(all *multiwatcherStore){
 	func(all *multiwatcherStore) {
-		all.Update(&multiwatcher.MachineInfo{Id: "0"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"})
 	},
 	func(all *multiwatcherStore) {
-		all.Update(&multiwatcher.MachineInfo{Id: "1"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "1"})
 	},
 	func(all *multiwatcherStore) {
-		all.Update(&multiwatcher.MachineInfo{Id: "2"})
+		all.Update(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "2"})
 	},
 	func(all *multiwatcherStore) {
-		all.Remove(multiwatcher.EntityId{"machine", "0"})
+		all.Remove(multiwatcher.EntityId{"machine", "uuid", "0"})
 	},
 	func(all *multiwatcherStore) {
 		all.Update(&multiwatcher.MachineInfo{
+			EnvUUID:    "uuid",
 			Id:         "1",
 			InstanceId: "i-1",
 		})
 	},
 	func(all *multiwatcherStore) {
-		all.Remove(multiwatcher.EntityId{"machine", "1"})
+		all.Remove(multiwatcher.EntityId{"machine", "uuid", "1"})
 	},
 }
 
@@ -433,7 +440,8 @@ var (
 		creationRevno: 3,
 		revno:         3,
 		info: &multiwatcher.MachineInfo{
-			Id: "2",
+			EnvUUID: "uuid",
+			Id:      "2",
 		},
 	}}
 	respondTestFinalRevno = int64(len(respondTestChanges))
@@ -615,9 +623,9 @@ func (*storeManagerSuite) TestRunStop(c *gc.C) {
 
 func (*storeManagerSuite) TestRun(c *gc.C) {
 	b := newTestBacking([]multiwatcher.EntityInfo{
-		&multiwatcher.MachineInfo{Id: "0"},
-		&multiwatcher.ServiceInfo{Name: "logging"},
-		&multiwatcher.ServiceInfo{Name: "wordpress"},
+		&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"},
+		&multiwatcher.ServiceInfo{EnvUUID: "uuid", Name: "logging"},
+		&multiwatcher.ServiceInfo{EnvUUID: "uuid", Name: "wordpress"},
 	})
 	sm := newStoreManager(b)
 	defer func() {
@@ -625,17 +633,17 @@ func (*storeManagerSuite) TestRun(c *gc.C) {
 	}()
 	w := &Multiwatcher{all: sm}
 	checkNext(c, w, []multiwatcher.Delta{
-		{Entity: &multiwatcher.MachineInfo{Id: "0"}},
-		{Entity: &multiwatcher.ServiceInfo{Name: "logging"}},
-		{Entity: &multiwatcher.ServiceInfo{Name: "wordpress"}},
+		{Entity: &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"}},
+		{Entity: &multiwatcher.ServiceInfo{EnvUUID: "uuid", Name: "logging"}},
+		{Entity: &multiwatcher.ServiceInfo{EnvUUID: "uuid", Name: "wordpress"}},
 	}, "")
-	b.updateEntity(&multiwatcher.MachineInfo{Id: "0", InstanceId: "i-0"})
+	b.updateEntity(&multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0", InstanceId: "i-0"})
 	checkNext(c, w, []multiwatcher.Delta{
-		{Entity: &multiwatcher.MachineInfo{Id: "0", InstanceId: "i-0"}},
+		{Entity: &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0", InstanceId: "i-0"}},
 	}, "")
-	b.deleteEntity(multiwatcher.EntityId{"machine", "0"})
+	b.deleteEntity(multiwatcher.EntityId{"machine", "uuid", "0"})
 	checkNext(c, w, []multiwatcher.Delta{
-		{Removed: true, Entity: &multiwatcher.MachineInfo{Id: "0"}},
+		{Removed: true, Entity: &multiwatcher.MachineInfo{EnvUUID: "uuid", Id: "0"}},
 	}, "")
 }
 
@@ -761,14 +769,14 @@ func assertWaitingRequests(c *gc.C, sm *storeManager, waiting map[*Multiwatcher]
 type storeManagerTestBacking struct {
 	mu       sync.Mutex
 	fetchErr error
-	entities map[interface{}]multiwatcher.EntityInfo
+	entities map[multiwatcher.EntityId]multiwatcher.EntityInfo
 	watchc   chan<- watcher.Change
 	txnRevno int64
 }
 
 func newTestBacking(initial []multiwatcher.EntityInfo) *storeManagerTestBacking {
 	b := &storeManagerTestBacking{
-		entities: make(map[interface{}]multiwatcher.EntityInfo),
+		entities: make(map[multiwatcher.EntityId]multiwatcher.EntityInfo),
 	}
 	for _, info := range initial {
 		b.entities[info.EntityId()] = info
@@ -777,9 +785,14 @@ func newTestBacking(initial []multiwatcher.EntityInfo) *storeManagerTestBacking 
 }
 
 func (b *storeManagerTestBacking) Changed(all *multiwatcherStore, change watcher.Change) error {
+	envUUID, changeId, ok := splitDocID(change.Id.(string))
+	if !ok {
+		return errors.Errorf("unexpected id format: %v", change.Id)
+	}
 	id := multiwatcher.EntityId{
-		Kind: change.C,
-		Id:   change.Id.(string),
+		Kind:    change.C,
+		EnvUUID: envUUID,
+		Id:      changeId,
 	}
 	info, err := b.fetch(id)
 	if err == mgo.ErrNotFound {
@@ -793,7 +806,7 @@ func (b *storeManagerTestBacking) Changed(all *multiwatcherStore, change watcher
 	return nil
 }
 
-func (b *storeManagerTestBacking) fetch(id interface{}) (multiwatcher.EntityInfo, error) {
+func (b *storeManagerTestBacking) fetch(id multiwatcher.EntityId) (multiwatcher.EntityInfo, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.fetchErr != nil {
@@ -841,7 +854,7 @@ func (b *storeManagerTestBacking) updateEntity(info multiwatcher.EntityInfo) {
 	if b.watchc != nil {
 		b.watchc <- watcher.Change{
 			C:     id.Kind,
-			Id:    id.Id,
+			Id:    createDocID(id.EnvUUID, id.Id),
 			Revno: b.txnRevno, // This is actually ignored, but fill it in anyway.
 		}
 	}
@@ -853,8 +866,7 @@ func (b *storeManagerTestBacking) setFetchError(err error) {
 	b.fetchErr = err
 }
 
-func (b *storeManagerTestBacking) deleteEntity(id0 interface{}) {
-	id := id0.(multiwatcher.EntityId)
+func (b *storeManagerTestBacking) deleteEntity(id multiwatcher.EntityId) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	delete(b.entities, id)
@@ -862,7 +874,7 @@ func (b *storeManagerTestBacking) deleteEntity(id0 interface{}) {
 	if b.watchc != nil {
 		b.watchc <- watcher.Change{
 			C:     id.Kind,
-			Id:    id.Id,
+			Id:    createDocID(id.EnvUUID, id.Id),
 			Revno: -1,
 		}
 	}
@@ -892,5 +904,6 @@ func checkNext(c *gc.C, w *Multiwatcher, deltas []multiwatcher.Delta, expectErr 
 		c.Check(err, gc.ErrorMatches, expectErr)
 		return
 	}
+	c.Assert(err, jc.ErrorIsNil)
 	checkDeltasEqual(c, d, deltas)
 }


### PR DESCRIPTION
To allow a single multiwatcherStore to track entities for multiple environments, EntityId include the environment UUID for the entity. This is needed to support a new watcher (coming soon) which
will watch all environments.

Also in this change: extracted the logic for State.docID and State.localID into standalone functions so they can be used independently (there will be more uses of these soon).

(Review request: http://reviews.vapour.ws/r/2279/)