### PR TITLE
Spooldirectory degenerate worker

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -186,6 +186,39 @@ var agentConfigTests = []struct {
 		c.Check(cfg.LogDir(), gc.Equals, agent.DefaultLogDir)
 	},
 }, {
+	about: "missing metricsSpoolDir sets default",
+	params: agent.AgentConfigParams{
+		DataDir:           "/data/dir",
+		Tag:               names.NewMachineTag("1"),
+		Password:          "sekrit",
+		UpgradedToVersion: version.Current.Number,
+		CACert:            "ca cert",
+		Environment:       testing.EnvironmentTag,
+		StateAddresses:    []string{"localhost:1234"},
+		APIAddresses:      []string{"localhost:1235"},
+		Nonce:             "a nonce",
+	},
+	inspectConfig: func(c *gc.C, cfg agent.Config) {
+		c.Check(cfg.MetricsSpoolDir(), gc.Equals, agent.DefaultMetricsSpoolDir)
+	},
+}, {
+	about: "setting a custom metricsSpoolDir",
+	params: agent.AgentConfigParams{
+		DataDir:           "/data/dir",
+		MetricsSpoolDir:   "/tmp/nowhere",
+		Tag:               names.NewMachineTag("1"),
+		Password:          "sekrit",
+		UpgradedToVersion: version.Current.Number,
+		CACert:            "ca cert",
+		Environment:       testing.EnvironmentTag,
+		StateAddresses:    []string{"localhost:1234"},
+		APIAddresses:      []string{"localhost:1235"},
+		Nonce:             "a nonce",
+	},
+	inspectConfig: func(c *gc.C, cfg agent.Config) {
+		c.Check(cfg.MetricsSpoolDir(), gc.Equals, "/tmp/nowhere")
+	},
+}, {
 	about: "agentConfig must not be a User tag",
 	params: agent.AgentConfigParams{
 		DataDir:           "/data/dir",

--- a/agent/export_test.go
+++ b/agent/export_test.go
@@ -52,6 +52,7 @@ func ConfigFileExists(config Config) bool {
 }
 
 var (
-	MachineJobFromParams = machineJobFromParams
-	IsLocalEnv           = &isLocalEnv
+	MachineJobFromParams   = machineJobFromParams
+	IsLocalEnv             = &isLocalEnv
+	DefaultMetricsSpoolDir = metricsSpoolDir
 )

--- a/agent/format-1.18.go
+++ b/agent/format-1.18.go
@@ -31,6 +31,7 @@ type format_1_18Serialization struct {
 	Tag               string
 	DataDir           string
 	LogDir            string
+	MetricsSpoolDir   string
 	Nonce             string
 	Jobs              []multiwatcher.MachineJob `yaml:",omitempty"`
 	UpgradedToVersion *version.Number           `yaml:"upgradedToVersion"`
@@ -93,6 +94,7 @@ func (formatter_1_18) unmarshal(data []byte) (*configInternal, error) {
 		tag:               tag,
 		dataDir:           format.DataDir,
 		logDir:            format.LogDir,
+		metricsSpoolDir:   format.MetricsSpoolDir,
 		jobs:              format.Jobs,
 		upgradedToVersion: *format.UpgradedToVersion,
 		nonce:             format.Nonce,
@@ -107,6 +109,9 @@ func (formatter_1_18) unmarshal(data []byte) (*configInternal, error) {
 	}
 	if config.dataDir == "" {
 		config.dataDir = DefaultDataDir
+	}
+	if config.metricsSpoolDir == "" {
+		config.metricsSpoolDir = metricsSpoolDir
 	}
 	if len(format.StateAddresses) > 0 {
 		config.stateDetails = &connectionDetails{
@@ -162,6 +167,7 @@ func (formatter_1_18) marshal(config *configInternal) ([]byte, error) {
 		Tag:               config.tag.String(),
 		DataDir:           config.dataDir,
 		LogDir:            config.logDir,
+		MetricsSpoolDir:   config.metricsSpoolDir,
 		Jobs:              config.jobs,
 		UpgradedToVersion: &config.upgradedToVersion,
 		Nonce:             config.nonce,

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -91,6 +91,10 @@ type InstanceConfig struct {
 	// LogDir holds the directory that juju logs will be written to.
 	LogDir string
 
+	// MetricsSpoolDir represents the spool directory path, where all
+	// metrics are stored.
+	MetricsSpoolDir string
+
 	// Jobs holds what machine jobs to run.
 	Jobs []multiwatcher.MachineJob
 
@@ -218,6 +222,7 @@ func (cfg *InstanceConfig) AgentConfig(
 		DataDir:           cfg.DataDir,
 		LogDir:            cfg.LogDir,
 		Jobs:              cfg.Jobs,
+		MetricsSpoolDir:   cfg.MetricsSpoolDir,
 		Tag:               tag,
 		UpgradedToVersion: toolsVersion,
 		Password:          password,
@@ -405,11 +410,16 @@ func NewInstanceConfig(
 	if err != nil {
 		return nil, err
 	}
+	metricsSpoolDir, err := paths.MetricsSpoolDir(series)
+	if err != nil {
+		return nil, err
+	}
 	cloudInitOutputLog := path.Join(logDir, "cloud-init-output.log")
 	icfg := &InstanceConfig{
 		// Fixed entries.
 		DataDir:                 dataDir,
 		LogDir:                  path.Join(logDir, "juju"),
+		MetricsSpoolDir:         metricsSpoolDir,
 		Jobs:                    []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 		CloudInitOutputLog:      cloudInitOutputLog,
 		MachineAgentServiceName: "jujud-" + names.NewMachineTag(machineID).String(),

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -1255,9 +1255,12 @@ func (*cloudinitSuite) TestWindowsCloudInit(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		logDir, err := paths.LogDir(test.cfg.Series)
 		c.Assert(err, jc.ErrorIsNil)
+		metricsSpoolDir, err := paths.MetricsSpoolDir(test.cfg.Series)
+		c.Assert(err, jc.ErrorIsNil)
 
 		test.cfg.DataDir = dataDir
 		test.cfg.LogDir = path.Join(logDir, "juju")
+		test.cfg.MetricsSpoolDir = metricsSpoolDir
 
 		ci, err := cloudinit.New("win8")
 		c.Assert(err, jc.ErrorIsNil)

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -839,6 +839,7 @@ Set-Content 'C:/Juju/lib/juju/agents/machine-10/agent.conf' @"
 tag: machine-10
 datadir: C:/Juju/lib/juju
 logdir: C:/Juju/log/juju
+metricsspooldir: C:/Juju/lib/juju/spool
 nonce: FAKE_NONCE
 jobs:
 - JobHostUnits

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -19,26 +19,29 @@ const (
 	confDir
 	jujuRun
 	certDir
+	metricsSpoolDir
 )
 
 var nixVals = map[osVarType]string{
-	tmpDir:     "/tmp",
-	logDir:     "/var/log",
-	dataDir:    "/var/lib/juju",
-	storageDir: "/var/lib/juju/storage",
-	confDir:    "/etc/juju",
-	jujuRun:    "/usr/bin/juju-run",
-	certDir:    "/etc/juju/certs.d",
+	tmpDir:          "/tmp",
+	logDir:          "/var/log",
+	dataDir:         "/var/lib/juju",
+	storageDir:      "/var/lib/juju/storage",
+	confDir:         "/etc/juju",
+	jujuRun:         "/usr/bin/juju-run",
+	certDir:         "/etc/juju/certs.d",
+	metricsSpoolDir: "/var/lib/juju/spool",
 }
 
 var winVals = map[osVarType]string{
-	tmpDir:     "C:/Juju/tmp",
-	logDir:     "C:/Juju/log",
-	dataDir:    "C:/Juju/lib/juju",
-	storageDir: "C:/Juju/lib/juju/storage",
-	confDir:    "C:/Juju/etc",
-	jujuRun:    "C:/Juju/bin/juju-run.exe",
-	certDir:    "C:/Juju/certs",
+	tmpDir:          "C:/Juju/tmp",
+	logDir:          "C:/Juju/log",
+	dataDir:         "C:/Juju/lib/juju",
+	storageDir:      "C:/Juju/lib/juju/storage",
+	confDir:         "C:/Juju/etc",
+	jujuRun:         "C:/Juju/bin/juju-run.exe",
+	certDir:         "C:/Juju/certs",
+	metricsSpoolDir: "C:/Juju/lib/juju/spool",
 }
 
 // osVal will lookup the value of the key valname
@@ -74,6 +77,12 @@ func LogDir(series string) (string, error) {
 // store tools, charms, locks, etc
 func DataDir(series string) (string, error) {
 	return osVal(series, dataDir)
+}
+
+// MetricsSpoolDir returns a filesystem path to the folder used by juju
+// to store metrics.
+func MetricsSpoolDir(series string) (string, error) {
+	return osVal(series, metricsSpoolDir)
 }
 
 // CertDir returns a filesystem path to the folder used by juju to

--- a/worker/metrics/spooldirectory/manifold.go
+++ b/worker/metrics/spooldirectory/manifold.go
@@ -1,0 +1,70 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package spooldirectory contains the implementation of a degenerate
+// worker that extracts the spool directory path from the agent
+// config and makes it available to other workers that depend
+// on it.
+package spooldirectory
+
+import (
+	"github.com/juju/errors"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldConfig specifies names a spooldirectory manifold should use to
+// address its dependencies.
+type ManifoldConfig util.AgentManifoldConfig
+
+// Manifold returns a dependency.Manifold that extracts the metrics
+// spool directory path from the agent.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	manifold := util.AgentManifold(util.AgentManifoldConfig(config), newWorker)
+	manifold.Output = outputFunc
+	return manifold
+}
+
+// newWorker creates a degenerate worker that provides access to the metrics
+// spool directory path.
+func newWorker(a agent.Agent) (worker.Worker, error) {
+	metricsSpoolDir := a.CurrentConfig().MetricsSpoolDir()
+	w := &metricsSpoolDirWorker{metricsSpoolDir: metricsSpoolDir}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+	}()
+	return w, nil
+}
+
+// outputFunc extracts the metrics spool directory path from a *metricsSpoolDirWorker.
+func outputFunc(in worker.Worker, out interface{}) error {
+	inWorker, _ := in.(*metricsSpoolDirWorker)
+	outPointer, _ := out.(*string)
+	if inWorker == nil || outPointer == nil {
+		return errors.Errorf("expected %T->%T; got %T->%T", inWorker, outPointer, in, out)
+	}
+	*outPointer = inWorker.metricsSpoolDir
+	return nil
+}
+
+// metricsSpoolDirWorker is a degenerate worker that exists only to hold
+// the metrics spool directory path.
+type metricsSpoolDirWorker struct {
+	tomb            tomb.Tomb
+	metricsSpoolDir string
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *metricsSpoolDirWorker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *metricsSpoolDirWorker) Wait() error {
+	return w.tomb.Wait()
+}

--- a/worker/metrics/spooldirectory/manifold_test.go
+++ b/worker/metrics/spooldirectory/manifold_test.go
@@ -1,0 +1,101 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package spooldirectory_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/fslock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/metrics/spooldirectory"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	testing.Stub
+	manifold    dependency.Manifold
+	getResource dependency.GetResourceFunc
+	lock        *fslock.Lock
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.Stub = testing.Stub{}
+	s.manifold = spooldirectory.Manifold(spooldirectory.ManifoldConfig{
+		AgentName: "agent-name",
+	})
+	s.getResource = dt.StubGetResource(dt.StubResources{
+		"agent-name": dt.StubResource{Output: &dummyAgent{spoolDir: "/path/to/data/dir"}},
+	})
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Check(s.manifold.Inputs, jc.DeepEquals, []string{"agent-name"})
+}
+
+func (s *ManifoldSuite) TestStartMissingAgent(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"agent-name": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+	s.CheckCalls(c, nil)
+}
+
+func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
+	s.setupWorkerTest(c)
+}
+
+func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
+	worker := s.setupWorkerTest(c)
+	var spoolDir string
+	err := s.manifold.Output(worker, &spoolDir)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(spoolDir, gc.Equals, "/path/to/data/dir")
+}
+
+func (s *ManifoldSuite) setupWorkerTest(c *gc.C) worker.Worker {
+	worker, err := s.manifold.Start(s.getResource)
+	c.Check(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		worker.Kill()
+		err := worker.Wait()
+		c.Check(err, jc.ErrorIsNil)
+	})
+	return worker
+}
+
+func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
+	worker := s.setupWorkerTest(c)
+	var spoolDirPlaceholder interface{}
+	err := s.manifold.Output(worker, &spoolDirPlaceholder)
+	c.Check(err.Error(), gc.Equals, "expected *spooldirectory.metricsSpoolDirWorker->*string; got *spooldirectory.metricsSpoolDirWorker->*interface {}")
+	c.Check(spoolDirPlaceholder, gc.IsNil)
+}
+
+type dummyAgent struct {
+	agent.Agent
+	spoolDir string
+}
+
+func (a dummyAgent) CurrentConfig() agent.Config {
+	return &dummyAgentConfig{spoolDir: a.spoolDir}
+}
+
+type dummyAgentConfig struct {
+	agent.Config
+	spoolDir string
+}
+
+func (ac dummyAgentConfig) MetricsSpoolDir() string {
+	return ac.spoolDir
+}

--- a/worker/metrics/spooldirectory/package_test.go
+++ b/worker/metrics/spooldirectory/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package spooldirectory_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
First step towards moving metrics spool directory to agent config and added a spool directory denegerate worker
that extracts the spool directory value from the agent config.

(Review request: http://reviews.vapour.ws/r/2381/)