### PR TITLE
Remove a skipped tests and better label some others

### DIFF
--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -111,7 +111,6 @@ func (s *RunHookSuite) TestPrepareHookError_Run(c *gc.C) {
 }
 
 func (s *RunHookSuite) TestPrepareHookError_Skip(c *gc.C) {
-	c.Skip("maltese-falcon")
 	s.testPrepareHookError(c, (operation.Factory).NewSkipHook, true, true)
 }
 

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -86,7 +86,7 @@ func (s *InterfaceSuite) TestAddingMetricsInWrongContext(c *gc.C) {
 
 func (s *InterfaceSuite) TestAddingMetrics(c *gc.C) {
 	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		uuid := utils.MustNewUUID()
 		ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"), runnertesting.NewRealPaths(c))

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -161,7 +161,7 @@ func (s *ContextFactorySuite) TestRelationHookContext(c *gc.C) {
 
 func (s *ContextFactorySuite) TestMetricsHookContext(c *gc.C) {
 	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		s.SetCharm(c, "metered")
 		hi := hook.Info{Kind: hooks.CollectMetrics}

--- a/worker/uniter/runner/context/flush_test.go
+++ b/worker/uniter/runner/context/flush_test.go
@@ -209,7 +209,7 @@ func (s *FlushContextSuite) TestRunHookAddUnitStorageOnSuccess(c *gc.C) {
 
 func (s *FlushContextSuite) TestFlushClosesMetricsRecorder(c *gc.C) {
 	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		uuid := utils.MustNewUUID()
 		ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"), runnertesting.NewRealPaths(c))
@@ -234,7 +234,7 @@ func (s *HookContextSuite) context(c *gc.C) *context.HookContext {
 
 func (s *FlushContextSuite) TestBuiltinMetric(c *gc.C) {
 	// TODO (cmars): port test over to collect manifold.
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		uuid := utils.MustNewUUID()
 		paths := runnertesting.NewRealPaths(c)
@@ -271,7 +271,7 @@ func (s *FlushContextSuite) TestBuiltinMetricNotGeneratedIfNotDefined(c *gc.C) {
 
 func (s *FlushContextSuite) TestRecorderIsClosedAfterBuiltIn(c *gc.C) {
 	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		uuid := utils.MustNewUUID()
 		paths := runnertesting.NewRealPaths(c)

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -204,7 +204,7 @@ func (s *FactorySuite) TestNewHookRunnerWithBadRelation(c *gc.C) {
 
 func (s *FactorySuite) TestNewHookRunnerMetricsDisabledHook(c *gc.C) {
 	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		s.SetCharm(c, "metered")
 		rnr, err := s.factory.NewHookRunner(hook.Info{Kind: hooks.Install})
@@ -218,7 +218,7 @@ func (s *FactorySuite) TestNewHookRunnerMetricsDisabledHook(c *gc.C) {
 
 func (s *FactorySuite) TestNewHookRunnerMetricsDisabledUndeclared(c *gc.C) {
 	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		s.SetCharm(c, "mysql")
 		rnr, err := s.factory.NewHookRunner(hook.Info{Kind: hooks.CollectMetrics})
@@ -232,7 +232,7 @@ func (s *FactorySuite) TestNewHookRunnerMetricsDisabledUndeclared(c *gc.C) {
 
 func (s *FactorySuite) TestNewHookRunnerMetricsDeclarationError(c *gc.C) {
 	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		rnr, err := s.factory.NewHookRunner(hook.Info{Kind: hooks.CollectMetrics})
 		c.Assert(errors.Cause(err), jc.Satisfies, os.IsNotExist)
@@ -242,7 +242,7 @@ func (s *FactorySuite) TestNewHookRunnerMetricsDeclarationError(c *gc.C) {
 
 func (s *FactorySuite) TestNewHookRunnerMetricsEnabled(c *gc.C) {
 	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon")
+	c.Skip("maltese-falcon metrics")
 	/*
 		s.SetCharm(c, "metered")
 


### PR DESCRIPTION
Remove a skip for a test which now passes and relabel some others to reflect that they're for metrics so we can better determine what core work remains.

(Review request: http://reviews.vapour.ws/r/2499/)