### PR TITLE
Backport leadership changes from master to 1.24

### DIFF
--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -1549,11 +1549,15 @@ func leadershipSettingsAccessorFactory(
 	auth common.Authorizer,
 ) *leadershipapiserver.LeadershipSettingsAccessor {
 	registerWatcher := func(serviceId string) (string, error) {
-		settingsWatcher := st.WatchLeadershipSettings(serviceId)
-		if _, ok := <-settingsWatcher.Changes(); ok {
-			return resources.Register(settingsWatcher), nil
+		service, err := st.Service(serviceId)
+		if err != nil {
+			return "", err
 		}
-		return "", watcher.EnsureErr(settingsWatcher)
+		w := service.WatchLeaderSettings()
+		if _, ok := <-w.Changes(); ok {
+			return resources.Register(w), nil
+		}
+		return "", watcher.EnsureErr(w)
 	}
 	getSettings := func(serviceId string) (map[string]string, error) {
 		service, err := st.Service(serviceId)

--- a/state/settings.go
+++ b/state/settings.go
@@ -271,10 +271,6 @@ func (st *State) ReadSettings(key string) (*Settings, error) {
 	return readSettings(st, key)
 }
 
-func (st *State) ReadLeadershipSettings(serviceId string) (*Settings, error) {
-	return readSettings(st, leadershipSettingsDocId(serviceId))
-}
-
 // readSettings returns the Settings for key.
 func readSettings(st *State, key string) (*Settings, error) {
 	s := newSettings(st, key)

--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -632,21 +632,14 @@ func (s *FilterSuite) TestStorageEvents(c *gc.C) {
 }
 
 func (s *FilterSuite) setLeaderSetting(c *gc.C, key, value string) {
-	// s.wordpress is the service object
-	currentSettings, err := s.State.ReadLeadershipSettings(s.wordpress.Tag().Id())
+	err := s.wordpress.UpdateLeaderSettings(successToken{}, map[string]string{key: value})
 	c.Assert(err, jc.ErrorIsNil)
-	currentSettings.Update(map[string]interface{}{key: value})
-	_, err = currentSettings.Write()
-	c.Assert(err, jc.ErrorIsNil)
-	// This is how we would set LeadershipSettings if we are the Leader,
-	// but as we are not guaranteed to be leader and the API is properly
-	// running. But we just want to test them getting changed, we poke
-	// directly into state
-	/// err := s.uniter.LeadershipSettings.Merge(
-	///     s.wordpress.Tag().Id(),
-	///     map[string]string{key: value},
-	/// )
-	/// c.Assert(err, jc.ErrorIsNil)
+}
+
+type successToken struct{}
+
+func (successToken) Check(interface{}) error {
+	return nil
 }
 
 func (s *FilterSuite) TestLeaderSettingsEventsSendsChanges(c *gc.C) {

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1454,22 +1454,21 @@ type setLeaderSettings map[string]string
 func (s setLeaderSettings) step(c *gc.C, ctx *context) {
 	// We do this directly on State, not the API, so we don't have to worry
 	// about getting an API conn for whatever unit's meant to be leader.
-	settings, err := ctx.st.ReadLeadershipSettings(ctx.svc.Name())
+	err := ctx.svc.UpdateLeaderSettings(successToken{}, s)
 	c.Assert(err, jc.ErrorIsNil)
-	for key := range settings.Map() {
-		settings.Delete(key)
-	}
-	for key, value := range s {
-		settings.Set(key, value)
-	}
-	_, err = settings.Write()
-	c.Assert(err, jc.ErrorIsNil)
+	ctx.s.BackingState.StartSync()
+}
+
+type successToken struct{}
+
+func (successToken) Check(interface{}) error {
+	return nil
 }
 
 type verifyLeaderSettings map[string]string
 
 func (verify verifyLeaderSettings) step(c *gc.C, ctx *context) {
-	actual, err := ctx.api.LeadershipSettings.Read(ctx.svc.Name())
+	actual, err := ctx.svc.LeaderSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actual, jc.DeepEquals, map[string]string(verify))
 }


### PR DESCRIPTION
This is a backport of the diff http://reviews.vapour.ws/r/2289/diff/1-2/
It's a straight cherry-pick with a couple of trivial conflict resolutions.

(Review request: http://reviews.vapour.ws/r/2291/)