### PR TITLE
Added spaces= to --constraints and fixed setting/getting issues

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -44,6 +44,7 @@ type Client struct {
 
 // NetworksSpecification holds the enabled and disabled networks for a
 // service.
+// TODO(dimitern): Drop this in a follow-up.
 type NetworksSpecification struct {
 	Enabled  []string
 	Disabled []string

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -264,6 +264,9 @@ func (c *Client) ServiceDeploy(args params.ServiceDeploy) error {
 // allows specifying networks to include or exclude on the machine
 // where the charm gets deployed (either with args.Network or with
 // constraints).
+//
+// TODO(dimitern): Drop the special handling of networks in favor of
+// spaces constraints, once possible.
 func (c *Client) ServiceDeployWithNetworks(args params.ServiceDeploy) error {
 	return c.ServiceDeploy(args)
 }

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -578,6 +578,7 @@ func (context *statusContext) processService(service *state.Service) (status api
 			return
 		}
 	}
+	// TODO(dimitern): Drop support for this in a follow-up.
 	if len(networks) > 0 || cons.HaveNetworks() {
 		// Only the explicitly requested networks (using "juju deploy
 		// <svc> --networks=...") will be enabled, and altough when

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -110,6 +110,9 @@ type InstanceConfig struct {
 	MachineContainerHostname string
 
 	// Networks holds a list of networks the instances should be on.
+	//
+	// TODO(dimitern): Drop this in a follow-up in favor or spaces
+	// constraints.
 	Networks []string
 
 	// AuthorizedKeys specifies the keys that are allowed to

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -32,7 +32,7 @@ type DeployCommand struct {
 	ServiceName  string
 	Config       cmd.FileVar
 	Constraints  constraints.Value
-	Networks     string
+	Networks     string // TODO(dimitern): Drop this in a follow-up and fix docs.
 	BumpRevision bool   // Remove this once the 1.16 support is dropped.
 	RepoPath     string // defaults to JUJU_REPOSITORY
 	RegisterURL  string

--- a/cmd/juju/commands/status.go
+++ b/cmd/juju/commands/status.go
@@ -352,6 +352,7 @@ func (sf *statusFormatter) format() formattedStatus {
 	for sn, s := range sf.status.Services {
 		out.Services[sn] = sf.formatService(sn, s)
 	}
+	// TODO(dimitern): Drop this and the related code in a follow-up.
 	for k, n := range sf.status.Networks {
 		if out.Networks == nil {
 			out.Networks = make(map[string]networkStatus)

--- a/constraints/constraints.go
+++ b/constraints/constraints.go
@@ -232,6 +232,49 @@ func (v Value) String() string {
 	return strings.Join(strs, " ")
 }
 
+// GoString allows printing a constraints.Value nicely with the fmt
+// package, especially when nested inside other types.
+func (v Value) GoString() string {
+	var values []string
+	if v.Arch != nil {
+		values = append(values, fmt.Sprintf("Arch: %q", *v.Arch))
+	}
+	if v.CpuCores != nil {
+		values = append(values, fmt.Sprintf("CpuCores: %v", *v.CpuCores))
+	}
+	if v.CpuPower != nil {
+		values = append(values, fmt.Sprintf("CpuPower: %v", *v.CpuPower))
+	}
+	if v.Mem != nil {
+		values = append(values, fmt.Sprintf("Mem: %v", *v.Mem))
+	}
+	if v.RootDisk != nil {
+		values = append(values, fmt.Sprintf("RootDisk: %v", *v.RootDisk))
+	}
+	if v.InstanceType != nil {
+		values = append(values, fmt.Sprintf("InstanceType: %q", *v.InstanceType))
+	}
+	if v.Container != nil {
+		values = append(values, fmt.Sprintf("Container: %q", *v.Container))
+	}
+	if v.Tags != nil && *v.Tags != nil {
+		values = append(values, fmt.Sprintf("Tags: %q", *v.Tags))
+	} else if v.Tags != nil {
+		values = append(values, "Tags: (*[]string)(nil)")
+	}
+	if v.Spaces != nil && *v.Spaces != nil {
+		values = append(values, fmt.Sprintf("Spaces: %q", *v.Spaces))
+	} else if v.Spaces != nil {
+		values = append(values, "Spaces: (*[]string)(nil)")
+	}
+	if v.Networks != nil && *v.Networks != nil {
+		values = append(values, fmt.Sprintf("Networks: %q", *v.Networks))
+	} else if v.Networks != nil {
+		values = append(values, "Networks: (*[]string)(nil)")
+	}
+	return fmt.Sprintf("{%s}", strings.Join(values, ", "))
+}
+
 func uintStr(i uint64) string {
 	if i == 0 {
 		return ""
@@ -554,9 +597,9 @@ func (v *Value) validateNetworks(networks *[]string) error {
 		return nil
 	}
 	for _, name := range *networks {
-		name := strings.TrimPrefix(name, "^")
-		if !names.IsValidNetwork(name) {
-			return fmt.Errorf("%q is not a valid network name", name)
+		netName := strings.TrimPrefix(name, "^")
+		if !names.IsValidNetwork(netName) {
+			return fmt.Errorf("%q is not a valid network name", netName)
 		}
 	}
 	v.Networks = networks
@@ -594,7 +637,8 @@ func parseSize(str string) (*uint64, error) {
 }
 
 // parseCommaDelimited returns the items in the value s. We expect the
-// tags to be comma delimited strings. It is used for tags and networks.
+// tags to be comma delimited strings. It is used for tags, spaces,
+// and networks.
 func parseCommaDelimited(s string) *[]string {
 	if s == "" {
 		return &[]string{}

--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -326,6 +326,9 @@ var parseConstraintsTests = []struct {
 }
 
 func (s *ConstraintsSuite) TestParseConstraints(c *gc.C) {
+	// TODO(dimitern): This test is inadequate and needs to check for
+	// more than just the reparsed output of String() matches the
+	// expected.
 	for i, t := range parseConstraintsTests {
 		c.Logf("test %d: %s", i, t.summary)
 		cons0, err := constraints.Parse(t.args...)

--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -265,13 +265,34 @@ var parseConstraintsTests = []struct {
 		args:    []string{"tags="},
 	},
 
+	// spaces
+	{
+		summary: "single space",
+		args:    []string{"spaces=space1"},
+	}, {
+		summary: "multiple spaces - positive",
+		args:    []string{"spaces=space1,space2"},
+	}, {
+		summary: "multiple spaces - negative",
+		args:    []string{"spaces=^dmz,^public"},
+	}, {
+		summary: "multiple spaces - positive and negative",
+		args:    []string{"spaces=admin,^area52,dmz,^public"},
+	}, {
+		summary: "no spaces",
+		args:    []string{"spaces="},
+	},
+
 	// networks
 	{
 		summary: "single network",
-		args:    []string{"networks=net1"},
+		args:    []string{"networks=space1"},
 	}, {
 		summary: "multiple networks - positive",
 		args:    []string{"networks=net1,net2"},
+	}, {
+		summary: "multiple networks - negative",
+		args:    []string{"networks=^net1,^net2"},
 	}, {
 		summary: "multiple networks - positive and negative",
 		args:    []string{"networks=net1,^net2,net3,^net4"},
@@ -294,12 +315,13 @@ var parseConstraintsTests = []struct {
 		summary: "kitchen sink together",
 		args: []string{
 			"root-disk=8G mem=2T  arch=i386  cpu-cores=4096 cpu-power=9001 container=lxc " +
-				"tags=foo,bar networks=net1,^net2 instance-type=foo"},
+				"tags=foo,bar spaces=space1,^space2 networks=net,^net2 instance-type=foo"},
 	}, {
 		summary: "kitchen sink separately",
 		args: []string{
 			"root-disk=8G", "mem=2T", "cpu-cores=4096", "cpu-power=9001", "arch=armhf",
-			"container=lxc", "tags=foo,bar", "networks=net1,^net2", "instance-type=foo"},
+			"container=lxc", "tags=foo,bar", "spaces=space1,^space2", "networks=net1,^net2",
+			"instance-type=foo"},
 	},
 }
 
@@ -322,7 +344,9 @@ func (s *ConstraintsSuite) TestParseConstraints(c *gc.C) {
 func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	con1 := constraints.MustParse("arch=amd64 mem=4G")
 	con2 := constraints.MustParse("cpu-cores=42")
-	con3 := constraints.MustParse("root-disk=8G container=lxc networks=net1,^net2")
+	con3 := constraints.MustParse(
+		"root-disk=8G container=lxc spaces=space1,^space2 networks=net1,^net2",
+	)
 	merged, err := constraints.Merge(con1, con2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(merged, jc.DeepEquals, constraints.MustParse("arch=amd64 mem=4G cpu-cores=42"))
@@ -331,7 +355,10 @@ func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	c.Assert(merged, jc.DeepEquals, con1)
 	merged, err = constraints.Merge(con1, con2, con3)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(merged, jc.DeepEquals, constraints.MustParse("arch=amd64 mem=4G cpu-cores=42 root-disk=8G container=lxc networks=net1,^net2"))
+	c.Assert(merged, jc.DeepEquals, constraints.
+		MustParse(
+		"arch=amd64 mem=4G cpu-cores=42 root-disk=8G container=lxc spaces=space1,^space2 networks=net1,^net2"),
+	)
 	merged, err = constraints.Merge()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(merged, jc.DeepEquals, constraints.Value{})
@@ -346,18 +373,39 @@ func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	c.Assert(merged, jc.DeepEquals, constraints.Value{})
 }
 
-func (s *ConstraintsSuite) TestParseMissingTagsAndNetworks(c *gc.C) {
+func (s *ConstraintsSuite) TestParseMissingTagsSpacesAndNetworks(c *gc.C) {
 	con := constraints.MustParse("arch=amd64 mem=4G cpu-cores=1 root-disk=8G")
 	c.Check(con.Tags, gc.IsNil)
+	c.Check(con.Spaces, gc.IsNil)
 	c.Check(con.Networks, gc.IsNil)
 }
 
-func (s *ConstraintsSuite) TestParseNoTagsNoNetworks(c *gc.C) {
-	con := constraints.MustParse("arch=amd64 mem=4G cpu-cores=1 root-disk=8G tags= networks=")
+func (s *ConstraintsSuite) TestParseNoTagsNoSpacesNoNetworks(c *gc.C) {
+	con := constraints.MustParse(
+		"arch=amd64 mem=4G cpu-cores=1 root-disk=8G tags= spaces= networks=",
+	)
 	c.Assert(con.Tags, gc.Not(gc.IsNil))
-	c.Assert(con.Networks, gc.Not(gc.IsNil))
+	c.Assert(con.Spaces, gc.Not(gc.IsNil))
 	c.Check(*con.Tags, gc.HasLen, 0)
+	c.Check(*con.Spaces, gc.HasLen, 0)
 	c.Check(*con.Networks, gc.HasLen, 0)
+}
+
+func (s *ConstraintsSuite) TestIncludeExcludeAndHaveSpaces(c *gc.C) {
+	con := constraints.MustParse("spaces=space1,^space2,space3,^space4")
+	c.Assert(con.Spaces, gc.Not(gc.IsNil))
+	c.Check(*con.Spaces, gc.HasLen, 4)
+	c.Check(con.IncludeSpaces(), jc.SameContents, []string{"space1", "space3"})
+	c.Check(con.ExcludeSpaces(), jc.SameContents, []string{"space2", "space4"})
+	c.Check(con.HaveSpaces(), jc.IsTrue)
+	c.Check(con.HaveNetworks(), jc.IsFalse)
+	con = constraints.MustParse("mem=4G")
+	c.Check(con.HaveSpaces(), jc.IsFalse)
+	con = constraints.MustParse("mem=4G spaces=space-foo,^space-bar")
+	c.Check(con.IncludeSpaces(), jc.SameContents, []string{"space-foo"})
+	c.Check(con.ExcludeSpaces(), jc.SameContents, []string{"space-bar"})
+	c.Check(con.HaveSpaces(), jc.IsTrue)
+	c.Check(con.HaveNetworks(), jc.IsFalse)
 }
 
 func (s *ConstraintsSuite) TestIncludeExcludeAndHaveNetworks(c *gc.C) {
@@ -367,10 +415,30 @@ func (s *ConstraintsSuite) TestIncludeExcludeAndHaveNetworks(c *gc.C) {
 	c.Check(con.IncludeNetworks(), jc.SameContents, []string{"net1", "net3"})
 	c.Check(con.ExcludeNetworks(), jc.SameContents, []string{"net2", "net4"})
 	c.Check(con.HaveNetworks(), jc.IsTrue)
+	c.Check(con.HaveSpaces(), jc.IsFalse)
 	con = constraints.MustParse("mem=4G")
 	c.Check(con.HaveNetworks(), jc.IsFalse)
-	con = constraints.MustParse("mem=4G networks=^net1,^net2")
+	con = constraints.MustParse("mem=4G networks=net-foo,^net-bar")
+	c.Check(con.IncludeNetworks(), jc.SameContents, []string{"net-foo"})
+	c.Check(con.ExcludeNetworks(), jc.SameContents, []string{"net-bar"})
 	c.Check(con.HaveNetworks(), jc.IsTrue)
+	c.Check(con.HaveSpaces(), jc.IsFalse)
+}
+
+func (s *ConstraintsSuite) TestInvalidSpaces(c *gc.C) {
+	invalidNames := []string{
+		"%$pace", "^foo#2", "+", "tcp:ip",
+		"^^myspace", "^^^^^^^^", "space^x",
+		"&-foo", "space/3", "^bar=4", "&#!",
+	}
+	for _, name := range invalidNames {
+		con, err := constraints.Parse("spaces=" + name)
+		expectName := strings.TrimPrefix(name, "^")
+		expectErr := fmt.Sprintf(`bad "spaces" constraint: %q is not a valid space name`, expectName)
+		c.Check(err, gc.NotNil)
+		c.Check(err.Error(), gc.Equals, expectErr)
+		c.Check(con, jc.DeepEquals, constraints.Value{})
+	}
 }
 
 func (s *ConstraintsSuite) TestInvalidNetworks(c *gc.C) {
@@ -397,6 +465,8 @@ func (s *ConstraintsSuite) TestIsEmpty(c *gc.C) {
 	con = constraints.MustParse("")
 	c.Check(&con, jc.Satisfies, constraints.IsEmpty)
 	con = constraints.MustParse("tags=")
+	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
+	con = constraints.MustParse("spaces=")
 	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
 	con = constraints.MustParse("networks=")
 	c.Check(&con, gc.Not(jc.Satisfies), constraints.IsEmpty)
@@ -456,6 +526,9 @@ var constraintsRoundtripTests = []roundTrip{
 	{"Tags1", constraints.Value{Tags: nil}},
 	{"Tags2", constraints.Value{Tags: &[]string{}}},
 	{"Tags3", constraints.Value{Tags: &[]string{"foo", "bar"}}},
+	{"Spaces1", constraints.Value{Spaces: nil}},
+	{"Spaces2", constraints.Value{Spaces: &[]string{}}},
+	{"Spaces3", constraints.Value{Spaces: &[]string{"space1", "^space2"}}},
 	{"Networks1", constraints.Value{Networks: nil}},
 	{"Networks2", constraints.Value{Networks: &[]string{}}},
 	{"Networks3", constraints.Value{Networks: &[]string{"net1", "^net2"}}},
@@ -469,6 +542,7 @@ var constraintsRoundtripTests = []roundTrip{
 		Mem:          uint64p(18000000000),
 		RootDisk:     uint64p(24000000000),
 		Tags:         &[]string{"foo", "bar"},
+		Spaces:       &[]string{"space1", "^space2"},
 		Networks:     &[]string{"net1", "^net2"},
 		InstanceType: strp("foo"),
 	}},
@@ -548,7 +622,7 @@ func (s *ConstraintsSuite) TestHasInstanceType(c *gc.C) {
 	c.Check(cons.HasInstanceType(), jc.IsTrue)
 }
 
-const initialWithoutCons = "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 networks=net1,^net2 tags=foo container=lxc instance-type=bar"
+const initialWithoutCons = "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 spaces=space1,^space2 networks=net1,^net2 tags=foo container=lxc instance-type=bar"
 
 var withoutTests = []struct {
 	initial string
@@ -557,43 +631,47 @@ var withoutTests = []struct {
 }{{
 	initial: initialWithoutCons,
 	without: []string{"root-disk"},
-	final:   "mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"mem"},
-	final:   "root-disk=8G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"arch"},
-	final:   "root-disk=8G mem=4G cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"cpu-power"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"cpu-cores"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"tags"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
+}, {
+	initial: initialWithoutCons,
+	without: []string{"spaces"},
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"networks"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo container=lxc instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxc instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"container"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 instance-type=bar",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 instance-type=bar",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"instance-type"},
-	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc",
+	final:   "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 container=lxc networks=net1,^net2",
 }, {
 	initial: initialWithoutCons,
 	without: []string{"root-disk", "mem", "arch"},
-	final:   "cpu-power=1000 cpu-cores=4 tags=foo networks=net1,^net2 container=lxc instance-type=bar",
+	final:   "cpu-power=1000 cpu-cores=4 tags=foo spaces=space1,^space2 networks=net1,^net2 container=lxc instance-type=bar",
 }}
 
 func (s *ConstraintsSuite) TestWithout(c *gc.C) {
@@ -615,7 +693,7 @@ func (s *ConstraintsSuite) TestWithoutError(c *gc.C) {
 func (s *ConstraintsSuite) TestAttributesWithValues(c *gc.C) {
 	for i, consStr := range []string{
 		"",
-		"root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 instance-type=foo tags=foo,bar networks=net1,^net2",
+		"root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4 instance-type=foo tags=foo,bar spaces=space1,^space2",
 	} {
 		c.Logf("test %d", i)
 		cons := constraints.MustParse(consStr)
@@ -654,6 +732,11 @@ func (s *ConstraintsSuite) TestAttributesWithValues(c *gc.C) {
 		} else {
 			assertMissing("tags")
 		}
+		if cons.Spaces != nil {
+			c.Check(obtained["spaces"], gc.DeepEquals, *cons.Spaces)
+		} else {
+			assertMissing("spaces")
+		}
 		if cons.Networks != nil {
 			c.Check(obtained["networks"], gc.DeepEquals, *cons.Networks)
 		} else {
@@ -673,13 +756,18 @@ var hasAnyTests = []struct {
 	expected []string
 }{
 	{
+		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 spaces=space1,^space2 cpu-cores=4",
+		attrs:    []string{"root-disk", "tags", "mem", "spaces"},
+		expected: []string{"root-disk", "mem", "spaces"},
+	},
+	{
 		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 networks=net1,^net2 cpu-cores=4",
 		attrs:    []string{"root-disk", "tags", "mem", "networks"},
 		expected: []string{"root-disk", "mem", "networks"},
 	},
 	{
 		cons:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
-		attrs:    []string{"tags", "networks"},
+		attrs:    []string{"tags", "spaces", "networks"},
 		expected: []string{},
 	},
 }

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -36,6 +36,7 @@ type DeployServiceParams struct {
 	// instead of a machine spec.
 	Placement []*instance.Placement
 	// Networks holds a list of networks to required to start on boot.
+	// TODO(dimitern): Drop this in a follow-up in favor of constraints.
 	Networks []string
 	Storage  map[string]storage.Constraints
 }
@@ -66,6 +67,8 @@ func DeployService(st *state.State, args DeployServiceParams) (*state.Service, e
 	}
 	// TODO(fwereade): transactional State.AddService including settings, constraints
 	// (minimumUnitCount, initialMachineIds?).
+
+	// TODO(dimitern): Drop --networks in a follow-up with an error.
 	if len(args.Networks) > 0 || args.Constraints.HaveNetworks() {
 		conf, err := st.EnvironConfig()
 		if err != nil {
@@ -79,6 +82,8 @@ func DeployService(st *state.State, args DeployServiceParams) (*state.Service, e
 			return nil, fmt.Errorf("cannot deploy with networks: not suppored by the environment")
 		}
 	}
+	// TODO(dimitern): In a follow-up drop Networks and use spaces
+	// constraints for this when possible.
 	service, err := st.AddService(
 		args.ServiceName,
 		args.ServiceOwner,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -957,6 +957,9 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		}
 	}
 	// Simulate networks added when requested.
+	//
+	// TODO(dimitern): Fix this in a follow-up to use constraints
+	// instead.
 	networks := append(args.Constraints.IncludeNetworks(), args.InstanceConfig.Networks...)
 	networkInfo := make([]network.InterfaceInfo, len(networks))
 	for i, netName := range networks {

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -66,6 +66,7 @@ func (env *environ) lookupArchitectures() ([]string, error) {
 
 var unsupportedConstraints = []string{
 	constraints.Tags,
+	// TODO(dimitern: Replace Networks with Spaces in a follow-up.
 	constraints.Networks,
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -900,6 +900,10 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	}
 
 	// Networking.
+	//
+	// TODO(dimitern): Once we can get from spaces constraints to MAAS
+	// networks (or even directly to spaces), include them in the
+	// instance selection.
 	requestedNetworks := args.InstanceConfig.Networks
 	includeNetworks := append(args.Constraints.IncludeNetworks(), requestedNetworks...)
 	excludeNetworks := args.Constraints.ExcludeNetworks()

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -56,6 +56,8 @@ type MachineTemplate struct {
 
 	// RequestedNetworks holds a list of network names the machine
 	// should be part of.
+	//
+	// TODO(dimitern): Drop this in favor of constraints in a follow-up.
 	RequestedNetworks []string
 
 	// Volumes holds the parameters for volumes that are to be created

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -213,6 +213,20 @@ func (st *State) addMachine(mdoc *machineDoc, ops []txn.Op) (*Machine, error) {
 	return newMachine(st, mdoc), nil
 }
 
+func (st *State) resolveMachineConstraints(cons constraints.Value) (constraints.Value, error) {
+	mcons, err := st.resolveConstraints(cons)
+	if err != nil {
+		return constraints.Value{}, err
+	}
+	// Machine constraints do not use a container constraint value.
+	// Both provisioning and deployment constraints use the same
+	// constraints.Value struct so here we clear the container
+	// value. Provisioning ignores the container value but clearing
+	// it avoids potential confusion.
+	mcons.Container = nil
+	return mcons, nil
+}
+
 // effectiveMachineTemplate verifies that the given template is
 // valid and combines it with values from the state
 // to produce a resulting template that more accurately
@@ -230,16 +244,10 @@ func (st *State) effectiveMachineTemplate(p MachineTemplate, allowStateServer bo
 		return tmpl, errors.New("cannot specify a nonce without an instance id")
 	}
 
-	p.Constraints, err = st.resolveConstraints(p.Constraints)
+	p.Constraints, err = st.resolveMachineConstraints(p.Constraints)
 	if err != nil {
 		return tmpl, err
 	}
-	// Machine constraints do not use a container constraint value.
-	// Both provisioning and deployment constraints use the same
-	// constraints.Value struct so here we clear the container
-	// value. Provisioning ignores the container value but clearing
-	// it avoids potential confusion.
-	p.Constraints.Container = nil
 
 	if len(p.Jobs) == 0 {
 		return tmpl, errors.New("no jobs specified")

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -74,24 +74,22 @@ func (s *storeManagerStateSuite) Reset(c *gc.C) {
 }
 
 func jcDeepEqualsCheck(c *gc.C, got, want interface{}) bool {
-	ok, message := jc.DeepEquals.Check([]interface{}{got, want}, []string{"got", "want"})
-	if !ok {
-		c.Logf(message)
+	ok, err := jc.DeepEqual(got, want)
+	if ok {
+		c.Check(err, jc.ErrorIsNil)
 	}
 	return ok
 }
 
 func assertEntitiesEqual(c *gc.C, got, want []multiwatcher.EntityInfo) {
-	if len(got) == 0 {
-		got = nil
-	}
-	if len(want) == 0 {
-		want = nil
-	}
 	if jcDeepEqualsCheck(c, got, want) {
 		return
 	}
-	c.Errorf("entity mismatch; got len %d; want %d", len(got), len(want))
+	if len(got) != len(want) {
+		c.Errorf("entity length mismatch; got %d; want %d", len(got), len(want))
+	} else {
+		c.Errorf("entity contents mismatch; same length %d", len(got))
+	}
 	// Lets construct a decent output.
 	var errorOutput string
 	errorOutput = "\ngot: \n"
@@ -1114,7 +1112,7 @@ func (s *storeManagerStateSuite) TestChangeServicesConstraints(c *gc.C) {
 					&multiwatcher.ServiceInfo{
 						EnvUUID:     st.EnvironUUID(),
 						Name:        "wordpress",
-						Constraints: constraints.MustParse("mem=4G cpu-cores= arch=amd64"),
+						Constraints: constraints.MustParse("mem=4G arch=amd64"),
 					}}}
 		},
 	}

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -428,7 +428,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineSetsConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	mcons, err := machine.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	expect := constraints.MustParse("mem=2G cpu-cores=2 cpu-power=400 networks=net3,^net4,^net5")
+	expect := constraints.MustParse("mem=2G cpu-cores=2 cpu-power=400")
 	c.Assert(mcons, gc.DeepEquals, expect)
 }
 

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
@@ -17,50 +16,102 @@ import (
 
 // constraintsDoc is the mongodb representation of a constraints.Value.
 type constraintsDoc struct {
-	EnvUUID      string `bson:"env-uuid"`
-	Arch         *string
-	CpuCores     *uint64
-	CpuPower     *uint64
-	Mem          *uint64
-	RootDisk     *uint64
-	InstanceType *string
-	Container    *instance.ContainerType
-	Tags         *[]string `bson:",omitempty"`
-	Spaces       *[]string `bson:",omitempty"`
+	EnvUUID      string                 `bson:"env-uuid"`
+	Arch         string                 `bson:",omitempty"`
+	CpuCores     uint64                 `bson:",omitempty"`
+	CpuPower     uint64                 `bson:",omitempty"`
+	Mem          uint64                 `bson:",omitempty"`
+	RootDisk     uint64                 `bson:",omitempty"`
+	InstanceType string                 `bson:",omitempty"`
+	Container    instance.ContainerType `bson:",omitempty"`
+	Tags         []string               `bson:",omitempty"`
+	Spaces       []string               `bson:",omitempty"`
 	// TODO(dimitern): Drop this once it's not possible to specify
 	// networks= in constraints.
-	Networks *[]string `bson:",omitempty"`
+	Networks []string `bson:",omitempty"`
 }
 
 func (doc constraintsDoc) value() constraints.Value {
+	var container *instance.ContainerType
+	if len(doc.Container) > 0 {
+		container = &doc.Container
+	}
 	return constraints.Value{
-		Arch:         doc.Arch,
-		CpuCores:     doc.CpuCores,
-		CpuPower:     doc.CpuPower,
-		Mem:          doc.Mem,
-		RootDisk:     doc.RootDisk,
-		InstanceType: doc.InstanceType,
-		Container:    doc.Container,
-		Tags:         doc.Tags,
-		Spaces:       doc.Spaces,
-		Networks:     doc.Networks,
+		Arch:         stringpIfSet(doc.Arch),
+		CpuCores:     uint64pIfSet(doc.CpuCores),
+		CpuPower:     uint64pIfSet(doc.CpuPower),
+		Mem:          uint64pIfSet(doc.Mem),
+		RootDisk:     uint64pIfSet(doc.RootDisk),
+		InstanceType: stringpIfSet(doc.InstanceType),
+		Container:    container,
+		Tags:         stringslicepIfSet(doc.Tags),
+		Spaces:       stringslicepIfSet(doc.Spaces),
+		Networks:     stringslicepIfSet(doc.Networks),
 	}
 }
 
-func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
-	return constraintsDoc{
-		EnvUUID:      st.EnvironUUID(),
-		Arch:         cons.Arch,
-		CpuCores:     cons.CpuCores,
-		CpuPower:     cons.CpuPower,
-		Mem:          cons.Mem,
-		RootDisk:     cons.RootDisk,
-		InstanceType: cons.InstanceType,
-		Container:    cons.Container,
-		Tags:         cons.Tags,
-		Spaces:       cons.Spaces,
-		Networks:     cons.Networks,
+func uint64pIfSet(v uint64) *uint64 {
+	if v > 0 {
+		return &v
 	}
+	return nil
+}
+
+func stringpIfSet(v string) *string {
+	if len(v) > 0 {
+		return &v
+	}
+	return nil
+}
+
+func stringslicepIfSet(v []string) *[]string {
+	if len(v) > 0 {
+		return &v
+	}
+	return nil
+}
+
+func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
+	doc := constraintsDoc{EnvUUID: st.EnvironUUID()}
+	// Make sure we don't store in state truly empty constraints:
+	//   (*[]string)(nil)
+	//   (*[]string)(&v)  (where v := []string(nil))
+	//   (*[]string)(&w)  (where w := []string{})
+	//   (*string)(nil)
+	//   (*string)(&s)    (where s := "")
+	//   (*uint64)(nil)
+	//   (*uint64)(&u)    (where u := 0)
+	if cons.Arch != nil && len(*cons.Arch) > 0 {
+		doc.Arch = *cons.Arch
+	}
+	if cons.CpuCores != nil && *cons.CpuCores > 0 {
+		doc.CpuCores = *cons.CpuCores
+	}
+	if cons.CpuPower != nil && *cons.CpuPower > 0 {
+		doc.CpuPower = *cons.CpuPower
+	}
+	if cons.Mem != nil && *cons.Mem > 0 {
+		doc.Mem = *cons.Mem
+	}
+	if cons.RootDisk != nil && *cons.RootDisk > 0 {
+		doc.RootDisk = *cons.RootDisk
+	}
+	if cons.InstanceType != nil && len(*cons.InstanceType) > 0 {
+		doc.InstanceType = *cons.InstanceType
+	}
+	if cons.Container != nil && len(*cons.Container) > 0 {
+		doc.Container = *cons.Container
+	}
+	if cons.Tags != nil && len(*cons.Tags) > 0 {
+		doc.Tags = *cons.Tags
+	}
+	if cons.Spaces != nil && len(*cons.Spaces) > 0 {
+		doc.Spaces = *cons.Spaces
+	}
+	if cons.Networks != nil && len(*cons.Networks) > 0 {
+		doc.Networks = *cons.Networks
+	}
+	return doc
 }
 
 func createConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {
@@ -72,12 +123,14 @@ func createConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {
 	}
 }
 
-func setConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {
-	return txn.Op{
-		C:      constraintsC,
-		Id:     st.docID(id),
-		Assert: txn.DocExists,
-		Update: bson.D{{"$set", newConstraintsDoc(st, cons)}},
+func setConstraintsOps(st *State, id string, cons constraints.Value) []txn.Op {
+	// Remove any existing constraints doc before re-creating it. This
+	// way we replace the doc rather than leaving lingering values
+	// from (most likely incorrect) earlier versions, just because
+	// they're not set on cons.
+	return []txn.Op{
+		removeConstraintsOp(st, id),
+		createConstraintsOp(st, id, cons),
 	}
 }
 
@@ -103,7 +156,7 @@ func readConstraints(st *State, id string) (constraints.Value, error) {
 }
 
 func writeConstraints(st *State, id string, cons constraints.Value) error {
-	ops := []txn.Op{setConstraintsOp(st, id, cons)}
+	ops := setConstraintsOps(st, id, cons)
 	if err := st.runTransaction(ops); err != nil {
 		return fmt.Errorf("cannot set constraints: %v", err)
 	}

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -26,7 +26,10 @@ type constraintsDoc struct {
 	InstanceType *string
 	Container    *instance.ContainerType
 	Tags         *[]string `bson:",omitempty"`
-	Networks     *[]string `bson:",omitempty"`
+	Spaces       *[]string `bson:",omitempty"`
+	// TODO(dimitern): Drop this once it's not possible to specify
+	// networks= in constraints.
+	Networks *[]string `bson:",omitempty"`
 }
 
 func (doc constraintsDoc) value() constraints.Value {
@@ -39,6 +42,7 @@ func (doc constraintsDoc) value() constraints.Value {
 		InstanceType: doc.InstanceType,
 		Container:    doc.Container,
 		Tags:         doc.Tags,
+		Spaces:       doc.Spaces,
 		Networks:     doc.Networks,
 	}
 }
@@ -54,6 +58,7 @@ func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
 		InstanceType: cons.InstanceType,
 		Container:    cons.Container,
 		Tags:         cons.Tags,
+		Spaces:       cons.Spaces,
 		Networks:     cons.Networks,
 	}
 }

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -22,7 +22,10 @@ func (s *constraintsValidationSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 	s.policy.GetConstraintsValidator = func(*config.Config) (constraints.Validator, error) {
 		validator := constraints.NewValidator()
-		validator.RegisterConflicts([]string{constraints.InstanceType}, []string{constraints.Mem, constraints.Arch})
+		validator.RegisterConflicts(
+			[]string{constraints.InstanceType},
+			[]string{constraints.Mem, constraints.Arch},
+		)
 		validator.RegisterUnsupported([]string{constraints.CpuPower})
 		return validator, nil
 	}
@@ -37,67 +40,180 @@ func (s *constraintsValidationSuite) addOneMachine(c *gc.C, cons constraints.Val
 }
 
 var setConstraintsTests = []struct {
+	about        string
+	consToSet    string
 	consFallback string
-	cons         string
-	expected     string
+
+	effectiveEnvironCons string // environment constraints after setting consFallback
+	effectiveServiceCons string // service constraints after setting consToSet
+	effectiveUnitCons    string // unit constraints after setting consToSet on the service
+	effectiveMachineCons string // machine constraints after setting consToSet
 }{{
-	cons:         "root-disk=8G mem=4G arch=amd64",
-	consFallback: "cpu-power=1000 cpu-cores=4",
-	expected:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
+	about:        "(implictly) empty constraints are OK and stored as empty",
+	consToSet:    "",
+	consFallback: "",
+
+	effectiveEnvironCons: "",
+	effectiveServiceCons: "",
+	effectiveUnitCons:    "",
+	effectiveMachineCons: "",
 }, {
-	cons:         "root-disk=8G mem=4G arch=amd64",
-	consFallback: "cpu-power=1000 cpu-cores=4 mem=8G",
-	expected:     "root-disk=8G mem=4G arch=amd64 cpu-power=1000 cpu-cores=4",
+	about:        "(implicitly) empty fallback constraints never override set constraints",
+	consToSet:    "instance-type=foo-42 cpu-power=9001 spaces=bar networks=net1,^net2",
+	consFallback: "",
+
+	effectiveEnvironCons: "", // environment constraints are stored as empty.
+	// i.e. there are no fallbacks and all the following cases are the same.
+	effectiveServiceCons: "instance-type=foo-42 cpu-power=9001 spaces=bar networks=net1,^net2",
+	effectiveUnitCons:    "instance-type=foo-42 cpu-power=9001 spaces=bar networks=net1,^net2",
+	effectiveMachineCons: "instance-type=foo-42 cpu-power=9001 spaces=bar networks=net1,^net2",
 }, {
-	consFallback: "root-disk=8G cpu-cores=4 instance-type=foo",
-	expected:     "root-disk=8G cpu-cores=4 instance-type=foo",
+	about:        "(implicitly) empty constraints override set fallbacks except for services",
+	consToSet:    "",
+	consFallback: "arch=amd64 cpu-cores=42 mem=2G tags=foo networks=net1,^net2",
+
+	effectiveEnvironCons: "arch=amd64 cpu-cores=42 mem=2G tags=foo networks=net1,^net2",
+	effectiveServiceCons: "", // set as given and not merged with fallbacks like below
+	effectiveUnitCons:    "arch=amd64 cpu-cores=42 mem=2G tags=foo networks=net1,^net2",
+	// set as given, then merged with fallbacks; since it's empty, it
+	// inherits everything from fallbacks; like the unit, but only
+	// because the service constraints are also empty.
+	effectiveMachineCons: "arch=amd64 cpu-cores=42 mem=2G tags=foo networks=net1,^net2",
 }, {
-	cons:     "root-disk=8G cpu-cores=4 instance-type=foo",
-	expected: "root-disk=8G cpu-cores=4 instance-type=foo",
+	about:        "(explicitly) empty constraints are OK and stored as empty",
+	consToSet:    "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces= networks=",
+	consFallback: "",
+	// cons.MustParse("") != cons.MustParse("mem= arch="), but when we
+	// store them in a state document, they are considered equal and
+	// empty values are never stored or read back as non-empty.
+	// Explicit empty values like "mem=" are only respected when
+	// merging given constraints with environment fallbacks (causing
+	// matching fallback values to be dropped).
+	effectiveEnvironCons: "",
+	effectiveServiceCons: "",
+	effectiveUnitCons:    "",
+	effectiveMachineCons: "",
 }, {
-	consFallback: "root-disk=8G instance-type=foo",
-	cons:         "root-disk=8G cpu-cores=4 instance-type=bar",
-	expected:     "root-disk=8G cpu-cores=4 instance-type=bar",
+	about:        "(explicitly) empty fallback constraints are OK and stored as empty",
+	consToSet:    "",
+	consFallback: "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces= networks=",
+	// same reason as above, however since the environment are only
+	// used as fallbacks there effectively is no difference between
+	// setting "mem=", "mem=0", or omitting it altogether.
+	effectiveEnvironCons: "",
+	effectiveServiceCons: "",
+	effectiveUnitCons:    "",
+	effectiveMachineCons: "",
 }, {
-	consFallback: "root-disk=8G mem=4G",
-	cons:         "root-disk=8G cpu-cores=4 instance-type=bar",
-	expected:     "root-disk=8G cpu-cores=4 instance-type=bar",
+	about:        "(explicitly) empty constraints and fallbacks are OK and stored as empty",
+	consToSet:    "arch= mem= cpu-cores= container=",
+	consFallback: "cpu-cores= cpu-power= root-disk= instance-type= container= tags= spaces= networks=",
+	// even though the explicitly empty values override the fallbacks,
+	// all are empty so result is the same when stored.
+	effectiveEnvironCons: "",
+	effectiveServiceCons: "",
+	effectiveUnitCons:    "",
+	effectiveMachineCons: "",
 }, {
-	consFallback: "root-disk=8G cpu-cores=4 instance-type=bar",
-	cons:         "root-disk=8G mem=4G",
-	expected:     "root-disk=8G cpu-cores=4 mem=4G",
+	about:        "(explicitly) empty constraints override set fallbacks for provisioning",
+	consToSet:    "cpu-cores= arch= spaces= networks= cpu-power=",
+	consFallback: "cpu-cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
+
+	effectiveEnvironCons: "cpu-cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
+	effectiveServiceCons: "", // stored as empty, so units will inherit just the fallbacks
+	effectiveUnitCons:    "cpu-cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
+	// machine constraints have no empty service constraints to inherit here,
+	// so they will override any matching fallbacks (tags, cpu-core, arch, spaces)
+	// with an explicit value (empty or not), while any not set explicitly will be
+	// inherited from then fallbacks only.
+	effectiveMachineCons: "tags=foo mem=4G",
+	// we're also checking if m.SetConstraints() does the same with
+	// regards to the effective constraints as AddMachine(), because
+	// some of these tests proved they had different behavior (i.e.
+	// container= was not set to empty)
 }, {
-	consFallback: "root-disk=8G cpu-cores=4 instance-type=bar",
-	cons:         "root-disk=8G arch=amd64 mem=4G",
-	expected:     "root-disk=8G cpu-cores=4 arch=amd64 mem=4G",
+	about:        "non-empty constraints always override empty or unset fallbacks",
+	consToSet:    "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar networks=^dmz,db",
+	consFallback: "cpu-cores= arch= tags=",
+
+	effectiveEnvironCons: "", // like the other cases when environ constraints end up empty.
+	effectiveServiceCons: "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar networks=^dmz,db",
+	effectiveUnitCons:    "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar networks=^dmz,db",
+	effectiveMachineCons: "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar networks=^dmz,db",
 }, {
-	consFallback: "cpu-cores=4 mem=4G networks=net1,^net3",
-	cons:         "networks=net2,^net4 mem=4G",
-	expected:     "cpu-cores=4 mem=4G networks=net2,^net4",
+	about:        "non-empty constraints always override set fallbacks",
+	consToSet:    "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar networks=^dmz,db",
+	consFallback: "cpu-cores=12 root-disk=10G arch=i386  tags=bar networks=net1,^net2",
+
+	effectiveEnvironCons: "cpu-cores=12 root-disk=10G arch=i386  tags=bar networks=net1,^net2",
+	effectiveServiceCons: "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar networks=^dmz,db",
+	effectiveUnitCons:    "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar networks=^dmz,db",
+	effectiveMachineCons: "cpu-cores=42 root-disk=20G arch=amd64 tags=foo,bar networks=^dmz,db",
 }, {
-	consFallback: "cpu-cores=4 mem=2G networks=",
-	cons:         "mem=4G networks=net1,^net3",
-	expected:     "cpu-cores=4 mem=4G networks=net1,^net3",
+	about:        "non-empty constraints override conflicting set fallbacks",
+	consToSet:    "mem=8G arch=amd64 cpu-cores=4 tags=bar",
+	consFallback: "instance-type=small cpu-power=1000", // instance-type conflicts mem, arch
+
+	effectiveEnvironCons: "instance-type=small cpu-power=1000",
+	effectiveServiceCons: "mem=8G arch=amd64 cpu-cores=4 tags=bar",
+	// both of the following contain the explicitly set constraints after
+	// resolving any conflicts with fallbacks (by dropping them).
+	effectiveUnitCons:    "mem=8G arch=amd64 cpu-cores=4 tags=bar cpu-power=1000",
+	effectiveMachineCons: "mem=8G arch=amd64 cpu-cores=4 tags=bar cpu-power=1000",
 }, {
-	consFallback: "cpu-cores=4 mem=4G spaces=space1,^space3",
-	cons:         "spaces=space2,^space4 mem=4G",
-	expected:     "cpu-cores=4 mem=4G spaces=space2,^space4",
+	about:        "set fallbacks are overriden differently for provisioning and deployment",
+	consToSet:    "networks= tags= cpu-power= spaces=bar",
+	consFallback: "networks=net1,^net3 tags=foo cpu-power=42",
+	// a variation of the above case showing the difference between
+	// deployment (service, unit) and provisioning (machine) constraints.
+	effectiveEnvironCons: "networks=net1,^net3 tags=foo cpu-power=42",
+	effectiveServiceCons: "spaces=bar", // set as given, empty values are dropped
+	// unit constraints are the effective service constraints from above,
+	// merged with the fallbacks, overriding them.
+	effectiveUnitCons: "networks=net1,^net3 tags=foo cpu-power=42 spaces=bar",
+	// machine provisioning constraints as set as given (before ignoring
+	// explicitly unset values) and then merged with fallbacks, overriding
+	// them for all matching explicit values.
+	effectiveMachineCons: "spaces=bar",
 }, {
-	consFallback: "cpu-cores=4 mem=2G spaces=",
-	cons:         "mem=4G spaces=space1,^space3",
-	expected:     "cpu-cores=4 mem=4G spaces=space1,^space3",
+	about:        "container type can only be used for deployment, not provisioning",
+	consToSet:    "container=kvm arch=amd64",
+	consFallback: "container=lxc mem=8G",
+	// service deployment constraints are transformed into machine
+	// provisioning constraints, and the container type only makes
+	// sense currently as a deployment constraint, it's cleared when
+	// merging service/environment deployment constraints into
+	// effective machine provisioning constraints.
+	effectiveEnvironCons: "container=lxc mem=8G",
+	effectiveServiceCons: "container=kvm arch=amd64",
+	effectiveUnitCons:    "container=kvm mem=8G arch=amd64",
+	effectiveMachineCons: "mem=8G arch=amd64",
 }}
 
 func (s *constraintsValidationSuite) TestMachineConstraints(c *gc.C) {
 	for i, t := range setConstraintsTests {
-		c.Logf("test %d: fallback: %q, cons: %q", i, t.consFallback, t.cons)
+		c.Logf(
+			"test %d: %s\nconsToSet: %q\nconsFallback: %q\n",
+			i, t.about, t.consToSet, t.consFallback,
+		)
+		// Set fallbacks as environment constraints and verify them.
 		err := s.State.SetEnvironConstraints(constraints.MustParse(t.consFallback))
 		c.Check(err, jc.ErrorIsNil)
-		m, err := s.addOneMachine(c, constraints.MustParse(t.cons))
+		econs, err := s.State.EnvironConstraints()
+		c.Check(econs, jc.DeepEquals, constraints.MustParse(t.effectiveEnvironCons))
+		// Set the machine provisioning constraints.
+		m, err := s.addOneMachine(c, constraints.MustParse(t.consToSet))
 		c.Check(err, jc.ErrorIsNil)
+		// New machine provisioning constraints get merged with the fallbacks.
 		cons, err := m.Constraints()
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(cons, jc.DeepEquals, constraints.MustParse(t.expected))
+		c.Check(cons, jc.DeepEquals, constraints.MustParse(t.effectiveMachineCons))
+		// Changing them should result in the same result before provisioning.
+		err = m.SetConstraints(constraints.MustParse(t.consToSet))
+		c.Check(err, jc.ErrorIsNil)
+		cons, err = m.Constraints()
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(cons, jc.DeepEquals, constraints.MustParse(t.effectiveMachineCons))
 	}
 }
 
@@ -105,15 +221,27 @@ func (s *constraintsValidationSuite) TestServiceConstraints(c *gc.C) {
 	charm := s.AddTestingCharm(c, "wordpress")
 	service := s.AddTestingService(c, "wordpress", charm)
 	for i, t := range setConstraintsTests {
-		c.Logf("test %d: fallback: %q, cons: %q", i, t.consFallback, t.cons)
+		c.Logf(
+			"test %d: %s\nconsToSet: %q\nconsFallback: %q\n",
+			i, t.about, t.consToSet, t.consFallback,
+		)
+		// Set fallbacks as environment constraints and verify them.
 		err := s.State.SetEnvironConstraints(constraints.MustParse(t.consFallback))
 		c.Check(err, jc.ErrorIsNil)
-		err = service.SetConstraints(constraints.MustParse(t.cons))
+		econs, err := s.State.EnvironConstraints()
+		c.Check(econs, jc.DeepEquals, constraints.MustParse(t.effectiveEnvironCons))
+		// Set the service deployment constraints.
+		err = service.SetConstraints(constraints.MustParse(t.consToSet))
 		c.Check(err, jc.ErrorIsNil)
 		u, err := service.AddUnit()
 		c.Check(err, jc.ErrorIsNil)
+		// New unit deployment constraints get merged with the fallbacks.
 		ucons, err := u.Constraints()
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(*ucons, jc.DeepEquals, constraints.MustParse(t.expected))
+		c.Check(*ucons, jc.DeepEquals, constraints.MustParse(t.effectiveUnitCons))
+		// Service constraints remain as set.
+		scons, err := service.Constraints()
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(scons, jc.DeepEquals, constraints.MustParse(t.effectiveServiceCons))
 	}
 }

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -78,6 +78,14 @@ var setConstraintsTests = []struct {
 	consFallback: "cpu-cores=4 mem=2G networks=",
 	cons:         "mem=4G networks=net1,^net3",
 	expected:     "cpu-cores=4 mem=4G networks=net1,^net3",
+}, {
+	consFallback: "cpu-cores=4 mem=4G spaces=space1,^space3",
+	cons:         "spaces=space2,^space4 mem=4G",
+	expected:     "cpu-cores=4 mem=4G spaces=space2,^space4",
+}, {
+	consFallback: "cpu-cores=4 mem=2G spaces=",
+	cons:         "mem=4G spaces=space1,^space3",
+	expected:     "cpu-cores=4 mem=4G spaces=space1,^space3",
 }}
 
 func (s *constraintsValidationSuite) TestMachineConstraints(c *gc.C) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -1261,6 +1261,9 @@ func (m *Machine) setAddresses(addresses []network.Address, field *[]address, fi
 // RequestedNetworks returns the list of network names the machine
 // should be on. Unlike networks specified with constraints, these
 // networks are required to be present on the machine.
+//
+// TODO(dimitern): Drop this when we can use space bindings derived
+// from constraints.
 func (m *Machine) RequestedNetworks() ([]string, error) {
 	return readRequestedNetworks(m.st, m.globalKey())
 }

--- a/state/service.go
+++ b/state/service.go
@@ -745,7 +745,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		if err != nil {
 			return "", nil, err
 		}
-		ops = append(ops, createConstraintsOp(s.st, agentGlobalKey, cons))
+		ops = append(ops, setConstraintsOps(s.st, agentGlobalKey, cons)...)
 	}
 	return name, ops, nil
 }
@@ -987,14 +987,12 @@ func (s *Service) SetConstraints(cons constraints.Value) (err error) {
 	if s.doc.Life != Alive {
 		return errNotAlive
 	}
-	ops := []txn.Op{
-		{
-			C:      servicesC,
-			Id:     s.doc.DocID,
-			Assert: isAliveDoc,
-		},
-		setConstraintsOp(s.st, s.globalKey(), cons),
-	}
+	ops := []txn.Op{{
+		C:      servicesC,
+		Id:     s.doc.DocID,
+		Assert: isAliveDoc,
+	}}
+	ops = append(ops, setConstraintsOps(s.st, s.globalKey(), cons)...)
 	return onAbort(s.st.runTransaction(ops), errNotAlive)
 }
 

--- a/state/service.go
+++ b/state/service.go
@@ -1001,6 +1001,9 @@ func (s *Service) SetConstraints(cons constraints.Value) (err error) {
 // Networks returns the networks a service is associated with. Unlike
 // networks specified with constraints, these networks are required to
 // be present on machines hosting this service's units.
+//
+// TODO(dimitern): Convert this to use spaces from constraints or drop
+// it entirely.
 func (s *Service) Networks() ([]string, error) {
 	return readRequestedNetworks(s.st, s.globalKey())
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -895,17 +895,18 @@ func (s *upgradesSuite) TestAddEnvUUIDToConstraints(c *gc.C) {
 			},
 		},
 		true)
-	// The test expects three records because there is a preexisting environment constraints doc in mongo.
+	// The test expects three records because there is a preexisting
+	// environment constraints doc in mongo.
 	c.Assert(count, gc.Equals, 3)
 
 	var newDoc constraintsDoc
 	s.FindId(c, coll, newIDs[0], &newDoc)
-	c.Assert(*newDoc.CpuCores, gc.Equals, uint64(4))
-	c.Assert(*newDoc.Networks, gc.DeepEquals, networks1)
+	c.Assert(newDoc.CpuCores, gc.Equals, uint64(4))
+	c.Assert(newDoc.Networks, jc.DeepEquals, networks1)
 
 	s.FindId(c, coll, newIDs[1], &newDoc)
-	c.Assert(*newDoc.CpuCores, gc.Equals, uint64(8))
-	c.Assert(*newDoc.Networks, gc.DeepEquals, networks2)
+	c.Assert(newDoc.CpuCores, gc.Equals, uint64(8))
+	c.Assert(newDoc.Networks, jc.DeepEquals, networks2)
 }
 
 func (s *upgradesSuite) TestAddEnvUUIDToConstraintsIdempotent(c *gc.C) {


### PR DESCRIPTION
This is an expansion of #2996, which just introduced support for
specifying a list of positive and negative space names in --constraints
with e.g. "spaces=positive1,^negative2,foo,bar,^baz". Negatives have "^"
as prefix, like tags= and (soon to be gone) networks=.

tl;dr; While testing it I've discovered a number of issues with our
constraints handling in state and fixed them.

I took the opportunity to expand the test coverage and document the
behavior around setting deployment and provisioning constraints and
their environment fallbacks. In brief:

 * machine.SetConstraints() behaved differently than state.AddMachine()
   and its relatives, which clear the container= constraint when
   resolving machine provisioning constraints using service deployment
   constraints and environment fallbacks.
 * setConstraintsOp() was not behaving correctly in a few cases,
   omitting values considered empty and thus leaving stale data in
   place, while making it *impossible* to unset any value of type
   `*[]string` once set (e.g. Tags, Networks, and now Spaces). This was
   fixed by making sure we always replace the constraints doc when we
   set it, and we never store or fetch empty values in state. Values are
   considered empty if they pass the double nil check: `v != nil &&
   isZero(*v)`, i.e. having a zero value for its type (slice pointers
   were especially affected - non-nil pointer to an empty slice).
 * fixed a few places where incorrect assumptions were made about how
   constraints work (i.e. relied on the buggy behavior), so while adding
   more tests I also added some comments describing how the constraints
   resolution works and why.

Tested multiple times with both -race and -cover and without.

(Review request: http://reviews.vapour.ws/r/2406/)