### PR TITLE
state: volumes shouldn't prevent destroy-env

### DIFF
--- a/state/environ.go
+++ b/state/environ.go
@@ -386,12 +386,12 @@ func checkManualMachines(machines []*Machine) error {
 // found.
 func (e *Environment) ensureDestroyable() error {
 
-	// TODO(waigani) bug #1475212: Environment destroy can miss manual machines and
-	// persistent volumes. We need to be able to assert the absence of these
-	// as part of the destroy txn, but in order to do this  manual machines
-	// and persistent volumes need to add refcounts to their environments.
+	// TODO(waigani) bug #1475212: Environment destroy can miss manual
+	// machines. We need to be able to assert the absence of these as
+	// part of the destroy txn, but in order to do this  manual machines
+	// need to add refcounts to their environments.
 
-	// First, check for manual machines. We bail out if there are any,
+	// Check for manual machines. We bail out if there are any,
 	// to stop the user from prematurely hobbling the environment.
 	machines, err := e.st.AllMachines()
 	if err != nil {
@@ -402,14 +402,6 @@ func (e *Environment) ensureDestroyable() error {
 		return errors.Trace(err)
 	}
 
-	// If there are any persistent volumes, the environment can't be destroyed.
-	volumes, err := e.st.PersistentVolumes()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(volumes) > 0 {
-		return ErrPersistentVolumesExist
-	}
 	return nil
 }
 

--- a/state/storage.go
+++ b/state/storage.go
@@ -23,11 +23,6 @@ import (
 	"github.com/juju/juju/storage/provider/registry"
 )
 
-var ErrPersistentVolumesExist = errors.New(`
-Environment cannot be destroyed until all persistent volumes have been destroyed.
-Run "juju storage list" to display persistent storage volumes.
-`[1:])
-
 // StorageInstance represents the state of a unit or service-wide storage
 // instance in the environment.
 type StorageInstance interface {

--- a/state/volume.go
+++ b/state/volume.go
@@ -306,15 +306,6 @@ func volumesToInterfaces(volumes []*volume) []Volume {
 	return result
 }
 
-// PersistentVolumes returns any alive persistent Volumes scoped to the environment or any machine.
-func (st *State) PersistentVolumes() ([]Volume, error) {
-	volumes, err := st.volumes(bson.D{{"info.persistent", true}})
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get persistent volumes")
-	}
-	return volumesToInterfaces(volumes), nil
-}
-
 func (st *State) storageInstanceVolume(tag names.StorageTag) (*volume, error) {
 	return st.volume(
 		bson.D{{"storageid", tag.Id()}},


### PR DESCRIPTION
Some time ago we added code to prevent destroy-environment
from succeeding if any persistent volumes were present in
the environment. This was necessary to prevent (except
through use of --force) leaking persistent volumes.

This is no longer necessary, as we now destroy all volumes
in the environment via env.Destroy().

(Review request: http://reviews.vapour.ws/r/2342/)