### PR TITLE
Added a context prepare step.

### DIFF
--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -49,6 +49,10 @@ func (ra *runAction) Prepare(state State) (*State, error) {
 		// this should *really* never happen, but let's not panic
 		return nil, errors.Trace(err)
 	}
+	err = rnr.Context().Prepare()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	ra.name = actionData.Name
 	ra.runner = rnr
 	return stateChange{

--- a/worker/uniter/operation/runcommands.go
+++ b/worker/uniter/operation/runcommands.go
@@ -47,7 +47,12 @@ func (rc *runCommands) Prepare(state State) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = rnr.Context().Prepare()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	rc.runner = rnr
+
 	return nil, nil
 }
 

--- a/worker/uniter/operation/runcommands_test.go
+++ b/worker/uniter/operation/runcommands_test.go
@@ -42,8 +42,13 @@ func (s *RunCommandsSuite) TestPrepareError(c *gc.C) {
 }
 
 func (s *RunCommandsSuite) TestPrepareSuccess(c *gc.C) {
+	ctx := &MockContext{}
 	runnerFactory := &MockRunnerFactory{
-		MockNewCommandRunner: &MockNewCommandRunner{},
+		MockNewCommandRunner: &MockNewCommandRunner{
+			runner: &MockRunner{
+				context: ctx,
+			},
+		},
 	}
 	factory := operation.NewFactory(operation.FactoryParams{
 		RunnerFactory: runnerFactory,
@@ -60,6 +65,30 @@ func (s *RunCommandsSuite) TestPrepareSuccess(c *gc.C) {
 		RemoteUnitName:  "foo/456",
 		ForceRemoteUnit: true,
 	})
+	ctx.CheckCall(c, 0, "Prepare")
+}
+
+func (s *RunCommandsSuite) TestPrepareCtxError(c *gc.C) {
+	ctx := &MockContext{}
+	ctx.SetErrors(errors.New("ctx prepare error"))
+	runnerFactory := &MockRunnerFactory{
+		MockNewCommandRunner: &MockNewCommandRunner{
+			runner: &MockRunner{
+				context: ctx,
+			},
+		},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		RunnerFactory: runnerFactory,
+	})
+	sendResponse := func(*utilexec.ExecResponse, error) { panic("not expected") }
+	op, err := factory.NewCommands(someCommandArgs, sendResponse)
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Prepare(operation.State{})
+	c.Assert(err, gc.ErrorMatches, "ctx prepare error")
+	c.Assert(newState, gc.IsNil)
+	ctx.CheckCall(c, 0, "Prepare")
 }
 
 func (s *RunCommandsSuite) TestExecuteRebootErrors(c *gc.C) {

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -55,6 +55,10 @@ func (rh *runHook) Prepare(state State) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = rnr.Context().Prepare()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	rh.name = name
 	rh.runner = rnr
 

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -5,6 +5,7 @@ package operation_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	utilexec "github.com/juju/utils/exec"
 	corecharm "gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charm.v5/hooks"
@@ -294,6 +295,7 @@ func (f *MockRunnerFactory) NewCommandRunner(commandInfo runner.CommandInfo) (ru
 
 type MockContext struct {
 	runner.Context
+	testing.Stub
 	actionData      *runner.ActionData
 	setStatusCalled bool
 	status          jujuc.StatusInfo
@@ -322,6 +324,11 @@ func (mock *MockContext) SetUnitStatus(status jujuc.StatusInfo) error {
 
 func (mock *MockContext) UnitStatus() (*jujuc.StatusInfo, error) {
 	return &mock.status, nil
+}
+
+func (mock *MockContext) Prepare() error {
+	mock.MethodCall(mock, "Prepare")
+	return mock.NextErr()
 }
 
 type MockRunAction struct {
@@ -427,6 +434,7 @@ func NewRunCommandsRunnerFactory(runResponse *utilexec.ExecResponse, runErr erro
 		MockNewCommandRunner: &MockNewCommandRunner{
 			runner: &MockRunner{
 				MockRunCommands: &MockRunCommands{response: runResponse, err: runErr},
+				context:         &MockContext{},
 			},
 		},
 	}

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -570,6 +570,17 @@ func (ctx *HookContext) addJujuUnitsMetric() error {
 	return nil
 }
 
+// Prepare implements the Context interface.
+func (ctx *HookContext) Prepare() error {
+	if ctx.actionData != nil {
+		err := ctx.state.ActionBegin(ctx.actionData.Tag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
 // Flush implements the Context interface.
 func (ctx *HookContext) Flush(process string, ctxErr error) (err error) {
 	// A non-existant metricsRecorder simply means that metrics were disabled

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -242,11 +242,6 @@ func (f *factory) NewActionRunner(actionId string) (Runner, error) {
 		return nil, errors.Trace(err)
 	}
 
-	err = f.state.ActionBegin(tag)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	name := action.Name()
 	spec, ok := ch.Actions().ActionSpecs[name]
 	if !ok {

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -42,9 +42,11 @@ type Context interface {
 	HookVars(paths Paths) []string
 	ActionData() (*ActionData, error)
 	SetProcess(process *os.Process)
-	Flush(badge string, failure error) error
 	HasExecutionSetUnitStatus() bool
 	ResetExecutionSetUnitStatus()
+
+	Prepare() error
+	Flush(badge string, failure error) error
 }
 
 // Paths exposes the paths needed by Runner.
@@ -97,6 +99,7 @@ func (runner *runner) RunCommands(commands string) (*utilexec.ExecResponse, erro
 		WorkingDir:  runner.paths.GetCharmDir(),
 		Environment: env,
 	}
+
 	err = command.Run()
 	if err != nil {
 		return nil, err

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -172,6 +172,10 @@ func (ctx *MockContext) SetProcess(process *os.Process) {
 	ctx.expectPid = process.Pid
 }
 
+func (ctx *MockContext) Prepare() error {
+	return nil
+}
+
 func (ctx *MockContext) Flush(badge string, failure error) error {
 	ctx.flushBadge = badge
 	ctx.flushFailure = failure


### PR DESCRIPTION
It's primary use in this case will be to set action execution status, which was previously done in the action
runner's constructor (while action execution finalization was performed during context flushing).

(Review request: http://reviews.vapour.ws/r/2305/)