### PR TITLE
added generic ValueWorker for use in degenerate-worker manifolds

### DIFF
--- a/worker/machinelock/manifold.go
+++ b/worker/machinelock/manifold.go
@@ -5,8 +5,6 @@ package machinelock
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/utils/fslock"
-	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
@@ -31,7 +29,7 @@ type ManifoldConfig util.AgentManifoldConfig
 // of their GetResourceFunc.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	manifold := util.AgentManifold(util.AgentManifoldConfig(config), newWorker)
-	manifold.Output = outputFunc
+	manifold.Output = util.ValueWorkerOutput
 	return manifold
 }
 
@@ -42,38 +40,5 @@ func newWorker(a agent.Agent) (worker.Worker, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	w := &machineLockWorker{lock: lock}
-	go func() {
-		defer w.tomb.Done()
-		<-w.tomb.Dying()
-	}()
-	return w, nil
-}
-
-// outputFunc extracts a *fslock.Lock from a *machineLockWorker.
-func outputFunc(in worker.Worker, out interface{}) error {
-	inWorker, _ := in.(*machineLockWorker)
-	outPointer, _ := out.(**fslock.Lock)
-	if inWorker == nil || outPointer == nil {
-		return errors.Errorf("expected %T->%T; got %T->%T", inWorker, outPointer, in, out)
-	}
-	*outPointer = inWorker.lock
-	return nil
-}
-
-// machineLockWorker is a degenerate worker that exists only to hold a reference
-// to its lock.
-type machineLockWorker struct {
-	tomb tomb.Tomb
-	lock *fslock.Lock
-}
-
-// Kill is part of the worker.Worker interface.
-func (w *machineLockWorker) Kill() {
-	w.tomb.Kill(nil)
-}
-
-// Wait is part of the worker.Worker interface.
-func (w *machineLockWorker) Wait() error {
-	return w.tomb.Wait()
+	return util.NewValueWorker(lock)
 }

--- a/worker/machinelock/manifold_test.go
+++ b/worker/machinelock/manifold_test.go
@@ -104,16 +104,16 @@ func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
 func (s *ManifoldSuite) TestOutputBadWorker(c *gc.C) {
 	var lock *fslock.Lock
 	err := s.manifold.Output(&dummyWorker{}, &lock)
-	c.Check(err.Error(), gc.Equals, "expected *machinelock.machineLockWorker->**fslock.Lock; got *machinelock_test.dummyWorker->**fslock.Lock")
+	c.Check(err, gc.ErrorMatches, "in should be a \\*valueWorker; is .*")
 	c.Check(lock, gc.IsNil)
 }
 
 func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
 	worker := s.setupWorkerTest(c)
-	var lock interface{}
+	var lock int
 	err := s.manifold.Output(worker, &lock)
-	c.Check(err.Error(), gc.Equals, "expected *machinelock.machineLockWorker->**fslock.Lock; got *machinelock.machineLockWorker->*interface {}")
-	c.Check(lock, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "cannot output into \\*int")
+	c.Check(lock, gc.Equals, 0)
 }
 
 type dummyAgent struct {

--- a/worker/util/valueworker.go
+++ b/worker/util/valueworker.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package util
+
+import (
+	"reflect"
+
+	"github.com/juju/errors"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/worker"
+)
+
+// valueWorker implements a degenerate worker wrapping a single value.
+type valueWorker struct {
+	tomb  tomb.Tomb
+	value interface{}
+}
+
+// Kill is part of the worker.Worker interface.
+func (v *valueWorker) Kill() {
+	v.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (v *valueWorker) Wait() error {
+	return v.tomb.Wait()
+}
+
+// NewValueWorker returns a degenerate worker that exposes the supplied value
+// when passed into ValueWorkerOutput.
+func NewValueWorker(value interface{}) (worker.Worker, error) {
+	if value == nil {
+		return nil, errors.New("NewValueWorker expects a value")
+	}
+	w := &valueWorker{
+		value: value,
+	}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+	}()
+	return w, nil
+}
+
+// ValueWorkerOutput sets the value wrapped by the supplied valueWorker into
+// the out pointer, if type-compatible, or fails.
+func ValueWorkerOutput(in worker.Worker, out interface{}) error {
+	inWorker, _ := in.(*valueWorker)
+	if inWorker == nil {
+		return errors.Errorf("in should be a *valueWorker; is %#v", in)
+	}
+	outV := reflect.ValueOf(out)
+	if outV.Kind() != reflect.Ptr {
+		return errors.Errorf("out should be a pointer; is %#v", out)
+	}
+	outValV := outV.Elem()
+	outValT := outValV.Type()
+	inValV := reflect.ValueOf(inWorker.value)
+	inValT := inValV.Type()
+	if !inValT.ConvertibleTo(outValT) {
+		return errors.Errorf("cannot output into %T", out)
+	}
+	outValV.Set(inValV.Convert(outValT))
+	return nil
+}

--- a/worker/util/valueworker_test.go
+++ b/worker/util/valueworker_test.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package util_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/util"
+)
+
+type ValueWorkerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ValueWorkerSuite{})
+
+func (s *ValueWorkerSuite) TestNewValueWorker_Success(c *gc.C) {
+	w, err := util.NewValueWorker("cheese")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = worker.Stop(w)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *ValueWorkerSuite) TestNewValueWorker_NilValue(c *gc.C) {
+	w, err := util.NewValueWorker(nil)
+	c.Check(err, gc.ErrorMatches, "NewValueWorker expects a value")
+	c.Check(w, gc.IsNil)
+}
+
+func (s *ValueWorkerSuite) TestValueWorkerOutput_Success(c *gc.C) {
+	value := &testType{}
+	w, err := util.NewValueWorker(value)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var outVal testInterface
+	err = util.ValueWorkerOutput(w, &outVal)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(outVal, gc.DeepEquals, value)
+}
+
+func (s *ValueWorkerSuite) TestValueWorkerOutput_BadInput(c *gc.C) {
+	var outVal testInterface
+	err := util.ValueWorkerOutput(&testType{}, &outVal)
+	c.Check(err, gc.ErrorMatches, "in should be a \\*valueWorker; is .*")
+	c.Check(outVal, gc.IsNil)
+}
+
+func (s *ValueWorkerSuite) TestValueWorkerOutput_BadOutputIndirection(c *gc.C) {
+	value := &testType{}
+	w, err := util.NewValueWorker(value)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var outVal string
+	err = util.ValueWorkerOutput(w, outVal)
+	c.Check(err, gc.ErrorMatches, "out should be a pointer; is .*")
+	c.Check(outVal, gc.Equals, "")
+}
+
+func (s *ValueWorkerSuite) TestValueWorkerOutput_BadOutputType(c *gc.C) {
+	value := &testType{}
+	w, err := util.NewValueWorker(value)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var outVal string
+	err = util.ValueWorkerOutput(w, &outVal)
+	c.Check(err, gc.ErrorMatches, "cannot output into \\*string")
+	c.Check(outVal, gc.Equals, "")
+}
+
+type testInterface interface {
+	worker.Worker
+	Foobar()
+}
+
+type testType struct {
+	testInterface
+}


### PR DESCRIPTION
and replaced the existing machineLockWorker implementation

(Review request: http://reviews.vapour.ws/r/2386/)