### PR TITLE
Merge pull request #2943 from perrito666/fix_1.24_history_worker_tests

### DIFF
--- a/worker/diskmanager/diskmanager.go
+++ b/worker/diskmanager/diskmanager.go
@@ -46,7 +46,7 @@ func NewWorker(l ListBlockDevicesFunc, b BlockDeviceSetter) worker.Worker {
 	f := func(stop <-chan struct{}) error {
 		return doWork(l, b, &old)
 	}
-	return worker.NewPeriodicWorker(f, listBlockDevicesPeriod)
+	return worker.NewPeriodicWorker(f, listBlockDevicesPeriod, worker.NewTimer)
 }
 
 func doWork(listf ListBlockDevicesFunc, b BlockDeviceSetter, old *[]storage.BlockDevice) error {

--- a/worker/metricworker/cleanup.go
+++ b/worker/metricworker/cleanup.go
@@ -35,5 +35,5 @@ func NewCleanup(client metricsmanager.MetricsManagerClient) worker.Worker {
 		}
 		return nil
 	}
-	return worker.NewPeriodicWorker(f, cleanupPeriod)
+	return worker.NewPeriodicWorker(f, cleanupPeriod, worker.NewTimer)
 }

--- a/worker/metricworker/sender.go
+++ b/worker/metricworker/sender.go
@@ -35,5 +35,5 @@ func NewSender(client metricsmanager.MetricsManagerClient) worker.Worker {
 		}
 		return nil
 	}
-	return worker.NewPeriodicWorker(f, senderPeriod)
+	return worker.NewPeriodicWorker(f, senderPeriod, worker.NewTimer)
 }

--- a/worker/periodicworker_test.go
+++ b/worker/periodicworker_test.go
@@ -28,7 +28,7 @@ func (s *periodicWorkerSuite) TestWait(c *gc.C) {
 		return testError
 	}
 
-	w := NewPeriodicWorker(doWork, defaultPeriod)
+	w := NewPeriodicWorker(doWork, defaultPeriod, NewTimer)
 	defer func() { c.Assert(Stop(w), gc.Equals, testError) }()
 	select {
 	case <-funcHasRun:
@@ -54,7 +54,7 @@ func (s *periodicWorkerSuite) TestWaitNil(c *gc.C) {
 		return nil
 	}
 
-	w := NewPeriodicWorker(doWork, defaultPeriod)
+	w := NewPeriodicWorker(doWork, defaultPeriod, NewTimer)
 	defer func() { c.Assert(Stop(w), gc.IsNil) }()
 	select {
 	case <-funcHasRun:
@@ -94,7 +94,7 @@ func runKillTest(c *gc.C, returnValue, expected error) {
 		return returnValue
 	}
 
-	w := NewPeriodicWorker(doWork, defaultPeriod)
+	w := NewPeriodicWorker(doWork, defaultPeriod, NewTimer)
 	defer func() { c.Assert(Stop(w), gc.Equals, expected) }()
 
 	select {
@@ -126,7 +126,7 @@ func (s *periodicWorkerSuite) TestCallUntilKilled(c *gc.C) {
 
 	period := time.Millisecond * 500
 	unacceptableWait := time.Second * 10
-	w := NewPeriodicWorker(doWork, period)
+	w := NewPeriodicWorker(doWork, period, NewTimer)
 	defer func() { c.Assert(Stop(w), gc.IsNil) }()
 	for i := 0; i < 5; i++ {
 		select {

--- a/worker/statushistorypruner/export_test.go
+++ b/worker/statushistorypruner/export_test.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statushistorypruner
+
+import (
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+)
+
+func NewPruneWorker(st *state.State, params *HistoryPrunerParams, t worker.NewTimerFunc, psh pruneHistoryFunc) worker.Worker {
+	w := &pruneWorker{
+		st:     st,
+		params: params,
+		pruner: psh,
+	}
+	return worker.NewPeriodicWorker(w.doPruning, w.params.PruneInterval, t)
+}

--- a/worker/statushistorypruner/package_test.go
+++ b/worker/statushistorypruner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statushistorypruner_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/statushistorypruner/worker_test.go
+++ b/worker/statushistorypruner/worker_test.go
@@ -1,0 +1,87 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package statushistorypruner_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/statushistorypruner"
+)
+
+type mockTimer struct {
+	period time.Duration
+	c      chan time.Time
+}
+
+func (t *mockTimer) Reset(d time.Duration) bool {
+	t.period = d
+	return true
+}
+
+func (t *mockTimer) CountDown() <-chan time.Time {
+	return t.c
+}
+
+func (t *mockTimer) fire() error {
+	select {
+	case t.c <- time.Time{}:
+	case <-time.After(coretesting.LongWait):
+		return errors.New("timed out waiting for pruner to run")
+	}
+	return nil
+}
+
+func newMockTimer(d time.Duration) worker.PeriodicTimer {
+	return &mockTimer{period: d,
+		c: make(chan time.Time),
+	}
+}
+
+var _ = gc.Suite(&statusHistoryPrunerSuite{})
+
+type statusHistoryPrunerSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *statusHistoryPrunerSuite) TestWorker(c *gc.C) {
+	var passedMaxLogs int
+	fakePruner := func(_ *state.State, maxLogs int) error {
+		passedMaxLogs = maxLogs
+		return nil
+	}
+	params := statushistorypruner.HistoryPrunerParams{
+		MaxLogsPerState: 3,
+		PruneInterval:   coretesting.ShortWait,
+	}
+	fakeTimer := newMockTimer(coretesting.LongWait)
+
+	fakeTimerFunc := func(d time.Duration) worker.PeriodicTimer {
+		// construction of timer should be with 0 because we intend it to
+		// run once before waiting.
+		c.Assert(d, gc.Equals, 0*time.Nanosecond)
+		return fakeTimer
+	}
+	pruner := statushistorypruner.NewPruneWorker(
+		&state.State{},
+		&params,
+		fakeTimerFunc,
+		fakePruner,
+	)
+	s.AddCleanup(func(*gc.C) {
+		pruner.Kill()
+		c.Assert(pruner.Wait(), jc.ErrorIsNil)
+	})
+	err := fakeTimer.(*mockTimer).fire()
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(passedMaxLogs, gc.Equals, 3)
+	// Reset will have been called with the actual PruneInterval
+	c.Assert(fakeTimer.(*mockTimer).period, gc.Equals, coretesting.ShortWait)
+}


### PR DESCRIPTION
Add tests to statushistorypruner worker

statushistorypruner individual functions where unittested but not the worker.
I added tests plus modified PeriodicWorker to be testable with custom timer implementations.

(Review request: http://reviews.vapour.ws/r/2322/)

(Review request: http://reviews.vapour.ws/r/2472/)