### PR TITLE
apiserver: added WatchAllEnvs and AllEnvWatcher endpoint

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -14,6 +14,7 @@ var facadeVersions = map[string]int{
 	"Action":                       0,
 	"Agent":                        1,
 	"AllWatcher":                   0,
+	"AllEnvWatcher":                1,
 	"Annotations":                  1,
 	"Backups":                      0,
 	"Block":                        1,

--- a/apiserver/restricted_root.go
+++ b/apiserver/restricted_root.go
@@ -26,6 +26,7 @@ func newRestrictedRoot(finder rpc.MethodFinder) *restrictedRoot {
 // of the API server. Any facade added here needs to work across environment
 // boundaries.
 var restrictedRootNames = set.NewStrings(
+	"AllEnvWatcher",
 	"EnvironmentManager",
 	"SystemManager",
 	"UserManager",

--- a/apiserver/restricted_root_test.go
+++ b/apiserver/restricted_root_test.go
@@ -35,6 +35,9 @@ func (r *restrictedRootSuite) assertMethodAllowed(c *gc.C, rootName string, vers
 }
 
 func (r *restrictedRootSuite) TestFindAllowedMethod(c *gc.C) {
+	r.assertMethodAllowed(c, "AllEnvWatcher", 1, "Next")
+	r.assertMethodAllowed(c, "AllEnvWatcher", 1, "Stop")
+
 	r.assertMethodAllowed(c, "EnvironmentManager", 1, "CreateEnvironment")
 	r.assertMethodAllowed(c, "EnvironmentManager", 1, "ListEnvironments")
 

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -6,12 +6,12 @@
 package systemmanager
 
 import (
-	"github.com/juju/utils/set"
 	"sort"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -32,6 +32,7 @@ type SystemManager interface {
 	EnvironmentConfig() (params.EnvironmentConfigResults, error)
 	ListBlockedEnvironments() (params.EnvironmentBlockInfoList, error)
 	RemoveBlocks(args params.RemoveBlocksArgs) error
+	WatchAllEnvs() (params.AllWatcherId, error)
 }
 
 // SystemManagerAPI implements the environment manager interface and is
@@ -40,6 +41,7 @@ type SystemManagerAPI struct {
 	state      *state.State
 	authorizer common.Authorizer
 	apiUser    names.UserTag
+	resources  *common.Resources
 }
 
 var _ SystemManager = (*SystemManagerAPI)(nil)
@@ -71,6 +73,7 @@ func NewSystemManagerAPI(
 		state:      st,
 		authorizer: authorizer,
 		apiUser:    apiUser,
+		resources:  resources,
 	}, nil
 }
 
@@ -251,6 +254,16 @@ func (s *SystemManagerAPI) RemoveBlocks(args params.RemoveBlocksArgs) error {
 		return errors.New("not supported")
 	}
 	return errors.Trace(s.state.RemoveAllBlocksForSystem())
+}
+
+// WatchAllEnvs starts watching events for all environments in the
+// system. The returned AllWatcherId should be used with Next on the
+// AllEnvWatcher endpoint to receive deltas.
+func (c *SystemManagerAPI) WatchAllEnvs() (params.AllWatcherId, error) {
+	w := c.state.WatchAllEnvs()
+	return params.AllWatcherId{
+		AllWatcherId: c.resources.Register(w),
+	}, nil
 }
 
 type orderedBlockInfo []params.EnvironmentBlockInfo

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -15,8 +15,16 @@ import (
 
 func init() {
 	common.RegisterFacade(
-		"AllWatcher", 0, newClientAllWatcher,
-		reflect.TypeOf((*srvClientAllWatcher)(nil)),
+		"AllWatcher", 0, NewAllWatcher,
+		reflect.TypeOf((*SrvAllWatcher)(nil)),
+	)
+	// Note: AllEnvWatcher uses the same infrastructure as AllWatcher
+	// but they are get under separate names as it possible the may
+	// diverge in the future (especially in terms of authorisation
+	// checks).
+	common.RegisterFacade(
+		"AllEnvWatcher", 1, NewAllWatcher,
+		reflect.TypeOf((*SrvAllWatcher)(nil)),
 	)
 	common.RegisterFacade(
 		"NotifyWatcher", 0, newNotifyWatcher,
@@ -44,38 +52,42 @@ func init() {
 	)
 }
 
-func newClientAllWatcher(st *state.State, resources *common.Resources, auth common.Authorizer, id string) (interface{}, error) {
+// NewAllEnvWatcher returns a new API server endpoint for interacting
+// with a watcher created by the WatchAll and WatchAllEnvs API calls.
+func NewAllWatcher(st *state.State, resources *common.Resources, auth common.Authorizer, id string) (interface{}, error) {
 	if !auth.AuthClient() {
 		return nil, common.ErrPerm
 	}
+
 	watcher, ok := resources.Get(id).(*state.Multiwatcher)
 	if !ok {
 		return nil, common.ErrUnknownWatcher
 	}
-	return &srvClientAllWatcher{
+	return &SrvAllWatcher{
 		watcher:   watcher,
 		id:        id,
 		resources: resources,
 	}, nil
 }
 
-// srvClientAllWatcher defines the API methods on a state.Multiwatcher.
-// which watches any changes to the state. Each client has its own current set
-// of watchers, stored in resources.
-type srvClientAllWatcher struct {
+// SrvAllWatcher defines the API methods on a state.Multiwatcher.
+// which watches any changes to the state. Each client has its own
+// current set of watchers, stored in resources. It is used by both
+// the AllWatcher and AllEnvWatcher facades.
+type SrvAllWatcher struct {
 	watcher   *state.Multiwatcher
 	id        string
 	resources *common.Resources
 }
 
-func (aw *srvClientAllWatcher) Next() (params.AllWatcherNextResults, error) {
+func (aw *SrvAllWatcher) Next() (params.AllWatcherNextResults, error) {
 	deltas, err := aw.watcher.Next()
 	return params.AllWatcherNextResults{
 		Deltas: deltas,
 	}, err
 }
 
-func (w *srvClientAllWatcher) Stop() error {
+func (w *SrvAllWatcher) Stop() error {
 	return w.resources.Stop(w.id)
 }
 


### PR DESCRIPTION
This provides API access to the allEnvWatcher functionality recently added to state.

(Review request: http://reviews.vapour.ws/r/2366/)