### PR TITLE
Improved status-history by removing sequence.

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -6,6 +6,7 @@ package state
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -466,13 +467,10 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 		Insert: mdoc,
 	}
 
-	// TODO(fwereade) this nowToTheSecond thing is crazy, and done only for
-	// consistency -- we should be storing timestamps properly.
-	now := nowToTheSecond()
 	statusDoc := statusDoc{
 		Status:  StatusPending,
 		EnvUUID: st.EnvironUUID(),
-		Updated: &now,
+		Updated: time.Now().UnixNano(),
 	}
 	globalKey := machineGlobalKey(mdoc.Id)
 	prereqOps = []txn.Op{

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -297,7 +297,7 @@ func allCollections() collectionSchema {
 		statusesC:           {},
 		statusesHistoryC: {
 			indexes: []mgo.Index{{
-				Key: []string{"env-uuid", "entityid"},
+				Key: []string{"env-uuid", "globalkey"},
 			}},
 		},
 

--- a/state/megawatcher.go
+++ b/state/megawatcher.go
@@ -502,7 +502,7 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id interfac
 		newInfo.Status.Current = multiwatcher.Status(s.Status)
 		newInfo.Status.Message = s.StatusInfo
 		newInfo.Status.Data = s.StatusData
-		newInfo.Status.Since = s.Updated
+		newInfo.Status.Since = unixNanoToTime(s.Updated)
 		info0 = &newInfo
 	case *multiwatcher.MachineInfo:
 		newInfo := *info
@@ -523,19 +523,19 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 		newInfo.WorkloadStatus.Current = multiwatcher.Status(s.Status)
 		newInfo.WorkloadStatus.Message = s.StatusInfo
 		newInfo.WorkloadStatus.Data = s.StatusData
-		newInfo.WorkloadStatus.Since = s.Updated
+		newInfo.WorkloadStatus.Since = unixNanoToTime(s.Updated)
 	} else {
 		newInfo.AgentStatus.Current = multiwatcher.Status(s.Status)
 		newInfo.AgentStatus.Message = s.StatusInfo
 		newInfo.AgentStatus.Data = s.StatusData
-		newInfo.AgentStatus.Since = s.Updated
+		newInfo.AgentStatus.Since = unixNanoToTime(s.Updated)
 		// If the unit was in error and now it's not, we need to reset its
 		// status back to what was previously recorded.
 		if newInfo.WorkloadStatus.Current == multiwatcher.Status(StatusError) {
 			newInfo.WorkloadStatus.Current = multiwatcher.Status(unitStatus.Status)
 			newInfo.WorkloadStatus.Message = unitStatus.Message
 			newInfo.WorkloadStatus.Data = unitStatus.Data
-			newInfo.WorkloadStatus.Since = s.Updated
+			newInfo.WorkloadStatus.Since = unixNanoToTime(s.Updated)
 		}
 	}
 

--- a/state/service.go
+++ b/state/service.go
@@ -691,14 +691,14 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	now := time.Now()
 	agentStatusDoc := statusDoc{
 		Status:  StatusAllocating,
-		Updated: &now,
+		Updated: now.UnixNano(),
 		EnvUUID: s.st.EnvironUUID(),
 	}
 	unitStatusDoc := statusDoc{
 		// TODO(fwereade): this violates the spec. Should be "waiting".
 		Status:     StatusUnknown,
 		StatusInfo: MessageWaitForAgentInit,
-		Updated:    &now,
+		Updated:    now.UnixNano(),
 		EnvUUID:    s.st.EnvironUUID(),
 	}
 	ops := []txn.Op{

--- a/state/state.go
+++ b/state/state.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -1111,8 +1112,6 @@ func (st *State) AddService(
 	}
 	svc := newService(st, svcDoc)
 
-	// TODO(fwereade): crazy, done for consistency.
-	now := nowToTheSecond()
 	statusDoc := statusDoc{
 		EnvUUID: st.EnvironUUID(),
 		// TODO(fwereade): this violates the spec. Should be "waiting".
@@ -1120,7 +1119,7 @@ func (st *State) AddService(
 		// behaviour.
 		Status:     StatusUnknown,
 		StatusInfo: MessageWaitForAgentInit,
-		Updated:    &now,
+		Updated:    time.Now().UnixNano(),
 		// This exists to preserve questionable unit-aggregation behaviour
 		// while we work out how to switch to an implementation that makes
 		// sense. It is also set in AddMissingServiceStatuses.

--- a/state/status.go
+++ b/state/status.go
@@ -26,9 +26,9 @@ type statusDoc struct {
 	StatusInfo string                 `bson:"statusinfo"`
 	StatusData map[string]interface{} `bson:"statusdata"`
 
-	// Updated might not be present on statuses dating from older versions
-	// of juju. Do not dereference without checking.
-	Updated *time.Time `bson:"updated"`
+	// Updated used to be a *time.Time that was not present on statuses dating
+	// from older versions of juju so this might be 0 for those cases.
+	Updated int64 `bson:"updated"`
 
 	// TODO(fwereade/wallyworld): lp:1479278
 	// NeverSet is a short-term hack to work around a misfeature in service
@@ -37,6 +37,11 @@ type statusDoc struct {
 	// reading them, if NeverSet is still true, we aggregate status from the
 	// units instead.
 	NeverSet bool `bson:"neverset"`
+}
+
+func unixNanoToTime(i int64) *time.Time {
+	t := time.Unix(0, i)
+	return &t
 }
 
 // mapKeys returns a copy of the supplied map, with all nested map[string]interface{}
@@ -84,7 +89,7 @@ func getStatus(st *State, globalKey, badge string) (_ StatusInfo, err error) {
 		Status:  doc.Status,
 		Message: doc.StatusInfo,
 		Data:    unescapeKeys(doc.StatusData),
-		Since:   doc.Updated,
+		Since:   unixNanoToTime(doc.Updated),
 	}, nil
 }
 
@@ -140,17 +145,14 @@ func setStatus(st *State, params setStatusParams) (err error) {
 
 	// TODO(fwereade): this can/should probably be recording the time the
 	// status was *set*, not the time it happened to arrive in state.
-	// And we shouldn't be throwing away accuracy here -- neither to the
-	// second right here *or* by serializing into mongo as a time.Time,
-	// which also discards precision.
 	// We should almost certainly be accepting StatusInfo in the exposed
 	// SetStatus methods, for symetry with the Status methods.
-	now := nowToTheSecond()
+	now := time.Now().UnixNano()
 	doc := statusDoc{
 		Status:     params.status,
 		StatusInfo: params.message,
 		StatusData: escapeKeys(params.rawData),
-		Updated:    &now,
+		Updated:    now,
 	}
 	probablyUpdateStatusHistory(st, params.globalKey, doc)
 
@@ -187,30 +189,20 @@ func updateStatusSource(st *State, globalKey string, doc statusDoc) jujutxn.Tran
 }
 
 type historicalStatusDoc struct {
-	Id         int                    `bson:"_id"`
 	EnvUUID    string                 `bson:"env-uuid"`
-	EntityId   string                 `bson:"entityid"`
+	GlobalKey  string                 `bson:"globalkey"`
 	Status     Status                 `bson:"status"`
 	StatusInfo string                 `bson:"statusinfo"`
 	StatusData map[string]interface{} `bson:"statusdata"`
 
 	// Updated might not be present on statuses copied by old versions of juju
 	// from yet older versions of juju. Do not dereference without checking.
-	Updated *time.Time `bson:"updated"`
+	// Updated *time.Time `bson:"updated"`
+	Updated int64 `bson:"updated"`
 }
 
 func probablyUpdateStatusHistory(st *State, globalKey string, doc statusDoc) {
-	// TODO(fwereade): we do NOT need every single status-history operation
-	// to write to the same document in mongodb. If you need to order them,
-	// use a time representation that does not discard precision, like an
-	// int64 holding the time's UnixNanoseconds.
-	id, err := st.sequence("statushistory")
-	if err != nil {
-		logger.Errorf("failed to generate id for status history: %v", err)
-		return
-	}
 	historyDoc := &historicalStatusDoc{
-		Id: id,
 		// We can't guarantee that the statusDoc we're dealing with has the
 		// env-uuid filled in; and envStateCollection does not trap inserts.
 		// Good to be explicit; better to fix leaky abstraction.
@@ -219,7 +211,7 @@ func probablyUpdateStatusHistory(st *State, globalKey string, doc statusDoc) {
 		StatusInfo: doc.StatusInfo,
 		StatusData: doc.StatusData, // coming from a statusDoc, already escaped
 		Updated:    doc.Updated,
-		EntityId:   globalKey,
+		GlobalKey:  globalKey,
 	}
 	history, closer := st.getCollection(statusesHistoryC)
 	defer closer()
@@ -234,8 +226,8 @@ func statusHistory(st *State, globalKey string, size int) ([]StatusInfo, error) 
 	defer closer()
 
 	var docs []historicalStatusDoc
-	query := statusHistory.Find(bson.D{{"entityid", globalKey}})
-	err := query.Sort("-_id").Limit(size).All(&docs)
+	query := statusHistory.Find(bson.D{{"globalkey", globalKey}})
+	err := query.Sort("-updated").Limit(size).All(&docs)
 	if err == mgo.ErrNotFound {
 		return []StatusInfo{}, errors.NotFoundf("status history")
 	} else if err != nil {
@@ -248,7 +240,7 @@ func statusHistory(st *State, globalKey string, size int) ([]StatusInfo, error) 
 			Status:  doc.Status,
 			Message: doc.StatusInfo,
 			Data:    unescapeKeys(doc.StatusData),
-			Since:   doc.Updated,
+			Since:   unixNanoToTime(doc.Updated),
 		}
 	}
 	return results, nil
@@ -284,8 +276,8 @@ func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
 			continue
 		}
 		_, err = historyW.RemoveAll(bson.D{
-			{"entityid", globalKey},
-			{"_id", bson.M{"$lt": keepUpTo}},
+			{"globalkey", globalKey},
+			{"updated", bson.M{"$lt": keepUpTo}},
 		})
 		if err != nil {
 			return errors.Trace(err)
@@ -296,26 +288,26 @@ func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
 
 // getOldestTimeToKeep returns the create time for the oldest
 // status log to be kept.
-func getOldestTimeToKeep(coll mongo.Collection, globalKey string, size int) (int, bool, error) {
+func getOldestTimeToKeep(coll mongo.Collection, globalKey string, size int) (int64, bool, error) {
 	result := historicalStatusDoc{}
-	err := coll.Find(bson.D{{"entityid", globalKey}}).Sort("-_id").Skip(size - 1).One(&result)
+	err := coll.Find(bson.D{{"globalkey", globalKey}}).Sort("-updated").Skip(size - 1).One(&result)
 	if err == mgo.ErrNotFound {
 		return -1, false, nil
 	}
 	if err != nil {
 		return -1, false, errors.Trace(err)
 	}
-	return result.Id, true, nil
+	return result.Updated, true, nil
 
 }
 
 // getEntitiesWithStatuses returns the ids for all entities that
 // have history entries
 func getEntitiesWithStatuses(coll mongo.Collection) ([]string, error) {
-	var entityKeys []string
-	err := coll.Find(nil).Distinct("entityid", &entityKeys)
+	var globalKeys []string
+	err := coll.Find(nil).Distinct("globalkey", &globalKeys)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return entityKeys, nil
+	return globalKeys, nil
 }

--- a/state/status_service_test.go
+++ b/state/status_service_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -97,7 +99,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *ServiceStatusSuite) TestSetStatusSince(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := time.Now()
 
 	err := s.service.SetStatus(state.StatusMaintenance, "", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/status_unit_test.go
+++ b/state/status_unit_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -109,7 +111,7 @@ func (s *UnitStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) TestSetUnitStatusSince(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := time.Now()
 	err := s.unit.SetStatus(state.StatusMaintenance, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := s.unit.Status()

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -152,7 +152,7 @@ func timeBeforeOrEqual(timeBefore, timeOther time.Time) bool {
 }
 
 func (s *StatusUnitAgentSuite) TestSetAgentStatusSince(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := time.Now()
 	err := s.agent.SetStatus(state.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := s.agent.Status()

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1612,7 +1612,7 @@ func changeUpdatedType(st *State, collection string) error {
 		updated, ok := doc["updated"].(time.Time)
 		if ok {
 			if err := wColl.Update(bson.M{"_id": id}, bson.M{"$set": bson.M{"updated": updated.UTC().UnixNano()}}); err != nil {
-				return errors.Annotatef(err, "cannot change %v updated from time to int64", doc["_id"])
+				return errors.Annotatef(err, "cannot change %v updated from time to int64", id)
 			}
 		}
 	}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1571,6 +1571,10 @@ func changeIdsFromSeqToAuto(st *State) (err error) {
 	for _, doc := range docs {
 		id, ok := doc["_id"].(string)
 		if !ok {
+			if _, isObjectId := doc["_id"].(bson.ObjectId); isObjectId {
+				continue
+			}
+
 			return errors.Errorf("unexpected id: %v", doc["_id"])
 		}
 		_, err := strconv.ParseInt(id, 10, 64)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1549,8 +1549,7 @@ func ChangeStatusUpdatedType(st *State) error {
 
 func changeIdsFromSeqToAuto(st *State) (err error) {
 	var (
-		docs           []bson.M
-		updatedIdsDocs []bson.M
+		docs []bson.M
 	)
 	rawColl, closer := st.getRawCollection(statusesHistoryC)
 	defer closer()
@@ -1577,7 +1576,6 @@ func changeIdsFromSeqToAuto(st *State) (err error) {
 		_, err := strconv.ParseInt(id, 10, 64)
 		if err == nil {
 			delete(doc, "_id")
-			updatedIdsDocs = append(updatedIdsDocs, doc)
 			if err := writeableColl.Insert(doc); err != nil {
 				return errors.Annotate(err, "cannot insert replacement doc without sequential id")
 			}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1446,11 +1447,36 @@ func AddMissingEnvUUIDOnStatuses(st *State) error {
 	return nil
 }
 
+// runForAllEnvStates will run runner function for every env passing a state
+// for that env.
+func runForAllEnvStates(st *State, runner func(st *State) error) error {
+	environments, closer := st.getCollection(environmentsC)
+	defer closer()
+
+	var envDocs []bson.M
+	err := environments.Find(nil).Select(bson.M{"_id": 1}).All(&envDocs)
+	if err != nil {
+		return errors.Annotate(err, "failed to read environments")
+	}
+
+	for _, envDoc := range envDocs {
+		envUUID := envDoc["_id"].(string)
+		envSt, err := st.ForEnviron(names.NewEnvironTag(envUUID))
+		if err != nil {
+			return errors.Annotatef(err, "failed to open environment %q", envUUID)
+		}
+		defer envSt.Close()
+		if err := runner(envSt); err != nil {
+			return errors.Annotatef(err, "environment UUID %q", envUUID)
+		}
+	}
+	return nil
+}
+
 // AddMissingServiceStatuses creates all service status documents that do
 // not already exist.
 func AddMissingServiceStatuses(st *State) error {
-	// TODO(fwereade): crazy, done for consistency.
-	now := nowToTheSecond()
+	now := time.Now()
 
 	environments, closer := st.getCollection(environmentsC)
 	defer closer()
@@ -1483,7 +1509,7 @@ func AddMissingServiceStatuses(st *State) error {
 					EnvUUID:    envSt.EnvironUUID(),
 					Status:     StatusUnknown,
 					StatusInfo: MessageWaitForAgentInit,
-					Updated:    &now,
+					Updated:    now.UnixNano(),
 					// This exists to preserve questionable unit-aggregation behaviour
 					// while we work out how to switch to an implementation that makes
 					// sense. It is also set in AddService.
@@ -1499,6 +1525,131 @@ func AddMissingServiceStatuses(st *State) error {
 			} else if err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+// ChangeStatusHistoryUpdatedType seeks for historicalStatusDoc records
+// whose updated attribute is a time and converts them to int64.
+func ChangeStatusHistoryUpdatedType(st *State) error {
+	if err := runForAllEnvStates(st, changeIdsFromSeqToAuto); err != nil {
+		return errors.Annotate(err, "cannot update ids of status history")
+	}
+	run := func(st *State) error { return changeUpdatedType(st, statusesHistoryC) }
+	return runForAllEnvStates(st, run)
+}
+
+// ChangeStatusUpdatedType seeks for statusDoc records
+// whose updated attribute is a time and converts them to int64.
+func ChangeStatusUpdatedType(st *State) error {
+	run := func(st *State) error { return changeUpdatedType(st, statusesC) }
+	return runForAllEnvStates(st, run)
+}
+
+func changeIdsFromSeqToAuto(st *State) (err error) {
+	var (
+		docs           []bson.M
+		updatedIdsDocs []bson.M
+	)
+	rawColl, closer := st.getRawCollection(statusesHistoryC)
+	defer closer()
+
+	coll, closer := st.getCollection(statusesHistoryC)
+	defer closer()
+
+	// Filtering is done by hand because the ids we are trying to modify
+	// do not have uuid.
+	err = rawColl.Find(bson.M{"env-uuid": st.EnvironUUID()}).All(&docs)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Annotatef(err, "cannot find all docs for %q", statusesHistoryC)
+	}
+
+	writeableColl := coll.Writeable()
+	for _, doc := range docs {
+		id, ok := doc["_id"].(string)
+		if !ok {
+			return errors.Errorf("unexpected id: %v", doc["_id"])
+		}
+		_, err := strconv.ParseInt(id, 10, 64)
+		if err == nil {
+			delete(doc, "_id")
+			updatedIdsDocs = append(updatedIdsDocs, doc)
+			if err := writeableColl.Insert(doc); err != nil {
+				return errors.Annotate(err, "cannot insert replacement doc without sequential id")
+			}
+			if err := rawColl.Remove(bson.M{"_id": id}); err != nil {
+				return errors.Annotatef(err, "cannot migrate %q ids from sequences, current id is: %s", statusesHistoryC, id)
+			}
+		}
+	}
+	return nil
+
+}
+
+func changeUpdatedType(st *State, collection string) error {
+	var docs []bson.M
+	coll, closer := st.getCollection(collection)
+	defer closer()
+
+	err := coll.Find(nil).All(&docs)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Annotatef(err, "cannot find all docs for collection %q", collection)
+	}
+
+	wColl := coll.Writeable()
+	for _, doc := range docs {
+		id := doc["_id"].(string)
+		updated, ok := doc["updated"].(time.Time)
+		if ok {
+			if err := wColl.UpdateId(id, bson.M{"updated": updated.UTC().UnixNano()}); err != nil {
+				return errors.Annotatef(err, "cannot change %q updated from time to int64", id)
+			}
+
+		}
+	}
+	return nil
+
+}
+
+// ChangeStatusHistoryEntityId renames entityId field to globalkey.
+func ChangeStatusHistoryEntityId(st *State) error {
+	return runForAllEnvStates(st, changeStatusHistoryEntityId)
+}
+
+func changeStatusHistoryEntityId(st *State) error {
+	statusHistory, closer := st.getRawCollection(statusesHistoryC)
+	defer closer()
+
+	var docs []bson.M
+	err := statusHistory.Find(bson.D{{
+		"entityid", bson.D{{"$exists", true}}}}).All(&docs)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Annotate(err, "cannot get entity ids")
+	}
+	for _, doc := range docs {
+		id, ok := doc["_id"].(string)
+		if !ok {
+			return errors.Errorf("unexpected id: %v", doc["_id"])
+		}
+		entityId, ok := doc["entityid"].(string)
+		if !ok {
+			return errors.Errorf("unexpected entity id: %v", doc["entityid"])
+		}
+		err := statusHistory.UpdateId(id, bson.M{
+			"$set":   bson.M{"globalkey": entityId},
+			"$unset": bson.M{"entityid": nil}})
+		if err != nil {
+			return errors.Annotatef(err, "cannot update %q entityid to globalkey", id)
 		}
 	}
 	return nil

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3468,7 +3468,8 @@ func (s *upgradesSuite) TestChangeEntityIdToGlobalKey(c *gc.C) {
 		"entityid", bson.D{{"$exists", true}}}}).All(&docs)
 	c.Assert(docs, gc.HasLen, 4)
 
-	ChangeStatusHistoryEntityId(s.state)
+	err = ChangeStatusHistoryEntityId(s.state)
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = sHistory.Find(bson.D{{
 		"entityid", bson.D{{"$exists", true}}}}).All(&docs)

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -39,6 +39,27 @@ func stateStepsFor124() []Step {
 				return migrateCharmStorage(context.State(), context.AgentConfig())
 			},
 		},
+		&upgradeStep{
+			description: "change entityid field on status history to globalkey",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.ChangeStatusHistoryEntityId(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "change updated field on statushistory from time to int",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.ChangeStatusHistoryUpdatedType(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "change updated field on status from time to int",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.ChangeStatusUpdatedType(context.State())
+			},
+		},
 	}
 }
 

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -29,6 +29,9 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 		"add block device documents for existing machines",
 		"add instance id field to IP addresses",
 		"migrate charm archives into environment storage",
+		"change entityid field on status history to globalkey",
+		"change updated field on statushistory from time to int",
+		"change updated field on status from time to int",
 	}
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
 }


### PR DESCRIPTION
Status history used a sequence as _id this was a poor decision
because it caused excessive writes to a given doc and also produced
a bug (lp:1479289) where statuses with clashing data where inserted
from various envs.
I changed the _ids to be handled by mgo, changed entityid to be
named globalkey as it is what it actually is and changed updated
field to hold an int64 thus improving precission of the stored time.

(Review request: http://reviews.vapour.ws/r/2297/)