### PR TITLE
Remove mgo test package dependency in machinelock tests.

### DIFF
--- a/worker/machinelock/package_test.go
+++ b/worker/machinelock/package_test.go
@@ -4,11 +4,11 @@
 package machinelock_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
-	coretesting "github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
-func TestPackage(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
 }


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/2380/)