### PR TITLE
cmd/juju: fix #1447899 upgrade juju fails

### DIFF
--- a/cmd/juju/upgradejuju.go
+++ b/cmd/juju/upgradejuju.go
@@ -348,11 +348,12 @@ func (context *upgradeContext) validate() (err error) {
 		// need to upgrade. If the CLI and agent major versions match, we find
 		// next available stable release to upgrade to by incrementing the
 		// minor version, starting from the current agent version and doing
-		// major.minor+1. If the CLI has a greater major version,
+		// major.minor+1.patch=0. If the CLI has a greater major version,
 		// we just use the CLI version as is.
 		nextVersion := context.agent
 		if nextVersion.Major == context.client.Major {
 			nextVersion.Minor += 1
+			nextVersion.Patch = 0
 		} else {
 			nextVersion = context.client
 		}

--- a/cmd/juju/upgradejuju_test.go
+++ b/cmd/juju/upgradejuju_test.go
@@ -297,6 +297,12 @@ var upgradeJujuTests = []struct {
 	args:           []string{"--upload-tools", "--version", "2.7.3"},
 	expectVersion:  "2.7.3.2",
 	expectUploaded: []string{"2.7.3.2-quantal-amd64", "2.7.3.2-%LTS%-amd64", "2.7.3.2-raring-amd64"},
+}, {
+	about:          "latest supported stable release",
+	tools:          []string{"1.21.3-quantal-amd64", "1.22.1-quantal-amd64"},
+	currentVersion: "1.22.1-quantal-amd64",
+	agentVersion:   "1.20.14",
+	expectVersion:  "1.21.3",
 }}
 
 func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {


### PR DESCRIPTION
A backport of the fix for issue #1447899

When upgrading an agent from a client that is more than one minor
version ahead, the agent's minor version is incremented. This branch
resets the agent's original patch version to zero. If this is not
done, juju will not find tools if the new version has no patch larger
than the old version's patch.

For example, upgrading a 1.20.14 agent using a 1.22.1 client will
result in a desired version of 1.21.14 - but if the newest available
1.21 tools is 1.21.3, juju will complain that no compatible tools are
available. This branch corrects the bug by returning, in this
scenario, a desired version of 1.21.0 and thus finding the 1.21.3
tools.

(Review request: http://reviews.vapour.ws/r/2501/)