### PR TITLE
environs/bootstrap: ValidateUploadAllowed takes a string, not a pointer

### DIFF
--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -22,13 +22,13 @@ var (
 
 // validateUploadAllowed returns an error if an attempt to upload tools should
 // not be allowed.
-func validateUploadAllowed(env environs.Environ, toolsArch *string) error {
+func validateUploadAllowed(env environs.Environ, toolsArch string) error {
 	// Now check that the architecture for which we are setting up an
 	// environment matches that from which we are bootstrapping.
 	hostArch := arch.HostArch()
 	// We can't build tools for a different architecture if one is specified.
-	if toolsArch != nil && *toolsArch != hostArch {
-		return fmt.Errorf("cannot build tools for %q using a machine running on %q", *toolsArch, hostArch)
+	if toolsArch != "" && toolsArch != hostArch {
+		return fmt.Errorf("cannot build tools for %q using a machine running on %q", toolsArch, hostArch)
 	}
 	// If no architecture is specified, ensure the target provider supports instances matching our architecture.
 	supportedArchitectures, err := env.SupportedArchitectures()
@@ -54,7 +54,12 @@ func validateUploadAllowed(env environs.Environ, toolsArch *string) error {
 // including tools that may be locally built and then
 // uploaded. Tools that need to be built will have an
 // empty URL.
-func findAvailableTools(env environs.Environ, vers *version.Number, arch *string, upload bool) (coretools.List, error) {
+func findAvailableTools(env environs.Environ, vers *version.Number, toolsArch *string, upload bool) (coretools.List, error) {
+	arch := arch.HostArch()
+	if toolsArch != nil {
+		arch = *toolsArch
+	}
+
 	if upload {
 		// We're forcing an upload: ensure we can do so.
 		if err := validateUploadAllowed(env, arch); err != nil {
@@ -75,7 +80,7 @@ func findAvailableTools(env environs.Environ, vers *version.Number, arch *string
 		}
 	}
 	logger.Infof("looking for bootstrap tools: version=%v", vers)
-	toolsList, findToolsErr := findBootstrapTools(env, vers, arch)
+	toolsList, findToolsErr := findBootstrapTools(env, vers, &arch)
 	if findToolsErr != nil && !errors.IsNotFound(findToolsErr) {
 		return nil, findToolsErr
 	}

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -54,7 +54,7 @@ func (s *toolsSuite) TestValidateUploadAllowed(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	// Host runs arm64, environment supports arm64.
 	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
-	err := bootstrap.ValidateUploadAllowed(env, arch.ARCH64)
+	err := bootstrap.ValidateUploadAllowed(env, arch.ARM64)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -32,8 +32,7 @@ func (s *toolsSuite) TestValidateUploadAllowedIncompatibleHostArch(c *gc.C) {
 	devVersion.Build = 1234
 	s.PatchValue(&version.Current, devVersion)
 	env := newEnviron("foo", useDefaultKeys, nil)
-	arch := arch.PPC64EL
-	err := bootstrap.ValidateUploadAllowed(env, &arch)
+	err := bootstrap.ValidateUploadAllowed(env, arch.PPC64EL)
 	c.Assert(err, gc.ErrorMatches, `cannot build tools for "ppc64el" using a machine running on "amd64"`)
 }
 
@@ -47,16 +46,15 @@ func (s *toolsSuite) TestValidateUploadAllowedIncompatibleTargetArch(c *gc.C) {
 	devVersion.Build = 1234
 	s.PatchValue(&version.Current, devVersion)
 	env := newEnviron("foo", useDefaultKeys, nil)
-	err := bootstrap.ValidateUploadAllowed(env, nil)
+	err := bootstrap.ValidateUploadAllowed(env, "")
 	c.Assert(err, gc.ErrorMatches, `environment "foo" of type dummy does not support instances running on "ppc64el"`)
 }
 
 func (s *toolsSuite) TestValidateUploadAllowed(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	// Host runs arm64, environment supports arm64.
-	arm64 := "arm64"
-	s.PatchValue(&arch.HostArch, func() string { return arm64 })
-	err := bootstrap.ValidateUploadAllowed(env, &arm64)
+	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
+	err := bootstrap.ValidateUploadAllowed(env, arch.ARCH64)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
This PR changes ValidateUploadAllowed to take a string for the arch, not a
pointer. The empty string has the same effect as a nil pointer and is easier
to use for both the caller and implementer.

(Review request: http://reviews.vapour.ws/r/2498/)