### PR TITLE
Fix 1484789: add-machine fails with hosted envs

### DIFF
--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -82,6 +82,9 @@ type EnvCommandBase struct {
 	// compatVersion defines the minimum CLI version
 	// that this command should be compatible with.
 	compatVerson *int
+
+	envGetterClient EnvironmentGetter
+	envGetterErr    error
 }
 
 func (c *EnvCommandBase) SetEnvName(envName string) {
@@ -96,6 +99,20 @@ func (c *EnvCommandBase) NewAPIClient() (*api.Client, error) {
 	return root.Client(), nil
 }
 
+// NewEnvironmentGetter returns a new object which implements the
+// EnvironmentGetter interface.
+func (c *EnvCommandBase) NewEnvironmentGetter() (EnvironmentGetter, error) {
+	if c.envGetterErr != nil {
+		return nil, c.envGetterErr
+	}
+
+	if c.envGetterClient != nil {
+		return c.envGetterClient, nil
+	}
+
+	return c.NewAPIClient()
+}
+
 func (c *EnvCommandBase) NewAPIRoot() (api.Connection, error) {
 	// This is work in progress as we remove the EnvName from downstream code.
 	// We want to be able to specify the environment in a number of ways, one of
@@ -106,12 +123,34 @@ func (c *EnvCommandBase) NewAPIRoot() (api.Connection, error) {
 	return juju.NewAPIFromName(c.envName)
 }
 
-func (c *EnvCommandBase) Config(store configstore.Storage) (*config.Config, error) {
+// Config returns the configuration for the environment; obtaining bootstrap
+// information from the API if necessary.  If callers already have an active
+// client API connection, it will be used.  Otherwise, a new API connection will
+// be used if necessary.
+func (c *EnvCommandBase) Config(store configstore.Storage, client EnvironmentGetter) (*config.Config, error) {
 	if c.envName == "" {
 		return nil, errors.Trace(ErrNoEnvironmentSpecified)
 	}
 	cfg, _, err := environs.ConfigForName(c.envName, store)
-	return cfg, err
+	if err == nil {
+		return cfg, err
+	} else if !environs.IsEmptyConfig(err) {
+		return nil, errors.Trace(err)
+	}
+
+	if client == nil {
+		client, err = c.NewEnvironmentGetter()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		defer client.Close()
+	}
+
+	bootstrapCfg, err := client.EnvironmentGet()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return config.New(config.NoDefaults, bootstrapCfg)
 }
 
 // ConnectionCredentials returns the credentials used to connect to the API for
@@ -302,6 +341,7 @@ func BootstrapContextNoVerify(cmdContext *cmd.Context) environs.BootstrapContext
 
 type EnvironmentGetter interface {
 	EnvironmentGet() (map[string]interface{}, error)
+	Close() error
 }
 
 // GetEnvironmentVersion retrieves the environment's agent-version

--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -133,7 +133,7 @@ func (c *EnvCommandBase) Config(store configstore.Storage, client EnvironmentGet
 	}
 	cfg, _, err := environs.ConfigForName(c.envName, store)
 	if err == nil {
-		return cfg, err
+		return cfg, nil
 	} else if !environs.IsEmptyConfig(err) {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/envcmd/export_test.go
+++ b/cmd/envcmd/export_test.go
@@ -9,3 +9,13 @@ var (
 	GetConfigStore                = &getConfigStore
 	EndpointRefresher             = &endpointRefresher
 )
+
+// NewEnvCommandBase returns a new EnvCommandBase with the environment name, client,
+// and error as specified for testing purposes.
+func NewEnvCommandBase(name string, client EnvironmentGetter, err error) *EnvCommandBase {
+	return &EnvCommandBase{
+		envName:         name,
+		envGetterClient: client,
+		envGetterErr:    err,
+	}
+}

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -134,7 +134,7 @@ func (c *RestoreCommand) rebootstrap(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	cfg, err := c.Config(store)
+	cfg, err := c.Config(store, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -209,7 +209,7 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 	var config *config.Config
 	if defaultStore, err := configstore.Default(); err != nil {
 		return err
-	} else if config, err = c.Config(defaultStore); err != nil {
+	} else if config, err = c.Config(defaultStore, client); err != nil {
 		return err
 	}
 

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -28,7 +28,7 @@ type ImageMetadataCommandBase struct {
 }
 
 func (c *ImageMetadataCommandBase) prepare(context *cmd.Context, store configstore.Storage) (environs.Environ, error) {
-	cfg, err := c.Config(store)
+	cfg, err := c.Config(store, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "could not get config from store")
 	}

--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -232,7 +232,7 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := c.Config(store)
+	cfg, err := c.Config(store, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixed EnvCommandBase to get bootstrap information
from the API if it doesn't exist in the configstore
(just like the system destroy command).

(Review request: http://reviews.vapour.ws/r/2468/)