### PR TITLE
storage: add volume status, use in storageprovisioner

### DIFF
--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -455,3 +455,13 @@ func (st *State) InstanceIds(tags []names.MachineTag) ([]params.StringResult, er
 	}
 	return results.Results, nil
 }
+
+// SetStatus sets the status of storage entities.
+func (st *State) SetStatus(args []params.EntityStatus) error {
+	var result params.ErrorResults
+	err := st.facade.FacadeCall("SetStatus", params.SetStatus{args}, &result)
+	if err != nil {
+		return err
+	}
+	return result.Combine()
+}

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -326,3 +326,22 @@ const (
 	// been asked to offer.
 	StatusActive Status = "active"
 )
+
+const (
+	// Status values specific to storage.
+
+	// StatusAttaching indicates that the storage is being attached
+	// to a machine.
+	StatusAttaching Status = "attaching"
+
+	// StatusAttached indicates that the storage is attached to a
+	// machine.
+	StatusAttached Status = "attached"
+
+	// StatusDetaching indicates that the storage is being detached
+	// from a machine.
+	StatusDetaching Status = "detaching"
+
+	// StatusDestroying indicates that the storage is being destroyed.
+	StatusDestroying Status = "destroying"
+)

--- a/apiserver/storageprovisioner/storageprovisioner.go
+++ b/apiserver/storageprovisioner/storageprovisioner.go
@@ -28,6 +28,7 @@ type StorageProvisionerAPI struct {
 	*common.DeadEnsurer
 	*common.EnvironWatcher
 	*common.InstanceIdGetter
+	*common.StatusSetter
 
 	st                       provisionerState
 	settings                 poolmanager.SettingsManager
@@ -164,6 +165,7 @@ func NewStorageProvisionerAPI(st *state.State, resources *common.Resources, auth
 		DeadEnsurer:      common.NewDeadEnsurer(stateInterface, getStorageEntityAuthFunc),
 		EnvironWatcher:   common.NewEnvironWatcher(stateInterface, resources, authorizer),
 		InstanceIdGetter: common.NewInstanceIdGetter(st, getMachineAuthFunc),
+		StatusSetter:     common.NewStatusSetter(st, getStorageEntityAuthFunc),
 
 		st:                       stateInterface,
 		settings:                 settings,

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -785,7 +785,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		api := st.StorageProvisioner(scope)
 		storageDir := filepath.Join(agentConfig.DataDir(), "storage")
 		return newStorageWorker(
-			scope, storageDir, api, api, api, api, api,
+			scope, storageDir, api, api, api, api, api, api,
 			clock.WallClock,
 		), nil
 	})
@@ -1144,7 +1144,7 @@ func (a *MachineAgent) startEnvWorkers(
 		scope := st.EnvironTag()
 		api := apiSt.StorageProvisioner(scope)
 		return newStorageWorker(
-			scope, "", api, api, api, api, api,
+			scope, "", api, api, api, api, api, api,
 			clock.WallClock,
 		), nil
 	})

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1432,6 +1432,7 @@ func (s *MachineSuite) TestMachineAgentRunsMachineStorageWorker(c *gc.C) {
 		_ storageprovisioner.LifecycleManager,
 		_ storageprovisioner.EnvironAccessor,
 		_ storageprovisioner.MachineAccessor,
+		_ storageprovisioner.StatusSetter,
 		_ clock.Clock,
 	) worker.Worker {
 		c.Check(scope, gc.Equals, m.Tag())
@@ -1468,6 +1469,7 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 		_ storageprovisioner.LifecycleManager,
 		_ storageprovisioner.EnvironAccessor,
 		_ storageprovisioner.MachineAccessor,
+		_ storageprovisioner.StatusSetter,
 		_ clock.Clock,
 	) worker.Worker {
 		// storageDir is empty for environ storage provisioners
@@ -1852,6 +1854,7 @@ func (s *MachineSuite) TestNewStorageWorkerIsScopedToNewEnviron(c *gc.C) {
 		_ storageprovisioner.LifecycleManager,
 		_ storageprovisioner.EnvironAccessor,
 		_ storageprovisioner.MachineAccessor,
+		_ storageprovisioner.StatusSetter,
 		_ clock.Clock,
 	) worker.Worker {
 		// storageDir is empty for environ storage provisioners

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -548,11 +548,11 @@ func (st *State) machineStorageOps(
 
 	// Create volumes and volume attachments.
 	for _, v := range args.volumes {
-		op, tag, err := st.addVolumeOp(v.Volume, mdoc.Id)
+		ops, tag, err := st.addVolumeOps(v.Volume, mdoc.Id)
 		if err != nil {
 			return nil, nil, nil, errors.Trace(err)
 		}
-		volumeOps = append(volumeOps, op)
+		volumeOps = append(volumeOps, ops...)
 		volumeAttachments = append(volumeAttachments, volumeAttachmentTemplate{
 			tag, v.Attachment,
 		})

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -50,7 +50,7 @@ var (
 	CurrentUpgradeId       = currentUpgradeId
 	NowToTheSecond         = nowToTheSecond
 	PickAddress            = &pickAddress
-	AddVolumeOp            = (*State).addVolumeOp
+	AddVolumeOps           = (*State).addVolumeOps
 	CombineMeterStatus     = combineMeterStatus
 )
 

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -715,19 +715,19 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 		return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Trace(err)
 	}
 	if !provider.Supports(storage.StorageKindFilesystem) {
-		var volumeOp txn.Op
+		var volumeOps []txn.Op
 		volumeParams := VolumeParams{
 			params.storage,
 			filesystemTag, // volume is bound to filesystem
 			params.Pool,
 			params.Size,
 		}
-		volumeOp, volumeTag, err = st.addVolumeOp(volumeParams, machineId)
+		volumeOps, volumeTag, err = st.addVolumeOps(volumeParams, machineId)
 		if err != nil {
 			return nil, names.FilesystemTag{}, names.VolumeTag{}, errors.Annotate(err, "creating backing volume")
 		}
 		volumeId = volumeTag.Id()
-		ops = append(ops, volumeOp)
+		ops = append(ops, volumeOps...)
 	}
 
 	filesystemOp := txn.Op{

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -15,7 +15,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
@@ -1088,9 +1087,9 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 }
 
 func (s *MachineSuite) addVolume(c *gc.C, params state.VolumeParams, machineId string) names.VolumeTag {
-	op, tag, err := state.AddVolumeOp(s.State, params, machineId)
+	ops, tag, err := state.AddVolumeOps(s.State, params, machineId)
 	c.Assert(err, jc.ErrorIsNil)
-	err = state.RunTransaction(s.State, []txn.Op{op})
+	err = state.RunTransaction(s.State, ops)
 	c.Assert(err, jc.ErrorIsNil)
 	return tag
 }

--- a/state/status.go
+++ b/state/status.go
@@ -174,7 +174,7 @@ func createStatusOp(st *State, globalKey string, doc statusDoc) txn.Op {
 		C:      statusesC,
 		Id:     st.docID(globalKey),
 		Assert: txn.DocMissing,
-		Insert: doc,
+		Insert: &doc,
 	}
 }
 

--- a/state/status_model.go
+++ b/state/status_model.go
@@ -12,7 +12,7 @@ import (
 // very clear reason.
 //
 // Status values currently apply to machine (agents), unit (agents), unit
-// (workloads) and service (workloads).
+// (workloads), service (workloads), and volumes.
 type Status string
 
 // StatusInfo holds a Status and associated information.
@@ -129,6 +129,23 @@ const (
 	// The unit believes it is correctly offering all the services it has
 	// been asked to offer.
 	StatusActive Status = "active"
+)
+
+// Status values specific to storage.
+const (
+	// StatusAttaching indicates that the storage is being attached to a
+	// machine.
+	StatusAttaching Status = "attaching"
+
+	// StatusDetaching indicates that the storage is attached to a machine.
+	StatusAttached Status = "attached"
+
+	// StatusDetaching indicates that the storage is being detached
+	// from a machine.
+	StatusDetaching Status = "detaching"
+
+	// StatusDestroying indicates that the storage is being destroyed.
+	StatusDestroying Status = "destroying"
 )
 
 const (

--- a/state/status_volume_test.go
+++ b/state/status_volume_test.go
@@ -1,0 +1,157 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+)
+
+type VolumeStatusSuite struct {
+	StorageStateSuiteBase
+	machine *state.Machine
+	volume  state.Volume
+}
+
+var _ = gc.Suite(&VolumeStatusSuite{})
+
+func (s *VolumeStatusSuite) SetUpTest(c *gc.C) {
+	s.StorageStateSuiteBase.SetUpTest(c)
+
+	machine, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Volumes: []state.MachineVolumeParams{{
+			Volume: state.VolumeParams{
+				Pool: "environscoped", Size: 1024,
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	volumeAttachments, err := machine.VolumeAttachments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volumeAttachments, gc.HasLen, 1)
+
+	volume, err := s.State.Volume(volumeAttachments[0].Volume())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.machine = machine
+	s.volume = volume
+}
+
+func (s *VolumeStatusSuite) TestInitialStatus(c *gc.C) {
+	s.checkInitialStatus(c)
+}
+
+func (s *VolumeStatusSuite) checkInitialStatus(c *gc.C) {
+	statusInfo, err := s.volume.Status()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Check(statusInfo.Message, gc.Equals, "")
+	c.Check(statusInfo.Data, gc.HasLen, 0)
+	c.Check(statusInfo.Since, gc.NotNil)
+}
+
+func (s *VolumeStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
+	err := s.volume.SetStatus(state.StatusError, "", nil)
+	c.Check(err, gc.ErrorMatches, `cannot set status "error" without info`)
+
+	s.checkInitialStatus(c)
+}
+
+func (s *VolumeStatusSuite) TestSetUnknownStatus(c *gc.C) {
+	err := s.volume.SetStatus(state.Status("vliegkat"), "orville", nil)
+	c.Assert(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
+
+	s.checkInitialStatus(c)
+}
+
+func (s *VolumeStatusSuite) TestSetOverwritesData(c *gc.C) {
+	err := s.volume.SetStatus(state.StatusAttaching, "blah", map[string]interface{}{
+		"pew.pew": "zap",
+	})
+	c.Check(err, jc.ErrorIsNil)
+
+	s.checkGetSetStatus(c)
+}
+
+func (s *VolumeStatusSuite) TestGetSetStatusAlive(c *gc.C) {
+	s.checkGetSetStatus(c)
+}
+
+func (s *VolumeStatusSuite) checkGetSetStatus(c *gc.C) {
+	err := s.volume.SetStatus(state.StatusAttaching, "blah", map[string]interface{}{
+		"$foo.bar.baz": map[string]interface{}{
+			"pew.pew": "zap",
+		},
+	})
+	c.Check(err, jc.ErrorIsNil)
+
+	volume, err := s.State.Volume(s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	statusInfo, err := volume.Status()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(statusInfo.Status, gc.Equals, state.StatusAttaching)
+	c.Check(statusInfo.Message, gc.Equals, "blah")
+	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
+		"$foo.bar.baz": map[string]interface{}{
+			"pew.pew": "zap",
+		},
+	})
+	c.Check(statusInfo.Since, gc.NotNil)
+}
+
+func (s *VolumeStatusSuite) TestGetSetStatusDying(c *gc.C) {
+	err := s.State.DestroyVolume(s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkGetSetStatus(c)
+}
+
+func (s *VolumeStatusSuite) TestGetSetStatusDead(c *gc.C) {
+	err := s.State.DestroyVolume(s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.DetachVolume(s.machine.MachineTag(), s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveVolumeAttachment(s.machine.MachineTag(), s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	volume, err := s.State.Volume(s.volume.VolumeTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(volume.Life(), gc.Equals, state.Dead)
+
+	// NOTE: it would be more technically correct to reject status updates
+	// while Dead, but it's easier and clearer, not to mention more efficient,
+	// to just depend on status doc existence.
+	s.checkGetSetStatus(c)
+}
+
+func (s *VolumeStatusSuite) TestGetSetStatusGone(c *gc.C) {
+	s.obliterateVolume(c, s.volume.VolumeTag())
+
+	err := s.volume.SetStatus(state.StatusAttaching, "not really", nil)
+	c.Check(err, gc.ErrorMatches, `cannot set status: volume not found`)
+
+	statusInfo, err := s.volume.Status()
+	c.Check(err, gc.ErrorMatches, `cannot get status: volume not found`)
+	c.Check(statusInfo, gc.DeepEquals, state.StatusInfo{})
+}
+
+func (s *VolumeStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
+	err := s.volume.SetStatus(state.StatusPending, "still", nil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *VolumeStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
+	err := s.State.SetVolumeInfo(s.volume.VolumeTag(), state.VolumeInfo{
+		VolumeId: "vol-ume",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.volume.SetStatus(state.StatusPending, "", nil)
+	c.Check(err, gc.ErrorMatches, `cannot set status "pending"`)
+}

--- a/state/volume.go
+++ b/state/volume.go
@@ -6,6 +6,7 @@ package state
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -19,8 +20,10 @@ import (
 
 // Volume describes a volume (disk, logical volume, etc.) in the environment.
 type Volume interface {
-	Entity
+	GlobalEntity
 	LifeBinder
+	StatusGetter
+	StatusSetter
 
 	// VolumeTag returns the tag for the volume.
 	VolumeTag() names.VolumeTag
@@ -68,6 +71,7 @@ type VolumeAttachment interface {
 }
 
 type volume struct {
+	st  *State
 	doc volumeDoc
 }
 
@@ -157,7 +161,12 @@ func (v *volume) validate() error {
 	return nil
 }
 
-// Tag is required to implement Entity.
+// globalKey is required to implement GlobalEntity.
+func (v *volume) globalKey() string {
+	return volumeGlobalKey(v.doc.Name)
+}
+
+// Tag is required to implement GlobalEntity.
 func (v *volume) Tag() names.Tag {
 	return v.VolumeTag()
 }
@@ -225,6 +234,16 @@ func (v *volume) Params() (VolumeParams, bool) {
 	return *v.doc.Params, true
 }
 
+// Status is required to implement StatusGetter.
+func (v *volume) Status() (StatusInfo, error) {
+	return v.st.VolumeStatus(v.VolumeTag())
+}
+
+// SetStatus is required to implement StatusSetter.
+func (v *volume) SetStatus(status Status, info string, data map[string]interface{}) error {
+	return v.st.SetVolumeStatus(v.VolumeTag(), status, info, data)
+}
+
 // Volume is required to implement VolumeAttachment.
 func (v *volumeAttachment) Volume() names.VolumeTag {
 	return names.NewVolumeTag(v.doc.Volume)
@@ -273,7 +292,7 @@ func (st *State) volumes(query interface{}) ([]*volume, error) {
 	}
 	volumes := make([]*volume, len(docs))
 	for i := range docs {
-		volume := &volume{docs[i]}
+		volume := &volume{st, docs[i]}
 		if err := volume.validate(); err != nil {
 			return nil, errors.Annotate(err, "validating volume")
 		}
@@ -676,12 +695,15 @@ func (st *State) RemoveVolume(tag names.VolumeTag) (err error) {
 		if volume.Life() != Dead {
 			return nil, errors.New("volume is not dead")
 		}
-		return []txn.Op{{
-			C:      volumesC,
-			Id:     tag.Id(),
-			Assert: txn.DocExists,
-			Remove: true,
-		}}, nil
+		return []txn.Op{
+			{
+				C:      volumesC,
+				Id:     tag.Id(),
+				Assert: txn.DocExists,
+				Remove: true,
+			},
+			removeStatusOp(st, volumeGlobalKey(tag.Id())),
+		}, nil
 	}
 	return st.run(buildTxn)
 }
@@ -702,41 +724,46 @@ func newVolumeName(st *State, machineId string) (string, error) {
 	return id, nil
 }
 
-// addVolumeOp returns a txn.Op to create a new volume with the specified
+// addVolumeOps returns txn.Ops to create a new volume with the specified
 // parameters. If the supplied machine ID is non-empty, and the storage
 // provider is machine-scoped, then the volume will be scoped to that
 // machine.
-func (st *State) addVolumeOp(params VolumeParams, machineId string) (txn.Op, names.VolumeTag, error) {
+func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, names.VolumeTag, error) {
 	if params.binding == nil {
 		params.binding = names.NewMachineTag(machineId)
 	}
 	params, err := st.volumeParamsWithDefaults(params)
 	if err != nil {
-		return txn.Op{}, names.VolumeTag{}, errors.Trace(err)
+		return nil, names.VolumeTag{}, errors.Trace(err)
 	}
 	machineId, err = st.validateVolumeParams(params, machineId)
 	if err != nil {
-		return txn.Op{}, names.VolumeTag{}, errors.Annotate(err, "validating volume params")
+		return nil, names.VolumeTag{}, errors.Annotate(err, "validating volume params")
 	}
-
 	name, err := newVolumeName(st, machineId)
 	if err != nil {
-		return txn.Op{}, names.VolumeTag{}, errors.Annotate(err, "cannot generate volume name")
+		return nil, names.VolumeTag{}, errors.Annotate(err, "cannot generate volume name")
 	}
-	op := txn.Op{
-		C:      volumesC,
-		Id:     name,
-		Assert: txn.DocMissing,
-		Insert: &volumeDoc{
-			Name:      name,
-			StorageId: params.storage.Id(),
-			Binding:   params.binding.String(),
-			Params:    &params,
-			// Every volume is created with one attachment.
-			AttachmentCount: 1,
+	ops := []txn.Op{
+		createStatusOp(st, volumeGlobalKey(name), statusDoc{
+			Status:  StatusPending,
+			Updated: time.Now().UnixNano(),
+		}),
+		{
+			C:      volumesC,
+			Id:     name,
+			Assert: txn.DocMissing,
+			Insert: &volumeDoc{
+				Name:      name,
+				StorageId: params.storage.Id(),
+				Binding:   params.binding.String(),
+				Params:    &params,
+				// Every volume is created with one attachment.
+				AttachmentCount: 1,
+			},
 		},
 	}
-	return op, names.NewVolumeTag(name), nil
+	return ops, names.NewVolumeTag(name), nil
 }
 
 func (st *State) volumeParamsWithDefaults(params VolumeParams) (VolumeParams, error) {
@@ -875,7 +902,9 @@ func (st *State) setVolumeAttachmentInfo(
 		// when we set info for the first time, ensuring that
 		// params and info are mutually exclusive.
 		_, unsetParams := va.Params()
-		ops := setVolumeAttachmentInfoOps(machineTag, volumeTag, info, unsetParams)
+		ops := setVolumeAttachmentInfoOps(
+			machineTag, volumeTag, info, unsetParams,
+		)
 		return ops, nil
 	}
 	return st.run(buildTxn)
@@ -928,6 +957,7 @@ func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error)
 		// we set info for the first time, ensuring that
 		// params and info are mutually exclusive.
 		var unsetParams bool
+		var ops []txn.Op
 		if params, ok := v.Params(); ok {
 			info.Pool = params.Pool
 			unsetParams = true
@@ -941,7 +971,8 @@ func (st *State) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (err error)
 				return nil, err
 			}
 		}
-		return setVolumeInfoOps(tag, info, unsetParams), nil
+		ops = append(ops, setVolumeInfoOps(tag, info, unsetParams)...)
+		return ops, nil
 	}
 	return st.run(buildTxn)
 }
@@ -987,4 +1018,47 @@ func (st *State) AllVolumes() ([]Volume, error) {
 		return nil, errors.Annotate(err, "cannot get volumes")
 	}
 	return volumesToInterfaces(volumes), nil
+}
+
+func volumeGlobalKey(name string) string {
+	return "v#" + name
+}
+
+// VolumeStatus returns the status of the specified volume.
+func (st *State) VolumeStatus(tag names.VolumeTag) (StatusInfo, error) {
+	return getStatus(st, volumeGlobalKey(tag.Id()), "volume")
+}
+
+// SetVolumeStatus sets the status of the specified volume.
+//
+// TODO(axw) create upgrade step to add status to existing volume docs.
+func (st *State) SetVolumeStatus(tag names.VolumeTag, status Status, info string, data map[string]interface{}) error {
+	switch status {
+	case StatusAttaching, StatusAttached, StatusDetaching, StatusDestroying:
+	case StatusError:
+		if info == "" {
+			return errors.Errorf("cannot set status %q without info", status)
+		}
+	case StatusPending:
+		// If a volume is not yet provisioned, we allow its status
+		// to be set back to pending (when a retry is to occur).
+		v, err := st.Volume(tag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		_, err = v.Info()
+		if errors.IsNotProvisioned(err) {
+			break
+		}
+		return errors.Errorf("cannot set status %q", status)
+	default:
+		return errors.Errorf("cannot set invalid status %q", status)
+	}
+	return setStatus(st, setStatusParams{
+		badge:     "volume",
+		globalKey: volumeGlobalKey(tag.Id()),
+		status:    status,
+		message:   info,
+		rawData:   data,
+	})
 }

--- a/state/volume.go
+++ b/state/volume.go
@@ -1030,8 +1030,6 @@ func (st *State) VolumeStatus(tag names.VolumeTag) (StatusInfo, error) {
 }
 
 // SetVolumeStatus sets the status of the specified volume.
-//
-// TODO(axw) create upgrade step to add status to existing volume docs.
 func (st *State) SetVolumeStatus(tag names.VolumeTag, status Status, info string, data map[string]interface{}) error {
 	switch status {
 	case StatusAttaching, StatusAttached, StatusDetaching, StatusDestroying:

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -76,6 +76,12 @@ func stateStepsFor125() []Step {
 			run: func(context Context) error {
 				return state.AddBindingToFilesystems(context.State())
 			}},
+		&upgradeStep{
+			description: "add status to volume",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddVolumeStatus(context.State())
+			}},
 	}
 }
 

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -33,6 +33,7 @@ func (s *steps125Suite) TestStateStepsFor125(c *gc.C) {
 		"add attachmentCount to filesystem",
 		"add binding to volume",
 		"add binding to filesystem",
+		"add status to volume",
 	}
 	assertStateSteps(c, version.MustParse("1.25.0"), expected)
 }

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -734,3 +734,16 @@ func (c *mockClock) After(d time.Duration) <-chan time.Time {
 	ch <- c.now
 	return ch
 }
+
+type mockStatusSetter struct {
+	args      []params.EntityStatus
+	setStatus func([]params.EntityStatus) error
+}
+
+func (m *mockStatusSetter) SetStatus(args []params.EntityStatus) error {
+	if m.setStatus != nil {
+		return m.setStatus(args)
+	}
+	m.args = append(m.args, args...)
+	return nil
+}

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -130,6 +130,11 @@ type LifecycleManager interface {
 	RemoveAttachments([]params.MachineStorageId) ([]params.ErrorResult, error)
 }
 
+// StatusSetter defines an interface used to set the status of entities.
+type StatusSetter interface {
+	SetStatus([]params.EntityStatus) error
+}
+
 // EnvironAccessor defines an interface used to enable a storage provisioner
 // worker to watch changes to and read environment config, to use when
 // provisioning storage.
@@ -158,6 +163,7 @@ func NewStorageProvisioner(
 	l LifecycleManager,
 	e EnvironAccessor,
 	m MachineAccessor,
+	s StatusSetter,
 	clock clock.Clock,
 ) worker.Worker {
 	w := &storageprovisioner{
@@ -168,6 +174,7 @@ func NewStorageProvisioner(
 		life:        l,
 		environ:     e,
 		machines:    m,
+		status:      s,
 		clock:       clock,
 	}
 	go func() {
@@ -190,6 +197,7 @@ type storageprovisioner struct {
 	life        LifecycleManager
 	environ     EnvironAccessor
 	machines    MachineAccessor
+	status      StatusSetter
 	clock       clock.Clock
 }
 
@@ -273,6 +281,7 @@ func (w *storageprovisioner) loop() error {
 		filesystemAccessor:                w.filesystems,
 		life:                              w.life,
 		machineAccessor:                   w.machines,
+		statusSetter:                      w.status,
 		time:                              w.clock,
 		volumes:                           make(map[names.VolumeTag]storage.Volume),
 		volumeAttachments:                 make(map[params.MachineStorageId]storage.VolumeAttachment),
@@ -432,6 +441,7 @@ type context struct {
 	filesystemAccessor FilesystemAccessor
 	life               LifecycleManager
 	machineAccessor    MachineAccessor
+	statusSetter       StatusSetter
 	time               clock.Clock
 
 	// volumes contains information about provisioned volumes.


### PR DESCRIPTION
This PR adds the StatusGetter and StatusSetter interfaces to state.Volume, and updates the storage provisioner to call StatusSet after attempting to create or attach volumes. There is also an upgrade step that adds status docs for existing volumes.

We will follow up with several more changes:
 - display status in the CLI (i.e. in "juju storage volume list")
 - update storage provisioner to set status when detaching or destroying
 - add status to filesystems as above

(Review request: http://reviews.vapour.ws/r/2353/)