### PR TITLE
apiserver: allow connections to Dying & Dead environments

### DIFF
--- a/apiserver/utils.go
+++ b/apiserver/utils.go
@@ -78,10 +78,8 @@ func validateEnvironUUID(args validateArgs) (*state.State, error) {
 		return nil, errors.Trace(common.UnknownEnvironmentError(args.envUUID))
 	}
 	envTag := names.NewEnvironTag(args.envUUID)
-	if env, err := ssState.GetEnvironment(envTag); err != nil {
+	if _, err := ssState.GetEnvironment(envTag); err != nil {
 		return nil, errors.Wrap(err, common.UnknownEnvironmentError(args.envUUID))
-	} else if env.Life() != state.Alive {
-		return nil, errors.Errorf("environment %q is no longer live", args.envUUID)
 	}
 	logger.Debugf("validate env uuid: %s", args.envUUID)
 	st, err := args.statePool.Get(args.envUUID)

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -98,19 +98,3 @@ func (s *utilsSuite) TestValidateOtherEnvironmentStateServerOnly(c *gc.C) {
 		})
 	c.Assert(err, gc.ErrorMatches, `requested environment ".*" is not the state server environment`)
 }
-
-func (s *utilsSuite) TestValidateNonAliveEnvironment(c *gc.C) {
-	envState := s.Factory.MakeEnvironment(c, nil)
-	defer envState.Close()
-	env, err := envState.Environment()
-	c.Assert(err, jc.ErrorIsNil)
-	err = env.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = validateEnvironUUID(
-		validateArgs{
-			statePool: s.pool,
-			envUUID:   envState.EnvironUUID(),
-		})
-	c.Assert(err, gc.ErrorMatches, `environment ".*" is no longer live`)
-}


### PR DESCRIPTION
We want to allow things like status and logs for Dying or Dead environments. Operations such as creating machines aren't allowed for non-alive environments so this is fairly safe to allow.

(Review request: http://reviews.vapour.ws/r/2446/)