### PR TITLE
State: Add time of dying and death to environ doc

### DIFF
--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -34,6 +35,26 @@ func (s *EnvironSuite) TestEnvironment(c *gc.C) {
 	c.Assert(env.Name(), gc.Equals, "testenv")
 	c.Assert(env.Owner(), gc.Equals, s.Owner)
 	c.Assert(env.Life(), gc.Equals, state.Alive)
+	c.Assert(env.TimeOfDying(), gc.Equals, time.Time{})
+	c.Assert(env.TimeOfDeath(), gc.Equals, time.Time{})
+}
+
+func (s *EnvironSuite) TestEnvironmentDestroy(c *gc.C) {
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	now := state.NowToTheSecond()
+	s.PatchValue(&state.NowToTheSecond, func() time.Time {
+		return now
+	})
+
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+	c.Assert(env.TimeOfDying().UTC(), gc.Equals, now.UTC())
+	c.Assert(env.TimeOfDeath(), gc.Equals, time.Time{})
 }
 
 func (s *EnvironSuite) TestNewEnvironmentNonExistentLocalUser(c *gc.C) {

--- a/state/life.go
+++ b/state/life.go
@@ -34,6 +34,7 @@ func (l Life) String() string {
 }
 
 var isAliveDoc = bson.D{{"life", Alive}}
+var isDyingDoc = bson.D{{"life", Dying}}
 var isDeadDoc = bson.D{{"life", Dead}}
 var notDeadDoc = bson.D{{"life", bson.D{{"$ne", Dead}}}}
 


### PR DESCRIPTION
- Add two new fields to the environmentDoc: "time-of-dying",
"time-of-death".

- Set time of dying when environment is destroyed and life set to
dying.

- Time of death will be set by a new worker, to be introduced in a
follow-up PR.

(Review request: http://reviews.vapour.ws/r/2364/)