### PR TITLE
Fixed the bzr revision id of gwacl in dependencies.tsv

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -50,5 +50,5 @@ gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:0
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20141121040613-ztm1q0iy9rune3zt	13
 launchpad.net/gomaasapi	bzr	michael.foord@canonical.com-20150703101140-oo7493pkzlzg7l6u	63
-launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20150810080433-4l0x47qsc16ure7c	245
+launchpad.net/gwacl	bzr	andrew.wilkins@canonical.com-20150811023840-kvosbu9d0kwwjfm2	245
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17


### PR DESCRIPTION
I'm getting an error when running `godeps -u dependencies.tsv`
on master:

`
godeps: cannot get information on "/home/dimitern/work/go/src/launchpad.net/gwacl": bzr revision-info has unexpected result "244.1.1 andrew.wilkins@canonical.com-20150810080433-4l0x47qsc16ure7c\n"
`

Even though the above is really an issue with godeps itself
(filed a separate MP for this), the current gwacl revision in
dependencies.tsv is wrong - it should be 245, which is the
parent merge commit of 244.1.1 and trunk at the time of landing.

(Review request: http://reviews.vapour.ws/r/2377/)