### PR TITLE
WIP: Unit agent dependency engine

### DIFF
--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -13,41 +13,15 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"github.com/juju/utils"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api"
-	apiagent "github.com/juju/juju/api/agent"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
-	"github.com/juju/juju/worker"
 )
-
-var (
-	apiOpen = openAPIForAgent
-
-	checkProvisionedStrategy = utils.AttemptStrategy{
-		Total: 1 * time.Minute,
-		Delay: 5 * time.Second,
-	}
-)
-
-// openAPIForAgent exists to handle the edge case that exists
-// when an environment is jumping several versions and doesn't
-// yet have the environment UUID cached in the agent config.
-// This happens only the first time an agent tries to connect
-// after an upgrade.  If there is no environment UUID set, then
-// use login version 1.
-func openAPIForAgent(info *api.Info, opts api.DialOpts) (*api.State, error) {
-	if info.EnvironTag.Id() == "" {
-		return api.OpenWithVersion(info, opts, 1)
-	}
-	return api.Open(info, opts)
-}
 
 type AgentConf interface {
 	// AddFlags injects common agent flags into f.
@@ -154,11 +128,6 @@ func (a *agentConf) SetStateServingInfo(info params.StateServingInfo) error {
 	})
 }
 
-type Agent interface {
-	Tag() names.Tag
-	ChangeConfig(agent.ConfigMutator) error
-}
-
 // The AgentState interface is implemented by state types
 // that represent running agents.
 type AgentState interface {
@@ -182,124 +151,3 @@ func isleep(d time.Duration, stop <-chan struct{}) bool {
 }
 
 type configChanger func(c *agent.Config)
-
-// OpenAPIState opens the API using the given information. The agent's
-// password is changed if the fallback password was used to connect to
-// the API.
-func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.Entity, outErr error) {
-	info := agentConfig.APIInfo()
-	st, usedOldPassword, err := openAPIStateUsingInfo(info, a, agentConfig.OldPassword())
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() {
-		if outErr != nil && st != nil {
-			st.Close()
-		}
-	}()
-
-	entity, err := st.Agent().Entity(a.Tag())
-	if err == nil && entity.Life() == params.Dead {
-		logger.Errorf("agent terminating - entity %q is dead", a.Tag())
-		return nil, nil, worker.ErrTerminateAgent
-	}
-	if params.IsCodeUnauthorized(err) {
-		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)
-		return nil, nil, worker.ErrTerminateAgent
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if !usedOldPassword {
-		// Call set password with the current password.  If we've recently
-		// become a state server, this will fix up our credentials in mongo.
-		if err := entity.SetPassword(info.Password); err != nil {
-			return nil, nil, errors.Annotate(err, "can't reset agent password")
-		}
-	} else {
-		// We succeeded in connecting with the fallback
-		// password, so we need to create a new password
-		// for the future.
-		newPassword, err := utils.RandomPassword()
-		if err != nil {
-			return nil, nil, err
-		}
-		err = setAgentPassword(newPassword, info.Password, a, entity)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// Reconnect to the API with the new password.
-		st.Close()
-		info.Password = newPassword
-		st, err = apiOpen(info, api.DialOpts{})
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	return st, entity, err
-}
-
-func setAgentPassword(newPw, oldPw string, a Agent, entity *apiagent.Entity) error {
-	// Change the configuration *before* setting the entity
-	// password, so that we avoid the possibility that
-	// we might successfully change the entity's
-	// password but fail to write the configuration,
-	// thus locking us out completely.
-	if err := a.ChangeConfig(func(c agent.ConfigSetter) error {
-		c.SetPassword(newPw)
-		c.SetOldPassword(oldPw)
-		return nil
-	}); err != nil {
-		return err
-	}
-	return entity.SetPassword(newPw)
-}
-
-// OpenAPIStateUsingInfo opens the API using the given API
-// information, and returns the opened state and the api entity with
-// the given tag.
-func OpenAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.State, error) {
-	st, _, err := openAPIStateUsingInfo(info, a, oldPassword)
-	return st, err
-}
-
-func openAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.State, bool, error) {
-	// We let the API dial fail immediately because the
-	// runner's loop outside the caller of openAPIState will
-	// keep on retrying. If we block for ages here,
-	// then the worker that's calling this cannot
-	// be interrupted.
-	st, err := apiOpen(info, api.DialOpts{})
-	usedOldPassword := false
-	if params.IsCodeUnauthorized(err) {
-		// We've perhaps used the wrong password, so
-		// try again with the fallback password.
-		infoCopy := *info
-		info = &infoCopy
-		info.Password = oldPassword
-		usedOldPassword = true
-		st, err = apiOpen(info, api.DialOpts{})
-	}
-	// The provisioner may take some time to record the agent's
-	// machine instance ID, so wait until it does so.
-	if params.IsCodeNotProvisioned(err) {
-		for a := checkProvisionedStrategy.Start(); a.Next(); {
-			st, err = apiOpen(info, api.DialOpts{})
-			if !params.IsCodeNotProvisioned(err) {
-				break
-			}
-		}
-	}
-	if err != nil {
-		if params.IsCodeNotProvisioned(err) || params.IsCodeUnauthorized(err) {
-			logger.Errorf("agent terminating due to error returned during API open: %v", err)
-			return nil, false, worker.ErrTerminateAgent
-		}
-		return nil, false, err
-	}
-
-	return st, usedOldPassword, nil
-}

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -134,36 +134,6 @@ func (s *AgentSuite) PrimeStateAgent(
 	return conf, agentTools
 }
 
-func (s *AgentSuite) RunTestOpenAPIState(c *gc.C, ent state.AgentEntity, agentCmd apicaller.Agent, initialPassword string) {
-	conf, err := agent.ReadConfig(agent.ConfigPath(s.DataDir(), ent.Tag()))
-	c.Assert(err, jc.ErrorIsNil)
-
-	conf.SetPassword("")
-	err = conf.Write()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Check that it starts initially and changes the password
-	assertOpen := func(conf agent.Config) {
-		st, gotEnt, err := apicaller.OpenAPIState(conf, agentCmd)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(st, gc.NotNil)
-		st.Close()
-		c.Assert(gotEnt.Tag(), gc.Equals, ent.Tag().String())
-	}
-	assertOpen(conf)
-
-	// Check that the initial password is no longer valid.
-	err = ent.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ent.PasswordValid(initialPassword), jc.IsFalse)
-
-	// Read the configuration and check that we can connect with it.
-	conf, err = agent.ReadConfig(agent.ConfigPath(conf.DataDir(), conf.Tag()))
-	c.Assert(err, gc.IsNil)
-	// Check we can open the API with the new configuration.
-	assertOpen(conf)
-}
-
 // writeStateAgentConfig creates and writes a state agent config.
 func writeStateAgentConfig(
 	c *gc.C, stateInfo *mongo.MongoInfo, dataDir string, tag names.Tag,

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -11,12 +11,10 @@ import (
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/api"
 	apienvironment "github.com/juju/juju/api/environment"
 	"github.com/juju/juju/apiserver/params"
 	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
@@ -27,83 +25,13 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/multiwatcher"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/proxyupdater"
 )
-
-var (
-	_ = gc.Suite(&apiOpenSuite{})
-)
-
-type apiOpenSuite struct{ coretesting.BaseSuite }
-
-func (s *apiOpenSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-	s.PatchValue(&checkProvisionedStrategy, utils.AttemptStrategy{})
-}
-
-func (s *apiOpenSuite) TestOpenAPIStateReplaceErrors(c *gc.C) {
-	type replaceErrors struct {
-		openErr    error
-		replaceErr error
-	}
-	var apiError error
-	s.PatchValue(&apiOpen, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
-		return nil, apiError
-	})
-	errReplacePairs := []replaceErrors{{
-		fmt.Errorf("blah"), nil,
-	}, {
-		openErr:    &params.Error{Code: params.CodeNotProvisioned},
-		replaceErr: worker.ErrTerminateAgent,
-	}, {
-		openErr:    &params.Error{Code: params.CodeUnauthorized},
-		replaceErr: worker.ErrTerminateAgent,
-	}}
-	for i, test := range errReplacePairs {
-		c.Logf("test %d", i)
-		apiError = test.openErr
-		_, _, err := OpenAPIState(fakeAPIOpenConfig{}, nil)
-		if test.replaceErr == nil {
-			c.Check(err, gc.Equals, test.openErr)
-		} else {
-			c.Check(err, gc.Equals, test.replaceErr)
-		}
-	}
-}
-
-func (s *apiOpenSuite) TestOpenAPIStateWaitsProvisioned(c *gc.C) {
-	s.PatchValue(&checkProvisionedStrategy.Min, 5)
-	var called int
-	s.PatchValue(&apiOpen, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
-		called++
-		if called == checkProvisionedStrategy.Min-1 {
-			return nil, &params.Error{Code: params.CodeUnauthorized}
-		}
-		return nil, &params.Error{Code: params.CodeNotProvisioned}
-	})
-	_, _, err := OpenAPIState(fakeAPIOpenConfig{}, nil)
-	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
-	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min-1)
-}
-
-func (s *apiOpenSuite) TestOpenAPIStateWaitsProvisionedGivesUp(c *gc.C) {
-	s.PatchValue(&checkProvisionedStrategy.Min, 5)
-	var called int
-	s.PatchValue(&apiOpen, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
-		called++
-		return nil, &params.Error{Code: params.CodeNotProvisioned}
-	})
-	_, _, err := OpenAPIState(fakeAPIOpenConfig{}, nil)
-	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
-	// +1 because we always attempt at least once outside the attempt strategy
-	// (twice if the API server initially returns CodeUnauthorized.)
-	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min+1)
-}
 
 type acCreator func() (cmd.Command, AgentConf)
 
@@ -206,7 +134,7 @@ func (s *AgentSuite) PrimeStateAgent(
 	return conf, agentTools
 }
 
-func (s *AgentSuite) RunTestOpenAPIState(c *gc.C, ent state.AgentEntity, agentCmd Agent, initialPassword string) {
+func (s *AgentSuite) RunTestOpenAPIState(c *gc.C, ent state.AgentEntity, agentCmd apicaller.Agent, initialPassword string) {
 	conf, err := agent.ReadConfig(agent.ConfigPath(s.DataDir(), ent.Tag()))
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -216,7 +144,7 @@ func (s *AgentSuite) RunTestOpenAPIState(c *gc.C, ent state.AgentEntity, agentCm
 
 	// Check that it starts initially and changes the password
 	assertOpen := func(conf agent.Config) {
-		st, gotEnt, err := OpenAPIState(conf, agentCmd)
+		st, gotEnt, err := apicaller.OpenAPIState(conf, agentCmd)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st, gc.NotNil)
 		st.Close()
@@ -266,9 +194,3 @@ func writeStateAgentConfig(
 	c.Assert(conf.Write(), gc.IsNil)
 	return conf
 }
-
-type fakeAPIOpenConfig struct{ agent.Config }
-
-func (fakeAPIOpenConfig) APIInfo() *api.Info              { return &api.Info{} }
-func (fakeAPIOpenConfig) OldPassword() string             { return "old" }
-func (fakeAPIOpenConfig) Jobs() []multiwatcher.MachineJob { return []multiwatcher.MachineJob{} }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -65,6 +65,7 @@ import (
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/addresser"
 	"github.com/juju/juju/worker/apiaddressupdater"
+	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/charmrevisionworker"
@@ -478,7 +479,7 @@ func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error
 	// We need to reopen the API to clear the reboot flag after
 	// scheduling the reboot. It may be cleaner to do this in the reboot
 	// worker, before returning the ErrRebootMachine.
-	st, _, err := OpenAPIState(agentCfg, a)
+	st, _, err := apicaller.OpenAPIState(agentCfg, a)
 	if err != nil {
 		logger.Infof("Reboot: Error connecting to state")
 		return errors.Trace(err)
@@ -640,7 +641,7 @@ func (a *MachineAgent) stateStarter(stopch <-chan struct{}) error {
 // workers that need an API connection.
 func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 	agentConfig := a.CurrentConfig()
-	st, entity, err := OpenAPIState(agentConfig, a)
+	st, entity, err := apicaller.OpenAPIState(agentConfig, a)
 	if err != nil {
 		return nil, err
 	}
@@ -1091,7 +1092,7 @@ func (a *MachineAgent) startEnvWorkers(
 	agentConfig := a.CurrentConfig()
 	apiInfo := agentConfig.APIInfo()
 	apiInfo.EnvironTag = st.EnvironTag()
-	apiSt, err := OpenAPIStateUsingInfo(apiInfo, a, agentConfig.OldPassword())
+	apiSt, err := apicaller.OpenAPIStateUsingInfo(apiInfo, a, agentConfig.OldPassword())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1134,10 +1134,9 @@ func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds .
 	}
 }
 
-func (s *MachineSuite) TestOpenStateFailsForJobHostUnitsButOpenAPIWorks(c *gc.C) {
+func (s *MachineSuite) TestOpenStateFailsForJobHostUnits(c *gc.C) {
 	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
 	a := s.newAgent(c, m)
-	s.RunTestOpenAPIState(c, m, a, initialMachinePassword)
 	s.assertJobWithAPI(c, state.JobHostUnits, func(conf agent.Config, st *api.State) {
 		s.AssertCannotOpenState(c, conf.Tag(), conf.DataDir())
 	})

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -6,9 +6,9 @@ package agent
 import (
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/juju/cmd"
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/featureflag"
@@ -17,20 +17,17 @@ import (
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
+<<<<<<< HEAD
 	"github.com/juju/juju/api/leadership"
+=======
+	"github.com/juju/juju/cmd/jujud/agent/unit"
+>>>>>>> dropped filter manifold (not a shared resource); added uniter manifold; uniter now gets leadership tracker as a resource from manifold, does not create its own; moved APIOpen funcs from cmd/jujud/agent to worker/agent; s/Api/API/ in some field names for consistency
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/apiaddressupdater"
-	workerlogger "github.com/juju/juju/worker/logger"
+	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/logsender"
-	"github.com/juju/juju/worker/proxyupdater"
-	"github.com/juju/juju/worker/rsyslog"
-	"github.com/juju/juju/worker/uniter"
-	"github.com/juju/juju/worker/uniter/operation"
-	"github.com/juju/juju/worker/upgrader"
 )
 
 var (
@@ -138,6 +135,7 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 }
 
 func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
+<<<<<<< HEAD
 	agentConfig := a.CurrentConfig()
 	dataDir := agentConfig.DataDir()
 	hookLock, err := cmdutil.HookExecutionLock(dataDir)
@@ -179,8 +177,17 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 		if err != nil {
 			logger.Warningf("unable to save environment uuid: %v", err)
 			// Not really fatal, just annoying.
+=======
+	manifolds := unit.Manifolds(a, a.bufferedLogs)
+	engine := dependency.NewEngine(cmdutil.IsFatal, 3*time.Second, 10*time.Millisecond)
+	if err := dependency.Install(engine, manifolds); err != nil {
+		if err := worker.Stop(engine); err != nil {
+			logger.Errorf("while stopping engine with bad manifolds: %v", err)
+>>>>>>> dropped filter manifold (not a shared resource); added uniter manifold; uniter now gets leadership tracker as a resource from manifold, does not create its own; moved APIOpen funcs from cmd/jujud/agent to worker/agent; s/Api/API/ in some field names for consistency
 		}
+		return nil, err
 	}
+<<<<<<< HEAD
 
 	unitTag, err := names.ParseUnitTag(entity.Tag())
 	if err != nil {
@@ -240,6 +247,9 @@ func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
 		})
 	}
 	return cmdutil.NewCloseWorker(logger, runner, st), nil
+=======
+	return engine, nil
+>>>>>>> dropped filter manifold (not a shared resource); added uniter manifold; uniter now gets leadership tracker as a resource from manifold, does not create its own; moved APIOpen funcs from cmd/jujud/agent to worker/agent; s/Api/API/ in some field names for consistency
 }
 
 func (a *UnitAgent) Tag() names.Tag {

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -17,11 +17,7 @@ import (
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
-<<<<<<< HEAD
-	"github.com/juju/juju/api/leadership"
-=======
 	"github.com/juju/juju/cmd/jujud/agent/unit"
->>>>>>> dropped filter manifold (not a shared resource); added uniter manifold; uniter now gets leadership tracker as a resource from manifold, does not create its own; moved APIOpen funcs from cmd/jujud/agent to worker/agent; s/Api/API/ in some field names for consistency
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/version"
@@ -134,122 +130,22 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 	return err
 }
 
-func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
-<<<<<<< HEAD
-	agentConfig := a.CurrentConfig()
-	dataDir := agentConfig.DataDir()
-	hookLock, err := cmdutil.HookExecutionLock(dataDir)
-	if err != nil {
-		return nil, err
-	}
-	st, entity, err := OpenAPIState(agentConfig, a)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		// TODO(fwereade): this is not properly tested. Old tests were both
-		// incomplete (missing a fail case) and evil (dependent on injecting
-		// an error in a patched-out upgrader API that shouldn't even be
-		// used at this level)... so I just deleted them. Not a major worry:
-		// this whole method will become redundant once we switch to the
-		// dependency engine (and specifically use worker/apicaller to
-		// connect).
-		if err != nil {
-			if err := st.Close(); err != nil {
-				logger.Errorf("while closing API: %v", err)
-			}
-		}
-	}()
+// APIWorkers returns a dependency.Engine running the unit agent's responsibilities.
+func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
+	manifolds := unit.Manifolds(unit.ManifoldsConfig{
+		Agent:               a,
+		LogSource:           a.bufferedLogs,
+		LeadershipGuarantee: 30 * time.Second,
+	})
 
-	// Ensure that the environment uuid is stored in the agent config.
-	// Luckily the API has it recorded for us after we connect.
-	if agentConfig.Environment().Id() == "" {
-		err := a.ChangeConfig(func(setter agent.ConfigSetter) error {
-			environTag, err := st.EnvironTag()
-			if err != nil {
-				return errors.Annotate(err, "no environment uuid set on api")
-			}
-
-			return setter.Migrate(agent.MigrateParams{
-				Environment: environTag,
-			})
-		})
-		if err != nil {
-			logger.Warningf("unable to save environment uuid: %v", err)
-			// Not really fatal, just annoying.
-=======
-	manifolds := unit.Manifolds(a, a.bufferedLogs)
 	engine := dependency.NewEngine(cmdutil.IsFatal, 3*time.Second, 10*time.Millisecond)
 	if err := dependency.Install(engine, manifolds); err != nil {
 		if err := worker.Stop(engine); err != nil {
 			logger.Errorf("while stopping engine with bad manifolds: %v", err)
->>>>>>> dropped filter manifold (not a shared resource); added uniter manifold; uniter now gets leadership tracker as a resource from manifold, does not create its own; moved APIOpen funcs from cmd/jujud/agent to worker/agent; s/Api/API/ in some field names for consistency
 		}
 		return nil, err
 	}
-<<<<<<< HEAD
-
-	unitTag, err := names.ParseUnitTag(entity.Tag())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	runner := worker.NewRunner(cmdutil.ConnectionIsFatal(logger, st), cmdutil.MoreImportant)
-
-	// start proxyupdater first to ensure proxy settings are correct
-	runner.StartWorker("proxyupdater", func() (worker.Worker, error) {
-		return proxyupdater.New(st.Environment(), false), nil
-	})
-	if feature.IsDbLogEnabled() {
-		runner.StartWorker("logsender", func() (worker.Worker, error) {
-			return logsender.New(a.bufferedLogs, agentConfig.APIInfo()), nil
-		})
-	}
-	runner.StartWorker("upgrader", func() (worker.Worker, error) {
-		return upgrader.NewAgentUpgrader(
-			st.Upgrader(),
-			agentConfig,
-			agentConfig.UpgradedToVersion(),
-			func() bool { return false },
-			a.initialAgentUpgradeCheckComplete,
-		), nil
-	})
-	runner.StartWorker("logger", func() (worker.Worker, error) {
-		return workerlogger.NewLogger(st.Logger(), agentConfig), nil
-	})
-	runner.StartWorker("uniter", func() (worker.Worker, error) {
-		uniterFacade, err := st.Uniter()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		uniterParams := uniter.UniterParams{
-			uniterFacade,
-			unitTag,
-			leadership.NewClient(st),
-			dataDir,
-			hookLock,
-			uniter.NewMetricsTimerChooser(),
-			uniter.NewUpdateStatusTimer(),
-			operation.NewExecutor,
-		}
-		return uniter.NewUniter(&uniterParams), nil
-	})
-
-	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {
-		uniterFacade, err := st.Uniter()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		return apiaddressupdater.NewAPIAddressUpdater(uniterFacade, a), nil
-	})
-	if !featureflag.Enabled(feature.DisableRsyslog) {
-		runner.StartWorker("rsyslog", func() (worker.Worker, error) {
-			return cmdutil.NewRsyslogConfigWorker(st.Rsyslog(), agentConfig, rsyslog.RsyslogModeForwarding)
-		})
-	}
-	return cmdutil.NewCloseWorker(logger, runner, st), nil
-=======
 	return engine, nil
->>>>>>> dropped filter manifold (not a shared resource); added uniter manifold; uniter now gets leadership tracker as a resource from manifold, does not create its own; moved APIOpen funcs from cmd/jujud/agent to worker/agent; s/Api/API/ in some field names for consistency
 }
 
 func (a *UnitAgent) Tag() names.Tag {

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -1,0 +1,142 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit
+
+import (
+	"time"
+
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/apiaddressupdater"
+	"github.com/juju/juju/worker/apicaller"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/leadership"
+	"github.com/juju/juju/worker/logger"
+	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/machinelock"
+	"github.com/juju/juju/worker/proxyupdater"
+	"github.com/juju/juju/worker/rsyslog"
+	"github.com/juju/juju/worker/uniter"
+	"github.com/juju/juju/worker/upgrader"
+)
+
+// Manifolds returns a set of co-configured manifolds covering the various
+// responsibilities of a standalone unit agent. It also accepts the logSource
+// argument because we haven't figured out how to thread all the logging bits
+// through a dependency engine yet.
+//
+// Thou Shalt Not Use String Literals In This Function. Or Else.
+func Manifolds(a agent.Agent, logSource logsender.LogRecordCh) dependency.Manifolds {
+	return dependency.Manifolds{
+
+		// The agent manifold references the enclosing agent, and is the
+		// foundation stone on which most other manifolds ultimately depend.
+		// (Currently, that is "all manifolds", but consider a shared clock.)
+		AgentName: agent.Manifold(a),
+
+		// The machine lock manifold is a thin concurrent wrapper around an
+		// FSLock in an agreed location. We expect it to be replaced with an
+		// in-memory lock when the unit agent moves into the machine agent.
+		MachineLockName: machinelock.Manifold(machinelock.ManifoldConfig{
+			AgentName: AgentName,
+		}),
+
+		// The api caller is a thin concurrent wrapper around a connection
+		// to some API server. It's used by many other manifolds, which all
+		// select their own desired facades. It will be interesting to see
+		// how this works when we consolidate the agents; might be best to
+		// handle the auth changes server-side..?
+		APICallerName: apicaller.Manifold(apicaller.ManifoldConfig{
+			AgentName: AgentName,
+		}),
+
+		// The log sender is a leaf worker that sends log messages to some
+		// API server, when configured so to do. We should only need one of
+		// these in a consolidated agent.
+		LogSenderName: logsender.Manifold(logsender.ManifoldConfig{
+			AgentName: AgentName,
+			LogSource: logSource,
+		}),
+
+		// The rsyslog config updater is a leaf worker that causes rsyslog
+		// to send messages to the state servers. We should only need one
+		// of these in a consolidated agent.
+		RsyslogConfigUpdaterName: rsyslog.Manifold(rsyslog.ManifoldConfig{
+			AgentName:     AgentName,
+			APICallerName: APICallerName,
+		}),
+
+		// The logging config updater if a leaf worker that indirectly
+		// controls the messages sent via the log sender or rsyslog,
+		// according to changes in environment config. We should only need
+		// one of these in a consolidated agent.
+		LoggingConfigUpdaterName: logger.Manifold(logger.ManifoldConfig{
+			AgentName:     AgentName,
+			APICallerName: APICallerName,
+		}),
+
+		// The api address updater is a leaf worker that rewrites agent config
+		// as the state server addresses change. We should only need one of
+		// these in a consolidated agent.
+		APIAdddressUpdaterName: apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
+			AgentName:     AgentName,
+			APICallerName: APICallerName,
+		}),
+
+		// The proxy config updater is a leaf worker that sets http/https/apt/etc
+		// proxy settings.
+		// TODO(fwereade): timing of this is suspicious. There was superstitious
+		// code trying to run this early; if that ever helped, it was only by
+		// coincidence. Probably we ought to be making components that might
+		// need proxy config into explicit dependenncies of the proxy updater...
+		ProxyConfigUpdaterName: proxyupdater.Manifold(proxyupdater.ManifoldConfig{
+			APICallerName: APICallerName,
+		}),
+
+		// The upgrader is a leaf worker that returns a specific error type
+		// recognised by the unit agent, causing other workers to be stopped
+		// and the agent to be restarted running the new tools. We should only
+		// need one of these in a consolidated agent, but we'll need to be
+		// careful about the interactions with the upgrade-steps worker.
+		UpgraderName: upgrader.Manifold(upgrader.ManifoldConfig{
+			AgentName:     AgentName,
+			APICallerName: APICallerName,
+		}),
+
+		// The leadership tracker attempts to secure and retain leadership of
+		// the unit's service, and is consulted on such matters by the
+		// uniter. As it stannds today, we'll need one per unit in a
+		// consolidated agent.
+		LeadershipTrackerName: leadership.Manifold(leadership.ManifoldConfig{
+			AgentName:           AgentName,
+			APICallerName:       APICallerName,
+			LeadershipGuarantee: 30 * time.Second,
+		}),
+
+		// The uniter installs charms; manages the unit's presence in its
+		// relations; creates suboordinate units; runs all the hooks; sends
+		// metrics; etc etc etc. We expect to break it up further in the
+		// coming weeks, and to need one per unit in a consolidated agent
+		// (and probably one for each component broken out).
+		UniterName: uniter.Manifold(uniter.ManifoldConfig{
+			AgentName:             AgentName,
+			APICallerName:         APICallerName,
+			LeadershipTrackerName: LeadershipTrackerName,
+			MachineLockName:       MachineLockName,
+		}),
+	}
+}
+
+const (
+	AgentName                = "agent"
+	APIAdddressUpdaterName   = "api-address-updater"
+	APICallerName            = "api-caller"
+	LeadershipTrackerName    = "leadership-tracker"
+	LoggingConfigUpdaterName = "logging-config-updater"
+	LogSenderName            = "log-sender"
+	MachineLockName          = "machine-lock"
+	ProxyConfigUpdaterName   = "proxy-config-updater"
+	RsyslogConfigUpdaterName = "rsyslog-config-updater"
+	UniterName               = "uniter"
+	UpgraderName             = "upgrader"
+)

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/unit"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/agent"
+)
+
+type ManifoldsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ManifoldsSuite{})
+
+func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
+	manifolds := unit.Manifolds(fakeAgent{}, nil)
+
+	for name, manifold := range manifolds {
+		c.Logf("checking %q manifold", name)
+		c.Check(manifold.Start, gc.NotNil)
+	}
+}
+
+func (s *ManifoldsSuite) TestAcyclic(c *gc.C) {
+	manifolds := unit.Manifolds(fakeAgent{}, nil)
+	count := len(manifolds)
+
+	// Because we've already got outgoing links stored conveniently, we check
+	// that the transpose of the graph is acyclic instead. Should be same.
+	done := make(map[string]bool)
+	doing := make(map[string]bool)
+	sorted := make([]string, 0, count)
+
+	// This _ hack to allow recursion feels less irritating that having to pull
+	// out a whole type to embody this algroithm. Alternatives appreciated.
+	visit := func(node string) {}
+	visit_ := func(node string) {
+		if doing[node] {
+			c.Fatalf("cycle detected at %q", node)
+		}
+		if !done[node] {
+			doing[node] = true
+			for _, input := range manifolds[node].Inputs {
+				visit(input)
+			}
+			done[node] = true
+			doing[node] = false
+			sorted = append(sorted, node)
+		}
+	}
+	visit = visit_
+
+	for node := range manifolds {
+		visit(node)
+	}
+	c.Logf("sorted: %v", sorted)
+	c.Check(sorted, gc.HasLen, count)
+}
+
+type fakeAgent struct {
+	agent.Agent
+}

--- a/cmd/jujud/agent/unit/package_test.go
+++ b/cmd/jujud/agent/unit/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -249,10 +249,10 @@ func (s *UnitSuite) TestWithDeadUnit(c *gc.C) {
 
 func (s *UnitSuite) TestOpenAPIState(c *gc.C) {
 	_, unit, _, _ := s.primeAgent(c)
-	s.RunTestOpenAPIState(c, unit, s.newAgent(c, unit), initialUnitPassword)
-}
+	var ent state.AgentEntity = unit
+	var agentCmd apicaller.Agent
+	initialPassword := initialUnitPassword
 
-func (s *UnitSuite) RunTestOpenAPIState(c *gc.C, ent state.AgentEntity, agentCmd apicaller.Agent, initialPassword string) {
 	conf, err := agent.ReadConfig(agent.ConfigPath(s.DataDir(), ent.Tag()))
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/apicaller/export_test.go
+++ b/worker/apicaller/export_test.go
@@ -3,4 +3,8 @@
 
 package apicaller
 
-var OpenConnection = &openConnection
+var (
+	OpenConnection           = &openConnection
+	OpenAPIForAgent          = &openAPIForAgent
+	CheckProvisionedStrategy = &checkProvisionedStrategy
+)

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -122,6 +122,7 @@ func openAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.St
 		usedOldPassword = true
 		st, err = openAPIForAgent(info, api.DialOpts{})
 	}
+
 	// The provisioner may take some time to record the agent's
 	// machine instance ID, so wait until it does so.
 	if params.IsCodeNotProvisioned(err) {

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -1,0 +1,164 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apicaller
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	apiagent "github.com/juju/juju/api/agent"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker"
+)
+
+type Agent interface {
+	Tag() names.Tag
+	ChangeConfig(agent.ConfigMutator) error
+}
+
+// OpenAPIState opens the API using the given information. The agent's
+// password is changed if the fallback password was used to connect to
+// the API.
+func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.Entity, outErr error) {
+	info := agentConfig.APIInfo()
+	st, usedOldPassword, err := openAPIStateUsingInfo(info, a, agentConfig.OldPassword())
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if outErr != nil && st != nil {
+			st.Close()
+		}
+	}()
+
+	entity, err := st.Agent().Entity(a.Tag())
+	if err == nil && entity.Life() == params.Dead {
+		logger.Errorf("agent terminating - entity %q is dead", a.Tag())
+		return nil, nil, worker.ErrTerminateAgent
+	}
+	if params.IsCodeUnauthorized(err) {
+		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)
+		return nil, nil, worker.ErrTerminateAgent
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !usedOldPassword {
+		// Call set password with the current password.  If we've recently
+		// become a state server, this will fix up our credentials in mongo.
+		if err := entity.SetPassword(info.Password); err != nil {
+			return nil, nil, errors.Annotate(err, "can't reset agent password")
+		}
+	} else {
+		// We succeeded in connecting with the fallback
+		// password, so we need to create a new password
+		// for the future.
+		newPassword, err := utils.RandomPassword()
+		if err != nil {
+			return nil, nil, err
+		}
+		err = setAgentPassword(newPassword, info.Password, a, entity)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Reconnect to the API with the new password.
+		st.Close()
+		info.Password = newPassword
+		st, err = openAPIForAgent(info, api.DialOpts{})
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return st, entity, err
+}
+
+func setAgentPassword(newPw, oldPw string, a Agent, entity *apiagent.Entity) error {
+	// Change the configuration *before* setting the entity
+	// password, so that we avoid the possibility that
+	// we might successfully change the entity's
+	// password but fail to write the configuration,
+	// thus locking us out completely.
+	if err := a.ChangeConfig(func(c agent.ConfigSetter) error {
+		c.SetPassword(newPw)
+		c.SetOldPassword(oldPw)
+		return nil
+	}); err != nil {
+		return err
+	}
+	return entity.SetPassword(newPw)
+}
+
+// OpenAPIStateUsingInfo opens the API using the given API
+// information, and returns the opened state and the api entity with
+// the given tag.
+func OpenAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.State, error) {
+	st, _, err := openAPIStateUsingInfo(info, a, oldPassword)
+	return st, err
+}
+
+func openAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.State, bool, error) {
+	// We let the API dial fail immediately because the
+	// runner's loop outside the caller of openAPIState will
+	// keep on retrying. If we block for ages here,
+	// then the worker that's calling this cannot
+	// be interrupted.
+	st, err := openAPIForAgent(info, api.DialOpts{})
+	usedOldPassword := false
+	if params.IsCodeUnauthorized(err) {
+		// We've perhaps used the wrong password, so
+		// try again with the fallback password.
+		infoCopy := *info
+		info = &infoCopy
+		info.Password = oldPassword
+		usedOldPassword = true
+		st, err = openAPIForAgent(info, api.DialOpts{})
+	}
+	// The provisioner may take some time to record the agent's
+	// machine instance ID, so wait until it does so.
+	if params.IsCodeNotProvisioned(err) {
+		for a := checkProvisionedStrategy.Start(); a.Next(); {
+			st, err = openAPIForAgent(info, api.DialOpts{})
+			if !params.IsCodeNotProvisioned(err) {
+				break
+			}
+		}
+	}
+	if err != nil {
+		if params.IsCodeNotProvisioned(err) || params.IsCodeUnauthorized(err) {
+			logger.Errorf("agent terminating due to error returned during API open: %v", err)
+			return nil, false, worker.ErrTerminateAgent
+		}
+		return nil, false, err
+	}
+
+	return st, usedOldPassword, nil
+}
+
+var (
+	// openAPIForAgent exists to handle the edge case that exists
+	// when an environment is jumping several versions and doesn't
+	// yet have the environment UUID cached in the agent config.
+	// This happens only the first time an agent tries to connect
+	// after an upgrade.  If there is no environment UUID set, then
+	// use login version 1.
+	openAPIForAgent = func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		if info.EnvironTag.Id() == "" {
+			return api.OpenWithVersion(info, opts, 1)
+		}
+		return api.Open(info, opts)
+	}
+
+	checkProvisionedStrategy = utils.AttemptStrategy{
+		Total: 1 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+)

--- a/worker/apicaller/open_test.go
+++ b/worker/apicaller/open_test.go
@@ -88,6 +88,10 @@ func (s *apiOpenSuite) TestOpenAPIStateWaitsProvisionedGivesUp(c *gc.C) {
 	c.Assert(called, gc.Equals, apicaller.CheckProvisionedStrategy.Min+1)
 }
 
+func (s *apiOpenSuite) TestOpenAPIStateRewritesInitialPassword(c *gc.C) {
+	c.Fatalf("not done")
+}
+
 type fakeAPIOpenConfig struct {
 	agent.Config
 }

--- a/worker/apicaller/open_test.go
+++ b/worker/apicaller/open_test.go
@@ -1,0 +1,97 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apicaller_test
+
+import (
+	"fmt"
+
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/multiwatcher"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/apicaller"
+)
+
+type apiOpenSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&apiOpenSuite{})
+
+func (s *apiOpenSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.PatchValue(apicaller.CheckProvisionedStrategy, utils.AttemptStrategy{})
+}
+
+func (s *apiOpenSuite) TestOpenAPIStateReplaceErrors(c *gc.C) {
+	type replaceErrors struct {
+		openErr    error
+		replaceErr error
+	}
+	var apiError error
+	s.PatchValue(apicaller.OpenAPIForAgent, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		return nil, apiError
+	})
+	errReplacePairs := []replaceErrors{{
+		fmt.Errorf("blah"), nil,
+	}, {
+		openErr:    &params.Error{Code: params.CodeNotProvisioned},
+		replaceErr: worker.ErrTerminateAgent,
+	}, {
+		openErr:    &params.Error{Code: params.CodeUnauthorized},
+		replaceErr: worker.ErrTerminateAgent,
+	}}
+	for i, test := range errReplacePairs {
+		c.Logf("test %d", i)
+		apiError = test.openErr
+		_, _, err := apicaller.OpenAPIState(fakeAPIOpenConfig{}, nil)
+		if test.replaceErr == nil {
+			c.Check(err, gc.Equals, test.openErr)
+		} else {
+			c.Check(err, gc.Equals, test.replaceErr)
+		}
+	}
+}
+
+func (s *apiOpenSuite) TestOpenAPIStateWaitsProvisioned(c *gc.C) {
+	s.PatchValue(&apicaller.CheckProvisionedStrategy.Min, 5)
+	var called int
+	s.PatchValue(apicaller.OpenAPIForAgent, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		called++
+		if called == apicaller.CheckProvisionedStrategy.Min-1 {
+			return nil, &params.Error{Code: params.CodeUnauthorized}
+		}
+		return nil, &params.Error{Code: params.CodeNotProvisioned}
+	})
+	_, _, err := apicaller.OpenAPIState(fakeAPIOpenConfig{}, nil)
+	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
+	c.Assert(called, gc.Equals, apicaller.CheckProvisionedStrategy.Min-1)
+}
+
+func (s *apiOpenSuite) TestOpenAPIStateWaitsProvisionedGivesUp(c *gc.C) {
+	s.PatchValue(&apicaller.CheckProvisionedStrategy.Min, 5)
+	var called int
+	s.PatchValue(apicaller.OpenAPIForAgent, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		called++
+		return nil, &params.Error{Code: params.CodeNotProvisioned}
+	})
+	_, _, err := apicaller.OpenAPIState(fakeAPIOpenConfig{}, nil)
+	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
+	// +1 because we always attempt at least once outside the attempt strategy
+	// (twice if the API server initially returns CodeUnauthorized.)
+	c.Assert(called, gc.Equals, apicaller.CheckProvisionedStrategy.Min+1)
+}
+
+type fakeAPIOpenConfig struct {
+	agent.Config
+}
+
+func (fakeAPIOpenConfig) APIInfo() *api.Info              { return &api.Info{} }
+func (fakeAPIOpenConfig) OldPassword() string             { return "old" }
+func (fakeAPIOpenConfig) Jobs() []multiwatcher.MachineJob { return []multiwatcher.MachineJob{} }

--- a/worker/apicaller/worker.go
+++ b/worker/apicaller/worker.go
@@ -9,7 +9,6 @@ import (
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/api/base"
-	jujudagent "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 )
@@ -29,7 +28,7 @@ type Connection interface {
 // this component without using a real API connection).
 var openConnection = func(agent agent.Agent) (Connection, error) {
 	currentConfig := agent.CurrentConfig()
-	st, _, err := jujudagent.OpenAPIState(currentConfig, agent)
+	st, _, err := OpenAPIState(currentConfig, agent)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/leadership/manifold.go
+++ b/worker/leadership/manifold.go
@@ -20,7 +20,7 @@ import (
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
 type ManifoldConfig struct {
 	AgentName           string
-	ApiCallerName       string
+	APICallerName       string
 	LeadershipGuarantee time.Duration
 }
 
@@ -30,7 +30,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
 			config.AgentName,
-			config.ApiCallerName,
+			config.APICallerName,
 		},
 		Start:  startFunc(config),
 		Output: outputFunc,
@@ -46,7 +46,7 @@ func startFunc(config ManifoldConfig) dependency.StartFunc {
 			return nil, err
 		}
 		var apiCaller base.APICaller
-		if err := getResource(config.ApiCallerName, &apiCaller); err != nil {
+		if err := getResource(config.APICallerName, &apiCaller); err != nil {
 			return nil, err
 		}
 		return newManifoldWorker(agent, apiCaller, config.LeadershipGuarantee)

--- a/worker/leadership/manifold_test.go
+++ b/worker/leadership/manifold_test.go
@@ -32,7 +32,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.Stub = testing.Stub{}
 	s.manifold = leadership.Manifold(leadership.ManifoldConfig{
 		AgentName:           "agent-name",
-		ApiCallerName:       "api-caller-name",
+		APICallerName:       "api-caller-name",
 		LeadershipGuarantee: 123456 * time.Millisecond,
 	})
 }

--- a/worker/logsender/manifold.go
+++ b/worker/logsender/manifold.go
@@ -1,0 +1,42 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsender
+
+import (
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	AgentName string
+	LogSource LogRecordCh
+}
+
+// Manifold returns a dependency manifold that runs a logger
+// worker, using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+
+			if !feature.IsDbLogEnabled() {
+				logger.Warningf("log sender manifold disabled by feature flag")
+				return nil, dependency.ErrMissing
+			}
+
+			var agent agent.Agent
+			if err := getResource(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			apiInfo := agent.CurrentConfig().APIInfo()
+			return New(config.LogSource, apiInfo), nil
+		},
+	}
+}

--- a/worker/rsyslog/manifold.go
+++ b/worker/rsyslog/manifold.go
@@ -4,9 +4,12 @@
 package rsyslog
 
 import (
+	"github.com/juju/utils/featureflag"
+
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/rsyslog"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
@@ -29,6 +32,12 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 // package factory function -- as part of the manifold -- and all tests should
 // thus be routed through it.
 var newWorker = func(agent agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+
+	if featureflag.Enabled(feature.DisableRsyslog) {
+		logger.Warningf("rsyslog config manifold disabled by feature flag")
+		return nil, dependency.ErrMissing
+	}
+
 	agentConfig := agent.CurrentConfig()
 	tag := agentConfig.Tag()
 	namespace := agentConfig.Value(coreagent.Namespace)

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -95,7 +95,7 @@ func syslogUser() string {
 // WatchForRsyslogChanges and updates rsyslog configuration based
 // on changes. The worker will remove the configuration file
 // on teardown.
-func NewRsyslogConfigWorker(st *apirsyslog.State, mode RsyslogMode, tag names.Tag, namespace string, stateServerAddrs []string, jujuConfigDir string) (worker.Worker, error) {
+var NewRsyslogConfigWorker = func(st *apirsyslog.State, mode RsyslogMode, tag names.Tag, namespace string, stateServerAddrs []string, jujuConfigDir string) (worker.Worker, error) {
 	if version.Current.OS == version.Windows && mode == RsyslogModeAccumulate {
 		return worker.NewNoOpWorker(), nil
 	}

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils/fslock"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/leadership"
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	AgentName             string
+	APICallerName         string
+	MachineLockName       string
+	LeadershipTrackerName string
+}
+
+// Manifold returns a dependency manifold that runs a uniter worker,
+// using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.LeadershipTrackerName,
+			config.MachineLockName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+
+			// Collect all required resources.
+			var agent agent.Agent
+			if err := getResource(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			var apiCaller base.APICaller
+			if err := getResource(config.APICallerName, &apiCaller); err != nil {
+				// TODO(fwereade): absence of an APICaller shouldn't be the end of
+				// the world -- we ought to return a type that can at least run the
+				// leader-deposed hook -- but that's not done yet.
+				return nil, err
+			}
+			var machineLock *fslock.Lock
+			if err := getResource(config.MachineLockName, &machineLock); err != nil {
+				return nil, err
+			}
+			var leadershipTracker leadership.Tracker
+			if err := getResource(config.LeadershipTrackerName, &leadershipTracker); err != nil {
+				return nil, err
+			}
+
+			// Configure and start the uniter.
+			config := agent.CurrentConfig()
+			tag := config.Tag()
+			unitTag, ok := tag.(names.UnitTag)
+			if !ok {
+				return nil, errors.Errorf("expected a unit tag, got %v", tag)
+			}
+			uniterFacade := uniter.NewState(apiCaller, unitTag)
+			return NewUniter(&UniterParams{
+				UniterFacade:         uniterFacade,
+				UnitTag:              unitTag,
+				LeadershipTracker:    leadershipTracker,
+				DataDir:              config.DataDir(),
+				MachineLock:          machineLock,
+				MetricsTimerChooser:  NewMetricsTimerChooser(),
+				UpdateStatusSignal:   NewUpdateStatusTimer(),
+				NewOperationExecutor: operation.NewExecutor,
+			}), nil
+		},
+	}
+}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
-	coreleadership "github.com/juju/juju/leadership"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/leadership"
@@ -71,7 +70,6 @@ type Uniter struct {
 	operationExecutor    operation.Executor
 	newOperationExecutor NewExecutorFunc
 
-	leadershipClaimer coreleadership.Claimer
 	leadershipTracker leadership.Tracker
 
 	hookLock    *fslock.Lock
@@ -103,11 +101,11 @@ type Uniter struct {
 
 // UniterParams hold all the necessary parameters for a new Uniter.
 type UniterParams struct {
-	St                   *uniter.State
+	UniterFacade         *uniter.State
 	UnitTag              names.UnitTag
-	LeadershipClaimer    coreleadership.Claimer
+	LeadershipTracker    leadership.Tracker
 	DataDir              string
-	HookLock             *fslock.Lock
+	MachineLock          *fslock.Lock
 	MetricsTimerChooser  *timerChooser
 	UpdateStatusSignal   TimedSignal
 	NewOperationExecutor NewExecutorFunc
@@ -120,10 +118,10 @@ type NewExecutorFunc func(string, func() (*corecharm.URL, error), func(string) (
 // hooks and operations provoked by changes in st.
 func NewUniter(uniterParams *UniterParams) *Uniter {
 	u := &Uniter{
-		st:                   uniterParams.St,
+		st:                   uniterParams.UniterFacade,
 		paths:                NewPaths(uniterParams.DataDir, uniterParams.UnitTag),
-		hookLock:             uniterParams.HookLock,
-		leadershipClaimer:    uniterParams.LeadershipClaimer,
+		hookLock:             uniterParams.MachineLock,
+		leadershipTracker:    uniterParams.LeadershipTracker,
 		metricsTimerChooser:  uniterParams.MetricsTimerChooser,
 		collectMetricsAt:     uniterParams.MetricsTimerChooser.inactive,
 		sendMetricsAt:        uniterParams.MetricsTimerChooser.inactive,
@@ -151,19 +149,6 @@ func (u *Uniter) runCleanups() {
 }
 
 func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
-	// Start tracking leadership state.
-	// TODO(fwereade): ideally, this wouldn't be created here; as a worker it's
-	// clearly better off being managed by a Runner. However, we haven't come up
-	// with a clean way to reference one (lineage of a...) worker from another,
-	// so for now the tracker is accessible only to its unit.
-	leadershipTracker := leadership.NewTrackerWorker(
-		unitTag, u.leadershipClaimer, leadershipGuarantee,
-	)
-	u.addCleanup(func() error {
-		return worker.Stop(leadershipTracker)
-	})
-	u.leadershipTracker = leadershipTracker
-
 	if err := u.init(unitTag); err != nil {
 		if err == worker.ErrTerminateAgent {
 			return err
@@ -179,8 +164,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	}
 	u.addCleanup(u.f.Stop)
 
-	// Stop the uniter if either of these components fails.
-	go func() { u.tomb.Kill(leadershipTracker.Wait()) }()
+	// Stop the uniter if the filter fails.
 	go func() { u.tomb.Kill(u.f.Wait()) }()
 
 	// Start handling leader settings events, or not, as appropriate.

--- a/worker/util/api.go
+++ b/worker/util/api.go
@@ -12,7 +12,7 @@ import (
 // Some (hopefully growing number of) manifolds completely depend on an API
 // connection; this type configures them.
 type ApiManifoldConfig struct {
-	ApiCallerName string
+	APICallerName string
 }
 
 // ApiStartFunc encapsulates the behaviour that varies among ApiManifolds.
@@ -23,11 +23,11 @@ type ApiStartFunc func(base.APICaller) (worker.Worker, error)
 func ApiManifold(config ApiManifoldConfig, start ApiStartFunc) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.ApiCallerName,
+			config.APICallerName,
 		},
 		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
 			var apiCaller base.APICaller
-			if err := getResource(config.ApiCallerName, &apiCaller); err != nil {
+			if err := getResource(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
 			}
 			return start(apiCaller)

--- a/worker/util/api_test.go
+++ b/worker/util/api_test.go
@@ -30,7 +30,7 @@ func (s *ApiManifoldSuite) SetUpTest(c *gc.C) {
 	s.Stub = testing.Stub{}
 	s.worker = &dummyWorker{}
 	s.manifold = util.ApiManifold(util.ApiManifoldConfig{
-		ApiCallerName: "api-caller-name",
+		APICallerName: "api-caller-name",
 	}, s.newWorker)
 }
 

--- a/worker/util/apiagent.go
+++ b/worker/util/apiagent.go
@@ -14,7 +14,7 @@ import (
 // type configures them.
 type AgentApiManifoldConfig struct {
 	AgentName     string
-	ApiCallerName string
+	APICallerName string
 }
 
 // AgentApiStartFunc encapsulates the behaviour that varies among AgentApiManifolds.
@@ -27,7 +27,7 @@ func AgentApiManifold(config AgentApiManifoldConfig, start AgentApiStartFunc) de
 	return dependency.Manifold{
 		Inputs: []string{
 			config.AgentName,
-			config.ApiCallerName,
+			config.APICallerName,
 		},
 		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
 			var agent agent.Agent
@@ -35,7 +35,7 @@ func AgentApiManifold(config AgentApiManifoldConfig, start AgentApiStartFunc) de
 				return nil, err
 			}
 			var apiCaller base.APICaller
-			if err := getResource(config.ApiCallerName, &apiCaller); err != nil {
+			if err := getResource(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
 			}
 			return start(agent, apiCaller)

--- a/worker/util/apiagent_test.go
+++ b/worker/util/apiagent_test.go
@@ -32,7 +32,7 @@ func (s *AgentApiManifoldSuite) SetUpTest(c *gc.C) {
 	s.worker = &dummyWorker{}
 	s.manifold = util.AgentApiManifold(util.AgentApiManifoldConfig{
 		AgentName:     "agent-name",
-		ApiCallerName: "api-caller-name",
+		APICallerName: "api-caller-name",
 	}, s.newWorker)
 }
 


### PR DESCRIPTION
Most important thing: `UnitAgent.APIWorkers` has been *greatly* simplified, by dint of representing the dependencies between workers as a `dependency.Manifolds` in the (new) `cmd/jujud/agent/unit` package. Look first at:

  * `cmd/jujud/agent/unit.go`
  * `cmd/jujud/agent/unit/manifolds.go`

...which are designed to make you feel good about everything else. Problems here should definitely be complained about. Then the complications start...

To resolve an import cycle, we move `OpenAPIState` and `OpenAPIStateUsingInfo` from `cmd/jujud/agent` into `worker/apicaller`. That's fine -- just a bunch of lines from `agent/agent.go` moved into `apicaller/open.go`. But then the first few tests move as well; and the exports of `checkProvisionedStrategy` and `openAPIForAgent` alongside the pre-existing `openConnection` start to smell. 

Then you try to move the rest of the OpenAPIState tests, that are deeply mired in the already-scary agent fixtures, and things become complicated, so you give up and leave them in place, pleading "barely worse-tested than when we started, and we gate on the full unit test suite anyway". This is obviously questionable, and could be addressed by introducing an `api.Connection` interface (that just exposed most of `*api.State`'s methods, at least to begin with) and thus making the OpenAPIState sanely mockable -- but it's arguably out of scope here.

Also needed to add manifolds for `worker/logsender` and `worker/uniter`; and to tweak the patching of `NewRsyslogConfigUpdater` to keep the agent tests passing; otherwise, s/Api/API/ in a few field names.

(Review request: http://reviews.vapour.ws/r/2319/)