### PR TITLE
state: log in to admin db before attempting any mongodb queries

### DIFF
--- a/state/open.go
+++ b/state/open.go
@@ -56,6 +56,13 @@ func open(tag names.EnvironTag, info *mongo.MongoInfo, opts mongo.DialOpts, poli
 	}
 	logger.Debugf("connection established")
 
+	err = mongodbLogin(session, info)
+	if err != nil {
+		session.Close()
+		return nil, errors.Trace(err)
+	}
+	logger.Debugf("mongodb login successful")
+
 	// In rare circumstances, we may be upgrading from pre-1.23, and not have the
 	// environment UUID available. In that case we need to infer what it might be;
 	// we depend on the assumption that this is the only circumstance in which
@@ -64,6 +71,7 @@ func open(tag names.EnvironTag, info *mongo.MongoInfo, opts mongo.DialOpts, poli
 		logger.Warningf("creating state without environment tag; inferring bootstrap environment")
 		ssInfo, err := readRawStateServerInfo(session)
 		if err != nil {
+			session.Close()
 			return nil, errors.Trace(err)
 		}
 		tag = ssInfo.EnvironmentTag
@@ -75,6 +83,21 @@ func open(tag names.EnvironTag, info *mongo.MongoInfo, opts mongo.DialOpts, poli
 		return nil, errors.Trace(err)
 	}
 	return st, nil
+}
+
+// mongodbLogin logs in to the mongodb admin database.
+func mongodbLogin(session *mgo.Session, mongoInfo *mongo.MongoInfo) error {
+	admin := session.DB("admin")
+	if mongoInfo.Tag != nil {
+		if err := admin.Login(mongoInfo.Tag.String(), mongoInfo.Password); err != nil {
+			return maybeUnauthorized(err, fmt.Sprintf("cannot log in to admin database as %q", mongoInfo.Tag))
+		}
+	} else if mongoInfo.Password != "" {
+		if err := admin.Login(mongo.AdminUser, mongoInfo.Password); err != nil {
+			return maybeUnauthorized(err, "cannot log in to admin database")
+		}
+	}
+	return nil
 }
 
 // Initialize sets up an initial empty state and returns it.
@@ -209,17 +232,6 @@ func isUnauthorized(err error) bool {
 // pwatcher, leadershipManager, or serverTag. You must start() the returned
 // *State before it will function correctly.
 func newState(environTag names.EnvironTag, session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (_ *State, resultErr error) {
-	admin := session.DB("admin")
-	if mongoInfo.Tag != nil {
-		if err := admin.Login(mongoInfo.Tag.String(), mongoInfo.Password); err != nil {
-			return nil, maybeUnauthorized(err, fmt.Sprintf("cannot log in to admin database as %q", mongoInfo.Tag))
-		}
-	} else if mongoInfo.Password != "" {
-		if err := admin.Login(mongo.AdminUser, mongoInfo.Password); err != nil {
-			return nil, maybeUnauthorized(err, "cannot log in to admin database")
-		}
-	}
-
 	// Set up database.
 	rawDB := session.DB(jujuDB)
 	database, err := allCollections().Load(rawDB, environTag.Id())


### PR DESCRIPTION
When upgrading from 1.22, the lack of an environ tag would cause open() to attempt to query stateServersC before the mongodb login had been done. The login is now down first.

Also added a missing session.Close call when readRawStateServerInfo fails.

Fixes LP #1479931.

(Review request: http://reviews.vapour.ws/r/2285/)