### PR TITLE
dependency/engine: Added a Reporter interface with Manifolds and engines

### DIFF
--- a/worker/dependency/interface.go
+++ b/worker/dependency/interface.go
@@ -20,6 +20,8 @@ type Engine interface {
 
 	// Engine is just another Worker.
 	worker.Worker
+
+	Reporter
 }
 
 // Manifold defines the behaviour of a node in an Engine's dependency graph. It's

--- a/worker/dependency/reporter.go
+++ b/worker/dependency/reporter.go
@@ -1,0 +1,13 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency
+
+// Reporter defines an interface that can be used to get reports
+// from types that implement this interface.
+// A report is just a map of values that might be of interest.
+// The primary use case is status reports.
+// Reporter implementations are expected to be go routine safe.
+type Reporter interface {
+	Report() map[string]interface{}
+}

--- a/worker/dependency/reporter_test.go
+++ b/worker/dependency/reporter_test.go
@@ -1,0 +1,64 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+func (s *EngineSuite) TestReport(c *gc.C) {
+	report := s.engine.Report()
+	c.Assert(report, jc.DeepEquals, map[string]interface{}{
+		"is-dying":       false,
+		"manifold-count": 0,
+		"workers":        map[string]interface{}{},
+	})
+}
+
+func (s *EngineSuite) TestShuttingDownEngineReport(c *gc.C) {
+	s.engine.Kill()
+	s.engine.Wait()
+	report := s.engine.Report()
+	c.Assert(report, jc.DeepEquals, map[string]interface{}{
+		"error": "engine is shutting down",
+	})
+}
+
+func (s *EngineSuite) TestReportReachesManifolds(c *gc.C) {
+	mh1 := newManifoldHarness()
+	manifold := mh1.Manifold()
+	err := s.engine.Install("task", manifold)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mh2 := newManifoldHarness()
+	err = s.engine.Install("another task", mh2.Manifold())
+	c.Assert(err, jc.ErrorIsNil)
+
+	mh1.AssertStart(c)
+	mh2.AssertStart(c)
+
+	report := s.engine.Report()
+	expectedReport := map[string]interface{}{
+		"is-dying":       false,
+		"manifold-count": 2,
+		"workers": map[string]interface{}{
+			"task": map[string]interface{}{
+				"starting": false,
+				"stopping": false,
+				"report": map[string]interface{}{
+					"key1": "hello there",
+				},
+			},
+			"another task": map[string]interface{}{
+				"starting": false,
+				"stopping": false,
+				"report": map[string]interface{}{
+					"key1": "hello there",
+				},
+			},
+		},
+	}
+	c.Assert(report, jc.DeepEquals, expectedReport)
+}

--- a/worker/dependency/util_test.go
+++ b/worker/dependency/util_test.go
@@ -117,6 +117,12 @@ func (w *minimalWorker) Wait() error {
 	return w.tomb.Wait()
 }
 
+func (w *minimalWorker) Report() map[string]interface{} {
+	return map[string]interface{}{
+		"key1": "hello there",
+	}
+}
+
 func startMinimalWorker(_ dependency.GetResourceFunc) (worker.Worker, error) {
 	w := &minimalWorker{}
 	go func() {


### PR DESCRIPTION
use to feedback status information about themselves.

(Review request: http://reviews.vapour.ws/r/2415/)