### PR TITLE
Check for NotImplemented err with new charms endpoint

### DIFF
--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -310,8 +310,11 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	err = registerMeteredCharm(c.RegisterURL, state, csClient.jar, curl.String(), serviceName, client.EnvironmentUUID())
-	if err != nil {
-		return err
+	if params.IsCodeNotImplemented(err) {
+		// The state server is too old to support metering.  Warn
+		// the user, but don't return an error.
+		ctx.Infof("Current state server version does not support charm metering.")
+		return nil
 	}
 
 	return block.ProcessBlockedError(err, block.BlockChange)

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -313,7 +313,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 	if params.IsCodeNotImplemented(err) {
 		// The state server is too old to support metering.  Warn
 		// the user, but don't return an error.
-		ctx.Infof("Current state server version does not support charm metering.")
+		logger.Warningf("current state server version does not support charm metering")
 		return nil
 	}
 

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/persistent-cookiejar"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -26,6 +27,7 @@ import (
 	"gopkg.in/macaroon-bakery.v0/bakerytest"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/service"
 	"github.com/juju/juju/constraints"
@@ -654,4 +656,21 @@ func (s *DeploySuite) TestAddMetricCredentialsHttp(c *gc.C) {
 	c.Assert(handler.registrationCalls, gc.HasLen, 1)
 	c.Assert(handler.registrationCalls[0].CharmURL, gc.DeepEquals, "local:quantal/metered-1")
 	c.Assert(handler.registrationCalls[0].ServiceName, gc.DeepEquals, "metered")
+}
+
+func (s *DeploySuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) {
+
+	s.PatchValue(&registerMeteredCharm, func(r string, s *api.State, j *cookiejar.Jar, c string, sv, e string) error {
+		return &params.Error{"IsMetered", params.CodeNotImplemented}
+	})
+
+	testcharms.Repo.ClonedDirPath(s.SeriesPath, "dummy")
+	ctx, err := coretesting.RunCommand(c, envcmd.Wrap(&DeployCommand{}), "local:dummy")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
+	output := strings.Split(coretesting.Stderr(ctx), "\n")
+	c.Check(output[0], gc.Matches, `Added charm ".*" to the environment.`)
+	c.Check(output[1], gc.Equals, "Current state server version does not support charm metering.")
+
 }

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -665,12 +665,7 @@ func (s *DeploySuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) {
 	})
 
 	testcharms.Repo.ClonedDirPath(s.SeriesPath, "dummy")
-	ctx, err := coretesting.RunCommand(c, envcmd.Wrap(&DeployCommand{}), "local:dummy")
+	_, err := coretesting.RunCommand(c, envcmd.Wrap(&DeployCommand{}), "local:dummy")
 	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(coretesting.Stdout(ctx), gc.Equals, "")
-	output := strings.Split(coretesting.Stderr(ctx), "\n")
-	c.Check(output[0], gc.Matches, `Added charm ".*" to the environment.`)
-	c.Check(output[1], gc.Equals, "Current state server version does not support charm metering.")
-
+	c.Check(c.GetTestLog(), jc.Contains, "current state server version does not support charm metering")
 }

--- a/cmd/juju/commands/register.go
+++ b/cmd/juju/commands/register.go
@@ -27,7 +27,7 @@ type metricRegistrationPost struct {
 	ServiceName     string `json:"service-name"`
 }
 
-func registerMeteredCharm(registrationURL string, state *api.State, jar *cookiejar.Jar, charmURL string, serviceName, environmentUUID string) error {
+var registerMeteredCharm = func(registrationURL string, state *api.State, jar *cookiejar.Jar, charmURL string, serviceName, environmentUUID string) error {
 	charmsClient := charms.NewClient(state)
 	defer charmsClient.Close()
 	metered, err := charmsClient.IsMetered(charmURL)


### PR DESCRIPTION
When deploying a charm to an older state server, the
call to charms.IsMetered may fail with NotImplemented.
Warn the user, but don't return an error from the
deploy.

Fix for bug: https://bugs.launchpad.net/juju-core/+bug/1480298

(Review request: http://reviews.vapour.ws/r/2287/)