### PR TITLE
state: all(Env)Watcher.TestStateWatcher reliability fixes

### DIFF
--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -703,7 +703,48 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 		},
 	}})
 
-	// Make some changes to the state.
+	// Destroy a machine and make sure that's seen.
+	err = m1.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	deltas = tw.All(1)
+	zeroOutTimestampsForDeltas(c, deltas)
+	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
+		Entity: &multiwatcher.MachineInfo{
+			EnvUUID:    s.state.EnvironUUID(),
+			Id:         "1",
+			Status:     multiwatcher.Status("pending"),
+			StatusData: map[string]interface{}{},
+			Life:       multiwatcher.Life("dying"),
+			Series:     "saucy",
+			Jobs:       []multiwatcher.MachineJob{JobHostUnits.ToParams()},
+			Addresses:  []network.Address{},
+			HasVote:    false,
+			WantsVote:  false,
+		},
+	}})
+
+	err = m1.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	deltas = tw.All(1)
+	zeroOutTimestampsForDeltas(c, deltas)
+	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
+		Entity: &multiwatcher.MachineInfo{
+			EnvUUID:    s.state.EnvironUUID(),
+			Id:         "1",
+			Status:     multiwatcher.Status("pending"),
+			StatusData: map[string]interface{}{},
+			Life:       multiwatcher.Life("dead"),
+			Series:     "saucy",
+			Jobs:       []multiwatcher.MachineJob{JobHostUnits.ToParams()},
+			Addresses:  []network.Address{},
+			HasVote:    false,
+			WantsVote:  false,
+		},
+	}})
+
+	// Make some more changes to the state.
 	arch := "amd64"
 	mem := uint64(4096)
 	hc := &instance.HardwareCharacteristics{
@@ -713,10 +754,6 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	err = m0.SetProvisioned("i-0", "bootstrap_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = m1.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-	err = m1.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
 	err = m1.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -753,14 +790,8 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	}, {
 		Removed: true,
 		Entity: &multiwatcher.MachineInfo{
-			EnvUUID:    s.state.EnvironUUID(),
-			Id:         "1",
-			Status:     multiwatcher.Status("pending"),
-			StatusData: map[string]interface{}{},
-			Life:       multiwatcher.Life("alive"),
-			Series:     "saucy",
-			Jobs:       []multiwatcher.MachineJob{JobHostUnits.ToParams()},
-			Addresses:  []network.Address{},
+			EnvUUID: s.state.EnvironUUID(),
+			Id:      "1",
 		},
 	}, {
 		Entity: &multiwatcher.MachineInfo{
@@ -1263,15 +1294,52 @@ func (s *allEnvWatcherStateSuite) TestStateWatcher(c *gc.C) {
 		},
 	}})
 
-	// Make some changes to the state, including the addition of a new
-	// environment.
+	// Destroy a machine and make sure that's seen.
+	err = m10.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	deltas = tw.All(1)
+	zeroOutTimestampsForDeltas(c, deltas)
+	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
+		Entity: &multiwatcher.MachineInfo{
+			EnvUUID:    st1.EnvironUUID(),
+			Id:         "0",
+			Status:     multiwatcher.Status("pending"),
+			StatusData: map[string]interface{}{},
+			Life:       multiwatcher.Life("dying"),
+			Series:     "saucy",
+			Jobs:       []multiwatcher.MachineJob{JobHostUnits.ToParams()},
+			Addresses:  []network.Address{},
+			HasVote:    false,
+			WantsVote:  false,
+		},
+	}})
+
+	err = m10.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+
+	deltas = tw.All(1)
+	zeroOutTimestampsForDeltas(c, deltas)
+	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
+		Entity: &multiwatcher.MachineInfo{
+			EnvUUID:    st1.EnvironUUID(),
+			Id:         "0",
+			Status:     multiwatcher.Status("pending"),
+			StatusData: map[string]interface{}{},
+			Life:       multiwatcher.Life("dead"),
+			Series:     "saucy",
+			Jobs:       []multiwatcher.MachineJob{JobHostUnits.ToParams()},
+			Addresses:  []network.Address{},
+			HasVote:    false,
+			WantsVote:  false,
+		},
+	}})
+
+	// Make further changes to the state, including the addition of a
+	// new environment.
 	err = m00.SetProvisioned("i-0", "bootstrap_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = m10.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-	err = m10.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
 	err = m10.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1295,7 +1363,6 @@ func (s *allEnvWatcherStateSuite) TestStateWatcher(c *gc.C) {
 
 	// Look for the state changes from the allwatcher.
 	deltas = tw.All(7)
-
 	zeroOutTimestampsForDeltas(c, deltas)
 
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
@@ -1316,14 +1383,8 @@ func (s *allEnvWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	}, {
 		Removed: true,
 		Entity: &multiwatcher.MachineInfo{
-			EnvUUID:    st1.EnvironUUID(),
-			Id:         "0",
-			Status:     multiwatcher.Status("pending"),
-			StatusData: map[string]interface{}{},
-			Life:       multiwatcher.Life("alive"),
-			Series:     "saucy",
-			Jobs:       []multiwatcher.MachineJob{JobHostUnits.ToParams()},
-			Addresses:  []network.Address{},
+			EnvUUID: st1.EnvironUUID(),
+			Id:      "0",
 		},
 	}, {
 		Entity: &multiwatcher.MachineInfo{


### PR DESCRIPTION
The destruction and removal of a machine could be reported in an unpredictable number of events if allowed to coalesce. Changed the tests to look for the deltas for each machine destruction step separately to avoid intermittent failures.

(Review request: http://reviews.vapour.ws/r/2457/)