### PR TITLE
upgrader responsibilities moved back into upgrader where they belong

### DIFF
--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -89,8 +89,6 @@ func agentConfig(tag names.Tag, datadir string) agent.Config {
 }
 
 func (s *UpgraderSuite) makeUpgrader(c *gc.C) *upgrader.Upgrader {
-	err := s.machine.SetAgentVersion(version.Current)
-	c.Assert(err, jc.ErrorIsNil)
 	return upgrader.NewAgentUpgrader(
 		s.state.Upgrader(),
 		agentConfig(s.machine.Tag(), s.DataDir()),


### PR DESCRIPTION
...and fallout from same, including some dropped test coverage because it was depending on abuse of the upgrader API in a non-upgrader context.