### PR TITLE
cloudconfig: windows userdata acl fix

### DIFF
--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -52,6 +52,7 @@ func (w *windowsConfigure) ConfigureBasic() error {
 		fmt.Sprintf(`mkdir "%s"`, binDir),
 		fmt.Sprintf(`mkdir "%s\locks"`, renderer.FromSlash(dataDir)),
 	)
+	w.conf.AddScripts(`setx /m PATH "$env:PATH;C:\Juju\bin\"`)
 	noncefile := renderer.Join(dataDir, NonceFile)
 	w.conf.AddScripts(
 		fmt.Sprintf(`Set-Content "%s" "%s"`, noncefile, shquote(w.icfg.MachineNonce)),

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -55,11 +55,11 @@ func (w *windowsConfigure) ConfigureBasic() error {
 		// Some providers create a baseDir before this step, but we need to
 		// make sure it exists before applying icacls
 		fmt.Sprintf(`mkdir -Force "%s"`, renderer.FromSlash(baseDir)),
-		fmt.Sprintf(`icacls "%s" /grant "jujud:(OI)(CI)(F)" /T`, renderer.FromSlash(baseDir)),
 		fmt.Sprintf(`mkdir %s`, renderer.FromSlash(tmpDir)),
 		fmt.Sprintf(`mkdir "%s"`, binDir),
 		fmt.Sprintf(`mkdir "%s\locks"`, renderer.FromSlash(dataDir)),
 	)
+	w.conf.AddScripts(setACLs(renderer.FromSlash(baseDir), fileSystem)...)
 	w.conf.AddScripts(`setx /m PATH "$env:PATH;C:\Juju\bin\"`)
 	noncefile := renderer.Join(dataDir, NonceFile)
 	w.conf.AddScripts(

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -17,6 +17,13 @@ import (
 	"github.com/juju/juju/juju/paths"
 )
 
+type aclType string
+
+const (
+	fileSystem    aclType = "FileSystem"
+	registryEntry aclType = "Registry"
+)
+
 type windowsConfigure struct {
 	baseConfigure
 }
@@ -44,6 +51,7 @@ func (w *windowsConfigure) ConfigureBasic() error {
 
 	w.conf.AddScripts(
 		fmt.Sprintf(`%s`, winPowershellHelperFunctions),
+
 		// Some providers create a baseDir before this step, but we need to
 		// make sure it exists before applying icacls
 		fmt.Sprintf(`mkdir -Force "%s"`, renderer.FromSlash(baseDir)),
@@ -107,17 +115,12 @@ func (w *windowsConfigure) ConfigureJuju() error {
 // permissions on it such that it's only accessible to administrators
 // It is exported because it is used in an upgrade step
 func CreateJujuRegistryKeyCmds() []string {
-	return []string{
+	aclCmds := setACLs(osenv.JujuRegistryKey, registryEntry)
+	regCmds := []string{
+
 		// Create a registry key for storing juju related information
 		fmt.Sprintf(`New-Item -Path '%s'`, osenv.JujuRegistryKey),
-		fmt.Sprintf(`$acl = Get-Acl -Path '%s'`, osenv.JujuRegistryKey),
 
-		// Reset the ACL's on it and add administrator access only.
-		`$acl.SetAccessRuleProtection($true, $false)`,
-		`$perm = "BUILTIN\Administrators", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"`,
-		`$rule = New-Object System.Security.AccessControl.RegistryAccessRule $perm`,
-		`$acl.SetAccessRule($rule)`,
-		fmt.Sprintf(`Set-Acl -Path '%s' -AclObject $acl`, osenv.JujuRegistryKey),
 		// Create a JUJU_DEV_FEATURE_FLAGS entry which may or may not be empty.
 		fmt.Sprintf(`New-ItemProperty -Path '%s' -Name '%s'`,
 			osenv.JujuRegistryKey,
@@ -126,5 +129,26 @@ func CreateJujuRegistryKeyCmds() []string {
 			osenv.JujuRegistryKey,
 			osenv.JujuFeatureFlagEnvKey,
 			featureflag.AsEnvironmentValue()),
+	}
+	return append(regCmds[:1], append(aclCmds, regCmds[1:]...)...)
+}
+
+func setACLs(path string, permType aclType) []string {
+	ruleModel := `$rule = New-Object System.Security.AccessControl.%sAccessRule %s`
+	permModel := `%s = "%s", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"`
+	adminPermVar := `$adminPerm`
+	jujudPermVar := `$jujudPerm`
+	return []string{
+		fmt.Sprintf(`$acl = Get-Acl -Path '%s'`, path),
+
+		// Reset the ACL's on it and add administrator access only.
+		`$acl.SetAccessRuleProtection($true, $false)`,
+		fmt.Sprintf(permModel, adminPermVar, `BUILTIN\Administrators`),
+		fmt.Sprintf(permModel, jujudPermVar, `jujud`),
+		fmt.Sprintf(ruleModel, permType, adminPermVar),
+		`$acl.AddAccessRule($rule)`,
+		fmt.Sprintf(ruleModel, permType, jujudPermVar),
+		`$acl.AddAccessRule($rule)`,
+		fmt.Sprintf(`Set-Acl -Path '%s' -AclObject $acl`, path),
 	}
 }

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -846,9 +846,12 @@ Set-Content $binDir\downloaded-tools.txt '{"version":"1.2.3-win8-amd64","url":"h
 New-Item -Path 'HKLM:\SOFTWARE\juju-core'
 $acl = Get-Acl -Path 'HKLM:\SOFTWARE\juju-core'
 $acl.SetAccessRuleProtection($true, $false)
-$perm = "BUILTIN\Administrators", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
-$rule = New-Object System.Security.AccessControl.RegistryAccessRule $perm
-$acl.SetAccessRule($rule)
+$adminPerm = "BUILTIN\Administrators", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
+$jujudPerm = "jujud", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
+$rule = New-Object System.Security.AccessControl.RegistryAccessRule $adminPerm
+$acl.AddAccessRule($rule)
+$rule = New-Object System.Security.AccessControl.RegistryAccessRule $jujudPerm
+$acl.AddAccessRule($rule)
 Set-Acl -Path 'HKLM:\SOFTWARE\juju-core' -AclObject $acl
 New-ItemProperty -Path 'HKLM:\SOFTWARE\juju-core' -Name 'JUJU_DEV_FEATURE_FLAGS'
 Set-ItemProperty -Path 'HKLM:\SOFTWARE\juju-core' -Name 'JUJU_DEV_FEATURE_FLAGS' -Value ''

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -826,10 +826,19 @@ $jujuCreds = New-Object System.Management.Automation.PSCredential ($juju_user, $
 
 
 mkdir -Force "C:\Juju"
-icacls "C:\Juju" /grant "jujud:(OI)(CI)(F)" /T
 mkdir C:\Juju\tmp
 mkdir "C:\Juju\bin"
 mkdir "C:\Juju\lib\juju\locks"
+$acl = Get-Acl -Path 'C:\Juju'
+$acl.SetAccessRuleProtection($true, $false)
+$adminPerm = "BUILTIN\Administrators", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
+$jujudPerm = "jujud", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
+$rule = New-Object System.Security.AccessControl.FileSystemAccessRule $adminPerm
+$acl.AddAccessRule($rule)
+$rule = New-Object System.Security.AccessControl.FileSystemAccessRule $jujudPerm
+$acl.AddAccessRule($rule)
+Set-Acl -Path 'C:\Juju' -AclObject $acl
+setx /m PATH "$env:PATH;C:\Juju\bin\"
 Set-Content "C:\Juju\lib\juju\nonce.txt" "'FAKE_NONCE'"
 $binDir="C:\Juju\lib\juju\tools\1.2.3-win8-amd64"
 mkdir 'C:\Juju\log\juju'


### PR DESCRIPTION
While hunting for other bugs I discovered the C:\Juju folder actually had permissions for everybody not only jujud(icacls was just adding jujud to the list). This makes sure that C:\Juju has the same permissions as the registry key.

It also adds C:\Juju\bin pack to PATH, that was removed in the untar PR.

(Review request: http://reviews.vapour.ws/r/2488/)