### PR TITLE
provider/azure: add volume source

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -50,5 +50,5 @@ gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:0
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20141121040613-ztm1q0iy9rune3zt	13
 launchpad.net/gomaasapi	bzr	michael.foord@canonical.com-20150703101140-oo7493pkzlzg7l6u	63
-launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20141203072923-27pcp2hckqyezbfe	242
+launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20150810080433-4l0x47qsc16ure7c	245
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -99,6 +99,12 @@ func (prov azureEnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.C
 	envCfg.Config = cfg
 	envCfg.attrs = validated
 
+	if _, ok := cfg.StorageDefaultBlockSource(); !ok {
+		// Default volume source not specified; set
+		// it to the azure storage provider.
+		envCfg.attrs[config.StorageDefaultBlockSourceKey] = storageProviderType
+	}
+
 	cert := envCfg.managementCertificate()
 	if cert == "" {
 		certPath := envCfg.attrs["management-certificate-path"].(string)

--- a/provider/azure/disks.go
+++ b/provider/azure/disks.go
@@ -23,7 +23,9 @@ const (
 
 const (
 	// volumeSizeMaxGiB is the maximum disk size (in gibibytes) for Azure disks.
-	volumeSizeMaxGiB = 1023 // 1023 GiB
+	//
+	// See: https://azure.microsoft.com/en-gb/documentation/articles/virtual-machines-disks-vhds/
+	volumeSizeMaxGiB = 1023
 )
 
 // azureStorageProvider is a storage provider for Azure disks.

--- a/provider/azure/disks.go
+++ b/provider/azure/disks.go
@@ -1,0 +1,422 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"launchpad.net/gwacl"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	storageProviderType = storage.ProviderType("azure")
+)
+
+const (
+	// volumeSizeMaxGiB is the maximum disk size (in gibibytes) for Azure disks.
+	volumeSizeMaxGiB = 1023 // 1023 GiB
+)
+
+// azureStorageProvider is a storage provider for Azure disks.
+type azureStorageProvider struct{}
+
+var _ storage.Provider = (*azureStorageProvider)(nil)
+
+var azureStorageConfigFields = schema.Fields{}
+
+var azureStorageConfigChecker = schema.FieldMap(
+	azureStorageConfigFields,
+	schema.Defaults{},
+)
+
+type azureStorageConfig struct {
+}
+
+func newAzureStorageConfig(attrs map[string]interface{}) (*azureStorageConfig, error) {
+	_, err := azureStorageConfigChecker.Coerce(attrs, nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "validating Azure storage config")
+	}
+	azureStorageConfig := &azureStorageConfig{}
+	return azureStorageConfig, nil
+}
+
+// ValidateConfig is defined on the Provider interface.
+func (e *azureStorageProvider) ValidateConfig(cfg *storage.Config) error {
+	_, err := newAzureStorageConfig(cfg.Attrs())
+	return errors.Trace(err)
+}
+
+// Supports is defined on the Provider interface.
+func (e *azureStorageProvider) Supports(k storage.StorageKind) bool {
+	return k == storage.StorageKindBlock
+}
+
+// Scope is defined on the Provider interface.
+func (e *azureStorageProvider) Scope() storage.Scope {
+	return storage.ScopeEnviron
+}
+
+// Dynamic is defined on the Provider interface.
+func (e *azureStorageProvider) Dynamic() bool {
+	return true
+}
+
+// VolumeSource is defined on the Provider interface.
+func (e *azureStorageProvider) VolumeSource(environConfig *config.Config, cfg *storage.Config) (storage.VolumeSource, error) {
+	env, err := NewEnviron(environConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	uuid, ok := environConfig.UUID()
+	if !ok {
+		return nil, errors.NotFoundf("environment UUID")
+	}
+	source := &azureVolumeSource{
+		env:     env,
+		envName: environConfig.Name(),
+		envUUID: uuid,
+	}
+	return source, nil
+}
+
+// FilesystemSource is defined on the Provider interface.
+func (e *azureStorageProvider) FilesystemSource(environConfig *config.Config, providerConfig *storage.Config) (storage.FilesystemSource, error) {
+	return nil, errors.NotSupportedf("filesystems")
+}
+
+type azureVolumeSource struct {
+	env     *azureEnviron
+	envName string // non-unique, informational only
+	envUUID string
+}
+
+var _ storage.VolumeSource = (*azureVolumeSource)(nil)
+
+// CreateVolumes is specified on the storage.VolumeSource interface.
+func (v *azureVolumeSource) CreateVolumes(params []storage.VolumeParams) (_ []storage.CreateVolumesResult, err error) {
+
+	// First, validate the params before we use them.
+	results := make([]storage.CreateVolumesResult, len(params))
+	for i, p := range params {
+		if err := v.ValidateVolumeParams(p); err != nil {
+			results[i].Error = err
+			continue
+		}
+	}
+
+	// TODO(axw) cache results of GetRole from createVolume for multiple
+	// attachments to the same machine. When doing so, be careful to
+	// ensure the cached role's in-use LUNs are updated between attachments.
+
+	for i, p := range params {
+		if results[i].Error != nil {
+			continue
+		}
+		volume, volumeAttachment, err := v.createVolume(p)
+		if err != nil {
+			results[i].Error = err
+			continue
+		}
+		results[i].Volume = volume
+		results[i].VolumeAttachment = volumeAttachment
+	}
+	return results, nil
+}
+
+func (v *azureVolumeSource) createVolume(p storage.VolumeParams) (*storage.Volume, *storage.VolumeAttachment, error) {
+	cloudServiceName, roleName := v.env.splitInstanceId(p.Attachment.InstanceId)
+	if roleName == "" {
+		return nil, nil, errors.NotSupportedf("attaching disks to legacy instances")
+	}
+	deploymentName := deploymentNameV2(cloudServiceName)
+
+	// Get the role first so we know which LUNs are in use.
+	role, err := v.getRole(p.Attachment.InstanceId)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "getting role")
+	}
+	lun, err := nextAvailableLUN(role)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "choosing LUN")
+	}
+
+	diskLabel := fmt.Sprintf("%s%s", v.env.getEnvPrefix(), p.Tag.String())
+	vhdFilename := p.Tag.String() + ".vhd"
+	mediaLink := v.vhdMediaLinkPrefix() + vhdFilename
+
+	// Create and attach a disk to the instance.
+	sizeInGib := mibToGib(p.Size)
+	if err := v.env.api.AddDataDisk(&gwacl.AddDataDiskRequest{
+		ServiceName:    cloudServiceName,
+		DeploymentName: deploymentName,
+		RoleName:       roleName,
+		DataVirtualHardDisk: gwacl.DataVirtualHardDisk{
+			DiskLabel:           diskLabel,
+			LogicalDiskSizeInGB: int(sizeInGib),
+			MediaLink:           mediaLink,
+			LUN:                 lun,
+		},
+	}); err != nil {
+		return nil, nil, errors.Annotate(err, "adding data disk")
+	}
+
+	// Data disks associate VHDs to machines. In Juju's storage model,
+	// the VHD is the volume and the disk is the volume attachment.
+	//
+	// Note that we don't currently support attaching/detaching volumes
+	// (see note on Persistent below), but using the VHD name as the
+	// volume ID at least allows that as a future option.
+	volumeId := vhdFilename
+
+	volume := storage.Volume{
+		p.Tag,
+		storage.VolumeInfo{
+			VolumeId: volumeId,
+			Size:     gibToMib(sizeInGib),
+			// We don't currently support persistent volumes in
+			// Azure, as it requires removal of "comp=media" when
+			// deleting VMs, complicating cleanup.
+			Persistent: false,
+		},
+	}
+	volumeAttachment := storage.VolumeAttachment{
+		p.Tag,
+		p.Attachment.Machine,
+		storage.VolumeAttachmentInfo{
+			BusAddress: diskBusAddress(lun),
+		},
+	}
+	return &volume, &volumeAttachment, nil
+}
+
+// vhdMediaLinkPrefix returns the media link prefix for disks
+// associated with the environment. gwacl's helper returns
+// http scheme URLs; we use https to simplify matching what
+// Azure returns. Azure always returns https, even if you
+// specified http originally.
+func (v *azureVolumeSource) vhdMediaLinkPrefix() string {
+	storageAccount := v.env.ecfg.storageAccountName()
+	dir := path.Join("vhds", v.envUUID)
+	mediaLink := gwacl.CreateVirtualHardDiskMediaLink(storageAccount, dir) + "/"
+	mediaLink = "https://" + mediaLink[len("http://"):]
+	return mediaLink
+}
+
+// ListVolumes is specified on the storage.VolumeSource interface.
+func (v *azureVolumeSource) ListVolumes() ([]string, error) {
+	disks, err := v.listDisks()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	volumeIds := make([]string, len(disks))
+	for i, disk := range disks {
+		_, volumeId := path.Split(disk.MediaLink)
+		volumeIds[i] = volumeId
+	}
+	return volumeIds, nil
+}
+
+func (v *azureVolumeSource) listDisks() ([]gwacl.Disk, error) {
+	disks, err := v.env.api.ListDisks()
+	if err != nil {
+		return nil, errors.Annotate(err, "listing disks")
+	}
+	mediaLinkPrefix := v.vhdMediaLinkPrefix()
+	matching := make([]gwacl.Disk, 0, len(disks))
+	for _, disk := range disks {
+		if strings.HasPrefix(disk.MediaLink, mediaLinkPrefix) {
+			matching = append(matching, disk)
+		}
+	}
+	return matching, nil
+}
+
+// DescribeVolumes is specified on the storage.VolumeSource interface.
+func (v *azureVolumeSource) DescribeVolumes(volIds []string) ([]storage.DescribeVolumesResult, error) {
+	disks, err := v.listDisks()
+	if err != nil {
+		return nil, errors.Annotate(err, "listing disks")
+	}
+
+	byVolumeId := make(map[string]gwacl.Disk)
+	for _, disk := range disks {
+		_, volumeId := path.Split(disk.MediaLink)
+		byVolumeId[volumeId] = disk
+	}
+
+	results := make([]storage.DescribeVolumesResult, len(volIds))
+	for i, volumeId := range volIds {
+		disk, ok := byVolumeId[volumeId]
+		if !ok {
+			results[i].Error = errors.NotFoundf("volume %v", volumeId)
+			continue
+		}
+		results[i].VolumeInfo = &storage.VolumeInfo{
+			VolumeId: volumeId,
+			Size:     gibToMib(uint64(disk.LogicalSizeInGB)),
+			// We don't support persistent volumes at the moment;
+			// see CreateVolumes.
+			Persistent: false,
+		}
+	}
+
+	return results, nil
+}
+
+// DestroyVolumes is specified on the storage.VolumeSource interface.
+func (v *azureVolumeSource) DestroyVolumes(volIds []string) ([]error, error) {
+	// We don't currently support persistent volumes.
+	return nil, errors.NotSupportedf("DestroyVolumes")
+}
+
+// ValidateVolumeParams is specified on the storage.VolumeSource interface.
+func (v *azureVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
+	if mibToGib(params.Size) > volumeSizeMaxGiB {
+		return errors.Errorf(
+			"%d GiB exceeds the maximum of %d GiB",
+			mibToGib(params.Size),
+			volumeSizeMaxGiB,
+		)
+	}
+	return nil
+}
+
+// AttachVolumes is specified on the storage.VolumeSource interface.
+func (v *azureVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error) {
+	// We don't currently support persistent volumes, but we do need to
+	// support "reattaching" volumes to machines; i.e. just verify that
+	// the attachment is in place, and fail otherwise.
+
+	type maybeRole struct {
+		role *gwacl.PersistentVMRole
+		err  error
+	}
+
+	roles := make(map[instance.Id]maybeRole)
+	for _, p := range attachParams {
+		if _, ok := roles[p.InstanceId]; ok {
+			continue
+		}
+		role, err := v.getRole(p.InstanceId)
+		roles[p.InstanceId] = maybeRole{role, err}
+	}
+
+	results := make([]storage.AttachVolumesResult, len(attachParams))
+	for i, p := range attachParams {
+		maybeRole := roles[p.InstanceId]
+		if maybeRole.err != nil {
+			results[i].Error = maybeRole.err
+			continue
+		}
+		volumeAttachment, err := v.attachVolume(p, maybeRole.role)
+		if err != nil {
+			results[i].Error = err
+			continue
+		}
+		results[i].VolumeAttachment = volumeAttachment
+	}
+	return results, nil
+}
+
+func (v *azureVolumeSource) attachVolume(
+	p storage.VolumeAttachmentParams,
+	role *gwacl.PersistentVMRole,
+) (*storage.VolumeAttachment, error) {
+
+	var disks []gwacl.DataVirtualHardDisk
+	if role.DataVirtualHardDisks != nil {
+		disks = *role.DataVirtualHardDisks
+	}
+
+	// Check if the disk is already attached to the machine.
+	mediaLinkPrefix := v.vhdMediaLinkPrefix()
+	for _, disk := range disks {
+		if !strings.HasPrefix(disk.MediaLink, mediaLinkPrefix) {
+			continue
+		}
+		_, volumeId := path.Split(disk.MediaLink)
+		if volumeId != p.VolumeId {
+			continue
+		}
+		return &storage.VolumeAttachment{
+			p.Volume,
+			p.Machine,
+			storage.VolumeAttachmentInfo{
+				BusAddress: diskBusAddress(disk.LUN),
+			},
+		}, nil
+	}
+
+	// If the disk is not attached already, the AttachVolumes call must
+	// fail. We do not support persistent volumes at the moment, and if
+	// we get here it means that the disk has been detached out of band.
+	return nil, errors.NotSupportedf("attaching volumes")
+}
+
+// DetachVolumes is specified on the storage.VolumeSource interface.
+func (v *azureVolumeSource) DetachVolumes(attachParams []storage.VolumeAttachmentParams) ([]error, error) {
+	// We don't currently support persistent volumes.
+	return nil, errors.NotSupportedf("detaching volumes")
+}
+
+func (v *azureVolumeSource) getRole(id instance.Id) (*gwacl.PersistentVMRole, error) {
+	cloudServiceName, roleName := v.env.splitInstanceId(id)
+	if roleName == "" {
+		return nil, errors.NotSupportedf("attaching disks to legacy instances")
+	}
+	deploymentName := deploymentNameV2(cloudServiceName)
+	return v.env.api.GetRole(&gwacl.GetRoleRequest{
+		ServiceName:    cloudServiceName,
+		DeploymentName: deploymentName,
+		RoleName:       roleName,
+	})
+}
+
+func nextAvailableLUN(role *gwacl.PersistentVMRole) (int, error) {
+	// Pick the smallest LUN not in use. We have to choose them in order,
+	// or the disks don't show up.
+	var inUse [32]bool
+	if role.DataVirtualHardDisks != nil {
+		for _, disk := range *role.DataVirtualHardDisks {
+			if disk.LUN < 0 || disk.LUN > 31 {
+				logger.Warningf("ignore disk with invalid LUN: %+v", disk)
+				continue
+			}
+			inUse[disk.LUN] = true
+		}
+	}
+	for i, inUse := range inUse {
+		if !inUse {
+			return i, nil
+		}
+	}
+	return -1, errors.New("all LUNs are in use")
+}
+
+// diskBusAddress returns the value to use in the BusAddress field of
+// VolumeAttachmentInfo for a disk with the specified LUN.
+func diskBusAddress(lun int) string {
+	return fmt.Sprintf("scsi@5:0.0.%d", lun)
+}
+
+// mibToGib converts mebibytes to gibibytes.
+// AWS expects GiB, we work in MiB; round up
+// to nearest GiB.
+func mibToGib(m uint64) uint64 {
+	return (m + 1023) / 1024
+}
+
+// gibToMib converts gibibytes to mebibytes.
+func gibToMib(g uint64) uint64 {
+	return g * 1024
+}

--- a/provider/azure/disks_test.go
+++ b/provider/azure/disks_test.go
@@ -5,6 +5,7 @@ package azure
 
 import (
 	"encoding/xml"
+	"fmt"
 	"net/http"
 
 	"github.com/juju/names"
@@ -16,7 +17,10 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-const mediaLinkPrefix = "https://account-name.blob.core.windows.net/vhds/deadbeef-0bad-400d-8000-4b1d0d06f00d/"
+var mediaLinkPrefix = fmt.Sprintf(
+	"https://account-name.blob.core.windows.net/vhds/%s/",
+	testing.EnvironmentTag.Id(),
+)
 
 type storageProviderSuite struct {
 	testing.BaseSuite
@@ -44,22 +48,6 @@ var _ = gc.Suite(&azureVolumeSuite{})
 
 type azureVolumeSuite struct {
 	testing.BaseSuite
-}
-
-func (s *azureVolumeSuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
-}
-
-func (s *azureVolumeSuite) TearDownSuite(c *gc.C) {
-	s.BaseSuite.TearDownSuite(c)
-}
-
-func (s *azureVolumeSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-}
-
-func (s *azureVolumeSuite) TearDownTest(c *gc.C) {
-	s.BaseSuite.TearDownTest(c)
 }
 
 func (s *azureVolumeSuite) volumeSource(c *gc.C, cfg *storage.Config) storage.VolumeSource {

--- a/provider/azure/disks_test.go
+++ b/provider/azure/disks_test.go
@@ -1,0 +1,524 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/gwacl"
+
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+)
+
+const mediaLinkPrefix = "https://account-name.blob.core.windows.net/vhds/deadbeef-0bad-400d-8000-4b1d0d06f00d/"
+
+type storageProviderSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&storageSuite{})
+
+func (*storageProviderSuite) TestValidateConfigUnknownConfig(c *gc.C) {
+	p := azureStorageProvider{}
+	cfg, err := storage.NewConfig("foo", storageProviderType, map[string]interface{}{
+		"unknown": "config",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.ValidateConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil) // unknown attrs ignored
+}
+
+func (s *storageProviderSuite) TestSupports(c *gc.C) {
+	p := azureStorageProvider{}
+	c.Assert(p.Supports(storage.StorageKindBlock), jc.IsTrue)
+	c.Assert(p.Supports(storage.StorageKindFilesystem), jc.IsFalse)
+}
+
+var _ = gc.Suite(&azureVolumeSuite{})
+
+type azureVolumeSuite struct {
+	testing.BaseSuite
+}
+
+func (s *azureVolumeSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *azureVolumeSuite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *azureVolumeSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *azureVolumeSuite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *azureVolumeSuite) volumeSource(c *gc.C, cfg *storage.Config) storage.VolumeSource {
+	envCfg := makeEnviron(c).Config()
+	p := azureStorageProvider{}
+	vs, err := p.VolumeSource(envCfg, cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	return vs
+}
+
+func (s *azureVolumeSuite) TestCreateVolumes(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	machine := names.NewMachineTag("123")
+	volume0 := names.NewVolumeTag("0")
+	volume1 := names.NewVolumeTag("1")
+
+	env := makeEnviron(c)
+	prefix := env.getEnvPrefix()
+	serviceName := "service"
+	service := makeDeployment(env, prefix+serviceName)
+
+	roleName := service.Deployments[0].RoleList[0].RoleName
+	inst, err := env.getInstance(service, roleName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	params := []storage.VolumeParams{{
+		Tag:      volume0,
+		Size:     10 * 1000,
+		Provider: storageProviderType,
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				Machine:    machine,
+				InstanceId: inst.Id(),
+			},
+		},
+	}, {
+		Tag:      volume1,
+		Size:     20 * 1000,
+		Provider: storageProviderType,
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				Machine:    machine,
+				InstanceId: inst.Id(),
+			},
+		},
+	}}
+
+	getRoleResponse0, err := xml.Marshal(&gwacl.PersistentVMRole{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Second time, respond saying LUN 0 is in use; this should
+	// cause LUN 1 to be assigned.
+	dataVirtualHardDisks := []gwacl.DataVirtualHardDisk{
+		{LUN: 0},
+	}
+	getRoleResponse1, err := xml.Marshal(&gwacl.PersistentVMRole{
+		DataVirtualHardDisks: &dataVirtualHardDisks,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	gwacl.PatchManagementAPIResponses([]gwacl.DispatcherResponse{
+		gwacl.NewDispatcherResponse(getRoleResponse0, http.StatusOK, nil),
+		gwacl.NewDispatcherResponse(nil, http.StatusOK, nil), // AddDataDisk
+		gwacl.NewDispatcherResponse(getRoleResponse1, http.StatusOK, nil),
+		gwacl.NewDispatcherResponse(nil, http.StatusOK, nil), // AddDataDisk
+	})
+
+	results, err := vs.CreateVolumes(params)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 2)
+	c.Assert(results[0], jc.DeepEquals, storage.CreateVolumesResult{
+		Volume: &storage.Volume{
+			Tag: volume0,
+			VolumeInfo: storage.VolumeInfo{
+				VolumeId: "volume-0.vhd",
+				Size:     10 * 1024, // rounded up
+			},
+		},
+		VolumeAttachment: &storage.VolumeAttachment{
+			Volume:  volume0,
+			Machine: machine,
+			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
+				BusAddress: "scsi@5:0.0.0",
+			},
+		}},
+	)
+	c.Assert(results[1], jc.DeepEquals, storage.CreateVolumesResult{
+		Volume: &storage.Volume{
+			Tag: volume1,
+			VolumeInfo: storage.VolumeInfo{
+				VolumeId: "volume-1.vhd",
+				Size:     20 * 1024, // rounded up
+			},
+		},
+		VolumeAttachment: &storage.VolumeAttachment{
+			Volume:  volume1,
+			Machine: machine,
+			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
+				BusAddress: "scsi@5:0.0.1",
+			},
+		}},
+	)
+}
+
+func (s *azureVolumeSuite) TestCreateVolumesInvalidVolumeParams(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	args := storage.VolumeParams{
+		Tag:      names.NewVolumeTag("0"),
+		Size:     1023 * 1024,
+		Provider: storageProviderType,
+	}
+	err := vs.ValidateVolumeParams(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	args.Size++ // One more MiB and we're out
+
+	results, err := vs.CreateVolumes([]storage.VolumeParams{args})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results[0].Error, gc.ErrorMatches, "1024 GiB exceeds the maximum of 1023 GiB")
+}
+
+func (s *azureVolumeSuite) TestCreateVolumesNoLuns(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	machine := names.NewMachineTag("123")
+	volume := names.NewVolumeTag("0")
+
+	env := makeEnviron(c)
+	prefix := env.getEnvPrefix()
+	serviceName := "service"
+	service := makeDeployment(env, prefix+serviceName)
+	roleName := service.Deployments[0].RoleList[0].RoleName
+	inst, err := env.getInstance(service, roleName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	params := []storage.VolumeParams{{
+		Tag:      volume,
+		Size:     10 * 1000,
+		Provider: storageProviderType,
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				Machine:    machine,
+				InstanceId: inst.Id(),
+			},
+		},
+	}}
+
+	dataVirtualHardDisks := make([]gwacl.DataVirtualHardDisk, 32)
+	for i := range dataVirtualHardDisks {
+		dataVirtualHardDisks[i].LUN = i
+	}
+	getRoleResponse, err := xml.Marshal(&gwacl.PersistentVMRole{
+		DataVirtualHardDisks: &dataVirtualHardDisks,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	gwacl.PatchManagementAPIResponses([]gwacl.DispatcherResponse{
+		gwacl.NewDispatcherResponse(getRoleResponse, http.StatusOK, nil),
+	})
+
+	results, err := vs.CreateVolumes(params)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, gc.ErrorMatches, "choosing LUN: all LUNs are in use")
+}
+
+func (s *azureVolumeSuite) TestCreateVolumesLegacyInstance(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	machine := names.NewMachineTag("123")
+	volume := names.NewVolumeTag("0")
+
+	env := makeEnviron(c)
+	prefix := env.getEnvPrefix()
+	serviceName := "service"
+	service := makeLegacyDeployment(env, prefix+serviceName)
+	inst, err := env.getInstance(service, "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	params := []storage.VolumeParams{{
+		Tag:      volume,
+		Size:     10 * 1000,
+		Provider: storageProviderType,
+		Attachment: &storage.VolumeAttachmentParams{
+			AttachmentParams: storage.AttachmentParams{
+				Machine:    machine,
+				InstanceId: inst.Id(),
+			},
+		},
+	}}
+
+	results, err := vs.CreateVolumes(params)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, gc.ErrorMatches, "attaching disks to legacy instances not supported")
+}
+
+func (s *azureVolumeSuite) TestDestroyVolumes(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+	results, err := vs.DestroyVolumes([]string{"volume-0.vhd", "volume-1.vhd"})
+	c.Assert(err, gc.ErrorMatches, "DestroyVolumes not supported")
+	c.Assert(results, gc.HasLen, 0)
+}
+
+func (s *azureVolumeSuite) TestDescribeVolumes(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	type disks struct {
+		Disks []gwacl.Disk `xml:"Disk"`
+	}
+
+	listDisksResponse, err := xml.Marshal(&disks{Disks: []gwacl.Disk{{
+		MediaLink:       mediaLinkPrefix + "volume-1.vhd",
+		LogicalSizeInGB: 22,
+	}, {
+		MediaLink:       mediaLinkPrefix + "volume-0.vhd",
+		LogicalSizeInGB: 11,
+	}, {
+		MediaLink:       "someOtherJunk.vhd",
+		LogicalSizeInGB: 33,
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+
+	gwacl.PatchManagementAPIResponses([]gwacl.DispatcherResponse{
+		gwacl.NewDispatcherResponse(listDisksResponse, http.StatusOK, nil),
+	})
+
+	volumes, err := vs.DescribeVolumes([]string{"volume-0.vhd", "volume-1.vhd"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumes, gc.HasLen, 2)
+	c.Assert(volumes, jc.DeepEquals, []storage.DescribeVolumesResult{{
+		VolumeInfo: &storage.VolumeInfo{
+			Size:     11 * 1024,
+			VolumeId: "volume-0.vhd",
+		},
+	}, {
+		VolumeInfo: &storage.VolumeInfo{
+			Size:     22 * 1024,
+			VolumeId: "volume-1.vhd",
+		},
+	}})
+}
+
+func (s *azureVolumeSuite) TestDescribeVolumesNotFound(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	type disks struct {
+		Disks []gwacl.Disk `xml:"Disk"`
+	}
+
+	listDisksResponse, err := xml.Marshal(&disks{Disks: []gwacl.Disk{{
+		MediaLink:       mediaLinkPrefix + "volume-0.vhd",
+		LogicalSizeInGB: 11,
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+
+	gwacl.PatchManagementAPIResponses([]gwacl.DispatcherResponse{
+		gwacl.NewDispatcherResponse(listDisksResponse, http.StatusOK, nil),
+	})
+
+	volumes, err := vs.DescribeVolumes([]string{"volume-0.vhd", "volume-1.vhd"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumes, gc.HasLen, 2)
+	c.Assert(volumes[0].Error, gc.IsNil)
+	c.Assert(volumes[1].Error, gc.ErrorMatches, "volume volume-1.vhd not found")
+}
+
+func (s *azureVolumeSuite) TestListVolumes(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	type disks struct {
+		Disks []gwacl.Disk `xml:"Disk"`
+	}
+
+	listDisksResponse, err := xml.Marshal(&disks{Disks: []gwacl.Disk{{
+		MediaLink:       mediaLinkPrefix + "volume-1.vhd",
+		LogicalSizeInGB: 22,
+	}, {
+		MediaLink:       mediaLinkPrefix + "volume-0.vhd",
+		LogicalSizeInGB: 11,
+	}, {
+		MediaLink:       "someOtherJunk.vhd",
+		LogicalSizeInGB: 33,
+	}}})
+	c.Assert(err, jc.ErrorIsNil)
+
+	gwacl.PatchManagementAPIResponses([]gwacl.DispatcherResponse{
+		gwacl.NewDispatcherResponse(listDisksResponse, http.StatusOK, nil),
+	})
+
+	volIds, err := vs.ListVolumes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volIds, jc.SameContents, []string{"volume-0.vhd", "volume-1.vhd"})
+}
+
+func (s *azureVolumeSuite) TestAttachVolumesAlreadyAttached(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	machine0 := names.NewMachineTag("0")
+	machine1 := names.NewMachineTag("1")
+	volume0 := names.NewVolumeTag("0")
+	volume1 := names.NewVolumeTag("1")
+	volume2 := names.NewVolumeTag("2")
+
+	env := makeEnviron(c)
+	prefix := env.getEnvPrefix()
+	service := makeDeployment(env, prefix+"service")
+	roleName0 := service.Deployments[0].RoleList[0].RoleName
+	roleName1 := service.Deployments[0].RoleList[1].RoleName
+	inst0, err := env.getInstance(service, roleName0)
+	c.Assert(err, jc.ErrorIsNil)
+	inst1, err := env.getInstance(service, roleName1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// First VM.
+	dataVirtualHardDisks0 := []gwacl.DataVirtualHardDisk{{
+		MediaLink:           mediaLinkPrefix + "volume-0.vhd",
+		LUN:                 0,
+		LogicalDiskSizeInGB: 1,
+	}, {
+		MediaLink:           mediaLinkPrefix + "volume-1.vhd",
+		LUN:                 1,
+		LogicalDiskSizeInGB: 2,
+	}}
+	getRoleResponse0, err := xml.Marshal(&gwacl.PersistentVMRole{
+		DataVirtualHardDisks: &dataVirtualHardDisks0,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Second VM.
+	dataVirtualHardDisks1 := []gwacl.DataVirtualHardDisk{{
+		MediaLink:           mediaLinkPrefix + "volume-2.vhd",
+		LUN:                 0,
+		LogicalDiskSizeInGB: 3,
+	}}
+	getRoleResponse1, err := xml.Marshal(&gwacl.PersistentVMRole{
+		DataVirtualHardDisks: &dataVirtualHardDisks1,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	gwacl.PatchManagementAPIResponses([]gwacl.DispatcherResponse{
+		gwacl.NewDispatcherResponse(getRoleResponse0, http.StatusOK, nil),
+		gwacl.NewDispatcherResponse(getRoleResponse1, http.StatusOK, nil),
+	})
+
+	results, err := vs.AttachVolumes([]storage.VolumeAttachmentParams{{
+		Volume:   volume0,
+		VolumeId: "volume-0.vhd",
+		AttachmentParams: storage.AttachmentParams{
+			Machine:    machine0,
+			InstanceId: inst0.Id(),
+		},
+	}, {
+		Volume:   volume1,
+		VolumeId: "volume-1.vhd",
+		AttachmentParams: storage.AttachmentParams{
+			Machine:    machine0,
+			InstanceId: inst0.Id(),
+		},
+	}, {
+		Volume:   volume2,
+		VolumeId: "volume-2.vhd",
+		AttachmentParams: storage.AttachmentParams{
+			Machine:    machine1,
+			InstanceId: inst1.Id(),
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, []storage.AttachVolumesResult{{
+		VolumeAttachment: &storage.VolumeAttachment{
+			Volume:  volume0,
+			Machine: machine0,
+			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
+				BusAddress: "scsi@5:0.0.0",
+			},
+		},
+	}, {
+		VolumeAttachment: &storage.VolumeAttachment{
+			Volume:  volume1,
+			Machine: machine0,
+			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
+				BusAddress: "scsi@5:0.0.1",
+			},
+		},
+	}, {
+		VolumeAttachment: &storage.VolumeAttachment{
+			Volume:  volume2,
+			Machine: machine1,
+			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
+				BusAddress: "scsi@5:0.0.0",
+			},
+		},
+	}})
+}
+
+func (s *azureVolumeSuite) TestAttachVolumesNotAttached(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	machine := names.NewMachineTag("0")
+	volume := names.NewVolumeTag("0")
+
+	env := makeEnviron(c)
+	prefix := env.getEnvPrefix()
+	service := makeDeployment(env, prefix+"service")
+	roleName := service.Deployments[0].RoleList[0].RoleName
+	inst, err := env.getInstance(service, roleName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	getRoleResponse, err := xml.Marshal(&gwacl.PersistentVMRole{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	gwacl.PatchManagementAPIResponses([]gwacl.DispatcherResponse{
+		gwacl.NewDispatcherResponse(getRoleResponse, http.StatusOK, nil),
+	})
+
+	results, err := vs.AttachVolumes([]storage.VolumeAttachmentParams{{
+		Volume:   volume,
+		VolumeId: "volume-0.vhd",
+		AttachmentParams: storage.AttachmentParams{
+			Machine:    machine,
+			InstanceId: inst.Id(),
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, gc.ErrorMatches, "attaching volumes not supported")
+}
+
+func (s *azureVolumeSuite) TestAttachVolumesGetRoleError(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+
+	machine := names.NewMachineTag("0")
+	volume := names.NewVolumeTag("0")
+
+	env := makeEnviron(c)
+	prefix := env.getEnvPrefix()
+	service := makeLegacyDeployment(env, prefix+"service")
+	inst, err := env.getInstance(service, "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := vs.AttachVolumes([]storage.VolumeAttachmentParams{{
+		Volume:   volume,
+		VolumeId: "volume-0.vhd",
+		AttachmentParams: storage.AttachmentParams{
+			Machine:    machine,
+			InstanceId: inst.Id(),
+		},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, gc.ErrorMatches, "attaching disks to legacy instances not supported")
+}
+
+func (s *azureVolumeSuite) TestDetachVolumes(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+	_, err := vs.DetachVolumes([]storage.VolumeAttachmentParams{{}})
+	c.Assert(err, gc.ErrorMatches, "detaching volumes not supported")
+}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -896,7 +896,7 @@ func (env *azureEnviron) newRole(roleSize string, vhd *gwacl.OSVirtualHardDisk, 
 	linuxConfigurationSet := gwacl.NewLinuxProvisioningConfigurationSet(hostname, username, password, userData, "true")
 	// Generate a Network Configuration with the initially required ports open.
 	networkConfigurationSet := gwacl.NewNetworkConfigurationSet(env.getInitialEndpoints(stateServer), nil)
-	role := gwacl.NewRole(
+	role := gwacl.NewLinuxRole(
 		roleSize, roleName, vhd,
 		[]gwacl.ConfigurationSet{*linuxConfigurationSet, *networkConfigurationSet},
 	)

--- a/provider/azure/init.go
+++ b/provider/azure/init.go
@@ -15,5 +15,7 @@ const (
 func init() {
 	environs.RegisterProvider(providerType, azureEnvironProvider{})
 
-	registry.RegisterEnvironStorageProviders(providerType)
+	// Register the Azure storage provider.
+	registry.RegisterProvider(storageProviderType, &azureStorageProvider{})
+	registry.RegisterEnvironStorageProviders(providerType, storageProviderType)
 }


### PR DESCRIPTION
This commit adds a storage.Provider for the azure provider. This
storage provider currently supports only non-persistent volumes;
volumes are created attached to machines, and when machines are
destroyed we supply the "comp=media" option which destroys all
attached disks and associated VHDs.

Requires https://github.com/juju/juju/pull/2947

(Review request: http://reviews.vapour.ws/r/2332/)