### PR TITLE
cmd/juju/storage: add status to volume list

### DIFF
--- a/api/agent/state.go
+++ b/api/agent/state.go
@@ -124,7 +124,7 @@ func (m *Entity) SetPassword(password string) error {
 func (m *Entity) ClearReboot() error {
 	var result params.ErrorResults
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: m.tag.String()},
 		},
 	}

--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -44,7 +44,7 @@ func (m *Machine) Refresh() error {
 func (m *Machine) SetStatus(status params.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: m.tag.String(), Status: status, Info: info, Data: data},
 		},
 	}

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -72,7 +72,7 @@ func (m *Machine) ProvisioningInfo() (*params.ProvisioningInfo, error) {
 func (m *Machine) SetStatus(status params.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: m.tag.String(), Status: status, Info: info, Data: data},
 		},
 	}

--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -457,7 +457,7 @@ func (st *State) InstanceIds(tags []names.MachineTag) ([]params.StringResult, er
 }
 
 // SetStatus sets the status of storage entities.
-func (st *State) SetStatus(args []params.EntityStatus) error {
+func (st *State) SetStatus(args []params.EntityStatusArgs) error {
 	var result params.ErrorResults
 	err := st.facade.FacadeCall("SetStatus", params.SetStatus{args}, &result)
 	if err != nil {

--- a/api/uniter/service.go
+++ b/api/uniter/service.go
@@ -169,7 +169,7 @@ func (s *Service) SetStatus(unitName string, status params.Status, info string, 
 	tag := names.NewUnitTag(unitName)
 	var result params.ErrorResults
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{
 				Tag:    tag.String(),
 				Status: status,

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -59,7 +59,7 @@ func (u *Unit) SetUnitStatus(status params.Status, info string, data map[string]
 	}
 	var result params.ErrorResults
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: u.tag.String(), Status: status, Info: info, Data: data},
 		},
 	}
@@ -99,7 +99,7 @@ func (u *Unit) UnitStatus() (params.StatusResult, error) {
 func (u *Unit) SetAgentStatus(status params.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: u.tag.String(), Status: status, Info: info, Data: data},
 		},
 	}

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -1012,9 +1012,9 @@ func (c *Client) RetryProvisioning(p params.Entities) (params.ErrorResults, erro
 	if err := c.check.ChangeAllowed(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
-	entityStatus := make([]params.EntityStatus, len(p.Entities))
+	entityStatus := make([]params.EntityStatusArgs, len(p.Entities))
 	for i, entity := range p.Entities {
-		entityStatus[i] = params.EntityStatus{Tag: entity.Tag, Data: map[string]interface{}{"transient": true}}
+		entityStatus[i] = params.EntityStatusArgs{Tag: entity.Tag, Data: map[string]interface{}{"transient": true}}
 	}
 	return c.api.statusSetter.UpdateStatus(params.SetStatus{
 		Entities: entityStatus,

--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -188,3 +188,13 @@ func (s *ServiceStatusGetter) Status(args params.Entities) (params.ServiceStatus
 	}
 	return result, nil
 }
+
+// EntityStatusFromState converts a state.StatusInfo into a params.EntityStatus.
+func EntityStatusFromState(status state.StatusInfo) params.EntityStatus {
+	return params.EntityStatus{
+		params.Status(status.Status),
+		status.Message,
+		status.Data,
+		status.Since,
+	}
+}

--- a/apiserver/common/setstatus_test.go
+++ b/apiserver/common/setstatus_test.go
@@ -34,7 +34,7 @@ func (s *statusSetterSuite) SetUpTest(c *gc.C) {
 func (s *statusSetterSuite) TestUnauthorized(c *gc.C) {
 	tag := names.NewMachineTag("42")
 	s.badTag = tag
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    tag.String(),
 		Status: params.StatusExecuting,
 	}}})
@@ -44,7 +44,7 @@ func (s *statusSetterSuite) TestUnauthorized(c *gc.C) {
 }
 
 func (s *statusSetterSuite) TestNotATag(c *gc.C) {
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    "not a tag",
 		Status: params.StatusExecuting,
 	}}})
@@ -54,7 +54,7 @@ func (s *statusSetterSuite) TestNotATag(c *gc.C) {
 }
 
 func (s *statusSetterSuite) TestNotFound(c *gc.C) {
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    names.NewMachineTag("42").String(),
 		Status: params.StatusDown,
 	}}})
@@ -65,7 +65,7 @@ func (s *statusSetterSuite) TestNotFound(c *gc.C) {
 
 func (s *statusSetterSuite) TestSetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    machine.Tag().String(),
 		Status: params.StatusStarted,
 	}}})
@@ -87,7 +87,7 @@ func (s *statusSetterSuite) TestSetUnitStatus(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &state.StatusInfo{
 		Status: state.StatusMaintenance,
 	}})
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
 		Status: params.StatusActive,
 	}}})
@@ -109,7 +109,7 @@ func (s *statusSetterSuite) TestSetServiceStatus(c *gc.C) {
 	service := s.Factory.MakeService(c, &factory.ServiceParams{Status: &state.StatusInfo{
 		Status: state.StatusMaintenance,
 	}})
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    service.Tag().String(),
 		Status: params.StatusActive,
 	}}})
@@ -126,7 +126,7 @@ func (s *statusSetterSuite) TestSetServiceStatus(c *gc.C) {
 
 func (s *statusSetterSuite) TestBulk(c *gc.C) {
 	s.badTag = names.NewMachineTag("42")
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    s.badTag.String(),
 		Status: params.StatusActive,
 	}, {
@@ -158,7 +158,7 @@ func (s *serviceStatusSetterSuite) TestUnauthorized(c *gc.C) {
 	// Machines are unauthorized since they are not units
 	tag := names.NewUnitTag("foo/0")
 	s.badTag = tag
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    tag.String(),
 		Status: params.StatusActive,
 	}}})
@@ -168,7 +168,7 @@ func (s *serviceStatusSetterSuite) TestUnauthorized(c *gc.C) {
 }
 
 func (s *serviceStatusSetterSuite) TestNotATag(c *gc.C) {
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    "not a tag",
 		Status: params.StatusActive,
 	}}})
@@ -178,7 +178,7 @@ func (s *serviceStatusSetterSuite) TestNotATag(c *gc.C) {
 }
 
 func (s *serviceStatusSetterSuite) TestNotFound(c *gc.C) {
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    names.NewUnitTag("foo/0").String(),
 		Status: params.StatusActive,
 	}}})
@@ -189,7 +189,7 @@ func (s *serviceStatusSetterSuite) TestNotFound(c *gc.C) {
 
 func (s *serviceStatusSetterSuite) TestSetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    machine.Tag().String(),
 		Status: params.StatusActive,
 	}}})
@@ -206,7 +206,7 @@ func (s *serviceStatusSetterSuite) TestSetServiceStatus(c *gc.C) {
 	service := s.Factory.MakeService(c, &factory.ServiceParams{Status: &state.StatusInfo{
 		Status: state.StatusMaintenance,
 	}})
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    service.Tag().String(),
 		Status: params.StatusActive,
 	}}})
@@ -222,7 +222,7 @@ func (s *serviceStatusSetterSuite) TestSetUnitStatusNotLeader(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &state.StatusInfo{
 		Status: state.StatusMaintenance,
 	}})
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
 		Status: params.StatusActive,
 	}}})
@@ -245,7 +245,7 @@ func (s *serviceStatusSetterSuite) TestSetUnitStatusIsLeader(c *gc.C) {
 		service.Name(),
 		unit.Name(),
 		time.Minute)
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
 		Status: params.StatusActive,
 	}}})
@@ -264,7 +264,7 @@ func (s *serviceStatusSetterSuite) TestSetUnitStatusIsLeader(c *gc.C) {
 func (s *serviceStatusSetterSuite) TestBulk(c *gc.C) {
 	s.badTag = names.NewMachineTag("42")
 	machine := s.Factory.MakeMachine(c, nil)
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatus{{
+	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    s.badTag.String(),
 		Status: params.StatusActive,
 	}, {

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -60,7 +60,7 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: "machine-1", Status: params.StatusError, Info: "not really"},
 			{Tag: "machine-0", Status: params.StatusStopped, Info: "foobar"},
 			{Tag: "machine-42", Status: params.StatusStarted, Info: "blah"},

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -339,8 +339,16 @@ type InstancesInfo struct {
 	Machines []InstanceInfo
 }
 
-// EntityStatus holds an entity tag, status and extra info.
+// EntityStatus holds the status of an entity.
 type EntityStatus struct {
+	Status Status
+	Info   string
+	Data   map[string]interface{}
+	Since  *time.Time
+}
+
+// EntityStatus holds parameters for setting the status of a single entity.
+type EntityStatusArgs struct {
 	Tag    string
 	Status Status
 	Info   string
@@ -349,7 +357,7 @@ type EntityStatus struct {
 
 // SetStatus holds the parameters for making a SetStatus/UpdateStatus call.
 type SetStatus struct {
-	Entities []EntityStatus
+	Entities []EntityStatusArgs
 }
 
 // InstanceStatus holds an entity tag and instance status.

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -506,6 +506,9 @@ type VolumeInstance struct {
 	// UnitTag is the tag of the unit attached to storage instance
 	// for this volume.
 	UnitTag string `json:"unit,omitempty"`
+
+	// Status contains the current status of the volume.
+	Status EntityStatus `json:"status"`
 }
 
 // VolumeItem contain volume, its attachments

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -331,7 +331,7 @@ func (s *withoutStateServerSuite) TestSetStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: s.machines[0].Tag().String(), Status: params.StatusError, Info: "not really",
 				Data: map[string]interface{}{"foo": "bar"}},
 			{Tag: s.machines[1].Tag().String(), Status: params.StatusStopped, Info: "foobar"},

--- a/apiserver/storage/package_test.go
+++ b/apiserver/storage/package_test.go
@@ -384,6 +384,10 @@ func (m *mockVolume) Info() (state.VolumeInfo, error) {
 	return state.VolumeInfo{}, errors.NotProvisionedf("%v", m.tag)
 }
 
+func (m *mockVolume) Status() (state.StatusInfo, error) {
+	return state.StatusInfo{Status: state.StatusAttached}, nil
+}
+
 type mockFilesystem struct {
 	state.Filesystem
 	tag names.FilesystemTag

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -490,6 +490,11 @@ func (a *API) convertStateVolumeToParams(st state.Volume) (params.VolumeInstance
 		volume.Persistent = info.Persistent
 		volume.VolumeId = info.VolumeId
 	}
+	status, err := st.Status()
+	if err != nil {
+		return params.VolumeInstance{}, errors.Trace(err)
+	}
+	volume.Status = common.EntityStatusFromState(status)
 	return volume, nil
 }
 

--- a/apiserver/uniter/uniter_base_test.go
+++ b/apiserver/uniter/uniter_base_test.go
@@ -135,7 +135,7 @@ func (s *uniterBaseSuite) testSetStatus(
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
 			{Tag: "unit-wordpress-0", Status: params.StatusRebooting, Info: "foobar"},
 			{Tag: "unit-foo-42", Status: params.StatusActive, Info: "blah"},
@@ -174,7 +174,7 @@ func (s *uniterBaseSuite) testSetAgentStatus(
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
 			{Tag: "unit-wordpress-0", Status: params.StatusExecuting, Info: "foobar"},
 			{Tag: "unit-foo-42", Status: params.StatusRebooting, Info: "blah"},
@@ -213,7 +213,7 @@ func (s *uniterBaseSuite) testSetUnitStatus(
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
-		Entities: []params.EntityStatus{
+		Entities: []params.EntityStatusArgs{
 			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
 			{Tag: "unit-wordpress-0", Status: params.StatusTerminated, Info: "foobar"},
 			{Tag: "unit-foo-42", Status: params.StatusActive, Info: "blah"},

--- a/cmd/juju/common/format.go
+++ b/cmd/juju/common/format.go
@@ -1,0 +1,23 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import "time"
+
+// FormatTime returns a string with the local time formatted
+// in an arbitrary format used for status or and localized tz
+// or in UTC timezone and format RFC3339 if u is specified.
+func FormatTime(t *time.Time, formatISO bool) string {
+	if formatISO {
+		// If requested, use ISO time format.
+		// The format we use is RFC3339 without the "T". From the spec:
+		// NOTE: ISO 8601 defines date and time separated by "T".
+		// Applications using this syntax may choose, for the sake of
+		// readability, to specify a full-date and full-time separated by
+		// (say) a space character.
+		return t.UTC().Format("2006-01-02 15:04:05Z")
+	}
+	// Otherwise use local time.
+	return t.Local().Format("02 Jan 2006 15:04:05Z07:00")
+}

--- a/cmd/juju/common/naturalsort.go
+++ b/cmd/juju/common/naturalsort.go
@@ -1,14 +1,21 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package status
+package common
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
 )
+
+// SortStringsNaturally sorts strings according to their natural sort order.
+func SortStringsNaturally(s []string) []string {
+	sort.Sort(naturally(s))
+	return s
+}
 
 type naturally []string
 

--- a/cmd/juju/common/naturalsort_test.go
+++ b/cmd/juju/common/naturalsort_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package status
+package common
 
 import (
 	"sort"

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/state/multiwatcher"
 )
 
@@ -144,7 +145,7 @@ func (sf *statusFormatter) getServiceStatusInfo(service params.ServiceStatus) st
 		Version: service.Status.Version,
 	}
 	if service.Status.Since != nil {
-		info.Since = formatStatusTime(service.Status.Since, sf.isoTime)
+		info.Since = common.FormatTime(service.Status.Since, sf.isoTime)
 	}
 	return info
 }
@@ -205,7 +206,7 @@ func (sf *statusFormatter) getWorkloadStatusInfo(unit params.UnitStatus) statusI
 		Version: unit.Workload.Version,
 	}
 	if unit.Workload.Since != nil {
-		info.Since = formatStatusTime(unit.Workload.Since, sf.isoTime)
+		info.Since = common.FormatTime(unit.Workload.Since, sf.isoTime)
 	}
 	return info
 }
@@ -218,7 +219,7 @@ func (sf *statusFormatter) getAgentStatusInfo(unit params.UnitStatus) statusInfo
 		Version: unit.UnitAgent.Version,
 	}
 	if unit.UnitAgent.Since != nil {
-		info.Since = formatStatusTime(unit.UnitAgent.Since, sf.isoTime)
+		info.Since = common.FormatTime(unit.UnitAgent.Since, sf.isoTime)
 	}
 	return info
 }

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/juju/osenv"
-	"launchpad.net/gnuflag"
 )
 
 type StatusHistoryCommand struct {
@@ -102,7 +103,7 @@ func (c *StatusHistoryCommand) Run(ctx *cmd.Context) error {
 	table := [][]string{{"TIME", "TYPE", "STATUS", "MESSAGE"}}
 	lengths := []int{1, 1, 1, 1}
 	for _, v := range statuses.Statuses {
-		fields := []string{formatStatusTime(v.Since, c.isoTime), string(v.Kind), string(v.Status), v.Info}
+		fields := []string{common.FormatTime(v.Since, c.isoTime), string(v.Kind), string(v.Status), v.Info}
 		for k, v := range fields {
 			if len(v) > lengths[k] {
 				lengths[k] = len(v)

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/juju/common"
 )
 
 // FormatOneline returns a brief list of units and their subordinates.
@@ -60,9 +61,9 @@ func formatOneline(value interface{}, printf onelinePrintf) ([]byte, error) {
 		printf(&out, format, uName, u, level)
 	}
 
-	for _, svcName := range sortStringsNaturally(stringKeysFromMap(fs.Services)) {
+	for _, svcName := range common.SortStringsNaturally(stringKeysFromMap(fs.Services)) {
 		svc := fs.Services[svcName]
-		for _, uName := range sortStringsNaturally(stringKeysFromMap(svc.Units)) {
+		for _, uName := range common.SortStringsNaturally(stringKeysFromMap(svc.Units)) {
 			unit := svc.Units[uName]
 			pprint(uName, unit, 0)
 			recurseUnits(unit, 1, pprint)

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 )
 
 // FormatSummary returns a summary of the current environment
@@ -53,7 +54,7 @@ func FormatSummary(value interface{}) ([]byte, error) {
 	p(" ")
 
 	p("# SERVICES:", fmt.Sprintf(" (%d)", len(fs.Services)))
-	for _, svcName := range sortStringsNaturally(stringKeysFromMap(svcExposure)) {
+	for _, svcName := range common.SortStringsNaturally(stringKeysFromMap(svcExposure)) {
 		s := svcExposure[svcName]
 		p(svcName, fmt.Sprintf("%d/%d\texposed", s[true], s[true]+s[false]))
 	}
@@ -121,7 +122,7 @@ func (f *summaryFormatter) trackUnit(name string, status unitStatus, indentLevel
 }
 
 func (f *summaryFormatter) printStateToCount(m map[params.Status]int) {
-	for _, status := range sortStringsNaturally(stringKeysFromMap(m)) {
+	for _, status := range common.SortStringsNaturally(stringKeysFromMap(m)) {
 		numInStatus := m[params.Status(status)]
 		f.delimitValuesWithTabs(status+":", fmt.Sprintf(" %d ", numInStatus))
 	}
@@ -155,7 +156,7 @@ func (f *summaryFormatter) resolveAndTrackIp(publicDns string) {
 
 func (f *summaryFormatter) aggregateMachineStates(machines map[string]machineStatus) map[params.Status]int {
 	stateToMachine := make(map[params.Status]int)
-	for _, name := range sortStringsNaturally(stringKeysFromMap(machines)) {
+	for _, name := range common.SortStringsNaturally(stringKeysFromMap(machines)) {
 		m := machines[name]
 		f.resolveAndTrackIp(m.DNSName)
 
@@ -170,10 +171,10 @@ func (f *summaryFormatter) aggregateMachineStates(machines map[string]machineSta
 
 func (f *summaryFormatter) aggregateServiceAndUnitStates(services map[string]serviceStatus) map[string]map[bool]int {
 	svcExposure := make(map[string]map[bool]int)
-	for _, name := range sortStringsNaturally(stringKeysFromMap(services)) {
+	for _, name := range common.SortStringsNaturally(stringKeysFromMap(services)) {
 		s := services[name]
 		// Grab unit states
-		for _, un := range sortStringsNaturally(stringKeysFromMap(s.Units)) {
+		for _, un := range common.SortStringsNaturally(stringKeysFromMap(s.Units)) {
 			u := s.Units[un]
 			f.trackUnit(un, u, 0)
 			recurseUnits(u, 1, f.trackUnit)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/charm.v5/hooks"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 )
 
 // FormatTabular returns a tabular summary of machines, services, and
@@ -37,7 +38,7 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	units := make(map[string]unitStatus)
 	p("[Services]")
 	p("NAME\tSTATUS\tEXPOSED\tCHARM")
-	for _, svcName := range sortStringsNaturally(stringKeysFromMap(fs.Services)) {
+	for _, svcName := range common.SortStringsNaturally(stringKeysFromMap(fs.Services)) {
 		svc := fs.Services[svcName]
 		for un, u := range svc.Units {
 			units[un] = u
@@ -81,7 +82,7 @@ func FormatTabular(value interface{}) ([]byte, error) {
 
 	p("\n[Units]")
 	p(strings.Join(header, "\t"))
-	for _, name := range sortStringsNaturally(stringKeysFromMap(units)) {
+	for _, name := range common.SortStringsNaturally(stringKeysFromMap(units)) {
 		u := units[name]
 		pUnit(name, u, 0)
 		const indentationLevel = 1
@@ -91,7 +92,7 @@ func FormatTabular(value interface{}) ([]byte, error) {
 
 	p("\n[Machines]")
 	p("ID\tSTATE\tVERSION\tDNS\tINS-ID\tSERIES\tHARDWARE")
-	for _, name := range sortStringsNaturally(stringKeysFromMap(fs.Machines)) {
+	for _, name := range common.SortStringsNaturally(stringKeysFromMap(fs.Machines)) {
 		m := fs.Machines[name]
 		p(m.Id, m.AgentState, m.AgentVersion, m.DNSName, m.InstanceId, m.Series, m.Hardware)
 	}

--- a/cmd/juju/status/package_test.go
+++ b/cmd/juju/status/package_test.go
@@ -4,11 +4,11 @@
 package status_test
 
 import (
-	"testing"
+	stdtesting "testing"
 
-	gc "gopkg.in/check.v1"
+	"github.com/juju/juju/testing"
 )
 
-func TestPackage(t *testing.T) {
-	gc.TestingT(t)
+func TestPackage(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
 }

--- a/cmd/juju/status/utils.go
+++ b/cmd/juju/status/utils.go
@@ -6,34 +6,9 @@ package status
 import (
 	"fmt"
 	"reflect"
-	"sort"
-	"time"
+
+	"github.com/juju/juju/cmd/juju/common"
 )
-
-// formatStatusTime returns a string with the local time
-// formatted in an arbitrary format used for status or
-// and localized tz or in utc timezone and format RFC3339
-// if u is specified.
-func formatStatusTime(t *time.Time, formatISO bool) string {
-	if formatISO {
-		// If requested, use ISO time format.
-		// The format we use is RFC3339 without the "T". From the spec:
-		// NOTE: ISO 8601 defines date and time separated by "T".
-		// Applications using this syntax may choose, for the sake of
-		// readability, to specify a full-date and full-time separated by
-		// (say) a space character.
-		return t.UTC().Format("2006-01-02 15:04:05Z")
-	} else {
-		// Otherwise use local time.
-		return t.Local().Format("02 Jan 2006 15:04:05Z07:00")
-	}
-}
-
-// sortStringsNaturally is syntactic sugar so we can do sorts in one line.
-func sortStringsNaturally(s []string) []string {
-	sort.Sort(naturally(s))
-	return s
-}
 
 // stringKeysFromMap takes a map with keys which are strings and returns
 // only the keys.
@@ -50,7 +25,7 @@ func recurseUnits(u unitStatus, il int, recurseMap func(string, unitStatus, int)
 	if len(u.Subordinates) == 0 {
 		return
 	}
-	for _, uName := range sortStringsNaturally(stringKeysFromMap(u.Subordinates)) {
+	for _, uName := range common.SortStringsNaturally(stringKeysFromMap(u.Subordinates)) {
 		unit := u.Subordinates[uName]
 		recurseMap(uName, unit, il)
 		recurseUnits(unit, il+1, recurseMap)

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/common"
 )
 
 const volumeCmdDoc = `
@@ -60,6 +61,15 @@ type VolumeInfo struct {
 
 	// from params.Volume. This is juju volume id.
 	Volume string `yaml:"volume,omitempty" json:"volume,omitempty"`
+
+	// from params.Volume.
+	Status EntityStatus `yaml:"status,omitempty" json:"status,omitempty"`
+}
+
+type EntityStatus struct {
+	Current params.Status `json:"current,omitempty" yaml:"current,omitempty"`
+	Message string        `json:"message,omitempty" yaml:"message,omitempty"`
+	Since   string        `json:"since,omitempty" yaml:"since,omitempty"`
 }
 
 // convertToVolumeInfo returns map of maps with volume info
@@ -126,6 +136,12 @@ func createInfo(volume params.VolumeInstance) (info VolumeInfo, unit, storage st
 	info.HardwareId = volume.HardwareId
 	info.Size = volume.Size
 	info.Persistent = volume.Persistent
+	info.Status = EntityStatus{
+		volume.Status.Status,
+		volume.Status.Info,
+		// TODO(axw) we should support formatting as ISO time
+		common.FormatTime(volume.Status.Since, false),
+	}
 
 	if v, err := idFromTag(volume.VolumeTag); err == nil {
 		info.Volume = v

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -35,7 +35,7 @@ func formatVolumeListTabularTyped(infos map[string]map[string]map[string]VolumeI
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("MACHINE", "UNIT", "STORAGE", "DEVICE", "VOLUME", "ID", "SIZE")
+	print("MACHINE", "UNIT", "STORAGE", "DEVICE", "VOLUME", "ID", "SIZE", "STATE", "MESSAGE")
 
 	// 1. sort by machines
 	machines := set.NewStrings()
@@ -57,7 +57,7 @@ func formatVolumeListTabularTyped(infos map[string]map[string]map[string]VolumeI
 		for _, unit := range units.SortedValues() {
 			unitStorages := machineUnits[unit]
 
-			// 3.sort by storage
+			// 3. sort by storage
 			storages := set.NewStrings()
 			for storage := range unitStorages {
 				if !storages.Contains(storage) {
@@ -66,8 +66,15 @@ func formatVolumeListTabularTyped(infos map[string]map[string]map[string]VolumeI
 			}
 			for _, storage := range storages.SortedValues() {
 				info := unitStorages[storage]
-				size := humanize.IBytes(info.Size * humanize.MiByte)
-				print(machine, unit, storage, info.DeviceName, info.Volume, info.VolumeId, size)
+				var size string
+				if info.Size > 0 {
+					size = humanize.IBytes(info.Size * humanize.MiByte)
+				}
+				print(
+					machine, unit, storage, info.DeviceName,
+					info.Volume, info.VolumeId, size,
+					string(info.Status.Current), info.Status.Message,
+				)
 			}
 		}
 	}

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -404,8 +404,8 @@ func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPersistentPool)
 	context := runVolumeList(c, "0")
 	expected := `
-MACHINE  UNIT             STORAGE  DEVICE  VOLUME  ID  SIZE
-0        storage-block/0  data/0           0           0B
+MACHINE  UNIT             STORAGE  DEVICE  VOLUME  ID  SIZE  STATE    MESSAGE
+0        storage-block/0  data/0           0                 pending  
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -110,7 +110,7 @@ func removeAttachments(ctx *context, ids []params.MachineStorageId) error {
 
 // setStatus sets the given entity statuses, if any. If setting
 // the status fails the error is logged but otherwise ignored.
-func setStatus(ctx *context, statuses []params.EntityStatus) {
+func setStatus(ctx *context, statuses []params.EntityStatusArgs) {
 	if len(statuses) > 0 {
 		if err := ctx.statusSetter.SetStatus(statuses); err != nil {
 			logger.Errorf("failed to set status: %v", err)

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -739,11 +739,11 @@ func (c *mockClock) After(d time.Duration) <-chan time.Time {
 }
 
 type mockStatusSetter struct {
-	args      []params.EntityStatus
-	setStatus func([]params.EntityStatus) error
+	args      []params.EntityStatusArgs
+	setStatus func([]params.EntityStatusArgs) error
 }
 
-func (m *mockStatusSetter) SetStatus(args []params.EntityStatus) error {
+func (m *mockStatusSetter) SetStatus(args []params.EntityStatusArgs) error {
 	if m.setStatus != nil {
 		return m.setStatus(args)
 	}

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -132,7 +132,7 @@ type LifecycleManager interface {
 
 // StatusSetter defines an interface used to set the status of entities.
 type StatusSetter interface {
-	SetStatus([]params.EntityStatus) error
+	SetStatus([]params.EntityStatusArgs) error
 }
 
 // EnvironAccessor defines an interface used to enable a storage provisioner

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -251,7 +251,7 @@ func (s *storageProvisionerSuite) TestCreateVolumeRetry(c *gc.C) {
 		30 * time.Minute,
 	})
 
-	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatus{
+	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
 		{Tag: "volume-1", Status: "pending", Info: "badness"},
 		{Tag: "volume-1", Status: "pending", Info: "badness"},
 		{Tag: "volume-1", Status: "pending", Info: "badness"},
@@ -333,7 +333,7 @@ func (s *storageProvisionerSuite) TestAttachVolumeRetry(c *gc.C) {
 		30 * time.Minute,
 	})
 
-	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatus{
+	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
 		{Tag: "volume-1", Status: "attaching", Info: ""},        // CreateVolumes
 		{Tag: "volume-1", Status: "attaching", Info: "badness"}, // AttachVolumes
 		{Tag: "volume-1", Status: "attaching", Info: "badness"},
@@ -1030,7 +1030,7 @@ func (s *storageProvisionerSuite) TestDetachVolumesRetry(c *gc.C) {
 		30 * time.Minute,
 	})
 
-	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatus{
+	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
 		{Tag: "volume-1", Status: "detaching", Info: "badness"}, // DetachVolumes
 		{Tag: "volume-1", Status: "detaching", Info: "badness"},
 		{Tag: "volume-1", Status: "detaching", Info: "badness"},
@@ -1272,7 +1272,7 @@ func (s *storageProvisionerSuite) TestDestroyVolumesRetry(c *gc.C) {
 		30 * time.Minute,
 	})
 
-	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatus{
+	c.Assert(args.statusSetter.args, jc.DeepEquals, []params.EntityStatusArgs{
 		{Tag: "volume-1", Status: "destroying", Info: "badness"},
 		{Tag: "volume-1", Status: "destroying", Info: "badness"},
 		{Tag: "volume-1", Status: "destroying", Info: "badness"},

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -27,7 +27,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 	var reschedule []scheduleOp
 	var volumes []storage.Volume
 	var volumeAttachments []storage.VolumeAttachment
-	var statuses []params.EntityStatus
+	var statuses []params.EntityStatusArgs
 	for sourceName, volumeParams := range paramsBySource {
 		logger.Debugf("creating volumes: %v", volumeParams)
 		volumeSource := volumeSources[sourceName]
@@ -36,7 +36,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 			return errors.Annotatef(err, "creating volumes from source %q", sourceName)
 		}
 		for i, result := range results {
-			statuses = append(statuses, params.EntityStatus{
+			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    volumeParams[i].Tag.String(),
 				Status: params.StatusAttaching,
 			})
@@ -116,7 +116,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 	}
 	var reschedule []scheduleOp
 	var volumeAttachments []storage.VolumeAttachment
-	var statuses []params.EntityStatus
+	var statuses []params.EntityStatusArgs
 	for sourceName, volumeAttachmentParams := range paramsBySource {
 		logger.Debugf("attaching volumes: %+v", volumeAttachmentParams)
 		volumeSource := volumeSources[sourceName]
@@ -126,7 +126,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 		}
 		for i, result := range results {
 			p := volumeAttachmentParams[i]
-			statuses = append(statuses, params.EntityStatus{
+			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    p.Volume.String(),
 				Status: params.StatusAttached,
 			})
@@ -182,7 +182,7 @@ func destroyVolumes(ctx *context, ops map[names.VolumeTag]*destroyVolumeOp) erro
 	}
 	var remove []names.Tag
 	var reschedule []scheduleOp
-	var statuses []params.EntityStatus
+	var statuses []params.EntityStatusArgs
 	for sourceName, volumeParams := range paramsBySource {
 		logger.Debugf("destroying volumes from %q: %v", sourceName, volumeParams)
 		volumeSource := volumeSources[sourceName]
@@ -206,7 +206,7 @@ func destroyVolumes(ctx *context, ops map[names.VolumeTag]*destroyVolumeOp) erro
 			}
 			// Failed to destroy volume; reschedule and update status.
 			reschedule = append(reschedule, ops[tag])
-			statuses = append(statuses, params.EntityStatus{
+			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
 				Status: params.StatusDestroying,
 				Info:   err.Error(),
@@ -234,7 +234,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 		return errors.Trace(err)
 	}
 	var reschedule []scheduleOp
-	var statuses []params.EntityStatus
+	var statuses []params.EntityStatusArgs
 	var remove []params.MachineStorageId
 	for sourceName, volumeAttachmentParams := range paramsBySource {
 		logger.Debugf("detaching volumes: %+v", volumeAttachmentParams)
@@ -245,7 +245,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 		}
 		for i, err := range errs {
 			p := volumeAttachmentParams[i]
-			statuses = append(statuses, params.EntityStatus{
+			statuses = append(statuses, params.EntityStatusArgs{
 				Tag: p.Volume.String(),
 				// TODO(axw) when we support multiple
 				// attachment, we'll have to check if


### PR DESCRIPTION
Add STATE and MESSAGE columns as in the main
tabular status output, and "current", "message"
and "since" fields to structured output.

There's a mechanical change which is done as
a separate commit that renames apiserver/params.EntityStatus
to EntityStatusArgs, and introduces a new EntityStatus
which represents status in state. The latter is
embedded in VolumeInstance.

(Review request: http://reviews.vapour.ws/r/2358/)