### PR TITLE
Don't use proxy for lxc images from state server

### DIFF
--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -20,8 +20,13 @@ var (
 	PreferFastLXC           = preferFastLXC
 	InitProcessCgroupFile   = &initProcessCgroupFile
 	RuntimeGOOS             = &runtimeGOOS
+	WriteWgetTmpFile        = &writeWgetTmpFile
 )
 
 func GetCreateWithCloneValue(mgr container.Manager) bool {
 	return mgr.(*containerManager).createWithClone
+}
+
+func WgetEnvironment(caCert []byte) ([]string, func(), error) {
+	return wgetEnvironment(caCert)
 }

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -43,6 +43,7 @@ var (
 	LxcObjectFactory      = golxc.Factory()
 	initProcessCgroupFile = "/proc/1/cgroup"
 	runtimeGOOS           = runtime.GOOS
+	writeWgetTmpFile      = ioutil.WriteFile
 )
 
 const (
@@ -463,12 +464,13 @@ func wgetEnvironment(caCert []byte) (execEnv []string, closer func(), _ error) {
 		return nil, nil, errors.Trace(err)
 	}
 
-	// Write the wget script.
+	// Write the wget script.  Don't use a proxy when getting
+	// the image as it's going through the state server.
 	wgetTmpl := `#!/bin/bash
-/usr/bin/wget --ca-certificate=%s $*
+/usr/bin/wget --no-proxy --ca-certificate=%s $*
 `
 	wget := fmt.Sprintf(wgetTmpl, caCertPath)
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "wget"), []byte(wget), 0755)
+	err = writeWgetTmpFile(filepath.Join(tmpDir, "wget"), []byte(wget), 0755)
 	if err != nil {
 		defer closer()
 		return nil, nil, errors.Trace(err)

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -1268,3 +1268,16 @@ func (s *LxcSuite) TestIsLXCSupportedNonLinuxSystem(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(supports, jc.IsFalse)
 }
+
+func (s *LxcSuite) TestWgetEnvironmentUsesNoProxy(c *gc.C) {
+	var wgetScript []byte
+	fakeCert := []byte("fakeCert")
+	s.PatchValue(lxc.WriteWgetTmpFile, func(filename string, data []byte, perm os.FileMode) error {
+		wgetScript = data
+		return nil
+	})
+	_, closer, err := lxc.WgetEnvironment(fakeCert)
+	c.Assert(err, jc.ErrorIsNil)
+	defer closer()
+	c.Assert(string(wgetScript), jc.Contains, "/usr/bin/wget --no-proxy --ca-certificate")
+}


### PR DESCRIPTION
Modified the wget command to include --no-proxy
so it doesn't attempt to go through the proxy
when contacting the state server to download
the image.

Fix for bug: https://bugs.launchpad.net/juju-core/+bug/1478660
Previously reviewed for 1.25: http://reviews.vapour.ws/r/2267/

Conflicts:
	container/lxc/export_test.go
	container/lxc/lxc.go
	container/lxc/lxc_test.go

(Review request: http://reviews.vapour.ws/r/2293/)