### PR TITLE
Fix bug #1468349

### DIFF
--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -58,7 +58,7 @@ func (dt discoveryTest) disableLocalDiscovery(c *gc.C, s *discoverySuite) {
 }
 
 func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
-	dt.os == version.Unknown
+	dt.os = version.Unknown
 	dt.setVersion(s)
 }
 

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -58,9 +58,8 @@ func (dt discoveryTest) disableLocalDiscovery(c *gc.C, s *discoverySuite) {
 }
 
 func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
-	s.PatchVersion(version.Binary{
-		OS: version.Unknown,
-	})
+	dt.os == version.Unknown
+	dt.setVersion(s)
 }
 
 func (dt discoveryTest) setLocal(c *gc.C, s *discoverySuite) {


### PR DESCRIPTION
Changed disableVersionDiscovery to only set the os version to unknown.

Problem was that version.Series was being erased, which isn't a problem in the upstart code path, but is in the initd one. The bug has more information.

(Review request: http://reviews.vapour.ws/r/2335/)