### PR TITLE
Fixed reboot on windows

### DIFF
--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -870,4 +870,5 @@ values:
 cmd.exe /C mklink /D C:\Juju\lib\juju\tools\machine-10 1.2.3-win8-amd64
 New-Service -Credential $jujuCreds -Name 'jujud-machine-10' -DependsOn Winmgmt -DisplayName 'juju agent for machine-10' '"C:\Juju\lib\juju\tools\machine-10\jujud.exe" machine --data-dir "C:\Juju\lib\juju" --machine-id 10 --debug'
 sc.exe failure 'jujud-machine-10' reset=5 actions=restart/1000
+sc.exe failureflag 'jujud-machine-10' 1
 Start-Service 'jujud-machine-10'`

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -148,9 +148,16 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	return code, nil
 }
 
+// This function exists to preserve test functionality.
+// On windows we need to catch the return code from main for
+// service functionality purposes, but on unix we can just os.Exit
+func MainWrapper(args []string) {
+	os.Exit(Main(args))
+}
+
 // Main is not redundant with main(), because it provides an entry point
 // for testing with arbitrary command line arguments.
-func Main(args []string) {
+func Main(args []string) int {
 	defer func() {
 		if r := recover(); r != nil {
 			buf := make([]byte, 4096)
@@ -180,7 +187,7 @@ func Main(args []string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 	}
-	os.Exit(code)
+	return code
 }
 
 type writerFactory struct{}

--- a/cmd/jujud/main_nix.go
+++ b/cmd/jujud/main_nix.go
@@ -18,5 +18,5 @@ func init() {
 }
 
 func main() {
-	Main(os.Args)
+	MainWrapper(os.Args)
 }

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -78,7 +78,7 @@ var flagRunMain = flag.Bool("run-main", false, "Run the application's main funct
 // tool itself.
 func TestRunMain(t *stdtesting.T) {
 	if *flagRunMain {
-		Main(flag.Args())
+		MainWrapper(flag.Args())
 	}
 }
 

--- a/cmd/jujud/main_windows.go
+++ b/cmd/jujud/main_windows.go
@@ -30,7 +30,7 @@ func main() {
 
 	commandName := filepath.Base(os.Args[0])
 	if isInteractive || commandName != names.Jujud {
-		Main(os.Args)
+		os.Exit(Main(os.Args))
 	} else {
 		s := service.SystemService{
 			Name: "jujud",

--- a/cmd/service/service_handler.go
+++ b/cmd/service/service_handler.go
@@ -16,31 +16,39 @@ type SystemService struct {
 	// by the service handler.
 	Name string
 	// Cmd is the function the service handler will run as a service.
-	Cmd func(args []string)
+	Cmd func(args []string) int
 	// Args is passed to Cmd() as function arguments.
 	Args []string
 }
 
 // Execute implements the svc.Handler interface
-func (s *SystemService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+func (s *SystemService) Execute(args []string, changeReq <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
 
-	go s.Cmd(s.Args)
+	errChannel := make(chan int, 1)
+
+	go func() {
+		err := s.Cmd(s.Args)
+		errChannel <- err
+	}()
 
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 
-	for c := range r {
-		switch c.Cmd {
-		case svc.Interrogate:
-			changes <- c.CurrentStatus
-		case svc.Stop, svc.Shutdown:
-			// TODO (gabriel-samfira): Add more robust handling of service termination
-			changes <- svc.Status{State: svc.StopPending}
-			return false, 0
+	for {
+		select {
+		case r := <-changeReq:
+			switch r.Cmd {
+			case svc.Interrogate:
+				changes <- r.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				changes <- svc.Status{State: svc.StopPending}
+				return false, 0
+			}
+		case err := <-errChannel:
+			return false, uint32(err)
 		}
 	}
-	return false, 0
 }
 
 // Run runs the service

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -236,6 +236,7 @@ func (s *Service) InstallCommands() ([]string, error) {
 		renderer.Quote(s.Service.Conf.Desc),
 		renderer.Quote(s.Service.Conf.ExecStart),
 		renderer.Quote(s.Service.Name),
+		renderer.Quote(s.Service.Name),
 	)
 	return strings.Split(cmd, "\n"), nil
 }
@@ -248,4 +249,5 @@ func (s *Service) StartCommands() ([]string, error) {
 
 const serviceInstallCommands = `
 New-Service -Credential $jujuCreds -Name %s -DependsOn Winmgmt -DisplayName %s %s
-sc.exe failure %s reset=5 actions=restart/1000`
+sc.exe failure %s reset=5 actions=restart/1000
+sc.exe failureflag %s 1`


### PR DESCRIPTION
After introducing the upgrades fix, there were some problems with reboots on windows. Specifically, because the upgrades fix made the services restart on failure they started restarting even when the reboot was triggered. 

This patch enables them to only restart when a exit code is present.

Testing done:
Deploy complex charms that trigger reboots and try to upgrade the agent when they're done.

(Review request: http://reviews.vapour.ws/r/2308/)