### PR TITLE
Fix lp1488581 - patch arch.HostArch

### DIFF
--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -203,6 +203,8 @@ func (s *toolsSuite) TestFindToolsExactInStorage(c *gc.C) {
 			{Version: version.MustParseBinary("1.22.0-trusty-amd64")},
 		},
 	}
+
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	s.PatchValue(&version.Current, version.MustParseBinary("1.22-beta1-trusty-amd64"))
 	s.testFindToolsExact(c, mockToolsStorage, true, true)
 	s.PatchValue(&version.Current, version.MustParseBinary("1.22.0-trusty-amd64"))

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -296,6 +296,7 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(
 	currentVersion.Arch = "amd64"
 	currentVersion.Tag = ""
 	s.PatchValue(&version.Current, currentVersion)
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -224,6 +224,7 @@ func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
 }
 
 func (s *toolsSuite) TestFindAvailableToolsAutoUpload(c *gc.C) {
+	s.PatchValue(&version.Current.Arch, "amd64")
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	trustyTools := &tools.Tools{
 		Version: version.MustParseBinary("1.2.3-trusty-amd64"),

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -224,7 +224,7 @@ func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
 }
 
 func (s *toolsSuite) TestFindAvailableToolsAutoUpload(c *gc.C) {
-	s.PatchValue(&version.Current.Arch, "amd64")
+	s.PatchValue(&version.Current.Arch, arch.AMD64)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	trustyTools := &tools.Tools{
 		Version: version.MustParseBinary("1.2.3-trusty-amd64"),


### PR DESCRIPTION
Added in patching of arch.HostArch in a few
tests which failed on non-amd64 archs.

(Review request: http://reviews.vapour.ws/r/2482/)