### PR TITLE
Add a Juju-level status for workload processes.

### DIFF
--- a/featuretests/processes_test.go
+++ b/featuretests/processes_test.go
@@ -146,8 +146,7 @@ func (s *processesHookContextSuite) TestHookLifecycle(c *gc.C) {
 		},
 		Status: process.Status{
 			State:   process.StateRunning,
-			Failed:  false,
-			Error:   false,
+			Blocker: "",
 			Message: "",
 		},
 		Details: process.Details{
@@ -225,8 +224,7 @@ func (s *processesHookContextSuite) TestRegister(c *gc.C) {
 		},
 		Status: process.Status{
 			State:   process.StateRunning,
-			Failed:  false,
-			Error:   false,
+			Blocker: "",
 			Message: "",
 		},
 		Details: process.Details{
@@ -283,8 +281,7 @@ func (s *processesHookContextSuite) TestLaunch(c *gc.C) {
 		},
 		Status: process.Status{
 			State:   process.StateRunning,
-			Failed:  false,
-			Error:   false,
+			Blocker: "",
 			Message: "",
 		},
 		Details: process.Details{
@@ -345,8 +342,7 @@ func (s *processesHookContextSuite) TestInfo(c *gc.C) {
 		},
 		Status: process.Status{
 			State:   process.StateRunning,
-			Failed:  false,
-			Error:   false,
+			Blocker: "",
 			Message: "",
 		},
 		Details: process.Details{

--- a/featuretests/processes_test.go
+++ b/featuretests/processes_test.go
@@ -153,7 +153,7 @@ func (s *processesHookContextSuite) TestHookLifecycle(c *gc.C) {
 		Details: process.Details{
 			ID: "xyz123",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}})
@@ -232,7 +232,7 @@ func (s *processesHookContextSuite) TestRegister(c *gc.C) {
 		Details: process.Details{
 			ID: "xyz123",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}})
@@ -290,7 +290,7 @@ func (s *processesHookContextSuite) TestLaunch(c *gc.C) {
 		Details: process.Details{
 			ID: "xyz123",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}})
@@ -352,7 +352,7 @@ func (s *processesHookContextSuite) TestInfo(c *gc.C) {
 		Details: process.Details{
 			ID: "xyz123",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}})

--- a/featuretests/processes_test.go
+++ b/featuretests/processes_test.go
@@ -144,6 +144,12 @@ func (s *processesHookContextSuite) TestHookLifecycle(c *gc.C) {
 				"IMPORTANT": "some value",
 			},
 		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Failed:  false,
+			Error:   false,
+			Message: "",
+		},
 		Details: process.Details{
 			ID: "xyz123",
 			Status: process.PluginStatus{
@@ -217,6 +223,12 @@ func (s *processesHookContextSuite) TestRegister(c *gc.C) {
 				"IMPORTANT": "some value",
 			},
 		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Failed:  false,
+			Error:   false,
+			Message: "",
+		},
 		Details: process.Details{
 			ID: "xyz123",
 			Status: process.PluginStatus{
@@ -268,6 +280,12 @@ func (s *processesHookContextSuite) TestLaunch(c *gc.C) {
 			EnvVars: map[string]string{
 				"IMPORTANT": "some value",
 			},
+		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Failed:  false,
+			Error:   false,
+			Message: "",
 		},
 		Details: process.Details{
 			ID: "xyz123",
@@ -324,6 +342,12 @@ func (s *processesHookContextSuite) TestInfo(c *gc.C) {
 			EnvVars: map[string]string{
 				"IMPORTANT": "some value",
 			},
+		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Failed:  false,
+			Error:   false,
+			Message: "",
 		},
 		Details: process.Details{
 			ID: "xyz123",

--- a/process/api/client/hookcontext.go
+++ b/process/api/client/hookcontext.go
@@ -75,11 +75,14 @@ func (c HookContextClient) ListProcesses(ids ...string) ([]api.ListProcessResult
 }
 
 // SetProcessesStatus calls the SetProcessesStatus API server method.
-func (c HookContextClient) SetProcessesStatus(status string, ids ...string) error {
+func (c HookContextClient) SetProcessesStatus(status process.Status, pluginStatus process.PluginStatus, ids ...string) error {
 	statusArgs := make([]api.SetProcessStatusArg, len(ids))
 	for i, id := range ids {
-		procStatus := api.ProcessStatus{Label: status}
-		statusArgs[i] = api.SetProcessStatusArg{ID: id, Status: procStatus}
+		statusArgs[i] = api.SetProcessStatusArg{
+			ID:           id,
+			Status:       api.Status2apiStatus(status),
+			PluginStatus: api.PluginStatus2apiPluginStatus(pluginStatus),
+		}
 	}
 
 	args := api.SetProcessesStatusArgs{Args: statusArgs}

--- a/process/api/client/hookcontext_test.go
+++ b/process/api/client/hookcontext_test.go
@@ -55,7 +55,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 		Details: api.ProcessDetails{
 			ID: "idfoo",
 			Status: api.PluginStatus{
-				Label: "process status",
+				State: "process status",
 			},
 		},
 	}
@@ -170,7 +170,7 @@ func (s *clientSuite) TestSetProcessesStatus(c *gc.C) {
 				Message: "okay",
 			},
 			PluginStatus: api.PluginStatus{
-				Label: "Running",
+				State: "Running",
 			},
 		})
 
@@ -183,7 +183,7 @@ func (s *clientSuite) TestSetProcessesStatus(c *gc.C) {
 		Message: "okay",
 	}
 	pluginStatus := process.PluginStatus{
-		Label: "Running",
+		State: "Running",
 	}
 	err := pclient.SetProcessesStatus(status, pluginStatus, "idfoo/bar")
 	c.Assert(err, jc.ErrorIsNil)

--- a/process/api/helpers.go
+++ b/process/api/helpers.go
@@ -69,8 +69,7 @@ func Proc2api(p process.Info) Process {
 func APIStatus2Status(status ProcessStatus) process.Status {
 	return process.Status{
 		State:   status.State,
-		Failed:  status.Failed,
-		Error:   status.Error,
+		Blocker: status.Blocker,
 		Message: status.Message,
 	}
 }
@@ -80,8 +79,7 @@ func APIStatus2Status(status ProcessStatus) process.Status {
 func Status2apiStatus(status process.Status) ProcessStatus {
 	return ProcessStatus{
 		State:   status.State,
-		Failed:  status.Failed,
-		Error:   status.Error,
+		Blocker: status.Blocker,
 		Message: status.Message,
 	}
 }

--- a/process/api/helpers.go
+++ b/process/api/helpers.go
@@ -90,7 +90,7 @@ func Status2apiStatus(status process.Status) ProcessStatus {
 // a process.PluginStatus struct.
 func APIPluginStatus2PluginStatus(status PluginStatus) process.PluginStatus {
 	return process.PluginStatus{
-		Label: status.Label,
+		State: status.State,
 	}
 }
 
@@ -98,7 +98,7 @@ func APIPluginStatus2PluginStatus(status PluginStatus) process.PluginStatus {
 // into an API PluginStatus struct.
 func PluginStatus2apiPluginStatus(status process.PluginStatus) PluginStatus {
 	return PluginStatus{
-		Label: status.Label,
+		State: status.State,
 	}
 }
 

--- a/process/api/helpers.go
+++ b/process/api/helpers.go
@@ -44,9 +44,10 @@ func Definition2api(d charm.Process) ProcessDefinition {
 func API2Proc(p Process) process.Info {
 	return process.Info{
 		Process: API2Definition(p.Definition),
+		Status:  APIStatus2Status(p.Status),
 		Details: process.Details{
 			ID:     p.Details.ID,
-			Status: APIStatus2Status(p.Details.Status),
+			Status: APIPluginStatus2PluginStatus(p.Details.Status),
 		},
 	}
 }
@@ -55,25 +56,48 @@ func API2Proc(p Process) process.Info {
 func Proc2api(p process.Info) Process {
 	return Process{
 		Definition: Definition2api(p.Process),
+		Status:     Status2apiStatus(p.Status),
 		Details: ProcessDetails{
 			ID:     p.Details.ID,
-			Status: Status2apiStatus(p.Details.Status),
+			Status: PluginStatus2apiPluginStatus(p.Details.Status),
 		},
 	}
 }
 
 // APIStatus2Status converts an API ProcessStatus struct into a
 // process.Status struct.
-func APIStatus2Status(status ProcessStatus) process.PluginStatus {
-	return process.PluginStatus{
-		Label: status.Label,
+func APIStatus2Status(status ProcessStatus) process.Status {
+	return process.Status{
+		State:   status.State,
+		Failed:  status.Failed,
+		Error:   status.Error,
+		Message: status.Message,
 	}
 }
 
 // Status2APIStatus converts a process.Status struct into an
 // API ProcessStatus struct.
-func Status2apiStatus(status process.PluginStatus) ProcessStatus {
+func Status2apiStatus(status process.Status) ProcessStatus {
 	return ProcessStatus{
+		State:   status.State,
+		Failed:  status.Failed,
+		Error:   status.Error,
+		Message: status.Message,
+	}
+}
+
+// APIPluginStatus2PluginStatus converts an API PluginStatus struct into
+// a process.PluginStatus struct.
+func APIPluginStatus2PluginStatus(status PluginStatus) process.PluginStatus {
+	return process.PluginStatus{
+		Label: status.Label,
+	}
+}
+
+// PluginStatus2APIPluginStatus converts a process.PluginStatus struct
+// into an API PluginStatus struct.
+func PluginStatus2apiPluginStatus(status process.PluginStatus) PluginStatus {
+	return PluginStatus{
 		Label: status.Label,
 	}
 }

--- a/process/api/helpers_test.go
+++ b/process/api/helpers_test.go
@@ -35,9 +35,15 @@ func (suite) TestAPI2Proc(c *gc.C) {
 			}},
 			EnvVars: map[string]string{"envfoo": "bar"},
 		},
+		Status: ProcessStatus{
+			State:   process.StateRunning,
+			Failed:  false,
+			Error:   false,
+			Message: "okay",
+		},
 		Details: ProcessDetails{
 			ID: "idfoo",
-			Status: ProcessStatus{
+			Status: PluginStatus{
 				Label: "process status",
 			},
 		},
@@ -75,6 +81,12 @@ func (suite) TestProc2API(c *gc.C) {
 				},
 			},
 			EnvVars: map[string]string{"envfoo": "bar"},
+		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Failed:  false,
+			Error:   false,
+			Message: "okay",
 		},
 		Details: process.Details{
 			ID: "idfoo",

--- a/process/api/helpers_test.go
+++ b/process/api/helpers_test.go
@@ -44,7 +44,7 @@ func (suite) TestAPI2Proc(c *gc.C) {
 		Details: ProcessDetails{
 			ID: "idfoo",
 			Status: PluginStatus{
-				Label: "process status",
+				State: "process status",
 			},
 		},
 	}
@@ -91,7 +91,7 @@ func (suite) TestProc2API(c *gc.C) {
 		Details: process.Details{
 			ID: "idfoo",
 			Status: process.PluginStatus{
-				Label: "process status",
+				State: "process status",
 			},
 		},
 	}

--- a/process/api/helpers_test.go
+++ b/process/api/helpers_test.go
@@ -37,8 +37,7 @@ func (suite) TestAPI2Proc(c *gc.C) {
 		},
 		Status: ProcessStatus{
 			State:   process.StateRunning,
-			Failed:  false,
-			Error:   false,
+			Blocker: "",
 			Message: "okay",
 		},
 		Details: ProcessDetails{
@@ -84,8 +83,7 @@ func (suite) TestProc2API(c *gc.C) {
 		},
 		Status: process.Status{
 			State:   process.StateRunning,
-			Failed:  false,
-			Error:   false,
+			Blocker: "",
 			Message: "okay",
 		},
 		Details: process.Details{

--- a/process/api/server-args.go
+++ b/process/api/server-args.go
@@ -153,12 +153,9 @@ type ProcessVolume struct {
 type ProcessStatus struct {
 	// State is the Juju-defined state the process is in.
 	State string
-	// Failed indicates that Juju could not interact with the plugin
-	// for the process.
-	Failed bool
-	// Error indicates that the plugin for the process reported that the
-	// process has an error.
-	Error bool
+	// Blocker identifies the kind of blocker preventing interaction
+	// with the process.
+	Blocker string
 	// Message is the human-readable information about the status of
 	// the process.
 	Message string

--- a/process/api/server-args.go
+++ b/process/api/server-args.go
@@ -174,7 +174,7 @@ type ProcessDetails struct {
 
 // PluginStatus represents the plugin-defined status for the process.
 type PluginStatus struct {
-	// Label represents the human-readable label returned by the plugin for
+	// State represents the human-readable label returned by the plugin for
 	// the process that represents the status of the workload process.
-	Label string
+	State string
 }

--- a/process/api/server-args.go
+++ b/process/api/server-args.go
@@ -82,8 +82,10 @@ type SetProcessesStatusArgs struct {
 type SetProcessStatusArg struct {
 	// ID is the ID of the process.
 	ID string
-	// status is the status of the process.
+	// Status is the status of the process.
 	Status ProcessStatus
+	// PluginStatus is the plugin-provided status of the process.
+	PluginStatus PluginStatus
 }
 
 // UnregisterProcessesArgs are the arguments for the UnregisterProcesses endpoint.
@@ -96,6 +98,8 @@ type UnregisterProcessesArgs struct {
 type Process struct {
 	// Process is information about the process itself.
 	Definition ProcessDefinition
+	// Status is the Juju-level status for the process.
+	Status ProcessStatus
 	// Details are the information returned from starting the process.
 	Details ProcessDetails
 }
@@ -145,16 +149,31 @@ type ProcessVolume struct {
 	Name string
 }
 
+// ProcessStatus represents the Juju-level status of the process.
+type ProcessStatus struct {
+	// State is the Juju-defined state the process is in.
+	State string
+	// Failed indicates that Juju could not interact with the plugin
+	// for the process.
+	Failed bool
+	// Error indicates that the plugin for the process reported that the
+	// process has an error.
+	Error bool
+	// Message is the human-readable information about the status of
+	// the process.
+	Message string
+}
+
 // ProcessDetails represents information about a process launched by a plugin.
 type ProcessDetails struct {
 	// ID is a unique string identifying the process to the plugin.
 	ID string
 	// Status is the status of the process after launch.
-	Status ProcessStatus
+	Status PluginStatus
 }
 
-// ProcessStatus represents the data returned from the Status call.
-type ProcessStatus struct {
+// PluginStatus represents the plugin-defined status for the process.
+type PluginStatus struct {
 	// Label represents the human-readable label returned by the plugin for
 	// the process that represents the status of the workload process.
 	Label string

--- a/process/api/server/hookcontext.go
+++ b/process/api/server/hookcontext.go
@@ -28,7 +28,7 @@ type UnitProcesses interface {
 	// unit's metadata.
 	ListDefinitions() ([]charm.Process, error)
 	// Settatus sets the status for the process with the given id on the unit.
-	SetStatus(id string, status process.PluginStatus) error
+	SetStatus(info process.Info) error
 	// Remove removes the information for the process with the given id.
 	Remove(id string) error
 }
@@ -134,8 +134,11 @@ func (a HookContextAPI) SetProcessesStatus(args api.SetProcessesStatusArgs) (api
 		res := api.ProcessResult{
 			ID: arg.ID,
 		}
-		status := api.APIPluginStatus2PluginStatus(arg.PluginStatus)
-		err := a.State.SetStatus(arg.ID, status)
+		var info process.Info
+		info.Name, info.Details.ID = process.ParseID(arg.ID)
+		info.Status = api.APIStatus2Status(arg.Status)
+		info.Details.Status = api.APIPluginStatus2PluginStatus(arg.PluginStatus)
+		err := a.State.SetStatus(info)
 		if err != nil {
 			res.Error = common.ServerError(err)
 			r.Error = common.ServerError(api.BulkFailure)

--- a/process/api/server/hookcontext.go
+++ b/process/api/server/hookcontext.go
@@ -28,7 +28,7 @@ type UnitProcesses interface {
 	// unit's metadata.
 	ListDefinitions() ([]charm.Process, error)
 	// Settatus sets the status for the process with the given id on the unit.
-	SetStatus(info process.Info) error
+	SetStatus(id string, status process.CombinedStatus) error
 	// Remove removes the information for the process with the given id.
 	Remove(id string) error
 }
@@ -134,11 +134,10 @@ func (a HookContextAPI) SetProcessesStatus(args api.SetProcessesStatusArgs) (api
 		res := api.ProcessResult{
 			ID: arg.ID,
 		}
-		var info process.Info
-		info.Name, info.Details.ID = process.ParseID(arg.ID)
-		info.Status = api.APIStatus2Status(arg.Status)
-		info.Details.Status = api.APIPluginStatus2PluginStatus(arg.PluginStatus)
-		err := a.State.SetStatus(info)
+		err := a.State.SetStatus(arg.ID, process.CombinedStatus{
+			Status:       api.APIStatus2Status(arg.Status),
+			PluginStatus: api.APIPluginStatus2PluginStatus(arg.PluginStatus),
+		})
 		if err != nil {
 			res.Error = common.ServerError(err)
 			r.Error = common.ServerError(api.BulkFailure)

--- a/process/api/server/hookcontext.go
+++ b/process/api/server/hookcontext.go
@@ -134,7 +134,7 @@ func (a HookContextAPI) SetProcessesStatus(args api.SetProcessesStatusArgs) (api
 		res := api.ProcessResult{
 			ID: arg.ID,
 		}
-		status := api.APIStatus2Status(arg.Status)
+		status := api.APIPluginStatus2PluginStatus(arg.PluginStatus)
 		err := a.State.SetStatus(arg.ID, status)
 		if err != nil {
 			res.Error = common.ServerError(err)

--- a/process/api/server/hookcontext_test.go
+++ b/process/api/server/hookcontext_test.go
@@ -368,19 +368,14 @@ func (suite) TestSetProcessStatus(c *gc.C) {
 	res, err := a.SetProcessesStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(st.info, jc.DeepEquals, process.Info{
-		Process: charm.Process{
-			Name: "fooID",
-		},
+	c.Check(st.id, gc.Equals, "fooID/bar")
+	c.Assert(st.status, jc.DeepEquals, process.CombinedStatus{
 		Status: process.Status{
 			State:   process.StateRunning,
 			Message: "okay",
 		},
-		Details: process.Details{
-			ID: "bar",
-			Status: process.PluginStatus{
-				State: "statusfoo",
-			},
+		PluginStatus: process.PluginStatus{
+			State: "statusfoo",
 		},
 	})
 
@@ -415,8 +410,9 @@ func (suite) TestUnregisterProcesses(c *gc.C) {
 
 type FakeState struct {
 	// inputs
-	id  string
-	ids []string
+	id     string
+	ids    []string
+	status process.CombinedStatus
 
 	// info is used as input and output
 	info process.Info
@@ -441,8 +437,9 @@ func (f *FakeState) ListDefinitions() ([]charm.Process, error) {
 	return f.defs, f.err
 }
 
-func (f *FakeState) SetStatus(info process.Info) error {
-	f.info = info
+func (f *FakeState) SetStatus(id string, status process.CombinedStatus) error {
+	f.id = id
+	f.status = status
 	return f.err
 }
 

--- a/process/api/server/hookcontext_test.go
+++ b/process/api/server/hookcontext_test.go
@@ -42,9 +42,13 @@ func (suite) TestRegisterProcess(c *gc.C) {
 				}},
 				EnvVars: map[string]string{"envfoo": "bar"},
 			},
+			Status: api.ProcessStatus{
+				State:   process.StateRunning,
+				Message: "okay",
+			},
 			Details: api.ProcessDetails{
 				ID: "idfoo",
-				Status: api.ProcessStatus{
+				Status: api.PluginStatus{
 					Label: "running",
 				},
 			},
@@ -88,6 +92,10 @@ func (suite) TestRegisterProcess(c *gc.C) {
 			},
 			EnvVars: map[string]string{"envfoo": "bar"},
 		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Message: "okay",
+		},
 		Details: process.Details{
 			ID: "idfoo",
 			Status: process.PluginStatus{
@@ -124,6 +132,10 @@ func (suite) TestListProcessesOne(c *gc.C) {
 				},
 			},
 			EnvVars: map[string]string{"envfoo": "bar"},
+		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Message: "okay",
 		},
 		Details: process.Details{
 			ID: "idfoo",
@@ -165,9 +177,13 @@ func (suite) TestListProcessesOne(c *gc.C) {
 			},
 			EnvVars: map[string]string{"envfoo": "bar"},
 		},
+		Status: api.ProcessStatus{
+			State:   process.StateRunning,
+			Message: "okay",
+		},
 		Details: api.ProcessDetails{
 			ID: "idfoo",
-			Status: api.ProcessStatus{
+			Status: api.PluginStatus{
 				Label: "running",
 			},
 		},
@@ -210,6 +226,10 @@ func (suite) TestListProcessesAll(c *gc.C) {
 			},
 			EnvVars: map[string]string{"envfoo": "bar"},
 		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Message: "okay",
+		},
 		Details: process.Details{
 			ID: "idfoo",
 			Status: process.PluginStatus{
@@ -248,9 +268,13 @@ func (suite) TestListProcessesAll(c *gc.C) {
 			},
 			EnvVars: map[string]string{"envfoo": "bar"},
 		},
+		Status: api.ProcessStatus{
+			State:   process.StateRunning,
+			Message: "okay",
+		},
 		Details: api.ProcessDetails{
 			ID: "idfoo",
-			Status: api.ProcessStatus{
+			Status: api.PluginStatus{
 				Label: "running",
 			},
 		},
@@ -333,6 +357,10 @@ func (suite) TestSetProcessStatus(c *gc.C) {
 		Args: []api.SetProcessStatusArg{{
 			ID: "fooID",
 			Status: api.ProcessStatus{
+				State:   process.StateRunning,
+				Message: "okay",
+			},
+			PluginStatus: api.PluginStatus{
 				Label: "statusfoo",
 			},
 		}},

--- a/process/api/server/hookcontext_test.go
+++ b/process/api/server/hookcontext_test.go
@@ -49,7 +49,7 @@ func (suite) TestRegisterProcess(c *gc.C) {
 			Details: api.ProcessDetails{
 				ID: "idfoo",
 				Status: api.PluginStatus{
-					Label: "running",
+					State: "running",
 				},
 			},
 		}},
@@ -99,7 +99,7 @@ func (suite) TestRegisterProcess(c *gc.C) {
 		Details: process.Details{
 			ID: "idfoo",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}
@@ -140,7 +140,7 @@ func (suite) TestListProcessesOne(c *gc.C) {
 		Details: process.Details{
 			ID: "idfoo",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}
@@ -184,7 +184,7 @@ func (suite) TestListProcessesOne(c *gc.C) {
 		Details: api.ProcessDetails{
 			ID: "idfoo",
 			Status: api.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}
@@ -233,7 +233,7 @@ func (suite) TestListProcessesAll(c *gc.C) {
 		Details: process.Details{
 			ID: "idfoo",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}
@@ -275,7 +275,7 @@ func (suite) TestListProcessesAll(c *gc.C) {
 		Details: api.ProcessDetails{
 			ID: "idfoo",
 			Status: api.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}
@@ -361,7 +361,7 @@ func (suite) TestSetProcessStatus(c *gc.C) {
 				Message: "okay",
 			},
 			PluginStatus: api.PluginStatus{
-				Label: "statusfoo",
+				State: "statusfoo",
 			},
 		}},
 	}
@@ -379,7 +379,7 @@ func (suite) TestSetProcessStatus(c *gc.C) {
 		Details: process.Details{
 			ID: "bar",
 			Status: process.PluginStatus{
-				Label: "statusfoo",
+				State: "statusfoo",
 			},
 		},
 	})

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -34,7 +34,7 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *baseSuite) newProc(name, ptype, id, status string) *process.Info {
-	return &process.Info{
+	info := &process.Info{
 		Process: charm.Process{
 			Name: name,
 			Type: ptype,
@@ -46,6 +46,12 @@ func (s *baseSuite) newProc(name, ptype, id, status string) *process.Info {
 			},
 		},
 	}
+	if status != "" {
+		info.Status = process.Status{
+			State: process.StateRunning,
+		}
+	}
+	return info
 }
 
 func (s *baseSuite) NewHookContext() (*stubHookContext, *jujuctesting.ContextInfo) {
@@ -188,6 +194,9 @@ func (c *stubAPIClient) setNew(ids ...string) []*process.Info {
 			Process: charm.Process{
 				Name: name,
 				Type: "myplugin",
+			},
+			Status: process.Status{
+				State: process.StateRunning,
 			},
 			Details: process.Details{
 				ID: pluginID,

--- a/process/context/base_test.go
+++ b/process/context/base_test.go
@@ -42,7 +42,7 @@ func (s *baseSuite) newProc(name, ptype, id, status string) *process.Info {
 		Details: process.Details{
 			ID: id,
 			Status: process.PluginStatus{
-				Label: status,
+				State: status,
 			},
 		},
 	}
@@ -201,7 +201,7 @@ func (c *stubAPIClient) setNew(ids ...string) []*process.Info {
 			Details: process.Details{
 				ID: pluginID,
 				Status: process.PluginStatus{
-					Label: "okay",
+					State: "okay",
 				},
 			},
 		}

--- a/process/context/command.go
+++ b/process/context/command.go
@@ -233,6 +233,9 @@ func (c *baseCommand) idsForName(name string) ([]string, error) {
 type registeringCommand struct {
 	baseCommand
 
+	// Status is the juju-level status to set for the process.
+	Status process.Status
+
 	// Details is the launch details returned from the process plugin.
 	Details process.Details
 
@@ -287,6 +290,11 @@ func (c *registeringCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	c.Status = process.Status{
+		State: process.StateRunning,
+		// TODO(ericsnow) Set a default Message?
+	}
+
 	return nil
 }
 
@@ -299,6 +307,7 @@ func (c *registeringCommand) register(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	info.Status = c.Status
 	info.Details = c.Details
 
 	logger.Tracef("registering %#v", info)

--- a/process/context/export_test.go
+++ b/process/context/export_test.go
@@ -49,6 +49,8 @@ func GetCmdInfo(cmd cmd.Command) *process.Info {
 	switch cmd := cmd.(type) {
 	case *ProcRegistrationCommand:
 		return cmd.info
+	case *ProcLaunchCommand:
+		return cmd.info
 	default:
 		return nil
 	}

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -165,6 +165,7 @@ myprocess0/xyz123:
   status:
     state: ""
     failed: false
+    error: false
     message: ""
   details:
     id: xyz123
@@ -198,6 +199,7 @@ myprocess0/xyz123:
   status:
     state: ""
     failed: false
+    error: false
     message: ""
   details:
     id: xyz123
@@ -217,6 +219,7 @@ myprocess1/xyz456:
   status:
     state: ""
     failed: false
+    error: false
     message: ""
   details:
     id: xyz456
@@ -236,6 +239,7 @@ myprocess2/xyz789:
   status:
     state: ""
     failed: false
+    error: false
     message: ""
   details:
     id: xyz789
@@ -269,6 +273,7 @@ myprocess0/xyz123:
   status:
     state: ""
     failed: false
+    error: false
     message: ""
   details:
     id: xyz123

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -30,7 +30,7 @@ var (
 		Details: process.Details{
 			ID: "xyz123",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}
@@ -44,7 +44,7 @@ var (
 		Details: process.Details{
 			ID: "xyz456",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}
@@ -56,7 +56,7 @@ var (
 		Details: process.Details{
 			ID: "xyz789",
 			Status: process.PluginStatus{
-				Label: "invalid",
+				State: "invalid",
 			},
 		},
 	}
@@ -170,7 +170,7 @@ myprocess0/xyz123:
   details:
     id: xyz123
     status:
-      label: running
+      state: running
 `[1:]
 	s.checkRun(c, expected, "")
 	s.Stub.CheckCallNames(c, "Get")
@@ -204,7 +204,7 @@ myprocess0/xyz123:
   details:
     id: xyz123
     status:
-      label: running
+      state: running
 myprocess1/xyz456:
   process:
     name: myprocess1
@@ -224,7 +224,7 @@ myprocess1/xyz456:
   details:
     id: xyz456
     status:
-      label: running
+      state: running
 myprocess2/xyz789:
   process:
     name: myprocess2
@@ -244,7 +244,7 @@ myprocess2/xyz789:
   details:
     id: xyz789
     status:
-      label: invalid
+      state: invalid
 `[1:]
 	s.checkRun(c, expected, "")
 	s.Stub.CheckCallNames(c, "List", "Get", "Get", "Get")
@@ -278,7 +278,7 @@ myprocess0/xyz123:
   details:
     id: xyz123
     status:
-      label: running
+      state: running
 `[1:]
 	s.checkRun(c, expected, "")
 	s.Stub.CheckCallNames(c, "List", "Get")

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -162,6 +162,10 @@ myprocess0/xyz123:
     volumes: []
     envvars:
       ENV_VAR: some value
+  status:
+    state: ""
+    failed: false
+    message: ""
   details:
     id: xyz123
     status:
@@ -191,6 +195,10 @@ myprocess0/xyz123:
     volumes: []
     envvars:
       ENV_VAR: some value
+  status:
+    state: ""
+    failed: false
+    message: ""
   details:
     id: xyz123
     status:
@@ -206,6 +214,10 @@ myprocess1/xyz456:
     ports: []
     volumes: []
     envvars: {}
+  status:
+    state: ""
+    failed: false
+    message: ""
   details:
     id: xyz456
     status:
@@ -221,6 +233,10 @@ myprocess2/xyz789:
     ports: []
     volumes: []
     envvars: {}
+  status:
+    state: ""
+    failed: false
+    message: ""
   details:
     id: xyz789
     status:
@@ -250,6 +266,10 @@ myprocess0/xyz123:
     volumes: []
     envvars:
       ENV_VAR: some value
+  status:
+    state: ""
+    failed: false
+    message: ""
   details:
     id: xyz123
     status:

--- a/process/context/info_test.go
+++ b/process/context/info_test.go
@@ -164,8 +164,7 @@ myprocess0/xyz123:
       ENV_VAR: some value
   status:
     state: ""
-    failed: false
-    error: false
+    blocker: ""
     message: ""
   details:
     id: xyz123
@@ -198,8 +197,7 @@ myprocess0/xyz123:
       ENV_VAR: some value
   status:
     state: ""
-    failed: false
-    error: false
+    blocker: ""
     message: ""
   details:
     id: xyz123
@@ -218,8 +216,7 @@ myprocess1/xyz456:
     envvars: {}
   status:
     state: ""
-    failed: false
-    error: false
+    blocker: ""
     message: ""
   details:
     id: xyz456
@@ -238,8 +235,7 @@ myprocess2/xyz789:
     envvars: {}
   status:
     state: ""
-    failed: false
-    error: false
+    blocker: ""
     message: ""
   details:
     id: xyz789
@@ -272,8 +268,7 @@ myprocess0/xyz123:
       ENV_VAR: some value
   status:
     state: ""
-    failed: false
-    error: false
+    blocker: ""
     message: ""
   details:
     id: xyz123

--- a/process/context/launch.go
+++ b/process/context/launch.go
@@ -90,6 +90,9 @@ func (c *ProcLaunchCommand) Run(ctx *cmd.Context) error {
 	}
 	c.Details = procDetails
 
+	// TODO(ericsnow) Register the proc even if it fails?
+	//  (e.g. set a status with a "failed" state)
+
 	if err := c.register(ctx); err != nil {
 		return errors.Trace(err)
 	}

--- a/process/context/launch_test.go
+++ b/process/context/launch_test.go
@@ -54,7 +54,7 @@ func (s *launchCmdSuite) TestRun(c *gc.C) {
 		return process.Details{
 			ID: "id",
 			Status: process.PluginStatus{
-				Label: "foo",
+				State: "foo",
 			},
 		}, nil
 	}

--- a/process/context/register.go
+++ b/process/context/register.go
@@ -25,6 +25,8 @@ the charm's metadata.yaml.
 `,
 }
 
+// TODO(ericsnow) Also support setting the juju-level status?
+
 // ProcRegistrationCommand implements the register command.
 type ProcRegistrationCommand struct {
 	registeringCommand

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -35,12 +35,12 @@ func (s *registerSuite) SetUpTest(c *gc.C) {
 func (s *registerSuite) init(c *gc.C, name, id, status string) {
 	err := s.registerCmd.Init([]string{
 		name,
-		`{"id":"` + id + `", "status":{"label":"` + status + `"}}`,
+		`{"id":"` + id + `", "status":{"state":"` + status + `"}}`,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.details = process.Details{
 		ID:     id,
-		Status: process.PluginStatus{Label: status},
+		Status: process.PluginStatus{State: status},
 	}
 }
 
@@ -79,14 +79,14 @@ the charm's metadata.yaml.
 func (s *registerSuite) TestInitAllArgs(c *gc.C) {
 	err := s.registerCmd.Init([]string{
 		s.proc.Name,
-		`{"id":"abc123", "status":{"label":"okay"}}`,
+		`{"id":"abc123", "status":{"state":"okay"}}`,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.registerCmd.Name, gc.Equals, s.proc.Name)
 	c.Check(s.registerCmd.Details, jc.DeepEquals, process.Details{
 		ID:     "abc123",
-		Status: process.PluginStatus{Label: "okay"},
+		Status: process.PluginStatus{State: "okay"},
 	})
 }
 
@@ -101,7 +101,7 @@ func (s *registerSuite) TestInitTooFewArgs(c *gc.C) {
 func (s *registerSuite) TestInitTooManyArgs(c *gc.C) {
 	err := s.registerCmd.Init([]string{
 		s.proc.Name,
-		`{"id":"abc123", "status":{"label":"okay"}}`,
+		`{"id":"abc123", "status":{"state":"okay"}}`,
 		"other",
 	})
 
@@ -129,7 +129,7 @@ func (s *registerSuite) TestInitEmptyID(c *gc.C) {
 func (s *registerSuite) TestInitMissingDetailsID(c *gc.C) {
 	err := s.registerCmd.Init([]string{
 		s.proc.Name,
-		`{"status":{"label":"okay"}}`,
+		`{"status":{"state":"okay"}}`,
 	})
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
@@ -147,7 +147,7 @@ func (s *registerSuite) TestInitMissingDetailsStatus(c *gc.C) {
 func (s *registerSuite) TestInitBadJSON(c *gc.C) {
 	err := s.registerCmd.Init([]string{
 		s.proc.Name,
-		`{"id":"abc123", "status":{"label":"okay"}`,
+		`{"id":"abc123", "status":{"state":"okay"}`,
 	})
 
 	c.Check(errors.Cause(err), gc.ErrorMatches, "unexpected end of JSON input")

--- a/process/context/register_test.go
+++ b/process/context/register_test.go
@@ -165,6 +165,7 @@ func (s *registerSuite) TestOverridesWithoutSubfield(c *gc.C) {
 	def.Description = "foo"
 	s.checkRunInfo(c, *s.proc, process.Info{
 		Process: def,
+		Status:  process.Status{State: process.StateRunning},
 		Details: s.details,
 	})
 }
@@ -181,6 +182,7 @@ func (s *registerSuite) TestOverridesWithSubfield(c *gc.C) {
 	def.EnvVars = map[string]string{"foo": "baz"}
 	s.checkRunInfo(c, *s.proc, process.Info{
 		Process: def,
+		Status:  process.Status{State: process.StateRunning},
 		Details: s.details,
 	})
 }
@@ -233,6 +235,7 @@ func (s *registerSuite) TestAdditionsWithoutSubfield(c *gc.C) {
 	def.Description = "foo"
 	s.checkRunInfo(c, *s.proc, process.Info{
 		Process: def,
+		Status:  process.Status{State: process.StateRunning},
 		Details: s.details,
 	})
 }
@@ -248,6 +251,7 @@ func (s *registerSuite) TestAdditionsWithSubfield(c *gc.C) {
 	def.EnvVars = map[string]string{"foo": "baz"}
 	s.checkRunInfo(c, *s.proc, process.Info{
 		Process: def,
+		Status:  process.Status{State: process.StateRunning},
 		Details: s.details,
 	})
 }
@@ -315,6 +319,7 @@ func (s *registerSuite) TestRunUpdatedProcess(c *gc.C) {
 	s.checkRun(c, "", "")
 
 	s.proc.Process = *s.registerCmd.UpdatedProcess
+	s.proc.Status.State = process.StateRunning
 	s.proc.Details = s.details
 	s.Stub.CheckCalls(c, []testing.StubCall{{
 		FuncName: "List",

--- a/process/info.go
+++ b/process/info.go
@@ -53,6 +53,10 @@ func (info Info) Validate() error {
 		return errors.Trace(err)
 	}
 
+	if err := info.Status.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+
 	if err := info.Details.Validate(); err != nil {
 		return errors.Trace(err)
 	}

--- a/process/info.go
+++ b/process/info.go
@@ -22,6 +22,9 @@ import (
 type Info struct {
 	charm.Process
 
+	// Status is the Juju-level status of the process.
+	Status Status
+
 	// Details is the information about the process which the plugin provided.
 	Details Details
 }

--- a/process/info.go
+++ b/process/info.go
@@ -50,7 +50,7 @@ func ParseID(id string) (string, string) {
 // Validate checks the process info to ensure it is correct.
 func (info Info) Validate() error {
 	if err := info.Process.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.NewNotValid(err, "")
 	}
 
 	if err := info.Status.Validate(); err != nil {

--- a/process/info_test.go
+++ b/process/info_test.go
@@ -4,6 +4,7 @@
 package process_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
@@ -72,6 +73,7 @@ func (s *infoSuite) TestParseIDExtras(c *gc.C) {
 
 func (s *infoSuite) TestValidateOkay(c *gc.C) {
 	info := s.newInfo("a proc", "docker")
+	info.Status.State = process.StateRunning
 	info.Details.ID = "my-proc"
 	info.Details.Status.Label = "running"
 	err := info.Validate()
@@ -83,14 +85,24 @@ func (s *infoSuite) TestValidateBadMetadata(c *gc.C) {
 	info := s.newInfo("a proc", "")
 	err := info.Validate()
 
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, ".*type: name is required")
+}
+
+func (s *infoSuite) TestValidateBadStatus(c *gc.C) {
+	info := s.newInfo("a proc", "docker")
+	err := info.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (s *infoSuite) TestValidateBadDetails(c *gc.C) {
 	info := s.newInfo("a proc", "docker")
+	info.Status.State = process.StateRunning
 	info.Details.ID = "my-proc"
 	err := info.Validate()
 
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, ".*Label cannot be empty.*")
 }
 

--- a/process/info_test.go
+++ b/process/info_test.go
@@ -75,7 +75,7 @@ func (s *infoSuite) TestValidateOkay(c *gc.C) {
 	info := s.newInfo("a proc", "docker")
 	info.Status.State = process.StateRunning
 	info.Details.ID = "my-proc"
-	info.Details.Status.Label = "running"
+	info.Details.Status.State = "running"
 	err := info.Validate()
 
 	c.Check(err, jc.ErrorIsNil)
@@ -103,13 +103,13 @@ func (s *infoSuite) TestValidateBadDetails(c *gc.C) {
 	err := info.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, ".*Label cannot be empty.*")
+	c.Check(err, gc.ErrorMatches, ".*State cannot be empty.*")
 }
 
 func (s *infoSuite) TestIsRegisteredTrue(c *gc.C) {
 	info := s.newInfo("a proc", "docker")
 	info.Details.ID = "abc123"
-	info.Details.Status.Label = "running"
+	info.Details.Status.State = "running"
 	isRegistered := info.IsRegistered()
 
 	c.Check(isRegistered, jc.IsTrue)

--- a/process/persistence/base_test.go
+++ b/process/persistence/base_test.go
@@ -47,9 +47,9 @@ func (s *BaseSuite) NewDoc(proc process.Info) *processDoc {
 		Type: proc.Type,
 
 		PluginID:       proc.Details.ID,
-		OriginalStatus: proc.Details.Status.Label,
+		OriginalStatus: proc.Details.Status.State,
 
-		PluginStatus: proc.Details.Status.Label,
+		PluginStatus: proc.Details.Status.State,
 	}
 }
 
@@ -96,7 +96,7 @@ func (s *BaseSuite) NewProcesses(pType string, ids ...string) []process.Info {
 			Details: process.Details{
 				ID: pluginID,
 				Status: process.PluginStatus{
-					Label: "running",
+					State: "running",
 				},
 			},
 		})

--- a/process/persistence/mongo.go
+++ b/process/persistence/mongo.go
@@ -71,16 +71,15 @@ func (pp Persistence) newInsertProcessOps(info process.Info) []txn.Op {
 	return ops
 }
 
-func (pp Persistence) newSetRawStatusOps(info process.Info) []txn.Op {
+func (pp Persistence) newSetRawStatusOps(id string, status process.CombinedStatus) []txn.Op {
+	id = pp.processID(id)
 	updates := bson.D{
-		{"state", info.Status.State},
-		{"failed", info.Status.Failed},
-		{"error", info.Status.Error},
-		{"status", info.Status.Message},
-		{"pluginstatus", info.Details.Status.State},
+		{"state", status.Status.State},
+		{"failed", status.Status.Failed},
+		{"error", status.Status.Error},
+		{"status", status.Status.Message},
+		{"pluginstatus", status.PluginStatus.State},
 	}
-
-	id := pp.processID(info.ID())
 	return []txn.Op{{
 		C:      workloadProcessesC,
 		Id:     id,

--- a/process/persistence/mongo.go
+++ b/process/persistence/mongo.go
@@ -75,8 +75,7 @@ func (pp Persistence) newSetRawStatusOps(id string, status process.CombinedStatu
 	id = pp.processID(id)
 	updates := bson.D{
 		{"state", status.Status.State},
-		{"failed", status.Status.Failed},
-		{"error", status.Status.Error},
+		{"blocker", status.Status.Blocker},
 		{"status", status.Status.Message},
 		{"pluginstatus", status.PluginStatus.State},
 	}
@@ -115,10 +114,9 @@ type processDoc struct {
 	Volumes     []string          `bson:"volumes"`
 	EnvVars     map[string]string `bson:"envvars"`
 
-	State  string `bson:"state"`
-	Failed bool   `bson:"failed"`
-	Error  bool   `bson:"error"`
-	Status string `bson:"status"`
+	State   string `bson:"state"`
+	Blocker string `bson:"blocker"`
+	Status  string `bson:"status"`
 
 	PluginID       string `bson:"pluginid"`
 	OriginalStatus string `bson:"origstatus"`
@@ -183,8 +181,7 @@ func (d processDoc) definition() charm.Process {
 func (d processDoc) status() process.Status {
 	return process.Status{
 		State:   d.State,
-		Failed:  d.Failed,
-		Error:   d.Error,
+		Blocker: d.Blocker,
 		Message: d.Status,
 	}
 }
@@ -226,10 +223,9 @@ func (pp Persistence) newProcessDoc(info process.Info) *processDoc {
 		Volumes:     volumes,
 		EnvVars:     definition.EnvVars,
 
-		State:  info.Status.State,
-		Failed: info.Status.Failed,
-		Error:  info.Status.Error,
-		Status: info.Status.Message,
+		State:   info.Status.State,
+		Blocker: info.Status.Blocker,
+		Status:  info.Status.Message,
 
 		PluginID:       info.Details.ID,
 		OriginalStatus: info.Details.Status.State,

--- a/process/persistence/mongo.go
+++ b/process/persistence/mongo.go
@@ -77,7 +77,7 @@ func (pp Persistence) newSetRawStatusOps(info process.Info) []txn.Op {
 		{"failed", info.Status.Failed},
 		{"error", info.Status.Error},
 		{"status", info.Status.Message},
-		{"pluginstatus", info.Details.Status.Label},
+		{"pluginstatus", info.Details.Status.State},
 	}
 
 	id := pp.processID(info.ID())
@@ -133,7 +133,7 @@ func (d processDoc) info() process.Info {
 		Status:  d.status(),
 		Details: d.details(),
 	}
-	info.Details.Status.Label = d.PluginStatus
+	info.Details.Status.State = d.PluginStatus
 	return info
 }
 
@@ -194,7 +194,7 @@ func (d processDoc) details() process.Details {
 	return process.Details{
 		ID: d.PluginID,
 		Status: process.PluginStatus{
-			Label: d.OriginalStatus,
+			State: d.OriginalStatus,
 		},
 	}
 }
@@ -233,9 +233,9 @@ func (pp Persistence) newProcessDoc(info process.Info) *processDoc {
 		Status: info.Status.Message,
 
 		PluginID:       info.Details.ID,
-		OriginalStatus: info.Details.Status.Label,
+		OriginalStatus: info.Details.Status.State,
 
-		PluginStatus: info.Details.Status.Label,
+		PluginStatus: info.Details.Status.State,
 	}
 }
 

--- a/process/persistence/processes.go
+++ b/process/persistence/processes.go
@@ -23,7 +23,7 @@ var logger = loggo.GetLogger("juju.process.persistence")
 // in the business logic) with ops factories available from the
 // persistence layer.
 
-// TODO(ericsnow) Move PersistencBase to the components package?
+// TODO(ericsnow) Move PersistenceBase to the components package?
 
 // PersistenceBase exposes the core persistence functionality needed
 // for workload processes.

--- a/process/persistence/processes.go
+++ b/process/persistence/processes.go
@@ -17,9 +17,13 @@ import (
 
 var logger = loggo.GetLogger("juju.process.persistence")
 
+// TODO(ericsnow) Store status in the status collection?
+
 // TODO(ericsnow) Implement persistence using a TXN abstraction (used
 // in the business logic) with ops factories available from the
 // persistence layer.
+
+// TODO(ericsnow) Move PersistencBase to the components package?
 
 // PersistenceBase exposes the core persistence functionality needed
 // for workload processes.
@@ -78,11 +82,13 @@ func (pp Persistence) Insert(info process.Info) (bool, error) {
 // persistence. The return value corresponds to whether or not the
 // record was found in persistence. Any other problem results in
 // an error. The process is not checked for inconsistent records.
-func (pp Persistence) SetStatus(id string, status process.PluginStatus) (bool, error) {
+func (pp Persistence) SetStatus(info process.Info) (bool, error) {
+	logger.Tracef("setting status for %q", info.ID())
+
 	var found bool
 	var ops []txn.Op
 	// TODO(ericsnow) Add unitPersistence.newEnsureAliveOp(pp.unit)?
-	ops = append(ops, pp.newSetRawStatusOps(id, status)...)
+	ops = append(ops, pp.newSetRawStatusOps(info)...)
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			found = false

--- a/process/persistence/processes.go
+++ b/process/persistence/processes.go
@@ -82,13 +82,13 @@ func (pp Persistence) Insert(info process.Info) (bool, error) {
 // persistence. The return value corresponds to whether or not the
 // record was found in persistence. Any other problem results in
 // an error. The process is not checked for inconsistent records.
-func (pp Persistence) SetStatus(info process.Info) (bool, error) {
-	logger.Tracef("setting status for %q", info.ID())
+func (pp Persistence) SetStatus(id string, status process.CombinedStatus) (bool, error) {
+	logger.Tracef("setting status for %q", id)
 
 	var found bool
 	var ops []txn.Op
 	// TODO(ericsnow) Add unitPersistence.newEnsureAliveOp(pp.unit)?
-	ops = append(ops, pp.newSetRawStatusOps(info)...)
+	ops = append(ops, pp.newSetRawStatusOps(id, status)...)
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			found = false

--- a/process/persistence/processes_test.go
+++ b/process/persistence/processes_test.go
@@ -126,8 +126,7 @@ func (s *procsPersistenceSuite) TestSetStatusOkay(c *gc.C) {
 			Update: bson.D{
 				{"$set", bson.D{
 					{"state", process.StateRunning},
-					{"failed", false},
-					{"error", false},
+					{"blocker", ""},
 					{"status", "good to go"},
 					{"pluginstatus", "still running"},
 				}},
@@ -154,8 +153,7 @@ func (s *procsPersistenceSuite) TestSetStatusMissing(c *gc.C) {
 			Update: bson.D{
 				{"$set", bson.D{
 					{"state", process.StateRunning},
-					{"failed", false},
-					{"error", false},
+					{"blocker", ""},
 					{"status", "good to go"},
 					{"pluginstatus", "still running"},
 				}},

--- a/process/persistence/processes_test.go
+++ b/process/persistence/processes_test.go
@@ -103,7 +103,7 @@ func newStatusInfo(id, state, message, pluginStatus string) process.Info {
 		},
 	}
 	info.Name, info.Details.ID = process.ParseID(id)
-	info.Details.Status.Label = pluginStatus
+	info.Details.Status.State = pluginStatus
 	return info
 }
 

--- a/process/plugin/plugin_test.go
+++ b/process/plugin/plugin_test.go
@@ -27,7 +27,7 @@ const exitstatus1 = "exit status 1: "
 
 func (s *suite) TestLaunch(c *gc.C) {
 	f := &fakeRunner{
-		out: []byte(`{ "id" : "foo", "status": { "label" : "bar" } }`),
+		out: []byte(`{ "id" : "foo", "status": { "state" : "bar" } }`),
 	}
 	s.PatchValue(&runCmd, f.runCmd)
 
@@ -39,7 +39,7 @@ func (s *suite) TestLaunch(c *gc.C) {
 	c.Assert(pd, gc.Equals, process.Details{
 		ID: "foo",
 		Status: process.PluginStatus{
-			Label: "bar",
+			State: "bar",
 		},
 	})
 
@@ -105,7 +105,7 @@ func (s *suite) TestLaunchErr(c *gc.C) {
 
 func (s *suite) TestStatus(c *gc.C) {
 	f := &fakeRunner{
-		out: []byte(`{ "label" : "status!" }`),
+		out: []byte(`{ "state" : "status!" }`),
 	}
 	s.PatchValue(&runCmd, f.runCmd)
 
@@ -114,7 +114,7 @@ func (s *suite) TestStatus(c *gc.C) {
 	status, err := p.Status("id")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.Equals, process.PluginStatus{
-		Label: "status!",
+		State: "status!",
 	})
 	c.Assert(f.name, gc.DeepEquals, p.Name)
 	c.Assert(f.cmd.Path, gc.Equals, p.Executable)

--- a/process/state/base_test.go
+++ b/process/state/base_test.go
@@ -97,18 +97,18 @@ func (s *fakeProcsPersistence) Insert(info process.Info) (bool, error) {
 	return true, nil
 }
 
-func (s *fakeProcsPersistence) SetStatus(info process.Info) (bool, error) {
-	s.AddCall("SetStatus", info)
+func (s *fakeProcsPersistence) SetStatus(id string, status process.CombinedStatus) (bool, error) {
+	s.AddCall("SetStatus", id, status)
 	if err := s.NextErr(); err != nil {
 		return false, errors.Trace(err)
 	}
 
-	proc, ok := s.procs[info.ID()]
+	proc, ok := s.procs[id]
 	if !ok {
 		return false, nil
 	}
-	proc.Status = info.Status
-	proc.Details.Status = info.Details.Status
+	proc.Status = status.Status
+	proc.Details.Status = status.PluginStatus
 	return true, nil
 }
 

--- a/process/state/base_test.go
+++ b/process/state/base_test.go
@@ -94,17 +94,18 @@ func (s *fakeProcsPersistence) Insert(info process.Info) (bool, error) {
 	return true, nil
 }
 
-func (s *fakeProcsPersistence) SetStatus(id string, status process.PluginStatus) (bool, error) {
-	s.AddCall("SetStatus", id, status)
+func (s *fakeProcsPersistence) SetStatus(info process.Info) (bool, error) {
+	s.AddCall("SetStatus", info)
 	if err := s.NextErr(); err != nil {
 		return false, errors.Trace(err)
 	}
 
-	proc, ok := s.procs[id]
+	proc, ok := s.procs[info.ID()]
 	if !ok {
 		return false, nil
 	}
-	proc.Details.Status = status
+	proc.Status = info.Status
+	proc.Details.Status = info.Details.Status
 	return true, nil
 }
 

--- a/process/state/base_test.go
+++ b/process/state/base_test.go
@@ -50,7 +50,7 @@ func (s *baseProcessesSuite) newProcesses(pType string, ids ...string) []process
 			Details: process.Details{
 				ID: pluginID,
 				Status: process.PluginStatus{
-					Label: "running",
+					State: "running",
 				},
 			},
 		})

--- a/process/state/base_test.go
+++ b/process/state/base_test.go
@@ -44,6 +44,9 @@ func (s *baseProcessesSuite) newProcesses(pType string, ids ...string) []process
 				Name: name,
 				Type: pType,
 			},
+			Status: process.Status{
+				State: process.StateRunning,
+			},
 			Details: process.Details{
 				ID: pluginID,
 				Status: process.PluginStatus{

--- a/process/state/processes.go
+++ b/process/state/processes.go
@@ -22,7 +22,7 @@ var logger = loggo.GetLogger("juju.process.state")
 // The persistence methods needed for workload processes in state.
 type processesPersistence interface {
 	Insert(info process.Info) (bool, error)
-	SetStatus(info process.Info) (bool, error)
+	SetStatus(id string, status process.CombinedStatus) (bool, error)
 	List(ids ...string) ([]process.Info, []string, error)
 	ListAll() ([]process.Info, error)
 	Remove(id string) (bool, error)
@@ -67,22 +67,20 @@ func (ps UnitProcesses) Add(info process.Info) error {
 	return nil
 }
 
-// TODO(ericsnow) Pass in (ID, status, pluginstatus) instead?
-
 // SetStatus updates the raw status for the identified process to the
 // provided value.
-func (ps UnitProcesses) SetStatus(info process.Info) error {
-	logger.Tracef("setting status for %q", info.ID())
-	if err := info.Status.Validate(); err != nil {
+func (ps UnitProcesses) SetStatus(id string, status process.CombinedStatus) error {
+	logger.Tracef("setting status for %q", id)
+	if err := status.Validate(); err != nil {
 		return errors.Trace(err)
 	}
 
-	found, err := ps.Persist.SetStatus(info)
+	found, err := ps.Persist.SetStatus(id, status)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if !found {
-		return errors.NotFoundf(info.ID())
+		return errors.NotFoundf(id)
 	}
 	return nil
 }

--- a/process/state/processes_test.go
+++ b/process/state/processes_test.go
@@ -72,31 +72,31 @@ func (s *unitProcessesSuite) TestAddAlreadyExists(c *gc.C) {
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
-func newStatusInfo(id, state, message, pluginStatus string) process.Info {
-	info := process.Info{
+func newStatusInfo(state, message, pluginStatus string) process.CombinedStatus {
+	return process.CombinedStatus{
 		Status: process.Status{
 			State:   state,
 			Message: message,
 		},
+		PluginStatus: process.PluginStatus{
+			State: pluginStatus,
+		},
 	}
-	info.Name, info.Details.ID = process.ParseID(id)
-	info.Details.Status.State = pluginStatus
-	return info
 }
 
 func (s *unitProcessesSuite) TestSetStatusOkay(c *gc.C) {
 	proc := s.newProcesses("docker", "procA")[0]
 	s.persist.setProcesses(&proc)
-	info := newStatusInfo(proc.ID(), process.StateRunning, "good to go", "okay")
+	status := newStatusInfo(process.StateRunning, "good to go", "okay")
 
 	ps := state.UnitProcesses{Persist: s.persist}
-	err := ps.SetStatus(info)
+	err := ps.SetStatus(proc.ID(), status)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "SetStatus")
 	current := s.persist.procs[proc.ID()]
-	c.Check(current.Status, jc.DeepEquals, info.Status)
-	c.Check(current.Details.Status, jc.DeepEquals, info.Details.Status)
+	c.Check(current.Status, jc.DeepEquals, status.Status)
+	c.Check(current.Details.Status, jc.DeepEquals, status.PluginStatus)
 }
 
 func (s *unitProcessesSuite) TestSetStatusFailed(c *gc.C) {
@@ -104,19 +104,19 @@ func (s *unitProcessesSuite) TestSetStatusFailed(c *gc.C) {
 	s.stub.SetErrors(failure)
 	proc := s.newProcesses("docker", "procA")[0]
 	s.persist.setProcesses(&proc)
-	info := newStatusInfo(proc.ID(), process.StateRunning, "good to go", "okay")
+	status := newStatusInfo(process.StateRunning, "good to go", "okay")
 
 	ps := state.UnitProcesses{Persist: s.persist}
-	err := ps.SetStatus(info)
+	err := ps.SetStatus(proc.ID(), status)
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 }
 
 func (s *unitProcessesSuite) TestSetStatusMissing(c *gc.C) {
-	info := newStatusInfo("some-proc", process.StateRunning, "good to go", "okay")
+	status := newStatusInfo(process.StateRunning, "good to go", "okay")
 
 	ps := state.UnitProcesses{Persist: s.persist}
-	err := ps.SetStatus(info)
+	err := ps.SetStatus("some/proc", status)
 
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/process/state/processes_test.go
+++ b/process/state/processes_test.go
@@ -80,7 +80,7 @@ func newStatusInfo(id, state, message, pluginStatus string) process.Info {
 		},
 	}
 	info.Name, info.Details.ID = process.ParseID(id)
-	info.Details.Status.Label = pluginStatus
+	info.Details.Status.State = pluginStatus
 	return info
 }
 

--- a/process/status.go
+++ b/process/status.go
@@ -47,7 +47,20 @@ type Status struct {
 	Message string
 }
 
-// TODO(ericsnow) Add a String method.
+// String returns a string representing the status of the process.
+func (s Status) String() string {
+	message := s.Message
+	if message == "" {
+		message = "<no message>"
+	}
+	if s.Failed {
+		return "(failed) " + message
+	}
+	if s.Error {
+		return "(error) " + message
+	}
+	return message
+}
 
 // IsBlocked indicates whether or not the workload process may proceed
 // to the next state.

--- a/process/status.go
+++ b/process/status.go
@@ -7,6 +7,17 @@ import (
 	"github.com/juju/errors"
 )
 
+// The Juju-recognized states in which a workload process might be.
+const (
+	StateUndefined = ""
+	StateDefined   = "defined"
+	StateStarting  = "starting"
+	StateRunning   = "running"
+	StateError     = "error"
+	StateStopping  = "stopping"
+	StateStopped   = "stopped"
+)
+
 // Status is the Juju-level status of a workload process.
 type Status struct {
 	// State is which state the process is in relative to Juju.

--- a/process/status.go
+++ b/process/status.go
@@ -196,16 +196,16 @@ func (s Status) Validate() error {
 
 // PluginStatus represents the data returned from the Plugin.Status call.
 type PluginStatus struct {
-	// Label represents the human-readable label returned by the plugin
+	// State is the human-readable label returned by the plugin
 	// that represents the status of the workload process.
-	Label string `json:"label"`
+	State string `json:"state"`
 }
 
 // Validate returns nil if this value is valid, and an error that satisfies
 // IsValid if it is not.
 func (s PluginStatus) Validate() error {
-	if s.Label == "" {
-		return errors.NotValidf("Label cannot be empty")
+	if s.State == "" {
+		return errors.NotValidf("State cannot be empty")
 	}
 	return nil
 }

--- a/process/status.go
+++ b/process/status.go
@@ -7,6 +7,19 @@ import (
 	"github.com/juju/errors"
 )
 
+// Status is the Juju-level status of a workload process.
+type Status struct {
+	// State is which state the process is in relative to Juju.
+	State string
+	// Failed identifies whether or not Juju got a failure while trying
+	// to interact with the process (via its plugin).
+	Failed bool
+	// Message is a human-readable message describing the current status
+	// of the process, why it is in the current state, or what Juju is
+	// doing right now relative to the process. There may be no message.
+	Message string
+}
+
 // PluginStatus represents the data returned from the Plugin.Status call.
 type PluginStatus struct {
 	// Label represents the human-readable label returned by the plugin

--- a/process/status.go
+++ b/process/status.go
@@ -30,6 +30,7 @@ var (
 )
 
 // TODO(ericsnow) Use a separate StatusInfo and keep Status (quasi-)immutable?
+// TODO(ericsnow) Move Info.Details.Status into Status here?
 
 // Status is the Juju-level status of a workload process.
 type Status struct {

--- a/process/status.go
+++ b/process/status.go
@@ -18,14 +18,12 @@ const (
 	StateStopped   = "stopped"
 )
 
-var (
-	okayStates = set.NewStrings(
-		StateDefined,
-		StateStarting,
-		StateRunning,
-		StateStopping,
-		StateStopped,
-	)
+var okayStates = set.NewStrings(
+	StateDefined,
+	StateStarting,
+	StateRunning,
+	StateStopping,
+	StateStopped,
 )
 
 // TODO(ericsnow) Use a separate StatusInfo and keep Status (quasi-)immutable?

--- a/process/status.go
+++ b/process/status.go
@@ -20,7 +20,6 @@ const (
 
 var (
 	okayStates = set.NewStrings(
-		StateUndefined, // TODO(ericsnow) Drop from the set.
 		StateDefined,
 		StateStarting,
 		StateRunning,

--- a/process/status.go
+++ b/process/status.go
@@ -7,6 +7,8 @@ import (
 	"github.com/juju/errors"
 )
 
+// TODO(ericsnow) Turn StateError into a field (like Failed)?
+
 // The Juju-recognized states in which a workload process might be.
 const (
 	StateUndefined = ""
@@ -17,6 +19,8 @@ const (
 	StateStopping  = "stopping"
 	StateStopped   = "stopped"
 )
+
+// TODO(ericsnow) Use a separate StatusInfo and keep Status (quasi-)immutable?
 
 // Status is the Juju-level status of a workload process.
 type Status struct {
@@ -29,6 +33,115 @@ type Status struct {
 	// of the process, why it is in the current state, or what Juju is
 	// doing right now relative to the process. There may be no message.
 	Message string
+}
+
+// TODO(ericsnow) Add a String method.
+
+// IsBlocked indicates whether or not the workload process may proceed
+// to the next state.
+func (s *Status) IsBlocked() bool {
+	return s.Failed || s.State == StateError
+}
+
+// Advance updates the state of the Status to the next appropriate one.
+// If a message is provided, it is set. Otherwise the current message
+// will be cleared.
+func (s *Status) Advance(message string) error {
+	if s.Failed {
+		return errors.Errorf("cannot advance from a failed state")
+	}
+	switch s.State {
+	case StateUndefined:
+		s.State = StateDefined
+	case StateDefined:
+		s.State = StateStarting
+	case StateStarting:
+		s.State = StateRunning
+	case StateRunning:
+		s.State = StateStopping
+	case StateError:
+		return errors.Errorf("cannot advance from an error state")
+	case StateStopping:
+		s.State = StateStopped
+	case StateStopped:
+		return errors.Errorf("cannot advance from a final state")
+	default:
+		return errors.NotValidf("unrecognized state %q", s.State)
+	}
+	s.Message = message
+	return nil
+}
+
+// SetFailed records that Juju encountered a problem when trying to
+// interact with the process. If Status.Failed is already true then the
+// message is updated. If the process is in an initial or final state
+// then an error is returned.
+func (s *Status) SetFailed(message string) error {
+	switch s.State {
+	case StateUndefined:
+		return errors.Errorf("cannot fail while in an initial state")
+	case StateDefined:
+		return errors.Errorf("cannot fail while in an initial state")
+	case StateStopped:
+		return errors.Errorf("cannot fail while in a final state")
+	}
+
+	if message == "" {
+		message = "problem while interacting with workload process"
+	}
+	s.Failed = true
+	s.Message = message
+	return nil
+}
+
+// SetError records that the workload process isn't working correctly,
+// as reported by the plugin. If already in an error state then the
+// message is updated. The process must be in a running state for there
+// to be an error. problems during starting and stopping are recorded
+// as failures rather than errors.
+func (s *Status) SetError(message string) error {
+	switch s.State {
+	case StateRunning:
+	case StateError:
+	default:
+		return errors.Errorf("can error only while running")
+	}
+
+	if message == "" {
+		message = "the workload process has an error"
+	}
+	s.State = StateError
+	s.Message = message
+	return nil
+}
+
+// Resolve clears any existing error or failure status for the process.
+// If a message is provided then it is set. Otherwise a message
+// describing what was resolved will be set. If the process is both
+// failed and in an error state then both will be resolved at once.
+// If the process isn't currently blocked then an error is returned.
+func (s *Status) Resolve(message string) error {
+	if !s.IsBlocked() {
+		// TODO(ericsnow) Do nothing?
+		return errors.Errorf("not in an error or failed state")
+	}
+
+	if s.State == StateError {
+		s.State = StateRunning
+		if message == "" {
+			// TODO(ericsnow) Add in the current message.
+			message = "error resolved"
+		}
+	} else if s.Failed {
+		if message == "" {
+			// TODO(ericsnow) Add in the current message.
+			message = "failure resolved"
+		}
+	}
+
+	s.Failed = false
+	s.Message = message
+	return nil
 }
 
 // PluginStatus represents the data returned from the Plugin.Status call.

--- a/process/status.go
+++ b/process/status.go
@@ -29,7 +29,6 @@ var (
 )
 
 // TODO(ericsnow) Use a separate StatusInfo and keep Status (quasi-)immutable?
-// TODO(ericsnow) Move Info.Details.Status into Status here?
 
 // Status is the Juju-level status of a workload process.
 type Status struct {
@@ -206,6 +205,27 @@ type PluginStatus struct {
 func (s PluginStatus) Validate() error {
 	if s.State == "" {
 		return errors.NotValidf("State cannot be empty")
+	}
+	return nil
+}
+
+// CombinedStatus holds the status information for a process,
+// from all sources.
+type CombinedStatus struct {
+	// Status is the Juju-level status information.
+	Status Status
+	// PluginStatus is the plugin-defined status information.
+	PluginStatus PluginStatus
+}
+
+// Validate returns nil if this value is valid, and an error that satisfies
+// IsValid if it is not.
+func (s CombinedStatus) Validate() error {
+	if err := s.Status.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	if err := s.PluginStatus.Validate(); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/process/status/client_test.go
+++ b/process/status/client_test.go
@@ -45,7 +45,7 @@ func (*clientSuite) TestGood(c *gc.C) {
 			Details: api.ProcessDetails{
 				ID: "id",
 				Status: api.PluginStatus{
-					Label: "Running",
+					State: "Running",
 				},
 			},
 		},
@@ -65,7 +65,7 @@ func (*clientSuite) TestGood(c *gc.C) {
 			Status: cliStatus{
 				State:       process.StateRunning,
 				Info:        "okay",
-				PluginState: in[0].Details.Status.Label,
+				PluginState: in[0].Details.Status.State,
 			},
 		},
 	}

--- a/process/status/client_test.go
+++ b/process/status/client_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/process"
 	"github.com/juju/juju/process/api"
 )
 
@@ -37,9 +38,13 @@ func (*clientSuite) TestGood(c *gc.C) {
 				Volumes:     []api.ProcessVolume{{ExternalMount: "ext", InternalMount: "int", Mode: "rw", Name: "foo"}},
 				EnvVars:     map[string]string{"baz": "baz"},
 			},
+			Status: api.ProcessStatus{
+				State:   process.StateRunning,
+				Message: "okay",
+			},
 			Details: api.ProcessDetails{
 				ID: "id",
-				Status: api.ProcessStatus{
+				Status: api.PluginStatus{
 					Label: "Running",
 				},
 			},

--- a/process/status/client_test.go
+++ b/process/status/client_test.go
@@ -63,7 +63,9 @@ func (*clientSuite) TestGood(c *gc.C) {
 			ID:   in[0].Details.ID,
 			Type: in[0].Definition.Type,
 			Status: cliStatus{
-				State: in[0].Details.Status.Label,
+				State:       process.StateRunning,
+				Info:        "okay",
+				PluginState: in[0].Details.Status.Label,
 			},
 		},
 	}

--- a/process/status/server_test.go
+++ b/process/status/server_test.go
@@ -45,7 +45,7 @@ func (*serverSuite) TestGood(c *gc.C) {
 		Details: process.Details{
 			ID: "idfoo",
 			Status: process.PluginStatus{
-				Label: "process status",
+				State: "process status",
 			},
 		},
 	}}

--- a/process/status/status.go
+++ b/process/status/status.go
@@ -54,7 +54,7 @@ func Format(b []byte) interface{} {
 			Status: cliStatus{
 				State:       status.State,
 				Info:        status.String(),
-				PluginState: info.Details.Status.Label,
+				PluginState: info.Details.Status.State,
 			},
 		}
 	}

--- a/process/status/status.go
+++ b/process/status/status.go
@@ -31,7 +31,9 @@ type cliDetails struct {
 }
 
 type cliStatus struct {
-	State string `json:"state" yaml:"state"`
+	State       string `json:"Juju state" yaml:"Juju state"`
+	Info        string `json:"info" yaml:"info"`
+	PluginState string `json:"plugin state" yaml:"plugin state"`
 }
 
 // Format converts the object returned from the API for our component
@@ -43,13 +45,16 @@ func Format(b []byte) interface{} {
 		return fmt.Errorf("error loading type returned from api: %s", err)
 	}
 
-	result := map[string]cliDetails{}
+	result := make(map[string]cliDetails, len(infos))
 	for _, info := range infos {
+		status := api.APIStatus2Status(info.Status)
 		result[info.Definition.Name] = cliDetails{
 			ID:   info.Details.ID,
 			Type: info.Definition.Type,
 			Status: cliStatus{
-				State: info.Details.Status.Label,
+				State:       status.State,
+				Info:        status.String(),
+				PluginState: info.Details.Status.Label,
 			},
 		}
 	}

--- a/process/status_test.go
+++ b/process/status_test.go
@@ -1,0 +1,346 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package process_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/process"
+	"github.com/juju/juju/testing"
+)
+
+var (
+	states = []string{
+		process.StateUndefined,
+		process.StateDefined,
+		process.StateStarting,
+		process.StateRunning,
+		process.StateError,
+		process.StateStopping,
+		process.StateStopped,
+	}
+
+	initialStates = []string{
+		process.StateUndefined,
+		process.StateDefined,
+	}
+
+	finalStates = []string{
+		process.StateStopped,
+	}
+)
+
+type statusSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&statusSuite{})
+
+func (s *statusSuite) newStatus(state string) process.Status {
+	return process.Status{
+		State: state,
+	}
+}
+
+func (s *statusSuite) checkStatus(c *gc.C, status process.Status, state, msg string) {
+	c.Check(status.State, gc.Equals, state)
+	c.Check(status.Failed, jc.IsFalse)
+	c.Check(status.Message, gc.Equals, msg)
+}
+
+func (s *statusSuite) TestIsBlockedFalse(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	blocked := status.IsBlocked()
+
+	c.Check(blocked, jc.IsFalse)
+}
+
+func (s *statusSuite) TestIsBlockedErrorOnly(c *gc.C) {
+	status := s.newStatus(process.StateError)
+	blocked := status.IsBlocked()
+
+	c.Check(blocked, jc.IsTrue)
+}
+
+func (s *statusSuite) TestIsBlockedFailedOnly(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	status.Failed = true
+	blocked := status.IsBlocked()
+
+	c.Check(blocked, jc.IsTrue)
+}
+
+func (s *statusSuite) TestIsBlockedErrorAndFailed(c *gc.C) {
+	status := s.newStatus(process.StateError)
+	status.Failed = true
+	blocked := status.IsBlocked()
+
+	c.Check(blocked, jc.IsTrue)
+}
+
+func (s *statusSuite) TestAdvanceTraverse(c *gc.C) {
+	status := process.Status{}
+	s.checkStatus(c, status, process.StateUndefined, "")
+
+	err := status.Advance("")
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStatus(c, status, process.StateDefined, "")
+
+	err = status.Advance("")
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStatus(c, status, process.StateStarting, "")
+
+	err = status.Advance("")
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStatus(c, status, process.StateRunning, "")
+
+	err = status.Advance("")
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStatus(c, status, process.StateStopping, "")
+
+	err = status.Advance("")
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStatus(c, status, process.StateStopped, "")
+
+	err = status.Advance("")
+	c.Check(err, gc.NotNil)
+}
+
+func (s *statusSuite) TestAdvanceMessage(c *gc.C) {
+	status := s.newStatus(process.StateDefined)
+	c.Assert(status.Message, gc.Equals, "")
+
+	err := status.Advance("good things to come")
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStatus(c, status, process.StateStarting, "good things to come")
+
+	err = status.Advance("rock and roll")
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStatus(c, status, process.StateRunning, "rock and roll")
+
+	err = status.Advance("")
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkStatus(c, status, process.StateStopping, "")
+}
+
+func (s *statusSuite) TestAdvanceInvalid(c *gc.C) {
+	status := s.newStatus("some bogus state")
+	err := status.Advance("")
+
+	c.Check(err, gc.ErrorMatches, `unrecognized state.*`)
+}
+
+func (s *statusSuite) TestAdvanceFinal(c *gc.C) {
+	for _, state := range finalStates {
+		c.Logf("checking %q", state)
+		status := s.newStatus(state)
+		err := status.Advance("")
+
+		c.Check(err, gc.ErrorMatches, `cannot advance from a final state`)
+	}
+}
+
+func (s *statusSuite) TestAdvanceFailed(c *gc.C) {
+	for _, state := range states {
+		c.Logf("checking %q", state)
+		status := s.newStatus(state)
+		status.Failed = true
+		err := status.Advance("")
+
+		c.Check(err, gc.ErrorMatches, `cannot advance from a failed state`)
+	}
+}
+
+func (s *statusSuite) TestAdvanceError(c *gc.C) {
+	status := s.newStatus(process.StateError)
+	err := status.Advance("")
+
+	c.Check(err, gc.ErrorMatches, `cannot advance from an error state`)
+}
+
+func (s *statusSuite) TestSetFailedOkay(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	status.Message = "good to go"
+	err := status.SetFailed("uh-oh")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(status.State, gc.Equals, process.StateRunning)
+	c.Check(status.Failed, jc.IsTrue)
+	c.Check(status.Message, gc.Equals, "uh-oh")
+}
+
+func (s *statusSuite) TestSetFailedDefaultMessage(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	status.Message = "good to go"
+	err := status.SetFailed("")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(status.State, gc.Equals, process.StateRunning)
+	c.Check(status.Failed, jc.IsTrue)
+	c.Check(status.Message, gc.Equals, "problem while interacting with workload process")
+}
+
+func (s *statusSuite) TestSetFailedAlreadyFailed(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	status.Message = "good to go"
+	err := status.SetFailed("")
+	c.Assert(err, jc.ErrorIsNil)
+	err = status.SetFailed("uh-oh")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(status.State, gc.Equals, process.StateRunning)
+	c.Check(status.Failed, jc.IsTrue)
+	c.Check(status.Message, gc.Equals, "uh-oh")
+}
+
+func (s *statusSuite) TestSetFailedAlreadyError(c *gc.C) {
+	status := s.newStatus(process.StateError)
+	err := status.SetFailed("uh-oh")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(status.State, gc.Equals, process.StateError)
+	c.Check(status.Failed, jc.IsTrue)
+	c.Check(status.Message, gc.Equals, "uh-oh")
+}
+
+func (s *statusSuite) TestSetFailedBadState(c *gc.C) {
+	status := process.Status{
+		Failed:  false,
+		Message: "good to go",
+	}
+	test := func(state, msg string) {
+		status.State = state
+		err := status.SetFailed("")
+
+		c.Check(err, gc.ErrorMatches, msg)
+		s.checkStatus(c, status, state, "good to go")
+	}
+	for _, state := range initialStates {
+		test(state, `cannot fail while in an initial state`)
+	}
+	for _, state := range finalStates {
+		test(state, `cannot fail while in a final state`)
+	}
+}
+
+func (s *statusSuite) TestSetErrorOkay(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	status.Message = "good to go"
+	err := status.SetError("uh-oh")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkStatus(c, status, process.StateError, "uh-oh")
+}
+
+func (s *statusSuite) TestSetErrorDefaultMessage(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	status.Message = "good to go"
+	err := status.SetError("")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkStatus(c, status, process.StateError, "the workload process has an error")
+}
+
+func (s *statusSuite) TestSetErrorAlreadyError(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	status.Message = "good to go"
+	err := status.SetError("")
+	c.Assert(err, jc.ErrorIsNil)
+	err = status.SetError("uh-oh")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkStatus(c, status, process.StateError, "uh-oh")
+}
+
+func (s *statusSuite) TestSetErrorAlreadyFailed(c *gc.C) {
+	status := s.newStatus(process.StateRunning)
+	status.Failed = true
+	status.Message = "good to go"
+	err := status.SetError("uh-oh")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(status.State, gc.Equals, process.StateError)
+	c.Check(status.Failed, jc.IsTrue)
+	c.Check(status.Message, gc.Equals, "uh-oh")
+}
+
+func (s *statusSuite) TestSetErrorBadState(c *gc.C) {
+	status := s.newStatus(process.StateStarting)
+	err := status.SetError("")
+
+	c.Check(err, gc.ErrorMatches, `can error only while running`)
+}
+
+func (s *statusSuite) TestResolveErrorOkay(c *gc.C) {
+	status := process.Status{
+		State:   process.StateError,
+		Failed:  false,
+		Message: "uh-oh",
+	}
+	err := status.Resolve("good to go")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkStatus(c, status, process.StateRunning, "good to go")
+}
+
+func (s *statusSuite) TestResolveErrorDefaultMessage(c *gc.C) {
+	status := process.Status{
+		State:   process.StateError,
+		Failed:  false,
+		Message: "uh-oh",
+	}
+	err := status.Resolve("")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkStatus(c, status, process.StateRunning, "error resolved")
+}
+
+func (s *statusSuite) TestResolveFailedOkay(c *gc.C) {
+	status := process.Status{
+		State:   process.StateRunning,
+		Failed:  true,
+		Message: "uh-oh",
+	}
+	err := status.Resolve("good to go")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkStatus(c, status, process.StateRunning, "good to go")
+}
+
+func (s *statusSuite) TestResolveFailedDefaultMessage(c *gc.C) {
+	status := process.Status{
+		State:   process.StateRunning,
+		Failed:  true,
+		Message: "uh-oh",
+	}
+	err := status.Resolve("")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkStatus(c, status, process.StateRunning, "failure resolved")
+}
+
+func (s *statusSuite) TestResolveErrorAndFailed(c *gc.C) {
+	status := process.Status{
+		State:   process.StateError,
+		Failed:  true,
+		Message: "uh-oh",
+	}
+	err := status.Resolve("")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkStatus(c, status, process.StateRunning, "error resolved")
+}
+
+func (s *statusSuite) TestResolveNotBlocked(c *gc.C) {
+	status := process.Status{
+		State:   process.StateRunning,
+		Failed:  false,
+		Message: "nothing wrong",
+	}
+	err := status.Resolve("good to go")
+
+	c.Check(err, gc.ErrorMatches, `not in an error or failed state`)
+	s.checkStatus(c, status, process.StateRunning, "nothing wrong")
+}

--- a/process/status_test.go
+++ b/process/status_test.go
@@ -426,8 +426,15 @@ func (s *statusSuite) TestResolveNotBlocked(c *gc.C) {
 }
 
 func (s *statusSuite) TestValidateOkay(c *gc.C) {
-	var status process.Status
+	status := process.Status{
+		Failed:  false,
+		Error:   false,
+		Message: "nothing wrong",
+	}
 	for _, state := range states {
+		if state == process.StateUndefined {
+			continue
+		}
 		c.Logf("checking %q", state)
 		status.State = state
 		err := status.Validate()
@@ -436,7 +443,24 @@ func (s *statusSuite) TestValidateOkay(c *gc.C) {
 	}
 }
 
-func (s *statusSuite) TestValidateBadStatus(c *gc.C) {
+func (s *statusSuite) TestValidateNoMessage(c *gc.C) {
+	status := process.Status{
+		State:   process.StateRunning,
+		Message: "",
+	}
+	err := status.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *statusSuite) TestValidateUndefinedState(c *gc.C) {
+	var status process.Status
+	err := status.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *statusSuite) TestValidateBadState(c *gc.C) {
 	var status process.Status
 	status.State = "some bogus state"
 	err := status.Validate()

--- a/process/status_test.go
+++ b/process/status_test.go
@@ -55,6 +55,63 @@ func (s *statusSuite) checkStatusOkay(c *gc.C, status process.Status, state, msg
 	s.checkStatus(c, status, state, msg, false, false)
 }
 
+func (s *statusSuite) TestStringOkay(c *gc.C) {
+	var status process.Status
+	status.Message = "nothing to see here"
+	for _, state := range states {
+		c.Logf("checking %q", state)
+		status.State = state
+		str := status.String()
+
+		c.Check(str, gc.Equals, "nothing to see here")
+	}
+}
+
+func (s *statusSuite) TestStringNoMessage(c *gc.C) {
+	var status process.Status
+	for _, state := range states {
+		c.Logf("checking %q", state)
+		status.State = state
+		str := status.String()
+
+		c.Check(str, gc.Equals, "<no message>")
+	}
+}
+
+func (s *statusSuite) TestStringFailed(c *gc.C) {
+	status := process.Status{
+		State:   process.StateRunning,
+		Failed:  true,
+		Message: "uh-oh",
+	}
+	str := status.String()
+
+	c.Check(str, gc.Equals, "(failed) uh-oh")
+}
+
+func (s *statusSuite) TestStringError(c *gc.C) {
+	status := process.Status{
+		State:   process.StateRunning,
+		Error:   true,
+		Message: "uh-oh",
+	}
+	str := status.String()
+
+	c.Check(str, gc.Equals, "(error) uh-oh")
+}
+
+func (s *statusSuite) TestStringFailedAndError(c *gc.C) {
+	status := process.Status{
+		State:   process.StateRunning,
+		Failed:  true,
+		Error:   true,
+		Message: "uh-oh",
+	}
+	str := status.String()
+
+	c.Check(str, gc.Equals, "(failed) uh-oh")
+}
+
 func (s *statusSuite) TestIsBlockedFalse(c *gc.C) {
 	status := s.newStatus(process.StateRunning)
 	blocked := status.IsBlocked()

--- a/state/processes.go
+++ b/state/processes.go
@@ -20,11 +20,11 @@ type UnitProcesses interface {
 	// already registered for the same (unit, proc name, plugin ID)
 	// then the request will fail. The unit must also be "alive".
 	Add(info process.Info) error
-	// SetStatus sets the raw status of a workload process. The process
-	// ID is in the format provided by process.Info.ID()
-	// ("<proc name>/<plugin ID>"). If the process is not in state then
-	// the request will fail.
-	SetStatus(id string, status process.PluginStatus) error
+	// SetStatus sets the status of a workload process. Only some fields
+	// must be set on the provided info: Name, Status, Details.ID, and
+	// Details.Status. If the process is not in state then the request
+	// will fail.
+	SetStatus(info process.Info) error
 	// List builds the list of workload processes registered for
 	// the given unit and IDs. If no IDs are provided then all
 	// registered processes for the unit are returned. In the case that

--- a/state/processes.go
+++ b/state/processes.go
@@ -24,7 +24,7 @@ type UnitProcesses interface {
 	// must be set on the provided info: Name, Status, Details.ID, and
 	// Details.Status. If the process is not in state then the request
 	// will fail.
-	SetStatus(info process.Info) error
+	SetStatus(id string, status process.CombinedStatus) error
 	// List builds the list of workload processes registered for
 	// the given unit and IDs. If no IDs are provided then all
 	// registered processes for the unit are returned. In the case that

--- a/state/processes_test.go
+++ b/state/processes_test.go
@@ -118,7 +118,7 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 		Details: process.Details{
 			ID: "xyz",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}
@@ -155,7 +155,7 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 		Details: process.Details{
 			ID: "xyz",
 			Status: process.PluginStatus{
-				Label: "running",
+				State: "running",
 			},
 		},
 	}})
@@ -175,7 +175,7 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 		Details: process.Details{
 			ID: "xyz",
 			Status: process.PluginStatus{
-				Label: "still running",
+				State: "still running",
 			},
 		},
 	})
@@ -211,7 +211,7 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 		Details: process.Details{
 			ID: "xyz",
 			Status: process.PluginStatus{
-				Label: "still running",
+				State: "still running",
 			},
 		},
 	}})

--- a/state/processes_test.go
+++ b/state/processes_test.go
@@ -164,19 +164,13 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(procs, jc.DeepEquals, []process.Info{info})
 
-	err = st.SetStatus(process.Info{
-		Process: charm.Process{
-			Name: "procA",
-		},
+	err = st.SetStatus("procA/xyz", process.CombinedStatus{
 		Status: process.Status{
 			State:   process.StateRunning,
 			Message: "still okay",
 		},
-		Details: process.Details{
-			ID: "xyz",
-			Status: process.PluginStatus{
-				State: "still running",
-			},
+		PluginStatus: process.PluginStatus{
+			State: "still running",
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/processes_test.go
+++ b/state/processes_test.go
@@ -111,6 +111,10 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 				"IMPORTANT": "true",
 			},
 		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Message: "okay",
+		},
 		Details: process.Details{
 			ID: "xyz",
 			Status: process.PluginStatus{
@@ -144,6 +148,10 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 				"IMPORTANT": "true",
 			},
 		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Message: "okay",
+		},
 		Details: process.Details{
 			ID: "xyz",
 			Status: process.PluginStatus{
@@ -156,8 +164,20 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(procs, jc.DeepEquals, []process.Info{info})
 
-	err = st.SetStatus("procA/xyz", process.PluginStatus{
-		Label: "still running",
+	err = st.SetStatus(process.Info{
+		Process: charm.Process{
+			Name: "procA",
+		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Message: "still okay",
+		},
+		Details: process.Details{
+			ID: "xyz",
+			Status: process.PluginStatus{
+				Label: "still running",
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -183,6 +203,10 @@ func (s *unitProcessesSuite) TestFunctional(c *gc.C) {
 			EnvVars: map[string]string{
 				"IMPORTANT": "true",
 			},
+		},
+		Status: process.Status{
+			State:   process.StateRunning,
+			Message: "still okay",
 		},
 		Details: process.Details{
 			ID: "xyz",


### PR DESCRIPTION
This allows Juju to track the status of a workload process, separately from the status reported by the plugin.

Key points:
 * add process.Status
 * add process.CombinedStatus (Status + PluginStatus, for set-status)
 * change PluginStatus.Label to "State"
 * update juju status to include the new status info

Notably, this patch does not store the new Juju-level status in the statuses collection.  That is deferred to a separate (future) work item.

(Review request: http://reviews.vapour.ws/r/2294/)