### PR TITLE
dependency/engine: Added a Reporter interface for manifolds and engines

### DIFF
--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -128,6 +128,20 @@ func (engine *engine) Install(name string, manifold Manifold) error {
 	}
 }
 
+// Report grabs status information about the engine.
+func (engine *engine) Report() map[string]interface{} {
+	status := map[string]interface{}{}
+	manifolds := map[string]interface{}{}
+
+	status["is-dying"] = engine.isDying()
+	status["manifold-count"] = len(engine.manifolds)
+	for k, v := range engine.manifolds {
+		manifolds[k] = v.Report()
+	}
+	status["manifolds"] = manifolds
+	return status
+}
+
 // gotInstall handles the params originally supplied to Install. It must only be
 // called from the loop goroutine.
 func (engine *engine) gotInstall(name string, manifold Manifold) error {

--- a/worker/dependency/interface.go
+++ b/worker/dependency/interface.go
@@ -20,6 +20,8 @@ type Engine interface {
 
 	// Engine is just another Worker.
 	worker.Worker
+
+	Reporter
 }
 
 // Manifold defines the behaviour of a node in an Engine's dependency graph. It's
@@ -36,10 +38,20 @@ type Manifold struct {
 	// Start is used to create a worker for the manifold. It must not be nil.
 	Start StartFunc
 
+	// Report is used to return status information about the manifold.
+	Reporter ReportFunc
+
 	// Output is used to implement a GetResourceFunc for manifolds that declare
 	// a dependency on this one; it can be nil if your manifold is a leaf node,
 	// or if it exposes no services to its dependents.
 	Output OutputFunc
+}
+
+func (m *Manifold) Report() map[string]interface{} {
+	if m.Reporter != nil {
+		return m.Reporter()
+	}
+	return nil
 }
 
 // Manifolds conveniently represents several Manifolds.
@@ -89,3 +101,6 @@ type OutputFunc func(in worker.Worker, out interface{}) error
 // an error that satisfies the engine's IsFatalFunc, the engine will stop all
 // its workers, shut itself down, and return the original fatal error via Wait().
 type IsFatalFunc func(err error) bool
+
+// ReportFunc is used to return status information about the manifold.
+type ReportFunc func() map[string]interface{}

--- a/worker/dependency/reporter.go
+++ b/worker/dependency/reporter.go
@@ -1,0 +1,12 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency
+
+// Reporter defines an interface that can be used to get reports
+// from types that implement this interface.
+// A report is just a map of values that might be of interest.
+// The primary use case is status reports
+type Reporter interface {
+	Report() map[string]interface{}
+}

--- a/worker/dependency/reporter_test.go
+++ b/worker/dependency/reporter_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+func (s *EngineSuite) TestReport(c *gc.C) {
+	mh1 := newManifoldHarness()
+	err := s.engine.Install("task", mh1.Manifold())
+	c.Assert(err, jc.ErrorIsNil)
+	mh1.AssertOneStart(c)
+
+	report := s.engine.Report()
+	c.Assert(report["is-dying"], gc.Equals, false)
+	c.Assert(report["manifold-count"], gc.Equals, 1)
+}
+
+func (s *EngineSuite) TestReportReachesManifolds(c *gc.C) {
+	mh1 := newManifoldHarness()
+	manifold := mh1.Manifold()
+	manifold.Reporter = func() map[string]interface{} {
+		return map[string]interface{}{"here": "hello world"}
+	}
+	err := s.engine.Install("task", manifold)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mh2 := newManifoldHarness()
+	err = s.engine.Install("another task", mh2.Manifold())
+	c.Assert(err, jc.ErrorIsNil)
+
+	report := s.engine.Report()
+	c.Assert(report["is-dying"], gc.Equals, false)
+	c.Assert(report["manifold-count"], gc.Equals, 2)
+	c.Assert(report["manifolds"], gc.HasLen, 2)
+	manifolds := report["manifolds"].(map[string]interface{})
+	c.Assert(manifolds["task"], gc.DeepEquals, map[string]interface{}{"here": "hello world"})
+	c.Assert(manifolds["another task"], gc.DeepEquals, map[string]interface{}(nil))
+}


### PR DESCRIPTION
It is useful to get status information about Engines and Manifolds. Manifolds will just call their given ReporterFunc to produce status information about themselves. The Engine will report information about itself and all Manifolds below it in the graph.

(Review request: http://reviews.vapour.ws/r/2368/)