### PR TITLE
provider/azure: Implement windows compatibility

### DIFF
--- a/provider/azure/disks_test.go
+++ b/provider/azure/disks_test.go
@@ -68,7 +68,7 @@ func (s *azureVolumeSuite) TestCreateVolumes(c *gc.C) {
 	env := makeEnviron(c)
 	prefix := env.getEnvPrefix()
 	serviceName := "service"
-	service := makeDeployment(env, prefix+serviceName)
+	service := makeDeployment(c, env, prefix+serviceName)
 
 	roleName := service.Deployments[0].RoleList[0].RoleName
 	inst, err := env.getInstance(service, roleName)
@@ -181,7 +181,7 @@ func (s *azureVolumeSuite) TestCreateVolumesNoLuns(c *gc.C) {
 	env := makeEnviron(c)
 	prefix := env.getEnvPrefix()
 	serviceName := "service"
-	service := makeDeployment(env, prefix+serviceName)
+	service := makeDeployment(c, env, prefix+serviceName)
 	roleName := service.Deployments[0].RoleList[0].RoleName
 	inst, err := env.getInstance(service, roleName)
 	c.Assert(err, jc.ErrorIsNil)
@@ -226,7 +226,7 @@ func (s *azureVolumeSuite) TestCreateVolumesLegacyInstance(c *gc.C) {
 	env := makeEnviron(c)
 	prefix := env.getEnvPrefix()
 	serviceName := "service"
-	service := makeLegacyDeployment(env, prefix+serviceName)
+	service := makeLegacyDeployment(c, env, prefix+serviceName)
 	inst, err := env.getInstance(service, "")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -358,7 +358,7 @@ func (s *azureVolumeSuite) TestAttachVolumesAlreadyAttached(c *gc.C) {
 
 	env := makeEnviron(c)
 	prefix := env.getEnvPrefix()
-	service := makeDeployment(env, prefix+"service")
+	service := makeDeployment(c, env, prefix+"service")
 	roleName0 := service.Deployments[0].RoleList[0].RoleName
 	roleName1 := service.Deployments[0].RoleList[1].RoleName
 	inst0, err := env.getInstance(service, roleName0)
@@ -455,7 +455,7 @@ func (s *azureVolumeSuite) TestAttachVolumesNotAttached(c *gc.C) {
 
 	env := makeEnviron(c)
 	prefix := env.getEnvPrefix()
-	service := makeDeployment(env, prefix+"service")
+	service := makeDeployment(c, env, prefix+"service")
 	roleName := service.Deployments[0].RoleList[0].RoleName
 	inst, err := env.getInstance(service, roleName)
 	c.Assert(err, jc.ErrorIsNil)
@@ -488,7 +488,7 @@ func (s *azureVolumeSuite) TestAttachVolumesGetRoleError(c *gc.C) {
 
 	env := makeEnviron(c)
 	prefix := env.getEnvPrefix()
-	service := makeLegacyDeployment(env, prefix+"service")
+	service := makeLegacyDeployment(c, env, prefix+"service")
 	inst, err := env.getInstance(service, "")
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -4,7 +4,9 @@
 package azure
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -31,6 +33,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/version"
 )
 
 const (
@@ -759,14 +762,20 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		}
 	}
 
-	vhd := env.newOSDisk(sourceImageName)
+	vhd, err := env.newOSDisk(sourceImageName, args.InstanceConfig.Series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	// If we're creating machine-0, we'll want to expose port 22.
 	// All other machines get an auto-generated public port for SSH.
 	stateServer := multiwatcher.AnyJobNeedsState(args.InstanceConfig.Jobs...)
-	role := env.newRole(instanceType.Id, vhd, string(userData), stateServer)
+	role, err := env.newRole(instanceType.Id, vhd, stateServer, string(userData), args.InstanceConfig.Series, snapshot)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	inst, err := createInstance(env, snapshot.api, role, cloudServiceName, stateServer)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	hc := &instance.HardwareCharacteristics{
 		Mem:      &instanceType.Mem,
@@ -835,15 +844,26 @@ func (env *azureEnviron) getInstance(hostedService *gwacl.HostedService, roleNam
 
 // newOSDisk creates a gwacl.OSVirtualHardDisk object suitable for an
 // Azure Virtual Machine.
-func (env *azureEnviron) newOSDisk(sourceImageName string) *gwacl.OSVirtualHardDisk {
+func (env *azureEnviron) newOSDisk(sourceImageName string, series string) (*gwacl.OSVirtualHardDisk, error) {
 	vhdName := gwacl.MakeRandomDiskName("juju")
 	vhdPath := fmt.Sprintf("vhds/%s", vhdName)
 	snap := env.getSnapshot()
 	storageAccount := snap.ecfg.storageAccountName()
 	mediaLink := gwacl.CreateVirtualHardDiskMediaLink(storageAccount, vhdPath)
+	os, err := version.GetOSFromSeries(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var OSType string
+	switch os {
+	case version.Windows:
+		OSType = "Windows"
+	default:
+		OSType = "Linux"
+	}
 	// The disk label is optional and the disk name can be omitted if
 	// mediaLink is provided.
-	return gwacl.NewOSVirtualHardDisk("", "", "", mediaLink, sourceImageName, "Linux")
+	return gwacl.NewOSVirtualHardDisk("", "", "", mediaLink, sourceImageName, OSType), nil
 }
 
 // getInitialEndpoints returns a slice of the endpoints every instance should have open
@@ -878,31 +898,128 @@ func (env *azureEnviron) getInitialEndpoints(stateServer bool) []gwacl.InputEndp
 // newRole creates a gwacl.Role object (an Azure Virtual Machine) which uses
 // the given Virtual Hard Drive.
 //
+// roleSize is the name of one of Azure's machine types, e.g. ExtraSmall,
+// Large, A6 etc.
+func (env *azureEnviron) newRole(roleSize string, vhd *gwacl.OSVirtualHardDisk, stateServer bool, userdata, series string, snapshot *azureEnviron) (*gwacl.Role, error) {
+	// Do some common initialization
+	roleName := gwacl.MakeRandomRoleName("juju")
+	hostname := roleName
+	password := gwacl.MakeRandomPassword()
+
+	os, err := version.GetOSFromSeries(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// Generate a Network Configuration with the initially required ports open.
+	networkConfigurationSet := gwacl.NewNetworkConfigurationSet(env.getInitialEndpoints(stateServer), nil)
+
+	var role *gwacl.Role
+	switch os {
+	case version.Windows:
+		role, err = makeWindowsRole(password, roleSize, roleName, userdata, vhd, networkConfigurationSet, snapshot)
+	default:
+		role, err = makeLinuxRole(hostname, password, roleSize, roleName, userdata, vhd, networkConfigurationSet)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	role.AvailabilitySetName = "juju"
+	return role, nil
+}
+
+// makeLinuxRole will create a gwacl.Role for a Linux VM.
 // The VM will have:
 // - an 'ubuntu' user defined with an unguessable (randomly generated) password
 // - its ssh port (TCP 22) open
 // (if a state server)
 // - its state port (TCP mongoDB) port open
 // - its API port (TCP) open
-//
-// roleSize is the name of one of Azure's machine types, e.g. ExtraSmall,
-// Large, A6 etc.
-func (env *azureEnviron) newRole(roleSize string, vhd *gwacl.OSVirtualHardDisk, userData string, stateServer bool) *gwacl.Role {
-	roleName := gwacl.MakeRandomRoleName("juju")
+// On Linux the userdata is sent as a base64 encoded string in the CustomData xml field of the role.
+func makeLinuxRole(
+	hostname, password, roleSize, roleName, userdata string,
+	vhd *gwacl.OSVirtualHardDisk, networkConfigSet *gwacl.ConfigurationSet) (*gwacl.Role, error) {
 	// Create a Linux Configuration with the username and the password
 	// empty and disable SSH with password authentication.
-	hostname := roleName
 	username := "ubuntu"
-	password := gwacl.MakeRandomPassword()
-	linuxConfigurationSet := gwacl.NewLinuxProvisioningConfigurationSet(hostname, username, password, userData, "true")
-	// Generate a Network Configuration with the initially required ports open.
-	networkConfigurationSet := gwacl.NewNetworkConfigurationSet(env.getInitialEndpoints(stateServer), nil)
-	role := gwacl.NewLinuxRole(
-		roleSize, roleName, vhd,
-		[]gwacl.ConfigurationSet{*linuxConfigurationSet, *networkConfigurationSet},
-	)
-	role.AvailabilitySetName = "juju"
-	return role
+	cfgSet := gwacl.NewLinuxProvisioningConfigurationSet(hostname, username, password, userdata, "true")
+	finalCfgSet := []gwacl.ConfigurationSet{*cfgSet, *networkConfigSet}
+	return gwacl.NewLinuxRole(roleSize, roleName, vhd, finalCfgSet), nil
+
+}
+
+// makeWindowsRole will create a gwacl.Role for a Windows VM.
+// The VM will have:
+// - an 'JujuAdministrator' user defined with an unguessable (randomly generated) password
+// TODO(bogdanteleaga): Open the winrm port and provide winrm access
+// - for now only port 22 is open(by default)
+// On Windows the userdata is uploaded to the storage and then a reference to it is sent
+// using CustomScriptExtension. For more details see makeUserdataResourceExtension
+func makeWindowsRole(
+	password, roleSize, roleName, userdata string, vhd *gwacl.OSVirtualHardDisk,
+	networkConfigSet *gwacl.ConfigurationSet, snapshot *azureEnviron) (*gwacl.Role, error) {
+	// Later we will add WinRM configuration here
+	// Windows does not accept hostnames over 15 characters.
+	roleName = roleName[:15]
+	hostname := roleName
+	username := "JujuAdministrator"
+	cfgSet := gwacl.NewWindowsProvisioningConfigurationSet(hostname, password, "true", "", nil, nil, username, "", userdata)
+	finalCfgSet := []gwacl.ConfigurationSet{*cfgSet, *networkConfigSet}
+	resourceExtension, err := makeUserdataResourceExtension(hostname, userdata, snapshot)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return gwacl.NewWindowsRole(roleSize, roleName, vhd, finalCfgSet, &[]gwacl.ResourceExtensionReference{*resourceExtension}, "true"), nil
+
+}
+
+// makeUserdataResourceExtension will upload the userdata to storage and then fill in the proper xml
+// following the example here
+// https://msdn.microsoft.com/en-us/library/azure/dn781373.aspx
+func makeUserdataResourceExtension(nonce string, userData string, snapshot *azureEnviron) (*gwacl.ResourceExtensionReference, error) {
+	// The bootstrap userdata script is the same for all machines.
+	// So we first check if it's already uploaded and if it isn't we upload it
+	_, err := snapshot.storage.Get(bootstrapUserdataScriptFilename)
+	if errors.IsNotFound(err) {
+		err := snapshot.storage.Put(bootstrapUserdataScriptFilename, bytes.NewReader([]byte(bootstrapUserdataScript)), int64(len(bootstrapUserdataScript)))
+		if err != nil {
+			logger.Errorf(err.Error())
+			return nil, errors.Annotate(err, "cannot upload userdata to storage")
+		}
+	}
+
+	uri, err := snapshot.storage.URL(bootstrapUserdataScriptFilename)
+	if err != nil {
+		logger.Errorf(err.Error())
+		return nil, errors.Trace(err)
+	}
+
+	scriptPublicConfig, err := makeUserdataResourceScripts(uri, bootstrapUserdataScriptFilename)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	publicParam := gwacl.NewResourceExtensionParameter("CustomScriptExtensionPublicConfigParameter", scriptPublicConfig, gwacl.ResourceExtensionParameterTypePublic)
+	return gwacl.NewResourceExtensionReference("MyCustomScriptExtension", "Microsoft.Compute", "CustomScriptExtension", "1.4", "", []gwacl.ResourceExtensionParameter{*publicParam}), nil
+}
+
+func makeUserdataResourceScripts(uri, filename string) (publicParam string, err error) {
+	type publicConfig struct {
+		FileUris         []string `json:"fileUris"`
+		CommandToExecute string   `json:"commandToExecute"`
+	}
+
+	public := publicConfig{
+		FileUris:         []string{uri},
+		CommandToExecute: fmt.Sprintf("powershell -ExecutionPolicy Unrestricted -file %s", filename),
+	}
+
+	publicConf, err := json.Marshal(public)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	scriptPublicConfig := base64.StdEncoding.EncodeToString(publicConf)
+
+	return scriptPublicConfig, nil
 }
 
 // StopInstances is specified in the InstanceBroker interface.

--- a/provider/azure/export_test.go
+++ b/provider/azure/export_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/juju/environs"
 )
 
+var MakeUserdataResourceScripts = makeUserdataResourceScripts
+
 func MakeEnvironForTest(c *gc.C) environs.Environ {
 	return makeEnviron(c)
 }

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -31,7 +31,7 @@ var _ = gc.Suite(&instanceSuite{})
 func (s *instanceSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.env = makeEnviron(c)
-	s.service = makeDeployment(s.env, "service-name")
+	s.service = makeDeployment(c, s.env, "service-name")
 	s.deployment = &s.service.Deployments[0]
 	s.deployment.Name = "deployment-one"
 	s.role = &s.deployment.RoleList[0]

--- a/provider/azure/userdata.go
+++ b/provider/azure/userdata.go
@@ -12,6 +12,17 @@ import (
 	"github.com/juju/juju/version"
 )
 
+const (
+	// The userdata on windows will arrive as CustomData.bin
+	// We need to execute that as a powershell script and then remove it
+	bootstrapUserdataScript = `#ps1_sysnative
+mv C:\AzureData\CustomData.bin C:\AzureData\CustomData.ps1
+& C:\AzureData\CustomData.ps1
+rm C:\AzureData\CustomData.ps1
+`
+	bootstrapUserdataScriptFilename = "juju-userdata.ps1"
+)
+
 type AzureRenderer struct{}
 
 func (AzureRenderer) EncodeUserdata(udata []byte, vers version.OSType) ([]byte, error) {
@@ -19,7 +30,7 @@ func (AzureRenderer) EncodeUserdata(udata []byte, vers version.OSType) ([]byte, 
 	case version.Ubuntu, version.CentOS:
 		return renderers.ToBase64(utils.Gzip(udata)), nil
 	case version.Windows:
-		return renderers.WinEmbedInScript(udata), nil
+		return renderers.ToBase64(renderers.WinEmbedInScript(udata)), nil
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", vers)
 	}


### PR DESCRIPTION
So apparently azure has different role requests for windows instances. This PR implements basic support for these.

At some point in the future we will probably get a PR that opens some sort of management port on the machines by default(like we have 22 on linux), but for now I haven't touched anything related to ports, which does mean 22 will be opened on windows machines.

(Review request: http://reviews.vapour.ws/r/2443/)