### PR TITLE
Possible fixes for lp:1457130 and lp:1455627

### DIFF
--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -96,6 +96,7 @@ func (s *pingerSuite) TestAgentConnectionShutsDownWithNoPing(c *gc.C) {
 
 func (s *pingerSuite) TestAgentConnectionDelaysShutdownWithPing(c *gc.C) {
 	const shortTimeout = 100 * time.Millisecond
+	const attemptDelay = shortTimeout / 4
 	s.PatchValue(apiserver.MaxClientPingInterval, time.Duration(shortTimeout))
 
 	st, _ := s.OpenAPIAsNewMachine(c)
@@ -103,10 +104,35 @@ func (s *pingerSuite) TestAgentConnectionDelaysShutdownWithPing(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// As long as we don't wait too long, the connection stays open
-	for i := 0; i < 10; i++ {
-		time.Sleep(shortTimeout / 4)
+	attempt := utils.AttemptStrategy{
+		Min:   10,
+		Delay: attemptDelay,
+	}
+	testStart := time.Now()
+	c.Logf(
+		"pinging %d times with %v delay, starting at %v",
+		attempt.Min, attempt.Delay, testStart,
+	)
+	var lastLoop time.Time
+	for a := attempt.Start(); a.Next(); {
+		testNow := time.Now()
+		loopDelta := testNow.Sub(lastLoop)
+		if lastLoop.IsZero() {
+			loopDelta = 0
+		}
+		c.Logf("duration since last iteration: %v", loopDelta)
 		err = st.Ping()
-		c.Assert(err, jc.ErrorIsNil)
+		if !c.Check(
+			err, jc.ErrorIsNil,
+			gc.Commentf(
+				"pinger timeout exceeded at %v (%v since the test start)",
+				testNow, testNow.Sub(testNow),
+			),
+		) {
+			c.Check(err, gc.ErrorMatches, "connection is shut down")
+			return
+		}
+		lastLoop = time.Now()
 	}
 
 	// However, once we stop pinging for too long, the connection dies

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -95,7 +95,7 @@ func (s *pingerSuite) TestAgentConnectionShutsDownWithNoPing(c *gc.C) {
 }
 
 func (s *pingerSuite) TestAgentConnectionDelaysShutdownWithPing(c *gc.C) {
-	const shortTimeout = 20 * time.Millisecond
+	const shortTimeout = 100 * time.Millisecond
 	s.PatchValue(apiserver.MaxClientPingInterval, time.Duration(shortTimeout))
 
 	st, _ := s.OpenAPIAsNewMachine(c)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -743,8 +743,10 @@ func (s *MachineSuite) testAddresserNewWorkerResult(c *gc.C, expectFinished bool
 		w, err := addresser.NewWorker(api)
 		c.Check(err, jc.ErrorIsNil)
 		if expectFinished {
+			// When the address-allocation feature flag is disabled.
 			c.Check(w, gc.FitsTypeOf, worker.FinishedWorker{})
 		} else {
+			// When the address-allocation feature flag is enabled.
 			c.Check(w, gc.Not(gc.FitsTypeOf), worker.FinishedWorker{})
 		}
 		return w, err

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -670,7 +670,11 @@ func (s *MachineSuite) TestManageEnvironRunsInstancePoller(c *gc.C) {
 	usefulVersion := version.Current
 	usefulVersion.Series = "quantal" // to match the charm created below
 	envtesting.AssertUploadFakeToolsVersions(
-		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), usefulVersion)
+		c, s.DefaultToolsStorage,
+		s.Environ.Config().AgentStream(),
+		s.Environ.Config().AgentStream(),
+		usefulVersion,
+	)
 	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
 	a := s.newAgent(c, m)
 	defer a.Stop()
@@ -730,7 +734,12 @@ func (s *MachineSuite) TestManageEnvironRunsPeergrouper(c *gc.C) {
 }
 
 func (s *MachineSuite) testAddresserNewWorkerResult(c *gc.C, expectFinished bool) {
+	started := make(chan struct{}, 1)
 	s.PatchValue(&newAddresser, func(api *apiaddresser.API) (worker.Worker, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
 		w, err := addresser.NewWorker(api)
 		c.Check(err, jc.ErrorIsNil)
 		if expectFinished {
@@ -743,21 +752,24 @@ func (s *MachineSuite) testAddresserNewWorkerResult(c *gc.C, expectFinished bool
 
 	m, _, _ := s.primeAgent(c, version.Current, state.JobManageEnviron)
 	a := s.newAgent(c, m)
-	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	defer a.Stop()
+	go func() {
+		c.Check(a.Run(nil), jc.ErrorIsNil)
+	}()
 
-	// Wait for firewaller as last worker.
-	s.singularRecord.nextRunner(c)
-	runner := s.singularRecord.nextRunner(c)
-	runner.waitForWorker(c, "firewaller")
+	select {
+	case <-started:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for addresser to start")
+	}
 }
 
-func (s *MachineSuite) TestAddresserWorkerRunsIfFeatureFlagEnabled(c *gc.C) {
+func (s *MachineSuite) TestAddresserWorkerDoesNotStopWhenAddressDeallocationSupported(c *gc.C) {
 	s.SetFeatureFlags(feature.AddressAllocation)
 	s.testAddresserNewWorkerResult(c, false)
 }
 
-func (s *MachineSuite) TestAddresserWorkerIsFineshedIfFeatureFlagDisabled(c *gc.C) {
+func (s *MachineSuite) TestAddresserWorkerStopsWhenAddressDeallocationNotSupported(c *gc.C) {
 	s.SetFeatureFlags()
 	s.testAddresserNewWorkerResult(c, true)
 }


### PR DESCRIPTION
Increased the timeout for this frequently flaky test:
pingerSuite.TestAgentConnectionDelaysShutdownWithPing

Hopefully this will make it more reliable on slower
machines/LXC/Windows.

Also improved the test around instancepoller:
MachineSuite.TestManageEnvironRunsInstancePoller

Both were reproducible on my machine, although not always.
With these I fixes I see no more regressions.

(Review request: http://reviews.vapour.ws/r/2454/)