### PR TITLE
storageprovisioner: don't attach after creating

### DIFF
--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -242,7 +242,10 @@ func (v *mockVolumeAccessor) VolumeAttachmentParams(ids []params.MachineStorageI
 }
 
 func (v *mockVolumeAccessor) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, error) {
-	return v.setVolumeInfo(volumes)
+	if v.setVolumeInfo != nil {
+		return v.setVolumeInfo(volumes)
+	}
+	return make([]params.ErrorResult, len(volumes)), nil
 }
 
 func (v *mockVolumeAccessor) SetVolumeAttachmentInfo(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -139,6 +139,61 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
 }
 
+func (s *storageProvisionerSuite) TestCreateVolumeCreatesAttachment(c *gc.C) {
+	volumeAccessor := newMockVolumeAccessor()
+	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+
+	volumeAttachmentInfoSet := make(chan interface{})
+	volumeAccessor.setVolumeAttachmentInfo = func(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
+		defer close(volumeAttachmentInfoSet)
+		return make([]params.ErrorResult, len(volumeAttachments)), nil
+	}
+
+	s.provider.createVolumesFunc = func(args []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
+		volumeAccessor.provisionedAttachments[params.MachineStorageId{
+			MachineTag:    args[0].Attachment.Machine.String(),
+			AttachmentTag: args[0].Attachment.Volume.String(),
+		}] = params.VolumeAttachment{
+			VolumeTag:  args[0].Attachment.Volume.String(),
+			MachineTag: args[0].Attachment.Machine.String(),
+		}
+		return []storage.CreateVolumesResult{{
+			Volume: &storage.Volume{
+				Tag: args[0].Tag,
+				VolumeInfo: storage.VolumeInfo{
+					VolumeId: "vol-ume",
+				},
+			},
+			VolumeAttachment: &storage.VolumeAttachment{
+				Volume:  args[0].Attachment.Volume,
+				Machine: args[0].Attachment.Machine,
+			},
+		}}, nil
+	}
+
+	attachVolumesCalled := make(chan interface{})
+	s.provider.attachVolumesFunc = func(args []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+		defer close(attachVolumesCalled)
+		return nil, errors.New("should not be called")
+	}
+
+	args := &workerArgs{volumes: volumeAccessor}
+	worker := newStorageProvisioner(c, args)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+	defer worker.Kill()
+
+	volumeAccessor.attachmentsWatcher.changes <- []params.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "volume-1",
+	}}
+	assertNoEvent(c, volumeAttachmentInfoSet, "volume attachment set")
+
+	// The worker should create volumes according to ids "1".
+	volumeAccessor.volumesWatcher.changes <- []string{"1"}
+	args.environ.watcher.changes <- struct{}{}
+	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
+	assertNoEvent(c, attachVolumesCalled, "AttachVolumes called")
+}
+
 func (s *storageProvisionerSuite) TestCreateVolumeRetry(c *gc.C) {
 	volumeInfoSet := make(chan interface{})
 	volumeAccessor := newMockVolumeAccessor()

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -527,6 +527,7 @@ func setVolumeAttachmentInfo(ctx *context, volumeAttachments []storage.VolumeAtt
 			AttachmentTag: volumeAttachments[i].Volume.String(),
 		}
 		ctx.volumeAttachments[id] = volumeAttachments[i]
+		removePendingVolumeAttachment(ctx, id)
 	}
 	return nil
 }


### PR DESCRIPTION
Clear pending volume attachments when setting
volume attachments; this prevents an unnecessary
reattachment just after creating a volume with
an attachment.

Fixes https://bugs.launchpad.net/juju-core/+bug/1483083

(Review request: http://reviews.vapour.ws/r/2330/)