### PR TITLE
Remove commented out tests, migrated to worker/metrics/collect.

### DIFF
--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -84,27 +84,6 @@ func (s *InterfaceSuite) TestAddingMetricsInWrongContext(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "metrics not allowed in this context")
 }
 
-func (s *InterfaceSuite) TestAddingMetrics(c *gc.C) {
-	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon metrics")
-	/*
-		uuid := utils.MustNewUUID()
-		ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"), runnertesting.NewRealPaths(c))
-		cleanup := context.PatchMetricsRecorder(ctx, &StubMetricsRecorder{&s.stub})
-		defer cleanup()
-
-		now := time.Now()
-		err := ctx.AddMetric("key", "123", now)
-		c.Assert(err, jc.ErrorIsNil)
-
-		s.stub.CheckCalls(c,
-			[]testing.StubCall{{
-				FuncName: "AddMetric",
-				Args:     []interface{}{"key", "123", now},
-			}})
-	*/
-}
-
 func (s *InterfaceSuite) TestAvailabilityZone(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
 	zone, err := ctx.AvailabilityZone()

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -159,25 +159,6 @@ func (s *ContextFactorySuite) TestRelationHookContext(c *gc.C) {
 	s.AssertNotStorageContext(c, ctx)
 }
 
-func (s *ContextFactorySuite) TestMetricsHookContext(c *gc.C) {
-	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon metrics")
-	/*
-		s.SetCharm(c, "metered")
-		hi := hook.Info{Kind: hooks.CollectMetrics}
-		ctx, err := s.factory.HookContext(hi)
-		c.Assert(err, jc.ErrorIsNil)
-
-		err = ctx.AddMetric("pings", "1", time.Now())
-		c.Assert(err, jc.ErrorIsNil)
-
-		s.AssertCoreContext(c, ctx)
-		s.AssertNotActionContext(c, ctx)
-		s.AssertNotRelationContext(c, ctx)
-		s.AssertNotStorageContext(c, ctx)
-	*/
-}
-
 func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 	// We need to set up a unit that has storage metadata defined.
 	ch := s.AddTestingCharm(c, "storage-block")

--- a/worker/uniter/runner/context/flush_test.go
+++ b/worker/uniter/runner/context/flush_test.go
@@ -207,51 +207,10 @@ func (s *FlushContextSuite) TestRunHookAddUnitStorageOnSuccess(c *gc.C) {
 	c.Assert(all, gc.HasLen, 0)
 }
 
-func (s *FlushContextSuite) TestFlushClosesMetricsRecorder(c *gc.C) {
-	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon metrics")
-	/*
-		uuid := utils.MustNewUUID()
-		ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("key"), runnertesting.NewRealPaths(c))
-
-		context.PatchMetricsRecorder(ctx, &StubMetricsRecorder{&s.stub})
-
-		err := ctx.AddMetric("key", "value", time.Now())
-
-		// Flush the context with a success.
-		err = ctx.Flush("success", nil)
-		c.Assert(err, jc.ErrorIsNil)
-
-		s.stub.CheckCallNames(c, "IsDeclaredMetric", "AddMetric", "Close")
-	*/
-}
-
 func (s *HookContextSuite) context(c *gc.C) *context.HookContext {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	return s.getHookContext(c, uuid.String(), -1, "", noProxies)
-}
-
-func (s *FlushContextSuite) TestBuiltinMetric(c *gc.C) {
-	// TODO (cmars): port test over to collect manifold.
-	c.Skip("maltese-falcon metrics")
-	/*
-		uuid := utils.MustNewUUID()
-		paths := runnertesting.NewRealPaths(c)
-		ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("juju-units"), paths)
-		reader, err := spool.NewJSONMetricReader(
-			paths.GetMetricsSpoolDir(),
-		)
-
-		err = ctx.Flush("some badge", nil)
-		c.Assert(err, jc.ErrorIsNil)
-		batches, err := reader.Read()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(batches, gc.HasLen, 1)
-		c.Assert(batches[0].Metrics, gc.HasLen, 1)
-		c.Assert(batches[0].Metrics[0].Key, gc.Equals, "juju-units")
-		c.Assert(batches[0].Metrics[0].Value, gc.Equals, "1")
-	*/
 }
 
 func (s *FlushContextSuite) TestBuiltinMetricNotGeneratedIfNotDefined(c *gc.C) {
@@ -267,19 +226,4 @@ func (s *FlushContextSuite) TestBuiltinMetricNotGeneratedIfNotDefined(c *gc.C) {
 	batches, err := reader.Read()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(batches, gc.HasLen, 0)
-}
-
-func (s *FlushContextSuite) TestRecorderIsClosedAfterBuiltIn(c *gc.C) {
-	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon metrics")
-	/*
-		uuid := utils.MustNewUUID()
-		paths := runnertesting.NewRealPaths(c)
-		ctx := s.getMeteredHookContext(c, uuid.String(), -1, "", noProxies, true, s.metricsDefinition("juju-units"), paths)
-		context.PatchMetricsRecorder(ctx, &StubMetricsRecorder{&s.stub})
-
-		err := ctx.Flush("some badge", nil)
-		c.Assert(err, jc.ErrorIsNil)
-		s.stub.CheckCallNames(c, "IsDeclaredMetric", "AddMetric", "Close")
-	*/
 }

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -202,59 +202,6 @@ func (s *FactorySuite) TestNewHookRunnerWithBadRelation(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown relation id: 12345`)
 }
 
-func (s *FactorySuite) TestNewHookRunnerMetricsDisabledHook(c *gc.C) {
-	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon metrics")
-	/*
-		s.SetCharm(c, "metered")
-		rnr, err := s.factory.NewHookRunner(hook.Info{Kind: hooks.Install})
-		c.Assert(err, jc.ErrorIsNil)
-		s.AssertPaths(c, rnr)
-		ctx := rnr.Context()
-		err = ctx.AddMetric("key", "value", time.Now())
-		c.Assert(err, gc.ErrorMatches, "metrics disabled")
-	*/
-}
-
-func (s *FactorySuite) TestNewHookRunnerMetricsDisabledUndeclared(c *gc.C) {
-	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon metrics")
-	/*
-		s.SetCharm(c, "mysql")
-		rnr, err := s.factory.NewHookRunner(hook.Info{Kind: hooks.CollectMetrics})
-		c.Assert(err, jc.ErrorIsNil)
-		s.AssertPaths(c, rnr)
-		ctx := rnr.Context()
-		err = ctx.AddMetric("key", "value", time.Now())
-		c.Assert(err, gc.ErrorMatches, "metrics disabled")
-	*/
-}
-
-func (s *FactorySuite) TestNewHookRunnerMetricsDeclarationError(c *gc.C) {
-	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon metrics")
-	/*
-		rnr, err := s.factory.NewHookRunner(hook.Info{Kind: hooks.CollectMetrics})
-		c.Assert(errors.Cause(err), jc.Satisfies, os.IsNotExist)
-		c.Assert(rnr, gc.IsNil)
-	*/
-}
-
-func (s *FactorySuite) TestNewHookRunnerMetricsEnabled(c *gc.C) {
-	// TODO(cmars): port over to collect manifold
-	c.Skip("maltese-falcon metrics")
-	/*
-		s.SetCharm(c, "metered")
-
-		rnr, err := s.factory.NewHookRunner(hook.Info{Kind: hooks.CollectMetrics})
-		c.Assert(err, jc.ErrorIsNil)
-		s.AssertPaths(c, rnr)
-		ctx := rnr.Context()
-		err = ctx.AddMetric("pings", "0.5", time.Now())
-		c.Assert(err, jc.ErrorIsNil)
-	*/
-}
-
 func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 	s.SetCharm(c, "dummy")
 	action, err := s.State.EnqueueAction(s.unit.Tag(), "snapshot", map[string]interface{}{


### PR DESCRIPTION
Removing commented-out metric tests from the uniter. Will note comparable test coverage in the RB review.