### PR TITLE
Undo workaround for golang/go#10628

### DIFF
--- a/apiserver/agent/agent_v0.go
+++ b/apiserver/agent/agent_v0.go
@@ -83,12 +83,6 @@ func (api *AgentAPIV0) getEntity(tag names.Tag) (result params.AgentGetEntitiesR
 	return
 }
 
-// work around golang.org/issue/10628
-
-func (api *AgentAPIV1) StateServingInfo() (result state.StateServingInfo, err error) {
-	return api.AgentAPIV0.StateServingInfo()
-}
-
 func (api *AgentAPIV0) StateServingInfo() (result state.StateServingInfo, err error) {
 	if !api.auth.AuthEnvironManager() {
 		err = common.ErrPerm

--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -249,12 +249,6 @@ func (info *environInfo) APICredentials() APICredentials {
 	}
 }
 
-// work around golang.org/issue/10628
-
-func (info *memInfo) APIEndpoint() APIEndpoint {
-	return info.environInfo.APIEndpoint()
-}
-
 // APIEndpoint implements EnvironInfo.APIEndpoint.
 func (info *environInfo) APIEndpoint() APIEndpoint {
 	info.mu.Lock()


### PR DESCRIPTION
Undo the workaround for golang/go#10628 now that the fix is available upstream.

(Review request: http://reviews.vapour.ws/r/2348/)