### PR TITLE
Allow agent-stream to have arbitrary values

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1532,7 +1532,6 @@ var configSchema = environschema.Fields{
 	AgentStreamKey: {
 		Description: `Version of Juju to use for deploy/upgrades.`,
 		Type:        environschema.Tstring,
-		Values:      []interface{}{"released", "devel", "proposed"},
 		Group:       environschema.EnvironGroup,
 	},
 	"agent-version": {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1484617

Remove restrictions on agent-stream config values.

(Review request: http://reviews.vapour.ws/r/2365/)