### PR TITLE
State: Add time of dying and death to environ doc

### DIFF
--- a/state/life.go
+++ b/state/life.go
@@ -34,6 +34,7 @@ func (l Life) String() string {
 }
 
 var isAliveDoc = bson.D{{"life", Alive}}
+var isDyingDoc = bson.D{{"life", Dying}}
 var isDeadDoc = bson.D{{"life", Dead}}
 var notDeadDoc = bson.D{{"life", bson.D{{"$ne", Dead}}}}
 


### PR DESCRIPTION
- Add two new fields to the environmentDoc: "time-of-dying",
"time-of-death".

- Set time of dying when environment is destroyed and life set to
dying.

- Time of death will be set by a new worker, to be introduced in a
follow-up PR.

(Review request: http://reviews.vapour.ws/r/2442/)