### PR TITLE
Implement AllSpaces for "space list" command.

### DIFF
--- a/apiserver/common/networking.go
+++ b/apiserver/common/networking.go
@@ -21,6 +21,7 @@ type BackingSubnet interface {
 	ProviderId() string
 	AvailabilityZones() []string
 	Status() string
+	SpaceName() string
 }
 
 // BackingSubnetInfo describes a single subnet to be added in the

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -308,6 +308,10 @@ func (f *FakeSubnet) VLANTag() int {
 	return f.info.VLANTag
 }
 
+func (f *FakeSubnet) SpaceName() string {
+	return f.info.SpaceName
+}
+
 // ResetStub resets all recorded calls and errors of the given stub.
 func ResetStub(stub *testing.Stub) {
 	*stub = testing.Stub{}

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -110,6 +110,12 @@ func (st *State) AddSpace(name string, subnets []string, isPublic bool) (newSpac
 		if _, err = st.Space(name); err == nil {
 			return nil, errors.AlreadyExistsf("space %q", name)
 		}
+		for _, subnetId := range subnets {
+			_, err := st.Subnet(subnetId)
+			if errors.IsNotFound(err) {
+				return nil, err
+			}
+		}
 	}
 	return newSpace, errors.Trace(err)
 }

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -99,6 +99,23 @@ func (st *State) Space(name string) (*Space, error) {
 	return &Space{st, doc}, nil
 }
 
+// AllSpaces returns all spaces from state.
+func (st *State) AllSpaces() ([]*Space, error) {
+	spacesCollection, closer := st.getCollection(spacesC)
+	defer closer()
+
+	docs := []spaceDoc{}
+	var spaces []*Space
+	err := spacesCollection.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get all spaces")
+	}
+	for _, doc := range docs {
+		spaces = append(spaces, &Space{st: st, doc: doc})
+	}
+	return spaces, nil
+}
+
 // EnsureDead sets the Life of the space to Dead, if it's Alive. It
 // does nothing otherwise.
 func (s *Space) EnsureDead() (err error) {

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -195,3 +195,9 @@ func (s *SpacesSuite) TestSpaceSubnets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actual, jc.DeepEquals, expected)
 }
+
+func (s *SpacesSuite) TestAllSpaces(c *gc.C) {
+	spaces, err := s.State.AllSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spaces, jc.DeepEquals, []*state.Space{})
+}

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -200,4 +200,26 @@ func (s *SpacesSuite) TestAllSpaces(c *gc.C) {
 	spaces, err := s.State.AllSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spaces, jc.DeepEquals, []*state.Space{})
+
+	subnets := []string{"1.1.1.0/24", "2.1.1.0/24", "3.1.1.0/24"}
+	isPublic := false
+	s.addSubnets(c, subnets)
+
+	_, err = s.State.AddSpace("first", []string{"1.1.1.0/24"}, isPublic)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("second", []string{"2.1.1.0/24"}, isPublic)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("third", []string{"3.1.1.0/24"}, isPublic)
+	c.Assert(err, jc.ErrorIsNil)
+
+	first, err := s.State.Space("first")
+	c.Assert(err, jc.ErrorIsNil)
+	second, err := s.State.Space("second")
+	c.Assert(err, jc.ErrorIsNil)
+	third, err := s.State.Space("third")
+	c.Assert(err, jc.ErrorIsNil)
+
+	actual, err := s.State.AllSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actual, jc.SameContents, []*state.Space{first, second, third})
 }

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -65,7 +65,7 @@ func (s *SpacesSuite) assertNoSpace(c *gc.C, name string) {
 }
 
 func assertSpace(c *gc.C, space *state.Space, name string, subnets []string, isPublic bool) {
-	c.Assert(state.SpaceDoc(space).Name, gc.Equals, name)
+	c.Assert(space.Name(), gc.Equals, name)
 	actualSubnets, err := space.Subnets()
 	c.Assert(err, jc.ErrorIsNil)
 	actualSubnetIds := make([]string, len(actualSubnets))

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -175,3 +175,23 @@ func (s *SpacesSuite) TestAddSpaceEmptyName(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot add space \"\": invalid space name")
 	s.assertNoSpace(c, name)
 }
+
+func (s *SpacesSuite) TestSpaceSubnets(c *gc.C) {
+	name := "my-space"
+	subnets := []string{"1.1.1.0/24", "2.1.1.0/24", "3.1.1.0/24", "4.1.1.0/24", "5.1.1.0/24"}
+	isPublic := false
+	s.addSubnets(c, subnets)
+
+	space, err := s.State.AddSpace(name, subnets, isPublic)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := []*state.Subnet{}
+	for _, cidr := range subnets {
+		subnet, err := s.State.Subnet(cidr)
+		c.Assert(err, jc.ErrorIsNil)
+		expected = append(expected, subnet)
+	}
+	actual, err := space.Subnets()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actual, jc.DeepEquals, expected)
+}

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -66,7 +66,9 @@ func (s *SpacesSuite) assertNoSpace(c *gc.C, name string) {
 
 func assertSpace(c *gc.C, space *state.Space, name string, subnets []string, isPublic bool) {
 	c.Assert(state.SpaceDoc(space).Name, gc.Equals, name)
-	c.Assert(state.SpaceDoc(space).Subnets, jc.DeepEquals, subnets)
+	err, actualSubnets := space.Subnets()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actualSubnets, jc.SameContents, subnets)
 	c.Assert(state.SpaceDoc(space).IsPublic, gc.Equals, isPublic)
 
 	c.Assert(space.Life(), gc.Equals, state.Alive)

--- a/state/state.go
+++ b/state/state.go
@@ -1217,6 +1217,7 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 		AllocatableIPHigh: args.AllocatableIPHigh,
 		AllocatableIPLow:  args.AllocatableIPLow,
 		AvailabilityZone:  args.AvailabilityZone,
+		SpaceName:         args.SpaceName,
 	}
 	subnet = &Subnet{doc: subDoc, st: st}
 	err = subnet.Validate()

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -57,6 +57,7 @@ type subnetDoc struct {
 	AvailabilityZone  string `bson:"availabilityzone,omitempty"`
 	IsPublic          bool   `bson:"is-public",omitempty`
 	// TODO(dooferlad 2015-08-03): add an upgrade step to insert IsPublic=false
+	SpaceName string `bson:"space-name",omitempty`
 }
 
 // Life returns whether the subnet is Alive, Dying or Dead.

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -38,6 +38,10 @@ type SubnetInfo struct {
 	// AvailabilityZone describes which availability zone this subnet is in. It can
 	// be empty if the provider does not support availability zones.
 	AvailabilityZone string
+
+	// SpaceName is the name of the space the subnet is associated with. It
+	// can be empty if the subnet is in the default space.
+	SpaceName string
 }
 
 type Subnet struct {

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -175,6 +175,12 @@ func (s *Subnet) AvailabilityZone() string {
 	return s.doc.AvailabilityZone
 }
 
+// SpaceName returns the space the subnet is associated with. If the subnet is
+// in the default space it will be the empty string.
+func (s *Subnet) SpaceName() string {
+	return s.doc.SpaceName
+}
+
 // Validate validates the subnet, checking the CIDR, VLANTag and
 // AllocatableIPHigh and Low, if present.
 func (s *Subnet) Validate() error {

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -30,6 +30,7 @@ func (s *SubnetSuite) TestAddSubnet(c *gc.C) {
 		AllocatableIPLow:  "192.168.1.0",
 		AllocatableIPHigh: "192.168.1.1",
 		AvailabilityZone:  "Timbuktu",
+		SpaceName:         "foo",
 	}
 
 	assertSubnet := func(subnet *state.Subnet) {
@@ -41,6 +42,7 @@ func (s *SubnetSuite) TestAddSubnet(c *gc.C) {
 		c.Assert(subnet.AvailabilityZone(), gc.Equals, "Timbuktu")
 		c.Assert(subnet.String(), gc.Equals, "192.168.1.0/24")
 		c.Assert(subnet.GoString(), gc.Equals, "192.168.1.0/24")
+		c.Assert(subnet.SpaceName(), gc.Equals, "foo")
 	}
 
 	subnet, err := s.State.AddSubnet(subnetInfo)


### PR DESCRIPTION
Implements AllSpaces on state, used by the "space list" command.

As part of this state.Space needs a Subnets method that returns all subnets associated with the space. This required changes to both spaces and subnets.

The requirement that all spaces have at least one subnet has been dropped. This will need more work in the CLI/API to complete.

(Review request: http://reviews.vapour.ws/r/2344/)