### PR TITLE
cloudconfig: sha256 windows userdata fix

### DIFF
--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -813,6 +813,17 @@ Function GUnZip-File{
 	rm $tempFile
 }
 
+Function Get-FileSHA256{
+	Param(
+		$FilePath
+	)
+	$hash = [Security.Cryptography.HashAlgorithm]::Create( "SHA256" )
+	$stream = ([IO.StreamReader]$FilePath).BaseStream
+	$res = -join ($hash.ComputeHash($stream) | ForEach { "{0:x2}" -f $_ })
+	$stream.Close()
+	return $res
+}
+
 $juju_passwd = Get-RandomPassword 20
 $juju_passwd += "^"
 create-account jujud "Juju Admin user" $juju_passwd

--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -527,7 +527,7 @@ namespace Tarer
 				}
 			}
 		}
-		
+
 		public void Read(Stream dataDestination)
 		{
 			int readBytes;
@@ -566,12 +566,12 @@ namespace Tarer
 				bytesRemainingToRead -= bytesRead;
 				remainingBytesInFile -= bytesRead;
 			}
-			
+
 			if(inStream.CanSeek && align512 > 0)
 			{
 				inStream.Seek(align512, SeekOrigin.Current);
 			}
-			else 
+			else
 			{
 				while(align512 > 0)
 				{
@@ -579,7 +579,7 @@ namespace Tarer
 					--align512;
 				}
 			}
-				
+
 			buffer = dataBuffer;
 			return bytesRead;
 		}
@@ -753,7 +753,7 @@ namespace Tarer
 					{
 						break;
 					}
-				}	  
+				}
 				if (position == value.Length)
 				{
 					position = value.Length - 100;

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -80,7 +80,7 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		`$WebClient = New-Object System.Net.WebClient`,
 		`[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}`,
 		fmt.Sprintf(`ExecRetry { $WebClient.DownloadFile('%s', "$binDir\tools.tar.gz") }`, w.icfg.Tools.URL),
-		`$dToolsHash = (Get-FileHash -Algorithm SHA256 "$binDir\tools.tar.gz").hash`,
+		`$dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"`,
 		fmt.Sprintf(`$dToolsHash > "$binDir\juju%s.sha256"`,
 			w.icfg.Tools.Version),
 		fmt.Sprintf(`if ($dToolsHash.ToLower() -ne "%s"){ Throw "Tools checksum mismatch"}`,

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -520,7 +520,7 @@ namespace Tarer
 				}
 			}
 		}
-		
+
 		public void Read(Stream dataDestination)
 		{
 			int readBytes;
@@ -559,12 +559,12 @@ namespace Tarer
 				bytesRemainingToRead -= bytesRead;
 				remainingBytesInFile -= bytesRead;
 			}
-			
+
 			if(inStream.CanSeek && align512 > 0)
 			{
 				inStream.Seek(align512, SeekOrigin.Current);
 			}
-			else 
+			else
 			{
 				while(align512 > 0)
 				{
@@ -572,7 +572,7 @@ namespace Tarer
 					--align512;
 				}
 			}
-				
+
 			buffer = dataBuffer;
 			return bytesRead;
 		}
@@ -746,7 +746,7 @@ namespace Tarer
 					{
 						break;
 					}
-				}	  
+				}
 				if (position == value.Length)
 				{
 					position = value.Length - 100;


### PR DESCRIPTION
The method we were using before does not work on older powershell versions.

(Review request: http://reviews.vapour.ws/r/2487/)