### PR TITLE
API endpoint for retrieving bundle changes.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -611,6 +611,16 @@ func (c *Client) DestroyEnvironment() error {
 	return c.facade.FacadeCall("DestroyEnvironment", nil, nil)
 }
 
+// GetBundleChanges returns the list of changes required to deploy the given
+// bundle data. The changes are sorted by requirements, so that they can be
+// applied in order.
+func (c *Client) GetBundleChanges(yaml string) (*params.GetBundleChangesResults, error) {
+	var results params.GetBundleChangesResults
+	args := params.GetBundleChanges{YAML: yaml}
+	err := c.facade.FacadeCall("GetBundleChanges", args, &results)
+	return &results, err
+}
+
 // AddLocalCharm prepares the given charm with a local: schema in its
 // URL, and uploads it via the API server, returning the assigned
 // charm URL. If the API server does not support charm uploads, an

--- a/apiserver/client/bundles.go
+++ b/apiserver/client/bundles.go
@@ -16,9 +16,9 @@ import (
 // GetBundleChanges returns the list of changes required to deploy the given
 // bundle data. The changes are sorted by requirements, so that they can be
 // applied in order.
-func (c *Client) GetBundleChanges(args params.GetBundleChanges) (params.GetBundleChangesResults, error) {
+func (c *Client) GetBundleChanges(args params.GetBundleChangesParams) (params.GetBundleChangesResults, error) {
 	var results params.GetBundleChangesResults
-	data, err := charm.ReadBundleData(strings.NewReader(args.YAML))
+	data, err := charm.ReadBundleData(strings.NewReader(args.BundleDataYAML))
 	if err != nil {
 		return results, errors.Annotate(err, "cannot read bundle YAML")
 	}
@@ -34,6 +34,15 @@ func (c *Client) GetBundleChanges(args params.GetBundleChanges) (params.GetBundl
 		// This should never happen as Verify only returns verification errors.
 		return results, errors.Annotate(err, "cannot verify bundle")
 	}
-	results.Changes = bundlechanges.FromData(data)
+	changes := bundlechanges.FromData(data)
+	results.Changes = make([]*params.BundleChangesChange, len(changes))
+	for i, c := range changes {
+		results.Changes[i] = &params.BundleChangesChange{
+			Id:       c.Id,
+			Method:   c.Method,
+			Args:     c.Args,
+			Requires: c.Requires,
+		}
+	}
 	return results, nil
 }

--- a/apiserver/client/bundles.go
+++ b/apiserver/client/bundles.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client
+
+import (
+	"strings"
+
+	"github.com/juju/bundlechanges"
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+// GetBundleChanges returns the list of changes required to deploy the given
+// bundle data. The changes are sorted by requirements, so that they can be
+// applied in order.
+func (c *Client) GetBundleChanges(args params.GetBundleChanges) (params.GetBundleChangesResults, error) {
+	var results params.GetBundleChangesResults
+	data, err := charm.ReadBundleData(strings.NewReader(args.YAML))
+	if err != nil {
+		return results, errors.Annotate(err, "cannot read bundle YAML")
+	}
+	// TODO frankban: provide a verifyConstraints function.
+	if err := data.Verify(nil); err != nil {
+		if err, ok := err.(*charm.VerificationError); ok {
+			results.Errors = make([]string, len(err.Errors))
+			for i, e := range err.Errors {
+				results.Errors[i] = e.Error()
+			}
+			return results, nil
+		}
+		// This should never happen as Verify only returns verification errors.
+		return results, errors.Annotate(err, "cannot verify bundle")
+	}
+	results.Changes = bundlechanges.FromData(data)
+	return results, nil
+}

--- a/apiserver/client/bundles_test.go
+++ b/apiserver/client/bundles_test.go
@@ -1,0 +1,87 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client_test
+
+import (
+	"github.com/juju/bundlechanges"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+type bundlesSuite struct {
+	baseSuite
+}
+
+var _ = gc.Suite(&bundlesSuite{})
+
+func (s *bundlesSuite) TestGetBundleChangesBundleContentError(c *gc.C) {
+	_, err := s.APIState.Client().GetBundleChanges(":")
+	c.Assert(err, gc.ErrorMatches, `cannot read bundle YAML: cannot unmarshal bundle data: YAML error: did not find expected key`)
+}
+
+func (s *bundlesSuite) TestGetBundleChangesBundleVerificationErrors(c *gc.C) {
+	yaml := `
+        services:
+            django:
+                charm: django
+                to: [1]
+            haproxy:
+                charm: 42
+                num_units: -1
+    `
+	r, err := s.APIState.Client().GetBundleChanges(yaml)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Changes, gc.IsNil)
+	c.Assert(r.Errors, jc.SameContents, []string{
+		`placement "1" refers to a machine not defined in this bundle`,
+		`too many units specified in unit placement for service "django"`,
+		`invalid charm URL in service "haproxy": charm URL has invalid charm name: "42"`,
+		`negative number of units specified on service "haproxy"`,
+	})
+}
+
+func (s *bundlesSuite) TestGetBundleChangesSuccess(c *gc.C) {
+	yaml := `
+        services:
+            django:
+                charm: django
+                options:
+                    debug: true
+            haproxy:
+                charm: cs:trusty/haproxy-42
+        relations:
+            - - django:web
+              - haproxy:web
+    `
+	r, err := s.APIState.Client().GetBundleChanges(yaml)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r, jc.DeepEquals, &params.GetBundleChangesResults{
+		Changes: []*bundlechanges.Change{{
+			Id:     "addCharm-0",
+			Method: "addCharm",
+			Args:   []interface{}{"django"},
+		}, {
+			Id:       "addService-1",
+			Method:   "deploy",
+			Args:     []interface{}{"django", "django", map[string]interface{}{"debug": true}},
+			Requires: []string{"addCharm-0"},
+		}, {
+			Id:     "addCharm-2",
+			Method: "addCharm",
+			Args:   []interface{}{"cs:trusty/haproxy-42"},
+		}, {
+			Id:       "addService-3",
+			Method:   "deploy",
+			Args:     []interface{}{"cs:trusty/haproxy-42", "haproxy", map[string]interface{}{}},
+			Requires: []string{"addCharm-2"},
+		}, {
+			Id:       "addRelation-4",
+			Method:   "addRelation",
+			Args:     []interface{}{"$addService-1:web", "$addService-3:web"},
+			Requires: []string{"addService-1", "addService-3"},
+		}},
+	})
+}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/bundlechanges"
 	"github.com/juju/errors"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v5"
@@ -744,17 +743,32 @@ type RebootActionResult struct {
 	Error  *Error       `json:"error,omitempty"`
 }
 
-// GetBundleChanges holds parameters for making the GetBundleChanges call.
-type GetBundleChanges struct {
-	// YAML holds the bundle YAML encoded content.
-	YAML string
+// GetBundleChangesParams holds parameters for making GetBundleChanges calls.
+type GetBundleChangesParams struct {
+	// BundleDataYAML is the YAML-encoded charm bundle data
+	// (see "github.com/juju/charm.BundleData").
+	BundleDataYAML string `json:"yaml"`
 }
 
 // GetBundleChangesResults holds results of the GetBundleChanges call.
 type GetBundleChangesResults struct {
 	// Changes holds the list of changes required to deploy the bundle.
 	// It is omitted if the provided bundle YAML has verification errors.
-	Changes []*bundlechanges.Change `json:"changes,omitempty"`
+	Changes []*BundleChangesChange `json:"changes,omitempty"`
 	// Errors holds possible bundle verification errors.
 	Errors []string `json:"errors,omitempty"`
+}
+
+// BundleChangesChange holds a single change required to deploy a bundle.
+type BundleChangesChange struct {
+	// Id is the unique identifier for this change.
+	Id string `json:"id"`
+	// Method is the action to be performed to apply this change.
+	Method string `json:"method"`
+	// Args holds a list of arguments to pass to the method.
+	Args []interface{} `json:"args"`
+	// Requires holds a list of dependencies for this change. Each dependency
+	// is represented by the corresponding change id, and must be applied
+	// before this change is applied.
+	Requires []string `json:"requires"`
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/bundlechanges"
 	"github.com/juju/errors"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v5"
@@ -741,4 +742,19 @@ type RebootActionResults struct {
 type RebootActionResult struct {
 	Result RebootAction `json:"result,omitempty"`
 	Error  *Error       `json:"error,omitempty"`
+}
+
+// GetBundleChanges holds parameters for making the GetBundleChanges call.
+type GetBundleChanges struct {
+	// YAML holds the bundle YAML encoded content.
+	YAML string
+}
+
+// GetBundleChangesResults holds results of the GetBundleChanges call.
+type GetBundleChangesResults struct {
+	// Changes holds the list of changes required to deploy the bundle.
+	// It is omitted if the provided bundle YAML has verification errors.
+	Changes []*bundlechanges.Change `json:"changes,omitempty"`
+	// Errors holds possible bundle verification errors.
+	Errors []string `json:"errors,omitempty"`
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,6 +10,7 @@ github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-2
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
+github.com/juju/bundlechanges	git	7f668162977d93f65b6bbbe3df8f02929d260ff2	2015-08-19T09:30:45Z
 github.com/juju/cmd	git	a7964f7cbac96484d1a9ba25e37bd32b7fa3cd90	2015-06-12T00:20:39Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z


### PR DESCRIPTION
Implement the GetBundleChanges API endpoint on the Client.
This is used to generate end return the list of changes
required to deploy a bundle (from the GUI perspective),
given a bundle YAML content.

(Review request: http://reviews.vapour.ws/r/2416/)