### PR TITLE
provider/ec2: fix DescribeVolumes

### DIFF
--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -342,13 +342,12 @@ func (s *ebsVolumeSuite) TestDestroyVolumesStillAttached(c *gc.C) {
 	c.Assert(ec2Vols.Volumes[0].Size, gc.Equals, 20)
 }
 
-func (s *ebsVolumeSuite) TestVolumes(c *gc.C) {
+func (s *ebsVolumeSuite) TestDescribeVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	s.assertCreateVolumes(c, vs, "")
 
 	vols, err := vs.DescribeVolumes([]string{"vol-0", "vol-1"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(vols, gc.HasLen, 2)
 	c.Assert(vols, jc.DeepEquals, []storage.DescribeVolumesResult{{
 		VolumeInfo: &storage.VolumeInfo{
 			Size:       10240,
@@ -362,6 +361,14 @@ func (s *ebsVolumeSuite) TestVolumes(c *gc.C) {
 			Persistent: true,
 		},
 	}})
+}
+
+func (s *ebsVolumeSuite) TestDescribeVolumesNotFound(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+	vols, err := vs.DescribeVolumes([]string{"vol-42"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vols, gc.HasLen, 1)
+	c.Assert(vols[0].Error, gc.ErrorMatches, "vol-42 not found")
 }
 
 func (s *ebsVolumeSuite) TestListVolumes(c *gc.C) {


### PR DESCRIPTION
Don't rely on the results being in the same
order as the volume IDs passed in, and don't
rely on there being the same number of results
as args.

(Review request: http://reviews.vapour.ws/r/2347/)