### PR TITLE
Switch to dependency engine.

### DIFF
--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/featureflag"
@@ -18,7 +17,6 @@ import (
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/jujud/agent/unit"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/network"
@@ -31,23 +29,6 @@ import (
 var (
 	agentLogger = loggo.GetLogger("juju.jujud")
 )
-
-type unitAgentWorkerFactory func(unit string, caller base.APICaller, runner worker.Runner) (func() (worker.Worker, error), error)
-
-var (
-	unitAgentWorkerNames []string
-	unitAgentWorkerFuncs = make(map[string]unitAgentWorkerFactory)
-)
-
-// RegisterUnitAgentWorker adds the worker to the list of workers to start.
-func RegisterUnitAgentWorker(name string, newWorkerFunc unitAgentWorkerFactory) error {
-	if _, ok := unitAgentWorkerFuncs[name]; ok {
-		return errors.Errorf("worker %q already registered", name)
-	}
-	unitAgentWorkerFuncs[name] = newWorkerFunc
-	unitAgentWorkerNames = append(unitAgentWorkerNames, name)
-	return nil
-}
 
 // UnitAgent is a cmd.Command responsible for running a unit agent.
 type UnitAgent struct {

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -154,17 +154,6 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		}
 		return nil, err
 	}
-
-	// XXX sort this out...
-	//for _, name := range unitAgentWorkerNames {
-	//      newWorkerFunc := unitAgentWorkerFuncs[name]
-	//      newWorker, err := newWorkerFunc(a.UnitName, st, runner)
-	//      if err != nil {
-	//              return workers, errors.Trace(err)
-	//      }
-	//      workers.Add(name, newWorker)
-	//}
-
 	return engine, nil
 }
 

--- a/cmd/jujud/agent/unit/export_test.go
+++ b/cmd/jujud/agent/unit/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit
+
+var (
+	RegisteredWorkers = registeredWorkers
+)

--- a/cmd/jujud/agent/unit/export_test.go
+++ b/cmd/jujud/agent/unit/export_test.go
@@ -4,5 +4,5 @@
 package unit
 
 var (
-	RegisteredWorkers = registeredWorkers
+	RegisteredManifolds = registeredManifolds
 )

--- a/cmd/jujud/agent/unit/export_test.go
+++ b/cmd/jujud/agent/unit/export_test.go
@@ -4,5 +4,5 @@
 package unit
 
 var (
-	RegisteredManifolds = registeredManifolds
+	RegisteredManifoldFuncs = registeredManifoldFuncs
 )

--- a/cmd/jujud/agent/unit/export_test.go
+++ b/cmd/jujud/agent/unit/export_test.go
@@ -4,5 +4,5 @@
 package unit
 
 var (
-	RegisteredManifoldFuncs = registeredManifoldFuncs
+	ComponentManifoldFuncs = componentManifoldFuncs
 )

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -25,15 +25,16 @@ import (
 )
 
 var (
-	registeredManifolds = make(map[string]func(ManifoldsConfig) (dependency.Manifold, error))
+	registeredManifoldFuncs = make(map[string]func(ManifoldsConfig) (dependency.Manifold, error))
 )
 
-// RegisterManifold adds the worker to the list of workers to start.
-func RegisterManifold(name string, newManifold func(ManifoldsConfig) (dependency.Manifold, error)) error {
-	if _, ok := registeredManifolds[name]; ok {
-		return errors.Errorf("%q manifold already registered", name)
+// RegisterManifoldFunc adds the given manifold factory func to the list
+// of component-registered manifest funcs.
+func RegisterManifoldFunc(name string, newManifold func(ManifoldsConfig) (dependency.Manifold, error)) error {
+	if _, ok := registeredManifoldFuncs[name]; ok {
+		return errors.Errorf("%q manifold func already registered", name)
 	}
-	registeredManifolds[name] = newManifold
+	registeredManifoldFuncs[name] = newManifold
 	return nil
 }
 
@@ -167,7 +168,7 @@ func Manifolds(config ManifoldsConfig) (dependency.Manifolds, error) {
 		}),
 	}
 
-	for name, newManifold := range registeredManifolds {
+	for name, newManifold := range registeredManifoldFuncs {
 		if _, ok := manifolds[name]; ok {
 			return manifolds, errors.Errorf("%q manifold already added", name)
 		}

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -25,16 +25,16 @@ import (
 )
 
 var (
-	registeredManifoldFuncs = make(map[string]func(ManifoldsConfig) (dependency.Manifold, error))
+	componentManifoldFuncs = make(map[string]func(ManifoldsConfig) (dependency.Manifold, error))
 )
 
-// RegisterManifoldFunc adds the given manifold factory func to the list
-// of component-registered manifest funcs.
-func RegisterManifoldFunc(name string, newManifold func(ManifoldsConfig) (dependency.Manifold, error)) error {
-	if _, ok := registeredManifoldFuncs[name]; ok {
+// RegisterComponentManifoldFunc adds the given manifold factory func
+// to the list of component-registered manifest funcs.
+func RegisterComponentManifoldFunc(name string, newManifold func(ManifoldsConfig) (dependency.Manifold, error)) error {
+	if _, ok := componentManifoldFuncs[name]; ok {
 		return errors.Errorf("%q manifold func already registered", name)
 	}
-	registeredManifoldFuncs[name] = newManifold
+	componentManifoldFuncs[name] = newManifold
 	return nil
 }
 
@@ -168,7 +168,7 @@ func Manifolds(config ManifoldsConfig) (dependency.Manifolds, error) {
 		}),
 	}
 
-	for name, newManifold := range registeredManifoldFuncs {
+	for name, newManifold := range componentManifoldFuncs {
 		if _, ok := manifolds[name]; ok {
 			return manifolds, errors.Errorf("%q manifold already added", name)
 		}

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -24,14 +24,12 @@ import (
 	"github.com/juju/juju/worker/upgrader"
 )
 
-type manifoldFactory func(config ManifoldsConfig) (dependency.Manifold, error)
-
 var (
-	registeredManifolds = make(map[string]manifoldFactory)
+	registeredManifolds = make(map[string]func(ManifoldsConfig) (dependency.Manifold, error))
 )
 
 // RegisterManifold adds the worker to the list of workers to start.
-func RegisterManifold(name string, newManifold manifoldFactory) error {
+func RegisterManifold(name string, newManifold func(ManifoldsConfig) (dependency.Manifold, error)) error {
 	if _, ok := registeredManifolds[name]; ok {
 		return errors.Errorf("%q manifold already registered", name)
 	}

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -9,8 +9,6 @@ import (
 	"github.com/juju/errors"
 
 	coreagent "github.com/juju/juju/agent"
-	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
 	"github.com/juju/juju/worker/apicaller"
@@ -26,20 +24,18 @@ import (
 	"github.com/juju/juju/worker/upgrader"
 )
 
-// TODO(ericsnow) Switch to manifolds.
-
-type workerFactory func(config ManifoldsConfig, caller base.APICaller) (func() (worker.Worker, error), error)
+type manifoldFactory func(config ManifoldsConfig) (dependency.Manifold, error)
 
 var (
-	registeredWorkers = make(map[string]workerFactory)
+	registeredManifolds = make(map[string]manifoldFactory)
 )
 
-// RegisterWorker adds the worker to the list of workers to start.
-func RegisterWorker(name string, newWorkerFunc workerFactory) error {
-	if _, ok := registeredWorkers[name]; ok {
-		return errors.Errorf("worker %q already registered", name)
+// RegisterManifold adds the worker to the list of workers to start.
+func RegisterManifold(name string, newManifold manifoldFactory) error {
+	if _, ok := registeredManifolds[name]; ok {
+		return errors.Errorf("%q manifold already registered", name)
 	}
-	registeredWorkers[name] = newWorkerFunc
+	registeredManifolds[name] = newManifold
 	return nil
 }
 
@@ -63,7 +59,7 @@ type ManifoldsConfig struct {
 // through a dependency engine yet.
 //
 // Thou Shalt Not Use String Literals In This Function. Or Else.
-func Manifolds(config ManifoldsConfig) dependency.Manifolds {
+func Manifolds(config ManifoldsConfig) (dependency.Manifolds, error) {
 	manifolds := dependency.Manifolds{
 
 		// The agent manifold references the enclosing agent, and is the
@@ -173,31 +169,19 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 	}
 
-	for name, newWorkerFunc := range registeredWorkers {
-		startFunc := func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
-			var caller base.APICaller
-			err := getResource(APICallerName, &caller)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			newWorker, err := newWorkerFunc(config, caller)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			worker, err := newWorker()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			return worker, nil
+	for name, newManifold := range registeredManifolds {
+		if _, ok := manifolds[name]; ok {
+			return manifolds, errors.Errorf("%q manifold already added", name)
 		}
-		manifold := dependency.Manifold{
-			Inputs: []string{APICallerName},
-			Start:  startFunc,
+
+		manifold, err := newManifold(config)
+		if err != nil {
+			return manifolds, errors.Trace(err)
 		}
 		manifolds[name] = manifold
 	}
 
-	return manifolds
+	return manifolds, nil
 }
 
 const (

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -6,7 +6,11 @@ package unit
 import (
 	"time"
 
+	"github.com/juju/errors"
+
 	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
 	"github.com/juju/juju/worker/apicaller"
@@ -21,6 +25,23 @@ import (
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/upgrader"
 )
+
+// TODO(ericsnow) Switch to manifolds.
+
+type workerFactory func(unit string, caller base.APICaller, runner worker.Runner) (func() (worker.Worker, error), error)
+
+var (
+	registeredWorkers = make(map[string]workerFactory)
+)
+
+// RegisterWorker adds the worker to the list of workers to start.
+func RegisterWorker(name string, newWorkerFunc workerFactory) error {
+	if _, ok := registeredWorkers[name]; ok {
+		return errors.Errorf("worker %q already registered", name)
+	}
+	registeredWorkers[name] = newWorkerFunc
+	return nil
+}
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
 type ManifoldsConfig struct {

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -28,7 +28,7 @@ import (
 
 // TODO(ericsnow) Switch to manifolds.
 
-type workerFactory func(unit string, caller base.APICaller, runner worker.Runner) (func() (worker.Worker, error), error)
+type workerFactory func(config ManifoldsConfig, caller base.APICaller) (func() (worker.Worker, error), error)
 
 var (
 	registeredWorkers = make(map[string]workerFactory)
@@ -64,7 +64,7 @@ type ManifoldsConfig struct {
 //
 // Thou Shalt Not Use String Literals In This Function. Or Else.
 func Manifolds(config ManifoldsConfig) dependency.Manifolds {
-	return dependency.Manifolds{
+	manifolds := dependency.Manifolds{
 
 		// The agent manifold references the enclosing agent, and is the
 		// foundation stone on which most other manifolds ultimately depend.
@@ -172,6 +172,32 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			MachineLockName:       MachineLockName,
 		}),
 	}
+
+	for name, newWorkerFunc := range registeredWorkers {
+		startFunc := func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			var caller base.APICaller
+			err := getResource(APICallerName, &caller)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			newWorker, err := newWorkerFunc(config, caller)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			worker, err := newWorker()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return worker, nil
+		}
+		manifold := dependency.Manifold{
+			Inputs: []string{APICallerName},
+			Start:  startFunc,
+		}
+		manifolds[name] = manifold
+	}
+
+	return manifolds
 }
 
 const (

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -10,11 +10,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cmd/jujud/agent/unit"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
+	deptesting "github.com/juju/juju/worker/dependency/testing"
 )
 
 type ManifoldsSuite struct {
@@ -37,19 +37,6 @@ func (s *ManifoldsSuite) TearDownTest(c *gc.C) {
 	}
 
 	s.BaseSuite.TearDownTest(c)
-}
-
-func (s *ManifoldsSuite) getResourceFunc(apiCaller base.APICaller) dependency.GetResourceFunc {
-	return func(name string, out interface{}) error {
-		s.stub.AddCall("getResource", name, out)
-		if err := s.stub.NextErr(); err != nil {
-			return errors.Trace(err)
-		}
-
-		unpacked := out.(*base.APICaller)
-		*unpacked = apiCaller
-		return nil
-	}
 }
 
 func (s *ManifoldsSuite) newManifold(config unit.ManifoldsConfig) (dependency.Manifold, error) {
@@ -129,7 +116,7 @@ func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 	})
 	s.stub.CheckCallNames(c, "newManifold", "newManifold")
 	s.stub.ResetCalls()
-	manifolds["spam"].Start(s.getResourceFunc(nil))
+	manifolds["spam"].Start(deptesting.StubGetResource(nil))
 	s.stub.CheckCallNames(c, "Start")
 }
 

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -32,8 +32,8 @@ func (s *ManifoldsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TearDownTest(c *gc.C) {
-	for name := range unit.RegisteredManifoldFuncs {
-		delete(unit.RegisteredManifoldFuncs, name)
+	for name := range unit.ComponentManifoldFuncs {
+		delete(unit.ComponentManifoldFuncs, name)
 	}
 
 	s.BaseSuite.TearDownTest(c)
@@ -66,14 +66,14 @@ func (s *ManifoldsSuite) newManifold(config unit.ManifoldsConfig) (dependency.Ma
 	return manifold, nil
 }
 
-func (s *ManifoldsSuite) TestRegisterManifoldFunc(c *gc.C) {
-	err := unit.RegisterManifoldFunc("spam", s.newManifold)
+func (s *ManifoldsSuite) TestRegisterComponentManifoldFunc(c *gc.C) {
+	err := unit.RegisterComponentManifoldFunc("spam", s.newManifold)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We can't compare functions so we jump through hoops instead.
-	c.Check(unit.RegisteredManifoldFuncs, gc.HasLen, 1)
+	c.Check(unit.ComponentManifoldFuncs, gc.HasLen, 1)
 	var config unit.ManifoldsConfig
-	registered := unit.RegisteredManifoldFuncs["spam"]
+	registered := unit.ComponentManifoldFuncs["spam"]
 	manifold, err := registered(config)
 	c.Assert(err, jc.ErrorIsNil)
 	manifold.Start(nil)
@@ -82,7 +82,7 @@ func (s *ManifoldsSuite) TestRegisterManifoldFunc(c *gc.C) {
 
 func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 	for _, name := range []string{"spam", "eggs"} {
-		err := unit.RegisterManifoldFunc(name, s.newManifold)
+		err := unit.RegisterComponentManifoldFunc(name, s.newManifold)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -4,6 +4,7 @@
 package unit_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -22,10 +23,26 @@ func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 		Agent: fakeAgent{},
 	})
 
+	var names []string
 	for name, manifold := range manifolds {
 		c.Logf("checking %q manifold", name)
 		c.Check(manifold.Start, gc.NotNil)
+		names = append(names, name)
 	}
+	c.Check(names, jc.SameContents, []string{
+		unit.AgentName,
+		unit.APIAdddressUpdaterName,
+		unit.APICallerName,
+		unit.APIInfoGateName,
+		unit.LeadershipTrackerName,
+		unit.LoggingConfigUpdaterName,
+		unit.LogSenderName,
+		unit.MachineLockName,
+		unit.ProxyConfigUpdaterName,
+		unit.RsyslogConfigUpdaterName,
+		unit.UniterName,
+		unit.UpgraderName,
+	})
 }
 
 // TODO(cmars) 2015/08/10: rework this into builtin Engine cycle checker.

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -32,8 +32,8 @@ func (s *ManifoldsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TearDownTest(c *gc.C) {
-	for name := range unit.RegisteredWorkers {
-		delete(unit.RegisteredWorkers, name)
+	for name := range unit.RegisteredManifolds {
+		delete(unit.RegisteredManifolds, name)
 	}
 
 	s.BaseSuite.TearDownTest(c)
@@ -52,14 +52,16 @@ func (s *ManifoldsSuite) getResourceFunc(apiCaller base.APICaller) dependency.Ge
 	}
 }
 
-func (s *ManifoldsSuite) newWorkerFunc(config unit.ManifoldsConfig, caller base.APICaller) (func() (worker.Worker, error), error) {
-	s.stub.AddCall("newWorkerFunc", config, caller)
+func (s *ManifoldsSuite) newManifold(config unit.ManifoldsConfig) (dependency.Manifold, error) {
+	var manifold dependency.Manifold
+
+	s.stub.AddCall("newManifold", config)
 	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
+		return manifold, errors.Trace(err)
 	}
 
-	return func() (worker.Worker, error) {
-		s.stub.AddCall("newWorker")
+	manifold.Start = func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+		s.stub.AddCall("Start", getResource)
 		if err := s.stub.NextErr(); err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -73,33 +75,35 @@ func (s *ManifoldsSuite) newWorkerFunc(config unit.ManifoldsConfig, caller base.
 			return nil
 		}
 		return worker.NewSimpleWorker(loop), nil
-	}, nil
+	}
+	return manifold, nil
 }
 
-func (s *ManifoldsSuite) TestRegisterWorker(c *gc.C) {
-	err := unit.RegisterWorker("spam", s.newWorkerFunc)
+func (s *ManifoldsSuite) TestRegisterManifold(c *gc.C) {
+	err := unit.RegisterManifold("spam", s.newManifold)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We can't compare functions so we jump through hoops instead.
-	c.Check(unit.RegisteredWorkers, gc.HasLen, 1)
+	c.Check(unit.RegisteredManifolds, gc.HasLen, 1)
 	var config unit.ManifoldsConfig
-	registered := unit.RegisteredWorkers["spam"]
-	newWorker, err := registered(config, nil)
+	registered := unit.RegisteredManifolds["spam"]
+	manifold, err := registered(config)
 	c.Assert(err, jc.ErrorIsNil)
-	newWorker()
-	s.stub.CheckCallNames(c, "newWorkerFunc", "newWorker")
+	manifold.Start(nil)
+	s.stub.CheckCallNames(c, "newManifold", "Start")
 }
 
 func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 	for _, name := range []string{"spam", "eggs"} {
-		err := unit.RegisterWorker(name, s.newWorkerFunc)
+		err := unit.RegisterManifold(name, s.newManifold)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
 	config := unit.ManifoldsConfig{
 		Agent: fakeAgent{},
 	}
-	manifolds := unit.Manifolds(config)
+	manifolds, err := unit.Manifolds(config)
+	c.Assert(err, jc.ErrorIsNil)
 
 	var names []string
 	for name, manifold := range manifolds {
@@ -123,16 +127,18 @@ func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 		"spam",
 		"eggs",
 	})
-	s.stub.CheckCalls(c, nil)
+	s.stub.CheckCallNames(c, "newManifold", "newManifold")
+	s.stub.ResetCalls()
 	manifolds["spam"].Start(s.getResourceFunc(nil))
-	s.stub.CheckCallNames(c, "getResource", "newWorkerFunc", "newWorker")
+	s.stub.CheckCallNames(c, "Start")
 }
 
 // TODO(cmars) 2015/08/10: rework this into builtin Engine cycle checker.
 func (s *ManifoldsSuite) TestAcyclic(c *gc.C) {
-	manifolds := unit.Manifolds(unit.ManifoldsConfig{
+	manifolds, err := unit.Manifolds(unit.ManifoldsConfig{
 		Agent: fakeAgent{},
 	})
+	c.Assert(err, jc.ErrorIsNil)
 	count := len(manifolds)
 
 	// Set of vars for depth-first topological sort of manifolds. (Note that,

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -32,8 +32,8 @@ func (s *ManifoldsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TearDownTest(c *gc.C) {
-	for name := range unit.RegisteredManifolds {
-		delete(unit.RegisteredManifolds, name)
+	for name := range unit.RegisteredManifoldFuncs {
+		delete(unit.RegisteredManifoldFuncs, name)
 	}
 
 	s.BaseSuite.TearDownTest(c)
@@ -66,14 +66,14 @@ func (s *ManifoldsSuite) newManifold(config unit.ManifoldsConfig) (dependency.Ma
 	return manifold, nil
 }
 
-func (s *ManifoldsSuite) TestRegisterManifold(c *gc.C) {
-	err := unit.RegisterManifold("spam", s.newManifold)
+func (s *ManifoldsSuite) TestRegisterManifoldFunc(c *gc.C) {
+	err := unit.RegisterManifoldFunc("spam", s.newManifold)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We can't compare functions so we jump through hoops instead.
-	c.Check(unit.RegisteredManifolds, gc.HasLen, 1)
+	c.Check(unit.RegisteredManifoldFuncs, gc.HasLen, 1)
 	var config unit.ManifoldsConfig
-	registered := unit.RegisteredManifolds["spam"]
+	registered := unit.RegisteredManifoldFuncs["spam"]
 	manifold, err := registered(config)
 	c.Assert(err, jc.ErrorIsNil)
 	manifold.Start(nil)
@@ -82,7 +82,7 @@ func (s *ManifoldsSuite) TestRegisterManifold(c *gc.C) {
 
 func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 	for _, name := range []string{"spam", "eggs"} {
-		err := unit.RegisterManifold(name, s.newManifold)
+		err := unit.RegisterManifoldFunc(name, s.newManifold)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -96,7 +96,7 @@ func (s *ManifoldsSuite) TestComponentManifold(c *gc.C) {
 	})
 }
 
-func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
+func (s *ManifoldsSuite) TestNames(c *gc.C) {
 	for _, name := range []string{"spam", "eggs"} {
 		err := unit.RegisterComponentManifoldFunc(name, s.newManifold)
 		c.Assert(err, jc.ErrorIsNil)
@@ -109,9 +109,7 @@ func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var names []string
-	for name, manifold := range manifolds {
-		c.Logf("checking %q manifold", name)
-		c.Check(manifold.Start, gc.NotNil)
+	for name := range manifolds {
 		names = append(names, name)
 	}
 	c.Check(names, jc.SameContents, []string{
@@ -130,6 +128,18 @@ func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 		"spam",
 		"eggs",
 	})
+}
+
+func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
+	manifolds, err := unit.Manifolds(unit.ManifoldsConfig{
+		Agent: fakeAgent{},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	for name, manifold := range manifolds {
+		c.Logf("checking %q manifold", name)
+		c.Check(manifold.Start, gc.NotNil)
+	}
 }
 
 // TODO(cmars) 2015/08/10: rework this into builtin Engine cycle checker.

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -40,7 +40,7 @@ func (s *ManifoldsSuite) TestRegisterComponentManifoldFunc(c *gc.C) {
 	expected := dependency.Manifold{
 		Inputs: []string{"ham", "eggs"},
 	}
-	newManifold := func(unit.ManifoldsConfig) (dependency.Manifold, error) {
+	newManifold := func(unit.ComponentManifoldConfig) (dependency.Manifold, error) {
 		return expected, nil
 	}
 	err := unit.RegisterComponentManifoldFunc("spam", newManifold)
@@ -49,7 +49,7 @@ func (s *ManifoldsSuite) TestRegisterComponentManifoldFunc(c *gc.C) {
 	// We can't compare functions (e.g. check unit.ComponentManifoldFuncs)
 	// so we jump through hoops instead.
 	c.Check(unit.ComponentManifoldFuncs, gc.HasLen, 1)
-	var config unit.ManifoldsConfig
+	var config unit.ComponentManifoldConfig
 	registered := unit.ComponentManifoldFuncs["spam"]
 	manifold, err := registered(config)
 	c.Assert(err, jc.ErrorIsNil)
@@ -60,12 +60,12 @@ func (s *ManifoldsSuite) TestComponentManifold(c *gc.C) {
 	manifold := dependency.Manifold{
 		Inputs: []string{"ham", "eggs"},
 	}
-	newManifold := func(unit.ManifoldsConfig) (dependency.Manifold, error) {
+	newManifold := func(unit.ComponentManifoldConfig) (dependency.Manifold, error) {
 		return manifold, nil
 	}
 	unit.ComponentManifoldFuncs["spam"] = newManifold
 
-	manifolds, err := unit.ComponentManifolds(unit.ManifoldsConfig{})
+	manifolds, err := unit.ComponentManifolds(unit.ComponentManifoldConfig{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(manifolds, jc.DeepEquals, dependency.Manifolds{
@@ -74,7 +74,7 @@ func (s *ManifoldsSuite) TestComponentManifold(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TestNames(c *gc.C) {
-	newManifold := func(unit.ManifoldsConfig) (dependency.Manifold, error) {
+	newManifold := func(unit.ComponentManifoldConfig) (dependency.Manifold, error) {
 		return dependency.Manifold{}, nil
 	}
 	for _, name := range []string{"spam", "eggs"} {

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/unit"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
 )
 
 type ManifoldsSuite struct {
@@ -38,8 +39,21 @@ func (s *ManifoldsSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-func (s *ManifoldsSuite) newWorkerFunc(unit string, caller base.APICaller, runner worker.Runner) (func() (worker.Worker, error), error) {
-	s.stub.AddCall("newWorkerFunc", unit, caller, runner)
+func (s *ManifoldsSuite) getResourceFunc(apiCaller base.APICaller) dependency.GetResourceFunc {
+	return func(name string, out interface{}) error {
+		s.stub.AddCall("getResource", name, out)
+		if err := s.stub.NextErr(); err != nil {
+			return errors.Trace(err)
+		}
+
+		unpacked := out.(*base.APICaller)
+		*unpacked = apiCaller
+		return nil
+	}
+}
+
+func (s *ManifoldsSuite) newWorkerFunc(config unit.ManifoldsConfig, caller base.APICaller) (func() (worker.Worker, error), error) {
+	s.stub.AddCall("newWorkerFunc", config, caller)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -50,8 +64,8 @@ func (s *ManifoldsSuite) newWorkerFunc(unit string, caller base.APICaller, runne
 			return nil, errors.Trace(err)
 		}
 
-		loop := func(<-chan struct{}) error {
-			s.stub.AddCall("loop")
+		loop := func(stopCh <-chan struct{}) error {
+			s.stub.AddCall("loop", stopCh)
 			if err := s.stub.NextErr(); err != nil {
 				return errors.Trace(err)
 			}
@@ -68,17 +82,24 @@ func (s *ManifoldsSuite) TestRegisterWorker(c *gc.C) {
 
 	// We can't compare functions so we jump through hoops instead.
 	c.Check(unit.RegisteredWorkers, gc.HasLen, 1)
+	var config unit.ManifoldsConfig
 	registered := unit.RegisteredWorkers["spam"]
-	newWorker, err := registered("a-service/0", nil, nil)
+	newWorker, err := registered(config, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	newWorker()
 	s.stub.CheckCallNames(c, "newWorkerFunc", "newWorker")
 }
 
 func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
-	manifolds := unit.Manifolds(unit.ManifoldsConfig{
+	for _, name := range []string{"spam", "eggs"} {
+		err := unit.RegisterWorker(name, s.newWorkerFunc)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	config := unit.ManifoldsConfig{
 		Agent: fakeAgent{},
-	})
+	}
+	manifolds := unit.Manifolds(config)
 
 	var names []string
 	for name, manifold := range manifolds {
@@ -99,7 +120,12 @@ func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 		unit.RsyslogConfigUpdaterName,
 		unit.UniterName,
 		unit.UpgraderName,
+		"spam",
+		"eggs",
 	})
+	s.stub.CheckCalls(c, nil)
+	manifolds["spam"].Start(s.getResourceFunc(nil))
+	s.stub.CheckCallNames(c, "getResource", "newWorkerFunc", "newWorker")
 }
 
 // TODO(cmars) 2015/08/10: rework this into builtin Engine cycle checker.

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -407,35 +407,6 @@ func (s *UnitSuite) TestUnitAgentRunsAPIAddressUpdaterWorker(c *gc.C) {
 	c.Fatalf("timeout while waiting for agent config to change")
 }
 
-// XXX Sort this out...
-//func (s *UnitSuite) TestUnitAgentAPIWorkers(c *gc.C) {
-//	err := RegisterUnitAgentWorker("spam", s.newWorkerFunc)
-//	c.Assert(err, jc.ErrorIsNil)
-//	err = RegisterUnitAgentWorker("eggs", s.newWorkerFunc)
-//	c.Assert(err, jc.ErrorIsNil)
-//
-//	a := NewUnitAgent(nil, nil)
-//	a.UnitName = "a-service/0"
-//	workers, err := a.apiWorkers(nil, nil, nil, nil)
-//	c.Assert(err, jc.ErrorIsNil)
-//	ids := workers.IDs()
-//
-//	expected := []string{
-//		"proxyupdater",
-//		"upgrader",
-//		"logger",
-//		"uniter",
-//		"apiaddressupdater",
-//		"rsyslog",
-//		"spam",
-//		"eggs",
-//	}
-//	c.Check(ids, jc.DeepEquals, expected)
-//	s.stub.CheckCallNames(c, "newWorkerFunc", "newWorkerFunc")
-//	c.Check(s.stub.Calls()[0].Args[0], gc.Equals, "a-service/0")
-//	c.Check(s.stub.Calls()[1].Args[0], gc.Equals, "a-service/0")
-//}
-
 func (s *UnitSuite) TestUseLumberjack(c *gc.C) {
 	ctx, err := cmd.DefaultContext()
 	c.Assert(err, gc.IsNil)

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -15,7 +15,7 @@ import (
 	apiserverclient "github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
 	cmdstatus "github.com/juju/juju/cmd/juju/status"
-	"github.com/juju/juju/cmd/jujud/agent"
+	"github.com/juju/juju/cmd/jujud/agent/unit"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/uniter/runner"
@@ -199,7 +199,7 @@ func (c workloads) registerWorkers() map[string]*workers.EventHandlers {
 
 		return newWorker, nil
 	}
-	err := agent.RegisterUnitAgentWorker(workload.ComponentName, newWorkerFunc)
+	err := unit.RegisterWorker(workload.ComponentName, newWorkerFunc)
 	if err != nil {
 		panic(err)
 	}

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v5"
 
@@ -31,6 +32,8 @@ import (
 	"github.com/juju/juju/workload/status"
 	"github.com/juju/juju/workload/workers"
 )
+
+var workloadsLogger = loggo.GetLogger("component.all.workload")
 
 type workloads struct{}
 

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -186,9 +186,39 @@ func (c workloads) registerUnitWorkers() map[string]*workers.EventHandlers {
 		}
 		unitEventHandlers[unitName] = unitHandler
 
-		manifold, err := c.newUnitManifold(unitHandler)
-		if err != nil {
-			return manifold, errors.Trace(err)
+		manifold := dependency.Manifold{
+			Inputs: []string{unit.APICallerName},
+		}
+		manifold.Start = func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			var caller base.APICaller
+			err := getResource(unit.APICallerName, &caller)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			apiClient := c.newHookContextAPIClient(caller)
+
+			engine, err := dependency.NewEngine(dependency.EngineConfig{
+				IsFatal:       cmdutil.IsFatal,
+				MoreImportant: func(_ error, worst error) error { return worst },
+				ErrorDelay:    3 * time.Second,
+				BounceDelay:   10 * time.Millisecond,
+			})
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			var runner worker.Runner            // TODO(ericsnow) Wrap engine in a runner.
+			unitHandler.Init(apiClient, runner) // TODO(ericsnow) Eliminate this...
+
+			manifolds := unitHandler.Manifolds()
+			if err := dependency.Install(engine, manifolds); err != nil {
+				if err := worker.Stop(engine); err != nil {
+					workloadsLogger.Errorf("while stopping engine with bad manifolds: %v", err)
+				}
+				return nil, errors.Trace(err)
+			}
+
+			return engine, nil
 		}
 		return manifold, nil
 	}
@@ -198,84 +228,6 @@ func (c workloads) registerUnitWorkers() map[string]*workers.EventHandlers {
 	}
 
 	return unitEventHandlers
-}
-
-func (c workloads) newUnitManifold(unitHandler *workers.EventHandlers) (dependency.Manifold, error) {
-	manifold := dependency.Manifold{
-		Inputs: []string{unit.APICallerName},
-	}
-	manifold.Start = func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
-		var caller base.APICaller
-		err := getResource(unit.APICallerName, &caller)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		apiClient := c.newHookContextAPIClient(caller)
-
-		engine, err := dependency.NewEngine(dependency.EngineConfig{
-			IsFatal:       cmdutil.IsFatal,
-			MoreImportant: func(_ error, worst error) error { return worst },
-			ErrorDelay:    3 * time.Second,
-			BounceDelay:   10 * time.Millisecond,
-		})
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		var runner worker.Runner // TODO(ericsnow) Wrap engine in a runner.
-		// TODO(ericsnow) Provide the runner as a resource.
-		unitHandler.Init(apiClient, runner) // TODO(ericsnow) Eliminate this...
-
-		err = engine.Install("events", dependency.Manifold{
-			Inputs: []string{},
-			Start: func(dependency.GetResourceFunc) (worker.Worker, error) {
-				// Pull all existing from State (via API) and add an event for each.
-				hctx, err := context.NewContextAPI(apiClient, unitHandler.AddEvents)
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				events, err := workers.InitialEvents(hctx)
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-
-				worker, err := unitHandler.NewWorker()
-				if err == nil {
-					return nil, errors.Trace(err)
-				}
-
-				// These must be added *after* the worker is started.
-				unitHandler.AddEvents(events...)
-
-				return worker, nil
-			},
-			Output: func(in worker.Worker, out interface{}) error {
-				// TODO(ericsnow) provide the runner
-				return nil
-			},
-		})
-		if err == nil {
-			return nil, errors.Trace(err)
-		}
-
-		err = engine.Install("apiclient", dependency.Manifold{
-			Inputs: []string{},
-			Start: func(dependency.GetResourceFunc) (worker.Worker, error) {
-				loop := func(<-chan struct{}) error { return nil }
-				return worker.NewSimpleWorker(loop), nil
-			},
-			Output: func(in worker.Worker, out interface{}) error {
-				// TODO(ericsnow) provide the APICaller
-				return nil
-			},
-		})
-		if err == nil {
-			return nil, errors.Trace(err)
-		}
-
-		return engine, nil
-	}
-	return manifold, nil
 }
 
 func (workloads) registerState() {

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -231,7 +231,7 @@ func (c workloads) newUnitManifold(unitHandler *workers.EventHandlers) (dependen
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
-				events, err := c.initialEvents(hctx)
+				events, err := workers.InitialEvents(hctx)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -273,34 +273,6 @@ func (c workloads) newUnitManifold(unitHandler *workers.EventHandlers) (dependen
 		return engine, nil
 	}
 	return manifold, nil
-}
-
-func (workloads) initialEvents(hctx context.Component) ([]workload.Event, error) {
-	ids, err := hctx.List()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var events []workload.Event
-	for _, id := range ids {
-		wl, err := hctx.Get(id)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		//TODO(wwitzel3) (Upgrade/Restart broken) during a restart of the worker, the Plugin loses its absPath for the executable.
-		plugin, err := hctx.Plugin(wl)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		events = append(events, workload.Event{
-			Kind:     workload.EventKindTracked,
-			ID:       wl.ID(),
-			Plugin:   plugin,
-			PluginID: wl.Details.ID,
-		})
-	}
-	return events, nil
 }
 
 func (workloads) registerState() {

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -165,12 +165,12 @@ func (c workloads) registerUnitWorkers() func(...workload.Event) error {
 		unitHandlers.RegisterHandler(handlerFunc)
 	}
 
-	newManifold := func(unit.ManifoldsConfig) (dependency.Manifold, error) {
+	newManifold := func(config unit.ComponentManifoldConfig) (dependency.Manifold, error) {
 		// At this point no workload workers are running for the unit.
 		// TODO(ericsnow) Move this code to workers.Manifold
 		// (and ManifoldConfig)?
 		apiConfig := util.ApiManifoldConfig{
-			APICallerName: unit.APICallerName,
+			APICallerName: config.APICallerName,
 		}
 		manifold := util.ApiManifold(apiConfig, func(caller base.APICaller) (worker.Worker, error) {
 			apiClient := c.newHookContextAPIClient(caller)

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -170,7 +170,7 @@ func (c workloads) registerUnitWorkers() *workers.EventHandlers {
 	}
 
 	newManifold := func(unit.ManifoldsConfig) (dependency.Manifold, error) {
-		// At this point no workload process workers are running for the unit.
+		// At this point no workload workers are running for the unit.
 		apiConfig := util.ApiManifoldConfig{
 			APICallerName: unit.APICallerName,
 		}

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -171,6 +171,8 @@ func (c workloads) registerUnitWorkers() *workers.EventHandlers {
 
 	newManifold := func(unit.ManifoldsConfig) (dependency.Manifold, error) {
 		// At this point no workload workers are running for the unit.
+		// TODO(ericsnow) Move this code to workers.Manifold
+		// (and ManifoldConfig)?
 		apiConfig := util.ApiManifoldConfig{
 			APICallerName: unit.APICallerName,
 		}

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -160,6 +160,7 @@ func (c workloads) registerUnitWorkers() *workers.EventHandlers {
 	}
 
 	handlerFuncs := []func([]workload.Event, context.APIClient, workers.Runner) error{
+		workers.WorkloadHandler,
 		workers.StatusEventHandler,
 	}
 

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -5,11 +5,9 @@ package all
 
 import (
 	"reflect"
-	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v5"
 
@@ -18,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	cmdstatus "github.com/juju/juju/cmd/juju/status"
 	"github.com/juju/juju/cmd/jujud/agent/unit"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
@@ -33,8 +30,6 @@ import (
 	"github.com/juju/juju/workload/status"
 	"github.com/juju/juju/workload/workers"
 )
-
-var workloadsLogger = loggo.GetLogger("component.all.workload")
 
 type workloads struct{}
 
@@ -192,29 +187,10 @@ func (c workloads) registerUnitWorkers() map[string]*workers.EventHandlers {
 		}
 		manifold := util.ApiManifold(apiConfig, func(caller base.APICaller) (worker.Worker, error) {
 			apiClient := c.newHookContextAPIClient(caller)
-
-			engine, err := dependency.NewEngine(dependency.EngineConfig{
-				IsFatal:       cmdutil.IsFatal,
-				MoreImportant: func(_ error, worst error) error { return worst },
-				ErrorDelay:    3 * time.Second,
-				BounceDelay:   10 * time.Millisecond,
-			})
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-
 			var runner worker.Runner            // TODO(ericsnow) Wrap engine in a runner.
 			unitHandler.Init(apiClient, runner) // TODO(ericsnow) Eliminate this...
 
-			manifolds := unitHandler.Manifolds()
-			if err := dependency.Install(engine, manifolds); err != nil {
-				if err := worker.Stop(engine); err != nil {
-					workloadsLogger.Errorf("while stopping engine with bad manifolds: %v", err)
-				}
-				return nil, errors.Trace(err)
-			}
-
-			return engine, nil
+			return unitHandler.StartEngine()
 		})
 		return manifold, nil
 	}

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -181,7 +181,7 @@ func (c workloads) registerUnitWorkers() *workers.EventHandlers {
 		})
 		return manifold, nil
 	}
-	err := unit.RegisterManifoldFunc(workload.ComponentName, newManifold)
+	err := unit.RegisterComponentManifoldFunc(workload.ComponentName, newManifold)
 	if err != nil {
 		panic(err)
 	}

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -175,8 +175,7 @@ func (c workloads) registerUnitWorkers() *workers.EventHandlers {
 		}
 		manifold := util.ApiManifold(apiConfig, func(caller base.APICaller) (worker.Worker, error) {
 			apiClient := c.newHookContextAPIClient(caller)
-			var runner worker.Runner // TODO(ericsnow) Wrap engine in a runner.
-			unitHandlers.Reset(apiClient, runner)
+			unitHandlers.Reset(apiClient)
 			return unitHandlers.StartEngine()
 		})
 		return manifold, nil

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -181,7 +181,7 @@ func (c workloads) registerUnitWorkers() *workers.EventHandlers {
 		})
 		return manifold, nil
 	}
-	err := unit.RegisterManifold(workload.ComponentName, newManifold)
+	err := unit.RegisterManifoldFunc(workload.ComponentName, newManifold)
 	if err != nil {
 		panic(err)
 	}

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -46,16 +46,18 @@ func (workloads) registerForClient() error {
 	return nil
 }
 
-func (c workloads) registerHookContext(handlers *workers.EventHandlers) {
+// TODO(ericsnow) Just pass in AddEvents?
+
+func (c workloads) registerHookContext(events *workers.Events) {
 	if !markRegistered(workload.ComponentName, "hook-context") {
 		return
 	}
 
 	runner.RegisterComponentFunc(workload.ComponentName,
 		func(unit string, caller base.APICaller) (jujuc.ContextComponent, error) {
-			var addEvents func(...workload.Event)
-			if handlers != nil {
-				addEvents = handlers.AddEvents
+			var addEvents func(...workload.Event) error
+			if events != nil {
+				addEvents = events.AddEvents
 			}
 			hctxClient := c.newHookContextAPIClient(caller)
 			// TODO(ericsnow) Pass the unit's tag through to the component?
@@ -154,7 +156,7 @@ func (workloads) registerHookContextCommands() {
 
 // TODO(ericsnow) Use a watcher instead of passing around the event handlers?
 
-func (c workloads) registerUnitWorkers() *workers.EventHandlers {
+func (c workloads) registerUnitWorkers() *workers.Events {
 	if !markRegistered(workload.ComponentName, "workers") {
 		return nil
 	}
@@ -188,7 +190,7 @@ func (c workloads) registerUnitWorkers() *workers.EventHandlers {
 		panic(err)
 	}
 
-	return unitHandlers
+	return unitHandlers.Events()
 }
 
 func (workloads) registerState() {

--- a/workload/context/base_test.go
+++ b/workload/context/base_test.go
@@ -190,7 +190,6 @@ func (c *stubContextComponent) Flush() error {
 }
 
 type stubAPIClient struct {
-	context.APIClient
 	stub        *testing.Stub
 	workloads   map[string]workload.Info
 	definitions map[string]charm.Workload
@@ -293,6 +292,20 @@ func (c *stubAPIClient) Untrack(ids []string) error {
 
 	for _, id := range ids {
 		delete(c.workloads, id)
+	}
+	return nil
+}
+
+func (c *stubAPIClient) SetStatus(status workload.Status, pluginStatus workload.PluginStatus, ids ...string) error {
+	c.stub.AddCall("SetStatus", status, pluginStatus, ids)
+	if err := c.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, id := range ids {
+		workload := c.workloads[id]
+		workload.Status = status
+		workload.Details.Status = pluginStatus
 	}
 	return nil
 }

--- a/workload/context/context_test.go
+++ b/workload/context/context_test.go
@@ -42,9 +42,12 @@ func (s *contextSuite) newContext(c *gc.C, workloads ...workload.Info) *context.
 	return ctx
 }
 
-func (s *contextSuite) addEvents(events ...workload.Event) {
+func (s *contextSuite) addEvents(events ...workload.Event) error {
 	s.Stub.AddCall("addEvents", events)
-	s.Stub.NextErr()
+	if err := s.Stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 func (s *contextSuite) TestNewContextEmpty(c *gc.C) {

--- a/workload/errors.go
+++ b/workload/errors.go
@@ -1,0 +1,11 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workload
+
+import (
+	"github.com/juju/errors"
+)
+
+// EventsClosed indicates that no more events may be added.
+var EventsClosed = errors.New("events closed")

--- a/workload/workers/engine.go
+++ b/workload/workers/engine.go
@@ -27,16 +27,18 @@ func newEngine() (dependency.Engine, error) {
 }
 
 func newEngineConfig() dependency.EngineConfig {
-	isFatal := func(err error) bool {
-		return false
-	}
-	moreImportant := func(err, worst error) error {
-		return worst
-	}
 	return dependency.EngineConfig{
 		IsFatal:       isFatal,
 		MoreImportant: moreImportant,
 		ErrorDelay:    engineErrorDelay,
 		BounceDelay:   engineBounceDelay,
 	}
+}
+
+func isFatal(err error) bool {
+	return false
+}
+
+func moreImportant(err, worst error) error {
+	return worst
 }

--- a/workload/workers/engine.go
+++ b/workload/workers/engine.go
@@ -35,10 +35,14 @@ func newEngineConfig() dependency.EngineConfig {
 	}
 }
 
+// isFatal is an implementation of the IsFatal function in
+// dependency.EnginConfig.
 func isFatal(err error) bool {
 	return false
 }
 
+// moreImportant is an implementation of the MoreImportant function in
+// dependency.EnginConfig.
 func moreImportant(err, worst error) error {
 	return worst
 }

--- a/workload/workers/engine.go
+++ b/workload/workers/engine.go
@@ -1,0 +1,42 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workers
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker/dependency"
+)
+
+const (
+	engineErrorDelay  = 3 * time.Second
+	engineBounceDelay = 10 * time.Second
+)
+
+func newEngine() (dependency.Engine, error) {
+	config := newEngineConfig()
+
+	engine, err := dependency.NewEngine(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return engine, nil
+}
+
+func newEngineConfig() dependency.EngineConfig {
+	isFatal := func(err error) bool {
+		return false
+	}
+	moreImportant := func(err, worst error) error {
+		return worst
+	}
+	return dependency.EngineConfig{
+		IsFatal:       isFatal,
+		MoreImportant: moreImportant,
+		ErrorDelay:    engineErrorDelay,
+		BounceDelay:   engineBounceDelay,
+	}
+}

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -93,18 +93,16 @@ func (eh *EventHandlers) eventsManifold() dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			worker, err := eh.NewWorker()
-			if err == nil {
-				return nil, errors.Trace(err)
-			}
-
+			workloadEventLogger.Debugf("starting new worker")
+			w := worker.NewSimpleWorker(eh.loop)
 			// These must be added *after* the worker is started.
 			eh.AddEvents(events...)
-
-			return worker, nil
+			return w, nil
 		},
 	}
 }
+
+// TODO(ericsnow) Use worker.util.ValueWorker in runnerManifold and apiManifold.
 
 func (eh *EventHandlers) runnerManifold() dependency.Manifold {
 	return dependency.Manifold{
@@ -132,12 +130,6 @@ func (eh *EventHandlers) apiManifold() dependency.Manifold {
 			return nil
 		},
 	}
-}
-
-// NewWorker wraps the EventHandler in a worker.
-func (eh *EventHandlers) NewWorker() (worker.Worker, error) {
-	workloadEventLogger.Debugf("starting new worker")
-	return worker.NewSimpleWorker(eh.loop), nil
 }
 
 func (eh *EventHandlers) handle(events []workload.Event) error {

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -33,14 +33,17 @@ type EventHandlers struct {
 }
 
 // NewEventHandlers wraps a new EventHandler around the provided channel.
-func NewEventHandlers(apiClient context.APIClient, runner Runner) *EventHandlers {
+func NewEventHandlers() *EventHandlers {
 	workloadEventLogger.Debugf("new event handler created")
 	eh := &EventHandlers{
-		events:    make(chan []workload.Event),
-		apiClient: apiClient,
-		runner:    newTrackingRunner(runner),
+		events: make(chan []workload.Event),
 	}
 	return eh
+}
+
+func (eh *EventHandlers) Init(apiClient context.APIClient, runner Runner) {
+	eh.apiClient = apiClient
+	eh.runner = newTrackingRunner(runner)
 }
 
 // Close cleans up the handler's resources.

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -101,6 +101,38 @@ func (eh *EventHandlers) loop(stopCh <-chan struct{}) error {
 	return nil
 }
 
+// InitialEvents returns the events that correspond to the current Juju state.
+func InitialEvents(hctx context.Component) ([]workload.Event, error) {
+	// TODO(ericsnow) Use an API call that returns all of them at once,
+	// rather than using a Get call for each?
+	ids, err := hctx.List()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var events []workload.Event
+	for _, id := range ids {
+		info, err := hctx.Get(id)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		// TODO(wwitzel3) (Upgrade/Restart broken) during a restart of the
+		// worker, the Plugin loses its absPath for the executable.
+		plugin, err := hctx.Plugin(info)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		events = append(events, workload.Event{
+			Kind:     workload.EventKindTracked,
+			ID:       info.ID(),
+			Plugin:   plugin,
+			PluginID: info.Details.ID,
+		})
+	}
+	return events, nil
+}
+
 type trackingRunner struct {
 	Runner
 	running set.Strings

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -48,7 +48,11 @@ func NewEventHandlers() *EventHandlers {
 	return eh
 }
 
-func (eh *EventHandlers) Init(apiClient context.APIClient, runner Runner) {
+// Reset resets the event handlers.
+func (eh *EventHandlers) Reset(apiClient context.APIClient, runner Runner) {
+	close(eh.events)
+	eh.events = make(chan []workload.Event)
+
 	eh.apiClient = apiClient
 	eh.runner = newTrackingRunner(runner)
 }
@@ -56,8 +60,10 @@ func (eh *EventHandlers) Init(apiClient context.APIClient, runner Runner) {
 // Close cleans up the handler's resources.
 func (eh *EventHandlers) Close() error {
 	close(eh.events)
-	if err := eh.runner.stopAll(); err != nil {
-		return errors.Trace(err)
+	if eh.runner != nil {
+		if err := eh.runner.stopAll(); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	return nil
 }

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/context"
 )
@@ -143,13 +144,9 @@ func (eh *EventHandlers) runnerManifold() dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{},
 		Start: func(dependency.GetResourceFunc) (worker.Worker, error) {
-			loop := func(<-chan struct{}) error { return nil }
-			return worker.NewSimpleWorker(loop), nil
+			return util.NewValueWorker(eh.runner)
 		},
-		Output: func(in worker.Worker, out interface{}) error {
-			// TODO(ericsnow) provide the runner
-			return nil
-		},
+		Output: util.ValueWorkerOutput,
 	}
 }
 
@@ -157,13 +154,9 @@ func (eh *EventHandlers) apiManifold() dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{},
 		Start: func(dependency.GetResourceFunc) (worker.Worker, error) {
-			loop := func(<-chan struct{}) error { return nil }
-			return worker.NewSimpleWorker(loop), nil
+			return util.NewValueWorker(eh.apiClient)
 		},
-		Output: func(in worker.Worker, out interface{}) error {
-			// TODO(ericsnow) provide the API client
-			return nil
-		},
+		Output: util.ValueWorkerOutput,
 	}
 }
 

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -79,6 +79,9 @@ func (eh *EventHandlers) RegisterHandler(handler func([]workload.Event, context.
 
 // AddEvents adds events to the list of events to be handled.
 func (eh *EventHandlers) AddEvents(events ...workload.Event) {
+	if len(events) == 0 {
+		return
+	}
 	eh.events <- events
 }
 

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -24,6 +24,8 @@ const (
 
 // TODO(ericsnow) Switch handlers to...manifests? workers?
 
+// TODO(ericsnow) Implement ManifoldConfig and Manifold() here?
+
 // EventHandlers orchestrates handling of events on workloads.
 type EventHandlers struct {
 	events   chan []workload.Event

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -16,6 +16,12 @@ import (
 
 var workloadEventLogger = loggo.GetLogger("juju.workload.workers.event")
 
+const (
+	resEvents    = "events"
+	resRunner    = "runner"
+	resAPIClient = "apiclient"
+)
+
 // Runner is the portion of worker.Worker needed for Event handlers.
 type Runner interface {
 	// Start a worker using the provided func.
@@ -68,11 +74,12 @@ func (eh *EventHandlers) AddEvents(events ...workload.Event) {
 	eh.events <- events
 }
 
+// Manifolds returns the set of manifolds that should be added for the unit.
 func (eh *EventHandlers) Manifolds() dependency.Manifolds {
 	return dependency.Manifolds{
-		"events":    eh.eventsManifold(),
-		"runner":    eh.runnerManifold(),
-		"apiclient": eh.apiManifold(),
+		resEvents:    eh.eventsManifold(),
+		resRunner:    eh.runnerManifold(),
+		resAPIClient: eh.apiManifold(),
 	}
 }
 

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -129,9 +129,12 @@ func (eh *EventHandlers) RegisterHandler(handler func([]workload.Event, context.
 	eh.handlers = append(eh.handlers, handler)
 }
 
-// Events returns the Events waiting to be handled.
-func (eh *EventHandlers) Events() *Events {
-	return eh.events
+// AddEvents adds events to the list of events to be handled.
+func (eh *EventHandlers) AddEvents(events ...workload.Event) error {
+	if err := eh.events.AddEvents(events...); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // StartEngine creates a new dependency engine and starts it.

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -36,7 +36,7 @@ type EventHandlers struct {
 	runner worker.Runner
 }
 
-// NewEventHandlers wraps a new EventHandler around the provided channel.
+// NewEventHandlers creates a new EventHandlers.
 func NewEventHandlers() *EventHandlers {
 	logger.Debugf("new event handler created")
 	var eh EventHandlers

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -142,11 +142,16 @@ func (eh *EventHandlers) loop(stopCh <-chan struct{}) error {
 			if !alive {
 				done = true
 			} else if err := eh.handleEvents(events); err != nil {
+				if err := eh.Close(); err != nil {
+					logger.Errorf("failed to close EventHandlers: %v", err)
+				}
 				return errors.Trace(err)
 			}
 		}
 	}
-	// TODO(ericsnow) Call eh.Close() here?
+	if err := eh.Close(); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -120,7 +120,7 @@ func (eh *EventHandlers) AddEvents(events ...workload.Event) error {
 	return nil
 }
 
-func (eh *EventHandlers) handle(events []workload.Event) error {
+func (eh *EventHandlers) handleEvents(events []workload.Event) error {
 	logger.Debugf("handling %d events", len(events))
 	for _, handleEvents := range eh.data.Handlers {
 		if err := handleEvents(events, eh.data.APIClient, eh.data.Runner); err != nil {
@@ -139,7 +139,7 @@ func (eh *EventHandlers) loop(stopCh <-chan struct{}) error {
 		case events, alive := <-eh.data.Events.events:
 			if !alive {
 				done = true
-			} else if err := eh.handle(events); err != nil {
+			} else if err := eh.handleEvents(events); err != nil {
 				return errors.Trace(err)
 			}
 		}

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -4,12 +4,15 @@
 package workers_test
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/dependency"
 	workertesting "github.com/juju/juju/worker/testing"
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/context"
@@ -21,7 +24,7 @@ type eventHandlerSuite struct {
 
 	stub      *gitjujutesting.Stub
 	runner    *workertesting.StubRunner
-	apiClient context.APIClient // TODO(ericsnow) Use a stub.
+	apiClient *stubAPIClient
 }
 
 var _ = gc.Suite(&eventHandlerSuite{})
@@ -31,6 +34,7 @@ func (s *eventHandlerSuite) SetUpTest(c *gc.C) {
 
 	s.stub = &gitjujutesting.Stub{}
 	s.runner = workertesting.NewStubRunner(s.stub)
+	s.apiClient = &stubAPIClient{stub: s.stub}
 }
 
 func (s *eventHandlerSuite) handler(events []workload.Event, apiClient context.APIClient, runner workers.Runner) error {
@@ -79,21 +83,30 @@ func (s *eventHandlerSuite) TestAddEvents(c *gc.C) {
 	c.Check(got, jc.DeepEquals, [][]workload.Event{events})
 }
 
-func (s *eventHandlerSuite) TestNewWorker(c *gc.C) {
+func (s *eventHandlerSuite) TestManifolds(c *gc.C) {
 	events := []workload.Event{{
 		Kind: workload.EventKindTracked,
 		ID:   "spam/eggs",
 	}}
+	engine, err := dependency.NewEngine(dependency.EngineConfig{
+		IsFatal:       func(error) bool { return false },
+		MoreImportant: func(_ error, worst error) error { return worst },
+		ErrorDelay:    3 * time.Second,
+		BounceDelay:   10 * time.Second,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
 	eh := workers.NewEventHandlers()
 	eh.Init(s.apiClient, s.runner)
 	eh.RegisterHandler(s.handler)
-	w, err := eh.NewWorker()
+	manifolds := eh.Manifolds()
+	err = dependency.Install(engine, manifolds)
 	c.Assert(err, jc.ErrorIsNil)
 
 	eh.AddEvents(events...)
 
-	w.Kill()
-	err = w.Wait()
+	engine.Kill()
+	err = engine.Wait()
 	c.Assert(err, jc.ErrorIsNil)
 	eh.Close()
 
@@ -102,10 +115,25 @@ func (s *eventHandlerSuite) TestNewWorker(c *gc.C) {
 		unhandled = append(unhandled, event)
 	}
 	c.Check(unhandled, gc.HasLen, 0)
-	s.stub.CheckCallNames(c, "handler")
-	c.Check(s.stub.Calls()[0].Args[0], gc.DeepEquals, events)
-	c.Check(s.stub.Calls()[0].Args[1], gc.DeepEquals, s.apiClient)
-	runner, running := workers.ExposeRunner(s.stub.Calls()[0].Args[2].(workers.Runner))
+	s.stub.CheckCallNames(c, "List", "handler", "handler")
+	c.Check(s.stub.Calls()[1].Args[0], gc.HasLen, 0)
+	c.Check(s.stub.Calls()[2].Args[0], gc.DeepEquals, events)
+	c.Check(s.stub.Calls()[2].Args[1], gc.DeepEquals, s.apiClient)
+	runner, running := workers.ExposeRunner(s.stub.Calls()[2].Args[2].(workers.Runner))
 	c.Check(runner, jc.DeepEquals, s.runner)
 	c.Check(running.Values(), gc.HasLen, 0)
+}
+
+type stubAPIClient struct {
+	context.APIClient
+	stub *gitjujutesting.Stub
+}
+
+func (c *stubAPIClient) List(ids ...string) ([]workload.Info, error) {
+	c.stub.AddCall("List", ids)
+	if err := c.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return nil, nil
 }

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -56,7 +56,7 @@ func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {
 	// TODO(ericsnow) Check something here.
 }
 
-func (s *eventHandlerSuite) TestAddEvents(c *gc.C) {
+func (s *eventHandlerSuite) TestAddEventsOkay(c *gc.C) {
 	events := []workload.Event{{
 		Kind: workload.EventKindTracked,
 		ID:   "spam/eggs",
@@ -73,6 +73,21 @@ func (s *eventHandlerSuite) TestAddEvents(c *gc.C) {
 		got = append(got, event)
 	}
 	c.Check(got, jc.DeepEquals, [][]workload.Event{events})
+}
+
+func (s *eventHandlerSuite) TestAddEventsEmpty(c *gc.C) {
+	eh := workers.NewEventHandlers()
+	eh.Reset(s.apiClient)
+	go func() {
+		eh.AddEvents()
+		eh.Close()
+	}()
+
+	var got [][]workload.Event
+	for event := range workers.ExposeChannel(eh) {
+		got = append(got, event)
+	}
+	c.Check(got, gc.HasLen, 0)
 }
 
 func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
@@ -99,10 +114,9 @@ func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
 		unhandled = append(unhandled, event)
 	}
 	c.Check(unhandled, gc.HasLen, 0)
-	s.stub.CheckCallNames(c, "List", "handler", "handler")
-	c.Check(s.stub.Calls()[1].Args[0], gc.HasLen, 0)
-	c.Check(s.stub.Calls()[2].Args[0], gc.DeepEquals, events)
-	c.Check(s.stub.Calls()[2].Args[1], gc.DeepEquals, s.apiClient)
+	s.stub.CheckCallNames(c, "List", "handler")
+	c.Check(s.stub.Calls()[1].Args[0], gc.DeepEquals, events)
+	c.Check(s.stub.Calls()[1].Args[1], gc.DeepEquals, s.apiClient)
 	// TODO(ericsnow) Check the runner.
 }
 

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -45,7 +45,6 @@ func (s *eventHandlerSuite) handler(events []workload.Event, apiClient context.A
 
 func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 	eh := workers.NewEventHandlers()
-	eh.Init(s.apiClient, s.runner)
 	defer eh.Close()
 
 	// TODO(ericsnow) This test is rather weak.
@@ -54,7 +53,6 @@ func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 
 func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {
 	eh := workers.NewEventHandlers()
-	eh.Init(s.apiClient, s.runner)
 	defer eh.Close()
 	eh.RegisterHandler(s.handler)
 
@@ -67,7 +65,7 @@ func (s *eventHandlerSuite) TestAddEvents(c *gc.C) {
 		ID:   "spam/eggs",
 	}}
 	eh := workers.NewEventHandlers()
-	eh.Init(s.apiClient, s.runner)
+	eh.Reset(s.apiClient, s.runner)
 	go func() {
 		eh.AddEvents(events...)
 		eh.Close()
@@ -87,7 +85,7 @@ func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
 	}}
 
 	eh := workers.NewEventHandlers()
-	eh.Init(s.apiClient, s.runner)
+	eh.Reset(s.apiClient, s.runner)
 	eh.RegisterHandler(s.handler)
 	engine, err := eh.StartEngine()
 	c.Assert(err, jc.ErrorIsNil)

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -4,15 +4,12 @@
 package workers_test
 
 import (
-	"time"
-
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/worker/dependency"
 	workertesting "github.com/juju/juju/worker/testing"
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/context"
@@ -83,24 +80,16 @@ func (s *eventHandlerSuite) TestAddEvents(c *gc.C) {
 	c.Check(got, jc.DeepEquals, [][]workload.Event{events})
 }
 
-func (s *eventHandlerSuite) TestManifolds(c *gc.C) {
+func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
 	events := []workload.Event{{
 		Kind: workload.EventKindTracked,
 		ID:   "spam/eggs",
 	}}
-	engine, err := dependency.NewEngine(dependency.EngineConfig{
-		IsFatal:       func(error) bool { return false },
-		MoreImportant: func(_ error, worst error) error { return worst },
-		ErrorDelay:    3 * time.Second,
-		BounceDelay:   10 * time.Second,
-	})
-	c.Assert(err, jc.ErrorIsNil)
 
 	eh := workers.NewEventHandlers()
 	eh.Init(s.apiClient, s.runner)
 	eh.RegisterHandler(s.handler)
-	manifolds := eh.Manifolds()
-	err = dependency.Install(engine, manifolds)
+	engine, err := eh.StartEngine()
 	c.Assert(err, jc.ErrorIsNil)
 
 	eh.AddEvents(events...)

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -43,7 +43,8 @@ func (s *eventHandlerSuite) handler(events []workload.Event, apiClient context.A
 }
 
 func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
-	eh := workers.NewEventHandlers(s.apiClient, s.runner)
+	eh := workers.NewEventHandlers()
+	eh.Init(s.apiClient, s.runner)
 	defer eh.Close()
 
 	// TODO(ericsnow) This test is rather weak.
@@ -51,7 +52,8 @@ func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 }
 
 func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {
-	eh := workers.NewEventHandlers(s.apiClient, s.runner)
+	eh := workers.NewEventHandlers()
+	eh.Init(s.apiClient, s.runner)
 	defer eh.Close()
 	eh.RegisterHandler(s.handler)
 
@@ -63,7 +65,8 @@ func (s *eventHandlerSuite) TestAddEvents(c *gc.C) {
 		Kind: workload.EventKindTracked,
 		ID:   "spam/eggs",
 	}}
-	eh := workers.NewEventHandlers(s.apiClient, s.runner)
+	eh := workers.NewEventHandlers()
+	eh.Init(s.apiClient, s.runner)
 	go func() {
 		eh.AddEvents(events...)
 		eh.Close()
@@ -81,7 +84,8 @@ func (s *eventHandlerSuite) TestNewWorker(c *gc.C) {
 		Kind: workload.EventKindTracked,
 		ID:   "spam/eggs",
 	}}
-	eh := workers.NewEventHandlers(s.apiClient, s.runner)
+	eh := workers.NewEventHandlers()
+	eh.Init(s.apiClient, s.runner)
 	eh.RegisterHandler(s.handler)
 	w, err := eh.NewWorker()
 	c.Assert(err, jc.ErrorIsNil)

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -109,7 +109,7 @@ func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
-	c.Check(data.Runner, gc.IsNil)
+	c.Check(data.Engine, gc.IsNil)
 }
 
 func (s *eventHandlerSuite) TestReset(c *gc.C) {
@@ -123,7 +123,7 @@ func (s *eventHandlerSuite) TestReset(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.Equals, s.apiClient)
-	c.Check(data.Runner, gc.IsNil)
+	c.Check(data.Engine, gc.IsNil)
 	s.stub.CheckCalls(c, nil)
 }
 
@@ -138,7 +138,7 @@ func (s *eventHandlerSuite) TestCloseFresh(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
-	c.Check(data.Runner, gc.IsNil)
+	c.Check(data.Engine, gc.IsNil)
 	s.stub.CheckCalls(c, nil)
 }
 
@@ -155,7 +155,7 @@ func (s *eventHandlerSuite) TestCloseIdempotent(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
-	c.Check(data.Runner, gc.IsNil)
+	c.Check(data.Engine, gc.IsNil)
 }
 
 func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {
@@ -178,7 +178,7 @@ func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
 	engine, err := eh.StartEngine()
 	c.Assert(err, jc.ErrorIsNil)
 	data := workers.ExposeEventHandlers(eh)
-	runner := data.Runner
+	runner := data.Engine
 
 	eh.AddEvents(events...)
 

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -146,6 +146,7 @@ func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
 	eh.RegisterHandler(s.handler)
 	engine, err := eh.StartEngine()
 	c.Assert(err, jc.ErrorIsNil)
+	_, _, _, runner := workers.ExposeEventHandlers(eh)
 
 	eh.AddEvents(events...)
 
@@ -158,7 +159,7 @@ func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
 	s.stub.CheckCallNames(c, "List", "handler")
 	c.Check(s.stub.Calls()[1].Args[0], gc.DeepEquals, events)
 	c.Check(s.stub.Calls()[1].Args[1], gc.DeepEquals, s.apiClient)
-	// TODO(ericsnow) Check the runner.
+	c.Check(runner, gc.NotNil)
 }
 
 type stubAPIClient struct {

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -19,7 +19,7 @@ type eventHandlerSuite struct {
 	testing.BaseSuite
 
 	stub      *gitjujutesting.Stub
-	apiClient context.APIClient // TODO(ericsnow) Use a stub.
+	apiClient *stubAPIClient
 }
 
 var _ = gc.Suite(&eventHandlerSuite{})

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -62,10 +62,14 @@ func (s *eventHandlerSuite) checkRegistered(c *gc.C, eh *workers.EventHandlers, 
 
 func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 	eh := workers.NewEventHandlers()
-	defer eh.Close()
+	c.Assert(eh, gc.NotNil)
+	eh.Close()
 
-	// TODO(ericsnow) This test is rather weak.
-	c.Check(eh, gc.NotNil)
+	s.checkUnhandled(c, eh)
+	s.checkRegistered(c, eh)
+	_, _, apiClient, runner := workers.ExposeEventHandlers(eh)
+	c.Check(apiClient, gc.IsNil)
+	c.Check(runner, gc.IsNil)
 }
 
 func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -72,6 +72,20 @@ func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 	c.Check(runner, gc.IsNil)
 }
 
+func (s *eventHandlerSuite) TestReset(c *gc.C) {
+	eh := workers.NewEventHandlers()
+	c.Assert(eh, gc.NotNil)
+	err := eh.Reset(s.apiClient)
+	c.Assert(err, jc.ErrorIsNil)
+	eh.Close()
+
+	s.checkUnhandled(c, eh)
+	s.checkRegistered(c, eh)
+	_, _, apiClient, runner := workers.ExposeEventHandlers(eh)
+	c.Check(apiClient, gc.Equals, s.apiClient)
+	c.Check(runner, gc.IsNil)
+}
+
 func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {
 	eh := workers.NewEventHandlers()
 	defer eh.Close()

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -50,6 +50,16 @@ func (s *eventHandlerSuite) checkUnhandled(c *gc.C, eh *workers.EventHandlers, e
 	c.Check(unhandled, jc.DeepEquals, expected)
 }
 
+func (s *eventHandlerSuite) checkRegistered(c *gc.C, eh *workers.EventHandlers, expected ...string) {
+	_, handlers, _, _ := workers.ExposeEventHandlers(eh)
+	for _, handler := range handlers {
+		err := handler(nil, s.apiClient, nil)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	c.Check(s.stub.Calls(), gc.HasLen, len(expected))
+	s.stub.CheckCallNames(c, expected...)
+}
+
 func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 	eh := workers.NewEventHandlers()
 	defer eh.Close()
@@ -63,7 +73,7 @@ func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {
 	defer eh.Close()
 	eh.RegisterHandler(s.handler)
 
-	// TODO(ericsnow) Check something here.
+	s.checkRegistered(c, eh, "handler")
 }
 
 func (s *eventHandlerSuite) TestAddEventsOkay(c *gc.C) {

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -86,6 +86,19 @@ func (s *eventHandlerSuite) TestReset(c *gc.C) {
 	c.Check(runner, gc.IsNil)
 }
 
+func (s *eventHandlerSuite) TestClose(c *gc.C) {
+	eh := workers.NewEventHandlers()
+	c.Assert(eh, gc.NotNil)
+	err := eh.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkUnhandled(c, eh)
+	s.checkRegistered(c, eh)
+	_, _, apiClient, runner := workers.ExposeEventHandlers(eh)
+	c.Check(apiClient, gc.IsNil)
+	c.Check(runner, gc.IsNil)
+}
+
 func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {
 	eh := workers.NewEventHandlers()
 	defer eh.Close()

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -84,6 +84,7 @@ func (s *eventHandlerSuite) TestReset(c *gc.C) {
 	_, _, apiClient, runner := workers.ExposeEventHandlers(eh)
 	c.Check(apiClient, gc.Equals, s.apiClient)
 	c.Check(runner, gc.IsNil)
+	s.stub.CheckCalls(c, nil)
 }
 
 func (s *eventHandlerSuite) TestClose(c *gc.C) {
@@ -97,6 +98,7 @@ func (s *eventHandlerSuite) TestClose(c *gc.C) {
 	_, _, apiClient, runner := workers.ExposeEventHandlers(eh)
 	c.Check(apiClient, gc.IsNil)
 	c.Check(runner, gc.IsNil)
+	s.stub.CheckCalls(c, nil)
 }
 
 func (s *eventHandlerSuite) TestRegisterHandler(c *gc.C) {

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -40,6 +40,16 @@ func (s *eventHandlerSuite) handler(events []workload.Event, apiClient context.A
 	return nil
 }
 
+func (s *eventHandlerSuite) checkUnhandled(c *gc.C, eh *workers.EventHandlers, expected ...[]workload.Event) {
+	eventsChan, _, _, _ := workers.ExposeEventHandlers(eh)
+
+	var unhandled [][]workload.Event
+	for events := range eventsChan {
+		unhandled = append(unhandled, events)
+	}
+	c.Check(unhandled, jc.DeepEquals, expected)
+}
+
 func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 	eh := workers.NewEventHandlers()
 	defer eh.Close()
@@ -68,11 +78,7 @@ func (s *eventHandlerSuite) TestAddEventsOkay(c *gc.C) {
 		eh.Close()
 	}()
 
-	var got [][]workload.Event
-	for event := range workers.ExposeChannel(eh) {
-		got = append(got, event)
-	}
-	c.Check(got, jc.DeepEquals, [][]workload.Event{events})
+	s.checkUnhandled(c, eh, events)
 }
 
 func (s *eventHandlerSuite) TestAddEventsEmpty(c *gc.C) {
@@ -83,11 +89,7 @@ func (s *eventHandlerSuite) TestAddEventsEmpty(c *gc.C) {
 		eh.Close()
 	}()
 
-	var got [][]workload.Event
-	for event := range workers.ExposeChannel(eh) {
-		got = append(got, event)
-	}
-	c.Check(got, gc.HasLen, 0)
+	s.checkUnhandled(c, eh)
 }
 
 func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
@@ -109,11 +111,7 @@ func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	eh.Close()
 
-	var unhandled [][]workload.Event
-	for event := range workers.ExposeChannel(eh) {
-		unhandled = append(unhandled, event)
-	}
-	c.Check(unhandled, gc.HasLen, 0)
+	s.checkUnhandled(c, eh)
 	s.stub.CheckCallNames(c, "List", "handler")
 	c.Check(s.stub.Calls()[1].Args[0], gc.DeepEquals, events)
 	c.Check(s.stub.Calls()[1].Args[1], gc.DeepEquals, s.apiClient)

--- a/workload/workers/export_test.go
+++ b/workload/workers/export_test.go
@@ -4,9 +4,11 @@
 package workers
 
 import (
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/workload"
+	"github.com/juju/juju/workload/context"
 )
 
-func ExposeChannel(events *EventHandlers) chan []workload.Event {
-	return events.events
+func ExposeEventHandlers(eh *EventHandlers) (chan []workload.Event, []func([]workload.Event, context.APIClient, Runner) error, context.APIClient, worker.Runner) {
+	return eh.events, eh.handlers, eh.apiClient, eh.runner
 }

--- a/workload/workers/export_test.go
+++ b/workload/workers/export_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/juju/juju/workload/context"
 )
 
-func ExposeEventHandlers(eh *EventHandlers) (chan []workload.Event, []func([]workload.Event, context.APIClient, Runner) error, context.APIClient, worker.Runner) {
+func ExposeEventHandlers(eh *EventHandlers) (*Events, []func([]workload.Event, context.APIClient, Runner) error, context.APIClient, worker.Runner) {
 	return eh.events, eh.handlers, eh.apiClient, eh.runner
+}
+
+func ExposeEvents(e *Events) chan []workload.Event {
+	return e.events
 }

--- a/workload/workers/export_test.go
+++ b/workload/workers/export_test.go
@@ -4,13 +4,11 @@
 package workers
 
 import (
-	"github.com/juju/juju/worker"
 	"github.com/juju/juju/workload"
-	"github.com/juju/juju/workload/context"
 )
 
-func ExposeEventHandlers(eh *EventHandlers) (*Events, []func([]workload.Event, context.APIClient, Runner) error, context.APIClient, worker.Runner) {
-	return eh.events, eh.handlers, eh.apiClient, eh.runner
+func ExposeEventHandlers(eh *EventHandlers) *eventHandlersData {
+	return &eh.data
 }
 
 func ExposeEvents(e *Events) chan []workload.Event {

--- a/workload/workers/export_test.go
+++ b/workload/workers/export_test.go
@@ -5,17 +5,8 @@ package workers
 
 import (
 	"github.com/juju/juju/workload"
-	"github.com/juju/utils/set"
 )
 
 func ExposeChannel(events *EventHandlers) chan []workload.Event {
 	return events.events
-}
-
-func ExposeRunner(runner Runner) (Runner, set.Strings) {
-	tracking, ok := runner.(*trackingRunner)
-	if !ok {
-		return runner, nil
-	}
-	return tracking.Runner, tracking.running
 }

--- a/workload/workers/runner.go
+++ b/workload/workers/runner.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/juju/worker"
 )
 
-// Runner is the portion of worker.Worker needed for Event handlers.
+// Runner is the portion of worker.Runner needed for Event handlers.
 type Runner interface {
 	// Start a worker using the provided func.
 	StartWorker(id string, newWorker func() (worker.Worker, error)) error

--- a/workload/workers/runner.go
+++ b/workload/workers/runner.go
@@ -1,0 +1,22 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workers
+
+import (
+	"github.com/juju/juju/worker"
+)
+
+// Runner is the portion of worker.Worker needed for Event handlers.
+type Runner interface {
+	// Start a worker using the provided func.
+	StartWorker(id string, newWorker func() (worker.Worker, error)) error
+	// Stop the identified worker.
+	StopWorker(id string) error
+}
+
+func newRunner() worker.Runner {
+	return worker.NewRunner(isFatal, func(err0, err1 error) bool {
+		return moreImportant(err0, err1) == err0
+	})
+}

--- a/workload/workers/workload.go
+++ b/workload/workers/workload.go
@@ -1,0 +1,63 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workers
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/workload"
+	"github.com/juju/juju/workload/context"
+)
+
+// WorkloadHandler returns an event handler that starts a worker for each
+// tracked workload workload. The worker waits until it is stopped.
+func WorkloadHandler(events []workload.Event, apiClient context.APIClient, runner Runner) error {
+	ph := newWorkloadHandler(apiClient, runner)
+	if err := ph.handleEvents(events); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+type workloadHandler struct {
+	apiClient context.APIClient
+	runner    Runner
+
+	newWorker func() (worker.Worker, error)
+}
+
+func newWorkloadHandler(apiClient context.APIClient, runner Runner) *workloadHandler {
+	ph := &workloadHandler{
+		apiClient: apiClient,
+		runner:    runner,
+		newWorker: func() (worker.Worker, error) {
+			return worker.NewNoOpWorker(), nil
+		},
+	}
+	return ph
+}
+
+func (ph *workloadHandler) handleEvents(events []workload.Event) error {
+	for _, event := range events {
+		if err := ph.handleEvent(event); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (ph *workloadHandler) handleEvent(event workload.Event) error {
+	switch event.Kind {
+	case workload.EventKindTracked:
+		if err := ph.runner.StartWorker(event.ID, ph.newWorker); err != nil {
+			return errors.Trace(err)
+		}
+	case workload.EventKindUntracked:
+		if err := ph.runner.StopWorker(event.ID); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
A previous patch added a worker registration mechanism to the unit agent.  The switch to dependency engine requires switching over to registering manifest factories instead of worker factories.  Note that we don't switch over to dependency engine entirely.  This is because it does not support stopping (and forgetting) workers like runners do.  We need that capability since workers specific to individual workload processes will come and go.

(Review request: http://reviews.vapour.ws/r/2405/)