### PR TITLE
Fixed constraints handling and improved tests, partially reverting an earlier change

### DIFF
--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -286,7 +286,7 @@ var parseConstraintsTests = []struct {
 	// networks
 	{
 		summary: "single network",
-		args:    []string{"networks=space1"},
+		args:    []string{"networks=net1"},
 	}, {
 		summary: "multiple networks - positive",
 		args:    []string{"networks=net1,net2"},

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1124,7 +1124,7 @@ func (s *allEnvWatcherStateSuite) TestChangeEnvironments(c *gc.C) {
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), s.owner)
-			err := svc.SetConstraints(constraints.MustParse("mem=4G cpu-cores= arch=amd64"))
+			err := svc.SetConstraints(constraints.MustParse("mem=4G arch=amd64"))
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -2008,7 +2008,7 @@ func testChangeServicesConstraints(c *gc.C, owner names.UserTag, runChangeTests 
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			svc := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
-			err := svc.SetConstraints(constraints.MustParse("mem=4G cpu-cores= arch=amd64"))
+			err := svc.SetConstraints(constraints.MustParse("mem=4G arch=amd64"))
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
@@ -16,102 +17,50 @@ import (
 
 // constraintsDoc is the mongodb representation of a constraints.Value.
 type constraintsDoc struct {
-	EnvUUID      string                 `bson:"env-uuid"`
-	Arch         string                 `bson:",omitempty"`
-	CpuCores     uint64                 `bson:",omitempty"`
-	CpuPower     uint64                 `bson:",omitempty"`
-	Mem          uint64                 `bson:",omitempty"`
-	RootDisk     uint64                 `bson:",omitempty"`
-	InstanceType string                 `bson:",omitempty"`
-	Container    instance.ContainerType `bson:",omitempty"`
-	Tags         []string               `bson:",omitempty"`
-	Spaces       []string               `bson:",omitempty"`
+	EnvUUID      string `bson:"env-uuid"`
+	Arch         *string
+	CpuCores     *uint64
+	CpuPower     *uint64
+	Mem          *uint64
+	RootDisk     *uint64
+	InstanceType *string
+	Container    *instance.ContainerType
+	Tags         *[]string
+	Spaces       *[]string
 	// TODO(dimitern): Drop this once it's not possible to specify
 	// networks= in constraints.
-	Networks []string `bson:",omitempty"`
+	Networks *[]string
 }
 
 func (doc constraintsDoc) value() constraints.Value {
-	var container *instance.ContainerType
-	if len(doc.Container) > 0 {
-		container = &doc.Container
-	}
 	return constraints.Value{
-		Arch:         stringpIfSet(doc.Arch),
-		CpuCores:     uint64pIfSet(doc.CpuCores),
-		CpuPower:     uint64pIfSet(doc.CpuPower),
-		Mem:          uint64pIfSet(doc.Mem),
-		RootDisk:     uint64pIfSet(doc.RootDisk),
-		InstanceType: stringpIfSet(doc.InstanceType),
-		Container:    container,
-		Tags:         stringslicepIfSet(doc.Tags),
-		Spaces:       stringslicepIfSet(doc.Spaces),
-		Networks:     stringslicepIfSet(doc.Networks),
+		Arch:         doc.Arch,
+		CpuCores:     doc.CpuCores,
+		CpuPower:     doc.CpuPower,
+		Mem:          doc.Mem,
+		RootDisk:     doc.RootDisk,
+		InstanceType: doc.InstanceType,
+		Container:    doc.Container,
+		Tags:         doc.Tags,
+		Spaces:       doc.Spaces,
+		Networks:     doc.Networks,
 	}
-}
-
-func uint64pIfSet(v uint64) *uint64 {
-	if v > 0 {
-		return &v
-	}
-	return nil
-}
-
-func stringpIfSet(v string) *string {
-	if len(v) > 0 {
-		return &v
-	}
-	return nil
-}
-
-func stringslicepIfSet(v []string) *[]string {
-	if len(v) > 0 {
-		return &v
-	}
-	return nil
 }
 
 func newConstraintsDoc(st *State, cons constraints.Value) constraintsDoc {
-	doc := constraintsDoc{EnvUUID: st.EnvironUUID()}
-	// Make sure we don't store in state truly empty constraints:
-	//   (*[]string)(nil)
-	//   (*[]string)(&v)  (where v := []string(nil))
-	//   (*[]string)(&w)  (where w := []string{})
-	//   (*string)(nil)
-	//   (*string)(&s)    (where s := "")
-	//   (*uint64)(nil)
-	//   (*uint64)(&u)    (where u := 0)
-	if cons.Arch != nil && len(*cons.Arch) > 0 {
-		doc.Arch = *cons.Arch
+	return constraintsDoc{
+		EnvUUID:      st.EnvironUUID(),
+		Arch:         cons.Arch,
+		CpuCores:     cons.CpuCores,
+		CpuPower:     cons.CpuPower,
+		Mem:          cons.Mem,
+		RootDisk:     cons.RootDisk,
+		InstanceType: cons.InstanceType,
+		Container:    cons.Container,
+		Tags:         cons.Tags,
+		Spaces:       cons.Spaces,
+		Networks:     cons.Networks,
 	}
-	if cons.CpuCores != nil && *cons.CpuCores > 0 {
-		doc.CpuCores = *cons.CpuCores
-	}
-	if cons.CpuPower != nil && *cons.CpuPower > 0 {
-		doc.CpuPower = *cons.CpuPower
-	}
-	if cons.Mem != nil && *cons.Mem > 0 {
-		doc.Mem = *cons.Mem
-	}
-	if cons.RootDisk != nil && *cons.RootDisk > 0 {
-		doc.RootDisk = *cons.RootDisk
-	}
-	if cons.InstanceType != nil && len(*cons.InstanceType) > 0 {
-		doc.InstanceType = *cons.InstanceType
-	}
-	if cons.Container != nil && len(*cons.Container) > 0 {
-		doc.Container = *cons.Container
-	}
-	if cons.Tags != nil && len(*cons.Tags) > 0 {
-		doc.Tags = *cons.Tags
-	}
-	if cons.Spaces != nil && len(*cons.Spaces) > 0 {
-		doc.Spaces = *cons.Spaces
-	}
-	if cons.Networks != nil && len(*cons.Networks) > 0 {
-		doc.Networks = *cons.Networks
-	}
-	return doc
 }
 
 func createConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {
@@ -123,14 +72,12 @@ func createConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {
 	}
 }
 
-func setConstraintsOps(st *State, id string, cons constraints.Value) []txn.Op {
-	// Remove any existing constraints doc before re-creating it. This
-	// way we replace the doc rather than leaving lingering values
-	// from (most likely incorrect) earlier versions, just because
-	// they're not set on cons.
-	return []txn.Op{
-		removeConstraintsOp(st, id),
-		createConstraintsOp(st, id, cons),
+func setConstraintsOp(st *State, id string, cons constraints.Value) txn.Op {
+	return txn.Op{
+		C:      constraintsC,
+		Id:     st.docID(id),
+		Assert: txn.DocExists,
+		Update: bson.D{{"$set", newConstraintsDoc(st, cons)}},
 	}
 }
 
@@ -156,7 +103,7 @@ func readConstraints(st *State, id string) (constraints.Value, error) {
 }
 
 func writeConstraints(st *State, id string, cons constraints.Value) error {
-	ops := setConstraintsOps(st, id, cons)
+	ops := []txn.Op{setConstraintsOp(st, id, cons)}
 	if err := st.runTransaction(ops); err != nil {
 		return fmt.Errorf("cannot set constraints: %v", err)
 	}

--- a/state/machine.go
+++ b/state/machine.go
@@ -1434,7 +1434,7 @@ func (m *Machine) SetConstraints(cons constraints.Value) (err error) {
 		return err
 	}
 
-	ops = append(ops, setConstraintsOps(m.st, m.globalKey(), mcons)...)
+	ops = append(ops, setConstraintsOp(m.st, m.globalKey(), mcons))
 	// make multiple attempts to push the ErrExcessiveContention case out of the
 	// realm of plausibility: it implies local state indicating unprovisioned,
 	// and remote state indicating provisioned (reasonable); but which changes

--- a/state/service.go
+++ b/state/service.go
@@ -748,7 +748,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		if err != nil {
 			return "", nil, err
 		}
-		ops = append(ops, setConstraintsOps(s.st, agentGlobalKey, cons)...)
+		ops = append(ops, createConstraintsOp(s.st, agentGlobalKey, cons))
 	}
 
 	// At the last moment we still have the statusDocs in scope, set the initial
@@ -1091,7 +1091,7 @@ func (s *Service) SetConstraints(cons constraints.Value) (err error) {
 		Id:     s.doc.DocID,
 		Assert: isAliveDoc,
 	}}
-	ops = append(ops, setConstraintsOps(s.st, s.globalKey(), cons)...)
+	ops = append(ops, setConstraintsOp(s.st, s.globalKey(), cons))
 	return onAbort(s.st.runTransaction(ops), errNotAlive)
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -901,12 +901,12 @@ func (s *upgradesSuite) TestAddEnvUUIDToConstraints(c *gc.C) {
 
 	var newDoc constraintsDoc
 	s.FindId(c, coll, newIDs[0], &newDoc)
-	c.Assert(newDoc.CpuCores, gc.Equals, uint64(4))
-	c.Assert(newDoc.Networks, jc.DeepEquals, networks1)
+	c.Assert(*newDoc.CpuCores, gc.Equals, uint64(4))
+	c.Assert(*newDoc.Networks, jc.DeepEquals, networks1)
 
 	s.FindId(c, coll, newIDs[1], &newDoc)
-	c.Assert(newDoc.CpuCores, gc.Equals, uint64(8))
-	c.Assert(newDoc.Networks, jc.DeepEquals, networks2)
+	c.Assert(*newDoc.CpuCores, gc.Equals, uint64(8))
+	c.Assert(*newDoc.Networks, jc.DeepEquals, networks2)
 }
 
 func (s *upgradesSuite) TestAddEnvUUIDToConstraintsIdempotent(c *gc.C) {


### PR DESCRIPTION
Reverted most of the behavior changing changes from PR #3026, as
discussed with fwereade. Kept the extended tests. All constraints are
now handled uniformly and always stored as set (including empty values).

It is now possible to override a list-style (tags, spaces, networks)
constraint with an empty value, unlike before #3026.

(Review request: http://reviews.vapour.ws/r/2463/)