### PR TITLE
worker/uniter: handle conflicted upgrades

### DIFF
--- a/worker/uniter/leadership/resolver.go
+++ b/worker/uniter/leadership/resolver.go
@@ -59,7 +59,7 @@ func (l *leadershipResolver) NextOp(
 		return opFactory.NewResignLeadership()
 	}
 
-	if localState.Kind == operation.Continue && !localState.Stopped {
+	if localState.Kind == operation.Continue {
 		// We want to run the leader settings hook if we're
 		// not the leader and the settings have changed.
 		if !localState.Leader && localState.LeaderSettingsVersion != remoteState.LeaderSettingsVersion {

--- a/worker/uniter/relation/relations.go
+++ b/worker/uniter/relation/relations.go
@@ -173,7 +173,7 @@ func (r *relations) NextHook(
 		return hook.Info{}, errors.Trace(err)
 	}
 
-	if localState.Kind != operation.Continue || localState.Stopped {
+	if localState.Kind != operation.Continue {
 		return hook.Info{}, resolver.ErrNoOperation
 	}
 

--- a/worker/uniter/resolver/interface.go
+++ b/worker/uniter/resolver/interface.go
@@ -58,6 +58,10 @@ type LocalState struct {
 	// by the committing of deploy (install/upgrade) ops.
 	CharmURL *charm.URL
 
+	// Conflicted indicates that the uniter is in a conflicted state,
+	// and needs either resolution or a forced upgrade to continue.
+	Conflicted bool
+
 	// Restart indicates that the resolver should exit with ErrRestart
 	// at the earliest opportunity.
 	Restart bool

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -24,6 +24,7 @@ type LoopConfig struct {
 	Factory             operation.Factory
 	UpdateStatusChannel func() <-chan time.Time
 	CharmURL            *charm.URL
+	Conflicted          bool
 	Dying               <-chan struct{}
 	OnIdle              func() error
 }
@@ -53,8 +54,11 @@ type LoopConfig struct {
 // charm URL being upgraded to.
 func Loop(cfg LoopConfig) (LocalState, error) {
 	rf := &resolverOpFactory{
-		Factory:    cfg.Factory,
-		LocalState: LocalState{CharmURL: cfg.CharmURL},
+		Factory: cfg.Factory,
+		LocalState: LocalState{
+			CharmURL:   cfg.CharmURL,
+			Conflicted: cfg.Conflicted,
+		},
 	}
 	for {
 		// TODO(axw) move update status to the watcher.

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -76,6 +76,7 @@ func (s *resolverOpFactory) wrapUpgradeOp(op operation.Operation, charmURL *char
 	return onCommitWrapper{op, func() {
 		s.LocalState.CharmURL = charmURL
 		s.LocalState.Restart = true
+		s.LocalState.Conflicted = false
 	}}
 }
 

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -106,12 +106,14 @@ func (s *ResolverOpFactorySuite) testUpgrade(
 	c *gc.C, meth func(resolver.ResolverOpFactory, *charm.URL) (operation.Operation, error),
 ) {
 	f := resolver.NewResolverOpFactory(s.opFactory)
+	f.LocalState.Conflicted = true
 	curl := charm.MustParseURL("cs:trusty/mysql")
 	op, err := meth(f, curl)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = op.Commit(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.LocalState.CharmURL, jc.DeepEquals, curl)
+	c.Assert(f.LocalState.Conflicted, jc.IsFalse)
 }
 
 func (s *ResolverOpFactorySuite) TestNewUpgradeError(c *gc.C) {

--- a/worker/uniter/storage/resolver.go
+++ b/worker/uniter/storage/resolver.go
@@ -87,8 +87,8 @@ func (s *storageResolver) nextOp(
 
 	var runStorageHooks bool
 	switch {
-	case localState.Kind == operation.Continue && !localState.Stopped:
-		// There's nothing in progress, and we've not stopped.
+	case localState.Kind == operation.Continue:
+		// There's nothing in progress.
 		runStorageHooks = true
 	case !localState.Installed && localState.Kind == operation.RunHook && localState.Step == operation.Queued:
 		// The install operation completed, and there's an install

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -604,7 +604,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
-	c.Skip("maltese-falcon")
+	//c.Skip("maltese-falcon")
 	//TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: currently does not work on windows")
@@ -961,7 +961,7 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
-	c.Skip("maltese-falcon")
+	//c.Skip("maltese-falcon")
 	coretesting.SkipIfGitNotAvailable(c)
 
 	// These tests are copies of the old git-deployer-related tests, to test that
@@ -1085,7 +1085,7 @@ func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
 			unitDying,
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
-			waitHooks{"upgrade-charm", "config-changed", "stop"},
+			waitHooks{"upgrade-charm", "config-changed", "leader-settings-changed", "stop"},
 			waitUniterDead{},
 		), ugt(
 			"upgrade conflict unit dead",

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -895,7 +895,6 @@ func (s *UniterSuite) TestUniterDeployerConversion(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
-	c.Skip("maltese-falcon")
 	coretesting.SkipIfPPC64EL(c, "lp:1448308")
 	//TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {
@@ -948,7 +947,7 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 			verifyWaitingUpgradeError{revision: 1},
 			fixUpgradeError{},
 			resolveError{state.ResolvedNoHooks},
-			waitHooks{"upgrade-charm", "config-changed", "stop"},
+			waitHooks{"upgrade-charm", "config-changed", "leader-settings-changed", "stop"},
 			waitUniterDead{},
 		), ut(
 			"upgrade conflict unit dead",

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -604,7 +604,6 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
-	//c.Skip("maltese-falcon")
 	//TODO(bogdanteleaga): Fix this on windows
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: currently does not work on windows")
@@ -961,7 +960,6 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
-	//c.Skip("maltese-falcon")
 	coretesting.SkipIfGitNotAvailable(c)
 
 	// These tests are copies of the old git-deployer-related tests, to test that


### PR DESCRIPTION
This PR fixes conflicted upgrade handling. If an
upgrade fails due to a conflict, we now set the
LocalState's Conflicted field to true, and then
we clear it when an upgrade operation is committed.

When in the conflicted state, we only accept two
methods of progressing: hook resolution, or a
forced upgrade. One creates a resolved-upgrade op,
and the other creates a revert-upgrade op. If
neither of these is true, we'll just for a state
change.

We also simplify handling of the Stopped local
state. If the unit has already run the Stop hook,
then it should not generate any more operations.
So we now check for life==Dead or Stopped at the
top of NextOp.

(Review request: http://reviews.vapour.ws/r/2500/)