### PR TITLE
environs/bootstrap: remove patching of version.Current.Arch

### DIFF
--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -126,8 +126,6 @@ func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 		c.Skip("issue 1403084: Currently does not work because of jujud problems")
 	}
 
-	// TODO(dfc) this should not be necessary
-	s.PatchValue(&version.Current.Arch, "arm64")
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
 	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
@@ -145,8 +143,6 @@ func (s *bootstrapSuite) TestBootstrapNoToolsDevelopmentConfig(c *gc.C) {
 		c.Skip("issue 1403084: Currently does not work because of jujud problems")
 	}
 
-	// TODO(dfc) this should not be necessary
-	s.PatchValue(&version.Current.Arch, "arm64")
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
 	s.PatchValue(bootstrap.FindTools, func(environs.Environ, int, int, string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")
@@ -447,7 +443,7 @@ func (e *bootstrapEnviron) Storage() storage.Storage {
 
 func (e *bootstrapEnviron) SupportedArchitectures() ([]string, error) {
 	e.supportedArchitecturesCount++
-	return []string{"amd64", "arm64"}, nil
+	return []string{arch.AMD64, arch.ARM64}, nil
 }
 
 func (e *bootstrapEnviron) ConstraintsValidator() (constraints.Validator, error) {

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -119,11 +119,11 @@ func locallyBuildableTools() (buildable coretools.List) {
 		if os, err := version.GetOSFromSeries(series); err != nil || os != version.Current.OS {
 			continue
 		}
-		binary := version.Binary {
+		binary := version.Binary{
 			Number: version.Current.Number,
 			Series: series,
-			Arch: arch.HostArch(),
-			OS: version.Current.OS,
+			Arch:   arch.HostArch(),
+			OS:     version.Current.OS,
 		}
 		// Increment the build number so we know it's a development build.
 		binary.Build++

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -258,11 +258,11 @@ func (s *toolsSuite) TestFindAvailableToolsCompleteNoValidate(c *gc.C) {
 
 	var allTools tools.List
 	for _, series := range version.SupportedSeries() {
-		binary := version.Binary {
+		binary := version.Binary{
 			Number: version.Current.Number,
 			Series: series,
-			Arch: arch.HostArch(),
-			OS: version.Current.OS,
+			Arch:   arch.HostArch(),
+			OS:     version.Current.OS,
 		}
 		allTools = append(allTools, &tools.Tools{
 			Version: binary,


### PR DESCRIPTION
Remove remaining instances of patching `version.Current.Arch`

(Review request: http://reviews.vapour.ws/r/2484/)