### PR TITLE
fwport fix for 1479289: Removed sequence from status history.

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -6,6 +6,7 @@ package state
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -466,13 +467,10 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 		Insert: mdoc,
 	}
 
-	// TODO(fwereade) this nowToTheSecond thing is crazy, and done only for
-	// consistency -- we should be storing timestamps properly.
-	now := nowToTheSecond()
 	statusDoc := statusDoc{
 		Status:  StatusPending,
 		EnvUUID: st.EnvironUUID(),
-		Updated: &now,
+		Updated: time.Now().UnixNano(),
 	}
 	globalKey := machineGlobalKey(mdoc.Id)
 	prereqOps = []txn.Op{

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -299,7 +299,7 @@ func allCollections() collectionSchema {
 		statusesC:           {},
 		statusesHistoryC: {
 			indexes: []mgo.Index{{
-				Key: []string{"env-uuid", "entityid"},
+				Key: []string{"env-uuid", "globalkey"},
 			}},
 		},
 

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -508,7 +508,7 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id string) 
 		newInfo.Status.Current = multiwatcher.Status(s.Status)
 		newInfo.Status.Message = s.StatusInfo
 		newInfo.Status.Data = s.StatusData
-		newInfo.Status.Since = s.Updated
+		newInfo.Status.Since = unixNanoToTime(s.Updated)
 		info0 = &newInfo
 	case *multiwatcher.MachineInfo:
 		newInfo := *info
@@ -529,19 +529,19 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 		newInfo.WorkloadStatus.Current = multiwatcher.Status(s.Status)
 		newInfo.WorkloadStatus.Message = s.StatusInfo
 		newInfo.WorkloadStatus.Data = s.StatusData
-		newInfo.WorkloadStatus.Since = s.Updated
+		newInfo.WorkloadStatus.Since = unixNanoToTime(s.Updated)
 	} else {
 		newInfo.AgentStatus.Current = multiwatcher.Status(s.Status)
 		newInfo.AgentStatus.Message = s.StatusInfo
 		newInfo.AgentStatus.Data = s.StatusData
-		newInfo.AgentStatus.Since = s.Updated
+		newInfo.AgentStatus.Since = unixNanoToTime(s.Updated)
 		// If the unit was in error and now it's not, we need to reset its
 		// status back to what was previously recorded.
 		if newInfo.WorkloadStatus.Current == multiwatcher.Status(StatusError) {
 			newInfo.WorkloadStatus.Current = multiwatcher.Status(unitStatus.Status)
 			newInfo.WorkloadStatus.Message = unitStatus.Message
 			newInfo.WorkloadStatus.Data = unitStatus.Data
-			newInfo.WorkloadStatus.Since = s.Updated
+			newInfo.WorkloadStatus.Since = unixNanoToTime(s.Updated)
 		}
 	}
 

--- a/state/service.go
+++ b/state/service.go
@@ -701,14 +701,14 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	now := time.Now()
 	agentStatusDoc := statusDoc{
 		Status:  StatusAllocating,
-		Updated: &now,
+		Updated: now.UnixNano(),
 		EnvUUID: s.st.EnvironUUID(),
 	}
 	unitStatusDoc := statusDoc{
 		// TODO(fwereade): this violates the spec. Should be "waiting".
 		Status:     StatusUnknown,
 		StatusInfo: MessageWaitForAgentInit,
-		Updated:    &now,
+		Updated:    now.UnixNano(),
 		EnvUUID:    s.st.EnvironUUID(),
 	}
 	ops := []txn.Op{

--- a/state/state.go
+++ b/state/state.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -1121,8 +1122,6 @@ func (st *State) AddService(
 	}
 	svc := newService(st, svcDoc)
 
-	// TODO(fwereade): crazy, done for consistency.
-	now := nowToTheSecond()
 	statusDoc := statusDoc{
 		EnvUUID: st.EnvironUUID(),
 		// TODO(fwereade): this violates the spec. Should be "waiting".
@@ -1130,7 +1129,7 @@ func (st *State) AddService(
 		// behaviour.
 		Status:     StatusUnknown,
 		StatusInfo: MessageWaitForAgentInit,
-		Updated:    &now,
+		Updated:    time.Now().UnixNano(),
 		// This exists to preserve questionable unit-aggregation behaviour
 		// while we work out how to switch to an implementation that makes
 		// sense. It is also set in AddMissingServiceStatuses.

--- a/state/status_service_test.go
+++ b/state/status_service_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -97,7 +99,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *ServiceStatusSuite) TestSetStatusSince(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := time.Now()
 
 	err := s.service.SetStatus(state.StatusMaintenance, "", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/status_unit_test.go
+++ b/state/status_unit_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -109,7 +111,7 @@ func (s *UnitStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) TestSetUnitStatusSince(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := time.Now()
 	err := s.unit.SetStatus(state.StatusMaintenance, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := s.unit.Status()

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -152,7 +152,7 @@ func timeBeforeOrEqual(timeBefore, timeOther time.Time) bool {
 }
 
 func (s *StatusUnitAgentSuite) TestSetAgentStatusSince(c *gc.C) {
-	now := state.NowToTheSecond()
+	now := time.Now()
 	err := s.agent.SetStatus(state.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := s.agent.Status()

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1876,6 +1876,10 @@ func changeIdsFromSeqToAuto(st *State) (err error) {
 	for _, doc := range docs {
 		id, ok := doc["_id"].(string)
 		if !ok {
+			if _, isObjectId := doc["_id"].(bson.ObjectId); isObjectId {
+				continue
+			}
+
 			return errors.Errorf("unexpected id: %v", doc["_id"])
 		}
 		_, err := strconv.ParseInt(id, 10, 64)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1583,11 +1584,36 @@ func AddMissingEnvUUIDOnStatuses(st *State) error {
 	return nil
 }
 
+// runForAllEnvStates will run runner function for every env passing a state
+// for that env.
+func runForAllEnvStates(st *State, runner func(st *State) error) error {
+	environments, closer := st.getCollection(environmentsC)
+	defer closer()
+
+	var envDocs []bson.M
+	err := environments.Find(nil).Select(bson.M{"_id": 1}).All(&envDocs)
+	if err != nil {
+		return errors.Annotate(err, "failed to read environments")
+	}
+
+	for _, envDoc := range envDocs {
+		envUUID := envDoc["_id"].(string)
+		envSt, err := st.ForEnviron(names.NewEnvironTag(envUUID))
+		if err != nil {
+			return errors.Annotatef(err, "failed to open environment %q", envUUID)
+		}
+		defer envSt.Close()
+		if err := runner(envSt); err != nil {
+			return errors.Annotatef(err, "environment UUID %q", envUUID)
+		}
+	}
+	return nil
+}
+
 // AddMissingServiceStatuses creates all service status documents that do
 // not already exist.
 func AddMissingServiceStatuses(st *State) error {
-	// TODO(fwereade): crazy, done for consistency.
-	now := nowToTheSecond()
+	now := time.Now()
 
 	environments, closer := st.getCollection(environmentsC)
 	defer closer()
@@ -1620,7 +1646,7 @@ func AddMissingServiceStatuses(st *State) error {
 					EnvUUID:    envSt.EnvironUUID(),
 					Status:     StatusUnknown,
 					StatusInfo: MessageWaitForAgentInit,
-					Updated:    &now,
+					Updated:    now.UnixNano(),
 					// This exists to preserve questionable unit-aggregation behaviour
 					// while we work out how to switch to an implementation that makes
 					// sense. It is also set in AddService.
@@ -1636,38 +1662,6 @@ func AddMissingServiceStatuses(st *State) error {
 			} else if err != nil {
 				return err
 			}
-		}
-	}
-	return nil
-}
-
-// AddStorageAttachmentCount adds storageInstanceDoc.AttachmentCount and
-// sets the right number to it.
-//func AddStorageAttachmentCount(st *State) error {
-//	return addAttachmentCount(st, storageInstancesC)
-//}
-
-// runForAllEnvStates will run runner function for every env passing a state
-// for that env.
-func runForAllEnvStates(st *State, runner func(st *State) error) error {
-	environments, closer := st.getCollection(environmentsC)
-	defer closer()
-
-	var envDocs []bson.M
-	err := environments.Find(nil).Select(bson.M{"_id": 1}).All(&envDocs)
-	if err != nil {
-		return errors.Annotate(err, "failed to read environments")
-	}
-
-	for _, envDoc := range envDocs {
-		envUUID := envDoc["_id"].(string)
-		envSt, err := st.ForEnviron(names.NewEnvironTag(envUUID))
-		if err != nil {
-			return errors.Annotatef(err, "failed to open environment %q", envUUID)
-		}
-		defer envSt.Close()
-		if err := runner(envSt); err != nil {
-			return errors.Annotatef(err, "environment UUID %q", envUUID)
 		}
 	}
 	return nil
@@ -1839,4 +1833,132 @@ func addBindingToFilesystems(st *State) error {
 // AddBindingToFilesystems adds the binding field to filesystemDoc and populates it.
 func AddBindingToFilesystems(st *State) error {
 	return runForAllEnvStates(st, addBindingToFilesystems)
+}
+
+// ChangeStatusHistoryUpdatedType seeks for historicalStatusDoc records
+// whose updated attribute is a time and converts them to int64.
+func ChangeStatusHistoryUpdatedType(st *State) error {
+	if err := runForAllEnvStates(st, changeIdsFromSeqToAuto); err != nil {
+		return errors.Annotate(err, "cannot update ids of status history")
+	}
+	run := func(st *State) error { return changeUpdatedType(st, statusesHistoryC) }
+	return runForAllEnvStates(st, run)
+}
+
+// ChangeStatusUpdatedType seeks for statusDoc records
+// whose updated attribute is a time and converts them to int64.
+func ChangeStatusUpdatedType(st *State) error {
+	run := func(st *State) error { return changeUpdatedType(st, statusesC) }
+	return runForAllEnvStates(st, run)
+}
+
+func changeIdsFromSeqToAuto(st *State) (err error) {
+	var (
+		docs []bson.M
+	)
+	rawColl, closer := st.getRawCollection(statusesHistoryC)
+	defer closer()
+
+	coll, closer := st.getCollection(statusesHistoryC)
+	defer closer()
+
+	// Filtering is done by hand because the ids we are trying to modify
+	// do not have uuid.
+	err = rawColl.Find(bson.M{"env-uuid": st.EnvironUUID()}).All(&docs)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Annotatef(err, "cannot find all docs for %q", statusesHistoryC)
+	}
+
+	writeableColl := coll.Writeable()
+	for _, doc := range docs {
+		id, ok := doc["_id"].(string)
+		if !ok {
+			return errors.Errorf("unexpected id: %v", doc["_id"])
+		}
+		_, err := strconv.ParseInt(id, 10, 64)
+		if err == nil {
+			// _id will be automatically added by mongo upon insert.
+			delete(doc, "_id")
+			if err := writeableColl.Insert(doc); err != nil {
+				return errors.Annotate(err, "cannot insert replacement doc without sequential id")
+			}
+			if err := rawColl.Remove(bson.M{"_id": id}); err != nil {
+				return errors.Annotatef(err, "cannot migrate %q ids from sequences, current id is: %s", statusesHistoryC, id)
+			}
+		}
+	}
+	return nil
+
+}
+
+func changeUpdatedType(st *State, collection string) error {
+	var docs []bson.M
+	coll, closer := st.getCollection(collection)
+	defer closer()
+	err := coll.Find(nil).All(&docs)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Annotatef(err, "cannot find all docs for collection %q", collection)
+	}
+
+	wColl := coll.Writeable()
+	for _, doc := range docs {
+		_, okString := doc["_id"].(string)
+		_, okOid := doc["_id"].(bson.ObjectId)
+		if !okString && !okOid {
+			return errors.Errorf("unexpected id: %v", doc["_id"])
+		}
+		id := doc["_id"]
+		updated, ok := doc["updated"].(time.Time)
+		if ok {
+			if err := wColl.Update(bson.M{"_id": id}, bson.M{"$set": bson.M{"updated": updated.UTC().UnixNano()}}); err != nil {
+				return errors.Annotatef(err, "cannot change %v updated from time to int64", id)
+			}
+		}
+	}
+	return nil
+}
+
+// ChangeStatusHistoryEntityId renames entityId field to globalkey.
+func ChangeStatusHistoryEntityId(st *State) error {
+	return runForAllEnvStates(st, changeStatusHistoryEntityId)
+}
+
+func changeStatusHistoryEntityId(st *State) error {
+	statusHistory, closer := st.getRawCollection(statusesHistoryC)
+	defer closer()
+
+	var docs []bson.M
+	err := statusHistory.Find(bson.D{{
+		"entityid", bson.D{{"$exists", true}}}}).All(&docs)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Annotate(err, "cannot get entity ids")
+	}
+	for _, doc := range docs {
+		_, okString := doc["_id"].(string)
+		_, okOid := doc["_id"].(bson.ObjectId)
+		if !okString && !okOid {
+			return errors.Errorf("unexpected id: %v", doc["_id"])
+		}
+		id := doc["_id"]
+		entityId, ok := doc["entityid"].(string)
+		if !ok {
+			return errors.Errorf("unexpected entity id: %v", doc["entityid"])
+		}
+		err := statusHistory.Update(bson.M{"_id": id}, bson.M{
+			"$set":   bson.M{"globalkey": entityId},
+			"$unset": bson.M{"entityid": nil}})
+		if err != nil {
+			return errors.Annotatef(err, "cannot update %q entityid to globalkey", id)
+		}
+	}
+	return nil
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3195,7 +3195,7 @@ func (s *upgradesSuite) TestSetHostedEnvironCountIdempotent(c *gc.C) {
 var index uint32
 
 // We can't use factory.MakeEnvironment due to an import cycle.
-func (s *upgradesSuite) makeEnvironment(c *gc.C) {
+func (s *upgradesSuite) makeEnvironment(c *gc.C) string {
 	st := s.state
 
 	env, err := st.Environment()
@@ -3211,6 +3211,7 @@ func (s *upgradesSuite) makeEnvironment(c *gc.C) {
 
 	err = st.runTransaction(ops)
 	c.Assert(err, jc.ErrorIsNil)
+	return uuid.String()
 }
 
 func (s *upgradesSuite) removeEnvCountDoc(c *gc.C) {
@@ -3362,7 +3363,7 @@ func (s *upgradesSuite) TestAddMissingServiceStatuses(c *gc.C) {
 	checkHistoryInserted := func(envUUID, entityid string) {
 		var doc statusDoc
 		err = history.Find(bson.D{{
-			"entityid", entityid,
+			"globalkey", entityid,
 		}, {
 			"env-uuid", envUUID,
 		}}).One(&doc)
@@ -3370,12 +3371,7 @@ func (s *upgradesSuite) TestAddMissingServiceStatuses(c *gc.C) {
 		checkStatusDoc(doc, false)
 	}
 	checkHistoryInserted(uuid0, "s#bar")
-
-	// TODO(fwereade): lp:1479289
-	// This doesn't work because we use sequence and can't prefix and int _id
-	// with the env-uuid, and thus end up with duplicate key errors when
-	// inserting history across multiple environments.
-	//checkHistoryInserted(uuid1, "s#ping")
+	checkHistoryInserted(uuid1, "s#ping")
 }
 
 func unsetField(st *State, id, collection, field string) error {
@@ -3573,4 +3569,347 @@ func (s *upgradesSuite) TestAddBindingToFilesystemsStorageBound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertFilesystemBinding(s.state, c, "storage-data-0")
+}
+
+func (s *upgradesSuite) TestChangeIdsFromSeqToAuto(c *gc.C) {
+	// Crate a new environment
+	uuid0 := s.makeEnvironment(c)
+	// Insert basic test data
+	sHistory, closer := s.state.getRawCollection(statusesHistoryC)
+	defer closer()
+	err := sHistory.Insert(
+		bson.D{
+			{"_id", "1"},
+			{"env-uuid", uuid0},
+			{"status", "status 1"},
+		},
+		bson.D{
+			{"_id", "2"},
+			{"env-uuid", uuid0},
+			{"status", "status 2"},
+		},
+		bson.D{
+			{"_id", "3"},
+			{"env-uuid", uuid0},
+			{"status", "status 3"},
+		},
+		bson.D{
+			{"_id", "4"},
+			{"env-uuid", uuid0},
+			{"status", "status 4"},
+		},
+		bson.D{
+			{"_id", "this is not a seq number"},
+			{"env-uuid", uuid0},
+			{"status", "status not sequence"},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// assert that the ids are in fact ints.
+	for i := 1; i < 5; i++ {
+		logger.Infof("checking that id %d is correctly in status history", i)
+		n, err := sHistory.FindId(fmt.Sprintf("%d", i)).Count()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(n, gc.Equals, 1)
+	}
+
+	// Get State for a particular env simulating runForAllEnvStates
+	envSt, err := s.state.ForEnviron(names.NewEnvironTag(uuid0))
+	defer envSt.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = changeIdsFromSeqToAuto(envSt)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// assert that there are no more int ids.
+	for i := 1; i < 5; i++ {
+		logger.Infof("checking that id %d is no longer in status history", i)
+		n, err := sHistory.FindId(fmt.Sprintf("%d", i)).Count()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(n, gc.Equals, 0)
+	}
+	// assert that the non int id was left untouched.
+	var doc bson.M
+	err = sHistory.FindId("this is not a seq number").One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	status := doc["status"].(string)
+	c.Assert(status, gc.Equals, "status not sequence")
+
+	// assert that the statuses left are correct.
+	var docs []bson.M
+	err = sHistory.Find(nil).All(&docs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(docs, gc.HasLen, 5)
+	statuses := make([]string, len(docs))
+	for i, d := range docs {
+		statuses[i] = d["status"].(string)
+	}
+
+	c.Assert(statuses, jc.SameContents, []string{"status 1", "status 2", "status 3", "status 4", "status not sequence"})
+}
+
+func (s *upgradesSuite) TestChangeStatusHistoryUpdatedFromTimeToInt64(c *gc.C) {
+	uuid0 := s.makeEnvironment(c)
+	uuid1 := s.makeEnvironment(c)
+	sHistory, closer := s.state.getRawCollection(statusesHistoryC)
+	defer closer()
+	epoch := time.Unix(0, 0).UTC()
+	// lets create a time with fine precision to check its left
+	// untouched.
+	nanoTime := epoch.Add(3 * time.Hour).Add(4 * time.Nanosecond).UTC().UnixNano()
+	err := sHistory.Insert(
+		bson.D{
+			{"_id", "0"},
+			{"test_id", "0"},
+			{"env-uuid", uuid0},
+			{"updated", epoch.Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", "1"},
+			{"test_id", "1"},
+			{"env-uuid", uuid0},
+			{"updated", epoch.Add(1 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", "2"},
+			{"test_id", "2"},
+			{"env-uuid", uuid0},
+			{"updated", epoch.Add(2 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", "3"},
+			{"test_id", "3"},
+			{"env-uuid", uuid1},
+			{"updated", epoch.Add(3 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", "4"},
+			{"test_id", "4"},
+			{"env-uuid", uuid1},
+			{"updated", epoch.Add(4 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", "5"},
+			{"test_id", "5"},
+			{"env-uuid", uuid1},
+			{"updated", epoch.Add(5 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", "6"},
+			{"test_id", "6"},
+			{"env-uuid", uuid0},
+			{"updated", nanoTime},
+		},
+		bson.D{
+			{"_id", "7"},
+			{"test_id", "7"},
+			{"env-uuid", uuid1},
+			{"updated", nanoTime},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = ChangeStatusHistoryUpdatedType(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+	var docs []bson.M
+	sHistory.Find(nil).All(&docs)
+	logger.Debugf("%v", docs)
+
+	var doc bson.M
+	for i := 0; i < 6; i++ {
+		logger.Debugf("checking entry %d", i)
+		err := sHistory.Find(bson.M{"test_id": fmt.Sprintf("%d", i)}).One(&doc)
+		c.Assert(err, jc.ErrorIsNil)
+
+		logger.Debugf("checking doc: %v", doc)
+		updatedTime, ok := doc["updated"].(int64)
+		c.Assert(ok, jc.IsTrue)
+		// time stored in mongo native format will have lost precision
+		c.Assert(updatedTime, gc.Equals, epoch.Add(time.Duration(i)*time.Hour).UTC().UnixNano())
+
+		newId, ok := doc["_id"].(bson.ObjectId)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(newId, gc.Not(gc.Equals), fmt.Sprintf("%d", i))
+	}
+	sHistory.Find(bson.M{"test_id": "6"}).One(&doc)
+	updatedTime, ok := doc["updated"].(int64)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(updatedTime, gc.Equals, nanoTime)
+	newId, ok := doc["_id"].(bson.ObjectId)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(newId, gc.Not(gc.Equals), "6")
+
+	sHistory.Find(bson.M{"test_id": "7"}).One(&doc)
+	updatedTime, ok = doc["updated"].(int64)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(updatedTime, gc.Equals, nanoTime)
+	newId, ok = doc["_id"].(bson.ObjectId)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(newId, gc.Not(gc.Equals), "7")
+
+}
+
+func (s *upgradesSuite) TestChangeStatusUpdatedFromTimeToInt64(c *gc.C) {
+	uuid0 := s.makeEnvironment(c)
+	uuid1 := s.makeEnvironment(c)
+	statuses, closer := s.state.getRawCollection(statusesC)
+	defer closer()
+	epoch := time.Unix(0, 0).UTC()
+	// lets create a time with fine precision to check its left
+	// untouched.
+	nanoTime := epoch.Add(3 * time.Hour).Add(4 * time.Nanosecond).UTC().UnixNano()
+	err := statuses.Insert(
+		bson.D{
+			{"_id", uuid0 + ":0"},
+			{"test_id", "0"},
+			{"env-uuid", uuid0},
+			{"updated", epoch.Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", uuid0 + ":1"},
+			{"test_id", "1"},
+			{"env-uuid", uuid0},
+			{"updated", epoch.Add(1 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", uuid0 + ":2"},
+			{"test_id", "2"},
+			{"env-uuid", uuid0},
+			{"updated", epoch.Add(2 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", uuid1 + ":3"},
+			{"test_id", "3"},
+			{"env-uuid", uuid1},
+			{"updated", epoch.Add(3 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", uuid1 + ":4"},
+			{"test_id", "4"},
+			{"env-uuid", uuid1},
+			{"updated", epoch.Add(4 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", uuid1 + ":5"},
+			{"test_id", "5"},
+			{"env-uuid", uuid1},
+			{"updated", epoch.Add(5 * time.Hour).Add(2 * time.Nanosecond)},
+		},
+		bson.D{
+			{"_id", uuid0 + ":6"},
+			{"test_id", "6"},
+			{"env-uuid", uuid0},
+			{"updated", nanoTime},
+		},
+		bson.D{
+			{"_id", uuid1 + ":7"},
+			{"test_id", "7"},
+			{"env-uuid", uuid1},
+			{"updated", nanoTime},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = ChangeStatusUpdatedType(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var doc bson.M
+	for i := 0; i < 6; i++ {
+		logger.Debugf("checking entry %d", i)
+		err := statuses.Find(bson.M{"test_id": fmt.Sprintf("%d", i)}).One(&doc)
+		c.Assert(err, jc.ErrorIsNil)
+
+		logger.Debugf("checking doc: %v", doc)
+		updatedTime, ok := doc["updated"].(int64)
+		c.Assert(ok, jc.IsTrue)
+		// time stored in mongo native format will have lost precision
+		c.Assert(updatedTime, gc.Equals, epoch.Add(time.Duration(i)*time.Hour).UTC().UnixNano())
+	}
+	statuses.Find(bson.M{"test_id": "6"}).One(&doc)
+	updatedTime, ok := doc["updated"].(int64)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(updatedTime, gc.Equals, nanoTime)
+
+	statuses.Find(bson.M{"test_id": "7"}).One(&doc)
+	updatedTime, ok = doc["updated"].(int64)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(updatedTime, gc.Equals, nanoTime)
+}
+
+func (s *upgradesSuite) TestChangeEntityIdToGlobalKey(c *gc.C) {
+	uuid0 := s.makeEnvironment(c)
+	uuid1 := s.makeEnvironment(c)
+	sHistory, closer := s.state.getRawCollection(statusesHistoryC)
+	defer closer()
+
+	err := sHistory.Insert(
+		bson.D{
+			{"_id", uuid0 + ":0"},
+			{"env-uuid", uuid0},
+			{"entityid", "global0"},
+		},
+		bson.D{
+			{"_id", uuid0 + ":1"},
+			{"env-uuid", uuid0},
+			{"entityid", "global1"},
+		},
+		bson.D{
+			{"_id", uuid0 + ":2"},
+			{"env-uuid", uuid0},
+			{"globalkey", "global2"},
+		},
+		bson.D{
+			{"_id", uuid0 + ":3"},
+			{"env-uuid", uuid0},
+			{"globalkey", "global3"},
+		},
+		bson.D{
+			{"_id", uuid1 + ":4"},
+			{"env-uuid", uuid1},
+			{"entityid", "global4"},
+		},
+		bson.D{
+			{"_id", uuid1 + ":5"},
+			{"env-uuid", uuid1},
+			{"entityid", "global5"},
+		},
+		bson.D{
+			{"_id", uuid1 + ":6"},
+			{"env-uuid", uuid1},
+			{"globalkey", "global6"},
+		},
+		bson.D{
+			{"_id", uuid1 + ":7"},
+			{"env-uuid", uuid1},
+			{"globalkey", "global7"},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var docs []bson.M
+	err = sHistory.Find(bson.D{{
+		"entityid", bson.D{{"$exists", true}}}}).All(&docs)
+	c.Assert(docs, gc.HasLen, 4)
+
+	ChangeStatusHistoryEntityId(s.state)
+
+	err = sHistory.Find(bson.D{{
+		"entityid", bson.D{{"$exists", true}}}}).All(&docs)
+	c.Assert(docs, gc.HasLen, 0)
+
+	var doc bson.M
+	for i := 0; i < 8; i++ {
+		u := uuid0
+		if i > 3 {
+			u = uuid1
+		}
+		logger.Debugf("checking global key %d", i)
+		logger.Debugf("doc has: %v", doc)
+		err := sHistory.FindId(fmt.Sprintf("%s:%d", u, i)).One(&doc)
+		c.Assert(err, jc.ErrorIsNil)
+		globalKey, ok := doc["globalkey"].(string)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(globalKey, gc.Equals, fmt.Sprintf("global%d", i))
+	}
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3892,7 +3892,8 @@ func (s *upgradesSuite) TestChangeEntityIdToGlobalKey(c *gc.C) {
 		"entityid", bson.D{{"$exists", true}}}}).All(&docs)
 	c.Assert(docs, gc.HasLen, 4)
 
-	ChangeStatusHistoryEntityId(s.state)
+	err = ChangeStatusHistoryEntityId(s.state)
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = sHistory.Find(bson.D{{
 		"entityid", bson.D{{"$exists", true}}}}).All(&docs)

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -48,6 +48,27 @@ func stateStepsFor124() []Step {
 				return migrateCharmStorage(context.State(), context.AgentConfig())
 			},
 		},
+		&upgradeStep{
+			description: "change entityid field on status history to globalkey",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.ChangeStatusHistoryEntityId(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "change updated field on statushistory from time to int",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.ChangeStatusHistoryUpdatedType(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "change updated field on status from time to int",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.ChangeStatusUpdatedType(context.State())
+			},
+		},
 	}
 }
 

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -30,6 +30,9 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 		"add instance id field to IP addresses",
 		"add UUID field to IP addresses",
 		"migrate charm archives into environment storage",
+		"change entityid field on status history to globalkey",
+		"change updated field on statushistory from time to int",
+		"change updated field on status from time to int",
 	}
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
 }


### PR DESCRIPTION
Status history used a sequence as _id, this was a poor decision
because it caused excessive writes to a given doc and also produced
a bug (lp:1479289) where statuses with clashing data where inserted
from various envs.
I changed the _ids to be handled by mgo, changed entityid to be
named globalkey as it is what it actually is and changed updated
field to hold an int64 thus improving precission of the stored time.
This is a fwport of rb:2297 it required some changes by hand so its not a straight
cherry pick from the merge.

(Review request: http://reviews.vapour.ws/r/2299/)