### PR TITLE
provider/ec2: don't attach volumes initially

### DIFF
--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -546,6 +546,9 @@ func (s *ebsVolumeSuite) TestAttachVolumes(c *gc.C) {
 	})
 }
 
+// TODO(axw) add tests for attempting to attach while
+// a volume is still in the "creating" state.
+
 func (s *ebsVolumeSuite) TestDetachVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)


### PR DESCRIPTION
Change CreateVolumes to not attach volumes initially,
but instead defer to AttachVolumes. This allows the
volume to stay in "creating" arbitrarily long without
failing the CreateVolumes call; AttachVolumes will
then be retried until the volume is in the "available"
state.

Also, fix a bug in DescribeVolumes to do with
identifying whether or not a volume is persistent.

Fixes https://bugs.launchpad.net/juju-core/+bug/1479546

(Review request: http://reviews.vapour.ws/r/2341/)