### PR TITLE
Added --constranits spaces= support

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -44,6 +44,7 @@ type Client struct {
 
 // NetworksSpecification holds the enabled and disabled networks for a
 // service.
+// TODO(dimitern): Drop this in a follow-up.
 type NetworksSpecification struct {
 	Enabled  []string
 	Disabled []string

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -264,6 +264,9 @@ func (c *Client) ServiceDeploy(args params.ServiceDeploy) error {
 // allows specifying networks to include or exclude on the machine
 // where the charm gets deployed (either with args.Network or with
 // constraints).
+//
+// TODO(dimitern): Drop the special handling of networks in favor of
+// spaces constraints, once possible.
 func (c *Client) ServiceDeployWithNetworks(args params.ServiceDeploy) error {
 	return c.ServiceDeploy(args)
 }

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -578,6 +578,7 @@ func (context *statusContext) processService(service *state.Service) (status api
 			return
 		}
 	}
+	// TODO(dimitern): Drop support for this in a follow-up.
 	if len(networks) > 0 || cons.HaveNetworks() {
 		// Only the explicitly requested networks (using "juju deploy
 		// <svc> --networks=...") will be enabled, and altough when

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -110,6 +110,9 @@ type InstanceConfig struct {
 	MachineContainerHostname string
 
 	// Networks holds a list of networks the instances should be on.
+	//
+	// TODO(dimitern): Drop this in a follow-up in favor or spaces
+	// constraints.
 	Networks []string
 
 	// AuthorizedKeys specifies the keys that are allowed to

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -32,7 +32,7 @@ type DeployCommand struct {
 	ServiceName  string
 	Config       cmd.FileVar
 	Constraints  constraints.Value
-	Networks     string
+	Networks     string // TODO(dimitern): Drop this in a follow-up and fix docs.
 	BumpRevision bool   // Remove this once the 1.16 support is dropped.
 	RepoPath     string // defaults to JUJU_REPOSITORY
 	RegisterURL  string
@@ -204,6 +204,8 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		ctx.Infof("--upgrade (or -u) is deprecated and ignored; charms are always deployed with a unique revision.")
 	}
 
+	// TODO(dimitern): Drop --networks and use spaces constraints
+	// below in a follow-up.
 	requestedNetworks, err := networkNamesToTags(parseNetworks(c.Networks))
 	if err != nil {
 		return err

--- a/cmd/juju/commands/status.go
+++ b/cmd/juju/commands/status.go
@@ -352,6 +352,7 @@ func (sf *statusFormatter) format() formattedStatus {
 	for sn, s := range sf.status.Services {
 		out.Services[sn] = sf.formatService(sn, s)
 	}
+	// TODO(dimitern): Drop this and the related code in a follow-up.
 	for k, n := range sf.status.Networks {
 		if out.Networks == nil {
 			out.Networks = make(map[string]networkStatus)

--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -265,13 +265,34 @@ var parseConstraintsTests = []struct {
 		args:    []string{"tags="},
 	},
 
+	// spaces
+	{
+		summary: "single space",
+		args:    []string{"spaces=space1"},
+	}, {
+		summary: "multiple spaces - positive",
+		args:    []string{"spaces=space1,space2"},
+	}, {
+		summary: "multiple spaces - negative",
+		args:    []string{"spaces=^dmz,^public"},
+	}, {
+		summary: "multiple spaces - positive and negative",
+		args:    []string{"spaces=admin,^area52,dmz,^public"},
+	}, {
+		summary: "no spaces",
+		args:    []string{"spaces="},
+	},
+
 	// networks
 	{
 		summary: "single network",
-		args:    []string{"networks=net1"},
+		args:    []string{"networks=space1"},
 	}, {
 		summary: "multiple networks - positive",
 		args:    []string{"networks=net1,net2"},
+	}, {
+		summary: "multiple networks - negative",
+		args:    []string{"networks=^net1,^net2"},
 	}, {
 		summary: "multiple networks - positive and negative",
 		args:    []string{"networks=net1,^net2,net3,^net4"},
@@ -294,12 +315,13 @@ var parseConstraintsTests = []struct {
 		summary: "kitchen sink together",
 		args: []string{
 			"root-disk=8G mem=2T  arch=i386  cpu-cores=4096 cpu-power=9001 container=lxc " +
-				"tags=foo,bar networks=net1,^net2 instance-type=foo"},
+				"tags=foo,bar spaces=space1,^space2 networks=net,^net2 instance-type=foo"},
 	}, {
 		summary: "kitchen sink separately",
 		args: []string{
 			"root-disk=8G", "mem=2T", "cpu-cores=4096", "cpu-power=9001", "arch=armhf",
-			"container=lxc", "tags=foo,bar", "networks=net1,^net2", "instance-type=foo"},
+			"container=lxc", "tags=foo,bar", "spaces=space1,^space2", "networks=net1,^net2",
+			"instance-type=foo"},
 	},
 }
 
@@ -322,7 +344,9 @@ func (s *ConstraintsSuite) TestParseConstraints(c *gc.C) {
 func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	con1 := constraints.MustParse("arch=amd64 mem=4G")
 	con2 := constraints.MustParse("cpu-cores=42")
-	con3 := constraints.MustParse("root-disk=8G container=lxc networks=net1,^net2")
+	con3 := constraints.MustParse(
+		"root-disk=8G container=lxc spaces=space1,^space2 networks=net1,^net2",
+	)
 	merged, err := constraints.Merge(con1, con2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(merged, jc.DeepEquals, constraints.MustParse("arch=amd64 mem=4G cpu-cores=42"))
@@ -331,7 +355,10 @@ func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	c.Assert(merged, jc.DeepEquals, con1)
 	merged, err = constraints.Merge(con1, con2, con3)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(merged, jc.DeepEquals, constraints.MustParse("arch=amd64 mem=4G cpu-cores=42 root-disk=8G container=lxc networks=net1,^net2"))
+	c.Assert(merged, jc.DeepEquals, constraints.
+		MustParse(
+		"arch=amd64 mem=4G cpu-cores=42 root-disk=8G container=lxc spaces=space1,^space2 networks=net1,^net2"),
+	)
 	merged, err = constraints.Merge()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(merged, jc.DeepEquals, constraints.Value{})
@@ -346,18 +373,39 @@ func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	c.Assert(merged, jc.DeepEquals, constraints.Value{})
 }
 
-func (s *ConstraintsSuite) TestParseMissingTagsAndNetworks(c *gc.C) {
+func (s *ConstraintsSuite) TestParseMissingTagsSpacesAndNetworks(c *gc.C) {
 	con := constraints.MustParse("arch=amd64 mem=4G cpu-cores=1 root-disk=8G")
 	c.Check(con.Tags, gc.IsNil)
+	c.Check(con.Spaces, gc.IsNil)
 	c.Check(con.Networks, gc.IsNil)
 }
 
-func (s *ConstraintsSuite) TestParseNoTagsNoNetworks(c *gc.C) {
-	con := constraints.MustParse("arch=amd64 mem=4G cpu-cores=1 root-disk=8G tags= networks=")
+func (s *ConstraintsSuite) TestParseNoTagsNoSpacesNoNetworks(c *gc.C) {
+	con := constraints.MustParse(
+		"arch=amd64 mem=4G cpu-cores=1 root-disk=8G tags= spaces= networks=",
+	)
 	c.Assert(con.Tags, gc.Not(gc.IsNil))
-	c.Assert(con.Networks, gc.Not(gc.IsNil))
+	c.Assert(con.Spaces, gc.Not(gc.IsNil))
 	c.Check(*con.Tags, gc.HasLen, 0)
+	c.Check(*con.Spaces, gc.HasLen, 0)
 	c.Check(*con.Networks, gc.HasLen, 0)
+}
+
+func (s *ConstraintsSuite) TestIncludeExcludeAndHaveSpaces(c *gc.C) {
+	con := constraints.MustParse("spaces=space1,^space2,space3,^space4")
+	c.Assert(con.Spaces, gc.Not(gc.IsNil))
+	c.Check(*con.Spaces, gc.HasLen, 4)
+	c.Check(con.IncludeSpaces(), jc.SameContents, []string{"space1", "space3"})
+	c.Check(con.ExcludeSpaces(), jc.SameContents, []string{"space2", "space4"})
+	c.Check(con.HaveSpaces(), jc.IsTrue)
+	c.Check(con.HaveNetworks(), jc.IsFalse)
+	con = constraints.MustParse("mem=4G")
+	c.Check(con.HaveSpaces(), jc.IsFalse)
+	con = constraints.MustParse("mem=4G spaces=space-foo,^space-bar")
+	c.Check(con.IncludeSpaces(), jc.SameContents, []string{"space-foo"})
+	c.Check(con.ExcludeSpaces(), jc.SameContents, []string{"space-bar"})
+	c.Check(con.HaveSpaces(), jc.IsTrue)
+	c.Check(con.HaveNetworks(), jc.IsFalse)
 }
 
 func (s *ConstraintsSuite) TestIncludeExcludeAndHaveNetworks(c *gc.C) {
@@ -367,10 +415,30 @@ func (s *ConstraintsSuite) TestIncludeExcludeAndHaveNetworks(c *gc.C) {
 	c.Check(con.IncludeNetworks(), jc.SameContents, []string{"net1", "net3"})
 	c.Check(con.ExcludeNetworks(), jc.SameContents, []string{"net2", "net4"})
 	c.Check(con.HaveNetworks(), jc.IsTrue)
+	c.Check(con.HaveSpaces(), jc.IsFalse)
 	con = constraints.MustParse("mem=4G")
 	c.Check(con.HaveNetworks(), jc.IsFalse)
-	con = constraints.MustParse("mem=4G networks=^net1,^net2")
+	con = constraints.MustParse("mem=4G networks=net-foo,^net-bar")
+	c.Check(con.IncludeNetworks(), jc.SameContents, []string{"net-foo"})
+	c.Check(con.ExcludeNetworks(), jc.SameContents, []string{"net-bar"})
 	c.Check(con.HaveNetworks(), jc.IsTrue)
+	c.Check(con.HaveSpaces(), jc.IsFalse)
+}
+
+func (s *ConstraintsSuite) TestInvalidSpaces(c *gc.C) {
+	invalidNames := []string{
+		"%$pace", "^foo#2", "+", "tcp:ip",
+		"^^myspace", "^^^^^^^^", "space^x",
+		"&-foo", "space/3", "^bar=4", "&#!",
+	}
+	for _, name := range invalidNames {
+		con, err := constraints.Parse("spaces=" + name)
+		expectName := strings.TrimPrefix(name, "^")
+		expectErr := fmt.Sprintf(`bad "spaces" constraint: %q is not a valid space name`, expectName)
+		c.Check(err, gc.NotNil)
+		c.Check(err.Error(), gc.Equals, expectErr)
+		c.Check(con, jc.DeepEquals, constraints.Value{})
+	}
 }
 
 func (s *ConstraintsSuite) TestInvalidNetworks(c *gc.C) {
@@ -397,6 +465,8 @@ func (s *ConstraintsSuite) TestIsEmpty(c *gc.C) {
 	con = constraints.MustParse("")
 	c.Check(&con, jc.Satisfies, constraints.IsEmpty)
 	con = constraints.MustParse("tags=")
+	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
+	con = constraints.MustParse("spaces=")
 	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
 	con = constraints.MustParse("networks=")
 	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
@@ -456,6 +526,9 @@ var constraintsRoundtripTests = []roundTrip{
 	{"Tags1", constraints.Value{Tags: nil}},
 	{"Tags2", constraints.Value{Tags: &[]string{}}},
 	{"Tags3", constraints.Value{Tags: &[]string{"foo", "bar"}}},
+	{"Spaces1", constraints.Value{Spaces: nil}},
+	{"Spaces2", constraints.Value{Spaces: &[]string{}}},
+	{"Spaces3", constraints.Value{Spaces: &[]string{"space1", "^space2"}}},
 	{"Networks1", constraints.Value{Networks: nil}},
 	{"Networks2", constraints.Value{Networks: &[]string{}}},
 	{"Networks3", constraints.Value{Networks: &[]string{"net1", "^net2"}}},
@@ -469,6 +542,7 @@ var constraintsRoundtripTests = []roundTrip{
 		Mem:          uint64p(18000000000),
 		RootDisk:     uint64p(24000000000),
 		Tags:         &[]string{"foo", "bar"},
+		Spaces:       &[]string{"space1", "^space2"},
 		Networks:     &[]string{"net1", "^net2"},
 		InstanceType: strp("foo"),
 	}},
@@ -548,7 +622,7 @@ func (s *ConstraintsSuite) TestHasInstanceType(c *gc.C) {
 	c.Check(cons.HasInstanceType(), jc.IsTrue)
 }
 
-const initialWithoutCons = "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 networks=net1,^net2 tags=foo container=lxc instance-type=bar"
+const initialWithoutCons = "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 spaces=space1,^space2 networks=net1,^net2 tags=foo container=lxc instance-type=bar"
 
 var withoutTests = []struct {
 	initial string
@@ -557,43 +631,47 @@ var withoutTests = []struct {
 }{{
 	initial: initialWithoutCons,
 	without: []string{"root-disk"},
-	final:   "mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"mem"},
-	final:   "root-disk=8G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"arch"},
-	final:   "root-disk=8G mem=4G cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"cpu-power"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"cpu-cores"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"tags"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
+}, {
+	initial: initialWithoutCons,
+	without: []string{"spaces"},
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"networks"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"container"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"instance-type"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxc networks=net1,^net2",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"root-disk", "mem", "arch"},
-	final:   "cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }}
 
 func (s *ConstraintsSuite) TestWithout(c *gc.C) {
@@ -615,7 +693,7 @@ func (s *ConstraintsSuite) TestWithoutError(c *gc.C) {
 func (s *ConstraintsSuite) TestAttributesWithValues(c *gc.C) {
 	for i, consStr := range []string{
 		"",
-		"root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 instance-type=foo tags=foo,bar networks=net1,^net2",
+		"root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 instance-type=foo tags=foo,bar spaces=space1,^space2",
 	} {
 		c.Logf("test %d", i)
 		cons := constraints.MustParse(consStr)
@@ -654,6 +732,11 @@ func (s *ConstraintsSuite) TestAttributesWithValues(c *gc.C) {
 		} else {
 			assertMissing("tags")
 		}
+		if cons.Spaces != nil {
+			c.Check(obtained["spaces"], gc.DeepEquals, *cons.Spaces)
+		} else {
+			assertMissing("spaces")
+		}
 		if cons.Networks != nil {
 			c.Check(obtained["networks"], gc.DeepEquals, *cons.Networks)
 		} else {
@@ -673,13 +756,18 @@ var hasAnyTests = []struct {
 	expected []string
 }{
 	{
+		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 spaces=space1,^space2 cpu-cores=4",
+		attrs:    []string{"root-disk", "tags", "mem", "spaces"},
+		expected: []string{"root-disk", "mem", "spaces"},
+	},
+	{
 		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 networks=net1,^net2 cpu-cores=4",
 		attrs:    []string{"root-disk", "tags", "mem", "networks"},
 		expected: []string{"root-disk", "mem", "networks"},
 	},
 	{
 		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
-		attrs:    []string{"tags", "networks"},
+		attrs:    []string{"tags", "spaces", "networks"},
 		expected: []string{},
 	},
 }

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -36,6 +36,7 @@ type DeployServiceParams struct {
 	// instead of a machine spec.
 	Placement []*instance.Placement
 	// Networks holds a list of networks to required to start on boot.
+	// TODO(dimitern): Drop this in a follow-up in favor of constraints.
 	Networks []string
 	Storage  map[string]storage.Constraints
 }
@@ -66,6 +67,8 @@ func DeployService(st *state.State, args DeployServiceParams) (*state.Service, e
 	}
 	// TODO(fwereade): transactional State.AddService including settings, constraints
 	// (minimumUnitCount, initialMachineIds?).
+
+	// TODO(dimitern): Drop --networks in a follow-up with an error.
 	if len(args.Networks) > 0 || args.Constraints.HaveNetworks() {
 		conf, err := st.EnvironConfig()
 		if err != nil {
@@ -79,6 +82,8 @@ func DeployService(st *state.State, args DeployServiceParams) (*state.Service, e
 			return nil, fmt.Errorf("cannot deploy with networks: not suppored by the environment")
 		}
 	}
+	// TODO(dimitern): In a follow-up drop Networks and use spaces
+	// constraints for this when possible.
 	service, err := st.AddService(
 		args.ServiceName,
 		args.ServiceOwner,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -957,6 +957,9 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		}
 	}
 	// Simulate networks added when requested.
+	//
+	// TODO(dimitern): Fix this in a follow-up to use constraints
+	// instead.
 	networks := append(args.Constraints.IncludeNetworks(), args.InstanceConfig.Networks...)
 	networkInfo := make([]network.InterfaceInfo, len(networks))
 	for i, netName := range networks {

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -66,6 +66,7 @@ func (env *environ) lookupArchitectures() ([]string, error) {
 
 var unsupportedConstraints = []string{
 	constraints.Tags,
+	// TODO(dimitern: Replace Networks with Spaces in a follow-up.
 	constraints.Networks,
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -900,6 +900,10 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	}
 
 	// Networking.
+	//
+	// TODO(dimitern): Once we can get from spaces constraints to MAAS
+	// networks (or even directly to spaces), include them in the
+	// instance selection.
 	requestedNetworks := args.InstanceConfig.Networks
 	includeNetworks := append(args.Constraints.IncludeNetworks(), requestedNetworks...)
 	excludeNetworks := args.Constraints.ExcludeNetworks()

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -56,6 +56,8 @@ type MachineTemplate struct {
 
 	// RequestedNetworks holds a list of network names the machine
 	// should be part of.
+	//
+	// TODO(dimitern): Drop this in favor of constraints in a follow-up.
 	RequestedNetworks []string
 
 	// Volumes holds the parameters for volumes that are to be created

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -26,7 +26,10 @@ type constraintsDoc struct {
 	InstanceType *string
 	Container    *instance.ContainerType
 	Tags         *[]string `bson:",omitempty"`
-	Networks     *[]string `bson:",omitempty"`
+	Spaces       *[]string `bson:",omitempty"`
+	// TODO(dimitern): Drop this once it's not possible to specify
+	// networks= in constraints.
+	Networks *[]string `bson:",omitempty"`
 }
 
 func (doc constraintsDoc) value() constraints.Value {
@@ -39,6 +42,7 @@ func (doc constraintsDoc) value() constraints.Value {
 		InstanceType: doc.InstanceType,
 		Container:    doc.Container,
 		Tags:         doc.Tags,
+		Spaces:       doc.Spaces,
 		Networks:     doc.Networks,
 	}
 }
@@ -54,6 +58,7 @@ func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
 		InstanceType: cons.InstanceType,
 		Container:    cons.Container,
 		Tags:         cons.Tags,
+		Spaces:       cons.Spaces,
 		Networks:     cons.Networks,
 	}
 }

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -78,6 +78,14 @@ var setConstraintsTests = []struct {
 	consFallback: "cpu-cores=4 mem=2G networks=",
 	cons:         "mem=4G networks=net1,^net3",
 	expected:     "cpu-cores=4 mem=4G networks=net1,^net3",
+}, {
+	consFallback: "cpu-cores=4 mem=4G spaces=space1,^space3",
+	cons:         "spaces=space2,^space4 mem=4G",
+	expected:     "cpu-cores=4 mem=4G spaces=space2,^space4",
+}, {
+	consFallback: "cpu-cores=4 mem=2G spaces=",
+	cons:         "mem=4G spaces=space1,^space3",
+	expected:     "cpu-cores=4 mem=4G spaces=space1,^space3",
 }}
 
 func (s *constraintsValidationSuite) TestMachineConstraints(c *gc.C) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -1261,6 +1261,9 @@ func (m *Machine) setAddresses(addresses []network.Address, field *[]address, fi
 // RequestedNetworks returns the list of network names the machine
 // should be on. Unlike networks specified with constraints, these
 // networks are required to be present on the machine.
+//
+// TODO(dimitern): Drop this when we can use space bindings derived
+// from constraints.
 func (m *Machine) RequestedNetworks() ([]string, error) {
 	return readRequestedNetworks(m.st, m.globalKey())
 }

--- a/state/service.go
+++ b/state/service.go
@@ -1001,6 +1001,9 @@ func (s *Service) SetConstraints(cons constraints.Value) (err error) {
 // Networks returns the networks a service is associated with. Unlike
 // networks specified with constraints, these networks are required to
 // be present on machines hosting this service's units.
+//
+// TODO(dimitern): Convert this to use spaces from constraints or drop
+// it entirely.
 func (s *Service) Networks() ([]string, error) {
 	return readRequestedNetworks(s.st, s.globalKey())
 }


### PR DESCRIPTION
First step towards being able to deploy workloads in a space.
For now, networks constraints support remain until we can drop
it. Added a lot of TODOs on key parts of the code we need to
keep in mind and address later (e.g. CLI, providers, API).

(Review request: http://reviews.vapour.ws/r/2376/)