### PR TITLE
Fix 1467037 - Remove camel case username envusers

### DIFF
--- a/state/envuser.go
+++ b/state/envuser.go
@@ -144,32 +144,36 @@ func (st *State) AddEnvironmentUser(user, createdBy names.UserTag) (*Environment
 	return &EnvironmentUser{st: st, doc: *doc}, nil
 }
 
-func createEnvUserOpAndDoc(envuuid string, user, createdBy names.UserTag, displayName string) (txn.Op, *envUserDoc) {
+// envUserID returns the document id of the environment user
+func envUserID(user names.UserTag) string {
 	username := user.Username()
-	usernameLowerCase := strings.ToLower(username)
+	return strings.ToLower(username)
+}
+
+func createEnvUserOpAndDoc(envuuid string, user, createdBy names.UserTag, displayName string) (txn.Op, *envUserDoc) {
 	creatorname := createdBy.Username()
 	doc := &envUserDoc{
-		ID:          usernameLowerCase,
+		ID:          envUserID(user),
 		EnvUUID:     envuuid,
-		UserName:    username,
+		UserName:    user.Username(),
 		DisplayName: displayName,
 		CreatedBy:   creatorname,
 		DateCreated: nowToTheSecond(),
 	}
 	op := txn.Op{
 		C:      envUsersC,
-		Id:     usernameLowerCase,
+		Id:     envUserID(user),
 		Assert: txn.DocMissing,
 		Insert: doc,
 	}
 	return op, doc
 }
 
-// RemoveEnvironmentUser adds a new user to the database.
+// RemoveEnvironmentUser removes a user from the database.
 func (st *State) RemoveEnvironmentUser(user names.UserTag) error {
 	ops := []txn.Op{{
 		C:      envUsersC,
-		Id:     user.Username(),
+		Id:     envUserID(user),
 		Assert: txn.DocExists,
 		Remove: true,
 	}}

--- a/state/envuser_test.go
+++ b/state/envuser_test.go
@@ -104,7 +104,7 @@ func (s *EnvUserSuite) TestAddEnvironmentNoCreatedByUserFails(c *gc.C) {
 }
 
 func (s *EnvUserSuite) TestRemoveEnvironmentUser(c *gc.C) {
-	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validusername"})
+	user := s.factory.MakeUser(c, &factory.UserParams{Name: "validUsername"})
 	_, err := s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
RemoveEnvironmentUser should convert the username
to lower case when creating the ID for the op.

Previously reviewed here: http://reviews.vapour.ws/r/2268/

(Review request: http://reviews.vapour.ws/r/2336/)