### PR TITLE
Replace unit agent worker.Runner with dependency.Engine.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -66,6 +66,7 @@ import (
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/addresser"
 	"github.com/juju/juju/worker/apiaddressupdater"
+	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/charmrevisionworker"
@@ -470,7 +471,7 @@ func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error
 	// We need to reopen the API to clear the reboot flag after
 	// scheduling the reboot. It may be cleaner to do this in the reboot
 	// worker, before returning the ErrRebootMachine.
-	st, _, err := OpenAPIState(a)
+	st, _, err := apicaller.OpenAPIState(a)
 	if err != nil {
 		logger.Infof("Reboot: Error connecting to state")
 		return errors.Trace(err)
@@ -631,7 +632,7 @@ func (a *MachineAgent) stateStarter(stopch <-chan struct{}) error {
 // APIWorker returns a Worker that connects to the API and starts any
 // workers that need an API connection.
 func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
-	st, entity, err := OpenAPIState(a)
+	st, entity, err := apicaller.OpenAPIState(a)
 	if err != nil {
 		return nil, err
 	}
@@ -1085,7 +1086,7 @@ func (a *MachineAgent) startEnvWorkers(
 	agentConfig := a.CurrentConfig()
 	apiInfo := agentConfig.APIInfo()
 	apiInfo.EnvironTag = st.EnvironTag()
-	apiSt, err := OpenAPIStateUsingInfo(apiInfo, agentConfig.OldPassword())
+	apiSt, err := apicaller.OpenAPIStateUsingInfo(apiInfo, agentConfig.OldPassword())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -64,6 +64,7 @@ import (
 	sshtesting "github.com/juju/juju/utils/ssh/testing"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/deployer"
@@ -1192,7 +1193,7 @@ func (s *MachineSuite) runOpenAPISTateTest(c *gc.C, machine *state.Machine, conf
 		agent := NewAgentConf(conf.DataDir())
 		err := agent.ReadConfig(tagString)
 		c.Assert(err, jc.ErrorIsNil)
-		st, gotEntity, err := OpenAPIState(agent)
+		st, gotEntity, err := apicaller.OpenAPIState(agent)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st, gc.NotNil)
 		st.Close()

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -6,9 +6,9 @@ package agent
 import (
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/juju/cmd"
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/featureflag"
@@ -17,20 +17,13 @@ import (
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api/leadership"
+	"github.com/juju/juju/cmd/jujud/agent/unit"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/apiaddressupdater"
-	workerlogger "github.com/juju/juju/worker/logger"
+	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/logsender"
-	"github.com/juju/juju/worker/proxyupdater"
-	"github.com/juju/juju/worker/rsyslog"
-	"github.com/juju/juju/worker/uniter"
-	"github.com/juju/juju/worker/uniter/operation"
-	"github.com/juju/juju/worker/upgrader"
 )
 
 var (
@@ -137,113 +130,22 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 	return err
 }
 
-func (a *UnitAgent) APIWorkers() (_ worker.Worker, err error) {
-	st, entity, err := OpenAPIState(a)
-	if err != nil {
+// APIWorkers returns a dependency.Engine running the unit agent's responsibilities.
+func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
+	manifolds := unit.Manifolds(unit.ManifoldsConfig{
+		Agent:               agent.APIHostPortsSetter{a},
+		LogSource:           a.bufferedLogs,
+		LeadershipGuarantee: 30 * time.Second,
+	})
+
+	engine := dependency.NewEngine(cmdutil.IsFatal, 3*time.Second, 10*time.Millisecond)
+	if err := dependency.Install(engine, manifolds); err != nil {
+		if err := worker.Stop(engine); err != nil {
+			logger.Errorf("while stopping engine with bad manifolds: %v", err)
+		}
 		return nil, err
 	}
-	defer func() {
-		// TODO(fwereade): this is not properly tested. Old tests were both
-		// incomplete (missing a fail case) and evil (dependent on injecting
-		// an error in a patched-out upgrader API that shouldn't even be
-		// used at this level)... so I just deleted them. Not a major worry:
-		// this whole method will become redundant once we switch to the
-		// dependency engine (and specifically use worker/apicaller to
-		// connect).
-		if err != nil {
-			if err := st.Close(); err != nil {
-				logger.Errorf("while closing API: %v", err)
-			}
-		}
-	}()
-
-	agentConfig := a.CurrentConfig()
-	dataDir := agentConfig.DataDir()
-	hookLock, err := cmdutil.HookExecutionLock(dataDir)
-	if err != nil {
-		return nil, err
-	}
-
-	// Ensure that the environment uuid is stored in the agent config.
-	// Luckily the API has it recorded for us after we connect.
-	if agentConfig.Environment().Id() == "" {
-		err := a.ChangeConfig(func(setter agent.ConfigSetter) error {
-			environTag, err := st.EnvironTag()
-			if err != nil {
-				return errors.Annotate(err, "no environment uuid set on api")
-			}
-
-			return setter.Migrate(agent.MigrateParams{
-				Environment: environTag,
-			})
-		})
-		if err != nil {
-			logger.Warningf("unable to save environment uuid: %v", err)
-			// Not really fatal, just annoying.
-		}
-	}
-
-	unitTag, err := names.ParseUnitTag(entity.Tag())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	runner := worker.NewRunner(cmdutil.ConnectionIsFatal(logger, st), cmdutil.MoreImportant)
-
-	// start proxyupdater first to ensure proxy settings are correct
-	runner.StartWorker("proxyupdater", func() (worker.Worker, error) {
-		return proxyupdater.New(st.Environment(), false), nil
-	})
-	if feature.IsDbLogEnabled() {
-		runner.StartWorker("logsender", func() (worker.Worker, error) {
-			return logsender.New(a.bufferedLogs, agentConfig.APIInfo()), nil
-		})
-	}
-	runner.StartWorker("upgrader", func() (worker.Worker, error) {
-		return upgrader.NewAgentUpgrader(
-			st.Upgrader(),
-			agentConfig,
-			agentConfig.UpgradedToVersion(),
-			func() bool { return false },
-			a.initialAgentUpgradeCheckComplete,
-		), nil
-	})
-	runner.StartWorker("logger", func() (worker.Worker, error) {
-		return workerlogger.NewLogger(st.Logger(), agentConfig), nil
-	})
-	runner.StartWorker("uniter", func() (worker.Worker, error) {
-		uniterFacade, err := st.Uniter()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		uniterParams := uniter.UniterParams{
-			uniterFacade,
-			unitTag,
-			leadership.NewClient(st),
-			dataDir,
-			hookLock,
-			uniter.NewMetricsTimerChooser(),
-			uniter.NewUpdateStatusTimer(),
-			operation.NewExecutor,
-		}
-		return uniter.NewUniter(&uniterParams), nil
-	})
-
-	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {
-		// XXX(fwereade): this is not a uniter, and should therefore not be
-		// using the uniter facade.
-		uniterFacade, err := st.Uniter()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		addressUpdater := agent.APIHostPortsSetter{a}
-		return apiaddressupdater.NewAPIAddressUpdater(uniterFacade, addressUpdater), nil
-	})
-	if !featureflag.Enabled(feature.DisableRsyslog) {
-		runner.StartWorker("rsyslog", func() (worker.Worker, error) {
-			return cmdutil.NewRsyslogConfigWorker(st.Rsyslog(), agentConfig, rsyslog.RsyslogModeForwarding)
-		})
-	}
-	return cmdutil.NewCloseWorker(logger, runner, st), nil
+	return engine, nil
 }
 
 func (a *UnitAgent) Tag() names.Tag {

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -1,0 +1,158 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit
+
+import (
+	"time"
+
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/apiaddressupdater"
+	"github.com/juju/juju/worker/apicaller"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/leadership"
+	"github.com/juju/juju/worker/logger"
+	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/machinelock"
+	"github.com/juju/juju/worker/proxyupdater"
+	"github.com/juju/juju/worker/rsyslog"
+	"github.com/juju/juju/worker/uniter"
+	"github.com/juju/juju/worker/upgrader"
+)
+
+// ManifoldsConfig allows specialisation of the result of Manifolds.
+type ManifoldsConfig struct {
+
+	// Agent contains the agent that will be wrapped and made available to
+	// its dependencies via a dependency.Engine.
+	Agent coreagent.Agent
+
+	// LogSource will be read from by the logsender component.
+	LogSource logsender.LogRecordCh
+
+	// LeadershipGuarantee controls the behaviour of the leadership tracker.
+	LeadershipGuarantee time.Duration
+}
+
+// Manifolds returns a set of co-configured manifolds covering the various
+// responsibilities of a standalone unit agent. It also accepts the logSource
+// argument because we haven't figured out how to thread all the logging bits
+// through a dependency engine yet.
+//
+// Thou Shalt Not Use String Literals In This Function. Or Else.
+func Manifolds(config ManifoldsConfig) dependency.Manifolds {
+	return dependency.Manifolds{
+
+		// The agent manifold references the enclosing agent, and is the
+		// foundation stone on which most other manifolds ultimately depend.
+		// (Currently, that is "all manifolds", but consider a shared clock.)
+		AgentName: agent.Manifold(config.Agent),
+
+		// The machine lock manifold is a thin concurrent wrapper around an
+		// FSLock in an agreed location. We expect it to be replaced with an
+		// in-memory lock when the unit agent moves into the machine agent.
+		MachineLockName: machinelock.Manifold(machinelock.ManifoldConfig{
+			AgentName: AgentName,
+		}),
+
+		// The api caller is a thin concurrent wrapper around a connection
+		// to some API server. It's used by many other manifolds, which all
+		// select their own desired facades. It will be interesting to see
+		// how this works when we consolidate the agents; might be best to
+		// handle the auth changes server-side..?
+		APICallerName: apicaller.Manifold(apicaller.ManifoldConfig{
+			AgentName: AgentName,
+		}),
+
+		// The log sender is a leaf worker that sends log messages to some
+		// API server, when configured so to do. We should only need one of
+		// these in a consolidated agent.
+		LogSenderName: logsender.Manifold(logsender.ManifoldConfig{
+			AgentName: AgentName,
+			LogSource: config.LogSource,
+		}),
+
+		// The rsyslog config updater is a leaf worker that causes rsyslog
+		// to send messages to the state servers. We should only need one
+		// of these in a consolidated agent.
+		RsyslogConfigUpdaterName: rsyslog.Manifold(rsyslog.ManifoldConfig{
+			AgentName:     AgentName,
+			APICallerName: APICallerName,
+		}),
+
+		// The logging config updater is a leaf worker that indirectly
+		// controls the messages sent via the log sender or rsyslog,
+		// according to changes in environment config. We should only need
+		// one of these in a consolidated agent.
+		LoggingConfigUpdaterName: logger.Manifold(logger.ManifoldConfig{
+			AgentName:     AgentName,
+			APICallerName: APICallerName,
+		}),
+
+		// The api address updater is a leaf worker that rewrites agent config
+		// as the state server addresses change. We should only need one of
+		// these in a consolidated agent.
+		APIAdddressUpdaterName: apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
+			AgentName:     AgentName,
+			APICallerName: APICallerName,
+		}),
+
+		// The proxy config updater is a leaf worker that sets http/https/apt/etc
+		// proxy settings.
+		// TODO(fwereade): timing of this is suspicious. There was superstitious
+		// code trying to run this early; if that ever helped, it was only by
+		// coincidence. Probably we ought to be making components that might
+		// need proxy config into explicit dependenncies of the proxy updater...
+		ProxyConfigUpdaterName: proxyupdater.Manifold(proxyupdater.ManifoldConfig{
+			APICallerName: APICallerName,
+		}),
+
+		// The upgrader is a leaf worker that returns a specific error type
+		// recognised by the unit agent, causing other workers to be stopped
+		// and the agent to be restarted running the new tools. We should only
+		// need one of these in a consolidated agent, but we'll need to be
+		// careful about behavioural differences, and interactions with the
+		// upgrade-steps worker.
+		UpgraderName: upgrader.Manifold(upgrader.ManifoldConfig{
+			AgentName:     AgentName,
+			APICallerName: APICallerName,
+		}),
+
+		// The leadership tracker attempts to secure and retain leadership of
+		// the unit's service, and is consulted on such matters by the
+		// uniter. As it stannds today, we'll need one per unit in a
+		// consolidated agent.
+		LeadershipTrackerName: leadership.Manifold(leadership.ManifoldConfig{
+			AgentName:           AgentName,
+			APICallerName:       APICallerName,
+			LeadershipGuarantee: config.LeadershipGuarantee,
+		}),
+
+		// The uniter installs charms; manages the unit's presence in its
+		// relations; creates suboordinate units; runs all the hooks; sends
+		// metrics; etc etc etc. We expect to break it up further in the
+		// coming weeks, and to need one per unit in a consolidated agent
+		// (and probably one for each component broken out).
+		UniterName: uniter.Manifold(uniter.ManifoldConfig{
+			AgentName:             AgentName,
+			APICallerName:         APICallerName,
+			LeadershipTrackerName: LeadershipTrackerName,
+			MachineLockName:       MachineLockName,
+		}),
+	}
+}
+
+const (
+	AgentName                = "agent"
+	APIAdddressUpdaterName   = "api-address-updater"
+	APICallerName            = "api-caller"
+	LeadershipTrackerName    = "leadership-tracker"
+	LoggingConfigUpdaterName = "logging-config-updater"
+	LogSenderName            = "log-sender"
+	MachineLockName          = "machine-lock"
+	ProxyConfigUpdaterName   = "proxy-config-updater"
+	RsyslogConfigUpdaterName = "rsyslog-config-updater"
+	UniterName               = "uniter"
+	UpgraderName             = "upgrader"
+)

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -1,0 +1,75 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cmd/jujud/agent/unit"
+	"github.com/juju/juju/testing"
+)
+
+type ManifoldsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ManifoldsSuite{})
+
+func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
+	manifolds := unit.Manifolds(unit.ManifoldsConfig{
+		Agent: fakeAgent{},
+	})
+
+	for name, manifold := range manifolds {
+		c.Logf("checking %q manifold", name)
+		c.Check(manifold.Start, gc.NotNil)
+	}
+}
+
+// TODO(cmars) 2015/08/10: rework this into builtin Engine cycle checker.
+func (s *ManifoldsSuite) TestAcyclic(c *gc.C) {
+	manifolds := unit.Manifolds(unit.ManifoldsConfig{
+		Agent: fakeAgent{},
+	})
+	count := len(manifolds)
+
+	// Set of vars for depth-first topological sort of manifolds. (Note that,
+	// because we've already got outgoing links stored conveniently, we're
+	// actually checking the transpose of the dependency graph. Cycles will
+	// still be cycles in either direction, though.)
+	done := make(map[string]bool)
+	doing := make(map[string]bool)
+	sorted := make([]string, 0, count)
+
+	// Stupid _-suffix malarkey allows recursion. Seems cleaner to keep these
+	// considerations inside this func than to embody the algorithm in a type.
+	visit := func(node string) {}
+	visit_ := func(node string) {
+		if doing[node] {
+			c.Fatalf("cycle detected at %q (considering: %v)", node, doing)
+		}
+		if !done[node] {
+			doing[node] = true
+			for _, input := range manifolds[node].Inputs {
+				visit(input)
+			}
+			done[node] = true
+			doing[node] = false
+			sorted = append(sorted, node)
+		}
+	}
+	visit = visit_
+
+	// Actually sort them, or fail if we find a cycle.
+	for node := range manifolds {
+		visit(node)
+	}
+	c.Logf("got: %v", sorted)
+	c.Check(sorted, gc.HasLen, count) // Final sanity check.
+}
+
+type fakeAgent struct {
+	agent.Agent
+}

--- a/cmd/jujud/agent/unit/package_test.go
+++ b/cmd/jujud/agent/unit/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/agent/manifold_test.go
+++ b/worker/agent/manifold_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 )
@@ -32,7 +33,7 @@ func (s *ManifoldSuite) TestOutput(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	defer assertStop(c, agentWorker)
 
-	var outputAgent agent.Agent
+	var outputAgent coreagent.Agent
 	err = manifold.Output(agentWorker, &outputAgent)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(outputAgent, jc.DeepEquals, inputAgent)
@@ -48,7 +49,7 @@ func (s *ManifoldSuite) TestOutputStoppedWorker(c *gc.C) {
 	// whether the (degenerate) worker is alive or not -- so no defer here.
 	assertStop(c, agentWorker)
 
-	var outputAgent agent.Agent
+	var outputAgent coreagent.Agent
 	err = manifold.Output(agentWorker, &outputAgent)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(outputAgent, jc.DeepEquals, inputAgent)
@@ -60,7 +61,7 @@ func (s *ManifoldSuite) TestOutputBadWorker(c *gc.C) {
 
 	var badWorker worker.Worker
 
-	var outputAgent agent.Agent
+	var outputAgent coreagent.Agent
 	err := manifold.Output(badWorker, &outputAgent)
 	c.Check(err.Error(), gc.Equals, "expected *agent.agentWorker->*agent.Agent; got <nil>->*agent.Agent")
 }
@@ -79,7 +80,7 @@ func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
 }
 
 type dummyAgent struct {
-	agent.Agent
+	coreagent.Agent
 }
 
 func assertStop(c *gc.C, w worker.Worker) {

--- a/worker/apicaller/export_test.go
+++ b/worker/apicaller/export_test.go
@@ -3,4 +3,8 @@
 
 package apicaller
 
-var OpenConnection = &openConnection
+var (
+	OpenConnection           = &openConnection
+	OpenAPIForAgent          = &apiOpen
+	CheckProvisionedStrategy = &checkProvisionedStrategy
+)

--- a/worker/apicaller/manifold.go
+++ b/worker/apicaller/manifold.go
@@ -6,10 +6,9 @@ package apicaller
 import (
 	"github.com/juju/errors"
 
-	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/util"
 )
@@ -35,24 +34,24 @@ func startFunc(config ManifoldConfig) dependency.StartFunc {
 	return func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
 
 		// Get dependencies and open a connection.
-		var agent agent.Agent
-		if err := getResource(config.AgentName, &agent); err != nil {
+		var a agent.Agent
+		if err := getResource(config.AgentName, &a); err != nil {
 			return nil, err
 		}
-		conn, err := openConnection(agent)
+		conn, err := openConnection(a)
 		if err != nil {
 			return nil, errors.Annotate(err, "cannot open api")
 		}
 
 		// Add the environment uuid to agent config if not present.
-		currentConfig := agent.CurrentConfig()
+		currentConfig := a.CurrentConfig()
 		if currentConfig.Environment().Id() == "" {
-			err := agent.ChangeConfig(func(setter coreagent.ConfigSetter) error {
+			err := a.ChangeConfig(func(setter agent.ConfigSetter) error {
 				environTag, err := conn.EnvironTag()
 				if err != nil {
 					return errors.Annotate(err, "no environment uuid set on api")
 				}
-				return setter.Migrate(coreagent.MigrateParams{
+				return setter.Migrate(agent.MigrateParams{
 					Environment: environTag,
 				})
 			})

--- a/worker/apicaller/manifold_test.go
+++ b/worker/apicaller/manifold_test.go
@@ -10,12 +10,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
@@ -55,8 +54,8 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		stub:   &testing.Stub{},
 		broken: make(chan struct{}),
 	}
-	s.PatchValue(apicaller.OpenConnection, func(agent agent.Agent) (api.Connection, error) {
-		s.AddCall("openConnection", agent)
+	s.PatchValue(apicaller.OpenConnection, func(a agent.Agent) (api.Connection, error) {
+		s.AddCall("openConnection", a)
 		if err := s.NextErr(); err != nil {
 			return nil, err
 		}
@@ -101,7 +100,7 @@ func (s *ManifoldSuite) TestStartSuccessWithEnvironnmentIdSet(c *gc.C) {
 	}})
 }
 
-func (s *ManifoldSuite) setupMutatorTest(c *gc.C) coreagent.ConfigMutator {
+func (s *ManifoldSuite) setupMutatorTest(c *gc.C) agent.ConfigMutator {
 	s.agent.env = names.EnvironTag{}
 	s.conn.stub = &s.Stub // will be unsafe if worker stopped before test finished
 	s.SetErrors(
@@ -117,7 +116,7 @@ func (s *ManifoldSuite) setupMutatorTest(c *gc.C) coreagent.ConfigMutator {
 	changeArgs := s.Calls()[1].Args
 	c.Assert(changeArgs, gc.HasLen, 1)
 	s.ResetCalls()
-	return changeArgs[0].(coreagent.ConfigMutator)
+	return changeArgs[0].(agent.ConfigMutator)
 }
 
 func (s *ManifoldSuite) TestStartSuccessWithEnvironnmentIdNotSet(c *gc.C) {
@@ -130,7 +129,7 @@ func (s *ManifoldSuite) TestStartSuccessWithEnvironnmentIdNotSet(c *gc.C) {
 		FuncName: "EnvironTag",
 	}, {
 		FuncName: "Migrate",
-		Args: []interface{}{coreagent.MigrateParams{
+		Args: []interface{}{agent.MigrateParams{
 			Environment: coretesting.EnvironmentTag,
 		}},
 	}})
@@ -158,7 +157,7 @@ func (s *ManifoldSuite) TestStartSuccessWithEnvironnmentIdNotSetMigrateFailure(c
 		FuncName: "EnvironTag",
 	}, {
 		FuncName: "Migrate",
-		Args: []interface{}{coreagent.MigrateParams{
+		Args: []interface{}{agent.MigrateParams{
 			Environment: coretesting.EnvironmentTag,
 		}},
 	}})

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -1,10 +1,7 @@
 // Copyright 2012-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// This file exists to collect the various bits of code related to OpenAPIState,
-// in preparation for moving them to worker/apicaller and breaking an impending
-// import cycle.
-package agent
+package apicaller
 
 import (
 	"time"

--- a/worker/apicaller/open_test.go
+++ b/worker/apicaller/open_test.go
@@ -1,7 +1,7 @@
 // Copyright 2012-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package agent
+package apicaller
 
 import (
 	"fmt"

--- a/worker/apicaller/util_test.go
+++ b/worker/apicaller/util_test.go
@@ -9,11 +9,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 )
 
 type mockAgent struct {
@@ -22,17 +21,17 @@ type mockAgent struct {
 	env  names.EnvironTag
 }
 
-func (mock *mockAgent) CurrentConfig() coreagent.Config {
+func (mock *mockAgent) CurrentConfig() agent.Config {
 	return dummyConfig{env: mock.env}
 }
 
-func (mock *mockAgent) ChangeConfig(mutator coreagent.ConfigMutator) error {
+func (mock *mockAgent) ChangeConfig(mutator agent.ConfigMutator) error {
 	mock.stub.AddCall("ChangeConfig", mutator)
 	return mock.stub.NextErr()
 }
 
 type dummyConfig struct {
-	coreagent.Config
+	agent.Config
 	env names.EnvironTag
 }
 
@@ -42,10 +41,10 @@ func (dummy dummyConfig) Environment() names.EnvironTag {
 
 type mockSetter struct {
 	stub *testing.Stub
-	coreagent.ConfigSetter
+	agent.ConfigSetter
 }
 
-func (mock *mockSetter) Migrate(params coreagent.MigrateParams) error {
+func (mock *mockSetter) Migrate(params agent.MigrateParams) error {
 	mock.stub.AddCall("Migrate", params)
 	return mock.stub.NextErr()
 }

--- a/worker/apicaller/worker.go
+++ b/worker/apicaller/worker.go
@@ -8,18 +8,17 @@ import (
 	"github.com/juju/loggo"
 	"launchpad.net/tomb"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
-	jujudagent "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 )
 
 var logger = loggo.GetLogger("juju.worker.apicaller")
 
 // openConnection exists to be patched out in export_test.go (and let us test
 // this component without using a real API connection).
-var openConnection = func(agent agent.Agent) (api.Connection, error) {
-	st, _, err := jujudagent.OpenAPIState(agent)
+var openConnection = func(a agent.Agent) (api.Connection, error) {
+	st, _, err := OpenAPIState(a)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/leadership/manifold_test.go
+++ b/worker/leadership/manifold_test.go
@@ -11,9 +11,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/leadership"
@@ -32,7 +32,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.Stub = testing.Stub{}
 	s.manifold = leadership.Manifold(leadership.ManifoldConfig{
 		AgentName:           "agent-name",
-		ApiCallerName:       "api-caller-name",
+		APICallerName:       "api-caller-name",
 		LeadershipGuarantee: 123456 * time.Millisecond,
 	})
 }
@@ -70,8 +70,8 @@ func (s *ManifoldSuite) TestStartError(c *gc.C) {
 		"agent-name":      dt.StubResource{Output: dummyAgent},
 		"api-caller-name": dt.StubResource{Output: dummyApiCaller},
 	})
-	s.PatchValue(leadership.NewManifoldWorker, func(agent agent.Agent, apiCaller base.APICaller, guarantee time.Duration) (worker.Worker, error) {
-		s.AddCall("newManifoldWorker", agent, apiCaller, guarantee)
+	s.PatchValue(leadership.NewManifoldWorker, func(a agent.Agent, apiCaller base.APICaller, guarantee time.Duration) (worker.Worker, error) {
+		s.AddCall("newManifoldWorker", a, apiCaller, guarantee)
 		return nil, errors.New("blammo")
 	})
 
@@ -92,8 +92,8 @@ func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
 		"api-caller-name": dt.StubResource{Output: dummyApiCaller},
 	})
 	dummyWorker := &dummyWorker{}
-	s.PatchValue(leadership.NewManifoldWorker, func(agent agent.Agent, apiCaller base.APICaller, guarantee time.Duration) (worker.Worker, error) {
-		s.AddCall("newManifoldWorker", agent, apiCaller, guarantee)
+	s.PatchValue(leadership.NewManifoldWorker, func(a agent.Agent, apiCaller base.APICaller, guarantee time.Duration) (worker.Worker, error) {
+		s.AddCall("newManifoldWorker", a, apiCaller, guarantee)
 		return dummyWorker, nil
 	})
 

--- a/worker/logger/manifold.go
+++ b/worker/logger/manifold.go
@@ -4,10 +4,10 @@
 package logger
 
 import (
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/logger"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/util"
 )
@@ -23,8 +23,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 }
 
 // newWorker trivially wraps NewLogger to specialise an AgentApiManifold.
-var newWorker = func(agent agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
-	currentConfig := agent.CurrentConfig()
+var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+	currentConfig := a.CurrentConfig()
 	loggerFacade := logger.NewState(apiCaller)
 	return NewLogger(loggerFacade, currentConfig), nil
 }

--- a/worker/logsender/manifold.go
+++ b/worker/logsender/manifold.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsender
+
+import (
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	AgentName string
+	LogSource LogRecordCh
+}
+
+// Manifold returns a dependency manifold that runs a logger
+// worker, using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			if !feature.IsDbLogEnabled() {
+				logger.Warningf("log sender manifold disabled by feature flag")
+				return nil, dependency.ErrMissing
+			}
+
+			var agent agent.Agent
+			if err := getResource(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			apiInfo := agent.CurrentConfig().APIInfo()
+			return New(config.LogSource, apiInfo), nil
+		},
+	}
+}

--- a/worker/machinelock/manifold.go
+++ b/worker/machinelock/manifold.go
@@ -8,9 +8,9 @@ import (
 	"github.com/juju/utils/fslock"
 	"launchpad.net/tomb"
 
+	"github.com/juju/juju/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/util"
 )
@@ -36,8 +36,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 }
 
 // newWorker creates a degenerate worker that provides access to an fslock.
-func newWorker(agent agent.Agent) (worker.Worker, error) {
-	dataDir := agent.CurrentConfig().DataDir()
+func newWorker(a agent.Agent) (worker.Worker, error) {
+	dataDir := a.CurrentConfig().DataDir()
 	lock, err := createLock(dataDir)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/machinelock/manifold_test.go
+++ b/worker/machinelock/manifold_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/juju/utils/fslock"
 	gc "gopkg.in/check.v1"
 
-	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/machinelock"
@@ -121,12 +120,12 @@ type dummyAgent struct {
 	agent.Agent
 }
 
-func (_ dummyAgent) CurrentConfig() coreagent.Config {
+func (_ dummyAgent) CurrentConfig() agent.Config {
 	return &dummyAgentConfig{}
 }
 
 type dummyAgentConfig struct {
-	coreagent.Config
+	agent.Config
 }
 
 func (_ dummyAgentConfig) DataDir() string {

--- a/worker/rsyslog/manifold.go
+++ b/worker/rsyslog/manifold.go
@@ -4,13 +4,14 @@
 package rsyslog
 
 import (
-	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/rsyslog"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/util"
+	"github.com/juju/utils/featureflag"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a
@@ -28,10 +29,15 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 // TODO(fwereade) 2015-05-11 Eventually, the method should be the sole accessible
 // package factory function -- as part of the manifold -- and all tests should
 // thus be routed through it.
-var newWorker = func(agent agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
-	agentConfig := agent.CurrentConfig()
+var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+	if featureflag.Enabled(feature.DisableRsyslog) {
+		logger.Warningf("rsyslog manifold disabled by feature flag")
+		return nil, dependency.ErrMissing
+	}
+
+	agentConfig := a.CurrentConfig()
 	tag := agentConfig.Tag()
-	namespace := agentConfig.Value(coreagent.Namespace)
+	namespace := agentConfig.Value(agent.Namespace)
 	addrs, err := agentConfig.APIAddresses()
 	if err != nil {
 		return nil, err

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -91,11 +91,13 @@ func syslogUser() string {
 	return user
 }
 
-// NewRsyslogConfigWorker returns a worker.Worker that uses
+var NewRsyslogConfigWorker = newRsyslogConfigWorker
+
+// newRsyslogConfigWorker returns a worker.Worker that uses
 // WatchForRsyslogChanges and updates rsyslog configuration based
 // on changes. The worker will remove the configuration file
 // on teardown.
-func NewRsyslogConfigWorker(st *apirsyslog.State, mode RsyslogMode, tag names.Tag, namespace string, stateServerAddrs []string, jujuConfigDir string) (worker.Worker, error) {
+func newRsyslogConfigWorker(st *apirsyslog.State, mode RsyslogMode, tag names.Tag, namespace string, stateServerAddrs []string, jujuConfigDir string) (worker.Worker, error) {
 	if version.Current.OS == version.Windows && mode == RsyslogModeAccumulate {
 		return worker.NewNoOpWorker(), nil
 	}

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils/fslock"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/leadership"
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	AgentName             string
+	APICallerName         string
+	MachineLockName       string
+	LeadershipTrackerName string
+}
+
+// Manifold returns a dependency manifold that runs a uniter worker,
+// using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.LeadershipTrackerName,
+			config.MachineLockName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+
+			// Collect all required resources.
+			var agent agent.Agent
+			if err := getResource(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			var apiCaller base.APICaller
+			if err := getResource(config.APICallerName, &apiCaller); err != nil {
+				// TODO(fwereade): absence of an APICaller shouldn't be the end of
+				// the world -- we ought to return a type that can at least run the
+				// leader-deposed hook -- but that's not done yet.
+				return nil, err
+			}
+			var machineLock *fslock.Lock
+			if err := getResource(config.MachineLockName, &machineLock); err != nil {
+				return nil, err
+			}
+			var leadershipTracker leadership.Tracker
+			if err := getResource(config.LeadershipTrackerName, &leadershipTracker); err != nil {
+				return nil, err
+			}
+
+			// Configure and start the uniter.
+			config := agent.CurrentConfig()
+			tag := config.Tag()
+			unitTag, ok := tag.(names.UnitTag)
+			if !ok {
+				return nil, errors.Errorf("expected a unit tag, got %v", tag)
+			}
+			uniterFacade := uniter.NewState(apiCaller, unitTag)
+			return NewUniter(&UniterParams{
+				UniterFacade:         uniterFacade,
+				UnitTag:              unitTag,
+				LeadershipTracker:    leadershipTracker,
+				DataDir:              config.DataDir(),
+				MachineLock:          machineLock,
+				MetricsTimerChooser:  NewMetricsTimerChooser(),
+				UpdateStatusSignal:   NewUpdateStatusTimer(),
+				NewOperationExecutor: operation.NewExecutor,
+			}), nil
+		},
+	}
+}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
-	coreleadership "github.com/juju/juju/leadership"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/leadership"
@@ -71,7 +70,6 @@ type Uniter struct {
 	operationExecutor    operation.Executor
 	newOperationExecutor NewExecutorFunc
 
-	leadershipClaimer coreleadership.Claimer
 	leadershipTracker leadership.Tracker
 
 	hookLock    *fslock.Lock
@@ -103,11 +101,11 @@ type Uniter struct {
 
 // UniterParams hold all the necessary parameters for a new Uniter.
 type UniterParams struct {
-	St                   *uniter.State
+	UniterFacade         *uniter.State
 	UnitTag              names.UnitTag
-	LeadershipClaimer    coreleadership.Claimer
+	LeadershipTracker    leadership.Tracker
 	DataDir              string
-	HookLock             *fslock.Lock
+	MachineLock          *fslock.Lock
 	MetricsTimerChooser  *timerChooser
 	UpdateStatusSignal   TimedSignal
 	NewOperationExecutor NewExecutorFunc
@@ -120,10 +118,10 @@ type NewExecutorFunc func(string, func() (*corecharm.URL, error), func(string) (
 // hooks and operations provoked by changes in st.
 func NewUniter(uniterParams *UniterParams) *Uniter {
 	u := &Uniter{
-		st:                   uniterParams.St,
+		st:                   uniterParams.UniterFacade,
 		paths:                NewPaths(uniterParams.DataDir, uniterParams.UnitTag),
-		hookLock:             uniterParams.HookLock,
-		leadershipClaimer:    uniterParams.LeadershipClaimer,
+		hookLock:             uniterParams.MachineLock,
+		leadershipTracker:    uniterParams.LeadershipTracker,
 		metricsTimerChooser:  uniterParams.MetricsTimerChooser,
 		collectMetricsAt:     uniterParams.MetricsTimerChooser.inactive,
 		sendMetricsAt:        uniterParams.MetricsTimerChooser.inactive,
@@ -151,19 +149,6 @@ func (u *Uniter) runCleanups() {
 }
 
 func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
-	// Start tracking leadership state.
-	// TODO(fwereade): ideally, this wouldn't be created here; as a worker it's
-	// clearly better off being managed by a Runner. However, we haven't come up
-	// with a clean way to reference one (lineage of a...) worker from another,
-	// so for now the tracker is accessible only to its unit.
-	leadershipTracker := leadership.NewTrackerWorker(
-		unitTag, u.leadershipClaimer, leadershipGuarantee,
-	)
-	u.addCleanup(func() error {
-		return worker.Stop(leadershipTracker)
-	})
-	u.leadershipTracker = leadershipTracker
-
 	if err := u.init(unitTag); err != nil {
 		if err == worker.ErrTerminateAgent {
 			return err
@@ -179,8 +164,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	}
 	u.addCleanup(u.f.Stop)
 
-	// Stop the uniter if either of these components fails.
-	go func() { u.tomb.Kill(leadershipTracker.Wait()) }()
+	// Stop the uniter if the filter fails.
 	go func() { u.tomb.Kill(u.f.Wait()) }()
 
 	// Start handling leader settings events, or not, as appropriate.

--- a/worker/upgrader/manifold.go
+++ b/worker/upgrader/manifold.go
@@ -4,10 +4,10 @@
 package upgrader
 
 import (
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/util"
 )
@@ -24,8 +24,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 // newWorker wraps NewUpgrader for the convenience of AgentApiManifold. It should
 // eventually replace NewUpgrader.
-var newWorker = func(agent agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
-	currentConfig := agent.CurrentConfig()
+var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+	currentConfig := a.CurrentConfig()
 	upgraderFacade := upgrader.NewState(apiCaller)
 	return NewAgentUpgrader(
 		upgraderFacade,

--- a/worker/util/agent.go
+++ b/worker/util/agent.go
@@ -4,8 +4,8 @@
 package util
 
 import (
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 )
 

--- a/worker/util/agent_test.go
+++ b/worker/util/agent_test.go
@@ -9,8 +9,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/util"
@@ -34,8 +34,8 @@ func (s *AgentManifoldSuite) SetUpTest(c *gc.C) {
 	}, s.newWorker)
 }
 
-func (s *AgentManifoldSuite) newWorker(agent agent.Agent) (worker.Worker, error) {
-	s.AddCall("newWorker", agent)
+func (s *AgentManifoldSuite) newWorker(a agent.Agent) (worker.Worker, error) {
+	s.AddCall("newWorker", a)
 	if err := s.NextErr(); err != nil {
 		return nil, err
 	}

--- a/worker/util/api.go
+++ b/worker/util/api.go
@@ -12,7 +12,7 @@ import (
 // Some (hopefully growing number of) manifolds completely depend on an API
 // connection; this type configures them.
 type ApiManifoldConfig struct {
-	ApiCallerName string
+	APICallerName string
 }
 
 // ApiStartFunc encapsulates the behaviour that varies among ApiManifolds.
@@ -23,11 +23,11 @@ type ApiStartFunc func(base.APICaller) (worker.Worker, error)
 func ApiManifold(config ApiManifoldConfig, start ApiStartFunc) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.ApiCallerName,
+			config.APICallerName,
 		},
 		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
 			var apiCaller base.APICaller
-			if err := getResource(config.ApiCallerName, &apiCaller); err != nil {
+			if err := getResource(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
 			}
 			return start(apiCaller)

--- a/worker/util/api_test.go
+++ b/worker/util/api_test.go
@@ -30,7 +30,7 @@ func (s *ApiManifoldSuite) SetUpTest(c *gc.C) {
 	s.Stub = testing.Stub{}
 	s.worker = &dummyWorker{}
 	s.manifold = util.ApiManifold(util.ApiManifoldConfig{
-		ApiCallerName: "api-caller-name",
+		APICallerName: "api-caller-name",
 	}, s.newWorker)
 }
 

--- a/worker/util/apiagent.go
+++ b/worker/util/apiagent.go
@@ -4,9 +4,9 @@
 package util
 
 import (
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 )
 
@@ -14,7 +14,7 @@ import (
 // type configures them.
 type AgentApiManifoldConfig struct {
 	AgentName     string
-	ApiCallerName string
+	APICallerName string
 }
 
 // AgentApiStartFunc encapsulates the behaviour that varies among AgentApiManifolds.
@@ -27,7 +27,7 @@ func AgentApiManifold(config AgentApiManifoldConfig, start AgentApiStartFunc) de
 	return dependency.Manifold{
 		Inputs: []string{
 			config.AgentName,
-			config.ApiCallerName,
+			config.APICallerName,
 		},
 		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
 			var agent agent.Agent
@@ -35,7 +35,7 @@ func AgentApiManifold(config AgentApiManifoldConfig, start AgentApiStartFunc) de
 				return nil, err
 			}
 			var apiCaller base.APICaller
-			if err := getResource(config.ApiCallerName, &apiCaller); err != nil {
+			if err := getResource(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
 			}
 			return start(agent, apiCaller)

--- a/worker/util/apiagent_test.go
+++ b/worker/util/apiagent_test.go
@@ -9,9 +9,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
 	dt "github.com/juju/juju/worker/dependency/testing"
 	"github.com/juju/juju/worker/util"
@@ -32,12 +32,12 @@ func (s *AgentApiManifoldSuite) SetUpTest(c *gc.C) {
 	s.worker = &dummyWorker{}
 	s.manifold = util.AgentApiManifold(util.AgentApiManifoldConfig{
 		AgentName:     "agent-name",
-		ApiCallerName: "api-caller-name",
+		APICallerName: "api-caller-name",
 	}, s.newWorker)
 }
 
-func (s *AgentApiManifoldSuite) newWorker(agent agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
-	s.AddCall("newWorker", agent, apiCaller)
+func (s *AgentApiManifoldSuite) newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+	s.AddCall("newWorker", a, apiCaller)
 	if err := s.NextErr(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a reconciliation of William's https://github.com/fwereade/juju/tree/uniter-dependency-engine-necro branch with recent refactorings.

(Review request: http://reviews.vapour.ws/r/2337/)