### PR TITLE
state changes for allEnvWatcher

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -874,13 +874,17 @@ func (p *backingOpenedPorts) removed(st *State, store *multiwatcherStore, id str
 		// Retrieve the units placed in the machine.
 		units, err := st.UnitsFor(info.Id)
 		if err != nil {
-			logger.Errorf("cannot retrieve units for %q: %v", info.Id, err)
+			// An error isn't returned here because the watcher is
+			// always acting a little behind reality. It is reasonable
+			// that entities have been deleted from State but we're
+			// still seeing events related to them from the watcher.
+			logger.Warningf("cannot retrieve units for %q: %v", info.Id, err)
 			return nil
 		}
 		// Update the ports on all units assigned to the machine.
 		for _, u := range units {
 			if err := updateUnitPorts(st, store, u); err != nil {
-				logger.Errorf("cannot update unit ports for %q: %v", u.Name(), err)
+				logger.Warningf("cannot update unit ports for %q: %v", u.Name(), err)
 			}
 		}
 	}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2618,14 +2618,9 @@ func makeActionInfo(a *Action, st *State) multiwatcher.ActionInfo {
 	}
 }
 
-func jcDeepEqualsCheck(c *gc.C, got, want interface{}) bool {
-	ok, message := jc.DeepEquals.Check([]interface{}{got, want}, []string{"got", "want"})
-	if !ok {
-		c.Logf(message)
-	}
-	return ok
-}
-
+// assertEntitiesEqual is a specialised version of the typical
+// jc.DeepEquals check that provides more informative output when
+// comparing EntityInfo slices.
 func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 	if len(got) == 0 {
 		got = nil
@@ -2633,7 +2628,8 @@ func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 	if len(want) == 0 {
 		want = nil
 	}
-	if jcDeepEqualsCheck(c, got, want) {
+
+	if deepEqual(c, got, want) {
 		return
 	}
 	c.Errorf("entity mismatch; got len %d; want %d", len(got), len(want))
@@ -2655,7 +2651,7 @@ func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 		for i := 0; i < len(got); i++ {
 			g := got[i]
 			w := want[i]
-			if !jcDeepEqualsCheck(c, g, w) {
+			if !deepEqual(c, g, w) {
 				firstDiffError += "\n"
 				firstDiffError += fmt.Sprintf("first difference at position %d", i)
 				firstDiffError += "got: \n"
@@ -2668,4 +2664,12 @@ func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
 		c.Errorf(firstDiffError)
 	}
 	c.FailNow()
+}
+
+func deepEqual(c *gc.C, got, want interface{}) bool {
+	same, err := jc.DeepEqual(got, want)
+	if err != nil {
+		c.Fatal(err.Error())
+	}
+	return same
 }

--- a/state/collection.go
+++ b/state/collection.go
@@ -4,8 +4,6 @@
 package state
 
 import (
-	"strings"
-
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
@@ -159,12 +157,4 @@ func (c *envStateCollection) mungeQuery(inq interface{}) bson.D {
 		panic("query must be bson.D, bson.M, or nil")
 	}
 	return outq
-}
-
-func ensureEnvUUID(envUUID, id string) string {
-	prefix := envUUID + ":"
-	if strings.HasPrefix(id, prefix) {
-		return id
-	}
-	return prefix + id
 }

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -107,6 +107,9 @@ type Backing interface {
 	// Unwatch stops watching for changes on the
 	// given channel.
 	Unwatch(in chan<- watcher.Change)
+
+	// Release cleans up resources opened by the Backing.
+	Release() error
 }
 
 // request holds a message from the Multiwatcher to the

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -90,6 +90,8 @@ func (d *Delta) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("Unexpected operation %q", operation)
 	}
 	switch entityKind {
+	case "environment":
+		d.Entity = new(EnvironmentInfo)
 	case "machine":
 		d.Entity = new(MachineInfo)
 	case "service":
@@ -102,6 +104,8 @@ func (d *Delta) UnmarshalJSON(data []byte) error {
 		d.Entity = new(AnnotationInfo)
 	case "block":
 		d.Entity = new(BlockInfo)
+	case "action":
+		d.Entity = new(ActionInfo)
 	default:
 		return fmt.Errorf("Unexpected entity name %q", entityKind)
 	}

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -324,3 +324,19 @@ const (
 	// BlockChange type identifies change blocks.
 	BlockChange BlockType = "BlockChange"
 )
+
+type EnvironmentInfo struct {
+	EnvUUID    string
+	Name       string
+	Life       Life
+	Owner      string
+	ServerUUID string
+}
+
+func (i *EnvironmentInfo) EntityId() EntityId {
+	return EntityId{
+		Kind:    "environment",
+		EnvUUID: i.EnvUUID,
+		Id:      i.EnvUUID,
+	}
+}

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -31,6 +31,8 @@ type EntityInfo interface {
 	EntityId() EntityId
 }
 
+// EntityId unique identifies an entity being tracked by the
+// multiwatcherStore.
 type EntityId struct {
 	Kind    string
 	EnvUUID string
@@ -119,8 +121,8 @@ type UnitSettings struct {
 	Version int64
 }
 
-// MachineInfo holds the information about a Machine
-// that is watched by StateMultiwatcher.
+// MachineInfo holds the information about a machine
+// that is tracked by multiwatcherStore.
 type MachineInfo struct {
 	EnvUUID                  string
 	Id                       string
@@ -139,6 +141,8 @@ type MachineInfo struct {
 	WantsVote                bool
 }
 
+// EntityId returns a unique identifier for a machine across
+// environments.
 func (i *MachineInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:    "machine",
@@ -147,6 +151,8 @@ func (i *MachineInfo) EntityId() EntityId {
 	}
 }
 
+// StatusInfo holds the unit and machine status information. It is
+// used by ServiceInfo and UnitInfo.
 type StatusInfo struct {
 	Err     error
 	Current Status
@@ -156,6 +162,8 @@ type StatusInfo struct {
 	Data    map[string]interface{}
 }
 
+// ServiceInfo holds the information about a service that is tracked
+// by multiwatcherStore.
 type ServiceInfo struct {
 	EnvUUID     string
 	Name        string
@@ -170,6 +178,8 @@ type ServiceInfo struct {
 	Status      StatusInfo
 }
 
+// EntityId returns a unique identifier for a service across
+// environments.
 func (i *ServiceInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:    "service",
@@ -178,6 +188,8 @@ func (i *ServiceInfo) EntityId() EntityId {
 	}
 }
 
+// UnitInfo holds the information about a unit
+// that is tracked by multiwatcherStore.
 type UnitInfo struct {
 	EnvUUID        string
 	Name           string
@@ -199,6 +211,8 @@ type UnitInfo struct {
 	AgentStatus    StatusInfo
 }
 
+// EntityId returns a unique identifier for a unit across
+// environments.
 func (i *UnitInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:    "unit",
@@ -207,6 +221,8 @@ func (i *UnitInfo) EntityId() EntityId {
 	}
 }
 
+// ActionInfo holds the information about a action that is tracked by
+// multiwatcherStore.
 type ActionInfo struct {
 	EnvUUID    string
 	Id         string
@@ -221,6 +237,8 @@ type ActionInfo struct {
 	Completed  time.Time
 }
 
+// EntityId returns a unique identifier for an action across
+// environments.
 func (i *ActionInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:    "action",
@@ -229,6 +247,8 @@ func (i *ActionInfo) EntityId() EntityId {
 	}
 }
 
+// RelationInfo holds the information about a relation that is tracked
+// by multiwatcherStore.
 type RelationInfo struct {
 	EnvUUID   string
 	Key       string
@@ -236,6 +256,14 @@ type RelationInfo struct {
 	Endpoints []Endpoint
 }
 
+// Endpoint holds a service-relation pair.
+type Endpoint struct {
+	ServiceName string
+	Relation    charm.Relation
+}
+
+// EntityId returns a unique identifier for a relation across
+// environments.
 func (i *RelationInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:    "relation",
@@ -244,23 +272,22 @@ func (i *RelationInfo) EntityId() EntityId {
 	}
 }
 
+// AnnotationInfo holds the information about an annotation that is
+// tracked by multiwatcherStore.
 type AnnotationInfo struct {
 	EnvUUID     string
 	Tag         string
 	Annotations map[string]string
 }
 
+// EntityId returns a unique identifier for an annotation across
+// environments.
 func (i *AnnotationInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:    "annotation",
 		EnvUUID: i.EnvUUID,
 		Id:      i.Tag,
 	}
-}
-
-type Endpoint struct {
-	ServiceName string
-	Relation    charm.Relation
 }
 
 // MachineJob values define responsibilities that machines may be
@@ -292,8 +319,8 @@ func AnyJobNeedsState(jobs ...MachineJob) bool {
 	return false
 }
 
-// BlockInfo holds the information about blocks
-// in this environment that are watched.
+// BlockInfo holds the information about a block that is tracked by
+// multiwatcherStore.
 type BlockInfo struct {
 	EnvUUID string
 	Id      string
@@ -302,7 +329,8 @@ type BlockInfo struct {
 	Tag     string
 }
 
-// EntityId returns block id.
+// EntityId returns a unique identifier for a block across
+// environments.
 func (i *BlockInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:    "block",
@@ -325,6 +353,8 @@ const (
 	BlockChange BlockType = "BlockChange"
 )
 
+// EnvironmentInfo holds the information about an environment that is
+// tracked by multiwatcherStore.
 type EnvironmentInfo struct {
 	EnvUUID    string
 	Name       string
@@ -333,6 +363,7 @@ type EnvironmentInfo struct {
 	ServerUUID string
 }
 
+// EntityId returns a unique identifier for an environment.
 func (i *EnvironmentInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:    "environment",

--- a/state/multiwatcher/multiwatcher_internal_test.go
+++ b/state/multiwatcher/multiwatcher_internal_test.go
@@ -17,6 +17,8 @@ var (
 	_ EntityInfo = (*RelationInfo)(nil)
 	_ EntityInfo = (*AnnotationInfo)(nil)
 	_ EntityInfo = (*BlockInfo)(nil)
+	_ EntityInfo = (*ActionInfo)(nil)
+	_ EntityInfo = (*EnvironmentInfo)(nil)
 )
 
 type ConstantsSuite struct{}

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -892,7 +892,7 @@ func (b *storeManagerTestBacking) updateEntity(info multiwatcher.EntityInfo) {
 	if b.watchc != nil {
 		b.watchc <- watcher.Change{
 			C:     id.Kind,
-			Id:    createDocID(id.EnvUUID, id.Id),
+			Id:    ensureEnvUUID(id.EnvUUID, id.Id),
 			Revno: b.txnRevno, // This is actually ignored, but fill it in anyway.
 		}
 	}
@@ -912,7 +912,7 @@ func (b *storeManagerTestBacking) deleteEntity(id multiwatcher.EntityId) {
 	if b.watchc != nil {
 		b.watchc <- watcher.Change{
 			C:     id.Kind,
-			Id:    createDocID(id.EnvUUID, id.Id),
+			Id:    ensureEnvUUID(id.EnvUUID, id.Id),
 			Revno: -1,
 		}
 	}

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -883,6 +883,10 @@ func (b *storeManagerTestBacking) GetAll(all *multiwatcherStore) error {
 	return nil
 }
 
+func (b *storeManagerTestBacking) Release() error {
+	return nil
+}
+
 func (b *storeManagerTestBacking) updateEntity(info multiwatcher.EntityInfo) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/state/state.go
+++ b/state/state.go
@@ -1415,7 +1415,7 @@ func (st *State) AllServices() (services []*Service, err error) {
 // where the environment uuid is prefixed to the
 // localID.
 func (st *State) docID(localID string) string {
-	return createDocID(st.EnvironUUID(), localID)
+	return ensureEnvUUID(st.EnvironUUID(), localID)
 }
 
 // localID returns the local id value by stripping
@@ -1441,9 +1441,9 @@ func (st *State) strictLocalID(ID string) (string, error) {
 	return localID, nil
 }
 
-// createDocID returns an environment UUID prefixed document ID. The
+// ensureEnvUUID returns an environment UUID prefixed document ID. The
 // prefix is only added if it isn't already there.
-func createDocID(envUUID, id string) string {
+func ensureEnvUUID(envUUID, id string) string {
 	prefix := envUUID + ":"
 	if strings.HasPrefix(id, prefix) {
 		return id


### PR DESCRIPTION
This PR completes most of the changes in the state package for the "all environments" watcher. There are still some bits to come but this is the meat of the feature.

---

state: added allEnvWatcherStateBacking

This manages the backing state for watcher that reports events for all environments.

Notable:

1. building of the allWatcherStateCollection has been extracted and cleaned up (see makeAllWatcherCollectionInfo).

2. allEnvWatcherStateBacking currently only works (and passes tests for) a single environment. Cross-env support is coming.

---

state: allEnvWatcherStateBacking.GetAll now works across environments

This method now correctly loads entities for all environments. Implementation and test infrastructure is largely shared with allWatcherStateBacking.GetAll.

---

state: ensureEnvUUID clean up

ensureEnvUUID and createDocID had been independently introduced by 2 developers at about the same time and are character-for-character identical. Settled on ensureEnvUUID.

--- 

state: allEnvWatcherStateBacking.Changed now works for multiple envs
    
The multiwatcher.Backing interface was extended to include a Release method so that test can clean up allEnvWatcherStateBacking's pooled State instances.

---

state: allEnvWatcherStateBacking now watches environments



(Review request: http://reviews.vapour.ws/r/2328/)