### PR TITLE
Skipped TestUniterUpgradeConflicts for i386

### DIFF
--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -890,6 +890,7 @@ func (s *UniterSuite) TestUniterDeployerConversion(c *gc.C) {
 
 func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 	coretesting.SkipIfPPC64EL(c, "lp:1448308")
+	coretesting.SkipIfI386(c, "lp:1442149")
 	//TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: currently does not work on windows")


### PR DESCRIPTION
As it is flaky and blocking the 1.24 release, this test is now skipped
on i386 (it's already skipped on PPC64 and Windows).

See bug http://pad.lv/1442149.

(Review request: http://reviews.vapour.ws/r/2286/)