### PR TITLE
consolidate Agent interface

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -194,7 +194,7 @@ type Config interface {
 	Environment() names.EnvironTag
 }
 
-type ConfigSetterOnly interface {
+type configSetterOnly interface {
 	// Clone returns a copy of the configuration that
 	// is unaffected by subsequent calls to the Set*
 	// methods
@@ -254,12 +254,12 @@ type ConfigWriter interface {
 
 type ConfigSetter interface {
 	Config
-	ConfigSetterOnly
+	configSetterOnly
 }
 
 type ConfigSetterWriter interface {
 	Config
-	ConfigSetterOnly
+	configSetterOnly
 	ConfigWriter
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -39,6 +39,48 @@ var (
 	confDir = paths.MustSucceed(paths.ConfDir(version.Current.Series))
 )
 
+// Agent exposes the agent's configuration to other components. This
+// interface should probably be segregated (agent.ConfigGetter and
+// agent.ConfigChanger?) but YAGNI *currently* advises against same.
+type Agent interface {
+
+	// CurrentConfig returns a copy of the agent's configuration. No
+	// guarantees regarding ongoing correctness are made.
+	CurrentConfig() Config
+
+	// ChangeConfig allows clients to change the agent's configuration
+	// by supplying a callback that applies the changes.
+	ChangeConfig(ConfigMutator) error
+}
+
+// APIHostPortsSetter trivially wraps an Agent to implement
+// worker/apiaddressupdater/APIAddressSetter.
+type APIHostPortsSetter struct {
+	Agent
+}
+
+// SetAPIHostPorts is the APIAddressSetter interface.
+func (s APIHostPortsSetter) SetAPIHostPorts(servers [][]network.HostPort) error {
+	return s.ChangeConfig(func(c ConfigSetter) error {
+		c.SetAPIHostPorts(servers)
+		return nil
+	})
+}
+
+// SetStateServingInfo trivially wraps an Agent to implement
+// worker/certupdater/SetStateServingInfo.
+type StateServingInfoSetter struct {
+	Agent
+}
+
+// SetStateServingInfo is the SetStateServingInfo interface.
+func (s StateServingInfoSetter) SetStateServingInfo(info params.StateServingInfo) error {
+	return s.ChangeConfig(func(c ConfigSetter) error {
+		c.SetStateServingInfo(info)
+		return nil
+	})
+}
+
 var (
 	// DefaultLogDir defines the default log directory for juju agents.
 	// It's defined as a variable so it could be overridden in tests.

--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -8,64 +8,40 @@ package agent
 
 import (
 	"sync"
-	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"github.com/juju/utils"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api"
-	apiagent "github.com/juju/juju/api/agent"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/network"
-	"github.com/juju/juju/state"
-	"github.com/juju/juju/version"
-	"github.com/juju/juju/worker"
 )
 
-var (
-	apiOpen = openAPIForAgent
-
-	checkProvisionedStrategy = utils.AttemptStrategy{
-		Total: 1 * time.Minute,
-		Delay: 5 * time.Second,
-	}
-)
-
-// openAPIForAgent exists to handle the edge case that exists
-// when an environment is jumping several versions and doesn't
-// yet have the environment UUID cached in the agent config.
-// This happens only the first time an agent tries to connect
-// after an upgrade.  If there is no environment UUID set, then
-// use login version 1.
-func openAPIForAgent(info *api.Info, opts api.DialOpts) (*api.State, error) {
-	if info.EnvironTag.Id() == "" {
-		return api.OpenWithVersion(info, opts, 1)
-	}
-	return api.Open(info, opts)
-}
-
+// AgentConf is a terribly confused interface.
+//
+// Parts of it are a mixin for cmd.Command implementations; others are a mixin
+// for agent.Agent implementations; others bridge the two. We should be aiming
+// to separate the cmd responsibilities from the agent responsibilities.
 type AgentConf interface {
+
 	// AddFlags injects common agent flags into f.
 	AddFlags(f *gnuflag.FlagSet)
+
 	// CheckArgs reports whether the given args are valid for this agent.
 	CheckArgs(args []string) error
-	// ReadConfig reads the agent's config from its config file.
-	ReadConfig(tag string) error
-	// ChangeConfig modifies this configuration using the given mutator.
-	ChangeConfig(change agent.ConfigMutator) error
-	// CurrentConfig returns the agent config for this agent.
-	CurrentConfig() agent.Config
-	// SetAPIHostPorts satisfies worker/apiaddressupdater/APIAddressSetter.
-	SetAPIHostPorts(servers [][]network.HostPort) error
-	// SetStateServingInfo satisfies worker/certupdater/SetStateServingInfo.
-	SetStateServingInfo(info params.StateServingInfo) error
+
 	// DataDir returns the directory where this agent should store its data.
 	DataDir() string
+
+	// ReadConfig reads the agent's config from its config file.
+	ReadConfig(tag string) error
+
+	// CurrentConfig returns the agent config for this agent.
+	CurrentConfig() agent.Config
+
+	// ChangeConfig modifies this configuration using the given mutator.
+	ChangeConfig(change agent.ConfigMutator) error
 }
 
 // NewAgentConf returns a new value that satisfies AgentConf
@@ -136,170 +112,4 @@ func (ch *agentConf) CurrentConfig() agent.Config {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	return ch._config.Clone()
-}
-
-// SetAPIHostPorts satisfies worker/apiaddressupdater/APIAddressSetter.
-func (a *agentConf) SetAPIHostPorts(servers [][]network.HostPort) error {
-	return a.ChangeConfig(func(c agent.ConfigSetter) error {
-		c.SetAPIHostPorts(servers)
-		return nil
-	})
-}
-
-// SetStateServingInfo satisfies worker/certupdater/SetStateServingInfo.
-func (a *agentConf) SetStateServingInfo(info params.StateServingInfo) error {
-	return a.ChangeConfig(func(c agent.ConfigSetter) error {
-		c.SetStateServingInfo(info)
-		return nil
-	})
-}
-
-type Agent interface {
-	Tag() names.Tag
-	ChangeConfig(agent.ConfigMutator) error
-}
-
-// The AgentState interface is implemented by state types
-// that represent running agents.
-type AgentState interface {
-	// SetAgentVersion sets the tools version that the agent is
-	// currently running.
-	SetAgentVersion(v version.Binary) error
-	Tag() string
-	Life() state.Life
-}
-
-// isleep waits for the given duration or until it receives a value on
-// stop.  It returns whether the full duration was slept without being
-// stopped.
-func isleep(d time.Duration, stop <-chan struct{}) bool {
-	select {
-	case <-stop:
-		return false
-	case <-time.After(d):
-	}
-	return true
-}
-
-type configChanger func(c *agent.Config)
-
-// OpenAPIState opens the API using the given information. The agent's
-// password is changed if the fallback password was used to connect to
-// the API.
-func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.Entity, outErr error) {
-	info := agentConfig.APIInfo()
-	st, usedOldPassword, err := openAPIStateUsingInfo(info, a, agentConfig.OldPassword())
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() {
-		if outErr != nil && st != nil {
-			st.Close()
-		}
-	}()
-
-	entity, err := st.Agent().Entity(a.Tag())
-	if err == nil && entity.Life() == params.Dead {
-		logger.Errorf("agent terminating - entity %q is dead", a.Tag())
-		return nil, nil, worker.ErrTerminateAgent
-	}
-	if params.IsCodeUnauthorized(err) {
-		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)
-		return nil, nil, worker.ErrTerminateAgent
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if !usedOldPassword {
-		// Call set password with the current password.  If we've recently
-		// become a state server, this will fix up our credentials in mongo.
-		if err := entity.SetPassword(info.Password); err != nil {
-			return nil, nil, errors.Annotate(err, "can't reset agent password")
-		}
-	} else {
-		// We succeeded in connecting with the fallback
-		// password, so we need to create a new password
-		// for the future.
-		newPassword, err := utils.RandomPassword()
-		if err != nil {
-			return nil, nil, err
-		}
-		err = setAgentPassword(newPassword, info.Password, a, entity)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// Reconnect to the API with the new password.
-		st.Close()
-		info.Password = newPassword
-		st, err = apiOpen(info, api.DialOpts{})
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	return st, entity, err
-}
-
-func setAgentPassword(newPw, oldPw string, a Agent, entity *apiagent.Entity) error {
-	// Change the configuration *before* setting the entity
-	// password, so that we avoid the possibility that
-	// we might successfully change the entity's
-	// password but fail to write the configuration,
-	// thus locking us out completely.
-	if err := a.ChangeConfig(func(c agent.ConfigSetter) error {
-		c.SetPassword(newPw)
-		c.SetOldPassword(oldPw)
-		return nil
-	}); err != nil {
-		return err
-	}
-	return entity.SetPassword(newPw)
-}
-
-// OpenAPIStateUsingInfo opens the API using the given API
-// information, and returns the opened state and the api entity with
-// the given tag.
-func OpenAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.State, error) {
-	st, _, err := openAPIStateUsingInfo(info, a, oldPassword)
-	return st, err
-}
-
-func openAPIStateUsingInfo(info *api.Info, a Agent, oldPassword string) (*api.State, bool, error) {
-	// We let the API dial fail immediately because the
-	// runner's loop outside the caller of openAPIState will
-	// keep on retrying. If we block for ages here,
-	// then the worker that's calling this cannot
-	// be interrupted.
-	st, err := apiOpen(info, api.DialOpts{})
-	usedOldPassword := false
-	if params.IsCodeUnauthorized(err) {
-		// We've perhaps used the wrong password, so
-		// try again with the fallback password.
-		infoCopy := *info
-		info = &infoCopy
-		info.Password = oldPassword
-		usedOldPassword = true
-		st, err = apiOpen(info, api.DialOpts{})
-	}
-	// The provisioner may take some time to record the agent's
-	// machine instance ID, so wait until it does so.
-	if params.IsCodeNotProvisioned(err) {
-		for a := checkProvisionedStrategy.Start(); a.Next(); {
-			st, err = apiOpen(info, api.DialOpts{})
-			if !params.IsCodeNotProvisioned(err) {
-				break
-			}
-		}
-	}
-	if err != nil {
-		if params.IsCodeNotProvisioned(err) || params.IsCodeUnauthorized(err) {
-			logger.Errorf("agent terminating due to error returned during API open: %v", err)
-			return nil, false, worker.ErrTerminateAgent
-		}
-		return nil, false, err
-	}
-
-	return st, usedOldPassword, nil
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -259,7 +259,6 @@ func (a *machineAgentCmd) Info() *cmd.Info {
 // MachineAgent given a machineId.
 func MachineAgentFactoryFn(
 	agentConfWriter AgentConfigWriter,
-	apiAddressSetter apiaddressupdater.APIAddressSetter,
 	bufferedLogs logsender.LogRecordCh,
 	loopDeviceManager looputil.LoopDeviceManager,
 ) func(string) *MachineAgent {
@@ -267,7 +266,6 @@ func MachineAgentFactoryFn(
 		return NewMachineAgent(
 			machineId,
 			agentConfWriter,
-			apiAddressSetter,
 			bufferedLogs,
 			NewUpgradeWorkerContext(),
 			worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant),
@@ -280,7 +278,6 @@ func MachineAgentFactoryFn(
 func NewMachineAgent(
 	machineId string,
 	agentConfWriter AgentConfigWriter,
-	apiAddressSetter apiaddressupdater.APIAddressSetter,
 	bufferedLogs logsender.LogRecordCh,
 	upgradeWorkerContext *upgradeWorkerContext,
 	runner worker.Runner,
@@ -289,7 +286,6 @@ func NewMachineAgent(
 	return &MachineAgent{
 		machineId:            machineId,
 		AgentConfigWriter:    agentConfWriter,
-		apiAddressSetter:     apiAddressSetter,
 		bufferedLogs:         bufferedLogs,
 		upgradeWorkerContext: upgradeWorkerContext,
 		workersStarted:       make(chan struct{}),
@@ -299,28 +295,23 @@ func NewMachineAgent(
 	}
 }
 
-// APIStateUpgrader defines the methods on the Upgrader that
-// agents call.
-type APIStateUpgrader interface {
-	SetVersion(string, version.Binary) error
-}
-
 // MachineAgent is responsible for tying together all functionality
-// needed to orchestarte a Jujud instance which controls a machine.
+// needed to orchestrate a Jujud instance which controls a machine.
 type MachineAgent struct {
 	AgentConfigWriter
 
 	tomb                 tomb.Tomb
 	machineId            string
 	previousAgentVersion version.Number
-	apiAddressSetter     apiaddressupdater.APIAddressSetter
 	runner               worker.Runner
 	bufferedLogs         logsender.LogRecordCh
 	configChangedVal     voyeur.Value
 	upgradeWorkerContext *upgradeWorkerContext
-	restoreMode          bool
-	restoring            bool
 	workersStarted       chan struct{}
+
+	// XXX(fwereade): these smell strongly of goroutine-unsafeness.
+	restoreMode bool
+	restoring   bool
 
 	// Used to signal that the upgrade worker will not
 	// reboot the agent on startup because there are no
@@ -400,7 +391,7 @@ func (a *MachineAgent) upgradeCertificateDNSNames() error {
 	if !update {
 		return nil
 	}
-	// Write a new certificate to the mongp pem and agent config files.
+	// Write a new certificate to the mongo pem and agent config files.
 	si.Cert, si.PrivateKey, err = cert.NewDefaultServer(agentConfig.CACert(), si.CAPrivateKey, dnsNames.Values())
 	if err != nil {
 		return err
@@ -478,7 +469,7 @@ func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error
 	// We need to reopen the API to clear the reboot flag after
 	// scheduling the reboot. It may be cleaner to do this in the reboot
 	// worker, before returning the ErrRebootMachine.
-	st, _, err := OpenAPIState(agentCfg, a)
+	st, _, err := OpenAPIState(a)
 	if err != nil {
 		logger.Infof("Reboot: Error connecting to state")
 		return errors.Trace(err)
@@ -639,8 +630,7 @@ func (a *MachineAgent) stateStarter(stopch <-chan struct{}) error {
 // APIWorker returns a Worker that connects to the API and starts any
 // workers that need an API connection.
 func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
-	agentConfig := a.CurrentConfig()
-	st, entity, err := OpenAPIState(agentConfig, a)
+	st, entity, err := OpenAPIState(a)
 	if err != nil {
 		return nil, err
 	}
@@ -660,8 +650,7 @@ func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 		}
 	}()
 
-	// Refresh the configuration, since it may have been updated after opening state.
-	agentConfig = a.CurrentConfig()
+	agentConfig := a.CurrentConfig()
 	for _, job := range entity.Jobs() {
 		if job.NeedsState() {
 			info, err := st.Agent().StateServingInfo()
@@ -758,7 +747,8 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		return rebootworker.NewReboot(reboot, agentConfig, lock)
 	})
 	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {
-		return apiaddressupdater.NewAPIAddressUpdater(st.Machiner(), a.apiAddressSetter), nil
+		addressUpdater := agent.APIHostPortsSetter{a}
+		return apiaddressupdater.NewAPIAddressUpdater(st.Machiner(), addressUpdater), nil
 	})
 	runner.StartWorker("logger", func() (worker.Worker, error) {
 		return workerlogger.NewLogger(st.Logger(), agentConfig), nil
@@ -1091,7 +1081,7 @@ func (a *MachineAgent) startEnvWorkers(
 	agentConfig := a.CurrentConfig()
 	apiInfo := agentConfig.APIInfo()
 	apiInfo.EnvironTag = st.EnvironTag()
-	apiSt, err := OpenAPIStateUsingInfo(apiInfo, a, agentConfig.OldPassword())
+	apiSt, err := OpenAPIStateUsingInfo(apiInfo, agentConfig.OldPassword())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -221,7 +221,7 @@ func (s *commonMachineSuite) newAgent(c *gc.C, m *state.Machine) *MachineAgent {
 	logsCh, err := logsender.InstallBufferedLogWriter(1024)
 	c.Assert(err, jc.ErrorIsNil)
 	machineAgentFactory := MachineAgentFactoryFn(
-		&agentConf, &agentConf, logsCh, &mockLoopDeviceManager{},
+		&agentConf, logsCh, &mockLoopDeviceManager{},
 	)
 	return machineAgentFactory(m.Id())
 }
@@ -232,8 +232,7 @@ func (s *MachineSuite) TestParseSuccess(c *gc.C) {
 		a := NewMachineAgentCmd(
 			nil,
 			MachineAgentFactoryFn(
-				&agentConf, &agentConf, nil,
-				&mockLoopDeviceManager{},
+				&agentConf, nil, &mockLoopDeviceManager{},
 			),
 			&agentConf,
 			&agentConf,
@@ -310,8 +309,7 @@ func (s *MachineSuite) TestUseLumberjack(c *gc.C) {
 	a := NewMachineAgentCmd(
 		ctx,
 		MachineAgentFactoryFn(
-			agentConf, agentConf, nil,
-			&mockLoopDeviceManager{},
+			agentConf, nil, &mockLoopDeviceManager{},
 		),
 		agentConf,
 		agentConf,
@@ -339,7 +337,7 @@ func (s *MachineSuite) TestDontUseLumberjack(c *gc.C) {
 	a := NewMachineAgentCmd(
 		ctx,
 		MachineAgentFactoryFn(
-			agentConf, agentConf, nil,
+			agentConf, nil,
 			&mockLoopDeviceManager{},
 		),
 		agentConf,
@@ -1134,11 +1132,14 @@ func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds .
 	}
 }
 
-func (s *MachineSuite) TestOpenStateFailsForJobHostUnitsButOpenAPIWorks(c *gc.C) {
-	m, _, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
-	a := s.newAgent(c, m)
-	s.RunTestOpenAPIState(c, m, a, initialMachinePassword)
+func (s *MachineSuite) TestOpenStateFailsForJobHostUnits(c *gc.C) {
 	s.assertJobWithAPI(c, state.JobHostUnits, func(conf agent.Config, st *api.State) {
+		s.AssertCannotOpenState(c, conf.Tag(), conf.DataDir())
+	})
+}
+
+func (s *MachineSuite) TestOpenStateFailsForJobManageNetworking(c *gc.C) {
+	s.assertJobWithAPI(c, state.JobManageNetworking, func(conf agent.Config, st *api.State) {
 		s.AssertCannotOpenState(c, conf.Tag(), conf.DataDir())
 	})
 }
@@ -1147,6 +1148,75 @@ func (s *MachineSuite) TestOpenStateWorksForJobManageEnviron(c *gc.C) {
 	s.assertJobWithAPI(c, state.JobManageEnviron, func(conf agent.Config, st *api.State) {
 		s.AssertCanOpenState(c, conf.Tag(), conf.DataDir())
 	})
+}
+
+func (s *MachineSuite) TestOpenAPIStateWorksForJobHostUnits(c *gc.C) {
+	machine, conf, _ := s.primeAgent(c, version.Current, state.JobHostUnits)
+	s.runOpenAPISTateTest(c, machine, conf)
+}
+
+func (s *MachineSuite) TestOpenAPIStateWorksForJobManageNetworking(c *gc.C) {
+	machine, conf, _ := s.primeAgent(c, version.Current, state.JobManageNetworking)
+	s.runOpenAPISTateTest(c, machine, conf)
+}
+
+func (s *MachineSuite) TestOpenAPIStateWorksForJobManageEnviron(c *gc.C) {
+	machine, conf, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	s.runOpenAPISTateTest(c, machine, conf)
+}
+
+func (s *MachineSuite) runOpenAPISTateTest(c *gc.C, machine *state.Machine, conf agent.Config) {
+	configPath := agent.ConfigPath(conf.DataDir(), conf.Tag())
+
+	// Set a failing password...
+	confW, err := agent.ReadConfig(configPath)
+	c.Assert(err, jc.ErrorIsNil)
+	confW.SetPassword("not-set-on-state-server")
+
+	// ...and also make sure the api info points to the testing api
+	// server (and not, as for JobManageEnviron machines, to the port
+	// chosen for the agent's own API server to run on. This is usually
+	// sane, but inconvenient here because we're not running the full
+	// agent and so the configured API server is not actually there).
+	apiInfo := s.APIInfo(c)
+	hostPorts, err := network.ParseHostPorts(apiInfo.Addrs...)
+	c.Assert(err, jc.ErrorIsNil)
+	confW.SetAPIHostPorts([][]network.HostPort{hostPorts})
+	err = confW.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that it successfully connects with the conf's old password.
+	assertOpen := func() {
+		tagString := conf.Tag().String()
+		agent := NewAgentConf(conf.DataDir())
+		err := agent.ReadConfig(tagString)
+		c.Assert(err, jc.ErrorIsNil)
+		st, gotEntity, err := OpenAPIState(agent)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(st, gc.NotNil)
+		st.Close()
+		c.Assert(gotEntity.Tag(), gc.Equals, tagString)
+	}
+	assertOpen()
+
+	// Check that the initial password is no longer valid.
+	assertPassword := func(password string, valid bool) {
+		err := machine.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(machine.PasswordValid(password), gc.Equals, valid)
+	}
+	assertPassword(initialMachinePassword, false)
+
+	// Read the configuration and check that we can connect with it.
+	confR, err := agent.ReadConfig(configPath)
+	c.Assert(err, gc.IsNil)
+	newPassword := confR.APIInfo().Password
+	assertPassword(newPassword, true)
+
+	// Double-check that we can open a fresh connection with the stored
+	// conf ... and that the password hasn't been changed again.
+	assertOpen()
+	assertPassword(newPassword, true)
 }
 
 func (s *MachineSuite) TestMachineAgentSymlinkJujuRun(c *gc.C) {

--- a/cmd/jujud/agent/open.go
+++ b/cmd/jujud/agent/open.go
@@ -1,0 +1,170 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// This file exists to collect the various bits of code related to OpenAPIState,
+// in preparation for moving them to worker/apicaller and breaking an impending
+// import cycle.
+package agent
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	apiagent "github.com/juju/juju/api/agent"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker"
+)
+
+var (
+	apiOpen = openAPIForAgent
+
+	checkProvisionedStrategy = utils.AttemptStrategy{
+		Total: 1 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+)
+
+// openAPIForAgent exists to handle the edge case that exists
+// when an environment is jumping several versions and doesn't
+// yet have the environment UUID cached in the agent config.
+// This happens only the first time an agent tries to connect
+// after an upgrade.  If there is no environment UUID set, then
+// use login version 1.
+func openAPIForAgent(info *api.Info, opts api.DialOpts) (*api.State, error) {
+	if info.EnvironTag.Id() == "" {
+		return api.OpenWithVersion(info, opts, 1)
+	}
+	return api.Open(info, opts)
+}
+
+// OpenAPIState opens the API using the given information. The agent's
+// password is changed if the fallback password was used to connect to
+// the API.
+func OpenAPIState(a agent.Agent) (_ *api.State, _ *apiagent.Entity, err error) {
+	agentConfig := a.CurrentConfig()
+	info := agentConfig.APIInfo()
+	st, usedOldPassword, err := openAPIStateUsingInfo(info, agentConfig.OldPassword())
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		// NOTE(fwereade): we may close and overwrite st below,
+		// so we need to double-check what we need to do here.
+		if err != nil && st != nil {
+			if err := st.Close(); err != nil {
+				logger.Errorf("while closing API connection: %v", err)
+			}
+		}
+	}()
+
+	tag := agentConfig.Tag()
+	entity, err := st.Agent().Entity(tag)
+	if err == nil && entity.Life() == params.Dead {
+		logger.Errorf("agent terminating - entity %q is dead", tag)
+		return nil, nil, worker.ErrTerminateAgent
+	}
+	if params.IsCodeUnauthorized(err) {
+		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)
+		return nil, nil, worker.ErrTerminateAgent
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !usedOldPassword {
+		// Call set password with the current password.  If we've recently
+		// become a state server, this will fix up our credentials in mongo.
+		if err := entity.SetPassword(info.Password); err != nil {
+			return nil, nil, errors.Annotate(err, "can't reset agent password")
+		}
+	} else {
+		// We succeeded in connecting with the fallback
+		// password, so we need to create a new password
+		// for the future.
+		logger.Debugf("replacing insecure password")
+		newPassword, err := utils.RandomPassword()
+		if err != nil {
+			return nil, nil, err
+		}
+		err = setAgentPassword(newPassword, info.Password, a, entity)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Reconnect to the API with the new password.
+		st.Close()
+		info.Password = newPassword
+		st, err = apiOpen(info, api.DialOpts{})
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return st, entity, err
+}
+
+func setAgentPassword(newPw, oldPw string, a agent.Agent, entity *apiagent.Entity) error {
+	// Change the configuration *before* setting the entity
+	// password, so that we avoid the possibility that
+	// we might successfully change the entity's
+	// password but fail to write the configuration,
+	// thus locking us out completely.
+	if err := a.ChangeConfig(func(c agent.ConfigSetter) error {
+		c.SetPassword(newPw)
+		c.SetOldPassword(oldPw)
+		return nil
+	}); err != nil {
+		return err
+	}
+	return entity.SetPassword(newPw)
+}
+
+// OpenAPIStateUsingInfo opens the API using the given API
+// information, and returns the opened state and the api entity with
+// the given tag.
+func OpenAPIStateUsingInfo(info *api.Info, oldPassword string) (*api.State, error) {
+	st, _, err := openAPIStateUsingInfo(info, oldPassword)
+	return st, err
+}
+
+func openAPIStateUsingInfo(info *api.Info, oldPassword string) (*api.State, bool, error) {
+	// We let the API dial fail immediately because the
+	// runner's loop outside the caller of openAPIState will
+	// keep on retrying. If we block for ages here,
+	// then the worker that's calling this cannot
+	// be interrupted.
+	st, err := apiOpen(info, api.DialOpts{})
+	usedOldPassword := false
+	if params.IsCodeUnauthorized(err) {
+		// We've perhaps used the wrong password, so
+		// try again with the fallback password.
+		infoCopy := *info
+		info = &infoCopy
+		info.Password = oldPassword
+		usedOldPassword = true
+		st, err = apiOpen(info, api.DialOpts{})
+	}
+	// The provisioner may take some time to record the agent's
+	// machine instance ID, so wait until it does so.
+	if params.IsCodeNotProvisioned(err) {
+		for a := checkProvisionedStrategy.Start(); a.Next(); {
+			st, err = apiOpen(info, api.DialOpts{})
+			if !params.IsCodeNotProvisioned(err) {
+				break
+			}
+		}
+	}
+	if err != nil {
+		if params.IsCodeNotProvisioned(err) || params.IsCodeUnauthorized(err) {
+			logger.Errorf("agent terminating due to error returned during API open: %v", err)
+			return nil, false, worker.ErrTerminateAgent
+		}
+		return nil, false, err
+	}
+
+	return st, usedOldPassword, nil
+}

--- a/cmd/jujud/agent/open.go
+++ b/cmd/jujud/agent/open.go
@@ -96,15 +96,21 @@ func OpenAPIState(a agent.Agent) (_ *api.State, _ *apiagent.Entity, err error) {
 		}
 
 		// Reconnect to the API with the new password.
-		st.Close()
+		if err := st.Close(); err != nil {
+			logger.Errorf("while closing API connection with old password: %v", err)
+		}
 		info.Password = newPassword
+
+		// NOTE(fwereade): this is where we rebind st. If you accidentally make
+		// it a local variable you will break this func in a subtle and currently-
+		// untested way.
 		st, err = apiOpen(info, api.DialOpts{})
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
-	return st, entity, err
+	return st, entity, nil
 }
 
 func setAgentPassword(newPw, oldPw string, a agent.Agent, entity *apiagent.Entity) error {

--- a/cmd/jujud/agent/open_test.go
+++ b/cmd/jujud/agent/open_test.go
@@ -1,0 +1,104 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"fmt"
+
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/multiwatcher"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+)
+
+type OpenAPIStateSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&OpenAPIStateSuite{})
+
+func (s *OpenAPIStateSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.PatchValue(&checkProvisionedStrategy, utils.AttemptStrategy{})
+}
+
+func (s *OpenAPIStateSuite) TestOpenAPIStateReplaceErrors(c *gc.C) {
+	type replaceErrors struct {
+		openErr    error
+		replaceErr error
+	}
+	var apiError error
+	s.PatchValue(&apiOpen, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		return nil, apiError
+	})
+	errReplacePairs := []replaceErrors{{
+		fmt.Errorf("blah"), nil,
+	}, {
+		openErr:    &params.Error{Code: params.CodeNotProvisioned},
+		replaceErr: worker.ErrTerminateAgent,
+	}, {
+		openErr:    &params.Error{Code: params.CodeUnauthorized},
+		replaceErr: worker.ErrTerminateAgent,
+	}}
+	for i, test := range errReplacePairs {
+		c.Logf("test %d", i)
+		apiError = test.openErr
+		_, _, err := OpenAPIState(fakeAgent{})
+		if test.replaceErr == nil {
+			c.Check(err, gc.Equals, test.openErr)
+		} else {
+			c.Check(err, gc.Equals, test.replaceErr)
+		}
+	}
+}
+
+func (s *OpenAPIStateSuite) TestOpenAPIStateWaitsProvisioned(c *gc.C) {
+	s.PatchValue(&checkProvisionedStrategy.Min, 5)
+	var called int
+	s.PatchValue(&apiOpen, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		called++
+		if called == checkProvisionedStrategy.Min-1 {
+			return nil, &params.Error{Code: params.CodeUnauthorized}
+		}
+		return nil, &params.Error{Code: params.CodeNotProvisioned}
+	})
+	_, _, err := OpenAPIState(fakeAgent{})
+	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
+	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min-1)
+}
+
+func (s *OpenAPIStateSuite) TestOpenAPIStateWaitsProvisionedGivesUp(c *gc.C) {
+	s.PatchValue(&checkProvisionedStrategy.Min, 5)
+	var called int
+	s.PatchValue(&apiOpen, func(info *api.Info, opts api.DialOpts) (*api.State, error) {
+		called++
+		return nil, &params.Error{Code: params.CodeNotProvisioned}
+	})
+	_, _, err := OpenAPIState(fakeAgent{})
+	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
+	// +1 because we always attempt at least once outside the attempt strategy
+	// (twice if the API server initially returns CodeUnauthorized.)
+	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min+1)
+}
+
+type fakeAgent struct {
+	agent.Agent
+}
+
+func (fakeAgent) CurrentConfig() agent.Config {
+	return fakeAPIOpenConfig{}
+}
+
+type fakeAPIOpenConfig struct {
+	agent.Config
+}
+
+func (fakeAPIOpenConfig) APIInfo() *api.Info              { return &api.Info{} }
+func (fakeAPIOpenConfig) OldPassword() string             { return "old" }
+func (fakeAPIOpenConfig) Jobs() []multiwatcher.MachineJob { return []multiwatcher.MachineJob{} }

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -248,65 +248,76 @@ func (s *UnitSuite) TestWithDeadUnit(c *gc.C) {
 }
 
 func (s *UnitSuite) TestOpenAPIState(c *gc.C) {
-	_, unit, _, _ := s.primeAgent(c)
-	s.RunTestOpenAPIState(c, unit, s.newAgent(c, unit), initialUnitPassword)
-}
+	_, unit, conf, _ := s.primeAgent(c)
+	configPath := agent.ConfigPath(conf.DataDir(), conf.Tag())
 
-func (s *UnitSuite) RunTestOpenAPIState(c *gc.C, ent state.AgentEntity, agentCmd Agent, initialPassword string) {
-	conf, err := agent.ReadConfig(agent.ConfigPath(s.DataDir(), ent.Tag()))
+	// Set an invalid password (but the old initial password will still work).
+	// This test is a sort of unsophisticated simulation of what might happen
+	// if a previous cycle had picked, and locally recorded, a new password;
+	// but failed to set it on the state server. Would be better to test that
+	// code path explicitly in future, but this suffices for now.
+	confW, err := agent.ReadConfig(configPath)
+	c.Assert(err, gc.IsNil)
+	confW.SetPassword("nonsense-borken")
+	err = confW.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
-	conf.SetPassword("")
-	err = conf.Write()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Check that it starts initially and changes the password
-	assertOpen := func(conf agent.Config) {
-		st, gotEnt, err := OpenAPIState(conf, agentCmd)
+	// Check that it successfully connects (with the conf's old password).
+	assertOpen := func() {
+		agent := NewAgentConf(conf.DataDir())
+		err := agent.ReadConfig(conf.Tag().String())
+		c.Assert(err, jc.ErrorIsNil)
+		st, gotEntity, err := OpenAPIState(agent)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st, gc.NotNil)
 		st.Close()
-		c.Assert(gotEnt.Tag(), gc.Equals, ent.Tag().String())
+		c.Assert(gotEntity.Tag(), gc.Equals, unit.Tag().String())
 	}
-	assertOpen(conf)
+	assertOpen()
 
-	// Check that the initial password is no longer valid.
-	err = ent.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ent.PasswordValid(initialPassword), jc.IsFalse)
+	// Check that the old password has been invalidated.
+	assertPassword := func(password string, valid bool) {
+		err := unit.Refresh()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(unit.PasswordValid(password), gc.Equals, valid)
+	}
+	assertPassword(initialUnitPassword, false)
 
-	// Read the configuration and check that we can connect with it.
-	conf, err = agent.ReadConfig(agent.ConfigPath(conf.DataDir(), conf.Tag()))
-	//conf = refreshConfig(c, conf)
+	// Read the stored password and check it's valid.
+	confR, err := agent.ReadConfig(configPath)
 	c.Assert(err, gc.IsNil)
-	// Check we can open the API with the new configuration.
-	assertOpen(conf)
+	newPassword := confR.APIInfo().Password
+	assertPassword(newPassword, true)
+
+	// Double-check that we can open a fresh connection with the stored
+	// conf ... and that the password hasn't been changed again.
+	assertOpen()
+	assertPassword(newPassword, true)
 }
 
 func (s *UnitSuite) TestOpenAPIStateWithBadCredsTerminates(c *gc.C) {
 	conf, _ := s.PrimeAgent(c, names.NewUnitTag("missing/0"), "no-password", version.Current)
-	_, _, err := OpenAPIState(conf, nil)
+
+	_, _, err := OpenAPIState(fakeConfAgent{conf: conf})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
-}
-
-type fakeUnitAgent struct {
-	unitName string
-}
-
-func (f *fakeUnitAgent) Tag() names.Tag {
-	return names.NewUnitTag(f.unitName)
-}
-
-func (f *fakeUnitAgent) ChangeConfig(agent.ConfigMutator) error {
-	panic("fakeUnitAgent.ChangeConfig called unexpectedly")
 }
 
 func (s *UnitSuite) TestOpenAPIStateWithDeadEntityTerminates(c *gc.C) {
 	_, unit, conf, _ := s.primeAgent(c)
 	err := unit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	_, _, err = OpenAPIState(conf, &fakeUnitAgent{"wordpress/0"})
+
+	_, _, err = OpenAPIState(fakeConfAgent{conf: conf})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
+}
+
+type fakeConfAgent struct {
+	agent.Agent
+	conf agent.Config
+}
+
+func (f fakeConfAgent) CurrentConfig() agent.Config {
+	return f.conf
 }
 
 func (s *UnitSuite) TestOpenStateFails(c *gc.C) {

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -134,11 +134,10 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 
 	// TODO(katco-): AgentConf type is doing too much. The
 	// MachineAgent type has called out the seperate concerns; the
-	// AgentConf should be split up to follow suite.
+	// AgentConf should be split up to follow suit.
 	agentConf := agentcmd.NewAgentConf("")
 	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
-		agentConf, agentConf, logCh,
-		looputil.NewLoopDeviceManager(),
+		agentConf, logCh, looputil.NewLoopDeviceManager(),
 	)
 	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
 

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -133,7 +133,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	jujud.Register(NewBootstrapCommand())
 
 	// TODO(katco-): AgentConf type is doing too much. The
-	// MachineAgent type has called out the seperate concerns; the
+	// MachineAgent type has called out the separate concerns; the
 	// AgentConf should be split up to follow suit.
 	agentConf := agentcmd.NewAgentConf("")
 	machineAgentFactory := agentcmd.MachineAgentFactoryFn(

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -96,7 +96,7 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 	agentConf.ReadConfig(m.Tag().String())
 	logsCh, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, agentConf, logsCh, nil)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logsCh, nil)
 	a := machineAgentFactory(m.Id())
 
 	// Ensure there's no logs to begin with.

--- a/worker/apicaller/worker.go
+++ b/worker/apicaller/worker.go
@@ -28,8 +28,7 @@ type Connection interface {
 // openConnection exists to be patched out in export_test.go (and let us test
 // this component without using a real API connection).
 var openConnection = func(agent agent.Agent) (Connection, error) {
-	currentConfig := agent.CurrentConfig()
-	st, _, err := jujudagent.OpenAPIState(currentConfig, agent)
+	st, _, err := jujudagent.OpenAPIState(agent)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Why:

It will make it easier to fully extract and properly test jujud/agent.OpenAPIState, which is my most immediate current goal on the way towards imposing some sanity on agents in general.

What:

  * cut Agent interface down to 2 methods, moved to top-level agent package
  * moved OpenAPIState and associated code into jujud/agent/open.go
  * cut a couple of interface-satisfying methods off AgentConf, represented them as wrapper types for Agent (which AgentConf already implements)
  * dropped unnecessary params from OpenAPIState and OpenAPIStateUsingInfo
  * deleted random dead code
  * slightly improved the OpenAPIState testing embedded in machine/unit agent suites; too hard to extract it properly in this CL

(Review request: http://reviews.vapour.ws/r/2323/)