### PR TITLE
state: clean up properly in allwatcher tests

### DIFF
--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2787,6 +2787,7 @@ type testWatcher struct {
 	st     *State
 	c      *gc.C
 	b      Backing
+	sm     *storeManager
 	w      *Multiwatcher
 	deltas chan []multiwatcher.Delta
 }
@@ -2798,6 +2799,7 @@ func newTestWatcher(b Backing, st *State, c *gc.C) *testWatcher {
 		st:     st,
 		c:      c,
 		b:      b,
+		sm:     sm,
 		w:      w,
 		deltas: make(chan []multiwatcher.Delta),
 	}
@@ -2872,7 +2874,8 @@ func (tw *testWatcher) All(expectedCount int) []multiwatcher.Delta {
 
 func (tw *testWatcher) Stop() {
 	tw.c.Assert(tw.w.Stop(), jc.ErrorIsNil)
-	tw.b.Release()
+	tw.c.Assert(tw.sm.Stop(), jc.ErrorIsNil)
+	tw.c.Assert(tw.b.Release(), jc.ErrorIsNil)
 }
 
 func (tw *testWatcher) AssertNoChange() {


### PR DESCRIPTION
The testWatcher used for the allwatcher tests has always been leaving a running storeManager goroutine running. This hasn't actually been much of a problem until the recent introduction of the allEnvWatcher. With the allEnvWatcher, if an event arrived after testWatcher.Stop() was called new State instances would get created causing our test infrastructure to notice the leaked mongodb connection and panic.

The storeManager is now stopped before closing down the backing store.

(Review request: http://reviews.vapour.ws/r/2456/)