### PR TITLE
Upgraded goamz dependencies and fixed EC2 tests where needed

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -34,7 +34,7 @@ golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:5
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
 google.golang.org/api	git	0d3983fb069cb6651353fc44c5cb604e263f2a93	2014-12-10T23:51:26Z
 google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T22:36:35Z
-gopkg.in/amz.v3	git	c94308488a39c2d6859aeb51edc28d0f22a9b74c	2015-07-28T01:49:23Z
+gopkg.in/amz.v3	git	c48fcea7c93a08f9c64b568a15ae5c40bbc6493d	2015-08-10T14:29:15Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	15098963088579c1cd9eb1a7da285831e548390b	2015-07-07T18:34:45Z
 gopkg.in/goose.v1	git	39e4e7a5d0eba2923cec7c841870e39decddf05e	2015-07-23T01:53:30Z

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -294,7 +294,12 @@ func (s *ConfigSuite) TestConfig(c *gc.C) {
 func (s *ConfigSuite) TestMissingAuth(c *gc.C) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	// Since r37 goamz uses these as fallbacks, so unset them too.
+
+	// Since PR #52 amz.v3 uses these AWS_ vars as fallbacks, if set.
+	os.Setenv("AWS_ACCESS_KEY", "")
+	os.Setenv("AWS_SECRET_KEY", "")
+
+	// Since LP r37 goamz uses also these EC2_ as fallbacks, so unset them too.
 	os.Setenv("EC2_ACCESS_KEY", "")
 	os.Setenv("EC2_SECRET_KEY", "")
 	test := configTests[0]

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -963,8 +963,9 @@ func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo
 // by the provider for the specified instance. subnetIds must not be
 // empty. Implements NetworkingEnviron.Subnets.
 func (e *environ) Subnets(_ instance.Id, subnetIds []network.Id) ([]network.SubnetInfo, error) {
-	// At some point in the future an empty netIds may mean "fetch all subnets"
-	// but until that functionality is needed it's an error.
+	// At some point in the future an empty subnetIds may mean "fetch
+	// all subnets" but until that functionality is needed it's an
+	// error.
 	if len(subnetIds) == 0 {
 		return nil, errors.Errorf("subnetIds must not be empty")
 	}


### PR DESCRIPTION
First step towards fixing http://pad.lv/1321442 - accepting non-default
VPCs for Juju environments in AWS. For now we just sync-up the goamz
version with extended ec2test server features for setting up complex
VPCs, subnets, zones, routes, etc.

Live tested with -amazon and/or -race and -cover.

(Review request: http://reviews.vapour.ws/r/2363/)