### PR TITLE
storage: update VolumeSource API

### DIFF
--- a/provider/common/destroy.go
+++ b/provider/common/destroy.go
@@ -104,7 +104,10 @@ func destroyVolumes(
 	}
 
 	var errStrings []string
-	errs := volumeSource.DestroyVolumes(volumeIds)
+	errs, err := volumeSource.DestroyVolumes(volumeIds)
+	if err != nil {
+		return errors.Annotate(err, "destroying volumes")
+	}
 	for _, err := range errs {
 		if err != nil {
 			errStrings = append(errStrings, err.Error())

--- a/provider/common/destroy_test.go
+++ b/provider/common/destroy_test.go
@@ -131,8 +131,8 @@ func (s *DestroySuite) TestDestroyEnvScopedVolumes(c *gc.C) {
 		ListVolumesFunc: func() ([]string, error) {
 			return []string{"vol-0", "vol-1", "vol-2"}, nil
 		},
-		DestroyVolumesFunc: func(ids []string) []error {
-			return make([]error, len(ids))
+		DestroyVolumesFunc: func(ids []string) ([]error, error) {
+			return make([]error, len(ids)), nil
 		},
 	}
 	staticProvider := &dummy.StorageProvider{
@@ -169,12 +169,12 @@ func (s *DestroySuite) TestDestroyVolumeErrors(c *gc.C) {
 		ListVolumesFunc: func() ([]string, error) {
 			return []string{"vol-0", "vol-1", "vol-2"}, nil
 		},
-		DestroyVolumesFunc: func(ids []string) []error {
+		DestroyVolumesFunc: func(ids []string) ([]error, error) {
 			return []error{
 				nil,
 				errors.New("cannot destroy vol-1"),
 				errors.New("cannot destroy vol-2"),
-			}
+			}, nil
 		},
 	}
 

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -5,7 +5,6 @@ package ec2
 
 import (
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -226,10 +225,10 @@ type ebsVolumeSource struct {
 var _ storage.VolumeSource = (*ebsVolumeSource)(nil)
 
 // parseVolumeOptions uses storage volume parameters to make a struct used to create volumes.
-func parseVolumeOptions(size uint64, attrs map[string]interface{}) (_ ec2.CreateVolume, persistent bool, _ error) {
+func parseVolumeOptions(size uint64, attrs map[string]interface{}) (_ ec2.CreateVolume, _ error) {
 	ebsConfig, err := newEbsConfig(attrs)
 	if err != nil {
-		return ec2.CreateVolume{}, false, errors.Trace(err)
+		return ec2.CreateVolume{}, errors.Trace(err)
 	}
 	vol := ec2.CreateVolume{
 		// Juju size is MiB, AWS size is GiB.
@@ -238,28 +237,54 @@ func parseVolumeOptions(size uint64, attrs map[string]interface{}) (_ ec2.Create
 		Encrypted:  ebsConfig.encrypted,
 		IOPS:       int64(ebsConfig.iops),
 	}
-	return vol, ebsConfig.persistent, nil
+	return vol, nil
 }
 
 // CreateVolumes is specified on the storage.VolumeSource interface.
-func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []storage.Volume, _ []storage.VolumeAttachment, err error) {
-	volumes := make([]storage.Volume, 0, len(params))
-	volumeAttachments := make([]storage.VolumeAttachment, 0, len(params))
+func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []storage.CreateVolumesResult, err error) {
 
-	// If there's an error, we delete any ones that are created.
+	// First, validate the params before we use them.
+	results := make([]storage.CreateVolumesResult, len(params))
+	instanceIds := set.NewStrings()
+	for i, p := range params {
+		if err := v.ValidateVolumeParams(p); err != nil {
+			results[i].Error = err
+			continue
+		}
+		instanceIds.Add(string(p.Attachment.InstanceId))
+	}
+
+	instances := make(instanceCache)
+	if instanceIds.Size() > 1 {
+		// We ignore the error, because we don't want an invalid
+		// InstanceId reference from one VolumeParams to prevent
+		// the creation of another volume.
+		_ = instances.update(v.ec2, instanceIds.Values()...)
+	}
+
+	for i, p := range params {
+		if results[i].Error != nil {
+			continue
+		}
+		volume, attachment, err := v.createVolume(p, instances)
+		if err != nil {
+			results[i].Error = err
+			continue
+		}
+		results[i].Volume = volume
+		results[i].VolumeAttachment = attachment
+	}
+	return results, nil
+}
+
+func (v *ebsVolumeSource) createVolume(p storage.VolumeParams, instances instanceCache) (_ *storage.Volume, _ *storage.VolumeAttachment, err error) {
+	var volumeId string
 	defer func() {
-		if err != nil && len(volumes) > 0 {
-			volIds := make([]string, len(volumes))
-			for i, v := range volumes {
-				volIds[i] = v.VolumeId
-			}
-			err2 := v.DestroyVolumes(volIds)
-			for i, volErr := range err2 {
-				if volErr == nil {
-					continue
-				}
-				logger.Warningf("error cleaning up volume %v: %v", volumes[i].Tag, volErr)
-			}
+		if err == nil || volumeId == "" {
+			return
+		}
+		if _, err := v.ec2.DeleteVolume(volumeId); err != nil {
+			logger.Warningf("error cleaning up volume %v: %v", volumeId, err)
 		}
 	}()
 
@@ -268,74 +293,58 @@ func (v *ebsVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []stor
 	// many there are and how big each one is. We also need to
 	// unmap ephemeral0 in cloud-init.
 
-	// First, validate the params before we use them.
-	instanceIds := set.NewStrings()
-	for _, p := range params {
-		if err := v.ValidateVolumeParams(p); err != nil {
-			return nil, nil, errors.Trace(err)
-		}
-		instanceIds.Add(string(p.Attachment.InstanceId))
+	// Create.
+	instId := string(p.Attachment.InstanceId)
+	if err := instances.update(v.ec2, instId); err != nil {
+		return nil, nil, errors.Trace(err)
 	}
-	instances, err := v.instances(instanceIds.Values())
+	inst, err := instances.get(instId)
 	if err != nil {
-		return nil, nil, errors.Annotate(err, "querying instance details")
+		// Can't create the volume without the instance,
+		// because we need to know what its AZ is.
+		return nil, nil, errors.Trace(err)
+	}
+	vol, _ := parseVolumeOptions(p.Size, p.Attributes)
+	vol.AvailZone = inst.AvailZone
+	resp, err := v.ec2.CreateVolume(vol)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	volumeId = resp.Id
+
+	// Tag.
+	resourceTags := make(map[string]string)
+	for k, v := range p.ResourceTags {
+		resourceTags[k] = v
+	}
+	resourceTags[tagName] = resourceName(p.Tag, v.envName)
+	if err := tagResources(v.ec2, resourceTags, volumeId); err != nil {
+		return nil, nil, errors.Annotate(err, "tagging volume")
 	}
 
-	for _, p := range params {
-		instId := string(p.Attachment.InstanceId)
-		vol, persistent, _ := parseVolumeOptions(p.Size, p.Attributes)
-		vol.AvailZone = instances[instId].AvailZone
-		resp, err := v.ec2.CreateVolume(vol)
-		if err != nil {
-			return nil, nil, err
-		}
-		volumeId := resp.Id
-		volumes = append(volumes, storage.Volume{
-			p.Tag,
-			storage.VolumeInfo{
-				VolumeId: volumeId,
-				Size:     gibToMib(uint64(resp.Size)),
-				// TODO(axw) Later, when we handle destruction of
-				// volumes within Juju, we should not mark any
-				// EBS volumes as persistent.
-				Persistent: persistent,
-			},
-		})
-
-		resourceTags := make(map[string]string)
-		for k, v := range p.ResourceTags {
-			resourceTags[k] = v
-		}
-		resourceTags[tagName] = resourceName(p.Tag, v.envName)
-		if err := tagResources(v.ec2, resourceTags, volumeId); err != nil {
-			return nil, nil, errors.Annotate(err, "tagging volume")
-		}
-
-		nextDeviceName := blockDeviceNamer(instances[instId])
-		requestDeviceName, actualDeviceName, err := v.attachOneVolume(nextDeviceName, resp.Volume.Id, instId, false)
-		if err != nil {
-			return nil, nil, errors.Annotatef(err, "attaching %v to %v", resp.Volume.Id, instId)
-		}
-		_, err = v.ec2.ModifyInstanceAttribute(&ec2.ModifyInstanceAttribute{
-			InstanceId: instId,
-			BlockDeviceMappings: []ec2.InstanceBlockDeviceMapping{{
-				DeviceName:          requestDeviceName,
-				VolumeId:            volumeId,
-				DeleteOnTermination: !persistent,
-			}},
-		}, nil)
-		if err != nil {
-			return nil, nil, errors.Annotatef(err, "binding termination of %v to %v", resp.Volume.Id, instId)
-		}
-		volumeAttachments = append(volumeAttachments, storage.VolumeAttachment{
-			p.Tag,
-			p.Attachment.Machine,
-			storage.VolumeAttachmentInfo{
-				DeviceName: actualDeviceName,
-			},
-		})
+	// Attach.
+	nextDeviceName := blockDeviceNamer(inst)
+	_, actualDeviceName, err := v.attachOneVolume(nextDeviceName, resp.Volume.Id, instId)
+	if err != nil {
+		return nil, nil, errors.Annotatef(err, "attaching %v to %v", resp.Volume.Id, instId)
 	}
-	return volumes, volumeAttachments, nil
+
+	volume := storage.Volume{
+		p.Tag,
+		storage.VolumeInfo{
+			VolumeId:   volumeId,
+			Size:       gibToMib(uint64(resp.Size)),
+			Persistent: true,
+		},
+	}
+	volumeAttachment := storage.VolumeAttachment{
+		p.Tag,
+		p.Attachment.Machine,
+		storage.VolumeAttachmentInfo{
+			DeviceName: actualDeviceName,
+		},
+	}
+	return &volume, &volumeAttachment, nil
 }
 
 // ListVolumes is specified on the storage.VolumeSource interface.
@@ -354,29 +363,33 @@ func (v *ebsVolumeSource) ListVolumes() ([]string, error) {
 }
 
 // DescribeVolumes is specified on the storage.VolumeSource interface.
-func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.VolumeInfo, error) {
+func (v *ebsVolumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVolumesResult, error) {
+	// TODO(axw) invalid volIds here should not cause the whole
+	// operation to fail. If we get an invalid volume ID response,
+	// fall back to querying each volume individually. That should
+	// be rare.
 	resp, err := v.ec2.Volumes(volIds, nil)
 	if err != nil {
 		return nil, err
 	}
-	vols := make([]storage.VolumeInfo, len(resp.Volumes))
+	results := make([]storage.DescribeVolumesResult, len(resp.Volumes))
 	for i, vol := range resp.Volumes {
-		vols[i] = storage.VolumeInfo{
+		results[i].VolumeInfo = &storage.VolumeInfo{
 			Size:     gibToMib(uint64(vol.Size)),
 			VolumeId: vol.Id,
 		}
 		for _, attachment := range vol.Attachments {
 			if !attachment.DeleteOnTermination {
-				vols[i].Persistent = true
+				results[i].VolumeInfo.Persistent = true
 				break
 			}
 		}
 	}
-	return vols, nil
+	return results, nil
 }
 
 // DestroyVolumes is specified on the storage.VolumeSource interface.
-func (v *ebsVolumeSource) DestroyVolumes(volIds []string) []error {
+func (v *ebsVolumeSource) DestroyVolumes(volIds []string) ([]error, error) {
 	var wg sync.WaitGroup
 	wg.Add(len(volIds))
 	results := make([]error, len(volIds))
@@ -387,7 +400,7 @@ func (v *ebsVolumeSource) DestroyVolumes(volIds []string) []error {
 		}(i, volumeId)
 	}
 	wg.Wait()
-	return results
+	return results, nil
 }
 
 var destroyVolumeAttempt = utils.AttemptStrategy{
@@ -459,8 +472,14 @@ func (v *ebsVolumeSource) destroyVolume(volumeId string) error {
 			}
 		}
 		if len(args) > 0 {
-			if err := v.DetachVolumes(args); err != nil {
+			results, err := v.DetachVolumes(args)
+			if err != nil {
 				return false, errors.Trace(err)
+			}
+			for _, err := range results {
+				if err != nil {
+					return false, errors.Trace(err)
+				}
 			}
 		}
 		return false, nil
@@ -491,7 +510,7 @@ func (v *ebsVolumeSource) destroyVolume(volumeId string) error {
 
 // ValidateVolumeParams is specified on the storage.VolumeSource interface.
 func (v *ebsVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
-	vol, _, err := parseVolumeOptions(params.Size, params.Attributes)
+	vol, err := parseVolumeOptions(params.Size, params.Attributes)
 	if err != nil {
 		return err
 	}
@@ -520,52 +539,53 @@ func (v *ebsVolumeSource) ValidateVolumeParams(params storage.VolumeParams) erro
 }
 
 // AttachVolumes is specified on the storage.VolumeSource interface.
-func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentParams) (attachments []storage.VolumeAttachment, err error) {
-	// If there's an error, we detach any ones that are attached.
-	var attached []storage.VolumeAttachmentParams
-	defer func() {
-		if err != nil && len(attachments) > 0 {
-			err2 := v.DetachVolumes(attached)
-			if err2 != nil {
-				logger.Warningf("error detaching volumes: %v", err2)
-			}
-		}
-	}()
-
+func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
 	// We need the virtualisation types for each instance we are
 	// attaching to so we can determine the device name.
 	instIds := set.NewStrings()
 	for _, p := range attachParams {
 		instIds.Add(string(p.InstanceId))
 	}
-	instances, err := v.instances(instIds.Values())
-	if err != nil {
-		return nil, errors.Trace(err)
+	instances := make(instanceCache)
+	if instIds.Size() > 1 {
+		// We ignore the error, because we don't want an invalid
+		// InstanceId reference from one VolumeParams to prevent
+		// the creation of another volume.
+		_ = instances.update(v.ec2, instIds.Values()...)
 	}
 
-	for _, params := range attachParams {
+	results := make([]storage.AttachVolumesResult, len(attachParams))
+	for i, params := range attachParams {
 		instId := string(params.InstanceId)
-		nextDeviceName := blockDeviceNamer(instances[instId])
-		_, deviceName, err := v.attachOneVolume(nextDeviceName, params.VolumeId, instId, false)
-		if err != nil {
-			return nil, errors.Annotatef(err, "attaching %v to %v", params.VolumeId, params.InstanceId)
+		if err := instances.update(v.ec2, instId); err != nil {
+			results[i].Error = err
+			continue
 		}
-		attached = append(attached, params)
-		attachments = append(attachments, storage.VolumeAttachment{
+		inst, err := instances.get(instId)
+		if err != nil {
+			results[i].Error = err
+			continue
+		}
+		nextDeviceName := blockDeviceNamer(inst)
+		_, deviceName, err := v.attachOneVolume(nextDeviceName, params.VolumeId, instId)
+		if err != nil {
+			results[i].Error = err
+			continue
+		}
+		results[i].VolumeAttachment = &storage.VolumeAttachment{
 			params.Volume,
 			params.Machine,
 			storage.VolumeAttachmentInfo{
 				DeviceName: deviceName,
 			},
-		})
+		}
 	}
-	return attachments, nil
+	return results, nil
 }
 
 func (v *ebsVolumeSource) attachOneVolume(
 	nextDeviceName func() (string, string, error),
 	volumeId, instId string,
-	deleteOnTermination bool,
 ) (string, string, error) {
 	// Wait for the volume to move out of "creating".
 	volume, err := v.waitVolumeCreated(volumeId)
@@ -681,41 +701,41 @@ func (v *ebsVolumeSource) describeVolume(volumeId string) (*ec2.Volume, error) {
 	return &resp.Volumes[0], nil
 }
 
-// instances returns a mapping from the specified instance IDs to ec2.Instance
-// structures. If any of the specified IDs does not refer to a running instance,
-// it will cause an error to be returned.
-func (v *ebsVolumeSource) instances(instIds []string) (map[string]ec2.Instance, error) {
-	instances := make(map[string]ec2.Instance)
-	// Can only attach to running instances.
+type instanceCache map[string]ec2.Instance
+
+func (c instanceCache) update(ec2client *ec2.EC2, ids ...string) error {
+	if len(ids) == 1 {
+		if _, ok := c[ids[0]]; ok {
+			return nil
+		}
+	}
 	filter := ec2.NewFilter()
 	filter.Add("instance-state-name", "running")
-	resp, err := v.ec2.Instances(instIds, filter)
+	resp, err := ec2client.Instances(ids, filter)
 	if err != nil {
-		return nil, err
+		return errors.Annotate(err, "querying instance details")
 	}
 	for j := range resp.Reservations {
 		r := &resp.Reservations[j]
 		for _, inst := range r.Instances {
-			instances[inst.InstanceId] = inst
+			c[inst.InstanceId] = inst
 		}
 	}
-	// TODO(wallyworld) - retry to allow instances to get to running state.
-	if len(instances) < len(instIds) {
-		notRunning := set.NewStrings(instIds...)
-		for id, _ := range instances {
-			notRunning.Remove(id)
-		}
-		return nil, errors.Errorf(
-			"volumes can only be attached to running instances, these instances are not running: %v",
-			strings.Join(notRunning.Values(), ","),
-		)
+	return nil
+}
+
+func (c instanceCache) get(id string) (ec2.Instance, error) {
+	inst, ok := c[id]
+	if !ok {
+		return ec2.Instance{}, errors.Errorf("cannot attach to non-running instance %v", id)
 	}
-	return instances, nil
+	return inst, nil
 }
 
 // DetachVolumes is specified on the storage.VolumeSource interface.
-func (v *ebsVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmentParams) error {
-	for _, params := range attachParams {
+func (v *ebsVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmentParams) ([]error, error) {
+	results := make([]error, len(attachParams))
+	for i, params := range attachParams {
 		_, err := v.ec2.DetachVolume(params.VolumeId, string(params.InstanceId), "", false)
 		// Process aws specific error information.
 		if err != nil {
@@ -728,10 +748,12 @@ func (v *ebsVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmentP
 			}
 		}
 		if err != nil {
-			return errors.Annotatef(err, "detaching %v from %v", params.Volume, params.Machine)
+			results[i] = errors.Annotatef(
+				err, "detaching %v from %v", params.Volume, params.Machine,
+			)
 		}
 	}
-	return nil
+	return results, nil
 }
 
 var errTooManyVolumes = errors.New("too many EBS volumes to attach")

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -499,7 +499,7 @@ func (s *ebsVolumeSuite) TestAttachVolumesNotRunning(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.Not(gc.HasLen), 0)
 	for _, result := range results {
-		c.Assert(errors.Cause(result.Error), gc.ErrorMatches, "cannot attach to non-running instance i-3")
+		c.Check(errors.Cause(result.Error), gc.ErrorMatches, "cannot attach to non-running instance i-3")
 	}
 }
 

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -102,7 +102,7 @@ func (s *ebsVolumeSuite) volumeSource(c *gc.C, cfg *storage.Config) storage.Volu
 	return vs
 }
 
-func (s *ebsVolumeSuite) createVolumes(vs storage.VolumeSource, instanceId string) ([]storage.Volume, error) {
+func (s *ebsVolumeSuite) createVolumes(vs storage.VolumeSource, instanceId string) ([]storage.CreateVolumesResult, error) {
 	if instanceId == "" {
 		instanceId = s.srv.ec2srv.NewInstances(1, "m1.medium", imageId, ec2test.Running, nil)[0]
 	}
@@ -114,7 +114,6 @@ func (s *ebsVolumeSuite) createVolumes(vs storage.VolumeSource, instanceId strin
 		Size:     10 * 1000,
 		Provider: ec2.EBS_ProviderType,
 		Attributes: map[string]interface{}{
-			"persistent":  true,
 			"volume-type": "io1",
 			"iops":        100,
 		},
@@ -130,9 +129,6 @@ func (s *ebsVolumeSuite) createVolumes(vs storage.VolumeSource, instanceId strin
 		Tag:      volume1,
 		Size:     20 * 1000,
 		Provider: ec2.EBS_ProviderType,
-		Attributes: map[string]interface{}{
-			"persistent": true,
-		},
 		Attachment: &storage.VolumeAttachmentParams{
 			AttachmentParams: storage.AttachmentParams{
 				InstanceId: instance.Id(instanceId),
@@ -154,36 +150,37 @@ func (s *ebsVolumeSuite) createVolumes(vs storage.VolumeSource, instanceId strin
 			},
 		},
 	}}
-	vols, _, err := vs.CreateVolumes(params)
-	return vols, err
+	return vs.CreateVolumes(params)
 }
 
 func (s *ebsVolumeSuite) assertCreateVolumes(c *gc.C, vs storage.VolumeSource, instanceId string) {
-	vols, err := s.createVolumes(vs, instanceId)
+	results, err := s.createVolumes(vs, instanceId)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(vols, gc.HasLen, 3)
-	c.Assert(vols, jc.SameContents, []storage.Volume{{
+	c.Assert(results, gc.HasLen, 3)
+	c.Assert(results[0].Volume, jc.DeepEquals, &storage.Volume{
 		names.NewVolumeTag("0"),
 		storage.VolumeInfo{
 			Size:       10240,
 			VolumeId:   "vol-0",
 			Persistent: true,
 		},
-	}, {
+	})
+	c.Assert(results[1].Volume, jc.DeepEquals, &storage.Volume{
 		names.NewVolumeTag("1"),
 		storage.VolumeInfo{
 			Size:       20480,
 			VolumeId:   "vol-1",
 			Persistent: true,
 		},
-	}, {
+	})
+	c.Assert(results[2].Volume, jc.DeepEquals, &storage.Volume{
 		names.NewVolumeTag("2"),
 		storage.VolumeInfo{
 			Size:       30720,
 			VolumeId:   "vol-2",
-			Persistent: false,
+			Persistent: true,
 		},
-	}})
+	})
 	ec2Client := ec2.StorageEC2(vs)
 	ec2Vols, err := ec2Client.Volumes(nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -224,31 +221,33 @@ func (s *ebsVolumeSuite) TestCreateVolumes(c *gc.C) {
 
 func (s *ebsVolumeSuite) TestVolumeTags(c *gc.C) {
 	vs := s.volumeSource(c, nil)
-	vols, err := s.createVolumes(vs, "")
+	results, err := s.createVolumes(vs, "")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(vols, gc.HasLen, 3)
-	c.Assert(vols, jc.SameContents, []storage.Volume{{
+	c.Assert(results, gc.HasLen, 3)
+	c.Assert(results[0].Volume, jc.DeepEquals, &storage.Volume{
 		names.NewVolumeTag("0"),
 		storage.VolumeInfo{
 			Size:       10240,
 			VolumeId:   "vol-0",
 			Persistent: true,
 		},
-	}, {
+	})
+	c.Assert(results[1].Volume, jc.DeepEquals, &storage.Volume{
 		names.NewVolumeTag("1"),
 		storage.VolumeInfo{
 			Size:       20480,
 			VolumeId:   "vol-1",
 			Persistent: true,
 		},
-	}, {
+	})
+	c.Assert(results[2].Volume, jc.DeepEquals, &storage.Volume{
 		names.NewVolumeTag("2"),
 		storage.VolumeInfo{
 			Size:       30720,
 			VolumeId:   "vol-2",
-			Persistent: false,
+			Persistent: true,
 		},
-	}})
+	})
 	ec2Client := ec2.StorageEC2(vs)
 	ec2Vols, err := ec2Client.Volumes(nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -294,10 +293,10 @@ func (s *ebsVolumeSuite) TestVolumeTypeAliases(c *gc.C) {
 		if alias[1] == "io1" {
 			params[0].Attributes["iops"] = 100
 		}
-		vols, _, err := vs.CreateVolumes(params)
+		results, err := vs.CreateVolumes(params)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(vols, gc.HasLen, 1)
-		c.Assert(vols[0].VolumeId, gc.Equals, fmt.Sprintf("vol-%d", i))
+		c.Assert(results, gc.HasLen, 1)
+		c.Assert(results[0].Volume.VolumeId, gc.Equals, fmt.Sprintf("vol-%d", i))
 	}
 	ec2Vols, err := ec2Client.Volumes(nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -313,9 +312,11 @@ func (s *ebsVolumeSuite) TestVolumeTypeAliases(c *gc.C) {
 func (s *ebsVolumeSuite) TestDestroyVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	err := vs.DetachVolumes(params)
+	errs, err := vs.DetachVolumes(params)
 	c.Assert(err, jc.ErrorIsNil)
-	errs := vs.DestroyVolumes([]string{"vol-0"})
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+	errs, err = vs.DestroyVolumes([]string{"vol-0"})
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 
 	ec2Client := ec2.StorageEC2(vs)
@@ -329,7 +330,8 @@ func (s *ebsVolumeSuite) TestDestroyVolumes(c *gc.C) {
 func (s *ebsVolumeSuite) TestDestroyVolumesStillAttached(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	s.setupAttachVolumesTest(c, vs, ec2test.Running)
-	errs := vs.DestroyVolumes([]string{"vol-0"})
+	errs, err := vs.DestroyVolumes([]string{"vol-0"})
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, jc.DeepEquals, []error{nil})
 
 	ec2Client := ec2.StorageEC2(vs)
@@ -347,12 +349,18 @@ func (s *ebsVolumeSuite) TestVolumes(c *gc.C) {
 	vols, err := vs.DescribeVolumes([]string{"vol-0", "vol-1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vols, gc.HasLen, 2)
-	c.Assert(vols, jc.SameContents, []storage.VolumeInfo{{
-		Size:     10240,
-		VolumeId: "vol-0",
+	c.Assert(vols, jc.DeepEquals, []storage.DescribeVolumesResult{{
+		VolumeInfo: &storage.VolumeInfo{
+			Size:       10240,
+			VolumeId:   "vol-0",
+			Persistent: true,
+		},
 	}, {
-		Size:     20480,
-		VolumeId: "vol-1",
+		VolumeInfo: &storage.VolumeInfo{
+			Size:       20480,
+			VolumeId:   "vol-1",
+			Persistent: true,
+		},
 	}})
 }
 
@@ -401,7 +409,7 @@ func (s *ebsVolumeSuite) TestCreateVolumesErrors(c *gc.C) {
 				},
 			},
 		},
-		err: "querying instance details: volumes can only be attached to running instances, these instances are not running: i-3",
+		err: "cannot attach to non-running instance i-3",
 	}, {
 		params: storage.VolumeParams{
 			Size:       100000000,
@@ -458,8 +466,10 @@ func (s *ebsVolumeSuite) TestCreateVolumesErrors(c *gc.C) {
 		},
 		err: "validating EBS storage config: volume-type: unexpected value \"what\"",
 	}} {
-		_, _, err := vs.CreateVolumes([]storage.VolumeParams{test.params})
-		c.Check(err, gc.ErrorMatches, test.err)
+		results, err := vs.CreateVolumes([]storage.VolumeParams{test.params})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(results, gc.HasLen, 1)
+		c.Check(results[0].Error, gc.ErrorMatches, test.err)
 	}
 }
 
@@ -485,8 +495,12 @@ func (s *ebsVolumeSuite) setupAttachVolumesTest(
 func (s *ebsVolumeSuite) TestAttachVolumesNotRunning(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	instanceId := s.srv.ec2srv.NewInstances(1, "m1.medium", imageId, ec2test.Pending, nil)[0]
-	_, err := s.createVolumes(vs, instanceId)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, ".* these instances are not running: i-3")
+	results, err := s.createVolumes(vs, instanceId)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.Not(gc.HasLen), 0)
+	for _, result := range results {
+		c.Assert(errors.Cause(result.Error), gc.ErrorMatches, "cannot attach to non-running instance i-3")
+	}
 }
 
 func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
@@ -495,7 +509,8 @@ func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
 	result, err := vs.AttachVolumes(params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
-	c.Assert(result[0], gc.Equals, storage.VolumeAttachment{
+	c.Assert(result[0].Error, jc.ErrorIsNil)
+	c.Assert(result[0].VolumeAttachment, jc.DeepEquals, &storage.VolumeAttachment{
 		names.NewVolumeTag("0"),
 		names.NewMachineTag("1"),
 		storage.VolumeAttachmentInfo{
@@ -510,18 +525,18 @@ func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
 	c.Assert(ec2Vols.Volumes, gc.HasLen, 3)
 	sortBySize(ec2Vols.Volumes)
 	c.Assert(ec2Vols.Volumes[0].Attachments, jc.DeepEquals, []awsec2.VolumeAttachment{{
-		VolumeId:            "vol-0",
-		InstanceId:          "i-3",
-		Device:              "/dev/sdf",
-		Status:              "attached",
-		DeleteOnTermination: true,
+		VolumeId:   "vol-0",
+		InstanceId: "i-3",
+		Device:     "/dev/sdf",
+		Status:     "attached",
 	}})
 
 	// Test idempotency.
 	result, err = vs.AttachVolumes(params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
-	c.Assert(result[0], gc.Equals, storage.VolumeAttachment{
+	c.Assert(result[0].Error, jc.ErrorIsNil)
+	c.Assert(result[0].VolumeAttachment, jc.DeepEquals, &storage.VolumeAttachment{
 		names.NewVolumeTag("0"),
 		names.NewMachineTag("1"),
 		storage.VolumeAttachmentInfo{
@@ -536,8 +551,9 @@ func (s *ebsVolumeSuite) TestDetachVolumes(c *gc.C) {
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)
 	_, err := vs.AttachVolumes(params)
 	c.Assert(err, jc.ErrorIsNil)
-	err = vs.DetachVolumes(params)
+	errs, err := vs.DetachVolumes(params)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
 
 	ec2Client := ec2.StorageEC2(vs)
 	ec2Vols, err := ec2Client.Volumes(nil, nil)
@@ -547,8 +563,9 @@ func (s *ebsVolumeSuite) TestDetachVolumes(c *gc.C) {
 	c.Assert(ec2Vols.Volumes[0].Attachments, gc.HasLen, 0)
 
 	// Test idempotent
-	err = vs.DetachVolumes(params)
+	errs, err = vs.DetachVolumes(params)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
 }
 
 type blockDeviceMappingSuite struct {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -69,7 +69,7 @@ type VolumeSource interface {
 	// CreateVolumes creates volumes with the specified parameters. If the
 	// volumes are initially attached, then CreateVolumes returns
 	// information about those attachments too.
-	CreateVolumes(params []VolumeParams) ([]Volume, []VolumeAttachment, error)
+	CreateVolumes(params []VolumeParams) ([]CreateVolumesResult, error)
 
 	// ListVolumes lists the provider volume IDs for every volume
 	// created by this volume source.
@@ -77,11 +77,11 @@ type VolumeSource interface {
 
 	// DescribeVolumes returns the properties of the volumes with the
 	// specified provider volume IDs.
-	DescribeVolumes(volIds []string) ([]VolumeInfo, error)
+	DescribeVolumes(volIds []string) ([]DescribeVolumesResult, error)
 
 	// DestroyVolumes destroys the volumes with the specified provider
 	// volume IDs.
-	DestroyVolumes(volIds []string) []error
+	DestroyVolumes(volIds []string) ([]error, error)
 
 	// ValidateVolumeParams validates the provided volume creation
 	// parameters, returning an error if they are invalid.
@@ -97,7 +97,7 @@ type VolumeSource interface {
 	// recording in state. For example, the ec2 provider must reject
 	// an attempt to attach a volume to an instance if they are in
 	// different availability zones.
-	AttachVolumes(params []VolumeAttachmentParams) ([]VolumeAttachment, error)
+	AttachVolumes(params []VolumeAttachmentParams) ([]AttachVolumesResult, error)
 
 	// DetachVolumes detaches the volumes with the specified provider
 	// volume IDs from the instances with the corresponding index.
@@ -105,7 +105,7 @@ type VolumeSource interface {
 	// TODO(axw) we need to record in state whether or not volumes
 	// are detachable, and reject attempts to attach/detach on
 	// that basis.
-	DetachVolumes(params []VolumeAttachmentParams) error
+	DetachVolumes(params []VolumeAttachmentParams) ([]error, error)
 }
 
 // FilesystemSource provides an interface for creating, destroying and
@@ -261,4 +261,27 @@ type FilesystemAttachmentParams struct {
 	// Path is the path at which the filesystem is to be mounted on the machine that
 	// this attachment corresponds to.
 	Path string
+}
+
+// CreateVolumesResult contains the result of a VolumeSource.CreateVolumes call
+// for one volume. Volume and VolumeAttachment should only be used if Error is
+// nil.
+type CreateVolumesResult struct {
+	Volume           *Volume
+	VolumeAttachment *VolumeAttachment
+	Error            error
+}
+
+// DescribeVolumesResult contains the result of a VolumeSource.DescribeVolumes call
+// for one volume. Volume should only be used if Error is nil.
+type DescribeVolumesResult struct {
+	VolumeInfo *VolumeInfo
+	Error      error
+}
+
+// AttachVolumesResult contains the result of a VolumeSource.AttachVolumes call
+// for one volume. VolumeAttachment should only be used if Error is nil.
+type AttachVolumesResult struct {
+	VolumeAttachment *VolumeAttachment
+	Error            error
 }

--- a/storage/provider/dummy/volumesource.go
+++ b/storage/provider/dummy/volumesource.go
@@ -12,22 +12,24 @@ import (
 type VolumeSource struct {
 	testing.Stub
 
-	CreateVolumesFunc        func([]storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error)
+	CreateVolumesFunc        func([]storage.VolumeParams) ([]storage.CreateVolumesResult, error)
 	ListVolumesFunc          func() ([]string, error)
-	DescribeVolumesFunc      func([]string) ([]storage.VolumeInfo, error)
-	DestroyVolumesFunc       func([]string) []error
+	DescribeVolumesFunc      func([]string) ([]storage.DescribeVolumesResult, error)
+	DestroyVolumesFunc       func([]string) ([]error, error)
 	ValidateVolumeParamsFunc func(storage.VolumeParams) error
-	AttachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]storage.VolumeAttachment, error)
-	DetachVolumesFunc        func([]storage.VolumeAttachmentParams) error
+	AttachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error)
+	DetachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]error, error)
 }
 
+var _ storage.VolumeSource = (*VolumeSource)(nil)
+
 // CreateVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.Volume, []storage.VolumeAttachment, error) {
+func (s *VolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
 	s.MethodCall(s, "CreateVolumes", params)
 	if s.CreateVolumesFunc != nil {
 		return s.CreateVolumesFunc(params)
 	}
-	return nil, nil, errors.NotImplementedf("CreateVolumes")
+	return nil, errors.NotImplementedf("CreateVolumes")
 }
 
 // ListVolumes is defined on storage.VolumeSource.
@@ -40,7 +42,7 @@ func (s *VolumeSource) ListVolumes() ([]string, error) {
 }
 
 // DescribeVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) DescribeVolumes(volIds []string) ([]storage.VolumeInfo, error) {
+func (s *VolumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVolumesResult, error) {
 	s.MethodCall(s, "DescribeVolumes", volIds)
 	if s.DescribeVolumesFunc != nil {
 		return s.DescribeVolumesFunc(volIds)
@@ -49,16 +51,12 @@ func (s *VolumeSource) DescribeVolumes(volIds []string) ([]storage.VolumeInfo, e
 }
 
 // DestroyVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) DestroyVolumes(volIds []string) []error {
+func (s *VolumeSource) DestroyVolumes(volIds []string) ([]error, error) {
 	s.MethodCall(s, "DestroyVolumes", volIds)
 	if s.DestroyVolumesFunc != nil {
 		return s.DestroyVolumesFunc(volIds)
 	}
-	errs := make([]error, len(volIds))
-	for i := range errs {
-		errs[i] = errors.NotImplementedf("DestroyVolumes")
-	}
-	return errs
+	return nil, errors.NotImplementedf("DestroyVolumes")
 }
 
 // ValidateVolumeParams is defined on storage.VolumeSource.
@@ -71,7 +69,7 @@ func (s *VolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
 }
 
 // AttachVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([]storage.VolumeAttachment, error) {
+func (s *VolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
 	s.MethodCall(s, "AttachVolumes", params)
 	if s.AttachVolumesFunc != nil {
 		return s.AttachVolumesFunc(params)
@@ -80,11 +78,10 @@ func (s *VolumeSource) AttachVolumes(params []storage.VolumeAttachmentParams) ([
 }
 
 // DetachVolumes is defined on storage.VolumeSource.
-func (s *VolumeSource) DetachVolumes(params []storage.VolumeAttachmentParams) error {
+func (s *VolumeSource) DetachVolumes(params []storage.VolumeAttachmentParams) ([]error, error) {
 	s.MethodCall(s, "DetachVolumes", params)
 	if s.DetachVolumesFunc != nil {
 		return s.DetachVolumesFunc(params)
 	}
-	return errors.NotImplementedf("DetachVolumes")
-
+	return nil, errors.NotImplementedf("DetachVolumes")
 }

--- a/storage/provider/dummy/volumesource.go
+++ b/storage/provider/dummy/volumesource.go
@@ -2,8 +2,9 @@ package dummy
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/storage"
 	"github.com/juju/testing"
+
+	"github.com/juju/juju/storage"
 )
 
 // VolumeSource is an implementation of storage.VolumeSource, suitable for
@@ -20,8 +21,6 @@ type VolumeSource struct {
 	AttachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error)
 	DetachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]error, error)
 }
-
-var _ storage.VolumeSource = (*VolumeSource)(nil)
 
 // CreateVolumes is defined on storage.VolumeSource.
 func (s *VolumeSource) CreateVolumes(params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {

--- a/worker/storageprovisioner/filesystems.go
+++ b/worker/storageprovisioner/filesystems.go
@@ -720,25 +720,6 @@ func filesystemFromParams(in params.Filesystem) (storage.Filesystem, error) {
 	}, nil
 }
 
-func filesystemAttachmentFromParams(in params.FilesystemAttachment) (storage.FilesystemAttachment, error) {
-	filesystemTag, err := names.ParseFilesystemTag(in.FilesystemTag)
-	if err != nil {
-		return storage.FilesystemAttachment{}, errors.Trace(err)
-	}
-	machineTag, err := names.ParseMachineTag(in.MachineTag)
-	if err != nil {
-		return storage.FilesystemAttachment{}, errors.Trace(err)
-	}
-	return storage.FilesystemAttachment{
-		filesystemTag,
-		machineTag,
-		storage.FilesystemAttachmentInfo{
-			in.Info.MountPoint,
-			in.Info.ReadOnly,
-		},
-	}, nil
-}
-
 func filesystemParamsFromParams(in params.FilesystemParams) (storage.FilesystemParams, error) {
 	filesystemTag, err := names.ParseFilesystemTag(in.FilesystemTag)
 	if err != nil {

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -666,12 +666,12 @@ func (s *storageProvisionerSuite) TestDetachVolumes(c *gc.C) {
 	}
 
 	detached := make(chan interface{})
-	s.provider.detachVolumesFunc = func(args []storage.VolumeAttachmentParams) error {
+	s.provider.detachVolumesFunc = func(args []storage.VolumeAttachmentParams) ([]error, error) {
 		c.Assert(args, gc.HasLen, 1)
 		c.Assert(args[0].Machine.String(), gc.Equals, expectedAttachmentIds[0].MachineTag)
 		c.Assert(args[0].Volume.String(), gc.Equals, expectedAttachmentIds[0].AttachmentTag)
 		defer close(detached)
-		return nil
+		return make([]error, len(args)), nil
 	}
 
 	removed := make(chan interface{})
@@ -834,9 +834,9 @@ func (s *storageProvisionerSuite) TestDestroyVolumes(c *gc.C) {
 	}
 
 	destroyedChan := make(chan interface{}, 1)
-	s.provider.destroyVolumesFunc = func(volumeIds []string) []error {
+	s.provider.destroyVolumesFunc = func(volumeIds []string) ([]error, error) {
 		destroyedChan <- volumeIds
-		return make([]error, len(volumeIds))
+		return make([]error, len(volumeIds)), nil
 	}
 
 	removedChan := make(chan interface{}, 1)

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -674,25 +674,6 @@ func volumeFromParams(in params.Volume) (storage.Volume, error) {
 	}, nil
 }
 
-func volumeAttachmentFromParams(in params.VolumeAttachment) (storage.VolumeAttachment, error) {
-	volumeTag, err := names.ParseVolumeTag(in.VolumeTag)
-	if err != nil {
-		return storage.VolumeAttachment{}, errors.Trace(err)
-	}
-	machineTag, err := names.ParseMachineTag(in.MachineTag)
-	if err != nil {
-		return storage.VolumeAttachment{}, errors.Trace(err)
-	}
-	return storage.VolumeAttachment{
-		volumeTag,
-		machineTag,
-		storage.VolumeAttachmentInfo{
-			in.Info.DeviceName,
-			in.Info.ReadOnly,
-		},
-	}, nil
-}
-
 func volumeParamsFromParams(in params.VolumeParams) (storage.VolumeParams, error) {
 	volumeTag, err := names.ParseVolumeTag(in.VolumeTag)
 	if err != nil {


### PR DESCRIPTION
The VolumeSource API is updated to better handle bulk calls. Individual operations' errors are now reported individually, rather than causing the entire operation to fail; i.e. like the apiserver bulk calls.

The storage provisioner has been adjusted, but only minimally. A follow-up will change the storage provisioner to not restart/return if individual operations fail, instead rescheduling them. We will follow up again with another change that propagates the error messages to volume/filesystem status in state, which will be presented via "juju storage ...".

There are some unrelated cleanups:
 - dead code removed from worker/storageprovisioner
 - cinder's CreateVolumes no longer attaches; this requires waiting for the volume to be created, so we're better off deferring. Later we'll remove the "waitVolume" call from attachVolume, and just let it fail and get rescheduled
 - "persistent" storage pool config now ignored by ebs and cinder -- we're handling persistent storage in the core now

(Review request: http://reviews.vapour.ws/r/2295/)