### PR TITLE
If the Juju version has a tag (eg alpha or beta), then by default use testing stream to find tools

### DIFF
--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -263,8 +263,9 @@ func (f *ToolsFinder) findMatchingTools(args params.FindToolsParams) (coretools.
 		return nil, err
 	}
 	filter := toolsFilter(args)
+	stream := envtools.PreferredStream(&args.Number, cfg.Development(), cfg.AgentStream())
 	simplestreamsList, err := envtoolsFindTools(
-		env, args.MajorVersion, args.MinorVersion, filter,
+		env, args.MajorVersion, args.MinorVersion, stream, filter,
 	)
 	if len(storageList) == 0 && err != nil {
 		return nil, err

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -224,7 +224,7 @@ func (s *toolsSuite) testFindToolsExact(c *gc.C, t common.ToolsStorageGetter, in
 		c.Assert(filter.Series, gc.Equals, version.Current.Series)
 		c.Assert(filter.Arch, gc.Equals, version.Current.Arch)
 		if develVersion {
-			c.Assert(stream, gc.Equals, "testing")
+			c.Assert(stream, gc.Equals, "devel")
 		} else {
 			c.Assert(stream, gc.Equals, "released")
 		}

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -296,6 +296,7 @@ func (s *toolsSuite) TestDownloadFetchesAndCaches(c *gc.C) {
 
 func (s *toolsSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 	// Upload fake tools, then upload over the top so the SHA256 hash does not match.
+	s.PatchValue(&version.Current.Number, version.MustParse("1.22.0"))
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", version.Current)[0]
@@ -310,6 +311,7 @@ func (s *toolsSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 
 func (s *toolsSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 	// Upload fake tools, then upload over the top so the SHA256 hash does not match.
+	s.PatchValue(&version.Current.Number, version.MustParse("1.22.0"))
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", version.Current)[0]

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/toolstorage"
+	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -296,7 +297,7 @@ func (s *toolsSuite) TestDownloadFetchesAndCaches(c *gc.C) {
 
 func (s *toolsSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 	// Upload fake tools, then upload over the top so the SHA256 hash does not match.
-	s.PatchValue(&version.Current.Number, version.MustParse("1.22.0"))
+	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", version.Current)[0]
@@ -311,7 +312,7 @@ func (s *toolsSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 
 func (s *toolsSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 	// Upload fake tools, then upload over the top so the SHA256 hash does not match.
-	s.PatchValue(&version.Current.Number, version.MustParse("1.22.0"))
+	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", version.Current)[0]

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -613,7 +613,7 @@ func (s *BootstrapSuite) TestInvalidLocalSource(c *gc.C) {
 
 	// Now check that there are no tools available.
 	_, err = envtools.FindTools(
-		env, version.Current.Major, version.Current.Minor, coretools.Filter{})
+		env, version.Current.Major, version.Current.Minor, "released", coretools.Filter{})
 	c.Assert(err, gc.FitsTypeOf, errors.NotFoundf(""))
 }
 
@@ -872,7 +872,7 @@ func resetJujuHome(c *gc.C, envName string) environs.Environ {
 // checkTools check if the environment contains the passed envtools.
 func checkTools(c *gc.C, env environs.Environ, expected []version.Binary) {
 	list, err := envtools.FindTools(
-		env, version.Current.Major, version.Current.Minor, coretools.Filter{})
+		env, version.Current.Major, version.Current.Minor, "released", coretools.Filter{})
 	c.Check(err, jc.ErrorIsNil)
 	c.Logf("found: " + list.String())
 	urls := list.URLs()

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -118,6 +118,7 @@ func (s *commonMachineSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *commonMachineSuite) SetUpTest(c *gc.C) {
+	s.AgentSuite.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	s.AgentSuite.SetUpTest(c)
 	s.TestSuite.SetUpTest(c)
 	s.AgentSuite.PatchValue(&charmrepo.CacheDir, c.MkDir())

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -86,6 +86,7 @@ func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 
 	s.BaseSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
+	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
 	s.makeTestEnv(c)
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -55,6 +55,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&envtools.DefaultBaseURL, storageDir)
 	stor, err := filestorage.NewFileStorageWriter(storageDir)
 	c.Assert(err, jc.ErrorIsNil)
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	envtesting.UploadFakeTools(c, stor, "released", "released")
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -310,7 +310,7 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(
 	}
 	stream := "released"
 	if toolsVersion != nil && toolsVersion.Tag != "" {
-		stream = "testing"
+		stream = "devel"
 		currentVersion.Tag = toolsVersion.Tag
 	}
 	_, err := envtesting.UploadFakeToolsVersions(env.storage, stream, stream, toolsBinaries...)

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -134,7 +134,7 @@ func (s *toolsSuite) TestFindBootstrapTools(c *gc.C) {
 			c.Check(findStream, gc.Equals, test.stream)
 		} else {
 			if test.dev || test.version.IsDev() {
-				c.Check(findStream, gc.Equals, "testing")
+				c.Check(findStream, gc.Equals, "devel")
 			} else {
 				c.Check(findStream, gc.Equals, "released")
 			}

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -84,6 +84,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 
 func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.CleanupSuite.SetUpTest(c)
+	t.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	storageDir := c.MkDir()
 	t.DefaultBaseURL = "file://" + storageDir + "/tools"
 	t.ToolsFixture.SetUpTest(c)

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -18,6 +18,7 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type OpenSuite struct {
@@ -38,6 +39,7 @@ func (s *OpenSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
+	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
 	// matches *Settings.Map()
 	cfg, err := config.New(config.NoDefaults, dummySampleConfig())
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -92,11 +92,7 @@ func SyncTools(syncContext *SyncContext) error {
 		// We now store the tools in a directory named after their stream, but the
 		// legacy behaviour is to store all tools in a single "releases" directory.
 		toolsDir = envtools.LegacyReleaseDirectory
-		if !version.Current.IsDev() {
-			syncContext.Stream = envtools.ReleasedStream
-		} else {
-			syncContext.Stream = envtools.TestingStream
-		}
+		syncContext.Stream = envtools.PreferredStream(&version.Current.Number, false, syncContext.Stream)
 	}
 	sourceTools, err := envtools.FindToolsForCloud(
 		[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{},

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -209,14 +209,19 @@ func convertToolsError(err *error) {
 // PreferredStream returns the tools stream used to search for tools, based
 // on the required version, whether devel mode is required, and any user specified stream.
 func PreferredStream(vers *version.Number, forceDevel bool, stream string) string {
+	// If the use has already nominated a specific stream, we'll use that.
 	if stream != "" && stream != ReleasedStream {
 		return stream
 	}
+	// If we're not upgrading from a known version, we use the
+	// currently running version.
 	if vers == nil {
 		vers = &version.Current.Number
 	}
+	// Devel versions are alpha or beta etc as defined by the version tag.
+	// The user can also force the use of devel streams via config.
 	if forceDevel || vers.IsDev() {
-		return TestingStream
+		return DevelStream
 	}
 	return ReleasedStream
 }

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -63,12 +63,12 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 // Define some boolean parameter values.
 const DoNotAllowRetry = false
 
-// FindTools returns a List containing all tools with a given
+// FindTools returns a List containing all tools in the given stream, with a given
 // major.minor version number available in the cloud instance, filtered by filter.
 // If minorVersion = -1, then only majorVersion is considered.
 // If no *available* tools have the supplied major.minor version number, or match the
 // supplied filter, the function returns a *NotFoundError.
-func FindTools(env environs.Environ, majorVersion, minorVersion int,
+func FindTools(env environs.Environ, majorVersion, minorVersion int, stream string,
 	filter coretools.Filter) (list coretools.List, err error) {
 
 	var cloudSpec simplestreams.CloudSpec
@@ -82,6 +82,7 @@ func FindTools(env environs.Environ, majorVersion, minorVersion int,
 		return nil, fmt.Errorf("cannot find tools without a complete cloud configuration")
 	}
 
+	logger.Infof("findng tools in stream %q", stream)
 	if minorVersion >= 0 {
 		logger.Infof("reading tools with major.minor version %d.%d", majorVersion, minorVersion)
 	} else {
@@ -102,11 +103,6 @@ func FindTools(env environs.Environ, majorVersion, minorVersion int,
 	sources, err := GetMetadataSources(env)
 	if err != nil {
 		return nil, err
-	}
-	stream := env.Config().AgentStream()
-	// For backwards compatibility with the config "development" attribute.
-	if stream == "" || env.Config().Development() {
-		stream = TestingStream
 	}
 	return FindToolsForCloud(sources, cloudSpec, stream, majorVersion, minorVersion, filter)
 }
@@ -171,7 +167,9 @@ func FindExactTools(env environs.Environ, vers version.Number, series string, ar
 		Series: series,
 		Arch:   arch,
 	}
-	availableTools, err := FindTools(env, vers.Major, vers.Minor, filter)
+	stream := PreferredStream(&vers, env.Config().Development(), env.Config().AgentStream())
+	logger.Infof("looking for tools in stream %q", stream)
+	availableTools, err := FindTools(env, vers.Major, vers.Minor, stream, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -206,4 +204,19 @@ func convertToolsError(err *error) {
 	if isToolsError(*err) {
 		*err = errors.NewNotFound(*err, "")
 	}
+}
+
+// PreferredStream returns the tools stream used to search for tools, based
+// on the required version, whether devel mode is required, and any user specified stream.
+func PreferredStream(vers *version.Number, forceDevel bool, stream string) string {
+	if stream != "" && stream != ReleasedStream {
+		return stream
+	}
+	if vers == nil {
+		vers = &version.Current.Number
+	}
+	if forceDevel || vers.IsDev() {
+		return TestingStream
+	}
+	return ReleasedStream
 }

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -159,7 +159,8 @@ func (s *SimpleStreamsToolsSuite) TestFindTools(c *gc.C) {
 		s.reset(c, nil)
 		custom := s.uploadCustom(c, test.custom...)
 		public := s.uploadPublic(c, test.public...)
-		actual, err := envtools.FindTools(s.env, test.major, test.minor, coretools.Filter{})
+		stream := envtools.PreferredStream(&version.Current.Number, s.env.Config().Development(), s.env.Config().AgentStream())
+		actual, err := envtools.FindTools(s.env, test.major, test.minor, stream, coretools.Filter{})
 		if test.err != nil {
 			if len(actual) > 0 {
 				c.Logf(actual.String())
@@ -188,7 +189,7 @@ func (s *SimpleStreamsToolsSuite) TestFindToolsFiltering(c *gc.C) {
 	logger.SetLogLevel(loggo.TRACE)
 
 	_, err := envtools.FindTools(
-		s.env, 1, -1, coretools.Filter{Number: version.Number{Major: 1, Minor: 2, Patch: 3}})
+		s.env, 1, -1, "released", coretools.Filter{Number: version.Number{Major: 1, Minor: 2, Patch: 3}})
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	// This is slightly overly prescriptive, but feel free to change or add
 	// messages. This still helps to ensure that all log messages are
@@ -264,6 +265,64 @@ func (s *SimpleStreamsToolsSuite) TestFindExactTools(c *gc.C) {
 		} else {
 			c.Check(err, jc.Satisfies, errors.IsNotFound)
 		}
+	}
+}
+
+var preferredStreamTests = []struct {
+	explicitVers   string
+	currentVers    string
+	forceDevel     bool
+	streamInConfig string
+	expected       string
+}{{
+	currentVers:    "1.22.0",
+	streamInConfig: "released",
+	expected:       "released",
+}, {
+	currentVers:    "1.22.0",
+	streamInConfig: "testing",
+	expected:       "testing",
+}, {
+	currentVers: "1.22.0",
+	expected:    "released",
+}, {
+	currentVers: "1.22-beta1",
+	expected:    "testing",
+}, {
+	currentVers:    "1.22-beta1",
+	streamInConfig: "released",
+	expected:       "testing",
+}, {
+	currentVers:    "1.22-beta1",
+	streamInConfig: "devel",
+	expected:       "devel",
+}, {
+	currentVers: "1.22.0",
+	forceDevel:  true,
+	expected:    "testing",
+}, {
+	currentVers:  "1.22.0",
+	explicitVers: "1.22-beta1",
+	expected:     "testing",
+}, {
+	currentVers:  "1.22-bta1",
+	explicitVers: "1.22.0",
+	expected:     "released",
+}}
+
+func (s *SimpleStreamsToolsSuite) TestPreferredStream(c *gc.C) {
+	for i, test := range preferredStreamTests {
+		c.Logf("\ntest %d", i)
+		origVers := version.Current
+		version.Current.Number = version.MustParse(test.currentVers)
+		var vers *version.Number
+		if test.explicitVers != "" {
+			v := version.MustParse(test.explicitVers)
+			vers = &v
+		}
+		obtained := envtools.PreferredStream(vers, test.forceDevel, test.streamInConfig)
+		c.Check(obtained, gc.Equals, test.expected)
+		version.Current = origVers
 	}
 }
 

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -280,18 +280,18 @@ var preferredStreamTests = []struct {
 	expected:       "released",
 }, {
 	currentVers:    "1.22.0",
-	streamInConfig: "testing",
-	expected:       "testing",
+	streamInConfig: "devel",
+	expected:       "devel",
 }, {
 	currentVers: "1.22.0",
 	expected:    "released",
 }, {
 	currentVers: "1.22-beta1",
-	expected:    "testing",
+	expected:    "devel",
 }, {
 	currentVers:    "1.22-beta1",
 	streamInConfig: "released",
-	expected:       "testing",
+	expected:       "devel",
 }, {
 	currentVers:    "1.22-beta1",
 	streamInConfig: "devel",
@@ -299,11 +299,11 @@ var preferredStreamTests = []struct {
 }, {
 	currentVers: "1.22.0",
 	forceDevel:  true,
-	expected:    "testing",
+	expected:    "devel",
 }, {
 	currentVers:  "1.22.0",
 	explicitVers: "1.22-beta1",
-	expected:     "testing",
+	expected:     "devel",
 }, {
 	currentVers:  "1.22-bta1",
 	explicitVers: "1.22.0",

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type NewAPIStateSuite struct {
@@ -65,6 +66,7 @@ func (cs *NewAPIStateSuite) TearDownTest(c *gc.C) {
 }
 
 func (cs *NewAPIStateSuite) TestNewAPIState(c *gc.C) {
+	cs.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := envtesting.BootstrapContext(c)
@@ -183,6 +185,7 @@ func (s *NewAPIClientSuite) TestNameDefault(c *gc.C) {
 	// and checking that the connection happens within that
 	// time.
 	s.PatchValue(juju.ProviderConnectDelay, coretesting.LongWait)
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	s.bootstrapEnv(c, coretesting.SampleEnvName, defaultConfigStore(c))
 
 	startTime := time.Now()
@@ -198,6 +201,7 @@ func (s *NewAPIClientSuite) TestNameDefault(c *gc.C) {
 func (s *NewAPIClientSuite) TestNameNotDefault(c *gc.C) {
 	envName := coretesting.SampleCertName + "-2"
 	coretesting.WriteEnvironments(c, coretesting.MultipleEnvConfig, envName)
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	s.bootstrapEnv(c, envName, defaultConfigStore(c))
 	apiclient, err := juju.NewAPIClientFromName(envName)
 	c.Assert(err, jc.ErrorIsNil)
@@ -244,6 +248,7 @@ func (s *NewAPIClientSuite) TestWithInfoOnly(c *gc.C) {
 
 func (s *NewAPIClientSuite) TestWithConfigAndNoInfo(c *gc.C) {
 	c.Skip("not really possible now that there is no defined admin user")
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 
 	store := newConfigStore(coretesting.SampleEnvName, &environInfo{
@@ -515,6 +520,7 @@ func (s *NewAPIClientSuite) TestWithInfoAPIOpenError(c *gc.C) {
 }
 
 func (s *NewAPIClientSuite) TestWithSlowInfoConnect(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 	store := configstore.NewMem()
 	s.bootstrapEnv(c, coretesting.SampleEnvName, store)
@@ -600,6 +606,7 @@ func setEndpointAddressAndHostname(c *gc.C, store configstore.Storage, envName s
 }
 
 func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 
 	store := configstore.NewMem()
@@ -670,6 +677,7 @@ func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
 }
 
 func (s *NewAPIClientSuite) TestBothError(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 	store := configstore.NewMem()
 	s.bootstrapEnv(c, coretesting.SampleEnvName, store)
@@ -694,6 +702,7 @@ func defaultConfigStore(c *gc.C) configstore.Storage {
 }
 
 func (s *NewAPIClientSuite) TestWithBootstrapConfigAndNoEnvironmentsFile(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 	store := configstore.NewMem()
 	s.bootstrapEnv(c, coretesting.SampleEnvName, store)
@@ -714,6 +723,7 @@ func (s *NewAPIClientSuite) TestWithBootstrapConfigAndNoEnvironmentsFile(c *gc.C
 }
 
 func (s *NewAPIClientSuite) TestWithBootstrapConfigTakesPrecedence(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	// We want to make sure that the code is using the bootstrap
 	// config rather than information from environments.yaml,
 	// even when there is an entry in environments.yaml

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -247,10 +247,10 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.PatchValue(&tools.DefaultBaseURL, s.DefaultToolsStorageDir)
 	stor, err := filestorage.NewFileStorageWriter(s.DefaultToolsStorageDir)
 	c.Assert(err, jc.ErrorIsNil)
-	// Upload tools to both release and testing streams since config will dictate that we
+	// Upload tools to both release and devel streams since config will dictate that we
 	// end up looking in both places.
 	envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", versions...)
-	envtesting.AssertUploadFakeToolsVersions(c, stor, "testing", "testing", versions...)
+	envtesting.AssertUploadFakeToolsVersions(c, stor, "devel", "devel", versions...)
 	s.DefaultToolsStorage = stor
 
 	err = bootstrap.Bootstrap(envcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{})

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -247,7 +247,10 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.PatchValue(&tools.DefaultBaseURL, s.DefaultToolsStorageDir)
 	stor, err := filestorage.NewFileStorageWriter(s.DefaultToolsStorageDir)
 	c.Assert(err, jc.ErrorIsNil)
+	// Upload tools to both release and testing streams since config will dictate that we
+	// end up looking in both places.
 	envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", versions...)
+	envtesting.AssertUploadFakeToolsVersions(c, stor, "testing", "testing", versions...)
 	s.DefaultToolsStorage = stor
 
 	err = bootstrap.Bootstrap(envcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{})

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -169,7 +169,8 @@ func StartInstanceWithParams(
 	if params.Constraints.Arch != nil {
 		filter.Arch = *params.Constraints.Arch
 	}
-	possibleTools, err := tools.FindTools(env, -1, -1, filter)
+	stream := tools.PreferredStream(&agentVersion, env.Config().Development(), env.Config().AgentStream())
+	possibleTools, err := tools.FindTools(env, -1, -1, stream, filter)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -80,6 +80,7 @@ func configGetter(c *gc.C) configFunc {
 }
 
 func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	checkPlacement := "directive"
 	checkCons := constraints.MustParse("mem=8G")
 	env := &mockEnviron{
@@ -124,6 +125,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestSuccess(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	stor := newStorage(s, c)
 	checkInstanceId := "i-success"
 	checkHardware := instance.MustParseHardware("arch=ppc64el mem=2T")

--- a/provider/common/destroy_test.go
+++ b/provider/common/destroy_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/storage/provider/registry"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type DestroySuite struct {
@@ -83,6 +84,7 @@ func (s *DestroySuite) TestSuccessWhenStorageErrors(c *gc.C) {
 }
 
 func (s *DestroySuite) TestSuccess(c *gc.C) {
+	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
 	stor := newStorage(s, c)
 	err := stor.Put("somewhere", strings.NewReader("stuff"), 5)
 	c.Assert(err, jc.ErrorIsNil)
@@ -111,6 +113,7 @@ func (s *DestroySuite) TestSuccess(c *gc.C) {
 }
 
 func (s *DestroySuite) TestSuccessWhenNoInstances(c *gc.C) {
+	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
 	stor := newStorage(s, c)
 	err := stor.Put("elsewhere", strings.NewReader("stuff"), 5)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 func TestPackage(t *stdtesting.T) {
@@ -97,6 +98,7 @@ func (s *suite) TearDownSuite(c *gc.C) {
 func (s *suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.SetFeatureFlags(feature.AddressAllocation)
+	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
 	s.MgoSuite.SetUpTest(c)
 	s.Tests.SetUpTest(c)
 }

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -76,14 +76,14 @@ func (s *ebsVolumeSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *ebsVolumeSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-	s.srv.startServer(c)
-	s.Tests.SetUpTest(c)
 	s.PatchValue(&version.Current, version.Binary{
-		Number: version.Current.Number,
+		Number: testing.FakeVersionNumber,
 		Series: testing.FakeDefaultSeries,
 		Arch:   arch.AMD64,
 	})
+	s.BaseSuite.SetUpTest(c)
+	s.srv.startServer(c)
+	s.Tests.SetUpTest(c)
 	s.PatchValue(&ec2.DestroyVolumeAttempt.Delay, time.Duration(0))
 }
 

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -54,7 +54,7 @@ func registerAmazonTests() {
 		"control-bucket": "juju-test-" + uniqueName,
 		"admin-secret":   "for real",
 		"firewall-mode":  config.FwInstance,
-		"agent-version":  version.Current.Number.String(),
+		"agent-version":  coretesting.FakeVersionNumber.String(),
 	})
 	gc.Suite(&LiveTests{
 		LiveTests: jujutest.LiveTests{
@@ -87,13 +87,13 @@ func (t *LiveTests) TearDownSuite(c *gc.C) {
 }
 
 func (t *LiveTests) SetUpTest(c *gc.C) {
-	t.BaseSuite.SetUpTest(c)
-	t.LiveTests.SetUpTest(c)
 	t.BaseSuite.PatchValue(&version.Current, version.Binary{
-		Number: version.Current.Number,
+		Number: coretesting.FakeVersionNumber,
 		Series: coretesting.FakeDefaultSeries,
 		Arch:   arch.AMD64,
 	})
+	t.BaseSuite.SetUpTest(c)
+	t.LiveTests.SetUpTest(c)
 }
 
 func (t *LiveTests) TearDownTest(c *gc.C) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -56,7 +56,7 @@ var localConfigAttrs = coretesting.FakeConfig().Merge(coretesting.Attrs{
 	"control-bucket": "test-bucket",
 	"access-key":     "x",
 	"secret-key":     "x",
-	"agent-version":  version.Current.Number.String(),
+	"agent-version":  coretesting.FakeVersionNumber.String(),
 })
 
 func registerLocalTests() {
@@ -191,15 +191,15 @@ func (t *localServerSuite) TearDownSuite(c *gc.C) {
 }
 
 func (t *localServerSuite) SetUpTest(c *gc.C) {
+	t.PatchValue(&version.Current, version.Binary{
+		Number: coretesting.FakeVersionNumber,
+		Series: coretesting.FakeDefaultSeries,
+		Arch:   arch.AMD64,
+	})
 	t.BaseSuite.SetUpTest(c)
 	t.SetFeatureFlags(feature.AddressAllocation)
 	t.srv.startServer(c)
 	t.Tests.SetUpTest(c)
-	t.PatchValue(&version.Current, version.Binary{
-		Number: version.Current.Number,
-		Series: coretesting.FakeDefaultSeries,
-		Arch:   arch.AMD64,
-	})
 }
 
 func (t *localServerSuite) TearDownTest(c *gc.C) {

--- a/provider/joyent/joyent_test.go
+++ b/provider/joyent/joyent_test.go
@@ -14,7 +14,6 @@ import (
 
 	envtesting "github.com/juju/juju/environs/testing"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 const (
@@ -92,7 +91,7 @@ func GetFakeConfig(sdcUrl, mantaUrl string) coretesting.Attrs {
 		"private-key-path": fmt.Sprintf("~/.ssh/%s", testKeyFileName),
 		"algorithm":        "rsa-sha256",
 		"control-dir":      "juju-test",
-		"agent-version":    version.Current.Number.String(),
+		"agent-version":    coretesting.FakeVersionNumber.String(),
 	})
 }
 

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/joyent"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 func registerLocalTests() {
@@ -119,6 +120,7 @@ func (s *localLiveSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *localLiveSuite) SetUpTest(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	s.providerSuite.SetUpTest(c)
 	creds := joyent.MakeCredentials(c, s.TestConfig)
 	joyent.UseExternalTestImageMetadata(creds)
@@ -152,6 +154,7 @@ func (s *localServerSuite) SetUpSuite(c *gc.C) {
 func (s *localServerSuite) SetUpTest(c *gc.C) {
 	s.providerSuite.SetUpTest(c)
 
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	s.cSrv = &localCloudAPIServer{}
 	s.mSrv = &localMantaServer{}
 	s.cSrv.setupServer(c)

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/service/common"
 	svctesting "github.com/juju/juju/service/common/testing"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -114,6 +115,7 @@ type localJujuTestSuite struct {
 
 func (s *localJujuTestSuite) SetUpTest(c *gc.C) {
 	s.baseProviderSuite.SetUpTest(c)
+	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
 	// Construct the directories first.
 	err := local.CreateDirs(c, minimalConfig(c))
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -14,6 +14,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 // Ensure maasEnviron supports environs.NetworkingEnviron.
@@ -43,6 +44,7 @@ func (s *providerSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *providerSuite) SetUpTest(c *gc.C) {
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	s.SetFeatureFlags(feature.AddressAllocation)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -77,7 +77,7 @@ func registerLocalTests() {
 		TenantName: "some tenant",
 	}
 	config := makeTestConfig(cred)
-	config["agent-version"] = version.Current.Number.String()
+	config["agent-version"] = coretesting.FakeVersionNumber.String()
 	config["authorized-keys"] = "fakekey"
 	gc.Suite(&localLiveSuite{
 		LiveTests: LiveTests{
@@ -229,6 +229,7 @@ func (s *localServerSuite) SetUpTest(c *gc.C) {
 		"image-metadata-url": containerURL + "/juju-dist-test",
 		"auth-url":           s.cred.URL,
 	})
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	s.Tests.SetUpTest(c)
 	// For testing, we create a storage instance to which is uploaded tools and image metadata.
 	s.env = s.Prepare(c)
@@ -1123,7 +1124,7 @@ func (s *localHTTPSServerSuite) SetUpSuite(c *gc.C) {
 
 func (s *localHTTPSServerSuite) createConfigAttrs(c *gc.C) map[string]interface{} {
 	attrs := makeTestConfig(s.cred)
-	attrs["agent-version"] = version.Current.Number.String()
+	attrs["agent-version"] = coretesting.FakeVersionNumber.String()
 	attrs["authorized-keys"] = "fakekey"
 	// In order to set up and tear down the environment properly, we must
 	// disable hostname verification
@@ -1145,6 +1146,7 @@ func (s *localHTTPSServerSuite) createConfigAttrs(c *gc.C) map[string]interface{
 
 func (s *localHTTPSServerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	s.srv.UseTLS = true
 	cred := &identity.Credentials{
 		User:       "fred",
@@ -1754,10 +1756,10 @@ func (s *noSwiftSuite) SetUpTest(c *gc.C) {
 		"region":          s.cred.Region,
 		"auth-url":        s.cred.URL,
 		"tenant-name":     s.cred.TenantName,
-		"agent-version":   version.Current.Number.String(),
+		"agent-version":   coretesting.FakeVersionNumber.String(),
 		"authorized-keys": "fakekey",
 	})
-
+	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
 	// Serve fake tools and image metadata using "filestorage",
 	// rather than Swift as the rest of the tests do.
 	storageDir := c.MkDir()

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/utils/ssh"
+	"github.com/juju/juju/version"
 )
 
 // FakeAuthKeys holds the authorized key used for testing
@@ -31,6 +32,9 @@ func init() {
 }
 
 const FakeDefaultSeries = "trusty"
+
+// FakeVersionNumber is a valid version number that can be used in testing.
+var FakeVersionNumber = version.MustParse("1.99.0")
 
 // EnvironmentTag is a defined known valid UUID that can be used in testing.
 var EnvironmentTag = names.NewEnvironTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -518,7 +518,7 @@ func (s *ProvisionerSuite) TestPossibleTools(c *gc.C) {
 	envtesting.AssertUploadFakeToolsVersions(c, stor, s.cfg.AgentStream(), s.cfg.AgentStream(), availableVersions...)
 
 	// Extract the tools that we expect to actually match.
-	expectedList, err := tools.FindTools(s.Environ, -1, -1, coretools.Filter{
+	expectedList, err := tools.FindTools(s.Environ, -1, -1, s.cfg.AgentStream(), coretools.Filter{
 		Number: currentVersion.Number,
 		Series: currentVersion.Series,
 	})


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1481500

We want to ship Juju 1.25 with wily in main.
We also want to release beta versions of Juju leading up to the wily release.
People should be able to deploy these beta Juju releases out of the box. This means that there should be no extra configuration necessary to bootstrap. However, beta tools are not published to released streams, only to devel. So we want to change Juju's tools search so that if the version asked for is a beta release, it looks automatically in a non release stream. ie "devel"

Tested live with AWS - an environment could be bootstrapped using beta tools with no additional config changes.

(Review request: http://reviews.vapour.ws/r/2340/)