### PR TITLE
Addresser cleaner startup

### DIFF
--- a/api/addresser/addresser.go
+++ b/api/addresser/addresser.go
@@ -31,6 +31,19 @@ func NewAPI(caller base.APICaller) *API {
 	}
 }
 
+// CanDeallocateAddresses checks if the current environment can
+// deallocate IP addresses.
+func (api *API) CanDeallocateAddresses() (bool, error) {
+	var result params.BoolResult
+	if err := api.facade.FacadeCall("CanDeallocateAddresses", nil, &result); err != nil {
+		return false, errors.Trace(err)
+	}
+	if result.Error == nil {
+		return result.Result, nil
+	}
+	return false, errors.Trace(result.Error)
+}
+
 // CleanupIPAddresses releases and removes the dead IP addresses. If not
 // all IP addresses could be released and removed a params.ErrTryAgain
 // is returned.

--- a/api/addresser/addresser_test.go
+++ b/api/addresser/addresser_test.go
@@ -42,6 +42,34 @@ func (s *AddresserSuite) TestNewAPIWithNilCaller(c *gc.C) {
 	c.Assert(panicFunc, gc.PanicMatches, "caller is nil")
 }
 
+func (s *AddresserSuite) TestCanDeallocateAddressesSuccess(c *gc.C) {
+	var called int
+	expectedResult := params.BoolResult{
+		Result: true,
+	}
+	apiCaller := successAPICaller(c, "CanDeallocateAddresses", nil, expectedResult, &called)
+	api := addresser.NewAPI(apiCaller)
+
+	ok, err := api.CanDeallocateAddresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(called, gc.Equals, 1)
+}
+
+func (s *AddresserSuite) TestCanDeallocateAddressesServerError(c *gc.C) {
+	var called int
+	expectedResult := params.BoolResult{
+		Error: apiservertesting.ServerError("server boom!"),
+	}
+	apiCaller := successAPICaller(c, "CanDeallocateAddresses", nil, expectedResult, &called)
+	api := addresser.NewAPI(apiCaller)
+
+	ok, err := api.CanDeallocateAddresses()
+	c.Assert(err, gc.ErrorMatches, "server boom!")
+	c.Assert(ok, jc.IsFalse)
+	c.Assert(called, gc.Equals, 1)
+}
+
 func (s *AddresserSuite) TestCleanupIPAddressesSuccess(c *gc.C) {
 	var called int
 	expectedResult := params.ErrorResult{}

--- a/apiserver/addresser/addresser.go
+++ b/apiserver/addresser/addresser.go
@@ -79,6 +79,10 @@ func (api *AddresserAPI) CanDeallocateAddresses() params.BoolResult {
 		result.Error = common.ServerError(err)
 		return result
 	}
+	if !api.canDeallocate {
+		result.Error = common.ServerError(errors.NotSupportedf("IP address deallocation"))
+		return result
+	}
 	result.Result = api.canDeallocate
 	return result
 }

--- a/apiserver/addresser/addresser.go
+++ b/apiserver/addresser/addresser.go
@@ -24,9 +24,9 @@ var logger = loggo.GetLogger("juju.apiserver.addresser")
 
 // AddresserAPI provides access to the Addresser API facade.
 type AddresserAPI struct {
-	st            StateInterface
-	resources     *common.Resources
-	authorizer    common.Authorizer
+	st         StateInterface
+	resources  *common.Resources
+	authorizer common.Authorizer
 }
 
 // NewAddresserAPI creates a new server-side Addresser API facade.
@@ -64,10 +64,8 @@ func (api *AddresserAPI) getNetworingEnviron() (environs.NetworkingEnviron, bool
 		return nil, false, nil
 	}
 	ok, err = netEnv.SupportsAddressAllocation(network.AnySubnet)
-	if err != nil {
-		if !errors.IsNotSupported(err) {
-			return nil, false, errors.Annotate(err, "checking allocation support")
-		}
+	if err != nil && !errors.IsNotSupported(err) {
+		return nil, false, errors.Annotate(err, "checking allocation support")
 	}
 	return netEnv, ok, nil
 }

--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -99,11 +99,11 @@ func (s *AddresserSuite) TestCanDeallocateAddressesConfigGetFailure(c *gc.C) {
 }
 
 func (s *AddresserSuite) TestCanDeallocateAddressesEnvironmentNewFailure(c *gc.C) {
-	config := tidelandTestingEnvConfig(c)
+	config := nonexTestingEnvConfig(c)
 	s.st.setConfig(c, config)
 
 	result := s.api.CanDeallocateAddresses()
-	c.Assert(result.Error, gc.ErrorMatches, `validating environment config: no registered provider for "tideland"`)
+	c.Assert(result.Error, gc.ErrorMatches, `validating environment config: no registered provider for "nonex"`)
 	c.Assert(result.Result, jc.IsFalse)
 }
 
@@ -200,7 +200,7 @@ func (s *AddresserSuite) TestCleanupIPAddressesConfigGetFailure(c *gc.C) {
 }
 
 func (s *AddresserSuite) TestCleanupIPAddressesEnvironmentNewFailure(c *gc.C) {
-	config := tidelandTestingEnvConfig(c)
+	config := nonexTestingEnvConfig(c)
 	s.st.setConfig(c, config)
 
 	dead, err := s.st.DeadIPAddresses()
@@ -209,7 +209,7 @@ func (s *AddresserSuite) TestCleanupIPAddressesEnvironmentNewFailure(c *gc.C) {
 
 	// Validation of configuration fails due to illegal provider.
 	apiErr := s.api.CleanupIPAddresses()
-	c.Assert(apiErr.Error, gc.ErrorMatches, `validating environment config: no registered provider for "tideland"`)
+	c.Assert(apiErr.Error, gc.ErrorMatches, `validating environment config: no registered provider for "nonex"`)
 
 	// Still has two dead addresses.
 	dead, err = s.st.DeadIPAddresses()
@@ -273,11 +273,11 @@ func testingEnvConfig(c *gc.C) *config.Config {
 	return env.Config()
 }
 
-// tidelandTestingEnvConfig prepares an environment configuration using
-// the illegal tideland provider.
-func tidelandTestingEnvConfig(c *gc.C) *config.Config {
+// nonexTestingEnvConfig prepares an environment configuration using
+// a non-existent provider.
+func nonexTestingEnvConfig(c *gc.C) *config.Config {
 	attrs := dummy.SampleConfig().Merge(coretesting.Attrs{
-		"type": "tideland",
+		"type": "nonex",
 	})
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -38,6 +38,11 @@ type AddresserSuite struct {
 
 var _ = gc.Suite(&AddresserSuite{})
 
+func (s *AddresserSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	environs.RegisterProvider("mock", mockEnvironProvider{})
+}
+
 func (s *AddresserSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.SetFeatureFlags(feature.AddressAllocation)
@@ -59,6 +64,56 @@ func (s *AddresserSuite) SetUpTest(c *gc.C) {
 func (s *AddresserSuite) TearDownTest(c *gc.C) {
 	dummy.Reset()
 	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *AddresserSuite) TestCanDeallocateAddressesEnabled(c *gc.C) {
+	config := testingEnvConfig(c)
+	s.st.setConfig(c, config)
+
+	result := s.api.CanDeallocateAddresses()
+	c.Assert(result, jc.DeepEquals, params.BoolResult{
+		Error:  nil,
+		Result: true,
+	})
+}
+
+func (s *AddresserSuite) TestCanDeallocateAddressesDisabled(c *gc.C) {
+	config := testingEnvConfig(c)
+	s.st.setConfig(c, config)
+	s.SetFeatureFlags()
+
+	result := s.api.CanDeallocateAddresses()
+	c.Assert(result.Error, gc.ErrorMatches, "checking allocation support: address allocation not supported")
+	c.Assert(result.Result, jc.IsFalse)
+}
+
+func (s *AddresserSuite) TestCanDeallocateAddressesConfigGetFailure(c *gc.C) {
+	config := testingEnvConfig(c)
+	s.st.setConfig(c, config)
+
+	s.st.stub.SetErrors(errors.New("ouch"))
+
+	result := s.api.CanDeallocateAddresses()
+	c.Assert(result.Error, gc.ErrorMatches, "getting environment config: ouch")
+	c.Assert(result.Result, jc.IsFalse)
+}
+
+func (s *AddresserSuite) TestCanDeallocateAddressesEnvironmentNewFailure(c *gc.C) {
+	config := tidelandTestingEnvConfig(c)
+	s.st.setConfig(c, config)
+
+	result := s.api.CanDeallocateAddresses()
+	c.Assert(result.Error, gc.ErrorMatches, `validating environment config: no registered provider for "tideland"`)
+	c.Assert(result.Result, jc.IsFalse)
+}
+
+func (s *AddresserSuite) TestCanDeallocateAddressesNotSupportedFailure(c *gc.C) {
+	config := mockTestingEnvConfig(c)
+	s.st.setConfig(c, config)
+
+	result := s.api.CanDeallocateAddresses()
+	c.Assert(result.Error, gc.ErrorMatches, "IP address deallocation not supported")
+	c.Assert(result.Result, jc.IsFalse)
 }
 
 func (s *AddresserSuite) TestCleanupIPAddressesSuccess(c *gc.C) {
@@ -230,7 +285,6 @@ func tidelandTestingEnvConfig(c *gc.C) *config.Config {
 // mockTestingEnvConfig prepares an environment configuration using
 // the mock provider which does not support networking.
 func mockTestingEnvConfig(c *gc.C) *config.Config {
-	environs.RegisterProvider("mock", mockEnvironProvider{})
 	cfg, err := config.New(config.NoDefaults, mockConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(cfg, envcmd.BootstrapContext(coretesting.Context(c)), configstore.NewMem())

--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -4,11 +4,9 @@
 package addresser_test
 
 import (
-	"errors"
-
-	gc "gopkg.in/check.v1"
-
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/addresser"
 	"github.com/juju/juju/apiserver/common"
@@ -83,8 +81,10 @@ func (s *AddresserSuite) TestCanDeallocateAddressesDisabled(c *gc.C) {
 	s.SetFeatureFlags()
 
 	result := s.api.CanDeallocateAddresses()
-	c.Assert(result.Error, gc.ErrorMatches, "checking allocation support: address allocation not supported")
-	c.Assert(result.Result, jc.IsFalse)
+	c.Assert(result, jc.DeepEquals, params.BoolResult{
+		Error:  nil,
+		Result: false,
+	})
 }
 
 func (s *AddresserSuite) TestCanDeallocateAddressesConfigGetFailure(c *gc.C) {
@@ -112,8 +112,10 @@ func (s *AddresserSuite) TestCanDeallocateAddressesNotSupportedFailure(c *gc.C) 
 	s.st.setConfig(c, config)
 
 	result := s.api.CanDeallocateAddresses()
-	c.Assert(result.Error, gc.ErrorMatches, "IP address deallocation not supported")
-	c.Assert(result.Result, jc.IsFalse)
+	c.Assert(result, jc.DeepEquals, params.BoolResult{
+		Error:  nil,
+		Result: false,
+	})
 }
 
 func (s *AddresserSuite) TestCleanupIPAddressesSuccess(c *gc.C) {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1158,20 +1158,10 @@ func (a *MachineAgent) startEnvWorkers(
 	singularRunner.StartWorker("cleaner", func() (worker.Worker, error) {
 		return newCleaner(apiSt.Cleaner()), nil
 	})
+	singularRunner.StartWorker("addresserworker", func() (worker.Worker, error) {
+		return newAddresser(apiSt.Addresser())
+	})
 
-	// Addresser Worker needs a networking environment. Check
-	// first before starting the worker.
-	isNetEnv, err := isNetworkingEnvironment(apiSt)
-	if err != nil {
-		return nil, errors.Annotate(err, "checking environment networking support")
-	}
-	if isNetEnv {
-		singularRunner.StartWorker("addresserworker", func() (worker.Worker, error) {
-			return newAddresser(apiSt.Addresser())
-		})
-	} else {
-		logger.Debugf("address deallocation not supported: not starting addresser worker")
-	}
 	// TODO(axw) 2013-09-24 bug #1229506
 	// Make another job to enable the firewaller. Not all
 	// environments are capable of managing ports
@@ -1189,19 +1179,6 @@ func (a *MachineAgent) startEnvWorkers(
 	}
 
 	return runner, nil
-}
-
-func isNetworkingEnvironment(apiConn api.Connection) (bool, error) {
-	envConfig, err := apiConn.Environment().EnvironConfig()
-	if err != nil {
-		return false, errors.Annotate(err, "cannot read environment config")
-	}
-	env, err := environs.New(envConfig)
-	if err != nil {
-		return false, errors.Annotate(err, "cannot get environment")
-	}
-	_, ok := environs.SupportsNetworking(env)
-	return ok, nil
 }
 
 var getFirewallMode = _getFirewallMode

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	apiaddresser "github.com/juju/juju/api/addresser"
 	apideployer "github.com/juju/juju/api/deployer"
 	apienvironment "github.com/juju/juju/api/environment"
 	apifirewaller "github.com/juju/juju/api/firewaller"
@@ -47,6 +48,7 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -64,6 +66,7 @@ import (
 	sshtesting "github.com/juju/juju/utils/ssh/testing"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/addresser"
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
@@ -724,6 +727,48 @@ func (s *MachineSuite) TestManageEnvironRunsPeergrouper(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for peergrouper worker to be started")
 	}
+}
+
+func (s *MachineSuite) TestAddresserWorkerRunsIfFeatureFlagEnabled(c *gc.C) {
+	s.SetFeatureFlags(feature.AddressAllocation)
+
+	s.PatchValue(&newAddresser, func(api *apiaddresser.API) (worker.Worker, error) {
+		w, err := addresser.NewWorker(api)
+		// TODO(mue) Get "connection is shut down" here?!?
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(w, gc.Not(gc.FitsTypeOf), worker.FinishedWorker{})
+		return w, err
+	})
+
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+
+	s.singularRecord.nextRunner(c)
+	runner := s.singularRecord.nextRunner(c)
+	runner.waitForWorker(c, "addresserworker")
+}
+
+func (s *MachineSuite) TestAddresserWorkerIsFineshedIfFeatureFlagDisabled(c *gc.C) {
+	s.SetFeatureFlags()
+
+	s.PatchValue(&newAddresser, func(api *apiaddresser.API) (worker.Worker, error) {
+		w, err := addresser.NewWorker(api)
+		// TODO(mue) Get "connection is shut down" here?!?
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(w, gc.FitsTypeOf, worker.FinishedWorker{})
+		return w, err
+	})
+
+	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+
+	s.singularRecord.nextRunner(c)
+	runner := s.singularRecord.nextRunner(c)
+	runner.waitForWorker(c, "addresserworker")
 }
 
 func (s *MachineSuite) TestManageEnvironRunsDbLogPrunerIfFeatureFlagEnabled(c *gc.C) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -734,7 +734,6 @@ func (s *MachineSuite) TestAddresserWorkerRunsIfFeatureFlagEnabled(c *gc.C) {
 
 	s.PatchValue(&newAddresser, func(api *apiaddresser.API) (worker.Worker, error) {
 		w, err := addresser.NewWorker(api)
-		// TODO(mue) Get "connection is shut down" here?!?
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(w, gc.Not(gc.FitsTypeOf), worker.FinishedWorker{})
 		return w, err
@@ -745,9 +744,10 @@ func (s *MachineSuite) TestAddresserWorkerRunsIfFeatureFlagEnabled(c *gc.C) {
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
 
+	// Wait for firewaller as last worker.
 	s.singularRecord.nextRunner(c)
 	runner := s.singularRecord.nextRunner(c)
-	runner.waitForWorker(c, "addresserworker")
+	runner.waitForWorker(c, "firewaller")
 }
 
 func (s *MachineSuite) TestAddresserWorkerIsFineshedIfFeatureFlagDisabled(c *gc.C) {
@@ -755,7 +755,6 @@ func (s *MachineSuite) TestAddresserWorkerIsFineshedIfFeatureFlagDisabled(c *gc.
 
 	s.PatchValue(&newAddresser, func(api *apiaddresser.API) (worker.Worker, error) {
 		w, err := addresser.NewWorker(api)
-		// TODO(mue) Get "connection is shut down" here?!?
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(w, gc.FitsTypeOf, worker.FinishedWorker{})
 		return w, err
@@ -766,9 +765,10 @@ func (s *MachineSuite) TestAddresserWorkerIsFineshedIfFeatureFlagDisabled(c *gc.
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
 
+	// Wait for firewaller as last worker.
 	s.singularRecord.nextRunner(c)
 	runner := s.singularRecord.nextRunner(c)
-	runner.waitForWorker(c, "addresserworker")
+	runner.waitForWorker(c, "firewaller")
 }
 
 func (s *MachineSuite) TestManageEnvironRunsDbLogPrunerIfFeatureFlagEnabled(c *gc.C) {

--- a/worker/addresser/worker.go
+++ b/worker/addresser/worker.go
@@ -24,12 +24,13 @@ type addresserHandler struct {
 func NewWorker(api *apiaddresser.API) (worker.Worker, error) {
 	ok, err := api.CanDeallocateAddresses()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "checking address deallocation")
 	}
 	if !ok {
 		// Environment does not support IP address
 		// deallocation.
-		return worker.NewFinishedWorker(), nil
+		logger.Debugf("address deallocation not supported; not starting worker")
+		return worker.FinishedWorker{}, nil
 	}
 	ah := &addresserHandler{
 		api: api,

--- a/worker/addresser/worker.go
+++ b/worker/addresser/worker.go
@@ -19,9 +19,18 @@ type addresserHandler struct {
 	api *apiaddresser.API
 }
 
-// NewWorker returns a worker that keeps track of
-// IP address lifecycles, releaseing and removing Dead addresses.
+// NewWorker returns a worker that keeps track of IP address
+// lifecycles, releaseing and removing dead addresses.
 func NewWorker(api *apiaddresser.API) (worker.Worker, error) {
+	ok, err := api.CanDeallocateAddresses()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !ok {
+		// Environment does not support IP address
+		// deallocation.
+		return worker.NewFinishedWorker(), nil
+	}
 	ah := &addresserHandler{
 		api: api,
 	}

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -194,6 +194,13 @@ func (s *workerEnabledSuite) SetUpTest(c *gc.C) {
 	s.workerSuite.SetUpTest(c)
 }
 
+func (s *workerEnabledSuite) TestWorkerIsStringsWorker(c *gc.C) {
+	// In case of an environment able to allocte/deallocate
+	// IP addresses the addresser worker is no finished worker.
+	// See also TestWorkerIsFinishedWorker.
+	c.Assert(worker.IsFinishedWorker(s.Worker), jc.IsFalse)
+}
+
 func (s *workerEnabledSuite) TestWorkerReleasesAlreadyDead(c *gc.C) {
 	// Wait for releases of 0.1.2.4 and 0.1.2.6 first. It's
 	// explicitely needed for this test for the assertion.
@@ -324,6 +331,13 @@ func (s *workerDisabledSuite) SetUpTest(c *gc.C) {
 	s.workerSuite.Enabled = false
 
 	s.workerSuite.SetUpTest(c)
+}
+
+func (s *workerDisabledSuite) TestWorkerIsFinishedWorker(c *gc.C) {
+	// In case of an environment not able to allocte/deallocate
+	// IP addresses the worker is a finished worker.
+	// See also TestWorkerIsStringsWorker.
+	c.Assert(worker.IsFinishedWorker(s.Worker), jc.IsTrue)
 }
 
 func (s *workerDisabledSuite) TestWorkerIgnoresAddresses(c *gc.C) {

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -198,7 +198,7 @@ func (s *workerEnabledSuite) TestWorkerIsStringsWorker(c *gc.C) {
 	// In case of an environment able to allocte/deallocate
 	// IP addresses the addresser worker is no finished worker.
 	// See also TestWorkerIsFinishedWorker.
-	c.Assert(worker.IsFinishedWorker(s.Worker), jc.IsFalse)
+	c.Assert(s.Worker, gc.Not(gc.FitsTypeOf), worker.FinishedWorker{})
 }
 
 func (s *workerEnabledSuite) TestWorkerReleasesAlreadyDead(c *gc.C) {
@@ -337,7 +337,7 @@ func (s *workerDisabledSuite) TestWorkerIsFinishedWorker(c *gc.C) {
 	// In case of an environment not able to allocte/deallocate
 	// IP addresses the worker is a finished worker.
 	// See also TestWorkerIsStringsWorker.
-	c.Assert(worker.IsFinishedWorker(s.Worker), jc.IsTrue)
+	c.Assert(s.Worker, gc.FitsTypeOf, worker.FinishedWorker{})
 }
 
 func (s *workerDisabledSuite) TestWorkerIgnoresAddresses(c *gc.C) {

--- a/worker/finishedworker.go
+++ b/worker/finishedworker.go
@@ -1,31 +1,16 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package worker
 
-// finishedWorker implements the worker returned by NewFinishedWorker.
-type finishedWorker struct{}
+// FinishedWorker is a worker that stops immediately with no error
+// when started by a Runner, which then removes it from the list of
+// workers without restarting it. Simply return FinishedWorker{}
+// where you need to avoid starting a worker at all.
+type FinishedWorker struct{}
 
-// NewFinishedWorker returns a worker that is doing nothing and immediatelly
-// finishes. It is used in those situations where the constructor of a
-// concrete worker detects that it is not needed, e.g. due to not supported
-// features of the current environment. Then instead of creating an
-// instance of that worker the finished worker is returned and ends
-// itself in a clean way.
-func NewFinishedWorker() Worker {
-	return &finishedWorker{}
-}
+// Kill implements Worker.Kill() and does nothing.
+func (w FinishedWorker) Kill() {}
 
-// Kill implements Worker.Kill().
-func (w *finishedWorker) Kill() {}
-
-// Wait implements Worker.Wait().
-func (w *finishedWorker) Wait() error {
-	return nil
-}
-
-// IsFinishedWorker returns true if the passed worker is a finished worker.
-func IsFinishedWorker(w Worker) bool {
-	_, ok := w.(*finishedWorker)
-	return ok
-}
+// Wait implements Worker.Wait() and immediately returns no error.
+func (w FinishedWorker) Wait() error { return nil }

--- a/worker/finishedworker.go
+++ b/worker/finishedworker.go
@@ -1,0 +1,31 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package worker
+
+// finishedWorker implements the worker returned by NewFinishedWorker.
+type finishedWorker struct{}
+
+// NewFinishedWorker returns a worker that is doing nothing and immediatelly
+// finishes. It is used in those situations where the constructor of a
+// concrete worker detects that it is not needed, e.g. due to not supported
+// features of the current environment. Then instead of creating an
+// instance of that worker the finished worker is returned and ends
+// itself in a clean way.
+func NewFinishedWorker() Worker {
+	return &finishedWorker{}
+}
+
+// Kill implements Worker.Kill().
+func (w *finishedWorker) Kill() {}
+
+// Wait implements Worker.Wait().
+func (w *finishedWorker) Wait() error {
+	return nil
+}
+
+// IsFinishedWorker returns true if the passed worker is a finished worker.
+func IsFinishedWorker(w Worker) bool {
+	_, ok := w.(*finishedWorker)
+	return ok
+}

--- a/worker/finishedworker_test.go
+++ b/worker/finishedworker_test.go
@@ -1,0 +1,21 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package worker_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker"
+)
+
+type finishedSuite struct {}
+
+var _ = gc.Suite(&finishedSuite{})
+
+func (s *finishedSuite) TestFinishedWorker(c *gc.C) {
+	// Pretty dumb test if interface is implemented
+	// and Wait() returns nil.
+	var fw worker.Worker = worker.FinishedWorker{}
+	c.Assert(fw.Wait(), gc.IsNil)
+}

--- a/worker/finishedworker_test.go
+++ b/worker/finishedworker_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/juju/juju/worker"
 )
 
-type finishedSuite struct {}
+type FinishedSuite struct{}
 
-var _ = gc.Suite(&finishedSuite{})
+var _ = gc.Suite(&FinishedSuite{})
 
-func (s *finishedSuite) TestFinishedWorker(c *gc.C) {
+func (s *FinishedSuite) TestFinishedWorker(c *gc.C) {
 	// Pretty dumb test if interface is implemented
 	// and Wait() returns nil.
 	var fw worker.Worker = worker.FinishedWorker{}

--- a/worker/runner_test.go
+++ b/worker/runner_test.go
@@ -177,28 +177,6 @@ func (*runnerSuite) TestOneWorkerRestartDelay(c *gc.C) {
 	c.Assert(worker.Stop(runner), gc.IsNil)
 }
 
-func (*runnerSuite) TestFinishedWorkerFinishes(c *gc.C) {
-	finishedWorker := worker.NewFinishedWorker()
-	c.Assert(finishedWorker.Wait(), gc.IsNil)
-
-	runner := worker.NewRunner(noneFatal, noImportance)
-	startedc := make(chan struct{}, 1)
-	starter := func() (worker.Worker, error) {
-		startedc <- struct{}{}
-		return finishedWorker, nil
-	}
-	err := runner.StartWorker("id", starter)
-	c.Assert(err, jc.ErrorIsNil)
-
-	select {
-	case <-startedc:
-	case <-time.After(1 * time.Second):
-		c.Fatalf("timed out waiting for start notification")
-	}
-
-	c.Assert(worker.Stop(runner), gc.IsNil)
-}
-
 type errorLevel int
 
 func (e errorLevel) Error() string {


### PR DESCRIPTION
The Addresser is the first worker using a new way to be started as discussed between William, Dimiter, and me. The test is not inside the machine agent anymore. Instead a worker is always started, checks if it is needed or can work (like here based on asking the environment if it is capable of IP addresses deallocation), and then returns its own instance or an instance of the finished worker. The implementation of that is very thin, it ends immediatelly with `err == nil` and is so not being restarted every three seconds.

More workers, like the Firewaller, will follow.

(Review request: http://reviews.vapour.ws/r/2419/)