### PR TITLE
WiP: Test that addresser does not start in not-supporting environment

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1192,9 +1192,7 @@ func (a *MachineAgent) startEnvWorkers(
 	return runner, nil
 }
 
-var isNetworkingEnvironment = _isNetworkingEnvironment
-
-func _isNetworkingEnvironment(apiConn api.Connection) (bool, error) {
+func isNetworkingEnvironment(apiConn api.Connection) (bool, error) {
 	envConfig, err := apiConn.Environment().EnvironConfig()
 	if err != nil {
 		return false, errors.Annotate(err, "cannot read environment config")

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1172,6 +1172,7 @@ func (a *MachineAgent) startEnvWorkers(
 	} else {
 		logger.Debugf("address deallocation not supported: not starting addresser worker")
 	}
+
 	// TODO(axw) 2013-09-24 bug #1229506
 	// Make another job to enable the firewaller. Not all
 	// environments are capable of managing ports
@@ -1191,7 +1192,9 @@ func (a *MachineAgent) startEnvWorkers(
 	return runner, nil
 }
 
-func isNetworkingEnvironment(apiConn api.Connection) (bool, error) {
+var isNetworkingEnvironment = _isNetworkingEnvironment
+
+func _isNetworkingEnvironment(apiConn api.Connection) (bool, error) {
 	envConfig, err := apiConn.Environment().EnvironConfig()
 	if err != nil {
 		return false, errors.Annotate(err, "cannot read environment config")

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -14,6 +14,9 @@ import (
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
 type Networking interface {
+	// SupportsNetworking checks if an environment supports networking.
+	SupportsNetworking() bool
+
 	// AllocateAddress requests a specific address to be allocated for the
 	// given instance on the given subnet.
 	AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
@@ -53,7 +56,10 @@ type NetworkingEnviron interface {
 // Networking in this case.
 func SupportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 	ne, ok := environ.(NetworkingEnviron)
-	return ne, ok
+	if !ok {
+		return nil, false
+	}
+	return ne, ne.SupportsNetworking()
 }
 
 // AddressAllocationEnabled is a shortcut for checking if the

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -196,6 +196,11 @@ func (env *environ) StopInstances(instances ...instance.Id) error {
 	return err
 }
 
+// SupportsNetworking implements the NetworkingEnviron interface.
+func (env *environ) SupportsNetworking() bool {
+	return false
+}
+
 // AllocateAddress requests a new address to be allocated for the
 // given instance on the given network.
 func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address, macAddress, hostname string) error {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -255,8 +255,8 @@ type environState struct {
 	ops          chan<- Operation
 	statePolicy  state.Policy
 	mu           sync.Mutex
-	maxId        int // maximum instance id allocated so far.
-	maxAddr      int // maximum allocated address last byte
+	maxId        int // Maximum instance id allocated so far.
+	maxAddr      int // Maximum allocated address last byte.
 	insts        map[instance.Id]*dummyInstance
 	globalPorts  map[network.PortRange]bool
 	bootstrapped bool
@@ -1091,6 +1091,11 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 		return false, nil
 	}
 	return true, nil
+}
+
+// SupportsNetworking implements the NetworkingEnviron interface.
+func (env *environ) SupportsNetworking() bool {
+	return environs.AddressAllocationEnabled()
 }
 
 // AllocateAddress requests an address to be allocated for the

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -829,6 +829,11 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 	return networkInterfaceId, nil
 }
 
+// SupportsNetworking implements the NetworkingEnviron interface.
+func (e *environ) SupportsNetworking() bool {
+	return environs.AddressAllocationEnabled()
+}
+
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
 func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -896,8 +896,8 @@ func (t *localServerSuite) TestSupportsAddressAllocationTrue(c *gc.C) {
 }
 
 func (t *localServerSuite) TestSupportsAddressAllocationWithNoFeatureFlag(c *gc.C) {
-	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
+	t.SetFeatureFlags() // clear the flags.
 	result, err := env.SupportsAddressAllocation("")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
@@ -905,16 +905,16 @@ func (t *localServerSuite) TestSupportsAddressAllocationWithNoFeatureFlag(c *gc.
 }
 
 func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
-	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
+	t.SetFeatureFlags() // clear the flags.
 	err := env.AllocateAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0], "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
-	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
+	t.SetFeatureFlags() // clear the flags.
 	err := env.ReleaseAddress("i-foo", "net1", network.NewAddress("1.2.3.4"), "")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -11,6 +11,11 @@ import (
 	"github.com/juju/juju/provider/common"
 )
 
+// SupportsNetworking implements the NetworkingEnviron interface.
+func (env *environ) SupportsNetworking() bool {
+	return false
+}
+
 // AllocateAddress implements environs.Environ, but is not implmemented.
 func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address, macAddress, hostname string) error {
 	return errors.Trace(errNotImplemented)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1440,6 +1440,11 @@ func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instan
 	return device, nil
 }
 
+// SupportsNetworking implements the NetworkingEnviron interface.
+func (environ *maasEnviron) SupportsNetworking() bool {
+	return environs.AddressAllocationEnabled()
+}
+
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
 func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) (err error) {

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -12,6 +12,11 @@ import (
 	"github.com/juju/juju/network"
 )
 
+// SupportsNetworking implements the NetworkingEnviron interface.
+func (env *environ) SupportsNetworking() bool {
+	return true
+}
+
 // AllocateAddress implements environs.Environ.
 func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr network.Address, _, _ string) error {
 	return env.changeAddress(instID, subnetID, addr, true)


### PR DESCRIPTION
Added a test that the addresser worker will not start if the environment doesn't support networking. This check had to be changed before, so now the dummy provider support now can be set by a feature flag too.

(Review request: http://reviews.vapour.ws/r/2390/)