### PR TITLE
LP 1486749: Disallow backups for hosted envs

### DIFF
--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -36,6 +36,11 @@ func NewAPI(st *state.State, resources *common.Resources, authorizer common.Auth
 		return nil, errors.Trace(common.ErrPerm)
 	}
 
+	// For now, backup operations are only permitted on the system environment.
+	if !st.IsStateServer() {
+		return nil, errors.New("backups are not supported for hosted environments")
+	}
+
 	// Get the backup paths.
 	dataDir, err := extractResourceValue(resources, "dataDir")
 	if err != nil {

--- a/apiserver/backups/backups_test.go
+++ b/apiserver/backups/backups_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
 	backupstesting "github.com/juju/juju/state/backups/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type backupsSuite struct {
@@ -76,4 +77,11 @@ func (s *backupsSuite) TestNewAPINotAuthorized(c *gc.C) {
 	_, err := backupsAPI.NewAPI(s.State, s.resources, s.authorizer)
 
 	c.Check(errors.Cause(err), gc.Equals, common.ErrPerm)
+}
+
+func (s *backupsSuite) TestNewAPIHostedEnvironmentFails(c *gc.C) {
+	otherState := factory.NewFactory(s.State).MakeEnvironment(c, nil)
+	defer otherState.Close()
+	_, err := backupsAPI.NewAPI(otherState, s.resources, s.authorizer)
+	c.Check(err, gc.ErrorMatches, "backups are not supported for hosted environments")
 }

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -10,16 +10,26 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/api/backups"
 	apiserverbackups "github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/feature"
 	statebackups "github.com/juju/juju/state/backups"
 )
 
 var backupsDoc = `
 "juju backups" is used to manage backups of the state of a juju environment.
+`
+
+var jesBackupsDoc = `
+"juju backups" is used to manage backups of the state of a juju system.
+Backups are only supported on juju systems, not hosted environments.  For
+more information on juju systems, see:
+
+    juju help juju-systems
 `
 
 const backupsPurpose = "create, manage, and restore backups of juju's state"
@@ -31,6 +41,10 @@ type Command struct {
 
 // NewCommand returns a new backups super-command.
 func NewCommand() cmd.Command {
+	if featureflag.Enabled(feature.JES) {
+		backupsDoc = jesBackupsDoc
+	}
+
 	backupsCmd := Command{
 		SuperCommand: *cmd.NewSuperCommand(
 			cmd.SuperCommandParams{


### PR DESCRIPTION
This patch disallows any backups command for a hosted
environment, as it is currently not supported. It prevents
an API connection to the Backups endpoint if not operating
on the system (state server) environment.

The doc for juju backups was updated to indicate that backups
are not supported for hosted environments, but only if the
JES flag is enabled, to avoid confusion for those who are not
running with this feature yet.

(Review request: http://reviews.vapour.ws/r/2444/)