### PR TITLE
Fix typos in juju help that users see.

### DIFF
--- a/cmd/juju/block/unblock.go
+++ b/cmd/juju/block/unblock.go
@@ -29,7 +29,7 @@ execution of operations that could alter environment.
 This is done by blocking certain commands from successful execution. Blocked commands
 must be manually unblocked to proceed.
 
-Some comands offer a --force option that can be used to bypass a block.
+Some commands offer a --force option that can be used to bypass a block.
 
 Commands that can be unblocked are grouped based on logical operations as follows:
 

--- a/cmd/juju/commands/authorizedkeys.go
+++ b/cmd/juju/commands/authorizedkeys.go
@@ -41,7 +41,7 @@ func NewAuthorizedKeysCommand() cmd.Command {
 			Name:        "authorized-keys",
 			Doc:         authKeysDoc,
 			UsagePrefix: "juju",
-			Purpose:     "manage authorized ssh keys",
+			Purpose:     "manage authorised ssh keys",
 			Aliases:     []string{"authorised-keys"},
 		}),
 	}

--- a/cmd/juju/commands/authorizedkeys_add.go
+++ b/cmd/juju/commands/authorizedkeys_add.go
@@ -14,7 +14,7 @@ import (
 )
 
 var addKeysDoc = `
-Add new authorized ssh keys to allow the holder of those keys to log on to Juju nodes or machines.
+Add new authorised ssh keys to allow the holder of those keys to log on to Juju nodes or machines.
 `
 
 // AddKeysCommand is used to add a new authorized ssh key for a user.

--- a/cmd/juju/commands/authorizedkeys_delete.go
+++ b/cmd/juju/commands/authorizedkeys_delete.go
@@ -19,7 +19,7 @@ The keys to delete are found by specifying either the "comment" portion of the s
 typically something like "user@host", or the key fingerprint found by using ssh-keygen.
 `
 
-// DeleteKeysCommand is used to delete authorized ssh keys for a user.
+// DeleteKeysCommand is used to delete authorised ssh keys for a user.
 type DeleteKeysCommand struct {
 	AuthorizedKeysBase
 	user   string

--- a/cmd/juju/commands/authorizedkeys_import.go
+++ b/cmd/juju/commands/authorizedkeys_import.go
@@ -14,7 +14,7 @@ import (
 )
 
 var importKeysDoc = `
-Import new authorized ssh keys to allow the holder of those keys to log on to Juju nodes or machines.
+Import new authorised ssh keys to allow the holder of those keys to log on to Juju nodes or machines.
 The keys are imported using ssh-import-id.
 `
 

--- a/cmd/juju/commands/authorizedkeys_list.go
+++ b/cmd/juju/commands/authorizedkeys_list.go
@@ -30,7 +30,7 @@ func (c *ListKeysCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Doc:     listKeysDoc,
-		Purpose: "list authorized ssh keys for a specified user",
+		Purpose: "list authorised ssh keys for a specified user",
 	}
 }
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -56,7 +56,7 @@ algorithm by using the "--to" flag. The value associated with "--to" is a
 "placement directive", which tells Juju how to identify the first machine to use.
 For more information on placement directives, see "juju help placement".
 
-Bootstrap initializes the cloud environment synchronously and displays information
+Bootstrap initialises the cloud environment synchronously and displays information
 about the current installation steps.  The time for bootstrap to complete varies
 across cloud providers from a few seconds to several minutes.  Once bootstrap has
 completed, you can run other juju commands against your environment. You can change
@@ -70,10 +70,11 @@ following settings in your environments.yaml (all values represent number of sec
     # How often to refresh state server addresses from the API server.
     bootstrap-addresses-delay: 10 # default: 10 seconds
 
-Private clouds may need to specify their own custom image metadata, and possibly upload
-Juju tools to cloud storage if no outgoing Internet access is available. In this case,
-use the --metadata-source paramater to tell bootstrap a local directory from which to
-upload tools and/or image metadata.
+Private clouds may need to specify their own custom image metadata, and
+possibly upload Juju tools to cloud storage if no outgoing Internet access is
+available. In this case, use the --metadata-source parameter to point
+bootstrap to a local directory from which to upload tools and/or image
+metadata.
 
 If agent-version is specifed, this is the default tools version to use when running the Juju agents.
 Only the numeric version is relevant. To enable ease of scripting, the full binary version

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -60,7 +60,7 @@ const sshDoc = `
 Launch an ssh shell on the machine identified by the <target> parameter.
 <target> can be either a machine id  as listed by "juju status" in the
 "machines" section or a unit name as listed in the "services" section.
-Any extra parameters are passsed as extra parameters to the ssh command.
+Any extra parameters are passed as extra parameters to the ssh command.
 
 Examples:
 

--- a/cmd/juju/service/unset.go
+++ b/cmd/juju/service/unset.go
@@ -23,7 +23,7 @@ type UnsetCommand struct {
 
 const unsetDoc = `
 Set one or more configuration options for the specified service to their
-default. See also the set commmand to set one or more configuration options for
+default. See also the set command to set one or more configuration options for
 a specified service.
 `
 

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -35,7 +35,7 @@ The statuses for the unit workload and/or agent are available.
     agent: will show statuses for the unit's agent
     workload: will show statuses for the unit's workload
     combined: will show agent and workload statuses combined
- and sorted by time of occurence.
+ and sorted by time of occurrence.
 `
 
 func (c *StatusHistoryCommand) Info() *cmd.Info {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -34,7 +34,7 @@ There are a number of ways to format the status output:
 
 - {short|line|oneline}: List units and their subordinates. For each
            unit, the IP address and agent status are listed.
-- summary: Displays the subnet(s) and port(s) the environment utilizes.
+- summary: Displays the subnet(s) and port(s) the environment utilises.
            Also displays aggregate information about:
            - MACHINES: total #, and # in each state.
            - UNITS: total #, and # in each state.


### PR DESCRIPTION
I filed a Launchpad bug (https://bugs.launchpad.net/juju-core/+bug/1486640) detailing some typos that are exposed to users via the command-line 'juju help' commands and in the official documentation hosted at jujucharms.com.  Since the latter is generated from 'juju help' the typos have to be fixed here.

(Review request: http://reviews.vapour.ws/r/2422/)