### PR TITLE
Fixed juju subnet list (added feature test)

### DIFF
--- a/api/subnets/subnets.go
+++ b/api/subnets/subnets.go
@@ -80,11 +80,17 @@ func (api *API) CreateSubnet(subnet names.SubnetTag, space names.SpaceTag, zones
 // ListSubnets fetches all the subnets known by the environment.
 func (api *API) ListSubnets(spaceTag *names.SpaceTag, zone string) ([]params.Subnet, error) {
 	var response params.ListSubnetsResults
-	params := params.ListSubnetsParams{
-		Filters: []params.ListSubnetsFilterParams{
-			{SpaceTag: spaceTag.String(), Zone: zone},
-		},
+	var space string
+	if spaceTag != nil {
+		space = spaceTag.String()
 	}
-	err := api.facade.FacadeCall("ListSubnets", params, &response)
-	return response.Results, err
+	args := params.SubnetsFilters{
+		SpaceTag: space,
+		Zone:     zone,
+	}
+	err := api.facade.FacadeCall("ListSubnets", args, &response)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return response.Results, nil
 }

--- a/api/subnets/subnets_test.go
+++ b/api/subnets/subnets_test.go
@@ -107,13 +107,12 @@ func makeCreateSubnetsArgs(cidr, space string, zones []string, isPublic bool) ap
 	return args
 }
 
-func makeListSubnetsArgs(space names.SpaceTag, zone string) apitesting.CheckArgs {
+func makeListSubnetsArgs(space *names.SpaceTag, zone string) apitesting.CheckArgs {
 	expectResults := params.ListSubnetsResults{}
-	expectArgs := params.ListSubnetsParams{
-		Filters: []params.ListSubnetsFilterParams{{
-			SpaceTag: space.String(),
-			Zone:     zone,
-		}}}
+	expectArgs := params.SubnetsFilters{
+		SpaceTag: space.String(),
+		Zone:     zone,
+	}
 	args := apitesting.CheckArgs{
 		Facade:  "Subnets",
 		Method:  "ListSubnets",
@@ -191,10 +190,10 @@ func (s *SubnetsSuite) TestCreateSubnetFails(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "bang")
 }
 
-func (s *SubnetsSuite) TestListSubnets(c *gc.C) {
+func (s *SubnetsSuite) TestListSubnetsNoResults(c *gc.C) {
 	space := names.NewSpaceTag("foo")
 	zone := "bar"
-	args := makeListSubnetsArgs(space, zone)
+	args := makeListSubnetsArgs(&space, zone)
 	s.prepareAPICall(c, &args, nil)
 	results, err := s.api.ListSubnets(&space, zone)
 	c.Assert(s.called, gc.Equals, 1)
@@ -207,7 +206,7 @@ func (s *SubnetsSuite) TestListSubnets(c *gc.C) {
 func (s *SubnetsSuite) TestListSubnetsFails(c *gc.C) {
 	space := names.NewSpaceTag("foo")
 	zone := "bar"
-	args := makeListSubnetsArgs(space, zone)
+	args := makeListSubnetsArgs(&space, zone)
 	s.prepareAPICall(c, &args, errors.New("bang"))
 	results, err := s.api.ListSubnets(&space, zone)
 	c.Assert(s.called, gc.Equals, 1)

--- a/apiserver/common/networking.go
+++ b/apiserver/common/networking.go
@@ -120,4 +120,7 @@ type NetworkBacking interface {
 
 	// AddSubnet creates a backing subnet for an existing subnet.
 	AddSubnet(BackingSubnetInfo) (BackingSubnet, error)
+
+	// AllSubnets returns all backing subnets.
+	AllSubnets() ([]BackingSubnet, error)
 }

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -502,14 +502,9 @@ type ListSubnetsResults struct {
 	Results []Subnet `json:"Results"`
 }
 
-// ListSubnetsParams holds the arguments of a ListSubnets API call.
-type ListSubnetsParams struct {
-	Filters []ListSubnetsFilterParams `json:"Filters"`
-}
-
-// ListSubnetsFilterParams holds an optional Space Tag and Availability Zone
-// for filtering the subnets returned by a ListSubnets call.
-type ListSubnetsFilterParams struct {
+// SubnetsFilters holds an optional SpaceTag and Zone for filtering
+// the subnets returned by a ListSubnets call.
+type SubnetsFilters struct {
 	SpaceTag string `json:"SpaceTag,omitempty"`
 	Zone     string `json:"Zone,omitempty"`
 }

--- a/apiserver/spaces/spaces_test.go
+++ b/apiserver/spaces/spaces_test.go
@@ -205,53 +205,42 @@ func (s *SpacesSuite) TestNoSubnets(c *gc.C) {
 }
 
 func (s *SpacesSuite) TestListSpacesDefault(c *gc.C) {
+	expected := []params.Space{{
+		Name: "default",
+		Subnets: []params.Subnet{{
+			CIDR:       "192.168.0.0/24",
+			ProviderId: "provider-192.168.0.0/24",
+			Zones:      []string{"foo"},
+			Status:     "in-use",
+			SpaceTag:   "space-default",
+		}, {
+			CIDR:       "192.168.3.0/24",
+			ProviderId: "provider-192.168.3.0/24",
+			VLANTag:    23,
+			Zones:      []string{"bar", "bam"},
+			SpaceTag:   "space-default",
+		}},
+	}, {
+		Name: "dmz",
+		Subnets: []params.Subnet{{
+			CIDR:       "192.168.1.0/24",
+			ProviderId: "provider-192.168.1.0/24",
+			VLANTag:    23,
+			Zones:      []string{"bar", "bam"},
+			SpaceTag:   "space-dmz",
+		}},
+	}, {
+		Name: "private",
+		Subnets: []params.Subnet{{
+			CIDR:       "192.168.2.0/24",
+			ProviderId: "provider-192.168.2.0/24",
+			Zones:      []string{"foo"},
+			Status:     "in-use",
+			SpaceTag:   "space-private",
+		}},
+	}}
 	spaces, err := s.facade.ListSpaces()
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []params.Space{
-		params.Space{
-			Name: "default",
-			Subnets: []params.Subnet{
-				params.Subnet{
-					CIDR:       "192.168.0.0/24",
-					ProviderId: "provider-192.168.0.0/24",
-					Zones:      []string{"foo"},
-					Status:     "in-use",
-					SpaceTag:   "space-default",
-				},
-				params.Subnet{
-					CIDR:       "192.168.3.0/24",
-					ProviderId: "provider-192.168.3.0/24",
-					VLANTag:    23,
-					Zones:      []string{"bar", "bam"},
-					SpaceTag:   "space-default",
-				},
-			},
-		},
-		params.Space{
-			Name: "dmz",
-			Subnets: []params.Subnet{
-				params.Subnet{
-					CIDR:       "192.168.1.0/24",
-					ProviderId: "provider-192.168.1.0/24",
-					VLANTag:    23,
-					Zones:      []string{"bar", "bam"},
-					SpaceTag:   "space-dmz",
-				},
-			},
-		},
-		params.Space{
-			Name: "private",
-			Subnets: []params.Subnet{
-				params.Subnet{
-					CIDR:       "192.168.2.0/24",
-					ProviderId: "provider-192.168.2.0/24",
-					Zones:      []string{"foo"},
-					Status:     "in-use",
-					SpaceTag:   "space-private",
-				},
-			},
-		},
-	}
 	c.Assert(spaces.Results, jc.DeepEquals, expected)
 }
 

--- a/apiserver/subnets/shims.go
+++ b/apiserver/subnets/shims.go
@@ -89,7 +89,6 @@ func (s *stateShim) EnvironConfig() (*config.Config, error) {
 }
 
 func (s *stateShim) AllSpaces() ([]common.BackingSpace, error) {
-	// TODO(dimitern): Make this ListSpaces() instead.
 	results, err := s.st.AllSpaces()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -115,6 +114,18 @@ func (s *stateShim) AddSubnet(info common.BackingSubnetInfo) (common.BackingSubn
 		SpaceName:        info.SpaceName,
 	})
 	return nil, err // Drop the first result, as it's unused.
+}
+
+func (s *stateShim) AllSubnets() ([]common.BackingSubnet, error) {
+	results, err := s.st.AllSubnets()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	subnets := make([]common.BackingSubnet, len(results))
+	for i, result := range results {
+		subnets[i] = &subnetShim{subnet: result}
+	}
+	return subnets, nil
 }
 
 type availZoneShim struct{}

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -454,6 +454,25 @@ func (sb *StubBacking) AllSpaces() ([]common.BackingSpace, error) {
 	return output, nil
 }
 
+func (sb *StubBacking) AllSubnets() ([]common.BackingSubnet, error) {
+	sb.MethodCall(sb, "AllSubnets")
+	if err := sb.NextErr(); err != nil {
+		return nil, err
+	}
+
+	// Filter duplicates.
+	seen := set.Strings{}
+	output := []common.BackingSubnet{}
+	for _, subnet := range sb.Subnets {
+		if seen.Contains(subnet.CIDR()) {
+			continue
+		}
+		seen.Add(subnet.CIDR())
+		output = append(output, subnet)
+	}
+	return output, nil
+}
+
 func (sb *StubBacking) AddSubnet(subnetInfo common.BackingSubnetInfo) (common.BackingSubnet, error) {
 	sb.MethodCall(sb, "AddSubnet", subnetInfo)
 	if err := sb.NextErr(); err != nil {

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/names"
-	"github.com/juju/utils/set"
 )
 
 // ListCommand displays a list of all subnets known to Juju
@@ -89,40 +88,6 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		// Validate space and/or zone, if given to display a nicer error
 		// message.
-		if c.spaceTag != nil {
-			spaces, err := api.AllSpaces()
-			if err != nil {
-				return errors.Annotate(err, "cannot list spaces")
-			}
-
-			spacesSet := set.NewTags(spaces...)
-			if !spacesSet.Contains(*c.spaceTag) {
-				sorted := spacesSet.SortedValues()
-				expected := make([]string, len(sorted))
-				for i, space := range sorted {
-					expected[i] = space.Id()
-				}
-				return errors.Errorf(
-					"%q is not a known space; expected one of: %s",
-					c.SpaceName, strings.Join(expected, ", "),
-				)
-			}
-		}
-		if c.ZoneName != "" {
-			zones, err := api.AllZones()
-			if err != nil {
-				return errors.Annotate(err, "cannot list zones")
-			}
-			zonesSet := set.NewStrings(zones...)
-			if !zonesSet.Contains(c.ZoneName) {
-				expected := strings.Join(zonesSet.SortedValues(), ", ")
-				return errors.Errorf(
-					"%q is not a known zone; expected one of: %s",
-					c.ZoneName, expected,
-				)
-			}
-		}
-
 		// Get the list of subnets, filtering them as requested.
 		subnets, err := api.ListSubnets(c.spaceTag, c.ZoneName)
 		if err != nil {

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -228,9 +228,9 @@ func (s *ListSuite) TestRunWhenNoneMatchSucceeds(c *gc.C) {
 		"--space", "default",
 	)
 
-	s.api.CheckCallNames(c, "AllSpaces", "ListSubnets", "Close")
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
 	tag := names.NewSpaceTag("default")
-	s.api.CheckCall(c, 1, "ListSubnets", &tag, "")
+	s.api.CheckCall(c, 0, "ListSubnets", &tag, "")
 }
 
 func (s *ListSuite) TestRunWhenNoSubnetsExistSucceeds(c *gc.C) {
@@ -268,9 +268,9 @@ subnets:
 		"--space", "public",
 	)
 
-	s.api.CheckCallNames(c, "AllSpaces", "ListSubnets", "Close")
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
 	tag := names.NewSpaceTag("public")
-	s.api.CheckCall(c, 1, "ListSubnets", &tag, "")
+	s.api.CheckCall(c, 0, "ListSubnets", &tag, "")
 	s.api.ResetCalls()
 
 	// Now filter by zone.
@@ -280,8 +280,8 @@ subnets:
 		"--zone", "zone1",
 	)
 
-	s.api.CheckCallNames(c, "AllZones", "ListSubnets", "Close")
-	s.api.CheckCall(c, 1, "ListSubnets", nil, "zone1")
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
+	s.api.CheckCall(c, 0, "ListSubnets", nil, "zone1")
 	s.api.ResetCalls()
 
 	// Finally, filter by both space and zone.
@@ -291,55 +291,9 @@ subnets:
 		"--zone", "zone1", "--space", "public",
 	)
 
-	s.api.CheckCallNames(c, "AllSpaces", "AllZones", "ListSubnets", "Close")
+	s.api.CheckCallNames(c, "ListSubnets", "Close")
 	tag = names.NewSpaceTag("public")
-	s.api.CheckCall(c, 2, "ListSubnets", &tag, "zone1")
-}
-
-func (s *ListSuite) TestRunWhenAllSpacesFails(c *gc.C) {
-	s.api.SetErrors(errors.NotValidf("foo"))
-
-	// Ensure the error cause is preserved.
-	err := s.AssertRunFails(c,
-		`cannot list spaces: foo not valid`,
-		"--space", "default",
-	)
-	c.Assert(err, jc.Satisfies, errors.IsNotValid)
-
-	s.api.CheckCallNames(c, "AllSpaces", "Close")
-}
-
-func (s *ListSuite) TestRunWithUnknownSpaceFails(c *gc.C) {
-	s.AssertRunFails(c,
-		// List of expected spaces is sorted.
-		`"foo" is not a known space; expected one of: default, dmz, public, vlan-42`,
-		"--space", "foo",
-	)
-
-	s.api.CheckCallNames(c, "AllSpaces", "Close")
-}
-
-func (s *ListSuite) TestRunWhenAllZonesFails(c *gc.C) {
-	s.api.SetErrors(errors.NotFoundf("bar"))
-
-	// Ensure the error cause is preserved.
-	err := s.AssertRunFails(c,
-		`cannot list zones: bar not found`,
-		"--zone", "zone1",
-	)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-
-	s.api.CheckCallNames(c, "AllZones", "Close")
-}
-
-func (s *ListSuite) TestRunWithUnknownZoneFails(c *gc.C) {
-	s.AssertRunFails(c,
-		// List of expected zones is sorted.
-		`"bar" is not a known zone; expected one of: zone1, zone2`,
-		"--zone", "bar",
-	)
-
-	s.api.CheckCallNames(c, "AllZones", "Close")
+	s.api.CheckCall(c, 0, "ListSubnets", &tag, "zone1")
 }
 
 func (s *ListSuite) TestRunWhenListSubnetFails(c *gc.C) {

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -163,13 +163,16 @@ func (s *cmdSubnetSuite) TestSubnetListResultsWithFilters(c *gc.C) {
 	})
 	s.AddSpace(c, "myspace", []string{"10.10.0.0/16"}, true)
 
-	expectedOutput := "{\"subnets\":{\"myspace\":{}}}\n"
 	context := s.RunSuper(c,
 		expectedSuccess,
 		"list", "--zone", "zone1", "--space", "myspace",
 	)
-	s.AssertOutput(c, context,
-		expectedOutput,
-		"", // no stderr output
-	)
+	c.Assert(testing.Stderr(context), gc.Equals, "") // no stderr expected
+	stdout := testing.Stdout(context)
+	c.Assert(stdout, jc.Contains, "subnets:")
+	c.Assert(stdout, jc.Contains, "10.10.0.0/16:")
+	c.Assert(stdout, jc.Contains, "space: myspace")
+	c.Assert(stdout, jc.Contains, "zones:")
+	c.Assert(stdout, jc.Contains, "- zone1")
+	c.Assert(stdout, gc.Not(jc.Contains), "10.0.0.0/8:")
 }

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -143,3 +143,33 @@ func (s *cmdSubnetSuite) TestSubnetAddWithZonesWithNoProviderZones(c *gc.C) {
 	c.Assert(subnet.ProviderId(), gc.Equals, "dummy-public")
 	c.Assert(subnet.AvailabilityZone(), gc.Equals, "zone1")
 }
+
+func (s *cmdSubnetSuite) TestSubnetListNoResults(c *gc.C) {
+	context := s.RunSuper(c, expectedSuccess, "list")
+	s.AssertOutput(c, context,
+		"", // no stdout output
+		"no subnets to display\n",
+	)
+}
+
+func (s *cmdSubnetSuite) TestSubnetListResultsWithFilters(c *gc.C) {
+	//	s.AddSpace(c, "myspace", nil, true)
+	s.AddSubnet(c, state.SubnetInfo{
+		CIDR: "10.0.0.0/8",
+	})
+	s.AddSubnet(c, state.SubnetInfo{
+		CIDR:             "10.10.0.0/16",
+		AvailabilityZone: "zone1",
+	})
+	s.AddSpace(c, "myspace", []string{"10.10.0.0/16"}, true)
+
+	expectedOutput := "{\"subnets\":{\"myspace\":{}}}\n"
+	context := s.RunSuper(c,
+		expectedSuccess,
+		"list", "--zone", "zone1", "--space", "myspace",
+	)
+	s.AssertOutput(c, context,
+		expectedOutput,
+		"", // no stderr output
+	)
+}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -960,11 +960,13 @@ func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo
 }
 
 // Subnets returns basic information about the specified subnets known
-// by the provider for the specified instance. Either instId or
-// subnetIds must be specified. Implements NetworkingEnviron.Subnets.
+// by the provider for the specified instance or list of ids. instId
+// equal to instance.UnknownId is the only supported value, other ones
+// result in NotSupportedError. subnetIds can be empty, in which case
+// all known are returned. Implements NetworkingEnviron.Subnets.
 func (e *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]network.SubnetInfo, error) {
-	if instId == "" && len(subnetIds) == 0 {
-		return nil, errors.Errorf("either instId or subnetIds must be set")
+	if instId != instance.UnknownId {
+		return nil, errors.NotSupportedf("instId")
 	}
 	ec2Inst := e.ec2()
 	// We can't filter by instance id here, unfortunately.
@@ -1021,6 +1023,7 @@ func (e *environ) Subnets(instId instance.Id, subnetIds []network.Id) ([]network
 			VLANTag:           0, // Not supported on EC2
 			AllocatableIPLow:  allocatableLow,
 			AllocatableIPHigh: allocatableHigh,
+			AvailabilityZones: []string{subnet.AvailZone},
 		}
 		logger.Tracef("found subnet with info %#v", info)
 		results = append(results, info)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -876,22 +876,39 @@ func (t *localServerSuite) TestSubnets(c *gc.C) {
 	subnets, err := env.Subnets("", []network.Id{"subnet-0"})
 	c.Assert(err, jc.ErrorIsNil)
 
+	// These are defined in the test server for the testing default
+	// VPC.
 	defaultSubnets := []network.SubnetInfo{{
-		// this is defined in the test server for the default-vpc
 		CIDR:              "10.10.0.0/24",
 		ProviderId:        "subnet-0",
 		VLANTag:           0,
 		AllocatableIPLow:  net.ParseIP("10.10.0.4").To4(),
 		AllocatableIPHigh: net.ParseIP("10.10.0.254").To4(),
+	}, {
+		CIDR:              "10.10.1.0/24",
+		ProviderId:        "subnet-1",
+		VLANTag:           0,
+		AllocatableIPLow:  net.ParseIP("10.10.1.4").To4(),
+		AllocatableIPHigh: net.ParseIP("10.10.1.254").To4(),
+	}, {
+		CIDR:              "10.10.2.0/24",
+		ProviderId:        "subnet-2",
+		VLANTag:           0,
+		AllocatableIPLow:  net.ParseIP("10.10.2.4").To4(),
+		AllocatableIPHigh: net.ParseIP("10.10.2.254").To4(),
 	}}
+	c.Assert(subnets, jc.DeepEquals, defaultSubnets[:1])
+
+	subnets, err = env.Subnets("ignored", nil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, jc.DeepEquals, defaultSubnets)
 }
 
-func (t *localServerSuite) TestSubnetsNoNetIds(c *gc.C) {
+func (t *localServerSuite) TestSubnetsNeitherInstIdsNorSubnetIds(c *gc.C) {
 	env, _ := t.setUpInstanceWithDefaultVpc(c)
 
 	_, err := env.Subnets("", []network.Id{})
-	c.Assert(err, gc.ErrorMatches, "subnetIds must not be empty")
+	c.Assert(err, gc.ErrorMatches, "either instId or subnetIds must be set")
 }
 
 func (t *localServerSuite) TestSubnetsMissingSubnet(c *gc.C) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -884,31 +884,34 @@ func (t *localServerSuite) TestSubnets(c *gc.C) {
 		VLANTag:           0,
 		AllocatableIPLow:  net.ParseIP("10.10.0.4").To4(),
 		AllocatableIPHigh: net.ParseIP("10.10.0.254").To4(),
+		AvailabilityZones: []string{"test-available"},
 	}, {
 		CIDR:              "10.10.1.0/24",
 		ProviderId:        "subnet-1",
 		VLANTag:           0,
 		AllocatableIPLow:  net.ParseIP("10.10.1.4").To4(),
 		AllocatableIPHigh: net.ParseIP("10.10.1.254").To4(),
+		AvailabilityZones: []string{"test-impaired"},
 	}, {
 		CIDR:              "10.10.2.0/24",
 		ProviderId:        "subnet-2",
 		VLANTag:           0,
 		AllocatableIPLow:  net.ParseIP("10.10.2.4").To4(),
 		AllocatableIPHigh: net.ParseIP("10.10.2.254").To4(),
+		AvailabilityZones: []string{"test-unavailable"},
 	}}
 	c.Assert(subnets, jc.DeepEquals, defaultSubnets[:1])
 
-	subnets, err = env.Subnets("ignored", nil)
+	subnets, err = env.Subnets(instance.UnknownId, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, jc.DeepEquals, defaultSubnets)
 }
 
-func (t *localServerSuite) TestSubnetsNeitherInstIdsNorSubnetIds(c *gc.C) {
+func (t *localServerSuite) TestSubnetsInstIdNotSupported(c *gc.C) {
 	env, _ := t.setUpInstanceWithDefaultVpc(c)
 
-	_, err := env.Subnets("", []network.Id{})
-	c.Assert(err, gc.ErrorMatches, "either instId or subnetIds must be set")
+	_, err := env.Subnets("foo", []network.Id{})
+	c.Assert(err, gc.ErrorMatches, "instId not supported")
 }
 
 func (t *localServerSuite) TestSubnetsMissingSubnet(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -1305,6 +1305,22 @@ func (st *State) Subnet(cidr string) (*Subnet, error) {
 	return &Subnet{st, *doc}, nil
 }
 
+// AllSubnets returns all known subnets in the environment.
+func (st *State) AllSubnets() (subnets []*Subnet, err error) {
+	subnetsCollection, closer := st.getCollection(subnetsC)
+	defer closer()
+
+	docs := []subnetDoc{}
+	err = subnetsCollection.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get all subnets")
+	}
+	for _, doc := range docs {
+		subnets = append(subnets, &Subnet{st, doc})
+	}
+	return subnets, nil
+}
+
 // AddNetwork creates a new network with the given params. If a
 // network with the same name or provider id already exists in state,
 // an error satisfying errors.IsAlreadyExists is returned.

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -217,6 +217,31 @@ func (s *SubnetSuite) TestRefresh(c *gc.C) {
 	c.Assert(subnetCopy.Life(), gc.Equals, state.Dead)
 }
 
+func (s *SubnetSuite) TestAllSubnets(c *gc.C) {
+	subnetInfos := []state.SubnetInfo{
+		{CIDR: "192.168.1.0/24"},
+		{CIDR: "8.8.8.0/24", SpaceName: "bar"},
+		{CIDR: "10.0.2.0/24", ProviderId: "foo"},
+		{CIDR: "2001:db8::/64", AvailabilityZone: "zone1"},
+	}
+
+	for _, info := range subnetInfos {
+		_, err := s.State.AddSubnet(info)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	subnets, err := s.State.AllSubnets()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(subnets, gc.HasLen, len(subnetInfos))
+
+	for i, subnet := range subnets {
+		c.Assert(subnet.CIDR(), gc.Equals, subnetInfos[i].CIDR)
+		c.Assert(subnet.ProviderId(), gc.Equals, subnetInfos[i].ProviderId)
+		c.Assert(subnet.SpaceName(), gc.Equals, subnetInfos[i].SpaceName)
+		c.Assert(subnet.AvailabilityZone(), gc.Equals, subnetInfos[i].AvailabilityZone)
+	}
+}
+
 func (s *SubnetSuite) TestPickNewAddressNoAddresses(c *gc.C) {
 	subnetInfo := state.SubnetInfo{
 		CIDR:              "192.168.1.0/24",


### PR DESCRIPTION
The arguments of ListSubnets needed to change to actually do something
useful. A few fixes needed to make the feature test work for juju subnet
list.

During live testing on EC2 a few more changes were necessary to make
sure both add and list work on AWS (e.g. allowing Subnets without ids to
get all of them).

(Review request: http://reviews.vapour.ws/r/2448/)