### PR TITLE
Add tests to statushistorypruner worker

### DIFF
--- a/worker/diskmanager/diskmanager.go
+++ b/worker/diskmanager/diskmanager.go
@@ -46,7 +46,7 @@ func NewWorker(l ListBlockDevicesFunc, b BlockDeviceSetter) worker.Worker {
 	f := func(stop <-chan struct{}) error {
 		return doWork(l, b, &old)
 	}
-	return worker.NewPeriodicWorker(f, listBlockDevicesPeriod)
+	return worker.NewPeriodicWorker(f, listBlockDevicesPeriod, worker.NewTimer)
 }
 
 func doWork(listf ListBlockDevicesFunc, b BlockDeviceSetter, old *[]storage.BlockDevice) error {

--- a/worker/metricworker/cleanup.go
+++ b/worker/metricworker/cleanup.go
@@ -35,5 +35,5 @@ func NewCleanup(client metricsmanager.MetricsManagerClient) worker.Worker {
 		}
 		return nil
 	}
-	return worker.NewPeriodicWorker(f, cleanupPeriod)
+	return worker.NewPeriodicWorker(f, cleanupPeriod, worker.NewTimer)
 }

--- a/worker/metricworker/sender.go
+++ b/worker/metricworker/sender.go
@@ -35,5 +35,5 @@ func NewSender(client metricsmanager.MetricsManagerClient) worker.Worker {
 		}
 		return nil
 	}
-	return worker.NewPeriodicWorker(f, senderPeriod)
+	return worker.NewPeriodicWorker(f, senderPeriod, worker.NewTimer)
 }

--- a/worker/periodicworker.go
+++ b/worker/periodicworker.go
@@ -21,26 +21,42 @@ type periodicWorker struct {
 	newTimer NewTimerFunc
 }
 
+// PeriodicWorkerCall represents the callable to be passed
+// to the periodic worker to be run every elapsed period.
 type PeriodicWorkerCall func(stop <-chan struct{}) error
 
+// PeriodicTimer is an interface for the timer that periodicworker
+// will use to handle the calls.
 type PeriodicTimer interface {
+	// Reset changes the timer to expire after duration d.
+	// It returns true if the timer had been active, false
+	// if the timer had expired or been stopped.
 	Reset(time.Duration) bool
+	// C returns the channel used to signal expiration of
+	// the timer duration.
 	C() <-chan time.Time
 }
+
+// NewTimerFunc is a constructor used to obtain the instance
+// of PeriodicTimer periodicWorker uses on its loop.
 type NewTimerFunc func(time.Duration) PeriodicTimer
 
+// Timer implements PeriodicTimer.
 type Timer struct {
 	timer *time.Timer
 }
 
+// Reset implements PeriodicTimer.
 func (t *Timer) Reset(d time.Duration) bool {
 	return t.timer.Reset(d)
 }
 
+// C implements PeriodicTimer.
 func (t *Timer) C() <-chan time.Time {
 	return t.timer.C
 }
 
+// NewTimer is the default implementation of NewTimerFunc.
 func NewTimer(d time.Duration) PeriodicTimer {
 	return &Timer{time.NewTimer(d)}
 }

--- a/worker/periodicworker.go
+++ b/worker/periodicworker.go
@@ -32,9 +32,10 @@ type PeriodicTimer interface {
 	// It returns true if the timer had been active, false
 	// if the timer had expired or been stopped.
 	Reset(time.Duration) bool
-	// C returns the channel used to signal expiration of
-	// the timer duration.
-	C() <-chan time.Time
+	// CountDown returns the channel used to signal expiration of
+	// the timer duration. The channel is called C in the base
+	// implementation of timer but the name is confusing.
+	CountDown() <-chan time.Time
 }
 
 // NewTimerFunc is a constructor used to obtain the instance
@@ -51,8 +52,8 @@ func (t *Timer) Reset(d time.Duration) bool {
 	return t.timer.Reset(d)
 }
 
-// C implements PeriodicTimer.
-func (t *Timer) C() <-chan time.Time {
+// CountDown implements PeriodicTimer.
+func (t *Timer) CountDown() <-chan time.Time {
 	return t.timer.C
 }
 
@@ -81,7 +82,7 @@ func (w *periodicWorker) run(call PeriodicWorkerCall, period time.Duration) erro
 		select {
 		case <-stop:
 			return tomb.ErrDying
-		case <-timer.C():
+		case <-timer.CountDown():
 			if err := call(stop); err != nil {
 				if err == ErrKilled {
 					return tomb.ErrDying

--- a/worker/periodicworker_test.go
+++ b/worker/periodicworker_test.go
@@ -28,7 +28,7 @@ func (s *periodicWorkerSuite) TestWait(c *gc.C) {
 		return testError
 	}
 
-	w := NewPeriodicWorker(doWork, defaultPeriod)
+	w := NewPeriodicWorker(doWork, defaultPeriod, NewTimer)
 	defer func() { c.Assert(Stop(w), gc.Equals, testError) }()
 	select {
 	case <-funcHasRun:
@@ -54,7 +54,7 @@ func (s *periodicWorkerSuite) TestWaitNil(c *gc.C) {
 		return nil
 	}
 
-	w := NewPeriodicWorker(doWork, defaultPeriod)
+	w := NewPeriodicWorker(doWork, defaultPeriod, NewTimer)
 	defer func() { c.Assert(Stop(w), gc.IsNil) }()
 	select {
 	case <-funcHasRun:
@@ -94,7 +94,7 @@ func runKillTest(c *gc.C, returnValue, expected error) {
 		return returnValue
 	}
 
-	w := NewPeriodicWorker(doWork, defaultPeriod)
+	w := NewPeriodicWorker(doWork, defaultPeriod, NewTimer)
 	defer func() { c.Assert(Stop(w), gc.Equals, expected) }()
 
 	select {
@@ -126,7 +126,7 @@ func (s *periodicWorkerSuite) TestCallUntilKilled(c *gc.C) {
 
 	period := time.Millisecond * 500
 	unacceptableWait := time.Second * 10
-	w := NewPeriodicWorker(doWork, period)
+	w := NewPeriodicWorker(doWork, period, NewTimer)
 	defer func() { c.Assert(Stop(w), gc.IsNil) }()
 	for i := 0; i < 5; i++ {
 		select {

--- a/worker/statushistorypruner/export_test.go
+++ b/worker/statushistorypruner/export_test.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statushistorypruner
+
+import (
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+)
+
+func NewForTests(st *state.State, params *HistoryPrunerParams, t worker.NewTimerFunc, psh pruneHistoryFunc) worker.Worker {
+	w := &pruneWorker{
+		st:     st,
+		params: params,
+		pruner: psh,
+	}
+	return worker.NewPeriodicWorker(w.doPruning, w.params.PruneInterval, t)
+}

--- a/worker/statushistorypruner/export_test.go
+++ b/worker/statushistorypruner/export_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/juju/worker"
 )
 
-func NewForTests(st *state.State, params *HistoryPrunerParams, t worker.NewTimerFunc, psh pruneHistoryFunc) worker.Worker {
+func NewPruneWorker(st *state.State, params *HistoryPrunerParams, t worker.NewTimerFunc, psh pruneHistoryFunc) worker.Worker {
 	w := &pruneWorker{
 		st:     st,
 		params: params,

--- a/worker/statushistorypruner/package_test.go
+++ b/worker/statushistorypruner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statushistorypruner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/statushistorypruner/worker_test.go
+++ b/worker/statushistorypruner/worker_test.go
@@ -1,0 +1,101 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statushistorypruner_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/statushistorypruner"
+)
+
+type Timer struct {
+	period time.Duration
+	c      chan time.Time
+	gcC    *gc.C
+}
+
+func (t *Timer) Reset(d time.Duration) bool {
+	t.period = d
+	return true
+}
+
+func (t *Timer) C() <-chan time.Time {
+	return t.c
+}
+
+func (t *Timer) Fire() {
+	select {
+	case t.c <- time.Time{}:
+	case <-time.After(coretesting.LongWait):
+		t.gcC.Fatalf("timed out waiting for pruner to run")
+	}
+}
+
+func NewTimer(d time.Duration, c *gc.C) worker.PeriodicTimer {
+	return &Timer{period: d,
+		c:   make(chan time.Time),
+		gcC: c}
+}
+
+var _ = gc.Suite(&StatusHistoryPrunerSuite{})
+
+type StatusHistoryPrunerSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *StatusHistoryPrunerSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *StatusHistoryPrunerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *StatusHistoryPrunerSuite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *StatusHistoryPrunerSuite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *StatusHistoryPrunerSuite) TestWorker(c *gc.C) {
+	var passedMaxLogs int
+	fakePruner := func(_ *state.State, maxLogs int) error {
+		passedMaxLogs = maxLogs
+		return nil
+	}
+	params := statushistorypruner.HistoryPrunerParams{
+		MaxLogsPerState: 3,
+		PruneInterval:   coretesting.ShortWait,
+	}
+	fakeTimer := NewTimer(coretesting.LongWait, c)
+
+	fakeTimerFunc := func(d time.Duration) worker.PeriodicTimer {
+		// construction of timer should be with 0 because we intend it to
+		// run once before waiting.
+		c.Assert(d, gc.Equals, 0*time.Nanosecond)
+		return fakeTimer
+	}
+	pruner := statushistorypruner.NewForTests(
+		&state.State{},
+		&params,
+		fakeTimerFunc,
+		fakePruner,
+	)
+	s.AddCleanup(func(*gc.C) {
+		pruner.Kill()
+		c.Assert(pruner.Wait(), jc.ErrorIsNil)
+	})
+	fakeTimer.(*Timer).Fire()
+	c.Assert(passedMaxLogs, gc.Equals, 3)
+	// Reset will have been called with the actual PruneInterval
+	c.Assert(fakeTimer.(*Timer).period, gc.Equals, coretesting.ShortWait)
+}


### PR DESCRIPTION
statushistorypruner individual functions where unittested but not the worker.
I added tests plus modified PeriodicWorker to be testable with custom timer implementations.

(Review request: http://reviews.vapour.ws/r/2322/)