### PR TITLE
Force shutdowns on windows

### DIFF
--- a/cmd/jujud/reboot/reboot_windows.go
+++ b/cmd/jujud/reboot/reboot_windows.go
@@ -15,7 +15,7 @@ func scheduleAction(action params.RebootAction, after int) error {
 	if action == params.ShouldDoNothing {
 		return nil
 	}
-	args := []string{"shutdown.exe"}
+	args := []string{"shutdown.exe", "-f"}
 	switch action {
 	case params.ShouldReboot:
 		args = append(args, "-r")

--- a/cmd/jujud/reboot/reboot_windows_test.go
+++ b/cmd/jujud/reboot/reboot_windows_test.go
@@ -16,6 +16,7 @@ const (
 
 func (s *RebootSuite) rebootCommandParams(c *gc.C) []string {
 	return []string{
+		"-f",
 		"-r",
 		"-t",
 		rebootTime,
@@ -24,6 +25,7 @@ func (s *RebootSuite) rebootCommandParams(c *gc.C) []string {
 
 func (s *RebootSuite) shutdownCommandParams(c *gc.C) []string {
 	return []string{
+		"-f",
 		"-s",
 		"-t",
 		rebootTime,


### PR DESCRIPTION
The shutdown command should have -f as a parameter on windows machines to catch some edge cases where it might not execute.

(Review request: http://reviews.vapour.ws/r/2371/)