### PR TITLE
worker/uniter: call deployer.Fix() in resolver

### DIFF
--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -17,6 +17,7 @@ import (
 type uniterResolver struct {
 	clearResolved   func() error
 	reportHookError func(hook.Info) error
+	fixDeployer     func() error
 
 	leadershipResolver resolver.Resolver
 	relationsResolver  resolver.Resolver
@@ -46,6 +47,12 @@ func (s *uniterResolver) NextOp(
 		// unit's charm URL. We need to restart the resolver
 		// loop so that we start watching the correct events.
 		return nil, resolver.ErrRestart
+	}
+
+	if localState.Kind == operation.Continue {
+		if err := s.fixDeployer(); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	op, err := s.leadershipResolver.NextOp(localState, remoteState, opFactory)

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package uniter
 
 import (

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -235,6 +235,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		uniterResolver := &uniterResolver{
 			clearResolved:      clearResolved,
 			reportHookError:    u.reportHookError,
+			fixDeployer:        u.deployer.Fix,
 			leadershipResolver: uniterleadership.NewResolver(),
 			relationsResolver:  relation.NewRelationsResolver(u.relations),
 			storageResolver:    storage.NewResolver(u.storage),

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -772,7 +772,6 @@ func (s *UniterSuite) TestUniterErrorStateUpgrade(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterDeployerConversion(c *gc.C) {
-	c.Skip("maltese-falcon")
 	coretesting.SkipIfGitNotAvailable(c)
 
 	deployerConversionTests := []uniterTest{


### PR DESCRIPTION
Call deployer.Fix() when we're in the equivalent of
ModeAbide, before looking for operations to execute.
Fixes TestUniterDeployerConversion in maltese-falcon.

(Review request: http://reviews.vapour.ws/r/2506/)