### PR TITLE
Use ParseReference rather than InferURL

### DIFF
--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -149,7 +149,7 @@ func (c *DeployCommand) Init(args []string) error {
 		c.ServiceName = args[1]
 		fallthrough
 	case 1:
-		if _, err := charm.InferURL(args[0], "fake"); err != nil {
+		if _, err := charm.ParseReference(args[0]); err != nil {
 			return fmt.Errorf("invalid charm name %q", args[0])
 		}
 		c.CharmName = args[0]

--- a/cmd/juju/commands/publish.go
+++ b/cmd/juju/commands/publish.go
@@ -99,7 +99,7 @@ func (c *PublishCommand) Run(ctx *cmd.Context) (err error) {
 			}
 		}
 	} else {
-		ref, err = charm.ParseReference(c.URL)
+		ref, err := charm.ParseReference(c.URL)
 		if err != nil {
 			return err
 		}

--- a/cmd/juju/commands/publish.go
+++ b/cmd/juju/commands/publish.go
@@ -99,7 +99,11 @@ func (c *PublishCommand) Run(ctx *cmd.Context) (err error) {
 			}
 		}
 	} else {
-		curl, err = charm.InferURL(c.URL, "")
+		ref, err = charm.ParseReference(c.URL)
+		if err != nil {
+			return err
+		}
+		curl, err = ref.URL("")
 		if err != nil {
 			return err
 		}

--- a/cmd/juju/commands/publish_test.go
+++ b/cmd/juju/commands/publish_test.go
@@ -143,7 +143,7 @@ func (s *PublishSuite) TestWrongRepository(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "charm URL must reference the juju charm store")
 }
 
-func (s *PublishSuite) TestInferURL(c *gc.C) {
+func (s *PublishSuite) TestParseReference(c *gc.C) {
 	addMeta(c, s.branch, "")
 
 	cmd := &PublishCommand{}

--- a/cmd/juju/commands/publish_test.go
+++ b/cmd/juju/commands/publish_test.go
@@ -114,7 +114,7 @@ func (s *PublishSuite) TestFrom(c *gc.C) {
 
 func (s *PublishSuite) TestMissingSeries(c *gc.C) {
 	_, err := s.runPublish(c, "cs:wordpress")
-	c.Assert(err, gc.ErrorMatches, `cannot infer charm URL for "cs:wordpress": charm url series is not resolved`)
+	c.Assert(err, gc.ErrorMatches, `charm url series is not resolved`)
 }
 
 func (s *PublishSuite) TestNotClean(c *gc.C) {


### PR DESCRIPTION
InferURL is [deprecated](https://github.com/juju/charm/blob/v5/url.go#L240) in favor of ParseReference, and future work around charm URLs will be taking place within ParseReference.

(Review request: http://reviews.vapour.ws/r/2467/)