### PR TITLE
Hook context, test coverage improvements

### DIFF
--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -1,0 +1,85 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package collect
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker/metrics/spool"
+	"github.com/juju/juju/worker/uniter/runner/context"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type hookContext struct {
+	jujuc.RestrictedContext
+
+	unitName string
+	id       string
+	recorder spool.MetricRecorder
+}
+
+func newHookContext(unitName string, recorder spool.MetricRecorder) *hookContext {
+	id := fmt.Sprintf("%s-%s-%d", unitName, "collect-metrics", rand.New(rand.NewSource(time.Now().Unix())).Int63())
+	return &hookContext{unitName: unitName, id: id, recorder: recorder}
+}
+
+// HookVars implements runner.Context.
+func (ctx *hookContext) HookVars(paths context.Paths) ([]string, error) {
+	// TODO(cmars): Provide restricted hook context vars.
+	return nil, nil
+}
+
+// UnitName implements runner.Context.
+func (ctx *hookContext) UnitName() string {
+	return ctx.unitName
+}
+
+// Flush implements runner.Context.
+func (ctx *hookContext) Flush(process string, ctxErr error) (err error) {
+	return ctx.recorder.Close()
+}
+
+// AddMetric implements runner.Context.
+func (ctx *hookContext) AddMetric(key string, value string, created time.Time) error {
+	return ctx.recorder.AddMetric(key, value, created)
+}
+
+// addJujuUnitsMetric adds the juju-units built in metric if it
+// is defined for this context.
+func (ctx *hookContext) addJujuUnitsMetric() error {
+	if ctx.recorder.IsDeclaredMetric("juju-units") {
+		err := ctx.recorder.AddMetric("juju-units", "1", time.Now().UTC())
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// SetProcess implements runner.Context.
+func (ctx *hookContext) SetProcess(process *os.Process) {}
+
+// ActionData implements runner.Context.
+func (ctx *hookContext) ActionData() (*context.ActionData, error) {
+	return nil, jujuc.ErrRestrictedContext
+}
+
+// HasExecutionSetUnitStatus implements runner.Context.
+func (ctx *hookContext) HasExecutionSetUnitStatus() bool { return false }
+
+// ResetExecutionSetUnitStatus implements runner.Context.
+func (ctx *hookContext) ResetExecutionSetUnitStatus() {}
+
+// Id implements runner.Context.
+func (ctx *hookContext) Id() string { return ctx.id }
+
+// Prepare implements runner.Context.
+func (ctx *hookContext) Prepare() error {
+	return jujuc.ErrRestrictedContext
+}

--- a/worker/metrics/collect/export_test.go
+++ b/worker/metrics/collect/export_test.go
@@ -16,6 +16,7 @@ var (
 	// NewHookContext returns a new hook context used to collect metrics.
 	// It is exported here for calling from tests, but not patching.
 	NewHookContext = newHookContext
-
-	_ runner.Context = (*hookContext)(nil)
 )
+
+// Ensure hookContext is a runner.Context.
+var _ runner.Context = (*hookContext)(nil)

--- a/worker/metrics/collect/export_test.go
+++ b/worker/metrics/collect/export_test.go
@@ -3,10 +3,7 @@
 
 package collect
 
-import (
-	"github.com/juju/juju/worker/metrics/spool"
-	"github.com/juju/juju/worker/uniter/runner"
-)
+import "github.com/juju/juju/worker/uniter/runner"
 
 var (
 	// NewCollect allows patching the function that creates the metric collection
@@ -15,9 +12,10 @@ var (
 
 	// NewRecorder allows patching the function that creates the metric recorder.
 	NewRecorder = &newRecorder
-)
 
-// NewHookContext returns a new hook context used to collect metrics.
-func NewHookContext(unitName string, recorder spool.MetricRecorder) runner.Context {
-	return &hookContext{unitName: unitName, recorder: recorder}
-}
+	// NewHookContext returns a new hook context used to collect metrics.
+	// It is exported here for calling from tests, but not patching.
+	NewHookContext = newHookContext
+
+	_ runner.Context = (*hookContext)(nil)
+)

--- a/worker/metrics/collect/export_test.go
+++ b/worker/metrics/collect/export_test.go
@@ -3,6 +3,11 @@
 
 package collect
 
+import (
+	"github.com/juju/juju/worker/metrics/spool"
+	"github.com/juju/juju/worker/uniter/runner"
+)
+
 var (
 	// NewCollect allows patching the function that creates the metric collection
 	// entity.
@@ -11,3 +16,8 @@ var (
 	// NewRecorder allows patching the function that creates the metric recorder.
 	NewRecorder = &newRecorder
 )
+
+// NewHookContext returns a new hook context used to collect metrics.
+func NewHookContext(unitName string, recorder spool.MetricRecorder) runner.Context {
+	return &hookContext{unitName: unitName, recorder: recorder}
+}

--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -8,6 +8,7 @@
 package collect
 
 import (
+	"os"
 	"time"
 
 	"github.com/juju/errors"
@@ -195,23 +196,23 @@ type hookContext struct {
 	recorder spool.MetricRecorder
 }
 
-// HookVars implements jujuc.Context.
+// HookVars implements runner.Context.
 func (ctx *hookContext) HookVars(paths context.Paths) ([]string, error) {
 	// TODO(cmars): Provide restricted hook context vars.
 	return nil, nil
 }
 
-// UnitName implements jujuc.Context.
+// UnitName implements runner.Context.
 func (ctx *hookContext) UnitName() string {
 	return ctx.unitName
 }
 
-// Flush implements jujuc.Context.
+// Flush implements runner.Context.
 func (ctx *hookContext) Flush(process string, ctxErr error) (err error) {
 	return ctx.recorder.Close()
 }
 
-// AddMetric implements jujuc.
+// AddMetric implements runner.Context.
 func (ctx *hookContext) AddMetric(key string, value string, created time.Time) error {
 	return ctx.recorder.AddMetric(key, value, created)
 }
@@ -226,4 +227,8 @@ func (ctx *hookContext) addJujuUnitsMetric() error {
 		}
 	}
 	return nil
+}
+
+// SetProcess implements runner.Context.
+func (ctx *hookContext) SetProcess(process *os.Process) {
 }

--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -8,7 +8,6 @@
 package collect
 
 import (
-	"os"
 	"time"
 
 	"github.com/juju/errors"
@@ -173,7 +172,7 @@ func (w *collect) Do(stop <-chan struct{}) error {
 		return errors.Annotate(err, "failed to instantiate metric recorder")
 	}
 
-	ctx := &hookContext{unitName: unitTag.String(), recorder: recorder}
+	ctx := newHookContext(unitTag.String(), recorder)
 	err = ctx.addJujuUnitsMetric()
 	if err != nil {
 		return errors.Annotatef(err, "error adding 'juju-units' metric")
@@ -185,50 +184,4 @@ func (w *collect) Do(stop <-chan struct{}) error {
 		return errors.Annotatef(err, "error running 'collect-metrics' hook")
 	}
 	return nil
-}
-
-type hookContext struct {
-	// TODO(cmars): deal with unimplemented methods in a better way than
-	// panicking. Need a proper restricted hook context.
-	runner.Context
-
-	unitName string
-	recorder spool.MetricRecorder
-}
-
-// HookVars implements runner.Context.
-func (ctx *hookContext) HookVars(paths context.Paths) ([]string, error) {
-	// TODO(cmars): Provide restricted hook context vars.
-	return nil, nil
-}
-
-// UnitName implements runner.Context.
-func (ctx *hookContext) UnitName() string {
-	return ctx.unitName
-}
-
-// Flush implements runner.Context.
-func (ctx *hookContext) Flush(process string, ctxErr error) (err error) {
-	return ctx.recorder.Close()
-}
-
-// AddMetric implements runner.Context.
-func (ctx *hookContext) AddMetric(key string, value string, created time.Time) error {
-	return ctx.recorder.AddMetric(key, value, created)
-}
-
-// addJujuUnitsMetric adds the juju-units built in metric if it
-// is defined for this context.
-func (ctx *hookContext) addJujuUnitsMetric() error {
-	if ctx.recorder.IsDeclaredMetric("juju-units") {
-		err := ctx.recorder.AddMetric("juju-units", "1", time.Now().UTC())
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
-// SetProcess implements runner.Context.
-func (ctx *hookContext) SetProcess(process *os.Process) {
 }

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -1,0 +1,129 @@
+// Copyright 2012-2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+)
+
+// ErrRestrictedContext indicates a method is not implemented in the given context.
+var ErrRestrictedContext = errors.NotImplementedf("not implemented for restricted context")
+
+// RestrictedContext is a base implementation for restricted contexts to embed,
+// so that an error is returned for methods that are not explicitly
+// implemented.
+type RestrictedContext struct{}
+
+// ConfigSettings implements jujuc.Context.
+func (*RestrictedContext) ConfigSettings() (charm.Settings, error) { return nil, ErrRestrictedContext }
+
+// UnitStatus implements jujuc.Context.
+func (*RestrictedContext) UnitStatus() (*StatusInfo, error) { return nil, ErrRestrictedContext }
+
+// SetUnitStatus implements jujuc.Context.
+func (*RestrictedContext) SetUnitStatus(StatusInfo) error { return ErrRestrictedContext }
+
+// ServiceStatus implements jujuc.Context.
+func (*RestrictedContext) ServiceStatus() (ServiceStatusInfo, error) {
+	return ServiceStatusInfo{}, ErrRestrictedContext
+}
+
+// SetServiceStatus implements jujuc.Context.
+func (*RestrictedContext) SetServiceStatus(StatusInfo) error { return ErrRestrictedContext }
+
+// AvailabilityZone implements jujuc.Context.
+func (*RestrictedContext) AvailabilityZone() (string, error) { return "", ErrRestrictedContext }
+
+// RequestReboot implements jujuc.Context.
+func (*RestrictedContext) RequestReboot(prio RebootPriority) error { return ErrRestrictedContext }
+
+// PublicAddress implements jujuc.Context.
+func (*RestrictedContext) PublicAddress() (string, error) { return "", ErrRestrictedContext }
+
+// PrivateAddress implements jujuc.Context.
+func (*RestrictedContext) PrivateAddress() (string, error) { return "", ErrRestrictedContext }
+
+// OpenPorts implements jujuc.Context.
+func (*RestrictedContext) OpenPorts(protocol string, fromPort, toPort int) error {
+	return ErrRestrictedContext
+}
+
+// ClosePorts implements jujuc.Context.
+func (*RestrictedContext) ClosePorts(protocol string, fromPort, toPort int) error {
+	return ErrRestrictedContext
+}
+
+// OpenedPorts implements jujuc.Context.
+func (*RestrictedContext) OpenedPorts() []network.PortRange { return nil }
+
+// IsLeader implements jujuc.Context.
+func (*RestrictedContext) IsLeader() (bool, error) { return false, ErrRestrictedContext }
+
+// LeaderSettings implements jujuc.Context.
+func (*RestrictedContext) LeaderSettings() (map[string]string, error) {
+	return nil, ErrRestrictedContext
+}
+
+// WriteLeaderSettings implements jujuc.Context.
+func (*RestrictedContext) WriteLeaderSettings(map[string]string) error { return ErrRestrictedContext }
+
+// AddMetric implements jujuc.Context.
+func (*RestrictedContext) AddMetric(string, string, time.Time) error { return ErrRestrictedContext }
+
+// StorageTags implements jujuc.Context.
+func (*RestrictedContext) StorageTags() ([]names.StorageTag, error) { return nil, ErrRestrictedContext }
+
+// Storage implements jujuc.Context.
+func (*RestrictedContext) Storage(names.StorageTag) (ContextStorageAttachment, error) {
+	return nil, ErrRestrictedContext
+}
+
+// HookStorage implements jujuc.Context.
+func (*RestrictedContext) HookStorage() (ContextStorageAttachment, error) {
+	return nil, ErrRestrictedContext
+}
+
+// AddUnitStorage implements jujuc.Context.
+func (*RestrictedContext) AddUnitStorage(map[string]params.StorageConstraints) error {
+	return ErrRestrictedContext
+}
+
+// Relation implements jujuc.Context.
+func (*RestrictedContext) Relation(id int) (ContextRelation, error) {
+	return nil, ErrRestrictedContext
+}
+
+// RelationIds implements jujuc.Context.
+func (*RestrictedContext) RelationIds() ([]int, error) { return nil, ErrRestrictedContext }
+
+// HookRelation implements jujuc.Context.
+func (*RestrictedContext) HookRelation() (ContextRelation, error) {
+	return nil, ErrRestrictedContext
+}
+
+// RemoteUnitName implements jujuc.Context.
+func (*RestrictedContext) RemoteUnitName() (string, error) { return "", ErrRestrictedContext }
+
+// ActionParams implements jujuc.Context.
+func (*RestrictedContext) ActionParams() (map[string]interface{}, error) {
+	return nil, ErrRestrictedContext
+}
+
+// UpdateActionResults implements jujuc.Context.
+func (*RestrictedContext) UpdateActionResults(keys []string, value string) error {
+	return ErrRestrictedContext
+}
+
+// SetActionMessage implements jujuc.Context.
+func (*RestrictedContext) SetActionMessage(string) error { return ErrRestrictedContext }
+
+// SetActionFailed implements jujuc.Context.
+func (*RestrictedContext) SetActionFailed() error { return ErrRestrictedContext }

--- a/worker/uniter/runner/jujuc/restricted_test.go
+++ b/worker/uniter/runner/jujuc/restricted_test.go
@@ -1,0 +1,18 @@
+// Copyright 2012-2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type restrictedContext struct {
+	*jujuc.RestrictedContext
+}
+
+// UnitName completes the jujuc.Context implementation, which the
+// RestrictedContext leaves out.
+func (*restrictedContext) UnitName() string { return "restricted" }
+
+var _ jujuc.Context = (*restrictedContext)(nil)


### PR DESCRIPTION
Hook context now embeds a base restricted context.
Unit test coverage for adding metrics with hook context.
Unit test coverage for interaction with uniteravailability resource.

(Review request: http://reviews.vapour.ws/r/2494/)