### PR TITLE
environs/bootstrap: remove patching of version.Current.Arch

### DIFF
--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -119,8 +119,12 @@ func locallyBuildableTools() (buildable coretools.List) {
 		if os, err := version.GetOSFromSeries(series); err != nil || os != version.Current.OS {
 			continue
 		}
-		binary := version.Current
-		binary.Series = series
+		binary := version.Binary {
+			Number: version.Current.Number,
+			Series: series,
+			Arch: arch.HostArch(),
+			OS: version.Current.OS,
+		}
 		// Increment the build number so we know it's a development build.
 		binary.Build++
 		buildable = append(buildable, &coretools.Tools{Version: binary})

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -224,7 +224,6 @@ func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
 }
 
 func (s *toolsSuite) TestFindAvailableToolsAutoUpload(c *gc.C) {
-	s.PatchValue(&version.Current.Arch, arch.AMD64)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	trustyTools := &tools.Tools{
 		Version: version.MustParseBinary("1.2.3-trusty-amd64"),
@@ -259,8 +258,12 @@ func (s *toolsSuite) TestFindAvailableToolsCompleteNoValidate(c *gc.C) {
 
 	var allTools tools.List
 	for _, series := range version.SupportedSeries() {
-		binary := version.Current
-		binary.Series = series
+		binary := version.Binary {
+			Number: version.Current.Number,
+			Series: series,
+			Arch: arch.HostArch(),
+			OS: version.Current.OS,
+		}
 		allTools = append(allTools, &tools.Tools{
 			Version: binary,
 			URL:     "http://testing.invalid/tools.tar.gz",


### PR DESCRIPTION
Remove remaining instances of patching `version.Current.Arch` in favour of patching `arch.HostArch`

(Review request: http://reviews.vapour.ws/r/2483/)