### PR TITLE
Added support for sending userdata on windows as a (small-sized) script

### DIFF
--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -807,3 +807,64 @@ $secpasswd = ConvertTo-SecureString $juju_passwd -AsPlainText -Force
 $jujuCreds = New-Object System.Management.Automation.PSCredential ($juju_user, $secpasswd)
 
 `
+
+var UserdataScript = `#ps1_sysnative
+$userdata=@"
+%s
+"@
+
+Function Decode-Base64 {
+    Param(
+        $inFile,
+        $outFile
+    )
+    $bufferSize = 9000 # should be a multiplier of 4
+    $buffer = New-Object char[] $bufferSize
+
+    $reader = [System.IO.File]::OpenText($inFile)
+    $writer = [System.IO.File]::OpenWrite($outFile)
+
+    $bytesRead = 0
+    do
+    {
+        $bytesRead = $reader.Read($buffer, 0, $bufferSize);
+        $bytes = [Convert]::FromBase64CharArray($buffer, 0, $bytesRead);
+        $writer.Write($bytes, 0, $bytes.Length);
+    } while ($bytesRead -eq $bufferSize);
+
+    $reader.Dispose()
+    $writer.Dispose()
+}
+
+Function GUnZip-File {
+    Param(
+        $inFile,
+        $outFile
+    )
+    $in = New-Object System.IO.FileStream $inFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
+    $out = New-Object System.IO.FileStream $outFile, ([IO.FileMode]::Create), ([IO.FileAccess]::Write), ([IO.FileShare]::None)
+    $gzipStream = New-Object System.IO.Compression.GZipStream $in, ([IO.Compression.CompressionMode]::Decompress)
+    $buffer = New-Object byte[](1024)
+    while($true){
+        $read = $gzipstream.Read($buffer, 0, 1024)
+        if ($read -le 0){break}
+        $out.Write($buffer, 0, $read)
+    }
+    $gzipStream.Close()
+    $out.Close()
+    $in.Close()
+}
+
+$b64File = "$env:TEMP\juju\udata.b64"
+$gzFile = "$env:TEMP\juju\udata.gz"
+$udataScript = "$env:TEMP\juju\udata.ps1"
+mkdir "$env:TEMP\juju"
+
+Set-Content $b64File $userdata
+Decode-Base64 -inFile $b64File -outFile $gzFile
+GUnZip-File -inFile $gzFile -outFile $udataScript
+
+& $udataScript
+
+rm -Recurse "$env:TEMP\juju"
+`

--- a/cloudconfig/providerinit/providerinit.go
+++ b/cloudconfig/providerinit/providerinit.go
@@ -7,12 +7,17 @@
 package providerinit
 
 import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.cloudconfig.providerinit")
@@ -55,10 +60,40 @@ func ComposeUserData(icfg *instancecfg.InstanceConfig, cloudcfg cloudinit.CloudC
 	if err != nil {
 		return nil, err
 	}
+	operatingSystem, err := version.GetOSFromSeries(icfg.Series)
+	if err != nil {
+		return nil, err
+	}
+	switch operatingSystem {
+	case version.Ubuntu, version.CentOS:
+		return gzippedUserdata(cloudcfg)
+	case version.Windows:
+		return encodedUserdata(cloudcfg)
+	default:
+		return nil, errors.New(fmt.Sprintf("Cannot compose userdata for os %s", operatingSystem))
+	}
+}
+
+// gzippedUserdata returns the rendered userdata in a gzipped format
+func gzippedUserdata(cloudcfg cloudinit.CloudConfig) ([]byte, error) {
 	data, err := cloudcfg.RenderYAML()
 	logger.Tracef("Generated cloud init:\n%s", string(data))
 	if err != nil {
 		return nil, err
 	}
 	return utils.Gzip(data), nil
+}
+
+// encodedUserdata for now is used on windows and it retuns a powershell script
+// which has the userdata embedded as base64(gzip(userdata))
+// We need this because most cloud provider do not accept gzipped userdata on
+// windows and they have size limitations
+func encodedUserdata(cloudcfg cloudinit.CloudConfig) ([]byte, error) {
+	zippedData, err := gzippedUserdata(cloudcfg)
+	if err != nil {
+		return nil, err
+	}
+
+	base64Data := base64.StdEncoding.EncodeToString(zippedData)
+	return []byte(fmt.Sprintf(cloudconfig.UserdataScript, base64Data)), nil
 }


### PR DESCRIPTION
The next PR for supporting windows on various clouds.

Since almost nobody supports windows userdata in some other format than powershell code, we're doing something similar to get-pip (https://bootstrap.pypa.io/get-pip.py). 

That is, we gzip it and base64 it and embed it inside a script. This satisfies the size constraints required by aws(16K).

It has been tested on maas, aws and azure.

(Review request: http://reviews.vapour.ws/r/2318/)