### PR TITLE
mongo: EnsureServer now always write out mongodb related config files

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -199,6 +199,29 @@ func EnsureServer(args EnsureServerParams) error {
 	}
 	logVersion(mongoPath)
 
+	if err := UpdateSSLKey(args.DataDir, args.Cert, args.PrivateKey); err != nil {
+		return err
+	}
+
+	err = utils.AtomicWriteFile(sharedSecretPath(args.DataDir), []byte(args.SharedSecret), 0600)
+	if err != nil {
+		return fmt.Errorf("cannot write mongod shared secret: %v", err)
+	}
+
+	// Disable the default mongodb installed by the mongodb-server package.
+	// Only do this if the file doesn't exist already, so users can run
+	// their own mongodb server if they wish to.
+	if _, err := os.Stat(mongoConfigPath); os.IsNotExist(err) {
+		err = utils.AtomicWriteFile(
+			mongoConfigPath,
+			[]byte("ENABLE_MONGODB=no"),
+			0644,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	svcConf := newConf(args.DataDir, dbDir, mongoPath, args.StatePort, oplogSizeMB, args.SetNumaControlPolicy)
 	svc, err := newService(ServiceName(args.Namespace), svcConf)
 	if err != nil {
@@ -223,29 +246,6 @@ func EnsureServer(args EnsureServerParams) error {
 				return svc.Start()
 			}
 			return nil
-		}
-	}
-
-	if err := UpdateSSLKey(args.DataDir, args.Cert, args.PrivateKey); err != nil {
-		return err
-	}
-
-	err = utils.AtomicWriteFile(sharedSecretPath(args.DataDir), []byte(args.SharedSecret), 0600)
-	if err != nil {
-		return fmt.Errorf("cannot write mongod shared secret: %v", err)
-	}
-
-	// Disable the default mongodb installed by the mongodb-server package.
-	// Only do this if the file doesn't exist already, so users can run
-	// their own mongodb server if they wish to.
-	if _, err := os.Stat(mongoConfigPath); os.IsNotExist(err) {
-		err = utils.AtomicWriteFile(
-			mongoConfigPath,
-			[]byte("ENABLE_MONGODB=no"),
-			0644,
-		)
-		if err != nil {
-			return err
 		}
 	}
 


### PR DESCRIPTION
We had seen reports of the mongod init system config being in place but the shared secret file not being there. Although it is not understood exactly how this happens, ensuring that the shared secret file, SSL key file and monogdb config file are all in place irrespective of the init system config is more robust and should fix the reported problem.

Fixes LP #1468579.

http://reviews.vapour.ws/r/2407/