### PR TITLE
Don't set CPU power if instance-type supplied.

### DIFF
--- a/environs/instances/image.go
+++ b/environs/instances/image.go
@@ -4,11 +4,13 @@
 package instances
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 
 	"github.com/juju/loggo"
 
+	"github.com/juju/errors"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/juju/arch"
@@ -54,83 +56,201 @@ type InstanceSpec struct {
 	order int
 }
 
-// FindInstanceSpec returns an InstanceSpec satisfying the supplied InstanceConstraint.
-// possibleImages contains a list of images matching the InstanceConstraint.
-// allInstanceTypes provides information on every known available instance type (name, memory, cpu cores etc) on
-// which instances can be run. The InstanceConstraint is used to filter allInstanceTypes and then a suitable image
-// compatible with the matching instance types is returned.
-func FindInstanceSpec(possibleImages []Image, ic *InstanceConstraint, allInstanceTypes []InstanceType) (*InstanceSpec, error) {
-	if len(possibleImages) == 0 {
-		return nil, fmt.Errorf("no %q images in %s with arches %s",
-			ic.Series, ic.Region, ic.Arches)
-	}
+type ImagePredicateFn func(Image) bool
 
-	matchingTypes, err := MatchingInstanceTypes(allInstanceTypes, ic.Region, ic.Constraints)
-	if err != nil {
-		return nil, err
-	}
-	if len(matchingTypes) == 0 {
-		return nil, fmt.Errorf("no instance types found matching constraint: %s", ic)
-	}
-
-	specs := []*InstanceSpec{}
-	for _, itype := range matchingTypes {
-		for _, image := range possibleImages {
-			if image.match(itype) {
-				specs = append(specs, &InstanceSpec{
-					InstanceType: itype,
-					Image:        image,
-					order:        len(specs),
-				})
+func (p ImagePredicateFn) And(preds ...ImagePredicateFn) ImagePredicateFn {
+	return func(i Image) bool {
+		for _, p := range append([]ImagePredicateFn{p}, preds...) {
+			if p == nil {
+				continue
+			} else if p(i) == false {
+				return false
 			}
 		}
-	}
-	if len(specs) > 0 {
-		sort.Sort(byArch(specs))
-		logger.Infof("find instance - using image with id: %v", specs[0].Image.Id)
-		return specs[0], nil
-	}
-
-	names := make([]string, len(matchingTypes))
-	for i, itype := range matchingTypes {
-		names[i] = itype.Name
-	}
-	return nil, fmt.Errorf("no %q images in %s matching instance types %v", ic.Series, ic.Region, names)
-}
-
-// byArch sorts InstanceSpecs first by descending word-size, then
-// alphabetically by name, and choose the first spec in the sequence.
-type byArch []*InstanceSpec
-
-func (a byArch) Len() int {
-	return len(a)
-}
-
-func (a byArch) Less(i, j int) bool {
-	iArchName := a[i].Image.Arch
-	jArchName := a[j].Image.Arch
-	iArch := arch.Info[iArchName]
-	jArch := arch.Info[jArchName]
-	// Wider word-size first.
-	switch {
-	case iArch.WordSize > jArch.WordSize:
 		return true
-	case iArch.WordSize < jArch.WordSize:
+	}
+}
+
+func (p ImagePredicateFn) Or(preds ...ImagePredicateFn) ImagePredicateFn {
+	return func(i Image) bool {
+		for _, p := range append([]ImagePredicateFn{p}, preds...) {
+			if p == nil {
+				continue
+			} else if p(i) {
+				return true
+			}
+		}
 		return false
 	}
-	// Alphabetically by arch name.
-	switch {
-	case iArchName < jArchName:
-		return true
-	case iArchName > jArchName:
-		return false
-	}
-	// If word-size and name the same, keep stable.
-	return a[i].order < a[j].order
 }
 
-func (a byArch) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
+func ImgMatchesInstanceType(instanceType InstanceType) ImagePredicateFn {
+	return func(image Image) bool {
+		return image.match(instanceType)
+	}
+}
+
+func ImgHasArch(arch *string) ImagePredicateFn {
+	return func(i Image) bool {
+		return arch == nil || *arch == i.Arch
+	}
+}
+
+func ImgHasVirtType(virtType *string) ImagePredicateFn {
+	return func(i Image) bool {
+		return virtType == nil || *virtType == i.VirtType
+	}
+}
+
+func ImgMatchesConstraint(constraint constraints.Value) ImagePredicateFn {
+	return ImagePredicateFn.And(
+		ImgHasArch(constraint.Arch),
+	)
+}
+
+func FilterImages(possibleImages []Image, matches ImagePredicateFn) []Image {
+	goodInstances := make([]Image, 0, len(possibleImages))
+	for _, image := range possibleImages {
+		if matches(image) == false {
+			continue
+		}
+		goodInstances = append(goodInstances, image)
+	}
+
+	return goodInstances
+}
+
+// FindInstanceSpec returns an InstanceSpec satisfying the supplied
+// InstanceConstraint. possibleImages contains a list of images
+// matching the InstanceConstraint. allInstanceTypes provides
+// information on every known available instance type (name, memory,
+// cpu cores etc) on which instances can be run. The
+// InstanceConstraint is used to filter allInstanceTypes and then a
+// suitable image compatible with the matching instance types is
+// returned.
+func FindInstanceSpec(
+	possibleImages []Image,
+	ic *InstanceConstraint,
+	instanceTypes []InstanceType,
+) (*InstanceSpec, error) {
+
+	for _, t := range instanceTypes {
+		fmt.Fprintf(&DebugBuffer, "(1)instanceType: %+v\n", t)
+		if t.VirtType != nil {
+			fmt.Fprintf(&DebugBuffer, "\t(1)virtType: %s\n", *t.VirtType)
+		}
+		if t.CpuPower != nil {
+			fmt.Fprintf(&DebugBuffer, "\t(1)cpuPower: %d\n", *t.CpuPower)
+		}
+	}
+
+	matches := MatchesConstraintsOrMinMem(ic.Constraints, minMemoryHeuristic)
+
+	instanceTypes = FilterInstanceTypes(instanceTypes, matches)
+	if len(instanceTypes) <= 0 {
+		return nil, fmt.Errorf("no instance types in %s matching constraints %q", ic.Region, ic.Constraints)
+	}
+	sort.Sort(byCost(instanceTypes))
+
+	var imagesFilter ImagePredicateFn
+	for _, instanceType := range instanceTypes {
+		imagesFilter = ImagePredicateFn.Or(
+			imagesFilter,
+			ImgMatchesInstanceType(instanceType),
+		)
+	}
+	imagesFilter = ImagePredicateFn.And(imagesFilter, ImgMatchesConstraint(ic.Constraints))
+
+	possibleImages = FilterImages(possibleImages, imagesFilter)
+
+	bestImages := findAlphaNumericallyFirstArchName(
+		findLargestWordSize(
+			possibleImages,
+			func(a string) int { return arch.Info[a].WordSize },
+		),
+	)
+	if len(bestImages) <= 0 {
+		fmt.Fprintf(&DebugBuffer, "(A)instanceTypes: %v\n", instanceTypes)
+		fmt.Fprintf(&DebugBuffer, "(A)possibleImages: %v\n", possibleImages)
+		return nil, generateImagesNotFoundError(ic, instanceTypes)
+	}
+	bestImage := bestImages[0]
+
+	for _, instanceType := range instanceTypes {
+		if bestImage.match(instanceType) {
+			for _, t := range instanceTypes {
+				fmt.Fprintf(&DebugBuffer, "(C)instanceType: %+v\n", t)
+				if t.VirtType != nil {
+					fmt.Fprintf(&DebugBuffer, "\t(C)virtType: %s\n", *t.VirtType)
+				}
+				if t.CpuPower != nil {
+					fmt.Fprintf(&DebugBuffer, "\t(C)cpuPower: %d\n", *t.CpuPower)
+				}
+			}
+			fmt.Fprintf(&DebugBuffer, "(C)possibleImages: %+v\n", possibleImages)
+			return &InstanceSpec{
+				InstanceType: instanceType,
+				Image:        bestImage,
+			}, nil
+		}
+	}
+
+	fmt.Printf("(B) possibleImages: %v", possibleImages)
+	return nil, generateImagesNotFoundError(ic, instanceTypes)
+}
+
+var DebugBuffer bytes.Buffer
+
+func generateImagesNotFoundError(constraint *InstanceConstraint, instanceTypes []InstanceType) error {
+	names := make([]string, 0, len(instanceTypes))
+	for _, itype := range instanceTypes {
+		names = append(names, itype.Name)
+	}
+	return fmt.Errorf("no %q images in %s matching instance types %v",
+		constraint.Series,
+		constraint.Region,
+		names,
+	)
+	return errors.NotFoundf(
+		"%q images in %s matching instance types %v",
+		constraint.Series,
+		constraint.Region,
+		instanceTypes,
+	)
+}
+
+func findAlphaNumericallyFirstArchName(images []Image) []Image {
+	if len(images) <= 0 {
+		return nil
+	}
+	bestImage := []Image{images[0]}
+	for _, image := range images[1:] {
+		switch archName := image.Arch; {
+		case archName < bestImage[0].Arch:
+			bestImage = []Image{image}
+		}
+	}
+
+	return bestImage
+}
+
+func findLargestWordSize(images []Image, wordSize func(string) int) []Image {
+	if len(images) <= 0 {
+		return nil
+	}
+
+	bestImage := []Image{images[0]}
+	bestWordSize := wordSize(images[0].Arch)
+	for _, image := range images[1:] {
+		switch ws := wordSize(image.Arch); {
+		case ws > bestWordSize:
+			bestWordSize = ws
+			bestImage = []Image{image}
+		case ws == bestWordSize:
+			bestImage = append(bestImage, image)
+		}
+	}
+	return bestImage
 }
 
 // Image holds the attributes that vary amongst relevant images for

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/juju/arch"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -380,6 +381,7 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 			continue
 		} else {
 			if !c.Check(err, jc.ErrorIsNil) {
+				c.Log(DebugBuffer.String())
 				continue
 			}
 			c.Check(spec.Image.Id, gc.Equals, t.imageId)
@@ -487,3 +489,24 @@ func (*imageSuite) TestInstanceConstraintString(c *gc.C) {
 		ic.String(), gc.Equals,
 		"{region: region, series: precise, arches: [amd64 arm64], constraints: mem=4096M, storage: [ebs ssd]}")
 }
+
+func (*imageSuite) TestFindLargestWordSize(c *gc.C) {
+	images := []Image{{Arch: "amd64"}, {Arch: "i386"}}
+	largest := findLargestWordSize(images, func(a string) int { return arch.Info[a].WordSize })
+	c.Assert(largest, gc.HasLen, 1)
+	c.Check(largest[0], gc.Equals, images[0])
+}
+
+// func (*imageSuite) TestFindInstanceSpecMultipleInstanceMatches(c *gc.C) {
+// 	images := []Image{{Arch: "amd64"}, {Arch: "i386"}}
+// 	ic := &InstanceConstraint{
+// 		Series: "precise",
+// 		Region: "region",
+// 		Arches: []string{"amd64"},
+// 	}
+// 	instanceTypes := []InstanceType{{Arches: []string{"amd64"}, Cost: 0}, {Arches: []string{"amd64"}, Cost: 1}}
+// 	instanceSpec, err := FindInstanceSpec(images, ic, instanceTypes)
+
+// 	c.Assert(err, jc.ErrorIsNil)
+// 	c.Check(instanceSpec.InstanceType, gc.DeepEquals, instanceTypes[0])
+// }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -490,14 +490,18 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		return nil, err
 	}
 
-	series := args.Tools.OneSeries()
-	spec, err := findInstanceSpec(sources, e.Config().ImageStream(), &instances.InstanceConstraint{
-		Region:      e.ecfg().region(),
-		Series:      series,
-		Arches:      arches,
-		Constraints: args.Constraints,
-		Storage:     []string{ssdStorage, ebsStorage},
-	})
+	spec, err := findInstanceSpec(
+		imagemetadata.Fetch,
+		sources,
+		e.Config().ImageStream(),
+		&instances.InstanceConstraint{
+			Region:      e.ecfg().region(),
+			Series:      args.Tools.OneSeries(),
+			Arches:      arches,
+			Constraints: args.Constraints,
+			Storage:     []string{ssdStorage, ebsStorage},
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -47,7 +47,9 @@ func filterImages(images []*imagemetadata.ImageMetadata, ic *instances.InstanceC
 func findInstanceSpec(
 	sources []simplestreams.DataSource, stream string, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
 
-	if ic.Constraints.CpuPower == nil {
+	// If the instance type is set, don't also set a default CPU power
+	// as this is implied.
+	if ic.Constraints.CpuPower == nil && ic.Constraints.InstanceType == nil {
 		ic.Constraints.CpuPower = instances.CpuPower(defaultCpuPower)
 	}
 	ec2Region := allRegions[ic.Region]


### PR DESCRIPTION
We don't want to set a default CPU power if instance-type was specified as a constraint.

(Review request: http://reviews.vapour.ws/r/2493/)