### PR TITLE
mongo: EnsureServer now always write out mongodb related config files

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -199,6 +199,29 @@ func EnsureServer(args EnsureServerParams) error {
 	}
 	logVersion(mongoPath)
 
+	if err := UpdateSSLKey(args.DataDir, args.Cert, args.PrivateKey); err != nil {
+		return err
+	}
+
+	err = utils.AtomicWriteFile(sharedSecretPath(args.DataDir), []byte(args.SharedSecret), 0600)
+	if err != nil {
+		return fmt.Errorf("cannot write mongod shared secret: %v", err)
+	}
+
+	// Disable the default mongodb installed by the mongodb-server package.
+	// Only do this if the file doesn't exist already, so users can run
+	// their own mongodb server if they wish to.
+	if _, err := os.Stat(mongoConfigPath); os.IsNotExist(err) {
+		err = utils.AtomicWriteFile(
+			mongoConfigPath,
+			[]byte("ENABLE_MONGODB=no"),
+			0644,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	svcConf := newConf(args.DataDir, dbDir, mongoPath, args.StatePort, oplogSizeMB, args.SetNumaControlPolicy)
 	svc, err := newService(ServiceName(args.Namespace), svcConf)
 	if err != nil {
@@ -223,29 +246,6 @@ func EnsureServer(args EnsureServerParams) error {
 				return svc.Start()
 			}
 			return nil
-		}
-	}
-
-	if err := UpdateSSLKey(args.DataDir, args.Cert, args.PrivateKey); err != nil {
-		return err
-	}
-
-	err = utils.AtomicWriteFile(sharedSecretPath(args.DataDir), []byte(args.SharedSecret), 0600)
-	if err != nil {
-		return fmt.Errorf("cannot write mongod shared secret: %v", err)
-	}
-
-	// Disable the default mongodb installed by the mongodb-server package.
-	// Only do this if the file doesn't exist already, so users can run
-	// their own mongodb server if they wish to.
-	if _, err := os.Stat(mongoConfigPath); os.IsNotExist(err) {
-		err = utils.AtomicWriteFile(
-			mongoConfigPath,
-			[]byte("ENABLE_MONGODB=no"),
-			0644,
-		)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -136,20 +136,30 @@ func testJournalDirs(dir string, c *gc.C) {
 	c.Assert(info.Size(), gc.Equals, size)
 }
 
-func (s *MongoSuite) TestEnsureServer(c *gc.C) {
-	dataDir := s.testEnsureServerNumaCtl(c, false)
+func (s *MongoSuite) assertSSLKeyFile(c *gc.C, dataDir string) {
+	contents, err := ioutil.ReadFile(mongo.SSLKeyPath(dataDir))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(contents), gc.Equals, testInfo.Cert+"\n"+testInfo.PrivateKey)
+}
 
+func (s *MongoSuite) assertSharedSecretFile(c *gc.C, dataDir string) {
+	contents, err := ioutil.ReadFile(mongo.SharedSecretPath(dataDir))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(contents), gc.Equals, testInfo.SharedSecret)
+}
+
+func (s *MongoSuite) assertMongoConfigFile(c *gc.C) {
 	contents, err := ioutil.ReadFile(s.mongodConfigPath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(contents, jc.DeepEquals, []byte("ENABLE_MONGODB=no"))
+}
 
-	contents, err = ioutil.ReadFile(mongo.SSLKeyPath(dataDir))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(contents), gc.Equals, testInfo.Cert+"\n"+testInfo.PrivateKey)
+func (s *MongoSuite) TestEnsureServer(c *gc.C) {
+	dataDir := s.testEnsureServerNumaCtl(c, false)
 
-	contents, err = ioutil.ReadFile(mongo.SharedSecretPath(dataDir))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(contents), gc.Equals, testInfo.SharedSecret)
+	s.assertSSLKeyFile(c, dataDir)
+	s.assertSharedSecretFile(c, dataDir)
+	s.assertMongoConfigFile(c)
 
 	// make sure that we log the version of mongodb as we get ready to
 	// start it
@@ -172,6 +182,11 @@ func (s *MongoSuite) TestEnsureServerServerExistsAndRunning(c *gc.C) {
 	err := mongo.EnsureServer(makeEnsureServerParams(dataDir, namespace))
 	c.Assert(err, jc.ErrorIsNil)
 
+	// These should still be written out even if the service was installed.
+	s.assertSSLKeyFile(c, dataDir)
+	s.assertSharedSecretFile(c, dataDir)
+	s.assertMongoConfigFile(c)
+
 	c.Check(s.data.Installed(), gc.HasLen, 0)
 	s.data.CheckCallNames(c, "Installed", "Exists", "Running")
 }
@@ -186,6 +201,11 @@ func (s *MongoSuite) TestEnsureServerServerExistsNotRunningIsStarted(c *gc.C) {
 
 	err := mongo.EnsureServer(makeEnsureServerParams(dataDir, namespace))
 	c.Assert(err, jc.ErrorIsNil)
+
+	// These should still be written out even if the service was installed.
+	s.assertSSLKeyFile(c, dataDir)
+	s.assertSharedSecretFile(c, dataDir)
+	s.assertMongoConfigFile(c)
 
 	c.Check(s.data.Installed(), gc.HasLen, 0)
 	s.data.CheckCallNames(c, "Installed", "Exists", "Running", "Start")


### PR DESCRIPTION
We had seen reports of the mongod init system config being in place but the shared secret file not being there. Although it is not understood exactly how this happens, ensuring that the shared secret file, SSL key file and monogdb config file are all in place irrespective of the init system config is more robust and should fix the reported problem.

Fixes LP #1468579.

(Review request: http://reviews.vapour.ws/r/2410/)