### PR TITLE
Do not read workloads from state

### DIFF
--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/api/base"
 	apiserverclient "github.com/juju/juju/apiserver/client"
@@ -201,8 +200,8 @@ func (workloads) registerState() {
 	// TODO(ericsnow) Use a more general registration mechanism.
 	//state.RegisterMultiEnvCollections(persistence.Collections...)
 
-	newUnitWorkloads := func(persist state.Persistence, unit names.UnitTag, getMetadata func() (*charm.Meta, error)) (state.UnitWorkloads, error) {
-		return workloadstate.NewUnitWorkloads(persist, unit, getMetadata), nil
+	newUnitWorkloads := func(persist state.Persistence, unit names.UnitTag) (state.UnitWorkloads, error) {
+		return workloadstate.NewUnitWorkloads(persist, unit), nil
 	}
 	state.SetWorkloadsComponent(newUnitWorkloads)
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -39,7 +39,7 @@ gopkg.in/amz.v3	git	bff3a097c4108da57bb8cbe3aad2990d74d23676	2015-08-20T12:28:33
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	15098963088579c1cd9eb1a7da285831e548390b	2015-07-07T18:34:45Z
 gopkg.in/goose.v1	git	be6030ce33a6d77f5e9c63b7698030e6431d5343	2015-08-24T15:19:40Z
-gopkg.in/juju/charm.v5	git	aad3e4a7a176c5de199f6293ecfe1bd6fbf0d7eb	2015-08-20T17:50:11Z
+gopkg.in/juju/charm.v5	git	cda894939799031b7a6fab7c5aa012483026cba3	2015-08-28T14:21:03Z
 gopkg.in/juju/charmstore.v4	git	b90d24652753eeb1f7d209483d499f6b24dcf25e	2015-07-10T10:24:09Z
 gopkg.in/juju/environschema.v1	git	16cc59268c09c22870cb4de8eb6248652535f315	2015-08-24T13:22:26Z
 gopkg.in/macaroon-bakery.v0	git	9593b80b01ba04b519769d045dffd6abd827d2fd	2015-04-10T07:46:55Z

--- a/state/workloads_test.go
+++ b/state/workloads_test.go
@@ -61,31 +61,6 @@ func (s *unitWorkloadsSuite) TestFunctional(c *gc.C) {
 	st, err := s.State.UnitWorkloads(unit)
 	c.Assert(err, jc.ErrorIsNil)
 
-	definitions, err := st.Definitions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(definitions, jc.DeepEquals, []charm.Workload{{
-		Name:        "workloadA",
-		Type:        "docker",
-		TypeOptions: map[string]string{},
-		Command:     "do-something cool",
-		Image:       "spam/eggs",
-		Volumes: []charm.WorkloadVolume{{
-			ExternalMount: "/var/nginx/html",
-			InternalMount: "/usr/share/nginx/html",
-			Mode:          "ro",
-			Name:          "",
-		}},
-		Ports: []charm.WorkloadPort{{
-			External: 8080,
-			Internal: 80,
-			Endpoint: "",
-		}},
-		EnvVars: map[string]string{
-			// TODO(erisnow) YAML coerces YES into true...
-			"IMPORTANT": "true",
-		},
-	}})
-
 	workloads, err := st.List()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(workloads, gc.HasLen, 0)

--- a/workload/api/client/hookcontext.go
+++ b/workload/api/client/hookcontext.go
@@ -6,7 +6,6 @@ package client
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/api"
@@ -27,24 +26,6 @@ type HookContextClient struct {
 // NewHookContextClient builds a new workload API client.
 func NewHookContextClient(caller facadeCaller) HookContextClient {
 	return HookContextClient{caller}
-}
-
-// Definitions calls the Definitions API server method.
-func (c HookContextClient) Definitions() ([]charm.Workload, error) {
-	var results api.DefinitionsResults
-	if err := c.FacadeCall("Definitions", nil, &results); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if results.Error != nil {
-		return nil, errors.Errorf(results.Error.GoString())
-	}
-
-	var definitions []charm.Workload
-	for _, result := range results.Results {
-		definition := api.API2Definition(result)
-		definitions = append(definitions, definition)
-	}
-	return definitions, nil
 }
 
 // Track calls the Track API server method.

--- a/workload/api/client/hookcontext_test.go
+++ b/workload/api/client/hookcontext_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/api"
@@ -60,42 +59,6 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 		},
 	}
 
-}
-
-func (s *clientSuite) TestDefinitions(c *gc.C) {
-	s.facade.FacadeCallFn = func(name string, params, response interface{}) error {
-		results := response.(*api.DefinitionsResults)
-		*results = api.DefinitionsResults{
-			Results: []api.WorkloadDefinition{s.definition},
-		}
-		return nil
-	}
-	pclient := client.NewHookContextClient(s.facade)
-
-	definitions, err := pclient.Definitions()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(definitions, jc.DeepEquals, []charm.Workload{{
-		Name:        "foobar",
-		Description: "desc",
-		Type:        "type",
-		TypeOptions: map[string]string{"foo": "bar"},
-		Command:     "cmd",
-		Image:       "img",
-		Ports: []charm.WorkloadPort{{
-			External: 8080,
-			Internal: 80,
-			Endpoint: "endpoint",
-		}},
-		Volumes: []charm.WorkloadVolume{{
-			ExternalMount: "/foo/bar",
-			InternalMount: "/baz/bat",
-			Mode:          "ro",
-			Name:          "volname",
-		}},
-		EnvVars: map[string]string{"envfoo": "bar"},
-	}})
-	s.stub.CheckCallNames(c, "FacadeCall")
 }
 
 func (s *clientSuite) TestTrack(c *gc.C) {

--- a/workload/api/server-args.go
+++ b/workload/api/server-args.go
@@ -63,14 +63,6 @@ type ListResult struct {
 	Error *params.Error
 }
 
-// DefinitionsResults contains the results for a call to Definitions.
-type DefinitionsResults struct {
-	// Results is the list of definition results.
-	Results []WorkloadDefinition
-	// Error is the error (if any) for the call as a whole.
-	Error *params.Error
-}
-
 // SetStatusArgs are the arguments for the SetStatus endpoint.
 type SetStatusArgs struct {
 	// Args is the list of arguments to pass to this function.

--- a/workload/api/server/hookcontext.go
+++ b/workload/api/server/hookcontext.go
@@ -8,7 +8,6 @@ package server
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/workload"
@@ -23,8 +22,6 @@ type UnitWorkloads interface {
 	Track(info workload.Info) error
 	// List returns information on the workload with the id on the unit.
 	List(ids ...string) ([]workload.Info, error)
-	// Definitions returns workload definitions found in the unit's metadata.
-	Definitions() ([]charm.Workload, error)
 	// Settatus sets the status for the workload with the given id on the unit.
 	SetStatus(id string, status workload.CombinedStatus) error
 	// Untrack removes the information for the workload with the given id.
@@ -40,24 +37,6 @@ type HookContextAPI struct {
 // NewHookContextAPI builds a new facade for the given State.
 func NewHookContextAPI(st UnitWorkloads) *HookContextAPI {
 	return &HookContextAPI{State: st}
-}
-
-// Definitions builds the list of workload definitions
-// found in the metadata of the unit's charm.
-func (a HookContextAPI) Definitions() (api.DefinitionsResults, error) {
-	var results api.DefinitionsResults
-
-	definitions, err := a.State.Definitions()
-	if err != nil {
-		results.Error = common.ServerError(err)
-		return results, nil
-	}
-
-	for _, definition := range definitions {
-		result := api.Definition2api(definition)
-		results.Results = append(results.Results, result)
-	}
-	return results, nil
 }
 
 // Track stores a workload to be tracked in state.

--- a/workload/api/server/hookcontext_test.go
+++ b/workload/api/server/hookcontext_test.go
@@ -291,65 +291,6 @@ func (suite) TestListAll(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, expectedResults)
 }
 
-func (suite) TestDefinitions(c *gc.C) {
-	definition := charm.Workload{
-		Name:        "foobar",
-		Description: "desc",
-		Type:        "type",
-		TypeOptions: map[string]string{"foo": "bar"},
-		Command:     "cmd",
-		Image:       "img",
-		Ports: []charm.WorkloadPort{
-			{
-				External: 8080,
-				Internal: 80,
-				Endpoint: "endpoint",
-			},
-		},
-		Volumes: []charm.WorkloadVolume{
-			{
-				ExternalMount: "/foo/bar",
-				InternalMount: "/baz/bat",
-				Mode:          "ro",
-				Name:          "volname",
-			},
-		},
-		EnvVars: map[string]string{"envfoo": "bar"},
-	}
-	st := &FakeState{defs: []charm.Workload{definition}}
-	a := HookContextAPI{st}
-
-	results, err := a.Definitions()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(results, jc.DeepEquals, api.DefinitionsResults{
-		Results: []api.WorkloadDefinition{{
-			Name:        "foobar",
-			Description: "desc",
-			Type:        "type",
-			TypeOptions: map[string]string{"foo": "bar"},
-			Command:     "cmd",
-			Image:       "img",
-			Ports: []api.WorkloadPort{
-				{
-					External: 8080,
-					Internal: 80,
-					Endpoint: "endpoint",
-				},
-			},
-			Volumes: []api.WorkloadVolume{
-				{
-					ExternalMount: "/foo/bar",
-					InternalMount: "/baz/bat",
-					Mode:          "ro",
-					Name:          "volname",
-				},
-			},
-			EnvVars: map[string]string{"envfoo": "bar"},
-		}},
-	})
-}
-
 func (suite) TestSetStatus(c *gc.C) {
 	st := &FakeState{}
 	a := HookContextAPI{st}
@@ -462,10 +403,6 @@ func (f *FakeState) Track(info workload.Info) error {
 func (f *FakeState) List(ids ...string) ([]workload.Info, error) {
 	f.ids = ids
 	return f.workloads, f.err
-}
-
-func (f *FakeState) Definitions() ([]charm.Workload, error) {
-	return f.defs, f.err
 }
 
 func (f *FakeState) SetStatus(id string, status workload.CombinedStatus) error {

--- a/workload/context/base_test.go
+++ b/workload/context/base_test.go
@@ -24,7 +24,8 @@ func init() {
 
 type baseSuite struct {
 	jujuctesting.ContextSuite
-	workload workload.Info
+	workload    workload.Info
+	definitions map[string]charm.Workload
 }
 
 func (s *baseSuite) SetUpTest(c *gc.C) {
@@ -172,19 +173,6 @@ func (c *stubContextComponent) Untrack(id string) error {
 	return nil
 }
 
-func (c *stubContextComponent) Definitions() ([]charm.Workload, error) {
-	c.stub.AddCall("Definitions")
-	if err := c.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var definitions []charm.Workload
-	for _, definition := range c.definitions {
-		definitions = append(definitions, definition)
-	}
-	return definitions, nil
-}
-
 func (c *stubContextComponent) Flush() error {
 	c.stub.AddCall("Flush")
 	if err := c.stub.NextErr(); err != nil {
@@ -237,19 +225,6 @@ func (c *stubAPIClient) setNew(ids ...string) []workload.Info {
 		workloads = append(workloads, wl)
 	}
 	return workloads
-}
-
-func (c *stubAPIClient) Definitions() ([]charm.Workload, error) {
-	c.stub.AddCall("Definitions")
-	if err := c.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var definitions []charm.Workload
-	for _, definition := range c.definitions {
-		definitions = append(definitions, definition)
-	}
-	return definitions, nil
 }
 
 func (c *stubAPIClient) List(ids ...string) ([]workload.Info, error) {

--- a/workload/context/command_test.go
+++ b/workload/context/command_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
@@ -36,6 +37,10 @@ func (s *commandSuite) SetUpTest(c *gc.C) {
 	s.cmdCtx = coretesting.Context(c)
 
 	s.setMetadata()
+}
+
+func (s *commandSuite) readDefinitions(ctx *cmd.Context) (map[string]charm.Workload, error) {
+	return s.compCtx.definitions, nil
 }
 
 func (s *commandSuite) setCommand(c *gc.C, name string, cmd cmd.Command) {
@@ -97,6 +102,6 @@ func (s *registeringCommandSuite) checkRunInfo(c *gc.C, orig, sent workload.Info
 	info := context.GetCmdInfo(s.cmd)
 	c.Check(info, jc.DeepEquals, &orig)
 
-	s.Stub.CheckCallNames(c, "List", "Definitions", "Track", "Flush")
-	c.Check(s.Stub.Calls()[2].Args, jc.DeepEquals, []interface{}{sent})
+	s.Stub.CheckCallNames(c, "List", "Track", "Flush")
+	c.Check(s.Stub.Calls()[1].Args, jc.DeepEquals, []interface{}{sent})
 }

--- a/workload/context/context.go
+++ b/workload/context/context.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/plugin"
@@ -24,8 +23,6 @@ type APIClient interface {
 	Track(workloads ...workload.Info) ([]string, error)
 	// Untrack removes the workloads from our list track.
 	Untrack(ids []string) ([]workload.Result, error)
-	// Definitions returns the workload definitions found in the unit's metadata.
-	Definitions() ([]charm.Workload, error)
 	// SetStatus sets the status for the given IDs.
 	SetStatus(status workload.Status, pluginStatus workload.PluginStatus, ids ...string) error
 }
@@ -45,8 +42,6 @@ type Component interface {
 	Untrack(id string) error
 	// List returns the list of registered workload IDs.
 	List() ([]string, error)
-	// Definitions returns the charm-defined workloads.
-	Definitions() ([]charm.Workload, error)
 	// Flush pushes the hook context data out to state.
 	Flush() error
 }
@@ -217,15 +212,6 @@ func (c *Context) Untrack(id string) error {
 	delete(c.workloads, id)
 
 	return nil
-}
-
-// Definitions returns the unit's charm-defined workloads.
-func (c *Context) Definitions() ([]charm.Workload, error) {
-	definitions, err := c.api.Definitions()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return definitions, nil
 }
 
 // TODO(ericsnow) The context machinery is not actually using this yet.

--- a/workload/context/context_test.go
+++ b/workload/context/context_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v5"
 
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
 	"github.com/juju/juju/workload"
@@ -303,23 +302,6 @@ func (s *contextSuite) TestSetOverwrite(c *gc.C) {
 
 	c.Check(before, jc.DeepEquals, []workload.Info{other})
 	c.Check(after, jc.DeepEquals, []workload.Info{info})
-}
-
-func (s *contextSuite) TestDefinitions(c *gc.C) {
-	definition := charm.Workload{
-		Name: "wlA",
-		Type: "myplugin",
-	}
-	s.apiClient.definitions["wlA"] = definition
-	ctx := context.NewContext(s.apiClient, s.addEvents)
-
-	definitions, err := ctx.Definitions()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(definitions, gc.DeepEquals, []charm.Workload{
-		definition,
-	})
-	s.Stub.CheckCallNames(c, "Definitions")
 }
 
 func (s *contextSuite) TestFlushDirty(c *gc.C) {

--- a/workload/context/track_test.go
+++ b/workload/context/track_test.go
@@ -29,6 +29,7 @@ func (s *trackSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.trackCmd = cmd
+	s.trackCmd.ReadDefinitions = s.readDefinitions
 	s.setCommand(c, "workload-track", s.trackCmd)
 }
 
@@ -297,7 +298,7 @@ func (s *trackSuite) TestRunOkay(c *gc.C) {
 	s.init(c, s.workload.Name, "abc123", "running")
 
 	s.checkRun(c, "", "")
-	s.Stub.CheckCallNames(c, "List", "Definitions", "Track", "Flush")
+	s.Stub.CheckCallNames(c, "List", "Track", "Flush")
 }
 
 func (s *trackSuite) TestRunAlreadyRegistered(c *gc.C) {
@@ -323,8 +324,6 @@ func (s *trackSuite) TestRunUpdatedWorkload(c *gc.C) {
 	s.workload.Details = s.details
 	s.Stub.CheckCalls(c, []testing.StubCall{{
 		FuncName: "List",
-	}, {
-		FuncName: "Definitions",
 	}, {
 		FuncName: "Track",
 		Args:     []interface{}{s.workload},

--- a/workload/state/workloads.go
+++ b/workload/state/workloads.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/persistence"
@@ -35,17 +34,14 @@ type UnitWorkloads struct {
 	Persist workloadsPersistence
 	// Unit identifies the unit associated with the workloads.
 	Unit names.UnitTag
-	// Metadata is a function that returns the metadata for the unit's charm.
-	Metadata func() (*charm.Meta, error)
 }
 
 // NewUnitWorkloads builds a UnitWorkloads for a unit.
-func NewUnitWorkloads(st persistence.PersistenceBase, unit names.UnitTag, getMetadata func() (*charm.Meta, error)) *UnitWorkloads {
+func NewUnitWorkloads(st persistence.PersistenceBase, unit names.UnitTag) *UnitWorkloads {
 	persist := persistence.NewPersistence(st, unit)
 	return &UnitWorkloads{
-		Persist:  persist,
-		Unit:     unit,
-		Metadata: getMetadata,
+		Persist: persist,
+		Unit:    unit,
 	}
 }
 
@@ -104,20 +100,6 @@ func (ps UnitWorkloads) List(ids ...string) ([]workload.Info, error) {
 		return nil, errors.Trace(err)
 	}
 	return results, nil
-}
-
-// ListDefinitions builds the list of workload definitions found in the
-// unit's charm metadata.
-func (ps UnitWorkloads) Definitions() ([]charm.Workload, error) {
-	meta, err := ps.Metadata()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	var definitions []charm.Workload
-	for _, definition := range meta.Workloads {
-		definitions = append(definitions, definition)
-	}
-	return definitions, nil
 }
 
 // Untrack removes the identified workload from state. It does not

--- a/workload/state/workloads_test.go
+++ b/workload/state/workloads_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/state"
@@ -173,34 +172,6 @@ func (s *unitWorkloadsSuite) TestListMissing(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(workloads, jc.DeepEquals, []workload.Info{wl})
-}
-
-func (s *unitWorkloadsSuite) TestDefinitions(c *gc.C) {
-	expected := s.newWorkloads("docker", "workloadA", "workloadB")
-	getMetadata := func() (*charm.Meta, error) {
-		meta := &charm.Meta{
-			Workloads: map[string]charm.Workload{
-				"workloadA": expected[0].Workload,
-				"workloadB": expected[1].Workload,
-			},
-		}
-		return meta, nil
-	}
-	ps := state.UnitWorkloads{Persist: s.persist}
-	ps.Metadata = getMetadata
-
-	definitions, err := ps.Definitions()
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.stub.CheckCalls(c, nil)
-	c.Check(definitions, gc.HasLen, 2)
-	if definitions[0].Name == "workloadA" {
-		c.Check(definitions[0], jc.DeepEquals, expected[0].Workload)
-		c.Check(definitions[1], jc.DeepEquals, expected[1].Workload)
-	} else {
-		c.Check(definitions[0], jc.DeepEquals, expected[1].Workload)
-		c.Check(definitions[1], jc.DeepEquals, expected[0].Workload)
-	}
 }
 
 func (s *unitWorkloadsSuite) TestUntrackOkay(c *gc.C) {


### PR DESCRIPTION
We are not longer storing workloads on the metadata (and therefore not in state). This patch removes all of the previous usage of reading workloads from state and replaces it with reading from the "workloads.yaml" file as a convention.

(Review request: http://reviews.vapour.ws/r/2522/)